### PR TITLE
Repin the responses auto-switch pins to the wiring #8768 actually shipped

### DIFF
--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -3790,9 +3790,13 @@ def test_responses_and_anthropic_wire_require_vision_from_images():
     import inspect
 
     responses_src = inspect.getsource(inference_route.openai_responses)
-    assert "require_vision = _messages_have_image(" in responses_src
+    # The image answer is hoisted into a local (the image preflight reuses it),
+    # so pin both halves: the derivation and the guard consuming it.
+    assert "_responses_has_image = _messages_have_image(" in responses_src
+    assert "require_vision = _responses_has_image" in responses_src
     anthropic_src = inspect.getsource(inference_route.anthropic_messages)
-    assert "require_vision = _anthropic_request_has_image(" in anthropic_src
+    assert "_anthropic_has_image = _anthropic_request_has_image(" in anthropic_src
+    assert "require_vision = _anthropic_has_image" in anthropic_src
     # /messages/count_tokens shares the /messages translation, so it needs the same
     # guard: an image count must not evict a vision model for a text-only target.
     count_src = inspect.getsource(inference_route.anthropic_count_tokens)
@@ -9078,7 +9082,10 @@ def test_streaming_responses_refuses_a_non_gguf_swap(monkeypatch):
         payload = _responses_payload(stream = streaming)
         with pytest.raises(RuntimeError):
             asyncio.run(inference_route.openai_responses(payload, object(), "tester"))
-        assert captured["gguf_only"] is streaming
+        # Non-streaming delegates its preflight to chat, whose switch call
+        # leaves gguf_only at its False default rather than passing it, so an
+        # absent kwarg is the non-GGUF-tolerant shape, not a missing guard.
+        assert captured.get("gguf_only", False) is streaming
 
 
 def test_a_pickle_checkpoint_is_not_switchable(tmp_path):


### PR DESCRIPTION
## What

Follow-up to #9949, second family keeping Backend CI red on main: two tests in `test_openai_auto_switch.py` assert a source shape that #8768's own refactors moved past, so they have been red in CI since landing.

- **`test_responses_and_anthropic_wire_require_vision_from_images`** — `openai_responses` and `anthropic_messages` hoist the image answer into a local (`_responses_has_image` / `_anthropic_has_image`) so the image preflight can reuse it; the pins expected the inline call. Now pin both halves — the derivation *and* the guard consuming it — which is strictly tighter than the old single-string pin. `anthropic_count_tokens` still calls inline and keeps its original pin.
- **`test_streaming_responses_refuses_a_non_gguf_swap`** — the non-streaming `/v1/responses` path delegates its preflight to chat, whose `_maybe_auto_switch_model` call leaves `gguf_only` at its False default instead of passing it, so `captured["gguf_only"]` KeyErrors. The test now reads the kwarg with the same False default the callee applies. The streaming arm is unchanged: it still requires the explicit `gguf_only=True` that keeps a streaming Responses request from evicting the resident GGUF.

Test-side only; the shipped guards are correct and verified present at their call sites (`require_vision`/`gguf_only` at the streaming-responses, anthropic-messages, and count-tokens switches).

## Verification

Both tests were the only `test_openai_auto_switch.py` failures in CI (per #9949's 3.13 leg); both pass locally with this change, and the rest of the file is untouched (572 pass locally; the handful of locally-failing tests are torch/vulkan-dependent ones that CI passes). Ruff clean.