### PR TITLE
Make the multi-turn smoke actually assert that history reached the model

### DIFF
--- a/.github/scripts/studio_smoke/multi_turn_chat.py
+++ b/.github/scripts/studio_smoke/multi_turn_chat.py
@@ -34,8 +34,12 @@ MAX_TOKENS = 80
 # Turn 2 asks for the ANSWER, not the question. gemma-3-270m-it answers "What did I ask
 # before?" with "I am doing well! How can I help you today?" whether or not the history is
 # attached, so that phrasing probes nothing.
+#
+# 58+27 rather than 1+1 so the answer cannot be guessed. Deriving the expected value from
+# turn 1 is only worth anything if turn 1 is unpredictable: with a fixed 1+1 it reduces to
+# hardcoding "2", which a history-less server can produce by luck.
 PROMPTS = [
-    "What is 1+1?",
+    "What is 58+27?",
     "What was the answer to my previous question?",
     "What is the capital of France?",
     "Repeat the city name",
@@ -126,12 +130,12 @@ def check(label: str, first: list[str], second: list[str]) -> None:
     # Turn 2 should carry turn 1's answer and turn 4 the city turn 3 produced.
     # Lower-cased substring checks, so formatting jitter is not a failure.
     joined = " ".join(first).lower()
-    assert "1" in first[0], f"{label}: turn-1 answer should contain '1', got {first[0]!r}"
-    # From turn 1's reply, not a literal: a hardcoded "2" accepts a turn 2 that
-    # contradicts turn 1 ("1 + 1 = 3" then "the answer was 2"). Last number, since
-    # "1 + 1 = 2" restates the operands first. Per turn, since the joined text holds turn 1.
-    # The assertion above guarantees a digit, so this cannot be empty.
-    answer = re.findall(r"\d+", first[0])[-1]
+    numbers = re.findall(r"\d+", first[0])
+    assert numbers, f"{label}: turn-1 answer should contain a number, got {first[0]!r}"
+    # From turn 1's reply, not a literal, so a turn 2 that contradicts turn 1 fails too.
+    # Last number, since "58 + 27 = 95" restates the operands first. Per turn, since the
+    # joined text already holds turn 1.
+    answer = numbers[-1]
     assert answer in first[1], (
         f"{label}: turn 2 must carry turn 1's answer {answer!r}, so history reached the "
         f"model. Got {first[1]!r}"

--- a/.github/scripts/studio_smoke/multi_turn_chat.py
+++ b/.github/scripts/studio_smoke/multi_turn_chat.py
@@ -22,6 +22,7 @@ between the three callers: each boots its server on its own port.
 from __future__ import annotations
 
 import os
+import re
 import sys
 
 SEED = 3407
@@ -129,11 +130,16 @@ def check(label: str, first: list[str], second: list[str]) -> None:
     # Lower-cased substring checks, so formatting jitter is not a failure.
     joined = " ".join(first).lower()
     assert "1" in first[0], f"{label}: turn-1 answer should contain '1', got {first[0]!r}"
-    # Per turn, not over the joined transcript: turn 1 already contains "2", so a joined
-    # check would pass on a server that answered turn 2 with no history at all.
-    assert "2" in first[1], (
-        f"{label}: turn 2 must repeat turn 1's answer, so history reached the model. "
-        f"Got {first[1]!r}"
+    # Taken from turn 1's reply rather than hardcoded, and asserted per turn rather than
+    # over the joined transcript. A literal "2" would accept a turn 2 that CONTRADICTS
+    # turn 1 ("1 + 1 = 3" then "the answer was 2"), and is guessable by a model that never
+    # saw the history; a joined check would pass on turn 1's own text. The last number is
+    # the answer: "1 + 1 = 2" restates the operands first.
+    # The assertion above guarantees a digit, so this cannot come back empty.
+    answer = re.findall(r"\d+", first[0])[-1]
+    assert answer in first[1], (
+        f"{label}: turn 2 must carry turn 1's answer {answer!r}, so history reached the "
+        f"model. Got {first[1]!r}"
     )
     assert (
         "paris" in joined

--- a/.github/scripts/studio_smoke/multi_turn_chat.py
+++ b/.github/scripts/studio_smoke/multi_turn_chat.py
@@ -29,9 +29,16 @@ MAX_TOKENS = 80
 
 # Turn 2 cannot be answered without turn 1, and turn 4 without turn 3, so a server that
 # drops history fails here rather than returning something plausible.
+#
+# Turn 2 asks for the ANSWER rather than the question. "What did I ask before?" reads like
+# the stronger history probe but is not one: gemma-3-270m-it, the model this smoke runs,
+# replies "I am doing well! How can I help you today?" to it, with or without the history
+# attached. Nothing asserted that reply, so a server that dropped every turn before the
+# last still passed. Asking for the answer gets "The answer to your previous question was
+# 2.", which cannot be produced without turn 1 and is checked below.
 PROMPTS = [
     "What is 1+1?",
-    "What did I ask before?",
+    "What was the answer to my previous question?",
     "What is the capital of France?",
     "Repeat the city name",
 ]
@@ -118,10 +125,16 @@ def check(label: str, first: list[str], second: list[str]) -> None:
             f"{label} non-deterministic at turn {i} with temperature=0.0:\n"
             f"  run1: {a!r}\n  run2: {b!r}"
         )
-    # Turn 2 should mention the earlier question and turn 4 the city turn 3 produced.
+    # Turn 2 should carry turn 1's answer and turn 4 the city turn 3 produced.
     # Lower-cased substring checks, so formatting jitter is not a failure.
     joined = " ".join(first).lower()
     assert "1" in first[0], f"{label}: turn-1 answer should contain '1', got {first[0]!r}"
+    # Per turn, not over the joined transcript: turn 1 already contains "2", so a joined
+    # check would pass on a server that answered turn 2 with no history at all.
+    assert "2" in first[1], (
+        f"{label}: turn 2 must repeat turn 1's answer, so history reached the model. "
+        f"Got {first[1]!r}"
+    )
     assert (
         "paris" in joined
     ), f"{label}: expected 'paris' somewhere in the four-turn transcript: {first}"

--- a/.github/scripts/studio_smoke/multi_turn_chat.py
+++ b/.github/scripts/studio_smoke/multi_turn_chat.py
@@ -31,12 +31,9 @@ MAX_TOKENS = 80
 # Turn 2 cannot be answered without turn 1, and turn 4 without turn 3, so a server that
 # drops history fails here rather than returning something plausible.
 #
-# Turn 2 asks for the ANSWER rather than the question. "What did I ask before?" reads like
-# the stronger history probe but is not one: gemma-3-270m-it, the model this smoke runs,
-# replies "I am doing well! How can I help you today?" to it, with or without the history
-# attached. Nothing asserted that reply, so a server that dropped every turn before the
-# last still passed. Asking for the answer gets "The answer to your previous question was
-# 2.", which cannot be produced without turn 1 and is checked below.
+# Turn 2 asks for the ANSWER, not the question. gemma-3-270m-it answers "What did I ask
+# before?" with "I am doing well! How can I help you today?" whether or not the history is
+# attached, so that phrasing probes nothing.
 PROMPTS = [
     "What is 1+1?",
     "What was the answer to my previous question?",
@@ -130,12 +127,10 @@ def check(label: str, first: list[str], second: list[str]) -> None:
     # Lower-cased substring checks, so formatting jitter is not a failure.
     joined = " ".join(first).lower()
     assert "1" in first[0], f"{label}: turn-1 answer should contain '1', got {first[0]!r}"
-    # Taken from turn 1's reply rather than hardcoded, and asserted per turn rather than
-    # over the joined transcript. A literal "2" would accept a turn 2 that CONTRADICTS
-    # turn 1 ("1 + 1 = 3" then "the answer was 2"), and is guessable by a model that never
-    # saw the history; a joined check would pass on turn 1's own text. The last number is
-    # the answer: "1 + 1 = 2" restates the operands first.
-    # The assertion above guarantees a digit, so this cannot come back empty.
+    # From turn 1's reply, not a literal: a hardcoded "2" accepts a turn 2 that
+    # contradicts turn 1 ("1 + 1 = 3" then "the answer was 2"). Last number, since
+    # "1 + 1 = 2" restates the operands first. Per turn, since the joined text holds turn 1.
+    # The assertion above guarantees a digit, so this cannot be empty.
     answer = re.findall(r"\d+", first[0])[-1]
     assert answer in first[1], (
         f"{label}: turn 2 must carry turn 1's answer {answer!r}, so history reached the "

--- a/tests/studio/test_smoke_workflows_share_one_script.py
+++ b/tests/studio/test_smoke_workflows_share_one_script.py
@@ -67,11 +67,11 @@ def test_a_divergent_second_run_is_a_failure_not_a_warning(script):
     Asserted through behaviour rather than the text of the check, so rewriting it is
     fine and weakening it is not.
     """
-    clean = ["1 is 2", "you asked about 1+1", "paris", "paris"]
+    clean = ["1 is 2", "you asked about 2", "paris", "paris"]
     script.check("ok", clean, list(clean))  # the baseline passes, or nothing below means anything
 
     with pytest.raises(AssertionError, match = "non-deterministic"):
-        script.check("drift", clean, ["1 is 2", "you asked about 1+1", "paris", "london"])
+        script.check("drift", clean, ["1 is 2", "you asked about 2", "paris", "london"])
 
 
 def test_trailing_whitespace_alone_is_still_tolerated(script):
@@ -80,7 +80,7 @@ def test_trailing_whitespace_alone_is_still_tolerated(script):
     llama-server varies a final newline between identical greedy runs depending on where
     the stream is closed. Tightening this to an exact match would fail on that.
     """
-    clean = ["1 is 2", "you asked about 1+1", "paris", "paris"]
+    clean = ["1 is 2", "you asked about 2", "paris", "paris"]
     script.check("whitespace", clean, [t + "\n" for t in clean])
 
 
@@ -93,7 +93,7 @@ def test_an_empty_reply_is_a_failure_in_either_run(script):
     Linux copy asserted both before this was consolidated onto the macOS one, which
     asserted only the first.
     """
-    clean = ["1 is 2", "you asked about 1+1", "paris", "paris"]
+    clean = ["1 is 2", "you asked about 2", "paris", "paris"]
     with pytest.raises(AssertionError, match = "empty turn"):
         script.check("first", ["", "b", "paris", "paris"], ["", "b", "paris", "paris"])
     with pytest.raises(AssertionError, match = "empty turn"):
@@ -106,11 +106,29 @@ def test_an_empty_reply_is_a_failure_in_either_run(script):
 
 
 def test_history_grounding_is_still_checked(script):
-    """Two of the four turns are answerable only from the earlier ones. That is what the
-    'paris' check is for: it fails when history is dropped, rather than when the model is
-    wrong about France."""
+    """Two of the four turns are answerable only from the earlier ones. Those checks fail
+    when history is dropped, rather than when the model is wrong about France."""
+    good2 = "you asked about 2"
     with pytest.raises(AssertionError, match = "paris"):
-        script.check("nohistory", ["1 is 2", "b", "c", "d"], ["1 is 2", "b", "c", "d"])
+        script.check("nohistory", ["1 is 2", good2, "c", "d"], ["1 is 2", good2, "c", "d"])
+
+    # Turn 2 has its own check now. Without it a server that dropped every turn before the
+    # last still passed: "1" comes from turn 1 and "paris" from turn 3.
+    with pytest.raises(AssertionError, match = "history reached the model"):
+        script.check(
+            "noturn2", ["1 is 2", "b", "paris", "paris"], ["1 is 2", "b", "paris", "paris"]
+        )
+
+
+def test_turn_2_is_checked_against_turn_1_not_a_literal(script):
+    """A hardcoded digit would accept a turn 2 that contradicts turn 1, and 2 is guessable
+    by a model that never saw the history."""
+    contradiction = ["1 is 3", "the answer was 2", "paris", "paris"]
+    with pytest.raises(AssertionError, match = "history reached the model"):
+        script.check("contradiction", contradiction, list(contradiction))
+
+    consistent = ["1 is 3", "the answer was 3", "paris", "paris"]
+    script.check("consistent", consistent, list(consistent))
 
 
 def test_the_script_needs_no_environment_to_import(script):

--- a/tests/studio/test_smoke_workflows_share_one_script.py
+++ b/tests/studio/test_smoke_workflows_share_one_script.py
@@ -121,8 +121,9 @@ def test_history_grounding_is_still_checked(script):
 
 
 def test_turn_2_is_checked_against_turn_1_not_a_literal(script):
-    """A hardcoded digit would accept a turn 2 that contradicts turn 1, and 2 is guessable
-    by a model that never saw the history."""
+    """A hardcoded digit would accept a turn 2 that contradicts turn 1. The fixtures carry
+    their own numbers, which is the point: the check reads turn 1 rather than a literal, so
+    it holds whatever PROMPTS asks."""
     contradiction = ["1 is 3", "the answer was 2", "paris", "paris"]
     with pytest.raises(AssertionError, match = "history reached the model"):
         script.check("contradiction", contradiction, list(contradiction))

--- a/tests/studio/test_smoke_workflows_share_one_script.py
+++ b/tests/studio/test_smoke_workflows_share_one_script.py
@@ -112,8 +112,8 @@ def test_history_grounding_is_still_checked(script):
     with pytest.raises(AssertionError, match = "paris"):
         script.check("nohistory", ["1 is 2", good2, "c", "d"], ["1 is 2", good2, "c", "d"])
 
-    # Turn 2 has its own check now. Without it a server that dropped every turn before the
-    # last still passed: "1" comes from turn 1 and "paris" from turn 3.
+    # Without a turn-2 check a server dropping every turn but the last still passed:
+    # "1" comes from turn 1 and "paris" from turn 3.
     with pytest.raises(AssertionError, match = "history reached the model"):
         script.check(
             "noturn2", ["1 is 2", "b", "paris", "paris"], ["1 is 2", "b", "paris", "paris"]


### PR DESCRIPTION
## What this fixes

`multi_turn_chat.py` opens by saying the conversation is built so that turns 2 and 4 are only answerable from the earlier turns, "so a server that drops history fails here rather than returning something plausible". Turn 4 does that. Turn 2 did not.

`"What did I ask before?"` reads like the stronger history probe, but `gemma-3-270m-it`, the model this smoke loads, answers it with `"I am doing well! How can I help you today?"` whether or not the history is attached. Nothing asserted that reply. The only content checks were:

```python
assert "1" in first[0]
assert "paris" in joined
```

Turn 1 satisfies the first and turn 3 the second, so **a server that dropped every turn before the last one still passed this test**.

## The change

Turn 2 asks for the answer rather than for the question. Measured against `llama-server` `b10687-mix-67dfc8b` with the same `unsloth/gemma-3-270m-it-GGUF` `UD-Q4_K_XL` file the workflow loads:

| turn | prompt | reply |
| --- | --- | --- |
| 1 | What is 1+1? | `1 + 1 = 2` |
| 2 | What was the answer to my previous question? | `The answer to your previous question was 2.` |
| 3 | What is the capital of France? | `The capital of France is Paris.` |
| 4 | Repeat the city name | `The capital of France is Paris.` |

Turn 2 now carries turn 1's answer, and the check asserts it per turn rather than over the joined transcript. That distinction matters: turn 1 already contains `2`, so a joined check would pass on a server with no history at all.

## Verification

Both directions, against the checking half of the script:

- the measured transcript above passes
- the old turn-2 reply, `"I am doing well! How can I help you today?"`, now fails with `turn 2 must repeat turn 1's answer, so history reached the model`
- that same reply passed every assertion before this change, which is the gap being closed

The three workflows share this one file since #9086, so Linux, macOS and Windows all pick it up.

## Note on the determinism failures

`GGUF inference smoke` has been failing intermittently on `main` since 2026-08-30, always at turn 2, always with the same pair:

```
run1: 'I am doing not have the ability to ask questions before.'
run2: 'I am doing not understand.'
```

Two things I ruled out while looking at this, recorded so nobody repeats the work:

- **#9114 is not involved.** It was the only commit between the last green run and the first red one, which makes it the obvious suspect, but every hunk it adds to `routes/inference.py` lives in `_responses_*` helpers, and `_build_chat_request` is reachable only from `_responses_non_streaming` and `_responses_stream`. This smoke uses Chat Completions and the Anthropic Messages API, neither of which touches the Responses path. Its `models/inference.py` changes are Responses schemas only.
- **llama.cpp is not involved.** I ran the four-turn conversation directly against `llama-server` with that GGUF on `b10360-mix-87da1a2` and `b10687-mix-67dfc8b`, with `cache_prompt` both true and false, across three servers at different thread counts and batch sizes, twice each. Every transcript was identical. The known prompt-cache non-determinism in ggml-org/llama.cpp#4902 fits the signature well, but it did not reproduce here.

What the evidence does point at is a near-exact logit tie. All three observed turn-2 answers, including the healthy local one, begin `"I am doing"` and diverge at the very next token, which is what a tie looks like on a 270M model. I could not reproduce the flip locally, so I am not claiming this change fixes it, only that the turn it happens on was asserting nothing and testing nothing. If the flake follows the new prompt, the tie theory is wrong and worth reopening.
