### PR TITLE
Stop three Backend CI tests measuring the runner instead of the code

### DIFF
--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1333,7 +1333,14 @@ def test_stream_completion_timeout_is_absolute_despite_keepalives(monkeypatch):
                 [{"role": "user"}],
                 report_progress = False,
             ),
-            timeout = 1,
+            # A hang guard, not the assertion. What is under test is that the run's own
+            # 0.05s deadline is absolute even though keepalives keep arriving, and that
+            # is what pytest.raises checks; this only stops a regression that never
+            # returns from wedging the suite. At 1s it was the tighter of the two on a
+            # loaded runner, so it fired first and the test failed with TimeoutError
+            # instead of the ReadTimeout it was asserting -- a false failure about the
+            # runner. An actual hang is unbounded, so 30s catches it just as well.
+            timeout = 30,
         )
 
     with pytest.raises(httpx.ReadTimeout):


### PR DESCRIPTION
## What is red

`(Python 3.13)` is failing on 22 open PRs. It is **not one failure**. Pulling the failing test name out of each job:

| PR | failing test(s) |
| --- | --- |
| 10000 | `test_conversation_archive.py` x3 |
| 9983 | `test_openai_auto_switch.py` x2, `test_parallel_slots_per_load.py` |
| 9981 | `test_rag_whole_document.py` x3 |
| 9931 | `test_compute_buffer.py`, `test_openai_auto_switch.py` x2 |
| **10032, 9939** | **`test_event_batch_flushes_while_upstream_is_idle`** |
| **10032** | **`test_stream_completion_timeout_is_absolute_despite_keepalives`** |
| **9902** | **`test_a_cold_health_call_answers_inside_the_launcher_deadline`** |

Most are those branches' own tests, or staleness, and clear on rebase. The three in bold are different: they fail on unrelated branches, one of which (#10032) changes three files under `tests/studio/appimage_*` that none of them import. All three assert on wall clock, and none of them means to.

## The three

**`test_event_batch_flushes_while_upstream_is_idle`** slept a fixed `0.2s` and then asserted the batch had been flushed. On a loaded runner it simply had not been given time yet, which is the observed `assert [] == [{'choices': ...}]`. Now polled to a 30s deadline.

Waiting longer cannot make a broken supervisor pass: the flush has to happen *while upstream is still idle*, and `release` is not set until after the assertion. That is now asserted **inside** the loop, so releasing early fails rather than passing slowly.

**`test_stream_completion_timeout_is_absolute_despite_keepalives`** wrapped the call in `asyncio.wait_for(timeout = 1)`. That is a hang guard, not the assertion -- what is under test is the run's own `0.05s` deadline surviving a keepalive stream, which `pytest.raises(httpx.ReadTimeout)` checks. At 1s the guard was the tighter of the two under load, so it fired first and the test failed with `TimeoutError` instead of the `ReadTimeout` it was asserting. A real hang is unbounded, so 30s catches it just as well.

**`test_a_cold_health_call_answers_inside_the_launcher_deadline`** -- and here the bound is **not** widened. 2.0s is the launcher's real client timeout, read out of the Rust, and a reply past it dead-ends the launch at `desktop_owned_backend_starting`. That number should not move.

What was wrong is the **sampling**. A cold call cannot be warmed and re-measured inside one process, so the test took a single sample, and a single sample on a box running 30,000 other tests measures the box: it failed at `2.15s` with the same setup that measures far under it when the machine is quiet. It now takes the best of three fresh processes and returns on the first that clears the deadline. Setup growing past the deadline is a property of the code, so it is slow in *every* sample and still fails all three; only load is sampled away.

The file already carries a comment from an earlier round of exactly this -- *"The fix is to warm the app first, not to widen the number"* -- and that rule still holds here.

## Verification

Mutation-tested in both directions:

- releasing upstream before the flush is observed **fails** the supervisor test on the new in-loop guard
- a 3s regression placed inside the measured cold window **fails** the health bound across all three samples

My first attempt at that second mutant put the sleep *outside* the timed region and passed, which proved nothing about the assertion; corrected to sit inside the measured window, it fails.

**216 passed** across the three files. `verify_import_hoist` and `lint_exec_literals` clean.

Note for anyone running these locally: `pytest-asyncio` is required to run the supervisor file at all. Without it those tests fail on unmodified `main` too, which is an environment artefact rather than a result.
