### PR TITLE
Fix Studio CPT overwriting LFM2 all-linear LoRA targets

### DIFF
--- a/studio/backend/assets/configs/model_defaults/other/unsloth_LFM2-1.2B.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_LFM2-1.2B.yaml
@@ -1,6 +1,6 @@
 # Model defaults for unsloth/LFM2-1.2B
 # Based on Liquid_LFM2_(1.2B)-Conversational.ipynb
-# Also applies to: unsloth/LFM2-1.2B
+# Also applies to: unsloth/LFM2-1.2B, LiquidAI/LFM2-1.2B, unsloth/LFM2-1.2B-unsloth-bnb-4bit
 # added inference parameters from unsloth notebook
 
 training:

--- a/studio/backend/tests/test_model_defaults_aliases_resolve.py
+++ b/studio/backend/tests/test_model_defaults_aliases_resolve.py
@@ -92,3 +92,15 @@ def test_claimed_alias_loads_its_own_defaults(config_name, alias):
     own = _load_tuned(_primary_name(config_name), config_name)
     assert _load_tuned(alias, config_name) == own
     assert _load_tuned(_on_disk(alias), config_name) == own
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "LiquidAI/LFM2-1.2B",
+        "unsloth/LFM2-1.2B-unsloth-bnb-4bit",
+    ],
+)
+def test_lfm2_supported_ids_use_all_linear_defaults(model_id):
+    config = _load_tuned(model_id, "unsloth_LFM2-1.2B.yaml")
+    assert config["lora"]["target_modules"] == ["all-linear"]

--- a/studio/backend/tests/test_vram_estimation.py
+++ b/studio/backend/tests/test_vram_estimation.py
@@ -2365,9 +2365,49 @@ def test_an_embedding_only_request_still_counts_the_default_projections():
     one_matrix = tied.vocab_size * tied.hidden_size
     for targets in (["embed_tokens"], ["embed_tokens", "lm_head"], ["lm_head"]):
         assert compute_lora_params(tied, 128, targets) == projections + one_matrix, targets
-    # "all-linear" expands in the trainer too, but matches no counter here unnormalized.
+    # For Llama, all-linear and the default projection set are equivalent.
     for targets in (["all-linear", "lm_head"], ["all-linear", "embed_tokens"]):
         assert compute_lora_params(tied, 128, targets) == projections + one_matrix, targets
+
+
+def test_cpt_all_linear_payload_counts_lfm2_linear_layers():
+    arch = ModelArchConfig(
+        hidden_size = 2048,
+        num_hidden_layers = 2,
+        num_attention_heads = 32,
+        num_key_value_heads = 8,
+        intermediate_size = 12288,
+        vocab_size = 65536,
+        tie_word_embeddings = True,
+        layer_types = ["conv", "full_attention"],
+        model_type = "lfm2",
+        block_auto_adjust_ff_dim = True,
+        block_ffn_dim_multiplier = 1.0,
+        block_multiple_of = 256,
+    )
+    all_linear = compute_lora_params(arch, 128, ["all-linear"])
+    combined = compute_lora_params(
+        arch,
+        128,
+        ["all-linear", "embed_tokens", "lm_head"],
+    )
+    one_matrix = arch.vocab_size * arch.hidden_size
+    conv_linears = [(2048, 6144), (2048, 2048), (2048, 8192), (2048, 8192), (8192, 2048)]
+    attention_linears = [
+        (2048, 2048),
+        (2048, 512),
+        (2048, 512),
+        (2048, 2048),
+        (2048, 8192),
+        (2048, 8192),
+        (8192, 2048),
+    ]
+    expected_all_linear = sum((in_dim + out_dim) * 128 for in_dim, out_dim in conv_linears)
+    expected_all_linear += sum((in_dim + out_dim) * 128 for in_dim, out_dim in attention_linears)
+
+    assert all_linear == expected_all_linear
+    assert combined == all_linear + one_matrix
+    assert all_linear > compute_lora_params(arch, 128, list(DEFAULT_TARGET_MODULES))
 
 
 def test_qualified_embedding_names_are_counted_too():

--- a/studio/backend/utils/hardware/vram_estimation.py
+++ b/studio/backend/utils/hardware/vram_estimation.py
@@ -101,6 +101,10 @@ class ModelArchConfig:
     moe_has_dense_mlp: bool = False
     dense_layer_indices: tuple = ()
     dense_intermediate_size: Optional[int] = None
+    model_type: Optional[str] = None
+    block_auto_adjust_ff_dim: bool = False
+    block_ffn_dim_multiplier: Optional[float] = None
+    block_multiple_of: int = 1
 
 
 @dataclass
@@ -376,6 +380,10 @@ def extract_arch_config(hf_config) -> Optional[ModelArchConfig]:
         moe_has_dense_mlp = bool(getattr(text_config, "enable_moe_block", False)),
         dense_layer_indices = dense_layer_indices,
         dense_intermediate_size = dense_intermediate_size,
+        model_type = getattr(text_config, "model_type", None),
+        block_auto_adjust_ff_dim = bool(getattr(text_config, "block_auto_adjust_ff_dim", False)),
+        block_ffn_dim_multiplier = getattr(text_config, "block_ffn_dim_multiplier", None),
+        block_multiple_of = getattr(text_config, "block_multiple_of", 1),
     )
 
 
@@ -524,6 +532,46 @@ def _text_linear_dims(arch: ModelArchConfig, layer_idx: int) -> Dict[str, tuple[
         }
     )
     return dims
+
+
+def _lora_linear_dims(arch: ModelArchConfig, layer_idx: int) -> Dict[str, tuple[int, int]]:
+    if arch.model_type != "lfm2":
+        return _text_linear_dims(arch, layer_idx)
+
+    hd = arch.hidden_size
+    mlp_size = arch.intermediate_size
+    if arch.block_auto_adjust_ff_dim:
+        mlp_size = int(2 * mlp_size / 3)
+        if arch.block_ffn_dim_multiplier is not None:
+            mlp_size = int(arch.block_ffn_dim_multiplier * mlp_size)
+            multiple = max(arch.block_multiple_of, 1)
+            mlp_size = multiple * ((mlp_size + multiple - 1) // multiple)
+    dims = {
+        "w1": (hd, mlp_size),
+        "w3": (hd, mlp_size),
+        "w2": (mlp_size, hd),
+    }
+    if _layer_types(arch)[layer_idx] == "conv":
+        dims.update({"in_proj": (hd, 3 * hd), "out_proj": (hd, hd)})
+        return dims
+
+    q_size, kv_size, has_k, has_v = _layer_attention_dims(arch, layer_idx)
+    dims.update({"q_proj": (hd, q_size), "out_proj": (q_size, hd)})
+    if has_k:
+        dims["k_proj"] = (hd, kv_size)
+    if has_v:
+        dims["v_proj"] = (hd, kv_size)
+    return dims
+
+
+def _is_lora_attention_linear(arch: ModelArchConfig, name: str) -> bool:
+    return name in ATTENTION_TARGET_MODULES or (
+        arch.model_type == "lfm2" and name in {"in_proj", "out_proj"}
+    )
+
+
+def _is_lora_mlp_linear(arch: ModelArchConfig, name: str) -> bool:
+    return name in MLP_TARGET_MODULES or (arch.model_type == "lfm2" and name in {"w1", "w2", "w3"})
 
 
 def _module_path_matches(skip_module: str, alias: str) -> bool:
@@ -931,17 +979,16 @@ def _full_weight_embedding_elements(arch: ModelArchConfig, target_modules) -> in
 
 
 def compute_lora_params(arch: ModelArchConfig, lora_rank: int, target_modules: list) -> int:
-    all_linear = _targets_all_linear(target_modules)
-    selected_modules = list(DEFAULT_TARGET_MODULES) if all_linear else target_modules
-    # Unsloth's CPT path hands the trainer everything but the embedding names, where an
-    # empty remainder becomes the default projections and "all-linear" expands to them
-    # (worker.py). Count those, or the estimate picks a GPU that then OOMs.
-    if not all_linear and _full_weight_embedding_elements(arch, target_modules):
-        remainder = [
-            m for m in selected_modules if str(m).rsplit(".", 1)[-1] not in EMBEDDING_TARGET_MODULES
+    embedding_params = _full_weight_embedding_elements(arch, target_modules)
+    lora_targets = target_modules
+    if embedding_params:
+        lora_targets = [
+            m for m in target_modules if str(m).rsplit(".", 1)[-1] not in EMBEDDING_TARGET_MODULES
         ]
-        if not remainder or _targets_all_linear(remainder):
-            selected_modules = list(selected_modules) + list(DEFAULT_TARGET_MODULES)
+        if not lora_targets:
+            lora_targets = list(DEFAULT_TARGET_MODULES)
+    all_linear = _targets_all_linear(lora_targets)
+    selected_modules = list(DEFAULT_TARGET_MODULES) if all_linear else lora_targets
     hd = arch.hidden_size
     r = lora_rank
     n_layers = arch.num_hidden_layers
@@ -954,15 +1001,15 @@ def compute_lora_params(arch: ModelArchConfig, lora_rank: int, target_modules: l
         per_layer_dense_mlp = []
         for layer_idx in range(n_layers):
             layer_dense = 0
-            for name, (in_dim, out_dim) in _text_linear_dims(
+            for name, (in_dim, out_dim) in _lora_linear_dims(
                 arch,
                 layer_idx,
             ).items():
-                if name not in selected_modules:
+                if not all_linear and name not in selected_modules:
                     continue
-                if name in ATTENTION_TARGET_MODULES:
+                if _is_lora_attention_linear(arch, name):
                     attn_total += in_dim * r + r * out_dim
-                elif name in MLP_TARGET_MODULES:
+                elif _is_lora_mlp_linear(arch, name):
                     layer_dense += in_dim * r + r * out_dim
             per_layer_dense_mlp.append(layer_dense)
             structured_dense_mlp += layer_dense
@@ -1007,8 +1054,8 @@ def compute_lora_params(arch: ModelArchConfig, lora_rank: int, target_modules: l
         return (
             attn_total
             + mlp_total
-            + _per_layer_input_lora_params(arch, r, target_modules)
-            + _full_weight_embedding_elements(arch, selected_modules)
+            + _per_layer_input_lora_params(arch, r, lora_targets)
+            + embedding_params
         )
     elif n_experts > 1:
         attn_total = _lora_attn_elements(arch, r, selected_modules) * n_layers
@@ -1064,8 +1111,8 @@ def compute_lora_params(arch: ModelArchConfig, lora_rank: int, target_modules: l
     return (
         attn_total
         + mlp_total
-        + _per_layer_input_lora_params(arch, r, target_modules)
-        + _full_weight_embedding_elements(arch, selected_modules)
+        + _per_layer_input_lora_params(arch, r, lora_targets)
+        + embedding_params
     )
 
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -278,6 +278,8 @@ MODEL_NAME_MAPPING = {
     ],
     "unsloth_LFM2-1.2B.yaml": [
         "unsloth/LFM2-1.2B",
+        "LiquidAI/LFM2-1.2B",
+        "unsloth/LFM2-1.2B-unsloth-bnb-4bit",
     ],
     "unsloth_llama-3-8b-bnb-4bit.yaml": [
         "unsloth/llama-3-8b",

--- a/studio/frontend/src/config/training.ts
+++ b/studio/frontend/src/config/training.ts
@@ -66,10 +66,23 @@ export function toggleCptTargetModule(
   targetModules: readonly string[],
   module: string,
 ): string[] {
+  if (
+    CPT_EMBEDDING_MODULES.some((embeddingModule) => embeddingModule === module)
+  ) {
+    return targetModules.includes(module)
+      ? targetModules.filter((candidate) => candidate !== module)
+      : [...targetModules, module];
+  }
+
   if (module === "all-linear") {
+    const embeddingModules = targetModules.filter((candidate) =>
+      CPT_EMBEDDING_MODULES.some(
+        (embeddingModule) => embeddingModule === candidate,
+      ),
+    );
     return isCptAllLinearTargetModules(targetModules)
-      ? [...CPT_TARGET_MODULES]
-      : ["all-linear", ...CPT_EMBEDDING_MODULES];
+      ? [...TARGET_MODULES, ...embeddingModules]
+      : ["all-linear", ...embeddingModules];
   }
 
   const namedTargetModules = targetModules.filter(

--- a/studio/frontend/src/config/training.ts
+++ b/studio/frontend/src/config/training.ts
@@ -17,12 +17,34 @@ export const TARGET_MODULES = [
   "down_proj",
 ];
 
+/** CPT trains embeddings via modules_to_save; the UI still lists them for visibility. */
+export const CPT_EMBEDDING_MODULES = ["embed_tokens", "lm_head"] as const;
+
 /** CPT requires embed_tokens and lm_head in addition to standard LoRA modules. */
 export const CPT_TARGET_MODULES = [
   ...TARGET_MODULES,
-  "embed_tokens",
-  "lm_head",
+  ...CPT_EMBEDDING_MODULES,
 ];
+
+/** Preserve architecture-specific all-linear defaults when entering CPT. */
+export function resolveCptTargetModules(
+  currentTargetModules: readonly string[],
+): string[] {
+  if (currentTargetModules.includes("all-linear")) {
+    return ["all-linear", ...CPT_EMBEDDING_MODULES];
+  }
+  return [...CPT_TARGET_MODULES];
+}
+
+/** Target-module chips shown in the CPT advanced-settings UI. */
+export function getCptUiTargetModules(
+  targetModules: readonly string[],
+): readonly string[] {
+  if (targetModules.includes("all-linear")) {
+    return ["all-linear", ...CPT_EMBEDDING_MODULES];
+  }
+  return CPT_TARGET_MODULES;
+}
 
 export const OPTIMIZER_OPTIONS: ReadonlyArray<{
   value: string;

--- a/studio/frontend/src/config/training.ts
+++ b/studio/frontend/src/config/training.ts
@@ -17,33 +17,67 @@ export const TARGET_MODULES = [
   "down_proj",
 ];
 
-/** CPT trains embeddings via modules_to_save; the UI still lists them for visibility. */
+/** CPT trains embeddings via modules_to_save; keep them visible in the UI. */
 export const CPT_EMBEDDING_MODULES = ["embed_tokens", "lm_head"] as const;
 
 /** CPT requires embed_tokens and lm_head in addition to standard LoRA modules. */
-export const CPT_TARGET_MODULES = [
-  ...TARGET_MODULES,
-  ...CPT_EMBEDDING_MODULES,
-];
+export const CPT_TARGET_MODULES = [...TARGET_MODULES, ...CPT_EMBEDDING_MODULES];
 
-/** Preserve architecture-specific all-linear defaults when entering CPT. */
+const CPT_UI_TARGET_MODULES = ["all-linear", ...CPT_TARGET_MODULES] as const;
+
+export function isCptAllLinearTargetModules(
+  targetModules: readonly string[],
+): boolean {
+  const loraTargetModules = targetModules.filter(
+    (module) =>
+      !CPT_EMBEDDING_MODULES.some(
+        (embeddingModule) => embeddingModule === module,
+      ),
+  );
+  return (
+    loraTargetModules.length === 1 && loraTargetModules[0] === "all-linear"
+  );
+}
+
+/** Preserve all-linear model defaults for CPT. */
 export function resolveCptTargetModules(
   currentTargetModules: readonly string[],
 ): string[] {
-  if (currentTargetModules.includes("all-linear")) {
+  if (isCptAllLinearTargetModules(currentTargetModules)) {
     return ["all-linear", ...CPT_EMBEDDING_MODULES];
   }
   return [...CPT_TARGET_MODULES];
 }
 
-/** Target-module chips shown in the CPT advanced-settings UI. */
-export function getCptUiTargetModules(
+export function getCptUiTargetModules(): readonly string[] {
+  return CPT_UI_TARGET_MODULES;
+}
+
+export function isCptTargetModuleActive(
   targetModules: readonly string[],
-): readonly string[] {
-  if (targetModules.includes("all-linear")) {
-    return ["all-linear", ...CPT_EMBEDDING_MODULES];
+  module: string,
+): boolean {
+  return module === "all-linear"
+    ? isCptAllLinearTargetModules(targetModules)
+    : targetModules.includes(module);
+}
+
+export function toggleCptTargetModule(
+  targetModules: readonly string[],
+  module: string,
+): string[] {
+  if (module === "all-linear") {
+    return isCptAllLinearTargetModules(targetModules)
+      ? [...CPT_TARGET_MODULES]
+      : ["all-linear", ...CPT_EMBEDDING_MODULES];
   }
-  return CPT_TARGET_MODULES;
+
+  const namedTargetModules = targetModules.filter(
+    (candidate) => candidate !== "all-linear",
+  );
+  return targetModules.includes(module)
+    ? namedTargetModules.filter((candidate) => candidate !== module)
+    : [...namedTargetModules, module];
 }
 
 export const OPTIMIZER_OPTIONS: ReadonlyArray<{

--- a/studio/frontend/src/features/studio/sections/lora-params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/lora-params-section.tsx
@@ -8,7 +8,12 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { usePlatformStore } from "@/config/env";
-import { TARGET_MODULES, getCptUiTargetModules } from "@/config/training";
+import {
+  TARGET_MODULES,
+  getCptUiTargetModules,
+  isCptTargetModuleActive,
+  toggleCptTargetModule,
+} from "@/config/training";
 import {
   isTrainingLoraVariantSupportedOnDevice,
   useTrainingConfigStore,
@@ -188,30 +193,39 @@ export function LoraParamsSection(): ReactElement | null {
                 {t("studio.params.targetModules")}
               </span>
               <div className="flex flex-wrap gap-1.5">
-                {(isCpt ? getCptUiTargetModules(store.targetModules) : TARGET_MODULES).map((module) => {
-                  const active = store.targetModules.includes(module);
-                  return (
-                    <button
-                      key={module}
-                      type="button"
-                      aria-pressed={active}
-                      onClick={() =>
-                        store.setTargetModules(
-                          active
-                            ? store.targetModules.filter(
-                                (candidate) => candidate !== module,
-                              )
-                            : [...store.targetModules, module],
-                        )
-                      }
-                      className={`cursor-pointer rounded-full border px-2.5 py-0.5 text-ui-11 font-mono transition-colors ${selectableOptionStateClassName(active)} ${
-                        active ? "text-foreground" : "text-muted-foreground"
-                      }`}
-                    >
-                      {module}
-                    </button>
-                  );
-                })}
+                {(isCpt ? getCptUiTargetModules() : TARGET_MODULES).map(
+                  (module) => {
+                    const active = isCpt
+                      ? isCptTargetModuleActive(store.targetModules, module)
+                      : store.targetModules.includes(module);
+                    return (
+                      <button
+                        key={module}
+                        type="button"
+                        aria-pressed={active}
+                        onClick={() =>
+                          store.setTargetModules(
+                            isCpt
+                              ? toggleCptTargetModule(
+                                  store.targetModules,
+                                  module,
+                                )
+                              : active
+                                ? store.targetModules.filter(
+                                    (candidate) => candidate !== module,
+                                  )
+                                : [...store.targetModules, module],
+                          )
+                        }
+                        className={`cursor-pointer rounded-full border px-2.5 py-0.5 text-ui-11 font-mono transition-colors ${selectableOptionStateClassName(active)} ${
+                          active ? "text-foreground" : "text-muted-foreground"
+                        }`}
+                      >
+                        {module}
+                      </button>
+                    );
+                  },
+                )}
               </div>
             </div>
           )}

--- a/studio/frontend/src/features/studio/sections/lora-params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/lora-params-section.tsx
@@ -8,7 +8,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { usePlatformStore } from "@/config/env";
-import { CPT_TARGET_MODULES, TARGET_MODULES } from "@/config/training";
+import { TARGET_MODULES, getCptUiTargetModules } from "@/config/training";
 import {
   isTrainingLoraVariantSupportedOnDevice,
   useTrainingConfigStore,
@@ -188,7 +188,7 @@ export function LoraParamsSection(): ReactElement | null {
                 {t("studio.params.targetModules")}
               </span>
               <div className="flex flex-wrap gap-1.5">
-                {(isCpt ? CPT_TARGET_MODULES : TARGET_MODULES).map((module) => {
+                {(isCpt ? getCptUiTargetModules(store.targetModules) : TARGET_MODULES).map((module) => {
                   const active = store.targetModules.includes(module);
                   return (
                     <button

--- a/studio/frontend/src/features/studio/wizard/advanced-settings-summary.ts
+++ b/studio/frontend/src/features/studio/wizard/advanced-settings-summary.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { CPT_TARGET_MODULES, DEFAULT_HYPERPARAMS } from "@/config/training";
+import { DEFAULT_HYPERPARAMS, resolveCptTargetModules } from "@/config/training";
 import type {
   AdvancedSettingsBaseline,
   TrainingConfigState,
@@ -90,7 +90,13 @@ function countNonDefaultLoraSettings(
     0,
   );
   const defaultTargetModules = isCpt
-    ? CPT_TARGET_MODULES
+    ? resolveCptTargetModules(
+        baselineValue(
+          baseline,
+          "targetModules",
+          DEFAULT_HYPERPARAMS.targetModules,
+        ),
+      )
     : baselineValue(
         baseline,
         "targetModules",

--- a/studio/frontend/src/features/training/stores/training-config-persistence.ts
+++ b/studio/frontend/src/features/training/stores/training-config-persistence.ts
@@ -222,6 +222,7 @@ function migrateThroughVersion19(
       learningRateManuallySet: inferLegacyLearningRateWasManuallySet(state),
       modelAdapterLearningRate: null,
       datasetFormatBeforeCpt: null,
+      targetModulesBeforeCpt: null,
     } satisfies TrainingMethodProvenance;
   }
 }
@@ -257,6 +258,7 @@ function normalizeTrainingMethodProvenance(
       : {};
   const modelAdapterLearningRate = provenance.modelAdapterLearningRate;
   const datasetFormatBeforeCpt = provenance.datasetFormatBeforeCpt;
+  const targetModulesBeforeCpt = provenance.targetModulesBeforeCpt;
   return {
     learningRateManuallySet:
       typeof provenance.learningRateManuallySet === "boolean"
@@ -273,6 +275,12 @@ function normalizeTrainingMethodProvenance(
       isDatasetFormat(datasetFormatBeforeCpt) &&
       datasetFormatBeforeCpt !== "raw"
         ? datasetFormatBeforeCpt
+        : null,
+    targetModulesBeforeCpt:
+      persistedState.trainingMethod === "cpt" &&
+      Array.isArray(targetModulesBeforeCpt) &&
+      targetModulesBeforeCpt.length > 0
+        ? [...targetModulesBeforeCpt]
         : null,
   };
 }

--- a/studio/frontend/src/features/training/stores/training-config-policy.ts
+++ b/studio/frontend/src/features/training/stores/training-config-policy.ts
@@ -65,6 +65,7 @@ export const initialTrainingConfigState: TrainingConfigState = {
     learningRateManuallySet: false,
     modelAdapterLearningRate: null,
     datasetFormatBeforeCpt: null,
+    targetModulesBeforeCpt: null,
   },
   datasetSource: "huggingface",
   browseDatasetSelection: createHfBrowseDatasetSelection(null),

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -325,6 +325,14 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
                       ...get().trainingMethodProvenance,
                       learningRateManuallySet: false,
                       modelAdapterLearningRate,
+                      ...(get().trainingMethod === "cpt" &&
+                      modelDefaultsPatch.targetModules !== undefined
+                        ? {
+                            targetModulesBeforeCpt: [
+                              ...modelDefaultsPatch.targetModules,
+                            ],
+                          }
+                        : {}),
                     },
                   }
                 : {}),

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -285,15 +285,16 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
                 : null;
 
             // Preserve CPT hyperparams: YAML adapter defaults are tuned for standard LoRA.
+            const cptTargetModules =
+              modelDefaultsPatch.targetModules ?? get().targetModules;
+            const cptDefaultsPatch = getCptModelDefaultsPatch(cptTargetModules);
             const cptOverrides =
               shouldApplyTrainingDefaults && get().trainingMethod === "cpt"
-                ? getCptModelDefaultsPatch()
+                ? cptDefaultsPatch
                 : {};
             const modelDefaultsBaseline = {
               ...modelDefaultsPatch,
-              ...(get().trainingMethod === "cpt"
-                ? getCptModelDefaultsPatch()
-                : {}),
+              ...(get().trainingMethod === "cpt" ? cptDefaultsPatch : {}),
             };
             const advancedSettingsBaseline =
               get().advancedSettingsBaseline ?? modelDefaultsBaseline;

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -81,6 +81,7 @@ let _trainOnCompletionsManuallySet = false;
 
 let _trainingMethodEditGeneration = 0;
 let _modelDefaultsEditGeneration = 0;
+let _targetModulesEditGeneration = 0;
 let _modelDefaultsEditBaseline: {
   modelName: string;
   editGeneration: number;
@@ -152,6 +153,8 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         const requestState = get();
         const requestedModelDefaultsEditGeneration =
           _modelDefaultsEditGeneration;
+        const requestedTargetModulesEditGeneration =
+          _targetModulesEditGeneration;
         if (applyTrainingDefaults) {
           _modelDefaultsEditBaseline = {
             modelName,
@@ -199,6 +202,12 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             if (!requestMatchesSelection()) return;
 
             const shouldApplyTrainingDefaults = canApplyTrainingDefaults();
+            const shouldApplyCptTargetDefaults =
+              applyTrainingDefaults &&
+              !shouldApplyTrainingDefaults &&
+              get().trainingMethod === "cpt" &&
+              _targetModulesEditGeneration ===
+                requestedTargetModulesEditGeneration;
             if (shouldApplyTrainingDefaults) {
               _trainOnCompletionsManuallySet = false;
             }
@@ -292,6 +301,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               shouldApplyTrainingDefaults && get().trainingMethod === "cpt"
                 ? cptDefaultsPatch
                 : {};
+            const cptTargetOverrides = shouldApplyCptTargetDefaults
+              ? { targetModules: cptDefaultsPatch.targetModules }
+              : {};
             const modelDefaultsBaseline = {
               ...modelDefaultsPatch,
               ...(get().trainingMethod === "cpt" ? cptDefaultsPatch : {}),
@@ -318,6 +330,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             set({
               ...patch,
               ...cptOverrides,
+              ...cptTargetOverrides,
               ...deferredCompletionDefault,
               ...(shouldApplyTrainingDefaults
                 ? {
@@ -335,10 +348,25 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
                         : {}),
                     },
                   }
-                : {}),
+                : shouldApplyCptTargetDefaults &&
+                    modelDefaultsPatch.targetModules !== undefined
+                  ? {
+                      trainingMethodProvenance: {
+                        ...get().trainingMethodProvenance,
+                        targetModulesBeforeCpt: [
+                          ...modelDefaultsPatch.targetModules,
+                        ],
+                      },
+                    }
+                  : {}),
               advancedSettingsBaseline: shouldApplyTrainingDefaults
                 ? modelDefaultsBaseline
-                : advancedSettingsBaseline,
+                : shouldApplyCptTargetDefaults
+                  ? {
+                      ...advancedSettingsBaseline,
+                      targetModules: cptDefaultsPatch.targetModules,
+                    }
+                  : advancedSettingsBaseline,
               modelType: inferredModelType,
               isVisionModel: modelDetails.is_vision,
               isEmbeddingModel: isEmbedding,
@@ -1273,11 +1301,15 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           setUserEdit({ finetuneAttentionModules }),
         setFinetuneMLPModules: (finetuneMLPModules) =>
           setUserEdit({ finetuneMLPModules }),
-        setTargetModules: (targetModules) => setUserEdit({ targetModules }),
+        setTargetModules: (targetModules) => {
+          _targetModulesEditGeneration += 1;
+          setUserEdit({ targetModules });
+        },
         setS3Config: (s3Config) => setUserEdit({ s3Config }),
         reset: () => {
           trainingDatasetCacheRejections.reset();
           _trainOnCompletionsManuallySet = false;
+          _targetModulesEditGeneration += 1;
           _modelDefaultsEditBaseline = null;
           setUserEdit(initialTrainingConfigState);
         },
@@ -1293,6 +1325,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         },
         applyConfigPatch: (config: BackendModelConfig) => {
           const patch = mapBackendModelConfigToTrainingPatch(config);
+          if (patch.targetModules !== undefined) {
+            _targetModulesEditGeneration += 1;
+          }
           setUserEdit((state) => ({
             ...patch,
             ...(patch.trainOnCompletions !== undefined

--- a/studio/frontend/src/features/training/stores/training-method-transition.ts
+++ b/studio/frontend/src/features/training/stores/training-method-transition.ts
@@ -2,12 +2,12 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import {
-  CPT_TARGET_MODULES,
   DEFAULT_HYPERPARAMS,
   LR_DEFAULT_CPT,
   LR_DEFAULT_FULL,
   LR_DEFAULT_LORA,
   TARGET_MODULES,
+  resolveCptTargetModules,
 } from "@/config/training";
 import { isAdapterMethod } from "@/types/training";
 import type { TrainingMethod } from "@/types/training";
@@ -29,30 +29,36 @@ type TrainingMethodStatePatch = Partial<
   >
 >;
 
-function getCptTrainingPatch(): TrainingMethodStatePatch {
+function getCptTrainingPatch(
+  currentTargetModules: readonly string[],
+): TrainingMethodStatePatch {
   return {
     loraRank: 128,
     loraAlpha: 32,
     loraVariant: "rslora",
-    targetModules: CPT_TARGET_MODULES,
+    targetModules: resolveCptTargetModules(currentTargetModules),
     datasetFormat: "raw",
     trainOnCompletions: false,
   };
 }
 
-export function getCptModelDefaultsPatch(): TrainingMethodStatePatch {
+export function getCptModelDefaultsPatch(
+  currentTargetModules: readonly string[] = DEFAULT_HYPERPARAMS.targetModules,
+): TrainingMethodStatePatch {
   return {
-    ...getCptTrainingPatch(),
+    ...getCptTrainingPatch(currentTargetModules),
     learningRate: LR_DEFAULT_CPT,
   };
 }
 
-function getRestoreFromCptPatch(): TrainingMethodStatePatch {
+function getRestoreFromCptPatch(
+  targetModulesBeforeCpt: string[] | null,
+): TrainingMethodStatePatch {
   return {
     loraRank: DEFAULT_HYPERPARAMS.loraRank,
     loraAlpha: DEFAULT_HYPERPARAMS.loraAlpha,
     loraVariant: DEFAULT_HYPERPARAMS.loraVariant,
-    targetModules: TARGET_MODULES,
+    targetModules: targetModulesBeforeCpt ?? TARGET_MODULES,
   };
 }
 
@@ -87,7 +93,10 @@ function resolveTrainingMethodLearningRate(
 export function buildTrainingMethodPatch(
   state: Pick<
     TrainingConfigState,
-    "trainingMethod" | "trainingMethodProvenance" | "datasetFormat"
+    | "trainingMethod"
+    | "trainingMethodProvenance"
+    | "datasetFormat"
+    | "targetModules"
   >,
   nextMethod: TrainingMethod,
 ): TrainingMethodStatePatch {
@@ -101,14 +110,19 @@ export function buildTrainingMethodPatch(
     )
       ? null
       : state.datasetFormat;
-    Object.assign(patch, getCptTrainingPatch());
+    provenance.targetModulesBeforeCpt = [...state.targetModules];
+    Object.assign(patch, getCptTrainingPatch(state.targetModules));
   }
   if (prevMethod === "cpt" && nextMethod !== "cpt") {
-    Object.assign(patch, getRestoreFromCptPatch());
+    Object.assign(
+      patch,
+      getRestoreFromCptPatch(provenance.targetModulesBeforeCpt),
+    );
     if (provenance.datasetFormatBeforeCpt !== null) {
       patch.datasetFormat = provenance.datasetFormatBeforeCpt;
     }
     provenance.datasetFormatBeforeCpt = null;
+    provenance.targetModulesBeforeCpt = null;
   }
 
   const learningRate = resolveTrainingMethodLearningRate(

--- a/studio/frontend/src/features/training/types/config.ts
+++ b/studio/frontend/src/features/training/types/config.ts
@@ -49,6 +49,7 @@ export interface TrainingMethodProvenance {
   learningRateManuallySet: boolean;
   modelAdapterLearningRate: number | null;
   datasetFormatBeforeCpt: DatasetFormat | null;
+  targetModulesBeforeCpt: string[] | null;
 }
 
 /** Column-to-role mapping, e.g. { "problem": "user", "solution": "assistant", "context": "system" } */

--- a/studio/frontend/tests/cpt-target-modules.test.ts
+++ b/studio/frontend/tests/cpt-target-modules.test.ts
@@ -80,3 +80,24 @@ test("CPT target controls switch all-linear without mixed state", () => {
     ["embed_tokens", "lm_head", "q_proj"],
   );
 });
+
+test("CPT embedding controls do not change the LoRA target mode", () => {
+  assert.deepEqual(
+    toggleCptTargetModule(
+      ["all-linear", "embed_tokens", "lm_head"],
+      "embed_tokens",
+    ),
+    ["all-linear", "lm_head"],
+  );
+  assert.deepEqual(
+    toggleCptTargetModule(["all-linear", "lm_head"], "embed_tokens"),
+    ["all-linear", "lm_head", "embed_tokens"],
+  );
+  assert.deepEqual(toggleCptTargetModule(["q_proj"], "all-linear"), [
+    "all-linear",
+  ]);
+  assert.deepEqual(
+    toggleCptTargetModule(["all-linear", "lm_head"], "all-linear"),
+    [...DEFAULT_HYPERPARAMS.targetModules, "lm_head"],
+  );
+});

--- a/studio/frontend/tests/cpt-target-modules.test.ts
+++ b/studio/frontend/tests/cpt-target-modules.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const {
+  CPT_TARGET_MODULES,
+  DEFAULT_HYPERPARAMS,
+  getCptUiTargetModules,
+  resolveCptTargetModules,
+} = await import("../src/config/training.ts");
+
+test("resolveCptTargetModules keeps all-linear for architecture-specific models", () => {
+  assert.deepEqual(resolveCptTargetModules(["all-linear"]), [
+    "all-linear",
+    "embed_tokens",
+    "lm_head",
+  ]);
+});
+
+test("resolveCptTargetModules keeps Llama defaults for standard adapters", () => {
+  assert.deepEqual(
+    resolveCptTargetModules(DEFAULT_HYPERPARAMS.targetModules),
+    CPT_TARGET_MODULES,
+  );
+});
+
+test("getCptUiTargetModules exposes all-linear in the CPT settings UI", () => {
+  assert.deepEqual(
+    getCptUiTargetModules(["all-linear", "embed_tokens", "lm_head"]),
+    ["all-linear", "embed_tokens", "lm_head"],
+  );
+  assert.deepEqual(getCptUiTargetModules(CPT_TARGET_MODULES), CPT_TARGET_MODULES);
+});

--- a/studio/frontend/tests/cpt-target-modules.test.ts
+++ b/studio/frontend/tests/cpt-target-modules.test.ts
@@ -12,7 +12,9 @@ const {
   CPT_TARGET_MODULES,
   DEFAULT_HYPERPARAMS,
   getCptUiTargetModules,
+  isCptTargetModuleActive,
   resolveCptTargetModules,
+  toggleCptTargetModule,
 } = await import("../src/config/training.ts");
 
 test("resolveCptTargetModules keeps all-linear for architecture-specific models", () => {
@@ -30,10 +32,51 @@ test("resolveCptTargetModules keeps Llama defaults for standard adapters", () =>
   );
 });
 
-test("getCptUiTargetModules exposes all-linear in the CPT settings UI", () => {
+test("resolveCptTargetModules treats all-linear as an exclusive sentinel", () => {
   assert.deepEqual(
-    getCptUiTargetModules(["all-linear", "embed_tokens", "lm_head"]),
+    resolveCptTargetModules(["all-linear", "embed_tokens", "lm_head"]),
     ["all-linear", "embed_tokens", "lm_head"],
   );
-  assert.deepEqual(getCptUiTargetModules(CPT_TARGET_MODULES), CPT_TARGET_MODULES);
+  assert.deepEqual(
+    resolveCptTargetModules(["all-linear", "q_proj"]),
+    CPT_TARGET_MODULES,
+  );
+});
+
+test("CPT target controls switch all-linear without mixed state", () => {
+  assert.deepEqual(getCptUiTargetModules(), [
+    "all-linear",
+    ...CPT_TARGET_MODULES,
+  ]);
+  assert.equal(
+    isCptTargetModuleActive(
+      ["all-linear", "embed_tokens", "lm_head"],
+      "all-linear",
+    ),
+    true,
+  );
+  assert.equal(
+    isCptTargetModuleActive(["all-linear", "q_proj"], "all-linear"),
+    false,
+  );
+  assert.equal(
+    isCptTargetModuleActive(["all-linear", "q_proj"], "q_proj"),
+    true,
+  );
+  assert.deepEqual(
+    toggleCptTargetModule(
+      ["all-linear", "embed_tokens", "lm_head"],
+      "all-linear",
+    ),
+    CPT_TARGET_MODULES,
+  );
+  assert.deepEqual(toggleCptTargetModule(CPT_TARGET_MODULES, "all-linear"), [
+    "all-linear",
+    "embed_tokens",
+    "lm_head",
+  ]);
+  assert.deepEqual(
+    toggleCptTargetModule(["all-linear", "embed_tokens", "lm_head"], "q_proj"),
+    ["embed_tokens", "lm_head", "q_proj"],
+  );
 });

--- a/studio/frontend/tests/training-config-persistence.test.ts
+++ b/studio/frontend/tests/training-config-persistence.test.ts
@@ -71,6 +71,7 @@ test("migration preserves tuned values while protecting them from model defaults
     learningRateManuallySet: true,
     modelAdapterLearningRate: null,
     datasetFormatBeforeCpt: null,
+    targetModulesBeforeCpt: null,
   });
   assert.equal("wandbToken" in migrated, false);
 });

--- a/studio/frontend/tests/training-cpt-model-switch.test.ts
+++ b/studio/frontend/tests/training-cpt-model-switch.test.ts
@@ -41,6 +41,31 @@ async function waitForModelDefaults(model: string): Promise<void> {
   throw new Error("model defaults did not settle");
 }
 
+function deferLfmDefaults(): () => void {
+  let resolveModelConfig!: (response: Response) => void;
+  setAuthFetchHandler(
+    () =>
+      new Promise<Response>((resolve) => {
+        resolveModelConfig = resolve;
+      }),
+  );
+  return () =>
+    resolveModelConfig(
+      Response.json({
+        id: "LiquidAI/LFM2-1.2B",
+        config: { lora: { target_modules: ["all-linear"] } },
+        is_vision: false,
+        is_embedding: false,
+        is_audio: false,
+        audio_type_known: true,
+        is_lora: false,
+        model_type: "text",
+        model_size_bytes: null,
+        max_position_embeddings: 32768,
+      }),
+    );
+}
+
 after(() => setAuthFetchHandler(null));
 
 test("leaving CPT after a model switch restores the new model targets", async () => {
@@ -88,5 +113,131 @@ test("leaving CPT after a model switch restores the new model targets", async ()
   useTrainingConfigStore.getState().setTrainingMethod("qlora");
   assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
     "all-linear",
+  ]);
+});
+
+test("model targets apply when CPT is selected during the defaults request", async () => {
+  useTrainingConfigStore.getState().reset();
+  const resolveModelConfig = deferLfmDefaults();
+
+  useTrainingConfigStore
+    .getState()
+    .selectTrainingModel("LiquidAI/LFM2-1.2B", "text");
+  useTrainingConfigStore.getState().setTrainingMethod("cpt");
+  resolveModelConfig();
+  await waitForModelDefaults("LiquidAI/LFM2-1.2B");
+
+  assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
+    "all-linear",
+    "embed_tokens",
+    "lm_head",
+  ]);
+});
+
+test("an explicit target edit still wins during the defaults request", async () => {
+  useTrainingConfigStore.getState().reset();
+  const resolveModelConfig = deferLfmDefaults();
+
+  useTrainingConfigStore
+    .getState()
+    .selectTrainingModel("LiquidAI/LFM2-1.2B", "text");
+  useTrainingConfigStore.getState().setTrainingMethod("cpt");
+  useTrainingConfigStore
+    .getState()
+    .setTargetModules(["q_proj", "embed_tokens", "lm_head"]);
+  resolveModelConfig();
+  await waitForModelDefaults("LiquidAI/LFM2-1.2B");
+
+  assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
+    "q_proj",
+    "embed_tokens",
+    "lm_head",
+  ]);
+});
+
+test("a target edit before entering CPT still wins", async () => {
+  useTrainingConfigStore.getState().reset();
+  const resolveModelConfig = deferLfmDefaults();
+
+  useTrainingConfigStore
+    .getState()
+    .selectTrainingModel("LiquidAI/LFM2-1.2B", "text");
+  useTrainingConfigStore.getState().setTargetModules(["q_proj"]);
+  useTrainingConfigStore.getState().setTrainingMethod("cpt");
+  resolveModelConfig();
+  await waitForModelDefaults("LiquidAI/LFM2-1.2B");
+
+  assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
+    ...LLAMA_TARGETS,
+    "embed_tokens",
+    "lm_head",
+  ]);
+  assert.deepEqual(
+    useTrainingConfigStore.getState().trainingMethodProvenance
+      .targetModulesBeforeCpt,
+    ["q_proj"],
+  );
+  useTrainingConfigStore.getState().setTrainingMethod("qlora");
+  assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
+    "q_proj",
+  ]);
+});
+
+test("an unrelated edit does not block the model targets", async () => {
+  useTrainingConfigStore.getState().reset();
+  const resolveModelConfig = deferLfmDefaults();
+
+  useTrainingConfigStore
+    .getState()
+    .selectTrainingModel("LiquidAI/LFM2-1.2B", "text");
+  useTrainingConfigStore.getState().setTrainingMethod("cpt");
+  useTrainingConfigStore.getState().setBatchSize(3);
+  resolveModelConfig();
+  await waitForModelDefaults("LiquidAI/LFM2-1.2B");
+
+  assert.equal(useTrainingConfigStore.getState().batchSize, 3);
+  assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
+    "all-linear",
+    "embed_tokens",
+    "lm_head",
+  ]);
+});
+
+test("an unrelated edit does not block targets when CPT was already active", async () => {
+  useTrainingConfigStore.getState().reset();
+  useTrainingConfigStore.getState().setTrainingMethod("cpt");
+  const resolveModelConfig = deferLfmDefaults();
+
+  useTrainingConfigStore
+    .getState()
+    .selectTrainingModel("LiquidAI/LFM2-1.2B", "text");
+  useTrainingConfigStore.getState().setBatchSize(3);
+  resolveModelConfig();
+  await waitForModelDefaults("LiquidAI/LFM2-1.2B");
+
+  assert.equal(useTrainingConfigStore.getState().batchSize, 3);
+  assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
+    "all-linear",
+    "embed_tokens",
+    "lm_head",
+  ]);
+});
+
+test("targets imported during the defaults request still win", async () => {
+  useTrainingConfigStore.getState().reset();
+  const resolveModelConfig = deferLfmDefaults();
+
+  useTrainingConfigStore
+    .getState()
+    .selectTrainingModel("LiquidAI/LFM2-1.2B", "text");
+  useTrainingConfigStore.getState().setTrainingMethod("cpt");
+  useTrainingConfigStore.getState().applyConfigPatch({
+    lora: { target_modules: ["q_proj"] },
+  });
+  resolveModelConfig();
+  await waitForModelDefaults("LiquidAI/LFM2-1.2B");
+
+  assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
+    "q_proj",
   ]);
 });

--- a/studio/frontend/tests/training-cpt-model-switch.test.ts
+++ b/studio/frontend/tests/training-cpt-model-switch.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+
+import {
+  installLocalStorageFake,
+  registerStoreStubResolver,
+} from "./helpers/kit.ts";
+
+registerStoreStubResolver();
+installLocalStorageFake();
+
+const { setAuthFetchHandler } = await import("@/features/auth");
+const { useTrainingConfigStore } = await import(
+  "../src/features/training/stores/training-config-store.ts"
+);
+
+const LLAMA_TARGETS = [
+  "q_proj",
+  "k_proj",
+  "v_proj",
+  "o_proj",
+  "gate_proj",
+  "up_proj",
+  "down_proj",
+];
+
+async function waitForModelDefaults(model: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const state = useTrainingConfigStore.getState();
+    if (
+      !state.isLoadingModelDefaults &&
+      state.modelDefaultsAppliedFor === model
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("model defaults did not settle");
+}
+
+after(() => setAuthFetchHandler(null));
+
+test("leaving CPT after a model switch restores the new model targets", async () => {
+  useTrainingConfigStore.getState().reset();
+  useTrainingConfigStore.setState({
+    selectedModel: "old/llama",
+    modelDefaultsAppliedFor: "old/llama",
+    trainingMethod: "cpt",
+    targetModules: [...LLAMA_TARGETS, "embed_tokens", "lm_head"],
+    trainingMethodProvenance: {
+      learningRateManuallySet: false,
+      modelAdapterLearningRate: null,
+      datasetFormatBeforeCpt: "chatml",
+      targetModulesBeforeCpt: [...LLAMA_TARGETS],
+    },
+  });
+
+  setAuthFetchHandler(() =>
+    Promise.resolve(
+      Response.json({
+        id: "LiquidAI/LFM2-1.2B",
+        config: { lora: { target_modules: ["all-linear"] } },
+        is_vision: false,
+        is_embedding: false,
+        is_audio: false,
+        audio_type_known: true,
+        is_lora: false,
+        model_type: "text",
+        model_size_bytes: null,
+        max_position_embeddings: 32768,
+      }),
+    ),
+  );
+
+  useTrainingConfigStore
+    .getState()
+    .selectTrainingModel("LiquidAI/LFM2-1.2B", "text");
+  await waitForModelDefaults("LiquidAI/LFM2-1.2B");
+
+  assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
+    "all-linear",
+    "embed_tokens",
+    "lm_head",
+  ]);
+  useTrainingConfigStore.getState().setTrainingMethod("qlora");
+  assert.deepEqual(useTrainingConfigStore.getState().targetModules, [
+    "all-linear",
+  ]);
+});

--- a/studio/frontend/tests/training-cpt-model-switch.test.ts
+++ b/studio/frontend/tests/training-cpt-model-switch.test.ts
@@ -12,7 +12,7 @@ import {
 registerStoreStubResolver();
 installLocalStorageFake();
 
-const { setAuthFetchHandler } = await import("@/features/auth");
+const { setAuthFetchHandler } = await import("./helpers/store-stubs/auth.ts");
 const { useTrainingConfigStore } = await import(
   "../src/features/training/stores/training-config-store.ts"
 );

--- a/studio/frontend/tests/training-method-provenance.test.ts
+++ b/studio/frontend/tests/training-method-provenance.test.ts
@@ -94,7 +94,7 @@ test("switching away from CPT restores pre-CPT target modules", () => {
     trainingMethodProvenance: {
       learningRateManuallySet: false,
       modelAdapterLearningRate: null,
-      datasetFormatBeforeCpt: "chatml",
+      datasetFormatBeforeCpt: "chatml" as const,
       targetModulesBeforeCpt: ["all-linear"],
     },
   };

--- a/studio/frontend/tests/training-method-provenance.test.ts
+++ b/studio/frontend/tests/training-method-provenance.test.ts
@@ -26,6 +26,7 @@ test("rehydrated CPT provenance survives the next method switch", () => {
       learningRateManuallySet: true,
       modelAdapterLearningRate: 0.00001,
       datasetFormatBeforeCpt: "sharegpt",
+      targetModulesBeforeCpt: null,
     },
   });
   const rehydrated = mergeTrainingConfig(
@@ -52,6 +53,7 @@ test("rehydrated model learning rate is restored for adapter methods", () => {
       learningRateManuallySet: false,
       modelAdapterLearningRate: 0.00001,
       datasetFormatBeforeCpt: null,
+      targetModulesBeforeCpt: null,
     },
   });
   const rehydrated = mergeTrainingConfig(
@@ -64,4 +66,41 @@ test("rehydrated model learning rate is restored for adapter methods", () => {
   };
 
   assert.equal(state.learningRate, 0.00001);
+});
+
+test("CPT preserves all-linear model defaults instead of Llama target names", () => {
+  const state = {
+    ...initialTrainingConfigState,
+    trainingMethod: "qlora" as const,
+    targetModules: ["all-linear"],
+    datasetFormat: "chatml" as const,
+  };
+  const patch = buildTrainingMethodPatch(state, "cpt");
+
+  assert.deepEqual(patch.targetModules, [
+    "all-linear",
+    "embed_tokens",
+    "lm_head",
+  ]);
+  assert.equal(patch.trainingMethodProvenance?.targetModulesBeforeCpt?.[0], "all-linear");
+});
+
+test("switching away from CPT restores pre-CPT target modules", () => {
+  const state = {
+    ...initialTrainingConfigState,
+    trainingMethod: "cpt" as const,
+    targetModules: ["all-linear", "embed_tokens", "lm_head"],
+    datasetFormat: "raw" as const,
+    trainingMethodProvenance: {
+      learningRateManuallySet: false,
+      modelAdapterLearningRate: null,
+      datasetFormatBeforeCpt: "chatml",
+      targetModulesBeforeCpt: ["all-linear"],
+    },
+  };
+  const patch = buildTrainingMethodPatch(state, "qlora");
+
+  assert.deepEqual(patch.targetModules, ["all-linear"]);
+  assert.equal(patch.datasetFormat, "chatml");
+  assert.equal(patch.trainingMethodProvenance?.targetModulesBeforeCpt, null);
 });


### PR DESCRIPTION
## Summary

Fixes #9866

When switching to Continued Pretraining (CPT) in Studio, the UI was replacing model-specific `all-linear` LoRA defaults with hardcoded Llama-style target module names (`q_proj`, `o_proj`, `gate_proj`, etc.).

For `LiquidAI/LFM2-1.2B`, this silently attached LoRA to only 18 modules (q/k/v projections) instead of all 92 eligible linear layers, because LFM2 uses architecture-specific names like `out_proj`, `in_proj`, `w1`, `w2`, and `w3`.

## Changes

- Add `resolveCptTargetModules()` to preserve `all-linear` when entering CPT
- Store and restore `targetModulesBeforeCpt` in training method provenance
- Show `all-linear` in the CPT advanced-settings UI when applicable
- Apply CPT defaults from model YAML target modules when loading model config

## Reproduction

Before fix (Studio CPT defaults on LFM2):
- 18 wrapped modules, 884,736 trainable LoRA parameters

With `all-linear`:
- 92 wrapped modules, 11,108,352 trainable LoRA parameters

## Test plan

- [x] `npm test -- tests/cpt-target-modules.test.ts tests/training-method-provenance.test.ts tests/training-config-persistence.test.ts`
- [x] Python reproduction confirms fixed CPT payload (`all-linear` + `modules_to_save`) covers all LFM2 linear modules