### PR TITLE
Studio: stop the per-chunk autosave writing back messages the server owns

### DIFF
--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -1966,21 +1966,36 @@ function useStudioRuntimeAdapters(
               sameResearchRun ||
               !incomingMetadata?.serverManaged ||
               existingRevision > incomingRevision);
-          // Echo the backend's stored metadata verbatim on autosave: merging
-          // incomingMetadata re-adds client-only fields (researchRun / serverRevision) the
-          // server never persisted, so _research_message_would_change sees a diff and
-          // rejects every streamed/snapshot update with 409.
-          const metadata = preserveServerManaged
-            ? existingMetadata
-            : incomingMetadata;
+          // Nothing to write: every field below is already the server's own.
+          //
+          // `preserveServerManaged` means the backend owns this message and refuses to let a
+          // client edit it. The autosave then echoes what it just read back at the server:
+          // `content` is `existingMessage.content`, `metadata` is `existingMetadata`, and
+          // `createdAt` is `existingMessage.createdAt`. `attachments` is empty because only a
+          // user message carries them and this branch is a server-managed generation. So the
+          // request cannot change anything, and the server answers 409 every time.
+          //
+          // Measured on a real session: one 43.6 s generation issued 265 PUTs of which 256 were
+          // rejected with "server-managed generation messages cannot be edited", a median 166 ms
+          // apart, plus 353 whole-thread GETs a median 339 ms apart from the
+          // `ensureStoredChatThread` inside `saveStoredChatMessage`. All of it against the same
+          // backend the model is saturating.
+          //
+          // `parentId` is the one field not echoed back, so a reparent could in principle differ
+          // here. It is dropped either way: the server rejects the whole request, so that update
+          // has never landed on this path. Skipping is behaviour-preserving, not a new trade.
+          if (preserveServerManaged) {
+            await throwIfHistoryWasCleared(remoteId);
+            return;
+          }
           await saveStoredChatMessage({
             id: message.id,
             threadId: remoteId,
             parentId: parentId ?? null,
             role: message.role,
-            content: preserveServerManaged ? existingMessage!.content : content,
+            content,
             ...(attachments.length > 0 && { attachments }),
-            ...(metadata && { metadata }),
+            ...(incomingMetadata && { metadata: incomingMetadata }),
             createdAt,
           });
           await throwIfHistoryWasCleared(remoteId);

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -1966,24 +1966,14 @@ function useStudioRuntimeAdapters(
               sameResearchRun ||
               !incomingMetadata?.serverManaged ||
               existingRevision > incomingRevision);
-          // Nothing to write: every field below is already the server's own.
+          // The backend owns this message and refuses client edits, and every field the save
+          // would send was just read back from it, so the request is answered 409 every time.
+          // One measured 43.6 s generation: 265 PUTs, 256 rejected, plus 353 whole-thread GETs
+          // from the `ensureStoredChatThread` inside `saveStoredChatMessage`. Returning here
+          // drops both.
           //
-          // `preserveServerManaged` means the backend owns this message and refuses to let a
-          // client edit it. The autosave then echoes what it just read back at the server:
-          // `content` is `existingMessage.content`, `metadata` is `existingMetadata`, and
-          // `createdAt` is `existingMessage.createdAt`. `attachments` is empty because only a
-          // user message carries them and this branch is a server-managed generation. So the
-          // request cannot change anything, and the server answers 409 every time.
-          //
-          // Measured on a real session: one 43.6 s generation issued 265 PUTs of which 256 were
-          // rejected with "server-managed generation messages cannot be edited", a median 166 ms
-          // apart, plus 353 whole-thread GETs a median 339 ms apart from the
-          // `ensureStoredChatThread` inside `saveStoredChatMessage`. All of it against the same
-          // backend the model is saturating.
-          //
-          // `parentId` is the one field not echoed back, so a reparent could in principle differ
-          // here. It is dropped either way: the server rejects the whole request, so that update
-          // has never landed on this path. Skipping is behaviour-preserving, not a new trade.
+          // `parentId` is the one field not echoed back, so a reparent could differ. It is
+          // dropped either way: the server rejects the whole request, so it never landed here.
           if (preserveServerManaged) {
             await throwIfHistoryWasCleared(remoteId);
             return;

--- a/studio/frontend/tests/server-managed-autosave-write.test.ts
+++ b/studio/frontend/tests/server-managed-autosave-write.test.ts
@@ -4,19 +4,13 @@
 /**
  * The per-chunk autosave must not write back a message the server owns.
  *
- * When `preserveServerManaged` is true the backend owns the message and refuses to let a client
- * edit it, and every field the autosave would send is one it just read from the backend. So the
- * request cannot change anything and is answered 409.
+ * Every field it would send was just read from the backend, which then refuses the edit. One
+ * measured 43.6 s generation: 265 PUTs, 256 rejected 409, plus 353 whole-thread GETs from the
+ * `ensureStoredChatThread` inside `saveStoredChatMessage`.
  *
- * Measured on a real session before this guard existed: one 43.6 s generation issued 265 PUTs of
- * which 256 were rejected with "server-managed generation messages cannot be edited", a median
- * 166 ms apart, plus 353 whole-thread GETs a median 339 ms apart from the `ensureStoredChatThread`
- * inside `saveStoredChatMessage`. All against the backend the model is saturating.
- *
- * This is a SOURCE guard rather than a behavioural one because the call site is an inline closure
- * inside the history adapter, with no seam to stub. It therefore pins ORDERING, not spelling: that
- * the `preserveServerManaged` early return appears before the `saveStoredChatMessage` call it
- * guards. A rename of either keeps working; moving the save above the guard does not.
+ * A source guard, because the call site is an inline closure with no seam to stub. It pins
+ * ORDERING rather than spelling: a rename keeps working, moving the save above the guard does
+ * not.
  */
 
 import assert from "node:assert/strict";

--- a/studio/frontend/tests/server-managed-autosave-write.test.ts
+++ b/studio/frontend/tests/server-managed-autosave-write.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * The per-chunk autosave must not write back a message the server owns.
+ *
+ * When `preserveServerManaged` is true the backend owns the message and refuses to let a client
+ * edit it, and every field the autosave would send is one it just read from the backend. So the
+ * request cannot change anything and is answered 409.
+ *
+ * Measured on a real session before this guard existed: one 43.6 s generation issued 265 PUTs of
+ * which 256 were rejected with "server-managed generation messages cannot be edited", a median
+ * 166 ms apart, plus 353 whole-thread GETs a median 339 ms apart from the `ensureStoredChatThread`
+ * inside `saveStoredChatMessage`. All against the backend the model is saturating.
+ *
+ * This is a SOURCE guard rather than a behavioural one because the call site is an inline closure
+ * inside the history adapter, with no seam to stub. It therefore pins ORDERING, not spelling: that
+ * the `preserveServerManaged` early return appears before the `saveStoredChatMessage` call it
+ * guards. A rename of either keeps working; moving the save above the guard does not.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PROVIDER = path.join(
+  HERE,
+  "..",
+  "src",
+  "features",
+  "chat",
+  "runtime-provider.tsx",
+);
+
+const source = readFileSync(PROVIDER, "utf8");
+
+/** The history adapter's append path, which is the one that autosaves per chunk. */
+function appendWindow(): string {
+  const anchor = source.indexOf("const preserveServerManaged =");
+  assert.notEqual(
+    anchor,
+    -1,
+    "the autosave no longer computes preserveServerManaged, so this guard is measuring nothing",
+  );
+  const end = source.indexOf("trackHistoryAppend(", anchor);
+  assert.notEqual(end, -1, "could not find the end of the append path");
+  return source.slice(anchor, end);
+}
+
+test("the autosave returns early instead of writing a server-managed message", () => {
+  const window = appendWindow();
+  const guard = window.search(/if\s*\(\s*preserveServerManaged\s*\)/);
+  assert.notEqual(
+    guard,
+    -1,
+    "no `if (preserveServerManaged)` guard in the append path: the per-chunk autosave will PUT a " +
+      "message the server owns and take a 409 on every chunk",
+  );
+  const save = window.indexOf("saveStoredChatMessage(");
+  assert.notEqual(save, -1, "the append path no longer saves at all, which is not the fix");
+  assert.ok(
+    guard < save,
+    "the `preserveServerManaged` guard must come BEFORE saveStoredChatMessage. Below it, the " +
+      "write still goes out and the 409 storm is unchanged",
+  );
+});
+
+test("the guard actually returns rather than only skipping fields", () => {
+  const window = appendWindow();
+  const guard = window.search(/if\s*\(\s*preserveServerManaged\s*\)/);
+  const save = window.indexOf("saveStoredChatMessage(");
+  const body = window.slice(guard, save);
+  assert.match(
+    body,
+    /\breturn\b/,
+    "the guard must return. Skipping only the changed fields still issues the PUT, and still " +
+      "runs the ensureStoredChatThread whole-thread GET inside saveStoredChatMessage",
+  );
+});
+
+test("the write no longer echoes the server's own content back at it", () => {
+  const window = appendWindow();
+  assert.doesNotMatch(
+    window,
+    /preserveServerManaged\s*\?\s*existingMessage/,
+    "the save still passes existingMessage.content when preserveServerManaged, which is the " +
+      "read-it-then-write-it-back shape this change removed",
+  );
+});


### PR DESCRIPTION
During a streamed reply the chat history adapter autosaves per chunk. When the message is server-managed, that autosave builds a write out of fields it has just read back from the backend, so the request cannot change anything, and the server answers `409 server-managed generation messages cannot be edited` every time.

## What the traffic looks like

From a real session, one generation lasting 43.6 s:

| | count |
|---|---|
| `PUT /api/chat/threads/{id}/messages/{id}` | 265, of which **256 rejected 409** |
| `GET /api/chat/threads/{id}` (whole thread) | 353 |

Median cadence 166 ms for the PUTs and 339 ms for the GETs. All of it against the same backend the model is saturating.

## Why the write can never do anything

At the call site, when `preserveServerManaged` is true:

- `content` was `existingMessage.content`
- `metadata` was `existingMetadata`
- `createdAt` was `existingMessage.createdAt`
- `attachments` is empty, because only a user message carries them and this branch is a server-managed generation

Every one of those came from the backend on the point read a few lines above. The write is the client handing the server its own record back, for a message the server refuses to let it edit.

## The change

Return before the save when `preserveServerManaged` is true.

That drops the whole-thread GET as well as the PUT, because `saveStoredChatMessage` calls `ensureStoredChatThread` before it saves, and that is what issues the read.

Three things follow from the early return and are cleaned up with it: `content` no longer needs the `preserveServerManaged ? existingMessage!.content : content` ternary, the `metadata` ternary collapses to `incomingMetadata`, and the comment about echoing the backend's stored metadata verbatim is removed because it now describes code that is gone.

`parentId` is the one field not echoed back, so a reparent could in principle differ here. It is dropped either way today: the server rejects the whole request, so that update has never landed on this path. Skipping is behaviour-preserving rather than a new trade.

## Test

`tests/server-managed-autosave-write.test.ts`, three assertions: the guard exists, it precedes `saveStoredChatMessage`, and it returns rather than only skipping fields.

It is a source guard rather than a behavioural one because the call site is an inline closure inside the history adapter with no seam to stub. It pins ordering rather than spelling, so renaming either symbol keeps working, while moving the save above the guard does not.

Mutation checked: with the guard removed, 2 of the 3 fail.

## Verification

- `tsc --noEmit` clean
- `eslint` on the changed file reports the same 10 problems as `main` does on the same file, so nothing new
- Full frontend suite: 5798 pass, 3 fail. The 3 are `tests/remend-complete-markdown.test.ts` and they fail identically on unmodified `main`, so they are inherited rather than caused here.

## What this does not claim

This does not claim to fix the reported flinching. It removes the mechanism that most plausibly causes it, and the reporter's video shows a one-frame layout excursion that returns to within 0.02% rather than a text rewind, which is consistent with a lagging snapshot landing for a frame. But nobody has reproduced the flinch end to end and shown it gone, and the video and the server log are different recordings, so no individual flinch has been matched to an individual read.

What is measured and not in doubt is the traffic: 256 rejected writes and 353 whole-thread reads during one answer, all of it avoidable.
