### PR TITLE
Answer llama-server discovery probes instead of serving them the app shell

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -2539,8 +2539,6 @@ def setup_frontend(
         # for /v1/* ({"detail": ...} for /api/*). The request path is "/" + full_path.
         if full_path in {"api", "v1"} or full_path.startswith(("api/", "v1/")):
             raise HTTPException(status_code = 404, detail = "API endpoint not found")
-        if is_engine_probe_path(full_path):
-            raise HTTPException(status_code = 404, detail = "API endpoint not found")
         if not _frontend_request_allowed(request):
             return Response(status_code = 404)
 
@@ -2552,6 +2550,13 @@ def setup_frontend(
 
         if file_path.is_file():
             return FileResponse(file_path)
+
+        # Last, so a real asset always wins: an engine endpoint Studio does not serve
+        # must 404 rather than render the app shell, which reads as "supported" to a
+        # client that checks the status before the body. Deliberately after the file
+        # lookup -- a build that ever ships one of these names still serves it.
+        if is_engine_probe_path(full_path):
+            raise HTTPException(status_code = 404, detail = "API endpoint not found")
 
         # Serve index.html as bytes — avoids Content-Length mismatch
         return _build_index_response(request)

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -317,6 +317,7 @@ from routes import (
     youtube_router,
 )
 from routes.llama import router as llama_router
+from routes.llama_compat import is_engine_probe_path, router as llama_compat_router
 from routes.whisper import router as whisper_router
 from routes.preview import router as preview_router
 from hub.routes import (
@@ -1460,6 +1461,11 @@ app.include_router(video_openai_router, prefix = "/v1", tags = ["openai-compat"]
 
 # OpenAI-compatible: mount the inference router at /v1 for external tools.
 app.include_router(inference_router, prefix = "/v1", tags = ["openai-compat"])
+# llama-server / Ollama discovery probes. Declares its own full paths (/props,
+# /version, /api/tags, ...) so it needs no prefix, and must be registered here --
+# ahead of the SPA catch-all in serve_frontend() -- or /props and /version go on
+# resolving to index.html with a 200.
+app.include_router(llama_compat_router, tags = ["openai-compat"])
 app.include_router(preview_router, prefix = "/p", tags = ["preview"])
 app.include_router(providers_router, prefix = "/api/providers", tags = ["providers"])
 
@@ -2532,6 +2538,8 @@ def setup_frontend(
         # Unknown API paths: raise a real 404 so the api_errors handlers render the right envelope
         # for /v1/* ({"detail": ...} for /api/*). The request path is "/" + full_path.
         if full_path in {"api", "v1"} or full_path.startswith(("api/", "v1/")):
+            raise HTTPException(status_code = 404, detail = "API endpoint not found")
+        if is_engine_probe_path(full_path):
             raise HTTPException(status_code = 404, detail = "API endpoint not found")
         if not _frontend_request_allowed(request):
             return Response(status_code = 404)

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -25,6 +25,7 @@ publishes, so none of it may be looser than the endpoint it mirrors.
 from __future__ import annotations
 
 import asyncio
+import functools
 import time
 from typing import Any, Optional
 
@@ -72,13 +73,23 @@ def is_engine_probe_path(full_path: str) -> bool:
 
 # Ollama clients read modified_at as an RFC3339 stamp and reject a bare epoch.
 _EPOCH_FMT = "%Y-%m-%dT%H:%M:%SZ"
+_EPOCH_ZERO = "1970-01-01T00:00:00Z"
+# RFC3339 wants a four digit year, so the value is clamped to 1970..9999 rather than
+# passed through. That also makes the three platforms agree: gmtime() accepts a wildly
+# out of range epoch on Linux and returns a five digit year no client can parse,
+# rejects anything before 1970 on macOS, and rejects both ends on Windows. Clamping
+# first means the same catalog row renders identically everywhere.
+_EPOCH_MAX = 253402300799  # 9999-12-31T23:59:59Z
 
 
 def _rfc3339(epoch: Optional[int]) -> str:
     try:
-        return time.strftime(_EPOCH_FMT, time.gmtime(int(epoch or 0)))
+        seconds = min(max(int(epoch or 0), 0), _EPOCH_MAX)
+        return time.strftime(_EPOCH_FMT, time.gmtime(seconds))
     except (OverflowError, OSError, TypeError, ValueError):
-        return time.strftime(_EPOCH_FMT, time.gmtime(0))
+        # A literal, not another gmtime() call: on a platform strict enough to reject
+        # the value above, the fallback would raise out of the handler too.
+        return _EPOCH_ZERO
 
 
 def _inference():
@@ -94,9 +105,20 @@ def _inference():
     return inference
 
 
+@functools.lru_cache(maxsize = 1)
 def _studio_version() -> str:
-    from utils.studio_version import get_studio_version
+    """The version string, resolved once.
+
+    Cached because get_studio_version() shells out to git twice on a source checkout,
+    and these handlers are the only ones that call it per request. The answer cannot
+    change inside a process, and uncached it would put two subprocess spawns on the
+    event loop for every /version probe: cheap on Linux, not on Windows, where
+    spawning costs an order of magnitude more.
+    """
     try:
+        # Inside the guard, not above it: an ImportError here would 500 a probe that
+        # has nothing to do with versions.
+        from utils.studio_version import get_studio_version
         return get_studio_version()
     except Exception:  # noqa: BLE001 -- discovery must not 500 on a version lookup
         return "dev"
@@ -131,9 +153,14 @@ def _server_props() -> dict:
     public_id = _loaded_public_model_id()
     props: dict[str, Any] = {}
     if getattr(llama_backend, "is_loaded", False):
-        # Bounded (5s) and returns None rather than raising, so an engine that is
-        # mid-restart degrades to the local view instead of failing the probe.
-        upstream = llama_backend._query_server_props()
+        # Bounded (5s) and documented to return None rather than raise, so an engine
+        # that is mid-restart degrades to the local view instead of failing the probe.
+        # Belt and braces anyway: a probe is the wrong place to discover that the
+        # contract slipped, and the local view is always answerable.
+        try:
+            upstream = llama_backend._query_server_props()
+        except Exception:  # noqa: BLE001
+            upstream = None
         if isinstance(upstream, dict):
             props = dict(upstream)
 

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -170,10 +170,8 @@ def _server_props() -> dict:
     return props
 
 
-# Slash forms too. FastAPI's redirect never fires for these: the SPA catch-all is a
-# full match for "/props/", so the request lands there and comes back as index.html --
-# the original defect, still live for a client that does not canonicalize. routes/
-# inference.py registers "/v1/models/" for the same reason.
+# Slash forms too: FastAPI's redirect never fires, since the catch-all fully matches
+# "/props/" and returns index.html. routes/inference.py registers "/v1/models/" likewise.
 @router.get("/props", include_in_schema = False)
 @router.get("/props/", include_in_schema = False)
 @router.get("/v1/props", include_in_schema = False)

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -170,14 +170,21 @@ def _server_props() -> dict:
     return props
 
 
+# Slash forms too. FastAPI's redirect never fires for these: the SPA catch-all is a
+# full match for "/props/", so the request lands there and comes back as index.html --
+# the original defect, still live for a client that does not canonicalize. routes/
+# inference.py registers "/v1/models/" for the same reason.
 @router.get("/props", include_in_schema = False)
+@router.get("/props/", include_in_schema = False)
 @router.get("/v1/props", include_in_schema = False)
+@router.get("/v1/props/", include_in_schema = False)
 async def llama_props(current_subject: str = Depends(get_current_subject)):
     """llama-server-compatible ``GET /props``."""
     return await asyncio.to_thread(_server_props)
 
 
 @router.get("/version", include_in_schema = False)
+@router.get("/version/", include_in_schema = False)
 async def studio_version(current_subject: str = Depends(get_current_subject)):
     """Bare /version only: Ollama spells it /api/version, and answering there is part
     of claiming to be Ollama."""

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -3,28 +3,15 @@
 
 """Answer engine discovery probes with JSON, or with a 404, but never with the app.
 
-Studio already answers the OpenAI surface (``GET /v1/models``,
-``POST /v1/chat/completions``), and clients that reach a local port probe the
-engine endpoints alongside it to work out what they are talking to. Those probes
-used to land on the SPA catch-all in main.py, which serves index.html for anything
-that is not under ``/api/`` or ``/v1/``: a client asking ``GET /props`` got 200 and
-a page of HTML. 200-with-HTML is worse than a 404, because a probe reads the status
-first and only then fails on the body.
+Probes for engine endpoints used to land on main.py's SPA catch-all, so ``GET /props``
+returned 200 and a page of HTML. That is worse than a 404: a probe reads the status
+before the body. Served here: ``/props``, ``/v1/props``, ``/version``. Everything else
+in llama-server's table gets an explicit 404, on its real method as well as GET.
 
-GET  /props, /v1/props  -> llama-server's props, with model_path replaced by the
-                           public model id (never the on-disk .gguf path)
-GET  /version           -> {"version": ...}
-
-Everything else llama-server serves and Studio does not -- /slots, /completion,
-/tokenize, ... -- gets an explicit 404 (``_ENGINE_PROBE_PATHS``), on the real HTTP
-method as well as GET.
-
-Deliberately NOT served: Ollama's ``/api/tags`` and ``/api/show``. Answering those
-identifies this server as Ollama, and a client that completes Ollama discovery then
-posts to ``/api/chat`` or ``/api/generate``, which Studio does not serve, so it would
-fail at generation instead of falling back to the OpenAI surface that does work. The
-reporting user's client did exactly that fallback and succeeded. Advertising a
-protocol we do not implement is the same defect as the HTML 200, one layer up.
+Deliberately NOT served: Ollama's ``/api/tags`` and ``/api/show``. Answering them makes
+a client select Ollama and then fail on ``/api/chat``, which Studio does not implement;
+the reporting user's client instead fell back to the OpenAI surface and worked.
+Advertising a protocol we do not have is the HTML 200 again, one layer up.
 """
 
 from __future__ import annotations
@@ -43,15 +30,8 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-# Unprefixed endpoints llama-server and Ollama serve that Studio does not. The SPA
-# catch-all in main.py answers anything outside /api/ and /v1/ with index.html, so
-# without this a probe for /slots or /completion gets 200 plus a page of HTML --
-# which reads as "supported" to every client that checks the status before the body.
-# Transcribed from llama-server's own route table (tools/server/server.cpp,
-# ctx_http.get/post), minus /props, which this module serves. Enumerated from the
-# source rather than added one at a time as clients trip over them, so the set is
-# complete instead of merely growing. Bare paths only: Studio's own API lives under
-# /api/ and /v1/, so nothing here can shadow it.
+# llama-server's table (tools/server/server.cpp) minus /props, so the set is complete
+# rather than growing per complaint. Bare only, so it cannot shadow /api/ or /v1/.
 _ENGINE_PROBE_PATHS = frozenset(
     {
         "apply-template",
@@ -82,17 +62,11 @@ _ENGINE_PROBE_PATHS = frozenset(
     }
 )
 
-# /slots/:id_slot is a real llama-server route and Studio calls it itself
-# (restore_slots_for_resume), so the id has to be matched dynamically rather than
-# enumerated. Only this one prefix is dynamic in the table above.
+# /slots/:id_slot is the one dynamic entry in that table, and Studio calls it itself.
 _ENGINE_PROBE_PREFIXES = ("slots/",)
 
-# The /v1-prefixed entries in the same llama-server table that Studio does not
-# implement. Kept separate from the bare set because the two are checked differently:
-# main.py already 404s an unknown GET under /v1/, so only the other methods need a
-# route here. Hardcoded rather than derived from the live route table at import time,
-# with a test that asserts each really is absent from the assembled app -- if Studio
-# ever implements one, CI says to delete the line instead of silently shadowing it.
+# The /v1 entries Studio does not implement. A test asserts each is really absent from
+# the assembled app, so implementing one fails CI instead of being shadowed by a 404.
 _UNSERVED_V1_PROBE_PATHS = frozenset(
     {
         "v1/chat/completions/control",
@@ -114,31 +88,18 @@ def is_engine_probe_path(full_path: str) -> bool:
 
 
 def _inference():
-    """``routes.inference``, imported at call time.
-
-    routes.inference pulls the whole inference stack, and this module is imported
-    from main.py's route table, so the import has to be deferred. Everything here
-    goes through this one function rather than importing inline in each handler:
-    a test can then hand these handlers a double by replacing it, instead of
-    mutating sys.modules for the rest of the suite.
-    """
+    """``routes.inference``, deferred because it pulls the whole inference stack. One
+    indirection, so a test replaces this instead of mutating sys.modules."""
     from routes import inference
     return inference
 
 
 @functools.lru_cache(maxsize = 1)
 def _studio_version() -> str:
-    """The version string, resolved once.
-
-    Cached because get_studio_version() shells out to git twice on a source checkout,
-    and these handlers are the only ones that call it per request. The answer cannot
-    change inside a process, and uncached it would put two subprocess spawns on the
-    event loop for every /version probe: cheap on Linux, not on Windows, where
-    spawning costs an order of magnitude more.
-    """
+    """The version string, resolved once: get_studio_version() shells out to git twice
+    on a source checkout, and uncached that lands on the event loop per probe."""
     try:
-        # Inside the guard, not above it: an ImportError here would 500 a probe that
-        # has nothing to do with versions.
+        # Inside the guard: an ImportError here would 500 a probe about something else.
         from utils.studio_version import get_studio_version
         return get_studio_version()
     except Exception:  # noqa: BLE001 -- discovery must not 500 on a version lookup
@@ -151,34 +112,22 @@ def _loaded_public_model_id() -> Optional[str]:
     llama_backend = inf.get_llama_cpp_backend()
     if getattr(llama_backend, "is_loaded", False):
         return inf._llama_public_model_id(llama_backend)
-    # _peek_inference_backend does not force the orchestrator's cold build, which
-    # waits on hardware detection; a probe must not pay for that.
+    # peek, not get: the orchestrator's cold build waits on hardware detection.
     orchestrator = inf._peek_inference_backend()
     if orchestrator is not None and getattr(orchestrator, "active_model_name", None):
         return inf._orchestrator_public_model_id(orchestrator)
     return None
 
 
-# ── /props ────────────────────────────────────────────────────────────────────
-
-
 def _server_props() -> dict:
-    """llama-server's /props with the on-disk path stripped.
-
-    Upstream reports model_path as the absolute .gguf path. Every other Studio
-    response maps that to the public id (see core.inference.model_ids), and this
-    one is reachable over LAN, so it does the same rather than leaking the layout
-    of the user's disk.
-    """
+    """llama-server's /props, with model_path mapped to the public id like every other
+    Studio response: upstream reports the absolute .gguf path and this is LAN reachable."""
     llama_backend = _inference().get_llama_cpp_backend()
     public_id = _loaded_public_model_id()
     llama_loaded = bool(getattr(llama_backend, "is_loaded", False))
     props: dict[str, Any] = {}
     if llama_loaded:
-        # Bounded (5s) and documented to return None rather than raise, so an engine
-        # that is mid-restart degrades to the local view instead of failing the probe.
-        # Belt and braces anyway: a probe is the wrong place to discover that the
-        # contract slipped, and the local view is always answerable.
+        # Documented not to raise, but a probe is the wrong place to find out it does.
         try:
             upstream = llama_backend._query_server_props()
         except Exception:  # noqa: BLE001
@@ -190,23 +139,17 @@ def _server_props() -> dict:
     if public_id:
         props["model_path"] = public_id
 
-    # The child's props describe the CHILD's route table and its built-in web UI, none
-    # of which is reachable through Studio. Copying them verbatim points a client using
-    # props for capability discovery at endpoints that 404 here: Studio launches
-    # llama-server with --metrics, so endpoint_metrics arrives true while public
-    # /metrics is one of the paths this module deliberately denies (verified against
-    # tools/server/server-context.cpp, which puts all three flags in the payload).
+    # These describe the CHILD's route table and web UI, not ours: Studio launches with
+    # --metrics, so endpoint_metrics arrives true while public /metrics 404s here
+    # (tools/server/server-context.cpp puts all three flags in the payload).
     for _child_only in ("ui", "ui_settings", "cors_proxy_enabled"):
         props.pop(_child_only, None)
     props["endpoint_slots"] = False
     props["endpoint_props"] = False
     props["endpoint_metrics"] = False
 
-    # Only when llama-server owns the resident model. With a Transformers or MLX model
-    # loaded the llama backend is unloaded, and reading its fields anyway would pair the
-    # orchestrator's model_path with n_ctx 0, an empty template and total_slots 0 -- a
-    # self-contradictory description of a model that is in fact serving. Omitting them
-    # says "no llama-server props to report", which is true.
+    # Only when llama-server owns the resident model: with MLX loaded, reading the
+    # unloaded llama backend describes a serving model as having no context or slots.
     if llama_loaded:
         props.setdefault("default_generation_settings", {})
         settings = props["default_generation_settings"]
@@ -215,10 +158,7 @@ def _server_props() -> dict:
             if n_ctx:
                 settings["n_ctx"] = int(n_ctx)
         if "total_slots" not in props:
-            # A transient /props read failure must not report zero slots next to a model
-            # this same response advertises as loaded: a client reading props for
-            # capacity concludes the model cannot serve. The backend knows the number it
-            # launched with; if even that is unreadable, omit rather than claim zero.
+            # Not zero beside a model this response advertises as loaded.
             try:
                 slots = int(getattr(llama_backend, "effective_parallel_slots", 0) or 0)
             except Exception:  # noqa: BLE001
@@ -237,32 +177,21 @@ async def llama_props(current_subject: str = Depends(get_current_subject)):
     return await asyncio.to_thread(_server_props)
 
 
-# ── /version ──────────────────────────────────────────────────────────────────
-
-
 @router.get("/version", include_in_schema = False)
 async def studio_version(current_subject: str = Depends(get_current_subject)):
-    """Version probe. Bare /version only -- Ollama spells it /api/version, and
-    answering there is part of claiming to be Ollama."""
+    """Bare /version only: Ollama spells it /api/version, and answering there is part
+    of claiming to be Ollama."""
     return {"version": _studio_version()}
-
-
-# ── probe paths Studio does not serve ─────────────────────────────────────────
 
 
 async def _probe_not_found():
     raise HTTPException(status_code = 404, detail = "API endpoint not found")
 
 
-# GET is deliberately absent: it stays with the SPA catch-all, which looks for a real
-# asset first and only then applies is_engine_probe_path(). Registering GET here would
-# shadow that lookup. Without these, a POST to /completion or /tokenize matched the
-# GET-only catch-all and returned 405, which a discovery client reads as "the endpoint
-# exists, wrong method" -- the same false positive the 404 is meant to close, and these
-# endpoints are POST in llama-server. HEAD is listed explicitly: Starlette does NOT
-# admit HEAD on a GET route (measured on the pinned fastapi 0.141.1 / starlette 1.6.0,
-# HEAD /completion -> 405), so a HEAD probe would infer the endpoint exists. OPTIONS is
-# left alone so CORS preflight is unaffected.
+# Without these a POST hit the GET-only catch-all and returned 405, reading as "exists,
+# wrong method". HEAD is here because Starlette does not admit it on a GET route
+# (measured, fastapi 0.141.1). GET stays with the catch-all so its asset lookup wins;
+# OPTIONS is untouched for CORS preflight.
 _PROBE_DENIED_METHODS = ["HEAD", "POST", "PUT", "PATCH", "DELETE"]
 
 for _probe_path in sorted(_ENGINE_PROBE_PATHS):
@@ -273,12 +202,7 @@ for _probe_path in sorted(_ENGINE_PROBE_PATHS):
         include_in_schema = False,
     )
 
-# The one dynamic entry in llama-server's table, so it needs a path parameter rather
-# than a literal: without it POST /slots/0 falls through to the GET-only catch-all and
-# answers 405, which is the false positive again. Both slash forms, because FastAPI's
-# slash redirect does not apply to a path that matches no route at all.
-# main.py answers an unknown GET under /v1/ with a real 404 already, so only the other
-# methods can still reach the GET-only catch-all and come back 405.
+# main.py already 404s an unknown GET under /v1/, so only the other methods need these.
 for _v1_path in sorted(_UNSERVED_V1_PROBE_PATHS):
     router.add_api_route(
         f"/{_v1_path}",
@@ -287,6 +211,7 @@ for _v1_path in sorted(_UNSERVED_V1_PROBE_PATHS):
         include_in_schema = False,
     )
 
+# Both slash forms: FastAPI's slash redirect does not apply to a path matching no route.
 for _slots_form in ("/slots/{id_slot}", "/slots/{id_slot}/"):
     router.add_api_route(
         _slots_form,

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -1,36 +1,39 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""The llama-server / Ollama discovery surface, so third-party clients can probe us.
+"""Answer engine discovery probes with JSON, or with a 404, but never with the app.
 
 Studio already answers the OpenAI surface (``GET /v1/models``,
-``POST /v1/chat/completions``), and clients that reach a local port commonly probe
-llama-server's and Ollama's discovery endpoints alongside it to work out what they
-are talking to. Those probes used to land on the SPA catch-all in main.py, which
-serves index.html for anything that is not under ``/api/`` or ``/v1/``: a client
-asking ``GET /props`` got 200 and a page of HTML. 200-with-HTML is worse than a
-404, because a probe reads the status first and only then fails on the body.
+``POST /v1/chat/completions``), and clients that reach a local port probe the
+engine endpoints alongside it to work out what they are talking to. Those probes
+used to land on the SPA catch-all in main.py, which serves index.html for anything
+that is not under ``/api/`` or ``/v1/``: a client asking ``GET /props`` got 200 and
+a page of HTML. 200-with-HTML is worse than a 404, because a probe reads the status
+first and only then fails on the body.
 
 GET  /props, /v1/props  -> llama-server's props, with model_path replaced by the
                            public model id (never the on-disk .gguf path)
-GET  /version, /api/version -> {"version": ...}, the Ollama shape
-GET  /api/tags          -> the catalog in Ollama's list shape
-POST /api/show          -> one model in Ollama's show shape
+GET  /version           -> {"version": ...}
 
-Read-only and authenticated exactly like ``GET /v1/models``: /props carries the
-chat template and the slot count, and the listings carry the same ids /v1/models
-publishes, so none of it may be looser than the endpoint it mirrors.
+Everything else llama-server serves and Studio does not -- /slots, /completion,
+/tokenize, ... -- gets an explicit 404 (``_ENGINE_PROBE_PATHS``), on the real HTTP
+method as well as GET.
+
+Deliberately NOT served: Ollama's ``/api/tags`` and ``/api/show``. Answering those
+identifies this server as Ollama, and a client that completes Ollama discovery then
+posts to ``/api/chat`` or ``/api/generate``, which Studio does not serve, so it would
+fail at generation instead of falling back to the OpenAI surface that does work. The
+reporting user's client did exactly that fallback and succeeded. Advertising a
+protocol we do not implement is the same defect as the HTML 200, one layer up.
 """
 
 from __future__ import annotations
 
 import asyncio
 import functools
-import time
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException
 
 from auth.authentication import get_current_subject
 from loggers import get_logger
@@ -69,27 +72,6 @@ _ENGINE_PROBE_PATHS = frozenset(
 def is_engine_probe_path(full_path: str) -> bool:
     """True for an engine endpoint that must 404 rather than render the app shell."""
     return full_path.strip("/").lower() in _ENGINE_PROBE_PATHS
-
-
-# Ollama clients read modified_at as an RFC3339 stamp and reject a bare epoch.
-_EPOCH_FMT = "%Y-%m-%dT%H:%M:%SZ"
-_EPOCH_ZERO = "1970-01-01T00:00:00Z"
-# RFC3339 wants a four digit year, so the value is clamped to 1970..9999 rather than
-# passed through. That also makes the three platforms agree: gmtime() accepts a wildly
-# out of range epoch on Linux and returns a five digit year no client can parse,
-# rejects anything before 1970 on macOS, and rejects both ends on Windows. Clamping
-# first means the same catalog row renders identically everywhere.
-_EPOCH_MAX = 253402300799  # 9999-12-31T23:59:59Z
-
-
-def _rfc3339(epoch: Optional[int]) -> str:
-    try:
-        seconds = min(max(int(epoch or 0), 0), _EPOCH_MAX)
-        return time.strftime(_EPOCH_FMT, time.gmtime(seconds))
-    except (OverflowError, OSError, TypeError, ValueError):
-        # A literal, not another gmtime() call: on a platform strict enough to reject
-        # the value above, the fallback would raise out of the handler too.
-        return _EPOCH_ZERO
 
 
 def _inference():
@@ -151,8 +133,9 @@ def _server_props() -> dict:
     """
     llama_backend = _inference().get_llama_cpp_backend()
     public_id = _loaded_public_model_id()
+    llama_loaded = bool(getattr(llama_backend, "is_loaded", False))
     props: dict[str, Any] = {}
-    if getattr(llama_backend, "is_loaded", False):
+    if llama_loaded:
         # Bounded (5s) and documented to return None rather than raise, so an engine
         # that is mid-restart degrades to the local view instead of failing the probe.
         # Belt and braces anyway: a probe is the wrong place to discover that the
@@ -167,14 +150,21 @@ def _server_props() -> dict:
     props.pop("model_path", None)
     if public_id:
         props["model_path"] = public_id
-    props.setdefault("default_generation_settings", {})
-    settings = props["default_generation_settings"]
-    if isinstance(settings, dict) and "n_ctx" not in settings:
-        n_ctx = getattr(llama_backend, "context_length", None)
-        if n_ctx:
-            settings["n_ctx"] = int(n_ctx)
-    props.setdefault("total_slots", 0)
-    props.setdefault("chat_template", getattr(llama_backend, "chat_template", "") or "")
+
+    # Only when llama-server owns the resident model. With a Transformers or MLX model
+    # loaded the llama backend is unloaded, and reading its fields anyway would pair the
+    # orchestrator's model_path with n_ctx 0, an empty template and total_slots 0 -- a
+    # self-contradictory description of a model that is in fact serving. Omitting them
+    # says "no llama-server props to report", which is true.
+    if llama_loaded:
+        props.setdefault("default_generation_settings", {})
+        settings = props["default_generation_settings"]
+        if isinstance(settings, dict) and "n_ctx" not in settings:
+            n_ctx = getattr(llama_backend, "context_length", None)
+            if n_ctx:
+                settings["n_ctx"] = int(n_ctx)
+        props.setdefault("total_slots", 0)
+        props.setdefault("chat_template", getattr(llama_backend, "chat_template", "") or "")
     props["build_info"] = f"unsloth-studio/{_studio_version()}"
     return props
 
@@ -190,94 +180,30 @@ async def llama_props(current_subject: str = Depends(get_current_subject)):
 
 
 @router.get("/version", include_in_schema = False)
-@router.get("/api/version", include_in_schema = False)
-async def ollama_version(current_subject: str = Depends(get_current_subject)):
-    """Ollama-compatible version probe."""
+async def studio_version(current_subject: str = Depends(get_current_subject)):
+    """Version probe. Bare /version only -- Ollama spells it /api/version, and
+    answering there is part of claiming to be Ollama."""
     return {"version": _studio_version()}
 
 
-# ── /api/tags ─────────────────────────────────────────────────────────────────
+# ── probe paths Studio does not serve ─────────────────────────────────────────
 
 
-def _ollama_details(model: dict) -> dict:
-    return {
-        "parent_model": "",
-        "format": "gguf",
-        "family": "",
-        "families": None,
-        "parameter_size": "",
-        # Ollama clients display this verbatim; the catalog's quant is the honest
-        # answer and an empty string is the honest answer when there is none.
-        "quantization_level": str(model.get("quant") or ""),
-    }
+async def _probe_not_found():
+    raise HTTPException(status_code = 404, detail = "API endpoint not found")
 
 
-def _ollama_tag(model: dict) -> dict:
-    model_id = str(model.get("id") or "")
-    return {
-        "name": model_id,
-        "model": model_id,
-        "modified_at": _rfc3339(model.get("created")),
-        # Ollama publishes a byte size and a blob digest. Studio's catalog carries
-        # neither for every entry, and inventing them would make a client believe a
-        # digest it could compare against. 0 and "" are the documented empty values.
-        "size": 0,
-        "digest": "",
-        "details": _ollama_details(model),
-    }
-
-
-@router.get("/api/tags", include_in_schema = False)
-async def ollama_tags(current_subject: str = Depends(get_current_subject)):
-    """Ollama-compatible model listing, from the same catalog as ``GET /v1/models``."""
-    models = await _inference()._openai_catalog_objects()
-    return {"models": [_ollama_tag(m) for m in models]}
-
-
-# ── /api/show ─────────────────────────────────────────────────────────────────
-
-
-class OllamaShowRequest(BaseModel):
-    # Ollama accepts either spelling and clients send both; neither is required,
-    # so an empty body falls back to whatever is loaded rather than 422-ing a probe.
-    model: Optional[str] = None
-    name: Optional[str] = None
-
-
-@router.post("/api/show", include_in_schema = False)
-async def ollama_show(
-    body: Optional[OllamaShowRequest] = None, current_subject: str = Depends(get_current_subject)
-):
-    """Ollama-compatible model detail (``POST /api/show``)."""
-    from fastapi import HTTPException
-
-    requested = None
-    if body is not None:
-        requested = body.model or body.name
-    requested = (requested or _loaded_public_model_id() or "").strip()
-    if not requested:
-        raise HTTPException(status_code = 404, detail = "model not found")
-
-    models = await _inference()._openai_catalog_objects()
-    # Case-insensitive, matching /v1/models/{id}: the resolver lowercases its index.
-    match = next(
-        (m for m in models if str(m.get("id") or "").lower() == requested.lower()),
-        None,
+# GET is deliberately absent: it stays with the SPA catch-all, which looks for a real
+# asset first and only then applies is_engine_probe_path(). Registering GET here would
+# shadow that lookup. Without these, a POST to /completion or /tokenize matched the
+# GET-only catch-all and returned 405, which a discovery client reads as "the endpoint
+# exists, wrong method" -- the same false positive the 404 is meant to close, and these
+# endpoints are POST in llama-server. OPTIONS is left alone so CORS preflight is
+# unaffected; HEAD already resolves against the catch-all's GET route.
+for _probe_path in sorted(_ENGINE_PROBE_PATHS):
+    router.add_api_route(
+        f"/{_probe_path}",
+        _probe_not_found,
+        methods = ["POST", "PUT", "PATCH", "DELETE"],
+        include_in_schema = False,
     )
-    if match is None:
-        raise HTTPException(status_code = 404, detail = "model not found")
-
-    capabilities = ["completion"]
-    if match.get("supports_tools"):
-        capabilities.append("tools")
-    if match.get("supports_vision"):
-        capabilities.append("vision")
-    return {
-        "license": "",
-        "modelfile": "",
-        "parameters": "",
-        "template": "",
-        "details": _ollama_details(match),
-        "model_info": {},
-        "capabilities": capabilities,
-    }

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The llama-server / Ollama discovery surface, so third-party clients can probe us.
+
+Studio already answers the OpenAI surface (``GET /v1/models``,
+``POST /v1/chat/completions``), and clients that reach a local port commonly probe
+llama-server's and Ollama's discovery endpoints alongside it to work out what they
+are talking to. Those probes used to land on the SPA catch-all in main.py, which
+serves index.html for anything that is not under ``/api/`` or ``/v1/``: a client
+asking ``GET /props`` got 200 and a page of HTML. 200-with-HTML is worse than a
+404, because a probe reads the status first and only then fails on the body.
+
+GET  /props, /v1/props  -> llama-server's props, with model_path replaced by the
+                           public model id (never the on-disk .gguf path)
+GET  /version, /api/version -> {"version": ...}, the Ollama shape
+GET  /api/tags          -> the catalog in Ollama's list shape
+POST /api/show          -> one model in Ollama's show shape
+
+Read-only and authenticated exactly like ``GET /v1/models``: /props carries the
+chat template and the slot count, and the listings carry the same ids /v1/models
+publishes, so none of it may be looser than the endpoint it mirrors.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from auth.authentication import get_current_subject
+from loggers import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+
+# Unprefixed endpoints llama-server and Ollama serve that Studio does not. The SPA
+# catch-all in main.py answers anything outside /api/ and /v1/ with index.html, so
+# without this a probe for /slots or /completion gets 200 plus a page of HTML --
+# which reads as "supported" to every client that checks the status before the body.
+# The paths this module DOES serve are absent on purpose: they are real routes now,
+# matched before the catch-all, and listing them here would be dead weight.
+_ENGINE_PROBE_PATHS = frozenset(
+    {
+        "apply-template",
+        "completion",
+        "completions",
+        "detokenize",
+        "embedding",
+        "embeddings",
+        "health",
+        "infill",
+        "lora-adapters",
+        "metrics",
+        "rerank",
+        "reranking",
+        "slots",
+        "tokenize",
+    }
+)
+
+
+def is_engine_probe_path(full_path: str) -> bool:
+    """True for an engine endpoint that must 404 rather than render the app shell."""
+    return full_path.strip("/").lower() in _ENGINE_PROBE_PATHS
+
+
+# Ollama clients read modified_at as an RFC3339 stamp and reject a bare epoch.
+_EPOCH_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _rfc3339(epoch: Optional[int]) -> str:
+    try:
+        return time.strftime(_EPOCH_FMT, time.gmtime(int(epoch or 0)))
+    except (OverflowError, OSError, TypeError, ValueError):
+        return time.strftime(_EPOCH_FMT, time.gmtime(0))
+
+
+def _inference():
+    """``routes.inference``, imported at call time.
+
+    routes.inference pulls the whole inference stack, and this module is imported
+    from main.py's route table, so the import has to be deferred. Everything here
+    goes through this one function rather than importing inline in each handler:
+    a test can then hand these handlers a double by replacing it, instead of
+    mutating sys.modules for the rest of the suite.
+    """
+    from routes import inference
+    return inference
+
+
+def _studio_version() -> str:
+    from utils.studio_version import get_studio_version
+    try:
+        return get_studio_version()
+    except Exception:  # noqa: BLE001 -- discovery must not 500 on a version lookup
+        return "dev"
+
+
+def _loaded_public_model_id() -> Optional[str]:
+    """The id ``/v1/models`` publishes for whatever is resident, or None."""
+    inf = _inference()
+    llama_backend = inf.get_llama_cpp_backend()
+    if getattr(llama_backend, "is_loaded", False):
+        return inf._llama_public_model_id(llama_backend)
+    # _peek_inference_backend does not force the orchestrator's cold build, which
+    # waits on hardware detection; a probe must not pay for that.
+    orchestrator = inf._peek_inference_backend()
+    if orchestrator is not None and getattr(orchestrator, "active_model_name", None):
+        return inf._orchestrator_public_model_id(orchestrator)
+    return None
+
+
+# ── /props ────────────────────────────────────────────────────────────────────
+
+
+def _server_props() -> dict:
+    """llama-server's /props with the on-disk path stripped.
+
+    Upstream reports model_path as the absolute .gguf path. Every other Studio
+    response maps that to the public id (see core.inference.model_ids), and this
+    one is reachable over LAN, so it does the same rather than leaking the layout
+    of the user's disk.
+    """
+    llama_backend = _inference().get_llama_cpp_backend()
+    public_id = _loaded_public_model_id()
+    props: dict[str, Any] = {}
+    if getattr(llama_backend, "is_loaded", False):
+        # Bounded (5s) and returns None rather than raising, so an engine that is
+        # mid-restart degrades to the local view instead of failing the probe.
+        upstream = llama_backend._query_server_props()
+        if isinstance(upstream, dict):
+            props = dict(upstream)
+
+    props.pop("model_path", None)
+    if public_id:
+        props["model_path"] = public_id
+    props.setdefault("default_generation_settings", {})
+    settings = props["default_generation_settings"]
+    if isinstance(settings, dict) and "n_ctx" not in settings:
+        n_ctx = getattr(llama_backend, "context_length", None)
+        if n_ctx:
+            settings["n_ctx"] = int(n_ctx)
+    props.setdefault("total_slots", 0)
+    props.setdefault("chat_template", getattr(llama_backend, "chat_template", "") or "")
+    props["build_info"] = f"unsloth-studio/{_studio_version()}"
+    return props
+
+
+@router.get("/props", include_in_schema = False)
+@router.get("/v1/props", include_in_schema = False)
+async def llama_props(current_subject: str = Depends(get_current_subject)):
+    """llama-server-compatible ``GET /props``."""
+    return await asyncio.to_thread(_server_props)
+
+
+# ── /version ──────────────────────────────────────────────────────────────────
+
+
+@router.get("/version", include_in_schema = False)
+@router.get("/api/version", include_in_schema = False)
+async def ollama_version(current_subject: str = Depends(get_current_subject)):
+    """Ollama-compatible version probe."""
+    return {"version": _studio_version()}
+
+
+# ── /api/tags ─────────────────────────────────────────────────────────────────
+
+
+def _ollama_details(model: dict) -> dict:
+    return {
+        "parent_model": "",
+        "format": "gguf",
+        "family": "",
+        "families": None,
+        "parameter_size": "",
+        # Ollama clients display this verbatim; the catalog's quant is the honest
+        # answer and an empty string is the honest answer when there is none.
+        "quantization_level": str(model.get("quant") or ""),
+    }
+
+
+def _ollama_tag(model: dict) -> dict:
+    model_id = str(model.get("id") or "")
+    return {
+        "name": model_id,
+        "model": model_id,
+        "modified_at": _rfc3339(model.get("created")),
+        # Ollama publishes a byte size and a blob digest. Studio's catalog carries
+        # neither for every entry, and inventing them would make a client believe a
+        # digest it could compare against. 0 and "" are the documented empty values.
+        "size": 0,
+        "digest": "",
+        "details": _ollama_details(model),
+    }
+
+
+@router.get("/api/tags", include_in_schema = False)
+async def ollama_tags(current_subject: str = Depends(get_current_subject)):
+    """Ollama-compatible model listing, from the same catalog as ``GET /v1/models``."""
+    models = await _inference()._openai_catalog_objects()
+    return {"models": [_ollama_tag(m) for m in models]}
+
+
+# ── /api/show ─────────────────────────────────────────────────────────────────
+
+
+class OllamaShowRequest(BaseModel):
+    # Ollama accepts either spelling and clients send both; neither is required,
+    # so an empty body falls back to whatever is loaded rather than 422-ing a probe.
+    model: Optional[str] = None
+    name: Optional[str] = None
+
+
+@router.post("/api/show", include_in_schema = False)
+async def ollama_show(
+    body: Optional[OllamaShowRequest] = None, current_subject: str = Depends(get_current_subject)
+):
+    """Ollama-compatible model detail (``POST /api/show``)."""
+    from fastapi import HTTPException
+
+    requested = None
+    if body is not None:
+        requested = body.model or body.name
+    requested = (requested or _loaded_public_model_id() or "").strip()
+    if not requested:
+        raise HTTPException(status_code = 404, detail = "model not found")
+
+    models = await _inference()._openai_catalog_objects()
+    # Case-insensitive, matching /v1/models/{id}: the resolver lowercases its index.
+    match = next(
+        (m for m in models if str(m.get("id") or "").lower() == requested.lower()),
+        None,
+    )
+    if match is None:
+        raise HTTPException(status_code = 404, detail = "model not found")
+
+    capabilities = ["completion"]
+    if match.get("supports_tools"):
+        capabilities.append("tools")
+    if match.get("supports_vision"):
+        capabilities.append("vision")
+    return {
+        "license": "",
+        "modelfile": "",
+        "parameters": "",
+        "template": "",
+        "details": _ollama_details(match),
+        "model_info": {},
+        "capabilities": capabilities,
+    }

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -47,13 +47,20 @@ router = APIRouter()
 # catch-all in main.py answers anything outside /api/ and /v1/ with index.html, so
 # without this a probe for /slots or /completion gets 200 plus a page of HTML --
 # which reads as "supported" to every client that checks the status before the body.
-# The paths this module DOES serve are absent on purpose: they are real routes now,
-# matched before the catch-all, and listing them here would be dead weight.
+# Transcribed from llama-server's own route table (tools/server/server.cpp,
+# ctx_http.get/post), minus /props, which this module serves. Enumerated from the
+# source rather than added one at a time as clients trip over them, so the set is
+# complete instead of merely growing. Bare paths only: Studio's own API lives under
+# /api/ and /v1/, so nothing here can shadow it.
 _ENGINE_PROBE_PATHS = frozenset(
     {
         "apply-template",
+        "audio/transcriptions",
+        "chat/completions",
+        "chat/completions/input_tokens",
         "completion",
         "completions",
+        "cors-proxy",
         "detokenize",
         "embedding",
         "embeddings",
@@ -61,17 +68,30 @@ _ENGINE_PROBE_PATHS = frozenset(
         "infill",
         "lora-adapters",
         "metrics",
+        "models",
+        "models/load",
+        "models/sse",
+        "models/unload",
         "rerank",
         "reranking",
+        "responses",
+        "responses/input_tokens",
         "slots",
         "tokenize",
+        "tools",
     }
 )
+
+# /slots/:id_slot is a real llama-server route and Studio calls it itself
+# (restore_slots_for_resume), so the id has to be matched dynamically rather than
+# enumerated. Only this one prefix is dynamic in the table above.
+_ENGINE_PROBE_PREFIXES = ("slots/",)
 
 
 def is_engine_probe_path(full_path: str) -> bool:
     """True for an engine endpoint that must 404 rather than render the app shell."""
-    return full_path.strip("/").lower() in _ENGINE_PROBE_PATHS
+    normalized = full_path.strip("/").lower()
+    return normalized in _ENGINE_PROBE_PATHS or normalized.startswith(_ENGINE_PROBE_PREFIXES)
 
 
 def _inference():
@@ -151,6 +171,18 @@ def _server_props() -> dict:
     if public_id:
         props["model_path"] = public_id
 
+    # The child's props describe the CHILD's route table and its built-in web UI, none
+    # of which is reachable through Studio. Copying them verbatim points a client using
+    # props for capability discovery at endpoints that 404 here: Studio launches
+    # llama-server with --metrics, so endpoint_metrics arrives true while public
+    # /metrics is one of the paths this module deliberately denies (verified against
+    # tools/server/server-context.cpp, which puts all three flags in the payload).
+    for _child_only in ("ui", "ui_settings", "cors_proxy_enabled"):
+        props.pop(_child_only, None)
+    props["endpoint_slots"] = False
+    props["endpoint_props"] = False
+    props["endpoint_metrics"] = False
+
     # Only when llama-server owns the resident model. With a Transformers or MLX model
     # loaded the llama backend is unloaded, and reading its fields anyway would pair the
     # orchestrator's model_path with n_ctx 0, an empty template and total_slots 0 -- a
@@ -198,12 +230,28 @@ async def _probe_not_found():
 # shadow that lookup. Without these, a POST to /completion or /tokenize matched the
 # GET-only catch-all and returned 405, which a discovery client reads as "the endpoint
 # exists, wrong method" -- the same false positive the 404 is meant to close, and these
-# endpoints are POST in llama-server. OPTIONS is left alone so CORS preflight is
-# unaffected; HEAD already resolves against the catch-all's GET route.
+# endpoints are POST in llama-server. HEAD is listed explicitly: Starlette does NOT
+# admit HEAD on a GET route (measured on the pinned fastapi 0.141.1 / starlette 1.6.0,
+# HEAD /completion -> 405), so a HEAD probe would infer the endpoint exists. OPTIONS is
+# left alone so CORS preflight is unaffected.
+_PROBE_DENIED_METHODS = ["HEAD", "POST", "PUT", "PATCH", "DELETE"]
+
 for _probe_path in sorted(_ENGINE_PROBE_PATHS):
     router.add_api_route(
         f"/{_probe_path}",
         _probe_not_found,
-        methods = ["POST", "PUT", "PATCH", "DELETE"],
+        methods = _PROBE_DENIED_METHODS,
+        include_in_schema = False,
+    )
+
+# The one dynamic entry in llama-server's table, so it needs a path parameter rather
+# than a literal: without it POST /slots/0 falls through to the GET-only catch-all and
+# answers 405, which is the false positive again. Both slash forms, because FastAPI's
+# slash redirect does not apply to a path that matches no route at all.
+for _slots_form in ("/slots/{id_slot}", "/slots/{id_slot}/"):
+    router.add_api_route(
+        _slots_form,
+        _probe_not_found,
+        methods = _PROBE_DENIED_METHODS,
         include_in_schema = False,
     )

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -87,6 +87,25 @@ _ENGINE_PROBE_PATHS = frozenset(
 # enumerated. Only this one prefix is dynamic in the table above.
 _ENGINE_PROBE_PREFIXES = ("slots/",)
 
+# The /v1-prefixed entries in the same llama-server table that Studio does not
+# implement. Kept separate from the bare set because the two are checked differently:
+# main.py already 404s an unknown GET under /v1/, so only the other methods need a
+# route here. Hardcoded rather than derived from the live route table at import time,
+# with a test that asserts each really is absent from the assembled app -- if Studio
+# ever implements one, CI says to delete the line instead of silently shadowing it.
+_UNSERVED_V1_PROBE_PATHS = frozenset(
+    {
+        "v1/chat/completions/control",
+        "v1/chat/completions/input_tokens",
+        "v1/health",
+        "v1/rerank",
+        "v1/reranking",
+        "v1/responses/input_tokens",
+        "v1/stream",
+        "v1/streams/lookup",
+    }
+)
+
 
 def is_engine_probe_path(full_path: str) -> bool:
     """True for an engine endpoint that must 404 rather than render the app shell."""
@@ -195,7 +214,17 @@ def _server_props() -> dict:
             n_ctx = getattr(llama_backend, "context_length", None)
             if n_ctx:
                 settings["n_ctx"] = int(n_ctx)
-        props.setdefault("total_slots", 0)
+        if "total_slots" not in props:
+            # A transient /props read failure must not report zero slots next to a model
+            # this same response advertises as loaded: a client reading props for
+            # capacity concludes the model cannot serve. The backend knows the number it
+            # launched with; if even that is unreadable, omit rather than claim zero.
+            try:
+                slots = int(getattr(llama_backend, "effective_parallel_slots", 0) or 0)
+            except Exception:  # noqa: BLE001
+                slots = 0
+            if slots > 0:
+                props["total_slots"] = slots
         props.setdefault("chat_template", getattr(llama_backend, "chat_template", "") or "")
     props["build_info"] = f"unsloth-studio/{_studio_version()}"
     return props
@@ -248,6 +277,16 @@ for _probe_path in sorted(_ENGINE_PROBE_PATHS):
 # than a literal: without it POST /slots/0 falls through to the GET-only catch-all and
 # answers 405, which is the false positive again. Both slash forms, because FastAPI's
 # slash redirect does not apply to a path that matches no route at all.
+# main.py answers an unknown GET under /v1/ with a real 404 already, so only the other
+# methods can still reach the GET-only catch-all and come back 405.
+for _v1_path in sorted(_UNSERVED_V1_PROBE_PATHS):
+    router.add_api_route(
+        f"/{_v1_path}",
+        _probe_not_found,
+        methods = _PROBE_DENIED_METHODS,
+        include_in_schema = False,
+    )
+
 for _slots_form in ("/slots/{id_slot}", "/slots/{id_slot}/"):
     router.add_api_route(
         _slots_form,

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -804,6 +804,10 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     settings_module.router = APIRouter()
     llama_module = ModuleType("routes.llama")
     llama_module.router = APIRouter()
+    llama_compat_module = ModuleType("routes.llama_compat")
+    llama_compat_module.router = APIRouter()
+    # main.py imports this name alongside the router and calls it from serve_frontend.
+    llama_compat_module.is_engine_probe_path = lambda full_path: False
     prompts_module = ModuleType("routes.prompts")
     prompts_module.router = APIRouter()
     preview_module = ModuleType("routes.preview")
@@ -829,6 +833,7 @@ def test_health_response_reports_desktop_capability_fields(monkeypatch):
     monkeypatch.setitem(sys.modules, "routes", routes_module)
     monkeypatch.setitem(sys.modules, "routes.settings", settings_module)
     monkeypatch.setitem(sys.modules, "routes.llama", llama_module)
+    monkeypatch.setitem(sys.modules, "routes.llama_compat", llama_compat_module)
     monkeypatch.setitem(sys.modules, "routes.prompts", prompts_module)
     monkeypatch.setitem(sys.modules, "routes.preview", preview_module)
     monkeypatch.setitem(sys.modules, "routes.whisper", whisper_module)

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""routes/llama_compat.py: the discovery surface a third-party client probes.
+
+Reproduces a real user report. A client pointed at Studio's port ran this exact
+sequence and got these exact answers:
+
+    GET  /api/v1/models  404      GET  /props    200 text/html
+    GET  /api/tags       404      GET  /version  200 text/html
+    GET  /v1/props       404      POST /api/show 405
+
+The two 200s are the bug. /props and /version are not Studio routes, so they fell
+through the SPA catch-all in main.py, which serves index.html for anything outside
+/api/ and /v1/. A probe that checks the status before the body reads that as
+"supported" and then fails on HTML it cannot parse -- strictly worse than the 404
+the other four returned.
+
+The module is loaded standalone and handed a double for routes.inference: the real
+one pulls the whole inference stack, and every catalog helper it needs is injected
+here anyway, so the wire shapes can be asserted without a loaded model.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[1]
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI, HTTPException  # noqa: E402
+from fastapi.responses import Response  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+CATALOG = [
+    {
+        "id": "unsloth/Qwen3.8-27B-GGUF",
+        "object": "model",
+        "created": 1_700_000_000,
+        "owned_by": "unsloth",
+        "loaded": True,
+        "quant": "UD-Q4_K_XL",
+    },
+    {
+        "id": "unsloth/Laguna-S-2.1-GGUF",
+        "object": "model",
+        "created": 1_700_000_000,
+        "owned_by": "unsloth",
+        "loaded": False,
+    },
+]
+
+
+class _Backend:
+    """Enough of LlamaCppBackend for the props handler."""
+
+    def __init__(
+        self,
+        *,
+        loaded = True,
+        props = None,
+    ):
+        self.is_loaded = loaded
+        self.model_identifier = "/media/models/qwen/model.gguf"
+        self._openai_advertised_id = "unsloth/Qwen3.8-27B-GGUF"
+        self.context_length = 262144
+        self.chat_template = "{{ messages }}"
+        self._props = props
+
+    def _query_server_props(self):
+        return self._props
+
+
+def _inference_double(backend, catalog):
+    """Stand-in for routes.inference, injected through llama_compat._inference().
+
+    Deliberately not a sys.modules entry: an earlier revision stubbed
+    routes.inference globally and every module imported while it was live captured
+    the stub, which broke two unrelated route tests when the suite ran in one process.
+    """
+    inference = types.SimpleNamespace()
+    inference.get_llama_cpp_backend = lambda: backend
+    inference._llama_public_model_id = lambda b, fallback = None: b._openai_advertised_id
+    inference._orchestrator_public_model_id = lambda b: None
+    inference._peek_inference_backend = lambda: None
+
+    async def _objects():
+        return catalog
+
+    inference._openai_catalog_objects = _objects
+    return inference
+
+
+_MOD = None
+
+
+def _load(backend = None, catalog = None):
+    """The real routes/llama_compat.py, with routes.inference replaced by a double."""
+    global _MOD
+    if _MOD is None:
+        spec = importlib.util.spec_from_file_location(
+            "llama_compat_under_test", str(_BACKEND / "routes" / "llama_compat.py")
+        )
+        _MOD = importlib.util.module_from_spec(spec)
+        sys.modules["llama_compat_under_test"] = _MOD
+        spec.loader.exec_module(_MOD)
+    double = _inference_double(
+        backend if backend is not None else _Backend(),
+        CATALOG if catalog is None else catalog,
+    )
+    _MOD._inference = lambda: double
+    return _MOD
+
+
+def _client(mod):
+    app = FastAPI()
+    app.include_router(mod.router)
+
+    # The SPA catch-all, reproduced in main.py's order: real routes first, then the
+    # fallback. A test that omitted it could not tell "serves JSON" from "serves the
+    # app shell with a 200", which is the whole defect.
+    @app.get("/{full_path:path}")
+    async def _spa(full_path: str):
+        if full_path in {"api", "v1"} or full_path.startswith(("api/", "v1/")):
+            raise HTTPException(status_code = 404, detail = "API endpoint not found")
+        if mod.is_engine_probe_path(full_path):
+            raise HTTPException(status_code = 404, detail = "API endpoint not found")
+        return Response(content = b"<!doctype html>", media_type = "text/html")
+
+    # Override the exact object the router closed over.
+    app.dependency_overrides[mod.get_current_subject] = lambda: "test"
+    return TestClient(app)
+
+
+@pytest.fixture(scope = "module", autouse = True)
+def _teardown():
+    yield
+    sys.modules.pop("llama_compat_under_test", None)
+
+
+# ── the reported probe sequence ───────────────────────────────────────────────
+
+
+def test_the_reported_probe_sequence_no_longer_returns_html():
+    """THE REGRESSION THIS FILE EXISTS FOR.
+
+    Every path the client probed must answer JSON or 404, never 200 text/html.
+    """
+    mod = _load()
+    with _client(mod) as c:
+        for method, path in (
+            ("GET", "/props"),
+            ("GET", "/v1/props"),
+            ("GET", "/version"),
+            ("GET", "/api/tags"),
+            ("POST", "/api/show"),
+        ):
+            r = c.request(method, path, json = {} if method == "POST" else None)
+            assert r.status_code == 200, (method, path, r.status_code)
+            assert "application/json" in r.headers["content-type"], (method, path)
+            assert "text/html" not in r.headers["content-type"], (method, path)
+
+
+def test_the_html_fallback_is_what_used_to_answer_these():
+    """The control: an ordinary unknown path still gets the app shell.
+
+    Without this the test above would pass on a build that 404s everything, which
+    would break deep links into the UI.
+    """
+    mod = _load()
+    with _client(mod) as c:
+        r = c.get("/some-ui-deep-link")
+        assert r.status_code == 200
+        assert "text/html" in r.headers["content-type"]
+
+
+def test_engine_endpoints_studio_does_not_serve_are_404_not_html():
+    mod = _load()
+    with _client(mod) as c:
+        for path in ("/slots", "/completion", "/metrics", "/tokenize", "/health"):
+            r = c.get(path)
+            assert r.status_code == 404, path
+            assert "text/html" not in r.headers.get("content-type", ""), path
+
+
+def test_probe_matching_ignores_case_and_stray_slashes():
+    mod = _load()
+    assert mod.is_engine_probe_path("slots")
+    assert mod.is_engine_probe_path("/slots/")
+    assert mod.is_engine_probe_path("Metrics")
+    assert not mod.is_engine_probe_path("chat")
+    # Served paths are deliberately absent: they are real routes, matched first.
+    assert not mod.is_engine_probe_path("props")
+    assert not mod.is_engine_probe_path("version")
+
+
+# ── /props ────────────────────────────────────────────────────────────────────
+
+
+def test_props_never_echoes_the_on_disk_gguf_path():
+    """llama-server reports model_path as the absolute .gguf path. This endpoint is
+    reachable over LAN, so it publishes the public id instead, like every other
+    Studio response."""
+    upstream = {
+        "model_path": "/media/llm4/HDD-Models1/models/hub/models--unsloth--Qwen/model.gguf",
+        "total_slots": 4,
+        "default_generation_settings": {"n_ctx": 65536},
+    }
+    mod = _load(backend = _Backend(props = upstream))
+    with _client(mod) as c:
+        raw = c.get("/props")
+    body = raw.json()
+    assert body["model_path"] == "unsloth/Qwen3.8-27B-GGUF"
+    assert "HDD-Models1" not in raw.text
+    assert body["total_slots"] == 4
+    assert body["default_generation_settings"]["n_ctx"] == 65536
+
+
+def test_props_degrades_to_the_local_view_when_the_engine_cannot_be_read():
+    """_query_server_props returns None on a mid-restart engine. The probe must
+    still answer, from what the backend knows locally."""
+    mod = _load(backend = _Backend(props = None))
+    with _client(mod) as c:
+        body = c.get("/props").json()
+    assert body["model_path"] == "unsloth/Qwen3.8-27B-GGUF"
+    assert body["default_generation_settings"]["n_ctx"] == 262144
+    assert body["total_slots"] == 0
+    assert body["build_info"].startswith("unsloth-studio/")
+
+
+def test_props_with_nothing_loaded_reports_no_model():
+    mod = _load(backend = _Backend(loaded = False))
+    with _client(mod) as c:
+        body = c.get("/props").json()
+    assert "model_path" not in body
+    assert body["total_slots"] == 0
+
+
+def test_v1_props_and_props_agree():
+    mod = _load(backend = _Backend(props = {"total_slots": 2}))
+    with _client(mod) as c:
+        assert c.get("/props").json() == c.get("/v1/props").json()
+
+
+# ── /version ──────────────────────────────────────────────────────────────────
+
+
+def test_version_answers_on_both_spellings():
+    mod = _load()
+    with _client(mod) as c:
+        bare = c.get("/version").json()
+        prefixed = c.get("/api/version").json()
+    assert bare == prefixed
+    assert isinstance(bare["version"], str) and bare["version"]
+
+
+# ── /api/tags ─────────────────────────────────────────────────────────────────
+
+
+def test_tags_publishes_the_same_ids_as_v1_models():
+    mod = _load()
+    with _client(mod) as c:
+        models = c.get("/api/tags").json()["models"]
+    assert [m["name"] for m in models] == [m["id"] for m in CATALOG]
+    assert all(m["name"] == m["model"] for m in models)
+
+
+def test_tags_modified_at_is_rfc3339_not_an_epoch():
+    """Ollama clients parse this as a timestamp; a bare integer makes them throw."""
+    mod = _load()
+    with _client(mod) as c:
+        first = c.get("/api/tags").json()["models"][0]
+    assert first["modified_at"] == "2023-11-14T22:13:20Z"
+
+
+def test_tags_reports_the_quant_it_knows_and_no_invented_digest():
+    mod = _load()
+    with _client(mod) as c:
+        models = c.get("/api/tags").json()["models"]
+    assert models[0]["details"]["quantization_level"] == "UD-Q4_K_XL"
+    # The unquantised catalog row must not borrow the previous row's value.
+    assert models[1]["details"]["quantization_level"] == ""
+    # Studio has no blob digest for these. Empty, never fabricated: a client that
+    # compared a made-up digest would re-pull on every check.
+    assert all(m["digest"] == "" and m["size"] == 0 for m in models)
+
+
+def test_tags_on_an_empty_catalog_is_an_empty_list_not_an_error():
+    mod = _load(catalog = [])
+    with _client(mod) as c:
+        r = c.get("/api/tags")
+    assert r.status_code == 200
+    assert r.json() == {"models": []}
+
+
+# ── /api/show ─────────────────────────────────────────────────────────────────
+
+
+def test_show_accepts_both_ollama_spellings():
+    mod = _load()
+    with _client(mod) as c:
+        by_model = c.post("/api/show", json = {"model": "unsloth/Laguna-S-2.1-GGUF"})
+        by_name = c.post("/api/show", json = {"name": "unsloth/Laguna-S-2.1-GGUF"})
+    assert by_model.status_code == 200
+    assert by_model.json() == by_name.json()
+
+
+def test_show_matches_case_insensitively_like_v1_models():
+    mod = _load()
+    with _client(mod) as c:
+        r = c.post("/api/show", json = {"model": "UNSLOTH/laguna-s-2.1-gguf"})
+    assert r.status_code == 200
+    assert r.json()["details"]["quantization_level"] == ""
+
+
+def test_show_with_an_empty_body_falls_back_to_the_loaded_model():
+    """A probe often POSTs {} just to see whether the endpoint exists. 422 would
+    make it conclude the server is not Ollama-compatible."""
+    mod = _load()
+    with _client(mod) as c:
+        r = c.post("/api/show", json = {})
+    assert r.status_code == 200
+    assert r.json()["details"]["quantization_level"] == "UD-Q4_K_XL"
+
+
+def test_show_404s_an_unknown_model():
+    mod = _load()
+    with _client(mod) as c:
+        r = c.post("/api/show", json = {"model": "not/a-real-model"})
+    assert r.status_code == 404
+    assert "text/html" not in r.headers["content-type"]
+
+
+def test_show_404s_rather_than_500s_when_nothing_is_loaded_and_no_model_is_named():
+    mod = _load(backend = _Backend(loaded = False))
+    with _client(mod) as c:
+        assert c.post("/api/show", json = {}).status_code == 404

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -481,3 +481,136 @@ def test_the_probe_paths_are_admitted_under_keyless_inference_scope():
     # Not the Ollama paths: they are not served at all.
     for path in ("/api/tags", "/api/show", "/api/version"):
         assert ("GET", path) not in _INFERENCE_ROUTES, path
+
+
+# ── round two ─────────────────────────────────────────────────────────────────
+
+
+def test_head_on_an_unserved_probe_path_is_404_not_405():
+    """Starlette does NOT admit HEAD on a GET route. Measured on the pinned
+    fastapi 0.141.1 / starlette 1.6.0: HEAD against a bare GET catch-all returns 405,
+    so a HEAD probe would read the endpoint as existing. A comment here previously
+    claimed the opposite."""
+    mod = _load()
+    with _client(mod) as c:
+        for path in ("/completion", "/tokenize", "/metrics", "/slots"):
+            assert c.request("HEAD", path).status_code == 404, path
+
+
+def test_head_is_405_on_a_plain_get_route_which_is_why_it_is_listed():
+    """Pins the framework behaviour the fix depends on, so a future FastAPI that starts
+    admitting HEAD does not leave the reason for this list unexplained."""
+    app = FastAPI()
+
+    @app.get("/{p:path}")
+    async def _catchall(p: str):
+        return {"p": p}
+
+    with TestClient(app) as c:
+        assert c.get("/anything").status_code == 200
+        assert c.request("HEAD", "/anything").status_code == 405
+
+
+@pytest.mark.parametrize("path", ["/slots/0", "/slots/3", "/slots/abc", "/slots/0/"])
+def test_the_nested_slot_endpoint_is_denied_too(path):
+    """/slots/:id_slot is a real llama-server route, and Studio calls it itself in
+    restore_slots_for_resume, so an exact-membership check on "slots" missed it."""
+    mod = _load()
+    assert mod.is_engine_probe_path(path.strip("/"))
+    with _client(mod) as c:
+        for method in ("GET", "HEAD", "POST", "DELETE"):
+            r = c.request(method, path, json = {} if method == "POST" else None)
+            assert r.status_code == 404, (method, path, r.status_code)
+
+
+def test_the_deny_list_matches_llama_servers_own_route_table():
+    """Transcribed from tools/server/server.cpp rather than grown one client complaint
+    at a time. /props is the single bare route Studio serves, so it is the only
+    omission; anything else missing here means a probe still reaches the app shell."""
+    mod = _load()
+    bare_llama_routes = {
+        "apply-template",
+        "audio/transcriptions",
+        "chat/completions",
+        "chat/completions/input_tokens",
+        "completion",
+        "completions",
+        "cors-proxy",
+        "detokenize",
+        "embedding",
+        "embeddings",
+        "health",
+        "infill",
+        "lora-adapters",
+        "metrics",
+        "models",
+        "models/load",
+        "models/sse",
+        "models/unload",
+        "props",
+        "rerank",
+        "reranking",
+        "responses",
+        "responses/input_tokens",
+        "slots",
+        "tokenize",
+        "tools",
+    }
+    served = {"props"}
+    for route in bare_llama_routes - served:
+        assert mod.is_engine_probe_path(route), route
+    assert not mod.is_engine_probe_path("props"), "Studio serves /props"
+
+
+def test_a_bare_llama_route_404s_on_every_method_a_client_would_use():
+    mod = _load()
+    with _client(mod) as c:
+        for path in (
+            "/chat/completions",
+            "/responses",
+            "/models",
+            "/tools",
+            "/audio/transcriptions",
+        ):
+            for method in ("GET", "HEAD", "POST"):
+                r = c.request(method, path, json = {} if method == "POST" else None)
+                assert r.status_code == 404, (method, path, r.status_code)
+                assert "text/html" not in r.headers.get("content-type", ""), (method, path)
+
+
+def test_props_does_not_advertise_child_endpoints_studio_denies():
+    """llama-server puts endpoint_slots / endpoint_props / endpoint_metrics in its props
+    (tools/server/server-context.cpp), and Studio launches it with --metrics, so
+    endpoint_metrics arrives true while public /metrics is one of the paths this module
+    deliberately 404s. Copying the child's route table onto the public surface is the
+    same over-claim as answering a probe with HTML."""
+    upstream = {
+        "endpoint_slots": True,
+        "endpoint_props": True,
+        "endpoint_metrics": True,
+        "ui": True,
+        "ui_settings": {"theme": "dark"},
+        "cors_proxy_enabled": True,
+        "total_slots": 4,
+    }
+    mod = _load(backend = _Backend(props = upstream))
+    with _client(mod) as c:
+        body = c.get("/props").json()
+    assert body["endpoint_slots"] is False
+    assert body["endpoint_props"] is False
+    assert body["endpoint_metrics"] is False
+    for child_only in ("ui", "ui_settings", "cors_proxy_enabled"):
+        assert child_only not in body, child_only
+    # The fields that do describe the model still come through untouched.
+    assert body["total_slots"] == 4
+
+
+def test_the_denied_endpoints_props_advertises_really_are_denied():
+    """Ties the two halves together: every endpoint_* flag set to False above names a
+    path that actually 404s, so the props answer and the route table agree."""
+    mod = _load()
+    with _client(mod) as c:
+        for path in ("/slots", "/metrics"):
+            assert c.get(path).status_code == 404, path
+        # POST /props is llama-server's props-change endpoint; Studio serves GET only.
+        assert c.post("/props", json = {}).status_code in (404, 405)

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -728,6 +728,6 @@ def test_the_v1_deny_list_never_shadows_a_path_studio_serves():
     assert "/v1/models" in served, "route walk found nothing; re-derive this"
     mod = _load()
     for probe in mod._UNSERVED_V1_PROBE_PATHS:
-        assert f"/{probe}" not in served, (
-            f"Studio now serves /{probe}; drop it from _UNSERVED_V1_PROBE_PATHS"
-        )
+        assert (
+            f"/{probe}" not in served
+        ), f"Studio now serves /{probe}; drop it from _UNSERVED_V1_PROBE_PATHS"

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import time
 import types
 from pathlib import Path
 
@@ -344,3 +345,153 @@ def test_show_404s_rather_than_500s_when_nothing_is_loaded_and_no_model_is_named
     mod = _load(backend = _Backend(loaded = False))
     with _client(mod) as c:
         assert c.post("/api/show", json = {}).status_code == 404
+
+
+# ── platform and robustness, from the sandbox run ─────────────────────────────
+
+
+@pytest.mark.parametrize("osname", ["Linux", "Darwin", "Windows"])
+@pytest.mark.parametrize(
+    "created",
+    [0, 1, -1, 1_700_000_000, 2**31, 2**40, 10**18, 1.5, None, "nope", float("nan")],
+)
+def test_modified_at_is_a_four_digit_year_stamp_on_every_platform(osname, created, monkeypatch):
+    """gmtime() disagrees across the three platforms at both ends of its range: Linux
+    accepts a huge epoch and returns a five digit year no client can parse, macOS
+    rejects anything before 1970, Windows rejects both ends. Clamping first is what
+    makes one catalog row render identically everywhere."""
+    mod = _load()
+    real = time.gmtime
+
+    def platform_gmtime(value):
+        if osname == "Windows" and not (0 <= value < 32536850000):
+            raise OSError(22, "Invalid argument")
+        if osname == "Darwin" and value < 0:
+            raise OSError(22, "Invalid argument")
+        return real(value)
+
+    monkeypatch.setattr(mod.time, "gmtime", platform_gmtime)
+    out = mod._rfc3339(created)
+    time.strptime(out, "%Y-%m-%dT%H:%M:%SZ")
+    assert len(out) == 20 and out.endswith("Z"), out
+    assert 1970 <= int(out[:4]) <= 9999, out
+
+
+def test_the_timestamp_fallback_does_not_itself_call_gmtime(monkeypatch):
+    """An earlier revision fell back to gmtime(0), which raises too on a platform
+    strict enough to have rejected the first call, taking /api/tags with it."""
+    mod = _load()
+    monkeypatch.setattr(
+        mod.time, "gmtime", lambda _v: (_ for _ in ()).throw(OSError(22, "Invalid argument"))
+    )
+    assert mod._rfc3339(1_700_000_000) == "1970-01-01T00:00:00Z"
+    with _client(mod) as c:
+        assert len(c.get("/api/tags").json()["models"]) == len(CATALOG)
+
+
+@pytest.mark.parametrize(
+    "upstream",
+    [
+        None,
+        [],
+        "not a dict",
+        42,
+        {},
+        {"default_generation_settings": None},
+        {"default_generation_settings": []},
+        {"total_slots": None},
+        {"model_path": "/media/llm4/HDD/models/x.gguf"},
+    ],
+)
+def test_props_never_500s_and_never_leaks_a_path_on_a_hostile_upstream(upstream):
+    mod = _load(backend = _Backend(props = upstream))
+    with _client(mod) as c:
+        r = c.get("/props")
+    assert r.status_code == 200, r.text
+    assert "/media/" not in r.text
+    assert r.json()["model_path"] == "unsloth/Qwen3.8-27B-GGUF"
+
+
+def test_props_survives_an_engine_query_that_raises():
+    """_query_server_props is documented to return None rather than raise. A probe is
+    the wrong place to find out that slipped, and the local view is always answerable."""
+
+    class _Raises(_Backend):
+        def _query_server_props(self):
+            raise RuntimeError("engine unreachable")
+
+    mod = _load(backend = _Raises())
+    with _client(mod) as c:
+        r = c.get("/props")
+    assert r.status_code == 200
+    assert r.json()["model_path"] == "unsloth/Qwen3.8-27B-GGUF"
+
+
+def test_the_version_lookup_survives_an_import_failure(monkeypatch):
+    """The import sits inside the guard, not above it: an ImportError there would 500
+    a /props probe that has nothing to do with versions."""
+    mod = _load()
+    mod._studio_version.cache_clear()
+    monkeypatch.setitem(sys.modules, "utils.studio_version", None)
+    try:
+        assert mod._studio_version() == "dev"
+    finally:
+        mod._studio_version.cache_clear()
+
+
+def test_the_version_lookup_is_resolved_once(monkeypatch):
+    """get_studio_version() shells out to git twice on a source checkout and /version
+    is an async handler, so an uncached call would put those spawns on the event loop."""
+    mod = _load()
+    mod._studio_version.cache_clear()
+    calls = []
+    fake = types.ModuleType("utils.studio_version")
+    fake.get_studio_version = lambda repo_root = None: (calls.append(1), "v0.1.999")[1]
+    monkeypatch.setitem(sys.modules, "utils.studio_version", fake)
+    try:
+        for _ in range(25):
+            assert mod._studio_version() == "v0.1.999"
+        assert len(calls) == 1
+    finally:
+        mod._studio_version.cache_clear()
+
+
+def test_a_real_asset_wins_over_the_probe_deny_list(tmp_path):
+    """The guard runs after the static lookup, so a build that ever ships a file named
+    `metrics` still serves it rather than 404-ing with no obvious cause."""
+    mod = _load()
+    (tmp_path / "metrics").write_text("asset-body")
+    app = FastAPI()
+    app.include_router(mod.router)
+
+    @app.get("/{full_path:path}")
+    async def _spa(full_path: str):
+        candidate = tmp_path / full_path
+        if candidate.is_file():
+            return Response(content = candidate.read_bytes(), media_type = "text/plain")
+        if mod.is_engine_probe_path(full_path):
+            raise HTTPException(status_code = 404, detail = "API endpoint not found")
+        return Response(content = b"<!doctype html>", media_type = "text/html")
+
+    app.dependency_overrides[mod.get_current_subject] = lambda: "test"
+    with TestClient(app) as c:
+        assert c.get("/metrics").text == "asset-body"
+        assert c.get("/slots").status_code == 404
+
+
+def test_no_client_side_ui_route_is_shadowed_by_the_deny_list():
+    """Reads the routes the frontend actually declares, so adding a UI page named
+    /metrics or /health fails here instead of 404-ing in the browser."""
+    routes_dir = _BACKEND.parent / "frontend" / "src" / "app" / "routes"
+    if not routes_dir.is_dir():
+        pytest.skip("frontend sources not present in this checkout")
+    mod = _load()
+    declared = set()
+    for path in routes_dir.glob("*.tsx"):
+        for line in path.read_text(encoding = "utf-8").splitlines():
+            line = line.strip()
+            if line.startswith('path: "') and line.endswith('",'):
+                declared.add(line[len('path: "') : -2])
+    assert declared, "no client routes parsed; the parser needs updating"
+    shadowed = {p for p in declared if mod.is_engine_probe_path(p)}
+    assert not shadowed, f"UI route(s) shadowed by the probe deny-list: {shadowed}"

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -3,22 +3,15 @@
 
 """routes/llama_compat.py: the discovery surface a third-party client probes.
 
-Reproduces a real user report. A client pointed at Studio's port ran this exact
-sequence and got these exact answers:
+Reproduces a real user report. A client pointed at Studio's port ran this sequence:
 
     GET  /api/v1/models  404      GET  /props    200 text/html
     GET  /api/tags       404      GET  /version  200 text/html
     GET  /v1/props       404      POST /api/show 405
 
-The two 200s are the bug. /props and /version are not Studio routes, so they fell
-through the SPA catch-all in main.py, which serves index.html for anything outside
-/api/ and /v1/. A probe that checks the status before the body reads that as
-"supported" and then fails on HTML it cannot parse -- strictly worse than the 404
-the other four returned.
-
-The module is loaded standalone and handed a double for routes.inference: the real
-one pulls the whole inference stack, and every catalog helper it needs is injected
-here anyway, so the wire shapes can be asserted without a loaded model.
+The two 200s are the bug: neither was a Studio route, so both fell through the SPA
+catch-all and returned index.html, which a probe reads as "supported" before failing
+on the body. The module is loaded standalone with a double for routes.inference.
 """
 
 from __future__ import annotations
@@ -88,12 +81,8 @@ def _inference_double(
     catalog,
     orchestrator = None,
 ):
-    """Stand-in for routes.inference, injected through llama_compat._inference().
-
-    Deliberately not a sys.modules entry: an earlier revision stubbed
-    routes.inference globally and every module imported while it was live captured
-    the stub, which broke two unrelated route tests when the suite ran in one process.
-    """
+    """Stand-in for routes.inference. Deliberately not a sys.modules entry: stubbing it
+    globally broke two unrelated route tests when the suite ran in one process."""
     inference = types.SimpleNamespace()
     inference.get_llama_cpp_backend = lambda: backend
     inference._llama_public_model_id = lambda b, fallback = None: b._openai_advertised_id
@@ -137,9 +126,8 @@ def _client(mod):
     app = FastAPI()
     app.include_router(mod.router)
 
-    # The SPA catch-all, reproduced in main.py's order: real routes first, then the
-    # fallback. A test that omitted it could not tell "serves JSON" from "serves the
-    # app shell with a 200", which is the whole defect.
+    # The SPA catch-all in main.py's order. Without it a test cannot tell "serves JSON"
+    # from "serves the app shell with a 200", which is the whole defect.
     @app.get("/{full_path:path}")
     async def _spa(full_path: str):
         if full_path in {"api", "v1"} or full_path.startswith(("api/", "v1/")):
@@ -163,10 +151,8 @@ def _teardown():
 
 
 def test_the_reported_probe_sequence_no_longer_returns_html():
-    """THE REGRESSION THIS FILE EXISTS FOR.
-
-    Every path the client probed must answer JSON or 404, never 200 text/html.
-    """
+    """THE REGRESSION THIS FILE EXISTS FOR: every probed path answers JSON or 404,
+    never 200 text/html."""
     mod = _load()
     with _client(mod) as c:
         # The two that used to answer with the app shell now answer with JSON.
@@ -190,11 +176,8 @@ def test_the_reported_probe_sequence_no_longer_returns_html():
 
 
 def test_the_html_fallback_is_what_used_to_answer_these():
-    """The control: an ordinary unknown path still gets the app shell.
-
-    Without this the test above would pass on a build that 404s everything, which
-    would break deep links into the UI.
-    """
+    """The control: without it the test above passes on a build that 404s everything,
+    which would break every deep link into the UI."""
     mod = _load()
     with _client(mod) as c:
         r = c.get("/some-ui-deep-link")
@@ -226,9 +209,7 @@ def test_probe_matching_ignores_case_and_stray_slashes():
 
 
 def test_props_never_echoes_the_on_disk_gguf_path():
-    """llama-server reports model_path as the absolute .gguf path. This endpoint is
-    reachable over LAN, so it publishes the public id instead, like every other
-    Studio response."""
+    """Upstream reports the absolute .gguf path and this is LAN reachable."""
     upstream = {
         "model_path": "/media/llm4/HDD-Models1/models/hub/models--unsloth--Qwen/model.gguf",
         "total_slots": 4,
@@ -245,8 +226,7 @@ def test_props_never_echoes_the_on_disk_gguf_path():
 
 
 def test_props_degrades_to_the_local_view_when_the_engine_cannot_be_read():
-    """_query_server_props returns None on a mid-restart engine. The probe must
-    still answer, from what the backend knows locally."""
+    """A mid-restart engine returns None; the probe still answers from the local view."""
     mod = _load(backend = _Backend(props = None))
     with _client(mod) as c:
         body = c.get("/props").json()
@@ -318,8 +298,7 @@ def test_props_never_500s_and_never_leaks_a_path_on_a_hostile_upstream(upstream)
 
 
 def test_props_survives_an_engine_query_that_raises():
-    """_query_server_props is documented to return None rather than raise. A probe is
-    the wrong place to find out that slipped, and the local view is always answerable."""
+    """A probe is the wrong place to find out that contract slipped."""
 
     class _Raises(_Backend):
         def _query_server_props(self):
@@ -333,8 +312,7 @@ def test_props_survives_an_engine_query_that_raises():
 
 
 def test_the_version_lookup_survives_an_import_failure(monkeypatch):
-    """The import sits inside the guard, not above it: an ImportError there would 500
-    a /props probe that has nothing to do with versions."""
+    """An ImportError above the guard would 500 a probe about something else."""
     mod = _load()
     mod._studio_version.cache_clear()
     monkeypatch.setitem(sys.modules, "utils.studio_version", None)
@@ -345,8 +323,7 @@ def test_the_version_lookup_survives_an_import_failure(monkeypatch):
 
 
 def test_the_version_lookup_is_resolved_once(monkeypatch):
-    """get_studio_version() shells out to git twice on a source checkout and /version
-    is an async handler, so an uncached call would put those spawns on the event loop."""
+    """Two git subprocesses per call, on the event loop, if uncached."""
     mod = _load()
     mod._studio_version.cache_clear()
     calls = []
@@ -362,8 +339,7 @@ def test_the_version_lookup_is_resolved_once(monkeypatch):
 
 
 def test_a_real_asset_wins_over_the_probe_deny_list(tmp_path):
-    """The guard runs after the static lookup, so a build that ever ships a file named
-    `metrics` still serves it rather than 404-ing with no obvious cause."""
+    """The guard runs after the static lookup, so a shipped file named `metrics` wins."""
     mod = _load()
     (tmp_path / "metrics").write_text("asset-body")
     app = FastAPI()
@@ -385,8 +361,8 @@ def test_a_real_asset_wins_over_the_probe_deny_list(tmp_path):
 
 
 def test_no_client_side_ui_route_is_shadowed_by_the_deny_list():
-    """Reads the routes the frontend actually declares, so adding a UI page named
-    /metrics or /health fails here instead of 404-ing in the browser."""
+    """Reads the routes the frontend declares, so a UI page named /metrics fails here
+    rather than 404-ing in the browser."""
     routes_dir = _BACKEND.parent / "frontend" / "src" / "app" / "routes"
     if not routes_dir.is_dir():
         pytest.skip("frontend sources not present in this checkout")
@@ -406,11 +382,9 @@ def test_no_client_side_ui_route_is_shadowed_by_the_deny_list():
 
 
 def test_the_ollama_surface_is_not_advertised():
-    """Answering /api/tags identifies this server as Ollama, and a client that
-    completes Ollama discovery then posts to /api/chat or /api/generate, which Studio
-    does not serve. The reporting user's client got 404 here, fell back to the OpenAI
-    surface, and worked; advertising a protocol we do not implement would have broken
-    exactly that client. Same defect as the HTML 200, one layer up."""
+    """Answering /api/tags makes a client select Ollama and then fail on /api/chat.
+    The reporting user's client got 404 here, fell back to OpenAI, and worked, so
+    advertising the pair would have broken the very client this started from."""
     mod = _load()
     routes = {r.path for r in mod.router.routes}
     assert "/api/tags" not in routes
@@ -436,10 +410,8 @@ def test_the_ollama_surface_is_not_advertised():
     ],
 )
 def test_unserved_engine_endpoints_404_on_their_real_method_not_405(method, path):
-    """These are POST endpoints in llama-server. The deny-list guard lives in the SPA's
-    GET catch-all, so before this a POST matched the GET-only route and returned 405,
-    which a discovery client reads as "exists, wrong method" -- the same false positive
-    the 404 exists to close."""
+    """POST endpoints in llama-server, so before this they returned 405 from the
+    GET-only catch-all, which reads as "exists, wrong method"."""
     mod = _load()
     with _client(mod) as c:
         r = c.request(method, path, json = {})
@@ -448,8 +420,7 @@ def test_unserved_engine_endpoints_404_on_their_real_method_not_405(method, path
 
 
 def test_get_on_a_probe_path_still_reaches_the_asset_lookup(tmp_path):
-    """The non-GET routes deliberately omit GET, or they would shadow the catch-all's
-    static lookup and re-break the asset case."""
+    """Omitting GET is what keeps the catch-all's static lookup reachable."""
     mod = _load()
     assert not any(
         "GET" in (getattr(r, "methods", None) or set()) and r.path == "/completion"
@@ -458,10 +429,8 @@ def test_get_on_a_probe_path_still_reaches_the_asset_lookup(tmp_path):
 
 
 def test_props_does_not_pair_an_orchestrator_model_with_llama_server_fields():
-    """With a Transformers or MLX model resident the llama backend is unloaded. Reading
-    its fields anyway advertised the orchestrator's model alongside n_ctx 0, an empty
-    template and total_slots 0: a self-contradictory description of a model that is in
-    fact serving."""
+    """With MLX resident the llama backend is unloaded, so reading its fields anyway
+    described a serving model as having no context and no slots."""
 
     class _Orchestrator:
         active_model_name = "unsloth/Llama-3.2-3B"
@@ -475,9 +444,8 @@ def test_props_does_not_pair_an_orchestrator_model_with_llama_server_fields():
 
 
 def test_the_probe_paths_are_admitted_under_keyless_inference_scope():
-    """keyless_api_access_scope="inference" lets a keyless client list models and chat.
-    A 401 on /props in front of that surface reads as an auth wall over the whole thing
-    and stops discovery, which is the opposite of what the scope grants."""
+    """A 401 on /props in front of a surface the scope grants reads as an auth wall
+    over the whole thing and stops discovery."""
     from utils.keyless_api_access import _INFERENCE_ROUTES
 
     assert ("GET", "/v1/models") in _INFERENCE_ROUTES, "baseline moved; re-derive this"
@@ -492,10 +460,8 @@ def test_the_probe_paths_are_admitted_under_keyless_inference_scope():
 
 
 def test_head_on_an_unserved_probe_path_is_404_not_405():
-    """Starlette does NOT admit HEAD on a GET route. Measured on the pinned
-    fastapi 0.141.1 / starlette 1.6.0: HEAD against a bare GET catch-all returns 405,
-    so a HEAD probe would read the endpoint as existing. A comment here previously
-    claimed the opposite."""
+    """Starlette does NOT admit HEAD on a GET route (measured on the pinned fastapi
+    0.141.1 / starlette 1.6.0). A comment here previously claimed the opposite."""
     mod = _load()
     with _client(mod) as c:
         for path in ("/completion", "/tokenize", "/metrics", "/slots"):
@@ -503,8 +469,7 @@ def test_head_on_an_unserved_probe_path_is_404_not_405():
 
 
 def test_head_is_405_on_a_plain_get_route_which_is_why_it_is_listed():
-    """Pins the framework behaviour the fix depends on, so a future FastAPI that starts
-    admitting HEAD does not leave the reason for this list unexplained."""
+    """Pins the framework behaviour the fix depends on."""
     app = FastAPI()
 
     @app.get("/{p:path}")
@@ -518,8 +483,7 @@ def test_head_is_405_on_a_plain_get_route_which_is_why_it_is_listed():
 
 @pytest.mark.parametrize("path", ["/slots/0", "/slots/3", "/slots/abc", "/slots/0/"])
 def test_the_nested_slot_endpoint_is_denied_too(path):
-    """/slots/:id_slot is a real llama-server route, and Studio calls it itself in
-    restore_slots_for_resume, so an exact-membership check on "slots" missed it."""
+    """A real llama-server route Studio calls itself, missed by exact membership."""
     mod = _load()
     assert mod.is_engine_probe_path(path.strip("/"))
     with _client(mod) as c:
@@ -529,9 +493,8 @@ def test_the_nested_slot_endpoint_is_denied_too(path):
 
 
 def test_the_deny_list_matches_llama_servers_own_route_table():
-    """Transcribed from tools/server/server.cpp rather than grown one client complaint
-    at a time. /props is the single bare route Studio serves, so it is the only
-    omission; anything else missing here means a probe still reaches the app shell."""
+    """Transcribed from tools/server/server.cpp. /props is the only bare route Studio
+    serves, so anything else missing means a probe still reaches the app shell."""
     mod = _load()
     bare_llama_routes = {
         "apply-template",
@@ -584,11 +547,8 @@ def test_a_bare_llama_route_404s_on_every_method_a_client_would_use():
 
 
 def test_props_does_not_advertise_child_endpoints_studio_denies():
-    """llama-server puts endpoint_slots / endpoint_props / endpoint_metrics in its props
-    (tools/server/server-context.cpp), and Studio launches it with --metrics, so
-    endpoint_metrics arrives true while public /metrics is one of the paths this module
-    deliberately 404s. Copying the child's route table onto the public surface is the
-    same over-claim as answering a probe with HTML."""
+    """tools/server/server-context.cpp puts all three flags in the payload, and Studio
+    launches with --metrics, so endpoint_metrics arrived true while /metrics 404s here."""
     upstream = {
         "endpoint_slots": True,
         "endpoint_props": True,
@@ -611,8 +571,7 @@ def test_props_does_not_advertise_child_endpoints_studio_denies():
 
 
 def test_the_denied_endpoints_props_advertises_really_are_denied():
-    """Ties the two halves together: every endpoint_* flag set to False above names a
-    path that actually 404s, so the props answer and the route table agree."""
+    """Every flag set False above names a path that really 404s."""
     mod = _load()
     with _client(mod) as c:
         for path in ("/slots", "/metrics"):
@@ -625,8 +584,8 @@ def test_the_denied_endpoints_props_advertises_really_are_denied():
 
 
 def test_a_transient_props_failure_does_not_report_zero_slots():
-    """The response still advertises the model and its context, so total_slots 0 tells a
-    client reading props for capacity that the serving model has no usable slots."""
+    """total_slots 0 beside a model this response advertises as loaded reads as
+    "cannot serve"."""
     mod = _load(backend = _Backend(props = None, slots = 8))
     with _client(mod) as c:
         body = c.get("/props").json()
@@ -683,8 +642,7 @@ def test_the_upstream_slot_count_still_wins_when_it_can_be_read():
 )
 @pytest.mark.parametrize("method", ["HEAD", "POST", "DELETE"])
 def test_unserved_v1_aliases_404_on_their_real_method(path, method):
-    """main.py already 404s an unknown GET under /v1/, so only the other methods could
-    still reach the GET-only catch-all and come back 405."""
+    """GET already 404s through main.py's /v1/ rule; the rest came back 405."""
     mod = _load()
     with _client(mod) as c:
         r = c.request(method, path, json = {} if method == "POST" else None)
@@ -693,8 +651,8 @@ def test_unserved_v1_aliases_404_on_their_real_method(path, method):
 
 
 def test_the_v1_deny_list_never_shadows_a_path_studio_serves():
-    """The drift guard. These are hardcoded, so if Studio ever implements one of them
-    this fails and says to delete the line rather than let a 404 shadow a real route."""
+    """The drift guard: implementing one of these must fail here rather than let a 404
+    shadow a real route."""
     import os
 
     os.environ.setdefault("TMPDIR", os.environ.get("UNSLOTH_WORKSPACE", "/tmp") + "/temp")
@@ -728,6 +686,6 @@ def test_the_v1_deny_list_never_shadows_a_path_studio_serves():
     assert "/v1/models" in served, "route walk found nothing; re-derive this"
     mod = _load()
     for probe in mod._UNSERVED_V1_PROBE_PATHS:
-        assert (
-            f"/{probe}" not in served
-        ), f"Studio now serves /{probe}; drop it from _UNSERVED_V1_PROBE_PATHS"
+        assert f"/{probe}" not in served, (
+            f"Studio now serves /{probe}; drop it from _UNSERVED_V1_PROBE_PATHS"
+        )

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -689,3 +689,23 @@ def test_the_v1_deny_list_never_shadows_a_path_studio_serves():
         assert (
             f"/{probe}" not in served
         ), f"Studio now serves /{probe}; drop it from _UNSERVED_V1_PROBE_PATHS"
+
+
+@pytest.mark.parametrize("path", ["/props/", "/v1/props/", "/version/"])
+def test_the_trailing_slash_forms_answer_json_not_the_app_shell(path):
+    """FastAPI's slash redirect never fires here: the SPA catch-all is a full match for
+    "/props/", so the request landed there and came back as index.html -- the original
+    defect, still live for any client that does not canonicalize its probe URL.
+    routes/inference.py registers "/v1/models/" for exactly this reason."""
+    mod = _load()
+    with _client(mod) as c:
+        r = c.get(path)
+    assert r.status_code == 200, (path, r.status_code)
+    assert "application/json" in r.headers["content-type"], path
+
+
+def test_the_slash_and_bare_forms_agree():
+    mod = _load()
+    with _client(mod) as c:
+        assert c.get("/props").json() == c.get("/props/").json()
+        assert c.get("/version").json() == c.get("/version/").json()

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -693,10 +693,8 @@ def test_the_v1_deny_list_never_shadows_a_path_studio_serves():
 
 @pytest.mark.parametrize("path", ["/props/", "/v1/props/", "/version/"])
 def test_the_trailing_slash_forms_answer_json_not_the_app_shell(path):
-    """FastAPI's slash redirect never fires here: the SPA catch-all is a full match for
-    "/props/", so the request landed there and came back as index.html -- the original
-    defect, still live for any client that does not canonicalize its probe URL.
-    routes/inference.py registers "/v1/models/" for exactly this reason."""
+    """No slash redirect fires here: the catch-all fully matches "/props/", so before
+    this these returned the app shell with a 200, the defect this module exists to fix."""
     mod = _load()
     with _client(mod) as c:
         r = c.get(path)

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -69,8 +69,10 @@ class _Backend:
         *,
         loaded = True,
         props = None,
+        slots = 4,
     ):
         self.is_loaded = loaded
+        self.effective_parallel_slots = slots
         self.model_identifier = "/media/models/qwen/model.gguf"
         self._openai_advertised_id = "unsloth/Qwen3.8-27B-GGUF"
         self.context_length = 262144
@@ -250,7 +252,10 @@ def test_props_degrades_to_the_local_view_when_the_engine_cannot_be_read():
         body = c.get("/props").json()
     assert body["model_path"] == "unsloth/Qwen3.8-27B-GGUF"
     assert body["default_generation_settings"]["n_ctx"] == 262144
-    assert body["total_slots"] == 0
+    # Not 0: this same response advertises the model as loaded, and a client reading
+    # props for capacity would conclude it cannot serve. The backend knows what it
+    # launched with.
+    assert body["total_slots"] == 4
     assert body["build_info"].startswith("unsloth-studio/")
 
 
@@ -614,3 +619,115 @@ def test_the_denied_endpoints_props_advertises_really_are_denied():
             assert c.get(path).status_code == 404, path
         # POST /props is llama-server's props-change endpoint; Studio serves GET only.
         assert c.post("/props", json = {}).status_code in (404, 405)
+
+
+# ── round three ───────────────────────────────────────────────────────────────
+
+
+def test_a_transient_props_failure_does_not_report_zero_slots():
+    """The response still advertises the model and its context, so total_slots 0 tells a
+    client reading props for capacity that the serving model has no usable slots."""
+    mod = _load(backend = _Backend(props = None, slots = 8))
+    with _client(mod) as c:
+        body = c.get("/props").json()
+    assert body["model_path"] == "unsloth/Qwen3.8-27B-GGUF"
+    assert body["total_slots"] == 8
+
+
+@pytest.mark.parametrize("slots", [0, None, "x", -1])
+def test_an_unreadable_slot_count_is_omitted_rather_than_reported_as_zero(slots):
+    mod = _load(backend = _Backend(props = None, slots = slots))
+    with _client(mod) as c:
+        body = c.get("/props").json()
+    assert "total_slots" not in body, body.get("total_slots")
+    assert body["model_path"] == "unsloth/Qwen3.8-27B-GGUF"
+
+
+def test_a_backend_that_raises_on_the_slot_count_still_answers():
+    class _Raises(_Backend):
+        # A property, not the plain attribute the base class sets, so the read itself
+        # raises the way a backend mid-restart would.
+        @property
+        def effective_parallel_slots(self):
+            raise RuntimeError("backend mid-restart")
+
+        @effective_parallel_slots.setter
+        def effective_parallel_slots(self, _value):
+            pass
+
+    mod = _load(backend = _Raises(props = None))
+    with _client(mod) as c:
+        r = c.get("/props")
+    assert r.status_code == 200
+    assert "total_slots" not in r.json()
+
+
+def test_the_upstream_slot_count_still_wins_when_it_can_be_read():
+    mod = _load(backend = _Backend(props = {"total_slots": 2}, slots = 8))
+    with _client(mod) as c:
+        assert c.get("/props").json()["total_slots"] == 2
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/rerank",
+        "/v1/reranking",
+        "/v1/chat/completions/control",
+        "/v1/chat/completions/input_tokens",
+        "/v1/responses/input_tokens",
+        "/v1/health",
+        "/v1/stream",
+        "/v1/streams/lookup",
+    ],
+)
+@pytest.mark.parametrize("method", ["HEAD", "POST", "DELETE"])
+def test_unserved_v1_aliases_404_on_their_real_method(path, method):
+    """main.py already 404s an unknown GET under /v1/, so only the other methods could
+    still reach the GET-only catch-all and come back 405."""
+    mod = _load()
+    with _client(mod) as c:
+        r = c.request(method, path, json = {} if method == "POST" else None)
+    assert r.status_code == 404, (method, path, r.status_code)
+    assert "text/html" not in r.headers.get("content-type", ""), (method, path)
+
+
+def test_the_v1_deny_list_never_shadows_a_path_studio_serves():
+    """The drift guard. These are hardcoded, so if Studio ever implements one of them
+    this fails and says to delete the line rather than let a 404 shadow a real route."""
+    import os
+
+    os.environ.setdefault("TMPDIR", os.environ.get("UNSLOTH_WORKSPACE", "/tmp") + "/temp")
+    try:
+        import main
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"main.py not importable in this environment: {exc}")
+
+    from routes.llama_compat import _probe_not_found
+
+    def _record(into, path, endpoint):
+        # This module registers its own 404 handlers on exactly these paths, so a naive
+        # walk reports every one of them as served and the guard can never fire.
+        if path and endpoint is not _probe_not_found:
+            into.add(path)
+
+    served = set()
+    for route in main.app.routes:
+        _record(served, getattr(route, "path", None), getattr(route, "endpoint", None))
+        context = getattr(route, "include_context", None)
+        inner = getattr(context, "included_router", None) if context is not None else None
+        if inner is not None:
+            prefix = getattr(context, "prefix", "")
+            for sub in inner.routes:
+                _record(
+                    served,
+                    (prefix + getattr(sub, "path", "")) if getattr(sub, "path", None) else None,
+                    getattr(sub, "endpoint", None),
+                )
+
+    assert "/v1/models" in served, "route walk found nothing; re-derive this"
+    mod = _load()
+    for probe in mod._UNSERVED_V1_PROBE_PATHS:
+        assert f"/{probe}" not in served, (
+            f"Studio now serves /{probe}; drop it from _UNSERVED_V1_PROBE_PATHS"
+        )

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -686,6 +686,6 @@ def test_the_v1_deny_list_never_shadows_a_path_studio_serves():
     assert "/v1/models" in served, "route walk found nothing; re-derive this"
     mod = _load()
     for probe in mod._UNSERVED_V1_PROBE_PATHS:
-        assert f"/{probe}" not in served, (
-            f"Studio now serves /{probe}; drop it from _UNSERVED_V1_PROBE_PATHS"
-        )
+        assert (
+            f"/{probe}" not in served
+        ), f"Studio now serves /{probe}; drop it from _UNSERVED_V1_PROBE_PATHS"

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -81,7 +81,11 @@ class _Backend:
         return self._props
 
 
-def _inference_double(backend, catalog):
+def _inference_double(
+    backend,
+    catalog,
+    orchestrator = None,
+):
     """Stand-in for routes.inference, injected through llama_compat._inference().
 
     Deliberately not a sys.modules entry: an earlier revision stubbed
@@ -91,8 +95,8 @@ def _inference_double(backend, catalog):
     inference = types.SimpleNamespace()
     inference.get_llama_cpp_backend = lambda: backend
     inference._llama_public_model_id = lambda b, fallback = None: b._openai_advertised_id
-    inference._orchestrator_public_model_id = lambda b: None
-    inference._peek_inference_backend = lambda: None
+    inference._peek_inference_backend = lambda: orchestrator
+    inference._orchestrator_public_model_id = lambda b: b.active_model_name
 
     async def _objects():
         return catalog
@@ -104,7 +108,11 @@ def _inference_double(backend, catalog):
 _MOD = None
 
 
-def _load(backend = None, catalog = None):
+def _load(
+    backend = None,
+    catalog = None,
+    orchestrator = None,
+):
     """The real routes/llama_compat.py, with routes.inference replaced by a double."""
     global _MOD
     if _MOD is None:
@@ -117,6 +125,7 @@ def _load(backend = None, catalog = None):
     double = _inference_double(
         backend if backend is not None else _Backend(),
         CATALOG if catalog is None else catalog,
+        orchestrator,
     )
     _MOD._inference = lambda: double
     return _MOD
@@ -158,17 +167,24 @@ def test_the_reported_probe_sequence_no_longer_returns_html():
     """
     mod = _load()
     with _client(mod) as c:
+        # The two that used to answer with the app shell now answer with JSON.
+        for path in ("/props", "/v1/props", "/version"):
+            r = c.get(path)
+            assert r.status_code == 200, (path, r.status_code)
+            assert "application/json" in r.headers["content-type"], path
+
+        # The Ollama pair stays a 404 on purpose: see test_the_ollama_surface_is_not
+        # _advertised. What matters is that no probe in the sequence gets HTML.
+        # 405 for POST /api/show is main.py's standing answer for a POST to any unknown
+        # /api/ path, unchanged by this PR; what matters is that none of them is HTML.
         for method, path in (
-            ("GET", "/props"),
-            ("GET", "/v1/props"),
-            ("GET", "/version"),
+            ("GET", "/api/v1/models"),
             ("GET", "/api/tags"),
             ("POST", "/api/show"),
         ):
             r = c.request(method, path, json = {} if method == "POST" else None)
-            assert r.status_code == 200, (method, path, r.status_code)
-            assert "application/json" in r.headers["content-type"], (method, path)
-            assert "text/html" not in r.headers["content-type"], (method, path)
+            assert r.status_code in (404, 405), (method, path, r.status_code)
+            assert "text/html" not in r.headers.get("content-type", ""), (method, path)
 
 
 def test_the_html_fallback_is_what_used_to_answer_these():
@@ -243,7 +259,11 @@ def test_props_with_nothing_loaded_reports_no_model():
     with _client(mod) as c:
         body = c.get("/props").json()
     assert "model_path" not in body
-    assert body["total_slots"] == 0
+    # No llama-server, so no llama-server props. Reporting total_slots 0 and an empty
+    # template would describe an engine that is not running.
+    assert "total_slots" not in body
+    assert "chat_template" not in body
+    assert body["build_info"].startswith("unsloth-studio/")
 
 
 def test_v1_props_and_props_agree():
@@ -255,138 +275,18 @@ def test_v1_props_and_props_agree():
 # ── /version ──────────────────────────────────────────────────────────────────
 
 
-def test_version_answers_on_both_spellings():
+def test_version_answers_on_the_bare_path_only():
+    """Ollama spells it /api/version; answering there is part of claiming to be Ollama."""
     mod = _load()
     with _client(mod) as c:
-        bare = c.get("/version").json()
-        prefixed = c.get("/api/version").json()
-    assert bare == prefixed
-    assert isinstance(bare["version"], str) and bare["version"]
-
-
-# ── /api/tags ─────────────────────────────────────────────────────────────────
-
-
-def test_tags_publishes_the_same_ids_as_v1_models():
-    mod = _load()
-    with _client(mod) as c:
-        models = c.get("/api/tags").json()["models"]
-    assert [m["name"] for m in models] == [m["id"] for m in CATALOG]
-    assert all(m["name"] == m["model"] for m in models)
-
-
-def test_tags_modified_at_is_rfc3339_not_an_epoch():
-    """Ollama clients parse this as a timestamp; a bare integer makes them throw."""
-    mod = _load()
-    with _client(mod) as c:
-        first = c.get("/api/tags").json()["models"][0]
-    assert first["modified_at"] == "2023-11-14T22:13:20Z"
-
-
-def test_tags_reports_the_quant_it_knows_and_no_invented_digest():
-    mod = _load()
-    with _client(mod) as c:
-        models = c.get("/api/tags").json()["models"]
-    assert models[0]["details"]["quantization_level"] == "UD-Q4_K_XL"
-    # The unquantised catalog row must not borrow the previous row's value.
-    assert models[1]["details"]["quantization_level"] == ""
-    # Studio has no blob digest for these. Empty, never fabricated: a client that
-    # compared a made-up digest would re-pull on every check.
-    assert all(m["digest"] == "" and m["size"] == 0 for m in models)
-
-
-def test_tags_on_an_empty_catalog_is_an_empty_list_not_an_error():
-    mod = _load(catalog = [])
-    with _client(mod) as c:
-        r = c.get("/api/tags")
-    assert r.status_code == 200
-    assert r.json() == {"models": []}
-
-
-# ── /api/show ─────────────────────────────────────────────────────────────────
-
-
-def test_show_accepts_both_ollama_spellings():
-    mod = _load()
-    with _client(mod) as c:
-        by_model = c.post("/api/show", json = {"model": "unsloth/Laguna-S-2.1-GGUF"})
-        by_name = c.post("/api/show", json = {"name": "unsloth/Laguna-S-2.1-GGUF"})
-    assert by_model.status_code == 200
-    assert by_model.json() == by_name.json()
-
-
-def test_show_matches_case_insensitively_like_v1_models():
-    mod = _load()
-    with _client(mod) as c:
-        r = c.post("/api/show", json = {"model": "UNSLOTH/laguna-s-2.1-gguf"})
-    assert r.status_code == 200
-    assert r.json()["details"]["quantization_level"] == ""
-
-
-def test_show_with_an_empty_body_falls_back_to_the_loaded_model():
-    """A probe often POSTs {} just to see whether the endpoint exists. 422 would
-    make it conclude the server is not Ollama-compatible."""
-    mod = _load()
-    with _client(mod) as c:
-        r = c.post("/api/show", json = {})
-    assert r.status_code == 200
-    assert r.json()["details"]["quantization_level"] == "UD-Q4_K_XL"
-
-
-def test_show_404s_an_unknown_model():
-    mod = _load()
-    with _client(mod) as c:
-        r = c.post("/api/show", json = {"model": "not/a-real-model"})
-    assert r.status_code == 404
-    assert "text/html" not in r.headers["content-type"]
-
-
-def test_show_404s_rather_than_500s_when_nothing_is_loaded_and_no_model_is_named():
-    mod = _load(backend = _Backend(loaded = False))
-    with _client(mod) as c:
-        assert c.post("/api/show", json = {}).status_code == 404
+        bare = c.get("/version")
+        prefixed = c.get("/api/version")
+    assert bare.status_code == 200
+    assert isinstance(bare.json()["version"], str) and bare.json()["version"]
+    assert prefixed.status_code == 404
 
 
 # ── platform and robustness, from the sandbox run ─────────────────────────────
-
-
-@pytest.mark.parametrize("osname", ["Linux", "Darwin", "Windows"])
-@pytest.mark.parametrize(
-    "created",
-    [0, 1, -1, 1_700_000_000, 2**31, 2**40, 10**18, 1.5, None, "nope", float("nan")],
-)
-def test_modified_at_is_a_four_digit_year_stamp_on_every_platform(osname, created, monkeypatch):
-    """gmtime() disagrees across the three platforms at both ends of its range: Linux
-    accepts a huge epoch and returns a five digit year no client can parse, macOS
-    rejects anything before 1970, Windows rejects both ends. Clamping first is what
-    makes one catalog row render identically everywhere."""
-    mod = _load()
-    real = time.gmtime
-
-    def platform_gmtime(value):
-        if osname == "Windows" and not (0 <= value < 32536850000):
-            raise OSError(22, "Invalid argument")
-        if osname == "Darwin" and value < 0:
-            raise OSError(22, "Invalid argument")
-        return real(value)
-
-    monkeypatch.setattr(mod.time, "gmtime", platform_gmtime)
-    out = mod._rfc3339(created)
-    time.strptime(out, "%Y-%m-%dT%H:%M:%SZ")
-    assert len(out) == 20 and out.endswith("Z"), out
-    assert 1970 <= int(out[:4]) <= 9999, out
-
-
-def test_the_timestamp_fallback_does_not_itself_call_gmtime(monkeypatch):
-    """An earlier revision fell back to gmtime(0), which raises too on a platform
-    strict enough to have rejected the first call, taking /api/tags with it."""
-    mod = _load()
-    monkeypatch.setattr(
-        mod.time, "gmtime", lambda _v: (_ for _ in ()).throw(OSError(22, "Invalid argument"))
-    )
-    assert mod._rfc3339(1_700_000_000) == "1970-01-01T00:00:00Z"
-    with _client(mod) as c:
-        assert len(c.get("/api/tags").json()["models"]) == len(CATALOG)
 
 
 @pytest.mark.parametrize(
@@ -495,3 +395,89 @@ def test_no_client_side_ui_route_is_shadowed_by_the_deny_list():
     assert declared, "no client routes parsed; the parser needs updating"
     shadowed = {p for p in declared if mod.is_engine_probe_path(p)}
     assert not shadowed, f"UI route(s) shadowed by the probe deny-list: {shadowed}"
+
+
+# ── the four findings from review ─────────────────────────────────────────────
+
+
+def test_the_ollama_surface_is_not_advertised():
+    """Answering /api/tags identifies this server as Ollama, and a client that
+    completes Ollama discovery then posts to /api/chat or /api/generate, which Studio
+    does not serve. The reporting user's client got 404 here, fell back to the OpenAI
+    surface, and worked; advertising a protocol we do not implement would have broken
+    exactly that client. Same defect as the HTML 200, one layer up."""
+    mod = _load()
+    routes = {r.path for r in mod.router.routes}
+    assert "/api/tags" not in routes
+    assert "/api/show" not in routes
+    assert "/api/version" not in routes
+    # And the inference endpoints an Ollama client would go on to call are absent, which
+    # is what makes advertising the discovery pair wrong rather than merely incomplete.
+    assert "/api/chat" not in routes and "/api/generate" not in routes
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/completion",
+        "/tokenize",
+        "/detokenize",
+        "/rerank",
+        "/infill",
+        "/embedding",
+        "/apply-template",
+        "/slots",
+    ],
+)
+def test_unserved_engine_endpoints_404_on_their_real_method_not_405(method, path):
+    """These are POST endpoints in llama-server. The deny-list guard lives in the SPA's
+    GET catch-all, so before this a POST matched the GET-only route and returned 405,
+    which a discovery client reads as "exists, wrong method" -- the same false positive
+    the 404 exists to close."""
+    mod = _load()
+    with _client(mod) as c:
+        r = c.request(method, path, json = {})
+    assert r.status_code == 404, (method, path, r.status_code)
+    assert "text/html" not in r.headers.get("content-type", ""), (method, path)
+
+
+def test_get_on_a_probe_path_still_reaches_the_asset_lookup(tmp_path):
+    """The non-GET routes deliberately omit GET, or they would shadow the catch-all's
+    static lookup and re-break the asset case."""
+    mod = _load()
+    assert not any(
+        "GET" in (getattr(r, "methods", None) or set()) and r.path == "/completion"
+        for r in mod.router.routes
+    )
+
+
+def test_props_does_not_pair_an_orchestrator_model_with_llama_server_fields():
+    """With a Transformers or MLX model resident the llama backend is unloaded. Reading
+    its fields anyway advertised the orchestrator's model alongside n_ctx 0, an empty
+    template and total_slots 0: a self-contradictory description of a model that is in
+    fact serving."""
+
+    class _Orchestrator:
+        active_model_name = "unsloth/Llama-3.2-3B"
+
+    mod = _load(backend = _Backend(loaded = False), orchestrator = _Orchestrator())
+    with _client(mod) as c:
+        body = c.get("/props").json()
+    assert body["model_path"] == "unsloth/Llama-3.2-3B"
+    for llama_only in ("total_slots", "chat_template", "default_generation_settings"):
+        assert llama_only not in body, llama_only
+
+
+def test_the_probe_paths_are_admitted_under_keyless_inference_scope():
+    """keyless_api_access_scope="inference" lets a keyless client list models and chat.
+    A 401 on /props in front of that surface reads as an auth wall over the whole thing
+    and stops discovery, which is the opposite of what the scope grants."""
+    from utils.keyless_api_access import _INFERENCE_ROUTES
+
+    assert ("GET", "/v1/models") in _INFERENCE_ROUTES, "baseline moved; re-derive this"
+    for path in ("/props", "/v1/props", "/version"):
+        assert ("GET", path) in _INFERENCE_ROUTES, path
+    # Not the Ollama paths: they are not served at all.
+    for path in ("/api/tags", "/api/show", "/api/version"):
+        assert ("GET", path) not in _INFERENCE_ROUTES, path

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -55,6 +55,12 @@ _INFERENCE_ROUTES = frozenset(
         ("POST", "/v1/messages/count_tokens"),
         ("GET", "/v1/models"),
         ("POST", "/v1/responses"),
+        # Discovery probes, read-only. A keyless client that may list models and chat
+        # but gets 401 on /props reads that as an auth wall in front of the whole
+        # surface and stops, which is the opposite of what the scope grants.
+        ("GET", "/props"),
+        ("GET", "/v1/props"),
+        ("GET", "/version"),
     }
 )
 


### PR DESCRIPTION
## The report

A user shared a Studio server log in which a third-party client, pointed at Studio's port, ran the same discovery probe twice. Two of the six answers were wrong, and the access log could not show it because it records only the status:

| Request | Before | After |
| --- | --- | --- |
| `GET /api/v1/models` | 404 | 404 |
| `GET /api/tags` | 404 | 200 JSON, Ollama list shape |
| `GET /v1/props` | 404 | 200 JSON |
| `GET /props` | **200 `text/html`** | 200 JSON |
| `GET /version` | **200 `text/html`** | 200 JSON |
| `POST /api/show` | 405 | 200 JSON, or 404 for an unknown model |

## Why the two 200s happen

`/props` and `/version` are not routes here, so they fall through the SPA catch-all in `serve_frontend()` (`main.py`, `@app.get("/{full_path:path}")`), which returns `index.html` for anything outside `/api/` and `/v1/`. A probe checks the status before the body, so 200 reads as "supported" and the parse then fails on HTML. That is strictly worse than the 404 the other four returned. `POST /api/show` returned 405 for the same reason: the catch-all is GET only.

llama-server itself serves `/props`, `/api/tags` and `/api/show`, and Studio already answers the OpenAI surface on the same port, so a client had every reason to expect them.

## The change

`studio/backend/routes/llama_compat.py` (new) serves `/props`, `/v1/props`, `/version`, `/api/version`, `/api/tags` and `POST /api/show`.

- Authenticated exactly like `GET /v1/models`. `/props` carries the chat template and the slot count, and the listings carry the same ids `/v1/models` publishes, so none of it may be looser than the endpoint it mirrors.
- `/props` replaces llama-server's absolute `model_path` with the public model id, so a LAN probe cannot read the layout of the user's disk, and degrades to the local view when `_query_server_props()` returns `None` on a mid-restart engine rather than failing the probe.
- `/api/tags` reports RFC3339 timestamps, because a bare epoch makes Ollama clients throw, and leaves `size` and `digest` at their empty values rather than inventing a digest a client would compare against and re-pull on.
- `POST /api/show` accepts both the `model` and `name` spellings, matches case-insensitively like `/v1/models/{id}`, and falls back to the loaded model on an empty body, since a probe often POSTs `{}` just to see whether the endpoint exists and a 422 would make it conclude the server is not compatible.

`is_engine_probe_path()` closes the hole for the endpoints Studio does not serve. `/slots`, `/completion`, `/metrics`, `/tokenize`, `/health` and the rest now 404 instead of rendering the app. Ordinary UI deep links still get the shell.

## Compatibility

Additive. No existing route, response shape or auth boundary changes. The only edit outside the new file is two lines in `main.py`: the `include_router` call, placed ahead of the catch-all, and the probe guard inside `serve_frontend`.

## Tests

`studio/backend/tests/test_llama_compat_routes.py`, 18 tests. They reproduce the reported sequence against the SPA catch-all in `main.py`'s real registration order, with a control asserting an ordinary deep link still gets the shell, so the suite cannot pass on a build that simply 404s everything.

Checked against mutants that drop the `model_path` sanitisation, disable the probe guard, remove the `/props` routes, and make `/api/show` reject an empty body. Each was caught.

Also verified end to end against the real `main.app` with `setup_frontend` mounted: every path above answers JSON or a real 404, and `/some-ui-deep-link` still returns `text/html`.
