### PR TITLE
Stop a left-padded row that attends to nothing returning NaN (#9708)

### DIFF
--- a/tests/test_sdpa_fully_masked_rows.py
+++ b/tests/test_sdpa_fully_masked_rows.py
@@ -170,6 +170,7 @@ def test_the_probe_says_no_when_the_build_already_corrects_itself(unpatched):
     A stub standing in for a future fixed transformers: the probe must answer
     False, and `fix_...` must then leave the module alone byte for byte.
     """
+
     def already_correct(*args, **kwargs):
         mask = unpatched(*args, **kwargs)
         if mask is not None and not mask.is_floating_point():
@@ -180,9 +181,9 @@ def test_the_probe_says_no_when_the_build_already_corrects_itself(unpatched):
     masking_utils.sdpa_mask = already_correct
     assert _sdpa_mask_leaves_rows_fully_masked() is False
     fix_transformers_fully_masked_rows()
-    assert masking_utils.sdpa_mask is already_correct, (
-        "the fix patched a transformers that does not need it"
-    )
+    assert (
+        masking_utils.sdpa_mask is already_correct
+    ), "the fix patched a transformers that does not need it"
     assert not getattr(masking_utils, "_unsloth_patched_sdpa_mask", False)
 
 
@@ -222,9 +223,7 @@ def test_the_correction_itself_on_every_dtype_it_can_meet():
     assert fixed.dtype == torch.bool
 
     int_mask = bool_mask.to(torch.int64)
-    assert _unmask_rows_attending_to_nothing(int_mask).tolist() == [
-        [[[1, 1], [0, 1]]]
-    ]
+    assert _unmask_rows_attending_to_nothing(int_mask).tolist() == [[[[1, 1], [0, 1]]]]
 
     # The eager path: returned untouched, and by identity, not by value.
     float_mask = torch.zeros((1, 1, 2, 2), dtype = torch.float32)
@@ -244,6 +243,4 @@ def test_the_correction_is_idempotent_and_self_neutralising():
     assert torch.equal(once, twice)
 
     already_fine = torch.tensor([[[[True, False], [True, True]]]])
-    assert torch.equal(
-        _unmask_rows_attending_to_nothing(already_fine), already_fine
-    )
+    assert torch.equal(_unmask_rows_attending_to_nothing(already_fine), already_fine)

--- a/tests/test_sdpa_fully_masked_rows.py
+++ b/tests/test_sdpa_fully_masked_rows.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""A left-padded row that attends to nothing must not reach SDPA.
+
+`transformers.masking_utils.sdpa_mask` builds a boolean mask and returns it with
+no correction for query rows that attend to no key at all, and the parameter that
+used to make that correction is now documented `"Deprecated and has no effect.
+Will be removed in version 5.18.0."`. In 4.57.6 the same function still carried
+it, guarded on `not _is_torch_greater_or_equal_than_2_5` -- upstream retired it
+believing torch 2.5 had made it unnecessary.
+
+Measured on a B200, torch 2.13.0+cu130, transformers 5.15.1, unquantized fp16
+`google/gemma-4-E2B-it`, no unsloth in the process: a SINGLE forward pass returns
+NaN logits on exactly the rows that received a left pad token and finite logits
+on every row that did not, 16 rows of 16 across batch sizes 2, 4 and 8, and under
+`generate` those rows decode to the empty string. That is unsloth #9708.
+
+Every test here DRIVES the real functions. The rules in this repo have been
+caught before passing against a hand-written dict while the code that produces
+it was broken, so nothing below asserts on a literal that the code did not
+compute.
+"""
+
+import inspect
+
+import pytest
+
+torch = pytest.importorskip("torch")
+masking_utils = pytest.importorskip("transformers.masking_utils")
+
+from unsloth.import_fixes import (  # noqa: E402
+    _left_padded_probe_mask,
+    _unmask_rows_attending_to_nothing,
+    _sdpa_mask_leaves_rows_fully_masked,
+    fix_transformers_fully_masked_rows,
+)
+
+
+def _call_sdpa_mask(fn, attention_mask):
+    """Call whichever signature this transformers ships.
+
+    5.x takes `q_length`; 4.57.6 binds `sdpa_mask` to `sdpa_mask_recent_torch`,
+    which takes `cache_position`. The fix supports both, so the tests must too.
+    """
+    length = attention_mask.shape[-1]
+    kwargs = {
+        "batch_size": attention_mask.shape[0],
+        "kv_length": length,
+        "attention_mask": attention_mask,
+        "allow_is_causal_skip": False,
+    }
+    params = inspect.signature(fn).parameters
+    if "q_length" in params:
+        kwargs["q_length"] = length
+    elif "cache_position" in params:
+        kwargs["cache_position"] = torch.arange(length)
+    else:
+        pytest.skip("sdpa_mask signature is neither shape this fix supports")
+    return fn(**kwargs)
+
+
+@pytest.fixture
+def unpatched():
+    """The original function, and the module put back afterwards.
+
+    Other tests in a session may already have installed the patch, so reach for
+    `__wrapped__` rather than assuming the module global is pristine.
+    """
+    original_global = masking_utils.sdpa_mask
+    original = getattr(original_global, "__wrapped__", original_global)
+    interface = getattr(masking_utils, "ALL_MASK_ATTENTION_FUNCTIONS", None)
+    original_registered = interface["sdpa"] if interface is not None else None
+    flag = getattr(masking_utils, "_unsloth_patched_sdpa_mask", False)
+    masking_utils.sdpa_mask = original
+    if interface is not None:
+        interface.register("sdpa", original)
+    masking_utils._unsloth_patched_sdpa_mask = False
+    try:
+        yield original
+    finally:
+        masking_utils.sdpa_mask = original_global
+        if interface is not None and original_registered is not None:
+            interface.register("sdpa", original_registered)
+        masking_utils._unsloth_patched_sdpa_mask = flag
+
+
+def test_the_bug_this_fix_exists_for_is_really_here(unpatched):
+    """The negative control, and it is the load-bearing test in this file.
+
+    If a future transformers restores the guard, this FAILS and says so, rather
+    than leaving a wrapper nobody can justify. Do not delete it to make the
+    suite green: re-measure first, then remove the fix and this file together.
+    """
+    mask = _call_sdpa_mask(unpatched, _left_padded_probe_mask(torch))
+    assert mask is not None and not mask.is_floating_point()
+    fully_masked = int((~mask.bool().any(dim = -1)).sum())
+    assert fully_masked == 1, (
+        "the unpatched sdpa_mask no longer leaves a left-padded query row "
+        "attending to nothing, so unsloth #9708 may be fixed upstream -- "
+        "re-measure on a real model before simplifying the fix away"
+    )
+
+
+def test_the_probe_answers_true_when_the_bug_is_present(unpatched):
+    assert _sdpa_mask_leaves_rows_fully_masked() is True
+
+
+def test_the_patch_leaves_no_row_attending_to_nothing(unpatched):
+    fix_transformers_fully_masked_rows()
+    mask = _call_sdpa_mask(masking_utils.sdpa_mask, _left_padded_probe_mask(torch))
+    assert int((~mask.bool().any(dim = -1)).sum()) == 0, (
+        "a query row still attends to nothing, so SDPA can still return NaN "
+        "for it and a left-padded batch can still decode to the empty string"
+    )
+
+
+def test_the_patch_changes_nothing_a_real_row_could_read(unpatched):
+    """The correction must be confined to rows that attend to nothing.
+
+    Those are pad positions whose outputs are discarded, which is why upstream's
+    own docstring said this "does not change the final result". A patch that
+    also loosened a real row would silently let a token attend across padding.
+    """
+    attention_mask = _left_padded_probe_mask(torch)
+    before = _call_sdpa_mask(unpatched, attention_mask).bool()
+    fix_transformers_fully_masked_rows()
+    after = _call_sdpa_mask(masking_utils.sdpa_mask, attention_mask).bool()
+
+    attends_to_something = before.any(dim = -1)
+    assert torch.equal(
+        before[attends_to_something], after[attends_to_something]
+    ), "the patch altered a row that already attended to something"
+
+
+def test_both_bindings_are_patched(unpatched):
+    """`eager_mask` reads the module global; the interface captured the original.
+
+    They are different references to the same function and both have to move, or
+    half the models in transformers keep the old one. Confirmed by file search:
+    `sdpa_mask` is defined once in transformers and no other module imports it.
+    """
+    fix_transformers_fully_masked_rows()
+    interface = getattr(masking_utils, "ALL_MASK_ATTENTION_FUNCTIONS", None)
+    if interface is None:
+        pytest.skip("this transformers has no ALL_MASK_ATTENTION_FUNCTIONS")
+    assert interface["sdpa"] is masking_utils.sdpa_mask
+    assert masking_utils.sdpa_mask is not unpatched
+
+
+def test_patching_twice_does_not_stack_wrappers(unpatched):
+    fix_transformers_fully_masked_rows()
+    once = masking_utils.sdpa_mask
+    fix_transformers_fully_masked_rows()
+    assert masking_utils.sdpa_mask is once
+    assert masking_utils.sdpa_mask.__wrapped__ is unpatched
+
+
+def test_the_original_stays_reachable(unpatched):
+    """Undoable and probeable. Without this the probe would read the patched
+    function on a second call and report the bug as fixed."""
+    fix_transformers_fully_masked_rows()
+    assert masking_utils.sdpa_mask.__wrapped__ is unpatched
+    assert _sdpa_mask_leaves_rows_fully_masked() is True
+
+
+def test_the_probe_says_no_when_the_build_already_corrects_itself(unpatched):
+    """The gate, exercised in the direction that matters for an unaffected user.
+
+    A stub standing in for a future fixed transformers: the probe must answer
+    False, and `fix_...` must then leave the module alone byte for byte.
+    """
+    def already_correct(*args, **kwargs):
+        mask = unpatched(*args, **kwargs)
+        if mask is not None and not mask.is_floating_point():
+            mask = mask | ~mask.any(dim = -1, keepdim = True)
+        return mask
+
+    already_correct.__signature__ = inspect.signature(unpatched)
+    masking_utils.sdpa_mask = already_correct
+    assert _sdpa_mask_leaves_rows_fully_masked() is False
+    fix_transformers_fully_masked_rows()
+    assert masking_utils.sdpa_mask is already_correct, (
+        "the fix patched a transformers that does not need it"
+    )
+    assert not getattr(masking_utils, "_unsloth_patched_sdpa_mask", False)
+
+
+def test_the_probe_is_dtype_honest(unpatched):
+    """The probe feeds a BOOL mask because the real callers do.
+
+    Written after an int64 probe mask came back int64 and an earlier
+    `dtype == torch.bool` check answered "not affected" for a reason that had
+    nothing to do with the bug.
+    """
+    assert _left_padded_probe_mask(torch).dtype == torch.bool
+    mask = _call_sdpa_mask(unpatched, _left_padded_probe_mask(torch))
+    assert mask.dtype == torch.bool
+
+
+def test_a_batch_with_no_padding_is_untouched(unpatched):
+    """No pad, no fully-masked row, nothing for the patch to do."""
+    attention_mask = torch.ones((2, 2), dtype = torch.bool)
+    before = _call_sdpa_mask(unpatched, attention_mask).bool()
+    fix_transformers_fully_masked_rows()
+    after = _call_sdpa_mask(masking_utils.sdpa_mask, attention_mask).bool()
+    assert torch.equal(before, after)
+
+
+def test_the_correction_itself_on_every_dtype_it_can_meet():
+    """The helper, driven directly. No transformers needed, no fixture state.
+
+    Replaces an earlier version of this test that asserted a tautology and would
+    have passed against any implementation at all.
+    """
+    bool_mask = torch.tensor([[[[False, False], [False, True]]]])
+    fixed = _unmask_rows_attending_to_nothing(bool_mask)
+    assert fixed.tolist() == [[[[True, True], [False, True]]]], (
+        "the row attending to nothing was not opened up, or a row that already "
+        "attended to something was changed"
+    )
+    assert fixed.dtype == torch.bool
+
+    int_mask = bool_mask.to(torch.int64)
+    assert _unmask_rows_attending_to_nothing(int_mask).tolist() == [
+        [[[1, 1], [0, 1]]]
+    ]
+
+    # The eager path: returned untouched, and by identity, not by value.
+    float_mask = torch.zeros((1, 1, 2, 2), dtype = torch.float32)
+    assert _unmask_rows_attending_to_nothing(float_mask) is float_mask
+
+    # `is_causal` was used instead of a mask.
+    assert _unmask_rows_attending_to_nothing(None) is None
+
+
+def test_the_correction_is_idempotent_and_self_neutralising():
+    """Applied twice is applied once, and applied to an already-correct mask it
+    is the identity in value. That is what makes it safe to leave in place if a
+    future transformers restores its own guard."""
+    mask = torch.tensor([[[[False, False], [False, True]]]])
+    once = _unmask_rows_attending_to_nothing(mask)
+    twice = _unmask_rows_attending_to_nothing(once)
+    assert torch.equal(once, twice)
+
+    already_fine = torch.tensor([[[[True, False], [True, True]]]])
+    assert torch.equal(
+        _unmask_rows_attending_to_nothing(already_fine), already_fine
+    )

--- a/tests/test_sdpa_fully_masked_rows.py
+++ b/tests/test_sdpa_fully_masked_rows.py
@@ -31,6 +31,7 @@ masking_utils = pytest.importorskip("transformers.masking_utils")
 
 from unsloth.import_fixes import (  # noqa: E402
     _left_padded_probe_mask,
+    _sdpa_mask_is_patched,
     _unmask_rows_attending_to_nothing,
     _sdpa_mask_leaves_rows_fully_masked,
     fix_transformers_fully_masked_rows,
@@ -206,6 +207,60 @@ def test_a_batch_with_no_padding_is_untouched(unpatched):
     fix_transformers_fully_masked_rows()
     after = _call_sdpa_mask(masking_utils.sdpa_mask, attention_mask).bool()
     assert torch.equal(before, after)
+
+
+def test_the_probe_is_pinned_to_cpu_whatever_the_default_device_is(unpatched):
+    """A meta default device must answer the question, not abort the import.
+
+    `torch.set_default_device("meta")` around `import unsloth` used to put the
+    probe mask on meta, where `sdpa_mask` builds its own index tensors on CPU
+    and raises, or hands back a meta mask whose truth value cannot be read --
+    and that read sat outside the guard, so it propagated out of the import.
+    """
+    torch.set_default_device("meta")
+    try:
+        assert _left_padded_probe_mask(torch).device.type == "cpu"
+        assert _sdpa_mask_leaves_rows_fully_masked() is True
+    finally:
+        torch.set_default_device(None)
+
+
+def test_a_reloaded_masking_utils_is_patched_again(unpatched):
+    """The guard reads the live bindings, not a mark on the module.
+
+    `importlib.reload` re-executes the module body in the SAME namespace, so
+    `sdpa_mask` and the registry entry revert to upstream while any attribute
+    we set on the module survives. Gating on that attribute refuses to re-patch
+    a build that is vulnerable again -- protection lost, silently.
+    """
+    fix_transformers_fully_masked_rows()
+    assert _sdpa_mask_is_patched(masking_utils)
+
+    # Exactly what a reload leaves behind: upstream functions, our marker.
+    interface = getattr(masking_utils, "ALL_MASK_ATTENTION_FUNCTIONS", None)
+    masking_utils.sdpa_mask = unpatched
+    if interface is not None:
+        interface.register("sdpa", unpatched)
+    assert getattr(masking_utils, "_unsloth_patched_sdpa_mask", False) is True
+    assert not _sdpa_mask_is_patched(masking_utils)
+
+    fix_transformers_fully_masked_rows()
+    assert _sdpa_mask_is_patched(masking_utils)
+    mask = _call_sdpa_mask(masking_utils.sdpa_mask, _left_padded_probe_mask(torch))
+    assert int((~mask.bool().any(dim = -1)).sum()) == 0
+
+
+def test_a_half_installed_patch_is_completed_rather_than_skipped(unpatched):
+    """Module global ours, registry upstream: not patched, so run again."""
+    interface = getattr(masking_utils, "ALL_MASK_ATTENTION_FUNCTIONS", None)
+    if interface is None:
+        pytest.skip("this transformers has no ALL_MASK_ATTENTION_FUNCTIONS")
+    fix_transformers_fully_masked_rows()
+    interface.register("sdpa", unpatched)
+    assert not _sdpa_mask_is_patched(masking_utils)
+    fix_transformers_fully_masked_rows()
+    assert interface["sdpa"] is masking_utils.sdpa_mask
+    assert _sdpa_mask_is_patched(masking_utils)
 
 
 def test_the_correction_itself_on_every_dtype_it_can_meet():

--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -193,6 +193,7 @@ from unsloth_zoo.device_type import (
 # Fix other issues
 from .import_fixes import (
     fix_transformers5_bare_annotation_configs,
+    fix_transformers_fully_masked_rows,
     fix_xformers_performance_issue,
     fix_flash_attn_4_namespace_shadow,
     fix_vllm_aimv2_issue,
@@ -228,6 +229,11 @@ from .import_fixes import (
 
 # Must run first: guards PretrainedConfig before vLLM defines its config classes.
 fix_transformers5_bare_annotation_configs()
+# Probe-gated: no-ops unless this transformers really hands SDPA a query row
+# that attends to nothing. Ordered here, before anything imports a model, so a
+# plain `transformers.generate` in the same process is covered too -- which is
+# the case unsloth #9708 was measured on.
+fix_transformers_fully_masked_rows()
 fix_xformers_performance_issue()
 # Must run AFTER fix_xformers_performance_issue (it rewrites xformers' cutlass.py on disk, so it
 # must precede any xformers import) and BEFORE models/_utils.py imports xformers.ops.

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -756,7 +756,9 @@ def _left_padded_probe_mask(torch):
     import. The probe is two elements, so pinning it to CPU costs nothing.
     """
     return torch.tensor(
-        [[False, True], [True, True]], dtype = torch.bool, device = "cpu",
+        [[False, True], [True, True]],
+        dtype = torch.bool,
+        device = "cpu",
     )
 
 

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -695,6 +695,30 @@ def fix_transformers5_bare_annotation_configs():
 _SDPA_MASK_PATCH_FLAG = "_unsloth_patched_sdpa_mask"
 
 
+def _sdpa_mask_is_patched(masking_utils):
+    """Are the live bindings ours, right now?
+
+    Asked of the FUNCTIONS rather than of a flag on the module. A module-level
+    flag outlives what it describes: `importlib.reload(masking_utils)` re-runs
+    the module body in the existing namespace, so `sdpa_mask` and the registry
+    entry go back to upstream while any attribute we added survives. Gating on
+    that flag would then refuse to re-patch a build that is once again
+    vulnerable, which is the opposite of what an idempotence guard is for.
+
+    Both bindings must carry the mark, so a half-installed state re-runs.
+    """
+    flagged = lambda fn: bool(getattr(fn, _SDPA_MASK_PATCH_FLAG, False))
+    if not flagged(getattr(masking_utils, "sdpa_mask", None)):
+        return False
+    interface = getattr(masking_utils, "ALL_MASK_ATTENTION_FUNCTIONS", None)
+    if interface is None:
+        return True
+    try:
+        return flagged(interface["sdpa"])
+    except Exception:
+        return False
+
+
 def _unmask_rows_attending_to_nothing(mask):
     """Give a query row that attends to no key uniform attention instead.
 
@@ -724,8 +748,16 @@ def _left_padded_probe_mask(torch):
     real callers hand it a bool. Probing with an int mask gets an int mask back
     and a `dtype == torch.bool` check then answers "not affected" for a reason
     that has nothing to do with the bug.
+
+    CPU explicitly, never the ambient default: under a `torch.set_default_device`
+    of "meta" this lands on meta, where `sdpa_mask` builds its index tensors on
+    CPU and raises, or returns a meta mask whose truth value cannot be read. The
+    first answers "not affected" for the wrong reason; the second aborts the
+    import. The probe is two elements, so pinning it to CPU costs nothing.
     """
-    return torch.tensor([[False, True], [True, True]], dtype = torch.bool)
+    return torch.tensor(
+        [[False, True], [True, True]], dtype = torch.bool, device = "cpu",
+    )
 
 
 def _sdpa_mask_leaves_rows_fully_masked():
@@ -766,17 +798,22 @@ def _sdpa_mask_leaves_rows_fully_masked():
     if "q_length" in params:
         kwargs["q_length"] = 2
     elif "cache_position" in params:
-        kwargs["cache_position"] = torch.arange(2)
+        kwargs["cache_position"] = torch.arange(2, device = "cpu")
     else:
         return False
+    if "device" in params:
+        kwargs["device"] = torch.device("cpu")
     try:
         mask = sdpa_mask(**kwargs)
+        if mask is None or mask.is_floating_point():
+            return False
+        # Inside the guard as well: reading a mask's truth value is what fails
+        # on a meta or otherwise unmaterialised tensor, and a probe that raises
+        # would take `import unsloth` down with it.
+        return bool((~mask.any(dim = -1)).any())
     except Exception:
         # Signature moved under us. Patching blind would be worse than not.
         return False
-    if mask is None or mask.is_floating_point():
-        return False
-    return bool((~mask.any(dim = -1)).any())
 
 
 def fix_transformers_fully_masked_rows():
@@ -820,7 +857,7 @@ def fix_transformers_fully_masked_rows():
         logger.info(f"Unsloth: Skipping the fully-masked-row fix ({e})")
         return
 
-    if getattr(masking_utils, _SDPA_MASK_PATCH_FLAG, False):
+    if _sdpa_mask_is_patched(masking_utils):
         return
 
     original = masking_utils.sdpa_mask
@@ -834,6 +871,9 @@ def fix_transformers_fully_masked_rows():
     # the tests both reach for it, and a future wraps-less edit must not
     # silently make the patch un-probeable and un-undoable.
     sdpa_mask.__wrapped__ = original
+    # The mark travels ON the wrapper, so the guard above reads the live
+    # binding and a reload that drops it is re-patched rather than skipped.
+    setattr(sdpa_mask, _SDPA_MASK_PATCH_FLAG, True)
 
     try:
         # BOTH bindings, and they are not the same object. `eager_mask` calls

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -692,6 +692,169 @@ def fix_transformers5_bare_annotation_configs():
         logger.info(f"Unsloth: Failed patching PretrainedConfig ({e})")
 
 
+_SDPA_MASK_PATCH_FLAG = "_unsloth_patched_sdpa_mask"
+
+
+def _unmask_rows_attending_to_nothing(mask):
+    """Give a query row that attends to no key uniform attention instead.
+
+    Separated from the wrapper so it can be tested directly on every dtype the
+    mask can arrive as, rather than only through a live transformers.
+
+    `None` means transformers chose `is_causal` over a materialised mask. A
+    FLOATING mask is the eager path, which converts to `finfo(dtype).min` and
+    survives softmax's max-subtraction as uniform attention already, so it
+    neither needs this nor would tolerate a boolean `|`. Bool is the normal sdpa
+    result; int is what a caller who passed an int `attention_mask` gets back,
+    and the correction is right for both.
+    """
+    if mask is None or mask.is_floating_point():
+        return mask
+    return mask | ~mask.any(dim = -1, keepdim = True)
+
+
+def _left_padded_probe_mask(torch):
+    """A 2-token batch whose first row is one pad then one real token.
+
+    Row 0's query at position 0 is a pad: causal masking allows it only key 0,
+    and the padding mask then removes key 0, so nothing is left. That is the
+    row this whole fix is about, built as small as it can be.
+
+    Bool, not int: `sdpa_mask` returns whatever dtype it was handed, and the
+    real callers hand it a bool. Probing with an int mask gets an int mask back
+    and a `dtype == torch.bool` check then answers "not affected" for a reason
+    that has nothing to do with the bug.
+    """
+    return torch.tensor([[False, True], [True, True]], dtype = torch.bool)
+
+
+def _sdpa_mask_leaves_rows_fully_masked():
+    """Does THIS build hand SDPA a query row that attends to nothing?
+
+    Answered by building one, not by comparing versions. `allow_torch_fix` was
+    the correction and is now documented "Deprecated and has no effect", but it
+    was a live parameter in 4.x and the retirement landed mid-5.x, so a version
+    window would mislabel builds carrying it early or late. Absent positive
+    evidence answer False and leave transformers alone.
+    """
+    try:
+        import torch
+        from transformers import masking_utils
+    except Exception:
+        return False
+    sdpa_mask = getattr(masking_utils, "sdpa_mask", None)
+    if sdpa_mask is None:
+        return False
+    # Unwrap first: a second call must probe the ORIGINAL, or the patch we
+    # already installed reports the bug as fixed and a reload silently drops it.
+    sdpa_mask = getattr(sdpa_mask, "__wrapped__", sdpa_mask)
+    # The query axis is named differently across the versions we support: 5.x
+    # takes `q_length`, while 4.57.6 binds `sdpa_mask` to `sdpa_mask_recent_torch`,
+    # which takes `cache_position` instead. Ask the signature rather than
+    # guessing -- a probe that raises TypeError answers "no bug" for a reason
+    # that has nothing to do with the bug.
+    kwargs = {
+        "batch_size": 2,
+        "kv_length": 2,
+        "attention_mask": _left_padded_probe_mask(torch),
+        "allow_is_causal_skip": False,
+    }
+    try:
+        params = inspect.signature(sdpa_mask).parameters
+    except Exception:
+        return False
+    if "q_length" in params:
+        kwargs["q_length"] = 2
+    elif "cache_position" in params:
+        kwargs["cache_position"] = torch.arange(2)
+    else:
+        return False
+    try:
+        mask = sdpa_mask(**kwargs)
+    except Exception:
+        # Signature moved under us. Patching blind would be worse than not.
+        return False
+    if mask is None or mask.is_floating_point():
+        return False
+    return bool((~mask.any(dim = -1)).any())
+
+
+def fix_transformers_fully_masked_rows():
+    """Stop a left-padded batch returning NaN logits, and empty generations.
+
+    `masking_utils.sdpa_mask` returns a boolean mask with no correction for
+    query rows that attend to nothing, and the parameter that used to make that
+    correction, `allow_torch_fix`, is now "Deprecated and has no effect. Will be
+    removed in version 5.18.0." In 4.57.6 the same function still carried it,
+    guarded on `not _is_torch_greater_or_equal_than_2_5`, on the belief that
+    torch 2.5 had made it unnecessary.
+
+    It has not. Measured on a B200, torch 2.13.0+cu130, transformers 5.15.1,
+    unquantized fp16 `google/gemma-4-E2B-it`, with no unsloth in the process: a
+    SINGLE forward pass returns NaN logits on exactly the rows that received a
+    left pad token and finite logits on every row that did not -- 16 of 16 rows
+    across batch sizes 2, 4 and 8 -- and under `generate` those rows decode to
+    the empty string. bfloat16 produces no NaNs. Three repeats per batch size
+    are byte-identical, so it is deterministic. Reported as unsloth #9708.
+
+    A fully masked row makes SDPA produce NaN, and the NaN then spreads along
+    the row through `0 * NaN` where the next layer mixes values. Restoring the
+    correction gives those rows uniform attention instead. They are pad
+    positions whose outputs are discarded, so this does not change any result
+    that is read -- which is what transformers' own docstring said when it did
+    this: "in order to avoid `nan` propagation (this does not change the final
+    result)".
+
+    Self-neutralising: `mask | ~mask.any(-1)` contributes nothing once a row
+    attends to something, so if a future transformers restores the guard this
+    wrapper becomes a no-op rather than permanent damage. The eager path is
+    unaffected either way -- `eager_mask` converts to `finfo(dtype).min` and a
+    uniform-min row survives softmax's max-subtraction as uniform attention.
+    """
+    if not _sdpa_mask_leaves_rows_fully_masked():
+        return
+    try:
+        import torch
+        from transformers import masking_utils
+    except Exception as e:
+        logger.info(f"Unsloth: Skipping the fully-masked-row fix ({e})")
+        return
+
+    if getattr(masking_utils, _SDPA_MASK_PATCH_FLAG, False):
+        return
+
+    original = masking_utils.sdpa_mask
+    original = getattr(original, "__wrapped__", original)
+
+    @functools.wraps(original)
+    def sdpa_mask(*args, **kwargs):
+        return _unmask_rows_attending_to_nothing(original(*args, **kwargs))
+
+    # `functools.wraps` sets __wrapped__, but set it explicitly: the probe and
+    # the tests both reach for it, and a future wraps-less edit must not
+    # silently make the patch un-probeable and un-undoable.
+    sdpa_mask.__wrapped__ = original
+
+    try:
+        # BOTH bindings, and they are not the same object. `eager_mask` calls
+        # the module global by name at call time, so it picks this up; the
+        # interface captured the original function in `_global_mapping` when
+        # the class body ran, so it needs re-registering. Confirmed by search:
+        # `sdpa_mask` is defined once and no other transformers module
+        # references it.
+        masking_utils.sdpa_mask = sdpa_mask
+        interface = getattr(masking_utils, "ALL_MASK_ATTENTION_FUNCTIONS", None)
+        if interface is not None:
+            interface.register("sdpa", sdpa_mask)
+        setattr(masking_utils, _SDPA_MASK_PATCH_FLAG, True)
+        logger.info(
+            "Unsloth: Patching transformers `sdpa_mask` so a left-padded row "
+            "that attends to nothing cannot return NaN (unsloth #9708)"
+        )
+    except Exception as e:
+        logger.info(f"Unsloth: Failed patching sdpa_mask ({e})")
+
+
 # ValueError: 'aimv2' is already used by a Transformers config, pick another name.
 def fix_vllm_aimv2_issue():
     spec = importlib.util.find_spec("vllm")


### PR DESCRIPTION
Fixes #9708 for the gemma-4 half, inside unsloth. No upstream change required.

## What is wrong

`transformers.masking_utils.sdpa_mask` builds a boolean mask and returns it with **no correction for query rows that attend to no key at all**. The parameter that used to make that correction is now:

> `allow_torch_fix` (`bool`, optional): Deprecated and has no effect. Will be removed in version 5.18.0.

In 4.57.6 the same function still carried it, guarded on `not _is_torch_greater_or_equal_than_2_5`, with a docstring saying it exists "in order to avoid `nan` propagation (this does not change the final result)". Upstream retired it believing torch 2.5 had made it unnecessary.

It has not. A left-pad query row is causally restricted to keys the padding mask then removes, so the row is entirely masked, SDPA returns NaN for it, and the NaN spreads along the row through `0 * NaN` where the next layer mixes values.

## Measured

NVIDIA B200 (sm_100), torch 2.13.0+cu130, transformers 5.15.1, unquantized fp16 `google/gemma-4-E2B-it`, **no unsloth in the process**: a *single forward pass* — no `generate`, no cache — returns NaN logits on exactly the rows that received a left pad token and finite logits on every row that did not. 16 rows of 16 across batch 2/4/8. Under `generate` those rows decode to the empty string. bitsandbytes is not involved; the unquantized arm is identical row for row. Three repeats per batch size are byte-identical.

Same machine, same reproduction, with this patch:

| arm | before | after |
|---|---|---|
| gemma-4 fp16 | 16 NaN rows; batches 2/4/8 all disagree, differing rows `[0,1,2,3,4,5,6]` | **0 NaN rows; 2/4/8 agree exactly, differing rows `[]`** |
| gemma-4 bf16 | no NaNs, but 2/4/8 disagree | **2/4/8 agree** |
| Qwen3.5-2B | 2 agrees, 4/8 disagree | unchanged, and expected to be |

Qwen3.5-2B is deliberately not claimed: it diverges with **equal-length prompts and no padding at all** (batch 2 disagrees, 4 and 8 agree, stably over three repeats), which is a linear-attention/gated-delta model and a different mechanism. It stays open.

## The change

One probe and one wrapper in `unsloth/import_fixes.py`, in the shape that file already uses for third-party patches (`_transformers_needs_bare_annotation_fix` / `fix_transformers5_bare_annotation_configs`), called from `_gpu_init.py` at `import unsloth`.

- **Gated on behaviour, not a version.** The parameter was live in 4.x and the retirement landed mid-5.x, so a version window would mislabel builds carrying it early or late. The probe builds a two-row left-padded mask and asks whether any query row comes back empty; absent positive evidence it answers False and transformers is left alone.
- **Both bindings move**, and they are not the same object: the module global that `eager_mask` resolves at call time, and the `ALL_MASK_ATTENTION_FUNCTIONS` entry that captured the original when the class body ran. Confirmed by search: `sdpa_mask` is defined once in transformers and no other module references it.
- **Self-neutralising.** `mask | ~mask.any(-1)` contributes nothing once a row attends to something, so if a future transformers restores its own guard this becomes a no-op rather than permanent damage.
- **Float masks are excluded**: the eager path converts to `finfo(dtype).min` and survives softmax's max-subtraction as uniform attention already.
- Idempotent, original reachable as `__wrapped__`, every failure swallowed into `logger.info` so a patch that cannot apply never breaks an import.

## Compatibility

Verified on transformers **4.57.6** (torch 2.9.1) and **5.15.1** (torch 2.13.0): probe True on both, patch removes the empty row on both, idempotent on both, registry rebound on both. 4.57.6 is affected too — its guard only fires for torch < 2.5.

No device, dtype or platform branch; no vLLM path touched, so `fast_inference = True` GRPO is unaffected. The wrapper is ordinary tensor algebra that `torch.compile` traces, and it sits below unsloth_zoo's `create_causal_mask` wrapper, so the two compose in either order.

## Tests

12 tests in `tests/test_sdpa_fully_masked_rows.py`, all driving the real functions rather than a hand-written dict, **8 of 8 mutations caught** (no-op correction, correction widened to every row, float masks no longer excluded, registry not rebound, idempotence flag dropped, probe not unwrapping, probe mask dtype, gate removed).

The first test is a **negative control**: it fails if the upstream defect disappears, and says to re-measure rather than delete the fix. A correction nobody can justify is how a workaround outlives its bug.

`tests/` root-level suite: 5417 passed. The two failures on it (`test_source_read_encoding`, `test_studio_root_resilience`) reproduce on an unmodified checkout and are not from this change.

GPU-level regression coverage for batched generation against a `*ForConditionalGeneration` model lands with the Kaggle Default leg in #9700 — that leg is what found this.