### PR TITLE
fix keyless access before desktop password setup

### DIFF
--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -451,7 +451,7 @@ def _invalid_api_key_detail(token: str) -> str:
 
 
 def _admin_credential() -> Tuple[str, Optional[str]]:
-    """resolve the local admin for keyless API access without applying the UI password gate."""
+    """Resolve the local admin for a keyless caller, without the UI password gate."""
     record = get_user_and_secret(DEFAULT_ADMIN_USERNAME)
     if record is None:
         raise HTTPException(

--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -450,20 +450,15 @@ def _invalid_api_key_detail(token: str) -> str:
     return "Invalid or expired API key"
 
 
-def _admin_credential(*, allow_password_change: bool) -> Tuple[str, Optional[str]]:
-    """Resolve the local admin for a caller admitted by the keyless API access setting."""
+def _admin_credential() -> Tuple[str, Optional[str]]:
+    """resolve the local admin for keyless API access without applying the UI password gate."""
     record = get_user_and_secret(DEFAULT_ADMIN_USERNAME)
     if record is None:
         raise HTTPException(
             status_code = status.HTTP_401_UNAUTHORIZED,
             detail = "Invalid or expired token",
         )
-    _salt, _pwd_hash, jwt_secret, must_change_password = record
-    if must_change_password and not allow_password_change:
-        raise HTTPException(
-            status_code = status.HTTP_403_FORBIDDEN,
-            detail = "Password change required",
-        )
+    _salt, _pwd_hash, jwt_secret, _must_change_password = record
     return DEFAULT_ADMIN_USERNAME, credential_generation(jwt_secret)
 
 
@@ -479,9 +474,7 @@ async def _get_current_credential(
     Credential reads run in the threadpool so stalled SQLite cannot block the event loop.
     """
     if credentials.scheme == KEYLESS_SCHEME:
-        return await run_in_threadpool(
-            _admin_credential, allow_password_change = allow_password_change
-        )
+        return await run_in_threadpool(_admin_credential)
 
     if credentials.scheme == KEYLESS_FALLBACK_SCHEME:
         from utils.keyless_api_access import APPROVED_DUMMY_BEARERS
@@ -490,9 +483,7 @@ async def _get_current_credential(
                 status_code = status.HTTP_401_UNAUTHORIZED,
                 detail = "Invalid authentication credentials",
             )
-        return await run_in_threadpool(
-            _admin_credential, allow_password_change = allow_password_change
-        )
+        return await run_in_threadpool(_admin_credential)
 
     token = credentials.credentials
 

--- a/studio/backend/tests/test_keyless_api_access.py
+++ b/studio/backend/tests/test_keyless_api_access.py
@@ -394,6 +394,45 @@ def test_desktop_password_setup_does_not_block_keyless_access(monkeypatch):
         assert subject_of(request) == storage.DEFAULT_ADMIN_USERNAME
 
 
+def test_setup_is_still_owed_after_keyless_access(monkeypatch):
+    """Admitting a keyless caller must not settle the password setup it skipped.
+
+    The UI routes to /change-password off ``/api/auth/status``, which takes no auth
+    dependency, and off the 403 detail that a browser session still gets. Keyless
+    reaches neither, so both have to keep reporting the setup as outstanding.
+    """
+    from routes.auth import auth_status
+
+    seed_user(must_change_password = True)
+    set_keyless_api_access("inference")
+    assert subject_of(request_for()) == storage.DEFAULT_ADMIN_USERNAME
+
+    assert storage.requires_password_change(storage.DEFAULT_ADMIN_USERNAME)
+    assert auth_status().requires_password_change is True
+
+    # The literal frontend/src/features/auth/api.ts matches to redirect the UI.
+    record = storage.get_user_and_secret(storage.DEFAULT_ADMIN_USERNAME)
+    token = create_access_token(subject = storage.DEFAULT_ADMIN_USERNAME, secret = record[2])
+    with pytest.raises(HTTPException) as excinfo:
+        subject_of(bearer_request(token))
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Password change required"
+
+
+def test_browser_guards_hold_before_password_setup():
+    """A page on another site stays out while the seeded password is still in place.
+
+    The gate this file stops applying to keyless callers was incidentally doubling
+    for these on a fresh install, so they are checked on their own footing here.
+    """
+    seed_user(must_change_password = True)
+    set_keyless_api_access("inference")
+    for headers in ({"Sec-Fetch-Site": "cross-site"}, {"Sec-Fetch-Site": "none"},
+                    {"Host": "evil.example"}):
+        assert not keyless_request_allowed(request_for(headers = headers))
+    assert keyless_request_allowed(request_for(headers = {"Sec-Fetch-Site": "same-origin"}))
+
+
 def test_protected_side_effect_guards_remain_wired():
     import inspect
     from routes import auth, inference, mcp_servers, preview, rag, training_history, video

--- a/studio/backend/tests/test_keyless_api_access.py
+++ b/studio/backend/tests/test_keyless_api_access.py
@@ -398,8 +398,7 @@ def test_setup_is_still_owed_after_keyless_access():
     """Admitting a keyless caller must not settle the password setup it skipped.
 
     The UI routes to /change-password off ``/api/auth/status``, which takes no auth
-    dependency, and off the 403 detail that a browser session still gets. Keyless
-    reaches neither, so both have to keep reporting the setup as outstanding.
+    dependency, and off the 403 a browser session still gets. Keyless reaches neither.
     """
     from routes.auth import auth_status
 
@@ -422,8 +421,8 @@ def test_setup_is_still_owed_after_keyless_access():
 def test_browser_guards_hold_before_password_setup():
     """A page on another site stays out while the seeded password is still in place.
 
-    The gate this file stops applying to keyless callers was incidentally doubling
-    for these on a fresh install, so they are checked on their own footing here.
+    The gate that no longer applies to keyless callers was incidentally doubling for
+    these, so they are pinned here on their own footing.
     """
     seed_user(must_change_password = True)
     set_keyless_api_access("inference")

--- a/studio/backend/tests/test_keyless_api_access.py
+++ b/studio/backend/tests/test_keyless_api_access.py
@@ -394,7 +394,7 @@ def test_desktop_password_setup_does_not_block_keyless_access(monkeypatch):
         assert subject_of(request) == storage.DEFAULT_ADMIN_USERNAME
 
 
-def test_setup_is_still_owed_after_keyless_access(monkeypatch):
+def test_setup_is_still_owed_after_keyless_access():
     """Admitting a keyless caller must not settle the password setup it skipped.
 
     The UI routes to /change-password off ``/api/auth/status``, which takes no auth

--- a/studio/backend/tests/test_keyless_api_access.py
+++ b/studio/backend/tests/test_keyless_api_access.py
@@ -55,9 +55,10 @@ def isolated_auth_db(tmp_path, monkeypatch):
     _reset_scope_cache()
 
 
-def seed_user():
+def seed_user(*, must_change_password = False):
     storage.create_initial_user(username = storage.DEFAULT_ADMIN_USERNAME,
-                                password = "human-password-123", jwt_secret = secrets.token_urlsafe(64))
+                                password = "human-password-123", jwt_secret = secrets.token_urlsafe(64),
+                                must_change_password = must_change_password)
 
 
 def app_state(**overrides):
@@ -104,12 +105,14 @@ def subject_of(request):
     return asyncio.run(get_current_subject(resolve(request)))
 
 
+INFERENCE_POST_PATHS = "/v1/chat/completions /v1/chat/count_tokens /v1/completions /v1/embeddings /v1/messages /v1/messages/count_tokens /v1/responses".split()
+
+
 def test_exact_route_matrix_matches_registered_topology():
     from routes.inference import router
 
-    allowed_posts = "/v1/chat/completions /v1/chat/count_tokens /v1/completions /v1/embeddings /v1/messages /v1/messages/count_tokens /v1/responses".split()
     denied_posts = "/v1/load /v1/unload /v1/validate /v1/generate/stream /v1/audio/speech /v1/images/generations /v1/external/openai/containers/create /v1x/chat".split()
-    allowed = {("POST", path) for path in allowed_posts} | {
+    allowed = {("POST", path) for path in INFERENCE_POST_PATHS} | {
         ("GET", "/v1/models"), ("GET", "/v1/models/unsloth/model")}
     denied = {("POST", path) for path in denied_posts} | {
         ("POST", "/v1/models"), ("GET", "/v1/chat/completions"), ("GET", "/v1/sandbox/abc")}
@@ -122,7 +125,7 @@ def test_exact_route_matrix_matches_registered_topology():
 
     registered = {(method, route.path) for route in router.routes
                   for method in getattr(route, "methods", set())}
-    intended = {("POST", path.removeprefix("/v1")) for path in allowed_posts} | {
+    intended = {("POST", path.removeprefix("/v1")) for path in INFERENCE_POST_PATHS} | {
         ("GET", "/models"), ("GET", "/models/{model_id:path}")}
     assert intended <= registered
 
@@ -350,6 +353,45 @@ def test_tool_policy_and_api_identity(monkeypatch):
 
     asyncio.run(KeylessToolPolicyMiddleware(enabled_between_layers)(
         asgi_scope(), lambda: None, lambda _message: None))
+
+
+def test_desktop_password_setup_does_not_block_keyless_access(monkeypatch):
+    import lan_access
+    from utils import host_policy
+
+    seed_user(must_change_password = True)
+    monkeypatch.setattr(lan_access, "lan_listener_status",
+                        lambda: {"running": True, "port": 8888,
+                                 "addresses": ["192.168.1.24"]})
+    monkeypatch.setattr(host_policy, "_lan_connector_active", True)
+    set_keyless_api_access("inference")
+
+    routes = [("POST", path) for path in INFERENCE_POST_PATHS] + [
+        ("GET", "/v1/models"),
+        ("GET", "/v1/models/unsloth/model"),
+    ]
+    transports = [
+        {},
+        {"server": ("192.168.1.24", 8888), "client": ("192.168.1.90", 54321)},
+    ]
+    for method, path in routes:
+        for transport in transports:
+            for bearer in (None, "not-needed"):
+                request = (
+                    request_for(method = method, path = path, **transport)
+                    if bearer is None
+                    else bearer_request(bearer, method = method, path = path, **transport)
+                )
+                assert subject_of(request) == storage.DEFAULT_ADMIN_USERNAME
+
+    set_keyless_api_access("full")
+    for bearer in (None, "not-needed"):
+        request = (
+            request_for(method = "POST", path = "/api/train/start")
+            if bearer is None
+            else bearer_request(bearer, method = "POST", path = "/api/train/start")
+        )
+        assert subject_of(request) == storage.DEFAULT_ADMIN_USERNAME
 
 
 def test_protected_side_effect_guards_remain_wired():


### PR DESCRIPTION
Fix keyless authentication for Desktop installs whose seeded browser password still requires setup.

- Resolve explicitly admitted `Keyless` and `KeylessBearer` callers as the local admin without applying the browser JWT password-change gate.
- Keep the browser JWT gate, API-key validation, route scope, and transport admission unchanged.
- Cover every keyless inference route over localhost and verified private LAN, with no header and `Bearer not-needed`, plus full-scope localhost.

Fixes #9846

Tests:
- `studio/backend/tests/test_keyless_api_access.py`: 11 passed
- Focused `studio/backend/tests/test_desktop_auth.py`: 5 passed, 43 deselected
- Ruff on both changed Python files: passed

GPU tests were not run because this changes CPU-only authentication logic.
