### PR TITLE
studio: add ordered arguments to mcp server settings

### DIFF
--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -550,6 +550,18 @@ jobs:
           mkdir -p logs/playwright_extra
           python tests/studio/playwright_extra_ui.py
 
+      - name: MCP arguments end to end (Playwright)
+        if: matrix.shard == 'extra'
+        env:
+          BASE_URL: http://127.0.0.1:18894
+          STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
+          STUDIO_NEW_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
+          PW_ART_DIR: logs/playwright_mcp_arguments
+          STUDIO_UI_STRICT: '1'
+        run: |
+          mkdir -p logs/playwright_mcp_arguments
+          python tests/studio/playwright_mcp_arguments.py
+
       - name: Per-chat settings persistence (Playwright)
         if: matrix.shard == 'extra'
         env:
@@ -819,6 +831,7 @@ jobs:
             logs/playwright
             logs/playwright-permissions-*
             logs/playwright_extra
+            logs/playwright_mcp_arguments
             logs/playwright_thread_settings
             logs/playwright_fontscale
             logs/playwright_update_banner

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -560,6 +560,9 @@ jobs:
           STUDIO_UI_STRICT: '1'
         run: |
           mkdir -p logs/playwright_mcp_arguments
+          studio_home="${UNSLOTH_STUDIO_HOME:-$HOME/.unsloth/studio}"
+          export STUDIO_MCP_PYTHON="$studio_home/unsloth_studio/bin/python"
+          test -x "$STUDIO_MCP_PYTHON"
           python tests/studio/playwright_mcp_arguments.py
 
       - name: Per-chat settings persistence (Playwright)

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -352,7 +352,32 @@ def _stdio_argv(parts: list, env: Optional[dict]) -> list:
         resolved = shutil.which(parts[0], path = path)
     except OSError:
         resolved = None
-    return [resolved or parts[0], *parts[1:]]
+    executable = resolved or parts[0]
+    if _IS_WINDOWS and _launcher_name(executable) in {"npm", "npx"}:
+        suffix = os.path.splitext(executable)[1].lower()
+        if suffix in {".cmd", ".bat"}:
+            launcher_dir = os.path.dirname(executable)
+            cli = os.path.join(
+                launcher_dir,
+                "node_modules",
+                "npm",
+                "bin",
+                f"{_launcher_name(executable)}-cli.js",
+            )
+            sibling_node = os.path.join(launcher_dir, "node.exe")
+            try:
+                node = sibling_node if os.path.isfile(sibling_node) else shutil.which("node", path = path)
+                cli_exists = os.path.isfile(cli)
+            except OSError:
+                node = None
+                cli_exists = False
+            if node and cli_exists:
+                # bypass cmd.exe so shell metacharacters remain literal argv.
+                return [node, cli, *parts[1:]]
+            raise ValueError(
+                f"Cannot launch {executable!r} without its Node executable and npm CLI script"
+            )
+    return [executable, *parts[1:]]
 
 
 def _client(

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -27,6 +27,7 @@ from loggers import get_logger
 logger = get_logger(__name__)
 
 MCP_TOOL_PREFIX = "mcp__"
+_WINDOWS_BATCH_UNSAFE_ARGUMENT_CHARS = frozenset('&|<>^()%!"\r\n')
 
 # A failed probe isn't cached (a recovered server must come back), but it's
 # recorded so a down server isn't re-probed -- and the chat send re-hung for
@@ -385,9 +386,11 @@ def _stdio_argv(parts: list, env: Optional[dict]) -> list:
             raise ValueError(
                 f"Cannot launch {executable!r} without its Node executable and npm CLI script"
             )
-        if suffix in {".cmd", ".bat"} and len(parts) > 1:
+        if suffix in {".cmd", ".bat"} and any(
+            _WINDOWS_BATCH_UNSAFE_ARGUMENT_CHARS.intersection(argument) for argument in parts[1:]
+        ):
             raise ValueError(
-                "Windows batch launchers cannot preserve MCP command arguments; "
+                "Windows batch launchers cannot safely preserve these MCP command arguments; "
                 "invoke the executable directly, or use node.exe with the JavaScript entry point"
             )
     return [executable, *parts[1:]]

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -366,7 +366,11 @@ def _stdio_argv(parts: list, env: Optional[dict]) -> list:
             )
             sibling_node = os.path.join(launcher_dir, "node.exe")
             try:
-                node = sibling_node if os.path.isfile(sibling_node) else shutil.which("node", path = path)
+                node = (
+                    sibling_node
+                    if os.path.isfile(sibling_node)
+                    else shutil.which("node", path = path)
+                )
                 cli_exists = os.path.isfile(cli)
             except OSError:
                 node = None

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -72,7 +72,10 @@ def _split_windows_command_line(address: str) -> list[str]:
             backslashes = 0
             i += 1
             continue
-        if ch.isspace() and not in_quotes:
+        # subprocess.list2cmdline() implements the MS C runtime grammar: only
+        # space and tab delimit arguments. Other Unicode/control whitespace is
+        # ordinary argument data and must not be split here.
+        if ch in (" ", "\t") and not in_quotes:
             if backslashes:
                 current.extend("\\" * backslashes)
                 arg_started = True
@@ -82,7 +85,7 @@ def _split_windows_command_line(address: str) -> list[str]:
                 current = []
                 arg_started = False
             i += 1
-            while i < len(address) and address[i].isspace():
+            while i < len(address) and address[i] in (" ", "\t"):
                 i += 1
             continue
         if backslashes:

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -13,6 +13,7 @@ import os
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -27,7 +28,8 @@ from loggers import get_logger
 logger = get_logger(__name__)
 
 MCP_TOOL_PREFIX = "mcp__"
-_WINDOWS_BATCH_UNSAFE_ARGUMENT_CHARS = frozenset('&|<>^()%!"\r\n')
+_WINDOWS_BATCH_ALWAYS_UNSAFE_ARGUMENT_CHARS = frozenset('%!"\r\n')
+_WINDOWS_BATCH_UNQUOTED_UNSAFE_ARGUMENT_CHARS = frozenset("&|<>^()")
 
 # A failed probe isn't cached (a recovered server must come back), but it's
 # recorded so a down server isn't re-probed -- and the chat send re-hung for
@@ -125,9 +127,18 @@ def join_stdio_command(parts: list[str]) -> str:
     one string in the url field. Windows uses list2cmdline so spaced/backslash
     paths round-trip through the posix=False quote-strip; posix uses shlex."""
     if sys.platform == "win32":
-        import subprocess
         return subprocess.list2cmdline(parts)
     return shlex.join(parts)
+
+
+def _windows_batch_argument_is_unsafe(argument: str) -> bool:
+    if _WINDOWS_BATCH_ALWAYS_UNSAFE_ARGUMENT_CHARS.intersection(argument):
+        return True
+    serialized = subprocess.list2cmdline([argument])
+    is_quoted = serialized.startswith('"') and serialized.endswith('"')
+    return not is_quoted and bool(
+        _WINDOWS_BATCH_UNQUOTED_UNSAFE_ARGUMENT_CHARS.intersection(argument)
+    )
 
 
 def _stdio_log_id(url: str) -> str:
@@ -387,7 +398,7 @@ def _stdio_argv(parts: list, env: Optional[dict]) -> list:
                 f"Cannot launch {executable!r} without its Node executable and npm CLI script"
             )
         if suffix in {".cmd", ".bat"} and any(
-            _WINDOWS_BATCH_UNSAFE_ARGUMENT_CHARS.intersection(argument) for argument in parts[1:]
+            _windows_batch_argument_is_unsafe(argument) for argument in parts[1:]
         ):
             raise ValueError(
                 "Windows batch launchers cannot safely preserve these MCP command arguments; "

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -312,6 +312,13 @@ def _stdio_env(headers: Optional[dict], command: Optional[str] = None) -> Option
     """Process env for a stdio server: its own vars, plus the managed Node bin dir
     on PATH so ``npx ...`` servers spawn on hosts with no usable system Node."""
     env = dict(headers or {})
+    for key, value in env.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ValueError("stdio environment names and values must be strings")
+        if "\x00" in key or "\x00" in value:
+            raise ValueError("stdio environment must not contain NUL characters")
+        if "=" in key:
+            raise ValueError("stdio environment variable names must not contain '='")
     key = _path_key(env)
     base = env.get(key)
     if isinstance(base, str) and not base:

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -345,17 +345,21 @@ def _stdio_argv(parts: list, env: Optional[dict]) -> list:
     """argv with argv[0] resolved against the child's PATH. Windows resolves the
     command against the parent environment before ``env`` applies, so a managed-only
     ``npx`` has to be handed over as a full path."""
-    path = (env or {}).get(_path_key(env or {}))
+    path_key = _path_key(env or {})
+    explicit_path = env is not None and path_key in env
+    path = (env or {}).get(path_key)
     if not isinstance(path, str):
         path = os.environ.get("PATH", "")
     try:
         resolved = shutil.which(parts[0], path = path)
     except OSError:
         resolved = None
+    if _IS_WINDOWS and resolved is None and explicit_path and not os.path.dirname(parts[0]):
+        raise ValueError(f"Cannot find {parts[0]!r} on the MCP server's configured PATH")
     executable = resolved or parts[0]
-    if _IS_WINDOWS and _launcher_name(executable) in {"npm", "npx"}:
+    if _IS_WINDOWS:
         suffix = os.path.splitext(executable)[1].lower()
-        if suffix in {".cmd", ".bat"}:
+        if suffix in {".cmd", ".bat"} and _launcher_name(executable) in {"npm", "npx"}:
             launcher_dir = os.path.dirname(executable)
             cli = os.path.join(
                 launcher_dir,
@@ -380,6 +384,11 @@ def _stdio_argv(parts: list, env: Optional[dict]) -> list:
                 return [node, cli, *parts[1:]]
             raise ValueError(
                 f"Cannot launch {executable!r} without its Node executable and npm CLI script"
+            )
+        if suffix in {".cmd", ".bat"} and len(parts) > 1:
+            raise ValueError(
+                "Windows batch launchers cannot preserve MCP command arguments; "
+                "invoke the executable directly, or use node.exe with the JavaScript entry point"
             )
     return [executable, *parts[1:]]
 

--- a/studio/backend/core/inference/mcp_config_import.py
+++ b/studio/backend/core/inference/mcp_config_import.py
@@ -97,7 +97,7 @@ def _parse_entry(name: str, spec: object) -> tuple[Optional[ParsedMcpEntry], Opt
             return None, f"{label}: import cannot preserve {', '.join(unsupported)}."
         if spec.get("oauth") is not None:
             return None, f"{label}: 'oauth' is only supported for remote servers."
-        args = spec.get("args") or []
+        args = spec["args"] if "args" in spec else []
         if not isinstance(args, list) or not all(isinstance(a, _SCALAR) for a in args):
             return None, f"{label}: 'args' must be a list of strings."
         env = spec.get("env")

--- a/studio/backend/models/mcp_servers.py
+++ b/studio/backend/models/mcp_servers.py
@@ -3,7 +3,7 @@
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictStr
 
 
 class McpServerCreate(BaseModel):
@@ -38,6 +38,19 @@ class McpServerTestRequest(BaseModel):
     url: str
     headers: Optional[dict[str, str]] = None
     use_oauth: bool = False
+
+
+class McpStdioDecodeRequest(BaseModel):
+    url: StrictStr
+
+
+class McpStdioCommand(BaseModel):
+    command: StrictStr
+    arguments: list[StrictStr] = Field(default_factory = list)
+
+
+class McpStdioEncodeResponse(BaseModel):
+    url: str
 
 
 class McpServerProbeResult(BaseModel):

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -68,49 +68,49 @@ def _looks_like_command(value: str) -> bool:
     return any(ch.isspace() for ch in value)
 
 
+def _normalize_stdio_command(url: str) -> str:
+    raw = url or ""
+    trimmed = raw.strip()
+    if not trimmed:
+        raise HTTPException(status_code = 400, detail = "command must not be empty")
+    # Leading whitespace is executable-field padding. At the other end, only
+    # space/tab delimit arguments on Windows. POSIX quoting protects whitespace.
+    normalized = raw.lstrip().rstrip(" \t") if sys.platform == "win32" else trimmed
+    try:
+        parts = parse_stdio_command(normalized)
+    except ValueError as exc:
+        raise log_and_http_error(
+            exc,
+            400,
+            "Invalid command. Check quoting and try again.",
+            event = "mcp_servers.invalid_command",
+            log = logger,
+        )
+    if not parts or not parts[0].strip():
+        raise HTTPException(status_code = 400, detail = "command must not be empty")
+    if any("\x00" in part for part in parts):
+        raise HTTPException(
+            status_code = 400,
+            detail = "command and arguments must not contain NUL characters",
+        )
+    if "://" in parts[0]:
+        raise HTTPException(
+            status_code = 400,
+            detail = "Enter an http(s):// URL, or a local command whose "
+            "first token is an executable (not a URL).",
+        )
+    return normalized
+
+
 def _validate_url(url: str) -> str:
     raw = url or ""
     trimmed = raw.strip()
     if not trimmed:
         raise HTTPException(status_code = 400, detail = "url must not be empty")
-    # When stdio is enabled, a non-HTTP value is a local command (reuses this
-    # field so stdio servers ride existing CRUD/storage).
+    # Non-HTTP values reuse the URL field for local commands. Syntax validation
+    # is policy-free, but persistence and execution stay behind the stdio gate.
     if stdio_mcp_enabled() and is_stdio(trimmed):
-        # Leading whitespace is executable-field padding. At the other end,
-        # only space/tab are command-line delimiters on Windows; stripping all
-        # Unicode whitespace would corrupt a canonical final argument emitted
-        # by subprocess.list2cmdline(). POSIX shlex quoting protects those
-        # values, so retain the legacy full-strip behavior there.
-        normalized = raw.lstrip().rstrip(" \t") if sys.platform == "win32" else trimmed
-        try:
-            parts = parse_stdio_command(normalized)
-        except ValueError as exc:
-            raise log_and_http_error(
-                exc,
-                400,
-                "Invalid command. Check quoting and try again.",
-                event = "mcp_servers.invalid_command",
-                log = logger,
-            )
-        if not parts or not parts[0].strip():
-            raise HTTPException(status_code = 400, detail = "command must not be empty")
-        if any("\x00" in part for part in parts):
-            # Python and the OS process boundary reject embedded NUL in every
-            # argv element. Refuse it here so encode, decode, CRUD, import and
-            # test cannot persist or probe a command that can never launch.
-            raise HTTPException(
-                status_code = 400,
-                detail = "command and arguments must not contain NUL characters",
-            )
-        if "://" in parts[0]:
-            # A URL-scheme first token is a mistyped URL, not a command. Reject
-            # cleanly instead of exec-ing it (mirrors the frontend check).
-            raise HTTPException(
-                status_code = 400,
-                detail = "Enter an http(s):// URL, or a local command whose "
-                "first token is an executable (not a URL).",
-            )
-        return normalized
+        return _normalize_stdio_command(raw)
     parsed = urlparse(trimmed)
     if parsed.scheme not in ("http", "https"):
         if _looks_like_command(trimmed):
@@ -158,9 +158,9 @@ def decode_stdio_command(
     via_api_key: ViaApiKey = False,
 ):
     require_ui_session_for_local_commands(via_api_key)
-    url = _validate_url(payload.url)
-    if not is_stdio(url):
+    if not is_stdio(payload.url.strip()):
         raise HTTPException(status_code = 400, detail = "HTTP(S) MCP servers do not have arguments")
+    url = _normalize_stdio_command(payload.url)
     parts = parse_stdio_command(url)
     return McpStdioCommand(command = parts[0], arguments = parts[1:])
 
@@ -181,7 +181,7 @@ def encode_stdio_command(
             detail = "command must be a local executable, not a URL",
         )
     url = join_stdio_command([command, *payload.arguments])
-    _validate_url(url)
+    _normalize_stdio_command(url)
     return McpStdioEncodeResponse(url = url)
 
 

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -455,12 +455,13 @@ async def test_mcp_server(
     if is_stdio(url):
         require_ui_session_for_local_commands(via_api_key)
     headers = _normalize_headers(payload.headers)
+    use_oauth = payload.use_oauth and not is_stdio(url)
     try:
         tools = await list_tools_async(
             url = url,
             headers = headers,
-            timeout = probe_timeout(url, payload.use_oauth),
-            use_oauth = payload.use_oauth,
+            timeout = probe_timeout(url, use_oauth),
+            use_oauth = use_oauth,
         )
     except Exception as exc:  # noqa: BLE001
         logger.error(

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -134,7 +134,18 @@ def _normalize_headers(headers: dict[str, str] | None) -> dict[str, str] | None:
     for raw_key, value in headers.items():
         key = str(raw_key).strip()
         if key:
-            out[key] = str(value)
+            normalized_value = str(value)
+            if "\x00" in key or "\x00" in normalized_value:
+                raise HTTPException(
+                    status_code = 400,
+                    detail = "headers and environment variables must not contain NUL characters",
+                )
+            if "=" in key:
+                raise HTTPException(
+                    status_code = 400,
+                    detail = "header and environment variable names must not contain '='",
+                )
+            out[key] = normalized_value
     return out or None
 
 
@@ -407,13 +418,13 @@ async def import_mcp_servers(
             # http entries and reports the stdio ones.
             if is_stdio(url):
                 require_ui_session_for_local_commands(via_api_key)
+            headers = _normalize_headers(entry.headers)
         except HTTPException as exc:
             errors.append(f"{entry.display_name}: {exc.detail}")
             continue
         if url in seen_urls:
             skipped.append(entry.display_name)
             continue
-        headers = _normalize_headers(entry.headers)
         server_id = uuid.uuid4().hex[:16]
         mcp_servers_db.create_server(
             id = server_id,

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import json
+import sys
 import uuid
 from typing import Annotated
 from urllib.parse import urlparse
@@ -23,6 +24,7 @@ from core.inference.mcp_client import (
     close_stdio_sessions,
     invalidate_tool_cache,
     is_stdio,
+    join_stdio_command,
     list_tools_async,
     parse_server_headers,
     parse_stdio_command,
@@ -41,6 +43,9 @@ from models.mcp_servers import (
     McpServerResponse,
     McpServerTestRequest,
     McpServerUpdate,
+    McpStdioCommand,
+    McpStdioDecodeRequest,
+    McpStdioEncodeResponse,
 )
 from storage import mcp_servers_db
 from utils.utils import safe_curated_detail, log_and_http_error
@@ -64,14 +69,21 @@ def _looks_like_command(value: str) -> bool:
 
 
 def _validate_url(url: str) -> str:
-    trimmed = (url or "").strip()
+    raw = url or ""
+    trimmed = raw.strip()
     if not trimmed:
         raise HTTPException(status_code = 400, detail = "url must not be empty")
     # When stdio is enabled, a non-HTTP value is a local command (reuses this
     # field so stdio servers ride existing CRUD/storage).
     if stdio_mcp_enabled() and is_stdio(trimmed):
+        # Leading whitespace is executable-field padding. At the other end,
+        # only space/tab are command-line delimiters on Windows; stripping all
+        # Unicode whitespace would corrupt a canonical final argument emitted
+        # by subprocess.list2cmdline(). POSIX shlex quoting protects those
+        # values, so retain the legacy full-strip behavior there.
+        normalized = raw.lstrip().rstrip(" \t") if sys.platform == "win32" else trimmed
         try:
-            parts = parse_stdio_command(trimmed)
+            parts = parse_stdio_command(normalized)
         except ValueError as exc:
             raise log_and_http_error(
                 exc,
@@ -90,7 +102,7 @@ def _validate_url(url: str) -> str:
                 detail = "Enter an http(s):// URL, or a local command whose "
                 "first token is an executable (not a URL).",
             )
-        return trimmed
+        return normalized
     parsed = urlparse(trimmed)
     if parsed.scheme not in ("http", "https"):
         if _looks_like_command(trimmed):
@@ -129,6 +141,40 @@ def _row_to_response(row: dict, *, include_headers: bool = True) -> McpServerRes
         created_at = row["created_at"],
         updated_at = row["updated_at"],
     )
+
+
+@router.post("/stdio/decode", response_model = McpStdioCommand)
+def decode_stdio_command(
+    payload: McpStdioDecodeRequest,
+    current_subject: str = Depends(get_current_subject),
+    via_api_key: ViaApiKey = False,
+):
+    require_ui_session_for_local_commands(via_api_key)
+    url = _validate_url(payload.url)
+    if not is_stdio(url):
+        raise HTTPException(status_code = 400, detail = "HTTP(S) MCP servers do not have arguments")
+    parts = parse_stdio_command(url)
+    return McpStdioCommand(command = parts[0], arguments = parts[1:])
+
+
+@router.post("/stdio/encode", response_model = McpStdioEncodeResponse)
+def encode_stdio_command(
+    payload: McpStdioCommand,
+    current_subject: str = Depends(get_current_subject),
+    via_api_key: ViaApiKey = False,
+):
+    require_ui_session_for_local_commands(via_api_key)
+    command = payload.command.strip()
+    if not command:
+        raise HTTPException(status_code = 400, detail = "command must not be empty")
+    if "://" in command:
+        raise HTTPException(
+            status_code = 400,
+            detail = "command must be a local executable, not a URL",
+        )
+    url = join_stdio_command([command, *payload.arguments])
+    _validate_url(url)
+    return McpStdioEncodeResponse(url = url)
 
 
 # FastAPI offloads sync reads; mutations stay on-loop to preserve atomic sequences.

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -94,6 +94,14 @@ def _validate_url(url: str) -> str:
             )
         if not parts or not parts[0].strip():
             raise HTTPException(status_code = 400, detail = "command must not be empty")
+        if any("\x00" in part for part in parts):
+            # Python and the OS process boundary reject embedded NUL in every
+            # argv element. Refuse it here so encode, decode, CRUD, import and
+            # test cannot persist or probe a command that can never launch.
+            raise HTTPException(
+                status_code = 400,
+                detail = "command and arguments must not contain NUL characters",
+            )
         if "://" in parts[0]:
             # A URL-scheme first token is a mistyped URL, not a command. Reject
             # cleanly instead of exec-ing it (mirrors the frontend check).

--- a/studio/backend/tests/fixtures/mcp_argument_echo_server.py
+++ b/studio/backend/tests/fixtures/mcp_argument_echo_server.py
@@ -10,7 +10,7 @@ from fastmcp import FastMCP
 
 launch_log = os.environ.get("UNSLOTH_MCP_ARGUMENT_LOG")
 if launch_log:
-    with open(launch_log, "a", encoding="utf-8") as log:
+    with open(launch_log, "a", encoding = "utf-8") as log:
         log.write(
             json.dumps(
                 {
@@ -36,4 +36,4 @@ def launch_state() -> str:
 
 
 if __name__ == "__main__":
-    server.run(transport="stdio", show_banner=False)
+    server.run(transport = "stdio", show_banner = False)

--- a/studio/backend/tests/fixtures/mcp_argument_echo_server.py
+++ b/studio/backend/tests/fixtures/mcp_argument_echo_server.py
@@ -8,6 +8,20 @@ import sys
 from fastmcp import FastMCP
 
 
+launch_log = os.environ.get("UNSLOTH_MCP_ARGUMENT_LOG")
+if launch_log:
+    with open(launch_log, "a", encoding="utf-8") as log:
+        log.write(
+            json.dumps(
+                {
+                    "arguments": sys.argv[1:],
+                    "marker": os.environ.get("UNSLOTH_MCP_ARGUMENT_MARKER"),
+                }
+            )
+            + "\n"
+        )
+
+
 server = FastMCP("argument echo")
 
 
@@ -22,4 +36,4 @@ def launch_state() -> str:
 
 
 if __name__ == "__main__":
-    server.run(transport = "stdio", show_banner = False)
+    server.run(transport="stdio", show_banner=False)

--- a/studio/backend/tests/fixtures/mcp_argument_echo_server.py
+++ b/studio/backend/tests/fixtures/mcp_argument_echo_server.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import json
+import os
+import sys
+
+from fastmcp import FastMCP
+
+
+server = FastMCP("argument echo")
+
+
+@server.tool
+def launch_state() -> str:
+    return json.dumps(
+        {
+            "arguments": sys.argv[1:],
+            "marker": os.environ.get("UNSLOTH_MCP_ARGUMENT_MARKER"),
+        }
+    )
+
+
+if __name__ == "__main__":
+    server.run(transport = "stdio", show_banner = False)

--- a/studio/backend/tests/test_mcp_config_import.py
+++ b/studio/backend/tests/test_mcp_config_import.py
@@ -41,6 +41,16 @@ def _disable(monkeypatch):
         ["uvx", "some-server", "--flag"],
         ["/usr/local/bin/my-server"],
         ["mcp-server-sqlite"],
+        [
+            "python",
+            "--url",
+            "https://example.com/value",
+            "a b",
+            "O'Reilly",
+            'say "hello"',
+            "trailing\\",
+            "",
+        ],
     ],
 )
 def test_join_parse_roundtrip_posix(monkeypatch, parts):
@@ -79,10 +89,37 @@ def test_join_parse_roundtrip_posix(monkeypatch, parts):
         ["node", "'draft'"],
         ["node", "'open", "close'"],
         ["node", ""],
+        [
+            "python",
+            "--url",
+            "https://example.com/value",
+            "a b",
+            'say "hello"',
+            "C:\\path with spaces\\trailing\\",
+            "",
+        ],
     ],
 )
 def test_join_parse_roundtrip_win32(monkeypatch, parts):
     monkeypatch.setattr(sys, "platform", "win32")
+    joined = mcp_client.join_stdio_command(parts)
+    assert mcp_client.parse_stdio_command(joined) == parts
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("a\u00a0b", id = "nbsp"),
+        pytest.param("a\nb", id = "newline"),
+        pytest.param("a\rb", id = "carriage-return"),
+        pytest.param("a\vb", id = "vertical-tab"),
+        pytest.param("a\fb", id = "form-feed"),
+        pytest.param("a\u2003b", id = "em-space"),
+    ],
+)
+def test_join_parse_roundtrip_win32_preserves_non_delimiter_whitespace(monkeypatch, value):
+    monkeypatch.setattr(sys, "platform", "win32")
+    parts = ["python", "--value", value, 'say "hello"', "a b", ""]
     joined = mcp_client.join_stdio_command(parts)
     assert mcp_client.parse_stdio_command(joined) == parts
 

--- a/studio/backend/tests/test_mcp_config_import.py
+++ b/studio/backend/tests/test_mcp_config_import.py
@@ -173,9 +173,7 @@ def test_parse_stdio_entry():
 
 @pytest.mark.parametrize("args", [None, "", 0, False, {}])
 def test_parse_rejects_explicit_non_list_args(args):
-    entries, errors = parse_mcp_config(
-        {"mcpServers": {"bad": {"command": "python", "args": args}}}
-    )
+    entries, errors = parse_mcp_config({"mcpServers": {"bad": {"command": "python", "args": args}}})
 
     assert entries == []
     assert errors == ["bad: 'args' must be a list of strings."]

--- a/studio/backend/tests/test_mcp_config_import.py
+++ b/studio/backend/tests/test_mcp_config_import.py
@@ -171,6 +171,16 @@ def test_parse_stdio_entry():
     assert mcp_client.parse_stdio_command(entry.url) == ["npx", "-y", "server", "/tmp"]
 
 
+@pytest.mark.parametrize("args", [None, "", 0, False, {}])
+def test_parse_rejects_explicit_non_list_args(args):
+    entries, errors = parse_mcp_config(
+        {"mcpServers": {"bad": {"command": "python", "args": args}}}
+    )
+
+    assert entries == []
+    assert errors == ["bad: 'args' must be a list of strings."]
+
+
 def test_parse_remote_entry():
     cfg = {
         "mcpServers": {

--- a/studio/backend/tests/test_mcp_servers.py
+++ b/studio/backend/tests/test_mcp_servers.py
@@ -265,6 +265,22 @@ def test_stdio_command_codec_is_stateless_and_never_probes(monkeypatch):
     assert (decoded.command, decoded.arguments) == ("python", ["-m", "mod"])
 
 
+def test_stdio_command_codec_remains_available_when_execution_is_disabled(monkeypatch):
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import McpStdioCommand, McpStdioDecodeRequest
+
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: False)
+    encoded = routes_mcp.encode_stdio_command(
+        McpStdioCommand(command = "python", arguments = ["a b", ""]),
+        current_subject = "u",
+    )
+    decoded = routes_mcp.decode_stdio_command(
+        McpStdioDecodeRequest(url = encoded.url), current_subject = "u"
+    )
+
+    assert (decoded.command, decoded.arguments) == ("python", ["a b", ""])
+
+
 @pytest.mark.parametrize(
     ("operation", "detail"),
     [

--- a/studio/backend/tests/test_mcp_servers.py
+++ b/studio/backend/tests/test_mcp_servers.py
@@ -190,9 +190,7 @@ def test_stdio_command_codec_windows_preserves_final_whitespace_argument_end_to_
     assert decoded.arguments == [final_argument]
 
     probe = asyncio.run(
-        routes_mcp.test_mcp_server(
-            McpServerTestRequest(url = encoded.url), current_subject = "u"
-        )
+        routes_mcp.test_mcp_server(McpServerTestRequest(url = encoded.url), current_subject = "u")
     )
     assert probe.ok is True
     assert probed_urls == [encoded.url]
@@ -311,7 +309,6 @@ def test_stdio_command_codec_rejects_invalid_input_before_probe(monkeypatch, ope
 @pytest.mark.parametrize("bad", [1, True, None, {"value": "x"}])
 def test_stdio_command_codec_rejects_non_string_arguments(bad):
     from models.mcp_servers import McpStdioCommand
-
     with pytest.raises(ValidationError):
         McpStdioCommand.model_validate({"command": "python", "arguments": [bad]})
 
@@ -379,16 +376,12 @@ def test_stdio_raw_nul_is_rejected_before_route_side_effects(tmp_path, monkeypat
     mcp_servers_db.create_server(id = "seed", display_name = "seed", url = "python ok")
     with pytest.raises(HTTPException):
         asyncio.run(
-            routes_mcp.update_mcp_server(
-                "seed", McpServerUpdate(url = raw), current_subject = "u"
-            )
+            routes_mcp.update_mcp_server("seed", McpServerUpdate(url = raw), current_subject = "u")
         )
     assert mcp_servers_db.get_server("seed")["url"] == "python ok"
 
     with pytest.raises(HTTPException):
-        asyncio.run(
-            routes_mcp.test_mcp_server(McpServerTestRequest(url = raw), current_subject = "u")
-        )
+        asyncio.run(routes_mcp.test_mcp_server(McpServerTestRequest(url = raw), current_subject = "u"))
 
     imported = asyncio.run(
         routes_mcp.import_mcp_servers(
@@ -1305,15 +1298,11 @@ def test_stdio_arguments_update_preserves_untouched_bytes_then_invalidates_once(
     assert closed == []
 
     encoded = routes_mcp.encode_stdio_command(
-        McpStdioCommand(
-            command = "python", arguments = ["-m", "mod", "--name", "a b", ""]
-        ),
+        McpStdioCommand(command = "python", arguments = ["-m", "mod", "--name", "a b", ""]),
         current_subject = "u",
     )
     asyncio.run(
-        routes_mcp.update_mcp_server(
-            "s1", McpServerUpdate(url = encoded.url), current_subject = "u"
-        )
+        routes_mcp.update_mcp_server("s1", McpServerUpdate(url = encoded.url), current_subject = "u")
     )
     assert mcp_servers_db.get_server("s1")["url"] == encoded.url
     assert mcp_client.parse_stdio_command(encoded.url) == [

--- a/studio/backend/tests/test_mcp_servers.py
+++ b/studio/backend/tests/test_mcp_servers.py
@@ -3,6 +3,7 @@
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from storage import mcp_servers_db
 
@@ -74,6 +75,17 @@ def test_validate_url_accepts_http_and_https():
     assert _validate_url("http://example.com/mcp") == "http://example.com/mcp"
     assert _validate_url("https://example.com/mcp") == "https://example.com/mcp"
     assert _validate_url("  https://example.com/mcp  ") == "https://example.com/mcp"
+    assert _validate_url("\n  https://example.com/mcp  \u2003") == "https://example.com/mcp"
+
+
+def test_validate_url_stdio_keeps_posix_outer_normalization(monkeypatch):
+    import sys
+
+    import routes.mcp_servers as routes_mcp
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+    assert routes_mcp._validate_url("\n  python --flag  \u2003") == "python --flag"
 
 
 @pytest.mark.parametrize("bad", ["", "   ", "ftp://x", "http://", "noscheme.com"])
@@ -82,6 +94,224 @@ def test_validate_url_rejects_bad(bad):
     with pytest.raises(HTTPException) as exc:
         _validate_url(bad)
     assert exc.value.status_code == 400
+
+
+def test_stdio_command_codec_roundtrip_preserves_order_empty_and_url_argument(monkeypatch):
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import McpStdioCommand, McpStdioDecodeRequest
+
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+    payload = McpStdioCommand(
+        command = "python",
+        arguments = ["-m", "mod", "--name", "a b", "", "https://example.com/value"],
+    )
+    encoded = routes_mcp.encode_stdio_command(payload, current_subject = "u")
+    decoded = routes_mcp.decode_stdio_command(
+        McpStdioDecodeRequest(url = encoded.url), current_subject = "u"
+    )
+
+    assert decoded.command == payload.command
+    assert decoded.arguments == payload.arguments
+    assert McpStdioCommand(command = "python").arguments == []
+
+
+def test_stdio_command_codec_strips_only_executable_outer_padding(monkeypatch):
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import McpStdioCommand, McpStdioDecodeRequest
+
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+    arguments = ["  keep outer spaces  ", "\nkeep control whitespace\n", ""]
+    encoded = routes_mcp.encode_stdio_command(
+        McpStdioCommand(command = "  python  ", arguments = arguments), current_subject = "u"
+    )
+    decoded = routes_mcp.decode_stdio_command(
+        McpStdioDecodeRequest(url = encoded.url), current_subject = "u"
+    )
+
+    assert decoded.command == "python"
+    assert decoded.arguments == arguments
+
+
+@pytest.mark.parametrize(
+    "final_argument",
+    [
+        pytest.param("\n", id = "newline"),
+        pytest.param("\r", id = "carriage-return"),
+        pytest.param("\v", id = "vertical-tab"),
+        pytest.param("\f", id = "form-feed"),
+        pytest.param("\u00a0", id = "nbsp"),
+        pytest.param("\u2003", id = "em-space"),
+    ],
+)
+def test_stdio_command_codec_windows_preserves_final_whitespace_argument_end_to_end(
+    tmp_path, monkeypatch, final_argument
+):
+    import asyncio
+    import sys
+
+    import fastmcp
+    from fastmcp.client import transports
+
+    from core.inference import mcp_client
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import (
+        McpServerCreate,
+        McpServerTestRequest,
+        McpServerUpdate,
+        McpStdioCommand,
+        McpStdioDecodeRequest,
+    )
+
+    _reset_db(tmp_path, monkeypatch)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+    monkeypatch.setattr(mcp_client, "stdio_mcp_enabled", lambda: True)
+    monkeypatch.setattr(routes_mcp, "close_stdio_sessions", lambda *args: None)
+
+    probed_urls: list[str] = []
+
+    async def capture_probe(**kwargs):
+        probed_urls.append(kwargs["url"])
+        return []
+
+    monkeypatch.setattr(routes_mcp, "list_tools_async", capture_probe)
+
+    encoded = routes_mcp.encode_stdio_command(
+        McpStdioCommand(command = "python", arguments = [final_argument]),
+        current_subject = "u",
+    )
+    decoded = routes_mcp.decode_stdio_command(
+        McpStdioDecodeRequest(url = encoded.url), current_subject = "u"
+    )
+
+    assert encoded.url.endswith(final_argument)
+    assert decoded.arguments == [final_argument]
+
+    probe = asyncio.run(
+        routes_mcp.test_mcp_server(
+            McpServerTestRequest(url = encoded.url), current_subject = "u"
+        )
+    )
+    assert probe.ok is True
+    assert probed_urls == [encoded.url]
+
+    created = asyncio.run(
+        routes_mcp.create_mcp_server(
+            McpServerCreate(display_name = "created", url = encoded.url),
+            current_subject = "u",
+        )
+    )
+    assert created.url == encoded.url
+    assert mcp_servers_db.get_server(created.id)["url"] == encoded.url
+    created_decoded = routes_mcp.decode_stdio_command(
+        McpStdioDecodeRequest(url = created.url), current_subject = "u"
+    )
+    assert created_decoded.arguments == [final_argument]
+
+    seed = asyncio.run(
+        routes_mcp.create_mcp_server(
+            McpServerCreate(display_name = "updated", url = "python seed"),
+            current_subject = "u",
+        )
+    )
+    updated = asyncio.run(
+        routes_mcp.update_mcp_server(
+            seed.id,
+            McpServerUpdate(url = encoded.url),
+            current_subject = "u",
+        )
+    )
+    assert updated.url == encoded.url
+    assert mcp_servers_db.get_server(seed.id)["url"] == encoded.url
+    updated_decoded = routes_mcp.decode_stdio_command(
+        McpStdioDecodeRequest(url = updated.url), current_subject = "u"
+    )
+    assert updated_decoded.arguments == [final_argument]
+
+    captured_transport = {}
+
+    class CapturingStdioTransport:
+        def __init__(self, **kwargs):
+            captured_transport.update(kwargs)
+
+    monkeypatch.setattr(fastmcp, "Client", lambda transport: transport)
+    monkeypatch.setattr(transports, "StdioTransport", CapturingStdioTransport)
+    monkeypatch.setattr(mcp_client, "_stdio_argv", lambda parts, env: parts)
+    mcp_client._client(updated.url, None)
+    assert captured_transport["command"] == "python"
+    assert captured_transport["args"] == [final_argument]
+    assert captured_transport["keep_alive"] is False
+
+
+def test_stdio_command_codec_is_stateless_and_never_probes(monkeypatch):
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import McpStdioCommand, McpStdioDecodeRequest
+
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+
+    def _never(*args, **kwargs):
+        raise AssertionError("codec must not access storage or transport")
+
+    monkeypatch.setattr(routes_mcp, "list_tools_async", _never)
+    monkeypatch.setattr(mcp_servers_db, "list_servers", _never)
+    monkeypatch.setattr(mcp_servers_db, "create_server", _never)
+    encoded = routes_mcp.encode_stdio_command(
+        McpStdioCommand(command = "python", arguments = ["-m", "mod"]),
+        current_subject = "u",
+    )
+    decoded = routes_mcp.decode_stdio_command(
+        McpStdioDecodeRequest(url = encoded.url), current_subject = "u"
+    )
+    assert (decoded.command, decoded.arguments) == ("python", ["-m", "mod"])
+
+
+@pytest.mark.parametrize(
+    ("operation", "detail"),
+    [
+        ("blank", "command must not be empty"),
+        ("url", "local executable"),
+        ("http_arguments", "local executable"),
+        ("remote_decode", "do not have arguments"),
+        ("malformed_decode", "Invalid command"),
+    ],
+)
+def test_stdio_command_codec_rejects_invalid_input_before_probe(monkeypatch, operation, detail):
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import McpStdioCommand, McpStdioDecodeRequest
+
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+
+    async def _never(**kwargs):
+        raise AssertionError("invalid codec input must not be probed")
+
+    monkeypatch.setattr(routes_mcp, "list_tools_async", _never)
+    with pytest.raises(HTTPException) as exc:
+        if operation == "blank":
+            routes_mcp.encode_stdio_command(McpStdioCommand(command = "   "), current_subject = "u")
+        elif operation in {"url", "http_arguments"}:
+            arguments = ["--flag"] if operation == "http_arguments" else []
+            routes_mcp.encode_stdio_command(
+                McpStdioCommand(command = "  https://example.com/mcp  ", arguments = arguments),
+                current_subject = "u",
+            )
+        elif operation == "remote_decode":
+            routes_mcp.decode_stdio_command(
+                McpStdioDecodeRequest(url = "https://example.com/mcp"), current_subject = "u"
+            )
+        else:
+            routes_mcp.decode_stdio_command(
+                McpStdioDecodeRequest(url = 'python "unterminated'), current_subject = "u"
+            )
+    assert exc.value.status_code == 400
+    assert detail in str(exc.value.detail)
+
+
+@pytest.mark.parametrize("bad", [1, True, None, {"value": "x"}])
+def test_stdio_command_codec_rejects_non_string_arguments(bad):
+    from models.mcp_servers import McpStdioCommand
+
+    with pytest.raises(ValidationError):
+        McpStdioCommand.model_validate({"command": "python", "arguments": [bad]})
 
 
 def test_normalize_headers():
@@ -941,6 +1171,70 @@ def test_update_stdio_command_change_closes_session(tmp_path, monkeypatch):
         )
     )
     assert len(closed) == 1
+
+
+def test_stdio_arguments_update_preserves_untouched_bytes_then_invalidates_once(
+    tmp_path, monkeypatch
+):
+    import asyncio
+    import json
+
+    from core.inference import mcp_client
+    from models.mcp_servers import McpServerUpdate, McpStdioCommand
+    import routes.mcp_servers as routes_mcp
+
+    _reset_db(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+    invalidated: list[str] = []
+    closed: list[tuple] = []
+    monkeypatch.setattr(routes_mcp, "invalidate_tool_cache", invalidated.append)
+    monkeypatch.setattr(routes_mcp, "close_stdio_sessions", lambda *args: closed.append(args))
+    cached = _one_tool()
+    monkeypatch.setattr(mcp_client, "_tool_cache", {"s1": cached})
+
+    original_url = "python  -m mod"
+    env = {"API_KEY": "secret"}
+    mcp_servers_db.create_server(
+        id = "s1",
+        display_name = "A",
+        url = original_url,
+        headers_json = json.dumps(env),
+        is_enabled = True,
+    )
+    asyncio.run(
+        routes_mcp.update_mcp_server(
+            "s1",
+            McpServerUpdate(display_name = "B", url = original_url, headers = env),
+            current_subject = "u",
+        )
+    )
+    assert mcp_servers_db.get_server("s1")["url"] == original_url
+    assert mcp_client.get_cached_tools("s1") == cached
+    assert invalidated == []
+    assert closed == []
+
+    encoded = routes_mcp.encode_stdio_command(
+        McpStdioCommand(
+            command = "python", arguments = ["-m", "mod", "--name", "a b", ""]
+        ),
+        current_subject = "u",
+    )
+    asyncio.run(
+        routes_mcp.update_mcp_server(
+            "s1", McpServerUpdate(url = encoded.url), current_subject = "u"
+        )
+    )
+    assert mcp_servers_db.get_server("s1")["url"] == encoded.url
+    assert mcp_client.parse_stdio_command(encoded.url) == [
+        "python",
+        "-m",
+        "mod",
+        "--name",
+        "a b",
+        "",
+    ]
+    assert invalidated == ["s1"]
+    assert closed == [(original_url, env)]
 
 
 def test_update_disable_evicts_tool_cache(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_mcp_servers.py
+++ b/studio/backend/tests/test_mcp_servers.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import json
+
 import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
@@ -312,6 +314,95 @@ def test_stdio_command_codec_rejects_non_string_arguments(bad):
 
     with pytest.raises(ValidationError):
         McpStdioCommand.model_validate({"command": "python", "arguments": [bad]})
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"command": "py\u0000thon", "arguments": []}, id = "command"),
+        pytest.param({"command": "python", "arguments": ["a\u0000b"]}, id = "argument"),
+    ],
+)
+def test_stdio_command_codec_rejects_json_nul(payload, monkeypatch):
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import McpStdioCommand
+
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+    command = McpStdioCommand.model_validate_json(json.dumps(payload))
+
+    with pytest.raises(HTTPException) as exc:
+        routes_mcp.encode_stdio_command(command, current_subject = "u")
+
+    assert exc.value.status_code == 400
+    assert "NUL" in str(exc.value.detail)
+
+
+def test_stdio_raw_nul_is_rejected_before_route_side_effects(tmp_path, monkeypatch):
+    import asyncio
+
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import (
+        McpServerCreate,
+        McpServerImportRequest,
+        McpServerTestRequest,
+        McpServerUpdate,
+        McpStdioDecodeRequest,
+    )
+
+    _reset_db(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+    raw = "python a\x00b"
+    side_effects: list[str] = []
+
+    async def unexpected_probe(**kwargs):
+        side_effects.append("probe")
+        return []
+
+    monkeypatch.setattr(routes_mcp, "list_tools_async", unexpected_probe)
+    monkeypatch.setattr(
+        routes_mcp, "invalidate_tool_cache", lambda *args: side_effects.append("invalidate")
+    )
+    monkeypatch.setattr(
+        routes_mcp, "close_stdio_sessions", lambda *args: side_effects.append("close")
+    )
+
+    with pytest.raises(HTTPException):
+        routes_mcp.decode_stdio_command(McpStdioDecodeRequest(url = raw), current_subject = "u")
+    with pytest.raises(HTTPException):
+        asyncio.run(
+            routes_mcp.create_mcp_server(
+                McpServerCreate(display_name = "bad", url = raw), current_subject = "u"
+            )
+        )
+    assert mcp_servers_db.list_servers() == []
+
+    mcp_servers_db.create_server(id = "seed", display_name = "seed", url = "python ok")
+    with pytest.raises(HTTPException):
+        asyncio.run(
+            routes_mcp.update_mcp_server(
+                "seed", McpServerUpdate(url = raw), current_subject = "u"
+            )
+        )
+    assert mcp_servers_db.get_server("seed")["url"] == "python ok"
+
+    with pytest.raises(HTTPException):
+        asyncio.run(
+            routes_mcp.test_mcp_server(McpServerTestRequest(url = raw), current_subject = "u")
+        )
+
+    imported = asyncio.run(
+        routes_mcp.import_mcp_servers(
+            McpServerImportRequest(
+                config = {"mcpServers": {"bad": {"command": "python", "args": ["a\x00b"]}}}
+            ),
+            current_subject = "u",
+        )
+    )
+    assert imported.created == []
+    assert len(imported.errors) == 1
+    assert "NUL" in imported.errors[0]
+    assert [row["id"] for row in mcp_servers_db.list_servers()] == ["seed"]
+    assert side_effects == []
 
 
 def test_normalize_headers():

--- a/studio/backend/tests/test_mcp_servers.py
+++ b/studio/backend/tests/test_mcp_servers.py
@@ -424,6 +424,80 @@ def test_normalize_headers():
     assert _normalize_headers({"   ": "x"}) is None
 
 
+@pytest.mark.parametrize(
+    "headers",
+    [
+        pytest.param({"BAD\x00NAME": "value"}, id = "nul-name"),
+        pytest.param({"NAME": "bad\x00value"}, id = "nul-value"),
+        pytest.param({"BAD=NAME": "value"}, id = "equals-name"),
+    ],
+)
+def test_invalid_headers_and_environment_are_rejected_before_side_effects(
+    headers, tmp_path, monkeypatch
+):
+    import asyncio
+
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import (
+        McpServerCreate,
+        McpServerImportRequest,
+        McpServerTestRequest,
+        McpServerUpdate,
+    )
+
+    _reset_db(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes_mcp, "stdio_mcp_enabled", lambda: True)
+    probes: list[str] = []
+
+    async def unexpected_probe(**kwargs):
+        probes.append("probe")
+        return []
+
+    monkeypatch.setattr(routes_mcp, "list_tools_async", unexpected_probe)
+    with pytest.raises(HTTPException):
+        asyncio.run(
+            routes_mcp.create_mcp_server(
+                McpServerCreate(display_name = "bad", url = "python server.py", headers = headers),
+                current_subject = "u",
+            )
+        )
+    assert mcp_servers_db.list_servers() == []
+
+    mcp_servers_db.create_server(id = "seed", display_name = "seed", url = "python server.py")
+    with pytest.raises(HTTPException):
+        asyncio.run(
+            routes_mcp.update_mcp_server(
+                "seed", McpServerUpdate(headers = headers), current_subject = "u"
+            )
+        )
+    assert mcp_servers_db.get_server("seed")["headers_json"] is None
+
+    with pytest.raises(HTTPException):
+        asyncio.run(
+            routes_mcp.test_mcp_server(
+                McpServerTestRequest(url = "python server.py", headers = headers),
+                current_subject = "u",
+            )
+        )
+
+    imported = asyncio.run(
+        routes_mcp.import_mcp_servers(
+            McpServerImportRequest(
+                config = {
+                    "mcpServers": {
+                        "bad": {"command": "python", "args": ["server.py"], "env": headers}
+                    }
+                }
+            ),
+            current_subject = "u",
+        )
+    )
+    assert imported.created == []
+    assert len(imported.errors) == 1
+    assert [row["id"] for row in mcp_servers_db.list_servers()] == ["seed"]
+    assert probes == []
+
+
 def test_changes_from_payload_tristate_headers():
     from routes.mcp_servers import _changes_from_payload
     from models.mcp_servers import McpServerUpdate

--- a/studio/backend/tests/test_mcp_stdio_api_key_gate.py
+++ b/studio/backend/tests/test_mcp_stdio_api_key_gate.py
@@ -63,7 +63,9 @@ STDIO_CMD = "/bin/sh -c id"
 
 
 @pytest.mark.parametrize("operation", ["encode", "decode"])
-def test_stdio_command_codec_refuses_api_key_before_work(monkeypatch, stdio_on, no_probe, operation):
+def test_stdio_command_codec_refuses_api_key_before_work(
+    monkeypatch, stdio_on, no_probe, operation
+):
     import routes.mcp_servers as routes_mcp
     from models.mcp_servers import McpStdioCommand, McpStdioDecodeRequest
 

--- a/studio/backend/tests/test_mcp_stdio_api_key_gate.py
+++ b/studio/backend/tests/test_mcp_stdio_api_key_gate.py
@@ -59,6 +59,34 @@ def no_probe(monkeypatch):
 STDIO_CMD = "/bin/sh -c id"
 
 
+# ── stdio form codec: command material is UI-session-only ──────────
+
+
+@pytest.mark.parametrize("operation", ["encode", "decode"])
+def test_stdio_command_codec_refuses_api_key_before_work(monkeypatch, stdio_on, no_probe, operation):
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import McpStdioCommand, McpStdioDecodeRequest
+
+    def _never(*args, **kwargs):
+        raise AssertionError("refused codec request must not access storage")
+
+    monkeypatch.setattr(mcp_servers_db, "list_servers", _never)
+    with pytest.raises(HTTPException) as exc:
+        if operation == "encode":
+            routes_mcp.encode_stdio_command(
+                McpStdioCommand(command = "python", arguments = ["--token", "secret"]),
+                current_subject = "api-key-user",
+                via_api_key = True,
+            )
+        else:
+            routes_mcp.decode_stdio_command(
+                McpStdioDecodeRequest(url = "python --token secret"),
+                current_subject = "api-key-user",
+                via_api_key = True,
+            )
+    assert exc.value.status_code == 403
+
+
 # ── /test: an unstored, caller-supplied command ─────────────────────
 
 
@@ -370,6 +398,8 @@ def test_default_is_ui_session_so_direct_calls_are_unaffected():
         "refresh_mcp_server_tools",
         "import_mcp_servers",
         "test_mcp_server",
+        "decode_stdio_command",
+        "encode_stdio_command",
     ):
         param = inspect.signature(getattr(routes_mcp, name)).parameters["via_api_key"]
         assert param.default is False, name

--- a/studio/backend/tests/test_mcp_stdio_improvements.py
+++ b/studio/backend/tests/test_mcp_stdio_improvements.py
@@ -46,6 +46,39 @@ def test_client_builds_stdio_when_enabled_without_spawning(monkeypatch):
     assert client is not None
 
 
+def test_client_builds_stdio_with_encoded_arguments_without_shell(monkeypatch):
+    import fastmcp
+    from fastmcp.client import transports
+    from models.mcp_servers import McpStdioCommand
+    import routes.mcp_servers as routes_mcp
+
+    _enable(monkeypatch)
+    captured = {}
+
+    class CapturingStdioTransport:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(fastmcp, "Client", lambda transport: transport)
+    monkeypatch.setattr(transports, "StdioTransport", CapturingStdioTransport)
+    monkeypatch.setattr(mcp_client, "_stdio_argv", lambda parts, env: parts)
+
+    encoded = routes_mcp.encode_stdio_command(
+        McpStdioCommand(
+            command = "  python  ",
+            arguments = ["-m", "mod", "--name", "a b", "", "  keep padding  "],
+        ),
+        current_subject = "u",
+    )
+    mcp_client._client(encoded.url, {"API_KEY": "secret"})
+
+    assert captured["command"] == "python"
+    assert captured["args"] == ["-m", "mod", "--name", "a b", "", "  keep padding  "]
+    assert captured["env"]["API_KEY"] == "secret"
+    assert captured["keep_alive"] is False
+    assert set(captured) == {"command", "args", "env", "keep_alive"}
+
+
 def test_client_http_unaffected_by_gate(monkeypatch):
     _disable(monkeypatch)
     assert mcp_client._client("https://example.com/mcp", None) is not None

--- a/studio/backend/tests/test_mcp_stdio_improvements.py
+++ b/studio/backend/tests/test_mcp_stdio_improvements.py
@@ -118,6 +118,30 @@ def test_create_keeps_oauth_for_http(tmp_path, monkeypatch):
     assert resp.use_oauth is True
 
 
+def test_connection_test_forces_oauth_off_for_stdio(monkeypatch):
+    import routes.mcp_servers as routes_mcp
+    from models.mcp_servers import McpServerTestRequest
+
+    _enable(monkeypatch)
+    captured = {}
+
+    async def capture_probe(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(routes_mcp, "list_tools_async", capture_probe)
+    result = asyncio.run(
+        routes_mcp.test_mcp_server(
+            McpServerTestRequest(url = "python server.py", use_oauth = True),
+            current_subject = "u",
+        )
+    )
+
+    assert result.ok is True
+    assert captured["use_oauth"] is False
+    assert captured["timeout"] == mcp_client.probe_timeout("python server.py", False)
+
+
 def test_update_url_to_stdio_clears_oauth(tmp_path, monkeypatch):
     import routes.mcp_servers as routes_mcp
     from models.mcp_servers import McpServerUpdate

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -9,6 +9,7 @@ Run from studio/backend:  python -m pytest tests/test_mcp_stdio_node_path.py -q
 import os
 import shutil
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -16,7 +17,7 @@ from core.inference import mcp_client
 from utils import node_runtime
 
 
-@pytest.fixture(autouse = True)
+@pytest.fixture(autouse=True)
 def _reset_managed_node_memo():
     node_runtime._reset_managed_node_check()
     yield
@@ -29,14 +30,14 @@ def managed_node(tmp_path, monkeypatch):
     tests cover PATH assembly, not `node -v`)."""
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
     bin_dir = tmp_path / "studio" / "node" / ("" if os.name == "nt" else "bin")
-    bin_dir.mkdir(parents = True, exist_ok = True)
+    bin_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
 
     def _no_usable_node(
         path,
-        require_npm = True,
-        require_npx = True,
+        require_npm=True,
+        require_npx=True,
     ):
         return False
 
@@ -61,7 +62,7 @@ def managed_node_install(tmp_path, monkeypatch):
     """The real locator + a stub node binary, so managed_node_usable() is exercised."""
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
     bin_dir = tmp_path / "studio" / "node" / ("" if os.name == "nt" else "bin")
-    bin_dir.mkdir(parents = True, exist_ok = True)
+    bin_dir.mkdir(parents=True, exist_ok=True)
     binary = node_runtime.managed_node_binary()
     binary.write_text("")
     return bin_dir
@@ -100,16 +101,16 @@ def test_stdio_env_keeps_server_env_and_extends_its_path(managed_node):
 
 def test_stdio_env_is_none_without_managed_node_or_vars(tmp_path, monkeypatch):
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
-    monkeypatch.delenv("PATH", raising = False)
+    monkeypatch.delenv("PATH", raising=False)
     assert mcp_client._stdio_env(None) is None
 
 
 @pytest.mark.parametrize(
     "environment",
     [
-        pytest.param({"BAD\x00NAME": "value"}, id = "nul-name"),
-        pytest.param({"NAME": "bad\x00value"}, id = "nul-value"),
-        pytest.param({"BAD=NAME": "value"}, id = "equals-name"),
+        pytest.param({"BAD\x00NAME": "value"}, id="nul-name"),
+        pytest.param({"NAME": "bad\x00value"}, id="nul-value"),
+        pytest.param({"BAD=NAME": "value"}, id="equals-name"),
     ],
 )
 def test_stdio_env_rejects_invalid_legacy_values(environment):
@@ -163,7 +164,7 @@ def test_stdio_argv_prefers_child_path_over_parent(managed_node, monkeypatch, tm
 def test_windows_stdio_argv_bypasses_batch_launcher(launcher, monkeypatch, tmp_path):
     bin_dir = tmp_path / "node"
     cli = bin_dir / "node_modules" / "npm" / "bin" / f"{launcher}-cli.js"
-    cli.parent.mkdir(parents = True)
+    cli.parent.mkdir(parents=True)
     cli.write_text("")
     node = bin_dir / "node.exe"
     node.write_text("")
@@ -173,7 +174,7 @@ def test_windows_stdio_argv_bypasses_batch_launcher(launcher, monkeypatch, tmp_p
     monkeypatch.setattr(
         mcp_client.shutil,
         "which",
-        lambda command, path = None: str(batch) if command == launcher else str(node),
+        lambda command, path=None: str(batch) if command == launcher else str(node),
     )
     arguments = ["%TOKEN%", "a&b", "x|y", 'say "hello"', "a b", ""]
 
@@ -187,10 +188,27 @@ def test_windows_stdio_argv_rejects_batch_when_cli_is_unknown(monkeypatch, tmp_p
     batch.parent.mkdir()
     batch.write_text("")
     monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
-    monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path = None: str(batch))
+    monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path=None: str(batch))
 
-    with pytest.raises(ValueError, match = "npm CLI script"):
+    with pytest.raises(ValueError, match="npm CLI script"):
         mcp_client._stdio_argv(["npx", "package"], {"PATH": str(tmp_path)})
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires an installed Windows Node runtime")
+@pytest.mark.parametrize("launcher", ["npm", "npx"])
+def test_windows_installed_node_launcher_avoids_cmd_shell(launcher):
+    resolved = shutil.which(launcher)
+    if resolved is None:
+        pytest.skip(f"{launcher} is not installed")
+    assert Path(resolved).suffix.lower() in (".cmd", ".bat")
+    arguments = ["%TOKEN%", "a&b", "x|y", 'say "hello"', "a b", ""]
+
+    argv = mcp_client._stdio_argv([launcher, *arguments], {"PATH": os.environ.get("PATH", "")})
+
+    assert Path(argv[0]).name.lower() == "node.exe"
+    assert Path(argv[1]).name.lower() == f"{launcher}-cli.js"
+    assert Path(argv[1]).is_file()
+    assert argv[2:] == arguments
 
 
 def test_client_spawns_managed_npx_by_full_path(managed_node, monkeypatch, tmp_path):
@@ -209,19 +227,19 @@ def test_runtime_free_dir_resolves_nothing(runtime_free_dir):
     Node the base PATH already resolves a runtime, so path_with_managed_node correctly
     returns it unchanged and the prepend assertions flip."""
     assert node_runtime._path_has_usable_node(str(runtime_free_dir)) is False
-    assert node_runtime._path_has_usable_node(str(runtime_free_dir), require_npm = False) is False
+    assert node_runtime._path_has_usable_node(str(runtime_free_dir), require_npm=False) is False
 
 
 def test_stale_managed_node_is_not_prepended(managed_node_install, monkeypatch, runtime_free_dir):
     """A dir left behind after the host moved to a system Node must not win the lookup."""
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: False)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: False)
     assert node_runtime.managed_node_usable() is False
     base = str(runtime_free_dir)
     assert node_runtime.path_with_managed_node(base) == base
 
 
 def test_usable_managed_node_is_prepended(managed_node_install, monkeypatch, runtime_free_dir):
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
     assert node_runtime.managed_node_usable() is True
     base = str(runtime_free_dir)
     expected = f"{managed_node_install}{os.pathsep}{base}"
@@ -231,7 +249,7 @@ def test_usable_managed_node_is_prepended(managed_node_install, monkeypatch, run
 def test_stale_managed_node_leaves_stdio_env_alone(
     managed_node_install, monkeypatch, runtime_free_dir
 ):
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: False)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: False)
     monkeypatch.setenv("PATH", str(runtime_free_dir))
     assert mcp_client._stdio_env(None)["PATH"] == str(runtime_free_dir)
 
@@ -240,7 +258,7 @@ def test_managed_node_check_is_memoized_on_success(managed_node_install, monkeyp
     """One probe per process once usable: _stdio_env runs on every client build."""
     calls = []
 
-    def _record(executable, path = None):
+    def _record(executable, path=None):
         calls.append(executable)
         return True
 
@@ -298,7 +316,7 @@ def test_stdio_env_preserves_empty_component_from_config(managed_node):
     assert env["PATH"] == f"{managed_node}{os.pathsep}{configured}"
 
 
-def _system_node_dir(tmp_path, with_npx = True):
+def _system_node_dir(tmp_path, with_npx=True):
     """A system runtime dir; without npx/npm it mirrors a host where setup picked bundled."""
     sysbin = tmp_path / "sysbin"
     sysbin.mkdir()
@@ -312,7 +330,7 @@ def _system_node_dir(tmp_path, with_npx = True):
 def _patch_floors(monkeypatch, predicate):
     """Both floors move together: the installers require node AND npm to pass."""
 
-    def _check(executable, path = None):
+    def _check(executable, path=None):
         return predicate(executable)
 
     monkeypatch.setattr(node_runtime, "_node_version_ok", _check)
@@ -322,7 +340,7 @@ def _patch_floors(monkeypatch, predicate):
 def test_adequate_system_node_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
     """A leftover managed install must not override a Node the PATH already provides."""
     sysbin = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
 
 
@@ -330,7 +348,7 @@ def test_managed_node_used_when_system_node_is_below_floor(
     managed_node_install, monkeypatch, tmp_path
 ):
     sysbin = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path = None: "sysbin" not in str(executable))
+    _patch_floors(monkeypatch, lambda executable, path=None: "sysbin" not in str(executable))
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
 
@@ -338,7 +356,7 @@ def test_managed_node_used_when_system_node_is_below_floor(
 def test_managed_node_used_when_path_has_no_node(managed_node_install, monkeypatch, tmp_path):
     empty = tmp_path / "empty"
     empty.mkdir()
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
     expected = f"{managed_node_install}{os.pathsep}{empty}"
     assert node_runtime.path_with_managed_node(str(empty)) == expected
 
@@ -346,7 +364,7 @@ def test_managed_node_used_when_path_has_no_node(managed_node_install, monkeypat
 def test_system_node_probe_is_memoized(managed_node_install, monkeypatch, tmp_path):
     sysbin = _system_node_dir(tmp_path)
     calls = []
-    _patch_floors(monkeypatch, lambda executable, path = None: calls.append(executable) or True)
+    _patch_floors(monkeypatch, lambda executable, path=None: calls.append(executable) or True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
     after_first = len(calls)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
@@ -370,11 +388,11 @@ def test_probe_memo_does_not_answer_across_paths(managed_node_install, monkeypat
 
     # Patched directly rather than through _patch_floors: that helper drops the path
     # argument, which is the whole dimension under test here.
-    def _npm_floor(executable, path = None):
+    def _npm_floor(executable, path=None):
         # The shim runs whichever node its PATH reaches, so only the good PATH clears.
         return path is not None and str(good) in path
 
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
     monkeypatch.setattr(node_runtime, "_npm_version_ok", _npm_floor)
     good_path = f"{shim}{os.pathsep}{good}"
     old_path = f"{shim}{os.pathsep}{old}"
@@ -386,22 +404,22 @@ def test_probe_memo_does_not_answer_across_paths(managed_node_install, monkeypat
 
 def test_managed_node_used_when_system_lacks_npx(managed_node_install, monkeypatch, tmp_path):
     """decide_node_source installs bundled when npm is missing, so node alone is not enough."""
-    sysbin = _system_node_dir(tmp_path, with_npx = False)
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
+    sysbin = _system_node_dir(tmp_path, with_npx=False)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
 
 
 def test_complete_system_runtime_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
     sysbin = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
 
 
 def test_shadowed_managed_dir_moves_to_front(managed_node_install, monkeypatch, tmp_path):
     """Already on PATH but behind a stale runtime: it has to move up, not stay put."""
     stale = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path = None: "sysbin" not in str(executable))
+    _patch_floors(monkeypatch, lambda executable, path=None: "sysbin" not in str(executable))
     configured = f"{stale}{os.pathsep}{managed_node_install}"
     expected = f"{managed_node_install}{os.pathsep}{stale}"
     assert node_runtime.path_with_managed_node(configured) == expected
@@ -409,7 +427,7 @@ def test_shadowed_managed_dir_moves_to_front(managed_node_install, monkeypatch, 
 
 def test_managed_dir_already_first_is_unchanged(managed_node_install, monkeypatch, tmp_path):
     stale = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path = None: "sysbin" not in str(executable))
+    _patch_floors(monkeypatch, lambda executable, path=None: "sysbin" not in str(executable))
     configured = f"{managed_node_install}{os.pathsep}{stale}"
     assert node_runtime.path_with_managed_node(configured) == configured
 
@@ -461,8 +479,9 @@ def test_windows_npx_sibling_runtime_is_the_one_validated(
     checked = []
     _patch_floors(
         monkeypatch,
-        lambda executable, path = None: checked.append(str(executable))
-        or not str(executable).startswith(str(old)),
+        lambda executable, path=None: (
+            checked.append(str(executable)) or not str(executable).startswith(str(old))
+        ),
     )
     configured = f"{good}{os.pathsep}{old}"
     result = node_runtime.path_with_managed_node(configured)
@@ -479,7 +498,7 @@ def test_posix_split_layout_still_trusts_the_path_node(managed_node_install, mon
     other.mkdir()
     _make_executable(other, "npm")
     _make_executable(other, "npx")
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     configured = f"{good}{os.pathsep}{other}"
     assert node_runtime.path_with_managed_node(configured) == configured
 
@@ -524,11 +543,11 @@ def test_npm_below_installer_floor_falls_back_to_managed(
 ):
     """Node clears its floor but npm is 10, which is why setup installed the managed one."""
     sysbin = _system_node_dir(tmp_path)
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
     monkeypatch.setattr(
         node_runtime,
         "_npm_version_ok",
-        lambda executable, path = None: not str(executable).startswith(str(sysbin)),
+        lambda executable, path=None: not str(executable).startswith(str(sysbin)),
     )
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
@@ -551,9 +570,9 @@ def _node_only_dir(tmp_path):
 
 def test_direct_node_server_keeps_a_node_only_path(managed_node_install, monkeypatch, tmp_path):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     unchanged = node_runtime.path_with_managed_node(
-        str(nodeonly), require_npm = False, require_npx = False
+        str(nodeonly), require_npm=False, require_npx=False
     )
     assert unchanged == str(nodeonly)
 
@@ -563,10 +582,10 @@ def test_npx_server_still_needs_npx_on_a_node_only_path(
 ):
     """node alone cannot launch an ``npx`` server, so the managed dir still goes on."""
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     expected = f"{managed_node_install}{os.pathsep}{nodeonly}"
     assert (
-        node_runtime.path_with_managed_node(str(nodeonly), require_npm = False, require_npx = True)
+        node_runtime.path_with_managed_node(str(nodeonly), require_npm=False, require_npx=True)
         == expected
     )
 
@@ -580,7 +599,7 @@ def test_npx_server_keeps_a_path_with_npx_but_no_npm(managed_node_install, monke
     curated.mkdir()
     _make_executable(curated, "node")
     _make_executable(curated, "npx")
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     monkeypatch.setenv("PATH", str(curated))
     assert mcp_client._stdio_env(None, "npx")["PATH"] == str(curated)
     assert mcp_client._stdio_argv(["npx", "-y", "server"], {"PATH": str(curated)})[0].startswith(
@@ -595,17 +614,17 @@ def test_npx_only_path_is_still_held_to_the_npm_floor(managed_node_install, monk
     curated.mkdir()
     _make_executable(curated, "node")
     _make_executable(curated, "npx")
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
     probed = []
 
-    def _npm_floor(executable, path = None):
+    def _npm_floor(executable, path=None):
         probed.append(str(executable))
         return False  # the bundled npm is below the installers' floor
 
     monkeypatch.setattr(node_runtime, "_npm_version_ok", _npm_floor)
     expected = f"{managed_node_install}{os.pathsep}{curated}"
     assert (
-        node_runtime.path_with_managed_node(str(curated), require_npm = False, require_npx = True)
+        node_runtime.path_with_managed_node(str(curated), require_npm=False, require_npx=True)
         == expected
     )
     assert any(os.path.basename(p).startswith("npx") for p in probed), probed
@@ -615,7 +634,7 @@ def test_stdio_env_does_not_shadow_node_for_a_direct_node_server(
     managed_node_install, monkeypatch, tmp_path
 ):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     monkeypatch.setenv("PATH", str(nodeonly))
     assert mcp_client._stdio_env(None, "node")["PATH"] == str(nodeonly)
 
@@ -624,7 +643,7 @@ def test_stdio_env_still_augments_for_npx_on_a_node_only_path(
     managed_node_install, monkeypatch, tmp_path
 ):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     monkeypatch.setenv("PATH", str(nodeonly))
     env = mcp_client._stdio_env(None, "npx")
     assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nodeonly}"
@@ -674,7 +693,7 @@ def test_direct_npm_server_does_not_need_npx(managed_node_install, monkeypatch, 
     nonpx.mkdir()
     _make_executable(nonpx, "node")
     _make_executable(nonpx, "npm")
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     monkeypatch.setenv("PATH", str(nonpx))
     assert mcp_client._stdio_env(None, "npm")["PATH"] == str(nonpx)
 
@@ -686,13 +705,13 @@ def test_npx_server_on_the_same_path_still_gets_managed(
     nonpx.mkdir()
     _make_executable(nonpx, "node")
     _make_executable(nonpx, "npm")
-    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    _patch_floors(monkeypatch, lambda executable, path=None: True)
     monkeypatch.setenv("PATH", str(nonpx))
     env = mcp_client._stdio_env(None, "npx")
     assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nonpx}"
 
 
-@pytest.mark.skipif(os.name == "nt", reason = "POSIX shebang launcher")
+@pytest.mark.skipif(os.name == "nt", reason="POSIX shebang launcher")
 def test_npm_probe_runs_with_the_candidate_path(managed_node_install, monkeypatch, tmp_path):
     """npm is a `#!/usr/bin/env node` script, so the probe needs the candidate's node."""
     toolchain = tmp_path / "toolchain"
@@ -724,18 +743,18 @@ def test_windows_npm_sibling_runtime_is_validated(managed_node_install, monkeypa
     monkeypatch.setattr(node_runtime, "_IS_WINDOWS", True)
     checked = []
 
-    def _record(executable, path = None):
+    def _record(executable, path=None):
         checked.append(str(executable))
         return not str(executable).startswith(str(old))
 
     _patch_floors(monkeypatch, lambda executable: _record(executable))
     configured = f"{good}{os.pathsep}{old}"
-    result = node_runtime.path_with_managed_node(configured, require_npm = True, require_npx = False)
+    result = node_runtime.path_with_managed_node(configured, require_npm=True, require_npx=False)
     assert any(c.endswith("node.exe") for c in checked), checked
     assert result == f"{managed_node_install}{os.pathsep}{configured}"
 
 
-def _good_node_only(tmp_path, name = "toolchain"):
+def _good_node_only(tmp_path, name="toolchain"):
     d = tmp_path / name
     d.mkdir()
     _make_executable(d, "node")

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -121,6 +121,7 @@ def test_stdio_env_rejects_invalid_legacy_values(environment):
 def test_client_passes_node_path_to_transport(managed_node, monkeypatch):
     monkeypatch.setenv("UNSLOTH_STUDIO_ALLOW_STDIO_MCP", "1")
     monkeypatch.setenv("PATH", "/usr/bin")
+    _make_executable(managed_node, "npx")
     client = mcp_client._client("npx -y @modelcontextprotocol/server-filesystem /tmp", None)
     assert client.transport.env["PATH"].split(os.pathsep)[0] == str(managed_node)
 
@@ -155,9 +156,13 @@ def test_stdio_argv_resolves_managed_npx(managed_node):
 
 
 def test_stdio_argv_keeps_unresolvable_command(managed_node):
-    argv = mcp_client._stdio_argv(
-        ["definitely-not-on-path-9304", "-y"], mcp_client._stdio_env(None)
-    )
+    parts = ["definitely-not-on-path-9304", "-y"]
+    env = mcp_client._stdio_env(None)
+    if os.name == "nt":
+        with pytest.raises(ValueError, match = "configured PATH"):
+            mcp_client._stdio_argv(parts, env)
+        return
+    argv = mcp_client._stdio_argv(parts, env)
     assert argv == ["definitely-not-on-path-9304", "-y"]
 
 

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -104,6 +104,19 @@ def test_stdio_env_is_none_without_managed_node_or_vars(tmp_path, monkeypatch):
     assert mcp_client._stdio_env(None) is None
 
 
+@pytest.mark.parametrize(
+    "environment",
+    [
+        pytest.param({"BAD\x00NAME": "value"}, id = "nul-name"),
+        pytest.param({"NAME": "bad\x00value"}, id = "nul-value"),
+        pytest.param({"BAD=NAME": "value"}, id = "equals-name"),
+    ],
+)
+def test_stdio_env_rejects_invalid_legacy_values(environment):
+    with pytest.raises(ValueError):
+        mcp_client._stdio_env(environment, "python")
+
+
 def test_client_passes_node_path_to_transport(managed_node, monkeypatch):
     monkeypatch.setenv("UNSLOTH_STUDIO_ALLOW_STDIO_MCP", "1")
     monkeypatch.setenv("PATH", "/usr/bin")

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -206,6 +206,28 @@ def test_windows_stdio_argv_rejects_batch_when_cli_is_unknown(monkeypatch, tmp_p
         mcp_client._stdio_argv(["npx", "package"], {"PATH": str(tmp_path)})
 
 
+def test_windows_stdio_argv_rejects_other_batch_arguments(monkeypatch, tmp_path):
+    batch = tmp_path / "mcp-server-example.cmd"
+    batch.write_text("")
+    monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
+    monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path = None: str(batch))
+
+    with pytest.raises(ValueError, match = "cannot preserve MCP command arguments"):
+        mcp_client._stdio_argv(
+            ["mcp-server-example", "%TOKEN%", "a&b", "x|y"],
+            {"PATH": str(tmp_path)},
+        )
+
+
+def test_windows_stdio_argv_keeps_argument_free_batch(monkeypatch, tmp_path):
+    batch = tmp_path / "mcp-server-example.cmd"
+    batch.write_text("")
+    monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
+    monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path = None: str(batch))
+
+    assert mcp_client._stdio_argv(["mcp-server-example"], {"PATH": str(tmp_path)}) == [str(batch)]
+
+
 @pytest.mark.skipif(os.name != "nt", reason = "requires an installed Windows Node runtime")
 @pytest.mark.parametrize("launcher", ["npm", "npx"])
 def test_windows_installed_node_launcher_avoids_cmd_shell(launcher):
@@ -298,7 +320,11 @@ def test_explicit_empty_path_blocks_host_lookup(managed_node, monkeypatch, tmp_p
     _make_executable(host, "hostcmd")
     monkeypatch.setenv("PATH", str(host))
     assert shutil.which("hostcmd") is not None
-    assert mcp_client._stdio_argv(["hostcmd"], {"PATH": ""}) == ["hostcmd"]
+    if os.name == "nt":
+        with pytest.raises(ValueError, match = "configured PATH"):
+            mcp_client._stdio_argv(["hostcmd"], {"PATH": ""})
+    else:
+        assert mcp_client._stdio_argv(["hostcmd"], {"PATH": ""}) == ["hostcmd"]
 
 
 def test_explicit_empty_path_still_allows_absolute_command(managed_node):
@@ -494,8 +520,9 @@ def test_windows_npx_sibling_runtime_is_the_one_validated(
     checked = []
     _patch_floors(
         monkeypatch,
-        lambda executable, path = None: checked.append(str(executable))
-        or not str(executable).startswith(str(old)),
+        lambda executable, path = None: (
+            checked.append(str(executable)) or not str(executable).startswith(str(old))
+        ),
     )
     configured = f"{good}{os.pathsep}{old}"
     result = node_runtime.path_with_managed_node(configured)
@@ -542,7 +569,8 @@ def test_windows_lowercase_empty_path_is_still_a_sandbox(managed_node, monkeypat
 
 
 def test_windows_lowercase_path_blocks_host_lookup(managed_node, windows_env):
-    assert mcp_client._stdio_argv(["npx"], {"Path": ""}) == ["npx"]
+    with pytest.raises(ValueError, match = "configured PATH"):
+        mcp_client._stdio_argv(["npx"], {"Path": ""})
 
 
 def test_posix_treats_path_and_lowercase_path_as_distinct(managed_node, monkeypatch, posix_env):

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -206,17 +206,31 @@ def test_windows_stdio_argv_rejects_batch_when_cli_is_unknown(monkeypatch, tmp_p
         mcp_client._stdio_argv(["npx", "package"], {"PATH": str(tmp_path)})
 
 
-def test_windows_stdio_argv_rejects_other_batch_arguments(monkeypatch, tmp_path):
+@pytest.mark.parametrize("argument", ["%TOKEN%", "a&b", "x|y", 'say "hello"', "(group)"])
+def test_windows_stdio_argv_rejects_unsafe_batch_arguments(argument, monkeypatch, tmp_path):
     batch = tmp_path / "mcp-server-example.cmd"
     batch.write_text("")
     monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
     monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path = None: str(batch))
 
-    with pytest.raises(ValueError, match = "cannot preserve MCP command arguments"):
+    with pytest.raises(ValueError, match = "cannot safely preserve these MCP command arguments"):
         mcp_client._stdio_argv(
-            ["mcp-server-example", "%TOKEN%", "a&b", "x|y"],
+            ["mcp-server-example", argument],
             {"PATH": str(tmp_path)},
         )
+
+
+def test_windows_stdio_argv_keeps_safe_batch_arguments(monkeypatch, tmp_path):
+    batch = tmp_path / "mcp-server-example.cmd"
+    batch.write_text("")
+    monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
+    monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path = None: str(batch))
+    arguments = ["--port", "3000", r"C:\Users\me\data", "a b", ""]
+
+    assert mcp_client._stdio_argv(["mcp-server-example", *arguments], {"PATH": str(tmp_path)}) == [
+        str(batch),
+        *arguments,
+    ]
 
 
 def test_windows_stdio_argv_keeps_argument_free_batch(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -129,17 +129,29 @@ def _make_executable(bin_dir, name):
     """A stub the platform's own PATH lookup will accept (.cmd via PATHEXT on Windows)."""
     path = bin_dir / (f"{name}.cmd" if os.name == "nt" else name)
     path.write_text("")
-    if os.name != "nt":
+    if os.name == "nt" and name in ("npm", "npx"):
+        (bin_dir / "node.exe").write_text("")
+        cli = bin_dir / "node_modules" / "npm" / "bin" / f"{name}-cli.js"
+        cli.parent.mkdir(parents = True, exist_ok = True)
+        cli.write_text("")
+    elif os.name != "nt":
         path.chmod(0o755)
     return path
+
+
+def _expected_node_launcher_argv(launcher, arguments):
+    if os.name != "nt":
+        return [str(launcher), *arguments]
+    bin_dir = launcher.parent
+    cli = bin_dir / "node_modules" / "npm" / "bin" / f"{launcher.stem}-cli.js"
+    return [str(bin_dir / "node.exe"), str(cli), *arguments]
 
 
 def test_stdio_argv_resolves_managed_npx(managed_node):
     npx = _make_executable(managed_node, "npx")
     env = mcp_client._stdio_env(None)
     argv = mcp_client._stdio_argv(["npx", "-y", "pkg"], env)
-    assert os.path.samefile(argv[0], npx)
-    assert argv[1:] == ["-y", "pkg"]
+    assert argv == _expected_node_launcher_argv(npx, ["-y", "pkg"])
 
 
 def test_stdio_argv_keeps_unresolvable_command(managed_node):
@@ -157,7 +169,7 @@ def test_stdio_argv_prefers_child_path_over_parent(managed_node, monkeypatch, tm
     monkeypatch.setenv("PATH", str(bare))
     assert shutil.which("npx") is None
     argv = mcp_client._stdio_argv(["npx"], mcp_client._stdio_env(None))
-    assert os.path.samefile(argv[0], npx)
+    assert argv == _expected_node_launcher_argv(npx, [])
 
 
 @pytest.mark.parametrize("launcher", ["npm", "npx"])
@@ -218,7 +230,10 @@ def test_client_spawns_managed_npx_by_full_path(managed_node, monkeypatch, tmp_p
     monkeypatch.setenv("PATH", str(bare))
     monkeypatch.setenv("UNSLOTH_STUDIO_ALLOW_STDIO_MCP", "1")
     client = mcp_client._client("npx -y @modelcontextprotocol/server-filesystem /tmp", None)
-    assert os.path.samefile(client.transport.command, npx)
+    expected = _expected_node_launcher_argv(
+        npx, ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    )
+    assert [client.transport.command, *client.transport.args] == expected
 
 
 def test_runtime_free_dir_resolves_nothing(runtime_free_dir):

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -225,7 +225,14 @@ def test_windows_stdio_argv_keeps_safe_batch_arguments(monkeypatch, tmp_path):
     batch.write_text("")
     monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
     monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path = None: str(batch))
-    arguments = ["--port", "3000", r"C:\Users\me\data", "a b", ""]
+    arguments = [
+        "--port",
+        "3000",
+        r"C:\Users\me\data",
+        r"C:\Program Files (x86)\mcp data",
+        "a & b",
+        "",
+    ]
 
     assert mcp_client._stdio_argv(["mcp-server-example", *arguments], {"PATH": str(tmp_path)}) == [
         str(batch),

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -159,6 +159,40 @@ def test_stdio_argv_prefers_child_path_over_parent(managed_node, monkeypatch, tm
     assert os.path.samefile(argv[0], npx)
 
 
+@pytest.mark.parametrize("launcher", ["npm", "npx"])
+def test_windows_stdio_argv_bypasses_batch_launcher(launcher, monkeypatch, tmp_path):
+    bin_dir = tmp_path / "node"
+    cli = bin_dir / "node_modules" / "npm" / "bin" / f"{launcher}-cli.js"
+    cli.parent.mkdir(parents = True)
+    cli.write_text("")
+    node = bin_dir / "node.exe"
+    node.write_text("")
+    batch = bin_dir / f"{launcher}.cmd"
+    batch.write_text("")
+    monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
+    monkeypatch.setattr(
+        mcp_client.shutil,
+        "which",
+        lambda command, path = None: str(batch) if command == launcher else str(node),
+    )
+    arguments = ["%TOKEN%", "a&b", "x|y", 'say "hello"', "a b", ""]
+
+    argv = mcp_client._stdio_argv([launcher, *arguments], {"PATH": str(bin_dir)})
+
+    assert argv == [str(node), str(cli), *arguments]
+
+
+def test_windows_stdio_argv_rejects_batch_when_cli_is_unknown(monkeypatch, tmp_path):
+    batch = tmp_path / "custom" / "npx.cmd"
+    batch.parent.mkdir()
+    batch.write_text("")
+    monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
+    monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path = None: str(batch))
+
+    with pytest.raises(ValueError, match = "npm CLI script"):
+        mcp_client._stdio_argv(["npx", "package"], {"PATH": str(tmp_path)})
+
+
 def test_client_spawns_managed_npx_by_full_path(managed_node, monkeypatch, tmp_path):
     npx = _make_executable(managed_node, "npx")
     bare = tmp_path / "empty"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -203,9 +203,7 @@ def test_windows_installed_node_launcher_avoids_cmd_shell(launcher):
     assert Path(resolved).suffix.lower() in (".cmd", ".bat")
     arguments = ["%TOKEN%", "a&b", "x|y", 'say "hello"', "a b", ""]
 
-    argv = mcp_client._stdio_argv(
-        [launcher, *arguments], {"PATH": os.environ.get("PATH", "")}
-    )
+    argv = mcp_client._stdio_argv([launcher, *arguments], {"PATH": os.environ.get("PATH", "")})
 
     assert Path(argv[0]).name.lower() == "node.exe"
     assert Path(argv[1]).name.lower() == f"{launcher}-cli.js"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -17,7 +17,7 @@ from core.inference import mcp_client
 from utils import node_runtime
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse = True)
 def _reset_managed_node_memo():
     node_runtime._reset_managed_node_check()
     yield
@@ -30,14 +30,14 @@ def managed_node(tmp_path, monkeypatch):
     tests cover PATH assembly, not `node -v`)."""
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
     bin_dir = tmp_path / "studio" / "node" / ("" if os.name == "nt" else "bin")
-    bin_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir.mkdir(parents = True, exist_ok = True)
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
 
     def _no_usable_node(
         path,
-        require_npm=True,
-        require_npx=True,
+        require_npm = True,
+        require_npx = True,
     ):
         return False
 
@@ -62,7 +62,7 @@ def managed_node_install(tmp_path, monkeypatch):
     """The real locator + a stub node binary, so managed_node_usable() is exercised."""
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
     bin_dir = tmp_path / "studio" / "node" / ("" if os.name == "nt" else "bin")
-    bin_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir.mkdir(parents = True, exist_ok = True)
     binary = node_runtime.managed_node_binary()
     binary.write_text("")
     return bin_dir
@@ -101,16 +101,16 @@ def test_stdio_env_keeps_server_env_and_extends_its_path(managed_node):
 
 def test_stdio_env_is_none_without_managed_node_or_vars(tmp_path, monkeypatch):
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
-    monkeypatch.delenv("PATH", raising=False)
+    monkeypatch.delenv("PATH", raising = False)
     assert mcp_client._stdio_env(None) is None
 
 
 @pytest.mark.parametrize(
     "environment",
     [
-        pytest.param({"BAD\x00NAME": "value"}, id="nul-name"),
-        pytest.param({"NAME": "bad\x00value"}, id="nul-value"),
-        pytest.param({"BAD=NAME": "value"}, id="equals-name"),
+        pytest.param({"BAD\x00NAME": "value"}, id = "nul-name"),
+        pytest.param({"NAME": "bad\x00value"}, id = "nul-value"),
+        pytest.param({"BAD=NAME": "value"}, id = "equals-name"),
     ],
 )
 def test_stdio_env_rejects_invalid_legacy_values(environment):
@@ -164,7 +164,7 @@ def test_stdio_argv_prefers_child_path_over_parent(managed_node, monkeypatch, tm
 def test_windows_stdio_argv_bypasses_batch_launcher(launcher, monkeypatch, tmp_path):
     bin_dir = tmp_path / "node"
     cli = bin_dir / "node_modules" / "npm" / "bin" / f"{launcher}-cli.js"
-    cli.parent.mkdir(parents=True)
+    cli.parent.mkdir(parents = True)
     cli.write_text("")
     node = bin_dir / "node.exe"
     node.write_text("")
@@ -174,7 +174,7 @@ def test_windows_stdio_argv_bypasses_batch_launcher(launcher, monkeypatch, tmp_p
     monkeypatch.setattr(
         mcp_client.shutil,
         "which",
-        lambda command, path=None: str(batch) if command == launcher else str(node),
+        lambda command, path = None: str(batch) if command == launcher else str(node),
     )
     arguments = ["%TOKEN%", "a&b", "x|y", 'say "hello"', "a b", ""]
 
@@ -188,13 +188,13 @@ def test_windows_stdio_argv_rejects_batch_when_cli_is_unknown(monkeypatch, tmp_p
     batch.parent.mkdir()
     batch.write_text("")
     monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
-    monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path=None: str(batch))
+    monkeypatch.setattr(mcp_client.shutil, "which", lambda command, path = None: str(batch))
 
-    with pytest.raises(ValueError, match="npm CLI script"):
+    with pytest.raises(ValueError, match = "npm CLI script"):
         mcp_client._stdio_argv(["npx", "package"], {"PATH": str(tmp_path)})
 
 
-@pytest.mark.skipif(os.name != "nt", reason="requires an installed Windows Node runtime")
+@pytest.mark.skipif(os.name != "nt", reason = "requires an installed Windows Node runtime")
 @pytest.mark.parametrize("launcher", ["npm", "npx"])
 def test_windows_installed_node_launcher_avoids_cmd_shell(launcher):
     resolved = shutil.which(launcher)
@@ -203,7 +203,9 @@ def test_windows_installed_node_launcher_avoids_cmd_shell(launcher):
     assert Path(resolved).suffix.lower() in (".cmd", ".bat")
     arguments = ["%TOKEN%", "a&b", "x|y", 'say "hello"', "a b", ""]
 
-    argv = mcp_client._stdio_argv([launcher, *arguments], {"PATH": os.environ.get("PATH", "")})
+    argv = mcp_client._stdio_argv(
+        [launcher, *arguments], {"PATH": os.environ.get("PATH", "")}
+    )
 
     assert Path(argv[0]).name.lower() == "node.exe"
     assert Path(argv[1]).name.lower() == f"{launcher}-cli.js"
@@ -227,19 +229,19 @@ def test_runtime_free_dir_resolves_nothing(runtime_free_dir):
     Node the base PATH already resolves a runtime, so path_with_managed_node correctly
     returns it unchanged and the prepend assertions flip."""
     assert node_runtime._path_has_usable_node(str(runtime_free_dir)) is False
-    assert node_runtime._path_has_usable_node(str(runtime_free_dir), require_npm=False) is False
+    assert node_runtime._path_has_usable_node(str(runtime_free_dir), require_npm = False) is False
 
 
 def test_stale_managed_node_is_not_prepended(managed_node_install, monkeypatch, runtime_free_dir):
     """A dir left behind after the host moved to a system Node must not win the lookup."""
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: False)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: False)
     assert node_runtime.managed_node_usable() is False
     base = str(runtime_free_dir)
     assert node_runtime.path_with_managed_node(base) == base
 
 
 def test_usable_managed_node_is_prepended(managed_node_install, monkeypatch, runtime_free_dir):
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     assert node_runtime.managed_node_usable() is True
     base = str(runtime_free_dir)
     expected = f"{managed_node_install}{os.pathsep}{base}"
@@ -249,7 +251,7 @@ def test_usable_managed_node_is_prepended(managed_node_install, monkeypatch, run
 def test_stale_managed_node_leaves_stdio_env_alone(
     managed_node_install, monkeypatch, runtime_free_dir
 ):
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: False)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: False)
     monkeypatch.setenv("PATH", str(runtime_free_dir))
     assert mcp_client._stdio_env(None)["PATH"] == str(runtime_free_dir)
 
@@ -258,7 +260,7 @@ def test_managed_node_check_is_memoized_on_success(managed_node_install, monkeyp
     """One probe per process once usable: _stdio_env runs on every client build."""
     calls = []
 
-    def _record(executable, path=None):
+    def _record(executable, path = None):
         calls.append(executable)
         return True
 
@@ -316,7 +318,7 @@ def test_stdio_env_preserves_empty_component_from_config(managed_node):
     assert env["PATH"] == f"{managed_node}{os.pathsep}{configured}"
 
 
-def _system_node_dir(tmp_path, with_npx=True):
+def _system_node_dir(tmp_path, with_npx = True):
     """A system runtime dir; without npx/npm it mirrors a host where setup picked bundled."""
     sysbin = tmp_path / "sysbin"
     sysbin.mkdir()
@@ -330,7 +332,7 @@ def _system_node_dir(tmp_path, with_npx=True):
 def _patch_floors(monkeypatch, predicate):
     """Both floors move together: the installers require node AND npm to pass."""
 
-    def _check(executable, path=None):
+    def _check(executable, path = None):
         return predicate(executable)
 
     monkeypatch.setattr(node_runtime, "_node_version_ok", _check)
@@ -340,7 +342,7 @@ def _patch_floors(monkeypatch, predicate):
 def test_adequate_system_node_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
     """A leftover managed install must not override a Node the PATH already provides."""
     sysbin = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
 
 
@@ -348,7 +350,7 @@ def test_managed_node_used_when_system_node_is_below_floor(
     managed_node_install, monkeypatch, tmp_path
 ):
     sysbin = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path=None: "sysbin" not in str(executable))
+    _patch_floors(monkeypatch, lambda executable, path = None: "sysbin" not in str(executable))
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
 
@@ -356,7 +358,7 @@ def test_managed_node_used_when_system_node_is_below_floor(
 def test_managed_node_used_when_path_has_no_node(managed_node_install, monkeypatch, tmp_path):
     empty = tmp_path / "empty"
     empty.mkdir()
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     expected = f"{managed_node_install}{os.pathsep}{empty}"
     assert node_runtime.path_with_managed_node(str(empty)) == expected
 
@@ -364,7 +366,7 @@ def test_managed_node_used_when_path_has_no_node(managed_node_install, monkeypat
 def test_system_node_probe_is_memoized(managed_node_install, monkeypatch, tmp_path):
     sysbin = _system_node_dir(tmp_path)
     calls = []
-    _patch_floors(monkeypatch, lambda executable, path=None: calls.append(executable) or True)
+    _patch_floors(monkeypatch, lambda executable, path = None: calls.append(executable) or True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
     after_first = len(calls)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
@@ -388,11 +390,11 @@ def test_probe_memo_does_not_answer_across_paths(managed_node_install, monkeypat
 
     # Patched directly rather than through _patch_floors: that helper drops the path
     # argument, which is the whole dimension under test here.
-    def _npm_floor(executable, path=None):
+    def _npm_floor(executable, path = None):
         # The shim runs whichever node its PATH reaches, so only the good PATH clears.
         return path is not None and str(good) in path
 
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     monkeypatch.setattr(node_runtime, "_npm_version_ok", _npm_floor)
     good_path = f"{shim}{os.pathsep}{good}"
     old_path = f"{shim}{os.pathsep}{old}"
@@ -404,22 +406,22 @@ def test_probe_memo_does_not_answer_across_paths(managed_node_install, monkeypat
 
 def test_managed_node_used_when_system_lacks_npx(managed_node_install, monkeypatch, tmp_path):
     """decide_node_source installs bundled when npm is missing, so node alone is not enough."""
-    sysbin = _system_node_dir(tmp_path, with_npx=False)
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
+    sysbin = _system_node_dir(tmp_path, with_npx = False)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
 
 
 def test_complete_system_runtime_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
     sysbin = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
 
 
 def test_shadowed_managed_dir_moves_to_front(managed_node_install, monkeypatch, tmp_path):
     """Already on PATH but behind a stale runtime: it has to move up, not stay put."""
     stale = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path=None: "sysbin" not in str(executable))
+    _patch_floors(monkeypatch, lambda executable, path = None: "sysbin" not in str(executable))
     configured = f"{stale}{os.pathsep}{managed_node_install}"
     expected = f"{managed_node_install}{os.pathsep}{stale}"
     assert node_runtime.path_with_managed_node(configured) == expected
@@ -427,7 +429,7 @@ def test_shadowed_managed_dir_moves_to_front(managed_node_install, monkeypatch, 
 
 def test_managed_dir_already_first_is_unchanged(managed_node_install, monkeypatch, tmp_path):
     stale = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path=None: "sysbin" not in str(executable))
+    _patch_floors(monkeypatch, lambda executable, path = None: "sysbin" not in str(executable))
     configured = f"{managed_node_install}{os.pathsep}{stale}"
     assert node_runtime.path_with_managed_node(configured) == configured
 
@@ -479,9 +481,8 @@ def test_windows_npx_sibling_runtime_is_the_one_validated(
     checked = []
     _patch_floors(
         monkeypatch,
-        lambda executable, path=None: (
-            checked.append(str(executable)) or not str(executable).startswith(str(old))
-        ),
+        lambda executable, path = None: checked.append(str(executable))
+        or not str(executable).startswith(str(old)),
     )
     configured = f"{good}{os.pathsep}{old}"
     result = node_runtime.path_with_managed_node(configured)
@@ -498,7 +499,7 @@ def test_posix_split_layout_still_trusts_the_path_node(managed_node_install, mon
     other.mkdir()
     _make_executable(other, "npm")
     _make_executable(other, "npx")
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     configured = f"{good}{os.pathsep}{other}"
     assert node_runtime.path_with_managed_node(configured) == configured
 
@@ -543,11 +544,11 @@ def test_npm_below_installer_floor_falls_back_to_managed(
 ):
     """Node clears its floor but npm is 10, which is why setup installed the managed one."""
     sysbin = _system_node_dir(tmp_path)
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     monkeypatch.setattr(
         node_runtime,
         "_npm_version_ok",
-        lambda executable, path=None: not str(executable).startswith(str(sysbin)),
+        lambda executable, path = None: not str(executable).startswith(str(sysbin)),
     )
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
@@ -570,9 +571,9 @@ def _node_only_dir(tmp_path):
 
 def test_direct_node_server_keeps_a_node_only_path(managed_node_install, monkeypatch, tmp_path):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     unchanged = node_runtime.path_with_managed_node(
-        str(nodeonly), require_npm=False, require_npx=False
+        str(nodeonly), require_npm = False, require_npx = False
     )
     assert unchanged == str(nodeonly)
 
@@ -582,10 +583,10 @@ def test_npx_server_still_needs_npx_on_a_node_only_path(
 ):
     """node alone cannot launch an ``npx`` server, so the managed dir still goes on."""
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     expected = f"{managed_node_install}{os.pathsep}{nodeonly}"
     assert (
-        node_runtime.path_with_managed_node(str(nodeonly), require_npm=False, require_npx=True)
+        node_runtime.path_with_managed_node(str(nodeonly), require_npm = False, require_npx = True)
         == expected
     )
 
@@ -599,7 +600,7 @@ def test_npx_server_keeps_a_path_with_npx_but_no_npm(managed_node_install, monke
     curated.mkdir()
     _make_executable(curated, "node")
     _make_executable(curated, "npx")
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(curated))
     assert mcp_client._stdio_env(None, "npx")["PATH"] == str(curated)
     assert mcp_client._stdio_argv(["npx", "-y", "server"], {"PATH": str(curated)})[0].startswith(
@@ -614,17 +615,17 @@ def test_npx_only_path_is_still_held_to_the_npm_floor(managed_node_install, monk
     curated.mkdir()
     _make_executable(curated, "node")
     _make_executable(curated, "npx")
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path=None: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     probed = []
 
-    def _npm_floor(executable, path=None):
+    def _npm_floor(executable, path = None):
         probed.append(str(executable))
         return False  # the bundled npm is below the installers' floor
 
     monkeypatch.setattr(node_runtime, "_npm_version_ok", _npm_floor)
     expected = f"{managed_node_install}{os.pathsep}{curated}"
     assert (
-        node_runtime.path_with_managed_node(str(curated), require_npm=False, require_npx=True)
+        node_runtime.path_with_managed_node(str(curated), require_npm = False, require_npx = True)
         == expected
     )
     assert any(os.path.basename(p).startswith("npx") for p in probed), probed
@@ -634,7 +635,7 @@ def test_stdio_env_does_not_shadow_node_for_a_direct_node_server(
     managed_node_install, monkeypatch, tmp_path
 ):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(nodeonly))
     assert mcp_client._stdio_env(None, "node")["PATH"] == str(nodeonly)
 
@@ -643,7 +644,7 @@ def test_stdio_env_still_augments_for_npx_on_a_node_only_path(
     managed_node_install, monkeypatch, tmp_path
 ):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(nodeonly))
     env = mcp_client._stdio_env(None, "npx")
     assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nodeonly}"
@@ -693,7 +694,7 @@ def test_direct_npm_server_does_not_need_npx(managed_node_install, monkeypatch, 
     nonpx.mkdir()
     _make_executable(nonpx, "node")
     _make_executable(nonpx, "npm")
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(nonpx))
     assert mcp_client._stdio_env(None, "npm")["PATH"] == str(nonpx)
 
@@ -705,13 +706,13 @@ def test_npx_server_on_the_same_path_still_gets_managed(
     nonpx.mkdir()
     _make_executable(nonpx, "node")
     _make_executable(nonpx, "npm")
-    _patch_floors(monkeypatch, lambda executable, path=None: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(nonpx))
     env = mcp_client._stdio_env(None, "npx")
     assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nonpx}"
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX shebang launcher")
+@pytest.mark.skipif(os.name == "nt", reason = "POSIX shebang launcher")
 def test_npm_probe_runs_with_the_candidate_path(managed_node_install, monkeypatch, tmp_path):
     """npm is a `#!/usr/bin/env node` script, so the probe needs the candidate's node."""
     toolchain = tmp_path / "toolchain"
@@ -743,18 +744,18 @@ def test_windows_npm_sibling_runtime_is_validated(managed_node_install, monkeypa
     monkeypatch.setattr(node_runtime, "_IS_WINDOWS", True)
     checked = []
 
-    def _record(executable, path=None):
+    def _record(executable, path = None):
         checked.append(str(executable))
         return not str(executable).startswith(str(old))
 
     _patch_floors(monkeypatch, lambda executable: _record(executable))
     configured = f"{good}{os.pathsep}{old}"
-    result = node_runtime.path_with_managed_node(configured, require_npm=True, require_npx=False)
+    result = node_runtime.path_with_managed_node(configured, require_npm = True, require_npx = False)
     assert any(c.endswith("node.exe") for c in checked), checked
     assert result == f"{managed_node_install}{os.pathsep}{configured}"
 
 
-def _good_node_only(tmp_path, name="toolchain"):
+def _good_node_only(tmp_path, name = "toolchain"):
     d = tmp_path / name
     d.mkdir()
     _make_executable(d, "node")

--- a/studio/backend/tests/test_mcp_stdio_real_server.py
+++ b/studio/backend/tests/test_mcp_stdio_real_server.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -144,4 +145,25 @@ def test_stdio_arguments_survive_real_crud_import_probe_and_launch(tmp_path, mon
     ) == {
         "arguments": imported_arguments,
         "marker": "import value",
+    }
+
+
+@pytest.mark.skipif(os.name != "nt", reason = "requires Windows batch launch semantics")
+@pytest.mark.timeout(45)
+def test_safe_arguments_survive_a_real_windows_batch_launcher(tmp_path, monkeypatch):
+    _reset_db(tmp_path, monkeypatch)
+    launcher = tmp_path / "mcp-server-example.cmd"
+    launcher.write_text(
+        f'@echo off\r\n"{sys.executable}" "{FIXTURE}" %*\r\n',
+        encoding = "utf-8",
+    )
+    arguments = ["--port", "3000", r"C:\Users\me\data", "a b", ""]
+    url = routes_mcp.encode_stdio_command(
+        McpStdioCommand(command = str(launcher), arguments = arguments),
+        current_subject = "u",
+    ).url
+
+    assert _launched_state(url, {"UNSLOTH_MCP_ARGUMENT_MARKER": "batch"}) == {
+        "arguments": arguments,
+        "marker": "batch",
     }

--- a/studio/backend/tests/test_mcp_stdio_real_server.py
+++ b/studio/backend/tests/test_mcp_stdio_real_server.py
@@ -157,7 +157,14 @@ def test_safe_arguments_survive_a_real_windows_batch_launcher(tmp_path, monkeypa
         f'@echo off\r\n"{sys.executable}" "{FIXTURE}" %*\r\n',
         encoding = "utf-8",
     )
-    arguments = ["--port", "3000", r"C:\Users\me\data", "a b", ""]
+    arguments = [
+        "--port",
+        "3000",
+        r"C:\Users\me\data",
+        r"C:\Program Files (x86)\mcp data",
+        "a & b",
+        "",
+    ]
     url = routes_mcp.encode_stdio_command(
         McpStdioCommand(command = str(launcher), arguments = arguments),
         current_subject = "u",

--- a/studio/backend/tests/test_mcp_stdio_real_server.py
+++ b/studio/backend/tests/test_mcp_stdio_real_server.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.inference import mcp_client
+from models.mcp_servers import (
+    McpServerCreate,
+    McpServerImportRequest,
+    McpServerTestRequest,
+    McpServerUpdate,
+    McpStdioCommand,
+    McpStdioDecodeRequest,
+)
+from routes import mcp_servers as routes_mcp
+from storage import mcp_servers_db
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "mcp_argument_echo_server.py"
+
+
+def _reset_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path))
+    monkeypatch.setenv("UNSLOTH_STUDIO_ALLOW_STDIO_MCP", "1")
+    monkeypatch.setattr(mcp_servers_db, "_schema_ready", False)
+
+
+def _encode(arguments: list[str]) -> str:
+    return routes_mcp.encode_stdio_command(
+        McpStdioCommand(command = sys.executable, arguments = [str(FIXTURE), *arguments]),
+        current_subject = "u",
+    ).url
+
+
+def _launched_state(url: str, environment: dict[str, str]) -> dict:
+    output = mcp_client.call_tool_sync(
+        url,
+        environment,
+        "launch_state",
+        {},
+        timeout = 20,
+    )
+    assert not output.startswith("Error:"), output
+    return json.loads(output)
+
+
+@pytest.mark.timeout(90)
+def test_stdio_arguments_survive_real_crud_import_probe_and_launch(tmp_path, monkeypatch):
+    _reset_db(tmp_path, monkeypatch)
+    original_arguments = [
+        "--flag",
+        "",
+        "a b",
+        'quote"inside',
+        "single'quote",
+        "trailing\\",
+        "https://example.com/value?q=a%20b",
+        "  keep outer spaces  ",
+    ]
+    environment = {"UNSLOTH_MCP_ARGUMENT_MARKER": "create value"}
+    encoded = _encode(original_arguments)
+
+    probe = asyncio.run(
+        routes_mcp.test_mcp_server(
+            McpServerTestRequest(url = encoded, headers = environment),
+            current_subject = "u",
+        )
+    )
+    assert (probe.ok, probe.tool_count, probe.error) == (True, 1, None)
+
+    created = asyncio.run(
+        routes_mcp.create_mcp_server(
+            McpServerCreate(
+                display_name = "argument echo",
+                url = encoded,
+                headers = environment,
+            ),
+            current_subject = "u",
+        )
+    )
+    persisted = mcp_servers_db.get_server(created.id)
+    assert persisted["url"] == encoded
+    assert json.loads(persisted["headers_json"]) == environment
+
+    listed = routes_mcp.list_mcp_servers(current_subject = "u")
+    assert [row.id for row in listed] == [created.id]
+    decoded = routes_mcp.decode_stdio_command(
+        McpStdioDecodeRequest(url = listed[0].url), current_subject = "u"
+    )
+    assert decoded.command == sys.executable
+    assert decoded.arguments == [str(FIXTURE), *original_arguments]
+    assert _launched_state(persisted["url"], environment) == {
+        "arguments": original_arguments,
+        "marker": "create value",
+    }
+
+    edited_arguments = ["second", "", "first", "a&b", "x|y", "%TOKEN%"]
+    edited_environment = {"UNSLOTH_MCP_ARGUMENT_MARKER": "edited value"}
+    edited_url = _encode(edited_arguments)
+    updated = asyncio.run(
+        routes_mcp.update_mcp_server(
+            created.id,
+            McpServerUpdate(url = edited_url, headers = edited_environment),
+            current_subject = "u",
+        )
+    )
+    assert updated.url == edited_url
+    refreshed = asyncio.run(routes_mcp.refresh_mcp_server_tools(created.id, current_subject = "u"))
+    assert (refreshed.ok, refreshed.tool_count) == (True, 1)
+    assert _launched_state(updated.url, edited_environment) == {
+        "arguments": edited_arguments,
+        "marker": "edited value",
+    }
+
+    imported_arguments = ["imported", "", "with spaces", 'say "hello"']
+    imported = asyncio.run(
+        routes_mcp.import_mcp_servers(
+            McpServerImportRequest(
+                config = {
+                    "mcpServers": {
+                        "imported echo": {
+                            "command": sys.executable,
+                            "args": [str(FIXTURE), *imported_arguments],
+                            "env": {"UNSLOTH_MCP_ARGUMENT_MARKER": "import value"},
+                        }
+                    }
+                }
+            ),
+            current_subject = "u",
+        )
+    )
+    assert imported.errors == []
+    assert imported.skipped == []
+    assert len(imported.created) == 1
+    imported_row = mcp_servers_db.get_server(imported.created[0].id)
+    assert _launched_state(
+        imported_row["url"],
+        mcp_client.parse_server_headers(imported_row),
+    ) == {
+        "arguments": imported_arguments,
+        "marker": "import value",
+    }

--- a/studio/frontend/src/features/chat/api/mcp-server-mutation-tracker.ts
+++ b/studio/frontend/src/features/chat/api/mcp-server-mutation-tracker.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+const pendingMcpServerMutations = new Set<Promise<void>>();
+const mutationSettlementListeners = new Set<(epoch: number) => void>();
+let mcpServerMutationEpoch = 0;
+
+export function subscribeToMcpServerMutationSettlements(
+  listener: (epoch: number) => void,
+): () => void {
+  mutationSettlementListeners.add(listener);
+  return () => mutationSettlementListeners.delete(listener);
+}
+
+export function trackMcpServerMutation<T>(mutation: Promise<T>): Promise<T> {
+  // The returned operation keeps its original result/rejection for its caller.
+  // The internal settlement promise always fulfills so background waiters never
+  // create an additional unhandled rejection when a component unmounts.
+  mcpServerMutationEpoch += 1;
+  const settlement = mutation.then(
+    () => undefined,
+    () => undefined,
+  );
+  pendingMcpServerMutations.add(settlement);
+  void settlement.then(() => {
+    pendingMcpServerMutations.delete(settlement);
+    mcpServerMutationEpoch += 1;
+    if (pendingMcpServerMutations.size !== 0) return;
+
+    const settledEpoch = mcpServerMutationEpoch;
+    for (const listener of [...mutationSettlementListeners]) {
+      try {
+        listener(settledEpoch);
+      } catch {
+        // Observers must not change caller promise semantics or block siblings.
+      }
+    }
+  });
+  return mutation;
+}
+
+export async function waitForPendingMcpServerMutations(): Promise<void> {
+  // A mutation may begin while an earlier batch is settling. Re-snapshot until
+  // the module-level set is empty so an open-time refresh cannot miss it.
+  while (pendingMcpServerMutations.size > 0) {
+    await Promise.all([...pendingMcpServerMutations]);
+  }
+}
+
+export async function readAfterPendingMcpServerMutations<T>(
+  read: () => Promise<T>,
+): Promise<T> {
+  while (true) {
+    await waitForPendingMcpServerMutations();
+    const epochBeforeRead = mcpServerMutationEpoch;
+    let result: T;
+    try {
+      result = await read();
+    } catch (error) {
+      await waitForPendingMcpServerMutations();
+      if (mcpServerMutationEpoch !== epochBeforeRead) continue;
+      throw error;
+    }
+    await waitForPendingMcpServerMutations();
+    if (mcpServerMutationEpoch === epochBeforeRead) return result;
+  }
+}

--- a/studio/frontend/src/features/chat/api/mcp-server-mutation-tracker.ts
+++ b/studio/frontend/src/features/chat/api/mcp-server-mutation-tracker.ts
@@ -5,6 +5,10 @@ const pendingMcpServerMutations = new Set<Promise<void>>();
 const mutationSettlementListeners = new Set<(epoch: number) => void>();
 let mcpServerMutationEpoch = 0;
 
+export function getMcpServerMutationEpoch(): number {
+  return mcpServerMutationEpoch;
+}
+
 export function subscribeToMcpServerMutationSettlements(
   listener: (epoch: number) => void,
 ): () => void {
@@ -25,8 +29,6 @@ export function trackMcpServerMutation<T>(mutation: Promise<T>): Promise<T> {
   void settlement.then(() => {
     pendingMcpServerMutations.delete(settlement);
     mcpServerMutationEpoch += 1;
-    if (pendingMcpServerMutations.size !== 0) return;
-
     const settledEpoch = mcpServerMutationEpoch;
     for (const listener of [...mutationSettlementListeners]) {
       try {
@@ -37,6 +39,23 @@ export function trackMcpServerMutation<T>(mutation: Promise<T>): Promise<T> {
     }
   });
   return mutation;
+}
+
+export async function readMcpServerMutationSnapshot<T>(
+  read: () => Promise<T>,
+): Promise<T> {
+  // Settlement-driven consumers need the newest stable server snapshot even
+  // if an unrelated, older mutation is still pending. Retry only when a
+  // mutation starts or settles across the read itself.
+  while (true) {
+    const epochBeforeRead = mcpServerMutationEpoch;
+    try {
+      const result = await read();
+      if (mcpServerMutationEpoch === epochBeforeRead) return result;
+    } catch (error) {
+      if (mcpServerMutationEpoch === epochBeforeRead) throw error;
+    }
+  }
 }
 
 export async function waitForPendingMcpServerMutations(): Promise<void> {

--- a/studio/frontend/src/features/chat/api/mcp-servers-api.ts
+++ b/studio/frontend/src/features/chat/api/mcp-servers-api.ts
@@ -5,7 +5,9 @@ import { authFetch } from "@/features/auth";
 import { formatFastApiDetail } from "@/lib/format-fastapi-error";
 
 import {
+  getMcpServerMutationEpoch,
   readAfterPendingMcpServerMutations,
+  readMcpServerMutationSnapshot,
   trackMcpServerMutation,
 } from "./mcp-server-mutation-tracker";
 
@@ -38,6 +40,10 @@ export interface McpStdioCommand {
 }
 
 let mcpServerListRequest: Promise<McpServerConfig[]> | null = null;
+let mcpServerSettlementListRequest: {
+  minimumEpoch: number;
+  promise: Promise<McpServerConfig[]>;
+} | null = null;
 
 function parseErrorText(status: number, body: unknown): string {
   if (body && typeof body === "object") {
@@ -65,7 +71,41 @@ async function mcpRequest<T>(
   return json as T;
 }
 
-export function listMcpServers(): Promise<McpServerConfig[]> {
+export function listMcpServers({
+  waitForPendingMutations = true,
+  minimumMutationEpoch,
+}: {
+  waitForPendingMutations?: boolean;
+  minimumMutationEpoch?: number;
+} = {}): Promise<McpServerConfig[]> {
+  if (!waitForPendingMutations) {
+    const requestedEpoch = minimumMutationEpoch ?? getMcpServerMutationEpoch();
+    if (
+      mcpServerSettlementListRequest &&
+      mcpServerSettlementListRequest.minimumEpoch >= requestedEpoch
+    ) {
+      return mcpServerSettlementListRequest.promise;
+    }
+    const request = readMcpServerMutationSnapshot(() =>
+      mcpRequest<McpServerConfig[]>("/"),
+    );
+    const slot = { minimumEpoch: requestedEpoch, promise: request };
+    mcpServerSettlementListRequest = slot;
+    void request.then(
+      () => {
+        if (mcpServerSettlementListRequest === slot) {
+          mcpServerSettlementListRequest = null;
+        }
+      },
+      () => {
+        if (mcpServerSettlementListRequest === slot) {
+          mcpServerSettlementListRequest = null;
+        }
+      },
+    );
+    return request;
+  }
+
   if (mcpServerListRequest) return mcpServerListRequest;
 
   const request = readAfterPendingMcpServerMutations(() =>
@@ -116,7 +156,8 @@ export function updateMcpServer(
   },
 ): Promise<McpServerConfig> {
   const body: Record<string, unknown> = {};
-  if (payload.displayName !== undefined) body.display_name = payload.displayName;
+  if (payload.displayName !== undefined)
+    body.display_name = payload.displayName;
   if (payload.url !== undefined) body.url = payload.url;
   if (payload.headers !== undefined) body.headers = payload.headers;
   if (payload.isEnabled !== undefined) body.is_enabled = payload.isEnabled;

--- a/studio/frontend/src/features/chat/api/mcp-servers-api.ts
+++ b/studio/frontend/src/features/chat/api/mcp-servers-api.ts
@@ -4,6 +4,11 @@
 import { authFetch } from "@/features/auth";
 import { formatFastApiDetail } from "@/lib/format-fastapi-error";
 
+import {
+  readAfterPendingMcpServerMutations,
+  trackMcpServerMutation,
+} from "./mcp-server-mutation-tracker";
+
 export interface McpServerConfig {
   id: string;
   display_name: string;
@@ -26,6 +31,13 @@ export interface McpServerImportResult {
   skipped: string[];
   errors: string[];
 }
+
+export interface McpStdioCommand {
+  command: string;
+  arguments: string[];
+}
+
+let mcpServerListRequest: Promise<McpServerConfig[]> | null = null;
 
 function parseErrorText(status: number, body: unknown): string {
   if (body && typeof body === "object") {
@@ -54,7 +66,21 @@ async function mcpRequest<T>(
 }
 
 export function listMcpServers(): Promise<McpServerConfig[]> {
-  return mcpRequest("/");
+  if (mcpServerListRequest) return mcpServerListRequest;
+
+  const request = readAfterPendingMcpServerMutations(() =>
+    mcpRequest<McpServerConfig[]>("/"),
+  );
+  mcpServerListRequest = request;
+  void request.then(
+    () => {
+      if (mcpServerListRequest === request) mcpServerListRequest = null;
+    },
+    () => {
+      if (mcpServerListRequest === request) mcpServerListRequest = null;
+    },
+  );
+  return request;
 }
 
 export function createMcpServer(payload: {
@@ -64,16 +90,18 @@ export function createMcpServer(payload: {
   isEnabled?: boolean;
   useOauth?: boolean;
 }): Promise<McpServerConfig> {
-  return mcpRequest("/", {
-    method: "POST",
-    body: {
-      display_name: payload.displayName,
-      url: payload.url,
-      headers: payload.headers ?? null,
-      is_enabled: payload.isEnabled ?? true,
-      use_oauth: payload.useOauth ?? false,
-    },
-  });
+  return trackMcpServerMutation(
+    mcpRequest("/", {
+      method: "POST",
+      body: {
+        display_name: payload.displayName,
+        url: payload.url,
+        headers: payload.headers ?? null,
+        is_enabled: payload.isEnabled ?? true,
+        use_oauth: payload.useOauth ?? false,
+      },
+    }),
+  );
 }
 
 export function updateMcpServer(
@@ -93,11 +121,15 @@ export function updateMcpServer(
   if (payload.headers !== undefined) body.headers = payload.headers;
   if (payload.isEnabled !== undefined) body.is_enabled = payload.isEnabled;
   if (payload.useOauth !== undefined) body.use_oauth = payload.useOauth;
-  return mcpRequest(`/${serverId}`, { method: "PUT", body });
+  return trackMcpServerMutation(
+    mcpRequest(`/${serverId}`, { method: "PUT", body }),
+  );
 }
 
 export function deleteMcpServer(serverId: string): Promise<void> {
-  return mcpRequest(`/${serverId}`, { method: "DELETE" });
+  return trackMcpServerMutation(
+    mcpRequest(`/${serverId}`, { method: "DELETE" }),
+  );
 }
 
 export function refreshMcpServerTools(
@@ -121,11 +153,29 @@ export function testMcpServer(payload: {
   });
 }
 
+export function decodeMcpStdioCommand(url: string): Promise<McpStdioCommand> {
+  return mcpRequest("/stdio/decode", {
+    method: "POST",
+    body: { url },
+  });
+}
+
+export function encodeMcpStdioCommand(payload: McpStdioCommand): Promise<{
+  url: string;
+}> {
+  return mcpRequest("/stdio/encode", {
+    method: "POST",
+    body: payload,
+  });
+}
+
 // Bulk-import servers from a standard mcpServers JSON config (Claude Desktop,
 // Cursor, Cline, VS Code). The backend skips duplicates and reports per-entry
 // errors instead of failing the whole batch.
 export function importMcpServers(
   config: unknown,
 ): Promise<McpServerImportResult> {
-  return mcpRequest("/import", { method: "POST", body: { config } });
+  return trackMcpServerMutation(
+    mcpRequest("/import", { method: "POST", body: { config } }),
+  );
 }

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -2,6 +2,13 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import {
+  Delete02Icon,
+  Edit03Icon,
+  PlusSignIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { RefreshCwIcon, UploadIcon } from "lucide-react";
+import {
   type ChangeEvent,
   useCallback,
   useEffect,
@@ -9,13 +16,6 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
-import {
-  Delete02Icon,
-  Edit03Icon,
-  PlusSignIcon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { RefreshCwIcon, UploadIcon } from "lucide-react";
 
 import {
   AlertDialog,
@@ -39,6 +39,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { subscribeToMcpServerMutationSettlements } from "./api/mcp-server-mutation-tracker";
 import {
   type McpServerConfig,
   createMcpServer,
@@ -51,7 +52,6 @@ import {
   testMcpServer,
   updateMcpServer,
 } from "./api/mcp-servers-api";
-import { subscribeToMcpServerMutationSettlements } from "./api/mcp-server-mutation-tracker";
 import {
   type McpStdioSnapshot,
   createMcpStdioSnapshot,
@@ -181,7 +181,7 @@ function ArgumentsEditor({
           {rows.map((row, index) => (
             <div key={row.id} className="flex items-center gap-2">
               <Input
-                data-reload-snapshot-sensitive
+                data-reload-snapshot-sensitive={true}
                 value={row.value}
                 disabled={disabled}
                 aria-label={`Argument ${index + 1}`}
@@ -276,7 +276,7 @@ function HeadersEditor({
                 onChange={(e) => update(row.id, { key: e.target.value })}
               />
               <Input
-                data-reload-snapshot-sensitive
+                data-reload-snapshot-sensitive={true}
                 value={row.value}
                 disabled={disabled}
                 placeholder={copy.valuePlaceholder}
@@ -306,7 +306,9 @@ export interface ChatMcpServersDialogProps {
 }
 
 type View =
-  { kind: "list" } | { kind: "create" } | { kind: "edit"; id: string };
+  | { kind: "list" }
+  | { kind: "create" }
+  | { kind: "edit"; id: string };
 
 export function ChatMcpServersDialog({
   open,
@@ -326,13 +328,18 @@ export function ChatMcpServersDialog({
     useState<McpServerConfig | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const formGenerationRef = useRef(0);
+  const actionGenerationRef = useRef(0);
   const activeEditIdRef = useRef<string | null>(null);
   const listRefreshGenerationRef = useRef(0);
+  const openRef = useRef(open);
+  openRef.current = open;
 
   useEffect(() => {
     return () => {
       formGenerationRef.current += 1;
+      actionGenerationRef.current += 1;
       activeEditIdRef.current = null;
+      openRef.current = false;
     };
   }, []);
 
@@ -346,21 +353,28 @@ export function ChatMcpServersDialog({
           waitForPendingMutations,
           minimumMutationEpoch,
         });
-        if (listRefreshGenerationRef.current !== generation) return;
+        if (listRefreshGenerationRef.current !== generation || !openRef.current)
+          return;
         setServers(rows);
       } catch (err) {
-        if (listRefreshGenerationRef.current !== generation) return;
+        if (listRefreshGenerationRef.current !== generation || !openRef.current)
+          return;
         toast.error("Failed to load MCP servers", {
           description: err instanceof Error ? err.message : String(err),
         });
       } finally {
-        if (listRefreshGenerationRef.current === generation) setLoading(false);
+        if (listRefreshGenerationRef.current === generation && openRef.current)
+          setLoading(false);
       }
     },
     [],
   );
 
   useEffect(() => {
+    if (!open) {
+      listRefreshGenerationRef.current += 1;
+      return;
+    }
     const unsubscribe = subscribeToMcpServerMutationSettlements((epoch) => {
       void refresh(false, epoch);
     });
@@ -368,10 +382,11 @@ export function ChatMcpServersDialog({
       unsubscribe();
       listRefreshGenerationRef.current += 1;
     };
-  }, [refresh]);
+  }, [open, refresh]);
 
   useEffect(() => {
     formGenerationRef.current += 1;
+    actionGenerationRef.current += 1;
     activeEditIdRef.current = null;
     let cancelled = false;
     queueMicrotask(() => {
@@ -380,6 +395,8 @@ export function ChatMcpServersDialog({
       setTesting(false);
       setCodecPending(false);
       setCodecError(null);
+      setImporting(false);
+      setConfirmingDelete(null);
       if (!open) return;
       void refresh();
       // Reset to the list on each open, else a stale create/edit view persists.
@@ -485,11 +502,14 @@ export function ChatMcpServersDialog({
     if (!next && saving && !codecPending) return;
     if (!next) {
       formGenerationRef.current += 1;
+      actionGenerationRef.current += 1;
       activeEditIdRef.current = null;
       setSaving(false);
       setTesting(false);
       setCodecPending(false);
       setCodecError(null);
+      setImporting(false);
+      setConfirmingDelete(null);
     }
     onOpenChange(next);
   }
@@ -635,16 +655,22 @@ export function ChatMcpServersDialog({
     const file = e.target.files?.[0];
     e.target.value = ""; // let the user re-pick the same file later
     if (!file) return;
+    const generation = actionGenerationRef.current;
+    setImporting(true);
     let config: unknown;
     try {
       config = JSON.parse(await file.text());
     } catch {
-      toast.error("Invalid JSON file");
+      if (actionGenerationRef.current === generation && openRef.current)
+        toast.error("Invalid JSON file");
+      if (actionGenerationRef.current === generation) setImporting(false);
       return;
     }
-    setImporting(true);
+    if (actionGenerationRef.current !== generation || !openRef.current) return;
     try {
       const result = await importMcpServers(config);
+      if (actionGenerationRef.current !== generation || !openRef.current)
+        return;
       const parts = [`${result.created.length} added`];
       if (result.skipped.length) parts.push(`${result.skipped.length} skipped`);
       if (result.errors.length) {
@@ -665,18 +691,23 @@ export function ChatMcpServersDialog({
         toast.success(summary);
       }
     } catch (err) {
+      if (actionGenerationRef.current !== generation || !openRef.current)
+        return;
       toast.error("Import failed", {
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      setImporting(false);
+      if (actionGenerationRef.current === generation) setImporting(false);
     }
   }
 
   async function removeServer(server: McpServerConfig) {
+    const generation = actionGenerationRef.current;
     try {
       await deleteMcpServer(server.id);
     } catch (err) {
+      if (actionGenerationRef.current !== generation || !openRef.current)
+        return;
       toast.error("Delete failed", {
         description: err instanceof Error ? err.message : String(err),
       });
@@ -684,6 +715,7 @@ export function ChatMcpServersDialog({
   }
 
   async function toggleEnabled(server: McpServerConfig, next: boolean) {
+    const generation = actionGenerationRef.current;
     // Optimistic update so the switch doesn't snap back during the round-trip.
     setServers((rows) =>
       rows.map((row) =>
@@ -693,6 +725,8 @@ export function ChatMcpServersDialog({
     try {
       await updateMcpServer(server.id, { isEnabled: next });
     } catch (err) {
+      if (actionGenerationRef.current !== generation || !openRef.current)
+        return;
       setServers((rows) =>
         rows.map((row) =>
           row.id === server.id ? { ...row, is_enabled: !next } : row,
@@ -705,9 +739,12 @@ export function ChatMcpServersDialog({
   }
 
   async function refreshTools(server: McpServerConfig) {
+    const generation = actionGenerationRef.current;
     setRefreshingId(server.id);
     try {
       const result = await refreshMcpServerTools(server.id);
+      if (actionGenerationRef.current !== generation || !openRef.current)
+        return;
       if (result.ok) {
         toast.success(
           `Refreshed "${server.display_name}" (${result.tool_count} tool${result.tool_count === 1 ? "" : "s"})`,
@@ -718,16 +755,18 @@ export function ChatMcpServersDialog({
         });
       }
     } catch (err) {
+      if (actionGenerationRef.current !== generation || !openRef.current)
+        return;
       toast.error("Refresh failed", {
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      setRefreshingId(null);
+      if (actionGenerationRef.current === generation) setRefreshingId(null);
     }
   }
 
   const showForm = view.kind !== "list";
-  const formPending = codecPending || testing || saving;
+  const formPending = importing || codecPending || testing || saving;
   // A local stdio command uses env vars, not headers or OAuth.
   const addressIsCommand = form.transport === "stdio";
 
@@ -935,7 +974,7 @@ export function ChatMcpServersDialog({
                 {importing ? <Spinner /> : <UploadIcon size={14} />}
                 Import config
               </Button>
-              <Button size="sm" onClick={startCreate}>
+              <Button size="sm" onClick={startCreate} disabled={importing}>
                 <HugeiconsIcon icon={PlusSignIcon} size={14} />
                 Add server
               </Button>
@@ -968,6 +1007,7 @@ export function ChatMcpServersDialog({
                         checked={server.is_enabled}
                         onCheckedChange={(next) => toggleEnabled(server, next)}
                         aria-label="Enable server"
+                        disabled={importing}
                       />
                       <Button
                         type="button"
@@ -976,7 +1016,7 @@ export function ChatMcpServersDialog({
                         onClick={() => refreshTools(server)}
                         aria-label="Refresh tools"
                         title="Refresh tools from this server"
-                        disabled={refreshingId === server.id}
+                        disabled={importing || refreshingId === server.id}
                       >
                         {refreshingId === server.id ? (
                           <Spinner />
@@ -990,6 +1030,7 @@ export function ChatMcpServersDialog({
                         size="icon"
                         onClick={() => void startEdit(server)}
                         aria-label="Edit server"
+                        disabled={importing}
                       >
                         <HugeiconsIcon icon={Edit03Icon} size={14} />
                       </Button>
@@ -999,6 +1040,7 @@ export function ChatMcpServersDialog({
                         size="icon"
                         onClick={() => setConfirmingDelete(server)}
                         aria-label="Delete server"
+                        disabled={importing}
                       >
                         <HugeiconsIcon icon={Delete02Icon} size={14} />
                       </Button>
@@ -1011,7 +1053,7 @@ export function ChatMcpServersDialog({
         )}
       </DialogContent>
       <AlertDialog
-        open={confirmingDelete !== null}
+        open={open && confirmingDelete !== null}
         onOpenChange={(next) => {
           if (!next) setConfirmingDelete(null);
         }}

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -323,7 +323,12 @@ export function ChatMcpServersDialog({
   const [codecPending, setCodecPending] = useState(false);
   const [codecError, setCodecError] = useState<string | null>(null);
   const [importing, setImporting] = useState(false);
-  const [refreshingId, setRefreshingId] = useState<string | null>(null);
+  const [refreshingIds, setRefreshingIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [togglingIds, setTogglingIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const [confirmingDelete, setConfirmingDelete] =
     useState<McpServerConfig | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -332,6 +337,8 @@ export function ChatMcpServersDialog({
   const activeEditIdRef = useRef<string | null>(null);
   const listRefreshGenerationRef = useRef(0);
   const openRef = useRef(open);
+  const refreshingIdsRef = useRef(new Set<string>());
+  const togglingIdsRef = useRef(new Set<string>());
   openRef.current = open;
 
   useEffect(() => {
@@ -355,7 +362,17 @@ export function ChatMcpServersDialog({
         });
         if (listRefreshGenerationRef.current !== generation || !openRef.current)
           return;
-        setServers(rows);
+        setServers((current) =>
+          rows.map((row) => {
+            if (!togglingIdsRef.current.has(row.id)) return row;
+            const optimistic = current.find(
+              (candidate) => candidate.id === row.id,
+            );
+            return optimistic
+              ? { ...row, is_enabled: optimistic.is_enabled }
+              : row;
+          }),
+        );
       } catch (err) {
         if (listRefreshGenerationRef.current !== generation || !openRef.current)
           return;
@@ -397,6 +414,8 @@ export function ChatMcpServersDialog({
       setCodecError(null);
       setImporting(false);
       setConfirmingDelete(null);
+      setRefreshingIds(new Set(refreshingIdsRef.current));
+      setTogglingIds(new Set(togglingIdsRef.current));
       if (!open) return;
       void refresh();
       // Reset to the list on each open, else a stale create/edit view persists.
@@ -715,7 +734,10 @@ export function ChatMcpServersDialog({
   }
 
   async function toggleEnabled(server: McpServerConfig, next: boolean) {
+    if (togglingIdsRef.current.has(server.id)) return;
     const generation = actionGenerationRef.current;
+    togglingIdsRef.current.add(server.id);
+    setTogglingIds(new Set(togglingIdsRef.current));
     // Optimistic update so the switch doesn't snap back during the round-trip.
     setServers((rows) =>
       rows.map((row) =>
@@ -735,12 +757,17 @@ export function ChatMcpServersDialog({
       toast.error("Update failed", {
         description: err instanceof Error ? err.message : String(err),
       });
+    } finally {
+      togglingIdsRef.current.delete(server.id);
+      if (openRef.current) setTogglingIds(new Set(togglingIdsRef.current));
     }
   }
 
   async function refreshTools(server: McpServerConfig) {
+    if (refreshingIdsRef.current.has(server.id)) return;
     const generation = actionGenerationRef.current;
-    setRefreshingId(server.id);
+    refreshingIdsRef.current.add(server.id);
+    setRefreshingIds(new Set(refreshingIdsRef.current));
     try {
       const result = await refreshMcpServerTools(server.id);
       if (actionGenerationRef.current !== generation || !openRef.current)
@@ -761,7 +788,8 @@ export function ChatMcpServersDialog({
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      if (actionGenerationRef.current === generation) setRefreshingId(null);
+      refreshingIdsRef.current.delete(server.id);
+      if (openRef.current) setRefreshingIds(new Set(refreshingIdsRef.current));
     }
   }
 
@@ -1007,7 +1035,7 @@ export function ChatMcpServersDialog({
                         checked={server.is_enabled}
                         onCheckedChange={(next) => toggleEnabled(server, next)}
                         aria-label="Enable server"
-                        disabled={importing}
+                        disabled={importing || togglingIds.has(server.id)}
                       />
                       <Button
                         type="button"
@@ -1016,9 +1044,9 @@ export function ChatMcpServersDialog({
                         onClick={() => refreshTools(server)}
                         aria-label="Refresh tools"
                         title="Refresh tools from this server"
-                        disabled={importing || refreshingId === server.id}
+                        disabled={importing || refreshingIds.has(server.id)}
                       >
-                        {refreshingId === server.id ? (
+                        {refreshingIds.has(server.id) ? (
                           <Spinner />
                         ) : (
                           <RefreshCwIcon size={14} />
@@ -1030,7 +1058,7 @@ export function ChatMcpServersDialog({
                         size="icon"
                         onClick={() => void startEdit(server)}
                         aria-label="Edit server"
-                        disabled={importing}
+                        disabled={importing || togglingIds.has(server.id)}
                       >
                         <HugeiconsIcon icon={Edit03Icon} size={14} />
                       </Button>
@@ -1040,7 +1068,7 @@ export function ChatMcpServersDialog({
                         size="icon"
                         onClick={() => setConfirmingDelete(server)}
                         aria-label="Delete server"
-                        disabled={importing}
+                        disabled={importing || togglingIds.has(server.id)}
                       >
                         <HugeiconsIcon icon={Delete02Icon} size={14} />
                       </Button>

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -9,7 +9,11 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
-import { Delete02Icon, Edit03Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
+import {
+  Delete02Icon,
+  Edit03Icon,
+  PlusSignIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { RefreshCwIcon, UploadIcon } from "lucide-react";
 
@@ -97,7 +101,9 @@ function argumentsToStrings(rows: readonly ArgumentRow[]): string[] {
   return rows.map((row) => row.value);
 }
 
-function headersToObject(rows: HeaderRow[]): Record<string, string> | undefined {
+function headersToObject(
+  rows: HeaderRow[],
+): Record<string, string> | undefined {
   const out: Record<string, string> = {};
   for (const row of rows) {
     const key = row.key.trim();
@@ -147,8 +153,7 @@ function ArgumentsEditor({
   const update = (id: string, value: string) =>
     onChange(rows.map((row) => (row.id === id ? { ...row, value } : row)));
   const add = () => onChange([...rows, { id: newRowId(), value: "" }]);
-  const remove = (id: string) =>
-    onChange(rows.filter((row) => row.id !== id));
+  const remove = (id: string) => onChange(rows.filter((row) => row.id !== id));
 
   return (
     <div className="grid gap-2">
@@ -213,10 +218,8 @@ function HeadersEditor({
 }) {
   const update = (id: string, patch: Partial<HeaderRow>) =>
     onChange(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
-  const add = () =>
-    onChange([...rows, { id: newRowId(), key: "", value: "" }]);
-  const remove = (id: string) =>
-    onChange(rows.filter((row) => row.id !== id));
+  const add = () => onChange([...rows, { id: newRowId(), key: "", value: "" }]);
+  const remove = (id: string) => onChange(rows.filter((row) => row.id !== id));
 
   const copy = stdio
     ? {
@@ -255,8 +258,8 @@ function HeadersEditor({
             "Optional. Environment variables passed to the server process."
           ) : (
             <>
-              Optional. Add an <code>Authorization</code> header here for servers
-              that require auth.
+              Optional. Add an <code>Authorization</code> header here for
+              servers that require auth.
             </>
           )}
         </div>
@@ -301,9 +304,7 @@ export interface ChatMcpServersDialogProps {
 }
 
 type View =
-  | { kind: "list" }
-  | { kind: "create" }
-  | { kind: "edit"; id: string };
+  { kind: "list" } | { kind: "create" } | { kind: "edit"; id: string };
 
 export function ChatMcpServersDialog({
   open,
@@ -319,9 +320,8 @@ export function ChatMcpServersDialog({
   const [codecError, setCodecError] = useState<string | null>(null);
   const [importing, setImporting] = useState(false);
   const [refreshingId, setRefreshingId] = useState<string | null>(null);
-  const [confirmingDelete, setConfirmingDelete] = useState<McpServerConfig | null>(
-    null,
-  );
+  const [confirmingDelete, setConfirmingDelete] =
+    useState<McpServerConfig | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const formGenerationRef = useRef(0);
   const activeEditIdRef = useRef<string | null>(null);
@@ -334,27 +334,33 @@ export function ChatMcpServersDialog({
     };
   }, []);
 
-  const refresh = useCallback(async () => {
-    const generation = listRefreshGenerationRef.current + 1;
-    listRefreshGenerationRef.current = generation;
-    setLoading(true);
-    try {
-      const rows = await listMcpServers();
-      if (listRefreshGenerationRef.current !== generation) return;
-      setServers(rows);
-    } catch (err) {
-      if (listRefreshGenerationRef.current !== generation) return;
-      toast.error("Failed to load MCP servers", {
-        description: err instanceof Error ? err.message : String(err),
-      });
-    } finally {
-      if (listRefreshGenerationRef.current === generation) setLoading(false);
-    }
-  }, []);
+  const refresh = useCallback(
+    async (waitForPendingMutations = true, minimumMutationEpoch = 0) => {
+      const generation = listRefreshGenerationRef.current + 1;
+      listRefreshGenerationRef.current = generation;
+      setLoading(true);
+      try {
+        const rows = await listMcpServers({
+          waitForPendingMutations,
+          minimumMutationEpoch,
+        });
+        if (listRefreshGenerationRef.current !== generation) return;
+        setServers(rows);
+      } catch (err) {
+        if (listRefreshGenerationRef.current !== generation) return;
+        toast.error("Failed to load MCP servers", {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        if (listRefreshGenerationRef.current === generation) setLoading(false);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
-    const unsubscribe = subscribeToMcpServerMutationSettlements(() => {
-      void refresh();
+    const unsubscribe = subscribeToMcpServerMutationSettlements((epoch) => {
+      void refresh(false, epoch);
     });
     return () => {
       unsubscribe();
@@ -365,10 +371,14 @@ export function ChatMcpServersDialog({
   useEffect(() => {
     formGenerationRef.current += 1;
     activeEditIdRef.current = null;
-    if (!open) return;
     let cancelled = false;
     queueMicrotask(() => {
       if (cancelled) return;
+      setSaving(false);
+      setTesting(false);
+      setCodecPending(false);
+      setCodecError(null);
+      if (!open) return;
       void refresh();
       // Reset to the list on each open, else a stale create/edit view persists.
       setView({ kind: "list" });
@@ -593,6 +603,7 @@ export function ChatMcpServersDialog({
           headers: headers ?? null,
           useOauth: stdio ? false : form.useOauth,
         });
+        if (formGenerationRef.current !== generation) return;
         toast.success("MCP server updated");
       } else {
         await createMcpServer({
@@ -601,6 +612,7 @@ export function ChatMcpServersDialog({
           headers: headers,
           useOauth: stdio ? false : form.useOauth,
         });
+        if (formGenerationRef.current !== generation) return;
         toast.success("MCP server added");
       }
       if (formGenerationRef.current !== generation) return;
@@ -864,9 +876,7 @@ export function ChatMcpServersDialog({
                 size="sm"
                 onClick={testConnection}
                 disabled={
-                  formPending ||
-                  codecError !== null ||
-                  !form.url.trim()
+                  formPending || codecError !== null || !form.url.trim()
                 }
               >
                 {testing ? <Spinner /> : null}
@@ -882,9 +892,7 @@ export function ChatMcpServersDialog({
                 </Button>
                 <Button
                   onClick={submitForm}
-                  disabled={
-                    formPending || codecError !== null
-                  }
+                  disabled={formPending || codecError !== null}
                 >
                   {saving ? <Spinner /> : null}
                   {view.kind === "edit" ? "Save changes" : "Add server"}

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -142,6 +142,31 @@ function transportFromAddress(
   return "stdio";
 }
 
+function formWithAddress(
+  form: FormState,
+  url: string,
+  preservePartialHttp: boolean,
+): FormState {
+  const transport = transportFromAddress(
+    url,
+    preservePartialHttp ? form.credentialTransport : null,
+  );
+  const nextCredentialTransport =
+    transport === "unknown" ? form.credentialTransport : transport;
+  const transportChanged =
+    transport !== "unknown" &&
+    form.credentialTransport !== null &&
+    form.credentialTransport !== transport;
+  return {
+    ...form,
+    url,
+    transport,
+    headers: transportChanged ? [] : form.headers,
+    credentialTransport: nextCredentialTransport,
+    useOauth: transport === "stdio" ? false : form.useOauth,
+  };
+}
+
 function isValidAddress(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
@@ -543,9 +568,9 @@ export function ChatMcpServersDialog({
   }
 
   function handleOpenChange(next: boolean) {
-    // Encoding can still be cancelled; once CRUD is in flight, dismissal
-    // cannot undo it and must wait for the authoritative refresh.
-    if (!next && saving && !codecPending) return;
+    // once crud starts, dismissal must wait for the authoritative refresh
+    if (!next && ((saving && !codecPending) || busyIdsRef.current.size > 0))
+      return;
     if (!next) {
       formGenerationRef.current += 1;
       actionGenerationRef.current += 1;
@@ -579,7 +604,7 @@ export function ChatMcpServersDialog({
   }
 
   async function testConnection() {
-    if (!form.url.trim()) {
+    if (!form.url.trim() || form.transport === "unknown") {
       toast.error("Enter an http(s):// URL or a local command first");
       return;
     }
@@ -630,7 +655,7 @@ export function ChatMcpServersDialog({
       toast.error("Display name is required");
       return;
     }
-    if (!form.url.trim()) {
+    if (!form.url.trim() || form.transport === "unknown") {
       toast.error("URL or command is required");
       return;
     }
@@ -856,7 +881,7 @@ export function ChatMcpServersDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="max-w-2xl"
-        showCloseButton={!(saving && !codecPending)}
+        showCloseButton={!(saving && !codecPending) && busyIds.size === 0}
         aria-busy={decodingCommand}
       >
         <DialogHeader>
@@ -922,28 +947,14 @@ export function ChatMcpServersDialog({
                 onChange={(e) => {
                   const url = e.target.value;
                   setCodecError(null);
-                  setForm((prev) => {
-                    const transport = transportFromAddress(
-                      url,
-                      prev.credentialTransport,
-                    );
-                    const nextCredentialTransport =
-                      transport === "unknown"
-                        ? prev.credentialTransport
-                        : transport;
-                    const transportChanged =
-                      transport !== "unknown" &&
-                      prev.credentialTransport !== null &&
-                      prev.credentialTransport !== transport;
-                    return {
-                      ...prev,
-                      url,
-                      transport,
-                      headers: transportChanged ? [] : prev.headers,
-                      credentialTransport: nextCredentialTransport,
-                      useOauth: transport === "stdio" ? false : prev.useOauth,
-                    };
-                  });
+                  setForm((prev) => formWithAddress(prev, url, true));
+                }}
+                onBlur={() => {
+                  setForm((prev) =>
+                    prev.transport === "unknown" && prev.url.trim()
+                      ? formWithAddress(prev, prev.url, false)
+                      : prev,
+                  );
                 }}
                 placeholder={
                   addressIsCommand
@@ -1051,7 +1062,10 @@ export function ChatMcpServersDialog({
                 size="sm"
                 onClick={testConnection}
                 disabled={
-                  formPending || codecError !== null || !form.url.trim()
+                  formPending ||
+                  codecError !== null ||
+                  form.transport === "unknown" ||
+                  !form.url.trim()
                 }
               >
                 {testing ? <Spinner /> : null}
@@ -1067,7 +1081,11 @@ export function ChatMcpServersDialog({
                 </Button>
                 <Button
                   onClick={submitForm}
-                  disabled={formPending || codecError !== null}
+                  disabled={
+                    formPending ||
+                    codecError !== null ||
+                    form.transport === "unknown"
+                  }
                 >
                   {saving ? <Spinner /> : null}
                   {view.kind === "edit" ? "Save changes" : "Add server"}

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -327,6 +327,13 @@ export function ChatMcpServersDialog({
   const activeEditIdRef = useRef<string | null>(null);
   const listRefreshGenerationRef = useRef(0);
 
+  useEffect(() => {
+    return () => {
+      formGenerationRef.current += 1;
+      activeEditIdRef.current = null;
+    };
+  }, []);
+
   const refresh = useCallback(async () => {
     const generation = listRefreshGenerationRef.current + 1;
     listRefreshGenerationRef.current = generation;

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { type ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "sonner";
 import { Delete02Icon, Edit03Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -32,18 +38,31 @@ import { Switch } from "@/components/ui/switch";
 import {
   type McpServerConfig,
   createMcpServer,
+  decodeMcpStdioCommand,
   deleteMcpServer,
+  encodeMcpStdioCommand,
   importMcpServers,
   listMcpServers,
   refreshMcpServerTools,
   testMcpServer,
   updateMcpServer,
 } from "./api/mcp-servers-api";
+import { subscribeToMcpServerMutationSettlements } from "./api/mcp-server-mutation-tracker";
+import {
+  type McpStdioSnapshot,
+  createMcpStdioSnapshot,
+  resolveMcpStdioUrl,
+} from "./mcp-server-form";
 type HeaderRow = { id: string; key: string; value: string };
+type ArgumentRow = { id: string; value: string };
+type FormTransport = "unknown" | "http" | "stdio";
 
 type FormState = {
   displayName: string;
   url: string;
+  transport: FormTransport;
+  arguments: ArgumentRow[];
+  stdioSnapshot: McpStdioSnapshot | null;
   headers: HeaderRow[];
   useOauth: boolean;
 };
@@ -51,6 +70,9 @@ type FormState = {
 const EMPTY_FORM: FormState = {
   displayName: "",
   url: "",
+  transport: "unknown",
+  arguments: [],
+  stdioSnapshot: null,
   headers: [],
   useOauth: false,
 };
@@ -65,6 +87,14 @@ function headersFromObject(headers: Record<string, string>): HeaderRow[] {
     key: k,
     value: v,
   }));
+}
+
+function argumentsFromStrings(arguments_: readonly string[]): ArgumentRow[] {
+  return arguments_.map((value) => ({ id: newRowId(), value }));
+}
+
+function argumentsToStrings(rows: readonly ArgumentRow[]): string[] {
+  return rows.map((row) => row.value);
 }
 
 function headersToObject(rows: HeaderRow[]): Record<string, string> | undefined {
@@ -84,6 +114,11 @@ function isHttpAddress(value: string): boolean {
   return trimmed.startsWith("http://") || trimmed.startsWith("https://");
 }
 
+function transportFromAddress(value: string): FormTransport {
+  if (!value.trim()) return "unknown";
+  return isHttpAddress(value) ? "http" : "stdio";
+}
+
 function isValidAddress(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
@@ -95,21 +130,86 @@ function isValidAddress(value: string): boolean {
       return false;
     }
   }
-  // Otherwise it's a local command (stdio); the backend gates whether those
-  // are allowed. Reject only when the command itself is a URL; "://" is fine
-  // inside an argument (e.g. a DB connection string passed to the server).
-  return !trimmed.split(/\s+/)[0].includes("://");
+  // The backend owns stdio parsing and validation. In particular, the browser
+  // must not split an executable or duplicate platform-specific quoting rules.
+  return true;
+}
+
+function ArgumentsEditor({
+  rows,
+  onChange,
+  disabled,
+}: {
+  rows: ArgumentRow[];
+  onChange: (rows: ArgumentRow[]) => void;
+  disabled: boolean;
+}) {
+  const update = (id: string, value: string) =>
+    onChange(rows.map((row) => (row.id === id ? { ...row, value } : row)));
+  const add = () => onChange([...rows, { id: newRowId(), value: "" }]);
+  const remove = (id: string) =>
+    onChange(rows.filter((row) => row.id !== id));
+
+  return (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between">
+        <Label className="text-sm">Arguments</Label>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={add}
+          disabled={disabled}
+        >
+          <HugeiconsIcon icon={PlusSignIcon} size={14} />
+          Add argument
+        </Button>
+      </div>
+      {rows.length === 0 ? (
+        <div className="text-xs text-muted-foreground">
+          Optional. Each row is one argument; row order is preserved.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {rows.map((row, index) => (
+            <div key={row.id} className="flex items-center gap-2">
+              <Input
+                data-reload-snapshot-sensitive
+                value={row.value}
+                disabled={disabled}
+                aria-label={`Argument ${index + 1}`}
+                placeholder={index === 0 ? "e.g. -y" : undefined}
+                onChange={(event) => update(row.id, event.target.value)}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => remove(row.id)}
+                disabled={disabled}
+                aria-label={`Remove argument ${index + 1}`}
+              >
+                <HugeiconsIcon icon={Delete02Icon} size={14} />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 function HeadersEditor({
   rows,
   onChange,
   stdio,
+  disabled,
 }: {
   rows: HeaderRow[];
   onChange: (rows: HeaderRow[]) => void;
   // stdio servers reuse this editor for environment variables instead of headers.
   stdio: boolean;
+  disabled: boolean;
 }) {
   const update = (id: string, patch: Partial<HeaderRow>) =>
     onChange(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
@@ -138,7 +238,13 @@ function HeadersEditor({
     <>
       <div className="flex items-center justify-between">
         <Label className="text-sm">{copy.label}</Label>
-        <Button type="button" variant="ghost" size="sm" onClick={add}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={add}
+          disabled={disabled}
+        >
           <HugeiconsIcon icon={PlusSignIcon} size={14} />
           {copy.add}
         </Button>
@@ -160,12 +266,14 @@ function HeadersEditor({
             <div key={row.id} className="flex items-center gap-2">
               <Input
                 value={row.key}
+                disabled={disabled}
                 placeholder={copy.keyPlaceholder}
                 onChange={(e) => update(row.id, { key: e.target.value })}
               />
               <Input
                 data-reload-snapshot-sensitive
                 value={row.value}
+                disabled={disabled}
                 placeholder={copy.valuePlaceholder}
                 onChange={(e) => update(row.id, { value: e.target.value })}
               />
@@ -174,6 +282,7 @@ function HeadersEditor({
                 variant="ghost"
                 size="icon"
                 onClick={() => remove(row.id)}
+                disabled={disabled}
                 aria-label={copy.remove}
               >
                 <HugeiconsIcon icon={Delete02Icon} size={14} />
@@ -206,68 +315,210 @@ export function ChatMcpServersDialog({
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
+  const [codecPending, setCodecPending] = useState(false);
+  const [codecError, setCodecError] = useState<string | null>(null);
   const [importing, setImporting] = useState(false);
   const [refreshingId, setRefreshingId] = useState<string | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState<McpServerConfig | null>(
     null,
   );
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const formGenerationRef = useRef(0);
+  const activeEditIdRef = useRef<string | null>(null);
+  const listRefreshGenerationRef = useRef(0);
 
   const refresh = useCallback(async () => {
+    const generation = listRefreshGenerationRef.current + 1;
+    listRefreshGenerationRef.current = generation;
     setLoading(true);
     try {
       const rows = await listMcpServers();
+      if (listRefreshGenerationRef.current !== generation) return;
       setServers(rows);
     } catch (err) {
+      if (listRefreshGenerationRef.current !== generation) return;
       toast.error("Failed to load MCP servers", {
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      setLoading(false);
+      if (listRefreshGenerationRef.current === generation) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
+    const unsubscribe = subscribeToMcpServerMutationSettlements(() => {
+      void refresh();
+    });
+    return () => {
+      unsubscribe();
+      listRefreshGenerationRef.current += 1;
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    formGenerationRef.current += 1;
+    activeEditIdRef.current = null;
     if (!open) return;
-    refresh();
-    // Reset to the list on each open, else a stale create/edit view persists.
-    setView({ kind: "list" });
-    setForm(EMPTY_FORM);
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      void refresh();
+      // Reset to the list on each open, else a stale create/edit view persists.
+      setView({ kind: "list" });
+      setForm(EMPTY_FORM);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [open, refresh]);
 
   function startCreate() {
+    formGenerationRef.current += 1;
+    activeEditIdRef.current = null;
+    setSaving(false);
+    setTesting(false);
+    setCodecPending(false);
+    setCodecError(null);
     setView({ kind: "create" });
     setForm(EMPTY_FORM);
   }
 
-  function startEdit(server: McpServerConfig) {
+  async function startEdit(server: McpServerConfig) {
+    const generation = formGenerationRef.current + 1;
+    formGenerationRef.current = generation;
+    activeEditIdRef.current = server.id;
+    setSaving(false);
+    setTesting(false);
+    setCodecError(null);
     setView({ kind: "edit", id: server.id });
-    setForm({
+    const baseForm: FormState = {
       displayName: server.display_name,
       url: server.url,
+      transport: isHttpAddress(server.url) ? "http" : "stdio",
+      arguments: [],
+      stdioSnapshot: null,
       headers: headersFromObject(server.headers ?? {}),
       useOauth: server.use_oauth ?? false,
-    });
+    };
+
+    if (isHttpAddress(server.url)) {
+      setCodecPending(false);
+      setForm(baseForm);
+      return;
+    }
+
+    setCodecPending(true);
+    setForm({ ...baseForm, url: "" });
+    try {
+      const decoded = await decodeMcpStdioCommand(server.url);
+      if (
+        formGenerationRef.current !== generation ||
+        activeEditIdRef.current !== server.id
+      ) {
+        return;
+      }
+      setForm({
+        ...baseForm,
+        url: decoded.command,
+        arguments: argumentsFromStrings(decoded.arguments ?? []),
+        stdioSnapshot: createMcpStdioSnapshot(
+          server.url,
+          decoded.command,
+          decoded.arguments ?? [],
+        ),
+        useOauth: false,
+      });
+    } catch (err) {
+      if (
+        formGenerationRef.current !== generation ||
+        activeEditIdRef.current !== server.id
+      ) {
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      setCodecError(message);
+      toast.error("Failed to read local command", { description: message });
+    } finally {
+      if (
+        formGenerationRef.current === generation &&
+        activeEditIdRef.current === server.id
+      ) {
+        setCodecPending(false);
+      }
+    }
   }
 
   function cancelForm() {
+    formGenerationRef.current += 1;
+    activeEditIdRef.current = null;
+    setSaving(false);
+    setTesting(false);
+    setCodecPending(false);
+    setCodecError(null);
     setView({ kind: "list" });
     setForm(EMPTY_FORM);
   }
 
+  function handleOpenChange(next: boolean) {
+    // Encoding can still be cancelled; once CRUD is in flight, dismissal
+    // cannot undo it and must wait for the authoritative refresh.
+    if (!next && saving && !codecPending) return;
+    if (!next) {
+      formGenerationRef.current += 1;
+      activeEditIdRef.current = null;
+      setSaving(false);
+      setTesting(false);
+      setCodecPending(false);
+      setCodecError(null);
+    }
+    onOpenChange(next);
+  }
+
+  async function encodeStdioForGeneration(
+    generation: number,
+    command: string,
+    arguments_: string[],
+  ): Promise<string | null> {
+    setCodecPending(true);
+    try {
+      const encoded = await encodeMcpStdioCommand({
+        command,
+        arguments: arguments_,
+      });
+      if (formGenerationRef.current !== generation) return null;
+      return encoded.url;
+    } finally {
+      if (formGenerationRef.current === generation) setCodecPending(false);
+    }
+  }
+
   async function testConnection() {
-    const trimmedUrl = form.url.trim();
-    if (!isValidAddress(trimmedUrl)) {
+    if (!form.url.trim()) {
       toast.error("Enter an http(s):// URL or a local command first");
       return;
     }
+    const stdio = form.transport === "stdio";
+    if (!stdio && !isValidAddress(form.url)) {
+      toast.error("Enter an http(s):// URL or a local command first");
+      return;
+    }
+    const generation = formGenerationRef.current;
     setTesting(true);
     try {
+      const url = stdio
+        ? await encodeStdioForGeneration(
+            generation,
+            form.url,
+            argumentsToStrings(form.arguments),
+          )
+        : form.url.trim();
+      if (url === null || formGenerationRef.current !== generation) return;
       const result = await testMcpServer({
-        url: trimmedUrl,
+        url,
         headers: headersToObject(form.headers),
-        useOauth: form.useOauth,
+        useOauth: stdio ? false : form.useOauth,
       });
+      if (formGenerationRef.current !== generation) return;
       if (result.ok) {
         toast.success(
           `Connected (${result.tool_count} tool${result.tool_count === 1 ? "" : "s"})`,
@@ -278,57 +529,82 @@ export function ChatMcpServersDialog({
         });
       }
     } catch (err) {
+      if (formGenerationRef.current !== generation) return;
       toast.error("Connection test failed", {
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      setTesting(false);
+      if (formGenerationRef.current === generation) setTesting(false);
     }
   }
 
   async function submitForm() {
     const trimmedName = form.displayName.trim();
-    const trimmedUrl = form.url.trim();
     if (!trimmedName) {
       toast.error("Display name is required");
       return;
     }
-    if (!trimmedUrl) {
+    if (!form.url.trim()) {
       toast.error("URL or command is required");
       return;
     }
-    if (!isValidAddress(trimmedUrl)) {
+    const stdio = form.transport === "stdio";
+    if (!stdio && !isValidAddress(form.url)) {
       toast.error("Enter an http(s):// URL or a local command");
       return;
     }
+    const generation = formGenerationRef.current;
     setSaving(true);
     try {
       const headers = headersToObject(form.headers);
+      let url: string;
+      if (stdio) {
+        const decision = resolveMcpStdioUrl(
+          form.url,
+          argumentsToStrings(form.arguments),
+          form.stdioSnapshot,
+        );
+        if (decision.kind === "reuse") {
+          url = decision.url;
+        } else {
+          const encodedUrl = await encodeStdioForGeneration(
+            generation,
+            decision.command,
+            decision.arguments,
+          );
+          if (encodedUrl === null) return;
+          url = encodedUrl;
+        }
+      } else {
+        url = form.url.trim();
+      }
+      if (formGenerationRef.current !== generation) return;
       if (view.kind === "edit") {
         await updateMcpServer(view.id, {
           displayName: trimmedName,
-          url: trimmedUrl,
+          url,
           headers: headers ?? null,
-          useOauth: form.useOauth,
+          useOauth: stdio ? false : form.useOauth,
         });
         toast.success("MCP server updated");
       } else {
         await createMcpServer({
           displayName: trimmedName,
-          url: trimmedUrl,
+          url,
           headers: headers,
-          useOauth: form.useOauth,
+          useOauth: stdio ? false : form.useOauth,
         });
         toast.success("MCP server added");
       }
+      if (formGenerationRef.current !== generation) return;
       cancelForm();
-      await refresh();
     } catch (err) {
+      if (formGenerationRef.current !== generation) return;
       toast.error("Save failed", {
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      setSaving(false);
+      if (formGenerationRef.current === generation) setSaving(false);
     }
   }
 
@@ -365,7 +641,6 @@ export function ChatMcpServersDialog({
       } else {
         toast.success(summary);
       }
-      await refresh();
     } catch (err) {
       toast.error("Import failed", {
         description: err instanceof Error ? err.message : String(err),
@@ -378,7 +653,6 @@ export function ChatMcpServersDialog({
   async function removeServer(server: McpServerConfig) {
     try {
       await deleteMcpServer(server.id);
-      await refresh();
     } catch (err) {
       toast.error("Delete failed", {
         description: err instanceof Error ? err.message : String(err),
@@ -430,13 +704,16 @@ export function ChatMcpServersDialog({
   }
 
   const showForm = view.kind !== "list";
+  const formPending = codecPending || testing || saving;
   // A local stdio command uses env vars, not headers or OAuth.
-  const addressIsCommand =
-    form.url.trim() !== "" && !isHttpAddress(form.url);
+  const addressIsCommand = form.transport === "stdio";
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-w-2xl"
+        showCloseButton={!(saving && !codecPending)}
+      >
         <DialogHeader>
           <DialogTitle>MCP Servers</DialogTitle>
           <DialogDescription>
@@ -449,6 +726,7 @@ export function ChatMcpServersDialog({
           accept="application/json,.json"
           className="hidden"
           onChange={onImportFile}
+          disabled={importing || formPending}
         />
 
         {showForm ? (
@@ -464,7 +742,7 @@ export function ChatMcpServersDialog({
                   variant="outline"
                   className="shrink-0"
                   onClick={() => fileInputRef.current?.click()}
-                  disabled={importing}
+                  disabled={importing || formPending}
                   title="Import servers from a mcpServers JSON config (Claude Desktop, Cursor, VS Code…)"
                 >
                   {importing ? <Spinner /> : <UploadIcon size={14} />}
@@ -477,6 +755,7 @@ export function ChatMcpServersDialog({
               <Input
                 id="mcp-display-name"
                 value={form.displayName}
+                disabled={formPending}
                 onChange={(e) =>
                   setForm((prev) => ({ ...prev, displayName: e.target.value }))
                 }
@@ -484,20 +763,62 @@ export function ChatMcpServersDialog({
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="mcp-url">URL or command</Label>
+              <Label htmlFor="mcp-url">
+                {addressIsCommand
+                  ? "Executable"
+                  : form.transport === "http"
+                    ? "URL"
+                    : "URL or executable"}
+              </Label>
               <Input
                 id="mcp-url"
                 value={form.url}
-                onChange={(e) =>
-                  setForm((prev) => ({ ...prev, url: e.target.value }))
+                disabled={formPending}
+                onChange={(e) => {
+                  const url = e.target.value;
+                  setCodecError(null);
+                  setForm((prev) => ({
+                    ...prev,
+                    url,
+                    transport: transportFromAddress(url),
+                  }));
+                }}
+                placeholder={
+                  addressIsCommand
+                    ? "e.g. npx"
+                    : form.transport === "http"
+                      ? "https://example.com/mcp"
+                      : "https://example.com/mcp or npx"
                 }
-                placeholder="https://example.com/mcp or npx -y @modelcontextprotocol/server-filesystem /tmp"
               />
               <span className="text-xs text-muted-foreground">
-                An http(s) URL for a remote server, or a local command to run an
-                stdio server (local installs only).
+                {addressIsCommand
+                  ? "The executable for a local stdio server. Add each local argument in an Arguments row below."
+                  : form.transport === "http"
+                    ? "An http(s) URL for a remote server."
+                    : "An http(s) URL for a remote server, or an executable for local stdio. Add local arguments in the Arguments rows."}
               </span>
             </div>
+
+            {addressIsCommand && (
+              <ArgumentsEditor
+                rows={form.arguments}
+                disabled={formPending}
+                onChange={(arguments_) =>
+                  setForm((prev) => ({ ...prev, arguments: arguments_ }))
+                }
+              />
+            )}
+
+            {codecError && (
+              <div
+                role="alert"
+                aria-live="assertive"
+                className="text-sm text-destructive"
+              >
+                {codecError}
+              </div>
+            )}
 
             {!addressIsCommand && (
               <div className="flex items-start justify-between gap-3">
@@ -514,6 +835,7 @@ export function ChatMcpServersDialog({
                 <Switch
                   id="mcp-oauth"
                   checked={form.useOauth}
+                  disabled={formPending}
                   onCheckedChange={(useOauth) =>
                     setForm((prev) => ({ ...prev, useOauth }))
                   }
@@ -525,6 +847,7 @@ export function ChatMcpServersDialog({
               rows={form.headers}
               onChange={(headers) => setForm((prev) => ({ ...prev, headers }))}
               stdio={addressIsCommand}
+              disabled={formPending}
             />
 
             <div className="flex items-center justify-between gap-2 pt-2">
@@ -533,16 +856,29 @@ export function ChatMcpServersDialog({
                 variant="outline"
                 size="sm"
                 onClick={testConnection}
-                disabled={testing || saving || !form.url.trim()}
+                disabled={
+                  formPending ||
+                  codecError !== null ||
+                  !form.url.trim()
+                }
               >
                 {testing ? <Spinner /> : null}
                 Test connection
               </Button>
               <div className="flex gap-2">
-                <Button variant="ghost" onClick={cancelForm} disabled={saving}>
+                <Button
+                  variant="ghost"
+                  onClick={cancelForm}
+                  disabled={saving && !codecPending}
+                >
                   Cancel
                 </Button>
-                <Button onClick={submitForm} disabled={saving}>
+                <Button
+                  onClick={submitForm}
+                  disabled={
+                    formPending || codecError !== null
+                  }
+                >
                   {saving ? <Spinner /> : null}
                   {view.kind === "edit" ? "Save changes" : "Add server"}
                 </Button>
@@ -615,7 +951,7 @@ export function ChatMcpServersDialog({
                         type="button"
                         variant="ghost"
                         size="icon"
-                        onClick={() => startEdit(server)}
+                        onClick={() => void startEdit(server)}
                         aria-label="Edit server"
                       >
                         <HugeiconsIcon icon={Edit03Icon} size={14} />

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -68,6 +68,7 @@ type FormState = {
   arguments: ArgumentRow[];
   stdioSnapshot: McpStdioSnapshot | null;
   headers: HeaderRow[];
+  credentialTransport: Exclude<FormTransport, "unknown"> | null;
   useOauth: boolean;
 };
 
@@ -78,6 +79,7 @@ const EMPTY_FORM: FormState = {
   arguments: [],
   stdioSnapshot: null,
   headers: [],
+  credentialTransport: null,
   useOauth: false,
 };
 
@@ -415,6 +417,7 @@ export function ChatMcpServersDialog({
       arguments: [],
       stdioSnapshot: null,
       headers: headersFromObject(server.headers ?? {}),
+      credentialTransport: isHttpAddress(server.url) ? "http" : "stdio",
       useOauth: server.use_oauth ?? false,
     };
 
@@ -606,6 +609,7 @@ export function ChatMcpServersDialog({
         if (formGenerationRef.current !== generation) return;
         toast.success("MCP server updated");
       } else {
+        if (url === undefined) return;
         await createMcpServer({
           displayName: trimmedName,
           url,
@@ -795,12 +799,26 @@ export function ChatMcpServersDialog({
                 disabled={formPending}
                 onChange={(e) => {
                   const url = e.target.value;
+                  const transport = transportFromAddress(url);
                   setCodecError(null);
-                  setForm((prev) => ({
-                    ...prev,
-                    url,
-                    transport: transportFromAddress(url),
-                  }));
+                  setForm((prev) => {
+                    const nextCredentialTransport =
+                      transport === "unknown"
+                        ? prev.credentialTransport
+                        : transport;
+                    const transportChanged =
+                      transport !== "unknown" &&
+                      prev.credentialTransport !== null &&
+                      prev.credentialTransport !== transport;
+                    return {
+                      ...prev,
+                      url,
+                      transport,
+                      headers: transportChanged ? [] : prev.headers,
+                      credentialTransport: nextCredentialTransport,
+                      useOauth: transport === "stdio" ? false : prev.useOauth,
+                    };
+                  });
                 }}
                 placeholder={
                   addressIsCommand
@@ -839,7 +857,7 @@ export function ChatMcpServersDialog({
               </div>
             )}
 
-            {!addressIsCommand && (
+            {form.transport === "http" && (
               <div className="flex items-start justify-between gap-3">
                 <div className="flex flex-col gap-0.5">
                   <Label className="text-sm" htmlFor="mcp-oauth">
@@ -862,12 +880,16 @@ export function ChatMcpServersDialog({
               </div>
             )}
 
-            <HeadersEditor
-              rows={form.headers}
-              onChange={(headers) => setForm((prev) => ({ ...prev, headers }))}
-              stdio={addressIsCommand}
-              disabled={formPending}
-            />
+            {form.transport !== "unknown" && (
+              <HeadersEditor
+                rows={form.headers}
+                onChange={(headers) =>
+                  setForm((prev) => ({ ...prev, headers }))
+                }
+                stdio={addressIsCommand}
+                disabled={formPending}
+              />
+            )}
 
             <div className="flex items-center justify-between gap-2 pt-2">
               <Button

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -321,6 +321,7 @@ export function ChatMcpServersDialog({
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
   const [codecPending, setCodecPending] = useState(false);
+  const [decodingCommand, setDecodingCommand] = useState(false);
   const [codecError, setCodecError] = useState<string | null>(null);
   const [importing, setImporting] = useState(false);
   const [refreshingIds, setRefreshingIds] = useState<ReadonlySet<string>>(
@@ -411,6 +412,7 @@ export function ChatMcpServersDialog({
       setSaving(false);
       setTesting(false);
       setCodecPending(false);
+      setDecodingCommand(false);
       setCodecError(null);
       setImporting(false);
       setConfirmingDelete(null);
@@ -433,6 +435,7 @@ export function ChatMcpServersDialog({
     setSaving(false);
     setTesting(false);
     setCodecPending(false);
+    setDecodingCommand(false);
     setCodecError(null);
     setView({ kind: "create" });
     setForm(EMPTY_FORM);
@@ -459,11 +462,13 @@ export function ChatMcpServersDialog({
 
     if (isHttpAddress(server.url)) {
       setCodecPending(false);
+      setDecodingCommand(false);
       setForm(baseForm);
       return;
     }
 
     setCodecPending(true);
+    setDecodingCommand(true);
     setForm(baseForm);
     try {
       const decoded = await decodeMcpStdioCommand(server.url);
@@ -500,6 +505,7 @@ export function ChatMcpServersDialog({
         activeEditIdRef.current === server.id
       ) {
         setCodecPending(false);
+        setDecodingCommand(false);
       }
     }
   }
@@ -510,6 +516,7 @@ export function ChatMcpServersDialog({
     setSaving(false);
     setTesting(false);
     setCodecPending(false);
+    setDecodingCommand(false);
     setCodecError(null);
     setView({ kind: "list" });
     setForm(EMPTY_FORM);
@@ -526,6 +533,7 @@ export function ChatMcpServersDialog({
       setSaving(false);
       setTesting(false);
       setCodecPending(false);
+      setDecodingCommand(false);
       setCodecError(null);
       setImporting(false);
       setConfirmingDelete(null);
@@ -803,6 +811,7 @@ export function ChatMcpServersDialog({
       <DialogContent
         className="max-w-2xl"
         showCloseButton={!(saving && !codecPending)}
+        aria-busy={decodingCommand}
       >
         <DialogHeader>
           <DialogTitle>MCP Servers</DialogTitle>
@@ -902,6 +911,16 @@ export function ChatMcpServersDialog({
                     ? "An http(s) URL for a remote server."
                     : "An http(s) URL for a remote server, or an executable for local stdio. Add local arguments in the Arguments rows."}
               </span>
+              {decodingCommand && (
+                <span
+                  role="status"
+                  aria-live="polite"
+                  className="flex items-center gap-2 text-xs text-muted-foreground"
+                >
+                  <Spinner />
+                  Reading local command…
+                </span>
+              )}
             </div>
 
             {addressIsCommand && (
@@ -915,12 +934,30 @@ export function ChatMcpServersDialog({
             )}
 
             {codecError && (
-              <div
-                role="alert"
-                aria-live="assertive"
-                className="text-sm text-destructive"
-              >
-                {codecError}
+              <div className="flex items-center justify-between gap-3">
+                <div
+                  role="alert"
+                  aria-live="assertive"
+                  className="text-sm text-destructive"
+                >
+                  {codecError}
+                </div>
+                {view.kind === "edit" && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={formPending}
+                    onClick={() => {
+                      const server = servers.find(
+                        (candidate) => candidate.id === view.id,
+                      );
+                      if (server) void startEdit(server);
+                    }}
+                  >
+                    Retry
+                  </Button>
+                )}
               </div>
             )}
 

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -425,7 +425,7 @@ export function ChatMcpServersDialog({
     }
 
     setCodecPending(true);
-    setForm({ ...baseForm, url: "" });
+    setForm(baseForm);
     try {
       const decoded = await decodeMcpStdioCommand(server.url);
       if (
@@ -574,7 +574,7 @@ export function ChatMcpServersDialog({
     setSaving(true);
     try {
       const headers = headersToObject(form.headers);
-      let url: string;
+      let url: string | undefined;
       if (stdio) {
         const decision = resolveMcpStdioUrl(
           form.url,
@@ -582,7 +582,7 @@ export function ChatMcpServersDialog({
           form.stdioSnapshot,
         );
         if (decision.kind === "reuse") {
-          url = decision.url;
+          url = view.kind === "edit" ? undefined : decision.url;
         } else {
           const encodedUrl = await encodeStdioForGeneration(
             generation,

--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -122,9 +122,24 @@ function isHttpAddress(value: string): boolean {
   return trimmed.startsWith("http://") || trimmed.startsWith("https://");
 }
 
-function transportFromAddress(value: string): FormTransport {
-  if (!value.trim()) return "unknown";
-  return isHttpAddress(value) ? "http" : "stdio";
+function transportFromAddress(
+  value: string,
+  credentialTransport: FormState["credentialTransport"] = null,
+): FormTransport {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return "unknown";
+  }
+  if (isHttpAddress(value)) {
+    return "http";
+  }
+  if (
+    credentialTransport === "http" &&
+    ("http://".startsWith(trimmed) || "https://".startsWith(trimmed))
+  ) {
+    return "unknown";
+  }
+  return "stdio";
 }
 
 function isValidAddress(value: string): boolean {
@@ -330,16 +345,20 @@ export function ChatMcpServersDialog({
   const [togglingIds, setTogglingIds] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
+  const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(() => new Set());
   const [confirmingDelete, setConfirmingDelete] =
     useState<McpServerConfig | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const formGenerationRef = useRef(0);
   const actionGenerationRef = useRef(0);
+  const importGenerationRef = useRef(0);
   const activeEditIdRef = useRef<string | null>(null);
   const listRefreshGenerationRef = useRef(0);
   const openRef = useRef(open);
   const refreshingIdsRef = useRef(new Set<string>());
   const togglingIdsRef = useRef(new Set<string>());
+  const busyIdsRef = useRef(new Set<string>());
+  const importingRef = useRef(false);
   openRef.current = open;
 
   useEffect(() => {
@@ -414,10 +433,11 @@ export function ChatMcpServersDialog({
       setCodecPending(false);
       setDecodingCommand(false);
       setCodecError(null);
-      setImporting(false);
+      setImporting(importingRef.current);
       setConfirmingDelete(null);
       setRefreshingIds(new Set(refreshingIdsRef.current));
       setTogglingIds(new Set(togglingIdsRef.current));
+      setBusyIds(new Set(busyIdsRef.current));
       if (!open) return;
       void refresh();
       // Reset to the list on each open, else a stale create/edit view persists.
@@ -535,7 +555,6 @@ export function ChatMcpServersDialog({
       setCodecPending(false);
       setDecodingCommand(false);
       setCodecError(null);
-      setImporting(false);
       setConfirmingDelete(null);
     }
     onOpenChange(next);
@@ -681,20 +700,23 @@ export function ChatMcpServersDialog({
   async function onImportFile(e: ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     e.target.value = ""; // let the user re-pick the same file later
-    if (!file) return;
+    if (!file || importingRef.current) return;
     const generation = actionGenerationRef.current;
+    const importGeneration = importGenerationRef.current + 1;
+    importGenerationRef.current = importGeneration;
+    importingRef.current = true;
     setImporting(true);
-    let config: unknown;
     try {
-      config = JSON.parse(await file.text());
-    } catch {
-      if (actionGenerationRef.current === generation && openRef.current)
-        toast.error("Invalid JSON file");
-      if (actionGenerationRef.current === generation) setImporting(false);
-      return;
-    }
-    if (actionGenerationRef.current !== generation || !openRef.current) return;
-    try {
+      let config: unknown;
+      try {
+        config = JSON.parse(await file.text());
+      } catch {
+        if (actionGenerationRef.current === generation && openRef.current)
+          toast.error("Invalid JSON file");
+        return;
+      }
+      if (actionGenerationRef.current !== generation || !openRef.current)
+        return;
       const result = await importMcpServers(config);
       if (actionGenerationRef.current !== generation || !openRef.current)
         return;
@@ -724,27 +746,41 @@ export function ChatMcpServersDialog({
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      if (actionGenerationRef.current === generation) setImporting(false);
+      if (importGenerationRef.current === importGeneration) {
+        importingRef.current = false;
+        if (openRef.current) setImporting(false);
+      }
     }
   }
 
   async function removeServer(server: McpServerConfig) {
+    if (busyIdsRef.current.has(server.id)) return;
     const generation = actionGenerationRef.current;
+    busyIdsRef.current.add(server.id);
+    setBusyIds(new Set(busyIdsRef.current));
     try {
       await deleteMcpServer(server.id);
+      if (actionGenerationRef.current !== generation || !openRef.current)
+        return;
+      setServers((rows) => rows.filter((row) => row.id !== server.id));
     } catch (err) {
       if (actionGenerationRef.current !== generation || !openRef.current)
         return;
       toast.error("Delete failed", {
         description: err instanceof Error ? err.message : String(err),
       });
+    } finally {
+      busyIdsRef.current.delete(server.id);
+      if (openRef.current) setBusyIds(new Set(busyIdsRef.current));
     }
   }
 
   async function toggleEnabled(server: McpServerConfig, next: boolean) {
-    if (togglingIdsRef.current.has(server.id)) return;
+    if (busyIdsRef.current.has(server.id)) return;
     const generation = actionGenerationRef.current;
+    busyIdsRef.current.add(server.id);
     togglingIdsRef.current.add(server.id);
+    setBusyIds(new Set(busyIdsRef.current));
     setTogglingIds(new Set(togglingIdsRef.current));
     // Optimistic update so the switch doesn't snap back during the round-trip.
     setServers((rows) =>
@@ -766,15 +802,21 @@ export function ChatMcpServersDialog({
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
+      busyIdsRef.current.delete(server.id);
       togglingIdsRef.current.delete(server.id);
-      if (openRef.current) setTogglingIds(new Set(togglingIdsRef.current));
+      if (openRef.current) {
+        setBusyIds(new Set(busyIdsRef.current));
+        setTogglingIds(new Set(togglingIdsRef.current));
+      }
     }
   }
 
   async function refreshTools(server: McpServerConfig) {
-    if (refreshingIdsRef.current.has(server.id)) return;
+    if (busyIdsRef.current.has(server.id)) return;
     const generation = actionGenerationRef.current;
+    busyIdsRef.current.add(server.id);
     refreshingIdsRef.current.add(server.id);
+    setBusyIds(new Set(busyIdsRef.current));
     setRefreshingIds(new Set(refreshingIdsRef.current));
     try {
       const result = await refreshMcpServerTools(server.id);
@@ -796,8 +838,12 @@ export function ChatMcpServersDialog({
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
+      busyIdsRef.current.delete(server.id);
       refreshingIdsRef.current.delete(server.id);
-      if (openRef.current) setRefreshingIds(new Set(refreshingIdsRef.current));
+      if (openRef.current) {
+        setBusyIds(new Set(busyIdsRef.current));
+        setRefreshingIds(new Set(refreshingIdsRef.current));
+      }
     }
   }
 
@@ -875,9 +921,12 @@ export function ChatMcpServersDialog({
                 disabled={formPending}
                 onChange={(e) => {
                   const url = e.target.value;
-                  const transport = transportFromAddress(url);
                   setCodecError(null);
                   setForm((prev) => {
+                    const transport = transportFromAddress(
+                      url,
+                      prev.credentialTransport,
+                    );
                     const nextCredentialTransport =
                       transport === "unknown"
                         ? prev.credentialTransport
@@ -1072,7 +1121,7 @@ export function ChatMcpServersDialog({
                         checked={server.is_enabled}
                         onCheckedChange={(next) => toggleEnabled(server, next)}
                         aria-label="Enable server"
-                        disabled={importing || togglingIds.has(server.id)}
+                        disabled={importing || busyIds.has(server.id)}
                       />
                       <Button
                         type="button"
@@ -1081,7 +1130,7 @@ export function ChatMcpServersDialog({
                         onClick={() => refreshTools(server)}
                         aria-label="Refresh tools"
                         title="Refresh tools from this server"
-                        disabled={importing || refreshingIds.has(server.id)}
+                        disabled={importing || busyIds.has(server.id)}
                       >
                         {refreshingIds.has(server.id) ? (
                           <Spinner />
@@ -1095,7 +1144,7 @@ export function ChatMcpServersDialog({
                         size="icon"
                         onClick={() => void startEdit(server)}
                         aria-label="Edit server"
-                        disabled={importing || togglingIds.has(server.id)}
+                        disabled={importing || busyIds.has(server.id)}
                       >
                         <HugeiconsIcon icon={Edit03Icon} size={14} />
                       </Button>
@@ -1105,7 +1154,7 @@ export function ChatMcpServersDialog({
                         size="icon"
                         onClick={() => setConfirmingDelete(server)}
                         aria-label="Delete server"
-                        disabled={importing || togglingIds.has(server.id)}
+                        disabled={importing || busyIds.has(server.id)}
                       >
                         <HugeiconsIcon icon={Delete02Icon} size={14} />
                       </Button>

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -23,17 +23,17 @@ import {
 } from "@/components/ui/tooltip";
 import { useShortcut } from "@/features/settings";
 
+import { subscribeToMcpServerMutationSettlements } from "./api/mcp-server-mutation-tracker";
 import {
   type McpServerConfig,
   createMcpServer,
   listMcpServers,
   updateMcpServer,
 } from "./api/mcp-servers-api";
-import { subscribeToMcpServerMutationSettlements } from "./api/mcp-server-mutation-tracker";
 import { ChatMcpServersDialog } from "./chat-mcp-servers-dialog";
+import { useChatActive } from "./runtime-provider";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import { useMcpServersDialogStore } from "./stores/mcp-servers-dialog-store";
-import { useChatActive } from "./runtime-provider";
 
 // Matches the Thinking pill chevron so the affordance reads the same.
 const ArrowDownStandardIcon: FC<{ className?: string }> = ({ className }) => (
@@ -110,7 +110,10 @@ export function McpComposerButton({
   const dialogOpen = useMcpServersDialogStore((s) => s.open);
   const setDialogOpen = useMcpServersDialogStore((s) => s.setOpen);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
+  const [pendingUrls, setPendingUrls] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const pendingUrlsRef = useRef(new Set<string>());
   const [hintKey, setHintKey] = useState<string | null>(null);
   const listRefreshGenerationRef = useRef(0);
 
@@ -177,8 +180,9 @@ export function McpComposerButton({
     disablesWebSearch?: boolean;
   }) {
     const norm = normalizeMcpUrl(args.url);
-    if (pendingUrl === norm) return; // guard rapid double-clicks
-    setPendingUrl(norm);
+    if (pendingUrlsRef.current.has(norm)) return; // guard rapid double-clicks
+    pendingUrlsRef.current.add(norm);
+    setPendingUrls(new Set(pendingUrlsRef.current));
     try {
       if (args.checked) {
         // Reuse the already-loaded row, else create one.
@@ -204,7 +208,8 @@ export function McpComposerButton({
         description: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      setPendingUrl(null);
+      pendingUrlsRef.current.delete(norm);
+      setPendingUrls(new Set(pendingUrlsRef.current));
     }
   }
 
@@ -223,7 +228,7 @@ export function McpComposerButton({
   }) => (
     <DropdownMenuItem
       key={opts.key}
-      disabled={pendingUrl === normalizeMcpUrl(opts.url)}
+      disabled={pendingUrls.has(normalizeMcpUrl(opts.url))}
       onSelect={(e) => {
         e.preventDefault();
         void toggleServer({

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -117,6 +117,7 @@ export function McpComposerButton({
   const pendingUrlsRef = useRef(new Set<string>());
   const [hintKey, setHintKey] = useState<string | null>(null);
   const listRefreshGenerationRef = useRef(0);
+  const hasLoadedServerSnapshotRef = useRef(false);
 
   // Grey out only when a loaded model lacks tool support; with no model yet,
   // MCP can still be pre-selected, like the other composer tools.
@@ -134,9 +135,15 @@ export function McpComposerButton({
         });
         if (listRefreshGenerationRef.current !== generation) return;
         setServers(rows);
+        hasLoadedServerSnapshotRef.current = true;
         setServersLoaded(true);
       } catch {
-        // Keep prior state if the list call fails.
+        if (
+          listRefreshGenerationRef.current === generation &&
+          hasLoadedServerSnapshotRef.current
+        ) {
+          setServersLoaded(true);
+        }
       }
     },
     [],

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -5,7 +5,7 @@ import { Tick02Icon } from "@/lib/tick-icon";
 import { McpServerIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { XIcon } from "lucide-react";
-import { type FC, useCallback, useEffect, useState } from "react";
+import { type FC, useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import {
@@ -29,6 +29,7 @@ import {
   listMcpServers,
   updateMcpServer,
 } from "./api/mcp-servers-api";
+import { subscribeToMcpServerMutationSettlements } from "./api/mcp-server-mutation-tracker";
 import { ChatMcpServersDialog } from "./chat-mcp-servers-dialog";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import { useMcpServersDialogStore } from "./stores/mcp-servers-dialog-store";
@@ -111,25 +112,45 @@ export function McpComposerButton({
   const [menuOpen, setMenuOpen] = useState(false);
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
   const [hintKey, setHintKey] = useState<string | null>(null);
+  const listRefreshGenerationRef = useRef(0);
 
   // Grey out only when a loaded model lacks tool support; with no model yet,
   // MCP can still be pre-selected, like the other composer tools.
   const usable = !modelLoaded || supportsTools;
 
   const refresh = useCallback(async () => {
+    const generation = listRefreshGenerationRef.current + 1;
+    listRefreshGenerationRef.current = generation;
     try {
       const rows = await listMcpServers();
+      if (listRefreshGenerationRef.current !== generation) return;
       setServers(rows);
     } catch {
       // Keep prior state if the list call fails.
     }
   }, []);
 
+  useEffect(() => {
+    const unsubscribe = subscribeToMcpServerMutationSettlements(() => {
+      void refresh();
+    });
+    return () => {
+      unsubscribe();
+      listRefreshGenerationRef.current += 1;
+    };
+  }, [refresh]);
+
   // Load the server list on mount, and again when the dialog closes: it can
   // be opened from the chord as well as from this menu.
   useEffect(() => {
     if (dialogOpen) return;
-    void refresh();
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) void refresh();
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [refresh, dialogOpen]);
 
   const enabledUrls = new Set(
@@ -172,7 +193,6 @@ export function McpComposerButton({
       } else if (args.existing) {
         await updateMcpServer(args.existing.id, { isEnabled: false });
       }
-      await refresh();
     } catch (err) {
       toast.error("Failed to update MCP server", {
         description: err instanceof Error ? err.message : String(err),

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -110,6 +110,7 @@ export function McpComposerButton({
   const dialogOpen = useMcpServersDialogStore((s) => s.open);
   const setDialogOpen = useMcpServersDialogStore((s) => s.setOpen);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [serversLoaded, setServersLoaded] = useState(false);
   const [pendingUrls, setPendingUrls] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
@@ -132,12 +133,25 @@ export function McpComposerButton({
         });
         if (listRefreshGenerationRef.current !== generation) return;
         setServers(rows);
+        setServersLoaded(true);
       } catch {
         // Keep prior state if the list call fails.
       }
     },
     [],
   );
+
+  const applyServer = useCallback((server: McpServerConfig) => {
+    setServers((current) => {
+      const index = current.findIndex(
+        (candidate) => candidate.id === server.id,
+      );
+      if (index === -1) return [...current, server];
+      return current.map((candidate) =>
+        candidate.id === server.id ? server : candidate,
+      );
+    });
+  }, []);
 
   useEffect(() => {
     const unsubscribe = subscribeToMcpServerMutationSettlements((epoch) => {
@@ -188,20 +202,26 @@ export function McpComposerButton({
         // Reuse the already-loaded row, else create one.
         if (args.existing) {
           if (!args.existing.is_enabled) {
-            await updateMcpServer(args.existing.id, { isEnabled: true });
+            applyServer(
+              await updateMcpServer(args.existing.id, { isEnabled: true }),
+            );
           }
         } else {
-          await createMcpServer({
-            displayName: args.displayName,
-            url: args.url,
-            isEnabled: true,
-          });
+          applyServer(
+            await createMcpServer({
+              displayName: args.displayName,
+              url: args.url,
+              isEnabled: true,
+            }),
+          );
         }
         setMcpEnabledForChat(true);
         // Search servers turn off the built-in Web Search to avoid overlap.
         if (args.disablesWebSearch) setToolsEnabled(false);
       } else if (args.existing) {
-        await updateMcpServer(args.existing.id, { isEnabled: false });
+        applyServer(
+          await updateMcpServer(args.existing.id, { isEnabled: false }),
+        );
       }
     } catch (err) {
       toast.error("Failed to update MCP server", {
@@ -228,7 +248,7 @@ export function McpComposerButton({
   }) => (
     <DropdownMenuItem
       key={opts.key}
-      disabled={pendingUrls.has(normalizeMcpUrl(opts.url))}
+      disabled={!serversLoaded || pendingUrls.has(normalizeMcpUrl(opts.url))}
       onSelect={(e) => {
         e.preventDefault();
         void toggleServer({

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -126,6 +126,7 @@ export function McpComposerButton({
     async (waitForPendingMutations = true, minimumMutationEpoch = 0) => {
       const generation = listRefreshGenerationRef.current + 1;
       listRefreshGenerationRef.current = generation;
+      setServersLoaded(false);
       try {
         const rows = await listMcpServers({
           waitForPendingMutations,

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -118,21 +118,27 @@ export function McpComposerButton({
   // MCP can still be pre-selected, like the other composer tools.
   const usable = !modelLoaded || supportsTools;
 
-  const refresh = useCallback(async () => {
-    const generation = listRefreshGenerationRef.current + 1;
-    listRefreshGenerationRef.current = generation;
-    try {
-      const rows = await listMcpServers();
-      if (listRefreshGenerationRef.current !== generation) return;
-      setServers(rows);
-    } catch {
-      // Keep prior state if the list call fails.
-    }
-  }, []);
+  const refresh = useCallback(
+    async (waitForPendingMutations = true, minimumMutationEpoch = 0) => {
+      const generation = listRefreshGenerationRef.current + 1;
+      listRefreshGenerationRef.current = generation;
+      try {
+        const rows = await listMcpServers({
+          waitForPendingMutations,
+          minimumMutationEpoch,
+        });
+        if (listRefreshGenerationRef.current !== generation) return;
+        setServers(rows);
+      } catch {
+        // Keep prior state if the list call fails.
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
-    const unsubscribe = subscribeToMcpServerMutationSettlements(() => {
-      void refresh();
+    const unsubscribe = subscribeToMcpServerMutationSettlements((epoch) => {
+      void refresh(false, epoch);
     });
     return () => {
       unsubscribe();
@@ -283,11 +289,13 @@ export function McpComposerButton({
                 aria-label="Turn off MCP"
                 tabIndex={-1}
                 onPointerDown={(e) => {
-                  if (e.currentTarget.closest('[data-pill-compact="true"]')) return;
+                  if (e.currentTarget.closest('[data-pill-compact="true"]'))
+                    return;
                   e.stopPropagation();
                 }}
                 onClick={(e) => {
-                  if (e.currentTarget.closest('[data-pill-compact="true"]')) return;
+                  if (e.currentTarget.closest('[data-pill-compact="true"]'))
+                    return;
                   e.stopPropagation();
                   setMcpEnabledForChat(false);
                 }}

--- a/studio/frontend/src/features/chat/mcp-server-form.ts
+++ b/studio/frontend/src/features/chat/mcp-server-form.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export interface McpStdioSnapshot {
+  originalUrl: string;
+  command: string;
+  arguments: string[];
+}
+
+export type McpStdioUrlDecision =
+  | { kind: "reuse"; url: string }
+  | { kind: "encode"; command: string; arguments: string[] };
+
+export function createMcpStdioSnapshot(
+  originalUrl: string,
+  command: string,
+  arguments_: readonly string[] = [],
+): McpStdioSnapshot {
+  return {
+    originalUrl,
+    command,
+    arguments: [...arguments_],
+  };
+}
+
+function sameArguments(left: readonly string[], right: readonly string[]) {
+  return (
+    left.length === right.length &&
+    left.every((argument, index) => argument === right[index])
+  );
+}
+
+export function resolveMcpStdioUrl(
+  command: string,
+  arguments_: readonly string[],
+  snapshot: McpStdioSnapshot | null,
+): McpStdioUrlDecision {
+  if (
+    snapshot !== null &&
+    command === snapshot.command &&
+    sameArguments(arguments_, snapshot.arguments)
+  ) {
+    return { kind: "reuse", url: snapshot.originalUrl };
+  }
+
+  return { kind: "encode", command, arguments: [...arguments_] };
+}

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -246,6 +246,14 @@ test("a decode error is announced and executable edits unlock manual recovery", 
   );
   assert.match(
     dialog,
+    /aria-busy=\{decodingCommand\}[\s\S]*role="status"\s*aria-live="polite"[\s\S]*Reading local command…/,
+  );
+  assert.match(
+    dialog,
+    /codecError && \([\s\S]*view\.kind === "edit"[\s\S]*void startEdit\(server\)[\s\S]*Retry/,
+  );
+  assert.match(
+    dialog,
     /disabled=\{\s*formPending \|\|\s*codecError !== null \|\|\s*!form\.url\.trim\(\)/,
   );
 });
@@ -380,7 +388,7 @@ test("full unmount invalidates cancellable stdio encode continuations", async ()
   );
   assert.match(
     openLifecycle,
-    /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;[\s\S]*setImporting\(false\);\s*setConfirmingDelete\(null\);[\s\S]*if \(!open\) return;/,
+    /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;[\s\S]*setCodecPending\(false\);\s*setDecodingCommand\(false\);[\s\S]*setConfirmingDelete\(null\);[\s\S]*if \(!open\) return;/,
     "route teardown must clear transient form state before a later reopen",
   );
   assert.match(

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -274,6 +274,35 @@ test("dialog actions and reconciliation stop when the dialog closes", () => {
   );
 });
 
+test("pending MCP actions remain keyed to their own server", () => {
+  const dialog = readFileSync(
+    new URL(
+      "../src/features/chat/chat-mcp-servers-dialog.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const composer = readFileSync(
+    new URL(
+      "../src/features/chat/mcp-composer-button.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+
+  assert.match(composer, /pendingUrlsRef = useRef\(new Set<string>\(\)\)/);
+  assert.match(
+    composer,
+    /pendingUrlsRef\.current\.delete\(norm\);\s*setPendingUrls\(new Set\(pendingUrlsRef\.current\)\)/,
+  );
+  assert.match(dialog, /refreshingIdsRef = useRef\(new Set<string>\(\)\)/);
+  assert.match(dialog, /togglingIdsRef = useRef\(new Set<string>\(\)\)/);
+  assert.match(
+    dialog,
+    /if \(!togglingIdsRef\.current\.has\(row\.id\)\) return row;[\s\S]*is_enabled: optimistic\.is_enabled/,
+  );
+});
+
 test("dialog closure is blocked only after a save mutation starts", () => {
   const dialog = readFileSync(
     new URL(
@@ -351,7 +380,7 @@ test("full unmount invalidates cancellable stdio encode continuations", async ()
   );
   assert.match(
     openLifecycle,
-    /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;[\s\S]*setImporting\(false\);\s*setConfirmingDelete\(null\);\s*if \(!open\) return;/,
+    /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;[\s\S]*setImporting\(false\);\s*setConfirmingDelete\(null\);[\s\S]*if \(!open\) return;/,
     "route teardown must clear transient form state before a later reopen",
   );
   assert.match(

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -140,7 +140,10 @@ test("the dialog wires backend codec calls, stale guards, and a stdio-only edito
   );
   assert.match(dialog, /!addressIsCommand && \([\s\S]*Use OAuth sign-in/);
   assert.match(dialog, /const decision = resolveMcpStdioUrl\(/);
-  assert.match(dialog, /decision\.kind === "reuse"[\s\S]*url = decision\.url/);
+  assert.match(
+    dialog,
+    /decision\.kind === "reuse"[\s\S]*url = view\.kind === "edit" \? undefined : decision\.url/,
+  );
   assert.match(
     dialog,
     /const url = stdio\s*\? await encodeStdioForGeneration\([\s\S]*testMcpServer\(\{\s*url,/,

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -129,7 +129,10 @@ test("the dialog wires backend codec calls, stale guards, and a stdio-only edito
   );
   assert.match(dialog, /addressIsCommand && \(\s*<ArgumentsEditor/);
   assert.match(dialog, /const addressIsCommand = form\.transport === "stdio"/);
-  assert.match(dialog, /const transport = transportFromAddress\(url\)/);
+  assert.match(
+    dialog,
+    /const transport = transportFromAddress\(\s*url,\s*prev\.credentialTransport,\s*\)/,
+  );
   assert.match(
     dialog,
     /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;[\s\S]*setView\(\{ kind: "list" \}\)/,

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -203,7 +203,7 @@ test("every mutable MCP form editor is locked for the full pending interval", ()
   );
   assert.match(
     dialog,
-    /const formPending = codecPending \|\| testing \|\| saving/,
+    /const formPending = importing \|\| codecPending \|\| testing \|\| saving/,
   );
   assert.match(
     dialog,
@@ -247,6 +247,30 @@ test("a decode error is announced and executable edits unlock manual recovery", 
   assert.match(
     dialog,
     /disabled=\{\s*formPending \|\|\s*codecError !== null \|\|\s*!form\.url\.trim\(\)/,
+  );
+});
+
+test("dialog actions and reconciliation stop when the dialog closes", () => {
+  const dialog = readFileSync(
+    new URL(
+      "../src/features/chat/chat-mcp-servers-dialog.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+
+  assert.match(
+    dialog,
+    /useEffect\(\(\) => \{\s*if \(!open\) \{[\s\S]*subscribeToMcpServerMutationSettlements/,
+  );
+  assert.match(
+    dialog,
+    /actionGenerationRef\.current !== generation \|\| !openRef\.current/,
+  );
+  assert.match(dialog, /open=\{open && confirmingDelete !== null\}/);
+  assert.match(
+    dialog,
+    /<Button size="sm" onClick=\{startCreate\} disabled=\{importing\}>/,
   );
 });
 
@@ -301,7 +325,7 @@ test("full unmount invalidates cancellable stdio encode continuations", async ()
   );
   const openLifecycle = sourceBetween(
     dialog,
-    "formGenerationRef.current += 1;\n    activeEditIdRef.current = null;",
+    "useEffect(() => {\n    formGenerationRef.current += 1;",
     "function startCreate",
   );
   const encode = sourceBetween(
@@ -322,12 +346,12 @@ test("full unmount invalidates cancellable stdio encode continuations", async ()
 
   assert.match(
     refsAndCleanup,
-    /useEffect\(\(\) => \{\s*return \(\) => \{\s*formGenerationRef\.current \+= 1;\s*activeEditIdRef\.current = null;\s*\};\s*\}, \[\]\)/,
+    /useEffect\(\(\) => \{\s*return \(\) => \{\s*formGenerationRef\.current \+= 1;\s*actionGenerationRef\.current \+= 1;\s*activeEditIdRef\.current = null;[\s\S]*\};\s*\}, \[\]\)/,
     "the component mount lifetime must invalidate the form identity on teardown",
   );
   assert.match(
     openLifecycle,
-    /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;\s*setSaving\(false\);\s*setTesting\(false\);\s*setCodecPending\(false\);\s*setCodecError\(null\);\s*if \(!open\) return;/,
+    /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;[\s\S]*setImporting\(false\);\s*setConfirmingDelete\(null\);\s*if \(!open\) return;/,
     "route teardown must clear transient form state before a later reopen",
   );
   assert.match(

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -131,7 +131,7 @@ test("the dialog wires backend codec calls, stale guards, and a stdio-only edito
   assert.match(dialog, /const addressIsCommand = form\.transport === "stdio"/);
   assert.match(
     dialog,
-    /const transport = transportFromAddress\(\s*url,\s*prev\.credentialTransport,\s*\)/,
+    /function formWithAddress[\s\S]*transportFromAddress\([\s\S]*preservePartialHttp \? form\.credentialTransport : null[\s\S]*headers: transportChanged \? \[\] : form\.headers/,
   );
   assert.match(
     dialog,
@@ -169,7 +169,7 @@ test("the dialog wires backend codec calls, stale guards, and a stdio-only edito
   assert.match(dialog, /Add local arguments in the Arguments rows/);
   assert.match(
     dialog,
-    /const transportChanged =[\s\S]*prev\.credentialTransport !== transport;[\s\S]*headers: transportChanged \? \[\] : prev\.headers/,
+    /setForm\(\(prev\) => formWithAddress\(prev, url, true\)\)/,
   );
   assert.doesNotMatch(dialog, /form\.url\.(?:split|join)\s*\(/);
   assert.doesNotMatch(dialog, /form\.arguments[^;\n]*\.join\s*\(/);
@@ -241,7 +241,7 @@ test("a decode error is announced and executable edits unlock manual recovery", 
 
   assert.match(
     dialog,
-    /id="mcp-url"[\s\S]*?onChange=\{\(e\) => \{[\s\S]*?setCodecError\(null\)[\s\S]*?transport,/,
+    /id="mcp-url"[\s\S]*?onChange=\{\(e\) => \{[\s\S]*?setCodecError\(null\)[\s\S]*?formWithAddress/,
   );
   assert.match(
     dialog,
@@ -257,7 +257,7 @@ test("a decode error is announced and executable edits unlock manual recovery", 
   );
   assert.match(
     dialog,
-    /disabled=\{\s*formPending \|\|\s*codecError !== null \|\|\s*!form\.url\.trim\(\)/,
+    /disabled=\{\s*formPending \|\|\s*codecError !== null \|\|\s*form\.transport === "unknown" \|\|\s*!form\.url\.trim\(\)/,
   );
 });
 
@@ -294,10 +294,7 @@ test("pending MCP actions remain keyed to their own server", () => {
     "utf8",
   );
   const composer = readFileSync(
-    new URL(
-      "../src/features/chat/mcp-composer-button.tsx",
-      import.meta.url,
-    ),
+    new URL("../src/features/chat/mcp-composer-button.tsx", import.meta.url),
     "utf8",
   );
 
@@ -314,7 +311,7 @@ test("pending MCP actions remain keyed to their own server", () => {
   );
 });
 
-test("dialog closure is blocked only after a save mutation starts", () => {
+test("dialog closure is blocked while a CRUD mutation is in flight", () => {
   const dialog = readFileSync(
     new URL(
       "../src/features/chat/chat-mcp-servers-dialog.tsx",
@@ -330,12 +327,12 @@ test("dialog closure is blocked only after a save mutation starts", () => {
 
   assert.match(
     closeHandler,
-    /if \(!next && saving && !codecPending\) return;[\s\S]*if \(!next\) \{[\s\S]*formGenerationRef\.current \+= 1;/,
+    /if \(!next && \(\(saving && !codecPending\) \|\| busyIdsRef\.current\.size > 0\)\)[\s\S]*return;[\s\S]*if \(!next\) \{[\s\S]*formGenerationRef\.current \+= 1;/,
     "the in-flight mutation guard must run before close invalidates the form generation",
   );
   assert.match(
     dialog,
-    /<DialogContent[\s\S]*?showCloseButton=\{!\(saving && !codecPending\)\}[\s\S]*?>/,
+    /<DialogContent[\s\S]*?showCloseButton=\{!\(saving && !codecPending\) && busyIds\.size === 0\}[\s\S]*?>/,
     "the built-in close control must disappear during the same mutation window",
   );
   assert.match(
@@ -347,6 +344,34 @@ test("dialog closure is blocked only after a save mutation starts", () => {
     dialog,
     /async function encodeStdioForGeneration[\s\S]*setCodecPending\(true\);[\s\S]*await encodeMcpStdioCommand/,
     "codec encoding remains distinguishable so it can still be cancelled before CRUD starts",
+  );
+});
+
+test("composer applies mutation responses before releasing each preset", () => {
+  const composer = readFileSync(
+    new URL("../src/features/chat/mcp-composer-button.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    composer,
+    /const applyServer = useCallback[\s\S]*setServers\(\(current\)[\s\S]*candidate\.id === server\.id/,
+  );
+  assert.match(
+    composer,
+    /applyServer\(\s*await createMcpServer\([\s\S]*pendingUrlsRef\.current\.delete\(norm\)/,
+  );
+  assert.match(
+    composer,
+    /applyServer\(\s*await updateMcpServer\([\s\S]*pendingUrlsRef\.current\.delete\(norm\)/,
+  );
+  assert.match(
+    composer,
+    /const \[serversLoaded, setServersLoaded\] = useState\(false\)[\s\S]*setServers\(rows\);\s*setServersLoaded\(true\)/,
+  );
+  assert.match(
+    composer,
+    /disabled=\{\s*!serversLoaded \|\| pendingUrls\.has\(normalizeMcpUrl\(opts\.url\)\)/,
   );
 });
 

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -367,7 +367,11 @@ test("composer applies mutation responses before releasing each preset", () => {
   );
   assert.match(
     composer,
-    /const \[serversLoaded, setServersLoaded\] = useState\(false\)[\s\S]*setServersLoaded\(false\);[\s\S]*setServers\(rows\);\s*setServersLoaded\(true\)/,
+    /const \[serversLoaded, setServersLoaded\] = useState\(false\)[\s\S]*const hasLoadedServerSnapshotRef = useRef\(false\);[\s\S]*setServersLoaded\(false\);[\s\S]*setServers\(rows\);\s*hasLoadedServerSnapshotRef\.current = true;\s*setServersLoaded\(true\)/,
+  );
+  assert.match(
+    composer,
+    /catch \{\s*if \(\s*listRefreshGenerationRef\.current === generation &&\s*hasLoadedServerSnapshotRef\.current\s*\) \{\s*setServersLoaded\(true\);/,
   );
   assert.match(
     composer,

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -278,6 +278,88 @@ test("dialog closure is blocked only after a save mutation starts", () => {
   );
 });
 
+test("full unmount invalidates cancellable stdio encode continuations", async () => {
+  const dialog = readFileSync(
+    new URL(
+      "../src/features/chat/chat-mcp-servers-dialog.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const refsAndCleanup = sourceBetween(
+    dialog,
+    "const formGenerationRef = useRef(0)",
+    "const refresh = useCallback",
+  );
+  const encode = sourceBetween(
+    dialog,
+    "async function encodeStdioForGeneration",
+    "async function testConnection",
+  );
+  const testContinuation = sourceBetween(
+    dialog,
+    "async function testConnection",
+    "async function submitForm",
+  );
+  const crudContinuation = sourceBetween(
+    dialog,
+    "async function submitForm",
+    "async function onImportFile",
+  );
+
+  assert.match(
+    refsAndCleanup,
+    /useEffect\(\(\) => \{\s*return \(\) => \{\s*formGenerationRef\.current \+= 1;\s*activeEditIdRef\.current = null;\s*\};\s*\}, \[\]\)/,
+    "the component mount lifetime must invalidate the form identity on teardown",
+  );
+  assert.match(
+    encode,
+    /await encodeMcpStdioCommand\([\s\S]*formGenerationRef\.current !== generation\) return null/,
+  );
+  assert.match(
+    testContinuation,
+    /await encodeStdioForGeneration\([\s\S]*if \(url === null \|\| formGenerationRef\.current !== generation\) return;[\s\S]*testMcpServer\(/,
+  );
+  assert.match(
+    crudContinuation,
+    /await encodeStdioForGeneration\([\s\S]*if \(encodedUrl === null\) return;[\s\S]*if \(formGenerationRef\.current !== generation\) return;[\s\S]*(?:updateMcpServer|createMcpServer)\(/,
+  );
+
+  const generation = { current: 7 };
+  const activeEditId = { current: "server-1" as string | null };
+  const encoded = deferred<string>();
+  let testCalls = 0;
+  let createCalls = 0;
+  let updateCalls = 0;
+  let staleUiEffects = 0;
+
+  async function continueAfterEncode(kind: "test" | "create" | "update") {
+    const capturedGeneration = generation.current;
+    await encoded.promise;
+    if (generation.current !== capturedGeneration) return;
+    if (kind === "test") testCalls += 1;
+    if (kind === "create") createCalls += 1;
+    if (kind === "update") updateCalls += 1;
+    staleUiEffects += 1;
+  }
+
+  const continuations = [
+    continueAfterEncode("test"),
+    continueAfterEncode("create"),
+    continueAfterEncode("update"),
+  ];
+  generation.current += 1;
+  activeEditId.current = null;
+  encoded.resolve("encoded command");
+  await Promise.all(continuations);
+
+  assert.equal(activeEditId.current, null);
+  assert.equal(testCalls, 0);
+  assert.equal(createCalls, 0);
+  assert.equal(updateCalls, 0);
+  assert.equal(staleUiEffects, 0);
+});
+
 test("open-time reconciliation waits for every mutation across component lifetimes", async () => {
   const first = deferred<void>();
   const second = deferred<void>();

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -129,7 +129,7 @@ test("the dialog wires backend codec calls, stale guards, and a stdio-only edito
   );
   assert.match(dialog, /addressIsCommand && \(\s*<ArgumentsEditor/);
   assert.match(dialog, /const addressIsCommand = form\.transport === "stdio"/);
-  assert.match(dialog, /transport: transportFromAddress\(url\)/);
+  assert.match(dialog, /const transport = transportFromAddress\(url\)/);
   assert.match(
     dialog,
     /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;[\s\S]*setView\(\{ kind: "list" \}\)/,
@@ -138,7 +138,10 @@ test("the dialog wires backend codec calls, stale guards, and a stdio-only edito
     dialog,
     /function ArgumentsEditor[\s\S]*\{ id: newRowId\(\), value: "" \}/,
   );
-  assert.match(dialog, /!addressIsCommand && \([\s\S]*Use OAuth sign-in/);
+  assert.match(
+    dialog,
+    /form\.transport === "http" && \([\s\S]*Use OAuth sign-in/,
+  );
   assert.match(dialog, /const decision = resolveMcpStdioUrl\(/);
   assert.match(
     dialog,
@@ -161,6 +164,10 @@ test("the dialog wires backend codec calls, stale guards, and a stdio-only edito
   assert.match(dialog, /URL or executable/);
   assert.match(dialog, /https:\/\/example\.com\/mcp or npx/);
   assert.match(dialog, /Add local arguments in the Arguments rows/);
+  assert.match(
+    dialog,
+    /const transportChanged =[\s\S]*prev\.credentialTransport !== transport;[\s\S]*headers: transportChanged \? \[\] : prev\.headers/,
+  );
   assert.doesNotMatch(dialog, /form\.url\.(?:split|join)\s*\(/);
   assert.doesNotMatch(dialog, /form\.arguments[^;\n]*\.join\s*\(/);
 });
@@ -231,7 +238,7 @@ test("a decode error is announced and executable edits unlock manual recovery", 
 
   assert.match(
     dialog,
-    /id="mcp-url"[\s\S]*?onChange=\{\(e\) => \{[\s\S]*?setCodecError\(null\)[\s\S]*?transport: transportFromAddress\(url\)/,
+    /id="mcp-url"[\s\S]*?onChange=\{\(e\) => \{[\s\S]*?setCodecError\(null\)[\s\S]*?transport,/,
   );
   assert.match(
     dialog,

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../src/features/chat/mcp-server-form.ts";
 import {
   readAfterPendingMcpServerMutations,
+  readMcpServerMutationSnapshot,
   subscribeToMcpServerMutationSettlements,
   trackMcpServerMutation,
   waitForPendingMcpServerMutations,
@@ -128,10 +129,7 @@ test("the dialog wires backend codec calls, stale guards, and a stdio-only edito
   );
   assert.match(dialog, /addressIsCommand && \(\s*<ArgumentsEditor/);
   assert.match(dialog, /const addressIsCommand = form\.transport === "stdio"/);
-  assert.match(
-    dialog,
-    /transport: transportFromAddress\(url\)/,
-  );
+  assert.match(dialog, /transport: transportFromAddress\(url\)/);
   assert.match(
     dialog,
     /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;[\s\S]*setView\(\{ kind: "list" \}\)/,
@@ -140,10 +138,7 @@ test("the dialog wires backend codec calls, stale guards, and a stdio-only edito
     dialog,
     /function ArgumentsEditor[\s\S]*\{ id: newRowId\(\), value: "" \}/,
   );
-  assert.match(
-    dialog,
-    /!addressIsCommand && \([\s\S]*Use OAuth sign-in/,
-  );
+  assert.match(dialog, /!addressIsCommand && \([\s\S]*Use OAuth sign-in/);
   assert.match(dialog, /const decision = resolveMcpStdioUrl\(/);
   assert.match(dialog, /decision\.kind === "reuse"[\s\S]*url = decision\.url/);
   assert.match(
@@ -196,7 +191,10 @@ test("every mutable MCP form editor is locked for the full pending interval", ()
     4,
     "header/env add, key, value, and remove must all be locked",
   );
-  assert.match(dialog, /const formPending = codecPending \|\| testing \|\| saving/);
+  assert.match(
+    dialog,
+    /const formPending = codecPending \|\| testing \|\| saving/,
+  );
   assert.match(
     dialog,
     /id="mcp-display-name"[\s\S]*?disabled=\{formPending\}[\s\S]*?\/>/,
@@ -291,6 +289,11 @@ test("full unmount invalidates cancellable stdio encode continuations", async ()
     "const formGenerationRef = useRef(0)",
     "const refresh = useCallback",
   );
+  const openLifecycle = sourceBetween(
+    dialog,
+    "formGenerationRef.current += 1;\n    activeEditIdRef.current = null;",
+    "function startCreate",
+  );
   const encode = sourceBetween(
     dialog,
     "async function encodeStdioForGeneration",
@@ -313,6 +316,11 @@ test("full unmount invalidates cancellable stdio encode continuations", async ()
     "the component mount lifetime must invalidate the form identity on teardown",
   );
   assert.match(
+    openLifecycle,
+    /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;\s*setSaving\(false\);\s*setTesting\(false\);\s*setCodecPending\(false\);\s*setCodecError\(null\);\s*if \(!open\) return;/,
+    "route teardown must clear transient form state before a later reopen",
+  );
+  assert.match(
     encode,
     /await encodeMcpStdioCommand\([\s\S]*formGenerationRef\.current !== generation\) return null/,
   );
@@ -323,6 +331,16 @@ test("full unmount invalidates cancellable stdio encode continuations", async ()
   assert.match(
     crudContinuation,
     /await encodeStdioForGeneration\([\s\S]*if \(encodedUrl === null\) return;[\s\S]*if \(formGenerationRef\.current !== generation\) return;[\s\S]*(?:updateMcpServer|createMcpServer)\(/,
+  );
+  assert.match(
+    crudContinuation,
+    /await updateMcpServer\([\s\S]*if \(formGenerationRef\.current !== generation\) return;\s*toast\.success\("MCP server updated"\)/,
+    "an unmounted edit must not emit a stale success toast",
+  );
+  assert.match(
+    crudContinuation,
+    /await createMcpServer\([\s\S]*if \(formGenerationRef\.current !== generation\) return;\s*toast\.success\("MCP server added"\)/,
+    "an unmounted create must not emit a stale success toast",
   );
 
   const generation = { current: 7 };
@@ -376,7 +394,11 @@ test("open-time reconciliation waits for every mutation across component lifetim
     reconciled = true;
   });
   await Promise.resolve();
-  assert.equal(reconciled, false, "the first pending mutation must hold refresh");
+  assert.equal(
+    reconciled,
+    false,
+    "the first pending mutation must hold refresh",
+  );
 
   // Simulate another API mutation starting after the opening component has
   // already captured and begun waiting on the first batch.
@@ -395,7 +417,44 @@ test("open-time reconciliation waits for every mutation across component lifetim
   await batchNotified.promise;
   unsubscribe();
   assert.equal(reconciled, true);
-  assert.equal(notificationCount, 1, "a drained mutation batch publishes once");
+  assert.equal(
+    notificationCount,
+    2,
+    "each settled mutation publishes its epoch",
+  );
+});
+
+test("a settled successor can reconcile while an older mutation remains pending", async () => {
+  const first = deferred<void>();
+  const second = deferred<void>();
+  let authoritativeRows = ["old"];
+  const snapshots: string[][] = [];
+  const successorVisible = deferred<void>();
+  const predecessorVisible = deferred<void>();
+
+  const unsubscribe = subscribeToMcpServerMutationSettlements(() => {
+    void readMcpServerMutationSnapshot(async () => [...authoritativeRows]).then(
+      (rows) => {
+        snapshots.push(rows);
+        if (rows.includes("successor")) successorVisible.resolve();
+        if (rows.includes("predecessor")) predecessorVisible.resolve();
+      },
+    );
+  });
+
+  trackMcpServerMutation(first.promise);
+  trackMcpServerMutation(second.promise);
+  authoritativeRows = ["old", "successor"];
+  second.resolve();
+  await successorVisible.promise;
+  assert.deepEqual(snapshots.at(-1), ["old", "successor"]);
+
+  authoritativeRows = ["old", "successor", "predecessor"];
+  first.resolve();
+  await predecessorVisible.promise;
+  await waitForPendingMcpServerMutations();
+  unsubscribe();
+  assert.deepEqual(snapshots.at(-1), ["old", "successor", "predecessor"]);
 });
 
 test("failed mutations settle waiters without leaking a tracker rejection", async () => {
@@ -448,7 +507,10 @@ test("settlement refreshes a mounted background consumer after another consumer 
   assert.deepEqual(foregroundRows, ["new"]);
   assert.deepEqual(backgroundRows, ["new"]);
   assert.equal(notificationCount, 1);
-  assert.ok(notifiedEpoch >= 2, "registration and settlement both advance epoch");
+  assert.ok(
+    notifiedEpoch >= 2,
+    "registration and settlement both advance epoch",
+  );
 });
 
 test("a list read retries when a mutation starts after its pre-read drain", async () => {
@@ -590,7 +652,8 @@ test("every list consumer uses the shared pending-mutation read barrier", () => 
 
   const listOccurrences = typescriptFilesUnder(chatRoot)
     .flatMap((file) => {
-      const count = readFileSync(file, "utf8").match(/\blistMcpServers\s*\(/g)?.length ?? 0;
+      const count =
+        readFileSync(file, "utf8").match(/\blistMcpServers\s*\(/g)?.length ?? 0;
       return Array.from({ length: count }, () =>
         relative(chatRoot, file).replaceAll("\\", "/"),
       );
@@ -613,19 +676,49 @@ test("every list consumer uses the shared pending-mutation read barrier", () => 
     /readAfterPendingMcpServerMutations\(\(\) =>[\s\S]*mcpRequest<McpServerConfig\[\]>\("\/"\)/,
     "the shared query boundary must retry reads that overlap tracked mutations",
   );
-  assert.match(listApi, /if \(mcpServerListRequest\) return mcpServerListRequest/);
-  assert.match(dialogRefresh, /await listMcpServers\(\)/);
-  assert.match(composerRefresh, /await listMcpServers\(\)/);
+  assert.match(
+    listApi,
+    /readMcpServerMutationSnapshot\(\(\) =>[\s\S]*mcpRequest<McpServerConfig\[\]>\("\/"\)/,
+    "settlement refreshes must not wait on unrelated older mutations",
+  );
+  assert.match(
+    listApi,
+    /minimumMutationEpoch \?\? getMcpServerMutationEpoch\(\)[\s\S]*mcpServerSettlementListRequest\.minimumEpoch >= requestedEpoch/,
+    "a newer settlement must replace a snapshot cached for an older epoch",
+  );
+  assert.match(
+    listApi,
+    /const slot = \{ minimumEpoch: requestedEpoch, promise: request \}[\s\S]*mcpServerSettlementListRequest === slot/,
+    "an older completion must not clear the successor epoch slot",
+  );
+  assert.match(
+    listApi,
+    /if \(mcpServerListRequest\) return mcpServerListRequest/,
+  );
+  assert.match(
+    dialogRefresh,
+    /await listMcpServers\(\{\s*waitForPendingMutations,\s*minimumMutationEpoch,\s*\}\)/,
+  );
+  assert.match(
+    composerRefresh,
+    /await listMcpServers\(\{\s*waitForPendingMutations,\s*minimumMutationEpoch,\s*\}\)/,
+  );
   assert.match(
     dialog,
-    /subscribeToMcpServerMutationSettlements\(\(\) => \{\s*void refresh\(\)/,
+    /subscribeToMcpServerMutationSettlements\(\(epoch\) => \{\s*void refresh\(false, epoch\)/,
   );
   assert.match(
     composer,
-    /subscribeToMcpServerMutationSettlements\(\(\) => \{\s*void refresh\(\)/,
+    /subscribeToMcpServerMutationSettlements\(\(epoch\) => \{\s*void refresh\(false, epoch\)/,
   );
-  assert.match(dialogRefresh, /listRefreshGenerationRef\.current !== generation/);
-  assert.match(composerRefresh, /listRefreshGenerationRef\.current !== generation/);
+  assert.match(
+    dialogRefresh,
+    /listRefreshGenerationRef\.current !== generation/,
+  );
+  assert.match(
+    composerRefresh,
+    /listRefreshGenerationRef\.current !== generation/,
+  );
   assert.doesNotMatch(dialog, /waitForPendingMcpServerMutations/);
   assert.doesNotMatch(composer, /waitForPendingMcpServerMutations/);
   assert.doesNotMatch(dialog, /await refresh\(\)/);

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -367,7 +367,7 @@ test("composer applies mutation responses before releasing each preset", () => {
   );
   assert.match(
     composer,
-    /const \[serversLoaded, setServersLoaded\] = useState\(false\)[\s\S]*setServers\(rows\);\s*setServersLoaded\(true\)/,
+    /const \[serversLoaded, setServersLoaded\] = useState\(false\)[\s\S]*setServersLoaded\(false\);[\s\S]*setServers\(rows\);\s*setServersLoaded\(true\)/,
   );
   assert.match(
     composer,

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -1,0 +1,551 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  createMcpStdioSnapshot,
+  resolveMcpStdioUrl,
+} from "../src/features/chat/mcp-server-form.ts";
+import {
+  readAfterPendingMcpServerMutations,
+  subscribeToMcpServerMutationSettlements,
+  trackMcpServerMutation,
+  waitForPendingMcpServerMutations,
+} from "../src/features/chat/api/mcp-server-mutation-tracker.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function sourceBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(startIndex, -1, `missing source marker: ${start}`);
+  assert.notEqual(endIndex, -1, `missing source marker: ${end}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function typescriptFilesUnder(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...typescriptFilesUnder(path));
+    } else if (/\.[cm]?tsx?$/.test(entry.name)) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+test("an unchanged stdio form reuses the exact original URL", () => {
+  const originalUrl = `python  -m mod --name "a b" ''`;
+  const snapshot = createMcpStdioSnapshot(originalUrl, "python", [
+    "-m",
+    "mod",
+    "--name",
+    "a b",
+    "",
+  ]);
+
+  assert.deepEqual(
+    resolveMcpStdioUrl("python", ["-m", "mod", "--name", "a b", ""], snapshot),
+    { kind: "reuse", url: originalUrl },
+  );
+});
+
+test("missing legacy arguments default to an empty ordered list", () => {
+  const snapshot = createMcpStdioSnapshot("python", "python");
+  assert.deepEqual(snapshot.arguments, []);
+  assert.deepEqual(resolveMcpStdioUrl("python", [], snapshot), {
+    kind: "reuse",
+    url: "python",
+  });
+});
+
+test("command, order, value, and intentional empty argument changes require encoding", () => {
+  const snapshot = createMcpStdioSnapshot("python -m mod", "python", [
+    "-m",
+    "mod",
+  ]);
+
+  for (const [command, arguments_] of [
+    ["python3", ["-m", "mod"]],
+    ["python", ["mod", "-m"]],
+    ["python", ["-m", "other"]],
+    ["python", ["-m", "mod", ""]],
+  ] as const) {
+    assert.deepEqual(resolveMcpStdioUrl(command, arguments_, snapshot), {
+      kind: "encode",
+      command,
+      arguments: [...arguments_],
+    });
+  }
+});
+
+test("the helper never parses, splits, joins, trims, or quotes commands", () => {
+  const helper = readFileSync(
+    new URL("../src/features/chat/mcp-server-form.ts", import.meta.url),
+    "utf8",
+  );
+  assert.doesNotMatch(helper, /\.(?:split|join|trim)\s*\(/);
+  assert.doesNotMatch(helper, /JSON\.stringify|replace\s*\(/);
+});
+
+test("the dialog wires backend codec calls, stale guards, and a stdio-only editor", () => {
+  const dialog = readFileSync(
+    new URL(
+      "../src/features/chat/chat-mcp-servers-dialog.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const api = readFileSync(
+    new URL("../src/features/chat/api/mcp-servers-api.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(api, /mcpRequest\("\/stdio\/decode"/);
+  assert.match(api, /mcpRequest\("\/stdio\/encode"/);
+  assert.match(dialog, /await decodeMcpStdioCommand\(server\.url\)/);
+  assert.match(dialog, /await encodeMcpStdioCommand\(\{/);
+  assert.match(dialog, /formGenerationRef\.current !== generation/);
+  assert.match(dialog, /activeEditIdRef\.current !== server\.id/);
+  assert.match(
+    dialog,
+    /function handleOpenChange[\s\S]*formGenerationRef\.current \+= 1;[\s\S]*onOpenChange\(next\)/,
+  );
+  assert.match(dialog, /addressIsCommand && \(\s*<ArgumentsEditor/);
+  assert.match(dialog, /const addressIsCommand = form\.transport === "stdio"/);
+  assert.match(
+    dialog,
+    /transport: transportFromAddress\(url\)/,
+  );
+  assert.match(
+    dialog,
+    /queueMicrotask\(\(\) => \{\s*if \(cancelled\) return;[\s\S]*setView\(\{ kind: "list" \}\)/,
+  );
+  assert.match(
+    dialog,
+    /function ArgumentsEditor[\s\S]*\{ id: newRowId\(\), value: "" \}/,
+  );
+  assert.match(
+    dialog,
+    /!addressIsCommand && \([\s\S]*Use OAuth sign-in/,
+  );
+  assert.match(dialog, /const decision = resolveMcpStdioUrl\(/);
+  assert.match(dialog, /decision\.kind === "reuse"[\s\S]*url = decision\.url/);
+  assert.match(
+    dialog,
+    /const url = stdio\s*\? await encodeStdioForGeneration\([\s\S]*testMcpServer\(\{\s*url,/,
+  );
+  assert.match(dialog, /return rows\.map\(\(row\) => row\.value\)/);
+  assert.match(
+    dialog,
+    /function ArgumentsEditor[\s\S]*data-reload-snapshot-sensitive/,
+  );
+  assert.match(api, /export function testMcpServer[\s\S]*body: \{\s*url:/);
+  assert.doesNotMatch(
+    dialog,
+    /npx -y @modelcontextprotocol\/server-filesystem \/tmp/,
+  );
+  assert.match(dialog, /URL or executable/);
+  assert.match(dialog, /https:\/\/example\.com\/mcp or npx/);
+  assert.match(dialog, /Add local arguments in the Arguments rows/);
+  assert.doesNotMatch(dialog, /form\.url\.(?:split|join)\s*\(/);
+  assert.doesNotMatch(dialog, /form\.arguments[^;\n]*\.join\s*\(/);
+});
+
+test("every mutable MCP form editor is locked for the full pending interval", () => {
+  const dialog = readFileSync(
+    new URL(
+      "../src/features/chat/chat-mcp-servers-dialog.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const argumentsEditor = sourceBetween(
+    dialog,
+    "function ArgumentsEditor",
+    "function HeadersEditor",
+  );
+  const headersEditor = sourceBetween(
+    dialog,
+    "function HeadersEditor",
+    "export interface ChatMcpServersDialogProps",
+  );
+
+  assert.equal(
+    argumentsEditor.match(/disabled=\{disabled\}/g)?.length,
+    3,
+    "argument add, input, and remove must all be locked",
+  );
+  assert.equal(
+    headersEditor.match(/disabled=\{disabled\}/g)?.length,
+    4,
+    "header/env add, key, value, and remove must all be locked",
+  );
+  assert.match(dialog, /const formPending = codecPending \|\| testing \|\| saving/);
+  assert.match(
+    dialog,
+    /id="mcp-display-name"[\s\S]*?disabled=\{formPending\}[\s\S]*?\/>/,
+  );
+  assert.match(
+    dialog,
+    /id="mcp-url"[\s\S]*?disabled=\{formPending\}[\s\S]*?\/>/,
+  );
+  assert.match(
+    dialog,
+    /<ArgumentsEditor[\s\S]*?disabled=\{formPending\}[\s\S]*?\/>/,
+  );
+  assert.match(
+    dialog,
+    /id="mcp-oauth"[\s\S]*?disabled=\{formPending\}[\s\S]*?\/>/,
+  );
+  assert.match(
+    dialog,
+    /<HeadersEditor[\s\S]*?disabled=\{formPending\}[\s\S]*?\/>/,
+  );
+});
+
+test("a decode error is announced and executable edits unlock manual recovery", () => {
+  const dialog = readFileSync(
+    new URL(
+      "../src/features/chat/chat-mcp-servers-dialog.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+
+  assert.match(
+    dialog,
+    /id="mcp-url"[\s\S]*?onChange=\{\(e\) => \{[\s\S]*?setCodecError\(null\)[\s\S]*?transport: transportFromAddress\(url\)/,
+  );
+  assert.match(
+    dialog,
+    /role="alert"\s*aria-live="assertive"[\s\S]*?\{codecError\}/,
+  );
+  assert.match(
+    dialog,
+    /disabled=\{\s*formPending \|\|\s*codecError !== null \|\|\s*!form\.url\.trim\(\)/,
+  );
+});
+
+test("dialog closure is blocked only after a save mutation starts", () => {
+  const dialog = readFileSync(
+    new URL(
+      "../src/features/chat/chat-mcp-servers-dialog.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const closeHandler = sourceBetween(
+    dialog,
+    "function handleOpenChange",
+    "async function encodeStdioForGeneration",
+  );
+
+  assert.match(
+    closeHandler,
+    /if \(!next && saving && !codecPending\) return;[\s\S]*if \(!next\) \{[\s\S]*formGenerationRef\.current \+= 1;/,
+    "the in-flight mutation guard must run before close invalidates the form generation",
+  );
+  assert.match(
+    dialog,
+    /<DialogContent[\s\S]*?showCloseButton=\{!\(saving && !codecPending\)\}[\s\S]*?>/,
+    "the built-in close control must disappear during the same mutation window",
+  );
+  assert.match(
+    dialog,
+    /onClick=\{cancelForm\}[\s\S]*?disabled=\{saving && !codecPending\}/,
+    "the visible Cancel action must use the same mutation boundary",
+  );
+  assert.match(
+    dialog,
+    /async function encodeStdioForGeneration[\s\S]*setCodecPending\(true\);[\s\S]*await encodeMcpStdioCommand/,
+    "codec encoding remains distinguishable so it can still be cancelled before CRUD starts",
+  );
+});
+
+test("open-time reconciliation waits for every mutation across component lifetimes", async () => {
+  const first = deferred<void>();
+  const second = deferred<void>();
+  const batchNotified = deferred<void>();
+  let notificationCount = 0;
+  const unsubscribe = subscribeToMcpServerMutationSettlements(() => {
+    notificationCount += 1;
+    batchNotified.resolve();
+  });
+  trackMcpServerMutation(first.promise);
+
+  let reconciled = false;
+  const reconciliation = waitForPendingMcpServerMutations().then(() => {
+    reconciled = true;
+  });
+  await Promise.resolve();
+  assert.equal(reconciled, false, "the first pending mutation must hold refresh");
+
+  // Simulate another API mutation starting after the opening component has
+  // already captured and begun waiting on the first batch.
+  trackMcpServerMutation(second.promise);
+  first.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(
+    reconciled,
+    false,
+    "a mutation added during settlement must also hold refresh",
+  );
+
+  second.resolve();
+  await reconciliation;
+  await batchNotified.promise;
+  unsubscribe();
+  assert.equal(reconciled, true);
+  assert.equal(notificationCount, 1, "a drained mutation batch publishes once");
+});
+
+test("failed mutations settle waiters without leaking a tracker rejection", async () => {
+  const mutation = deferred<void>();
+  const tracked = trackMcpServerMutation(mutation.promise);
+  assert.equal(tracked, mutation.promise);
+  const expectedFailure = assert.rejects(tracked, /save failed/);
+  const reconciliation = waitForPendingMcpServerMutations();
+
+  mutation.reject(new Error("save failed"));
+  await expectedFailure;
+  await reconciliation;
+  await waitForPendingMcpServerMutations();
+});
+
+test("settlement refreshes a mounted background consumer after another consumer mutates", async () => {
+  let authoritativeRows = ["old"];
+  let backgroundRows = await readAfterPendingMcpServerMutations(async () => [
+    ...authoritativeRows,
+  ]);
+  let foregroundRows = [...backgroundRows];
+  const backgroundUpdated = deferred<void>();
+  let notificationCount = 0;
+  let notifiedEpoch = 0;
+
+  const unsubscribe = subscribeToMcpServerMutationSettlements((epoch) => {
+    notificationCount += 1;
+    notifiedEpoch = epoch;
+    void readAfterPendingMcpServerMutations(async () => [
+      ...authoritativeRows,
+    ]).then((rows) => {
+      backgroundRows = rows;
+      backgroundUpdated.resolve();
+    });
+  });
+
+  const mutation = deferred<string>();
+  const tracked = trackMcpServerMutation(mutation.promise);
+  assert.equal(tracked, mutation.promise);
+  authoritativeRows = ["new"];
+  mutation.resolve("saved");
+
+  assert.equal(await tracked, "saved");
+  foregroundRows = await readAfterPendingMcpServerMutations(async () => [
+    ...authoritativeRows,
+  ]);
+  await backgroundUpdated.promise;
+  unsubscribe();
+
+  assert.deepEqual(foregroundRows, ["new"]);
+  assert.deepEqual(backgroundRows, ["new"]);
+  assert.equal(notificationCount, 1);
+  assert.ok(notifiedEpoch >= 2, "registration and settlement both advance epoch");
+});
+
+test("a list read retries when a mutation starts after its pre-read drain", async () => {
+  let authoritativeRows = ["old"];
+  let readCount = 0;
+  const firstReadStarted = deferred<void>();
+  const firstReadResult = deferred<string[]>();
+
+  const stableRead = readAfterPendingMcpServerMutations(async () => {
+    readCount += 1;
+    if (readCount === 1) {
+      firstReadStarted.resolve();
+      return firstReadResult.promise;
+    }
+    return [...authoritativeRows];
+  });
+
+  await firstReadStarted.promise;
+  const mutation = deferred<void>();
+  const tracked = trackMcpServerMutation(mutation.promise);
+  firstReadResult.resolve(["old"]);
+  authoritativeRows = ["new"];
+  mutation.resolve();
+
+  await tracked;
+  assert.deepEqual(await stableRead, ["new"]);
+  assert.equal(readCount, 2, "the overlapping old read must be retried once");
+});
+
+test("a rejected overlapping list read retries after settlement subscribers join it", async () => {
+  let authoritativeRows = ["old"];
+  let readCount = 0;
+  let listRequest: Promise<string[]> | null = null;
+  const firstReadStarted = deferred<void>();
+  const firstReadResult = deferred<string[]>();
+
+  function listRows(): Promise<string[]> {
+    if (listRequest) return listRequest;
+    const request = readAfterPendingMcpServerMutations(async () => {
+      readCount += 1;
+      if (readCount === 1) {
+        firstReadStarted.resolve();
+        return firstReadResult.promise;
+      }
+      return [...authoritativeRows];
+    });
+    listRequest = request;
+    void request.then(
+      () => {
+        if (listRequest === request) listRequest = null;
+      },
+      () => {
+        if (listRequest === request) listRequest = null;
+      },
+    );
+    return request;
+  }
+
+  const originalRequest = listRows();
+  await firstReadStarted.promise;
+
+  const subscriberJoined = deferred<void>();
+  let subscriberRequest: Promise<string[]> | null = null;
+  let notificationCount = 0;
+  const unsubscribe = subscribeToMcpServerMutationSettlements(() => {
+    notificationCount += 1;
+    subscriberRequest = listRows();
+    subscriberJoined.resolve();
+  });
+
+  const mutation = deferred<void>();
+  const tracked = trackMcpServerMutation(mutation.promise);
+  authoritativeRows = ["new"];
+  mutation.resolve();
+  await tracked;
+  await subscriberJoined.promise;
+
+  assert.equal(
+    subscriberRequest,
+    originalRequest,
+    "the settlement subscriber must initially join the in-flight GET",
+  );
+  firstReadResult.reject(new Error("transient list failure"));
+
+  assert.deepEqual(await originalRequest, ["new"]);
+  assert.deepEqual(await subscriberRequest, ["new"]);
+  unsubscribe();
+  assert.equal(notificationCount, 1);
+  assert.equal(readCount, 2, "the failed overlapping GET gets one fresh retry");
+});
+
+test("a list rejection without an epoch change preserves the original error", async () => {
+  const expected = new Error("unrelated list failure");
+  let readCount = 0;
+  await assert.rejects(
+    readAfterPendingMcpServerMutations(async () => {
+      readCount += 1;
+      throw expected;
+    }),
+    (error) => error === expected,
+  );
+  assert.equal(readCount, 1, "an unrelated failure must not be retried");
+});
+
+test("every list consumer uses the shared pending-mutation read barrier", () => {
+  const chatRoot = fileURLToPath(
+    new URL("../src/features/chat/", import.meta.url),
+  );
+  const dialog = readFileSync(
+    new URL(
+      "../src/features/chat/chat-mcp-servers-dialog.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const api = readFileSync(
+    new URL("../src/features/chat/api/mcp-servers-api.ts", import.meta.url),
+    "utf8",
+  );
+  const composer = readFileSync(
+    new URL("../src/features/chat/mcp-composer-button.tsx", import.meta.url),
+    "utf8",
+  );
+  const listApi = sourceBetween(
+    api,
+    "export function listMcpServers",
+    "export function createMcpServer",
+  );
+  const dialogRefresh = sourceBetween(
+    dialog,
+    "const refresh = useCallback",
+    "useEffect(() =>",
+  );
+  const composerRefresh = sourceBetween(
+    composer,
+    "const refresh = useCallback",
+    "// Load the server list on mount",
+  );
+
+  const listOccurrences = typescriptFilesUnder(chatRoot)
+    .flatMap((file) => {
+      const count = readFileSync(file, "utf8").match(/\blistMcpServers\s*\(/g)?.length ?? 0;
+      return Array.from({ length: count }, () =>
+        relative(chatRoot, file).replaceAll("\\", "/"),
+      );
+    })
+    .sort();
+
+  assert.deepEqual(listOccurrences, [
+    "api/mcp-servers-api.ts",
+    "chat-mcp-servers-dialog.tsx",
+    "mcp-composer-button.tsx",
+  ]);
+
+  assert.equal(
+    api.match(/return trackMcpServerMutation\(/g)?.length,
+    4,
+    "create, update, delete, and import must register at the API boundary",
+  );
+  assert.match(
+    listApi,
+    /readAfterPendingMcpServerMutations\(\(\) =>[\s\S]*mcpRequest<McpServerConfig\[\]>\("\/"\)/,
+    "the shared query boundary must retry reads that overlap tracked mutations",
+  );
+  assert.match(listApi, /if \(mcpServerListRequest\) return mcpServerListRequest/);
+  assert.match(dialogRefresh, /await listMcpServers\(\)/);
+  assert.match(composerRefresh, /await listMcpServers\(\)/);
+  assert.match(
+    dialog,
+    /subscribeToMcpServerMutationSettlements\(\(\) => \{\s*void refresh\(\)/,
+  );
+  assert.match(
+    composer,
+    /subscribeToMcpServerMutationSettlements\(\(\) => \{\s*void refresh\(\)/,
+  );
+  assert.match(dialogRefresh, /listRefreshGenerationRef\.current !== generation/);
+  assert.match(composerRefresh, /listRefreshGenerationRef\.current !== generation/);
+  assert.doesNotMatch(dialog, /waitForPendingMcpServerMutations/);
+  assert.doesNotMatch(composer, /waitForPendingMcpServerMutations/);
+  assert.doesNotMatch(dialog, /await refresh\(\)/);
+  assert.doesNotMatch(composer, /await refresh\(\)/);
+});

--- a/tests/studio/playwright_mcp_arguments.py
+++ b/tests/studio/playwright_mcp_arguments.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from playwright.sync_api import expect, sync_playwright
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _playwright_robust import (  # noqa: E402
+    chromium_launch_args,
+    install_view_transition_killer,
+    install_wall_clock_watchdog,
+    wait_for_health,
+)
+
+
+BASE = os.environ["BASE_URL"].rstrip("/")
+OLD = os.environ["STUDIO_OLD_PW"]
+NEW = os.environ["STUDIO_NEW_PW"]
+ART = Path(os.environ.get("PW_ART_DIR", "logs/playwright-mcp-arguments"))
+BROWSER = os.environ.get("STUDIO_PLAYWRIGHT_BROWSER", "chromium").lower()
+CHANNEL = os.environ.get("STUDIO_PLAYWRIGHT_CHANNEL") or None
+WALL_TIMEOUT_S = float(os.environ.get("STUDIO_UI_WALL_TIMEOUT_S", "420"))
+SOURCE_FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "studio"
+    / "backend"
+    / "tests"
+    / "fixtures"
+    / "mcp_argument_echo_server.py"
+)
+
+
+def info(message: str) -> None:
+    print(f"[mcp-ui] {message}", flush=True)
+
+
+def api(
+    path: str,
+    payload: dict | None = None,
+    token: str | None = None,
+    method: str = "POST",
+) -> dict | list:
+    request = urllib.request.Request(
+        BASE + path,
+        data=json.dumps(payload).encode() if payload is not None else None,
+        headers={
+            "Content-Type": "application/json",
+            **({"Authorization": f"Bearer {token}"} if token else {}),
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        body = response.read()
+        return json.loads(body) if body else {}
+
+
+def authenticate() -> dict:
+    try:
+        session = api("/api/auth/login", {"username": "unsloth", "password": NEW})
+        if not session.get("must_change_password"):
+            return session
+    except urllib.error.HTTPError:
+        pass
+    initial = api("/api/auth/login", {"username": "unsloth", "password": OLD})
+    try:
+        api(
+            "/api/auth/change-password",
+            {"current_password": OLD, "new_password": NEW},
+            initial["access_token"],
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code not in (400, 401, 403):
+            raise
+    return api("/api/auth/login", {"username": "unsloth", "password": NEW})
+
+
+def remove_prior_test_servers(token: str) -> None:
+    servers = api("/api/mcp/servers/", token=token, method="GET")
+    assert isinstance(servers, list)
+    for server in servers:
+        if server.get("display_name") not in (
+            "Playwright argument echo",
+            "Playwright imported echo",
+        ):
+            continue
+        api(
+            f"/api/mcp/servers/{server['id']}",
+            token=token,
+            method="DELETE",
+        )
+
+
+def open_dialog(page):
+    page.keyboard.press("Control+Alt+m")
+    dialog = page.get_by_role("dialog", name="MCP Servers")
+    expect(dialog).to_be_visible()
+    return dialog
+
+
+def row_for(dialog, name: str):
+    row = dialog.locator("li").filter(has_text=name)
+    expect(row).to_have_count(1)
+    return row
+
+
+def fill_arguments(dialog, arguments: list[str]) -> None:
+    for index, argument in enumerate(arguments, start=1):
+        dialog.get_by_role("button", name="Add argument").click()
+        dialog.get_by_role("textbox", name=f"Argument {index}", exact=True).fill(argument)
+
+
+def fill_environment(dialog, values: dict[str, str]) -> None:
+    for key, value in values.items():
+        dialog.get_by_role("button", name="Add variable").click()
+        keys = dialog.get_by_placeholder("Variable name")
+        vals = dialog.get_by_placeholder("Variable value")
+        keys.nth(keys.count() - 1).fill(key)
+        vals.nth(vals.count() - 1).fill(value)
+
+
+def assert_arguments(dialog, expected: list[str]) -> None:
+    inputs = dialog.locator('[aria-label^="Argument "]')
+    expect(inputs).to_have_count(len(expected))
+    for index, value in enumerate(expected):
+        expect(inputs.nth(index)).to_have_value(value)
+
+
+def screenshot(dialog, name: str) -> None:
+    dialog.screenshot(path=str(ART / f"{name}-{BROWSER}.png"))
+
+
+def delay_real_response(seconds: float):
+    def handler(route):
+        response = route.fetch()
+        time.sleep(seconds)
+        route.fulfill(response=response)
+
+    return handler
+
+
+def run(page, launch_log: Path, fixture: Path) -> None:
+    page.goto(BASE + "/hub", wait_until="domcontentloaded")
+    page.goto(BASE + "/chat", wait_until="domcontentloaded")
+    page.wait_for_timeout(1000)
+    if page.url.startswith(BASE + "/login") or page.url.startswith(BASE + "/change-password"):
+        raise AssertionError(f"not authenticated: {page.url}")
+
+    dialog = open_dialog(page)
+    dialog.get_by_role("button", name="Add server").click()
+    dialog.locator("#mcp-display-name").fill("Playwright argument echo")
+    dialog.locator("#mcp-url").fill(sys.executable)
+    arguments = [
+        str(fixture),
+        "--flag",
+        "",
+        "a b",
+        'quote"inside',
+        "single'quote",
+        "trailing\\",
+        "https://example.com/value?q=a%20b",
+        "  keep outer spaces  ",
+    ]
+    fill_arguments(dialog, arguments)
+    environment = {
+        "UNSLOTH_MCP_ARGUMENT_MARKER": "playwright create",
+        "UNSLOTH_MCP_ARGUMENT_LOG": str(launch_log),
+    }
+    fill_environment(dialog, environment)
+    screenshot(dialog, "fixed-create-filled")
+
+    dialog.get_by_role("button", name="Test connection").click()
+    expect(page.get_by_text("Connected (1 tool)")).to_be_visible(timeout=30_000)
+    dialog.get_by_role("button", name="Add server").click()
+    row = row_for(dialog, "Playwright argument echo")
+    expect(row).to_contain_text("--flag")
+
+    page.route("**/api/mcp/servers/stdio/decode", delay_real_response(1.5))
+    row.get_by_role("button", name="Edit server").click(no_wait_after=True)
+    loading = dialog.get_by_text("Reading local command…", exact=True)
+    expect(loading).to_be_visible()
+    screenshot(dialog, "fixed-edit-loading")
+    page.unroute("**/api/mcp/servers/stdio/decode")
+    expect(loading).to_be_hidden(timeout=10_000)
+    assert_arguments(dialog, arguments)
+    screenshot(dialog, "fixed-edit-hydrated")
+
+    dialog.get_by_role("button", name="Cancel").click()
+    dialog.get_by_role("button", name="Close").click()
+    page.reload(wait_until="domcontentloaded")
+    page.wait_for_timeout(500)
+    dialog = open_dialog(page)
+    row = row_for(dialog, "Playwright argument echo")
+    row.get_by_role("button", name="Edit server").click()
+    assert_arguments(dialog, arguments)
+
+    edited = [str(fixture), "second", "", "first", "a&b", "x|y", "%TOKEN%"]
+    inputs = dialog.locator('[aria-label^="Argument "]')
+    while inputs.count() > len(edited):
+        dialog.get_by_role("button", name=f"Remove argument {inputs.count()}").click()
+    for index, value in enumerate(edited):
+        dialog.get_by_role("textbox", name=f"Argument {index + 1}", exact=True).fill(value)
+    dialog.get_by_placeholder("Variable value").first.fill("playwright edited")
+    dialog.get_by_role("button", name="Save changes").click()
+    expect(page.get_by_text("MCP server updated")).to_be_visible()
+    row = row_for(dialog, "Playwright argument echo")
+    row.get_by_role("button", name="Edit server").click()
+    assert_arguments(dialog, edited)
+    screenshot(dialog, "fixed-edit-persisted")
+
+    dialog.get_by_role("button", name="Cancel").click()
+    row = row_for(dialog, "Playwright argument echo")
+    launches_before_refresh = len(launch_log.read_text(encoding="utf-8").splitlines())
+    row.get_by_role("button", name="Refresh tools").click()
+    expect(page.get_by_text('Refreshed "Playwright argument echo" (1 tool)')).to_be_visible(
+        timeout=30_000
+    )
+    launches_after_refresh = len(launch_log.read_text(encoding="utf-8").splitlines())
+    assert launches_after_refresh == launches_before_refresh + 1
+
+    imported = {
+        "mcpServers": {
+            "Playwright imported echo": {
+                "command": sys.executable,
+                "args": [str(fixture), "imported", "", "with spaces", 'say "hello"'],
+                "env": {
+                    "UNSLOTH_MCP_ARGUMENT_MARKER": "playwright import",
+                    "UNSLOTH_MCP_ARGUMENT_LOG": str(launch_log),
+                },
+            }
+        }
+    }
+    dialog.locator('input[type="file"]').set_input_files(
+        {
+            "name": "mcp-config.json",
+            "mimeType": "application/json",
+            "buffer": json.dumps(imported).encode(),
+        }
+    )
+    expect(page.get_by_text("1 added")).to_be_visible(timeout=10_000)
+    imported_row = row_for(dialog, "Playwright imported echo")
+    imported_row.get_by_role("button", name="Edit server").click()
+    assert_arguments(dialog, [str(fixture), "imported", "", "with spaces", 'say "hello"'])
+    dialog.get_by_role("button", name="Test connection").click()
+    expect(page.get_by_text("Connected (1 tool)")).to_be_visible(timeout=30_000)
+    dialog.get_by_role("button", name="Cancel").click()
+    imported_row = row_for(dialog, "Playwright imported echo")
+    imported_row.get_by_role("button", name="Refresh tools").click()
+    expect(page.get_by_text('Refreshed "Playwright imported echo" (1 tool)')).to_be_visible(
+        timeout=30_000
+    )
+
+    row = row_for(dialog, "Playwright argument echo")
+    page.route(
+        "**/api/mcp/servers/stdio/decode",
+        lambda route: route.fulfill(
+            status=500,
+            content_type="application/json",
+            body=json.dumps({"detail": "forced decode failure"}),
+        ),
+        times=1,
+    )
+    row.get_by_role("button", name="Edit server").click()
+    expect(dialog.get_by_role("alert")).to_contain_text("forced decode failure")
+    expect(dialog.locator("#mcp-url")).not_to_have_value("")
+    screenshot(dialog, "fixed-edit-error")
+    dialog.get_by_role("button", name="Retry").click()
+    assert_arguments(dialog, edited)
+
+    expect(dialog.get_by_placeholder("Variable name")).to_have_count(2)
+    dialog.locator("#mcp-url").fill("https://example.com/mcp")
+    expect(dialog.get_by_text("Custom headers", exact=True)).to_be_visible()
+    expect(dialog.get_by_placeholder("Header name")).to_have_count(0)
+    dialog.get_by_role("button", name="Add header").click()
+    dialog.get_by_placeholder("Header name").fill("Authorization")
+    dialog.get_by_placeholder("Header value").fill("Bearer remote-secret")
+    dialog.locator("#mcp-url").fill(sys.executable)
+    expect(dialog.get_by_text("Environment variables", exact=True)).to_be_visible()
+    expect(dialog.get_by_placeholder("Variable name")).to_have_count(0)
+    screenshot(dialog, "fixed-transport-credentials-cleared")
+    dialog.get_by_role("button", name="Cancel").click()
+
+    row = row_for(dialog, "Playwright argument echo")
+    row.get_by_role("button", name="Delete server").click()
+    expect(page.get_by_role("alertdialog", name="Delete MCP server")).to_be_visible()
+    page.go_back(wait_until="domcontentloaded")
+    expect(page).to_have_url(BASE + "/hub")
+    expect(page.get_by_role("alertdialog", name="Delete MCP server")).to_have_count(0)
+    page.screenshot(path=str(ART / f"fixed-delete-route-closed-{BROWSER}.png"))
+
+    records = [json.loads(line) for line in launch_log.read_text(encoding="utf-8").splitlines()]
+    expected_runs = [record for record in records if record["marker"] == "playwright edited"]
+    assert expected_runs
+    assert all(record["arguments"] == edited[1:] for record in expected_runs)
+    imported_runs = [record for record in records if record["marker"] == "playwright import"]
+    assert imported_runs
+    assert all(
+        record["arguments"] == ["imported", "", "with spaces", 'say "hello"']
+        for record in imported_runs
+    )
+
+
+def main() -> int:
+    ART.mkdir(parents=True, exist_ok=True)
+    fixture_dir = ART / "fixture directory with spaces"
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+    fixture = fixture_dir / SOURCE_FIXTURE.name
+    shutil.copyfile(SOURCE_FIXTURE, fixture)
+    launch_log = ART / "argument launches.jsonl"
+    launch_log.unlink(missing_ok=True)
+    wait_for_health(BASE, timeout=60, info=info)
+    session = authenticate()
+    remove_prior_test_servers(session["access_token"])
+    seed_js = (
+        "(() => {"
+        f"localStorage.setItem('unsloth_auth_token', {json.dumps(session['access_token'])});"
+        f"localStorage.setItem('unsloth_refresh_token', {json.dumps(session.get('refresh_token', ''))});"
+        "localStorage.setItem('unsloth_keyboard_shortcuts', "
+        "JSON.stringify({openMcpServers:{primary:'Mod+Alt+KeyM'}}));"
+        "})();"
+    )
+    install_wall_clock_watchdog(WALL_TIMEOUT_S, label="mcp-arguments", info=info)
+    with sync_playwright() as playwright:
+        if BROWSER not in ("chromium", "firefox", "webkit"):
+            raise AssertionError(f"unsupported browser: {BROWSER}")
+        browser_type = getattr(playwright, BROWSER)
+        launch_kwargs: dict = {"headless": True}
+        if BROWSER == "chromium":
+            launch_kwargs["args"] = chromium_launch_args()
+            if CHANNEL:
+                launch_kwargs["channel"] = CHANNEL
+        browser = browser_type.launch(**launch_kwargs)
+        context = browser.new_context(
+            viewport={"width": 1280, "height": 900},
+            reduced_motion="reduce",
+        )
+        install_view_transition_killer(context)
+        context.add_init_script(seed_js)
+        page = context.new_page()
+        page.set_default_timeout(15_000)
+        try:
+            run(page, launch_log, fixture)
+        finally:
+            page.screenshot(path=str(ART / f"fixed-final-{BROWSER}.png"), full_page=True)
+            context.close()
+            browser.close()
+    info("PASS real stdio create, edit, import, probe, persistence, reconnect, and launch")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/studio/playwright_mcp_arguments.py
+++ b/tests/studio/playwright_mcp_arguments.py
@@ -148,6 +148,18 @@ def delay_real_response(seconds: float):
     return handler
 
 
+def hold_next_request(page, pattern: str) -> list:
+    held: list = []
+    page.route(pattern, lambda route: held.append(route), times = 1)
+    return held
+
+
+def release_request(page, held: list) -> None:
+    page.wait_for_timeout(50)
+    assert len(held) == 1
+    held[0].continue_()
+
+
 def run(page, launch_log: Path, fixture: Path) -> None:
     page.goto(BASE + "/hub", wait_until = "domcontentloaded")
     page.goto(BASE + "/chat", wait_until = "domcontentloaded")
@@ -220,7 +232,14 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     dialog.get_by_role("button", name = "Cancel").click()
     row = row_for(dialog, "Playwright argument echo")
     launches_before_refresh = len(launch_log.read_text(encoding = "utf-8").splitlines())
-    row.get_by_role("button", name = "Refresh tools").click()
+    held_refresh = hold_next_request(page, "**/api/mcp/servers/*/refresh")
+    row.get_by_role("button", name = "Refresh tools").click(no_wait_after = True)
+    expect(row.get_by_role("switch", name = "Enable server")).to_be_disabled()
+    expect(row.get_by_role("button", name = "Refresh tools")).to_be_disabled()
+    expect(row.get_by_role("button", name = "Edit server")).to_be_disabled()
+    expect(row.get_by_role("button", name = "Delete server")).to_be_disabled()
+    screenshot(dialog, "fixed-row-busy")
+    release_request(page, held_refresh)
     expect(page.get_by_text('Refreshed "Playwright argument echo" (1 tool)')).to_be_visible(
         timeout = 30_000
     )
@@ -239,6 +258,7 @@ def run(page, launch_log: Path, fixture: Path) -> None:
             }
         }
     }
+    held_import = hold_next_request(page, "**/api/mcp/servers/import")
     dialog.locator('input[type="file"]').set_input_files(
         {
             "name": "mcp-config.json",
@@ -246,7 +266,15 @@ def run(page, launch_log: Path, fixture: Path) -> None:
             "buffer": json.dumps(imported).encode(),
         }
     )
-    expect(page.get_by_text("1 added")).to_be_visible(timeout = 10_000)
+    expect(dialog.get_by_role("button", name = "Import")).to_be_disabled()
+    expect(dialog.get_by_role("button", name = "Add server")).to_be_disabled()
+    dialog.get_by_role("button", name = "Close").click()
+    dialog = open_dialog(page)
+    expect(dialog.get_by_role("button", name = "Import")).to_be_disabled()
+    expect(dialog.get_by_role("button", name = "Add server")).to_be_disabled()
+    screenshot(dialog, "fixed-import-reopened-busy")
+    release_request(page, held_import)
+    expect(dialog.get_by_role("button", name = "Import")).to_be_enabled(timeout = 10_000)
     imported_row = row_for(dialog, "Playwright imported echo")
     imported_row.get_by_role("button", name = "Edit server").click()
     assert_arguments(dialog, [str(fixture), "imported", "", "with spaces", 'say "hello"'])
@@ -283,6 +311,16 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     dialog.get_by_role("button", name = "Add header").click()
     dialog.get_by_placeholder("Header name").fill("Authorization")
     dialog.get_by_placeholder("Header value").fill("Bearer remote-secret")
+    oauth = dialog.get_by_role("switch", name = "Use OAuth sign-in")
+    oauth.click()
+    expect(oauth).to_be_checked()
+    address = dialog.locator("#mcp-url")
+    address.fill("")
+    address.press_sequentially("https://example.org/mcp")
+    expect(dialog.get_by_placeholder("Header name")).to_have_count(1)
+    expect(dialog.get_by_placeholder("Header name")).to_have_value("Authorization")
+    expect(oauth).to_be_checked()
+    screenshot(dialog, "fixed-http-typing-preserves-credentials")
     dialog.locator("#mcp-url").fill(sys.executable)
     expect(dialog.get_by_text("Environment variables", exact = True)).to_be_visible()
     expect(dialog.get_by_placeholder("Variable name")).to_have_count(0)

--- a/tests/studio/playwright_mcp_arguments.py
+++ b/tests/studio/playwright_mcp_arguments.py
@@ -272,6 +272,13 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     expect(dialog.get_by_role("button", name = "Import")).to_be_disabled()
     expect(dialog.get_by_role("button", name = "Add server")).to_be_disabled()
     dialog.get_by_role("button", name = "Close").click()
+    composer = page.get_by_role("button", name = "MCP servers")
+    composer.click()
+    expect(page.get_by_role("menuitem", name = "Unsloth Docs")).to_be_disabled()
+    page.get_by_role("menu").screenshot(
+        path = str(ART / f"fixed-composer-import-reconciliation-busy-{BROWSER}.png")
+    )
+    page.keyboard.press("Escape")
     dialog = open_dialog(page)
     expect(dialog.get_by_role("button", name = "Import")).to_be_disabled()
     expect(dialog.get_by_role("button", name = "Add server")).to_be_disabled()
@@ -324,6 +331,10 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     expect(dialog.get_by_placeholder("Header name")).to_have_value("Authorization")
     expect(oauth).to_be_checked()
     screenshot(dialog, "fixed-http-typing-preserves-credentials")
+    address.fill("https:/")
+    expect(dialog.get_by_role("button", name = "Save changes")).to_be_disabled()
+    expect(dialog.get_by_role("button", name = "Test connection")).to_be_disabled()
+    screenshot(dialog, "fixed-partial-http-save-disabled")
     address.fill("http")
     expect(dialog.get_by_role("button", name = "Save changes")).to_be_disabled()
     expect(dialog.get_by_role("button", name = "Test connection")).to_be_disabled()
@@ -365,17 +376,21 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     )
     page.route("**/api/mcp/servers/", hold_first_list)
     preset.click()
-    expect(preset).to_be_enabled(timeout = 10_000)
+    expect(preset).to_be_disabled(timeout = 10_000)
+    deadline = time.monotonic() + 10
+    while (not held_list or writes.count("POST") != 1) and time.monotonic() < deadline:
+        page.wait_for_timeout(50)
     assert held_list and writes.count("POST") == 1
     page.get_by_role("menu").screenshot(
-        path = str(ART / f"fixed-composer-preset-settles-locally-{BROWSER}.png")
+        path = str(ART / f"fixed-composer-preset-waits-for-refresh-{BROWSER}.png")
     )
+    release_request(page, held_list)
+    page.unroute("**/api/mcp/servers/", hold_first_list)
+    expect(preset).to_be_enabled(timeout = 10_000)
     preset.click()
     page.wait_for_timeout(500)
     assert writes.count("POST") == 1
     assert writes.count("PUT") == 1
-    release_request(page, held_list)
-    page.unroute("**/api/mcp/servers/", hold_first_list)
     page.get_by_role("menuitem", name = "Manage MCP servers").press("Enter")
     dialog = page.get_by_role("dialog", name = "MCP Servers")
     expect(dialog).to_be_visible()

--- a/tests/studio/playwright_mcp_arguments.py
+++ b/tests/studio/playwright_mcp_arguments.py
@@ -38,6 +38,7 @@ SOURCE_FIXTURE = (
     / "fixtures"
     / "mcp_argument_echo_server.py"
 )
+MCP_PYTHON = os.environ.get("STUDIO_MCP_PYTHON", sys.executable)
 
 
 def info(message: str) -> None:
@@ -91,6 +92,7 @@ def remove_prior_test_servers(token: str) -> None:
         if server.get("display_name") not in (
             "Playwright argument echo",
             "Playwright imported echo",
+            "Unsloth Docs",
         ):
             continue
         api(
@@ -170,7 +172,7 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     dialog = open_dialog(page)
     dialog.get_by_role("button", name = "Add server").click()
     dialog.locator("#mcp-display-name").fill("Playwright argument echo")
-    dialog.locator("#mcp-url").fill(sys.executable)
+    dialog.locator("#mcp-url").fill(MCP_PYTHON)
     arguments = [
         str(fixture),
         "--flag",
@@ -238,6 +240,7 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     expect(row.get_by_role("button", name = "Refresh tools")).to_be_disabled()
     expect(row.get_by_role("button", name = "Edit server")).to_be_disabled()
     expect(row.get_by_role("button", name = "Delete server")).to_be_disabled()
+    expect(dialog.get_by_role("button", name = "Close")).to_have_count(0)
     screenshot(dialog, "fixed-row-busy")
     release_request(page, held_refresh)
     expect(page.get_by_text('Refreshed "Playwright argument echo" (1 tool)')).to_be_visible(
@@ -249,7 +252,7 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     imported = {
         "mcpServers": {
             "Playwright imported echo": {
-                "command": sys.executable,
+                "command": MCP_PYTHON,
                 "args": [str(fixture), "imported", "", "with spaces", 'say "hello"'],
                 "env": {
                     "UNSLOTH_MCP_ARGUMENT_MARKER": "playwright import",
@@ -321,16 +324,68 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     expect(dialog.get_by_placeholder("Header name")).to_have_value("Authorization")
     expect(oauth).to_be_checked()
     screenshot(dialog, "fixed-http-typing-preserves-credentials")
-    dialog.locator("#mcp-url").fill(sys.executable)
+    address.fill("http")
+    expect(dialog.get_by_role("button", name = "Save changes")).to_be_disabled()
+    expect(dialog.get_by_role("button", name = "Test connection")).to_be_disabled()
+    screenshot(dialog, "fixed-ambiguous-http-save-disabled")
+    address.blur()
+    expect(dialog.get_by_text("Environment variables", exact = True)).to_be_visible()
+    expect(dialog.get_by_placeholder("Variable name")).to_have_count(0)
+    expect(dialog.get_by_role("switch", name = "Use OAuth sign-in")).to_have_count(0)
+    screenshot(dialog, "fixed-ambiguous-http-command-clears-credentials")
+    dialog.locator("#mcp-url").fill(MCP_PYTHON)
     expect(dialog.get_by_text("Environment variables", exact = True)).to_be_visible()
     expect(dialog.get_by_placeholder("Variable name")).to_have_count(0)
     screenshot(dialog, "fixed-transport-credentials-cleared")
     dialog.get_by_role("button", name = "Cancel").click()
 
+    dialog.get_by_role("button", name = "Close").click()
+    composer = page.get_by_role("button", name = "MCP servers")
+    expect(composer).to_be_visible()
+    composer.click()
+    preset = page.get_by_role("menuitem", name = "Unsloth Docs")
+    expect(preset).to_be_enabled()
+    page.wait_for_timeout(250)
+    held_list: list = []
+
+    def hold_first_list(route):
+        if route.request.method == "GET" and not held_list:
+            held_list.append(route)
+        else:
+            route.continue_()
+
+    writes = []
+    page.on(
+        "request",
+        lambda request: (
+            writes.append(request.method)
+            if "/api/mcp/servers/" in request.url and request.method in ("POST", "PUT")
+            else None
+        ),
+    )
+    page.route("**/api/mcp/servers/", hold_first_list)
+    preset.click()
+    expect(preset).to_be_enabled(timeout = 10_000)
+    assert held_list and writes.count("POST") == 1
+    page.get_by_role("menu").screenshot(
+        path = str(ART / f"fixed-composer-preset-settles-locally-{BROWSER}.png")
+    )
+    preset.click()
+    page.wait_for_timeout(500)
+    assert writes.count("POST") == 1
+    assert writes.count("PUT") == 1
+    release_request(page, held_list)
+    page.unroute("**/api/mcp/servers/", hold_first_list)
+    page.get_by_role("menuitem", name = "Manage MCP servers").press("Enter")
+    dialog = page.get_by_role("dialog", name = "MCP Servers")
+    expect(dialog).to_be_visible()
+    expect(dialog.locator("li").filter(has_text = "Unsloth Docs")).to_have_count(1)
+    screenshot(dialog, "fixed-composer-preset-no-duplicate")
+
     row = row_for(dialog, "Playwright argument echo")
     row.get_by_role("button", name = "Delete server").click()
     expect(page.get_by_role("alertdialog", name = "Delete MCP server")).to_be_visible()
-    page.go_back(wait_until = "domcontentloaded")
+    page.goto(BASE + "/hub", wait_until = "domcontentloaded")
     expect(page).to_have_url(BASE + "/hub")
     expect(page.get_by_role("alertdialog", name = "Delete MCP server")).to_have_count(0)
     page.screenshot(path = str(ART / f"fixed-delete-route-closed-{BROWSER}.png"))
@@ -364,6 +419,7 @@ def main() -> int:
         f"localStorage.setItem('unsloth_refresh_token', {json.dumps(session.get('refresh_token', ''))});"
         "localStorage.setItem('unsloth_keyboard_shortcuts', "
         "JSON.stringify({openMcpServers:{primary:'Mod+Alt+KeyM'}}));"
+        "localStorage.setItem('unsloth_chat_mcp_enabled', 'true');"
         "})();"
     )
     install_wall_clock_watchdog(WALL_TIMEOUT_S, label = "mcp-arguments", info = info)
@@ -391,6 +447,7 @@ def main() -> int:
             page.screenshot(path = str(ART / f"fixed-final-{BROWSER}.png"), full_page = True)
             context.close()
             browser.close()
+            remove_prior_test_servers(session["access_token"])
     info("PASS real stdio create, edit, import, probe, persistence, reconnect, and launch")
     return 0
 

--- a/tests/studio/playwright_mcp_arguments.py
+++ b/tests/studio/playwright_mcp_arguments.py
@@ -391,6 +391,26 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     page.wait_for_timeout(500)
     assert writes.count("POST") == 1
     assert writes.count("PUT") == 1
+    failed_list = []
+
+    def fail_next_list(route):
+        if route.request.method == "GET" and not failed_list:
+            failed_list.append(route.request.url)
+            route.fulfill(status = 503, json = {"detail": "temporary list failure"})
+        else:
+            route.continue_()
+
+    page.route("**/api/mcp/servers/", fail_next_list)
+    preset.click()
+    deadline = time.monotonic() + 10
+    while (not failed_list or writes.count("PUT") != 2) and time.monotonic() < deadline:
+        page.wait_for_timeout(50)
+    assert failed_list and writes.count("PUT") == 2
+    expect(preset).to_be_enabled()
+    page.get_by_role("menu").screenshot(
+        path = str(ART / f"fixed-composer-recovers-after-refresh-error-{BROWSER}.png")
+    )
+    page.unroute("**/api/mcp/servers/", fail_next_list)
     page.get_by_role("menuitem", name = "Manage MCP servers").press("Enter")
     dialog = page.get_by_role("dialog", name = "MCP Servers")
     expect(dialog).to_be_visible()

--- a/tests/studio/playwright_mcp_arguments.py
+++ b/tests/studio/playwright_mcp_arguments.py
@@ -41,7 +41,7 @@ SOURCE_FIXTURE = (
 
 
 def info(message: str) -> None:
-    print(f"[mcp-ui] {message}", flush=True)
+    print(f"[mcp-ui] {message}", flush = True)
 
 
 def api(
@@ -52,14 +52,14 @@ def api(
 ) -> dict | list:
     request = urllib.request.Request(
         BASE + path,
-        data=json.dumps(payload).encode() if payload is not None else None,
-        headers={
+        data = json.dumps(payload).encode() if payload is not None else None,
+        headers = {
             "Content-Type": "application/json",
             **({"Authorization": f"Bearer {token}"} if token else {}),
         },
-        method=method,
+        method = method,
     )
-    with urllib.request.urlopen(request, timeout=30) as response:
+    with urllib.request.urlopen(request, timeout = 30) as response:
         body = response.read()
         return json.loads(body) if body else {}
 
@@ -85,7 +85,7 @@ def authenticate() -> dict:
 
 
 def remove_prior_test_servers(token: str) -> None:
-    servers = api("/api/mcp/servers/", token=token, method="GET")
+    servers = api("/api/mcp/servers/", token = token, method = "GET")
     assert isinstance(servers, list)
     for server in servers:
         if server.get("display_name") not in (
@@ -95,33 +95,33 @@ def remove_prior_test_servers(token: str) -> None:
             continue
         api(
             f"/api/mcp/servers/{server['id']}",
-            token=token,
-            method="DELETE",
+            token = token,
+            method = "DELETE",
         )
 
 
 def open_dialog(page):
     page.keyboard.press("Control+Alt+m")
-    dialog = page.get_by_role("dialog", name="MCP Servers")
+    dialog = page.get_by_role("dialog", name = "MCP Servers")
     expect(dialog).to_be_visible()
     return dialog
 
 
 def row_for(dialog, name: str):
-    row = dialog.locator("li").filter(has_text=name)
+    row = dialog.locator("li").filter(has_text = name)
     expect(row).to_have_count(1)
     return row
 
 
 def fill_arguments(dialog, arguments: list[str]) -> None:
-    for index, argument in enumerate(arguments, start=1):
-        dialog.get_by_role("button", name="Add argument").click()
-        dialog.get_by_role("textbox", name=f"Argument {index}", exact=True).fill(argument)
+    for index, argument in enumerate(arguments, start = 1):
+        dialog.get_by_role("button", name = "Add argument").click()
+        dialog.get_by_role("textbox", name = f"Argument {index}", exact = True).fill(argument)
 
 
 def fill_environment(dialog, values: dict[str, str]) -> None:
     for key, value in values.items():
-        dialog.get_by_role("button", name="Add variable").click()
+        dialog.get_by_role("button", name = "Add variable").click()
         keys = dialog.get_by_placeholder("Variable name")
         vals = dialog.get_by_placeholder("Variable value")
         keys.nth(keys.count() - 1).fill(key)
@@ -136,27 +136,27 @@ def assert_arguments(dialog, expected: list[str]) -> None:
 
 
 def screenshot(dialog, name: str) -> None:
-    dialog.screenshot(path=str(ART / f"{name}-{BROWSER}.png"))
+    dialog.screenshot(path = str(ART / f"{name}-{BROWSER}.png"))
 
 
 def delay_real_response(seconds: float):
     def handler(route):
         response = route.fetch()
         time.sleep(seconds)
-        route.fulfill(response=response)
+        route.fulfill(response = response)
 
     return handler
 
 
 def run(page, launch_log: Path, fixture: Path) -> None:
-    page.goto(BASE + "/hub", wait_until="domcontentloaded")
-    page.goto(BASE + "/chat", wait_until="domcontentloaded")
+    page.goto(BASE + "/hub", wait_until = "domcontentloaded")
+    page.goto(BASE + "/chat", wait_until = "domcontentloaded")
     page.wait_for_timeout(1000)
     if page.url.startswith(BASE + "/login") or page.url.startswith(BASE + "/change-password"):
         raise AssertionError(f"not authenticated: {page.url}")
 
     dialog = open_dialog(page)
-    dialog.get_by_role("button", name="Add server").click()
+    dialog.get_by_role("button", name = "Add server").click()
     dialog.locator("#mcp-display-name").fill("Playwright argument echo")
     dialog.locator("#mcp-url").fill(sys.executable)
     arguments = [
@@ -178,53 +178,53 @@ def run(page, launch_log: Path, fixture: Path) -> None:
     fill_environment(dialog, environment)
     screenshot(dialog, "fixed-create-filled")
 
-    dialog.get_by_role("button", name="Test connection").click()
-    expect(page.get_by_text("Connected (1 tool)")).to_be_visible(timeout=30_000)
-    dialog.get_by_role("button", name="Add server").click()
+    dialog.get_by_role("button", name = "Test connection").click()
+    expect(page.get_by_text("Connected (1 tool)")).to_be_visible(timeout = 30_000)
+    dialog.get_by_role("button", name = "Add server").click()
     row = row_for(dialog, "Playwright argument echo")
     expect(row).to_contain_text("--flag")
 
     page.route("**/api/mcp/servers/stdio/decode", delay_real_response(1.5))
-    row.get_by_role("button", name="Edit server").click(no_wait_after=True)
-    loading = dialog.get_by_text("Reading local command…", exact=True)
+    row.get_by_role("button", name = "Edit server").click(no_wait_after = True)
+    loading = dialog.get_by_text("Reading local command…", exact = True)
     expect(loading).to_be_visible()
     screenshot(dialog, "fixed-edit-loading")
     page.unroute("**/api/mcp/servers/stdio/decode")
-    expect(loading).to_be_hidden(timeout=10_000)
+    expect(loading).to_be_hidden(timeout = 10_000)
     assert_arguments(dialog, arguments)
     screenshot(dialog, "fixed-edit-hydrated")
 
-    dialog.get_by_role("button", name="Cancel").click()
-    dialog.get_by_role("button", name="Close").click()
-    page.reload(wait_until="domcontentloaded")
+    dialog.get_by_role("button", name = "Cancel").click()
+    dialog.get_by_role("button", name = "Close").click()
+    page.reload(wait_until = "domcontentloaded")
     page.wait_for_timeout(500)
     dialog = open_dialog(page)
     row = row_for(dialog, "Playwright argument echo")
-    row.get_by_role("button", name="Edit server").click()
+    row.get_by_role("button", name = "Edit server").click()
     assert_arguments(dialog, arguments)
 
     edited = [str(fixture), "second", "", "first", "a&b", "x|y", "%TOKEN%"]
     inputs = dialog.locator('[aria-label^="Argument "]')
     while inputs.count() > len(edited):
-        dialog.get_by_role("button", name=f"Remove argument {inputs.count()}").click()
+        dialog.get_by_role("button", name = f"Remove argument {inputs.count()}").click()
     for index, value in enumerate(edited):
-        dialog.get_by_role("textbox", name=f"Argument {index + 1}", exact=True).fill(value)
+        dialog.get_by_role("textbox", name = f"Argument {index + 1}", exact = True).fill(value)
     dialog.get_by_placeholder("Variable value").first.fill("playwright edited")
-    dialog.get_by_role("button", name="Save changes").click()
+    dialog.get_by_role("button", name = "Save changes").click()
     expect(page.get_by_text("MCP server updated")).to_be_visible()
     row = row_for(dialog, "Playwright argument echo")
-    row.get_by_role("button", name="Edit server").click()
+    row.get_by_role("button", name = "Edit server").click()
     assert_arguments(dialog, edited)
     screenshot(dialog, "fixed-edit-persisted")
 
-    dialog.get_by_role("button", name="Cancel").click()
+    dialog.get_by_role("button", name = "Cancel").click()
     row = row_for(dialog, "Playwright argument echo")
-    launches_before_refresh = len(launch_log.read_text(encoding="utf-8").splitlines())
-    row.get_by_role("button", name="Refresh tools").click()
+    launches_before_refresh = len(launch_log.read_text(encoding = "utf-8").splitlines())
+    row.get_by_role("button", name = "Refresh tools").click()
     expect(page.get_by_text('Refreshed "Playwright argument echo" (1 tool)')).to_be_visible(
-        timeout=30_000
+        timeout = 30_000
     )
-    launches_after_refresh = len(launch_log.read_text(encoding="utf-8").splitlines())
+    launches_after_refresh = len(launch_log.read_text(encoding = "utf-8").splitlines())
     assert launches_after_refresh == launches_before_refresh + 1
 
     imported = {
@@ -246,58 +246,58 @@ def run(page, launch_log: Path, fixture: Path) -> None:
             "buffer": json.dumps(imported).encode(),
         }
     )
-    expect(page.get_by_text("1 added")).to_be_visible(timeout=10_000)
+    expect(page.get_by_text("1 added")).to_be_visible(timeout = 10_000)
     imported_row = row_for(dialog, "Playwright imported echo")
-    imported_row.get_by_role("button", name="Edit server").click()
+    imported_row.get_by_role("button", name = "Edit server").click()
     assert_arguments(dialog, [str(fixture), "imported", "", "with spaces", 'say "hello"'])
-    dialog.get_by_role("button", name="Test connection").click()
-    expect(page.get_by_text("Connected (1 tool)")).to_be_visible(timeout=30_000)
-    dialog.get_by_role("button", name="Cancel").click()
+    dialog.get_by_role("button", name = "Test connection").click()
+    expect(page.get_by_text("Connected (1 tool)")).to_be_visible(timeout = 30_000)
+    dialog.get_by_role("button", name = "Cancel").click()
     imported_row = row_for(dialog, "Playwright imported echo")
-    imported_row.get_by_role("button", name="Refresh tools").click()
+    imported_row.get_by_role("button", name = "Refresh tools").click()
     expect(page.get_by_text('Refreshed "Playwright imported echo" (1 tool)')).to_be_visible(
-        timeout=30_000
+        timeout = 30_000
     )
 
     row = row_for(dialog, "Playwright argument echo")
     page.route(
         "**/api/mcp/servers/stdio/decode",
         lambda route: route.fulfill(
-            status=500,
-            content_type="application/json",
-            body=json.dumps({"detail": "forced decode failure"}),
+            status = 500,
+            content_type = "application/json",
+            body = json.dumps({"detail": "forced decode failure"}),
         ),
-        times=1,
+        times = 1,
     )
-    row.get_by_role("button", name="Edit server").click()
+    row.get_by_role("button", name = "Edit server").click()
     expect(dialog.get_by_role("alert")).to_contain_text("forced decode failure")
     expect(dialog.locator("#mcp-url")).not_to_have_value("")
     screenshot(dialog, "fixed-edit-error")
-    dialog.get_by_role("button", name="Retry").click()
+    dialog.get_by_role("button", name = "Retry").click()
     assert_arguments(dialog, edited)
 
     expect(dialog.get_by_placeholder("Variable name")).to_have_count(2)
     dialog.locator("#mcp-url").fill("https://example.com/mcp")
-    expect(dialog.get_by_text("Custom headers", exact=True)).to_be_visible()
+    expect(dialog.get_by_text("Custom headers", exact = True)).to_be_visible()
     expect(dialog.get_by_placeholder("Header name")).to_have_count(0)
-    dialog.get_by_role("button", name="Add header").click()
+    dialog.get_by_role("button", name = "Add header").click()
     dialog.get_by_placeholder("Header name").fill("Authorization")
     dialog.get_by_placeholder("Header value").fill("Bearer remote-secret")
     dialog.locator("#mcp-url").fill(sys.executable)
-    expect(dialog.get_by_text("Environment variables", exact=True)).to_be_visible()
+    expect(dialog.get_by_text("Environment variables", exact = True)).to_be_visible()
     expect(dialog.get_by_placeholder("Variable name")).to_have_count(0)
     screenshot(dialog, "fixed-transport-credentials-cleared")
-    dialog.get_by_role("button", name="Cancel").click()
+    dialog.get_by_role("button", name = "Cancel").click()
 
     row = row_for(dialog, "Playwright argument echo")
-    row.get_by_role("button", name="Delete server").click()
-    expect(page.get_by_role("alertdialog", name="Delete MCP server")).to_be_visible()
-    page.go_back(wait_until="domcontentloaded")
+    row.get_by_role("button", name = "Delete server").click()
+    expect(page.get_by_role("alertdialog", name = "Delete MCP server")).to_be_visible()
+    page.go_back(wait_until = "domcontentloaded")
     expect(page).to_have_url(BASE + "/hub")
-    expect(page.get_by_role("alertdialog", name="Delete MCP server")).to_have_count(0)
-    page.screenshot(path=str(ART / f"fixed-delete-route-closed-{BROWSER}.png"))
+    expect(page.get_by_role("alertdialog", name = "Delete MCP server")).to_have_count(0)
+    page.screenshot(path = str(ART / f"fixed-delete-route-closed-{BROWSER}.png"))
 
-    records = [json.loads(line) for line in launch_log.read_text(encoding="utf-8").splitlines()]
+    records = [json.loads(line) for line in launch_log.read_text(encoding = "utf-8").splitlines()]
     expected_runs = [record for record in records if record["marker"] == "playwright edited"]
     assert expected_runs
     assert all(record["arguments"] == edited[1:] for record in expected_runs)
@@ -310,14 +310,14 @@ def run(page, launch_log: Path, fixture: Path) -> None:
 
 
 def main() -> int:
-    ART.mkdir(parents=True, exist_ok=True)
+    ART.mkdir(parents = True, exist_ok = True)
     fixture_dir = ART / "fixture directory with spaces"
-    fixture_dir.mkdir(parents=True, exist_ok=True)
+    fixture_dir.mkdir(parents = True, exist_ok = True)
     fixture = fixture_dir / SOURCE_FIXTURE.name
     shutil.copyfile(SOURCE_FIXTURE, fixture)
     launch_log = ART / "argument launches.jsonl"
-    launch_log.unlink(missing_ok=True)
-    wait_for_health(BASE, timeout=60, info=info)
+    launch_log.unlink(missing_ok = True)
+    wait_for_health(BASE, timeout = 60, info = info)
     session = authenticate()
     remove_prior_test_servers(session["access_token"])
     seed_js = (
@@ -328,7 +328,7 @@ def main() -> int:
         "JSON.stringify({openMcpServers:{primary:'Mod+Alt+KeyM'}}));"
         "})();"
     )
-    install_wall_clock_watchdog(WALL_TIMEOUT_S, label="mcp-arguments", info=info)
+    install_wall_clock_watchdog(WALL_TIMEOUT_S, label = "mcp-arguments", info = info)
     with sync_playwright() as playwright:
         if BROWSER not in ("chromium", "firefox", "webkit"):
             raise AssertionError(f"unsupported browser: {BROWSER}")
@@ -340,8 +340,8 @@ def main() -> int:
                 launch_kwargs["channel"] = CHANNEL
         browser = browser_type.launch(**launch_kwargs)
         context = browser.new_context(
-            viewport={"width": 1280, "height": 900},
-            reduced_motion="reduce",
+            viewport = {"width": 1280, "height": 900},
+            reduced_motion = "reduce",
         )
         install_view_transition_killer(context)
         context.add_init_script(seed_js)
@@ -350,7 +350,7 @@ def main() -> int:
         try:
             run(page, launch_log, fixture)
         finally:
-            page.screenshot(path=str(ART / f"fixed-final-{BROWSER}.png"), full_page=True)
+            page.screenshot(path = str(ART / f"fixed-final-{BROWSER}.png"), full_page = True)
             context.close()
             browser.close()
     info("PASS real stdio create, edit, import, probe, persistence, reconnect, and launch")

--- a/tests/studio/playwright_mcp_arguments.py
+++ b/tests/studio/playwright_mcp_arguments.py
@@ -103,7 +103,8 @@ def remove_prior_test_servers(token: str) -> None:
 
 
 def open_dialog(page):
-    page.keyboard.press("Control+Alt+m")
+    page.get_by_role("button", name = "MCP servers").click()
+    page.get_by_role("menuitem", name = "Manage MCP servers").press("Enter")
     dialog = page.get_by_role("dialog", name = "MCP Servers")
     expect(dialog).to_be_visible()
     return dialog
@@ -452,8 +453,6 @@ def main() -> int:
         "(() => {"
         f"localStorage.setItem('unsloth_auth_token', {json.dumps(session['access_token'])});"
         f"localStorage.setItem('unsloth_refresh_token', {json.dumps(session.get('refresh_token', ''))});"
-        "localStorage.setItem('unsloth_keyboard_shortcuts', "
-        "JSON.stringify({openMcpServers:{primary:'Mod+Alt+KeyM'}}));"
         "localStorage.setItem('unsloth_chat_mcp_enabled', 'true');"
         "})();"
     )

--- a/tests/studio/test_playwright_suites_run_in_ci.py
+++ b/tests/studio/test_playwright_suites_run_in_ci.py
@@ -249,9 +249,9 @@ def test_the_linux_job_still_drives_all_three_browser_engines():
     # the repo-wide scan above. What the relaxation gives up is the port literal, which
     # this check was never really about; test_indicator_browsers_run_in_parallel.py asserts
     # the ports are distinct, which is the property the number was standing in for.
-    assert "run-studio-indicator-browser.sh" in runs, (
-        "the ui-indicator job no longer invokes the cross-browser indicator helper at all"
-    )
+    assert (
+        "run-studio-indicator-browser.sh" in runs
+    ), "the ui-indicator job no longer invokes the cross-browser indicator helper at all"
     missing = [
         engine
         for engine in ("chromium", "firefox", "webkit")

--- a/tests/studio/test_playwright_suites_run_in_ci.py
+++ b/tests/studio/test_playwright_suites_run_in_ci.py
@@ -163,6 +163,22 @@ def test_every_playwright_driver_is_invoked_by_ci():
     )
 
 
+def test_mcp_argument_driver_launches_the_managed_studio_python():
+    document = yaml.safe_load(
+        (REPO / ".github" / "workflows" / "studio-ui-smoke.yml").read_text(encoding = "utf-8")
+    )
+    steps = document["jobs"]["ui-smoke"]["steps"]
+    run = next(
+        str(step["run"])
+        for step in steps
+        if step.get("name") == "MCP arguments end to end (Playwright)"
+    )
+    driver = (REPO / "tests" / "studio" / "playwright_mcp_arguments.py").read_text(encoding = "utf-8")
+
+    assert 'export STUDIO_MCP_PYTHON="$studio_home/unsloth_studio/bin/python"' in run
+    assert 'os.environ.get("STUDIO_MCP_PYTHON", sys.executable)' in driver
+
+
 def test_the_exemptions_are_still_exempt_and_still_exist():
     """An exemption that outlives its file, or its reason, quietly shrinks the check."""
     names = {driver.name for driver in DRIVERS}
@@ -233,9 +249,9 @@ def test_the_linux_job_still_drives_all_three_browser_engines():
     # the repo-wide scan above. What the relaxation gives up is the port literal, which
     # this check was never really about; test_indicator_browsers_run_in_parallel.py asserts
     # the ports are distinct, which is the property the number was standing in for.
-    assert (
-        "run-studio-indicator-browser.sh" in runs
-    ), "the ui-indicator job no longer invokes the cross-browser indicator helper at all"
+    assert "run-studio-indicator-browser.sh" in runs, (
+        "the ui-indicator job no longer invokes the cross-browser indicator helper at all"
+    )
     missing = [
         engine
         for engine in ("chromium", "firefox", "webkit")


### PR DESCRIPTION
## Summary

Adds an ordered arguments editor for stdio MCP servers in Studio. Commands now preserve argument order, exact values, and intentional empty arguments across create, edit, import, connection testing, persistence, reconnect, and process launch.

## Motivation

Many MCP servers require command-line arguments, but Studio exposed their executable and arguments as one command field. That made structured editing impossible and made exact empty, quoted, and ordered argument handling opaque.

## Changes

- Adds a stdio-only arguments editor and authenticated backend codec endpoints while preserving unchanged legacy command URLs.
- Keeps Windows and POSIX command parsing and joining on the backend so the browser never reconstructs shell syntax.
- Rejects invalid environment names and embedded NUL characters before persistence, probing, cache/session changes, or process creation.
- Bypasses Windows npm and npx batch launchers so command-shell metacharacters remain literal argv values.
- Clears credentials when switching transports and scopes async MCP actions to the open dialog and affected server.
- Adds visible decode loading, failure, and retry states.
- Adds real FastMCP child-process and live Playwright coverage to checked-in Studio CI.

Studio has no MCP config export endpoint or UI flow, so this PR does not claim export support.

## Focused tests

```text
backend MCP tests: 290 passed, 4 skipped on Linux
frontend MCP tests: 19 passed
frontend typecheck: passed
frontend production build: passed
live Chromium Playwright flow: passed
Windows/POSIX codec fuzz: 267,368 round trips passed
```

The live flow starts real FastMCP stdio child processes and verifies create, edit, import, connection testing, reload persistence, tool refresh/reconnect, and process launch with empty, ordered, spaced, quoted, backslash, URL, shell-metacharacter, and percent-delimited arguments.

## UI evidence

Main editor comparison: base `4b52ff56b` to reviewed head `0af2fb160`.

![Before and after MCP command editor](https://raw.githubusercontent.com/mahiatlinux/unsloth/evidence-pr-9943-0e6b61f8/ui-evidence/pr-9943/0e6b61f8/before-after-command-editor.png)

![Decode loading state](https://raw.githubusercontent.com/mahiatlinux/unsloth/evidence-pr-9943-0e6b61f8/ui-evidence/pr-9943/0e6b61f8/fixed-edit-loading-chromium.png)

![Decode failure and retry state](https://raw.githubusercontent.com/mahiatlinux/unsloth/evidence-pr-9943-0e6b61f8/ui-evidence/pr-9943/0e6b61f8/fixed-edit-error-chromium.png)

Additional before/after evidence for HTTP credential editing, same-row mutation locking, and import-close-reopen behavior is in the [post-push review comment](https://github.com/unslothai/unsloth/pull/9943#issuecomment-5459193079).

## Related

Closes #9737
