### PR TITLE
Skip the inline-code mask when every backtick is inside a fence

### DIFF
--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -124,6 +124,27 @@ function findInlineCodeRegions(
   content: string,
   blockRegions: Array<[number, number]>,
 ): Array<[number, number]> {
+  // Every backtick inside a block region becomes a space in the mask below, so
+  // unless one sits outside a block region the mask cannot contain a backtick,
+  // `codeSpans` returns nothing and the whole rebuild is spent to learn that.
+  // Worth checking first because the streaming path calls this once per frame
+  // over a growing prefix, twice per preprocessLaTeX, so the rebuild is O(n) per
+  // frame and O(n^2) over a reply; and a reply carrying one fenced example and
+  // no inline code, where every backtick is inside the fence, is the common
+  // shape rather than a corner case.
+  let spanTickOutsideBlock = false;
+  for (
+    let index = content.indexOf("`");
+    index !== -1;
+    index = content.indexOf("`", index + 1)
+  ) {
+    if (!isInRegion(index, blockRegions)) {
+      spanTickOutsideBlock = true;
+      break;
+    }
+  }
+  if (!spanTickOutsideBlock) return [];
+
   let masked = content;
   if (blockRegions.length > 0) {
     const parts: string[] = [];

--- a/studio/frontend/tests/latex-code-regions.test.ts
+++ b/studio/frontend/tests/latex-code-regions.test.ts
@@ -135,3 +135,36 @@ test("same-line nested items set the continuation content column", () => {
     "-   - item\n\n        $x$",
   );
 });
+
+test("a fence's backticks do not stand in for an inline span", () => {
+  // findInlineCodeRegions returns early when no backtick sits outside a block
+  // region, because the mask it would build turns every backtick inside one
+  // into a space and can only yield no spans. The early return has to agree
+  // with the scan it replaces in both directions, so pin both.
+  const fence = "```python\ndef step(lr):\n    return lr\n```";
+
+  // All backticks inside the fence: nothing is an inline span, so currency in
+  // prose is still escaped and currency inside the fence is still left alone.
+  assert.equal(
+    preprocessLaTeX(`${fence}\n\ncosts $5 a run\n`),
+    `${fence}\n\ncosts \\$5 a run\n`,
+  );
+  assert.equal(
+    preprocessLaTeX("```sh\nrun --seed $1\n```\n"),
+    "```sh\nrun --seed $1\n```\n",
+  );
+
+  // One backtick outside the fence, so the scan still has to run: the inline
+  // span protects its own currency while prose currency is escaped.
+  assert.equal(
+    preprocessLaTeX(`${fence}\n\n\`cost $5\` and $6 in prose\n`),
+    `${fence}\n\n\`cost $5\` and \\$6 in prose\n`,
+  );
+
+  // An inline span before the fence, which the region scan reaches only after
+  // the fence has been masked out.
+  assert.equal(
+    preprocessLaTeX(`\`keep $7\` then\n\n${fence}\n\nand $8\n`),
+    `\`keep $7\` then\n\n${fence}\n\nand \\$8\n`,
+  );
+});


### PR DESCRIPTION
Recovers most of a streaming performance regression that `Frontend CI` has been failing on intermittently.

### What the test was telling us

`a reply with math streams near the cost of one without` in `streaming-latex-retro-edit.test.ts` has been failing on and off in `Frontend build + bundle sanity` and `Frontend unit tests (Windows)`:

```
math reply cost 4.2x the plain reply (math 510 ms, plain 122 ms)
```

It reads as a timing flake, so I checked before touching the threshold. It is not a flake. On an idle host the ratio is a stable 3.3x, with under 2 percent variance across runs. The test's own comment says it should be 1.1x to 1.2x.

Bisected across the 191 commits touching `studio/frontend/src`, first bad commit `e584ffc4` (#9796, escaped inline math in lists). Measured either side of it on the same host, same Node, same `node_modules`:

| | before #9796 | after |
|---|---|---|
| ratio the test measures | 1.5x | 3.3x |
| `preprocessLaTeX` | 55 ms | 166 ms |
| `stabilizeStreamingMarkdown` | 3 ms | 3 ms |
| `cache.update` | 42 ms | 39 ms |

All of it is in `preprocessLaTeX`. A CPU profile puts 29 percent of total runtime in `findInlineCodeRegions`, which #9796 added, and which `findCodeBlockRegions` now calls. `preprocessLaTeX` runs `findCodeBlockRegions` twice per frame, once inside `convertLatexDelimiters` and once for currency escaping, at 66 ms per pass out of 169 ms total.

### The change

`findInlineCodeRegions` masks every block region to spaces and rescans the result. When no backtick sits outside a block region the mask cannot contain one, so the scan can only return nothing and the whole rebuild is spent to learn that.

The check is exact rather than a heuristic. The mask replaces every non-line-ending character inside a block region with a space, so with no backtick outside one the masked string holds no backtick at all, `codeSpans` returns an empty list and `crossesBlock` is false. Returning early is the same answer by a shorter route.

It matters because the streaming path calls this once per frame over a growing prefix, so the mask is O(n) per frame and O(n^2) over a reply, and a reply with one fenced example and no inline code is the ordinary shape.

### Result

On the fixture that test uses, 300 units and 23,000 characters over 958 frames:

- math arm 217 ms to 136 ms
- ratio 3.35x to 2.11x

That clears the threshold of 4 with real headroom on slower CI hardware. It does not fully close the gap to the 1.5x before #9796; the rest is the second `findCodeBlockRegions` pass, which cannot be reused as is because conversion shifts offsets and can change indented-code detection. Left alone here rather than guessed at.

### Verification

- Full frontend suite: 5976 tests, 5976 pass, 0 fail
- The new test pins both directions, because an early return that fired too eagerly would look like a pure speedup. Currency in prose beside a fence is still escaped, currency inside the fence is still left alone, and an inline span before or after a fence still protects its own currency.
- Confirmed the new test fails if the early return is made unconditional: `` `cost $5` `` comes back as `` `cost \$5` ``.

### Note on the threshold

I deliberately did not touch the threshold of 4. It is what guards the whole-prefix rebuild that measured 9.8x, which is the thing the test exists for, and moving it would have hidden this instead of fixing it.
