### PR TITLE
studio: accept shared youtube clipboard links

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -59,7 +59,7 @@ import {
   promptQueueActiveItemChanged,
   reorderPromptQueueItems,
   pasteClipboardFiles,
-  extractYoutubeVideoId,
+  extractYoutubeVideoUrlFromClipboard,
   pasteLongTextAsFile,
   isPlainPasteChord,
   plainPasteStillCounts,
@@ -2397,17 +2397,17 @@ const Composer: FC<{
       );
       plainPasteAtRef.current = 0;
       const pastedText = event.clipboardData?.getData("text/plain") ?? "";
-      if (extractYoutubeVideoId(pastedText)) {
-        setYoutubeLink(pastedText.trim());
-      }
+      const pastedYoutubeUrl = extractYoutubeVideoUrlFromClipboard(
+        event.clipboardData,
+      );
       // Bulk text pastes attach as a file instead of filling the input, except
       // in image-edit mode, whose submit path takes an inline instruction only.
       const input = event.currentTarget;
+      const { selectionStart, selectionEnd, value } = input;
       // An attachment is serialised after all inline text, so only a paste that
       // was already heading to the end can become one. Mid-text pastes stay
       // inline, where the order the user typed them in survives.
       const pasteGoesLast = input.selectionEnd === input.value.length;
-      const { selectionStart, selectionEnd, value } = input;
       // Swallowing the paste also swallowed the replacement the browser would
       // have made. Only once the attachment is in, and only if the composer is
       // still the one that was pasted into, or a failed paste eats the text.
@@ -2446,6 +2446,30 @@ const Composer: FC<{
             description: "The clipboard item is unsupported, unreadable, or exceeds its size limit.",
           }),
       );
+      if (event.defaultPrevented) return;
+      if (pastedYoutubeUrl) {
+        setYoutubeLink(pastedYoutubeUrl);
+        if (!pastedText.includes(pastedYoutubeUrl)) {
+          event.preventDefault();
+          const youtubePasteText =
+            pastedText.length === 0
+              ? pastedYoutubeUrl
+              : `${pastedText}${pastedText.endsWith("\n") ? "" : "\n"}${pastedYoutubeUrl}`;
+          const caret = selectionStart + youtubePasteText.length;
+          aui
+            .composer()
+            .setText(
+              value.slice(0, selectionStart) +
+                youtubePasteText +
+                value.slice(selectionEnd),
+            );
+          requestAnimationFrame(() => input.setSelectionRange(caret, caret));
+          if (justSentRef.current?.draftKey === draftKeyRef.current) {
+            justSentRef.current = null;
+          }
+          return;
+        }
+      }
       // A paste is a gesture, so it retires the guard and re-pasting the sent
       // prompt goes through. Last, and only when the browser will really insert
       // the text: a payload carrying files is preventDefaulted above, so

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -215,7 +215,10 @@ export type { ProjectRecord } from "./types";
 export { clearAllChats, countAllChats } from "./utils/clear-all-chats";
 export { offerToDeleteKeptSandboxes } from "./utils/offer-kept-sandbox-files";
 export { pasteClipboardFiles } from "./utils/clipboard-files";
-export { extractYoutubeVideoId } from "./utils/youtube-url";
+export {
+  extractYoutubeVideoId,
+  extractYoutubeVideoUrlFromClipboard,
+} from "./utils/youtube-url";
 export {
   isSearchImagesToolResult,
   searchImagePath,

--- a/studio/frontend/src/features/chat/utils/clipboard-files.ts
+++ b/studio/frontend/src/features/chat/utils/clipboard-files.ts
@@ -204,7 +204,11 @@ export function pasteClipboardFiles(
   }
 
   const advertisesFiles = clipboardAdvertisesFiles(clipboardData);
-  if (!advertisesFiles && clipboardHasPlainText(clipboardData)) return;
+  const hasUriList = Array.from(clipboardData.types).some((type) =>
+    type.toLowerCase().includes("uri-list"),
+  );
+  if (!advertisesFiles && (clipboardHasPlainText(clipboardData) || hasUriList))
+    return;
 
   if (advertisesFiles) event.preventDefault();
   addNativeClipboardFiles(addFiles, onError);

--- a/studio/frontend/src/features/chat/utils/youtube-url.ts
+++ b/studio/frontend/src/features/chat/utils/youtube-url.ts
@@ -14,6 +14,9 @@ const WATCH_HOSTS = new Set([
 ]);
 const SHORT_HOSTS = new Set(["youtu.be"]);
 const ID_PATH_PREFIXES = ["/shorts/", "/embed/", "/live/", "/v/"];
+const MAX_CLIPBOARD_TEXT_LENGTH = 8192;
+const WHITESPACE = /\s+/;
+const LINE_BREAK = /\r?\n/;
 
 /** The 11-character video id in a YouTube URL, or null if it is not one. */
 export function extractYoutubeVideoId(value: string): string | null {
@@ -43,4 +46,29 @@ export function extractYoutubeVideoId(value: string): string | null {
     }
   }
   return VIDEO_ID.test(candidate) ? candidate : null;
+}
+
+function findYoutubeVideoUrl(value: string, uriList = false): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_CLIPBOARD_TEXT_LENGTH) {
+    return null;
+  }
+  for (const part of trimmed.split(uriList ? LINE_BREAK : WHITESPACE)) {
+    const candidate = part.trim();
+    if (uriList && candidate.startsWith("#")) continue;
+    if (extractYoutubeVideoId(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function extractYoutubeVideoUrlFromClipboard(
+  clipboardData: { getData(type: string): string } | null,
+): string | null {
+  if (!clipboardData) return null;
+  return (
+    findYoutubeVideoUrl(clipboardData.getData("text/plain")) ??
+    findYoutubeVideoUrl(clipboardData.getData("text/uri-list"), true)
+  );
 }

--- a/studio/frontend/tests/youtube-url.test.ts
+++ b/studio/frontend/tests/youtube-url.test.ts
@@ -4,7 +4,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { extractYoutubeVideoId } from "../src/features/chat/utils/youtube-url.ts";
+import {
+  extractYoutubeVideoId,
+  extractYoutubeVideoUrlFromClipboard,
+} from "../src/features/chat/utils/youtube-url.ts";
 
 const ID = "dQw4w9WgXcQ";
 
@@ -42,4 +45,35 @@ test("rejects look-alike hosts and non-video URLs", () => {
   ]) {
     assert.equal(extractYoutubeVideoId(url), null, url);
   }
+});
+
+test("finds YouTube links in clipboard text and URI payloads", () => {
+  const shortUrl = `https://youtu.be/${ID}`;
+  const cases: Array<[Record<string, string>, string | null]> = [
+    [{ "text/plain": `Rick Astley\n${shortUrl}` }, shortUrl],
+    [{ "text/uri-list": `# copied link\r\n${shortUrl}\r\n` }, shortUrl],
+    [{ "text/plain": "Rick Astley", "text/uri-list": shortUrl }, shortUrl],
+    [
+      { "text/uri-list": `# source ${shortUrl}\r\nhttps://example.com/video` },
+      null,
+    ],
+  ];
+  for (const [data, expected] of cases) {
+    assert.equal(
+      extractYoutubeVideoUrlFromClipboard({
+        getData: (type: string) => data[type] ?? "",
+      }),
+      expected,
+    );
+  }
+});
+
+test("rejects clipboard payloads without a YouTube video link", () => {
+  assert.equal(extractYoutubeVideoUrlFromClipboard(null), null);
+  assert.equal(
+    extractYoutubeVideoUrlFromClipboard({
+      getData: () => "Read https://example.com/watch?v=dQw4w9WgXcQ",
+    }),
+    null,
+  );
 });


### PR DESCRIPTION
Detect YouTube URLs in shared clipboard payloads so the transcript attachment offer works for mobile and LAN clients.

- accept title-plus-link text and `text/uri-list` payloads
- preserve the plain-text label when the URL is stored separately
- keep file and long-text attachment handling ahead of link insertion
- ignore URI-list comments when selecting a video URL

## Checks
- `node --experimental-strip-types --test tests/youtube-url.test.ts` (4 passed)
- `npm run typecheck`
- `npm run build`
- Playwright smoke tests in Chromium and WebKit with a mobile viewport over LAN HTTP
