### PR TITLE
Give the cancel drain a budget sized for a loaded runner

### DIFF
--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -5206,13 +5206,26 @@ class TestGgufVisionToolRouting:
                     current_subject = "test",
                 )
             )
-            assert await asyncio.to_thread(started.wait, 1.0)
+            # Generous budgets. What this test asserts is that cancelling the
+            # request drains the worker, and none of the numbers below are part
+            # of that: they only bound how long to wait before calling it hung.
+            # A one-second bound on a THREAD START is a bound on the scheduler,
+            # not on this code, and it went red once on a runner busy with the
+            # rest of the backend suite. Failing here still takes seconds, and
+            # the assertion is unchanged.
+            assert await asyncio.to_thread(started.wait, self._DRAIN_BUDGET_S)
 
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
-                await asyncio.wait_for(task, timeout = 1.0)
+                await asyncio.wait_for(task, timeout = self._DRAIN_BUDGET_S)
 
-            assert released.is_set()
+            # Waited on, not sampled. Cancelling the task unblocks the awaiting
+            # coroutine; it does not join the worker, which is off polling
+            # cancel_event every 5ms and only then sets this. Reading it the
+            # instant the await returns is a race that happens to be won on an
+            # idle box, and it is the drain itself that matters, not whether it
+            # had already finished by the time we looked.
+            assert await asyncio.to_thread(released.wait, self._DRAIN_BUDGET_S)
             assert get_llama_admission_queue("http://llama.tool.test").snapshot().active == 0
             [entry] = monitor.snapshot()
             assert entry["status"] == "cancelled"
@@ -5324,6 +5337,11 @@ class TestGgufVisionToolRouting:
 
         assert json.loads(response.body)["choices"][0]["message"]["content"] == "reply"
         assert captured["perf_callback"] is None
+
+    # Wall-clock bound for the cancel drain. Only ever hit when something is
+    # genuinely stuck, so it is sized for a loaded runner rather than for the
+    # ~5ms this takes when it works.
+    _DRAIN_BUDGET_S = 30.0
 
     def test_non_streaming_gguf_cancel_drains_worker(self, monkeypatch):
         async def _run():


### PR DESCRIPTION
`Backend CI` → `(Python 3.13)` failed on main `8849f481d`:

```
test_non_streaming_gguf_cancel_drains_worker - assert False
```

That `assert` is `await asyncio.to_thread(started.wait, 1.0)`, so what timed out is a **thread start**. It is a bound on the scheduler, not on the code under test, and the job was running the rest of the backend suite beside it.

### The change

What this test asserts is that cancelling the request drains the worker. None of the numbers are part of that claim; they only decide how long to wait before calling it hung. They move to one constant, `30.0`, sized for a loaded runner rather than for the ~5ms this takes when it works.

The last assertion also stops being a sample:

```python
assert released.is_set()          # before
assert await asyncio.to_thread(released.wait, self._DRAIN_BUDGET_S)   # after
```

Cancelling the task unblocks the awaiting coroutine; it does not join the worker, which is off polling `cancel_event` every 5ms and only then sets `released`. Reading it the instant the await returns is a race that happens to be won on an idle box. The drain is the point, not whether it had already finished by the time the test looked.

### It keeps its teeth

With the worker changed to ignore `cancel_event` entirely:

```
FAILED tests/test_openai_tool_passthrough.py::TestGgufVisionToolRouting::test_non_streaming_gguf_cancel_drains_worker
1 failed, 346 deselected in 50.05s
```

### What this is, honestly

A robustification, not a demonstrated fix. **The original failure did not reproduce here.** Pinned to one core against 16 spinners the test still passed, taking 173s against a normal 4.4s — a 39x slowdown that never came near the one-second bound. It is one failure in eight runs on main, with the four commits before it green.

I am not claiming to have proven the mechanism. The budgets were incidental to the assertion either way, and widening them costs nothing on a test that is only slow when something is genuinely wrong.

`studio/backend/tests/test_openai_tool_passthrough.py`: 347 passed.
