### PR TITLE
Settle the compact layout before measuring the permission pill

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -338,11 +338,7 @@ def exercise_permission_mode_controls(page, shoot):
     # a box no user ever sees. The floating monitor's own viewport checks below
     # settle the same way rather than measuring immediately.
     def fits_compact(box) -> bool:
-        return (
-            box is not None
-            and box["x"] >= 0
-            and box["x"] + box["width"] <= compact_width
-        )
+        return box is not None and box["x"] >= 0 and box["x"] + box["width"] <= compact_width
 
     deadline = time.time() + 5
     box = pill.bounding_box()

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -326,10 +326,30 @@ def exercise_permission_mode_controls(page, shoot):
     expect(page.get_by_role("alertdialog")).to_have_count(0)
 
     # Pointer and compact-layout coverage.
-    page.set_viewport_size({"width": 390, "height": 844})
+    compact_width = 390
+    page.set_viewport_size({"width": compact_width, "height": 844})
     expect(pill).to_be_visible()
+
+    # Let the reflow land before measuring. set_viewport_size returns once the
+    # viewport is set, not once the layout has responded to it, and
+    # to_be_visible does not cover the gap: the pill is already visible, at its
+    # old width. Reading the box straight away can catch the pre-reflow
+    # geometry, which is off the right edge of the narrow viewport and fails on
+    # a box no user ever sees. The floating monitor's own viewport checks below
+    # settle the same way rather than measuring immediately.
+    def fits_compact(box) -> bool:
+        return (
+            box is not None
+            and box["x"] >= 0
+            and box["x"] + box["width"] <= compact_width
+        )
+
+    deadline = time.time() + 5
     box = pill.bounding_box()
-    if box is None or box["x"] < 0 or box["x"] + box["width"] > 390:
+    while not fits_compact(box) and time.time() < deadline:
+        page.wait_for_timeout(50)
+        box = pill.bounding_box()
+    if not fits_compact(box):
         fail(f"permission pill is clipped in compact layout: {box!r}")
     page.set_viewport_size({"width": 1280, "height": 900})
 


### PR DESCRIPTION
`Chat UI Tests (chat)` failed on #9991 with a geometry assertion that had nothing to do with that change:

```
[ui] FAIL: permission pill is clipped in compact layout:
{'x': 328, 'y': 568.5, 'width': 108.046875, 'height': 51.375}
```

328 + 108 = 436, against a 390px viewport.

### Why it happens

`exercise_permission_mode_controls` sets the compact viewport and reads the bounding box on the next line:

```python
page.set_viewport_size({"width": 390, "height": 844})
expect(pill).to_be_visible()
box = pill.bounding_box()
```

`set_viewport_size` returns once the viewport is set, not once the layout has responded to it. The `to_be_visible` between them does not cover the gap either, because the pill is already visible, at its old width. When the reflow has not landed yet the box that gets measured is the pre-reflow one, which sits off the right edge of the narrow viewport, and the run fails on geometry no user ever sees.

That makes it timing dependent rather than deterministic, which matches how it behaves: it passes on main and on other open PRs, and turned up once on a run whose only other content was an unrelated change to inline-code region detection. The same run also logged `webkit: TargetClosedError`, so that leg was already unhappy.

### The fix

Poll the box until it fits the compact viewport or five seconds pass. This is the pattern the file already uses for the same problem: the floating monitor's viewport checks a few hundred lines down go through `wait_for_box`, which loops on a predicate with a five second deadline, rather than measuring immediately after a resize.

The assertion itself is unchanged. A pill that is genuinely clipped still fails; it just has to still be clipped once the layout has settled, which is the thing the test means to check.
