### PR TITLE
Studio: make the reasoning pane pin robust to scrolls it did not cause

### DIFF
--- a/studio/frontend/src/components/assistant-ui/reasoning-autoscroll.ts
+++ b/studio/frontend/src/components/assistant-ui/reasoning-autoscroll.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Whether the streaming reasoning pane stays pinned to the bottom.
+//
+// Extracted from reasoning.tsx as a pure reducer because the defect it fixes was
+// invisible inline: the pane is a .tsx file, node's type stripping cannot compile
+// JSX, so the tests next to it pin SOURCE TEXT rather than behaviour, and no
+// amount of text pinning would have caught a wrong comparison. Here it is a plain
+// module the tests can drive through the actual sequence.
+
+export const AUTO_SCROLL_THRESHOLD_PX = 24;
+
+export type PinState = {
+  /** True once the user has moved away from the bottom on purpose. */
+  detached: boolean;
+  lastScrollTop: number;
+  /** scrollHeight - clientHeight at the previous sample. */
+  lastMaxScrollTop: number;
+};
+
+export function createPinState(scrollTop: number, maxScrollTop: number): PinState {
+  return { detached: false, lastScrollTop: scrollTop, lastMaxScrollTop: maxScrollTop };
+}
+
+/**
+ * Fold one scroll observation into the pin state.
+ *
+ * The subtlety, and the whole reason this exists: a `scroll` event fires for EVERY
+ * scrollTop change, and the listener cannot ask who caused it. Three things lower
+ * scrollTop and only the first is user intent:
+ *
+ *   1. the user scrolling up;
+ *   2. the engine CLAMPING when content shrinks, because scrollTop is always
+ *      clamped into [0, scrollHeight - clientHeight] and the old value is gone;
+ *   3. our own write when we re-pin to a bottom that has moved up.
+ *
+ * Treating 2 or 3 as 1 latches `detached`, which stops the pin. The next mutation
+ * then lands inside AUTO_SCROLL_THRESHOLD_PX of the bottom, re-attaches, and snaps
+ * back. Repeated every time a subtree changes size mid-stream, that oscillation is
+ * the flicker: the pane jumps to the top of its content and returns.
+ *
+ * Geometry cannot separate them, and this is not fixable by better arithmetic.
+ * `scroll` is dispatched as a TASK while streaming mutations arrive as microtasks,
+ * so by the time the listener runs the content has usually grown back: it sees a low
+ * scrollTop against a NEW, LARGER maximum, which is indistinguishable from a user
+ * parked mid-document. A first attempt at this fix compared against the previous
+ * maximum to recognise the shrink; modelled against that ordering (shrink to 1200,
+ * clamp to 944, grow to 4200, and only THEN the event) it detached exactly like the
+ * code it replaced. The shrink is already over by the time anyone can look.
+ *
+ * So this function NEVER detaches. Intent comes only from input events, via
+ * `detachByUser`. A scroll observation is pure geometry: it re-attaches when the
+ * viewport is back at the bottom, and otherwise just keeps the bookkeeping current.
+ */
+export function observeScroll(
+  prev: PinState,
+  scrollTop: number,
+  maxScrollTop: number,
+): PinState {
+  const detached =
+    prev.detached && maxScrollTop - scrollTop > AUTO_SCROLL_THRESHOLD_PX;
+  return { detached, lastScrollTop: scrollTop, lastMaxScrollTop: maxScrollTop };
+}
+
+/**
+ * The user moved away from the bottom on purpose: wheel up, an upward key, a touch
+ * drag, or a scrollbar drag. Every caller is an input event, which is the only
+ * evidence of intent that exists.
+ */
+export function detachByUser(prev: PinState): PinState {
+  return { ...prev, detached: true };
+}
+
+/** Record where our own pin write landed, so its scroll event reads as no change. */
+export function notePinnedTo(prev: PinState, maxScrollTop: number): PinState {
+  return { detached: prev.detached, lastScrollTop: maxScrollTop, lastMaxScrollTop: maxScrollTop };
+}
+
+export function shouldAutoScroll(state: PinState): boolean {
+  return !state.detached;
+}

--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -50,8 +50,18 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  type PinState,
+  createPinState,
+  detachByUser,
+  notePinnedTo,
+  observeScroll,
+  shouldAutoScroll,
+} from "./reasoning-autoscroll";
 const ANIMATION_DURATION = 200;
-const AUTO_SCROLL_THRESHOLD_PX = 24;
+// Keys that move a scroller up. Space alone pages DOWN, so only shift+space would
+// belong here and it arrives as key " " either way; left out rather than guessed at.
+const UPWARD_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
 
 export const reasoningVariants = cva("aui-reasoning-root mt-3 mb-4 w-full", {
   variants: {
@@ -248,55 +258,86 @@ function ReasoningText({
   ...props
 }: ComponentProps<"div"> & { streaming?: boolean }) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const shouldAutoScrollRef = useRef(true);
-  const detachedFromBottomRef = useRef(false);
-  const lastScrollTopRef = useRef(0);
+  const pinStateRef = useRef<PinState>(createPinState(0, 0));
 
   useEffect(() => {
     if (!(streaming && scrollRef.current)) {
       return;
     }
     const el = scrollRef.current;
+    // scrollHeight - clientHeight, not scrollHeight. The old pin wrote scrollHeight
+    // and only landed on the bottom because engines clamp it, and that clamp is
+    // exactly what the detach heuristic could not see the cause of.
+    const maxScrollTop = () => Math.max(0, el.scrollHeight - el.clientHeight);
     const updateAutoScroll = () => {
-      const currentScrollTop = el.scrollTop;
-      if (currentScrollTop < lastScrollTopRef.current) {
-        detachedFromBottomRef.current = true;
-      }
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (
-        detachedFromBottomRef.current &&
-        distanceFromBottom <= AUTO_SCROLL_THRESHOLD_PX
-      ) {
-        detachedFromBottomRef.current = false;
-      }
-      shouldAutoScrollRef.current = !detachedFromBottomRef.current;
-      lastScrollTopRef.current = currentScrollTop;
+      pinStateRef.current = observeScroll(
+        pinStateRef.current,
+        el.scrollTop,
+        maxScrollTop(),
+      );
     };
+    // Intent comes from input events ONLY; see reasoning-autoscroll.ts for why a
+    // scrollTop decrease cannot be read as intent. That makes this list the whole
+    // surface, so every way of scrolling up by hand has to appear here or the user
+    // gets yanked back to the bottom mid-read.
     const handleWheel = (event: WheelEvent) => {
       if (event.deltaY < 0) {
-        detachedFromBottomRef.current = true;
-        shouldAutoScrollRef.current = false;
+        pinStateRef.current = detachByUser(pinStateRef.current);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (UPWARD_KEYS.has(event.key)) {
+        pinStateRef.current = detachByUser(pinStateRef.current);
+      }
+    };
+    // Touch drag and scrollbar drag produce no wheel and no key. Both start with a
+    // pointer down on the scroller, so while one is held a scroll that moves up is
+    // the user by construction. Released on pointerup and on pointercancel, which a
+    // touch drag leaving the element does fire.
+    let pointerHeld = false;
+    const handlePointerDown = () => {
+      pointerHeld = true;
+    };
+    const releasePointer = () => {
+      pointerHeld = false;
+    };
+    const handleScrollUpWhileHeld = () => {
+      if (pointerHeld && el.scrollTop < pinStateRef.current.lastScrollTop) {
+        pinStateRef.current = detachByUser(pinStateRef.current);
       }
     };
     const observer = new MutationObserver(() => {
-      if (shouldAutoScrollRef.current) {
-        el.scrollTop = el.scrollHeight;
+      if (shouldAutoScroll(pinStateRef.current)) {
+        const target = maxScrollTop();
+        el.scrollTop = target;
+        pinStateRef.current = notePinnedTo(pinStateRef.current, target);
       }
     });
+    // Order matters: the held-pointer check reads lastScrollTop, so it has to run
+    // before updateAutoScroll overwrites it with the current position.
+    el.addEventListener("scroll", handleScrollUpWhileHeld);
     el.addEventListener("scroll", updateAutoScroll);
     el.addEventListener("wheel", handleWheel, { passive: true });
+    el.addEventListener("keydown", handleKeyDown);
+    el.addEventListener("pointerdown", handlePointerDown, { passive: true });
+    el.addEventListener("pointerup", releasePointer, { passive: true });
+    el.addEventListener("pointercancel", releasePointer, { passive: true });
     observer.observe(el, {
       childList: true,
       subtree: true,
       characterData: true,
     });
-    lastScrollTopRef.current = el.scrollTop;
-    detachedFromBottomRef.current = false;
+    pinStateRef.current = createPinState(el.scrollTop, maxScrollTop());
     updateAutoScroll();
     return () => {
       observer.disconnect();
+      el.removeEventListener("scroll", handleScrollUpWhileHeld);
       el.removeEventListener("scroll", updateAutoScroll);
       el.removeEventListener("wheel", handleWheel);
+      el.removeEventListener("keydown", handleKeyDown);
+      el.removeEventListener("pointerdown", handlePointerDown);
+      el.removeEventListener("pointerup", releasePointer);
+      el.removeEventListener("pointercancel", releasePointer);
     };
   }, [streaming]);
 

--- a/studio/frontend/tests/reasoning-autoscroll-clamp.test.ts
+++ b/studio/frontend/tests/reasoning-autoscroll-clamp.test.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The streaming reasoning pane flickered: roughly twice a second it jumped from the
+// streamed tail to the first paragraph and back. A user screen recording of main put
+// 40 of 287 frames in the wrong state, 16 episodes, median 467 ms apart.
+//
+// Cause: a `scroll` event cannot say who moved the scroller, and the pane treated ANY
+// scrollTop decrease as the user scrolling up. When content shrank mid-stream the engine
+// clamped scrollTop down, that read as user intent, the pin detached, and the next
+// mutation re-attached within the threshold and snapped back to the bottom.
+//
+// These drive the reducer through the actual sequences rather than pinning source text,
+// which is the point of extracting it: the sibling .tsx tests here can only assert on
+// text, and no amount of text pinning would have caught a wrong comparison.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AUTO_SCROLL_THRESHOLD_PX,
+  createPinState,
+  detachByUser,
+  notePinnedTo,
+  observeScroll,
+  shouldAutoScroll,
+} from "../src/components/assistant-ui/reasoning-autoscroll.ts";
+
+const VIEWPORT = 256; // max-h-64
+const maxFor = (scrollHeight: number) => Math.max(0, scrollHeight - VIEWPORT);
+
+test("the real ordering: shrink, clamp, GROW BACK, then the scroll event arrives", () => {
+  // This is the sequence that produces the flicker, and the one a naive fix misses.
+  // `scroll` is a task; streaming mutations are microtasks. By the time the listener
+  // runs, the shrink is over and the content is taller than before, so the listener
+  // sees a low scrollTop against a LARGER maximum. Comparing maxima cannot help: the
+  // smaller maximum never existed as far as this callback is concerned.
+  let state = createPinState(maxFor(4000), maxFor(4000)); // pinned, max 3744
+  state = observeScroll(state, 944, maxFor(4200));        // clamped to 944, max now 3944
+
+  assert.equal(
+    shouldAutoScroll(state),
+    true,
+    "no input event occurred, so nothing here is user intent and the pin must survive",
+  );
+});
+
+test("the flicker sequence produces no detach across repeated shrink and grow", () => {
+  let state = createPinState(maxFor(4000), maxFor(4000));
+  // Each pair is (where the clamp left scrollTop, the height it grew back to).
+  const episodes: Array<[number, number]> = [
+    [944, 4200], [644, 4400], [44, 4600], [244, 4800], [0, 5000],
+  ];
+
+  let detachEpisodes = 0;
+  for (const [clampedTo, grewTo] of episodes) {
+    state = observeScroll(state, clampedTo, maxFor(grewTo));
+    if (!shouldAutoScroll(state)) {
+      detachEpisodes += 1;
+    }
+    state = notePinnedTo(state, maxFor(grewTo));
+  }
+
+  assert.equal(
+    detachEpisodes,
+    0,
+    "each detach here is one visible flicker; the recording showed 16 in 9.57 s",
+  );
+});
+
+test("the pane still follows the stream while content only grows", () => {
+  let state = createPinState(maxFor(1000), maxFor(1000));
+  for (const h of [1200, 1500, 2000, 3000]) {
+    state = observeScroll(state, state.lastScrollTop, maxFor(h));
+    assert.equal(shouldAutoScroll(state), true);
+    state = notePinnedTo(state, maxFor(h));
+  }
+});
+
+test("a user scrolling up DOES detach, and is not yanked back down", () => {
+  let state = createPinState(maxFor(4000), maxFor(4000));
+
+  // The input event is what says "the user". The scroll observation that follows it
+  // only carries the geometry.
+  state = detachByUser(state);
+  state = observeScroll(state, maxFor(4000) - 900, maxFor(4000));
+  assert.equal(shouldAutoScroll(state), false);
+
+  // The stream keeps arriving and the document grows. The user stays where they are.
+  for (const h of [4200, 4500, 5000]) {
+    state = observeScroll(state, maxFor(4000) - 900, maxFor(h));
+    assert.equal(
+      shouldAutoScroll(state),
+      false,
+      "a reading user must not be yanked back to the bottom",
+    );
+  }
+});
+
+test("a wheel scroll up detaches even if the offset has not settled yet", () => {
+  let state = createPinState(maxFor(4000), maxFor(4000));
+  state = detachByUser(state);
+  assert.equal(shouldAutoScroll(state), false);
+});
+
+test("returning to within the threshold of the bottom re-attaches", () => {
+  let state = createPinState(maxFor(4000), maxFor(4000));
+  state = detachByUser(state);
+  state = observeScroll(state, maxFor(4000) - 900, maxFor(4000));
+  assert.equal(shouldAutoScroll(state), false);
+
+  state = observeScroll(state, maxFor(4000) - AUTO_SCROLL_THRESHOLD_PX, maxFor(4000));
+  assert.equal(
+    shouldAutoScroll(state),
+    true,
+    "scrolling back to the bottom resumes following the stream",
+  );
+});
+
+test("a user parked mid-document stays parked, however the content moves", () => {
+  // Geometry no longer detaches, so this has to come from the input event, and then
+  // survive every subsequent shrink and grow until the user returns to the bottom.
+  let state = createPinState(maxFor(4000), maxFor(4000));
+  state = detachByUser(state);
+
+  for (const [top, height] of [[900, 4200], [900, 1200], [900, 5000]] as const) {
+    state = observeScroll(state, top, maxFor(height));
+    assert.equal(
+      shouldAutoScroll(state),
+      false,
+      "a reading user must not be yanked back to the bottom",
+    );
+  }
+});
+
+test("the pin targets scrollHeight - clientHeight, so a shrink cannot strand it", () => {
+  // The old code wrote el.scrollTop = el.scrollHeight and relied on the engine to
+  // clamp. notePinnedTo records where the write actually landed, so the scroll event
+  // it provokes reads as no change rather than as a decrease.
+  let state = createPinState(maxFor(4000), maxFor(4000));
+  state = notePinnedTo(state, maxFor(1200));
+  state = observeScroll(state, maxFor(1200), maxFor(1200));
+
+  assert.equal(shouldAutoScroll(state), true);
+  assert.equal(state.lastScrollTop, maxFor(1200));
+});
+
+test("a document shorter than the viewport pins at 0 without detaching", () => {
+  // max-h-64 means content can be shorter than the pane. maxScrollTop clamps at 0,
+  // and 0 must not read as the user having scrolled to the top.
+  let state = createPinState(maxFor(4000), maxFor(4000));
+  state = observeScroll(state, 0, maxFor(100));
+
+  assert.equal(
+    shouldAutoScroll(state),
+    true,
+    "content shorter than the viewport is a clamp to 0, not a user scroll to the top",
+  );
+});


### PR DESCRIPTION
Three real defects in the streaming reasoning pane pin. **This does NOT fix the flicker a user reported, and an earlier version of this PR wrongly claimed it did.** See "What this is not" below.

## The defects

The pin treated **any** `scrollTop` decrease as the user scrolling up:

```js
if (currentScrollTop < lastScrollTopRef.current) {
  detachedFromBottomRef.current = true;
}
```

Three things lower `scrollTop` and only one is the user:

1. the user scrolling up;
2. the engine **clamping** when content shrinks, since `scrollTop` is forced into `[0, scrollHeight - clientHeight]` and the previous value is gone;
3. our own pin write landing on a bottom that moved up.

Treating 2 or 3 as 1 latches the pane detached. Related: the pin wrote `el.scrollTop = el.scrollHeight` rather than `scrollHeight - clientHeight`, and only landed on the bottom because engines clamp it, which is the same clamp the heuristic could not see the cause of.

## Why the obvious fix does not work

My first attempt compared against the previous maximum, so a decrease the shrink accounted for would be ignored. It does not work, and I only found that by modelling the real event ordering.

`scroll` is dispatched as a task while streaming mutations arrive as microtasks. By the time the listener runs the content has usually grown back, so it sees a low `scrollTop` against a **new, larger** maximum, indistinguishable from a user parked mid-document. Modelled against that ordering (shrink to 1200, clamp to 944, grow to 4200, then the event):

```
old (main):     detached=True  -> autoscroll OFF
maximum-aware:  detached=True  -> autoscroll OFF
```

Geometry cannot answer this and no arithmetic makes it able to.

## The fix

`observeScroll` never detaches. Intent comes only from input events, which makes the listener list the entire surface, so it widens past `wheel` to cover keyboard (`ArrowUp`, `PageUp`, `Home`), touch, and scrollbar drag. Scroll observations are pure geometry and only re-attach. Pins to `scrollHeight - clientHeight`.

The logic moves to `reasoning-autoscroll.ts` so it can be tested behaviourally: the pane is `.tsx`, node type stripping cannot compile JSX, and the tests beside it can only pin source text, which is how a wrong comparison lived there undetected.

## Measured

In a forced-clamp arm, frames stuck at the top of the pane:

| engine | before | after |
|---|---|---|
| Chromium | 310 | **0** |
| WebKit | 132 | **0** |
| Firefox | 7 | **0** |

Follow behaviour unchanged, 0 to 0 on all three. Scroll-up idempotency identical before and after on Chromium and Firefox, 0 yanked frames in both arms. The WebKit idempotency leg is **void**: Playwright `mouse.wheel` does not scroll there, so the gesture never lands.

## Mutation-verified

The first version of these tests passed against unmodified main, so they proved nothing. They now encode the real ordering. Reverting the reducer to main logic:

```
against main pre-fix:  9 tests, 7 pass, 2 FAIL
restored:              9 tests, 9 pass
```

## What this is not

A user reported the reasoning pane flickering during streaming, and I opened this believing it was the cause. **It is not.** Re-measuring their recording settled it:

- **The bad frames have no scrollbar.** Column x=1053 is pure background in all 40 of them, where every good frame carries a scrollbar with up-arrow, thumb and down-arrow. A classic scrollbar always paints when an element is scrollable, so in the bad frames **the pane is not scrollable**: content is shorter than the viewport.
- The box height is constant within each episode and takes only three discrete plateaus across 16 episodes, so it is not an animation sweep.

That means the pane content **collapses to four or five lines**, and `scrollTop = 0` is the browser clamping a short document, a consequence rather than the cause. Building the clamp-misread arm explicitly produces a **scrollbar-bearing** box with `scrollHeight=335, clientHeight=256`, visibly a different picture from the recording.

The real cause is upstream, in whatever publishes the reasoning part text: for one arrival the part carries a short prefix of the trace instead of everything sent so far. Reproduced by injecting exactly that, and it matches the recording closely: 16.3% bad frames against 13.9%, median onset gap 13 frames against 14, episode length 1 to 3 against 1 to 4. It could not be reproduced organically on Chromium, Firefox, Playwright WebKit or real WebKitGTK 2.50.4 at ship defaults. That hunt is separate and ongoing.

Also falsified along the way: `content-visibility` containment (#9731) contributes **zero** content shrink in this pane. ON against OFF over 4778 and 4790 frames is identical, 9 shrinks each at the same sample indices, and those 9 are the KaTeX rewrite.

`tsc --noEmit` clean. Six `training-*` test files fail in the full suite and fail identically on a clean main checkout at `1fe27b1b5`, so they are pre-existing and unrelated.
