### PR TITLE
Name utf-8 on the offload test's two source reads

### DIFF
--- a/tests/test_offload_frozen_module_device.py
+++ b/tests/test_offload_frozen_module_device.py
@@ -37,7 +37,7 @@ def _load_helper():
     import pathlib
 
     root = pathlib.Path(__file__).resolve().parents[1]
-    src = (root / "unsloth" / "models" / "llama.py").read_text()
+    src = (root / "unsloth" / "models" / "llama.py").read_text(encoding = "utf-8")
     tree = ast.parse(src)
     fn = next(
         node
@@ -251,7 +251,9 @@ def test_the_continued_pretraining_call_sites_pass_the_recorded_device():
     import pathlib
 
     root = pathlib.Path(__file__).resolve().parents[1]
-    tree = ast.parse((root / "unsloth" / "models" / "llama.py").read_text())
+    tree = ast.parse(
+        (root / "unsloth" / "models" / "llama.py").read_text(encoding = "utf-8")
+    )
 
     checked = 0
     for node in ast.walk(tree):

--- a/tests/test_offload_frozen_module_device.py
+++ b/tests/test_offload_frozen_module_device.py
@@ -251,9 +251,7 @@ def test_the_continued_pretraining_call_sites_pass_the_recorded_device():
     import pathlib
 
     root = pathlib.Path(__file__).resolve().parents[1]
-    tree = ast.parse(
-        (root / "unsloth" / "models" / "llama.py").read_text(encoding = "utf-8")
-    )
+    tree = ast.parse((root / "unsloth" / "models" / "llama.py").read_text(encoding = "utf-8"))
 
     checked = 0
     for node in ast.walk(tree):


### PR DESCRIPTION
## What

Main's `Repo tests (CPU)` leg went red at 97c7ef653 / 3d531a8b6: the new `tests/test_offload_frozen_module_device.py` (#10034) reads `unsloth/models/llama.py` twice with the platform default encoding, and the drift test `test_source_read_encoding.py::test_checked_in_file_reads_name_an_encoding` pins every checked-in file read to name `encoding = "utf-8"` — so source inspection cannot silently break on Windows the day the inspected file gains a non-ASCII byte.

```
AssertionError: 2 file reads in the test trees touch a checked-in file with the platform
default encoding ... ['tests/test_offload_frozen_module_device.py:40: read_text()',
 'tests/test_offload_frozen_module_device.py:254: read_text()']
```

## How

Adds `encoding = "utf-8"` to both `read_text()` calls — the two lines the pin names, nothing else.

## Verification

- On main HEAD (3d531a8b6): `tests/test_source_read_encoding.py` FAILS with the message above (reproduced locally before the change).
- With this change: `tests/test_source_read_encoding.py` + the full `tests/test_offload_frozen_module_device.py` suite → 20 passed, 1 skipped. ruff clean; `scripts/run_ruff_format.py` makes no further changes.
- Failing main runs: https://github.com/unslothai/unsloth/actions/runs/33352183461 (and the run at 97c7ef653).