### PR TITLE
Studio: respawn when a dead owned backend blocks launch

### DIFF
--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -308,6 +308,42 @@ export function useTauriBackend() {
         case "external_conflict":
           setIsExternalServer(false);
           stopExternalServerPoll();
+          // A dead spawned handle used to return "still starting" forever and never
+          // call start_managed_server (#9756). Native preflight now clears dead
+          // children; if we still see this (race), wait briefly and retry once.
+          if (preflight.reason === "desktop_owned_backend_starting") {
+            setBackendStatus("starting");
+            setStartupMessage(INITIAL_STARTUP_MESSAGE);
+            await wait(1500);
+            const retry = await invoke<DesktopPreflightResult>("desktop_preflight");
+            if (retry.disposition === "managed_ready") {
+              setIsExternalServer(false);
+              stopExternalServerPoll();
+              setBackendStatus("starting");
+              await startManagedServer();
+              return;
+            }
+            if (retry.disposition === "owned_ready" && retry.port) {
+              setApiBase(retry.port);
+              portRef.current = retry.port;
+              setIsExternalServer(false);
+              stopExternalServerPoll();
+              setStartupMessage(SERVER_STARTUP_MESSAGE);
+              setRunningStatus();
+              return;
+            }
+            if (retry.disposition === "attached_ready" && retry.port) {
+              setApiBase(retry.port);
+              portRef.current = retry.port;
+              setIsExternalServer(true);
+              setStartupMessage(SERVER_STARTUP_MESSAGE);
+              setRunningStatus();
+              startExternalServerPoll(retry.port);
+              return;
+            }
+            setBackendError(externalConflictMessage(retry.disposition === "external_conflict" ? retry : preflight));
+            return;
+          }
           setBackendError(externalConflictMessage(preflight));
           return;
         case "not_installed":

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -273,10 +273,18 @@ pub async fn desktop_preflight_result_with_state(
                 Some(port) => backend::probe_ownerless_spawned_backend(port).await,
                 None => backend,
             };
-            return Ok((
-                choose_ownerless_spawned_preflight(&managed, &probe, snapshot.port),
-                None,
-            ));
+            let transitional = choose_ownerless_spawned_preflight(&managed, &probe, snapshot.port);
+            if transitional.disposition == DesktopPreflightDisposition::ExternalConflict
+                && transitional.reason.as_deref() == Some("desktop_owned_backend_starting")
+                && crate::process::clear_dead_spawned_backend_if_current(
+                    state,
+                    snapshot.generation,
+                    "ownerless spawned backend no longer answers",
+                )
+            {
+                return Ok((choose_preflight(managed, backend), None));
+            }
+            return Ok((transitional, None));
         };
         match crate::desktop_backend_owner::probe_owned_backend_state(
             owner,
@@ -319,6 +327,16 @@ pub async fn desktop_preflight_result_with_state(
                         snapshot.port,
                         "state owner probe no longer verifies",
                     );
+                    return Ok((choose_preflight(managed, backend), None));
+                }
+                // Spawned but unreachable: if the child is already dead, clear and
+                // fall through to managed_ready so we spawn again (#9756). A live
+                // child still gets the transitional "starting" disposition.
+                if crate::process::clear_dead_spawned_backend_if_current(
+                    state,
+                    snapshot.generation,
+                    "state owner probe no longer verifies",
+                ) {
                     return Ok((choose_preflight(managed, backend), None));
                 }
                 return Ok((

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -1233,6 +1233,47 @@ pub(crate) fn clear_adopted_backend_if_current(
     true
 }
 
+/// Drop a spawned backend whose child has already exited.
+///
+/// Preflight otherwise keeps returning `desktop_owned_backend_starting` forever
+/// for a dead handle, so the UI never reaches `managed_ready` / `start_managed_server`
+/// (#9756). Live children are left alone so a real in-flight spawn still waits.
+pub(crate) fn clear_dead_spawned_backend_if_current(
+    state: &BackendState,
+    generation: u64,
+    reason: &str,
+) -> bool {
+    let mut proc = match state.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if proc.generation != generation {
+        return false;
+    }
+    let Some(child) = proc.owned.as_mut().and_then(OwnedBackendHandle::spawned_child_mut) else {
+        return false;
+    };
+    let dead = match child.try_wait() {
+        Ok(Some(_)) => true,
+        Ok(None) => false,
+        // Cannot observe the child: prefer clearing so launch can respawn rather
+        // than claim "still starting" indefinitely.
+        Err(_) => true,
+    };
+    if !dead {
+        return false;
+    }
+
+    warn!("Clearing dead spawned backend state after {reason}");
+    if let Some(owned) = proc.owned.take() {
+        owned.remove_owner_metadata();
+    }
+    proc.port = None;
+    proc.diagnostics_session = None;
+    proc.adopted_watchdog_generation = None;
+    true
+}
+
 pub(crate) fn claim_adopted_watchdog_if_current(state: &BackendState, generation: u64) -> bool {
     let mut proc = match state.lock() {
         Ok(guard) => guard,


### PR DESCRIPTION
## Summary
- When desktop preflight still holds a **spawned** backend handle but the child has exited (or cannot be observed), clear that state and fall through to `managed_ready` so `start_managed_server` runs again.
- Previously this returned `external_conflict` / `desktop_owned_backend_starting` forever — matching [#9756](https://github.com/unslothai/unsloth/issues/9756) (probes only, never spawn).
- Renderer: one short retry if that transitional conflict is still seen (race with teardown).

Fixes #9756

## Test plan
- [ ] Kill the managed backend process while Desktop is running, then reload / re-open → app should spawn again instead of hanging
- [ ] Normal cold start still reaches `start_managed_server`
- [ ] Live in-flight spawn still waits (does not clear a living child)