### PR TITLE
Dim an over budget model row instead of pilling every line

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -635,16 +635,16 @@ function DownloadedBadge() {
 function VramBadge({ status }: { status?: VramFitStatus | null }) {
   if (status === "exceeds") {
     return (
-      // Held in the layout but painted only on the hovered row: on a list where most rows are over
-      // budget, one pill per row is a wall of red. The dimmed row carries the verdict until then.
-      <span className="whitespace-nowrap text-ui-9 font-medium !text-red-700 !bg-red-50 dark:!text-red-300 dark:!bg-red-500/15 px-1.5 py-0.5 rounded opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100">
+      // Orange, not red: over budget is a fit verdict, not a failure. Held in the layout but
+      // painted only on the hovered row, so a mostly over budget list is not a wall of colour.
+      <span className="whitespace-nowrap text-ui-9 font-medium !text-orange-700 !bg-orange-50 dark:!text-orange-300 dark:!bg-orange-500/15 px-1.5 py-0.5 rounded opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100">
         OOM
       </span>
     );
   }
   if (status === "tight") {
     return (
-      <span className="whitespace-nowrap text-ui-9 font-medium !text-amber-400">
+      <span className="whitespace-nowrap text-ui-9 font-medium !text-yellow-400">
         TIGHT
       </span>
     );

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -635,7 +635,9 @@ function DownloadedBadge() {
 function VramBadge({ status }: { status?: VramFitStatus | null }) {
   if (status === "exceeds") {
     return (
-      <span className="whitespace-nowrap text-ui-9 font-medium !text-red-700 !bg-red-50 dark:!text-red-300 dark:!bg-red-500/15 px-1.5 py-0.5 rounded">
+      // Held in the layout but painted only on the hovered row: on a list where most rows are over
+      // budget, one pill per row is a wall of red. The dimmed row carries the verdict until then.
+      <span className="whitespace-nowrap text-ui-9 font-medium !text-red-700 !bg-red-50 dark:!text-red-300 dark:!bg-red-500/15 px-1.5 py-0.5 rounded opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100">
         OOM
       </span>
     );
@@ -936,7 +938,7 @@ function ModelRow({
         // pl-[5.5px]: the dot is centred in a 14px hover target, so 5.5 + (14 - 5) / 2 lands it
         // on 10px, level with the section labels at px-2.5. Inside a w-full button, so the hover
         // pill itself does not move.
-        "flex w-full flex-col items-stretch py-1.5 pl-[5.5px] pr-2 text-left text-sm transition-colors hover:bg-[#ececec] focus-visible:bg-[#ececec] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:hover:bg-[var(--sidebar-accent)] dark:focus-visible:bg-[var(--sidebar-accent)]",
+        "group/row flex w-full flex-col items-stretch py-1.5 pl-[5.5px] pr-2 text-left text-sm transition-colors hover:bg-[#ececec] focus-visible:bg-[#ececec] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:hover:bg-[var(--sidebar-accent)] dark:focus-visible:bg-[var(--sidebar-accent)]",
         showMemoryBar ? "rounded-2xl" : "rounded-full",
         selected && "bg-[#ececec] dark:bg-[var(--sidebar-accent)]",
         className,
@@ -944,7 +946,16 @@ function ModelRow({
     >
       {/* gap-1: the quant chip ends the name group, so what this separates is that chip from the
           first meta mark. 4px is the rhythm the meta columns already keep among themselves. */}
-      <span className="flex w-full items-center gap-1">
+      <span
+        className={cn(
+          "flex w-full items-center gap-1",
+          // Over budget reads as a dimmed row, which scans; hover restores it and shows the pill.
+          // The selected row keeps full weight, since it is the one being considered.
+          exceeds &&
+            !selected &&
+            "opacity-60 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100",
+        )}
+      >
         <span className="flex min-w-0 flex-1 items-baseline">
           {/* Fixed slot, so names start on one line with or without a dot. */}
           {aligned ? (

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -632,18 +632,31 @@ function DownloadedBadge() {
 }
 
 /** VRAM verdict for Hub rows: over budget, or a tight fit. */
-function VramBadge({ status }: { status?: VramFitStatus | null }) {
+function VramBadge({
+  status,
+  /** Model rows hold the pill in the layout and paint it on hover; variant rows always show it. */
+  revealOnHover = false,
+}: {
+  status?: VramFitStatus | null;
+  revealOnHover?: boolean;
+}) {
   if (status === "exceeds") {
     return (
-      // Orange, not red: over budget is a fit verdict, not a failure. Held in the layout but
-      // painted only on the hovered row, so a mostly over budget list is not a wall of colour.
-      <span className="whitespace-nowrap text-ui-9 font-medium !text-orange-700 !bg-orange-50 dark:!text-orange-300 dark:!bg-orange-500/15 px-1.5 py-0.5 rounded opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100">
+      // Orange, not red: over budget is a fit verdict, not a failure.
+      <span
+        className={cn(
+          "whitespace-nowrap text-ui-9 font-medium !text-orange-700 !bg-orange-50 dark:!text-orange-300 dark:!bg-orange-500/15 px-1.5 py-0.5 rounded",
+          revealOnHover &&
+            "opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100",
+        )}
+      >
         OOM
       </span>
     );
   }
   if (status === "tight") {
     return (
+      // Yellow, a step below the pill, so the two verdicts do not share a hue.
       <span className="whitespace-nowrap text-ui-9 font-medium !text-yellow-400">
         TIGHT
       </span>
@@ -1053,10 +1066,10 @@ function ModelRow({
                 META_COLUMN.vram,
               )}
             >
-              <VramBadge status={vramStatus} />
+              <VramBadge status={vramStatus} revealOnHover={true} />
             </span>
           ) : (
-            <VramBadge status={vramStatus} />
+            <VramBadge status={vramStatus} revealOnHover={true} />
           )}
           {aligned ? (
             <span
@@ -1925,16 +1938,7 @@ function GgufVariantExpander({
               ) : null}
             </span>
             <span className="flex items-center gap-1.5 shrink-0">
-              {oom && (
-                <span className="text-ui-9 font-medium !text-red-700 !bg-red-50 dark:!text-red-300 dark:!bg-red-500/15 px-1.5 py-0.5 rounded">
-                  OOM
-                </span>
-              )}
-              {tight && (
-                <span className="text-ui-9 font-medium !text-amber-400">
-                  TIGHT
-                </span>
-              )}
+              <VramBadge status={oom ? "exceeds" : tight ? "tight" : null} />
               <span className="font-mono text-ui-10 text-muted-foreground tabular-nums">
                 {companionBytes === null ? (
                   <SizeText value={formatBytes(v.size_bytes)} />

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -651,7 +651,7 @@ const VRAM_VERDICT = {
     exceeds: {
       label: "Does not fit",
       tone: ORANGE,
-      hint: "Model doesn't fit but still works with offloading. Expect slower inference.",
+      hint: "Model may not fit but still works with offloading. Expect slower inference.",
     },
     tight: {
       label: "Tight fit",

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -89,6 +89,7 @@ import {
   FlimSlateIcon,
   Folder02Icon,
   HelpCircleIcon,
+  InformationCircleIcon,
   Image03Icon,
   PinIcon,
   RemoveCircleIcon,
@@ -631,38 +632,57 @@ function DownloadedBadge() {
   );
 }
 
-/** VRAM verdict for Hub rows: over budget, or a tight fit. */
+/** What each fit verdict marks and says. Tight spills past VRAM into system RAM; oom clears
+ *  neither budget, so it pages further still. Orange over yellow: a step, not an error. */
+const VRAM_VERDICT = {
+  exceeds: {
+    label: "Does not fit",
+    tone: "!text-orange-600 dark:!text-orange-300",
+    hint: "Model doesn't fit. Expect much slower inference.",
+  },
+  tight: {
+    label: "Tight fit",
+    tone: "!text-yellow-600 dark:!text-yellow-400",
+    hint: "Model only fits by spilling into system RAM. Expect slower inference.",
+  },
+} as const;
+
+/** VRAM verdict: an info mark that names itself on hover, rather than a shouted pill. */
 function VramBadge({
   status,
-  /** Model rows hold the pill in the layout and paint it on hover; variant rows always show it. */
+  /** Model rows hold the mark in the layout and paint it on hover; variant rows always show it. */
   revealOnHover = false,
 }: {
   status?: VramFitStatus | null;
   revealOnHover?: boolean;
 }) {
-  if (status === "exceeds") {
-    return (
-      // Orange, not red: over budget is a fit verdict, not a failure.
-      <span
-        className={cn(
-          "whitespace-nowrap text-ui-9 font-medium !text-orange-700 !bg-orange-50 dark:!text-orange-300 dark:!bg-orange-500/15 px-1.5 py-0.5 rounded",
-          revealOnHover &&
-            "opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100",
-        )}
-      >
-        OOM
-      </span>
-    );
-  }
-  if (status === "tight") {
-    return (
-      // Yellow, a step below the pill, so the two verdicts do not share a hue.
-      <span className="whitespace-nowrap text-ui-9 font-medium !text-yellow-400">
-        TIGHT
-      </span>
-    );
-  }
-  return null;
+  const verdict =
+    status === "exceeds" || status === "tight" ? VRAM_VERDICT[status] : null;
+  if (!verdict) return null;
+  return (
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild={true}>
+        <span
+          aria-label={verdict.label}
+          className={cn(
+            "flex size-[18px] shrink-0 items-center justify-center",
+            verdict.tone,
+            revealOnHover &&
+              "opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100",
+          )}
+        >
+          <HugeiconsIcon
+            icon={InformationCircleIcon}
+            className="size-3.5"
+            strokeWidth={1.8}
+          />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="tooltip-compact">
+        {verdict.hint}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 const SIZE_PARTS_RE = /^(~?)([\d.]+)\s*([A-Za-z]+)$/;
@@ -799,8 +819,8 @@ const META_COLUMN = {
   badgeDevice: "min-w-min min-[560px]:w-[26px]",
   // Hub draws the disk mark and no vision badge (18+4+14). A second glyph grows it via min-w-min.
   badgeWide: "min-w-min min-[560px]:w-[36px]",
-  // The "OOM" pill, wider than bare "TIGHT" (Hub rows).
-  vram: "min-w-min min-[560px]:w-[4em]",
+  // The fit mark (Hub rows), one 18px glyph.
+  vram: "min-w-min min-[560px]:w-[18px]",
   // Device rows hug the chip. A column sized for "235B" spends 6.1px in front of a "30B", and that
   // leftover IS the gap to the modality mark; -ml-0.5 against the cluster's gap-1 makes it 2px. In
   // exchange a wider label pulls that row's name and quant chip left. Hub keeps its "2779.5B".

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -633,12 +633,13 @@ function DownloadedBadge() {
 }
 
 /** What each fit verdict marks and says. Tight spills past VRAM into system RAM; oom clears
- *  neither budget, so it pages further still. Orange over yellow: a step, not an error. */
+ *  neither budget, so it offloads further still. Both still run, so neither reads as an error:
+ *  orange over red, and yellow one step below it. */
 const VRAM_VERDICT = {
   exceeds: {
     label: "Does not fit",
     tone: "!text-orange-600 dark:!text-orange-300",
-    hint: "Model doesn't fit. Expect much slower inference.",
+    hint: "Model doesn't fit but can still work with offloading. Expect slower inference.",
   },
   tight: {
     label: "Tight fit",

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -635,36 +635,78 @@ function DownloadedBadge() {
 /** What each fit verdict marks and says. Tight spills past VRAM into system RAM; oom clears
  *  neither budget, so it offloads further still. Both still run, so neither reads as an error:
  *  orange over red, and yellow one step below it. */
+const AMBER = "!text-yellow-600 dark:!text-yellow-400";
+const ORANGE = "!text-orange-600 dark:!text-orange-300";
+
+/** Two vocabularies reach this badge and they do not mean the same thing.
+ *
+ *  A VARIANT row's verdict comes from the GGUF classifier: `tight` is a spill out of VRAM into
+ *  system RAM, `exceeds` clears neither budget.
+ *
+ *  A MODEL row's comes from `checkVramFit`, where `tight` is 75-100% of VRAM, which still fits on
+ *  the card entirely. Telling that row it spills into system RAM was simply false, and it is the
+ *  common case on a normal GPU. */
 const VRAM_VERDICT = {
-  exceeds: {
-    label: "Does not fit",
-    tone: "!text-orange-600 dark:!text-orange-300",
-    hint: "Model doesn't fit but can still work with offloading. Expect slower inference.",
+  gguf: {
+    exceeds: {
+      label: "Does not fit",
+      tone: ORANGE,
+      hint: "Model doesn't fit but still works with offloading. Expect slower inference.",
+    },
+    tight: {
+      label: "Tight fit",
+      tone: AMBER,
+      hint: "Only fits by spilling into system RAM. Expect slower inference.",
+    },
   },
-  tight: {
-    label: "Tight fit",
-    tone: "!text-yellow-600 dark:!text-yellow-400",
-    hint: "Model only fits by spilling into system RAM. Expect slower inference.",
+  device: {
+    // A model row's `exceeds` is a GGUF repo whose smallest quant is over budget (llama-server
+    // offloads it) OR a curated pipeline that cannot offload at all. One string covers both only
+    // by promising nothing about which happens; the two are separated in the follow-up.
+    exceeds: {
+      label: "Does not fit",
+      tone: ORANGE,
+      hint: "Needs more memory than this device has.",
+    },
+    tight: {
+      label: "Tight fit",
+      tone: AMBER,
+      hint: "Uses nearly all your VRAM, with little headroom for anything else.",
+    },
   },
 } as const;
 
 /** VRAM verdict: an info mark that names itself on hover, rather than a shouted pill. */
 function VramBadge({
   status,
+  /** Which vocabulary `status` is spoken in. See VRAM_VERDICT: the same word means different
+   *  things on a model row and on a quant row. */
+  source,
   /** Model rows hold the mark in the layout and paint it on hover; variant rows always show it. */
   revealOnHover = false,
 }: {
   status?: VramFitStatus | null;
+  source: "gguf" | "device";
   revealOnHover?: boolean;
 }) {
   const verdict =
-    status === "exceeds" || status === "tight" ? VRAM_VERDICT[status] : null;
+    status === "exceeds" || status === "tight"
+      ? VRAM_VERDICT[source][status]
+      : null;
   if (!verdict) return null;
   return (
     <Tooltip delayDuration={0}>
       <TooltipTrigger asChild={true}>
+        {/* The mark sits inside the row/variant button, so a tap meant to read the explanation
+            would otherwise select the model or start its download. */}
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: the handler suppresses the enclosing
+            button, it does not add an interaction of its own */}
         <span
           aria-label={verdict.label}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
           className={cn(
             "flex size-[18px] shrink-0 items-center justify-center",
             verdict.tone,
@@ -1087,10 +1129,10 @@ function ModelRow({
                 META_COLUMN.vram,
               )}
             >
-              <VramBadge status={vramStatus} revealOnHover={true} />
+              <VramBadge status={vramStatus} source="device" revealOnHover={!selected} />
             </span>
           ) : (
-            <VramBadge status={vramStatus} revealOnHover={true} />
+            <VramBadge status={vramStatus} source="device" revealOnHover={!selected} />
           )}
           {aligned ? (
             <span
@@ -1959,7 +2001,10 @@ function GgufVariantExpander({
               ) : null}
             </span>
             <span className="flex items-center gap-1.5 shrink-0">
-              <VramBadge status={oom ? "exceeds" : tight ? "tight" : null} />
+              <VramBadge
+                status={oom ? "exceeds" : tight ? "tight" : null}
+                source="gguf"
+              />
               <span className="font-mono text-ui-10 text-muted-foreground tabular-nums">
                 {companionBytes === null ? (
                   <SizeText value={formatBytes(v.size_bytes)} />

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -84,8 +84,8 @@ test("the parameter chip hugs its label so the gap to the modality mark is the r
 });
 
 test("an over budget row dims instead of putting a pill on every line", () => {
-  // Recommended is mostly over budget on a normal GPU, so a pill per row was a wall of red. The
-  // row dims and the pill is painted only while that row is hovered or focused.
+  // Recommended is mostly over budget on a normal GPU, so a pill per row was a wall of colour.
+  // The row dims and the pill is painted only while that row is hovered or focused.
   assert.ok(PICKERS.includes("group/row flex w-full flex-col items-stretch"));
   assert.ok(
     PICKERS.includes(

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -83,6 +83,27 @@ test("the parameter chip hugs its label so the gap to the modality mark is the r
   assert.ok(PICKERS.includes('paramWide: "min-w-min min-[560px]:w-[5.2em]"'));
 });
 
+test("an over budget row dims instead of putting a pill on every line", () => {
+  // Recommended is mostly over budget on a normal GPU, so a pill per row was a wall of red. The
+  // row dims and the pill is painted only while that row is hovered or focused.
+  assert.ok(PICKERS.includes("group/row flex w-full flex-col items-stretch"));
+  assert.ok(
+    PICKERS.includes(
+      "rounded opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100",
+    ),
+  );
+  assert.ok(
+    PICKERS.includes(
+      '"opacity-60 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100"',
+    ),
+  );
+  // The pill is hidden, not removed, and its slot keeps a width, so revealing it cannot reflow.
+  assert.ok(PICKERS.includes('vram: "min-w-min min-[560px]:w-[4em]"'));
+  // TIGHT is rare enough to stay put; only the OOM pill hides.
+  const tight = PICKERS.slice(PICKERS.indexOf('if (status === "tight")'));
+  assert.ok(!tight.slice(0, 300).includes("opacity-0"));
+});
+
 test("aligned meta slots spend their slack on the name", () => {
   // Centring a lone glyph splits the slack either side of it, reading as a gap on both sides.
   assert.ok(

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -106,15 +106,15 @@ test("one fit badge, so a colour or reveal change cannot miss a list", () => {
   assert.equal(PICKERS.split("VRAM_VERDICT = {").length - 1, 1, "one verdict table");
   assert.ok(!PICKERS.includes("!text-red-700"), "no red fit badge left");
   assert.ok(!PICKERS.includes(">\n        OOM\n"), "no OOM text pill left");
-  // Variant rows render the shared badge and opt out of the hover reveal.
-  assert.ok(
-    PICKERS.includes(
-      '<VramBadge status={oom ? "exceeds" : tight ? "tight" : null} />',
-    ),
+  // Variant rows render the shared badge, in the GGUF vocabulary, and opt out of the hover reveal.
+  assert.match(
+    PICKERS,
+    /<VramBadge\n\s*status=\{oom \? "exceeds" : tight \? "tight" : null\}\n\s*source="gguf"\n\s*\/>/,
   );
   assert.equal(
-    PICKERS.split("<VramBadge status={vramStatus} revealOnHover={true} />")
-      .length - 1,
+    PICKERS.split(
+      '<VramBadge status={vramStatus} source="device" revealOnHover={!selected} />',
+    ).length - 1,
     2,
     "both model row slots reveal on hover",
   );
@@ -124,17 +124,37 @@ test("each fit verdict is an info mark that explains itself", () => {
   // A pill shouted a three letter acronym; the mark says what it means on hover. Tight spills
   // past VRAM into system RAM, oom clears neither budget, so the two hints differ.
   assert.ok(PICKERS.includes("icon={InformationCircleIcon}"));
-  // Neither verdict blocks a load, so both hints say what to expect rather than refusing.
+  // A GGUF over budget still loads: llama-server hands it to --fit.
   assert.ok(
     PICKERS.includes(
-      "hint: \"Model doesn't fit but can still work with offloading. Expect slower inference.\"",
+      "hint: \"Model doesn't fit but still works with offloading. Expect slower inference.\"",
+    ),
+  );
+  // A model row's `tight` comes from checkVramFit, which is 75-100% of VRAM: it fits on the card
+  // entirely, so telling that row it spills into system RAM was false. The two vocabularies now
+  // get their own copy, chosen at the call site.
+  assert.ok(
+    PICKERS.includes(
+      'hint: "Only fits by spilling into system RAM. Expect slower inference."',
     ),
   );
   assert.ok(
     PICKERS.includes(
-      'hint: "Model only fits by spilling into system RAM. Expect slower inference."',
+      'hint: "Uses nearly all your VRAM, with little headroom for anything else."',
     ),
   );
+  // And a model row's `exceeds` no longer promises a slow load: it can be a curated pipeline whose
+  // loader refuses CPU offload outright.
+  assert.ok(
+    PICKERS.includes('hint: "Needs more memory than this device has."'),
+  );
+  assert.ok(PICKERS.includes('source="gguf"'));
+  assert.ok(PICKERS.includes('source="device"'));
+  // A selected over-budget row is exempt from dimming, so hiding its mark left it with no verdict
+  // at all until hovered, which is nothing at rest and nothing on touch.
+  assert.match(PICKERS, /exceeds &&\n\s*!selected &&/);
+  // And the mark suppresses the button it sits inside, so reading it cannot start a download.
+  assert.match(PICKERS, /onClick=\{\(event\) => \{\n\s*event\.preventDefault\(\);/);
   // Both marks are reachable by screen readers without the tooltip.
   assert.ok(PICKERS.includes('label: "Does not fit"'));
   assert.ok(PICKERS.includes('label: "Tight fit"'));

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -89,7 +89,7 @@ test("an over budget row dims instead of putting a pill on every line", () => {
   assert.ok(PICKERS.includes("group/row flex w-full flex-col items-stretch"));
   assert.ok(
     PICKERS.includes(
-      "rounded opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100",
+      '"opacity-0 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100"',
     ),
   );
   assert.ok(
@@ -102,6 +102,26 @@ test("an over budget row dims instead of putting a pill on every line", () => {
   // TIGHT is rare enough to stay put; only the OOM pill hides.
   const tight = PICKERS.slice(PICKERS.indexOf('if (status === "tight")'));
   assert.ok(!tight.slice(0, 300).includes("opacity-0"));
+});
+
+test("one fit badge, so a colour or reveal change cannot miss a list", () => {
+  // The quantization rows had their own copy and stayed red when the pill went orange.
+  // Match on the text colour: "!bg-orange-50" is also a prefix of "!bg-orange-500/15".
+  assert.equal(PICKERS.split("!text-orange-700").length - 1, 1, "one OOM pill");
+  assert.equal(PICKERS.split("!text-yellow-400").length - 1, 1, "one TIGHT label");
+  assert.ok(!PICKERS.includes("!text-red-700"), "no red fit badge left");
+  // Variant rows render the shared badge and opt out of the hover reveal.
+  assert.ok(
+    PICKERS.includes(
+      '<VramBadge status={oom ? "exceeds" : tight ? "tight" : null} />',
+    ),
+  );
+  assert.equal(
+    PICKERS.split("<VramBadge status={vramStatus} revealOnHover={true} />")
+      .length - 1,
+    2,
+    "both model row slots reveal on hover",
+  );
 });
 
 test("aligned meta slots spend their slack on the name", () => {

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -127,7 +127,7 @@ test("each fit verdict is an info mark that explains itself", () => {
   // A GGUF over budget still loads: llama-server hands it to --fit.
   assert.ok(
     PICKERS.includes(
-      "hint: \"Model doesn't fit but still works with offloading. Expect slower inference.\"",
+      "hint: \"Model may not fit but still works with offloading. Expect slower inference.\"",
     ),
   );
   // A model row's `tight` comes from checkVramFit, which is 75-100% of VRAM: it fits on the card

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -124,9 +124,10 @@ test("each fit verdict is an info mark that explains itself", () => {
   // A pill shouted a three letter acronym; the mark says what it means on hover. Tight spills
   // past VRAM into system RAM, oom clears neither budget, so the two hints differ.
   assert.ok(PICKERS.includes("icon={InformationCircleIcon}"));
+  // Neither verdict blocks a load, so both hints say what to expect rather than refusing.
   assert.ok(
     PICKERS.includes(
-      "hint: \"Model doesn't fit. Expect much slower inference.\"",
+      "hint: \"Model doesn't fit but can still work with offloading. Expect slower inference.\"",
     ),
   );
   assert.ok(

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -97,19 +97,15 @@ test("an over budget row dims instead of putting a pill on every line", () => {
       '"opacity-60 transition-opacity group-hover/row:opacity-100 group-focus-visible/row:opacity-100"',
     ),
   );
-  // The pill is hidden, not removed, and its slot keeps a width, so revealing it cannot reflow.
-  assert.ok(PICKERS.includes('vram: "min-w-min min-[560px]:w-[4em]"'));
-  // TIGHT is rare enough to stay put; only the OOM pill hides.
-  const tight = PICKERS.slice(PICKERS.indexOf('if (status === "tight")'));
-  assert.ok(!tight.slice(0, 300).includes("opacity-0"));
+  // The mark is hidden, not removed, and its slot keeps a width, so revealing it cannot reflow.
+  assert.ok(PICKERS.includes('vram: "min-w-min min-[560px]:w-[18px]"'));
 });
 
 test("one fit badge, so a colour or reveal change cannot miss a list", () => {
   // The quantization rows had their own copy and stayed red when the pill went orange.
-  // Match on the text colour: "!bg-orange-50" is also a prefix of "!bg-orange-500/15".
-  assert.equal(PICKERS.split("!text-orange-700").length - 1, 1, "one OOM pill");
-  assert.equal(PICKERS.split("!text-yellow-400").length - 1, 1, "one TIGHT label");
+  assert.equal(PICKERS.split("VRAM_VERDICT = {").length - 1, 1, "one verdict table");
   assert.ok(!PICKERS.includes("!text-red-700"), "no red fit badge left");
+  assert.ok(!PICKERS.includes(">\n        OOM\n"), "no OOM text pill left");
   // Variant rows render the shared badge and opt out of the hover reveal.
   assert.ok(
     PICKERS.includes(
@@ -122,6 +118,26 @@ test("one fit badge, so a colour or reveal change cannot miss a list", () => {
     2,
     "both model row slots reveal on hover",
   );
+});
+
+test("each fit verdict is an info mark that explains itself", () => {
+  // A pill shouted a three letter acronym; the mark says what it means on hover. Tight spills
+  // past VRAM into system RAM, oom clears neither budget, so the two hints differ.
+  assert.ok(PICKERS.includes("icon={InformationCircleIcon}"));
+  assert.ok(
+    PICKERS.includes(
+      "hint: \"Model doesn't fit. Expect much slower inference.\"",
+    ),
+  );
+  assert.ok(
+    PICKERS.includes(
+      'hint: "Model only fits by spilling into system RAM. Expect slower inference."',
+    ),
+  );
+  // Both marks are reachable by screen readers without the tooltip.
+  assert.ok(PICKERS.includes('label: "Does not fit"'));
+  assert.ok(PICKERS.includes('label: "Tight fit"'));
+  assert.ok(PICKERS.includes("aria-label={verdict.label}"));
 });
 
 test("aligned meta slots spend their slack on the name", () => {


### PR DESCRIPTION
Stacked on #10006, which is why the base here is `studio-picker-row-metadata-widths` rather than `main`. Both touch the same two lines of the row button, so keeping them separate off `main` would only produce a conflict. Merge #10006 first and this retargets cleanly.

On a normal GPU almost every Recommended row is over budget, so almost every row carried an `OOM` pill. Forty rows of it reads as an error state rather than as a per row verdict, and it buries the handful of rows that actually fit. In the list I tested, 3 of the first 10 rows fit and the other 7 were pills.

Two changes, both about turning that from noise back into information.

### The row carries the verdict, the pill waits for attention

An over budget row drops to 60% opacity, and the pill is painted only while that row is hovered or focused.

- `VramBadge` keeps the pill in the layout at `opacity-0`, revealed by `group-hover/row` and `group-focus-visible/row`.
- The row content dims when `exceeds && !selected`. The selected row keeps full weight, since it is the one being considered.
- The row button becomes `group/row` so both can key off it.

**Why opacity rather than not rendering it.** The pill is hidden, not removed, so the `vram` slot keeps its width and revealing it cannot reflow the row. Measured on hover, the pill's left edge stays at 661.7px and the parameter chip's at 700.2px, identical to the unhovered state. It also stays in the accessibility tree, so the verdict is still announced rather than being hover only information. The row tooltip already gives the number (`Needs ~118GB VRAM (GPU: 64GB)`), so hovering surfaces both the pill and the reason.

### One badge, so this cannot happen again

The quantization rows carried their own copy of the `OOM` and `TIGHT` markup, so they stayed red when the model rows went orange. Both now render `VramBadge`, which grows a `revealOnHover` flag:

- Model rows hold the pill in the layout and paint it on hover.
- Variant rows always show it. Picking a variant that fits is the reason that list is open, so there the verdict is the point rather than noise.

A test pins there being one definition of each label, so the next colour or behaviour change cannot miss a list.

### The pill says nothing useful, so it became an info mark

`OOM` is jargon, and a coloured pill repeated down a list says it loudly without saying what to do about it. Both verdicts are now one info mark that explains itself on hover:

| verdict | mark | tooltip |
|---|---|---|
| `exceeds` | orange info | Model doesn't fit but can still work with offloading. Expect slower inference. |
| `tight` | yellow info | Model only fits by spilling into system RAM. Expect slower inference. |

The wording follows `classifyGgufFit`: `tight` clears the GPU budget only with RAM offload, `oom` clears neither, so `tight` is the milder of the two and the hints say so rather than both reading as failure. Red is gone entirely, since neither is an error the user caused.

Each mark carries an `aria-label` (`Does not fit`, `Tight fit`), so the verdict still reaches a screen reader without the tooltip. The hub slot drops from `4em` to `18px`, since it holds one glyph now rather than a three letter pill, and that width goes back to the name.

### Verified in the running picker

| state | row content | `OOM` pill |
|---|---|---|
| over budget, at rest | 0.6 | 0 |
| over budget, hovered | 1 | 1 |
| over budget, focused via Tab | 1 | 1 |
| fits (`Qwen3.8-27B-GGUF`) | 1 | no pill |

Keyboard was worth checking separately: arrow keys in this list move an active descendant and leave DOM focus in the search field, so `group-focus-visible` would not have fired on its own. Rows are `tabindex="0"` buttons though, so tabbing to one does light it up, confirmed above.

Typecheck clean, frontend suite at 5982 tests.



