### PR TITLE
Pin Claude Code to the loaded model's real context window

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -2551,6 +2551,9 @@ def _claude_local_env(base: str, key: str, entry: dict) -> dict:
     }
     window = entry.get("context_length") or entry.get("max_context_length")
     if window:
+        # claude assumes 200k for a model id it does not recognize, and clamps
+        # AUTO_COMPACT_WINDOW to [100k, that]. MAX_CONTEXT_TOKENS sets the window itself.
+        env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] = str(int(window))
         env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(int(window))
         env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] = "90"
     return env

--- a/unsloth_cli/tests/test_claude_subagent_mcp.py
+++ b/unsloth_cli/tests/test_claude_subagent_mcp.py
@@ -260,6 +260,7 @@ def test_local_child_uses_unsloth_without_overwriting_parent_auth(
     assert child_env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8888"
     assert child_env["ANTHROPIC_AUTH_TOKEN"] == "sk-unsloth-test"
     assert child_env["ANTHROPIC_MODEL"] == "unsloth/model-GGUF:Q4_K_M"
+    assert child_env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "32768"
     assert child_env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "32768"
     assert child_env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] == "90"
     assert "ANTHROPIC_API_KEY" not in child_env

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1463,9 +1463,11 @@ def test_connect_claude_no_launch(fake_studio):
     # Attribution header is suppressed for the session via env + --settings, never
     # by writing the user's ~/.claude/settings.json.
     _assert_env_set(result.output, "CLAUDE_CODE_ATTRIBUTION_HEADER", "0")
-    # Auto-compact window is sized to the loaded model's real context length so the
-    # session compacts before it overflows the local server's (much smaller) window,
-    # and compaction is forced at 90% of it for headroom.
+    # Claude assumes 200k for an unrecognized model id and clamps the auto-compact
+    # window into [100k, that], so the real window has to be pinned as well.
+    _assert_env_set(
+        result.output, "CLAUDE_CODE_MAX_CONTEXT_TOKENS", str(MODEL["context_length"])
+    )
     _assert_env_set(result.output, "CLAUDE_CODE_AUTO_COMPACT_WINDOW", str(MODEL["context_length"]))
     _assert_env_set(result.output, "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "90")
     assert f"claude --model {MODEL['id']} --exclude-dynamic-system-prompt-sections" in result.output
@@ -1641,6 +1643,7 @@ def test_connect_claude_compact_window_omitted_without_context(fake_studio, monk
     monkeypatch.setattr(start, "_resolve_model", lambda *a, **k: {"id": "local-model"})
     result = CliRunner().invoke(start.start_app, ["claude", "--no-launch"])
     assert result.exit_code == 0, result.output
+    assert "CLAUDE_CODE_MAX_CONTEXT_TOKENS" not in result.output
     assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in result.output
     assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in result.output
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1465,9 +1465,7 @@ def test_connect_claude_no_launch(fake_studio):
     _assert_env_set(result.output, "CLAUDE_CODE_ATTRIBUTION_HEADER", "0")
     # Claude assumes 200k for an unrecognized model id and clamps the auto-compact
     # window into [100k, that], so the real window has to be pinned as well.
-    _assert_env_set(
-        result.output, "CLAUDE_CODE_MAX_CONTEXT_TOKENS", str(MODEL["context_length"])
-    )
+    _assert_env_set(result.output, "CLAUDE_CODE_MAX_CONTEXT_TOKENS", str(MODEL["context_length"]))
     _assert_env_set(result.output, "CLAUDE_CODE_AUTO_COMPACT_WINDOW", str(MODEL["context_length"]))
     _assert_env_set(result.output, "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "90")
     assert f"claude --model {MODEL['id']} --exclude-dynamic-system-prompt-sections" in result.output


### PR DESCRIPTION
Claude Code does not recognise Unsloth model ids, so it assumes a 200k context. The setting exported for the real window is treated as a hint and clamped between 100k and that assumed 200k, so the loaded size never reaches it.

Twelve turns of the same conversation on a 64k model. Before, no compaction ran, the conversation grew past the server's window, and turn 11 failed. After, compaction ran five times and all twelve turns completed. The failing run reports "contextWindow": 200000 against a server serving 65536.

Below 100k the clamp raises the hint instead, so a small model overruns the server before anything reacts.

This exports the setting Claude Code reads as the real window. The existing one stays and has no effect once the window is correct.