### PR TITLE
Stop the slot re-fit tests encoding the fit floor as a literal

### DIFF
--- a/studio/backend/tests/test_slot_reduction_context_refit.py
+++ b/studio/backend/tests/test_slot_reduction_context_refit.py
@@ -249,6 +249,14 @@ class TestWhatMustNotMove:
         assert (got["slots"], got["ctx"]) == (slots, ctx)
 
 
+# Multiples of the fit floor rather than literals. _AUTO_OFFLOAD_CTX is documented
+# to sit at or above _FIT_MIN_CTX, so sweeping it below the floor would drive the
+# planner through a state the product never reaches and call whatever came back a
+# regression. Identical to [4096, 8192, 16384, 32768] while the floor is 4096, and
+# still the intended sweep after it moves.
+_OFFLOAD_SWEEP = [llama_cpp._FIT_MIN_CTX * step for step in (1, 2, 4, 8)]
+
+
 class TestTheReductionIsPricedAtTheFitFloor:
     """The search that picks the slot count must not be priced at _AUTO_OFFLOAD_CTX.
 
@@ -278,7 +286,7 @@ class TestTheReductionIsPricedAtTheFitFloor:
         (10_500, DENSE),
     ]
 
-    @pytest.mark.parametrize("offload_ctx", [4096, 8192, 16384, 32768])
+    @pytest.mark.parametrize("offload_ctx", _OFFLOAD_SWEEP)
     def test_moving_the_offload_fallback_does_not_move_the_placement(
         self, tmp_path, monkeypatch, offload_ctx
     ):
@@ -292,7 +300,7 @@ class TestTheReductionIsPricedAtTheFitFloor:
         assert (got["slots"], got["fit"], got["ctx"], got["devices"]) == (2, "off", 7_680, "0")
 
     @pytest.mark.parametrize("weights_mib,metadata", RESCUED)
-    @pytest.mark.parametrize("offload_ctx", [4096, 8192])
+    @pytest.mark.parametrize("offload_ctx", _OFFLOAD_SWEEP[:2])
     def test_a_load_the_reduction_can_rescue_never_offloads(
         self, tmp_path, monkeypatch, weights_mib, metadata, offload_ctx
     ):
@@ -393,15 +401,26 @@ class TestAGgufWithNoNativeContext:
     """Cover slot reduction when native-context metadata is absent."""
 
     @pytest.mark.parametrize(
-        "vram_mib,weights_mib,asked,slots",
+        "vram_mib,weights_mib,asked",
         [
-            (12 * 1024, 9_000, 8, 3),
-            (16 * 1024, 12_000, 8, 5),
+            (12 * 1024, 9_000, 8),
+            (16 * 1024, 12_000, 8),
         ],
     )
     def test_the_reduction_still_pins_without_a_native_context(
-        self, tmp_path, vram_mib, weights_mib, asked, slots
+        self, tmp_path, vram_mib, weights_mib, asked
     ):
+        """Without native-context metadata the search has no length to expand to,
+        so the reduction pins at the fit floor itself.
+
+        The floor is read, not spelled 4096, for the reason
+        test_weights_that_fit_nowhere_still_offload gives about _AUTO_OFFLOAD_CTX:
+        a literal here is a re-edit every time the constant moves, and the re-edit
+        is indistinguishable from noticing that placement changed. The exact
+        surviving slot count is left unpinned for the same reason -- it is
+        arithmetic against the floor, not the claim in this test's name. What must
+        hold is that a reduction happened at all and that it stayed resident.
+        """
         got = _plan(
             tmp_path,
             weights_mib = weights_mib,
@@ -410,7 +429,10 @@ class TestAGgufWithNoNativeContext:
             vram_mib = vram_mib,
             metadata = NO_NATIVE_CTX,
         )
-        assert (got["slots"], got["fit"], got["ctx"]) == (slots, "off", 4096)
+        assert (got["fit"], got["ctx"]) == ("off", llama_cpp._FIT_MIN_CTX)
+        assert 1 <= got["slots"] < asked, (
+            f"the reduction did not fire: asked for {asked}, kept {got['slots']}"
+        )
 
     def test_no_planner_exception_is_swallowed(self, tmp_path, monkeypatch):
         """The broad placement handler must not hide a planner failure."""

--- a/studio/backend/tests/test_slot_reduction_context_refit.py
+++ b/studio/backend/tests/test_slot_reduction_context_refit.py
@@ -430,9 +430,9 @@ class TestAGgufWithNoNativeContext:
             metadata = NO_NATIVE_CTX,
         )
         assert (got["fit"], got["ctx"]) == ("off", llama_cpp._FIT_MIN_CTX)
-        assert 1 <= got["slots"] < asked, (
-            f"the reduction did not fire: asked for {asked}, kept {got['slots']}"
-        )
+        assert (
+            1 <= got["slots"] < asked
+        ), f"the reduction did not fire: asked for {asked}, kept {got['slots']}"
 
     def test_no_planner_exception_is_swallowed(self, tmp_path, monkeypatch):
         """The broad placement handler must not hide a planner failure."""

--- a/studio/backend/tests/test_slot_refit_ctx_checkpoints.py
+++ b/studio/backend/tests/test_slot_refit_ctx_checkpoints.py
@@ -177,12 +177,29 @@ class TestTheRefitDoesNotSpendTheReserve:
         self, tmp_path, checkpoints
     ):
         """Unpriced, the two stay identical however large --ctx-checkpoints gets,
-        while the child allocates it anyway."""
+        while the child allocates it anyway.
+
+        The claim is that the reserve is CHARGED, not that context specifically is
+        what pays. There are three ways to pay, and which one applies depends on how
+        big the reserve is relative to the budget: give up context at the same slot
+        count, give up a slot, or give up residency and offload. At 16 and 32
+        checkpoints this fixture already takes the third -- `--fit on` at the offload
+        fallback -- and `charged["ctx"] < free["ctx"]` only held there by arithmetic
+        coincidence, because the fallback happens to be shorter than the resident
+        plan's context. Naming the three keeps a real regression (nothing was
+        charged: same slots, same context, same residency) distinguishable from the
+        planner picking a different axis, which a raised fit floor can do on its own.
+        """
         free = _plan(tmp_path, weights_mib = 9_200, n_parallel = 4, ctx_checkpoints = 0)
         charged = _plan(tmp_path, weights_mib = 9_200, n_parallel = 4, ctx_checkpoints = checkpoints)
         assert charged["reserve_bytes"] > 0
         assert charged["checkpoints"] == str(checkpoints)
-        assert charged["ctx"] < free["ctx"], (free, charged)
+        if charged["fit"] != free["fit"]:
+            assert charged["fit"] == "on", (free, charged)
+        elif charged["slots"] != free["slots"]:
+            assert charged["slots"] < free["slots"], (free, charged)
+        else:
+            assert charged["ctx"] < free["ctx"], (free, charged)
 
     def test_a_plan_with_room_for_it_still_stays_on_gpu(self, tmp_path):
         """The reserve costs context, not the GPU pin, while there is room."""

--- a/studio/backend/tests/test_slot_refit_platform_matrix.py
+++ b/studio/backend/tests/test_slot_refit_platform_matrix.py
@@ -95,13 +95,22 @@ class _RefitSpy:
         return False
 
 
+# The shared fixture the platform cells run on: a load that does not fit at the
+# asked slot count but does fit at a reduced one, so the re-fit has something to do.
+# Named because whether it still sits in that band depends on _FIT_MIN_CTX, and
+# test_the_fixture_still_reaches_the_refit_at_this_fit_floor reports it by name when
+# a floor change moves it out.
+_FIXTURE_WEIGHTS_MIB = 10_200
+_FIXTURE_SLOTS = 4
+
+
 def _plan(
     tmp_path,
     *,
     os_key,
     vendor,
-    weights_mib = 10_200,
-    n_parallel = 4,
+    weights_mib = _FIXTURE_WEIGHTS_MIB,
+    n_parallel = _FIXTURE_SLOTS,
     vram_mib = CARD_MIB,
     n_ctx = 0,
     tensor_parallel = False,
@@ -169,14 +178,40 @@ def _plan(
 
 
 class TestWhoTheRefitIsAllowedToTouch:
+    def test_the_fixture_still_reaches_the_refit_at_this_fit_floor(self, tmp_path):
+        """Anti-vacuity, and the first thing to read when the cells below go red.
+
+        Every REACHABLE cell shares one fixture, and whether that fixture reaches
+        the re-fit at all depends on _FIT_MIN_CTX: the probe prices each candidate
+        at the floor, so raising the floor can leave no slot count that fits, and
+        `if not _uf_slots:` then skips the whole reduction. That turns all nine
+        cells red at once with `assert 0 > 0`, which reads like the re-fit was
+        deleted when the block is untouched and only the fixture went stale.
+        """
+        got, entries = _plan(tmp_path, os_key = "linux", vendor = "nvidia")
+        assert entries > 0, (
+            f"the shared fixture ({_FIXTURE_WEIGHTS_MIB} MiB of weights on a "
+            f"{CARD_MIB} MiB card, asking {_FIXTURE_SLOTS} slots) no longer produces "
+            f"a reducible plan at _FIT_MIN_CTX={llama_mod._FIT_MIN_CTX}. The planner "
+            f"returned {got}. Resize the fixture into the reducible band -- the nine "
+            f"cells below are about WHICH hosts may re-fit, and cannot answer that "
+            f"question from a fixture where nobody can."
+        )
+
     @pytest.mark.parametrize("os_key,vendor", ALL_CELLS, ids = [f"{o}-{v}" for o, v in ALL_CELLS])
     def test_only_a_gpu_host_enters_the_refit(self, tmp_path, os_key, vendor):
         """Metal and CPU-only hosts must not reach the new block at all."""
-        _, entries = _plan(tmp_path, os_key = os_key, vendor = vendor)
+        got, entries = _plan(tmp_path, os_key = os_key, vendor = vendor)
         if (os_key, vendor) in REACHABLE:
-            assert entries > 0, f"{os_key}/{vendor} should re-fit"
+            assert entries > 0, (
+                f"{os_key}/{vendor} should re-fit but made no reduced-slot probe. "
+                f"If every REACHABLE cell failed together the fixture is stale, not "
+                f"the platform gate -- see "
+                f"test_the_fixture_still_reaches_the_refit_at_this_fit_floor. "
+                f"Plan: {got}"
+            )
         else:
-            assert entries == 0, f"{os_key}/{vendor} must not re-fit"
+            assert entries == 0, f"{os_key}/{vendor} must not re-fit, but did. Plan: {got}"
 
     @pytest.mark.parametrize("os_key", ["macos_arm", "macos_intel"])
     def test_macos_plans_exactly_as_it_did(self, tmp_path, os_key):


### PR DESCRIPTION
## Why

These three files pin placement outcomes that are arithmetic against `_FIT_MIN_CTX`, so moving the floor re-edits the tests - and the re-edit is indistinguishable from noticing that placement changed. #9492 already moved it once. `test_weights_that_fit_nowhere_still_offload` reads `_AUTO_OFFLOAD_CTX` for exactly this reason; this extends that treatment to its neighbours.

This is not a fix for a red test on `main` - all 91 pass today. It is groundwork so the next floor change reports its cause instead of its symptom. #9822 is the live example: it raises `_FIT_MIN_CTX` 4096 -> 8192 and turns 51 of these red, most of them opaquely.

**No production code changes.**

## What

- `test_the_reduction_still_pins_without_a_native_context` spelled the floor as `4096` and pinned the surviving slot count. Now reads the constant, and asserts *that a reduction happened* rather than which number it landed on.
- The `_AUTO_OFFLOAD_CTX` sweeps were literals including values below a raised floor, so they drove the planner through a state the product never reaches - `_AUTO_OFFLOAD_CTX` is documented to sit at or above `_FIT_MIN_CTX`. Now multiples of the floor: identical values today (4096 x [1,2,4,8]), still the intended sweep after a move.
- The checkpoint reserve test asserted the reserve is paid **in context**. There are three ways to pay - context, a slot, or residency - and at 16 and 32 checkpoints this fixture already offloads, where the old assertion held only because the offload fallback happens to be shorter than the resident plan. I found this by writing the two-way version first and watching it fail. All three are now named, so "nothing was charged" stays distinguishable from "a different axis paid".
- The platform matrix shares one fixture across nine cells, and whether it reaches the re-fit at all depends on the floor. A floor change turns all nine red with `assert 0 > 0`, which reads like the re-fit was deleted when the block is untouched and only the fixture went stale. Added an anti-vacuity test that names the fixture, the floor and the plan the planner actually returned:

```
the shared fixture (10200 MiB of weights on a 12288 MiB card, asking 4 slots) no
longer produces a reducible plan at _FIT_MIN_CTX=8192. The planner returned
{'ctx': 8192, 'slots': 4, 'fit': 'on', ...}. Resize the fixture into the
reducible band -- the nine cells below are about WHICH hosts may re-fit, and
cannot answer that question from a fixture where nobody can.
```

## What this deliberately does not do

Simulating #9822's bump locally, the `RESCUED` band still fails after these changes:

```
test_a_load_the_reduction_can_rescue_never_offloads
  AssertionError: a placeable load was handed to --fit offload
```

That is correct and I have left it. Those rows are the `--fit off` bands #9492/#6718 exist to protect, and the failure is the ~3x decode collapse being reported, not a stale expectation. Robustifying a test must not mean sanding off the part that objects. Raised separately on #9822.

## Verification

`pytest studio/backend/tests/test_slot_reduction_context_refit.py test_slot_refit_platform_matrix.py test_slot_refit_ctx_checkpoints.py test_auto_offload_ctx_fit_floor_coupling.py` -> 91 passed (90 before, +1 anti-vacuity test).

Also re-ran with `_FIT_MIN_CTX` locally forced to 8192 to confirm the new diagnostics fire and read correctly, then restored it. `llama_cpp.py` is untouched in this PR.