### PR TITLE
Budget the dyld classifier in CPU time, not wall clock

### DIFF
--- a/studio/backend/tests/test_llama_cpp_start_failure_classification.py
+++ b/studio/backend/tests/test_llama_cpp_start_failure_classification.py
@@ -1205,7 +1205,19 @@ class TestTheDyldReasonIsBounded:
             "dyld[1]: Library not loaded: @rpath/libllama.dylib\n"
             "  Reason: tried: " + "'a' (" * 20000
         )
-        start = time.perf_counter()
+        # CPU time, not wall clock. What the caps buy is that the candidate scan
+        # stops being quadratic, and that is a cost in cycles: a runner that
+        # descheduls this thread inflates the wall reading without a single extra
+        # cycle being spent. Measured here pinned to one core, the classifier holds
+        # ~0.0097s of CPU whether it runs alone or against four spinners, while the
+        # wall reading goes to 0.0516s, 5.3x, on identical work. CI hit that at
+        # 1.006s against this 1.0s budget and failed by six milliseconds, on a
+        # classifier costing ten.
+        #
+        # The budget stays 1.0s because it is still the right number: healthy is
+        # ~0.01s and the regression it guards is 6.3s, so there are two orders of
+        # magnitude of room on either side. It is only the clock that was wrong.
+        start = time.process_time()
         msg = _classify(
             out,
             "/models/x.gguf",
@@ -1213,7 +1225,7 @@ class TestTheDyldReasonIsBounded:
             1,
             "/Users/me/.unsloth/llama.cpp/build/bin/llama-server",
         )
-        assert time.perf_counter() - start < 1.0
+        assert time.process_time() - start < 1.0
         assert "libllama.dylib" in msg
 
     def test_a_real_reason_is_not_truncated(self):


### PR DESCRIPTION
`Backend CI` → `(Python 3.13)` failed on main `a6887c5ee`:

```
test_a_pathological_reason_does_not_stall_the_classifier
AssertionError: assert (728.070290015 - 727.064322356) < 1.0
```

1.006s against a 1.0s budget. Missed by six milliseconds, on a classifier that costs about ten.

### Nothing regressed

The caps #8574 added are working. Measured locally, the classifier holds **0.0097s median** over seven runs, 0.0168s worst — a hundredfold margin under the budget. The clock was the wrong one.

What the caps buy is that the candidate scan stops being quadratic, and that is a cost in **cycles**. Wall clock also counts every microsecond the thread is not running, and a hosted runner running the whole backend suite deschedules freely. Pinned to one core, against four spinners on that same core:

| run | wall | cpu |
| --- | --- | --- |
| no contention | 0.0097s | 0.0097s |
| contended | 0.0429s | 0.0118s |
| contended | 0.0249s | 0.0098s |
| contended | 0.0516s | 0.0096s |

Identical work. The wall reading moves 5.3x; the CPU reading does not move at all. CI charged the classifier for time it spent waiting for a core.

### The change

The assertion measures `time.process_time()`. The budget stays `1.0` because it was never the problem: healthy is ~0.01s and the regression it guards is 6.3s, two orders of magnitude of room on either side.

### It keeps its teeth

Lifting `_DYLD_REASON_MAX_CHARS` and `_DYLD_REASON_SCAN_CHARS` to 100M restores the quadratic scan, and the assertion catches it on CPU time at **6.33s** — the 6.3s the docstring records:

```
>       assert time.process_time() - start < 1.0
E       AssertionError: assert (18.279022593 - 11.94483655) < 1.0
```

Under the four spinners above the whole file passes, taking 25.4s wall for what is normally 6s.

### What this does not show

That the old assertion would have failed under that same contention. It would not have: 0.0516s is well inside 1.0s. CI's 1.006s on a 0.01s classifier is roughly a hundredfold inflation, heavier than four spinners on one core reproduce here. The mechanism is what is demonstrated, and it is the only thing that explains a six-millisecond miss on a budget with a hundredfold margin.

`studio/backend/tests/test_llama_cpp_start_failure_classification.py`: 224 passed.
