### PR TITLE
Let the native-audio suite skip where torchaudio is absent

### DIFF
--- a/studio/backend/tests/test_native_audio.py
+++ b/studio/backend/tests/test_native_audio.py
@@ -11,8 +11,12 @@ import threading
 from types import SimpleNamespace
 
 import pytest
-import torch
-import torchaudio
+
+# CPU CI installs torch for the backend job but not torchaudio, so an
+# unconditional import fails the whole file at collection (house pattern:
+# test_audio_probe_target.py).
+torch = pytest.importorskip("torch")
+torchaudio = pytest.importorskip("torchaudio")
 
 from core.inference.native_audio import (
     HIGGS_TTS2_CODEC_REPO,


### PR DESCRIPTION
## What

Third of the current Backend CI red families on main (see #9949's leg for the inventory): `tests/test_native_audio.py` dies at collection with `ModuleNotFoundError: No module named 'torchaudio'`.

c5b234381 (higgs/moss/minimax audio models) rewrote the file with unconditional `import torch` / `import torchaudio`. The backend CI job's environment carries torch but not torchaudio, so every run since reports a collection error for the whole file.

## Fix

Gate both imports through `pytest.importorskip`, which is the house pattern the audio siblings already use (`test_audio_probe_target.py` line 17). Where torchaudio is installed the suite runs exactly as before; where it is not, the file skips instead of erroring.

## Verification

Locally (torch-less env): collection error → `1 skipped`. Ruff clean.