### PR TITLE
Share the fixture backend version with the model-download E2E

### DIFF
--- a/tests/studio/appimage_model_download_webdriver.py
+++ b/tests/studio/appimage_model_download_webdriver.py
@@ -23,7 +23,11 @@ from pathlib import Path
 from typing import Any
 
 
-from appimage_test_support import assert_no_loader_errors
+from appimage_test_support import (
+    FIXTURE_BACKEND_VERSION,
+    assert_fixture_version_clears_floor,
+    assert_no_loader_errors,
+)
 
 
 REPO_ID = "unsloth/FLUX.2-klein-4B-GGUF"
@@ -91,14 +95,6 @@ def _wait_for(
             last = str(error)
         time.sleep(0.25)
     raise AssertionError(f"Timed out waiting for {description}; last result: {last!r}")
-
-
-def _minimum_backend_version() -> str:
-    source = (REPO_ROOT / "studio/src-tauri/src/preflight/version.rs").read_text(encoding = "utf-8")
-    match = re.search(r'MIN_DESKTOP_BACKEND_VERSION: &str = "([^"]+)"', source)
-    if not match:
-        raise RuntimeError("Could not read MIN_DESKTOP_BACKEND_VERSION")
-    return match.group(1)
 
 
 def _write_backend_fixture(home: Path, request_log: Path) -> None:
@@ -176,7 +172,7 @@ def _write_backend_fixture(home: Path, request_log: Path) -> None:
                         return self.send_json({{
                             "status": "alive",
                             "service": "Unsloth UI Backend",
-                            "version": {_minimum_backend_version()!r},
+                            "version": {FIXTURE_BACKEND_VERSION!r},
                             "desktop_protocol_version": 1,
                             "desktop_manageability_version": 2,
                             "supports_desktop_auth": True,
@@ -335,7 +331,7 @@ def _write_backend_fixture(home: Path, request_log: Path) -> None:
                   "supports_provision_desktop_auth": True,
                   "supports_desktop_backend_ownership": True,
                   "studio_install_ok": True,
-                  "version": _minimum_backend_version(),
+                  "version": FIXTURE_BACKEND_VERSION,
               }, separators = (",", ":"))}'
               exit 0
             fi
@@ -446,6 +442,7 @@ def _install_colrv1_probe_font(config_dir: Path, data_dir: Path) -> dict[str, st
 
 
 def main() -> None:
+    assert_fixture_version_clears_floor(REPO_ROOT)
     appimage_value = os.environ.get("APPIMAGE_PATH", "")
     if not appimage_value:
         raise SystemExit("APPIMAGE_PATH must name the AppImage under test")

--- a/tests/studio/appimage_model_download_webdriver.py
+++ b/tests/studio/appimage_model_download_webdriver.py
@@ -9,7 +9,6 @@ import base64
 import hashlib
 import json
 import os
-import re
 import shutil
 import signal
 import socket

--- a/tests/studio/appimage_portability_smoke.py
+++ b/tests/studio/appimage_portability_smoke.py
@@ -16,45 +16,14 @@ import textwrap
 import time
 from pathlib import Path
 
-from appimage_test_support import assert_no_loader_errors
+from appimage_test_support import (
+    FIXTURE_BACKEND_VERSION,
+    assert_fixture_version_clears_floor,
+    assert_no_loader_errors,
+)
 
 ROOT_ID = "a" * 64
 DESKTOP_SECRET = "appimage-portability-secret"
-
-
-# What the fixture reports as the managed backend's version.
-#
-# It used to report MIN_DESKTOP_BACKEND_VERSION, read out of version.rs, and that
-# is only the right answer for a build this repo made. The floor is not the only
-# gate: managed_backend_version_stale_reason() compares against
-# expected_backend_version(), which is
-#
-#     option_env!("UNSLOTH_DESKTOP_BACKEND_VERSION").unwrap_or(MIN_DESKTOP_BACKEND_VERSION)
-#
-# and the release workflow STAMPS that from the same pypi_version as the updater
-# manifest. So a PR build, which leaves it unset, accepted the floor and passed,
-# while every published AppImage rejected it: v0.1.804-beta is pinned to backend
-# 2026.8.22, judged the fixture's 2026.8.4 `desktop_backend_version_outdated`,
-# and went off to run its bundled installer instead of authenticating. That is
-# the app behaving correctly, and it is why the nightly failed on all five
-# distros while the pull_request lane on the same commit passed.
-#
-# The fixture cannot know the stamped value, so it reports one no build can
-# consider outdated. Both comparisons are one-sided -- compatible is `>= floor`
-# and outdated is `< expected` -- so nothing above rejects a version for being
-# too new. If that ever changes it is a real contract change and this should
-# fail loudly rather than quietly report the floor again.
-FIXTURE_BACKEND_VERSION = "9999.12.31"
-
-
-def _minimum_backend_version(repo_root: Path) -> str:
-    source = (repo_root / "studio/src-tauri/src/preflight/version.rs").read_text(encoding = "utf-8")
-    marker = 'MIN_DESKTOP_BACKEND_VERSION: &str = "'
-    start = source.find(marker)
-    if start < 0:
-        raise RuntimeError("Could not read the minimum desktop backend version")
-    start += len(marker)
-    return source[start : source.index('"', start)]
 
 
 # The dispositions that mean the app gave up on the fixture and went to repair.
@@ -260,14 +229,7 @@ def main() -> None:
     install_id = home / ".unsloth/studio/share/studio_install_id"
     install_id.parent.mkdir(parents = True)
     install_id.write_text(ROOT_ID, encoding = "utf-8")
-    # Guard that the sentinel really is above the floor it has to clear, so a floor
-    # that ever reaches 9999 fails here by name instead of as an unexplained timeout.
-    # Compared on the leading component: a string compare would read "999" as above
-    # "9999", which is the one answer this must not get wrong.
-    floor = _minimum_backend_version(repo_root)
-    assert int(floor.split(".")[0]) < int(
-        FIXTURE_BACKEND_VERSION.split(".")[0]
-    ), f"fixture version {FIXTURE_BACKEND_VERSION} no longer clears the floor {floor}"
+    assert_fixture_version_clears_floor(repo_root)
     request_log = _write_fixture(art_dir, home, FIXTURE_BACKEND_VERSION)
 
     env = {

--- a/tests/studio/appimage_test_support.py
+++ b/tests/studio/appimage_test_support.py
@@ -43,9 +43,7 @@ def assert_fixture_version_clears_floor(repo_root: Path) -> None:
     Compared on the leading component: a string compare would read "999" as above
     "9999", which is the one answer this must not get wrong.
     """
-    source = (repo_root / "studio/src-tauri/src/preflight/version.rs").read_text(
-        encoding = "utf-8"
-    )
+    source = (repo_root / "studio/src-tauri/src/preflight/version.rs").read_text(encoding = "utf-8")
     marker = 'MIN_DESKTOP_BACKEND_VERSION: &str = "'
     start = source.find(marker)
     if start < 0:

--- a/tests/studio/appimage_test_support.py
+++ b/tests/studio/appimage_test_support.py
@@ -13,6 +13,50 @@ LOADER_ERROR_MARKERS = (
     "undefined symbol:",
 )
 
+# What a fixture reports as the managed backend's version.
+#
+# Not MIN_DESKTOP_BACKEND_VERSION, which is only the right answer for a build made
+# here. The floor is not the only gate: managed_backend_version_stale_reason()
+# compares against expected_backend_version(), which is
+#
+#     option_env!("UNSLOTH_DESKTOP_BACKEND_VERSION").unwrap_or(MIN_DESKTOP_BACKEND_VERSION)
+#
+# and the release workflow stamps that from the same pypi_version as the updater
+# manifest. A build from this repo leaves it unset and accepts the floor; a
+# published one does not. v0.1.804-beta is pinned to backend 2026.8.22 and read
+# the floor as `desktop_backend_version_outdated`, so it ran its bundled installer
+# instead of doing what the test was watching for. Every AppImage lane of the
+# nightly failed on that while the pull_request lane, testing an unstamped build
+# of the same commit, passed.
+#
+# A fixture cannot know what a given release stamped, so it reports a version no
+# build can call outdated. Both comparisons are one-sided, compatible is
+# `>= floor` and outdated is `< expected`, so nothing rejects a version for being
+# too new. It lives here rather than in either test because #10001 fixed only the
+# portability smoke and the model-download E2E kept failing for exactly this.
+FIXTURE_BACKEND_VERSION = "9999.12.31"
+
+
+def assert_fixture_version_clears_floor(repo_root: Path) -> None:
+    """Fail by name if the floor ever catches up with the sentinel.
+
+    Compared on the leading component: a string compare would read "999" as above
+    "9999", which is the one answer this must not get wrong.
+    """
+    source = (repo_root / "studio/src-tauri/src/preflight/version.rs").read_text(
+        encoding = "utf-8"
+    )
+    marker = 'MIN_DESKTOP_BACKEND_VERSION: &str = "'
+    start = source.find(marker)
+    if start < 0:
+        raise RuntimeError("Could not read the minimum desktop backend version")
+    start += len(marker)
+    floor = source[start : source.index('"', start)]
+    if int(floor.split(".")[0]) >= int(FIXTURE_BACKEND_VERSION.split(".")[0]):
+        raise RuntimeError(
+            f"fixture version {FIXTURE_BACKEND_VERSION} no longer clears the floor {floor}"
+        )
+
 
 def assert_no_loader_errors(*logs: Path) -> None:
     """Reject mixed host/bundle loader failures even when the UI path succeeds."""


### PR DESCRIPTION
#10001 fixed the portability smoke and left the sixth AppImage lane failing for exactly the reason it had just fixed.

Dispatching `Desktop app clean machine` against the published `v0.1.804-beta` is what showed it:

| lane | before #10001 | after #10001 |
| --- | --- | --- |
| `AppImage ubuntu-22.04` | failure | **success** |
| `AppImage ubuntu-22.04-no-gles` | failure | **success** |
| `AppImage ubuntu-24.04-wayland` | failure | **success** |
| `AppImage debian-12` | failure | **success** |
| `AppImage fedora-44` | failure | **success** |
| `AppImage model download E2E` | failure | failure |

Its artifact from that same post-fix run carries the verdict #10001 was written for:

```
install probe result Stale { ..., reason: "desktop_backend_version_outdated" }
desktop_preflight completed disposition=ManagedStale port=None
start_managed_repair command called
```

`appimage_model_download_webdriver.py` had its own copy of the helper that reads `MIN_DESKTOP_BACKEND_VERSION`, and reported it at two call sites. A released build pinned to backend `2026.8.22` reads that floor as outdated, reinstalls, and never sends the `POST /api/hub/download` the test waits for. It does recover to `Ready` about fifty seconds later off the back of a full reinstall, which is well past the point the assertion has already failed.

### The change

The constant and the floor guard move to `appimage_test_support.py`, which both files already import. Two copies of one fixture detail is precisely what let one be fixed and the other not, and a third packaged-app test would have copied whichever it happened to be looking at.

The guard raises rather than asserts, so it survives `-O`, and it compares the leading component: a string compare would read `999` as above `9999`, which is the one answer it must not get wrong.

### Verification

- Portability smoke re-run against the real downloaded `v0.1.804-beta`: unchanged, still `install probe result Ready`.
- Guard passes against the real floor (`2026.8.4`); setting the floor to `9999.1.1` fails it by name with `fixture version 9999.12.31 no longer clears the floor 9999.1.1`.
- No `_minimum_backend_version` copies remain in `tests/studio/`.

The E2E lane only runs off `schedule` / `workflow_dispatch` against a stamped release, so I will dispatch this branch against `v0.1.804-beta` to confirm rather than infer.
