### PR TITLE
Patch Accelerator.distributed_type as a property, not a bare function

### DIFF
--- a/tests/test_accelerator_distributed_type_patch.py
+++ b/tests/test_accelerator_distributed_type_patch.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/tests/test_accelerator_distributed_type_patch.py
+++ b/tests/test_accelerator_distributed_type_patch.py
@@ -1,0 +1,98 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The single-device block in `_utils.py` forces accelerate into non-distributed mode.
+
+`Accelerator.distributed_type` is a `@property` upstream, so assigning a plain
+function to it binds as a method rather than replacing the value. Accelerate then
+compares a bound method against the enum, e.g.
+
+    if (... and self.verify_device_map(obj)
+            and self.distributed_type != DistributedType.NO ...):
+        raise ValueError("You can't train a model that has been loaded with "
+                         "`device_map='auto'` in any distributed mode. ...")
+
+which is always True, so the guard fires on a single device -- exactly the case the
+block exists to rule out. Reported as #10016 for a single-GPU 4-bit QLoRA run whose
+model legitimately spanned devices.
+
+`import unsloth` needs a CUDA or XPU build (`torch_amp_custom_fwd` is only defined
+on those branches), so these run the real assignment against the real accelerate
+class in a fresh interpreter instead, taking the statement from the source so a
+revert to a bare lambda is caught.
+"""
+
+import ast
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_UTILS = _ROOT / "unsloth" / "models" / "_utils.py"
+
+accelerate = pytest.importorskip("accelerate")
+
+
+def _patch_statement() -> ast.Assign:
+    """The one assignment `_utils.py` makes to `Accelerator.distributed_type`."""
+    tree = ast.parse(_UTILS.read_text(encoding = "utf-8"))
+    matches = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and ast.unparse(node.targets[0]).endswith("Accelerator.distributed_type")
+    ]
+    assert len(matches) == 1, f"expected one assignment, found {len(matches)}"
+    return matches[0]
+
+
+def test_distributed_type_is_replaced_with_a_property():
+    value = _patch_statement().value
+    assert isinstance(value, ast.Call) and ast.unparse(value.func) == "property", (
+        "Accelerator.distributed_type is a property upstream; a bare function binds "
+        "as a method and never compares equal to a DistributedType member"
+    )
+
+
+def test_patched_distributed_type_reads_as_no():
+    """The assignment, run for real, has to leave the attribute reading as NO."""
+    statement = ast.unparse(_patch_statement())
+    script = textwrap.dedent(
+        f"""
+        import accelerate.accelerator
+        from accelerate.utils.dataclasses import DistributedType
+
+        {statement}
+
+        # Read it off an instance without standing up a real distributed backend.
+        accelerator = accelerate.accelerator.Accelerator.__new__(
+            accelerate.accelerator.Accelerator
+        )
+        value = accelerator.distributed_type
+        print(repr(value))
+        print(value == DistributedType.NO, value != DistributedType.NO)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output = True, text = True
+    )
+    assert result.returncode == 0, result.stderr
+    value, comparisons = result.stdout.strip().splitlines()[-2:]
+    assert value == repr(accelerate.utils.dataclasses.DistributedType.NO), value
+    # The second is what accelerate's device_map guards actually test.
+    assert comparisons == "True False", comparisons

--- a/tests/test_accelerator_distributed_type_patch.py
+++ b/tests/test_accelerator_distributed_type_patch.py
@@ -88,9 +88,7 @@ def test_patched_distributed_type_reads_as_no():
         print(value == DistributedType.NO, value != DistributedType.NO)
         """
     )
-    result = subprocess.run(
-        [sys.executable, "-c", script], capture_output = True, text = True
-    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output = True, text = True)
     assert result.returncode == 0, result.stderr
     value, comparisons = result.stdout.strip().splitlines()[-2:]
     assert value == repr(accelerate.utils.dataclasses.DistributedType.NO), value

--- a/tests/test_accelerator_distributed_type_patch.py
+++ b/tests/test_accelerator_distributed_type_patch.py
@@ -12,25 +12,10 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""The single-device block in `_utils.py` forces accelerate into non-distributed mode.
-
-`Accelerator.distributed_type` is a `@property` upstream, so assigning a plain
-function to it binds as a method rather than replacing the value. Accelerate then
-compares a bound method against the enum, e.g.
-
-    if (... and self.verify_device_map(obj)
-            and self.distributed_type != DistributedType.NO ...):
-        raise ValueError("You can't train a model that has been loaded with "
-                         "`device_map='auto'` in any distributed mode. ...")
-
-which is always True, so the guard fires on a single device -- exactly the case the
-block exists to rule out. Reported as #10016 for a single-GPU 4-bit QLoRA run whose
-model legitimately spanned devices.
-
-`import unsloth` needs a CUDA or XPU build (`torch_amp_custom_fwd` is only defined
-on those branches), so these run the real assignment against the real accelerate
-class in a fresh interpreter instead, taking the statement from the source so a
-revert to a bare lambda is caught.
+"""`_utils.py` must patch `Accelerator.distributed_type` with a property, not a bare
+function: a function binds as a method and inverts accelerate's `!= NO` device_map
+guards on a single device (#10016). `import unsloth` needs CUDA or XPU, so these run
+the statement from source in a fresh interpreter, which also catches a revert.
 """
 
 import ast
@@ -48,7 +33,7 @@ accelerate = pytest.importorskip("accelerate")
 
 
 def _patch_statement() -> ast.Assign:
-    """The one assignment `_utils.py` makes to `Accelerator.distributed_type`."""
+    """The one assignment to `Accelerator.distributed_type`; a second would be ambiguous."""
     tree = ast.parse(_UTILS.read_text(encoding = "utf-8"))
     matches = [
         node
@@ -70,7 +55,7 @@ def test_distributed_type_is_replaced_with_a_property():
 
 
 def test_patched_distributed_type_reads_as_no():
-    """The assignment, run for real, has to leave the attribute reading as NO."""
+    """Running the real assignment must leave the attribute reading as NO."""
     statement = ast.unparse(_patch_statement())
     script = textwrap.dedent(
         f"""

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2873,9 +2873,7 @@ if DEVICE_COUNT == 1 and int(os.environ.get("WORLD_SIZE", "1")) <= 1:
     # accelerate compares a bound method against the enum and is always True. That
     # fires the "can't train a model loaded with device_map='auto' in any distributed
     # mode" guard on a single device, which is the case this whole block exists for.
-    accelerate.accelerator.Accelerator.distributed_type = property(
-        lambda self: DistributedType.NO
-    )
+    accelerate.accelerator.Accelerator.distributed_type = property(lambda self: DistributedType.NO)
 
 
 # to move multiple tensors to the same device

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2868,7 +2868,14 @@ if DEVICE_COUNT == 1 and int(os.environ.get("WORLD_SIZE", "1")) <= 1:
     import accelerate.state
 
     accelerate.state.PartialState._prepare_backend = _prepare_backend
-    accelerate.accelerator.Accelerator.distributed_type = lambda *args, **kwargs: DistributedType.NO
+    # `Accelerator.distributed_type` is a property upstream, so a bare function here
+    # binds as a method and every `self.distributed_type != DistributedType.NO` in
+    # accelerate compares a bound method against the enum and is always True. That
+    # fires the "can't train a model loaded with device_map='auto' in any distributed
+    # mode" guard on a single device, which is the case this whole block exists for.
+    accelerate.accelerator.Accelerator.distributed_type = property(
+        lambda self: DistributedType.NO
+    )
 
 
 # to move multiple tensors to the same device

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2868,11 +2868,8 @@ if DEVICE_COUNT == 1 and int(os.environ.get("WORLD_SIZE", "1")) <= 1:
     import accelerate.state
 
     accelerate.state.PartialState._prepare_backend = _prepare_backend
-    # `Accelerator.distributed_type` is a property upstream, so a bare function here
-    # binds as a method and every `self.distributed_type != DistributedType.NO` in
-    # accelerate compares a bound method against the enum and is always True. That
-    # fires the "can't train a model loaded with device_map='auto' in any distributed
-    # mode" guard on a single device, which is the case this whole block exists for.
+    # Must be a property: a bare function binds as a method, inverting every
+    # `!= DistributedType.NO` guard in accelerate (#10016).
     accelerate.accelerator.Accelerator.distributed_type = property(lambda self: DistributedType.NO)
 
 


### PR DESCRIPTION
Fixes #10016.

### Symptom

`unsloth/models/_utils.py` forces accelerate into non-distributed mode on a single device. One of the two patches does not take:

```python
>>> import accelerate.accelerator
>>> from accelerate.utils.dataclasses import DistributedType
>>> accelerate.accelerator.Accelerator.distributed_type = lambda *args, **kwargs: DistributedType.NO
>>> Accelerator().distributed_type
<bound method <lambda> of <accelerate.accelerator.Accelerator object at 0x...>>
```

`Accelerator.distributed_type` is a `@property` upstream, so assigning a plain function to the class attribute binds it as a method instead of replacing the value.

### Why it bites

Everything accelerate does with it compares a bound method against an enum member. The `!= DistributedType.NO` guards flip from `False` to `True` on a single device, which is the exact case this block exists to rule out:

| | with the lambda | as a property |
| --- | --- | --- |
| `accelerator.distributed_type` | `<bound method <lambda>>` | `DistributedType.NO` |
| `!= DistributedType.NO` | `True` | `False` |
| `== DistributedType.NO` | `False` | `True` |

The two the reporter hit, both in `accelerate/accelerator.py`:

```python
            if (isinstance(obj, torch.nn.Module)
                    and self.verify_device_map(obj)
                    and self.distributed_type != DistributedType.NO       # line 1474
                    and os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false") != "true"):
                raise ValueError(
                    "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode. ...")
```

and the 4-bit variant at line 1839, `if len(model_devices) > 1 and self.distributed_type != DistributedType.NO`. It stays hidden while `verify_device_map` is False, and surfaces as soon as a model legitimately spans devices, as in #10016's single-GPU 4-bit QLoRA with `device_map={"": 0, "model.visual": "cpu"}`. `accelerator.py:1374`, `:1810` and `local_sgd.py:81` read the same way.

### Fix

Wrap the lambda in `property()`, which is how accelerate declares the attribute. One line plus a comment saying why it has to be a property.

Two things I checked before choosing this over the alternatives:

- **Not redundant with the `_prepare_backend` patch above it.** That one makes `PartialState` report `NO` at construction, but `AcceleratorState` can set `DEEPSPEED`, `FSDP` or `MEGATRON_LM` afterwards (`accelerate/state.py:973`, `:1011`, `:1020`), and `Accelerator.distributed_type` just forwards `self.state.distributed_type`. So deleting the line would change behaviour; keeping it as a property preserves the original intent exactly.
- **A read-only property is no more restrictive than what is there now.** Nothing assigns to `Accelerator.distributed_type`, in accelerate or here: every `self.distributed_type = ...` in accelerate is on `PartialState` / `AcceleratorState` / `SageMakerConfig`, never on `Accelerator`, and upstream's property has no setter either.

### Test

`tests/test_accelerator_distributed_type_patch.py` pins both halves: that the assignment is a `property(...)` call, and that running the real statement against the real accelerate class leaves the attribute reading as `DistributedType.NO` with the comparison the device-map guards make coming out `False`.

`import unsloth` needs a CUDA or XPU build here (`torch_amp_custom_fwd` is only defined on those branches, and `tests/test_allow_cpu_import_driverless.py` skips entirely on this host), so the test takes the statement out of the source with `ast` and executes it in a fresh interpreter. That also means a revert to a bare lambda is caught rather than silently passing.

```
# this branch
2 passed

# with _utils.py reverted, test kept
2 failed
E  AssertionError: Accelerator.distributed_type is a property upstream; a bare function
   binds as a method and never compares equal to a DistributedType member
E  assert '<bound method <lambda> of <accelerate.accelerator.Accelerator object at 0x...>>'
        == "<DistributedType.NO: 'NO'>"
```

`tests/test_collection_hygiene.py` (3 passed) and `tests/test_source_read_encoding.py` (1 passed) are green with the new file. `tests/test_enforce_kwargs_spacing.py` reports the identical 20 failures with and without this change, none of them naming the new file, so they are pre-existing.
