### PR TITLE
Apply the kwarg-spacing hook to the no-progress tool results test

### DIFF
--- a/studio/backend/tests/test_no_progress_tool_results.py
+++ b/studio/backend/tests/test_no_progress_tool_results.py
@@ -531,6 +531,4 @@ def test_a_resumed_turn_sizes_its_recall_by_what_is_left(monkeypatch):
         )
     )
 
-    assert 1000 not in caps, (
-        f"a resumed turn sized its recall against the whole cap: {caps}"
-    )
+    assert 1000 not in caps, f"a resumed turn sized its recall against the whole cap: {caps}"


### PR DESCRIPTION
## What

main currently fails its own `pre-commit.ci - push` run, and every open PR inherits the failure because the PR check runs against the merge with main. The failing hook is `ruff-format-with-kwargs`, and at this moment exactly one file in the tree does not satisfy it:

```
studio/backend/tests/test_no_progress_tool_results.py
```

It arrived in #9768. The hook joins the short multi-line assert back onto one line:

```python
-    assert 1000 not in caps, (
-        f"a resumed turn sized its recall against the whole cap: {caps}"
-    )
+    assert 1000 not in caps, f"a resumed turn sized its recall against the whole cap: {caps}"
```

## Why it keeps happening

pre-commit.ci autofixes by pushing to the PR branch, so a PR merged before its autofix lands carries the unformatted file onto main. main's own push run then fails and cannot self-heal, since autofix only applies to pull requests. The count stays small and rotates as PRs land: it was two files earlier today, both fixed in passing by #9822.

## Verification

Ran the hook at the version CI pins, `ruff==0.6.9`, over the whole tree at this branch's head: zero files modified. The change is formatting only, confirmed AST-identical by comparing `ast.dump` before and after, and `tests/test_no_progress_tool_results.py` is 12 passed.