### PR TITLE
tests: contain os.environ writes so they cannot outlive a test

### DIFF
--- a/tests/_shared/environ_isolation.py
+++ b/tests/_shared/environ_isolation.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Keep an in-process installer run from leaking ``os.environ`` into the session.
+
+``os.environ`` is process-global. A test that drives production code which writes it
+leaves that value set for the rest of the xdist worker's session, and every subprocess
+the worker spawns afterwards inherits it. Same class as the shared venv root closed in
+issue #9586's channel 1, different medium -- and no file sweep or ``git status`` check
+can see this one.
+
+The observed instance: ``_install_bnb_windows_rocm()`` in ``studio/install_python_stack.py``
+sets ``BNB_ROCM_VERSION`` and ``UNSLOTH_BNB_ROCM_VERSION_SOURCE`` so the worker subprocess
+inherits them, which is correct for a real install. A few lines above the write, the same
+function READS both to decide whether to re-detect and re-persist. So a later test in the
+same worker takes the other branch, ``_persist_detected_version`` stays false, and the
+``sitecustomize`` write never happens -- the test passes for the wrong reason, and which
+way it goes depends on worker ordering.
+
+``monkeypatch`` cannot close this. It restores only the keys it was itself asked to set;
+a direct ``os.environ[...] = ...`` inside production code is invisible to it.
+
+Restoration mutates ``os.environ`` in place rather than rebinding it. The mapping proxies
+``putenv``/``unsetenv`` to the real process environment, which is what subprocesses read,
+and other modules hold references to the same object.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator
+
+
+@contextlib.contextmanager
+def contained_environ() -> Iterator[None]:
+    """Restore ``os.environ`` to its entry state on exit.
+
+    Restores keys the body added, changed, or deleted. Teardown is sound for this
+    medium in a way it would not be for files: a hard-killed worker takes its own
+    environment with it, so there is no residue for a later run to inherit.
+    """
+    before = dict(os.environ)
+    try:
+        yield
+    finally:
+        # Delete first, then re-set: a key the body renamed shows up in both loops,
+        # and doing it in this order leaves the entry value rather than nothing.
+        for key in [key for key in os.environ if key not in before]:
+            del os.environ[key]
+        for key, value in before.items():
+            if os.environ.get(key) != value:
+                os.environ[key] = value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,3 +218,16 @@ def _apply_upstream_import_fixes_for_tests() -> None:
 
 
 _apply_upstream_import_fixes_for_tests()
+
+
+@pytest.fixture(autouse = True)
+def _contain_environ():
+    """Mechanism: tests/_shared/environ_isolation.py.
+
+    Autouse rather than opt-in because the writer is production code, not the test:
+    whoever adds the next in-process installer driver cannot be expected to know it
+    writes os.environ, and nothing in a file sweep or `git status` would tell them.
+    """
+    from environ_isolation import contained_environ
+    with contained_environ():
+        yield

--- a/tests/test_environ_isolation_9586.py
+++ b/tests/test_environ_isolation_9586.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Regression tests for issue #9586 channel 5: os.environ leaking out of a test.
+
+The medium is what makes this one distinct. Neither `git status` nor any stray-file
+sweep can see a process-global environment write, so the containment needs its own
+tests rather than riding on the file-residue ones.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_SHARED = Path(__file__).resolve().parent / "_shared"
+if str(_SHARED) not in sys.path:
+    sys.path.insert(0, str(_SHARED))
+
+from environ_isolation import contained_environ  # noqa: E402
+
+
+# The exact pair _install_bnb_windows_rocm() writes, kept as literals rather than
+# imported: the point is the observed leak, and importing studio.install_python_stack
+# to read the constant would drag the installer into this test for a string.
+_LEAKED_BY_THE_INSTALLER = {
+    "BNB_ROCM_VERSION": "72",
+    "UNSLOTH_BNB_ROCM_VERSION_SOURCE": "detected",
+}
+
+
+def test_the_installer_pair_does_not_outlive_the_block():
+    """The observed instance, by name.
+
+    `_install_bnb_windows_rocm()` sets both so the worker subprocess inherits them,
+    which is right for a real install. It then READS both a few lines above the write
+    to decide whether to re-detect, so a value surviving into a later test in the same
+    worker flips that branch and the test passes for the wrong reason.
+    """
+    before = dict(os.environ)
+    for key in _LEAKED_BY_THE_INSTALLER:
+        assert key not in before, f"{key} leaked into this test from somewhere earlier"
+
+    with contained_environ():
+        os.environ.update(_LEAKED_BY_THE_INSTALLER)
+        assert os.environ["BNB_ROCM_VERSION"] == "72"
+
+    assert dict(os.environ) == before
+
+
+def test_a_key_added_inside_is_removed():
+    before = dict(os.environ)
+    with contained_environ():
+        os.environ["UNSLOTH_TEST_9586_ADDED"] = "1"
+    assert "UNSLOTH_TEST_9586_ADDED" not in os.environ
+    assert dict(os.environ) == before
+
+
+def test_a_key_changed_inside_is_put_back(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_TEST_9586_CHANGED", "original")
+    with contained_environ():
+        os.environ["UNSLOTH_TEST_9586_CHANGED"] = "overwritten"
+    assert os.environ["UNSLOTH_TEST_9586_CHANGED"] == "original"
+
+
+def test_a_key_deleted_inside_is_put_back(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_TEST_9586_DELETED", "original")
+    with contained_environ():
+        del os.environ["UNSLOTH_TEST_9586_DELETED"]
+    assert os.environ["UNSLOTH_TEST_9586_DELETED"] == "original"
+
+
+def test_the_body_raising_still_restores():
+    """Containment cannot depend on the test passing."""
+    before = dict(os.environ)
+    with pytest.raises(RuntimeError):
+        with contained_environ():
+            os.environ["UNSLOTH_TEST_9586_RAISED"] = "1"
+            raise RuntimeError("boom")
+    assert "UNSLOTH_TEST_9586_RAISED" not in os.environ
+    assert dict(os.environ) == before
+
+
+def test_restoration_writes_through_to_the_real_environment():
+    """os.environ is mutated in place, not rebound.
+
+    Subprocesses read the process environment through putenv, not through whatever
+    object this module happens to hold, so a restore that rebound os.environ would
+    leave every child still seeing the leaked value.
+    """
+    environ_before = os.environ
+    with contained_environ():
+        os.environ["UNSLOTH_TEST_9586_INPLACE"] = "1"
+    assert os.environ is environ_before
+    assert os.getenv("UNSLOTH_TEST_9586_INPLACE") is None
+
+
+def test_the_containment_fixture_is_autouse(request):
+    """Pins the wiring, not the mechanism.
+
+    An ordering-based test ("a later test cannot see it") is not a pin: under xdist
+    the two halves can land on different workers, where it passes for free.
+    """
+    assert "_contain_environ" in request.fixturenames


### PR DESCRIPTION
Channel 5 of #9586.

## The leak

`os.environ` is process-global. A test that drives production code which writes it leaves
that value set for the rest of the xdist worker's session, and every subprocess the worker
spawns afterwards inherits it. Same class as the shared venv root closed by #9587, different
medium — and neither `git status` nor any stray-file sweep can see this one.

## Evidence

Reproduced at head with a session-finish plugin diffing `os.environ`, one file at a time, on
Windows / Python 3.13:

| file | environment after |
|---|---|
| `tests/studio/install/test_rocm_support.py` | `BNB_ROCM_VERSION: None → '72'`<br>`UNSLOTH_BNB_ROCM_VERSION_SOURCE: None → 'detected'` |
| `tests/studio/install/test_amd_fastpath_probe.py` | clean |
| `tests/studio/install/test_pr5940_followups.py` | clean |
| `tests/test_windows_rocm_bnb_version.py` | clean |

Same pair the issue records from a Linux sweep, so the leak is the code path, not the
platform.

## Why it is not inert

`_install_bnb_windows_rocm()` sets both so the worker subprocess inherits them, which is
correct for a real install. It then **reads** both a few lines above the write to decide
whether to re-detect. A later test in the same worker therefore takes the other branch,
`_persist_detected_version` stays false, the `sitecustomize` write never happens, and the
test passes for the wrong reason — decided by worker ordering.

`monkeypatch` cannot close this. It restores only the keys it was itself asked to set; a
direct `os.environ[...] = ...` inside production code is invisible to it.

## The change

`tests/_shared/environ_isolation.py` holds the mechanism, matching where #9587 put its own.
`tests/conftest.py` applies it autouse, because the writer is production code rather than
the test — whoever adds the next in-process installer driver has no way to know it writes
the environment.

Restoration mutates `os.environ` in place rather than rebinding it: the mapping proxies
`putenv`/`unsetenv` to the real process environment, which is what subprocesses read.

Teardown is sound for this medium in a way the issue notes it is not for files. A
hard-killed worker takes its own environment with it, so there is no residue for a later run
to inherit.

## Tests

`tests/test_environ_isolation_9586.py`, 7 tests:

| test | pins |
|---|---|
| `test_the_installer_pair_does_not_outlive_the_block` | the observed pair, by name |
| `test_a_key_added_inside_is_removed` | add |
| `test_a_key_changed_inside_is_put_back` | change |
| `test_a_key_deleted_inside_is_put_back` | delete |
| `test_the_body_raising_still_restores` | containment cannot depend on the test passing |
| `test_restoration_writes_through_to_the_real_environment` | in-place restore — a rebinding one would leave every child process still seeing the leaked value |
| `test_the_containment_fixture_is_autouse` | the wiring; **this is the one that fails without the change** |

An ordering-based test ("a later test cannot see it") is deliberately not used: under xdist
the two halves can land on different workers, where it passes for free.

## Collateral

Measured on the same tree, fixture in and out:

| selection | with | without |
|---|---|---|
| `tests/python` | 839 passed / 47 failed | 839 passed / 47 failed |
| `tests/studio/install` | 2402 passed / 98 failed | 2402 passed / 98 failed |

The pre-existing failures are a Windows box running Linux-shaped tests, not this change.

## One consequence worth naming

A test that deliberately set an environment variable for a **later** test in the same file
would stop working. Nothing in `tests/` does, and such a test is the defect this closes
rather than a use case, but the behaviour change is real.

## Not in scope

Channel 5 only, and only the `tests/` root.

Measuring `studio/backend/tests/test_torchao_select.py` the same way shows that root leaks
`CUDA_DEVICE_ORDER` and `TOKENIZERS_PARALLELISM`. Both are written at module scope by
production modules it imports **lazily, inside a test body**, so a `--collect-only` run
there is clean and only the first test to reach the import pays. Same class, different
writer, wider blast radius — left for its own change rather than folded in here.

Refs #9586.
