### PR TITLE
Ask one formula whether a GGUF fits

### DIFF
--- a/studio/frontend/src/features/hub/catalog/download-section.tsx
+++ b/studio/frontend/src/features/hub/catalog/download-section.tsx
@@ -21,6 +21,7 @@ export function DownloadSection({
   preferredGgufFileIntent = 0,
   isLoadingThisModel,
   gpuGb,
+  gpuCount,
   systemRamGb,
   cachePath,
   knownBytes,
@@ -46,6 +47,7 @@ export function DownloadSection({
   preferredGgufFileIntent?: number;
   isLoadingThisModel: boolean;
   gpuGb?: number;
+  gpuCount?: number;
   systemRamGb?: number;
   cachePath?: string | null;
   knownBytes?: number | null;
@@ -69,6 +71,7 @@ export function DownloadSection({
         preferredFileIntent={preferredGgufFileIntent}
         isLoadingThisModel={isLoadingThisModel}
         gpuGb={gpuGb}
+        gpuCount={gpuCount}
         systemRamGb={systemRamGb}
         cachePath={cachePath}
         isPartial={isPartial}

--- a/studio/frontend/src/features/hub/catalog/download-section.tsx
+++ b/studio/frontend/src/features/hub/catalog/download-section.tsx
@@ -31,6 +31,7 @@ export function DownloadSection({
   onTrain,
   onChange,
   showMemoryBar = true,
+  mediaRuntime = false,
 }: {
   repoId: string;
   isGguf: boolean;
@@ -59,6 +60,7 @@ export function DownloadSection({
   /** False for diffusion / audio / video GGUFs, which do not load through
    *  llama.cpp and so have nothing the KV estimator can say about them. */
   showMemoryBar?: boolean;
+  mediaRuntime?: boolean;
 }) {
   if (isGguf || preferredGgufFile) {
     return (
@@ -80,6 +82,7 @@ export function DownloadSection({
         onEject={onEject}
         onChange={onChange}
         showMemoryBar={showMemoryBar}
+        mediaRuntime={mediaRuntime}
       />
     );
   }

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -120,7 +120,7 @@ const FIT_BADGE: Record<GgufFitClass, FitBadgeMeta> = {
   partial: {
     label: "Partial offload",
     tooltip:
-      "Model doesn't fit but still works with offloading. Expect slower inference.",
+      "Model may not fit but still works with offloading. Expect slower inference.",
     iconClassName: "text-sky-600 dark:text-sky-400",
   },
   ram: {
@@ -134,7 +134,7 @@ const FIT_BADGE: Record<GgufFitClass, FitBadgeMeta> = {
     // Not "won't fit": llama-server never refuses a GGUF on size, it hands it to --fit. Same words
     // the chat picker uses, where this class and `partial` share one mark.
     tooltip:
-      "Model doesn't fit but still works with offloading. Expect slower inference.",
+      "Model may not fit but still works with offloading. Expect slower inference.",
     iconClassName: "text-rose-600 dark:text-rose-400",
   },
 };

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -23,10 +23,10 @@ import {
 import { usePlatformStore } from "@/config/env";
 import { getCachedModelPath, revealCachedModel } from "@/features/chat";
 import { pinKey, usePinnedModelsStore } from "@/features/model-picker";
+import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { type GgufFitClass, classifyGgufFit } from "@/lib/gguf-fit";
-import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import {
@@ -59,7 +59,6 @@ import {
 } from "../download-manager";
 import { useOnlineStatus } from "../hooks/use-online-status";
 import { type GgufVariantDetail, deleteCachedModel } from "../inventory";
-import { formatBytes } from "../lib/format";
 import {
   ggufFilenamesMatch,
   ggufSelectionOverrideMatchesIntent,
@@ -75,6 +74,7 @@ import {
   normalizeGgufVariantIdentity,
 } from "../lib/model-identity";
 import { useHfTokenStore } from "../stores/hf-token-store";
+import { DeleteImpactSummary, useDeleteImpact } from "./delete-impact";
 import { DotTag } from "./dot-tag";
 import { DownloadStopIndicator } from "./download-cancel-indicator";
 import {
@@ -92,7 +92,6 @@ import {
   GgufDownloadStatusCard,
   GgufDownloadingFallbackCard,
 } from "./gguf-status-cards";
-import { DeleteImpactSummary, useDeleteImpact } from "./delete-impact";
 import { useDeleteConfirmAction } from "./use-delete-confirm-action";
 import { useDownloadCardState } from "./use-download-card-state";
 import { useGgufVariantFetchState } from "./use-gguf-variant-fetch-state";
@@ -111,14 +110,16 @@ const FIT_BADGE: Record<GgufFitClass, FitBadgeMeta> = {
   },
   marginal: {
     label: "Might fit",
+    // Not "loading can fail": _select_gpus scores against FREE VRAM and hands a miss to --fit, so
+    // a busy card costs speed rather than the load. Same words the chat picker uses.
     tooltip:
-      "Might fit. Within the last GB of VRAM headroom, so loading can fail if other apps are using GPU memory.",
+      "Fits your GPU with almost no room to spare. If other apps are using VRAM, it offloads and runs slower.",
     iconClassName: "text-amber-600 dark:text-amber-400",
   },
   partial: {
     label: "Partial offload",
     tooltip:
-      "Partial offload possible. Exceeds VRAM but fits with system RAM offload. Inference will be slower.",
+      "Model doesn't fit but still works with offloading. Expect slower inference.",
     iconClassName: "text-sky-600 dark:text-sky-400",
   },
   ram: {
@@ -822,7 +823,11 @@ export function GgufDownloadCard({
   const deleteTargetLabel = deleteTargetVariant
     ? ggufVariantDisplayLabel(deleteTargetVariant)
     : deleteTarget;
-  const deleteImpact = useDeleteImpact(deleteTarget !== null, repoId, deleteTarget);
+  const deleteImpact = useDeleteImpact(
+    deleteTarget !== null,
+    repoId,
+    deleteTarget,
+  );
   const { deleting, runDelete } = useDeleteConfirmAction({
     action: async () => {
       if (!deleteTarget) return;

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -255,7 +255,12 @@ interface GgufVariantMenuItem {
 
 function createGgufVariantMenuItems(
   variants: readonly GgufVariantDetail[] | null,
-  resources: { gpuGb?: number; systemRamGb?: number; budgetFraction?: number },
+  resources: {
+    gpuGb?: number;
+    gpuCount?: number;
+    systemRamGb?: number;
+    budgetFraction?: number;
+  },
 ): GgufVariantMenuItem[] {
   if (!variants) return [];
   return variants.map((variant) => ({
@@ -556,6 +561,7 @@ export function GgufDownloadCard({
   preferredFileIntent = 0,
   isLoadingThisModel,
   gpuGb,
+  gpuCount,
   systemRamGb,
   cachePath,
   preferLocalCache = false,
@@ -573,6 +579,8 @@ export function GgufDownloadCard({
   preferredFileIntent?: number;
   isLoadingThisModel: boolean;
   gpuGb?: number;
+  /** GPUs gpuGb sums, for the loader's per-card VRAM reserve. */
+  gpuCount?: number;
   systemRamGb?: number;
   cachePath?: string | null;
   preferLocalCache?: boolean;
@@ -640,10 +648,11 @@ export function GgufDownloadCard({
     if (!variants) return null;
     return sortDownloadableGgufVariants(variants, {
       gpuGb,
+      gpuCount,
       systemRamGb,
       budgetFraction,
     });
-  }, [variants, gpuGb, systemRamGb, budgetFraction]);
+  }, [variants, gpuGb, gpuCount, systemRamGb, budgetFraction]);
   const selectLiveGgufVariantStates = useMemo(
     () => createLiveGgufVariantStatesSelector(repoId),
     [repoId],
@@ -668,10 +677,11 @@ export function GgufDownloadCard({
     () =>
       createGgufVariantMenuItems(sortedVariants, {
         gpuGb,
+        gpuCount,
         systemRamGb,
         budgetFraction,
       }),
-    [gpuGb, sortedVariants, systemRamGb, budgetFraction],
+    [gpuGb, gpuCount, sortedVariants, systemRamGb, budgetFraction],
   );
 
   const selectedQuant =
@@ -769,11 +779,12 @@ export function GgufDownloadCard({
       selected
         ? classifyGgufFit(selected.size_bytes, {
             gpuGb,
+            gpuCount,
             systemRamGb,
             budgetFraction,
           })
         : null,
-    [gpuGb, selected?.size_bytes, systemRamGb, budgetFraction],
+    [gpuGb, gpuCount, selected?.size_bytes, systemRamGb, budgetFraction],
   );
   const selectedDownloadSizeLabel = selected
     ? ggufVariantTransferLabel(selected)

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -129,8 +129,11 @@ const FIT_BADGE: Record<GgufFitClass, FitBadgeMeta> = {
     iconClassName: "text-sky-600 dark:text-sky-400",
   },
   oom: {
-    label: "Won't fit",
-    tooltip: "Exceeds combined VRAM and system RAM budget.",
+    label: "Does not fit",
+    // Not "won't fit": llama-server never refuses a GGUF on size, it hands it to --fit. Same words
+    // the chat picker uses, where this class and `partial` share one mark.
+    tooltip:
+      "Model doesn't fit but still works with offloading. Expect slower inference.",
     iconClassName: "text-rose-600 dark:text-rose-400",
   },
 };

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -110,11 +110,12 @@ const FIT_BADGE: Record<GgufFitClass, FitBadgeMeta> = {
     iconClassName: "text-emerald-600 dark:text-emerald-400",
   },
   marginal: {
-    label: "Might fit",
-    // Not "loading can fail": _select_gpus scores against FREE VRAM and hands a miss to --fit, so
-    // a busy card costs speed rather than the load. Same words the chat picker uses.
+    label: "Over budget",
+    // Not conditional on other apps: _vram_usable_mib gives free - reserve, which on an idle card
+    // is exactly the budget this tier has already passed, so the load takes --fit every time.
+    // Same words the chat picker uses.
     tooltip:
-      "Fits your GPU with almost no room to spare. If other apps are using VRAM, it offloads and runs slower.",
+      "Larger than your VRAM Budget allows, so part of it offloads even on an idle GPU. It is still smaller than the card, so raising the budget can keep it resident.",
     iconClassName: "text-amber-600 dark:text-amber-400",
   },
   partial: {

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -23,10 +23,10 @@ import {
 import { usePlatformStore } from "@/config/env";
 import { getCachedModelPath, revealCachedModel } from "@/features/chat";
 import { pinKey, usePinnedModelsStore } from "@/features/model-picker";
-import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { type GgufFitClass, classifyGgufFit } from "@/lib/gguf-fit";
+import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import {
@@ -59,6 +59,7 @@ import {
 } from "../download-manager";
 import { useOnlineStatus } from "../hooks/use-online-status";
 import { type GgufVariantDetail, deleteCachedModel } from "../inventory";
+import { formatBytes } from "../lib/format";
 import {
   ggufFilenamesMatch,
   ggufSelectionOverrideMatchesIntent,
@@ -74,7 +75,6 @@ import {
   normalizeGgufVariantIdentity,
 } from "../lib/model-identity";
 import { useHfTokenStore } from "../stores/hf-token-store";
-import { DeleteImpactSummary, useDeleteImpact } from "./delete-impact";
 import { DotTag } from "./dot-tag";
 import { DownloadStopIndicator } from "./download-cancel-indicator";
 import {
@@ -92,6 +92,7 @@ import {
   GgufDownloadStatusCard,
   GgufDownloadingFallbackCard,
 } from "./gguf-status-cards";
+import { DeleteImpactSummary, useDeleteImpact } from "./delete-impact";
 import { useDeleteConfirmAction } from "./use-delete-confirm-action";
 import { useDownloadCardState } from "./use-download-card-state";
 import { useGgufVariantFetchState } from "./use-gguf-variant-fetch-state";
@@ -826,11 +827,7 @@ export function GgufDownloadCard({
   const deleteTargetLabel = deleteTargetVariant
     ? ggufVariantDisplayLabel(deleteTargetVariant)
     : deleteTarget;
-  const deleteImpact = useDeleteImpact(
-    deleteTarget !== null,
-    repoId,
-    deleteTarget,
-  );
+  const deleteImpact = useDeleteImpact(deleteTarget !== null, repoId, deleteTarget);
   const { deleting, runDelete } = useDeleteConfirmAction({
     action: async () => {
       if (!deleteTarget) return;

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -570,6 +570,7 @@ export function GgufDownloadCard({
   onEject,
   onChange,
   showMemoryBar = true,
+  mediaRuntime = false,
 }: {
   repoId: string;
   isActive: boolean;
@@ -597,6 +598,11 @@ export function GgufDownloadCard({
    *  weights-only verdict anyway, which is a confident number about the wrong
    *  runtime. The picker suppresses these rows for the same reason. */
   showMemoryBar?: boolean;
+  /** This repo is placed by the diffusion planner, not llama-server. Suppresses the fit badges
+   *  for the same reason it suppresses the memory bar: the budget and the offload rules here are
+   *  llama.cpp's, and an oversized diffusion model gets told it "still works with offloading"
+   *  when on a host pool the planner refuses the load outright. */
+  mediaRuntime?: boolean;
 }) {
   const hfToken = useHfTokenStore((s) => s.token);
   const online = useOnlineStatus();
@@ -773,7 +779,9 @@ export function GgufDownloadCard({
     !downloadingThisVariant &&
     !isLoadingThisModel &&
     !selectedIsActive;
-  const showFitInfo = Boolean(gpuGb) || Boolean(systemRamGb);
+  // No verdict beats a wrong one: a media repo's fit is the diffusion planner's question, and
+  // this card only knows how to answer llama.cpp's. The picker still badges those rows.
+  const showFitInfo = !mediaRuntime && (Boolean(gpuGb) || Boolean(systemRamGb));
   const selectedFit = useMemo(
     () =>
       selected

--- a/studio/frontend/src/features/hub/catalog/local-on-device-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/local-on-device-card.tsx
@@ -105,6 +105,8 @@ interface LocalOnDeviceCardProps {
   preferredFileIntent?: number;
 
   gpuGb?: number;
+  /** GPUs gpuGb sums, for the loader's per-card VRAM reserve. */
+  gpuCount?: number;
   systemRamGb?: number;
   unsupportedReason?: string | null;
   onLoad: (opts?: LocalLoadOptions) => void;
@@ -238,6 +240,7 @@ export function LocalOnDeviceCard({
   preferredFileIntent = 0,
 
   gpuGb,
+  gpuCount,
   systemRamGb,
   unsupportedReason,
   onLoad,
@@ -356,6 +359,7 @@ export function LocalOnDeviceCard({
             defaultVariant: currentVariantState.defaultVariant,
             activeGgufVariant: isActive ? activeGgufVariant : null,
             gpuGb,
+            gpuCount,
             systemRamGb,
             budgetFraction,
           })
@@ -366,6 +370,7 @@ export function LocalOnDeviceCard({
       isActive,
       activeGgufVariant,
       gpuGb,
+      gpuCount,
       systemRamGb,
       budgetFraction,
     ],

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -396,6 +396,8 @@ export type ModelInspectorRuntime = {
     status: "fits" | "tight" | "exceeds";
   } | null;
   gpuGb?: number;
+  /** GPUs gpuGb sums, for the loader's per-card VRAM reserve. */
+  gpuCount?: number;
   systemRamGb?: number;
 };
 
@@ -443,6 +445,7 @@ export const ModelInspector = memo(function ModelInspector({
     minMemory,
     vramInfo,
     gpuGb,
+    gpuCount,
     systemRamGb,
   } = runtime;
   const {
@@ -730,6 +733,7 @@ export const ModelInspector = memo(function ModelInspector({
               isLoading={isLoadingThisModel}
               loadingPhase={loadingPhase}
               gpuGb={gpuGb}
+              gpuCount={gpuCount}
               systemRamGb={systemRamGb}
 
               preferredFile={preferredGgufFile}
@@ -766,6 +770,7 @@ export const ModelInspector = memo(function ModelInspector({
               preferredGgufFileIntent={preferredGgufFileIntent}
               isLoadingThisModel={isLoadingThisModel}
               gpuGb={gpuGb}
+              gpuCount={gpuCount}
               systemRamGb={systemRamGb}
               cachePath={model.path}
               knownBytes={model.cachedBytes}

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -755,6 +755,7 @@ export const ModelInspector = memo(function ModelInspector({
           ) : (
             <DownloadSection
               showMemoryBar={!runsOnMediaRuntime}
+              mediaRuntime={runsOnMediaRuntime}
               repoId={model.isLocal ? (model.hubRepoId ?? model.id) : model.id}
               isGguf={model.isGguf}
               isDownloaded={model.isDownloaded}

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -12,8 +12,8 @@ import {
   useChatModelRuntime,
   useChatRuntimeStore,
 } from "@/features/chat";
-import { useHubInfiniteScroll } from "@/features/hub";
 import { useOnlineStatus } from "@/features/hub/hooks/use-online-status";
+import { useHubInfiniteScroll } from "@/features/hub";
 import {
   type ModelPickTarget,
   type PerModelConfig,
@@ -25,12 +25,12 @@ import {
   resolveInitialConfig,
   useActiveModelConfig,
 } from "@/features/model-picker";
-import { taskForMediaPick } from "@/features/model-picker/components/model-selector/audio-picker-policy";
 import { loadOpenAIAutoSwitchSettings } from "@/features/settings";
+import { taskForMediaPick } from "@/features/model-picker/components/model-selector/audio-picker-policy";
+import { diffusionRouteSearch } from "@/lib/diffusion-route-search";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useGpuInfo, useInferenceGpuInfo } from "@/hooks/use-gpu-info";
 import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
-import { diffusionRouteSearch } from "@/lib/diffusion-route-search";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { useNavigate, useSearch } from "@tanstack/react-router";
@@ -43,7 +43,6 @@ import {
   useState,
 } from "react";
 import { ExternalLinkConfirmDialog } from "./catalog/external-link-confirm-dialog";
-import { FreeUpSpaceDialog } from "./catalog/free-up-space-dialog";
 import { HubDetailView } from "./catalog/hub-detail-view";
 import { HubFeed } from "./catalog/hub-feed";
 import { HubModelSettingsView } from "./catalog/hub-model-settings-view";
@@ -64,6 +63,7 @@ import {
   ResultListHeader,
 } from "./catalog/models-table";
 import { ModelsToolbar } from "./catalog/models-toolbar";
+import { FreeUpSpaceDialog } from "./catalog/free-up-space-dialog";
 import { OnDeviceFoldersDialog } from "./catalog/on-device-folders-dialog";
 import { OwnerScopeToggle } from "./catalog/owner-scope-toggle";
 import { useDiscoverSearch } from "./hooks/use-discover-search";
@@ -81,6 +81,12 @@ import { useHubInventory } from "./inventory";
 import { LOCAL_MODEL_SOURCE } from "./inventory/constants";
 import { settingsGgufVariantForRow } from "./inventory/settings-identity";
 import { adoptResidentModelStatus } from "./lib/adopt-inference-status";
+import { subscribeResidentStatusRefresh } from "./lib/resident-status-refresh";
+import {
+  type RefreshSupersession,
+  registerRefresh,
+  supersedingRefresh,
+} from "./lib/superseded-refresh";
 import {
   CHANNEL_TO_SECTION,
   type ChannelId,
@@ -106,14 +112,8 @@ import {
   matchesModelType,
 } from "./lib/model-type-filter";
 import { resolveOwnerProviderLogo } from "./lib/provider-logos";
-import { subscribeResidentStatusRefresh } from "./lib/resident-status-refresh";
-import {
-  type RefreshSupersession,
-  registerRefresh,
-  supersedingRefresh,
-} from "./lib/superseded-refresh";
-import { fingerprintToken } from "./lib/token-fingerprint";
 import { studioPageForTask } from "./lib/unsloth-support";
+import { fingerprintToken } from "./lib/token-fingerprint";
 import {
   buildDiscoverRows,
   detectResultFormat,
@@ -898,11 +898,9 @@ export function ModelsPage() {
         // Models already on disk stay visible regardless of device fit, matching the chat selector.
         (!fitOnDeviceOnly ||
           row.isAvailableOnDevice ||
-          hfModelFitsDevice(
-            row.result,
-            row.result.isGguf ? inferenceGpu : gpu,
-            { budgetFraction },
-          )),
+          hfModelFitsDevice(row.result, row.result.isGguf ? inferenceGpu : gpu, {
+            budgetFraction,
+          })),
     );
   }, [
     budgetFraction,
@@ -1329,8 +1327,7 @@ export function ModelsPage() {
       // `task` is not optional here: only CachedModelRepo carries pipelineTag, so every
       // cached GGUF repo (the reported MiniMax-H3 case) reports its modality on `task`.
       const mediaPage = studioPageForTask(
-        taskForMediaPick(selectedModel.pipelineTag, selectedModel.task) ??
-          undefined,
+        taskForMediaPick(selectedModel.pipelineTag, selectedModel.task) ?? undefined,
       );
       // The target pages read a routed `model` as a Hub id, so a runId that is a PATH would
       // arrive as a repo that does not exist -- prefer the Hub id, which loads the same copy
@@ -1338,8 +1335,7 @@ export function ModelsPage() {
       // (left on today's route, and the backend preflight now refuses it by name) and a
       // cached repo the inventory pinned to its snapshot directory, whose symlinked entries
       // the pages' containment check rejects anyway.
-      const routeId =
-        runId && !looksLikeLocalPath(runId) ? runId : selectedModel.hubRepoId;
+      const routeId = runId && !looksLikeLocalPath(runId) ? runId : selectedModel.hubRepoId;
       if (
         mediaPage &&
         routableToMediaPage(selectedModel.kind, selectedModel.localSource) &&
@@ -1709,13 +1705,42 @@ export function ModelsPage() {
     ],
   );
 
-  const catalogState = useMemo<ModelsCatalogState>(() => {
-    const typeFilterActive = !isDatasetMode && inventoryTypeFilter !== "all";
-    return {
+  const catalogState = useMemo<ModelsCatalogState>(
+    () => {
+      const typeFilterActive =
+        !isDatasetMode && inventoryTypeFilter !== "all";
+      return {
+        tab,
+        discoverRows: listRows,
+        cachedRows: filteredCachedRows,
+        localRows: filteredLocalRows,
+        selectedId,
+        isLoading,
+        downloadedReady,
+        inventoryError,
+        inventoryWarning,
+        query,
+        activeCheckpoint,
+        activeGgufVariant,
+        searchError,
+        searchFailure,
+        online,
+        isDataset: isDatasetMode,
+        inventoryTokens,
+        scannedCount,
+        loadingIntentCount: discoverFetchIntent,
+        hasMore,
+        manualFetchAvailable: discoverManualFetchAvailable,
+        hasActiveFilters:
+          !isFeedMode &&
+          (deferredFormatFilter !== "all" ||
+            deferredCapabilityFilter !== "all" ||
+            (tab === "downloaded" && typeFilterActive)),
+        typeFilterActive,
+      };
+    },
+    [
       tab,
-      discoverRows: listRows,
-      cachedRows: filteredCachedRows,
-      localRows: filteredLocalRows,
       selectedId,
       isLoading,
       downloadedReady,
@@ -1727,46 +1752,21 @@ export function ModelsPage() {
       searchError,
       searchFailure,
       online,
-      isDataset: isDatasetMode,
       inventoryTokens,
       scannedCount,
-      loadingIntentCount: discoverFetchIntent,
       hasMore,
-      manualFetchAvailable: discoverManualFetchAvailable,
-      hasActiveFilters:
-        !isFeedMode &&
-        (deferredFormatFilter !== "all" ||
-          deferredCapabilityFilter !== "all" ||
-          (tab === "downloaded" && typeFilterActive)),
-      typeFilterActive,
-    };
-  }, [
-    tab,
-    selectedId,
-    isLoading,
-    downloadedReady,
-    inventoryError,
-    inventoryWarning,
-    query,
-    activeCheckpoint,
-    activeGgufVariant,
-    searchError,
-    searchFailure,
-    online,
-    inventoryTokens,
-    scannedCount,
-    hasMore,
-    isFeedMode,
-    listRows,
-    filteredCachedRows,
-    filteredLocalRows,
-    isDatasetMode,
-    discoverFetchIntent,
-    discoverManualFetchAvailable,
-    deferredFormatFilter,
-    deferredCapabilityFilter,
-    inventoryTypeFilter,
-  ]);
+      isFeedMode,
+      listRows,
+      filteredCachedRows,
+      filteredLocalRows,
+      isDatasetMode,
+      discoverFetchIntent,
+      discoverManualFetchAvailable,
+      deferredFormatFilter,
+      deferredCapabilityFilter,
+      inventoryTypeFilter,
+    ],
+  );
 
   const catalogPagination = useMemo<ModelsCatalogPagination>(
     () => ({
@@ -2020,6 +2020,7 @@ export function ModelsPage() {
               <HubDetailView
                 model={selectedModel}
                 preferredGgufFile={preferredGgufFile}
+
                 preferredGgufFileIntent={preferredGgufFileIntent}
                 isDataset={isDatasetMode}
                 metadataUnavailable={metadataUnavailable}
@@ -2044,6 +2045,7 @@ export function ModelsPage() {
               <HubDetailView
                 model={selectedModel}
                 preferredGgufFile={preferredGgufFile}
+
                 preferredGgufFileIntent={preferredGgufFileIntent}
                 isDataset={isDatasetMode}
                 metadataUnavailable={metadataUnavailable}

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -900,6 +900,7 @@ export function ModelsPage() {
           row.isAvailableOnDevice ||
           hfModelFitsDevice(row.result, row.result.isGguf ? inferenceGpu : gpu, {
             budgetFraction,
+            gpuCount: inferenceGpu.deviceCount,
           })),
     );
   }, [
@@ -943,7 +944,10 @@ export function ModelsPage() {
           (row) =>
             !fitOnDeviceOnly ||
             row.isAvailableOnDevice ||
-            hfModelFitsDevice(row.result, inferenceGpu, { budgetFraction }),
+            hfModelFitsDevice(row.result, inferenceGpu, {
+              budgetFraction,
+              gpuCount: inferenceGpu.deviceCount,
+            }),
         ),
     [
       budgetFraction,
@@ -1664,6 +1668,7 @@ export function ModelsPage() {
       minMemory,
       vramInfo,
       gpuGb: inferenceGpu.available ? inferenceGpu.memoryTotalGb : undefined,
+      gpuCount: inferenceGpu.deviceCount,
       systemRamGb:
         inferenceGpu.systemRamAvailableGb > 0
           ? inferenceGpu.systemRamAvailableGb
@@ -1678,6 +1683,7 @@ export function ModelsPage() {
       vramInfo,
       inferenceGpu.available,
       inferenceGpu.memoryTotalGb,
+      inferenceGpu.deviceCount,
       inferenceGpu.systemRamAvailableGb,
     ],
   );

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -22,6 +22,7 @@ import {
   applyPerModelConfigToRuntime,
   currentRuntimePerModelConfig,
   hfModelFitsDevice,
+  loadScopedGpu,
   resolveInitialConfig,
   useActiveModelConfig,
 } from "@/features/model-picker";
@@ -71,6 +72,7 @@ import { useFeedWriteBack } from "./hooks/use-feed-write-back";
 import { useHiddenEmbeddingModelIds } from "./hooks/use-hidden-embedding-models";
 import { useHubFeed } from "./hooks/use-hub-feed";
 import type {
+  HfModelResult,
   HfModelSearchChannel,
   HfSortDirection,
   HfSortKey,
@@ -378,6 +380,27 @@ export function ModelsPage() {
   // the 0.97 default without it, so lowering the setting moved the badges and not the filter.
   const budgetFraction = useVramBudgetFraction() ?? undefined;
   const inferenceGpu = useInferenceGpuInfo();
+  // One fit answer for every Hub row, picked the way the task pickers pick it: by the runtime that
+  // PLACES the row. An image or video repo goes to the diffusion planner, on one torch device,
+  // under the media rule, so judging it by llama.cpp's budget kept a 52 GiB media GGUF that clears
+  // 62.1 GiB on a 64 GiB Mac and blows the planner's 44.8. Everything else keeps the GGUF
+  // backend's own inventory, which is the one thing llama.cpp rows must be judged against.
+  const rowFitsDevice = useCallback(
+    (result: HfModelResult) => {
+      const mediaRow = studioPageForTask(result.pipelineTag) !== undefined;
+      const source = loadScopedGpu(
+        mediaRow || !result.isGguf ? gpu : inferenceGpu,
+        mediaRow,
+      );
+      return hfModelFitsDevice(result, source, {
+        budgetFraction,
+        gpuCount: source.deviceCount,
+        mediaLoad: mediaRow,
+        hostPooledMemory: gpu.loadDeviceSharesHostMemory,
+      });
+    },
+    [budgetFraction, gpu, inferenceGpu],
+  );
   // Browser reachability, which is what every client here asks about: the
   // selected model's metadata and the cached feed each issue their own request.
   // On the discovery phase they would stay blocked at "probing" until a
@@ -898,13 +921,10 @@ export function ModelsPage() {
         // Models already on disk stay visible regardless of device fit, matching the chat selector.
         (!fitOnDeviceOnly ||
           row.isAvailableOnDevice ||
-          hfModelFitsDevice(row.result, row.result.isGguf ? inferenceGpu : gpu, {
-            budgetFraction,
-            gpuCount: inferenceGpu.deviceCount,
-          })),
+          rowFitsDevice(row.result)),
     );
   }, [
-    budgetFraction,
+    rowFitsDevice,
     discoverRows,
     hiddenEmbeddingModelIds,
     isDatasetMode,
@@ -913,8 +933,6 @@ export function ModelsPage() {
     deferredCapabilityFilter,
     activeChannel,
     fitOnDeviceOnly,
-    gpu,
-    inferenceGpu,
   ]);
 
   const listRows = filteredDiscoverRows;
@@ -944,13 +962,11 @@ export function ModelsPage() {
           (row) =>
             !fitOnDeviceOnly ||
             row.isAvailableOnDevice ||
-            hfModelFitsDevice(row.result, inferenceGpu, {
-              budgetFraction,
-              gpuCount: inferenceGpu.deviceCount,
-            }),
+            rowFitsDevice(row.result),
         ),
     [
       budgetFraction,
+      rowFitsDevice,
       hubFeed.trending.results,
       hiddenEmbeddingModelIds,
       modelDiscoveryInventorySignature,

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -901,7 +901,7 @@ export function ModelsPage() {
           hfModelFitsDevice(
             row.result,
             row.result.isGguf ? inferenceGpu : gpu,
-            budgetFraction,
+            { budgetFraction },
           )),
     );
   }, [
@@ -945,7 +945,7 @@ export function ModelsPage() {
           (row) =>
             !fitOnDeviceOnly ||
             row.isAvailableOnDevice ||
-            hfModelFitsDevice(row.result, inferenceGpu, budgetFraction),
+            hfModelFitsDevice(row.result, inferenceGpu, { budgetFraction }),
         ),
     [
       budgetFraction,

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -12,8 +12,8 @@ import {
   useChatModelRuntime,
   useChatRuntimeStore,
 } from "@/features/chat";
-import { useOnlineStatus } from "@/features/hub/hooks/use-online-status";
 import { useHubInfiniteScroll } from "@/features/hub";
+import { useOnlineStatus } from "@/features/hub/hooks/use-online-status";
 import {
   type ModelPickTarget,
   type PerModelConfig,
@@ -25,11 +25,12 @@ import {
   resolveInitialConfig,
   useActiveModelConfig,
 } from "@/features/model-picker";
-import { loadOpenAIAutoSwitchSettings } from "@/features/settings";
 import { taskForMediaPick } from "@/features/model-picker/components/model-selector/audio-picker-policy";
-import { diffusionRouteSearch } from "@/lib/diffusion-route-search";
+import { loadOpenAIAutoSwitchSettings } from "@/features/settings";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useGpuInfo, useInferenceGpuInfo } from "@/hooks/use-gpu-info";
+import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
+import { diffusionRouteSearch } from "@/lib/diffusion-route-search";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { useNavigate, useSearch } from "@tanstack/react-router";
@@ -42,6 +43,7 @@ import {
   useState,
 } from "react";
 import { ExternalLinkConfirmDialog } from "./catalog/external-link-confirm-dialog";
+import { FreeUpSpaceDialog } from "./catalog/free-up-space-dialog";
 import { HubDetailView } from "./catalog/hub-detail-view";
 import { HubFeed } from "./catalog/hub-feed";
 import { HubModelSettingsView } from "./catalog/hub-model-settings-view";
@@ -62,7 +64,6 @@ import {
   ResultListHeader,
 } from "./catalog/models-table";
 import { ModelsToolbar } from "./catalog/models-toolbar";
-import { FreeUpSpaceDialog } from "./catalog/free-up-space-dialog";
 import { OnDeviceFoldersDialog } from "./catalog/on-device-folders-dialog";
 import { OwnerScopeToggle } from "./catalog/owner-scope-toggle";
 import { useDiscoverSearch } from "./hooks/use-discover-search";
@@ -80,12 +81,6 @@ import { useHubInventory } from "./inventory";
 import { LOCAL_MODEL_SOURCE } from "./inventory/constants";
 import { settingsGgufVariantForRow } from "./inventory/settings-identity";
 import { adoptResidentModelStatus } from "./lib/adopt-inference-status";
-import { subscribeResidentStatusRefresh } from "./lib/resident-status-refresh";
-import {
-  type RefreshSupersession,
-  registerRefresh,
-  supersedingRefresh,
-} from "./lib/superseded-refresh";
 import {
   CHANNEL_TO_SECTION,
   type ChannelId,
@@ -111,8 +106,14 @@ import {
   matchesModelType,
 } from "./lib/model-type-filter";
 import { resolveOwnerProviderLogo } from "./lib/provider-logos";
-import { studioPageForTask } from "./lib/unsloth-support";
+import { subscribeResidentStatusRefresh } from "./lib/resident-status-refresh";
+import {
+  type RefreshSupersession,
+  registerRefresh,
+  supersedingRefresh,
+} from "./lib/superseded-refresh";
 import { fingerprintToken } from "./lib/token-fingerprint";
+import { studioPageForTask } from "./lib/unsloth-support";
 import {
   buildDiscoverRows,
   detectResultFormat,
@@ -373,6 +374,9 @@ function selectedRepoMatchesRuntime(
 export function ModelsPage() {
   const navigate = useNavigate();
   const gpu = useGpuInfo();
+  // The saved VRAM Budget the loader admits against. The "Fits on device" filter scored against
+  // the 0.97 default without it, so lowering the setting moved the badges and not the filter.
+  const budgetFraction = useVramBudgetFraction() ?? undefined;
   const inferenceGpu = useInferenceGpuInfo();
   // Browser reachability, which is what every client here asks about: the
   // selected model's metadata and the cached feed each issue their own request.
@@ -897,9 +901,11 @@ export function ModelsPage() {
           hfModelFitsDevice(
             row.result,
             row.result.isGguf ? inferenceGpu : gpu,
+            budgetFraction,
           )),
     );
   }, [
+    budgetFraction,
     discoverRows,
     hiddenEmbeddingModelIds,
     isDatasetMode,
@@ -939,9 +945,10 @@ export function ModelsPage() {
           (row) =>
             !fitOnDeviceOnly ||
             row.isAvailableOnDevice ||
-            hfModelFitsDevice(row.result, inferenceGpu),
+            hfModelFitsDevice(row.result, inferenceGpu, budgetFraction),
         ),
     [
+      budgetFraction,
       hubFeed.trending.results,
       hiddenEmbeddingModelIds,
       modelDiscoveryInventorySignature,
@@ -1322,7 +1329,8 @@ export function ModelsPage() {
       // `task` is not optional here: only CachedModelRepo carries pipelineTag, so every
       // cached GGUF repo (the reported MiniMax-H3 case) reports its modality on `task`.
       const mediaPage = studioPageForTask(
-        taskForMediaPick(selectedModel.pipelineTag, selectedModel.task) ?? undefined,
+        taskForMediaPick(selectedModel.pipelineTag, selectedModel.task) ??
+          undefined,
       );
       // The target pages read a routed `model` as a Hub id, so a runId that is a PATH would
       // arrive as a repo that does not exist -- prefer the Hub id, which loads the same copy
@@ -1330,7 +1338,8 @@ export function ModelsPage() {
       // (left on today's route, and the backend preflight now refuses it by name) and a
       // cached repo the inventory pinned to its snapshot directory, whose symlinked entries
       // the pages' containment check rejects anyway.
-      const routeId = runId && !looksLikeLocalPath(runId) ? runId : selectedModel.hubRepoId;
+      const routeId =
+        runId && !looksLikeLocalPath(runId) ? runId : selectedModel.hubRepoId;
       if (
         mediaPage &&
         routableToMediaPage(selectedModel.kind, selectedModel.localSource) &&
@@ -1700,42 +1709,13 @@ export function ModelsPage() {
     ],
   );
 
-  const catalogState = useMemo<ModelsCatalogState>(
-    () => {
-      const typeFilterActive =
-        !isDatasetMode && inventoryTypeFilter !== "all";
-      return {
-        tab,
-        discoverRows: listRows,
-        cachedRows: filteredCachedRows,
-        localRows: filteredLocalRows,
-        selectedId,
-        isLoading,
-        downloadedReady,
-        inventoryError,
-        inventoryWarning,
-        query,
-        activeCheckpoint,
-        activeGgufVariant,
-        searchError,
-        searchFailure,
-        online,
-        isDataset: isDatasetMode,
-        inventoryTokens,
-        scannedCount,
-        loadingIntentCount: discoverFetchIntent,
-        hasMore,
-        manualFetchAvailable: discoverManualFetchAvailable,
-        hasActiveFilters:
-          !isFeedMode &&
-          (deferredFormatFilter !== "all" ||
-            deferredCapabilityFilter !== "all" ||
-            (tab === "downloaded" && typeFilterActive)),
-        typeFilterActive,
-      };
-    },
-    [
+  const catalogState = useMemo<ModelsCatalogState>(() => {
+    const typeFilterActive = !isDatasetMode && inventoryTypeFilter !== "all";
+    return {
       tab,
+      discoverRows: listRows,
+      cachedRows: filteredCachedRows,
+      localRows: filteredLocalRows,
       selectedId,
       isLoading,
       downloadedReady,
@@ -1747,21 +1727,46 @@ export function ModelsPage() {
       searchError,
       searchFailure,
       online,
+      isDataset: isDatasetMode,
       inventoryTokens,
       scannedCount,
+      loadingIntentCount: discoverFetchIntent,
       hasMore,
-      isFeedMode,
-      listRows,
-      filteredCachedRows,
-      filteredLocalRows,
-      isDatasetMode,
-      discoverFetchIntent,
-      discoverManualFetchAvailable,
-      deferredFormatFilter,
-      deferredCapabilityFilter,
-      inventoryTypeFilter,
-    ],
-  );
+      manualFetchAvailable: discoverManualFetchAvailable,
+      hasActiveFilters:
+        !isFeedMode &&
+        (deferredFormatFilter !== "all" ||
+          deferredCapabilityFilter !== "all" ||
+          (tab === "downloaded" && typeFilterActive)),
+      typeFilterActive,
+    };
+  }, [
+    tab,
+    selectedId,
+    isLoading,
+    downloadedReady,
+    inventoryError,
+    inventoryWarning,
+    query,
+    activeCheckpoint,
+    activeGgufVariant,
+    searchError,
+    searchFailure,
+    online,
+    inventoryTokens,
+    scannedCount,
+    hasMore,
+    isFeedMode,
+    listRows,
+    filteredCachedRows,
+    filteredLocalRows,
+    isDatasetMode,
+    discoverFetchIntent,
+    discoverManualFetchAvailable,
+    deferredFormatFilter,
+    deferredCapabilityFilter,
+    inventoryTypeFilter,
+  ]);
 
   const catalogPagination = useMemo<ModelsCatalogPagination>(
     () => ({
@@ -2015,7 +2020,6 @@ export function ModelsPage() {
               <HubDetailView
                 model={selectedModel}
                 preferredGgufFile={preferredGgufFile}
-
                 preferredGgufFileIntent={preferredGgufFileIntent}
                 isDataset={isDatasetMode}
                 metadataUnavailable={metadataUnavailable}
@@ -2040,7 +2044,6 @@ export function ModelsPage() {
               <HubDetailView
                 model={selectedModel}
                 preferredGgufFile={preferredGgufFile}
-
                 preferredGgufFileIntent={preferredGgufFileIntent}
                 isDataset={isDatasetMode}
                 metadataUnavailable={metadataUnavailable}

--- a/studio/frontend/src/features/hub/lib/gguf-variant-sort.ts
+++ b/studio/frontend/src/features/hub/lib/gguf-variant-sort.ts
@@ -12,6 +12,9 @@ type GgufVariantResources = {
   /** The saved VRAM Budget, so the sort ranks against the line the loader will
    *  actually admit at rather than against the default. */
   budgetFraction?: number;
+  /** GPUs gpuGb sums, so the sort charges the loader's per-card VRAM reserve as
+   *  many times as the loader does. */
+  gpuCount?: number;
 };
 
 export function ggufVariantDisplayLabel(

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
@@ -23,6 +23,7 @@ import {
   curatedArtifactFitsDevice,
   curatedDisplayNameFor,
   curatedRowLabelFor,
+  ggufFitRuns,
   groupForRepoId,
   groupMatchesQuery,
   loadSpecFor,
@@ -33,8 +34,14 @@ import {
 
 // ── canonicalKeyFor: suffix stripping, owner preserved ─────────────────────────
 
-assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-GGUF"), "unsloth/qwen-image-2512");
-assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-FP8"), "unsloth/qwen-image-2512");
+assert.equal(
+  canonicalKeyFor("unsloth/Qwen-Image-2512-GGUF"),
+  "unsloth/qwen-image-2512",
+);
+assert.equal(
+  canonicalKeyFor("unsloth/Qwen-Image-2512-FP8"),
+  "unsloth/qwen-image-2512",
+);
 assert.equal(
   canonicalKeyFor("unsloth/Qwen-Image-2512-unsloth-bnb-4bit"),
   "unsloth/qwen-image-2512",
@@ -43,15 +50,36 @@ assert.equal(
   canonicalKeyFor("ideogram-ai/ideogram-4-nf4-diffusers"),
   "ideogram-ai/ideogram-4",
 );
-assert.equal(canonicalKeyFor("Wan-AI/Wan2.2-TI2V-5B-Diffusers"), "wan-ai/wan2.2-ti2v-5b");
+assert.equal(
+  canonicalKeyFor("Wan-AI/Wan2.2-TI2V-5B-Diffusers"),
+  "wan-ai/wan2.2-ti2v-5b",
+);
 assert.equal(canonicalKeyFor("lightricks/ltx-2.3-fp8"), "lightricks/ltx-2.3");
 // Prequant suffixes strip regardless of case: -GGUF/-FP8/-int8/-nvfp4 all route to the base name.
-assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-int8"), "unsloth/qwen-image-2512");
-assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-INT8"), "unsloth/qwen-image-2512");
-assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-nvfp4"), "unsloth/qwen-image-2512");
-assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-NVFP4"), "unsloth/qwen-image-2512");
-assert.equal(canonicalKeyFor("unsloth/qwen-image-2512-gguf"), "unsloth/qwen-image-2512");
-assert.equal(canonicalKeyFor("unsloth/qwen-image-2512-fp8"), "unsloth/qwen-image-2512");
+assert.equal(
+  canonicalKeyFor("unsloth/Qwen-Image-2512-int8"),
+  "unsloth/qwen-image-2512",
+);
+assert.equal(
+  canonicalKeyFor("unsloth/Qwen-Image-2512-INT8"),
+  "unsloth/qwen-image-2512",
+);
+assert.equal(
+  canonicalKeyFor("unsloth/Qwen-Image-2512-nvfp4"),
+  "unsloth/qwen-image-2512",
+);
+assert.equal(
+  canonicalKeyFor("unsloth/Qwen-Image-2512-NVFP4"),
+  "unsloth/qwen-image-2512",
+);
+assert.equal(
+  canonicalKeyFor("unsloth/qwen-image-2512-gguf"),
+  "unsloth/qwen-image-2512",
+);
+assert.equal(
+  canonicalKeyFor("unsloth/qwen-image-2512-fp8"),
+  "unsloth/qwen-image-2512",
+);
 
 // ── stripArtifactSuffixesForDisplay: case-preserving base name for row labels ──
 
@@ -103,14 +131,23 @@ for (const artifact of qwen2512.artifacts) {
 // Cross-owner aliases resolve only because they are declared.
 assert.equal(groupForRepoId("Qwen/Qwen-Image-2512", IMAGE_CATALOG), qwen2512);
 // Undeclared prequant variants (any case) route to the base group via the stripped key.
-assert.equal(groupForRepoId("unsloth/Qwen-Image-2512-INT8", IMAGE_CATALOG), qwen2512);
-assert.equal(groupForRepoId("unsloth/Qwen-Image-2512-NVFP4", IMAGE_CATALOG), qwen2512);
+assert.equal(
+  groupForRepoId("unsloth/Qwen-Image-2512-INT8", IMAGE_CATALOG),
+  qwen2512,
+);
+assert.equal(
+  groupForRepoId("unsloth/Qwen-Image-2512-NVFP4", IMAGE_CATALOG),
+  qwen2512,
+);
 assert.equal(
   groupForRepoId("Tongyi-MAI/Z-Image-Turbo", IMAGE_CATALOG)?.canonicalId,
   "unsloth/Z-Image-Turbo",
 );
 // A sibling artifact of an aliased owner groups via the alias' stripped key.
-assert.equal(groupForRepoId("Qwen/Qwen-Image-2512-FP8", IMAGE_CATALOG), qwen2512);
+assert.equal(
+  groupForRepoId("Qwen/Qwen-Image-2512-FP8", IMAGE_CATALOG),
+  qwen2512,
+);
 // Unknown repos pass through ungrouped.
 assert.equal(groupForRepoId("someone/some-model-GGUF", IMAGE_CATALOG), null);
 assert.equal(groupForRepoId("unsloth/Llama-3.3-70B-GGUF", VIDEO_CATALOG), null);
@@ -145,7 +182,10 @@ for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG, AUDIO_CATALOG]) {
   for (const group of catalog) {
     for (const artifact of group.artifacts) {
       const lowered = artifact.repoId.toLowerCase();
-      assert.ok(!seen.has(lowered), `duplicate artifact id: ${artifact.repoId}`);
+      assert.ok(
+        !seen.has(lowered),
+        `duplicate artifact id: ${artifact.repoId}`,
+      );
       seen.add(lowered);
       assert.equal(
         groupForRepoId(artifact.repoId, catalog),
@@ -153,7 +193,10 @@ for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG, AUDIO_CATALOG]) {
         `artifact ${artifact.repoId} resolves to a different group`,
       );
       if (artifact.loadKind === "single_file") {
-        assert.ok(artifact.filename, `single_file ${artifact.repoId} needs a filename`);
+        assert.ok(
+          artifact.filename,
+          `single_file ${artifact.repoId} needs a filename`,
+        );
       }
     }
     for (const alias of group.aliases ?? []) {
@@ -199,11 +242,16 @@ for (const id of OLD_PIPELINE_MODELS) {
   assert.equal(got.kind, "pipeline", id);
 }
 // GGUF artifacts report the gguf kind; unknown ids report null.
-assert.equal(loadSpecFor("unsloth/Z-Image-Turbo-GGUF", IMAGE_CATALOG)?.kind, "gguf");
+assert.equal(
+  loadSpecFor("unsloth/Z-Image-Turbo-GGUF", IMAGE_CATALOG)?.kind,
+  "gguf",
+);
 assert.equal(loadSpecFor("someone/unknown", IMAGE_CATALOG), null);
 
 // Every old curated id is still present as an option (backwards compat).
-const imageOptionIds = new Set(catalogToModelOptions(IMAGE_CATALOG).map((o) => o.id));
+const imageOptionIds = new Set(
+  catalogToModelOptions(IMAGE_CATALOG).map((o) => o.id),
+);
 for (const id of [
   "unsloth/Z-Image-Turbo-GGUF",
   "unsloth/Z-Image-GGUF",
@@ -219,7 +267,9 @@ for (const id of [
 ]) {
   assert.ok(imageOptionIds.has(id), `image option missing: ${id}`);
 }
-const videoOptionIds = new Set(catalogToModelOptions(VIDEO_CATALOG).map((o) => o.id));
+const videoOptionIds = new Set(
+  catalogToModelOptions(VIDEO_CATALOG).map((o) => o.id),
+);
 for (const id of [
   "unsloth/LTX-2.3-GGUF",
   "unsloth/MiniMax-H3-GGUF",
@@ -256,18 +306,24 @@ assert.deepEqual(curatedRowLabelFor("unsloth/MiniMax-H3-GGUF", VIDEO_CATALOG), {
   name: "MiniMax-H3-GGUF",
   tags: [],
 });
-assert.deepEqual(curatedRowLabelFor("unsloth/Z-Image-Turbo-GGUF", IMAGE_CATALOG), {
-  name: "Z-Image-Turbo-GGUF",
-  tags: [],
-});
+assert.deepEqual(
+  curatedRowLabelFor("unsloth/Z-Image-Turbo-GGUF", IMAGE_CATALOG),
+  {
+    name: "Z-Image-Turbo-GGUF",
+    tags: [],
+  },
+);
 
 // ── host-aware rows ────────────────────────────────────────────────────────────
 // On a host that can place a diffusion pipeline, the two H3 rows say which is which. The gap is
 // roughly 10x, and the names alone gave the user nothing to choose on.
-assert.deepEqual(curatedRowLabelFor("MiniMaxAI/MiniMax-H3", VIDEO_CATALOG, "accelerated"), {
-  name: "MiniMax H3 (Fast FP8)",
-  tags: ["BF16"],
-});
+assert.deepEqual(
+  curatedRowLabelFor("MiniMaxAI/MiniMax-H3", VIDEO_CATALOG, "accelerated"),
+  {
+    name: "MiniMax H3 (Fast FP8)",
+    tags: ["BF16"],
+  },
+);
 assert.deepEqual(
   curatedRowLabelFor("unsloth/MiniMax-H3-GGUF", VIDEO_CATALOG, "accelerated"),
   { name: "MiniMax-H3-GGUF (Slow)", tags: [] },
@@ -284,7 +340,11 @@ assert.equal(
   "MiniMax H3 (Fast FP8)",
 );
 assert.equal(
-  curatedDisplayNameFor("unsloth/MiniMax-H3-GGUF", VIDEO_CATALOG, "accelerated"),
+  curatedDisplayNameFor(
+    "unsloth/MiniMax-H3-GGUF",
+    VIDEO_CATALOG,
+    "accelerated",
+  ),
   "MiniMax-H3-GGUF (Slow)",
 );
 // No other model claims a speed nobody measured.
@@ -316,7 +376,9 @@ for (const [label, catalog] of [
   ["image", IMAGE_CATALOG],
   ["audio", AUDIO_CATALOG],
 ] as const) {
-  const offered = new Set(catalogToModelOptions(catalog, "gguf-only").map((o) => o.id));
+  const offered = new Set(
+    catalogToModelOptions(catalog, "gguf-only").map((o) => o.id),
+  );
   for (const group of catalog) {
     assert.ok(
       group.artifacts.some((artifact) => offered.has(artifact.repoId)),
@@ -335,7 +397,10 @@ for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG, AUDIO_CATALOG]) {
     for (const artifact of group.artifacts) {
       if (artifact.format !== "gguf") continue;
       const row = curatedRowLabelFor(artifact.repoId, catalog);
-      assert.ok(row?.name.endsWith("-GGUF"), `${artifact.repoId} row reads "${row?.name}"`);
+      assert.ok(
+        row?.name.endsWith("-GGUF"),
+        `${artifact.repoId} row reads "${row?.name}"`,
+      );
       assert.deepEqual(row?.tags, []);
     }
   }
@@ -364,7 +429,10 @@ assert.deepEqual(curatedRowLabelFor("Lightricks/LTX-2", VIDEO_CATALOG), {
   name: "LTX 2 (base)",
   tags: [],
 });
-assert.equal(curatedRowLabelFor("someone/not-in-the-catalog", VIDEO_CATALOG), null);
+assert.equal(
+  curatedRowLabelFor("someone/not-in-the-catalog", VIDEO_CATALOG),
+  null,
+);
 
 // No two rows of a group may render identically, or the picker offers the same thing twice.
 for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG]) {
@@ -374,7 +442,11 @@ for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG]) {
       const row = curatedRowLabelFor(artifact.repoId, catalog);
       assert.ok(row, `${artifact.repoId} is in the catalog it came from`);
       const key = `${row.name} | ${row.tags.join(",")}`;
-      assert.equal(seen.has(key), false, `${group.displayName}: two rows both read "${key}"`);
+      assert.equal(
+        seen.has(key),
+        false,
+        `${group.displayName}: two rows both read "${key}"`,
+      );
       seen.add(key);
     }
   }
@@ -464,14 +536,39 @@ assert.equal(
 // ── classifyGgufFit ────────────────────────────────────────────────────────────
 
 const GB = 1024 ** 3;
+// Delegated to lib/gguf-fit, the formula the Hub badge uses: 0.97 of the card (or the saved VRAM
+// Budget) against weights + KV, then RAM offload at 0.5. The rule here used to be 0.7 of each
+// against the raw file size, which matched neither the Hub nor the loader.
 assert.equal(classifyGgufFit(10 * GB, { gpuGb: 24, systemRamGb: 64 }), "fits");
-assert.equal(classifyGgufFit(20 * GB, { gpuGb: 24, systemRamGb: 64 }), "tight");
+// 20 GiB needs 24.0: past the 23.28 budget, still inside the 24 GiB card.
+assert.equal(
+  classifyGgufFit(20 * GB, { gpuGb: 24, systemRamGb: 64 }),
+  "marginal",
+);
+// 40 GiB needs 47.0: past the card, inside card + RAM offload.
+assert.equal(
+  classifyGgufFit(40 * GB, { gpuGb: 24, systemRamGb: 64 }),
+  "partial",
+);
 assert.equal(classifyGgufFit(100 * GB, { gpuGb: 24, systemRamGb: 64 }), "oom");
 // Unknown device: never scare with OOM.
 assert.equal(classifyGgufFit(100 * GB, { gpuGb: 0, systemRamGb: 0 }), "fits");
-// Unified-memory host (no GPU budget): fit-or-oom against RAM.
-assert.equal(classifyGgufFit(30 * GB, { gpuGb: 0, systemRamGb: 64 }), "fits");
+// No GPU at all: RAM alone, at the 0.5 offload share.
+assert.equal(classifyGgufFit(20 * GB, { gpuGb: 0, systemRamGb: 64 }), "ram");
 assert.equal(classifyGgufFit(60 * GB, { gpuGb: 0, systemRamGb: 64 }), "oom");
+// The saved VRAM Budget moves the line. The old rule ignored the setting entirely, so lowering it
+// changed the Hub's verdict and left the picker's untouched.
+assert.equal(
+  classifyGgufFit(16 * GB, { gpuGb: 24, systemRamGb: 0, budgetFraction: 0.97 }),
+  "fits",
+);
+assert.equal(
+  classifyGgufFit(16 * GB, { gpuGb: 24, systemRamGb: 0, budgetFraction: 0.8 }),
+  "marginal",
+);
+// Only oom fails to load; marginal and partial both run.
+assert.equal(ggufFitRuns("partial"), true);
+assert.equal(ggufFitRuns("oom"), false);
 
 // ── pickDefaultQuant ───────────────────────────────────────────────────────────
 
@@ -520,28 +617,40 @@ const notDownloaded = () => false;
 const qwenGroup = qwen2512;
 // 8 GB consumer GPU: nothing prequant fits (fp8 24 GB, bnb 14 GB) -> GGUF.
 assert.equal(
-  pickDefaultArtifact(qwenGroup, { gpuGb: 8, systemRamGb: 32, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(qwenGroup, {
+    gpuGb: 8,
+    systemRamGb: 32,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 // 24 GB: bnb-4bit (14 GB) fits the 16.8 GB budget.
 assert.equal(
-  pickDefaultArtifact(qwenGroup, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(qwenGroup, {
+    gpuGb: 24,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).format,
   "bnb-4bit",
 );
 // 48 GB: still bnb-4bit. The group has no fp8 artifact -- fp8 is family-denied for qwen-image
 // (it renders black), and the -FP8 repo ships prequant .pt checkpoints, not a single-file
 // safetensors, so the row that used to win here auto-routed to a download that 404s.
 assert.equal(
-  pickDefaultArtifact(qwenGroup, { gpuGb: 48, systemRamGb: 64, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(qwenGroup, {
+    gpuGb: 48,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).format,
   "bnb-4bit",
 );
 // Unknown device: GGUF (the backend plans offload itself).
 assert.equal(
-  pickDefaultArtifact(qwenGroup, { gpuGb: 0, systemRamGb: 0, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(qwenGroup, {
+    gpuGb: 0,
+    systemRamGb: 0,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 // Downloaded-first: a downloaded bnb-4bit beats everything undownloaded.
@@ -566,16 +675,22 @@ assert.equal(
 const ideogram = groupForRepoId("ideogram-ai/ideogram-4-fp8", IMAGE_CATALOG);
 assert.ok(ideogram);
 assert.equal(
-  pickDefaultArtifact(ideogram, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
-    .repoId,
+  pickDefaultArtifact(ideogram, {
+    gpuGb: 24,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).repoId,
   "ideogram-ai/ideogram-4-nf4-diffusers",
 );
 // A gated BF16 artifact (FLUX.1-dev) is NOT auto-routed when undownloaded even on a big GPU: the download would fail without license/token access.
 const fluxDevRoute = groupForRepoId("unsloth/FLUX.1-dev", IMAGE_CATALOG);
 assert.ok(fluxDevRoute);
 assert.equal(
-  pickDefaultArtifact(fluxDevRoute, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(fluxDevRoute, {
+    gpuGb: 80,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 // But an already-downloaded gated BF16 (the user clearly has access) is still returned.
@@ -588,11 +703,17 @@ assert.equal(
   "black-forest-labs/FLUX.1-dev",
 );
 // FLUX.1 Krea dev: gated BF16 skipped when undownloaded -> the open QuantStack GGUF, whose repo id also resolves to the group.
-const kreaDevRoute = groupForRepoId("black-forest-labs/FLUX.1-Krea-dev", IMAGE_CATALOG);
+const kreaDevRoute = groupForRepoId(
+  "black-forest-labs/FLUX.1-Krea-dev",
+  IMAGE_CATALOG,
+);
 assert.ok(kreaDevRoute);
 assert.equal(
-  pickDefaultArtifact(kreaDevRoute, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
-    .repoId,
+  pickDefaultArtifact(kreaDevRoute, {
+    gpuGb: 80,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).repoId,
   "QuantStack/FLUX.1-Krea-dev-GGUF",
 );
 assert.equal(
@@ -603,11 +724,17 @@ assert.equal(
 const lumina = groupForRepoId("Alpha-VLLM/Lumina-Image-2.0", IMAGE_CATALOG);
 assert.ok(lumina);
 assert.equal(
-  pickDefaultArtifact(lumina, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
-    .repoId,
+  pickDefaultArtifact(lumina, {
+    gpuGb: 24,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).repoId,
   "Alpha-VLLM/Lumina-Image-2.0",
 );
-assert.equal(loadSpecFor("Alpha-VLLM/Lumina-Image-2.0", IMAGE_CATALOG)?.kind, "pipeline");
+assert.equal(
+  loadSpecFor("Alpha-VLLM/Lumina-Image-2.0", IMAGE_CATALOG)?.kind,
+  "pipeline",
+);
 // HunyuanImage 2.1: the 50 GB bf16 pipeline misses a 24 GB card so a bare click routes to the QuantStack GGUF; on a large GPU bf16 wins. Both ids share one group.
 const hyimage = groupForRepoId(
   "hunyuanvideo-community/HunyuanImage-2.1-Diffusers",
@@ -618,36 +745,61 @@ assert.ok(hyimage);
 // from the Hub, so the group has no quant ladder left. 50 GB still fits a 24 GB card's 61.6 GB
 // budget, so this asserts the group did not silently vanish along with its GGUF.
 assert.equal(
-  pickDefaultArtifact(hyimage, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
-    .repoId,
+  pickDefaultArtifact(hyimage, {
+    gpuGb: 24,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).repoId,
   "hunyuanvideo-community/HunyuanImage-2.1-Diffusers",
 );
 assert.equal(
-  pickDefaultArtifact(hyimage, { gpuGb: 141, systemRamGb: 128, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(hyimage, {
+    gpuGb: 141,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).format,
   "bf16",
 );
 // HiDream I1: all three variants group together, a datacenter GPU auto-routes to the Full bf16 (catalog order wins among equal sizes), and 24 GB hides the group.
 const hidream = groupForRepoId("HiDream-ai/HiDream-I1-Full", IMAGE_CATALOG);
 assert.ok(hidream);
-assert.equal(groupForRepoId("HiDream-ai/HiDream-I1-Dev", IMAGE_CATALOG), hidream);
-assert.equal(groupForRepoId("HiDream-ai/HiDream-I1-Fast", IMAGE_CATALOG), hidream);
 assert.equal(
-  pickDefaultArtifact(hidream, { gpuGb: 141, systemRamGb: 128, isDownloaded: notDownloaded })
-    .repoId,
+  groupForRepoId("HiDream-ai/HiDream-I1-Dev", IMAGE_CATALOG),
+  hidream,
+);
+assert.equal(
+  groupForRepoId("HiDream-ai/HiDream-I1-Fast", IMAGE_CATALOG),
+  hidream,
+);
+assert.equal(
+  pickDefaultArtifact(hidream, {
+    gpuGb: 141,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).repoId,
   "HiDream-ai/HiDream-I1-Full",
 );
 assert.equal(
-  catalogGroupFitsDevice(hidream, { gpuGb: 24, systemRamGb: 32 }, notDownloaded),
+  catalogGroupFitsDevice(
+    hidream,
+    { gpuGb: 24, systemRamGb: 32 },
+    notDownloaded,
+  ),
   false,
 );
 // FLUX.1-schnell is Apache-2.0 but gated on the Hub, so a not-downloaded BF16 is skipped and the
 // open GGUF is auto-routed instead, even on a GPU that fits the pipeline.
-const fluxSchnellRoute = groupForRepoId("unsloth/FLUX.1-schnell", IMAGE_CATALOG);
+const fluxSchnellRoute = groupForRepoId(
+  "unsloth/FLUX.1-schnell",
+  IMAGE_CATALOG,
+);
 assert.ok(fluxSchnellRoute);
 assert.equal(
-  pickDefaultArtifact(fluxSchnellRoute, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(fluxSchnellRoute, {
+    gpuGb: 80,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 // HunyuanVideo on 80 GB: the highest-quality artifact that FITS (720p, 52 GB <= budget 56) wins.
@@ -657,14 +809,20 @@ const hunyuan = groupForRepoId(
 );
 assert.ok(hunyuan);
 assert.equal(
-  pickDefaultArtifact(hunyuan, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
-    .label,
+  pickDefaultArtifact(hunyuan, {
+    gpuGb: 80,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).label,
   "BF16 - 720p",
 );
 // Same-format artifacts keep declaration order, so 720p is listed first and the fit loop returns it; a budget of 42 skips it (52 > 42) and falls back to 480p (40).
 assert.equal(
-  pickDefaultArtifact(hunyuan, { gpuGb: 60, systemRamGb: 128, isDownloaded: notDownloaded })
-    .label,
+  pickDefaultArtifact(hunyuan, {
+    gpuGb: 60,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).label,
   "BF16 - 480p",
 );
 
@@ -672,28 +830,43 @@ assert.equal(
 const h3 = groupForRepoId("MiniMaxAI/MiniMax-H3", VIDEO_CATALOG);
 assert.ok(h3);
 assert.equal(
-  pickDefaultArtifact(h3, { gpuGb: 48, systemRamGb: 256, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(h3, {
+    gpuGb: 48,
+    systemRamGb: 256,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(h3, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(h3, {
+    gpuGb: 80,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(h3, { gpuGb: 80, systemRamGb: 192, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(h3, {
+    gpuGb: 80,
+    systemRamGb: 192,
+    isDownloaded: notDownloaded,
+  }).format,
   "bf16",
 );
 assert.equal(
-  pickDefaultArtifact(h3, { gpuGb: 122, systemRamGb: 96, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(h3, {
+    gpuGb: 122,
+    systemRamGb: 96,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(h3, { gpuGb: 123, systemRamGb: 96, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(h3, {
+    gpuGb: 123,
+    systemRamGb: 96,
+    isDownloaded: notDownloaded,
+  }).format,
   "bf16",
 );
 // The upper tier, in the units the picker is actually handed: 132 GiB of VRAM is 141.7 decimal
@@ -701,34 +874,49 @@ assert.equal(
 // 85 GiB of RAM is 91.3 GB. So this host fits, and a tier table written in decimal GB would
 // wrongly send it to GGUF.
 assert.equal(
-  pickDefaultArtifact(h3, { gpuGb: 132, systemRamGb: 85, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(h3, {
+    gpuGb: 132,
+    systemRamGb: 85,
+    isDownloaded: notDownloaded,
+  }).format,
   "bf16",
 );
 
 // ── official BF16 artifacts (added so groups are not unsloth-quant-only) ────────
 // Qwen-Image-2512 BF16 (54 GB) misses a 24/48 GB budget (bnb-4bit/fp8 win there, asserted above) but on an 80 GB GPU (budget 56) it fits and wins.
 assert.equal(
-  pickDefaultArtifact(qwenGroup, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(qwenGroup, {
+    gpuGb: 80,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).format,
   "bf16",
 );
 assert.equal(
-  pickDefaultArtifact(qwenGroup, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
-    .repoId,
+  pickDefaultArtifact(qwenGroup, {
+    gpuGb: 80,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).repoId,
   "Qwen/Qwen-Image-2512",
 );
 // Z-Image-Turbo BF16 (30 GB) misses 24 GB (bnb-4bit wins) but fits a 48 GB GPU (budget 33.6) and wins.
 const zturbo = groupForRepoId("unsloth/Z-Image-Turbo", IMAGE_CATALOG);
 assert.ok(zturbo);
 assert.equal(
-  pickDefaultArtifact(zturbo, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(zturbo, {
+    gpuGb: 24,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).format,
   "bnb-4bit",
 );
 assert.equal(
-  pickDefaultArtifact(zturbo, { gpuGb: 48, systemRamGb: 64, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(zturbo, {
+    gpuGb: 48,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).format,
   "bf16",
 );
 // FLUX.1-dev BF16 (32 GB) fits a 48 GB GPU but is GATED, so a bare click routes to the open GGUF unless it is already downloaded. Small GPU -> GGUF.
@@ -736,8 +924,11 @@ const fluxDev = groupForRepoId("black-forest-labs/FLUX.1-dev", IMAGE_CATALOG);
 assert.ok(fluxDev);
 assert.equal(fluxDev.canonicalId, "unsloth/FLUX.1-dev");
 assert.equal(
-  pickDefaultArtifact(fluxDev, { gpuGb: 48, systemRamGb: 64, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(fluxDev, {
+    gpuGb: 48,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 assert.equal(
@@ -749,8 +940,11 @@ assert.equal(
   "bf16",
 );
 assert.equal(
-  pickDefaultArtifact(fluxDev, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(fluxDev, {
+    gpuGb: 24,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 // LTX-2.3 video carries the official BF16 single file (no FP8: the loader refuses its scaled-fp8 one), which keeps the ~50 GB Gemma3 encoder resident, so B200-class only.
@@ -764,33 +958,54 @@ assert.equal(groupForRepoId("Lightricks/LTX-2.3", VIDEO_CATALOG), ltxGroup);
 // The retired id is not an artifact, so it can never be handed to a load as a repo to fetch.
 assert.equal(loadSpecFor("unsloth/LTX-2.3", VIDEO_CATALOG), null);
 assert.equal(
-  pickDefaultArtifact(ltxGroup, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(ltxGroup, {
+    gpuGb: 24,
+    systemRamGb: 64,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(ltxGroup, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(ltxGroup, {
+    gpuGb: 80,
+    systemRamGb: 128,
+    isDownloaded: notDownloaded,
+  }).format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(ltxGroup, { gpuGb: 192, systemRamGb: 256, isDownloaded: notDownloaded })
-    .format,
+  pickDefaultArtifact(ltxGroup, {
+    gpuGb: 192,
+    systemRamGb: 256,
+    isDownloaded: notDownloaded,
+  }).format,
   "bf16",
 );
 // The LTX-2.3 official checkpoints load as single-file against the family base.
-assert.equal(loadSpecFor("Lightricks/LTX-2.3", VIDEO_CATALOG)?.kind, "single_file");
+assert.equal(
+  loadSpecFor("Lightricks/LTX-2.3", VIDEO_CATALOG)?.kind,
+  "single_file",
+);
 assert.equal(
   loadSpecFor("Lightricks/LTX-2.3", VIDEO_CATALOG)?.filename,
   "ltx-2.3-22b-distilled.safetensors",
 );
 // The official image BF16 pipelines load via from_pretrained (pipeline kind).
-assert.equal(loadSpecFor("Tongyi-MAI/Z-Image-Turbo", IMAGE_CATALOG)?.kind, "pipeline");
-assert.equal(loadSpecFor("Qwen/Qwen-Image-2512", IMAGE_CATALOG)?.kind, "pipeline");
+assert.equal(
+  loadSpecFor("Tongyi-MAI/Z-Image-Turbo", IMAGE_CATALOG)?.kind,
+  "pipeline",
+);
+assert.equal(
+  loadSpecFor("Qwen/Qwen-Image-2512", IMAGE_CATALOG)?.kind,
+  "pipeline",
+);
 
 // ── catalogGroupFitsDevice (the fit-on-device toggle for catalog rows) ─────────
 
-const wanA14b = groupForRepoId("Wan-AI/Wan2.2-T2V-A14B-Diffusers", VIDEO_CATALOG);
+const wanA14b = groupForRepoId(
+  "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+  VIDEO_CATALOG,
+);
 const ltxBase = groupForRepoId("Lightricks/LTX-2", VIDEO_CATALOG);
 const hunyuanFit = groupForRepoId(
   "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v",
@@ -805,7 +1020,11 @@ assert.equal(catalogGroupFitsDevice(ltxBase, consumer, notDownloaded), false); /
 assert.equal(catalogGroupFitsDevice(hunyuanFit, consumer, notDownloaded), true);
 // But on a tiny device even those are hidden.
 assert.equal(
-  catalogGroupFitsDevice(hunyuanFit, { gpuGb: 8, systemRamGb: 8 }, notDownloaded),
+  catalogGroupFitsDevice(
+    hunyuanFit,
+    { gpuGb: 8, systemRamGb: 8 },
+    notDownloaded,
+  ),
   false,
 );
 // A GGUF in the group is always runnable (its quant ladder self-fits + offloads), so LTX-2.3 stays visible on a tiny card despite its 90 GB BF16 sibling.
@@ -823,10 +1042,17 @@ assert.equal(
   true,
 );
 // Unknown device budget keeps everything (we cannot tell), even a 114 GB group.
-assert.equal(catalogGroupFitsDevice(wanA14b, { gpuGb: 0, systemRamGb: 0 }, notDownloaded), true);
+assert.equal(
+  catalogGroupFitsDevice(wanA14b, { gpuGb: 0, systemRamGb: 0 }, notDownloaded),
+  true,
+);
 // On a B200-class budget the large bf16 groups fit and stay visible.
 assert.equal(
-  catalogGroupFitsDevice(wanA14b, { gpuGb: 192, systemRamGb: 256 }, notDownloaded),
+  catalogGroupFitsDevice(
+    wanA14b,
+    { gpuGb: 192, systemRamGb: 256 },
+    notDownloaded,
+  ),
   true,
 );
 
@@ -834,12 +1060,19 @@ assert.equal(
 
 // Every audio group carries a task tag; the other catalogs carry none.
 for (const group of AUDIO_CATALOG) {
-  assert.ok(group.task === "tts" || group.task === "stt", `audio group ${group.canonicalId} needs a task`);
+  assert.ok(
+    group.task === "tts" || group.task === "stt",
+    `audio group ${group.canonicalId} needs a task`,
+  );
   assert.equal(group.scope, "audio");
 }
 for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG]) {
   for (const group of catalog) {
-    assert.equal(group.task, undefined, `non-audio group ${group.canonicalId} must not carry a task`);
+    assert.equal(
+      group.task,
+      undefined,
+      `non-audio group ${group.canonicalId} must not carry a task`,
+    );
   }
 }
 // The Orpheus GGUF groups with its safetensors base and reports the gguf load kind.
@@ -847,11 +1080,20 @@ const orpheus = groupForRepoId("unsloth/orpheus-3b-0.1-ft-GGUF", AUDIO_CATALOG);
 assert.ok(orpheus);
 assert.equal(orpheus.canonicalId, "unsloth/orpheus-3b-0.1-ft");
 assert.equal(orpheus.task, "tts");
-assert.equal(loadSpecFor("unsloth/orpheus-3b-0.1-ft-GGUF", AUDIO_CATALOG)?.kind, "gguf");
+assert.equal(
+  loadSpecFor("unsloth/orpheus-3b-0.1-ft-GGUF", AUDIO_CATALOG)?.kind,
+  "gguf",
+);
 assert.equal(loadSpecFor("unsloth/csm-1b", AUDIO_CATALOG)?.kind, "pipeline");
 // The whisper sidecar repos resolve as stt groups.
-assert.equal(groupForRepoId("unsloth/whisper-large-v3-turbo", AUDIO_CATALOG)?.task, "stt");
-assert.equal(groupForRepoId("unslothai/Qwen3-ASR-0.6B-GGUF", AUDIO_CATALOG)?.task, "stt");
+assert.equal(
+  groupForRepoId("unsloth/whisper-large-v3-turbo", AUDIO_CATALOG)?.task,
+  "stt",
+);
+assert.equal(
+  groupForRepoId("unslothai/Qwen3-ASR-0.6B-GGUF", AUDIO_CATALOG)?.task,
+  "stt",
+);
 // A chat model stays unknown to the audio catalog.
 assert.equal(groupForRepoId("unsloth/Llama-3.3-70B-GGUF", AUDIO_CATALOG), null);
 // MiniMax Music3 publishes a 67 GB repository, but its official BF16 modular loader
@@ -859,19 +1101,17 @@ assert.equal(groupForRepoId("unsloth/Llama-3.3-70B-GGUF", AUDIO_CATALOG), null);
 const minimaxMusic = groupForRepoId("MiniMaxAI/MiniMax-Music3", AUDIO_CATALOG);
 assert.ok(minimaxMusic);
 assert.equal(
-  curatedArtifactFitsDevice(
-    "MiniMaxAI/MiniMax-Music3",
-    AUDIO_CATALOG,
-    { gpuGb: 95, systemRamGb: 0 },
-  ),
+  curatedArtifactFitsDevice("MiniMaxAI/MiniMax-Music3", AUDIO_CATALOG, {
+    gpuGb: 95,
+    systemRamGb: 0,
+  }),
   true,
 );
 assert.equal(
-  curatedArtifactFitsDevice(
-    "MiniMaxAI/MiniMax-Music3",
-    AUDIO_CATALOG,
-    { gpuGb: 23, systemRamGb: 256 },
-  ),
+  curatedArtifactFitsDevice("MiniMaxAI/MiniMax-Music3", AUDIO_CATALOG, {
+    gpuGb: 23,
+    systemRamGb: 256,
+  }),
   false,
 );
 
@@ -946,20 +1186,28 @@ async function fetchWithRetry(
   let why = "unknown";
   for (let attempt = 1; attempt <= NETWORK_ATTEMPTS; attempt++) {
     if (Date.now() >= networkDeadlineAt) {
-      return { response: null, body: "", why: "the network check ran out of its overall budget" };
+      return {
+        response: null,
+        body: "",
+        why: "the network check ran out of its overall budget",
+      };
     }
     try {
       // A per-attempt deadline, or a peer that accepts the connection and then stalls has no
       // retry and no fail-open: fetch simply never settles, and the scheduled job dies on its own
       // 10-minute timeout as a RED run. Which is the one outcome this check promises not to
       // produce for a network blip.
-      const response = await fetch(url, { ...init, signal: AbortSignal.timeout(NETWORK_TIMEOUT_MS) });
+      const response = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(NETWORK_TIMEOUT_MS),
+      });
       // Read the body HERE, under that same deadline. Headers can arrive promptly and the body
       // still stall, and the caller parses outside this function where an abort would surface as
       // "the Hub answered 200 with unreadable JSON" -- a catalog failure, for a stalled socket.
       // It also drains the 429/5xx responses we are about to retry, rather than leaking them.
       const body = init?.method === "HEAD" ? "" : await response.text();
-      if (response.status !== 429 && response.status < 500) return { response, body, why: "" };
+      if (response.status !== 429 && response.status < 500)
+        return { response, body, why: "" };
       why = `HTTP ${response.status}`;
     } catch (err) {
       why = String(err);
@@ -970,13 +1218,18 @@ async function fetchWithRetry(
 }
 
 /** Run `work` over `items`, a few at a time: ~35 repos, and the Hub does not need a thundering herd. */
-async function inBatches<T>(items: T[], work: (item: T) => Promise<void>): Promise<void> {
+async function inBatches<T>(
+  items: T[],
+  work: (item: T) => Promise<void>,
+): Promise<void> {
   for (let i = 0; i < items.length; i += NETWORK_BATCH) {
     await Promise.all(items.slice(i, i + NETWORK_BATCH).map(work));
   }
 }
 
-async function checkCatalogAgainstTheHub(catalogs: CatalogGroup[][]): Promise<string[]> {
+async function checkCatalogAgainstTheHub(
+  catalogs: CatalogGroup[][],
+): Promise<string[]> {
   networkDeadlineAt = Date.now() + NETWORK_DEADLINE_MS;
   const failures: string[] = [];
   const groups = catalogs.flat();
@@ -990,76 +1243,94 @@ async function checkCatalogAgainstTheHub(catalogs: CatalogGroup[][]): Promise<st
     }
   }
 
-  await inBatches([...artifactsByRepo.entries()], async ([repoId, artifacts]) => {
-    const { response, body, why } = await fetchWithRetry(`${HF_API}/${repoId}`);
-    if (response === null) {
-      console.warn(
-        `::warning::${repoId}: the Hub did not answer after ${NETWORK_ATTEMPTS} attempts (${why}). Not a verdict about the catalog.`,
+  await inBatches(
+    [...artifactsByRepo.entries()],
+    async ([repoId, artifacts]) => {
+      const { response, body, why } = await fetchWithRetry(
+        `${HF_API}/${repoId}`,
       );
-      return;
-    }
-    if (!response.ok) {
-      // 401 on the METADATA endpoint means private-or-absent (the Hub will not say which);
-      // a gated-but-public repo answers 200 with gated set, so this is never just "needs a licence".
-      failures.push(
-        `${repoId}: HTTP ${response.status} from ${HF_API}/${repoId} -- the repo is missing, renamed or private, so no user can download it`,
-      );
-      return;
-    }
-    let repo: HubRepo;
-    try {
-      repo = JSON.parse(body) as HubRepo;
-    } catch (err) {
-      // A 200 that is not JSON is a captive portal or a proxy, not a catalog problem. Reject the
-      // run rather than throwing out of Promise.all with a raw stack.
-      failures.push(`${repoId}: the Hub answered 200 with unreadable JSON (${err})`);
-      return;
-    }
-    const hubGated = Boolean(repo.gated);
-    for (const artifact of artifacts) {
-      const declaredGated = artifact.gated === true;
-      if (hubGated && !declaredGated) {
-        failures.push(
-          `${repoId}: the Hub reports gated=${JSON.stringify(repo.gated)} but the catalog entry has no \`gated: true\`, so an anonymous download 401s`,
-        );
-      } else if (!hubGated && declaredGated) {
-        failures.push(
-          `${repoId}: marked \`gated: true\` but the Hub reports it open -- the router skips it for no reason`,
-        );
-      }
-    }
-
-    const declaredFiles = [
-      ...new Set(artifacts.map((a) => a.filename).filter((f): f is string => Boolean(f))),
-    ];
-    if (declaredFiles.length === 0) return;
-    const listed = new Set((repo.siblings ?? []).map((s) => s.rfilename));
-    for (const filename of declaredFiles) {
-      if (!listed.has(filename)) {
-        failures.push(`${repoId}: declares '${filename}', which the repo does not contain`);
-        continue;
-      }
-      if (hubGated) continue; // resolve/ 401s without a token; the sibling list is the check.
-      // Listed is not the same as fetchable: resolve/ is the endpoint the download hits.
-      const head = await fetchWithRetry(`${HF_RESOLVE}/${repoId}/resolve/main/${filename}`, {
-        method: "HEAD",
-      });
-      if (head.response === null) {
+      if (response === null) {
         console.warn(
-          `::warning::${repoId}: could not HEAD '${filename}' (${head.why}). Not a verdict.`,
+          `::warning::${repoId}: the Hub did not answer after ${NETWORK_ATTEMPTS} attempts (${why}). Not a verdict about the catalog.`,
         );
-      } else if (!head.response.ok) {
-        failures.push(
-          `${repoId}: '${filename}' is listed but resolve/main returned HTTP ${head.response.status}`,
-        );
+        return;
       }
-    }
-  });
+      if (!response.ok) {
+        // 401 on the METADATA endpoint means private-or-absent (the Hub will not say which);
+        // a gated-but-public repo answers 200 with gated set, so this is never just "needs a licence".
+        failures.push(
+          `${repoId}: HTTP ${response.status} from ${HF_API}/${repoId} -- the repo is missing, renamed or private, so no user can download it`,
+        );
+        return;
+      }
+      let repo: HubRepo;
+      try {
+        repo = JSON.parse(body) as HubRepo;
+      } catch (err) {
+        // A 200 that is not JSON is a captive portal or a proxy, not a catalog problem. Reject the
+        // run rather than throwing out of Promise.all with a raw stack.
+        failures.push(
+          `${repoId}: the Hub answered 200 with unreadable JSON (${err})`,
+        );
+        return;
+      }
+      const hubGated = Boolean(repo.gated);
+      for (const artifact of artifacts) {
+        const declaredGated = artifact.gated === true;
+        if (hubGated && !declaredGated) {
+          failures.push(
+            `${repoId}: the Hub reports gated=${JSON.stringify(repo.gated)} but the catalog entry has no \`gated: true\`, so an anonymous download 401s`,
+          );
+        } else if (!hubGated && declaredGated) {
+          failures.push(
+            `${repoId}: marked \`gated: true\` but the Hub reports it open -- the router skips it for no reason`,
+          );
+        }
+      }
+
+      const declaredFiles = [
+        ...new Set(
+          artifacts
+            .map((a) => a.filename)
+            .filter((f): f is string => Boolean(f)),
+        ),
+      ];
+      if (declaredFiles.length === 0) return;
+      const listed = new Set((repo.siblings ?? []).map((s) => s.rfilename));
+      for (const filename of declaredFiles) {
+        if (!listed.has(filename)) {
+          failures.push(
+            `${repoId}: declares '${filename}', which the repo does not contain`,
+          );
+          continue;
+        }
+        if (hubGated) continue; // resolve/ 401s without a token; the sibling list is the check.
+        // Listed is not the same as fetchable: resolve/ is the endpoint the download hits.
+        const head = await fetchWithRetry(
+          `${HF_RESOLVE}/${repoId}/resolve/main/${filename}`,
+          {
+            method: "HEAD",
+          },
+        );
+        if (head.response === null) {
+          console.warn(
+            `::warning::${repoId}: could not HEAD '${filename}' (${head.why}). Not a verdict.`,
+          );
+        } else if (!head.response.ok) {
+          failures.push(
+            `${repoId}: '${filename}' is listed but resolve/main returned HTTP ${head.response.status}`,
+          );
+        }
+      }
+    },
+  );
 
   // Advisory only. A canonicalId is a display/grouping key, and 15 of them are deliberately not
   // repos; but one that is BOTH `unsloth/*`-shaped and dead clears every owner guard in the app,
   // so it is worth naming without failing a scheduled job over it.
-  const artifactIds = new Set([...artifactsByRepo.keys()].map((id) => id.toLowerCase()));
+  const artifactIds = new Set(
+    [...artifactsByRepo.keys()].map((id) => id.toLowerCase()),
+  );
   const orphans = groups
     .map((g) => g.canonicalId)
     .filter((id) => !artifactIds.has(id.toLowerCase()));
@@ -1077,12 +1348,19 @@ async function checkCatalogAgainstTheHub(catalogs: CatalogGroup[][]): Promise<st
 }
 
 if (process.argv.includes("--network")) {
-  console.log("model-catalog check: --network, asking the Hub about every declared artifact...");
-  const failures = await checkCatalogAgainstTheHub([IMAGE_CATALOG, VIDEO_CATALOG]);
+  console.log(
+    "model-catalog check: --network, asking the Hub about every declared artifact...",
+  );
+  const failures = await checkCatalogAgainstTheHub([
+    IMAGE_CATALOG,
+    VIDEO_CATALOG,
+  ]);
   if (failures.length > 0) {
     for (const failure of failures) console.error(`::error::${failure}`);
     console.error(`model-catalog network check: ${failures.length} problem(s)`);
     process.exit(1);
   }
-  console.log("model-catalog network check: every declared repo, file and gated flag agrees with the Hub");
+  console.log(
+    "model-catalog network check: every declared repo, file and gated flag agrees with the Hub",
+  );
 }

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
@@ -490,6 +490,18 @@ assert.equal(
   classifyGgufFit(16 * GB, { gpuGb: 24, systemRamGb: 0, budgetFraction: 0.8 }),
   "marginal",
 );
+// At the top of the slider the loader still keeps its 512 MiB floor (_VRAM_FLOOR_RESERVE_MIB), so
+// a 20 GiB quant needing 24.0 GiB is handed to --fit rather than admitted. `gpuGb * fraction` said
+// otherwise, and the whole point of this file is that the badge matches _select_gpus.
+assert.equal(
+  classifyGgufFit(20 * GB, { gpuGb: 24, systemRamGb: 0, budgetFraction: 1 }),
+  "marginal",
+);
+// The floor never exceeds the default budget's own reserve, so 0.97 is unchanged by it.
+assert.equal(
+  classifyGgufFit(19 * GB, { gpuGb: 24, systemRamGb: 0, budgetFraction: 0.97 }),
+  "fits",
+);
 
 // ── classifyMediaGgufFit ──────────────────────────────────────────────────────
 // Images / Video place a GGUF through the diffusion backend, whose budget on a 64 GiB unified host

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
@@ -502,6 +502,34 @@ assert.equal(
   classifyGgufFit(19 * GB, { gpuGb: 24, systemRamGb: 0, budgetFraction: 0.97 }),
   "fits",
 );
+// The floor is charged once per CARD: _select_gpus calls _vram_usable_mib for every device and
+// sums, so two 24 GiB cards at 1.0 offer 47.0 GiB, not 47.5. A 40.2 GiB file needs 47.23.
+assert.equal(
+  classifyGgufFit(40.2 * GB, {
+    gpuGb: 48,
+    systemRamGb: 0,
+    budgetFraction: 1,
+    gpuCount: 2,
+  }),
+  "marginal",
+);
+// Same file, same cards, counted as one box: the verdict this correction exists to remove.
+assert.equal(
+  classifyGgufFit(40.2 * GB, { gpuGb: 48, systemRamGb: 0, budgetFraction: 1 }),
+  "fits",
+);
+// Below the default the percentage term still wins on either count, so nothing moves.
+for (const gpuCount of [1, 2, 4]) {
+  assert.equal(
+    classifyGgufFit(39 * GB, {
+      gpuGb: 48,
+      systemRamGb: 0,
+      budgetFraction: 0.97,
+      gpuCount,
+    }),
+    "fits",
+  );
+}
 
 // ── classifyMediaGgufFit ──────────────────────────────────────────────────────
 // Images / Video place a GGUF through the diffusion backend, whose budget on a 64 GiB unified host

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
@@ -20,6 +20,7 @@ import {
   catalogGroupFitsDevice,
   catalogToModelOptions,
   classifyGgufFit,
+  classifyMediaGgufFit,
   curatedArtifactFitsDevice,
   curatedDisplayNameFor,
   curatedRowLabelFor,
@@ -566,6 +567,22 @@ assert.equal(
   classifyGgufFit(16 * GB, { gpuGb: 24, systemRamGb: 0, budgetFraction: 0.8 }),
   "marginal",
 );
+// ── classifyMediaGgufFit ──────────────────────────────────────────────────────
+// Images / Video place a GGUF through the diffusion backend, whose budget on a 64 GiB unified host
+// is (total - 20% reserve) * 0.85 = 43.5 GiB (diffusion_memory.py). This rule allows 44.8; the
+// llama.cpp one allows 62.1 and would promise loads the planner refuses.
+assert.equal(classifyMediaGgufFit(40 * GB, 64, 0), "fits"); // 40 <= 44.8
+assert.equal(classifyMediaGgufFit(50 * GB, 64, 0), "oom"); // past 44.8, no RAM tier
+// The same 50 GiB file reads as fitting under the llama.cpp rule, which is the regression this
+// guard exists to prevent: 50 * 1.15 + 1 = 58.5 <= 64 * 0.97.
+assert.equal(classifyGgufFit(50 * GB, { gpuGb: 64, systemRamGb: 0 }), "fits");
+// A discrete card with RAM keeps the offload tier the rule always had.
+assert.equal(classifyMediaGgufFit(20 * GB, 24, 64), "partial");
+assert.equal(classifyMediaGgufFit(100 * GB, 24, 64), "oom");
+// No GPU: RAM alone, fit or not.
+assert.equal(classifyMediaGgufFit(30 * GB, 0, 64), "fits");
+assert.equal(classifyMediaGgufFit(60 * GB, 0, 64), "oom");
+
 // Only oom fails to load; marginal and partial both run.
 assert.equal(ggufFitRuns("partial"), true);
 assert.equal(ggufFitRuns("oom"), false);

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
@@ -35,14 +35,8 @@ import {
 
 // ── canonicalKeyFor: suffix stripping, owner preserved ─────────────────────────
 
-assert.equal(
-  canonicalKeyFor("unsloth/Qwen-Image-2512-GGUF"),
-  "unsloth/qwen-image-2512",
-);
-assert.equal(
-  canonicalKeyFor("unsloth/Qwen-Image-2512-FP8"),
-  "unsloth/qwen-image-2512",
-);
+assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-GGUF"), "unsloth/qwen-image-2512");
+assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-FP8"), "unsloth/qwen-image-2512");
 assert.equal(
   canonicalKeyFor("unsloth/Qwen-Image-2512-unsloth-bnb-4bit"),
   "unsloth/qwen-image-2512",
@@ -51,36 +45,15 @@ assert.equal(
   canonicalKeyFor("ideogram-ai/ideogram-4-nf4-diffusers"),
   "ideogram-ai/ideogram-4",
 );
-assert.equal(
-  canonicalKeyFor("Wan-AI/Wan2.2-TI2V-5B-Diffusers"),
-  "wan-ai/wan2.2-ti2v-5b",
-);
+assert.equal(canonicalKeyFor("Wan-AI/Wan2.2-TI2V-5B-Diffusers"), "wan-ai/wan2.2-ti2v-5b");
 assert.equal(canonicalKeyFor("lightricks/ltx-2.3-fp8"), "lightricks/ltx-2.3");
 // Prequant suffixes strip regardless of case: -GGUF/-FP8/-int8/-nvfp4 all route to the base name.
-assert.equal(
-  canonicalKeyFor("unsloth/Qwen-Image-2512-int8"),
-  "unsloth/qwen-image-2512",
-);
-assert.equal(
-  canonicalKeyFor("unsloth/Qwen-Image-2512-INT8"),
-  "unsloth/qwen-image-2512",
-);
-assert.equal(
-  canonicalKeyFor("unsloth/Qwen-Image-2512-nvfp4"),
-  "unsloth/qwen-image-2512",
-);
-assert.equal(
-  canonicalKeyFor("unsloth/Qwen-Image-2512-NVFP4"),
-  "unsloth/qwen-image-2512",
-);
-assert.equal(
-  canonicalKeyFor("unsloth/qwen-image-2512-gguf"),
-  "unsloth/qwen-image-2512",
-);
-assert.equal(
-  canonicalKeyFor("unsloth/qwen-image-2512-fp8"),
-  "unsloth/qwen-image-2512",
-);
+assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-int8"), "unsloth/qwen-image-2512");
+assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-INT8"), "unsloth/qwen-image-2512");
+assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-nvfp4"), "unsloth/qwen-image-2512");
+assert.equal(canonicalKeyFor("unsloth/Qwen-Image-2512-NVFP4"), "unsloth/qwen-image-2512");
+assert.equal(canonicalKeyFor("unsloth/qwen-image-2512-gguf"), "unsloth/qwen-image-2512");
+assert.equal(canonicalKeyFor("unsloth/qwen-image-2512-fp8"), "unsloth/qwen-image-2512");
 
 // ── stripArtifactSuffixesForDisplay: case-preserving base name for row labels ──
 
@@ -132,23 +105,14 @@ for (const artifact of qwen2512.artifacts) {
 // Cross-owner aliases resolve only because they are declared.
 assert.equal(groupForRepoId("Qwen/Qwen-Image-2512", IMAGE_CATALOG), qwen2512);
 // Undeclared prequant variants (any case) route to the base group via the stripped key.
-assert.equal(
-  groupForRepoId("unsloth/Qwen-Image-2512-INT8", IMAGE_CATALOG),
-  qwen2512,
-);
-assert.equal(
-  groupForRepoId("unsloth/Qwen-Image-2512-NVFP4", IMAGE_CATALOG),
-  qwen2512,
-);
+assert.equal(groupForRepoId("unsloth/Qwen-Image-2512-INT8", IMAGE_CATALOG), qwen2512);
+assert.equal(groupForRepoId("unsloth/Qwen-Image-2512-NVFP4", IMAGE_CATALOG), qwen2512);
 assert.equal(
   groupForRepoId("Tongyi-MAI/Z-Image-Turbo", IMAGE_CATALOG)?.canonicalId,
   "unsloth/Z-Image-Turbo",
 );
 // A sibling artifact of an aliased owner groups via the alias' stripped key.
-assert.equal(
-  groupForRepoId("Qwen/Qwen-Image-2512-FP8", IMAGE_CATALOG),
-  qwen2512,
-);
+assert.equal(groupForRepoId("Qwen/Qwen-Image-2512-FP8", IMAGE_CATALOG), qwen2512);
 // Unknown repos pass through ungrouped.
 assert.equal(groupForRepoId("someone/some-model-GGUF", IMAGE_CATALOG), null);
 assert.equal(groupForRepoId("unsloth/Llama-3.3-70B-GGUF", VIDEO_CATALOG), null);
@@ -183,10 +147,7 @@ for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG, AUDIO_CATALOG]) {
   for (const group of catalog) {
     for (const artifact of group.artifacts) {
       const lowered = artifact.repoId.toLowerCase();
-      assert.ok(
-        !seen.has(lowered),
-        `duplicate artifact id: ${artifact.repoId}`,
-      );
+      assert.ok(!seen.has(lowered), `duplicate artifact id: ${artifact.repoId}`);
       seen.add(lowered);
       assert.equal(
         groupForRepoId(artifact.repoId, catalog),
@@ -194,10 +155,7 @@ for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG, AUDIO_CATALOG]) {
         `artifact ${artifact.repoId} resolves to a different group`,
       );
       if (artifact.loadKind === "single_file") {
-        assert.ok(
-          artifact.filename,
-          `single_file ${artifact.repoId} needs a filename`,
-        );
+        assert.ok(artifact.filename, `single_file ${artifact.repoId} needs a filename`);
       }
     }
     for (const alias of group.aliases ?? []) {
@@ -243,16 +201,11 @@ for (const id of OLD_PIPELINE_MODELS) {
   assert.equal(got.kind, "pipeline", id);
 }
 // GGUF artifacts report the gguf kind; unknown ids report null.
-assert.equal(
-  loadSpecFor("unsloth/Z-Image-Turbo-GGUF", IMAGE_CATALOG)?.kind,
-  "gguf",
-);
+assert.equal(loadSpecFor("unsloth/Z-Image-Turbo-GGUF", IMAGE_CATALOG)?.kind, "gguf");
 assert.equal(loadSpecFor("someone/unknown", IMAGE_CATALOG), null);
 
 // Every old curated id is still present as an option (backwards compat).
-const imageOptionIds = new Set(
-  catalogToModelOptions(IMAGE_CATALOG).map((o) => o.id),
-);
+const imageOptionIds = new Set(catalogToModelOptions(IMAGE_CATALOG).map((o) => o.id));
 for (const id of [
   "unsloth/Z-Image-Turbo-GGUF",
   "unsloth/Z-Image-GGUF",
@@ -268,9 +221,7 @@ for (const id of [
 ]) {
   assert.ok(imageOptionIds.has(id), `image option missing: ${id}`);
 }
-const videoOptionIds = new Set(
-  catalogToModelOptions(VIDEO_CATALOG).map((o) => o.id),
-);
+const videoOptionIds = new Set(catalogToModelOptions(VIDEO_CATALOG).map((o) => o.id));
 for (const id of [
   "unsloth/LTX-2.3-GGUF",
   "unsloth/MiniMax-H3-GGUF",
@@ -307,24 +258,18 @@ assert.deepEqual(curatedRowLabelFor("unsloth/MiniMax-H3-GGUF", VIDEO_CATALOG), {
   name: "MiniMax-H3-GGUF",
   tags: [],
 });
-assert.deepEqual(
-  curatedRowLabelFor("unsloth/Z-Image-Turbo-GGUF", IMAGE_CATALOG),
-  {
-    name: "Z-Image-Turbo-GGUF",
-    tags: [],
-  },
-);
+assert.deepEqual(curatedRowLabelFor("unsloth/Z-Image-Turbo-GGUF", IMAGE_CATALOG), {
+  name: "Z-Image-Turbo-GGUF",
+  tags: [],
+});
 
 // ── host-aware rows ────────────────────────────────────────────────────────────
 // On a host that can place a diffusion pipeline, the two H3 rows say which is which. The gap is
 // roughly 10x, and the names alone gave the user nothing to choose on.
-assert.deepEqual(
-  curatedRowLabelFor("MiniMaxAI/MiniMax-H3", VIDEO_CATALOG, "accelerated"),
-  {
-    name: "MiniMax H3 (Fast FP8)",
-    tags: ["BF16"],
-  },
-);
+assert.deepEqual(curatedRowLabelFor("MiniMaxAI/MiniMax-H3", VIDEO_CATALOG, "accelerated"), {
+  name: "MiniMax H3 (Fast FP8)",
+  tags: ["BF16"],
+});
 assert.deepEqual(
   curatedRowLabelFor("unsloth/MiniMax-H3-GGUF", VIDEO_CATALOG, "accelerated"),
   { name: "MiniMax-H3-GGUF (Slow)", tags: [] },
@@ -341,11 +286,7 @@ assert.equal(
   "MiniMax H3 (Fast FP8)",
 );
 assert.equal(
-  curatedDisplayNameFor(
-    "unsloth/MiniMax-H3-GGUF",
-    VIDEO_CATALOG,
-    "accelerated",
-  ),
+  curatedDisplayNameFor("unsloth/MiniMax-H3-GGUF", VIDEO_CATALOG, "accelerated"),
   "MiniMax-H3-GGUF (Slow)",
 );
 // No other model claims a speed nobody measured.
@@ -377,9 +318,7 @@ for (const [label, catalog] of [
   ["image", IMAGE_CATALOG],
   ["audio", AUDIO_CATALOG],
 ] as const) {
-  const offered = new Set(
-    catalogToModelOptions(catalog, "gguf-only").map((o) => o.id),
-  );
+  const offered = new Set(catalogToModelOptions(catalog, "gguf-only").map((o) => o.id));
   for (const group of catalog) {
     assert.ok(
       group.artifacts.some((artifact) => offered.has(artifact.repoId)),
@@ -398,10 +337,7 @@ for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG, AUDIO_CATALOG]) {
     for (const artifact of group.artifacts) {
       if (artifact.format !== "gguf") continue;
       const row = curatedRowLabelFor(artifact.repoId, catalog);
-      assert.ok(
-        row?.name.endsWith("-GGUF"),
-        `${artifact.repoId} row reads "${row?.name}"`,
-      );
+      assert.ok(row?.name.endsWith("-GGUF"), `${artifact.repoId} row reads "${row?.name}"`);
       assert.deepEqual(row?.tags, []);
     }
   }
@@ -430,10 +366,7 @@ assert.deepEqual(curatedRowLabelFor("Lightricks/LTX-2", VIDEO_CATALOG), {
   name: "LTX 2 (base)",
   tags: [],
 });
-assert.equal(
-  curatedRowLabelFor("someone/not-in-the-catalog", VIDEO_CATALOG),
-  null,
-);
+assert.equal(curatedRowLabelFor("someone/not-in-the-catalog", VIDEO_CATALOG), null);
 
 // No two rows of a group may render identically, or the picker offers the same thing twice.
 for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG]) {
@@ -443,11 +376,7 @@ for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG]) {
       const row = curatedRowLabelFor(artifact.repoId, catalog);
       assert.ok(row, `${artifact.repoId} is in the catalog it came from`);
       const key = `${row.name} | ${row.tags.join(",")}`;
-      assert.equal(
-        seen.has(key),
-        false,
-        `${group.displayName}: two rows both read "${key}"`,
-      );
+      assert.equal(seen.has(key), false, `${group.displayName}: two rows both read "${key}"`);
       seen.add(key);
     }
   }
@@ -542,15 +471,9 @@ const GB = 1024 ** 3;
 // against the raw file size, which matched neither the Hub nor the loader.
 assert.equal(classifyGgufFit(10 * GB, { gpuGb: 24, systemRamGb: 64 }), "fits");
 // 20 GiB needs 24.0: past the 23.28 budget, still inside the 24 GiB card.
-assert.equal(
-  classifyGgufFit(20 * GB, { gpuGb: 24, systemRamGb: 64 }),
-  "marginal",
-);
+assert.equal(classifyGgufFit(20 * GB, { gpuGb: 24, systemRamGb: 64 }), "marginal");
 // 40 GiB needs 47.0: past the card, inside card + RAM offload.
-assert.equal(
-  classifyGgufFit(40 * GB, { gpuGb: 24, systemRamGb: 64 }),
-  "partial",
-);
+assert.equal(classifyGgufFit(40 * GB, { gpuGb: 24, systemRamGb: 64 }), "partial");
 assert.equal(classifyGgufFit(100 * GB, { gpuGb: 24, systemRamGb: 64 }), "oom");
 // Unknown device: never scare with OOM.
 assert.equal(classifyGgufFit(100 * GB, { gpuGb: 0, systemRamGb: 0 }), "fits");
@@ -567,6 +490,7 @@ assert.equal(
   classifyGgufFit(16 * GB, { gpuGb: 24, systemRamGb: 0, budgetFraction: 0.8 }),
   "marginal",
 );
+
 // ── classifyMediaGgufFit ──────────────────────────────────────────────────────
 // Images / Video place a GGUF through the diffusion backend, whose budget on a 64 GiB unified host
 // is (total - 20% reserve) * 0.85 = 43.5 GiB (diffusion_memory.py). This rule allows 44.8; the
@@ -634,40 +558,28 @@ const notDownloaded = () => false;
 const qwenGroup = qwen2512;
 // 8 GB consumer GPU: nothing prequant fits (fp8 24 GB, bnb 14 GB) -> GGUF.
 assert.equal(
-  pickDefaultArtifact(qwenGroup, {
-    gpuGb: 8,
-    systemRamGb: 32,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(qwenGroup, { gpuGb: 8, systemRamGb: 32, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 // 24 GB: bnb-4bit (14 GB) fits the 16.8 GB budget.
 assert.equal(
-  pickDefaultArtifact(qwenGroup, {
-    gpuGb: 24,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(qwenGroup, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
+    .format,
   "bnb-4bit",
 );
 // 48 GB: still bnb-4bit. The group has no fp8 artifact -- fp8 is family-denied for qwen-image
 // (it renders black), and the -FP8 repo ships prequant .pt checkpoints, not a single-file
 // safetensors, so the row that used to win here auto-routed to a download that 404s.
 assert.equal(
-  pickDefaultArtifact(qwenGroup, {
-    gpuGb: 48,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(qwenGroup, { gpuGb: 48, systemRamGb: 64, isDownloaded: notDownloaded })
+    .format,
   "bnb-4bit",
 );
 // Unknown device: GGUF (the backend plans offload itself).
 assert.equal(
-  pickDefaultArtifact(qwenGroup, {
-    gpuGb: 0,
-    systemRamGb: 0,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(qwenGroup, { gpuGb: 0, systemRamGb: 0, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 // Downloaded-first: a downloaded bnb-4bit beats everything undownloaded.
@@ -692,22 +604,16 @@ assert.equal(
 const ideogram = groupForRepoId("ideogram-ai/ideogram-4-fp8", IMAGE_CATALOG);
 assert.ok(ideogram);
 assert.equal(
-  pickDefaultArtifact(ideogram, {
-    gpuGb: 24,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).repoId,
+  pickDefaultArtifact(ideogram, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
+    .repoId,
   "ideogram-ai/ideogram-4-nf4-diffusers",
 );
 // A gated BF16 artifact (FLUX.1-dev) is NOT auto-routed when undownloaded even on a big GPU: the download would fail without license/token access.
 const fluxDevRoute = groupForRepoId("unsloth/FLUX.1-dev", IMAGE_CATALOG);
 assert.ok(fluxDevRoute);
 assert.equal(
-  pickDefaultArtifact(fluxDevRoute, {
-    gpuGb: 80,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(fluxDevRoute, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 // But an already-downloaded gated BF16 (the user clearly has access) is still returned.
@@ -720,17 +626,11 @@ assert.equal(
   "black-forest-labs/FLUX.1-dev",
 );
 // FLUX.1 Krea dev: gated BF16 skipped when undownloaded -> the open QuantStack GGUF, whose repo id also resolves to the group.
-const kreaDevRoute = groupForRepoId(
-  "black-forest-labs/FLUX.1-Krea-dev",
-  IMAGE_CATALOG,
-);
+const kreaDevRoute = groupForRepoId("black-forest-labs/FLUX.1-Krea-dev", IMAGE_CATALOG);
 assert.ok(kreaDevRoute);
 assert.equal(
-  pickDefaultArtifact(kreaDevRoute, {
-    gpuGb: 80,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).repoId,
+  pickDefaultArtifact(kreaDevRoute, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
+    .repoId,
   "QuantStack/FLUX.1-Krea-dev-GGUF",
 );
 assert.equal(
@@ -741,17 +641,11 @@ assert.equal(
 const lumina = groupForRepoId("Alpha-VLLM/Lumina-Image-2.0", IMAGE_CATALOG);
 assert.ok(lumina);
 assert.equal(
-  pickDefaultArtifact(lumina, {
-    gpuGb: 24,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).repoId,
+  pickDefaultArtifact(lumina, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
+    .repoId,
   "Alpha-VLLM/Lumina-Image-2.0",
 );
-assert.equal(
-  loadSpecFor("Alpha-VLLM/Lumina-Image-2.0", IMAGE_CATALOG)?.kind,
-  "pipeline",
-);
+assert.equal(loadSpecFor("Alpha-VLLM/Lumina-Image-2.0", IMAGE_CATALOG)?.kind, "pipeline");
 // HunyuanImage 2.1: the 50 GB bf16 pipeline misses a 24 GB card so a bare click routes to the QuantStack GGUF; on a large GPU bf16 wins. Both ids share one group.
 const hyimage = groupForRepoId(
   "hunyuanvideo-community/HunyuanImage-2.1-Diffusers",
@@ -762,61 +656,36 @@ assert.ok(hyimage);
 // from the Hub, so the group has no quant ladder left. 50 GB still fits a 24 GB card's 61.6 GB
 // budget, so this asserts the group did not silently vanish along with its GGUF.
 assert.equal(
-  pickDefaultArtifact(hyimage, {
-    gpuGb: 24,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).repoId,
+  pickDefaultArtifact(hyimage, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
+    .repoId,
   "hunyuanvideo-community/HunyuanImage-2.1-Diffusers",
 );
 assert.equal(
-  pickDefaultArtifact(hyimage, {
-    gpuGb: 141,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(hyimage, { gpuGb: 141, systemRamGb: 128, isDownloaded: notDownloaded })
+    .format,
   "bf16",
 );
 // HiDream I1: all three variants group together, a datacenter GPU auto-routes to the Full bf16 (catalog order wins among equal sizes), and 24 GB hides the group.
 const hidream = groupForRepoId("HiDream-ai/HiDream-I1-Full", IMAGE_CATALOG);
 assert.ok(hidream);
+assert.equal(groupForRepoId("HiDream-ai/HiDream-I1-Dev", IMAGE_CATALOG), hidream);
+assert.equal(groupForRepoId("HiDream-ai/HiDream-I1-Fast", IMAGE_CATALOG), hidream);
 assert.equal(
-  groupForRepoId("HiDream-ai/HiDream-I1-Dev", IMAGE_CATALOG),
-  hidream,
-);
-assert.equal(
-  groupForRepoId("HiDream-ai/HiDream-I1-Fast", IMAGE_CATALOG),
-  hidream,
-);
-assert.equal(
-  pickDefaultArtifact(hidream, {
-    gpuGb: 141,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).repoId,
+  pickDefaultArtifact(hidream, { gpuGb: 141, systemRamGb: 128, isDownloaded: notDownloaded })
+    .repoId,
   "HiDream-ai/HiDream-I1-Full",
 );
 assert.equal(
-  catalogGroupFitsDevice(
-    hidream,
-    { gpuGb: 24, systemRamGb: 32 },
-    notDownloaded,
-  ),
+  catalogGroupFitsDevice(hidream, { gpuGb: 24, systemRamGb: 32 }, notDownloaded),
   false,
 );
 // FLUX.1-schnell is Apache-2.0 but gated on the Hub, so a not-downloaded BF16 is skipped and the
 // open GGUF is auto-routed instead, even on a GPU that fits the pipeline.
-const fluxSchnellRoute = groupForRepoId(
-  "unsloth/FLUX.1-schnell",
-  IMAGE_CATALOG,
-);
+const fluxSchnellRoute = groupForRepoId("unsloth/FLUX.1-schnell", IMAGE_CATALOG);
 assert.ok(fluxSchnellRoute);
 assert.equal(
-  pickDefaultArtifact(fluxSchnellRoute, {
-    gpuGb: 80,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(fluxSchnellRoute, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 // HunyuanVideo on 80 GB: the highest-quality artifact that FITS (720p, 52 GB <= budget 56) wins.
@@ -826,20 +695,14 @@ const hunyuan = groupForRepoId(
 );
 assert.ok(hunyuan);
 assert.equal(
-  pickDefaultArtifact(hunyuan, {
-    gpuGb: 80,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).label,
+  pickDefaultArtifact(hunyuan, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
+    .label,
   "BF16 - 720p",
 );
 // Same-format artifacts keep declaration order, so 720p is listed first and the fit loop returns it; a budget of 42 skips it (52 > 42) and falls back to 480p (40).
 assert.equal(
-  pickDefaultArtifact(hunyuan, {
-    gpuGb: 60,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).label,
+  pickDefaultArtifact(hunyuan, { gpuGb: 60, systemRamGb: 128, isDownloaded: notDownloaded })
+    .label,
   "BF16 - 480p",
 );
 
@@ -847,43 +710,28 @@ assert.equal(
 const h3 = groupForRepoId("MiniMaxAI/MiniMax-H3", VIDEO_CATALOG);
 assert.ok(h3);
 assert.equal(
-  pickDefaultArtifact(h3, {
-    gpuGb: 48,
-    systemRamGb: 256,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(h3, { gpuGb: 48, systemRamGb: 256, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(h3, {
-    gpuGb: 80,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(h3, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(h3, {
-    gpuGb: 80,
-    systemRamGb: 192,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(h3, { gpuGb: 80, systemRamGb: 192, isDownloaded: notDownloaded })
+    .format,
   "bf16",
 );
 assert.equal(
-  pickDefaultArtifact(h3, {
-    gpuGb: 122,
-    systemRamGb: 96,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(h3, { gpuGb: 122, systemRamGb: 96, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(h3, {
-    gpuGb: 123,
-    systemRamGb: 96,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(h3, { gpuGb: 123, systemRamGb: 96, isDownloaded: notDownloaded })
+    .format,
   "bf16",
 );
 // The upper tier, in the units the picker is actually handed: 132 GiB of VRAM is 141.7 decimal
@@ -891,49 +739,34 @@ assert.equal(
 // 85 GiB of RAM is 91.3 GB. So this host fits, and a tier table written in decimal GB would
 // wrongly send it to GGUF.
 assert.equal(
-  pickDefaultArtifact(h3, {
-    gpuGb: 132,
-    systemRamGb: 85,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(h3, { gpuGb: 132, systemRamGb: 85, isDownloaded: notDownloaded })
+    .format,
   "bf16",
 );
 
 // ── official BF16 artifacts (added so groups are not unsloth-quant-only) ────────
 // Qwen-Image-2512 BF16 (54 GB) misses a 24/48 GB budget (bnb-4bit/fp8 win there, asserted above) but on an 80 GB GPU (budget 56) it fits and wins.
 assert.equal(
-  pickDefaultArtifact(qwenGroup, {
-    gpuGb: 80,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(qwenGroup, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
+    .format,
   "bf16",
 );
 assert.equal(
-  pickDefaultArtifact(qwenGroup, {
-    gpuGb: 80,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).repoId,
+  pickDefaultArtifact(qwenGroup, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
+    .repoId,
   "Qwen/Qwen-Image-2512",
 );
 // Z-Image-Turbo BF16 (30 GB) misses 24 GB (bnb-4bit wins) but fits a 48 GB GPU (budget 33.6) and wins.
 const zturbo = groupForRepoId("unsloth/Z-Image-Turbo", IMAGE_CATALOG);
 assert.ok(zturbo);
 assert.equal(
-  pickDefaultArtifact(zturbo, {
-    gpuGb: 24,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(zturbo, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
+    .format,
   "bnb-4bit",
 );
 assert.equal(
-  pickDefaultArtifact(zturbo, {
-    gpuGb: 48,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(zturbo, { gpuGb: 48, systemRamGb: 64, isDownloaded: notDownloaded })
+    .format,
   "bf16",
 );
 // FLUX.1-dev BF16 (32 GB) fits a 48 GB GPU but is GATED, so a bare click routes to the open GGUF unless it is already downloaded. Small GPU -> GGUF.
@@ -941,11 +774,8 @@ const fluxDev = groupForRepoId("black-forest-labs/FLUX.1-dev", IMAGE_CATALOG);
 assert.ok(fluxDev);
 assert.equal(fluxDev.canonicalId, "unsloth/FLUX.1-dev");
 assert.equal(
-  pickDefaultArtifact(fluxDev, {
-    gpuGb: 48,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(fluxDev, { gpuGb: 48, systemRamGb: 64, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 assert.equal(
@@ -957,11 +787,8 @@ assert.equal(
   "bf16",
 );
 assert.equal(
-  pickDefaultArtifact(fluxDev, {
-    gpuGb: 24,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(fluxDev, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 // LTX-2.3 video carries the official BF16 single file (no FP8: the loader refuses its scaled-fp8 one), which keeps the ~50 GB Gemma3 encoder resident, so B200-class only.
@@ -975,54 +802,33 @@ assert.equal(groupForRepoId("Lightricks/LTX-2.3", VIDEO_CATALOG), ltxGroup);
 // The retired id is not an artifact, so it can never be handed to a load as a repo to fetch.
 assert.equal(loadSpecFor("unsloth/LTX-2.3", VIDEO_CATALOG), null);
 assert.equal(
-  pickDefaultArtifact(ltxGroup, {
-    gpuGb: 24,
-    systemRamGb: 64,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(ltxGroup, { gpuGb: 24, systemRamGb: 64, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(ltxGroup, {
-    gpuGb: 80,
-    systemRamGb: 128,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(ltxGroup, { gpuGb: 80, systemRamGb: 128, isDownloaded: notDownloaded })
+    .format,
   "gguf",
 );
 assert.equal(
-  pickDefaultArtifact(ltxGroup, {
-    gpuGb: 192,
-    systemRamGb: 256,
-    isDownloaded: notDownloaded,
-  }).format,
+  pickDefaultArtifact(ltxGroup, { gpuGb: 192, systemRamGb: 256, isDownloaded: notDownloaded })
+    .format,
   "bf16",
 );
 // The LTX-2.3 official checkpoints load as single-file against the family base.
-assert.equal(
-  loadSpecFor("Lightricks/LTX-2.3", VIDEO_CATALOG)?.kind,
-  "single_file",
-);
+assert.equal(loadSpecFor("Lightricks/LTX-2.3", VIDEO_CATALOG)?.kind, "single_file");
 assert.equal(
   loadSpecFor("Lightricks/LTX-2.3", VIDEO_CATALOG)?.filename,
   "ltx-2.3-22b-distilled.safetensors",
 );
 // The official image BF16 pipelines load via from_pretrained (pipeline kind).
-assert.equal(
-  loadSpecFor("Tongyi-MAI/Z-Image-Turbo", IMAGE_CATALOG)?.kind,
-  "pipeline",
-);
-assert.equal(
-  loadSpecFor("Qwen/Qwen-Image-2512", IMAGE_CATALOG)?.kind,
-  "pipeline",
-);
+assert.equal(loadSpecFor("Tongyi-MAI/Z-Image-Turbo", IMAGE_CATALOG)?.kind, "pipeline");
+assert.equal(loadSpecFor("Qwen/Qwen-Image-2512", IMAGE_CATALOG)?.kind, "pipeline");
 
 // ── catalogGroupFitsDevice (the fit-on-device toggle for catalog rows) ─────────
 
-const wanA14b = groupForRepoId(
-  "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
-  VIDEO_CATALOG,
-);
+const wanA14b = groupForRepoId("Wan-AI/Wan2.2-T2V-A14B-Diffusers", VIDEO_CATALOG);
 const ltxBase = groupForRepoId("Lightricks/LTX-2", VIDEO_CATALOG);
 const hunyuanFit = groupForRepoId(
   "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v",
@@ -1037,11 +843,7 @@ assert.equal(catalogGroupFitsDevice(ltxBase, consumer, notDownloaded), false); /
 assert.equal(catalogGroupFitsDevice(hunyuanFit, consumer, notDownloaded), true);
 // But on a tiny device even those are hidden.
 assert.equal(
-  catalogGroupFitsDevice(
-    hunyuanFit,
-    { gpuGb: 8, systemRamGb: 8 },
-    notDownloaded,
-  ),
+  catalogGroupFitsDevice(hunyuanFit, { gpuGb: 8, systemRamGb: 8 }, notDownloaded),
   false,
 );
 // A GGUF in the group is always runnable (its quant ladder self-fits + offloads), so LTX-2.3 stays visible on a tiny card despite its 90 GB BF16 sibling.
@@ -1059,17 +861,10 @@ assert.equal(
   true,
 );
 // Unknown device budget keeps everything (we cannot tell), even a 114 GB group.
-assert.equal(
-  catalogGroupFitsDevice(wanA14b, { gpuGb: 0, systemRamGb: 0 }, notDownloaded),
-  true,
-);
+assert.equal(catalogGroupFitsDevice(wanA14b, { gpuGb: 0, systemRamGb: 0 }, notDownloaded), true);
 // On a B200-class budget the large bf16 groups fit and stay visible.
 assert.equal(
-  catalogGroupFitsDevice(
-    wanA14b,
-    { gpuGb: 192, systemRamGb: 256 },
-    notDownloaded,
-  ),
+  catalogGroupFitsDevice(wanA14b, { gpuGb: 192, systemRamGb: 256 }, notDownloaded),
   true,
 );
 
@@ -1077,19 +872,12 @@ assert.equal(
 
 // Every audio group carries a task tag; the other catalogs carry none.
 for (const group of AUDIO_CATALOG) {
-  assert.ok(
-    group.task === "tts" || group.task === "stt",
-    `audio group ${group.canonicalId} needs a task`,
-  );
+  assert.ok(group.task === "tts" || group.task === "stt", `audio group ${group.canonicalId} needs a task`);
   assert.equal(group.scope, "audio");
 }
 for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG]) {
   for (const group of catalog) {
-    assert.equal(
-      group.task,
-      undefined,
-      `non-audio group ${group.canonicalId} must not carry a task`,
-    );
+    assert.equal(group.task, undefined, `non-audio group ${group.canonicalId} must not carry a task`);
   }
 }
 // The Orpheus GGUF groups with its safetensors base and reports the gguf load kind.
@@ -1097,20 +885,11 @@ const orpheus = groupForRepoId("unsloth/orpheus-3b-0.1-ft-GGUF", AUDIO_CATALOG);
 assert.ok(orpheus);
 assert.equal(orpheus.canonicalId, "unsloth/orpheus-3b-0.1-ft");
 assert.equal(orpheus.task, "tts");
-assert.equal(
-  loadSpecFor("unsloth/orpheus-3b-0.1-ft-GGUF", AUDIO_CATALOG)?.kind,
-  "gguf",
-);
+assert.equal(loadSpecFor("unsloth/orpheus-3b-0.1-ft-GGUF", AUDIO_CATALOG)?.kind, "gguf");
 assert.equal(loadSpecFor("unsloth/csm-1b", AUDIO_CATALOG)?.kind, "pipeline");
 // The whisper sidecar repos resolve as stt groups.
-assert.equal(
-  groupForRepoId("unsloth/whisper-large-v3-turbo", AUDIO_CATALOG)?.task,
-  "stt",
-);
-assert.equal(
-  groupForRepoId("unslothai/Qwen3-ASR-0.6B-GGUF", AUDIO_CATALOG)?.task,
-  "stt",
-);
+assert.equal(groupForRepoId("unsloth/whisper-large-v3-turbo", AUDIO_CATALOG)?.task, "stt");
+assert.equal(groupForRepoId("unslothai/Qwen3-ASR-0.6B-GGUF", AUDIO_CATALOG)?.task, "stt");
 // A chat model stays unknown to the audio catalog.
 assert.equal(groupForRepoId("unsloth/Llama-3.3-70B-GGUF", AUDIO_CATALOG), null);
 // MiniMax Music3 publishes a 67 GB repository, but its official BF16 modular loader
@@ -1118,17 +897,19 @@ assert.equal(groupForRepoId("unsloth/Llama-3.3-70B-GGUF", AUDIO_CATALOG), null);
 const minimaxMusic = groupForRepoId("MiniMaxAI/MiniMax-Music3", AUDIO_CATALOG);
 assert.ok(minimaxMusic);
 assert.equal(
-  curatedArtifactFitsDevice("MiniMaxAI/MiniMax-Music3", AUDIO_CATALOG, {
-    gpuGb: 95,
-    systemRamGb: 0,
-  }),
+  curatedArtifactFitsDevice(
+    "MiniMaxAI/MiniMax-Music3",
+    AUDIO_CATALOG,
+    { gpuGb: 95, systemRamGb: 0 },
+  ),
   true,
 );
 assert.equal(
-  curatedArtifactFitsDevice("MiniMaxAI/MiniMax-Music3", AUDIO_CATALOG, {
-    gpuGb: 23,
-    systemRamGb: 256,
-  }),
+  curatedArtifactFitsDevice(
+    "MiniMaxAI/MiniMax-Music3",
+    AUDIO_CATALOG,
+    { gpuGb: 23, systemRamGb: 256 },
+  ),
   false,
 );
 
@@ -1203,28 +984,20 @@ async function fetchWithRetry(
   let why = "unknown";
   for (let attempt = 1; attempt <= NETWORK_ATTEMPTS; attempt++) {
     if (Date.now() >= networkDeadlineAt) {
-      return {
-        response: null,
-        body: "",
-        why: "the network check ran out of its overall budget",
-      };
+      return { response: null, body: "", why: "the network check ran out of its overall budget" };
     }
     try {
       // A per-attempt deadline, or a peer that accepts the connection and then stalls has no
       // retry and no fail-open: fetch simply never settles, and the scheduled job dies on its own
       // 10-minute timeout as a RED run. Which is the one outcome this check promises not to
       // produce for a network blip.
-      const response = await fetch(url, {
-        ...init,
-        signal: AbortSignal.timeout(NETWORK_TIMEOUT_MS),
-      });
+      const response = await fetch(url, { ...init, signal: AbortSignal.timeout(NETWORK_TIMEOUT_MS) });
       // Read the body HERE, under that same deadline. Headers can arrive promptly and the body
       // still stall, and the caller parses outside this function where an abort would surface as
       // "the Hub answered 200 with unreadable JSON" -- a catalog failure, for a stalled socket.
       // It also drains the 429/5xx responses we are about to retry, rather than leaking them.
       const body = init?.method === "HEAD" ? "" : await response.text();
-      if (response.status !== 429 && response.status < 500)
-        return { response, body, why: "" };
+      if (response.status !== 429 && response.status < 500) return { response, body, why: "" };
       why = `HTTP ${response.status}`;
     } catch (err) {
       why = String(err);
@@ -1235,18 +1008,13 @@ async function fetchWithRetry(
 }
 
 /** Run `work` over `items`, a few at a time: ~35 repos, and the Hub does not need a thundering herd. */
-async function inBatches<T>(
-  items: T[],
-  work: (item: T) => Promise<void>,
-): Promise<void> {
+async function inBatches<T>(items: T[], work: (item: T) => Promise<void>): Promise<void> {
   for (let i = 0; i < items.length; i += NETWORK_BATCH) {
     await Promise.all(items.slice(i, i + NETWORK_BATCH).map(work));
   }
 }
 
-async function checkCatalogAgainstTheHub(
-  catalogs: CatalogGroup[][],
-): Promise<string[]> {
+async function checkCatalogAgainstTheHub(catalogs: CatalogGroup[][]): Promise<string[]> {
   networkDeadlineAt = Date.now() + NETWORK_DEADLINE_MS;
   const failures: string[] = [];
   const groups = catalogs.flat();
@@ -1260,94 +1028,76 @@ async function checkCatalogAgainstTheHub(
     }
   }
 
-  await inBatches(
-    [...artifactsByRepo.entries()],
-    async ([repoId, artifacts]) => {
-      const { response, body, why } = await fetchWithRetry(
-        `${HF_API}/${repoId}`,
+  await inBatches([...artifactsByRepo.entries()], async ([repoId, artifacts]) => {
+    const { response, body, why } = await fetchWithRetry(`${HF_API}/${repoId}`);
+    if (response === null) {
+      console.warn(
+        `::warning::${repoId}: the Hub did not answer after ${NETWORK_ATTEMPTS} attempts (${why}). Not a verdict about the catalog.`,
       );
-      if (response === null) {
-        console.warn(
-          `::warning::${repoId}: the Hub did not answer after ${NETWORK_ATTEMPTS} attempts (${why}). Not a verdict about the catalog.`,
-        );
-        return;
-      }
-      if (!response.ok) {
-        // 401 on the METADATA endpoint means private-or-absent (the Hub will not say which);
-        // a gated-but-public repo answers 200 with gated set, so this is never just "needs a licence".
+      return;
+    }
+    if (!response.ok) {
+      // 401 on the METADATA endpoint means private-or-absent (the Hub will not say which);
+      // a gated-but-public repo answers 200 with gated set, so this is never just "needs a licence".
+      failures.push(
+        `${repoId}: HTTP ${response.status} from ${HF_API}/${repoId} -- the repo is missing, renamed or private, so no user can download it`,
+      );
+      return;
+    }
+    let repo: HubRepo;
+    try {
+      repo = JSON.parse(body) as HubRepo;
+    } catch (err) {
+      // A 200 that is not JSON is a captive portal or a proxy, not a catalog problem. Reject the
+      // run rather than throwing out of Promise.all with a raw stack.
+      failures.push(`${repoId}: the Hub answered 200 with unreadable JSON (${err})`);
+      return;
+    }
+    const hubGated = Boolean(repo.gated);
+    for (const artifact of artifacts) {
+      const declaredGated = artifact.gated === true;
+      if (hubGated && !declaredGated) {
         failures.push(
-          `${repoId}: HTTP ${response.status} from ${HF_API}/${repoId} -- the repo is missing, renamed or private, so no user can download it`,
+          `${repoId}: the Hub reports gated=${JSON.stringify(repo.gated)} but the catalog entry has no \`gated: true\`, so an anonymous download 401s`,
         );
-        return;
-      }
-      let repo: HubRepo;
-      try {
-        repo = JSON.parse(body) as HubRepo;
-      } catch (err) {
-        // A 200 that is not JSON is a captive portal or a proxy, not a catalog problem. Reject the
-        // run rather than throwing out of Promise.all with a raw stack.
+      } else if (!hubGated && declaredGated) {
         failures.push(
-          `${repoId}: the Hub answered 200 with unreadable JSON (${err})`,
+          `${repoId}: marked \`gated: true\` but the Hub reports it open -- the router skips it for no reason`,
         );
-        return;
       }
-      const hubGated = Boolean(repo.gated);
-      for (const artifact of artifacts) {
-        const declaredGated = artifact.gated === true;
-        if (hubGated && !declaredGated) {
-          failures.push(
-            `${repoId}: the Hub reports gated=${JSON.stringify(repo.gated)} but the catalog entry has no \`gated: true\`, so an anonymous download 401s`,
-          );
-        } else if (!hubGated && declaredGated) {
-          failures.push(
-            `${repoId}: marked \`gated: true\` but the Hub reports it open -- the router skips it for no reason`,
-          );
-        }
-      }
+    }
 
-      const declaredFiles = [
-        ...new Set(
-          artifacts
-            .map((a) => a.filename)
-            .filter((f): f is string => Boolean(f)),
-        ),
-      ];
-      if (declaredFiles.length === 0) return;
-      const listed = new Set((repo.siblings ?? []).map((s) => s.rfilename));
-      for (const filename of declaredFiles) {
-        if (!listed.has(filename)) {
-          failures.push(
-            `${repoId}: declares '${filename}', which the repo does not contain`,
-          );
-          continue;
-        }
-        if (hubGated) continue; // resolve/ 401s without a token; the sibling list is the check.
-        // Listed is not the same as fetchable: resolve/ is the endpoint the download hits.
-        const head = await fetchWithRetry(
-          `${HF_RESOLVE}/${repoId}/resolve/main/${filename}`,
-          {
-            method: "HEAD",
-          },
-        );
-        if (head.response === null) {
-          console.warn(
-            `::warning::${repoId}: could not HEAD '${filename}' (${head.why}). Not a verdict.`,
-          );
-        } else if (!head.response.ok) {
-          failures.push(
-            `${repoId}: '${filename}' is listed but resolve/main returned HTTP ${head.response.status}`,
-          );
-        }
+    const declaredFiles = [
+      ...new Set(artifacts.map((a) => a.filename).filter((f): f is string => Boolean(f))),
+    ];
+    if (declaredFiles.length === 0) return;
+    const listed = new Set((repo.siblings ?? []).map((s) => s.rfilename));
+    for (const filename of declaredFiles) {
+      if (!listed.has(filename)) {
+        failures.push(`${repoId}: declares '${filename}', which the repo does not contain`);
+        continue;
       }
-    },
-  );
+      if (hubGated) continue; // resolve/ 401s without a token; the sibling list is the check.
+      // Listed is not the same as fetchable: resolve/ is the endpoint the download hits.
+      const head = await fetchWithRetry(`${HF_RESOLVE}/${repoId}/resolve/main/${filename}`, {
+        method: "HEAD",
+      });
+      if (head.response === null) {
+        console.warn(
+          `::warning::${repoId}: could not HEAD '${filename}' (${head.why}). Not a verdict.`,
+        );
+      } else if (!head.response.ok) {
+        failures.push(
+          `${repoId}: '${filename}' is listed but resolve/main returned HTTP ${head.response.status}`,
+        );
+      }
+    }
+  });
 
   // Advisory only. A canonicalId is a display/grouping key, and 15 of them are deliberately not
   // repos; but one that is BOTH `unsloth/*`-shaped and dead clears every owner guard in the app,
   // so it is worth naming without failing a scheduled job over it.
-  const artifactIds = new Set(
-    [...artifactsByRepo.keys()].map((id) => id.toLowerCase()),
-  );
+  const artifactIds = new Set([...artifactsByRepo.keys()].map((id) => id.toLowerCase()));
   const orphans = groups
     .map((g) => g.canonicalId)
     .filter((id) => !artifactIds.has(id.toLowerCase()));
@@ -1365,19 +1115,12 @@ async function checkCatalogAgainstTheHub(
 }
 
 if (process.argv.includes("--network")) {
-  console.log(
-    "model-catalog check: --network, asking the Hub about every declared artifact...",
-  );
-  const failures = await checkCatalogAgainstTheHub([
-    IMAGE_CATALOG,
-    VIDEO_CATALOG,
-  ]);
+  console.log("model-catalog check: --network, asking the Hub about every declared artifact...");
+  const failures = await checkCatalogAgainstTheHub([IMAGE_CATALOG, VIDEO_CATALOG]);
   if (failures.length > 0) {
     for (const failure of failures) console.error(`::error::${failure}`);
     console.error(`model-catalog network check: ${failures.length} problem(s)`);
     process.exit(1);
   }
-  console.log(
-    "model-catalog network check: every declared repo, file and gated flag agrees with the Hub",
-  );
+  console.log("model-catalog network check: every declared repo, file and gated flag agrees with the Hub");
 }

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
@@ -950,6 +950,8 @@ export interface DeviceBudget {
   systemRamGb: number;
   /** The user's saved VRAM Budget. Absent falls back to the loader's default. */
   budgetFraction?: number;
+  /** GPUs gpuGb sums, for the loader's per-card VRAM reserve. Absent means one. */
+  gpuCount?: number;
 }
 
 /** GGUF fit, delegated to the one formula the Hub badge already uses.

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
@@ -69,10 +69,7 @@ export interface CatalogGroup {
 
 // ── artifact constructors (keep the data tables terse) ─────────────────────────
 
-const gguf = (
-  repoId: string,
-  extra?: Partial<ModelArtifact>,
-): ModelArtifact => ({
+const gguf = (repoId: string, extra?: Partial<ModelArtifact>): ModelArtifact => ({
   repoId,
   format: "gguf",
   loadKind: "gguf",
@@ -151,9 +148,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     artifacts: [
       bf16Pipeline("Tongyi-MAI/Z-Image-Turbo", 30, { totalParams: 6154908736 }),
-      bnb4bit("unsloth/Z-Image-Turbo-unsloth-bnb-4bit", 8, {
-        totalParams: 3210823936,
-      }),
+      bnb4bit("unsloth/Z-Image-Turbo-unsloth-bnb-4bit", 8, { totalParams: 3210823936 }),
       gguf("unsloth/Z-Image-Turbo-GGUF"),
     ],
   },
@@ -179,9 +174,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
       // single-file .safetensors, and fp8 is denied for this family anyway
       // (_FAMILY_SCHEME_DENY: qwen-image renders every frame black under fp8). The repo's int8
       // half is reached through the backend prequant path, not from here.
-      bnb4bit("unsloth/Qwen-Image-2512-unsloth-bnb-4bit", 14, {
-        totalParams: 10850871408,
-      }),
+      bnb4bit("unsloth/Qwen-Image-2512-unsloth-bnb-4bit", 14, { totalParams: 10850871408 }),
       gguf("unsloth/Qwen-Image-2512-GGUF"),
     ],
   },
@@ -203,10 +196,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     artifacts: [
       // Apache-2.0 but still gated on the Hub (gated: "auto", a contact-info form), so an
       // anonymous download 401s exactly like dev. The licence and the gate are independent.
-      bf16Pipeline("black-forest-labs/FLUX.1-schnell", 32, {
-        gated: true,
-        totalParams: 11891178560,
-      }),
+      bf16Pipeline("black-forest-labs/FLUX.1-schnell", 32, { gated: true, totalParams: 11891178560 }),
       gguf("unsloth/FLUX.1-schnell-GGUF"),
     ],
   },
@@ -217,10 +207,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     artifacts: [
       // FLUX.1-dev is gated (license acceptance + token), like FLUX.1-schnell above.
-      bf16Pipeline("black-forest-labs/FLUX.1-dev", 32, {
-        gated: true,
-        totalParams: 11901408320,
-      }),
+      bf16Pipeline("black-forest-labs/FLUX.1-dev", 32, { gated: true, totalParams: 11901408320 }),
       gguf("unsloth/FLUX.1-dev-GGUF"),
     ],
   },
@@ -231,10 +218,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     description: "Text-to-image",
     scope: "image",
     artifacts: [
-      bf16Pipeline("black-forest-labs/FLUX.1-Krea-dev", 32, {
-        gated: true,
-        totalParams: 11901408320,
-      }),
+      bf16Pipeline("black-forest-labs/FLUX.1-Krea-dev", 32, { gated: true, totalParams: 11901408320 }),
       gguf("QuantStack/FLUX.1-Krea-dev-GGUF"),
     ],
   },
@@ -258,9 +242,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     description: "Image editing",
     scope: "image",
     artifacts: [
-      bf16Pipeline("Qwen/Qwen-Image-Edit-2511", 54, {
-        totalParams: 20430401088,
-      }),
+      bf16Pipeline("Qwen/Qwen-Image-Edit-2511", 54, { totalParams: 20430401088 }),
       gguf("unsloth/Qwen-Image-Edit-2511-GGUF"),
     ],
   },
@@ -271,10 +253,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     artifacts: [
       // FLUX.1-Kontext-dev is gated on the Hub (license acceptance + token).
-      bf16Pipeline("black-forest-labs/FLUX.1-Kontext-dev", 32, {
-        gated: true,
-        totalParams: 11901408320,
-      }),
+      bf16Pipeline("black-forest-labs/FLUX.1-Kontext-dev", 32, { gated: true, totalParams: 11901408320 }),
       gguf("unsloth/FLUX.1-Kontext-dev-GGUF"),
     ],
   },
@@ -285,12 +264,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     // Gated on the Hub, and the group's only artifact, so a bare click has nothing open to fall
     // through to: the picker must show the gate rather than start a download that 401s.
-    artifacts: [
-      bf16Pipeline("krea/Krea-2-Turbo", 18, {
-        gated: true,
-        totalParams: 12820073036,
-      }),
-    ],
+    artifacts: [bf16Pipeline("krea/Krea-2-Turbo", 18, { gated: true, totalParams: 12820073036 })],
   },
   {
     // 2.6B DiT + Gemma2-2B encoder, ~11 GB bf16-resident (ships fp32, cast on load). Apache-2.0, ungated. No upstream GGUF quants, so the official pipeline is the only artifact.
@@ -298,11 +272,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     displayName: "Lumina Image 2.0",
     description: "Text-to-image",
     scope: "image",
-    artifacts: [
-      bf16Pipeline("Alpha-VLLM/Lumina-Image-2.0", 11, {
-        totalParams: 2609769152,
-      }),
-    ],
+    artifacts: [bf16Pipeline("Alpha-VLLM/Lumina-Image-2.0", 11, { totalParams: 2609769152 })],
   },
   {
     // 17B dual-stream 2K-native DiT with a Qwen2.5-VL encoder; the mirror guider components load natively on diffusers 0.39.
@@ -319,9 +289,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     description: "Text-to-image",
     scope: "image",
     artifacts: [
-      bf16Pipeline("hunyuanvideo-community/HunyuanImage-2.1-Diffusers", 50, {
-        totalParams: 17425795520,
-      }),
+      bf16Pipeline("hunyuanvideo-community/HunyuanImage-2.1-Diffusers", 50, { totalParams: 17425795520 }),
     ],
   },
   {
@@ -332,9 +300,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     description: "Text-to-image",
     scope: "image",
     artifacts: [
-      bf16Pipeline("HiDream-ai/HiDream-I1-Full", 63, {
-        totalParams: 17105733184,
-      }),
+      bf16Pipeline("HiDream-ai/HiDream-I1-Full", 63, { totalParams: 17105733184 }),
       bf16Pipeline("HiDream-ai/HiDream-I1-Dev", 63, {
         label: "BF16 - Dev (distilled)",
         keywords: ["bf16", "dev", "distilled"],
@@ -355,14 +321,8 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     artifacts: [
       // Both Ideogram repos are gated on the Hub, so neither can be auto-routed anonymously.
-      fp8Pipeline("ideogram-ai/ideogram-4-fp8", 46, {
-        gated: true,
-        totalParams: 9281557760,
-      }),
-      bnb4bit("ideogram-ai/ideogram-4-nf4-diffusers", 11, {
-        gated: true,
-        totalParams: 4785317809,
-      }),
+      fp8Pipeline("ideogram-ai/ideogram-4-fp8", 46, { gated: true, totalParams: 9281557760 }),
+      bnb4bit("ideogram-ai/ideogram-4-nf4-diffusers", 11, { gated: true, totalParams: 4785317809 }),
     ],
   },
   // SDXL Turbo and Base are different checkpoints with different step/guidance defaults, so two groups.
@@ -371,12 +331,7 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     displayName: "SDXL Turbo",
     description: "Text-to-image",
     scope: "image",
-    artifacts: [
-      bf16Pipeline("stabilityai/sdxl-turbo", 8, {
-        label: "Safetensors",
-        totalParams: 2567463684,
-      }),
-    ],
+    artifacts: [bf16Pipeline("stabilityai/sdxl-turbo", 8, { label: "Safetensors", totalParams: 2567463684 })],
   },
   {
     canonicalId: "stabilityai/stable-diffusion-xl-base-1.0",
@@ -449,7 +404,11 @@ export const VIDEO_CATALOG: CatalogGroup[] = [
     scope: "video",
     capabilities: { audio: true },
     artifacts: [
-      bf16Single("Lightricks/LTX-2.3", "ltx-2.3-22b-distilled.safetensors", 90),
+      bf16Single(
+        "Lightricks/LTX-2.3",
+        "ltx-2.3-22b-distilled.safetensors",
+        90,
+      ),
       // No FP8 artifact: the LTX-2.3 loader refuses the official scaled-FP8 single file (it carries .weight_scale/.input_scale), so a click would start a ~76 GB download that always fails.
       // 21.0B is what the Hub reports for this repo; carrying it keeps the row identical when the listing is unavailable (offline, rate-limited).
       gguf("unsloth/LTX-2.3-GGUF", { totalParams: 21_005_004_544 }),
@@ -461,31 +420,21 @@ export const VIDEO_CATALOG: CatalogGroup[] = [
     description: "Text-to-video with audio",
     scope: "video",
     capabilities: { audio: true },
-    artifacts: [
-      bf16Pipeline("Lightricks/LTX-2", 90, { totalParams: 18876174592 }),
-    ],
+    artifacts: [bf16Pipeline("Lightricks/LTX-2", 90, { totalParams: 18876174592 })],
   },
   {
     canonicalId: "Wan-AI/Wan2.2-TI2V-5B",
     displayName: "Wan 2.2 TI2V 5B",
     description: "Text-to-video 720p",
     scope: "video",
-    artifacts: [
-      bf16Pipeline("Wan-AI/Wan2.2-TI2V-5B-Diffusers", 30, {
-        totalParams: 4999787712,
-      }),
-    ],
+    artifacts: [bf16Pipeline("Wan-AI/Wan2.2-TI2V-5B-Diffusers", 30, { totalParams: 4999787712 })],
   },
   {
     canonicalId: "Wan-AI/Wan2.2-T2V-A14B",
     displayName: "Wan 2.2 T2V A14B (MoE)",
     description: "Text-to-video, dual-expert",
     scope: "video",
-    artifacts: [
-      bf16Pipeline("Wan-AI/Wan2.2-T2V-A14B-Diffusers", 114, {
-        totalParams: 14288491584,
-      }),
-    ],
+    artifacts: [bf16Pipeline("Wan-AI/Wan2.2-T2V-A14B-Diffusers", 114, { totalParams: 14288491584 })],
   },
   {
     canonicalId: "hunyuanvideo-community/HunyuanVideo-1.5",
@@ -495,24 +444,16 @@ export const VIDEO_CATALOG: CatalogGroup[] = [
     artifacts: [
       // Highest-quality first: pickDefaultArtifact sorts only by FORMAT, so these two bf16 artifacts keep catalog order and the fit
       // loop returns the first that fits. 720p (52 GB) precedes 480p (40 GB), so an 80 GB card (0.7*budget=56) picks 720p.
-      bf16Pipeline(
-        "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v",
-        52,
-        {
-          label: "BF16 - 720p",
-          keywords: ["bf16", "720p"],
-          totalParams: 8326608160,
-        },
-      ),
-      bf16Pipeline(
-        "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v",
-        40,
-        {
-          label: "BF16 - 480p",
-          keywords: ["bf16", "480p"],
-          totalParams: 8326608160,
-        },
-      ),
+      bf16Pipeline("hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v", 52, {
+        label: "BF16 - 720p",
+        keywords: ["bf16", "720p"],
+        totalParams: 8326608160,
+      }),
+      bf16Pipeline("hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v", 40, {
+        label: "BF16 - 480p",
+        keywords: ["bf16", "480p"],
+        totalParams: 8326608160,
+      }),
     ],
   },
 ];
@@ -548,9 +489,7 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Text-to-speech",
     scope: "audio",
     task: "tts",
-    artifacts: [
-      bf16Pipeline("unsloth/Spark-TTS-0.5B", 3, { label: "Safetensors" }),
-    ],
+    artifacts: [bf16Pipeline("unsloth/Spark-TTS-0.5B", 3, { label: "Safetensors" })],
   },
   {
     canonicalId: "unsloth/Llama-OuteTTS-1.0-1B",
@@ -636,7 +575,9 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [gguf("unslothai/Qwen3-ASR-0.6B-GGUF", { deviceQuant: "Q8_0" })],
+    artifacts: [
+      gguf("unslothai/Qwen3-ASR-0.6B-GGUF", { deviceQuant: "Q8_0" }),
+    ],
   },
   {
     canonicalId: "unslothai/Qwen3-ASR-1.7B-GGUF",
@@ -644,7 +585,9 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [gguf("unslothai/Qwen3-ASR-1.7B-GGUF", { deviceQuant: "Q8_0" })],
+    artifacts: [
+      gguf("unslothai/Qwen3-ASR-1.7B-GGUF", { deviceQuant: "Q8_0" }),
+    ],
   },
   {
     canonicalId: "unsloth/whisper-large-v3-turbo",
@@ -653,9 +596,7 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     scope: "audio",
     task: "stt",
     artifacts: [
-      bf16Pipeline("unsloth/whisper-large-v3-turbo", 2, {
-        label: "Safetensors",
-      }),
+      bf16Pipeline("unsloth/whisper-large-v3-turbo", 2, { label: "Safetensors" }),
     ],
   },
   {
@@ -674,9 +615,7 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [
-      bf16Pipeline("unsloth/whisper-small", 1, { label: "Safetensors" }),
-    ],
+    artifacts: [bf16Pipeline("unsloth/whisper-small", 1, { label: "Safetensors" })],
   },
   // Both sidecars carry tiny/base (GGML_STT_REPOS, STT_MODEL_REPOS) and Voice
   // settings lists them; only this picker was missing them.
@@ -686,9 +625,7 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [
-      bf16Pipeline("unsloth/whisper-base", 1, { label: "Safetensors" }),
-    ],
+    artifacts: [bf16Pipeline("unsloth/whisper-base", 1, { label: "Safetensors" })],
   },
   {
     canonicalId: "unsloth/whisper-tiny",
@@ -696,9 +633,7 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [
-      bf16Pipeline("unsloth/whisper-tiny", 1, { label: "Safetensors" }),
-    ],
+    artifacts: [bf16Pipeline("unsloth/whisper-tiny", 1, { label: "Safetensors" })],
   },
 ];
 
@@ -806,9 +741,7 @@ export function groupForRepoId(
 ): CatalogGroup | null {
   const index = indexFor(catalog);
   const lowered = repoId.trim().toLowerCase();
-  return (
-    index.byId.get(lowered) ?? index.byKey.get(canonicalKeyFor(lowered)) ?? null
-  );
+  return index.byId.get(lowered) ?? index.byKey.get(canonicalKeyFor(lowered)) ?? null;
 }
 
 /** The exact curated artifact for a repo id (null when the repo only matches a group by key/alias). */
@@ -881,9 +814,7 @@ export function curatedDisplayNameFor(
   // trigger and curatedRowLabelFor names the row, so a divergence would rename the model as the
   // popover opens.
   if (h3PerfSuffix(repoId, host)) {
-    return (
-      curatedRowLabelFor(repoId, catalog, host)?.name ?? hit.group.displayName
-    );
+    return curatedRowLabelFor(repoId, catalog, host)?.name ?? hit.group.displayName;
   }
   return hit.group.artifacts.length > 1
     ? `${hit.group.displayName} (${hit.artifact.label})`
@@ -919,14 +850,10 @@ export function curatedRowLabelFor(
   // name and let it say so. A chip would only repeat the suffix.
   if (hit.artifact.format === "gguf") {
     const leaf = hit.artifact.repoId.split("/").pop() ?? hit.artifact.repoId;
-    return {
-      name: qualify(GGUF_SUFFIX_RE.test(leaf) ? leaf : `${leaf}-GGUF`),
-      tags: [],
-    };
+    return { name: qualify(GGUF_SUFFIX_RE.test(leaf) ? leaf : `${leaf}-GGUF`), tags: [] };
   }
   // A group with one artifact has nothing to distinguish, so it stays bare, exactly as before.
-  if (hit.group.artifacts.length <= 1)
-    return { name: qualify(hit.group.displayName), tags: [] };
+  if (hit.group.artifacts.length <= 1) return { name: qualify(hit.group.displayName), tags: [] };
   const [format, ...rest] = hit.artifact.label.split(LABEL_PART_SEPARATOR);
   const tags = [format.replace(OFFICIAL_SUFFIX_RE, "").trim()].filter(Boolean);
   const kept: string[] = [];
@@ -955,9 +882,7 @@ export function catalogToModelOptions(
       if (!curatedArtifactIsOfferable(artifact.repoId, host)) continue;
       options.push({
         id: artifact.repoId,
-        name:
-          curatedDisplayNameFor(artifact.repoId, catalog, host) ??
-          group.displayName,
+        name: curatedDisplayNameFor(artifact.repoId, catalog, host) ?? group.displayName,
         description: `${group.description} - ${artifact.label}`,
         isGguf: artifact.format === "gguf",
         deviceQuant: artifact.deviceQuant,
@@ -1124,14 +1049,10 @@ const FORMAT_QUALITY: Record<ArtifactFormat, number> = {
   gguf: 3,
 };
 
-function fitsArtifactBudget(
-  artifact: ModelArtifact,
-  budget: DeviceBudget,
-): boolean {
+function fitsArtifactBudget(artifact: ModelArtifact, budget: DeviceBudget): boolean {
   if (artifact.offloadFitTiers?.length) {
     return artifact.offloadFitTiers.some(
-      (tier) =>
-        budget.gpuGb >= tier.gpuGb && budget.systemRamGb >= tier.systemRamGb,
+      (tier) => budget.gpuGb >= tier.gpuGb && budget.systemRamGb >= tier.systemRamGb,
     );
   }
   if (artifact.approxSizeGb === undefined) return false;
@@ -1156,9 +1077,7 @@ export function pickDefaultArtifact(
     const downloadedGguf = downloaded.find((a) => a.format === "gguf");
     if (downloadedGguf) return downloadedGguf;
     return downloaded.sort(
-      (a, b) =>
-        (a.approxSizeGb ?? Number.POSITIVE_INFINITY) -
-        (b.approxSizeGb ?? Number.POSITIVE_INFINITY),
+      (a, b) => (a.approxSizeGb ?? Infinity) - (b.approxSizeGb ?? Infinity),
     )[0];
   }
   if (!input.gpuGb || input.gpuGb <= 0) {
@@ -1166,19 +1085,13 @@ export function pickDefaultArtifact(
   }
   for (const artifact of artifacts) {
     // Skip a gated, NOT-downloaded artifact: auto-routing there fails the download without license/token access, so fall through to an open one. The downloaded branch above still returns gated artifacts.
-    if (
-      artifact.format !== "gguf" &&
-      !artifact.gated &&
-      fitsArtifactBudget(artifact, input)
-    ) {
+    if (artifact.format !== "gguf" && !artifact.gated && fitsArtifactBudget(artifact, input)) {
       return artifact;
     }
   }
   if (ggufArtifact) return ggufArtifact;
   return artifacts.sort(
-    (a, b) =>
-      (a.approxSizeGb ?? Number.POSITIVE_INFINITY) -
-      (b.approxSizeGb ?? Number.POSITIVE_INFINITY),
+    (a, b) => (a.approxSizeGb ?? Infinity) - (b.approxSizeGb ?? Infinity),
   )[0];
 }
 
@@ -1204,8 +1117,7 @@ export function curatedArtifactFitsDevice(
   if (!hit || hit.artifact.format === "gguf") return undefined;
   const { group, artifact } = hit;
   if (budget.gpuGb <= 0 && budget.systemRamGb <= 0) return undefined;
-  if (artifact.offloadFitTiers?.length)
-    return fitsArtifactBudget(artifact, budget);
+  if (artifact.offloadFitTiers?.length) return fitsArtifactBudget(artifact, budget);
   if (artifact.approxSizeGb === undefined) return undefined;
   // Transcription retries a failed device load on CPU (stt_sidecar.py), so RAM is a real budget
   // there -- but the WHOLE model goes to whichever device it lands on, never split across both,
@@ -1236,8 +1148,7 @@ export function catalogGroupFitsDevice(
     if (a.format === "gguf") return true;
     if (a.offloadFitTiers?.length) {
       return a.offloadFitTiers.some(
-        (tier) =>
-          budget.gpuGb >= tier.gpuGb && budget.systemRamGb >= tier.systemRamGb,
+        (tier) => budget.gpuGb >= tier.gpuGb && budget.systemRamGb >= tier.systemRamGb,
       );
     }
     return a.approxSizeGb !== undefined && a.approxSizeGb <= budgetGb;

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
@@ -1044,6 +1044,31 @@ export function classifyGgufFit(
   return classifyGgufFitForDevice(sizeBytes, budget);
 }
 
+/** Fit rule for a GGUF the IMAGES / VIDEO / AUDIO pickers offer, which is the one case the shared
+ *  llama.cpp formula must not judge: those loads go through the diffusion backend, whose budget is
+ *  free memory minus a reserve at a 0.85 margin (`diffusion_memory.py`, `_reserve_mib` is 20% on
+ *  unified memory), and which explicitly cannot offload there. On a 64 GiB Mac that planner allows
+ *  about 43.5 GiB where llama.cpp allows 62.1. This rule, the picker's own from before the
+ *  classifiers were merged, allows 44.8, so it is the closer of the two by 18 GiB.
+ *
+ *  It is not the diffusion planner either. It is here so unifying chat's verdict with the Hub's
+ *  does not quietly promise media loads that cannot be placed; a real diffusion predicate is its
+ *  own change. */
+export function classifyMediaGgufFit(
+  sizeBytes: number,
+  gpuGb: number,
+  systemRamGb: number,
+): GgufFitClass {
+  const gpuBudgetGb = gpuGb * 0.7;
+  const totalBudgetGb = gpuBudgetGb + systemRamGb * 0.7;
+  const gb = sizeBytes / 1024 ** 3;
+  if (gb <= 0 || gb <= gpuBudgetGb) return "fits";
+  if (gpuBudgetGb <= 0) return gb <= totalBudgetGb ? "fits" : "oom";
+  // "partial", where this rule used to say "tight": the state it describes is a spill out of the
+  // card, which is what partial means. Tight now means a full GPU load with no room to spare.
+  return gb <= totalBudgetGb ? "partial" : "oom";
+}
+
 /** Whether a verdict still loads. Only `oom` clears neither budget; `marginal` and `partial` run,
  *  the second by offloading to CPU. */
 export function ggufFitRuns(fit: GgufFitClass): boolean {

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
@@ -5,6 +5,10 @@
 // Pure helpers, no React/DOM deps. See model-catalog.check.ts (`npm run catalog:check`).
 
 import {
+  type GgufFitClass,
+  classifyGgufFit as classifyGgufFitForDevice,
+} from "../../../../lib/gguf-fit.ts";
+import {
   type HostClass,
   curatedArtifactIsOfferable,
   h3PerfSuffix,
@@ -65,7 +69,10 @@ export interface CatalogGroup {
 
 // ── artifact constructors (keep the data tables terse) ─────────────────────────
 
-const gguf = (repoId: string, extra?: Partial<ModelArtifact>): ModelArtifact => ({
+const gguf = (
+  repoId: string,
+  extra?: Partial<ModelArtifact>,
+): ModelArtifact => ({
   repoId,
   format: "gguf",
   loadKind: "gguf",
@@ -144,7 +151,9 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     artifacts: [
       bf16Pipeline("Tongyi-MAI/Z-Image-Turbo", 30, { totalParams: 6154908736 }),
-      bnb4bit("unsloth/Z-Image-Turbo-unsloth-bnb-4bit", 8, { totalParams: 3210823936 }),
+      bnb4bit("unsloth/Z-Image-Turbo-unsloth-bnb-4bit", 8, {
+        totalParams: 3210823936,
+      }),
       gguf("unsloth/Z-Image-Turbo-GGUF"),
     ],
   },
@@ -170,7 +179,9 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
       // single-file .safetensors, and fp8 is denied for this family anyway
       // (_FAMILY_SCHEME_DENY: qwen-image renders every frame black under fp8). The repo's int8
       // half is reached through the backend prequant path, not from here.
-      bnb4bit("unsloth/Qwen-Image-2512-unsloth-bnb-4bit", 14, { totalParams: 10850871408 }),
+      bnb4bit("unsloth/Qwen-Image-2512-unsloth-bnb-4bit", 14, {
+        totalParams: 10850871408,
+      }),
       gguf("unsloth/Qwen-Image-2512-GGUF"),
     ],
   },
@@ -192,7 +203,10 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     artifacts: [
       // Apache-2.0 but still gated on the Hub (gated: "auto", a contact-info form), so an
       // anonymous download 401s exactly like dev. The licence and the gate are independent.
-      bf16Pipeline("black-forest-labs/FLUX.1-schnell", 32, { gated: true, totalParams: 11891178560 }),
+      bf16Pipeline("black-forest-labs/FLUX.1-schnell", 32, {
+        gated: true,
+        totalParams: 11891178560,
+      }),
       gguf("unsloth/FLUX.1-schnell-GGUF"),
     ],
   },
@@ -203,7 +217,10 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     artifacts: [
       // FLUX.1-dev is gated (license acceptance + token), like FLUX.1-schnell above.
-      bf16Pipeline("black-forest-labs/FLUX.1-dev", 32, { gated: true, totalParams: 11901408320 }),
+      bf16Pipeline("black-forest-labs/FLUX.1-dev", 32, {
+        gated: true,
+        totalParams: 11901408320,
+      }),
       gguf("unsloth/FLUX.1-dev-GGUF"),
     ],
   },
@@ -214,7 +231,10 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     description: "Text-to-image",
     scope: "image",
     artifacts: [
-      bf16Pipeline("black-forest-labs/FLUX.1-Krea-dev", 32, { gated: true, totalParams: 11901408320 }),
+      bf16Pipeline("black-forest-labs/FLUX.1-Krea-dev", 32, {
+        gated: true,
+        totalParams: 11901408320,
+      }),
       gguf("QuantStack/FLUX.1-Krea-dev-GGUF"),
     ],
   },
@@ -238,7 +258,9 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     description: "Image editing",
     scope: "image",
     artifacts: [
-      bf16Pipeline("Qwen/Qwen-Image-Edit-2511", 54, { totalParams: 20430401088 }),
+      bf16Pipeline("Qwen/Qwen-Image-Edit-2511", 54, {
+        totalParams: 20430401088,
+      }),
       gguf("unsloth/Qwen-Image-Edit-2511-GGUF"),
     ],
   },
@@ -249,7 +271,10 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     artifacts: [
       // FLUX.1-Kontext-dev is gated on the Hub (license acceptance + token).
-      bf16Pipeline("black-forest-labs/FLUX.1-Kontext-dev", 32, { gated: true, totalParams: 11901408320 }),
+      bf16Pipeline("black-forest-labs/FLUX.1-Kontext-dev", 32, {
+        gated: true,
+        totalParams: 11901408320,
+      }),
       gguf("unsloth/FLUX.1-Kontext-dev-GGUF"),
     ],
   },
@@ -260,7 +285,12 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     // Gated on the Hub, and the group's only artifact, so a bare click has nothing open to fall
     // through to: the picker must show the gate rather than start a download that 401s.
-    artifacts: [bf16Pipeline("krea/Krea-2-Turbo", 18, { gated: true, totalParams: 12820073036 })],
+    artifacts: [
+      bf16Pipeline("krea/Krea-2-Turbo", 18, {
+        gated: true,
+        totalParams: 12820073036,
+      }),
+    ],
   },
   {
     // 2.6B DiT + Gemma2-2B encoder, ~11 GB bf16-resident (ships fp32, cast on load). Apache-2.0, ungated. No upstream GGUF quants, so the official pipeline is the only artifact.
@@ -268,7 +298,11 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     displayName: "Lumina Image 2.0",
     description: "Text-to-image",
     scope: "image",
-    artifacts: [bf16Pipeline("Alpha-VLLM/Lumina-Image-2.0", 11, { totalParams: 2609769152 })],
+    artifacts: [
+      bf16Pipeline("Alpha-VLLM/Lumina-Image-2.0", 11, {
+        totalParams: 2609769152,
+      }),
+    ],
   },
   {
     // 17B dual-stream 2K-native DiT with a Qwen2.5-VL encoder; the mirror guider components load natively on diffusers 0.39.
@@ -285,7 +319,9 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     description: "Text-to-image",
     scope: "image",
     artifacts: [
-      bf16Pipeline("hunyuanvideo-community/HunyuanImage-2.1-Diffusers", 50, { totalParams: 17425795520 }),
+      bf16Pipeline("hunyuanvideo-community/HunyuanImage-2.1-Diffusers", 50, {
+        totalParams: 17425795520,
+      }),
     ],
   },
   {
@@ -296,7 +332,9 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     description: "Text-to-image",
     scope: "image",
     artifacts: [
-      bf16Pipeline("HiDream-ai/HiDream-I1-Full", 63, { totalParams: 17105733184 }),
+      bf16Pipeline("HiDream-ai/HiDream-I1-Full", 63, {
+        totalParams: 17105733184,
+      }),
       bf16Pipeline("HiDream-ai/HiDream-I1-Dev", 63, {
         label: "BF16 - Dev (distilled)",
         keywords: ["bf16", "dev", "distilled"],
@@ -317,8 +355,14 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     scope: "image",
     artifacts: [
       // Both Ideogram repos are gated on the Hub, so neither can be auto-routed anonymously.
-      fp8Pipeline("ideogram-ai/ideogram-4-fp8", 46, { gated: true, totalParams: 9281557760 }),
-      bnb4bit("ideogram-ai/ideogram-4-nf4-diffusers", 11, { gated: true, totalParams: 4785317809 }),
+      fp8Pipeline("ideogram-ai/ideogram-4-fp8", 46, {
+        gated: true,
+        totalParams: 9281557760,
+      }),
+      bnb4bit("ideogram-ai/ideogram-4-nf4-diffusers", 11, {
+        gated: true,
+        totalParams: 4785317809,
+      }),
     ],
   },
   // SDXL Turbo and Base are different checkpoints with different step/guidance defaults, so two groups.
@@ -327,7 +371,12 @@ export const IMAGE_CATALOG: CatalogGroup[] = [
     displayName: "SDXL Turbo",
     description: "Text-to-image",
     scope: "image",
-    artifacts: [bf16Pipeline("stabilityai/sdxl-turbo", 8, { label: "Safetensors", totalParams: 2567463684 })],
+    artifacts: [
+      bf16Pipeline("stabilityai/sdxl-turbo", 8, {
+        label: "Safetensors",
+        totalParams: 2567463684,
+      }),
+    ],
   },
   {
     canonicalId: "stabilityai/stable-diffusion-xl-base-1.0",
@@ -400,11 +449,7 @@ export const VIDEO_CATALOG: CatalogGroup[] = [
     scope: "video",
     capabilities: { audio: true },
     artifacts: [
-      bf16Single(
-        "Lightricks/LTX-2.3",
-        "ltx-2.3-22b-distilled.safetensors",
-        90,
-      ),
+      bf16Single("Lightricks/LTX-2.3", "ltx-2.3-22b-distilled.safetensors", 90),
       // No FP8 artifact: the LTX-2.3 loader refuses the official scaled-FP8 single file (it carries .weight_scale/.input_scale), so a click would start a ~76 GB download that always fails.
       // 21.0B is what the Hub reports for this repo; carrying it keeps the row identical when the listing is unavailable (offline, rate-limited).
       gguf("unsloth/LTX-2.3-GGUF", { totalParams: 21_005_004_544 }),
@@ -416,21 +461,31 @@ export const VIDEO_CATALOG: CatalogGroup[] = [
     description: "Text-to-video with audio",
     scope: "video",
     capabilities: { audio: true },
-    artifacts: [bf16Pipeline("Lightricks/LTX-2", 90, { totalParams: 18876174592 })],
+    artifacts: [
+      bf16Pipeline("Lightricks/LTX-2", 90, { totalParams: 18876174592 }),
+    ],
   },
   {
     canonicalId: "Wan-AI/Wan2.2-TI2V-5B",
     displayName: "Wan 2.2 TI2V 5B",
     description: "Text-to-video 720p",
     scope: "video",
-    artifacts: [bf16Pipeline("Wan-AI/Wan2.2-TI2V-5B-Diffusers", 30, { totalParams: 4999787712 })],
+    artifacts: [
+      bf16Pipeline("Wan-AI/Wan2.2-TI2V-5B-Diffusers", 30, {
+        totalParams: 4999787712,
+      }),
+    ],
   },
   {
     canonicalId: "Wan-AI/Wan2.2-T2V-A14B",
     displayName: "Wan 2.2 T2V A14B (MoE)",
     description: "Text-to-video, dual-expert",
     scope: "video",
-    artifacts: [bf16Pipeline("Wan-AI/Wan2.2-T2V-A14B-Diffusers", 114, { totalParams: 14288491584 })],
+    artifacts: [
+      bf16Pipeline("Wan-AI/Wan2.2-T2V-A14B-Diffusers", 114, {
+        totalParams: 14288491584,
+      }),
+    ],
   },
   {
     canonicalId: "hunyuanvideo-community/HunyuanVideo-1.5",
@@ -440,16 +495,24 @@ export const VIDEO_CATALOG: CatalogGroup[] = [
     artifacts: [
       // Highest-quality first: pickDefaultArtifact sorts only by FORMAT, so these two bf16 artifacts keep catalog order and the fit
       // loop returns the first that fits. 720p (52 GB) precedes 480p (40 GB), so an 80 GB card (0.7*budget=56) picks 720p.
-      bf16Pipeline("hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v", 52, {
-        label: "BF16 - 720p",
-        keywords: ["bf16", "720p"],
-        totalParams: 8326608160,
-      }),
-      bf16Pipeline("hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v", 40, {
-        label: "BF16 - 480p",
-        keywords: ["bf16", "480p"],
-        totalParams: 8326608160,
-      }),
+      bf16Pipeline(
+        "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v",
+        52,
+        {
+          label: "BF16 - 720p",
+          keywords: ["bf16", "720p"],
+          totalParams: 8326608160,
+        },
+      ),
+      bf16Pipeline(
+        "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v",
+        40,
+        {
+          label: "BF16 - 480p",
+          keywords: ["bf16", "480p"],
+          totalParams: 8326608160,
+        },
+      ),
     ],
   },
 ];
@@ -485,7 +548,9 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Text-to-speech",
     scope: "audio",
     task: "tts",
-    artifacts: [bf16Pipeline("unsloth/Spark-TTS-0.5B", 3, { label: "Safetensors" })],
+    artifacts: [
+      bf16Pipeline("unsloth/Spark-TTS-0.5B", 3, { label: "Safetensors" }),
+    ],
   },
   {
     canonicalId: "unsloth/Llama-OuteTTS-1.0-1B",
@@ -571,9 +636,7 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [
-      gguf("unslothai/Qwen3-ASR-0.6B-GGUF", { deviceQuant: "Q8_0" }),
-    ],
+    artifacts: [gguf("unslothai/Qwen3-ASR-0.6B-GGUF", { deviceQuant: "Q8_0" })],
   },
   {
     canonicalId: "unslothai/Qwen3-ASR-1.7B-GGUF",
@@ -581,9 +644,7 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [
-      gguf("unslothai/Qwen3-ASR-1.7B-GGUF", { deviceQuant: "Q8_0" }),
-    ],
+    artifacts: [gguf("unslothai/Qwen3-ASR-1.7B-GGUF", { deviceQuant: "Q8_0" })],
   },
   {
     canonicalId: "unsloth/whisper-large-v3-turbo",
@@ -592,7 +653,9 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     scope: "audio",
     task: "stt",
     artifacts: [
-      bf16Pipeline("unsloth/whisper-large-v3-turbo", 2, { label: "Safetensors" }),
+      bf16Pipeline("unsloth/whisper-large-v3-turbo", 2, {
+        label: "Safetensors",
+      }),
     ],
   },
   {
@@ -611,7 +674,9 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [bf16Pipeline("unsloth/whisper-small", 1, { label: "Safetensors" })],
+    artifacts: [
+      bf16Pipeline("unsloth/whisper-small", 1, { label: "Safetensors" }),
+    ],
   },
   // Both sidecars carry tiny/base (GGML_STT_REPOS, STT_MODEL_REPOS) and Voice
   // settings lists them; only this picker was missing them.
@@ -621,7 +686,9 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [bf16Pipeline("unsloth/whisper-base", 1, { label: "Safetensors" })],
+    artifacts: [
+      bf16Pipeline("unsloth/whisper-base", 1, { label: "Safetensors" }),
+    ],
   },
   {
     canonicalId: "unsloth/whisper-tiny",
@@ -629,7 +696,9 @@ export const AUDIO_CATALOG: CatalogGroup[] = [
     description: "Speech-to-text",
     scope: "audio",
     task: "stt",
-    artifacts: [bf16Pipeline("unsloth/whisper-tiny", 1, { label: "Safetensors" })],
+    artifacts: [
+      bf16Pipeline("unsloth/whisper-tiny", 1, { label: "Safetensors" }),
+    ],
   },
 ];
 
@@ -737,7 +806,9 @@ export function groupForRepoId(
 ): CatalogGroup | null {
   const index = indexFor(catalog);
   const lowered = repoId.trim().toLowerCase();
-  return index.byId.get(lowered) ?? index.byKey.get(canonicalKeyFor(lowered)) ?? null;
+  return (
+    index.byId.get(lowered) ?? index.byKey.get(canonicalKeyFor(lowered)) ?? null
+  );
 }
 
 /** The exact curated artifact for a repo id (null when the repo only matches a group by key/alias). */
@@ -810,7 +881,9 @@ export function curatedDisplayNameFor(
   // trigger and curatedRowLabelFor names the row, so a divergence would rename the model as the
   // popover opens.
   if (h3PerfSuffix(repoId, host)) {
-    return curatedRowLabelFor(repoId, catalog, host)?.name ?? hit.group.displayName;
+    return (
+      curatedRowLabelFor(repoId, catalog, host)?.name ?? hit.group.displayName
+    );
   }
   return hit.group.artifacts.length > 1
     ? `${hit.group.displayName} (${hit.artifact.label})`
@@ -846,10 +919,14 @@ export function curatedRowLabelFor(
   // name and let it say so. A chip would only repeat the suffix.
   if (hit.artifact.format === "gguf") {
     const leaf = hit.artifact.repoId.split("/").pop() ?? hit.artifact.repoId;
-    return { name: qualify(GGUF_SUFFIX_RE.test(leaf) ? leaf : `${leaf}-GGUF`), tags: [] };
+    return {
+      name: qualify(GGUF_SUFFIX_RE.test(leaf) ? leaf : `${leaf}-GGUF`),
+      tags: [],
+    };
   }
   // A group with one artifact has nothing to distinguish, so it stays bare, exactly as before.
-  if (hit.group.artifacts.length <= 1) return { name: qualify(hit.group.displayName), tags: [] };
+  if (hit.group.artifacts.length <= 1)
+    return { name: qualify(hit.group.displayName), tags: [] };
   const [format, ...rest] = hit.artifact.label.split(LABEL_PART_SEPARATOR);
   const tags = [format.replace(OFFICIAL_SUFFIX_RE, "").trim()].filter(Boolean);
   const kept: string[] = [];
@@ -878,7 +955,9 @@ export function catalogToModelOptions(
       if (!curatedArtifactIsOfferable(artifact.repoId, host)) continue;
       options.push({
         id: artifact.repoId,
-        name: curatedDisplayNameFor(artifact.repoId, catalog, host) ?? group.displayName,
+        name:
+          curatedDisplayNameFor(artifact.repoId, catalog, host) ??
+          group.displayName,
         description: `${group.description} - ${artifact.label}`,
         isGguf: artifact.format === "gguf",
         deviceQuant: artifact.deviceQuant,
@@ -944,21 +1023,31 @@ export interface DeviceBudget {
   gpuGb: number;
   /** Available system RAM in GB (for the GGUF offload tier). */
   systemRamGb: number;
+  /** The user's saved VRAM Budget. Absent falls back to the loader's default. */
+  budgetFraction?: number;
 }
 
-/** GGUF fit classification matching llama-server _select_gpus: fits = model <= 0.7 * GPU; tight = fits with 0.7 * RAM offload; oom = neither. */
+/** GGUF fit, delegated to the one formula the Hub badge already uses.
+ *
+ * This used to carry its own rule (0.7 * GPU + 0.7 * RAM, raw file size) whose comment claimed to
+ * match `_select_gpus`. It did not: the loader admits against `_active_vram_fraction()`, the saved
+ * VRAM Budget or 0.97, over weights PLUS estimated KV cache. 0.7 appeared nowhere in the backend,
+ * so chat hid quants the loader would have taken and ignored the budget setting entirely. */
 export function classifyGgufFit(
   sizeBytes: number,
   budget: DeviceBudget,
-): "fits" | "tight" | "oom" {
-  const gpuBudgetGb = (budget.gpuGb || 0) * 0.7;
-  const totalBudgetGb = gpuBudgetGb + (budget.systemRamGb || 0) * 0.7;
-  if (totalBudgetGb <= 0) return "fits";
-  const gb = sizeBytes / 1024 ** 3;
-  if (gb <= 0 || gb <= gpuBudgetGb) return "fits";
-  if (gpuBudgetGb <= 0) return gb <= totalBudgetGb ? "fits" : "oom";
-  if (gb <= totalBudgetGb) return "tight";
-  return "oom";
+): GgufFitClass {
+  // Nothing measured, so a verdict would be invented. Callers that know the budget really is zero
+  // (a probed Vulkan device) decide that for themselves.
+  if ((budget.gpuGb || 0) <= 0 && (budget.systemRamGb || 0) <= 0) return "fits";
+  if (sizeBytes <= 0) return "fits";
+  return classifyGgufFitForDevice(sizeBytes, budget);
+}
+
+/** Whether a verdict still loads. Only `oom` clears neither budget; `marginal` and `partial` run,
+ *  the second by offloading to CPU. */
+export function ggufFitRuns(fit: GgufFitClass): boolean {
+  return fit !== "oom";
 }
 
 export interface QuantVariant {
@@ -975,22 +1064,23 @@ export function pickDefaultQuant(
   budget: DeviceBudget,
 ): QuantVariant | null {
   if (!variants || variants.length === 0) return null;
-  const totalBudgetGb =
-    (budget.gpuGb || 0) * 0.7 + (budget.systemRamGb || 0) * 0.7;
+  const anyBudget = (budget.gpuGb || 0) > 0 || (budget.systemRamGb || 0) > 0;
+  const runs = (v: QuantVariant) =>
+    ggufFitRuns(classifyGgufFit(v.size_bytes, budget));
   const downloadedFitting = variants
-    .filter((v) => v.downloaded && classifyGgufFit(v.size_bytes, budget) !== "oom")
+    .filter((v) => v.downloaded && runs(v))
     .sort((a, b) => b.size_bytes - a.size_bytes);
   if (downloadedFitting.length > 0) return downloadedFitting[0];
   const byQuant = (quant: string | null) =>
     quant ? (variants.find((v) => v.quant === quant) ?? null) : null;
   // No budget knowledge at all: trust the repo default.
-  if (totalBudgetGb <= 0) return byQuant(defaultVariant) ?? variants[0];
+  if (!anyBudget) return byQuant(defaultVariant) ?? variants[0];
   const defaultV = byQuant(defaultVariant);
-  if (defaultV && classifyGgufFit(defaultV.size_bytes, budget) !== "oom") {
+  if (defaultV && runs(defaultV)) {
     return defaultV;
   }
   const fitting = variants
-    .filter((v) => classifyGgufFit(v.size_bytes, budget) !== "oom")
+    .filter(runs)
     .sort((a, b) => b.size_bytes - a.size_bytes);
   if (fitting.length > 0) return fitting[0];
   const smallest = [...variants].sort((a, b) => a.size_bytes - b.size_bytes);
@@ -1009,10 +1099,14 @@ const FORMAT_QUALITY: Record<ArtifactFormat, number> = {
   gguf: 3,
 };
 
-function fitsArtifactBudget(artifact: ModelArtifact, budget: DeviceBudget): boolean {
+function fitsArtifactBudget(
+  artifact: ModelArtifact,
+  budget: DeviceBudget,
+): boolean {
   if (artifact.offloadFitTiers?.length) {
     return artifact.offloadFitTiers.some(
-      (tier) => budget.gpuGb >= tier.gpuGb && budget.systemRamGb >= tier.systemRamGb,
+      (tier) =>
+        budget.gpuGb >= tier.gpuGb && budget.systemRamGb >= tier.systemRamGb,
     );
   }
   if (artifact.approxSizeGb === undefined) return false;
@@ -1037,7 +1131,9 @@ export function pickDefaultArtifact(
     const downloadedGguf = downloaded.find((a) => a.format === "gguf");
     if (downloadedGguf) return downloadedGguf;
     return downloaded.sort(
-      (a, b) => (a.approxSizeGb ?? Infinity) - (b.approxSizeGb ?? Infinity),
+      (a, b) =>
+        (a.approxSizeGb ?? Number.POSITIVE_INFINITY) -
+        (b.approxSizeGb ?? Number.POSITIVE_INFINITY),
     )[0];
   }
   if (!input.gpuGb || input.gpuGb <= 0) {
@@ -1045,13 +1141,19 @@ export function pickDefaultArtifact(
   }
   for (const artifact of artifacts) {
     // Skip a gated, NOT-downloaded artifact: auto-routing there fails the download without license/token access, so fall through to an open one. The downloaded branch above still returns gated artifacts.
-    if (artifact.format !== "gguf" && !artifact.gated && fitsArtifactBudget(artifact, input)) {
+    if (
+      artifact.format !== "gguf" &&
+      !artifact.gated &&
+      fitsArtifactBudget(artifact, input)
+    ) {
       return artifact;
     }
   }
   if (ggufArtifact) return ggufArtifact;
   return artifacts.sort(
-    (a, b) => (a.approxSizeGb ?? Infinity) - (b.approxSizeGb ?? Infinity),
+    (a, b) =>
+      (a.approxSizeGb ?? Number.POSITIVE_INFINITY) -
+      (b.approxSizeGb ?? Number.POSITIVE_INFINITY),
   )[0];
 }
 
@@ -1077,7 +1179,8 @@ export function curatedArtifactFitsDevice(
   if (!hit || hit.artifact.format === "gguf") return undefined;
   const { group, artifact } = hit;
   if (budget.gpuGb <= 0 && budget.systemRamGb <= 0) return undefined;
-  if (artifact.offloadFitTiers?.length) return fitsArtifactBudget(artifact, budget);
+  if (artifact.offloadFitTiers?.length)
+    return fitsArtifactBudget(artifact, budget);
   if (artifact.approxSizeGb === undefined) return undefined;
   // Transcription retries a failed device load on CPU (stt_sidecar.py), so RAM is a real budget
   // there -- but the WHOLE model goes to whichever device it lands on, never split across both,
@@ -1108,7 +1211,8 @@ export function catalogGroupFitsDevice(
     if (a.format === "gguf") return true;
     if (a.offloadFitTiers?.length) {
       return a.offloadFitTiers.some(
-        (tier) => budget.gpuGb >= tier.gpuGb && budget.systemRamGb >= tier.systemRamGb,
+        (tier) =>
+          budget.gpuGb >= tier.gpuGb && budget.systemRamGb >= tier.systemRamGb,
       );
     }
     return a.approxSizeGb !== undefined && a.approxSizeGb <= budgetGb;

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -75,7 +75,7 @@ import {
 } from "@/hooks/use-model-memory";
 import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
 import { diffusionRouteSearch } from "@/lib/diffusion-route-search";
-import type { GgufFitClass } from "@/lib/gguf-fit";
+import { type GgufFitClass, requiredGgufMemoryGb } from "@/lib/gguf-fit";
 import { extractParamLabel } from "@/lib/model-size";
 import { toast } from "@/lib/toast";
 import { cn, formatCompact } from "@/lib/utils";
@@ -3502,7 +3502,17 @@ export function HubModelPicker({
           // The classifier's own verdict, so a GGUF row never borrows "exceeds", which is the
           // torch-only refusal used by the curated branch below.
           status: ggufRowFit(sizeBytes, inferenceGpu),
-          est: sizeBytes ? Math.round(sizeBytes / 1024 ** 3) : 0,
+          // The figure the verdict was reached with, not the raw file size. classifyGgufFit scores
+          // weights PLUS activations and KV, so a 20 GiB quant needing 24 GiB read "tight fit"
+          // beside a tooltip saying "~20GB VRAM". The media rule scores the raw size, so that one
+          // keeps it.
+          est: sizeBytes
+            ? Math.round(
+                diffusionLoad
+                  ? sizeBytes / 1024 ** 3
+                  : requiredGgufMemoryGb(sizeBytes),
+              )
+            : 0,
         });
         continue;
       }

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -658,7 +658,7 @@ const MIGHT_FIT: FitVerdict = {
 const OFFLOADS: FitVerdict = {
   label: "Does not fit",
   tone: ORANGE,
-  hint: "Model doesn't fit but still works with offloading. Expect slower inference.",
+  hint: "Model may not fit but still works with offloading. Expect slower inference.",
 };
 /** checkVramFit's 75-100% band, which is the ONLY source of `tight` here: a torch estimate that
  *  still fits on the card entirely. It has no --fit, so it neither spills nor offloads. */

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3347,7 +3347,12 @@ export function HubModelPicker({
   const recommendedMeta = useMemo(() => {
     const map = new Map<
       string,
-      { meta: string | null; status: VramFitStatus | null; est: number }
+      {
+        meta: string | null;
+        /** GGUF rows carry the classifier's own verdict; curated torch rows carry "exceeds". */
+        status: GgufFitClass | VramFitStatus | null;
+        est: number;
+      }
     >();
     /** Size-based verdict for a row whose real footprint we know, against the budget that row
      *  actually loads into. Same split as the list's own fit filter, so the badge and the
@@ -3409,7 +3414,9 @@ export function HubModelPicker({
           (params ? estimateQuantBytes(params) : undefined);
         map.set(r.id, {
           meta,
-          status: exceedsSize(sizeBytes, inferenceGpu) ? "exceeds" : null,
+          // "oom", not "exceeds": this row is a GGUF, so llama-server offloads it rather than
+          // refusing it, and the mark has to say so. "exceeds" is the torch verdict below.
+          status: exceedsSize(sizeBytes, inferenceGpu) ? "oom" : null,
           est: sizeBytes ? Math.round(sizeBytes / 1024 ** 3) : 0,
         });
         continue;

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -12,6 +12,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { usePlatformStore } from "@/config/env";
+import { INVENTORY_FRESHNESS_WINDOW_MS } from "@/features/hub/inventory";
 import { ApiProviderLogo } from "@/features/chat";
 import {
   type ScanFolderInfo,
@@ -62,7 +63,6 @@ import {
   useOnlineStatus,
 } from "@/features/hub";
 import type { HfTaskFilter } from "@/features/hub/hooks/use-hub-model-search";
-import { INVENTORY_FRESHNESS_WINDOW_MS } from "@/features/hub/inventory";
 import {
   useDebouncedValue,
   useGpuInfo,
@@ -91,8 +91,8 @@ import {
   FlimSlateIcon,
   Folder02Icon,
   HelpCircleIcon,
-  Image03Icon,
   InformationCircleIcon,
+  Image03Icon,
   PinIcon,
   RemoveCircleIcon,
   Search01Icon,
@@ -119,13 +119,13 @@ import { useChatPickerInventory } from "../../inventory/use-chat-picker-inventor
 import {
   type CommunityModelPolicy,
   allowedHiddenModelIdMatches,
-  audioPickIsRoutable,
   audioPipelineTagFor,
+  audioPickIsRoutable,
+  localAudioRowIsUndecodableGguf,
   communityAudioRowIsRunnable,
   curatedAudioInventoryMatches,
   curatedAudioInventoryTask,
   filesystemRowsSupportedForTask,
-  localAudioRowIsUndecodableGguf,
   macTtsHubRowIsRunnable,
   nativeAudioCheckpointIsLoadable,
   shouldDiscoverCommunityModels,
@@ -135,8 +135,6 @@ import {
   taskPickerRowMatches,
 } from "./audio-picker-policy";
 import { FolderBrowser } from "./folder-browser";
-import { curatedArtifactIsOfferable } from "./host-artifact-policy";
-import { localGgufKindFor } from "./local-gguf-policy";
 import {
   type ModelCapabilities,
   detectCapabilities,
@@ -155,6 +153,8 @@ import {
   curatedTotalParamsFor,
   groupForRepoId,
 } from "./model-catalog";
+import { curatedArtifactIsOfferable } from "./host-artifact-policy";
+import { localGgufKindFor } from "./local-gguf-policy";
 import { ModelDeleteAction } from "./model-delete-action";
 import { ModelLoadSettingsAction } from "./model-load-settings-action";
 import { ModelRowMenu } from "./model-row-menu";
@@ -207,8 +207,8 @@ import type {
   DeletedModelRef,
   ExternalModelOption,
   LoraModelOption,
-  ModelDownloadFootprintResolver,
   ModelOption,
+  ModelDownloadFootprintResolver,
   ModelSelectorChangeMeta,
 } from "./types";
 import { describeVariantListingError } from "./variant-listing-error";
@@ -515,9 +515,9 @@ const CAPABILITY_BADGES: {
  * where only some models carry a soundtrack. Context rather than a prop because every row in the
  * tree wants the same answer and it comes from the picker, not the row.
  */
-const CapabilityScope = createContext<
-  readonly (keyof ModelCapabilities)[] | null
->(null);
+const CapabilityScope = createContext<readonly (keyof ModelCapabilities)[] | null>(
+  null,
+);
 
 // The row reserves a fixed slot for these (META_COLUMN.badge), so the cap is what keeps every
 // column after it lined up.
@@ -797,11 +797,7 @@ export function GgufDownloadFootprint({
         aria-hidden={true}
         className="flex size-3.5 shrink-0 items-center justify-center text-muted-foreground/70"
       >
-        <HugeiconsIcon
-          icon={HelpCircleIcon}
-          className="size-3"
-          strokeWidth={1.8}
-        />
+        <HugeiconsIcon icon={HelpCircleIcon} className="size-3" strokeWidth={1.8} />
       </span>
     </span>
   );
@@ -819,8 +815,7 @@ export function GgufDownloadFootprintExplanation({
     <>
       <span className="font-medium">Full required size</span>
       <span className="ml-1 text-muted-foreground">
-        {formatBytes(checkpointBytes)} model + {formatBytes(companionBytes)}{" "}
-        required assets
+        {formatBytes(checkpointBytes)} model + {formatBytes(companionBytes)} required assets
       </span>
     </>
   );
@@ -2439,9 +2434,7 @@ function localPathTooltip(
   return (
     <>
       <span className="block break-words">{name}</span>
-      {detail ? (
-        <span className="mt-0.5 block break-words">{detail}</span>
-      ) : null}
+      {detail ? <span className="mt-0.5 block break-words">{detail}</span> : null}
       <span className="block mt-1 text-ui-10 text-muted-foreground break-all">
         {path}
       </span>
@@ -3159,9 +3152,7 @@ export function HubModelPicker({
   const [formatFilter, setFormatFilter] = useState<FormatFilter>("all");
   // What this picker's task filter has already established about every row it can show. The Images
   // and Video pages pass their generation tasks; chat passes none and keeps the full set.
-  const capabilityScope = useMemo<
-    readonly (keyof ModelCapabilities)[] | null
-  >(() => {
+  const capabilityScope = useMemo<readonly (keyof ModelCapabilities)[] | null>(() => {
     const tasks: readonly string[] = task
       ? typeof task === "string"
         ? [task]
@@ -3199,9 +3190,7 @@ export function HubModelPicker({
       // them, and hiding what is already on disk reads as Unsloth having lost the model.
       if (downloadedSet.has(id.toLowerCase())) return true;
       const hit = artifactForRepoId(id, catalog);
-      return hit
-        ? curatedArtifactIsOfferable(hit.artifact.repoId, hostClass)
-        : true;
+      return hit ? curatedArtifactIsOfferable(hit.artifact.repoId, hostClass) : true;
     },
     [catalog, downloadedSet, hostClass],
   );
@@ -3229,9 +3218,7 @@ export function HubModelPicker({
         // Size from the catalog, not an id "<n>B" guess: the guess is missing for
         // most curated ids and wrong for others (Wan2.2-TI2V-5B is 30 GB, not 2),
         // and non-unsloth ids never get a listing row to correct it.
-        curatedSizeBytes: catalog
-          ? curatedSizeBytesFor(id, catalog)
-          : undefined,
+        curatedSizeBytes: catalog ? curatedSizeBytesFor(id, catalog) : undefined,
         // Same reason the size is curated: a seed the listing does not return has no
         // other source for its param chip, and most curated ids carry no "<n>B" token.
         totalParams: catalog ? curatedTotalParamsFor(id, catalog) : undefined,
@@ -3314,7 +3301,10 @@ export function HubModelPicker({
       (catalogFit(r.id, pipelineBudget) ??
         hfModelFitsDevice(r, r.isGguf ? rowInferenceGpu : rowGpu, {
           budgetFraction,
-          mediaLoad: taskScoped && r.isGguf,
+          // Not `&& r.isGguf`: on a task page a safetensors row is placed by the same backend, and
+          // this rule IS the budget those rows had before the classifiers were merged. Restricting
+          // it to GGUF left this gate disagreeing with searchRowFitsDevice about the same row.
+          mediaLoad: taskScoped,
         }));
     const unslothRows = orderRecommendedRows({
       seeds: catalogSeedRows,
@@ -3757,8 +3747,7 @@ export function HubModelPicker({
               task: m.task,
               audioType: m.audio_type,
               isGguf: localModelIsGguf(m),
-              isCurated:
-                artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
+              isCurated: artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
               // Task and codec came from the filesystem classifier, so a renamed CSM file
               // cannot borrow an Orpheus-looking path to clear the gate.
               taskFromGgufArch: true,
@@ -3805,8 +3794,7 @@ export function HubModelPicker({
               task: m.task,
               audioType: m.audio_type,
               isGguf: localModelIsGguf(m),
-              isCurated:
-                artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
+              isCurated: artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
               // Task and codec came from the filesystem classifier, so a renamed CSM file
               // cannot borrow an Orpheus-looking path to clear the gate.
               taskFromGgufArch: true,
@@ -3856,8 +3844,7 @@ export function HubModelPicker({
               task: m.task,
               audioType: m.audio_type,
               isGguf: localModelIsGguf(m),
-              isCurated:
-                artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
+              isCurated: artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
               // Task and codec came from the filesystem classifier, so a renamed CSM file
               // cannot borrow an Orpheus-looking path to clear the gate.
               taskFromGgufArch: true,
@@ -4002,7 +3989,9 @@ export function HubModelPicker({
             isDirectGguf: m.isDirectGguf,
           }),
       )
-      .filter((m) => nativeAudioCheckpointIsLoadable(m.audioType, m.exportType))
+      .filter((m) =>
+        nativeAudioCheckpointIsLoadable(m.audioType, m.exportType),
+      )
       .filter((m) => {
         const text = normalizeForSearch(
           `${m.name} ${m.baseModel ?? ""} ${m.id}`,
@@ -6112,11 +6101,7 @@ export function HubModelPicker({
                                     } else {
                                       onSelect(
                                         m.id,
-                                        localModelMeta(
-                                          false,
-                                          m.task,
-                                          m.audio_type,
-                                        ),
+                                        localModelMeta(false, m.task, m.audio_type),
                                       );
                                     }
                                   }}
@@ -6157,11 +6142,7 @@ export function HubModelPicker({
                                     onConfigure={() =>
                                       onConfigure(
                                         m.id,
-                                        localModelMeta(
-                                          false,
-                                          m.task,
-                                          m.audio_type,
-                                        ),
+                                        localModelMeta(false, m.task, m.audio_type),
                                       )
                                     }
                                   />
@@ -6176,9 +6157,7 @@ export function HubModelPicker({
                                   repoId={m.id}
                                   onDevice={true}
                                   onSelect={onSelect}
-                                  resolveDownloadFootprint={
-                                    resolveDownloadFootprint
-                                  }
+                                  resolveDownloadFootprint={resolveDownloadFootprint}
                                   onConfigure={onConfigure}
                                   parentOptionKey={optionKey}
                                   onNavigatePastStart={() =>
@@ -6268,11 +6247,7 @@ export function HubModelPicker({
                                     } else {
                                       onSelect(
                                         m.id,
-                                        localModelMeta(
-                                          false,
-                                          m.task,
-                                          m.audio_type,
-                                        ),
+                                        localModelMeta(false, m.task, m.audio_type),
                                       );
                                     }
                                   }}
@@ -6313,11 +6288,7 @@ export function HubModelPicker({
                                     onConfigure={() =>
                                       onConfigure(
                                         m.id,
-                                        localModelMeta(
-                                          false,
-                                          m.task,
-                                          m.audio_type,
-                                        ),
+                                        localModelMeta(false, m.task, m.audio_type),
                                       )
                                     }
                                   />
@@ -6330,9 +6301,7 @@ export function HubModelPicker({
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
-                                resolveDownloadFootprint={
-                                  resolveDownloadFootprint
-                                }
+                                resolveDownloadFootprint={resolveDownloadFootprint}
                                 onConfigure={onConfigure}
                                 parentOptionKey={optionKey}
                                 onNavigatePastStart={() =>
@@ -6411,11 +6380,7 @@ export function HubModelPicker({
                                     } else {
                                       onSelect(
                                         m.id,
-                                        localModelMeta(
-                                          false,
-                                          m.task,
-                                          m.audio_type,
-                                        ),
+                                        localModelMeta(false, m.task, m.audio_type),
                                       );
                                     }
                                   }}
@@ -6452,11 +6417,7 @@ export function HubModelPicker({
                                     onConfigure={() =>
                                       onConfigure(
                                         m.id,
-                                        localModelMeta(
-                                          false,
-                                          m.task,
-                                          m.audio_type,
-                                        ),
+                                        localModelMeta(false, m.task, m.audio_type),
                                       )
                                     }
                                   />
@@ -6469,9 +6430,7 @@ export function HubModelPicker({
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
-                                resolveDownloadFootprint={
-                                  resolveDownloadFootprint
-                                }
+                              resolveDownloadFootprint={resolveDownloadFootprint}
                                 onConfigure={onConfigure}
                                 parentOptionKey={optionKey}
                                 onNavigatePastStart={() =>
@@ -6565,9 +6524,7 @@ export function HubModelPicker({
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}
-                                resolveDownloadFootprint={
-                                  resolveDownloadFootprint
-                                }
+                                resolveDownloadFootprint={resolveDownloadFootprint}
                                 onConfigure={onConfigure}
                                 hfToken={hfToken || undefined}
                                 parentOptionKey={optionKey}
@@ -6690,9 +6647,7 @@ export function HubModelPicker({
                               repoId={id}
                               pipelineTag={pipelineTagById.get(id) ?? null}
                               onSelect={onSelect}
-                              resolveDownloadFootprint={
-                                resolveDownloadFootprint
-                              }
+                                resolveDownloadFootprint={resolveDownloadFootprint}
                               onConfigure={onConfigure}
                               hfToken={hfToken || undefined}
                               parentOptionKey={optionKey}
@@ -6806,9 +6761,7 @@ export function HubModelPicker({
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}
-                                resolveDownloadFootprint={
-                                  resolveDownloadFootprint
-                                }
+                                resolveDownloadFootprint={resolveDownloadFootprint}
                                 onConfigure={onConfigure}
                                 hfToken={hfToken || undefined}
                                 parentOptionKey={optionKey}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -644,17 +644,18 @@ interface FitVerdict {
 const AMBER = "!text-yellow-600 dark:!text-yellow-400";
 const ORANGE = "!text-orange-600 dark:!text-orange-300";
 
-/** Over budget but still card-sized: it loads, and can fail when something else holds VRAM. */
+/** Over budget but still card-sized. `_select_gpus` scores against FREE VRAM, so whether this
+ *  lands on the GPU depends on what else is resident; missing it costs speed, not the load. */
 const MIGHT_FIT: FitVerdict = {
   label: "Might fit",
   tone: AMBER,
-  hint: "Only fits by using nearly all your VRAM. Loading can fail while other apps hold GPU memory.",
+  hint: "Fits your GPU with almost no room to spare. If other apps are using VRAM, it offloads and runs slower.",
 };
 /** Past the card, inside VRAM plus RAM: llama-server's --fit puts the rest on CPU. */
 const OFFLOADS: FitVerdict = {
   label: "Partial offload",
   tone: ORANGE,
-  hint: "Model doesn't fit but can still work with offloading. Expect slower inference.",
+  hint: "Model doesn't fit but still works with offloading. Expect slower inference.",
 };
 /** Clears neither budget. The one verdict here that does not load. */
 const WONT_FIT: FitVerdict = {

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -704,13 +704,26 @@ const VRAM_VERDICT: Record<GgufFitClass | VramFitStatus, FitVerdict | null> = {
  *  with no Python exception".
  *
  *  Telling that user the model "still works with offloading" is the worst thing this badge could
- *  say, so a diffusion oom on a shared pool takes the verdict that means it will not load. */
+ *  say, so a diffusion oom on a host pool takes the verdict that means it will not load.
+ *
+ *  `hostPooled` is the LOAD DEVICE's answer, and folds unified_memory in: hardware.py sets
+ *  shared_memory only on Windows, so a Linux ROCm APU arrives as unified true / shared false while
+ *  `diffusion_memory.py` still classifies it `unified_memory` and refuses. Reading the aggregate
+ *  shared flag missed that host, and reading a plain some(unified) would refuse on a discrete card
+ *  that merely sits beside an iGPU. */
 function diffusionRefuses(
   fit: GgufFitClass,
   diffusionLoad: boolean,
-  sharedMemory: boolean,
+  hostPooled: boolean,
 ): boolean {
-  return fit === "oom" && diffusionLoad && sharedMemory;
+  return fit === "oom" && diffusionLoad && hostPooled;
+}
+
+/** The RAM a media verdict may add to the GPU budget. Zero on a host pool, where the two are the
+ *  same bytes: `classifyMediaGgufFit` adds them, so an APU counted its GTT window AND the host RAM
+ *  behind it and returned `partial` (offload) for a load the planner refuses outright. */
+function mediaRamBudgetGb(systemRamGb: number, hostPooled: boolean): number {
+  return hostPooled ? 0 : systemRamGb;
 }
 
 /** The verdicts that read as over budget, which is what dims a row. `marginal` does not: it is
@@ -1491,16 +1504,19 @@ function GgufVariantExpander({
   allowPin = false,
   onHasVision,
   diffusionLoad = false,
-  sharedMemory = false,
+  hostPooledMemory = false,
+  gpuCount,
 }: {
   repoId: string;
   pipelineTag?: string | null;
   /** True on Images / Video, where a GGUF is placed by the diffusion backend rather than
    *  llama-server, so the llama.cpp budget does not apply. Audio is task-scoped but not this. */
   diffusionLoad?: boolean;
-  /** The GPU pool is host memory (Apple Silicon, an APU). Only matters for a diffusion load: see
-   *  `diffusionRefuses`. */
-  sharedMemory?: boolean;
+  /** The LOAD DEVICE's memory is a window into host RAM (Apple Silicon, a ROCm APU). Only a
+   *  diffusion load reads it: see `diffusionRefuses`. */
+  hostPooledMemory?: boolean;
+  /** How many GPUs gpuGb is the sum of, for the loader's per-card VRAM reserve. */
+  gpuCount?: number;
   /** Snapshot the cached listing pinned this repo to, if any. */
   loadId?: string | null;
   /** Cache directory this downloaded row represents, if any. */
@@ -1668,12 +1684,17 @@ function GgufVariantExpander({
       // non-empty variant is OOM, which classifyGgufFit cannot tell apart from "not probed yet".
       if (!anyBudgetGb) return budgetKnown ? "oom" : "fits";
       if (diffusionLoad) {
-        return classifyMediaGgufFit(sizeBytes, gpuGb ?? 0, systemRamGb ?? 0);
+        return classifyMediaGgufFit(
+          sizeBytes,
+          gpuGb ?? 0,
+          mediaRamBudgetGb(systemRamGb ?? 0, hostPooledMemory),
+        );
       }
       return classifyGgufFit(sizeBytes, {
         gpuGb: gpuGb ?? 0,
         systemRamGb: systemRamGb ?? 0,
         budgetFraction,
+        gpuCount,
       });
     },
     [
@@ -1683,6 +1704,8 @@ function GgufVariantExpander({
       systemRamGb,
       budgetFraction,
       diffusionLoad,
+      hostPooledMemory,
+      gpuCount,
     ],
   );
 
@@ -2057,7 +2080,7 @@ function GgufVariantExpander({
             <span className="flex items-center gap-1.5 shrink-0">
               <VramBadge
                 status={
-                  diffusionRefuses(fit, diffusionLoad, sharedMemory)
+                  diffusionRefuses(fit, diffusionLoad, hostPooledMemory)
                     ? "exceeds"
                     : fit
                 }
@@ -3365,6 +3388,9 @@ export function HubModelPicker({
           // this rule IS the budget those rows had before the classifiers were merged. Restricting
           // it to GGUF left this gate disagreeing with searchRowFitsDevice about the same row.
           mediaLoad: diffusionLoad,
+          hostPooledMemory: gpu.loadDeviceSharesHostMemory,
+          // One device on a task page, so the per-card reserve is charged once there.
+          gpuCount: taskScoped ? 1 : inferenceGpu.deviceCount,
         }));
     const unslothRows = orderRecommendedRows({
       seeds: catalogSeedRows,
@@ -3444,15 +3470,19 @@ export function HubModelPicker({
         ? classifyMediaGgufFit(
             sizeBytes,
             budget.memoryTotalGb,
-            budget.systemRamAvailableGb,
+            mediaRamBudgetGb(
+              budget.systemRamAvailableGb,
+              gpu.loadDeviceSharesHostMemory,
+            ),
           )
         : classifyGgufFit(sizeBytes, {
             gpuGb: budget.memoryTotalGb,
             systemRamGb: budget.systemRamAvailableGb,
             budgetFraction,
+            gpuCount: budget.deviceCount,
           });
       if (fit === "fits") return null;
-      return diffusionRefuses(fit, diffusionLoad, gpu.sharedMemory)
+      return diffusionRefuses(fit, diffusionLoad, gpu.loadDeviceSharesHostMemory)
         ? "exceeds"
         : fit;
     };
@@ -4367,6 +4397,8 @@ export function HubModelPicker({
           // this picks the diffusion RULE, which only Images and Video use.
           diffusionLoad,
           budgetFraction,
+          gpuCount: inferenceGpu.deviceCount,
+          hostPooledMemory: gpu.loadDeviceSharesHostMemory,
         },
       ),
     [
@@ -5341,7 +5373,8 @@ export function HubModelPicker({
         {expanderOpen && (
           <GgufVariantExpander
             diffusionLoad={diffusionLoad}
-            sharedMemory={gpu.sharedMemory}
+            hostPooledMemory={gpu.loadDeviceSharesHostMemory}
+            gpuCount={inferenceGpu.deviceCount}
             repoId={c.repo_id}
             pipelineTag={c.task ?? null}
             loadId={c.load_id}
@@ -6234,7 +6267,8 @@ export function HubModelPicker({
                               isGgufExpanded(m.id) && (
                                 <GgufVariantExpander
                                   diffusionLoad={diffusionLoad}
-                                  sharedMemory={gpu.sharedMemory}
+                                  hostPooledMemory={gpu.loadDeviceSharesHostMemory}
+                                  gpuCount={inferenceGpu.deviceCount}
                                   repoId={m.id}
                                   onDevice={true}
                                   onSelect={onSelect}
@@ -6379,7 +6413,8 @@ export function HubModelPicker({
                             {isGguf && !isGgufFile && isGgufExpanded(m.id) && (
                               <GgufVariantExpander
                                 diffusionLoad={diffusionLoad}
-                                sharedMemory={gpu.sharedMemory}
+                                hostPooledMemory={gpu.loadDeviceSharesHostMemory}
+                                gpuCount={inferenceGpu.deviceCount}
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
@@ -6509,7 +6544,8 @@ export function HubModelPicker({
                             {isGguf && !isGgufFile && isGgufExpanded(m.id) && (
                               <GgufVariantExpander
                                 diffusionLoad={diffusionLoad}
-                                sharedMemory={gpu.sharedMemory}
+                                hostPooledMemory={gpu.loadDeviceSharesHostMemory}
+                                gpuCount={inferenceGpu.deviceCount}
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
@@ -6604,7 +6640,8 @@ export function HubModelPicker({
                             {expandedGguf === id && (
                               <GgufVariantExpander
                                 diffusionLoad={diffusionLoad}
-                                sharedMemory={gpu.sharedMemory}
+                                hostPooledMemory={gpu.loadDeviceSharesHostMemory}
+                                gpuCount={inferenceGpu.deviceCount}
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}
@@ -6728,7 +6765,8 @@ export function HubModelPicker({
                           {expandedGguf === id && (
                             <GgufVariantExpander
                               diffusionLoad={diffusionLoad}
-                              sharedMemory={gpu.sharedMemory}
+                              hostPooledMemory={gpu.loadDeviceSharesHostMemory}
+                              gpuCount={inferenceGpu.deviceCount}
                               repoId={id}
                               pipelineTag={pipelineTagById.get(id) ?? null}
                               onSelect={onSelect}
@@ -6843,7 +6881,8 @@ export function HubModelPicker({
                             {expandedGguf === id && (
                               <GgufVariantExpander
                                 diffusionLoad={diffusionLoad}
-                                sharedMemory={gpu.sharedMemory}
+                                hostPooledMemory={gpu.loadDeviceSharesHostMemory}
+                                gpuCount={inferenceGpu.deviceCount}
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -12,7 +12,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { usePlatformStore } from "@/config/env";
-import { INVENTORY_FRESHNESS_WINDOW_MS } from "@/features/hub/inventory";
 import { ApiProviderLogo } from "@/features/chat";
 import {
   type ScanFolderInfo,
@@ -63,6 +62,7 @@ import {
   useOnlineStatus,
 } from "@/features/hub";
 import type { HfTaskFilter } from "@/features/hub/hooks/use-hub-model-search";
+import { INVENTORY_FRESHNESS_WINDOW_MS } from "@/features/hub/inventory";
 import {
   useDebouncedValue,
   useGpuInfo,
@@ -73,7 +73,9 @@ import {
   type ModelMemorySource,
   useModelMemory,
 } from "@/hooks/use-model-memory";
+import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
 import { diffusionRouteSearch } from "@/lib/diffusion-route-search";
+import type { GgufFitClass } from "@/lib/gguf-fit";
 import { extractParamLabel } from "@/lib/model-size";
 import { toast } from "@/lib/toast";
 import { cn, formatCompact } from "@/lib/utils";
@@ -89,8 +91,8 @@ import {
   FlimSlateIcon,
   Folder02Icon,
   HelpCircleIcon,
-  InformationCircleIcon,
   Image03Icon,
+  InformationCircleIcon,
   PinIcon,
   RemoveCircleIcon,
   Search01Icon,
@@ -117,13 +119,13 @@ import { useChatPickerInventory } from "../../inventory/use-chat-picker-inventor
 import {
   type CommunityModelPolicy,
   allowedHiddenModelIdMatches,
-  audioPipelineTagFor,
   audioPickIsRoutable,
-  localAudioRowIsUndecodableGguf,
+  audioPipelineTagFor,
   communityAudioRowIsRunnable,
   curatedAudioInventoryMatches,
   curatedAudioInventoryTask,
   filesystemRowsSupportedForTask,
+  localAudioRowIsUndecodableGguf,
   macTtsHubRowIsRunnable,
   nativeAudioCheckpointIsLoadable,
   shouldDiscoverCommunityModels,
@@ -133,6 +135,8 @@ import {
   taskPickerRowMatches,
 } from "./audio-picker-policy";
 import { FolderBrowser } from "./folder-browser";
+import { curatedArtifactIsOfferable } from "./host-artifact-policy";
+import { localGgufKindFor } from "./local-gguf-policy";
 import {
   type ModelCapabilities,
   detectCapabilities,
@@ -142,6 +146,7 @@ import {
   type CatalogGroup,
   type DeviceBudget,
   artifactForRepoId,
+  classifyGgufFit,
   curatedArtifactFitsDevice,
   curatedCapabilitiesFor,
   curatedRowLabelFor,
@@ -149,8 +154,6 @@ import {
   curatedTotalParamsFor,
   groupForRepoId,
 } from "./model-catalog";
-import { curatedArtifactIsOfferable } from "./host-artifact-policy";
-import { localGgufKindFor } from "./local-gguf-policy";
 import { ModelDeleteAction } from "./model-delete-action";
 import { ModelLoadSettingsAction } from "./model-load-settings-action";
 import { ModelRowMenu } from "./model-row-menu";
@@ -204,8 +207,8 @@ import type {
   DeletedModelRef,
   ExternalModelOption,
   LoraModelOption,
-  ModelOption,
   ModelDownloadFootprintResolver,
+  ModelOption,
   ModelSelectorChangeMeta,
 } from "./types";
 import { describeVariantListingError } from "./variant-listing-error";
@@ -512,9 +515,9 @@ const CAPABILITY_BADGES: {
  * where only some models carry a soundtrack. Context rather than a prop because every row in the
  * tree wants the same answer and it comes from the picker, not the row.
  */
-const CapabilityScope = createContext<readonly (keyof ModelCapabilities)[] | null>(
-  null,
-);
+const CapabilityScope = createContext<
+  readonly (keyof ModelCapabilities)[] | null
+>(null);
 
 // The row reserves a fixed slot for these (META_COLUMN.badge), so the cap is what keeps every
 // column after it lined up.
@@ -632,67 +635,72 @@ function DownloadedBadge() {
   );
 }
 
-/** What each fit verdict marks and says. Tight spills past VRAM into system RAM; oom clears
- *  neither budget, so it offloads further still. Both still run, so neither reads as an error:
- *  orange over red, and yellow one step below it. */
+interface FitVerdict {
+  label: string;
+  tone: string;
+  hint: string;
+}
+
 const AMBER = "!text-yellow-600 dark:!text-yellow-400";
 const ORANGE = "!text-orange-600 dark:!text-orange-300";
 
-/** Two vocabularies reach this badge and they do not mean the same thing.
- *
- *  A VARIANT row's verdict comes from the GGUF classifier: `tight` is a spill out of VRAM into
- *  system RAM, `exceeds` clears neither budget.
- *
- *  A MODEL row's comes from `checkVramFit`, where `tight` is 75-100% of VRAM, which still fits on
- *  the card entirely. Telling that row it spills into system RAM was simply false, and it is the
- *  common case on a normal GPU. */
-const VRAM_VERDICT = {
-  gguf: {
-    exceeds: {
-      label: "Does not fit",
-      tone: ORANGE,
-      hint: "Model may not fit but still works with offloading. Expect slower inference.",
-    },
-    tight: {
-      label: "Tight fit",
-      tone: AMBER,
-      hint: "Only fits by spilling into system RAM. Expect slower inference.",
-    },
+/** Over budget but still card-sized: it loads, and can fail when something else holds VRAM. */
+const MIGHT_FIT: FitVerdict = {
+  label: "Might fit",
+  tone: AMBER,
+  hint: "Only fits by using nearly all your VRAM. Loading can fail while other apps hold GPU memory.",
+};
+/** Past the card, inside VRAM plus RAM: llama-server's --fit puts the rest on CPU. */
+const OFFLOADS: FitVerdict = {
+  label: "Partial offload",
+  tone: ORANGE,
+  hint: "Model doesn't fit but can still work with offloading. Expect slower inference.",
+};
+/** Clears neither budget. The one verdict here that does not load. */
+const WONT_FIT: FitVerdict = {
+  label: "Does not fit",
+  tone: ORANGE,
+  hint: "Larger than your VRAM and system RAM together. This model will not load.",
+};
+
+/** What each fit verdict marks and says, keyed by the Hub's classes so one question has one
+ *  vocabulary. `tight` and `exceeds` are the training estimator's words for two of the same
+ *  states, mapped here rather than given a second set of colours and copy. */
+const VRAM_VERDICT: Record<GgufFitClass | VramFitStatus, FitVerdict | null> = {
+  fits: null,
+  marginal: MIGHT_FIT,
+  tight: MIGHT_FIT,
+  partial: OFFLOADS,
+  ram: {
+    label: "RAM fallback",
+    tone: ORANGE,
+    hint: "No GPU detected. Runs on system RAM and CPU. Expect much slower inference.",
   },
-  device: {
-    // A model row's `exceeds` is a GGUF repo whose smallest quant is over budget (llama-server
-    // offloads it) OR a curated pipeline that cannot offload at all. One string covers both only
-    // by promising nothing about which happens; the two are separated in the follow-up.
-    exceeds: {
-      label: "Does not fit",
-      tone: ORANGE,
-      hint: "Needs more memory than this device has.",
-    },
-    tight: {
-      label: "Tight fit",
-      tone: AMBER,
-      hint: "Uses nearly all your VRAM, with little headroom for anything else.",
-    },
-  },
-} as const;
+  oom: WONT_FIT,
+  exceeds: WONT_FIT,
+};
+
+/** The verdicts that read as over budget, which is what dims a row. `marginal` does not: it is
+ *  a full GPU load, just without much room to spare. */
+function isOverBudget(status?: GgufFitClass | VramFitStatus | null): boolean {
+  return (
+    status === "partial" ||
+    status === "ram" ||
+    status === "oom" ||
+    status === "exceeds"
+  );
+}
 
 /** VRAM verdict: an info mark that names itself on hover, rather than a shouted pill. */
 function VramBadge({
   status,
-  /** Which vocabulary `status` is spoken in. See VRAM_VERDICT: the same word means different
-   *  things on a model row and on a quant row. */
-  source,
   /** Model rows hold the mark in the layout and paint it on hover; variant rows always show it. */
   revealOnHover = false,
 }: {
-  status?: VramFitStatus | null;
-  source: "gguf" | "device";
+  status?: GgufFitClass | VramFitStatus | null;
   revealOnHover?: boolean;
 }) {
-  const verdict =
-    status === "exceeds" || status === "tight"
-      ? VRAM_VERDICT[source][status]
-      : null;
+  const verdict = status ? VRAM_VERDICT[status] : null;
   if (!verdict) return null;
   return (
     <Tooltip delayDuration={0}>
@@ -784,7 +792,11 @@ export function GgufDownloadFootprint({
         aria-hidden={true}
         className="flex size-3.5 shrink-0 items-center justify-center text-muted-foreground/70"
       >
-        <HugeiconsIcon icon={HelpCircleIcon} className="size-3" strokeWidth={1.8} />
+        <HugeiconsIcon
+          icon={HelpCircleIcon}
+          className="size-3"
+          strokeWidth={1.8}
+        />
       </span>
     </span>
   );
@@ -802,7 +814,8 @@ export function GgufDownloadFootprintExplanation({
     <>
       <span className="font-medium">Full required size</span>
       <span className="ml-1 text-muted-foreground">
-        {formatBytes(checkpointBytes)} model + {formatBytes(companionBytes)} required assets
+        {formatBytes(checkpointBytes)} model + {formatBytes(companionBytes)}{" "}
+        required assets
       </span>
     </>
   );
@@ -912,7 +925,7 @@ function ModelRow({
   /** Override badge state when authoritative runtime state is available. */
   loaded?: boolean;
   onClick: () => void;
-  vramStatus?: VramFitStatus | null;
+  vramStatus?: GgufFitClass | VramFitStatus | null;
   vramEst?: number;
   gpuGb?: number;
   tooltipText?: ReactNode;
@@ -947,14 +960,14 @@ function ModelRow({
   memory?: ModelMemorySource;
   className?: string;
 }) {
-  const exceeds = vramStatus === "exceeds";
+  const exceeds = isOverBudget(vramStatus);
   const showVramTooltip =
     vramEst != null && vramEst > 0 && gpuGb != null && gpuGb > 0;
   const vramTooltipText =
     showVramTooltip && vramStatus
       ? exceeds
         ? `Needs ~${vramEst}GB VRAM (GPU: ${gpuGb}GB)`
-        : vramStatus === "tight"
+        : vramStatus === "tight" || vramStatus === "marginal"
           ? `~${vramEst}GB VRAM (tight fit on ${gpuGb}GB)`
           : `~${vramEst}GB VRAM`
       : null;
@@ -1129,10 +1142,10 @@ function ModelRow({
                 META_COLUMN.vram,
               )}
             >
-              <VramBadge status={vramStatus} source="device" revealOnHover={!selected} />
+              <VramBadge status={vramStatus} revealOnHover={!selected} />
             </span>
           ) : (
-            <VramBadge status={vramStatus} source="device" revealOnHover={!selected} />
+            <VramBadge status={vramStatus} revealOnHover={!selected} />
           )}
           {aligned ? (
             <span
@@ -1608,27 +1621,23 @@ function GgufVariantExpander({
     ],
   );
 
-  // GGUF fit classification matching llama-server's _select_gpus logic:
-  //   fits  = model <= 0.7 * total GPU memory
-  //   tight = model > 0.7 * GPU but <= 0.7 * GPU + 0.7 * system RAM (--fit uses CPU offload)
-  //   oom   = model > 0.7 * GPU + 0.7 * system RAM
-  const gpuBudgetGb = (gpuGb ?? 0) * 0.7;
-  const totalBudgetGb = gpuBudgetGb + (systemRamGb ?? 0) * 0.7;
+  // The user's saved VRAM Budget, which is what the loader admits against. The picker used to
+  // ignore it, so moving the slider changed the Hub's verdicts and left chat's untouched.
+  const budgetFraction = useVramBudgetFraction() ?? undefined;
+  const anyBudgetGb = (gpuGb ?? 0) > 0 || (systemRamGb ?? 0) > 0;
 
   const getGgufFit = useCallback(
-    (sizeBytes: number): "fits" | "tight" | "oom" => {
-      // Preserve permissive behavior only when no budget was measured. A known
-      // zero Vulkan budget means every non-empty variant is OOM.
-      if (totalBudgetGb <= 0) return budgetKnown ? "oom" : "fits";
-      const gb = sizeBytes / 1024 ** 3;
-      if (gb <= 0 || gb <= gpuBudgetGb) return "fits";
-      // No-GPU / unified-memory hosts (Mac) have only the RAM budget, so the tier
-      // collapses to fit-or-oom against system RAM.
-      if (gpuBudgetGb <= 0) return gb <= totalBudgetGb ? "fits" : "oom";
-      if (gb <= totalBudgetGb) return "tight";
-      return "oom";
+    (sizeBytes: number): GgufFitClass => {
+      // Permissive only when no budget was measured. A known zero Vulkan budget means every
+      // non-empty variant is OOM, which classifyGgufFit cannot tell apart from "not probed yet".
+      if (!anyBudgetGb) return budgetKnown ? "oom" : "fits";
+      return classifyGgufFit(sizeBytes, {
+        gpuGb: gpuGb ?? 0,
+        systemRamGb: systemRamGb ?? 0,
+        budgetFraction,
+      });
     },
-    [budgetKnown, gpuBudgetGb, totalBudgetGb],
+    [budgetKnown, anyBudgetGb, gpuGb, systemRamGb, budgetFraction],
   );
 
   const variantGroups = useMemo(
@@ -1646,7 +1655,7 @@ function GgufVariantExpander({
     const recommended = new Map<string, string>();
     for (const group of variantGroups) {
       const preferred = preferredByGroup.get(group.key) ?? null;
-      if (totalBudgetGb <= 0 && !budgetKnown) {
+      if (!anyBudgetGb && !budgetKnown) {
         if (preferred) recommended.set(group.key, preferred.quant);
         continue;
       }
@@ -1667,7 +1676,7 @@ function GgufVariantExpander({
       if (smallest) recommended.set(group.key, smallest.quant);
     }
     return recommended;
-  }, [variantGroups, preferredByGroup, totalBudgetGb, budgetKnown, getGgufFit]);
+  }, [variantGroups, preferredByGroup, anyBudgetGb, budgetKnown, getGgufFit]);
   // The same recommendations, reachable from a row. `effectiveRecommendedByGroup`
   // is keyed by PRESENTATION group ("quantizations", "text-frames",
   // "reference-media"); the footprint pass below buckets by the backend's
@@ -1943,7 +1952,6 @@ function GgufVariantExpander({
           effectiveRecommendedByGroup.get(group.key) === v.quant;
         const fit = getGgufFit(v.size_bytes);
         const oom = fit === "oom";
-        const tight = fit === "tight";
         const expectedBytes = ggufVariantExpectedBytes(v);
         // This row's own dependency group, never the listing's: see the
         // footprintVariants comment above.
@@ -2001,10 +2009,7 @@ function GgufVariantExpander({
               ) : null}
             </span>
             <span className="flex items-center gap-1.5 shrink-0">
-              <VramBadge
-                status={oom ? "exceeds" : tight ? "tight" : null}
-                source="gguf"
-              />
+              <VramBadge status={fit} />
               <span className="font-mono text-ui-10 text-muted-foreground tabular-nums">
                 {companionBytes === null ? (
                   <SizeText value={formatBytes(v.size_bytes)} />
@@ -2422,7 +2427,9 @@ function localPathTooltip(
   return (
     <>
       <span className="block break-words">{name}</span>
-      {detail ? <span className="mt-0.5 block break-words">{detail}</span> : null}
+      {detail ? (
+        <span className="mt-0.5 block break-words">{detail}</span>
+      ) : null}
       <span className="block mt-1 text-ui-10 text-muted-foreground break-all">
         {path}
       </span>
@@ -3136,7 +3143,9 @@ export function HubModelPicker({
   const [formatFilter, setFormatFilter] = useState<FormatFilter>("all");
   // What this picker's task filter has already established about every row it can show. The Images
   // and Video pages pass their generation tasks; chat passes none and keeps the full set.
-  const capabilityScope = useMemo<readonly (keyof ModelCapabilities)[] | null>(() => {
+  const capabilityScope = useMemo<
+    readonly (keyof ModelCapabilities)[] | null
+  >(() => {
     const tasks: readonly string[] = task
       ? typeof task === "string"
         ? [task]
@@ -3174,7 +3183,9 @@ export function HubModelPicker({
       // them, and hiding what is already on disk reads as Unsloth having lost the model.
       if (downloadedSet.has(id.toLowerCase())) return true;
       const hit = artifactForRepoId(id, catalog);
-      return hit ? curatedArtifactIsOfferable(hit.artifact.repoId, hostClass) : true;
+      return hit
+        ? curatedArtifactIsOfferable(hit.artifact.repoId, hostClass)
+        : true;
     },
     [catalog, downloadedSet, hostClass],
   );
@@ -3202,7 +3213,9 @@ export function HubModelPicker({
         // Size from the catalog, not an id "<n>B" guess: the guess is missing for
         // most curated ids and wrong for others (Wan2.2-TI2V-5B is 30 GB, not 2),
         // and non-unsloth ids never get a listing row to correct it.
-        curatedSizeBytes: catalog ? curatedSizeBytesFor(id, catalog) : undefined,
+        curatedSizeBytes: catalog
+          ? curatedSizeBytesFor(id, catalog)
+          : undefined,
         // Same reason the size is curated: a seed the listing does not return has no
         // other source for its param chip, and most curated ids carry no "<n>B" token.
         totalParams: catalog ? curatedTotalParamsFor(id, catalog) : undefined,
@@ -3700,7 +3713,8 @@ export function HubModelPicker({
               task: m.task,
               audioType: m.audio_type,
               isGguf: localModelIsGguf(m),
-              isCurated: artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
+              isCurated:
+                artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
               // Task and codec came from the filesystem classifier, so a renamed CSM file
               // cannot borrow an Orpheus-looking path to clear the gate.
               taskFromGgufArch: true,
@@ -3747,7 +3761,8 @@ export function HubModelPicker({
               task: m.task,
               audioType: m.audio_type,
               isGguf: localModelIsGguf(m),
-              isCurated: artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
+              isCurated:
+                artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
               // Task and codec came from the filesystem classifier, so a renamed CSM file
               // cannot borrow an Orpheus-looking path to clear the gate.
               taskFromGgufArch: true,
@@ -3797,7 +3812,8 @@ export function HubModelPicker({
               task: m.task,
               audioType: m.audio_type,
               isGguf: localModelIsGguf(m),
-              isCurated: artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
+              isCurated:
+                artifactForRepoId(m.model_id ?? m.id, AUDIO_CATALOG) !== null,
               // Task and codec came from the filesystem classifier, so a renamed CSM file
               // cannot borrow an Orpheus-looking path to clear the gate.
               taskFromGgufArch: true,
@@ -3942,9 +3958,7 @@ export function HubModelPicker({
             isDirectGguf: m.isDirectGguf,
           }),
       )
-      .filter((m) =>
-        nativeAudioCheckpointIsLoadable(m.audioType, m.exportType),
-      )
+      .filter((m) => nativeAudioCheckpointIsLoadable(m.audioType, m.exportType))
       .filter((m) => {
         const text = normalizeForSearch(
           `${m.name} ${m.baseModel ?? ""} ${m.id}`,
@@ -6051,7 +6065,11 @@ export function HubModelPicker({
                                     } else {
                                       onSelect(
                                         m.id,
-                                        localModelMeta(false, m.task, m.audio_type),
+                                        localModelMeta(
+                                          false,
+                                          m.task,
+                                          m.audio_type,
+                                        ),
                                       );
                                     }
                                   }}
@@ -6092,7 +6110,11 @@ export function HubModelPicker({
                                     onConfigure={() =>
                                       onConfigure(
                                         m.id,
-                                        localModelMeta(false, m.task, m.audio_type),
+                                        localModelMeta(
+                                          false,
+                                          m.task,
+                                          m.audio_type,
+                                        ),
                                       )
                                     }
                                   />
@@ -6106,7 +6128,9 @@ export function HubModelPicker({
                                   repoId={m.id}
                                   onDevice={true}
                                   onSelect={onSelect}
-                                  resolveDownloadFootprint={resolveDownloadFootprint}
+                                  resolveDownloadFootprint={
+                                    resolveDownloadFootprint
+                                  }
                                   onConfigure={onConfigure}
                                   parentOptionKey={optionKey}
                                   onNavigatePastStart={() =>
@@ -6196,7 +6220,11 @@ export function HubModelPicker({
                                     } else {
                                       onSelect(
                                         m.id,
-                                        localModelMeta(false, m.task, m.audio_type),
+                                        localModelMeta(
+                                          false,
+                                          m.task,
+                                          m.audio_type,
+                                        ),
                                       );
                                     }
                                   }}
@@ -6237,7 +6265,11 @@ export function HubModelPicker({
                                     onConfigure={() =>
                                       onConfigure(
                                         m.id,
-                                        localModelMeta(false, m.task, m.audio_type),
+                                        localModelMeta(
+                                          false,
+                                          m.task,
+                                          m.audio_type,
+                                        ),
                                       )
                                     }
                                   />
@@ -6249,7 +6281,9 @@ export function HubModelPicker({
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
-                                resolveDownloadFootprint={resolveDownloadFootprint}
+                                resolveDownloadFootprint={
+                                  resolveDownloadFootprint
+                                }
                                 onConfigure={onConfigure}
                                 parentOptionKey={optionKey}
                                 onNavigatePastStart={() =>
@@ -6328,7 +6362,11 @@ export function HubModelPicker({
                                     } else {
                                       onSelect(
                                         m.id,
-                                        localModelMeta(false, m.task, m.audio_type),
+                                        localModelMeta(
+                                          false,
+                                          m.task,
+                                          m.audio_type,
+                                        ),
                                       );
                                     }
                                   }}
@@ -6365,7 +6403,11 @@ export function HubModelPicker({
                                     onConfigure={() =>
                                       onConfigure(
                                         m.id,
-                                        localModelMeta(false, m.task, m.audio_type),
+                                        localModelMeta(
+                                          false,
+                                          m.task,
+                                          m.audio_type,
+                                        ),
                                       )
                                     }
                                   />
@@ -6377,7 +6419,9 @@ export function HubModelPicker({
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
-                              resolveDownloadFootprint={resolveDownloadFootprint}
+                                resolveDownloadFootprint={
+                                  resolveDownloadFootprint
+                                }
                                 onConfigure={onConfigure}
                                 parentOptionKey={optionKey}
                                 onNavigatePastStart={() =>
@@ -6470,7 +6514,9 @@ export function HubModelPicker({
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}
-                                resolveDownloadFootprint={resolveDownloadFootprint}
+                                resolveDownloadFootprint={
+                                  resolveDownloadFootprint
+                                }
                                 onConfigure={onConfigure}
                                 hfToken={hfToken || undefined}
                                 parentOptionKey={optionKey}
@@ -6592,7 +6638,9 @@ export function HubModelPicker({
                               repoId={id}
                               pipelineTag={pipelineTagById.get(id) ?? null}
                               onSelect={onSelect}
-                                resolveDownloadFootprint={resolveDownloadFootprint}
+                              resolveDownloadFootprint={
+                                resolveDownloadFootprint
+                              }
                               onConfigure={onConfigure}
                               hfToken={hfToken || undefined}
                               parentOptionKey={optionKey}
@@ -6705,7 +6753,9 @@ export function HubModelPicker({
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}
-                                resolveDownloadFootprint={resolveDownloadFootprint}
+                                resolveDownloadFootprint={
+                                  resolveDownloadFootprint
+                                }
                                 onConfigure={onConfigure}
                                 hfToken={hfToken || undefined}
                                 parentOptionKey={optionKey}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -651,22 +651,26 @@ const MIGHT_FIT: FitVerdict = {
   tone: AMBER,
   hint: "Fits your GPU with almost no room to spare. If other apps are using VRAM, it offloads and runs slower.",
 };
-/** Past the card, inside VRAM plus RAM: llama-server's --fit puts the rest on CPU. */
+/** Past the card. Every GGUF over budget lands here, however far over, because llama-server never
+ *  refuses one on size: `_select_gpus` returns `(None, use_fit=True)` and `--fit` offloads the
+ *  rest to CPU. Splitting this by how far over only mattered on hosts where the RAM tier exists,
+ *  and it cost the honest answer on the ones where it does not. */
 const OFFLOADS: FitVerdict = {
-  label: "Partial offload",
+  label: "Does not fit",
   tone: ORANGE,
   hint: "Model doesn't fit but still works with offloading. Expect slower inference.",
 };
-/** Clears neither budget. The one verdict here that does not load. */
+/** A torch load, which has no --fit to fall back on: the pipeline goes wholly on the device. */
 const WONT_FIT: FitVerdict = {
   label: "Does not fit",
   tone: ORANGE,
-  hint: "Larger than your VRAM and system RAM together. This model will not load.",
+  hint: "Needs more VRAM than this device has. This model will not load.",
 };
 
 /** What each fit verdict marks and says, keyed by the Hub's classes so one question has one
- *  vocabulary. `tight` and `exceeds` are the training estimator's words for two of the same
- *  states, mapped here rather than given a second set of colours and copy. */
+ *  vocabulary. `tight` and `exceeds` are the training estimator's words, mapped on rather than
+ *  given a second set of colours and copy. `exceeds` is the only one that cannot offload: it
+ *  reaches here from a torch pipeline or the QLoRA estimate, never from a GGUF. */
 const VRAM_VERDICT: Record<GgufFitClass | VramFitStatus, FitVerdict | null> = {
   fits: null,
   marginal: MIGHT_FIT,
@@ -677,7 +681,7 @@ const VRAM_VERDICT: Record<GgufFitClass | VramFitStatus, FitVerdict | null> = {
     tone: ORANGE,
     hint: "No GPU detected. Runs on system RAM and CPU. Expect much slower inference.",
   },
-  oom: WONT_FIT,
+  oom: OFFLOADS,
   exceeds: WONT_FIT,
 };
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -671,7 +671,9 @@ const DEVICE_TIGHT: FitVerdict = {
 const WONT_FIT: FitVerdict = {
   label: "Does not fit",
   tone: ORANGE,
-  hint: "Needs more VRAM than this device has. This model will not load.",
+  // "memory", not "VRAM": this also carries a diffusion refusal on a shared pool, where the two
+  // are the same bytes and calling it VRAM would read as a different number than the user has.
+  hint: "Needs more memory than this device has. This model will not load.",
 };
 
 /** What each fit verdict marks and says, keyed by the Hub's classes so one question has one
@@ -691,6 +693,25 @@ const VRAM_VERDICT: Record<GgufFitClass | VramFitStatus, FitVerdict | null> = {
   oom: OFFLOADS,
   exceeds: WONT_FIT,
 };
+
+/** Whether a diffusion `oom` is a REFUSAL rather than an offload.
+ *
+ *  On discrete VRAM an oversized pipeline still loads: `diffusion_memory.py` degrades it to group
+ *  or whole-module CPU offload and streams from host RAM. On a shared pool there is nowhere to
+ *  stream from, so `unified_memory_shortfall_message` refuses up front, and the docstring is blunt
+ *  about why: without the refusal the load "allocates past physical memory", with no torch OOM to
+ *  catch because the MPS high-watermark is disabled, so "the failure is the OS killing the process
+ *  with no Python exception".
+ *
+ *  Telling that user the model "still works with offloading" is the worst thing this badge could
+ *  say, so a diffusion oom on a shared pool takes the verdict that means it will not load. */
+function diffusionRefuses(
+  fit: GgufFitClass,
+  diffusionLoad: boolean,
+  sharedMemory: boolean,
+): boolean {
+  return fit === "oom" && diffusionLoad && sharedMemory;
+}
 
 /** The verdicts that read as over budget, which is what dims a row. `marginal` does not: it is
  *  a full GPU load, just without much room to spare. */
@@ -1469,13 +1490,17 @@ function GgufVariantExpander({
   onDevice = false,
   allowPin = false,
   onHasVision,
-  taskScoped = false,
+  diffusionLoad = false,
+  sharedMemory = false,
 }: {
   repoId: string;
   pipelineTag?: string | null;
-  /** True on Images / Video / Audio, where a GGUF is placed by the diffusion backend rather than
-   *  llama-server, so the llama.cpp budget does not apply. */
-  taskScoped?: boolean;
+  /** True on Images / Video, where a GGUF is placed by the diffusion backend rather than
+   *  llama-server, so the llama.cpp budget does not apply. Audio is task-scoped but not this. */
+  diffusionLoad?: boolean;
+  /** The GPU pool is host memory (Apple Silicon, an APU). Only matters for a diffusion load: see
+   *  `diffusionRefuses`. */
+  sharedMemory?: boolean;
   /** Snapshot the cached listing pinned this repo to, if any. */
   loadId?: string | null;
   /** Cache directory this downloaded row represents, if any. */
@@ -1642,7 +1667,7 @@ function GgufVariantExpander({
       // Permissive only when no budget was measured. A known zero Vulkan budget means every
       // non-empty variant is OOM, which classifyGgufFit cannot tell apart from "not probed yet".
       if (!anyBudgetGb) return budgetKnown ? "oom" : "fits";
-      if (taskScoped) {
+      if (diffusionLoad) {
         return classifyMediaGgufFit(sizeBytes, gpuGb ?? 0, systemRamGb ?? 0);
       }
       return classifyGgufFit(sizeBytes, {
@@ -1651,7 +1676,14 @@ function GgufVariantExpander({
         budgetFraction,
       });
     },
-    [budgetKnown, anyBudgetGb, gpuGb, systemRamGb, budgetFraction, taskScoped],
+    [
+      budgetKnown,
+      anyBudgetGb,
+      gpuGb,
+      systemRamGb,
+      budgetFraction,
+      diffusionLoad,
+    ],
   );
 
   const variantGroups = useMemo(
@@ -2023,7 +2055,13 @@ function GgufVariantExpander({
               ) : null}
             </span>
             <span className="flex items-center gap-1.5 shrink-0">
-              <VramBadge status={fit} />
+              <VramBadge
+                status={
+                  diffusionRefuses(fit, diffusionLoad, sharedMemory)
+                    ? "exceeds"
+                    : fit
+                }
+              />
               <span className="font-mono text-ui-10 text-muted-foreground tabular-nums">
                 {companionBytes === null ? (
                   <SizeText value={formatBytes(v.size_bytes)} />
@@ -2210,6 +2248,15 @@ export const VIDEO_GEN_TASKS = [
   "image-to-video",
   "image-text-to-video",
 ] as const;
+
+/** The tasks whose GGUFs are placed by the DIFFUSION backend, which is the only reason a picker
+ *  scores against `classifyMediaGgufFit`. Audio is task-scoped too but does not belong here: its
+ *  GGUFs go to llama.cpp (TTS) or the whisper sidecars (stt_ggml_sidecar.py, stt_mtmd_sidecar.py),
+ *  so scoring them at 70% hid runnable models and picked a smaller quant than needed. */
+const DIFFUSION_TASKS: ReadonlySet<string> = new Set([
+  ...IMAGE_GEN_TASKS,
+  ...VIDEO_GEN_TASKS,
+]);
 
 // Speech pipeline tasks: owned by the Audio page. TTS picks load there rather than into chat; ASR picks map to the dictation sidecar.
 export const AUDIO_GEN_TASKS = [
@@ -2554,6 +2601,12 @@ export function HubModelPicker({
   // rows alone left the parent rows and the "Fits on device" filter scoring against the 0.97
   // default, so lowering the setting moved one and not the other.
   const budgetFraction = useVramBudgetFraction() ?? undefined;
+  // Whether THIS picker's rows load through the diffusion backend. Not `Boolean(task)`: Audio is
+  // task-scoped for the single-device budget but runs its GGUFs under llama.cpp / whisper.
+  const diffusionLoad = useMemo(() => {
+    const tasks = task ? (typeof task === "string" ? [task] : task) : [];
+    return tasks.some((entry) => DIFFUSION_TASKS.has(entry));
+  }, [task]);
   // What the backend actually holds, not the dropdown highlight, which can be a
   // staged pick. The selection alone was wrong: an image or video load evicts
   // the chat model and leaves the pick untouched, so its rows kept the "Loaded"
@@ -3311,7 +3364,7 @@ export function HubModelPicker({
           // Not `&& r.isGguf`: on a task page a safetensors row is placed by the same backend, and
           // this rule IS the budget those rows had before the classifiers were merged. Restricting
           // it to GGUF left this gate disagreeing with searchRowFitsDevice about the same row.
-          mediaLoad: taskScoped,
+          mediaLoad: diffusionLoad,
         }));
     const unslothRows = orderRecommendedRows({
       seeds: catalogSeedRows,
@@ -3333,6 +3386,7 @@ export function HubModelPicker({
     return [...unslothRows, ...communityRows];
   }, [
     budgetFraction,
+    diffusionLoad,
     recommendedSearch.results,
     catalogSeedRows,
     downloadedSet,
@@ -3376,7 +3430,7 @@ export function HubModelPicker({
     const ggufRowFit = (
       sizeBytes: number | undefined,
       budget: typeof inferenceGpu,
-    ): GgufFitClass | null => {
+    ): GgufFitClass | VramFitStatus | null => {
       const anyBudget =
         budget.memoryTotalGb > 0 || budget.systemRamAvailableGb > 0;
       if (!budget.budgetKnown && !anyBudget) return null;
@@ -3386,7 +3440,7 @@ export function HubModelPicker({
       // Images / Video place this GGUF through the diffusion backend, so it takes the same rule
       // its quant rows take. Judging the parent by llama.cpp's budget and the children by the
       // media one let a row read as fitting while everything inside it read as oom.
-      const fit = Boolean(task)
+      const fit = diffusionLoad
         ? classifyMediaGgufFit(
             sizeBytes,
             budget.memoryTotalGb,
@@ -3397,7 +3451,10 @@ export function HubModelPicker({
             systemRamGb: budget.systemRamAvailableGb,
             budgetFraction,
           });
-      return fit === "fits" ? null : fit;
+      if (fit === "fits") return null;
+      return diffusionRefuses(fit, diffusionLoad, gpu.sharedMemory)
+        ? "exceeds"
+        : fit;
     };
     // A curated pipeline loads through torch, and a task load puts the whole thing on ONE
     // device, so it is judged there. inferenceGpu is the GGUF backend's inventory, which can
@@ -3474,6 +3531,7 @@ export function HubModelPicker({
     return map;
   }, [
     budgetFraction,
+    diffusionLoad,
     recommendedSearch.results,
     communityBrowse.results,
     catalogSeedRows,
@@ -4295,12 +4353,16 @@ export function HubModelPicker({
           gpu,
           inferenceGpu,
           taskScoped: Boolean(task),
+          // Separate from taskScoped: that picks the single-device budget for every task page,
+          // this picks the diffusion RULE, which only Images and Video use.
+          diffusionLoad,
           budgetFraction,
         },
       ),
     [
       budgetFraction,
       catalog,
+      diffusionLoad,
       catalogFit,
       gpu,
       inferenceGpu,
@@ -5268,7 +5330,8 @@ export function HubModelPicker({
         </div>
         {expanderOpen && (
           <GgufVariantExpander
-            taskScoped={Boolean(task)}
+            diffusionLoad={diffusionLoad}
+            sharedMemory={gpu.sharedMemory}
             repoId={c.repo_id}
             pipelineTag={c.task ?? null}
             loadId={c.load_id}
@@ -6160,7 +6223,8 @@ export function HubModelPicker({
                               !isDirectGguf &&
                               isGgufExpanded(m.id) && (
                                 <GgufVariantExpander
-                                  taskScoped={Boolean(task)}
+                                  diffusionLoad={diffusionLoad}
+                                  sharedMemory={gpu.sharedMemory}
                                   repoId={m.id}
                                   onDevice={true}
                                   onSelect={onSelect}
@@ -6304,7 +6368,8 @@ export function HubModelPicker({
                             </div>
                             {isGguf && !isGgufFile && isGgufExpanded(m.id) && (
                               <GgufVariantExpander
-                                taskScoped={Boolean(task)}
+                                diffusionLoad={diffusionLoad}
+                                sharedMemory={gpu.sharedMemory}
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
@@ -6433,11 +6498,12 @@ export function HubModelPicker({
                             </div>
                             {isGguf && !isGgufFile && isGgufExpanded(m.id) && (
                               <GgufVariantExpander
-                                taskScoped={Boolean(task)}
+                                diffusionLoad={diffusionLoad}
+                                sharedMemory={gpu.sharedMemory}
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
-                              resolveDownloadFootprint={resolveDownloadFootprint}
+                                resolveDownloadFootprint={resolveDownloadFootprint}
                                 onConfigure={onConfigure}
                                 parentOptionKey={optionKey}
                                 onNavigatePastStart={() =>
@@ -6527,7 +6593,8 @@ export function HubModelPicker({
                             />
                             {expandedGguf === id && (
                               <GgufVariantExpander
-                                taskScoped={Boolean(task)}
+                                diffusionLoad={diffusionLoad}
+                                sharedMemory={gpu.sharedMemory}
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}
@@ -6650,11 +6717,12 @@ export function HubModelPicker({
                           />
                           {expandedGguf === id && (
                             <GgufVariantExpander
-                              taskScoped={Boolean(task)}
+                              diffusionLoad={diffusionLoad}
+                              sharedMemory={gpu.sharedMemory}
                               repoId={id}
                               pipelineTag={pipelineTagById.get(id) ?? null}
                               onSelect={onSelect}
-                                resolveDownloadFootprint={resolveDownloadFootprint}
+                              resolveDownloadFootprint={resolveDownloadFootprint}
                               onConfigure={onConfigure}
                               hfToken={hfToken || undefined}
                               parentOptionKey={optionKey}
@@ -6764,7 +6832,8 @@ export function HubModelPicker({
                             />
                             {expandedGguf === id && (
                               <GgufVariantExpander
-                                taskScoped={Boolean(task)}
+                                diffusionLoad={diffusionLoad}
+                                sharedMemory={gpu.sharedMemory}
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3387,7 +3387,7 @@ export function HubModelPicker({
       // The catalog's own verdict where it has one, so this list and the OOM badge on its rows
       // cannot disagree: hfModelFitsDevice counts RAM toward a load that never leaves the card.
       (catalogFit(r.id, pipelineBudget) ??
-        hfModelFitsDevice(r, r.isGguf ? rowInferenceGpu : rowGpu, {
+        hfModelFitsDevice(r, diffusionLoad || !r.isGguf ? rowGpu : rowInferenceGpu, {
           budgetFraction,
           // Not `&& r.isGguf`: on a task page a safetensors row is placed by the same backend, and
           // this rule IS the budget those rows had before the classifiers were merged. Restricting
@@ -3494,8 +3494,15 @@ export function HubModelPicker({
     // A curated pipeline loads through torch, and a task load puts the whole thing on ONE
     // device, so it is judged there. inferenceGpu is the GGUF backend's inventory, which can
     // be a different install (Vulkan llama.cpp) or the sum of several cards.
-    const pipelineBudget = artifactBudget(loadScopedGpu(gpu, Boolean(task)));
-    const rowInferenceGpu = loadScopedGpu(inferenceGpu, Boolean(task));
+    const rowGpu = loadScopedGpu(gpu, Boolean(task));
+    const pipelineBudget = artifactBudget(rowGpu);
+    // The inventory of the runtime that PLACES the row, not of its file format. An Images or
+    // Video GGUF goes to the diffusion backend, which is torch, and on a Vulkan chat build
+    // inferenceGpu is a different device set entirely: it can see a card torch cannot, so the
+    // media rule was scoring against capacity the diffusion loader never gets to use.
+    const rowInferenceGpu = diffusionLoad
+      ? rowGpu
+      : loadScopedGpu(inferenceGpu, Boolean(task));
     // Community rows come from their own listing; without them folded in here
     // they render with no size or VRAM chip.
     for (const r of [
@@ -3837,14 +3844,17 @@ export function HubModelPicker({
     info.available
       ? loadScopedGpu(info, Boolean(task)).memoryTotalGb
       : undefined;
-  const expanderGpuGb = expanderGpuGbFrom(inferenceGpu);
+  // Images / Video place through torch even where llama.cpp is a Vulkan build, so their budget
+  // comes from the torch inventory. Everything else keeps the GGUF backend's own.
+  const expanderBudgetGpu = diffusionLoad ? gpu : inferenceGpu;
+  const expanderGpuGb = expanderGpuGbFrom(expanderBudgetGpu);
   const expanderSystemGpuGb = expanderGpuGbFrom(gpu);
   // From the SAME scoping decision as the capacity above: loadScopedGpu narrows the count to 1
-  // with memoryTotalGb, so the per-card reserve is never charged host-wide against one card.
-  const expanderGpuCount = loadScopedGpu(
-    inferenceGpu,
-    Boolean(task),
-  ).deviceCount;
+  // with memoryTotalGb, so the per-card reserve is never charged host-wide against one card,
+  // and the RAM tier is the one that belongs to the device the load lands on.
+  const expanderScopedGpu = loadScopedGpu(expanderBudgetGpu, Boolean(task));
+  const expanderGpuCount = expanderScopedGpu.deviceCount;
+  const expanderRamGb = expanderScopedGpu.systemRamAvailableGb;
 
   // Each local section's search is scoped to its own models (matched by name).
   const localQuery = normalizeForSearch(debouncedQuery.trim());
@@ -5404,7 +5414,7 @@ export function HubModelPicker({
             onNavigatePastStart={() => hubModelList.focusOption(optionKey)}
             onNavigatePastEnd={() => hubModelList.moveFocus(optionKey, "next")}
             gpuGb={expanderGpuGb}
-            systemRamGb={inferenceGpu.systemRamAvailableGb || undefined}
+            systemRamGb={expanderRamGb || undefined}
             budgetKnown={inferenceGpu.budgetKnown}
             variantActions={{
               onUpdate: (quant, expectedBytes) =>
@@ -6300,10 +6310,7 @@ export function HubModelPicker({
                                       ? inferenceGpu.memoryTotalGb
                                       : undefined
                                   }
-                                  systemRamGb={
-                                    inferenceGpu.systemRamAvailableGb ||
-                                    undefined
-                                  }
+                                  systemRamGb={expanderRamGb || undefined}
                                   budgetKnown={inferenceGpu.budgetKnown}
                                 />
                               )}
@@ -6442,9 +6449,7 @@ export function HubModelPicker({
                                   hubModelList.moveFocus(optionKey, "next")
                                 }
                                 gpuGb={expanderGpuGb}
-                                systemRamGb={
-                                  inferenceGpu.systemRamAvailableGb || undefined
-                                }
+                                systemRamGb={expanderRamGb || undefined}
                                 budgetKnown={inferenceGpu.budgetKnown}
                               />
                             )}
@@ -6573,9 +6578,7 @@ export function HubModelPicker({
                                   hubModelList.moveFocus(optionKey, "next")
                                 }
                                 gpuGb={expanderGpuGb}
-                                systemRamGb={
-                                  inferenceGpu.systemRamAvailableGb || undefined
-                                }
+                                systemRamGb={expanderRamGb || undefined}
                                 budgetKnown={inferenceGpu.budgetKnown}
                               />
                             )}
@@ -6670,9 +6673,7 @@ export function HubModelPicker({
                                   hubModelList.moveFocus(optionKey, "next")
                                 }
                                 gpuGb={expanderGpuGb}
-                                systemRamGb={
-                                  inferenceGpu.systemRamAvailableGb || undefined
-                                }
+                                systemRamGb={expanderRamGb || undefined}
                                 budgetKnown={inferenceGpu.budgetKnown}
                                 variantActions={{
                                   onDelete: async (quant) => {
@@ -6795,9 +6796,7 @@ export function HubModelPicker({
                                 hubModelList.moveFocus(optionKey, "next")
                               }
                               gpuGb={expanderGpuGb}
-                              systemRamGb={
-                                inferenceGpu.systemRamAvailableGb || undefined
-                              }
+                              systemRamGb={expanderRamGb || undefined}
                               budgetKnown={inferenceGpu.budgetKnown}
                               variantActions={{
                                 onDelete: async (quant) => {
@@ -6911,9 +6910,7 @@ export function HubModelPicker({
                                   hubModelList.moveFocus(optionKey, "next")
                                 }
                                 gpuGb={expanderGpuGb}
-                                systemRamGb={
-                                  inferenceGpu.systemRamAvailableGb || undefined
-                                }
+                                systemRamGb={expanderRamGb || undefined}
                                 budgetKnown={inferenceGpu.budgetKnown}
                                 variantActions={{
                                   onDelete: async (quant) => {

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -147,6 +147,7 @@ import {
   type DeviceBudget,
   artifactForRepoId,
   classifyGgufFit,
+  classifyMediaGgufFit,
   curatedArtifactFitsDevice,
   curatedCapabilitiesFor,
   curatedRowLabelFor,
@@ -171,7 +172,6 @@ import {
 import {
   type FormatFilter,
   estimateQuantBytes,
-  fitsDevice,
   hfModelFitsDevice,
   isMlxId,
   isMobileVariant,
@@ -1467,9 +1467,13 @@ function GgufVariantExpander({
   onDevice = false,
   allowPin = false,
   onHasVision,
+  taskScoped = false,
 }: {
   repoId: string;
   pipelineTag?: string | null;
+  /** True on Images / Video / Audio, where a GGUF is placed by the diffusion backend rather than
+   *  llama-server, so the llama.cpp budget does not apply. */
+  taskScoped?: boolean;
   /** Snapshot the cached listing pinned this repo to, if any. */
   loadId?: string | null;
   /** Cache directory this downloaded row represents, if any. */
@@ -1636,13 +1640,16 @@ function GgufVariantExpander({
       // Permissive only when no budget was measured. A known zero Vulkan budget means every
       // non-empty variant is OOM, which classifyGgufFit cannot tell apart from "not probed yet".
       if (!anyBudgetGb) return budgetKnown ? "oom" : "fits";
+      if (taskScoped) {
+        return classifyMediaGgufFit(sizeBytes, gpuGb ?? 0, systemRamGb ?? 0);
+      }
       return classifyGgufFit(sizeBytes, {
         gpuGb: gpuGb ?? 0,
         systemRamGb: systemRamGb ?? 0,
         budgetFraction,
       });
     },
-    [budgetKnown, anyBudgetGb, gpuGb, systemRamGb, budgetFraction],
+    [budgetKnown, anyBudgetGb, gpuGb, systemRamGb, budgetFraction, taskScoped],
   );
 
   const variantGroups = useMemo(
@@ -2543,6 +2550,10 @@ export function HubModelPicker({
 }) {
   const gpu = useGpuInfo();
   const inferenceGpu = useInferenceGpuInfo();
+  // The saved VRAM Budget, threaded into every fit call in this component. Passing it to the quant
+  // rows alone left the parent rows and the "Fits on device" filter scoring against the 0.97
+  // default, so lowering the setting moved one and not the other.
+  const budgetFraction = useVramBudgetFraction() ?? undefined;
   // What the backend actually holds, not the dropdown highlight, which can be a
   // staged pick. The selection alone was wrong: an image or video load evicts
   // the chat model and leaves the pick untouched, so its rows kept the "Loaded"
@@ -3301,7 +3312,11 @@ export function HubModelPicker({
       // The catalog's own verdict where it has one, so this list and the OOM badge on its rows
       // cannot disagree: hfModelFitsDevice counts RAM toward a load that never leaves the card.
       (catalogFit(r.id, pipelineBudget) ??
-        hfModelFitsDevice(r, r.isGguf ? rowInferenceGpu : rowGpu));
+        hfModelFitsDevice(
+          r,
+          r.isGguf ? rowInferenceGpu : rowGpu,
+          budgetFraction,
+        ));
     const unslothRows = orderRecommendedRows({
       seeds: catalogSeedRows,
       results: recommendedSearch.results,
@@ -3321,6 +3336,7 @@ export function HubModelPicker({
       .filter((r) => !deviceFiltered || fits(r));
     return [...unslothRows, ...communityRows];
   }, [
+    budgetFraction,
     recommendedSearch.results,
     catalogSeedRows,
     downloadedSet,
@@ -3355,22 +3371,29 @@ export function HubModelPicker({
       }
     >();
     /** Size-based verdict for a row whose real footprint we know, against the budget that row
-     *  actually loads into. Same split as the list's own fit filter, so the badge and the
-     *  "Fits on device" gate cannot disagree about one row. */
-    const exceedsSize = (
+     *  actually loads into. Same classifier as the quant rows below it, so the badge and the
+     *  "Fits on device" gate cannot disagree about one row.
+     *
+     *  Returns the verdict, not a boolean. A boolean collapsed `marginal` and `partial` into "no
+     *  badge", so a repo whose SMALLEST quant already needs offload rendered as a clean fit beside
+     *  expanded rows saying the opposite. */
+    const ggufRowFit = (
       sizeBytes: number | undefined,
       budget: typeof inferenceGpu,
-    ) =>
-      (budget.budgetKnown ||
-        budget.memoryTotalGb > 0 ||
-        budget.systemRamAvailableGb > 0) &&
-      sizeBytes != null &&
-      !fitsDevice({
-        sizeBytes,
+    ): GgufFitClass | null => {
+      const anyBudget =
+        budget.memoryTotalGb > 0 || budget.systemRamAvailableGb > 0;
+      if (!budget.budgetKnown && !anyBudget) return null;
+      if (sizeBytes == null) return null;
+      // Probed and genuinely zero (a Vulkan device reporting nothing) means nothing fits.
+      if (!anyBudget) return "oom";
+      const fit = classifyGgufFit(sizeBytes, {
         gpuGb: budget.memoryTotalGb,
         systemRamGb: budget.systemRamAvailableGb,
-        budgetKnown: budget.budgetKnown,
+        budgetFraction,
       });
+      return fit === "fits" ? null : fit;
+    };
     // A curated pipeline loads through torch, and a task load puts the whole thing on ONE
     // device, so it is judged there. inferenceGpu is the GGUF backend's inventory, which can
     // be a different install (Vulkan llama.cpp) or the sum of several cards.
@@ -3414,9 +3437,9 @@ export function HubModelPicker({
           (params ? estimateQuantBytes(params) : undefined);
         map.set(r.id, {
           meta,
-          // "oom", not "exceeds": this row is a GGUF, so llama-server offloads it rather than
-          // refusing it, and the mark has to say so. "exceeds" is the torch verdict below.
-          status: exceedsSize(sizeBytes, inferenceGpu) ? "oom" : null,
+          // The classifier's own verdict, so a GGUF row never borrows "exceeds", which is the
+          // torch-only refusal used by the curated branch below.
+          status: ggufRowFit(sizeBytes, inferenceGpu),
           est: sizeBytes ? Math.round(sizeBytes / 1024 ** 3) : 0,
         });
         continue;
@@ -3445,6 +3468,7 @@ export function HubModelPicker({
     }
     return map;
   }, [
+    budgetFraction,
     recommendedSearch.results,
     communityBrowse.results,
     catalogSeedRows,
@@ -4267,9 +4291,11 @@ export function HubModelPicker({
           gpu,
           inferenceGpu,
           taskScoped: Boolean(task),
+          budgetFraction,
         },
       ),
     [
+      budgetFraction,
       catalog,
       catalogFit,
       gpu,
@@ -5238,6 +5264,7 @@ export function HubModelPicker({
         </div>
         {expanderOpen && (
           <GgufVariantExpander
+            taskScoped={Boolean(task)}
             repoId={c.repo_id}
             pipelineTag={c.task ?? null}
             loadId={c.load_id}
@@ -6137,6 +6164,7 @@ export function HubModelPicker({
                               !isDirectGguf &&
                               isGgufExpanded(m.id) && (
                                 <GgufVariantExpander
+                                  taskScoped={Boolean(task)}
                                   repoId={m.id}
                                   onDevice={true}
                                   onSelect={onSelect}
@@ -6290,6 +6318,7 @@ export function HubModelPicker({
                             </div>
                             {isGguf && !isGgufFile && isGgufExpanded(m.id) && (
                               <GgufVariantExpander
+                                taskScoped={Boolean(task)}
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
@@ -6428,6 +6457,7 @@ export function HubModelPicker({
                             </div>
                             {isGguf && !isGgufFile && isGgufExpanded(m.id) && (
                               <GgufVariantExpander
+                                taskScoped={Boolean(task)}
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
@@ -6523,6 +6553,7 @@ export function HubModelPicker({
                             />
                             {expandedGguf === id && (
                               <GgufVariantExpander
+                                taskScoped={Boolean(task)}
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}
@@ -6647,6 +6678,7 @@ export function HubModelPicker({
                           />
                           {expandedGguf === id && (
                             <GgufVariantExpander
+                              taskScoped={Boolean(task)}
                               repoId={id}
                               pipelineTag={pipelineTagById.get(id) ?? null}
                               onSelect={onSelect}
@@ -6762,6 +6794,7 @@ export function HubModelPicker({
                             />
                             {expandedGguf === id && (
                               <GgufVariantExpander
+                                taskScoped={Boolean(task)}
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3389,8 +3389,8 @@ export function HubModelPicker({
           // it to GGUF left this gate disagreeing with searchRowFitsDevice about the same row.
           mediaLoad: diffusionLoad,
           hostPooledMemory: gpu.loadDeviceSharesHostMemory,
-          // One device on a task page, so the per-card reserve is charged once there.
-          gpuCount: taskScoped ? 1 : inferenceGpu.deviceCount,
+          // The scoped inventory's own count, so it always describes rowInferenceGpu's capacity.
+          gpuCount: rowInferenceGpu.deviceCount,
         }));
     const unslothRows = orderRecommendedRows({
       seeds: catalogSeedRows,
@@ -3830,6 +3830,12 @@ export function HubModelPicker({
       : undefined;
   const expanderGpuGb = expanderGpuGbFrom(inferenceGpu);
   const expanderSystemGpuGb = expanderGpuGbFrom(gpu);
+  // From the SAME scoping decision as the capacity above: loadScopedGpu narrows the count to 1
+  // with memoryTotalGb, so the per-card reserve is never charged host-wide against one card.
+  const expanderGpuCount = loadScopedGpu(
+    inferenceGpu,
+    Boolean(task),
+  ).deviceCount;
 
   // Each local section's search is scoped to its own models (matched by name).
   const localQuery = normalizeForSearch(debouncedQuery.trim());
@@ -4397,7 +4403,6 @@ export function HubModelPicker({
           // this picks the diffusion RULE, which only Images and Video use.
           diffusionLoad,
           budgetFraction,
-          gpuCount: inferenceGpu.deviceCount,
           hostPooledMemory: gpu.loadDeviceSharesHostMemory,
         },
       ),
@@ -5374,7 +5379,7 @@ export function HubModelPicker({
           <GgufVariantExpander
             diffusionLoad={diffusionLoad}
             hostPooledMemory={gpu.loadDeviceSharesHostMemory}
-            gpuCount={inferenceGpu.deviceCount}
+            gpuCount={expanderGpuCount}
             repoId={c.repo_id}
             pipelineTag={c.task ?? null}
             loadId={c.load_id}
@@ -6268,7 +6273,7 @@ export function HubModelPicker({
                                 <GgufVariantExpander
                                   diffusionLoad={diffusionLoad}
                                   hostPooledMemory={gpu.loadDeviceSharesHostMemory}
-                                  gpuCount={inferenceGpu.deviceCount}
+                                  gpuCount={expanderGpuCount}
                                   repoId={m.id}
                                   onDevice={true}
                                   onSelect={onSelect}
@@ -6414,7 +6419,7 @@ export function HubModelPicker({
                               <GgufVariantExpander
                                 diffusionLoad={diffusionLoad}
                                 hostPooledMemory={gpu.loadDeviceSharesHostMemory}
-                                gpuCount={inferenceGpu.deviceCount}
+                                gpuCount={expanderGpuCount}
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
@@ -6545,7 +6550,7 @@ export function HubModelPicker({
                               <GgufVariantExpander
                                 diffusionLoad={diffusionLoad}
                                 hostPooledMemory={gpu.loadDeviceSharesHostMemory}
-                                gpuCount={inferenceGpu.deviceCount}
+                                gpuCount={expanderGpuCount}
                                 repoId={m.id}
                                 onDevice={true}
                                 onSelect={onSelect}
@@ -6641,7 +6646,7 @@ export function HubModelPicker({
                               <GgufVariantExpander
                                 diffusionLoad={diffusionLoad}
                                 hostPooledMemory={gpu.loadDeviceSharesHostMemory}
-                                gpuCount={inferenceGpu.deviceCount}
+                                gpuCount={expanderGpuCount}
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}
@@ -6766,7 +6771,7 @@ export function HubModelPicker({
                             <GgufVariantExpander
                               diffusionLoad={diffusionLoad}
                               hostPooledMemory={gpu.loadDeviceSharesHostMemory}
-                              gpuCount={inferenceGpu.deviceCount}
+                              gpuCount={expanderGpuCount}
                               repoId={id}
                               pipelineTag={pipelineTagById.get(id) ?? null}
                               onSelect={onSelect}
@@ -6882,7 +6887,7 @@ export function HubModelPicker({
                               <GgufVariantExpander
                                 diffusionLoad={diffusionLoad}
                                 hostPooledMemory={gpu.loadDeviceSharesHostMemory}
-                                gpuCount={inferenceGpu.deviceCount}
+                                gpuCount={expanderGpuCount}
                                 repoId={id}
                                 pipelineTag={pipelineTagById.get(id) ?? null}
                                 onSelect={onSelect}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -5144,7 +5144,7 @@ export function HubModelPicker({
                 ? undefined
                 : { repoId: entry.repoId, quant: entry.quant }
             }
-            gpuGb={inferenceGpu.memoryTotalGb}
+            gpuGb={expanderGpuGb}
             alignMeta="device"
             selected={isSelected}
             loaded={isLoaded}
@@ -5290,7 +5290,7 @@ export function HubModelPicker({
                     loadId: c.load_id,
                   }
             }
-            gpuGb={inferenceGpu.memoryTotalGb}
+            gpuGb={expanderGpuGb}
             showVision={c.has_vision || sole.hasVision}
             selected={isSelected}
             loaded={rowState.loaded}
@@ -5415,7 +5415,7 @@ export function HubModelPicker({
             onNavigatePastEnd={() => hubModelList.moveFocus(optionKey, "next")}
             gpuGb={expanderGpuGb}
             systemRamGb={expanderRamGb || undefined}
-            budgetKnown={inferenceGpu.budgetKnown}
+            budgetKnown={expanderBudgetGpu.budgetKnown}
             variantActions={{
               onUpdate: (quant, expectedBytes) =>
                 updateGgufVariant(c.repo_id, quant, expectedBytes),
@@ -6305,13 +6305,9 @@ export function HubModelPicker({
                                   onNavigatePastEnd={() =>
                                     hubModelList.moveFocus(optionKey, "next")
                                   }
-                                  gpuGb={
-                                    inferenceGpu.available
-                                      ? inferenceGpu.memoryTotalGb
-                                      : undefined
-                                  }
+                                  gpuGb={expanderGpuGb}
                                   systemRamGb={expanderRamGb || undefined}
-                                  budgetKnown={inferenceGpu.budgetKnown}
+                                  budgetKnown={expanderBudgetGpu.budgetKnown}
                                 />
                               )}
                           </div>
@@ -6450,7 +6446,7 @@ export function HubModelPicker({
                                 }
                                 gpuGb={expanderGpuGb}
                                 systemRamGb={expanderRamGb || undefined}
-                                budgetKnown={inferenceGpu.budgetKnown}
+                                budgetKnown={expanderBudgetGpu.budgetKnown}
                               />
                             )}
                           </div>
@@ -6579,7 +6575,7 @@ export function HubModelPicker({
                                 }
                                 gpuGb={expanderGpuGb}
                                 systemRamGb={expanderRamGb || undefined}
-                                budgetKnown={inferenceGpu.budgetKnown}
+                                budgetKnown={expanderBudgetGpu.budgetKnown}
                               />
                             )}
                           </div>
@@ -6674,7 +6670,7 @@ export function HubModelPicker({
                                 }
                                 gpuGb={expanderGpuGb}
                                 systemRamGb={expanderRamGb || undefined}
-                                budgetKnown={inferenceGpu.budgetKnown}
+                                budgetKnown={expanderBudgetGpu.budgetKnown}
                                 variantActions={{
                                   onDelete: async (quant) => {
                                     await deleteCachedModel(
@@ -6797,7 +6793,7 @@ export function HubModelPicker({
                               }
                               gpuGb={expanderGpuGb}
                               systemRamGb={expanderRamGb || undefined}
-                              budgetKnown={inferenceGpu.budgetKnown}
+                              budgetKnown={expanderBudgetGpu.budgetKnown}
                               variantActions={{
                                 onDelete: async (quant) => {
                                   await deleteCachedModel(
@@ -6911,7 +6907,7 @@ export function HubModelPicker({
                                 }
                                 gpuGb={expanderGpuGb}
                                 systemRamGb={expanderRamGb || undefined}
-                                budgetKnown={inferenceGpu.budgetKnown}
+                                budgetKnown={expanderBudgetGpu.budgetKnown}
                                 variantActions={{
                                   onDelete: async (quant) => {
                                     await deleteCachedModel(

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -719,9 +719,11 @@ function diffusionRefuses(
   return fit === "oom" && diffusionLoad && hostPooled;
 }
 
-/** The RAM a media verdict may add to the GPU budget. Zero on a host pool, where the two are the
- *  same bytes: `classifyMediaGgufFit` adds them, so an APU counted its GTT window AND the host RAM
- *  behind it and returned `partial` (offload) for a load the planner refuses outright. */
+/** The RAM a DIFFUSION verdict may add to the GPU budget. Zero on a host pool: offload there
+ *  moves bytes inside the one pool and frees nothing, so `classifyMediaGgufFit` adding a RAM tier
+ *  promised an offload the planner refuses. llama.cpp is not this case -- a GGUF really does spill
+ *  into whatever host RAM the GPU window does not already cover, and `systemRamAvailableGb` now
+ *  has that window subtracted out. */
 function mediaRamBudgetGb(systemRamGb: number, hostPooled: boolean): number {
   return hostPooled ? 0 : systemRamGb;
 }
@@ -1007,7 +1009,10 @@ function ModelRow({
   const vramTooltipText =
     showVramTooltip && vramStatus
       ? exceeds
-        ? `Needs ~${vramEst}GB VRAM (GPU: ${gpuGb}GB)`
+        ? // "memory", not "VRAM": every over-budget verdict here is a total. A GGUF at
+          // `partial` splits across VRAM and RAM, and the figure is weights plus activations
+          // plus KV, so "Needs ~47GB VRAM" contradicted the offload verdict beside it.
+          `Needs ~${vramEst}GB memory (GPU: ${gpuGb}GB)`
         : vramStatus === "tight" || vramStatus === "marginal"
           ? `~${vramEst}GB VRAM (tight fit on ${gpuGb}GB)`
           : `~${vramEst}GB VRAM`
@@ -3490,6 +3495,7 @@ export function HubModelPicker({
     // device, so it is judged there. inferenceGpu is the GGUF backend's inventory, which can
     // be a different install (Vulkan llama.cpp) or the sum of several cards.
     const pipelineBudget = artifactBudget(loadScopedGpu(gpu, Boolean(task)));
+    const rowInferenceGpu = loadScopedGpu(inferenceGpu, Boolean(task));
     // Community rows come from their own listing; without them folded in here
     // they render with no size or VRAM chip.
     for (const r of [
@@ -3531,7 +3537,10 @@ export function HubModelPicker({
           meta,
           // The classifier's own verdict, so a GGUF row never borrows "exceeds", which is the
           // torch-only refusal used by the curated branch below.
-          status: ggufRowFit(sizeBytes, inferenceGpu),
+          // The device the load LANDS on, same as the quant rows under it and the fit filter
+          // beside it. The curated branch below already scoped; this one did not, so a downloaded
+          // media parent could read as safe while every variant inside it read as oom.
+          status: ggufRowFit(sizeBytes, rowInferenceGpu),
           // The figure the verdict was reached with, not the raw file size. classifyGgufFit scores
           // weights PLUS activations and KV, so a 20 GiB quant needing 24 GiB read "tight fit"
           // beside a tooltip saying "~20GB VRAM". The media rule scores the raw size, so that one
@@ -6990,6 +6999,8 @@ function FineTunedRows({
     available: boolean;
     budgetKnown: boolean;
     memoryTotalGb: number;
+    /** GPUs memoryTotalGb sums, for the loader's per-card VRAM reserve. */
+    deviceCount?: number;
     systemRamAvailableGb: number;
   };
 }) {
@@ -7141,6 +7152,7 @@ function FineTunedRows({
                   loraModelList.moveFocus(optionKey, "next")
                 }
                 gpuGb={gpu.available ? gpu.memoryTotalGb : undefined}
+                gpuCount={gpu.deviceCount}
                 systemRamGb={gpu.systemRamAvailableGb || undefined}
                 budgetKnown={gpu.budgetKnown}
                 sourceOverride={isExportedGguf ? "exported" : undefined}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -646,10 +646,14 @@ const ORANGE = "!text-orange-600 dark:!text-orange-300";
 
 /** Over budget but still card-sized. `_select_gpus` scores against FREE VRAM, so whether this
  *  lands on the GPU depends on what else is resident; missing it costs speed, not the load. */
+/** Over the VRAM Budget, still smaller than the card. Not conditional: `_vram_usable_mib` gives
+ *  `free - reserve`, which on a completely idle card IS the budget this tier has already passed,
+ *  so `_select_gpus` hands it to --fit every time. Other apps only shrink `free` further. Raising
+ *  the budget is the lever that keeps it resident, which is why the card size is worth saying. */
 const MIGHT_FIT: FitVerdict = {
-  label: "Might fit",
+  label: "Over budget",
   tone: AMBER,
-  hint: "Fits your GPU with almost no room to spare. If other apps are using VRAM, it offloads and runs slower.",
+  hint: "Larger than your VRAM Budget allows, so part of it offloads even on an idle GPU. It is still smaller than the card, so raising the budget can keep it resident.",
 };
 /** Past the card. Every GGUF over budget lands here, however far over, because llama-server never
  *  refuses one on size: `_select_gpus` returns `(None, use_fit=True)` and `--fit` offloads the

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3312,11 +3312,10 @@ export function HubModelPicker({
       // The catalog's own verdict where it has one, so this list and the OOM badge on its rows
       // cannot disagree: hfModelFitsDevice counts RAM toward a load that never leaves the card.
       (catalogFit(r.id, pipelineBudget) ??
-        hfModelFitsDevice(
-          r,
-          r.isGguf ? rowInferenceGpu : rowGpu,
+        hfModelFitsDevice(r, r.isGguf ? rowInferenceGpu : rowGpu, {
           budgetFraction,
-        ));
+          mediaLoad: taskScoped && r.isGguf,
+        }));
     const unslothRows = orderRecommendedRows({
       seeds: catalogSeedRows,
       results: recommendedSearch.results,
@@ -3387,11 +3386,20 @@ export function HubModelPicker({
       if (sizeBytes == null) return null;
       // Probed and genuinely zero (a Vulkan device reporting nothing) means nothing fits.
       if (!anyBudget) return "oom";
-      const fit = classifyGgufFit(sizeBytes, {
-        gpuGb: budget.memoryTotalGb,
-        systemRamGb: budget.systemRamAvailableGb,
-        budgetFraction,
-      });
+      // Images / Video place this GGUF through the diffusion backend, so it takes the same rule
+      // its quant rows take. Judging the parent by llama.cpp's budget and the children by the
+      // media one let a row read as fitting while everything inside it read as oom.
+      const fit = Boolean(task)
+        ? classifyMediaGgufFit(
+            sizeBytes,
+            budget.memoryTotalGb,
+            budget.systemRamAvailableGb,
+          )
+        : classifyGgufFit(sizeBytes, {
+            gpuGb: budget.memoryTotalGb,
+            systemRamGb: budget.systemRamAvailableGb,
+            budgetFraction,
+          });
       return fit === "fits" ? null : fit;
     };
     // A curated pipeline loads through torch, and a task load puts the whole thing on ONE

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -660,6 +660,13 @@ const OFFLOADS: FitVerdict = {
   tone: ORANGE,
   hint: "Model doesn't fit but still works with offloading. Expect slower inference.",
 };
+/** checkVramFit's 75-100% band, which is the ONLY source of `tight` here: a torch estimate that
+ *  still fits on the card entirely. It has no --fit, so it neither spills nor offloads. */
+const DEVICE_TIGHT: FitVerdict = {
+  label: "Tight fit",
+  tone: AMBER,
+  hint: "Uses nearly all your VRAM, with little headroom for anything else.",
+};
 /** A torch load, which has no --fit to fall back on: the pipeline goes wholly on the device. */
 const WONT_FIT: FitVerdict = {
   label: "Does not fit",
@@ -668,13 +675,13 @@ const WONT_FIT: FitVerdict = {
 };
 
 /** What each fit verdict marks and says, keyed by the Hub's classes so one question has one
- *  vocabulary. `tight` and `exceeds` are the training estimator's words, mapped on rather than
- *  given a second set of colours and copy. `exceeds` is the only one that cannot offload: it
- *  reaches here from a torch pipeline or the QLoRA estimate, never from a GGUF. */
+ *  vocabulary. `tight` and `exceeds` are the training estimator's words and reach here ONLY from a
+ *  torch pipeline or the QLoRA estimate, never from a GGUF, so both describe a load with no --fit
+ *  to fall back on. That is why neither says anything about offloading. */
 const VRAM_VERDICT: Record<GgufFitClass | VramFitStatus, FitVerdict | null> = {
   fits: null,
   marginal: MIGHT_FIT,
-  tight: MIGHT_FIT,
+  tight: DEVICE_TIGHT,
   partial: OFFLOADS,
   ram: {
     label: "RAM fallback",

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -97,10 +97,16 @@ export function fitsDevice(opts: {
   budgetKnown?: boolean;
   requireKnown?: boolean;
   budgetFraction?: number;
+  /** How many GPUs gpuGb sums, so the gate charges the loader's per-card VRAM reserve the same
+   *  number of times the badge does. Absent means one. */
+  gpuCount?: number;
   /** Images / Video: the row is placed by the diffusion backend, not llama-server, so it takes the
    *  media rule the quant rows under it use. Applies to every format on those pages, GGUF or not:
    *  that rule is the budget all of them had before the classifiers were merged. */
   mediaLoad?: boolean;
+  /** The load device's memory is a window into host RAM, so RAM is not a second budget to add.
+   *  Media rule only; the llama.cpp one already takes a RAM figure with the pool removed. */
+  hostPooledMemory?: boolean;
 }): boolean {
   const {
     sizeBytes,
@@ -109,7 +115,9 @@ export function fitsDevice(opts: {
     budgetKnown,
     requireKnown,
     budgetFraction,
+    gpuCount,
     mediaLoad,
+    hostPooledMemory,
   } = opts;
   // Unified-memory hosts (Mac / no discrete GPU) report system RAM but no GPU, so the budget must
   // include RAM. Only an entirely unknown budget fits freely.
@@ -119,12 +127,20 @@ export function fitsDevice(opts: {
   if (sizeBytes && sizeBytes > 0) {
     if (mediaLoad) {
       return (
-        classifyMediaGgufFit(sizeBytes, gpuGb ?? 0, systemRamGb ?? 0) !== "oom"
+        classifyMediaGgufFit(
+          sizeBytes,
+          gpuGb ?? 0,
+          hostPooledMemory ? 0 : (systemRamGb ?? 0),
+        ) !== "oom"
       );
     }
     return (
-      classifyGgufFit(sizeBytes, { gpuGb, systemRamGb, budgetFraction }) !==
-      "oom"
+      classifyGgufFit(sizeBytes, {
+        gpuGb,
+        systemRamGb,
+        budgetFraction,
+        gpuCount,
+      }) !== "oom"
     );
   }
   return requireKnown ? false : true;
@@ -155,7 +171,12 @@ export function hfModelFitsDevice(
   /** `budgetFraction` is the user's saved VRAM Budget: omitted scores against the loader's default,
    *  so a caller that forgets it judges rows on a budget the user has already replaced.
    *  `mediaLoad` picks the diffusion rule for an Images / Video row. */
-  opts: { budgetFraction?: number; mediaLoad?: boolean } = {},
+  opts: {
+    budgetFraction?: number;
+    gpuCount?: number;
+    mediaLoad?: boolean;
+    hostPooledMemory?: boolean;
+  } = {},
 ): boolean {
   if (
     gpu.memoryTotalGb <= 0 &&
@@ -177,7 +198,9 @@ export function hfModelFitsDevice(
     budgetKnown: gpu.budgetKnown,
     requireKnown: true,
     budgetFraction: opts.budgetFraction,
+    gpuCount: opts.gpuCount,
     mediaLoad: opts.mediaLoad,
+    hostPooledMemory: opts.hostPooledMemory,
   });
 }
 
@@ -239,6 +262,11 @@ export function searchRowFitsDevice<
      *  picks the diffusion RULE, which Audio must not get: its GGUFs run under llama.cpp. */
     diffusionLoad?: boolean;
     budgetFraction?: number;
+    /** How many GPUs the unscoped aggregate sums. A task-scoped row is narrowed to one device by
+     *  loadScopedGpu, so this only ever applies to chat. */
+    gpuCount?: number;
+    /** The image/video load device's pool is host RAM, so RAM is not a second budget. */
+    hostPooledMemory?: boolean;
   },
 ): boolean {
   const source = opts.isGguf ? opts.inferenceGpu : opts.gpu;
@@ -251,7 +279,12 @@ export function searchRowFitsDevice<
     loadScopedGpu(source, opts.taskScoped),
     // A task-scoped row is a media load, so it takes the media rule as well as the single-device
     // budget. Without this the search gate disagreed with the quant rows it gates.
-    { budgetFraction: opts.budgetFraction, mediaLoad: opts.diffusionLoad },
+    {
+      budgetFraction: opts.budgetFraction,
+      gpuCount: opts.taskScoped ? 1 : opts.gpuCount,
+      mediaLoad: opts.diffusionLoad,
+      hostPooledMemory: opts.hostPooledMemory,
+    },
   );
 }
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -235,6 +235,9 @@ export function searchRowFitsDevice<
     gpu: G;
     inferenceGpu: G;
     taskScoped: boolean;
+    /** Images / Video only. `taskScoped` picks the single-device budget for every task page; this
+     *  picks the diffusion RULE, which Audio must not get: its GGUFs run under llama.cpp. */
+    diffusionLoad?: boolean;
     budgetFraction?: number;
   },
 ): boolean {
@@ -248,7 +251,7 @@ export function searchRowFitsDevice<
     loadScopedGpu(source, opts.taskScoped),
     // A task-scoped row is a media load, so it takes the media rule as well as the single-device
     // budget. Without this the search gate disagreed with the quant rows it gates.
-    { budgetFraction: opts.budgetFraction, mediaLoad: opts.taskScoped },
+    { budgetFraction: opts.budgetFraction, mediaLoad: opts.diffusionLoad },
   );
 }
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -4,6 +4,8 @@
 // Pure helpers for the Recommended list: which formats to surface and whether a
 // model fits the device. No React/DOM deps so they are easy to test.
 
+import { classifyGgufFit } from "../../../../lib/gguf-fit.ts";
+
 const GGUF_SUFFIX_RE = /-GGUF(?:$|-)/i;
 const MLX_RE = /-MLX(?:$|-)/i;
 
@@ -66,7 +68,7 @@ const PARAM_RE = /(?:^|[-_/. ])[eE]?(\d+(?:\.\d+)?)\s*[bB](?=$|[-_./ ])/;
 export function paramsFromId(id: string): number | undefined {
   const match = PARAM_RE.exec(id);
   if (!match) return undefined;
-  const billions = parseFloat(match[1]);
+  const billions = Number.parseFloat(match[1]);
   return Number.isFinite(billions) && billions > 0 ? billions * 1e9 : undefined;
 }
 
@@ -79,36 +81,40 @@ export function estimateQuantBytes(params: number): number {
   return params * MIN_QUANT_BYTES_PER_PARAM;
 }
 
-/** A model fits when its on-disk size (or a precomputed VRAM estimate) is within
- * the device budget (0.7*GPU + 0.7*RAM). Unknown device means we cannot tell, so
- * treat it as fitting. Unknown size normally fits too, but Recommended passes
- * `requireKnown` so a model we cannot size (e.g. a huge GGUF with no metadata or
- * size token) is hidden rather than wrongly shown. */
+/** A model fits when it can run at all: `classifyGgufFit` short of `oom`, so a partial CPU
+ * offload counts, since that loads and merely runs slower. Shares the loader's formula with the
+ * Hub badge and the quant rows, because this predicate ALSO gates the "Fits on device" filter,
+ * and a filter that hides a row the quant list would badge as runnable is the same bug twice.
+ *
+ * Unknown device means we cannot tell, so treat it as fitting. Unknown size normally fits too,
+ * but Recommended passes `requireKnown` so a model we cannot size (e.g. a huge GGUF with no
+ * metadata or size token) is hidden rather than wrongly shown. */
 export function fitsDevice(opts: {
   sizeBytes?: number;
-  estimatedVramGb?: number;
   gpuGb?: number;
   systemRamGb?: number;
   budgetKnown?: boolean;
   requireKnown?: boolean;
+  budgetFraction?: number;
 }): boolean {
   const {
     sizeBytes,
-    estimatedVramGb,
     gpuGb,
     systemRamGb,
     budgetKnown,
     requireKnown,
+    budgetFraction,
   } = opts;
-  // Unified-memory hosts (Mac / no discrete GPU) report system RAM but no GPU,
-  // so the budget must include RAM. Only an entirely unknown budget fits freely.
-  const budgetGb = Math.max(0, gpuGb ?? 0) * 0.7 + Math.max(0, systemRamGb ?? 0) * 0.7;
-  if (budgetGb <= 0) return !budgetKnown;
+  // Unified-memory hosts (Mac / no discrete GPU) report system RAM but no GPU, so the budget must
+  // include RAM. Only an entirely unknown budget fits freely.
+  const anyBudget =
+    Math.max(0, gpuGb ?? 0) > 0 || Math.max(0, systemRamGb ?? 0) > 0;
+  if (!anyBudget) return !budgetKnown;
   if (sizeBytes && sizeBytes > 0) {
-    return sizeBytes / 1024 ** 3 <= budgetGb;
-  }
-  if (estimatedVramGb && estimatedVramGb > 0) {
-    return estimatedVramGb <= budgetGb;
+    return (
+      classifyGgufFit(sizeBytes, { gpuGb, systemRamGb, budgetFraction }) !==
+      "oom"
+    );
   }
   return requireKnown ? false : true;
 }

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -97,8 +97,9 @@ export function fitsDevice(opts: {
   budgetKnown?: boolean;
   requireKnown?: boolean;
   budgetFraction?: number;
-  /** Images / Video: the row is placed by the diffusion backend, not llama-server, so it is judged
-   *  by the media rule the quant rows under it use. */
+  /** Images / Video: the row is placed by the diffusion backend, not llama-server, so it takes the
+   *  media rule the quant rows under it use. Applies to every format on those pages, GGUF or not:
+   *  that rule is the budget all of them had before the classifiers were merged. */
   mediaLoad?: boolean;
 }): boolean {
   const {

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -5,6 +5,7 @@
 // model fits the device. No React/DOM deps so they are easy to test.
 
 import { classifyGgufFit } from "../../../../lib/gguf-fit.ts";
+import { classifyMediaGgufFit } from "./model-catalog.ts";
 
 const GGUF_SUFFIX_RE = /-GGUF(?:$|-)/i;
 const MLX_RE = /-MLX(?:$|-)/i;
@@ -96,6 +97,9 @@ export function fitsDevice(opts: {
   budgetKnown?: boolean;
   requireKnown?: boolean;
   budgetFraction?: number;
+  /** Images / Video: the row is placed by the diffusion backend, not llama-server, so it is judged
+   *  by the media rule the quant rows under it use. */
+  mediaLoad?: boolean;
 }): boolean {
   const {
     sizeBytes,
@@ -104,6 +108,7 @@ export function fitsDevice(opts: {
     budgetKnown,
     requireKnown,
     budgetFraction,
+    mediaLoad,
   } = opts;
   // Unified-memory hosts (Mac / no discrete GPU) report system RAM but no GPU, so the budget must
   // include RAM. Only an entirely unknown budget fits freely.
@@ -111,6 +116,11 @@ export function fitsDevice(opts: {
     Math.max(0, gpuGb ?? 0) > 0 || Math.max(0, systemRamGb ?? 0) > 0;
   if (!anyBudget) return !budgetKnown;
   if (sizeBytes && sizeBytes > 0) {
+    if (mediaLoad) {
+      return (
+        classifyMediaGgufFit(sizeBytes, gpuGb ?? 0, systemRamGb ?? 0) !== "oom"
+      );
+    }
     return (
       classifyGgufFit(sizeBytes, { gpuGb, systemRamGb, budgetFraction }) !==
       "oom"
@@ -141,9 +151,10 @@ export function hfModelFitsDevice(
     systemRamAvailableGb: number;
     budgetKnown?: boolean;
   },
-  /** The user's saved VRAM Budget. Omitted scores against the loader's default, so a caller that
-   *  forgets it judges rows on a budget the user has already replaced. */
-  budgetFraction?: number,
+  /** `budgetFraction` is the user's saved VRAM Budget: omitted scores against the loader's default,
+   *  so a caller that forgets it judges rows on a budget the user has already replaced.
+   *  `mediaLoad` picks the diffusion rule for an Images / Video row. */
+  opts: { budgetFraction?: number; mediaLoad?: boolean } = {},
 ): boolean {
   if (
     gpu.memoryTotalGb <= 0 &&
@@ -164,7 +175,8 @@ export function hfModelFitsDevice(
     systemRamGb: gpu.systemRamAvailableGb,
     budgetKnown: gpu.budgetKnown,
     requireKnown: true,
-    budgetFraction,
+    budgetFraction: opts.budgetFraction,
+    mediaLoad: opts.mediaLoad,
   });
 }
 
@@ -233,7 +245,9 @@ export function searchRowFitsDevice<
       curatedSizeBytes: row.curatedSizeBytes ?? opts.curatedSizeBytes,
     },
     loadScopedGpu(source, opts.taskScoped),
-    opts.budgetFraction,
+    // A task-scoped row is a media load, so it takes the media rule as well as the single-device
+    // budget. Without this the search gate disagreed with the quant rows it gates.
+    { budgetFraction: opts.budgetFraction, mediaLoad: opts.taskScoped },
   );
 }
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -292,7 +292,7 @@ export function searchRowFitsDevice<
   },
 ): boolean {
   const source = loadScopedGpu(
-    opts.isGguf ? opts.inferenceGpu : opts.gpu,
+    opts.diffusionLoad || !opts.isGguf ? opts.gpu : opts.inferenceGpu,
     opts.taskScoped,
   );
   return hfModelFitsDevice(

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -126,6 +126,9 @@ export function fitsDevice(opts: {
   if (!anyBudget) return !budgetKnown;
   if (sizeBytes && sizeBytes > 0) {
     if (mediaLoad) {
+      // No RAM tier on a host pool: diffusion offload moves bytes inside that one pool and frees
+      // nothing. llama.cpp below keeps its tier, because a GGUF really does spill into whatever
+      // host RAM the GPU window does not already cover.
       return (
         classifyMediaGgufFit(
           sizeBytes,
@@ -215,6 +218,7 @@ export function loadScopedGpu<
     maxDeviceMemoryGb: number;
     loadDeviceMemoryGb: number;
     loadDeviceSharedMemory?: boolean;
+    loadDeviceSharesHostMemory?: boolean;
     systemRamAvailableGb: number;
     systemRamAvailableHostGb?: number;
     deviceCount?: number;
@@ -230,11 +234,23 @@ export function loadScopedGpu<
     // once per HOST GPU against a ONE-card budget. Two 24 GiB cards at a 1.0 setting scored an
     // audio quant against 23.28 GiB where the loader offers the selected card's 23.5.
     deviceCount: 1,
-    systemRamAvailableGb:
-      gpu.loadDeviceSharedMemory === false
-        ? (gpu.systemRamAvailableHostGb ?? gpu.systemRamAvailableGb)
-        : gpu.systemRamAvailableGb,
+    // The raw-host figure is the RAM a DEDICATED task device may claim back from a shared GPU's
+    // reservation. Gated on the folded flag, not shared_memory: that one is Windows-only, so a
+    // Linux ROCm APU took this branch and undid the very subtraction that keeps its GTT window
+    // out of the RAM tier.
+    systemRamAvailableGb: hostPooledLoadDevice(gpu)
+      ? gpu.systemRamAvailableGb
+      : (gpu.systemRamAvailableHostGb ?? gpu.systemRamAvailableGb),
   };
+}
+
+/** Whether the device a task load lands on draws from host RAM. Prefers the folded flag, which
+ *  counts a Linux APU that reports unified_memory without shared_memory. */
+function hostPooledLoadDevice(gpu: {
+  loadDeviceSharedMemory?: boolean;
+  loadDeviceSharesHostMemory?: boolean;
+}): boolean {
+  return gpu.loadDeviceSharesHostMemory ?? gpu.loadDeviceSharedMemory === true;
 }
 
 /** One fit predicate for both search lists (curated matches and the Hub rows

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -141,6 +141,9 @@ export function hfModelFitsDevice(
     systemRamAvailableGb: number;
     budgetKnown?: boolean;
   },
+  /** The user's saved VRAM Budget. Omitted scores against the loader's default, so a caller that
+   *  forgets it judges rows on a budget the user has already replaced. */
+  budgetFraction?: number,
 ): boolean {
   if (
     gpu.memoryTotalGb <= 0 &&
@@ -161,6 +164,7 @@ export function hfModelFitsDevice(
     systemRamGb: gpu.systemRamAvailableGb,
     budgetKnown: gpu.budgetKnown,
     requireKnown: true,
+    budgetFraction,
   });
 }
 
@@ -218,6 +222,7 @@ export function searchRowFitsDevice<
     gpu: G;
     inferenceGpu: G;
     taskScoped: boolean;
+    budgetFraction?: number;
   },
 ): boolean {
   const source = opts.isGguf ? opts.inferenceGpu : opts.gpu;
@@ -228,6 +233,7 @@ export function searchRowFitsDevice<
       curatedSizeBytes: row.curatedSizeBytes ?? opts.curatedSizeBytes,
     },
     loadScopedGpu(source, opts.taskScoped),
+    opts.budgetFraction,
   );
 }
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -217,14 +217,19 @@ export function loadScopedGpu<
     loadDeviceSharedMemory?: boolean;
     systemRamAvailableGb: number;
     systemRamAvailableHostGb?: number;
+    deviceCount?: number;
   },
->(gpu: T, taskScoped: boolean): T {
+>(gpu: T, taskScoped: boolean): T & { deviceCount?: number } {
   if (!taskScoped || !gpu.available) return gpu;
   const deviceGb = gpu.loadDeviceMemoryGb || gpu.maxDeviceMemoryGb;
   if (deviceGb <= 0) return gpu;
   return {
     ...gpu,
     memoryTotalGb: deviceGb,
+    // Narrowed with the capacity it describes, or the loader's per-card VRAM reserve gets charged
+    // once per HOST GPU against a ONE-card budget. Two 24 GiB cards at a 1.0 setting scored an
+    // audio quant against 23.28 GiB where the loader offers the selected card's 23.5.
+    deviceCount: 1,
     systemRamAvailableGb:
       gpu.loadDeviceSharedMemory === false
         ? (gpu.systemRamAvailableHostGb ?? gpu.systemRamAvailableGb)
@@ -244,6 +249,7 @@ export function searchRowFitsDevice<
     loadDeviceMemoryGb: number;
     systemRamAvailableGb: number;
     budgetKnown?: boolean;
+    deviceCount?: number;
   },
 >(
   row: {
@@ -262,26 +268,30 @@ export function searchRowFitsDevice<
      *  picks the diffusion RULE, which Audio must not get: its GGUFs run under llama.cpp. */
     diffusionLoad?: boolean;
     budgetFraction?: number;
-    /** How many GPUs the unscoped aggregate sums. A task-scoped row is narrowed to one device by
-     *  loadScopedGpu, so this only ever applies to chat. */
+    /** How many GPUs the aggregate sums, when the caller's inventory does not carry the count
+     *  itself. loadScopedGpu narrows it to 1 with the capacity, so a task page needs nothing here. */
     gpuCount?: number;
     /** The image/video load device's pool is host RAM, so RAM is not a second budget. */
     hostPooledMemory?: boolean;
   },
 ): boolean {
-  const source = opts.isGguf ? opts.inferenceGpu : opts.gpu;
+  const source = loadScopedGpu(
+    opts.isGguf ? opts.inferenceGpu : opts.gpu,
+    opts.taskScoped,
+  );
   return hfModelFitsDevice(
     {
       ...row,
       isGguf: opts.isGguf,
       curatedSizeBytes: row.curatedSizeBytes ?? opts.curatedSizeBytes,
     },
-    loadScopedGpu(source, opts.taskScoped),
+    source,
     // A task-scoped row is a media load, so it takes the media rule as well as the single-device
     // budget. Without this the search gate disagreed with the quant rows it gates.
     {
       budgetFraction: opts.budgetFraction,
-      gpuCount: opts.taskScoped ? 1 : opts.gpuCount,
+      // From the SCOPED budget, so the count always describes the capacity beside it.
+      gpuCount: source.deviceCount ?? opts.gpuCount,
       mediaLoad: opts.diffusionLoad,
       hostPooledMemory: opts.hostPooledMemory,
     },

--- a/studio/frontend/src/features/model-picker/index.ts
+++ b/studio/frontend/src/features/model-picker/index.ts
@@ -10,7 +10,10 @@ export {
   pinKey,
   usePinnedModelsStore,
 } from "./components/model-selector/pinned-models";
-export { hfModelFitsDevice } from "./components/model-selector/recommended-fit";
+export {
+  hfModelFitsDevice,
+  loadScopedGpu,
+} from "./components/model-selector/recommended-fit";
 export {
   NumericValueInput,
   type NumericValueInputHandle,

--- a/studio/frontend/src/hooks/gpu-vram.ts
+++ b/studio/frontend/src/hooks/gpu-vram.ts
@@ -128,7 +128,7 @@ export interface MemoryCapacityDevice {
 /** Whether this device's memory is a view into host RAM rather than beside it.
  *  The one question capacity cares about; the two flags are how the backend
  *  happens to report it on two platforms. */
-function sharesHostMemory(device: {
+export function sharesHostMemory(device: {
   sharedMemory?: boolean;
   unifiedMemory?: boolean;
 }): boolean {

--- a/studio/frontend/src/hooks/use-gpu-info.ts
+++ b/studio/frontend/src/hooks/use-gpu-info.ts
@@ -15,6 +15,7 @@ import {
 import {
   gpuMemoryTotalsGb,
   gpuSharedHostMemoryGb,
+  sharesHostMemory,
   systemRamAvailableOutsideSharedPoolGb,
 } from "./gpu-vram";
 import {
@@ -57,6 +58,12 @@ export interface GpuInfo {
   loadDeviceMemoryGb: number;
   /** true when the image/video load device uses the host memory pool. */
   loadDeviceSharedMemory: boolean;
+  /** The same question with the ROCm APU included: `shared_memory` is that flag AND Windows, so a
+   *  Linux APU reads as not-shared while its total is still a window into host RAM. Offload frees
+   *  nothing on either, which is the only thing a diffusion verdict needs to know. */
+  loadDeviceSharesHostMemory: boolean;
+  /** How many GPUs memoryTotalGb is the sum of, for the loader's per-card VRAM reserve. */
+  deviceCount: number;
   cpuCore: number;
   cpuThread: number;
   /** host RAM free after removing the host-backed shared GPU pool. */
@@ -79,6 +86,8 @@ const DEFAULT_GPU: GpuInfo = {
   maxDeviceMemoryGb: 0,
   loadDeviceMemoryGb: 0,
   loadDeviceSharedMemory: false,
+  loadDeviceSharesHostMemory: false,
+  deviceCount: 0,
   cpuCore: 0,
   cpuThread: 0,
   systemRamAvailableGb: 0,
@@ -133,6 +142,11 @@ function toGpuInfo(
     // Lowest visible ordinal = torch's current device = where the pipeline lands.
     loadDeviceMemoryGb: loadDevice?.memory_total_gb ?? 0,
     loadDeviceSharedMemory: loadDevice?.shared_memory === true,
+    loadDeviceSharesHostMemory: sharesHostMemory({
+      sharedMemory: loadDevice?.shared_memory === true,
+      unifiedMemory: loadDevice?.unified_memory === true,
+    }),
+    deviceCount: devices.length,
   };
 }
 

--- a/studio/frontend/src/hooks/use-gpu-info.ts
+++ b/studio/frontend/src/hooks/use-gpu-info.ts
@@ -119,9 +119,20 @@ function toGpuInfo(
   const loadDevice = pickLoadDevice(devices);
   return {
     ...base,
+    // Folded, not raw `shared_memory`: hardware.py sets that flag only on Windows, so a Linux ROCm
+    // APU arrives unified true / shared false and its GTT window was never subtracted here. The
+    // RAM tier then offered the very bytes the window is a view INTO as a second budget.
     systemRamAvailableGb: systemRamAvailableOutsideSharedPoolGb(
       base.systemRamAvailableGb,
-      gpuSharedHostMemoryGb(devices),
+      gpuSharedHostMemoryGb(
+        devices.map((device) => ({
+          ...device,
+          shared_memory: sharesHostMemory({
+            sharedMemory: device.shared_memory === true,
+            unifiedMemory: device.unified_memory === true,
+          }),
+        })),
+      ),
     ),
     sharedMemory: memoryTotals.shared > 0 && memoryTotals.dedicated === 0,
     // Additive, and deliberately some() where sharedMemory above is "no dedicated

--- a/studio/frontend/src/lib/gguf-fit.ts
+++ b/studio/frontend/src/lib/gguf-fit.ts
@@ -25,6 +25,10 @@ export interface GgufFitInput {
    *  against the 0.97 default's 23.28 GiB, so a 18 to 19 GiB quant was badged
    *  `fits` beside a bar reporting an overage. */
   budgetFraction?: number;
+  /** How many GPUs `gpuGb` is the sum of. Only the reserve floor uses it, and only
+   *  above the default budget; absent means one card, which is what every verdict
+   *  scored against before it existed. */
+  gpuCount?: number;
 }
 
 /** Fraction of GPU VRAM treated as usable.
@@ -64,7 +68,7 @@ export function requiredGgufMemoryGb(
 
 export function classifyGgufFit(
   sizeBytes: number,
-  { gpuGb, systemRamGb, budgetFraction }: GgufFitInput,
+  { gpuGb, systemRamGb, budgetFraction, gpuCount }: GgufFitInput,
 ): GgufFitClass {
   const required = requiredGgufMemoryGb(sizeBytes);
   if (!gpuGb || gpuGb <= 0) {
@@ -86,10 +90,22 @@ export function classifyGgufFit(
   // always wins and this is identical; above it, `gpuGb * fraction` claimed capacity the backend
   // does not offer, and a 20 GiB file on a full 24 GiB card at 1.0 read `fits` while `_select_gpus`
   // fell back to --fit.
-  const reserveFloorGb = Math.min(
-    VRAM_RESERVE_FLOOR_GB,
-    (1 - DEFAULT_VRAM_BUDGET_FRACTION) * gpuGb,
-  );
+  //
+  // Charged per CARD, not per host: `_select_gpus` calls `_vram_usable_mib` for every device and
+  // sums the results, so a k-GPU box holds back k floors. One floor for the whole box read 47.5
+  // GiB usable on two 24 GiB cards at 1.0 where the loader offers 47.0, so a file needing 47.2
+  // read `fits` against a load that fell back to --fit. Exact on matched cards, an even split on
+  // a mixed one, which is still far nearer than charging the floor once.
+  const cards =
+    typeof gpuCount === "number" && Number.isFinite(gpuCount) && gpuCount >= 1
+      ? Math.floor(gpuCount)
+      : 1;
+  const reserveFloorGb =
+    cards *
+    Math.min(
+      VRAM_RESERVE_FLOOR_GB,
+      (1 - DEFAULT_VRAM_BUDGET_FRACTION) * (gpuGb / cards),
+    );
   const budget = gpuGb - Math.max((1 - fraction) * gpuGb, reserveFloorGb);
   if (required <= budget) return "fits";
   // Raw card, deliberately. This band means "over your budget, still card-sized",

--- a/studio/frontend/src/lib/gguf-fit.ts
+++ b/studio/frontend/src/lib/gguf-fit.ts
@@ -44,6 +44,9 @@ export interface GgufFitInput {
  * filter). */
 export { DEFAULT_VRAM_BUDGET_FRACTION as VRAM_HEADROOM_RATIO } from "./memory/thresholds.ts";
 import { DEFAULT_VRAM_BUDGET_FRACTION } from "./memory/thresholds.ts";
+/** The loader's absolute reserve floor, `_VRAM_FLOOR_RESERVE_MIB` (512 MiB) in llama_cpp.py.
+ *  Capped there at 3% of the card, so it never rises above the default budget's own reserve. */
+const VRAM_RESERVE_FLOOR_GB = 512 / 1024;
 /** GGUF weights are file size; runtime activations add roughly this fraction. */
 const ACTIVATIONS_RATIO = 0.15;
 /** Flat KV/context allowance at a typical 4K window. */
@@ -77,7 +80,17 @@ export function classifyGgufFit(
     budgetFraction <= 1
       ? budgetFraction
       : DEFAULT_VRAM_BUDGET_FRACTION;
-  const budget = gpuGb * fraction;
+  // Not simply `gpuGb * fraction`. The loader's `_vram_usable_mib` charges
+  // `max((1 - frac) * total, floor)`, where the floor is `min(512 MiB, 3% of total)`, so the
+  // reserve never disappears at the top of the slider. Below the 0.97 default the percentage term
+  // always wins and this is identical; above it, `gpuGb * fraction` claimed capacity the backend
+  // does not offer, and a 20 GiB file on a full 24 GiB card at 1.0 read `fits` while `_select_gpus`
+  // fell back to --fit.
+  const reserveFloorGb = Math.min(
+    VRAM_RESERVE_FLOOR_GB,
+    (1 - DEFAULT_VRAM_BUDGET_FRACTION) * gpuGb,
+  );
+  const budget = gpuGb - Math.max((1 - fraction) * gpuGb, reserveFloorGb);
   if (required <= budget) return "fits";
   // Raw card, deliberately. This band means "over your budget, still card-sized",
   // which is the only thing that distinguishes it from `fits`: scoring it against

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -257,17 +257,31 @@ test("chat and the Hub answer the fit question with one formula", () => {
   // Threaded through the row filters as well. Passing it to the quant rows alone left the parent
   // rows and the "Fits on device" gate scoring against the 0.97 default.
   assert.ok(HUB_PAGE.includes("useVramBudgetFraction()"));
-  assert.match(
-    HUB_PAGE,
-    /hfModelFitsDevice\(row\.result, inferenceGpu, \{\n\s*budgetFraction,/,
-  );
   assert.ok(RECOMMENDED.includes("budgetFraction?: number;"));
   // Both surfaces count the cards, or the Hub badge and the picker badge diverge again the moment
-  // the VRAM Budget goes above the default on a multi-GPU host.
+  // the VRAM Budget goes above the default on a multi-GPU host. The two row gates take it from
+  // the SCOPED source, which is 1 for a media row and the host count otherwise.
+  assert.ok(HUB_PAGE.includes("gpuCount: source.deviceCount"));
+  assert.ok(HUB_PAGE.includes("gpuCount: inferenceGpu.deviceCount"));
+  // And both gates ask one helper, which picks the budget by the runtime that places the row: an
+  // image or video repo goes to the diffusion planner on one torch device, under the media rule.
+  // Judged by llama.cpp the Hub kept a 52 GiB media GGUF that clears 62.1 GiB on a 64 GiB Mac
+  // and blows the planner's 44.8.
   assert.equal(
-    HUB_PAGE.split("gpuCount: inferenceGpu.deviceCount").length - 1,
-    3,
-    "every Hub gate and the inspector",
+    HUB_PAGE.split("rowFitsDevice(row.result)").length - 1,
+    2,
+    "both Hub fit gates",
+  );
+  assert.ok(
+    HUB_PAGE.includes(
+      "mediaRow || !result.isGguf ? gpu : inferenceGpu,",
+    ),
+  );
+  assert.ok(HUB_PAGE.includes("mediaLoad: mediaRow,"));
+  assert.ok(
+    HUB_PAGE.includes(
+      "studioPageForTask(result.pipelineTag) !== undefined",
+    ),
   );
   // The count is narrowed WITH the capacity, so it can never describe a different inventory than
   // the gpuGb beside it. A task page puts the load on one device; charging the per-card reserve
@@ -347,12 +361,21 @@ test("each fit verdict is an info mark that explains itself", () => {
       '"Model may not fit but still works with offloading. Expect slower inference."',
     ),
   );
-  // Neither surface claims a marginal load can fail. _select_gpus scores against FREE VRAM and
-  // hands a miss to --fit, so a busy card costs speed, not the load.
+  // Neither surface makes a marginal offload conditional on other apps. _vram_usable_mib gives
+  // free - reserve, which on a completely idle card IS the budget this tier has already passed,
+  // so _select_gpus takes --fit every time; other apps only shrink free further. Saying it
+  // "fits with almost no room to spare" promised a resident load the loader never admits.
   const mightFitHint =
-    "Fits your GPU with almost no room to spare. If other apps are using VRAM, it offloads and runs slower.";
+    "Larger than your VRAM Budget allows, so part of it offloads even on an idle GPU. It is still smaller than the card, so raising the budget can keep it resident.";
   assert.ok(PICKERS.includes(mightFitHint));
   assert.ok(HUB_CARD.includes(mightFitHint));
+  assert.ok(
+    !PICKERS.includes("If other apps are using VRAM"),
+    "no conditional offload copy",
+  );
+  assert.ok(!HUB_CARD.includes("If other apps are using VRAM"));
+  assert.ok(!PICKERS.includes('label: "Might fit"'));
+  assert.ok(!HUB_CARD.includes('label: "Might fit"'));
   assert.ok(!PICKERS.includes("Loading can fail while other apps"));
   assert.ok(!HUB_CARD.includes("Within the last GB of VRAM headroom"));
   // The Hub's oom row says it too, so the two surfaces read alike on a host where every
@@ -367,7 +390,7 @@ test("each fit verdict is an info mark that explains itself", () => {
   );
 
   // Marks are reachable by screen readers without the tooltip.
-  assert.ok(PICKERS.includes('label: "Might fit"'));
+  assert.ok(PICKERS.includes('label: "Over budget"'));
   assert.ok(PICKERS.includes('label: "Does not fit"'));
   // "will not load" is right for `exceeds`, which only ever comes from a torch row: inference.py
   // calls raise_if_offloaded after loading, and that raises ValueError on any CPU or disk offload

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -15,6 +15,7 @@ const PICKERS = read(
 );
 const MODELS_TABLE = read("../src/features/hub/catalog/models-table.tsx");
 const HUB_CARD = read("../src/features/hub/catalog/gguf-download-card.tsx");
+const HUB_PAGE = read("../src/features/hub/hub-page.tsx");
 const CATALOG = read(
   "../src/features/model-picker/components/model-selector/model-catalog.ts",
 );
@@ -127,12 +128,14 @@ test("one fit badge, so a colour or reveal change cannot miss a list", () => {
   // between them to drift.
   assert.ok(PICKERS.includes("<VramBadge status={fit} />"));
   assert.equal(
-    PICKERS.split(
-      '<VramBadge status={vramStatus} source="device" revealOnHover={!selected} />',
-    ).length - 1,
+    PICKERS.split("<VramBadge status={vramStatus} revealOnHover={!selected} />")
+      .length - 1,
     2,
     "both model row slots reveal on hover",
   );
+  // A selected row is exempt from dimming, so hiding its mark too left it with no verdict at all
+  // until hovered, which is nothing at rest and nothing on touch.
+  assert.match(PICKERS, /exceeds &&\n\s*!selected &&/);
 });
 
 test("chat and the Hub answer the fit question with one formula", () => {
@@ -148,16 +151,39 @@ test("chat and the Hub answer the fit question with one formula", () => {
     "and so does the Recommended fit filter",
   );
   // No copy of the old budget survives in either GGUF path.
-  for (const [name, src] of [
-    ["pickers", PICKERS],
-    ["recommended-fit", RECOMMENDED],
-  ] as const) {
-    assert.ok(!src.includes("* 0.7"), `${name} has no 0.7 budget left`);
-  }
+  assert.ok(
+    !RECOMMENDED.includes("* 0.7"),
+    "recommended-fit has no 0.7 budget left",
+  );
+  assert.ok(!PICKERS.includes("* 0.7"), "pickers has no 0.7 budget left");
+  // model-catalog keeps one, and only for the media pickers: a GGUF offered on Images or Video is
+  // placed by the diffusion backend, whose budget is far below llama.cpp's. On a 64 GiB Mac that
+  // planner allows about 43.5 GiB, this rule 44.8, the llama.cpp rule 62.1. The boundaries are
+  // asserted for real in model-catalog.check.ts.
+  assert.ok(CATALOG.includes("export function classifyMediaGgufFit("));
+  assert.match(
+    PICKERS,
+    /if \(taskScoped\) \{\n\s*return classifyMediaGgufFit\(/,
+  );
+  // And every media call site sets the flag, or the guard silently does nothing.
+  assert.equal(
+    PICKERS.split("taskScoped={Boolean(task)}").length - 1,
+    7,
+    "every task-scoped expander",
+  );
   // The saved VRAM Budget now reaches chat. Moving the slider used to change the Hub's verdicts
   // and leave the picker's untouched.
   assert.ok(PICKERS.includes("useVramBudgetFraction()"));
   assert.ok(PICKERS.includes("budgetFraction,"));
+  // Threaded through the row filters as well. Passing it to the quant rows alone left the parent
+  // rows and the "Fits on device" gate scoring against the 0.97 default.
+  assert.ok(HUB_PAGE.includes("useVramBudgetFraction()"));
+  assert.match(
+    HUB_PAGE,
+    /hfModelFitsDevice\(row\.result, inferenceGpu, budgetFraction\)/,
+  );
+  assert.ok(RECOMMENDED.includes("budgetFraction?: number,"));
+  assert.ok(RECOMMENDED.includes("opts.budgetFraction,"));
 });
 
 test("each fit verdict is an info mark that explains itself", () => {
@@ -229,10 +255,13 @@ test("a GGUF row takes the GGUF verdict, not the torch refusal", () => {
   // This branch used to set "exceeds", the one verdict that says a model will not load. A GGUF is
   // offloaded by llama-server rather than refused, so the row said the opposite of what happens,
   // and it is the verdict shown on the Recommended list where most rows are over budget.
-  assert.ok(
-    PICKERS.includes(
-      'status: exceedsSize(sizeBytes, inferenceGpu) ? "oom" : null,',
-    ),
+  assert.ok(PICKERS.includes("status: ggufRowFit(sizeBytes, inferenceGpu),"));
+  // A boolean here collapsed marginal and partial into "no badge", so a repo whose smallest quant
+  // already needed offload rendered as a clean fit beside variant rows saying otherwise.
+  assert.ok(!PICKERS.includes("exceedsSize"));
+  assert.match(
+    PICKERS,
+    /const ggufRowFit = \([\s\S]{0,200}\): GgufFitClass \| null =>/,
   );
   // Every surviving producer of "exceeds" is a curated torch pipeline, which has no --fit.
   const producers = PICKERS.split("\n").filter(

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -23,6 +23,7 @@ const RECOMMENDED = read(
   "../src/features/model-picker/components/model-selector/recommended-fit.ts",
 );
 const GPU_INFO = read("../src/hooks/use-gpu-info.ts");
+const INSPECTOR = read("../src/features/hub/catalog/model-inspector.tsx");
 const SIDEBAR = read("../src/components/app-sidebar.tsx");
 const CSS = read("../src/index.css");
 
@@ -199,6 +200,33 @@ test("chat and the Hub answer the fit question with one formula", () => {
   assert.ok(
     !PICKERS.includes("inferenceGpu.systemRamAvailableGb"),
     "no expander takes the GGUF backend's RAM directly",
+  );
+  // The custom-folder expander was the one that kept reaching for the raw aggregate: on a media
+  // page it classified against memory the diffusion loader never sees, and it was not even
+  // load-scoped. Every row-level budget in this file now comes from the one chosen source.
+  assert.ok(
+    !PICKERS.includes("inferenceGpu.memoryTotalGb"),
+    "no row takes the GGUF backend's capacity directly",
+  );
+  assert.ok(
+    !PICKERS.includes("budgetKnown={inferenceGpu.budgetKnown}"),
+    "and none takes its probe state either",
+  );
+  assert.equal(
+    PICKERS.split("gpuGb={expanderGpuGb}").length - 1,
+    9,
+    "seven expanders and the two quant rows beside them",
+  );
+  // The Hub card answers llama.cpp's question, so it must not answer it about a diffusion repo:
+  // an oom there would read "still works with offloading" for a load the planner refuses.
+  assert.ok(
+    HUB_CARD.includes(
+      "const showFitInfo = !mediaRuntime && (Boolean(gpuGb) || Boolean(systemRamGb));",
+    ),
+  );
+  assert.match(
+    INSPECTOR,
+    /showMemoryBar=\{!runsOnMediaRuntime\}\n\s*mediaRuntime=\{runsOnMediaRuntime\}/,
   );
   // Parent rows and the fit gate take the same rule as the quant rows under them, or a media row
   // reads as fitting while everything inside it reads as oom.

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -225,6 +225,25 @@ test("each fit verdict is an info mark that explains itself", () => {
   );
 });
 
+test("a GGUF row takes the GGUF verdict, not the torch refusal", () => {
+  // This branch used to set "exceeds", the one verdict that says a model will not load. A GGUF is
+  // offloaded by llama-server rather than refused, so the row said the opposite of what happens,
+  // and it is the verdict shown on the Recommended list where most rows are over budget.
+  assert.ok(
+    PICKERS.includes(
+      'status: exceedsSize(sizeBytes, inferenceGpu) ? "oom" : null,',
+    ),
+  );
+  // Every surviving producer of "exceeds" is a curated torch pipeline, which has no --fit.
+  const producers = PICKERS.split("\n").filter(
+    (line) => line.includes('"exceeds"') && line.includes("status:"),
+  );
+  assert.equal(producers.length, 2, "curated rows only");
+  for (const line of producers) {
+    assert.match(line, /curatedFits \? null : "exceeds"/);
+  }
+});
+
 test("aligned meta slots spend their slack on the name", () => {
   // Centring a lone glyph splits the slack either side of it, reading as a gap on both sides.
   assert.ok(

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -167,10 +167,20 @@ test("each fit verdict is an info mark that explains itself", () => {
   // over budget but still card-sized needs no system RAM, so it fires on unified memory too.
   assert.ok(PICKERS.includes("marginal: MIGHT_FIT"));
   assert.ok(PICKERS.includes("partial: OFFLOADS"));
-  assert.ok(PICKERS.includes("oom: WONT_FIT"));
+  // Every over-budget GGUF says the same thing, however far over. llama-server never refuses one
+  // on size: _select_gpus returns use_fit and --fit offloads the rest. Splitting the copy here hid
+  // the honest answer on unified memory, where the RAM tier cannot fire and everything reads oom.
+  assert.ok(PICKERS.includes("oom: OFFLOADS"));
+  // A torch pipeline has no --fit, so that one keeps a refusal.
+  assert.ok(PICKERS.includes("exceeds: WONT_FIT"));
+  assert.ok(
+    PICKERS.includes(
+      'hint: "Needs more VRAM than this device has. This model will not load."',
+    ),
+  );
+  assert.ok(!PICKERS.includes("Larger than your VRAM and system RAM together"));
   // The training estimator's three words map onto those rather than carrying their own copy.
   assert.ok(PICKERS.includes("tight: MIGHT_FIT"));
-  assert.ok(PICKERS.includes("exceeds: WONT_FIT"));
   // Only oom fails to load, so only its hint says so; partial offloads and runs slower.
   assert.ok(
     PICKERS.includes(
@@ -191,13 +201,18 @@ test("each fit verdict is an info mark that explains itself", () => {
   assert.ok(HUB_CARD.includes(mightFitHint));
   assert.ok(!PICKERS.includes("Loading can fail while other apps"));
   assert.ok(!HUB_CARD.includes("Within the last GB of VRAM headroom"));
-  assert.ok(
-    PICKERS.includes(
-      'hint: "Larger than your VRAM and system RAM together. This model will not load."',
-    ),
+  // The Hub's oom row says it too, so the two surfaces read alike on a host where every
+  // over-budget quant lands in that class.
+  assert.ok(!HUB_CARD.includes('label: "Won\'t fit"'));
+  assert.equal(
+    HUB_CARD.split(
+      '"Model doesn\'t fit but still works with offloading. Expect slower inference."',
+    ).length - 1,
+    2,
+    "partial and oom both",
   );
+
   // Marks are reachable by screen readers without the tooltip.
-  assert.ok(PICKERS.includes('label: "Partial offload"'));
   assert.ok(PICKERS.includes('label: "Might fit"'));
   assert.ok(PICKERS.includes('label: "Does not fit"'));
   assert.ok(PICKERS.includes("aria-label={verdict.label}"));

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -126,7 +126,10 @@ test("one fit badge, so a colour or reveal change cannot miss a list", () => {
   assert.ok(!PICKERS.includes(">\n        OOM\n"), "no OOM text pill left");
   // Variant rows hand the classifier's verdict straight to the badge, with no second mapping
   // between them to drift.
-  assert.ok(PICKERS.includes("<VramBadge status={fit} />"));
+  assert.match(
+    PICKERS,
+    /<VramBadge\n\s*status=\{\n\s*diffusionRefuses\(fit, diffusionLoad, sharedMemory\)/,
+  );
   assert.equal(
     PICKERS.split("<VramBadge status={vramStatus} revealOnHover={!selected} />")
       .length - 1,
@@ -163,17 +166,26 @@ test("chat and the Hub answer the fit question with one formula", () => {
   assert.ok(CATALOG.includes("export function classifyMediaGgufFit("));
   assert.match(
     PICKERS,
-    /if \(taskScoped\) \{\n\s*return classifyMediaGgufFit\(/,
+    /if \(diffusionLoad\) \{\n\s*return classifyMediaGgufFit\(/,
   );
+  // Diffusion tasks only. Audio is task-scoped too but runs its GGUFs under llama.cpp (TTS) and
+  // the whisper sidecars (ASR), so scoring it at 70% hid runnable models and shrank the quant.
+  assert.ok(PICKERS.includes("const DIFFUSION_TASKS: ReadonlySet<string>"));
+  assert.match(PICKERS, /\.\.\.IMAGE_GEN_TASKS,\n\s*\.\.\.VIDEO_GEN_TASKS,/);
+  assert.ok(
+    !PICKERS.includes("mediaLoad: taskScoped,"),
+    "no task-wide media rule",
+  );
+  assert.ok(RECOMMENDED.includes("mediaLoad: opts.diffusionLoad"));
   // Parent rows and the fit gate take the same rule as the quant rows under them, or a media row
   // reads as fitting while everything inside it reads as oom.
-  assert.match(PICKERS, /Boolean\(task\)\n\s*\? classifyMediaGgufFit\(/);
+  assert.match(PICKERS, /diffusionLoad\n\s*\? classifyMediaGgufFit\(/);
   // Both gates read the flag the same way, or one hides a row the other keeps.
-  assert.ok(PICKERS.includes("mediaLoad: taskScoped,"));
-  assert.ok(RECOMMENDED.includes("mediaLoad: opts.taskScoped }"));
+  assert.ok(PICKERS.includes("mediaLoad: diffusionLoad,"));
+  assert.ok(RECOMMENDED.includes("mediaLoad: opts.diffusionLoad }"));
   // And every media call site sets the flag, or the guard silently does nothing.
   assert.equal(
-    PICKERS.split("taskScoped={Boolean(task)}").length - 1,
+    PICKERS.split("diffusionLoad={diffusionLoad}").length - 1,
     7,
     "every task-scoped expander",
   );
@@ -211,7 +223,7 @@ test("each fit verdict is an info mark that explains itself", () => {
   assert.ok(PICKERS.includes("exceeds: WONT_FIT"));
   assert.ok(
     PICKERS.includes(
-      'hint: "Needs more VRAM than this device has. This model will not load."',
+      'hint: "Needs more memory than this device has. This model will not load."',
     ),
   );
   assert.ok(!PICKERS.includes("Larger than your VRAM and system RAM together"));
@@ -264,7 +276,7 @@ test("each fit verdict is an info mark that explains itself", () => {
   // handed to --fit instead, which is why it says the opposite.
   assert.ok(
     PICKERS.includes(
-      'hint: "Needs more VRAM than this device has. This model will not load."',
+      'hint: "Needs more memory than this device has. This model will not load."',
     ),
   );
   assert.ok(PICKERS.includes("aria-label={verdict.label}"));
@@ -287,7 +299,7 @@ test("a GGUF row takes the GGUF verdict, not the torch refusal", () => {
   assert.ok(!PICKERS.includes("exceedsSize"));
   assert.match(
     PICKERS,
-    /const ggufRowFit = \([\s\S]{0,200}\): GgufFitClass \| null =>/,
+    /const ggufRowFit = \([\s\S]{0,220}\): GgufFitClass \| VramFitStatus \| null =>/,
   );
   // Every surviving producer of "exceeds" is a curated torch pipeline, which has no --fit.
   const producers = PICKERS.split("\n").filter(
@@ -297,6 +309,37 @@ test("a GGUF row takes the GGUF verdict, not the torch refusal", () => {
   for (const line of producers) {
     assert.match(line, /curatedFits \? null : "exceeds"/);
   }
+});
+
+test("a diffusion model too big for a shared pool is refused, not offloaded", () => {
+  // diffusion_memory.py refuses up front on unified memory: offload "moves bytes within that pool
+  // and frees nothing", and without the refusal the load "allocates past physical memory" with
+  // "the failure is the OS killing the process with no Python exception". Saying it still works
+  // with offloading is the worst thing this badge could say there.
+  assert.ok(PICKERS.includes("function diffusionRefuses("));
+  assert.ok(
+    PICKERS.includes('return fit === "oom" && diffusionLoad && sharedMemory;'),
+  );
+  // Both the quant rows and the parent row take it.
+  assert.match(
+    PICKERS,
+    /diffusionRefuses\(fit, diffusionLoad, sharedMemory\)\n\s*\? "exceeds"/,
+  );
+  assert.match(
+    PICKERS,
+    /diffusionRefuses\(fit, diffusionLoad, gpu\.sharedMemory\)\n\s*\? "exceeds"/,
+  );
+  // On a shared pool "VRAM" would name a number the user does not have.
+  assert.ok(
+    PICKERS.includes(
+      'hint: "Needs more memory than this device has. This model will not load."',
+    ),
+  );
+  assert.equal(
+    PICKERS.split("sharedMemory={gpu.sharedMemory}").length - 1,
+    7,
+    "every task-scoped expander learns the pool kind",
+  );
 });
 
 test("aligned meta slots spend their slack on the name", () => {

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -227,13 +227,13 @@ test("each fit verdict is an info mark that explains itself", () => {
   // Only oom fails to load, so only its hint says so; partial offloads and runs slower.
   assert.ok(
     PICKERS.includes(
-      'hint: "Model doesn\'t fit but still works with offloading. Expect slower inference."',
+      'hint: "Model may not fit but still works with offloading. Expect slower inference."',
     ),
   );
   // The Hub says it in the same words, which is the point of sharing the classifier.
   assert.ok(
     HUB_CARD.includes(
-      '"Model doesn\'t fit but still works with offloading. Expect slower inference."',
+      '"Model may not fit but still works with offloading. Expect slower inference."',
     ),
   );
   // Neither surface claims a marginal load can fail. _select_gpus scores against FREE VRAM and
@@ -249,7 +249,7 @@ test("each fit verdict is an info mark that explains itself", () => {
   assert.ok(!HUB_CARD.includes('label: "Won\'t fit"'));
   assert.equal(
     HUB_CARD.split(
-      '"Model doesn\'t fit but still works with offloading. Expect slower inference."',
+      '"Model may not fit but still works with offloading. Expect slower inference."',
     ).length - 1,
     2,
     "partial and oom both",

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -219,10 +219,21 @@ test("chat and the Hub answer the fit question with one formula", () => {
     3,
     "every Hub gate and the inspector",
   );
-  assert.ok(PICKERS.includes("gpuCount: inferenceGpu.deviceCount"));
+  // The count is narrowed WITH the capacity, so it can never describe a different inventory than
+  // the gpuGb beside it. A task page puts the load on one device; charging the per-card reserve
+  // once per host GPU against that one card scored an audio quant at 23.28 GiB where the loader
+  // offers the selected card's 23.5.
+  assert.ok(RECOMMENDED.includes("deviceCount: 1,"), "scoped to one device");
+  assert.ok(PICKERS.includes("gpuCount: rowInferenceGpu.deviceCount"));
+  assert.ok(RECOMMENDED.includes("gpuCount: source.deviceCount ?? opts.gpuCount"));
+  assert.equal(
+    PICKERS.split("gpuCount={expanderGpuCount}").length - 1,
+    7,
+    "every expander counts the scoped inventory",
+  );
   assert.ok(
-    PICKERS.includes("gpuCount: taskScoped ? 1 : inferenceGpu.deviceCount"),
-    "one device on a task page, so one reserve",
+    !PICKERS.includes("gpuCount={inferenceGpu.deviceCount}"),
+    "never the unscoped host count",
   );
   assert.ok(HUB_CARD.includes("gpuCount?: number;"));
   assert.ok(RECOMMENDED.includes("budgetFraction: opts.budgetFraction,"));

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -216,7 +216,14 @@ test("each fit verdict is an info mark that explains itself", () => {
   );
   assert.ok(!PICKERS.includes("Larger than your VRAM and system RAM together"));
   // The training estimator's three words map onto those rather than carrying their own copy.
-  assert.ok(PICKERS.includes("tight: MIGHT_FIT"));
+  // `tight` reaches the badge only from checkVramFit's 75-100% band, a torch estimate that still
+  // fits on the card. Aliasing it to the GGUF copy told those rows they spill into system RAM.
+  assert.ok(PICKERS.includes("tight: DEVICE_TIGHT"));
+  assert.ok(
+    PICKERS.includes(
+      'hint: "Uses nearly all your VRAM, with little headroom for anything else."',
+    ),
+  );
   // Only oom fails to load, so only its hint says so; partial offloads and runs slower.
   assert.ok(
     PICKERS.includes(

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -226,14 +226,32 @@ test("chat and the Hub answer the fit question with one formula", () => {
   assert.ok(RECOMMENDED.includes("deviceCount: 1,"), "scoped to one device");
   assert.ok(PICKERS.includes("gpuCount: rowInferenceGpu.deviceCount"));
   assert.ok(RECOMMENDED.includes("gpuCount: source.deviceCount ?? opts.gpuCount"));
-  assert.equal(
-    PICKERS.split("gpuCount={expanderGpuCount}").length - 1,
-    7,
-    "every expander counts the scoped inventory",
-  );
   assert.ok(
     !PICKERS.includes("gpuCount={inferenceGpu.deviceCount}"),
     "never the unscoped host count",
+  );
+  // Counted against the expanders themselves, not a fixed 7: the fine-tuned / exported GGUF list
+  // is the eighth and was missed, so its host read as one card and over-budgeted at a 1.0 setting.
+  assert.equal(
+    PICKERS.split("gpuCount={expanderGpuCount}").length - 1,
+    7,
+    "every task-scoped expander counts the scoped inventory",
+  );
+  assert.equal(
+    PICKERS.split("gpuCount={gpu.deviceCount}").length - 1,
+    1,
+    "the exported GGUF list counts its own host",
+  );
+  assert.equal(
+    PICKERS.split("<GgufVariantExpander").length - 1,
+    8,
+    "and that is every expander there is",
+  );
+  // The APU window comes out of the RAM tier where the figure is built, so every rule downstream
+  // sees one pool counted once.
+  assert.ok(
+    GPU_INFO.includes("shared_memory: sharesHostMemory({"),
+    "the RAM tier folds unified in",
   );
   assert.ok(HUB_CARD.includes("gpuCount?: number;"));
   assert.ok(RECOMMENDED.includes("budgetFraction: opts.budgetFraction,"));
@@ -311,6 +329,14 @@ test("each fit verdict is an info mark that explains itself", () => {
     ),
   );
   assert.ok(PICKERS.includes("aria-label={verdict.label}"));
+  // An over-budget figure is a TOTAL: `partial` splits across VRAM and RAM, and the number is
+  // weights plus activations plus KV, so "Needs ~47GB VRAM" argued with the offload verdict.
+  assert.ok(
+    PICKERS.includes("`Needs ~${vramEst}GB memory (GPU: ${gpuGb}GB)`"),
+  );
+  assert.ok(!PICKERS.includes("GB VRAM (GPU:"), "no VRAM wording on an overage");
+  // A load that stays on the card still says VRAM, which is what it means there.
+  assert.ok(PICKERS.includes("GB VRAM (tight fit on"));
   // A marginal row is a full GPU load, so it is not dimmed with the over budget ones.
   assert.ok(
     PICKERS.includes(
@@ -324,7 +350,7 @@ test("a GGUF row takes the GGUF verdict, not the torch refusal", () => {
   // This branch used to set "exceeds", the one verdict that says a model will not load. A GGUF is
   // offloaded by llama-server rather than refused, so the row said the opposite of what happens,
   // and it is the verdict shown on the Recommended list where most rows are over budget.
-  assert.ok(PICKERS.includes("status: ggufRowFit(sizeBytes, inferenceGpu),"));
+  assert.ok(PICKERS.includes("status: ggufRowFit(sizeBytes, rowInferenceGpu),"));
   // A boolean here collapsed marginal and partial into "no badge", so a repo whose smallest quant
   // already needed offload rendered as a clean fit beside variant rows saying otherwise.
   assert.ok(!PICKERS.includes("exceedsSize"));

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -14,6 +14,12 @@ const PICKERS = read(
   "../src/features/model-picker/components/model-selector/pickers.tsx",
 );
 const MODELS_TABLE = read("../src/features/hub/catalog/models-table.tsx");
+const CATALOG = read(
+  "../src/features/model-picker/components/model-selector/model-catalog.ts",
+);
+const RECOMMENDED = read(
+  "../src/features/model-picker/components/model-selector/recommended-fit.ts",
+);
 const SIDEBAR = read("../src/components/app-sidebar.tsx");
 const CSS = read("../src/index.css");
 
@@ -58,10 +64,16 @@ test("a row's leading dot starts where its section label does", () => {
   // Section labels sit at px-2.5. The dot is centred in a 14px hover target, so its slot starts
   // at 10 - (14 - 5) / 2 = 5.5px for the dot to land on 10px. px-2 put it at 12.5px.
   assert.match(PICKERS, /py-1\.5 pl-\[5\.5px\] pr-2 text-left text-sm/);
-  const label = PICKERS.slice(PICKERS.indexOf("flex items-center justify-between gap-1 px-2.5"));
+  const label = PICKERS.slice(
+    PICKERS.indexOf("flex items-center justify-between gap-1 px-2.5"),
+  );
   assert.ok(label.startsWith("flex items-center justify-between gap-1 px-2.5"));
   // The 14px hover target is what makes 5.5 the right number; shrinking it would move the dot.
-  assert.ok(PICKERS.includes('className="flex size-[14px] shrink-0 items-center justify-center"'));
+  assert.ok(
+    PICKERS.includes(
+      'className="flex size-[14px] shrink-0 items-center justify-center"',
+    ),
+  );
 });
 
 test("the parameter and size columns are sized to the ink they hold", () => {
@@ -103,14 +115,16 @@ test("an over budget row dims instead of putting a pill on every line", () => {
 
 test("one fit badge, so a colour or reveal change cannot miss a list", () => {
   // The quantization rows had their own copy and stayed red when the pill went orange.
-  assert.equal(PICKERS.split("VRAM_VERDICT = {").length - 1, 1, "one verdict table");
+  assert.equal(
+    PICKERS.split("const VRAM_VERDICT").length - 1,
+    1,
+    "one verdict table",
+  );
   assert.ok(!PICKERS.includes("!text-red-700"), "no red fit badge left");
   assert.ok(!PICKERS.includes(">\n        OOM\n"), "no OOM text pill left");
-  // Variant rows render the shared badge, in the GGUF vocabulary, and opt out of the hover reveal.
-  assert.match(
-    PICKERS,
-    /<VramBadge\n\s*status=\{oom \? "exceeds" : tight \? "tight" : null\}\n\s*source="gguf"\n\s*\/>/,
-  );
+  // Variant rows hand the classifier's verdict straight to the badge, with no second mapping
+  // between them to drift.
+  assert.ok(PICKERS.includes("<VramBadge status={fit} />"));
   assert.equal(
     PICKERS.split(
       '<VramBadge status={vramStatus} source="device" revealOnHover={!selected} />',
@@ -120,45 +134,65 @@ test("one fit badge, so a colour or reveal change cannot miss a list", () => {
   );
 });
 
+test("chat and the Hub answer the fit question with one formula", () => {
+  // The picker carried its own rule: 0.7 of GPU plus 0.7 of RAM against the raw file size, with a
+  // comment claiming it matched _select_gpus. The loader admits against the saved VRAM Budget or
+  // 0.97, over weights PLUS estimated KV, so 0.7 matched neither the loader nor the Hub badge.
+  assert.ok(
+    CATALOG.includes("return classifyGgufFitForDevice(sizeBytes, budget);"),
+    "the catalog classifier delegates",
+  );
+  assert.ok(
+    RECOMMENDED.includes('from "../../../../lib/gguf-fit.ts"'),
+    "and so does the Recommended fit filter",
+  );
+  // No copy of the old budget survives in either GGUF path.
+  for (const [name, src] of [
+    ["pickers", PICKERS],
+    ["recommended-fit", RECOMMENDED],
+  ] as const) {
+    assert.ok(!src.includes("* 0.7"), `${name} has no 0.7 budget left`);
+  }
+  // The saved VRAM Budget now reaches chat. Moving the slider used to change the Hub's verdicts
+  // and leave the picker's untouched.
+  assert.ok(PICKERS.includes("useVramBudgetFraction()"));
+  assert.ok(PICKERS.includes("budgetFraction,"));
+});
+
 test("each fit verdict is an info mark that explains itself", () => {
-  // A pill shouted a three letter acronym; the mark says what it means on hover. Tight spills
-  // past VRAM into system RAM, oom clears neither budget, so the two hints differ.
+  // A pill shouted a three letter acronym; the mark says what it means on hover.
   assert.ok(PICKERS.includes("icon={InformationCircleIcon}"));
-  // A GGUF over budget still loads: llama-server hands it to --fit.
+  // Keyed by the Hub's five classes, which is how the picker gained the tier it was missing:
+  // over budget but still card-sized needs no system RAM, so it fires on unified memory too.
+  assert.ok(PICKERS.includes("marginal: MIGHT_FIT"));
+  assert.ok(PICKERS.includes("partial: OFFLOADS"));
+  assert.ok(PICKERS.includes("oom: WONT_FIT"));
+  // The training estimator's three words map onto those rather than carrying their own copy.
+  assert.ok(PICKERS.includes("tight: MIGHT_FIT"));
+  assert.ok(PICKERS.includes("exceeds: WONT_FIT"));
+  // Only oom fails to load, so only its hint says so; partial offloads and runs slower.
   assert.ok(
     PICKERS.includes(
-      "hint: \"Model may not fit but still works with offloading. Expect slower inference.\"",
-    ),
-  );
-  // A model row's `tight` comes from checkVramFit, which is 75-100% of VRAM: it fits on the card
-  // entirely, so telling that row it spills into system RAM was false. The two vocabularies now
-  // get their own copy, chosen at the call site.
-  assert.ok(
-    PICKERS.includes(
-      'hint: "Only fits by spilling into system RAM. Expect slower inference."',
+      'hint: "Model doesn\'t fit but can still work with offloading. Expect slower inference."',
     ),
   );
   assert.ok(
     PICKERS.includes(
-      'hint: "Uses nearly all your VRAM, with little headroom for anything else."',
+      'hint: "Larger than your VRAM and system RAM together. This model will not load."',
     ),
   );
-  // And a model row's `exceeds` no longer promises a slow load: it can be a curated pipeline whose
-  // loader refuses CPU offload outright.
-  assert.ok(
-    PICKERS.includes('hint: "Needs more memory than this device has."'),
-  );
-  assert.ok(PICKERS.includes('source="gguf"'));
-  assert.ok(PICKERS.includes('source="device"'));
-  // A selected over-budget row is exempt from dimming, so hiding its mark left it with no verdict
-  // at all until hovered, which is nothing at rest and nothing on touch.
-  assert.match(PICKERS, /exceeds &&\n\s*!selected &&/);
-  // And the mark suppresses the button it sits inside, so reading it cannot start a download.
-  assert.match(PICKERS, /onClick=\{\(event\) => \{\n\s*event\.preventDefault\(\);/);
-  // Both marks are reachable by screen readers without the tooltip.
+  // Marks are reachable by screen readers without the tooltip.
+  assert.ok(PICKERS.includes('label: "Partial offload"'));
+  assert.ok(PICKERS.includes('label: "Might fit"'));
   assert.ok(PICKERS.includes('label: "Does not fit"'));
-  assert.ok(PICKERS.includes('label: "Tight fit"'));
   assert.ok(PICKERS.includes("aria-label={verdict.label}"));
+  // A marginal row is a full GPU load, so it is not dimmed with the over budget ones.
+  assert.ok(
+    PICKERS.includes(
+      'return status === "partial" || status === "ram" || status === "oom" || status === "exceeds";',
+    ) || /function isOverBudget[\s\S]{0,320}"exceeds"/.test(PICKERS),
+    "dimming covers the orange verdicts only",
+  );
 });
 
 test("aligned meta slots spend their slack on the name", () => {

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -22,6 +22,7 @@ const CATALOG = read(
 const RECOMMENDED = read(
   "../src/features/model-picker/components/model-selector/recommended-fit.ts",
 );
+const GPU_INFO = read("../src/hooks/use-gpu-info.ts");
 const SIDEBAR = read("../src/components/app-sidebar.tsx");
 const CSS = read("../src/index.css");
 
@@ -128,7 +129,7 @@ test("one fit badge, so a colour or reveal change cannot miss a list", () => {
   // between them to drift.
   assert.match(
     PICKERS,
-    /<VramBadge\n\s*status=\{\n\s*diffusionRefuses\(fit, diffusionLoad, sharedMemory\)/,
+    /<VramBadge\n\s*status=\{\n\s*diffusionRefuses\(fit, diffusionLoad, hostPooledMemory\)/,
   );
   assert.equal(
     PICKERS.split("<VramBadge status={vramStatus} revealOnHover={!selected} />")
@@ -182,12 +183,22 @@ test("chat and the Hub answer the fit question with one formula", () => {
   assert.match(PICKERS, /diffusionLoad\n\s*\? classifyMediaGgufFit\(/);
   // Both gates read the flag the same way, or one hides a row the other keeps.
   assert.ok(PICKERS.includes("mediaLoad: diffusionLoad,"));
-  assert.ok(RECOMMENDED.includes("mediaLoad: opts.diffusionLoad }"));
   // And every media call site sets the flag, or the guard silently does nothing.
   assert.equal(
     PICKERS.split("diffusionLoad={diffusionLoad}").length - 1,
     7,
     "every task-scoped expander",
+  );
+  // The RAM tier is dropped on a host pool, or the media rule adds the APU's window to the very
+  // RAM it is a window INTO and returns partial for a load the planner refuses.
+  assert.ok(PICKERS.includes("function mediaRamBudgetGb("));
+  assert.ok(
+    PICKERS.includes("return hostPooled ? 0 : systemRamGb;"),
+    "no RAM budget beside a host pool",
+  );
+  assert.ok(
+    RECOMMENDED.includes("hostPooledMemory ? 0 : (systemRamGb ?? 0)"),
+    "the gate drops it too",
   );
   // The saved VRAM Budget now reaches chat. Moving the slider used to change the Hub's verdicts
   // and leave the picker's untouched.
@@ -198,13 +209,22 @@ test("chat and the Hub answer the fit question with one formula", () => {
   assert.ok(HUB_PAGE.includes("useVramBudgetFraction()"));
   assert.match(
     HUB_PAGE,
-    /hfModelFitsDevice\(row\.result, inferenceGpu, \{ budgetFraction \}\)/,
+    /hfModelFitsDevice\(row\.result, inferenceGpu, \{\n\s*budgetFraction,/,
   );
+  assert.ok(RECOMMENDED.includes("budgetFraction?: number;"));
+  // Both surfaces count the cards, or the Hub badge and the picker badge diverge again the moment
+  // the VRAM Budget goes above the default on a multi-GPU host.
+  assert.equal(
+    HUB_PAGE.split("gpuCount: inferenceGpu.deviceCount").length - 1,
+    3,
+    "every Hub gate and the inspector",
+  );
+  assert.ok(PICKERS.includes("gpuCount: inferenceGpu.deviceCount"));
   assert.ok(
-    RECOMMENDED.includes(
-      "opts: { budgetFraction?: number; mediaLoad?: boolean } = {},",
-    ),
+    PICKERS.includes("gpuCount: taskScoped ? 1 : inferenceGpu.deviceCount"),
+    "one device on a task page, so one reserve",
   );
+  assert.ok(HUB_CARD.includes("gpuCount?: number;"));
   assert.ok(RECOMMENDED.includes("budgetFraction: opts.budgetFraction,"));
 });
 
@@ -318,16 +338,25 @@ test("a diffusion model too big for a shared pool is refused, not offloaded", ()
   // with offloading is the worst thing this badge could say there.
   assert.ok(PICKERS.includes("function diffusionRefuses("));
   assert.ok(
-    PICKERS.includes('return fit === "oom" && diffusionLoad && sharedMemory;'),
+    PICKERS.includes('return fit === "oom" && diffusionLoad && hostPooled;'),
+  );
+  // The LOAD DEVICE's pool, folding unified_memory in. hardware.py sets shared_memory only on
+  // Windows, so a Linux ROCm APU arrives unified true / shared false while diffusion_memory.py
+  // still calls it unified_memory and refuses. The aggregate shared flag missed that host.
+  assert.ok(!PICKERS.includes("gpu.sharedMemory"), "not the aggregate flag");
+  assert.ok(
+    GPU_INFO.includes("loadDeviceSharesHostMemory: sharesHostMemory({"),
+    "the flag is the load device's, folded",
   );
   // Both the quant rows and the parent row take it.
   assert.match(
     PICKERS,
-    /diffusionRefuses\(fit, diffusionLoad, sharedMemory\)\n\s*\? "exceeds"/,
+    /diffusionRefuses\(fit, diffusionLoad, hostPooledMemory\)\n\s*\? "exceeds"/,
   );
-  assert.match(
-    PICKERS,
-    /diffusionRefuses\(fit, diffusionLoad, gpu\.sharedMemory\)\n\s*\? "exceeds"/,
+  assert.ok(
+    PICKERS.includes(
+      "diffusionRefuses(fit, diffusionLoad, gpu.loadDeviceSharesHostMemory)",
+    ),
   );
   // On a shared pool "VRAM" would name a number the user does not have.
   assert.ok(
@@ -336,7 +365,8 @@ test("a diffusion model too big for a shared pool is refused, not offloaded", ()
     ),
   );
   assert.equal(
-    PICKERS.split("sharedMemory={gpu.sharedMemory}").length - 1,
+    PICKERS.split("hostPooledMemory={gpu.loadDeviceSharesHostMemory}").length -
+      1,
     7,
     "every task-scoped expander learns the pool kind",
   );

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -342,6 +342,17 @@ test("a diffusion model too big for a shared pool is refused, not offloaded", ()
   );
 });
 
+test("the row tooltip reports the figure the verdict was reached with", () => {
+  // classifyGgufFit scores weights PLUS activations and KV, so a 20 GiB quant needing 24 GiB read
+  // "tight fit" beside a tooltip saying "~20GB VRAM". The media rule scores raw size, so it keeps
+  // the raw number.
+  assert.ok(PICKERS.includes("requiredGgufMemoryGb(sizeBytes)"));
+  assert.match(
+    PICKERS,
+    /diffusionLoad\n\s*\? sizeBytes \/ 1024 \*\* 3\n\s*: requiredGgufMemoryGb\(sizeBytes\)/,
+  );
+});
+
 test("aligned meta slots spend their slack on the name", () => {
   // Centring a lone glyph splits the slack either side of it, reading as a gap on both sides.
   assert.ok(

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -165,6 +165,11 @@ test("chat and the Hub answer the fit question with one formula", () => {
     PICKERS,
     /if \(taskScoped\) \{\n\s*return classifyMediaGgufFit\(/,
   );
+  // Parent rows and the fit gate take the same rule as the quant rows under them, or a media row
+  // reads as fitting while everything inside it reads as oom.
+  assert.match(PICKERS, /Boolean\(task\)\n\s*\? classifyMediaGgufFit\(/);
+  assert.ok(PICKERS.includes("mediaLoad: taskScoped && r.isGguf,"));
+  assert.ok(RECOMMENDED.includes("mediaLoad: opts.taskScoped }"));
   // And every media call site sets the flag, or the guard silently does nothing.
   assert.equal(
     PICKERS.split("taskScoped={Boolean(task)}").length - 1,
@@ -180,10 +185,14 @@ test("chat and the Hub answer the fit question with one formula", () => {
   assert.ok(HUB_PAGE.includes("useVramBudgetFraction()"));
   assert.match(
     HUB_PAGE,
-    /hfModelFitsDevice\(row\.result, inferenceGpu, budgetFraction\)/,
+    /hfModelFitsDevice\(row\.result, inferenceGpu, \{ budgetFraction \}\)/,
   );
-  assert.ok(RECOMMENDED.includes("budgetFraction?: number,"));
-  assert.ok(RECOMMENDED.includes("opts.budgetFraction,"));
+  assert.ok(
+    RECOMMENDED.includes(
+      "opts: { budgetFraction?: number; mediaLoad?: boolean } = {},",
+    ),
+  );
+  assert.ok(RECOMMENDED.includes("budgetFraction: opts.budgetFraction,"));
 });
 
 test("each fit verdict is an info mark that explains itself", () => {

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -14,6 +14,7 @@ const PICKERS = read(
   "../src/features/model-picker/components/model-selector/pickers.tsx",
 );
 const MODELS_TABLE = read("../src/features/hub/catalog/models-table.tsx");
+const HUB_CARD = read("../src/features/hub/catalog/gguf-download-card.tsx");
 const CATALOG = read(
   "../src/features/model-picker/components/model-selector/model-catalog.ts",
 );
@@ -173,9 +174,23 @@ test("each fit verdict is an info mark that explains itself", () => {
   // Only oom fails to load, so only its hint says so; partial offloads and runs slower.
   assert.ok(
     PICKERS.includes(
-      'hint: "Model doesn\'t fit but can still work with offloading. Expect slower inference."',
+      'hint: "Model doesn\'t fit but still works with offloading. Expect slower inference."',
     ),
   );
+  // The Hub says it in the same words, which is the point of sharing the classifier.
+  assert.ok(
+    HUB_CARD.includes(
+      '"Model doesn\'t fit but still works with offloading. Expect slower inference."',
+    ),
+  );
+  // Neither surface claims a marginal load can fail. _select_gpus scores against FREE VRAM and
+  // hands a miss to --fit, so a busy card costs speed, not the load.
+  const mightFitHint =
+    "Fits your GPU with almost no room to spare. If other apps are using VRAM, it offloads and runs slower.";
+  assert.ok(PICKERS.includes(mightFitHint));
+  assert.ok(HUB_CARD.includes(mightFitHint));
+  assert.ok(!PICKERS.includes("Loading can fail while other apps"));
+  assert.ok(!HUB_CARD.includes("Within the last GB of VRAM headroom"));
   assert.ok(
     PICKERS.includes(
       'hint: "Larger than your VRAM and system RAM together. This model will not load."',

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -178,6 +178,28 @@ test("chat and the Hub answer the fit question with one formula", () => {
     "no task-wide media rule",
   );
   assert.ok(RECOMMENDED.includes("mediaLoad: opts.diffusionLoad"));
+  // The RULE and the DEVICE SOURCE both follow the runtime that places the row. A diffusion load
+  // is torch whatever the file format is, and on a Vulkan chat build inferenceGpu is a different
+  // device set: it can see a card torch cannot, so a media GGUF was badged and recommended
+  // against capacity the diffusion loader never gets.
+  assert.ok(
+    RECOMMENDED.includes(
+      "opts.diffusionLoad || !opts.isGguf ? opts.gpu : opts.inferenceGpu",
+    ),
+  );
+  assert.ok(
+    PICKERS.includes(
+      "diffusionLoad || !r.isGguf ? rowGpu : rowInferenceGpu",
+    ),
+  );
+  assert.ok(
+    PICKERS.includes("const expanderBudgetGpu = diffusionLoad ? gpu : inferenceGpu;"),
+  );
+  // And every expander reads that one budget, rather than reaching for inferenceGpu itself.
+  assert.ok(
+    !PICKERS.includes("inferenceGpu.systemRamAvailableGb"),
+    "no expander takes the GGUF backend's RAM directly",
+  );
   // Parent rows and the fit gate take the same rule as the quant rows under them, or a media row
   // reads as fitting while everything inside it reads as oom.
   assert.match(PICKERS, /diffusionLoad\n\s*\? classifyMediaGgufFit\(/);

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -168,7 +168,8 @@ test("chat and the Hub answer the fit question with one formula", () => {
   // Parent rows and the fit gate take the same rule as the quant rows under them, or a media row
   // reads as fitting while everything inside it reads as oom.
   assert.match(PICKERS, /Boolean\(task\)\n\s*\? classifyMediaGgufFit\(/);
-  assert.ok(PICKERS.includes("mediaLoad: taskScoped && r.isGguf,"));
+  // Both gates read the flag the same way, or one hides a row the other keeps.
+  assert.ok(PICKERS.includes("mediaLoad: taskScoped,"));
   assert.ok(RECOMMENDED.includes("mediaLoad: opts.taskScoped }"));
   // And every media call site sets the flag, or the guard silently does nothing.
   assert.equal(
@@ -250,6 +251,15 @@ test("each fit verdict is an info mark that explains itself", () => {
   // Marks are reachable by screen readers without the tooltip.
   assert.ok(PICKERS.includes('label: "Might fit"'));
   assert.ok(PICKERS.includes('label: "Does not fit"'));
+  // "will not load" is right for `exceeds`, which only ever comes from a torch row: inference.py
+  // calls raise_if_offloaded after loading, and that raises ValueError on any CPU or disk offload
+  // ("Inference does not support models loaded with CPU or disk offload"). A GGUF over budget is
+  // handed to --fit instead, which is why it says the opposite.
+  assert.ok(
+    PICKERS.includes(
+      'hint: "Needs more VRAM than this device has. This model will not load."',
+    ),
+  );
   assert.ok(PICKERS.includes("aria-label={verdict.label}"));
   // A marginal row is a full GPU load, so it is not dimmed with the over budget ones.
   assert.ok(

--- a/studio/frontend/tests/recommended-catalog-seeds.test.ts
+++ b/studio/frontend/tests/recommended-catalog-seeds.test.ts
@@ -377,6 +377,39 @@ test("both search lists judge a curated id the same way", () => {
   assert.equal(searchRowFitsDevice({ id: BNB, totalParams: 6e9 }, opts), false);
 });
 
+test("the Hub fit gate judges a media GGUF by the planner that places it", () => {
+  // The reported case: 52 GiB of video GGUF on a 64 GiB Mac. llama.cpp allows 52 * 1.15 + 1 =
+  // 60.8 against a 63.5 GiB budget, so the "Fits on device" filter kept it; the diffusion planner
+  // allows 44.8 and cannot offload on a host pool, so it never places.
+  const mac = {
+    available: true,
+    budgetKnown: true,
+    memoryTotalGb: 64,
+    maxDeviceMemoryGb: 64,
+    loadDeviceMemoryGb: 64,
+    loadDeviceSharedMemory: true,
+    loadDeviceSharesHostMemory: true,
+    systemRamAvailableGb: 0,
+    systemRamAvailableHostGb: 64,
+    deviceCount: 1,
+  };
+  const row = {
+    id: "unsloth/Some-Video-GGUF",
+    isGguf: true,
+    estimatedSizeBytes: 52 * 1024 ** 3,
+  };
+  assert.equal(hfModelFitsDevice(row, mac, { gpuCount: 1 }), true);
+  const scoped = loadScopedGpu(mac, true);
+  assert.equal(
+    hfModelFitsDevice(row, scoped, {
+      gpuCount: scoped.deviceCount,
+      mediaLoad: true,
+      hostPooledMemory: true,
+    }),
+    false,
+  );
+});
+
 test("a media GGUF is sized against torch, not the GGUF backend", () => {
   // A Vulkan llama.cpp build sees cards torch cannot, so inferenceGpu is a different inventory
   // (use-gpu-info.ts keeps the torch view for diffusion for exactly this reason). Picking the

--- a/studio/frontend/tests/recommended-catalog-seeds.test.ts
+++ b/studio/frontend/tests/recommended-catalog-seeds.test.ts
@@ -9,6 +9,7 @@ import {
   VIDEO_CATALOG,
   curatedSizeBytesFor,
 } from "../src/features/model-picker/components/model-selector/model-catalog.ts";
+import { classifyGgufFit } from "../src/lib/gguf-fit.ts";
 import {
   hfModelFitsDevice,
   loadScopedGpu,
@@ -304,6 +305,53 @@ test("a dedicated task device keeps RAM reserved by a shared GPU", () => {
   assert.equal(loadScopedGpu(mixedHost, true).systemRamAvailableGb, 40);
   assert.equal(loadScopedGpu(sharedLoadDevice, true).systemRamAvailableGb, 8);
   assert.equal(loadScopedGpu(mixedHost, false), mixedHost);
+
+  // A Linux ROCm APU reports unified_memory without shared_memory, so it used to take the
+  // raw-host branch above and undo the very subtraction that keeps its GTT window out of the RAM
+  // tier. The folded flag is what the reservation question actually turns on.
+  const linuxApu = {
+    ...mixedHost,
+    loadDeviceMemoryGb: 32,
+    loadDeviceSharedMemory: false,
+    loadDeviceSharesHostMemory: true,
+  };
+  assert.equal(loadScopedGpu(linuxApu, true).systemRamAvailableGb, 8);
+  // The dedicated card still claims it back: this gate narrowed, it did not close.
+  assert.equal(
+    loadScopedGpu({ ...linuxApu, loadDeviceSharesHostMemory: false }, true)
+      .systemRamAvailableGb,
+    40,
+  );
+});
+
+test("a unified GPU window is not also offered as system RAM", () => {
+  // 48 GiB host, a 32 GiB GTT window. gpuMemoryTotalsGb counts that window as DEDICATED when
+  // shared_memory is false, so systemRamAvailableGb kept the whole 48 and classifyGgufFit added
+  // half of it to the window a second time: a ~43 GiB file needing ~50 scored `partial` against
+  // an invented ~55 GiB budget, promising an offload into memory the machine does not have.
+  const apu = {
+    available: true,
+    budgetKnown: true,
+    memoryTotalGb: 32,
+    maxDeviceMemoryGb: 32,
+    loadDeviceMemoryGb: 32,
+    loadDeviceSharedMemory: false,
+    loadDeviceSharesHostMemory: true,
+    systemRamAvailableHostGb: 48,
+    deviceCount: 1,
+  };
+  const scoped = (systemRamAvailableGb: number) =>
+    loadScopedGpu({ ...apu, systemRamAvailableGb }, true);
+  const verdict = (g: ReturnType<typeof scoped>) =>
+    classifyGgufFit(43 * 1024 ** 3, {
+      gpuGb: g.memoryTotalGb,
+      systemRamGb: g.systemRamAvailableGb,
+      gpuCount: g.deviceCount,
+    });
+  // Unsubtracted, the way a Linux APU used to arrive.
+  assert.equal(verdict(scoped(48)), "partial");
+  // Subtracted once, the way Windows and Apple Silicon always were.
+  assert.equal(verdict(scoped(48 - 32)), "oom");
 });
 
 test("both search lists judge a curated id the same way", () => {

--- a/studio/frontend/tests/recommended-catalog-seeds.test.ts
+++ b/studio/frontend/tests/recommended-catalog-seeds.test.ts
@@ -272,6 +272,16 @@ test("a task row is sized against the device the load lands on", () => {
   const sdxl = seed(SDXL);
   assert.equal(hfModelFitsDevice(sdxl, twoCards), true);
   assert.equal(hfModelFitsDevice(sdxl, loadScopedGpu(twoCards, true)), false);
+  // The device COUNT narrows with the capacity. classifyGgufFit charges the loader's per-card VRAM
+  // reserve once per card, so leaving the host count of 2 on a one-card budget held back two
+  // floors against a single device and under-budgeted every scoped quant.
+  assert.equal(loadScopedGpu(twoCards, false).deviceCount, undefined);
+  assert.equal(loadScopedGpu(twoCards, true).deviceCount, 1);
+  const twoOfThree = { ...twoCards, deviceCount: 3 };
+  assert.equal(loadScopedGpu(twoOfThree, false).deviceCount, 3);
+  assert.equal(loadScopedGpu(twoOfThree, true).deviceCount, 1);
+  // An unscoped load keeps the host count, so chat still charges one floor per card.
+  assert.equal(loadScopedGpu(twoOfThree, true).memoryTotalGb, 8);
 });
 
 test("a dedicated task device keeps RAM reserved by a shared GPU", () => {

--- a/studio/frontend/tests/recommended-catalog-seeds.test.ts
+++ b/studio/frontend/tests/recommended-catalog-seeds.test.ts
@@ -377,6 +377,41 @@ test("both search lists judge a curated id the same way", () => {
   assert.equal(searchRowFitsDevice({ id: BNB, totalParams: 6e9 }, opts), false);
 });
 
+test("a media GGUF is sized against torch, not the GGUF backend", () => {
+  // A Vulkan llama.cpp build sees cards torch cannot, so inferenceGpu is a different inventory
+  // (use-gpu-info.ts keeps the torch view for diffusion for exactly this reason). Picking the
+  // budget by FILE FORMAT sent an Images GGUF to the Vulkan card's capacity, which the diffusion
+  // loader never gets to use.
+  const vulkanCard = {
+    available: true,
+    budgetKnown: true,
+    memoryTotalGb: 24,
+    maxDeviceMemoryGb: 24,
+    loadDeviceMemoryGb: 24,
+    systemRamAvailableGb: 0,
+  };
+  const torchCard = { ...vulkanCard, memoryTotalGb: 12, maxDeviceMemoryGb: 12, loadDeviceMemoryGb: 12 };
+  // 14 GiB: inside the 24 GiB card's media budget (16.8), past the 12 GiB one's (8.4).
+  const row = { id: "unsloth/Some-Image-GGUF", estimatedSizeBytes: 14 * 1024 ** 3 };
+  const opts = {
+    isGguf: true,
+    gpu: torchCard,
+    inferenceGpu: vulkanCard,
+    taskScoped: true,
+    diffusionLoad: true,
+  };
+  assert.equal(searchRowFitsDevice(row, opts), false);
+  // Chat is the case the GGUF backend's own inventory is right for, and it still gets it.
+  assert.equal(
+    searchRowFitsDevice(row, {
+      ...opts,
+      taskScoped: false,
+      diffusionLoad: false,
+    }),
+    true,
+  );
+});
+
 test("a search row is sized against the device a task load lands on", () => {
   const twoCards = {
     available: true,

--- a/studio/frontend/tests/recommended-catalog-seeds.test.ts
+++ b/studio/frontend/tests/recommended-catalog-seeds.test.ts
@@ -84,7 +84,11 @@ test("a listing row that passes the filters takes over its seed, in catalog orde
 });
 
 test("device fit is judged on whichever row renders", () => {
-  const small = { memoryTotalGb: 6, systemRamAvailableGb: 0, budgetKnown: true };
+  const small = {
+    memoryTotalGb: 6,
+    systemRamAvailableGb: 0,
+    budgetKnown: true,
+  };
   const big = { memoryTotalGb: 80, systemRamAvailableGb: 0, budgetKnown: true };
   const listedLtx: Row = {
     id: LTX,
@@ -129,7 +133,11 @@ test("device fit is judged on whichever row renders", () => {
 });
 
 test("an unlisted seed is sized from its id, and hidden when it cannot be", () => {
-  const small = { memoryTotalGb: 6, systemRamAvailableGb: 0, budgetKnown: true };
+  const small = {
+    memoryTotalGb: 6,
+    systemRamAvailableGb: 0,
+    budgetKnown: true,
+  };
   // "LTX-2.3" has no "<n>B" token, so requireKnown hides it; "klein-9B" reads
   // as 9B -> 3.6 GB, inside the 4.2 GB budget.
   assert.equal(hfModelFitsDevice(SEEDS[0], small), false);
@@ -161,7 +169,11 @@ const seed = (id: string, catalog = IMAGE_CATALOG): Row => ({
 
 test("a catalog-sized seed is judged on the catalog size, not on its id", () => {
   // 24 GB card -> 16.8 GB budget.
-  const card = { memoryTotalGb: 24, systemRamAvailableGb: 0, budgetKnown: true };
+  const card = {
+    memoryTotalGb: 24,
+    systemRamAvailableGb: 0,
+    budgetKnown: true,
+  };
   const sdxl = seed(SDXL);
   const wan = seed(WAN, VIDEO_CATALOG);
   // SDXL Turbo is 8 GB but its id has no "<n>B" token to guess from; Wan 2.2
@@ -185,7 +197,11 @@ test("a catalog-sized seed is judged on the catalog size, not on its id", () => 
 });
 
 test("a listing row still overrides the catalog size it seeded with", () => {
-  const card = { memoryTotalGb: 24, systemRamAvailableGb: 0, budgetKnown: true };
+  const card = {
+    memoryTotalGb: 24,
+    systemRamAvailableGb: 0,
+    budgetKnown: true,
+  };
   // GGUF groups carry no catalog size, so an unsized GGUF seed stays hidden.
   assert.equal(curatedSizeBytesFor(LTX, VIDEO_CATALOG), undefined);
   assert.equal(hfModelFitsDevice({ id: LTX, isGguf: true }, card), false);
@@ -340,4 +356,28 @@ test("a GPU-less host keeps its unified-memory budget", () => {
     systemRamAvailableGb: 64,
   };
   assert.equal(loadScopedGpu(mac, true), mac);
+});
+
+test("a media row is judged by the rule its quant rows use", () => {
+  // Images / Video place a GGUF through the diffusion backend, whose budget on a 64 GiB unified
+  // host is (total - 20% reserve) * 0.85 = 43.5 GiB (diffusion_memory.py). llama.cpp allows 62.1.
+  // Judging the parent row by one and its quants by the other let a row read as fitting while
+  // everything inside it read as oom.
+  const mac = { memoryTotalGb: 64, systemRamAvailableGb: 0, budgetKnown: true };
+  const row = {
+    id: "unsloth/Some-Image-Model-GGUF",
+    isGguf: true,
+    // 50 GiB, which the two rules disagree about: 50 > 44.8, but 50 * 1.15 + 1 = 58.5 <= 62.1.
+    curatedSizeBytes: 50 * 1024 ** 3,
+  };
+  assert.equal(
+    hfModelFitsDevice(row, mac),
+    true,
+    "chat keeps the llama.cpp rule",
+  );
+  assert.equal(
+    hfModelFitsDevice(row, mac, { mediaLoad: true }),
+    false,
+    "a media row does not",
+  );
 });

--- a/studio/frontend/tests/recommended-catalog-seeds.test.ts
+++ b/studio/frontend/tests/recommended-catalog-seeds.test.ts
@@ -380,4 +380,9 @@ test("a media row is judged by the rule its quant rows use", () => {
     false,
     "a media row does not",
   );
+  // Every format on a task page, not just GGUF: this rule is the budget all of them had before the
+  // classifiers were merged, and restricting it to GGUF left the list gate and the search gate
+  // answering differently for one row.
+  const safetensors = { ...row, id: "unsloth/Some-Image-Model", isGguf: false };
+  assert.equal(hfModelFitsDevice(safetensors, mac, { mediaLoad: true }), false);
 });

--- a/studio/frontend/tests/recommended-curated-row-metadata.test.ts
+++ b/studio/frontend/tests/recommended-curated-row-metadata.test.ts
@@ -283,8 +283,12 @@ for (const declaration of ["recommendedMeta", "recommendedVramMap"]) {
     assert.ok(estimatorAt >= 0, `${declaration} no longer estimates VRAM at all`);
     assert.ok(curatedAt < estimatorAt, "the QLoRA estimator runs first");
     // A task load puts the whole pipeline on one device, and torch is not the GGUF backend's
-    // inventory, so the budget is the load-scoped one the list's own fit filter uses.
-    assert.match(text, /artifactBudget\(loadScopedGpu\(gpu, Boolean\(task\)\)\)/);
+    // inventory, so the budget is the load-scoped one the list's own fit filter uses. Inline or
+    // via a local, as long as what reaches artifactBudget went through loadScopedGpu(gpu, ...).
+    assert.match(
+      text,
+      /artifactBudget\(loadScopedGpu\(gpu, Boolean\(task\)\)\)|rowGpu = loadScopedGpu\(gpu, Boolean\(task\)\);[\s\S]{0,400}artifactBudget\(rowGpu\)/,
+    );
   });
 }
 
@@ -313,9 +317,12 @@ test("GGUF rows keep the inference backend's budget", () => {
     declarationText("recommendedMeta"),
     /ggufRowFit\(sizeBytes, rowInferenceGpu\)/,
   );
+  // And it is the inventory of the runtime that PLACES the row, not of its file format: an
+  // Images or Video GGUF goes to torch, which on a Vulkan chat build is a different device set
+  // than llama.cpp reports.
   assert.match(
     declarationText("recommendedMeta"),
-    /rowInferenceGpu = loadScopedGpu\(inferenceGpu, Boolean\(task\)\)/,
+    /rowInferenceGpu = diffusionLoad\n\s*\? rowGpu\n\s*: loadScopedGpu\(inferenceGpu, Boolean\(task\)\)/,
   );
 });
 

--- a/studio/frontend/tests/recommended-curated-row-metadata.test.ts
+++ b/studio/frontend/tests/recommended-curated-row-metadata.test.ts
@@ -309,7 +309,7 @@ test("GGUF rows keep the inference backend's budget", () => {
   // They load through llama.cpp, so its inventory is the right one for them.
   assert.match(
     declarationText("recommendedMeta"),
-    /exceedsSize\(sizeBytes, inferenceGpu\)/,
+    /ggufRowFit\(sizeBytes, inferenceGpu\)/,
   );
 });
 

--- a/studio/frontend/tests/recommended-curated-row-metadata.test.ts
+++ b/studio/frontend/tests/recommended-curated-row-metadata.test.ts
@@ -306,10 +306,16 @@ test("every list that judges a row against the device asks the same helper", () 
 });
 
 test("GGUF rows keep the inference backend's budget", () => {
-  // They load through llama.cpp, so its inventory is the right one for them.
+  // They load through llama.cpp, so its inventory is the right one for them, load-scoped the way
+  // the quant rows and the fit filter scope it: a task load lands on ONE device, and judging the
+  // parent by the multi-GPU sum let a downloaded media row read as safe over oom variants.
   assert.match(
     declarationText("recommendedMeta"),
-    /ggufRowFit\(sizeBytes, inferenceGpu\)/,
+    /ggufRowFit\(sizeBytes, rowInferenceGpu\)/,
+  );
+  assert.match(
+    declarationText("recommendedMeta"),
+    /rowInferenceGpu = loadScopedGpu\(inferenceGpu, Boolean\(task\)\)/,
   );
 });
 


### PR DESCRIPTION
Stacked on #10007, which adds the info mark this PR gives more tiers to. Base is `studio-picker-oom-on-hover`; happy to retarget to `main` once that merges.

## The problem

Chat and the Hub answered "will this GGUF fit?" with two different formulas, so they disagreed about the same file on the same machine.

The Hub uses `lib/gguf-fit.ts`, which mirrors the backend: `_select_gpus` admits against `_active_vram_fraction()`, the user's saved VRAM Budget or `_CTX_FIT_VRAM_FRACTION = 0.97`, and its docstring says `model_size_bytes` "should include weights and estimated KV cache".

The picker carried its own rule instead, `0.7 * GPU + 0.7 * RAM` against the raw file size, in seven places across three files. Its comment claimed to match `_select_gpus`. It did not, and 0.7 appears nowhere in the backend.

On a 64 GB host that put the two surfaces 9 GB apart:

| | fits up to | middle tier | does not fit |
| --- | --- | --- | --- |
| Picker (before) | 48 GB shown | never reachable | above 48 GB |
| Hub | 57 GB shown | 57 to 59 GB | above 59 GB |

So the Hub badged a 53 GB quant "Full offload likely possible" while the picker badged 52 GB as not fitting. The picker also never read the VRAM Budget setting, so moving that slider changed the Hub's verdicts and left chat's alone.

The missing middle tier has its own cause. The Hub's amber tier is "over your budget, still card-sized", which needs no system RAM. The picker's was defined solely as RAM offload, and on unified memory `systemRamAvailableGb` is correctly 0 (`systemRamAvailableOutsideSharedPoolGb` subtracts the host-backed shared pool so the same 64 GB is not counted twice). That made the tier an empty range on every Apple Silicon machine.

## The change

Both GGUF paths now call `lib/gguf-fit.ts`:

- `classifyGgufFit` in `model-catalog.ts` delegates, and gains `budgetFraction`.
- `fitsDevice` in `recommended-fit.ts` delegates. It gates the "Fits on device" filter as well as the row badge, so leaving it behind would have kept the same bug in the filter.
- `pickers.tsx` drops its inline copy of the formula and passes `useVramBudgetFraction()`.

The badge keys off that file's five classes, mapping the training estimator's `tight` and `exceeds` onto them rather than keeping a second set of colours and copy:

| Class | Mark | Says |
| --- | --- | --- |
| `fits` | none | |
| `marginal` | yellow | Fits your GPU with almost no room to spare. If other apps are using VRAM, it offloads and runs slower. |
| `partial` | orange | Model may not fit but still works with offloading. Expect slower inference. |
| `ram` | orange | No GPU detected. Runs on system RAM and CPU. Expect much slower inference. |
| `oom` | orange | Model may not fit but still works with offloading. Expect slower inference. |

Row dimming now covers the orange verdicts only. A `marginal` row is a full GPU load and should not read as over budget.


## Wording

Both surfaces now use the same two sentences, which is the payoff of sharing the classifier.

`partial` and `oom` say the same sentence deliberately. llama-server never refuses a GGUF on size: `_select_gpus` returns `(None, use_fit=True)` and `--fit` offloads the rest to CPU, and there is no size-based refusal anywhere on that path. Giving `oom` its own "will not load" copy also put that claim in front of every unified-memory user, since the offload tier needs system RAM beside VRAM and there it is one pool. The refusal copy survives only for `exceeds`, which reaches the badge from a torch pipeline or the QLoRA estimate, neither of which has a `--fit` to fall back on.

The GGUF **model rows** needed the same treatment. Their branch in `recommendedMeta` set `"exceeds"`, which is the torch verdict, so a GGUF repo whose smallest sizable quant is over budget claimed a refusal that never happens. That is most of the Recommended list on a normal device. They now set `"oom"` and read like the quant rows below them, and `"exceeds"` is left to the two curated branches that judge torch pipelines, where the refusal is true because the pipeline goes wholly on one device with no `--fit`.

The `marginal` copy also had a factual error in both places. The Hub said "loading can fail if other apps are using GPU memory" and the picker said the same. `_select_gpus` scores against FREE VRAM and hands a miss to `--fit`, so a busy card costs speed rather than the load. Both now say it offloads and runs slower.

## Behaviour that changes

All of it toward what the loader does:

- More quants read as fitting on a large unified-memory host. Fewer on a discrete GPU with plenty of RAM, since offload is credited at 0.5 of RAM rather than 0.7.
- `pickDefaultQuant` and the Recommended pick follow the same line, so a bare group click can land on a larger quant than before.
- The VRAM Budget setting now applies to chat.

## Verified

`Qwen3.5-122B-A10B-MTP-GGUF` on a 64 GB M3 Max, read out of the running picker:

```
39 GB  UD-IQ1_M        (no mark)
40 GB  UD-IQ2_XXS      (no mark)
43 GB  UD-Q2_K_XL      (no mark)
48 GB  UD-IQ3_XXS      (no mark)
52 GB  UD-IQ3_S        (no mark)
58 GB  UD-Q3_K_M       Might fit
58 GB  UD-Q3_K_XL      Might fit      <- now the recommended pick
62 GB  UD-IQ4_XS       Does not fit
63 GB  UD-IQ4_NL       Does not fit
```

Same three tiers on the same rows the Hub puts them on. The 52 GB quant the picker used to reject now reads as fitting, matching the Hub's green 53 GB.

`npm run typecheck`, `npm run catalog:check` and `npm test` (6010 tests) all pass. `model-catalog.check.ts` pins the new tier boundaries including the budget-fraction case, and the layout test file gains a guard that no copy of the 0.7 budget survives in either GGUF path.

## Left alone

`model-catalog.ts` still uses `0.7 * card` for non-GGUF artifact budgets. Those size torch pipelines, and the shared formula is weights plus KV for llama.cpp, so it does not apply there.

One thing worth a second opinion: `oom` is orange rather than red because red was called too heavy earlier, back when that tier also covered models that merely offloaded. It no longer does, so red may be right for it now. One line if we want it.




