### PR TITLE
Size the model picker's row metadata to the ink it holds

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -779,16 +779,21 @@ const META_COLUMN = {
   badge: "min-w-min min-[560px]:w-[24px]",
   // One glyph plus the disk mark (18 + 4 + 14).
   badgeMid: "min-w-min min-[560px]:w-[36px]",
-  // Unscoped chat: a generation glyph and audio, plus whichever of vision (On Device rows) or the
-  // disk mark (Hub rows) that list carries -- the two never appear on the same row (18+4+18+4+24).
-  badgeWide: "min-w-min min-[560px]:w-[68px]",
+  // On Device draws the vision badge and no disk mark: 26px is that badge measured, so rows with
+  // and without one still line up. One slot sized for both lists left ~44px empty on every row.
+  badgeDevice: "min-w-min min-[560px]:w-[26px]",
+  // Hub draws the disk mark and no vision badge (18+4+14). A second glyph grows it via min-w-min.
+  badgeWide: "min-w-min min-[560px]:w-[36px]",
   // The "OOM" pill, wider than bare "TIGHT" (Hub rows).
   vram: "min-w-min min-[560px]:w-[4em]",
-  // "235B" on device rows; Hub rows report "2779.5B", hence paramWide.
-  param: "min-w-min min-[560px]:w-[3.6em]",
+  // Device rows hug the chip. A column sized for "235B" spends 6.1px in front of a "30B", and that
+  // leftover IS the gap to the modality mark; -ml-0.5 against the cluster's gap-1 makes it 2px. In
+  // exchange a wider label pulls that row's name and quant chip left. Hub keeps its "2779.5B".
+  param: "min-w-min -ml-0.5",
   paramWide: "min-w-min min-[560px]:w-[5.2em]",
-  // "536 MB".
-  size: "min-w-min min-[560px]:w-[4.2em]",
+  // formatBytes writes no space ("536MB"), so the widest this holds is 29.5px, not the ~40px a
+  // spaced "536 MB" needs. The surplus sat between the parameter chip and the size.
+  size: "min-w-min min-[560px]:w-[3.2em]",
   // The format dot that leads the row; the name lives in its tooltip.
   format: "min-[560px]:w-[14px]",
 } as const;
@@ -888,15 +893,18 @@ function ModelRow({
   const capabilityScope = useContext(CapabilityScope);
   const capabilityBadges = visibleCapabilityBadges(caps, capabilityScope);
   const showCaps = capabilityBadges.length > 0;
+  const aligned = alignMeta !== undefined;
   // Reserve only what this picker's scope can draw. The Images and Audio pickers draw no glyph and
   // Video draws one, so holding the chat row's slot open there is dead space on every row.
+  // Unscoped chat splits again by list: On Device marks vision, Hub marks the disk.
   const badgeColumn =
     capabilityScope === null || capabilityScope.length > 1
-      ? META_COLUMN.badgeWide
+      ? alignMeta === "device"
+        ? META_COLUMN.badgeDevice
+        : META_COLUMN.badgeWide
       : capabilityScope.length === 1
         ? META_COLUMN.badgeMid
         : META_COLUMN.badge;
-  const aligned = alignMeta !== undefined;
   // One dot per row. A second format shares the first's colour anyway, so it
   // rides along in the tooltip instead of pushing the name out of line.
   const formatDot = parsed.formats[0]
@@ -925,13 +933,18 @@ function ModelRow({
       }}
       onClick={onClick}
       className={cn(
-        "flex w-full flex-col items-stretch px-2 py-1.5 text-left text-sm transition-colors hover:bg-[#ececec] focus-visible:bg-[#ececec] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:hover:bg-[var(--sidebar-accent)] dark:focus-visible:bg-[var(--sidebar-accent)]",
+        // pl-[5.5px]: the dot is centred in a 14px hover target, so 5.5 + (14 - 5) / 2 lands it
+        // on 10px, level with the section labels at px-2.5. Inside a w-full button, so the hover
+        // pill itself does not move.
+        "flex w-full flex-col items-stretch py-1.5 pl-[5.5px] pr-2 text-left text-sm transition-colors hover:bg-[#ececec] focus-visible:bg-[#ececec] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:hover:bg-[var(--sidebar-accent)] dark:focus-visible:bg-[var(--sidebar-accent)]",
         showMemoryBar ? "rounded-2xl" : "rounded-full",
         selected && "bg-[#ececec] dark:bg-[var(--sidebar-accent)]",
         className,
       )}
     >
-      <span className="flex w-full items-center gap-2">
+      {/* gap-1: the quant chip ends the name group, so what this separates is that chip from the
+          first meta mark. 4px is the rhythm the meta columns already keep among themselves. */}
+      <span className="flex w-full items-center gap-1">
         <span className="flex min-w-0 flex-1 items-baseline">
           {/* Fixed slot, so names start on one line with or without a dot. */}
           {aligned ? (
@@ -967,7 +980,8 @@ function ModelRow({
           {alignMeta === "device" ? (
             <span
               className={cn(
-                "ml-1.5 flex shrink-0 items-center self-center text-ui-9",
+                // ml-0.5: the chip carries px-1 of its own, so 2px still leaves 6px of air.
+                "ml-0.5 flex shrink-0 items-center self-center text-ui-9",
                 META_COLUMN.quant,
               )}
             >
@@ -997,7 +1011,8 @@ function ModelRow({
           {aligned ? (
             <span
               className={cn(
-                "flex shrink-0 items-center justify-center gap-1 text-ui-10",
+                // Right, not centre: slack belongs to the name, not split either side of a glyph.
+                "flex shrink-0 items-center justify-end gap-1 text-ui-10",
                 badgeColumn,
               )}
             >

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -43,6 +43,55 @@ test("the scoped badge column reserves the wider on-device marker", () => {
   assert.ok(PICKERS.includes('badgeMid: "min-w-min min-[560px]:w-[36px]"'));
 });
 
+test("the unscoped badge column is sized per list, not to the union of both", () => {
+  // One slot sized for both lists left ~44px of empty column on every On Device row. 26px is the
+  // vision badge measured, so rows with and without one keep the same column positions.
+  assert.ok(PICKERS.includes('badgeDevice: "min-w-min min-[560px]:w-[26px]"'));
+  assert.ok(PICKERS.includes('badgeWide: "min-w-min min-[560px]:w-[36px]"'));
+  assert.match(
+    PICKERS,
+    /alignMeta === "device"\n\s*\? META_COLUMN\.badgeDevice\n\s*: META_COLUMN\.badgeWide/,
+  );
+});
+
+test("a row's leading dot starts where its section label does", () => {
+  // Section labels sit at px-2.5. The dot is centred in a 14px hover target, so its slot starts
+  // at 10 - (14 - 5) / 2 = 5.5px for the dot to land on 10px. px-2 put it at 12.5px.
+  assert.match(PICKERS, /py-1\.5 pl-\[5\.5px\] pr-2 text-left text-sm/);
+  const label = PICKERS.slice(PICKERS.indexOf("flex items-center justify-between gap-1 px-2.5"));
+  assert.ok(label.startsWith("flex items-center justify-between gap-1 px-2.5"));
+  // The 14px hover target is what makes 5.5 the right number; shrinking it would move the dot.
+  assert.ok(PICKERS.includes('className="flex size-[14px] shrink-0 items-center justify-center"'));
+});
+
+test("the parameter and size columns are sized to the ink they hold", () => {
+  // The widest size formatBytes writes ("128GB", no space) is 29.5px, not the ~40px a spaced
+  // "536 MB" would need.
+  assert.ok(PICKERS.includes('size: "min-w-min min-[560px]:w-[3.2em]"'));
+  // The no-space format is what makes 3.2em enough; a spaced size would need ~4.2em again.
+  assert.match(
+    PICKERS,
+    /No space: "145MB" reads as one value beside the quant chip\./,
+  );
+});
+
+test("the parameter chip hugs its label so the gap to the modality mark is the row's own", () => {
+  // A fixed right-aligned column spends its leftover in front of the chip, and that leftover is
+  // the gap to the modality mark, which no gap setting can undo. Hugging plus -ml-0.5 gives 2px.
+  assert.ok(PICKERS.includes('param: "min-w-min -ml-0.5"'));
+  // Hub keeps a column: its labels run to "2779.5B".
+  assert.ok(PICKERS.includes('paramWide: "min-w-min min-[560px]:w-[5.2em]"'));
+});
+
+test("aligned meta slots spend their slack on the name", () => {
+  // Centring a lone glyph splits the slack either side of it, reading as a gap on both sides.
+  assert.ok(
+    PICKERS.includes(
+      '"flex shrink-0 items-center justify-end gap-1 text-ui-10"',
+    ),
+  );
+});
+
 test("every select-model surface shares that one badge", () => {
   // Images, Video and Audio render the same ModelSelector, so there is no
   // second copy of the badge to keep in step.


### PR DESCRIPTION
On Device model names truncate much earlier than they need to. The metadata columns to their right reserve worst case widths that most rows never fill, and the name column is what pays for it.

Measured in the running picker at the default panel width (`--picker-panel-w`, 485px), on a row reading `NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF`:

| | before |
|---|---|
| name column | 145.3px, shown as `NVIDIA-Nemotron-3-...` |
| quant chip to modality mark | 31.3px |
| modality mark to `30B` | 26.8px |
| `30B` to `18GB` | 19.5px |

Those gaps are not padding anyone chose. They are leftover inside fixed columns, and every pixel of it comes out of the name.

### Where the width went

**The badge slot reserved 68px for two lists that never overlap.** On Device rows draw the vision badge and no disk mark; Hub rows draw the disk mark and no vision badge. One slot sized for both left about 44px empty on every On Device row. It was also `justify-center`, so a lone glyph split its slack either side of itself, which is where both the 31.3px and part of the 26.8px above came from.

**The size column was sized as if `formatBytes` wrote a space.** It does not. The comment right above it says so: `// No space: "145MB" reads as one value beside the quant chip.` So the widest string it ever holds is `128GB` at 29.5px, not the 39.4px a spaced `536 MB` would need. The surplus showed up after short sizes, 17.6px after `19GB`.

**The parameter column was right aligned and wider than its label.** A column sized for `235B` is 6.1px wider than `30B`, and right aligned it spends that leftover in front of the chip, which is exactly the gap to the modality mark. No gap setting can reach under it while the column stays fixed.

**The row's `gap-2` was separating the wrong thing.** It was picked to hold the name off the metadata, but the quant chip ends the name group, so what it actually separated was that chip from the first meta mark.

### Changes

- `badgeWide` (68px) splits into `badgeDevice` (26px, the vision badge measured) and `badgeWide` (36px, glyph plus gap plus disk mark), chosen by `alignMeta`.
- Aligned badge slot goes `justify-center` to `justify-end`.
- `size` goes `4.2em` to `3.2em`.
- `param` drops its fixed width and hugs the chip, with `-ml-0.5` against the cluster's `gap-1` to keep a 2px gap.
- Row `gap-2` to `gap-1`, and the quant slot's `ml-1.5` to `ml-0.5`.

### Separately: the leading dot was 2.5px out

Section labels (`UNSLOTH`, `FINE-TUNED`, `CUSTOM FOLDERS`) sit at `px-2.5`, so their ink starts at 10px. The row's dot is centred in a 14px hover target, so a symmetric `px-2` landed it at 8 + (14 - 5) / 2 = 12.5px. The row now uses `pl-[5.5px] pr-2` so the dot itself lands on 10px. The padding is inside a `w-full` button, so the hover pill does not move, only the ink within it.

### Result

Same row, same machine, same panel width:

| | before | after |
|---|---|---|
| name column | 145.3px | 210.6px |
| name shown | `NVIDIA-Nemotron-3-...` | `NVIDIA-Nemotron-3-Nano-Om...` |
| badge slot | 68px | 26px |
| name to quant chip | 6.0px | 2.0px |
| quant chip to modality mark | 31.3px | 6.7px |
| modality mark to `30B` | 26.8px | 2.0px |
| `30B` to `18GB` | 19.5px | 10.1px |
| dot / section label left edge | 328.5 / 326.0 | 326.0 / 326.0 |

45% more name for no new width and no change to what a row displays.

### What this trades away

Two of these columns now grow through `min-w-min` on rows the common case does not cover, which shifts that one row's earlier columns left. Both are deliberate, and both are cheaper than charging every row for the worst case:

- A row drawing a capability glyph alongside the vision badge takes the badge slot from 26px to 47.3px and gives up 21.3px of name. On name detected rows this needs an audio or generation family word in the repo id, so in practice it is rare.
- A row labelled `235B` is 6.1px wider than `30B` and pulls its name and quant chip left by that much.

Hub rows keep their parameter column, since their labels run to `2779.5B`.

### Verification

Numbers above are read off the live DOM in the running picker, before and after, rather than estimated. Typecheck clean and the frontend suite passes at 5981 tests, including four new cases in `on-device-dot-and-header-alignment.test.ts` that pin the per list badge widths, the dot arithmetic, the size column reasoning and the hugging parameter chip.
