### PR TITLE
Reject a macOS llama.cpp prebuilt that dyld will not load

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5218,12 +5218,8 @@ def looks_like_macos_loader_failure(text: str) -> bool:
     lowered = text.lower()
     if any(marker in lowered for marker in _MACOS_LOADER_FAILURE_MARKERS):
         return True
-    # Deliberately no bare "dyld[pid]:" prefix rule. DYLD_PRINT_LIBRARIES and
-    # friends make dyld narrate every image it loads under that same prefix, on a
-    # run that reached main perfectly well -- which, paired with llama-quantize's
-    # nonzero --version, would reject a healthy bundle for anyone who happens to
-    # have the diagnostic set. The prefix says who is speaking, not that anything
-    # went wrong; the markers above say what went wrong.
+    # No bare "dyld[pid]:" rule: DYLD_PRINT_LIBRARIES narrates a healthy load
+    # under that same prefix. It says who is speaking, not that anything failed.
     return looks_like_macos_incompatibility(text)
 
 
@@ -5262,12 +5258,10 @@ def macos_dyld_load_issues(
 ) -> list[str]:
     """Issue strings for every installed executable dyld refuses to load.
 
-    `--version` returns in about a second and forces dyld to resolve the whole
-    link graph, so this catches a missing dylib, a missing symbol and a too-new
-    slice for the cost of a process spawn -- unlike validate_server, which loads
-    a model and is gated off for checksummed bundles (#5854). Executables only:
-    a broken dylib surfaces through whichever binary links it, and the dylibs
-    themselves cannot be exec'd."""
+    `--version` costs a process spawn and still makes dyld resolve the whole link
+    graph, so it catches a missing dylib, a missing symbol or a too-new slice --
+    unlike validate_server, which loads a model and is off for checksummed bundles
+    (#5854). Executables only: a broken dylib surfaces through whatever links it."""
     issues: list[str] = []
     seen: set[Path] = set()
     for binary_path in binaries:
@@ -5279,9 +5273,8 @@ def macos_dyld_load_issues(
             continue
         seen.add(resolved)
         env = binary_env(binary_path, install_dir, host)
-        # The probe reads dyld's output, so keep the user's dyld diagnostics out
-        # of it: DYLD_PRINT_LIBRARIES narrates every image loaded, and
-        # DYLD_INSERT_LIBRARIES can fail on its own account and blame the bundle.
+        # Keep the user's dyld diagnostics out of output we are about to parse:
+        # DYLD_PRINT_* narrates, DYLD_INSERT_LIBRARIES can fail and blame the bundle.
         for noisy in [k for k in env if k.startswith("DYLD_PRINT_")]:
             env.pop(noisy, None)
         env.pop("DYLD_INSERT_LIBRARIES", None)
@@ -5295,19 +5288,12 @@ def macos_dyld_load_issues(
         if result.returncode == 0:
             continue
         output = (result.stdout + result.stderr).strip()
-        # A non-zero exit is NOT evidence of a bad link. llama-quantize answers
-        # --version by printing its quantization table and exiting non-zero, which
-        # is a binary that loaded perfectly; assert_macho_minos.sh in the llama.cpp
-        # fork makes the same distinction for the same reason. Treating the code as
-        # the verdict rejected every published prebuilt, walked the release history
-        # to its end and fell back to a source build.
-        #
-        # So require dyld's own signature. It names both the library it could not
-        # load and the dylib that asked for it, which is also better evidence than
-        # anything otool -L could yield here: an absolute install name absent from
-        # disk is the normal case for /usr/lib, whose members live in the shared
-        # cache, so "missing from disk" cannot separate the culprit from its
-        # healthy peers.
+        # A non-zero exit is not evidence of a bad link: llama-quantize answers
+        # --version by printing its table and exiting 1. Reading the code as the
+        # verdict rejected every published prebuilt and fell back to a source
+        # build. Require dyld's own signature instead -- it also names the dylib
+        # that asked, which otool -L cannot, since an absolute install name absent
+        # from disk is the normal case for /usr/lib's shared-cache members.
         if not looks_like_macos_loader_failure(output):
             continue
         detail = " | ".join(output.splitlines()[-5:]) or f"exit {result.returncode}"
@@ -5330,11 +5316,9 @@ def preflight_macos_installed_binaries(
     then died on first launch. Raising PrebuiltFallback here spends a source
     build instead of installing something that cannot start.
 
-    Only the static comparison needs the host version; dyld does not. An
-    unreadable or unparseable ``platform.mac_ver()`` used to skip both, deferring
-    to a runtime validation that is disabled by default for checksummed bundles
-    (#5854) -- so the one host that could still give a definitive answer was the
-    one that got no check at all."""
+    Only the static comparison needs the host version; dyld does not. Skipping
+    both on an unparseable ``platform.mac_ver()`` left that host with no check at
+    all, since the runtime validation it deferred to is off by default (#5854)."""
     if not host.is_macos:
         return
     if host.macos_version is not None:
@@ -6950,11 +6934,9 @@ def existing_install_matches_choice(
             )
         except Exception:
             return False
-    # The same check on the macOS side, and the one that reaches the users who
-    # matter most here: a bundle that cannot load is usually ALREADY installed by
-    # the time the installer learns to reject it. Without this, re-running the
-    # installer sees a matching fingerprint, reuses the broken tree and fails at
-    # first launch again. Returning False re-installs instead.
+    # The macOS side, and the one that reaches most affected users: a bundle that
+    # cannot load is usually already installed by the time the installer learns to
+    # reject it, so a matching fingerprint would reuse the broken tree forever.
     elif host.is_macos:
         try:
             preflight_macos_installed_binaries(

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5313,22 +5313,28 @@ def preflight_macos_installed_binaries(
     """Reject a macos prebuilt whose minimum-OS is newer than the host, or that
     dyld will not load at all. The upstream selector pins a loadable release up
     front, so here this is the post-download backstop; the published/fork path
-    also uses it to advance the walk-back. No-op when the host macOS version is
-    unknown (runtime validates).
+    also uses it to advance the walk-back.
 
     The load probe is the macOS counterpart of preflight_linux_installed_binaries'
     ldd sweep, which this side went without: a bundle whose libggml-rpc.0.dylib
     links a /usr/lib/librdma.dylib that exists on the builder and nowhere else
     passed the minos scan, was logged "prebuilt installed and validated", and
     then died on first launch. Raising PrebuiltFallback here spends a source
-    build instead of installing something that cannot start."""
-    if not host.is_macos or host.macos_version is None:
+    build instead of installing something that cannot start.
+
+    Only the static comparison needs the host version; dyld does not. An
+    unreadable or unparseable ``platform.mac_ver()`` used to skip both, deferring
+    to a runtime validation that is disabled by default for checksummed bundles
+    (#5854) -- so the one host that could still give a definitive answer was the
+    one that got no check at all."""
+    if not host.is_macos:
         return
-    issues = macos_binary_minos_issues(binaries, install_dir, host)
-    if issues:
-        raise PrebuiltFallback(
-            "macos prebuilt requires a newer macOS than this host:\n" + "\n".join(issues)
-        )
+    if host.macos_version is not None:
+        issues = macos_binary_minos_issues(binaries, install_dir, host)
+        if issues:
+            raise PrebuiltFallback(
+                "macos prebuilt requires a newer macOS than this host:\n" + "\n".join(issues)
+            )
     load_issues = macos_dyld_load_issues(binaries, install_dir, host)
     if load_issues:
         raise PrebuiltFallback(

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5218,10 +5218,12 @@ def looks_like_macos_loader_failure(text: str) -> bool:
     lowered = text.lower()
     if any(marker in lowered for marker in _MACOS_LOADER_FAILURE_MARKERS):
         return True
-    # dyld prefixes its own diagnostics, with or without a pid: "dyld: ..." on
-    # older releases, "dyld[41694]: ..." on current ones.
-    if re.search(r"^\s*dyld(\[\d+\])?:", text, re.MULTILINE):
-        return True
+    # Deliberately no bare "dyld[pid]:" prefix rule. DYLD_PRINT_LIBRARIES and
+    # friends make dyld narrate every image it loads under that same prefix, on a
+    # run that reached main perfectly well -- which, paired with llama-quantize's
+    # nonzero --version, would reject a healthy bundle for anyone who happens to
+    # have the diagnostic set. The prefix says who is speaking, not that anything
+    # went wrong; the markers above say what went wrong.
     return looks_like_macos_incompatibility(text)
 
 
@@ -5277,6 +5279,12 @@ def macos_dyld_load_issues(
             continue
         seen.add(resolved)
         env = binary_env(binary_path, install_dir, host)
+        # The probe reads dyld's output, so keep the user's dyld diagnostics out
+        # of it: DYLD_PRINT_LIBRARIES narrates every image loaded, and
+        # DYLD_INSERT_LIBRARIES can fail on its own account and blame the bundle.
+        for noisy in [k for k in env if k.startswith("DYLD_PRINT_")]:
+            env.pop(noisy, None)
+        env.pop("DYLD_INSERT_LIBRARIES", None)
         try:
             result = run_capture([str(binary_path), "--version"], timeout = 60, env = env)
         except Exception as exc:
@@ -6936,6 +6944,20 @@ def existing_install_matches_choice(
     if host.is_linux:
         try:
             preflight_linux_installed_binaries(
+                [runtime_dir / "llama-server", runtime_dir / "llama-quantize"],
+                install_dir,
+                host,
+            )
+        except Exception:
+            return False
+    # The same check on the macOS side, and the one that reaches the users who
+    # matter most here: a bundle that cannot load is usually ALREADY installed by
+    # the time the installer learns to reject it. Without this, re-running the
+    # installer sees a matching fingerprint, reuses the broken tree and fails at
+    # first launch again. Returning False re-installs instead.
+    elif host.is_macos:
+        try:
+            preflight_macos_installed_binaries(
                 [runtime_dir / "llama-server", runtime_dir / "llama-quantize"],
                 install_dir,
                 host,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5191,6 +5191,40 @@ def looks_like_macos_incompatibility(text: str) -> bool:
     return "Symbol not found" in text and "MTLResidency" in text
 
 
+_MACOS_LOADER_FAILURE_MARKERS = (
+    "library not loaded",
+    "symbol not found",
+    "image not found",
+    "no suitable image found",
+    "incompatible library version",
+    "code signature",
+)
+
+
+def looks_like_macos_loader_failure(text: str) -> bool:
+    """True when output is dyld refusing to load the image, rather than a program
+    that started and exited non-zero.
+
+    The distinction is the whole point: llama-quantize answers --version by
+    printing its quantization table and exiting non-zero, so an exit code cannot
+    separate "never reached main" from "ran and disagreed". dyld failures are
+    recognisable by what they say, and they say it before any program output.
+    Deliberately narrow -- a false positive here rejects a working prebuilt and
+    spends a source build, so anything unrecognised is treated as healthy and
+    left to the runtime validation that follows.
+    """
+    if not text:
+        return False
+    lowered = text.lower()
+    if any(marker in lowered for marker in _MACOS_LOADER_FAILURE_MARKERS):
+        return True
+    # dyld prefixes its own diagnostics, with or without a pid: "dyld: ..." on
+    # older releases, "dyld[41694]: ..." on current ones.
+    if re.search(r"^\s*dyld(\[\d+\])?:", text, re.MULTILINE):
+        return True
+    return looks_like_macos_incompatibility(text)
+
+
 def macos_binary_minos_issues(
     binaries: Iterable[Path], install_dir: Path, host: HostInfo
 ) -> list[str]:
@@ -5252,12 +5286,22 @@ def macos_dyld_load_issues(
             continue
         if result.returncode == 0:
             continue
-        # dyld names both the library it could not load and the dylib that asked
-        # for it, which is better evidence than anything otool -L could be made to
-        # yield here: an absolute install name that is absent from disk is the
-        # normal case for /usr/lib, whose members live in the shared cache, so
-        # "missing from disk" cannot separate the culprit from its healthy peers.
         output = (result.stdout + result.stderr).strip()
+        # A non-zero exit is NOT evidence of a bad link. llama-quantize answers
+        # --version by printing its quantization table and exiting non-zero, which
+        # is a binary that loaded perfectly; assert_macho_minos.sh in the llama.cpp
+        # fork makes the same distinction for the same reason. Treating the code as
+        # the verdict rejected every published prebuilt, walked the release history
+        # to its end and fell back to a source build.
+        #
+        # So require dyld's own signature. It names both the library it could not
+        # load and the dylib that asked for it, which is also better evidence than
+        # anything otool -L could yield here: an absolute install name absent from
+        # disk is the normal case for /usr/lib, whose members live in the shared
+        # cache, so "missing from disk" cannot separate the culprit from its
+        # healthy peers.
+        if not looks_like_macos_loader_failure(output):
+            continue
         detail = " | ".join(output.splitlines()[-5:]) or f"exit {result.returncode}"
         issues.append(f"{binary_path.name}: {detail}")
     return issues

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5244,9 +5244,7 @@ def macos_dyld_load_issues(
         seen.add(resolved)
         env = binary_env(binary_path, install_dir, host)
         try:
-            result = run_capture(
-                [str(binary_path), "--version"], timeout = 60, env = env
-            )
+            result = run_capture([str(binary_path), "--version"], timeout = 60, env = env)
         except Exception as exc:
             # A timeout or a refusal to spawn is not evidence of a bad link, and
             # calling it one would reject a healthy bundle on a loaded machine.

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5221,19 +5221,76 @@ def macos_binary_minos_issues(
     return issues
 
 
+def macos_dyld_load_issues(
+    binaries: Iterable[Path], install_dir: Path, host: HostInfo
+) -> list[str]:
+    """Issue strings for every installed executable dyld refuses to load.
+
+    `--version` returns in about a second and forces dyld to resolve the whole
+    link graph, so this catches a missing dylib, a missing symbol and a too-new
+    slice for the cost of a process spawn -- unlike validate_server, which loads
+    a model and is gated off for checksummed bundles (#5854). Executables only:
+    a broken dylib surfaces through whichever binary links it, and the dylibs
+    themselves cannot be exec'd."""
+    issues: list[str] = []
+    seen: set[Path] = set()
+    for binary_path in binaries:
+        try:
+            resolved = binary_path.resolve()
+        except Exception:
+            resolved = binary_path
+        if resolved in seen or not binary_path.is_file():
+            continue
+        seen.add(resolved)
+        env = binary_env(binary_path, install_dir, host)
+        try:
+            result = run_capture(
+                [str(binary_path), "--version"], timeout = 60, env = env
+            )
+        except Exception as exc:
+            # A timeout or a refusal to spawn is not evidence of a bad link, and
+            # calling it one would reject a healthy bundle on a loaded machine.
+            log(f"macos load probe could not run {binary_path.name}: {exc}")
+            continue
+        if result.returncode == 0:
+            continue
+        # dyld names both the library it could not load and the dylib that asked
+        # for it, which is better evidence than anything otool -L could be made to
+        # yield here: an absolute install name that is absent from disk is the
+        # normal case for /usr/lib, whose members live in the shared cache, so
+        # "missing from disk" cannot separate the culprit from its healthy peers.
+        output = (result.stdout + result.stderr).strip()
+        detail = " | ".join(output.splitlines()[-5:]) or f"exit {result.returncode}"
+        issues.append(f"{binary_path.name}: {detail}")
+    return issues
+
+
 def preflight_macos_installed_binaries(
     binaries: Iterable[Path], install_dir: Path, host: HostInfo
 ) -> None:
-    """Reject a macos prebuilt whose minimum-OS is newer than the host. The
-    upstream selector pins a loadable release up front, so here this is the
-    post-download backstop; the published/fork path also uses it to advance the
-    walk-back. No-op when the host macOS version is unknown (runtime validates)."""
+    """Reject a macos prebuilt whose minimum-OS is newer than the host, or that
+    dyld will not load at all. The upstream selector pins a loadable release up
+    front, so here this is the post-download backstop; the published/fork path
+    also uses it to advance the walk-back. No-op when the host macOS version is
+    unknown (runtime validates).
+
+    The load probe is the macOS counterpart of preflight_linux_installed_binaries'
+    ldd sweep, which this side went without: a bundle whose libggml-rpc.0.dylib
+    links a /usr/lib/librdma.dylib that exists on the builder and nowhere else
+    passed the minos scan, was logged "prebuilt installed and validated", and
+    then died on first launch. Raising PrebuiltFallback here spends a source
+    build instead of installing something that cannot start."""
     if not host.is_macos or host.macos_version is None:
         return
     issues = macos_binary_minos_issues(binaries, install_dir, host)
     if issues:
         raise PrebuiltFallback(
             "macos prebuilt requires a newer macOS than this host:\n" + "\n".join(issues)
+        )
+    load_issues = macos_dyld_load_issues(binaries, install_dir, host)
+    if load_issues:
+        raise PrebuiltFallback(
+            "macos prebuilt does not load on this host:\n" + "\n".join(load_issues)
         )
 
 

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -4283,6 +4283,98 @@ def test_existing_install_matches_choice_fails_when_install_tree_incomplete_maco
     )
 
 
+def test_existing_macos_install_that_cannot_load_is_not_reused(tmp_path: Path, monkeypatch):
+    """A bundle that dyld refuses must not be accepted just because its
+    fingerprint matches.
+
+    This is the path that reaches the users who matter: a bundle that cannot
+    load is usually ALREADY installed by the time the installer learns to reject
+    it, and the reuse check ran the Linux preflight only. Re-running the
+    installer then saw a matching fingerprint, kept the broken tree and failed at
+    first launch again.
+    """
+    install_dir = tmp_path / "llama.cpp"
+    install_dir.mkdir()
+    write_macos_install_shape(install_dir)
+
+    host = HostInfo(
+        system = "Darwin",
+        machine = "arm64",
+        is_windows = False,
+        is_linux = False,
+        is_macos = True,
+        is_x86_64 = False,
+        is_arm64 = True,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+        visible_cuda_devices = None,
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        macos_version = (15, 5),
+    )
+    choice = AssetChoice(
+        repo = "unslothai/llama.cpp",
+        tag = "release-1",
+        name = "llama-b9001-bin-macos-arm64.tar.gz",
+        url = "https://example.com/llama-b9001-bin-macos-arm64.tar.gz",
+        source_label = "upstream",
+        install_kind = "macos-arm64",
+        expected_sha256 = "a" * 64,
+    )
+    checksums = ApprovedReleaseChecksums(
+        repo = "unslothai/llama.cpp",
+        release_tag = "release-1",
+        upstream_tag = "b9001",
+        source_commit = "deadbeef",
+        artifacts = {
+            source_archive_logical_name("b9001"): ApprovedArtifactHash(
+                asset_name = source_archive_logical_name("b9001"),
+                sha256 = "b" * 64,
+                repo = "ggml-org/llama.cpp",
+                kind = "upstream-source",
+            ),
+            choice.name: ApprovedArtifactHash(
+                asset_name = choice.name,
+                sha256 = choice.expected_sha256,
+                repo = "ggml-org/llama.cpp",
+                kind = "upstream-prebuilt",
+            ),
+        },
+    )
+    write_prebuilt_metadata(
+        install_dir,
+        requested_tag = "latest",
+        llama_tag = "b9001",
+        release_tag = "release-1",
+        choice = choice,
+        approved_checksums = checksums,
+        prebuilt_fallback_used = False,
+    )
+
+    def matches() -> bool:
+        return existing_install_matches_choice(
+            install_dir,
+            host,
+            llama_tag = "b9001",
+            release_tag = "release-1",
+            choice = choice,
+            approved_checksums = checksums,
+        )
+
+    # Loads cleanly -> reuse is correct.
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "macos_dyld_load_issues", lambda *a, **k: [])
+    assert matches() is True
+
+    # dyld refuses it -> the cached tree must be rejected so it gets reinstalled.
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "macos_dyld_load_issues",
+        lambda *a, **k: ["llama-server: Library not loaded: /usr/lib/librdma.dylib"],
+    )
+    assert matches() is False
+
+
 def test_paired_runtime_dll_patterns_excludes_executables() -> None:
     """The paired runtime archive must contribute only CUDA DLLs (no *.exe/*.dll) so it can't overwrite binaries."""
     paired_runtime_dll_patterns = INSTALL_LLAMA_PREBUILT.paired_runtime_dll_patterns

--- a/tests/studio/install/test_macos_version_compat.py
+++ b/tests/studio/install/test_macos_version_compat.py
@@ -358,10 +358,12 @@ class TestTheProbeEnvironment:
 
         def capture(command, **kwargs):
             seen.update(kwargs.get("env") or {})
+
             class Result:
                 returncode = 0
                 stdout = ""
                 stderr = ""
+
             return Result()
 
         monkeypatch.setattr(ILP, "run_capture", capture)

--- a/tests/studio/install/test_macos_version_compat.py
+++ b/tests/studio/install/test_macos_version_compat.py
@@ -261,6 +261,23 @@ class TestMacosDyldLoadProbe:
         binaries[0].chmod(0o644)
         ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
 
+    def test_a_nonzero_exit_with_program_output_is_not_a_link_failure(self, tmp_path):
+        """llama-quantize answers --version by printing its quantization table and
+        exiting non-zero. Reading the exit code as the verdict rejected every
+        published prebuilt, walked the release history to its end, and fell back to
+        a source build on every macOS runner.
+        """
+        install_dir, binaries = self._bundle(
+            tmp_path,
+            exit_code = 1,
+            message = (
+                "llama-quantize: 7 or Q8_0 : 7.96G, +0.0026 ppl @ Llama-3-8B | "
+                "1 or F16 : 14.00G, +0.0020 ppl @ Mistral-7B"
+            ),
+        )
+        ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
+
+
     def test_the_referencing_dylib_survives_into_the_message(self, tmp_path):
         """dyld names the library AND the dylib that asked for it. The second half
         is what says libggml-rpc rather than llama-server is at fault, so keep
@@ -276,6 +293,36 @@ class TestMacosDyldLoadProbe:
         message = str(caught.value)
         assert "librdma" in message
         assert "libggml-rpc" in message
+
+
+
+class TestLooksLikeMacosLoaderFailure:
+    """Narrow by design: a false positive rejects a working prebuilt."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "dyld[41694]: Library not loaded: /usr/lib/librdma.dylib",
+            "dyld: Library not loaded: /usr/lib/libfoo.dylib",
+            "Symbol not found: _OBJC_CLASS_$_MTLResidencySetDescriptor",
+            "dyld[1]: no suitable image found.",
+        ],
+    )
+    def test_loader_failures_are_recognised(self, text):
+        assert ILP.looks_like_macos_loader_failure(text)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "llama-quantize: 7 or Q8_0 : 7.96G, +0.0026 ppl @ Llama-3-8B",
+            "usage: llama-quantize [--help] model-f32.gguf",
+            "error: failed to load model 'foo.gguf'",
+            "main: build = 10639 (f6f92fe)",
+        ],
+    )
+    def test_ordinary_program_output_is_not_a_loader_failure(self, text):
+        assert not ILP.looks_like_macos_loader_failure(text)
 
 
 def _fake_macos_releases(tags):

--- a/tests/studio/install/test_macos_version_compat.py
+++ b/tests/studio/install/test_macos_version_compat.py
@@ -182,9 +182,10 @@ class TestPreflightMacosInstalledBinaries:
         # Must not raise on a macOS 15 host.
         ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
 
-    def test_skips_when_host_version_unknown(self, tmp_path):
+    def test_skips_the_minos_comparison_when_host_version_unknown(self, tmp_path):
         install_dir, binaries = self._install_dir(tmp_path, (26, 0))
-        # Unknown host version -> defer to runtime validation, do not raise.
+        # No host version to compare against, so the static check cannot run.
+        # These fixtures are not executable, so the load probe finds nothing either.
         ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host(None))
 
     def test_noop_on_non_macos_host(self, tmp_path):
@@ -260,6 +261,20 @@ class TestMacosDyldLoadProbe:
         install_dir, binaries = self._bundle(tmp_path, exit_code = 0)
         binaries[0].chmod(0o644)
         ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
+
+    def test_the_probe_still_runs_when_the_host_version_is_unknown(self, tmp_path):
+        """Only the static comparison needs the version; dyld does not.
+
+        Skipping both left the checksummed path with no check at all, since the
+        runtime validation it deferred to is disabled by default (#5854).
+        """
+        install_dir, binaries = self._bundle(
+            tmp_path,
+            exit_code = 1,
+            message = "dyld[1]: Library not loaded: /usr/lib/librdma.dylib",
+        )
+        with pytest.raises(PrebuiltFallback, match = "does not load on this host"):
+            ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host(None))
 
     def test_a_nonzero_exit_with_program_output_is_not_a_link_failure(self, tmp_path):
         """llama-quantize answers --version by printing its quantization table and

--- a/tests/studio/install/test_macos_version_compat.py
+++ b/tests/studio/install/test_macos_version_compat.py
@@ -207,6 +207,78 @@ class TestPreflightMacosInstalledBinaries:
         ILP.preflight_macos_installed_binaries(binaries, install_dir, linux_host)
 
 
+class TestMacosDyldLoadProbe:
+    """The minos scan reads a header; it cannot see an install name pointing at a
+    library that exists on the builder and nowhere else. That shipped: a bundle
+    whose libggml-rpc.0.dylib wanted /usr/lib/librdma.dylib passed preflight, was
+    logged "prebuilt installed and validated", and then died on first launch."""
+
+    def _bundle(self, tmp_path, *, exit_code, message = ""):
+        bin_dir = tmp_path / "build" / "bin"
+        bin_dir.mkdir(parents = True)
+        # A real spawnable file, not a Mach-O sample: the point is to reach dyld.
+        # macho_minimum_macos returns None for a non-Mach-O, so the minos gate
+        # ahead of the probe stays quiet and the probe is what decides.
+        server = bin_dir / "llama-server"
+        server.write_text(f'#!/bin/sh\necho "{message}" >&2\nexit {exit_code}\n')
+        server.chmod(0o755)
+        return tmp_path, (server,)
+
+    def test_rejects_a_binary_dyld_will_not_load(self, tmp_path):
+        install_dir, binaries = self._bundle(
+            tmp_path,
+            exit_code = 1,
+            message = "dyld: Library not loaded: /usr/lib/librdma.dylib",
+        )
+        with pytest.raises(PrebuiltFallback, match = "does not load on this host"):
+            ILP.preflight_macos_installed_binaries(
+                binaries, install_dir, make_macos_host((15, 5))
+            )
+
+    def test_the_message_names_the_library(self, tmp_path):
+        install_dir, binaries = self._bundle(
+            tmp_path,
+            exit_code = 1,
+            message = "dyld: Library not loaded: /usr/lib/librdma.dylib",
+        )
+        with pytest.raises(PrebuiltFallback) as caught:
+            ILP.preflight_macos_installed_binaries(
+                binaries, install_dir, make_macos_host((15, 5))
+            )
+        # Without the name the operator gets an exit code and no lead to follow.
+        assert "librdma" in str(caught.value)
+
+    def test_accepts_a_binary_that_loads(self, tmp_path):
+        install_dir, binaries = self._bundle(tmp_path, exit_code = 0, message = "")
+        ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
+
+    def test_a_binary_that_cannot_be_spawned_is_not_a_link_failure(self, tmp_path):
+        """A refusal to exec says nothing about the link graph, and treating it as
+        a verdict would reject healthy bundles on a loaded or locked-down host."""
+        install_dir, binaries = self._bundle(tmp_path, exit_code = 0)
+        binaries[0].chmod(0o644)
+        ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
+
+
+    def test_the_referencing_dylib_survives_into_the_message(self, tmp_path):
+        """dyld names the library AND the dylib that asked for it. The second half
+        is what says libggml-rpc rather than llama-server is at fault, so keep
+        enough of the tail to carry it."""
+        real = (
+            "dyld[41694]: Library not loaded: /usr/lib/librdma.dylib\\n"
+            "  Referenced from: /Users/r/.unsloth/llama.cpp/build/bin/libggml-rpc.0.dylib\\n"
+            "  Reason: tried: '/usr/lib/librdma.dylib' (no such file)"
+        )
+        install_dir, binaries = self._bundle(tmp_path, exit_code = 1, message = real)
+        with pytest.raises(PrebuiltFallback) as caught:
+            ILP.preflight_macos_installed_binaries(
+                binaries, install_dir, make_macos_host((15, 5))
+            )
+        message = str(caught.value)
+        assert "librdma" in message
+        assert "libggml-rpc" in message
+
+
 def _fake_macos_releases(tags):
     return [
         {

--- a/tests/studio/install/test_macos_version_compat.py
+++ b/tests/studio/install/test_macos_version_compat.py
@@ -213,7 +213,13 @@ class TestMacosDyldLoadProbe:
     whose libggml-rpc.0.dylib wanted /usr/lib/librdma.dylib passed preflight, was
     logged "prebuilt installed and validated", and then died on first launch."""
 
-    def _bundle(self, tmp_path, *, exit_code, message = ""):
+    def _bundle(
+        self,
+        tmp_path,
+        *,
+        exit_code,
+        message = "",
+    ):
         bin_dir = tmp_path / "build" / "bin"
         bin_dir.mkdir(parents = True)
         # A real spawnable file, not a Mach-O sample: the point is to reach dyld.
@@ -231,9 +237,7 @@ class TestMacosDyldLoadProbe:
             message = "dyld: Library not loaded: /usr/lib/librdma.dylib",
         )
         with pytest.raises(PrebuiltFallback, match = "does not load on this host"):
-            ILP.preflight_macos_installed_binaries(
-                binaries, install_dir, make_macos_host((15, 5))
-            )
+            ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
 
     def test_the_message_names_the_library(self, tmp_path):
         install_dir, binaries = self._bundle(
@@ -242,9 +246,7 @@ class TestMacosDyldLoadProbe:
             message = "dyld: Library not loaded: /usr/lib/librdma.dylib",
         )
         with pytest.raises(PrebuiltFallback) as caught:
-            ILP.preflight_macos_installed_binaries(
-                binaries, install_dir, make_macos_host((15, 5))
-            )
+            ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
         # Without the name the operator gets an exit code and no lead to follow.
         assert "librdma" in str(caught.value)
 
@@ -259,7 +261,6 @@ class TestMacosDyldLoadProbe:
         binaries[0].chmod(0o644)
         ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
 
-
     def test_the_referencing_dylib_survives_into_the_message(self, tmp_path):
         """dyld names the library AND the dylib that asked for it. The second half
         is what says libggml-rpc rather than llama-server is at fault, so keep
@@ -271,9 +272,7 @@ class TestMacosDyldLoadProbe:
         )
         install_dir, binaries = self._bundle(tmp_path, exit_code = 1, message = real)
         with pytest.raises(PrebuiltFallback) as caught:
-            ILP.preflight_macos_installed_binaries(
-                binaries, install_dir, make_macos_host((15, 5))
-            )
+            ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
         message = str(caught.value)
         assert "librdma" in message
         assert "libggml-rpc" in message

--- a/tests/studio/install/test_macos_version_compat.py
+++ b/tests/studio/install/test_macos_version_compat.py
@@ -332,10 +332,42 @@ class TestLooksLikeMacosLoaderFailure:
             "usage: llama-quantize [--help] model-f32.gguf",
             "error: failed to load model 'foo.gguf'",
             "main: build = 10639 (f6f92fe)",
+            # DYLD_PRINT_LIBRARIES narrates a perfectly healthy load under the
+            # same prefix a failure uses, so the prefix alone cannot be the test.
+            "dyld[4711]: /usr/lib/libSystem.B.dylib\ndyld[4711]: /usr/lib/libc++.1.dylib",
         ],
     )
     def test_ordinary_program_output_is_not_a_loader_failure(self, text):
         assert not ILP.looks_like_macos_loader_failure(text)
+
+
+class TestTheProbeEnvironment:
+    def test_dyld_diagnostics_are_kept_out_of_the_probe(self, tmp_path, monkeypatch):
+        """A user's DYLD_PRINT_* would otherwise be echoed into the output the
+        probe reads, and llama-quantize's nonzero --version would turn that
+        narration into a rejection."""
+        monkeypatch.setenv("DYLD_PRINT_LIBRARIES", "1")
+        monkeypatch.setenv("DYLD_INSERT_LIBRARIES", "/tmp/evil.dylib")
+        seen = {}
+
+        bin_dir = tmp_path / "build" / "bin"
+        bin_dir.mkdir(parents = True)
+        server = bin_dir / "llama-server"
+        server.write_text("#!/bin/sh\nexit 0\n")
+        server.chmod(0o755)
+
+        def capture(command, **kwargs):
+            seen.update(kwargs.get("env") or {})
+            class Result:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(ILP, "run_capture", capture)
+        ILP.macos_dyld_load_issues([server], tmp_path, make_macos_host((15, 5)))
+        assert "DYLD_PRINT_LIBRARIES" not in seen
+        assert "DYLD_INSERT_LIBRARIES" not in seen
 
 
 def _fake_macos_releases(tags):

--- a/tests/studio/install/test_macos_version_compat.py
+++ b/tests/studio/install/test_macos_version_compat.py
@@ -277,7 +277,6 @@ class TestMacosDyldLoadProbe:
         )
         ILP.preflight_macos_installed_binaries(binaries, install_dir, make_macos_host((15, 5)))
 
-
     def test_the_referencing_dylib_survives_into_the_message(self, tmp_path):
         """dyld names the library AND the dylib that asked for it. The second half
         is what says libggml-rpc rather than llama-server is at fault, so keep
@@ -293,7 +292,6 @@ class TestMacosDyldLoadProbe:
         message = str(caught.value)
         assert "librdma" in message
         assert "libggml-rpc" in message
-
 
 
 class TestLooksLikeMacosLoaderFailure:


### PR DESCRIPTION
## The failure

Every macOS lane on every open PR:

```
dyld[41694]: Library not loaded: /usr/lib/librdma.dylib
  Referenced from: .../llama.cpp/build/bin/libggml-rpc.0.dylib
  Reason: tried: '/usr/lib/librdma.dylib' (no such file) ...
llama-server failed to launch on macOS 15.7.7 (dyld load / symbol error)
```

Upstream llama.cpp `b114b4739` (2026-08-25, "rpc: support apple RDMA as an RPC transport") added RDMA with **auto-detection**:

```cmake
if (APPLE)
    set(RDMA_LIB_NAME rdma)
find_library(RDMA_LIB ${RDMA_LIB_NAME})
if (RDMA_LIB)
    option(GGML_RPC_RDMA "..." ON)
```

The build host resolved `librdma`, so `/usr/lib/librdma.dylib` was baked into `libggml-rpc.0.dylib`. macOS 15 has no such library. Release `b10639-mix-f6f92fe` (2026-08-27) is the first to contain that commit; `b10472-mix-4b653db` predates it and is fine.

**This PR does not fix the artifact** - that needs a rebuild with `-DGGML_RPC_RDMA=OFF` in `unslothai/llama.cpp` and a republish. It fixes the reason a bundle like that reached users at all.

## The gap

`preflight_linux_installed_binaries` runs an `ldd` sweep and refuses a bundle with an unresolved library. The macOS side only compared minimum-OS versions. So the bundle passed preflight, was logged `prebuilt installed and validated`, and then died on first launch.

The one check that would have caught it, `validate_server`, is skipped for checksummed bundles since #5854 because it loads a model and costs minutes.

## The fix

`llama-server --version` costs a process spawn and still makes dyld resolve the whole link graph, so it catches a missing dylib, a missing symbol and a too-new slice. Failing here raises `PrebuiltFallback`, which spends a source build instead of installing something that cannot start.

Two deliberate choices:

- **Report dyld's own output rather than scanning install names with `otool -L`.** An absolute install name absent from disk is the *normal* case for `/usr/lib`, whose members live in the dyld shared cache, so "missing from disk" cannot separate the culprit from its healthy peers. I wrote the otool version first; a test caught it flagging `libSystem.B.dylib`. dyld names both the library and the dylib that asked for it, which is strictly better evidence.
- **A binary that cannot be spawned is not treated as a link failure.** That would reject healthy bundles on a loaded or locked-down host.

`.github/scripts/assert-llama-loads.sh` needs no change - it did its job and caught this.

## Verification

`python -m pytest -q tests/studio/install/` -> 2719 passed, 3 failed. The 3 are pre-existing on `main` in `test_managed_node_runtime.py` and unrelated (confirmed by stashing this change).

New tests in `test_macos_version_compat.py`: rejects a binary dyld refuses, keeps the referencing dylib in the message, accepts one that loads, and does not treat an unspawnable binary as a link failure.

I cannot run dyld on this host, so the probe's behaviour against a real broken bundle is argued from the CI log above rather than reproduced locally.