### PR TITLE
tests: stop the CLI suite downloading cloudflared

### DIFF
--- a/unsloth_cli/tests/conftest.py
+++ b/unsloth_cli/tests/conftest.py
@@ -46,3 +46,38 @@ def stub_tool_policy_state(monkeypatch):
     state_mod.tool_policy = tp_mod
     monkeypatch.setitem(sys.modules, "state", state_mod)
     monkeypatch.setitem(sys.modules, "state.tool_policy", tp_mod)
+
+
+@pytest.fixture(autouse = True)
+def _no_cloudflared_download(monkeypatch, tmp_path):
+    """Stop a unit test fetching the 40 MB cloudflared binary (issue #9586, channel 3a).
+
+    The `--secure` path calls a helper that loads studio/backend/cloudflare_tunnel.py by
+    file path and asks `ensure_cloudflared()` whether a tunnel could start. That call
+    DOWNLOADS the binary when none is found: measured on Linux, eight tests across
+    test_studio_secure_flag.py and test_studio_cloudflare_flag.py each fetched 39,799,316
+    bytes into ~/.unsloth/studio/bin/cloudflared. The suite then depends on network
+    reachability and writes a large file outside anything it owns.
+
+    Satisfied through PATH rather than by patching the module. The helper does
+    `spec_from_file_location("studio.backend.cloudflare_tunnel", ...)` and execs a FRESH
+    module object on every call, so `monkeypatch.setattr` on an imported
+    `cloudflare_tunnel` reaches a different object entirely and the download still happens
+    -- measured. `find_cloudflared()` consults `shutil.which("cloudflared")` first and
+    returns early, so a stub on PATH satisfies every copy of the module, and the real
+    lookup, cache-path and platform-asset code still runs.
+
+    Both names: shutil.which keys off os.name for PATHEXT, which these tests do not
+    monkeypatch even where they do set sys.platform.
+    """
+    import os as _os
+
+    stub_dir = tmp_path / "fake-bin"
+    stub_dir.mkdir()
+    for name in ("cloudflared", "cloudflared.exe"):
+        stub = stub_dir / name
+        # Contents are irrelevant: shutil.which checks existence and the executable
+        # bit, and nothing ever runs this file.
+        stub.write_text("", encoding = "utf-8")
+        stub.chmod(0o755)
+    monkeypatch.setenv("PATH", str(stub_dir) + _os.pathsep + _os.environ.get("PATH", ""))

--- a/unsloth_cli/tests/test_no_cloudflared_download_9586.py
+++ b/unsloth_cli/tests/test_no_cloudflared_download_9586.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for issue #9586 channel 3a: a unit test downloading cloudflared.
+
+The `--secure` path asks whether a tunnel could start, and that question is answered by
+`ensure_cloudflared()`, which FETCHES a ~40 MB binary when none is found. The `unsloth run`
+re-exec tests in this root reach it for real, so the suite depended on network reachability
+and wrote a large file outside anything it owns.
+
+The guard is a stub on PATH, not a patched module, because the caller execs a fresh copy of
+`cloudflare_tunnel` by file path on every call -- see the conftest fixture for the
+measurement behind that.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+_BACKEND = Path(__file__).resolve().parents[2] / "studio" / "backend"
+
+
+def _cloudflare_tunnel():
+    if str(_BACKEND) not in sys.path:
+        sys.path.insert(0, str(_BACKEND))
+    import cloudflare_tunnel
+    return cloudflare_tunnel
+
+
+def test_a_cloudflared_is_visible_on_path():
+    """The guard itself. Without it `which` finds nothing and the fetch path opens."""
+    found = shutil.which("cloudflared")
+    assert found, "conftest should have put a cloudflared stub on PATH"
+    assert "fake-bin" in found, found
+
+
+def test_find_cloudflared_returns_the_stub_rather_than_reaching_the_cache():
+    """`find_cloudflared` consults PATH first, which is what makes the guard work.
+
+    Both halves asserted non-empty. Comparing the two results alone passes vacuously
+    without the guard -- `which` finds nothing, `find_cloudflared` has nothing cached
+    yet, and `None == None` holds while the very next test performs the download.
+    """
+    ct = _cloudflare_tunnel()
+
+    on_path = shutil.which("cloudflared")
+    assert on_path, "conftest should have put a cloudflared stub on PATH"
+
+    found = ct.find_cloudflared()
+    assert found, "find_cloudflared should resolve the PATH stub"
+    assert found == on_path
+
+
+def test_ensure_cloudflared_returns_without_fetching():
+    """The real function, unpatched, taking its early-return branch.
+
+    Nothing here is stubbed: the lookup, the cache path and the platform asset logic all
+    run. Only the *outcome* differs, because a cloudflared is already visible.
+    """
+    ct = _cloudflare_tunnel()
+
+    assert ct.ensure_cloudflared() == shutil.which("cloudflared")
+
+
+def test_no_cloudflared_binary_is_written_into_the_studio_bin_root():
+    """The observable the issue reports: ~39.8 MB appearing under the studio home."""
+    ct = _cloudflare_tunnel()
+
+    cached = ct._cache_path()
+    if cached is None:
+        return
+    assert not cached.exists(), f"a test fetched cloudflared to {cached}"
+
+
+def test_the_guard_survives_a_freshly_exec_d_copy_of_the_module():
+    """The property a patched module object would NOT have.
+
+    `unsloth_cli/commands/studio.py` loads cloudflare_tunnel with
+    `spec_from_file_location(...)` and execs it anew on every call, so a `monkeypatch`
+    against an imported copy reaches a different object and the download still happens.
+    A PATH stub satisfies any copy.
+    """
+    import importlib.util
+
+    tunnel_py = _BACKEND / "cloudflare_tunnel.py"
+    if not tunnel_py.is_file():
+        return
+
+    if str(_BACKEND) not in sys.path:
+        sys.path.insert(0, str(_BACKEND))
+    spec = importlib.util.spec_from_file_location("studio.backend.cloudflare_tunnel", tunnel_py)
+    assert spec is not None and spec.loader is not None
+    fresh = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(fresh)
+
+    assert fresh.ensure_cloudflared() == shutil.which("cloudflared")
+    cached = fresh._cache_path()
+    if cached is not None:
+        assert not cached.exists(), f"the fresh copy fetched cloudflared to {cached}"


### PR DESCRIPTION
Channel 3a of #9586 — the last of its five.

## The defect

The `--secure` path asks whether a tunnel could start, and that question is answered by
`ensure_cloudflared()`, which **fetches a ~40 MB binary** when none is found. The
`unsloth run` re-exec tests in `unsloth_cli/tests` reach it for real.

## Reproduced at head

In a Linux container, eight tests across `test_studio_secure_flag.py` and
`test_studio_cloudflare_flag.py` each fetched:

| | |
|---|---|
| destination | `~/.unsloth/studio/bin/cloudflared` |
| size | **39,799,316 bytes** |

That is the figure the issue records. It does **not** reproduce on Windows, which is why it
needed the container.

## The change, and why not the obvious one

**First attempt: patch the module. It does not work, measured.**
`_tunnel_binary_confirmed_unavailable()` at `unsloth_cli/commands/studio.py:1431` loads the
helper with

```python
spec = importlib.util.spec_from_file_location("studio.backend.cloudflare_tunnel", tunnel_py)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
```

— a **fresh module object on every call**. `monkeypatch.setattr` against an imported
`cloudflare_tunnel` reaches a different object entirely, and the download still happens.

**What works: a stub on PATH.** `find_cloudflared()` consults
`shutil.which("cloudflared")` before anything else, so one stub satisfies *every* copy of
the module however it was loaded. The real lookup, cache-path and platform-asset code all
still run; only the outcome changes, to the one a machine that already has cloudflared
gives.

`studio/backend/tests/test_cloudflare_tunnel.py` owns the download's real coverage and is in
a different root, so it is untouched.

## Tests

`unsloth_cli/tests/test_no_cloudflared_download_9586.py` — **all five fail without the
change**, with the binary appearing:

| test | pins |
|---|---|
| `test_no_cloudflared_binary_is_written_into_the_studio_bin_root` | the observable the issue reports |
| `test_ensure_cloudflared_returns_without_fetching` | the real function, unpatched, taking its early return |
| `test_find_cloudflared_returns_the_stub_rather_than_reaching_the_cache` | why PATH is the seam that works — both halves asserted non-empty, since comparing the two results alone passes vacuously (`None == None`) before anything downloads |
| `test_a_cloudflared_is_visible_on_path` | the guard itself |
| `test_the_guard_survives_a_freshly_exec_d_copy_of_the_module` | the property a patched module object would **not** have — it execs its own fresh copy, the way the caller does, and asserts that one does not fetch either |

## Collateral

Linux container, `unsloth_cli/tests` under `-n 4`, same tree:

| | passed | failed |
|---|---|---|
| with the guard | 1098 | 4 |
| without | 1098 | 4 |

On Windows the three files whose `-n 4` counts moved are **identical in isolation** either
way (4/51, 1/15, 12/0). That root's full-run count swings **70, 78, 77** across three runs
on an *unmodified* tree, so the xdist figure carries no signal in either direction.

## One consequence worth naming

Every test in this root now sees a cloudflared on PATH, so one that wanted to exercise the
absent-binary branch would have to unset it. None does today, and that branch keeps its
coverage in the backend root.

## Also worth naming

With this in place `unsloth_cli/tests` runs to completion under `docker run --network none`
— **1103 passed, 4 failed** — which it could not before.

Refs #9586.
