### PR TITLE
tests: keep the unsloth_cli suite out of the real studio home

### DIFF
--- a/unsloth_cli/tests/conftest.py
+++ b/unsloth_cli/tests/conftest.py
@@ -3,6 +3,36 @@
 
 """Shared fixtures for the unsloth_cli tests."""
 
+# --- studio home isolation (issue #9586, channel 3) -----------------------------------
+# Redirect the HOME the studio root is inferred FROM, at module scope, before any test
+# module imports the production code.
+#
+# Module scope, not a fixture: unsloth_cli/commands/studio.py binds
+# `STUDIO_HOME, _STUDIO_HOME_IS_CUSTOM = _resolve_studio_home()` at import, and
+# studio/backend/auth/storage.py binds `DB_PATH = auth_db_path()` the same way. Measured,
+# an autouse fixture and pytest_configure both run AFTER those bindings and left auth.db
+# in the real ~/.unsloth/studio/auth/. This is the placement tests/conftest.py already
+# uses for its compile-cache block, for the same reason.
+#
+# HOME rather than UNSLOTH_STUDIO_HOME, which is the obvious lever and the wrong one:
+# _resolve_studio_home() returns whether the home was explicitly set, and
+# _fail_if_install_damaged() puts `UNSLOTH_STUDIO_HOME=... ` into the repair command it
+# prints when it was. Setting that variable to isolate the tests therefore changes the
+# output other tests in this root assert on -- measured, it breaks
+# test_a_no_torch_install_keeps_that_mode_in_the_reinstall. The variable is an input to
+# the behaviour under test, so it cannot also be the isolation mechanism.
+#
+# No teardown, deliberately: the path is redirected rather than cleaned up, so a
+# hard-killed worker cannot leave residue in the real home.
+import os as _os  # noqa: E402
+import tempfile as _tempfile  # noqa: E402
+
+_ISOLATED_HOME = _tempfile.mkdtemp(prefix = "unsloth-cli-tests-home-")
+# Both names: POSIX resolves ~ through HOME, Windows through USERPROFILE.
+_os.environ["HOME"] = _ISOLATED_HOME
+_os.environ["USERPROFILE"] = _ISOLATED_HOME
+# --------------------------------------------------------------------------------------
+
 import sys
 import types
 

--- a/unsloth_cli/tests/test_studio_home_isolation_9586.py
+++ b/unsloth_cli/tests/test_studio_home_isolation_9586.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for issue #9586 channel 3: tests writing the user's real studio home.
+
+Two things make this channel distinct, and there is a test for each.
+
+The BINDING: ``STUDIO_HOME`` resolves at import, so the usual remedy -- an autouse fixture
+-- runs too late, and a test that only read the environment would pass while the constant
+every write goes through still pointed at the user's home.
+
+The LEVER: ``UNSLOTH_STUDIO_HOME`` is the obvious way to redirect it and the wrong one,
+because the production code reports whether it was set. Isolating with it changes output
+this root asserts on elsewhere.
+
+Nothing here imports ``conftest``. Importing it under its package path re-executes the
+module, which allocates a SECOND temporary home and repoints ``HOME`` mid-test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+_ISOLATION_PREFIX = "unsloth-cli-tests-home-"
+_CONFTEST = Path(__file__).resolve().parent / "conftest.py"
+
+
+def test_the_resolved_constant_points_off_the_users_home():
+    """The pin that matters: the constant, not the environment variable.
+
+    ``unsloth_cli.commands.studio.STUDIO_HOME`` is bound by ``_resolve_studio_home()`` at
+    import. Applied in a fixture or in ``pytest_configure`` the redirect would be too late
+    and this would still resolve under the real user's home.
+    """
+    from unsloth_cli.commands.studio import STUDIO_HOME
+
+    resolved = Path(STUDIO_HOME).resolve()
+    assert Path.home().resolve() in resolved.parents
+    assert any(part.startswith(_ISOLATION_PREFIX) for part in resolved.parts), resolved
+
+
+def test_the_isolation_does_not_present_as_a_custom_studio_home():
+    """Why HOME is redirected and ``UNSLOTH_STUDIO_HOME`` is not.
+
+    ``_resolve_studio_home()`` reports whether the home was explicitly set, and
+    ``_fail_if_install_damaged()`` puts ``UNSLOTH_STUDIO_HOME=...`` into the repair command
+    it prints when it was. Isolating through that variable changes output other tests in
+    this root assert on -- measured, it breaks
+    ``test_a_no_torch_install_keeps_that_mode_in_the_reinstall``. The variable is an input
+    to the behaviour under test, so it cannot also be the isolation mechanism.
+    """
+    from unsloth_cli.commands import studio as studio_mod
+
+    assert studio_mod._STUDIO_HOME_IS_CUSTOM is False
+    assert "UNSLOTH_STUDIO_HOME" not in os.environ
+
+
+def test_the_redirect_is_applied_at_module_scope():
+    """Pins the placement, which is the whole mechanism.
+
+    A fixture cannot be substituted: the constants above are already bound by the time one
+    runs. Read from disk rather than via ``inspect``, because importing the module to
+    inspect it would re-run the redirect.
+    """
+    source = _CONFTEST.read_text(encoding = "utf-8")
+
+    redirect = source.index('_os.environ["HOME"]')
+    assert redirect < source.index("\ndef "), "must precede every function in the module"
+    assert redirect < source.index("@pytest.fixture"), "must not be inside or after a fixture"


### PR DESCRIPTION
Channel 3 of #9586, for the `unsloth_cli/tests` root.

## The defect

`unsloth_cli/tests` has no studio-home isolation, so tests that reach the auth layer create
and write the running user's own `~/.unsloth/studio/auth/auth.db`.

Observed from a bare run on a clean checkout — no fixture, no flag:

```
pytest unsloth_cli/tests/test_studio_secure_flag.py
→ ~/.unsloth/studio/auth/auth.db   (36864 B, created)
```

## Why the obvious remedies do not work

The issue names the import-time trap and it holds. `unsloth_cli/commands/studio.py:120`
binds `STUDIO_HOME, _STUDIO_HOME_IS_CUSTOM = _resolve_studio_home()`, and
`studio/backend/auth/storage.py:21` binds `DB_PATH = auth_db_path()`, both at import.

Measured, one hook at a time:

| redirect applied in | real `~/.unsloth/studio/auth/auth.db` written? |
|---|---|
| autouse fixture | **yes** — too late |
| `pytest_configure` | **yes** — too late |
| conftest **module scope** | no |

`tests/conftest.py` already places its compile-cache block at module scope for exactly this
reason, and says so.

## The lever matters as much as the placement

`UNSLOTH_STUDIO_HOME` is the obvious way to redirect and the wrong one.
`_resolve_studio_home()` reports **whether the home was explicitly set**, and
`_fail_if_install_damaged()` puts `UNSLOTH_STUDIO_HOME=… ` into the repair command it prints
when it was:

```python
if _STUDIO_HOME_IS_CUSTOM:
    env = f"UNSLOTH_STUDIO_HOME={shlex.quote(str(STUDIO_HOME))} "
if no_torch:
    env += "UNSLOTH_NO_TORCH=1 "
```

So isolating through that variable changes output this root asserts on elsewhere. Measured,
it breaks `test_a_no_torch_install_keeps_that_mode_in_the_reinstall`, whose expected
`| UNSLOTH_NO_TORCH=1 sh` gains a home assignment in front of it — deterministic, 3 runs
each way, 5 failures with it against 4 without.

**A variable that is an input to the behaviour under test cannot also be the isolation
mechanism.**

## The change

Redirect `HOME` and `USERPROFILE` at conftest module scope. That moves the inferred studio
root while leaving `_STUDIO_HOME_IS_CUSTOM` false, so nothing else observes a difference:

```
Path.home()   F:\TEMP\unsloth-cli-tests-home-xxxxxxxx
STUDIO_HOME   F:\TEMP\unsloth-cli-tests-home-xxxxxxxx\.unsloth\studio
IS_CUSTOM     False
```

No teardown, deliberately — the path is redirected rather than cleaned up, so a hard-killed
worker cannot leave residue in the real home.

## Tests

`unsloth_cli/tests/test_studio_home_isolation_9586.py`:

| test | pins | fails without the change |
|---|---|---|
| `test_the_resolved_constant_points_off_the_users_home` | the bound constant, not the environment variable — which is what a too-late redirect would still get right | **yes** |
| `test_the_redirect_is_applied_at_module_scope` | the placement, which is the whole mechanism | **yes** |
| `test_the_isolation_does_not_present_as_a_custom_studio_home` | the lever — `_STUDIO_HOME_IS_CUSTOM` stays false | no — parity guard, by design |

None of them import `conftest`: importing it under its package path re-executes the module
and allocates a second temporary home, repointing `HOME` mid-test.

## Collateral

`unsloth_cli/tests`, same tree, redirect in and out:

| | failures |
|---|---|
| with the change | 68 |
| without | 68 |

Identical **sets**, not just counts (`comm` on the sorted `FAILED` lines, both directions
empty). Those 68 are a Windows box running Linux-shaped tests, not this change.

## One consequence worth naming

`HOME` and `USERPROFILE` are redirected for the whole root, so a test that deliberately read
the real user's home would now see the temporary one. None does today.

## Not in scope

The `unsloth_cli/tests` root only. Channel 3 also lists residue from
`studio/backend/tests`, which has its own `_isolate_studio_home` fixture and a different
resolution path; that is left for its own change rather than folded in here.

Refs #9586.
