### PR TITLE
Put the smart offload planner back behind its flag

### DIFF
--- a/studio/backend/core/inference/offload_planner.py
+++ b/studio/backend/core/inference/offload_planner.py
@@ -857,21 +857,29 @@ _SMART_OFFLOAD_ON = ("1", "true", "yes", "on", "enabled")
 
 
 def smart_offload_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
-    """Whether the launch path may plan a spill. ON unless explicitly disabled.
+    """Whether the launch path may plan a spill. OFF unless explicitly enabled.
 
-    It shipped opt-in "until it has run on more than one machine". It has: 118
-    paired runs across T4, L4, RTX PRO 6000, A100, B200 and a real gfx1151 APU,
-    faster on generation in 111, and 100% KV cache retention in all 83 runs
-    where the layer-count arm would have split the cache to host RAM.
+    This was briefly opt-OUT, on 118 paired runs across T4, L4, RTX PRO 6000,
+    A100, B200 and a gfx1151 APU. Every one of those hosts is a large one, and
+    that turned out to be the whole of the calibration set: #9861 measured 76
+    paired cells on a 6-core desktop and the planner was slower in 40 of the 43
+    it planned, by up to 8x on generation.
 
-    Default does not mean it places every load: it abstains often, and every
-    abstain still falls through to ``--fit on``.
+    The mechanism is not the host size alone. ``rank`` in offload_cost_model
+    scores a placement as prefill PLUS generation, but the planner only ever
+    calls ``generation_penalty_ms``, so prefill is not priced at all -- which is
+    why #9861 measured prefill slower in 43 of 43 planned cells, without one
+    exception. A gate that does not count half the request cannot be trusted to
+    fire by default, so it goes back behind the flag until it does.
 
-    An UNRECOGNISED value disables. The typos are not symmetric for an opt-OUT
-    flag: ``flase`` meaning off must not hand back the thing it was switching
-    off, while fumbling an on-spelling only keeps the old behaviour.
+    Off does not mean the load is unplaced: every path that would have consulted
+    the planner falls through to ``--fit on``, which is what the same report
+    measured at 0.93x to 1.16x across all 33 cells where the planner declined.
+
+    An UNRECOGNISED value disables, same as before, and now agrees with the
+    default rather than reversing it.
     """
     raw = (os.environ if env is None else env).get("UNSLOTH_SMART_OFFLOAD")
     if raw is None:
-        return True
+        return False
     return str(raw).strip().lower() in _SMART_OFFLOAD_ON

--- a/studio/backend/tests/test_offload_planner_seam.py
+++ b/studio/backend/tests/test_offload_planner_seam.py
@@ -212,15 +212,22 @@ def test_the_seam_reads_no_attribute_the_real_backend_lacks():
     assert "self._HOST_RAM_HEADROOM_MIB" not in source
 
 
-def test_the_planner_is_on_by_default():
-    """No env, a plan. The flag is now opt-OUT."""
-    assert smart_offload_enabled({}) is True
-    # A load that fits is still PLANNED, it just spills nothing.
-    roomy = _Stub()._planned_tensor_spill(_inputs(), env = {})
-    assert roomy is not None and not roomy.spills_anything
+def test_the_planner_is_off_by_default():
+    """No env, no plan. The flag is opt-IN again after #9861.
 
-    # A load that does not fit gets a real plan with no env set at all.
-    tight = _Stub()._planned_tensor_spill(_inputs(free_mib = 14 * 1024), env = {})
+    A load that would otherwise get a real spill plan is the case that matters:
+    if only the roomy one were checked, the default could flip back unnoticed,
+    since a fitting load plans nothing either way.
+    """
+    assert smart_offload_enabled({}) is False
+    assert _Stub()._planned_tensor_spill(_inputs(), env = {}) is None
+    assert _Stub()._planned_tensor_spill(_inputs(free_mib = 14 * 1024), env = {}) is None
+
+    # The same tight load still plans when asked explicitly, so the revert moved
+    # the default and nothing else.
+    tight = _Stub()._planned_tensor_spill(
+        _inputs(free_mib = 14 * 1024), env = {"UNSLOTH_SMART_OFFLOAD": "1"}
+    )
     assert tight is not None and tight.spills_anything
 
 
@@ -238,9 +245,8 @@ def test_an_explicit_off_still_disables(value):
 
 @pytest.mark.parametrize("value", ["nope", "flase", "onn", "2"])
 def test_an_unrecognised_value_disables_rather_than_enables(value):
-    """The typos are not symmetric for an opt-OUT flag: `flase` meaning off must
-    not hand back the thing it was switching off, while fumbling an on-spelling
-    only keeps the previous behaviour."""
+    """A fumbled on-spelling must not turn the planner on by accident, and now
+    lands on the same answer as setting nothing at all."""
     assert smart_offload_enabled({"UNSLOTH_SMART_OFFLOAD": value}) is False
 
 


### PR DESCRIPTION
Addresses the default in #9861.

## What

`UNSLOTH_SMART_OFFLOAD` goes back to opt-in.

## Why

Reading the planner to check #9861's report turned up something larger than the report claims: **the cost model does not gate the decision at all.**

Every abstain in `offload_planner.py` is a feasibility abstain -- layout incomplete (:385), unified memory (:390), no creditable VRAM (:393), no usable context (:399), per-device shortfall (:699, :740), multi-device partial spill (:677). There is no cost-based abstain anywhere. If a spill covers the deficit, it is taken. `_spill_penalty_ms` (:198) is computed once at :838 into `Plan.predicted_gen_penalty_ms`, and that field is read only by tests. The planner never asks whether spilling beats letting `--fit on` place the model.

Two things follow, and both are independent of how the benchmark was shaped:

1. `rank()` in `offload_cost_model.py` scores prefill plus generation, and `prefill_penalty_ms_per_token` is implemented and calibrated. Neither has a caller. Prefill is unpriced, which is why #9861 measured it slower in 43 of 43 planned cells with no exception.
2. Because it spills whenever it can rather than when it should, it spills in cells where `--fit on` kept the model fully resident. #9861 found two.

A gate that never consults its own cost model should not be on by default.

## What I am NOT resting this on

The report's generation column shows 40 of 43 cells slower, and I quoted that in an earlier version of this description. The reporter has since disclosed the limitation themselves: the cache is allocated at 32768 but only about 2.2K tokens are ever live, so those cells are measured "where the planner pays in full and collects almost nothing", and they ask that the number be read as the short-sequence end of the range. That is fair and I am not leaning on it.

It cuts at our own evidence too, which is the part worth saying out loud. The Colab matrix behind #9779 ran at `ctx=4096, npred=16, depth=0` (`temp/cloudrun/nb/offload_bench*.ipynb`). `depth=0` is an empty KV cache. So the thing this planner exists to protect -- a live cache -- was not really measured on either side of the argument. A depth sweep is the next piece of work.

## What this does not change

The planner still works when asked for. Every path that would have consulted it falls through to `--fit on`, which #9861 measured at 0.93x to 1.16x across all 33 cells where the planner declined, so the fallback is neutral there.

For the record, two of the report's other observations: the host thread count IS already wired (`HostProfile(threads = os.cpu_count() or 1)` at `llama_cpp.py:25105`, about 3.9x generation multiplier at 12 threads), so the model mispredicts with information it has rather than for lack of it; and the two-GPU result, 0 plans in 13 cells, is the deliberate partial-spill abstain at `offload_planner.py:658` working as designed, not a gap.

## Tests

`test_the_planner_is_on_by_default` becomes `test_the_planner_is_off_by_default`, and asserts against a load that WOULD spill rather than only a roomy one, so the default cannot flip back unnoticed behind a load that plans nothing either way. It also checks the same tight load still plans when the flag is set explicitly, so this moved the default and nothing else.

508 offload tests pass.
