### PR TITLE
feat: load oci:// models via llmman serve

### DIFF
--- a/tests/test_llmman.py
+++ b/tests/test_llmman.py
@@ -1,0 +1,164 @@
+"""The `llmman serve` client: the daemon protocol behind oci:// model paths.
+
+Exercised against a real HTTP server on a loopback port rather than mocks, so
+the NDJSON streaming contract is genuinely tested.
+"""
+
+import http.server
+import json
+import socketserver
+import threading
+
+import pytest
+from unsloth import llmman
+
+
+def _ndjson(*objs):
+    return "".join(json.dumps(o) + "\n" for o in objs)
+
+
+class _FakeDaemon:
+    """A minimal stand-in for `llmman serve`, on a real loopback port."""
+
+    def __init__(self):
+        self.version = {"version": "0.1.0", "pid": 1}
+        self.pull_body = _ndjson({"status": "success"})
+        self.pull_status = 200
+        self.last_request = None
+        daemon = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def _send(self, status, body, ctype):
+                raw = body.encode()
+                self.send_response(status)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+            def do_GET(self):
+                self._send(200, json.dumps(daemon.version), "application/json")
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                daemon.last_request = json.loads(self.rfile.read(length))
+                self._send(daemon.pull_status, daemon.pull_body, "application/x-ndjson")
+
+        self._server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_address[1]}"
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+@pytest.fixture
+def daemon():
+    d = _FakeDaemon()
+    yield d
+    d.close()
+
+
+def test_accepts_a_llmman_daemon(daemon):
+    llmman.check_daemon(daemon.url)
+
+
+def test_rejects_a_non_llmman_server(daemon):
+    daemon.version = {"hello": "world"}
+    with pytest.raises(RuntimeError, match="not an llmman daemon"):
+        llmman.check_daemon(daemon.url)
+
+
+def test_reports_nothing_listening_actionably():
+    with pytest.raises(RuntimeError, match="llmman serve"):
+        llmman.check_daemon("http://127.0.0.1:1")
+
+
+def test_pull_succeeds_and_forwards_progress(daemon):
+    daemon.pull_body = _ndjson(
+        {"status": "pulling manifest"},
+        {"status": "pulling blobs", "completed": 50, "total": 100},
+        {"status": "success"},
+    )
+    seen = []
+    llmman.pull(daemon.url, "ghcr.io/org/model:tag", lambda *a: seen.append(a))
+
+    assert daemon.last_request == {"model": "ghcr.io/org/model:tag"}
+    assert seen == [("pulling manifest", 0, 0), ("pulling blobs", 50, 100)]
+
+
+def test_reports_an_in_band_error_at_http_200(daemon):
+    # The daemon streams errors in-band, so a 200 does not mean success.
+    daemon.pull_body = _ndjson({"status": "pulling"}, {"error": "unauthorized"})
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_rejects_a_stream_that_ends_without_success(daemon):
+    daemon.pull_body = _ndjson({"status": "pulling blobs"})
+    with pytest.raises(RuntimeError, match="without reporting success"):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_reports_a_non_ok_status(daemon):
+    daemon.pull_status = 400
+    daemon.pull_body = '{"error":"bad request"}'
+    with pytest.raises(RuntimeError):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_tolerates_a_non_json_diagnostic_line(daemon):
+    daemon.pull_body = "not json\n" + _ndjson({"status": "success"})
+    llmman.pull(daemon.url, "ref")
+
+
+def test_recognizes_the_oci_scheme():
+    assert llmman.is_oci_ref("oci://ghcr.io/org/model:tag")
+    assert llmman.is_oci_ref("OCI://ghcr.io/org/model:tag")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "unsloth/Llama-3.2-1B-Instruct",
+        "meta-llama/Llama-3.2-1B-Instruct",
+        "ghcr.io/org/model:tag",
+        "/local/path/to/model",
+        "",
+        None,
+    ],
+)
+def test_leaves_every_other_model_name_alone(value):
+    # A bare HF repo id must never be claimed; the name mappers own those.
+    assert not llmman.is_oci_ref(value)
+
+
+def test_strips_the_scheme_only_when_present():
+    assert llmman.strip_scheme("oci://ghcr.io/org/model:tag") == "ghcr.io/org/model:tag"
+    assert llmman.strip_scheme("unsloth/Llama-3.2-1B") == "unsloth/Llama-3.2-1B"
+
+
+@pytest.mark.parametrize("ref", ["oci://", "oci://   "])
+def test_rejects_an_empty_reference(ref):
+    with pytest.raises(ValueError):
+        llmman.resolve_model(ref)
+
+
+@pytest.mark.parametrize(
+    "host,want",
+    [
+        ("", "http://127.0.0.1:17434"),
+        ("1.2.3.4:9999", "http://1.2.3.4:9999"),
+        ("1.2.3.4", "http://1.2.3.4:17434"),
+        # A wildcard bind is meaningful to the server but not to a client.
+        ("0.0.0.0:9999", "http://127.0.0.1:9999"),
+        ("[::]:9999", "http://[::1]:9999"),
+    ],
+)
+def test_endpoint_parsing(monkeypatch, host, want):
+    monkeypatch.setenv(llmman.HOST_ENV, host)
+    assert llmman.endpoint() == want

--- a/tests/test_llmman.py
+++ b/tests/test_llmman.py
@@ -49,7 +49,7 @@ class _FakeDaemon:
 
         self._server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
         self.url = f"http://127.0.0.1:{self._server.server_address[1]}"
-        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+        threading.Thread(target = self._server.serve_forever, daemon = True).start()
 
     def close(self):
         self._server.shutdown()
@@ -69,12 +69,12 @@ def test_accepts_a_llmman_daemon(daemon):
 
 def test_rejects_a_non_llmman_server(daemon):
     daemon.version = {"hello": "world"}
-    with pytest.raises(RuntimeError, match="not an llmman daemon"):
+    with pytest.raises(RuntimeError, match = "not an llmman daemon"):
         llmman.check_daemon(daemon.url)
 
 
 def test_reports_nothing_listening_actionably():
-    with pytest.raises(RuntimeError, match="llmman serve"):
+    with pytest.raises(RuntimeError, match = "llmman serve"):
         llmman.check_daemon("http://127.0.0.1:1")
 
 
@@ -94,13 +94,13 @@ def test_pull_succeeds_and_forwards_progress(daemon):
 def test_reports_an_in_band_error_at_http_200(daemon):
     # The daemon streams errors in-band, so a 200 does not mean success.
     daemon.pull_body = _ndjson({"status": "pulling"}, {"error": "unauthorized"})
-    with pytest.raises(RuntimeError, match="unauthorized"):
+    with pytest.raises(RuntimeError, match = "unauthorized"):
         llmman.pull(daemon.url, "ref")
 
 
 def test_rejects_a_stream_that_ends_without_success(daemon):
     daemon.pull_body = _ndjson({"status": "pulling blobs"})
-    with pytest.raises(RuntimeError, match="without reporting success"):
+    with pytest.raises(RuntimeError, match = "without reporting success"):
         llmman.pull(daemon.url, "ref")
 
 

--- a/unsloth/llmman.py
+++ b/unsloth/llmman.py
@@ -1,0 +1,261 @@
+"""Client for a running ``llmman serve`` daemon.
+
+Used to acquire models published as CNCF ModelPack
+(https://github.com/modelpack/model-spec) OCI artifacts. The daemon owns the
+registry work -- ModelPack media types, registry auth, resumable blob download
+and a content-addressed store -- so it is not reimplemented here.
+
+Contract (from llmman's src/cmd/serve.rs and src/daemon.rs):
+  - LLMMAN_HOST is ``[scheme://]host[:port][/path]``, default 127.0.0.1:17434.
+    A wildcard bind host (0.0.0.0, ::) is rewritten to loopback, since a client
+    cannot connect to "every interface".
+  - ``GET /api/version`` -> ``{"version":..., "exe":..., "pid":...}``.
+  - ``POST /api/pull`` ``{"model": ref}`` -> NDJSON stream of ``{"status":...}``
+    objects, terminated by ``{"status":"success"}`` or ``{"error":"..."}``.
+    An error can arrive in-band at HTTP 200.
+  - ``llmman resolve --no-pull <ref>`` -> one line of JSON carrying ``path``.
+"""
+
+import ipaddress
+import json
+import logging
+import os
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+HOST_ENV = "LLMMAN_HOST"
+BIN_ENV = "UNSLOTH_LLMMAN_BIN"
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 17434
+
+PROBE_TIMEOUT_SECONDS = 5
+
+
+def _connectable_host(host: str) -> str:
+    """Rewrite a wildcard bind host to its loopback equivalent."""
+    try:
+        ip = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return host
+    if not ip.is_unspecified:
+        return host
+    return "127.0.0.1" if ip.version == 4 else "::1"
+
+
+def endpoint() -> str:
+    """The http origin of the llmman daemon, honouring LLMMAN_HOST."""
+    raw = os.getenv(HOST_ENV, "").strip().strip("\"'")
+    if not raw:
+        return f"http://{DEFAULT_HOST}:{DEFAULT_PORT}"
+
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    raw = raw.split("/", 1)[0]
+
+    host, port = raw, DEFAULT_PORT
+    if raw.startswith("["):  # bracketed IPv6, optionally with :port
+        close = raw.find("]")
+        if close != -1:
+            host = raw[: close + 1]
+            rest = raw[close + 1 :]
+            if rest.startswith(":") and rest[1:].isdigit():
+                port = int(rest[1:])
+    elif raw.count(":") == 1:
+        maybe_host, maybe_port = raw.rsplit(":", 1)
+        if maybe_port.isdigit():
+            host, port = maybe_host, int(maybe_port)
+
+    host = host or DEFAULT_HOST
+    resolved = _connectable_host(host)
+    if ":" in resolved and not resolved.startswith("["):
+        resolved = f"[{resolved}]"
+    return f"http://{resolved}:{port}"
+
+
+def llmman_bin() -> str:
+    """The llmman executable name, overridable per project."""
+    return os.getenv(BIN_ENV, "").strip() or "llmman"
+
+
+def check_daemon(base: str) -> None:
+    """Confirm an llmman daemon is listening and is actually llmman."""
+    url = base + "/api/version"
+    try:
+        with urllib.request.urlopen(url, timeout=PROBE_TIMEOUT_SECONDS) as resp:
+            if resp.status != 200:
+                raise RuntimeError(
+                    f"llmman daemon at {base} answered /api/version with HTTP {resp.status}"
+                )
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"no llmman daemon reachable at {base} ({exc.reason}). Start one with "
+            f"`llmman serve`, or point {HOST_ENV} at an existing daemon."
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"the server at {base} is not an llmman daemon (unparseable /api/version)"
+        ) from exc
+
+    if not isinstance(payload, dict) or not payload.get("version"):
+        raise RuntimeError(
+            f"the server at {base} is not an llmman daemon (no version in /api/version)"
+        )
+
+
+def pull(base: str, reference: str, progress=None) -> None:
+    """Stream POST /api/pull until the daemon reports success.
+
+    ``progress`` receives ``(status, completed, total)``. An error can arrive
+    in-band at HTTP 200, and a stream that ends without ``success`` is also a
+    failure -- neither is treated as a completed pull.
+    """
+    body = json.dumps({"model": reference}).encode("utf-8")
+    req = urllib.request.Request(
+        base + "/api/pull",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    succeeded = False
+    try:
+        with urllib.request.urlopen(req) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"llmman pull of {reference!r} failed: HTTP {resp.status}")
+            for raw_line in resp:
+                line = raw_line.decode("utf-8").strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    # Tolerate a non-JSON diagnostic rather than aborting a
+                    # pull that may still be progressing.
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if obj.get("error"):
+                    raise RuntimeError(f"llmman pull of {reference!r} failed: {obj['error']}")
+                status = obj.get("status")
+                if status == "success":
+                    succeeded = True
+                    continue
+                if progress is not None and status:
+                    progress(status, obj.get("completed", 0), obj.get("total", 0))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"llmman pull of {reference!r} failed: HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"llmman pull of {reference!r} failed: {exc.reason}") from exc
+
+    if not succeeded:
+        raise RuntimeError(f"llmman pull of {reference!r} ended without reporting success")
+
+
+def parse_resolve_output(stdout: str, reference: str) -> str:
+    """Parse ``llmman resolve`` stdout into the resolved local path."""
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError(f"llmman resolve {reference!r}: no output on stdout")
+
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: could not parse output as JSON: {lines[-1]}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        # A protocol violation rather than a caller type error, so RuntimeError
+        # keeps every llmman failure one exception type for callers.
+        raise RuntimeError(  # noqa: TRY004
+            f"llmman resolve {reference!r}: expected a JSON object, got {lines[-1]}"
+        )
+
+    path = payload.get("path")
+    if not isinstance(path, str) or not path.strip():
+        raise RuntimeError(f"llmman resolve {reference!r}: returned an empty path")
+    if not os.path.exists(path):
+        raise RuntimeError(f"llmman resolve {reference!r}: reported path {path!r} does not exist")
+    return path
+
+
+def resolve(reference: str) -> str:
+    """Ask the CLI where the daemon's pull left the model on disk.
+
+    ``--no-pull`` guarantees this only reports on bytes ``/api/pull`` already
+    fetched, so the daemon stays the only thing that touches the network.
+    """
+    binary = llmman_bin()
+    if shutil.which(binary) is None and not os.path.isfile(binary):
+        raise RuntimeError(
+            f"{binary!r} not found. Install llmman "
+            "(https://github.com/llmmanorg/llmman) and put it on PATH, or set "
+            f"{BIN_ENV} to its location."
+        )
+
+    completed = subprocess.run(
+        [binary, "resolve", "--no-pull", reference],
+        capture_output=True,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"`{binary} resolve --no-pull {reference}` failed with exit code "
+            f"{completed.returncode}: {completed.stderr.strip()}"
+        )
+    return parse_resolve_output(completed.stdout, reference)
+
+
+def pull_and_resolve(reference: str, progress=None) -> str:
+    """Full acquisition: probe the daemon, pull through it, report the path."""
+    base = endpoint()
+    check_daemon(base)
+    logger.info("Pulling %s via llmman daemon at %s", reference, base)
+    pull(base, reference, progress)
+    return resolve(reference)
+
+
+SCHEME = "oci://"
+
+
+def is_oci_ref(model_name) -> bool:
+    """Whether ``model_name`` carries the ``oci://`` scheme.
+
+    An explicit scheme is required rather than sniffing a bare
+    ``registry/name:tag``: that shape is indistinguishable from a HuggingFace
+    repo id, so guessing would silently hijack existing model names.
+    """
+    if not model_name:
+        return False
+    return str(model_name).lower().startswith(SCHEME)
+
+
+def strip_scheme(model_name) -> str:
+    """Drop the ``oci://`` prefix, leaving the bare registry reference."""
+    text = str(model_name)
+    if is_oci_ref(text):
+        return text[len(SCHEME) :]
+    return text
+
+
+def resolve_model(model_name) -> str:
+    """Pull an ``oci://`` reference through llmman and return the local path."""
+    reference = strip_scheme(model_name).strip()
+    if not reference:
+        raise ValueError(f"empty OCI model reference: {model_name!r}")
+
+    def _progress(status, completed, total):
+        if total:
+            logger.info("llmman: %s (%s/%s bytes)", status, completed, total)
+        else:
+            logger.info("llmman: %s", status)
+
+    return pull_and_resolve(reference, progress=_progress)

--- a/unsloth/llmman.py
+++ b/unsloth/llmman.py
@@ -86,7 +86,7 @@ def check_daemon(base: str) -> None:
     """Confirm an llmman daemon is listening and is actually llmman."""
     url = base + "/api/version"
     try:
-        with urllib.request.urlopen(url, timeout=PROBE_TIMEOUT_SECONDS) as resp:
+        with urllib.request.urlopen(url, timeout = PROBE_TIMEOUT_SECONDS) as resp:
             if resp.status != 200:
                 raise RuntimeError(
                     f"llmman daemon at {base} answered /api/version with HTTP {resp.status}"
@@ -108,7 +108,11 @@ def check_daemon(base: str) -> None:
         )
 
 
-def pull(base: str, reference: str, progress=None) -> None:
+def pull(
+    base: str,
+    reference: str,
+    progress = None,
+) -> None:
     """Stream POST /api/pull until the daemon reports success.
 
     ``progress`` receives ``(status, completed, total)``. An error can arrive
@@ -118,9 +122,9 @@ def pull(base: str, reference: str, progress=None) -> None:
     body = json.dumps({"model": reference}).encode("utf-8")
     req = urllib.request.Request(
         base + "/api/pull",
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
+        data = body,
+        headers = {"Content-Type": "application/json"},
+        method = "POST",
     )
 
     succeeded = False
@@ -201,10 +205,10 @@ def resolve(reference: str) -> str:
 
     completed = subprocess.run(
         [binary, "resolve", "--no-pull", reference],
-        capture_output=True,
-        stdin=subprocess.DEVNULL,
-        text=True,
-        check=False,
+        capture_output = True,
+        stdin = subprocess.DEVNULL,
+        text = True,
+        check = False,
     )
     if completed.returncode != 0:
         raise RuntimeError(
@@ -214,7 +218,7 @@ def resolve(reference: str) -> str:
     return parse_resolve_output(completed.stdout, reference)
 
 
-def pull_and_resolve(reference: str, progress=None) -> str:
+def pull_and_resolve(reference: str, progress = None) -> str:
     """Full acquisition: probe the daemon, pull through it, report the path."""
     base = endpoint()
     check_daemon(base)
@@ -258,4 +262,4 @@ def resolve_model(model_name) -> str:
         else:
             logger.info("llmman: %s", status)
 
-    return pull_and_resolve(reference, progress=_progress)
+    return pull_and_resolve(reference, progress = _progress)

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -30,6 +30,7 @@ from ._custom_dtype import register_custom_dtype
 from .granite import FastGraniteModel
 from .llama import FastLlamaModel, logger, _vllm_will_load_weights
 from .mistral import FastMistralModel
+from .. import llmman
 from .qwen2 import FastQwen2Model
 from .qwen3 import FastQwen3Model
 from .qwen3_moe import FastQwen3MoeModel
@@ -475,6 +476,14 @@ class FastLanguageModel(FastLlamaModel):
             if q_load_in_8bit:
                 load_in_8bit = True
                 load_in_4bit = False
+
+        # A CNCF ModelPack artifact is pulled through an llmman daemon and
+        # extracted; from here it is an ordinary local directory. The name
+        # mappers only understand HuggingFace repo ids, so they are skipped for
+        # it -- there is no pre-quantized Unsloth mirror of a private artifact.
+        if llmman.is_oci_ref(model_name):
+            model_name = llmman.resolve_model(model_name)
+            use_exact_model_name = True
 
         # Login to allow private models
         # Before normalization: dtype is also derived below from a 4bit config's
@@ -1295,6 +1304,14 @@ class FastModel(FastBaseModel):
             if q_load_in_8bit:
                 load_in_8bit = True
                 load_in_4bit = False
+
+        # A CNCF ModelPack artifact is pulled through an llmman daemon and
+        # extracted; from here it is an ordinary local directory. The name
+        # mappers only understand HuggingFace repo ids, so they are skipped for
+        # it -- there is no pre-quantized Unsloth mirror of a private artifact.
+        if llmman.is_oci_ref(model_name):
+            model_name = llmman.resolve_model(model_name)
+            use_exact_model_name = True
 
         # Login to allow private models
         # Before normalization: dtype is also derived below from a 4bit config's


### PR DESCRIPTION
## What

Adds an `oci://` scheme so a model published as a [CNCF ModelPack](https://github.com/modelpack/model-spec) artifact can be loaded anywhere a HuggingFace repo id works:

```python
model, tokenizer = FastLanguageModel.from_pretrained(
    model_name = "oci://ghcr.io/org/model:tag",
    max_seq_length = 2048,
    load_in_4bit = True,
)
```

Model distribution is increasingly moving to OCI registries -- the same registries, credentials, mirroring and air-gap tooling a deployment already uses for container images. For a locked-down or air-gapped training environment that is usually easier to run than reaching the Hub, and it lets an internal registry mirror serve base models to every training job.

## How

Resolution happens in **both** `FastLanguageModel.from_pretrained` and `FastModel.from_pretrained`, immediately before `hf_login`, rewriting `model_name` to the extracted directory and setting `use_exact_model_name = True`.

That last part is the design point worth reviewing: the name mappers (`INT_TO_FLOAT_MAPPER`, `MAP_TO_UNSLOTH_16bit`, the remote mapper refresh) only understand HuggingFace repo ids. There is no pre-quantized Unsloth mirror of a private OCI artifact, and `get_model_name`'s `model_name.count("/") == 1` heuristic would misfire on a registry reference. Skipping them for `oci://` is the correct behaviour rather than a shortcut -- everything after that point sees an ordinary local directory, exactly as if a local path had been passed.

Acquisition is delegated to a running [`llmman serve`](https://github.com/llmmanorg/llmman) rather than hand-rolled: llmman already implements the ModelPack media types, registry auth, resumable blob download and a content-addressed store.

New `unsloth/llmman.py` is the daemon client, stdlib-only (`urllib`), **no new dependency**:

- `GET /api/version` probes reachability *and* identity -- a server answering without a `version` field is reported as "not an llmman daemon", worth distinguishing from nothing listening.
- `POST /api/pull` streams NDJSON so a multi-gigabyte fetch is not silent. An error arrives **in-band at HTTP 200**, and a stream that ends without `success` is also a failure -- both are errors, not a completed pull.
- `llmman resolve --no-pull` reports where the bytes landed; `--no-pull` keeps the daemon the only thing that touches the network.
- `LLMMAN_HOST` is honoured with llmman's own parsing, including rewriting a wildcard bind (`0.0.0.0`, `[::]`) to loopback.

A load needs both the daemon reachable and the binary on `PATH` (or `UNSLOTH_LLMMAN_BIN`); each missing piece has its own actionable error, and neither is required unless an `oci://` model name is used.

**Explicit scheme, no sniffing.** A bare `registry/name:tag` is indistinguishable from a HuggingFace repo id (`unsloth/Llama-3.2-1B-Instruct`); guessing would silently hijack existing model names and break the mapper lookups. Every other name reaches exactly the path it did before.

The diff to `loader.py` is **17 added lines, zero deletions**.

## Testing

New `tests/test_llmman.py`, running against a **real HTTP server on a loopback port** rather than mocks, so the NDJSON contract is genuinely exercised.

```
$ pytest tests/test_llmman.py
23 passed
```

**All 23 executed here.** Coverage: `/api/version` accepted, a non-llmman server rejected, nothing-listening reported actionably; pull success with forwarded byte progress and the exact request body asserted; in-band error at HTTP 200; a stream ending without `success`; non-OK status; a non-JSON diagnostic tolerated; scheme detection incl. case-insensitivity; that `unsloth/...` and `meta-llama/...` repo ids, a bare registry ref and a local path are **not** claimed; `strip_scheme` round-trips; empty reference rejected; every `LLMMAN_HOST` form incl. wildcard-to-loopback.

- [x] `ruff format` and `ruff check` clean on both new files

Not verified here, flagged rather than implied: the two `from_pretrained` branches are covered by inspection rather than execution -- importing `unsloth.models.loader` needs torch, transformers and bitsandbytes, unavailable in this environment. No end-to-end load against a live `llmman serve` backed by a real registry.

> Disclosure: written with AI assistance.
