### PR TITLE
Chat: keep id-less parallel tool calls from collapsing into one slot

### DIFF
--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -357,8 +357,7 @@ def _same_json_value(left: Any, right: Any) -> bool:
         return False
     if isinstance(left, list):
         return len(left) == len(right) and all(
-            _same_json_value(left_item, right_item)
-            for left_item, right_item in zip(left, right)
+            _same_json_value(left_item, right_item) for left_item, right_item in zip(left, right)
         )
     if isinstance(left, dict):
         return left.keys() == right.keys() and all(

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -647,10 +647,7 @@ class _Turn:
             complete, tail = _split_top_level_json_documents(combined)
             segments = [*complete, *([tail] if tail else [])]
             if not repeated_snapshot and len(segments) > 1:
-                if (
-                    not current["function"]["name"]
-                    and not (current_complete and not current_tail)
-                ):
+                if not current["function"]["name"] and not (current_complete and not current_tail):
                     current["function"]["name"] = name_fragment
                 current["function"]["arguments"] = segments[0]
                 self.incomplete_split_keys.discard(key)
@@ -714,11 +711,7 @@ class _Turn:
         for position, (key, call) in enumerate(ordered_calls):
             fallback_id = _mint_streamed_tool_call_id(streamed)
             raw_call_id = call.get("id")
-            stream_id = (
-                raw_call_id
-                if isinstance(raw_call_id, str) and raw_call_id
-                else fallback_id
-            )
+            stream_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id else fallback_id
             if key is not None:
                 if stream_id in streamed:
                     stream_id = _mint_streamed_tool_call_id(streamed)

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -690,7 +690,10 @@ class _Turn:
                         split_call["id"] = stable_id
                         self.key_by_call_id[stable_id] = split_key
                     if segment_index == 0 and isinstance(extra, dict) and extra:
-                        split_call["extra_content"] = dict(extra)
+                        metadata_call = (
+                            current if stable_id and not had_existing_arguments else split_call
+                        )
+                        metadata_call["extra_content"] = dict(extra)
                     split_complete, split_tail = _split_top_level_json_documents(segment)
                     if not split_complete or split_tail:
                         self.incomplete_split_keys.add(split_key)

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -366,6 +366,17 @@ def _same_json_value(left: Any, right: Any) -> bool:
     return left == right
 
 
+def _is_repeated_json_snapshot(existing: str, fragment: str) -> bool:
+    if not fragment.strip():
+        return False
+    if existing == fragment:
+        return True
+    if "{" not in fragment and "[" not in fragment:
+        return False
+    complete, tail = _split_top_level_json_documents(fragment)
+    return len(complete) == 1 and not tail and _same_json_document(existing, fragment)
+
+
 def _delta_text(content: Any) -> str:
     """Text of a content delta, whether it is a plain string or content parts.
 
@@ -646,6 +657,10 @@ class _Turn:
                 # reorder parallel calls against what the model actually sent.
             current = self.by_index[key]
             exact_stable_id = bool(stable_id and current.get("id") == stable_id)
+            if exact_stable_id and _is_repeated_json_snapshot(
+                current["function"]["arguments"], args_fragment
+            ):
+                repeated_snapshot = True
             same_stable_call = exact_stable_id or adopted_stable_id
             current_complete: list[str] = []
             current_tail = current["function"]["arguments"]

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -369,12 +369,12 @@ def _same_json_value(left: Any, right: Any) -> bool:
 def _is_repeated_json_snapshot(existing: str, fragment: str) -> bool:
     if not fragment.strip():
         return False
-    if existing == fragment:
-        return True
     if "{" not in fragment and "[" not in fragment:
         return False
     complete, tail = _split_top_level_json_documents(fragment)
-    return len(complete) == 1 and not tail and _same_json_document(existing, fragment)
+    if len(complete) != 1 or tail:
+        return False
+    return existing == fragment or _same_json_document(existing, fragment)
 
 
 def _delta_text(content: Any) -> str:

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -269,6 +269,61 @@ def _normalized_call(call: dict[str, Any], fallback_id: str = "") -> dict[str, A
     return normalized
 
 
+def _split_top_level_json_documents(text: str) -> tuple[list[str], str]:
+    unsplit = ([], text)
+    complete: list[str] = []
+    closing: list[str] = []
+    start = -1
+    in_string = False
+    escaped = False
+
+    for index, character in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if not closing:
+            if character in "{[":
+                start = index
+                closing.append("}" if character == "{" else "]")
+                continue
+            if character.isspace():
+                continue
+            return unsplit
+        if character == '"':
+            in_string = True
+            continue
+        if character in "{[":
+            closing.append("}" if character == "{" else "]")
+            continue
+        if character not in "}]":
+            continue
+        if closing.pop() != character:
+            return unsplit
+        if closing:
+            continue
+        document = text[start : index + 1]
+        try:
+            json.loads(document)
+        except (TypeError, ValueError, json.JSONDecodeError, RecursionError):
+            return unsplit
+        complete.append(document)
+        start = -1
+
+    return complete, "" if start == -1 else text[start:]
+
+
+def _mint_streamed_tool_call_id(taken: set[str]) -> str:
+    index = 0
+    while f"tool_call_{index}" in taken:
+        index += 1
+    return f"tool_call_{index}"
+
+
 def _delta_text(content: Any) -> str:
     """Text of a content delta, whether it is a plain string or content parts.
 
@@ -360,7 +415,10 @@ class _Turn:
     # call key each delta index maps to: the index itself until a second call
     # forks off it, then (index, call_id).
     open_key_by_index: dict[int, Any] = field(default_factory = dict)
+    key_by_call_id: dict[str, Any] = field(default_factory = dict)
     last_index: int | None = None
+    split_seq: int = 0
+    incomplete_split_keys: set[Any] = field(default_factory = set)
     round: int = 0
     healed: list[dict[str, Any]] = field(default_factory = list)
     text: list[str] = field(default_factory = list)
@@ -462,6 +520,25 @@ class _Turn:
             blocks.append(f"{header}\n{body}")
         return "\n\n".join(blocks)
 
+    def _new_split_key(self, index: int) -> tuple[int, str, int]:
+        self.split_seq += 1
+        return (index, "split", self.split_seq)
+
+    def _new_call(self, key: Any, index: int) -> dict[str, Any]:
+        call = {
+            "id": "",
+            "type": "function",
+            "function": {"name": "", "arguments": ""},
+            "_delta_index": index,
+        }
+        self.by_index[key] = call
+        self.order.append(key)
+        return call
+
+    @staticmethod
+    def _merge_name(current: str, fragment: str) -> str:
+        return fragment if fragment.startswith(current) else current + fragment
+
     def merge_structured(self, raw_calls: list[Any]) -> None:
         for raw_call in raw_calls:
             if not isinstance(raw_call, dict):
@@ -474,13 +551,32 @@ class _Turn:
                 # continue the call that is already open instead.
                 index = self.last_index if self.last_index is not None else len(self.order)
             call_id = raw_call.get("id")
+            function = raw_call.get("function")
+            function = function if isinstance(function, dict) else {}
+            name_fragment = function.get("name")
+            name_fragment = name_fragment if isinstance(name_fragment, str) else ""
+            args_fragment = function.get("arguments")
+            args_fragment = args_fragment if isinstance(args_fragment, str) else ""
             # continue whichever call owns this index now: index restarts at 0
             # for every tool round, so after a fork the bare argument fragments
             # belong to the newer call.
             key: Any = self.open_key_by_index.get(index, index)
-            if isinstance(call_id, str) and call_id:
+            stable_id = call_id if isinstance(call_id, str) and call_id else ""
+            if stable_id in self.key_by_call_id:
+                key = self.key_by_call_id[stable_id]
+            elif stable_id and not name_fragment and not args_fragment:
+                key = next(
+                    (
+                        candidate
+                        for candidate in self.order
+                        if self.by_index[candidate].get("_delta_index") == index
+                        and not self.by_index[candidate].get("id")
+                    ),
+                    key,
+                )
+            elif stable_id:
                 open_id = self.by_index.get(key, {}).get("id")
-                if open_id and open_id != call_id:
+                if open_id and open_id != stable_id:
                     # Two distinct calls reported at the same index. Merging them
                     # concatenates their argument JSON into one unparseable blob
                     # and loses an intent, so key the second on its own id.
@@ -488,29 +584,63 @@ class _Turn:
                     # back to it: an id beats the latest-index mapping, which only
                     # exists to place the fragments that carry no id.
                     first_id = self.by_index.get(index, {}).get("id")
-                    key = index if first_id == call_id else (index, call_id)
+                    key = index if first_id == stable_id else (index, stable_id)
             self.last_index = index
             self.open_key_by_index[index] = key
             if key not in self.by_index:
-                self.by_index[key] = {
-                    "id": "",
-                    "type": "function",
-                    "function": {"name": "", "arguments": ""},
-                }
+                self._new_call(key, index)
                 # First-seen order, so a negative or out-of-order index cannot
                 # reorder parallel calls against what the model actually sent.
-                self.order.append(key)
             current = self.by_index[key]
-            if isinstance(call_id, str) and call_id:
-                current["id"] = call_id
+            exact_stable_id = bool(stable_id and current.get("id") == stable_id)
+            current_complete, current_tail = _split_top_level_json_documents(
+                current["function"]["arguments"]
+            )
+            if (
+                current_complete
+                and not current_tail
+                and not exact_stable_id
+                and name_fragment
+                and not args_fragment
+            ):
+                key = self._new_split_key(index)
+                current = self._new_call(key, index)
+                self.open_key_by_index[index] = key
+            if stable_id:
+                current["id"] = stable_id
+                self.key_by_call_id[stable_id] = key
             extra = raw_call.get("extra_content")
+            combined = current["function"]["arguments"] + args_fragment
+            complete, tail = _split_top_level_json_documents(combined)
+            segments = [*complete, *([tail] if tail else [])]
+            if not exact_stable_id and len(segments) > 1:
+                if not current["function"]["name"]:
+                    current["function"]["name"] = name_fragment
+                current["function"]["arguments"] = segments[0]
+                self.incomplete_split_keys.discard(key)
+                for segment_index, segment in enumerate(segments[1:]):
+                    split_key = self._new_split_key(index)
+                    split_call = self._new_call(split_key, index)
+                    split_call["function"]["name"] = name_fragment or current["function"]["name"]
+                    split_call["function"]["arguments"] = segment
+                    if segment_index == 0 and stable_id:
+                        current["id"] = ""
+                        split_call["id"] = stable_id
+                        self.key_by_call_id[stable_id] = split_key
+                    if segment_index == 0 and isinstance(extra, dict) and extra:
+                        split_call["extra_content"] = dict(extra)
+                    split_complete, split_tail = _split_top_level_json_documents(segment)
+                    if not split_complete or split_tail:
+                        self.incomplete_split_keys.add(split_key)
+                    key = split_key
+                    current = split_call
+                self.open_key_by_index[index] = key
+                continue
             if isinstance(extra, dict) and extra:
-                # Gemini 3 stows this call's thoughtSignature here, and the
+                # gemini 3 stows this call's thoughtSignature here, and the
                 # native translator rejects a replayed functionCall without it.
-                # Per call, so it cannot ride along on the delta-level slot.
                 current["extra_content"] = {**current.get("extra_content", {}), **extra}
-            function = raw_call.get("function")
-            if isinstance(function, dict):
+            if function:
                 # Two provider dialects, and picking either one alone breaks the
                 # other. llama-server re-sends the whole name as it grows ("web"
                 # then "web_search"), so appending yields "webweb_search".
@@ -519,17 +649,21 @@ class _Turn:
                 # check and the call silently never runs. A fragment that already
                 # starts with what we have is the whole name resent; anything
                 # else continues it.
-                fragment = function.get("name")
-                if isinstance(fragment, str) and fragment:
+                if name_fragment:
                     accumulated = current["function"]["name"]
-                    if fragment.startswith(accumulated):
-                        current["function"]["name"] = fragment
-                    else:
-                        current["function"]["name"] = accumulated + fragment
-                if isinstance(function.get("arguments"), str):
-                    current["function"]["arguments"] += function["arguments"]
+                    current["function"]["name"] = self._merge_name(
+                        accumulated, name_fragment
+                    )
+                current["function"]["arguments"] = combined
+                complete, tail = _split_top_level_json_documents(combined)
+                if complete and not tail:
+                    self.incomplete_split_keys.discard(key)
 
-    def calls(self, taken: set[str] | None = None) -> list[dict[str, Any]]:
+    def calls(
+        self,
+        taken: set[str] | None = None,
+        streamed_ids: set[str] | None = None,
+    ) -> list[dict[str, Any]]:
         """Every call this turn produced, with ids unique across the whole run.
 
         ``taken`` carries the ids already used by earlier turns. A provider that
@@ -538,19 +672,26 @@ class _Turn:
         the conversation replayed upstream.
         """
         seen: set[str] = taken if taken is not None else set()
+        streamed = streamed_ids if streamed_ids is not None else set()
         out: list[dict[str, Any]] = []
-        for position, call in enumerate(
-            [self.by_index[key] for key in self.order] + list(self.healed)
-        ):
-            normalized = _normalized_call(call, fallback_id = f"call_{self.round}_{position}")
+        ordered_calls = [
+            (key, self.by_index[key]) for key in self.order
+        ] + [(None, call) for call in self.healed]
+        for position, (key, call) in enumerate(ordered_calls):
+            if key in self.incomplete_split_keys:
+                continue
+            fallback_id = _mint_streamed_tool_call_id(streamed)
+            normalized = _normalized_call(call, fallback_id = fallback_id)
             if normalized is None:
                 continue
+            stream_id = normalized["id"]
+            streamed.add(stream_id)
             if normalized["id"] in seen:
                 # The client keyed the card it painted on the id the provider
                 # streamed, so keep that one for the events aimed at the card.
                 # Never replayed upstream: the conversation carries the
                 # de-duplicated id, which is the whole point of the rename.
-                normalized["stream_id"] = normalized["id"]
+                normalized["stream_id"] = stream_id
                 # The renamed id is itself stored and replayed, so a single-shot
                 # rename collides again on the next request. Counting up over a
                 # finite ledger terminates and leaves the first attempt as is.
@@ -814,6 +955,7 @@ async def stream_with_studio_tools(
     last_reprompt_text = ""
     provider_turns = 0
     used_call_ids: set[str] = _replayed_call_ids(conversation)
+    streamed_call_ids: set[str] = set()
     spent_budget_passes = 0
     fruitless_turns = 0
     # One provider call per possible execution, plus headroom for the no-op,
@@ -1037,7 +1179,11 @@ async def stream_with_studio_tools(
         # so the scraped web text in its prompts cannot reach python or terminal,
         # so a naive or compromised endpoint echoing a call back must not be able
         # to execute it here.
-        calls = [] if (truncated or tool_choice == "none") else turn.calls(used_call_ids)
+        calls = (
+            []
+            if (truncated or tool_choice == "none")
+            else turn.calls(used_call_ids, streamed_call_ids)
+        )
         if not calls:
             # No tool this turn. A model that only said what it was about to do
             # gets one nudge to actually do it, the same recovery the local loops

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -324,6 +324,17 @@ def _mint_streamed_tool_call_id(taken: set[str]) -> str:
     return f"tool_call_{index}"
 
 
+def _argument_fragment(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (dict, list)):
+        try:
+            return json.dumps(value, ensure_ascii = False, separators = (",", ":"))
+        except (TypeError, ValueError, RecursionError):
+            pass
+    return ""
+
+
 def _delta_text(content: Any) -> str:
     """Text of a content delta, whether it is a plain string or content parts.
 
@@ -555,28 +566,37 @@ class _Turn:
             function = function if isinstance(function, dict) else {}
             name_fragment = function.get("name")
             name_fragment = name_fragment if isinstance(name_fragment, str) else ""
-            args_fragment = function.get("arguments")
-            args_fragment = args_fragment if isinstance(args_fragment, str) else ""
+            args_fragment = _argument_fragment(function.get("arguments"))
             # continue whichever call owns this index now: index restarts at 0
             # for every tool round, so after a fork the bare argument fragments
             # belong to the newer call.
             key: Any = self.open_key_by_index.get(index, index)
             stable_id = call_id if isinstance(call_id, str) and call_id else ""
+            adopted_stable_id = False
+            repeated_snapshot = False
             if stable_id in self.key_by_call_id:
                 key = self.key_by_call_id[stable_id]
-            elif stable_id and not name_fragment and not args_fragment:
-                key = next(
-                    (
-                        candidate
-                        for candidate in self.order
-                        if self.by_index[candidate].get("_delta_index") == index
-                        and not self.by_index[candidate].get("id")
-                    ),
-                    key,
-                )
             elif stable_id:
+                for candidate in self.order:
+                    candidate_call = self.by_index[candidate]
+                    candidate_function = candidate_call["function"]
+                    if (
+                        candidate_call.get("_delta_index") != index
+                        or candidate_call.get("id")
+                        or (
+                            name_fragment
+                            and candidate_function["name"]
+                            and candidate_function["name"] != name_fragment
+                        )
+                    ):
+                        continue
+                    if not args_fragment or candidate_function["arguments"] == args_fragment:
+                        key = candidate
+                        adopted_stable_id = True
+                        repeated_snapshot = bool(args_fragment)
+                        break
                 open_id = self.by_index.get(key, {}).get("id")
-                if open_id and open_id != stable_id:
+                if not adopted_stable_id and open_id and open_id != stable_id:
                     # Two distinct calls reported at the same index. Merging them
                     # concatenates their argument JSON into one unparseable blob
                     # and loses an intent, so key the second on its own id.
@@ -593,13 +613,14 @@ class _Turn:
                 # reorder parallel calls against what the model actually sent.
             current = self.by_index[key]
             exact_stable_id = bool(stable_id and current.get("id") == stable_id)
+            same_stable_call = exact_stable_id or adopted_stable_id
             current_complete, current_tail = _split_top_level_json_documents(
                 current["function"]["arguments"]
             )
             if (
                 current_complete
                 and not current_tail
-                and not exact_stable_id
+                and not same_stable_call
                 and name_fragment
                 and not args_fragment
             ):
@@ -610,10 +631,13 @@ class _Turn:
                 current["id"] = stable_id
                 self.key_by_call_id[stable_id] = key
             extra = raw_call.get("extra_content")
-            combined = current["function"]["arguments"] + args_fragment
+            had_existing_arguments = bool(current["function"]["arguments"])
+            combined = current["function"]["arguments"] + (
+                "" if repeated_snapshot else args_fragment
+            )
             complete, tail = _split_top_level_json_documents(combined)
             segments = [*complete, *([tail] if tail else [])]
-            if not exact_stable_id and len(segments) > 1:
+            if not repeated_snapshot and len(segments) > 1:
                 if not current["function"]["name"]:
                     current["function"]["name"] = name_fragment
                 current["function"]["arguments"] = segments[0]
@@ -623,7 +647,7 @@ class _Turn:
                     split_call = self._new_call(split_key, index)
                     split_call["function"]["name"] = name_fragment or current["function"]["name"]
                     split_call["function"]["arguments"] = segment
-                    if segment_index == 0 and stable_id:
+                    if segment_index == 0 and stable_id and had_existing_arguments:
                         current["id"] = ""
                         split_call["id"] = stable_id
                         self.key_by_call_id[stable_id] = split_key
@@ -683,7 +707,11 @@ class _Turn:
             if normalized is None:
                 continue
             stream_id = normalized["id"]
+            if stream_id in streamed:
+                stream_id = _mint_streamed_tool_call_id(streamed)
             streamed.add(stream_id)
+            if stream_id != normalized["id"]:
+                normalized["stream_id"] = stream_id
             if normalized["id"] in seen:
                 # The client keyed the card it painted on the id the provider
                 # streamed, so keep that one for the events aimed at the card.
@@ -1237,13 +1265,14 @@ async def stream_with_studio_tools(
         for call in calls:
             if cancel_event.is_set():
                 break
+            decision = controller.prepare_call(call)
             if not unlimited and remaining <= 0:
                 # Budget spent. Answer the model so it stops asking, but never
                 # execute: the cap is a safety limit, not a hint to the provider.
                 for card_line in _unrun_call_card(
                     tool_name = call["function"]["name"],
                     tool_call_id = call.get("stream_id") or call["id"],
-                    arguments = call.get("arguments"),
+                    arguments = decision.tool_start_payload()["arguments"],
                     result = _TOOL_BUDGET_EXHAUSTED,
                     provenance = _unrun_provenance(call["function"]["name"], round_id),
                 ):
@@ -1253,13 +1282,7 @@ async def stream_with_studio_tools(
                 # further down, so this one would arrive as an orphan
                 # role="tool" message and OpenAI, Anthropic and Gemini all
                 # reject that history instead of answering.
-                exhausted_call: dict[str, Any] = {
-                    "id": call["id"],
-                    "type": "function",
-                    # Copied: the normalized call also carries a parsed
-                    # arguments dict that must not reach the provider.
-                    "function": dict(call["function"]),
-                }
+                exhausted_call = decision.as_assistant_tool_call()
                 exhausted_extra = call.get("extra_content")
                 if isinstance(exhausted_extra, dict) and exhausted_extra:
                     exhausted_call["extra_content"] = exhausted_extra
@@ -1273,7 +1296,6 @@ async def stream_with_studio_tools(
                     }
                 )
                 continue
-            decision = controller.prepare_call(call)
             # The frontend groups a round's reasoning by this id
             # (codexLocalToolRoundId), so every tool card the loop emits has to
             # carry it, not just the budget-exhausted one built by hand above.
@@ -1315,6 +1337,7 @@ async def stream_with_studio_tools(
             name = decision.tool_name
             arguments = decision.arguments
             call_id = decision.tool_call_id
+            frontend_call_id = call.get("stream_id") or call_id
             needs_confirmation = (
                 confirm_tool_calls and not bypass_permissions and permission_mode != "off"
             )
@@ -1326,6 +1349,7 @@ async def stream_with_studio_tools(
             )
 
             start_event = decision.tool_start_event()
+            start_event["tool_call_id"] = frontend_call_id
             start_event["approval_id"] = approval_id
             start_event["awaiting_confirmation"] = needs_confirmation
             denied = False
@@ -1374,7 +1398,7 @@ async def stream_with_studio_tools(
                     {
                         "type": "tool_end",
                         "tool_name": name,
-                        "tool_call_id": call_id,
+                        "tool_call_id": frontend_call_id,
                         "result": TOOL_REJECTED_MESSAGE,
                         "provenance": decision.provenance,
                     }
@@ -1433,7 +1457,7 @@ async def stream_with_studio_tools(
             tool_stream = stream_tool_execution(
                 _invoke,
                 tool_name = name,
-                tool_call_id = call_id,
+                tool_call_id = frontend_call_id,
                 cancel_event = cancel_event,
             )
             outcome: dict[str, Any] = {}
@@ -1490,7 +1514,9 @@ async def stream_with_studio_tools(
             executed_any = True
             # Opens the post-tool phase; carried-over stall text would eat its nudge.
             last_reprompt_text = ""
-            yield _sse(completion.tool_end_event())
+            end_event = completion.tool_end_event()
+            end_event["tool_call_id"] = frontend_call_id
+            yield _sse(end_event)
             tool_messages.append(completion.tool_message())
 
         # An empty status clears the badge between iterations.

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -335,6 +335,13 @@ def _argument_fragment(value: Any) -> str:
     return ""
 
 
+def _same_json_document(left: str, right: str) -> bool:
+    try:
+        return json.loads(left) == json.loads(right)
+    except (TypeError, ValueError, json.JSONDecodeError, RecursionError):
+        return False
+
+
 def _delta_text(content: Any) -> str:
     """Text of a content delta, whether it is a plain string or content parts.
 
@@ -590,10 +597,12 @@ class _Turn:
                         )
                     ):
                         continue
-                    if not args_fragment or candidate_function["arguments"] == args_fragment:
+                    if not args_fragment.strip() or _same_json_document(
+                        candidate_function["arguments"], args_fragment
+                    ):
                         key = candidate
                         adopted_stable_id = True
-                        repeated_snapshot = bool(args_fragment)
+                        repeated_snapshot = bool(args_fragment.strip())
                         break
                 open_id = self.by_index.get(key, {}).get("id")
                 if not adopted_stable_id and open_id and open_id != stable_id:
@@ -622,7 +631,7 @@ class _Turn:
                 and not current_tail
                 and not same_stable_call
                 and name_fragment
-                and not args_fragment
+                and not args_fragment.strip()
             ):
                 key = self._new_split_key(index)
                 current = self._new_call(key, index)
@@ -638,7 +647,10 @@ class _Turn:
             complete, tail = _split_top_level_json_documents(combined)
             segments = [*complete, *([tail] if tail else [])]
             if not repeated_snapshot and len(segments) > 1:
-                if not current["function"]["name"]:
+                if (
+                    not current["function"]["name"]
+                    and not (current_complete and not current_tail)
+                ):
                     current["function"]["name"] = name_fragment
                 current["function"]["arguments"] = segments[0]
                 self.incomplete_split_keys.discard(key)
@@ -700,8 +712,6 @@ class _Turn:
             (None, call) for call in self.healed
         ]
         for position, (key, call) in enumerate(ordered_calls):
-            if key in self.incomplete_split_keys:
-                continue
             fallback_id = _mint_streamed_tool_call_id(streamed)
             normalized = _normalized_call(call, fallback_id = fallback_id)
             if normalized is None:
@@ -710,6 +720,8 @@ class _Turn:
             if stream_id in streamed:
                 stream_id = _mint_streamed_tool_call_id(streamed)
             streamed.add(stream_id)
+            if key in self.incomplete_split_keys:
+                continue
             if stream_id != normalized["id"]:
                 normalized["stream_id"] = stream_id
             if normalized["id"] in seen:

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -337,9 +337,34 @@ def _argument_fragment(value: Any) -> str:
 
 def _same_json_document(left: str, right: str) -> bool:
     try:
-        return json.loads(left) == json.loads(right)
+        return _same_json_value(json.loads(left), json.loads(right))
     except (TypeError, ValueError, json.JSONDecodeError, RecursionError):
         return False
+
+
+def _same_json_value(left: Any, right: Any) -> bool:
+    if isinstance(left, bool) or isinstance(right, bool):
+        return type(left) is type(right) and left == right
+    if isinstance(left, (int, float)) or isinstance(right, (int, float)):
+        return (
+            isinstance(left, (int, float))
+            and not isinstance(left, bool)
+            and isinstance(right, (int, float))
+            and not isinstance(right, bool)
+            and left == right
+        )
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            _same_json_value(left_item, right_item)
+            for left_item, right_item in zip(left, right)
+        )
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            _same_json_value(left[key], right[key]) for key in left
+        )
+    return left == right
 
 
 def _delta_text(content: Any) -> str:
@@ -632,6 +657,7 @@ class _Turn:
                 and not same_stable_call
                 and name_fragment
                 and not args_fragment.strip()
+                and current["function"]["name"]
             ):
                 key = self._new_split_key(index)
                 current = self._new_call(key, index)

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -647,9 +647,12 @@ class _Turn:
             current = self.by_index[key]
             exact_stable_id = bool(stable_id and current.get("id") == stable_id)
             same_stable_call = exact_stable_id or adopted_stable_id
-            current_complete, current_tail = _split_top_level_json_documents(
-                current["function"]["arguments"]
-            )
+            current_complete: list[str] = []
+            current_tail = current["function"]["arguments"]
+            if name_fragment and (
+                not args_fragment.strip() or not current["function"]["name"]
+            ):
+                current_complete, current_tail = _split_top_level_json_documents(current_tail)
             if (
                 current_complete
                 and not current_tail
@@ -669,7 +672,10 @@ class _Turn:
             combined = current["function"]["arguments"] + (
                 "" if repeated_snapshot else args_fragment
             )
-            complete, tail = _split_top_level_json_documents(combined)
+            if "{" in args_fragment or "[" in args_fragment:
+                complete, tail = _split_top_level_json_documents(combined)
+            else:
+                complete, tail = [], combined
             segments = [*complete, *([tail] if tail else [])]
             if not repeated_snapshot and len(segments) > 1:
                 if not current["function"]["name"] and not (current_complete and not current_tail):
@@ -711,9 +717,12 @@ class _Turn:
                     accumulated = current["function"]["name"]
                     current["function"]["name"] = self._merge_name(accumulated, name_fragment)
                 current["function"]["arguments"] = combined
-                complete, tail = _split_top_level_json_documents(combined)
-                if complete and not tail:
-                    self.incomplete_split_keys.discard(key)
+                if key in self.incomplete_split_keys and (
+                    "}" in args_fragment or "]" in args_fragment
+                ):
+                    complete, tail = _split_top_level_json_documents(combined)
+                    if complete and not tail:
+                        self.incomplete_split_keys.discard(key)
 
     def calls(
         self,

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -651,9 +651,7 @@ class _Turn:
                 # else continues it.
                 if name_fragment:
                     accumulated = current["function"]["name"]
-                    current["function"]["name"] = self._merge_name(
-                        accumulated, name_fragment
-                    )
+                    current["function"]["name"] = self._merge_name(accumulated, name_fragment)
                 current["function"]["arguments"] = combined
                 complete, tail = _split_top_level_json_documents(combined)
                 if complete and not tail:
@@ -674,9 +672,9 @@ class _Turn:
         seen: set[str] = taken if taken is not None else set()
         streamed = streamed_ids if streamed_ids is not None else set()
         out: list[dict[str, Any]] = []
-        ordered_calls = [
-            (key, self.by_index[key]) for key in self.order
-        ] + [(None, call) for call in self.healed]
+        ordered_calls = [(key, self.by_index[key]) for key in self.order] + [
+            (None, call) for call in self.healed
+        ]
         for position, (key, call) in enumerate(ordered_calls):
             if key in self.incomplete_split_keys:
                 continue

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -649,9 +649,7 @@ class _Turn:
             same_stable_call = exact_stable_id or adopted_stable_id
             current_complete: list[str] = []
             current_tail = current["function"]["arguments"]
-            if name_fragment and (
-                not args_fragment.strip() or not current["function"]["name"]
-            ):
+            if name_fragment and (not args_fragment.strip() or not current["function"]["name"]):
                 current_complete, current_tail = _split_top_level_json_documents(current_tail)
             if (
                 current_complete

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -713,15 +713,26 @@ class _Turn:
         ]
         for position, (key, call) in enumerate(ordered_calls):
             fallback_id = _mint_streamed_tool_call_id(streamed)
+            raw_call_id = call.get("id")
+            stream_id = (
+                raw_call_id
+                if isinstance(raw_call_id, str) and raw_call_id
+                else fallback_id
+            )
+            if key is not None:
+                if stream_id in streamed:
+                    stream_id = _mint_streamed_tool_call_id(streamed)
+                streamed.add(stream_id)
+                if key in self.incomplete_split_keys:
+                    continue
             normalized = _normalized_call(call, fallback_id = fallback_id)
             if normalized is None:
                 continue
-            stream_id = normalized["id"]
-            if stream_id in streamed:
-                stream_id = _mint_streamed_tool_call_id(streamed)
-            streamed.add(stream_id)
-            if key in self.incomplete_split_keys:
-                continue
+            if key is None:
+                stream_id = normalized["id"]
+                if stream_id in streamed:
+                    stream_id = _mint_streamed_tool_call_id(streamed)
+                streamed.add(stream_id)
             if stream_id != normalized["id"]:
                 normalized["stream_id"] = stream_id
             if normalized["id"] in seen:

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -57,6 +57,7 @@ def _tool(name: str, description: str = "") -> dict:
 
 
 WEB = _tool("web_search")
+FETCH = _tool("web_fetch")
 PY = _tool("python")
 
 
@@ -216,6 +217,51 @@ def test_structured_call_executes_and_continues(executed):
     follow_up = transport.requests[1]["messages"]
     assert [message["role"] for message in follow_up[-2:]] == ["assistant", "tool"]
     assert follow_up[-1]["content"] == "RESULT<web_search>"
+
+
+@pytest.mark.parametrize("count", [2, 3, 4, 8])
+def test_idless_parallel_calls_reusing_index_zero_execute_separately(executed, count):
+    calls = [
+        {
+            "index": 0,
+            "function": {
+                "name": "web_fetch" if position % 2 == 0 else "web_search",
+                "arguments": json.dumps({"query": f"request-{position}"}),
+            },
+        }
+        for position in range(count)
+    ]
+    transport = FakeTransport(
+        [
+            [*[_sse({"tool_calls": [call]}) for call in calls], _sse(finish = "tool_calls"), _DONE],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    lines = _run(transport, tools = [WEB, FETCH])
+
+    assert [call["arguments"] for call in executed] == [
+        {"query": f"request-{position}"} for position in range(count)
+    ]
+    starts = _events(lines, "tool_start")
+    ends = _events(lines, "tool_end")
+    assert len(starts) == len(ends) == count
+    assert [event["tool_call_id"] for event in starts] == [
+        f"tool_call_{position}" for position in range(count)
+    ]
+    replayed = transport.requests[1]["messages"]
+    replayed_calls = [
+        call
+        for message in replayed
+        if message.get("role") == "assistant"
+        for call in message.get("tool_calls") or []
+    ]
+    assert len(replayed_calls) == count
+    assert len({call["id"] for call in replayed_calls}) == count
+    assert [json.loads(call["function"]["arguments"]) for call in replayed_calls] == [
+        {"query": f"request-{position}"} for position in range(count)
+    ]
 
 
 def test_a_conversation_search_here_gets_the_active_branch(executed):

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1221,8 +1221,8 @@ def test_whitespace_arguments_keep_a_name_only_opening_separate(executed):
     transport = FakeTransport(
         [
             [
-                _sse({"tool_calls": [_call_delta(0, None, "web_search", '{}')]}),
-                _sse({"tool_calls": [_call_delta(0, None, "web_fetch", ' ')]}),
+                _sse({"tool_calls": [_call_delta(0, None, "web_search", "{}")]}),
+                _sse({"tool_calls": [_call_delta(0, None, "web_fetch", " ")]}),
                 _sse({"tool_calls": [{"index": 0, "function": {"arguments": '{"query":"b"}'}}]}),
                 _sse(finish = "tool_calls"),
                 _DONE,
@@ -1537,6 +1537,4 @@ def test_a_later_name_does_not_activate_a_completed_unnamed_call(executed):
     assert [(call["name"], call["arguments"]) for call in executed] == [
         ("web_search", {"query": "ok"})
     ]
-    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == [
-        "tool_call_1"
-    ]
+    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == ["tool_call_1"]

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1117,8 +1117,8 @@ def test_a_skipped_duplicate_closes_the_card_the_provider_already_painted(execut
     card for every call. A repeat is answered with a nudge and never executed,
     which used to leave that card running for the rest of the answer.
 
-    The event has to carry the id the provider streamed: a repeated call is
-    exactly the one the loop renames to keep the replayed history unambiguous.
+    Event ids must also be unique when the provider reuses an id in a later
+    round, or the second result resolves to the first card.
     """
     repeat = [
         _sse({"tool_calls": [_call_delta(0, "call_a", "web_search", '{"query":"a"}')]}),
@@ -1138,7 +1138,7 @@ def test_a_skipped_duplicate_closes_the_card_the_provider_already_painted(execut
     assert len(executed) == 1
     ends = _events(lines, "tool_end")
     assert len(ends) == 2
-    assert [end["tool_call_id"] for end in ends] == ["call_a", "call_a"]
+    assert [end["tool_call_id"] for end in ends] == ["call_a", "tool_call_0"]
     assert ends[1]["result"].startswith("Unsloth did not run this call")
     # Opened as well as closed. The client retires a card id when it closes it,
     # so a second tool_end on the same id resolves to no card and the adapter
@@ -1146,7 +1146,7 @@ def test_a_skipped_duplicate_closes_the_card_the_provider_already_painted(execut
     # the card the second event closes, and keeps the loop's invariant that
     # every tool_end has a matching tool_start.
     starts = _events(lines, "tool_start")
-    assert [start["tool_call_id"] for start in starts] == ["call_a", "call_a"]
+    assert [start["tool_call_id"] for start in starts] == ["call_a", "tool_call_0"]
 
 
 def test_a_second_call_at_one_index_keeps_its_own_argument_fragments(executed):
@@ -1215,3 +1215,246 @@ def test_a_fragment_naming_its_call_goes_back_to_that_call(executed):
     _run(transport)
 
     assert [call["arguments"] for call in executed] == [{"query": "first"}, {"query": "second"}]
+
+
+@pytest.mark.parametrize("late_arguments", ["", '{"query":"first"}'])
+def test_a_delayed_id_adopts_the_idless_call(executed, late_arguments):
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(0, None, "web_search", '{"query":"first"}')
+                        ]
+                    }
+                ),
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(0, "call_a", "web_search", late_arguments)
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    lines = _run(transport)
+
+    assert [call["arguments"] for call in executed] == [{"query": "first"}]
+    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == ["call_a"]
+
+
+def test_delayed_named_ids_adopt_parallel_calls_in_order(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(0, None, "web_search", '{"query":"first"}'),
+                            _call_delta(0, None, "web_fetch", '{"query":"second"}'),
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [_call_delta(0, "call_a", "web_search", "")]}),
+                _sse({"tool_calls": [_call_delta(0, "call_b", "web_fetch", "")]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    lines = _run(transport, tools = [WEB, FETCH])
+
+    assert [call["arguments"] for call in executed] == [
+        {"query": "first"},
+        {"query": "second"},
+    ]
+    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == [
+        "call_a",
+        "call_b",
+    ]
+
+
+def test_a_fresh_stable_multi_document_delta_keeps_id_on_first_call(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(
+                                0,
+                                "call_a",
+                                "web_search",
+                                '{"query":"first"}{"query":"second"}',
+                            )
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    lines = _run(transport)
+
+    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == [
+        "call_a",
+        "tool_call_0",
+    ]
+    assert [call["arguments"] for call in executed] == [
+        {"query": "first"},
+        {"query": "second"},
+    ]
+
+
+def test_stream_and_replay_ids_stay_unique_when_provider_ids_collide(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(0, None, "web_search", '{"query":"first"}'),
+                            _call_delta(1, "tool_call_0", "web_search", '{"query":"second"}'),
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    lines = _run(transport)
+
+    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == [
+        "tool_call_0",
+        "tool_call_1",
+    ]
+    replayed_calls = [
+        call
+        for message in transport.requests[1]["messages"]
+        if message.get("role") == "assistant"
+        for call in message.get("tool_calls") or []
+    ]
+    assert len({call["id"] for call in replayed_calls}) == 2
+
+
+def test_reloaded_ids_do_not_rename_frontend_events(executed):
+    history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                _call_delta(0, "tool_call_0", "web_search", '{"query":"old"}')
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "tool_call_0",
+            "name": "web_search",
+            "content": "old result",
+        },
+        {"role": "user", "content": "again"},
+    ]
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(0, None, "web_search", '{"query":"new"}')
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    lines = _run(transport, messages = history)
+
+    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == ["tool_call_0"]
+    replayed = transport.requests[1]["messages"]
+    new_call = [
+        call
+        for message in replayed
+        if message.get("role") == "assistant"
+        for call in message.get("tool_calls") or []
+        if json.loads(call["function"]["arguments"]) == {"query": "new"}
+    ][0]
+    assert new_call["id"] != "tool_call_0"
+
+
+def test_decoded_object_arguments_execute_unchanged(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(0, None, "web_search", {"query": "decoded"})
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    _run(transport)
+
+    assert executed[0]["arguments"] == {"query": "decoded"}
+
+
+def test_budget_exhaustion_replays_malformed_arguments_as_valid_json(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(0, None, "web_search", '{"query":"first"}'),
+                            _call_delta(1, None, "web_search", '{"query":'),
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    _run(transport, max_calls = 1)
+
+    replayed_calls = [
+        call
+        for message in transport.requests[1]["messages"]
+        if message.get("role") == "assistant"
+        for call in message.get("tool_calls") or []
+    ]
+    assert len(replayed_calls) == 2
+    assert all(json.loads(call["function"]["arguments"]) for call in replayed_calls)

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1532,8 +1532,11 @@ def test_a_later_name_does_not_activate_a_completed_unnamed_call(executed):
         heals = False,
     )
 
-    _run(transport)
+    lines = _run(transport)
 
     assert [(call["name"], call["arguments"]) for call in executed] == [
         ("web_search", {"query": "ok"})
+    ]
+    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == [
+        "tool_call_1"
     ]

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1422,21 +1422,17 @@ def test_delayed_named_ids_adopt_parallel_calls_in_order(executed):
 
 
 def test_a_fresh_stable_multi_document_delta_keeps_id_on_first_call(executed):
+    delta = _call_delta(
+        0,
+        "call_a",
+        "web_search",
+        '{"query":"first"}{"query":"second"}',
+    )
+    delta["extra_content"] = {"google": {"thought_signature": "SIG-A"}}
     transport = FakeTransport(
         [
             [
-                _sse(
-                    {
-                        "tool_calls": [
-                            _call_delta(
-                                0,
-                                "call_a",
-                                "web_search",
-                                '{"query":"first"}{"query":"second"}',
-                            )
-                        ]
-                    }
-                ),
+                _sse({"tool_calls": [delta]}),
                 _sse(finish = "tool_calls"),
                 _DONE,
             ],
@@ -1452,6 +1448,16 @@ def test_a_fresh_stable_multi_document_delta_keeps_id_on_first_call(executed):
         "tool_call_0",
     ]
     assert [call["arguments"] for call in executed] == [{"query": "first"}, {"query": "second"}]
+    replayed_calls = [
+        call
+        for message in transport.requests[1]["messages"]
+        if message.get("role") == "assistant"
+        for call in message.get("tool_calls") or []
+    ]
+    assert replayed_calls[0]["extra_content"] == {
+        "google": {"thought_signature": "SIG-A"}
+    }
+    assert "extra_content" not in replayed_calls[1]
 
 
 def test_stream_and_replay_ids_stay_unique_when_provider_ids_collide(executed):

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1390,6 +1390,33 @@ def test_a_delayed_id_adopts_a_semantically_equal_snapshot(executed):
     assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == ["call_a"]
 
 
+def test_a_stable_id_repeated_snapshot_executes_once(executed):
+    call = _call_delta(0, "call_a", "web_search", '{"query":"first"}')
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [call]}),
+                _sse({"tool_calls": [call]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    _run(transport)
+
+    assert [item["arguments"] for item in executed] == [{"query": "first"}]
+    replayed_calls = [
+        replayed_call
+        for message in transport.requests[1]["messages"]
+        if message.get("role") == "assistant"
+        for replayed_call in message.get("tool_calls") or []
+    ]
+    assert len(replayed_calls) == 1
+
+
 def test_delayed_named_ids_adopt_parallel_calls_in_order(executed):
     transport = FakeTransport(
         [

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1217,6 +1217,29 @@ def test_a_fragment_naming_its_call_goes_back_to_that_call(executed):
     assert [call["arguments"] for call in executed] == [{"query": "first"}, {"query": "second"}]
 
 
+def test_whitespace_arguments_keep_a_name_only_opening_separate(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [_call_delta(0, None, "web_search", '{}')]}),
+                _sse({"tool_calls": [_call_delta(0, None, "web_fetch", ' ')]}),
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": '{"query":"b"}'}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    _run(transport, tools = [WEB, FETCH])
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {}),
+        ("web_fetch", {"query": "b"}),
+    ]
+
+
 @pytest.mark.parametrize("late_arguments", ["", '{"query":"first"}'])
 def test_a_delayed_id_adopts_the_idless_call(executed, late_arguments):
     transport = FakeTransport(
@@ -1235,6 +1258,49 @@ def test_a_delayed_id_adopts_the_idless_call(executed, late_arguments):
     lines = _run(transport)
 
     assert [call["arguments"] for call in executed] == [{"query": "first"}]
+    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == ["call_a"]
+
+
+def test_a_delayed_id_adopts_a_semantically_equal_snapshot(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(
+                                0,
+                                None,
+                                "web_search",
+                                '{ "query": "first", "nested": {"x": 2} }',
+                            )
+                        ]
+                    }
+                ),
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(
+                                0,
+                                "call_a",
+                                "web_search",
+                                {"nested": {"x": 2}, "query": "first"},
+                            )
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    lines = _run(transport)
+
+    assert len(executed) == 1
+    assert executed[0]["arguments"] == {"query": "first", "nested": {"x": 2}}
     assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == ["call_a"]
 
 
@@ -1426,3 +1492,48 @@ def test_budget_exhaustion_replays_malformed_arguments_as_valid_json(executed):
     ]
     assert len(replayed_calls) == 2
     assert all(json.loads(call["function"]["arguments"]) for call in replayed_calls)
+
+
+def test_incomplete_split_calls_still_reserve_their_stream_ids(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [_call_delta(0, None, "web_search", '{"query":"a"}')]}),
+                _sse({"tool_calls": [_call_delta(0, None, "web_search", '{"query":')]}),
+                _sse({"tool_calls": [_call_delta(1, None, "web_search", '{"query":"c"}')]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    lines = _run(transport)
+
+    assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == [
+        "tool_call_0",
+        "tool_call_2",
+    ]
+    assert [call["arguments"] for call in executed] == [{"query": "a"}, {"query": "c"}]
+
+
+def test_a_later_name_does_not_activate_a_completed_unnamed_call(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": '{"bad":1}'}}]}),
+                _sse({"tool_calls": [_call_delta(0, None, "web_search", '{"query":"ok"}')]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    _run(transport)
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "ok"})
+    ]

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1222,20 +1222,8 @@ def test_a_delayed_id_adopts_the_idless_call(executed, late_arguments):
     transport = FakeTransport(
         [
             [
-                _sse(
-                    {
-                        "tool_calls": [
-                            _call_delta(0, None, "web_search", '{"query":"first"}')
-                        ]
-                    }
-                ),
-                _sse(
-                    {
-                        "tool_calls": [
-                            _call_delta(0, "call_a", "web_search", late_arguments)
-                        ]
-                    }
-                ),
+                _sse({"tool_calls": [_call_delta(0, None, "web_search", '{"query":"first"}')]}),
+                _sse({"tool_calls": [_call_delta(0, "call_a", "web_search", late_arguments)]}),
                 _sse(finish = "tool_calls"),
                 _DONE,
             ],
@@ -1274,10 +1262,7 @@ def test_delayed_named_ids_adopt_parallel_calls_in_order(executed):
 
     lines = _run(transport, tools = [WEB, FETCH])
 
-    assert [call["arguments"] for call in executed] == [
-        {"query": "first"},
-        {"query": "second"},
-    ]
+    assert [call["arguments"] for call in executed] == [{"query": "first"}, {"query": "second"}]
     assert [event["tool_call_id"] for event in _events(lines, "tool_start")] == [
         "call_a",
         "call_b",
@@ -1314,10 +1299,7 @@ def test_a_fresh_stable_multi_document_delta_keeps_id_on_first_call(executed):
         "call_a",
         "tool_call_0",
     ]
-    assert [call["arguments"] for call in executed] == [
-        {"query": "first"},
-        {"query": "second"},
-    ]
+    assert [call["arguments"] for call in executed] == [{"query": "first"}, {"query": "second"}]
 
 
 def test_stream_and_replay_ids_stay_unique_when_provider_ids_collide(executed):
@@ -1360,9 +1342,7 @@ def test_reloaded_ids_do_not_rename_frontend_events(executed):
         {
             "role": "assistant",
             "content": "",
-            "tool_calls": [
-                _call_delta(0, "tool_call_0", "web_search", '{"query":"old"}')
-            ],
+            "tool_calls": [_call_delta(0, "tool_call_0", "web_search", '{"query":"old"}')],
         },
         {
             "role": "tool",
@@ -1375,13 +1355,7 @@ def test_reloaded_ids_do_not_rename_frontend_events(executed):
     transport = FakeTransport(
         [
             [
-                _sse(
-                    {
-                        "tool_calls": [
-                            _call_delta(0, None, "web_search", '{"query":"new"}')
-                        ]
-                    }
-                ),
+                _sse({"tool_calls": [_call_delta(0, None, "web_search", '{"query":"new"}')]}),
                 _sse(finish = "tool_calls"),
                 _DONE,
             ],
@@ -1408,13 +1382,7 @@ def test_decoded_object_arguments_execute_unchanged(executed):
     transport = FakeTransport(
         [
             [
-                _sse(
-                    {
-                        "tool_calls": [
-                            _call_delta(0, None, "web_search", {"query": "decoded"})
-                        ]
-                    }
-                ),
+                _sse({"tool_calls": [_call_delta(0, None, "web_search", {"query": "decoded"})]}),
                 _sse(finish = "tool_calls"),
                 _DONE,
             ],

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1454,9 +1454,7 @@ def test_a_fresh_stable_multi_document_delta_keeps_id_on_first_call(executed):
         if message.get("role") == "assistant"
         for call in message.get("tool_calls") or []
     ]
-    assert replayed_calls[0]["extra_content"] == {
-        "google": {"thought_signature": "SIG-A"}
-    }
+    assert replayed_calls[0]["extra_content"] == {"google": {"thought_signature": "SIG-A"}}
     assert "extra_content" not in replayed_calls[1]
 
 

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -264,6 +264,92 @@ def test_idless_parallel_calls_reusing_index_zero_execute_separately(executed, c
     ]
 
 
+def test_delayed_id_distinguishes_json_boolean_from_number(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":1}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_boolean",
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":true}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    _run(transport)
+
+    assert len(executed) == 2
+    assert executed[0]["arguments"]["query"] == 1
+    assert type(executed[0]["arguments"]["query"]) is int
+    assert executed[1]["arguments"]["query"] is True
+
+
+def test_name_arriving_after_arguments_attaches_to_the_call(executed):
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"arguments": '{"query":"late-name"}'},
+                            }
+                        ]
+                    }
+                ),
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"name": "web_search", "arguments": ""},
+                            }
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+
+    _run(transport)
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "late-name"})
+    ]
+
+
 def test_a_conversation_search_here_gets_the_active_branch(executed):
     """The provider loops share the local paths' tool catalogue.
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -7072,13 +7072,23 @@ export function createOpenAIStreamAdapter(
                   const exactStableMatch = Boolean(
                     stablePartId && matchedPart?.toolCallId === stablePartId,
                   );
-                  const matchedDocuments = matchedPart
-                    ? splitTopLevelJsonDocuments(matchedPart.argsText ?? "")
-                    : null;
-                  const matchedClosed = Boolean(
-                    matchedDocuments?.complete.length === 1 &&
-                      !matchedDocuments.tail,
+                  const checkCompletedSlot = Boolean(
+                    matchedPart &&
+                      !exactStableMatch &&
+                      matchedPart.toolName &&
+                      nameFragment &&
+                      argsFragmentIsBlank,
                   );
+                  const matchedClosed = checkCompletedSlot
+                    ? (() => {
+                        const documents = splitTopLevelJsonDocuments(
+                          matchedPart?.argsText ?? "",
+                        );
+                        return (
+                          documents.complete.length === 1 && !documents.tail
+                        );
+                      })()
+                    : false;
                   // an id-less opening landing on a slot whose arguments are
                   // already a complete JSON document is the next parallel
                   // call, not a continuation: some proxies strip ids and
@@ -7102,13 +7112,21 @@ export function createOpenAIStreamAdapter(
                     codexRoundToolCallIds.push(stablePartId);
                   }
                   streamedChars += argsFragment.length + nameFragment.length;
-                  if (!exactStableMatch || argsFragment) {
-                    const split = splitTopLevelJsonDocuments(
+                  let combinedDocuments: ReturnType<
+                    typeof splitTopLevelJsonDocuments
+                  > | null = null;
+                  if (
+                    (!exactStableMatch || argsFragment) &&
+                    (argsFragment.includes("{") || argsFragment.includes("["))
+                  ) {
+                    combinedDocuments = splitTopLevelJsonDocuments(
                       (matchedPart?.argsText ?? "") + argsFragment,
                     );
                     const segments = [
-                      ...split.complete,
-                      ...(split.tail ? [split.tail] : []),
+                      ...combinedDocuments.complete,
+                      ...(combinedDocuments.tail
+                        ? [combinedDocuments.tail]
+                        : []),
                     ];
                     if (segments.length > 1) {
                       const firstNewSegment = matchedPart ? 1 : 0;
@@ -7175,7 +7193,8 @@ export function createOpenAIStreamAdapter(
                             ? { _has_stable_id: true }
                             : {}),
                           ...(idx !== undefined ? { _delta_index: idx } : {}),
-                          ...(split.tail && argsText === split.tail
+                          ...(combinedDocuments.tail &&
+                          argsText === combinedDocuments.tail
                             ? { _split_tail: true }
                             : {}),
                         });
@@ -7191,7 +7210,12 @@ export function createOpenAIStreamAdapter(
                       nameFragment,
                     );
                     const merged = (existing.argsText ?? "") + argsFragment;
-                    const mergedDocuments = splitTopLevelJsonDocuments(merged);
+                    const mergedDocuments =
+                      combinedDocuments ??
+                      ((existing as PositionedToolCallPart)._split_tail &&
+                      (argsFragment.includes("}") || argsFragment.includes("]"))
+                        ? splitTopLevelJsonDocuments(merged)
+                        : null);
                     const parsedArgs = parseStreamedToolCallArgs(merged);
                     const prevExtra = (existing as PositionedToolCallPart)
                       .extra_content;
@@ -7223,7 +7247,7 @@ export function createOpenAIStreamAdapter(
                       _split_tail:
                         (existing as PositionedToolCallPart)._split_tail &&
                         !(
-                          mergedDocuments.complete.length === 1 &&
+                          mergedDocuments?.complete.length === 1 &&
                           !mergedDocuments.tail
                         )
                           ? true

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -109,6 +109,8 @@ import {
 import { toolCallReplayArguments } from "../tool-call-arguments";
 import {
   findStreamedToolCallPartIndex,
+  fragmentStartsNewToolCall,
+  mintStreamedToolCallId,
   resolveToolCallPartId,
 } from "../tool-call-id";
 
@@ -6932,15 +6934,28 @@ export function createOpenAIStreamAdapter(
                   // match by resolved id when the fragment carries one, else by
                   // index slot; streams that send neither get a minted
                   // tool_call_<n> id.
+                  const argsFragment = call.function?.arguments ?? "";
                   const existingIndex = findStreamedToolCallPartIndex(
                     toolCallParts,
                     stablePartId,
                     idx,
                   );
-                  const existing =
+                  const matchedPart =
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
+                  // An id-less opening landing on a slot whose arguments are
+                  // already a complete JSON document is the next parallel
+                  // call, not a continuation: some proxies strip ids and
+                  // renumber every call's index to 0, and merging would glue
+                  // the argument JSONs into one malformed string that poisons
+                  // the thread on replay (#9807).
+                  const existing =
+                    matchedPart !== undefined &&
+                    !stablePartId &&
+                    fragmentStartsNewToolCall(matchedPart.argsText, argsFragment)
+                      ? undefined
+                      : matchedPart;
 
                   if (
                     stablePartId &&
@@ -6948,7 +6963,6 @@ export function createOpenAIStreamAdapter(
                   ) {
                     codexRoundToolCallIds.push(stablePartId);
                   }
-                  const argsFragment = call.function?.arguments ?? "";
                   streamedChars +=
                     argsFragment.length + (call.function?.name?.length ?? 0);
                   if (existing) {
@@ -6998,9 +7012,12 @@ export function createOpenAIStreamAdapter(
                     };
                     toolCallParts[existingIndex] = updated;
                   } else {
+                    // Minted collision-free: a boundary-split parallel call
+                    // shares its delta index with the part it split from, so
+                    // the plain tool_call_<idx> spelling is already taken.
                     const callId =
                       stablePartId ||
-                      `tool_call_${idx ?? toolCallParts.length}`;
+                      mintStreamedToolCallId(toolCallParts, idx);
 
                     if (!codexRoundToolCallIds.includes(callId)) {
                       codexRoundToolCallIds.push(callId);

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -116,6 +116,7 @@ import {
   findStreamedToolCallPartIndex,
   mintStreamedToolCallId,
   resolveToolCallPartId,
+  sameJsonDocument,
   splitTopLevelJsonDocuments,
 } from "../tool-call-id";
 
@@ -6972,7 +6973,10 @@ export function createOpenAIStreamAdapter(
                       stablePartId = resolveToolPartId(stableId);
                       if (
                         rawArgsFragment &&
-                        toolCallParts[delayedIndex].argsText === rawArgsFragment
+                        sameJsonDocument(
+                          toolCallParts[delayedIndex].argsText ?? "",
+                          rawArgsFragment,
+                        )
                       ) {
                         argsFragment = "";
                       }
@@ -7006,6 +7010,7 @@ export function createOpenAIStreamAdapter(
                   // match by resolved id when the fragment carries one, else by
                   // index slot; streams that send neither get a minted
                   // tool_call_<n> id.
+                  const argsFragmentIsBlank = !argsFragment.trim();
                   const exactStableIndex = stablePartId
                     ? toolCallParts.findIndex(
                         (part) => part.toolCallId === stablePartId,
@@ -7014,7 +7019,7 @@ export function createOpenAIStreamAdapter(
                   const existingIndex =
                     exactStableIndex !== -1
                       ? exactStableIndex
-                      : stablePartId && !nameFragment && !argsFragment
+                      : stablePartId && !nameFragment && argsFragmentIsBlank
                         ? findOldestUnownedStreamedToolCallPartIndex(
                             toolCallParts,
                             idx,
@@ -7049,7 +7054,7 @@ export function createOpenAIStreamAdapter(
                     !exactStableMatch &&
                     matchedClosed &&
                     Boolean(nameFragment) &&
-                    !argsFragment
+                    argsFragmentIsBlank
                       ? undefined
                       : matchedPart;
 
@@ -7146,6 +7151,7 @@ export function createOpenAIStreamAdapter(
                     const prevName = existing.toolName ?? "";
                     const nextName = nameFragment || prevName;
                     const merged = (existing.argsText ?? "") + argsFragment;
+                    const mergedDocuments = splitTopLevelJsonDocuments(merged);
                     const parsedArgs = parseStreamedToolCallArgs(merged);
                     const prevExtra = (existing as PositionedToolCallPart)
                       .extra_content;
@@ -7174,7 +7180,14 @@ export function createOpenAIStreamAdapter(
                           ? { extra_content: prevExtra }
                           : {}),
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
-                      _split_tail: undefined,
+                      _split_tail:
+                        (existing as PositionedToolCallPart)._split_tail &&
+                        !(
+                          mergedDocuments.complete.length === 1 &&
+                          !mergedDocuments.tail
+                        )
+                          ? true
+                          : undefined,
                     };
                     toolCallParts[existingIndex] = updated;
                   } else {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -115,6 +115,7 @@ import {
   findOldestUnownedStreamedToolCallPartIndex,
   findDelayedStableToolCallPartIndex,
   findStreamedToolCallPartIndex,
+  isRepeatedJsonSnapshot,
   mergeStreamedToolCallName,
   mintStreamedToolCallId,
   resolveToolCallPartId,
@@ -7072,6 +7073,15 @@ export function createOpenAIStreamAdapter(
                   const exactStableMatch = Boolean(
                     stablePartId && matchedPart?.toolCallId === stablePartId,
                   );
+                  if (
+                    exactStableMatch &&
+                    isRepeatedJsonSnapshot(
+                      matchedPart?.argsText ?? "",
+                      argsFragment,
+                    )
+                  ) {
+                    argsFragment = "";
+                  }
                   const checkCompletedSlot = Boolean(
                     matchedPart &&
                       !exactStableMatch &&
@@ -7111,7 +7121,7 @@ export function createOpenAIStreamAdapter(
                   ) {
                     codexRoundToolCallIds.push(stablePartId);
                   }
-                  streamedChars += argsFragment.length + nameFragment.length;
+                  streamedChars += rawArgsFragment.length + nameFragment.length;
                   let combinedDocuments: ReturnType<
                     typeof splitTopLevelJsonDocuments
                   > | null = null;

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -111,6 +111,7 @@ import {
   toolCallReplayArguments,
 } from "../tool-call-arguments";
 import {
+  bindStreamedToolCallBackendIds,
   findOldestUnownedStreamedToolCallPartIndex,
   findDelayedStableToolCallPartIndex,
   findStreamedToolCallPartIndex,
@@ -7027,8 +7028,11 @@ export function createOpenAIStreamAdapter(
                         idx,
                         streamedToolCallIds,
                       );
-                      toolPartIdByBackendId.set(stableId, stablePartId);
-                      toolPartIdByBackendId.set(stablePartId, stablePartId);
+                      bindStreamedToolCallBackendIds(
+                        toolPartIdByBackendId,
+                        stableId,
+                        stablePartId,
+                      );
                     } else {
                       stablePartId = resolveToolPartId(stableId);
                     }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -114,6 +114,7 @@ import {
   findOldestUnownedStreamedToolCallPartIndex,
   findDelayedStableToolCallPartIndex,
   findStreamedToolCallPartIndex,
+  mergeStreamedToolCallName,
   mintStreamedToolCallId,
   resolveToolCallPartId,
   sameJsonDocument,
@@ -6971,16 +6972,32 @@ export function createOpenAIStreamAdapter(
                       const provisionalPartId =
                         toolCallParts[delayedIndex].toolCallId;
                       stablePartId = resolveToolPartId(stableId);
+                      const displacedIndex = toolCallParts.findIndex(
+                        (part, partIndex) =>
+                          partIndex !== delayedIndex &&
+                          part.toolCallId === stablePartId,
+                      );
                       if (
-                        rawArgsFragment &&
-                        sameJsonDocument(
-                          toolCallParts[delayedIndex].argsText ?? "",
-                          rawArgsFragment,
-                        )
+                        displacedIndex !== -1 &&
+                        provisionalPartId !== stablePartId
                       ) {
-                        argsFragment = "";
-                      }
-                      if (provisionalPartId !== stablePartId) {
+                        toolCallParts[displacedIndex] = {
+                          ...toolCallParts[displacedIndex],
+                          toolCallId: provisionalPartId,
+                        };
+                        toolPartIdByBackendId.set(
+                          provisionalPartId,
+                          provisionalPartId,
+                        );
+                        codexRoundToolCallIds = codexRoundToolCallIds.map(
+                          (callId) =>
+                            callId === provisionalPartId
+                              ? stablePartId as string
+                              : callId === stablePartId
+                                ? provisionalPartId
+                                : callId,
+                        );
+                      } else if (provisionalPartId !== stablePartId) {
                         toolPartIdByBackendId.delete(provisionalPartId);
                         streamedToolCallIds.delete(provisionalPartId);
                         codexRoundToolCallIds = codexRoundToolCallIds.map(
@@ -6990,12 +7007,27 @@ export function createOpenAIStreamAdapter(
                               : callId,
                         );
                       }
+                      toolCallParts[delayedIndex] = {
+                        ...toolCallParts[delayedIndex],
+                        toolCallId: stablePartId,
+                        _has_stable_id: true,
+                      };
+                      if (
+                        rawArgsFragment &&
+                        sameJsonDocument(
+                          toolCallParts[delayedIndex].argsText ?? "",
+                          rawArgsFragment,
+                        )
+                      ) {
+                        argsFragment = "";
+                      }
                     } else if (streamedToolCallIds.has(stableId)) {
                       stablePartId = mintStreamedToolCallId(
                         toolCallParts,
                         idx,
                         streamedToolCallIds,
                       );
+                      toolPartIdByBackendId.set(stableId, stablePartId);
                       toolPartIdByBackendId.set(stablePartId, stablePartId);
                     } else {
                       stablePartId = resolveToolPartId(stableId);
@@ -7053,6 +7085,7 @@ export function createOpenAIStreamAdapter(
                     matchedPart !== undefined &&
                     !exactStableMatch &&
                     matchedClosed &&
+                    Boolean(matchedPart.toolName) &&
                     Boolean(nameFragment) &&
                     argsFragmentIsBlank
                       ? undefined
@@ -7149,7 +7182,10 @@ export function createOpenAIStreamAdapter(
                   }
                   if (existing) {
                     const prevName = existing.toolName ?? "";
-                    const nextName = nameFragment || prevName;
+                    const nextName = mergeStreamedToolCallName(
+                      prevName,
+                      nameFragment,
+                    );
                     const merged = (existing.argsText ?? "") + argsFragment;
                     const mergedDocuments = splitTopLevelJsonDocuments(merged);
                     const parsedArgs = parseStreamedToolCallArgs(merged);

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -106,9 +106,13 @@ import {
   type CodexReasoningLedger,
 } from "../codex-reasoning";
 
-import { toolCallReplayArguments } from "../tool-call-arguments";
+import {
+  streamedToolCallArguments,
+  toolCallReplayArguments,
+} from "../tool-call-arguments";
 import {
   findOldestUnownedStreamedToolCallPartIndex,
+  findDelayedStableToolCallPartIndex,
   findStreamedToolCallPartIndex,
   mintStreamedToolCallId,
   resolveToolCallPartId,
@@ -5277,6 +5281,7 @@ export function createOpenAIStreamAdapter(
         textCursor?: number;
         _delta_index?: number;
         _has_stable_id?: boolean;
+        _split_tail?: boolean;
         extra_content?: unknown;
         provenance?: ToolCallProvenance;
       };
@@ -5294,6 +5299,8 @@ export function createOpenAIStreamAdapter(
       // key is unique; every tool_start/output/args/end resolves the same id via
       // this map, dropped at tool_end.
       const toolPartIdByBackendId = new Map<string, string>();
+      const toolPartIdByProviderId = new Map<string, string>();
+      const streamedToolCallIds = new Set<string>();
       const resolveToolPartId = (backendToolCallId: string): string =>
         resolveToolCallPartId(
           toolPartIdByBackendId,
@@ -6506,6 +6513,7 @@ export function createOpenAIStreamAdapter(
                       toolName: toolEvent.tool_name as string,
                       argsText: JSON.stringify(toolArgs),
                       args: toolArgs,
+                      _split_tail: undefined,
                       provenance: mergeToolProvenance(
                         existing.provenance,
                         toolProvenance,
@@ -6539,6 +6547,9 @@ export function createOpenAIStreamAdapter(
                   if (backendToolCallId) {
                     toolConfirmationIdsByBackendId.delete(backendToolCallId);
                     toolPartIdByBackendId.delete(backendToolCallId);
+                  }
+                  for (const [providerId, partId] of toolPartIdByProviderId) {
+                    if (partId === id) toolPartIdByProviderId.delete(providerId);
                   }
                   useChatRuntimeStore.getState().clearToolConfirmation(id);
                   // The result replaces the live output, but if the stream
@@ -6928,7 +6939,7 @@ export function createOpenAIStreamAdapter(
                   const call = tc as {
                     id?: string;
                     index?: number;
-                    function?: { name?: string; arguments?: string };
+                    function?: { name?: string; arguments?: unknown };
                     extra_content?: unknown;
                   };
                   const idx =
@@ -6941,20 +6952,60 @@ export function createOpenAIStreamAdapter(
                     typeof call.function?.name === "string"
                       ? call.function.name
                       : "";
-                  // Unsloth's local Codex loop follows the OpenAI tool-call delta with
-                  // tool_start/tool_end events. Resolve the backend id now so all three
-                  // event shapes update one run-unique card instead of leaving the raw
-                  // provisional card beside a second execution card.
-                  const stablePartId = stableId
-                    ? resolveToolPartId(stableId)
+                  const rawArgsFragment = streamedToolCallArguments(
+                    call.function?.arguments,
+                  );
+                  let argsFragment = rawArgsFragment;
+                  let stablePartId = stableId
+                    ? toolPartIdByProviderId.get(stableId)
                     : undefined;
+                  if (stableId && !stablePartId) {
+                    const delayedIndex = findDelayedStableToolCallPartIndex(
+                      toolCallParts,
+                      idx,
+                      nameFragment,
+                      rawArgsFragment,
+                    );
+                    if (delayedIndex !== -1) {
+                      const provisionalPartId =
+                        toolCallParts[delayedIndex].toolCallId;
+                      stablePartId = resolveToolPartId(stableId);
+                      if (
+                        rawArgsFragment &&
+                        toolCallParts[delayedIndex].argsText === rawArgsFragment
+                      ) {
+                        argsFragment = "";
+                      }
+                      if (provisionalPartId !== stablePartId) {
+                        toolPartIdByBackendId.delete(provisionalPartId);
+                        streamedToolCallIds.delete(provisionalPartId);
+                        codexRoundToolCallIds = codexRoundToolCallIds.map(
+                          (callId) =>
+                            callId === provisionalPartId
+                              ? stablePartId as string
+                              : callId,
+                        );
+                      }
+                    } else if (streamedToolCallIds.has(stableId)) {
+                      stablePartId = mintStreamedToolCallId(
+                        toolCallParts,
+                        idx,
+                        streamedToolCallIds,
+                      );
+                      toolPartIdByBackendId.set(stablePartId, stablePartId);
+                    } else {
+                      stablePartId = resolveToolPartId(stableId);
+                    }
+                    toolPartIdByProviderId.set(stableId, stablePartId);
+                    streamedToolCallIds.add(
+                      stablePartId.startsWith(`${stableId}:`)
+                        ? stableId
+                        : stablePartId,
+                    );
+                  }
                   // match by resolved id when the fragment carries one, else by
                   // index slot; streams that send neither get a minted
                   // tool_call_<n> id.
-                  const argsFragment =
-                    typeof call.function?.arguments === "string"
-                      ? call.function.arguments
-                      : "";
                   const exactStableIndex = stablePartId
                     ? toolCallParts.findIndex(
                         (part) => part.toolCallId === stablePartId,
@@ -7009,7 +7060,7 @@ export function createOpenAIStreamAdapter(
                     codexRoundToolCallIds.push(stablePartId);
                   }
                   streamedChars += argsFragment.length + nameFragment.length;
-                  if (!exactStableMatch) {
+                  if (!exactStableMatch || argsFragment) {
                     const split = splitTopLevelJsonDocuments(
                       (matchedPart?.argsText ?? "") + argsFragment,
                     );
@@ -7020,10 +7071,33 @@ export function createOpenAIStreamAdapter(
                     if (segments.length > 1) {
                       const firstNewSegment = matchedPart ? 1 : 0;
                       if (matchedPart) {
+                        let settledPartId = matchedPart.toolCallId;
+                        if (exactStableMatch) {
+                          settledPartId = mintStreamedToolCallId(
+                            toolCallParts,
+                            idx,
+                            streamedToolCallIds,
+                          );
+                          toolPartIdByBackendId.set(
+                            settledPartId,
+                            settledPartId,
+                          );
+                          streamedToolCallIds.add(settledPartId);
+                          if (
+                            !codexRoundToolCallIds.includes(settledPartId)
+                          ) {
+                            codexRoundToolCallIds.push(settledPartId);
+                          }
+                        }
                         toolCallParts[existingIndex] = {
                           ...(matchedPart as PositionedToolCallPart),
+                          toolCallId: settledPartId,
+                          ...(exactStableMatch
+                            ? { _has_stable_id: undefined }
+                            : {}),
                           argsText: segments[0],
                           args: parseStreamedToolCallArgs(segments[0]),
+                          _split_tail: undefined,
                         };
                       }
                       for (const [segmentIndex, argsText] of segments
@@ -7035,10 +7109,11 @@ export function createOpenAIStreamAdapter(
                             : mintStreamedToolCallId(
                                 toolCallParts,
                                 idx,
-                                toolPartIdByBackendId.keys(),
+                                streamedToolCallIds,
                               );
                         if (!stablePartId || callId !== stablePartId) {
                           toolPartIdByBackendId.set(callId, callId);
+                          streamedToolCallIds.add(callId);
                         }
                         if (!codexRoundToolCallIds.includes(callId)) {
                           codexRoundToolCallIds.push(callId);
@@ -7058,6 +7133,9 @@ export function createOpenAIStreamAdapter(
                             ? { _has_stable_id: true }
                             : {}),
                           ...(idx !== undefined ? { _delta_index: idx } : {}),
+                          ...(split.tail && argsText === split.tail
+                            ? { _split_tail: true }
+                            : {}),
                         });
                       }
                       addedToolCall = true;
@@ -7096,6 +7174,7 @@ export function createOpenAIStreamAdapter(
                           ? { extra_content: prevExtra }
                           : {}),
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
+                      _split_tail: undefined,
                     };
                     toolCallParts[existingIndex] = updated;
                   } else {
@@ -7107,11 +7186,12 @@ export function createOpenAIStreamAdapter(
                       mintStreamedToolCallId(
                         toolCallParts,
                         idx,
-                        toolPartIdByBackendId.keys(),
+                        streamedToolCallIds,
                       );
 
                     if (!stablePartId) {
                       toolPartIdByBackendId.set(callId, callId);
+                      streamedToolCallIds.add(callId);
                     }
 
                     if (!codexRoundToolCallIds.includes(callId)) {
@@ -7362,6 +7442,12 @@ export function createOpenAIStreamAdapter(
         // the open <think> tag so the reasoning panel parses cleanly.
         closeReasoningContent();
         settleFirstTokenOk();
+
+        for (let i = toolCallParts.length - 1; i >= 0; i -= 1) {
+          if (toolCallParts[i]._split_tail && !toolCallParts[i].result) {
+            toolCallParts.splice(i, 1);
+          }
+        }
 
         // Extract source parts from completed web_search and web_fetch
         // calls. Both emit the same `Title:` / `URL:` / `Snippet:` block

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -108,6 +108,7 @@ import {
 
 import { toolCallReplayArguments } from "../tool-call-arguments";
 import {
+  findOldestUnownedStreamedToolCallPartIndex,
   findStreamedToolCallPartIndex,
   mintStreamedToolCallId,
   resolveToolCallPartId,
@@ -6954,11 +6955,24 @@ export function createOpenAIStreamAdapter(
                     typeof call.function?.arguments === "string"
                       ? call.function.arguments
                       : "";
-                  const existingIndex = findStreamedToolCallPartIndex(
-                    toolCallParts,
-                    stablePartId,
-                    idx,
-                  );
+                  const exactStableIndex = stablePartId
+                    ? toolCallParts.findIndex(
+                        (part) => part.toolCallId === stablePartId,
+                      )
+                    : -1;
+                  const existingIndex =
+                    exactStableIndex !== -1
+                      ? exactStableIndex
+                      : stablePartId && !nameFragment && !argsFragment
+                        ? findOldestUnownedStreamedToolCallPartIndex(
+                            toolCallParts,
+                            idx,
+                          )
+                        : findStreamedToolCallPartIndex(
+                            toolCallParts,
+                            stablePartId,
+                            idx,
+                          );
                   const matchedPart =
                     existingIndex === -1
                       ? undefined
@@ -7018,7 +7032,11 @@ export function createOpenAIStreamAdapter(
                         const callId =
                           segmentIndex === 0 && stablePartId
                             ? stablePartId
-                            : mintStreamedToolCallId(toolCallParts, idx);
+                            : mintStreamedToolCallId(
+                                toolCallParts,
+                                idx,
+                                toolPartIdByBackendId.keys(),
+                              );
                         if (!stablePartId || callId !== stablePartId) {
                           toolPartIdByBackendId.set(callId, callId);
                         }
@@ -7086,7 +7104,11 @@ export function createOpenAIStreamAdapter(
                     // the plain tool_call_<idx> spelling is already taken.
                     const callId =
                       stablePartId ||
-                      mintStreamedToolCallId(toolCallParts, idx);
+                      mintStreamedToolCallId(
+                        toolCallParts,
+                        idx,
+                        toolPartIdByBackendId.keys(),
+                      );
 
                     if (!stablePartId) {
                       toolPartIdByBackendId.set(callId, callId);

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -109,9 +109,9 @@ import {
 import { toolCallReplayArguments } from "../tool-call-arguments";
 import {
   findStreamedToolCallPartIndex,
-  fragmentStartsNewToolCall,
   mintStreamedToolCallId,
   resolveToolCallPartId,
+  splitTopLevelJsonDocuments,
 } from "../tool-call-id";
 
 import { buildResearchInferenceRequest } from "../research-inference-request";
@@ -469,6 +469,15 @@ function parseLiveToolArgs(
     return null;
   }
   return { args: parsed, argsText: candidate };
+}
+
+function parseStreamedToolCallArgs(raw: string): ToolCallMessagePart["args"] {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as ToolCallMessagePart["args"];
+  } catch {
+    return { _raw: raw } as ToolCallMessagePart["args"];
+  }
 }
 
 function parseSystemVariablesMap(raw: string): Record<string, unknown> {
@@ -6923,7 +6932,14 @@ export function createOpenAIStreamAdapter(
                   };
                   const idx =
                     typeof call.index === "number" ? call.index : undefined;
-                  const stableId = call.id;
+                  const stableId =
+                    typeof call.id === "string" && call.id
+                      ? call.id
+                      : undefined;
+                  const nameFragment =
+                    typeof call.function?.name === "string"
+                      ? call.function.name
+                      : "";
                   // Unsloth's local Codex loop follows the OpenAI tool-call delta with
                   // tool_start/tool_end events. Resolve the backend id now so all three
                   // event shapes update one run-unique card instead of leaving the raw
@@ -6934,7 +6950,10 @@ export function createOpenAIStreamAdapter(
                   // match by resolved id when the fragment carries one, else by
                   // index slot; streams that send neither get a minted
                   // tool_call_<n> id.
-                  const argsFragment = call.function?.arguments ?? "";
+                  const argsFragment =
+                    typeof call.function?.arguments === "string"
+                      ? call.function.arguments
+                      : "";
                   const existingIndex = findStreamedToolCallPartIndex(
                     toolCallParts,
                     stablePartId,
@@ -6944,7 +6963,17 @@ export function createOpenAIStreamAdapter(
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
-                  // An id-less opening landing on a slot whose arguments are
+                  const exactStableMatch = Boolean(
+                    stablePartId && matchedPart?.toolCallId === stablePartId,
+                  );
+                  const matchedDocuments = matchedPart
+                    ? splitTopLevelJsonDocuments(matchedPart.argsText ?? "")
+                    : null;
+                  const matchedClosed = Boolean(
+                    matchedDocuments?.complete.length === 1 &&
+                      !matchedDocuments.tail,
+                  );
+                  // an id-less opening landing on a slot whose arguments are
                   // already a complete JSON document is the next parallel
                   // call, not a continuation: some proxies strip ids and
                   // renumber every call's index to 0, and merging would glue
@@ -6952,8 +6981,10 @@ export function createOpenAIStreamAdapter(
                   // the thread on replay (#9807).
                   const existing =
                     matchedPart !== undefined &&
-                    !stablePartId &&
-                    fragmentStartsNewToolCall(matchedPart.argsText, argsFragment)
+                    !exactStableMatch &&
+                    matchedClosed &&
+                    Boolean(nameFragment) &&
+                    !argsFragment
                       ? undefined
                       : matchedPart;
 
@@ -6963,25 +6994,63 @@ export function createOpenAIStreamAdapter(
                   ) {
                     codexRoundToolCallIds.push(stablePartId);
                   }
-                  streamedChars +=
-                    argsFragment.length + (call.function?.name?.length ?? 0);
+                  streamedChars += argsFragment.length + nameFragment.length;
+                  if (!exactStableMatch) {
+                    const split = splitTopLevelJsonDocuments(
+                      (matchedPart?.argsText ?? "") + argsFragment,
+                    );
+                    const segments = [
+                      ...split.complete,
+                      ...(split.tail ? [split.tail] : []),
+                    ];
+                    if (segments.length > 1) {
+                      const firstNewSegment = matchedPart ? 1 : 0;
+                      if (matchedPart) {
+                        toolCallParts[existingIndex] = {
+                          ...(matchedPart as PositionedToolCallPart),
+                          argsText: segments[0],
+                          args: parseStreamedToolCallArgs(segments[0]),
+                        };
+                      }
+                      for (const [segmentIndex, argsText] of segments
+                        .slice(firstNewSegment)
+                        .entries()) {
+                        const callId =
+                          segmentIndex === 0 && stablePartId
+                            ? stablePartId
+                            : mintStreamedToolCallId(toolCallParts, idx);
+                        if (!stablePartId || callId !== stablePartId) {
+                          toolPartIdByBackendId.set(callId, callId);
+                        }
+                        if (!codexRoundToolCallIds.includes(callId)) {
+                          codexRoundToolCallIds.push(callId);
+                        }
+                        toolCallParts.push({
+                          type: "tool-call" as const,
+                          toolCallId: callId,
+                          toolName: nameFragment || matchedPart?.toolName || "",
+                          argsText,
+                          args: parseStreamedToolCallArgs(argsText),
+                          textCursor: cumulativeText.length,
+                          ...(segmentIndex === 0 &&
+                          call.extra_content !== undefined
+                            ? { extra_content: call.extra_content }
+                            : {}),
+                          ...(segmentIndex === 0 && stablePartId
+                            ? { _has_stable_id: true }
+                            : {}),
+                          ...(idx !== undefined ? { _delta_index: idx } : {}),
+                        });
+                      }
+                      addedToolCall = true;
+                      continue;
+                    }
+                  }
                   if (existing) {
                     const prevName = existing.toolName ?? "";
-                    const nextName = call.function?.name ?? prevName;
+                    const nextName = nameFragment || prevName;
                     const merged = (existing.argsText ?? "") + argsFragment;
-                    let parsedArgs: ToolCallMessagePart["args"] =
-                      existing.args ?? {};
-                    if (merged) {
-                      try {
-                        parsedArgs = JSON.parse(
-                          merged,
-                        ) as ToolCallMessagePart["args"];
-                      } catch {
-                        parsedArgs = {
-                          _raw: merged,
-                        } as ToolCallMessagePart["args"];
-                      }
-                    }
+                    const parsedArgs = parseStreamedToolCallArgs(merged);
                     const prevExtra = (existing as PositionedToolCallPart)
                       .extra_content;
                     if (
@@ -7012,33 +7081,26 @@ export function createOpenAIStreamAdapter(
                     };
                     toolCallParts[existingIndex] = updated;
                   } else {
-                    // Minted collision-free: a boundary-split parallel call
+                    // minted collision-free: a boundary-split parallel call
                     // shares its delta index with the part it split from, so
                     // the plain tool_call_<idx> spelling is already taken.
                     const callId =
                       stablePartId ||
                       mintStreamedToolCallId(toolCallParts, idx);
 
+                    if (!stablePartId) {
+                      toolPartIdByBackendId.set(callId, callId);
+                    }
+
                     if (!codexRoundToolCallIds.includes(callId)) {
                       codexRoundToolCallIds.push(callId);
                     }
                     const argsText = argsFragment;
-                    let parsedArgs: ToolCallMessagePart["args"] = {};
-                    if (argsText) {
-                      try {
-                        parsedArgs = JSON.parse(
-                          argsText,
-                        ) as ToolCallMessagePart["args"];
-                      } catch {
-                        parsedArgs = {
-                          _raw: argsText,
-                        } as ToolCallMessagePart["args"];
-                      }
-                    }
+                    const parsedArgs = parseStreamedToolCallArgs(argsText);
                     const fresh: PositionedToolCallPart = {
                       type: "tool-call" as const,
                       toolCallId: callId,
-                      toolName: call.function?.name ?? "",
+                      toolName: nameFragment,
                       argsText,
                       args: parsedArgs,
                       textCursor: cumulativeText.length,

--- a/studio/frontend/src/features/chat/tool-call-arguments.ts
+++ b/studio/frontend/src/features/chat/tool-call-arguments.ts
@@ -21,5 +21,17 @@ export function toolCallReplayArguments(
       // unparsable, so the structured args below stand in for it
     }
   }
-  return JSON.stringify(args ?? {});
+  const structured =
+    args !== null && typeof args === "object" && !Array.isArray(args)
+      ? (args as Record<string, unknown>)
+      : null;
+  if (
+    typeof argsText === "string" &&
+    structured !== null &&
+    Object.keys(structured).length === 1 &&
+    structured._raw === argsText
+  ) {
+    return "{}";
+  }
+  return JSON.stringify(args ?? {}) ?? "{}";
 }

--- a/studio/frontend/src/features/chat/tool-call-arguments.ts
+++ b/studio/frontend/src/features/chat/tool-call-arguments.ts
@@ -35,3 +35,17 @@ export function toolCallReplayArguments(
   }
   return JSON.stringify(args ?? {}) ?? "{}";
 }
+
+export function streamedToolCallArguments(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || typeof value !== "object") {
+    return "";
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -19,6 +19,8 @@ export function resolveToolCallPartId(
 
 export interface StreamedToolCallPart {
   toolCallId: string;
+  toolName?: string;
+  argsText?: string;
   _delta_index?: number;
   _has_stable_id?: boolean;
 }
@@ -119,6 +121,27 @@ export function findOldestUnownedStreamedToolCallPartIndex(
     (part) =>
       part._delta_index === deltaIndex && part._has_stable_id !== true,
   );
+}
+
+export function findDelayedStableToolCallPartIndex(
+  parts: readonly StreamedToolCallPart[],
+  deltaIndex: number | undefined,
+  name: string,
+  argumentsText: string,
+): number {
+  if (deltaIndex === undefined) {
+    return -1;
+  }
+  return parts.findIndex((part) => {
+    if (
+      part._delta_index !== deltaIndex ||
+      part._has_stable_id === true ||
+      (name && part.toolName && part.toolName !== name)
+    ) {
+      return false;
+    }
+    return !argumentsText || part.argsText === argumentsText;
+  });
 }
 
 /**

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -239,6 +239,9 @@ export function fragmentStartsNewToolCall(
 ): boolean {
   const existing = existingArgsText ?? "";
   if (!existing.trim() || !fragmentArguments.trim()) return false;
+  if (!fragmentArguments.includes("{") && !fragmentArguments.includes("[")) {
+    return false;
+  }
   const split = splitTopLevelJsonDocuments(existing + fragmentArguments);
   return (
     split.complete.length > 1 ||

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -17,6 +17,15 @@ export function resolveToolCallPartId(
   return partId;
 }
 
+export function bindStreamedToolCallBackendIds(
+  ids: Map<string, string>,
+  providerId: string,
+  streamId: string,
+): void {
+  if (!ids.has(providerId)) ids.set(providerId, streamId);
+  ids.set(streamId, streamId);
+}
+
 export interface StreamedToolCallPart {
   toolCallId: string;
   toolName?: string;

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -105,7 +105,14 @@ function containsUnsafeJsonInteger(text: string): boolean {
 }
 
 export function sameJsonDocument(left: string, right: string): boolean {
-  if (left.trim() === right.trim()) return true;
+  if (left.trim() === right.trim()) {
+    try {
+      JSON.parse(left);
+      return true;
+    } catch {
+      return false;
+    }
+  }
   if (containsUnsafeJsonInteger(left) || containsUnsafeJsonInteger(right)) {
     return false;
   }
@@ -183,13 +190,12 @@ export function isRepeatedJsonSnapshot(
   fragment: string,
 ): boolean {
   if (!fragment.trim()) return false;
-  if (existing === fragment) return true;
   if (!fragment.includes("{") && !fragment.includes("[")) return false;
   const documents = splitTopLevelJsonDocuments(fragment);
   return (
     documents.complete.length === 1 &&
     !documents.tail &&
-    sameJsonDocument(existing, fragment)
+    (existing === fragment || sameJsonDocument(existing, fragment))
   );
 }
 

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -30,6 +30,47 @@ export interface JsonDocumentSplit {
   tail: string;
 }
 
+function sameJsonValue(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => sameJsonValue(value, right[index]))
+    );
+  }
+  if (
+    left === null ||
+    right === null ||
+    typeof left !== "object" ||
+    typeof right !== "object"
+  ) {
+    return false;
+  }
+  const leftObject = left as Record<string, unknown>;
+  const rightObject = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftObject);
+  return (
+    leftKeys.length === Object.keys(rightObject).length &&
+    leftKeys.every(
+      (key) =>
+        Object.hasOwn(rightObject, key) &&
+        sameJsonValue(leftObject[key], rightObject[key]),
+    )
+  );
+}
+
+export function sameJsonDocument(left: string, right: string): boolean {
+  try {
+    return sameJsonValue(JSON.parse(left), JSON.parse(right));
+  } catch {
+    return false;
+  }
+}
+
 /** split a stream slot into complete top-level JSON documents and its open tail. */
 export function splitTopLevelJsonDocuments(text: string): JsonDocumentSplit {
   const unsplit = { complete: [], tail: text };
@@ -140,7 +181,10 @@ export function findDelayedStableToolCallPartIndex(
     ) {
       return false;
     }
-    return !argumentsText || part.argsText === argumentsText;
+    return (
+      !argumentsText.trim() ||
+      sameJsonDocument(part.argsText ?? "", argumentsText)
+    );
   });
 }
 

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -99,9 +99,26 @@ function findDeltaIndexSlot(
     if (part._delta_index !== deltaIndex) {
       continue;
     }
-    return unownedOnly && part._has_stable_id ? -1 : i;
+    if (unownedOnly && part._has_stable_id) {
+      continue;
+    }
+    return i;
   }
   return -1;
+}
+
+/** oldest id-less part holding `deltaIndex`, or -1. */
+export function findOldestUnownedStreamedToolCallPartIndex(
+  parts: readonly StreamedToolCallPart[],
+  deltaIndex: number | undefined,
+): number {
+  if (deltaIndex === undefined) {
+    return -1;
+  }
+  return parts.findIndex(
+    (part) =>
+      part._delta_index === deltaIndex && part._has_stable_id !== true,
+  );
 }
 
 /**
@@ -152,16 +169,19 @@ export function fragmentStartsNewToolCall(
   );
 }
 
-/** A `tool_call_<n>` id no existing part already carries. */
+/** a `tool_call_<n>` id no existing part already carries. */
 export function mintStreamedToolCallId(
   parts: readonly StreamedToolCallPart[],
-  deltaIndex: number | undefined,
+  _deltaIndex: number | undefined,
+  reservedIds: Iterable<string> = [],
 ): string {
-  let candidate = `tool_call_${deltaIndex ?? parts.length}`;
-  let next = parts.length;
-  while (parts.some((part) => part.toolCallId === candidate)) {
-    candidate = `tool_call_${next}`;
+  const taken = new Set(reservedIds);
+  for (const part of parts) {
+    taken.add(part.toolCallId);
+  }
+  let next = 0;
+  while (taken.has(`tool_call_${next}`)) {
     next += 1;
   }
-  return candidate;
+  return `tool_call_${next}`;
 }

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -67,3 +67,49 @@ export function findStreamedToolCallPartIndex(
   const byId = parts.findIndex((part) => part.toolCallId === partId);
   return byId === -1 ? findDeltaIndexSlot(parts, deltaIndex, true) : byId;
 }
+
+/**
+ * True when an id-less fragment cannot be a continuation of the arguments a
+ * slot has already accumulated: the accumulated text forms a complete JSON
+ * document and the fragment opens another one.
+ *
+ * Some proxies strip tool-call ids AND renumber every parallel call's index
+ * to 0 (LiteLLM), so slot matching alone lands each call's opening fragment
+ * on the previous call's part and the argument JSONs concatenate into one
+ * malformed string, which then poisons the thread on replay (#9807). A
+ * complete JSON document never continues into another `{`/`[`, so this
+ * boundary is safe for genuinely chunked arguments.
+ */
+export function fragmentStartsNewToolCall(
+  existingArgsText: string | undefined,
+  fragmentArguments: string,
+): boolean {
+  const settled = (existingArgsText ?? "").trim();
+  if (!settled) {
+    return false;
+  }
+  const opening = fragmentArguments.trimStart();
+  if (!(opening.startsWith("{") || opening.startsWith("["))) {
+    return false;
+  }
+  try {
+    JSON.parse(settled);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+/** A `tool_call_<n>` id no existing part already carries. */
+export function mintStreamedToolCallId(
+  parts: readonly StreamedToolCallPart[],
+  deltaIndex: number | undefined,
+): string {
+  let candidate = `tool_call_${deltaIndex ?? parts.length}`;
+  let next = parts.length;
+  while (parts.some((part) => part.toolCallId === candidate)) {
+    candidate = `tool_call_${next}`;
+    next += 1;
+  }
+  return candidate;
+}

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -28,7 +28,7 @@ export interface JsonDocumentSplit {
   tail: string;
 }
 
-/** Split a stream slot into complete top-level JSON documents and its open tail. */
+/** split a stream slot into complete top-level JSON documents and its open tail. */
 export function splitTopLevelJsonDocuments(text: string): JsonDocumentSplit {
   const unsplit = { complete: [], tail: text };
   const complete: string[] = [];
@@ -146,7 +146,10 @@ export function fragmentStartsNewToolCall(
   const existing = existingArgsText ?? "";
   if (!existing.trim() || !fragmentArguments.trim()) return false;
   const split = splitTopLevelJsonDocuments(existing + fragmentArguments);
-  return split.complete.length > 1 || (split.complete.length === 1 && Boolean(split.tail));
+  return (
+    split.complete.length > 1 ||
+    (split.complete.length === 1 && Boolean(split.tail))
+  );
 }
 
 /** A `tool_call_<n>` id no existing part already carries. */

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -23,6 +23,65 @@ export interface StreamedToolCallPart {
   _has_stable_id?: boolean;
 }
 
+export interface JsonDocumentSplit {
+  complete: string[];
+  tail: string;
+}
+
+/** Split a stream slot into complete top-level JSON documents and its open tail. */
+export function splitTopLevelJsonDocuments(text: string): JsonDocumentSplit {
+  const unsplit = { complete: [], tail: text };
+  const complete: string[] = [];
+  const closing: string[] = [];
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (closing.length === 0) {
+      if (character === "{" || character === "[") {
+        start = index;
+        closing.push(character === "{" ? "}" : "]");
+        continue;
+      }
+      if (/\s/u.test(character)) continue;
+      return unsplit;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{" || character === "[") {
+      closing.push(character === "{" ? "}" : "]");
+      continue;
+    }
+    if (character !== "}" && character !== "]") continue;
+    if (closing.pop() !== character) return unsplit;
+    if (closing.length !== 0) continue;
+
+    const document = text.slice(start, index + 1);
+    try {
+      JSON.parse(document);
+    } catch {
+      return unsplit;
+    }
+    complete.push(document);
+    start = -1;
+  }
+
+  return {
+    complete,
+    tail: start === -1 ? "" : text.slice(start),
+  };
+}
+
 /**
  * Newest part holding `deltaIndex`, or -1. `unownedOnly` restricts the match to
  * a slot no provider id has claimed yet.
@@ -84,20 +143,10 @@ export function fragmentStartsNewToolCall(
   existingArgsText: string | undefined,
   fragmentArguments: string,
 ): boolean {
-  const settled = (existingArgsText ?? "").trim();
-  if (!settled) {
-    return false;
-  }
-  const opening = fragmentArguments.trimStart();
-  if (!(opening.startsWith("{") || opening.startsWith("["))) {
-    return false;
-  }
-  try {
-    JSON.parse(settled);
-  } catch {
-    return false;
-  }
-  return true;
+  const existing = existingArgsText ?? "";
+  if (!existing.trim() || !fragmentArguments.trim()) return false;
+  const split = splitTopLevelJsonDocuments(existing + fragmentArguments);
+  return split.complete.length > 1 || (split.complete.length === 1 && Boolean(split.tail));
 }
 
 /** A `tool_call_<n>` id no existing part already carries. */

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -73,7 +73,42 @@ function sameJsonValue(left: unknown, right: unknown): boolean {
   );
 }
 
+function containsUnsafeJsonInteger(text: string): boolean {
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character !== "-" && (character < "0" || character > "9")) {
+      continue;
+    }
+    const match = text
+      .slice(index)
+      .match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/u);
+    if (!match) continue;
+    const value = Number(match[0]);
+    if (!Number.isFinite(value) || (Number.isInteger(value) && !Number.isSafeInteger(value))) {
+      return true;
+    }
+    index += match[0].length - 1;
+  }
+  return false;
+}
+
 export function sameJsonDocument(left: string, right: string): boolean {
+  if (left.trim() === right.trim()) return true;
+  if (containsUnsafeJsonInteger(left) || containsUnsafeJsonInteger(right)) {
+    return false;
+  }
   try {
     return sameJsonValue(JSON.parse(left), JSON.parse(right));
   } catch {

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -178,6 +178,21 @@ export function splitTopLevelJsonDocuments(text: string): JsonDocumentSplit {
   };
 }
 
+export function isRepeatedJsonSnapshot(
+  existing: string,
+  fragment: string,
+): boolean {
+  if (!fragment.trim()) return false;
+  if (existing === fragment) return true;
+  if (!fragment.includes("{") && !fragment.includes("[")) return false;
+  const documents = splitTopLevelJsonDocuments(fragment);
+  return (
+    documents.complete.length === 1 &&
+    !documents.tail &&
+    sameJsonDocument(existing, fragment)
+  );
+}
+
 /**
  * Newest part holding `deltaIndex`, or -1. `unownedOnly` restricts the match to
  * a slot no provider id has claimed yet.

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -21,6 +21,7 @@ export interface StreamedToolCallPart {
   toolCallId: string;
   toolName?: string;
   argsText?: string;
+  result?: unknown;
   _delta_index?: number;
   _has_stable_id?: boolean;
 }
@@ -69,6 +70,14 @@ export function sameJsonDocument(left: string, right: string): boolean {
   } catch {
     return false;
   }
+}
+
+export function mergeStreamedToolCallName(
+  current: string,
+  fragment: string,
+): string {
+  if (!fragment) return current;
+  return fragment.startsWith(current) ? fragment : current + fragment;
 }
 
 /** split a stream slot into complete top-level JSON documents and its open tail. */
@@ -177,6 +186,7 @@ export function findDelayedStableToolCallPartIndex(
     if (
       part._delta_index !== deltaIndex ||
       part._has_stable_id === true ||
+      part.result !== undefined ||
       (name && part.toolName && part.toolName !== name)
     ) {
       return false;

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -525,6 +525,26 @@ test("streaming tool-call argument deltas are paced like the text path", () => {
   );
 });
 
+test("plain tool argument fragments do not rescan the accumulated JSON", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  assert.match(
+    loop,
+    /\(argsFragment\.includes\("\{"\) \|\| argsFragment\.includes\("\["\)\)[\s\S]{0,120}?combinedDocuments = splitTopLevelJsonDocuments/,
+  );
+  assert.match(
+    loop,
+    /_split_tail &&[\s\S]{0,120}?\(argsFragment\.includes\("\}"\) \|\| argsFragment\.includes\("\]"\)\)[\s\S]{0,80}?\? splitTopLevelJsonDocuments/,
+  );
+  assert.ok(
+    loop.includes("const matchedClosed = checkCompletedSlot"),
+    "completed-slot detection scans every argument fragment",
+  );
+});
+
 test("the gate is fed every arrival, not only the tool-call ones", () => {
   const loop = regionOf(
     "for await (const chunk of stream) {",

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -506,8 +506,8 @@ test("streaming tool-call argument deltas are paced like the text path", () => {
 
   // Both branches of the OpenAI delta.tool_calls accumulator feed the counter,
   // so a turn that only streams a call's arguments is still capped.
-  const count = loop.indexOf(
-    "streamedChars +=\n                    argsFragment.length",
+  const count = loop.search(
+    /streamedChars\s*\+=\s*argsFragment\.length\s*\+\s*nameFragment\.length/,
   );
   assert.notEqual(count, -1, "tool-call argument deltas are not counted");
 

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -507,7 +507,7 @@ test("streaming tool-call argument deltas are paced like the text path", () => {
   // Both branches of the OpenAI delta.tool_calls accumulator feed the counter,
   // so a turn that only streams a call's arguments is still capped.
   const count = loop.search(
-    /streamedChars\s*\+=\s*argsFragment\.length\s*\+\s*nameFragment\.length/,
+    /streamedChars\s*\+=\s*rawArgsFragment\.length\s*\+\s*nameFragment\.length/,
   );
   assert.notEqual(count, -1, "tool-call argument deltas are not counted");
 

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -16,43 +16,82 @@ import {
 interface DeltaFragment {
   id?: string;
   index?: number;
+  name?: string;
   arguments: string;
 }
 
 /** Accumulate `delta.tool_calls[]` fragments the way the chat adapter does. */
 function accumulate(
   fragments: DeltaFragment[],
-): (StreamedToolCallPart & { argsText: string })[] {
-  const parts: (StreamedToolCallPart & { argsText: string })[] = [];
+): (StreamedToolCallPart & { argsText: string; toolName?: string })[] {
+  const parts: (StreamedToolCallPart & {
+    argsText: string;
+    toolName?: string;
+  })[] = [];
+  const append = (
+    fragment: DeltaFragment,
+    argsText: string,
+    id = fragment.id,
+  ) => {
+    parts.push({
+      toolCallId: id ?? mintStreamedToolCallId(parts, fragment.index),
+      toolName: fragment.name,
+      argsText,
+      ...(id ? { _has_stable_id: true } : {}),
+      ...(fragment.index !== undefined ? { _delta_index: fragment.index } : {}),
+    });
+  };
   for (const fragment of fragments) {
     const matched = findStreamedToolCallPartIndex(
       parts,
       fragment.id,
       fragment.index,
     );
-    // Mirrors the adapter: an id-less opening landing on a slot whose
-    // arguments are already complete is the next parallel call (#9807).
+    const matchedPart = matched === -1 ? undefined : parts[matched];
+    const exactId = Boolean(
+      fragment.id && matchedPart?.toolCallId === fragment.id,
+    );
+    const settled = matchedPart
+      ? splitTopLevelJsonDocuments(matchedPart.argsText)
+      : null;
     const target =
       matched !== -1 &&
-      !fragment.id &&
-      fragmentStartsNewToolCall(parts[matched].argsText, fragment.arguments)
+      !exactId &&
+      settled?.complete.length === 1 &&
+      !settled.tail &&
+      Boolean(fragment.name) &&
+      !fragment.arguments
         ? -1
         : matched;
+    if (!exactId) {
+      const split = splitTopLevelJsonDocuments(
+        (matchedPart?.argsText ?? "") + fragment.arguments,
+      );
+      const segments = [...split.complete, ...(split.tail ? [split.tail] : [])];
+      if (segments.length > 1) {
+        const firstNewSegment = matchedPart ? 1 : 0;
+        if (matchedPart)
+          parts[matched] = { ...matchedPart, argsText: segments[0] };
+        for (const [segmentIndex, segment] of segments
+          .slice(firstNewSegment)
+          .entries()) {
+          append(
+            fragment,
+            segment,
+            segmentIndex === 0 ? fragment.id : undefined,
+          );
+        }
+        continue;
+      }
+    }
     if (target === -1) {
-      parts.push({
-        toolCallId:
-          fragment.id ?? mintStreamedToolCallId(parts, fragment.index),
-        argsText: fragment.arguments,
-        ...(fragment.id ? { _has_stable_id: true } : {}),
-        ...(fragment.index !== undefined
-          ? { _delta_index: fragment.index }
-          : {}),
-      });
+      append(fragment, fragment.arguments);
       continue;
     }
     parts[target] = {
       ...parts[target],
       ...(fragment.id ? { toolCallId: fragment.id, _has_stable_id: true } : {}),
+      ...(fragment.name ? { toolName: fragment.name } : {}),
       argsText: parts[target].argsText + fragment.arguments,
     };
   }
@@ -232,7 +271,12 @@ test("JSON document boundaries keep an incomplete final document as the tail", (
 });
 
 test("JSON document boundaries reject mismatched or non-document text", () => {
-  for (const text of ['{"a":1]','{"a":1}suffix','"{\\"a\\":1}"','true{"a":1}']) {
+  for (const text of [
+    '{"a":1]',
+    '{"a":1}suffix',
+    '"{\\"a\\":1}"',
+    'true{"a":1}',
+  ]) {
     assert.deepEqual(splitTopLevelJsonDocuments(text), {
       complete: [],
       tail: text,
@@ -266,4 +310,47 @@ test("a document-looking continuation is not split while the first document is o
     fragmentStartsNewToolCall('{"text":"prefix', '{\\"nested\\":true}"}'),
     false,
   );
+});
+
+test("a name-only opening does not rename the completed call before it", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: '{"a":1}' },
+    { index: 0, name: "beta", arguments: "" },
+    { index: 0, arguments: '{"b":2}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["alpha", '{"a":1}'],
+      ["beta", '{"b":2}'],
+    ],
+  );
+});
+
+test("one fragment can close a call and open the next call", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: '{"a":' },
+    { index: 0, name: "beta", arguments: '1}{"b":2}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["alpha", '{"a":1}'],
+      ["beta", '{"b":2}'],
+    ],
+  );
+});
+
+test("one fresh fragment can contain several complete calls", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: '{"a":1}{"b":2}[]' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.argsText),
+    ['{"a":1}', '{"b":2}', "[]"],
+  );
+  assert.equal(new Set(parts.map((part) => part.toolCallId)).size, 3);
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -4,9 +4,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { toolCallReplayArguments } from "../src/features/chat/tool-call-arguments.ts";
+import {
+  streamedToolCallArguments,
+  toolCallReplayArguments,
+} from "../src/features/chat/tool-call-arguments.ts";
 import {
   type StreamedToolCallPart,
+  findDelayedStableToolCallPartIndex,
   findOldestUnownedStreamedToolCallPartIndex,
   findStreamedToolCallPartIndex,
   fragmentStartsNewToolCall,
@@ -21,19 +25,24 @@ interface DeltaFragment {
   arguments: string;
 }
 
+type AccumulatedPart = StreamedToolCallPart & {
+  argsText: string;
+  toolName?: string;
+  splitTail?: boolean;
+};
+
 /** Accumulate `delta.tool_calls[]` fragments the way the chat adapter does. */
 function accumulate(
   fragments: DeltaFragment[],
-): (StreamedToolCallPart & { argsText: string; toolName?: string })[] {
-  const parts: (StreamedToolCallPart & {
-    argsText: string;
-    toolName?: string;
-  })[] = [];
+): AccumulatedPart[] {
+  const parts: AccumulatedPart[] = [];
   const usedIds = new Set<string>();
+  const providerIds = new Map<string, string>();
   const append = (
     fragment: DeltaFragment,
     argsText: string,
     id = fragment.id,
+    splitTail = false,
   ) => {
     parts.push({
       toolCallId:
@@ -42,22 +51,50 @@ function accumulate(
       argsText,
       ...(id ? { _has_stable_id: true } : {}),
       ...(fragment.index !== undefined ? { _delta_index: fragment.index } : {}),
+      ...(splitTail ? { splitTail: true } : {}),
     });
     usedIds.add(parts[parts.length - 1].toolCallId);
   };
-  for (const fragment of fragments) {
-    const exact = fragment.id
-      ? parts.findIndex((part) => part.toolCallId === fragment.id)
+  for (const rawFragment of fragments) {
+    let fragment = rawFragment;
+    let partId = fragment.id ? providerIds.get(fragment.id) : undefined;
+    if (fragment.id && !partId) {
+      const providerId = fragment.id;
+      const delayed = findDelayedStableToolCallPartIndex(
+        parts,
+        fragment.index,
+        fragment.name ?? "",
+        fragment.arguments,
+      );
+      if (delayed !== -1) {
+        const provisionalId = parts[delayed].toolCallId;
+        partId = providerId;
+        parts[delayed].toolCallId = partId;
+        parts[delayed]._has_stable_id = true;
+        usedIds.delete(provisionalId);
+        if (fragment.arguments === parts[delayed].argsText) {
+          fragment = { ...fragment, arguments: "" };
+        }
+      } else {
+        partId = usedIds.has(providerId)
+          ? mintStreamedToolCallId(parts, fragment.index, usedIds)
+          : providerId;
+      }
+      providerIds.set(providerId, partId);
+      usedIds.add(partId);
+    }
+    const exact = partId
+      ? parts.findIndex((part) => part.toolCallId === partId)
       : -1;
     const matched =
       exact !== -1
         ? exact
-        : fragment.id && !fragment.name && !fragment.arguments
+        : partId && !fragment.name && !fragment.arguments
           ? findOldestUnownedStreamedToolCallPartIndex(parts, fragment.index)
-          : findStreamedToolCallPartIndex(parts, fragment.id, fragment.index);
+          : findStreamedToolCallPartIndex(parts, partId, fragment.index);
     const matchedPart = matched === -1 ? undefined : parts[matched];
     const exactId = Boolean(
-      fragment.id && matchedPart?.toolCallId === fragment.id,
+      partId && matchedPart?.toolCallId === partId,
     );
     const settled = matchedPart
       ? splitTopLevelJsonDocuments(matchedPart.argsText)
@@ -86,25 +123,29 @@ function accumulate(
           append(
             fragment,
             segment,
-            segmentIndex === 0 ? fragment.id : undefined,
+            segmentIndex === 0
+              ? partId
+              : mintStreamedToolCallId(parts, fragment.index, usedIds),
+            Boolean(split.tail && segment === split.tail),
           );
         }
         continue;
       }
     }
     if (target === -1) {
-      append(fragment, fragment.arguments);
+      append(fragment, fragment.arguments, partId);
       continue;
     }
     parts[target] = {
       ...parts[target],
-      ...(fragment.id ? { toolCallId: fragment.id, _has_stable_id: true } : {}),
+      ...(partId ? { toolCallId: partId, _has_stable_id: true } : {}),
       ...(fragment.name ? { toolName: fragment.name } : {}),
       argsText: parts[target].argsText + fragment.arguments,
+      splitTail: false,
     };
-    if (fragment.id) usedIds.add(fragment.id);
+    if (partId) usedIds.add(partId);
   }
-  return parts;
+  return parts.filter((part) => !part.splitTail);
 }
 
 test("tool rounds that both reuse index 0 stay separate calls", () => {
@@ -368,6 +409,25 @@ test("one fresh fragment can contain several complete calls", () => {
   assert.equal(new Set(parts.map((part) => part.toolCallId)).size, 3);
 });
 
+test("a fresh multi-document fragment keeps its stable id on the first call", () => {
+  const parts = accumulate([
+    {
+      id: "call-a",
+      index: 0,
+      name: "alpha",
+      arguments: '{"a":1}{"b":2}',
+    },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.argsText]),
+    [
+      ["call-a", '{"a":1}'],
+      ["tool_call_0", '{"b":2}'],
+    ],
+  );
+});
+
 test("delayed ids claim same-index calls in announcement order", () => {
   const parts = accumulate([
     { index: 0, name: "alpha", arguments: '{"a":1}' },
@@ -390,4 +450,47 @@ test("minted ids never reuse an adopted or stable id", () => {
   const parts = [{ toolCallId: "stable" }, { toolCallId: "tool_call_1" }];
 
   assert.equal(mintStreamedToolCallId(parts, 0, reserved), "tool_call_3");
+});
+
+test("a delayed id carrying an exact snapshot does not duplicate the call", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: '{"a":1}' },
+    { id: "call-a", index: 0, name: "alpha", arguments: '{"a":1}' },
+    { index: 0, name: "beta", arguments: '{"b":2}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.argsText]),
+    [
+      ["call-a", '{"a":1}'],
+      ["tool_call_0", '{"b":2}'],
+    ],
+  );
+});
+
+test("a stable id collision mints a distinct stream id", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: '{"a":1}' },
+    { id: "tool_call_0", index: 1, name: "beta", arguments: '{"b":2}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.toolCallId),
+    ["tool_call_0", "tool_call_1"],
+  );
+});
+
+test("decoded object arguments preserve their JSON payload", () => {
+  assert.equal(
+    streamedToolCallArguments({ query: "雪", nested: [1, { ok: true }] }),
+    '{"query":"雪","nested":[1,{"ok":true}]}',
+  );
+});
+
+test("an incomplete split tail is not persisted as a call", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: '{"a":1}{"b":' },
+  ]);
+
+  assert.deepEqual(parts.map((part) => part.argsText), ['{"a":1}']);
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -15,6 +15,7 @@ import {
   findStreamedToolCallPartIndex,
   fragmentStartsNewToolCall,
   mintStreamedToolCallId,
+  sameJsonDocument,
   splitTopLevelJsonDocuments,
 } from "../src/features/chat/tool-call-id.ts";
 
@@ -72,7 +73,7 @@ function accumulate(
         parts[delayed].toolCallId = partId;
         parts[delayed]._has_stable_id = true;
         usedIds.delete(provisionalId);
-        if (fragment.arguments === parts[delayed].argsText) {
+        if (sameJsonDocument(fragment.arguments, parts[delayed].argsText)) {
           fragment = { ...fragment, arguments: "" };
         }
       } else {
@@ -89,7 +90,7 @@ function accumulate(
     const matched =
       exact !== -1
         ? exact
-        : partId && !fragment.name && !fragment.arguments
+        : partId && !fragment.name && !fragment.arguments.trim()
           ? findOldestUnownedStreamedToolCallPartIndex(parts, fragment.index)
           : findStreamedToolCallPartIndex(parts, partId, fragment.index);
     const matchedPart = matched === -1 ? undefined : parts[matched];
@@ -105,7 +106,7 @@ function accumulate(
       settled?.complete.length === 1 &&
       !settled.tail &&
       Boolean(fragment.name) &&
-      !fragment.arguments
+      !fragment.arguments.trim()
         ? -1
         : matched;
     if (!exactId) {
@@ -136,12 +137,19 @@ function accumulate(
       append(fragment, fragment.arguments, partId);
       continue;
     }
+    const mergedArgsText = parts[target].argsText + fragment.arguments;
+    const mergedDocuments = splitTopLevelJsonDocuments(mergedArgsText);
     parts[target] = {
       ...parts[target],
       ...(partId ? { toolCallId: partId, _has_stable_id: true } : {}),
       ...(fragment.name ? { toolName: fragment.name } : {}),
-      argsText: parts[target].argsText + fragment.arguments,
-      splitTail: false,
+      argsText: mergedArgsText,
+      splitTail:
+        parts[target].splitTail &&
+        !(
+          mergedDocuments.complete.length === 1 &&
+          !mergedDocuments.tail
+        ),
     };
     if (partId) usedIds.add(partId);
   }
@@ -382,6 +390,22 @@ test("a name-only opening does not rename the completed call before it", () => {
   );
 });
 
+test("whitespace arguments still leave a name-only opening separate", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: "{}" },
+    { index: 0, name: "beta", arguments: " " },
+    { index: 0, arguments: '{"b":2}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["alpha", "{}"],
+      ["beta", ' {"b":2}'],
+    ],
+  );
+});
+
 test("one fragment can close a call and open the next call", () => {
   const parts = accumulate([
     { index: 0, name: "alpha", arguments: '{"a":' },
@@ -468,6 +492,27 @@ test("a delayed id carrying an exact snapshot does not duplicate the call", () =
   );
 });
 
+test("a delayed id adopts a semantically equal JSON snapshot", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: '{ "a": 1, "nested": {"x": 2} }' },
+    {
+      id: "call-a",
+      index: 0,
+      name: "alpha",
+      arguments: '{"nested":{"x":2},"a":1}',
+    },
+    { index: 0, name: "beta", arguments: '{"b":2}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.argsText]),
+    [
+      ["call-a", '{ "a": 1, "nested": {"x": 2} }'],
+      ["tool_call_0", '{"b":2}'],
+    ],
+  );
+});
+
 test("a stable id collision mints a distinct stream id", () => {
   const parts = accumulate([
     { index: 0, name: "alpha", arguments: '{"a":1}' },
@@ -489,7 +534,16 @@ test("decoded object arguments preserve their JSON payload", () => {
 
 test("an incomplete split tail is not persisted as a call", () => {
   const parts = accumulate([
+    { id: "call-a", index: 0, name: "alpha", arguments: '{"a":1}{"b":' },
+  ]);
+
+  assert.deepEqual(parts.map((part) => part.argsText), ['{"a":1}']);
+});
+
+test("a delayed id does not make an incomplete split tail persist", () => {
+  const parts = accumulate([
     { index: 0, name: "alpha", arguments: '{"a":1}{"b":' },
+    { id: "call-b", index: 0, name: "alpha", arguments: "" },
   ]);
 
   assert.deepEqual(parts.map((part) => part.argsText), ['{"a":1}']);

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -213,13 +213,17 @@ test("replayed arguments keep parsable text and fall back otherwise", () => {
     toolCallReplayArguments('{"query":"first"}{"query":"second"}', {
       _raw: '{"query":"first"}{"query":"second"}',
     }),
-    '{"_raw":"{\\"query\\":\\"first\\"}{\\"query\\":\\"second\\"}"}',
+    "{}",
   );
   assert.equal(
     toolCallReplayArguments("", { query: "first" }),
     '{"query":"first"}',
   );
   assert.equal(toolCallReplayArguments(undefined, undefined), "{}");
+  assert.equal(
+    toolCallReplayArguments(undefined, { _raw: "user supplied" }),
+    '{"_raw":"user supplied"}',
+  );
 });
 
 test("id-less parallel calls renumbered to index 0 stay separate calls", () => {

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -10,6 +10,7 @@ import {
   findStreamedToolCallPartIndex,
   fragmentStartsNewToolCall,
   mintStreamedToolCallId,
+  splitTopLevelJsonDocuments,
 } from "../src/features/chat/tool-call-id.ts";
 
 interface DeltaFragment {
@@ -207,5 +208,62 @@ test("an id-less chunked continuation still merges into its own call", () => {
   assert.deepEqual(
     parts.map((part) => part.argsText),
     ['{"url":"https://example.com/1"}', '{"url":"https://example.com/2"}'],
+  );
+});
+
+test("JSON document boundaries survive strings, nesting, whitespace, and Unicode", () => {
+  const documents = [
+    JSON.stringify({ nested: { items: [1, { text: '} ] { " \\\\ 雪' }] } }),
+    "[]",
+    "{}",
+    '[{"emoji":"🦥"}]',
+  ];
+  const split = splitTopLevelJsonDocuments(` \n${documents.join(" \t\r\n")}  `);
+
+  assert.deepEqual(split.complete, documents);
+  assert.equal(split.tail, "");
+});
+
+test("JSON document boundaries keep an incomplete final document as the tail", () => {
+  assert.deepEqual(splitTopLevelJsonDocuments('{"a":1} \n ["open"'), {
+    complete: ['{"a":1}'],
+    tail: '["open"',
+  });
+});
+
+test("JSON document boundaries reject mismatched or non-document text", () => {
+  for (const text of ['{"a":1]','{"a":1}suffix','"{\\"a\\":1}"','true{"a":1}']) {
+    assert.deepEqual(splitTopLevelJsonDocuments(text), {
+      complete: [],
+      tail: text,
+    });
+  }
+});
+
+test("new-call detection works when the SSE boundary lands inside either document", () => {
+  const first = '{"path":"C:\\\\tmp","nested":[{"text":"{x}"}]}';
+  const second = '{"query":"雪 🦥"}';
+  for (let firstCut = 1; firstCut <= first.length; firstCut += 1) {
+    const existing = first.slice(0, firstCut);
+    const remainder = first.slice(firstCut) + second;
+    assert.equal(
+      fragmentStartsNewToolCall(existing, remainder),
+      true,
+      `missed boundary after first character ${firstCut}`,
+    );
+  }
+  for (let secondCut = 1; secondCut <= second.length; secondCut += 1) {
+    assert.equal(
+      fragmentStartsNewToolCall(first, second.slice(0, secondCut)),
+      true,
+      `missed partial second document at character ${secondCut}`,
+    );
+  }
+});
+
+test("a document-looking continuation is not split while the first document is open", () => {
+  assert.equal(
+    fragmentStartsNewToolCall('{"text":"prefix', '{\\"nested\\":true}"}'),
+    false,
   );
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -522,6 +522,7 @@ test("an existing stable id ignores a repeated cumulative snapshot", () => {
     parts.map((part) => [part.toolCallId, part.argsText]),
     [["call-a", '{"a":1}']],
   );
+  assert.equal(isRepeatedJsonSnapshot('{"a":', '{"a":'), false);
 });
 
 test("a delayed id adopts a semantically equal JSON snapshot", () => {

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -15,6 +15,7 @@ import {
   findOldestUnownedStreamedToolCallPartIndex,
   findStreamedToolCallPartIndex,
   fragmentStartsNewToolCall,
+  isRepeatedJsonSnapshot,
   mergeStreamedToolCallName,
   mintStreamedToolCallId,
   sameJsonDocument,
@@ -106,6 +107,12 @@ function accumulate(
     const exactId = Boolean(
       partId && matchedPart?.toolCallId === partId,
     );
+    if (
+      exactId &&
+      isRepeatedJsonSnapshot(matchedPart?.argsText ?? "", fragment.arguments)
+    ) {
+      fragment = { ...fragment, arguments: "" };
+    }
     const settled = matchedPart
       ? splitTopLevelJsonDocuments(matchedPart.argsText)
       : null;
@@ -502,6 +509,18 @@ test("a delayed id carrying an exact snapshot does not duplicate the call", () =
       ["call-a", '{"a":1}'],
       ["tool_call_0", '{"b":2}'],
     ],
+  );
+});
+
+test("an existing stable id ignores a repeated cumulative snapshot", () => {
+  const parts = accumulate([
+    { id: "call-a", index: 0, name: "alpha", arguments: '{"a":1}' },
+    { id: "call-a", index: 0, name: "alpha", arguments: '{"a":1}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.argsText]),
+    [["call-a", '{"a":1}']],
   );
 });
 

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -8,6 +8,8 @@ import { toolCallReplayArguments } from "../src/features/chat/tool-call-argument
 import {
   type StreamedToolCallPart,
   findStreamedToolCallPartIndex,
+  fragmentStartsNewToolCall,
+  mintStreamedToolCallId,
 } from "../src/features/chat/tool-call-id.ts";
 
 interface DeltaFragment {
@@ -22,15 +24,23 @@ function accumulate(
 ): (StreamedToolCallPart & { argsText: string })[] {
   const parts: (StreamedToolCallPart & { argsText: string })[] = [];
   for (const fragment of fragments) {
-    const target = findStreamedToolCallPartIndex(
+    const matched = findStreamedToolCallPartIndex(
       parts,
       fragment.id,
       fragment.index,
     );
+    // Mirrors the adapter: an id-less opening landing on a slot whose
+    // arguments are already complete is the next parallel call (#9807).
+    const target =
+      matched !== -1 &&
+      !fragment.id &&
+      fragmentStartsNewToolCall(parts[matched].argsText, fragment.arguments)
+        ? -1
+        : matched;
     if (target === -1) {
       parts.push({
         toolCallId:
-          fragment.id ?? `tool_call_${fragment.index ?? parts.length}`,
+          fragment.id ?? mintStreamedToolCallId(parts, fragment.index),
         argsText: fragment.arguments,
         ...(fragment.id ? { _has_stable_id: true } : {}),
         ...(fragment.index !== undefined
@@ -161,4 +171,41 @@ test("replayed arguments keep parsable text and fall back otherwise", () => {
     '{"query":"first"}',
   );
   assert.equal(toolCallReplayArguments(undefined, undefined), "{}");
+});
+
+test("id-less parallel calls renumbered to index 0 stay separate calls", () => {
+  // LiteLLM's proxy can strip ids and renumber every parallel call's index to
+  // 0. Each opening fragment then "continues" the newest slot-0 part and the
+  // argument JSONs concatenate into one malformed string that poisons the
+  // thread on replay (#9807).
+  const parts = accumulate([
+    { index: 0, arguments: '{"url":"https://example.com/1"}' },
+    { index: 0, arguments: '{"url":"https://example.com/2"}' },
+    { index: 0, arguments: '{"query":"example search"}' },
+    { index: 0, arguments: '{"url":"https://example.com/3"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.argsText),
+    [
+      '{"url":"https://example.com/1"}',
+      '{"url":"https://example.com/2"}',
+      '{"query":"example search"}',
+      '{"url":"https://example.com/3"}',
+    ],
+  );
+  assert.equal(new Set(parts.map((part) => part.toolCallId)).size, 4);
+});
+
+test("an id-less chunked continuation still merges into its own call", () => {
+  const parts = accumulate([
+    { index: 0, arguments: '{"url":' },
+    { index: 0, arguments: '"https://example.com/1"}' },
+    { index: 0, arguments: '{"url":"https://example.com/2"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.argsText),
+    ['{"url":"https://example.com/1"}', '{"url":"https://example.com/2"}'],
+  );
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -526,6 +526,30 @@ test("a delayed id adopts a semantically equal JSON snapshot", () => {
   );
 });
 
+test("JSON snapshot matching does not round unsafe integers", () => {
+  assert.equal(
+    sameJsonDocument(
+      '{"id":9007199254740992}',
+      '{"id":9007199254740993}',
+    ),
+    false,
+  );
+  assert.equal(
+    sameJsonDocument(
+      ' {"id":9007199254740993} ',
+      '{"id":9007199254740993}',
+    ),
+    true,
+  );
+  assert.equal(
+    sameJsonDocument(
+      '{"id":"9007199254740993","ok":true}',
+      '{"ok":true,"id":"9007199254740993"}',
+    ),
+    true,
+  );
+});
+
 test("a stable id collision mints a distinct stream id", () => {
   const parts = accumulate([
     { index: 0, name: "alpha", arguments: '{"a":1}' },

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { toolCallReplayArguments } from "../src/features/chat/tool-call-arguments.ts";
 import {
   type StreamedToolCallPart,
+  findOldestUnownedStreamedToolCallPartIndex,
   findStreamedToolCallPartIndex,
   fragmentStartsNewToolCall,
   mintStreamedToolCallId,
@@ -28,25 +29,32 @@ function accumulate(
     argsText: string;
     toolName?: string;
   })[] = [];
+  const usedIds = new Set<string>();
   const append = (
     fragment: DeltaFragment,
     argsText: string,
     id = fragment.id,
   ) => {
     parts.push({
-      toolCallId: id ?? mintStreamedToolCallId(parts, fragment.index),
+      toolCallId:
+        id ?? mintStreamedToolCallId(parts, fragment.index, usedIds),
       toolName: fragment.name,
       argsText,
       ...(id ? { _has_stable_id: true } : {}),
       ...(fragment.index !== undefined ? { _delta_index: fragment.index } : {}),
     });
+    usedIds.add(parts[parts.length - 1].toolCallId);
   };
   for (const fragment of fragments) {
-    const matched = findStreamedToolCallPartIndex(
-      parts,
-      fragment.id,
-      fragment.index,
-    );
+    const exact = fragment.id
+      ? parts.findIndex((part) => part.toolCallId === fragment.id)
+      : -1;
+    const matched =
+      exact !== -1
+        ? exact
+        : fragment.id && !fragment.name && !fragment.arguments
+          ? findOldestUnownedStreamedToolCallPartIndex(parts, fragment.index)
+          : findStreamedToolCallPartIndex(parts, fragment.id, fragment.index);
     const matchedPart = matched === -1 ? undefined : parts[matched];
     const exactId = Boolean(
       fragment.id && matchedPart?.toolCallId === fragment.id,
@@ -94,6 +102,7 @@ function accumulate(
       ...(fragment.name ? { toolName: fragment.name } : {}),
       argsText: parts[target].argsText + fragment.arguments,
     };
+    if (fragment.id) usedIds.add(fragment.id);
   }
   return parts;
 }
@@ -353,4 +362,28 @@ test("one fresh fragment can contain several complete calls", () => {
     ['{"a":1}', '{"b":2}', "[]"],
   );
   assert.equal(new Set(parts.map((part) => part.toolCallId)).size, 3);
+});
+
+test("delayed ids claim same-index calls in announcement order", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: '{"a":1}' },
+    { index: 0, name: "beta", arguments: '{"b":2}' },
+    { id: "call-a", index: 0, arguments: "" },
+    { id: "call-b", index: 0, arguments: "" },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.toolName, part.argsText]),
+    [
+      ["call-a", "alpha", '{"a":1}'],
+      ["call-b", "beta", '{"b":2}'],
+    ],
+  );
+});
+
+test("minted ids never reuse an adopted or stable id", () => {
+  const reserved = new Set(["tool_call_0", "tool_call_2"]);
+  const parts = [{ toolCallId: "stable" }, { toolCallId: "tool_call_1" }];
+
+  assert.equal(mintStreamedToolCallId(parts, 0, reserved), "tool_call_3");
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -14,6 +14,7 @@ import {
   findOldestUnownedStreamedToolCallPartIndex,
   findStreamedToolCallPartIndex,
   fragmentStartsNewToolCall,
+  mergeStreamedToolCallName,
   mintStreamedToolCallId,
   sameJsonDocument,
   splitTopLevelJsonDocuments,
@@ -70,9 +71,16 @@ function accumulate(
       if (delayed !== -1) {
         const provisionalId = parts[delayed].toolCallId;
         partId = providerId;
+        const displaced = parts.findIndex(
+          (part, index) => index !== delayed && part.toolCallId === partId,
+        );
+        if (displaced !== -1 && provisionalId !== partId) {
+          parts[displaced].toolCallId = provisionalId;
+        } else {
+          usedIds.delete(provisionalId);
+        }
         parts[delayed].toolCallId = partId;
         parts[delayed]._has_stable_id = true;
-        usedIds.delete(provisionalId);
         if (sameJsonDocument(fragment.arguments, parts[delayed].argsText)) {
           fragment = { ...fragment, arguments: "" };
         }
@@ -105,6 +113,7 @@ function accumulate(
       !exactId &&
       settled?.complete.length === 1 &&
       !settled.tail &&
+      Boolean(matchedPart?.toolName) &&
       Boolean(fragment.name) &&
       !fragment.arguments.trim()
         ? -1
@@ -142,7 +151,10 @@ function accumulate(
     parts[target] = {
       ...parts[target],
       ...(partId ? { toolCallId: partId, _has_stable_id: true } : {}),
-      ...(fragment.name ? { toolName: fragment.name } : {}),
+      toolName: mergeStreamedToolCallName(
+        parts[target].toolName ?? "",
+        fragment.name ?? "",
+      ),
       argsText: mergedArgsText,
       splitTail:
         parts[target].splitTail &&
@@ -547,4 +559,75 @@ test("a delayed id does not make an incomplete split tail persist", () => {
   ]);
 
   assert.deepEqual(parts.map((part) => part.argsText), ['{"a":1}']);
+});
+
+test("fragmented names still match a delayed stable id", () => {
+  const parts = accumulate([
+    { index: 0, name: "web", arguments: '{"query":"' },
+    { index: 0, name: "_search", arguments: 'value"}' },
+    {
+      index: 0,
+      id: "call-search",
+      name: "web_search",
+      arguments: '{"query":"value"}',
+    },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.toolName, part.argsText]),
+    [["call-search", "web_search", '{"query":"value"}']],
+  );
+});
+
+test("delayed adoption retargets a displaced provisional id", () => {
+  const parts = accumulate([
+    { index: 0, name: "alpha", arguments: '{"query":"first"}' },
+    { index: 0, name: "beta", arguments: '{"query":"second"}' },
+    {
+      index: 0,
+      id: "tool_call_1",
+      name: "alpha",
+      arguments: '{"query":"first"}',
+    },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.argsText]),
+    [
+      ["tool_call_1", '{"query":"first"}'],
+      ["tool_call_0", '{"query":"second"}'],
+    ],
+  );
+});
+
+test("a late name attaches to its argument-only call", () => {
+  const parts = accumulate([
+    { index: 0, arguments: '{"query":"late-name"}' },
+    { index: 0, name: "web_search", arguments: "" },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [["web_search", '{"query":"late-name"}']],
+  );
+});
+
+test("delayed ids ignore completed calls from earlier rounds", () => {
+  const parts: StreamedToolCallPart[] = [
+    {
+      toolCallId: "tool_call_0",
+      toolName: "alpha",
+      argsText: '{"query":"old"}',
+      result: "done",
+      _delta_index: 0,
+    },
+    {
+      toolCallId: "tool_call_1",
+      toolName: "alpha",
+      argsText: '{"query":"new"}',
+      _delta_index: 0,
+    },
+  ];
+
+  assert.equal(findDelayedStableToolCallPartIndex(parts, 0, "", ""), 1);
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/features/chat/tool-call-arguments.ts";
 import {
   type StreamedToolCallPart,
+  bindStreamedToolCallBackendIds,
   findDelayedStableToolCallPartIndex,
   findOldestUnownedStreamedToolCallPartIndex,
   findStreamedToolCallPartIndex,
@@ -535,6 +536,17 @@ test("a stable id collision mints a distinct stream id", () => {
     parts.map((part) => part.toolCallId),
     ["tool_call_0", "tool_call_1"],
   );
+
+  const backendIds = new Map([["tool_call_0", "tool_call_0"]]);
+  bindStreamedToolCallBackendIds(
+    backendIds,
+    "tool_call_0",
+    "tool_call_1",
+  );
+  assert.deepEqual([...backendIds], [
+    ["tool_call_0", "tool_call_0"],
+    ["tool_call_1", "tool_call_1"],
+  ]);
 });
 
 test("decoded object arguments preserve their JSON payload", () => {


### PR DESCRIPTION
## What

Fixes #9807. A backend that streams tool-call deltas without ids and with every parallel call renumbered to index 0 (LiteLLM in front of vLLM does both) made each call's opening fragment "continue" the newest slot-0 part. The argument JSONs were glued into one malformed `argsText` (`{\"url\":...}{\"url\":...}{...}`), stashed under `args._raw`, persisted, and replayed verbatim — so the backend's `json.loads` on historical `function.arguments` threw `Extra data` and every later tool-calling turn in the thread 400'd. Thread permanently poisoned.

## How

The boundary the issue proposed, applied at the slot matcher: a complete JSON document never continues into another `{`/`[`, so an id-less fragment that opens a new document on a slot whose accumulated arguments already parse cleanly is the **next parallel call**, not a continuation. New `fragmentStartsNewToolCall()` in `tool-call-id.ts`, consulted by the adapter before merging; fragments carrying a stable id keep their exact current behavior (including the late-id adoption path).

The split-off call mints its id through a new collision-free `mintStreamedToolCallId()` — the plain `tool_call_<idx>` spelling is already taken by the part it split from.

## Reproduced → fixed

Two new tests in `tests/tool-call-delta-index.test.ts`, driven through the file's existing `accumulate()` mirror of the adapter:
- the reporter's exact four-call shape (id-less, all index 0) — **fails on main** with all four JSONs concatenated into one part, passes here with four parts, distinct ids, each a single valid document
- an id-less *chunked* continuation (`{\"url\":` + `\"...\"}`) still merges into its own call, then a following complete document starts a new one

All 8 pre-existing tests in the file still pass unchanged — chunked arguments, per-index parallel accumulation, multi-round index reuse, and late-id adoption are unaffected.

## Not in this PR

The replay side still forwards whatever `argsText` holds, so threads poisoned before this fix stay broken until a new chat; tolerating/splitting malformed historical arguments at `toolCallReplayArguments` (and the backend-strictness question the reporter split out) would be a follow-up with its own semantics discussion.

## Tests

Tool-call suite 10/10; frontend unit suite 5149 pass with only the 3 pre-existing failures also on main; `tsc` clean; biome format clean on the touched files; neighboring frontend-contract suites (86 tests) pass.