### PR TITLE
fix(studio): accept trailing slash for model discovery

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -22396,6 +22396,12 @@ async def _openai_catalog_objects() -> list[dict]:
     return list(by_id.values())
 
 
+# Some OpenAI-compatible clients (notably DEVONthink) probe ``/v1/models/``
+# literally and do not follow FastAPI's automatic slash redirect. Register the
+# slash form directly so model discovery reaches authentication and returns the
+# catalog in one response. Keep it out of the schema because it is only a wire
+# compatibility alias for the canonical OpenAI path.
+@router.get("/models/", include_in_schema = False)
 @router.get("/models")
 async def openai_list_models(current_subject: str = Depends(get_current_subject)):
     """

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -460,6 +460,7 @@ def test_openai_compat_routes_bound_to_handlers_with_auth():
         ("POST", "/messages/count_tokens"): "anthropic_count_tokens",
         ("POST", "/audio/generate"): "generate_audio",
         ("GET", "/models"): "openai_list_models",
+        ("GET", "/models/"): "openai_list_models",
         ("GET", "/models/{model_id:path}"): "openai_retrieve_model",
     }
     seen = {}


### PR DESCRIPTION
## Summary

- register `/v1/models/` as a direct compatibility alias for `/v1/models`
- keep the alias out of OpenAPI while preserving the existing authentication dependency
- cover both paths in the router contract test

## Why

DEVONthink probes `GET /v1/models/` when configuring an OpenAI-compatible provider. Without an explicit collection route for the trailing-slash form, the existing `/models/{model_id:path}` catch-all consumes the empty path segment and returns an authenticated `404 model_not_found` response instead of the model catalog.

Registering `/v1/models/` directly makes that request return the same OpenAI-compatible catalog as `/v1/models`.

DEVONthink documents the required discovery endpoint here: https://discourse.devontechnologies.com/t/how-to-use-an-api-gateway/84925/5

## Validation

- `python3 -m py_compile studio/backend/routes/inference.py studio/backend/tests/test_openai_auto_switch.py`
- verified both route decorators and the `get_current_subject` dependency via AST
- `git diff --check`