### PR TITLE
studio: fix openai route ci tests

### DIFF
--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -3836,9 +3836,11 @@ def test_responses_and_anthropic_wire_require_vision_from_images():
     import inspect
 
     responses_src = inspect.getsource(inference_route.openai_responses)
-    assert "require_vision = _messages_have_image(" in responses_src
+    assert "_responses_has_image = _messages_have_image(" in responses_src
+    assert "require_vision = _responses_has_image" in responses_src
     anthropic_src = inspect.getsource(inference_route.anthropic_messages)
-    assert "require_vision = _anthropic_request_has_image(" in anthropic_src
+    assert "_anthropic_has_image = _anthropic_request_has_image(" in anthropic_src
+    assert "require_vision = _anthropic_has_image" in anthropic_src
     # /messages/count_tokens shares the /messages translation, so it needs the same
     # guard: an image count must not evict a vision model for a text-only target.
     count_src = inspect.getsource(inference_route.anthropic_count_tokens)
@@ -9124,7 +9126,7 @@ def test_streaming_responses_refuses_a_non_gguf_swap(monkeypatch):
         payload = _responses_payload(stream = streaming)
         with pytest.raises(RuntimeError):
             asyncio.run(inference_route.openai_responses(payload, object(), "tester"))
-        assert captured["gguf_only"] is streaming
+        assert captured.get("gguf_only", False) is streaming
 
 
 def test_a_pickle_checkpoint_is_not_switchable(tmp_path):

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -9126,7 +9126,15 @@ def test_streaming_responses_refuses_a_non_gguf_swap(monkeypatch):
         payload = _responses_payload(stream = streaming)
         with pytest.raises(RuntimeError):
             asyncio.run(inference_route.openai_responses(payload, object(), "tester"))
-        assert captured.get("gguf_only", False) is streaming
+        # Only the streaming branch preflights here, and it must pin GGUF. The
+        # non-streaming one delegates its preflight to the chat route, whose own
+        # switch is right NOT to pin, so it passes no gguf_only at all. Asserting
+        # the key is absent rather than falsy keeps that distinction: `.get(...,
+        # False)` would also pass if the streaming branch stopped sending it.
+        if streaming:
+            assert captured["gguf_only"] is True
+        else:
+            assert "gguf_only" not in captured
 
 
 def test_a_pickle_checkpoint_is_not_switchable(tmp_path):

--- a/studio/backend/tests/test_video_attachment_part.py
+++ b/studio/backend/tests/test_video_attachment_part.py
@@ -144,9 +144,9 @@ def test_video_joins_the_projector_requirement_before_switching():
     cannot serve it either. Audio already votes here."""
     source = _inference_source()
     start = source.index("_needs_image = bool(_pre_parsed[2])")
-    block = source[start : start + 400]
-    assert "payload.audio_base64" in block
-    assert "payload.video_base64" in block
+    switch = source.index("await _maybe_auto_switch_model(", start)
+    assert start < source.index("payload.audio_base64", start) < switch
+    assert start < source.index("payload.video_base64", start) < switch
 
 
 def test_an_external_provider_refuses_video_rather_than_ignoring_it():


### PR DESCRIPTION
#8768 changed Responses and Anthropic routing, current-subject propagation, and projector detection without updating the matching backend tests. Its merge introduced 19 Backend Python 3.13 failures compared with its first parent.

- Pass the current subject to Responses adapter test doubles.
- Match the two-step vision detection used by Responses and Anthropic routes.
- Treat an omitted `gguf_only` value as false for non-streaming requests.
- Locate projector checks relative to `_maybe_auto_switch_model` instead of a fixed source slice.

The async singleton failure was already fixed by `0d41a7203`. This fixes the remaining 18 failures.

## Checks

- Ruff check passed.
- Focused backend tests: 24 passed.
