### PR TITLE
fix(studio): restore parallel vision chat slots

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5294,6 +5294,9 @@ class LlamaCppBackend:
         # the GGUF alone can tell us.
         self._has_video_input: bool = False
         self._mmproj_has_audio: bool = False  # clip.has_audio_encoder, set at load
+        # clip.projector_type, set at load: the family whose image-token ceiling KV
+        # admission sizes an image against.
+        self._mmproj_projector_type: Optional[str] = None
         # clip.has_vision_encoder, set at load; True keeps an undeclared projector capable.
         self._mmproj_accepts_image: bool = True
         # Monotonic timestamp set in _kill_process; read by load_model
@@ -19441,13 +19444,20 @@ class LlamaCppBackend:
                     if (_pv_mmproj_unpinnable or (disable_vision and not _dv_env_mmproj_kept))
                     else (os.environ.get("LLAMA_ARG_MMPROJ") or "")
                 )
+                self._mmproj_projector_type = None
                 if launch_mmproj_path or os.path.isfile(_mmproj_probe):
                     try:
-                        from utils.models.gguf_metadata import mmproj_capabilities
+                        from utils.models.gguf_metadata import (
+                            mmproj_capabilities,
+                            read_mmproj_projector_type,
+                        )
 
                         has_audio, accepts_image = mmproj_capabilities(_mmproj_probe)
                         self._mmproj_has_audio = has_audio
                         self._mmproj_accepts_image = accepts_image
+                        # The family name, so KV admission can look up how many tokens
+                        # one image may become instead of assuming a ceiling.
+                        self._mmproj_projector_type = read_mmproj_projector_type(_mmproj_probe)
                     except Exception as e:
                         logger.debug(f"mmproj capability read failed: {e}")
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1624,23 +1624,17 @@ def _openai_llama_admission_extra_prompt_tokens(payload) -> int:
     return extra
 
 
-# KV positions to reserve per image, as an upper bound rather than an estimate.
+# An upper bound per image, not an estimate: under-reserving hands out a slot the cache
+# cannot back, which is the overcommit #9392 exists to stop.
 #
-# 4096 is llama.cpp's default ceiling on Qwen-VL embeddings per image (the projector
-# resizes to its own pixel limits, so transport size never enters into it), but the
-# embeddings are not the whole cost: mtmd wraps them in delimiter tokens. Measured
-# against llama-server b10639, a 2048x2048 image costs 4098 on Qwen3-VL-4B, i.e. the
-# cap plus two, and 258 on Gemma 3 4B (256 embeddings plus the same two). A flat 4096
-# is therefore provably BELOW the real ceiling, and under-reserving is the one
-# direction this accounting must never err in: it hands out a slot the cache cannot
-# back, which is the overcommit #9392 exists to stop.
-#
-# The wrapper allowance is deliberately much larger than the two tokens measured, to
-# cover projectors whose delimiters are longer. It is still a bound, not a guess: a
-# projector whose embeddings alone exceed the cap (tiling or multi-crop families, or a
-# llama-server started by hand with a raised --image-max-tokens; Studio never passes
-# one) is outside what this constant can promise, and wants a projector-aware
-# allowance read off the loaded mmproj rather than a bigger number here.
+# 4096 is llama.cpp's default Qwen-VL embedding cap (the projector resizes to its own
+# pixel limits, so transport size never enters into it), but mtmd wraps the embeddings
+# in delimiters. Measured on llama-server b10639: 4098 for a 2048x2048 image on
+# Qwen3-VL-4B, 258 on Gemma 3 4B. The wrapper allowance is far above the two measured
+# so longer delimiters still fit. A projector whose embeddings alone exceed the cap
+# (tiling or multi-crop, or a hand-started llama-server with a raised
+# --image-max-tokens; Studio never passes one) needs a projector-aware allowance read
+# off the loaded mmproj, not a bigger number here.
 _OPENAI_LLAMA_ADMISSION_IMAGE_EMBEDDING_CAP = 4096
 _OPENAI_LLAMA_ADMISSION_IMAGE_WRAPPER_TOKENS = 128
 _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = (
@@ -1651,21 +1645,17 @@ _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = (
 def _openai_llama_admission_messages_for_estimate(messages) -> tuple[list[dict], int]:
     """Remove image bytes before estimating the textual part of a prompt.
 
-    llama.cpp's multimodal processor decodes an image and turns it into
-    model-specific embedding tokens. The base64 transport is neither prompt text nor
-    a stable proxy for those tokens. Keep the small shape of each image part for the
-    JSON estimate, and return its count so the caller can add a bounded media
-    allowance.
+    mtmd turns an image into model-specific embedding tokens, so its base64 transport
+    is neither prompt text nor a proxy for that count. Keep each image part's shape for
+    the JSON estimate and return the count, so the caller can add a bounded allowance.
     """
     estimate_messages = []
     image_parts = 0
     for message in messages:
-        # exclude_none, like every other dump of these models in this file, and like
-        # the generation paths this estimate is trying to predict. Without it the
-        # five unset optional fields on ChatMessage are serialised as `"name": null`
-        # and priced as prompt text: 34 tokens for `{"role": "user", "content":
-        # "hi"}` against 8, which on a long thread is thousands of tokens of KV
-        # reserved for punctuation that is never sent.
+        # exclude_none like every other dump here, including the generation paths this
+        # predicts: the five unset optionals on ChatMessage otherwise serialise as
+        # `"name": null` and get priced as prompt text (34 tokens for a two-key message
+        # against 8), reserving KV for punctuation that is never sent.
         message_dict = (
             message if isinstance(message, dict) else message.model_dump(exclude_none = True)
         )
@@ -1697,15 +1687,13 @@ def _openai_llama_admission_messages_for_estimate(messages) -> tuple[list[dict],
 def _openai_llama_admission_media_tokens(payload, *, message_image_parts: int = 0) -> int:
     """Estimate media KV usage without charging transport bytes as prompt tokens.
 
-    The GGUF generation path injects the legacy top-level image only when the
-    request has no message-level image. Studio sends both spellings for the same
-    image, so counting both would reserve the same image twice. A fixed allowance is
-    deliberately used because the exact mtmd token count depends on the loaded
-    vision projector and image preprocessing, not on base64 length.
+    Both builders inject the legacy top-level image only when the messages carry none
+    (`_messages_carry_an_image`), and Studio sends the same image in both spellings, so
+    charging both would reserve it twice. The allowance is fixed because the real mtmd
+    count follows the loaded projector, not base64 length.
 
-    Audio and video keep their existing top-level accounting until the corresponding
-    model-specific KV estimate is available; this fix is scoped to the image path
-    that regressed vision-chat concurrency.
+    Audio and video keep the old top-level accounting until they have a model-specific
+    estimate; this is scoped to the image path that regressed vision concurrency.
     """
     extra = 0
     extra += max(0, message_image_parts) * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
@@ -27723,12 +27711,10 @@ def _splice_image_into_last_user(messages: list[dict], image_part: dict) -> None
 def _messages_carry_an_image(messages: list[dict]) -> bool:
     """Whether the built message list already has a message-level image part.
 
-    The one place that question is answered, because both builders and the KV
-    admission estimate have to answer it the SAME way. Studio sends the current
-    image twice, as an ``image_url`` part and as the legacy top-level field, so a
-    builder that splices the legacy copy on top of the part sends the image
-    twice, while admission (which counts parts) charges for it once. Two copies
-    of this predicate is how that drift happened.
+    One place, because both builders and the KV estimate must answer it the same way.
+    Studio sends the image as an ``image_url`` part AND the legacy top-level field, so a
+    builder that splices the legacy copy on top sends two images against a reservation
+    for one. Two copies of this predicate is how that drift happened.
     """
     return any(
         isinstance(msg.get("content"), list)
@@ -27754,12 +27740,11 @@ def _openai_messages_for_passthrough(payload) -> list[dict]:
     support) and spliced into the last user message as an OpenAI ``image_url``
     content part so vision + function-calling requests work transparently.
 
-    Only when the messages carry no image of their own, matching
-    ``_openai_messages_for_gguf_chat``. Studio echoes the current image into both
-    spellings, so splicing unconditionally sent a tools or response_format
-    request two copies of one image while admission reserved one: measured at
-    4417 tokens reserved against 8466 really charged, which overcommits the KV
-    cache on any backend with more slots than that gap allows.
+    Only when the messages carry none of their own, matching
+    ``_openai_messages_for_gguf_chat``. Studio echoes the image into both spellings, so
+    splicing unconditionally sent a tools or response_format request two copies against
+    a reservation for one: 4417 reserved against 8466 charged, which overcommits the KV
+    cache wherever the slot count lets that gap accumulate.
     """
     messages = _strip_provider_synthetic_tool_history(
         _drop_empty_assistant_sentinels([m.model_dump(exclude_none = True) for m in payload.messages])

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1662,17 +1662,54 @@ def _extra_args_image_max_tokens(extra_args) -> Optional[int]:
     return found
 
 
+# Embeddings one image may become, per projector family, from llama.cpp's own
+# `set_limit_image_tokens` calls in tools/mtmd/clip.cpp; the keys are the
+# `clip.projector_type` strings in clip-impl.h, which is what the mmproj GGUF carries.
+# There is no universal default -- `--image-max-tokens` documents itself as "read from
+# model" -- and the spread is three orders of magnitude, so assuming any one number
+# under-reserves somebody. A family absent here falls back to the default ceiling
+# below, which is the pre-existing behaviour rather than a new guess.
+_MMPROJ_IMAGE_TOKEN_MAX = {
+    "qwen2vl_merger": 4096,
+    "qwen2.5vl_merger": 4096,
+    "qwen3vl_merger": 4096,
+    "glm4v": 4096,
+    "kimik25": 4096,
+    "muse-glimmer": 4096,
+    "youtuvl": 62500,
+    "hunyuanvl": 16384,
+    "pixtral": 1024,
+    "lightonocr": 1024,
+    "kimivl": 1024,
+    "minimax_m3": 576,
+    "gemma4v": 280,
+    "gemma4uv": 280,
+    "lfm2": 256,
+}
+
+
 def _openai_llama_admission_image_tokens(llama_backend) -> int:
     """Per-image KV allowance for the backend that is actually running.
 
-    ``--image-max-tokens`` is not Unsloth-managed, so ``llama_extra_args`` can raise the
-    projector ceiling. Measured on b10639 with ``--image-max-tokens 8192``: a 4096x4096
-    Qwen3-VL image costs 8102, against 4098 at the default, so reserving the default
-    would admit concurrent requests the cache cannot hold.
+    Two things move the ceiling off the default. The loaded projector sets its own:
+    measured on b10639, a max-resolution image is 4098 KV positions on Qwen3-VL-4B and
+    258 on Gemma 3 4B, and clip.cpp's own table runs from 256 (lfm2) to 62500 (youtuvl).
+    And ``--image-max-tokens`` is not an Unsloth-managed flag, so ``llama_extra_args``
+    forwards one verbatim: with ``--image-max-tokens 8192`` that same Qwen3-VL image
+    costs 8102.
+
+    Takes the LARGER of the two rather than trusting the flag, because llama-server
+    applies it only to dynamic-resolution projectors -- a low cap against a fixed
+    resolution one is ignored, and believing it would reserve less than the image costs.
+    Over-reserving is the safe direction; under-reserving hands out a slot the cache
+    cannot back.
     """
-    cap = _extra_args_image_max_tokens(getattr(llama_backend, "_extra_args", None))
-    if cap is None:
-        return _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+    projector = getattr(llama_backend, "_mmproj_projector_type", None)
+    known = _MMPROJ_IMAGE_TOKEN_MAX.get(str(projector).strip().lower()) if projector else None
+    cap = max(
+        known or _OPENAI_LLAMA_ADMISSION_IMAGE_EMBEDDING_CAP,
+        _extra_args_image_max_tokens(getattr(llama_backend, "_extra_args", None)) or 0,
+    )
     return cap + _OPENAI_LLAMA_ADMISSION_IMAGE_WRAPPER_TOKENS
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1624,7 +1624,28 @@ def _openai_llama_admission_extra_prompt_tokens(payload) -> int:
     return extra
 
 
-_OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = 4096
+# KV positions to reserve per image, as an upper bound rather than an estimate.
+#
+# 4096 is llama.cpp's default ceiling on Qwen-VL embeddings per image (the projector
+# resizes to its own pixel limits, so transport size never enters into it), but the
+# embeddings are not the whole cost: mtmd wraps them in delimiter tokens. Measured
+# against llama-server b10639, a 2048x2048 image costs 4098 on Qwen3-VL-4B, i.e. the
+# cap plus two, and 258 on Gemma 3 4B (256 embeddings plus the same two). A flat 4096
+# is therefore provably BELOW the real ceiling, and under-reserving is the one
+# direction this accounting must never err in: it hands out a slot the cache cannot
+# back, which is the overcommit #9392 exists to stop.
+#
+# The wrapper allowance is deliberately much larger than the two tokens measured, to
+# cover projectors whose delimiters are longer. It is still a bound, not a guess: a
+# projector whose embeddings alone exceed the cap (tiling or multi-crop families, or a
+# llama-server started by hand with a raised --image-max-tokens; Studio never passes
+# one) is outside what this constant can promise, and wants a projector-aware
+# allowance read off the loaded mmproj rather than a bigger number here.
+_OPENAI_LLAMA_ADMISSION_IMAGE_EMBEDDING_CAP = 4096
+_OPENAI_LLAMA_ADMISSION_IMAGE_WRAPPER_TOKENS = 128
+_OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = (
+    _OPENAI_LLAMA_ADMISSION_IMAGE_EMBEDDING_CAP + _OPENAI_LLAMA_ADMISSION_IMAGE_WRAPPER_TOKENS
+)
 
 
 def _openai_llama_admission_messages_for_estimate(messages) -> tuple[list[dict], int]:
@@ -1639,11 +1660,15 @@ def _openai_llama_admission_messages_for_estimate(messages) -> tuple[list[dict],
     estimate_messages = []
     image_parts = 0
     for message in messages:
-        message_dict = message if isinstance(message, dict) else message.model_dump()
-        if not isinstance(message_dict, dict):
-            estimate_messages.append(message_dict)
-            continue
-
+        # exclude_none, like every other dump of these models in this file, and like
+        # the generation paths this estimate is trying to predict. Without it the
+        # five unset optional fields on ChatMessage are serialised as `"name": null`
+        # and priced as prompt text: 34 tokens for `{"role": "user", "content":
+        # "hi"}` against 8, which on a long thread is thousands of tokens of KV
+        # reserved for punctuation that is never sent.
+        message_dict = (
+            message if isinstance(message, dict) else message.model_dump(exclude_none = True)
+        )
         estimate_message = dict(message_dict)
         content = message_dict.get("content")
         if isinstance(content, list):
@@ -27695,6 +27720,25 @@ def _splice_image_into_last_user(messages: list[dict], image_part: dict) -> None
         messages.append({"role": "user", "content": [image_part]})
 
 
+def _messages_carry_an_image(messages: list[dict]) -> bool:
+    """Whether the built message list already has a message-level image part.
+
+    The one place that question is answered, because both builders and the KV
+    admission estimate have to answer it the SAME way. Studio sends the current
+    image twice, as an ``image_url`` part and as the legacy top-level field, so a
+    builder that splices the legacy copy on top of the part sends the image
+    twice, while admission (which counts parts) charges for it once. Two copies
+    of this predicate is how that drift happened.
+    """
+    return any(
+        isinstance(msg.get("content"), list)
+        and any(
+            isinstance(part, dict) and part.get("type") == "image_url" for part in msg["content"]
+        )
+        for msg in messages
+    )
+
+
 def _openai_messages_for_passthrough(payload) -> list[dict]:
     """Build OpenAI-format message dicts for the /v1/chat/completions
     passthrough path.
@@ -27709,12 +27753,19 @@ def _openai_messages_for_passthrough(payload) -> list[dict]:
     image is re-encoded to PNG (llama-server's stb_image has limited format
     support) and spliced into the last user message as an OpenAI ``image_url``
     content part so vision + function-calling requests work transparently.
+
+    Only when the messages carry no image of their own, matching
+    ``_openai_messages_for_gguf_chat``. Studio echoes the current image into both
+    spellings, so splicing unconditionally sent a tools or response_format
+    request two copies of one image while admission reserved one: measured at
+    4417 tokens reserved against 8466 really charged, which overcommits the KV
+    cache on any backend with more slots than that gap allows.
     """
     messages = _strip_provider_synthetic_tool_history(
         _drop_empty_assistant_sentinels([m.model_dump(exclude_none = True) for m in payload.messages])
     )
 
-    if not payload.image_base64:
+    if not payload.image_base64 or _messages_carry_an_image(messages):
         return messages
 
     try:
@@ -27799,12 +27850,7 @@ def _openai_messages_for_gguf_chat(payload, is_vision: bool) -> tuple[list[dict]
             )
         )
     )
-    has_message_image = any(
-        isinstance(msg.get("content"), list)
-        and any(part.get("type") == "image_url" for part in msg["content"])
-        for msg in messages
-    )
-    if payload.image_base64 and not has_message_image:
+    if payload.image_base64 and not _messages_carry_an_image(messages):
         # Legacy bytes can be any format; the normalizer below sniffs and
         # re-encodes to PNG, so the declared mime is rewritten anyway.
         image_part = {

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1624,23 +1624,70 @@ def _openai_llama_admission_extra_prompt_tokens(payload) -> int:
     return extra
 
 
-def _openai_llama_admission_media_tokens(payload) -> int:
-    """Media the request carries in Unsloth's legacy top-level fields, in tokens.
+_OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = 4096
 
-    Unsloth's own composer sends every attachment as ``image_base64`` /
-    ``audio_base64`` / ``video_base64``, never as ``messages`` content parts, and the
-    generation path splices them into the prompt AFTER this estimate is taken
-    (``_openai_messages_for_gguf_chat``, ``_inject_audio_part``,
-    ``_inject_video_part``). Charging only ``messages`` therefore priced an image at
-    zero while llama.cpp's mtmd embeddings occupy real KV positions, so two
-    media-heavy chats with a line of text each were admitted against a cache that
-    holds one.
 
-    Sized as the same media inlined as a data URL is already sized, so the two
-    spellings of one request cost the same rather than 30x apart.
+def _openai_llama_admission_messages_for_estimate(messages) -> tuple[list[dict], int]:
+    """Remove image bytes before estimating the textual part of a prompt.
+
+    llama.cpp's multimodal processor decodes an image and turns it into
+    model-specific embedding tokens. The base64 transport is neither prompt text nor
+    a stable proxy for those tokens. Keep the small shape of each image part for the
+    JSON estimate, and return its count so the caller can add a bounded media
+    allowance.
+    """
+    estimate_messages = []
+    image_parts = 0
+    for message in messages:
+        message_dict = message if isinstance(message, dict) else message.model_dump()
+        if not isinstance(message_dict, dict):
+            estimate_messages.append(message_dict)
+            continue
+
+        estimate_message = dict(message_dict)
+        content = message_dict.get("content")
+        if isinstance(content, list):
+            estimate_content = []
+            for part in content:
+                if not isinstance(part, dict) or part.get("type") != "image_url":
+                    estimate_content.append(part)
+                    continue
+
+                image_parts += 1
+                image_url = part.get("image_url")
+                compact_image_url = {"url": "[image]"}
+                if isinstance(image_url, dict) and image_url.get("detail") is not None:
+                    compact_image_url["detail"] = image_url["detail"]
+                estimate_content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": compact_image_url,
+                    }
+                )
+            estimate_message["content"] = estimate_content
+        estimate_messages.append(estimate_message)
+    return estimate_messages, image_parts
+
+
+def _openai_llama_admission_media_tokens(payload, *, message_image_parts: int = 0) -> int:
+    """Estimate media KV usage without charging transport bytes as prompt tokens.
+
+    The GGUF generation path injects the legacy top-level image only when the
+    request has no message-level image. Studio sends both spellings for the same
+    image, so counting both would reserve the same image twice. A fixed allowance is
+    deliberately used because the exact mtmd token count depends on the loaded
+    vision projector and image preprocessing, not on base64 length.
+
+    Audio and video keep their existing top-level accounting until the corresponding
+    model-specific KV estimate is available; this fix is scoped to the image path
+    that regressed vision-chat concurrency.
     """
     extra = 0
-    for attribute in ("image_base64", "audio_base64", "video_base64"):
+    extra += max(0, message_image_parts) * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+    image = getattr(payload, "image_base64", None)
+    if message_image_parts == 0 and isinstance(image, str) and image:
+        extra += _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+    for attribute in ("audio_base64", "video_base64"):
         value = getattr(payload, attribute, None)
         if isinstance(value, str) and value:
             extra += max(1, len(value) // 4)
@@ -1669,11 +1716,17 @@ def _openai_llama_admission_tokens(
     messages = getattr(payload, "messages", None)
     if isinstance(messages, list) and messages:
         try:
+            estimate_messages, message_image_parts = _openai_llama_admission_messages_for_estimate(
+                messages
+            )
             prompt_tokens = estimate_messages_tokens_dense(
-                [m if isinstance(m, dict) else m.model_dump() for m in messages]
+                estimate_messages
             )
             prompt_tokens += _openai_llama_admission_extra_prompt_tokens(payload)
-            prompt_tokens += _openai_llama_admission_media_tokens(payload)
+            prompt_tokens += _openai_llama_admission_media_tokens(
+                payload,
+                message_image_parts = message_image_parts,
+            )
         except Exception:
             prompt_tokens = None
     else:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1665,11 +1665,10 @@ def _extra_args_image_max_tokens(extra_args) -> Optional[int]:
 def _openai_llama_admission_image_tokens(llama_backend) -> int:
     """Per-image KV allowance for the backend that is actually running.
 
-    ``--image-max-tokens`` is not an Unsloth-managed flag, so a load can raise the
-    projector's ceiling through ``llama_extra_args`` and make one image cost far more
-    than the default. Measured on b10639 with ``--image-max-tokens 8192``: a 4096x4096
-    Qwen3-VL image costs 8102, against 4098 at the default. Reserving the default
-    against that backend would admit concurrent requests the cache cannot hold.
+    ``--image-max-tokens`` is not Unsloth-managed, so ``llama_extra_args`` can raise the
+    projector ceiling. Measured on b10639 with ``--image-max-tokens 8192``: a 4096x4096
+    Qwen3-VL image costs 8102, against 4098 at the default, so reserving the default
+    would admit concurrent requests the cache cannot hold.
     """
     cap = _extra_args_image_max_tokens(getattr(llama_backend, "_extra_args", None))
     if cap is None:
@@ -27877,10 +27876,9 @@ def _openai_messages_for_gguf_chat(payload, is_vision: bool) -> tuple[list[dict]
             )
         )
     )
-    # `_legacy_image_is_distinct`, not "the messages carry no image": Studio's echo is
-    # byte-equal to a part already here and must not be spliced twice, but a legacy
-    # image the thread does not hold is a real attachment, and dropping it answers
-    # without the image the client just sent. Admission charges on the same predicate.
+    # Distinctness, not "the messages carry no image": Studio's echo is byte-equal to a
+    # part already here and must not be spliced twice, but a legacy image the thread
+    # does not hold is a real attachment. Admission charges on the same predicate.
     if _legacy_image_is_distinct(payload):
         # Legacy bytes can be any format; the normalizer below sniffs and
         # re-encodes to PNG, so the declared mime is rewritten anyway.

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1719,9 +1719,7 @@ def _openai_llama_admission_tokens(
             estimate_messages, message_image_parts = _openai_llama_admission_messages_for_estimate(
                 messages
             )
-            prompt_tokens = estimate_messages_tokens_dense(
-                estimate_messages
-            )
+            prompt_tokens = estimate_messages_tokens_dense(estimate_messages)
             prompt_tokens += _openai_llama_admission_extra_prompt_tokens(payload)
             prompt_tokens += _openai_llama_admission_media_tokens(
                 payload,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1631,15 +1631,50 @@ def _openai_llama_admission_extra_prompt_tokens(payload) -> int:
 # pixel limits, so transport size never enters into it), but mtmd wraps the embeddings
 # in delimiters. Measured on llama-server b10639: 4098 for a 2048x2048 image on
 # Qwen3-VL-4B, 258 on Gemma 3 4B. The wrapper allowance is far above the two measured
-# so longer delimiters still fit. A projector whose embeddings alone exceed the cap
-# (tiling or multi-crop, or a hand-started llama-server with a raised
-# --image-max-tokens; Studio never passes one) needs a projector-aware allowance read
-# off the loaded mmproj, not a bigger number here.
+# so longer delimiters still fit. Only the DEFAULT, though: a load may raise the cap
+# (`_openai_llama_admission_image_tokens`), and a projector whose embeddings exceed it
+# on their own (tiling or multi-crop families) still wants an allowance read off the
+# loaded mmproj rather than a bigger number here.
 _OPENAI_LLAMA_ADMISSION_IMAGE_EMBEDDING_CAP = 4096
 _OPENAI_LLAMA_ADMISSION_IMAGE_WRAPPER_TOKENS = 128
 _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = (
     _OPENAI_LLAMA_ADMISSION_IMAGE_EMBEDDING_CAP + _OPENAI_LLAMA_ADMISSION_IMAGE_WRAPPER_TOKENS
 )
+
+
+def _extra_args_image_max_tokens(extra_args) -> Optional[int]:
+    """The ``--image-max-tokens N`` a load passed through, or None. Last wins.
+
+    Both spellings, since llama-server accepts ``--flag N`` and ``--flag=N``.
+    """
+    args = [str(arg) for arg in (extra_args or ())]
+    found = None
+    for index, raw in enumerate(args):
+        if raw.startswith("--image-max-tokens="):
+            value = raw.partition("=")[2]
+        elif raw == "--image-max-tokens" and index + 1 < len(args):
+            value = args[index + 1]
+        else:
+            continue
+        parsed = _positive_int_or_none(value)
+        if parsed is not None:
+            found = parsed
+    return found
+
+
+def _openai_llama_admission_image_tokens(llama_backend) -> int:
+    """Per-image KV allowance for the backend that is actually running.
+
+    ``--image-max-tokens`` is not an Unsloth-managed flag, so a load can raise the
+    projector's ceiling through ``llama_extra_args`` and make one image cost far more
+    than the default. Measured on b10639 with ``--image-max-tokens 8192``: a 4096x4096
+    Qwen3-VL image costs 8102, against 4098 at the default. Reserving the default
+    against that backend would admit concurrent requests the cache cannot hold.
+    """
+    cap = _extra_args_image_max_tokens(getattr(llama_backend, "_extra_args", None))
+    if cap is None:
+        return _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+    return cap + _OPENAI_LLAMA_ADMISSION_IMAGE_WRAPPER_TOKENS
 
 
 def _openai_llama_admission_messages_for_estimate(messages) -> tuple[list[dict], int]:
@@ -1684,22 +1719,27 @@ def _openai_llama_admission_messages_for_estimate(messages) -> tuple[list[dict],
     return estimate_messages, image_parts
 
 
-def _openai_llama_admission_media_tokens(payload, *, message_image_parts: int = 0) -> int:
+def _openai_llama_admission_media_tokens(
+    payload,
+    *,
+    message_image_parts: int = 0,
+    image_tokens: int = _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS,
+) -> int:
     """Estimate media KV usage without charging transport bytes as prompt tokens.
 
-    Both builders inject the legacy top-level image only when the messages carry none
-    (`_messages_carry_an_image`), and Studio sends the same image in both spellings, so
-    charging both would reserve it twice. The allowance is fixed because the real mtmd
-    count follows the loaded projector, not base64 length.
+    Charges the legacy top-level image on exactly the condition both builders splice it
+    on, ``_legacy_image_is_distinct``: Studio echoes one image into both spellings, so
+    charging that twice reserves it twice, while a legacy image the messages do not
+    already carry is a second image really sent. The allowance is per-image rather than
+    per-byte because the real mtmd count follows the loaded projector, not base64 length.
 
     Audio and video keep the old top-level accounting until they have a model-specific
     estimate; this is scoped to the image path that regressed vision concurrency.
     """
     extra = 0
-    extra += max(0, message_image_parts) * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
-    image = getattr(payload, "image_base64", None)
-    if message_image_parts == 0 and isinstance(image, str) and image:
-        extra += _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+    extra += max(0, message_image_parts) * image_tokens
+    if _legacy_image_is_distinct(payload):
+        extra += image_tokens
     for attribute in ("audio_base64", "video_base64"):
         value = getattr(payload, attribute, None)
         if isinstance(value, str) and value:
@@ -1713,6 +1753,7 @@ def _openai_llama_admission_tokens(
     budget: Optional[int],
     capacity: int,
     tool_loop: bool = False,
+    image_tokens: int = _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS,
 ) -> Optional[int]:
     """KV a request will occupy: what is sent, plus what it may generate.
 
@@ -1737,6 +1778,7 @@ def _openai_llama_admission_tokens(
             prompt_tokens += _openai_llama_admission_media_tokens(
                 payload,
                 message_image_parts = message_image_parts,
+                image_tokens = image_tokens,
             )
         except Exception:
             prompt_tokens = None
@@ -1806,6 +1848,7 @@ def _openai_llama_admission_reserve(
             budget = budget,
             capacity = capacity,
             tool_loop = tool_loop,
+            image_tokens = _openai_llama_admission_image_tokens(llama_backend),
         )
         if payload is not None
         else None,
@@ -16380,26 +16423,42 @@ def _legacy_image_is_distinct(payload) -> bool:
     against that one value alone: matching any image in the thread let a client
     resend an older image, or an assistant's, and hid a real attachment.
     """
-    if not payload.image_base64:
+    image = getattr(payload, "image_base64", None)
+    if not image:
         return False
-    return _latest_user_image_payload(payload.messages) != payload.image_base64
+    return _latest_user_image_payload(getattr(payload, "messages", None)) != image
 
 
-def _latest_user_image_payload(messages: list) -> "Optional[str]":
+def _latest_user_image_payload(messages) -> "Optional[str]":
     """The value ``findLatestUserImageBase64`` would put in ``image_base64``.
 
     Its scan order: newest turn first, user turns only, first image part, ``data:``
     prefix stripped the way :func:`_extract_content_parts` strips it. A part that
     yields nothing does not end the scan, since the frontend walks on past a falsy
     read; stopping on one refused Studio's echo of a valid earlier image.
+
+    Reads models and plain dicts alike: the generation paths only ever hold models, but
+    the KV admission estimate sees whatever the caller passed, and both have to answer
+    "is the legacy field an echo?" the same way or the reservation stops matching the
+    prompt.
     """
-    for msg in reversed(messages):
-        if msg.role != "user" or not isinstance(msg.content, list):
+    for msg in reversed(list(messages or ())):
+        role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+        content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", None)
+        if role != "user" or not isinstance(content, list):
             continue
-        for part in msg.content:
-            if part.type != "image_url":
+        for part in content:
+            if isinstance(part, dict):
+                if part.get("type") != "image_url":
+                    continue
+                image_url = part.get("image_url")
+                url = image_url.get("url") if isinstance(image_url, dict) else image_url
+            else:
+                if getattr(part, "type", None) != "image_url":
+                    continue
+                url = getattr(getattr(part, "image_url", None), "url", None)
+            if not isinstance(url, str):
                 continue
-            url = part.image_url.url
             encoded = url.partition(",")[2] if url.startswith("data:") else url
             if encoded:
                 return encoded
@@ -27708,23 +27767,6 @@ def _splice_image_into_last_user(messages: list[dict], image_part: dict) -> None
         messages.append({"role": "user", "content": [image_part]})
 
 
-def _messages_carry_an_image(messages: list[dict]) -> bool:
-    """Whether the built message list already has a message-level image part.
-
-    One place, because both builders and the KV estimate must answer it the same way.
-    Studio sends the image as an ``image_url`` part AND the legacy top-level field, so a
-    builder that splices the legacy copy on top sends two images against a reservation
-    for one. Two copies of this predicate is how that drift happened.
-    """
-    return any(
-        isinstance(msg.get("content"), list)
-        and any(
-            isinstance(part, dict) and part.get("type") == "image_url" for part in msg["content"]
-        )
-        for msg in messages
-    )
-
-
 def _openai_messages_for_passthrough(payload) -> list[dict]:
     """Build OpenAI-format message dicts for the /v1/chat/completions
     passthrough path.
@@ -27740,17 +27782,17 @@ def _openai_messages_for_passthrough(payload) -> list[dict]:
     support) and spliced into the last user message as an OpenAI ``image_url``
     content part so vision + function-calling requests work transparently.
 
-    Only when the messages carry none of their own, matching
-    ``_openai_messages_for_gguf_chat``. Studio echoes the image into both spellings, so
-    splicing unconditionally sent a tools or response_format request two copies against
-    a reservation for one: 4417 reserved against 8466 charged, which overcommits the KV
-    cache wherever the slot count lets that gap accumulate.
+    Only when it is a real second image, matching ``_openai_messages_for_gguf_chat`` and
+    what admission charges for. Studio echoes the current image into both spellings, so
+    splicing that unconditionally sent a tools or response_format request two copies
+    against a reservation for one: 4417 reserved against 8466 charged, which overcommits
+    the KV cache wherever the slot count lets that gap accumulate.
     """
     messages = _strip_provider_synthetic_tool_history(
         _drop_empty_assistant_sentinels([m.model_dump(exclude_none = True) for m in payload.messages])
     )
 
-    if not payload.image_base64 or _messages_carry_an_image(messages):
+    if not _legacy_image_is_distinct(payload):
         return messages
 
     try:
@@ -27835,7 +27877,11 @@ def _openai_messages_for_gguf_chat(payload, is_vision: bool) -> tuple[list[dict]
             )
         )
     )
-    if payload.image_base64 and not _messages_carry_an_image(messages):
+    # `_legacy_image_is_distinct`, not "the messages carry no image": Studio's echo is
+    # byte-equal to a part already here and must not be spliced twice, but a legacy
+    # image the thread does not hold is a real attachment, and dropping it answers
+    # without the image the client just sent. Admission charges on the same predicate.
+    if _legacy_image_is_distinct(payload):
         # Legacy bytes can be any format; the normalizer below sniffs and
         # re-encodes to PNG, so the declared mime is rewritten anyway.
         image_part = {

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -34,6 +34,18 @@ def _image_b64(kib: int = 200) -> str:
     return base64.b64encode(b"\x89PNG" + b"x" * (kib * 1024)).decode()
 
 
+# Two real, decodable, DIFFERENT PNGs. The builders decode and re-encode, unlike the
+# estimator, so the synthetic fixture above cannot reach them; and the pair has to
+# differ for a distinct-legacy-image case to be distinct at all.
+_TINY_PNG = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC"
+)
+_OTHER_PNG = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFklEQVR4nGP8z8DAwMDAxMDAwMDAAAANHQED"
+    "asKb6QAAAABJRU5ErkJggg=="
+)
+
+
 class TestMediaIsCharged:
     def test_legacy_image_costs_what_the_same_image_inline_costs(self):
         image = _image_b64()
@@ -109,6 +121,10 @@ class TestMediaIsCharged:
         echo; `_openai_messages_for_passthrough` (taken when a client sends ``tools`` or
         a ``response_format``) spliced it in regardless, sending two copies against a
         reservation for one: 4417 reserved against 8466 charged on llama-server b10639.
+
+        The echo is the only thing that may be dropped. A legacy image the thread does
+        not already hold is a real attachment, so both builders send it and admission
+        charges for it -- keyed on the same predicate, or the two answers drift again.
         """
         from models.inference import ChatCompletionRequest
         from routes.inference import (
@@ -118,11 +134,7 @@ class TestMediaIsCharged:
             _openai_messages_for_passthrough,
         )
 
-        # A real 1x1 PNG: the builders decode and re-encode, unlike the estimator.
-        image = (
-            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQ"
-            "AAAABJRU5ErkJggg=="
-        )
+        image = _TINY_PNG
         inline_part = {
             "type": "image_url",
             "image_url": {"url": f"data:image/png;base64,{image}"},
@@ -154,6 +166,19 @@ class TestMediaIsCharged:
                 max_tokens = 128,
                 messages = [{"role": "user", "content": "what is this?"}],
                 image_base64 = image,
+            ),
+            # An older image in history plus a genuinely different one attached to this
+            # turn through the legacy field: two images, and both must be charged.
+            "history image plus a distinct legacy attachment": ChatCompletionRequest(
+                model = "m",
+                max_tokens = 128,
+                messages = [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "and this?"}, inline_part],
+                    }
+                ],
+                image_base64 = _OTHER_PNG,
             ),
         }
 
@@ -196,6 +221,38 @@ class TestMediaIsCharged:
             assert (
                 _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS >= tokens
             ), f"per-image allowance under-reserves {model}"
+
+    def test_the_allowance_follows_a_raised_image_token_cap(self):
+        """A load can raise the projector ceiling, and the reservation has to follow it.
+
+        ``--image-max-tokens`` is not Unsloth-managed, so ``llama_extra_args`` forwards
+        it verbatim. Measured on b10639 with ``--image-max-tokens 8192``: a 4096x4096
+        Qwen3-VL image costs 8102, against 4098 at the default. Reserving the default
+        against that backend admits concurrent requests the cache cannot hold.
+        """
+        from routes.inference import _openai_llama_admission_image_tokens
+
+        class _Backend:
+            def __init__(self, extra_args):
+                self._extra_args = extra_args
+
+        assert _openai_llama_admission_image_tokens(_Backend(None)) == (
+            _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+        )
+        for spelling in (["--image-max-tokens", "8192"], ["--image-max-tokens=8192"]):
+            allowance = _openai_llama_admission_image_tokens(_Backend(spelling))
+            assert allowance > _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+            assert allowance >= 8102, f"{spelling} under-reserves the measured cost"
+        # A lowered cap reserves less, which is the whole point of reading it.
+        assert (
+            _openai_llama_admission_image_tokens(_Backend(["--image-max-tokens", "512"]))
+            < _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+        )
+        # Junk must not be mistaken for a cap, and must not raise.
+        for junk in (["--image-max-tokens"], ["--image-max-tokens", "abc"], ["-c", "40000"]):
+            assert _openai_llama_admission_image_tokens(_Backend(junk)) == (
+                _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+            )
 
     def test_two_large_studio_image_chats_can_be_admitted_together(self):
         """A large base64 transport must not turn each vision request into a full-cache lease."""

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -107,12 +107,12 @@ class TestMediaIsCharged:
         inline_cost = _openai_llama_admission_tokens(inline, budget = 1_000_000, capacity = 4)
 
         assert dual_cost == inline_cost
-        assert (
-            dual_cost < 2 * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
-        ), "the echo must be charged once, not once per spelling"
-        assert (
-            dual_cost >= _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
-        ), "image bytes must be bounded but still charged"
+        assert dual_cost < 2 * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS, (
+            "the echo must be charged once, not once per spelling"
+        )
+        assert dual_cost >= _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS, (
+            "image bytes must be bounded but still charged"
+        )
 
     def test_every_builder_forwards_exactly_what_admission_charged(self):
         """The reservation is only a bound if it counts the images actually sent.
@@ -218,9 +218,9 @@ class TestMediaIsCharged:
         """
         measured_worst_case = {"qwen3-vl-4b": 4098, "gemma-3-4b": 258}
         for model, tokens in measured_worst_case.items():
-            assert (
-                _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS >= tokens
-            ), f"per-image allowance under-reserves {model}"
+            assert _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS >= tokens, (
+                f"per-image allowance under-reserves {model}"
+            )
 
     def test_the_allowance_follows_a_raised_image_token_cap(self):
         """A load can raise the projector ceiling, and the reservation has to follow it.
@@ -230,29 +230,53 @@ class TestMediaIsCharged:
         Qwen3-VL image costs 8102, against 4098 at the default. Reserving the default
         against that backend admits concurrent requests the cache cannot hold.
         """
-        from routes.inference import _openai_llama_admission_image_tokens
+        from routes.inference import (
+            _MMPROJ_IMAGE_TOKEN_MAX,
+            _openai_llama_admission_image_tokens,
+        )
 
         class _Backend:
-            def __init__(self, extra_args):
+            def __init__(
+                self,
+                extra_args = None,
+                projector = None,
+            ):
                 self._extra_args = extra_args
+                self._mmproj_projector_type = projector
 
-        assert _openai_llama_admission_image_tokens(_Backend(None)) == (
+        assert _openai_llama_admission_image_tokens(_Backend()) == (
             _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
         )
         for spelling in (["--image-max-tokens", "8192"], ["--image-max-tokens=8192"]):
             allowance = _openai_llama_admission_image_tokens(_Backend(spelling))
             assert allowance > _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
             assert allowance >= 8102, f"{spelling} under-reserves the measured cost"
-        # A lowered cap reserves less, which is the whole point of reading it.
-        assert (
-            _openai_llama_admission_image_tokens(_Backend(["--image-max-tokens", "512"]))
-            < _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
-        )
         # Junk must not be mistaken for a cap, and must not raise.
         for junk in (["--image-max-tokens"], ["--image-max-tokens", "abc"], ["-c", "40000"]):
             assert _openai_llama_admission_image_tokens(_Backend(junk)) == (
                 _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
             )
+
+        # Every family llama.cpp gives its own ceiling must be bounded, including the
+        # ones far above the default: youtuvl is 62500 and hunyuanvl 16384, so a flat
+        # default would have reserved a fraction of what one image really costs.
+        for projector, ceiling in _MMPROJ_IMAGE_TOKEN_MAX.items():
+            assert _openai_llama_admission_image_tokens(_Backend(projector = projector)) >= ceiling
+        assert _openai_llama_admission_image_tokens(_Backend(projector = "youtuvl")) >= 62500
+        # A projector with a small ceiling reserves near it rather than the default.
+        assert _openai_llama_admission_image_tokens(_Backend(projector = "lfm2")) < 1024
+        # An unknown family keeps the default rather than inventing a number.
+        assert _openai_llama_admission_image_tokens(_Backend(projector = "nope")) == (
+            _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+        )
+        # The flag is only honoured by dynamic-resolution projectors, so a LOW cap must
+        # not talk the reservation below what a fixed-resolution one really costs.
+        assert (
+            _openai_llama_admission_image_tokens(
+                _Backend(["--image-max-tokens", "16"], projector = "qwen3vl_merger")
+            )
+            >= _MMPROJ_IMAGE_TOKEN_MAX["qwen3vl_merger"]
+        )
 
     def test_two_large_studio_image_chats_can_be_admitted_together(self):
         """A large base64 transport must not turn each vision request into a full-cache lease."""

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -95,12 +95,12 @@ class TestMediaIsCharged:
         inline_cost = _openai_llama_admission_tokens(inline, budget = 1_000_000, capacity = 4)
 
         assert dual_cost == inline_cost
-        assert dual_cost < 2 * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS, (
-            "the echo must be charged once, not once per spelling"
-        )
-        assert dual_cost >= _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS, (
-            "image bytes must be bounded but still charged"
-        )
+        assert (
+            dual_cost < 2 * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+        ), "the echo must be charged once, not once per spelling"
+        assert (
+            dual_cost >= _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+        ), "image bytes must be bounded but still charged"
 
     def test_every_builder_forwards_exactly_what_admission_charged(self):
         """The reservation is only a bound if it counts the images actually sent.
@@ -193,9 +193,9 @@ class TestMediaIsCharged:
         """
         measured_worst_case = {"qwen3-vl-4b": 4098, "gemma-3-4b": 258}
         for model, tokens in measured_worst_case.items():
-            assert _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS >= tokens, (
-                f"per-image allowance under-reserves {model}"
-            )
+            assert (
+                _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS >= tokens
+            ), f"per-image allowance under-reserves {model}"
 
     def test_two_large_studio_image_chats_can_be_admitted_together(self):
         """A large base64 transport must not turn each vision request into a full-cache lease."""

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -57,16 +57,14 @@ class TestMediaIsCharged:
             ],
             max_tokens = 128,
         )
-        # Budget well clear of both costs. At 4096 the estimate is clamped to the
-        # budget by `max(1, min(budget, ...))` on BOTH sides, so the two agreed at
-        # the clamp whatever the estimator did and the assertion proved nothing.
+        # Clear of the clamp: at 4096 `max(1, min(budget, ...))` pinned both sides to the
+        # budget, so they agreed whatever the estimator did and this proved nothing.
         legacy_cost = _openai_llama_admission_tokens(legacy, budget = 1_000_000, capacity = 4)
         inline_cost = _openai_llama_admission_tokens(inline, budget = 1_000_000, capacity = 4)
-        # The wire spelling must not change the KV commitment for the same image.
-        # Not to the token: the inline spelling really does send a content-part
-        # wrapper the legacy one does not, and the compact marker standing in for the
-        # bytes is itself a few tokens of JSON. What must not survive is the 30x gap
-        # between pricing an image at its base64 length and pricing it at its text.
+        # The wire spelling must not change the commitment. Not to the token: inline
+        # really does send a content-part wrapper legacy does not, and the marker is
+        # itself a little JSON. What must not survive is the 30x gap between pricing an
+        # image at its base64 length and at its text.
         assert abs(legacy_cost - inline_cost) <= 64, (legacy_cost, inline_cost)
         assert max(legacy_cost, inline_cost) < 2 * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
 
@@ -91,9 +89,8 @@ class TestMediaIsCharged:
         )
         inline = _Payload(messages = inline_messages, max_tokens = 128)
 
-        # A budget no clamp can reach: at 65536 a 1 MiB image priced as prompt text
-        # clamps to the budget on both sides, so `dual == inline` held on the
-        # unfixed estimator too and only the upper bound below did any work.
+        # Clear of the clamp: at 65536 a 1 MiB image priced as prompt text pinned both
+        # sides to the budget, so `dual == inline` held on the unfixed estimator too.
         dual_cost = _openai_llama_admission_tokens(dual, budget = 1_000_000, capacity = 4)
         inline_cost = _openai_llama_admission_tokens(inline, budget = 1_000_000, capacity = 4)
 
@@ -108,13 +105,10 @@ class TestMediaIsCharged:
     def test_every_builder_forwards_exactly_what_admission_charged(self):
         """The reservation is only a bound if it counts the images actually sent.
 
-        Studio echoes one image into both the ``image_url`` part and the legacy
-        top-level field. `_openai_messages_for_gguf_chat` has always dropped the
-        echo, but `_openai_messages_for_passthrough` -- the builder a request with
-        client ``tools`` or a ``response_format`` goes through -- spliced it in
-        unconditionally, so it sent two copies of one image against a reservation
-        for one. Measured against llama-server b10639 with a 2048x2048 image: 4417
-        reserved, 8466 really charged.
+        Studio echoes one image into both spellings. The GGUF builder always dropped the
+        echo; `_openai_messages_for_passthrough` (taken when a client sends ``tools`` or
+        a ``response_format``) spliced it in regardless, sending two copies against a
+        reservation for one: 4417 reserved against 8466 charged on llama-server b10639.
         """
         from models.inference import ChatCompletionRequest
         from routes.inference import (
@@ -192,12 +186,10 @@ class TestMediaIsCharged:
     def test_the_allowance_bounds_a_real_projector(self):
         """The per-image charge is an upper bound, not an estimate.
 
-        Measured against llama-server b10639: a 2048x2048 image costs 4098 KV
-        positions on Qwen3-VL-4B (llama.cpp's 4096-embedding cap for that projector
-        plus two mtmd delimiters) and 258 on Gemma 3 4B, at every resolution and
-        every encoded size. A flat 4096 was below the Qwen figure, and reserving
-        less than a request costs is what lets two of them collide in a cache that
-        holds one.
+        Measured on llama-server b10639: 4098 KV positions for a 2048x2048 image on
+        Qwen3-VL-4B (the 4096-embedding cap plus two mtmd delimiters) and 258 on Gemma 3
+        4B, at every resolution and encoded size. A flat 4096 sat below the Qwen figure,
+        and reserving less than a request costs is what lets two collide in one cache.
         """
         measured_worst_case = {"qwen3-vl-4b": 4098, "gemma-3-4b": 258}
         for model, tokens in measured_worst_case.items():

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Two holes in the KV reservation the estimator has to charge for.
+"""Media and tool-loop cases that the KV reservation has to charge for.
 
-Media: Unsloth's composer sends attachments in the legacy top-level ``image_base64`` /
-``audio_base64`` / ``video_base64`` fields, and the generation path splices them into
-the prompt AFTER admission is decided. Charging only ``messages`` priced an image at
-zero while llama.cpp's mtmd embeddings take real KV positions.
+Media: Unsloth's composer sends the current image in both a message-level
+``image_url`` part and the legacy top-level ``image_base64`` field. The generation
+path splices legacy media into the prompt AFTER admission is decided. Admission must
+charge the resulting image once, without treating base64 bytes as prompt text.
 
 Tool loop: the server-side loop opens on ``enable_tools`` / ``mcp_enabled`` / the CLI
 policy / a checkpoint repair, none of which require a client ``tools`` array, so a
@@ -56,9 +56,78 @@ class TestMediaIsCharged:
         )
         legacy_cost = _openai_llama_admission_tokens(legacy, budget = 4096, capacity = 4)
         inline_cost = _openai_llama_admission_tokens(inline, budget = 4096, capacity = 4)
-        # Before the fix this was 139 against 4096: the same request, one spelling
-        # charged the whole cache and the other charged its 13 characters of text.
+        # The wire spelling must not change the KV commitment for the same image.
         assert legacy_cost == inline_cost
+
+    def test_studio_image_echo_is_charged_once_and_is_bounded(self):
+        image = _image_b64(1024)
+        inline_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{image}"},
+                    },
+                ],
+            }
+        ]
+        dual = _Payload(
+            messages = inline_messages,
+            image_base64 = image,
+            max_tokens = 128,
+        )
+        inline = _Payload(messages = inline_messages, max_tokens = 128)
+
+        dual_cost = _openai_llama_admission_tokens(dual, budget = 65536, capacity = 4)
+        inline_cost = _openai_llama_admission_tokens(inline, budget = 65536, capacity = 4)
+
+        assert dual_cost == inline_cost
+        assert 4096 <= dual_cost < 10_000, "image bytes must be bounded but still charged"
+
+    def test_two_large_studio_image_chats_can_be_admitted_together(self):
+        """A large base64 transport must not turn each vision request into a full-cache lease."""
+        import asyncio
+
+        from core.inference.llama_admission import LlamaAdmissionConfig, LlamaAdmissionQueue
+
+        async def scenario():
+            queue = LlamaAdmissionQueue("media")
+            config = LlamaAdmissionConfig()
+            image = _image_b64(1024)
+            leases = []
+            for _ in range(2):
+                payload = _Payload(
+                    messages = [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "describe"},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {"url": f"data:image/png;base64,{image}"},
+                                },
+                            ],
+                        }
+                    ],
+                    image_base64 = image,
+                    max_tokens = 128,
+                )
+                reservation = queue.reserve(
+                    capacity = 4,
+                    config = config,
+                    budget = 12_000,
+                    tokens = _openai_llama_admission_tokens(payload, budget = 12_000, capacity = 4),
+                )
+                leases.append(reservation.lease_nowait())
+            admitted = [lease is not None for lease in leases]
+            for lease in leases:
+                if lease is not None:
+                    lease.release()
+            return admitted
+
+        assert asyncio.run(scenario()) == [True, True]
 
     def test_two_image_chats_are_not_both_admitted(self):
         """The live failure, with images instead of text."""
@@ -88,8 +157,8 @@ class TestMediaIsCharged:
 
         first, second = asyncio.run(scenario())
         assert first is not None, "the first image chat owns the cache"
-        # A 4 KiB image is ~5.4k base64 characters, about 1365 tokens on top of a
-        # 2048 cache that already holds one such request: the second must queue.
+        # The conservative per-image allowance alone is larger than this tiny cache,
+        # so the second request must still queue rather than overcommit it.
         assert second is None
 
     def test_audio_and_video_are_charged_too(self):

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -16,7 +16,10 @@ estimate for a lease that runs up to 25 growing rounds.
 
 import base64
 
-from routes.inference import _openai_llama_admission_tokens
+from routes.inference import (
+    _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS,
+    _openai_llama_admission_tokens,
+)
 
 
 class _Payload:
@@ -54,10 +57,18 @@ class TestMediaIsCharged:
             ],
             max_tokens = 128,
         )
-        legacy_cost = _openai_llama_admission_tokens(legacy, budget = 4096, capacity = 4)
-        inline_cost = _openai_llama_admission_tokens(inline, budget = 4096, capacity = 4)
+        # Budget well clear of both costs. At 4096 the estimate is clamped to the
+        # budget by `max(1, min(budget, ...))` on BOTH sides, so the two agreed at
+        # the clamp whatever the estimator did and the assertion proved nothing.
+        legacy_cost = _openai_llama_admission_tokens(legacy, budget = 1_000_000, capacity = 4)
+        inline_cost = _openai_llama_admission_tokens(inline, budget = 1_000_000, capacity = 4)
         # The wire spelling must not change the KV commitment for the same image.
-        assert legacy_cost == inline_cost
+        # Not to the token: the inline spelling really does send a content-part
+        # wrapper the legacy one does not, and the compact marker standing in for the
+        # bytes is itself a few tokens of JSON. What must not survive is the 30x gap
+        # between pricing an image at its base64 length and pricing it at its text.
+        assert abs(legacy_cost - inline_cost) <= 64, (legacy_cost, inline_cost)
+        assert max(legacy_cost, inline_cost) < 2 * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
 
     def test_studio_image_echo_is_charged_once_and_is_bounded(self):
         image = _image_b64(1024)
@@ -80,11 +91,119 @@ class TestMediaIsCharged:
         )
         inline = _Payload(messages = inline_messages, max_tokens = 128)
 
-        dual_cost = _openai_llama_admission_tokens(dual, budget = 65536, capacity = 4)
-        inline_cost = _openai_llama_admission_tokens(inline, budget = 65536, capacity = 4)
+        # A budget no clamp can reach: at 65536 a 1 MiB image priced as prompt text
+        # clamps to the budget on both sides, so `dual == inline` held on the
+        # unfixed estimator too and only the upper bound below did any work.
+        dual_cost = _openai_llama_admission_tokens(dual, budget = 1_000_000, capacity = 4)
+        inline_cost = _openai_llama_admission_tokens(inline, budget = 1_000_000, capacity = 4)
 
         assert dual_cost == inline_cost
-        assert 4096 <= dual_cost < 10_000, "image bytes must be bounded but still charged"
+        assert dual_cost < 2 * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS, (
+            "the echo must be charged once, not once per spelling"
+        )
+        assert dual_cost >= _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS, (
+            "image bytes must be bounded but still charged"
+        )
+
+    def test_every_builder_forwards_exactly_what_admission_charged(self):
+        """The reservation is only a bound if it counts the images actually sent.
+
+        Studio echoes one image into both the ``image_url`` part and the legacy
+        top-level field. `_openai_messages_for_gguf_chat` has always dropped the
+        echo, but `_openai_messages_for_passthrough` -- the builder a request with
+        client ``tools`` or a ``response_format`` goes through -- spliced it in
+        unconditionally, so it sent two copies of one image against a reservation
+        for one. Measured against llama-server b10639 with a 2048x2048 image: 4417
+        reserved, 8466 really charged.
+        """
+        from models.inference import ChatCompletionRequest
+        from routes.inference import (
+            _openai_llama_admission_media_tokens,
+            _openai_llama_admission_messages_for_estimate,
+            _openai_messages_for_gguf_chat,
+            _openai_messages_for_passthrough,
+        )
+
+        # A real 1x1 PNG: the builders decode and re-encode, unlike the estimator.
+        image = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQ"
+            "AAAABJRU5ErkJggg=="
+        )
+        inline_part = {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{image}"},
+        }
+        shapes = {
+            "studio dual": ChatCompletionRequest(
+                model = "m",
+                max_tokens = 128,
+                messages = [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "what is this?"}, inline_part],
+                    }
+                ],
+                image_base64 = image,
+            ),
+            "inline only": ChatCompletionRequest(
+                model = "m",
+                max_tokens = 128,
+                messages = [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "what is this?"}, inline_part],
+                    }
+                ],
+            ),
+            "legacy only": ChatCompletionRequest(
+                model = "m",
+                max_tokens = 128,
+                messages = [{"role": "user", "content": "what is this?"}],
+                image_base64 = image,
+            ),
+        }
+
+        def _forwarded(messages):
+            return sum(
+                1
+                for msg in messages
+                if isinstance(msg.get("content"), list)
+                for part in msg["content"]
+                if isinstance(part, dict) and part.get("type") == "image_url"
+            )
+
+        for name, payload in shapes.items():
+            _, message_image_parts = _openai_llama_admission_messages_for_estimate(payload.messages)
+            billed = (
+                _openai_llama_admission_media_tokens(
+                    payload, message_image_parts = message_image_parts
+                )
+                // _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
+            )
+            for builder_name, messages in (
+                ("gguf chat", _openai_messages_for_gguf_chat(payload, True)[0]),
+                ("passthrough", _openai_messages_for_passthrough(payload)),
+            ):
+                assert _forwarded(messages) == billed, (
+                    f"{name} via {builder_name}: forwarded {_forwarded(messages)} "
+                    f"image(s) but admission charged for {billed}"
+                )
+
+    def test_the_allowance_bounds_a_real_projector(self):
+        """The per-image charge is an upper bound, not an estimate.
+
+        Measured against llama-server b10639: a 2048x2048 image costs 4098 KV
+        positions on Qwen3-VL-4B (llama.cpp's 4096-embedding cap for that projector
+        plus two mtmd delimiters) and 258 on Gemma 3 4B, at every resolution and
+        every encoded size. A flat 4096 was below the Qwen figure, and reserving
+        less than a request costs is what lets two of them collide in a cache that
+        holds one.
+        """
+        measured_worst_case = {"qwen3-vl-4b": 4098, "gemma-3-4b": 258}
+        for model, tokens in measured_worst_case.items():
+            assert _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS >= tokens, (
+                f"per-image allowance under-reserves {model}"
+            )
 
     def test_two_large_studio_image_chats_can_be_admitted_together(self):
         """A large base64 transport must not turn each vision request into a full-cache lease."""

--- a/studio/backend/utils/models/gguf_metadata.py
+++ b/studio/backend/utils/models/gguf_metadata.py
@@ -595,6 +595,16 @@ def read_mmproj_audio_capability(path: str) -> Optional[bool]:
     return _read_gguf_bool(path, "clip.has_audio_encoder")
 
 
+def read_mmproj_projector_type(path: str) -> Optional[str]:
+    """``clip.projector_type`` from an mmproj GGUF, or None if absent/unreadable.
+
+    The family name llama.cpp keys its per-projector image-token limits on
+    (``qwen3vl_merger``, ``gemma3``, ``pixtral``, ...), so a caller sizing the KV an
+    image will occupy can look the ceiling up instead of assuming one.
+    """
+    return _read_gguf_string(path, "clip.projector_type")
+
+
 def read_mmproj_vision_capability(path: str) -> Optional[bool]:
     """``clip.has_vision_encoder`` from an mmproj GGUF: ``True``/``False`` if
     present, ``None`` if absent/unreadable."""


### PR DESCRIPTION
## Summary

- Restore concurrent local vision chat requests when the shared KV cache has room.
- Keep the existing KV admission guard for genuinely large prompt/output commitments.

## Root cause

- Studio sends the current image as both a message-level `image_url` and the legacy top-level `image_base64` field.
- Admission charged the raw Base64/Data-URL bytes as dense prompt text and charged the duplicate legacy field again.
- Normal images therefore saturated the estimated KV budget, so the FIFO queue admitted one vision request at a time and could delay following text requests.

## Fix

- Replace image payload bytes with a compact marker before dense message estimation.
- Charge one bounded 4,096-token image allowance per message-level image, or once for a legacy-only image.
- Add regressions for the Studio dual representation, bounded large-image accounting, and concurrent vision leases.

## Testing

- `python -m compileall -q routes/inference.py tests/test_llama_admission_kv_budget_media_and_tools.py` — passed.
- Targeted admission smoke — passed (dual-image deduplication, bounded cost, queue parallelism, and unchanged audio/video/tool-loop behavior).
- Focused pytest suite was not runnable in this checkout because the available runtime does not include `pytest` or `fastapi`.

## Issue

Fixes #9840