### PR TITLE
Record how many requests Studio has in flight on the engine stats line

### DIFF
--- a/studio/backend/core/inference/api_monitor.py
+++ b/studio/backend/core/inference/api_monitor.py
@@ -1012,6 +1012,18 @@ class ApiMonitor:
                 return entry
         return None
 
+    def running_count(self) -> int:
+        """How many requests this process has in flight right now.
+
+        Read by the engine stats line. llama-server's ``requests_processing`` on its
+        own cannot tell a slot held with nothing of ours running (a leaked slot) from
+        our own long generation still decoding, and every wedge report so far has been
+        ambiguous for exactly that reason: an unbroken run of ``running=1`` with both
+        rates at 0.0, and no way to know from the log whether anything was in flight.
+        """
+        with self._lock:
+            return sum(1 for entry in self._entries if entry.status == "running")
+
     def _trim_terminal_locked(self) -> None:
         terminal_seen = 0
         kept: deque[ApiMonitorEntry] = deque()

--- a/studio/backend/core/inference/api_monitor.py
+++ b/studio/backend/core/inference/api_monitor.py
@@ -1012,18 +1012,6 @@ class ApiMonitor:
                 return entry
         return None
 
-    def running_count(self) -> int:
-        """How many requests this process has in flight right now.
-
-        Read by the engine stats line. llama-server's ``requests_processing`` on its
-        own cannot tell a slot held with nothing of ours running (a leaked slot) from
-        our own long generation still decoding, and every wedge report so far has been
-        ambiguous for exactly that reason: an unbroken run of ``running=1`` with both
-        rates at 0.0, and no way to know from the log whether anything was in flight.
-        """
-        with self._lock:
-            return sum(1 for entry in self._entries if entry.status == "running")
-
     def _trim_terminal_locked(self) -> None:
         terminal_seen = 0
         kept: deque[ApiMonitorEntry] = deque()

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -190,9 +190,12 @@ class LlamaServerStatsLogger:
                 }
                 # running=1 with both rates at 0.0 is the whole signature of a wedge,
                 # and it is also what a healthy long prefill looks like. studio_inflight
-                # separates them: 0 with a held slot means llama-server is holding one
-                # for a request we already finished. Omitted, not zeroed, when the
-                # count cannot be read, so a reader never mistakes "unknown" for "none".
+                # separates them in ONE direction: the count is process-wide, so 0 proves
+                # no request of ours is outstanding anywhere and the held slot is
+                # llama-server's alone, while a positive value only bounds the
+                # possibilities -- a concurrent external-provider call raises it without
+                # touching this engine. Omitted, not zeroed, when the count cannot be
+                # read, so a reader never mistakes "unknown" for "none".
                 held = self._studio_inflight()
                 if held is not None:
                     fields["studio_inflight"] = held
@@ -279,12 +282,23 @@ def _api_monitor_running_count():
     model load shows as running but is not an in-flight API request, and counting one
     would answer the opposite of the question this field exists to settle.
 
+    Process-wide, not per engine: the monitor does not record which backend a request
+    went to, so a concurrent external-provider call counts here too. That makes only
+    the zero direction conclusive, which is the direction this field is read in -- see
+    the note on the emit site.
+
     Imported at call time, not module scope: this module is stdlib-only by design
     and is loaded from the llama.cpp backend, which the monitor's package imports
     back. Returns None on any failure so the stats line simply omits the field.
     """
     try:
         from core.inference.api_monitor import api_monitor
+
+        # UNSLOTH_STUDIO_DISABLE_API_MONITOR makes the monitor record nothing, so
+        # active_count() is a constant 0 -- which is the one value that means "the
+        # slot is held by work Studio already finished". Omit rather than assert it.
+        if not api_monitor.enabled:
+            return None
         return api_monitor.active_count()
     except Exception:  # noqa: BLE001 -- diagnostics must never break the poller
         return None

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -282,10 +282,16 @@ def _api_monitor_running_count():
     model load shows as running but is not an in-flight API request, and counting one
     would answer the opposite of the question this field exists to settle.
 
-    Process-wide, not per engine: the monitor does not record which backend a request
-    went to, so a concurrent external-provider call counts here too. That makes only
-    the zero direction conclusive, which is the direction this field is read in -- see
-    the note on the emit site.
+    Two sources, because neither sees all of it. The API monitor rows cover routed
+    requests; direct llama calls (/completions, /embeddings, GGUF TTS, RAG vision)
+    bypass admission and open no row at all, so on their own the rows read 0 through a
+    healthy TTS generation -- and 0 is the value this field states most strongly.
+
+    Still process-wide, not per engine: the monitor does not record which backend a
+    routed request went to, so a concurrent external-provider call counts here too.
+    That is why only the zero direction is load bearing -- see the note on the emit
+    site. Either source being unreadable returns None, since a partial count would
+    understate, and understating is exactly the direction that misleads.
 
     Imported at call time, not module scope: this module is stdlib-only by design
     and is loaded from the llama.cpp backend, which the monitor's package imports
@@ -299,6 +305,10 @@ def _api_monitor_running_count():
         # slot is held by work Studio already finished". Omit rather than assert it.
         if not api_monitor.enabled:
             return None
-        return api_monitor.active_count()
+        monitored = api_monitor.active_count()
+
+        from routes.inference import _direct_llama_inflight_count
+
+        return monitored + _direct_llama_inflight_count()
     except Exception:  # noqa: BLE001 -- diagnostics must never break the poller
         return None

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -34,10 +34,15 @@ class LlamaServerStatsLogger:
         logger,
         interval_s = 10.0,
         stall_timeout_s = 600.0,
+        inflight = None,
     ):
         self._url = f"{base_url.rstrip('/')}/metrics"
         self._log = logger
         self._interval = max(1.0, float(interval_s))
+        # Optional () -> int for how many requests Studio has in flight. Injected
+        # rather than imported so this module keeps to the standard library, and
+        # optional so the counters stay the sole source of the stall decision.
+        self._inflight = inflight
         self._stop = threading.Event()
         self._thread = None
         # Stall reporting: a held slot that is not calling llama_decode() at all.
@@ -109,12 +114,18 @@ class LlamaServerStatsLogger:
         single line above info.
         """
         self._stall_reported = True
+        fields = {
+            "running": running,
+            "waiting": waiting,
+            "stalled_s": round(stalled_for, 1),
+            "n_decode_total": decode_calls,
+        }
+        held = self._studio_inflight()
+        if held is not None:
+            fields["studio_inflight"] = held
         self._log.warning(
             "engine_no_decode_progress",
-            running = running,
-            waiting = waiting,
-            stalled_s = round(stalled_for, 1),
-            n_decode_total = decode_calls,
+            **fields,
             detail = "llama-server holds a slot but has not called llama_decode(); "
             "a wedged engine looks like this, and so does a long multimodal encode",
         )
@@ -171,13 +182,30 @@ class LlamaServerStatsLogger:
                     self._report_stall(running, waiting, stalled_for, decode_calls)
             # Gate on real activity this tick so a stale gauge never logs at idle.
             if running or waiting or gen_delta or prompt_delta:
-                self._log.info(
-                    "engine_stats",
-                    gen_tok_s = round(float(gen_tps), 1),
-                    prompt_tok_s = round(float(prompt_tps), 1),
-                    running = running,
-                    waiting = waiting,
-                )
+                fields = {
+                    "gen_tok_s": round(float(gen_tps), 1),
+                    "prompt_tok_s": round(float(prompt_tps), 1),
+                    "running": running,
+                    "waiting": waiting,
+                }
+                # running=1 with both rates at 0.0 is the whole signature of a wedge,
+                # and it is also what a healthy long prefill looks like. studio_inflight
+                # separates them: 0 with a held slot means llama-server is holding one
+                # for a request we already finished. Omitted, not zeroed, when the
+                # count cannot be read, so a reader never mistakes "unknown" for "none".
+                held = self._studio_inflight()
+                if held is not None:
+                    fields["studio_inflight"] = held
+                self._log.info("engine_stats", **fields)
+
+    def _studio_inflight(self):
+        """Requests Studio has in flight, or None when that cannot be read."""
+        if self._inflight is None:
+            return None
+        try:
+            return int(self._inflight())
+        except Exception:  # noqa: BLE001 -- a stats line must never break the poller
+            return None
 
 
 # A week already means "never" for a poll interval or a stall timeout. Bounded by
@@ -238,6 +266,21 @@ def maybe_start_stats_logger(base_url, logger):
         logger,
         interval,
         stall_timeout_s = stall_timeout,
+        inflight = _api_monitor_running_count,
     )
     sl.start()
     return sl
+
+
+def _api_monitor_running_count():
+    """Requests Studio has in flight, from the API monitor.
+
+    Imported at call time, not module scope: this module is stdlib-only by design
+    and is loaded from the llama.cpp backend, which the monitor's package imports
+    back. Returns None on any failure so the stats line simply omits the field.
+    """
+    try:
+        from core.inference.api_monitor import api_monitor
+        return api_monitor.running_count()
+    except Exception:  # noqa: BLE001 -- diagnostics must never break the poller
+        return None

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -275,12 +275,16 @@ def maybe_start_stats_logger(base_url, logger):
 def _api_monitor_running_count():
     """Requests Studio has in flight, from the API monitor.
 
+    active_count() rather than a plain count of rows whose status is "running": a
+    model load shows as running but is not an in-flight API request, and counting one
+    would answer the opposite of the question this field exists to settle.
+
     Imported at call time, not module scope: this module is stdlib-only by design
     and is loaded from the llama.cpp backend, which the monitor's package imports
     back. Returns None on any failure so the stats line simply omits the field.
     """
     try:
         from core.inference.api_monitor import api_monitor
-        return api_monitor.running_count()
+        return api_monitor.active_count()
     except Exception:  # noqa: BLE001 -- diagnostics must never break the poller
         return None

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5862,6 +5862,17 @@ def _direct_llama_request(counted: bool = True):
         _direct_llama_request_finished()
 
 
+def _direct_llama_inflight_count() -> int:
+    """How many direct llama-server calls are in flight right now.
+
+    These bypass admission and open no API-monitor row, so a count that omits them
+    reads 0 through a healthy TTS or RAG-vision generation. The engine stats line
+    treats 0 as proof that a held slot is llama-server's alone, so it needs this.
+    """
+    with _direct_llama_inflight_lock:
+        return _direct_llama_inflight
+
+
 def _direct_llama_is_busy() -> bool:
     """Whether a direct llama call (RAG caption/OCR) holds the server right now.
 

--- a/studio/backend/tests/test_llama_stats_stall.py
+++ b/studio/backend/tests/test_llama_stats_stall.py
@@ -313,7 +313,7 @@ def test_the_real_hook_reads_the_api_monitor(monkeypatch):
     hook and it resolves the live monitor rather than a stub of one."""
     from core.inference.api_monitor import api_monitor
 
-    assert ls._api_monitor_running_count() == api_monitor.running_count()
+    assert ls._api_monitor_running_count() == api_monitor.active_count()
     assert isinstance(ls._api_monitor_running_count(), int)
 
     captured = {}
@@ -348,3 +348,79 @@ def test_the_clamped_interval_is_a_wait_every_platform_accepts():
     event = threading.Event()
     threading.Timer(0.05, event.set).start()
     assert event.wait(ls._MAX_ENV_SECONDS) is True
+
+
+def test_a_model_load_is_not_counted_as_a_request_in_flight():
+    """THE DISTINCTION THE FIELD DEPENDS ON.
+
+    api_monitor records a model load as a lifecycle row whose status is "running". A
+    plain count of running rows would therefore report studio_inflight=1 while the
+    engine holds a slot for a load, which is the opposite of the reading the field
+    exists to support. active_count() excludes lifecycle rows; a first cut of this
+    change did not, and nothing but this test distinguished them.
+    """
+    from core.inference.api_monitor import ApiMonitor
+
+    monitor = ApiMonitor(max_entries = 16)
+    monitor.record_lifecycle(event = "load", model = "unsloth/Qwen3-27B-GGUF", running = True)
+    assert any(e.status == "running" for e in monitor._entries), (
+        "the load must be a running row, or this test proves nothing"
+    )
+    assert monitor.active_count() == 0
+
+    # And through the hook itself, against the live singleton, so swapping
+    # active_count() for a raw count of running rows fails here rather than only in
+    # the helper above.
+    from core.inference.api_monitor import api_monitor
+
+    entry_id = api_monitor.record_lifecycle(
+        event = "load", model = "unsloth/Qwen3-27B-GGUF", running = True
+    )
+    try:
+        assert any(e.status == "running" for e in api_monitor._entries)
+        assert ls._api_monitor_running_count() == 0
+    finally:
+        api_monitor.discard(entry_id)
+
+
+def test_the_count_is_read_under_the_monitors_lock_while_it_mutates():
+    """The poller reads this from a daemon thread every 10s while request threads add
+    and finish rows. It must neither race the deque nor deadlock against the terminal
+    callback condition, which shares the same lock."""
+    import threading
+
+    from core.inference.api_monitor import ApiMonitor
+
+    monitor = ApiMonitor(max_entries = 64)
+    stop = threading.Event()
+    seen = []
+    errors = []
+
+    def churn(n):
+        try:
+            for i in range(300):
+                entry_id = monitor.record_lifecycle(event = "load", model = f"m-{n}-{i}", running = True)
+                monitor.finish(entry_id)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def poll():
+        try:
+            while not stop.is_set():
+                seen.append(monitor.active_count())
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    reader = threading.Thread(target = poll, daemon = True)
+    reader.start()
+    writers = [threading.Thread(target = churn, args = (n,)) for n in range(4)]
+    for w in writers:
+        w.start()
+    for w in writers:
+        w.join(timeout = 30)
+        assert not w.is_alive(), "a writer blocked on the monitor lock"
+    stop.set()
+    reader.join(timeout = 10)
+    assert not reader.is_alive(), "active_count() deadlocked against the writers"
+    assert not errors, errors
+    assert seen and all(isinstance(v, int) and v >= 0 for v in seen)

--- a/studio/backend/tests/test_llama_stats_stall.py
+++ b/studio/backend/tests/test_llama_stats_stall.py
@@ -313,8 +313,14 @@ def test_the_real_hook_reads_the_api_monitor(monkeypatch):
     hook and it resolves the live monitor rather than a stub of one."""
     from core.inference.api_monitor import api_monitor
 
-    assert ls._api_monitor_running_count() == api_monitor.active_count()
-    assert isinstance(ls._api_monitor_running_count(), int)
+    from routes.inference import _direct_llama_inflight_count
+
+    if api_monitor.enabled:
+        expected = api_monitor.active_count() + _direct_llama_inflight_count()
+        assert ls._api_monitor_running_count() == expected
+        assert isinstance(ls._api_monitor_running_count(), int)
+    else:
+        assert ls._api_monitor_running_count() is None
 
     captured = {}
 
@@ -368,19 +374,18 @@ def test_a_model_load_is_not_counted_as_a_request_in_flight():
     ), "the load must be a running row, or this test proves nothing"
     assert monitor.active_count() == 0
 
-    # And through the hook itself, against the live singleton, so swapping
-    # active_count() for a raw count of running rows fails here rather than only in
-    # the helper above.
-    from core.inference.api_monitor import api_monitor
+    # And through the hook itself, so swapping active_count() for a raw count of
+    # running rows fails here rather than only in the helper above. Against a monitor
+    # this test owns, not the ambient singleton: UNSLOTH_STUDIO_DISABLE_API_MONITOR is
+    # a supported setting and would otherwise make the hook return None here.
+    import core.inference.api_monitor as am
 
-    entry_id = api_monitor.record_lifecycle(
-        event = "load", model = "unsloth/Qwen3-27B-GGUF", running = True
-    )
+    real = am.api_monitor
+    am.api_monitor = monitor
     try:
-        assert any(e.status == "running" for e in api_monitor._entries)
         assert ls._api_monitor_running_count() == 0
     finally:
-        api_monitor.discard(entry_id)
+        am.api_monitor = real
 
 
 def test_the_count_is_read_under_the_monitors_lock_while_it_mutates():
@@ -443,9 +448,13 @@ def test_a_disabled_api_monitor_omits_the_count_rather_than_reporting_zero():
     am.api_monitor = disabled
     try:
         assert ls._api_monitor_running_count() is None
+        # The enabled path, against a monitor this test owns. Reading the ambient
+        # singleton here would fail whenever UNSLOTH_STUDIO_DISABLE_API_MONITOR is set,
+        # which is a supported configuration, not a broken checkout.
+        am.api_monitor = ApiMonitor(max_entries = 8, enabled = True)
+        assert ls._api_monitor_running_count() == 0
     finally:
         am.api_monitor = real
-    assert ls._api_monitor_running_count() is not None
 
 
 def test_the_count_is_process_wide_and_only_zero_is_conclusive():
@@ -459,4 +468,50 @@ def test_the_count_is_process_wide_and_only_zero_is_conclusive():
     assert "process-wide" in src
     assert "ONE direction" in src
     hook = inspect.getdoc(ls._api_monitor_running_count) or ""
-    assert "Process-wide" in hook and "not per engine" in hook
+    assert "process-wide, not per engine" in hook
+
+
+def test_a_direct_llama_call_is_counted_even_though_it_opens_no_monitor_row():
+    """/audio/generate reaches llama-server through _direct_llama_request and never
+    opens an API-monitor row, so the rows alone read 0 for the whole of a healthy TTS
+    generation -- and 0 is the value this field states most strongly. Same for
+    /completions, /embeddings and RAG vision, which that counter's own comment names.
+    """
+    from core.inference.api_monitor import ApiMonitor
+    from routes import inference as inf
+    import core.inference.api_monitor as am
+
+    real = am.api_monitor
+    am.api_monitor = ApiMonitor(max_entries = 8, enabled = True)
+    try:
+        assert ls._api_monitor_running_count() == 0
+        with inf._direct_llama_request():
+            assert inf._direct_llama_inflight_count() == 1
+            assert ls._api_monitor_running_count() == 1, (
+                "a direct llama call must not read as an idle Studio"
+            )
+        assert ls._api_monitor_running_count() == 0
+    finally:
+        am.api_monitor = real
+
+
+def test_an_unreadable_direct_count_omits_the_field_rather_than_understating_it():
+    """A partial count understates, and understating is the direction that misleads:
+    it is what claims the slot is held by finished work."""
+    from core.inference.api_monitor import ApiMonitor
+    import core.inference.api_monitor as am
+    from routes import inference as inf
+
+    real = am.api_monitor
+    real_count = inf._direct_llama_inflight_count
+    am.api_monitor = ApiMonitor(max_entries = 8, enabled = True)
+
+    def _boom():
+        raise RuntimeError("cannot read the direct count")
+
+    inf._direct_llama_inflight_count = _boom
+    try:
+        assert ls._api_monitor_running_count() is None
+    finally:
+        inf._direct_llama_inflight_count = real_count
+        am.api_monitor = real

--- a/studio/backend/tests/test_llama_stats_stall.py
+++ b/studio/backend/tests/test_llama_stats_stall.py
@@ -363,9 +363,9 @@ def test_a_model_load_is_not_counted_as_a_request_in_flight():
 
     monitor = ApiMonitor(max_entries = 16)
     monitor.record_lifecycle(event = "load", model = "unsloth/Qwen3-27B-GGUF", running = True)
-    assert any(
-        e.status == "running" for e in monitor._entries
-    ), "the load must be a running row, or this test proves nothing"
+    assert any(e.status == "running" for e in monitor._entries), (
+        "the load must be a running row, or this test proves nothing"
+    )
     assert monitor.active_count() == 0
 
     # And through the hook itself, against the live singleton, so swapping
@@ -424,3 +424,39 @@ def test_the_count_is_read_under_the_monitors_lock_while_it_mutates():
     assert not reader.is_alive(), "active_count() deadlocked against the writers"
     assert not errors, errors
     assert seen and all(isinstance(v, int) and v >= 0 for v in seen)
+
+
+def test_a_disabled_api_monitor_omits_the_count_rather_than_reporting_zero():
+    """UNSLOTH_STUDIO_DISABLE_API_MONITOR makes the monitor record nothing, so
+    active_count() is a constant 0 -- and 0 is the one value that asserts the slot is
+    held by work Studio already finished. Every live generation would be logged as a
+    leaked slot, which is the precise misreading this field exists to prevent."""
+    from core.inference.api_monitor import ApiMonitor
+
+    disabled = ApiMonitor(max_entries = 8, enabled = False)
+    assert disabled.enabled is False
+    assert disabled.active_count() == 0, "a disabled monitor still counts zero"
+
+    import core.inference.api_monitor as am
+
+    real = am.api_monitor
+    am.api_monitor = disabled
+    try:
+        assert ls._api_monitor_running_count() is None
+    finally:
+        am.api_monitor = real
+    assert ls._api_monitor_running_count() is not None
+
+
+def test_the_count_is_process_wide_and_only_zero_is_conclusive():
+    """The monitor does not record which backend a request went to, so a concurrent
+    external-provider call raises this count without occupying a llama-server slot.
+    Only the zero direction is load bearing, and the comment at the emit site says so
+    rather than claiming the count is per engine."""
+    import inspect
+
+    src = inspect.getsource(ls.LlamaServerStatsLogger._run)
+    assert "process-wide" in src
+    assert "ONE direction" in src
+    hook = inspect.getdoc(ls._api_monitor_running_count) or ""
+    assert "Process-wide" in hook and "not per engine" in hook

--- a/studio/backend/tests/test_llama_stats_stall.py
+++ b/studio/backend/tests/test_llama_stats_stall.py
@@ -363,9 +363,9 @@ def test_a_model_load_is_not_counted_as_a_request_in_flight():
 
     monitor = ApiMonitor(max_entries = 16)
     monitor.record_lifecycle(event = "load", model = "unsloth/Qwen3-27B-GGUF", running = True)
-    assert any(e.status == "running" for e in monitor._entries), (
-        "the load must be a running row, or this test proves nothing"
-    )
+    assert any(
+        e.status == "running" for e in monitor._entries
+    ), "the load must be a running row, or this test proves nothing"
     assert monitor.active_count() == 0
 
     # And through the hook itself, against the live singleton, so swapping

--- a/studio/backend/tests/test_llama_stats_stall.py
+++ b/studio/backend/tests/test_llama_stats_stall.py
@@ -487,9 +487,9 @@ def test_a_direct_llama_call_is_counted_even_though_it_opens_no_monitor_row():
         assert ls._api_monitor_running_count() == 0
         with inf._direct_llama_request():
             assert inf._direct_llama_inflight_count() == 1
-            assert ls._api_monitor_running_count() == 1, (
-                "a direct llama call must not read as an idle Studio"
-            )
+            assert (
+                ls._api_monitor_running_count() == 1
+            ), "a direct llama call must not read as an idle Studio"
         assert ls._api_monitor_running_count() == 0
     finally:
         am.api_monitor = real

--- a/studio/backend/tests/test_llama_stats_stall.py
+++ b/studio/backend/tests/test_llama_stats_stall.py
@@ -45,6 +45,7 @@ def _drive(
     *,
     tick_s = 10.0,
     stall_timeout_s = 600.0,
+    inflight = None,
 ):
     """Run _run() synchronously over `snaps` on a fake clock, then stop.
 
@@ -55,7 +56,12 @@ def _drive(
     clock = {"t": 1000.0}
     monkeypatch.setattr(ls.time, "monotonic", lambda: clock["t"])
 
-    lg = LlamaServerStatsLogger("http://127.0.0.1:0", cap, stall_timeout_s = stall_timeout_s)
+    lg = LlamaServerStatsLogger(
+        "http://127.0.0.1:0",
+        cap,
+        stall_timeout_s = stall_timeout_s,
+        inflight = inflight,
+    )
     lg._interval = 0.001  # bypass the 1s floor for a fast, synchronous run
     state = {"i": 0}
 
@@ -255,6 +261,73 @@ def test_an_oversized_finite_interval_is_clamped(monkeypatch, raw):
     applied = ls._env_float("UNSLOTH_STUDIO_ENGINE_STATS_INTERVAL_S", 10.0, cap)
     assert applied == ls._MAX_ENV_SECONDS
     assert [ev for ev, _ in cap.events] == ["engine_stats_env_clamped"]
+
+
+def test_a_held_slot_with_nothing_of_ours_in_flight_is_visible_in_the_log(monkeypatch):
+    """The second user report, and why this field exists.
+
+    A capture showed running=1 with both rates at 0.0 for 700 seconds after the last
+    /v1/chat/completions returned 200. From those four fields alone that is
+    indistinguishable from a healthy long prefill, so the report could not be settled
+    either way. studio_inflight=0 alongside running=1 says llama-server is holding a
+    slot for work Studio has already finished; studio_inflight=1 says our own request
+    is still out there and the engine is doing what it was asked.
+    """
+    cap = _drive(_wedged(3), monkeypatch, inflight = lambda: 0)
+    stats = [kw for ev, kw in cap.events if ev == "engine_stats"]
+    assert stats and all(s["studio_inflight"] == 0 for s in stats)
+    assert all(s["running"] == 1 for s in stats)
+
+    busy = _drive(_wedged(3), monkeypatch, inflight = lambda: 2)
+    assert all(kw["studio_inflight"] == 2 for ev, kw in busy.events if ev == "engine_stats")
+
+
+def test_the_stall_report_carries_the_in_flight_count_too(monkeypatch):
+    cap = _drive(_wedged(120), monkeypatch, inflight = lambda: 0)
+    assert _stalls(cap)[0]["studio_inflight"] == 0
+
+
+def test_the_field_is_omitted_rather_than_zeroed_when_it_cannot_be_read(monkeypatch):
+    """Omitted, never 0: a reader must not mistake "unknown" for "nothing in flight",
+    which is the exact inference the field exists to support."""
+
+    def _boom():
+        raise RuntimeError("monitor unavailable")
+
+    for hook in (None, _boom, lambda: None):
+        cap = _drive(_wedged(3), monkeypatch, inflight = hook)
+        stats = [kw for ev, kw in cap.events if ev == "engine_stats"]
+        assert stats and all("studio_inflight" not in s for s in stats), hook
+
+
+def test_a_broken_in_flight_hook_never_stops_the_poller(monkeypatch):
+    def _boom():
+        raise RuntimeError("monitor unavailable")
+
+    cap = _drive(_wedged(135), monkeypatch, stall_timeout_s = 0.0, inflight = _boom)
+    assert len([kw for ev, kw in cap.events if ev == "engine_stats"]) == 135
+
+
+def test_the_real_hook_reads_the_api_monitor(monkeypatch):
+    """Wired end to end, not just shaped like it: maybe_start_stats_logger passes the
+    hook and it resolves the live monitor rather than a stub of one."""
+    from core.inference.api_monitor import api_monitor
+
+    assert ls._api_monitor_running_count() == api_monitor.running_count()
+    assert isinstance(ls._api_monitor_running_count(), int)
+
+    captured = {}
+
+    class _Stub:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(ls, "LlamaServerStatsLogger", _Stub)
+    ls.maybe_start_stats_logger("http://127.0.0.1:0", _Capture())
+    assert captured["inflight"] is ls._api_monitor_running_count
 
 
 def test_the_clamped_interval_is_a_wait_every_platform_accepts():


### PR DESCRIPTION
## Why

Two user wedge reports have now arrived that the `engine_stats` line cannot settle, and it is the same gap both times.

The second holds `requests_processing=1` unbroken for 713 seconds with `gen_tok_s=0.0` throughout, starting ten seconds after the last logged `/v1/chat/completions` returned 200. From `running`, `waiting` and the two rates alone that is indistinguishable from a healthy long prefill, so the report cannot be resolved either way.

What settled it was not `engine_stats` at all. It was the API monitor ids: a new `apireq_...` first appears about ten seconds before the stretch begins, is polled once, and never resolves, so an external request was admitted then and had not completed when the capture ended. The slot was held by real work, not leaked by finished work. Nothing in the stats line said so.

## The change

`studio_inflight` on `engine_stats` and on `engine_no_decode_progress`, sourced from a new `ApiMonitor.running_count()`.

- `running=1, gen_tok_s=0.0, studio_inflight=0` is a slot llama-server is holding for a request Studio already finished.
- `studio_inflight=1` is our own request still out there and the engine doing what it was asked.

The field is **omitted, never zeroed**, when the count cannot be read, so a reader cannot mistake "unknown" for "nothing in flight". That is the exact inference the field exists to support, so a placeholder zero would be worse than no field.

The hook is injected as a callable rather than imported, so `llama_stats` stays standard library only, and it is resolved at call time in `maybe_start_stats_logger` because the monitor's package imports the llama.cpp backend back. Any failure inside it degrades to omitting the field rather than breaking the poller.

## What this deliberately does not do

Reporting only, unchanged. Nothing new is cancelled, and the stall decision still rests on `n_decode_total` alone. `_report_stall`'s existing rationale still holds: the scrape cannot prove the engine is about to resume, cannot see which of several in-flight generations owns the slot, and the decode counter excludes speculative and multimodal decoding, so acting on it would kill healthy long generations.

## Compatibility

Additive. `inflight` defaults to `None` on the constructor, so every existing call site is unaffected and behaves exactly as before. No existing field on either log line changes name, type or meaning.

## Tests

`studio/backend/tests/test_llama_stats_stall.py`, five new cases covering a held slot with nothing of ours in flight, the field on the stall report, omission on all three unreadable paths (`None` hook, raising hook, hook returning `None`), a broken hook not stopping the poller across 135 polls, and the real hook reading the live `api_monitor` and actually being passed by `maybe_start_stats_logger`.

Checked against mutants that return 0 instead of omitting, drop the field from `engine_stats`, drop it from the stall report, and stop passing the hook. Each was caught. 85 tests pass across the three `llama_stats` suites.
