### PR TITLE
Re-check whisper after the llama phase, so it stops raising a second banner

### DIFF
--- a/studio/backend/tests/test_combined_update.py
+++ b/studio/backend/tests/test_combined_update.py
@@ -737,3 +737,79 @@ def test_chained_progress_windows(monkeypatch, tmp_path):
     assert seen["at_whisper_start"] == pytest.approx(0.7)
     assert seen["mid_whisper"] == pytest.approx(0.7 + 0.5 * 0.3)
     assert job["progress"] == 1.0
+
+
+def test_whisper_is_rechecked_after_the_llama_phase(monkeypatch, tmp_path):
+    """A llama update can be what makes a whisper update visible in the first place.
+
+    The job plans every phase before any of them runs, so whisper is judged against the
+    llama build about to be replaced. Without a re-check the pair is discovered by the
+    next poll instead, which raises a second banner for whisper.cpp seconds after the
+    llama one: the two popups the single update item exists to avoid.
+    """
+    calls = {"plan": 0, "install": 0}
+
+    def plan(**kwargs):
+        calls["plan"] += 1
+        # Re-planned after the llama phase, so it must not still be claiming the
+        # llama update is pending.
+        assert kwargs.get("paired_llama_will_update") is False
+        assert kwargs.get("force_refresh") is True
+        return {"update_available": True, "skip_reason": None, "phase": {"install_dir": "d"}}
+
+    monkeypatch.setattr(wupd, "chained_phase_plan", plan)
+    monkeypatch.setattr(
+        wupd,
+        "run_chained_phase",
+        lambda phase, set_progress: calls.__setitem__("install", calls["install"] + 1)
+        or {"to_tag": "v1.9.2-unsloth.12"},
+    )
+
+    result = wupd.run_chained_phase_after_llama(lambda _f: None)
+
+    assert calls == {"plan": 1, "install": 1}
+    assert result["to_tag"] == "v1.9.2-unsloth.12"
+
+
+@pytest.mark.parametrize(
+    "plan",
+    [
+        {"update_available": False, "skip_reason": "up_to_date", "phase": None},
+        {"update_available": False, "skip_reason": "paired_llama_unavailable", "phase": None},
+        {"update_available": True, "skip_reason": None, "phase": None},
+    ],
+)
+def test_the_recheck_is_a_no_op_when_there_is_nothing_to_install(monkeypatch, plan):
+    """Including the case the old code could not reach: no compatible whisper release
+    for the llama that was just installed. Reported as a skip carrying the reason, so
+    the breakdown reads the same as a skip decided before the job started."""
+    monkeypatch.setattr(wupd, "chained_phase_plan", lambda **_kw: plan)
+
+    def must_not_run(*_a, **_kw):
+        raise AssertionError("nothing to install, so the installer must not be called")
+
+    monkeypatch.setattr(wupd, "run_chained_phase", must_not_run)
+
+    result = wupd.run_chained_phase_after_llama(lambda _f: None)
+    assert result["skipped"] is True
+    assert result["skip_reason"] == (plan["skip_reason"] or "up_to_date")
+
+
+def test_the_recheck_is_not_scheduled_when_the_whisper_probe_failed(monkeypatch, tmp_path):
+    """The re-check must not resurrect a probe that already failed.
+
+    _whisper_chain_status returns None when the piggyback is unavailable, which the
+    planner flattens to an empty plan. Scheduling a re-check on that would re-import the
+    module the probe just failed on, undoing the fail-open that keeps a broken whisper
+    from taking a llama update down with it.
+    """
+    llama_dir = _setup_llama(monkeypatch, tmp_path)
+    monkeypatch.setattr(upd, "_whisper_chain_status", lambda **kw: None)
+    _patch_llama_installer(
+        monkeypatch, on_start = lambda cmd: _write_llama_install(llama_dir, "b9518")
+    )
+
+    assert upd.start_update()["started"] is True
+    job = _wait_for_job()
+    assert job["state"] == "success", job
+    assert job["phases"]["whisper"]["state"] == "skipped"

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -1166,6 +1166,17 @@ def _start_llama_job(backend_request: Optional[str] = None) -> dict:
                 if whisper_spec.get("repair")
                 else (lambda set_progress: _whisper.run_chained_phase(whisper_spec, set_progress))
             )
+        elif backend_request is None and llama_spec is not None and whisper_plan:
+            # Whisper looked up to date, but that was measured against the llama build
+            # about to be replaced. Re-check once the new one is in place instead of
+            # letting the next poll raise a second banner for whisper.cpp seconds after
+            # this job finishes. It reports a skip when there is nothing to do.
+            #
+            # Only when the probe produced a plan: an empty one means the piggyback is
+            # disabled or the probe failed, and re-importing the module there would undo
+            # the fail-open that keeps a broken whisper from touching a llama update.
+            from utils import whisper_cpp_update as _whisper
+            whisper_run = _whisper.run_chained_phase_after_llama
 
         phases = [
             {
@@ -1212,8 +1223,11 @@ def _start_llama_job(backend_request: Optional[str] = None) -> dict:
         ]
         running = " + ".join(
             name
-            for name, spec in (("llama.cpp", llama_spec), ("whisper.cpp", whisper_spec))
-            if spec
+            for name, present in (
+                ("llama.cpp", llama_spec is not None),
+                ("whisper.cpp", whisper_run is not None),
+            )
+            if present
         )
         if backend_request is not None and llama_spec is not None:
             starting_message = f"Installing the {backend_request} llama.cpp build..."

--- a/studio/backend/utils/prebuilt/update_flow.py
+++ b/studio/backend/utils/prebuilt/update_flow.py
@@ -495,12 +495,22 @@ def run_chained_update(phases: list[dict], *, job: dict, job_lock: threading.Loc
         set_progress(1.0)
         offset += weight
         with job_lock:
-            job["phases"][name].update(
-                state = PHASE_SUCCESS,
-                to_tag = result.get("to_tag"),
-                reload_required = result.get("reload_required"),
-                message = result.get("message") or "",
-            )
+            if result.get("skipped"):
+                # A phase that can only decide there is nothing to do once the phases
+                # before it have run. Reported as skipped, with its reason, rather than
+                # as a success with no message, so the breakdown reads the same whether
+                # the decision was made at planning time or here.
+                job["phases"][name].update(
+                    state = PHASE_SKIPPED,
+                    reason = result.get("skip_reason") or "up_to_date",
+                )
+            else:
+                job["phases"][name].update(
+                    state = PHASE_SUCCESS,
+                    to_tag = result.get("to_tag"),
+                    reload_required = result.get("reload_required"),
+                    message = result.get("message") or "",
+                )
         if result.get("message"):
             done_messages.append(result["message"])
         # Only phases affecting the primary (llama) server may raise the job-level

--- a/studio/backend/utils/whisper_cpp_update.py
+++ b/studio/backend/utils/whisper_cpp_update.py
@@ -594,6 +594,28 @@ def chained_phase_plan(
     return plan
 
 
+def run_chained_phase_after_llama(set_progress) -> dict:
+    """Re-plan whisper AFTER the llama phase, then install if it is now behind.
+
+    The job's phases are planned before any of them run, so whisper is judged against
+    the OLD llama. A llama update that first makes a newer whisper available, or that
+    first makes one pairable, is therefore invisible at planning time and surfaces
+    afterwards as a SECOND update banner for whisper.cpp, moments after the llama one.
+    Re-planning here keeps the pair in the single job the update item promises.
+
+    ``paired_llama_will_update`` is False because by now it already has, so the plan
+    consults the installer's resolver and skips cleanly when no compatible whisper
+    release exists rather than attempting an install that cannot succeed. Nothing to do
+    is reported as a skip carrying the plan's reason, so the phase breakdown reads the
+    same as it did when the decision was made before the job started.
+    """
+    plan = chained_phase_plan(force_refresh = True, paired_llama_will_update = False)
+    phase = plan.get("phase")
+    if not plan.get("update_available") or phase is None:
+        return {"skipped": True, "skip_reason": plan.get("skip_reason") or "up_to_date"}
+    return run_chained_phase(phase, set_progress)
+
+
 def run_chained_phase(phase: dict, set_progress) -> dict:
     """Run the whisper phase of a combined update (spec from chained_phase_plan):
     same unload/install/cache-refresh path as the standalone job, reporting


### PR DESCRIPTION
## The two popups

`routes/llama.py` calls itself "the single main update item" and `POST /api/llama/update` really does chain a whisper phase. In practice you can still get two popups in a row, one for llama.cpp and then one for whisper.cpp.

The cause is ordering. The job plans every phase before any of them runs:

```python
whisper_plan = _whisper_phase_plan(
    backend_request,
    llama_will_run = llama_spec is not None,
    ...
)
```

So whisper is judged against the llama build that is about to be replaced. A llama update that is itself what makes a newer whisper available, or what first makes one pairable, is invisible at that moment. The job finishes, the next poll sees whisper behind, and `update_component` flips:

```python
status["update_component"] = (
    "llama" if status["llama_update_available"]
    else "whisper" if whisper_update_available
    else None
)
```

The frontend reads that single value straight into its label, so the same banner reappears naming whisper.cpp seconds after the llama one. `dismiss()` is only `setVisible(false)` with no memory of which component was dismissed, so closing the first does nothing about the second.

## The change

Re-plan whisper once the new llama is in place and run it in the same job, instead of leaving it for the next poll to raise a banner about.

`paired_llama_will_update` is `False` by then, because it already did, so the plan consults the installer's read-only resolver and skips cleanly when no compatible whisper release exists rather than attempting an install that cannot succeed. That matters: the old code assumed the new llama would always supply a workable pairing, and the comment said so, but that assumption is exactly what failed while whisper stayed pinned to `b10472-mix-4b653db` and llama shipped `b10639`, `b10672`, `b10679` and `b10687`.

Behaviour after this change matches the rule the update item was written for:

| llama.cpp | whisper.cpp | result |
| --- | --- | --- |
| behind | behind | one banner, one apply, both installed |
| behind | current at plan time, behind after | one banner, one apply, whisper picked up by the re-check |
| behind | no compatible release | one banner, whisper phase skipped with a reason, no second popup |
| current | behind | whisper-only banner, which is correct and already guarded |

## Two things it deliberately preserves

**Skip reasons survive.** A phase can now report a skip from its result, not only from its plan, so the breakdown still reads `skipped: up_to_date` or `skipped: local_link` rather than degrading into a success with an empty message. Deciding later must not mean explaining less. Without this, `test_apply_llama_only_when_whisper_current` and `test_apply_skips_whisper_local_link_silently` both broke, and they were right to.

**The fail-open holds.** The re-check is scheduled only when the probe actually produced a plan. An empty one means the piggyback is disabled or the probe failed, and re-importing the module there would undo the guard that keeps a broken whisper from taking a llama update down with it. `test_llama_update_survives_unavailable_whisper_module` catches exactly that, and caught it here.

## Tests

- the re-check re-plans with `paired_llama_will_update = False` and `force_refresh = True`, then installs
- it is a no-op for `up_to_date`, `paired_llama_unavailable`, and a plan that claims an update but carries no phase, reporting a skip with the reason in each case
- it is not scheduled at all when the whisper probe failed

`test_combined_update.py` and `test_llama_backend_switch.py` are 64 passed, and the wider update surface is 3847 passed. One unrelated failure, `test_mlx_repair.py::test_install_requires_prebuilt_wheels`, fails identically without this branch: it is a local `huggingface-hub` version mismatch, not a code defect.

## Not in this PR

When both are behind, the banner still says only `llama.cpp`, even though the apply covers whisper too. Naming the union would mean changing `update_component` from a single `Literal["llama", "whisper"]` into something the frontend can render as both, which touches the status shape, the hook and the component. It is worth doing, but it is a separate change and it is cosmetic: with this fix the second popup is gone either way.
