### PR TITLE
Name the encoding when the offload test reads llama.py

### DIFF
--- a/tests/test_offload_frozen_module_device.py
+++ b/tests/test_offload_frozen_module_device.py
@@ -37,7 +37,7 @@ def _load_helper():
     import pathlib
 
     root = pathlib.Path(__file__).resolve().parents[1]
-    src = (root / "unsloth" / "models" / "llama.py").read_text()
+    src = (root / "unsloth" / "models" / "llama.py").read_text(encoding = "utf-8")
     tree = ast.parse(src)
     fn = next(
         node
@@ -251,7 +251,9 @@ def test_the_continued_pretraining_call_sites_pass_the_recorded_device():
     import pathlib
 
     root = pathlib.Path(__file__).resolve().parents[1]
-    tree = ast.parse((root / "unsloth" / "models" / "llama.py").read_text())
+    tree = ast.parse(
+        (root / "unsloth" / "models" / "llama.py").read_text(encoding = "utf-8")
+    )
 
     checked = 0
     for node in ast.walk(tree):

--- a/tests/test_offload_frozen_module_device.py
+++ b/tests/test_offload_frozen_module_device.py
@@ -251,9 +251,7 @@ def test_the_continued_pretraining_call_sites_pass_the_recorded_device():
     import pathlib
 
     root = pathlib.Path(__file__).resolve().parents[1]
-    tree = ast.parse(
-        (root / "unsloth" / "models" / "llama.py").read_text(encoding = "utf-8")
-    )
+    tree = ast.parse((root / "unsloth" / "models" / "llama.py").read_text(encoding = "utf-8"))
 
     checked = 0
     for node in ast.walk(tree):


### PR DESCRIPTION
## What is red

`main` is failing `Repo tests (CPU)`:

```
FAILED tests/test_source_read_encoding.py::test_checked_in_file_reads_name_an_encoding
  tests/test_offload_frozen_module_device.py:40: read_text()
  tests/test_offload_frozen_module_device.py:254: read_text()
```

## Why it is on main

#10034 added that file with two bare `read_text()` calls, and **its own CI caught them** -- that was its single failing check. It merged at `02:54:14` on head `14c6f0b5c`; the fix I had pushed to that branch landed a few minutes later, so it is not in the squash. This is the same change, reapplied against `main`.

## The verdict

The gate is right and the reads were wrong. Both read `unsloth/models/llama.py`, a checked-in source file, with the platform default encoding -- `cp1252` on Windows.

Latent rather than live: `llama.py` is 177,788 bytes and currently **all ASCII**, so nothing breaks today. Failing at the point the read is *added* is precisely what this gate is for. Without it, the breakage surfaces months from now, on Windows only, the first time someone puts a non-ASCII character in `llama.py`.

## Verification

`tests/test_source_read_encoding.py` and the file's own 20 tests: **21 passed**.

The gate's own effectiveness needs no separate mutation check here -- it demonstrably caught this on #10034's CI before the merge.