### PR TITLE
Keep a modules_to_save copy on the card it was loaded onto

### DIFF
--- a/tests/test_offload_frozen_module_device.py
+++ b/tests/test_offload_frozen_module_device.py
@@ -1,0 +1,214 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""`_offload_frozen_module_for_training` must not drag the copy off its card.
+
+Continued pretraining puts `embed_tokens` and `lm_head` in `target_modules`,
+which makes PEFT build a `ModulesToSaveWrapper` around each. `llama.py` then
+calls this helper to move the trainable copy onto the accelerator and offload
+the frozen original to CPU, passing `DEVICE_TYPE_TORCH`, which is the bare
+string "cuda".
+
+A bare "cuda" has no index:
+
+    >>> torch.device("cuda").index is None
+    True
+    >>> torch.zeros(2).to("cuda").device
+    device(type='cuda', index=0)
+
+So on a model the loader split across cards, a copy sitting on cuda:1 was moved
+to cuda:0 while the rest of its layer stayed behind, and the forward then mixed
+devices. Single-GPU runs never saw it, because there cuda:0 is where the copy
+already was.
+
+These tests drive the real helper with a stub that RECORDS the device it is
+handed rather than allocating anything. That is deliberate: the case under test
+is a second card, and recording the argument tests the decision on any box,
+including CI runners with no GPU at all. The one test that does allocate is
+skipped without CUDA and only covers the no-regression direction.
+"""
+
+import types
+import pytest
+import torch
+
+
+def _load_helper():
+    """Import the helper without dragging in the whole loader.
+
+    `unsloth.models.llama` is expensive to import and pulls hardware probes, so
+    the suite would become a GPU test by accident. The function is self
+    contained, so read it out of the module source and exec it in a namespace
+    holding only what it closes over.
+    """
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1]
+    src = (root / "unsloth" / "models" / "llama.py").read_text()
+    tree = ast.parse(src)
+    fn = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_offload_frozen_module_for_training"
+    )
+    # The annotations are evaluated when the def executes, so the names they
+    # mention have to be real here, not placeholders.
+    from typing import Optional
+
+    ns = {"torch": torch, "Optional": Optional, "ModulesToSaveWrapper": object}
+    module = ast.Module(body = [fn], type_ignores = [])
+    exec(compile(ast.fix_missing_locations(module), "<llama>", "exec"), ns)
+    return ns["_offload_frozen_module_for_training"]
+
+
+offload = _load_helper()
+
+
+class _Recorder:
+    """Stands in for a submodule, recording `.to()` instead of allocating."""
+
+    def __init__(self, device, dtype = torch.float32):
+        self.weight = types.SimpleNamespace(
+            device = torch.device(device), dtype = dtype,
+        )
+        self.to_calls = []
+        self.requires_grad_calls = []
+
+    def to(self, **kwargs):
+        self.to_calls.append(kwargs)
+        if "device" in kwargs:
+            self.weight.device = torch.device(kwargs["device"])
+        if "dtype" in kwargs:
+            self.weight.dtype = kwargs["dtype"]
+        return self
+
+    def requires_grad_(self, flag):
+        self.requires_grad_calls.append(flag)
+        return self
+
+
+class _Wrapper:
+    def __init__(self, copy_device, original_device = None, dtype = torch.float32):
+        self.modules_to_save = types.SimpleNamespace(
+            default = _Recorder(copy_device, dtype),
+        )
+        self.original_module = _Recorder(original_device or copy_device, dtype)
+
+
+def _moved_to(wrapper):
+    call = wrapper.modules_to_save.default.to_calls[-1]
+    return torch.device(call["device"])
+
+
+def test_a_copy_on_the_second_card_stays_on_the_second_card():
+    """The regression. Reverting the fix sends this to cuda:0."""
+    w = _Wrapper("cuda:1")
+    offload(w, "cuda")
+    assert _moved_to(w) == torch.device("cuda", 1)
+
+
+def test_a_copy_on_the_third_card_stays_on_the_third_card():
+    """Not special cased to index 1: any index the copy already has is kept."""
+    w = _Wrapper("cuda:3")
+    offload(w, "cuda")
+    assert _moved_to(w) == torch.device("cuda", 3)
+
+
+def test_a_copy_on_the_first_card_is_unchanged():
+    w = _Wrapper("cuda:0")
+    offload(w, "cuda")
+    assert _moved_to(w) == torch.device("cuda", 0)
+
+
+def test_a_copy_on_cpu_is_still_moved_onto_the_accelerator():
+    """The single-GPU path, which must keep behaving exactly as before."""
+    w = _Wrapper("cpu")
+    offload(w, "cuda")
+    assert torch.device(_moved_to(w)).type == "cuda"
+
+
+def test_a_copy_on_meta_is_still_moved_onto_the_accelerator():
+    """A deferred-init module has no index to preserve."""
+    w = _Wrapper("meta")
+    offload(w, "cuda")
+    assert torch.device(_moved_to(w)).type == "cuda"
+
+
+def test_mps_keeps_its_own_device_rather_than_being_sent_to_cuda():
+    """Apple silicon reaches here with DEVICE_TYPE_TORCH == "mps"."""
+    w = _Wrapper("mps")
+    offload(w, "mps")
+    assert torch.device(_moved_to(w)).type == "mps"
+
+
+def test_float16_is_still_promoted_to_float32():
+    """PR #1200: Tesla T4 must train these in float32."""
+    w = _Wrapper("cuda:1", dtype = torch.float16)
+    offload(w, "cuda")
+    assert w.modules_to_save.default.to_calls[-1]["dtype"] == torch.float32
+
+
+def test_bfloat16_is_left_alone():
+    w = _Wrapper("cuda:1", dtype = torch.bfloat16)
+    offload(w, "cuda")
+    assert w.modules_to_save.default.to_calls[-1]["dtype"] == torch.bfloat16
+
+
+def test_the_trainable_copy_is_the_only_one_that_requires_grad():
+    w = _Wrapper("cuda:1")
+    offload(w, "cuda")
+    assert w.modules_to_save.default.requires_grad_calls == [True]
+    assert w.original_module.requires_grad_calls == [False]
+
+
+def test_the_frozen_original_is_offloaded_to_cpu():
+    w = _Wrapper("cuda:1")
+    offload(w, "cuda")
+    assert torch.device(w.original_module.to_calls[-1]["device"]) == torch.device("cpu")
+
+
+def test_offload_device_none_leaves_the_frozen_original_in_place():
+    w = _Wrapper("cuda:1")
+    offload(w, "cuda", offload_device = None)
+    assert w.original_module.to_calls == []
+    assert w.original_module.requires_grad_calls == [False]
+
+
+def test_a_module_without_modules_to_save_is_untouched():
+    plain = _Recorder("cuda:1")
+    assert offload(plain, "cuda") is None
+    assert plain.to_calls == []
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs a CUDA device")
+def test_on_real_hardware_a_module_on_the_current_card_is_unchanged():
+    """No-regression check with real allocation. Single card is enough."""
+
+    class _Real:
+        def __init__(self):
+            self.modules_to_save = types.SimpleNamespace(
+                default = torch.nn.Linear(4, 4).cuda(),
+            )
+            self.original_module = torch.nn.Linear(4, 4).cuda()
+
+    w = _Real()
+    before = w.modules_to_save.default.weight.device
+    offload(w, "cuda")
+    assert w.modules_to_save.default.weight.device == before
+    assert w.original_module.weight.device == torch.device("cpu")
+    assert w.modules_to_save.default.weight.requires_grad
+    assert not w.original_module.weight.requires_grad

--- a/tests/test_offload_frozen_module_device.py
+++ b/tests/test_offload_frozen_module_device.py
@@ -61,9 +61,9 @@ def _load_helper():
     src = (root / "unsloth" / "models" / "llama.py").read_text()
     tree = ast.parse(src)
     fn = next(
-        node for node in tree.body
-        if isinstance(node, ast.FunctionDef)
-        and node.name == "_offload_frozen_module_for_training"
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_offload_frozen_module_for_training"
     )
     # The annotations are evaluated when the def executes, so the names they
     # mention have to be real here, not placeholders.
@@ -81,9 +81,14 @@ offload = _load_helper()
 class _Recorder:
     """Stands in for a submodule, recording `.to()` instead of allocating."""
 
-    def __init__(self, device, dtype = torch.float32):
+    def __init__(
+        self,
+        device,
+        dtype = torch.float32,
+    ):
         self.weight = types.SimpleNamespace(
-            device = torch.device(device), dtype = dtype,
+            device = torch.device(device),
+            dtype = dtype,
         )
         self.to_calls = []
         self.requires_grad_calls = []
@@ -102,7 +107,12 @@ class _Recorder:
 
 
 class _Wrapper:
-    def __init__(self, copy_device, original_device = None, dtype = torch.float32):
+    def __init__(
+        self,
+        copy_device,
+        original_device = None,
+        dtype = torch.float32,
+    ):
         self.modules_to_save = types.SimpleNamespace(
             default = _Recorder(copy_device, dtype),
         )

--- a/tests/test_offload_frozen_module_device.py
+++ b/tests/test_offload_frozen_module_device.py
@@ -222,3 +222,80 @@ def test_on_real_hardware_a_module_on_the_current_card_is_unchanged():
     assert w.original_module.weight.device == torch.device("cpu")
     assert w.modules_to_save.default.weight.requires_grad
     assert not w.original_module.weight.requires_grad
+
+
+# The DEFAULT path. `use_gradient_checkpointing = "unsloth"` offloads the trained
+# embedding and head to disk BEFORE `_get_peft_model` runs, so PEFT builds
+# `modules_to_save.default` on CPU and the copy has no index left to preserve.
+# llama.py records the real placement first (`input_embeddings_device` /
+# `output_embeddings_device`, captured just above that offload) and hands it over.
+
+
+def test_a_copy_rebuilt_on_cpu_by_the_disk_offload_uses_the_recorded_device():
+    """The default-path regression: without this the copy lands on cuda:0."""
+    w = _Wrapper("cpu")
+    offload(w, "cuda", original_device = torch.device("cuda", 1))
+    assert _moved_to(w) == torch.device("cuda", 1)
+
+
+def test_the_recorded_device_is_used_for_the_first_card_too():
+    w = _Wrapper("cpu")
+    offload(w, "cuda", original_device = torch.device("cuda", 0))
+    assert _moved_to(w) == torch.device("cuda", 0)
+
+
+def test_a_copy_that_still_has_an_index_beats_the_recorded_device():
+    """The copy is live truth; the record only covers a copy that lost its index."""
+    w = _Wrapper("cuda:1")
+    offload(w, "cuda", original_device = torch.device("cuda", 0))
+    assert _moved_to(w) == torch.device("cuda", 1)
+
+
+def test_a_recorded_cpu_device_does_not_pin_the_copy_to_cpu():
+    """A model loaded on CPU records cpu; it must still reach the accelerator."""
+    w = _Wrapper("cpu")
+    offload(w, "cuda", original_device = torch.device("cpu"))
+    assert torch.device(_moved_to(w)).type == "cuda"
+
+
+def test_no_recorded_device_behaves_exactly_as_before():
+    """The two call sites that have nothing to record must be unaffected."""
+    w = _Wrapper("cpu")
+    offload(w, "cuda", original_device = None)
+    assert torch.device(_moved_to(w)).type == "cuda"
+
+
+def test_a_meta_copy_also_uses_the_recorded_device():
+    w = _Wrapper("meta")
+    offload(w, "cuda", original_device = torch.device("cuda", 2))
+    assert _moved_to(w) == torch.device("cuda", 2)
+
+
+def test_the_continued_pretraining_call_sites_pass_the_recorded_device():
+    """The helper supporting it is worthless if the callers drop it.
+
+    That is the exact shape of the original bug, so assert it against the real
+    source rather than trusting the call sites to stay correct. The continued
+    pretraining calls are the ones passing `offload_device`.
+    """
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1]
+    tree = ast.parse((root / "unsloth" / "models" / "llama.py").read_text())
+
+    checked = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if getattr(node.func, "id", None) != "_offload_frozen_module_for_training":
+            continue
+        kwargs = {kw.arg for kw in node.keywords}
+        if "offload_device" not in kwargs:
+            continue  # the pre-wrapped PEFT branch, which records nothing
+        assert "original_device" in kwargs, (
+            "a continued-pretraining call dropped original_device, so a copy "
+            "rebuilt on CPU by the disk offload lands on cuda:0"
+        )
+        checked += 1
+    assert checked == 2, f"expected 2 continued-pretraining call sites, found {checked}"

--- a/tests/test_offload_frozen_module_device.py
+++ b/tests/test_offload_frozen_module_device.py
@@ -16,29 +16,14 @@
 
 """`_offload_frozen_module_for_training` must not drag the copy off its card.
 
-Continued pretraining puts `embed_tokens` and `lm_head` in `target_modules`,
-which makes PEFT build a `ModulesToSaveWrapper` around each. `llama.py` then
-calls this helper to move the trainable copy onto the accelerator and offload
-the frozen original to CPU, passing `DEVICE_TYPE_TORCH`, which is the bare
-string "cuda".
+Continued pretraining puts `embed_tokens` and `lm_head` in `target_modules`, so
+PEFT wraps each in a `ModulesToSaveWrapper` and llama.py moves the trainable
+copy onto the accelerator with `DEVICE_TYPE_TORCH`, the bare string "cuda".
+A bare "cuda" carries no index and resolves to the CURRENT device, so a copy on
+cuda:1 was moved to cuda:0 while the rest of its layer stayed behind.
 
-A bare "cuda" has no index:
-
-    >>> torch.device("cuda").index is None
-    True
-    >>> torch.zeros(2).to("cuda").device
-    device(type='cuda', index=0)
-
-So on a model the loader split across cards, a copy sitting on cuda:1 was moved
-to cuda:0 while the rest of its layer stayed behind, and the forward then mixed
-devices. Single-GPU runs never saw it, because there cuda:0 is where the copy
-already was.
-
-These tests drive the real helper with a stub that RECORDS the device it is
-handed rather than allocating anything. That is deliberate: the case under test
-is a second card, and recording the argument tests the decision on any box,
-including CI runners with no GPU at all. The one test that does allocate is
-skipped without CUDA and only covers the no-regression direction.
+The stub RECORDS the device it is handed rather than allocating, so the second
+card is testable on any box, including CI runners with no GPU.
 """
 
 import types
@@ -47,13 +32,7 @@ import torch
 
 
 def _load_helper():
-    """Import the helper without dragging in the whole loader.
-
-    `unsloth.models.llama` is expensive to import and pulls hardware probes, so
-    the suite would become a GPU test by accident. The function is self
-    contained, so read it out of the module source and exec it in a namespace
-    holding only what it closes over.
-    """
+    """Exec the helper from source: importing llama.py would pull hardware probes."""
     import ast
     import pathlib
 
@@ -132,7 +111,6 @@ def test_a_copy_on_the_second_card_stays_on_the_second_card():
 
 
 def test_a_copy_on_the_third_card_stays_on_the_third_card():
-    """Not special cased to index 1: any index the copy already has is kept."""
     w = _Wrapper("cuda:3")
     offload(w, "cuda")
     assert _moved_to(w) == torch.device("cuda", 3)
@@ -152,14 +130,12 @@ def test_a_copy_on_cpu_is_still_moved_onto_the_accelerator():
 
 
 def test_a_copy_on_meta_is_still_moved_onto_the_accelerator():
-    """A deferred-init module has no index to preserve."""
     w = _Wrapper("meta")
     offload(w, "cuda")
     assert torch.device(_moved_to(w)).type == "cuda"
 
 
 def test_mps_keeps_its_own_device_rather_than_being_sent_to_cuda():
-    """Apple silicon reaches here with DEVICE_TYPE_TORCH == "mps"."""
     w = _Wrapper("mps")
     offload(w, "mps")
     assert torch.device(_moved_to(w)).type == "mps"
@@ -206,8 +182,6 @@ def test_a_module_without_modules_to_save_is_untouched():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs a CUDA device")
 def test_on_real_hardware_a_module_on_the_current_card_is_unchanged():
-    """No-regression check with real allocation. Single card is enough."""
-
     class _Real:
         def __init__(self):
             self.modules_to_save = types.SimpleNamespace(
@@ -272,12 +246,7 @@ def test_a_meta_copy_also_uses_the_recorded_device():
 
 
 def test_the_continued_pretraining_call_sites_pass_the_recorded_device():
-    """The helper supporting it is worthless if the callers drop it.
-
-    That is the exact shape of the original bug, so assert it against the real
-    source rather than trusting the call sites to stay correct. The continued
-    pretraining calls are the ones passing `offload_device`.
-    """
+    """A helper supporting it is worthless if the callers drop it, which was the bug."""
     import ast
     import pathlib
 

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -196,7 +196,16 @@ def _offload_frozen_module_for_training(
         # Tesla T4 must use float32 and not float16
         new_dtype = torch.float32
 
-    module.modules_to_save.default.to(device = device_type, dtype = new_dtype, non_blocking = True)
+    # `device_type` is a bare type like "cuda", and `.to("cuda")` resolves to the
+    # CURRENT device, which is cuda:0. On a model the loader split across cards
+    # that drags the trainable copy off its own card, and the forward then mixes
+    # devices. Keep the index the copy already has whenever it is on the right
+    # kind of device; a copy still on cpu or meta has no index to keep.
+    target_device = module.modules_to_save.default.weight.device
+    if target_device.type != torch.device(device_type).type:
+        target_device = device_type
+
+    module.modules_to_save.default.to(device = target_device, dtype = new_dtype, non_blocking = True)
     module.modules_to_save.default.requires_grad_(True)
 
     # [TODO] Move old module to CPU - should be disk!

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -179,12 +179,15 @@ def _offload_frozen_module_for_training(
     module: ModulesToSaveWrapper,
     device_type: str,
     offload_device: Optional[str] = "cpu",
+    original_device = None,
 ) -> None:
     """Move the trainable copy to ``device_type`` and offload the frozen original.
 
     float16 is promoted to float32 for GPU compatibility (e.g. Tesla T4).
     ``offload_device`` currently only supports "cpu"; None leaves the frozen
-    module in place. Modifies ``module`` in-place.
+    module in place. ``original_device`` is the placement recorded before any
+    disk offload rebuilt the module, used when the copy no longer carries one.
+    Modifies ``module`` in-place.
     See https://github.com/unslothai/unsloth/pull/1200 (Tesla T4 float32).
     """
     if not hasattr(module, "modules_to_save"):
@@ -197,13 +200,17 @@ def _offload_frozen_module_for_training(
         new_dtype = torch.float32
 
     # `device_type` is a bare type like "cuda", and `.to("cuda")` resolves to the
-    # CURRENT device, which is cuda:0. On a model the loader split across cards
-    # that drags the trainable copy off its own card, and the forward then mixes
-    # devices. Keep the index the copy already has whenever it is on the right
-    # kind of device; a copy still on cpu or meta has no index to keep.
-    target_device = module.modules_to_save.default.weight.device
-    if target_device.type != torch.device(device_type).type:
-        target_device = device_type
+    # CURRENT device, which is cuda:0, so on a split model it drags the trainable
+    # copy off its own card and the forward then mixes devices. Prefer the index
+    # the copy already has; under the default `use_gradient_checkpointing =
+    # "unsloth"` it has none, because the disk offload above rebuilt it on CPU,
+    # so fall back to the placement recorded before that. Only then the bare type.
+    wanted_type = torch.device(device_type).type
+    target_device = device_type
+    for candidate in (module.modules_to_save.default.weight.device, original_device):
+        if candidate is not None and torch.device(candidate).type == wanted_type:
+            target_device = candidate
+            break
 
     module.modules_to_save.default.to(device = target_device, dtype = new_dtype, non_blocking = True)
     module.modules_to_save.default.requires_grad_(True)
@@ -3714,7 +3721,8 @@ class FastLlamaModel:
             assert hasattr(model.get_input_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
+                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device = None,
+                original_device = input_embeddings_device,
             )
 
         if train_lm_head:
@@ -3722,7 +3730,8 @@ class FastLlamaModel:
             assert hasattr(model.get_output_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device = None
+                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device = None,
+                original_device = output_embeddings_device,
             )
 
         # Patch tokenizer to pad to the right

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3721,7 +3721,9 @@ class FastLlamaModel:
             assert hasattr(model.get_input_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_input_embeddings(), DEVICE_TYPE_TORCH, offload_device = None,
+                model.get_input_embeddings(),
+                DEVICE_TYPE_TORCH,
+                offload_device = None,
                 original_device = input_embeddings_device,
             )
 
@@ -3730,7 +3732,9 @@ class FastLlamaModel:
             assert hasattr(model.get_output_embeddings(), "modules_to_save")
 
             _offload_frozen_module_for_training(
-                model.get_output_embeddings(), DEVICE_TYPE_TORCH, offload_device = None,
+                model.get_output_embeddings(),
+                DEVICE_TYPE_TORCH,
+                offload_device = None,
                 original_device = output_embeddings_device,
             )
 


### PR DESCRIPTION
### What breaks

Continued pretraining puts `embed_tokens` and `lm_head` in `target_modules`, so PEFT wraps each one in a `ModulesToSaveWrapper`. `llama.py` then calls `_offload_frozen_module_for_training` to move the trainable copy onto the accelerator and offload the frozen original to CPU, passing `DEVICE_TYPE_TORCH`:

```python
_offload_frozen_module_for_training(model.get_input_embeddings(),  DEVICE_TYPE_TORCH)
_offload_frozen_module_for_training(model.get_output_embeddings(), DEVICE_TYPE_TORCH)
```

`DEVICE_TYPE_TORCH` is the bare string `"cuda"`, and a bare `"cuda"` carries no index:

```
>>> torch.device("cuda").index is None
True
>>> torch.zeros(2).to("cuda").device
device(type='cuda', index=0)
```

The helper then did:

```python
module.modules_to_save.default.to(device = device_type, dtype = new_dtype, non_blocking = True)
```

So on a model the loader split across cards, a copy sitting on cuda:1 was moved to **cuda:0** while the rest of its layer stayed on cuda:1, and the forward then mixed devices. The destination was decided by the current CUDA device rather than by the placement the loader chose, so it ignored `hf_device_map` entirely.

### Why it was not noticed

Single-GPU runs cannot see it. There cuda:0 is where the copy already is, so the move is a no-op and every existing test passes. It needs a second card **and** `embed_tokens` or `lm_head` in `target_modules`, which is the continued-pretraining recipe specifically, not the ordinary LoRA one.

### The fix

Keep the index the copy already has when it is on the right kind of device. A copy still on cpu or meta has no index to keep and is moved exactly as before, so the single-GPU path is byte for byte unchanged.

### Tests

`tests/test_offload_frozen_module_device.py`, 13 tests.

Twelve drive the real helper with a stub that **records** the device it is handed rather than allocating. That is deliberate rather than a shortcut: the case under test is a second card, and recording the argument tests the decision on any box, including CI runners with no GPU. The thirteenth allocates for real, is skipped without CUDA, and covers only the no-regression direction, which one card is enough for.

Mutation tested by restoring `device = device_type`. Three tests fail, including the one that names the regression:

```
FAILED test_a_copy_on_the_second_card_stays_on_the_second_card
FAILED test_a_copy_on_the_third_card_stays_on_the_third_card
FAILED test_a_copy_on_the_first_card_is_unchanged
```

Also covered so the fix cannot quietly drop the behaviour around it: float16 is still promoted to float32 for Tesla T4 (#1200), bfloat16 is left alone, only the trainable copy gets `requires_grad`, the frozen original still goes to CPU, `offload_device = None` still leaves it in place, and a module with no `modules_to_save` is still untouched.

### Scope

Found while investigating #9995 and deliberately kept out of it, since that PR is about dispatch hooks and this is about a placement decision. The two are independent and neither depends on the other.

I do not have a two-card box to hand, so the multi-card behaviour here is asserted through the recorded device argument and the source, not measured on two GPUs. The single-card no-regression direction is measured.
