### PR TITLE
Shed inherited provider routing before spawning the local Claude subagent

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -162,7 +162,20 @@ class _PassthroughCommand(TyperCommand):
         return remaining
 
 
-_CLAUDE_ENV_UNSET = ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
+_CLAUDE_ENV_UNSET = (
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    # Gateway/provider routing outranks ANTHROPIC_BASE_URL in Claude Code, so
+    # an inherited Foundry/Bedrock/Vertex setup silently sends local-agent
+    # traffic to the remote gateway, which 404s the local model id (#9864).
+    # With the toggles unset, the companion *_BASE_URL vars are inert; the
+    # Foundry pair is stripped anyway since it is provider-specific.
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "ANTHROPIC_FOUNDRY_BASE_URL",
+    "ANTHROPIC_FOUNDRY_RESOURCE",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+)
 _CODEX_ENV_UNSET = ("OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_ACCESS_TOKEN")
 
 # Shared by every agent command; only the config/env/command differ.
@@ -3532,14 +3545,7 @@ def _wsl_shim_env(
 
 
 _NPM_CMD_SHIM_HEAD = (
-    "@ECHO off\n"
-    "GOTO start\n"
-    ":find_dp0\n"
-    "SET dp0=%~dp0\n"
-    "EXIT /b\n"
-    ":start\n"
-    "SETLOCAL\n"
-    "CALL :find_dp0\n"
+    "@ECHO off\nGOTO start\n:find_dp0\nSET dp0=%~dp0\nEXIT /b\n:start\nSETLOCAL\nCALL :find_dp0\n"
 )
 _NPM_NODE_CMD_SHIM_PREFIX = (
     re.escape(_NPM_CMD_SHIM_HEAD)

--- a/unsloth_cli/tests/test_claude_subagent_mcp.py
+++ b/unsloth_cli/tests/test_claude_subagent_mcp.py
@@ -259,6 +259,51 @@ def test_local_child_uses_unsloth_without_overwriting_parent_auth(
     assert "CLAUDE_CODE_OAUTH_TOKEN" not in child_env
 
 
+def test_local_child_sheds_inherited_provider_routing(monkeypatch, tmp_path):
+    # Claude Code's Foundry/Bedrock/Vertex routing outranks ANTHROPIC_BASE_URL,
+    # so an inherited gateway setup silently sends "local agent" traffic to the
+    # remote gateway, which then 404s the local model id (#9864).
+    captured = {}
+    monkeypatch.setenv("UNSLOTH_CLAUDE_SUBAGENT_BASE_URL", "http://127.0.0.1:8888")
+    monkeypatch.setenv("UNSLOTH_CLAUDE_SUBAGENT_API_KEY", "sk-unsloth-test")
+    monkeypatch.setenv("UNSLOTH_CLAUDE_SUBAGENT_MODEL", "unsloth/model-GGUF:Q4_K_M")
+    monkeypatch.setenv("CLAUDE_CODE_USE_FOUNDRY", "1")
+    monkeypatch.setenv("ANTHROPIC_FOUNDRY_BASE_URL", "https://gateway.azure-api.net/anthropic")
+    monkeypatch.setenv("ANTHROPIC_FOUNDRY_RESOURCE", "corp-foundry")
+    monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+    monkeypatch.setenv("CLAUDE_CODE_USE_VERTEX", "1")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(bridge.shutil, "which", lambda _: "/usr/local/bin/claude")
+    monkeypatch.setattr(bridge, "_claude_flags", lambda model: ["--settings", "{}"])
+
+    class Process:
+        pid = 1234
+        returncode = 0
+
+        def communicate(self, timeout):
+            return json.dumps({"is_error": False, "result": "LOCAL_OK"}), ""
+
+        def poll(self):
+            return self.returncode
+
+    def popen(command, **kwargs):
+        captured.update(kwargs)
+        return Process()
+
+    monkeypatch.setattr(bridge.subprocess, "Popen", popen)
+    assert bridge.run_local_agent("reply exactly LOCAL_OK") == "LOCAL_OK"
+    child_env = captured["env"]
+    assert child_env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8888"
+    for name in (
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "ANTHROPIC_FOUNDRY_BASE_URL",
+        "ANTHROPIC_FOUNDRY_RESOURCE",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+    ):
+        assert child_env.get(name, "") == "", name
+
+
 def test_read_only_local_child_uses_plan_mode(monkeypatch, tmp_path):
     captured = {}
     monkeypatch.setenv("UNSLOTH_CLAUDE_SUBAGENT_BASE_URL", "http://127.0.0.1:8888")
@@ -394,8 +439,7 @@ def test_stop_child_kills_survivors_after_leader_exit(monkeypatch, tmp_path):
     monkeypatch.setattr(bridge, "_CANCEL_GRACE_SECONDS", 0.2)
     marker = tmp_path / "grandchild-survived"
     grandchild = (
-        "import pathlib, sys, time; time.sleep(1.0); "
-        "pathlib.Path(sys.argv[1]).write_text('alive')"
+        "import pathlib, sys, time; time.sleep(1.0); pathlib.Path(sys.argv[1]).write_text('alive')"
     )
     process = subprocess.Popen(
         [


### PR DESCRIPTION
## What

Fixes #9864. With Claude Code configured for Azure AI Foundry (or Bedrock/Vertex) in the parent shell, the Unsloth local-agent bridge spawned a child that inherited those routing vars — and Claude Code's provider routing **outranks** `ANTHROPIC_BASE_URL`, so every `unsloth_agent` task went to the remote gateway instead of the local server, failing with a misleading `unrecognized_model` 404. Beyond the breakage, prompts the user intended to keep on-device left the machine.

## How

`_CLAUDE_ENV_UNSET` grows the routing toggles (`CLAUDE_CODE_USE_FOUNDRY` / `_BEDROCK` / `_VERTEX`) plus the Foundry pair (`ANTHROPIC_FOUNDRY_BASE_URL`, `ANTHROPIC_FOUNDRY_RESOURCE`), exactly as the issue proposed. One list covers all three consumers: the MCP subagent bridge, `unsloth start claude`, and the printed `--no-launch` recipes (POSIX inline blanks and PowerShell `Remove-Item` lines alike). With the toggles unset the provider-specific `*_BASE_URL` companions for Bedrock/Vertex are inert, so those are left alone — the goal is restoring local routing, not scrubbing unrelated cloud config.

## Reproduced → fixed

New test `test_local_child_sheds_inherited_provider_routing` sets the five vars in the parent env and asserts the child env carries none of them while `ANTHROPIC_BASE_URL` still points at the local server. It fails on main (the child inherits all five) and passes with this change. The WSL-bridge path blanks the same names to empty strings, the treatment the existing credential vars already get.

## Tests

Full `unsloth_cli/tests`: 1053 passed, 7 skipped. Ruff clean, kwarg-spacing formatter applied.