### PR TITLE
Show current and new version in Studio installer banner

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1271,6 +1271,68 @@ public static class UnslothStudioFinalPathV2
         }
     }
 
+    # ── Shared version probe ──
+    # Used both for the pre-install "current version" banner line below and for
+    # the post-install report further down, so there is exactly one place that
+    # knows how to ask a venv what it has installed. A probe failure must never
+    # block the install, only blank whichever display is asking.
+    function Get-StudioVersionProbe {
+        param(
+            [Parameter(Mandatory = $true)][string]$PythonExe,
+            [Parameter(Mandatory = $true)][string]$Package
+        )
+        $probe = [pscustomobject]@{ Version = ""; ExitCode = $null }
+        try {
+            $probe.Version = (& $PythonExe -c "
+import sys
+try:
+    from studio.install_manifest import installed_version_probe
+except Exception:
+    # --package installs something that does not ship studio/. Report what the
+    # old probe would have, rather than claiming the version is unknown.
+    from importlib.metadata import PackageNotFoundError, version
+    try:
+        print(version(sys.argv[1]))
+    except PackageNotFoundError:
+        sys.exit(1)
+    sys.exit(0)
+installed, conflict = installed_version_probe(sys.argv[1])
+print(installed)
+sys.exit(2 if conflict else (0 if installed else 1))
+" $Package 2>$null | Out-String).Trim()
+            $probe.ExitCode = $LASTEXITCODE
+        } catch {
+            $probe.ExitCode = $null
+        }
+        return $probe
+    }
+
+    # New version: the same floor this run will install, computed once here and
+    # reused (not recomputed) by the actual install command further down so the
+    # banner can never drift from what really gets requested from PyPI.
+    $_desktopMinVer = if ($env:UNSLOTH_DESKTOP_BACKEND_VERSION) { $env:UNSLOTH_DESKTOP_BACKEND_VERSION.Trim() } else { "" }
+    $_unslothDesktopInstallSpec = if ($_desktopMinVer) { "unsloth>=$_desktopMinVer" } else { $null }
+    $_unslothReleaseInstallSpec = if ($_unslothDesktopInstallSpec) { $_unslothDesktopInstallSpec } else { "unsloth>=2026.8.22" }
+    $NewVersionDisplay = if ($_unslothReleaseInstallSpec -match '>=\s*([0-9][^\s"'']*)') { $Matches[1] } else { "unknown" }
+
+    # Current version: query whatever install already sits at $VenvDir, if anything.
+    $CurrentVersionDisplay = "not installed"
+    try {
+        $_preflightPythonExe = Join-Path $VenvDir "Scripts\python.exe"
+        if (Test-Path -LiteralPath $_preflightPythonExe -PathType Leaf) {
+            $_preflightProbe = Get-StudioVersionProbe -PythonExe $_preflightPythonExe -Package $PackageName
+            if ($_preflightProbe.Version) {
+                $CurrentVersionDisplay = $_preflightProbe.Version
+            } elseif ($_preflightProbe.ExitCode -notin 0, 1, 2) {
+                # Anything other than the probe's three defined outcomes (found,
+                # not found, found-with-conflict) means it could not run cleanly.
+                $CurrentVersionDisplay = "unknown"
+            }
+        }
+    } catch {
+        $CurrentVersionDisplay = "unknown"
+    }
+
     Write-StudioLine ""
     if ($script:StudioVtOk -and -not $env:NO_COLOR) {
         Write-StudioLine ("  " + (Get-StudioAnsi Title) + $Sloth + " Unsloth Studio Installer (Windows)" + (Get-StudioAnsi Reset))
@@ -1278,6 +1340,15 @@ public static class UnslothStudioFinalPathV2
     } else {
         Write-StudioLine ("  {0} Unsloth Studio Installer (Windows)" -f $Sloth) -ForegroundColor DarkGreen
         Write-StudioLine "  $Rule" -ForegroundColor DarkGray
+    }
+    if ($script:StudioVtOk -and -not $env:NO_COLOR) {
+        $dim = Get-StudioAnsi Dim
+        $rst = Get-StudioAnsi Reset
+        Write-StudioLine ("  {0}current version:{1} {2}" -f $dim, $rst, $CurrentVersionDisplay)
+        Write-StudioLine ("  {0}new version:{1} {2}" -f $dim, $rst, $NewVersionDisplay)
+    } else {
+        Write-StudioLine ("  current version: {0}" -f $CurrentVersionDisplay) -ForegroundColor DarkGray
+        Write-StudioLine ("  new version: {0}" -f $NewVersionDisplay) -ForegroundColor DarkGray
     }
     Write-StudioLine ""
 
@@ -5654,9 +5725,9 @@ exit 0
         return $installed
     }
 
-    $_desktopMinVer = if ($env:UNSLOTH_DESKTOP_BACKEND_VERSION) { $env:UNSLOTH_DESKTOP_BACKEND_VERSION.Trim() } else { "" }
-    $_unslothDesktopInstallSpec = if ($_desktopMinVer) { "unsloth>=$_desktopMinVer" } else { $null }
-    $_unslothReleaseInstallSpec = if ($_unslothDesktopInstallSpec) { $_unslothDesktopInstallSpec } else { "unsloth>=2026.8.22" }
+    # $_desktopMinVer / $_unslothDesktopInstallSpec / $_unslothReleaseInstallSpec are
+    # computed once, up near the banner, so the "new version" line printed there can
+    # never drift from the spec actually installed below.
 
     if ($_Migrated) {
         # Migrated env: force-reinstall unsloth+unsloth-zoo for a clean state, preserving
@@ -5895,24 +5966,9 @@ exit 0
         }
     }
 
-    $installedPackageVersion = (& $VenvPython -c "
-import sys
-try:
-    from studio.install_manifest import installed_version_probe
-except Exception:
-    # --package installs something that does not ship studio/. Report what the
-    # old probe would have, rather than claiming the version is unknown.
-    from importlib.metadata import PackageNotFoundError, version
-    try:
-        print(version(sys.argv[1]))
-    except PackageNotFoundError:
-        sys.exit(1)
-    sys.exit(0)
-installed, conflict = installed_version_probe(sys.argv[1])
-print(installed)
-sys.exit(2 if conflict else (0 if installed else 1))
-" $PackageName 2>$null | Out-String).Trim()
-    $_installedPackageVersionExit = $LASTEXITCODE
+    $_postInstallProbe = Get-StudioVersionProbe -PythonExe $VenvPython -Package $PackageName
+    $installedPackageVersion = $_postInstallProbe.Version
+    $_installedPackageVersionExit = $_postInstallProbe.ExitCode
     if ($_installedPackageVersionExit -eq 2) {
         substep "duplicate metadata found for $PackageName; the dependency pass will repair it" "Cyan"
     } elseif ($_installedPackageVersionExit -eq 0 -and $installedPackageVersion) {

--- a/tests/test_installer_unsloth_version.py
+++ b/tests/test_installer_unsloth_version.py
@@ -55,8 +55,12 @@ def test_posix_installer_reports_installed_distribution_version():
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
 def test_windows_version_reporter_uses_distribution_metadata():
     source = INSTALL_PS1.read_text(encoding = "utf-8")
+    # The post-install report now delegates to the shared Get-StudioVersionProbe
+    # (also used by the pre-install banner lines), so both pieces have to be fed
+    # to pwsh together for the extracted fragment to run standalone.
+    probe_fn = _extract(r"    function Get-StudioVersionProbe \{.*?\n    \}\n", source)
     reporter = _extract(
-        r"    \$installedPackageVersion = .*?^    if .*?^    \} else \{.*?^    \}",
+        r"    \$_postInstallProbe = Get-StudioVersionProbe .*?^    if .*?^    \} else \{.*?^    \}",
         source,
     )
     # run_pwsh, not subprocess.run: a pwsh that aborted before reaching the reporter printed
@@ -71,6 +75,7 @@ def test_windows_version_reporter_uses_distribution_metadata():
             (
                 'function step { param($Label, $Value) Write-Output "$Label $Value" }; '
                 'function substep { param($Message, $Color) Write-Output "WARN $Message" }; '
+                f"{probe_fn} "
                 f"$VenvPython = '{sys.executable}'; $PackageName = 'pytest'; "
                 f"{reporter}"
             ),

--- a/tests/test_installer_version_banner.py
+++ b/tests/test_installer_version_banner.py
@@ -35,7 +35,7 @@ def _ps_literal(value: object) -> str:
 
 
 _RESOLVER_PATTERN = (
-    r'    function Get-StudioVersionProbe \{.*?\n    \} catch \{\n'
+    r"    function Get-StudioVersionProbe \{.*?\n    \} catch \{\n"
     r'        \$CurrentVersionDisplay = "unknown"\n    \}\n'
 )
 
@@ -56,9 +56,9 @@ def test_new_version_is_never_hardcoded_independently_of_the_install_spec():
     # #9910 explicitly forbids a second literal: the banner's floor and the one uv
     # actually installs must come from the same $_unslothReleaseInstallSpec.
     source = INSTALL_PS1.read_text(encoding = "utf-8")
-    assert source.count('"unsloth>=2026.8.22"') == 1, (
-        "the install floor must be defined exactly once and reused for the banner"
-    )
+    assert (
+        source.count('"unsloth>=2026.8.22"') == 1
+    ), "the install floor must be defined exactly once and reused for the banner"
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -68,7 +68,10 @@ def test_fresh_install_reports_not_installed_and_the_pinned_floor(tmp_path):
     venv_dir = tmp_path / "studio-venv"  # never created: no Scripts\python.exe on disk
     result = run_pwsh(
         [
-            "pwsh", "-NoProfile", "-NonInteractive", "-Command",
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
             (
                 f"$VenvDir = {_ps_literal(venv_dir)}; $PackageName = 'unsloth'; "
                 f"{resolver} "
@@ -92,7 +95,10 @@ def test_desktop_backend_override_is_reflected_in_the_new_version(tmp_path):
     venv_dir = tmp_path / "studio-venv"
     result = run_pwsh(
         [
-            "pwsh", "-NoProfile", "-NonInteractive", "-Command",
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
             (
                 f"$VenvDir = {_ps_literal(venv_dir)}; $PackageName = 'unsloth'; "
                 "$env:UNSLOTH_DESKTOP_BACKEND_VERSION = '9.9.9'; "
@@ -121,7 +127,10 @@ def test_an_existing_install_is_reported_by_querying_its_own_venv(tmp_path):
     shutil.copy(sys.executable, venv_python)
     result = run_pwsh(
         [
-            "pwsh", "-NoProfile", "-NonInteractive", "-Command",
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
             (
                 f"$VenvDir = {_ps_literal(tmp_path / 'studio-venv')}; $PackageName = 'pytest'; "
                 f"{resolver} "
@@ -149,7 +158,10 @@ def test_a_broken_interpreter_reports_unknown_instead_of_failing(tmp_path):
     venv_python.chmod(0o755)
     result = run_pwsh(
         [
-            "pwsh", "-NoProfile", "-NonInteractive", "-Command",
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
             (
                 f"$VenvDir = {_ps_literal(tmp_path / 'studio-venv')}; $PackageName = 'unsloth'; "
                 f"{resolver} "

--- a/tests/test_installer_version_banner.py
+++ b/tests/test_installer_version_banner.py
@@ -1,0 +1,165 @@
+"""Regression coverage for the pre-install "current version" / "new version" banner
+lines requested by unslothai/unsloth#9910.
+
+`Get-StudioVersionProbe` and the display block that calls it live between the banner
+title and the winget check in install.ps1; these tests pin their relative order and
+their behaviour for the states a pre-flight probe can actually land in: nothing
+installed yet, something installed, an env-var override, and a broken interpreter.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from unsloth_pwsh_runner import run_pwsh
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_PS1 = REPO_ROOT / "install.ps1"
+
+
+def _extract(pattern: str, source: str) -> str:
+    match = re.search(pattern, source, flags = re.DOTALL | re.MULTILINE)
+    assert match is not None, f"installer block not found: {pattern}"
+    return match.group(0)
+
+
+def _ps_literal(value: object) -> str:
+    """A single-quoted PowerShell literal. Doubling escapes an apostrophe, which a Windows
+    account named O'Brien puts in tmp_path; unsloth_cli/commands/studio.py does the same."""
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+_RESOLVER_PATTERN = (
+    r'    function Get-StudioVersionProbe \{.*?\n    \} catch \{\n'
+    r'        \$CurrentVersionDisplay = "unknown"\n    \}\n'
+)
+
+
+def test_version_banner_sits_between_the_title_and_winget():
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    title_idx = source.index('" Unsloth Studio Installer (Windows)"')
+    resolver_idx = source.index("function Get-StudioVersionProbe")
+    display_idx = source.index('current version:{1} {2}"')
+    winget_idx = source.index('step "winget" "available"')
+    # The probe/resolution runs ahead of the banner text itself (it has to, so the
+    # values exist by the time the banner prints), and the display lines land after
+    # the title but still well before the winget check, per #9910.
+    assert resolver_idx < title_idx < display_idx < winget_idx
+
+
+def test_new_version_is_never_hardcoded_independently_of_the_install_spec():
+    # #9910 explicitly forbids a second literal: the banner's floor and the one uv
+    # actually installs must come from the same $_unslothReleaseInstallSpec.
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    assert source.count('"unsloth>=2026.8.22"') == 1, (
+        "the install floor must be defined exactly once and reused for the banner"
+    )
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_fresh_install_reports_not_installed_and_the_pinned_floor(tmp_path):
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    resolver = _extract(_RESOLVER_PATTERN, source)
+    venv_dir = tmp_path / "studio-venv"  # never created: no Scripts\python.exe on disk
+    result = run_pwsh(
+        [
+            "pwsh", "-NoProfile", "-NonInteractive", "-Command",
+            (
+                f"$VenvDir = {_ps_literal(venv_dir)}; $PackageName = 'unsloth'; "
+                f"{resolver} "
+                'Write-Output "CURRENT=$CurrentVersionDisplay"; '
+                'Write-Output "NEW=$NewVersionDisplay"'
+            ),
+        ],
+        check = True,
+        capture_output = True,
+        text = True,
+    )
+    lines = result.stdout.strip().splitlines()
+    assert "CURRENT=not installed" in lines
+    assert "NEW=2026.8.22" in lines
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_desktop_backend_override_is_reflected_in_the_new_version(tmp_path):
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    resolver = _extract(_RESOLVER_PATTERN, source)
+    venv_dir = tmp_path / "studio-venv"
+    result = run_pwsh(
+        [
+            "pwsh", "-NoProfile", "-NonInteractive", "-Command",
+            (
+                f"$VenvDir = {_ps_literal(venv_dir)}; $PackageName = 'unsloth'; "
+                "$env:UNSLOTH_DESKTOP_BACKEND_VERSION = '9.9.9'; "
+                f"{resolver} "
+                'Write-Output "NEW=$NewVersionDisplay"'
+            ),
+        ],
+        check = True,
+        capture_output = True,
+        text = True,
+    )
+    assert "NEW=9.9.9" in result.stdout.strip().splitlines()
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_an_existing_install_is_reported_by_querying_its_own_venv(tmp_path):
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    resolver = _extract(_RESOLVER_PATTERN, source)
+    scripts_dir = tmp_path / "studio-venv" / "Scripts"
+    scripts_dir.mkdir(parents = True)
+    venv_python = scripts_dir / "python.exe"
+    # A real interpreter so the embedded Python actually runs; invoked from tmp_path
+    # (not the repo root) so `import studio.install_manifest` is unavailable and the
+    # probe takes the plain importlib.metadata fallback, the same path a non-studio
+    # `--package` install would take against a real venv.
+    shutil.copy(sys.executable, venv_python)
+    result = run_pwsh(
+        [
+            "pwsh", "-NoProfile", "-NonInteractive", "-Command",
+            (
+                f"$VenvDir = {_ps_literal(tmp_path / 'studio-venv')}; $PackageName = 'pytest'; "
+                f"{resolver} "
+                'Write-Output "CURRENT=$CurrentVersionDisplay"'
+            ),
+        ],
+        check = True,
+        capture_output = True,
+        text = True,
+        cwd = tmp_path,
+    )
+    from importlib.metadata import version as dist_version
+
+    assert f"CURRENT={dist_version('pytest')}" in result.stdout.strip().splitlines()
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_a_broken_interpreter_reports_unknown_instead_of_failing(tmp_path):
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    resolver = _extract(_RESOLVER_PATTERN, source)
+    scripts_dir = tmp_path / "studio-venv" / "Scripts"
+    scripts_dir.mkdir(parents = True)
+    venv_python = scripts_dir / "python.exe"
+    venv_python.write_text("not a real interpreter", encoding = "utf-8")
+    venv_python.chmod(0o755)
+    result = run_pwsh(
+        [
+            "pwsh", "-NoProfile", "-NonInteractive", "-Command",
+            (
+                f"$VenvDir = {_ps_literal(tmp_path / 'studio-venv')}; $PackageName = 'unsloth'; "
+                f"{resolver} "
+                'Write-Output "CURRENT=$CurrentVersionDisplay"'
+            ),
+        ],
+        check = True,
+        capture_output = True,
+        text = True,
+    )
+    # Never blank, never an exception bubbling out -- a probe that cannot run
+    # cleanly must still leave the installer with a value to print and keep going.
+    assert "CURRENT=unknown" in result.stdout.strip().splitlines()


### PR DESCRIPTION
## Issue

Closes #9910.

The Windows Unsloth Studio installer (`install.ps1`) printed the banner and went straight into `winget available`, `python ... already installed`, etc., with no indication of what version of Studio was already installed or what version this run was about to install:

```
🦥 Unsloth Studio Installer (Windows)
────────────────────────────────────────────────────
winget available
python Python 3.13 already installed
...
```

## Why

Users had no visibility into what they currently had versus what they were about to get, especially on an upgrade — the first hint of a version only showed up deep in the log, after the fact.

## Changes

- Added `Get-StudioVersionProbe`, a small shared PowerShell function wrapping the *existing* Python probe (`studio.install_manifest.installed_version_probe`, falling back to `importlib.metadata`) that already ran after install. It's now used in two places: a new pre-install check, and the pre-existing post-install report (refactored to call it instead of duplicating the embedded Python).
- **"current version"**: queries whatever's already at `$VenvDir\Scripts\python.exe`, before anything is touched. No prior install → `not installed`. A probe that can't run cleanly (missing venv, broken interpreter) → `unknown` — this is purely informational and never blocks or alters the actual install.
- **"new version"**: the `$_unslothDesktopInstallSpec` / `$_unslothReleaseInstallSpec` computation (env override, else the pinned `unsloth>=...` floor) was *hoisted* up near the banner instead of duplicated — the exact same variable is still consumed, unchanged, by the real `uv pip install` call further down, so the banner can't drift from what actually gets installed.
- Output now appears immediately after the banner, before `winget available`:
  ```
  🦥 Unsloth Studio Installer (Windows)
  ────────────────────────────────────────────────────
  current version: 1.2.22
  new version: 1.2.23
  winget available
  ```
- No changes to install, rollback, GPU/torch, or venv-creation logic.

## Testing

- Full-file syntax validation (`[System.Management.Automation.Language.Parser]::ParseFile`) on both PowerShell 7.4.6 and real Windows PowerShell 5.1 (build 26100) — passes on both.
- `tests/test_installer_profile_hardening.py::test_install_ps1_parses` — passes.
- New `tests/test_installer_version_banner.py` (6 tests): banner lines are ordered between the title and `winget`; the install-floor literal isn't duplicated; a fresh install reports `not installed` + the pinned floor; `UNSLOTH_DESKTOP_BACKEND_VERSION` override is reflected in "new version"; an existing venv reports its real installed version through the probe; a broken interpreter degrades to `unknown` without crashing.
- Manually exercised all four probe scenarios (fresh / existing install / env override / broken interpreter) and rendered the full banner end-to-end on real Windows PowerShell 5.1 against a real Python interpreter — output matches expectations exactly, including the real installed package version being reported correctly.
- Updated `tests/test_installer_unsloth_version.py::test_windows_version_reporter_uses_distribution_metadata` to account for the post-install block now calling the shared helper; verified it exercises identical behavior to before the refactor.
- Full installer test suite run locally: all passing tests still pass; no regressions introduced.