### PR TITLE
Studio: fix unscrollable model dropdowns on the export page

### DIFF
--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -1141,7 +1141,7 @@ export function ExportPage() {
                                       No models found
                                     </ComboboxEmpty>
                                   )}
-                                  <ComboboxList className="p-1 !max-h-none !overflow-visible">
+                                  <ComboboxList>
                                     {(id: string) => (
                                       <ComboboxItem
                                         key={id}
@@ -1254,7 +1254,7 @@ export function ExportPage() {
                                     No local models found
                                   </ComboboxEmpty>
                                 )}
-                                <ComboboxList className="p-1 !max-h-none !overflow-visible">
+                                <ComboboxList>
                                   {(id: string) => {
                                     const model = localMetaById.get(id);
                                     const source =


### PR DESCRIPTION
## Impact

On the Export page, the model dropdowns cannot be scrolled. Every option past the height of the popup is rendered but unreachable — by mouse wheel, by scrollbar, and by keyboard. This affects the **Local Model** and **Hugging Face** source tabs.

The severity scales with how many models a user has, and it is invisible on a small machine. With a populated Hugging Face cache the local list renders 306 entries into a 10642px list inside a 569px popup, so roughly the first sixteen models are selectable and the remaining ~290 cannot be picked at all. Users hitting this have to know and type the exact path by hand. It applies to every discovery source the list mixes together — HF cache, custom folders, and local directories.

The **Fine-tuned** tab is unaffected; it uses `Select`, not `Combobox`.
<img width="1294" height="1394" alt="图片" src="https://github.com/user-attachments/assets/263d24e9-b74f-4572-9f23-4292a07a163e" />

## Root cause

`ComboboxList` owns the bounded scroll container for the popup:

```
no-scrollbar max-h-[min(calc(--spacing(72)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto p-1 data-empty:p-0 overflow-y-auto overscroll-contain
```

Both export call sites passed `className="p-1 !max-h-none !overflow-visible"`, which defeats exactly the two declarations that make it work. The list then grows to full content height with no scrollable ancestor, and the `ComboboxContent` popup that wraps it is `overflow-hidden` — so the overflow is clipped rather than scrolled, with nothing able to bring it back into view.

Measured on the Local Model Path dropdown with 306 cached models:

| | before | after |
|---|---|---|
| list `max-height` | `none` | `252px` |
| list `overflow-y` | `visible` | `auto` |
| clientHeight / scrollHeight | 10642 / 10642 | 252 / 10642 |
| max `scrollTop` | **0** | **10390** |

The `p-1` in the override was redundant — the base already applies `p-1` plus `data-empty:p-0` — so dropping the whole `className` restores the component's own behavior without changing padding.

## What changed

Two lines, both removing the override so the shared component's scroll container applies:

```diff
-<ComboboxList className="p-1 !max-h-none !overflow-visible">
+<ComboboxList>
```

This matches every other `ComboboxList` call site in the frontend; these two were the only ones overriding the contract, and the only occurrences of `!max-h-none` or `!overflow-visible` anywhere in `studio/frontend`.

## Notes for reviewers

**This is not a regression.** It has been present since the feature was introduced in #4365. At that commit's parent, `ComboboxList` already carried `max-h`/`overflow-y-auto` and `ComboboxContent` already carried `overflow-hidden`, and `export-page.tsx` contained no `Combobox` at all — so there is no earlier working revision to bisect to. The override was in the very first written form of both call sites and has not been touched since.

That PR also included a "fix selector ring clipping" change, which is the likely origin: it added `overflow-visible` to the two wrapper `div`s around the inputs, where a focus ring genuinely is clipped. **Those wrappers are deliberately left untouched here.** The override on the list could not have served that purpose anyway — the popup above it is `overflow-hidden`, so anything escaping the list is still clipped one level up, and `ComboboxItem` is `outline-hidden` and highlights with a background fill, so there is no ring on list items to clip.

**Behavior change worth a look:** the popup is now 252px instead of consuming all available height, so about 7 options are visible at once instead of 16. 252px is the shared cap used by every other combobox in Studio, so this aligns the export page with the rest of the app — but if a taller list is wanted here, the right lever is raising `max-h` while keeping `overflow-y-auto`, not removing the scroll container.

## Validation

Verified in a running Studio instance against a real Hugging Face cache, comparing the same build with and without the change:

- Local Model Path, 306 models: DOM measurements above; wheel scrolling confirmed reaching the end of the list.
- Hugging Face model search, 48 results for `qwen`: `clientHeight` 252, `scrollHeight` 1676, `overflow-y: auto`, max `scrollTop` 1424.
- Fine-tuned tab confirmed unaffected — all four `SelectContent` usages on the page are bare, and the select viewport carries its own `overflow-y-auto`.

Static checks:

```bash
npx tsc -b --pretty false          # exit 0
npx biome check src/features/export/export-page.tsx
```

`biome` reports 1 error and 20 warnings on this file, identical to the same command on `main` — all pre-existing, none introduced.

No test is added. The frontend suite is `node --test` over `tests/**/*.test.ts` with no DOM or component harness, so the only expressible assertion would be a source-text check for the absence of a class name, which is weaker than the measurements above and brittle against refactors.
