### PR TITLE
tests: keep the subprocess-fix directory out of the shared tempdir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,15 +41,51 @@ for _up in _iso.parents:
 # not per RUN, so a test session leaves a directory that every later Python process on the
 # machine imports from, and two concurrent runs share one.
 #
-# Redirecting tempfile.tempdir moves it to a per-run location. tempfile.tempdir is the
-# documented override; TMPDIR/TEMP/TMP are read by gettempdir() once and then cached, so
-# setting those is unreliable once anything has resolved a temp path.
+# Moving it to a per-run location takes BOTH levers, because they cover different scopes:
 #
-# NOT cleaned up on exit, deliberately: a hard-killed worker cannot then leave residue in
-# the shared tempdir, which a `finally` unlink could not promise.
+#   tempfile.tempdir   this process. gettempdir() reads TMPDIR/TEMP/TMP once and then
+#                      caches the answer, so by the time this runs the environment alone
+#                      can no longer move it.
+#   TMPDIR/TEMP/TMP    child interpreters, which resolve their own temp root from the
+#                      environment they are handed. tempfile.tempdir is a module
+#                      attribute and does not survive exec, so setting it alone leaves
+#                      children on the shared root -- and a child that imports unsloth
+#                      re-runs the write from _gpu_init.py. `_run()` in
+#                      tests/test_broken_tf_does_not_break_import.py spawns exactly that.
+#
+# Removed at normal exit. pytest roots its tmp_path tree at gettempdir() and prunes only
+# the `pytest-*` siblings it finds beside it, so a fresh root per run means that pruning
+# never sees an earlier run and every run leaks its whole fixture tree. A hard-killed
+# process still leaves its root behind, which is harmless: it is an isolated directory,
+# not the shared sitecustomize path this channel is about. Pass --basetemp, or set
+# PYTEST_DEBUG_TEMPROOT, to keep a run's fixtures for post-mortem inspection.
+import atexit as _atexit  # noqa: E402
+import glob as _glob  # noqa: E402
+import os as _os  # noqa: E402
+import shutil as _shutil  # noqa: E402
 import tempfile as _tempfile  # noqa: E402
 
+# Captured before the redirect. The tests assert this session adds nothing to the shared
+# root -- not that the root is globally empty, which would fail on precisely the machines
+# #9586 describes, where a stray from before this fix is already sitting there.
+_SHARED_TEMPDIR = _tempfile.gettempdir()
+_PRE_EXISTING_FIX_DIRS = frozenset(
+    _glob.glob(_os.path.join(_SHARED_TEMPDIR, "unsloth_subprocess_import_fix*"))
+)
+
 _tempfile.tempdir = _tempfile.mkdtemp(prefix = "unsloth-tests-")
+_os.environ["TEMP"] = _tempfile.tempdir
+_os.environ["TMP"] = _tempfile.tempdir
+if _os.name == "nt":
+    # Removed, not set. gettempdir() reads TMPDIR before TEMP on every platform, so a
+    # TMPDIR the session happened to inherit would win over the TEMP set above and let a
+    # child resolve some other root; clearing it makes TEMP authoritative. Setting it
+    # instead would hand a Windows path to the POSIX spelling that install.sh and
+    # tests/sh read, which is not a trade worth making when clearing it suffices.
+    _os.environ.pop("TMPDIR", None)
+else:
+    _os.environ["TMPDIR"] = _tempfile.tempdir
+_atexit.register(_shutil.rmtree, _tempfile.tempdir, ignore_errors = True)
 # -----------------------------------------------------------------------------------
 
 # --- shared test helpers on sys.path -----------------------------------------------
@@ -82,6 +118,26 @@ def _contain_installer_venv_root(tmp_path_factory, monkeypatch):
     """
     from installer_venv_root import contain_installer_venv_root
     contain_installer_venv_root(monkeypatch, tmp_path_factory)
+
+
+@pytest.fixture(scope = "session")
+def shared_tempdir_before_redirect() -> str:
+    """The machine-shared temp root, as it was before this conftest redirected away.
+
+    Read from the snapshot rather than from TMPDIR/TEMP/TMP, which now point at the
+    per-run root -- see the containment block at the top of this file.
+    """
+    return _SHARED_TEMPDIR
+
+
+@pytest.fixture(scope = "session")
+def pre_existing_fix_dirs() -> frozenset:
+    """Subprocess-fix directories already in the shared root when this session started.
+
+    A machine that ran an unsloth suite before this fix landed still carries one, and it
+    is not this session's to fail on. Tests assert nothing is ADDED to this set.
+    """
+    return _PRE_EXISTING_FIX_DIRS
 
 
 def _has_real_accelerator() -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,29 @@ for _up in _iso.parents:
         break
 # -----------------------------------------------------------------------------------
 
+# --- subprocess-fix directory containment (issue #9586, channel 2) -----------------
+# Must run at MODULE scope, before _apply_upstream_import_fixes_for_tests() at the bottom
+# of this file triggers `import unsloth`. A fixture cannot do it: the write happens while
+# this module is still being imported, long before any fixture runs.
+#
+# unsloth/import_fixes.py:_subprocess_fix_directory() builds
+# `<gettempdir()>/unsloth_subprocess_import_fix-<uid>` and writes a sitecustomize.py into
+# it, then prepends that directory to PYTHONPATH. That is correct for a real install --
+# the whole point is that child processes inherit it -- but the path is scoped per USER,
+# not per RUN, so a test session leaves a directory that every later Python process on the
+# machine imports from, and two concurrent runs share one.
+#
+# Redirecting tempfile.tempdir moves it to a per-run location. tempfile.tempdir is the
+# documented override; TMPDIR/TEMP/TMP are read by gettempdir() once and then cached, so
+# setting those is unreliable once anything has resolved a temp path.
+#
+# NOT cleaned up on exit, deliberately: a hard-killed worker cannot then leave residue in
+# the shared tempdir, which a `finally` unlink could not promise.
+import tempfile as _tempfile  # noqa: E402
+
+_tempfile.tempdir = _tempfile.mkdtemp(prefix = "unsloth-tests-")
+# -----------------------------------------------------------------------------------
+
 # --- shared test helpers on sys.path -----------------------------------------------
 # tests/_shared holds no package marker and pytest only puts a *test file's* own
 # directory on sys.path, so tests/python/, tests/studio/install/ and tests/security/

--- a/tests/test_subprocess_fix_dir_containment_9586.py
+++ b/tests/test_subprocess_fix_dir_containment_9586.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Regression tests for issue #9586 channel 2: the subprocess-fix directory in /tmp.
+
+``unsloth/import_fixes.py:_subprocess_fix_directory()`` builds
+``<gettempdir()>/unsloth_subprocess_import_fix-<uid>``, writes a ``sitecustomize.py`` into
+it and prepends the directory to ``PYTHONPATH``. That is correct for a real install -- the
+point is that children inherit it -- but the path is scoped per **user**, not per **run**.
+
+Two properties follow, and each has a test here:
+
+* the directory a test session creates must not be the machine-shared one, and
+* the redirect has to be applied at conftest **module** scope, because the write happens
+  while that module is still being imported.
+
+The write itself is gated on a torch/torchao version skew (torchao >= 0.18 against a torch
+predating ``aten._grouped_mm``, which arrived in 2.8), so on a matched pair nothing is
+written at all. These tests therefore assert *where* a temp path resolves rather than
+requiring the skew to be present.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+_PREFIX = "unsloth-tests-"
+_CONFTEST = Path(__file__).resolve().parent / "conftest.py"
+_FIX_DIRNAME = "unsloth_subprocess_import_fix"
+
+
+def test_the_session_tempdir_is_not_the_shared_one():
+    resolved = Path(tempfile.gettempdir()).resolve()
+    assert resolved.name.startswith(_PREFIX), resolved
+
+    shared = Path(
+        os.environ.get("TMPDIR") or os.environ.get("TEMP") or os.environ.get("TMP") or "/tmp"
+    ).resolve()
+    assert resolved != shared
+
+
+def test_the_fix_directory_would_land_off_the_shared_tempdir():
+    """The path expression from `_subprocess_fix_directory`, built the same way.
+
+    Asserted by construction rather than by calling the function, which is gated on a
+    version skew that a matched torch/torchao pair does not have.
+    """
+    directory = (
+        Path(tempfile.gettempdir())
+        / f"{_FIX_DIRNAME}-{os.getuid() if hasattr(os, 'getuid') else 'user'}"
+    )
+
+    session_tmp = Path(tempfile.gettempdir()).resolve()
+    assert session_tmp in directory.resolve().parents
+
+    shared = Path(
+        os.environ.get("TMPDIR") or os.environ.get("TEMP") or os.environ.get("TMP") or "/tmp"
+    ).resolve()
+    assert directory.resolve().parent != shared
+
+
+def test_no_fix_directory_is_left_in_the_shared_tempdir():
+    """The observable the issue reports, checked where it would actually land."""
+    shared = Path(
+        os.environ.get("TMPDIR") or os.environ.get("TEMP") or os.environ.get("TMP") or "/tmp"
+    )
+    if not shared.is_dir():
+        return
+    strays = sorted(shared.glob(f"{_FIX_DIRNAME}*"))
+    assert not strays, f"subprocess-fix directories left in the shared tempdir: {strays}"
+
+
+def test_the_redirect_is_applied_at_module_scope():
+    """Pins the placement, which is the whole mechanism.
+
+    A fixture cannot be substituted: `_apply_upstream_import_fixes_for_tests()` runs while
+    conftest is still being imported, so the write has already happened by the time any
+    fixture could run. Read from disk rather than via `inspect`, because importing the
+    module to inspect it would re-run the redirect and allocate a second directory.
+    """
+    source = _CONFTEST.read_text(encoding = "utf-8")
+
+    # Anchored to line start: a bare substring matches the mention of the trigger inside
+    # the comment above the redirect itself, which is earlier in the file, and the
+    # assertion would then compare the redirect against its own documentation.
+    redirect = source.index("\n_tempfile.tempdir = ")
+    trigger = source.index("\n_apply_upstream_import_fixes_for_tests()")
+    assert redirect < trigger, "the redirect must precede the import that triggers the write"
+    assert redirect < source.index("\ndef "), "must precede every function in the module"

--- a/tests/test_subprocess_fix_dir_containment_9586.py
+++ b/tests/test_subprocess_fix_dir_containment_9586.py
@@ -8,9 +8,11 @@
 it and prepends the directory to ``PYTHONPATH``. That is correct for a real install -- the
 point is that children inherit it -- but the path is scoped per **user**, not per **run**.
 
-Two properties follow, and each has a test here:
+Three properties follow, and each has a test here:
 
-* the directory a test session creates must not be the machine-shared one, and
+* the directory a test session creates must not be the machine-shared one,
+* a child interpreter must resolve the same per-run root, because a child that imports
+  unsloth re-runs the write, and
 * the redirect has to be applied at conftest **module** scope, because the write happens
   while that module is still being imported.
 
@@ -22,7 +24,10 @@ requiring the skew to be present.
 
 from __future__ import annotations
 
+import glob
 import os
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -32,17 +37,13 @@ _CONFTEST = Path(__file__).resolve().parent / "conftest.py"
 _FIX_DIRNAME = "unsloth_subprocess_import_fix"
 
 
-def test_the_session_tempdir_is_not_the_shared_one():
+def test_the_session_tempdir_is_not_the_shared_one(shared_tempdir_before_redirect):
     resolved = Path(tempfile.gettempdir()).resolve()
     assert resolved.name.startswith(_PREFIX), resolved
-
-    shared = Path(
-        os.environ.get("TMPDIR") or os.environ.get("TEMP") or os.environ.get("TMP") or "/tmp"
-    ).resolve()
-    assert resolved != shared
+    assert resolved != Path(shared_tempdir_before_redirect).resolve()
 
 
-def test_the_fix_directory_would_land_off_the_shared_tempdir():
+def test_the_fix_directory_would_land_off_the_shared_tempdir(shared_tempdir_before_redirect):
     """The path expression from `_subprocess_fix_directory`, built the same way.
 
     Asserted by construction rather than by calling the function, which is gated on a
@@ -55,22 +56,109 @@ def test_the_fix_directory_would_land_off_the_shared_tempdir():
 
     session_tmp = Path(tempfile.gettempdir()).resolve()
     assert session_tmp in directory.resolve().parents
-
-    shared = Path(
-        os.environ.get("TMPDIR") or os.environ.get("TEMP") or os.environ.get("TMP") or "/tmp"
-    ).resolve()
-    assert directory.resolve().parent != shared
+    assert directory.resolve().parent != Path(shared_tempdir_before_redirect).resolve()
 
 
-def test_no_fix_directory_is_left_in_the_shared_tempdir():
-    """The observable the issue reports, checked where it would actually land."""
-    shared = Path(
-        os.environ.get("TMPDIR") or os.environ.get("TEMP") or os.environ.get("TMP") or "/tmp"
-    )
+def test_no_fix_directory_is_added_to_the_shared_tempdir(
+    shared_tempdir_before_redirect, pre_existing_fix_dirs
+):
+    """The observable the issue reports, checked where it would actually land.
+
+    Compared against a snapshot taken before the redirect, not against an empty root. A
+    machine affected by #9586 already carries a stray from before this fix, and failing on
+    that would fail this suite on exactly the machines it is meant to protect.
+    """
+    shared = Path(shared_tempdir_before_redirect)
     if not shared.is_dir():
         return
-    strays = sorted(shared.glob(f"{_FIX_DIRNAME}*"))
-    assert not strays, f"subprocess-fix directories left in the shared tempdir: {strays}"
+    now = frozenset(glob.glob(os.path.join(str(shared), f"{_FIX_DIRNAME}*")))
+    added = sorted(now - set(pre_existing_fix_dirs))
+    assert not added, f"this session added subprocess-fix directories: {added}"
+
+
+def test_the_temp_environment_points_at_the_session_tempdir():
+    """`tempfile.tempdir` is a module attribute and does not survive exec.
+
+    Children resolve their own temp root from the environment, so the environment has to
+    be moved too or the containment stops at this process.
+    """
+    session_tmp = Path(tempfile.gettempdir()).resolve()
+    # Anchored on the per-run prefix, not only on equality: with no redirect at all
+    # gettempdir() and TEMP are BOTH the shared root, and comparing them alone passes.
+    assert session_tmp.name.startswith(_PREFIX), session_tmp
+    for name in ("TEMP", "TMP"):
+        value = os.environ.get(name)
+        assert value, f"{name} is not set"
+        assert Path(value).resolve() == session_tmp, name
+
+
+def test_tmpdir_is_left_posix_shaped_or_unset():
+    """On Windows TMPDIR must be cleared, not set, and TEMP left authoritative.
+
+    gettempdir() reads TMPDIR before TEMP on every platform, so a TMPDIR inherited from
+    the surrounding session would win over the redirect and let a child resolve some
+    other root. Clearing it also keeps a Windows path out of the POSIX spelling that
+    install.sh and tests/sh read.
+    """
+    value = os.environ.get("TMPDIR")
+    if os.name == "nt":
+        assert value is None, f"TMPDIR must not be handed a Windows path: {value!r}"
+        return
+    assert value, "TMPDIR is not set"
+    assert Path(value).resolve() == Path(tempfile.gettempdir()).resolve()
+
+
+def test_a_child_interpreter_resolves_the_session_tempdir():
+    """The property `tempfile.tempdir` alone does NOT have.
+
+    Spawned the way `_run()` in tests/test_broken_tf_does_not_break_import.py spawns one:
+    the parent's environment, passed through. Such a child imports unsloth, which re-runs
+    the write via `_gpu_init.py`, so a child left on the shared root recreates the very
+    directory this channel is about.
+    """
+    child = subprocess.run(
+        [sys.executable, "-c", "import tempfile; print(tempfile.gettempdir())"],
+        capture_output = True,
+        text = True,
+        env = dict(os.environ),
+        timeout = 120,
+    )
+
+    assert child.returncode == 0, child.stderr
+    resolved = Path(child.stdout.strip()).resolve()
+    # The prefix check is what makes this non-vacuous. With no redirect anywhere, parent
+    # and child both resolve the shared root and the equality below holds for the wrong
+    # reason -- measured against origin/main, where this test passed until it was added.
+    assert resolved.name.startswith(_PREFIX), child.stdout
+    assert resolved == Path(tempfile.gettempdir()).resolve(), child.stdout
+
+
+def test_the_session_tempdir_is_removed_at_normal_exit():
+    """Runs the real containment block in a child and checks its root is gone after.
+
+    pytest roots its tmp_path tree at `gettempdir()` and prunes only the `pytest-*`
+    siblings beside it, so a fresh root per run means that pruning never sees an earlier
+    run. Without the atexit cleanup every run leaks its whole fixture tree.
+
+    The block is read from conftest rather than restated, so it cannot drift: if it moves,
+    the extraction fails and this test says so.
+    """
+    source = _CONFTEST.read_text(encoding = "utf-8")
+    start = source.index("# --- subprocess-fix directory containment")
+    end = source.index("\n", source.index("_atexit.register(", start))
+    block = source[start:end]
+
+    child = subprocess.run(
+        [sys.executable, "-c", block + "\nprint(_tempfile.tempdir)\n"],
+        capture_output = True,
+        text = True,
+        timeout = 120,
+    )
+
+    assert child.returncode == 0, child.stderr
+    root = Path(child.stdout.strip())
+    assert root.name.startswith(_PREFIX), child.stdout
+    assert not root.exists(), f"the per-run root outlived the process that made it: {root}"
 
 
 def test_the_redirect_is_applied_at_module_scope():


### PR DESCRIPTION
Channel 2 of #9586 — the one the issue names as the priority.

## The defect

`_subprocess_fix_directory()` in `unsloth/import_fixes.py` builds

```python
<gettempdir()>/unsloth_subprocess_import_fix-<uid>
```

writes a `sitecustomize.py` into it, and prepends that directory to `PYTHONPATH`. That is
right for a real install — children are meant to inherit it. The problem is the scope the
issue identifies: the path is per **user**, not per **run**. A test session therefore
leaves a directory that every later Python process on the machine imports from, and two
concurrent runs share one.

## Reproduced at head

**The write is gated on a torch/torchao version skew, not on platform or GPU** — which is
why it shows nothing on a default install:

```python
if importlib.util.find_spec("torchao") is None:   return None
if Version(torchao) < Version("0.18.0"):          return None
if torch already has the F symbols and aten._grouped_mm:
    return None   # "this torch is new enough; nothing to do"
```

`aten._grouped_mm` arrived in torch 2.8, so torchao ≥ 0.18 against torch < 2.8 is the pair
that fires it. With **torch 2.7.1+cpu and torchao 0.18.0** in a Linux container, a single

```
pytest tests/python/test_windows_studio_update_launcher.py
```

produced:

| | |
|---|---|
| directory | `/tmp/unsloth_subprocess_import_fix-0` |
| file | `sitecustomize.py`, **7540 bytes**, mode `600` |
| `PYTHONPATH` | set to that directory |

7540 bytes is the size the issue records.

## The change

Redirect the temp root at conftest **module** scope, moving the directory to a per-run
location, and carry that root across the process boundary.

**Module scope is required, not stylistic.** The write happens inside
`_apply_upstream_import_fixes_for_tests()` while `tests/conftest.py` is still being
imported, so a fixture — autouse included — runs long after the file already exists.

**Both levers are needed, and they are not alternatives.** `tempfile.tempdir` covers this
process, whose `gettempdir()` has already read and cached the environment. `TMPDIR`/`TEMP`/
`TMP` cover child interpreters, which resolve their own root from the environment they are
handed — `tempfile.tempdir` is a module attribute and does not survive exec. Measured end
to end under the skew above:

| | parent | child resolves | fix directory created at |
|---|---|---|---|
| `tempfile.tempdir` only | `/tmp/unsloth-tests-n5fsp0w4` | `/tmp` | **`/tmp/unsloth_subprocess_import_fix-0`** |
| both | `/tmp/unsloth-tests-qrx3gbpq` | the parent's root | `…/unsloth-tests-qrx3gbpq/unsloth_subprocess_import_fix-0` |

`_run()` in `tests/test_broken_tf_does_not_break_import.py` spawns exactly such a child and
has it import unsloth, which re-runs the write through `_gpu_init.py`.

**On Windows `TMPDIR` is cleared rather than set.** `_candidate_tempdir_list` reads
`TMPDIR` before `TEMP` on every platform, so one inherited from the surrounding session
would win over the redirect; and setting it would hand a Windows path to the POSIX spelling
`install.sh` and `tests/sh` read.

**Removed at normal exit.** pytest roots its `tmp_path` tree at `gettempdir()` and prunes
only the `pytest-*` siblings beside it, so a fresh root per run means that pruning never
sees an earlier run: eight orphaned `unsloth-tests-*` roots, 4.9 MB, had collected on one
machine in three days. A hard-killed worker still leaves its root behind, which is harmless
— that is an isolated directory, not the shared `sitecustomize` path this channel is about.
The cost is pytest's own keep-the-last-three retention, so `--basetemp` and
`PYTEST_DEBUG_TEMPROOT` are named in the comment.

## Tests

`tests/test_subprocess_fix_dir_containment_9586.py`:

| test | pins | fails without the change |
|---|---|---|
| `test_a_child_interpreter_resolves_the_session_tempdir` | the process boundary | **yes** |
| `test_the_temp_environment_points_at_the_session_tempdir` | the environment half | **yes** |
| `test_tmpdir_is_left_posix_shaped_or_unset` | the platform split | **yes** on Linux; on Windows it asserts the variable stays unset, which holds either way |
| `test_the_session_tempdir_is_removed_at_normal_exit` | the cleanup | **yes** |
| `test_no_fix_directory_is_added_to_the_shared_tempdir` | the observable the issue reports | **yes**, as a setup error |
| `test_the_redirect_is_applied_at_module_scope` | the placement, which is the whole mechanism | **yes** |
| `test_the_session_tempdir_is_not_the_shared_one` | the redirect itself | **yes**, as a setup error; meaningful without the skew |
| `test_the_fix_directory_would_land_off_the_shared_tempdir` | the path expression, built as production builds it | **yes**, as a setup error; meaningful without the skew |

Re-measured 2026-09-16 on `main` at `c5faa7fb3`, in a Linux container: all 8 pass with this change. With only the test file, 5 fail, and the 3 marked *setup error* cannot start, because the `shared_tempdir_before_redirect` fixture they take is part of this change. An earlier version of this table said two of them pass without it; they do not.

The last two assert where a temp path *resolves* rather than requiring the version skew to
be present, so they stay meaningful on a matched torch/torchao pair, where nothing is
written at all.

`test_no_fix_directory_is_added_to_the_shared_tempdir` compares against a snapshot taken in
conftest **before** the redirect. Asserting the shared root is globally empty would fail on
any machine already carrying a stray from before this fix — that is, on precisely the
machines this issue describes.

Both cross-process tests assert the resolved root carries the per-run prefix, not merely
that parent and child agree: with no redirect anywhere they agree on the *shared* root, and
equality alone passes.

The placement test anchors its search to line start. A bare substring matched the mention of
the trigger inside the new comment and compared the redirect against its own documentation.

## Collateral

Same tree, change in and out:

| | passed | failed | skipped | errors |
|---|---|---|---|---|
| Linux container (`tests/python`, `-n 4`) | 1095 / 1095 | 13 / 13 | | |
| Windows (`tests/python`, `-n 4`) | 881 / 881 | 72 / 72 | | |
| Windows, the 29 top-level suites that spawn subprocesses | 548 / 540 | 46 / 46 | 154 / 154 | 5 / 5 |

Identical in both directions; the 548 / 540 delta is exactly the new tests.

## One consequence worth naming

Every test under `tests/` now sees a per-run tempdir and a matching environment, so one that
deliberately shared a path through the system tempdir across sessions would stop working.
None does.

## Not in scope

**This contains the test-side leak only.** Whether the production directory should itself be
run-scoped or lifetime-bounded is a behaviour change for a real install — it would alter
what child processes inherit — so it is left for you rather than decided here. The issue's
phrasing ("the gap is lifetime and run-scope, not ownership") reads as pointing at that
larger question too; happy to take it as a follow-up if you want it.

Refs #9586.

