### PR TITLE
Stop a resumed turn retracting text it already streamed

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -226,8 +226,8 @@ import type { CachedGgufRepo, CachedModelRepo } from "./chat-api";
 import {
   budgetImpliesTruncation,
   CONTINUE_INSTRUCTION,
+  createContinuationMerger,
   type IncompleteReason,
-  joinContinuation,
   readIncompleteInfo,
   readContinuationRequest,
   rejectsAssistantPrefill,
@@ -5191,18 +5191,20 @@ export function createOpenAIStreamAdapter(
       // is for providers that may ignore the prefill and repeat or restart.
       const repairContinuation =
         isExternalRequest && !resumesExactly(externalProvider?.providerType);
-      const mergeContinuation = (text: string): string =>
-        continuationPartial && repairContinuation
-          ? joinContinuation(
-              continuationPartial,
-              text.slice(continuationPartial.length),
-            )
-          : text;
+      // Streamed publishes get the cumulative text unchanged; the repairs run once, on
+      // the finished turn. Both of them re-decide as the continuation grows, so running
+      // them per arrival published a SHORTER text than the arrival before it, and the
+      // restart branch published only the continuation, dropping the whole partial the
+      // reader was already looking at.
+      const mergeContinuation = createContinuationMerger(
+        continuationPartial,
+        repairContinuation,
+      );
       // The parse of everything already streamed, extended by each delta.
-      // `mergeContinuation` can rewrite the prefix it is handed, and a rewritten
-      // prefix is exactly what an extend-only parse cannot follow, so that one
-      // path keeps reparsing the whole reply as before. It is a continuation of
-      // an external provider that may repeat itself, not the streaming case.
+      // The final merge can rewrite the prefix it is handed, and a rewritten prefix is
+      // exactly what an extend-only parse cannot follow, so that one path keeps
+      // reparsing the whole reply as before. It is a continuation of an external
+      // provider that may repeat itself, not the streaming case.
       const segmentedText = createSegmentedAssistantText({
         trustAppends: !(continuationPartial && repairContinuation),
       });
@@ -7344,7 +7346,7 @@ export function createOpenAIStreamAdapter(
         ) {
           // Rendered parts, not the raw stream: `cumulativeText` carries <think>.
           const answerText = answerTextFromParts(
-            buildAssistantContent(mergeContinuation(cumulativeText)),
+            buildAssistantContent(mergeContinuation(cumulativeText, { final: true })),
           );
           const subjects = missingListSubjects(answerText, toolCallParts);
           if (subjects.length > 0) {
@@ -7422,7 +7424,7 @@ export function createOpenAIStreamAdapter(
         reasoningDurationTracker.finishGroup();
         yield {
           content: [
-            ...buildAssistantContent(mergeContinuation(cumulativeText)),
+            ...buildAssistantContent(mergeContinuation(cumulativeText, { final: true })),
             ...sourceParts,
             ...documentCitationParts,
           ],
@@ -7555,7 +7557,7 @@ export function createOpenAIStreamAdapter(
         }
         if (!abortSignal.aborted) {
           closeReasoningContent();
-          const partialText = mergeContinuation(cumulativeText);
+          const partialText = mergeContinuation(cumulativeText, { final: true });
           const partialContent = buildAssistantContent(partialText);
           if (partialContent.length > 0) {
             const partialTiming = buildTiming(

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -144,33 +144,55 @@ export function joinContinuation(
 /**
  * The merge a resumed turn applies to its cumulative text, streaming and at the end.
  *
- * Both repairs above are decided by looking at the whole continuation, so both change
- * their minds as it grows: `stripContinuationOverlap` rewrites the join as a longer
- * overlap starts matching, and `isRestart` cannot fire at all until the continuation is
- * RESTART_PROBE characters long, at which point it drops the partial entirely. Run per
- * arrival, that makes the published text NON-MONOTONIC. Driven character by character
- * over a 1602-character partial, the restart branch collapsed the published text from
- * 1649 characters to 48 in a single arrival.
+ * Both repairs above are decided by looking at the whole continuation, so run per arrival
+ * both change their minds as it grows: `stripContinuationOverlap` rewrites the join once a
+ * longer overlap starts matching, and `isRestart` cannot fire at all until the continuation
+ * reaches RESTART_PROBE characters, at which point it drops the partial entirely. That made
+ * the published text NON-MONOTONIC. Driven character by character over a 1602-character
+ * partial, the restart branch took it from 1649 characters to 48 in one arrival.
  *
- * Nothing renders a retraction gracefully: the reasoning pane draws whatever it is
- * handed, so an arrival carrying a short prefix of the previous one is a pane that
- * visibly loses its content and then gets it back.
+ * Nothing downstream renders a retraction gracefully, so an arrival carrying a short prefix
+ * of the one before it is a pane that visibly loses its content and gets it back.
  *
- * So a streamed merge is the identity. `cumulativeText` is append-only, and passing it
- * through unchanged is what makes every publish a superset of the last. The repairs run
- * once, on the finished turn, which is what `joinContinuation`'s `streaming` option was
- * always for: production never passed it, so the check it exists to suppress ran on
- * every streamed publish instead of once at the end.
+ * Repairing only at the end does not work either: assistant-ui drops what a run yields after
+ * an abort, so Stop persists the last STREAMED yield, and the terminal merge sits behind
+ * `!abortSignal.aborted`. An unrepaired live value therefore SAVES `partial + repeated tail`,
+ * and the Continue built on it replays that duplicate.
+ *
+ * So the merge WAITS for the repair to become decidable instead of dropping it. Neither
+ * decision can change once the continuation reaches `min(partial.length, MAX_OVERLAP)`: a
+ * matching overlap stays matching as more text arrives, so the trim only ever grows and is
+ * capped there, and `isRestart` reads a fixed RESTART_PROBE-character prefix. Measured over
+ * all three shapes (clean, repeated tail, restart), the trim never decreases and both answers
+ * are constant from that point.
+ *
+ * Until then the merge publishes the partial alone rather than a join it may have to take
+ * back. After it, the answer is stable and the continuation only grows, so every publish is a
+ * superset of the last AND carries the repair.
+ *
+ * There is deliberately no latch. An earlier draft cached the decision, but re-deriving it per
+ * call is equivalent precisely BECAUSE it is stable past `settleAt`, and a mutation that
+ * removed the cache changed no test. State that buys nothing is state that can go stale.
+ *
+ * One deliberate exception: a genuine restart replaces the partial with the new answer, which
+ * is shorter. That is one transition at the settle point, not a per-arrival oscillation, and it is the
+ * correct thing to show; appending a restart to the partial would read as a stutter.
  */
 export function createContinuationMerger(
   partial: string,
   repair: boolean,
 ): (cumulative: string, options?: { final?: boolean }) => string {
+  const settleAt = Math.min(partial.length, MAX_OVERLAP);
+
   return (cumulative, { final = false } = {}) => {
-    if (!partial || !repair || !final) {
+    if (!partial || !repair) {
       return cumulative;
     }
-    return joinContinuation(partial, cumulative.slice(partial.length));
+    const continuation = cumulative.slice(partial.length);
+    if (!final && continuation.length < settleAt) {
+      return partial;
+    }
+    return joinContinuation(partial, continuation);
   };
 }
 

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -144,55 +144,44 @@ export function joinContinuation(
 /**
  * The merge a resumed turn applies to its cumulative text, streaming and at the end.
  *
- * Both repairs above are decided by looking at the whole continuation, so run per arrival
- * both change their minds as it grows: `stripContinuationOverlap` rewrites the join once a
- * longer overlap starts matching, and `isRestart` cannot fire at all until the continuation
- * reaches RESTART_PROBE characters, at which point it drops the partial entirely. That made
- * the published text NON-MONOTONIC. Driven character by character over a 1602-character
- * partial, the restart branch took it from 1649 characters to 48 in one arrival.
+ * The bug this fixes is `isRestart` running per arrival. It cannot fire until the continuation
+ * reaches RESTART_PROBE characters, and the moment it does it publishes the continuation ALONE.
+ * Over a 1602-character partial that took the value from 1649 characters to 48 in one arrival,
+ * measured character by character. That is not only a visible collapse: Stop persists the last
+ * STREAMED yield, because assistant-ui drops what a run yields after an abort and the terminal
+ * merge sits behind `!abortSignal.aborted`, so stopping in that window SAVED the 48 characters
+ * and discarded the whole partial the user was reading.
  *
- * Nothing downstream renders a retraction gracefully, so an arrival carrying a short prefix
- * of the one before it is a pane that visibly loses its content and gets it back.
+ * `streaming` exists for exactly this and production never passed it. It suppresses the restart
+ * check, which needs more text than early chunks carry, and leaves the overlap trim, which only
+ * ever removes text the continuation itself repeated. So a streamed merge keeps the partial and
+ * the new text, always, and a genuine restart is collapsed once at the end where the evidence
+ * for it is complete.
  *
- * Repairing only at the end does not work either: assistant-ui drops what a run yields after
- * an abort, so Stop persists the last STREAMED yield, and the terminal merge sits behind
- * `!abortSignal.aborted`. An unrepaired live value therefore SAVES `partial + repeated tail`,
- * and the Continue built on it replays that duplicate.
+ * Two things were tried first and are recorded because both were worse:
  *
- * So the merge WAITS for the repair to become decidable instead of dropping it. Neither
- * decision can change once the continuation reaches `min(partial.length, MAX_OVERLAP)`: a
- * matching overlap stays matching as more text arrives, so the trim only ever grows and is
- * capped there, and `isRestart` reads a fixed RESTART_PROBE-character prefix. Measured over
- * all three shapes (clean, repeated tail, restart), the trim never decreases and both answers
- * are constant from that point.
+ *   * repairing ONLY at the end. That saves `partial + repeated tail` on Stop, so a Continue
+ *     built on it replays the duplicate. It swapped a display bug for a stored one.
+ *   * holding the partial until the trim could no longer change (at `min(partial.length,
+ *     MAX_OVERLAP)`). Monotonic, but Stop inside that window persisted the STALE PARTIAL and
+ *     discarded every newly generated character, which is worse than either.
  *
- * Until then the merge publishes the partial alone rather than a join it may have to take
- * back. After it, the answer is stable and the continuation only grows, so every publish is a
- * superset of the last AND carries the repair.
- *
- * There is deliberately no latch. An earlier draft cached the decision, but re-deriving it per
- * call is equivalent precisely BECAUSE it is stable past `settleAt`, and a mutation that
- * removed the cache changed no test. State that buys nothing is state that can go stale.
- *
- * One deliberate exception: a genuine restart replaces the partial with the new answer, which
- * is shorter. That is one transition at the settle point, not a per-arrival oscillation, and it is the
- * correct thing to show; appending a restart to the partial would read as a stutter.
+ * The overlap trim can still shift the join by up to MAX_OVERLAP characters as a longer overlap
+ * starts matching, so a publish is not strictly monotonic. That is bounded, rare, confined to
+ * external-provider continuations, and never loses text. It is deliberately not worth holding
+ * generated output back to avoid.
  */
 export function createContinuationMerger(
   partial: string,
   repair: boolean,
 ): (cumulative: string, options?: { final?: boolean }) => string {
-  const settleAt = Math.min(partial.length, MAX_OVERLAP);
-
   return (cumulative, { final = false } = {}) => {
     if (!partial || !repair) {
       return cumulative;
     }
-    const continuation = cumulative.slice(partial.length);
-    if (!final && continuation.length < settleAt) {
-      return partial;
-    }
-    return joinContinuation(partial, continuation);
+    return joinContinuation(partial, cumulative.slice(partial.length), {
+      streaming: !final,
+    });
   };
 }
 

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -142,6 +142,39 @@ export function joinContinuation(
 }
 
 /**
+ * The merge a resumed turn applies to its cumulative text, streaming and at the end.
+ *
+ * Both repairs above are decided by looking at the whole continuation, so both change
+ * their minds as it grows: `stripContinuationOverlap` rewrites the join as a longer
+ * overlap starts matching, and `isRestart` cannot fire at all until the continuation is
+ * RESTART_PROBE characters long, at which point it drops the partial entirely. Run per
+ * arrival, that makes the published text NON-MONOTONIC. Driven character by character
+ * over a 1602-character partial, the restart branch collapsed the published text from
+ * 1649 characters to 48 in a single arrival.
+ *
+ * Nothing renders a retraction gracefully: the reasoning pane draws whatever it is
+ * handed, so an arrival carrying a short prefix of the previous one is a pane that
+ * visibly loses its content and then gets it back.
+ *
+ * So a streamed merge is the identity. `cumulativeText` is append-only, and passing it
+ * through unchanged is what makes every publish a superset of the last. The repairs run
+ * once, on the finished turn, which is what `joinContinuation`'s `streaming` option was
+ * always for: production never passed it, so the check it exists to suppress ran on
+ * every streamed publish instead of once at the end.
+ */
+export function createContinuationMerger(
+  partial: string,
+  repair: boolean,
+): (cumulative: string, options?: { final?: boolean }) => string {
+  return (cumulative, { final = false } = {}) => {
+    if (!partial || !repair || !final) {
+      return cumulative;
+    }
+    return joinContinuation(partial, cumulative.slice(partial.length));
+  };
+}
+
+/**
  * Whether a finished MLX turn used its whole budget, i.e. stopped for length.
  *
  * MLX alone needs the inference: it reports finish_reason "stop" at the cap. Everyone

--- a/studio/frontend/tests/chat-adapter-scan-cost.test.ts
+++ b/studio/frontend/tests/chat-adapter-scan-cost.test.ts
@@ -602,8 +602,14 @@ test("the trailing strip runs on the finished reply, not on every arrival", () =
     true,
     "the strip must sit after the SSE loop, not inside it",
   );
+  // Pinned as a prefix, deliberately. What this test is about is WHERE the final
+  // build sits relative to the strip, not how the merge is spelled, and pinning the
+  // closing parens made it fail the first time an argument was added to
+  // `mergeContinuation` even though the ordering it guards was untouched. A pin that
+  // breaks on unrelated edits gets "fixed" by re-pinning, and one of those days it
+  // gets re-pinned past a real reordering.
   const finalBuild = source.indexOf(
-    "buildAssistantContent(mergeContinuation(cumulativeText))",
+    "buildAssistantContent(mergeContinuation(cumulativeText",
     strip,
   );
   assert.equal(

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -1928,19 +1928,21 @@ test("the gate's pulse is tagged where it is fired and read where it matters", (
 // The live streaming publish path used to run the restart check on every arrival.
 //
 // `joinContinuation` takes a `streaming` option whose whole purpose is to skip that
-// check, and whose docstring says it "runs once at the end". Nothing in production
-// ever passed it: the only callers with `streaming: true` were the two tests above.
-// So on every streamed publish the adapter asked "is this a restart?" of a
-// continuation that was still 48 characters long, and the first time the answer came
-// back yes it published the continuation ALONE, dropping the entire partial.
+// check, and whose docstring says it "runs once at the end". Nothing in production ever
+// passed it: the only callers with `streaming: true` were the two tests above. So on
+// every streamed publish the adapter asked "is this a restart?" of a continuation that
+// was still 48 characters long, and the first time the answer came back yes it published
+// the continuation ALONE, dropping the entire partial. Over a 1602-character partial that
+// took the published text from 1649 characters to 48 in one arrival.
 //
-// Driven character by character over a partial of 1602 characters, that collapsed the
-// published text from 1649 characters to 48 in one arrival, a 97% regression in what
-// the pane had to render. The reasoning pane renders whatever it is handed, so an
-// arrival carrying a short prefix is a pane that visibly loses its content.
+// Repairing only at the end is not the answer either, and that is the subtle half. Stop
+// persists the last STREAMED yield, because assistant-ui drops what a run yields after an
+// abort and the terminal merge sits behind `!abortSignal.aborted`. So a live value that
+// skipped the repair SAVES `partial + repeated tail`.
 //
-// These pin the property the publish path actually needs, which is monotonicity: text
-// already shown to the user must never be withdrawn mid-stream.
+// The merge therefore latches its decisions instead of dropping or re-deciding them, and
+// these pin both halves: nothing already shown is withdrawn, and what Stop would save is
+// repaired.
 
 const { createContinuationMerger } = await import(
   "../src/features/chat/utils/continuation.ts"
@@ -1952,48 +1954,112 @@ const REASONING =
   "First I need to consider what the existing schema looks like, and " +
   "whether an online migration is even possible given the constraints. ";
 
-/** Replay a stream one character at a time and report the worst backwards step. */
-function worstDrop(partial: string, tail: string): number {
+/** Replay a stream one character at a time, collecting what each arrival would publish. */
+function replay(partial: string, tail: string): string[] {
   const merge = createContinuationMerger(partial, true);
+  const published: string[] = [];
   let cumulative = partial;
-  let previous = merge(cumulative).length;
-  let worst = 0;
+  published.push(merge(cumulative));
   for (const character of tail) {
     cumulative += character;
-    const current = merge(cumulative).length;
-    worst = Math.max(worst, previous - current);
-    previous = current;
+    published.push(merge(cumulative));
   }
-  return worst;
+  return published;
 }
 
-test("a provider that restarts cannot retract the partial mid-stream", () => {
-  const partial = REASONING.repeat(6);
-  assert.equal(
-    worstDrop(partial, `${REASONING}and so on. `),
-    0,
-    "the restart check ran per arrival and dropped the whole partial the moment it fired",
-  );
-});
+/** Every arrival where the published text got shorter than the arrival before it. */
+function retractions(published: string[]): number[] {
+  const drops: number[] = [];
+  for (let i = 1; i < published.length; i += 1) {
+    if (published[i].length < published[i - 1].length) {
+      drops.push(published[i - 1].length - published[i].length);
+    }
+  }
+  return drops;
+}
 
-test("a provider repeating its own tail cannot retract text either", () => {
+test("a provider repeating its own tail never retracts published text", () => {
   const partial = REASONING.repeat(6);
-  assert.equal(
-    worstDrop(partial, `${partial.slice(-60)}and then it continues onward. `),
-    0,
+  const published = replay(
+    partial,
+    `${partial.slice(-60)}and then it continues onward from there. `,
+  );
+
+  assert.deepEqual(
+    retractions(published),
+    [],
     "a growing overlap match rewrote the tail, withdrawing characters already published",
   );
 });
 
+test("what Stop would save mid-stream is repaired, not the duplicated tail", () => {
+  // The regression that makes "repair only at the end" wrong. Stop keeps the last streamed
+  // yield, so the live value has to be the repaired one.
+  const partial = REASONING.repeat(6);
+  const repeated = partial.slice(-60);
+  const published = replay(partial, `${repeated}and then it continues onward from there. `);
+  const saved = published[published.length - 1];
+
+  assert.equal(
+    saved.includes(`${repeated}${repeated}`),
+    false,
+    "the repeated tail survived into the value Stop persists",
+  );
+  assert.equal(saved.startsWith(partial), true, "the partial itself must be intact");
+});
+
+test("a restart retracts exactly once, when the decision latches", () => {
+  // A genuine restart replaces the partial, which is shorter, and that is correct: appending
+  // it would read as a stutter. What must not happen is the per-arrival oscillation, so the
+  // count is the assertion, not the absence.
+  const partial = REASONING.repeat(6);
+  const published = replay(partial, `${REASONING}and so on. `.repeat(3));
+
+  assert.equal(
+    retractions(published).length,
+    1,
+    "the restart decision must latch once, not be re-taken on every arrival",
+  );
+});
+
+test("nothing is published that a later arrival takes back", () => {
+  // Before the decision can be made, publishing a join would mean withdrawing it later, so
+  // the merge holds the partial rather than guessing.
+  const partial = REASONING.repeat(6);
+  const published = replay(partial, `${partial.slice(-60)}and onward. `);
+
+  assert.equal(published[0], partial, "an undecided merge publishes the partial alone");
+  for (let i = 1; i < published.length; i += 1) {
+    assert.equal(
+      published[i].startsWith(published[i - 1]) ||
+        published[i].length >= published[i - 1].length,
+      true,
+    );
+  }
+});
+
 test("the final merge still repairs a restart, which is where that check belongs", () => {
-  // Skipping the check while streaming would be a truncation bug of its own if the
-  // finished turn kept the duplicated opening, so the terminal merge must still run it.
   const partial = REASONING.repeat(6);
   const restart = `${REASONING}and so on. `;
   assert.equal(
     createContinuationMerger(partial, true)(partial + restart, { final: true }),
     restart,
     "a genuine restart is still collapsed once the turn is complete",
+  );
+});
+
+test("a short continuation that never settles is still repaired at the end", () => {
+  // The stream can stop before the decision point, so `final` has to force it.
+  const partial = REASONING.repeat(6);
+  const repeated = partial.slice(-40);
+  const merge = createContinuationMerger(partial, true);
+  const cumulative = `${partial}${repeated}rest. `;
+
+  assert.equal(merge(cumulative), partial, "undecided while short");
+  assert.equal(
+    merge(cumulative, { final: true }),
+    `${partial}rest. `,
+    "the terminal merge decides and trims the repeated tail",
   );
 });
 

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -1924,3 +1924,84 @@ test("the gate's pulse is tagged where it is fired and read where it matters", (
     "a deadline here is the arming timeout coming back, which lapses live continuations",
   );
 });
+
+// The live streaming publish path used to run the restart check on every arrival.
+//
+// `joinContinuation` takes a `streaming` option whose whole purpose is to skip that
+// check, and whose docstring says it "runs once at the end". Nothing in production
+// ever passed it: the only callers with `streaming: true` were the two tests above.
+// So on every streamed publish the adapter asked "is this a restart?" of a
+// continuation that was still 48 characters long, and the first time the answer came
+// back yes it published the continuation ALONE, dropping the entire partial.
+//
+// Driven character by character over a partial of 1602 characters, that collapsed the
+// published text from 1649 characters to 48 in one arrival, a 97% regression in what
+// the pane had to render. The reasoning pane renders whatever it is handed, so an
+// arrival carrying a short prefix is a pane that visibly loses its content.
+//
+// These pin the property the publish path actually needs, which is monotonicity: text
+// already shown to the user must never be withdrawn mid-stream.
+
+const { createContinuationMerger } = await import(
+  "../src/features/chat/utils/continuation.ts"
+);
+
+const REASONING =
+  "Okay, so the user is asking about how to structure the migration. " +
+  "Let me think through this carefully step by step before answering. " +
+  "First I need to consider what the existing schema looks like, and " +
+  "whether an online migration is even possible given the constraints. ";
+
+/** Replay a stream one character at a time and report the worst backwards step. */
+function worstDrop(partial: string, tail: string): number {
+  const merge = createContinuationMerger(partial, true);
+  let cumulative = partial;
+  let previous = merge(cumulative).length;
+  let worst = 0;
+  for (const character of tail) {
+    cumulative += character;
+    const current = merge(cumulative).length;
+    worst = Math.max(worst, previous - current);
+    previous = current;
+  }
+  return worst;
+}
+
+test("a provider that restarts cannot retract the partial mid-stream", () => {
+  const partial = REASONING.repeat(6);
+  assert.equal(
+    worstDrop(partial, `${REASONING}and so on. `),
+    0,
+    "the restart check ran per arrival and dropped the whole partial the moment it fired",
+  );
+});
+
+test("a provider repeating its own tail cannot retract text either", () => {
+  const partial = REASONING.repeat(6);
+  assert.equal(
+    worstDrop(partial, `${partial.slice(-60)}and then it continues onward. `),
+    0,
+    "a growing overlap match rewrote the tail, withdrawing characters already published",
+  );
+});
+
+test("the final merge still repairs a restart, which is where that check belongs", () => {
+  // Skipping the check while streaming would be a truncation bug of its own if the
+  // finished turn kept the duplicated opening, so the terminal merge must still run it.
+  const partial = REASONING.repeat(6);
+  const restart = `${REASONING}and so on. `;
+  assert.equal(
+    createContinuationMerger(partial, true)(partial + restart, { final: true }),
+    restart,
+    "a genuine restart is still collapsed once the turn is complete",
+  );
+});
+
+test("a merger with repair off is the identity, streaming or final", () => {
+  // Local backends resume at the exact token boundary, so nothing may be trimmed.
+  const partial = REASONING.repeat(2);
+  const merge = createContinuationMerger(partial, false);
+  const full = `${partial}${REASONING}`;
+  assert.equal(merge(full), full);
+  assert.equal(merge(full, { final: true }), full);
+});

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -1927,22 +1927,19 @@ test("the gate's pulse is tagged where it is fired and read where it matters", (
 
 // The live streaming publish path used to run the restart check on every arrival.
 //
-// `joinContinuation` takes a `streaming` option whose whole purpose is to skip that
-// check, and whose docstring says it "runs once at the end". Nothing in production ever
-// passed it: the only callers with `streaming: true` were the two tests above. So on
-// every streamed publish the adapter asked "is this a restart?" of a continuation that
-// was still 48 characters long, and the first time the answer came back yes it published
-// the continuation ALONE, dropping the entire partial. Over a 1602-character partial that
-// took the published text from 1649 characters to 48 in one arrival.
+// `isRestart` cannot fire until the continuation reaches 48 characters, and the moment it
+// does it publishes the continuation ALONE. Over a 1602-character partial that took the
+// published value from 1649 characters to 48 in a single arrival.
 //
-// Repairing only at the end is not the answer either, and that is the subtle half. Stop
-// persists the last STREAMED yield, because assistant-ui drops what a run yields after an
-// abort and the terminal merge sits behind `!abortSignal.aborted`. So a live value that
-// skipped the repair SAVES `partial + repeated tail`.
+// That is not just a visible collapse. Stop persists the last STREAMED yield, because
+// assistant-ui drops what a run yields after an abort and the terminal merge sits behind
+// `!abortSignal.aborted`. So stopping in that window SAVED the 48 characters and threw away
+// the whole partial the user was reading.
 //
-// The merge therefore latches its decisions instead of dropping or re-deciding them, and
-// these pin both halves: nothing already shown is withdrawn, and what Stop would save is
-// repaired.
+// `joinContinuation`'s `streaming` option exists precisely to suppress that check, and
+// production never passed it. These pin the property that actually matters here, which is not
+// monotonicity but TEXT PRESERVATION: no streamed publish may drop the partial, and none may
+// withhold what the model has generated.
 
 const { createContinuationMerger } = await import(
   "../src/features/chat/utils/continuation.ts"
@@ -1967,37 +1964,41 @@ function replay(partial: string, tail: string): string[] {
   return published;
 }
 
-/** Every arrival where the published text got shorter than the arrival before it. */
-function retractions(published: string[]): number[] {
-  const drops: number[] = [];
-  for (let i = 1; i < published.length; i += 1) {
-    if (published[i].length < published[i - 1].length) {
-      drops.push(published[i - 1].length - published[i].length);
-    }
-  }
-  return drops;
-}
-
-test("a provider repeating its own tail never retracts published text", () => {
+test("a restart mid-stream never discards the partial", () => {
+  // The original defect, and the one that loses data: Stop here persisted 48 characters.
   const partial = REASONING.repeat(6);
-  const published = replay(
-    partial,
-    `${partial.slice(-60)}and then it continues onward from there. `,
-  );
+  const published = replay(partial, `${REASONING}and so on. `.repeat(2));
 
-  assert.deepEqual(
-    retractions(published),
-    [],
-    "a growing overlap match rewrote the tail, withdrawing characters already published",
+  for (const value of published) {
+    assert.equal(
+      value.startsWith(partial),
+      true,
+      "a streamed publish dropped the partial, so Stop would save only the restart",
+    );
+  }
+});
+
+test("no streamed publish withholds generated text", () => {
+  // The failure mode of holding the partial back until the repair settles: Stop inside that
+  // window saves the stale partial and every new character is lost.
+  const partial = REASONING.repeat(6);
+  const tail = "The second consideration is throughput, which matters here. ";
+  const published = replay(partial, tail);
+  const last = published[published.length - 1];
+
+  assert.equal(last, `${partial}${tail}`, "the new text must be present in the live value");
+  assert.equal(
+    published[10].length > partial.length,
+    true,
+    "text generated early must appear early, not wait for a settle point",
   );
 });
 
-test("what Stop would save mid-stream is repaired, not the duplicated tail", () => {
-  // The regression that makes "repair only at the end" wrong. Stop keeps the last streamed
-  // yield, so the live value has to be the repaired one.
+test("what Stop would save mid-stream carries the overlap repair", () => {
+  // The failure mode of repairing only at the end: the duplicated tail reaches storage.
   const partial = REASONING.repeat(6);
   const repeated = partial.slice(-60);
-  const published = replay(partial, `${repeated}and then it continues onward from there. `);
+  const published = replay(partial, `${repeated}and then it continues onward. `);
   const saved = published[published.length - 1];
 
   assert.equal(
@@ -2008,58 +2009,44 @@ test("what Stop would save mid-stream is repaired, not the duplicated tail", () 
   assert.equal(saved.startsWith(partial), true, "the partial itself must be intact");
 });
 
-test("a restart retracts exactly once, when the decision latches", () => {
-  // A genuine restart replaces the partial, which is shorter, and that is correct: appending
-  // it would read as a stutter. What must not happen is the per-arrival oscillation, so the
-  // count is the assertion, not the absence.
+test("the join can shift by the overlap, and never by more", () => {
+  // Honest about what is NOT fixed. A longer overlap starting to match rewrites the join, so
+  // the published length can dip. It is bounded by MAX_OVERLAP and never loses text, which is
+  // why it is not worth holding output back to avoid.
   const partial = REASONING.repeat(6);
-  const published = replay(partial, `${REASONING}and so on. `.repeat(3));
-
-  assert.equal(
-    retractions(published).length,
-    1,
-    "the restart decision must latch once, not be re-taken on every arrival",
+  const published = replay(
+    partial,
+    `${partial.slice(-60)}and then it continues onward from there. `,
   );
-});
 
-test("nothing is published that a later arrival takes back", () => {
-  // Before the decision can be made, publishing a join would mean withdrawing it later, so
-  // the merge holds the partial rather than guessing.
-  const partial = REASONING.repeat(6);
-  const published = replay(partial, `${partial.slice(-60)}and onward. `);
-
-  assert.equal(published[0], partial, "an undecided merge publishes the partial alone");
+  let worst = 0;
   for (let i = 1; i < published.length; i += 1) {
-    assert.equal(
-      published[i].startsWith(published[i - 1]) ||
-        published[i].length >= published[i - 1].length,
-      true,
-    );
+    worst = Math.max(worst, published[i - 1].length - published[i].length);
   }
+  assert.equal(worst <= 400, true, `the join shifted by ${worst}, beyond MAX_OVERLAP`);
 });
 
-test("the final merge still repairs a restart, which is where that check belongs", () => {
+test("the final merge still collapses a genuine restart", () => {
   const partial = REASONING.repeat(6);
   const restart = `${REASONING}and so on. `;
   assert.equal(
     createContinuationMerger(partial, true)(partial + restart, { final: true }),
     restart,
-    "a genuine restart is still collapsed once the turn is complete",
+    "a restart is collapsed once the turn is complete and the evidence is in",
   );
 });
 
-test("a short continuation that never settles is still repaired at the end", () => {
-  // The stream can stop before the decision point, so `final` has to force it.
-  const partial = REASONING.repeat(6);
-  const repeated = partial.slice(-40);
+test("a short partial with a whitespace-led restart is not collapsed mid-stream", () => {
+  // `isRestart` calls trimStart(), so a leading newline shifts when it can fire. With the
+  // restart check off while streaming, that timing cannot produce a mid-stream collapse.
+  const partial = "Sure, here is a plan for the migration you asked me about.";
   const merge = createContinuationMerger(partial, true);
-  const cumulative = `${partial}${repeated}rest. `;
+  const restart = `\n${partial}`;
 
-  assert.equal(merge(cumulative), partial, "undecided while short");
   assert.equal(
-    merge(cumulative, { final: true }),
-    `${partial}rest. `,
-    "the terminal merge decides and trims the repeated tail",
+    merge(`${partial}${restart}`).startsWith(partial),
+    true,
+    "the partial must survive a whitespace-led restart while streaming",
   );
 });
 


### PR DESCRIPTION
## The defect

`joinContinuation` takes a `streaming` option whose whole purpose is to skip the restart check while text is still arriving. Its docstring says that check "runs once at the end".

Nothing in production ever passed it. The only callers with `streaming: true` were two tests, so `mergeContinuation` ran the full repair on **every streamed publish**.

`isRestart` cannot fire until the continuation reaches `RESTART_PROBE` (48) characters. The moment it does, it publishes the continuation **alone**. Driving the real function a character at a time over a 1602-character partial, that took the published value from 1649 characters to 48 in one arrival.

That is not only a visible collapse. **Stop persists the last streamed yield** (assistant-ui drops what a run yields after an abort, and the terminal merge sits behind `!abortSignal.aborted` at `chat-adapter.ts:7558`), so stopping in that window saved the 48 characters and discarded the whole partial the user was reading.

## The fix

Pass `streaming: !final`.

It suppresses only the restart check, which is the branch that discards the partial and the one that genuinely needs more text than early chunks carry. It leaves the overlap trim, which only ever removes text the continuation itself repeated. So every streamed publish carries the partial **and** everything generated since, with no waiting, and a genuine restart is still collapsed once at the end where the evidence for it is complete.

Scope is narrow: only a resumed turn against an external provider that does not resume exactly reaches any of this. Local backends and exact-resume providers were already the identity on both paths.

## What this does NOT fix, stated plainly

The overlap trim can still shift the join by up to `MAX_OVERLAP` (400) characters as a longer overlap starts matching, so a streamed publish is **not strictly monotonic**. Measured worst case in my probe: 59 characters.

That is bounded, confined to external-provider continuations, and never loses text. It is deliberately not worth withholding generated output to avoid, and the test asserts the bound rather than pretending it is zero.

## Two designs I tried first, both worse

Recorded because they are the instructive part, and both were caught in review rather than by me.

1. **Repair only on the finished turn.** Since Stop saves the last streamed yield, that persists `partial + repeated tail` when a provider restates the partial's tail, and a Continue built on it replays the duplicate. It swapped a display bug for a stored one.

2. **Hold the partial until the trim could no longer change** (at `min(partial.length, MAX_OVERLAP)`). Publishes became monotonic, but Stop inside that window persists the **stale partial and discards every newly generated character**. That is worse than either of the other two, and an earlier version of this description presented it as a feature, saying "what Stop saves is repaired at every point". It was data loss.

The lesson I would keep: on this path, **text preservation outranks monotonicity**. The tests are written around that and no longer assert monotonicity at all.

## Verification

- `tsc --noEmit` clean.
- Full frontend suite: 5751 passed, 3 failed. The three are `remend-complete-markdown.test.ts`, an artefact of my local checkout resolving remend 1.3.0 rather than the pinned 1.3.1; that file's own comment says "The first test fails on remend 1.3.0, which is the point of the bump". Environmental and unrelated; CI installs the pin.
- Mutation check: dropping the `streaming` flag turns red both the test that no streamed publish discards the partial and the whitespace-led-restart regression test.
- Tests pin text preservation: no streamed publish drops the partial, none withholds generated text, the value Stop would save carries the overlap repair, and the final merge still collapses a restart.

## The other commits

Adding an argument to `mergeContinuation` broke the issue #9098 guard in `chat-adapter-scan-cost.test.ts`, which located the final build with `indexOf` on the full call text including its closing parens. The ordering that guard protects was never violated, only the spelling changed. It now pins the prefix; searching from the strip position it still only matches the post-strip builds, so a final build moved above the strip fails exactly as before.

## What this is not

This is **not** a fix for the reasoning pane flicker reported against main. That flicker has since been attributed to a different mechanism entirely: a generation-recovery follower replaying a run the same tab is still streaming, importing a lagging prefix over the live content. This PR was found while looking for that and stands on its own.
