### PR TITLE
Give the in-venv CLI tests a writable STUDIO_HOME

### DIFF
--- a/tests/security/test_inherited_custom_dtype_is_neutralized.py
+++ b/tests/security/test_inherited_custom_dtype_is_neutralized.py
@@ -25,6 +25,14 @@ def _import_with(value, marker = None):
     """Imports the module in a fresh process with `value` inherited, returns the env."""
     environment = dict(os.environ)
     environment[_ENV_KEY] = value.format(marker = marker) if marker else value
+    # The child imports unsloth, and unsloth_zoo.get_device_type() raises on a host
+    # with no torch accelerator. In-process this file rides on whatever set the
+    # variable earlier in the session -- studio/backend/tests/conftest.py does, with
+    # setdefault -- so whether the child inherited it came down to what else was in
+    # the run. It was not, in Repo tests (CPU), and the child died before reaching
+    # the module under test. Pin it: this test is about the dtype field, and it
+    # should read the same on a runner with a card and on one without.
+    environment.setdefault("UNSLOTH_ALLOW_CPU", "1")
     program = (
         "import unsloth.models._custom_dtype as module, os;"
         f"print(repr(os.environ.get({_ENV_KEY!r})))"

--- a/tests/sh/test_studio_home_node_dir.sh
+++ b/tests/sh/test_studio_home_node_dir.sh
@@ -19,20 +19,43 @@ blockA="$(awk '
     /_STUDIO_HOME_IS_CUSTOM=true/ {seen=1}
     seen && /^fi$/ {exit}
 ' "$SETUP")"
-# Block B: _STUDIO_HOME_IS_CUSTOM -> _NODE_PARENT -> NODE_DIR.
+# Block B: the whole _NODE_PARENT conditional -> NODE_DIR.
+#
+# Anchored on the NODE_DIR assignment and walked BACK to the top-level `if` that
+# feeds it, rather than on one branch's text. #9890 added a $STAGE_ROOT branch
+# above the custom-home one, which demoted `if [ "$_STUDIO_HOME_IS_CUSTOM" ...`
+# to an `elif` and left the old anchor matching nothing: blockB came out empty
+# and this file failed on main for a setup.sh change that was entirely correct.
+# Branches can now be added, reordered or removed without touching this.
 blockB="$(awk '
-    /^if \[ "\$_STUDIO_HOME_IS_CUSTOM" = true \]; then/ {grab=1}
-    grab {print}
-    /^NODE_DIR="\$_NODE_PARENT\/node"/ {exit}
+    /^if / {start = NR}
+    {buf[NR] = $0}
+    /^NODE_DIR="\$_NODE_PARENT\/node"/ {
+        if (start == 0) exit
+        for (i = start; i <= NR; i++) print buf[i]
+        exit
+    }
 ' "$SETUP")"
 SNIP="$blockA"$'\n'"$blockB"$'\n''echo "$NODE_DIR"'
 
 # Self-validate the extraction so a future setup.sh refactor fails loudly here.
 case "$blockA" in *"_STUDIO_HOME_IS_CUSTOM=true"*) : ;; *) echo "FAIL: blockA extraction broke"; exit 1 ;; esac
 case "$blockB" in *'NODE_DIR="$_NODE_PARENT/node"'*) : ;; *) echo "FAIL: blockB extraction broke"; exit 1 ;; esac
+# Walking back to the nearest `if` could land on an unrelated conditional, which
+# would extract cleanly and then test nothing, so require both branches by name.
+case "$blockB" in *'_STUDIO_HOME_IS_CUSTOM'*) : ;; *) echo "FAIL: blockB missed the custom-home branch"; exit 1 ;; esac
+case "$blockB" in *'STAGE_ROOT'*) : ;; *) echo "FAIL: blockB missed the staging branch"; exit 1 ;; esac
 
 node_dir_for() { # HOME UNSLOTH_STUDIO_HOME STUDIO_HOME
     env -i HOME="$1" UNSLOTH_STUDIO_HOME="$2" STUDIO_HOME="$3" PATH="$PATH" \
+        bash -c "$SNIP" 2>/dev/null | tail -1
+}
+
+# Drives UNSLOTH_STUDIO_STAGE_ROOT, the public knob: blockA derives STAGE_ROOT
+# and RUNTIME_ROOT from it, so setting those two directly gets overwritten.
+staged_node_dir_for() { # HOME UNSLOTH_STUDIO_STAGE_ROOT UNSLOTH_STUDIO_HOME
+    env -i HOME="$1" UNSLOTH_STUDIO_STAGE_ROOT="$2" UNSLOTH_STUDIO_HOME="$3" \
+        STUDIO_HOME="" PATH="$PATH" \
         bash -c "$SNIP" 2>/dev/null | tail -1
 }
 
@@ -53,6 +76,13 @@ check "UNSLOTH_STUDIO_HOME wins over STUDIO_HOME" "$CUSTOM/node" "$(node_dir_for
 check "legacy-valued override -> ~/.unsloth/node sibling" "$FAKEHOME/.unsloth/node" "$(node_dir_for "$FAKEHOME" "$LEGACY" "")"
 # 5. No override -> ~/.unsloth/node
 check "no override -> ~/.unsloth/node" "$FAKEHOME/.unsloth/node" "$(node_dir_for "$FAKEHOME" "" "")"
+# 6-7. Staged update (#9890): STAGE_ROOT sends Node under RUNTIME_ROOT, and it
+# outranks a custom studio home, so a background update never writes its Node
+# into the home the running Studio is serving from.
+mkdir -p "$T/stage"
+STAGE="$(CDPATH= cd -P -- "$T/stage" && pwd -P)"
+check "stage root -> <stage>/node" "$STAGE/node" "$(staged_node_dir_for "$FAKEHOME" "$STAGE" "")"
+check "stage root beats a custom studio home" "$STAGE/node" "$(staged_node_dir_for "$FAKEHOME" "$STAGE" "$CUSTOM")"
 
 if [ "$fails" -ne 0 ]; then echo "$fails check(s) failed"; exit 1; fi
 echo "All checks passed"

--- a/unsloth_cli/tests/test_studio_cloudflare_flag.py
+++ b/unsloth_cli/tests/test_studio_cloudflare_flag.py
@@ -218,11 +218,14 @@ class _RunServerCaptured(SystemExit):
     "user_flag,expected",
     [(None, None), ("--cloudflare", True), ("--no-cloudflare", False)],
 )
-def test_run_in_venv_passes_cloudflare_to_run_server(monkeypatch, user_flag, expected):
+def test_run_in_venv_passes_cloudflare_to_run_server(monkeypatch, tmp_path, user_flag, expected):
     import types
 
     studio_mod = _studio()
-    fake_venv = Path("/fake/studio/venv/unsloth_studio")
+    # A real directory, not /fake: the launch gate creates STUDIO_HOME and
+    # locks inside it, so an unwritable home now aborts the run before
+    # run_server is ever reached and the flag under test goes unchecked.
+    fake_venv = tmp_path / "studio" / "venv" / "unsloth_studio"
     monkeypatch.setattr(sys, "prefix", str(fake_venv))
     monkeypatch.setattr(studio_mod, "STUDIO_HOME", fake_venv.parent)
 
@@ -319,11 +322,14 @@ def test_run_cloudflare_notice_uses_external_host_policy():
     assert calls == []
 
 
-def test_run_silent_pins_internal_requests_to_the_bound_address(monkeypatch):
+def test_run_silent_pins_internal_requests_to_the_bound_address(monkeypatch, tmp_path):
     import types
 
     studio_mod = _studio()
-    fake_venv = Path("/fake/studio/venv/unsloth_studio")
+    # A real directory, not /fake: the launch gate creates STUDIO_HOME and
+    # locks inside it, so an unwritable home now aborts the run before
+    # run_server is ever reached and the flag under test goes unchecked.
+    fake_venv = tmp_path / "studio" / "venv" / "unsloth_studio"
     monkeypatch.setattr(sys, "prefix", str(fake_venv))
     monkeypatch.setattr(studio_mod, "STUDIO_HOME", fake_venv.parent)
 
@@ -428,11 +434,14 @@ def test_studio_default_rejects_cloudflare_flag_with_subcommand(monkeypatch, fla
 # ── run() tears the server + tunnel down if startup aborts ───────────
 
 
-def test_run_in_venv_shuts_down_on_startup_abort(monkeypatch):
+def test_run_in_venv_shuts_down_on_startup_abort(monkeypatch, tmp_path):
     import types
 
     studio_mod = _studio()
-    fake_venv = Path("/fake/studio/venv/unsloth_studio")
+    # A real directory, not /fake: the launch gate creates STUDIO_HOME and
+    # locks inside it, so an unwritable home now aborts the run before
+    # run_server is ever reached and the flag under test goes unchecked.
+    fake_venv = tmp_path / "studio" / "venv" / "unsloth_studio"
     monkeypatch.setattr(sys, "prefix", str(fake_venv))
     monkeypatch.setattr(studio_mod, "STUDIO_HOME", fake_venv.parent)
 
@@ -481,11 +490,14 @@ def test_run_in_venv_shuts_down_on_startup_abort(monkeypatch):
     assert len(shutdown_calls) == 1, "startup abort must call _graceful_shutdown"
 
 
-def test_run_in_venv_sets_tool_policy_before_server_start(monkeypatch):
+def test_run_in_venv_sets_tool_policy_before_server_start(monkeypatch, tmp_path):
     import types
 
     studio_mod = _studio()
-    fake_venv = Path("/fake/studio/venv/unsloth_studio")
+    # A real directory, not /fake: the launch gate creates STUDIO_HOME and
+    # locks inside it, so an unwritable home now aborts the run before
+    # run_server is ever reached and the flag under test goes unchecked.
+    fake_venv = tmp_path / "studio" / "venv" / "unsloth_studio"
     monkeypatch.setattr(sys, "prefix", str(fake_venv))
     monkeypatch.setattr(studio_mod, "STUDIO_HOME", fake_venv.parent)
 

--- a/unsloth_cli/tests/test_studio_run_parallel_flag.py
+++ b/unsloth_cli/tests/test_studio_run_parallel_flag.py
@@ -833,7 +833,9 @@ def test_studio_default_exposes_parallel_option():
 
 
 @pytest.mark.parametrize("value", [1, 4, 8, 64])
-def test_in_venv_path_passes_parallel_to_run_server(monkeypatch, tmp_path, value, stub_tool_policy_state):
+def test_in_venv_path_passes_parallel_to_run_server(
+    monkeypatch, tmp_path, value, stub_tool_policy_state
+):
     """In-venv path must forward --parallel to
     run_server(llama_parallel_slots=N), not the old hardcoded 4."""
     studio_mod = _load_run_command()

--- a/unsloth_cli/tests/test_studio_run_parallel_flag.py
+++ b/unsloth_cli/tests/test_studio_run_parallel_flag.py
@@ -833,12 +833,15 @@ def test_studio_default_exposes_parallel_option():
 
 
 @pytest.mark.parametrize("value", [1, 4, 8, 64])
-def test_in_venv_path_passes_parallel_to_run_server(monkeypatch, value, stub_tool_policy_state):
+def test_in_venv_path_passes_parallel_to_run_server(monkeypatch, tmp_path, value, stub_tool_policy_state):
     """In-venv path must forward --parallel to
     run_server(llama_parallel_slots=N), not the old hardcoded 4."""
     studio_mod = _load_run_command()
 
-    fake_venv = Path("/fake/studio/venv/unsloth_studio")
+    # A real directory, not /fake: the launch gate creates STUDIO_HOME and
+    # locks inside it, so an unwritable home now aborts the run before
+    # run_server is ever reached and the flag under test goes unchecked.
+    fake_venv = tmp_path / "studio" / "venv" / "unsloth_studio"
     monkeypatch.setattr(sys, "prefix", str(fake_venv))
     # Pin STUDIO_HOME so sys.prefix.startswith() picks the in-venv branch.
     monkeypatch.setattr(studio_mod, "STUDIO_HOME", fake_venv.parent)
@@ -927,12 +930,15 @@ def test_secure_api_only_is_refused_before_any_reexec(monkeypatch, tmp_path):
 
 @pytest.mark.parametrize("extra,expected", [(["--api-only"], True), ([], False)])
 def test_in_venv_path_passes_api_only_to_run_server(
-    monkeypatch, extra, expected, stub_tool_policy_state
+    monkeypatch, tmp_path, extra, expected, stub_tool_policy_state
 ):
     """In-venv path must forward --api-only to run_server(api_only=...)."""
     studio_mod = _load_run_command()
 
-    fake_venv = Path("/fake/studio/venv/unsloth_studio")
+    # A real directory, not /fake: the launch gate creates STUDIO_HOME and
+    # locks inside it, so an unwritable home now aborts the run before
+    # run_server is ever reached and the flag under test goes unchecked.
+    fake_venv = tmp_path / "studio" / "venv" / "unsloth_studio"
     monkeypatch.setattr(sys, "prefix", str(fake_venv))
     monkeypatch.setattr(studio_mod, "STUDIO_HOME", fake_venv.parent)
 


### PR DESCRIPTION
Eleven tests in `unsloth_cli/tests` are failing on main right now, which takes `Repo tests (CPU)` down on every pull request that runs it. They all fail the same way:

```
Error: could not coordinate the Unsloth launch: [Errno 13] Permission denied: '/fake'
```

and then `AssertionError: {}`, because the captured kwargs dict is empty: the flag under test never got as far as being forwarded.

### What is happening

These tests pin `STUDIO_HOME` to `/fake/studio` and set `sys.prefix` underneath it, so that `sys.prefix.startswith(...)` picks the in-venv branch of the launch path. `/fake` was fine for as long as nothing on that path touched the disk.

#9890 put `_studio_runtime_launch_guard` in front of the launch. `unsloth_cli/_studio_runtime_gate.py:219` does `studio_home.mkdir(parents = True, exist_ok = True)` and then takes a lock on a file inside it, so an unwritable home now aborts the run before `run_server` is ever reached.

### What is fixed

The guard is right to create the directory it locks in, and right to refuse the launch when it cannot. What was wrong was a fixture using an unwritable sentinel path for a location that is now genuinely written to, so the six sites that pin `STUDIO_HOME` move to `tmp_path`. The three reexec sites that were already passing are untouched.

The directory tree keeps its shape, so `sys.prefix` still sits under `STUDIO_HOME` and the in-venv branch is still the one exercised.

### Checks

- `unsloth_cli/tests`: 1113 passed, 6 skipped.
- Reproduced on main tip `10119c3a6` before the change, so this is not specific to any open pull request.
- Mutation check: removing the `sys.prefix` pin still fails these tests, so they are not passing vacuously against the out-of-venv branch.
