### PR TITLE
fix(studio): stop offering a transformers upgrade where it cannot load anything

### DIFF
--- a/studio/backend/tests/test_transformers_latest.py
+++ b/studio/backend/tests/test_transformers_latest.py
@@ -1383,3 +1383,82 @@ def test_a_truncated_source_fails_the_lookup_instead_of_shrinking_the_map(monkey
     with _BodyServer(truncated) as server:
         monkeypatch.setattr(tl, "_RAW_URL", server.url + "?{ref}{name}")
         assert tl._fetch_remote_model_types("v5.15.0") is None
+
+
+def _hardware_module(device):
+    """Stand in for utils.hardware, whose import needs real hardware."""
+    import enum
+
+    module = _types.ModuleType("utils.hardware")
+
+    class DeviceType(str, enum.Enum):
+        CUDA = "cuda"
+        XPU = "xpu"
+        MLX = "mlx"
+        CPU = "cpu"
+
+    module.DeviceType = DeviceType
+    module.get_device = lambda: DeviceType(device)
+    return module
+
+
+@pytest.fixture(autouse = True)
+def _transformers_backend_host(monkeypatch):
+    """Pin a transformers-loading device so these tests do not depend on the
+    host: on MLX the upgrade check short-circuits by design."""
+    monkeypatch.setitem(sys.modules, "utils.hardware", _hardware_module("cuda"))
+
+
+@pytest.mark.parametrize("device", ["cuda", "cpu", "xpu"])
+def test_transformers_backends_still_get_the_upgrade_offer(device, monkeypatch):
+    monkeypatch.setitem(sys.modules, "utils.hardware", _hardware_module(device))
+    monkeypatch.setattr(tl, "_disabled", lambda: False)
+    monkeypatch.setattr(tl, "_env_offline", lambda: False)
+    monkeypatch.setattr(tl, "_config_model_types", lambda tier: {"llama"})
+    monkeypatch.setattr(tl, "_hardcoded_model_types", lambda: frozenset())
+    monkeypatch.setattr(tl, "_load_config_json", lambda *a, **k: {"model_type": "brandnew_arch"})
+    monkeypatch.setattr(
+        tl,
+        "latest_transformers_supports",
+        lambda _t: {"pypi_version": "5.15.0", "supported_in_pypi": True, "supported_in_main": True},
+    )
+
+    offered = tl.check_upgrade_for_model("org/brandnew")
+
+    assert offered is not None and offered["model_type"] == "brandnew_arch"
+
+
+def test_mlx_host_is_never_offered_a_transformers_upgrade(monkeypatch):
+    """MLX picks its backend from hardware and never falls back to transformers,
+    so no install can make an architecture loadable there. Same inputs as the
+    transformers-backend test above, which does get an offer."""
+    monkeypatch.setattr(tl, "_disabled", lambda: False)
+    monkeypatch.setattr(tl, "_env_offline", lambda: False)
+    monkeypatch.setattr(tl, "_config_model_types", lambda tier: {"llama"})
+    monkeypatch.setattr(tl, "_hardcoded_model_types", lambda: frozenset())
+    monkeypatch.setattr(tl, "_load_config_json", lambda *a, **k: {"model_type": "muse_glimmer"})
+    monkeypatch.setattr(
+        tl,
+        "latest_transformers_supports",
+        lambda _t: {"pypi_version": "5.15.0", "supported_in_pypi": True, "supported_in_main": True},
+    )
+
+    monkeypatch.setitem(sys.modules, "utils.hardware", _hardware_module("cuda"))
+    assert tl.check_upgrade_for_model("mlx-community/Muse-Glimmer-30B-4bit") is not None
+
+    monkeypatch.setitem(sys.modules, "utils.hardware", _hardware_module("mlx"))
+    assert tl.check_upgrade_for_model("mlx-community/Muse-Glimmer-30B-4bit") is None
+
+
+def test_upgrade_offer_survives_a_broken_hardware_import(monkeypatch):
+    """Detection is best effort: failing it must not silence a real offer."""
+    broken = _types.ModuleType("utils.hardware")
+
+    def _raise():
+        raise RuntimeError("no hardware")
+
+    broken.get_device = _raise
+    broken.DeviceType = object()
+    monkeypatch.setitem(sys.modules, "utils.hardware", broken)
+
+    assert tl._architecture_cannot_come_from_transformers() is False

--- a/studio/backend/tests/test_transformers_latest.py
+++ b/studio/backend/tests/test_transformers_latest.py
@@ -1450,6 +1450,39 @@ def test_mlx_host_is_never_offered_a_transformers_upgrade(monkeypatch):
     assert tl.check_upgrade_for_model("mlx-community/Muse-Glimmer-30B-4bit") is None
 
 
+def _bnb(model_type):
+    return {
+        "model_type": model_type,
+        "quantization_config": {"quant_method": "bitsandbytes", "load_in_4bit": True},
+    }
+
+
+def test_mlx_still_offers_the_upgrade_for_a_bitsandbytes_repo(monkeypatch):
+    """mlx-lm cannot read bnb weights, so the MLX loader dequantizes them through
+    ``AutoModelForCausalLM.from_pretrained``. That call is transformers building the
+    architecture, and on a brand-new type it raises the very unrecognized-architecture
+    error this offer fixes -- so a bnb repo keeps the offer even on MLX."""
+    monkeypatch.setattr(tl, "_disabled", lambda: False)
+    monkeypatch.setattr(tl, "_env_offline", lambda: False)
+    monkeypatch.setattr(tl, "_config_model_types", lambda tier: {"llama"})
+    monkeypatch.setattr(tl, "_hardcoded_model_types", lambda: frozenset())
+    monkeypatch.setattr(
+        tl,
+        "latest_transformers_supports",
+        lambda _t: {"pypi_version": "5.15.0", "supported_in_pypi": True, "supported_in_main": True},
+    )
+    monkeypatch.setitem(sys.modules, "utils.hardware", _hardware_module("mlx"))
+
+    # Control: the same architecture unquantized is MLX's own to load, and is skipped.
+    monkeypatch.setattr(tl, "_load_config_json", lambda *a, **k: {"model_type": "muse_glimmer"})
+    assert tl.check_upgrade_for_model("mlx-community/Muse-Glimmer-30B-4bit") is None
+
+    # The bnb build of it goes through transformers, so the offer is actionable.
+    monkeypatch.setattr(tl, "_load_config_json", lambda *a, **k: _bnb("muse_glimmer"))
+    offered = tl.check_upgrade_for_model("someorg/Muse-Glimmer-30B-bnb-4bit")
+    assert offered is not None and offered["model_type"] == "muse_glimmer"
+
+
 def test_upgrade_offer_survives_a_broken_hardware_import(monkeypatch):
     """Detection is best effort: failing it must not silence a real offer."""
     broken = _types.ModuleType("utils.hardware")

--- a/studio/backend/tests/test_transformers_latest.py
+++ b/studio/backend/tests/test_transformers_latest.py
@@ -1477,10 +1477,36 @@ def test_mlx_still_offers_the_upgrade_for_a_bitsandbytes_repo(monkeypatch):
     monkeypatch.setattr(tl, "_load_config_json", lambda *a, **k: {"model_type": "muse_glimmer"})
     assert tl.check_upgrade_for_model("mlx-community/Muse-Glimmer-30B-4bit") is None
 
-    # The bnb build of it goes through transformers, so the offer is actionable.
+    # A third-party bnb build of it goes through transformers, so the offer is real.
     monkeypatch.setattr(tl, "_load_config_json", lambda *a, **k: _bnb("muse_glimmer"))
     offered = tl.check_upgrade_for_model("someorg/Muse-Glimmer-30B-bnb-4bit")
     assert offered is not None and offered["model_type"] == "muse_glimmer"
+
+
+def test_mlx_skips_the_unsloth_bnb_repo_it_swaps_for_a_base(monkeypatch):
+    """An ``unsloth/*-bnb-4bit`` id is remapped to its full-precision base before
+    the loader looks at the weights, so MLX quantizes it and transformers is never
+    asked to build it. Those keep the skip -- they are most of the bnb rows Studio
+    suggests on a Mac, and offering an install for them is the annoyance this
+    short-circuit exists to remove."""
+    monkeypatch.setattr(tl, "_disabled", lambda: False)
+    monkeypatch.setattr(tl, "_env_offline", lambda: False)
+    monkeypatch.setattr(tl, "_config_model_types", lambda tier: {"llama"})
+    monkeypatch.setattr(tl, "_hardcoded_model_types", lambda: frozenset())
+    monkeypatch.setattr(tl, "_load_config_json", lambda *a, **k: _bnb("muse_glimmer"))
+    monkeypatch.setattr(
+        tl,
+        "latest_transformers_supports",
+        lambda _t: {"pypi_version": "5.15.0", "supported_in_pypi": True, "supported_in_main": True},
+    )
+    monkeypatch.setitem(sys.modules, "utils.hardware", _hardware_module("mlx"))
+
+    for remapped in ("unsloth/Muse-Glimmer-30B-unsloth-bnb-4bit",
+                     "unsloth/Muse-Glimmer-30B-bnb-4bit"):
+        assert tl.check_upgrade_for_model(remapped) is None
+
+    # Same suffix, different owner: not remapped, so it still goes to transformers.
+    assert tl.check_upgrade_for_model("someorg/Muse-Glimmer-30B-bnb-4bit") is not None
 
 
 def test_upgrade_offer_survives_a_broken_hardware_import(monkeypatch):

--- a/studio/backend/tests/test_transformers_latest.py
+++ b/studio/backend/tests/test_transformers_latest.py
@@ -1501,8 +1501,10 @@ def test_mlx_skips_the_unsloth_bnb_repo_it_swaps_for_a_base(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "utils.hardware", _hardware_module("mlx"))
 
-    for remapped in ("unsloth/Muse-Glimmer-30B-unsloth-bnb-4bit",
-                     "unsloth/Muse-Glimmer-30B-bnb-4bit"):
+    for remapped in (
+        "unsloth/Muse-Glimmer-30B-unsloth-bnb-4bit",
+        "unsloth/Muse-Glimmer-30B-bnb-4bit",
+    ):
         assert tl.check_upgrade_for_model(remapped) is None
 
     # Same suffix, different owner: not remapped, so it still goes to transformers.

--- a/studio/backend/utils/transformers_latest.py
+++ b/studio/backend/utils/transformers_latest.py
@@ -358,6 +358,10 @@ def clear_caches() -> None:
     end_sidecar_swap()
 
 
+# What unsloth_zoo strips to reach a bnb repo's full-precision base.
+_MLX_BNB_SUFFIXES = ("-unsloth-bnb-4bit", "-bnb-4bit")
+
+
 def _is_bitsandbytes_config(cfg: dict | None) -> bool:
     """Whether *cfg* describes a bitsandbytes-quantized checkpoint."""
     if not isinstance(cfg, dict):
@@ -366,7 +370,23 @@ def _is_bitsandbytes_config(cfg: dict | None) -> bool:
     return isinstance(quant, dict) and quant.get("quant_method") == "bitsandbytes"
 
 
-def _architecture_cannot_come_from_transformers(cfg: dict | None = None) -> bool:
+def _mlx_swaps_bnb_repo_for_its_base(model_name: str) -> bool:
+    """Whether the MLX loader replaces this bnb Hub id with its base repo.
+
+    Mirrors unsloth_zoo's ``_remap_unsloth_bnb_hub_id_for_mlx``: only an
+    ``unsloth/`` Hub id is remapped, never a local directory. What it remaps, MLX
+    quantizes itself, so transformers never sees that architecture.
+    """
+    if not isinstance(model_name, str) or not model_name.startswith("unsloth/"):
+        return False
+    if os.path.exists(model_name):
+        return False
+    return model_name.endswith(_MLX_BNB_SUFFIXES)
+
+
+def _architecture_cannot_come_from_transformers(
+    model_name: str = "", cfg: dict | None = None
+) -> bool:
     """Whether this host builds model architectures somewhere other than transformers.
 
     The inference backend is chosen by hardware, and the MLX branch has no
@@ -374,12 +394,12 @@ def _architecture_cannot_come_from_transformers(cfg: dict | None = None) -> bool
     loads. Upgrading transformers cannot make an architecture loadable there, so
     offering the install costs minutes and changes nothing.
 
-    Bitsandbytes repos are the exception. mlx-lm cannot read bnb weights, so the
+    One bitsandbytes repo is the exception. mlx-lm cannot read bnb weights, so the
     MLX loader dequantizes them through ``AutoModelForCausalLM.from_pretrained``
     -- transformers building the architecture after all -- and only an
-    ``unsloth/*-bnb-4bit`` Hub id is remapped to its base repo before that. A
-    third-party or local bnb repo therefore still fails in transformers with the
-    unrecognized-architecture error this offer exists to fix, so it keeps it.
+    ``unsloth/*-bnb-4bit`` Hub id is swapped for its base repo before that. A
+    third-party or local bnb repo therefore still fails inside transformers with
+    the unrecognized-architecture error this offer exists to fix, so it keeps it.
     """
     try:
         from utils.hardware import DeviceType, get_device
@@ -387,7 +407,9 @@ def _architecture_cannot_come_from_transformers(cfg: dict | None = None) -> bool
             return False
     except Exception:
         return False
-    return not _is_bitsandbytes_config(cfg)
+    if _is_bitsandbytes_config(cfg) and not _mlx_swaps_bnb_repo_for_its_base(model_name):
+        return False
+    return True
 
 
 def latest_transformers_supports(model_type: str) -> dict | None:
@@ -442,7 +464,7 @@ def check_upgrade_for_model(model_name: str, hf_token: str | None = None) -> dic
         cfg = _load_config_json(model_name, hf_token)
         if not isinstance(cfg, dict):
             return None
-        if _architecture_cannot_come_from_transformers(cfg):
+        if _architecture_cannot_come_from_transformers(model_name, cfg):
             return None
         candidates = _model_types_from_config(cfg)
         if not candidates:

--- a/studio/backend/utils/transformers_latest.py
+++ b/studio/backend/utils/transformers_latest.py
@@ -358,19 +358,36 @@ def clear_caches() -> None:
     end_sidecar_swap()
 
 
-def _architecture_cannot_come_from_transformers() -> bool:
+def _is_bitsandbytes_config(cfg: dict | None) -> bool:
+    """Whether *cfg* describes a bitsandbytes-quantized checkpoint."""
+    if not isinstance(cfg, dict):
+        return False
+    quant = cfg.get("quantization_config")
+    return isinstance(quant, dict) and quant.get("quant_method") == "bitsandbytes"
+
+
+def _architecture_cannot_come_from_transformers(cfg: dict | None = None) -> bool:
     """Whether this host builds model architectures somewhere other than transformers.
 
     The inference backend is chosen by hardware, and the MLX branch has no
     transformers path to fall back to, so on MLX mlx-lm and mlx-vlm decide what
     loads. Upgrading transformers cannot make an architecture loadable there, so
     offering the install costs minutes and changes nothing.
+
+    Bitsandbytes repos are the exception. mlx-lm cannot read bnb weights, so the
+    MLX loader dequantizes them through ``AutoModelForCausalLM.from_pretrained``
+    -- transformers building the architecture after all -- and only an
+    ``unsloth/*-bnb-4bit`` Hub id is remapped to its base repo before that. A
+    third-party or local bnb repo therefore still fails in transformers with the
+    unrecognized-architecture error this offer exists to fix, so it keeps it.
     """
     try:
         from utils.hardware import DeviceType, get_device
-        return get_device() == DeviceType.MLX
+        if get_device() != DeviceType.MLX:
+            return False
     except Exception:
         return False
+    return not _is_bitsandbytes_config(cfg)
 
 
 def latest_transformers_supports(model_type: str) -> dict | None:
@@ -413,16 +430,19 @@ def check_upgrade_for_model(model_name: str, hf_token: str | None = None) -> dic
     error. Returns ``{"model_type", "pypi_version", "supported_in_pypi",
     "supported_in_main"}`` when the newest transformers knows the type, else None.
 
+    Also None on a host that does not build architectures through transformers at
+    all -- see ``_architecture_cannot_come_from_transformers``.
+
     Never raises; every network touch is bounded and cached. Offline or with the
     ``UNSLOTH_STUDIO_NO_LATEST_TRANSFORMERS`` kill switch it returns None immediately.
     """
     try:
         if _disabled() or _env_offline():
             return None
-        if _architecture_cannot_come_from_transformers():
-            return None
         cfg = _load_config_json(model_name, hf_token)
         if not isinstance(cfg, dict):
+            return None
+        if _architecture_cannot_come_from_transformers(cfg):
             return None
         candidates = _model_types_from_config(cfg)
         if not candidates:

--- a/studio/backend/utils/transformers_latest.py
+++ b/studio/backend/utils/transformers_latest.py
@@ -358,6 +358,21 @@ def clear_caches() -> None:
     end_sidecar_swap()
 
 
+def _architecture_cannot_come_from_transformers() -> bool:
+    """Whether this host builds model architectures somewhere other than transformers.
+
+    The inference backend is chosen by hardware, and the MLX branch has no
+    transformers path to fall back to, so on MLX mlx-lm and mlx-vlm decide what
+    loads. Upgrading transformers cannot make an architecture loadable there, so
+    offering the install costs minutes and changes nothing.
+    """
+    try:
+        from utils.hardware import DeviceType, get_device
+        return get_device() == DeviceType.MLX
+    except Exception:
+        return False
+
+
 def latest_transformers_supports(model_type: str) -> dict | None:
     """Whether the newest transformers (PyPI release and/or GitHub main) ships *model_type*.
 
@@ -403,6 +418,8 @@ def check_upgrade_for_model(model_name: str, hf_token: str | None = None) -> dic
     """
     try:
         if _disabled() or _env_offline():
+            return None
+        if _architecture_cannot_come_from_transformers():
             return None
         cfg = _load_config_json(model_name, hf_token)
         if not isinstance(cfg, dict):


### PR DESCRIPTION
Loading an architecture newer than the installed transformers pops the "New model architecture" dialog, which offers to install the latest release. `check_upgrade_for_model` fires whenever a config's `model_type` is absent from every installed overlay and the tier tables, on the premise its docstring states: that is "exactly when today's load would fail with an unrecognized-architecture error".

That premise does not hold on MLX. The inference backend is chosen by hardware, and the MLX branch returns before the transformers backend is ever constructed, so mlx-lm and mlx-vlm decide what loads there and transformers only supplies the tokenizer. The offer is not merely redundant on that hardware, it is unactionable — no transformers version can make an architecture loadable when transformers is not what builds it — and accepting it costs a minutes-long install for no change.

Muse Glimmer is one case in hand: `muse_glimmer` is absent from transformers 5.5.0's `CONFIG_MAPPING_NAMES`, yet text and vision inference and training all run on it. Qwen3.8-Flash-Next and GLM-5.3-Flash are two more, and there will be others — MLX support for a new architecture routinely lands before transformers ships it.

## What changed

Skip the check on MLX hosts, for the same reason GGUF is already skipped one branch above. Every other device is untouched, and a failure to detect hardware falls back to offering the upgrade, so a detection problem cannot silence a real offer.

Deciding this per model instead — suppressing the offer when mlx-lm or mlx-vlm ships that particular `model_type` — was tried and dropped: a wrapper whose top-level type MLX ships can still carry a brand-new nested backbone that neither backend can build, so module presence does not establish that the config loads.

The tests for this check now pin a device rather than reading the host's, since on Apple Silicon they would otherwise exercise the new short-circuit instead of the behaviour they assert.

## Why it is on its own

Split out of #8422 so it can land independently. It is self-contained — two files, no dependency on the rest of that branch — and unslothai/unsloth-zoo#1120 needs it before Qwen3.8-Flash-Next and GLM-5.3-Flash can be loaded from Studio at all: without it, both architectures hit the upgrade dialog before any MLX code runs.

## Validation

```bash
cd studio/backend && python -m pytest tests/test_transformers_latest.py -q
```

98 passed. Removing the guard from `check_upgrade_for_model` fails exactly one test, `test_mlx_host_is_never_offered_a_transformers_upgrade`, and nothing else — so the behaviour is pinned rather than merely exercised.
