### PR TITLE
studio: tell users when a canvas is blocked by the network access setting

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -25,6 +25,7 @@ on:
       - 'tests/studio/probe_dismiss_guard.py'
       - 'tests/studio/playwright_settings_tabs.py'
       - 'tests/studio/playwright_keyboard_shortcuts.py'
+      - 'tests/studio/playwright_tool_activity.py'
       - 'tests/studio/playwright_stream_pacing.py'
       - 'tests/studio/playwright_code_block_flicker.py'
       - 'tests/studio/_code_block_flicker_analysis.py'
@@ -433,6 +434,12 @@ jobs:
       - name: Browser smoke for keyboard shortcuts
         working-directory: ${{ github.workspace }}
         run: python3 tests/studio/playwright_keyboard_shortcuts.py
+
+      - name: Browser smoke for tool activity collapse
+        working-directory: ${{ github.workspace }}
+        env:
+          PW_ENGINE: chromium
+        run: python3 tests/studio/playwright_tool_activity.py --json
 
       # A panel that cannot be fetched is new with lazy loading, and nothing above the
       # root-mounted dialog catches, so unguarded it unmounts Unsloth, not one panel.

--- a/studio/backend/tests/test_gpu_init_crash_message.py
+++ b/studio/backend/tests/test_gpu_init_crash_message.py
@@ -206,7 +206,7 @@ def _run_cpu_fallback_load(
         )
         if not available:
             return None
-        return ["/staged/llama-server", "--device", "none"], None
+        return ["/staged/llama-server", "--device", "none"], None, None
 
     backend._wait_for_health = _wait_for_health
     backend._prepare_cpu_fallback_launch = _prepare_cpu_fallback
@@ -614,7 +614,7 @@ class TestCpuIsolatedReplay:
 
         prepared = backend._prepare_cpu_fallback_launch("/original/server", ["original"], env, {})
 
-        assert prepared == (["/staged/server", "--device", "none"], None)
+        assert prepared == (["/staged/server", "--device", "none"], None, None)
         assert env[loader_path] == "/staged/libs"
         assert env["KEEP"] == "1"
 

--- a/studio/backend/tests/test_memory_contract.py
+++ b/studio/backend/tests/test_memory_contract.py
@@ -175,7 +175,9 @@ class TestTheRouteOverrides:
         """
         from pathlib import Path
 
-        source = (Path(__file__).resolve().parent.parent / "routes" / "models.py").read_text()
+        source = (Path(__file__).resolve().parent.parent / "routes" / "models.py").read_text(
+            encoding = "utf-8"
+        )
         for field in ("gpu_bytes", "compute_bytes", "total_bytes", "n_ctx"):
             assert f"_estimate.{field} =" not in source, (
                 f"routes/models.py assigns {field} onto a built MemoryEstimate. "

--- a/studio/frontend/smoke-tool-activity-main.tsx
+++ b/studio/frontend/smoke-tool-activity-main.tsx
@@ -19,15 +19,6 @@
 
 import "@/index.css";
 
-// Load-bearing import order. `tool-group.tsx` reaches the `@/features/chat`
-// barrel, which re-exports chat-runtime-store, which sits in a cycle with it;
-// entering that graph from the barrel or from `assistant-ui/thread` dies with
-// "Cannot access 'CHAT_GPU_MEMORY_MODE_KEY' before initialization". Entering
-// from the store module orders it correctly. Observed, not theorised, and a
-// property of the app's module graph rather than of anything under test.
-/* eslint-disable no-restricted-imports -- a harness entry point, not app code. */
-import "@/features/chat/stores/chat-runtime-store";
-
 import {
   ToolFallbackContent,
   ToolFallbackRoot,

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -447,14 +447,17 @@ function RootLayout() {
 
   // Gated like the workspace chords below: /login has no shell, and /chat
   // bounces straight back off requireAuth.
-  useShortcut("newChat", () => startNewChat(), { enabled: !isAuthFlowRoute });
+  const routeShortcutEnabled = !isAuthFlowRoute && !settingsDialogOpen;
+  useShortcut("newChat", () => startNewChat(), {
+    enabled: routeShortcutEnabled,
+  });
   useShortcut(
     "newTemporaryChat",
     () => startNewChat({ incognito: true, standalone: true }),
-    { enabled: !isAuthFlowRoute },
+    { enabled: routeShortcutEnabled },
   );
   useShortcut("newStandaloneChat", () => startNewChat({ standalone: true }), {
-    enabled: !isAuthFlowRoute,
+    enabled: routeShortcutEnabled,
   });
 
   // Workspaces. The shell is mounted on every route, so the chords live here.
@@ -464,32 +467,40 @@ function RootLayout() {
   useShortcut(
     "switchToChat",
     () => void navigate({ to: "/chat", search: chatSearch }),
-    { enabled: !isAuthFlowRoute },
+    { enabled: routeShortcutEnabled },
   );
   useShortcut("switchToProjects", goTo("/projects"), {
-    enabled: !isAuthFlowRoute,
+    enabled: routeShortcutEnabled,
   });
-  useShortcut("switchToHub", goTo("/hub"), { enabled: !isAuthFlowRoute });
+  useShortcut("switchToHub", goTo("/hub"), {
+    enabled: routeShortcutEnabled,
+  });
   // Train is the one workspace the chat-only guard turns away, so its chord is
   // the one that has to ask first: firing it on a host without the hardware
   // would bounce off /studio and land the user on /chat, away from whatever
   // they had open. The sidebar disables the row on the same measured check,
   // and only once measured, since the guess is what the row waits out too.
   useShortcut("switchToTrain", goTo("/studio"), {
-    enabled: !isAuthFlowRoute && !chatOnlyMeasured,
+    enabled: routeShortcutEnabled && !chatOnlyMeasured,
   });
   useShortcut("switchToRecipes", goTo("/data-recipes"), {
-    enabled: !isAuthFlowRoute,
+    enabled: routeShortcutEnabled,
   });
-  useShortcut("switchToImages", goTo("/images"), { enabled: !isAuthFlowRoute });
+  useShortcut("switchToImages", goTo("/images"), {
+    enabled: routeShortcutEnabled,
+  });
   // /video checks auth and nothing else, so an ungated chord would put the
   // unsupported-hardware gate where the user's workspace was. Train's chord
   // waits on the same measurement; this one has its own predicate to wait on.
   useShortcut("switchToVideo", goTo("/video"), {
-    enabled: !isAuthFlowRoute && !videoDisabled,
+    enabled: routeShortcutEnabled && !videoDisabled,
   });
-  useShortcut("switchToAudio", goTo("/audio"), { enabled: !isAuthFlowRoute });
-  useShortcut("switchToExport", goTo("/export"), { enabled: !isAuthFlowRoute });
+  useShortcut("switchToAudio", goTo("/audio"), {
+    enabled: routeShortcutEnabled,
+  });
+  useShortcut("switchToExport", goTo("/export"), {
+    enabled: routeShortcutEnabled,
+  });
 
   useEffect(() => {
     if (isChatRoute) return;

--- a/studio/frontend/src/components/assistant-ui/tool-group.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-group.tsx
@@ -10,12 +10,12 @@ import {
 } from "react";
 import { useAuiState } from "@assistant-ui/react";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { useChatPreferencesStore } from "@/features/chat/stores/chat-preferences-store";
 import {
   toolOutputKey,
-  useChatPreferencesStore,
   useToolPaneScope,
   useUnresolvedToolPaneScope,
-} from "@/features/chat";
+} from "@/features/chat/tool-output-scope";
 import { ChevronDownIcon } from "lucide-react";
 import { Wrench01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";

--- a/studio/frontend/src/components/ui/alert.tsx
+++ b/studio/frontend/src/components/ui/alert.tsx
@@ -7,7 +7,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
-  "grid gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 w-full relative group/alert",
+  "grid gap-0.5 rounded-lg border px-4 py-3 text-start text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pe-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 w-full relative group/alert",
   {
     variants: {
       variant: {
@@ -70,7 +70,7 @@ function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-action"
-      className={cn("absolute top-2.5 right-3", className)}
+      className={cn("absolute top-2.5 end-3", className)}
       {...props}
     />
   );

--- a/studio/frontend/src/features/chat/artifacts/artifact-surface.tsx
+++ b/studio/frontend/src/features/chat/artifacts/artifact-surface.tsx
@@ -110,6 +110,7 @@ export function ArtifactSurface({
   const [copied, setCopied] = useState(false);
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const surfaceRef = useRef<HTMLElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const previousFocusRef = useRef<Element | null>(null);
   const filename = getArtifactFilename(artifact);
   const sourceMarkdown = useMemo(
@@ -312,6 +313,7 @@ export function ArtifactSurface({
             </Button>
           ) : null}
           <Button
+            ref={closeButtonRef}
             type="button"
             variant="ghost"
             size="icon"
@@ -344,6 +346,9 @@ export function ArtifactSurface({
             title={artifact.title}
             fill={true}
             className="h-full"
+            actionFocusTargetRef={
+              variant === "overlay" ? closeButtonRef : undefined
+            }
           />
         ) : (
           <div className="h-full overflow-auto text-xs leading-relaxed [&_[data-streamdown=code-block]]:!my-0 [&_[data-streamdown=code-block]]:!gap-0 [&_[data-streamdown=code-block]]:!rounded-none [&_[data-streamdown=code-block]]:!border-0 [&_[data-streamdown=code-block]]:!bg-transparent [&_[data-streamdown=code-block]]:!p-0 [&_[data-streamdown=code-block-body]]:!border-0 [&_[data-streamdown=code-block-body]]:!bg-transparent [&_[data-streamdown=code-block-body]]:!p-0 [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:text-xs [&_pre]:leading-relaxed [&_code]:text-xs">

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -3,14 +3,19 @@
 
 "use client";
 
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 // eslint-disable-next-line no-restricted-imports -- the settings barrel imports this feature back
 import { useSettingsDialogStore } from "@/features/settings/stores/settings-dialog-store";
 import { useT } from "@/i18n";
 import { apiUrl } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
-import { ShieldAlertIcon } from "lucide-react";
+import { ShieldAlertIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import { hashArtifactCode } from "./types";
@@ -129,6 +134,8 @@ export function ArtifactHtmlFrame({
   const [grantedCode, setGrantedCode] = useState<string | null>(null);
   const grantedForCanvas = grantedCode === code;
   const networkAllowed = networkAccessEnabled || grantedForCanvas;
+  const [dismissedCode, setDismissedCode] = useState<string | null>(null);
+  const dismissedForCanvas = dismissedCode === code;
   const artifactHtml = useMemo(() => buildArtifactSrcDoc(code), [code]);
   // Identifies this load to the frame, which stamps its blocked reports with it.
   const codeVersion = useMemo(() => hashArtifactCode(code), [code]);
@@ -200,7 +207,8 @@ export function ArtifactHtmlFrame({
     // canvas on screen, rather than relying on postArtifactHtml changing.
   }, [postArtifactHtml, code, codeVersion]);
 
-  const showBlockedBanner = !networkAllowed && blockedForCanvas.uris.length > 0;
+  const showBlockedBanner =
+    !networkAllowed && !dismissedForCanvas && blockedForCanvas.uris.length > 0;
   const shownHosts = blockedForCanvas.hosts
     .slice(0, BLOCKED_HOSTS_SHOWN)
     .join(", ");
@@ -225,6 +233,16 @@ export function ArtifactHtmlFrame({
         <div className="absolute inset-x-0 top-0 p-2">
           <Alert className="border-amber-500/40 bg-background/95 shadow-md backdrop-blur">
             <ShieldAlertIcon className="text-amber-500" />
+            <AlertAction>
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                aria-label={t("settings.chat.artifacts.blockedDismiss")}
+                onClick={() => setDismissedCode(code)}
+              >
+                <XIcon />
+              </Button>
+            </AlertAction>
             <AlertTitle>{t("settings.chat.artifacts.blockedTitle")}</AlertTitle>
             <AlertDescription>
               <p>

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -3,10 +3,14 @@
 
 "use client";
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+// eslint-disable-next-line no-restricted-imports -- the settings barrel imports this feature back
+import { useSettingsDialogStore } from "@/features/settings/stores/settings-dialog-store";
 import { useT } from "@/i18n";
 import { apiUrl } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
+import { ShieldAlertIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import { hashArtifactCode } from "./types";
@@ -218,22 +222,44 @@ export function ArtifactHtmlFrame({
         title={title}
       />
       {showBlockedBanner ? (
-        <div className="absolute inset-x-0 bottom-0 flex flex-wrap items-center justify-between gap-2 border-t bg-background/95 px-3 py-2 text-xs backdrop-blur">
-          <span className="text-muted-foreground">
-            {t(
-              blockedForCanvas.uris.length === 1
-                ? "settings.chat.artifacts.blockedBanner"
-                : "settings.chat.artifacts.blockedBannerPlural",
-              { count: blockedForCanvas.uris.length, hosts: blockedFrom },
-            )}
-          </span>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setGrantedCode(code)}
-          >
-            {t("settings.chat.artifacts.blockedBannerAction")}
-          </Button>
+        <div className="absolute inset-x-0 top-0 p-2">
+          <Alert className="border-amber-500/40 bg-background/95 shadow-md backdrop-blur">
+            <ShieldAlertIcon className="text-amber-500" />
+            <AlertTitle>{t("settings.chat.artifacts.blockedTitle")}</AlertTitle>
+            <AlertDescription>
+              <p>
+                {t(
+                  blockedForCanvas.uris.length === 1
+                    ? "settings.chat.artifacts.blockedBanner"
+                    : "settings.chat.artifacts.blockedBannerPlural",
+                  { count: blockedForCanvas.uris.length, hosts: blockedFrom },
+                )}{" "}
+                {t("settings.chat.artifacts.blockedHint", {
+                  setting: t("settings.chat.artifacts.allowNetworkAccess"),
+                })}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    useSettingsDialogStore.getState().openDialog("chat", {
+                      scrollTarget: "chat-canvas-network",
+                    })
+                  }
+                >
+                  {t("settings.chat.artifacts.blockedSettingsAction")}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setGrantedCode(code)}
+                >
+                  {t("settings.chat.artifacts.blockedBannerAction")}
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
         </div>
       ) : null}
     </div>

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -274,7 +274,13 @@ export function ArtifactHtmlFrame({
                   setting: t("settings.chat.artifacts.allowNetworkAccess"),
                 })}
               </p>
+              {/* Same pairing as the tool Allow / Always allow controls: the
+                  narrow grant leads as the primary action and the one that
+                  widens every canvas is the quieter outline beside it. */}
               <div className="flex flex-wrap gap-2">
+                <Button size="sm" onClick={() => setGrantedCode(code)}>
+                  {t("settings.chat.artifacts.blockedBannerAction")}
+                </Button>
                 <Button
                   size="sm"
                   variant="outline"
@@ -289,13 +295,6 @@ export function ArtifactHtmlFrame({
                   }}
                 >
                   {t("settings.chat.artifacts.blockedSettingsAction")}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => setGrantedCode(code)}
-                >
-                  {t("settings.chat.artifacts.blockedBannerAction")}
                 </Button>
               </div>
             </AlertDescription>

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -252,7 +252,10 @@ export function ArtifactHtmlFrame({
                 size="icon-sm"
                 variant="ghost"
                 aria-label={t("settings.chat.artifacts.blockedDismiss")}
-                onClick={() => setDismissedCode(code)}
+                onClick={() => {
+                  iframeRef.current?.focus({ preventScroll: true });
+                  setDismissedCode(code);
+                }}
               >
                 <XIcon />
               </Button>

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -111,6 +111,10 @@ export function ArtifactHtmlFrame({
 }) {
   const t = useT();
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  // Focus target the settings deep link hands off to. The banner button that
+  // opens the dialog unmounts as soon as the setting goes on, and the dialog
+  // only restores an opener that is still connected.
+  const frameRef = useRef<HTMLDivElement>(null);
   // Every canvas honors this, fence or tool. Off by default; the standing half
   // of the gate, alongside the per-canvas grant below.
   const networkAccessEnabled = useChatRuntimeStore(
@@ -218,7 +222,11 @@ export function ArtifactHtmlFrame({
       : shownHosts;
 
   return (
-    <div className={cn("relative", fill ? "h-full" : undefined)}>
+    <div
+      ref={frameRef}
+      tabIndex={-1}
+      className={cn("relative outline-none", fill ? "h-full" : undefined)}
+    >
       <iframe
         ref={iframeRef}
         src={src}
@@ -245,7 +253,11 @@ export function ArtifactHtmlFrame({
             </AlertAction>
             <AlertTitle>{t("settings.chat.artifacts.blockedTitle")}</AlertTitle>
             <AlertDescription>
-              <p>
+              {/* Alert is an assertive live region, and the count climbs once per
+                  blocked URL, up to BLOCKED_URIS_TRACKED. Excluding this line
+                  keeps the appearance announced once instead of the whole alert
+                  re-reading on every report. */}
+              <p aria-live="off">
                 {t(
                   blockedForCanvas.uris.length === 1
                     ? "settings.chat.artifacts.blockedBanner"
@@ -260,11 +272,15 @@ export function ArtifactHtmlFrame({
                 <Button
                   size="sm"
                   variant="outline"
-                  onClick={() =>
+                  onClick={() => {
+                    // Focus the canvas before the dialog captures its opener:
+                    // this button is gone by the time the dialog closes, and an
+                    // opener that unmounted leaves focus on <body>.
+                    frameRef.current?.focus({ preventScroll: true });
                     useSettingsDialogStore.getState().openDialog("chat", {
                       scrollTarget: "chat-canvas-network",
-                    })
-                  }
+                    });
+                  }}
                 >
                   {t("settings.chat.artifacts.blockedSettingsAction")}
                 </Button>

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -225,7 +225,13 @@ export function ArtifactHtmlFrame({
     <div
       ref={frameRef}
       tabIndex={-1}
-      className={cn("relative outline-none", fill ? "h-full" : undefined)}
+      className={cn(
+        // outline-none drops the UA ring the tabIndex above would otherwise
+        // paint; the focus-visible ring puts one back for the keyboard user
+        // this element exists to catch, inset so it sits over the canvas.
+        "relative outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+        fill ? "h-full" : undefined,
+      )}
     >
       <iframe
         ref={iframeRef}

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -236,7 +236,11 @@ export function ArtifactHtmlFrame({
       />
       {showBlockedBanner ? (
         <div className="absolute inset-x-0 top-0 p-2">
-          <Alert className="border-amber-500/40 bg-background/95 shadow-md backdrop-blur">
+          <Alert
+            role="group"
+            aria-label={t("settings.chat.artifacts.blockedTitle")}
+            className="border-amber-500/40 bg-background/95 shadow-md backdrop-blur"
+          >
             <ShieldAlertIcon className="text-amber-500" />
             <AlertAction>
               <Button
@@ -251,13 +255,17 @@ export function ArtifactHtmlFrame({
                 <XIcon />
               </Button>
             </AlertAction>
-            <AlertTitle>{t("settings.chat.artifacts.blockedTitle")}</AlertTitle>
+            <AlertTitle role="alert">
+              {t("settings.chat.artifacts.blockedTitle")}
+              <span className="sr-only">
+                {" "}
+                {t("settings.chat.artifacts.blockedHint", {
+                  setting: t("settings.chat.artifacts.allowNetworkAccess"),
+                })}
+              </span>
+            </AlertTitle>
             <AlertDescription>
-              {/* Alert is an assertive live region, and the count climbs once per
-                  blocked URL, up to BLOCKED_URIS_TRACKED. Excluding this line
-                  keeps the appearance announced once instead of the whole alert
-                  re-reading on every report. */}
-              <p aria-live="off">
+              <p>
                 {t(
                   blockedForCanvas.uris.length === 1
                     ? "settings.chat.artifacts.blockedBanner"
@@ -268,9 +276,6 @@ export function ArtifactHtmlFrame({
                   setting: t("settings.chat.artifacts.allowNetworkAccess"),
                 })}
               </p>
-              {/* Same pairing as the tool Allow / Always allow controls: the
-                  narrow grant leads as the primary action and the one that
-                  widens every canvas is the quieter outline beside it. */}
               <div className="flex flex-wrap gap-2">
                 <Button
                   size="sm"

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -16,7 +16,14 @@ import { useT } from "@/i18n";
 import { apiUrl } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
 import { ShieldAlertIcon, XIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import { hashArtifactCode } from "./types";
 
@@ -103,11 +110,13 @@ export function ArtifactHtmlFrame({
   title = "HTML canvas preview",
   className,
   fill = false,
+  actionFocusTargetRef,
 }: {
   code: string;
   title?: string;
   className?: string;
   fill?: boolean;
+  actionFocusTargetRef?: RefObject<HTMLElement | null>;
 }) {
   const t = useT();
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -216,6 +225,11 @@ export function ArtifactHtmlFrame({
     blockedForCanvas.hosts.length > BLOCKED_HOSTS_SHOWN
       ? `${shownHosts}…`
       : shownHosts;
+  const focusAfterAction = () => {
+    (actionFocusTargetRef?.current ?? iframeRef.current)?.focus({
+      preventScroll: true,
+    });
+  };
 
   return (
     <div
@@ -248,7 +262,7 @@ export function ArtifactHtmlFrame({
                 variant="ghost"
                 aria-label={t("settings.chat.artifacts.blockedDismiss")}
                 onClick={() => {
-                  iframeRef.current?.focus({ preventScroll: true });
+                  focusAfterAction();
                   setDismissedCode(code);
                 }}
               >
@@ -280,7 +294,7 @@ export function ArtifactHtmlFrame({
                 <Button
                   size="sm"
                   onClick={() => {
-                    iframeRef.current?.focus({ preventScroll: true });
+                    focusAfterAction();
                     setGrantedCode(code);
                   }}
                 >
@@ -292,7 +306,8 @@ export function ArtifactHtmlFrame({
                   onClick={() => {
                     useSettingsDialogStore.getState().openDialog("chat", {
                       scrollTarget: "chat-canvas-network",
-                      focusFallback: iframeRef.current,
+                      focusFallback:
+                        actionFocusTargetRef?.current ?? iframeRef.current,
                     });
                   }}
                 >

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -111,10 +111,6 @@ export function ArtifactHtmlFrame({
 }) {
   const t = useT();
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  // Focus target the settings deep link hands off to. The banner button that
-  // opens the dialog unmounts as soon as the setting goes on, and the dialog
-  // only restores an opener that is still connected.
-  const frameRef = useRef<HTMLDivElement>(null);
   // Every canvas honors this, fence or tool. Off by default; the standing half
   // of the gate, alongside the per-canvas grant below.
   const networkAccessEnabled = useChatRuntimeStore(
@@ -223,15 +219,7 @@ export function ArtifactHtmlFrame({
 
   return (
     <div
-      ref={frameRef}
-      tabIndex={-1}
-      className={cn(
-        // outline-none drops the UA ring the tabIndex above would otherwise
-        // paint; the focus-visible ring puts one back for the keyboard user
-        // this element exists to catch, inset so it sits over the canvas.
-        "relative outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
-        fill ? "h-full" : undefined,
-      )}
+      className={cn("relative", fill ? "h-full" : undefined)}
     >
       <iframe
         ref={iframeRef}
@@ -239,7 +227,10 @@ export function ArtifactHtmlFrame({
         sandbox="allow-scripts"
         referrerPolicy="no-referrer"
         onLoad={postArtifactHtml}
-        className={cn("block w-full border-0 bg-background", className)}
+        className={cn(
+          "block w-full border-0 bg-background outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
+          className,
+        )}
         style={{ height: fill ? "100%" : height }}
         title={title}
       />
@@ -294,12 +285,9 @@ export function ArtifactHtmlFrame({
                   size="sm"
                   variant="outline"
                   onClick={() => {
-                    // Focus the canvas before the dialog captures its opener:
-                    // this button is gone by the time the dialog closes, and an
-                    // opener that unmounted leaves focus on <body>.
-                    frameRef.current?.focus({ preventScroll: true });
                     useSettingsDialogStore.getState().openDialog("chat", {
                       scrollTarget: "chat-canvas-network",
+                      focusFallback: iframeRef.current,
                     });
                   }}
                 >

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -281,7 +281,13 @@ export function ArtifactHtmlFrame({
                   narrow grant leads as the primary action and the one that
                   widens every canvas is the quieter outline beside it. */}
               <div className="flex flex-wrap gap-2">
-                <Button size="sm" onClick={() => setGrantedCode(code)}>
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    iframeRef.current?.focus({ preventScroll: true });
+                    setGrantedCode(code);
+                  }}
+                >
                   {t("settings.chat.artifacts.blockedBannerAction")}
                 </Button>
                 <Button

--- a/studio/frontend/src/features/chat/artifacts/html-frame.tsx
+++ b/studio/frontend/src/features/chat/artifacts/html-frame.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 // eslint-disable-next-line no-restricted-imports -- the settings barrel imports this feature back
 import { useSettingsDialogStore } from "@/features/settings/stores/settings-dialog-store";
-import { useT } from "@/i18n";
+import { useLocale, useT } from "@/i18n";
 import { apiUrl } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
 import { ShieldAlertIcon, XIcon } from "lucide-react";
@@ -119,6 +119,7 @@ export function ArtifactHtmlFrame({
   actionFocusTargetRef?: RefObject<HTMLElement | null>;
 }) {
   const t = useT();
+  const locale = useLocale();
   const iframeRef = useRef<HTMLIFrameElement>(null);
   // Every canvas honors this, fence or tool. Off by default; the standing half
   // of the gate, alongside the per-canvas grant below.
@@ -252,6 +253,7 @@ export function ArtifactHtmlFrame({
         <div className="absolute inset-x-0 top-0 p-2">
           <Alert
             role="group"
+            dir={locale === "ar" ? "rtl" : "ltr"}
             aria-label={t("settings.chat.artifacts.blockedTitle")}
             className="border-amber-500/40 bg-background/95 shadow-md backdrop-blur"
           >

--- a/studio/frontend/src/features/chat/presets/preset-load-config.ts
+++ b/studio/frontend/src/features/chat/presets/preset-load-config.ts
@@ -5,7 +5,7 @@ import {
   applyPerModelConfigToRuntime,
   currentRuntimePerModelConfig,
   perModelConfigsEqual,
-} from "@/features/model-picker";
+} from "@/features/model-picker/model-config/apply-per-model-config";
 import {
   CONTEXT_LENGTH_MIN,
   DEFAULT_PER_MODEL_CONFIG,

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -2,7 +2,10 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
-import { mirrorHfTokenInto, useHfTokenStore } from "@/features/hub";
+import {
+  mirrorHfTokenInto,
+  useHfTokenStore,
+} from "@/features/hub/stores/hf-token-store";
 import {
   cachedPinnableGpuIndexKind,
   reconcileCachedGpuSelection,

--- a/studio/frontend/src/features/model-picker/model-config/apply-per-model-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/apply-per-model-config.ts
@@ -3,13 +3,13 @@
 
 import {
   GPU_LAYERS_AUTO,
-  defaultInferenceParams,
   normalizeSpeculativeType,
   readPersistedGpuMemoryMode,
   readPersistedSpeculativeType,
   reconcilePersistedGpuSelection,
   useChatRuntimeStore,
-} from "@/features/chat";
+} from "@/features/chat/stores/chat-runtime-store";
+import { defaultInferenceParams } from "@/features/chat/presets/preset-policy";
 // Its own module so hosts needing only the signature skip the chat runtime store.
 import { gpuFieldsSignature } from "./config-signature";
 import {

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -250,6 +250,7 @@ export function SettingsDialog() {
   const setActiveTab = useSettingsDialogStore((s) => s.setActiveTab);
   const closeDialog = useSettingsDialogStore((s) => s.closeDialog);
   const opener = useSettingsDialogStore((s) => s.opener);
+  const openerFallback = useSettingsDialogStore((s) => s.openerFallback);
   const reduced = useReducedMotion();
   // Mounting a heavy tab panel (System, Connections) in the same commit as
   // the nav highlight makes the highlight lag the click. Render the panel
@@ -389,12 +390,14 @@ export function SettingsDialog() {
           showCloseButton={false}
           overlayClassName="bg-black/30 supports-backdrop-filter:backdrop-blur-[2px]"
           onCloseAutoFocus={(e) => {
-            // Restore focus to the element that triggered openDialog(). Radix's
-            // FocusScope races our rAF-scheduled tab focus and loses the
-            // previous-focus reference, so restore it by hand.
-            if (opener && opener.isConnected) {
+            // radix loses its previous-focus reference when the tab focus runs in requestAnimationFrame.
+            const focusTarget = [opener, openerFallback].find(
+              (element) =>
+                element?.isConnected && !element.closest("[inert], [hidden]"),
+            );
+            if (focusTarget) {
               e.preventDefault();
-              opener.focus({ preventScroll: true });
+              focusTarget.focus({ preventScroll: true });
             }
           }}
           className={cn(

--- a/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
@@ -70,6 +70,26 @@ function captureOpener(): HTMLElement | null {
     : null;
 }
 
+function focusForOpen(
+  state: SettingsDialogState,
+  requestedFallback: HTMLElement | null = null,
+) {
+  if (state.open) {
+    return {
+      opener: state.opener,
+      openerFallback: state.openerFallback,
+    };
+  }
+  const opener = captureOpener();
+  if (opener?.closest("[data-slot=dialog-content]")) {
+    return {
+      opener: state.opener,
+      openerFallback: state.openerFallback,
+    };
+  }
+  return { opener, openerFallback: requestedFallback };
+}
+
 const ACTIVE_TAB_KEY = "unsloth_settings_active_tab";
 
 function loadInitialTab(): SettingsTab {
@@ -128,28 +148,25 @@ export const useSettingsDialogStore = create<SettingsDialogState>((set) => ({
         // A caller that names a target replaces whatever was still pending.
         scrollTarget: options?.scrollTarget ?? pending.scrollTarget,
         archivedRequested: pending.archivedRequested,
-        opener: captureOpener(),
-        openerFallback: options?.focusFallback ?? null,
+        ...focusForOpen(state, options?.focusFallback),
       };
     }),
   openArchivedChats: () =>
-    set({
+    set((state) => ({
       open: true,
       activeTab: "data",
       scrollTarget: null,
       archivedRequested: "chats",
-      opener: captureOpener(),
-      openerFallback: null,
-    }),
+      ...focusForOpen(state),
+    })),
   openArchivedMedia: (shelf) =>
-    set({
+    set((state) => ({
       open: true,
       activeTab: "data",
       scrollTarget: null,
       archivedRequested: shelf,
-      opener: captureOpener(),
-      openerFallback: null,
-    }),
+      ...focusForOpen(state),
+    })),
   consumeArchivedChatsRequest: () => set({ archivedRequested: null }),
   consumeScrollTarget: (target) =>
     set((state) => ({

--- a/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
@@ -36,6 +36,7 @@ export type ArchivedShelf = "chats" | "images" | "videos";
 
 interface OpenDialogOptions {
   scrollTarget?: SettingsScrollTarget;
+  focusFallback?: HTMLElement | null;
 }
 
 interface SettingsDialogState {
@@ -47,6 +48,7 @@ interface SettingsDialogState {
   // previous-focus capture, leaving focus on <body> after close. We restore
   // explicitly via onCloseAutoFocus.
   opener: HTMLElement | null;
+  openerFallback: HTMLElement | null;
   // Set when something asks to jump straight to an archive listing (the archive
   // toast). DataTab uses it as its initial subpage, then clears it. See requestsFor
   // for how long it lives unconsumed.
@@ -114,6 +116,7 @@ export const useSettingsDialogStore = create<SettingsDialogState>((set) => ({
   activeTab: loadInitialTab(),
   scrollTarget: null,
   opener: null,
+  openerFallback: null,
   archivedRequested: null,
   openDialog: (tab, options) =>
     set((state) => {
@@ -126,6 +129,7 @@ export const useSettingsDialogStore = create<SettingsDialogState>((set) => ({
         scrollTarget: options?.scrollTarget ?? pending.scrollTarget,
         archivedRequested: pending.archivedRequested,
         opener: captureOpener(),
+        openerFallback: options?.focusFallback ?? null,
       };
     }),
   openArchivedChats: () =>
@@ -135,6 +139,7 @@ export const useSettingsDialogStore = create<SettingsDialogState>((set) => ({
       scrollTarget: null,
       archivedRequested: "chats",
       opener: captureOpener(),
+      openerFallback: null,
     }),
   openArchivedMedia: (shelf) =>
     set({
@@ -143,6 +148,7 @@ export const useSettingsDialogStore = create<SettingsDialogState>((set) => ({
       scrollTarget: null,
       archivedRequested: shelf,
       opener: captureOpener(),
+      openerFallback: null,
     }),
   consumeArchivedChatsRequest: () => set({ archivedRequested: null }),
   consumeScrollTarget: (target) =>

--- a/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
@@ -26,7 +26,10 @@ export const SETTINGS_TABS = [
 
 export type SettingsTab = (typeof SETTINGS_TABS)[number];
 
-export type SettingsScrollTarget = "about-updates" | "appearance-sidebar-nav";
+export type SettingsScrollTarget =
+  | "about-updates"
+  | "appearance-sidebar-nav"
+  | "chat-canvas-network";
 
 /** Which archive the Data tab should open straight into. */
 export type ArchivedShelf = "chats" | "images" | "videos";
@@ -84,6 +87,7 @@ function loadInitialTab(): SettingsTab {
 const SCROLL_TARGET_TAB: Record<SettingsScrollTarget, SettingsTab> = {
   "about-updates": "about",
   "appearance-sidebar-nav": "appearance",
+  "chat-canvas-network": "chat",
 };
 
 /**

--- a/studio/frontend/src/features/settings/tabs/chat-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/chat-tab.tsx
@@ -38,10 +38,11 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Columns2Icon } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { ReactNode } from "react";
 import { SettingsRow } from "../components/settings-row";
 import { SettingsSection } from "../components/settings-section";
+import { useSettingsDialogStore } from "../stores/settings-dialog-store";
 
 // Adjustable "+" menu items shown in settings, in display order. Icons mirror
 // the ones used in the composer + menu itself.
@@ -195,6 +196,22 @@ export function ChatTab() {
   const setSearchImages = useChatRuntimeStore(
     (state) => state.setSearchImages,
   );
+  const networkAccessRowRef = useRef<HTMLDivElement | null>(null);
+  const scrollTarget = useSettingsDialogStore((s) => s.scrollTarget);
+  const consumeScrollTarget = useSettingsDialogStore(
+    (s) => s.consumeScrollTarget,
+  );
+  useEffect(() => {
+    if (scrollTarget !== "chat-canvas-network") return;
+    const frame = window.requestAnimationFrame(() => {
+      networkAccessRowRef.current?.scrollIntoView({
+        block: "center",
+        behavior: "smooth",
+      });
+      consumeScrollTarget("chat-canvas-network");
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [consumeScrollTarget, scrollTarget]);
   const hydratePersistedSettings = useChatRuntimeStore(
     (state) => state.hydratePersistedSettings,
   );
@@ -503,17 +520,19 @@ export function ChatTab() {
             onCheckedChange={setCollapseHtmlArtifacts}
           />
         </SettingsRow>
-        <SettingsRow
-          label={t("settings.chat.artifacts.allowNetworkAccess")}
-          description={t(
-            "settings.chat.artifacts.allowNetworkAccessDescription",
-          )}
-        >
-          <Switch
-            checked={allowArtifactNetworkAccess}
-            onCheckedChange={setAllowArtifactNetworkAccess}
-          />
-        </SettingsRow>
+        <div ref={networkAccessRowRef}>
+          <SettingsRow
+            label={t("settings.chat.artifacts.allowNetworkAccess")}
+            description={t(
+              "settings.chat.artifacts.allowNetworkAccessDescription",
+            )}
+          >
+            <Switch
+              checked={allowArtifactNetworkAccess}
+              onCheckedChange={setAllowArtifactNetworkAccess}
+            />
+          </SettingsRow>
+        </div>
       </SettingsSection>
 
       <SettingsSection title={t("settings.chat.webSearch.title")}>

--- a/studio/frontend/src/i18n/locale-store.ts
+++ b/studio/frontend/src/i18n/locale-store.ts
@@ -165,10 +165,9 @@ function writeStoredPreference(preference: LocalePreference): void {
   }
 }
 
-function syncDocumentLocale(locale: Locale): void {
+function syncDocumentLang(locale: Locale): void {
   if (typeof document === "undefined") return;
   document.documentElement.lang = locale;
-  document.documentElement.dir = locale === "ar" ? "rtl" : "ltr";
 }
 
 function notifySubscribers(): void {
@@ -196,7 +195,7 @@ function commitPreference(
   pendingPreferenceShouldPersist = false;
   // This preference's catalog is loaded, so a retry has nothing left to fix.
   currentCatalogFailed = false;
-  syncDocumentLocale(locale);
+  syncDocumentLang(locale);
   if (didChange) notifySubscribers();
   return "applied";
 }
@@ -217,7 +216,7 @@ function commitFallbackLocale(
   pendingPreferenceShouldPersist = false;
   // Adopted, but on the fallback catalog rather than this preference's own.
   currentCatalogFailed = true;
-  syncDocumentLocale(currentLocale);
+  syncDocumentLang(currentLocale);
   if (didChange) notifySubscribers();
 }
 

--- a/studio/frontend/src/i18n/locale-store.ts
+++ b/studio/frontend/src/i18n/locale-store.ts
@@ -165,9 +165,10 @@ function writeStoredPreference(preference: LocalePreference): void {
   }
 }
 
-function syncDocumentLang(locale: Locale): void {
+function syncDocumentLocale(locale: Locale): void {
   if (typeof document === "undefined") return;
   document.documentElement.lang = locale;
+  document.documentElement.dir = locale === "ar" ? "rtl" : "ltr";
 }
 
 function notifySubscribers(): void {
@@ -195,7 +196,7 @@ function commitPreference(
   pendingPreferenceShouldPersist = false;
   // This preference's catalog is loaded, so a retry has nothing left to fix.
   currentCatalogFailed = false;
-  syncDocumentLang(locale);
+  syncDocumentLocale(locale);
   if (didChange) notifySubscribers();
   return "applied";
 }
@@ -216,7 +217,7 @@ function commitFallbackLocale(
   pendingPreferenceShouldPersist = false;
   // Adopted, but on the fallback catalog rather than this preference's own.
   currentCatalogFailed = true;
-  syncDocumentLang(currentLocale);
+  syncDocumentLocale(currentLocale);
   if (didChange) notifySubscribers();
 }
 

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -1401,6 +1401,10 @@ export const ar = {
         blockedBanner: "تم حظر {count} مورد خارجي من {hosts}.",
         blockedBannerPlural: "تم حظر {count} موارد خارجية من {hosts}.",
         blockedBannerAction: "السماح لهذا الـ Canvas",
+        blockedTitle: "الوصول إلى الشبكة لـ Canvas معطّل",
+        blockedHint:
+          "فعّل «{setting}» في الإعدادات ← الدردشة للسماح لـ Canvas بتحميل الموارد الخارجية، أو اسمح بذلك لهذا الـ Canvas فقط.",
+        blockedSettingsAction: "فتح الإعدادات",
       },
       data: "البيانات",
       exportHistory: "تصدير سجل المحادثات",

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -1405,6 +1405,7 @@ export const ar = {
         blockedHint:
           "فعّل «{setting}» في الإعدادات ← الدردشة للسماح لـ Canvas بتحميل الموارد الخارجية، أو اسمح بذلك لهذا الـ Canvas فقط.",
         blockedSettingsAction: "فتح الإعدادات",
+        blockedDismiss: "تجاهل",
       },
       data: "البيانات",
       exportHistory: "تصدير سجل المحادثات",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -1445,6 +1445,7 @@ export const de = {
         blockedHint:
           "Aktiviere „{setting}“ unter Einstellungen → Chat, damit Canvases externe Ressourcen laden können, oder erlaube es nur für dieses Canvas.",
         blockedSettingsAction: "Einstellungen öffnen",
+        blockedDismiss: "Schließen",
       },
       data: "Daten",
       exportHistory: "Chatverlauf exportieren",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -1441,6 +1441,10 @@ export const de = {
         blockedBanner: "{count} externe Ressource von {hosts} blockiert.",
         blockedBannerPlural: "{count} externe Ressourcen von {hosts} blockiert.",
         blockedBannerAction: "Für dieses Canvas erlauben",
+        blockedTitle: "Canvas-Netzwerkzugriff ist deaktiviert",
+        blockedHint:
+          "Aktiviere „{setting}“ unter Einstellungen → Chat, damit Canvases externe Ressourcen laden können, oder erlaube es nur für dieses Canvas.",
+        blockedSettingsAction: "Einstellungen öffnen",
       },
       data: "Daten",
       exportHistory: "Chatverlauf exportieren",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -1394,6 +1394,10 @@ export const en = {
         blockedBanner: "Blocked {count} external resource from {hosts}.",
         blockedBannerPlural: "Blocked {count} external resources from {hosts}.",
         blockedBannerAction: "Allow for this canvas",
+        blockedTitle: "Canvas network access is off",
+        blockedHint:
+          "Turn on “{setting}” in Settings → Chat to let canvases load external resources, or allow it just for this canvas.",
+        blockedSettingsAction: "Open Settings",
       },
       data: "Data",
       exportHistory: "Export chat history",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -1398,6 +1398,7 @@ export const en = {
         blockedHint:
           "Turn on “{setting}” in Settings → Chat to let canvases load external resources, or allow it just for this canvas.",
         blockedSettingsAction: "Open Settings",
+        blockedDismiss: "Dismiss",
       },
       data: "Data",
       exportHistory: "Export chat history",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -1436,6 +1436,7 @@ export const es = {
         blockedHint:
           "Activa “{setting}” en Ajustes → Chat para que los Canvas carguen recursos externos, o permítelo solo en este Canvas.",
         blockedSettingsAction: "Abrir ajustes",
+        blockedDismiss: "Descartar",
       },
       data: "Datos",
       exportHistory: "Exportar historial de chat",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -1432,6 +1432,10 @@ export const es = {
         blockedBanner: "Se bloqueó {count} recurso externo de {hosts}.",
         blockedBannerPlural: "Se bloquearon {count} recursos externos de {hosts}.",
         blockedBannerAction: "Permitir en este Canvas",
+        blockedTitle: "El acceso a la red del Canvas está desactivado",
+        blockedHint:
+          "Activa “{setting}” en Ajustes → Chat para que los Canvas carguen recursos externos, o permítelo solo en este Canvas.",
+        blockedSettingsAction: "Abrir ajustes",
       },
       data: "Datos",
       exportHistory: "Exportar historial de chat",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -1438,6 +1438,10 @@ export const fr = {
         blockedBanner: "{count} ressource externe bloquée depuis {hosts}.",
         blockedBannerPlural: "{count} ressources externes bloquées depuis {hosts}.",
         blockedBannerAction: "Autoriser pour ce Canvas",
+        blockedTitle: "L'accès réseau du Canvas est désactivé",
+        blockedHint:
+          "Activez « {setting} » dans Paramètres → Chat pour que les Canvas chargent des ressources externes, ou autorisez-le uniquement pour ce Canvas.",
+        blockedSettingsAction: "Ouvrir les paramètres",
       },
       data: "Données",
       exportHistory: "Exporter l'historique des discussions",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -1442,6 +1442,7 @@ export const fr = {
         blockedHint:
           "Activez « {setting} » dans Paramètres → Chat pour que les Canvas chargent des ressources externes, ou autorisez-le uniquement pour ce Canvas.",
         blockedSettingsAction: "Ouvrir les paramètres",
+        blockedDismiss: "Ignorer",
       },
       data: "Données",
       exportHistory: "Exporter l'historique des discussions",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -1411,6 +1411,7 @@ export const hi = {
         blockedHint:
           "Canvas को बाहरी संसाधन लोड करने देने के लिए सेटिंग्स → चैट में “{setting}” चालू करें, या केवल इस Canvas के लिए अनुमति दें।",
         blockedSettingsAction: "सेटिंग्स खोलें",
+        blockedDismiss: "खारिज करें",
       },
       data: "डेटा",
       exportHistory: "चैट इतिहास एक्सपोर्ट करें",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -1407,6 +1407,10 @@ export const hi = {
         blockedBanner: "{hosts} से {count} बाहरी संसाधन अवरुद्ध किया गया।",
         blockedBannerPlural: "{hosts} से {count} बाहरी संसाधन अवरुद्ध किए गए।",
         blockedBannerAction: "इस Canvas के लिए अनुमति दें",
+        blockedTitle: "Canvas नेटवर्क एक्सेस बंद है",
+        blockedHint:
+          "Canvas को बाहरी संसाधन लोड करने देने के लिए सेटिंग्स → चैट में “{setting}” चालू करें, या केवल इस Canvas के लिए अनुमति दें।",
+        blockedSettingsAction: "सेटिंग्स खोलें",
       },
       data: "डेटा",
       exportHistory: "चैट इतिहास एक्सपोर्ट करें",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -1410,6 +1410,7 @@ export const it = {
         blockedHint:
           "Attiva “{setting}” in Impostazioni → Chat per consentire ai Canvas di caricare risorse esterne, oppure consentilo solo per questo Canvas.",
         blockedSettingsAction: "Apri impostazioni",
+        blockedDismiss: "Ignora",
       },
       data: "Dati",
       exportHistory: "Esporta la cronologia delle chat",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -1406,6 +1406,10 @@ export const it = {
         blockedBanner: "Bloccata {count} risorsa esterna da {hosts}.",
         blockedBannerPlural: "Bloccate {count} risorse esterne da {hosts}.",
         blockedBannerAction: "Consenti per questo Canvas",
+        blockedTitle: "L'accesso alla rete del Canvas è disattivato",
+        blockedHint:
+          "Attiva “{setting}” in Impostazioni → Chat per consentire ai Canvas di caricare risorse esterne, oppure consentilo solo per questo Canvas.",
+        blockedSettingsAction: "Apri impostazioni",
       },
       data: "Dati",
       exportHistory: "Esporta la cronologia delle chat",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -1387,6 +1387,10 @@ export const ja = {
         blockedBanner: "{hosts} からの外部リソース {count} 件をブロックしました。",
         blockedBannerPlural: "{hosts} からの外部リソース {count} 件をブロックしました。",
         blockedBannerAction: "この Canvas で許可",
+        blockedTitle: "Canvas のネットワークアクセスはオフです",
+        blockedHint:
+          "設定 → チャットで「{setting}」をオンにすると Canvas が外部リソースを読み込めます。この Canvas だけ許可することもできます。",
+        blockedSettingsAction: "設定を開く",
       },
       data: "データ",
       exportHistory: "チャット履歴をエクスポート",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -1391,6 +1391,7 @@ export const ja = {
         blockedHint:
           "設定 → チャットで「{setting}」をオンにすると Canvas が外部リソースを読み込めます。この Canvas だけ許可することもできます。",
         blockedSettingsAction: "設定を開く",
+        blockedDismiss: "閉じる",
       },
       data: "データ",
       exportHistory: "チャット履歴をエクスポート",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -1398,6 +1398,10 @@ export const ko = {
         blockedBanner: "{hosts}의 외부 리소스 {count}개를 차단했습니다.",
         blockedBannerPlural: "{hosts}의 외부 리소스 {count}개를 차단했습니다.",
         blockedBannerAction: "이 Canvas에서 허용",
+        blockedTitle: "Canvas 네트워크 액세스가 꺼져 있습니다",
+        blockedHint:
+          "설정 → 채팅에서 “{setting}”을 켜면 Canvas가 외부 리소스를 불러올 수 있습니다. 이 Canvas에서만 허용할 수도 있습니다.",
+        blockedSettingsAction: "설정 열기",
       },
       data: "데이터",
       exportHistory: "채팅 기록 내보내기",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -1402,6 +1402,7 @@ export const ko = {
         blockedHint:
           "설정 → 채팅에서 “{setting}”을 켜면 Canvas가 외부 리소스를 불러올 수 있습니다. 이 Canvas에서만 허용할 수도 있습니다.",
         blockedSettingsAction: "설정 열기",
+        blockedDismiss: "닫기",
       },
       data: "데이터",
       exportHistory: "채팅 기록 내보내기",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -1424,6 +1424,7 @@ export const ptBR = {
         blockedHint:
           "Ative “{setting}” em Configurações → Chat para que os Canvas carreguem recursos externos, ou permita apenas neste Canvas.",
         blockedSettingsAction: "Abrir configurações",
+        blockedDismiss: "Dispensar",
       },
       data: "Dados",
       exportHistory: "Exportar histórico de chat",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -1420,6 +1420,10 @@ export const ptBR = {
         blockedBanner: "{count} recurso externo de {hosts} bloqueado.",
         blockedBannerPlural: "{count} recursos externos de {hosts} bloqueados.",
         blockedBannerAction: "Permitir neste Canvas",
+        blockedTitle: "O acesso à rede do Canvas está desativado",
+        blockedHint:
+          "Ative “{setting}” em Configurações → Chat para que os Canvas carreguem recursos externos, ou permita apenas neste Canvas.",
+        blockedSettingsAction: "Abrir configurações",
       },
       data: "Dados",
       exportHistory: "Exportar histórico de chat",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -1417,6 +1417,10 @@ export const ru = {
         blockedBanner: "Заблокирован {count} внешний ресурс с {hosts}.",
         blockedBannerPlural: "Заблокировано внешних ресурсов: {count} с {hosts}.",
         blockedBannerAction: "Разрешить для этого Canvas",
+        blockedTitle: "Доступ Canvas к сети отключён",
+        blockedHint:
+          "Включите «{setting}» в разделе Настройки → Чат, чтобы Canvas мог загружать внешние ресурсы, или разрешите только для этого Canvas.",
+        blockedSettingsAction: "Открыть настройки",
       },
       data: "Данные",
       exportHistory: "Экспортировать историю чатов",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -1421,6 +1421,7 @@ export const ru = {
         blockedHint:
           "Включите «{setting}» в разделе Настройки → Чат, чтобы Canvas мог загружать внешние ресурсы, или разрешите только для этого Canvas.",
         blockedSettingsAction: "Открыть настройки",
+        blockedDismiss: "Закрыть",
       },
       data: "Данные",
       exportHistory: "Экспортировать историю чатов",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -1376,6 +1376,7 @@ export const zhCN = {
         blockedHint:
           "在“设置 → 聊天”中开启“{setting}”以允许 Canvas 加载外部资源，或仅对此 Canvas 允许。",
         blockedSettingsAction: "打开设置",
+        blockedDismiss: "关闭",
       },
       data: "数据",
       exportHistory: "导出聊天记录",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -1372,6 +1372,10 @@ export const zhCN = {
         blockedBanner: "已阻止来自 {hosts} 的 {count} 个外部资源。",
         blockedBannerPlural: "已阻止来自 {hosts} 的 {count} 个外部资源。",
         blockedBannerAction: "允许此 Canvas",
+        blockedTitle: "Canvas 网络访问已关闭",
+        blockedHint:
+          "在“设置 → 聊天”中开启“{setting}”以允许 Canvas 加载外部资源，或仅对此 Canvas 允许。",
+        blockedSettingsAction: "打开设置",
       },
       data: "数据",
       exportHistory: "导出聊天记录",

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -467,46 +467,20 @@ test("granting network access leaves focus on the canvas", () => {
   assert.ok(focusAt < grantAt, "focus must move before the button unmounts");
 });
 
-// Turning the setting on unmounts the button that opened the dialog, and the
-// settings dialog only restores an opener that is still connected. Without a
-// target that outlives the banner, closing the dialog drops focus on <body>.
-test("the settings deep link parks focus somewhere that outlives the banner", () => {
-  const source = sourceFile(FRAME);
-  const handlers: string[] = [];
-  const visit = (node: ts.Node): void => {
-    if (
-      ts.isCallExpression(node) &&
-      node.expression.getText().endsWith(".openDialog")
-    ) {
-      for (let at: ts.Node = node; at.parent; at = at.parent) {
-        if (ts.isJsxAttribute(at.parent)) {
-          handlers.push(at.getText());
-          break;
-        }
-      }
-    }
-    node.forEachChild(visit);
-  };
-  source.forEachChild(visit);
-  assert.equal(handlers.length, 1, "the deep link is not in one JSX handler");
-  const handler = handlers[0];
-  const focusAt = handler.indexOf("frameRef.current?.focus");
-  const openAt = handler.indexOf(".openDialog");
-  assert.ok(focusAt >= 0, "the handler must hand the frame focus");
-  assert.ok(
-    focusAt < openAt,
-    "the frame must take focus BEFORE the dialog captures its opener",
+test("the settings deep link keeps the invoking button as its opener", () => {
+  const handler = readHandlerCalling(
+    "useSettingsDialogStore.getState().openDialog",
   );
+  assert.match(handler, /focusFallback:\s*iframeRef\.current/);
+  assert.doesNotMatch(handler, /iframeRef\.current\?\.focus/);
 });
 
-test("the frame itself can hold that focus, and shows it", () => {
-  const tag = readTagWithRef("frameRef");
-  assert.match(tag, /tabIndex=\{-1\}/);
-  // outline-none suppresses the ring the tabIndex would otherwise paint, so
-  // without a replacement the keyboard user lands on an unmarked canvas.
+test("the named iframe is the visible focus fallback", () => {
+  const tag = readTagWithRef("iframeRef");
+  assert.match(tag, /title=\{title\}/);
   assert.match(
     tag,
-    /focus-visible:ring/,
+    /focus-visible:outline/,
     "the restored focus target needs a visible focus treatment",
   );
 });

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -499,3 +499,41 @@ test("the climbing blocked count is kept out of the assertive alert", () => {
     "the count line must opt out of the live region",
   );
 });
+
+/** The opening tag of the `<Button>` whose subtree calls `needle`. */
+function readButtonCalling(needle: string): string {
+  const source = sourceFile(FRAME);
+  let text: string | undefined;
+  const visit = (node: ts.Node): void => {
+    const opening = openingTag(node);
+    if (
+      opening?.tagName.getText() === "Button" &&
+      node.getText().includes(needle)
+    ) {
+      text = opening.getText();
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  assert.ok(text, `no <Button> calls ${needle}`);
+  return text;
+}
+
+// The grant covers one canvas; the settings link turns network access on for
+// every canvas from here on. Studio's tool controls lead with the narrow grant
+// -- Allow is the primary, Always allow the outline beside it -- so the banner
+// matches, and the emphasis never lands on the action that widens the most.
+test("the emphasized action is the per-canvas grant, not the global setting", () => {
+  const grant = readButtonCalling("setGrantedCode");
+  const settings = readButtonCalling("openDialog");
+  assert.doesNotMatch(
+    grant,
+    /variant=/,
+    "the per-canvas grant must stay the default (primary) button",
+  );
+  assert.match(
+    settings,
+    /variant="outline"/,
+    "the global setting must be the quieter outline button",
+  );
+});

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -414,3 +414,80 @@ test("the banner deep-links to the network access setting", () => {
   assert.match(deepLinks[0].options, /scrollTarget:\s*"chat-canvas-network"/);
   assert.equal(deepLinks[0].handler, "onClick");
 });
+
+/** The opening tag of whichever element carries `ref={<name>}`. */
+function readTagWithRef(name: string): string {
+  const source = sourceFile(FRAME);
+  let text: string | undefined;
+  const visit = (node: ts.Node): void => {
+    const opening = openingTag(node);
+    if (opening?.getText().includes(`ref={${name}}`)) {
+      text = opening.getText();
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  assert.ok(text, `no element carries ref={${name}}`);
+  return text;
+}
+
+// Turning the setting on unmounts the button that opened the dialog, and the
+// settings dialog only restores an opener that is still connected. Without a
+// target that outlives the banner, closing the dialog drops focus on <body>.
+test("the settings deep link parks focus somewhere that outlives the banner", () => {
+  const source = sourceFile(FRAME);
+  const handlers: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText().endsWith(".openDialog")
+    ) {
+      for (let at: ts.Node = node; at.parent; at = at.parent) {
+        if (ts.isJsxAttribute(at.parent)) {
+          handlers.push(at.getText());
+          break;
+        }
+      }
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  assert.equal(handlers.length, 1, "the deep link is not in one JSX handler");
+  const handler = handlers[0];
+  const focusAt = handler.indexOf("frameRef.current?.focus");
+  const openAt = handler.indexOf(".openDialog");
+  assert.ok(focusAt >= 0, "the handler must hand the frame focus");
+  assert.ok(
+    focusAt < openAt,
+    "the frame must take focus BEFORE the dialog captures its opener",
+  );
+});
+
+test("the frame itself can hold that focus", () => {
+  assert.match(readTagWithRef("frameRef"), /tabIndex=\{-1\}/);
+});
+
+// Alert is assertive and atomic, so any change inside it re-reads the title,
+// the description and the actions. The count climbs once per blocked URL, so
+// left in the region a CDN-heavy canvas interrupts a screen reader repeatedly.
+test("the climbing blocked count is kept out of the assertive alert", () => {
+  const source = sourceFile(FRAME);
+  let paragraph: string | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isJsxElement(node) &&
+      node.openingElement.tagName.getText() === "p" &&
+      node.getText().includes("blockedBanner")
+    ) {
+      paragraph = node.getText();
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  assert.ok(paragraph, "the paragraph carrying the blocked count is missing");
+  assert.match(
+    paragraph,
+    /aria-live="off"/,
+    "the count line must opt out of the live region",
+  );
+});

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -459,6 +459,14 @@ test("dismissing the banner leaves focus on the canvas", () => {
   assert.ok(focusAt < dismissAt, "focus must move before the button unmounts");
 });
 
+test("granting network access leaves focus on the canvas", () => {
+  const handler = readHandlerCalling("setGrantedCode");
+  const focusAt = handler.indexOf("iframeRef.current?.focus");
+  const grantAt = handler.indexOf("setGrantedCode");
+  assert.ok(focusAt >= 0, "the grant must hand focus to the canvas");
+  assert.ok(focusAt < grantAt, "focus must move before the button unmounts");
+});
+
 // Turning the setting on unmounts the button that opened the dialog, and the
 // settings dialog only restores an opener that is still connected. Without a
 // target that outlives the banner, closing the dialog drops focus on <body>.

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -25,6 +25,7 @@ const sourceFile = (relative: string): ts.SourceFile => {
 
 const SURFACE = "../src/features/chat/artifacts/artifact-surface.tsx";
 const FRAME = "../src/features/chat/artifacts/html-frame.tsx";
+const ALERT = "../src/components/ui/alert.tsx";
 
 /** Every `<ArtifactHtmlFrame>` opening tag in the artifact surface. */
 function readFrameOpeningTags(): string[] {
@@ -483,6 +484,17 @@ test("the named iframe is the visible focus fallback", () => {
     /focus-visible:outline/,
     "the restored focus target needs a visible focus treatment",
   );
+});
+
+test("the shared alert uses logical alignment and action spacing", () => {
+  const source = readFileSync(
+    fileURLToPath(new URL(ALERT, import.meta.url)),
+    "utf8",
+  );
+  assert.match(source, /text-start/);
+  assert.match(source, /has-data-\[slot=alert-action\]:pe-18/);
+  assert.match(source, /absolute top-2\.5 end-3/);
+  assert.doesNotMatch(source, /\btext-left\b|\bpr-18\b|\bright-3\b/);
 });
 
 test("the climbing blocked count stays outside the assertive live region", () => {

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -454,7 +454,7 @@ function readHandlerCalling(needle: string): string {
 
 test("dismissing the banner leaves focus on the canvas", () => {
   const handler = readHandlerCalling("setDismissedCode");
-  const focusAt = handler.indexOf("iframeRef.current?.focus");
+  const focusAt = handler.indexOf("focusAfterAction");
   const dismissAt = handler.indexOf("setDismissedCode");
   assert.ok(focusAt >= 0, "the dismissal must hand focus to the canvas");
   assert.ok(focusAt < dismissAt, "focus must move before the button unmounts");
@@ -462,7 +462,7 @@ test("dismissing the banner leaves focus on the canvas", () => {
 
 test("granting network access leaves focus on the canvas", () => {
   const handler = readHandlerCalling("setGrantedCode");
-  const focusAt = handler.indexOf("iframeRef.current?.focus");
+  const focusAt = handler.indexOf("focusAfterAction");
   const grantAt = handler.indexOf("setGrantedCode");
   assert.ok(focusAt >= 0, "the grant must hand focus to the canvas");
   assert.ok(focusAt < grantAt, "focus must move before the button unmounts");
@@ -472,8 +472,32 @@ test("the settings deep link keeps the invoking button as its opener", () => {
   const handler = readHandlerCalling(
     "useSettingsDialogStore.getState().openDialog",
   );
-  assert.match(handler, /focusFallback:\s*iframeRef\.current/);
+  assert.match(
+    handler,
+    /focusFallback:\s*actionFocusTargetRef\?\.current \?\? iframeRef\.current/,
+  );
   assert.doesNotMatch(handler, /iframeRef\.current\?\.focus/);
+});
+
+test("fullscreen canvas actions return focus inside the dialog", () => {
+  const tags = readFrameOpeningTags();
+  assert.equal(tags.length, 1);
+  assert.match(
+    tags[0],
+    /actionFocusTargetRef=\{\s*variant === "overlay" \? closeButtonRef : undefined\s*\}/,
+  );
+  const surface = readFileSync(
+    fileURLToPath(new URL(SURFACE, import.meta.url)),
+    "utf8",
+  );
+  assert.match(
+    surface,
+    /ref=\{closeButtonRef\}[\s\S]*?aria-label="Close canvas"/,
+  );
+  assert.match(
+    readConst("focusAfterAction"),
+    /\(actionFocusTargetRef\?\.current \?\? iframeRef\.current\)\?\.focus/,
+  );
 });
 
 test("the named iframe is the visible focus fallback", () => {

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -521,6 +521,19 @@ test("the shared alert uses logical alignment and action spacing", () => {
   assert.doesNotMatch(source, /\btext-left\b|\bpr-18\b|\bright-3\b/);
 });
 
+test("the blocked alert scopes direction to its locale", () => {
+  const source = sourceFile(FRAME);
+  let alert: string | undefined;
+  const visit = (node: ts.Node): void => {
+    const opening = openingTag(node);
+    if (opening?.tagName.getText() === "Alert") alert = opening.getText();
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  assert.ok(alert, "blocked alert not found");
+  assert.match(alert, /dir=\{locale === "ar" \? "rtl" : "ltr"\}/);
+});
+
 test("the climbing blocked count stays outside the assertive live region", () => {
   const source = sourceFile(FRAME);
   let alert: string | undefined;

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -485,13 +485,19 @@ test("the named iframe is the visible focus fallback", () => {
   );
 });
 
-// Alert is assertive and atomic, so any change inside it re-reads the title,
-// the description and the actions. The count climbs once per blocked URL, so
-// left in the region a CDN-heavy canvas interrupts a screen reader repeatedly.
-test("the climbing blocked count is kept out of the assertive alert", () => {
+test("the climbing blocked count stays outside the assertive live region", () => {
   const source = sourceFile(FRAME);
+  let alert: string | undefined;
+  let alertTitle: string | undefined;
   let paragraph: string | undefined;
   const visit = (node: ts.Node): void => {
+    const opening = openingTag(node);
+    if (opening?.tagName.getText() === "Alert") {
+      alert = opening.getText();
+    }
+    if (opening?.tagName.getText() === "AlertTitle") {
+      alertTitle = opening.getText();
+    }
     if (
       ts.isJsxElement(node) &&
       node.openingElement.tagName.getText() === "p" &&
@@ -502,12 +508,12 @@ test("the climbing blocked count is kept out of the assertive alert", () => {
     node.forEachChild(visit);
   };
   source.forEachChild(visit);
+  assert.ok(alert, "the blocked alert is missing");
+  assert.ok(alertTitle, "the blocked alert title is missing");
   assert.ok(paragraph, "the paragraph carrying the blocked count is missing");
-  assert.match(
-    paragraph,
-    /aria-live="off"/,
-    "the count line must opt out of the live region",
-  );
+  assert.match(alert, /role="group"/);
+  assert.match(alertTitle, /role="alert"/);
+  assert.doesNotMatch(paragraph, /aria-live/);
 });
 
 /** The opening tag of the `<Button>` whose subtree calls `needle`. */

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -463,8 +463,16 @@ test("the settings deep link parks focus somewhere that outlives the banner", ()
   );
 });
 
-test("the frame itself can hold that focus", () => {
-  assert.match(readTagWithRef("frameRef"), /tabIndex=\{-1\}/);
+test("the frame itself can hold that focus, and shows it", () => {
+  const tag = readTagWithRef("frameRef");
+  assert.match(tag, /tabIndex=\{-1\}/);
+  // outline-none suppresses the ring the tabIndex would otherwise paint, so
+  // without a replacement the keyboard user lands on an unmarked canvas.
+  assert.match(
+    tag,
+    /focus-visible:ring/,
+    "the restored focus target needs a visible focus treatment",
+  );
 });
 
 // Alert is assertive and atomic, so any change inside it re-reads the title,

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -431,6 +431,34 @@ function readTagWithRef(name: string): string {
   return text;
 }
 
+/** The JSX handler that contains a call to `needle`. */
+function readHandlerCalling(needle: string): string {
+  const source = sourceFile(FRAME);
+  let text: string | undefined;
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && node.expression.getText() === needle) {
+      for (let at: ts.Node = node; at.parent; at = at.parent) {
+        if (ts.isJsxAttribute(at.parent)) {
+          text = at.parent.getText();
+          break;
+        }
+      }
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  assert.ok(text, `no JSX handler calls ${needle}`);
+  return text;
+}
+
+test("dismissing the banner leaves focus on the canvas", () => {
+  const handler = readHandlerCalling("setDismissedCode");
+  const focusAt = handler.indexOf("iframeRef.current?.focus");
+  const dismissAt = handler.indexOf("setDismissedCode");
+  assert.ok(focusAt >= 0, "the dismissal must hand focus to the canvas");
+  assert.ok(focusAt < dismissAt, "focus must move before the button unmounts");
+});
+
 // Turning the setting on unmounts the button that opened the dialog, and the
 // settings dialog only restores an opener that is still connected. Without a
 // target that outlives the banner, closing the dialog drops focus on <body>.

--- a/studio/frontend/tests/artifact-frame-network-access.test.ts
+++ b/studio/frontend/tests/artifact-frame-network-access.test.ts
@@ -159,15 +159,14 @@ test("no write resets the blocked list wholesale", () => {
 
 const GRANT_SETTER = /\bsetGranted\w*\(/;
 
-/** Arguments of every `setGrantedCode(...)` call, with the enclosing JSX handler. */
-function readGrantCalls(): { argument: string; handler: string | null }[] {
+/** Arguments of every `<setter>(...)` call, with the enclosing JSX handler. */
+function readSetterCalls(
+  setter: string,
+): { argument: string; handler: string | null }[] {
   const source = sourceFile(FRAME);
   const calls: { argument: string; handler: string | null }[] = [];
   const visit = (node: ts.Node): void => {
-    if (
-      ts.isCallExpression(node) &&
-      node.expression.getText() === "setGrantedCode"
-    ) {
+    if (ts.isCallExpression(node) && node.expression.getText() === setter) {
       let handler: string | null = null;
       for (let at: ts.Node = node; at.parent; at = at.parent) {
         if (ts.isJsxAttribute(at.parent)) {
@@ -182,6 +181,8 @@ function readGrantCalls(): { argument: string; handler: string | null }[] {
   source.forEachChild(visit);
   return calls;
 }
+
+const readGrantCalls = () => readSetterCalls("setGrantedCode");
 
 // The canvas is what reports being blocked, so the grant must never be reachable
 // from that path or a page could post its way onto the network. Only a JSX click
@@ -359,4 +360,57 @@ test("blocked-resource state is capped against the untrusted canvas", () => {
     "the cap must be checked before the duplicate scan",
   );
   assert.match(updater, BAILS_OUT);
+});
+
+test("only a click can dismiss the banner, and only for the code on screen", () => {
+  const calls = readSetterCalls("setDismissedCode");
+  assert.ok(calls.length > 0, "setDismissedCode is never called");
+  for (const { argument, handler } of calls) {
+    assert.equal(argument, "code", "the dismissal stores the current code");
+    assert.equal(
+      handler,
+      "onClick",
+      "the dismissal must come from a click handler",
+    );
+  }
+});
+
+test("the dismissal is tied to the code it was dismissed for", () => {
+  assert.equal(readConst("dismissedForCanvas"), "dismissedCode === code");
+  assert.match(readConst("showBlockedBanner"), /!dismissedForCanvas/);
+});
+
+test("the banner deep-links to the network access setting", () => {
+  const source = sourceFile(FRAME);
+  const deepLinks: { tab: string; options: string; handler: string | null }[] =
+    [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText().endsWith(".openDialog")
+    ) {
+      let handler: string | null = null;
+      for (let at: ts.Node = node; at.parent; at = at.parent) {
+        if (ts.isJsxAttribute(at.parent)) {
+          handler = at.parent.name.getText();
+          break;
+        }
+      }
+      deepLinks.push({
+        tab: node.arguments[0]?.getText() ?? "",
+        options: node.arguments[1]?.getText() ?? "",
+        handler,
+      });
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  assert.equal(
+    deepLinks.length,
+    1,
+    "the banner opens the settings dialog once",
+  );
+  assert.equal(deepLinks[0].tab, '"chat"');
+  assert.match(deepLinks[0].options, /scrollTarget:\s*"chat-canvas-network"/);
+  assert.equal(deepLinks[0].handler, "onClick");
 });

--- a/studio/frontend/tests/keyboard-shortcuts.test.ts
+++ b/studio/frontend/tests/keyboard-shortcuts.test.ts
@@ -347,7 +347,11 @@ test("the workspace chords land where the guard lets them", async () => {
   );
   assert.match(
     root,
-    /useShortcut\("switchToTrain", goTo\("\/studio"\), \{\n\s*enabled: !isAuthFlowRoute && !chatOnlyMeasured,/,
+    /const routeShortcutEnabled = !isAuthFlowRoute && !settingsDialogOpen;/,
+  );
+  assert.match(
+    root,
+    /useShortcut\("switchToTrain", goTo\("\/studio"\), \{\n\s*enabled: routeShortcutEnabled && !chatOnlyMeasured,/,
   );
   // Video has its own predicate rather than the chat-only one: /video checks
   // auth and nothing else, so the chord would land on the unsupported-hardware
@@ -358,7 +362,7 @@ test("the workspace chords land where the guard lets them", async () => {
   );
   assert.match(
     root,
-    /useShortcut\("switchToVideo", goTo\("\/video"\), \{\n\s*enabled: !isAuthFlowRoute && !videoDisabled,/,
+    /useShortcut\("switchToVideo", goTo\("\/video"\), \{\n\s*enabled: routeShortcutEnabled && !videoDisabled,/,
   );
   const sidebar = await readFile(
     new URL("../src/components/app-sidebar.tsx", import.meta.url),
@@ -1372,7 +1376,7 @@ test("the new-chat chords stay out of the auth flow", async () => {
     const at = root.indexOf(`"${id}"`);
     assert.ok(at !== -1, `${id} is registered`);
     const call = root.slice(at, root.indexOf("\n  );", at) + 5);
-    assert.match(call, /enabled: !isAuthFlowRoute/, `${id} is gated`);
+    assert.match(call, /enabled: routeShortcutEnabled/, `${id} is gated`);
   }
 });
 
@@ -1387,7 +1391,7 @@ test("switching back to Chat lands on the view the user left", async () => {
   assert.ok(at !== -1, "switchToChat is registered");
   const call = root.slice(at, root.indexOf("\n  );", at) + 5);
   assert.match(call, /navigate\(\{ to: "\/chat", search: chatSearch \}\)/);
-  assert.match(call, /enabled: !isAuthFlowRoute/);
+  assert.match(call, /enabled: routeShortcutEnabled/);
   // The other workspaces keep the bare helper; only chat carries a search.
   assert.match(root, /useShortcut\("switchToImages", goTo\("\/images"\)/);
   // location.search is the raw URL's, not the matched route's, so a seeded

--- a/studio/frontend/tests/lazy-locale-loading.test.ts
+++ b/studio/frontend/tests/lazy-locale-loading.test.ts
@@ -41,7 +41,6 @@ function fireStorageEvent(key: string | null, newValue: string | null): void {
 }
 
 let documentLanguage = "";
-let documentDirection = "";
 Object.assign(globalThis, {
   document: {
     documentElement: {
@@ -50,12 +49,6 @@ Object.assign(globalThis, {
       },
       set lang(value: string) {
         documentLanguage = value;
-      },
-      get dir() {
-        return documentDirection;
-      },
-      set dir(value: string) {
-        documentDirection = value;
       },
     },
   },
@@ -85,18 +78,7 @@ test("initialization waits for the saved locale catalog before committing it", a
   assert.equal(localeStore.getLocale(), "de");
   assert.equal(localeStore.getLocalePreference(), "de");
   assert.equal(documentLanguage, "de");
-  assert.equal(documentDirection, "ltr");
   assert.equal(messagesModule.translate("common.cancel"), "Abbrechen");
-});
-
-test("the document direction follows the committed locale", async () => {
-  assert.equal(await localeStore.setLocale("ar"), "applied");
-  assert.equal(documentLanguage, "ar");
-  assert.equal(documentDirection, "rtl");
-
-  assert.equal(await localeStore.setLocale("en"), "applied");
-  assert.equal(documentLanguage, "en");
-  assert.equal(documentDirection, "ltr");
 });
 
 test("concurrent requests share one catalog load", async () => {

--- a/studio/frontend/tests/lazy-locale-loading.test.ts
+++ b/studio/frontend/tests/lazy-locale-loading.test.ts
@@ -41,6 +41,7 @@ function fireStorageEvent(key: string | null, newValue: string | null): void {
 }
 
 let documentLanguage = "";
+let documentDirection = "";
 Object.assign(globalThis, {
   document: {
     documentElement: {
@@ -49,6 +50,12 @@ Object.assign(globalThis, {
       },
       set lang(value: string) {
         documentLanguage = value;
+      },
+      get dir() {
+        return documentDirection;
+      },
+      set dir(value: string) {
+        documentDirection = value;
       },
     },
   },
@@ -78,7 +85,18 @@ test("initialization waits for the saved locale catalog before committing it", a
   assert.equal(localeStore.getLocale(), "de");
   assert.equal(localeStore.getLocalePreference(), "de");
   assert.equal(documentLanguage, "de");
+  assert.equal(documentDirection, "ltr");
   assert.equal(messagesModule.translate("common.cancel"), "Abbrechen");
+});
+
+test("the document direction follows the committed locale", async () => {
+  assert.equal(await localeStore.setLocale("ar"), "applied");
+  assert.equal(documentLanguage, "ar");
+  assert.equal(documentDirection, "rtl");
+
+  assert.equal(await localeStore.setLocale("en"), "applied");
+  assert.equal(documentLanguage, "en");
+  assert.equal(documentDirection, "ltr");
 });
 
 test("concurrent requests share one catalog load", async () => {

--- a/studio/frontend/tests/module-scope-cycle-safety.test.ts
+++ b/studio/frontend/tests/module-scope-cycle-safety.test.ts
@@ -21,6 +21,10 @@ import ts from "typescript";
 const SRC = fileURLToPath(new URL("../src", import.meta.url));
 const KEYS = path.join(SRC, "features/chat/stores/sidebar-organization-keys.ts");
 const GENERAL_TAB = path.join(SRC, "features/settings/tabs/general-tab.tsx");
+const CHAT_RUNTIME = path.join(
+  SRC,
+  "features/chat/stores/chat-runtime-store.ts",
+);
 
 const parse = (file: string, text: string) =>
   ts.createSourceFile(
@@ -149,5 +153,18 @@ test("the model memory hook imports no feature barrel", async () => {
     barrels,
     [],
     "a bare @/features/<name> import here closes the cycle and the dev server white screens again",
+  );
+});
+
+test("the chat runtime imports the Hub token store directly", async () => {
+  const text = await readFile(CHAT_RUNTIME, "utf8");
+  const specifiers = staticSpecifiers(CHAT_RUNTIME, text);
+  assert.ok(
+    specifiers.includes("@/features/hub/stores/hf-token-store"),
+    "chat-runtime-store.ts must import the token store directly",
+  );
+  assert.ok(
+    !specifiers.includes("@/features/hub"),
+    "the Hub barrel closes a module-scope cycle through the model picker",
   );
 });

--- a/studio/frontend/tests/module-scope-cycle-safety.test.ts
+++ b/studio/frontend/tests/module-scope-cycle-safety.test.ts
@@ -25,6 +25,15 @@ const CHAT_RUNTIME = path.join(
   SRC,
   "features/chat/stores/chat-runtime-store.ts",
 );
+const PRESET_LOAD_CONFIG = path.join(
+  SRC,
+  "features/chat/presets/preset-load-config.ts",
+);
+const APPLY_PER_MODEL_CONFIG = path.join(
+  SRC,
+  "features/model-picker/model-config/apply-per-model-config.ts",
+);
+const TOOL_GROUP = path.join(SRC, "components/assistant-ui/tool-group.tsx");
 
 const parse = (file: string, text: string) =>
   ts.createSourceFile(
@@ -167,4 +176,22 @@ test("the chat runtime imports the Hub token store directly", async () => {
     !specifiers.includes("@/features/hub"),
     "the Hub barrel closes a module-scope cycle through the model picker",
   );
+});
+
+test("the startup cycle imports no feature barrel", async () => {
+  for (const file of [
+    PRESET_LOAD_CONFIG,
+    APPLY_PER_MODEL_CONFIG,
+    TOOL_GROUP,
+  ]) {
+    const text = await readFile(file, "utf8");
+    const barrels = staticSpecifiers(file, text).filter((specifier) =>
+      /^@\/features\/[^/]+$/.test(specifier),
+    );
+    assert.deepEqual(
+      barrels,
+      [],
+      `${path.relative(SRC, file)} closes the chat-store and model-picker cycle`,
+    );
+  }
 });

--- a/studio/frontend/tests/settings-deep-open-requests.test.ts
+++ b/studio/frontend/tests/settings-deep-open-requests.test.ts
@@ -19,6 +19,7 @@ function reset(): void {
     activeTab: "general",
     scrollTarget: null,
     opener: null,
+    openerFallback: null,
     archivedRequested: null,
   });
 }
@@ -131,4 +132,14 @@ test("the canvas network target lands on Chat and stays until Chat reads it", ()
   assert.equal(store.getState().scrollTarget, "chat-canvas-network");
   store.getState().setActiveTab("about");
   assert.equal(store.getState().scrollTarget, null);
+});
+
+test("a deep link can provide a stable focus fallback", () => {
+  reset();
+  const fallback = {} as HTMLElement;
+  store.getState().openDialog("chat", {
+    scrollTarget: "chat-canvas-network",
+    focusFallback: fallback,
+  });
+  assert.equal(store.getState().openerFallback, fallback);
 });

--- a/studio/frontend/tests/settings-deep-open-requests.test.ts
+++ b/studio/frontend/tests/settings-deep-open-requests.test.ts
@@ -123,3 +123,12 @@ test("consuming a scroll target clears it", () => {
   store.getState().consumeScrollTarget("about-updates");
   assert.equal(store.getState().scrollTarget, null);
 });
+
+test("the canvas network target lands on Chat and stays until Chat reads it", () => {
+  reset();
+  store.getState().openDialog("chat", { scrollTarget: "chat-canvas-network" });
+  assert.equal(store.getState().activeTab, "chat");
+  assert.equal(store.getState().scrollTarget, "chat-canvas-network");
+  store.getState().setActiveTab("about");
+  assert.equal(store.getState().scrollTarget, null);
+});

--- a/studio/frontend/tests/settings-deep-open-requests.test.ts
+++ b/studio/frontend/tests/settings-deep-open-requests.test.ts
@@ -143,3 +143,21 @@ test("a deep link can provide a stable focus fallback", () => {
   });
   assert.equal(store.getState().openerFallback, fallback);
 });
+
+test("repeated opens preserve the external focus targets", () => {
+  reset();
+  const opener = {} as HTMLElement;
+  const fallback = {} as HTMLElement;
+  store.setState({ open: true, opener, openerFallback: fallback });
+
+  const repeatOpens = [
+    () => store.getState().openDialog("keyboard-shortcuts"),
+    () => store.getState().openArchivedChats(),
+    () => store.getState().openArchivedMedia("images"),
+  ];
+  for (const repeatOpen of repeatOpens) {
+    repeatOpen();
+    assert.equal(store.getState().opener, opener);
+    assert.equal(store.getState().openerFallback, fallback);
+  }
+});

--- a/studio/frontend/tests/shortcut-dispatch-guards.test.ts
+++ b/studio/frontend/tests/shortcut-dispatch-guards.test.ts
@@ -5,6 +5,8 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+import ts from "typescript";
+
 import { registerBundlerResolver } from "./helpers/kit.ts";
 
 registerBundlerResolver();
@@ -181,6 +183,66 @@ test("both composers gate dictation on the foreground", async () => {
       `${path} starts the microphone behind a modal`,
     );
   }
+});
+
+test("route shortcuts stay idle while Settings is open", async () => {
+  const sourceText = await readFile(
+    new URL("../src/app/routes/__root.tsx", import.meta.url),
+    "utf8",
+  );
+  const source = ts.createSourceFile(
+    "__root.tsx",
+    sourceText,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const enabledById = new Map<string, string>();
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText() === "useShortcut" &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      ts.isObjectLiteralExpression(node.arguments[2])
+    ) {
+      const enabled = node.arguments[2].properties.find(
+        (property): property is ts.PropertyAssignment =>
+          ts.isPropertyAssignment(property) && property.name.getText() === "enabled",
+      );
+      if (enabled) {
+        enabledById.set(node.arguments[0].text, enabled.initializer.getText());
+      }
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+
+  for (const id of [
+    "newChat",
+    "newTemporaryChat",
+    "newStandaloneChat",
+    "switchToChat",
+    "switchToProjects",
+    "switchToHub",
+    "switchToRecipes",
+    "switchToImages",
+    "switchToAudio",
+    "switchToExport",
+  ]) {
+    assert.equal(enabledById.get(id), "routeShortcutEnabled", id);
+  }
+  assert.equal(
+    enabledById.get("switchToTrain"),
+    "routeShortcutEnabled && !chatOnlyMeasured",
+  );
+  assert.equal(
+    enabledById.get("switchToVideo"),
+    "routeShortcutEnabled && !videoDisabled",
+  );
+  assert.match(
+    sourceText,
+    /const routeShortcutEnabled = !isAuthFlowRoute && !settingsDialogOpen;/,
+  );
 });
 
 // The sidebar used to hold the unread set in component state, which died with
@@ -523,8 +585,8 @@ test("the workspace chords wait on the same verdict their rows do", async () => 
     new URL("../src/app/routes/__root.tsx", import.meta.url),
     "utf8",
   );
-  assert.match(root, /enabled: !isAuthFlowRoute && !chatOnlyMeasured,/);
-  assert.match(root, /enabled: !isAuthFlowRoute && !videoDisabled,/);
+  assert.match(root, /enabled: routeShortcutEnabled && !chatOnlyMeasured,/);
+  assert.match(root, /enabled: routeShortcutEnabled && !videoDisabled,/);
   const rowState = await readFile(
     new URL("../src/components/nav-row-state.ts", import.meta.url),
     "utf8",

--- a/tests/studio/probe_dismiss_guard.py
+++ b/tests/studio/probe_dismiss_guard.py
@@ -48,12 +48,11 @@ The guard must swallow too little nowhere:
                  swallow-too-little direction only: the second pointer's own press raises no
                  `click` while a touch point is live, on either tree, so it cannot also stand in
                  for the swallow-too-much direction.
-  dismiss_then_  click the button to dismiss, then press Space, the key a reader uses to scroll.
-    space        No click is involved for the guard to swallow: the press it DID swallow left the
-                 button focused, and a focused button activates on Space. Discriminates on
-                 chromium, firefox and webkit. The modal shape cannot reach it, because with
-                 `pointer-events: none` on the body the press lands on `HTML` and focus never
-                 moves off `BODY`.
+  dismiss_then_  click the button to dismiss, then press Space. The swallowed press must move
+    space        focus off the dangerous control and back to the menu trigger. Space then reopens
+                 the menu instead of activating Delete. Discriminates on chromium, firefox and
+                 webkit. The modal shape cannot reach it, because with `pointer-events: none` on
+                 the body the press lands on `HTML` and focus never moves off `BODY`.
 
 and too much nowhere:
 
@@ -113,6 +112,12 @@ CHARS = int(os.environ.get("PROBE_CHARS", "25000"))
 HOLD_MS = int(os.environ.get("PROBE_HOLD_MS", "600"))
 # Deliberately beyond CLICK_GRACE_MS (500).
 GRACE_HOLD_MS = int(os.environ.get("PROBE_GRACE_HOLD_MS", "900"))
+SPACE_REOPEN_CASES = {
+    "held_space_then_space",
+    "dismiss_then_space",
+    "drag_then_space",
+    "blur_then_space",
+}
 
 OPEN_MENU_JS = """
 async () => {
@@ -144,6 +149,16 @@ FACTS_JS = """
     bodyPointerEvents: getComputedStyle(document.body).pointerEvents,
     deleteRect: r ? { x: r.x + r.width / 2, y: r.y + r.height / 2 } : null,
     assistantMessages: document.querySelectorAll('[data-role="assistant"]').length,
+  };
+}
+"""
+
+FOCUS_FACTS_JS = """
+() => {
+  const trigger = window.__heavyThread.actionButton("More");
+  return {
+    menuClosed: !document.querySelector(".aui-action-bar-more-content"),
+    focusReturnedToTrigger: document.activeElement === trigger,
   };
 }
 """
@@ -284,6 +299,7 @@ async def one_case(
     if not opened.get("ok"):
         return {"case": case, "error": "menu never opened"}
     before = await page.evaluate(FACTS_JS)
+    before_space = None
     rect = before["deleteRect"]
     if not rect:
         return {"case": case, "error": "no Delete button"}
@@ -342,11 +358,13 @@ async def one_case(
         await page.wait_for_timeout(120)
         await page.keyboard.up("Space")
         await page.wait_for_timeout(300)
+        before_space = await page.evaluate(FOCUS_FACTS_JS)
         await page.keyboard.press("Space")
     elif case == "dismiss_then_space":
         # A swallowed dismissal must not leave Delete focused for Space activation.
         await page.mouse.click(x, y)
         await page.wait_for_timeout(300)
+        before_space = await page.evaluate(FOCUS_FACTS_JS)
         await page.keyboard.press("Space")
     elif case in ("drag_then_space", "blur_then_space"):
         # A drag may retarget the click; blur exercises the no-click cleanup path.
@@ -361,6 +379,7 @@ async def one_case(
         await page.mouse.move(spot["x"], spot["y"])
         await page.mouse.up()
         await page.wait_for_timeout(700)
+        before_space = await page.evaluate(FOCUS_FACTS_JS)
         await page.keyboard.press("Space")
     elif case == "dismiss_on_composer":
         # Dismissing into the composer must preserve its caret.
@@ -562,7 +581,7 @@ async def one_case(
 
     await page.wait_for_timeout(1500)
     after = await page.evaluate(FACTS_JS)
-    return {
+    result = {
         "case": case,
         "bodyPointerEvents": before["bodyPointerEvents"],
         "assistantMessagesBefore": before["assistantMessages"],
@@ -570,6 +589,15 @@ async def one_case(
         "deleted": after["assistantMessages"] < before["assistantMessages"],
         "menuClosed": not after["menuOpen"],
     }
+    if before_space is not None:
+        result.update(
+            {
+                "menuClosedBeforeSpace": before_space["menuClosed"],
+                "focusReturnedToTrigger": before_space["focusReturnedToTrigger"],
+                "menuReopenedBySpace": after["menuOpen"],
+            }
+        )
+    return result
 
 
 async def run(engine: str, cases: list[str]) -> dict:
@@ -636,7 +664,21 @@ def main() -> int:
     for case, why in skipped:
         print(f"[probe] SKIPPED {case}: {why}", flush = True)
     deleted = [c["case"] for c in result["cases"] if c.get("deleted")]
-    stuck = [c["case"] for c in result["cases"] if "menuClosed" in c and not c["menuClosed"]]
+    stuck = [
+        c["case"]
+        for c in result["cases"]
+        if "menuClosed" in c and not c["menuClosed"] and c["case"] not in SPACE_REOPEN_CASES
+    ]
+    unsafe_space = [
+        c["case"]
+        for c in result["cases"]
+        if c["case"] in SPACE_REOPEN_CASES
+        and (
+            not c.get("menuClosedBeforeSpace")
+            or not c.get("focusReturnedToTrigger")
+            or not c.get("menuReopenedBySpace")
+        )
+    ]
     broken = [c["case"] for c in result["cases"] if c.get("error")]
     over = [
         c["case"]
@@ -658,7 +700,13 @@ def main() -> int:
         print(f"[probe] FAIL: cases did not run: {broken}", flush = True)
     if stuck:
         print(f"[probe] FAIL: the menu did not close on {stuck}", flush = True)
-    if deleted or broken or stuck:
+    if unsafe_space:
+        print(
+            "[probe] FAIL: the Space follow-up did not dismiss safely, restore trigger focus, "
+            f"and reopen the menu: {unsafe_space}",
+            flush = True,
+        )
+    if deleted or broken or stuck or unsafe_space:
         return 1
     print("[probe] PASS: no dismissal variant reached the control underneath", flush = True)
     return 0


### PR DESCRIPTION
When "Allow canvas network access" is off (the default), a canvas that loads anything from the internet, like a script from a CDN, shows up blank. The only hint was a small line at the bottom of the canvas, and it never mentioned that there is a setting for this. So it looked like the canvas was broken.

This change replaces that line with a clear message at the top of the canvas. It says network access is off, names the sites that were blocked, and offers three options: open the setting in Settings > Chat, allow it just for this canvas, or close the message.

Nothing about how canvases are blocked or allowed has changed. The setting, its default, and the backend are the same. Tests cover the new buttons, and the message was checked in Chrome, Firefox, and Safari engines, in light and dark mode, on narrow layouts, and in all supported languages.