### PR TITLE
Give the responses-adapter fakes the subject the route now passes

### DIFF
--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -804,7 +804,7 @@ class TestResponsesNonStreamingAdapter:
     ):
         import routes.inference as inf_mod
 
-        async def fake_chat_completions(chat_req, request):
+        async def fake_chat_completions(chat_req, request, current_subject):
             return JSONResponse(
                 content = {
                     "model": "test-model",
@@ -855,7 +855,7 @@ class TestResponsesNonStreamingAdapter:
         import routes.inference as inf_mod
         import routes.inference as inf_mod
 
-        async def fake_chat_completions(chat_req, request):
+        async def fake_chat_completions(chat_req, request, current_subject):
             assert request.state.skip_api_monitor is True
             return JSONResponse(
                 content = {
@@ -911,7 +911,7 @@ class TestResponsesNonStreamingAdapter:
 
         usage = {"prompt_tokens": 11, "completion_tokens": 50, "total_tokens": 61}
 
-        async def fake_chat_completions(chat_req, request):
+        async def fake_chat_completions(chat_req, request, current_subject):
             assert request.state.skip_api_monitor is True
             # monitor_id is None here: this call's own row is the suppressed one.
             if observations is not None:
@@ -1030,7 +1030,7 @@ class TestResponsesNonStreamingAdapter:
     def test_monitor_records_tool_only_reply(self, monkeypatch):
         import routes.inference as inf_mod
 
-        async def fake_chat_completions(chat_req, request):
+        async def fake_chat_completions(chat_req, request, current_subject):
             assert request.state.skip_api_monitor is True
             return JSONResponse(
                 content = {
@@ -1085,7 +1085,7 @@ class TestResponsesNonStreamingAdapter:
     def test_cancelled_chat_completion_finalizes_monitor(self, monkeypatch):
         import routes.inference as inf_mod
 
-        async def fake_chat_completions(chat_req, request):
+        async def fake_chat_completions(chat_req, request, current_subject):
             assert request.state.skip_api_monitor is True
             raise asyncio.CancelledError()
 


### PR DESCRIPTION
## What

Backend CI has been red on main for ~20 consecutive runs. One of the two failure families is 15 tests in `test_responses_tool_passthrough.py` dying on arity:

```
TypeError: fake_chat_completions() takes 2 positional arguments but 3 were given
```

## Cause

37d3b6fdf (#8768) made the `/v1/responses` adapter pass `current_subject` positionally into `openai_chat_completions`, but the five `fake_chat_completions` stubs in this file still take `(chat_req, request)`, so every test that drives the adapter dies before asserting anything.

## Fix

Accept the third argument in the five stubs. Test-side only — the production call is correct (other patchers in the suite, e.g. `test_chat_generation_supervisor.py` and `test_active_generations.py`, already pass or accept the subject).

## Verification

- `test_responses_tool_passthrough.py`: 15 failed → **117 passed**
- Neighboring patchers of the same route (`test_chat_generation_supervisor`, `test_active_generations`, `test_api_profile_usage_routes`): 235 pass together
- Ruff clean, formatter applied

## Not in this PR

The other red family on main — 8 `test_openai_auto_switch.py` failures from the same #8768 (`gguf_only` capture KeyErrors and `_host_has_a_non_gguf_backend` probing real `find_spec("torch")` in a torch-less CI env) — needs per-test care; happy to follow up separately.