### PR TITLE
Fix duplicate GGUF rows in custom model folders

### DIFF
--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -397,7 +397,7 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
         _resolve_hf_cache_dir,
         _is_hidden_model,
     )
-    from hub.utils.gguf import dedupe_custom_gguf_rows
+    from hub.utils.gguf import dedupe_custom_gguf_rows, suppress_grouped_gguf_file_rows
     from utils.paths import legacy_hf_cache_dir, hf_default_cache_dir, lmstudio_model_dirs
     from utils.hf_cache_settings import known_hf_hub_caches
     from core.inference.model_ids import public_model_id
@@ -456,16 +456,16 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
         logger.debug("auto-switch: LM Studio scan failed: %s", exc)
     try:
         from storage.studio_db import list_scan_folders
+        custom_found = []
         for folder in list_scan_folders():
             try:
                 fp = Path(folder["path"])
-                found += dedupe_custom_gguf_rows(
-                    _scan_models_dir(fp, limit = 200)
-                    + _scan_hf_once(fp)
-                    + _scan_lmstudio_dir(fp)
+                custom_found += dedupe_custom_gguf_rows(
+                    _scan_models_dir(fp, limit = 200) + _scan_hf_once(fp) + _scan_lmstudio_dir(fp)
                 )
             except Exception as exc:
                 logger.debug("auto-switch: scan folder %r failed: %s", folder, exc)
+        found += suppress_grouped_gguf_file_rows(custom_found)
     except Exception as exc:
         logger.debug("auto-switch: scan folders enumerate failed: %s", exc)
     for info in found:

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -456,6 +456,7 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
         logger.debug("auto-switch: LM Studio scan failed: %s", exc)
     try:
         from storage.studio_db import list_scan_folders
+
         custom_found = []
         for folder in list_scan_folders():
             try:

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -397,6 +397,7 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
         _resolve_hf_cache_dir,
         _is_hidden_model,
     )
+    from hub.utils.gguf import dedupe_custom_gguf_rows
     from utils.paths import legacy_hf_cache_dir, hf_default_cache_dir, lmstudio_model_dirs
     from utils.hf_cache_settings import known_hf_hub_caches
     from core.inference.model_ids import public_model_id
@@ -458,8 +459,10 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
         for folder in list_scan_folders():
             try:
                 fp = Path(folder["path"])
-                found += (
-                    _scan_models_dir(fp, limit = 200) + _scan_hf_once(fp) + _scan_lmstudio_dir(fp)
+                found += dedupe_custom_gguf_rows(
+                    _scan_models_dir(fp, limit = 200)
+                    + _scan_hf_once(fp)
+                    + _scan_lmstudio_dir(fp)
                 )
             except Exception as exc:
                 logger.debug("auto-switch: scan folder %r failed: %s", folder, exc)

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -810,7 +810,7 @@ def _scan_custom_folder(
         path = Path(model.path)
         family = gguf.gguf_variant_family(path.name)
         is_loose_shard = (
-            model.source == "lmstudio"
+            model.source in {"models_dir", "lmstudio"}
             and model.model_format == "gguf"
             and not _safe_is_dir(path)
             and family != path.stem

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -586,23 +586,11 @@ def _inventory_path_identity(raw_path: str) -> str:
 
 def _inventory_physical_identity(raw_path: str) -> str:
     """physical identity for an existing discovered path without lossy name folding."""
-    try:
-        path = os.path.realpath(os.path.expanduser(raw_path))
-        stat = os.stat(path)
-        if stat.st_ino:
-            return "\x00".join(("stat", str(stat.st_dev), str(stat.st_ino)))
-        return f"path\x00{path}"
-    except (OSError, UnicodeError, ValueError):
-        return f"path\x00{os.path.abspath(os.path.expanduser(raw_path))}"
+    return gguf.local_path_physical_identity(raw_path)
 
 
 def _inventory_resolved_parent_identity(raw_path: str) -> str:
-    try:
-        resolved = os.path.realpath(os.path.expanduser(raw_path))
-        parent = str(Path(resolved).parent)
-    except (OSError, UnicodeError, ValueError):
-        parent = str(Path(raw_path).parent)
-    return _inventory_physical_identity(parent)
+    return gguf.local_path_parent_physical_identity(raw_path)
 
 
 def _coerce_scan_folder_path(raw_path: str) -> str:
@@ -825,87 +813,7 @@ def _scan_custom_folder(
         elif detect_gguf_model(model.path, model_root = str(folder_path)) is not None:
             selectable.append(model)
 
-    seen_loose_shard_families: set[tuple[str, str]] = set()
-    unsharded_selectable: list[LocalModelInfo] = []
-    for model in selectable:
-        path = Path(model.path)
-        family = gguf.gguf_variant_family(path.name)
-        is_loose_shard = (
-            model.source in {"models_dir", "lmstudio"}
-            and model.model_format == "gguf"
-            and not _safe_is_dir(path)
-            and family != path.stem
-        )
-        if is_loose_shard:
-            shard_key = (_inventory_physical_identity(str(path.parent)), family)
-            if shard_key in seen_loose_shard_families:
-                continue
-            seen_loose_shard_families.add(shard_key)
-        unsharded_selectable.append(model)
-    selectable = unsharded_selectable
-
-    grouped_gguf_dirs = {
-        _inventory_physical_identity(model.path)
-        for model in selectable
-        if model.source != "lmstudio"
-        and model.model_format == "gguf"
-        and not model.partial
-        and _safe_is_dir(Path(model.path))
-    }
-    lmstudio_files_by_parent: dict[str, list[Path]] = {}
-    for model in selectable:
-        path = Path(model.path)
-        if (
-            model.source == "lmstudio"
-            and model.model_format == "gguf"
-            and not _safe_is_dir(path)
-        ):
-            lmstudio_files_by_parent.setdefault(
-                _inventory_physical_identity(str(path.parent)), []
-            ).append(path)
-
-    grouped_decisions: dict[str, bool] = {}
-    for parent, files in lmstudio_files_by_parent.items():
-        if parent not in grouped_gguf_dirs:
-            continue
-        families = {gguf.gguf_checkpoint_family(path.name) for path in files}
-        variant_keys = [gguf.gguf_variant_key(path.name) for path in files]
-        exact_families_by_variant: dict[str, set[str]] = {}
-        for path, variant_key in zip(files, variant_keys):
-            exact_families_by_variant.setdefault(variant_key.casefold(), set()).add(
-                gguf.gguf_variant_family(path.name)
-            )
-        has_ambiguous_variant = any(
-            len(exact_families) > 1
-            for exact_families in exact_families_by_variant.values()
-        )
-        grouped_decisions[parent] = (
-            len(files) == 1
-            or (
-                not has_ambiguous_variant
-                and (
-                    families == {None}
-                    or (None not in families and len(families) == 1)
-                )
-            )
-            or all(gguf.is_h3_denoiser_variant_key(key) for key in variant_keys)
-        )
-
-    if grouped_decisions:
-        filtered: list[LocalModelInfo] = []
-        for model in selectable:
-            path = Path(model.path)
-            is_dir = _safe_is_dir(path)
-            identity = _inventory_physical_identity(str(path if is_dir else path.parent))
-            keep_group = grouped_decisions.get(identity)
-            if (
-                keep_group is not None
-                and model.model_format == "gguf"
-                and ((is_dir and not keep_group) or (not is_dir and keep_group))
-            ):
-                continue
-            filtered.append(model)
-        selectable = filtered
+    selectable = gguf.dedupe_custom_gguf_rows(selectable)
     remaining = _MAX_MODELS_PER_CUSTOM_FOLDER - len(selectable)
     if remaining > 0:
         selectable.extend(scan_ollama_dir(folder_path, limit = remaining))

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -22,7 +22,7 @@ from hub.storage.scan_folders import (
     list_scan_folders,
     remove_scan_folder,
 )
-from hub.utils import download_manifest, inventory_scan as hf_cache_scan
+from hub.utils import download_manifest, gguf, inventory_scan as hf_cache_scan
 from hub.utils.paths import (
     hf_default_cache_dir,
     legacy_hf_cache_dir,
@@ -804,30 +804,53 @@ def _scan_custom_folder(
         elif detect_gguf_model(model.path, model_root = str(folder_path)) is not None:
             selectable.append(model)
 
-    # The generic pass treats an immediate child directory containing GGUFs as
-    # one model whose files are quant variants.  The LM Studio compatibility
-    # pass can interpret the same directory as a publisher and publish those
-    # files again as separate models.  Keep compatibility rows only where the
-    # generic scan did not already claim their containing model directory.
     grouped_gguf_dirs = {
-        Path(model.path)
+        _inventory_path_identity(model.path)
         for model in selectable
         if model.source != "lmstudio"
         and model.model_format == "gguf"
         and not model.partial
         and _safe_is_dir(Path(model.path))
     }
-    if grouped_gguf_dirs:
-        selectable = [
-            model
-            for model in selectable
-            if not (
-                model.source == "lmstudio"
+    lmstudio_files_by_parent: dict[str, list[Path]] = {}
+    for model in selectable:
+        path = Path(model.path)
+        if (
+            model.source == "lmstudio"
+            and model.model_format == "gguf"
+            and not _safe_is_dir(path)
+        ):
+            lmstudio_files_by_parent.setdefault(
+                _inventory_path_identity(str(path.parent)), []
+            ).append(path)
+
+    grouped_decisions: dict[str, bool] = {}
+    for parent, files in lmstudio_files_by_parent.items():
+        if parent not in grouped_gguf_dirs:
+            continue
+        families = {gguf.gguf_checkpoint_family(path.name) for path in files}
+        variant_keys = [gguf.gguf_variant_key(path.name) for path in files]
+        grouped_decisions[parent] = (
+            len(files) == 1
+            or (None not in families and len(families) == 1)
+            or all(gguf.is_h3_denoiser_variant_key(key) for key in variant_keys)
+        )
+
+    if grouped_decisions:
+        filtered: list[LocalModelInfo] = []
+        for model in selectable:
+            path = Path(model.path)
+            is_dir = _safe_is_dir(path)
+            identity = _inventory_path_identity(str(path if is_dir else path.parent))
+            keep_group = grouped_decisions.get(identity)
+            if (
+                keep_group is not None
                 and model.model_format == "gguf"
-                and not _safe_is_dir(Path(model.path))
-                and Path(model.path).parent in grouped_gguf_dirs
-            )
-        ]
+                and ((is_dir and not keep_group) or (not is_dir and keep_group))
+            ):
+                continue
+            filtered.append(model)
+        selectable = filtered
     remaining = _MAX_MODELS_PER_CUSTOM_FOLDER - len(selectable)
     if remaining > 0:
         selectable.extend(scan_ollama_dir(folder_path, limit = remaining))

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -804,6 +804,25 @@ def _scan_custom_folder(
         elif detect_gguf_model(model.path, model_root = str(folder_path)) is not None:
             selectable.append(model)
 
+    seen_loose_shard_families: set[tuple[str, str]] = set()
+    unsharded_selectable: list[LocalModelInfo] = []
+    for model in selectable:
+        path = Path(model.path)
+        family = gguf.gguf_variant_family(path.name)
+        is_loose_shard = (
+            model.source == "lmstudio"
+            and model.model_format == "gguf"
+            and not _safe_is_dir(path)
+            and family != path.stem
+        )
+        if is_loose_shard:
+            shard_key = (_inventory_path_identity(str(path.parent)), family)
+            if shard_key in seen_loose_shard_families:
+                continue
+            seen_loose_shard_families.add(shard_key)
+        unsharded_selectable.append(model)
+    selectable = unsharded_selectable
+
     grouped_gguf_dirs = {
         _inventory_path_identity(model.path)
         for model in selectable

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -584,6 +584,27 @@ def _inventory_path_identity(raw_path: str) -> str:
         return os.path.normcase(raw)
 
 
+def _inventory_physical_identity(raw_path: str) -> str:
+    """physical identity for an existing discovered path without lossy name folding."""
+    try:
+        path = os.path.realpath(os.path.expanduser(raw_path))
+        stat = os.stat(path)
+        if stat.st_ino:
+            return "\x00".join(("stat", str(stat.st_dev), str(stat.st_ino)))
+        return f"path\x00{path}"
+    except (OSError, UnicodeError, ValueError):
+        return f"path\x00{os.path.abspath(os.path.expanduser(raw_path))}"
+
+
+def _inventory_resolved_parent_identity(raw_path: str) -> str:
+    try:
+        resolved = os.path.realpath(os.path.expanduser(raw_path))
+        parent = str(Path(resolved).parent)
+    except (OSError, UnicodeError, ValueError):
+        parent = str(Path(raw_path).parent)
+    return _inventory_physical_identity(parent)
+
+
 def _coerce_scan_folder_path(raw_path: str) -> str:
     """Normalize a scan registration target; the registry stores directories, so a pasted weight-file path is reduced to its parent folder."""
     if not raw_path or not raw_path.strip():
@@ -816,7 +837,7 @@ def _scan_custom_folder(
             and family != path.stem
         )
         if is_loose_shard:
-            shard_key = (_inventory_path_identity(str(path.parent)), family)
+            shard_key = (_inventory_physical_identity(str(path.parent)), family)
             if shard_key in seen_loose_shard_families:
                 continue
             seen_loose_shard_families.add(shard_key)
@@ -824,7 +845,7 @@ def _scan_custom_folder(
     selectable = unsharded_selectable
 
     grouped_gguf_dirs = {
-        _inventory_path_identity(model.path)
+        _inventory_physical_identity(model.path)
         for model in selectable
         if model.source != "lmstudio"
         and model.model_format == "gguf"
@@ -840,7 +861,7 @@ def _scan_custom_folder(
             and not _safe_is_dir(path)
         ):
             lmstudio_files_by_parent.setdefault(
-                _inventory_path_identity(str(path.parent)), []
+                _inventory_physical_identity(str(path.parent)), []
             ).append(path)
 
     grouped_decisions: dict[str, bool] = {}
@@ -875,7 +896,7 @@ def _scan_custom_folder(
         for model in selectable:
             path = Path(model.path)
             is_dir = _safe_is_dir(path)
-            identity = _inventory_path_identity(str(path if is_dir else path.parent))
+            identity = _inventory_physical_identity(str(path if is_dir else path.parent))
             keep_group = grouped_decisions.get(identity)
             if (
                 keep_group is not None
@@ -942,8 +963,8 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
             key = _local_inventory_id(
                 "custom",
                 model.model_format,
-                _inventory_path_identity(model.path),
-                model.format_variant,
+                _inventory_physical_identity(model.path),
+                None,
             )
         else:
             row_key = model.inventory_id or model.id
@@ -966,7 +987,7 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
             deduped[key] = model
 
     grouped_custom_gguf_dirs = {
-        _inventory_path_identity(model.path)
+        _inventory_physical_identity(model.path)
         for model in deduped.values()
         if model.source == "custom"
         and model.model_format == "gguf"
@@ -982,7 +1003,7 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
                 model.source == "custom"
                 and model.model_format == "gguf"
                 and not _safe_is_dir(Path(model.path))
-                and _inventory_path_identity(str(Path(model.path).parent))
+                and _inventory_resolved_parent_identity(model.path)
                 in grouped_custom_gguf_dirs
             )
         }

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -904,9 +904,16 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
                     model.format_variant or "",
                 )
             )
+        elif model.source == "custom":
+            key = _local_inventory_id(
+                "custom",
+                model.model_format,
+                _inventory_path_identity(model.path),
+                model.format_variant,
+            )
         else:
             row_key = model.inventory_id or model.id
-            key = f"{row_key}\x00custom" if model.source == "custom" else row_key
+            key = row_key
         existing = deduped.get(key)
         prefer_candidate = existing is None
         if existing is not None:
@@ -924,15 +931,8 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
         if prefer_candidate:
             deduped[key] = model
 
-    def _lexical_path_identity(raw_path: str) -> str:
-        try:
-            normalized = normalize_path(raw_path)
-            return os.path.normcase(os.path.abspath(os.path.expanduser(normalized)))
-        except (OSError, UnicodeError, ValueError):
-            return os.path.normcase(raw_path)
-
     grouped_custom_gguf_dirs = {
-        _lexical_path_identity(model.path)
+        _inventory_path_identity(model.path)
         for model in deduped.values()
         if model.source == "custom"
         and model.model_format == "gguf"
@@ -948,7 +948,7 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
                 model.source == "custom"
                 and model.model_format == "gguf"
                 and not _safe_is_dir(Path(model.path))
-                and _lexical_path_identity(str(Path(model.path).parent))
+                and _inventory_path_identity(str(Path(model.path).parent))
                 in grouped_custom_gguf_dirs
             )
         }

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -914,9 +914,7 @@ def _filter_hidden_models(local_models: List[LocalModelInfo]) -> list[LocalModel
     return visible
 
 
-def _filter_and_dedupe_local_models(
-    local_models: List[LocalModelInfo],
-) -> list[LocalModelInfo]:
+def _filter_and_dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelInfo]:
     return _dedupe_local_models(_filter_hidden_models(local_models))
 
 

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -843,8 +843,10 @@ def _scan_custom_folder(
             len(files) == 1
             or (
                 not has_ambiguous_variant
-                and None not in families
-                and len(families) == 1
+                and (
+                    families == {None}
+                    or (None not in families and len(families) == 1)
+                )
             )
             or all(gguf.is_h3_denoiser_variant_key(key) for key in variant_keys)
         )

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -589,10 +589,6 @@ def _inventory_physical_identity(raw_path: str) -> str:
     return gguf.local_path_physical_identity(raw_path)
 
 
-def _inventory_resolved_parent_identity(raw_path: str) -> str:
-    return gguf.local_path_parent_physical_identity(raw_path)
-
-
 def _coerce_scan_folder_path(raw_path: str) -> str:
     """Normalize a scan registration target; the registry stores directories, so a pasted weight-file path is reduced to its parent folder."""
     if not raw_path or not raw_path.strip():
@@ -894,29 +890,11 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
         if prefer_candidate:
             deduped[key] = model
 
-    grouped_custom_gguf_dirs = {
-        _inventory_physical_identity(model.path)
-        for model in deduped.values()
-        if model.source == "custom"
-        and model.model_format == "gguf"
-        and not model.partial
-        and model.capabilities.requires_variant
-        and _safe_is_dir(Path(model.path))
-    }
-    if grouped_custom_gguf_dirs:
-        deduped = {
-            key: model
-            for key, model in deduped.items()
-            if not (
-                model.source == "custom"
-                and model.model_format == "gguf"
-                and not _safe_is_dir(Path(model.path))
-                and _inventory_resolved_parent_identity(model.path)
-                in grouped_custom_gguf_dirs
-            )
-        }
+    deduped_values = list(deduped.values())
+    custom_values = [model for model in deduped_values if model.source == "custom"]
     return sorted(
-        deduped.values(),
+        [model for model in deduped_values if model.source != "custom"]
+        + gguf.suppress_grouped_gguf_file_rows(custom_values),
         key = lambda item: item.updated_at or 0,
         reverse = True,
     )

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -830,9 +830,22 @@ def _scan_custom_folder(
             continue
         families = {gguf.gguf_checkpoint_family(path.name) for path in files}
         variant_keys = [gguf.gguf_variant_key(path.name) for path in files]
+        exact_families_by_variant: dict[str, set[str]] = {}
+        for path, variant_key in zip(files, variant_keys):
+            exact_families_by_variant.setdefault(variant_key.casefold(), set()).add(
+                gguf.gguf_variant_family(path.name)
+            )
+        has_ambiguous_variant = any(
+            len(exact_families) > 1
+            for exact_families in exact_families_by_variant.values()
+        )
         grouped_decisions[parent] = (
             len(files) == 1
-            or (None not in families and len(families) == 1)
+            or (
+                not has_ambiguous_variant
+                and None not in families
+                and len(families) == 1
+            )
             or all(gguf.is_h3_denoiser_variant_key(key) for key in variant_keys)
         )
 

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -803,6 +803,31 @@ def _scan_custom_folder(
                 selectable.append(model)
         elif detect_gguf_model(model.path, model_root = str(folder_path)) is not None:
             selectable.append(model)
+
+    # The generic pass treats an immediate child directory containing GGUFs as
+    # one model whose files are quant variants.  The LM Studio compatibility
+    # pass can interpret the same directory as a publisher and publish those
+    # files again as separate models.  Keep compatibility rows only where the
+    # generic scan did not already claim their containing model directory.
+    grouped_gguf_dirs = {
+        Path(model.path)
+        for model in selectable
+        if model.source != "lmstudio"
+        and model.model_format == "gguf"
+        and not model.partial
+        and _safe_is_dir(Path(model.path))
+    }
+    if grouped_gguf_dirs:
+        selectable = [
+            model
+            for model in selectable
+            if not (
+                model.source == "lmstudio"
+                and model.model_format == "gguf"
+                and not _safe_is_dir(Path(model.path))
+                and Path(model.path).parent in grouped_gguf_dirs
+            )
+        ]
     remaining = _MAX_MODELS_PER_CUSTOM_FOLDER - len(selectable)
     if remaining > 0:
         selectable.extend(scan_ollama_dir(folder_path, limit = remaining))

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -1028,6 +1028,12 @@ def _filter_hidden_models(local_models: List[LocalModelInfo]) -> list[LocalModel
     return visible
 
 
+def _filter_and_dedupe_local_models(
+    local_models: List[LocalModelInfo],
+) -> list[LocalModelInfo]:
+    return _dedupe_local_models(_filter_hidden_models(local_models))
+
+
 async def _scan_local_models_response(
     models_dir: str, custom_folders: list[dict], sources: _LocalInventorySources
 ) -> LocalModelListResponse:
@@ -1057,7 +1063,7 @@ async def _scan_local_models_response(
             known_hf_caches,
             custom_folders,
         )
-        models = _dedupe_local_models(_filter_hidden_models(local_models))
+        models = await asyncio.to_thread(_filter_and_dedupe_local_models, local_models)
         return LocalModelListResponse(
             models_dir = str(models_root),
             hf_cache_dir = str(hf_cache_dir),

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -923,6 +923,35 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
                 )
         if prefer_candidate:
             deduped[key] = model
+
+    def _lexical_path_identity(raw_path: str) -> str:
+        try:
+            normalized = normalize_path(raw_path)
+            return os.path.normcase(os.path.abspath(os.path.expanduser(normalized)))
+        except (OSError, UnicodeError, ValueError):
+            return os.path.normcase(raw_path)
+
+    grouped_custom_gguf_dirs = {
+        _lexical_path_identity(model.path)
+        for model in deduped.values()
+        if model.source == "custom"
+        and model.model_format == "gguf"
+        and not model.partial
+        and model.capabilities.requires_variant
+        and _safe_is_dir(Path(model.path))
+    }
+    if grouped_custom_gguf_dirs:
+        deduped = {
+            key: model
+            for key, model in deduped.items()
+            if not (
+                model.source == "custom"
+                and model.model_format == "gguf"
+                and not _safe_is_dir(Path(model.path))
+                and _lexical_path_identity(str(Path(model.path).parent))
+                in grouped_custom_gguf_dirs
+            )
+        }
     return sorted(
         deduped.values(),
         key = lambda item: item.updated_at or 0,

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -232,6 +232,15 @@ def test_split_gguf_shards_stay_grouped(tmp_path):
     assert [Path(row.path) for row in _custom_rows(root)] == [model]
 
 
+def test_pre_quant_split_markers_stay_grouped(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "model-00001-of-00002-Q4_K_M.gguf")
+    _write_gguf(model / "model-00002-of-00002-Q4_K_M.gguf")
+
+    assert [Path(row.path) for row in _custom_rows(root)] == [model]
+
+
 def test_minimax_h3_partitions_stay_grouped(tmp_path):
     root = tmp_path / "root"
     model = root / "minimax-h3"
@@ -303,19 +312,10 @@ def test_incomplete_direct_split_is_not_collapsed(tmp_path):
     assert {Path(row.path) for row in rows} == {first, third}
 
 
-@pytest.mark.parametrize(
-    "names",
-    [
-        (
-            "alpha-00001-of-00002-final-Q4_K_M.gguf",
-            "alpha-00002-of-00002-final-Q4_K_M.gguf",
-        ),
-        ("model-Q4_K_M-01-of-02.gguf", "model-Q4_K_M-02-of-02.gguf"),
-    ],
-)
-def test_noncanonical_split_like_names_stay_separate(tmp_path, names):
+def test_two_digit_split_like_names_stay_separate(tmp_path):
     root = tmp_path / "root"
     holder = root / "holder"
+    names = ("model-Q4_K_M-01-of-02.gguf", "model-Q4_K_M-02-of-02.gguf")
     expected = {_write_gguf(holder / name) for name in names}
 
     rows = _custom_rows(root)

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from hub.utils import gguf
+
+
+def test_checkpoint_family_matches_quantized_and_split_variants():
+    assert gguf.gguf_checkpoint_family("model-a-Q4_K_M.gguf") == "model-a"
+    assert gguf.gguf_checkpoint_family("model-a-Q8_0.gguf") == "model-a"
+    assert gguf.gguf_checkpoint_family("model-Q4_K_M-00001-of-00002.gguf") == "model"
+    assert gguf.gguf_checkpoint_family("model-Q4_K_M-00002-of-00002.gguf") == "model"
+
+
+def test_checkpoint_family_keeps_distinct_models_separate():
+    assert gguf.gguf_checkpoint_family("model-a-Q4_K_M.gguf") == "model-a"
+    assert gguf.gguf_checkpoint_family("model-b-Q4_K_M.gguf") == "model-b"
+    assert gguf.gguf_checkpoint_family("alpha.gguf") == "alpha"
+    assert gguf.gguf_checkpoint_family("beta.gguf") == "beta"
+
+
+def test_checkpoint_family_normalizes_quant_directories_and_windows_separators():
+    assert gguf.gguf_checkpoint_family("Q4_K_M/model.gguf") == "model"
+    assert gguf.gguf_checkpoint_family(r"Q8_0\model.gguf") == "model"
+    assert gguf.gguf_checkpoint_family("Q4_K_M.gguf") is None

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -4,6 +4,7 @@
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -198,6 +199,19 @@ def test_loose_symlink_into_grouped_model_does_not_add_a_row(tmp_path):
     assert [Path(row.path) for row in rows] == [model]
 
 
+def test_renamed_loose_symlink_into_grouped_model_does_not_add_a_row(tmp_path):
+    grouped_root = tmp_path / "grouped-root"
+    model = grouped_root / "model"
+    target = _write_gguf(model / "model-Q4_K_M.gguf")
+    loose_root = tmp_path / "loose-root"
+    loose_root.mkdir()
+    _symlink_file(loose_root / "latest.gguf", target)
+
+    rows = _custom_rows(grouped_root, loose_root)
+
+    assert [Path(row.path) for row in rows] == [model]
+
+
 def test_symlinked_and_real_parent_roots_dedupe_group_rows(tmp_path):
     real_root = tmp_path / "real"
     real_model = real_root / "model"
@@ -296,13 +310,17 @@ def test_incomplete_direct_split_is_not_collapsed(tmp_path):
 @pytest.mark.parametrize(
     "names",
     [
-        ("model-00001-of-00002-old.gguf", "model-00002-of-00002-old.gguf"),
-        ("model-001-of-002.gguf", "model-002-of-002.gguf"),
+        (
+            "alpha-00001-of-00002-final-Q4_K_M.gguf",
+            "alpha-00002-of-00002-final-Q4_K_M.gguf",
+        ),
+        ("model-Q4_K_M-001-of-002.gguf", "model-Q4_K_M-002-of-002.gguf"),
     ],
 )
 def test_noncanonical_split_like_names_stay_separate(tmp_path, names):
-    root = tmp_path / "direct-model-root"
-    expected = {_write_gguf(root / name) for name in names}
+    root = tmp_path / "root"
+    holder = root / "holder"
+    expected = {_write_gguf(holder / name) for name in names}
 
     rows = _custom_rows(root)
 
@@ -339,6 +357,132 @@ def test_nested_quant_directory_stays_in_the_parent_group(tmp_path):
     assert {variant.quant for variant in variants} == {"Q4_K_M", "Q8_0"}
 
 
+def test_overlapping_nested_quant_root_keeps_the_parent_group(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "model-a-Q4_K_M.gguf")
+    quant_dir = model / "Q8_0"
+    _write_gguf(quant_dir / "model-a-Q8_0.gguf")
+    (quant_dir / "config.json").write_text("{}", encoding = "utf-8")
+
+    rows = _custom_rows(root, quant_dir)
+
+    assert [Path(row.path) for row in rows] == [model]
+
+
+def test_quant_named_independent_model_root_stays_selectable(tmp_path):
+    root = tmp_path / "root"
+    parent = root / "parent"
+    _write_gguf(parent / "model-a-Q4_K_M.gguf")
+    (parent / "config.json").write_text("{}", encoding = "utf-8")
+    child = parent / "Q8_0"
+    _write_gguf(child / "model-b-Q8_0.gguf")
+    (child / "config.json").write_text("{}", encoding = "utf-8")
+
+    rows = _custom_rows(root, child)
+
+    assert {Path(row.path) for row in rows} == {parent, child}
+
+
+def test_symlinked_nested_quant_root_keeps_the_real_parent_group(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "model-a-Q4_K_M.gguf")
+    quant_dir = model / "Q8_0"
+    _write_gguf(quant_dir / "model-a-Q8_0.gguf")
+    (quant_dir / "config.json").write_text("{}", encoding = "utf-8")
+    alias_model = tmp_path / "alias-model"
+    _symlink_dir(alias_model, model)
+
+    rows = _custom_rows(root, alias_model / "Q8_0")
+
+    assert [Path(row.path) for row in rows] == [model]
+
+
+def test_overlapping_nested_independent_model_root_stays_selectable(tmp_path):
+    root = tmp_path / "root"
+    parent = root / "parent"
+    _write_gguf(parent / "parent-Q4_K_M.gguf")
+    (parent / "config.json").write_text("{}", encoding = "utf-8")
+    child = parent / "child"
+    _write_gguf(child / "child-Q8_0.gguf")
+    (child / "config.json").write_text("{}", encoding = "utf-8")
+
+    rows = _custom_rows(root, child)
+
+    assert {Path(row.path) for row in rows} == {parent, child}
+
+
+def test_overlapping_nested_independent_loose_root_stays_selectable(tmp_path):
+    root = tmp_path / "root"
+    parent = root / "parent"
+    _write_gguf(parent / "parent-Q4_K_M.gguf")
+    (parent / "config.json").write_text("{}", encoding = "utf-8")
+    child = parent / "child"
+    loose = _write_gguf(child / "child-Q8_0.gguf")
+
+    rows = _custom_rows(root, child)
+
+    assert {Path(row.path) for row in rows} == {parent, loose}
+
+
+def test_aliased_nested_independent_loose_root_stays_selectable(tmp_path):
+    root = tmp_path / "root"
+    parent = root / "parent"
+    _write_gguf(parent / "parent-Q4_K_M.gguf")
+    (parent / "config.json").write_text("{}", encoding = "utf-8")
+    child = parent / "child"
+    loose = _write_gguf(child / "child-Q8_0.gguf")
+    alias_child = tmp_path / "alias-child"
+    _symlink_dir(alias_child, child)
+
+    rows = _custom_rows(root, alias_child)
+
+    assert {Path(row.path).resolve() for row in rows} == {
+        parent.resolve(),
+        loose.resolve(),
+    }
+
+
+def test_mixed_nested_roots_dedupe_only_the_matching_quant_group(tmp_path):
+    root = tmp_path / "root"
+    parent = root / "parent"
+    _write_gguf(parent / "model-a-Q4_K_M.gguf")
+    (parent / "config.json").write_text("{}", encoding = "utf-8")
+    quant_dir = parent / "Q8_0"
+    _write_gguf(quant_dir / "model-a-Q8_0.gguf")
+    (quant_dir / "config.json").write_text("{}", encoding = "utf-8")
+    child = parent / "child"
+    _write_gguf(child / "child-Q4_K_M.gguf")
+    (child / "config.json").write_text("{}", encoding = "utf-8")
+
+    rows = _custom_rows(root, quant_dir, child)
+
+    assert {Path(row.path) for row in rows} == {parent, child}
+
+
+def test_big_endian_companion_does_not_leave_a_duplicate_loose_row(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "model-Q4_K_M.gguf")
+    _write_gguf(model / "model-Q4_K_M-be.gguf")
+
+    rows = _custom_rows(root, model)
+
+    assert [Path(row.path) for row in rows] == [model]
+
+
+def test_mtp_companion_does_not_leave_a_duplicate_loose_row(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "model-Q4_K_M.gguf")
+    _write_gguf(model / "MTP" / "model-Q8_0.gguf")
+
+    rows = _custom_rows(root, model)
+
+    assert [Path(row.path) for row in rows] == [model]
+
+
 def test_nested_symlinked_variant_directory_stays_selectable(tmp_path):
     root = tmp_path / "root"
     model = root / "model"
@@ -356,6 +500,55 @@ def test_nested_symlinked_variant_directory_stays_selectable(tmp_path):
     assert Path(
         _find_local_gguf_by_variant(str(alias), "Q8_0", model_root = str(root))
     ).samefile(q8)
+
+
+def test_windows_junction_child_is_suppressed_when_parent_walk_sees_it(
+    tmp_path, monkeypatch
+):
+    model = tmp_path / "root" / "model"
+    q4 = _write_gguf(model / "model-a-Q4_K_M.gguf")
+    outside = tmp_path / "outside" / "Q8_0"
+    q8 = _write_gguf(outside / "model-a-Q8_0.gguf")
+    child = model / "Q8_0"
+    _symlink_dir(child, outside)
+    linked_q8 = child / q8.name
+    parent_row = SimpleNamespace(model_format = "gguf", partial = False, path = str(model))
+    child_row = SimpleNamespace(model_format = "gguf", partial = False, path = str(child))
+
+    monkeypatch.setattr(
+        gguf,
+        "iter_gguf_files",
+        lambda directory, recursive = False: iter(
+            [q4, linked_q8] if directory == model else [linked_q8]
+        ),
+    )
+
+    assert gguf.suppress_grouped_gguf_file_rows([parent_row, child_row]) == [parent_row]
+
+
+def test_windows_junction_independent_child_stays_selectable(tmp_path, monkeypatch):
+    model = tmp_path / "root" / "model"
+    q4 = _write_gguf(model / "model-a-Q4_K_M.gguf")
+    outside = tmp_path / "outside" / "child"
+    q8 = _write_gguf(outside / "child-Q8_0.gguf")
+    child = model / "child"
+    _symlink_dir(child, outside)
+    linked_q8 = child / q8.name
+    parent_row = SimpleNamespace(model_format = "gguf", partial = False, path = str(model))
+    child_row = SimpleNamespace(model_format = "gguf", partial = False, path = str(child))
+
+    monkeypatch.setattr(
+        gguf,
+        "iter_gguf_files",
+        lambda directory, recursive = False: iter(
+            [q4, linked_q8] if directory == model else [linked_q8]
+        ),
+    )
+
+    assert gguf.suppress_grouped_gguf_file_rows([parent_row, child_row]) == [
+        parent_row,
+        child_row,
+    ]
 
 
 def test_lmstudio_publisher_model_layout_keeps_its_model_id(tmp_path):

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -64,6 +64,7 @@ def test_checkpoint_family_keeps_distinct_models_separate():
 def test_checkpoint_family_normalizes_quant_directories_and_windows_separators():
     assert gguf.gguf_checkpoint_family("Q4_K_M/model.gguf") == "model"
     assert gguf.gguf_checkpoint_family(r"Q8_0\model.gguf") == "model"
+    assert gguf.gguf_checkpoint_family("Q8_0/model-a-Q8_0.gguf") == "model-a"
     assert gguf.gguf_checkpoint_family("Q4_K_M.gguf") is None
 
 
@@ -261,13 +262,71 @@ def test_direct_custom_model_root_keeps_loose_variants(tmp_path):
 
 def test_direct_custom_model_root_dedupes_split_shards(tmp_path):
     root = tmp_path / "direct-model-root"
-    _write_gguf(root / "Q4_K_M-00001-of-00002.gguf")
-    _write_gguf(root / "Q4_K_M-00002-of-00002.gguf")
+    first = _write_gguf(root / "Q4_K_M-00001-of-00002.gguf", 11)
+    _write_gguf(root / "Q4_K_M-00002-of-00002.gguf", 7)
 
     rows = _custom_rows(root)
 
     assert len(rows) == 1
-    assert gguf.gguf_variant_family(Path(rows[0].path).name) == "Q4_K_M"
+    assert Path(rows[0].path) == first
+    assert rows[0].size_bytes == 18
+    assert Path(detect_gguf_model(rows[0].path, model_root = str(root))) == first
+
+
+def test_direct_split_prefix_matching_follows_the_loader(tmp_path):
+    root = tmp_path / "direct-model-root"
+    first = _write_gguf(root / "Model-Q4_K_M-00001-of-00002.gguf", 11)
+    _write_gguf(root / "model-Q4_K_M-00002-of-00002.gguf", 7)
+
+    rows = _custom_rows(root)
+
+    assert [(Path(row.path), row.size_bytes) for row in rows] == [(first, 18)]
+
+
+@pytest.mark.parametrize(
+    "names",
+    [
+        ("model-00001-of-00002-old.gguf", "model-00002-of-00002-old.gguf"),
+        ("model-001-of-002.gguf", "model-002-of-002.gguf"),
+    ],
+)
+def test_noncanonical_split_like_names_stay_separate(tmp_path, names):
+    root = tmp_path / "direct-model-root"
+    expected = {_write_gguf(root / name) for name in names}
+
+    rows = _custom_rows(root)
+
+    assert {Path(row.path) for row in rows} == expected
+
+
+def test_nested_independent_gguf_models_do_not_share_a_parent_group(tmp_path):
+    root = tmp_path / "root"
+    publisher = root / "publisher"
+    loose = _write_gguf(publisher / "model-a-Q4_K_M.gguf")
+    nested = publisher / "model-b"
+    _write_gguf(nested / "model-b-Q8_0.gguf")
+
+    rows = _custom_rows(root)
+
+    assert {Path(row.path) for row in rows} == {loose, nested}
+    variants, _ = gguf.list_local_gguf_variants(str(nested), model_root = str(root))
+    assert [variant.quant for variant in variants] == ["Q8_0"]
+    assert _find_local_gguf_by_variant(
+        str(nested), "Q4_K_M", model_root = str(root)
+    ) is None
+
+
+def test_nested_quant_directory_stays_in_the_parent_group(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "model-a-Q4_K_M.gguf")
+    _write_gguf(model / "Q8_0" / "model-a-Q8_0.gguf")
+
+    rows = _custom_rows(root)
+
+    assert [Path(row.path) for row in rows] == [model]
+    variants, _ = gguf.list_local_gguf_variants(str(model), model_root = str(root))
+    assert {variant.quant for variant in variants} == {"Q4_K_M", "Q8_0"}
 
 
 def test_lmstudio_publisher_model_layout_keeps_its_model_id(tmp_path):

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -1,7 +1,24 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+from pathlib import Path
+
+from hub.services.models import local_inventory
 from hub.utils import gguf
+
+
+def _write_gguf(path: Path, size: int = 4) -> Path:
+    path.parent.mkdir(parents = True, exist_ok = True)
+    path.write_bytes(b"G" * size)
+    return path
+
+
+def _custom_rows(root: Path):
+    rows = [
+        local_inventory._promote_to_custom_source(row)
+        for row in local_inventory._scan_custom_folder(root)
+    ]
+    return local_inventory._dedupe_local_models(rows)
 
 
 def test_checkpoint_family_matches_quantized_and_split_variants():
@@ -22,3 +39,33 @@ def test_checkpoint_family_normalizes_quant_directories_and_windows_separators()
     assert gguf.gguf_checkpoint_family("Q4_K_M/model.gguf") == "model"
     assert gguf.gguf_checkpoint_family(r"Q8_0\model.gguf") == "model"
     assert gguf.gguf_checkpoint_family("Q4_K_M.gguf") is None
+
+
+def test_same_checkpoint_quantizations_use_one_grouped_row(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model-a"
+    _write_gguf(model / "model-a-Q4_K_M.gguf")
+    _write_gguf(model / "model-a-Q8_0.gguf")
+
+    assert [Path(row.path) for row in _custom_rows(root)] == [model]
+
+
+def test_distinct_checkpoints_sharing_a_quant_use_file_rows(tmp_path):
+    root = tmp_path / "root"
+    holder = root / "publisher"
+    model_a = _write_gguf(holder / "model-a-Q4_K_M.gguf")
+    model_b = _write_gguf(holder / "model-b-Q4_K_M.gguf")
+
+    rows = _custom_rows(root)
+
+    assert {Path(row.path) for row in rows} == {model_a, model_b}
+    assert all(not row.capabilities.requires_variant for row in rows)
+
+
+def test_unqualified_distinct_checkpoints_use_file_rows(tmp_path):
+    root = tmp_path / "root"
+    holder = root / "holder"
+    alpha = _write_gguf(holder / "alpha.gguf")
+    beta = _write_gguf(holder / "beta.gguf")
+
+    assert {Path(row.path) for row in _custom_rows(root)} == {alpha, beta}

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -8,6 +8,7 @@ import pytest
 
 from hub.services.models import local_inventory
 from hub.utils import gguf
+from utils.models.model_config import detect_gguf_model, _find_local_gguf_by_variant
 
 
 def _write_gguf(path: Path, size: int = 4) -> Path:
@@ -35,6 +36,15 @@ def _symlink_dir(alias: Path, target: Path) -> None:
         pytest.skip(f"symlink creation unavailable: {error}")
 
 
+def _symlink_file(alias: Path, target: Path) -> None:
+    if not hasattr(os, "symlink"):
+        pytest.skip("symlinks unavailable")
+    try:
+        alias.symlink_to(target)
+    except OSError as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
+
+
 def test_checkpoint_family_matches_quantized_and_split_variants():
     assert gguf.gguf_checkpoint_family("model-a-Q4_K_M.gguf") == "model-a"
     assert gguf.gguf_checkpoint_family("model-a-Q8_0.gguf") == "model-a"
@@ -58,10 +68,16 @@ def test_checkpoint_family_normalizes_quant_directories_and_windows_separators()
 def test_same_checkpoint_quantizations_use_one_grouped_row(tmp_path):
     root = tmp_path / "root"
     model = root / "model-a"
-    _write_gguf(model / "model-a-Q4_K_M.gguf")
-    _write_gguf(model / "model-a-Q8_0.gguf")
+    q4 = _write_gguf(model / "model-a-Q4_K_M.gguf", 8)
+    q8 = _write_gguf(model / "model-a-Q8_0.gguf", 16)
 
     assert [Path(row.path) for row in _custom_rows(root)] == [model]
+    variants, _ = gguf.list_local_gguf_variants(str(model), model_root = str(root))
+    assert {variant.quant for variant in variants} == {"Q4_K_M", "Q8_0"}
+    assert Path(detect_gguf_model(str(model), model_root = str(root))) == q8
+    assert Path(
+        _find_local_gguf_by_variant(str(model), "Q4_K_M", model_root = str(root))
+    ) == q4
 
 
 def test_distinct_checkpoints_sharing_a_quant_use_file_rows(tmp_path):
@@ -121,3 +137,34 @@ def test_symlinked_and_real_parent_roots_dedupe_group_rows(tmp_path):
 
     assert len(rows) == 1
     assert Path(rows[0].path).resolve() == real_model.resolve()
+
+
+def test_split_gguf_shards_stay_grouped(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "model-Q4_K_M-00001-of-00002.gguf")
+    _write_gguf(model / "model-Q4_K_M-00002-of-00002.gguf")
+
+    assert [Path(row.path) for row in _custom_rows(root)] == [model]
+
+
+def test_minimax_h3_partitions_stay_grouped(tmp_path):
+    root = tmp_path / "root"
+    model = root / "minimax-h3"
+    _write_gguf(model / "minimax_h3_fl2va-Q4_K_M.gguf")
+    _write_gguf(model / "minimax_h3_ref2va-Q4_K_M.gguf")
+
+    assert [Path(row.path) for row in _custom_rows(root)] == [model]
+
+
+def test_symlinked_variant_stays_grouped_and_loadable(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    target = _write_gguf(tmp_path / "outside" / "model-Q4_K_M.gguf")
+    model.mkdir(parents = True)
+    _symlink_file(model / target.name, target)
+
+    rows = _custom_rows(root)
+
+    assert [Path(row.path) for row in rows] == [model]
+    assert Path(detect_gguf_model(str(model), model_root = str(root))).samefile(target)

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -283,6 +283,16 @@ def test_direct_split_prefix_matching_follows_the_loader(tmp_path):
     assert [(Path(row.path), row.size_bytes) for row in rows] == [(first, 18)]
 
 
+def test_incomplete_direct_split_is_not_collapsed(tmp_path):
+    root = tmp_path / "direct-model-root"
+    first = _write_gguf(root / "model-Q4_K_M-00001-of-00003.gguf")
+    third = _write_gguf(root / "model-Q4_K_M-00003-of-00003.gguf")
+
+    rows = _custom_rows(root)
+
+    assert {Path(row.path) for row in rows} == {first, third}
+
+
 @pytest.mark.parametrize(
     "names",
     [

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -231,6 +231,17 @@ def test_direct_custom_model_root_keeps_loose_variants(tmp_path):
     assert {Path(row.path) for row in _custom_rows(root)} == {q4, q8}
 
 
+def test_direct_custom_model_root_dedupes_split_shards(tmp_path):
+    root = tmp_path / "direct-model-root"
+    _write_gguf(root / "Q4_K_M-00001-of-00002.gguf")
+    _write_gguf(root / "Q4_K_M-00002-of-00002.gguf")
+
+    rows = _custom_rows(root)
+
+    assert len(rows) == 1
+    assert gguf.gguf_variant_family(Path(rows[0].path).name) == "Q4_K_M"
+
+
 def test_lmstudio_publisher_model_layout_keeps_its_model_id(tmp_path):
     root = tmp_path / "lmstudio"
     model = root / "publisher" / "model"

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -339,6 +339,25 @@ def test_nested_quant_directory_stays_in_the_parent_group(tmp_path):
     assert {variant.quant for variant in variants} == {"Q4_K_M", "Q8_0"}
 
 
+def test_nested_symlinked_variant_directory_stays_selectable(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    q4 = _write_gguf(model / "model-a-Q4_K_M.gguf")
+    q8_dir = tmp_path / "outside" / "Q8_0"
+    q8 = _write_gguf(q8_dir / "model-a-Q8_0.gguf")
+    alias = model / "Q8_0"
+    _symlink_dir(alias, q8_dir)
+
+    rows = _custom_rows(root)
+
+    assert {Path(row.path) for row in rows} == {q4, alias}
+    variants, _ = gguf.list_local_gguf_variants(str(alias), model_root = str(root))
+    assert [variant.quant for variant in variants] == ["Q8_0"]
+    assert Path(
+        _find_local_gguf_by_variant(str(alias), "Q8_0", model_root = str(root))
+    ).samefile(q8)
+
+
 def test_lmstudio_publisher_model_layout_keeps_its_model_id(tmp_path):
     root = tmp_path / "lmstudio"
     model = root / "publisher" / "model"

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import json
 import os
 from pathlib import Path
 
@@ -168,3 +169,77 @@ def test_symlinked_variant_stays_grouped_and_loadable(tmp_path):
 
     assert [Path(row.path) for row in rows] == [model]
     assert Path(detect_gguf_model(str(model), model_root = str(root))).samefile(target)
+
+
+def test_loose_gguf_models_stay_separate(tmp_path):
+    root = tmp_path / "root"
+    alpha = _write_gguf(root / "alpha-Q4_K_M.gguf")
+    beta = _write_gguf(root / "beta-Q8_0.gguf")
+
+    assert {Path(row.path) for row in _custom_rows(root)} == {alpha, beta}
+
+
+def test_direct_custom_model_root_keeps_loose_variants(tmp_path):
+    root = tmp_path / "direct-model-root"
+    q4 = _write_gguf(root / "model-Q4_K_M.gguf")
+    q8 = _write_gguf(root / "model-Q8_0.gguf")
+
+    assert {Path(row.path) for row in _custom_rows(root)} == {q4, q8}
+
+
+def test_lmstudio_publisher_model_layout_keeps_its_model_id(tmp_path):
+    root = tmp_path / "lmstudio"
+    model = root / "publisher" / "model"
+    _write_gguf(model / "model-Q4_K_M.gguf")
+    _write_gguf(model / "model-Q8_0.gguf")
+
+    rows = local_inventory._scan_custom_folder(root)
+
+    assert [(Path(row.path), row.model_id) for row in rows] == [(model, "publisher/model")]
+
+
+def test_mixed_gguf_and_safetensors_keep_one_row_per_format(tmp_path):
+    root = tmp_path / "root"
+    model = root / "hybrid"
+    _write_gguf(model / "hybrid-Q4_K_M.gguf")
+    _write_gguf(model / "model.safetensors")
+    (model / "config.json").write_text(json.dumps({"model_type": "llama"}))
+
+    rows = _custom_rows(root)
+
+    assert {(Path(row.path), row.model_format) for row in rows} == {
+        (model, "gguf"),
+        (model, "safetensors"),
+    }
+
+
+def test_incomplete_custom_models_stay_hidden(tmp_path):
+    root = tmp_path / "root"
+    partial = root / "partial"
+    partial.mkdir(parents = True)
+    (partial / "config.json").write_text("{}")
+    _write_gguf(partial / "model.gguf.incomplete")
+    complete = _write_gguf(root / "complete.gguf")
+
+    assert [Path(row.path) for row in _custom_rows(root)] == [complete]
+
+
+def test_mixed_case_gguf_suffixes_stay_grouped(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "model-Q4_K_M.GGUF")
+    _write_gguf(model / "model-Q8_0.GguF")
+
+    assert [Path(row.path) for row in _custom_rows(root)] == [model]
+
+
+def test_symlinked_model_directory_stays_grouped(tmp_path):
+    real_model = tmp_path / "outside" / "model"
+    _write_gguf(real_model / "model-Q4_K_M.gguf")
+    _write_gguf(real_model / "model-Q8_0.gguf")
+    root = tmp_path / "root"
+    root.mkdir()
+    alias = root / "model-alias"
+    _symlink_dir(alias, real_model)
+
+    assert [Path(row.path) for row in _custom_rows(root)] == [alias]

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -124,6 +124,28 @@ def test_unqualified_distinct_checkpoints_use_file_rows(tmp_path):
     assert {Path(row.path) for row in _custom_rows(root)} == {alpha, beta}
 
 
+def test_bare_quant_filenames_use_the_parent_model_group(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    q4 = _write_gguf(model / "Q4_K_M.gguf")
+    q8 = _write_gguf(model / "Q8_0.gguf")
+
+    assert [Path(row.path) for row in _custom_rows(root)] == [model]
+    variants, _ = gguf.list_local_gguf_variants(str(model), model_root = str(root))
+    assert {Path(variant.filename).name for variant in variants} == {q4.name, q8.name}
+
+
+def test_bare_quant_shards_use_the_parent_model_group(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "Q4_K_M-00001-of-00002.gguf")
+    _write_gguf(model / "Q4_K_M-00002-of-00002.gguf")
+
+    rows = _custom_rows(root)
+
+    assert [Path(row.path) for row in rows] == [model]
+
+
 def test_overlapping_parent_and_model_roots_keep_the_grouped_row(tmp_path):
     root = tmp_path / "root"
     model = root / "model"

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -93,6 +93,28 @@ def test_distinct_checkpoints_sharing_a_quant_use_file_rows(tmp_path):
     assert all(not row.capabilities.requires_variant for row in rows)
 
 
+@pytest.mark.parametrize(
+    ("first_name", "second_name"),
+    [
+        ("model-a-Q4_K_M.gguf", "model.a-Q4_K_M.gguf"),
+        ("Model-A-Q4_K_M.gguf", "model-a-Q4_K_M.gguf"),
+    ],
+)
+def test_same_quant_checkpoint_names_preserve_exact_identity(
+    tmp_path, first_name, second_name
+):
+    root = tmp_path / "root"
+    holder = root / "holder"
+    first = _write_gguf(holder / first_name)
+    second = _write_gguf(holder / second_name)
+    if first.samefile(second):
+        pytest.skip("filesystem does not preserve the distinct names")
+
+    rows = _custom_rows(root)
+
+    assert {Path(row.path) for row in rows} == {first, second}
+
+
 def test_unqualified_distinct_checkpoints_use_file_rows(tmp_path):
     root = tmp_path / "root"
     holder = root / "holder"

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -169,6 +169,31 @@ def test_symlinked_parent_and_real_model_roots_keep_one_row(tmp_path):
     assert Path(rows[0].path).resolve() == real_model.resolve()
 
 
+def test_loose_file_symlink_dedupes_by_physical_identity(tmp_path):
+    root = tmp_path / "root"
+    target = _write_gguf(root / "model-Q4_K_M.gguf")
+    alias = root / "latest.gguf"
+    _symlink_file(alias, target)
+
+    rows = _custom_rows(root)
+
+    assert len(rows) == 1
+    assert Path(rows[0].path).samefile(target)
+
+
+def test_loose_symlink_into_grouped_model_does_not_add_a_row(tmp_path):
+    grouped_root = tmp_path / "grouped-root"
+    model = grouped_root / "model"
+    target = _write_gguf(model / "model-Q4_K_M.gguf")
+    loose_root = tmp_path / "loose-root"
+    loose_root.mkdir()
+    _symlink_file(loose_root / "model-Q4_K_M.gguf", target)
+
+    rows = _custom_rows(grouped_root, loose_root)
+
+    assert [Path(row.path) for row in rows] == [model]
+
+
 def test_symlinked_and_real_parent_roots_dedupe_group_rows(tmp_path):
     real_root = tmp_path / "real"
     real_model = real_root / "model"
@@ -298,3 +323,33 @@ def test_symlinked_model_directory_stays_grouped(tmp_path):
     _symlink_dir(alias, real_model)
 
     assert [Path(row.path) for row in _custom_rows(root)] == [alias]
+
+
+def test_physical_identity_preserves_native_posix_names(tmp_path):
+    if os.sep == "\\":
+        pytest.skip("names are not distinct on Windows")
+    backslash_root = tmp_path / "model\\one"
+    nested_root = tmp_path / "model" / "one"
+    trailing_root = tmp_path / "model "
+    plain_root = tmp_path / "model"
+    paths = {
+        _write_gguf(backslash_root / "model-Q4_K_M.gguf"),
+        _write_gguf(nested_root / "model-Q4_K_M.gguf"),
+        _write_gguf(trailing_root / "model-Q4_K_M.gguf"),
+        _write_gguf(plain_root / "model-Q4_K_M.gguf"),
+    }
+
+    discovered = [
+        local_inventory._promote_to_custom_source(
+            local_inventory._local_model_info(
+                scan_path = path,
+                load_path = path,
+                source = "lmstudio",
+                model_format = "gguf",
+            )
+        )
+        for path in paths
+    ]
+    rows = local_inventory._dedupe_local_models(discovered)
+
+    assert {Path(row.path) for row in rows} == paths

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -58,6 +58,7 @@ def test_checkpoint_family_keeps_distinct_models_separate():
     assert gguf.gguf_checkpoint_family("model-b-Q4_K_M.gguf") == "model-b"
     assert gguf.gguf_checkpoint_family("alpha.gguf") == "alpha"
     assert gguf.gguf_checkpoint_family("beta.gguf") == "beta"
+    assert gguf.gguf_checkpoint_family("Model-A-Q4_K_M.gguf") == "Model-A"
 
 
 def test_checkpoint_family_normalizes_quant_directories_and_windows_separators():
@@ -98,9 +99,11 @@ def test_distinct_checkpoints_sharing_a_quant_use_file_rows(tmp_path):
     [
         ("model-a-Q4_K_M.gguf", "model.a-Q4_K_M.gguf"),
         ("Model-A-Q4_K_M.gguf", "model-a-Q4_K_M.gguf"),
+        ("model-a-Q4_K_M.gguf", "model.a-Q8_0.gguf"),
+        ("Model-A-Q4_K_M.gguf", "model-a-Q8_0.gguf"),
     ],
 )
-def test_same_quant_checkpoint_names_preserve_exact_identity(
+def test_checkpoint_names_preserve_exact_identity(
     tmp_path, first_name, second_name
 ):
     root = tmp_path / "root"

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -310,7 +310,7 @@ def test_incomplete_direct_split_is_not_collapsed(tmp_path):
             "alpha-00001-of-00002-final-Q4_K_M.gguf",
             "alpha-00002-of-00002-final-Q4_K_M.gguf",
         ),
-        ("model-Q4_K_M-001-of-002.gguf", "model-Q4_K_M-002-of-002.gguf"),
+        ("model-Q4_K_M-01-of-02.gguf", "model-Q4_K_M-02-of-02.gguf"),
     ],
 )
 def test_noncanonical_split_like_names_stay_separate(tmp_path, names):

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -79,9 +79,7 @@ def test_same_checkpoint_quantizations_use_one_grouped_row(tmp_path):
     variants, _ = gguf.list_local_gguf_variants(str(model), model_root = str(root))
     assert {variant.quant for variant in variants} == {"Q4_K_M", "Q8_0"}
     assert Path(detect_gguf_model(str(model), model_root = str(root))) == q8
-    assert Path(
-        _find_local_gguf_by_variant(str(model), "Q4_K_M", model_root = str(root))
-    ) == q4
+    assert Path(_find_local_gguf_by_variant(str(model), "Q4_K_M", model_root = str(root))) == q4
 
 
 def test_distinct_checkpoints_sharing_a_quant_use_file_rows(tmp_path):
@@ -105,9 +103,7 @@ def test_distinct_checkpoints_sharing_a_quant_use_file_rows(tmp_path):
         ("Model-A-Q4_K_M.gguf", "model-a-Q8_0.gguf"),
     ],
 )
-def test_checkpoint_names_preserve_exact_identity(
-    tmp_path, first_name, second_name
-):
+def test_checkpoint_names_preserve_exact_identity(tmp_path, first_name, second_name):
     root = tmp_path / "root"
     holder = root / "holder"
     first = _write_gguf(holder / first_name)
@@ -339,9 +335,7 @@ def test_nested_independent_gguf_models_do_not_share_a_parent_group(tmp_path):
     assert {Path(row.path) for row in rows} == {loose, nested}
     variants, _ = gguf.list_local_gguf_variants(str(nested), model_root = str(root))
     assert [variant.quant for variant in variants] == ["Q8_0"]
-    assert _find_local_gguf_by_variant(
-        str(nested), "Q4_K_M", model_root = str(root)
-    ) is None
+    assert _find_local_gguf_by_variant(str(nested), "Q4_K_M", model_root = str(root)) is None
 
 
 def test_nested_quant_directory_stays_in_the_parent_group(tmp_path):
@@ -438,10 +432,7 @@ def test_aliased_nested_independent_loose_root_stays_selectable(tmp_path):
 
     rows = _custom_rows(root, alias_child)
 
-    assert {Path(row.path).resolve() for row in rows} == {
-        parent.resolve(),
-        loose.resolve(),
-    }
+    assert {Path(row.path).resolve() for row in rows} == {parent.resolve(), loose.resolve()}
 
 
 def test_mixed_nested_roots_dedupe_only_the_matching_quant_group(tmp_path):
@@ -497,14 +488,10 @@ def test_nested_symlinked_variant_directory_stays_selectable(tmp_path):
     assert {Path(row.path) for row in rows} == {q4, alias}
     variants, _ = gguf.list_local_gguf_variants(str(alias), model_root = str(root))
     assert [variant.quant for variant in variants] == ["Q8_0"]
-    assert Path(
-        _find_local_gguf_by_variant(str(alias), "Q8_0", model_root = str(root))
-    ).samefile(q8)
+    assert Path(_find_local_gguf_by_variant(str(alias), "Q8_0", model_root = str(root))).samefile(q8)
 
 
-def test_windows_junction_child_is_suppressed_when_parent_walk_sees_it(
-    tmp_path, monkeypatch
-):
+def test_windows_junction_child_is_suppressed_when_parent_walk_sees_it(tmp_path, monkeypatch):
     model = tmp_path / "root" / "model"
     q4 = _write_gguf(model / "model-a-Q4_K_M.gguf")
     outside = tmp_path / "outside" / "Q8_0"

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import os
 from pathlib import Path
+
+import pytest
 
 from hub.services.models import local_inventory
 from hub.utils import gguf
@@ -21,6 +24,15 @@ def _custom_rows(*roots: Path):
             for row in local_inventory._scan_custom_folder(root)
         )
     return local_inventory._dedupe_local_models(rows)
+
+
+def _symlink_dir(alias: Path, target: Path) -> None:
+    if not hasattr(os, "symlink"):
+        pytest.skip("symlinks unavailable")
+    try:
+        alias.symlink_to(target, target_is_directory = True)
+    except OSError as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
 
 
 def test_checkpoint_family_matches_quantized_and_split_variants():
@@ -79,3 +91,33 @@ def test_overlapping_parent_and_model_roots_keep_the_grouped_row(tmp_path):
     _write_gguf(model / "model-Q4_K_M.gguf")
 
     assert [Path(row.path) for row in _custom_rows(root, model)] == [model]
+
+
+def test_symlinked_parent_and_real_model_roots_keep_one_row(tmp_path):
+    real_model = tmp_path / "outside" / "model"
+    _write_gguf(real_model / "model-Q4_K_M.gguf")
+    _write_gguf(real_model / "model-Q8_0.gguf")
+    alias_root = tmp_path / "aliases"
+    alias_root.mkdir()
+    alias_model = alias_root / "model"
+    _symlink_dir(alias_model, real_model)
+
+    rows = _custom_rows(alias_root, real_model)
+
+    assert len(rows) == 1
+    assert Path(rows[0].path).resolve() == real_model.resolve()
+
+
+def test_symlinked_and_real_parent_roots_dedupe_group_rows(tmp_path):
+    real_root = tmp_path / "real"
+    real_model = real_root / "model"
+    _write_gguf(real_model / "model-Q4_K_M.gguf")
+    _write_gguf(real_model / "model-Q8_0.gguf")
+    alias_root = tmp_path / "aliases"
+    alias_root.mkdir()
+    _symlink_dir(alias_root / "model", real_model)
+
+    rows = _custom_rows(real_root, alias_root)
+
+    assert len(rows) == 1
+    assert Path(rows[0].path).resolve() == real_model.resolve()

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -13,11 +13,13 @@ def _write_gguf(path: Path, size: int = 4) -> Path:
     return path
 
 
-def _custom_rows(root: Path):
-    rows = [
-        local_inventory._promote_to_custom_source(row)
-        for row in local_inventory._scan_custom_folder(root)
-    ]
+def _custom_rows(*roots: Path):
+    rows = []
+    for root in roots:
+        rows.extend(
+            local_inventory._promote_to_custom_source(row)
+            for row in local_inventory._scan_custom_folder(root)
+        )
     return local_inventory._dedupe_local_models(rows)
 
 
@@ -69,3 +71,11 @@ def test_unqualified_distinct_checkpoints_use_file_rows(tmp_path):
     beta = _write_gguf(holder / "beta.gguf")
 
     assert {Path(row.path) for row in _custom_rows(root)} == {alpha, beta}
+
+
+def test_overlapping_parent_and_model_roots_keep_the_grouped_row(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    _write_gguf(model / "model-Q4_K_M.gguf")
+
+    assert [Path(row.path) for row in _custom_rows(root, model)] == [model]

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -244,6 +244,73 @@ def test_custom_inventory_filters_dspark_companions_at_registered_root(tmp_path)
     assert local_inventory._scan_custom_folder(root) == []
 
 
+def test_custom_inventory_groups_nested_gguf_files_once(tmp_path):
+    """A model folder is one picker row whose GGUF files are its variants.
+
+    The generic custom-folder scan already publishes that directory.  The LM
+    Studio compatibility pass must not also publish every GGUF inside it as a
+    second top-level model.
+    """
+    root = tmp_path / "hub"
+    model_dir = root / "qwen38-27b-qat"
+    model_dir.mkdir(parents = True)
+    for quant in ("q2_0", "q3_m"):
+        (model_dir / f"qwen38-27b-qat-{quant}.gguf").write_bytes(b"GGUF")
+
+    rows = local_inventory._scan_custom_folder(root)
+
+    assert [Path(row.path) for row in rows] == [model_dir]
+
+
+def test_custom_inventory_keeps_lmstudio_publisher_model_layout(tmp_path):
+    root = tmp_path / "lmstudio"
+    model_dir = root / "publisher" / "model"
+    model_dir.mkdir(parents = True)
+    (model_dir / "model-q4_k_m.gguf").write_bytes(b"GGUF")
+
+    rows = local_inventory._scan_custom_folder(root)
+
+    assert [(Path(row.path), row.model_id) for row in rows] == [
+        (model_dir, "publisher/model")
+    ]
+
+
+def test_custom_inventory_keeps_file_row_beneath_partial_group(tmp_path, monkeypatch):
+    root = tmp_path / "hub"
+    model_dir = root / "model"
+    model_dir.mkdir(parents = True)
+    model_file = model_dir / "model-q4_k_m.gguf"
+    model_file.write_bytes(b"GGUF")
+    partial_group = model_common._local_model_info(
+        scan_path = model_dir,
+        load_path = model_dir,
+        source = "hf_cache",
+        model_format = "gguf",
+        model_id = "publisher/model",
+        partial = True,
+    )
+    complete_file = model_common._local_model_info(
+        scan_path = model_file,
+        load_path = model_file,
+        source = "lmstudio",
+        model_format = "gguf",
+    )
+    monkeypatch.setattr(local_inventory, "_scan_models_dir", lambda *_a, **_kw: [])
+    monkeypatch.setattr(
+        local_inventory,
+        "_scan_hf_cache",
+        lambda *_a, **_kw: [partial_group],
+    )
+    monkeypatch.setattr(
+        local_inventory,
+        "_scan_lmstudio_dir",
+        lambda *_a, **_kw: [complete_file],
+    )
+    monkeypatch.setattr(local_inventory, "scan_ollama_dir", lambda *_a, **_kw: [])
+
+    assert local_inventory._scan_custom_folder(root) == [partial_group, complete_file]
+
+
 def test_unregistered_variant_identity_stays_scan_relative(tmp_path):
     from utils.models.model_config import list_local_gguf_variants
 

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -270,9 +270,7 @@ def test_custom_inventory_keeps_lmstudio_publisher_model_layout(tmp_path):
 
     rows = local_inventory._scan_custom_folder(root)
 
-    assert [(Path(row.path), row.model_id) for row in rows] == [
-        (model_dir, "publisher/model")
-    ]
+    assert [(Path(row.path), row.model_id) for row in rows] == [(model_dir, "publisher/model")]
 
 
 def test_custom_inventory_keeps_file_row_beneath_partial_group(tmp_path, monkeypatch):

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -254,7 +254,7 @@ def test_custom_inventory_groups_nested_gguf_files_once(tmp_path):
     root = tmp_path / "hub"
     model_dir = root / "qwen38-27b-qat"
     model_dir.mkdir(parents = True)
-    for quant in ("q2_0", "q3_m"):
+    for quant in ("q2_0", "q3_k_m"):
         (model_dir / f"qwen38-27b-qat-{quant}.gguf").write_bytes(b"GGUF")
 
     rows = local_inventory._scan_custom_folder(root)

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -984,6 +984,30 @@ def test_local_inventory_scan_stops_retrying_under_constant_invalidation(monkeyp
     assert local_inventory._local_inventory_flights == {}
 
 
+def test_local_inventory_filters_and_dedupes_off_event_loop(monkeypatch):
+    main_thread = threading.get_ident()
+    worker_threads = []
+    original_dedupe = local_inventory._dedupe_local_models
+
+    async def collect(*_args, **_kwargs):
+        return []
+
+    def record_dedupe(rows):
+        worker_threads.append(threading.get_ident())
+        return original_dedupe(rows)
+
+    monkeypatch.setattr(local_inventory, "_collect_models_from_default_sources", collect)
+    monkeypatch.setattr(local_inventory, "_dedupe_local_models", record_dedupe)
+
+    asyncio.run(
+        local_inventory._scan_local_models_response(
+            "./models", [], local_inventory._local_inventory_sources()
+        )
+    )
+
+    assert worker_threads and worker_threads[0] != main_thread
+
+
 @pytest.mark.parametrize("change_kind", ["folders", "epoch"])
 def test_local_inventory_requests_share_scan(monkeypatch, change_kind):
     # What the flight key needs from the helper is that it is total and stable on

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -456,6 +456,17 @@ def gguf_variant_family(filename: str) -> str:
     return _unknown_gguf_variant_key(filename)
 
 
+def gguf_checkpoint_family(filename: str) -> Optional[str]:
+    """the checkpoint name shared by quant variants, or ``None`` when unnamed."""
+    path = filename.replace("\\", "/")
+    family = gguf_variant_family(path)
+    quant = quant_token_with_bpw(path)
+    if quant is not None:
+        family = re.sub(re.escape(quant), "", family, count = 1, flags = re.IGNORECASE)
+    normalized = re.sub(r"[-_.\s]+", "-", family).strip("-/")
+    return normalized.casefold() or None
+
+
 def extract_quant_label(filename: str) -> str:
     return extract_quant_token(filename) or _unknown_gguf_variant_key(filename)
 

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -72,7 +72,7 @@ GGUF_QUANT_PREFERENCE = [
     "F32",
 ]
 
-_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{3,}-of-\d{3,}(?=\.gguf$|$)", re.IGNORECASE)
+_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{3,}-of-\d{3,}", re.IGNORECASE)
 _GGUF_QUANT_RE = re.compile(
     r"(UD-)?"
     r"(MXFP[0-9]+(?:_[A-Z0-9]+)*"

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -514,6 +514,36 @@ def should_group_local_gguf_files(filenames: Sequence[str]) -> bool:
     ) or all(is_h3_denoiser_variant_key(key) for key in variant_keys)
 
 
+def suppress_grouped_gguf_file_rows(rows: Sequence[object]) -> list:
+    """Drop loose rows already represented by a physical GGUF directory row."""
+
+    def row_path_is_dir(row) -> bool:
+        try:
+            return Path(getattr(row, "path", "")).is_dir()
+        except OSError:
+            return False
+
+    grouped_dirs = {
+        local_path_physical_identity(getattr(row, "path", ""))
+        for row in rows
+        if getattr(row, "model_format", None) == "gguf"
+        and not getattr(row, "partial", False)
+        and row_path_is_dir(row)
+    }
+    if not grouped_dirs:
+        return list(rows)
+    return [
+        row
+        for row in rows
+        if not (
+            getattr(row, "model_format", None) == "gguf"
+            and not row_path_is_dir(row)
+            and local_path_parent_physical_identity(getattr(row, "path", ""))
+            in grouped_dirs
+        )
+    ]
+
+
 def dedupe_custom_gguf_rows(rows: Sequence[object]) -> list:
     """Remove scanner overlap while preserving independently loadable GGUF checkpoints."""
     from utils.models.model_config import colocated_split_shards
@@ -633,12 +663,16 @@ def dedupe_custom_gguf_rows(rows: Sequence[object]) -> list:
 
         filenames = [path.name for path in files_by_parent[parent_identity]]
         nested_identities = set()
+        parent_visible_files = {
+            local_path_physical_identity(str(file))
+            for file in iter_gguf_files(parent_path, recursive = True)
+        }
         for nested_path in nested_paths:
             nested_identities.add(local_path_physical_identity(str(nested_path)))
             try:
                 relative_parent = nested_path.relative_to(parent_path)
-                filenames.extend(
-                    str(relative_parent / file.name)
+                nested_files = [
+                    file
                     for file in nested_path.iterdir()
                     if file.is_file()
                     and is_gguf_filename(file.name)
@@ -646,10 +680,17 @@ def dedupe_custom_gguf_rows(rows: Sequence[object]) -> list:
                     and not is_imatrix_filename(file.name)
                     and not is_mtp_drafter_path(file.name)
                     and not is_appledouble_metadata(file)
-                )
+                ]
             except OSError:
                 grouped_decisions[parent_identity] = False
                 break
+            if not nested_files or any(
+                local_path_physical_identity(str(file)) not in parent_visible_files
+                for file in nested_files
+            ):
+                grouped_decisions[parent_identity] = False
+                break
+            filenames.extend(str(relative_parent / file.name) for file in nested_files)
         else:
             grouped_decisions[parent_identity] = should_group_local_gguf_files(filenames)
         if grouped_decisions[parent_identity]:

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -525,8 +525,7 @@ def suppress_grouped_gguf_file_rows(rows: Sequence[object]) -> list:
         return list(rows)
 
     paths_by_group = {
-        id(row): list(iter_gguf_files(directory, recursive = True))
-        for row, directory in grouped_rows
+        id(row): list(iter_gguf_files(directory, recursive = True)) for row, directory in grouped_rows
     }
     physical_ancestors_by_group = {
         id(row): {
@@ -552,9 +551,7 @@ def suppress_grouped_gguf_file_rows(rows: Sequence[object]) -> list:
             ):
                 continue
             file_identity = local_path_physical_identity(str(file))
-            families_by_file.setdefault(file_identity, set()).add(
-                gguf_checkpoint_family(filename)
-            )
+            families_by_file.setdefault(file_identity, set()).add(gguf_checkpoint_family(filename))
         families_by_group[id(row)] = families_by_file
 
     nested_groups_to_drop = set()
@@ -609,21 +606,16 @@ def suppress_grouped_gguf_file_rows(rows: Sequence[object]) -> list:
                 for parent in (resolved_parent, *resolved_parent.parents)
             }
             for grouped_row, directory in grouped_rows:
-                grouped_families = families_by_group[id(grouped_row)].get(
-                    file_identity, set()
-                )
+                grouped_families = families_by_group[id(grouped_row)].get(file_identity, set())
                 if not grouped_families:
                     continue
                 try:
                     lexically_nested = bool(loose_path.relative_to(directory).parts)
                 except ValueError:
                     lexically_nested = False
-                grouped_identity = local_path_physical_identity(
-                    getattr(grouped_row, "path", "")
-                )
+                grouped_identity = local_path_physical_identity(getattr(grouped_row, "path", ""))
                 if (
-                    not lexically_nested
-                    and grouped_identity not in physical_parent_ancestry
+                    not lexically_nested and grouped_identity not in physical_parent_ancestry
                 ) or family in grouped_families:
                     break
             else:
@@ -686,15 +678,9 @@ def dedupe_custom_gguf_rows(rows: Sequence[object]) -> list:
                     size_bytes += shard.stat().st_size
                 except OSError:
                     pass
-            replacement_rows[id(chosen)] = chosen.model_copy(
-                update = {"size_bytes": size_bytes}
-            )
+            replacement_rows[id(chosen)] = chosen.model_copy(update = {"size_bytes": size_bytes})
 
-    deduped = [
-        replacement_rows.get(id(row), row)
-        for row in deduped
-        if id(row) not in dropped_rows
-    ]
+    deduped = [replacement_rows.get(id(row), row) for row in deduped if id(row) not in dropped_rows]
 
     grouped_dirs = {
         local_path_physical_identity(getattr(row, "path", ""))
@@ -720,9 +706,9 @@ def dedupe_custom_gguf_rows(rows: Sequence[object]) -> list:
             and not getattr(row, "partial", False)
             and not row_path_is_dir(row)
         ):
-            files_by_parent.setdefault(
-                local_path_physical_identity(str(path.parent)), []
-            ).append(path)
+            files_by_parent.setdefault(local_path_physical_identity(str(path.parent)), []).append(
+                path
+            )
 
     grouped_decisions = {
         parent: should_group_local_gguf_files([path.name for path in files])
@@ -792,12 +778,12 @@ def dedupe_custom_gguf_rows(rows: Sequence[object]) -> list:
         is_dir = row_path_is_dir(row)
         identity = local_path_physical_identity(str(path if is_dir else path.parent))
         keep_group = grouped_decisions.get(identity)
-        if (
-            getattr(row, "model_format", None) == "gguf"
-            and (
-                (keep_group is not None and ((is_dir and not keep_group) or (not is_dir and keep_group)))
-                or (is_dir and local_path_physical_identity(str(path)) in nested_groups_to_drop)
+        if getattr(row, "model_format", None) == "gguf" and (
+            (
+                keep_group is not None
+                and ((is_dir and not keep_group) or (not is_dir and keep_group))
             )
+            or (is_dir and local_path_physical_identity(str(path)) in nested_groups_to_drop)
         ):
             continue
         filtered.append(row)

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -72,7 +72,7 @@ GGUF_QUANT_PREFERENCE = [
     "F32",
 ]
 
-_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{3,}-of-\d{3,}", re.IGNORECASE)
+_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{5}-of-\d{5}(?=\.gguf$|$)", re.IGNORECASE)
 _GGUF_QUANT_RE = re.compile(
     r"(UD-)?"
     r"(MXFP[0-9]+(?:_[A-Z0-9]+)*"
@@ -483,16 +483,6 @@ def local_path_physical_identity(raw_path: str) -> str:
         return f"path\x00{os.path.abspath(os.path.expanduser(raw_path))}"
 
 
-def local_path_parent_physical_identity(raw_path: str) -> str:
-    """Physical identity of a local file's resolved parent directory."""
-    try:
-        resolved = os.path.realpath(os.path.expanduser(raw_path))
-        parent = str(Path(resolved).parent)
-    except (OSError, UnicodeError, ValueError):
-        parent = str(Path(raw_path).parent)
-    return local_path_physical_identity(parent)
-
-
 def should_group_local_gguf_files(filenames: Sequence[str]) -> bool:
     """Whether filenames are variants of one selectable checkpoint."""
     if len(filenames) == 1:
@@ -515,7 +505,8 @@ def should_group_local_gguf_files(filenames: Sequence[str]) -> bool:
 
 
 def suppress_grouped_gguf_file_rows(rows: Sequence[object]) -> list:
-    """Drop loose rows already represented by a physical GGUF directory row."""
+    """Drop rows already represented by a physical GGUF directory row."""
+    from utils.models.model_config import _extract_quant_label as _loader_quant
 
     def row_path_is_dir(row) -> bool:
         try:
@@ -523,25 +514,124 @@ def suppress_grouped_gguf_file_rows(rows: Sequence[object]) -> list:
         except OSError:
             return False
 
-    grouped_dirs = {
-        local_path_physical_identity(getattr(row, "path", ""))
+    grouped_rows = [
+        (row, Path(os.path.abspath(os.path.expanduser(getattr(row, "path", "")))))
         for row in rows
         if getattr(row, "model_format", None) == "gguf"
         and not getattr(row, "partial", False)
         and row_path_is_dir(row)
-    }
-    if not grouped_dirs:
-        return list(rows)
-    return [
-        row
-        for row in rows
-        if not (
-            getattr(row, "model_format", None) == "gguf"
-            and not row_path_is_dir(row)
-            and local_path_parent_physical_identity(getattr(row, "path", ""))
-            in grouped_dirs
-        )
     ]
+    if not grouped_rows:
+        return list(rows)
+
+    paths_by_group = {
+        id(row): list(iter_gguf_files(directory, recursive = True))
+        for row, directory in grouped_rows
+    }
+    physical_ancestors_by_group = {
+        id(row): {
+            local_path_physical_identity(str(parent))
+            for parent in Path(os.path.realpath(directory)).parents
+        }
+        for row, directory in grouped_rows
+    }
+    families_by_group = {}
+    for row, directory in grouped_rows:
+        families_by_file = {}
+        for file in paths_by_group[id(row)]:
+            try:
+                filename = str(file.relative_to(directory))
+            except ValueError:
+                filename = file.name
+            if (
+                is_mmproj_filename(file.name)
+                or is_imatrix_filename(file.name)
+                or is_mtp_drafter_path(filename)
+                or is_appledouble_metadata(file)
+                or is_big_endian_gguf_path(filename, _loader_quant(filename))
+            ):
+                continue
+            file_identity = local_path_physical_identity(str(file))
+            families_by_file.setdefault(file_identity, set()).add(
+                gguf_checkpoint_family(filename)
+            )
+        families_by_group[id(row)] = families_by_file
+
+    nested_groups_to_drop = set()
+    for row, directory in grouped_rows:
+        families_by_file = families_by_group[id(row)]
+        if not families_by_file:
+            continue
+        physical_ancestors = physical_ancestors_by_group[id(row)]
+        for parent_row, parent_directory in grouped_rows:
+            if row is parent_row:
+                continue
+            parent_families_by_file = families_by_group[id(parent_row)]
+            parent_identity = local_path_physical_identity(getattr(parent_row, "path", ""))
+            try:
+                lexically_nested = bool(directory.relative_to(parent_directory).parts)
+            except ValueError:
+                lexically_nested = False
+            matching_families = [
+                families & parent_families_by_file.get(file_identity, set())
+                for file_identity, families in families_by_file.items()
+            ]
+            outside_families = set().union(
+                *(
+                    families
+                    for file_identity, families in parent_families_by_file.items()
+                    if file_identity not in families_by_file
+                )
+            )
+            if (
+                (lexically_nested or parent_identity in physical_ancestors)
+                and all(matching_families)
+                and (
+                    not outside_families
+                    or all(families & outside_families for families in matching_families)
+                )
+            ):
+                nested_groups_to_drop.add(id(row))
+                break
+
+    filtered = []
+    for row in rows:
+        if id(row) in nested_groups_to_drop:
+            continue
+        if getattr(row, "model_format", None) == "gguf" and not row_path_is_dir(row):
+            path = getattr(row, "path", "")
+            loose_path = Path(os.path.abspath(os.path.expanduser(path)))
+            file_identity = local_path_physical_identity(path)
+            family = gguf_checkpoint_family(Path(path).name)
+            resolved_parent = Path(os.path.realpath(loose_path.parent))
+            physical_parent_ancestry = {
+                local_path_physical_identity(str(parent))
+                for parent in (resolved_parent, *resolved_parent.parents)
+            }
+            for grouped_row, directory in grouped_rows:
+                grouped_families = families_by_group[id(grouped_row)].get(
+                    file_identity, set()
+                )
+                if not grouped_families:
+                    continue
+                try:
+                    lexically_nested = bool(loose_path.relative_to(directory).parts)
+                except ValueError:
+                    lexically_nested = False
+                grouped_identity = local_path_physical_identity(
+                    getattr(grouped_row, "path", "")
+                )
+                if (
+                    not lexically_nested
+                    and grouped_identity not in physical_parent_ancestry
+                ) or family in grouped_families:
+                    break
+            else:
+                filtered.append(row)
+                continue
+            continue
+        filtered.append(row)
+    return filtered
 
 
 def dedupe_custom_gguf_rows(rows: Sequence[object]) -> list:

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -457,14 +457,13 @@ def gguf_variant_family(filename: str) -> str:
 
 
 def gguf_checkpoint_family(filename: str) -> Optional[str]:
-    """the checkpoint name shared by quant variants, or ``None`` when unnamed."""
+    """the exact checkpoint name shared by quant variants, or ``None`` when unnamed."""
     path = filename.replace("\\", "/")
     family = gguf_variant_family(path)
     quant = quant_token_with_bpw(path)
     if quant is not None:
         family = re.sub(re.escape(quant), "", family, count = 1, flags = re.IGNORECASE)
-    normalized = re.sub(r"[-_.\s]+", "-", family).strip("-/")
-    return normalized.casefold() or None
+    return family.strip("-_. /\t\r\n") or None
 
 
 def extract_quant_label(filename: str) -> str:

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -72,7 +72,7 @@ GGUF_QUANT_PREFERENCE = [
     "F32",
 ]
 
-_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{5}-of-\d{5}(?=\.gguf$|$)", re.IGNORECASE)
+_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{3,}-of-\d{3,}(?=\.gguf$|$)", re.IGNORECASE)
 _GGUF_QUANT_RE = re.compile(
     r"(UD-)?"
     r"(MXFP[0-9]+(?:_[A-Z0-9]+)*"

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -459,11 +459,218 @@ def gguf_variant_family(filename: str) -> str:
 def gguf_checkpoint_family(filename: str) -> Optional[str]:
     """the exact checkpoint name shared by quant variants, or ``None`` when unnamed."""
     path = filename.replace("\\", "/")
-    family = gguf_variant_family(path)
-    quant = quant_token_with_bpw(path)
+    family_parts = gguf_variant_family(path).split("/")
+    basename = family_parts.pop()
+    family_parts = [
+        segment for segment in family_parts if segment and not _is_quant_directory(segment)
+    ]
+    quant = quant_token_with_bpw(basename)
     if quant is not None:
-        family = re.sub(re.escape(quant), "", family, count = 1, flags = re.IGNORECASE)
+        basename = re.sub(re.escape(quant), "", basename, count = 1, flags = re.IGNORECASE)
+    family = "/".join((*family_parts, basename))
     return family.strip("-_. /\t\r\n") or None
+
+
+def local_path_physical_identity(raw_path: str) -> str:
+    """Identity for an existing local path without folding valid filename characters."""
+    try:
+        path = os.path.realpath(os.path.expanduser(raw_path))
+        stat = os.stat(path)
+        if stat.st_ino:
+            return "\x00".join(("stat", str(stat.st_dev), str(stat.st_ino)))
+        return f"path\x00{path}"
+    except (OSError, UnicodeError, ValueError):
+        return f"path\x00{os.path.abspath(os.path.expanduser(raw_path))}"
+
+
+def local_path_parent_physical_identity(raw_path: str) -> str:
+    """Physical identity of a local file's resolved parent directory."""
+    try:
+        resolved = os.path.realpath(os.path.expanduser(raw_path))
+        parent = str(Path(resolved).parent)
+    except (OSError, UnicodeError, ValueError):
+        parent = str(Path(raw_path).parent)
+    return local_path_physical_identity(parent)
+
+
+def should_group_local_gguf_files(filenames: Sequence[str]) -> bool:
+    """Whether filenames are variants of one selectable checkpoint."""
+    if len(filenames) == 1:
+        return True
+
+    families = {gguf_checkpoint_family(filename) for filename in filenames}
+    variant_keys = [gguf_variant_key(filename) for filename in filenames]
+    exact_families_by_variant: dict[str, set[str]] = {}
+    for filename, variant_key in zip(filenames, variant_keys):
+        exact_families_by_variant.setdefault(variant_key.casefold(), set()).add(
+            gguf_variant_family(filename)
+        )
+    has_ambiguous_variant = any(
+        len(exact_families) > 1 for exact_families in exact_families_by_variant.values()
+    )
+    return (
+        not has_ambiguous_variant
+        and (families == {None} or (None not in families and len(families) == 1))
+    ) or all(is_h3_denoiser_variant_key(key) for key in variant_keys)
+
+
+def dedupe_custom_gguf_rows(rows: Sequence[object]) -> list:
+    """Remove scanner overlap while preserving independently loadable GGUF checkpoints."""
+    from utils.models.model_config import colocated_split_shards
+
+    def row_path_is_dir(row) -> bool:
+        try:
+            return Path(getattr(row, "path", "")).is_dir()
+        except OSError:
+            return False
+
+    deduped = list(rows)
+    split_groups: dict[tuple[str, ...], list[tuple[object, Path, list[Path]]]] = {}
+    for row in deduped:
+        path = Path(getattr(row, "path", ""))
+        if (
+            getattr(row, "source", None) not in {"models_dir", "lmstudio"}
+            or getattr(row, "model_format", None) != "gguf"
+            or getattr(row, "partial", False)
+            or row_path_is_dir(row)
+        ):
+            continue
+        shards, complete = colocated_split_shards(path)
+        if not complete or len(shards) < 2:
+            continue
+        key = tuple(local_path_physical_identity(str(shard)) for shard in shards)
+        split_groups.setdefault(key, []).append((row, path, shards))
+
+    dropped_rows: set[int] = set()
+    replacement_rows: dict[int, object] = {}
+    for candidates in split_groups.values():
+        shards = candidates[0][2]
+        first_identity = local_path_physical_identity(str(shards[0]))
+        chosen = next(
+            (
+                row
+                for row, path, _shards in candidates
+                if local_path_physical_identity(str(path)) == first_identity
+            ),
+            None,
+        )
+        if chosen is None:
+            continue
+        for row, _path, _shards in candidates:
+            if row is not chosen:
+                dropped_rows.add(id(row))
+        if hasattr(chosen, "size_bytes"):
+            size_bytes = 0
+            for shard in shards:
+                try:
+                    size_bytes += shard.stat().st_size
+                except OSError:
+                    pass
+            replacement_rows[id(chosen)] = chosen.model_copy(
+                update = {"size_bytes": size_bytes}
+            )
+
+    deduped = [
+        replacement_rows.get(id(row), row)
+        for row in deduped
+        if id(row) not in dropped_rows
+    ]
+
+    grouped_dirs = {
+        local_path_physical_identity(getattr(row, "path", ""))
+        for row in deduped
+        if getattr(row, "source", None) != "lmstudio"
+        and getattr(row, "model_format", None) == "gguf"
+        and not getattr(row, "partial", False)
+        and row_path_is_dir(row)
+    }
+    gguf_dirs = [
+        Path(getattr(row, "path", ""))
+        for row in deduped
+        if getattr(row, "model_format", None) == "gguf"
+        and not getattr(row, "partial", False)
+        and row_path_is_dir(row)
+    ]
+    files_by_parent: dict[str, list[Path]] = {}
+    for row in deduped:
+        path = Path(getattr(row, "path", ""))
+        if (
+            getattr(row, "source", None) == "lmstudio"
+            and getattr(row, "model_format", None) == "gguf"
+            and not getattr(row, "partial", False)
+            and not row_path_is_dir(row)
+        ):
+            files_by_parent.setdefault(
+                local_path_physical_identity(str(path.parent)), []
+            ).append(path)
+
+    grouped_decisions = {
+        parent: should_group_local_gguf_files([path.name for path in files])
+        for parent, files in files_by_parent.items()
+        if parent in grouped_dirs
+    }
+    if not grouped_decisions:
+        return deduped
+
+    grouped_paths = {
+        local_path_physical_identity(str(path)): path
+        for path in gguf_dirs
+        if local_path_physical_identity(str(path)) in grouped_decisions
+    }
+    nested_groups_to_drop: set[str] = set()
+    for parent_identity, parent_path in grouped_paths.items():
+        nested_paths = []
+        for candidate in gguf_dirs:
+            if candidate == parent_path:
+                continue
+            try:
+                candidate.relative_to(parent_path)
+            except ValueError:
+                continue
+            nested_paths.append(candidate)
+        if not nested_paths:
+            continue
+
+        filenames = [path.name for path in files_by_parent[parent_identity]]
+        nested_identities = set()
+        for nested_path in nested_paths:
+            nested_identities.add(local_path_physical_identity(str(nested_path)))
+            try:
+                relative_parent = nested_path.relative_to(parent_path)
+                filenames.extend(
+                    str(relative_parent / file.name)
+                    for file in nested_path.iterdir()
+                    if file.is_file()
+                    and is_gguf_filename(file.name)
+                    and not is_mmproj_filename(file.name)
+                    and not is_imatrix_filename(file.name)
+                    and not is_mtp_drafter_path(file.name)
+                    and not is_appledouble_metadata(file)
+                )
+            except OSError:
+                grouped_decisions[parent_identity] = False
+                break
+        else:
+            grouped_decisions[parent_identity] = should_group_local_gguf_files(filenames)
+        if grouped_decisions[parent_identity]:
+            nested_groups_to_drop.update(nested_identities)
+
+    filtered = []
+    for row in deduped:
+        path = Path(getattr(row, "path", ""))
+        is_dir = row_path_is_dir(row)
+        identity = local_path_physical_identity(str(path if is_dir else path.parent))
+        keep_group = grouped_decisions.get(identity)
+        if (
+            getattr(row, "model_format", None) == "gguf"
+            and (
+                (keep_group is not None and ((is_dir and not keep_group) or (not is_dir and keep_group)))
+                or (is_dir and local_path_physical_identity(str(path)) in nested_groups_to_drop)
+            )
+        ):
+            continue
+        filtered.append(row)
+    return filtered
 
 
 def extract_quant_label(filename: str) -> str:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1158,21 +1158,19 @@ def collect_local_models(
     deduped: dict[str, LocalModelInfo] = {}
     for model in local_models:
         semantic_id = model.model_id if model.source == "hf_cache" and model.model_id else model.id
-        key = (
-            "\x00".join(
-                (
-                    (
-                        model.model_id
-                        if model.model_id and model.model_id.startswith("ollama/")
-                        else gguf_utils.local_path_physical_identity(model.path)
-                    ),
-                    model.model_format or "",
-                    "custom",
+        if model.source == "custom":
+            physical_identity = gguf_utils.local_path_physical_identity(model.path)
+            if (
+                model.model_id
+                and model.model_id.startswith("ollama/")
+                and any(
+                    part in (".studio_links", "ollama_links") for part in Path(model.path).parts
                 )
-            )
-            if model.source == "custom"
-            else semantic_id
-        )
+            ):
+                physical_identity = "\x00".join((model.model_id, physical_identity))
+            key = "\x00".join((physical_identity, model.model_format or "", "custom"))
+        else:
+            key = semantic_id
         existing = deduped.get(key)
         prefer_model = existing is None
         if existing is not None and model.source == existing.source == "hf_cache":

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1030,6 +1030,7 @@ def collect_local_models(
     must already be validated/trusted by the caller.
     """
     from storage.studio_db import list_scan_folders
+    from hub.utils import gguf as gguf_utils
     from utils.models.model_config import detect_gguf_model
 
     sources = sources or _compat_local_inventory_sources()
@@ -1138,6 +1139,7 @@ def collect_local_models(
                     is not None
                 ):
                     custom_models.append(model)
+            custom_models = gguf_utils.dedupe_custom_gguf_rows(custom_models)
             if len(custom_models) < _MAX_MODELS_PER_FOLDER:
                 custom_models += _scan_ollama_dir(
                     folder_path,
@@ -1156,7 +1158,17 @@ def collect_local_models(
     deduped: dict[str, LocalModelInfo] = {}
     for model in local_models:
         semantic_id = model.model_id if model.source == "hf_cache" and model.model_id else model.id
-        key = f"{semantic_id}\x00custom" if model.source == "custom" else semantic_id
+        key = (
+            "\x00".join(
+                (
+                    gguf_utils.local_path_physical_identity(model.path),
+                    model.model_format or "",
+                    "custom",
+                )
+            )
+            if model.source == "custom"
+            else semantic_id
+        )
         existing = deduped.get(key)
         prefer_model = existing is None
         if existing is not None and model.source == existing.source == "hf_cache":

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1161,7 +1161,11 @@ def collect_local_models(
         key = (
             "\x00".join(
                 (
-                    gguf_utils.local_path_physical_identity(model.path),
+                    (
+                        model.model_id
+                        if model.model_id and model.model_id.startswith("ollama/")
+                        else gguf_utils.local_path_physical_identity(model.path)
+                    ),
                     model.model_format or "",
                     "custom",
                 )
@@ -1181,8 +1185,11 @@ def collect_local_models(
         if prefer_model:
             deduped[key] = model
 
+    deduped_values = list(deduped.values())
+    custom_values = [model for model in deduped_values if model.source == "custom"]
     models = sorted(
-        deduped.values(),
+        [model for model in deduped_values if model.source != "custom"]
+        + gguf_utils.suppress_grouped_gguf_file_rows(custom_values),
         key = lambda item: item.updated_at or 0,
         reverse = True,
     )

--- a/studio/backend/tests/test_local_model_format.py
+++ b/studio/backend/tests/test_local_model_format.py
@@ -42,6 +42,47 @@ def _touch(path: Path) -> Path:
     return path
 
 
+def _empty_compat_sources(tmp_path: Path):
+    empty = tmp_path / "empty"
+    return models_route._CompatLocalInventorySources(
+        empty / "active",
+        empty / "legacy",
+        empty / "default",
+        (),
+        (),
+    )
+
+
+def test_compat_inventory_groups_custom_gguf_variants(tmp_path):
+    root = tmp_path / "custom"
+    model = root / "publisher"
+    _touch(model / "model-Q4_K_M.gguf")
+    _touch(model / "model-Q8_0.gguf")
+
+    rows = models_route.collect_local_models(
+        tmp_path / "models",
+        custom_folders = [{"path": str(root)}],
+        sources = _empty_compat_sources(tmp_path),
+    )
+
+    assert [(row.source, Path(row.path)) for row in rows] == [("custom", model)]
+
+
+def test_compat_inventory_preserves_distinct_custom_ggufs(tmp_path):
+    root = tmp_path / "custom"
+    holder = root / "publisher"
+    first = _touch(holder / "model-a-Q4_K_M.gguf")
+    second = _touch(holder / "model-b-Q4_K_M.gguf")
+
+    rows = models_route.collect_local_models(
+        tmp_path / "models",
+        custom_folders = [{"path": str(root)}],
+        sources = _empty_compat_sources(tmp_path),
+    )
+
+    assert {Path(row.path) for row in rows} == {first, second}
+
+
 def test_local_adapter_chat_capability_uses_its_local_base(tmp_path):
     from hub.services.models.common import _classify_local_path
 

--- a/studio/backend/tests/test_local_model_format.py
+++ b/studio/backend/tests/test_local_model_format.py
@@ -98,6 +98,44 @@ def test_compat_inventory_dedupes_overlapping_custom_roots(tmp_path):
     assert [(row.source, Path(row.path)) for row in rows] == [("custom", model)]
 
 
+def test_compat_inventory_dedupes_nested_quant_root(tmp_path):
+    root = tmp_path / "custom"
+    model = root / "publisher"
+    _touch(model / "model-a-Q4_K_M.gguf")
+    quant_dir = model / "Q8_0"
+    _touch(quant_dir / "model-a-Q8_0.gguf")
+    (quant_dir / "config.json").write_text("{}", encoding = "utf-8")
+
+    rows = models_route.collect_local_models(
+        tmp_path / "models",
+        custom_folders = [{"path": str(root)}, {"path": str(quant_dir)}],
+        sources = _empty_compat_sources(tmp_path),
+    )
+
+    assert [(row.source, Path(row.path)) for row in rows] == [("custom", model)]
+
+
+def test_compat_inventory_preserves_nested_independent_model_root(tmp_path):
+    root = tmp_path / "custom"
+    parent = root / "parent"
+    _touch(parent / "parent-Q4_K_M.gguf")
+    (parent / "config.json").write_text("{}", encoding = "utf-8")
+    child = parent / "child"
+    _touch(child / "child-Q8_0.gguf")
+    (child / "config.json").write_text("{}", encoding = "utf-8")
+
+    rows = models_route.collect_local_models(
+        tmp_path / "models",
+        custom_folders = [{"path": str(root)}, {"path": str(child)}],
+        sources = _empty_compat_sources(tmp_path),
+    )
+
+    assert {(row.source, Path(row.path)) for row in rows} == {
+        ("custom", parent),
+        ("custom", child),
+    }
+
+
 def test_compat_inventory_keeps_custom_section_copy(tmp_path):
     root = tmp_path / "models"
     model = root / "publisher"
@@ -138,27 +176,78 @@ def test_compat_inventory_does_not_cross_dedupe_default_sources(tmp_path):
     }
 
 
-def test_compat_inventory_preserves_ollama_tags_sharing_a_blob(tmp_path, monkeypatch):
-    blob = _touch(tmp_path / "ollama" / "blobs" / "sha256-model")
-    tags = [
-        models_route.LocalModelInfo(
-            id = str(blob),
-            model_id = f"ollama/model:{tag}",
-            display_name = f"model:{tag}",
-            path = str(blob),
-            source = "custom",
-        )
-        for tag in ("latest", "v1")
-    ]
-    monkeypatch.setattr(models_route, "_scan_ollama_dir", lambda *_a, **_kw: tags)
+def test_compat_inventory_preserves_ollama_tags_sharing_a_blob(tmp_path):
+    root = tmp_path / "ollama"
+    digest = "sha256-model"
+    _touch(root / "blobs" / digest)
+    manifest = json.dumps(
+        {
+            "layers": [
+                {
+                    "mediaType": "application/vnd.ollama.image.model",
+                    "digest": digest.replace("-", ":", 1),
+                }
+            ]
+        }
+    )
+    tags = root / "manifests" / "registry.ollama.ai" / "library" / "model"
+    tags.mkdir(parents = True)
+    for tag in ("latest", "v1"):
+        (tags / tag).write_text(manifest, encoding = "utf-8")
 
     rows = models_route.collect_local_models(
         tmp_path / "models",
-        custom_folders = [{"path": str(tmp_path / "ollama")}],
+        custom_folders = [{"path": str(root)}],
         sources = _empty_compat_sources(tmp_path),
     )
 
     assert {row.model_id for row in rows} == {"ollama/model:latest", "ollama/model:v1"}
+
+
+def test_compat_inventory_preserves_same_ollama_tag_from_distinct_stores(tmp_path):
+    roots = [tmp_path / "ollama-one", tmp_path / "ollama-two"]
+    for index, root in enumerate(roots):
+        digest = f"sha256-model-{index}"
+        _touch(root / "blobs" / digest)
+        tag = root / "manifests" / "registry.ollama.ai" / "library" / "model" / "latest"
+        tag.parent.mkdir(parents = True)
+        tag.write_text(
+            json.dumps(
+                {
+                    "layers": [
+                        {
+                            "mediaType": "application/vnd.ollama.image.model",
+                            "digest": digest.replace("-", ":", 1),
+                        }
+                    ]
+                }
+            ),
+            encoding = "utf-8",
+        )
+
+    rows = models_route.collect_local_models(
+        tmp_path / "models",
+        custom_folders = [{"path": str(root)} for root in roots],
+        sources = _empty_compat_sources(tmp_path),
+    )
+
+    assert [row.model_id for row in rows] == ["ollama/model:latest"] * 2
+    assert len({Path(row.path).resolve() for row in rows}) == 2
+
+
+def test_compat_inventory_dedupes_lmstudio_publisher_named_ollama(tmp_path):
+    root = tmp_path / "lmstudio"
+    model = root / "ollama" / "foo"
+    _touch(model / "foo-Q4_K_M.gguf")
+    (model / "config.json").write_text("{}", encoding = "utf-8")
+
+    rows = models_route.collect_local_models(
+        tmp_path / "models",
+        custom_folders = [{"path": str(root)}, {"path": str(model)}],
+        sources = _empty_compat_sources(tmp_path),
+    )
+
+    assert [Path(row.path) for row in rows] == [model]
 
 
 def test_local_adapter_chat_capability_uses_its_local_base(tmp_path):

--- a/studio/backend/tests/test_local_model_format.py
+++ b/studio/backend/tests/test_local_model_format.py
@@ -83,6 +83,84 @@ def test_compat_inventory_preserves_distinct_custom_ggufs(tmp_path):
     assert {Path(row.path) for row in rows} == {first, second}
 
 
+def test_compat_inventory_dedupes_overlapping_custom_roots(tmp_path):
+    root = tmp_path / "custom"
+    model = root / "publisher"
+    _touch(model / "model-Q4_K_M.gguf")
+    _touch(model / "model-Q8_0.gguf")
+
+    rows = models_route.collect_local_models(
+        tmp_path / "models",
+        custom_folders = [{"path": str(root)}, {"path": str(model)}],
+        sources = _empty_compat_sources(tmp_path),
+    )
+
+    assert [(row.source, Path(row.path)) for row in rows] == [("custom", model)]
+
+
+def test_compat_inventory_keeps_custom_section_copy(tmp_path):
+    root = tmp_path / "models"
+    model = root / "publisher"
+    q4 = _touch(model / "model-Q4_K_M.gguf")
+    q8 = _touch(model / "model-Q8_0.gguf")
+
+    rows = models_route.collect_local_models(
+        root,
+        custom_folders = [{"path": str(model)}],
+        sources = _empty_compat_sources(tmp_path),
+    )
+
+    assert {(row.source, Path(row.path)) for row in rows} == {
+        ("models_dir", model),
+        ("custom", q4),
+        ("custom", q8),
+    }
+
+
+def test_compat_inventory_does_not_cross_dedupe_default_sources(tmp_path):
+    root = tmp_path / "models"
+    holder = root / "publisher"
+    first = _touch(holder / "model-a-Q4_K_M.gguf")
+    second = _touch(holder / "model-b-Q4_K_M.gguf")
+    empty = _empty_compat_sources(tmp_path)
+    sources = empty._replace(lm_dirs = (root,))
+
+    rows = models_route.collect_local_models(
+        root,
+        custom_folders = [],
+        sources = sources,
+    )
+
+    assert {(row.source, Path(row.path)) for row in rows} == {
+        ("models_dir", holder),
+        ("lmstudio", first),
+        ("lmstudio", second),
+    }
+
+
+def test_compat_inventory_preserves_ollama_tags_sharing_a_blob(tmp_path, monkeypatch):
+    blob = _touch(tmp_path / "ollama" / "blobs" / "sha256-model")
+    tags = [
+        models_route.LocalModelInfo(
+            id = str(blob),
+            model_id = f"ollama/model:{tag}",
+            display_name = f"model:{tag}",
+            path = str(blob),
+            source = "custom",
+        )
+        for tag in ("latest", "v1")
+    ]
+    monkeypatch.setattr(models_route, "_scan_ollama_dir", lambda *_a, **_kw: tags)
+
+    rows = models_route.collect_local_models(
+        tmp_path / "models",
+        custom_folders = [{"path": str(tmp_path / "ollama")}],
+        sources = _empty_compat_sources(tmp_path),
+    )
+
+    assert {row.model_id for row in rows} == {"ollama/model:latest", "ollama/model:v1"}
+
+
 def test_local_adapter_chat_capability_uses_its_local_base(tmp_path):
     from hub.services.models.common import _classify_local_path
 

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -2588,7 +2588,10 @@ def test_build_index_groups_overlapping_custom_gguf_roots(tmp_path, monkeypatch)
     model = root / "publisher"
     model.mkdir(parents = True)
     (model / "model-Q4_K_M.gguf").write_bytes(b"x")
-    (model / "model-Q8_0.gguf").write_bytes(b"xx")
+    quant_dir = model / "Q8_0"
+    quant_dir.mkdir()
+    (quant_dir / "model-Q8_0.gguf").write_bytes(b"xx")
+    (quant_dir / "config.json").write_text("{}", encoding = "utf-8")
     scan_models_dir = models_route._scan_models_dir
     scan_lmstudio_dir = models_route._scan_lmstudio_dir
 
@@ -2596,13 +2599,13 @@ def test_build_index_groups_overlapping_custom_gguf_roots(tmp_path, monkeypatch)
         models_route,
         "_scan_models_dir",
         lambda path, **kwargs: scan_models_dir(path, **kwargs)
-        if path in {root, model}
+        if path in {root, quant_dir}
         else [],
     )
     monkeypatch.setattr(
         models_route,
         "_scan_lmstudio_dir",
-        lambda path: scan_lmstudio_dir(path) if path in {root, model} else [],
+        lambda path: scan_lmstudio_dir(path) if path in {root, quant_dir} else [],
     )
     monkeypatch.setattr(models_route, "_scan_hf_cache", lambda *a, **k: [])
     monkeypatch.setattr(models_route, "_resolve_hf_cache_dir", lambda: tmp_path / "active")
@@ -2614,7 +2617,7 @@ def test_build_index_groups_overlapping_custom_gguf_roots(tmp_path, monkeypatch)
     monkeypatch.setattr(
         studio_db,
         "list_scan_folders",
-        lambda: [{"path": str(root)}, {"path": str(model)}],
+        lambda: [{"path": str(root)}, {"path": str(quant_dir)}],
     )
 
     index = resolver._build_index()

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -2598,9 +2598,7 @@ def test_build_index_groups_overlapping_custom_gguf_roots(tmp_path, monkeypatch)
     monkeypatch.setattr(
         models_route,
         "_scan_models_dir",
-        lambda path, **kwargs: scan_models_dir(path, **kwargs)
-        if path in {root, quant_dir}
-        else [],
+        lambda path, **kwargs: scan_models_dir(path, **kwargs) if path in {root, quant_dir} else [],
     )
     monkeypatch.setattr(
         models_route,

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -2578,7 +2578,7 @@ def test_build_index_survives_a_failing_scanner(tmp_path, monkeypatch):
     assert any(e.loader_id == "org/Repo-GGUF" for e in index.values())
 
 
-def test_build_index_groups_custom_gguf_variants(tmp_path, monkeypatch):
+def test_build_index_groups_overlapping_custom_gguf_roots(tmp_path, monkeypatch):
     import routes.models as models_route
     from storage import studio_db
     from utils import hf_cache_settings
@@ -2595,12 +2595,14 @@ def test_build_index_groups_custom_gguf_variants(tmp_path, monkeypatch):
     monkeypatch.setattr(
         models_route,
         "_scan_models_dir",
-        lambda path, **kwargs: scan_models_dir(path, **kwargs) if path == root else [],
+        lambda path, **kwargs: scan_models_dir(path, **kwargs)
+        if path in {root, model}
+        else [],
     )
     monkeypatch.setattr(
         models_route,
         "_scan_lmstudio_dir",
-        lambda path: scan_lmstudio_dir(path) if path == root else [],
+        lambda path: scan_lmstudio_dir(path) if path in {root, model} else [],
     )
     monkeypatch.setattr(models_route, "_scan_hf_cache", lambda *a, **k: [])
     monkeypatch.setattr(models_route, "_resolve_hf_cache_dir", lambda: tmp_path / "active")
@@ -2609,7 +2611,11 @@ def test_build_index_groups_custom_gguf_variants(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "legacy_hf_cache_dir", lambda: None)
     monkeypatch.setattr(paths, "hf_default_cache_dir", lambda: None)
     monkeypatch.setattr(paths, "lmstudio_model_dirs", lambda: [])
-    monkeypatch.setattr(studio_db, "list_scan_folders", lambda: [{"path": str(root)}])
+    monkeypatch.setattr(
+        studio_db,
+        "list_scan_folders",
+        lambda: [{"path": str(root)}, {"path": str(model)}],
+    )
 
     index = resolver._build_index()
 

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -2578,6 +2578,45 @@ def test_build_index_survives_a_failing_scanner(tmp_path, monkeypatch):
     assert any(e.loader_id == "org/Repo-GGUF" for e in index.values())
 
 
+def test_build_index_groups_custom_gguf_variants(tmp_path, monkeypatch):
+    import routes.models as models_route
+    from storage import studio_db
+    from utils import hf_cache_settings
+    import utils.paths as paths
+
+    root = tmp_path / "custom"
+    model = root / "publisher"
+    model.mkdir(parents = True)
+    (model / "model-Q4_K_M.gguf").write_bytes(b"x")
+    (model / "model-Q8_0.gguf").write_bytes(b"xx")
+    scan_models_dir = models_route._scan_models_dir
+    scan_lmstudio_dir = models_route._scan_lmstudio_dir
+
+    monkeypatch.setattr(
+        models_route,
+        "_scan_models_dir",
+        lambda path, **kwargs: scan_models_dir(path, **kwargs) if path == root else [],
+    )
+    monkeypatch.setattr(
+        models_route,
+        "_scan_lmstudio_dir",
+        lambda path: scan_lmstudio_dir(path) if path == root else [],
+    )
+    monkeypatch.setattr(models_route, "_scan_hf_cache", lambda *a, **k: [])
+    monkeypatch.setattr(models_route, "_resolve_hf_cache_dir", lambda: tmp_path / "active")
+    monkeypatch.setattr(models_route, "_is_hidden_model", lambda *a, **k: False)
+    monkeypatch.setattr(hf_cache_settings, "known_hf_hub_caches", lambda: [])
+    monkeypatch.setattr(paths, "legacy_hf_cache_dir", lambda: None)
+    monkeypatch.setattr(paths, "hf_default_cache_dir", lambda: None)
+    monkeypatch.setattr(paths, "lmstudio_model_dirs", lambda: [])
+    monkeypatch.setattr(studio_db, "list_scan_folders", lambda: [{"path": str(root)}])
+
+    index = resolver._build_index()
+
+    assert {entry.load_path for entry in index.values()} == {str(model)}
+    assert {entry.variants for entry in index.values()} == {("Q4_K_M", "Q8_0")}
+
+
 def test_non_gguf_entries_skip_gguf_sibling_revision_scans(tmp_path, monkeypatch):
     from types import SimpleNamespace
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -2392,7 +2392,7 @@ _GGUF_KNOWN_QUANT_RE = re.compile(
 
 
 _FLOAT_PRECISION_QUANTS = frozenset({"BF16", "F16", "F32"})
-_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{3,}-of-\d{3,}(?=\.gguf$|$)", re.IGNORECASE)
+_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{3,}-of-\d{3,}", re.IGNORECASE)
 
 
 def _select_known_quant_match(text: str):

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -2392,7 +2392,7 @@ _GGUF_KNOWN_QUANT_RE = re.compile(
 
 
 _FLOAT_PRECISION_QUANTS = frozenset({"BF16", "F16", "F32"})
-_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{3,}-of-\d{3,}", re.IGNORECASE)
+_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{5}-of-\d{5}(?=\.gguf$|$)", re.IGNORECASE)
 
 
 def _select_known_quant_match(text: str):

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -2392,7 +2392,7 @@ _GGUF_KNOWN_QUANT_RE = re.compile(
 
 
 _FLOAT_PRECISION_QUANTS = frozenset({"BF16", "F16", "F32"})
-_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{5}-of-\d{5}(?=\.gguf$|$)", re.IGNORECASE)
+_GGUF_SPLIT_SUFFIX_RE = re.compile(r"-\d{3,}-of-\d{3,}(?=\.gguf$|$)", re.IGNORECASE)
 
 
 def _select_known_quant_match(text: str):


### PR DESCRIPTION
## Summary
- prevent a custom GGUF model directory from also appearing as individual LM Studio compatibility rows
- suppress only immediate child GGUF files when a complete grouped directory already represents them
- preserve partial cache rows and the standard publisher/model LM Studio layout

## Reproduction
Register a custom scan root containing model-name/model-q4_k_m.gguf. Before this change the picker shows both the model-name group and the nested GGUF file as separate top-level models. After this change it shows only the grouped model and keeps the GGUFs available as variants.

## Regression coverage
A deterministic baseline/fix matrix covered 11 layouts including loose GGUFs, direct model roots, grouped variants, standard LM Studio publisher/model folders, mixed formats, safetensors, symlinks, and overlapping custom roots.

## Tests
- 279 passed in studio/backend/hub/tests/test_model_services.py
- 43 passed in studio/backend/tests/test_local_model_format.py
- ruff check on the changed service and tests
- git diff --check