### PR TITLE
Move two source pins to where recent main commits left their targets

### DIFF
--- a/studio/backend/tests/test_parallel_slots_per_load.py
+++ b/studio/backend/tests/test_parallel_slots_per_load.py
@@ -320,7 +320,9 @@ def test_route_resolves_slots_once_before_dedupe_guard_and_load():
     resolved_intent = load_impl.index("_resolve_gguf_load_intent(")
     resolved_dedupe = load_impl.index("_reuse_loaded_gguf(", resolved_intent)
     guard = load_impl.index("_guard_chat_load_against_training")
-    load_call = load_impl.index("llama_backend.load_model")
+    # The impl loads through its backend-dispatch local, not the module-level
+    # llama_backend, since the MLX split (#8768).
+    load_call = load_impl.index("backend.load_model")
     assert resolve < fast_dedupe < active_intent
     assert active_intent < resolved_intent < resolved_dedupe
     assert resolved_dedupe < guard < load_call

--- a/studio/backend/tests/test_video_attachment_part.py
+++ b/studio/backend/tests/test_video_attachment_part.py
@@ -144,7 +144,10 @@ def test_video_joins_the_projector_requirement_before_switching():
     cannot serve it either. Audio already votes here."""
     source = _inference_source()
     start = source.index("_needs_image = bool(_pre_parsed[2])")
-    block = source[start : start + 400]
+    # 600, not 400: the block gained explanatory comments and a widened
+    # _needs_image derivation, which pushed the modality votes past the old
+    # window while leaving the wiring itself intact.
+    block = source[start : start + 600]
     assert "payload.audio_base64" in block
     assert "payload.video_base64" in block
 


### PR DESCRIPTION
## What

Last two of the Backend CI red families on main (inventory in #9949; siblings #9956, #9957). Both are source-inspection tests whose guarded wiring is intact — the pins just point at pre-refactor spellings:

- **`test_parallel_slots_per_load.py::test_route_resolves_slots_once_before_dedupe_guard_and_load`** — pinned `llama_backend.load_model`, but `_load_model_impl` loads through its backend-dispatch local (`backend.load_model`) since the MLX split in #8768, so `.index()` throws `ValueError: substring not found`. The ordering chain the test proves (resolve < fast-dedupe < intent < resolved-dedupe < training-guard < load) is unchanged, verified by position against the current source.
- **`test_video_attachment_part.py::test_video_joins_the_projector_requirement_before_switching`** — scanned a 400-char window after `_needs_image = bool(_pre_parsed[2])` for the audio/video modality votes; explanatory comments and the widened `_needs_image` derivation pushed the votes to ~430+ chars. Widened to 600; both votes are exactly where the test expects, feeding the same `_needs_vision`.

Test-side only.

## Verification

Both files green locally: 41 passed, 1 skipped (was 2 failed). Ruff clean.