### PR TITLE
Fix sidebar footer width and context menu radius

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1905,19 +1905,20 @@ export function AppSidebar() {
   const chatDisabled = trainingInProgress;
   const usesDesktopTitlebar = usesCustomTitlebar || usesNativeMacTitlebar;
 
-  // One box for every row pill, so a hover pill has the same edges wherever it
-  // lands. Rows outside the list scroller add the rail width it does not lose,
-  // so both end on the same edge whether or not the scrollbar takes space.
-  // Logical sides, since the rail is on the inline end and moves under rtl.
+  // Navigation rows share one box, so a hover pill has the same edges wherever
+  // it lands. Rows outside the list scroller add the rail width it does not
+  // lose, so both end on the same edge whether or not the scrollbar takes
+  // space. Logical sides, since the rail moves under rtl.
   const rowPadding = usesDesktopTitlebar
     ? "ps-[5px] pe-[calc(var(--sidebar-rail,0px)+5px)]"
     : "ps-1.5 pe-[calc(var(--sidebar-rail,0px)+6px)]";
 
-  // Inside it the rail already sits in that space, so this is just the gap
-  // between a pill and the scrollbar, matched to the gap on the other side.
-  const scrollRowPadding = usesDesktopTitlebar ? "px-[5px]" : "px-1.5";
+  // Inside the scroller the rail already occupies that space. The profile
+  // footer also uses this padding deliberately: its width is independent of
+  // whether the unrelated recent-chat list currently has a scrollbar.
+  const unrailedRowPadding = usesDesktopTitlebar ? "px-[5px]" : "px-1.5";
 
-  // Header actions end where a hovered row's "…" does: scrollRowPadding + the
+  // Header actions end where a hovered row's "…" does: unrailedRowPadding + the
   // action's own pr-1.5. 12px normally (the pr-3 class default), 11px here.
   const headerRightPadding = usesDesktopTitlebar
     ? "sidebar-sticky-label-desktop"
@@ -3639,7 +3640,7 @@ export function AppSidebar() {
           data-tour="navbar"
           className={cn(
             "group-data-[collapsible=icon]:px-0 py-0 shrink-0",
-            scrollRowPadding,
+            unrailedRowPadding,
           )}
         >
 
@@ -3828,7 +3829,7 @@ export function AppSidebar() {
                 })}
               </SidebarGroupLabel>
               <CollapsibleContent>
-                <SidebarGroupContent className={scrollRowPadding}>
+                <SidebarGroupContent className={unrailedRowPadding}>
                   <SidebarMenu>
                     {sortedPinnedChatItems.map((item, index) =>
                       renderChatSidebarItem(
@@ -3888,7 +3889,7 @@ export function AppSidebar() {
                   </button>
                 </SidebarGroupLabel>
                 <CollapsibleContent>
-                  <SidebarGroupContent className={scrollRowPadding}>
+                  <SidebarGroupContent className={unrailedRowPadding}>
                     <SidebarMenu>
                       {visibleProjectRecords.map((project, projectIndex) => {
                         const projectChats =
@@ -4129,7 +4130,7 @@ export function AppSidebar() {
                 </button>
               </SidebarGroupLabel>
               <CollapsibleContent>
-                <SidebarGroupContent className={scrollRowPadding}>
+                <SidebarGroupContent className={unrailedRowPadding}>
                   <SidebarMenu>
                     {sortedRecentChatItems.map((item, index) =>
                       renderChatSidebarItem(
@@ -4172,7 +4173,7 @@ export function AppSidebar() {
               </CollapsibleTrigger>
             </SidebarGroupLabel>
             <CollapsibleContent>
-              <SidebarGroupContent className={scrollRowPadding}>
+              <SidebarGroupContent className={unrailedRowPadding}>
                 <SidebarMenu>
                   {runItems.map((run) => {
                     // Explicit selection wins. Otherwise highlight the active job only while the "Current Run"
@@ -4264,8 +4265,9 @@ export function AppSidebar() {
       <SidebarFooter
         className={cn(
           "relative pb-[11px] group-data-[collapsible=icon]:px-0",
-          // Same box as the rows above.
-          rowPadding,
+          // The profile is outside the recent-chat scroller and keeps its full
+          // width when that scroller gains or loses a scrollbar.
+          unrailedRowPadding,
           // pt-[3px] cancels the profile button's -3px margin, so the 8px
           // above it is whatever sits over the footer edge (the fade plateau,
           // or the list's pb-2 once the fade is hidden) and 8px sits below.

--- a/studio/frontend/src/components/ui/context-menu.tsx
+++ b/studio/frontend/src/components/ui/context-menu.tsx
@@ -98,7 +98,7 @@ function ContextMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive focus:*:[svg]:text-accent-foreground gap-2.5 rounded-xl px-3 py-2 text-sm [&_svg:not([class*='size-'])]:size-4 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive focus:*:[svg]:text-accent-foreground gap-2.5 rounded-[11px] px-3 py-2 text-sm [&_svg:not([class*='size-'])]:size-4 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}

--- a/studio/frontend/tests/context-menu-item-radius.test.ts
+++ b/studio/frontend/tests/context-menu-item-radius.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const RECTANGLE_RADIUS = /rounded-\[11px\]/;
+const PILL_RADIUS = /\brounded-(?:full|xl)\b/;
+
+function componentSource(path: string): Promise<string> {
+  return readFile(new URL(path, import.meta.url), "utf8");
+}
+
+function functionBody(source: string, name: string): string {
+  const start = source.indexOf(`function ${name}(`);
+  if (start === -1) throw new Error(`no ${name} component`);
+  const next = source.indexOf("\nfunction ", start + 1);
+  return source.slice(start, next === -1 ? undefined : next);
+}
+
+test("context-menu item hover matches the standard dropdown rectangle", async () => {
+  const contextItem = functionBody(
+    await componentSource("../src/components/ui/context-menu.tsx"),
+    "ContextMenuItem",
+  );
+  const dropdownItem = functionBody(
+    await componentSource("../src/components/ui/dropdown-menu.tsx"),
+    "DropdownMenuItem",
+  );
+
+  assert.match(dropdownItem, RECTANGLE_RADIUS);
+  assert.match(contextItem, RECTANGLE_RADIUS);
+  assert.doesNotMatch(contextItem, PILL_RADIUS);
+});

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -73,11 +73,11 @@ test("footer profile sits 11px above the sidebar edge", async () => {
   );
 });
 
-test("every sidebar row pill sits in one shared box", async () => {
+test("navigation rows align while the profile footer ignores the scroll rail", async () => {
   // A recent chat's pill has to match New Chat's. The rows inside the scroller
-  // lose the rail's width, so the rows outside add it back and both end on one
-  // edge; both pads match, so a pill sits the same distance from the scrollbar
-  // as from the near edge. Logical sides, since the rail moves under rtl.
+  // lose the rail's width, so New Chat adds it back and both end on one edge.
+  // The profile footer is unrelated to that list and must keep its full width
+  // when the scrollbar appears. Logical sides, since the rail moves under rtl.
   const source = await sidebarSource();
   assert.match(
     source,
@@ -85,12 +85,21 @@ test("every sidebar row pill sits in one shared box", async () => {
   );
   assert.match(
     source,
-    /const scrollRowPadding = usesDesktopTitlebar \? "px-\[5px\]" : "px-1\.5"/,
+    /const unrailedRowPadding = usesDesktopTitlebar \? "px-\[5px\]" : "px-1\.5"/,
   );
-  // New Chat and the footer sit outside the scroller.
-  assert.equal(source.match(/(?<!const )rowPadding[,}]/g)?.length, 2);
-  // Nav rows, pinned chats, Projects, Recents, training runs sit inside it.
-  assert.equal(source.match(/scrollRowPadding[,}]/g)?.length, 5);
+  // New Chat is the only outside row that aligns with the scroller's rail.
+  assert.equal(source.match(/(?<!const )rowPadding[,}]/g)?.length, 1);
+  // Nav rows, pinned chats, Projects, Recents, and training runs sit inside the
+  // scroller; the footer is the sixth unrailed use outside it.
+  assert.equal(source.match(/unrailedRowPadding[,}]/g)?.length, 6);
+
+  const footer = source
+    .split("<SidebarFooter")[1]
+    ?.split("</SidebarFooter>")[0];
+  assert.ok(footer, "no sidebar footer");
+  const footerProps = footer.split(">\n")[0];
+  assert.match(footerProps, /unrailedRowPadding/);
+  assert.doesNotMatch(footerProps, /var\(--sidebar-rail/);
   assert.equal(source.match(/"pl-2 pr-\[5px\]"/g), null);
 });
 


### PR DESCRIPTION
## Summary

- Keep the bottom profile row width independent of the recent-chat scrollbar.
- Match context-menu item corners to the standard dropdown menu radius.
- Add regression coverage for both UI contracts.

## Testing

- node --experimental-strip-types --test tests/sidebar-action-rows-inert.test.ts tests/context-menu-item-radius.test.ts
- npm run typecheck