### PR TITLE
fix(studio): read tool-call arguments as the types their schema declares

### DIFF
--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -29,7 +29,10 @@ import os
 from collections.abc import Mapping
 from typing import Any, Optional
 
-from core.inference.tool_loop_controller import coerce_tool_arguments
+from core.inference.tool_loop_controller import (
+    coerce_arguments_by_schema,
+    coerce_tool_arguments,
+)
 from core.tool_healing import parse_tool_calls_from_text
 
 # Only the formats this healer's parser can promote -- narrower than the loops'
@@ -147,15 +150,20 @@ def _string_arg_key_from_schema(schema: Any) -> Optional[str]:
 def _coerce_promoted_arguments(
     raw_args: Any, tool_name: str, tool_schemas: Optional[dict]
 ) -> Optional[dict]:
-    if isinstance(raw_args, Mapping):
-        return dict(raw_args)
+    """Promoted arguments, typed against the client's declared schema: the call was TEXT a
+    moment ago, so its XML parameters arrive as raw strings and closing a truncated container
+    is this healer's own job rather than something to gate."""
+    parameters = (tool_schemas or {}).get(tool_name)
+    properties = parameters.get("properties") if isinstance(parameters, Mapping) else None
+    parsed = raw_args
     if isinstance(raw_args, str):
         try:
             parsed = json.loads(raw_args)
-            if isinstance(parsed, Mapping):
-                return dict(parsed)
         except (json.JSONDecodeError, ValueError):
-            pass
+            parsed = raw_args
+    if isinstance(parsed, Mapping):
+        return coerce_arguments_by_schema(parsed, properties, repair = True)
+    if isinstance(raw_args, str):
         if tool_schemas is not None:
             key = _string_arg_key_from_schema(tool_schemas.get(tool_name))
             return {key: raw_args} if key else None

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -11,9 +11,11 @@ backend-specific modules.
 
 from __future__ import annotations
 
+import ast
 import copy
 import json
 import math
+import re
 from dataclasses import dataclass, field
 from typing import Any, Collection, Literal, Mapping, Sequence
 from urllib.parse import urlparse
@@ -346,16 +348,54 @@ def canonical_tool_call_key(tool_name: str, arguments: Mapping[str, Any]) -> str
     return f"{tool_name}:{canonical_args}"
 
 
-# `_edit_file_replace_all`'s words, minus the empty string, which is an absent value rather
-# than a boolean one. That tool still reads its own "" as false.
-# "0" and "1" are deliberately absent: they are the only spellings with a JSON scalar
-# counterpart, and a native `0` for the same parameter arrives already typed and is left
-# alone, so reading them would make one argument mean different things in the two call
-# syntaxes. `edit_file` still reads them, for its own parameter, where no such pair exists.
+# "0"/"1" are left out: a native `0` arrives already typed, so they would mean two things.
 _SCHEMA_TRUE_WORDS = frozenset({"true", "yes"})
 _SCHEMA_FALSE_WORDS = frozenset({"false", "no"})
-# What this walk follows to find a declaration. `nullable` is OpenAPI 3.0's spelling of a
-# type union, which several MCP servers still generate.
+# Not ValueErrors, so a decode-shaped except would let deep model output escape as a 500.
+_DECODE_ERRORS = (ValueError, RecursionError)
+_LITERAL_ERRORS = (*_DECODE_ERRORS, SyntaxError, MemoryError)
+
+
+# A JSON string, open or closed; group 1 is the closing quote, which `endswith` cannot stand
+# in for because an open string can end on an escaped one. The `\?$` tail stops a started
+# match from ever failing, which would send `finditer` back over every later quote.
+_JSON_STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*(?:(")|\\?$)', re.S)
+_JSON_CLOSER = {"[": "]", "{": "}"}
+
+
+def _balanced(segment: str, opened: "list[str]") -> str:
+    kept: list[str] = []
+    for ch in segment:
+        if ch in _JSON_CLOSER:
+            opened.append(_JSON_CLOSER[ch])
+            kept.append(ch)
+        elif ch in "]}":
+            # The commonest slip: a closer of the wrong kind becomes the right one.
+            if opened:
+                kept.append(opened.pop())
+        else:
+            kept.append(ch)
+    return "".join(kept)
+
+
+def _repair_json_value(text: str) -> Any:
+    """Parse near-valid JSON whose brackets do not balance, or None if it still will not."""
+    parts: list[str] = []
+    opened: list[str] = []
+    cursor = 0
+    open_string = ""
+    for match in _JSON_STRING_RE.finditer(text):
+        parts += [_balanced(text[cursor : match.start()], opened), match.group()]
+        open_string = "" if match.group(1) else '"'
+        cursor = match.end()
+    parts += [_balanced(text[cursor:], opened), open_string, *reversed(opened)]
+    try:
+        return json.loads("".join(parts), strict = False)
+    except _DECODE_ERRORS:
+        return None
+
+
+# Followed to find a declaration; `nullable` is OpenAPI 3.0's spelling of a type union.
 _READ_KEYWORDS = frozenset(
     {
         "type",
@@ -470,7 +510,7 @@ def _read_schema(spec: Any) -> "tuple[Any, str | None, bool]":
     return chosen, rest[0] if rest else None, "null" in named
 
 
-def _coerce_declared_value(text: str, declared: str) -> Any:
+def _coerce_declared_value(text: str, declared: str, repair: bool) -> Any:
     stripped = text.strip()
     if declared == "boolean":
         lowered = stripped.lower()
@@ -492,10 +532,48 @@ def _coerce_declared_value(text: str, declared: str) -> Any:
         # Exactness is unguarded: float64 IS JSON's number type, so a JSON call agrees.
         if math.isfinite(number) and (declared == "number" or number.is_integer()):
             return number
+    elif declared == "array":
+        return _coerce_container(text, list, repair)
+    elif declared == "object":
+        return _coerce_container(text, dict, repair)
     return text
 
 
-def _coerce_one_property(value: Any, spec: Any) -> Any:
+def _usable_container(value: Any, want: type) -> bool:
+    """A ``want`` that survives the JSON re-encoding of ``arguments``: both decoders admit
+    what ``json.dumps`` will not write back, such as an integer key returning as a STRING."""
+    if not isinstance(value, want):
+        return False
+    try:
+        dumped = json.dumps(value, allow_nan = False, sort_keys = True, ensure_ascii = False)
+        dumped.encode("utf-8")  # a lone surrogate survives dumps and dies encoding the reply
+        return json.loads(dumped) == value
+    except (TypeError, ValueError, RecursionError):
+        return False
+
+
+def _coerce_container(text: str, want: type, repair: bool) -> Any:
+    """``text`` read as the DECLARED container, tolerating a Python literal and, when
+    ``repair``, unbalanced brackets. Rewriting brackets is what auto-heal opts out of."""
+    try:
+        parsed = json.loads(text, strict = False)
+    except _DECODE_ERRORS:
+        parsed = None
+    if _usable_container(parsed, want):
+        return parsed
+    try:
+        literal = ast.literal_eval(text)
+    except _LITERAL_ERRORS:
+        literal = None
+    if isinstance(literal, tuple):
+        literal = list(literal)
+    if _usable_container(literal, want):
+        return literal
+    repaired = _repair_json_value(text) if repair else None
+    return repaired if _usable_container(repaired, want) else text
+
+
+def _coerce_one_property(value: Any, spec: Any, repair: bool) -> Any:
     """One value read against its property schema."""
     spec, declared, nullable = _read_schema(spec)
     if spec is None or not isinstance(value, str):
@@ -506,10 +584,15 @@ def _coerce_one_property(value: Any, spec: Any) -> Any:
         return None
     if declared is None:
         return value
-    return _coerce_declared_value(value, declared)
+    return _coerce_declared_value(value, declared, repair)
 
 
-def coerce_arguments_by_schema(arguments: Mapping[str, Any], properties: Any) -> dict:
+def coerce_arguments_by_schema(
+    arguments: Mapping[str, Any],
+    properties: Any,
+    *,
+    repair: bool = False,
+) -> dict:
     """Arguments with each string value that declares a non-string type read as that type.
 
     A tool-call parser is given tool NAMES, never schemas, so an XML-form parameter is stored
@@ -525,7 +608,7 @@ def coerce_arguments_by_schema(arguments: Mapping[str, Any], properties: Any) ->
     """
     if not isinstance(properties, Mapping) or not properties:
         return dict(arguments)
-    return {k: _coerce_one_property(v, properties.get(k)) for k, v in arguments.items()}
+    return {k: _coerce_one_property(v, properties.get(k), repair) for k, v in arguments.items()}
 
 
 def _declared_properties(tool_name: str, tool_schemas) -> Any:
@@ -548,17 +631,20 @@ def coerce_tool_arguments(
     """Normalize model-emitted ``function.arguments`` to a dictionary.
 
     Typing against ``tool_schemas`` is not gated on ``heal``: healing invents structure the
-    model never sent, while reading a value as its own schema declares it is the tool's
-    contract, and gating it would return `bool("false")` to auto-heal-off users.
+    model never sent, while reading a value as its schema declares it is the tool's contract.
     """
     properties = _declared_properties(tool_name, tool_schemas) if tool_name else None
     if isinstance(raw_args, Mapping):
-        return CoercedArguments(coerce_arguments_by_schema(raw_args, properties), False)
+        return CoercedArguments(
+            coerce_arguments_by_schema(raw_args, properties, repair = heal), False
+        )
     if isinstance(raw_args, str):
         try:
             parsed = json.loads(raw_args)
             if isinstance(parsed, Mapping):
-                return CoercedArguments(coerce_arguments_by_schema(parsed, properties), False)
+                return CoercedArguments(
+                    coerce_arguments_by_schema(parsed, properties, repair = heal), False
+                )
         except (json.JSONDecodeError, ValueError):
             pass
         if heal:

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -510,6 +510,10 @@ def _read_schema(spec: Any) -> "tuple[Any, str | None, bool]":
     return chosen, rest[0] if rest else None, "null" in named
 
 
+# A schema is model-facing data, so its nesting is not trusted to be shallow.
+_MAX_SCHEMA_DEPTH = 8
+
+
 def _coerce_declared_value(text: str, declared: str, repair: bool) -> Any:
     stripped = text.strip()
     if declared == "boolean":
@@ -573,18 +577,45 @@ def _coerce_container(text: str, want: type, repair: bool) -> Any:
     return repaired if _usable_container(repaired, want) else text
 
 
-def _coerce_one_property(value: Any, spec: Any, repair: bool) -> Any:
-    """One value read against its property schema."""
+def _coerce_by_property(value: Any, spec: Any, depth: int, repair: bool) -> Any:
+    if depth >= _MAX_SCHEMA_DEPTH:
+        return value
     spec, declared, nullable = _read_schema(spec)
-    if spec is None or not isinstance(value, str):
+    if spec is None:
         return value
-    if declared == "string":
-        return value
-    if nullable and value.strip().lower() == "null":
-        return None
-    if declared is None:
-        return value
-    return _coerce_declared_value(value, declared, repair)
+    if isinstance(value, str):
+        if declared == "string":
+            return value
+        if nullable and value.strip().lower() == "null":
+            return None
+        if declared is None:
+            return value
+        value = _coerce_declared_value(value, declared, repair)
+    # Descent needs the SAME declaration the conversion needs: without one a text value is
+    # not decoded, so descending into an already-decoded one would make the syntaxes disagree.
+    if declared == "object" and isinstance(value, Mapping):
+        nested = spec.get("properties")
+        nested = nested if isinstance(nested, Mapping) else {}
+        extra = spec.get("additionalProperties")
+        extra = extra if isinstance(extra, Mapping) else None
+        if nested or extra:
+            return {
+                k: _coerce_by_property(v, nested.get(k, extra), depth + 1, repair)
+                for k, v in value.items()
+            }
+    elif declared == "array" and isinstance(value, list):
+        items = spec.get("items")
+        prefix = items if isinstance(items, list) else spec.get("prefixItems")
+        if isinstance(prefix, list):
+            # A schema per position: draft-07 tuple `items`, 2020-12 `prefixItems`.
+            rest = spec.get("additionalItems") if isinstance(items, list) else items
+            return [
+                _coerce_by_property(v, prefix[i] if i < len(prefix) else rest, depth + 1, repair)
+                for i, v in enumerate(value)
+            ]
+        if isinstance(items, Mapping):
+            return [_coerce_by_property(v, items, depth + 1, repair) for v in value]
+    return value
 
 
 def coerce_arguments_by_schema(
@@ -597,18 +628,12 @@ def coerce_arguments_by_schema(
 
     A tool-call parser is given tool NAMES, never schemas, so an XML-form parameter is stored
     as raw text: ``replace_all`` reaches the tool as ``"false"``, and ``bool("false")`` is
-    True. A declared string is returned untouched, as is any value no single type resolves
-    for -- a schema composing, referencing or branching where this does not read, or a
-    genuine either/or. An already-typed value is untouched. A value that will not convert
-    keeps its raw string, leaving the tool to report what is
-    wrong rather than ending here.
-
-    A scalar's text carries no type, so it is read only where its spelling names the declared
-    type and nothing else could have been meant.
+    True. A container's text IS its JSON; a scalar's carries no type, so it is read only
+    where its spelling names the declared type. Anything else keeps its text.
     """
     if not isinstance(properties, Mapping) or not properties:
         return dict(arguments)
-    return {k: _coerce_one_property(v, properties.get(k), repair) for k, v in arguments.items()}
+    return {k: _coerce_by_property(v, properties.get(k), 0, repair) for k, v in arguments.items()}
 
 
 def _declared_properties(tool_name: str, tool_schemas) -> Any:

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import copy
 import json
+import math
 from dataclasses import dataclass, field
 from typing import Any, Collection, Literal, Mapping, Sequence
 from urllib.parse import urlparse
@@ -345,6 +346,198 @@ def canonical_tool_call_key(tool_name: str, arguments: Mapping[str, Any]) -> str
     return f"{tool_name}:{canonical_args}"
 
 
+# `_edit_file_replace_all`'s words, minus the empty string, which is an absent value rather
+# than a boolean one. That tool still reads its own "" as false.
+# "0" and "1" are deliberately absent: they are the only spellings with a JSON scalar
+# counterpart, and a native `0` for the same parameter arrives already typed and is left
+# alone, so reading them would make one argument mean different things in the two call
+# syntaxes. `edit_file` still reads them, for its own parameter, where no such pair exists.
+_SCHEMA_TRUE_WORDS = frozenset({"true", "yes"})
+_SCHEMA_FALSE_WORDS = frozenset({"false", "no"})
+# What this walk follows to find a declaration. `nullable` is OpenAPI 3.0's spelling of a
+# type union, which several MCP servers still generate.
+_READ_KEYWORDS = frozenset(
+    {
+        "type",
+        "nullable",
+        "properties",
+        "items",
+        "prefixItems",
+        "additionalItems",
+        "additionalProperties",
+    }
+)
+# Cannot move a declaration out of reach: annotations, and constraints that only reject.
+_INERT_KEYWORDS = frozenset(
+    {
+        "title",
+        "description",
+        "default",
+        "examples",
+        "example",
+        "deprecated",
+        "readOnly",
+        "writeOnly",
+        "format",
+        "$comment",
+        "$schema",
+        "$id",
+        "$anchor",
+        "$defs",
+        "definitions",
+        "enum",
+        "const",
+        "required",
+        "dependentRequired",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "minLength",
+        "maxLength",
+        "pattern",
+        "minItems",
+        "maxItems",
+        "uniqueItems",
+        "minContains",
+        "maxContains",
+        "minProperties",
+        "maxProperties",
+    }
+)
+_UNION_KEYWORDS = frozenset({"anyOf", "oneOf"})
+# Matched exactly: an unknown type name is as unreadable as an unknown keyword.
+_JSON_SCHEMA_TYPES = frozenset(
+    {
+        "array",
+        "boolean",
+        "integer",
+        "null",
+        "number",
+        "object",
+        "string",
+    }
+)
+_KNOWN_KEYWORDS = _READ_KEYWORDS | _INERT_KEYWORDS | _UNION_KEYWORDS
+
+
+def _readable(spec: Any) -> bool:
+    """An allowlist, because composition, reference and a later draft's keywords can all move
+    a declaration out of this walk's reach."""
+    return isinstance(spec, Mapping) and spec.keys() <= _KNOWN_KEYWORDS
+
+
+def _read_schema(spec: Any) -> "tuple[Any, str | None, bool]":
+    """The subschema to read against, its one declared type, and whether it admits null;
+    ``(None, ...)`` leaves it alone. A union collapses to its single non-null branch, so
+    every branch must name one: reading the integer branch of ``anyOf: [{integer}, {$ref}]``
+    would turn ``"001"`` into 1."""
+    if not _readable(spec):
+        return None, None, False
+    union = _UNION_KEYWORDS & spec.keys()
+    if union and (len(union) > 1 or not _READ_KEYWORDS.isdisjoint(spec)):
+        return None, None, False
+    kind = spec.get("type")
+    chosen = spec
+    if isinstance(kind, str):
+        named = [kind]
+    elif isinstance(kind, list):
+        named = list(kind)
+    elif union:
+        branches = spec.get("anyOf") or spec.get("oneOf")
+        if not isinstance(branches, list) or not branches:
+            return None, None, False
+        named = []
+        for branch in branches:
+            name = branch.get("type") if _readable(branch) else None
+            if not isinstance(name, str) or _UNION_KEYWORDS & branch.keys():
+                return None, None, False
+            named.append(name)
+            if named[-1] != "null":
+                chosen = branch
+    elif kind is None:
+        return spec, None, False
+    else:
+        return None, None, False
+    if not named or not all(isinstance(name, str) and name in _JSON_SCHEMA_TYPES for name in named):
+        return None, None, False
+    if chosen.get("nullable") is True:
+        named.append("null")
+    rest = [k for k in named if k != "null"]
+    if len(rest) > 1 or (not rest and "null" not in named):
+        return None, None, False
+    return chosen, rest[0] if rest else None, "null" in named
+
+
+def _coerce_declared_value(text: str, declared: str) -> Any:
+    stripped = text.strip()
+    if declared == "boolean":
+        lowered = stripped.lower()
+        if lowered in _SCHEMA_TRUE_WORDS:
+            return True
+        if lowered in _SCHEMA_FALSE_WORDS:
+            return False
+    elif declared in ("integer", "number"):
+        try:
+            # float() would round 9007199254740993, which an already-numeric argument keeps.
+            return int(stripped)
+        except ValueError:
+            pass
+        try:
+            number = float(stripped)
+        except (ValueError, OverflowError):
+            return text
+        # "nan"/"inf" parse, but json.dumps writes them bare and the client rejects that.
+        # Exactness is unguarded: float64 IS JSON's number type, so a JSON call agrees.
+        if math.isfinite(number) and (declared == "number" or number.is_integer()):
+            return number
+    return text
+
+
+def _coerce_one_property(value: Any, spec: Any) -> Any:
+    """One value read against its property schema."""
+    spec, declared, nullable = _read_schema(spec)
+    if spec is None or not isinstance(value, str):
+        return value
+    if declared == "string":
+        return value
+    if nullable and value.strip().lower() == "null":
+        return None
+    if declared is None:
+        return value
+    return _coerce_declared_value(value, declared)
+
+
+def coerce_arguments_by_schema(arguments: Mapping[str, Any], properties: Any) -> dict:
+    """Arguments with each string value that declares a non-string type read as that type.
+
+    A tool-call parser is given tool NAMES, never schemas, so an XML-form parameter is stored
+    as raw text: ``replace_all`` reaches the tool as ``"false"``, and ``bool("false")`` is
+    True. A declared string is returned untouched, as is any value no single type resolves
+    for -- a schema composing, referencing or branching where this does not read, or a
+    genuine either/or. An already-typed value is untouched. A value that will not convert
+    keeps its raw string, leaving the tool to report what is
+    wrong rather than ending here.
+
+    A scalar's text carries no type, so it is read only where its spelling names the declared
+    type and nothing else could have been meant.
+    """
+    if not isinstance(properties, Mapping) or not properties:
+        return dict(arguments)
+    return {k: _coerce_one_property(v, properties.get(k)) for k, v in arguments.items()}
+
+
+def _declared_properties(tool_name: str, tool_schemas) -> Any:
+    for tool in tool_schemas or []:
+        function = tool.get("function") if isinstance(tool, Mapping) else None
+        if not isinstance(function, Mapping) or function.get("name") != tool_name:
+            continue
+        parameters = function.get("parameters")
+        return parameters.get("properties") if isinstance(parameters, Mapping) else None
+    return None
+
+
 def coerce_tool_arguments(
     raw_args: Any,
     *,
@@ -352,14 +545,20 @@ def coerce_tool_arguments(
     tool_name: str = "",
     tool_schemas = None,
 ) -> CoercedArguments:
-    """Normalize model-emitted ``function.arguments`` to a dictionary."""
+    """Normalize model-emitted ``function.arguments`` to a dictionary.
+
+    Typing against ``tool_schemas`` is not gated on ``heal``: healing invents structure the
+    model never sent, while reading a value as its own schema declares it is the tool's
+    contract, and gating it would return `bool("false")` to auto-heal-off users.
+    """
+    properties = _declared_properties(tool_name, tool_schemas) if tool_name else None
     if isinstance(raw_args, Mapping):
-        return CoercedArguments(dict(raw_args), False)
+        return CoercedArguments(coerce_arguments_by_schema(raw_args, properties), False)
     if isinstance(raw_args, str):
         try:
             parsed = json.loads(raw_args)
             if isinstance(parsed, Mapping):
-                return CoercedArguments(dict(parsed), False)
+                return CoercedArguments(coerce_arguments_by_schema(parsed, properties), False)
         except (json.JSONDecodeError, ValueError):
             pass
         if heal:

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -1519,3 +1519,59 @@ class TestHealerSignalAlignment:
         (call,) = _events_calls(events)
         assert call["function"]["name"] == "web_search"
         assert healer.healed
+
+
+# --- client-supplied tool schemas -------------------------------------------------------
+# A coding agent on `unsloth start` declares its own tools, so schemas live in the request.
+
+
+def _client_tool(name, properties):
+    return {
+        "type": "function",
+        "function": {"name": name, "parameters": {"type": "object", "properties": properties}},
+    }
+
+
+GREP_TOOL = _client_tool(
+    "Grep",
+    {
+        "pattern": {"type": "string"},
+        "multiline": {"type": "boolean"},
+        "head_limit": {"type": "integer"},
+        "timeout": {"type": "integer"},
+    },
+)
+# Spells `timeout` the other way, so neither call reads through the other tool's schema.
+FETCH_TOOL = _client_tool("WebFetch", {"url": {"type": "string"}, "timeout": {"type": "string"}})
+CLIENT_TOOLS = [FETCH_TOOL, GREP_TOOL]
+CLIENT_NAMES = {"WebFetch", "Grep"}
+
+
+def _healed_arguments(content):
+    msg = {"role": "assistant", "content": content}
+    assert heal_openai_message(msg, CLIENT_NAMES, CLIENT_TOOLS) is True
+    (call,) = msg["tool_calls"]
+    return json.loads(call["function"]["arguments"])
+
+
+class TestClientToolSchemaTyping:
+    def test_xml_parameters_arrive_as_their_declared_types(self):
+        """Both spell "false": the declared flag becomes a boolean, the search text stays text."""
+        arguments = _healed_arguments(
+            "<function=Grep>"
+            "<parameter=pattern>false</parameter>"
+            "<parameter=head_limit>25</parameter>"
+            "<parameter=multiline>false</parameter>"
+            "</function>"
+        )
+        assert arguments == {"pattern": "false", "head_limit": 25, "multiline": False}
+
+    def test_each_call_is_typed_through_its_own_tools_schema(self):
+        """One key, two declarations: `timeout` is milliseconds on Grep and a duration
+        string on WebFetch. A schema picked by position, or merged across the request, has
+        one answer for both keys and so reads one of these calls wrong."""
+        call = (
+            "<function=%s><parameter=%s>x</parameter><parameter=timeout>30</parameter></function>"
+        )
+        assert _healed_arguments(call % ("WebFetch", "url")) == {"url": "x", "timeout": "30"}
+        assert _healed_arguments(call % ("Grep", "pattern")) == {"pattern": "x", "timeout": 30}

--- a/studio/backend/tests/test_tool_loop_controller.py
+++ b/studio/backend/tests/test_tool_loop_controller.py
@@ -17,11 +17,14 @@ from core.inference.tool_loop_controller import (
     ToolLoopController,
     append_deferred_nudges,
     canonical_tool_call_key,
+    coerce_arguments_by_schema,
     coerce_tool_arguments,
     status_for_tool,
     strip_result_for_model,
     tool_event_provenance,
 )
+from core.inference.tool_call_parser import parse_tool_calls_from_text
+from core.inference.tools import ALL_TOOLS, _mcp_specs_for_server
 
 
 def test_append_deferred_nudges_merges_deduped_into_one_message():
@@ -278,3 +281,72 @@ def test_strip_result_for_model_removes_frontend_image_sentinel():
     assert strip_result_for_model('text\n__IMAGES__:{"paths":[]}') == "text"
     assert strip_result_for_model("text __IMAGES__:payload") == "text"
     assert strip_result_for_model("plain text") == "plain text"
+
+
+# --- schema-aware argument typing -------------------------------------------------------
+
+_MCP_SERVER = {"id": "notes", "display_name": "Notes"}
+_MCP_TOOL = {
+    "name": "search",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "limit": {"type": "integer"},
+            "fuzzy": {"type": "boolean"},
+            "depth": {"type": ["integer", "null"]},
+        },
+    },
+}
+_MCP_PROPS = _MCP_TOOL["inputSchema"]["properties"]
+_UNCHANGED = object()
+
+
+def _mcp_tool_schemas():
+    return _mcp_specs_for_server(_MCP_SERVER, [_MCP_TOOL])
+
+
+def _coerce_one(key, value, props):
+    return coerce_arguments_by_schema({key: value}, props)[key]
+
+
+@pytest.mark.parametrize(
+    "key, text, expected",
+    [
+        ("fuzzy", " False ", False),
+        ("limit", "25", 25),
+        ("limit", "9007199254740993", 9007199254740993),  # float() would round this
+        ("depth", "null", None),
+        ("fuzzy", "null", _UNCHANGED),  # null is not a boolean; None would mean False
+    ],
+)
+def test_a_value_reads_as_the_type_its_schema_declares(key, text, expected):
+    got = _coerce_one(key, text, _MCP_PROPS)
+    want = text if expected is _UNCHANGED else expected
+    # Types too: `False == 0` and `25 == 25.0`, so equality alone would miss a swap.
+    assert got == want and type(got) is type(want)
+    seam = coerce_tool_arguments(
+        json.dumps({key: text}),
+        heal = False,
+        tool_name = "mcp__notes__search",
+        tool_schemas = _mcp_tool_schemas(),
+    )
+    assert seam.arguments[key] == want and seam.healed is False
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        # The walk stops on any keyword it does not follow, whichever one it is.
+        {"type": "boolean", "$ref": "#/$defs/Flag"},
+        # Collapsing a union discards the rest, so it is read only where it is all there is.
+        {"anyOf": [{"type": "boolean"}], "properties": {"x": {"type": "boolean"}}},
+    ],
+)
+def test_a_schema_this_walk_cannot_read_is_left_alone(spec):
+    assert _coerce_one("f", "false", {"f": spec}) == "false"
+    assert _coerce_one("f", "null", {"f": {"anyOf": [spec, {"type": "null"}]}}) == "null"
+    # Falsified so the refusal cannot swallow real schemas: `nullable` spells a type union.
+    annotated = {"type": "boolean", "title": "F", "enum": [False]}
+    assert _coerce_one("f", "false", {"f": annotated}) is False
+    assert _coerce_one("f", "null", {"f": {"type": "boolean", "nullable": True}}) is None

--- a/studio/backend/tests/test_tool_loop_controller.py
+++ b/studio/backend/tests/test_tool_loop_controller.py
@@ -399,3 +399,23 @@ def test_an_mcp_tool_call_parsed_from_xml_arrives_typed():
     assert decision.as_assistant_tool_call()["function"]["arguments"] == (
         '{"depth":null,"fuzzy":false,"limit":25,"query":"ship dates","tags":["a","b"]}'
     )
+
+
+def test_a_declared_type_nested_in_a_container_is_read_too():
+    """`edit_file` declares replace_all inside `edits.items`, so the top level is not enough
+    and text that spells a boolean must survive as text."""
+    edits = (
+        '[{"old_string":"a","new_string":"b","replace_all":"false"},'
+        '{"old_string":"false","new_string":"null","replace_all":"true"}]'
+    )
+    edit_file = next(t for t in ALL_TOOLS if t["function"]["name"] == "edit_file")
+    props = edit_file["function"]["parameters"]["properties"]
+    typed = [
+        {"old_string": "a", "new_string": "b", "replace_all": False},
+        {"old_string": "false", "new_string": "null", "replace_all": True},
+    ]
+    call = {"path": "app.py", "edits": edits}
+    assert coerce_arguments_by_schema(call, props) == {"path": "app.py", "edits": typed}
+    # An already-typed container is descended into too: its elements can still be text.
+    call = {"path": "app.py", "edits": json.loads(edits)}
+    assert coerce_arguments_by_schema(call, props) == {"path": "app.py", "edits": typed}

--- a/studio/backend/tests/test_tool_loop_controller.py
+++ b/studio/backend/tests/test_tool_loop_controller.py
@@ -294,6 +294,7 @@ _MCP_TOOL = {
             "query": {"type": "string"},
             "limit": {"type": "integer"},
             "fuzzy": {"type": "boolean"},
+            "tags": {"type": "array", "items": {"type": "string"}},
             "depth": {"type": ["integer", "null"]},
         },
     },
@@ -316,6 +317,7 @@ def _coerce_one(key, value, props):
         ("fuzzy", " False ", False),
         ("limit", "25", 25),
         ("limit", "9007199254740993", 9007199254740993),  # float() would round this
+        ("tags", "('a', 'b')", ["a", "b"]),
         ("depth", "null", None),
         ("fuzzy", "null", _UNCHANGED),  # null is not a boolean; None would mean False
     ],
@@ -350,3 +352,50 @@ def test_a_schema_this_walk_cannot_read_is_left_alone(spec):
     annotated = {"type": "boolean", "title": "F", "enum": [False]}
     assert _coerce_one("f", "false", {"f": annotated}) is False
     assert _coerce_one("f", "null", {"f": {"type": "boolean", "nullable": True}}) is None
+
+
+@pytest.mark.parametrize(
+    "text, repaired",
+    [
+        ('["a","b"}', ["a", "b"]),  # a closer not matching the innermost opener
+        ('["a","b\\"', ["a", 'b"']),  # an open string ending on an ESCAPED quote
+    ],
+)
+def test_a_malformed_container_is_repaired_only_when_healing(text, repaired):
+    """Rewriting brackets invents structure, which is what the auto-heal opt-out is for."""
+
+    def at_seam(heal):
+        return coerce_tool_arguments(
+            json.dumps({"tags": text}),
+            heal = heal,
+            tool_name = "mcp__notes__search",
+            tool_schemas = _mcp_tool_schemas(),
+        ).arguments["tags"]
+
+    assert at_seam(True) == repaired
+    assert at_seam(False) == text
+
+
+def test_an_mcp_tool_call_parsed_from_xml_arrives_typed():
+    content = (
+        "<function=mcp__notes__search>"
+        "<parameter=query>ship dates</parameter>"
+        "<parameter=limit>25</parameter>"
+        "<parameter=fuzzy>false</parameter>"
+        '<parameter=tags>["a","b"]</parameter>'
+        "<parameter=depth>null</parameter>"
+        "</function>"
+    )
+    calls = parse_tool_calls_from_text(content)
+    decision = ToolLoopController(tools = _mcp_tool_schemas()).prepare_call(calls[0])
+    assert decision.arguments == {
+        "query": "ship dates",
+        "limit": 25,
+        "fuzzy": False,
+        "tags": ["a", "b"],
+        "depth": None,
+    }
+    # The turn replayed to the model carries the typed values too, not the strings.
+    assert decision.as_assistant_tool_call()["function"]["arguments"] == (
+        '{"depth":null,"fuzzy":false,"limit":25,"query":"ship dates","tags":["a","b"]}'
+    )


### PR DESCRIPTION
## What breaks today

A tool-call parser is handed tool *names*, never schemas, so a call written in XML form stores every parameter as the raw text between the tags. `<parameter=replace_all>false</parameter>` reaches the tool as the string `"false"`, and `bool("false")` is `True`.

This repository already documents the consequence, in `_edit_file_replace_all`:

> `bool("false")` is True, and models do emit the JSON string. Coercing it that way turns the multi-match guard off and rewrites every occurrence.

That guard, and `_opt_int` beside it, fix the two built-ins where the failure was noticed. MCP tools and client-supplied tools get no such defense, so the same text reaches them untyped. The failure direction is the problem: a model that correctly writes "don't do the destructive thing" gets the destructive thing, because the false-y spelling is truthy.

Containers fail differently and more visibly. A declared `array` or `object` written as text arrives as a string, which any argument-validating server rejects outright, so the call simply errors. Driving a real MCP server over HTTP with a call a local model actually wrote:

```text
== the model wrote ==
<function=mcp__flagcheck__set_flag_raw><parameter=enabled>false</parameter><parameter=retries>3</parameter><parameter=note>nightly run</parameter><parameter=tags>["release", "mlx"]</parameter></function>

== a tool that does not validate its arguments receives ==
{"enabled": ["str", "false"], "retries": ["str", "3"], "tags": ["str", "[\"release\", \"mlx\"]"]}

== a typed tool receives ==
Error: 1 validation error for call[set_flag]
tags  Input should be a valid list [type=list_type, input_value='["release", "mlx"]', input_type=str]
```

The turn replayed back to the model carries the same strings, so the model is taught its own untyped output.

## What changed

`coerce_tool_arguments` already received `tool_schemas`, but used them only to guess a single argument name when healing. It now reads each argument against the type its schema declares, at both seams that build arguments for a tool: the tool-loop controller and the client-tool passthrough.

The invariant the change is built around, and the one the tests assert:

> An argument written as text reaches the tool as what the same argument sent as native JSON would, typed as far as the schema readably declares and no further.

That is claimed for containers, because a container's text *is* its JSON. It is not claimed for scalars: a scalar's text carries no type, so a scalar is read only where its spelling names the declared type and nothing else could have been meant.

After the change, both tools above receive `False`, `3`, and `["release", "mlx"]`, and the replayed turn carries the typed values.

## What is deliberately not read

A schema is read only when every keyword in it is one this walk follows or one that cannot move a declaration out of its reach. It is an allowlist, not a blacklist, because composition, conditionals and reference are open-ended — `allOf`, `$ref`, `patternProperties`, `if`/`then`/`else`, `unevaluated*`, a vendor extension, whatever a later draft adds. An unrecognized keyword leaves the value exactly as it arrived, which is what it would have been anyway.

Specific consequences worth knowing:

- A union collapses to its single non-null branch, and that branch is what is read — this is the shape Pydantic emits for `Optional[bool]`, and so what every FastMCP server publishes. A union standing beside any other declaration is not read, because collapsing would discard what the wrapper said.
- `Optional[Model]` puts a `$ref` in the branch, which is not resolved, so nested Pydantic models stay untyped. This is the narrowest point of the change's reach and the natural follow-up.
- `nullable: true` is read as the type union OpenAPI 3.0 spells with it, since several MCP servers are generated from that.
- `"0"` and `"1"` are **not** read as booleans. They are the only boolean spellings with a JSON scalar counterpart, and a native `0` for the same parameter arrives already typed and is left alone, so reading them would make one argument mean two things depending on which call syntax the model used.
- A value that will not convert keeps its raw string, leaving the tool to report what is wrong with it rather than the coercion layer ending the turn.

Typing is not gated on auto-heal: healing invents structure the model never sent, whereas reading a value as its own schema declares it is the tool's contract, and gating it would hand `bool("false")` back to anyone who turned auto-heal off. Closing a truncated container *is* inventing structure, so that part does follow the setting.

## Risk

The change reads values that previously passed through untouched, so a tool that was quietly relying on receiving a string for a parameter its own schema declares as a boolean, integer or container would see a different type. That is the defect being fixed rather than a compatibility surface, but it is the behavior change to look at.

Containers are converted only when the decoded value survives an exact round trip through the JSON encoding the replay and passthrough paths use. Both decoders admit things `json.dumps` will not write back — sets and bytes raise, `1e400` emits a bare `Infinity`, an integer key returns as a string key — and a tool acting on a value the replay and the client never see would be worse than the raw text.

Descent into converted containers is bounded at 8 levels, since a schema is model-facing data and its nesting is not trusted to be shallow.

Repairing a container the model left unbalanced rewrites brackets it did not write, so it happens only under auto-heal and only for a parameter whose schema declares a container. Reading a value the model wrote whole is not gated that way.

One case is knowingly left open, and it is not introduced by the coercion: an integer above 2^53 reaches the browser as a JSON number, so the confirmation card renders it rounded while execution uses the exact value. A native JSON call already does this today, and after this change a text-form call does too, since both produce a byte-identical `tool_start` event. The fix belongs in how large integers cross that boundary rather than in whether the argument is typed, since declining to type them would hand a tool that declares `int64` a string for ordinary values like snowflake ids and nanosecond timestamps.
## Validation

```bash
python -m pytest tests/test_tool_loop_controller.py tests/test_passthrough_healing.py -q
```

The suite covers both the seams users actually hit: an MCP-registered tool driven end to end from XML text through the parser and the controller, and a client-supplied tool through the passthrough healer, including per-tool schema resolution where two tools declare the same key differently.

Beyond the suite, out of tree: an identity sweep asserting the coercion is the identity on well-formed arguments across every built-in schema, an MCP-shaped spec and a Pydantic-generated one; the exhaustive keyword, union, spelling and round-trip matrices; a falsification pass showing the refusals do not reject legitimate input, against real numbers and real schemas; a 59-mutant battery in which every mutant is killed except one proved equivalent; and the live MCP run quoted above, driven with text a local model produced rather than hand-written.

