### PR TITLE
Stop one slow SQLite writer from becoming a stream of Studio log errors

### DIFF
--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -56,7 +56,12 @@ from core.research.prompts import (
 )
 from loggers import get_logger
 from storage import research_runs_db as db
-from storage.studio_db import get_chat_message, list_chat_messages, upsert_chat_message
+from storage.studio_db import (
+    get_chat_message,
+    is_sqlite_busy_error,
+    list_chat_messages,
+    upsert_chat_message,
+)
 
 logger = get_logger(__name__)
 _URL_BLOCK = re.compile(
@@ -1119,12 +1124,15 @@ class ResearchSupervisor:
             except sqlite3.OperationalError as exc:
                 # Losing a race for the writer lock is a normal outcome of polling a
                 # shared database, not a fault: one slow writer elsewhere produced six
-                # identical multi-line tracebacks in a single session. Retry quietly and
-                # let a genuine, non-transient sqlite failure fall through to the
-                # traceback below.
-                if "locked" not in str(exc).lower() and "busy" not in str(exc).lower():
-                    raise
-                logger.warning("research.supervisor_db_busy: %s", exc)
+                # identical multi-line tracebacks in a single session. Only the busy case
+                # is quietened; anything else keeps the traceback it had before. Both
+                # still sleep and continue, because re-raising here would escape the
+                # while loop and stop the supervisor for the life of the process --
+                # the sibling `except Exception` below cannot catch a raise from here.
+                if is_sqlite_busy_error(exc):
+                    logger.warning("research.supervisor_db_busy: %s", exc)
+                else:
+                    logger.exception("research.supervisor_iteration_failed")
                 await asyncio.sleep(1)
             except Exception:
                 logger.exception("research.supervisor_iteration_failed")

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1122,13 +1122,10 @@ class ResearchSupervisor:
             except asyncio.CancelledError:
                 raise
             except sqlite3.OperationalError as exc:
-                # Losing a race for the writer lock is a normal outcome of polling a
-                # shared database, not a fault: one slow writer elsewhere produced six
-                # identical multi-line tracebacks in a single session. Only the busy case
-                # is quietened; anything else keeps the traceback it had before. Both
-                # still sleep and continue, because re-raising here would escape the
-                # while loop and stop the supervisor for the life of the process --
-                # the sibling `except Exception` below cannot catch a raise from here.
+                # Losing the writer lock is normal for polling, not a fault, and produced
+                # six tracebacks in one session. Only that case is quietened. Neither may
+                # re-raise: that escapes the while loop and stops the supervisor for the
+                # life of the process, and the sibling `except Exception` cannot catch it.
                 if is_sqlite_busy_error(exc):
                     logger.warning("research.supervisor_db_busy: %s", exc)
                 else:

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1116,6 +1116,16 @@ class ResearchSupervisor:
                 await self._process(run)
             except asyncio.CancelledError:
                 raise
+            except sqlite3.OperationalError as exc:
+                # Losing a race for the writer lock is a normal outcome of polling a
+                # shared database, not a fault: one slow writer elsewhere produced six
+                # identical multi-line tracebacks in a single session. Retry quietly and
+                # let a genuine, non-transient sqlite failure fall through to the
+                # traceback below.
+                if "locked" not in str(exc).lower() and "busy" not in str(exc).lower():
+                    raise
+                logger.warning("research.supervisor_db_busy: %s", exc)
+                await asyncio.sleep(1)
             except Exception:
                 logger.exception("research.supervisor_iteration_failed")
                 await asyncio.sleep(1)

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1407,6 +1407,11 @@ app.add_middleware(
     allow_credentials = True,
     allow_methods = ["*"],
     allow_headers = ["*"],
+    # allow_headers governs the REQUEST side; a response header stays unreadable to JS
+    # unless it is exposed. Studio is same-origin in the common case but not from
+    # tauri://localhost or a tunnel, and the chat autosave has to tell a protected message
+    # apart from a thread-id collision to know whether to stop or to surface the failure.
+    expose_headers = ["X-Unsloth-Conflict-Kind"],
     # is_allowed_origin closes the moment the tunnel URL clears, but a preflight
     # already cached by the browser does not. Measured in WebKit: with Starlette's
     # 600s default, a state-changing request still REACHED the server after remote

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1407,10 +1407,8 @@ app.add_middleware(
     allow_credentials = True,
     allow_methods = ["*"],
     allow_headers = ["*"],
-    # allow_headers governs the REQUEST side; a response header stays unreadable to JS
-    # unless it is exposed. Studio is same-origin in the common case but not from
-    # tauri://localhost or a tunnel, and the chat autosave has to tell a protected message
-    # apart from a thread-id collision to know whether to stop or to surface the failure.
+    # allow_headers is the REQUEST side; a response header is unreadable to JS unless
+    # exposed, and Studio is cross-origin from tauri://localhost and tunnels.
     expose_headers = ["X-Unsloth-Conflict-Kind"],
     # is_allowed_origin closes the moment the tunnel URL clears, but a preflight
     # already cached by the browser does not. Measured in WebKit: with Starlette's

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -582,6 +582,20 @@ class ChatImportLedgerRecordResponse(BaseModel):
     inserted: int
 
 
+# The client cannot tell the two 409s apart from the status alone, and they mean opposite
+# things: a protected message is the server refusing an edit it owns, so the autosave should
+# stop; a thread collision is an ordinary failure the caller must see and handle. Answering
+# both the same way made the frontend swallow a collision as success. The kind rides in a
+# response header rather than the body so `detail` stays a plain string for every existing
+# client; `expose_headers` in main.py is what lets a cross-origin Studio read it.
+CONFLICT_KIND_HEADER = "X-Unsloth-Conflict-Kind"
+
+
+def _conflict_headers(exc: Exception) -> dict:
+    kind = "protected" if isinstance(exc, ChatMessageProtectedError) else "thread-collision"
+    return {CONFLICT_KIND_HEADER: kind}
+
+
 @router.get("/threads", response_model = ChatThreadListResponse)
 def list_threads(
     model_type: Optional[str] = Query(None),
@@ -1031,6 +1045,7 @@ def delete_attachment(
             safe_curated_detail(exc),
             event = "chat_history.delete_attachment_conflict",
             log = logger,
+            headers = _conflict_headers(exc),
         ) from exc
     if not deleted:
         raise HTTPException(status_code = 404, detail = "Attachment not found")
@@ -1351,6 +1366,7 @@ def save_thread_message(
             safe_curated_detail(exc),
             event = "chat_history.save_message_conflict",
             log = logger,
+            headers = _conflict_headers(exc),
         ) from exc
 
 
@@ -1394,6 +1410,7 @@ def replace_thread_messages(
             safe_curated_detail(exc),
             event = "chat_history.replace_messages_conflict",
             log = logger,
+            headers = _conflict_headers(exc),
         ) from exc
 
 

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -582,12 +582,9 @@ class ChatImportLedgerRecordResponse(BaseModel):
     inserted: int
 
 
-# The client cannot tell the two 409s apart from the status alone, and they mean opposite
-# things: a protected message is the server refusing an edit it owns, so the autosave should
-# stop; a thread collision is an ordinary failure the caller must see and handle. Answering
-# both the same way made the frontend swallow a collision as success. The kind rides in a
-# response header rather than the body so `detail` stays a plain string for every existing
-# client; `expose_headers` in main.py is what lets a cross-origin Studio read it.
+# Both conflicts are 409 and mean opposite things: protected means stop resending, a thread
+# collision means surface the failure. In a header, not the body, so `detail` stays a plain
+# string for existing clients; main.py must expose it for a cross-origin Studio to read it.
 CONFLICT_KIND_HEADER = "X-Unsloth-Conflict-Kind"
 
 

--- a/studio/backend/storage/api_usage_db.py
+++ b/studio/backend/storage/api_usage_db.py
@@ -15,7 +15,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Callable, Optional
 
-from storage.studio_db import get_connection
+from storage.studio_db import get_connection, is_sqlite_busy_error
 
 
 # Kept aligned with the API monitor's defensive upper bound. The storage layer
@@ -94,8 +94,8 @@ def canonical_api_model(model: object) -> str:
 
 
 def _is_busy_error(exc: sqlite3.OperationalError) -> bool:
-    message = str(exc).lower()
-    return "locked" in message or "busy" in message
+    # One definition, in the module that owns the contended file.
+    return is_sqlite_busy_error(exc)
 
 
 def _sleep_after_busy(delay: float) -> None:

--- a/studio/backend/storage/research_runs_db.py
+++ b/studio/backend/storage/research_runs_db.py
@@ -870,11 +870,9 @@ _CLAIMABLE_SQL = """SELECT r.id FROM research_runs r
 def _has_claimable(now: int) -> bool:
     """Read-only probe for claimable work, taking no write lock.
 
-    The supervisor polls twice a second for the whole life of the process, and almost
-    every poll finds nothing. Opening BEGIN IMMEDIATE first meant an idle Studio grabbed
-    studio.db's writer lock 2x/second forever, so any genuinely slow writer elsewhere
-    turned into a stream of "database is locked" failures here. Checking first costs one
-    indexed read and keeps the write lock for polls that will actually claim something.
+    The supervisor polls twice a second forever and almost every poll finds nothing, so
+    opening BEGIN IMMEDIATE first meant an idle Studio held the writer lock 2x/second and
+    any slow writer elsewhere became a stream of "database is locked" here.
     """
     conn = get_connection()
     try:

--- a/studio/backend/storage/research_runs_db.py
+++ b/studio/backend/storage/research_runs_db.py
@@ -859,7 +859,35 @@ def retry(run_id: str, max_retries: int = 3) -> str:
         conn.close()
 
 
+_CLAIMABLE_SQL = """SELECT r.id FROM research_runs r
+               JOIN research_thread_claims c ON c.thread_id=r.thread_id
+               WHERE r.owner_subject=c.owner_subject
+                 AND r.status IN ('planning','queued','running','cancelling')
+                 AND (r.lease_owner IS NULL OR r.lease_expires_at < ?)
+               LIMIT 1"""
+
+
+def _has_claimable(now: int) -> bool:
+    """Read-only probe for claimable work, taking no write lock.
+
+    The supervisor polls twice a second for the whole life of the process, and almost
+    every poll finds nothing. Opening BEGIN IMMEDIATE first meant an idle Studio grabbed
+    studio.db's writer lock 2x/second forever, so any genuinely slow writer elsewhere
+    turned into a stream of "database is locked" failures here. Checking first costs one
+    indexed read and keeps the write lock for polls that will actually claim something.
+    """
+    conn = get_connection()
+    try:
+        return conn.execute(_CLAIMABLE_SQL, (now,)).fetchone() is not None
+    finally:
+        conn.close()
+
+
 def claim_next(worker_id: str, lease_ms: int = 120_000) -> dict | None:
+    # Advisory only: the row can disappear between this probe and the transaction below,
+    # which the "row is None" branch inside already handles.
+    if not _has_claimable(now_ms()):
+        return None
     conn = get_connection()
     try:
         conn.execute("BEGIN IMMEDIATE")

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -603,10 +603,18 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         END
         """
     )
+    # Scoped to the two columns _rebuild_chat_attachment_inventory actually reads. The
+    # unscoped version fired on any UPDATE, so a generation status change -- which touches
+    # only metadata_json, from chat_generation_runs_db and research_runs_db -- marked the
+    # inventory dirty, and the next chat autosave paid for a full DELETE + re-hash of every
+    # attachment in every thread while holding the writer lock inside BEGIN IMMEDIATE.
+    # Dropped rather than IF NOT EXISTS: existing installs already carry the unscoped
+    # trigger, and a create would silently keep it.
+    conn.execute("DROP TRIGGER IF EXISTS chat_attachment_inventory_dirty_update")
     conn.execute(
         """
-        CREATE TRIGGER IF NOT EXISTS chat_attachment_inventory_dirty_update
-        AFTER UPDATE ON chat_messages
+        CREATE TRIGGER chat_attachment_inventory_dirty_update
+        AFTER UPDATE OF attachments_json, content_json ON chat_messages
         BEGIN
             INSERT INTO chat_attachment_inventory_state
                 (singleton, inventory_version, dirty, backfilled_at)
@@ -1174,6 +1182,14 @@ def get_connection(busy_timeout_seconds: float = _BUSY_TIMEOUT_SECONDS) -> sqlit
     conn.row_factory = sqlite3.Row
     # foreign_keys is session-scoped; set per connection
     conn.execute("PRAGMA foreign_keys=ON")
+    # Under WAL, sqlite still defaults to synchronous=FULL, which fsyncs on every commit
+    # while holding the writer lock. On a machine whose disk is busy -- a Colab session
+    # pulling a multi-GB GGUF, say -- one commit blocked for 37s, and every other writer
+    # (notably the research supervisor's claim_next) spent that whole window timing out
+    # with "database is locked". NORMAL is the documented safe pairing for WAL: it can
+    # lose the last transactions on a host power loss, but never corrupts the database,
+    # which is the right trade for a local UI's settings and chat history.
+    conn.execute("PRAGMA synchronous=NORMAL")
     if not _schema_ready:
         with _schema_lock:
             if not _schema_ready:

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -1165,12 +1165,49 @@ def bulk_upsert_prompt_lists(lists: list[dict]) -> int:
         conn.close()
 
 
+def is_sqlite_busy_error(exc: sqlite3.OperationalError) -> bool:
+    """Is this the writer lock being held elsewhere, rather than a real fault?
+
+    sqlite reports it as plain OperationalError, so the message is the only signal.
+    Lives here because studio.db is the contended file and several modules need the
+    same answer; storage.api_usage_db delegates to it.
+    """
+    message = str(exc).lower()
+    return "locked" in message or "busy" in message
+
+
 # sqlite's own default, kept for every caller that may run on the event loop
 _BUSY_TIMEOUT_SECONDS = 5.0
 
 # only for the chat history transactions that run in Starlette's threadpool, where a large clear
 # can hold the writer lock past the default and the failure escapes as an unmapped 500
 _CONTENDED_BUSY_TIMEOUT_SECONDS = 30.0
+
+
+def _apply_wal_synchronous(conn: sqlite3.Connection) -> None:
+    """Drop to synchronous=NORMAL, but only while the file is really in WAL mode.
+
+    Under WAL, sqlite still defaults to synchronous=FULL, which fsyncs on every commit
+    while holding the writer lock. On a machine whose disk is busy -- a Colab session
+    pulling a multi-GB GGUF, say -- one commit blocked for 37s, and every other writer
+    (notably the research supervisor's claim_next) spent that whole window timing out
+    with "database is locked". NORMAL is sqlite's own recommended pairing for WAL: it
+    can lose the last transactions to a host power loss, but the database is never
+    corrupted, and commits stay durable across an application crash either way.
+
+    The WAL check is not decoration. `PRAGMA journal_mode=WAL` silently declines on
+    filesystems without proper shared-memory support (network shares, some FUSE and
+    container-mounted paths, which Windows users hit most often), leaving the file on a
+    rollback journal where NORMAL drops the very fsync that keeps it consistent. Those
+    installs keep FULL and simply do not get the speedup. journal_mode is persistent in
+    the file, so this reads what is actually in force rather than what was requested.
+    """
+    try:
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    except (sqlite3.Error, TypeError, IndexError):
+        return
+    if isinstance(mode, str) and mode.lower() == "wal":
+        conn.execute("PRAGMA synchronous=NORMAL")
 
 
 def get_connection(busy_timeout_seconds: float = _BUSY_TIMEOUT_SECONDS) -> sqlite3.Connection:
@@ -1182,14 +1219,6 @@ def get_connection(busy_timeout_seconds: float = _BUSY_TIMEOUT_SECONDS) -> sqlit
     conn.row_factory = sqlite3.Row
     # foreign_keys is session-scoped; set per connection
     conn.execute("PRAGMA foreign_keys=ON")
-    # Under WAL, sqlite still defaults to synchronous=FULL, which fsyncs on every commit
-    # while holding the writer lock. On a machine whose disk is busy -- a Colab session
-    # pulling a multi-GB GGUF, say -- one commit blocked for 37s, and every other writer
-    # (notably the research supervisor's claim_next) spent that whole window timing out
-    # with "database is locked". NORMAL is the documented safe pairing for WAL: it can
-    # lose the last transactions on a host power loss, but never corrupts the database,
-    # which is the right trade for a local UI's settings and chat history.
-    conn.execute("PRAGMA synchronous=NORMAL")
     if not _schema_ready:
         with _schema_lock:
             if not _schema_ready:
@@ -1200,6 +1229,7 @@ def get_connection(busy_timeout_seconds: float = _BUSY_TIMEOUT_SECONDS) -> sqlit
                 except Exception:
                     conn.close()
                     raise
+    _apply_wal_synchronous(conn)
     return conn
 
 

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -266,6 +266,51 @@ def delete_chat_project_workspace(project: dict) -> None:
     delete_project_workspace(project)
 
 
+_INVENTORY_UPDATE_TRIGGER = "chat_attachment_inventory_dirty_update"
+
+_INVENTORY_UPDATE_TRIGGER_SQL = f"""
+    CREATE TRIGGER IF NOT EXISTS {_INVENTORY_UPDATE_TRIGGER}
+    AFTER UPDATE OF attachments_json, content_json ON chat_messages
+    BEGIN
+        INSERT INTO chat_attachment_inventory_state
+            (singleton, inventory_version, dirty, backfilled_at)
+        VALUES (1, 0, 1, 0)
+        ON CONFLICT(singleton) DO UPDATE SET dirty = 1;
+    END
+"""
+
+
+def _replace_inventory_update_trigger(conn: sqlite3.Connection) -> None:
+    """Swap the unscoped trigger for the scoped one, safely for concurrent openers.
+
+    Two Studio processes on one studio.db each have their own `_schema_ready`, and DDL
+    does not open a transaction under sqlite3's legacy transaction control (only DML
+    does), so a bare DROP + CREATE pair can interleave as drop/drop/create/create and the
+    second CREATE raises "trigger already exists" out of `get_connection`. Three guards:
+    skip entirely when the scoped trigger is already installed, hold the writer lock
+    across the pair, and keep IF NOT EXISTS on the create so even a lost race cannot
+    raise.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+        (_INVENTORY_UPDATE_TRIGGER,),
+    ).fetchone()
+    # row[0], not row["sql"]: _ensure_schema also runs on connections whose row_factory
+    # is still the default tuple.
+    if row is not None and "UPDATE OF" in (row[0] or ""):
+        return
+    if conn.in_transaction:
+        conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        conn.execute(f"DROP TRIGGER IF EXISTS {_INVENTORY_UPDATE_TRIGGER}")
+        conn.execute(_INVENTORY_UPDATE_TRIGGER_SQL)
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
+
+
 def _ensure_schema(conn: sqlite3.Connection) -> None:
     """Create tables and indexes if they don't exist. Called once per process."""
     conn.execute("PRAGMA journal_mode=WAL")
@@ -610,19 +655,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     # attachment in every thread while holding the writer lock inside BEGIN IMMEDIATE.
     # Dropped rather than IF NOT EXISTS: existing installs already carry the unscoped
     # trigger, and a create would silently keep it.
-    conn.execute("DROP TRIGGER IF EXISTS chat_attachment_inventory_dirty_update")
-    conn.execute(
-        """
-        CREATE TRIGGER chat_attachment_inventory_dirty_update
-        AFTER UPDATE OF attachments_json, content_json ON chat_messages
-        BEGIN
-            INSERT INTO chat_attachment_inventory_state
-                (singleton, inventory_version, dirty, backfilled_at)
-            VALUES (1, 0, 1, 0)
-            ON CONFLICT(singleton) DO UPDATE SET dirty = 1;
-        END
-        """
-    )
+    _replace_inventory_update_trigger(conn)
     conn.execute(
         """
         CREATE TRIGGER IF NOT EXISTS chat_attachment_inventory_dirty_delete

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -283,13 +283,10 @@ _INVENTORY_UPDATE_TRIGGER_SQL = f"""
 def _replace_inventory_update_trigger(conn: sqlite3.Connection) -> None:
     """Swap the unscoped trigger for the scoped one, safely for concurrent openers.
 
-    Two Studio processes on one studio.db each have their own `_schema_ready`, and DDL
-    does not open a transaction under sqlite3's legacy transaction control (only DML
-    does), so a bare DROP + CREATE pair can interleave as drop/drop/create/create and the
-    second CREATE raises "trigger already exists" out of `get_connection`. Three guards:
-    skip entirely when the scoped trigger is already installed, hold the writer lock
-    across the pair, and keep IF NOT EXISTS on the create so even a lost race cannot
-    raise.
+    DDL does not open a transaction under sqlite3's legacy transaction control, only DML
+    does, so a bare DROP + CREATE pair can interleave across processes as
+    drop/drop/create/create and the second CREATE raises out of `get_connection`. Hence:
+    skip when already scoped, hold the writer lock across the pair, IF NOT EXISTS on top.
     """
     row = conn.execute(
         "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = ?",
@@ -648,13 +645,9 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         END
         """
     )
-    # Scoped to the two columns _rebuild_chat_attachment_inventory actually reads. The
-    # unscoped version fired on any UPDATE, so a generation status change -- which touches
-    # only metadata_json, from chat_generation_runs_db and research_runs_db -- marked the
-    # inventory dirty, and the next chat autosave paid for a full DELETE + re-hash of every
-    # attachment in every thread while holding the writer lock inside BEGIN IMMEDIATE.
-    # Dropped rather than IF NOT EXISTS: existing installs already carry the unscoped
-    # trigger, and a create would silently keep it.
+    # Scoped to the columns _rebuild_chat_attachment_inventory reads: unscoped, a generation
+    # status change (metadata_json only) dirtied the inventory, so the next autosave re-hashed
+    # every attachment under the writer lock. Dropped, since a create would keep the old one.
     _replace_inventory_update_trigger(conn)
     conn.execute(
         """

--- a/studio/backend/tests/test_chat_history_routes.py
+++ b/studio/backend/tests/test_chat_history_routes.py
@@ -11,6 +11,7 @@ import threading
 from types import SimpleNamespace
 
 import pytest
+from typing import Optional
 from fastapi import HTTPException
 from pydantic import ValidationError
 
@@ -1297,7 +1298,7 @@ def test_a_plain_replay_with_nothing_outstanding_still_reaps_nothing(monkeypatch
     assert len(reaps) == 1, "a replay behind a completed reap must not touch the registry"
 
 
-def _conflict_kind(exc_info) -> str | None:
+def _conflict_kind(exc_info) -> Optional[str]:
     return (exc_info.value.headers or {}).get(chat_history.CONFLICT_KIND_HEADER)
 
 

--- a/studio/backend/tests/test_chat_history_routes.py
+++ b/studio/backend/tests/test_chat_history_routes.py
@@ -1295,3 +1295,48 @@ def test_a_plain_replay_with_nothing_outstanding_still_reaps_nothing(monkeypatch
     assert len(reaps) == 1
     clear()
     assert len(reaps) == 1, "a replay behind a completed reap must not touch the registry"
+
+
+def _conflict_kind(exc_info) -> str | None:
+    return (exc_info.value.headers or {}).get(chat_history.CONFLICT_KIND_HEADER)
+
+
+@pytest.mark.parametrize(
+    "error, kind",
+    [
+        (
+            lambda: chat_history.ChatMessageProtectedError(
+                "server-managed generation messages cannot be edited"
+            ),
+            "protected",
+        ),
+        (
+            lambda: chat_history.ChatMessageConflictError(
+                "Message id already belongs to another thread: m1"
+            ),
+            "thread-collision",
+        ),
+    ],
+)
+def test_the_two_conflicts_are_distinguishable_on_the_wire(monkeypatch, error, kind):
+    """Both are 409, and they mean opposite things to the client.
+
+    A protected message is the server refusing an edit it owns, so the autosave stops. A
+    thread collision is an ordinary failure the caller has to see; answering both the same
+    way let the frontend swallow a collision as success and lose the message.
+    """
+    monkeypatch.setattr(chat_history, "get_chat_thread", lambda _thread_id: {"id": "t1"})
+
+    def reject(*_args, **_kwargs):
+        raise error()
+
+    monkeypatch.setattr(chat_history, "upsert_chat_message", reject)
+
+    message = chat_history.ChatMessage(
+        id = "m1", threadId = "t1", role = "assistant", content = [], createdAt = 1
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        chat_history.save_thread_message("t1", "m1", message, current_subject = "u")
+
+    assert exc_info.value.status_code == 409
+    assert _conflict_kind(exc_info) == kind

--- a/studio/backend/tests/test_studio_db_write_lock_contention.py
+++ b/studio/backend/tests/test_studio_db_write_lock_contention.py
@@ -1,17 +1,5 @@
-# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 """studio.db must not turn one slow writer into a stream of "database is locked".
 
 A live Colab session logged six `research.supervisor_iteration_failed` tracebacks in 37

--- a/studio/backend/tests/test_studio_db_write_lock_contention.py
+++ b/studio/backend/tests/test_studio_db_write_lock_contention.py
@@ -15,16 +15,27 @@
 """studio.db must not turn one slow writer into a stream of "database is locked".
 
 A live Colab session logged six `research.supervisor_iteration_failed` tracebacks in 37
-seconds while a settings write and a multi-GB model download shared the disk. Each guards a
-distinct link in that chain.
+seconds while a settings write and a multi-GB model download shared the disk. Each test
+here guards a distinct link in that chain, plus the upgrade and downgrade paths, since
+every existing install already carries the old schema.
+
+Nothing here needs a GPU or a network: the behaviour under test is SQLite pragmas, one
+poll query, and log levels.
 """
 
+import asyncio
+import logging
 import sqlite3
+import threading
+import time
+from pathlib import Path
 
 import pytest
 
 import storage.research_runs_db as research_runs_db
 import storage.studio_db as studio_db
+
+FULL, NORMAL = 2, 1
 
 
 @pytest.fixture
@@ -37,84 +48,515 @@ def db(tmp_path, monkeypatch):
     return tmp_path / "studio.db"
 
 
-def test_connections_use_wal_with_normal_sync(db):
-    """synchronous=FULL fsyncs under the writer lock; NORMAL is the WAL-safe pairing."""
-    conn = studio_db.get_connection()
+def _journal_mode(path: Path) -> str:
+    conn = sqlite3.connect(str(path))
     try:
-        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
-        # 1 == NORMAL. FULL (2) is what made a single commit block for 37s on a busy disk.
-        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1
+        return str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
     finally:
         conn.close()
 
 
-def test_claim_next_takes_no_write_lock_when_idle(db):
-    """The supervisor polls twice a second forever; an empty poll must stay a read.
+def _synchronous(conn: sqlite3.Connection) -> int:
+    return int(conn.execute("PRAGMA synchronous").fetchone()[0])
 
-    Holding the writer lock elsewhere and calling claim_next reproduces the original
-    failure exactly: it used to raise OperationalError after the 5s busy timeout.
+
+def _seed_message(
+    conn,
+    thread = "t1",
+    message = "m1",
+):
+    conn.execute(
+        "INSERT OR IGNORE INTO chat_threads (id, title, model_type, created_at, updated_at) "
+        "VALUES (?, 'T', 'gguf', 0, 0)",
+        (thread,),
+    )
+    conn.execute(
+        "INSERT INTO chat_messages "
+        "(id, thread_id, role, content_json, attachments_json, metadata_json, created_at) "
+        "VALUES (?, ?, 'assistant', '[]', '[]', '{}', 0)",
+        (message, thread),
+    )
+    conn.commit()
+
+
+def _dirty(conn) -> int:
+    row = conn.execute(
+        "SELECT dirty FROM chat_attachment_inventory_state WHERE singleton = 1"
+    ).fetchone()
+    return int(row["dirty"])
+
+
+def _hold_writer_lock(conn) -> None:
+    conn.execute("BEGIN IMMEDIATE")
+    conn.execute(
+        "INSERT INTO app_settings (key, value_json, updated_at) VALUES ('probe','1','0') "
+        "ON CONFLICT(key) DO UPDATE SET value_json='1'"
+    )
+
+
+# --- synchronous=NORMAL, but only where WAL makes it safe -------------------------------
+
+
+def test_wal_database_drops_to_normal(db):
+    """synchronous=FULL fsyncs under the writer lock; NORMAL is the WAL-safe pairing."""
+    assert _journal_mode(db) == "wal"
+    conn = studio_db.get_connection()
+    try:
+        assert _synchronous(conn) == NORMAL
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("mode", ["delete", "truncate", "persist", "memory"])
+def test_non_wal_journal_keeps_full(db, monkeypatch, mode):
+    """PRAGMA journal_mode=WAL silently declines on filesystems without shared memory.
+
+    Network shares and some FUSE or container mounts land there, Windows users most
+    often. A rollback journal needs the fsync NORMAL removes, so those installs keep
+    FULL and simply do not get the speedup.
     """
+    setup = sqlite3.connect(str(db))
+    try:
+        setup.execute(f"PRAGMA journal_mode={mode}")
+        setup.commit()
+    finally:
+        setup.close()
+    assert _journal_mode(db) != "wal"
+
+    monkeypatch.setattr(studio_db, "_schema_ready", True)
+    conn = studio_db.get_connection()
+    try:
+        assert _synchronous(conn) == FULL, f"{mode} must not lose its commit fsync"
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [None, (None,), ("",), (123,), sqlite3.OperationalError("pragma unavailable")],
+)
+def test_unreadable_journal_mode_is_not_treated_as_wal(answer):
+    """An unexpected or failing answer keeps the safe default rather than raising.
+
+    sqlite3.Connection is a C type and cannot be monkeypatched, so this uses a double.
+    """
+
+    class Connection:
+        def __init__(self):
+            self.executed = []
+
+        def execute(self, sql, *args):
+            self.executed.append(sql)
+            if isinstance(answer, Exception):
+                raise answer
+            return type("Cursor", (), {"fetchone": lambda _self: answer})()
+
+    conn = Connection()
+    studio_db._apply_wal_synchronous(conn)
+    assert "PRAGMA synchronous=NORMAL" not in conn.executed
+
+
+def test_committed_rows_survive_a_reopen(db):
+    """NORMAL changes fsync timing, not correctness."""
+    conn = studio_db.get_connection()
+    try:
+        _seed_message(conn, "t-durable", "m-durable")
+    finally:
+        conn.close()
+    conn = studio_db.get_connection()
+    try:
+        assert (
+            conn.execute("SELECT id FROM chat_messages WHERE id = 'm-durable'").fetchone()
+            is not None
+        )
+    finally:
+        conn.close()
+
+
+def test_concurrent_openers_all_get_normal(db):
+    results, errors = [], []
+
+    def worker():
+        try:
+            conn = studio_db.get_connection()
+            try:
+                results.append(_synchronous(conn))
+            finally:
+                conn.close()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target = worker) for _ in range(16)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert not errors, errors
+    assert results == [NORMAL] * 16
+
+
+# --- the attachment inventory is dirtied by attachments, not by bookkeeping -------------
+
+
+@pytest.mark.parametrize(
+    "sql, dirties, why",
+    [
+        (
+            "UPDATE chat_messages SET metadata_json='{\"a\":1}' WHERE id='m1'",
+            False,
+            "a generation status change touches no attachment",
+        ),
+        (
+            "UPDATE chat_messages SET role='user' WHERE id='m1'",
+            False,
+            "role is not an inventory input",
+        ),
+        (
+            "UPDATE chat_messages SET attachments_json='[{}]' WHERE id='m1'",
+            True,
+            "attachments changed",
+        ),
+        (
+            "UPDATE chat_messages SET content_json='[{\"t\":1}]' WHERE id='m1'",
+            True,
+            "inline content can carry data URIs",
+        ),
+        (
+            "UPDATE chat_messages SET attachments_json='[]' WHERE id='m1'",
+            True,
+            "UPDATE OF fires on the SET list, not on a changed value",
+        ),
+        ("DELETE FROM chat_messages WHERE id='m1'", True, "rows went away"),
+    ],
+)
+def test_inventory_trigger_scope(db, sql, dirties, why):
+    """The rebuild re-hashes every attachment in every thread inside BEGIN IMMEDIATE, so
+    dirtying it from an unrelated column is what made an ordinary autosave hold the
+    writer lock for as long as the history was large."""
+    conn = studio_db.get_connection()
+    try:
+        _seed_message(conn)
+        studio_db._mark_chat_attachment_inventory_clean(conn)
+        conn.commit()
+        assert _dirty(conn) == 0
+        conn.execute(sql)
+        conn.commit()
+        assert _dirty(conn) == (1 if dirties else 0), why
+    finally:
+        conn.close()
+
+
+def test_upgrade_replaces_the_unscoped_trigger(tmp_path, monkeypatch):
+    """Every existing install already carries the unscoped trigger.
+
+    CREATE TRIGGER IF NOT EXISTS would have kept it silently, so the fix drops first.
+    """
+    path = tmp_path / "studio.db"
+    monkeypatch.setattr(studio_db, "studio_db_path", lambda: path)
+    monkeypatch.setattr(studio_db, "_schema_ready", False)
+
+    conn = studio_db.get_connection()
+    try:
+        conn.execute("DROP TRIGGER IF EXISTS chat_attachment_inventory_dirty_update")
+        conn.execute(
+            """
+            CREATE TRIGGER chat_attachment_inventory_dirty_update
+            AFTER UPDATE ON chat_messages
+            BEGIN
+                INSERT INTO chat_attachment_inventory_state
+                    (singleton, inventory_version, dirty, backfilled_at)
+                VALUES (1, 0, 1, 0)
+                ON CONFLICT(singleton) DO UPDATE SET dirty = 1;
+            END
+            """
+        )
+        conn.commit()
+        assert (
+            "UPDATE OF"
+            not in conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name='chat_attachment_inventory_dirty_update'"
+            ).fetchone()[0]
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(studio_db, "_schema_ready", False)
+    conn = studio_db.get_connection()
+    try:
+        assert (
+            "UPDATE OF attachments_json, content_json"
+            in conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name='chat_attachment_inventory_dirty_update'"
+            ).fetchone()[0]
+        )
+        _seed_message(conn)
+        studio_db._mark_chat_attachment_inventory_clean(conn)
+        conn.commit()
+        conn.execute("UPDATE chat_messages SET metadata_json='{\"x\":1}' WHERE id='m1'")
+        conn.commit()
+        assert _dirty(conn) == 0
+    finally:
+        conn.close()
+
+
+def test_downgrade_still_sees_attachment_changes(db):
+    """An older Unsloth run against an upgraded database keeps the scoped trigger, since
+    its CREATE TRIGGER IF NOT EXISTS finds the name taken. That is safe: the scoped
+    trigger still fires for everything the inventory derives from."""
+    conn = studio_db.get_connection()
+    try:
+        conn.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS chat_attachment_inventory_dirty_update
+            AFTER UPDATE ON chat_messages
+            BEGIN
+                INSERT INTO chat_attachment_inventory_state
+                    (singleton, inventory_version, dirty, backfilled_at)
+                VALUES (1, 0, 1, 0)
+                ON CONFLICT(singleton) DO UPDATE SET dirty = 1;
+            END
+            """
+        )
+        conn.commit()
+        _seed_message(conn)
+        studio_db._mark_chat_attachment_inventory_clean(conn)
+        conn.commit()
+        conn.execute("UPDATE chat_messages SET attachments_json='[{}]' WHERE id='m1'")
+        conn.commit()
+        assert _dirty(conn) == 1
+    finally:
+        conn.close()
+
+
+# --- claim_next: cheap when idle, unchanged when there is work --------------------------
+
+
+def _make_run(
+    run_id = "r1",
+    thread = "t1",
+    status = "queued",
+):
+    studio_db.upsert_chat_thread({"id": thread, "title": "T", "modelType": "gguf", "createdAt": 1})
+    studio_db.upsert_chat_message(
+        {"id": f"u-{run_id}", "threadId": thread, "role": "user", "content": [], "createdAt": 2}
+    )
+    studio_db.upsert_chat_message(
+        {
+            "id": f"a-{run_id}",
+            "threadId": thread,
+            "parentId": f"u-{run_id}",
+            "role": "assistant",
+            "content": [],
+            "createdAt": 3,
+        }
+    )
+    research_runs_db.create_run(
+        run_id = run_id,
+        owner_subject = "sub",
+        thread_id = thread,
+        user_message_id = f"u-{run_id}",
+        assistant_message_id = f"a-{run_id}",
+        config = {},
+    )
+    if status != "queued":
+        conn = studio_db.get_connection()
+        try:
+            conn.execute("UPDATE research_runs SET status=? WHERE id=?", (status, run_id))
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def test_idle_poll_takes_no_write_lock(db):
+    """The original failure reproduced: this used to raise after the 5s busy timeout."""
     holder = studio_db.get_connection()
     try:
-        holder.execute("BEGIN IMMEDIATE")
-        holder.execute(
-            "INSERT INTO app_settings (key, value_json, updated_at) VALUES ('probe', '1', '0') "
-            "ON CONFLICT(key) DO UPDATE SET value_json = '1'"
-        )
-        # No commit: the writer lock stays held for the duration of this call.
+        _hold_writer_lock(holder)
+        started = time.monotonic()
         assert research_runs_db.claim_next("worker-1") is None
+        assert time.monotonic() - started < 1.0, "must not have queued behind the writer"
     finally:
         holder.rollback()
         holder.close()
 
 
-def test_metadata_only_update_does_not_dirty_attachment_inventory(db):
-    """A generation status change must not schedule a full attachment rebuild.
+def test_claim_next_still_claims_real_work(db):
+    _make_run()
+    claimed = research_runs_db.claim_next("worker-1")
+    assert claimed is not None and claimed["id"] == "r1"
+    assert research_runs_db.claim_next("worker-2") is None, "the lease excludes others"
 
-    The rebuild re-hashes every attachment in every thread inside BEGIN IMMEDIATE, so
-    dirtying it from an unrelated column is what made an ordinary autosave hold the lock.
-    """
+
+@pytest.mark.parametrize("status", ["planning", "queued", "running", "cancelling"])
+def test_probe_agrees_with_the_transaction_when_claimable(db, status):
+    _make_run(status = status)
+    assert research_runs_db._has_claimable(research_runs_db.now_ms()) is True
+    assert research_runs_db.claim_next("worker-1") is not None
+
+
+@pytest.mark.parametrize(
+    "status", ["completed", "failed", "cancelled", "paused", "awaiting_approval"]
+)
+def test_probe_agrees_with_the_transaction_when_not_claimable(db, status):
+    _make_run(status = status)
+    assert research_runs_db._has_claimable(research_runs_db.now_ms()) is False
+    assert research_runs_db.claim_next("worker-1") is None
+
+
+def test_expired_lease_becomes_claimable_again(db):
+    _make_run()
+    assert research_runs_db.claim_next("worker-1") is not None
+    assert research_runs_db._has_claimable(research_runs_db.now_ms()) is False
     conn = studio_db.get_connection()
     try:
         conn.execute(
-            "INSERT INTO chat_threads (id, title, model_type, created_at, updated_at) "
-            "VALUES ('t1', 'T', 'gguf', 0, 0)"
-        )
-        conn.execute(
-            "INSERT INTO chat_messages "
-            "(id, thread_id, role, content_json, attachments_json, metadata_json, created_at) "
-            "VALUES ('m1', 't1', 'assistant', '[]', '[]', '{}', 0)"
+            "UPDATE research_runs SET lease_expires_at=? WHERE id='r1'",
+            (research_runs_db.now_ms() - 1,),
         )
         conn.commit()
-        studio_db._mark_chat_attachment_inventory_clean(conn)
-        conn.commit()
-
-        def dirty() -> int:
-            row = conn.execute(
-                "SELECT dirty FROM chat_attachment_inventory_state WHERE singleton = 1"
-            ).fetchone()
-            return int(row["dirty"])
-
-        assert dirty() == 0
-        # What chat_generation_runs_db does on every status transition.
-        conn.execute("UPDATE chat_messages SET metadata_json = '{\"a\":1}' WHERE id = 'm1'")
-        conn.commit()
-        assert dirty() == 0, "a metadata-only update must not dirty the inventory"
-
-        # A real attachment change still must.
-        conn.execute("UPDATE chat_messages SET attachments_json = '[{}]' WHERE id = 'm1'")
-        conn.commit()
-        assert dirty() == 1
     finally:
         conn.close()
+    assert research_runs_db._has_claimable(research_runs_db.now_ms()) is True
+    assert research_runs_db.claim_next("worker-2") is not None
+
+
+def test_run_without_a_thread_claim_is_invisible(db):
+    """The probe must reproduce the transaction's join, not just its WHERE clause."""
+    _make_run()
+    conn = studio_db.get_connection()
+    try:
+        conn.execute("DELETE FROM research_thread_claims")
+        conn.commit()
+    finally:
+        conn.close()
+    assert research_runs_db._has_claimable(research_runs_db.now_ms()) is False
+    assert research_runs_db.claim_next("worker-1") is None
+
+
+def test_concurrent_workers_claim_a_run_exactly_once(db):
+    _make_run()
+    claims, errors = [], []
+
+    def worker(name):
+        try:
+            if research_runs_db.claim_next(name) is not None:
+                claims.append(name)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target = worker, args = (f"w{i}",)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert not errors, errors
+    assert len(claims) == 1, f"the read-first probe must not let two workers claim: {claims}"
+
+
+# --- the busy predicate and the supervisor's error ladder -------------------------------
+
+
+@pytest.mark.parametrize(
+    "message, busy",
+    [
+        ("database is locked", True),
+        ("database table is locked", True),
+        ("database is busy", True),
+        ("attempt to write a readonly database", False),
+        ("no such table: research_runs", False),
+        ("disk I/O error", False),
+        ("unable to open database file", False),
+    ],
+)
+def test_busy_predicate(message, busy):
+    assert studio_db.is_sqlite_busy_error(sqlite3.OperationalError(message)) is busy
+
+
+def test_api_usage_db_shares_one_definition():
+    import storage.api_usage_db as api_usage_db
+    assert api_usage_db._is_busy_error(sqlite3.OperationalError("database is locked"))
+    assert not api_usage_db._is_busy_error(sqlite3.OperationalError("disk I/O error"))
+
+
+class _Ladder:
+    """The supervisor's except-ladder without its dependencies.
+
+    Mirrors ResearchSupervisor._loop in core/research_runs.py; the control flow is the
+    point, since the regression this guards was a control-flow one.
+    """
+
+    def __init__(self, raises, logger):
+        self._raises = list(raises)
+        self.logger = logger
+        self.iterations = 0
+        self.survived = False
+
+    async def run(self):
+        for exc in self._raises:
+            self.iterations += 1
+            try:
+                if exc is not None:
+                    raise exc
+            except asyncio.CancelledError:
+                raise
+            except sqlite3.OperationalError as err:
+                if studio_db.is_sqlite_busy_error(err):
+                    self.logger.warning("research.supervisor_db_busy: %s", err)
+                else:
+                    self.logger.exception("research.supervisor_iteration_failed")
+                await asyncio.sleep(0)
+            except Exception:
+                self.logger.exception("research.supervisor_iteration_failed")
+                await asyncio.sleep(0)
+        self.survived = True
+
+
+def _levels(caplog):
+    return [(record.levelname, record.exc_info is not None) for record in caplog.records]
+
+
+def test_lock_contention_is_six_warnings_not_six_tracebacks(caplog):
+    logger = logging.getLogger("test.supervisor.busy")
+    ladder = _Ladder([sqlite3.OperationalError("database is locked")] * 6, logger)
+    with caplog.at_level(logging.WARNING, logger = logger.name):
+        asyncio.run(ladder.run())
+    assert ladder.survived
+    assert _levels(caplog) == [("WARNING", False)] * 6
+
+
+def test_a_real_sqlite_fault_does_not_stop_the_supervisor(caplog):
+    """Re-raising here would escape the while loop, because a sibling `except Exception`
+    cannot catch a raise from its own ladder. The supervisor would stop for the life of
+    the process, silently, which is worse than the log noise this change removes."""
+    logger = logging.getLogger("test.supervisor.fault")
+    ladder = _Ladder([sqlite3.OperationalError("no such table: research_runs"), None, None], logger)
+    with caplog.at_level(logging.ERROR, logger = logger.name):
+        asyncio.run(ladder.run())
+    assert ladder.survived and ladder.iterations == 3
+    assert _levels(caplog) == [("ERROR", True)], "and it keeps its traceback"
+
+
+def test_unrelated_exceptions_are_unchanged(caplog):
+    logger = logging.getLogger("test.supervisor.other")
+    ladder = _Ladder([ValueError("boom"), None], logger)
+    with caplog.at_level(logging.ERROR, logger = logger.name):
+        asyncio.run(ladder.run())
+    assert ladder.survived
+    assert _levels(caplog) == [("ERROR", True)]
+
+
+def test_cancellation_still_propagates():
+    logger = logging.getLogger("test.supervisor.cancel")
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(_Ladder([asyncio.CancelledError()], logger).run())
+
+
+# --- expected client errors are not server faults ---------------------------------------
 
 
 class _RecordingLogger:
-    """The module logger is structlog, so caplog cannot see it; log_and_http_error
-    accepts an explicit one, which is what the routes pass anyway."""
-
     def __init__(self):
-        self.calls: list[tuple[str, dict]] = []
+        self.calls = []
 
     def warning(self, *args, **kwargs):
         self.calls.append(("warning", kwargs))
@@ -123,56 +565,24 @@ class _RecordingLogger:
         self.calls.append(("error", kwargs))
 
 
-def test_client_errors_log_without_a_traceback():
-    """A 409 is the caller's business, not a server fault: one warning line, no stack.
-
-    Logging it at error with exc_info put 54 full tracebacks in a single session's log.
-    """
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 409, 422, 429])
+def test_client_errors_log_one_warning_without_a_traceback(status):
+    """One streamed generation put 54 rejected saves in the log, each with a full stack."""
     from utils.utils import log_and_http_error
 
-    error = ValueError("server-managed generation messages cannot be edited")
-
     log = _RecordingLogger()
-    exc = log_and_http_error(error, 409, "Conflict", event = "chat.conflict", log = log)
-    assert exc.status_code == 409
-    assert exc.detail == "Conflict", "the raw exception text must not reach the client"
-    assert log.calls == [("warning", {})], "4xx: one warning, no exc_info"
+    error = log_and_http_error(ValueError("x"), status, "public", event = "e", log = log)
+    assert error.status_code == status
+    assert error.detail == "public", "the raw exception must never reach the client"
+    assert log.calls == [("warning", {})]
 
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+def test_server_errors_keep_their_traceback(status):
+    from utils.utils import log_and_http_error
+
+    raised = ValueError("x")
     log = _RecordingLogger()
-    log_and_http_error(error, 500, "Boom", event = "server.broke", log = log)
+    log_and_http_error(raised, status, "public", event = "e", log = log)
     level, kwargs = log.calls[0]
-    assert level == "error" and kwargs.get("exc_info") is error, "5xx keeps its traceback"
-
-
-def test_claim_next_still_claims_real_work(db):
-    """The read-first probe is an optimisation, not a suppression: a claimable run must
-    still be claimed, or the supervisor would quietly stop doing its job."""
-    # Through the modules' own APIs, so the fixture cannot drift from the real schema.
-    studio_db.upsert_chat_thread({"id": "t1", "title": "T", "modelType": "gguf", "createdAt": 1})
-    studio_db.upsert_chat_message(
-        {"id": "u1", "threadId": "t1", "role": "user", "content": [], "createdAt": 2}
-    )
-    studio_db.upsert_chat_message(
-        {
-            "id": "a1",
-            "threadId": "t1",
-            "parentId": "u1",
-            "role": "assistant",
-            "content": [],
-            "createdAt": 3,
-        }
-    )
-    research_runs_db.create_run(
-        run_id = "r1",
-        owner_subject = "sub",
-        thread_id = "t1",
-        user_message_id = "u1",
-        assistant_message_id = "a1",
-        config = {},
-    )
-
-    assert research_runs_db._has_claimable(research_runs_db.now_ms()) is True
-    claimed = research_runs_db.claim_next("worker-1")
-    assert claimed is not None and claimed["id"] == "r1"
-    # Claimed once: the lease is now held, so the next poll is idle again.
-    assert research_runs_db.claim_next("worker-2") is None
+    assert level == "error" and kwargs.get("exc_info") is raised

--- a/studio/backend/tests/test_studio_db_write_lock_contention.py
+++ b/studio/backend/tests/test_studio_db_write_lock_contention.py
@@ -377,10 +377,8 @@ def test_the_migration_is_skipped_once_the_scoped_trigger_is_installed(db):
 def test_a_lost_create_race_cannot_raise(db):
     """The interleave itself, forced rather than raced for.
 
-    Timing this out of two live threads does not work: every DDL statement takes the
-    writer lock, so the window between the drop committing and the create is far too
-    narrow to sample. Driving the four statements by hand is the same sequence with the
-    scheduler taken out, and it shows what each half does.
+    Racing two threads for it does not work: every DDL statement takes the writer lock, so
+    the window between the drop committing and the create is too narrow to sample.
     """
     setup = studio_db.get_connection()
     try:
@@ -397,8 +395,8 @@ def test_a_lost_create_race_cannot_raise(db):
         first.execute(studio_db._INVENTORY_UPDATE_TRIGGER_SQL)
         first.commit()
 
-        # Without IF NOT EXISTS this is the crash: it comes straight out of get_connection,
-        # so the second process fails to open the database at all.
+        # Without IF NOT EXISTS this raises out of get_connection, so the second process
+        # cannot open the database at all.
         unguarded = studio_db._INVENTORY_UPDATE_TRIGGER_SQL.replace("IF NOT EXISTS ", "")
         with pytest.raises(sqlite3.OperationalError, match = "already exists"):
             second.execute(unguarded)
@@ -421,10 +419,9 @@ def test_a_lost_create_race_cannot_raise(db):
 
 
 def test_the_drop_and_the_create_share_one_writer_lock():
-    """Held across both, so no opener ever sees the table without its trigger.
+    """Held across both, so no opener sees the table without its trigger.
 
-    sqlite3.Connection is a C type and cannot be monkeypatched, so this uses a double and
-    asserts the statement order the fix depends on.
+    sqlite3.Connection is a C type and cannot be monkeypatched, hence the double.
     """
 
     class Connection:

--- a/studio/backend/tests/test_studio_db_write_lock_contention.py
+++ b/studio/backend/tests/test_studio_db_write_lock_contention.py
@@ -287,6 +287,173 @@ def test_upgrade_replaces_the_unscoped_trigger(tmp_path, monkeypatch):
         conn.close()
 
 
+def _legacy_unscoped_trigger(conn) -> None:
+    conn.execute("DROP TRIGGER IF EXISTS chat_attachment_inventory_dirty_update")
+    conn.execute(
+        """
+        CREATE TRIGGER chat_attachment_inventory_dirty_update
+        AFTER UPDATE ON chat_messages
+        BEGIN
+            INSERT INTO chat_attachment_inventory_state
+                (singleton, inventory_version, dirty, backfilled_at)
+            VALUES (1, 0, 1, 0)
+            ON CONFLICT(singleton) DO UPDATE SET dirty = 1;
+        END
+        """
+    )
+    conn.commit()
+
+
+def test_eight_processes_upgrading_at_once_all_succeed(db):
+    """Two Studio processes on one studio.db each carry their own `_schema_ready`.
+
+    DDL does not open a transaction under sqlite3's legacy transaction control -- only
+    INSERT/UPDATE/DELETE/REPLACE do -- so a bare DROP + CREATE pair runs in autocommit and
+    can interleave as drop/drop/create/create, where the second CREATE raises
+    "trigger already exists" straight out of get_connection. The forced sequence is in
+    test_a_lost_create_race_cannot_raise; this is the end-to-end shape of it.
+    """
+    setup = studio_db.get_connection()
+    try:
+        _legacy_unscoped_trigger(setup)
+    finally:
+        setup.close()
+
+    errors, seen = [], []
+    start = threading.Barrier(8)
+
+    def worker():
+        conn = sqlite3.connect(str(db), timeout = 10)
+        conn.row_factory = sqlite3.Row
+        try:
+            start.wait(timeout = 10)
+            studio_db._replace_inventory_update_trigger(conn)
+            seen.append(
+                conn.execute(
+                    "SELECT sql FROM sqlite_master WHERE name = ?",
+                    ("chat_attachment_inventory_dirty_update",),
+                ).fetchone()["sql"]
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target = worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors, errors
+    assert len(seen) == 8
+    assert all("UPDATE OF attachments_json, content_json" in sql for sql in seen)
+
+
+def test_the_migration_is_skipped_once_the_scoped_trigger_is_installed(db):
+    """Every connection would otherwise re-drop and re-create it, taking the writer lock
+    on a hot path for nothing."""
+    conn = studio_db.get_connection()
+    try:
+        assert (
+            "UPDATE OF"
+            in conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = ?",
+                ("chat_attachment_inventory_dirty_update",),
+            ).fetchone()["sql"]
+        )
+        held = sqlite3.connect(str(db), timeout = 0.2)
+        try:
+            _hold_writer_lock(held)
+            # No writer lock is taken, so this returns even while one is held elsewhere.
+            studio_db._replace_inventory_update_trigger(conn)
+        finally:
+            held.rollback()
+            held.close()
+    finally:
+        conn.close()
+
+
+def test_a_lost_create_race_cannot_raise(db):
+    """The interleave itself, forced rather than raced for.
+
+    Timing this out of two live threads does not work: every DDL statement takes the
+    writer lock, so the window between the drop committing and the create is far too
+    narrow to sample. Driving the four statements by hand is the same sequence with the
+    scheduler taken out, and it shows what each half does.
+    """
+    setup = studio_db.get_connection()
+    try:
+        _legacy_unscoped_trigger(setup)
+    finally:
+        setup.close()
+
+    first = sqlite3.connect(str(db), timeout = 10)
+    second = sqlite3.connect(str(db), timeout = 10)
+    try:
+        for conn in (first, second):
+            conn.execute("DROP TRIGGER IF EXISTS chat_attachment_inventory_dirty_update")
+            conn.commit()
+        first.execute(studio_db._INVENTORY_UPDATE_TRIGGER_SQL)
+        first.commit()
+
+        # Without IF NOT EXISTS this is the crash: it comes straight out of get_connection,
+        # so the second process fails to open the database at all.
+        unguarded = studio_db._INVENTORY_UPDATE_TRIGGER_SQL.replace("IF NOT EXISTS ", "")
+        with pytest.raises(sqlite3.OperationalError, match = "already exists"):
+            second.execute(unguarded)
+
+        second.execute(studio_db._INVENTORY_UPDATE_TRIGGER_SQL)
+        second.commit()
+    finally:
+        first.close()
+        second.close()
+
+    conn = sqlite3.connect(str(db))
+    try:
+        sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name = ?",
+            ("chat_attachment_inventory_dirty_update",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "UPDATE OF attachments_json, content_json" in sql
+
+
+def test_the_drop_and_the_create_share_one_writer_lock():
+    """Held across both, so no opener ever sees the table without its trigger.
+
+    sqlite3.Connection is a C type and cannot be monkeypatched, so this uses a double and
+    asserts the statement order the fix depends on.
+    """
+
+    class Connection:
+        in_transaction = False
+
+        def __init__(self):
+            self.executed = []
+            self.committed = 0
+
+        def execute(self, sql, *args):
+            self.executed.append(" ".join(sql.split())[:40])
+            return type("Cursor", (), {"fetchone": lambda _self: None})()
+
+        def commit(self):
+            self.committed += 1
+
+        def rollback(self):
+            raise AssertionError("nothing here should roll back")
+
+    conn = Connection()
+    studio_db._replace_inventory_update_trigger(conn)
+
+    kinds = [sql.split()[0] for sql in conn.executed]
+    assert kinds == ["SELECT", "BEGIN", "DROP", "CREATE"], conn.executed
+    assert conn.executed[1].startswith("BEGIN IMMEDIATE"), conn.executed[1]
+    assert "IF NOT EXISTS" in conn.executed[3]
+    assert conn.committed == 1, "one commit, at the end of the pair"
+
+
 def test_downgrade_still_sees_attachment_changes(db):
     """An older Unsloth run against an upgraded database keeps the scoped trigger, since
     its CREATE TRIGGER IF NOT EXISTS finds the name taken. That is safe: the scoped

--- a/studio/backend/tests/test_studio_db_write_lock_contention.py
+++ b/studio/backend/tests/test_studio_db_write_lock_contention.py
@@ -133,13 +133,13 @@ def test_client_errors_log_without_a_traceback():
     error = ValueError("server-managed generation messages cannot be edited")
 
     log = _RecordingLogger()
-    exc = log_and_http_error(error, 409, "Conflict", event="chat.conflict", log=log)
+    exc = log_and_http_error(error, 409, "Conflict", event = "chat.conflict", log = log)
     assert exc.status_code == 409
     assert exc.detail == "Conflict", "the raw exception text must not reach the client"
     assert log.calls == [("warning", {})], "4xx: one warning, no exc_info"
 
     log = _RecordingLogger()
-    log_and_http_error(error, 500, "Boom", event="server.broke", log=log)
+    log_and_http_error(error, 500, "Boom", event = "server.broke", log = log)
     level, kwargs = log.calls[0]
     assert level == "error" and kwargs.get("exc_info") is error, "5xx keeps its traceback"
 
@@ -148,9 +148,7 @@ def test_claim_next_still_claims_real_work(db):
     """The read-first probe is an optimisation, not a suppression: a claimable run must
     still be claimed, or the supervisor would quietly stop doing its job."""
     # Through the modules' own APIs, so the fixture cannot drift from the real schema.
-    studio_db.upsert_chat_thread(
-        {"id": "t1", "title": "T", "modelType": "gguf", "createdAt": 1}
-    )
+    studio_db.upsert_chat_thread({"id": "t1", "title": "T", "modelType": "gguf", "createdAt": 1})
     studio_db.upsert_chat_message(
         {"id": "u1", "threadId": "t1", "role": "user", "content": [], "createdAt": 2}
     )
@@ -165,12 +163,12 @@ def test_claim_next_still_claims_real_work(db):
         }
     )
     research_runs_db.create_run(
-        run_id="r1",
-        owner_subject="sub",
-        thread_id="t1",
-        user_message_id="u1",
-        assistant_message_id="a1",
-        config={},
+        run_id = "r1",
+        owner_subject = "sub",
+        thread_id = "t1",
+        user_message_id = "u1",
+        assistant_message_id = "a1",
+        config = {},
     )
 
     assert research_runs_db._has_claimable(research_runs_db.now_ms()) is True

--- a/studio/backend/tests/test_studio_db_write_lock_contention.py
+++ b/studio/backend/tests/test_studio_db_write_lock_contention.py
@@ -1,0 +1,180 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""studio.db must not turn one slow writer into a stream of "database is locked".
+
+A live Colab session logged six `research.supervisor_iteration_failed` tracebacks in 37
+seconds while a settings write and a multi-GB model download shared the disk. Each guards a
+distinct link in that chain.
+"""
+
+import sqlite3
+
+import pytest
+
+import storage.research_runs_db as research_runs_db
+import storage.studio_db as studio_db
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    """A studio.db in a temp dir, with the per-process schema latch reset."""
+    monkeypatch.setattr(studio_db, "studio_db_path", lambda: tmp_path / "studio.db")
+    monkeypatch.setattr(studio_db, "_schema_ready", False)
+    conn = studio_db.get_connection()
+    conn.close()
+    return tmp_path / "studio.db"
+
+
+def test_connections_use_wal_with_normal_sync(db):
+    """synchronous=FULL fsyncs under the writer lock; NORMAL is the WAL-safe pairing."""
+    conn = studio_db.get_connection()
+    try:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        # 1 == NORMAL. FULL (2) is what made a single commit block for 37s on a busy disk.
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_claim_next_takes_no_write_lock_when_idle(db):
+    """The supervisor polls twice a second forever; an empty poll must stay a read.
+
+    Holding the writer lock elsewhere and calling claim_next reproduces the original
+    failure exactly: it used to raise OperationalError after the 5s busy timeout.
+    """
+    holder = studio_db.get_connection()
+    try:
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute(
+            "INSERT INTO app_settings (key, value_json, updated_at) VALUES ('probe', '1', '0') "
+            "ON CONFLICT(key) DO UPDATE SET value_json = '1'"
+        )
+        # No commit: the writer lock stays held for the duration of this call.
+        assert research_runs_db.claim_next("worker-1") is None
+    finally:
+        holder.rollback()
+        holder.close()
+
+
+def test_metadata_only_update_does_not_dirty_attachment_inventory(db):
+    """A generation status change must not schedule a full attachment rebuild.
+
+    The rebuild re-hashes every attachment in every thread inside BEGIN IMMEDIATE, so
+    dirtying it from an unrelated column is what made an ordinary autosave hold the lock.
+    """
+    conn = studio_db.get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO chat_threads (id, title, model_type, created_at, updated_at) "
+            "VALUES ('t1', 'T', 'gguf', 0, 0)"
+        )
+        conn.execute(
+            "INSERT INTO chat_messages "
+            "(id, thread_id, role, content_json, attachments_json, metadata_json, created_at) "
+            "VALUES ('m1', 't1', 'assistant', '[]', '[]', '{}', 0)"
+        )
+        conn.commit()
+        studio_db._mark_chat_attachment_inventory_clean(conn)
+        conn.commit()
+
+        def dirty() -> int:
+            row = conn.execute(
+                "SELECT dirty FROM chat_attachment_inventory_state WHERE singleton = 1"
+            ).fetchone()
+            return int(row["dirty"])
+
+        assert dirty() == 0
+        # What chat_generation_runs_db does on every status transition.
+        conn.execute("UPDATE chat_messages SET metadata_json = '{\"a\":1}' WHERE id = 'm1'")
+        conn.commit()
+        assert dirty() == 0, "a metadata-only update must not dirty the inventory"
+
+        # A real attachment change still must.
+        conn.execute("UPDATE chat_messages SET attachments_json = '[{}]' WHERE id = 'm1'")
+        conn.commit()
+        assert dirty() == 1
+    finally:
+        conn.close()
+
+
+class _RecordingLogger:
+    """The module logger is structlog, so caplog cannot see it; log_and_http_error
+    accepts an explicit one, which is what the routes pass anyway."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    def warning(self, *args, **kwargs):
+        self.calls.append(("warning", kwargs))
+
+    def error(self, *args, **kwargs):
+        self.calls.append(("error", kwargs))
+
+
+def test_client_errors_log_without_a_traceback():
+    """A 409 is the caller's business, not a server fault: one warning line, no stack.
+
+    Logging it at error with exc_info put 54 full tracebacks in a single session's log.
+    """
+    from utils.utils import log_and_http_error
+
+    error = ValueError("server-managed generation messages cannot be edited")
+
+    log = _RecordingLogger()
+    exc = log_and_http_error(error, 409, "Conflict", event="chat.conflict", log=log)
+    assert exc.status_code == 409
+    assert exc.detail == "Conflict", "the raw exception text must not reach the client"
+    assert log.calls == [("warning", {})], "4xx: one warning, no exc_info"
+
+    log = _RecordingLogger()
+    log_and_http_error(error, 500, "Boom", event="server.broke", log=log)
+    level, kwargs = log.calls[0]
+    assert level == "error" and kwargs.get("exc_info") is error, "5xx keeps its traceback"
+
+
+def test_claim_next_still_claims_real_work(db):
+    """The read-first probe is an optimisation, not a suppression: a claimable run must
+    still be claimed, or the supervisor would quietly stop doing its job."""
+    # Through the modules' own APIs, so the fixture cannot drift from the real schema.
+    studio_db.upsert_chat_thread(
+        {"id": "t1", "title": "T", "modelType": "gguf", "createdAt": 1}
+    )
+    studio_db.upsert_chat_message(
+        {"id": "u1", "threadId": "t1", "role": "user", "content": [], "createdAt": 2}
+    )
+    studio_db.upsert_chat_message(
+        {
+            "id": "a1",
+            "threadId": "t1",
+            "parentId": "u1",
+            "role": "assistant",
+            "content": [],
+            "createdAt": 3,
+        }
+    )
+    research_runs_db.create_run(
+        run_id="r1",
+        owner_subject="sub",
+        thread_id="t1",
+        user_message_id="u1",
+        assistant_message_id="a1",
+        config={},
+    )
+
+    assert research_runs_db._has_claimable(research_runs_db.now_ms()) is True
+    claimed = research_runs_db.claim_next("worker-1")
+    assert claimed is not None and claimed["id"] == "r1"
+    # Claimed once: the lease is now held, so the next poll is idle again.
+    assert research_runs_db.claim_next("worker-2") is None

--- a/studio/backend/utils/hf_xet_fallback.py
+++ b/studio/backend/utils/hf_xet_fallback.py
@@ -234,9 +234,15 @@ def cached_xet_health(**kwargs: Any) -> Any:
 
     Capability reads use this path so opening Hub cannot initialize Unsloth Zoo. A real
     download calls :func:`xet_health`, which loads the optional module and populates this cache.
+
+    Read without ``_load_lock`` on purpose. Taking it made this "already loaded?" question wait
+    on whatever import another thread was holding it for -- a torch-loading `import unsloth_zoo`
+    that runs for seconds -- so the one path guaranteed never to load Zoo was the one blocked by
+    loading it. A dict lookup keyed by a plain string is atomic under the GIL, and the only
+    writers publish a fully-built module (or ``None``) in a single assignment, so the worst
+    outcome is reading the pre-import value and correctly answering "not loaded yet".
     """
-    with _load_lock:
-        module = _optional_modules.get("unsloth_zoo.hf_xet_health", _UNTRIED)
+    module = _optional_modules.get("unsloth_zoo.hf_xet_health", _UNTRIED)
     return None if module is _UNTRIED else _xet_health_from(module, **kwargs)
 
 

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -848,14 +848,9 @@ def log_and_http_error(
     """
     from fastapi import HTTPException
 
-    # exc_info=error works for both structlog and stdlib loggers.
-    #
-    # A 4xx is a normal outcome the caller is expected to handle, not a server fault, so it
-    # is logged as a single warning line without a traceback. Logging it at error with
-    # exc_info made routine client behaviour indistinguishable from a real failure: one
-    # streamed generation put 54 rejected message saves in the log, each with a full
-    # stack, burying everything else. 5xx keeps error + traceback -- that is a server bug
-    # and the stack is the only way to find it.
+    # A 4xx is a normal outcome the caller handles, so one warning line and no traceback:
+    # at error with exc_info, one generation buried the log under 54 rejected saves. 5xx
+    # keeps the traceback, since that is a server bug. exc_info works for structlog too.
     emitter = log or logger
     if 400 <= status_code < 500:
         emitter.warning(f"{event}: {error}")

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -839,6 +839,7 @@ def log_and_http_error(
     *,
     event: str = "request_failed",
     log = None,
+    headers: dict | None = None,
 ):
     """Log ``error`` in full server-side and return an ``HTTPException`` whose
     ``detail`` is only ``public_message`` -- never the raw exception text.
@@ -860,7 +861,7 @@ def log_and_http_error(
         emitter.warning(f"{event}: {error}")
     else:
         emitter.error(f"{event}: {error}", exc_info = error)
-    return HTTPException(status_code = status_code, detail = public_message)
+    return HTTPException(status_code = status_code, detail = public_message, headers = headers)
 
 
 @contextmanager

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -848,7 +848,18 @@ def log_and_http_error(
     from fastapi import HTTPException
 
     # exc_info=error works for both structlog and stdlib loggers.
-    (log or logger).error(f"{event}: {error}", exc_info = error)
+    #
+    # A 4xx is a normal outcome the caller is expected to handle, not a server fault, so it
+    # is logged as a single warning line without a traceback. Logging it at error with
+    # exc_info made routine client behaviour indistinguishable from a real failure: one
+    # streamed generation put 54 rejected message saves in the log, each with a full
+    # stack, burying everything else. 5xx keeps error + traceback -- that is a server bug
+    # and the stack is the only way to find it.
+    emitter = log or logger
+    if 400 <= status_code < 500:
+        emitter.warning(f"{event}: {error}")
+    else:
+        emitter.error(f"{event}: {error}", exc_info = error)
     return HTTPException(status_code = status_code, detail = public_message)
 
 

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -839,7 +839,7 @@ def log_and_http_error(
     *,
     event: str = "request_failed",
     log = None,
-    headers: dict | None = None,
+    headers: Optional[dict] = None,
 ):
     """Log ``error`` in full server-side and return an ``HTTPException`` whose
     ``detail`` is only ``public_message`` -- never the raw exception text.

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -1138,8 +1138,11 @@ export class ChatMessageProtectedError extends Error {
   readonly messageId: string;
   readonly threadId: string;
 
-  constructor(threadId: string, messageId: string) {
-    super(`Message ${messageId} is server-managed and cannot be edited`);
+  constructor(threadId: string, messageId: string, detail?: string) {
+    // Keep the server's own wording when it sent one. A manual edit surfaces this text
+    // to the user, and replacing a specific explanation with a generic one would be a
+    // regression for the caller that is not the autosave.
+    super(detail || `Message ${messageId} is server-managed and cannot be edited`);
     this.name = "ChatMessageProtectedError";
     this.threadId = threadId;
     this.messageId = messageId;
@@ -1162,7 +1165,14 @@ export async function saveChatMessage(
     },
   );
   if (response.status === 409) {
-    throw new ChatMessageProtectedError(message.threadId, message.id);
+    // Read the body here rather than letting parseJsonOrThrow do it: a Response body can
+    // only be consumed once, and this needs the server's detail to carry into the error.
+    const body = await response.json().catch(() => null);
+    throw new ChatMessageProtectedError(
+      message.threadId,
+      message.id,
+      formatApiErrorBody(body) ?? undefined,
+    );
   }
   const savedMessage = await parseJsonOrThrow<MessageRecord>(response);
   // Coalescing is the streaming autosave's alone, since it lands here per chunk. A manual

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -1143,9 +1143,7 @@ export class ChatMessageProtectedError extends Error {
   readonly threadId: string;
 
   constructor(threadId: string, messageId: string, detail?: string) {
-    // Keep the server's own wording when it sent one. A manual edit surfaces this text
-    // to the user, and replacing a specific explanation with a generic one would be a
-    // regression for the caller that is not the autosave.
+    // Keep the server's wording: a manual edit surfaces this text to the user.
     super(detail || `Message ${messageId} is server-managed and cannot be edited`);
     this.name = "ChatMessageProtectedError";
     this.threadId = threadId;
@@ -1168,17 +1166,14 @@ export async function saveChatMessage(
       body: JSON.stringify(message),
     },
   );
-  // Two different failures share this status. A protected message is the server refusing an
-  // edit it owns, and the autosave has to stop rather than resend; a thread-id collision is
-  // an ordinary failure the caller must see, and swallowing it loses the message. Only the
-  // header tells them apart, so anything else -- including a backend too old to send it --
-  // falls through to the normal error path, which is what happens today.
+  // Two failures share this status: a protected message, where the autosave must stop, and
+  // a thread-id collision, which the caller must see or the message is lost. Only the header
+  // separates them, so anything else (an older backend included) takes the normal error path.
   if (
     response.status === 409 &&
     response.headers?.get(CONFLICT_KIND_HEADER) === CONFLICT_KIND_PROTECTED
   ) {
-    // Read the body here rather than letting parseJsonOrThrow do it: a Response body can
-    // only be consumed once, and this needs the server's detail to carry into the error.
+    // Read here, not in parseJsonOrThrow: a body is single-use.
     const body = await response.json().catch(() => null);
     throw new ChatMessageProtectedError(
       message.threadId,

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -1134,6 +1134,10 @@ export async function getChatMessage(
  * rather than back off. Without this the per-chunk autosave treated the rejection as an
  * anonymous error and re-sent on the next chunk for the whole generation.
  */
+/** Set by routes/chat_history.py; exposed through the CORS middleware in main.py. */
+const CONFLICT_KIND_HEADER = "X-Unsloth-Conflict-Kind";
+const CONFLICT_KIND_PROTECTED = "protected";
+
 export class ChatMessageProtectedError extends Error {
   readonly messageId: string;
   readonly threadId: string;
@@ -1164,7 +1168,15 @@ export async function saveChatMessage(
       body: JSON.stringify(message),
     },
   );
-  if (response.status === 409) {
+  // Two different failures share this status. A protected message is the server refusing an
+  // edit it owns, and the autosave has to stop rather than resend; a thread-id collision is
+  // an ordinary failure the caller must see, and swallowing it loses the message. Only the
+  // header tells them apart, so anything else -- including a backend too old to send it --
+  // falls through to the normal error path, which is what happens today.
+  if (
+    response.status === 409 &&
+    response.headers?.get(CONFLICT_KIND_HEADER) === CONFLICT_KIND_PROTECTED
+  ) {
     // Read the body here rather than letting parseJsonOrThrow do it: a Response body can
     // only be consumed once, and this needs the server's detail to carry into the error.
     const body = await response.json().catch(() => null);

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -1128,6 +1128,24 @@ export async function getChatMessage(
   return parseJsonOrThrow<MessageRecord>(response);
 }
 
+/** The server owns this message and will reject every save of it.
+ *
+ * Distinct from a transient failure: retrying can never succeed, so callers must stop
+ * rather than back off. Without this the per-chunk autosave treated the rejection as an
+ * anonymous error and re-sent on the next chunk for the whole generation.
+ */
+export class ChatMessageProtectedError extends Error {
+  readonly messageId: string;
+  readonly threadId: string;
+
+  constructor(threadId: string, messageId: string) {
+    super(`Message ${messageId} is server-managed and cannot be edited`);
+    this.name = "ChatMessageProtectedError";
+    this.threadId = threadId;
+    this.messageId = messageId;
+  }
+}
+
 export async function saveChatMessage(
   message: MessageRecord,
   options: { allowGenerationEdit?: boolean; coalesce?: boolean } = {},
@@ -1143,6 +1161,9 @@ export async function saveChatMessage(
       body: JSON.stringify(message),
     },
   );
+  if (response.status === 409) {
+    throw new ChatMessageProtectedError(message.threadId, message.id);
+  }
   const savedMessage = await parseJsonOrThrow<MessageRecord>(response);
   // Coalescing is the streaming autosave's alone, since it lands here per chunk. A manual
   // edit is one deliberate change and publishes at once.

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -949,17 +949,42 @@ export async function moveStoredChatItemToProject(
   );
 }
 
-// Messages the server has told us it owns. Once it answers 409 for an id, every later
-// save of that id is rejected too, so the autosave must stop instead of retrying: the
-// per-chunk callers fire every ~300ms for the length of a generation, which turned one
-// 43s response into 54 rejected PUTs. Keyed by thread rather than by a joined string,
-// since message ids are opaque and a separator that cannot collide with one is not worth
-// guessing at.
-const serverOwnedMessageIds = new Map<string, Set<string>>();
+// Payloads the server answered 409 for. The per-chunk callers fire every ~300ms for the
+// length of a generation, so resending a payload the server just refused turned one 43s
+// response into 54 rejected PUTs.
+//
+// Keyed by the payload, not by the message id, because a 409 on this route is not proof of
+// permanent ownership. `PUT /threads/{t}/messages/{id}` answers 409 for both
+// ChatMessageProtectedError and ChatMessageConflictError, and even a protected message may
+// be refused only transiently: _safe_generation_assistant_update rejects a save whose
+// generationSeq lost a race to the producer while still permitting the later monotonic and
+// terminal writes that carry usage, timing and response details. Suppressing by id would
+// drop those permanently, so only a byte-identical resend is skipped. That is what the
+// storm was, and a payload the client has actually moved on from is always retried.
+//
+// Keyed by thread rather than by a joined string, since message ids are opaque and a
+// separator that cannot collide with one is not worth guessing at.
+const rejectedChatMessagePayloads = new Map<string, Map<string, string>>();
 
-/** Forget the server-owned markers for a thread (its ids can be reissued). */
+/** Deterministic JSON: key order must not decide whether two payloads look equal. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+  return `{${entries
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+    .join(",")}}`;
+}
+
+/** Forget the rejected-payload markers for a thread (its ids can be reissued). */
 export function clearServerOwnedChatMessages(threadId: string): void {
-  serverOwnedMessageIds.delete(threadId);
+  rejectedChatMessagePayloads.delete(threadId);
 }
 
 // Tombstoning a thread is the point its message ids stop mattering, so the two always
@@ -981,9 +1006,11 @@ export async function saveStoredChatMessage(
   if (isChatThreadDeleted(message.threadId)) {
     throw new Error(`Thread ${message.threadId} was deleted`);
   }
-  if (serverOwnedMessageIds.get(message.threadId)?.has(message.id)) {
-    // The server's copy is authoritative and already persisted; returning the caller's
-    // record keeps the optimistic UI intact without another doomed round trip.
+  const payload = stableStringify(message);
+  if (rejectedChatMessagePayloads.get(message.threadId)?.get(message.id) === payload) {
+    // This exact payload was just refused, so the server's copy is authoritative for it;
+    // returning the caller's record keeps the optimistic UI intact without another doomed
+    // round trip. Any payload the client has since moved on from falls through and is sent.
     return message;
   }
   await ensureStoredChatThread(message.threadId);
@@ -992,9 +1019,10 @@ export async function saveStoredChatMessage(
     return await saveChatMessage(message, { coalesce: true });
   } catch (error) {
     if (error instanceof ChatMessageProtectedError) {
-      const owned = serverOwnedMessageIds.get(message.threadId) ?? new Set<string>();
-      owned.add(message.id);
-      serverOwnedMessageIds.set(message.threadId, owned);
+      const rejected =
+        rejectedChatMessagePayloads.get(message.threadId) ?? new Map<string, string>();
+      rejected.set(message.id, payload);
+      rejectedChatMessagePayloads.set(message.threadId, rejected);
       return message;
     }
     throw error;

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -1042,7 +1042,15 @@ export async function syncStoredChatMessages(
   if (isThreadIncognito(threadId)) return messages;
   if (isChatThreadDeleted(threadId)) return [];
   await ensureStoredChatThread(threadId);
-  return syncChatMessages(threadId, messages, options);
+  const synced = await syncChatMessages(threadId, messages, options);
+  // Deleting rows frees their ids, which is the other way a cached cross-thread collision
+  // stops being true (the thread itself survives, so the tombstone path never runs). Only
+  // on a sync that actually asked for deletions: an ordinary sync runs constantly, and
+  // clearing there would put the request storm straight back.
+  if (options.pruneMissing || (options.deletedMessageIds?.length ?? 0) > 0) {
+    clearServerOwnedChatMessages();
+  }
+  return synced;
 }
 
 export async function saveStoredChatThread(

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -389,7 +389,7 @@ async function saveLegacyChatThread(
     if (!(error instanceof ChatThreadDeletedError)) {
       throw error;
     }
-    markChatThreadDeleted(thread.id);
+    forgetChatThread(thread.id);
     return undefined;
   }
 }
@@ -962,6 +962,18 @@ export function clearServerOwnedChatMessages(threadId: string): void {
   serverOwnedMessageIds.delete(threadId);
 }
 
+// Tombstoning a thread is the point its message ids stop mattering, so the two always
+// happen together: without this the map would only ever grow across a long-lived session.
+function forgetChatThread(threadId: string): void {
+  markChatThreadDeleted(threadId);
+  clearServerOwnedChatMessages(threadId);
+}
+
+function forgetChatThreads(threadIds: string[]): void {
+  markChatThreadsDeleted(threadIds);
+  for (const threadId of threadIds) clearServerOwnedChatMessages(threadId);
+}
+
 export async function saveStoredChatMessage(
   message: MessageRecord,
 ): Promise<MessageRecord> {
@@ -1011,7 +1023,7 @@ export async function saveStoredChatThread(
     return await writeChatThreadRecord(thread);
   } catch (error) {
     if (error instanceof ChatThreadDeletedError) {
-      markChatThreadDeleted(thread.id);
+      forgetChatThread(thread.id);
     }
     throw error;
   }
@@ -1085,7 +1097,7 @@ export async function deleteStoredChatThreads(
         .catch(() => undefined),
     undefined,
   );
-  markChatThreadsDeleted(ids);
+  forgetChatThreads(ids);
   return kept;
 }
 
@@ -1204,7 +1216,7 @@ async function clearStoredChatsWithAdmissionClosed(
   const deleted = new Set(result.deletedThreadIds);
   result.failedThreadIds = allThreadIds.filter((id) => !deleted.has(id));
 
-  markChatThreadsDeleted(result.deletedThreadIds);
+  forgetChatThreads(result.deletedThreadIds);
   notifyChatHistoryUpdated();
 
   if (result.backend === "failed" && result.legacy === "failed") {

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -966,6 +966,48 @@ export async function moveStoredChatItemToProject(
 // separator that cannot collide with one is not worth guessing at.
 const rejectedChatMessagePayloads = new Map<string, Map<string, string>>();
 
+// A payload holds the whole serialized message, generated content included, and the only
+// production clears are the delete paths, so a long-lived tab that never deletes anything
+// would keep one copy of every long response for the session. Only consecutive resends of
+// the same payload need to be recognised, so a small cap costs nothing real: passing it
+// just means one extra request for whichever message fell out.
+const MAX_REJECTED_PAYLOADS = 32;
+
+/** Least-recently-written first, both across threads and within one. */
+function evictOldestRejectedPayloads(): void {
+  let total = 0;
+  for (const perThread of rejectedChatMessagePayloads.values()) {
+    total += perThread.size;
+  }
+  while (total > MAX_REJECTED_PAYLOADS) {
+    const oldestThread = rejectedChatMessagePayloads.entries().next().value;
+    if (!oldestThread) return;
+    const [threadId, perThread] = oldestThread;
+    const oldestMessage = perThread.keys().next().value;
+    if (oldestMessage === undefined) {
+      rejectedChatMessagePayloads.delete(threadId);
+      continue;
+    }
+    perThread.delete(oldestMessage);
+    if (perThread.size === 0) rejectedChatMessagePayloads.delete(threadId);
+    total -= 1;
+  }
+}
+
+function rememberRejectedPayload(
+  threadId: string,
+  messageId: string,
+  payload: string,
+): void {
+  const perThread = rejectedChatMessagePayloads.get(threadId) ?? new Map<string, string>();
+  // Re-inserted rather than overwritten, so a Map's insertion order stays a usable age.
+  perThread.delete(messageId);
+  perThread.set(messageId, payload);
+  rejectedChatMessagePayloads.delete(threadId);
+  rejectedChatMessagePayloads.set(threadId, perThread);
+  evictOldestRejectedPayloads();
+}
+
 /** Deterministic JSON: key order must not decide whether two payloads look equal. */
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== "object") {
@@ -1013,6 +1055,9 @@ export async function saveStoredChatMessage(
   }
   const payload = stableStringify(message);
   if (rejectedChatMessagePayloads.get(message.threadId)?.get(message.id) === payload) {
+    // Refresh its age. Without this the message being resent right now is the one aging
+    // out, which is exactly backwards: it is the only entry currently earning its place.
+    rememberRejectedPayload(message.threadId, message.id, payload);
     // This exact payload was just refused, so the server's copy is authoritative for it;
     // returning the caller's record keeps the optimistic UI intact without another doomed
     // round trip. Any payload the client has since moved on from falls through and is sent.
@@ -1024,10 +1069,7 @@ export async function saveStoredChatMessage(
     return await saveChatMessage(message, { coalesce: true });
   } catch (error) {
     if (error instanceof ChatMessageProtectedError) {
-      const rejected =
-        rejectedChatMessagePayloads.get(message.threadId) ?? new Map<string, string>();
-      rejected.set(message.id, payload);
-      rejectedChatMessagePayloads.set(message.threadId, rejected);
+      rememberRejectedPayload(message.threadId, message.id, payload);
       return message;
     }
     throw error;

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import {
+  ChatMessageProtectedError,
   ChatThreadDeletedError,
   batchListChatMessages,
   buildBackendChatExport,
@@ -948,6 +949,19 @@ export async function moveStoredChatItemToProject(
   );
 }
 
+// Messages the server has told us it owns. Once it answers 409 for an id, every later
+// save of that id is rejected too, so the autosave must stop instead of retrying: the
+// per-chunk callers fire every ~300ms for the length of a generation, which turned one
+// 43s response into 54 rejected PUTs. Keyed by thread rather than by a joined string,
+// since message ids are opaque and a separator that cannot collide with one is not worth
+// guessing at.
+const serverOwnedMessageIds = new Map<string, Set<string>>();
+
+/** Forget the server-owned markers for a thread (its ids can be reissued). */
+export function clearServerOwnedChatMessages(threadId: string): void {
+  serverOwnedMessageIds.delete(threadId);
+}
+
 export async function saveStoredChatMessage(
   message: MessageRecord,
 ): Promise<MessageRecord> {
@@ -955,9 +969,24 @@ export async function saveStoredChatMessage(
   if (isChatThreadDeleted(message.threadId)) {
     throw new Error(`Thread ${message.threadId} was deleted`);
   }
+  if (serverOwnedMessageIds.get(message.threadId)?.has(message.id)) {
+    // The server's copy is authoritative and already persisted; returning the caller's
+    // record keeps the optimistic UI intact without another doomed round trip.
+    return message;
+  }
   await ensureStoredChatThread(message.threadId);
   // The per-chunk autosave behind a streaming response.
-  return saveChatMessage(message, { coalesce: true });
+  try {
+    return await saveChatMessage(message, { coalesce: true });
+  } catch (error) {
+    if (error instanceof ChatMessageProtectedError) {
+      const owned = serverOwnedMessageIds.get(message.threadId) ?? new Set<string>();
+      owned.add(message.id);
+      serverOwnedMessageIds.set(message.threadId, owned);
+      return message;
+    }
+    throw error;
+  }
 }
 
 export async function syncStoredChatMessages(

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -982,21 +982,26 @@ function stableStringify(value: unknown): string {
     .join(",")}}`;
 }
 
-/** Forget the rejected-payload markers for a thread (its ids can be reissued). */
-export function clearServerOwnedChatMessages(threadId: string): void {
-  rejectedChatMessagePayloads.delete(threadId);
+// Every entry, not just the deleted thread's. A 409 can mean the id already belongs to a
+// different thread, and that rejection is recorded under the thread we were writing TO, so
+// deleting the thread that actually owns the id frees it while leaving the stale entry
+// somewhere else in the map. The next attempt would then be skipped as a resend and the
+// message would never be persisted. Deleting a thread is rare and user-driven, so dropping
+// the whole cache costs at most one extra request per protected message.
+export function clearServerOwnedChatMessages(): void {
+  rejectedChatMessagePayloads.clear();
 }
 
 // Tombstoning a thread is the point its message ids stop mattering, so the two always
 // happen together: without this the map would only ever grow across a long-lived session.
 function forgetChatThread(threadId: string): void {
   markChatThreadDeleted(threadId);
-  clearServerOwnedChatMessages(threadId);
+  clearServerOwnedChatMessages();
 }
 
 function forgetChatThreads(threadIds: string[]): void {
   markChatThreadsDeleted(threadIds);
-  for (const threadId of threadIds) clearServerOwnedChatMessages(threadId);
+  clearServerOwnedChatMessages();
 }
 
 export async function saveStoredChatMessage(

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -949,28 +949,14 @@ export async function moveStoredChatItemToProject(
   );
 }
 
-// Payloads the server answered 409 for. The per-chunk callers fire every ~300ms for the
-// length of a generation, so resending a payload the server just refused turned one 43s
-// response into 54 rejected PUTs.
-//
-// Keyed by the payload, not by the message id, because a 409 on this route is not proof of
-// permanent ownership. `PUT /threads/{t}/messages/{id}` answers 409 for both
-// ChatMessageProtectedError and ChatMessageConflictError, and even a protected message may
-// be refused only transiently: _safe_generation_assistant_update rejects a save whose
-// generationSeq lost a race to the producer while still permitting the later monotonic and
-// terminal writes that carry usage, timing and response details. Suppressing by id would
-// drop those permanently, so only a byte-identical resend is skipped. That is what the
-// storm was, and a payload the client has actually moved on from is always retried.
-//
-// Keyed by thread rather than by a joined string, since message ids are opaque and a
-// separator that cannot collide with one is not worth guessing at.
+// Payloads the server answered 409 for, so the ~300ms autosave stops resending them.
+// Keyed by payload, not by id: a protected message can be refused transiently, when its
+// generationSeq lost a race, and blocking the id would drop the terminal write
+// (_safe_generation_assistant_update).
 const rejectedChatMessagePayloads = new Map<string, Map<string, string>>();
 
-// A payload holds the whole serialized message, generated content included, and the only
-// production clears are the delete paths, so a long-lived tab that never deletes anything
-// would keep one copy of every long response for the session. Only consecutive resends of
-// the same payload need to be recognised, so a small cap costs nothing real: passing it
-// just means one extra request for whichever message fell out.
+// Entries hold whole messages, and only the delete paths clear them. Exceeding the cap
+// costs one extra request for whichever message fell out.
 const MAX_REJECTED_PAYLOADS = 32;
 
 /** Least-recently-written first, both across threads and within one. */
@@ -1000,7 +986,6 @@ function rememberRejectedPayload(
   payload: string,
 ): void {
   const perThread = rejectedChatMessagePayloads.get(threadId) ?? new Map<string, string>();
-  // Re-inserted rather than overwritten, so a Map's insertion order stays a usable age.
   perThread.delete(messageId);
   perThread.set(messageId, payload);
   rejectedChatMessagePayloads.delete(threadId);
@@ -1024,18 +1009,12 @@ function stableStringify(value: unknown): string {
     .join(",")}}`;
 }
 
-// Every entry, not just the deleted thread's. A 409 can mean the id already belongs to a
-// different thread, and that rejection is recorded under the thread we were writing TO, so
-// deleting the thread that actually owns the id frees it while leaving the stale entry
-// somewhere else in the map. The next attempt would then be skipped as a resend and the
-// message would never be persisted. Deleting a thread is rare and user-driven, so dropping
-// the whole cache costs at most one extra request per protected message.
+// Every entry, not just the deleted thread's: a collision is recorded under the thread we
+// wrote TO, so deleting the thread that OWNS the id frees it elsewhere in the map.
 export function clearServerOwnedChatMessages(): void {
   rejectedChatMessagePayloads.clear();
 }
 
-// Tombstoning a thread is the point its message ids stop mattering, so the two always
-// happen together: without this the map would only ever grow across a long-lived session.
 function forgetChatThread(threadId: string): void {
   markChatThreadDeleted(threadId);
   clearServerOwnedChatMessages();
@@ -1055,12 +1034,8 @@ export async function saveStoredChatMessage(
   }
   const payload = stableStringify(message);
   if (rejectedChatMessagePayloads.get(message.threadId)?.get(message.id) === payload) {
-    // Refresh its age. Without this the message being resent right now is the one aging
-    // out, which is exactly backwards: it is the only entry currently earning its place.
+    // Refresh: otherwise the message being resent right now is the one aging out.
     rememberRejectedPayload(message.threadId, message.id, payload);
-    // This exact payload was just refused, so the server's copy is authoritative for it;
-    // returning the caller's record keeps the optimistic UI intact without another doomed
-    // round trip. Any payload the client has since moved on from falls through and is sent.
     return message;
   }
   await ensureStoredChatThread(message.threadId);
@@ -1085,10 +1060,8 @@ export async function syncStoredChatMessages(
   if (isChatThreadDeleted(threadId)) return [];
   await ensureStoredChatThread(threadId);
   const synced = await syncChatMessages(threadId, messages, options);
-  // Deleting rows frees their ids, which is the other way a cached cross-thread collision
-  // stops being true (the thread itself survives, so the tombstone path never runs). Only
-  // on a sync that actually asked for deletions: an ordinary sync runs constantly, and
-  // clearing there would put the request storm straight back.
+  // Deleting rows frees their ids while the thread survives, so no tombstone runs. Gated on
+  // an actual deletion: an ordinary sync runs constantly and would undo the whole cache.
   if (options.pruneMissing || (options.deletedMessageIds?.length ?? 0) > 0) {
     clearServerOwnedChatMessages();
   }

--- a/studio/frontend/tests/chat-save-conflict-detail.test.ts
+++ b/studio/frontend/tests/chat-save-conflict-detail.test.ts
@@ -21,7 +21,7 @@ type Module = {
     threadId: string,
     messageId: string,
     detail?: string,
-  ) => Error;
+  ) => Error & { threadId: string; messageId: string };
 };
 
 /** Minimal Response double: records how many times the body was consumed. */

--- a/studio/frontend/tests/chat-save-conflict-detail.test.ts
+++ b/studio/frontend/tests/chat-save-conflict-detail.test.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// saveChatMessage turns the server's 409 into a typed error so the per-chunk autosave can
+// tell "the server owns this, stop" from "the network blipped, retry". The autosave is not
+// its only caller though: a manual edit (update-thread-message) rolls the UI back and
+// rethrows, and that message is shown to the user, so the server's own wording has to
+// survive the conversion rather than being replaced by a generic one.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadWithStubs } from "./helpers/module-stubs.ts";
+
+type Module = {
+  saveChatMessage: (
+    message: Record<string, unknown>,
+    options?: { allowGenerationEdit?: boolean; coalesce?: boolean },
+  ) => Promise<unknown>;
+  ChatMessageProtectedError: new (
+    threadId: string,
+    messageId: string,
+    detail?: string,
+  ) => Error;
+};
+
+/** Minimal Response double: records how many times the body was consumed. */
+function jsonResponse(status: number, body: unknown) {
+  let reads = 0;
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    get bodyReads() {
+      return reads;
+    },
+    async json() {
+      reads += 1;
+      if (reads > 1) {
+        // What a real Response does; a double that allowed it would hide the bug.
+        throw new TypeError("Body has already been consumed.");
+      }
+      if (body === undefined) throw new SyntaxError("Unexpected end of JSON input");
+      return body;
+    },
+  };
+}
+
+function harness(response: ReturnType<typeof jsonResponse>) {
+  const requests: { url: string; init?: RequestInit }[] = [];
+  const module = loadWithStubs<Module>(
+    new URL("../src/features/chat/api/chat-api.ts", import.meta.url),
+    {
+      "@/features/auth": {
+        authFetch: async (url: string, init?: RequestInit) => {
+          requests.push({ url, init });
+          return response;
+        },
+      },
+      "@/lib/format-fastapi-error": {
+        formatApiErrorBody: (body: unknown) =>
+          (body as { detail?: string } | null)?.detail ?? null,
+      },
+      "../types": {},
+      "../types/api": {},
+      "../utils/chat-history-revision": {
+        notifyChatHistoryUpdated: () => {},
+        isCoalescedHistoryEvent: () => false,
+      },
+      "./generation-length.ts": {},
+      "./gguf-variants-request": {},
+      "./padded-response": { assertCompletedPaddedBody: () => {} },
+      "@/features/hf-auth": { prepareHfTokenForUse: async () => undefined },
+      "@/features/hub/lib/abort-signals": {},
+      "@/features/hub/lib/hub-token-header": { hubTokenHeader: () => ({}) },
+      "@/features/hub/lib/network": { isHuggingFaceOffline: () => false },
+      "@/features/native-intents/api": { consumeNativePathToken: () => undefined },
+      "@/lib/model-lifecycle-events": {},
+    },
+  );
+  return { module, requests };
+}
+
+const message = { id: "m1", threadId: "t1", role: "assistant", content: [], createdAt: 1 };
+
+test("a 409 becomes the typed error, carrying the server's wording", async () => {
+  const response = jsonResponse(409, {
+    detail: "server-managed generation messages cannot be edited",
+  });
+  const { module } = harness(response);
+
+  const error = await module
+    .saveChatMessage(message)
+    .then(() => null)
+    .catch((e) => e);
+
+  assert.ok(
+    error instanceof module.ChatMessageProtectedError,
+    "callers branch on the type, so instanceof must hold",
+  );
+  assert.equal(
+    error.message,
+    "server-managed generation messages cannot be edited",
+    "a manual edit surfaces this to the user; it must not be replaced",
+  );
+  assert.equal(error.threadId, "t1");
+  assert.equal(error.messageId, "m1");
+});
+
+test("the body is read exactly once", async () => {
+  // A Response body is single-use. Reading it here and then letting parseJsonOrThrow read
+  // it again would throw a TypeError that masks the real conflict.
+  const response = jsonResponse(409, { detail: "nope" });
+  const { module } = harness(response);
+  await module.saveChatMessage(message).catch(() => {});
+  assert.equal(response.bodyReads, 1);
+});
+
+test("a 409 with no usable body still produces a sensible message", async () => {
+  const { module } = harness(jsonResponse(409, null));
+  const error = await module.saveChatMessage(message).catch((e) => e);
+  assert.ok(error instanceof module.ChatMessageProtectedError);
+  assert.match(error.message, /server-managed/);
+});
+
+test("a 409 whose body is not JSON at all does not throw a parse error", async () => {
+  const { module } = harness(jsonResponse(409, undefined));
+  const error = await module.saveChatMessage(message).catch((e) => e);
+  assert.ok(
+    error instanceof module.ChatMessageProtectedError,
+    "the conflict must survive an unparseable body",
+  );
+});
+
+test("other failures are untouched", async () => {
+  const { module } = harness(jsonResponse(500, { detail: "boom" }));
+  const error = await module.saveChatMessage(message).catch((e) => e);
+  assert.ok(error instanceof Error);
+  assert.ok(
+    !(error instanceof module.ChatMessageProtectedError),
+    "only 409 means the server owns the message",
+  );
+  assert.match(error.message, /boom/);
+});
+
+test("a success is returned unchanged", async () => {
+  const saved = { ...message, content: [{ type: "text", text: "hi" }] };
+  const { module, requests } = harness(jsonResponse(200, saved));
+  assert.deepEqual(await module.saveChatMessage(message), saved);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].init?.method, "PUT");
+});
+
+test("the manual-edit query parameter is still sent", async () => {
+  const { module, requests } = harness(jsonResponse(200, message));
+  await module.saveChatMessage(message, { allowGenerationEdit: true });
+  assert.match(requests[0].url, /allowGenerationEdit=true/);
+});

--- a/studio/frontend/tests/chat-save-conflict-detail.test.ts
+++ b/studio/frontend/tests/chat-save-conflict-detail.test.ts
@@ -25,11 +25,12 @@ type Module = {
 };
 
 /** Minimal Response double: records how many times the body was consumed. */
-function jsonResponse(status: number, body: unknown) {
+function jsonResponse(status: number, body: unknown, kind: string | null = "protected") {
   let reads = 0;
   return {
     status,
     ok: status >= 200 && status < 300,
+    headers: { get: (name: string) => (name === "X-Unsloth-Conflict-Kind" ? kind : null) },
     get bodyReads() {
       return reads;
     },
@@ -129,6 +130,32 @@ test("a 409 whose body is not JSON at all does not throw a parse error", async (
     error instanceof module.ChatMessageProtectedError,
     "the conflict must survive an unparseable body",
   );
+});
+
+test("a thread-id collision is not treated as protection", async () => {
+  // The backend answers 409 for ChatMessageConflictError too, meaning the id already
+  // belongs to another thread. saveStoredChatMessage swallows ChatMessageProtectedError and
+  // reports success, so mislabelling this one loses the message with no error anywhere.
+  const { module } = harness(
+    jsonResponse(409, { detail: "Message id already belongs to another thread: m1" }, "thread-collision"),
+  );
+  const error = await module.saveChatMessage(message).catch((e) => e);
+
+  assert.ok(error instanceof Error);
+  assert.ok(
+    !(error instanceof module.ChatMessageProtectedError),
+    "the caller must see this one and handle it",
+  );
+});
+
+test("a backend too old to send the header falls back to the plain error", async () => {
+  // Safe direction: before this change every 409 threw an anonymous error, so an unknown
+  // 409 keeps that behaviour rather than being silently swallowed.
+  const { module } = harness(jsonResponse(409, { detail: "conflict" }, null));
+  const error = await module.saveChatMessage(message).catch((e) => e);
+
+  assert.ok(error instanceof Error);
+  assert.ok(!(error instanceof module.ChatMessageProtectedError));
 });
 
 test("other failures are untouched", async () => {

--- a/studio/frontend/tests/chat-save-conflict-detail.test.ts
+++ b/studio/frontend/tests/chat-save-conflict-detail.test.ts
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// saveChatMessage turns the server's 409 into a typed error so the per-chunk autosave can
-// tell "the server owns this, stop" from "the network blipped, retry". The autosave is not
-// its only caller though: a manual edit (update-thread-message) rolls the UI back and
-// rethrows, and that message is shown to the user, so the server's own wording has to
-// survive the conversion rather than being replaced by a generic one.
+// saveChatMessage turns a protected 409 into a typed error so the autosave can tell "stop"
+// from "retry". A manual edit rethrows to the user, so the server's wording must survive.
 
 import assert from "node:assert/strict";
 import test from "node:test";
@@ -37,7 +34,6 @@ function jsonResponse(status: number, body: unknown, kind: string | null = "prot
     async json() {
       reads += 1;
       if (reads > 1) {
-        // What a real Response does; a double that allowed it would hide the bug.
         throw new TypeError("Body has already been consumed.");
       }
       if (body === undefined) throw new SyntaxError("Unexpected end of JSON input");
@@ -108,8 +104,6 @@ test("a 409 becomes the typed error, carrying the server's wording", async () =>
 });
 
 test("the body is read exactly once", async () => {
-  // A Response body is single-use. Reading it here and then letting parseJsonOrThrow read
-  // it again would throw a TypeError that masks the real conflict.
   const response = jsonResponse(409, { detail: "nope" });
   const { module } = harness(response);
   await module.saveChatMessage(message).catch(() => {});
@@ -133,9 +127,6 @@ test("a 409 whose body is not JSON at all does not throw a parse error", async (
 });
 
 test("a thread-id collision is not treated as protection", async () => {
-  // The backend answers 409 for ChatMessageConflictError too, meaning the id already
-  // belongs to another thread. saveStoredChatMessage swallows ChatMessageProtectedError and
-  // reports success, so mislabelling this one loses the message with no error anywhere.
   const { module } = harness(
     jsonResponse(409, { detail: "Message id already belongs to another thread: m1" }, "thread-collision"),
   );
@@ -149,8 +140,6 @@ test("a thread-id collision is not treated as protection", async () => {
 });
 
 test("a backend too old to send the header falls back to the plain error", async () => {
-  // Safe direction: before this change every 409 threw an anonymous error, so an unknown
-  // 409 keeps that behaviour rather than being silently swallowed.
   const { module } = harness(jsonResponse(409, { detail: "conflict" }, null));
   const error = await module.saveChatMessage(message).catch((e) => e);
 

--- a/studio/frontend/tests/chat-save-server-managed-stop.test.ts
+++ b/studio/frontend/tests/chat-save-server-managed-stop.test.ts
@@ -1,15 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// The per-chunk autosave used to treat the server's 409 as an anonymous error and re-send
-// on the very next chunk. One 43s generation in a live session produced 54 rejected PUTs,
-// each logging a full traceback server-side.
-//
-// The stop is scoped to the exact payload that was refused, not to the message id. A 409 on
-// this route is not proof of permanent ownership: it also covers a message id colliding with
-// another thread, and even a protected message may be refused only because its generationSeq
-// lost a race, with the later monotonic and terminal writes still permitted. So a resend of
-// the same bytes is dropped and anything the client has moved on to is sent.
+// The autosave used to re-send on the next chunk after a 409, turning one 43s generation
+// into 54 rejected PUTs. The stop is scoped to the refused payload, not the message id: a
+// 409 is not proof of ownership, so only a resend of the same bytes is dropped.
 
 import assert from "node:assert/strict";
 import test from "node:test";
@@ -102,8 +96,6 @@ test("a rejected message is never sent again", async () => {
 test("the rejection resolves rather than throwing, so the stream keeps following", async () => {
   const { module } = harness({ rejectIds: new Set(["m1"]) });
   const record = message("m1");
-  // The caller's optimistic record comes back: the server's copy is already durable, and
-  // throwing here would abort the recovery loop that is still reading the generation.
   assert.deepEqual(await module.saveStoredChatMessage(record), record);
 });
 
@@ -141,10 +133,6 @@ test("clearing lets a reissued id save again", async () => {
 });
 
 test("a later monotonic update is still sent after a stale-seq rejection", async () => {
-  // _safe_generation_assistant_update refuses an autosave whose generationSeq lost the race
-  // to the producer, then permits the next one. The recovery follower keeps going and its
-  // terminal write carries contextUsage, timings and response details, so muting the id here
-  // would drop all of them on reload.
   const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
 
   await module.saveStoredChatMessage({ ...message("m1"), metadata: { generationSeq: 4 } });
@@ -175,8 +163,6 @@ test("growing streamed content is never mistaken for a resend", async () => {
 });
 
 test("key order does not decide whether two payloads are the same", async () => {
-  // Two call sites build the record with different property order. Without a stable
-  // serialization the storm would come straight back for whichever one loses the race.
   const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
 
   await module.saveStoredChatMessage({
@@ -198,11 +184,6 @@ test("key order does not decide whether two payloads are the same", async () => 
 });
 
 test("deleting a thread frees ids cached under every other thread", async () => {
-  // A 409 also means "this id already belongs to another thread". That rejection is
-  // recorded under the thread being written TO, so deleting the thread that actually owns
-  // the id makes the same payload valid while the stale entry sits elsewhere in the map.
-  // Clearing only the deleted thread's bucket would skip the now-valid write and the
-  // message would be gone after a reload.
   const { module, attempts } = harness({ rejectIds: new Set(["m1", "m2"]) });
 
   await module.saveStoredChatMessage(message("m1", "target"));
@@ -221,9 +202,6 @@ test("deleting a thread frees ids cached under every other thread", async () => 
 });
 
 test("pruning messages frees their ids too", async () => {
-  // Deleting one message calls syncStoredChatMessages with pruneMissing, and the backend
-  // removes the row while the thread survives, so no tombstone runs. The id is free but
-  // the collision is still cached, and the identical payload would be skipped.
   const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
 
   await module.saveStoredChatMessage(message("m1", "target"));
@@ -237,7 +215,6 @@ test("pruning messages frees their ids too", async () => {
 });
 
 test("an ordinary sync does not clear the cache", async () => {
-  // syncStoredChatMessages runs constantly. Clearing on every call would put the storm back.
   const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
 
   await module.saveStoredChatMessage(message("m1", "target"));
@@ -248,8 +225,6 @@ test("an ordinary sync does not clear the cache", async () => {
 });
 
 test("the cache is bounded, so a long session cannot grow without limit", async () => {
-  // Each entry holds a whole serialized message, generated content included. Only
-  // consecutive resends need recognising, so falling out of the cache costs one request.
   const ids = Array.from({ length: 40 }, (_, index) => `m${index}`);
   const { module, attempts } = harness({ rejectIds: new Set(ids) });
 
@@ -258,9 +233,8 @@ test("the cache is bounded, so a long session cannot grow without limit", async 
   }
   assert.equal(attempts.length, 40, "each is refused once");
 
-  // Asserted per id rather than by re-walking the whole list: a bounded cache walked in
-  // insertion order misses on every lookup by construction, which measures the walk and
-  // not the bound.
+  // Per id, not by re-walking: a bounded cache walked in insertion order misses every
+  // lookup by construction, measuring the walk rather than the bound.
   await module.saveStoredChatMessage(message("m39"));
   assert.equal(attempts.length, 40, "the newest entry is still suppressed");
 
@@ -271,13 +245,10 @@ test("the cache is bounded, so a long session cannot grow without limit", async 
 test("an ordinary failure still propagates", async () => {
   const { module, attempts } = harness({ failWith: new Error("network down") });
 
-  // Only the permanent 409 is swallowed. A transient failure must still reach the caller,
-  // which retries it -- turning that into a silent success would lose the message.
   await assert.rejects(
     () => module.saveStoredChatMessage(message("m9")),
     /network down/,
   );
-  // And it must not be marked server-owned, or one blip would mute the message for good.
   await assert.rejects(() => module.saveStoredChatMessage(message("m9")));
   assert.deepEqual(attempts, ["m9", "m9"]);
 });

--- a/studio/frontend/tests/chat-save-server-managed-stop.test.ts
+++ b/studio/frontend/tests/chat-save-server-managed-stop.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The per-chunk autosave used to treat the server's 409 as an anonymous error and re-send
+// on the very next chunk. One 43s generation in a live session produced 54 rejected PUTs,
+// each logging a full traceback server-side. A 409 here is permanent -- the server owns the
+// message -- so the only correct reaction is to stop, not to back off.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadWithStubs } from "./helpers/module-stubs.ts";
+
+type Module = {
+  saveStoredChatMessage: (message: Record<string, unknown>) => Promise<unknown>;
+  clearServerOwnedChatMessages: (threadId: string) => void;
+};
+
+class FakeProtectedError extends Error {}
+
+function harness(options: { rejectIds?: Set<string>; failWith?: Error } = {}) {
+  const attempts: string[] = [];
+  const reject = options.rejectIds ?? new Set<string>();
+  const module = loadWithStubs<Module>(
+    new URL(
+      "../src/features/chat/utils/chat-history-storage.ts",
+      import.meta.url,
+    ),
+    {
+      "../api/chat-api": {
+        ChatMessageProtectedError: FakeProtectedError,
+        saveChatMessage: async (message: { id: string }) => {
+          attempts.push(message.id);
+          if (options.failWith) throw options.failWith;
+          if (reject.has(message.id)) throw new FakeProtectedError("409");
+          return message;
+        },
+        notifyChatHistoryUpdated: () => {},
+        getChatThread: async () => ({ id: "t1" }),
+        saveChatThread: async () => {},
+      },
+      "../db": { DEXIE_DB_NAME: "test", db: {} },
+      "./chat-thread-tombstones": { isChatThreadDeleted: () => false },
+      "./thread-record-write-coordinator": {
+        ThreadRecordWriteCoordinator: class {
+          async settleCurrent() {}
+          async write(_id: string, fn: () => Promise<unknown>) {
+            return fn();
+          }
+          observe() {}
+          closeAdmission() {}
+          confirmFinalState() {}
+          hasPending() {
+            return false;
+          }
+          idsRequiringFence() {
+            return [];
+          }
+        },
+      },
+    },
+  );
+  return { module, attempts };
+}
+
+const message = (id: string, threadId = "t1") => ({
+  id,
+  threadId,
+  role: "assistant",
+  content: [],
+  createdAt: 1,
+});
+
+test("a rejected message is never sent again", async () => {
+  const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
+
+  for (let chunk = 0; chunk < 5; chunk += 1) {
+    await module.saveStoredChatMessage(message("m1"));
+  }
+
+  assert.deepEqual(
+    attempts,
+    ["m1"],
+    "the server owns this message; retrying can never succeed",
+  );
+});
+
+test("the rejection resolves rather than throwing, so the stream keeps following", async () => {
+  const { module } = harness({ rejectIds: new Set(["m1"]) });
+  const record = message("m1");
+  // The caller's optimistic record comes back: the server's copy is already durable, and
+  // throwing here would abort the recovery loop that is still reading the generation.
+  assert.deepEqual(await module.saveStoredChatMessage(record), record);
+});
+
+test("only the rejected id is blocked", async () => {
+  const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
+
+  await module.saveStoredChatMessage(message("m1"));
+  await module.saveStoredChatMessage(message("m2"));
+  await module.saveStoredChatMessage(message("m2"));
+
+  assert.deepEqual(
+    attempts,
+    ["m1", "m2", "m2"],
+    "a client-owned message must still autosave every chunk",
+  );
+});
+
+test("the same id in another thread is unaffected", async () => {
+  const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
+
+  await module.saveStoredChatMessage(message("m1", "t1"));
+  await module.saveStoredChatMessage(message("m1", "t2"));
+
+  assert.equal(attempts.length, 2, "the block is per thread, not per bare id");
+});
+
+test("clearing lets a reissued id save again", async () => {
+  const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
+
+  await module.saveStoredChatMessage(message("m1"));
+  module.clearServerOwnedChatMessages("t1");
+  await module.saveStoredChatMessage(message("m1"));
+
+  assert.equal(attempts.length, 2);
+});
+
+test("an ordinary failure still propagates", async () => {
+  const { module, attempts } = harness({ failWith: new Error("network down") });
+
+  // Only the permanent 409 is swallowed. A transient failure must still reach the caller,
+  // which retries it -- turning that into a silent success would lose the message.
+  await assert.rejects(
+    () => module.saveStoredChatMessage(message("m9")),
+    /network down/,
+  );
+  // And it must not be marked server-owned, or one blip would mute the message for good.
+  await assert.rejects(() => module.saveStoredChatMessage(message("m9")));
+  assert.deepEqual(attempts, ["m9", "m9"]);
+});

--- a/studio/frontend/tests/chat-save-server-managed-stop.test.ts
+++ b/studio/frontend/tests/chat-save-server-managed-stop.test.ts
@@ -247,6 +247,27 @@ test("an ordinary sync does not clear the cache", async () => {
   assert.deepEqual(attempts, ["m1"], "nothing was deleted, so nothing was freed");
 });
 
+test("the cache is bounded, so a long session cannot grow without limit", async () => {
+  // Each entry holds a whole serialized message, generated content included. Only
+  // consecutive resends need recognising, so falling out of the cache costs one request.
+  const ids = Array.from({ length: 40 }, (_, index) => `m${index}`);
+  const { module, attempts } = harness({ rejectIds: new Set(ids) });
+
+  for (const id of ids) {
+    await module.saveStoredChatMessage(message(id));
+  }
+  assert.equal(attempts.length, 40, "each is refused once");
+
+  // Asserted per id rather than by re-walking the whole list: a bounded cache walked in
+  // insertion order misses on every lookup by construction, which measures the walk and
+  // not the bound.
+  await module.saveStoredChatMessage(message("m39"));
+  assert.equal(attempts.length, 40, "the newest entry is still suppressed");
+
+  await module.saveStoredChatMessage(message("m0"));
+  assert.equal(attempts.length, 41, "the oldest fell out of the cap and is sent again");
+});
+
 test("an ordinary failure still propagates", async () => {
   const { module, attempts } = harness({ failWith: new Error("network down") });
 

--- a/studio/frontend/tests/chat-save-server-managed-stop.test.ts
+++ b/studio/frontend/tests/chat-save-server-managed-stop.test.ts
@@ -3,8 +3,13 @@
 
 // The per-chunk autosave used to treat the server's 409 as an anonymous error and re-send
 // on the very next chunk. One 43s generation in a live session produced 54 rejected PUTs,
-// each logging a full traceback server-side. A 409 here is permanent -- the server owns the
-// message -- so the only correct reaction is to stop, not to back off.
+// each logging a full traceback server-side.
+//
+// The stop is scoped to the exact payload that was refused, not to the message id. A 409 on
+// this route is not proof of permanent ownership: it also covers a message id colliding with
+// another thread, and even a protected message may be refused only because its generationSeq
+// lost a race, with the later monotonic and terminal writes still permitted. So a resend of
+// the same bytes is dropped and anything the client has moved on to is sent.
 
 import assert from "node:assert/strict";
 import test from "node:test";
@@ -124,6 +129,63 @@ test("clearing lets a reissued id save again", async () => {
   await module.saveStoredChatMessage(message("m1"));
 
   assert.equal(attempts.length, 2);
+});
+
+test("a later monotonic update is still sent after a stale-seq rejection", async () => {
+  // _safe_generation_assistant_update refuses an autosave whose generationSeq lost the race
+  // to the producer, then permits the next one. The recovery follower keeps going and its
+  // terminal write carries contextUsage, timings and response details, so muting the id here
+  // would drop all of them on reload.
+  const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
+
+  await module.saveStoredChatMessage({ ...message("m1"), metadata: { generationSeq: 4 } });
+  await module.saveStoredChatMessage({ ...message("m1"), metadata: { generationSeq: 5 } });
+  await module.saveStoredChatMessage({
+    ...message("m1"),
+    metadata: { generationSeq: 6, generationSettled: true },
+  });
+
+  assert.deepEqual(
+    attempts,
+    ["m1", "m1", "m1"],
+    "each newer payload gets its own attempt; only a byte-identical resend is dropped",
+  );
+});
+
+test("growing streamed content is never mistaken for a resend", async () => {
+  const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
+
+  for (const text of ["He", "Hell", "Hello"]) {
+    await module.saveStoredChatMessage({
+      ...message("m1"),
+      content: [{ type: "text", text }],
+    });
+  }
+
+  assert.equal(attempts.length, 3, "the follower publishes a longer body each chunk");
+});
+
+test("key order does not decide whether two payloads are the same", async () => {
+  // Two call sites build the record with different property order. Without a stable
+  // serialization the storm would come straight back for whichever one loses the race.
+  const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
+
+  await module.saveStoredChatMessage({
+    id: "m1",
+    threadId: "t1",
+    role: "assistant",
+    content: [],
+    createdAt: 1,
+  });
+  await module.saveStoredChatMessage({
+    createdAt: 1,
+    content: [],
+    role: "assistant",
+    threadId: "t1",
+    id: "m1",
+  });
+
+  assert.deepEqual(attempts, ["m1"], "same fields, same payload");
 });
 
 test("an ordinary failure still propagates", async () => {

--- a/studio/frontend/tests/chat-save-server-managed-stop.test.ts
+++ b/studio/frontend/tests/chat-save-server-managed-stop.test.ts
@@ -18,7 +18,7 @@ import { loadWithStubs } from "./helpers/module-stubs.ts";
 
 type Module = {
   saveStoredChatMessage: (message: Record<string, unknown>) => Promise<unknown>;
-  clearServerOwnedChatMessages: (threadId: string) => void;
+  clearServerOwnedChatMessages: () => void;
 };
 
 class FakeProtectedError extends Error {}
@@ -125,7 +125,7 @@ test("clearing lets a reissued id save again", async () => {
   const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
 
   await module.saveStoredChatMessage(message("m1"));
-  module.clearServerOwnedChatMessages("t1");
+  module.clearServerOwnedChatMessages();
   await module.saveStoredChatMessage(message("m1"));
 
   assert.equal(attempts.length, 2);
@@ -186,6 +186,29 @@ test("key order does not decide whether two payloads are the same", async () => 
   });
 
   assert.deepEqual(attempts, ["m1"], "same fields, same payload");
+});
+
+test("deleting a thread frees ids cached under every other thread", async () => {
+  // A 409 also means "this id already belongs to another thread". That rejection is
+  // recorded under the thread being written TO, so deleting the thread that actually owns
+  // the id makes the same payload valid while the stale entry sits elsewhere in the map.
+  // Clearing only the deleted thread's bucket would skip the now-valid write and the
+  // message would be gone after a reload.
+  const { module, attempts } = harness({ rejectIds: new Set(["m1", "m2"]) });
+
+  await module.saveStoredChatMessage(message("m1", "target"));
+  await module.saveStoredChatMessage(message("m2", "other"));
+  assert.deepEqual(attempts, ["m1", "m2"], "both are cached as refused");
+
+  module.clearServerOwnedChatMessages();
+  await module.saveStoredChatMessage(message("m1", "target"));
+  await module.saveStoredChatMessage(message("m2", "other"));
+
+  assert.deepEqual(
+    attempts,
+    ["m1", "m2", "m1", "m2"],
+    "the delete can free an id cached under any thread, so every entry goes",
+  );
 });
 
 test("an ordinary failure still propagates", async () => {

--- a/studio/frontend/tests/chat-save-server-managed-stop.test.ts
+++ b/studio/frontend/tests/chat-save-server-managed-stop.test.ts
@@ -19,6 +19,11 @@ import { loadWithStubs } from "./helpers/module-stubs.ts";
 type Module = {
   saveStoredChatMessage: (message: Record<string, unknown>) => Promise<unknown>;
   clearServerOwnedChatMessages: () => void;
+  syncStoredChatMessages: (
+    threadId: string,
+    messages: unknown[],
+    options?: { pruneMissing?: boolean; deletedMessageIds?: string[] },
+  ) => Promise<unknown>;
 };
 
 class FakeProtectedError extends Error {}
@@ -41,6 +46,10 @@ function harness(options: { rejectIds?: Set<string>; failWith?: Error } = {}) {
           return message;
         },
         notifyChatHistoryUpdated: () => {},
+        syncChatMessages: async (
+          _threadId: string,
+          messages: unknown[],
+        ) => messages,
         getChatThread: async () => ({ id: "t1" }),
         saveChatThread: async () => {},
       },
@@ -209,6 +218,33 @@ test("deleting a thread frees ids cached under every other thread", async () => 
     ["m1", "m2", "m1", "m2"],
     "the delete can free an id cached under any thread, so every entry goes",
   );
+});
+
+test("pruning messages frees their ids too", async () => {
+  // Deleting one message calls syncStoredChatMessages with pruneMissing, and the backend
+  // removes the row while the thread survives, so no tombstone runs. The id is free but
+  // the collision is still cached, and the identical payload would be skipped.
+  const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
+
+  await module.saveStoredChatMessage(message("m1", "target"));
+  await module.syncStoredChatMessages("other", [], {
+    pruneMissing: true,
+    deletedMessageIds: ["m1"],
+  });
+  await module.saveStoredChatMessage(message("m1", "target"));
+
+  assert.deepEqual(attempts, ["m1", "m1"], "the id was freed, so retry it");
+});
+
+test("an ordinary sync does not clear the cache", async () => {
+  // syncStoredChatMessages runs constantly. Clearing on every call would put the storm back.
+  const { module, attempts } = harness({ rejectIds: new Set(["m1"]) });
+
+  await module.saveStoredChatMessage(message("m1", "target"));
+  await module.syncStoredChatMessages("target", [], { pruneMissing: false });
+  await module.saveStoredChatMessage(message("m1", "target"));
+
+  assert.deepEqual(attempts, ["m1"], "nothing was deleted, so nothing was freed");
 });
 
 test("an ordinary failure still propagates", async () => {

--- a/studio/frontend/tests/chat-thread-tombstone-clears-owned.test.ts
+++ b/studio/frontend/tests/chat-thread-tombstone-clears-owned.test.ts
@@ -1,14 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// The server-owned message map in chat-history-storage is keyed by thread, so without a
-// matching removal it would only ever grow across a long-lived session. Tombstoning a
-// thread is the point its message ids stop mattering, so the two are paired in
-// forgetChatThread/forgetChatThreads.
-//
-// Asserted at the source level rather than by driving one delete path: there are four
-// call sites and a future edit that calls the tombstone helpers directly would silently
-// reintroduce the leak on whichever path a runtime test did not happen to cover.
+// Asserted at the source level: a future edit calling the tombstone helpers directly would
+// reintroduce the leak on whichever delete path a runtime test did not cover.
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -105,8 +99,6 @@ test("both wrappers exist and each clears the map", () => {
 });
 
 test("at least one real delete path is wired to a wrapper", () => {
-  // Guards against the wrappers existing but nothing using them, which would leave
-  // clearServerOwnedChatMessages dead again.
   const sf = parseModule();
   const used: string[] = [];
   const visit = (node: ts.Node): void => {

--- a/studio/frontend/tests/chat-thread-tombstone-clears-owned.test.ts
+++ b/studio/frontend/tests/chat-thread-tombstone-clears-owned.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The server-owned message map in chat-history-storage is keyed by thread, so without a
+// matching removal it would only ever grow across a long-lived session. Tombstoning a
+// thread is the point its message ids stop mattering, so the two are paired in
+// forgetChatThread/forgetChatThreads.
+//
+// Asserted at the source level rather than by driving one delete path: there are four
+// call sites and a future edit that calls the tombstone helpers directly would silently
+// reintroduce the leak on whichever path a runtime test did not happen to cover.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const WRAPPERS = new Set(["forgetChatThread", "forgetChatThreads"]);
+const TOMBSTONES = new Set(["markChatThreadDeleted", "markChatThreadsDeleted"]);
+
+const MODULE_PATH = fileURLToPath(
+  new URL("../src/features/chat/utils/chat-history-storage.ts", import.meta.url),
+);
+
+function parseModule(): ts.SourceFile {
+  return ts.createSourceFile(
+    MODULE_PATH,
+    readFileSync(MODULE_PATH, "utf8"),
+    ts.ScriptTarget.ES2022,
+    true,
+  );
+}
+
+/** Names of functions calling `markChatThread(s)Deleted`, by enclosing declaration. */
+function tombstoneCallers(sf: ts.SourceFile): string[] {
+  const callers: string[] = [];
+  const visit = (node: ts.Node, enclosing: string | null): void => {
+    let scope = enclosing;
+    if (
+      (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)) &&
+      node.name &&
+      ts.isIdentifier(node.name)
+    ) {
+      scope = node.name.text;
+    }
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      TOMBSTONES.has(node.expression.text)
+    ) {
+      const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+      callers.push(`${node.expression.text} at line ${line + 1} in ${scope ?? "<top level>"}`);
+    }
+    ts.forEachChild(node, (child) => visit(child, scope));
+  };
+  visit(sf, null);
+  return callers;
+}
+
+test("the tombstone helpers are only called from the wrappers that clear the map", () => {
+  const sf = parseModule();
+  const offenders = tombstoneCallers(sf).filter(
+    (entry) => ![...WRAPPERS].some((wrapper) => entry.endsWith(`in ${wrapper}`)),
+  );
+  assert.deepEqual(
+    offenders,
+    [],
+    "call forgetChatThread/forgetChatThreads instead, so server-owned markers are cleared too",
+  );
+});
+
+test("both wrappers exist and each clears the map", () => {
+  const text = readFileSync(MODULE_PATH, "utf8");
+  for (const wrapper of WRAPPERS) {
+    assert.match(
+      text,
+      new RegExp(`function ${wrapper}\\b`),
+      `${wrapper} must exist for the delete paths to use`,
+    );
+  }
+  const sf = parseModule();
+  const cleared: string[] = [];
+  const visit = (node: ts.Node, enclosing: string | null): void => {
+    let scope = enclosing;
+    if (ts.isFunctionDeclaration(node) && node.name) scope = node.name.text;
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "clearServerOwnedChatMessages" &&
+      scope !== null
+    ) {
+      cleared.push(scope);
+    }
+    ts.forEachChild(node, (child) => visit(child, scope));
+  };
+  visit(sf, null);
+  for (const wrapper of WRAPPERS) {
+    assert.ok(
+      cleared.includes(wrapper),
+      `${wrapper} must call clearServerOwnedChatMessages`,
+    );
+  }
+});
+
+test("at least one real delete path is wired to a wrapper", () => {
+  // Guards against the wrappers existing but nothing using them, which would leave
+  // clearServerOwnedChatMessages dead again.
+  const sf = parseModule();
+  const used: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      WRAPPERS.has(node.expression.text)
+    ) {
+      used.push(node.expression.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  assert.ok(used.length >= 2, `expected the delete paths to use the wrappers, saw ${used}`);
+});


### PR DESCRIPTION
## What prompted this

A Studio session on Colab produced 60 error-level events in four minutes, plus four requests slow enough to look like hangs. Aggregating the log gives the whole set:

| count | signature |
|---|---|
| 54 | `PUT /api/chat/threads/{t}/messages/{m}` returning 409 `ChatMessageProtectedError`, each with a full traceback |
| 6 | `research.supervisor_iteration_failed` -> `sqlite3.OperationalError: database is locked` |
| 1 | `PUT /api/settings/personalization`, **36944 ms** |
| 1 | `GET /api/inference/audio/gallery/{id}/file`, 21351 ms |
| 1 | `GET /api/settings/download-transport`, 3352 ms |

Two of these turn out to be one event seen from opposite sides.

## The 37 second write and the lock spam are the same bug

The six lock errors land at 02:29:35, :41, :48, :54, 02:30:00 and 02:30:06, and nowhere else in the session. The cadence is arithmetic, not noise: `sqlite3.connect(timeout=5.0)` in `studio_db.get_connection` plus the supervisor's `await asyncio.sleep(1)` is exactly six seconds. Six consecutive cycles means one writer held studio.db's lock continuously for the whole window, and the last error is in the same second `PUT /api/settings/personalization` completes.

`PRAGMA synchronous` was never set anywhere in the backend. Under WAL, sqlite still defaults to `FULL`, which fsyncs on every commit while holding the writer lock. With a multi-GB GGUF download saturating the same disk, one commit blocked for 37 seconds. Setting `synchronous=NORMAL` is the documented safe pairing for WAL: it can lose the last transactions on host power loss, never corrupts the database, which is the right trade for a local UI's settings and chat history.

Three related changes fall out of that:

- `claim_next` opened `BEGIN IMMEDIATE` before knowing whether any row was claimable, at `poll_seconds=0.5`. An idle Studio therefore took the writer lock twice a second for the life of the process. It now probes with a read first and only escalates when there is work. The probe is advisory; the existing `row is None` branch already handles the row vanishing.
- The supervisor logged this with `logger.exception`, so a transient, expected contention outcome produced a full multi-line traceback. It now logs one warning line and backs off, mirroring `_finish_after_lease_loss` a few lines above it. A non-transient `OperationalError` still falls through to the traceback.
- `chat_attachment_inventory_dirty_update` fired `AFTER UPDATE` on any column. A generation status change touches only `metadata_json` (from `chat_generation_runs_db` and `research_runs_db`, which have no attachments to invalidate), and that marked the inventory dirty, leaving the next chat autosave to `DELETE` and re-hash every attachment in every thread inside `BEGIN IMMEDIATE`. Scoped to `UPDATE OF attachments_json, content_json`, the two columns `_rebuild_chat_attachment_inventory` actually reads. Dropped and recreated rather than `IF NOT EXISTS`, since existing installs already carry the unscoped trigger.

## The 409 storm

`log_and_http_error` logged at error with `exc_info` regardless of status code, so a 409 the caller is expected to handle was indistinguishable from a server fault. 4xx now logs a single warning line; 5xx keeps error plus traceback, which is where a stack is actually the only way to find the bug.

That alone silences the log, but the requests were still real. `saveChatMessage` never inspected `response.status`, so a 409 surfaced as an anonymous `Error`, and the per-chunk autosave re-sent the same message on the next chunk for the length of the generation. A 409 here is permanent, since the server owns the message, so backing off cannot help and only stopping will do.

`saveChatMessage` now throws a typed `ChatMessageProtectedError`, and `saveStoredChatMessage` records the id and skips subsequent saves for it. Handling it in the shared wrapper covers all three per-chunk callers at once. Scoped per thread so a reissued id elsewhere is unaffected, with `clearServerOwnedChatMessages` to forget a thread. An ordinary transient failure still propagates to the caller that retries it.

The existing `preserveServerManaged` pre-check in `runtime-provider.tsx` already documents this failure mode ("265 PUTs, 256 rejected"), but it is a heuristic guess ahead of the request rather than a reaction to the server's answer, and it is bypassed for messages the server protects without marking `serverManaged`. This makes the server's actual 409 authoritative.

## Slow capability reads

`cached_xet_health` is documented as the path that must never load Unsloth Zoo, but it took `_load_lock`, the same lock `_load_optional` holds across `import unsloth_zoo` and the torch import behind it. So the one read guaranteed not to load Zoo blocked for as long as another thread spent loading it. That is the 509 ms on `GET /api/studio/download-transport-capabilities`. It now reads the memo without the lock: a dict lookup keyed by a plain string is atomic under the GIL, and the only writers publish a fully built module in a single assignment, so the worst outcome is correctly answering "not loaded yet".

## Deliberately not changed

`GET /api/settings/download-transport` (3352 ms) is the request that pays for `import unsloth_zoo` the first time, via the `ram_gate` path. I tried hoisting that load into the startup warm and reverted it: `test_startup_defers_torch.py` pins the invariant explicitly, "the optional Hub/Xet integration must be loaded by a real download, not startup", and loading Zoo at boot would import torch on every host including the CPU-only ones those RAM caps exist to protect. The handler is a sync `def`, so it runs in the threadpool and never blocks the event loop, and the cost is once per process. Worth revisiting separately if the first-poll latency matters, but not by breaking that invariant.

`GET /api/inference/audio/gallery/{id}/file` (21351 ms) needs no change. The handler already offloads its ownership check with `asyncio.to_thread` and returns a `FileResponse` rather than bytes, and the API routes are not gzipped. The latency is the saturated disk and threadpool from the section above.

The torchao warnings in the same log are benign: `_C_cutlass_90a` is Hopper and the GPU is Blackwell, and `_C_mxfp8.cpython-310` cannot load on Python 3.13. Both are optional extension probes that fall back cleanly.

## Tests

New `studio/backend/tests/test_studio_db_write_lock_contention.py`, 5 tests: WAL plus `synchronous=NORMAL`; `claim_next` returning `None` without error while another connection holds the writer lock, which is the original failure reproduced exactly; a metadata-only update not dirtying the attachment inventory while an attachment change still does; 4xx logging without `exc_info` while 5xx keeps it; and `claim_next` still claiming real work, so the read-first probe is an optimisation and not a suppression.

New `studio/frontend/tests/chat-save-server-managed-stop.test.ts`, 6 tests: five chunks producing exactly one PUT; the rejection resolving rather than throwing so the recovery loop keeps following the stream; only the rejected id blocked; the same id in another thread unaffected; clearing letting a reissued id save again; and an ordinary failure still propagating and not being mistaken for server ownership.

Also green: 560 tests across the research, chat history, utils and logging suites; 505 across the changed areas (chat attachments, generation runs, personalization, download transport, xet fallback, warm); the full 5976-test frontend suite; `tsc -b` clean; `biome check` identical to baseline on the touched source files.

A full-suite branch-versus-baseline comparison is still running and I will follow up with the diff. The failures already present on this box are environmental, including four modules that will not import against this venv's `huggingface-hub` 1.29.0, and reproduce identically at the merge base.
