### PR TITLE
Run the tool-activity browser suite, and read models.py as UTF-8

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -24,6 +24,7 @@ on:
       - 'tests/studio/playwright_heavy_thread.py'
       - 'tests/studio/probe_dismiss_guard.py'
       - 'tests/studio/playwright_settings_tabs.py'
+      - 'tests/studio/playwright_tool_activity.py'
       - 'tests/studio/playwright_keyboard_shortcuts.py'
       - 'tests/studio/playwright_stream_pacing.py'
       - 'tests/studio/playwright_code_block_flicker.py'
@@ -424,6 +425,15 @@ jobs:
       - name: Browser smoke for the settings tab panels
         working-directory: ${{ github.workspace }}
         run: python3 tests/studio/playwright_settings_tabs.py
+
+      # The node suite reaches the reducers, the store and the JSX wiring through the
+      # TypeScript AST, and none of that sees a Radix Collapsible: whether closed content
+      # is still in the DOM, what aria-expanded says, and where the page lands after a
+      # collapse are browser questions. Added by #9803 without a step, so it ran nowhere
+      # and every job stayed green over it.
+      - name: Browser smoke for the collapse-tool-activity preference
+        working-directory: ${{ github.workspace }}
+        run: python3 tests/studio/playwright_tool_activity.py
 
       # A listener is not a pure function: what a chord does to a focused button, to a
       # text field, on auto-repeat, or under AltGr is only answerable in a browser, and

--- a/studio/backend/tests/test_memory_contract.py
+++ b/studio/backend/tests/test_memory_contract.py
@@ -175,7 +175,7 @@ class TestTheRouteOverrides:
         """
         from pathlib import Path
 
-        source = (Path(__file__).resolve().parent.parent / "routes" / "models.py").read_text()
+        source = (Path(__file__).resolve().parent.parent / "routes" / "models.py").read_text(encoding = "utf-8")
         for field in ("gpu_bytes", "compute_bytes", "total_bytes", "n_ctx"):
             assert f"_estimate.{field} =" not in source, (
                 f"routes/models.py assigns {field} onto a built MemoryEstimate. "

--- a/studio/backend/tests/test_memory_contract.py
+++ b/studio/backend/tests/test_memory_contract.py
@@ -175,7 +175,9 @@ class TestTheRouteOverrides:
         """
         from pathlib import Path
 
-        source = (Path(__file__).resolve().parent.parent / "routes" / "models.py").read_text(encoding = "utf-8")
+        source = (Path(__file__).resolve().parent.parent / "routes" / "models.py").read_text(
+            encoding = "utf-8"
+        )
         for field in ("gpu_bytes", "compute_bytes", "total_bytes", "n_ctx"):
             assert f"_estimate.{field} =" not in source, (
                 f"routes/models.py assigns {field} onto a built MemoryEstimate. "


### PR DESCRIPTION
`Repo tests (CPU)` is red on `main`, so every PR branched from it inherits two failures that have nothing to do with the PR. Both guards are correct and both offending changes are wrong, so this fixes the offending side rather than the guards.

## The orphaned Playwright suite

`tests/studio/playwright_tool_activity.py` arrived with #9803 and no workflow step, so it ran nowhere and every job stayed green over it. `test_playwright_suites_run_in_ci.py` exists to catch exactly that.

It gets a step rather than a `NOT_IN_CI` entry because it is a gate, not a measurement harness: it drives `studio/frontend/smoke-tool-activity.html` through 13 scenes and exits non-zero when one misses its expectation. The questions it asks are not reachable from the node suite, which sees the reducers, the store and the JSX wiring through the TypeScript AST but never a Radix Collapsible: whether closed content is still in the DOM, what `aria-expanded` says, and where the page lands after a collapse.

Placed next to the settings-tabs smoke, whose `PW_ENGINE` convention it already documents itself as following, with the matching `paths` filter entry so it triggers on its own edits.

## The encoding

`test_memory_contract.py:178` read `routes/models.py` with the platform default encoding, which breaks on Windows as soon as that file gains a non-ASCII byte. Added by #9830. `tests/test_source_read_encoding.py` is the guard.

## Verification

`tests/test_source_read_encoding.py` and `tests/studio/test_playwright_suites_run_in_ci.py`: 8 passed. Workflow YAML parses.
