### PR TITLE
tests: keep the start-server log out of the shared tempdir

### DIFF
--- a/unsloth_cli/tests/conftest.py
+++ b/unsloth_cli/tests/conftest.py
@@ -4,6 +4,7 @@
 """Shared fixtures for the unsloth_cli tests."""
 
 import sys
+import tempfile
 import types
 
 import pytest
@@ -46,3 +47,26 @@ def stub_tool_policy_state(monkeypatch):
     state_mod.tool_policy = tp_mod
     monkeypatch.setitem(sys.modules, "state", state_mod)
     monkeypatch.setitem(sys.modules, "state.tool_policy", tp_mod)
+
+
+@pytest.fixture(autouse = True)
+def _contain_tempdir(monkeypatch, tmp_path):
+    """Point tempfile at a per-test directory (issue #9586, channel 4).
+
+    `_start_studio_server()` opens
+    `Path(tempfile.gettempdir()) / f"unsloth-start-server-{os.getpid()}.log"`, so a test
+    that drives it for real leaves that file in the shared tempdir. The name carries the
+    pid, so it accumulates rather than collides -- measured, a full `unsloth_cli/tests`
+    run under `-n 4` left one per worker and nothing else.
+
+    A fixture is early enough here, unlike the studio-home case in the same conftest:
+    gettempdir() is called inside the function rather than bound at import.
+
+    `tempfile.tempdir` is the documented override and beats TMPDIR/TEMP/TMP, which
+    gettempdir() consults only once and then caches. Redirecting rather than cleaning up
+    is deliberate: pytest owns tmp_path, so a hard-killed worker cannot leave residue in
+    the shared tempdir the way a `finally` unlink could.
+    """
+    private = tmp_path / "tempdir"
+    private.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(private))

--- a/unsloth_cli/tests/test_start_server_log_containment_9586.py
+++ b/unsloth_cli/tests/test_start_server_log_containment_9586.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for issue #9586 channel 4: the start-server log left in the tempdir.
+
+``_start_studio_server()`` opens
+``Path(tempfile.gettempdir()) / f"unsloth-start-server-{os.getpid()}.log"``. The name
+carries the pid, so a test that drives it for real accumulates a file per run rather than
+colliding with the last one.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def test_the_tempdir_is_private_to_this_test():
+    """The containment itself.
+
+    ``tempfile.tempdir`` is the documented override; TMPDIR/TEMP/TMP are consulted by
+    ``gettempdir()`` only once and then cached, so setting those in a fixture would be
+    too late in a session that had already resolved one.
+    """
+    resolved = Path(tempfile.gettempdir()).resolve()
+    assert resolved.name == "tempdir"
+    assert resolved.is_dir()
+
+    system_tmp = Path(os.environ.get("TEMP") or os.environ.get("TMPDIR") or "/tmp").resolve()
+    assert resolved != system_tmp
+
+
+def test_the_start_server_log_lands_in_the_private_tempdir(monkeypatch):
+    """The pin that matters, by the real path expression.
+
+    Built the way ``_start_studio_server`` builds it rather than by calling it, which
+    would spawn a server. If the containment regressed, this would resolve into the
+    shared tempdir the whole machine can traverse.
+    """
+    log_path = Path(tempfile.gettempdir()) / f"unsloth-start-server-{os.getpid()}.log"
+
+    private = Path(tempfile.gettempdir()).resolve()
+    assert private in log_path.resolve().parents
+
+    system_tmp = Path(os.environ.get("TEMP") or os.environ.get("TMPDIR") or "/tmp")
+    assert log_path.resolve().parent != system_tmp.resolve()
+
+
+def test_the_real_driver_leaves_the_shared_tempdir_clean(monkeypatch):
+    """End to end against the actual function, with only the spawn stubbed.
+
+    This is the case the issue observed: a test that drives ``_start_studio_server`` for
+    real. The stubs mirror
+    ``test_start_studio_server_forwards_tool_flags_via_command_and_env``, so the log is
+    opened exactly as it is in production.
+    """
+    from unsloth_cli.commands import start as start_mod
+
+    system_tmp = Path(os.environ.get("TEMP") or os.environ.get("TMPDIR") or "/tmp").resolve()
+    before = set(system_tmp.glob("unsloth-start-server-*.log"))
+
+    class FakePopen:
+        def __init__(self, command, **kwargs):
+            self.pid = 1
+
+        def poll(self):
+            return None
+
+    # _start_studio_server sets this module global and registers an atexit shutdown for
+    # it. Restoring it through monkeypatch keeps this test from leaving process state
+    # behind, which would be an odd thing for a test in this series to do.
+    monkeypatch.setattr(start_mod, "_auto_served_server", None)
+    monkeypatch.setattr(start_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(start_mod, "_studio_healthy", lambda base, timeout = 3.0: True)
+    # Must contain the key marker: the readiness loop spins until _SERVER_START_TIMEOUT_S
+    # without it, which is what the sibling test's stub is doing too.
+    monkeypatch.setattr(start_mod, "_log_tail", lambda path, lines = 20: "API Key: sk-unsloth-x")
+    monkeypatch.setattr(start_mod.time, "sleep", lambda _s: None)
+
+    start_mod._start_studio_server(
+        "http://127.0.0.1:8888",
+        "unsloth/M-GGUF",
+        start_mod.LoadOptions(),
+    )
+
+    assert set(system_tmp.glob("unsloth-start-server-*.log")) == before
+
+    # And it did land somewhere -- a test that wrote nothing would pass the check above
+    # for the wrong reason.
+    private = Path(tempfile.gettempdir())
+    assert list(private.glob("unsloth-start-server-*.log"))


### PR DESCRIPTION
Channel 4 of #9586.

## The defect

`_start_studio_server()` opens its log in the shared tempdir:

```python
log_path = Path(tempfile.gettempdir()) / f"unsloth-start-server-{os.getpid()}.log"
```

The name carries the pid, so a test that drives the function for real accumulates a file
per run rather than overwriting the last one.

## Reproduced at head

Windows / Python 3.13. A full `unsloth_cli/tests` run under `-n 4`, diffing the tempdir
before and after:

| | |
|---|---|
| new entries in the shared tempdir | `unsloth-start-server-6928.log`, `unsloth-start-server-8132.log` |
| anything else left behind | none |

Two files, one per worker that reached
`test_start_studio_server_forwards_tool_flags_via_command_and_env` — the only test in the
root that calls the function rather than stubbing it.

That measurement is also why this is a fixture rather than a tempdir redirect for the whole
root: there is one call site, not a class of them.

## The change

An autouse fixture in `unsloth_cli/tests/conftest.py` points `tempfile.tempdir` at a
per-test directory under `tmp_path`.

Two details are deliberate:

- **A fixture is early enough here**, unlike the studio-home case in the same conftest:
  `gettempdir()` is called inside the function rather than bound at import.
- **`tempfile.tempdir`, not `TMPDIR`/`TEMP`/`TMP`.** `gettempdir()` consults the environment
  once and caches the answer, so a session that had already resolved one would ignore the
  variables.

Redirecting rather than unlinking afterwards follows the issue's own note: pytest owns
`tmp_path`, so a hard-killed worker cannot leave residue — which a `finally` unlink cannot
promise.

## Tests

`unsloth_cli/tests/test_start_server_log_containment_9586.py`:

| test | pins | fails without the change |
|---|---|---|
| `test_the_real_driver_leaves_the_shared_tempdir_clean` | drives the real function with only the spawn stubbed; asserts the shared tempdir is unchanged **and** that the log landed somewhere — without the second half, a test that wrote nothing would pass for the wrong reason | **yes** |
| `test_the_start_server_log_lands_in_the_private_tempdir` | the log path expression, built as production builds it | **yes** |
| `test_the_tempdir_is_private_to_this_test` | the redirect itself | **yes** |

The first mirrors the stubs of the sibling test that already drives this function, including
`_log_tail` returning the key marker — without it the readiness loop spins to
`_SERVER_START_TIMEOUT_S`. It also restores `_auto_served_server`, which the function sets
as a module global with an `atexit` shutdown attached; leaving that behind would be an odd
thing for a test in this series to do.

## Collateral

`unsloth_cli/tests` under `-n 4`, measured twice in each direction:

| | failures |
|---|---|
| with the change | 68–69 |
| without | 68–69 |

The ±1 is `test_studio_update_verify.py`, which is order-dependent under xdist and varies on
an **unmodified** tree. Run in isolation that file is 4 failed / 51 passed identically with
and without the change, three runs each — so it is not moved by this.

TEMP residue after a full root run goes from two files to none.

## One consequence worth naming

Every test in this root now sees a private tempdir, so one that deliberately shared a path
through the system tempdir across tests would stop working. None does.

## Not in scope

Channel 4 only. It touches the same conftest as the channel 3 change, so whichever lands
second will want a trivial rebase; the two additions are at opposite ends of the file and do
not overlap.

Refs #9586.
