### PR TITLE
Fix the dev-server white screen from a two-barrel import cycle

### DIFF
--- a/studio/frontend/src/hooks/use-model-memory.ts
+++ b/studio/frontend/src/hooks/use-model-memory.ts
@@ -10,24 +10,30 @@
  * one. Ten rows of the same model cost one read.
  */
 
+// Deep paths, not the `@/features/chat` barrel, and that is load-bearing. The barrel
+// reaches this file back: chat -> apply-inference-status-to-store -> model-picker ->
+// model-selector -> pickers -> here. Importing the barrel closed that ring, and under
+// dev's unbundled ESM the app died on a blank page with "Cannot access
+// 'CHAT_GPU_MEMORY_MODE_KEY' before initialization". Production builds hid it, because
+// the bundler hoists the declarations into one module and the ordering stops mattering.
+import { estimateKvCache } from "@/features/chat/api/chat-api";
 import {
   CHAT_GPU_MEMORY_MODE_KEY,
   CHAT_SPECULATIVE_TYPE_KEY,
-  estimateKvCache,
   readPersistedGpuMemoryMode,
   readPersistedSpeculativeType,
   useChatRuntimeStore,
-} from "@/features/chat";
+} from "@/features/chat/stores/chat-runtime-store";
 import {
   normalizeGgufVariantIdentity,
   normalizeModelIdentity,
-} from "@/features/hub";
+} from "@/features/hub/lib/model-identity";
 import {
   PER_MODEL_CONFIG_STORAGE_KEY,
   PER_MODEL_CONFIG_UPDATED_EVENT,
   type PerModelConfig,
   listPerModelConfigs,
-} from "@/features/model-picker";
+} from "@/features/model-picker/model-config/per-model-config";
 import {
   loadVramBudgetSettings,
   subscribeVramBudgetSettings,

--- a/studio/frontend/tests/module-scope-cycle-safety.test.ts
+++ b/studio/frontend/tests/module-scope-cycle-safety.test.ts
@@ -116,3 +116,38 @@ test("the key is still read at module scope, so the guard above is load-bearing"
     "general-tab no longer reads the key at module scope; drop this file's guards",
   );
 });
+
+/**
+ * The same white screen, reached a second way.
+ *
+ * `use-model-memory.ts` imported `CHAT_GPU_MEMORY_MODE_KEY` and friends from the
+ * `@/features/chat` barrel, and the barrel reaches this file back:
+ *
+ *   chat -> apply-inference-status-to-store -> model-picker -> model-selector
+ *        -> pickers -> use-model-memory -> chat
+ *
+ * Under dev's unbundled ESM that ring evaluated `use-model-memory` before the chat
+ * barrel had finished, and the module-scope const read threw "Cannot access
+ * 'CHAT_GPU_MEMORY_MODE_KEY' before initialization". Measured on main: the page threw,
+ * `#root` had 0 children and the body was empty. With the deep imports below there is
+ * no page error and the app renders.
+ *
+ * Production builds never showed it. The bundler hoists these declarations into one
+ * module, so the ordering the dev server exposes stops existing, which is exactly the
+ * kind of defect that survives review and CI and only ever bites whoever runs the dev
+ * server next.
+ */
+const MODEL_MEMORY = path.join(SRC, "hooks/use-model-memory.ts");
+
+test("the model memory hook imports no feature barrel", async () => {
+  const text = await readFile(MODEL_MEMORY, "utf8");
+  const barrels = staticSpecifiers(MODEL_MEMORY, text).filter((specifier) =>
+    /^@\/features\/[^/]+$/.test(specifier),
+  );
+
+  assert.deepEqual(
+    barrels,
+    [],
+    "a bare @/features/<name> import here closes the cycle and the dev server white screens again",
+  );
+});


### PR DESCRIPTION
## The defect

`npm run dev` serves a blank page on main. The console shows:

```
Uncaught ReferenceError: Cannot access 'CHAT_GPU_MEMORY_MODE_KEY' before initialization
```

`use-model-memory.ts` imported that constant and four of its neighbours from the `@/features/chat` barrel, and the barrel reaches the same file back:

```
chat -> lib/apply-inference-status-to-store
     -> model-picker -> components/model-selector
     -> model-selector/pickers -> hooks/use-model-memory -> chat
```

Under the dev server's unbundled ESM that ring evaluates `use-model-memory` before the chat barrel has finished, so its module-scope read hits the temporal dead zone and throws while the tree is mounting.

Production builds never showed it. The bundler hoists these declarations into a single module, so the ordering the dev server exposes stops existing. That is why it got through review and CI.

## Measured, in a real browser

Loading the page with Chromium and capturing page errors:

| | `#root` children | page error |
| --- | --- | --- |
| main | 0 | `Cannot access 'CHAT_GPU_MEMORY_MODE_KEY' before initialization` |
| this branch | 3 | none |

On main the body is empty. On this branch it renders the login screen.

## The fix

The imports now name the modules that define the symbols rather than the barrel. That is already the convention elsewhere in the tree; `tool-group.tsx` imports `useChatRuntimeStore` from `@/features/chat/stores/chat-runtime-store` the same way.

The guard goes in `module-scope-cycle-safety.test.ts`, which exists for this exact class of white screen, and fails if a bare `@/features/<name>` import comes back to this file.

## What this does not claim

It does not remove every cycle in the tree. One still runs through `chat-runtime-store -> preset-load-config -> the model-picker barrel -> the chat barrel`, and the page loads with it present.

That is the point: a cycle on its own is harmless. What broke the app was this specific module reading a `const` across the ring at evaluation time. I chased the graph for a while, then switched to checking the browser, because the browser is the thing that decides. Removing the remaining cycles is worth doing but is not needed to unbreak the dev server, and bundling it here would make an unreviewable change out of a two-line one.

## Verification

- `tsc --noEmit` clean.
- `npm run build` clean.
- Full frontend suite: 5745 passed, 3 failed. The three are `remend-complete-markdown.test.ts`, an artefact of my local checkout resolving remend 1.3.0 rather than the pinned 1.3.1. That file's own comment says "The first test fails on remend 1.3.0, which is the point of the bump", so they are environmental and unrelated. CI installs the pin.
- Mutation check: putting the barrel import back turns the new guard red, and restoring the deep import turns it green.