### PR TITLE
Use the head-aware planner for Studio's multi-GPU device map

### DIFF
--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -81,15 +81,14 @@ _PYTORCH_MISSING_MESSAGE = (
 _LLAMA_CPP_SCRIPTS_WARNING_EMITTED = False
 
 
-def _multi_gpu_device_map_kwargs(planner_eligible: bool = True) -> dict:
+def _multi_gpu_device_map_kwargs() -> dict:
     """``device_map`` kwargs for sharding a checkpoint across every visible GPU.
 
     unsloth's ``from_pretrained`` defaults to ``device_map="sequential"``, which stacks
     the whole model on GPU0 and OOMs multi-GPU hosts whose other GPUs sit empty (#7053).
     Returns a sharding map only on a real multi-GPU CUDA/ROCm host (mirroring the
     inference loader's ``get_device_map``), else empty so single-GPU, CPU and MLX loads
-    keep the loader default. ``planner_eligible = False`` for the CSM and Whisper
-    branches below, which pass a concrete ``auto_model`` the planner will not plan."""
+    keep the loader default."""
     if _IS_MLX:
         return {}
     try:
@@ -97,15 +96,15 @@ def _multi_gpu_device_map_kwargs(planner_eligible: bool = True) -> dict:
 
         visible = get_parent_visible_gpu_ids()
         if len(visible) > 1:
-            device_map = get_device_map(visible, planner_eligible = planner_eligible)
+            device_map = get_device_map(visible)
         elif not visible:
             # UUID/MIG masks resolve to no numeric ids; get_device_map(None) falls back to the visible count.
-            device_map = get_device_map(None, planner_eligible = planner_eligible)
+            device_map = get_device_map(None)
         else:
             return {}
-        # Both sharding answers `get_device_map` gives. A "balanced"-only whitelist
-        # dropped the map once CUDA began asking for "unsloth".
-        if device_map in ("balanced", "unsloth"):
+        # Every sharding answer `get_device_map` gives. A "balanced"-only whitelist
+        # dropped the map the moment CUDA began asking for a planned one.
+        if device_map in ("balanced", "unsloth", "unsloth_balanced"):
             return {"device_map": device_map}
     except Exception as exc:
         logger.debug(f"multi-GPU device_map resolution failed; using loader default: {exc}")
@@ -492,6 +491,13 @@ class ExportBackend:
             # Skip the Hub when offline so a no-internet export uses the local cache.
             local_files_only = _hf_offline()
 
+            # Shard across every visible GPU instead of stacking on GPU0 (#7053); {} on single-GPU/CPU/MLX.
+            _device_map_kw = (
+                _multi_gpu_device_map_kwargs()
+                if _device_map_override is None
+                else _device_map_override
+            )
+
             # Run the type-detection probes in the forced-offline window (else a gated
             # base 404s); it covers is_vision_model's Hub reads + the transformers-5
             # subprocess, and local_files_only makes detect_audio_type's requests.get skip.
@@ -502,18 +508,6 @@ class ExportBackend:
                 self.is_vision = not self._audio_type and is_vision_model(
                     model_id, hf_token = token, local_files_only = local_files_only
                 )
-
-            # Shard across every visible GPU instead of stacking on GPU0 (#7053); {} on
-            # single-GPU/CPU/MLX. After detection, not before: the CSM and Whisper
-            # branches pass a concrete auto_model the planner declines, and the map they
-            # get depends on which branch this is.
-            _device_map_kw = (
-                _multi_gpu_device_map_kwargs(
-                    planner_eligible = self._audio_type not in ("csm", "whisper"),
-                )
-                if _device_map_override is None
-                else _device_map_override
-            )
 
             if self._audio_type == "csm":
                 from unsloth import FastModel
@@ -663,9 +657,7 @@ class ExportBackend:
                     or _is_cpu_spill_rejection(e)
                     or _is_device_map_infeasible(e)
                 )
-                and _multi_gpu_device_map_kwargs(
-                    planner_eligible = self._audio_type not in ("csm", "whisper")
-                )
+                and _multi_gpu_device_map_kwargs()
             ):
                 # Retry outside this block: the live traceback pins the half-built model's
                 # frames, so an in-block retry inherits the exhausted device.

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -102,7 +102,7 @@ def _multi_gpu_device_map_kwargs() -> dict:
             device_map = get_device_map(None)
         else:
             return {}
-        # Every sharding answer `get_device_map` gives. A "balanced"-only whitelist
+        # Every sharding answer `get_device_map` gives; a "balanced"-only whitelist
         # dropped the map the moment CUDA began asking for a planned one.
         if device_map in ("balanced", "unsloth", "unsloth_balanced"):
             return {"device_map": device_map}
@@ -143,13 +143,12 @@ def _is_cpu_spill_rejection(exc: BaseException) -> bool:
 
 
 def _is_device_map_infeasible(exc: BaseException) -> bool:
-    """The ``"unsloth"`` planner declining to place the model, matched by class name.
+    """The planner refusing to place the model, matched by class name.
 
-    It raises rather than spilling a bitsandbytes model to CPU. That is right for a
-    load the user asked for and wrong here: it budgets from free memory read before
-    this process opens a context, so a training or chat job holding the other cards
-    can make it refuse a model the single-device loader still fits. By name, because
-    importing the class would tie the export to a version that defines it.
+    It raises rather than spilling a bitsandbytes model to CPU, budgeting from free
+    memory read before this process opens a context -- so a training or chat job
+    holding the other cards can make it refuse a model the single-device loader
+    still fits. By name, so the export does not require a version defining it.
     """
     return type(exc).__name__ == "DeviceMapInfeasible"
 
@@ -681,8 +680,8 @@ class ExportBackend:
             trust_remote_code = trust_remote_code,
             hf_token = hf_token,
             # Named, not omitted: an omitted map is unsloth's DEFAULT_DEVICE_MAP, which
-            # `requested_device_map` upgrades back to the planner, so the retry would
-            # re-run the placement that just failed. A typed "sequential" passes through.
+            # `requested_device_map` upgrades back to the planner, re-running the
+            # placement that just failed. A typed "sequential" passes through.
             _device_map_override = {"device_map": "sequential"},
         )
 

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -102,9 +102,8 @@ def _multi_gpu_device_map_kwargs() -> dict:
             device_map = get_device_map(None)
         else:
             return {}
-        # Both sharding answers `get_device_map` can give. A whitelist of just
-        # "balanced" silently dropped the map the moment CUDA started asking for
-        # "unsloth", leaving the export on the loader default.
+        # Both sharding answers `get_device_map` gives. A "balanced"-only whitelist
+        # dropped the map once CUDA began asking for "unsloth".
         if device_map in ("balanced", "unsloth"):
             return {"device_map": device_map}
     except Exception as exc:
@@ -144,14 +143,13 @@ def _is_cpu_spill_rejection(exc: BaseException) -> bool:
 
 
 def _is_device_map_infeasible(exc: BaseException) -> bool:
-    """The ``"unsloth"`` planner declining to place the model, by class name.
+    """The ``"unsloth"`` planner declining to place the model, matched by class name.
 
-    It raises rather than spilling a bitsandbytes model to CPU, which is the right
-    answer for a load the user asked for and the wrong one here: the planner budgets
-    from free memory read before this process opens a context, so a training or chat
-    job holding the other cards can make it refuse a model the single-device loader
-    still fits. Matched by name because the class lives in unsloth and importing it
-    would tie the export to a version that defines it.
+    It raises rather than spilling a bitsandbytes model to CPU. That is right for a
+    load the user asked for and wrong here: it budgets from free memory read before
+    this process opens a context, so a training or chat job holding the other cards
+    can make it refuse a model the single-device loader still fits. By name, because
+    importing the class would tie the export to a version that defines it.
     """
     return type(exc).__name__ == "DeviceMapInfeasible"
 
@@ -682,11 +680,9 @@ class ExportBackend:
             load_in_4bit = load_in_4bit,
             trust_remote_code = trust_remote_code,
             hf_token = hf_token,
-            # Spelled out, not omitted. An omitted device_map takes unsloth's
-            # DEFAULT_DEVICE_MAP, which `requested_device_map` upgrades back to the
-            # planner unless UNSLOTH_AUTO_DEVICE_MAP=0, so the retry would re-run the
-            # placement that just failed and report the same error. An explicitly typed
-            # "sequential" is a choice the caller made and passes through untouched.
+            # Named, not omitted: an omitted map is unsloth's DEFAULT_DEVICE_MAP, which
+            # `requested_device_map` upgrades back to the planner, so the retry would
+            # re-run the placement that just failed. A typed "sequential" passes through.
             _device_map_override = {"device_map": "sequential"},
         )
 

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -102,7 +102,10 @@ def _multi_gpu_device_map_kwargs() -> dict:
             device_map = get_device_map(None)
         else:
             return {}
-        if device_map == "balanced":
+        # Both sharding answers `get_device_map` can give. A whitelist of just
+        # "balanced" silently dropped the map the moment CUDA started asking for
+        # "unsloth", leaving the export on the loader default.
+        if device_map in ("balanced", "unsloth"):
             return {"device_map": device_map}
     except Exception as exc:
         logger.debug(f"multi-GPU device_map resolution failed; using loader default: {exc}")
@@ -138,6 +141,19 @@ def _is_cpu_spill_rejection(exc: BaseException) -> bool:
     match it explicitly. See transformers ``quantizers/quantizer_bnb_4bit.py``.
     """
     return "dispatched on the cpu or the disk" in str(exc).lower()
+
+
+def _is_device_map_infeasible(exc: BaseException) -> bool:
+    """The ``"unsloth"`` planner declining to place the model, by class name.
+
+    It raises rather than spilling a bitsandbytes model to CPU, which is the right
+    answer for a load the user asked for and the wrong one here: the planner budgets
+    from free memory read before this process opens a context, so a training or chat
+    job holding the other cards can make it refuse a model the single-device loader
+    still fits. Matched by name because the class lives in unsloth and importing it
+    would tie the export to a version that defines it.
+    """
+    return type(exc).__name__ == "DeviceMapInfeasible"
 
 
 class _CpuSpillRetry(Exception):
@@ -638,7 +654,10 @@ class ExportBackend:
             if (
                 _device_map_override is None
                 and (
-                    isinstance(e, _CpuSpillRetry) or _is_oom_error(e) or _is_cpu_spill_rejection(e)
+                    isinstance(e, _CpuSpillRetry)
+                    or _is_oom_error(e)
+                    or _is_cpu_spill_rejection(e)
+                    or _is_device_map_infeasible(e)
                 )
                 and _multi_gpu_device_map_kwargs()
             ):

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -673,7 +673,7 @@ class ExportBackend:
 
         logger.warning(
             f"Multi-GPU export load unusable ({retry_reason}); retrying on "
-            f"the single-device loader default."
+            f"the sequential loader default."
         )
         self.cleanup_memory()
         return self.load_checkpoint(
@@ -682,7 +682,12 @@ class ExportBackend:
             load_in_4bit = load_in_4bit,
             trust_remote_code = trust_remote_code,
             hf_token = hf_token,
-            _device_map_override = {},
+            # Spelled out, not omitted. An omitted device_map takes unsloth's
+            # DEFAULT_DEVICE_MAP, which `requested_device_map` upgrades back to the
+            # planner unless UNSLOTH_AUTO_DEVICE_MAP=0, so the retry would re-run the
+            # placement that just failed and report the same error. An explicitly typed
+            # "sequential" is a choice the caller made and passes through untouched.
+            _device_map_override = {"device_map": "sequential"},
         )
 
     def _write_export_metadata(self, save_directory: str):

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -81,14 +81,15 @@ _PYTORCH_MISSING_MESSAGE = (
 _LLAMA_CPP_SCRIPTS_WARNING_EMITTED = False
 
 
-def _multi_gpu_device_map_kwargs() -> dict:
+def _multi_gpu_device_map_kwargs(planner_eligible: bool = True) -> dict:
     """``device_map`` kwargs for sharding a checkpoint across every visible GPU.
 
     unsloth's ``from_pretrained`` defaults to ``device_map="sequential"``, which stacks
     the whole model on GPU0 and OOMs multi-GPU hosts whose other GPUs sit empty (#7053).
-    Returns ``{"device_map": "balanced"}`` only on a real multi-GPU CUDA/ROCm host
-    (mirroring the inference loader's ``get_device_map``), else empty so single-GPU, CPU
-    and MLX loads keep the loader default."""
+    Returns a sharding map only on a real multi-GPU CUDA/ROCm host (mirroring the
+    inference loader's ``get_device_map``), else empty so single-GPU, CPU and MLX loads
+    keep the loader default. ``planner_eligible = False`` for the CSM and Whisper
+    branches below, which pass a concrete ``auto_model`` the planner will not plan."""
     if _IS_MLX:
         return {}
     try:
@@ -96,10 +97,10 @@ def _multi_gpu_device_map_kwargs() -> dict:
 
         visible = get_parent_visible_gpu_ids()
         if len(visible) > 1:
-            device_map = get_device_map(visible)
+            device_map = get_device_map(visible, planner_eligible = planner_eligible)
         elif not visible:
             # UUID/MIG masks resolve to no numeric ids; get_device_map(None) falls back to the visible count.
-            device_map = get_device_map(None)
+            device_map = get_device_map(None, planner_eligible = planner_eligible)
         else:
             return {}
         # Both sharding answers `get_device_map` gives. A "balanced"-only whitelist
@@ -491,13 +492,6 @@ class ExportBackend:
             # Skip the Hub when offline so a no-internet export uses the local cache.
             local_files_only = _hf_offline()
 
-            # Shard across every visible GPU instead of stacking on GPU0 (#7053); {} on single-GPU/CPU/MLX.
-            _device_map_kw = (
-                _multi_gpu_device_map_kwargs()
-                if _device_map_override is None
-                else _device_map_override
-            )
-
             # Run the type-detection probes in the forced-offline window (else a gated
             # base 404s); it covers is_vision_model's Hub reads + the transformers-5
             # subprocess, and local_files_only makes detect_audio_type's requests.get skip.
@@ -508,6 +502,18 @@ class ExportBackend:
                 self.is_vision = not self._audio_type and is_vision_model(
                     model_id, hf_token = token, local_files_only = local_files_only
                 )
+
+            # Shard across every visible GPU instead of stacking on GPU0 (#7053); {} on
+            # single-GPU/CPU/MLX. After detection, not before: the CSM and Whisper
+            # branches pass a concrete auto_model the planner declines, and the map they
+            # get depends on which branch this is.
+            _device_map_kw = (
+                _multi_gpu_device_map_kwargs(
+                    planner_eligible = self._audio_type not in ("csm", "whisper"),
+                )
+                if _device_map_override is None
+                else _device_map_override
+            )
 
             if self._audio_type == "csm":
                 from unsloth import FastModel
@@ -657,7 +663,7 @@ class ExportBackend:
                     or _is_cpu_spill_rejection(e)
                     or _is_device_map_infeasible(e)
                 )
-                and _multi_gpu_device_map_kwargs()
+                and _multi_gpu_device_map_kwargs(planner_eligible = self._audio_type not in ("csm", "whisper"))
             ):
                 # Retry outside this block: the live traceback pins the half-built model's
                 # frames, so an in-block retry inherits the exhausted device.

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -663,7 +663,9 @@ class ExportBackend:
                     or _is_cpu_spill_rejection(e)
                     or _is_device_map_infeasible(e)
                 )
-                and _multi_gpu_device_map_kwargs(planner_eligible = self._audio_type not in ("csm", "whisper"))
+                and _multi_gpu_device_map_kwargs(
+                    planner_eligible = self._audio_type not in ("csm", "whisper")
+                )
             ):
                 # Retry outside this block: the live traceback pins the half-built model's
                 # frames, so an in-block retry inherits the exhausted device.

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -363,9 +363,8 @@ class InferenceBackend:
                 return False
 
             self.loading_models.add(model_name)
-            # CSM and Whisper load through an explicit auto_model with no _model_mapping,
-            # which unsloth's planner declines; its "sequential" fallback fills cuda:0
-            # before touching the other cards, so those two keep "balanced".
+            # CSM and Whisper pass an explicit auto_model with no _model_mapping, which
+            # the planner declines; its "sequential" fallback fills cuda:0 first.
             device_map = get_device_map(
                 gpu_ids,
                 planner_eligible = not (config.is_audio and config.audio_type in ("csm", "whisper")),

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -363,12 +363,7 @@ class InferenceBackend:
                 return False
 
             self.loading_models.add(model_name)
-            # CSM and Whisper pass an explicit auto_model with no _model_mapping, which
-            # the planner declines; its "sequential" fallback fills cuda:0 first.
-            device_map = get_device_map(
-                gpu_ids,
-                planner_eligible = not (config.is_audio and config.audio_type in ("csm", "whisper")),
-            )
+            device_map = get_device_map(gpu_ids)
             logger.info(
                 f"Using device_map='{device_map}' ({get_visible_gpu_count()} GPU(s) visible)"
             )

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -363,7 +363,13 @@ class InferenceBackend:
                 return False
 
             self.loading_models.add(model_name)
-            device_map = get_device_map(gpu_ids)
+            # CSM and Whisper load through an explicit auto_model with no _model_mapping,
+            # which unsloth's planner declines; its "sequential" fallback fills cuda:0
+            # before touching the other cards, so those two keep "balanced".
+            device_map = get_device_map(
+                gpu_ids,
+                planner_eligible = not (config.is_audio and config.audio_type in ("csm", "whisper")),
+            )
             logger.info(
                 f"Using device_map='{device_map}' ({get_visible_gpu_count()} GPU(s) visible)"
             )

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -982,9 +982,8 @@ class UnslothTrainer:
                         self._update_progress(error = friendly, is_training = False)
                         return False
 
-            # A full finetune, and the two audio routes that pass an explicit auto_model,
-            # are ones unsloth's planner declines; its "sequential" fallback fills cuda:0
-            # first, which is the wrong shape for a training run. They keep "balanced".
+            # The planner declines a full finetune and an explicit auto_model, and its
+            # "sequential" fallback fills cuda:0 first: wrong shape for a training run.
             device_map = get_device_map(
                 gpu_ids,
                 planner_eligible = not full_finetuning and self._audio_type not in ("csm", "whisper"),

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3479,9 +3479,9 @@ class UnslothTrainer:
                 # kills the feature. Env-only, deliberately NOT worker.py's
                 # _data_parallel_world_size, which also counts visible CUDA devices:
                 # that bounds a row subset where over-counting is free, this feeds a
-                # veto where both directions are wrong. Unsloth's multi-GPU load is
-                # device_map="balanced", model-parallel to transformers with _n_gpu = 1,
-                # so a balanced 4-GPU run draws one GPU's rows per step and counting
+                # veto where both directions are wrong. Unsloth's multi-GPU load is a
+                # sharding device_map, model-parallel to transformers with _n_gpu = 1,
+                # so a sharded 4-GPU run draws one GPU's rows per step and counting
                 # devices would report 4x the passes, vetoing a qualifying run.
                 world_size = world_size_from_env()
                 if world_size > 1:

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -982,7 +982,13 @@ class UnslothTrainer:
                         self._update_progress(error = friendly, is_training = False)
                         return False
 
-            device_map = get_device_map(gpu_ids)
+            # A full finetune, and the two audio routes that pass an explicit auto_model,
+            # are ones unsloth's planner declines; its "sequential" fallback fills cuda:0
+            # first, which is the wrong shape for a training run. They keep "balanced".
+            device_map = get_device_map(
+                gpu_ids,
+                planner_eligible = not full_finetuning and self._audio_type not in ("csm", "whisper"),
+            )
             logger.info(
                 f"Using device_map='{device_map}' ({get_visible_gpu_count()} GPU(s) visible)"
             )

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -982,12 +982,7 @@ class UnslothTrainer:
                         self._update_progress(error = friendly, is_training = False)
                         return False
 
-            # The planner declines a full finetune and an explicit auto_model, and its
-            # "sequential" fallback fills cuda:0 first: wrong shape for a training run.
-            device_map = get_device_map(
-                gpu_ids,
-                planner_eligible = not full_finetuning and self._audio_type not in ("csm", "whisper"),
-            )
+            device_map = get_device_map(gpu_ids)
             logger.info(
                 f"Using device_map='{device_map}' ({get_visible_gpu_count()} GPU(s) visible)"
             )
@@ -1783,7 +1778,7 @@ class UnslothTrainer:
 
         result_dataset = Dataset.from_list(processed_examples)
         logger.info(
-            f"CSM preprocessing complete: {len(result_dataset)} examples " f"({skipped} skipped)\n"
+            f"CSM preprocessing complete: {len(result_dataset)} examples ({skipped} skipped)\n"
         )
         return result_dataset
 
@@ -2034,7 +2029,7 @@ class UnslothTrainer:
 
         result_dataset = Dataset.from_list(processed_examples)
         logger.info(
-            f"SNAC preprocessing complete: {len(result_dataset)} examples " f"({skipped} skipped)\n"
+            f"SNAC preprocessing complete: {len(result_dataset)} examples ({skipped} skipped)\n"
         )
         return result_dataset
 
@@ -2225,8 +2220,7 @@ class UnslothTrainer:
 
         result_dataset = Dataset.from_list(processed_examples)
         logger.info(
-            f"BiCodec preprocessing complete: {len(result_dataset)} examples "
-            f"({skipped} skipped)\n"
+            f"BiCodec preprocessing complete: {len(result_dataset)} examples ({skipped} skipped)\n"
         )
         sample = result_dataset[0]["text"]
         logger.info(f"Sample text (first 200 chars): {sample[:200]}...\n")
@@ -2418,7 +2412,7 @@ class UnslothTrainer:
 
         result_dataset = HFDataset.from_list(processed_examples)
         logger.info(
-            f"DAC preprocessing complete: {len(result_dataset)} examples " f"({skipped} skipped)\n"
+            f"DAC preprocessing complete: {len(result_dataset)} examples ({skipped} skipped)\n"
         )
         sample = result_dataset[0]["text"]
         logger.info(f"Sample text (first 200 chars): {sample[:200]}...\n")
@@ -2792,8 +2786,7 @@ class UnslothTrainer:
                                 self.dataset_snapshot_path
                             )
                             logger.info(
-                                f"Loaded cached dataset for {dataset_source}: "
-                                f"{len(dataset)} rows\n"
+                                f"Loaded cached dataset for {dataset_source}: {len(dataset)} rows\n"
                             )
                         except Exception as error:
                             from hub.utils.dataset_cache import (
@@ -2808,8 +2801,7 @@ class UnslothTrainer:
                                 raise
                             self._update_progress(
                                 status_message = (
-                                    f"Cached dataset unavailable; "
-                                    f"downloading {dataset_source}..."
+                                    f"Cached dataset unavailable; downloading {dataset_source}..."
                                 )
                             )
                             dataset = None

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -92,8 +92,8 @@ def _data_parallel_world_size() -> int:
     extra rank does. XPU and MPS stay at one device there, so only CUDA counts.
 
     The larger of the two, never the sum: a distributed run forces n_gpu to 1, and a
-    model-parallel one (device_map="balanced", which is what Unsloth's own multi-GPU
-    load uses) forces it to 1 as well. Rounding up when the model turns out to be
+    model-parallel one (a sharding device_map, which is what Unsloth's own multi-GPU
+    load uses: "unsloth" on CUDA, "balanced" elsewhere) forces it to 1 as well. Rounding up when the model turns out to be
     sharded rather than replicated only tokenizes a larger subset of a corpus this
     bound is orders of magnitude below anyway; rounding down means the run silently
     re-reads rows it has already trained on.

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -93,7 +93,7 @@ def _data_parallel_world_size() -> int:
 
     The larger of the two, never the sum: a distributed run forces n_gpu to 1, and a
     model-parallel one (a sharding device_map, which is what Unsloth's own multi-GPU
-    load uses: "unsloth" on CUDA, "balanced" elsewhere) forces it to 1 as well. Rounding up when the model turns out to be
+    load uses) forces it to 1 as well. Rounding up when the model turns out to be
     sharded rather than replicated only tokenizes a larger subset of a corpus this
     bound is orders of magnitude below anyway; rounding down means the run silently
     re-reads rows it has already trained on.

--- a/studio/backend/tests/test_export_multi_gpu_device_map.py
+++ b/studio/backend/tests/test_export_multi_gpu_device_map.py
@@ -408,7 +408,9 @@ def test_the_retry_names_sequential_rather_than_omitting_the_device_map(monkeypa
             # Stands in for the planner: it refuses whenever it is the one asked to place.
             if kwargs.get("device_map") in ("unsloth", None) or "device_map" not in kwargs:
                 raise DeviceMapInfeasible("needs 7.57 GiB free on cuda:0, has 4.10 GiB")
-            return types.SimpleNamespace(hf_device_map = {"model.layers.0": 0}), types.SimpleNamespace()
+            return types.SimpleNamespace(
+                hf_device_map = {"model.layers.0": 0}
+            ), types.SimpleNamespace()
 
     monkeypatch.setattr(mod, "FastLanguageModel", _RefusesAnyPlan)
     monkeypatch.setattr(mod, "detect_audio_type", lambda *a, **k: None)

--- a/studio/backend/tests/test_export_multi_gpu_device_map.py
+++ b/studio/backend/tests/test_export_multi_gpu_device_map.py
@@ -144,7 +144,9 @@ def _load_text_checkpoint(monkeypatch, tmp_path, device_map_kwargs):
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: device_map_kwargs)
+    monkeypatch.setattr(
+        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: device_map_kwargs
+    )
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -252,7 +254,9 @@ def _run_spill_loader(monkeypatch, tmp_path, device_map_kwargs):
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: device_map_kwargs)
+    monkeypatch.setattr(
+        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: device_map_kwargs
+    )
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -297,7 +301,11 @@ def test_retry_result_is_kept_even_if_it_also_offloads(monkeypatch, tmp_path):
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "balanced"})
+    monkeypatch.setattr(
+        mod,
+        "_multi_gpu_device_map_kwargs",
+        lambda planner_eligible = True: {"device_map": "balanced"},
+    )
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -347,7 +355,9 @@ def test_planner_refusal_retries_on_the_single_device_loader(monkeypatch, tmp_pa
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"})
+    monkeypatch.setattr(
+        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"}
+    )
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -379,7 +389,9 @@ def test_an_unrelated_error_is_still_reported_rather_than_retried(monkeypatch, t
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"})
+    monkeypatch.setattr(
+        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"}
+    )
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -423,7 +435,9 @@ def test_the_retry_names_sequential_rather_than_omitting_the_device_map(monkeypa
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"})
+    monkeypatch.setattr(
+        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"}
+    )
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()

--- a/studio/backend/tests/test_export_multi_gpu_device_map.py
+++ b/studio/backend/tests/test_export_multi_gpu_device_map.py
@@ -262,7 +262,9 @@ def test_successful_load_that_offloads_to_cpu_retries_single_device(monkeypatch,
     assert ok, message
     assert len(calls) == 2
     assert calls[0]["device_map"] == "balanced"
-    assert "device_map" not in calls[1]
+    # Named, not omitted: an omitted map is unsloth's marked default, which is upgraded
+    # back to the planner rather than being the single-device load this retry wants.
+    assert calls[1]["device_map"] == "sequential"
 
 
 def test_single_gpu_offload_is_left_alone(monkeypatch, tmp_path):
@@ -350,7 +352,7 @@ def test_planner_refusal_retries_on_the_single_device_loader(monkeypatch, tmp_pa
     assert ok, message
     assert len(_RefusesThenLoads.calls) == 2
     assert _RefusesThenLoads.calls[0]["device_map"] == "unsloth"
-    assert "device_map" not in _RefusesThenLoads.calls[1]
+    assert _RefusesThenLoads.calls[1]["device_map"] == "sequential"
 
 
 def test_an_unrelated_error_is_still_reported_rather_than_retried(monkeypatch, tmp_path):
@@ -382,3 +384,46 @@ def test_an_unrelated_error_is_still_reported_rather_than_retried(monkeypatch, t
     assert not ok
     assert len(_AlwaysBroken.calls) == 1
     assert "not valid JSON" in message
+
+
+def test_the_retry_names_sequential_rather_than_omitting_the_device_map(monkeypatch, tmp_path):
+    """An omitted device_map is not the loader default any more.
+
+    unsloth's signature default is `DEFAULT_DEVICE_MAP`, a marked "sequential" that
+    `requested_device_map` upgrades back to the planner unless UNSLOTH_AUTO_DEVICE_MAP=0.
+    So `_device_map_override = {}` would re-run the very placement that just failed and
+    report the same error, and the retry would look like a fallback while being none.
+    """
+    mod = _export_mod(monkeypatch)
+
+    class DeviceMapInfeasible(RuntimeError):
+        pass
+
+    class _RefusesAnyPlan:
+        calls: list[dict] = []
+
+        @classmethod
+        def from_pretrained(cls, **kwargs):
+            cls.calls.append(kwargs)
+            # Stands in for the planner: it refuses whenever it is the one asked to place.
+            if kwargs.get("device_map") in ("unsloth", None) or "device_map" not in kwargs:
+                raise DeviceMapInfeasible("needs 7.57 GiB free on cuda:0, has 4.10 GiB")
+            return types.SimpleNamespace(hf_device_map = {"model.layers.0": 0}), types.SimpleNamespace()
+
+    monkeypatch.setattr(mod, "FastLanguageModel", _RefusesAnyPlan)
+    monkeypatch.setattr(mod, "detect_audio_type", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
+    monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
+    monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "unsloth"})
+
+    checkpoint = tmp_path / "checkpoint-100"
+    checkpoint.mkdir()
+    backend = mod.ExportBackend.__new__(mod.ExportBackend)
+    backend.cleanup_memory = lambda: None
+    ok, message = backend.load_checkpoint(str(checkpoint))
+
+    assert ok, message
+    assert len(_RefusesAnyPlan.calls) == 2
+    assert _RefusesAnyPlan.calls[0]["device_map"] == "unsloth"
+    assert _RefusesAnyPlan.calls[1]["device_map"] == "sequential"

--- a/studio/backend/tests/test_export_multi_gpu_device_map.py
+++ b/studio/backend/tests/test_export_multi_gpu_device_map.py
@@ -330,7 +330,9 @@ def test_planner_refusal_retries_on_the_single_device_loader(monkeypatch, tmp_pa
             cls.calls.append(kwargs)
             if len(cls.calls) == 1:
                 raise DeviceMapInfeasible("2 x 8 GiB is not enough for the head")
-            return types.SimpleNamespace(hf_device_map = {"model.layers.0": 0}), types.SimpleNamespace()
+            return types.SimpleNamespace(
+                hf_device_map = {"model.layers.0": 0}
+            ), types.SimpleNamespace()
 
     monkeypatch.setattr(mod, "FastLanguageModel", _RefusesThenLoads)
     monkeypatch.setattr(mod, "detect_audio_type", lambda *a, **k: None)

--- a/studio/backend/tests/test_export_multi_gpu_device_map.py
+++ b/studio/backend/tests/test_export_multi_gpu_device_map.py
@@ -36,7 +36,11 @@ def _export_mod(monkeypatch):
 def _stub_hardware(monkeypatch, visible, device_map):
     hw = sys.modules["utils.hardware"]
     monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: visible, raising = False)
-    monkeypatch.setattr(hw, "get_device_map", lambda ids: device_map, raising = False)
+    # Keyword-accepting, like the real one: a stub that only takes the positional would
+    # raise TypeError into the helper's `except Exception` and read as "no multi-GPU host".
+    monkeypatch.setattr(
+        hw, "get_device_map", lambda ids, planner_eligible = True: device_map, raising = False
+    )
 
 
 # ── _multi_gpu_device_map_kwargs ──
@@ -83,7 +87,7 @@ def test_uuid_mig_mask_falls_back_to_count_detection(monkeypatch):
     monkeypatch.setattr(
         hw,
         "get_device_map",
-        lambda ids: "balanced" if ids is None else "sequential",
+        lambda ids, planner_eligible = True: "balanced" if ids is None else "sequential",
         raising = False,
     )
     assert mod._multi_gpu_device_map_kwargs() == {"device_map": "balanced"}
@@ -95,7 +99,9 @@ def test_no_visible_gpus_keeps_loader_default(monkeypatch):
     monkeypatch.setattr(mod, "_IS_MLX", False)
     hw = sys.modules["utils.hardware"]
     monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: [], raising = False)
-    monkeypatch.setattr(hw, "get_device_map", lambda ids: "sequential", raising = False)
+    monkeypatch.setattr(
+        hw, "get_device_map", lambda ids, planner_eligible = True: "sequential", raising = False
+    )
     assert mod._multi_gpu_device_map_kwargs() == {}
 
 
@@ -138,7 +144,7 @@ def _load_text_checkpoint(monkeypatch, tmp_path, device_map_kwargs):
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: device_map_kwargs)
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: device_map_kwargs)
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -195,7 +201,7 @@ def test_load_checkpoint_repairs_legacy_cache_identity_without_rewriting_adapter
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: {})
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {})
 
     backend = mod.ExportBackend.__new__(mod.ExportBackend)
     backend.cleanup_memory = lambda: None
@@ -246,7 +252,7 @@ def _run_spill_loader(monkeypatch, tmp_path, device_map_kwargs):
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: device_map_kwargs)
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: device_map_kwargs)
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -291,7 +297,7 @@ def test_retry_result_is_kept_even_if_it_also_offloads(monkeypatch, tmp_path):
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "balanced"})
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "balanced"})
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -341,7 +347,7 @@ def test_planner_refusal_retries_on_the_single_device_loader(monkeypatch, tmp_pa
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "unsloth"})
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"})
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -373,7 +379,7 @@ def test_an_unrelated_error_is_still_reported_rather_than_retried(monkeypatch, t
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "unsloth"})
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"})
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -417,7 +423,7 @@ def test_the_retry_names_sequential_rather_than_omitting_the_device_map(monkeypa
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "unsloth"})
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"})
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -429,3 +435,53 @@ def test_the_retry_names_sequential_rather_than_omitting_the_device_map(monkeypa
     assert len(_RefusesAnyPlan.calls) == 2
     assert _RefusesAnyPlan.calls[0]["device_map"] == "unsloth"
     assert _RefusesAnyPlan.calls[1]["device_map"] == "sequential"
+
+
+# ── the audio export routes, which the planner will not plan ──
+
+
+def test_an_audio_export_keeps_balanced_and_a_text_export_gets_the_planner(monkeypatch):
+    """`load_checkpoint`'s CSM and Whisper branches pass a concrete `auto_model`, so the
+    planner declines and falls back to filling cuda:0. They need the sharding map they
+    had. The flag is what selects it, so both directions are asserted."""
+    mod = _export_mod(monkeypatch)
+    monkeypatch.setattr(mod, "_IS_MLX", False)
+    hw = sys.modules["utils.hardware"]
+    monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: [0, 1], raising = False)
+    monkeypatch.setattr(
+        hw,
+        "get_device_map",
+        lambda ids, planner_eligible = True: "unsloth" if planner_eligible else "balanced",
+        raising = False,
+    )
+    assert mod._multi_gpu_device_map_kwargs() == {"device_map": "unsloth"}
+    assert mod._multi_gpu_device_map_kwargs(planner_eligible = False) == {"device_map": "balanced"}
+
+
+def test_the_map_is_resolved_after_the_audio_type_is_known(monkeypatch, tmp_path):
+    """Ordering, not just the argument: the map used to be built before
+    `detect_audio_type` ran, so the audio branches could not have influenced it however
+    the flag was wired."""
+    mod = _export_mod(monkeypatch)
+    seen = []
+
+    def _kwargs(planner_eligible = True):
+        seen.append(planner_eligible)
+        return {"device_map": "balanced" if not planner_eligible else "unsloth"}
+
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", _kwargs)
+    monkeypatch.setattr(mod, "detect_audio_type", lambda *a, **k: "whisper")
+    monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
+    monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
+    monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
+
+    checkpoint = tmp_path / "checkpoint-100"
+    checkpoint.mkdir()
+    backend = mod.ExportBackend.__new__(mod.ExportBackend)
+    backend.cleanup_memory = lambda: None
+    # The whisper branch imports FastModel locally and will fail on these stubs; the load
+    # itself is not what this asserts. What matters is that by the time the map was
+    # resolved, the audio type was already known.
+    backend.load_checkpoint(str(checkpoint))
+
+    assert seen == [False], f"expected one ineligible resolution, got {seen}"

--- a/studio/backend/tests/test_export_multi_gpu_device_map.py
+++ b/studio/backend/tests/test_export_multi_gpu_device_map.py
@@ -36,11 +36,7 @@ def _export_mod(monkeypatch):
 def _stub_hardware(monkeypatch, visible, device_map):
     hw = sys.modules["utils.hardware"]
     monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: visible, raising = False)
-    # Keyword-accepting, like the real one: a stub that only takes the positional would
-    # raise TypeError into the helper's `except Exception` and read as "no multi-GPU host".
-    monkeypatch.setattr(
-        hw, "get_device_map", lambda ids, planner_eligible = True: device_map, raising = False
-    )
+    monkeypatch.setattr(hw, "get_device_map", lambda ids: device_map, raising = False)
 
 
 # ── _multi_gpu_device_map_kwargs ──
@@ -59,8 +55,8 @@ def test_multi_gpu_cuda_host_passes_the_unsloth_planner_through(monkeypatch):
     single-GPU stacking this file exists to prevent."""
     mod = _export_mod(monkeypatch)
     monkeypatch.setattr(mod, "_IS_MLX", False)
-    _stub_hardware(monkeypatch, [0, 1, 2], "unsloth")
-    assert mod._multi_gpu_device_map_kwargs() == {"device_map": "unsloth"}
+    _stub_hardware(monkeypatch, [0, 1, 2], "unsloth_balanced")
+    assert mod._multi_gpu_device_map_kwargs() == {"device_map": "unsloth_balanced"}
 
 
 def test_single_gpu_host_keeps_loader_default(monkeypatch):
@@ -87,7 +83,7 @@ def test_uuid_mig_mask_falls_back_to_count_detection(monkeypatch):
     monkeypatch.setattr(
         hw,
         "get_device_map",
-        lambda ids, planner_eligible = True: "balanced" if ids is None else "sequential",
+        lambda ids: "balanced" if ids is None else "sequential",
         raising = False,
     )
     assert mod._multi_gpu_device_map_kwargs() == {"device_map": "balanced"}
@@ -99,9 +95,7 @@ def test_no_visible_gpus_keeps_loader_default(monkeypatch):
     monkeypatch.setattr(mod, "_IS_MLX", False)
     hw = sys.modules["utils.hardware"]
     monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: [], raising = False)
-    monkeypatch.setattr(
-        hw, "get_device_map", lambda ids, planner_eligible = True: "sequential", raising = False
-    )
+    monkeypatch.setattr(hw, "get_device_map", lambda ids: "sequential", raising = False)
     assert mod._multi_gpu_device_map_kwargs() == {}
 
 
@@ -144,9 +138,7 @@ def _load_text_checkpoint(monkeypatch, tmp_path, device_map_kwargs):
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(
-        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: device_map_kwargs
-    )
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: device_map_kwargs)
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -203,7 +195,7 @@ def test_load_checkpoint_repairs_legacy_cache_identity_without_rewriting_adapter
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {})
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: {})
 
     backend = mod.ExportBackend.__new__(mod.ExportBackend)
     backend.cleanup_memory = lambda: None
@@ -254,9 +246,7 @@ def _run_spill_loader(monkeypatch, tmp_path, device_map_kwargs):
     monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-    monkeypatch.setattr(
-        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: device_map_kwargs
-    )
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: device_map_kwargs)
 
     checkpoint = tmp_path / "checkpoint-100"
     checkpoint.mkdir()
@@ -304,7 +294,7 @@ def test_retry_result_is_kept_even_if_it_also_offloads(monkeypatch, tmp_path):
     monkeypatch.setattr(
         mod,
         "_multi_gpu_device_map_kwargs",
-        lambda planner_eligible = True: {"device_map": "balanced"},
+        lambda: {"device_map": "balanced"},
     )
 
     checkpoint = tmp_path / "checkpoint-100"
@@ -356,7 +346,7 @@ def test_planner_refusal_retries_on_the_single_device_loader(monkeypatch, tmp_pa
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
     monkeypatch.setattr(
-        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"}
+        mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "unsloth_balanced"}
     )
 
     checkpoint = tmp_path / "checkpoint-100"
@@ -367,7 +357,7 @@ def test_planner_refusal_retries_on_the_single_device_loader(monkeypatch, tmp_pa
 
     assert ok, message
     assert len(_RefusesThenLoads.calls) == 2
-    assert _RefusesThenLoads.calls[0]["device_map"] == "unsloth"
+    assert _RefusesThenLoads.calls[0]["device_map"] == "unsloth_balanced"
     assert _RefusesThenLoads.calls[1]["device_map"] == "sequential"
 
 
@@ -390,7 +380,7 @@ def test_an_unrelated_error_is_still_reported_rather_than_retried(monkeypatch, t
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
     monkeypatch.setattr(
-        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"}
+        mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "unsloth_balanced"}
     )
 
     checkpoint = tmp_path / "checkpoint-100"
@@ -424,7 +414,10 @@ def test_the_retry_names_sequential_rather_than_omitting_the_device_map(monkeypa
         def from_pretrained(cls, **kwargs):
             cls.calls.append(kwargs)
             # Stands in for the planner: it refuses whenever it is the one asked to place.
-            if kwargs.get("device_map") in ("unsloth", None) or "device_map" not in kwargs:
+            if (
+                kwargs.get("device_map") in ("unsloth", "unsloth_balanced", None)
+                or "device_map" not in kwargs
+            ):
                 raise DeviceMapInfeasible("needs 7.57 GiB free on cuda:0, has 4.10 GiB")
             return types.SimpleNamespace(
                 hf_device_map = {"model.layers.0": 0}
@@ -436,7 +429,7 @@ def test_the_retry_names_sequential_rather_than_omitting_the_device_map(monkeypa
     monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
     monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
     monkeypatch.setattr(
-        mod, "_multi_gpu_device_map_kwargs", lambda planner_eligible = True: {"device_map": "unsloth"}
+        mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "unsloth_balanced"}
     )
 
     checkpoint = tmp_path / "checkpoint-100"
@@ -447,55 +440,5 @@ def test_the_retry_names_sequential_rather_than_omitting_the_device_map(monkeypa
 
     assert ok, message
     assert len(_RefusesAnyPlan.calls) == 2
-    assert _RefusesAnyPlan.calls[0]["device_map"] == "unsloth"
+    assert _RefusesAnyPlan.calls[0]["device_map"] == "unsloth_balanced"
     assert _RefusesAnyPlan.calls[1]["device_map"] == "sequential"
-
-
-# ── the audio export routes, which the planner will not plan ──
-
-
-def test_an_audio_export_keeps_balanced_and_a_text_export_gets_the_planner(monkeypatch):
-    """`load_checkpoint`'s CSM and Whisper branches pass a concrete `auto_model`, so the
-    planner declines and falls back to filling cuda:0. They need the sharding map they
-    had. The flag is what selects it, so both directions are asserted."""
-    mod = _export_mod(monkeypatch)
-    monkeypatch.setattr(mod, "_IS_MLX", False)
-    hw = sys.modules["utils.hardware"]
-    monkeypatch.setattr(hw, "get_parent_visible_gpu_ids", lambda: [0, 1], raising = False)
-    monkeypatch.setattr(
-        hw,
-        "get_device_map",
-        lambda ids, planner_eligible = True: "unsloth" if planner_eligible else "balanced",
-        raising = False,
-    )
-    assert mod._multi_gpu_device_map_kwargs() == {"device_map": "unsloth"}
-    assert mod._multi_gpu_device_map_kwargs(planner_eligible = False) == {"device_map": "balanced"}
-
-
-def test_the_map_is_resolved_after_the_audio_type_is_known(monkeypatch, tmp_path):
-    """Ordering, not just the argument: the map used to be built before
-    `detect_audio_type` ran, so the audio branches could not have influenced it however
-    the flag was wired."""
-    mod = _export_mod(monkeypatch)
-    seen = []
-
-    def _kwargs(planner_eligible = True):
-        seen.append(planner_eligible)
-        return {"device_map": "balanced" if not planner_eligible else "unsloth"}
-
-    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", _kwargs)
-    monkeypatch.setattr(mod, "detect_audio_type", lambda *a, **k: "whisper")
-    monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
-    monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
-    monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
-
-    checkpoint = tmp_path / "checkpoint-100"
-    checkpoint.mkdir()
-    backend = mod.ExportBackend.__new__(mod.ExportBackend)
-    backend.cleanup_memory = lambda: None
-    # The whisper branch imports FastModel locally and will fail on these stubs; the load
-    # itself is not what this asserts. What matters is that by the time the map was
-    # resolved, the audio type was already known.
-    backend.load_checkpoint(str(checkpoint))
-
-    assert seen == [False], f"expected one ineligible resolution, got {seen}"

--- a/studio/backend/tests/test_export_multi_gpu_device_map.py
+++ b/studio/backend/tests/test_export_multi_gpu_device_map.py
@@ -3,8 +3,9 @@
 
 """Export checkpoint loading must shard across every visible GPU (#7053): the
 ``device_map="sequential"`` loader default stacks the whole model on GPU0 and OOMs
-while the other GPUs sit empty. The loader now passes ``device_map="balanced"``, but
-only on a real multi-GPU CUDA/ROCm host, so single-GPU, CPU and MLX are untouched."""
+while the other GPUs sit empty. The loader now passes whichever sharding map
+``get_device_map`` resolves (``"unsloth"`` on CUDA, ``"balanced"`` elsewhere), but only
+on a real multi-GPU host, so single-GPU, CPU and MLX are untouched."""
 
 from __future__ import annotations
 
@@ -46,6 +47,16 @@ def test_multi_gpu_host_gets_balanced(monkeypatch):
     monkeypatch.setattr(mod, "_IS_MLX", False)
     _stub_hardware(monkeypatch, [0, 1, 2], "balanced")
     assert mod._multi_gpu_device_map_kwargs() == {"device_map": "balanced"}
+
+
+def test_multi_gpu_cuda_host_passes_the_unsloth_planner_through(monkeypatch):
+    """CUDA multi-GPU now resolves to "unsloth". A whitelist of just "balanced"
+    dropped the map and left the export on the loader default, which is the
+    single-GPU stacking this file exists to prevent."""
+    mod = _export_mod(monkeypatch)
+    monkeypatch.setattr(mod, "_IS_MLX", False)
+    _stub_hardware(monkeypatch, [0, 1, 2], "unsloth")
+    assert mod._multi_gpu_device_map_kwargs() == {"device_map": "unsloth"}
 
 
 def test_single_gpu_host_keeps_loader_default(monkeypatch):
@@ -287,3 +298,85 @@ def test_retry_result_is_kept_even_if_it_also_offloads(monkeypatch, tmp_path):
     ok, message = backend.load_checkpoint(str(checkpoint))
     assert ok, message
     assert len(_AlwaysSpills.calls) == 2
+
+
+# ── the "unsloth" planner refusing to place the model ──
+
+
+def test_is_device_map_infeasible_matches_by_class_name(monkeypatch):
+    mod = _export_mod(monkeypatch)
+
+    class DeviceMapInfeasible(RuntimeError):
+        pass
+
+    assert mod._is_device_map_infeasible(DeviceMapInfeasible("needs 7.5 GiB free on cuda:0"))
+    assert not mod._is_device_map_infeasible(RuntimeError("needs 7.5 GiB free on cuda:0"))
+
+
+def test_planner_refusal_retries_on_the_single_device_loader(monkeypatch, tmp_path):
+    """The planner budgets from memory read before this process opens a context, so a
+    training or chat job holding the other cards can make it refuse a model the old
+    single-device load still fits. That was a working export before the switch."""
+    mod = _export_mod(monkeypatch)
+
+    class DeviceMapInfeasible(RuntimeError):
+        pass
+
+    class _RefusesThenLoads:
+        calls: list[dict] = []
+
+        @classmethod
+        def from_pretrained(cls, **kwargs):
+            cls.calls.append(kwargs)
+            if len(cls.calls) == 1:
+                raise DeviceMapInfeasible("2 x 8 GiB is not enough for the head")
+            return types.SimpleNamespace(hf_device_map = {"model.layers.0": 0}), types.SimpleNamespace()
+
+    monkeypatch.setattr(mod, "FastLanguageModel", _RefusesThenLoads)
+    monkeypatch.setattr(mod, "detect_audio_type", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
+    monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
+    monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "unsloth"})
+
+    checkpoint = tmp_path / "checkpoint-100"
+    checkpoint.mkdir()
+    backend = mod.ExportBackend.__new__(mod.ExportBackend)
+    backend.cleanup_memory = lambda: None
+    ok, message = backend.load_checkpoint(str(checkpoint))
+
+    assert ok, message
+    assert len(_RefusesThenLoads.calls) == 2
+    assert _RefusesThenLoads.calls[0]["device_map"] == "unsloth"
+    assert "device_map" not in _RefusesThenLoads.calls[1]
+
+
+def test_an_unrelated_error_is_still_reported_rather_than_retried(monkeypatch, tmp_path):
+    # The retry is for placement, not for every failure: a broken checkpoint must not
+    # be loaded twice and reported against the second attempt.
+    mod = _export_mod(monkeypatch)
+
+    class _AlwaysBroken:
+        calls: list[dict] = []
+
+        @classmethod
+        def from_pretrained(cls, **kwargs):
+            cls.calls.append(kwargs)
+            raise ValueError("adapter_config.json is not valid JSON")
+
+    monkeypatch.setattr(mod, "FastLanguageModel", _AlwaysBroken)
+    monkeypatch.setattr(mod, "detect_audio_type", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "is_vision_model", lambda *a, **k: False)
+    monkeypatch.setattr(mod, "_hf_offline", lambda *a, **k: False)
+    monkeypatch.setattr(mod, "_offline_window_if", lambda flag: contextlib.nullcontext())
+    monkeypatch.setattr(mod, "_multi_gpu_device_map_kwargs", lambda: {"device_map": "unsloth"})
+
+    checkpoint = tmp_path / "checkpoint-100"
+    checkpoint.mkdir()
+    backend = mod.ExportBackend.__new__(mod.ExportBackend)
+    backend.cleanup_memory = lambda: None
+    ok, message = backend.load_checkpoint(str(checkpoint))
+
+    assert not ok
+    assert len(_AlwaysBroken.calls) == 1
+    assert "not valid JSON" in message

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -2313,15 +2313,13 @@ class TestEstimateFp16ModelSizeBytesPrefersLocalWeights(unittest.TestCase):
 class TestDeviceMapAcrossPlatformsAndAccelerators(_GpuCacheResetMixin, unittest.TestCase):
     """The full [Windows, Linux, WSL, Mac] x [NVIDIA, AMD, Intel, Apple, CPU] product.
 
-    Two claims, and the second is the one worth a test of its own: the answer must be
-    something the loader can read, and it must not vary by operating system. A device
-    map is decided from the accelerator alone, and an OS-dependent answer would mean a
-    user's placement changed when they moved the same box between Linux and WSL.
+    Two claims: the answer is something the loader can read, and it does not vary by
+    operating system. An OS-dependent answer would move a user's placement when they
+    moved the same box between Linux and WSL.
 
-    ROCm is the row to read carefully. Studio reports an AMD card as DeviceType.CUDA
-    (torch.version.hip is set but the torch.cuda API is the one in use), so AMD takes
-    the same branch as NVIDIA. That is intended: unsloth maps its DEVICE_TYPE "hip" to
-    DEVICE_TYPE_TORCH "cuda", so the planner runs and reads memory through the same API.
+    The AMD row is the one to read carefully. Studio reports a ROCm card as
+    DeviceType.CUDA, and unsloth maps its "hip" device type to DEVICE_TYPE_TORCH
+    "cuda", so AMD takes the NVIDIA branch and the planner runs there.
     """
 
     # sys.platform, os.name, platform.system(), platform.release()
@@ -2378,21 +2376,18 @@ class TestDeviceMapAcrossPlatformsAndAccelerators(_GpuCacheResetMixin, unittest.
 
 
 class TestPlannerIneligibleRoutesKeepBalanced(_GpuCacheResetMixin, unittest.TestCase):
-    """Routes unsloth's planner refuses to plan must keep a sharding map.
+    """Routes the planner refuses to plan must keep a sharding map.
 
-    `resolve_unsloth_device_map` turns `"unsloth"` into `"sequential"` for a full
-    finetune and for an explicit `auto_model` class with no `_model_mapping`. That
-    fallback is not a shard: `get_max_memory` gives cuda:0 its whole free budget, so
-    `infer_auto_device_map` fills it before touching cuda:1. Measured on
-    `unsloth/Qwen2.5-7B-Instruct` in bf16 across two cards, replicating the transformers
-    branch exactly:
+    `resolve_unsloth_device_map` returns `"sequential"` for a full finetune and for an
+    explicit `auto_model` with no `_model_mapping`, and that is not a shard:
+    `get_max_memory` gives cuda:0 its whole free budget, so `infer_auto_device_map`
+    fills it first. On `unsloth/Qwen2.5-7B-Instruct` in bf16 across two cards:
 
-        card 8 GiB   sequential {'0': 14, '1': 18}   balanced {'0': 13, '1': 19}
-        card 16 GiB  sequential {'0': 1}             balanced {'0': 13, '1': 19}
+        8 GiB each   sequential {'0': 14, '1': 18}   balanced {'0': 13, '1': 19}
+        16 GiB each  sequential {'0': 1}             balanced {'0': 13, '1': 19}
 
-    At 16 GiB the weights fit on one card, so sequential puts the whole model there with
-    nothing left for optimizer state, where balanced spreads it. Those routes therefore
-    keep the map they had before the planner switch.
+    At 16 GiB the weights fit on one card, so sequential puts them all there with
+    nothing left for optimizer state.
     """
 
     def test_a_full_finetune_keeps_balanced(self):
@@ -2417,11 +2412,11 @@ class TestPlannerIneligibleRoutesKeepBalanced(_GpuCacheResetMixin, unittest.Test
 
 
 class TestStudioLoadersDeclareTheirPlannerEligibility(unittest.TestCase):
-    """The two call sites must pass the flag, and no third auto_model may appear unnoticed.
+    """Every loader must pass the flag, and no new auto_model may appear unnoticed.
 
-    The eligibility rule lives in unsloth (`_planner_skip_reason` fires for an explicit
-    `auto_model` whose class has no `_model_mapping`), so a new Studio route that passes
-    one would silently lose its shard with nothing red. This pins the known set instead.
+    The rule lives in unsloth (`_planner_skip_reason` fires for an explicit `auto_model`
+    with no `_model_mapping`), so a new Studio route passing one would lose its shard
+    with nothing red. This pins the known set instead.
     """
 
     KNOWN_AUTO_MODELS = {"CsmForConditionalGeneration", "WhisperForConditionalGeneration"}

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -553,14 +553,24 @@ class TestGpuAutoSelection(_GpuCacheResetMixin, unittest.TestCase):
         with patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA):
             self.assertEqual(get_device_map(None), "sequential")
             self.assertEqual(get_device_map([0]), "sequential")
-            self.assertEqual(get_device_map([0, 1]), "balanced")
+            self.assertEqual(get_device_map([0, 1]), "unsloth")
 
     def test_get_device_map_uses_all_inherited_visible_gpus_for_uuid_masks(self):
         with (
             patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
             patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA),
         ):
-            self.assertEqual(get_device_map(None), "balanced")
+            self.assertEqual(get_device_map(None), "unsloth")
+
+    def test_xpu_keeps_balanced_because_the_unsloth_planner_is_cuda_only(self):
+        """The planner falls back to "sequential" off CUDA, which would undo the shard."""
+        with patch("utils.hardware.hardware.get_device", return_value = DeviceType.XPU):
+            self.assertEqual(get_device_map([0, 1]), "balanced")
+
+    def test_a_single_gpu_never_asks_for_a_plan(self):
+        for device in (DeviceType.CUDA, DeviceType.XPU):
+            with patch("utils.hardware.hardware.get_device", return_value = device):
+                self.assertEqual(get_device_map([0]), "sequential")
 
     def test_get_offloaded_device_map_entries_returns_only_cpu_and_disk(self):
         model = SimpleNamespace(

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -2375,3 +2375,94 @@ class TestDeviceMapAcrossPlatformsAndAccelerators(_GpuCacheResetMixin, unittest.
                         f"{label} with {len(gpu_ids)} GPU(s) answered {answers} across "
                         "operating systems; the placement must not move with the OS",
                     )
+
+
+class TestPlannerIneligibleRoutesKeepBalanced(_GpuCacheResetMixin, unittest.TestCase):
+    """Routes unsloth's planner refuses to plan must keep a sharding map.
+
+    `resolve_unsloth_device_map` turns `"unsloth"` into `"sequential"` for a full
+    finetune and for an explicit `auto_model` class with no `_model_mapping`. That
+    fallback is not a shard: `get_max_memory` gives cuda:0 its whole free budget, so
+    `infer_auto_device_map` fills it before touching cuda:1. Measured on
+    `unsloth/Qwen2.5-7B-Instruct` in bf16 across two cards, replicating the transformers
+    branch exactly:
+
+        card 8 GiB   sequential {'0': 14, '1': 18}   balanced {'0': 13, '1': 19}
+        card 16 GiB  sequential {'0': 1}             balanced {'0': 13, '1': 19}
+
+    At 16 GiB the weights fit on one card, so sequential puts the whole model there with
+    nothing left for optimizer state, where balanced spreads it. Those routes therefore
+    keep the map they had before the planner switch.
+    """
+
+    def test_a_full_finetune_keeps_balanced(self):
+        with patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA):
+            self.assertEqual(get_device_map([0, 1], planner_eligible = False), "balanced")
+
+    def test_an_eligible_load_still_gets_the_planner(self):
+        with patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA):
+            self.assertEqual(get_device_map([0, 1], planner_eligible = True), "unsloth")
+            self.assertEqual(get_device_map([0, 1]), "unsloth")  # eligible by default
+
+    def test_ineligibility_does_not_invent_a_shard_on_one_gpu(self):
+        for device in (DeviceType.CUDA, DeviceType.XPU, DeviceType.CPU):
+            with patch("utils.hardware.hardware.get_device", return_value = device):
+                self.assertEqual(get_device_map([0], planner_eligible = False), "sequential")
+
+    def test_xpu_is_unaffected_by_the_flag(self):
+        # XPU already keeps "balanced"; eligibility is a CUDA-only distinction.
+        with patch("utils.hardware.hardware.get_device", return_value = DeviceType.XPU):
+            self.assertEqual(get_device_map([0, 1], planner_eligible = True), "balanced")
+            self.assertEqual(get_device_map([0, 1], planner_eligible = False), "balanced")
+
+
+class TestStudioLoadersDeclareTheirPlannerEligibility(unittest.TestCase):
+    """The two call sites must pass the flag, and no third auto_model may appear unnoticed.
+
+    The eligibility rule lives in unsloth (`_planner_skip_reason` fires for an explicit
+    `auto_model` whose class has no `_model_mapping`), so a new Studio route that passes
+    one would silently lose its shard with nothing red. This pins the known set instead.
+    """
+
+    KNOWN_AUTO_MODELS = {"CsmForConditionalGeneration", "WhisperForConditionalGeneration"}
+    LOADERS = ("core/inference/inference.py", "core/training/trainer.py")
+
+    def _source(self, relative):
+        return (Path(__file__).resolve().parent.parent / relative).read_text(encoding = "utf-8")
+
+    def test_both_loaders_pass_planner_eligible(self):
+        import ast
+
+        for relative in self.LOADERS:
+            tree = ast.parse(self._source(relative))
+            calls = [
+                node for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and getattr(node.func, "id", None) == "get_device_map"
+            ]
+            self.assertTrue(calls, f"{relative}: no get_device_map call found")
+            for call in calls:
+                self.assertIn(
+                    "planner_eligible", {kw.arg for kw in call.keywords},
+                    f"{relative}:{call.lineno} calls get_device_map without planner_eligible; "
+                    "a planner-ineligible route would silently fall back to sequential",
+                )
+
+    def test_the_set_of_explicit_auto_model_classes_is_the_one_the_flag_covers(self):
+        import ast
+
+        seen = set()
+        for relative in self.LOADERS:
+            tree = ast.parse(self._source(relative))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                for keyword in node.keywords:
+                    if keyword.arg == "auto_model" and isinstance(keyword.value, ast.Name):
+                        seen.add(keyword.value.id)
+        self.assertEqual(
+            seen, self.KNOWN_AUTO_MODELS,
+            "the explicit auto_model classes Studio loads changed. Each one has to be "
+            "checked for a _model_mapping: without it unsloth's planner declines and the "
+            "route needs planner_eligible = False to keep its shard.",
+        )

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -2425,7 +2425,14 @@ class TestStudioLoadersDeclareTheirPlannerEligibility(unittest.TestCase):
     """
 
     KNOWN_AUTO_MODELS = {"CsmForConditionalGeneration", "WhisperForConditionalGeneration"}
-    LOADERS = ("core/inference/inference.py", "core/training/trainer.py")
+    # Every module that resolves a device map for a load. export.py was missing from this
+    # list once, and its CSM and Whisper branches kept asking for the planner with nothing
+    # red: the guard is only worth what its scope covers.
+    LOADERS = (
+        "core/inference/inference.py",
+        "core/training/trainer.py",
+        "core/export/export.py",
+    )
 
     def _source(self, relative):
         return (Path(__file__).resolve().parent.parent / relative).read_text(encoding = "utf-8")
@@ -2437,7 +2444,14 @@ class TestStudioLoadersDeclareTheirPlannerEligibility(unittest.TestCase):
             calls = [
                 node
                 for node in ast.walk(tree)
-                if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "get_device_map"
+                if isinstance(node, ast.Call)
+                and getattr(node.func, "id", None)
+                in ("get_device_map", "_multi_gpu_device_map_kwargs")
+                # The helper's own body is where the flag is forwarded, not passed.
+                and not (
+                    getattr(node.func, "id", None) == "get_device_map"
+                    and relative.endswith("export.py")
+                )
             ]
             self.assertTrue(calls, f"{relative}: no get_device_map call found")
             for call in calls:

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -2432,18 +2432,18 @@ class TestStudioLoadersDeclareTheirPlannerEligibility(unittest.TestCase):
 
     def test_both_loaders_pass_planner_eligible(self):
         import ast
-
         for relative in self.LOADERS:
             tree = ast.parse(self._source(relative))
             calls = [
-                node for node in ast.walk(tree)
-                if isinstance(node, ast.Call)
-                and getattr(node.func, "id", None) == "get_device_map"
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "get_device_map"
             ]
             self.assertTrue(calls, f"{relative}: no get_device_map call found")
             for call in calls:
                 self.assertIn(
-                    "planner_eligible", {kw.arg for kw in call.keywords},
+                    "planner_eligible",
+                    {kw.arg for kw in call.keywords},
                     f"{relative}:{call.lineno} calls get_device_map without planner_eligible; "
                     "a planner-ineligible route would silently fall back to sequential",
                 )
@@ -2461,7 +2461,8 @@ class TestStudioLoadersDeclareTheirPlannerEligibility(unittest.TestCase):
                     if keyword.arg == "auto_model" and isinstance(keyword.value, ast.Name):
                         seen.add(keyword.value.id)
         self.assertEqual(
-            seen, self.KNOWN_AUTO_MODELS,
+            seen,
+            self.KNOWN_AUTO_MODELS,
             "the explicit auto_model classes Studio loads changed. Each one has to be "
             "checked for a _model_mapping: without it unsloth's planner declines and the "
             "route needs planner_eligible = False to keep its shard.",

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -2308,3 +2308,69 @@ class TestEstimateFp16ModelSizeBytesPrefersLocalWeights(unittest.TestCase):
             self.assertEqual(src, "safetensors")
             mock_load.assert_not_called()
             mock_local.assert_not_called()
+
+
+class TestDeviceMapAcrossPlatformsAndAccelerators(_GpuCacheResetMixin, unittest.TestCase):
+    """The full [Windows, Linux, WSL, Mac] x [NVIDIA, AMD, Intel, Apple, CPU] product.
+
+    Two claims, and the second is the one worth a test of its own: the answer must be
+    something the loader can read, and it must not vary by operating system. A device
+    map is decided from the accelerator alone, and an OS-dependent answer would mean a
+    user's placement changed when they moved the same box between Linux and WSL.
+
+    ROCm is the row to read carefully. Studio reports an AMD card as DeviceType.CUDA
+    (torch.version.hip is set but the torch.cuda API is the one in use), so AMD takes
+    the same branch as NVIDIA. That is intended: unsloth maps its DEVICE_TYPE "hip" to
+    DEVICE_TYPE_TORCH "cuda", so the planner runs and reads memory through the same API.
+    """
+
+    # sys.platform, os.name, platform.system(), platform.release()
+    OSES = {
+        "Linux":   ("linux",  "posix", "Linux",   "6.8.0-generic"),
+        "WSL":     ("linux",  "posix", "Linux",   "5.15.0-microsoft-standard-WSL2"),
+        "Windows": ("win32",  "nt",    "Windows", "10"),
+        "Mac":     ("darwin", "posix", "Darwin",  "23.5.0"),
+    }
+    ACCELERATORS = {
+        "NVIDIA":      (DeviceType.CUDA, "unsloth"),
+        "AMD (ROCm)":  (DeviceType.CUDA, "unsloth"),
+        "Intel (XPU)": (DeviceType.XPU,  "balanced"),
+        "Apple (MLX)": (DeviceType.MLX,  "sequential"),
+        "CPU only":    (DeviceType.CPU,  "sequential"),
+    }
+    READABLE = {"sequential", "balanced", "unsloth"}
+
+    def _answer(self, os_key, device, gpu_ids):
+        platform_name, os_name, system, release = self.OSES[os_key]
+        with (
+            patch.object(sys, "platform", platform_name),
+            patch.object(os, "name", os_name),
+            patch("platform.system", return_value = system),
+            patch("platform.release", return_value = release),
+            patch("utils.hardware.hardware.get_device", return_value = device),
+        ):
+            return get_device_map(gpu_ids)
+
+    def test_every_cell_of_the_product(self):
+        for os_key in self.OSES:
+            for label, (device, multi_answer) in self.ACCELERATORS.items():
+                for gpu_ids, want in (
+                    ([0], "sequential"),
+                    ([0, 1], multi_answer),
+                    (list(range(8)), multi_answer),
+                ):
+                    with self.subTest(os = os_key, accelerator = label, gpus = len(gpu_ids)):
+                        got = self._answer(os_key, device, gpu_ids)
+                        self.assertEqual(got, want)
+                        self.assertIn(got, self.READABLE)
+
+    def test_the_answer_does_not_depend_on_the_operating_system(self):
+        for label, (device, _) in self.ACCELERATORS.items():
+            for gpu_ids in ([0], [0, 1], list(range(8))):
+                answers = {self._answer(key, device, gpu_ids) for key in self.OSES}
+                with self.subTest(accelerator = label, gpus = len(gpu_ids)):
+                    self.assertEqual(
+                        len(answers), 1,
+                        f"{label} with {len(gpu_ids)} GPU(s) answered {answers} across "
+                        "operating systems; the placement must not move with the OS",
+                    )

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -2326,17 +2326,17 @@ class TestDeviceMapAcrossPlatformsAndAccelerators(_GpuCacheResetMixin, unittest.
 
     # sys.platform, os.name, platform.system(), platform.release()
     OSES = {
-        "Linux":   ("linux",  "posix", "Linux",   "6.8.0-generic"),
-        "WSL":     ("linux",  "posix", "Linux",   "5.15.0-microsoft-standard-WSL2"),
-        "Windows": ("win32",  "nt",    "Windows", "10"),
-        "Mac":     ("darwin", "posix", "Darwin",  "23.5.0"),
+        "Linux": ("linux", "posix", "Linux", "6.8.0-generic"),
+        "WSL": ("linux", "posix", "Linux", "5.15.0-microsoft-standard-WSL2"),
+        "Windows": ("win32", "nt", "Windows", "10"),
+        "Mac": ("darwin", "posix", "Darwin", "23.5.0"),
     }
     ACCELERATORS = {
-        "NVIDIA":      (DeviceType.CUDA, "unsloth"),
-        "AMD (ROCm)":  (DeviceType.CUDA, "unsloth"),
-        "Intel (XPU)": (DeviceType.XPU,  "balanced"),
-        "Apple (MLX)": (DeviceType.MLX,  "sequential"),
-        "CPU only":    (DeviceType.CPU,  "sequential"),
+        "NVIDIA": (DeviceType.CUDA, "unsloth"),
+        "AMD (ROCm)": (DeviceType.CUDA, "unsloth"),
+        "Intel (XPU)": (DeviceType.XPU, "balanced"),
+        "Apple (MLX)": (DeviceType.MLX, "sequential"),
+        "CPU only": (DeviceType.CPU, "sequential"),
     }
     READABLE = {"sequential", "balanced", "unsloth"}
 
@@ -2370,7 +2370,8 @@ class TestDeviceMapAcrossPlatformsAndAccelerators(_GpuCacheResetMixin, unittest.
                 answers = {self._answer(key, device, gpu_ids) for key in self.OSES}
                 with self.subTest(accelerator = label, gpus = len(gpu_ids)):
                     self.assertEqual(
-                        len(answers), 1,
+                        len(answers),
+                        1,
                         f"{label} with {len(gpu_ids)} GPU(s) answered {answers} across "
                         "operating systems; the placement must not move with the OS",
                     )

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -2417,12 +2417,46 @@ class TestTheFallbackNameIsOneUnslothResolves(unittest.TestCase):
     A typo, or a rename on the unsloth side, would reach transformers as an unrecognised
     device_map and raise "the value needs to be a device name ... but found X". Read from
     the loader rather than repeated here, so the two cannot drift apart.
+
+    Parsed rather than imported: `import unsloth` needs unsloth_zoo, which the backend
+    test environment does not install, and skipping there would leave the one place the
+    two sides are compared unrun in CI.
     """
 
-    def test_the_cuda_answer_is_a_planned_map_unsloth_accepts(self):
-        from unsloth.models.loader_utils import _PLANNED_DEVICE_MAPS
+    def _planned_device_maps(self):
+        import ast
 
+        source = None
+        here = os.path.dirname(os.path.abspath(__file__))
+        candidate = os.path.join(here, "..", "..", "..", "unsloth", "models", "loader_utils.py")
+        if os.path.exists(candidate):
+            source = open(candidate, encoding = "utf-8").read()
+        else:
+            # An installed Studio: find_spec locates the package without executing it.
+            import importlib.util
+
+            spec = importlib.util.find_spec("unsloth")
+            locations = list(getattr(spec, "submodule_search_locations", None) or [])
+            for location in locations:
+                installed = os.path.join(location, "models", "loader_utils.py")
+                if os.path.exists(installed):
+                    source = open(installed, encoding = "utf-8").read()
+                    break
+        self.assertIsNotNone(source, "loader_utils.py not found; the comparison cannot be made")
+
+        namespace = {}
+        for node in ast.parse(source).body:
+            if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", None) in (
+                "UNSLOTH_DEVICE_MAP",
+                "UNSLOTH_BALANCED_DEVICE_MAP",
+                "_PLANNED_DEVICE_MAPS",
+            ):
+                exec(ast.get_source_segment(source, node), namespace)
+        return namespace["_PLANNED_DEVICE_MAPS"]
+
+    def test_the_cuda_answer_is_a_planned_map_unsloth_accepts(self):
+        planned = self._planned_device_maps()
         with patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA):
             answer = get_device_map([0, 1])
-        self.assertIn(answer, _PLANNED_DEVICE_MAPS)
-        self.assertEqual(_PLANNED_DEVICE_MAPS[answer], "balanced")
+        self.assertIn(answer, planned)
+        self.assertEqual(planned[answer], "balanced")

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -553,14 +553,14 @@ class TestGpuAutoSelection(_GpuCacheResetMixin, unittest.TestCase):
         with patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA):
             self.assertEqual(get_device_map(None), "sequential")
             self.assertEqual(get_device_map([0]), "sequential")
-            self.assertEqual(get_device_map([0, 1]), "unsloth")
+            self.assertEqual(get_device_map([0, 1]), "unsloth_balanced")
 
     def test_get_device_map_uses_all_inherited_visible_gpus_for_uuid_masks(self):
         with (
             patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
             patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA),
         ):
-            self.assertEqual(get_device_map(None), "unsloth")
+            self.assertEqual(get_device_map(None), "unsloth_balanced")
 
     def test_xpu_keeps_balanced_because_the_unsloth_planner_is_cuda_only(self):
         """The planner falls back to "sequential" off CUDA, which would undo the shard."""
@@ -2330,13 +2330,13 @@ class TestDeviceMapAcrossPlatformsAndAccelerators(_GpuCacheResetMixin, unittest.
         "Mac": ("darwin", "posix", "Darwin", "23.5.0"),
     }
     ACCELERATORS = {
-        "NVIDIA": (DeviceType.CUDA, "unsloth"),
-        "AMD (ROCm)": (DeviceType.CUDA, "unsloth"),
+        "NVIDIA": (DeviceType.CUDA, "unsloth_balanced"),
+        "AMD (ROCm)": (DeviceType.CUDA, "unsloth_balanced"),
         "Intel (XPU)": (DeviceType.XPU, "balanced"),
         "Apple (MLX)": (DeviceType.MLX, "sequential"),
         "CPU only": (DeviceType.CPU, "sequential"),
     }
-    READABLE = {"sequential", "balanced", "unsloth"}
+    READABLE = {"sequential", "balanced", "unsloth_balanced"}
 
     def _answer(self, os_key, device, gpu_ids):
         platform_name, os_name, system, release = self.OSES[os_key]
@@ -2375,104 +2375,54 @@ class TestDeviceMapAcrossPlatformsAndAccelerators(_GpuCacheResetMixin, unittest.
                     )
 
 
-class TestPlannerIneligibleRoutesKeepBalanced(_GpuCacheResetMixin, unittest.TestCase):
-    """Routes the planner refuses to plan must keep a sharding map.
+class TestTheCudaMapNamesItsFallback(_GpuCacheResetMixin, unittest.TestCase):
+    """CUDA asks for `"unsloth_balanced"`, not `"unsloth"`.
 
-    `resolve_unsloth_device_map` returns `"sequential"` for a full finetune and for an
-    explicit `auto_model` with no `_model_mapping`, and that is not a shard:
-    `get_max_memory` gives cuda:0 its whole free budget, so `infer_auto_device_map`
-    fills it first. On `unsloth/Qwen2.5-7B-Instruct` in bf16 across two cards:
+    The planner declines several shapes -- a full finetune, an explicit `auto_model` with
+    no `_model_mapping`, a Falcon-H1 checkpoint missing the mamba exclusions -- and plain
+    `"unsloth"` falls back to `"sequential"`, which is not a shard: `get_max_memory` gives
+    cuda:0 its whole free budget, so `infer_auto_device_map` fills it first. On
+    `unsloth/Qwen2.5-7B-Instruct` in bf16 across two cards:
 
         8 GiB each   sequential {'0': 14, '1': 18}   balanced {'0': 13, '1': 19}
         16 GiB each  sequential {'0': 1}             balanced {'0': 13, '1': 19}
 
-    At 16 GiB the weights fit on one card, so sequential puts them all there with
-    nothing left for optimizer state.
+    At 16 GiB the weights fit on one card, so sequential puts them all there with nothing
+    left for optimizer state. Naming the fallback covers every declined shape, including
+    ones Studio cannot detect and ones unsloth adds later.
     """
 
-    def test_a_full_finetune_keeps_balanced(self):
+    def test_multi_gpu_cuda_names_the_balanced_fallback(self):
         with patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA):
-            self.assertEqual(get_device_map([0, 1], planner_eligible = False), "balanced")
+            self.assertEqual(get_device_map([0, 1]), "unsloth_balanced")
 
-    def test_an_eligible_load_still_gets_the_planner(self):
+    def test_the_plain_sentinel_is_not_used(self):
+        # "unsloth" alone falls back to "sequential" on every veto path, which is the bug.
         with patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA):
-            self.assertEqual(get_device_map([0, 1], planner_eligible = True), "unsloth")
-            self.assertEqual(get_device_map([0, 1]), "unsloth")  # eligible by default
+            self.assertNotEqual(get_device_map([0, 1]), "unsloth")
 
-    def test_ineligibility_does_not_invent_a_shard_on_one_gpu(self):
+    def test_xpu_keeps_plain_balanced(self):
+        with patch("utils.hardware.hardware.get_device", return_value = DeviceType.XPU):
+            self.assertEqual(get_device_map([0, 1]), "balanced")
+
+    def test_a_single_gpu_never_asks_for_a_plan(self):
         for device in (DeviceType.CUDA, DeviceType.XPU, DeviceType.CPU):
             with patch("utils.hardware.hardware.get_device", return_value = device):
-                self.assertEqual(get_device_map([0], planner_eligible = False), "sequential")
-
-    def test_xpu_is_unaffected_by_the_flag(self):
-        # XPU already keeps "balanced"; eligibility is a CUDA-only distinction.
-        with patch("utils.hardware.hardware.get_device", return_value = DeviceType.XPU):
-            self.assertEqual(get_device_map([0, 1], planner_eligible = True), "balanced")
-            self.assertEqual(get_device_map([0, 1], planner_eligible = False), "balanced")
+                self.assertEqual(get_device_map([0]), "sequential")
 
 
-class TestStudioLoadersDeclareTheirPlannerEligibility(unittest.TestCase):
-    """Every loader must pass the flag, and no new auto_model may appear unnoticed.
+class TestTheFallbackNameIsOneUnslothResolves(unittest.TestCase):
+    """The string Studio emits has to be one unsloth's resolver knows.
 
-    The rule lives in unsloth (`_planner_skip_reason` fires for an explicit `auto_model`
-    with no `_model_mapping`), so a new Studio route passing one would lose its shard
-    with nothing red. This pins the known set instead.
+    A typo, or a rename on the unsloth side, would reach transformers as an unrecognised
+    device_map and raise "the value needs to be a device name ... but found X". Read from
+    the loader rather than repeated here, so the two cannot drift apart.
     """
 
-    KNOWN_AUTO_MODELS = {"CsmForConditionalGeneration", "WhisperForConditionalGeneration"}
-    # Every module that resolves a device map for a load. export.py was missing from this
-    # list once, and its CSM and Whisper branches kept asking for the planner with nothing
-    # red: the guard is only worth what its scope covers.
-    LOADERS = (
-        "core/inference/inference.py",
-        "core/training/trainer.py",
-        "core/export/export.py",
-    )
+    def test_the_cuda_answer_is_a_planned_map_unsloth_accepts(self):
+        from unsloth.models.loader_utils import _PLANNED_DEVICE_MAPS
 
-    def _source(self, relative):
-        return (Path(__file__).resolve().parent.parent / relative).read_text(encoding = "utf-8")
-
-    def test_both_loaders_pass_planner_eligible(self):
-        import ast
-        for relative in self.LOADERS:
-            tree = ast.parse(self._source(relative))
-            calls = [
-                node
-                for node in ast.walk(tree)
-                if isinstance(node, ast.Call)
-                and getattr(node.func, "id", None)
-                in ("get_device_map", "_multi_gpu_device_map_kwargs")
-                # The helper's own body is where the flag is forwarded, not passed.
-                and not (
-                    getattr(node.func, "id", None) == "get_device_map"
-                    and relative.endswith("export.py")
-                )
-            ]
-            self.assertTrue(calls, f"{relative}: no get_device_map call found")
-            for call in calls:
-                self.assertIn(
-                    "planner_eligible",
-                    {kw.arg for kw in call.keywords},
-                    f"{relative}:{call.lineno} calls get_device_map without planner_eligible; "
-                    "a planner-ineligible route would silently fall back to sequential",
-                )
-
-    def test_the_set_of_explicit_auto_model_classes_is_the_one_the_flag_covers(self):
-        import ast
-
-        seen = set()
-        for relative in self.LOADERS:
-            tree = ast.parse(self._source(relative))
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.Call):
-                    continue
-                for keyword in node.keywords:
-                    if keyword.arg == "auto_model" and isinstance(keyword.value, ast.Name):
-                        seen.add(keyword.value.id)
-        self.assertEqual(
-            seen,
-            self.KNOWN_AUTO_MODELS,
-            "the explicit auto_model classes Studio loads changed. Each one has to be "
-            "checked for a _model_mapping: without it unsloth's planner declines and the "
-            "route needs planner_eligible = False to keep its shard.",
-        )
+        with patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA):
+            answer = get_device_map([0, 1])
+        self.assertIn(answer, _PLANNED_DEVICE_MAPS)
+        self.assertEqual(_PLANNED_DEVICE_MAPS[answer], "balanced")

--- a/studio/backend/tests/test_gpu_selection_sandbox.py
+++ b/studio/backend/tests/test_gpu_selection_sandbox.py
@@ -325,12 +325,12 @@ class TestGetDeviceMap(unittest.TestCase):
             dm = get_device_map(gpu_ids = [0])
             self.assertEqual(dm, "sequential")
 
-    def test_multi_gpu_returns_balanced(self):
+    def test_multi_gpu_returns_the_unsloth_planner(self):
         from utils.hardware.hardware import get_device_map
         import utils.hardware.hardware as hw
         with patch.object(hw, "get_device", return_value = hw.DeviceType.CUDA):
             dm = get_device_map(gpu_ids = [0, 1])
-            self.assertEqual(dm, "balanced")
+            self.assertEqual(dm, "unsloth")
 
     def test_cpu_returns_sequential(self):
         from utils.hardware.hardware import get_device_map

--- a/studio/backend/tests/test_gpu_selection_sandbox.py
+++ b/studio/backend/tests/test_gpu_selection_sandbox.py
@@ -330,7 +330,7 @@ class TestGetDeviceMap(unittest.TestCase):
         import utils.hardware.hardware as hw
         with patch.object(hw, "get_device", return_value = hw.DeviceType.CUDA):
             dm = get_device_map(gpu_ids = [0, 1])
-            self.assertEqual(dm, "unsloth")
+            self.assertEqual(dm, "unsloth_balanced")
 
     def test_cpu_returns_sequential(self):
         from utils.hardware.hardware import get_device_map

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -4936,7 +4936,11 @@ def apply_gpu_ids(gpu_ids, backend: Optional[str] = None) -> None:
         logger.info("Applied gpu_ids: CUDA_VISIBLE_DEVICES='%s'", value)
 
 
-def get_device_map(gpu_ids: Optional[list[int]] = None) -> str:
+def get_device_map(
+    gpu_ids: Optional[list[int]] = None,
+    *,
+    planner_eligible: bool = True,
+) -> str:
     """Return the Hugging Face ``device_map`` string for model loading.
 
     Returns ``"unsloth"`` on CUDA, or ``"balanced"`` on XPU, to shard across
@@ -4959,6 +4963,17 @@ def get_device_map(gpu_ids: Optional[list[int]] = None) -> str:
     XPU keeps ``"balanced"`` deliberately: the unsloth planner has no memory
     budgets for non-CUDA backends and falls back to ``"sequential"`` there, so
     asking for it would quietly collapse XPU sharding onto one device.
+
+    ``planner_eligible = False`` is the same reservation for a CUDA load the
+    planner will refuse to plan: a full finetune, or an explicit ``auto_model``
+    class with no ``_model_mapping`` (``CsmForConditionalGeneration``,
+    ``WhisperForConditionalGeneration``), which
+    ``resolve_unsloth_device_map`` turns into ``"sequential"``. That fallback
+    fills cuda:0 to its whole free budget before touching cuda:1, so a
+    checkpoint that fits on one card lands entirely there with no headroom for
+    optimizer state -- measured on a 7B in bf16 across 2x16 GiB, ``sequential``
+    gives ``{"": 0}`` where ``balanced`` gives 13 modules to cuda:0 and 19 to
+    cuda:1. Those routes keep the map they had.
 
     Returns ``"sequential"`` (single device) otherwise, including CPU/MLX
     backends.
@@ -4993,7 +5008,9 @@ def get_device_map(gpu_ids: Optional[list[int]] = None) -> str:
                     multi_gpu = True
 
         if multi_gpu:
-            return "unsloth" if device == DeviceType.CUDA else "balanced"
+            if device == DeviceType.CUDA and planner_eligible:
+                return "unsloth"
+            return "balanced"
 
     return "sequential"
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -4936,11 +4936,7 @@ def apply_gpu_ids(gpu_ids, backend: Optional[str] = None) -> None:
         logger.info("Applied gpu_ids: CUDA_VISIBLE_DEVICES='%s'", value)
 
 
-def get_device_map(
-    gpu_ids: Optional[list[int]] = None,
-    *,
-    planner_eligible: bool = True,
-) -> str:
+def get_device_map(gpu_ids: Optional[list[int]] = None, *, planner_eligible: bool = True) -> str:
     """Return the Hugging Face ``device_map`` string for model loading.
 
     Returns ``"unsloth"`` on CUDA, or ``"balanced"`` on XPU, to shard across

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -4939,11 +4939,26 @@ def apply_gpu_ids(gpu_ids, backend: Optional[str] = None) -> None:
 def get_device_map(gpu_ids: Optional[list[int]] = None) -> str:
     """Return the Hugging Face ``device_map`` string for model loading.
 
-    Returns ``"balanced"`` (shard evenly across GPUs) when:
+    Returns ``"unsloth"`` on CUDA, or ``"balanced"`` on XPU, to shard across
+    GPUs when:
       - ``gpu_ids`` explicitly lists >1 GPU, **or**
       - ``CUDA_VISIBLE_DEVICES``/``ZE_AFFINITY_MASK`` uses non-numeric
         identifiers (UUID/MIG/wildcard) and >1 GPU is visible (fallback:
         numeric IDs unresolvable, so assume multi-GPU is intended).
+
+    CUDA asks for unsloth's head-aware planner rather than accelerate's
+    ``"balanced"``. ``balanced`` caps every device except the last at roughly
+    ``model_size / n_devices`` and then charges cuda:0 alone for the largest
+    layer, so on a small quantized model the unquantized ``lm_head`` does not
+    fit and every module lands on the last card. That is not a split, and a
+    4bit model placed wholly on a non-zero card cannot be trained at all:
+    ``Accelerator.prepare_model`` rejects it with "You can't train a model that
+    has been loaded in 8-bit or 4-bit precision on a different device than the
+    one you're training on".
+
+    XPU keeps ``"balanced"`` deliberately: the unsloth planner has no memory
+    budgets for non-CUDA backends and falls back to ``"sequential"`` there, so
+    asking for it would quietly collapse XPU sharding onto one device.
 
     Returns ``"sequential"`` (single device) otherwise, including CPU/MLX
     backends.
@@ -4978,7 +4993,7 @@ def get_device_map(gpu_ids: Optional[list[int]] = None) -> str:
                     multi_gpu = True
 
         if multi_gpu:
-            return "balanced"
+            return "unsloth" if device == DeviceType.CUDA else "balanced"
 
     return "sequential"
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -4936,11 +4936,11 @@ def apply_gpu_ids(gpu_ids, backend: Optional[str] = None) -> None:
         logger.info("Applied gpu_ids: CUDA_VISIBLE_DEVICES='%s'", value)
 
 
-def get_device_map(gpu_ids: Optional[list[int]] = None, *, planner_eligible: bool = True) -> str:
+def get_device_map(gpu_ids: Optional[list[int]] = None) -> str:
     """Return the Hugging Face ``device_map`` string for model loading.
 
-    Returns ``"unsloth"`` on CUDA, or ``"balanced"`` on XPU, to shard across
-    GPUs when:
+    Returns ``"unsloth_balanced"`` on CUDA, or ``"balanced"`` on XPU, to shard
+    across GPUs when:
       - ``gpu_ids`` explicitly lists >1 GPU, **or**
       - ``CUDA_VISIBLE_DEVICES``/``ZE_AFFINITY_MASK`` uses non-numeric
         identifiers (UUID/MIG/wildcard) and >1 GPU is visible (fallback:
@@ -4953,16 +4953,20 @@ def get_device_map(gpu_ids: Optional[list[int]] = None, *, planner_eligible: boo
     module lands on the last card, and a 4bit model wholly on a non-zero card
     cannot be trained: ``Accelerator.prepare_model`` refuses it.
 
-    Two cases keep ``"balanced"``, both because the planner would decline and
-    its ``"sequential"`` fallback fills cuda:0 to its whole free budget before
-    touching cuda:1 -- on a 7B in bf16 across 2x16 GiB that is the entire model
-    on cuda:0, against 13/19 for ``balanced``, leaving no room for optimizer
-    state:
+    ``"unsloth_balanced"`` rather than ``"unsloth"``, because the planner
+    declines several shapes -- a full finetune, an explicit ``auto_model`` with
+    no ``_model_mapping``, a Falcon-H1 checkpoint whose bundled quantization
+    config omits the mamba exclusions, and any it adds later -- and its plain
+    fallback is ``"sequential"``, which fills cuda:0 to its whole free budget
+    before touching cuda:1. On a 7B in bf16 across 2x16 GiB that is the whole
+    model on cuda:0 against 13/19 for ``balanced``, with nothing left for
+    optimizer state, which is the opposite of what a caller that selected
+    several cards on their combined capacity asked for. Naming the fallback
+    keeps every declined shape sharded without Studio enumerating a list that
+    belongs to unsloth.
 
-      - XPU, where the planner has no memory budgets at all;
-      - ``planner_eligible = False``, for a full finetune or an explicit
-        ``auto_model`` class with no ``_model_mapping``
-        (``CsmForConditionalGeneration``, ``WhisperForConditionalGeneration``).
+    XPU keeps plain ``"balanced"``: the planner has no memory budgets for
+    non-CUDA backends at all.
 
     Returns ``"sequential"`` (single device) otherwise, including CPU/MLX
     backends.
@@ -4997,9 +5001,7 @@ def get_device_map(gpu_ids: Optional[list[int]] = None, *, planner_eligible: boo
                     multi_gpu = True
 
         if multi_gpu:
-            if device == DeviceType.CUDA and planner_eligible:
-                return "unsloth"
-            return "balanced"
+            return "unsloth_balanced" if device == DeviceType.CUDA else "balanced"
 
     return "sequential"
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -4950,30 +4950,23 @@ def get_device_map(
         identifiers (UUID/MIG/wildcard) and >1 GPU is visible (fallback:
         numeric IDs unresolvable, so assume multi-GPU is intended).
 
-    CUDA asks for unsloth's head-aware planner rather than accelerate's
-    ``"balanced"``. ``balanced`` caps every device except the last at roughly
-    ``model_size / n_devices`` and then charges cuda:0 alone for the largest
-    layer, so on a small quantized model the unquantized ``lm_head`` does not
-    fit and every module lands on the last card. That is not a split, and a
-    4bit model placed wholly on a non-zero card cannot be trained at all:
-    ``Accelerator.prepare_model`` rejects it with "You can't train a model that
-    has been loaded in 8-bit or 4-bit precision on a different device than the
-    one you're training on".
+    CUDA asks for unsloth's head-aware planner instead of accelerate's
+    ``"balanced"``, which caps every device but the last at about
+    ``model_size / n_devices`` and charges cuda:0 alone for the largest layer.
+    On a quantized model the unquantized ``lm_head`` then does not fit, every
+    module lands on the last card, and a 4bit model wholly on a non-zero card
+    cannot be trained: ``Accelerator.prepare_model`` refuses it.
 
-    XPU keeps ``"balanced"`` deliberately: the unsloth planner has no memory
-    budgets for non-CUDA backends and falls back to ``"sequential"`` there, so
-    asking for it would quietly collapse XPU sharding onto one device.
+    Two cases keep ``"balanced"``, both because the planner would decline and
+    its ``"sequential"`` fallback fills cuda:0 to its whole free budget before
+    touching cuda:1 -- on a 7B in bf16 across 2x16 GiB that is the entire model
+    on cuda:0, against 13/19 for ``balanced``, leaving no room for optimizer
+    state:
 
-    ``planner_eligible = False`` is the same reservation for a CUDA load the
-    planner will refuse to plan: a full finetune, or an explicit ``auto_model``
-    class with no ``_model_mapping`` (``CsmForConditionalGeneration``,
-    ``WhisperForConditionalGeneration``), which
-    ``resolve_unsloth_device_map`` turns into ``"sequential"``. That fallback
-    fills cuda:0 to its whole free budget before touching cuda:1, so a
-    checkpoint that fits on one card lands entirely there with no headroom for
-    optimizer state -- measured on a 7B in bf16 across 2x16 GiB, ``sequential``
-    gives ``{"": 0}`` where ``balanced`` gives 13 modules to cuda:0 and 19 to
-    cuda:1. Those routes keep the map they had.
+      - XPU, where the planner has no memory budgets at all;
+      - ``planner_eligible = False``, for a full finetune or an explicit
+        ``auto_model`` class with no ``_model_mapping``
+        (``CsmForConditionalGeneration``, ``WhisperForConditionalGeneration``).
 
     Returns ``"sequential"`` (single device) otherwise, including CPU/MLX
     backends.

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -4948,25 +4948,19 @@ def get_device_map(gpu_ids: Optional[list[int]] = None) -> str:
 
     CUDA asks for unsloth's head-aware planner instead of accelerate's
     ``"balanced"``, which caps every device but the last at about
-    ``model_size / n_devices`` and charges cuda:0 alone for the largest layer.
-    On a quantized model the unquantized ``lm_head`` then does not fit, every
-    module lands on the last card, and a 4bit model wholly on a non-zero card
-    cannot be trained: ``Accelerator.prepare_model`` refuses it.
+    ``model_size / n_devices``. On a quantized model the unquantized ``lm_head``
+    then does not fit on cuda:0, every module lands on the last card, and a 4bit
+    model wholly on a non-zero card cannot be trained: ``prepare_model`` refuses it.
 
-    ``"unsloth_balanced"`` rather than ``"unsloth"``, because the planner
-    declines several shapes -- a full finetune, an explicit ``auto_model`` with
-    no ``_model_mapping``, a Falcon-H1 checkpoint whose bundled quantization
-    config omits the mamba exclusions, and any it adds later -- and its plain
-    fallback is ``"sequential"``, which fills cuda:0 to its whole free budget
-    before touching cuda:1. On a 7B in bf16 across 2x16 GiB that is the whole
-    model on cuda:0 against 13/19 for ``balanced``, with nothing left for
-    optimizer state, which is the opposite of what a caller that selected
-    several cards on their combined capacity asked for. Naming the fallback
-    keeps every declined shape sharded without Studio enumerating a list that
-    belongs to unsloth.
+    ``"unsloth_balanced"`` rather than ``"unsloth"`` because the planner declines
+    several shapes -- a full finetune, an ``auto_model`` with no ``_model_mapping``,
+    a Falcon-H1 checkpoint missing the mamba exclusions, and any added later -- and
+    the plain name falls back to ``"sequential"``, which fills cuda:0 to its whole
+    free budget: a 7B in bf16 across 2x16 GiB lands entirely on cuda:0 against 13/19
+    for ``balanced``. Naming the fallback keeps every declined shape sharded without
+    Studio enumerating a list that belongs to unsloth.
 
-    XPU keeps plain ``"balanced"``: the planner has no memory budgets for
-    non-CUDA backends at all.
+    XPU keeps plain ``"balanced"``: the planner has no non-CUDA memory budgets.
 
     Returns ``"sequential"`` (single device) otherwise, including CPU/MLX
     backends.

--- a/tests/studio/test_hardware_dispatch_matrix.py
+++ b/tests/studio/test_hardware_dispatch_matrix.py
@@ -303,9 +303,9 @@ def test_studio_detect_hardware_matches_profile(profile, spoof_hardware):
         f"profile {profile.name}: expected {profile.expect_device_type}, "
         f"got {detected!r}. {profile.extra_notes}"
     )
-    assert hw.IS_ROCM is profile.expect_is_rocm, (
-        f"profile {profile.name}: expected IS_ROCM={profile.expect_is_rocm}, got {hw.IS_ROCM}"
-    )
+    assert (
+        hw.IS_ROCM is profile.expect_is_rocm
+    ), f"profile {profile.name}: expected IS_ROCM={profile.expect_is_rocm}, got {hw.IS_ROCM}"
 
 
 @pytest.mark.parametrize("profile", PROFILES, ids = PROFILE_IDS)

--- a/tests/studio/test_hardware_dispatch_matrix.py
+++ b/tests/studio/test_hardware_dispatch_matrix.py
@@ -242,7 +242,7 @@ def spoof_hardware(monkeypatch):
                 ):
                     if name == "mlx" or name.startswith("mlx."):
                         raise ImportError(
-                            f"mlx import blocked by spoof_hardware " f"(profile={profile.name})"
+                            f"mlx import blocked by spoof_hardware (profile={profile.name})"
                         )
                     return None
 
@@ -304,7 +304,7 @@ def test_studio_detect_hardware_matches_profile(profile, spoof_hardware):
         f"got {detected!r}. {profile.extra_notes}"
     )
     assert hw.IS_ROCM is profile.expect_is_rocm, (
-        f"profile {profile.name}: expected IS_ROCM={profile.expect_is_rocm}, " f"got {hw.IS_ROCM}"
+        f"profile {profile.name}: expected IS_ROCM={profile.expect_is_rocm}, got {hw.IS_ROCM}"
     )
 
 
@@ -415,6 +415,8 @@ def _loader_device_map_helpers():
                 exec(_ast.get_source_segment(source, node), namespace)
             elif isinstance(node, _ast.Assign) and getattr(node.targets[0], "id", None) in (
                 "UNSLOTH_DEVICE_MAP",
+                "UNSLOTH_BALANCED_DEVICE_MAP",
+                "_PLANNED_DEVICE_MAPS",
                 "DEFAULT_DEVICE_MAP",
                 "_SIZE_UNITS",
             ):
@@ -435,11 +437,12 @@ def _loader_device_map_helpers():
 def test_studio_placement_survives_the_loader_opt_in(
     profile, gpu_ids, opt_in, spoof_hardware, monkeypatch
 ):
-    """Whatever Unsloth decided, the loader hands the same thing to transformers.
+    """Whatever Unsloth decided, the loader hands transformers a map of the same shape.
 
-    The one value the opt-in can rewrite is "sequential", and Unsloth only produces that
-    when it selected a single device -- at which point the worker has already narrowed the
-    visible set, the planner sees one GPU and declines back to "sequential".
+    "sequential" and "balanced" survive untouched. "unsloth_balanced" is a request to
+    plan, so the loader may answer with a plan or, when it declines -- as it does here,
+    with no planner installed -- with the sharding map that name declines to. What it
+    must never do is turn a multi-GPU ask into "sequential", which fills cuda:0 first.
     """
     spoof_hardware(profile)
     hw = _import_studio_hardware_module()
@@ -448,7 +451,7 @@ def test_studio_placement_survives_the_loader_opt_in(
         pytest.skip(f"{profile.name} does not take an explicit gpu_ids")
 
     device_map = hw.get_device_map(gpu_ids)
-    assert device_map in ("balanced", "sequential")
+    assert device_map in ("balanced", "sequential", "unsloth_balanced")
 
     if opt_in == "unset":
         monkeypatch.delenv("UNSLOTH_AUTO_DEVICE_MAP", raising = False)
@@ -463,7 +466,9 @@ def test_studio_placement_survives_the_loader_opt_in(
     resolved = loader["resolve_unsloth_device_map"](
         loader["requested_device_map"](device_map), "unsloth/Qwen3-0.6B"
     )
-    assert resolved == device_map, (
+    # No planner module is installed, so a planned name always reaches its fallback.
+    expected = loader["_PLANNED_DEVICE_MAPS"].get(device_map, device_map)
+    assert resolved == expected, (
         f"profile {profile.name}, gpu_ids={gpu_ids}, UNSLOTH_AUTO_DEVICE_MAP={opt_in}: "
         f"Unsloth asked for {device_map!r} and the loader produced {resolved!r}"
     )
@@ -472,12 +477,18 @@ def test_studio_placement_survives_the_loader_opt_in(
 @pytest.mark.parametrize("profile", PROFILES, ids = PROFILE_IDS)
 def test_studio_never_speaks_the_planning_sentinel(profile, spoof_hardware):
     """get_device_map is the only thing that names a placement for Unsloth's loads, and
-    "unsloth" is not one of its answers on any backend. If it ever becomes one, the
-    Unsloth-side reasoning above stops holding and this fails first."""
+    the plain "unsloth" sentinel is not one of its answers on any backend.
+
+    That name declines to "sequential", which gives cuda:0 its whole free budget and so
+    puts a model that fits there on one card. Every path the planner vetoes -- a full
+    finetune, an `auto_model` with no `_model_mapping`, a Falcon-H1 checkpoint missing
+    the mamba exclusions -- ends in that fallback, so a multi-GPU ask has to use the
+    name whose fallback still shards.
+    """
     spoof_hardware(profile)
     hw = _import_studio_hardware_module()
     answers = {hw.get_device_map(None), hw.get_device_map([])}
     if hw.get_device() in (hw.DeviceType.CUDA, hw.DeviceType.XPU):
         answers |= {hw.get_device_map([0]), hw.get_device_map([0, 1])}
     assert "unsloth" not in answers
-    assert answers <= {"balanced", "sequential"}
+    assert answers <= {"balanced", "sequential", "unsloth_balanced"}

--- a/tests/test_unsloth_device_map_leaks.py
+++ b/tests/test_unsloth_device_map_leaks.py
@@ -210,3 +210,39 @@ def test_every_planned_map_membership_test_is_guarded_against_a_dict():
                 f"{name}: a membership test on _PLANNED_DEVICE_MAPS with no isinstance "
                 f"guard beside it -- an explicit dict device_map raises TypeError here"
             )
+
+
+def test_sentence_transformer_declines_to_a_value_st_device_normalises():
+    """Whatever planned name is asked for, this loader declines to "sequential".
+
+    `st_device` only normalises dicts, "auto" and "sequential"; anything else reaches
+    `SentenceTransformer(device = ...)` and then `.to(...)`, so declining to "balanced"
+    -- the value that name declines to everywhere else -- would raise on a string that
+    is not a torch device. Nothing is sharded here, so the sharding fallback is wrong.
+    """
+    tree = ast.parse(_source("sentence_transformer.py"))
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "from_pretrained"
+    )
+
+    declines = [
+        ast.unparse(node.value)
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign)
+        and any(getattr(t, "id", None) == "device_map" for t in node.targets)
+        and ast.unparse(node.value) != "requested_device_map(device_map)"
+    ]
+    assert "'sequential'" in declines, "the decline is not a literal 'sequential'"
+    assert "_PLANNED_DEVICE_MAPS[device_map]" not in declines, (
+        "declining to the sharding fallback sends 'balanced' to SentenceTransformer(device=)"
+    )
+
+    whitelists = [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.List)
+        and [getattr(e, "value", None) for e in node.elts] == ["auto", "sequential"]
+    ]
+    assert whitelists, "the st_device whitelist changed; re-check what the decline may be"

--- a/tests/test_unsloth_device_map_leaks.py
+++ b/tests/test_unsloth_device_map_leaks.py
@@ -235,9 +235,9 @@ def test_sentence_transformer_declines_to_a_value_st_device_normalises():
         and ast.unparse(node.value) != "requested_device_map(device_map)"
     ]
     assert "'sequential'" in declines, "the decline is not a literal 'sequential'"
-    assert "_PLANNED_DEVICE_MAPS[device_map]" not in declines, (
-        "declining to the sharding fallback sends 'balanced' to SentenceTransformer(device=)"
-    )
+    assert (
+        "_PLANNED_DEVICE_MAPS[device_map]" not in declines
+    ), "declining to the sharding fallback sends 'balanced' to SentenceTransformer(device=)"
 
     whitelists = [
         node

--- a/tests/test_unsloth_device_map_leaks.py
+++ b/tests/test_unsloth_device_map_leaks.py
@@ -115,7 +115,10 @@ def test_sentence_transformer_never_hands_the_sentinel_to_sentence_transformers(
         for node in ast.walk(function)
         if isinstance(node, ast.Compare)
         and ast.unparse(node.left) == "device_map"
-        and any(ast.unparse(c) == "UNSLOTH_DEVICE_MAP" for c in node.comparators)
+        and any(
+            ast.unparse(c) in ("UNSLOTH_DEVICE_MAP", "_PLANNED_DEVICE_MAPS")
+            for c in node.comparators
+        )
     ]
     assert spends, "the 'unsloth' sentinel reaches SentenceTransformer(device = ...) unresolved"
 
@@ -176,3 +179,36 @@ def test_sentence_transformer_decline_survives_the_env_var():
     assert "os.environ['UNSLOTH_AUTO_DEVICE_MAP']" not in ast.unparse(
         function
     ), "the process-wide pin is back; every other thread sees it"
+
+
+def test_every_planned_map_membership_test_is_guarded_against_a_dict():
+    """`device_map` is a dict as often as it is a string, and dicts are unhashable.
+
+    `{"": 0, "model.vision_tower": 1} in _PLANNED_DEVICE_MAPS` raises TypeError, so an
+    explicit placement -- the one shape a user hand-wrote and most wants honoured -- would
+    fail the load outright. Both call sites take the `isinstance` first for that reason,
+    and there is no way to notice from reading either one alone.
+    """
+    for name in os.listdir(MODELS):
+        if not name.endswith(".py"):
+            continue
+        tree = ast.parse(_source(name))
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Compare)
+                and any(
+                    ast.unparse(c) == "_PLANNED_DEVICE_MAPS" for c in node.comparators
+                )
+            ):
+                continue
+            # One tree, walked twice: a second parse gives different node objects, so
+            # the identity test below would find no parent and pass on anything.
+            parents = [
+                ast.unparse(outer)
+                for outer in ast.walk(tree)
+                if isinstance(outer, ast.BoolOp) and node in ast.walk(outer)
+            ]
+            assert any("isinstance(" in text and ", str)" in text for text in parents), (
+                f"{name}: a membership test on _PLANNED_DEVICE_MAPS with no isinstance "
+                f"guard beside it -- an explicit dict device_map raises TypeError here"
+            )

--- a/tests/test_unsloth_device_map_leaks.py
+++ b/tests/test_unsloth_device_map_leaks.py
@@ -196,9 +196,7 @@ def test_every_planned_map_membership_test_is_guarded_against_a_dict():
         for node in ast.walk(tree):
             if not (
                 isinstance(node, ast.Compare)
-                and any(
-                    ast.unparse(c) == "_PLANNED_DEVICE_MAPS" for c in node.comparators
-                )
+                and any(ast.unparse(c) == "_PLANNED_DEVICE_MAPS" for c in node.comparators)
             ):
                 continue
             # One tree, walked twice: a second parse gives different node objects, so

--- a/tests/test_unsloth_device_map_optin.py
+++ b/tests/test_unsloth_device_map_optin.py
@@ -73,6 +73,8 @@ def _load(
             exec(ast.get_source_segment(_SRC, node), ns)
         elif isinstance(node, ast.Assign) and getattr(node.targets[0], "id", None) in (
             "UNSLOTH_DEVICE_MAP",
+            "UNSLOTH_BALANCED_DEVICE_MAP",
+            "_PLANNED_DEVICE_MAPS",
             "DEFAULT_DEVICE_MAP",
             "_SIZE_UNITS",
         ):
@@ -377,6 +379,74 @@ def test_an_infeasible_plan_is_raised_not_swallowed():
     ns = _load(planner = _infeasible)
     with pytest.raises(DeviceMapInfeasible):
         ns["resolve_unsloth_device_map"]("unsloth", "m")
+
+
+# ------------------------------------------------- the second name, whose decline shards
+
+
+@pytest.mark.parametrize(
+    "kwargs,devices,planner",
+    [
+        ({"skip_reason": "text_only"}, 2, None),
+        ({"fast_inference": True}, 2, None),
+        ({"full_finetuning": True}, 2, None),
+        ({}, 2, lambda *a, **k: None),
+        ({}, 2, lambda *a, **k: (_ for _ in ()).throw(RuntimeError("hub unreachable"))),
+    ],
+)
+def test_the_balanced_sentinel_declines_to_balanced_not_sequential(kwargs, devices, planner):
+    """`"unsloth_balanced"` is the same plan with a different answer when it is declined.
+
+    "sequential" is not a shard: `get_max_memory` gives cuda:0 its whole free budget, so
+    `infer_auto_device_map` fills it first and a model that fits lands there whole. On
+    `unsloth/Qwen2.5-7B-Instruct` in bf16 across two cards, 16 GiB each, "sequential"
+    answers {'0': 1} where "balanced" answers {'0': 13, '1': 19}. A caller that asked to
+    plan across several cards wants a split even when the planner declines, and it
+    declines on more shapes than a caller can enumerate -- a full finetune, an
+    `auto_model` with no `_model_mapping`, a prequantized Falcon-H1 checkpoint.
+    """
+    ns = _load(devices = devices, planner = planner)
+    assert ns["resolve_unsloth_device_map"]("unsloth_balanced", "m", **kwargs) == "balanced"
+    # The plain sentinel is unchanged: an existing caller keeps the answer it had.
+    assert ns["resolve_unsloth_device_map"]("unsloth", "m", **kwargs) == "sequential"
+
+
+@pytest.mark.parametrize("devices", [0, 1])
+def test_the_balanced_sentinel_declines_to_balanced_on_one_device_too(devices):
+    """The silent fallbacks are the easy ones to leave hardcoded, and both were."""
+    ns = _load(devices = devices, planner = lambda *a, **k: pytest.fail("nothing to plan"))
+    assert ns["resolve_unsloth_device_map"]("unsloth_balanced", "m") == "balanced"
+
+
+def test_both_names_plan_identically_when_the_planner_answers():
+    """The name chooses the fallback and nothing else, so a plan is not a second code
+    path that could drift."""
+    planned = {"": 0, "model.vision_tower": 1}
+    for name in ("unsloth", "unsloth_balanced"):
+        ns = _load(planner = lambda *a, **k: _Plan(dict(planned)))
+        assert ns["resolve_unsloth_device_map"](name, "m") == planned
+
+
+def test_an_infeasible_plan_is_still_raised_for_the_balanced_name():
+    """The one deliberate raise must not be softened into a shard by the new name."""
+
+    class DeviceMapInfeasible(RuntimeError):
+        pass
+
+    def _infeasible(*a, **k):
+        raise DeviceMapInfeasible("needs 7.57 GiB free on cuda:0, has 4.10 GiB")
+
+    ns = _load(planner = _infeasible)
+    with pytest.raises(DeviceMapInfeasible):
+        ns["resolve_unsloth_device_map"]("unsloth_balanced", "m")
+
+
+def test_the_default_device_map_still_resolves_to_the_plain_sentinel():
+    """An omitted device_map becomes the planner, and its decline has always been
+    "sequential" -- which is also what an omitted device_map got before planning existed.
+    Widening that to "balanced" would change what every single-card caller loads."""
+    ns = _load()
+    assert ns["requested_device_map"](ns["DEFAULT_DEVICE_MAP"]) == "unsloth"
 
 
 # ------------------------------------------------------------- when it does plan

--- a/tests/test_unsloth_device_map_platform_matrix.py
+++ b/tests/test_unsloth_device_map_platform_matrix.py
@@ -153,6 +153,8 @@ def _build(
             exec(ast.get_source_segment(_SRC, node), ns)
         elif isinstance(node, ast.Assign) and getattr(node.targets[0], "id", None) in (
             "UNSLOTH_DEVICE_MAP",
+            "UNSLOTH_BALANCED_DEVICE_MAP",
+            "_PLANNED_DEVICE_MAPS",
             "DEFAULT_DEVICE_MAP",
             "_SIZE_UNITS",
         ):

--- a/tests/test_unsloth_device_map_review_fixes.py
+++ b/tests/test_unsloth_device_map_review_fixes.py
@@ -91,7 +91,13 @@ def _build(
             or (
                 isinstance(node, ast.Assign)
                 and getattr(node.targets[0], "id", None)
-                in ("UNSLOTH_DEVICE_MAP", "DEFAULT_DEVICE_MAP", "_SIZE_UNITS")
+                in (
+                    "UNSLOTH_DEVICE_MAP",
+                    "UNSLOTH_BALANCED_DEVICE_MAP",
+                    "_PLANNED_DEVICE_MAPS",
+                    "DEFAULT_DEVICE_MAP",
+                    "_SIZE_UNITS",
+                )
             )
         )
         if keep:

--- a/unsloth/models/loader_utils.py
+++ b/unsloth/models/loader_utils.py
@@ -120,6 +120,16 @@ def prepare_device_map():
 
 UNSLOTH_DEVICE_MAP = "unsloth"
 
+# Same planner, different answer when it declines. Every veto path in
+# `resolve_unsloth_device_map` ends in "sequential", which fills the first device to its
+# whole free budget before touching the next one -- right for a loader default, wrong for
+# a caller that picked several cards on their combined capacity and would rather have an
+# even split than a full first card. Naming the fallback is what makes that reachable
+# without every such caller having to enumerate the veto reasons, which are unsloth's and
+# can grow.
+UNSLOTH_BALANCED_DEVICE_MAP = "unsloth_balanced"
+_PLANNED_DEVICE_MAPS = {UNSLOTH_DEVICE_MAP: "sequential", UNSLOTH_BALANCED_DEVICE_MAP: "balanced"}
+
 # A string, not None, so an explicit False stays distinguishable from "unset".
 OFFLOAD_EMBEDDING_AUTO = "auto"
 
@@ -343,12 +353,14 @@ def resolve_unsloth_device_map(
     `skip_reason` is the caller's veto, for when only the caller can tell the planner
     would describe a different model than the load builds.
     """
-    if device_map != UNSLOTH_DEVICE_MAP:
+    # `isinstance` first: a caller's explicit dict is unhashable, so `in` alone raises.
+    if not isinstance(device_map, str) or device_map not in _PLANNED_DEVICE_MAPS:
         return device_map
+    _declined = _PLANNED_DEVICE_MAPS[device_map]
 
     def _fallback(reason):
-        print(f"Unsloth: Not planning a device map; {reason}. Using `sequential`.")
-        return "sequential"
+        print(f"Unsloth: Not planning a device map; {reason}. Using `{_declined}`.")
+        return _declined
 
     if skip_reason is not None:
         return _fallback(skip_reason)
@@ -395,7 +407,7 @@ def resolve_unsloth_device_map(
             and 0 <= device < device_count
         ]
     if len(probe) < 2:
-        return "sequential"
+        return _declined
 
     try:
         from unsloth_zoo.device_map_planner import plan_device_map_for_pretrained
@@ -434,7 +446,7 @@ def resolve_unsloth_device_map(
         return _fallback(f"planning failed ({error})")
 
     if plan is None:
-        return "sequential"
+        return _declined
     print(plan.describe())
     return plan.device_map
 

--- a/unsloth/models/loader_utils.py
+++ b/unsloth/models/loader_utils.py
@@ -120,13 +120,10 @@ def prepare_device_map():
 
 UNSLOTH_DEVICE_MAP = "unsloth"
 
-# Same planner, different answer when it declines. Every veto path in
-# `resolve_unsloth_device_map` ends in "sequential", which fills the first device to its
-# whole free budget before touching the next one -- right for a loader default, wrong for
-# a caller that picked several cards on their combined capacity and would rather have an
-# even split than a full first card. Naming the fallback is what makes that reachable
-# without every such caller having to enumerate the veto reasons, which are unsloth's and
-# can grow.
+# Same planner, different answer when it declines. Every veto path ends in "sequential",
+# which fills the first device to its whole free budget -- right for a loader default,
+# wrong for a caller that picked several cards on their combined capacity. Naming the
+# fallback spares such a caller enumerating veto reasons that are unsloth's and can grow.
 UNSLOTH_BALANCED_DEVICE_MAP = "unsloth_balanced"
 _PLANNED_DEVICE_MAPS = {UNSLOTH_DEVICE_MAP: "sequential", UNSLOTH_BALANCED_DEVICE_MAP: "balanced"}
 

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -17,7 +17,7 @@ import logging
 from .loader import FastModel, DISABLE_SDPA_MODEL_NAMES
 from .loader_utils import (
     DEFAULT_DEVICE_MAP,
-    UNSLOTH_DEVICE_MAP,
+    _PLANNED_DEVICE_MAPS,
     requested_device_map,
     unmarked_device_map,
 )
@@ -1509,12 +1509,14 @@ class FastSentenceTransformer(FastModel):
         # would pull any split model back onto one card. The env-var opt-in is resolved too,
         # or `UNSLOTH_AUTO_DEVICE_MAP=1` asks for a plan without ever naming the sentinel.
         device_map = requested_device_map(device_map)
-        if device_map == UNSLOTH_DEVICE_MAP:
+        # `isinstance` first: a caller's explicit dict is unhashable, so `in` alone raises.
+        if isinstance(device_map, str) and device_map in _PLANNED_DEVICE_MAPS:
+            declined = _PLANNED_DEVICE_MAPS[device_map]
             print(
                 "Unsloth: Not planning a device map; SentenceTransformer moves the assembled "
-                "model onto a single device. Using `sequential`."
+                f"model onto a single device. Using `{declined}`."
             )
-            device_map = "sequential"
+            device_map = declined
 
         # Validate the load modes BEFORE the prefetch so a bad config fails without downloading weights.
         # Guard on not for_inference: that branch below never used these flags.

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1509,14 +1509,17 @@ class FastSentenceTransformer(FastModel):
         # would pull any split model back onto one card. The env-var opt-in is resolved too,
         # or `UNSLOTH_AUTO_DEVICE_MAP=1` asks for a plan without ever naming the sentinel.
         device_map = requested_device_map(device_map)
+        # Always "sequential", never the asked-for name's own declined value: the `st_device`
+        # blocks below normalise only dicts, "auto" and "sequential", so "balanced" would
+        # reach `SentenceTransformer(device = "balanced")` and then `.to("balanced")`, which
+        # is not a torch device. There is nothing to shard here in any case.
         # `isinstance` first: a caller's explicit dict is unhashable, so `in` alone raises.
         if isinstance(device_map, str) and device_map in _PLANNED_DEVICE_MAPS:
-            declined = _PLANNED_DEVICE_MAPS[device_map]
             print(
                 "Unsloth: Not planning a device map; SentenceTransformer moves the assembled "
-                f"model onto a single device. Using `{declined}`."
+                "model onto a single device. Using `sequential`."
             )
-            device_map = declined
+            device_map = "sequential"
 
         # Validate the load modes BEFORE the prefetch so a bad config fails without downloading weights.
         # Guard on not for_inference: that branch below never used these flags.


### PR DESCRIPTION
## Before

`get_device_map` answered `"balanced"` for every multi-GPU host, and on a small or quantized model with a large vocabulary that is not a split.

The mechanism is upstream and acknowledged there. From huggingface/accelerate#3244, which was opened to fix it and never merged:

> For models with a small number of parameters but a large vocabulary size (e.g. *Gemma2 2B*), the `embed_tokens` layer can consume a significant amount of memory. This layer might exceed the `max_memory` limit on the initial devices. As a result, the `infer_auto_device_map` function bypasses all earlier devices, placing the `embed_tokens` layer and all subsequent layers on the last device. A similar issue arises with quantized models. Since embedding layers are often **not quantized**, the `max_memory` per device might be insufficient.

Measured on 2x Tesla T4, `unsloth/Qwen3-0.6B`, `load_in_4bit = True` (the run recorded in #10033), accelerate says so in as many words:

```
Not enough space on 0 to put model.embed_tokens (space available 73161963.2,
module size 155582464.0). This module cannot be split, going to the next device.
```

Every parameter then lands on cuda:1, `clean_device_map` collapses the result to `{"": 1}`, and training dies at the first step:

```
ValueError: You can't train a model that has been loaded in 8-bit or 4-bit
precision on a different device than the one you're training on
```

So the setting whose job is to shard across cards produced a one-card placement that cannot train, and the second card sat empty either way.

## After

CUDA asks for unsloth's own head-aware planner (`device_map = "unsloth"`), which sizes the embedding and the head before the layers instead of discovering afterwards that the head does not fit. Everything else is unchanged.

On the same two 14.56 GiB cards the planner produces a genuine split and says what it did:

```
output head        : lm_head -> cuda:1
head headroom      : 0.359 GiB
tied to head       : ['model.embed_tokens']
  cuda:0  budget 13.10 GiB  weights 0.240 GiB  free 12.864 GiB
  cuda:1  budget 13.10 GiB  weights 0.362 GiB  free 12.742 GiB   <- output head
```

## Is this a real issue, and one honest qualification

The failure is real and was measured, and the mechanism is upstream's own description of it. But it is **stack dependent**, and this PR should not claim otherwise.

Replicating the transformers branch exactly (quantizer-adjusted target dtype, `get_special_dtypes_update`, `get_balanced_memory`, `adjust_max_memory`, `infer_auto_device_map`) on the accelerate installed here, **48 configurations produced zero collapses**: 8 checkpoints x 4 card sizes, plus a sweep of the 0.5-vs-1.0 bytes-per-parameter sizing axis. On accelerate 1.14.0 with transformers 4.57.6, `"balanced"` splits Qwen3-0.6B 8/24 rather than collapsing.

What separates the two is the cuda:0 budget `get_balanced_memory` derives. The hardware run got 73161963 bytes and sized `embed_tokens` at 1.0 byte per parameter; here the budget is 170564443 bytes and the embedding is 0.5 bytes per parameter, so it fits.

Driving `infer_auto_device_map` at the budget the hardware recorded reproduces the collapse exactly, and locates the cliff:

| cuda:0 budget (bytes) | placement | collapsed |
| --- | --- | --- |
| 73161963 (the measured one) | `{'1': 1}` | yes, the whole model on cuda:1 |
| 100000000 | `{'1': 1}` | yes |
| 155582465 | `{'1': 1}` | yes |
| 200000000 | `{'0': 2, '1': 3}` | no |
| 400000000 | `{'0': 15, '1': 17}` | no |

So: the collapse needs a particular library combination to arrive at a tight enough cuda:0 budget, and this change removes the dependence on that arithmetic rather than fixing one version of it.

## Does it break the paths that work today

- **Single GPU** is untouched, on every backend. Verified end to end on this box: Studio answers `"sequential"`, `unsloth/Qwen3-0.6B` in 4bit loads in 7.8s with all 310 parameters on cuda:0 and generates `The capital of France is Paris.`
- **CPU, MLX and Apple** are untouched; they never reach the multi-GPU branch.
- **XPU keeps `"balanced"` deliberately.** The planner has no memory budgets for non-CUDA backends and falls back to `"sequential"` there, so handing it an XPU host would silently collapse the shard onto one device.
- **AMD takes the new branch, and that is intended.** Studio reports a ROCm card as `DeviceType.CUDA`, and unsloth maps its `DEVICE_TYPE` `"hip"` to `DEVICE_TYPE_TORCH` `"cuda"`, so the planner runs there and reads memory through the same `torch.cuda` API. Called out because a reader could reasonably assume otherwise.
- **Old installs cannot see a mismatch.** `pyproject.toml` packages `studio.backend*` inside the `unsloth` distribution, so the backend that asks for `"unsloth"` and the loader that understands it are the same install at the same version.
- **Everything Studio hands a `device_map` to is an unsloth `Fast*` loader** in inference, training and export. Nothing passes it to raw transformers.

## What could go wrong, and what the simulations found

The one way this could break a working path is the string escaping to transformers, which rejects anything outside its four keywords:

```python
elif isinstance(device_map, str) and device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
    try: device_map = {"": torch.device(device_map)}
    except RuntimeError: raise ValueError("... but found unsloth")
```

`torch.device("unsloth")` raises, so a leak is a hard failure. It is therefore checked by execution, not by reading call sites.

| simulation | result |
| --- | --- |
| the sentinel never survives the resolver (12 declining paths, subprocess each) | 12 / 12, all return `"sequential"` |
| every non-sentinel value passes through byte for byte (9 values, strings, dicts and an int) | 9 / 9 |
| `FastLanguageModel`, `FastModel`, `FastVisionModel` with transformers intercepted, 1 real GPU | 3 / 3, `'sequential'` reached transformers |
| the same three with two 14.56 GiB cards spoofed | 3 / 3, a dict spanning cuda:0 and cuda:1 |
| [Windows, Linux, WSL, Mac] x [NVIDIA, AMD, Intel, Apple, CPU] x [1, 2, 8 GPUs, UUID mask] | 80 / 80 cells, and the answer never varies by OS |
| an isolated `uv venv` with `unsloth_zoo==2026.8.2`, which predates the planner | loads, prints `the planner is unavailable`, uses `"sequential"` |
| real load on this box, Studio's own decision, generate | `"sequential"`, 7.8s, 310 params on cuda:0, coherent output |

Two of those need their reasoning stated rather than just their tick.

**Old `unsloth_zoo`.** The planner lives in `unsloth_zoo.device_map_planner`, which versions independently of unsloth. It first appears between zoo `2026.8.2` and `2026.8.9` (measured by inspecting both wheels). The branch's `pyproject.toml` asks for `unsloth_zoo>=2026.8.16`, so pip cannot produce the skew, but `--no-deps` can, and the Colab and Kaggle templates use exactly that. A sandbox built that way degrades cleanly: the import fails, unsloth prints `Not planning a device map; the planner is unavailable (No module named 'unsloth_zoo.device_map_planner'). Using sequential.`, and the load proceeds.

That fallback is only safe if `"sequential"` is still a multi-GPU answer, which it is: transformers takes the same `infer_auto_device_map` path for both and differs only in deriving `max_memory` from `get_max_memory` rather than `get_balanced_memory`. Measured on a 7B in 4bit across two cards:

| card | sequential | balanced |
| --- | --- | --- |
| 3.0 GiB | `{'0': 5, '1': 21, 'disk': 6}` | `{'0': 5, '1': 21, 'disk': 6}` |
| 4.0 GiB | `{'0': 13, '1': 19}` | `{'0': 6, '1': 25, 'disk': 1}` |
| 6.0 GiB | `{'0': 27, '1': 5}` | `{'0': 6, '1': 26}` |

**The planner's refusal.** It raises `DeviceMapInfeasible` rather than spilling a bitsandbytes model to CPU, so the question is whether there is a case where `"balanced"` gives a usable load and the planner does not. Studio's inference path calls `raise_if_offloaded`, which rejects any load with modules on CPU or disk, and bitsandbytes refuses such a map outright, so a spill is already a failure there. Swept across card sizes on a 7B in 4bit:

| card | balanced | usable | planner | usable |
| --- | --- | --- | --- | --- |
| 2.0 GiB | `{'0': 3, '1': 8, 'disk': 21}` | no | refuses | no |
| 3.0 GiB | `{'0': 5, '1': 21, 'disk': 6}` | no | refuses | no |
| 4.0 GiB | `{'0': 6, '1': 25, 'disk': 1}` | no | `{'0': 18, '1': 14}` | **yes** |
| 5.0 GiB and up | `{'0': 6, '1': 26}` | yes | `{'0': 18, '1': 14}` | yes |

**Zero rows** where balanced is usable and the planner is not, and one row where the planner is strictly better. So no fallback is needed on the inference path, and that is a measurement rather than an argument.

## The export retry is widened anyway, for a case a static sweep cannot model

The export already retries on the single-device loader default for OOM, for bitsandbytes' CPU-spill rejection, and for a load that silently offloads. The planner budgets from free memory read **before this process opens a CUDA context**, so a training or chat job holding the other cards can make it refuse a model the old single-device load still fits. That is a live-contention condition, not a placement one, so it does not appear in the sweeps above. `DeviceMapInfeasible` now joins that same retry, matched by class name so the export is not tied to a version that defines it.

Training deliberately does **not** get this. A plan that does not fit becomes an OOM in the middle of a run, and a refusal carrying the numbers is the better answer there.

## Two call sites that would have silently dropped the map

`core/export/export.py` whitelisted the literal `"balanced"`, so the moment CUDA started answering `"unsloth"` the export would have fallen back to the loader default it was added to avoid, with nothing red. Widened to both sharding answers, with a test.

Two comments in `core/training/` named `device_map="balanced"` as the map Unsloth's multi-GPU load uses, while reasoning about transformers setting `_n_gpu = 1` for a model-parallel run. The reasoning is unchanged (the planner also produces a dict map); the names are now accurate.

## Tests

`77 passed` in `test_gpu_selection.py` (81 subtests), `19 passed` in `test_export_multi_gpu_device_map.py`, and the full `studio/backend` suite run against this branch and against `main` produces the **same failures**, so nothing here regresses. New coverage:

- CUDA multi-GPU resolves to `"unsloth"`, including under a UUID/MIG mask
- XPU multi-GPU still resolves to `"balanced"`
- a single GPU never asks for a plan, on either backend
- the full platform x accelerator product, plus an explicit assertion that the answer does not vary by operating system
- the export passes `"unsloth"` through
- `_is_device_map_infeasible` matches by class name, not by message
- a planner refusal retries on the single-device loader; an unrelated error is still reported after one attempt

Every new guard was mutation-tested by reintroducing the bug it catches:

| mutation | caught by |
| --- | --- |
| CUDA back to `"balanced"` | 3 tests |
| `"unsloth"` for every device, XPU included | 9 tests |
| the answer made to vary on Windows | 8 tests |
| a device map string the loader cannot read | 27 tests |
| export whitelist narrowed back to `"balanced"` | 1 test |