### PR TITLE
Reject a new studio union offender even when the recorded count is unchanged

### DIFF
--- a/tests/test_python39_compatibility.py
+++ b/tests/test_python39_compatibility.py
@@ -396,13 +396,16 @@ def test_studio_evaluated_unions_do_not_grow():
     # Name the files that are NEW against the recorded set, not the whole list. A bare
     # count told you only that 37 exceeded 35, and the full list was truncated at 2000
     # chars, so finding the two additions meant re-running the scan on an older checkout
-    # and diffing by hand. The count still governs the assertion, so a swap (one file
-    # fixed, one added) cannot slip through on set membership alone.
+    # and diffing by hand. Membership governs the assertion alongside the count: a swap
+    # that fixes one recorded file and adds one new one leaves the count equal, so a
+    # count alone would pass it, and the new file is the one thing this test exists to
+    # stop. The count stays because it also catches net growth that adds nothing new,
+    # which happens when a recorded file is fixed without being dropped from the list.
     added = [p for p in offenders if p not in STUDIO_UNION_DEBT_FILES]
     removed = [p for p in sorted(STUDIO_UNION_DEBT_FILES) if p not in offenders]
-    assert len(offenders) <= len(STUDIO_UNION_DEBT_FILES), (
-        f"{len(offenders)} studio files now evaluate PEP 604 unions on the floor, up from "
-        f"{len(STUDIO_UNION_DEBT_FILES)}. Add `from __future__ import annotations` to "
+    assert not added and len(offenders) <= len(STUDIO_UNION_DEBT_FILES), (
+        f"{len(offenders)} studio files now evaluate PEP 604 unions on the floor, against "
+        f"{len(STUDIO_UNION_DEBT_FILES)} recorded. Add `from __future__ import annotations` to "
         "these, do not raise the ratchet:\n  "
         + "\n  ".join(added or offenders)
         + (


### PR DESCRIPTION
## What

`test_studio_evaluated_unions_do_not_grow` computes `added`, the offenders that are not in `STUDIO_UNION_DEBT_FILES`, and then never asserts on it. Only the cardinality is compared:

```python
added = [p for p in offenders if p not in STUDIO_UNION_DEBT_FILES]
assert len(offenders) <= len(STUDIO_UNION_DEBT_FILES), ...
```

A change that fixes one recorded file and adds one new offending studio module leaves both sides at 35, so the ratchet passes and a module that raises `TypeError` on import at the declared 3.9 floor ships unnoticed. The comment directly above claims the opposite, that a swap "cannot slip through on set membership alone".

The swap does not have to happen in one commit. The assertion is `<=` and nothing makes the recorded list shrink when a file is fixed, so every unrecorded fix leaves permanent slack for a later addition to sit in.

Nothing else covers this: `test_no_pep604_unions_are_evaluated_on_the_declared_floor` gates annotation scanning on `PACKAGE_ROOT in path.parents` and skips everything outside `unsloth/`.

## Change

Assert `not added` alongside the count. The count stays, since it still catches net growth that introduces no new path, which is what an unrecorded fix produces. The comment is reworded to describe what the assertion now does.

## Verification

Simulating the swap on a clean tree, by adding `from __future__ import annotations` to a recorded offender and adding a new `studio/backend/routes/` module annotated `int | None`, so the count stays at 35:

- before: `1 passed`, the new module is invisible to the ratchet
- after: `1 failed`, naming `studio/backend/routes/brand_new_route.py`

With the swap reverted, `tests/test_python39_compatibility.py` is `8 passed`, so a clean tree is unaffected.

Reported against #9826, which merged before it was addressed.