### PR TITLE
Pre-flight whisper pairing before the chained install

### DIFF
--- a/studio/backend/tests/test_combined_update.py
+++ b/studio/backend/tests/test_combined_update.py
@@ -742,7 +742,6 @@ def test_chained_progress_windows(monkeypatch, tmp_path):
 def _slim_phase(**over):
     phase = {
         "install_dir": "d",
-        "install_kind": "slim",
         "repo": "unslothai/whisper.cpp",
         "asset": None,
         "backend": "cpu",
@@ -809,18 +808,48 @@ def test_a_workable_pairing_still_installs(monkeypatch):
     assert result == {"to_tag": "v1.9.2-unsloth.12"}
 
 
-@pytest.mark.parametrize("install_kind", ["full", None])
-def test_only_a_slim_install_is_pre_flighted(monkeypatch, install_kind):
-    """A full install carries its own ggml, so llama's build cannot strand it."""
+def test_a_legacy_fat_install_is_pre_flighted_too(monkeypatch):
+    """The pre-flight asks about the TARGET release, not the installed one.
 
-    def must_not_resolve(**_kw):
-        raise AssertionError("pairing is irrelevant to a non-slim install")
+    A fat marker omits install_kind by design (prebuilt_core: "fat markers keep the
+    legacy payload exactly"), and published releases are slim-only now. So gating the
+    pre-flight on the installed marker would skip it for exactly the host most likely
+    to be handed its first slim bundle, and that host would hit the doomed install this
+    change exists to prevent.
+    """
+    monkeypatch.setattr(
+        wupd,
+        "_resolve_prebuilt_for_host",
+        lambda **_kw: {"prebuilt_available": False, "unavailable_reason": "incompatible"},
+    )
 
-    monkeypatch.setattr(wupd, "_resolve_prebuilt_for_host", must_not_resolve)
+    def must_not_install(*_a, **_kw):
+        raise AssertionError("the install cannot succeed, so it must not be attempted")
+
+    monkeypatch.setattr(wupd, "run_chained_phase", must_not_install)
+
+    # No install_kind at all: the legacy fat marker.
+    assert wupd.run_chained_phase_after_llama(_slim_phase(), lambda _f: None) == {
+        "skipped": True,
+        "skip_reason": "paired_llama_unavailable",
+    }
+
+
+def test_a_fat_target_release_is_never_reported_incompatible(monkeypatch):
+    """Which is why probing unconditionally costs nothing in correctness.
+
+    _slim_release_incompatibility deliberately explains only a slim pairing failure, so
+    a fat target can answer available or unresolved but never incompatible, and the
+    skip below stays unreachable for it.
+    """
+    monkeypatch.setattr(
+        wupd,
+        "_resolve_prebuilt_for_host",
+        lambda **_kw: {"prebuilt_available": True, "install_kind": "fat"},
+    )
     monkeypatch.setattr(wupd, "run_chained_phase", lambda phase, _sp: {"to_tag": "v1"})
 
-    phase = _slim_phase(install_kind = install_kind)
-    assert wupd.run_chained_phase_after_llama(phase, lambda _f: None) == {"to_tag": "v1"}
+    assert wupd.run_chained_phase_after_llama(_slim_phase(), lambda _f: None) == {"to_tag": "v1"}
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_combined_update.py
+++ b/studio/backend/tests/test_combined_update.py
@@ -753,12 +753,8 @@ def _slim_phase(**over):
 
 
 def test_a_slim_pairing_gap_skips_instead_of_failing_the_job(monkeypatch):
-    """The state the pipeline was in for ten days.
-
-    chained_phase_plan waives its pairing gate when llama updates first, assuming the
-    new llama supplies a workable pairing. When no whisper release exists for it, the
-    install exits 2 and a llama update that already landed is reported as failed.
-    """
+    """The state the pipeline was in for ten days: no whisper release paired to the
+    llama being installed, so the phase exits 2 and fails a job llama already won."""
     monkeypatch.setattr(
         wupd,
         "_resolve_prebuilt_for_host",
@@ -777,10 +773,9 @@ def test_a_slim_pairing_gap_skips_instead_of_failing_the_job(monkeypatch):
 
 
 def test_the_pre_flight_probes_the_release_that_would_be_installed(monkeypatch):
-    """Not the download host's latest pointer, which sorts by commit date and can lag
-    the published_at pick the freshness check used (the #6219 class the phase pins
-    against). Probing one release and installing another can skip a valid update or
-    wave through a doomed one."""
+    """Probing one release and installing another can skip a valid update or wave
+    through a doomed one. The unpinned latest pointer sorts by commit date and can lag
+    the published_at pick the phase pins against (#6219)."""
     seen = {}
 
     def spy(**kw):
@@ -811,11 +806,9 @@ def test_a_workable_pairing_still_installs(monkeypatch):
 def test_a_legacy_fat_install_is_pre_flighted_too(monkeypatch):
     """The pre-flight asks about the TARGET release, not the installed one.
 
-    A fat marker omits install_kind by design (prebuilt_core: "fat markers keep the
-    legacy payload exactly"), and published releases are slim-only now. So gating the
-    pre-flight on the installed marker would skip it for exactly the host most likely
-    to be handed its first slim bundle, and that host would hit the doomed install this
-    change exists to prevent.
+    A fat marker omits install_kind by design ("fat markers keep the legacy payload
+    exactly"), and releases are slim-only now, so gating on the installed marker would
+    skip exactly the host about to be handed its first slim bundle.
     """
     monkeypatch.setattr(
         wupd,
@@ -836,12 +829,8 @@ def test_a_legacy_fat_install_is_pre_flighted_too(monkeypatch):
 
 
 def test_a_fat_target_release_is_never_reported_incompatible(monkeypatch):
-    """Which is why probing unconditionally costs nothing in correctness.
-
-    _slim_release_incompatibility deliberately explains only a slim pairing failure, so
-    a fat target can answer available or unresolved but never incompatible, and the
-    skip below stays unreachable for it.
-    """
+    """Why probing unconditionally costs nothing: _slim_release_incompatibility explains
+    only a slim pairing failure, so a fat target can never be reported incompatible."""
     monkeypatch.setattr(
         wupd,
         "_resolve_prebuilt_for_host",
@@ -855,9 +844,8 @@ def test_a_fat_target_release_is_never_reported_incompatible(monkeypatch):
 @pytest.mark.parametrize(
     "resolved",
     [
-        # The resolver ran and could not get an answer: --resolve-prebuilt maps an
-        # unreachable API or an unreadable manifest to exit 0 with no prebuilt, so this
-        # is what a network failure looks like, not a pairing gap.
+        # --resolve-prebuilt maps an unreachable API to exit 0 with no prebuilt, so
+        # this is what a network failure looks like, not a pairing gap.
         {"prebuilt_available": False, "unavailable_reason": "unresolved"},
         # An installer that predates unavailable_reason. Unknown, so not a gap.
         {"prebuilt_available": False},
@@ -866,13 +854,8 @@ def test_a_fat_target_release_is_never_reported_incompatible(monkeypatch):
     ],
 )
 def test_a_pre_flight_that_cannot_answer_still_attempts_the_install(monkeypatch, resolved):
-    """Fail towards the install, not the skip.
-
-    The pre-flight exists to avoid an attempt known to be doomed. One that cannot
-    answer knows nothing, so attempting keeps the previous behaviour, exit 2 included,
-    rather than silently skipping an update that would have worked and reporting a
-    pairing gap that was never established.
-    """
+    """Fail towards the install: a pre-flight that cannot answer knows nothing, and
+    skipping would report a pairing gap that was never established."""
     monkeypatch.setattr(wupd, "_resolve_prebuilt_for_host", lambda **_kw: resolved)
     monkeypatch.setattr(wupd, "run_chained_phase", lambda phase, _sp: {"to_tag": "v1"})
 
@@ -890,11 +873,8 @@ def test_a_probe_that_raises_still_attempts_the_install(monkeypatch):
 
 
 def test_an_incompatible_release_that_slips_past_the_pre_flight_still_errors(monkeypatch):
-    """The pre-flight narrows when exit 2 happens; it must not swallow it.
-
-    test_whisper_phase_exit_2_is_a_failed_phase pins that an attempted install which
-    turns out incompatible stays an actionable job error rather than a false success.
-    """
+    """The pre-flight narrows when exit 2 happens; it must not swallow it. Pinned
+    alongside test_whisper_phase_exit_2_is_a_failed_phase."""
     monkeypatch.setattr(
         wupd, "_resolve_prebuilt_for_host", lambda **_kw: {"prebuilt_available": True}
     )

--- a/studio/backend/tests/test_combined_update.py
+++ b/studio/backend/tests/test_combined_update.py
@@ -761,7 +761,9 @@ def test_a_slim_pairing_gap_skips_instead_of_failing_the_job(monkeypatch):
     install exits 2 and a llama update that already landed is reported as failed.
     """
     monkeypatch.setattr(
-        wupd, "_resolve_prebuilt_for_host", lambda **_kw: {"prebuilt_available": False}
+        wupd,
+        "_resolve_prebuilt_for_host",
+        lambda **_kw: {"prebuilt_available": False, "unavailable_reason": "incompatible"},
     )
 
     def must_not_install(*_a, **_kw):
@@ -773,6 +775,26 @@ def test_a_slim_pairing_gap_skips_instead_of_failing_the_job(monkeypatch):
         "skipped": True,
         "skip_reason": "paired_llama_unavailable",
     }
+
+
+def test_the_pre_flight_probes_the_release_that_would_be_installed(monkeypatch):
+    """Not the download host's latest pointer, which sorts by commit date and can lag
+    the published_at pick the freshness check used (the #6219 class the phase pins
+    against). Probing one release and installing another can skip a valid update or
+    wave through a doomed one."""
+    seen = {}
+
+    def spy(**kw):
+        seen.update(kw)
+        return {"prebuilt_available": True}
+
+    monkeypatch.setattr(wupd, "_resolve_prebuilt_for_host", spy)
+    monkeypatch.setattr(wupd, "run_chained_phase", lambda phase, _sp: {"to_tag": "t"})
+
+    phase = _slim_phase(repo = "unslothai/whisper.cpp", pin_release_tag = "v1.9.2-unsloth.12")
+    wupd.run_chained_phase_after_llama(phase, lambda _f: None)
+    assert seen["published_repo"] == "unslothai/whisper.cpp"
+    assert seen["published_release_tag"] == "v1.9.2-unsloth.12"
 
 
 def test_a_workable_pairing_still_installs(monkeypatch):
@@ -801,14 +823,34 @@ def test_only_a_slim_install_is_pre_flighted(monkeypatch, install_kind):
     assert wupd.run_chained_phase_after_llama(phase, lambda _f: None) == {"to_tag": "v1"}
 
 
-def test_a_pre_flight_that_cannot_answer_still_attempts_the_install(monkeypatch):
+@pytest.mark.parametrize(
+    "resolved",
+    [
+        # The resolver ran and could not get an answer: --resolve-prebuilt maps an
+        # unreachable API or an unreadable manifest to exit 0 with no prebuilt, so this
+        # is what a network failure looks like, not a pairing gap.
+        {"prebuilt_available": False, "unavailable_reason": "unresolved"},
+        # An installer that predates unavailable_reason. Unknown, so not a gap.
+        {"prebuilt_available": False},
+        # The wrapper's own fail-open: nonzero exit, timeout, or unparseable output.
+        None,
+    ],
+)
+def test_a_pre_flight_that_cannot_answer_still_attempts_the_install(monkeypatch, resolved):
     """Fail towards the install, not the skip.
 
-    The pre-flight exists to avoid an attempt known to be doomed. One that cannot answer
-    knows nothing, so attempting keeps the previous behaviour, exit 2 included, rather
-    than silently skipping an update that would have worked.
+    The pre-flight exists to avoid an attempt known to be doomed. One that cannot
+    answer knows nothing, so attempting keeps the previous behaviour, exit 2 included,
+    rather than silently skipping an update that would have worked and reporting a
+    pairing gap that was never established.
     """
+    monkeypatch.setattr(wupd, "_resolve_prebuilt_for_host", lambda **_kw: resolved)
+    monkeypatch.setattr(wupd, "run_chained_phase", lambda phase, _sp: {"to_tag": "v1"})
 
+    assert wupd.run_chained_phase_after_llama(_slim_phase(), lambda _f: None) == {"to_tag": "v1"}
+
+
+def test_a_probe_that_raises_still_attempts_the_install(monkeypatch):
     def boom(**_kw):
         raise RuntimeError("resolver blew up")
 

--- a/studio/backend/tests/test_combined_update.py
+++ b/studio/backend/tests/test_combined_update.py
@@ -737,3 +737,101 @@ def test_chained_progress_windows(monkeypatch, tmp_path):
     assert seen["at_whisper_start"] == pytest.approx(0.7)
     assert seen["mid_whisper"] == pytest.approx(0.7 + 0.5 * 0.3)
     assert job["progress"] == 1.0
+
+
+def _slim_phase(**over):
+    phase = {
+        "install_dir": "d",
+        "install_kind": "slim",
+        "repo": "unslothai/whisper.cpp",
+        "asset": None,
+        "backend": "cpu",
+        "script": "s",
+        "pin_release_tag": None,
+    }
+    phase.update(over)
+    return phase
+
+
+def test_a_slim_pairing_gap_skips_instead_of_failing_the_job(monkeypatch):
+    """The state the pipeline was in for ten days.
+
+    chained_phase_plan waives its pairing gate when llama updates first, assuming the
+    new llama supplies a workable pairing. When no whisper release exists for it, the
+    install exits 2 and a llama update that already landed is reported as failed.
+    """
+    monkeypatch.setattr(
+        wupd, "_resolve_prebuilt_for_host", lambda **_kw: {"prebuilt_available": False}
+    )
+
+    def must_not_install(*_a, **_kw):
+        raise AssertionError("the install cannot succeed, so it must not be attempted")
+
+    monkeypatch.setattr(wupd, "run_chained_phase", must_not_install)
+
+    assert wupd.run_chained_phase_after_llama(_slim_phase(), lambda _f: None) == {
+        "skipped": True,
+        "skip_reason": "paired_llama_unavailable",
+    }
+
+
+def test_a_workable_pairing_still_installs(monkeypatch):
+    monkeypatch.setattr(
+        wupd, "_resolve_prebuilt_for_host", lambda **_kw: {"prebuilt_available": True}
+    )
+    monkeypatch.setattr(
+        wupd, "run_chained_phase", lambda phase, _sp: {"to_tag": "v1.9.2-unsloth.12"}
+    )
+
+    result = wupd.run_chained_phase_after_llama(_slim_phase(), lambda _f: None)
+    assert result == {"to_tag": "v1.9.2-unsloth.12"}
+
+
+@pytest.mark.parametrize("install_kind", ["full", None])
+def test_only_a_slim_install_is_pre_flighted(monkeypatch, install_kind):
+    """A full install carries its own ggml, so llama's build cannot strand it."""
+
+    def must_not_resolve(**_kw):
+        raise AssertionError("pairing is irrelevant to a non-slim install")
+
+    monkeypatch.setattr(wupd, "_resolve_prebuilt_for_host", must_not_resolve)
+    monkeypatch.setattr(wupd, "run_chained_phase", lambda phase, _sp: {"to_tag": "v1"})
+
+    phase = _slim_phase(install_kind = install_kind)
+    assert wupd.run_chained_phase_after_llama(phase, lambda _f: None) == {"to_tag": "v1"}
+
+
+def test_a_pre_flight_that_cannot_answer_still_attempts_the_install(monkeypatch):
+    """Fail towards the install, not the skip.
+
+    The pre-flight exists to avoid an attempt known to be doomed. One that cannot answer
+    knows nothing, so attempting keeps the previous behaviour, exit 2 included, rather
+    than silently skipping an update that would have worked.
+    """
+
+    def boom(**_kw):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr(wupd, "_resolve_prebuilt_for_host", boom)
+    monkeypatch.setattr(wupd, "run_chained_phase", lambda phase, _sp: {"to_tag": "v1"})
+
+    assert wupd.run_chained_phase_after_llama(_slim_phase(), lambda _f: None) == {"to_tag": "v1"}
+
+
+def test_an_incompatible_release_that_slips_past_the_pre_flight_still_errors(monkeypatch):
+    """The pre-flight narrows when exit 2 happens; it must not swallow it.
+
+    test_whisper_phase_exit_2_is_a_failed_phase pins that an attempted install which
+    turns out incompatible stays an actionable job error rather than a false success.
+    """
+    monkeypatch.setattr(
+        wupd, "_resolve_prebuilt_for_host", lambda **_kw: {"prebuilt_available": True}
+    )
+
+    def exit_2(*_a, **_kw):
+        raise wupd._flow.InstallerExit(2, "installer exited 2: incompatible release")
+
+    monkeypatch.setattr(wupd, "run_chained_phase", exit_2)
+
+    with pytest.raises(wupd._flow.InstallerExit):
+        wupd.run_chained_phase_after_llama(_slim_phase(), lambda _f: None)

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -1164,6 +1164,15 @@ def _start_llama_job(backend_request: Optional[str] = None) -> dict:
             whisper_run = (
                 (lambda set_progress: _whisper.run_repair_phase(whisper_spec, set_progress))
                 if whisper_spec.get("repair")
+                # Pairing was left unchecked by the plan when llama is updating first, so
+                # confirm it once the new llama is actually installed rather than running
+                # an install that can only exit 2 and fail the whole job.
+                else (
+                    lambda set_progress: _whisper.run_chained_phase_after_llama(
+                        whisper_spec, set_progress
+                    )
+                )
+                if llama_spec is not None
                 else (lambda set_progress: _whisper.run_chained_phase(whisper_spec, set_progress))
             )
 

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -1164,9 +1164,7 @@ def _start_llama_job(backend_request: Optional[str] = None) -> dict:
             whisper_run = (
                 (lambda set_progress: _whisper.run_repair_phase(whisper_spec, set_progress))
                 if whisper_spec.get("repair")
-                # Pairing was left unchecked by the plan when llama is updating first, so
-                # confirm it once the new llama is actually installed rather than running
-                # an install that can only exit 2 and fail the whole job.
+                # The plan left pairing unchecked because llama runs first.
                 else (
                     lambda set_progress: _whisper.run_chained_phase_after_llama(
                         whisper_spec, set_progress

--- a/studio/backend/utils/prebuilt/update_flow.py
+++ b/studio/backend/utils/prebuilt/update_flow.py
@@ -496,10 +496,8 @@ def run_chained_update(phases: list[dict], *, job: dict, job_lock: threading.Loc
         offset += weight
         with job_lock:
             if result.get("skipped"):
-                # A phase that can only tell there is nothing to do once the phases
-                # before it have run. Reported as skipped with its reason, not as a
-                # success with no message, so the breakdown reads the same whether the
-                # decision was reached at planning time or here.
+                # Skipped with a reason, not a success with no message: deciding late
+                # must not mean explaining less.
                 job["phases"][name].update(
                     state = PHASE_SKIPPED,
                     reason = result.get("skip_reason") or "up_to_date",

--- a/studio/backend/utils/prebuilt/update_flow.py
+++ b/studio/backend/utils/prebuilt/update_flow.py
@@ -495,12 +495,22 @@ def run_chained_update(phases: list[dict], *, job: dict, job_lock: threading.Loc
         set_progress(1.0)
         offset += weight
         with job_lock:
-            job["phases"][name].update(
-                state = PHASE_SUCCESS,
-                to_tag = result.get("to_tag"),
-                reload_required = result.get("reload_required"),
-                message = result.get("message") or "",
-            )
+            if result.get("skipped"):
+                # A phase that can only tell there is nothing to do once the phases
+                # before it have run. Reported as skipped with its reason, not as a
+                # success with no message, so the breakdown reads the same whether the
+                # decision was reached at planning time or here.
+                job["phases"][name].update(
+                    state = PHASE_SKIPPED,
+                    reason = result.get("skip_reason") or "up_to_date",
+                )
+            else:
+                job["phases"][name].update(
+                    state = PHASE_SUCCESS,
+                    to_tag = result.get("to_tag"),
+                    reload_required = result.get("reload_required"),
+                    message = result.get("message") or "",
+                )
         if result.get("message"):
             done_messages.append(result["message"])
         # Only phases affecting the primary (llama) server may raise the job-level

--- a/studio/backend/utils/whisper_cpp_update.py
+++ b/studio/backend/utils/whisper_cpp_update.py
@@ -98,13 +98,26 @@ _resolve_memo: dict = {}
 
 
 def _resolve_prebuilt_for_host(
-    *, force_refresh: bool = False, backend: Optional[str] = None
+    *,
+    force_refresh: bool = False,
+    backend: Optional[str] = None,
+    published_repo: Optional[str] = None,
+    published_release_tag: Optional[str] = None,
 ) -> Optional[dict]:
     """Run install_whisper_prebuilt.py --resolve-prebuilt (no download); return
     {prebuilt_available, repo, release_tag, upstream_tag, backend, asset, os,
     arch, ...} or None. Fail-open: any error -> None so a source build never
-    blocks the app."""
+    blocks the app.
+
+    published_repo/published_release_tag probe one exact release instead of the
+    download host's latest pointer, which sorts by commit date and can lag the
+    published_at pick (#6219). A caller about to install a pinned release must
+    pass the same pin, or it probes a different artifact than it installs."""
     extra_args = ("--backend", backend) if backend else ()
+    if published_repo:
+        extra_args += ("--published-repo", published_repo)
+    if published_release_tag:
+        extra_args += ("--published-release-tag", published_release_tag)
     return _flow.resolve_prebuilt_for_host(
         force_refresh = force_refresh,
         memo = _resolve_memo,
@@ -618,17 +631,23 @@ def run_chained_phase_after_llama(phase: dict, set_progress) -> dict:
         return run_chained_phase(phase, set_progress)
     try:
         backend = phase.get("backend")
+        repo = phase.get("repo")
+        pin = phase.get("pin_release_tag")
         resolved = _resolve_prebuilt_for_host(
             force_refresh = True,
             backend = backend if isinstance(backend, str) else None,
+            published_repo = repo if isinstance(repo, str) else None,
+            published_release_tag = pin if isinstance(pin, str) else None,
         )
     except Exception as exc:
-        # Fail towards the install rather than the skip: the pre-flight exists to avoid
-        # an attempt known to be doomed, and a pre-flight that cannot answer knows
-        # nothing. Attempting keeps the old behaviour, including exit 2 if it is wrong.
         logger.debug("whisper pairing pre-flight failed", error = str(exc))
-        return run_chained_phase(phase, set_progress)
-    if not (resolved or {}).get("prebuilt_available"):
+        resolved = None
+    # Skip only on a POSITIVE answer that this release cannot pair, the exit-2 case.
+    # Fail towards the install for everything else: an unreachable API, an unreadable
+    # manifest and a resolver that never ran all report prebuilt_available=false too,
+    # and a pre-flight that could not answer knows nothing. Attempting there keeps the
+    # previous behaviour rather than skipping an update that would have worked.
+    if (resolved or {}).get("unavailable_reason") == "incompatible":
         return {"skipped": True, "skip_reason": "paired_llama_unavailable"}
     return run_chained_phase(phase, set_progress)
 

--- a/studio/backend/utils/whisper_cpp_update.py
+++ b/studio/backend/utils/whisper_cpp_update.py
@@ -577,6 +577,9 @@ def chained_phase_plan(
     plan["update_available"] = True
     plan["phase"] = {
         "install_dir": install_dir,
+        # Only a slim install is pinned to llama's ggml, so only it needs the
+        # pairing re-checked when the llama phase runs first.
+        "install_kind": marker.get("install_kind"),
         "repo": marker.get("published_repo") or DEFAULT_PUBLISHED_REPO,
         "asset": marker.get("asset"),
         "backend": marker.get("backend"),
@@ -592,6 +595,42 @@ def chained_phase_plan(
         "pin_release_tag": None if sys.platform == "darwin" else status.get("latest_tag"),
     }
     return plan
+
+
+def run_chained_phase_after_llama(phase: dict, set_progress) -> dict:
+    """Confirm the new llama can actually pair, then run the whisper phase.
+
+    chained_phase_plan skips its pairing gate when the llama phase will run first, on
+    the grounds that llama "supplies the repaired pairing instead". That holds only
+    while a whisper release exists for the llama build being installed, and for ten days
+    it did not: llama shipped b10639, b10672, b10679 and b10687 while the newest whisper
+    bundle stayed pinned to b10472-mix-4b653db. The phase then ran an install that could
+    not succeed, the installer exited 2, and a llama update that had already landed was
+    reported as a failed job.
+
+    So make the check the plan deferred, now that the new llama is in place. A gap is the
+    same clean skip the plan itself would have produced had llama not been updating. It
+    is NOT a way to swallow a failed install: an attempt that does go ahead still
+    surfaces exit 2 as a job error, which is what makes an incompatible release
+    actionable rather than a false success.
+    """
+    if phase.get("install_kind") != "slim":
+        return run_chained_phase(phase, set_progress)
+    try:
+        backend = phase.get("backend")
+        resolved = _resolve_prebuilt_for_host(
+            force_refresh = True,
+            backend = backend if isinstance(backend, str) else None,
+        )
+    except Exception as exc:
+        # Fail towards the install rather than the skip: the pre-flight exists to avoid
+        # an attempt known to be doomed, and a pre-flight that cannot answer knows
+        # nothing. Attempting keeps the old behaviour, including exit 2 if it is wrong.
+        logger.debug("whisper pairing pre-flight failed", error = str(exc))
+        return run_chained_phase(phase, set_progress)
+    if not (resolved or {}).get("prebuilt_available"):
+        return {"skipped": True, "skip_reason": "paired_llama_unavailable"}
+    return run_chained_phase(phase, set_progress)
 
 
 def run_chained_phase(phase: dict, set_progress) -> dict:

--- a/studio/backend/utils/whisper_cpp_update.py
+++ b/studio/backend/utils/whisper_cpp_update.py
@@ -109,10 +109,9 @@ def _resolve_prebuilt_for_host(
     arch, ...} or None. Fail-open: any error -> None so a source build never
     blocks the app.
 
-    published_repo/published_release_tag probe one exact release instead of the
-    download host's latest pointer, which sorts by commit date and can lag the
-    published_at pick (#6219). A caller about to install a pinned release must
-    pass the same pin, or it probes a different artifact than it installs."""
+    A caller installing a pinned release must pass the same pin here, or it probes
+    a different artifact than it installs: the unpinned latest pointer sorts by
+    commit date and can lag the published_at pick (#6219)."""
     extra_args = ("--backend", backend) if backend else ()
     if published_repo:
         extra_args += ("--published-repo", published_repo)
@@ -608,21 +607,14 @@ def chained_phase_plan(
 
 
 def run_chained_phase_after_llama(phase: dict, set_progress) -> dict:
-    """Confirm the new llama can actually pair, then run the whisper phase.
+    """Make the pairing check chained_phase_plan deferred, now that llama is installed.
 
-    chained_phase_plan skips its pairing gate when the llama phase will run first, on
-    the grounds that llama "supplies the repaired pairing instead". That holds only
-    while a whisper release exists for the llama build being installed, and for ten days
-    it did not: llama shipped b10639, b10672, b10679 and b10687 while the newest whisper
-    bundle stayed pinned to b10472-mix-4b653db. The phase then ran an install that could
-    not succeed, the installer exited 2, and a llama update that had already landed was
-    reported as a failed job.
+    The plan assumes the new llama supplies a workable pairing. That was false for ten
+    days (llama reached b10687, whisper stayed on b10472-mix-4b653db), so the phase ran
+    an install that could only exit 2 and failed a job llama had already won.
 
-    So make the check the plan deferred, now that the new llama is in place. A gap is the
-    same clean skip the plan itself would have produced had llama not been updating. It
-    is NOT a way to swallow a failed install: an attempt that does go ahead still
-    surfaces exit 2 as a job error, which is what makes an incompatible release
-    actionable rather than a false success.
+    An attempt that goes ahead still surfaces exit 2, which is what keeps an
+    incompatible release actionable rather than a false success.
     """
     try:
         backend = phase.get("backend")
@@ -637,18 +629,10 @@ def run_chained_phase_after_llama(phase: dict, set_progress) -> dict:
     except Exception as exc:
         logger.debug("whisper pairing pre-flight failed", error = str(exc))
         resolved = None
-    # Skip only on a POSITIVE answer that this release cannot pair, the exit-2 case.
-    # Fail towards the install for everything else: an unreachable API, an unreadable
-    # manifest and a resolver that never ran all report prebuilt_available=false too,
-    # and a pre-flight that could not answer knows nothing. Attempting there keeps the
-    # previous behaviour rather than skipping an update that would have worked.
-    #
-    # This asks about the TARGET release, so it needs no test on the installed one. Only
-    # a slim release can be reported incompatible (_slim_release_incompatibility
-    # explains nothing else), and gating on the installed marker instead would miss the
-    # upgrade that matters most: a fat install carries no install_kind at all, by
-    # design, while releases are now slim-only, so exactly the host most likely to
-    # receive its first slim bundle would have skipped the check.
+    # A POSITIVE incompatibility only: an unreachable API reports prebuilt_available
+    # false too, and a pre-flight that cannot answer must fail towards the install.
+    # Deliberately no test on the INSTALLED kind -- a fat marker carries no
+    # install_kind, so gating on it skips the host most likely to meet a pairing gap.
     if (resolved or {}).get("unavailable_reason") == "incompatible":
         return {"skipped": True, "skip_reason": "paired_llama_unavailable"}
     return run_chained_phase(phase, set_progress)

--- a/studio/backend/utils/whisper_cpp_update.py
+++ b/studio/backend/utils/whisper_cpp_update.py
@@ -590,9 +590,6 @@ def chained_phase_plan(
     plan["update_available"] = True
     plan["phase"] = {
         "install_dir": install_dir,
-        # Only a slim install is pinned to llama's ggml, so only it needs the
-        # pairing re-checked when the llama phase runs first.
-        "install_kind": marker.get("install_kind"),
         "repo": marker.get("published_repo") or DEFAULT_PUBLISHED_REPO,
         "asset": marker.get("asset"),
         "backend": marker.get("backend"),
@@ -627,8 +624,6 @@ def run_chained_phase_after_llama(phase: dict, set_progress) -> dict:
     surfaces exit 2 as a job error, which is what makes an incompatible release
     actionable rather than a false success.
     """
-    if phase.get("install_kind") != "slim":
-        return run_chained_phase(phase, set_progress)
     try:
         backend = phase.get("backend")
         repo = phase.get("repo")
@@ -647,6 +642,13 @@ def run_chained_phase_after_llama(phase: dict, set_progress) -> dict:
     # manifest and a resolver that never ran all report prebuilt_available=false too,
     # and a pre-flight that could not answer knows nothing. Attempting there keeps the
     # previous behaviour rather than skipping an update that would have worked.
+    #
+    # This asks about the TARGET release, so it needs no test on the installed one. Only
+    # a slim release can be reported incompatible (_slim_release_incompatibility
+    # explains nothing else), and gating on the installed marker instead would miss the
+    # upgrade that matters most: a fat install carries no install_kind at all, by
+    # design, while releases are now slim-only, so exactly the host most likely to
+    # receive its first slim bundle would have skipped the check.
     if (resolved or {}).get("unavailable_reason") == "incompatible":
         return {"skipped": True, "skip_reason": "paired_llama_unavailable"}
     return run_chained_phase(phase, set_progress)

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -1403,6 +1403,24 @@ def resolver_payload_extra(artifact: dict[str, Any]) -> dict[str, Any]:
     return {"install_kind": "slim" if artifact.get("install_kind") == "slim" else "fat"}
 
 
+def unavailable_payload(published_repo: str, exc: BaseException) -> dict[str, Any]:
+    """The resolver's negative answer, carrying WHY it is negative.
+
+    The install path already separates these: ReleaseCompatibilityError is exit 2
+    (a valid release this runtime cannot pair) and everything else is exit 1 (an
+    operational failure). The resolver used to flatten both into a bare
+    prebuilt_available=false, so a caller could not tell a confirmed pairing gap
+    from a probe that never got an answer.
+    """
+    return {
+        "prebuilt_available": False,
+        "repo": published_repo,
+        "unavailable_reason": (
+            "incompatible" if isinstance(exc, ReleaseCompatibilityError) else "unresolved"
+        ),
+    }
+
+
 def resolve_prebuilt(
     host: HostInfo,
     *,
@@ -1422,8 +1440,8 @@ def resolve_prebuilt(
             requested_backend = requested_backend,
             verify_checksums = False,
         )
-    except PrebuiltFallback:
-        return {"prebuilt_available": False, "repo": published_repo}
+    except PrebuiltFallback as exc:
+        return unavailable_payload(published_repo, exc)
     os_token, arch_token = host_platform_tokens(host)
     payload = {
         "prebuilt_available": True,
@@ -1545,11 +1563,11 @@ def main(argv: list[str] | None = None) -> int:
                 backend = args.backend,
                 cpu_fallback = args.cpu_fallback,
             )
-        except PrebuiltFallback:
-            payload = {"prebuilt_available": False, "repo": args.published_repo}
+        except PrebuiltFallback as exc:
+            payload = unavailable_payload(args.published_repo, exc)
         except Exception as exc:  # noqa: BLE001 - probe must never crash the caller
             log(f"resolve failed: {exc}")
-            payload = {"prebuilt_available": False, "repo": args.published_repo}
+            payload = unavailable_payload(args.published_repo, exc)
         emit_resolver_output(payload, output_format = args.output_format)
         return EXIT_SUCCESS
 

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -1404,14 +1404,9 @@ def resolver_payload_extra(artifact: dict[str, Any]) -> dict[str, Any]:
 
 
 def unavailable_payload(published_repo: str, exc: BaseException) -> dict[str, Any]:
-    """The resolver's negative answer, carrying WHY it is negative.
-
-    The install path already separates these: ReleaseCompatibilityError is exit 2
-    (a valid release this runtime cannot pair) and everything else is exit 1 (an
-    operational failure). The resolver used to flatten both into a bare
-    prebuilt_available=false, so a caller could not tell a confirmed pairing gap
-    from a probe that never got an answer.
-    """
+    """The resolver's negative answer, carrying WHY: the same split the install path
+    makes (ReleaseCompatibilityError is exit 2, everything else exit 1). Flattened, a
+    caller cannot tell a confirmed pairing gap from a probe that never answered."""
     return {
         "prebuilt_available": False,
         "repo": published_repo,

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -470,7 +470,8 @@ def test_main_maps_unexpected_error_to_exit_error(tmp_path, monkeypatch):
 
 def test_resolve_mode_unexpected_error_reports_unavailable(monkeypatch, capsys):
     # An unexpected failure inside the probe maps to prebuilt_available=False, not
-    # a traceback, so the caller falls back cleanly.
+    # a traceback, so the caller falls back cleanly. It is reported as unresolved,
+    # since nothing was learned about whether a prebuilt exists.
     host = _host("linux", "x64")
     monkeypatch.setattr(M, "detect_host", lambda: host)
 
@@ -481,7 +482,46 @@ def test_resolve_mode_unexpected_error_reports_unavailable(monkeypatch, capsys):
     rc = M.main(["--resolve-prebuilt", "--output-format", "json"])
     assert rc == M.EXIT_SUCCESS
     payload = json.loads(capsys.readouterr().out.strip())
-    assert payload == {"prebuilt_available": False, "repo": "unslothai/whisper.cpp"}
+    assert payload == {
+        "prebuilt_available": False,
+        "repo": "unslothai/whisper.cpp",
+        "unavailable_reason": "unresolved",
+    }
+
+
+def test_resolve_mode_separates_incompatible_from_unresolved(monkeypatch, capsys):
+    """The probe's negative answer must say WHY it is negative.
+
+    The install path already draws this line: ReleaseCompatibilityError is exit 2 and
+    every other failure is exit 1. Flattening both into a bare prebuilt_available=false
+    left a caller unable to tell a confirmed pairing gap from an unreachable API, so
+    an update was skipped over a network blip.
+    """
+    monkeypatch.setattr(M, "detect_host", lambda: _host("linux", "x64"))
+
+    def incompatible(repo, *, published_release_tag = None):
+        raise ReleaseCompatibilityError("slim bundle requires llama.cpp b2; installed b1")
+
+    monkeypatch.setattr(M, "fetch_release_for_install", incompatible)
+    assert M.main(["--resolve-prebuilt", "--output-format", "json"]) == M.EXIT_SUCCESS
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["prebuilt_available"] is False
+    assert payload["unavailable_reason"] == "incompatible"
+
+
+def test_resolve_mode_reports_an_ordinary_fallback_as_unresolved(monkeypatch, capsys):
+    """A plain PrebuiltFallback is an unsupported platform, a malformed manifest, a
+    checksum failure. _slim_release_incompatibility deliberately excludes those, so
+    they are not a pairing gap either."""
+    monkeypatch.setattr(M, "detect_host", lambda: _host("linux", "x64"))
+
+    def fallback(repo, *, published_release_tag = None):
+        raise M.PrebuiltFallback("manifest omitted an 'artifacts' list")
+
+    monkeypatch.setattr(M, "fetch_release_for_install", fallback)
+    assert M.main(["--resolve-prebuilt", "--output-format", "json"]) == M.EXIT_SUCCESS
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["unavailable_reason"] == "unresolved"
 
 
 # ── --rocm-gfx / --has-rocm overrides (llama parity) ──

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -490,13 +490,8 @@ def test_resolve_mode_unexpected_error_reports_unavailable(monkeypatch, capsys):
 
 
 def test_resolve_mode_separates_incompatible_from_unresolved(monkeypatch, capsys):
-    """The probe's negative answer must say WHY it is negative.
-
-    The install path already draws this line: ReleaseCompatibilityError is exit 2 and
-    every other failure is exit 1. Flattening both into a bare prebuilt_available=false
-    left a caller unable to tell a confirmed pairing gap from an unreachable API, so
-    an update was skipped over a network blip.
-    """
+    """The probe's negative answer must say WHY, as the install path already does
+    (exit 2 against exit 1). Flattened, a network blip reads as a pairing gap."""
     monkeypatch.setattr(M, "detect_host", lambda: _host("linux", "x64"))
 
     def incompatible(repo, *, published_release_tag = None):
@@ -510,9 +505,8 @@ def test_resolve_mode_separates_incompatible_from_unresolved(monkeypatch, capsys
 
 
 def test_resolve_mode_reports_an_ordinary_fallback_as_unresolved(monkeypatch, capsys):
-    """A plain PrebuiltFallback is an unsupported platform, a malformed manifest, a
-    checksum failure. _slim_release_incompatibility deliberately excludes those, so
-    they are not a pairing gap either."""
+    """An unsupported platform, a malformed manifest, a checksum failure:
+    _slim_release_incompatibility excludes those, so they are not a pairing gap."""
     monkeypatch.setattr(M, "detect_host", lambda: _host("linux", "x64"))
 
     def fallback(repo, *, published_release_tag = None):


### PR DESCRIPTION
## The defect

`chained_phase_plan` waives its pairing gate when the llama phase will run first:

```python
if marker.get("install_kind") == "slim" and not paired_llama_will_update:
    ...
    # When the llama phase will run first, it supplies the repaired pairing instead.
```

That assumption holds only while a whisper release actually exists for the llama build being installed. For ten days it did not. llama shipped `b10639`, `b10672`, `b10679` and `b10687` while the newest whisper bundle stayed pinned to `b10472-mix-4b653db`, because the whisper.cpp release resolver was failing on every trigger (fixed separately in unslothai/whisper.cpp#26).

The result: the whisper phase runs an install that cannot succeed, the installer exits 2, and a llama update that has already landed on disk is reported as a failed job.

## The change

Do the check the plan deferred, once the new llama is actually in place.

`run_chained_phase_after_llama` resolves the pairing with `force_refresh = True` and, when no prebuilt is available for the newly installed llama, reports the phase as skipped with `paired_llama_unavailable`. That is the same clean skip the plan itself would have produced had llama not been updating, and the same reason string, so the outcome does not depend on which order the phases happened to be planned in.

Three deliberate limits:

- Only `install_kind == "slim"` is pre-flighted. A full install carries its own ggml, so llama's build cannot strand it, and the plan's own gate is scoped the same way.
- A probe that raises falls through to the install. The pre-flight exists to avoid an attempt known to be doomed, and one that cannot answer knows nothing, so attempting keeps the previous behaviour rather than silently skipping an update that would have worked.
- `run_chained_update` now honours a skip reported from a phase result, not only from a plan. Deciding later must not mean explaining less: the breakdown still reads `skipped: <reason>` rather than degrading into a success with an empty message.

## What this deliberately does not do

It narrows when exit 2 happens. It does not swallow it.

`test_whisper_phase_exit_2_is_a_failed_phase` pins the policy that an incompatible release "must remain an actionable job error instead of producing a false success toast and hiding the banner". An attempt that does go ahead and turns out incompatible still raises, and there is a test asserting that specifically, so the pre-flight cannot be used as a way to hide a failed install.

## Tests

Six new cases in `test_combined_update.py`:

- a slim install with no available prebuilt skips with `paired_llama_unavailable` and the install is never attempted (the assertion fires if it is)
- a workable pairing still installs
- `full` and an absent `install_kind` are not pre-flighted at all, asserted by making the resolver raise
- a resolver exception still attempts the install
- an incompatible release that slips past the pre-flight still raises

`test_combined_update.py` and `test_llama_backend_switch.py`: 66 passed.

Wider update surface, `-k "update or whisper or llama or install or prebuilt"`: **4307 passed, 7 failed**. Clean `main` in a separate worktree, same selection: **4301 passed, 7 failed**, and the seven are the same tests. They are `test_diffusion_*` and `test_mlx_repair`, all from a local `huggingface-hub` version mismatch, unrelated to this branch. The +6 is exactly the new cases.

## Note

This replaces #10026, which I closed. That PR started from a claim I could not support: that a llama update can newly expose a whisper update. `whisper_cpp_freshness.py` has no llama reference at all, so `update_available` there is a pure tag comparison and a llama update cannot flip it. The real defect is the one above, and this PR does only that.

I reasoned this from the source and reproduced it through the tests rather than by driving a live Studio through a real llama-then-whisper update, so the end-to-end sequence is inferred rather than observed.
