### PR TITLE
studio: fix audio ci tests

### DIFF
--- a/studio/backend/tests/test_native_audio.py
+++ b/studio/backend/tests/test_native_audio.py
@@ -12,7 +12,6 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-import torchaudio
 
 from core.inference.native_audio import (
     HIGGS_TTS2_CODEC_REPO,
@@ -506,13 +505,20 @@ def test_moss_local_generation_contract():
     assert seen["mode"] == "generation" and seen["generate"]["audio_top_k"] == 50
 
 
-def test_moss_nano_generation_contract():
+def test_moss_nano_generation_contract(monkeypatch):
     seen = {}
+
+    original_torchaudio = SimpleNamespace(
+        save = lambda *_args, **_kwargs: pytest.fail("the save proxy was not installed")
+    )
+    monkeypatch.setattr(sys.modules[__name__], "torchaudio", original_torchaudio, raising = False)
 
     class Model:
         def inference(self, **kwargs):
             seen.update(kwargs)
-            torchaudio.save(kwargs["output_audio_path"], torch.zeros((2, 480)), 48000)
+            sys.modules[__name__].torchaudio.save(
+                kwargs["output_audio_path"], torch.zeros((2, 480)), 48000
+            )
             return {"sample_rate": 48000}
 
     codec, tokenizer = object(), object()
@@ -523,7 +529,6 @@ def test_moss_nano_generation_contract():
         audio_codec = codec,
         sample_rate = 48000,
     )
-    original_torchaudio = sys.modules[__name__].torchaudio
     wav, rate = backend.generate_audio_response("Portable <|im_start|>speech", max_new_tokens = 375)
     assert wav[:4] == b"RIFF" and rate == 48000
     assert sys.modules[__name__].torchaudio is original_torchaudio

--- a/studio/frontend/tests/audio-generation-stop.test.ts
+++ b/studio/frontend/tests/audio-generation-stop.test.ts
@@ -76,7 +76,7 @@ test("a saved clip the refresh missed keeps its response audio mounted", () => {
   // player rendered the empty state.
   assert.match(
     source,
-    /const selectClip = useCallback\(\(id: string, keepFallback = false\) => \{[\s\S]*if \(!keepFallback\) setFallbackClip\(null\);/,
+    /const selectClip = useCallback\(\s*\(id: string, keepFallback = false\) => \{[\s\S]*if \(!keepFallback\) setFallbackClip\(null\);/,
   );
   assert.match(source, /saved: true,\s*\}\);\s*selectClip\(generated\.clip_id, true\);/);
 });

--- a/studio/frontend/tests/audio-model-eject.test.ts
+++ b/studio/frontend/tests/audio-model-eject.test.ts
@@ -201,7 +201,7 @@ test("a dictation model this page did not load survives a mode switch", () => {
   // Eject unloaded a model this page never loaded. Model only, not model plus engine: a
   // "gguf" pick without whisper-server is served by the Transformers fallback and reports
   // residency under that engine, so requiring the requested engine leaked the sidecar.
-  assert.match(source, /claim !== null && claim === sttLoadedModel;/);
+  assert.match(source, /claim !== null &&\s*claim === sttLoadedModel;/);
   // Ownership is claimed after a successful load, not before it: claiming up front left the
   // flag set when a download was cancelled while the backend kept the previous resident
   // model, so leaving Transcribe unloaded another surface's model.

--- a/studio/frontend/tests/audio-page-policy.test.ts
+++ b/studio/frontend/tests/audio-page-policy.test.ts
@@ -507,7 +507,7 @@ test("a recording is stopped at the sidecar's duration and size limits", () => {
 test("the trained-model list applies the native-aware macOS policy", () => {
   assert.match(
     audioPageSource,
-    /!isMac \|\|\s*trainedTtsCheckpointIsRunnableOnMac\(lora\.audio_type, lora\.export_type\)/,
+    /!isMac \|\|\s*trainedTtsCheckpointIsRunnableOnMac\(\s*lora\.audio_type,\s*lora\.export_type,?\s*\)/,
   );
 });
 

--- a/studio/frontend/tests/audio-tts-download-manager.test.ts
+++ b/studio/frontend/tests/audio-tts-download-manager.test.ts
@@ -113,7 +113,10 @@ test("managed completion loads the exact GGUF only when Audio is active and idle
 test("switching to Transcribe invalidates a pending staged TTS auto-load", () => {
   const invalidateStart = source.indexOf("const invalidatePendingTtsSelection");
   const transitionStart = source.indexOf("const transitionMode", invalidateStart);
-  assert.match(source.slice(invalidateStart, transitionStart), /invalidatePendingStagedTts\(\);/);
+  const invalidateSelection = source.slice(invalidateStart, transitionStart);
+  assert.match(invalidateSelection, /ttsPickGeneration\.current \+= 1;/);
+  assert.match(invalidateSelection, /pendingRoutedTtsPick\.current = null;/);
+  assert.match(invalidateSelection, /invalidatePendingStagedTts\(\);/);
   assert.match(
     source,
     /if \(nextMode === "transcribe"\) invalidatePendingTtsSelection\(\)/,

--- a/studio/frontend/tests/audio-tts-download-manager.test.ts
+++ b/studio/frontend/tests/audio-tts-download-manager.test.ts
@@ -81,7 +81,7 @@ test("a preflight that loses to generation queues its load until generation ends
   );
   assert.match(
     source,
-    /generateAbort\.current = null;\s*busyRef\.current = null;\s*setBusy\(null\);\s*if \(activeRef\.current\) replayQueuedTtsPick\(\)/,
+    /generateAbort\.current = null;\s*busyRef\.current = null;\s*setBusy\(null\);\s*if \(activeRef\.current && modeRef\.current === "speak"\)\s*replayQueuedTtsPick\(\)/,
   );
 });
 
@@ -111,9 +111,12 @@ test("managed completion loads the exact GGUF only when Audio is active and idle
 });
 
 test("switching to Transcribe invalidates a pending staged TTS auto-load", () => {
+  const invalidateStart = source.indexOf("const invalidatePendingTtsSelection");
+  const transitionStart = source.indexOf("const transitionMode", invalidateStart);
+  assert.match(source.slice(invalidateStart, transitionStart), /invalidatePendingStagedTts\(\);/);
   assert.match(
     source,
-    /if \(nextMode === "transcribe"\) invalidatePendingStagedTts\(\)/,
+    /if \(nextMode === "transcribe"\) invalidatePendingTtsSelection\(\)/,
   );
   assert.match(
     source,
@@ -121,7 +124,7 @@ test("switching to Transcribe invalidates a pending staged TTS auto-load", () =>
   );
   assert.match(
     source,
-    /if \(nextMode === mode\)[\s\S]*return true;[\s\S]*if \(!canTransitionAudioMode\(busyRef\.current\)\)[\s\S]*return false;[\s\S]*if \(nextMode === "transcribe"\) invalidatePendingStagedTts\(\)/,
+    /if \(nextMode === mode\)[\s\S]*return true;[\s\S]*if \(!canTransitionAudioMode\(busyRef\.current\)\)[\s\S]*return false;[\s\S]*if \(nextMode === "transcribe"\) invalidatePendingTtsSelection\(\)/,
     "a rejected mode switch must not discard the still-owned staged load",
   );
 });

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -364,13 +364,11 @@ class TestSdistOnlyBuildArgs:
             req = next((k for k in node.keywords if k.arg == "req"), None)
             if req is None or "diffusers-pin.txt" not in ast.unparse(req.value):
                 continue
-            arguments = " ".join(ast.unparse(argument) for argument in node.args)
-            assert "_sdist_only_build_args('diffusers')" not in arguments
-            literal_arguments = [
-                argument.value
-                for argument in node.args
-                if isinstance(argument, ast.Constant) and isinstance(argument.value, str)
-            ]
+            try:
+                literal_arguments = [ast.literal_eval(argument) for argument in node.args]
+            except (ValueError, TypeError):
+                pytest.fail("the diffusers pin options must remain literal and auditable")
+            assert all(isinstance(argument, str) for argument in literal_arguments)
             assert not any(argument.startswith("--no-binary") for argument in literal_arguments)
             return
         pytest.fail("no pip_install(req=.../diffusers-pin.txt) call found")

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -357,6 +357,10 @@ class TestSdistOnlyBuildArgs:
 
     def test_the_diffusers_release_is_not_forced_through_a_source_build(self):
         """The pinned release ships wheels, so forcing a source build defeats the pin."""
+        pin_lines = (ips.REQ_ROOT / "diffusers-pin.txt").read_text(encoding = "utf-8").splitlines()
+        pin_options = [line.split("#", 1)[0].strip() for line in pin_lines]
+        assert not any(option.startswith("--no-binary") for option in pin_options)
+
         tree = ast.parse(Path(ips.__file__).read_text(encoding = "utf-8"))
         for node in ast.walk(tree):
             if not (isinstance(node, ast.Call) and getattr(node.func, "id", None) == "pip_install"):

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -364,8 +364,14 @@ class TestSdistOnlyBuildArgs:
             req = next((k for k in node.keywords if k.arg == "req"), None)
             if req is None or "diffusers-pin.txt" not in ast.unparse(req.value):
                 continue
-            splat = " ".join(ast.unparse(a.value) for a in node.args if isinstance(a, ast.Starred))
-            assert "_sdist_only_build_args('diffusers')" not in splat
+            arguments = " ".join(ast.unparse(argument) for argument in node.args)
+            assert "_sdist_only_build_args('diffusers')" not in arguments
+            literal_arguments = [
+                argument.value
+                for argument in node.args
+                if isinstance(argument, ast.Constant) and isinstance(argument.value, str)
+            ]
+            assert not any(argument.startswith("--no-binary") for argument in literal_arguments)
             return
         pytest.fail("no pip_install(req=.../diffusers-pin.txt) call found")
 

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -355,13 +355,8 @@ class TestSdistOnlyBuildArgs:
         # The unconditional ones are always present.
         assert set(ips.SDIST_ONLY_PACKAGES) <= set(names)
 
-    def test_the_diffusers_pin_is_exempted_on_the_archive_path(self):
-        """The pin is a source ARCHIVE, and uv's no-build refuses to build one, so the
-        install still died here after extras.txt was fixed.
-
-        Guarded on python >= 3.10 because diffusers-pin.txt resolves a released wheel
-        below that, which must not be forced through a source build.
-        """
+    def test_the_diffusers_release_is_not_forced_through_a_source_build(self):
+        """The pinned release ships wheels, so forcing a source build defeats the pin."""
         tree = ast.parse(Path(ips.__file__).read_text(encoding = "utf-8"))
         for node in ast.walk(tree):
             if not (isinstance(node, ast.Call) and getattr(node.func, "id", None) == "pip_install"):
@@ -370,13 +365,7 @@ class TestSdistOnlyBuildArgs:
             if req is None or "diffusers-pin.txt" not in ast.unparse(req.value):
                 continue
             splat = " ".join(ast.unparse(a.value) for a in node.args if isinstance(a, ast.Starred))
-            assert (
-                "_sdist_only_build_args('diffusers')" in splat
-            ), f"the diffusers pin at line {node.lineno} must exempt the source archive"
-            assert "version_info >= (3, 10)" in splat, (
-                "the exemption must be guarded so the pre-3.10 wheel is not forced "
-                f"through a source build (line {node.lineno})"
-            )
+            assert "_sdist_only_build_args('diffusers')" not in splat
             return
         pytest.fail("no pip_install(req=.../diffusers-pin.txt) call found")
 


### PR DESCRIPTION
#8794 introduced one native-audio collection error, one Repo CPU assertion failure, and five frontend contract failures compared with its first parent. Existing red checks were unchanged and are outside this PR.

- Test the MOSS Nano torchaudio proxy without importing optional `torchaudio`.
- Match the released `diffusers==0.40.0` wheel installation path.
- Update frontend source contracts for the current formatted code.
- Preserve coverage that Transcribe invalidates both routed and staged TTS selections.

## Checks

- Ruff check passed.
- Python tests: 35 passed.
- Frontend tests: 71 passed.
- The staged-TTS assertion failed under mutation as expected.
