### PR TITLE
Studio: split parallel tool calls at JSON document boundaries

### DIFF
--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -712,8 +712,7 @@ class _Turn:
         return [
             self.by_index[key]
             for key in self.order
-            if key in self.split_keys
-            and self.boundaries.get(key, _EMPTY_BOUNDARIES).is_open()
+            if key in self.split_keys and self.boundaries.get(key, _EMPTY_BOUNDARIES).is_open()
         ]
 
     def calls(

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -582,6 +582,13 @@ class _Turn:
             # for every tool round, so after a fork the bare argument fragments
             # belong to the newer call.
             key: Any = self.open_key_by_index.get(index, index)
+            claimed_waiting = False
+            # Only a fragment that also names its call can claim one a split left
+            # waiting. A bare id has nothing to match on, so it stays with the
+            # call this index has open, which is also where the client put it.
+            names_its_call = isinstance(raw_call.get("function"), dict) and bool(
+                raw_call["function"].get("name")
+            )
             if isinstance(call_id, str) and call_id:
                 open_id = self.by_index.get(key, {}).get("id")
                 if open_id and open_id != call_id:
@@ -597,12 +604,14 @@ class _Turn:
                     else:
                         # A split can leave calls waiting for an identity; the id
                         # claims the first of those before opening a new call.
-                        waiting = self._unclaimed_key(index)
+                        waiting = self._unclaimed_key(index) if names_its_call else None
+                        claimed_waiting = waiting is not None
                         key = waiting if waiting is not None else (index, call_id)
-                elif not open_id:
+                elif not open_id and names_its_call:
                     waiting = self._unclaimed_key(index)
                     if waiting is not None:
                         key = waiting
+                        claimed_waiting = True
             self.last_index = index
             self.open_key_by_index[index] = key
             if key not in self.by_index:
@@ -667,6 +676,7 @@ class _Turn:
                 closed = _ArgumentBoundaries()
                 closed.closed = True
                 self.boundaries[key] = closed
+                self.split_keys.add(key)
                 for segment in segments[1:]:
                     key = (index, "split", len(self.order))
                     self.by_index[key] = {
@@ -709,7 +719,12 @@ class _Turn:
                 # starts with what we have is the whole name resent; anything
                 # else continues it.
                 accumulated = named["function"]["name"]
-                if name_fragment.startswith(accumulated):
+                if claimed_waiting:
+                    # The id names the call it just claimed. Whatever name that
+                    # call carried was inherited from the split, not a fragment
+                    # this one continues.
+                    named["function"]["name"] = name_fragment
+                elif name_fragment.startswith(accumulated):
                     named["function"]["name"] = name_fragment
                 else:
                     named["function"]["name"] = accumulated + name_fragment
@@ -731,12 +746,15 @@ class _Turn:
             streamed.add(call["card_id"])
 
     def _unclaimed_key(self, index: int) -> Any:
-        """First call at ``index`` that no id and no name has claimed yet."""
+        """First call at ``index`` no provider id has claimed yet.
+
+        Not "and no name": a split hands its own name down to every segment, so
+        a named segment can still be waiting for the id that belongs to it.
+        """
         for key in self.order:
             if (key[0] if isinstance(key, tuple) else key) != index:
                 continue
-            call = self.by_index[key]
-            if not call.get("id") and not call["function"]["name"]:
+            if not self.by_index[key].get("id"):
                 return key
         return None
 
@@ -1291,6 +1309,28 @@ async def stream_with_studio_tools(
             if (truncated or tool_choice == "none")
             else turn.calls(used_call_ids, streamed_call_ids)
         )
+        # Close cards for unfinished split calls that will not run. A truncated
+        # turn closes every card of its own further up, so only this path is left.
+        if not truncated and tool_choice != "none":
+            for withheld_call in turn.withheld():
+                withheld_id = withheld_call.get("card_id")
+                withheld_function = withheld_call.get("function")
+                withheld_name = (
+                    withheld_function.get("name") if isinstance(withheld_function, dict) else ""
+                )
+                if not isinstance(withheld_id, str) or not withheld_id:
+                    continue
+                if not isinstance(withheld_name, str):
+                    withheld_name = ""
+                for card_line in _unrun_call_card(
+                    tool_name = withheld_name,
+                    tool_call_id = withheld_id,
+                    # Cut off mid-write, so there is nothing well formed to show.
+                    arguments = {},
+                    result = _TOOL_UNFINISHED,
+                    provenance = _unrun_provenance(withheld_name, round_id + 1),
+                ):
+                    yield card_line
         if not calls:
             # No tool this turn. A model that only said what it was about to do
             # gets one nudge to actually do it, the same recovery the local loops
@@ -1369,26 +1409,6 @@ async def stream_with_studio_tools(
             break
 
         round_id += 1
-        # Close cards for unfinished split calls that will not run.
-        for withheld_call in turn.withheld():
-            withheld_id = withheld_call.get("card_id")
-            withheld_function = withheld_call.get("function")
-            withheld_name = (
-                withheld_function.get("name") if isinstance(withheld_function, dict) else ""
-            )
-            if not isinstance(withheld_id, str) or not withheld_id:
-                continue
-            if not isinstance(withheld_name, str):
-                withheld_name = ""
-            for card_line in _unrun_call_card(
-                tool_name = withheld_name,
-                tool_call_id = withheld_id,
-                # Cut off mid-write, so there is nothing well formed to show.
-                arguments = {},
-                result = _TOOL_UNFINISHED,
-                provenance = _unrun_provenance(withheld_name, round_id),
-            ):
-                yield card_line
         assistant_tool_calls: list[dict[str, Any]] = []
         tool_messages: list[dict[str, Any]] = []
         noop_messages: list[dict[str, Any]] = []

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -275,10 +275,7 @@ def _normalized_call(call: dict[str, Any], fallback_id: str = "") -> dict[str, A
 
 
 class _ArgumentBoundaries:
-    """Find adjacent JSON documents without rescanning prior fragments.
-
-    Malformed arguments are left whole rather than split into more bad calls.
-    """
+    """Find adjacent JSON documents incrementally, leaving malformed input whole."""
 
     __slots__ = ("depth", "in_string", "escaped", "start", "closed", "invalid", "scanned")
 
@@ -635,9 +632,7 @@ class _Turn:
                 # leave several waiting: the name belongs to one of those.
                 and current["function"]["name"]
                 and self._unnamed_key(index) is None
-                # A whole name resent as it grows is the same call, read exactly
-                # the way the merge below reads it. A second call on that tool
-                # arrives with its own arguments and splits at their boundary.
+                # A resent growing name stays on the current call.
                 and not name_fragment.startswith(current["function"]["name"])
                 and scan.holds_one_complete_document()
             ):
@@ -680,9 +675,7 @@ class _Turn:
                 # Apply per-call metadata after splitting so it follows the new call.
                 current["extra_content"] = {**current.get("extra_content", {}), **extra}
             if name_fragment:
-                # Arguments can arrive before their names, and a split then leaves
-                # several calls here unnamed. The newest slot is the last of them,
-                # so route the name to the first one still waiting instead.
+                # Route late names to the first unnamed split call.
                 named = current
                 if not (isinstance(call_id, str) and call_id):
                     waiting = self._unnamed_key(index)
@@ -1276,10 +1269,7 @@ async def stream_with_studio_tools(
                 last_reprompt_text = visible_answer
                 stalled_hosted = turn.hosted_replay_text()
                 if stalled_hosted:
-                    # A hosted tool did run, the model just did not go on to ask
-                    # for a local one. The replay below never happens on this
-                    # path, so the reprompted request would be told to continue
-                    # from output it can no longer see.
+                    # Preserve hosted output for the reprompt.
                     stalled_message: dict[str, Any] = {
                         "role": "assistant",
                         "content": (
@@ -1306,11 +1296,7 @@ async def stream_with_studio_tools(
             break
 
         round_id += 1
-        # A call this loop split off and will not run was still relayed to the
-        # client as part of the provider's own delta, so a card is already open
-        # for it. Close it the way every other unrun call is closed: nothing
-        # else ever names it again, and a client left to notice that on its own
-        # has to guess at the provider turn boundary to do it.
+        # Close cards for unfinished split calls that will not run.
         for withheld_call in turn.withheld():
             withheld_id = withheld_call.get("card_id")
             withheld_function = withheld_call.get("function")

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -633,9 +633,10 @@ class _Turn:
                 and not (isinstance(call_id, str) and call_id)
                 # An unnamed call claims the next name itself.
                 and current["function"]["name"]
-                # A resent whole name is the same call; a second call with that
-                # name arrives with its own arguments and splits there.
-                and name_fragment != current["function"]["name"]
+                # A whole name resent as it grows is the same call, read exactly
+                # the way the merge below reads it. A second call on that tool
+                # arrives with its own arguments and splits at their boundary.
+                and not name_fragment.startswith(current["function"]["name"])
                 and scan.holds_one_complete_document()
             ):
                 # A name after a finished named call opens the next call.

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -104,6 +104,11 @@ _TOOL_TRUNCATED = (
     "output limit."
 )
 
+_TOOL_UNFINISHED = (
+    "Unsloth did not execute this tool call because the provider never finished writing its "
+    "arguments."
+)
+
 # Card text for a call the controller skipped. The client already painted a card
 # from the provider's own tool_calls delta, so it needs a short result; the long
 # model-facing nudge stays in the conversation.
@@ -702,6 +707,15 @@ class _Turn:
             call["card_id"] = _mint_streamed_tool_call_id(streamed, index)
             streamed.add(call["card_id"])
 
+    def withheld(self) -> list[dict[str, Any]]:
+        """Split calls whose own document never closed, so ``calls`` drops them."""
+        return [
+            self.by_index[key]
+            for key in self.order
+            if key in self.split_keys
+            and self.boundaries.get(key, _EMPTY_BOUNDARIES).is_open()
+        ]
+
     def calls(
         self,
         taken: set[str] | None = None,
@@ -1273,6 +1287,30 @@ async def stream_with_studio_tools(
             break
 
         round_id += 1
+        # A call this loop split off and will not run was still relayed to the
+        # client as part of the provider's own delta, so a card is already open
+        # for it. Close it the way every other unrun call is closed: nothing
+        # else ever names it again, and a client left to notice that on its own
+        # has to guess at the provider turn boundary to do it.
+        for withheld_call in turn.withheld():
+            withheld_id = withheld_call.get("card_id")
+            withheld_function = withheld_call.get("function")
+            withheld_name = (
+                withheld_function.get("name") if isinstance(withheld_function, dict) else ""
+            )
+            if not isinstance(withheld_id, str) or not withheld_id:
+                continue
+            if not isinstance(withheld_name, str):
+                withheld_name = ""
+            for card_line in _unrun_call_card(
+                tool_name = withheld_name,
+                tool_call_id = withheld_id,
+                # Cut off mid-write, so there is nothing well formed to show.
+                arguments = {},
+                result = _TOOL_UNFINISHED,
+                provenance = _unrun_provenance(withheld_name, round_id),
+            ):
+                yield card_line
         assistant_tool_calls: list[dict[str, Any]] = []
         tool_messages: list[dict[str, Any]] = []
         noop_messages: list[dict[str, Any]] = []

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -631,8 +631,10 @@ class _Turn:
             elif (
                 name_fragment
                 and not (isinstance(call_id, str) and call_id)
-                # An unnamed call claims the next name itself.
+                # An unnamed call claims the next name itself, and a split can
+                # leave several waiting: the name belongs to one of those.
                 and current["function"]["name"]
+                and self._unnamed_key(index) is None
                 # A whole name resent as it grows is the same call, read exactly
                 # the way the merge below reads it. A second call on that tool
                 # arrives with its own arguments and splits at their boundary.
@@ -678,6 +680,14 @@ class _Turn:
                 # Apply per-call metadata after splitting so it follows the new call.
                 current["extra_content"] = {**current.get("extra_content", {}), **extra}
             if name_fragment:
+                # Arguments can arrive before their names, and a split then leaves
+                # several calls here unnamed. The newest slot is the last of them,
+                # so route the name to the first one still waiting instead.
+                named = current
+                if not (isinstance(call_id, str) and call_id):
+                    waiting = self._unnamed_key(index)
+                    if waiting is not None:
+                        named = self.by_index[waiting]
                 # Two provider dialects, and picking either one alone breaks the
                 # other. llama-server re-sends the whole name as it grows ("web"
                 # then "web_search"), so appending yields "webweb_search".
@@ -686,11 +696,11 @@ class _Turn:
                 # check and the call silently never runs. A fragment that already
                 # starts with what we have is the whole name resent; anything
                 # else continues it.
-                accumulated = current["function"]["name"]
+                accumulated = named["function"]["name"]
                 if name_fragment.startswith(accumulated):
-                    current["function"]["name"] = name_fragment
+                    named["function"]["name"] = name_fragment
                 else:
-                    current["function"]["name"] = accumulated + name_fragment
+                    named["function"]["name"] = accumulated + name_fragment
             if argument_fragment is not None:
                 current["function"]["arguments"] += argument_fragment
 
@@ -707,6 +717,15 @@ class _Turn:
             index = key[0] if isinstance(key, tuple) else key
             call["card_id"] = _mint_streamed_tool_call_id(streamed, index)
             streamed.add(call["card_id"])
+
+    def _unnamed_key(self, index: int) -> Any:
+        """First call at ``index`` still waiting for a name, or None."""
+        for key in self.order:
+            if (key[0] if isinstance(key, tuple) else key) != index:
+                continue
+            if not self.by_index[key]["function"]["name"]:
+                return key
+        return None
 
     def withheld(self) -> list[dict[str, Any]]:
         """Split calls whose own document never closed, so ``calls`` drops them."""

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -106,8 +106,7 @@ _TOOL_TRUNCATED = (
 )
 
 _TOOL_UNFINISHED = (
-    "Unsloth did not execute this tool call because the provider never finished writing its "
-    "arguments."
+    "Unsloth did not execute this tool call because the provider never finished writing it."
 )
 
 # Card text for a call the controller skipped. The client already painted a card
@@ -340,6 +339,15 @@ class _ArgumentBoundaries:
     def is_open(self) -> bool:
         """Whether a document has begun here and has not finished."""
         return self.depth > 0
+
+    def unfinished(self) -> bool:
+        """Whether this scan never turned into a valid document.
+
+        The boundary is recorded when the next ``{`` arrives, before that
+        document has parsed, so a split can already be permanent by the time a
+        later fragment closes it into something that does not parse.
+        """
+        return self.depth > 0 or self.invalid
 
     def rebase(self) -> None:
         """Reset offsets after moving the scan to a split call."""
@@ -584,7 +592,17 @@ class _Turn:
                     # back to it: an id beats the latest-index mapping, which only
                     # exists to place the fragments that carry no id.
                     first_id = self.by_index.get(index, {}).get("id")
-                    key = index if first_id == call_id else (index, call_id)
+                    if first_id == call_id:
+                        key = index
+                    else:
+                        # A split can leave calls waiting for an identity; the id
+                        # claims the first of those before opening a new call.
+                        waiting = self._unclaimed_key(index)
+                        key = waiting if waiting is not None else (index, call_id)
+                elif not open_id:
+                    waiting = self._unclaimed_key(index)
+                    if waiting is not None:
+                        key = waiting
             self.last_index = index
             self.open_key_by_index[index] = key
             if key not in self.by_index:
@@ -712,6 +730,16 @@ class _Turn:
             call["card_id"] = _mint_streamed_tool_call_id(streamed, index)
             streamed.add(call["card_id"])
 
+    def _unclaimed_key(self, index: int) -> Any:
+        """First call at ``index`` that no id and no name has claimed yet."""
+        for key in self.order:
+            if (key[0] if isinstance(key, tuple) else key) != index:
+                continue
+            call = self.by_index[key]
+            if not call.get("id") and not call["function"]["name"]:
+                return key
+        return None
+
     def _unnamed_key(self, index: int) -> Any:
         """First call at ``index`` still waiting for a name, or None."""
         for key in self.order:
@@ -721,13 +749,19 @@ class _Turn:
                 return key
         return None
 
+    def _withheld_split(self, key: Any) -> bool:
+        """A split call this turn will not run: never finished, or never named."""
+        if key not in self.split_keys:
+            return False
+        if self.boundaries.get(key, _EMPTY_BOUNDARIES).unfinished():
+            return True
+        # A provider can send fewer names than documents, and _normalized_call
+        # drops a nameless call, so its card would never be closed either.
+        return not self.by_index[key]["function"]["name"]
+
     def withheld(self) -> list[dict[str, Any]]:
-        """Split calls whose own document never closed, so ``calls`` drops them."""
-        return [
-            self.by_index[key]
-            for key in self.order
-            if key in self.split_keys and self.boundaries.get(key, _EMPTY_BOUNDARIES).is_open()
-        ]
+        """Split calls ``calls`` drops, so the loop can close the cards for them."""
+        return [self.by_index[key] for key in self.order if self._withheld_split(key)]
 
     def calls(
         self,
@@ -750,7 +784,7 @@ class _Turn:
             (key, self.by_index[key]) for key in self.order
         ] + [(None, call) for call in self.healed]
         for position, (key, call) in enumerate(ordered):
-            if key in self.split_keys and self.boundaries.get(key, _EMPTY_BOUNDARIES).is_open():
+            if self._withheld_split(key):
                 # Provider-opened malformed calls retain the existing coercion path.
                 continue
             normalized = _normalized_call(call, fallback_id = f"call_{self.round}_{position}")

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -269,6 +269,95 @@ def _normalized_call(call: dict[str, Any], fallback_id: str = "") -> dict[str, A
     return normalized
 
 
+class _ArgumentBoundaries:
+    """Find adjacent JSON documents without rescanning prior fragments.
+
+    Malformed arguments are left whole rather than split into more bad calls.
+    """
+
+    __slots__ = ("depth", "in_string", "escaped", "start", "closed", "invalid", "scanned")
+
+    def __init__(self) -> None:
+        self.depth = 0
+        self.in_string = False
+        self.escaped = False
+        self.start = -1
+        self.closed = False
+        self.invalid = False
+        # Exposed for deterministic complexity tests.
+        self.scanned = 0
+
+    def feed(self, text: str, position: int) -> list[int]:
+        """Offsets in ``text`` at or after ``position`` that open another call."""
+        if self.invalid:
+            return []
+        boundaries: list[int] = []
+        for index in range(position, len(text)):
+            self.scanned += 1
+            character = text[index]
+            if self.in_string:
+                if self.escaped:
+                    self.escaped = False
+                elif character == "\\":
+                    self.escaped = True
+                elif character == '"':
+                    self.in_string = False
+                continue
+            if self.depth == 0:
+                if character.isspace():
+                    continue
+                if character not in "{[":
+                    self.invalid = True
+                    return []
+                if self.closed:
+                    boundaries.append(index)
+                    self.closed = False
+                self.start = index
+                self.depth = 1
+                continue
+            if character == '"':
+                self.in_string = True
+            elif character in "{[":
+                self.depth += 1
+            elif character in "}]":
+                self.depth -= 1
+                if self.depth == 0:
+                    try:
+                        # Parsing also rejects mismatched delimiters.
+                        json.loads(text[self.start : index + 1])
+                    except (TypeError, ValueError, RecursionError):
+                        self.invalid = True
+                        return []
+                    self.closed = True
+        return boundaries
+
+    def holds_one_complete_document(self) -> bool:
+        return self.closed and self.depth == 0 and not self.invalid
+
+    def is_open(self) -> bool:
+        """Whether a document has begun here and has not finished."""
+        return self.depth > 0
+
+    def rebase(self) -> None:
+        """Reset offsets after moving the scan to a split call."""
+        self.start = 0
+
+
+_EMPTY_BOUNDARIES = _ArgumentBoundaries()
+
+
+def _mint_streamed_tool_call_id(taken: set[str], index: Any) -> str:
+    """Mirror the frontend's ``tool_call_<n>`` minting."""
+    if isinstance(index, int) and not isinstance(index, bool):
+        preferred = f"tool_call_{index}"
+        if preferred not in taken:
+            return preferred
+    next_free = 0
+    while f"tool_call_{next_free}" in taken:
+        next_free += 1
+    return f"tool_call_{next_free}"
+
+
 def _delta_text(content: Any) -> str:
     """Text of a content delta, whether it is a plain string or content parts.
 
@@ -360,6 +449,10 @@ class _Turn:
     # call key each delta index maps to: the index itself until a second call
     # forks off it, then (index, call_id).
     open_key_by_index: dict[int, Any] = field(default_factory = dict)
+    # Live JSON-boundary scan per call, so the arguments are read once per turn.
+    boundaries: dict[Any, "_ArgumentBoundaries"] = field(default_factory = dict)
+    # Only split calls are withheld when their JSON is unfinished.
+    split_keys: set[Any] = field(default_factory = set)
     last_index: int | None = None
     round: int = 0
     healed: list[dict[str, Any]] = field(default_factory = list)
@@ -503,14 +596,81 @@ class _Turn:
             current = self.by_index[key]
             if isinstance(call_id, str) and call_id:
                 current["id"] = call_id
+            function = raw_call.get("function")
+            name_fragment = function.get("name") if isinstance(function, dict) else None
+            if not isinstance(name_fragment, str):
+                name_fragment = None
+            argument_fragment = (
+                function.get("arguments") if isinstance(function, dict) else None
+            )
+            if not isinstance(argument_fragment, str):
+                argument_fragment = None
+
+            scan = self.boundaries.get(key)
+            if scan is None:
+                scan = _ArgumentBoundaries()
+                self.boundaries[key] = scan
+
+            # Id-less calls sharing an index are separated at JSON boundaries.
+            # Scan every stream so a late id does not invalidate the state.
+            segments: list[str] = []
+            split_carries_the_scan = False
+            if argument_fragment:
+                position = len(current["function"]["arguments"])
+                current["function"]["arguments"] += argument_fragment
+                argument_fragment = None
+                buffer = current["function"]["arguments"]
+                cuts = scan.feed(buffer, position)
+                if cuts and not (isinstance(call_id, str) and call_id):
+                    edges = [0, *cuts, len(buffer)]
+                    segments = [buffer[a:b] for a, b in zip(edges, edges[1:])]
+                    split_carries_the_scan = True
+            elif (
+                name_fragment
+                and not (isinstance(call_id, str) and call_id)
+                # An unnamed call claims the next name itself.
+                and current["function"]["name"]
+                and scan.holds_one_complete_document()
+            ):
+                # A name after a finished named call opens the next call.
+                segments = [current["function"]["arguments"], ""]
+
+            if segments:
+                # Segment 0 stays on the current call and must not remain nameless.
+                if name_fragment and not current["function"]["name"]:
+                    current["function"]["name"] = name_fragment
+                inherited = current["function"]["name"]
+                current["function"]["arguments"] = segments[0]
+                closed = _ArgumentBoundaries()
+                closed.closed = True
+                self.boundaries[key] = closed
+                for segment in segments[1:]:
+                    key = (index, "split", len(self.order))
+                    self.by_index[key] = {
+                        "id": "",
+                        "type": "function",
+                        "function": {
+                            "name": name_fragment or inherited,
+                            "arguments": segment,
+                        },
+                    }
+                    self.order.append(key)
+                    self.split_keys.add(key)
+                    self.open_key_by_index[index] = key
+                    current = self.by_index[key]
+                # Only the final segment can still be open.
+                if split_carries_the_scan:
+                    scan.rebase()
+                    self.boundaries[key] = scan
+                else:
+                    self.boundaries[key] = _ArgumentBoundaries()
+                argument_fragment = None
+
             extra = raw_call.get("extra_content")
             if isinstance(extra, dict) and extra:
-                # Gemini 3 stows this call's thoughtSignature here, and the
-                # native translator rejects a replayed functionCall without it.
-                # Per call, so it cannot ride along on the delta-level slot.
+                # Apply per-call metadata after splitting so it follows the new call.
                 current["extra_content"] = {**current.get("extra_content", {}), **extra}
-            function = raw_call.get("function")
-            if isinstance(function, dict):
+            if name_fragment:
                 # Two provider dialects, and picking either one alone breaks the
                 # other. llama-server re-sends the whole name as it grows ("web"
                 # then "web_search"), so appending yields "webweb_search".
@@ -519,32 +679,59 @@ class _Turn:
                 # check and the call silently never runs. A fragment that already
                 # starts with what we have is the whole name resent; anything
                 # else continues it.
-                fragment = function.get("name")
-                if isinstance(fragment, str) and fragment:
-                    accumulated = current["function"]["name"]
-                    if fragment.startswith(accumulated):
-                        current["function"]["name"] = fragment
-                    else:
-                        current["function"]["name"] = accumulated + fragment
-                if isinstance(function.get("arguments"), str):
-                    current["function"]["arguments"] += function["arguments"]
+                accumulated = current["function"]["name"]
+                if name_fragment.startswith(accumulated):
+                    current["function"]["name"] = name_fragment
+                else:
+                    current["function"]["name"] = accumulated + name_fragment
+            if argument_fragment is not None:
+                current["function"]["arguments"] += argument_fragment
 
-    def calls(self, taken: set[str] | None = None) -> list[dict[str, Any]]:
+    def assign_card_ids(self, streamed: set[str]) -> None:
+        """Assign frontend card ids, including for truncated turns."""
+        for key in self.order:
+            call = self.by_index[key]
+            if call.get("card_id"):
+                continue
+            raw_id = call.get("id")
+            if isinstance(raw_id, str) and raw_id:
+                streamed.add(raw_id)
+                continue
+            index = key[0] if isinstance(key, tuple) else key
+            call["card_id"] = _mint_streamed_tool_call_id(streamed, index)
+            streamed.add(call["card_id"])
+
+    def calls(
+        self,
+        taken: set[str] | None = None,
+        streamed: set[str] | None = None,
+    ) -> list[dict[str, Any]]:
         """Every call this turn produced, with ids unique across the whole run.
 
         ``taken`` carries the ids already used by earlier turns. A provider that
         restarts its numbering each turn, and the healer (which always mints
         call_0 first), would otherwise put two different results under one id in
         the conversation replayed upstream.
+
+        ``streamed`` reserves card ids across every round of this response.
         """
         seen: set[str] = taken if taken is not None else set()
+        self.assign_card_ids(streamed if streamed is not None else set())
         out: list[dict[str, Any]] = []
-        for position, call in enumerate(
-            [self.by_index[key] for key in self.order] + list(self.healed)
-        ):
+        ordered: list[tuple[Any, dict[str, Any]]] = [
+            (key, self.by_index[key]) for key in self.order
+        ] + [(None, call) for call in self.healed]
+        for position, (key, call) in enumerate(ordered):
+            if key in self.split_keys and self.boundaries.get(key, _EMPTY_BOUNDARIES).is_open():
+                # Provider-opened malformed calls retain the existing coercion path.
+                continue
             normalized = _normalized_call(call, fallback_id = f"call_{self.round}_{position}")
             if normalized is None:
                 continue
+            # Conversation ids are global; card ids restart with each response.
+            card_id = call.get("card_id")
+            if card_id:
+                normalized["card_id"] = card_id
             if normalized["id"] in seen:
                 # The client keyed the card it painted on the id the provider
                 # streamed, so keep that one for the events aimed at the card.
@@ -814,6 +1001,8 @@ async def stream_with_studio_tools(
     last_reprompt_text = ""
     provider_turns = 0
     used_call_ids: set[str] = _replayed_call_ids(conversation)
+    # Card ids span every provider round in this response.
+    streamed_call_ids: set[str] = set()
     spent_budget_passes = 0
     fruitless_turns = 0
     # One provider call per possible execution, plus headroom for the no-op,
@@ -1005,14 +1194,10 @@ async def stream_with_studio_tools(
                 turn.text.append(span)
                 yield _sse({"choices": [{"index": 0, "delta": {"content": span}}]})
         if truncated:
-            # The other half of the same problem. A call the provider streamed as
-            # a tool_calls delta was relayed as it arrived, so the client already
-            # has a card for it, and refusing to run it leaves that card open for
-            # the rest of the response. Close it the way every other unrun call
-            # is closed. Structured only: a healed call was never streamed, and
-            # the span released just above is what tells the user about that one.
+            # Structured calls already painted cards, so close them without running.
+            turn.assign_card_ids(streamed_call_ids)
             for raw_call in turn.by_index.values():
-                truncated_id = raw_call.get("id")
+                truncated_id = raw_call.get("card_id") or raw_call.get("id")
                 function = raw_call.get("function")
                 name = function.get("name") if isinstance(function, dict) else None
                 if not isinstance(truncated_id, str) or not truncated_id:
@@ -1024,8 +1209,6 @@ async def stream_with_studio_tools(
                 for card_line in _unrun_call_card(
                     tool_name = name,
                     tool_call_id = truncated_id,
-                    # The arguments are cut off mid-write, so there is nothing
-                    # well formed to show; the result says what happened.
                     arguments = {},
                     result = _TOOL_TRUNCATED,
                     provenance = _unrun_provenance(name, round_id + 1),
@@ -1037,7 +1220,11 @@ async def stream_with_studio_tools(
         # so the scraped web text in its prompts cannot reach python or terminal,
         # so a naive or compromised endpoint echoing a call back must not be able
         # to execute it here.
-        calls = [] if (truncated or tool_choice == "none") else turn.calls(used_call_ids)
+        calls = (
+            []
+            if (truncated or tool_choice == "none")
+            else turn.calls(used_call_ids, streamed_call_ids)
+        )
         if not calls:
             # No tool this turn. A model that only said what it was about to do
             # gets one nudge to actually do it, the same recovery the local loops
@@ -1098,7 +1285,9 @@ async def stream_with_studio_tools(
                 # execute: the cap is a safety limit, not a hint to the provider.
                 for card_line in _unrun_call_card(
                     tool_name = call["function"]["name"],
-                    tool_call_id = call.get("stream_id") or call["id"],
+                    tool_call_id = (
+                        call.get("card_id") or call.get("stream_id") or call["id"]
+                    ),
                     arguments = call.get("arguments"),
                     result = _TOOL_BUDGET_EXHAUSTED,
                     provenance = _unrun_provenance(call["function"]["name"], round_id),
@@ -1153,7 +1342,9 @@ async def stream_with_studio_tools(
                     continue
                 for card_line in _unrun_call_card(
                     tool_name = decision.tool_name,
-                    tool_call_id = call.get("stream_id") or decision.tool_call_id,
+                    tool_call_id = (
+                        call.get("card_id") or call.get("stream_id") or decision.tool_call_id
+                    ),
                     arguments = decision.arguments,
                     result = _TOOL_SKIPPED.get(decision.action, "Unsloth did not run this call."),
                     provenance = decision.provenance,
@@ -1170,7 +1361,8 @@ async def stream_with_studio_tools(
 
             name = decision.tool_name
             arguments = decision.arguments
-            call_id = decision.tool_call_id
+            # Visible events use the response-scoped card id.
+            call_id = decision.card_call_id
             needs_confirmation = (
                 confirm_tool_calls and not bypass_permissions and permission_mode != "off"
             )
@@ -1240,8 +1432,10 @@ async def stream_with_studio_tools(
                     "name": name,
                     "content": TOOL_REJECTED_MESSAGE,
                 }
-                if call_id:
-                    denied_message["tool_call_id"] = call_id
+                # Replayed upstream, so it pairs with the assistant call by the
+                # conversation identity rather than by the card's.
+                if decision.tool_call_id:
+                    denied_message["tool_call_id"] = decision.tool_call_id
                 tool_messages.append(denied_message)
                 # A denial is an answer, not a stall: never nudge after one.
                 reprompts = max_reprompts

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -600,9 +600,7 @@ class _Turn:
             name_fragment = function.get("name") if isinstance(function, dict) else None
             if not isinstance(name_fragment, str):
                 name_fragment = None
-            argument_fragment = (
-                function.get("arguments") if isinstance(function, dict) else None
-            )
+            argument_fragment = function.get("arguments") if isinstance(function, dict) else None
             if not isinstance(argument_fragment, str):
                 argument_fragment = None
 
@@ -1285,9 +1283,7 @@ async def stream_with_studio_tools(
                 # execute: the cap is a safety limit, not a hint to the provider.
                 for card_line in _unrun_call_card(
                     tool_name = call["function"]["name"],
-                    tool_call_id = (
-                        call.get("card_id") or call.get("stream_id") or call["id"]
-                    ),
+                    tool_call_id = (call.get("card_id") or call.get("stream_id") or call["id"]),
                     arguments = call.get("arguments"),
                     result = _TOOL_BUDGET_EXHAUSTED,
                     provenance = _unrun_provenance(call["function"]["name"], round_id),

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -628,6 +628,9 @@ class _Turn:
                 and not (isinstance(call_id, str) and call_id)
                 # An unnamed call claims the next name itself.
                 and current["function"]["name"]
+                # A resent whole name is the same call; a second call with that
+                # name arrives with its own arguments and splits there.
+                and name_fragment != current["function"]["name"]
                 and scan.holds_one_complete_document()
             ):
                 # A name after a finished named call opens the next call.

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -190,10 +190,17 @@ class ToolCallDecision:
     tool_name: str
     arguments: dict[str, Any]
     tool_call_id: str = ""
+    # Response-scoped card id for a provider call that had no id.
+    stream_call_id: str = ""
     key: str = ""
     provenance: dict[str, Any] = field(default_factory = dict)
     status_text: str = ""
     noop_result: str = ""
+
+    @property
+    def card_call_id(self) -> str:
+        """The id every client-visible event for this call must carry."""
+        return self.stream_call_id or self.tool_call_id
 
     @property
     def should_execute(self) -> bool:
@@ -232,7 +239,7 @@ class ToolCallDecision:
         arguments = {"raw": fragment} if fragment is not None else self.arguments
         return {
             "tool_name": self.tool_name,
-            "tool_call_id": self.tool_call_id,
+            "tool_call_id": self.card_call_id,
             "arguments": arguments,
             "provenance": self.provenance,
         }
@@ -282,7 +289,7 @@ class ToolCallCompletion:
         """Build the payload fields for a real tool_end event."""
         return {
             "tool_name": self.decision.tool_name,
-            "tool_call_id": self.decision.tool_call_id,
+            "tool_call_id": self.decision.card_call_id,
             "result": self.result,
             "provenance": self.decision.provenance,
         }
@@ -723,6 +730,7 @@ class ToolLoopController:
             tool_name = tool_name,
             arguments = coerced.arguments,
             tool_call_id = str(tool_call.get("id") or ""),
+            stream_call_id = str(tool_call.get("card_id") or ""),
             key = key,
             provenance = provenance,
             status_text = status_for_tool(tool_name, coerced.arguments),

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1375,6 +1375,30 @@ def test_a_name_resent_after_its_arguments_closed_is_not_a_second_call(executed)
     ]
 
 
+def test_a_growing_name_after_early_arguments_still_names_one_call(executed):
+    """Arguments ahead of the name, then the whole name resent as it grows."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {"tool_calls": [{"index": 0, "function": {"arguments": '{"query":"first"}'}}]}
+                ),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web"}}]}),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web_search"}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "first"})
+    ]
+
+
 def test_a_second_call_with_the_same_name_still_splits_on_its_arguments(executed):
     """The resend guard does not merge two real calls on one tool."""
     transport = FakeTransport(

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1301,11 +1301,7 @@ def test_an_id_less_name_opens_the_next_call_once_the_slot_closed(executed):
                 ),
                 _sse({"tool_calls": [{"index": 0, "function": {"name": "web_fetch"}}]}),
                 _sse(
-                    {
-                        "tool_calls": [
-                            {"index": 0, "function": {"arguments": '{"query":"second"}'}}
-                        ]
-                    }
+                    {"tool_calls": [{"index": 0, "function": {"arguments": '{"query":"second"}'}}]}
                 ),
                 _sse(finish = "tool_calls"),
                 _DONE,
@@ -1330,11 +1326,7 @@ def test_a_name_resent_as_it_grows_still_names_one_call(executed):
                 _sse({"tool_calls": [{"index": 0, "function": {"name": "web"}}]}),
                 _sse({"tool_calls": [{"index": 0, "function": {"name": "web_search"}}]}),
                 _sse(
-                    {
-                        "tool_calls": [
-                            {"index": 0, "function": {"arguments": '{"query":"first"}'}}
-                        ]
-                    }
+                    {"tool_calls": [{"index": 0, "function": {"arguments": '{"query":"first"}'}}]}
                 ),
                 _sse(finish = "tool_calls"),
                 _DONE,
@@ -1423,11 +1415,7 @@ def test_arguments_streamed_before_the_name_stay_with_their_call(executed):
         [
             [
                 _sse(
-                    {
-                        "tool_calls": [
-                            {"index": 0, "function": {"arguments": '{"query":"first"}'}}
-                        ]
-                    }
+                    {"tool_calls": [{"index": 0, "function": {"arguments": '{"query":"first"}'}}]}
                 ),
                 _sse({"tool_calls": [{"index": 0, "function": {"name": "web_search"}}]}),
                 _sse(finish = "tool_calls"),
@@ -1451,9 +1439,7 @@ def test_balanced_text_that_is_not_json_is_never_split(executed):
         [{"index": 0, "function": {"name": "web_search", "arguments": "{bad}{worse}"}}]
     )
 
-    assert [call["function"]["arguments"] for call in turn.by_index.values()] == [
-        "{bad}{worse}"
-    ]
+    assert [call["function"]["arguments"] for call in turn.by_index.values()] == ["{bad}{worse}"]
 
 
 def test_a_long_argument_is_read_once_not_once_per_fragment():
@@ -1461,13 +1447,9 @@ def test_a_long_argument_is_read_once_not_once_per_fragment():
     opening = '{"code":"'
     body = "x" * (64 * 1024)
     turn = loop_mod._Turn()
-    turn.merge_structured(
-        [{"index": 0, "function": {"name": "python", "arguments": opening}}]
-    )
+    turn.merge_structured([{"index": 0, "function": {"name": "python", "arguments": opening}}])
     for at in range(0, len(body), 1024):
-        turn.merge_structured(
-            [{"index": 0, "function": {"arguments": body[at : at + 1024]}}]
-        )
+        turn.merge_structured([{"index": 0, "function": {"arguments": body[at : at + 1024]}}])
 
     assert turn.boundaries[0].scanned == len(opening) + len(body)
 
@@ -1661,10 +1643,7 @@ def test_id_less_calls_address_their_events_to_the_painted_card(executed):
     )
     lines = _run(transport)
 
-    assert [call["arguments"] for call in executed] == [
-        {"query": "first"},
-        {"query": "second"},
-    ]
+    assert [call["arguments"] for call in executed] == [{"query": "first"}, {"query": "second"}]
     assert _event_ids(lines, "tool_start") == ["tool_call_0", "tool_call_1"]
     assert _event_ids(lines, "tool_end") == ["tool_call_0", "tool_call_1"]
 
@@ -1681,10 +1660,7 @@ def test_a_second_round_keeps_numbering_where_the_first_stopped(executed):
     )
     lines = _run(transport)
 
-    assert [call["arguments"] for call in executed] == [
-        {"query": "first"},
-        {"query": "second"},
-    ]
+    assert [call["arguments"] for call in executed] == [{"query": "first"}, {"query": "second"}]
     assert _event_ids(lines, "tool_start") == ["tool_call_0", "tool_call_1"]
     assert _event_ids(lines, "tool_end") == ["tool_call_0", "tool_call_1"]
 

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1669,9 +1669,7 @@ def test_a_late_id_claims_the_call_a_split_left_waiting(executed):
         [
             [
                 _sse({"tool_calls": [{"index": 0, "function": {"arguments": '{"a":1}{"b":2}'}}]}),
-                _sse(
-                    {"tool_calls": [{"index": 0, "id": "A", "function": {"name": "web_search"}}]}
-                ),
+                _sse({"tool_calls": [{"index": 0, "id": "A", "function": {"name": "web_search"}}]}),
                 _sse({"tool_calls": [{"index": 0, "id": "B", "function": {"name": "web_fetch"}}]}),
                 _sse(finish = "tool_calls"),
                 _DONE,

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1169,3 +1169,697 @@ def test_a_fragment_naming_its_call_goes_back_to_that_call(executed):
     _run(transport)
 
     assert [call["arguments"] for call in executed] == [{"query": "first"}, {"query": "second"}]
+
+
+FETCH = _tool("web_fetch")
+
+
+def test_id_less_parallel_calls_at_one_index_stay_separate(executed):
+    """Recover id-less parallel calls collapsed onto index 0 (#9807)."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_fetch",
+                                    "arguments": '{"query":"first"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"second"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_fetch",
+                                    "arguments": '{"query":"third"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport, tools = [WEB, FETCH])
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_fetch", {"query": "first"}),
+        ("web_search", {"query": "second"}),
+        ("web_fetch", {"query": "third"}),
+    ]
+
+
+def test_id_less_arguments_still_accumulate_across_fragments(executed):
+    """The boundary must not cut a call whose JSON is still being streamed."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": '"first"}'}}]}),
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_fetch",
+                                    "arguments": '{"query":"second"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport, tools = [WEB, FETCH])
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "first"}),
+        ("web_fetch", {"query": "second"}),
+    ]
+
+
+def test_an_id_less_name_opens_the_next_call_once_the_slot_closed(executed):
+    """A name after a completed call opens the next call."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"first"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web_fetch"}}]}),
+                _sse(
+                    {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '{"query":"second"}'}}
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport, tools = [WEB, FETCH])
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "first"}),
+        ("web_fetch", {"query": "second"}),
+    ]
+
+
+def test_a_name_resent_as_it_grows_still_names_one_call(executed):
+    """A resent growing name remains on one call."""
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web"}}]}),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web_search"}}]}),
+                _sse(
+                    {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '{"query":"first"}'}}
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "first"})
+    ]
+
+
+def test_one_fragment_holding_two_documents_is_two_named_calls(executed):
+    """Both calls split from one named fragment keep the name."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"first"}{"query":"second"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "first"}),
+        ("web_search", {"query": "second"}),
+    ]
+
+
+def test_a_complete_document_followed_by_an_open_one_keeps_both(executed):
+    """A split keeps both the completed call and its streamed tail."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"first"}{"query":',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": '"second"}'}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "first"}),
+        ("web_search", {"query": "second"}),
+    ]
+
+
+def test_arguments_streamed_before_the_name_stay_with_their_call(executed):
+    """A late name stays with its preceding arguments."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '{"query":"first"}'}}
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web_search"}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "first"})
+    ]
+
+
+def test_balanced_text_that_is_not_json_is_never_split(executed):
+    """Balanced malformed text remains one call."""
+    turn = loop_mod._Turn()
+    turn.merge_structured(
+        [{"index": 0, "function": {"name": "web_search", "arguments": "{bad}{worse}"}}]
+    )
+
+    assert [call["function"]["arguments"] for call in turn.by_index.values()] == [
+        "{bad}{worse}"
+    ]
+
+
+def test_a_long_argument_is_read_once_not_once_per_fragment():
+    """Count scanned characters instead of timing the implementation."""
+    opening = '{"code":"'
+    body = "x" * (64 * 1024)
+    turn = loop_mod._Turn()
+    turn.merge_structured(
+        [{"index": 0, "function": {"name": "python", "arguments": opening}}]
+    )
+    for at in range(0, len(body), 1024):
+        turn.merge_structured(
+            [{"index": 0, "function": {"arguments": body[at : at + 1024]}}]
+        )
+
+    assert turn.boundaries[0].scanned == len(opening) + len(body)
+
+
+def test_a_call_split_off_mid_document_keeps_accumulating(executed):
+    """A boundary scan follows the call split from its original slot."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"first"}{"query":',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": '"second"}'}}]}),
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"third"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [call["arguments"] for call in executed] == [
+        {"query": "first"},
+        {"query": "second"},
+        {"query": "third"},
+    ]
+
+
+def test_a_provider_that_stops_mid_document_does_not_run_the_tail(executed):
+    """Run the completed call but not its unfinished split tail."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"first"}{"query":',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [call["arguments"] for call in executed] == [{"query": "first"}]
+
+
+def test_id_less_calls_carry_the_card_id_the_client_painted(executed):
+    """Id-less calls use the card ids the client minted."""
+    turn = loop_mod._Turn()
+    for query in ("first", "second", "third"):
+        turn.merge_structured(
+            [
+                {
+                    "index": 0,
+                    "function": {"name": "web_search", "arguments": '{"query":"%s"}' % query},
+                }
+            ]
+        )
+
+    assert [call["card_id"] for call in turn.calls()] == [
+        "tool_call_0",
+        "tool_call_1",
+        "tool_call_2",
+    ]
+
+
+def test_parallel_indices_keep_the_client_s_per_index_card_id(executed):
+    """The client names the first call at an index ``tool_call_<index>``."""
+    turn = loop_mod._Turn()
+    turn.merge_structured(
+        [{"index": 1, "function": {"name": "web_search", "arguments": '{"query":"only"}'}}]
+    )
+
+    assert [call["card_id"] for call in turn.calls()] == ["tool_call_1"]
+
+
+def test_a_provider_id_still_owns_its_card(executed):
+    """A stream that carries ids is untouched: no card id is invented for it."""
+    turn = loop_mod._Turn()
+    turn.merge_structured(
+        [
+            {
+                "index": 0,
+                "id": "call_abc",
+                "function": {"name": "web_search", "arguments": '{"query":"only"}'},
+            }
+        ]
+    )
+
+    calls = turn.calls()
+    assert [call["id"] for call in calls] == ["call_abc"]
+    assert "card_id" not in calls[0]
+
+
+def test_a_lone_unfinished_call_the_provider_opened_itself_still_runs(executed):
+    """Only split calls are withheld for unfinished JSON."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": "{not json at all",
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [call["name"] for call in executed] == ["web_search"]
+
+
+def _id_less_call(query):
+    return _sse(
+        {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "function": {"name": "web_search", "arguments": '{"query":"%s"}' % query},
+                }
+            ]
+        }
+    )
+
+
+def _event_ids(lines, kind):
+    return [event.get("tool_call_id") for event in _events(lines, kind)]
+
+
+def test_id_less_calls_address_their_events_to_the_painted_card(executed):
+    """Execution events address the provisional id-less cards."""
+    transport = FakeTransport(
+        [
+            [
+                _id_less_call("first"),
+                _id_less_call("second"),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    assert [call["arguments"] for call in executed] == [
+        {"query": "first"},
+        {"query": "second"},
+    ]
+    assert _event_ids(lines, "tool_start") == ["tool_call_0", "tool_call_1"]
+    assert _event_ids(lines, "tool_end") == ["tool_call_0", "tool_call_1"]
+
+
+def test_a_second_round_keeps_numbering_where_the_first_stopped(executed):
+    """Card-id numbering spans every round of one response."""
+    transport = FakeTransport(
+        [
+            [_id_less_call("first"), _sse(finish = "tool_calls"), _DONE],
+            [_id_less_call("second"), _sse(finish = "tool_calls"), _DONE],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    assert [call["arguments"] for call in executed] == [
+        {"query": "first"},
+        {"query": "second"},
+    ]
+    assert _event_ids(lines, "tool_start") == ["tool_call_0", "tool_call_1"]
+    assert _event_ids(lines, "tool_end") == ["tool_call_0", "tool_call_1"]
+
+
+def test_the_replayed_call_and_its_result_pair_on_the_conversation_id(executed):
+    """Replay uses the conversation id while events use the card id."""
+    transport = FakeTransport(
+        [
+            [_id_less_call("first"), _sse(finish = "tool_calls"), _DONE],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    follow_up = transport.requests[1]["messages"]
+    assistant = follow_up[-2]
+    tool_result = follow_up[-1]
+    replayed = [entry["id"] for entry in assistant["tool_calls"]]
+    assert len(replayed) == 1
+    assert tool_result["tool_call_id"] == replayed[0]
+    assert _event_ids(lines, "tool_start") == ["tool_call_0"]
+
+
+def test_a_provider_that_sends_ids_keeps_addressing_events_to_them(executed):
+    """Nothing is renumbered for a stream that already identifies its calls."""
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [_call_delta(0, "call_a", "web_search", '{"query":"x"}')]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    assert _event_ids(lines, "tool_start") == ["call_a"]
+    assert _event_ids(lines, "tool_end") == ["call_a"]
+
+
+def test_a_new_response_addresses_cards_the_history_already_named(executed):
+    """Historical conversation ids do not rename new response cards."""
+    history = [
+        {"role": "user", "content": "first question"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "tool_call_0",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": '{"query":"old"}'},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "tool_call_0",
+            "name": "web_search",
+            "content": "old",
+        },
+        {"role": "user", "content": "second question"},
+    ]
+    transport = FakeTransport(
+        [
+            [_id_less_call("new"), _sse(finish = "tool_calls"), _DONE],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport, messages = history)
+
+    assert _event_ids(lines, "tool_start") == ["tool_call_0"]
+    assert _event_ids(lines, "tool_end") == ["tool_call_0"]
+    # The new replay id remains unique against history.
+    follow_up = transport.requests[-1]["messages"]
+    assistant = [m for m in follow_up if m.get("role") == "assistant" and m.get("tool_calls")][-1]
+    replayed = [entry["id"] for entry in assistant["tool_calls"]]
+    assert replayed != ["tool_call_0"]
+    assert [m for m in follow_up if m.get("role") == "tool"][-1]["tool_call_id"] == replayed[0]
+
+
+def test_a_provider_id_in_the_minted_namespace_is_not_handed_out_twice(executed):
+    """Provider ids are reserved from the card-id namespace."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            _call_delta(0, "tool_call_0", "web_search", '{"query":"named"}')
+                        ]
+                    }
+                ),
+                _id_less_call("recovered"),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    assert [call["arguments"] for call in executed] == [
+        {"query": "named"},
+        {"query": "recovered"},
+    ]
+    assert _event_ids(lines, "tool_start") == ["tool_call_0", "tool_call_1"]
+    assert _event_ids(lines, "tool_end") == ["tool_call_0", "tool_call_1"]
+
+
+def test_a_repeated_provider_id_still_reaches_two_separate_cards(executed):
+    """Repeated provider ids retain the existing distinct-event behavior."""
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [_call_delta(0, "dup", "web_search", '{"query":"a"}')]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [
+                _sse({"tool_calls": [_call_delta(0, "dup", "web_search", '{"query":"b"}')]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    ids = _event_ids(lines, "tool_start")
+    assert len(ids) == len(set(ids)) == 2, ids
+    assert ids[0] == "dup"
+
+
+def test_budget_exhaustion_closes_the_card_a_recovered_call_painted(executed):
+    """Budget exhaustion closes the recovered call's visible card."""
+    transport = FakeTransport(
+        [
+            [
+                _id_less_call("first"),
+                _id_less_call("second"),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport, max_calls = 1)
+
+    assert [call["arguments"] for call in executed] == [{"query": "first"}]
+    assert _event_ids(lines, "tool_end") == ["tool_call_0", "tool_call_1"]
+
+
+def test_a_truncated_turn_closes_the_cards_recovered_calls_painted(executed):
+    """Truncation closes visible cards for recovered calls."""
+    transport = FakeTransport(
+        [
+            [
+                _id_less_call("first"),
+                _id_less_call("second"),
+                _sse(finish = "length"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    assert executed == []
+    assert _event_ids(lines, "tool_end") == ["tool_call_0", "tool_call_1"]

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1399,6 +1399,29 @@ def test_a_growing_name_after_early_arguments_still_names_one_call(executed):
     ]
 
 
+def test_late_names_fill_the_calls_a_split_left_waiting(executed):
+    """Both documents arrive before either name, so both calls wait for one."""
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": '{"a":1}{"b":2}'}}]}),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web_search"}}]}),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web_fetch"}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport, tools = [WEB, FETCH])
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"a": 1}),
+        ("web_fetch", {"b": 2}),
+    ]
+
+
 def test_a_second_call_with_the_same_name_still_splits_on_its_arguments(executed):
     """The resend guard does not merge two real calls on one tool."""
     transport = FakeTransport(

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1647,10 +1647,7 @@ def test_a_provider_that_stops_mid_document_does_not_run_the_tail(executed):
     lines = _run(transport)
 
     assert [call["arguments"] for call in executed] == [{"query": "first"}]
-    # The tail was relayed inside the provider's own delta, so a card is open for
-    # it. Closing it here is what frees the client from guessing where the
-    # provider turn ended in order to stop feeding the next round into it. It is
-    # closed before the round runs, so a cancel or a spent budget cannot skip it.
+    # Close the unfinished tail before the completed call runs.
     assert _event_ids(lines, "tool_start") == ["tool_call_1", "tool_call_0"]
     assert _event_ids(lines, "tool_end") == ["tool_call_1", "tool_call_0"]
     assert any(loop_mod._TOOL_UNFINISHED in line for line in lines)

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1342,6 +1342,76 @@ def test_a_name_resent_as_it_grows_still_names_one_call(executed):
     ]
 
 
+def test_a_name_resent_after_its_arguments_closed_is_not_a_second_call(executed):
+    """A whole name resent after the arguments closed stays on the same call."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"first"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web_search"}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "first"})
+    ]
+
+
+def test_a_second_call_with_the_same_name_still_splits_on_its_arguments(executed):
+    """The resend guard does not merge two real calls on one tool."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"first"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web_search"}}]}),
+                _sse(
+                    {"tool_calls": [{"index": 0, "function": {"arguments": '{"query":"second"}'}}]}
+                ),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport)
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"query": "first"}),
+        ("web_search", {"query": "second"}),
+    ]
+
+
 def test_one_fragment_holding_two_documents_is_two_named_calls(executed):
     """Both calls split from one named fragment keep the name."""
     transport = FakeTransport(

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1597,9 +1597,16 @@ def test_a_provider_that_stops_mid_document_does_not_run_the_tail(executed):
         ],
         heals = False,
     )
-    _run(transport)
+    lines = _run(transport)
 
     assert [call["arguments"] for call in executed] == [{"query": "first"}]
+    # The tail was relayed inside the provider's own delta, so a card is open for
+    # it. Closing it here is what frees the client from guessing where the
+    # provider turn ended in order to stop feeding the next round into it. It is
+    # closed before the round runs, so a cancel or a spent budget cannot skip it.
+    assert _event_ids(lines, "tool_start") == ["tool_call_1", "tool_call_0"]
+    assert _event_ids(lines, "tool_end") == ["tool_call_1", "tool_call_0"]
+    assert any(loop_mod._TOOL_UNFINISHED in line for line in lines)
 
 
 def test_id_less_calls_carry_the_card_id_the_client_painted(executed):

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1613,6 +1613,81 @@ def test_a_growing_name_after_early_arguments_still_names_one_call(executed):
     ]
 
 
+def test_a_split_document_that_never_parses_is_not_run(executed):
+    """A boundary opens before its document parses, so the split can be wrong."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"name": "web_search", "arguments": '{"q":"ok"}{bad'},
+                            }
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": "}"}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    assert [call["arguments"] for call in executed] == [{"q": "ok"}]
+    assert any(loop_mod._TOOL_UNFINISHED in line for line in lines)
+
+
+def test_a_split_call_that_never_gets_a_name_closes_its_card(executed):
+    """Fewer names than documents leaves a card nothing else would close."""
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": '{"a":1}{"b":2}'}}]}),
+                _sse({"tool_calls": [{"index": 0, "function": {"name": "web_search"}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    assert [call["arguments"] for call in executed] == [{"a": 1}]
+    assert _event_ids(lines, "tool_start") == ["tool_call_1", "tool_call_0"]
+    assert _event_ids(lines, "tool_end") == ["tool_call_1", "tool_call_0"]
+
+
+def test_a_late_id_claims_the_call_a_split_left_waiting(executed):
+    """Documents ahead of both names and ids, then the ids arrive."""
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": '{"a":1}{"b":2}'}}]}),
+                _sse(
+                    {"tool_calls": [{"index": 0, "id": "A", "function": {"name": "web_search"}}]}
+                ),
+                _sse({"tool_calls": [{"index": 0, "id": "B", "function": {"name": "web_fetch"}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport, tools = [WEB, FETCH])
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"a": 1}),
+        ("web_fetch", {"b": 2}),
+    ]
+
+
 def test_late_names_fill_the_calls_a_split_left_waiting(executed):
     """Both documents arrive before either name, so both calls wait for one."""
     transport = FakeTransport(

--- a/studio/backend/tests/test_studio_tool_loop.py
+++ b/studio/backend/tests/test_studio_tool_loop.py
@@ -1686,6 +1686,58 @@ def test_a_late_id_claims_the_call_a_split_left_waiting(executed):
     ]
 
 
+def test_a_late_id_claims_a_split_call_that_inherited_a_name(executed):
+    """A split hands its name down, so only the missing id marks a call waiting."""
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"name": "web_search", "arguments": '{"a":1}{"b":2}'},
+                            }
+                        ]
+                    }
+                ),
+                _sse({"tool_calls": [{"index": 0, "id": "A", "function": {"name": "web_search"}}]}),
+                _sse({"tool_calls": [{"index": 0, "id": "B", "function": {"name": "web_fetch"}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    _run(transport, tools = [WEB, FETCH])
+
+    assert [(call["name"], call["arguments"]) for call in executed] == [
+        ("web_search", {"a": 1}),
+        ("web_fetch", {"b": 2}),
+    ]
+
+
+def test_a_turn_of_only_withheld_calls_still_closes_their_cards(executed):
+    """Every call withheld leaves the call list empty, and cards still open."""
+    transport = FakeTransport(
+        [
+            [
+                _sse({"tool_calls": [{"index": 0, "function": {"arguments": '{"a":1}{"b":2}'}}]}),
+                _sse(finish = "tool_calls"),
+                _DONE,
+            ],
+            [_sse({"content": "done"}), _sse(finish = "stop"), _DONE],
+        ],
+        heals = False,
+    )
+    lines = _run(transport)
+
+    assert executed == []
+    assert _event_ids(lines, "tool_start") == ["tool_call_0", "tool_call_1"]
+    assert _event_ids(lines, "tool_end") == ["tool_call_0", "tool_call_1"]
+
+
 def test_late_names_fill_the_calls_a_split_left_waiting(executed):
     """Both documents arrive before either name, so both calls wait for one."""
     transport = FakeTransport(

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -6962,10 +6962,15 @@ export function createOpenAIStreamAdapter(
                     stablePartId,
                     idx,
                   );
-                  const matched =
+                  const slotPart =
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
+                  // A card the backend already closed takes no more fragments:
+                  // the next delta in its slot is the next round's call, whatever
+                  // its scan was left holding after a malformed first round.
+                  const matched =
+                    slotPart?.result === undefined ? slotPart : undefined;
 
                   const argsFragment = call.function?.arguments ?? "";
                   const nameFragment = call.function?.name ?? "";
@@ -6994,6 +6999,9 @@ export function createOpenAIStreamAdapter(
                     !argsFragment &&
                     Boolean(nameFragment) &&
                     Boolean(matched?.toolName) &&
+                    // A resent whole name is the same call; a second call with
+                    // that name arrives with its own arguments and splits there.
+                    nameFragment !== matched?.toolName &&
                     scan.holdsOneCompleteDocument();
                   const existing = namedNextCall ? undefined : matched;
 
@@ -7041,7 +7049,11 @@ export function createOpenAIStreamAdapter(
                         argsText,
                         args: parseStreamedToolCallArgs(argsText),
                         textCursor: cumulativeText.length,
-                        ...(call.extra_content !== undefined
+                        // One signature belongs to one call. The backend puts it
+                        // on the last call the delta opened; replaying a copy on
+                        // each of them fails Gemini's signature validation.
+                        ...(call.extra_content !== undefined &&
+                        position === segments.length - 1
                           ? { extra_content: call.extra_content }
                           : {}),
                         ...(idx !== undefined ? { _delta_index: idx } : {}),

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -7000,9 +7000,10 @@ export function createOpenAIStreamAdapter(
                     !argsFragment &&
                     Boolean(nameFragment) &&
                     Boolean(matched?.toolName) &&
-                    // A resent whole name is the same call; a second call with
-                    // that name arrives with its own arguments and splits there.
-                    nameFragment !== matched?.toolName &&
+                    // A whole name resent as it grows is the same call. A second
+                    // call on that tool arrives with its own arguments and splits
+                    // at their boundary.
+                    !nameFragment.startsWith(matched?.toolName ?? "") &&
                     scan.holdsOneCompleteDocument();
                   const existing = namedNextCall ? undefined : matched;
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -111,6 +111,7 @@ import {
   ToolCallArgumentBoundaries,
   bindStreamedToolCallBackendId,
   findStreamedToolCallPartIndex,
+  findUnclaimedToolCallPartIndex,
   findUnnamedToolCallPartIndex,
   mintStreamedToolCallId,
   resolveToolCallPartId,
@@ -6958,11 +6959,23 @@ export function createOpenAIStreamAdapter(
                   // match by resolved id when the fragment carries one, else by
                   // index slot; streams that send neither get a minted
                   // tool_call_<n> id.
-                  const existingIndex = findStreamedToolCallPartIndex(
+                  let existingIndex = findStreamedToolCallPartIndex(
                     toolCallParts,
                     stablePartId,
                     idx,
                   );
+                  if (
+                    stablePartId &&
+                    existingIndex !== -1 &&
+                    toolCallParts[existingIndex].toolCallId !== stablePartId
+                  ) {
+                    // A late id claims the first call a split left waiting.
+                    const unclaimed = findUnclaimedToolCallPartIndex(
+                      toolCallParts,
+                      idx,
+                    );
+                    if (unclaimed !== -1) existingIndex = unclaimed;
+                  }
                   const slotPart =
                     existingIndex === -1
                       ? undefined
@@ -7414,7 +7427,7 @@ export function createOpenAIStreamAdapter(
           if (
             splitTailPartIds.has(part.toolCallId) &&
             part.result === undefined &&
-            toolArgumentBoundaries.get(part.toolCallId)?.isOpen()
+            toolArgumentBoundaries.get(part.toolCallId)?.isUnfinished()
           ) {
             toolCallParts.splice(i, 1);
           }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -6966,10 +6966,13 @@ export function createOpenAIStreamAdapter(
                   );
                   if (
                     stablePartId &&
+                    call.function?.name &&
                     existingIndex !== -1 &&
                     toolCallParts[existingIndex].toolCallId !== stablePartId
                   ) {
-                    // A late id claims the first call a split left waiting.
+                    // A late id that also names its call claims the first one a
+                    // split left waiting. A bare id has nothing to match on, so
+                    // it stays with the call this slot has open.
                     const unclaimed = findUnclaimedToolCallPartIndex(
                       toolCallParts,
                       idx,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -6492,6 +6492,12 @@ export function createOpenAIStreamAdapter(
                   toolEvent.provenance,
                 );
                 if (toolEvent.type === "tool_start") {
+                  // The loop only runs a call once the provider turn is over, so
+                  // this is the boundary a provider that omits finish_reason
+                  // never gives us. Hosted tool events arrive on the same shape
+                  // but come from providers that stamp real ids, which never
+                  // split.
+                  retireWithheldSplitCalls();
                   const backendToolCallId =
                     (toolEvent.tool_call_id as string) || "";
                   const approvalId = (toolEvent.approval_id as string) || "";
@@ -6909,6 +6915,8 @@ export function createOpenAIStreamAdapter(
                 codexRoundToolCallIds = [];
                 // The provider turn is over, so the backend now decides which
                 // split calls it withholds. Retire them before the next round.
+                // Not the only boundary: a provider may omit finish_reason and
+                // the backend runs the turn anyway, so tool_start retires too.
                 retireWithheldSplitCalls();
               }
               // Kimi / DeepSeek stream thinking via delta.reasoning_content;

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -108,8 +108,12 @@ import {
 
 import { toolCallReplayArguments } from "../tool-call-arguments";
 import {
+  ToolCallArgumentBoundaries,
+  bindStreamedToolCallBackendId,
   findStreamedToolCallPartIndex,
+  mintStreamedToolCallId,
   resolveToolCallPartId,
+  toolCallArgumentSegments,
 } from "../tool-call-id";
 
 import { buildResearchInferenceRequest } from "../research-inference-request";
@@ -467,6 +471,16 @@ function parseLiveToolArgs(
     return null;
   }
   return { args: parsed, argsText: candidate };
+}
+
+/** Streamed arguments as structured args, keeping unparsable text as `_raw`. */
+function parseStreamedToolCallArgs(raw: string): ToolCallMessagePart["args"] {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as ToolCallMessagePart["args"];
+  } catch {
+    return { _raw: raw } as ToolCallMessagePart["args"];
+  }
 }
 
 function parseSystemVariablesMap(raw: string): Record<string, unknown> {
@@ -5282,6 +5296,16 @@ export function createOpenAIStreamAdapter(
       // key is unique; every tool_start/output/args/end resolves the same id via
       // this map, dropped at tool_end.
       const toolPartIdByBackendId = new Map<string, string>();
+      // Provider ids remain reserved after their live reconciliation entries expire.
+      const providerToolCallIds = new Set<string>();
+      // Live JSON-boundary scan per streamed call, so a long argument is read
+      // once across the turn rather than once per fragment.
+      const toolArgumentBoundaries = new Map<
+        string,
+        ToolCallArgumentBoundaries
+      >();
+      // Calls a boundary split off whose own document has not closed yet.
+      const splitTailPartIds = new Set<string>();
       const resolveToolPartId = (backendToolCallId: string): string =>
         resolveToolCallPartId(
           toolPartIdByBackendId,
@@ -6926,6 +6950,7 @@ export function createOpenAIStreamAdapter(
                   // tool_start/tool_end events. Resolve the backend id now so all three
                   // event shapes update one run-unique card instead of leaving the raw
                   // provisional card beside a second execution card.
+                  if (stableId) providerToolCallIds.add(stableId);
                   const stablePartId = stableId
                     ? resolveToolPartId(stableId)
                     : undefined;
@@ -6937,10 +6962,39 @@ export function createOpenAIStreamAdapter(
                     stablePartId,
                     idx,
                   );
-                  const existing =
+                  const matched =
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
+
+                  const argsFragment = call.function?.arguments ?? "";
+                  const nameFragment = call.function?.name ?? "";
+                  // Split id-less calls collapsed onto one index at JSON boundaries
+                  // (#9807). Calls with provider ids are already distinct.
+                  let scan = matched
+                    ? toolArgumentBoundaries.get(matched.toolCallId)
+                    : undefined;
+                  if (!scan) {
+                    scan = new ToolCallArgumentBoundaries();
+                    if (matched) {
+                      toolArgumentBoundaries.set(matched.toolCallId, scan);
+                    }
+                  }
+                  // Scan every stream so a late id does not invalidate the state.
+                  const accumulated = matched?.argsText ?? "";
+                  const cuts = argsFragment ? scan.feed(argsFragment) : [];
+                  const segments =
+                    cuts.length > 0 && !stablePartId
+                      ? toolCallArgumentSegments(accumulated + argsFragment, cuts)
+                      : [];
+                  // A name after a finished named call opens the next call.
+                  const namedNextCall =
+                    !stablePartId &&
+                    !argsFragment &&
+                    Boolean(nameFragment) &&
+                    Boolean(matched?.toolName) &&
+                    scan.holdsOneCompleteDocument();
+                  const existing = namedNextCall ? undefined : matched;
 
                   if (
                     stablePartId &&
@@ -6948,9 +7002,64 @@ export function createOpenAIStreamAdapter(
                   ) {
                     codexRoundToolCallIds.push(stablePartId);
                   }
-                  const argsFragment = call.function?.arguments ?? "";
-                  streamedChars +=
-                    argsFragment.length + (call.function?.name?.length ?? 0);
+                  streamedChars += argsFragment.length + nameFragment.length;
+
+                  if (segments.length > 1) {
+                    // Segment 0 finishes the current call; later segments open calls.
+                    const splitName = nameFragment || matched?.toolName || "";
+                    let lastSplitId = "";
+                    for (const [position, argsText] of segments.entries()) {
+                      if (position === 0 && matched) {
+                        toolCallParts[existingIndex] = {
+                          ...(matched as PositionedToolCallPart),
+                          // Do not leave the completed call nameless.
+                          toolName: matched.toolName || splitName,
+                          argsText,
+                          args: parseStreamedToolCallArgs(argsText),
+                        };
+                        toolArgumentBoundaries.set(
+                          matched.toolCallId,
+                          new ToolCallArgumentBoundaries(),
+                        );
+                        continue;
+                      }
+                      const splitId = mintStreamedToolCallId(
+                        toolCallParts,
+                        `tool_call_${idx ?? toolCallParts.length}`,
+                        providerToolCallIds,
+                      );
+                      if (!codexRoundToolCallIds.includes(splitId)) {
+                        codexRoundToolCallIds.push(splitId);
+                      }
+                      // Bind later backend events to this provisional card.
+                      bindStreamedToolCallBackendId(toolPartIdByBackendId, splitId);
+                      toolCallParts.push({
+                        type: "tool-call" as const,
+                        toolCallId: splitId,
+                        toolName: splitName,
+                        argsText,
+                        args: parseStreamedToolCallArgs(argsText),
+                        textCursor: cumulativeText.length,
+                        ...(call.extra_content !== undefined
+                          ? { extra_content: call.extra_content }
+                          : {}),
+                        ...(idx !== undefined ? { _delta_index: idx } : {}),
+                      });
+                      lastSplitId = splitId;
+                      addedToolCall = true;
+                    }
+                    // Only the last segment can remain open.
+                    if (lastSplitId) {
+                      scan.rebase(segments[segments.length - 1]);
+                      toolArgumentBoundaries.set(lastSplitId, scan);
+                      splitTailPartIds.add(lastSplitId);
+                    }
+                    if (call.extra_content !== undefined) {
+                      replayStateChanged = true;
+                    }
+                    continue;
+                  }
+
                   if (existing) {
                     const prevName = existing.toolName ?? "";
                     const nextName = call.function?.name ?? prevName;
@@ -6997,31 +7106,33 @@ export function createOpenAIStreamAdapter(
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
                     };
                     toolCallParts[existingIndex] = updated;
+                    if (stablePartId && stablePartId !== existing.toolCallId) {
+                      // Move the scan with the renamed part.
+                      toolArgumentBoundaries.delete(existing.toolCallId);
+                      toolArgumentBoundaries.set(stablePartId, scan);
+                    }
                   } else {
                     const callId =
                       stablePartId ||
-                      `tool_call_${idx ?? toolCallParts.length}`;
+                      mintStreamedToolCallId(
+                        toolCallParts,
+                        `tool_call_${idx ?? toolCallParts.length}`,
+                        providerToolCallIds,
+                      );
 
                     if (!codexRoundToolCallIds.includes(callId)) {
                       codexRoundToolCallIds.push(callId);
                     }
-                    const argsText = argsFragment;
-                    let parsedArgs: ToolCallMessagePart["args"] = {};
-                    if (argsText) {
-                      try {
-                        parsedArgs = JSON.parse(
-                          argsText,
-                        ) as ToolCallMessagePart["args"];
-                      } catch {
-                        parsedArgs = {
-                          _raw: argsText,
-                        } as ToolCallMessagePart["args"];
-                      }
+                    if (!stablePartId) {
+                      // Bind later backend events to this provisional card.
+                      bindStreamedToolCallBackendId(toolPartIdByBackendId, callId);
                     }
+                    const argsText = argsFragment;
+                    const parsedArgs = parseStreamedToolCallArgs(argsText);
                     const fresh: PositionedToolCallPart = {
                       type: "tool-call" as const,
                       toolCallId: callId,
-                      toolName: call.function?.name ?? "",
+                      toolName: nameFragment,
                       argsText,
                       args: parsedArgs,
                       textCursor: cumulativeText.length,
@@ -7032,6 +7143,11 @@ export function createOpenAIStreamAdapter(
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
                     };
                     toolCallParts.push(fresh);
+                    // A name-only fork starts with a fresh scan.
+                    toolArgumentBoundaries.set(
+                      callId,
+                      matched ? new ToolCallArgumentBoundaries() : scan,
+                    );
                     addedToolCall = true;
                   }
                 }
@@ -7261,6 +7377,18 @@ export function createOpenAIStreamAdapter(
         // the open <think> tag so the reasoning panel parses cleanly.
         closeReasoningContent();
         settleFirstTokenOk();
+
+        // The backend withholds unfinished split calls, so remove their open cards.
+        for (let i = toolCallParts.length - 1; i >= 0; i -= 1) {
+          const part = toolCallParts[i];
+          if (
+            splitTailPartIds.has(part.toolCallId) &&
+            part.result === undefined &&
+            toolArgumentBoundaries.get(part.toolCallId)?.isOpen()
+          ) {
+            toolCallParts.splice(i, 1);
+          }
+        }
 
         // Extract source parts from completed web_search and web_fetch
         // calls. Both emit the same `Title:` / `URL:` / `Snippet:` block

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5306,21 +5306,6 @@ export function createOpenAIStreamAdapter(
       >();
       // Calls a boundary split off whose own document has not closed yet.
       const splitTailPartIds = new Set<string>();
-      // Split calls the backend has already withheld. Their card stays until the
-      // final sweep, but no event will ever reach it, so the next round's id-less
-      // delta has to open its own call instead of continuing this one.
-      const retiredSplitTailIds = new Set<string>();
-      const retireWithheldSplitCalls = (): void => {
-        for (const part of toolCallParts) {
-          if (
-            splitTailPartIds.has(part.toolCallId) &&
-            part.result === undefined &&
-            toolArgumentBoundaries.get(part.toolCallId)?.isOpen()
-          ) {
-            retiredSplitTailIds.add(part.toolCallId);
-          }
-        }
-      };
       const resolveToolPartId = (backendToolCallId: string): string =>
         resolveToolCallPartId(
           toolPartIdByBackendId,
@@ -6492,12 +6477,6 @@ export function createOpenAIStreamAdapter(
                   toolEvent.provenance,
                 );
                 if (toolEvent.type === "tool_start") {
-                  // The loop only runs a call once the provider turn is over, so
-                  // this is the boundary a provider that omits finish_reason
-                  // never gives us. Hosted tool events arrive on the same shape
-                  // but come from providers that stamp real ids, which never
-                  // split.
-                  retireWithheldSplitCalls();
                   const backendToolCallId =
                     (toolEvent.tool_call_id as string) || "";
                   const approvalId = (toolEvent.approval_id as string) || "";
@@ -6913,11 +6892,6 @@ export function createOpenAIStreamAdapter(
 
               if (chunk.choices?.[0]?.finish_reason) {
                 codexRoundToolCallIds = [];
-                // The provider turn is over, so the backend now decides which
-                // split calls it withholds. Retire them before the next round.
-                // Not the only boundary: a provider may omit finish_reason and
-                // the backend runs the turn anyway, so tool_start retires too.
-                retireWithheldSplitCalls();
               }
               // Kimi / DeepSeek stream thinking via delta.reasoning_content;
               // wrap inline as <think>...</think> for parseAssistantContent.
@@ -6992,15 +6966,12 @@ export function createOpenAIStreamAdapter(
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
-                  // A card the backend already closed, or one it withheld, takes
-                  // no more fragments: the next delta in its slot is the next
-                  // round's call, whatever its scan was left holding.
+                  // A card the backend already closed takes no more fragments:
+                  // the next delta in its slot is the next round's call, whatever
+                  // its scan was left holding. A split call it withheld is closed
+                  // too, so no boundary has to be guessed at here.
                   const matched =
-                    slotPart &&
-                    slotPart.result === undefined &&
-                    !retiredSplitTailIds.has(slotPart.toolCallId)
-                      ? slotPart
-                      : undefined;
+                    slotPart?.result === undefined ? slotPart : undefined;
 
                   const argsFragment = call.function?.arguments ?? "";
                   const nameFragment = call.function?.name ?? "";
@@ -7428,7 +7399,8 @@ export function createOpenAIStreamAdapter(
         closeReasoningContent();
         settleFirstTokenOk();
 
-        // The backend withholds unfinished split calls, so remove their open cards.
+        // A split call the backend withheld is closed by its own unrun card. This
+        // is the net for a stream that ends before that lands.
         for (let i = toolCallParts.length - 1; i >= 0; i -= 1) {
           const part = toolCallParts[i];
           if (

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -6967,10 +6967,7 @@ export function createOpenAIStreamAdapter(
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
-                  // A card the backend already closed takes no more fragments:
-                  // the next delta in its slot is the next round's call, whatever
-                  // its scan was left holding. A split call it withheld is closed
-                  // too, so no boundary has to be guessed at here.
+                  // Do not append a new round to a closed card.
                   const matched =
                     slotPart?.result === undefined ? slotPart : undefined;
 
@@ -6995,10 +6992,7 @@ export function createOpenAIStreamAdapter(
                     cuts.length > 0 && !stablePartId
                       ? toolCallArgumentSegments(scan.text(), cuts)
                       : [];
-                  // A name after a finished named call opens the next call.
-                  // A name with no id belongs to the first call in this slot
-                  // still waiting for one: a split leaves several unnamed when
-                  // the arguments arrived first, and the newest is the last.
+                  // Route an id-less name to the first unnamed call in its slot.
                   const namedIndex =
                     nameFragment && !stablePartId
                       ? findUnnamedToolCallPartIndex(toolCallParts, idx)
@@ -7009,9 +7003,7 @@ export function createOpenAIStreamAdapter(
                     Boolean(nameFragment) &&
                     Boolean(matched?.toolName) &&
                     namedIndex === -1 &&
-                    // A whole name resent as it grows is the same call. A second
-                    // call on that tool arrives with its own arguments and splits
-                    // at their boundary.
+                    // A resent growing name stays on the current call.
                     !nameFragment.startsWith(matched?.toolName ?? "") &&
                     scan.holdsOneCompleteDocument();
                   const existing = namedNextCall ? undefined : matched;
@@ -7060,9 +7052,7 @@ export function createOpenAIStreamAdapter(
                         argsText,
                         args: parseStreamedToolCallArgs(argsText),
                         textCursor: cumulativeText.length,
-                        // One signature belongs to one call. The backend puts it
-                        // on the last call the delta opened; replaying a copy on
-                        // each of them fails Gemini's signature validation.
+                        // Attach per-call metadata only to the last split call.
                         ...(call.extra_content !== undefined &&
                         position === segments.length - 1
                           ? { extra_content: call.extra_content }
@@ -7143,8 +7133,7 @@ export function createOpenAIStreamAdapter(
                       };
                     }
                     if (stablePartId && stablePartId !== existing.toolCallId) {
-                      // Move the scan and the split-tail marker with the renamed
-                      // part, else the cleanup below no longer finds its card.
+                      // Keep split state keyed to the renamed card.
                       toolArgumentBoundaries.delete(existing.toolCallId);
                       toolArgumentBoundaries.set(stablePartId, scan);
                       if (splitTailPartIds.delete(existing.toolCallId)) {
@@ -7183,9 +7172,7 @@ export function createOpenAIStreamAdapter(
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
                     };
                     toolCallParts.push(fresh);
-                    // A name-only fork starts with a fresh scan, and is a split
-                    // like any other: the backend withholds it too if its own
-                    // document never closes.
+                    // Track a name-only fork as a new split call.
                     toolArgumentBoundaries.set(
                       callId,
                       matched ? new ToolCallArgumentBoundaries() : scan,
@@ -7421,8 +7408,7 @@ export function createOpenAIStreamAdapter(
         closeReasoningContent();
         settleFirstTokenOk();
 
-        // A split call the backend withheld is closed by its own unrun card. This
-        // is the net for a stream that ends before that lands.
+        // Drop unfinished split calls if their closing event never arrives.
         for (let i = toolCallParts.length - 1; i >= 0; i -= 1) {
           const part = toolCallParts[i];
           if (

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -111,6 +111,7 @@ import {
   ToolCallArgumentBoundaries,
   bindStreamedToolCallBackendId,
   findStreamedToolCallPartIndex,
+  findUnnamedToolCallPartIndex,
   mintStreamedToolCallId,
   resolveToolCallPartId,
   toolCallArgumentSegments,
@@ -6995,11 +6996,19 @@ export function createOpenAIStreamAdapter(
                       ? toolCallArgumentSegments(scan.text(), cuts)
                       : [];
                   // A name after a finished named call opens the next call.
+                  // A name with no id belongs to the first call in this slot
+                  // still waiting for one: a split leaves several unnamed when
+                  // the arguments arrived first, and the newest is the last.
+                  const namedIndex =
+                    nameFragment && !stablePartId
+                      ? findUnnamedToolCallPartIndex(toolCallParts, idx)
+                      : -1;
                   const namedNextCall =
                     !stablePartId &&
                     !argsFragment &&
                     Boolean(nameFragment) &&
                     Boolean(matched?.toolName) &&
+                    namedIndex === -1 &&
                     // A whole name resent as it grows is the same call. A second
                     // call on that tool arrives with its own arguments and splits
                     // at their boundary.
@@ -7077,7 +7086,10 @@ export function createOpenAIStreamAdapter(
 
                   if (existing) {
                     const prevName = existing.toolName ?? "";
-                    const nextName = call.function?.name ?? prevName;
+                    const nextName =
+                      namedIndex === -1 || namedIndex === existingIndex
+                        ? (call.function?.name ?? prevName)
+                        : prevName;
                     const merged = (existing.argsText ?? "") + argsFragment;
                     let parsedArgs: ToolCallMessagePart["args"] =
                       existing.args ?? {};
@@ -7121,6 +7133,15 @@ export function createOpenAIStreamAdapter(
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
                     };
                     toolCallParts[existingIndex] = updated;
+                    if (namedIndex !== -1 && namedIndex !== existingIndex) {
+                      const waiting = toolCallParts[
+                        namedIndex
+                      ] as PositionedToolCallPart;
+                      toolCallParts[namedIndex] = {
+                        ...waiting,
+                        toolName: nameFragment,
+                      };
+                    }
                     if (stablePartId && stablePartId !== existing.toolCallId) {
                       // Move the scan and the split-tail marker with the renamed
                       // part, else the cleanup below no longer finds its card.

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -6981,11 +6981,12 @@ export function createOpenAIStreamAdapter(
                     }
                   }
                   // Scan every stream so a late id does not invalidate the state.
-                  const accumulated = matched?.argsText ?? "";
                   const cuts = argsFragment ? scan.feed(argsFragment) : [];
+                  // Cut the scan's own text: tool_start rewrites argsText to the
+                  // arguments it parsed, which no longer matches these offsets.
                   const segments =
                     cuts.length > 0 && !stablePartId
-                      ? toolCallArgumentSegments(accumulated + argsFragment, cuts)
+                      ? toolCallArgumentSegments(scan.text(), cuts)
                       : [];
                   // A name after a finished named call opens the next call.
                   const namedNextCall =
@@ -7107,9 +7108,13 @@ export function createOpenAIStreamAdapter(
                     };
                     toolCallParts[existingIndex] = updated;
                     if (stablePartId && stablePartId !== existing.toolCallId) {
-                      // Move the scan with the renamed part.
+                      // Move the scan and the split-tail marker with the renamed
+                      // part, else the cleanup below no longer finds its card.
                       toolArgumentBoundaries.delete(existing.toolCallId);
                       toolArgumentBoundaries.set(stablePartId, scan);
+                      if (splitTailPartIds.delete(existing.toolCallId)) {
+                        splitTailPartIds.add(stablePartId);
+                      }
                     }
                   } else {
                     const callId =

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5306,6 +5306,21 @@ export function createOpenAIStreamAdapter(
       >();
       // Calls a boundary split off whose own document has not closed yet.
       const splitTailPartIds = new Set<string>();
+      // Split calls the backend has already withheld. Their card stays until the
+      // final sweep, but no event will ever reach it, so the next round's id-less
+      // delta has to open its own call instead of continuing this one.
+      const retiredSplitTailIds = new Set<string>();
+      const retireWithheldSplitCalls = (): void => {
+        for (const part of toolCallParts) {
+          if (
+            splitTailPartIds.has(part.toolCallId) &&
+            part.result === undefined &&
+            toolArgumentBoundaries.get(part.toolCallId)?.isOpen()
+          ) {
+            retiredSplitTailIds.add(part.toolCallId);
+          }
+        }
+      };
       const resolveToolPartId = (backendToolCallId: string): string =>
         resolveToolCallPartId(
           toolPartIdByBackendId,
@@ -6892,6 +6907,9 @@ export function createOpenAIStreamAdapter(
 
               if (chunk.choices?.[0]?.finish_reason) {
                 codexRoundToolCallIds = [];
+                // The provider turn is over, so the backend now decides which
+                // split calls it withholds. Retire them before the next round.
+                retireWithheldSplitCalls();
               }
               // Kimi / DeepSeek stream thinking via delta.reasoning_content;
               // wrap inline as <think>...</think> for parseAssistantContent.
@@ -6966,11 +6984,15 @@ export function createOpenAIStreamAdapter(
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
-                  // A card the backend already closed takes no more fragments:
-                  // the next delta in its slot is the next round's call, whatever
-                  // its scan was left holding after a malformed first round.
+                  // A card the backend already closed, or one it withheld, takes
+                  // no more fragments: the next delta in its slot is the next
+                  // round's call, whatever its scan was left holding.
                   const matched =
-                    slotPart?.result === undefined ? slotPart : undefined;
+                    slotPart &&
+                    slotPart.result === undefined &&
+                    !retiredSplitTailIds.has(slotPart.toolCallId)
+                      ? slotPart
+                      : undefined;
 
                   const argsFragment = call.function?.arguments ?? "";
                   const nameFragment = call.function?.name ?? "";
@@ -7160,11 +7182,14 @@ export function createOpenAIStreamAdapter(
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
                     };
                     toolCallParts.push(fresh);
-                    // A name-only fork starts with a fresh scan.
+                    // A name-only fork starts with a fresh scan, and is a split
+                    // like any other: the backend withholds it too if its own
+                    // document never closes.
                     toolArgumentBoundaries.set(
                       callId,
                       matched ? new ToolCallArgumentBoundaries() : scan,
                     );
+                    if (matched) splitTailPartIds.add(callId);
                     addedToolCall = true;
                   }
                 }

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -27,6 +27,7 @@ export function bindStreamedToolCallBackendId(
 
 export interface StreamedToolCallPart {
   toolCallId: string;
+  toolName?: string;
   argsText?: string;
   _delta_index?: number;
   _has_stable_id?: boolean;
@@ -154,6 +155,22 @@ export function mintStreamedToolCallId(
   let next = 0;
   while (taken.has(`tool_call_${next}`)) next += 1;
   return `tool_call_${next}`;
+}
+
+/**
+ * First part in `deltaIndex`'s slot still waiting for a name, or -1. Arguments
+ * can arrive before their names, and a split then leaves several such calls.
+ */
+export function findUnnamedToolCallPartIndex(
+  parts: readonly StreamedToolCallPart[],
+  deltaIndex: number | undefined,
+): number {
+  if (deltaIndex === undefined) return -1;
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i];
+    if (part._delta_index === deltaIndex && !part.toolName) return i;
+  }
+  return -1;
 }
 
 /**

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -42,16 +42,19 @@ export class ToolCallArgumentBoundaries {
   private escaped = false;
   private closed = false;
   private invalid = false;
-  /** Total characters fed. */
-  private consumed = 0;
+  /** Everything fed so far. Tool events rewrite the part's own argsText, so
+   * the offsets `feed` returns can only index text this scan owns. */
+  private raw = "";
   /** Current document text, retained only until it parses. */
   private open: string[] = [];
   /** Exposed for deterministic complexity tests. */
   scanned = 0;
 
-  /** Offsets into the accumulated arguments where `fragment` opens another call. */
+  /** Offsets into `text()` where `fragment` opens another call. */
   feed(fragment: string): number[] {
     if (this.invalid) return [];
+    const base = this.raw.length;
+    this.raw += fragment;
     const boundaries: number[] = [];
     // Start of this fragment's contribution to the open document.
     let from = this.depth > 0 ? 0 : -1;
@@ -72,7 +75,7 @@ export class ToolCallArgumentBoundaries {
           return [];
         }
         if (this.closed) {
-          boundaries.push(this.consumed + i);
+          boundaries.push(base + i);
           this.closed = false;
         }
         from = i;
@@ -103,8 +106,12 @@ export class ToolCallArgumentBoundaries {
     }
 
     if (this.depth > 0) this.open.push(fragment.slice(from < 0 ? 0 : from));
-    this.consumed += fragment.length;
     return boundaries;
+  }
+
+  /** The arguments as the provider streamed them, which `feed` indexes into. */
+  text(): string {
+    return this.raw;
   }
 
   holdsOneCompleteDocument(): boolean {
@@ -118,7 +125,7 @@ export class ToolCallArgumentBoundaries {
 
   /** Reset offsets after moving the scan to a split call. */
   rebase(text: string): void {
-    this.consumed = text.length;
+    this.raw = text;
     this.open = this.depth > 0 ? [text] : [];
   }
 }

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -33,18 +33,14 @@ export interface StreamedToolCallPart {
   _has_stable_id?: boolean;
 }
 
-/**
- * Find adjacent JSON documents without rescanning prior fragments.
- * Malformed arguments are left whole rather than split into more bad calls.
- */
+/** Find adjacent JSON documents incrementally, leaving malformed input whole. */
 export class ToolCallArgumentBoundaries {
   private depth = 0;
   private inString = false;
   private escaped = false;
   private closed = false;
   private invalid = false;
-  /** Everything fed so far. Tool events rewrite the part's own argsText, so
-   * the offsets `feed` returns can only index text this scan owns. */
+  /** Provider text used as the coordinate space for boundary offsets. */
   private raw = "";
   /** Current document text, retained only until it parses. */
   private open: string[] = [];
@@ -140,10 +136,7 @@ export function toolCallArgumentSegments(
   return edges.slice(0, -1).map((from, i) => text.slice(from, edges[i + 1]));
 }
 
-/**
- * Return `preferred` or the lowest free `tool_call_<n>`.
- * `reserved` contains provider ids that are not visible in the part ids.
- */
+/** Return `preferred` or the lowest unreserved `tool_call_<n>`. */
 export function mintStreamedToolCallId(
   parts: readonly StreamedToolCallPart[],
   preferred: string,
@@ -157,10 +150,7 @@ export function mintStreamedToolCallId(
   return `tool_call_${next}`;
 }
 
-/**
- * First part in `deltaIndex`'s slot still waiting for a name, or -1. Arguments
- * can arrive before their names, and a split then leaves several such calls.
- */
+/** Return the first unnamed part in `deltaIndex`'s slot, or -1. */
 export function findUnnamedToolCallPartIndex(
   parts: readonly StreamedToolCallPart[],
   deltaIndex: number | undefined,

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -156,8 +156,9 @@ export function mintStreamedToolCallId(
   return `tool_call_${next}`;
 }
 
-/** Return the first part in `deltaIndex`'s slot that no id and no name has
- * claimed, or -1. A late id claims one of these before opening a new call. */
+/** Return the first part in `deltaIndex`'s slot no provider id has claimed, or
+ * -1. Not "and unnamed": a split hands its name down to every segment, so a
+ * named one can still be waiting for the id that belongs to it. */
 export function findUnclaimedToolCallPartIndex(
   parts: readonly StreamedToolCallPart[],
   deltaIndex: number | undefined,
@@ -165,13 +166,7 @@ export function findUnclaimedToolCallPartIndex(
   if (deltaIndex === undefined) return -1;
   for (let i = 0; i < parts.length; i += 1) {
     const part = parts[i];
-    if (
-      part._delta_index === deltaIndex &&
-      !part._has_stable_id &&
-      !part.toolName
-    ) {
-      return i;
-    }
+    if (part._delta_index === deltaIndex && !part._has_stable_id) return i;
   }
   return -1;
 }

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -17,10 +17,136 @@ export function resolveToolCallPartId(
   return partId;
 }
 
+/** Bind an id-less streamed card to the backend's matching minted id. */
+export function bindStreamedToolCallBackendId(
+  ids: Map<string, string>,
+  partId: string,
+): void {
+  if (!ids.has(partId)) ids.set(partId, partId);
+}
+
 export interface StreamedToolCallPart {
   toolCallId: string;
+  argsText?: string;
   _delta_index?: number;
   _has_stable_id?: boolean;
+}
+
+/**
+ * Find adjacent JSON documents without rescanning prior fragments.
+ * Malformed arguments are left whole rather than split into more bad calls.
+ */
+export class ToolCallArgumentBoundaries {
+  private depth = 0;
+  private inString = false;
+  private escaped = false;
+  private closed = false;
+  private invalid = false;
+  /** Total characters fed. */
+  private consumed = 0;
+  /** Current document text, retained only until it parses. */
+  private open: string[] = [];
+  /** Exposed for deterministic complexity tests. */
+  scanned = 0;
+
+  /** Offsets into the accumulated arguments where `fragment` opens another call. */
+  feed(fragment: string): number[] {
+    if (this.invalid) return [];
+    const boundaries: number[] = [];
+    // Start of this fragment's contribution to the open document.
+    let from = this.depth > 0 ? 0 : -1;
+
+    for (let i = 0; i < fragment.length; i += 1) {
+      this.scanned += 1;
+      const character = fragment[i];
+      if (this.inString) {
+        if (this.escaped) this.escaped = false;
+        else if (character === "\\") this.escaped = true;
+        else if (character === '"') this.inString = false;
+        continue;
+      }
+      if (this.depth === 0) {
+        if (/\s/u.test(character)) continue;
+        if (character !== "{" && character !== "[") {
+          this.invalid = true;
+          return [];
+        }
+        if (this.closed) {
+          boundaries.push(this.consumed + i);
+          this.closed = false;
+        }
+        from = i;
+        this.depth = 1;
+        continue;
+      }
+      if (character === '"') {
+        this.inString = true;
+      } else if (character === "{" || character === "[") {
+        this.depth += 1;
+      } else if (character === "}" || character === "]") {
+        this.depth -= 1;
+        if (this.depth === 0) {
+          const document =
+            this.open.join("") + fragment.slice(from < 0 ? 0 : from, i + 1);
+          this.open = [];
+          from = -1;
+          try {
+            // Parsing also rejects mismatched delimiters.
+            JSON.parse(document);
+          } catch {
+            this.invalid = true;
+            return [];
+          }
+          this.closed = true;
+        }
+      }
+    }
+
+    if (this.depth > 0) this.open.push(fragment.slice(from < 0 ? 0 : from));
+    this.consumed += fragment.length;
+    return boundaries;
+  }
+
+  holdsOneCompleteDocument(): boolean {
+    return this.closed && this.depth === 0 && !this.invalid;
+  }
+
+  /** Whether a document has begun here and has not finished. */
+  isOpen(): boolean {
+    return this.depth > 0;
+  }
+
+  /** Reset offsets after moving the scan to a split call. */
+  rebase(text: string): void {
+    this.consumed = text.length;
+    this.open = this.depth > 0 ? [text] : [];
+  }
+}
+
+/** Cut `text` at `boundaries` into one string per call. */
+export function toolCallArgumentSegments(
+  text: string,
+  boundaries: readonly number[],
+): string[] {
+  const edges = [0, ...boundaries, text.length];
+  return edges.slice(0, -1).map((from, i) => text.slice(from, edges[i + 1]));
+}
+
+/**
+ * Return `preferred` or the lowest free `tool_call_<n>`.
+ * `reserved` contains provider ids that are not visible in the part ids.
+ */
+export function mintStreamedToolCallId(
+  parts: readonly StreamedToolCallPart[],
+  preferred: string,
+  reserved: Iterable<string> = [],
+): string {
+  const taken = new Set(parts.map((part) => part.toolCallId));
+  for (const id of reserved) taken.add(id);
+  if (!taken.has(preferred)) return preferred;
+  let next = 0;
+  while (taken.has(`tool_call_${next}`)) next += 1;
+  return `tool_call_${next}`;
 }
 
 /**

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -120,6 +120,12 @@ export class ToolCallArgumentBoundaries {
     return this.depth > 0;
   }
 
+  /** Whether this scan never turned into a valid document. A boundary is
+   * recorded when the next `{` arrives, before that document has parsed. */
+  isUnfinished(): boolean {
+    return this.depth > 0 || this.invalid;
+  }
+
   /** Reset offsets after moving the scan to a split call. */
   rebase(text: string): void {
     this.raw = text;
@@ -148,6 +154,26 @@ export function mintStreamedToolCallId(
   let next = 0;
   while (taken.has(`tool_call_${next}`)) next += 1;
   return `tool_call_${next}`;
+}
+
+/** Return the first part in `deltaIndex`'s slot that no id and no name has
+ * claimed, or -1. A late id claims one of these before opening a new call. */
+export function findUnclaimedToolCallPartIndex(
+  parts: readonly StreamedToolCallPart[],
+  deltaIndex: number | undefined,
+): number {
+  if (deltaIndex === undefined) return -1;
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i];
+    if (
+      part._delta_index === deltaIndex &&
+      !part._has_stable_id &&
+      !part.toolName
+    ) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 /** Return the first unnamed part in `deltaIndex`'s slot, or -1. */

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -504,10 +504,10 @@ test("streaming tool-call argument deltas are paced like the text path", () => {
     "} catch (streamError) {",
   );
 
-  // Both branches of the OpenAI delta.tool_calls accumulator feed the counter,
+  // Every branch of the OpenAI delta.tool_calls accumulator feeds the counter,
   // so a turn that only streams a call's arguments is still capped.
   const count = loop.indexOf(
-    "streamedChars +=\n                    argsFragment.length",
+    "streamedChars += argsFragment.length + nameFragment.length;",
   );
   assert.notEqual(count, -1, "tool-call argument deltas are not counted");
 

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -22,17 +22,41 @@ interface DeltaFragment {
   arguments: string;
 }
 
+/** The adapter's tool_start branch, which replaces argsText with the arguments
+ * the backend parsed out of it. */
+interface ToolStartEvent {
+  toolStart: string;
+}
+
+type StreamEvent = DeltaFragment | ToolStartEvent;
+
 type AccumulatedPart = StreamedToolCallPart & {
   argsText: string;
   toolName: string;
 };
 
-/** Accumulate `delta.tool_calls[]` fragments the way the chat adapter does. */
-function accumulate(fragments: DeltaFragment[]): AccumulatedPart[] {
+/** Accumulate `delta.tool_calls[]` fragments the way the chat adapter does.
+ * `endOfStream` also runs the sweep the adapter runs once the stream closes. */
+function accumulate(
+  fragments: StreamEvent[],
+  endOfStream = false,
+): AccumulatedPart[] {
   const parts: AccumulatedPart[] = [];
   const scans = new Map<string, ToolCallArgumentBoundaries>();
   const providerIds = new Set<string>();
-  for (const fragment of fragments) {
+  const splitTails = new Set<string>();
+  for (const event of fragments) {
+    if ("toolStart" in event) {
+      const at = parts.findIndex((part) => part.toolCallId === event.toolStart);
+      if (at !== -1) {
+        parts[at] = {
+          ...parts[at],
+          argsText: JSON.stringify(JSON.parse(parts[at].argsText)),
+        };
+      }
+      continue;
+    }
+    const fragment = event;
     if (fragment.id) providerIds.add(fragment.id);
     const target = findStreamedToolCallPartIndex(
       parts,
@@ -46,11 +70,10 @@ function accumulate(fragments: DeltaFragment[]): AccumulatedPart[] {
       scan = new ToolCallArgumentBoundaries();
       if (matched) scans.set(matched.toolCallId, scan);
     }
-    const accumulated = matched?.argsText ?? "";
     const cuts = fragment.arguments ? scan.feed(fragment.arguments) : [];
     const segments =
       cuts.length > 0 && !fragment.id
-        ? toolCallArgumentSegments(accumulated + fragment.arguments, cuts)
+        ? toolCallArgumentSegments(scan.text(), cuts)
         : [];
     const namedNextCall =
       !fragment.id &&
@@ -90,6 +113,7 @@ function accumulate(fragments: DeltaFragment[]): AccumulatedPart[] {
       if (lastSplitId) {
         scan.rebase(segments[segments.length - 1]);
         scans.set(lastSplitId, scan);
+        splitTails.add(lastSplitId);
       }
       continue;
     }
@@ -106,6 +130,7 @@ function accumulate(fragments: DeltaFragment[]): AccumulatedPart[] {
       if (fragment.id && fragment.id !== matched.toolCallId) {
         scans.delete(matched.toolCallId);
         scans.set(fragment.id, scan);
+        if (splitTails.delete(matched.toolCallId)) splitTails.add(fragment.id);
       }
       continue;
     }
@@ -125,6 +150,18 @@ function accumulate(fragments: DeltaFragment[]): AccumulatedPart[] {
       ...(fragment.id ? { _has_stable_id: true } : {}),
       ...(fragment.index !== undefined ? { _delta_index: fragment.index } : {}),
     });
+  }
+  // The backend withholds a split call whose JSON never closed, so its card
+  // has to go.
+  if (endOfStream) {
+    for (let i = parts.length - 1; i >= 0; i -= 1) {
+      if (
+        splitTails.has(parts[i].toolCallId) &&
+        scans.get(parts[i].toolCallId)?.isOpen()
+      ) {
+        parts.splice(i, 1);
+      }
+    }
   }
   return parts;
 }
@@ -491,4 +528,54 @@ test("replayed arguments keep parsable text and fall back otherwise", () => {
     '{"query":"first"}',
   );
   assert.equal(toolCallReplayArguments(undefined, undefined), "{}");
+});
+
+// Both rounds are id-less and reuse index 0, so the second round's arguments
+// are cut off the first round's. tool_start has by then replaced argsText with
+// the arguments the backend parsed, which is a character shorter than the raw
+// JSON, so a cut measured against argsText lands inside both documents.
+test("a next round splits correctly after tool_start rewrites the arguments", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_search", arguments: '{"query": "first"}' },
+    { toolStart: "tool_call_0" },
+    { index: 0, name: "web_search", arguments: '{"query":"second"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, JSON.parse(part.argsText)]),
+    [
+      ["tool_call_0", { query: "first" }],
+      ["tool_call_1", { query: "second" }],
+    ],
+  );
+});
+
+test("boundary offsets index the scan's own text, not the part's", () => {
+  const scan = new ToolCallArgumentBoundaries();
+  assert.deepEqual(scan.feed('{"query": "first"}'), []);
+  const cuts = scan.feed('{"query":"second"}');
+
+  assert.deepEqual(cuts, [18]);
+  assert.deepEqual(toolCallArgumentSegments(scan.text(), cuts), [
+    '{"query": "first"}',
+    '{"query":"second"}',
+  ]);
+});
+
+// The backend withholds a split call whose JSON never closed, so nothing ever
+// closes its card. A provider id stamped on that tail renames the part, and the
+// sweep has to follow the rename or the card spins for the rest of the response.
+test("a split tail renamed by a late id is still dropped when its JSON never closes", () => {
+  const parts = accumulate(
+    [
+      { index: 0, name: "web_search", arguments: '{"a":1}{"b":' },
+      { id: "call-A", index: 0, arguments: "" },
+    ],
+    true,
+  );
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.argsText]),
+    [["tool_call_0", '{"a":1}']],
+  );
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -20,6 +20,7 @@ interface DeltaFragment {
   index?: number;
   name?: string;
   arguments: string;
+  extra?: unknown;
 }
 
 /** The adapter's tool_start branch, which replaces argsText with the arguments
@@ -28,11 +29,27 @@ interface ToolStartEvent {
   toolStart: string;
 }
 
-type StreamEvent = DeltaFragment | ToolStartEvent;
+/** The adapter's tool_end branch, which puts a result on the card. */
+interface ToolEndEvent {
+  toolEnd: string;
+}
+
+type StreamEvent = DeltaFragment | ToolStartEvent | ToolEndEvent;
+
+/** The adapter's parseStreamedToolCallArgs, used by the tool_start mirror. */
+function parseArgs(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return { _raw: raw };
+  }
+}
 
 type AccumulatedPart = StreamedToolCallPart & {
   argsText: string;
   toolName: string;
+  extra_content?: unknown;
+  result?: unknown;
 };
 
 /** Accumulate `delta.tool_calls[]` fragments the way the chat adapter does.
@@ -51,9 +68,14 @@ function accumulate(
       if (at !== -1) {
         parts[at] = {
           ...parts[at],
-          argsText: JSON.stringify(JSON.parse(parts[at].argsText)),
+          argsText: JSON.stringify(parseArgs(parts[at].argsText)),
         };
       }
+      continue;
+    }
+    if ("toolEnd" in event) {
+      const at = parts.findIndex((part) => part.toolCallId === event.toolEnd);
+      if (at !== -1) parts[at] = { ...parts[at], result: "done" };
       continue;
     }
     const fragment = event;
@@ -63,7 +85,8 @@ function accumulate(
       fragment.id,
       fragment.index,
     );
-    const matched = target === -1 ? undefined : parts[target];
+    const slotPart = target === -1 ? undefined : parts[target];
+    const matched = slotPart?.result === undefined ? slotPart : undefined;
     const name = fragment.name ?? "";
     let scan = matched ? scans.get(matched.toolCallId) : undefined;
     if (!scan) {
@@ -80,6 +103,7 @@ function accumulate(
       !fragment.arguments &&
       Boolean(name) &&
       Boolean(matched?.toolName) &&
+      name !== matched?.toolName &&
       scan.holdsOneCompleteDocument();
 
     if (segments.length > 1) {
@@ -104,6 +128,9 @@ function accumulate(
           toolCallId: splitId,
           toolName: splitName,
           argsText,
+          ...(fragment.extra !== undefined && position === segments.length - 1
+            ? { extra_content: fragment.extra }
+            : {}),
           ...(fragment.index !== undefined
             ? { _delta_index: fragment.index }
             : {}),
@@ -577,5 +604,74 @@ test("a split tail renamed by a late id is still dropped when its JSON never clo
   assert.deepEqual(
     parts.map((part) => [part.toolCallId, part.argsText]),
     [["tool_call_0", '{"a":1}']],
+  );
+});
+
+// A thought signature belongs to one function call. Replaying a copy of it on
+// every call a split opened fails Gemini's signature validation, and the
+// backend puts it on the last call the delta opened.
+test("split metadata rides only the last call the delta opened", () => {
+  const parts = accumulate([
+    {
+      index: 0,
+      name: "web_search",
+      arguments: '{"a":1}{"b":2}',
+      extra: { thought_signature: "S" },
+    },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.extra_content),
+    [undefined, { thought_signature: "S" }],
+  );
+});
+
+// The first round's arguments never parsed, so its scan is stuck invalid. The
+// call ran anyway under the coercion path and its card is closed, so the next
+// round's fragments must open their own call rather than append to it.
+test("a finished malformed call does not swallow the next round", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_search", arguments: "{bad}" },
+    { toolStart: "tool_call_0" },
+    { toolEnd: "tool_call_0" },
+    { index: 0, name: "web_search", arguments: '{"query":"second"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.argsText]),
+    [
+      ["tool_call_0", '{"_raw":"{bad}"}'],
+      ["tool_call_1", '{"query":"second"}'],
+    ],
+  );
+});
+
+// The accumulator supports dialects that resend a whole name, so a resend after
+// the arguments closed is the same call, not a second one to run with {}.
+test("a name resent after its arguments closed opens no second call", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_search", arguments: '{"query":"first"}' },
+    { index: 0, name: "web_search", arguments: "" },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [["web_search", '{"query":"first"}']],
+  );
+});
+
+test("a second call on the same tool still splits on its arguments", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_search", arguments: '{"query":"first"}' },
+    { index: 0, name: "web_search", arguments: "" },
+    { index: 0, arguments: '{"query":"second"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["web_search", '{"query":"first"}'],
+      ["web_search", '{"query":"second"}'],
+    ],
   );
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -7,43 +7,124 @@ import test from "node:test";
 import { toolCallReplayArguments } from "../src/features/chat/tool-call-arguments.ts";
 import {
   type StreamedToolCallPart,
+  ToolCallArgumentBoundaries,
+  bindStreamedToolCallBackendId,
   findStreamedToolCallPartIndex,
+  mintStreamedToolCallId,
+  resolveToolCallPartId,
+  toolCallArgumentSegments,
 } from "../src/features/chat/tool-call-id.ts";
 
 interface DeltaFragment {
   id?: string;
   index?: number;
+  name?: string;
   arguments: string;
 }
 
+type AccumulatedPart = StreamedToolCallPart & {
+  argsText: string;
+  toolName: string;
+};
+
 /** Accumulate `delta.tool_calls[]` fragments the way the chat adapter does. */
-function accumulate(
-  fragments: DeltaFragment[],
-): (StreamedToolCallPart & { argsText: string })[] {
-  const parts: (StreamedToolCallPart & { argsText: string })[] = [];
+function accumulate(fragments: DeltaFragment[]): AccumulatedPart[] {
+  const parts: AccumulatedPart[] = [];
+  const scans = new Map<string, ToolCallArgumentBoundaries>();
+  const providerIds = new Set<string>();
   for (const fragment of fragments) {
+    if (fragment.id) providerIds.add(fragment.id);
     const target = findStreamedToolCallPartIndex(
       parts,
       fragment.id,
       fragment.index,
     );
-    if (target === -1) {
-      parts.push({
-        toolCallId:
-          fragment.id ?? `tool_call_${fragment.index ?? parts.length}`,
-        argsText: fragment.arguments,
-        ...(fragment.id ? { _has_stable_id: true } : {}),
-        ...(fragment.index !== undefined
-          ? { _delta_index: fragment.index }
-          : {}),
-      });
+    const matched = target === -1 ? undefined : parts[target];
+    const name = fragment.name ?? "";
+    let scan = matched ? scans.get(matched.toolCallId) : undefined;
+    if (!scan) {
+      scan = new ToolCallArgumentBoundaries();
+      if (matched) scans.set(matched.toolCallId, scan);
+    }
+    const accumulated = matched?.argsText ?? "";
+    const cuts = fragment.arguments ? scan.feed(fragment.arguments) : [];
+    const segments =
+      cuts.length > 0 && !fragment.id
+        ? toolCallArgumentSegments(accumulated + fragment.arguments, cuts)
+        : [];
+    const namedNextCall =
+      !fragment.id &&
+      !fragment.arguments &&
+      Boolean(name) &&
+      Boolean(matched?.toolName) &&
+      scan.holdsOneCompleteDocument();
+
+    if (segments.length > 1) {
+      const splitName = name || matched?.toolName || "";
+      let lastSplitId = "";
+      for (const [position, argsText] of segments.entries()) {
+        if (position === 0 && matched) {
+          parts[target] = {
+            ...matched,
+            toolName: matched.toolName || splitName,
+            argsText,
+          };
+          scans.set(matched.toolCallId, new ToolCallArgumentBoundaries());
+          continue;
+        }
+        const splitId = mintStreamedToolCallId(
+          parts,
+          `tool_call_${fragment.index ?? parts.length}`,
+          providerIds,
+        );
+        parts.push({
+          toolCallId: splitId,
+          toolName: splitName,
+          argsText,
+          ...(fragment.index !== undefined
+            ? { _delta_index: fragment.index }
+            : {}),
+        });
+        lastSplitId = splitId;
+      }
+      if (lastSplitId) {
+        scan.rebase(segments[segments.length - 1]);
+        scans.set(lastSplitId, scan);
+      }
       continue;
     }
-    parts[target] = {
-      ...parts[target],
-      ...(fragment.id ? { toolCallId: fragment.id, _has_stable_id: true } : {}),
-      argsText: parts[target].argsText + fragment.arguments,
-    };
+
+    if (matched && !namedNextCall) {
+      parts[target] = {
+        ...matched,
+        ...(fragment.id
+          ? { toolCallId: fragment.id, _has_stable_id: true }
+          : {}),
+        toolName: fragment.name ?? matched.toolName,
+        argsText: matched.argsText + fragment.arguments,
+      };
+      if (fragment.id && fragment.id !== matched.toolCallId) {
+        scans.delete(matched.toolCallId);
+        scans.set(fragment.id, scan);
+      }
+      continue;
+    }
+
+    const callId =
+      fragment.id ??
+      mintStreamedToolCallId(
+        parts,
+        `tool_call_${fragment.index ?? parts.length}`,
+        providerIds,
+      );
+    scans.set(callId, matched ? new ToolCallArgumentBoundaries() : scan);
+    parts.push({
+      toolCallId: callId,
+      toolName: name,
+      argsText: fragment.arguments,
+      ...(fragment.id ? { _has_stable_id: true } : {}),
+      ...(fragment.index !== undefined ? { _delta_index: fragment.index } : {}),
+    });
   }
   return parts;
 }
@@ -143,6 +224,255 @@ test("a fragment carrying neither id nor index starts its own call", () => {
     ),
     -1,
   );
+});
+
+test("id-less parallel calls at one index stay separate calls", () => {
+  // The #9807 stream reports every id-less call at index 0.
+  const parts = accumulate([
+    {
+      index: 0,
+      name: "web_fetch",
+      arguments: '{"url":"https://example.com/1"}',
+    },
+    {
+      index: 0,
+      name: "web_fetch",
+      arguments: '{"url":"https://example.com/2"}',
+    },
+    { index: 0, name: "web_search", arguments: '{"query":"example search"}' },
+    {
+      index: 0,
+      name: "web_fetch",
+      arguments: '{"url":"https://example.com/3"}',
+    },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["web_fetch", '{"url":"https://example.com/1"}'],
+      ["web_fetch", '{"url":"https://example.com/2"}'],
+      ["web_search", '{"query":"example search"}'],
+      ["web_fetch", '{"url":"https://example.com/3"}'],
+    ],
+  );
+  assert.equal(new Set(parts.map((part) => part.toolCallId)).size, 4);
+  for (const part of parts) {
+    assert.doesNotThrow(() => JSON.parse(part.argsText));
+  }
+});
+
+test("an id-less call still accumulates across argument fragments", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_fetch", arguments: '{"url":' },
+    { index: 0, arguments: '"https://example.com/1"}' },
+    { index: 0, name: "web_search", arguments: '{"query":"example"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["web_fetch", '{"url":"https://example.com/1"}'],
+      ["web_search", '{"query":"example"}'],
+    ],
+  );
+});
+
+test("one fragment holding two documents is two calls", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_fetch", arguments: '{"url":"a"}{"url":"b"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.argsText),
+    ['{"url":"a"}', '{"url":"b"}'],
+  );
+});
+
+test("an id-less name lands on the next call once the slot's document closed", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_fetch", arguments: '{"url":"a"}' },
+    { index: 0, name: "web_search", arguments: "" },
+    { index: 0, arguments: '{"query":"b"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["web_fetch", '{"url":"a"}'],
+      ["web_search", '{"query":"b"}'],
+    ],
+  );
+});
+
+test("a name growing over several fragments still names one call", () => {
+  const parts = accumulate([
+    { index: 0, name: "web", arguments: "" },
+    { index: 0, name: "web_search", arguments: "" },
+    { index: 0, arguments: '{"query":"b"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [["web_search", '{"query":"b"}']],
+  );
+});
+
+test("a split names the call it opened and the one it closed", () => {
+  const parts = accumulate([
+    { index: 0, arguments: '{"url":"a"}' },
+    { index: 0, name: "web_fetch", arguments: '{"url":"b"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["web_fetch", '{"url":"a"}'],
+      ["web_fetch", '{"url":"b"}'],
+    ],
+  );
+});
+
+test("a complete document followed by an open one keeps both calls", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_fetch", arguments: '{"url":"a"}{"url":' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["web_fetch", '{"url":"a"}'],
+      ["web_fetch", '{"url":'],
+    ],
+  );
+});
+
+test("balanced text that is not JSON is never split", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_fetch", arguments: "{bad}{worse}" },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.argsText),
+    ["{bad}{worse}"],
+  );
+});
+
+test("arguments that are not JSON are left whole", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_search", arguments: "query=" },
+    { index: 0, arguments: "example" },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.argsText),
+    ["query=example"],
+  );
+});
+
+test("a third id-less call still splits off the second", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_fetch", arguments: '{"url":"1"}' },
+    { index: 0, name: "web_search", arguments: '{"q":"2"}' },
+    { index: 0, name: "web_fetch", arguments: '{"url":"3"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["web_fetch", '{"url":"1"}'],
+      ["web_search", '{"q":"2"}'],
+      ["web_fetch", '{"url":"3"}'],
+    ],
+  );
+});
+
+test("a call split off mid-document keeps accumulating its own arguments", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_fetch", arguments: '{"url":"1"}{"url":' },
+    { index: 0, arguments: '"2"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.argsText),
+    ['{"url":"1"}', '{"url":"2"}'],
+  );
+});
+
+test("an id-less call's backend events find the card it painted", () => {
+  const ids = new Map<string, string>();
+  let minted = 0;
+  const createId = () => `run-scoped-${(minted += 1)}`;
+
+  bindStreamedToolCallBackendId(ids, "tool_call_0");
+
+  assert.equal(
+    resolveToolCallPartId(ids, "tool_call_0", undefined, "last", createId),
+    "tool_call_0",
+  );
+  assert.equal(minted, 0, "a bound id must not mint a run-scoped one");
+
+  assert.equal(
+    resolveToolCallPartId(ids, "call_from_nowhere", undefined, "last", createId),
+    "run-scoped-1",
+  );
+});
+
+test("a provider id stays reserved after its call has finished", () => {
+  const parts = accumulate([
+    { id: "tool_call_0", index: 0, name: "web_search", arguments: '{"q":"a"}' },
+    { index: 0, name: "web_search", arguments: '{"q":"b"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.toolCallId),
+    ["tool_call_0", "tool_call_1"],
+  );
+});
+
+test("an id adopted late frees the spelling its call was painted under", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_search", arguments: '{"q":' },
+    { id: "call_a", index: 0, arguments: '"a"}' },
+    { index: 0, name: "web_search", arguments: '{"q":"b"}' },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => part.toolCallId),
+    ["call_a", "tool_call_0"],
+  );
+});
+
+test("minting skips a spelling the backend already reserved", () => {
+  const parts = [
+    { toolCallId: "tool_call_0:run-1", _delta_index: 0, _has_stable_id: true },
+  ];
+  const claimed = new Map<string, string>([["tool_call_0", "tool_call_0:run-1"]]);
+
+  assert.equal(
+    mintStreamedToolCallId(parts, "tool_call_0", claimed.keys()),
+    "tool_call_1",
+  );
+  assert.equal(mintStreamedToolCallId(parts, "tool_call_0"), "tool_call_0");
+});
+
+test("binding never steals an id another part already owns", () => {
+  const ids = new Map<string, string>([["tool_call_0", "already-mine"]]);
+  bindStreamedToolCallBackendId(ids, "tool_call_0");
+
+  assert.equal(ids.get("tool_call_0"), "already-mine");
+});
+
+test("a long argument is read once, not once per fragment", () => {
+  const opening = '{"code":"';
+  const body = "x".repeat(64 * 1024);
+  const scan = new ToolCallArgumentBoundaries();
+  scan.feed(opening);
+  for (let at = 0; at < body.length; at += 1024) {
+    scan.feed(body.slice(at, at + 1024));
+  }
+
+  assert.equal(scan.scanned, opening.length + body.length);
 });
 
 test("replayed arguments keep parsable text and fall back otherwise", () => {

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -10,6 +10,7 @@ import {
   ToolCallArgumentBoundaries,
   bindStreamedToolCallBackendId,
   findStreamedToolCallPartIndex,
+  findUnnamedToolCallPartIndex,
   mintStreamedToolCallId,
   resolveToolCallPartId,
   toolCallArgumentSegments,
@@ -105,11 +106,16 @@ function accumulate(
       cuts.length > 0 && !fragment.id
         ? toolCallArgumentSegments(scan.text(), cuts)
         : [];
+    const namedIndex =
+      name && !fragment.id
+        ? findUnnamedToolCallPartIndex(parts, fragment.index)
+        : -1;
     const namedNextCall =
       !fragment.id &&
       !fragment.arguments &&
       Boolean(name) &&
       Boolean(matched?.toolName) &&
+      namedIndex === -1 &&
       !name.startsWith(matched?.toolName ?? "") &&
       scan.holdsOneCompleteDocument();
 
@@ -158,9 +164,15 @@ function accumulate(
         ...(fragment.id
           ? { toolCallId: fragment.id, _has_stable_id: true }
           : {}),
-        toolName: fragment.name ?? matched.toolName,
+        toolName:
+          namedIndex === -1 || namedIndex === target
+            ? (fragment.name ?? matched.toolName)
+            : matched.toolName,
         argsText: matched.argsText + fragment.arguments,
       };
+      if (namedIndex !== -1 && namedIndex !== target) {
+        parts[namedIndex] = { ...parts[namedIndex], toolName: name };
+      }
       if (fragment.id && fragment.id !== matched.toolCallId) {
         scans.delete(matched.toolCallId);
         scans.set(fragment.id, scan);
@@ -740,5 +752,25 @@ test("a growing name after early arguments still names one call", () => {
   assert.deepEqual(
     parts.map((part) => [part.toolName, part.argsText]),
     [["web_search", '{"query":"first"}']],
+  );
+});
+
+// Both documents arrive before either name, so the split leaves two calls
+// waiting. The newest slot is the last of them, so routing the names there put
+// the first name on the second call, dropped the unnamed first, and forked an
+// empty third on the name after it.
+test("late names fill the calls a split left waiting, in order", () => {
+  const parts = accumulate([
+    { index: 0, arguments: '{"a":1}{"b":2}' },
+    { index: 0, name: "web_search", arguments: "" },
+    { index: 0, name: "web_fetch", arguments: "" },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [
+      ["web_search", '{"a":1}'],
+      ["web_fetch", '{"b":2}'],
+    ],
   );
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -10,6 +10,7 @@ import {
   ToolCallArgumentBoundaries,
   bindStreamedToolCallBackendId,
   findStreamedToolCallPartIndex,
+  findUnclaimedToolCallPartIndex,
   findUnnamedToolCallPartIndex,
   mintStreamedToolCallId,
   resolveToolCallPartId,
@@ -65,7 +66,7 @@ function accumulate(
   const withheld = (part: AccumulatedPart) =>
     splitTails.has(part.toolCallId) &&
     part.result === undefined &&
-    scans.get(part.toolCallId)?.isOpen() === true;
+    scans.get(part.toolCallId)?.isUnfinished() === true;
   for (const event of fragments) {
     if ("toolStart" in event) {
       const at = parts.findIndex((part) => part.toolCallId === event.toolStart);
@@ -86,11 +87,19 @@ function accumulate(
     }
     const fragment = event;
     if (fragment.id) providerIds.add(fragment.id);
-    const target = findStreamedToolCallPartIndex(
+    let target = findStreamedToolCallPartIndex(
       parts,
       fragment.id,
       fragment.index,
     );
+    if (
+      fragment.id &&
+      target !== -1 &&
+      parts[target].toolCallId !== fragment.id
+    ) {
+      const unclaimed = findUnclaimedToolCallPartIndex(parts, fragment.index);
+      if (unclaimed !== -1) target = unclaimed;
+    }
     const slotPart = target === -1 ? undefined : parts[target];
     const matched = slotPart?.result === undefined ? slotPart : undefined;
     const name = fragment.name ?? "";
@@ -747,6 +756,37 @@ test("late names fill the calls a split left waiting, in order", () => {
     [
       ["web_search", '{"a":1}'],
       ["web_fetch", '{"b":2}'],
+    ],
+  );
+});
+
+// The boundary is recorded when the next `{` arrives, before that document has
+// parsed, so a split is already permanent when a later fragment closes it into
+// something malformed. The tail must not then look finished.
+test("a split whose document never parses counts as unfinished", () => {
+  const scan = new ToolCallArgumentBoundaries();
+  assert.deepEqual(scan.feed('{"q":"ok"}{bad'), [10]);
+  scan.feed("}");
+
+  assert.equal(scan.isOpen(), false);
+  assert.equal(scan.isUnfinished(), true);
+});
+
+// Two documents arrive before any identity, then late ids name them. Targeting
+// the open slot bound the first id to the second document, left the first
+// unnamed for the backend to drop, and opened an empty third call.
+test("a late id claims the first call a split left waiting", () => {
+  const parts = accumulate([
+    { index: 0, arguments: '{"a":1}{"b":2}' },
+    { id: "A", index: 0, name: "web_search", arguments: "" },
+    { id: "B", index: 0, name: "web_fetch", arguments: "" },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.toolName, part.argsText]),
+    [
+      ["A", "web_search", '{"a":1}'],
+      ["B", "web_fetch", '{"b":2}'],
     ],
   );
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -34,7 +34,16 @@ interface ToolEndEvent {
   toolEnd: string;
 }
 
-type StreamEvent = DeltaFragment | ToolStartEvent | ToolEndEvent;
+/** The provider-turn boundary, where the backend decides what it withholds. */
+interface RoundEndEvent {
+  finishReason: string;
+}
+
+type StreamEvent =
+  | DeltaFragment
+  | ToolStartEvent
+  | ToolEndEvent
+  | RoundEndEvent;
 
 /** The adapter's parseStreamedToolCallArgs, used by the tool_start mirror. */
 function parseArgs(raw: string): unknown {
@@ -62,7 +71,18 @@ function accumulate(
   const scans = new Map<string, ToolCallArgumentBoundaries>();
   const providerIds = new Set<string>();
   const splitTails = new Set<string>();
+  const retired = new Set<string>();
+  const withheld = (part: AccumulatedPart) =>
+    splitTails.has(part.toolCallId) &&
+    part.result === undefined &&
+    scans.get(part.toolCallId)?.isOpen() === true;
   for (const event of fragments) {
+    if ("finishReason" in event) {
+      for (const part of parts) {
+        if (withheld(part)) retired.add(part.toolCallId);
+      }
+      continue;
+    }
     if ("toolStart" in event) {
       const at = parts.findIndex((part) => part.toolCallId === event.toolStart);
       if (at !== -1) {
@@ -86,7 +106,12 @@ function accumulate(
       fragment.index,
     );
     const slotPart = target === -1 ? undefined : parts[target];
-    const matched = slotPart?.result === undefined ? slotPart : undefined;
+    const matched =
+      slotPart &&
+      slotPart.result === undefined &&
+      !retired.has(slotPart.toolCallId)
+        ? slotPart
+        : undefined;
     const name = fragment.name ?? "";
     let scan = matched ? scans.get(matched.toolCallId) : undefined;
     if (!scan) {
@@ -170,6 +195,7 @@ function accumulate(
         providerIds,
       );
     scans.set(callId, matched ? new ToolCallArgumentBoundaries() : scan);
+    if (matched) splitTails.add(callId);
     parts.push({
       toolCallId: callId,
       toolName: name,
@@ -182,12 +208,7 @@ function accumulate(
   // has to go.
   if (endOfStream) {
     for (let i = parts.length - 1; i >= 0; i -= 1) {
-      if (
-        splitTails.has(parts[i].toolCallId) &&
-        scans.get(parts[i].toolCallId)?.isOpen()
-      ) {
-        parts.splice(i, 1);
-      }
+      if (withheld(parts[i])) parts.splice(i, 1);
     }
   }
   return parts;
@@ -672,6 +693,51 @@ test("a second call on the same tool still splits on its arguments", () => {
     [
       ["web_search", '{"query":"first"}'],
       ["web_search", '{"query":"second"}'],
+    ],
+  );
+});
+
+// The name fork is a split like any other, so the backend withholds it when its
+// own document never closes. Without the marker the sweep cannot find its card
+// and it runs for the rest of the response.
+test("a name fork left unfinished is swept like any other split tail", () => {
+  const parts = accumulate(
+    [
+      { index: 0, name: "web_fetch", arguments: '{"url":"a"}' },
+      { index: 0, name: "web_search", arguments: "" },
+      { index: 0, arguments: '{"query":' },
+    ],
+    true,
+  );
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [["web_fetch", '{"url":"a"}']],
+  );
+});
+
+// The backend withheld the tail and ran only the first call, so the next round
+// has to open its own card. Continuing the tail fed the new arguments into a
+// call no event ever reaches, and the sweep then deleted them.
+test("a withheld split tail does not take the next round's arguments", () => {
+  const parts = accumulate(
+    [
+      { index: 0, name: "web_search", arguments: '{"a":1}{"b":' },
+      { toolStart: "tool_call_0" },
+      { toolEnd: "tool_call_0" },
+      { finishReason: "tool_calls" },
+      { index: 0, name: "web_search", arguments: '{"query":"second"}' },
+    ],
+    true,
+  );
+
+  // tool_call_1 is the withheld tail: its spelling stays spoken for, which is
+  // what keeps the next round on the tool_call_2 the backend mints for it.
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.argsText]),
+    [
+      ["tool_call_0", '{"a":1}'],
+      ["tool_call_2", '{"query":"second"}'],
     ],
   );
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -24,9 +24,10 @@ interface DeltaFragment {
 }
 
 /** The adapter's tool_start branch, which replaces argsText with the arguments
- * the backend parsed out of it. */
+ * the backend parsed out of it. An unrun card carries `{}`. */
 interface ToolStartEvent {
   toolStart: string;
+  arguments?: unknown;
 }
 
 /** The adapter's tool_end branch, which puts a result on the card. */
@@ -34,16 +35,7 @@ interface ToolEndEvent {
   toolEnd: string;
 }
 
-/** The provider-turn boundary, where the backend decides what it withholds. */
-interface RoundEndEvent {
-  finishReason: string;
-}
-
-type StreamEvent =
-  | DeltaFragment
-  | ToolStartEvent
-  | ToolEndEvent
-  | RoundEndEvent;
+type StreamEvent = DeltaFragment | ToolStartEvent | ToolEndEvent;
 
 /** The adapter's parseStreamedToolCallArgs, used by the tool_start mirror. */
 function parseArgs(raw: string): unknown {
@@ -71,30 +63,19 @@ function accumulate(
   const scans = new Map<string, ToolCallArgumentBoundaries>();
   const providerIds = new Set<string>();
   const splitTails = new Set<string>();
-  const retired = new Set<string>();
   const withheld = (part: AccumulatedPart) =>
     splitTails.has(part.toolCallId) &&
     part.result === undefined &&
     scans.get(part.toolCallId)?.isOpen() === true;
   for (const event of fragments) {
-    if ("finishReason" in event) {
-      for (const part of parts) {
-        if (withheld(part)) retired.add(part.toolCallId);
-      }
-      continue;
-    }
     if ("toolStart" in event) {
-      // The loop runs a call only once the provider turn is over, so tool_start
-      // is a round boundary too, and the one a provider that omits
-      // finish_reason still gives us.
-      for (const part of parts) {
-        if (withheld(part)) retired.add(part.toolCallId);
-      }
       const at = parts.findIndex((part) => part.toolCallId === event.toolStart);
       if (at !== -1) {
         parts[at] = {
           ...parts[at],
-          argsText: JSON.stringify(parseArgs(parts[at].argsText)),
+          argsText: JSON.stringify(
+            "arguments" in event ? event.arguments : parseArgs(parts[at].argsText),
+          ),
         };
       }
       continue;
@@ -112,12 +93,7 @@ function accumulate(
       fragment.index,
     );
     const slotPart = target === -1 ? undefined : parts[target];
-    const matched =
-      slotPart &&
-      slotPart.result === undefined &&
-      !retired.has(slotPart.toolCallId)
-        ? slotPart
-        : undefined;
+    const matched = slotPart?.result === undefined ? slotPart : undefined;
     const name = fragment.name ?? "";
     let scan = matched ? scans.get(matched.toolCallId) : undefined;
     if (!scan) {
@@ -722,48 +698,29 @@ test("a name fork left unfinished is swept like any other split tail", () => {
   );
 });
 
-// The backend withheld the tail and ran only the first call, so the next round
-// has to open its own card. Continuing the tail fed the new arguments into a
-// call no event ever reaches, and the sweep then deleted them.
+// The backend withheld the tail and closed its card with an unrun pair, so the
+// next round opens its own call. Before that close existed the tail stayed a
+// live match and swallowed the next round's arguments, which the sweep deleted.
 test("a withheld split tail does not take the next round's arguments", () => {
   const parts = accumulate(
     [
       { index: 0, name: "web_search", arguments: '{"a":1}{"b":' },
-      { finishReason: "tool_calls" },
-      { index: 0, name: "web_search", arguments: '{"query":"second"}' },
-    ],
-    true,
-  );
-
-  // tool_call_1 is the withheld tail: its spelling stays spoken for, which is
-  // what keeps the next round on the tool_call_2 the backend mints for it.
-  assert.deepEqual(
-    parts.map((part) => [part.toolCallId, part.argsText]),
-    [
-      ["tool_call_0", '{"a":1}'],
-      ["tool_call_2", '{"query":"second"}'],
-    ],
-  );
-});
-
-// The backend consumes each turn's [DONE] and runs the turn whether or not the
-// provider ever sent a finish_reason, so the boundary cannot depend on that
-// field alone. tool_start is emitted only after the turn, so it stands in.
-test("a withheld split tail is retired without a finish_reason", () => {
-  const parts = accumulate(
-    [
-      { index: 0, name: "web_search", arguments: '{"a":1}{"b":' },
-      { toolStart: "tool_call_0" },
+      { toolStart: "tool_call_1", arguments: {} },
+      { toolEnd: "tool_call_1" },
+      { toolStart: "tool_call_0", arguments: { a: 1 } },
       { toolEnd: "tool_call_0" },
       { index: 0, name: "web_search", arguments: '{"query":"second"}' },
     ],
     true,
   );
 
+  // tool_call_1 is the withheld tail. Its spelling stays spoken for, which is
+  // what keeps the next round on the tool_call_2 the backend mints for it.
   assert.deepEqual(
     parts.map((part) => [part.toolCallId, part.argsText]),
     [
       ["tool_call_0", '{"a":1}'],
+      ["tool_call_1", "{}"],
       ["tool_call_2", '{"query":"second"}'],
     ],
   );

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -94,6 +94,7 @@ function accumulate(
     );
     if (
       fragment.id &&
+      fragment.name &&
       target !== -1 &&
       parts[target].toolCallId !== fragment.id
     ) {
@@ -778,6 +779,25 @@ test("a split whose document never parses counts as unfinished", () => {
 test("a late id claims the first call a split left waiting", () => {
   const parts = accumulate([
     { index: 0, arguments: '{"a":1}{"b":2}' },
+    { id: "A", index: 0, name: "web_search", arguments: "" },
+    { id: "B", index: 0, name: "web_fetch", arguments: "" },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.toolName, part.argsText]),
+    [
+      ["A", "web_search", '{"a":1}'],
+      ["B", "web_fetch", '{"b":2}'],
+    ],
+  );
+});
+
+// The split hands its own name down to every segment, so a named segment can
+// still be waiting for the id that belongs to it. Requiring the name to be
+// missing bound the first id to the second document and opened an empty third.
+test("a late id claims a split call that inherited a name", () => {
+  const parts = accumulate([
+    { index: 0, name: "web_search", arguments: '{"a":1}{"b":2}' },
     { id: "A", index: 0, name: "web_search", arguments: "" },
     { id: "B", index: 0, name: "web_fetch", arguments: "" },
   ]);

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -24,8 +24,7 @@ interface DeltaFragment {
   extra?: unknown;
 }
 
-/** The adapter's tool_start branch, which replaces argsText with the arguments
- * the backend parsed out of it. An unrun card carries `{}`. */
+/** A tool_start event mirrored from the adapter. */
 interface ToolStartEvent {
   toolStart: string;
   arguments?: unknown;
@@ -54,8 +53,7 @@ type AccumulatedPart = StreamedToolCallPart & {
   result?: unknown;
 };
 
-/** Accumulate `delta.tool_calls[]` fragments the way the chat adapter does.
- * `endOfStream` also runs the sweep the adapter runs once the stream closes. */
+/** Mirror the adapter's tool-call accumulator and optional final sweep. */
 function accumulate(
   fragments: StreamEvent[],
   endOfStream = false,
@@ -198,8 +196,7 @@ function accumulate(
       ...(fragment.index !== undefined ? { _delta_index: fragment.index } : {}),
     });
   }
-  // The backend withholds a split call whose JSON never closed, so its card
-  // has to go.
+  // Drop split calls that the backend withheld.
   if (endOfStream) {
     for (let i = parts.length - 1; i >= 0; i -= 1) {
       if (withheld(parts[i])) parts.splice(i, 1);
@@ -572,10 +569,7 @@ test("replayed arguments keep parsable text and fall back otherwise", () => {
   assert.equal(toolCallReplayArguments(undefined, undefined), "{}");
 });
 
-// Both rounds are id-less and reuse index 0, so the second round's arguments
-// are cut off the first round's. tool_start has by then replaced argsText with
-// the arguments the backend parsed, which is a character shorter than the raw
-// JSON, so a cut measured against argsText lands inside both documents.
+// Boundary offsets must survive tool_start rewriting argsText.
 test("a next round splits correctly after tool_start rewrites the arguments", () => {
   const parts = accumulate([
     { index: 0, name: "web_search", arguments: '{"query": "first"}' },
@@ -604,9 +598,7 @@ test("boundary offsets index the scan's own text, not the part's", () => {
   ]);
 });
 
-// The backend withholds a split call whose JSON never closed, so nothing ever
-// closes its card. A provider id stamped on that tail renames the part, and the
-// sweep has to follow the rename or the card spins for the rest of the response.
+// A late provider id must not hide an unfinished split tail from cleanup.
 test("a split tail renamed by a late id is still dropped when its JSON never closes", () => {
   const parts = accumulate(
     [
@@ -622,9 +614,7 @@ test("a split tail renamed by a late id is still dropped when its JSON never clo
   );
 });
 
-// A thought signature belongs to one function call. Replaying a copy of it on
-// every call a split opened fails Gemini's signature validation, and the
-// backend puts it on the last call the delta opened.
+// Per-call metadata belongs only to the last call opened by a split.
 test("split metadata rides only the last call the delta opened", () => {
   const parts = accumulate([
     {
@@ -641,9 +631,7 @@ test("split metadata rides only the last call the delta opened", () => {
   );
 });
 
-// The first round's arguments never parsed, so its scan is stuck invalid. The
-// call ran anyway under the coercion path and its card is closed, so the next
-// round's fragments must open their own call rather than append to it.
+// A closed malformed call must not absorb the next round.
 test("a finished malformed call does not swallow the next round", () => {
   const parts = accumulate([
     { index: 0, name: "web_search", arguments: "{bad}" },
@@ -661,8 +649,7 @@ test("a finished malformed call does not swallow the next round", () => {
   );
 });
 
-// The accumulator supports dialects that resend a whole name, so a resend after
-// the arguments closed is the same call, not a second one to run with {}.
+// A resent whole name stays on the completed call.
 test("a name resent after its arguments closed opens no second call", () => {
   const parts = accumulate([
     { index: 0, name: "web_search", arguments: '{"query":"first"}' },
@@ -691,9 +678,7 @@ test("a second call on the same tool still splits on its arguments", () => {
   );
 });
 
-// The name fork is a split like any other, so the backend withholds it when its
-// own document never closes. Without the marker the sweep cannot find its card
-// and it runs for the rest of the response.
+// Cleanup must include unfinished name-only forks.
 test("a name fork left unfinished is swept like any other split tail", () => {
   const parts = accumulate(
     [
@@ -710,9 +695,7 @@ test("a name fork left unfinished is swept like any other split tail", () => {
   );
 });
 
-// The backend withheld the tail and closed its card with an unrun pair, so the
-// next round opens its own call. Before that close existed the tail stayed a
-// live match and swallowed the next round's arguments, which the sweep deleted.
+// A closed split tail must not absorb the next round.
 test("a withheld split tail does not take the next round's arguments", () => {
   const parts = accumulate(
     [
@@ -726,8 +709,7 @@ test("a withheld split tail does not take the next round's arguments", () => {
     true,
   );
 
-  // tool_call_1 is the withheld tail. Its spelling stays spoken for, which is
-  // what keeps the next round on the tool_call_2 the backend mints for it.
+  // The closed tail keeps tool_call_1 reserved.
   assert.deepEqual(
     parts.map((part) => [part.toolCallId, part.argsText]),
     [
@@ -738,10 +720,7 @@ test("a withheld split tail does not take the next round's arguments", () => {
   );
 });
 
-// Two dialects the accumulator already supports, together: arguments ahead of
-// the name, then the whole name resent as it grows. Reading the second name as
-// a new call left the arguments on a "web" call nothing can run and executed
-// web_search with nothing.
+// Early arguments and a resent growing name must remain one call.
 test("a growing name after early arguments still names one call", () => {
   const parts = accumulate([
     { index: 0, arguments: '{"query":"first"}' },
@@ -755,10 +734,7 @@ test("a growing name after early arguments still names one call", () => {
   );
 });
 
-// Both documents arrive before either name, so the split leaves two calls
-// waiting. The newest slot is the last of them, so routing the names there put
-// the first name on the second call, dropped the unnamed first, and forked an
-// empty third on the name after it.
+// Late names fill unnamed split calls in order.
 test("late names fill the calls a split left waiting, in order", () => {
   const parts = accumulate([
     { index: 0, arguments: '{"a":1}{"b":2}' },

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -110,7 +110,7 @@ function accumulate(
       !fragment.arguments &&
       Boolean(name) &&
       Boolean(matched?.toolName) &&
-      name !== matched?.toolName &&
+      !name.startsWith(matched?.toolName ?? "") &&
       scan.holdsOneCompleteDocument();
 
     if (segments.length > 1) {
@@ -723,5 +723,22 @@ test("a withheld split tail does not take the next round's arguments", () => {
       ["tool_call_1", "{}"],
       ["tool_call_2", '{"query":"second"}'],
     ],
+  );
+});
+
+// Two dialects the accumulator already supports, together: arguments ahead of
+// the name, then the whole name resent as it grows. Reading the second name as
+// a new call left the arguments on a "web" call nothing can run and executed
+// web_search with nothing.
+test("a growing name after early arguments still names one call", () => {
+  const parts = accumulate([
+    { index: 0, arguments: '{"query":"first"}' },
+    { index: 0, name: "web", arguments: "" },
+    { index: 0, name: "web_search", arguments: "" },
+  ]);
+
+  assert.deepEqual(
+    parts.map((part) => [part.toolName, part.argsText]),
+    [["web_search", '{"query":"first"}']],
   );
 });

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -84,6 +84,12 @@ function accumulate(
       continue;
     }
     if ("toolStart" in event) {
+      // The loop runs a call only once the provider turn is over, so tool_start
+      // is a round boundary too, and the one a provider that omits
+      // finish_reason still gives us.
+      for (const part of parts) {
+        if (withheld(part)) retired.add(part.toolCallId);
+      }
       const at = parts.findIndex((part) => part.toolCallId === event.toolStart);
       if (at !== -1) {
         parts[at] = {
@@ -723,8 +729,6 @@ test("a withheld split tail does not take the next round's arguments", () => {
   const parts = accumulate(
     [
       { index: 0, name: "web_search", arguments: '{"a":1}{"b":' },
-      { toolStart: "tool_call_0" },
-      { toolEnd: "tool_call_0" },
       { finishReason: "tool_calls" },
       { index: 0, name: "web_search", arguments: '{"query":"second"}' },
     ],
@@ -733,6 +737,29 @@ test("a withheld split tail does not take the next round's arguments", () => {
 
   // tool_call_1 is the withheld tail: its spelling stays spoken for, which is
   // what keeps the next round on the tool_call_2 the backend mints for it.
+  assert.deepEqual(
+    parts.map((part) => [part.toolCallId, part.argsText]),
+    [
+      ["tool_call_0", '{"a":1}'],
+      ["tool_call_2", '{"query":"second"}'],
+    ],
+  );
+});
+
+// The backend consumes each turn's [DONE] and runs the turn whether or not the
+// provider ever sent a finish_reason, so the boundary cannot depend on that
+// field alone. tool_start is emitted only after the turn, so it stands in.
+test("a withheld split tail is retired without a finish_reason", () => {
+  const parts = accumulate(
+    [
+      { index: 0, name: "web_search", arguments: '{"a":1}{"b":' },
+      { toolStart: "tool_call_0" },
+      { toolEnd: "tool_call_0" },
+      { index: 0, name: "web_search", arguments: '{"query":"second"}' },
+    ],
+    true,
+  );
+
   assert.deepEqual(
     parts.map((part) => [part.toolCallId, part.argsText]),
     [


### PR DESCRIPTION
## Summary

Fixes #9807.

This addresses the same issue as #9909 and #9817 with coordinated frontend and backend recovery.

Some OpenAI-compatible backends omit tool-call ids and report every parallel call at the same `index`. The frontend and backend then accumulate those calls in one slot, concatenating their argument objects into invalid JSON and losing all but one call.

This change separates id-less calls when their streamed arguments contain adjacent top-level JSON documents. The same recovery runs in both the frontend stream adapter and backend tool loop.

## Implementation

- Incremental scanners track JSON depth and string state across fragments, avoiding a full rescan after every delta.
- A boundary is accepted only after the completed document parses. Malformed arguments remain one call instead of being split into several malformed calls.
- Only id-less calls are split. Calls carrying provider ids continue through the existing id-based matching path.
- Names and per-call metadata follow the call opened by each split.
- Response-scoped card ids remain aligned between the frontend and backend, while conversation ids remain unique for replay.
- An unfinished call created by a split is not executed. Its card was already painted from the provider's own delta, so the loop closes it with an unrun card rather than leaving it open, the same way every other call it declines to run is closed. Provider-opened malformed calls retain the existing coercion behavior.

The scanners are linear in the amount of streamed argument text. Tests enforce this by counting scanned characters rather than relying on timing.

## Verification

- Frontend focused tests: 27 passed.
- Backend tool-loop and stream-abuse tests: 107 passed.
- Frontend typecheck passed.
- Full frontend suite matches the merge base: 5966 passed and the same 8 unrelated failures.
- The broader backend tool, agentic, and controller selection has the same 17 failures as the merge base.

The issue's four-call stream produces four distinct calls with valid arguments after this change. No live provider was tested.

## Scope

This does not repair already persisted malformed conversations or change how strict providers handle malformed historical arguments. Existing chats affected by #9807 still require a new conversation.

