### PR TITLE
fix(studio): preserve model-specific target modules (e.g. all-linear) in CPT transition (#9866)

### DIFF
--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -285,14 +285,21 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
                 : null;
 
             // Preserve CPT hyperparams: YAML adapter defaults are tuned for standard LoRA.
+            // Target modules are the exception - a model-specific default (e.g. LFM2's
+            // "all-linear") must survive into CPT rather than being clobbered by the
+            // generic Llama-style CPT fallback.
             const cptOverrides =
               shouldApplyTrainingDefaults && get().trainingMethod === "cpt"
-                ? getCptModelDefaultsPatch()
+                ? getCptModelDefaultsPatch(
+                    modelDefaultsPatch.targetModules ?? get().targetModules,
+                  )
                 : {};
             const modelDefaultsBaseline = {
               ...modelDefaultsPatch,
               ...(get().trainingMethod === "cpt"
-                ? getCptModelDefaultsPatch()
+                ? getCptModelDefaultsPatch(
+                    modelDefaultsPatch.targetModules ?? get().targetModules,
+                  )
                 : {}),
             };
             const advancedSettingsBaseline =

--- a/studio/frontend/src/features/training/stores/training-method-transition.ts
+++ b/studio/frontend/src/features/training/stores/training-method-transition.ts
@@ -29,20 +29,38 @@ type TrainingMethodStatePatch = Partial<
   >
 >;
 
-function getCptTrainingPatch(): TrainingMethodStatePatch {
+function arraysEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+// A model whose default target modules differ from the generic Llama-style
+// list (e.g. LFM2's "all-linear") has declared an architecture-specific LoRA
+// target. CPT must not clobber that with the hard-coded Llama fallback.
+function resolveCptTargetModules(currentTargetModules: string[]): string[] {
+  const isModelSpecific =
+    currentTargetModules.length > 0 &&
+    !arraysEqual(currentTargetModules, TARGET_MODULES);
+  return isModelSpecific ? currentTargetModules : CPT_TARGET_MODULES;
+}
+
+function getCptTrainingPatch(
+  currentTargetModules: string[],
+): TrainingMethodStatePatch {
   return {
     loraRank: 128,
     loraAlpha: 32,
     loraVariant: "rslora",
-    targetModules: CPT_TARGET_MODULES,
+    targetModules: resolveCptTargetModules(currentTargetModules),
     datasetFormat: "raw",
     trainOnCompletions: false,
   };
 }
 
-export function getCptModelDefaultsPatch(): TrainingMethodStatePatch {
+export function getCptModelDefaultsPatch(
+  currentTargetModules: string[],
+): TrainingMethodStatePatch {
   return {
-    ...getCptTrainingPatch(),
+    ...getCptTrainingPatch(currentTargetModules),
     learningRate: LR_DEFAULT_CPT,
   };
 }
@@ -87,7 +105,10 @@ function resolveTrainingMethodLearningRate(
 export function buildTrainingMethodPatch(
   state: Pick<
     TrainingConfigState,
-    "trainingMethod" | "trainingMethodProvenance" | "datasetFormat"
+    | "trainingMethod"
+    | "trainingMethodProvenance"
+    | "datasetFormat"
+    | "targetModules"
   >,
   nextMethod: TrainingMethod,
 ): TrainingMethodStatePatch {
@@ -101,7 +122,7 @@ export function buildTrainingMethodPatch(
     )
       ? null
       : state.datasetFormat;
-    Object.assign(patch, getCptTrainingPatch());
+    Object.assign(patch, getCptTrainingPatch(state.targetModules));
   }
   if (prevMethod === "cpt" && nextMethod !== "cpt") {
     Object.assign(patch, getRestoreFromCptPatch());


### PR DESCRIPTION
### Summary
Fixes #9866 where transitioning to CPT mode in Studio unconditionally overrode model-specific `target_modules` (such as LFM2's `"all-linear"`) with the hard-coded Llama target module list.

### Cause
`getCptTrainingPatch()` in `studio/frontend/src/features/training/stores/training-method-transition.ts` and `training-config-store.ts` were setting `targetModules: CPT_TARGET_MODULES` unconditionally upon transitioning to CPT or reloading model YAML defaults while in CPT mode. This silently degraded training on non-Llama architectures like `LiquidAI/LFM2-1.2B`, reducing trainable modules from 92 (11.1M params) down to 18 (0.88M params).

### Fix
- Introduced `resolveCptTargetModules()` to check whether the active model specifies an architecture-specific target module configuration (e.g., `"all-linear"`).
- Preserves model defaults if present; otherwise falls back to the generic CPT target list.
- Threaded current target modules across `getCptTrainingPatch`, `getCptModelDefaultsPatch`, and `buildTrainingMethodPatch`.

### Validation
- Confirmed minimal Python reproduction wraps all 92 modules / 11.1M parameters on `LiquidAI/LFM2-1.2B`.
- `npm run typecheck` passed clean.
- `npm test` passed clean (5,813 tests).