### PR TITLE
Studio: resume HTTP after Xet stall without a transport-conflict banner

### DIFF
--- a/studio/frontend/src/features/hub/catalog/download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/download-card.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -57,6 +57,17 @@ export function DownloadCard({
   children: ReactNode;
   dialogs?: ReactNode;
 }) {
+  // This card is the only surface that shows the conflict dialog. Staging and
+  // Chat park useRepoDownload on an idle repo id; clearing from that hook
+  // dropped a recorded conflict before Hub could show it. Clear here when the
+  // card unmounts or the bound conflict key changes (repo / variant).
+  useEffect(
+    () => () => {
+      job.cancelConflict();
+    },
+    [job.cancelConflict],
+  );
+
   return (
     <>
       <div className="hub-download-card">

--- a/studio/frontend/src/features/hub/catalog/download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/download-card.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { type ReactNode, useEffect } from "react";
+import type { ReactNode } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -57,17 +57,6 @@ export function DownloadCard({
   children: ReactNode;
   dialogs?: ReactNode;
 }) {
-  // This card is the only surface that shows the conflict dialog. Staging and
-  // Chat park useRepoDownload on an idle repo id; clearing from that hook
-  // dropped a recorded conflict before Hub could show it. Clear here when the
-  // card unmounts or the bound conflict key changes (repo / variant).
-  useEffect(
-    () => () => {
-      job.cancelConflict();
-    },
-    [job.cancelConflict],
-  );
-
   return (
     <>
       <div className="hub-download-card">

--- a/studio/frontend/src/features/hub/download-manager/constants.ts
+++ b/studio/frontend/src/features/hub/download-manager/constants.ts
@@ -115,6 +115,30 @@ export function isResolvedTransport(
   );
 }
 
+export type MismatchStartAction = ResolvedTransport | "conflict";
+
+/** When a partial on disk was written by a different transport than this start
+ * resolved to, pick whether to continue or ask the user.
+ *
+ * Xet cannot byte-resume. Auto and HTTP follow the stall watchdog's HTTP
+ * fallback instead of parking the start on a Hub dialog Chat/Video cannot
+ * resolve. Only an explicit Xet preference versus an HTTP partial is a real
+ * choice (keep resumable bytes, or restart on Xet). */
+export function mismatchStartAction(
+  preferred: TransportMode,
+  resolved: ResolvedTransport,
+  lastTransport: ResolvedTransport,
+): MismatchStartAction {
+  if (lastTransport === resolved) return resolved;
+  if (lastTransport === TRANSPORT.HTTP) {
+    if (preferred === TRANSPORT.XET && resolved === TRANSPORT.XET) {
+      return "conflict";
+    }
+    return TRANSPORT.HTTP;
+  }
+  return TRANSPORT.HTTP;
+}
+
 export const DOWNLOAD_KIND = {
   MODEL: "model",
   DATASET: "dataset",

--- a/studio/frontend/src/features/hub/download-manager/constants.ts
+++ b/studio/frontend/src/features/hub/download-manager/constants.ts
@@ -122,17 +122,18 @@ export type MismatchStartAction = ResolvedTransport | "conflict";
  *
  * Xet cannot byte-resume. Auto and HTTP follow the stall watchdog's HTTP
  * fallback instead of parking the start on a Hub dialog Chat/Video cannot
- * resolve. Only an explicit Xet preference versus an HTTP partial is a real
- * choice (keep resumable bytes, or restart on Xet). */
+ * resolve. Only an explicit Xet preference versus a resumable HTTP partial is
+ * a real choice (keep resumable bytes, or restart on Xet). */
 export function mismatchStartAction(
   preferred: TransportMode,
   resolved: ResolvedTransport,
   lastTransport: ResolvedTransport,
+  resumable = true,
 ): MismatchStartAction {
   if (lastTransport === resolved) return resolved;
   if (lastTransport === TRANSPORT.HTTP) {
     if (preferred === TRANSPORT.XET && resolved === TRANSPORT.XET) {
-      return "conflict";
+      return resumable ? "conflict" : resolved;
     }
     return TRANSPORT.HTTP;
   }

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -4,7 +4,12 @@
 import { toast } from "@/lib/toast";
 import { disposableTimeoutSignal } from "../lib/abort-signals";
 import { getActiveModelDownloads } from "./api";
-import { TRANSPORT, type TransportMode } from "./constants";
+import {
+  mismatchStartAction,
+  TRANSPORT,
+  type ResolvedTransport,
+  type TransportMode,
+} from "./constants";
 import {
   apiTransportStatusWithRetry,
   effectiveTransportMode,
@@ -61,13 +66,13 @@ function hasActiveOrPendingStart(req: DownloadRequest): boolean {
   );
 }
 
-function asTransportMode(value: unknown): TransportMode | null {
+function asTransportMode(value: unknown): ResolvedTransport | null {
   return value === TRANSPORT.HTTP || value === TRANSPORT.XET ? value : null;
 }
 
 async function activeSiblingTransport(
   req: DownloadRequest,
-): Promise<TransportMode | null> {
+): Promise<ResolvedTransport | null> {
   if (req.kind !== "model" || !req.variant) return null;
   const timeout = disposableTimeoutSignal(TRANSPORT_STATUS_TIMEOUT_MS);
   const downloads = await getActiveModelDownloads(req.repoId, timeout.signal, {
@@ -155,16 +160,17 @@ export async function requestStart(
   // during; read after them it would name the page they moved to.
   const originRoute = currentRoute();
   return runWithPendingStartGuard(req, async () => {
-    let mode: TransportMode = await resolveTransportMode();
+    const preferred: TransportMode = await resolveTransportMode();
+    let mode: TransportMode = preferred;
     try {
-      mode = await effectiveTransportMode(mode);
+      mode = await effectiveTransportMode(preferred);
     } catch (err) {
       console.warn(
         "Transport capability check failed; using the selected transport.",
         err,
       );
     }
-    let siblingTransport: TransportMode | null = null;
+    let siblingTransport: ResolvedTransport | null = null;
     let siblingProbed = false;
     try {
       siblingTransport = await activeSiblingTransport(req);
@@ -183,22 +189,33 @@ export async function requestStart(
     }
     try {
       const status = await apiTransportStatusWithRetry(req);
-      if (
-        status.has_partial &&
-        status.last_transport &&
-        status.last_transport !== mode
-      ) {
-        setConflict(jobKeyOf(req.kind, req.repoId, req.variant), {
-          info: {
-            previous: status.last_transport,
-            next: mode,
-            resumable: status.resumable,
-          },
-          // Without the caller's line: resolved later from the Hub, where "it'll
-          // load automatically" is a promise chat cannot keep. The notice stands.
-          pending: { ...req, callerToast: undefined },
-        });
-        return "conflict";
+      const last = asTransportMode(status.last_transport);
+      const resolved = asTransportMode(mode);
+      if (status.has_partial && last && resolved && last !== resolved) {
+        const action = mismatchStartAction(preferred, resolved, last);
+        if (action === "conflict") {
+          setConflict(jobKeyOf(req.kind, req.repoId, req.variant), {
+            info: {
+              previous: last,
+              next: resolved,
+              resumable: status.resumable,
+            },
+            // Without the caller's line: resolved later from the Hub, where "it'll
+            // load automatically" is a promise chat cannot keep. The notice stands.
+            pending: { ...req, callerToast: undefined },
+          });
+          return "conflict";
+        }
+        if (siblingProbed && siblingTransport && siblingTransport !== action) {
+          toast.info("Another variant is already downloading", {
+            description:
+              siblingTransport === TRANSPORT.XET
+                ? "This repository is currently downloading with Xet. Switch to Xet or wait for it to finish."
+                : "This repository is currently downloading with HTTP. Switch to HTTP or wait for it to finish.",
+          });
+          return "busy";
+        }
+        mode = action;
       }
       if (status.has_partial && !status.last_transport) {
         toast.info("Restarting this download", {

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -175,7 +175,11 @@ export async function requestStart(
     try {
       siblingTransport = await activeSiblingTransport(req);
       siblingProbed = true;
-      if (siblingTransport && siblingTransport !== mode) {
+      if (
+        siblingTransport &&
+        siblingTransport !== mode &&
+        preferred !== TRANSPORT.AUTO
+      ) {
         toast.info("Another variant is already downloading", {
           description:
             siblingTransport === TRANSPORT.XET
@@ -211,15 +215,6 @@ export async function requestStart(
           });
           return "conflict";
         }
-        if (siblingProbed && siblingTransport && siblingTransport !== action) {
-          toast.info("Another variant is already downloading", {
-            description:
-              siblingTransport === TRANSPORT.XET
-                ? "This repository is currently downloading with Xet. Switch to Xet or wait for it to finish."
-                : "This repository is currently downloading with HTTP. Switch to HTTP or wait for it to finish.",
-          });
-          return "busy";
-        }
         mode = action;
       }
       if (status.has_partial && !status.last_transport) {
@@ -251,6 +246,16 @@ export async function requestStart(
           "Starting with the selected transport. If a partial from another transport exists, it may be restarted from the beginning.",
       });
     }
+    if (siblingProbed && siblingTransport && siblingTransport !== mode) {
+      toast.info("Another variant is already downloading", {
+        description:
+          siblingTransport === TRANSPORT.XET
+            ? "This repository is currently downloading with Xet. Switch to Xet or wait for it to finish."
+            : "This repository is currently downloading with HTTP. Switch to HTTP or wait for it to finish.",
+      });
+      return "busy";
+    }
+
     await startJob(req, { useXet: mode === TRANSPORT.XET, originRoute });
     return isJobActiveFor(req) ? "started" : "error";
   });

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -192,7 +192,12 @@ export async function requestStart(
       const last = asTransportMode(status.last_transport);
       const resolved = asTransportMode(mode);
       if (status.has_partial && last && resolved && last !== resolved) {
-        const action = mismatchStartAction(preferred, resolved, last);
+        const action = mismatchStartAction(
+          preferred,
+          resolved,
+          last,
+          status.resumable,
+        );
         if (action === "conflict") {
           setConflict(jobKeyOf(req.kind, req.repoId, req.variant), {
             info: {

--- a/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
+++ b/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useLatestRef } from "../hooks/use-latest-ref";
 import type { ResolvedTransport } from "./constants";
@@ -119,9 +119,25 @@ export function useRepoDownload(config: RepoDownloadConfig): DownloadJob {
     (state) => state.conflicts[conflictKey]?.info ?? null,
   );
 
-  // Do not cancelConflict on unmount or conflictKey change here. Chat and
-  // Video staging reuse this hook and park it on an idle repo id, which would
-  // wipe a start Hub still needs to show. DownloadCard owns that cleanup.
+  // Chat and Video staging park this hook on an idle repo id when the queue
+  // clears. That is not leaving the download surface, so skip cancel there or
+  // Hub never sees the banner. A real unmount or a switch to another repo
+  // still clears: the ref already holds the next id when this cleanup runs.
+  const repoIdRef = useRef(repoId);
+  repoIdRef.current = repoId;
+  useEffect(
+    () => () => {
+      const parked = repoIdRef.current;
+      if (
+        parked === "__staged_download_idle__" ||
+        parked === "__hub_autoload_idle__"
+      ) {
+        return;
+      }
+      downloadManager.cancelConflict(conflictKey);
+    },
+    [conflictKey],
+  );
 
   const requestStartDownload = useCallback(
     async (variant: string | null, expectedBytes: number) => {

--- a/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
+++ b/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
@@ -119,13 +119,6 @@ export function useRepoDownload(config: RepoDownloadConfig): DownloadJob {
     (state) => state.conflicts[conflictKey]?.info ?? null,
   );
 
-  useEffect(
-    () => () => {
-      downloadManager.cancelConflict(conflictKey);
-    },
-    [conflictKey],
-  );
-
   const requestStartDownload = useCallback(
     async (variant: string | null, expectedBytes: number) => {
       // This surface renders the conflict resolver (transportConflict), so the

--- a/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
+++ b/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
@@ -119,6 +119,10 @@ export function useRepoDownload(config: RepoDownloadConfig): DownloadJob {
     (state) => state.conflicts[conflictKey]?.info ?? null,
   );
 
+  // Do not cancelConflict on unmount or conflictKey change here. Chat and
+  // Video staging reuse this hook and park it on an idle repo id, which would
+  // wipe a start Hub still needs to show. DownloadCard owns that cleanup.
+
   const requestStartDownload = useCallback(
     async (variant: string | null, expectedBytes: number) => {
       // This surface renders the conflict resolver (transportConflict), so the

--- a/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
+++ b/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
@@ -11,6 +11,7 @@ import {
   type JobListeners,
   downloadManager,
   jobKeyOf,
+  repoKeyOf,
   selectActiveJob,
   subscribeJobListeners,
   useDownloadManagerStore,
@@ -115,9 +116,24 @@ export function useRepoDownload(config: RepoDownloadConfig): DownloadJob {
     () => jobKeyOf(kind, repoId, activeVariant ?? null),
     [activeVariant, kind, repoId],
   );
-  const transportConflict = useDownloadManagerStore(
-    (state) => state.conflicts[conflictKey]?.info ?? null,
+  const repoConflictKey = useMemo(
+    () => repoKeyOf(kind, repoId),
+    [kind, repoId],
   );
+  const visibleConflict = useDownloadManagerStore(
+    useShallow((state) => {
+      const exact = state.conflicts[conflictKey];
+      if (exact) return { key: conflictKey, info: exact.info };
+      const scoped = Object.entries(state.conflicts).find(([key]) =>
+        key.startsWith(`${repoConflictKey}#`),
+      );
+      return scoped
+        ? { key: scoped[0], info: scoped[1].info }
+        : { key: conflictKey, info: null };
+    }),
+  );
+  const visibleConflictKey = visibleConflict.key;
+  const transportConflict = visibleConflict.info;
 
   // Chat and Video staging park this hook on an idle repo id when the queue
   // clears. Keep that conflict for Hub, but remember its key so a later real
@@ -176,16 +192,16 @@ export function useRepoDownload(config: RepoDownloadConfig): DownloadJob {
   );
 
   const resumeConflict = useCallback(
-    () => downloadManager.resumeConflict(conflictKey),
-    [conflictKey],
+    () => downloadManager.resumeConflict(visibleConflictKey),
+    [visibleConflictKey],
   );
   const restartConflict = useCallback(
-    () => downloadManager.restartConflict(conflictKey),
-    [conflictKey],
+    () => downloadManager.restartConflict(visibleConflictKey),
+    [visibleConflictKey],
   );
   const cancelConflict = useCallback(
-    () => downloadManager.cancelConflict(conflictKey),
-    [conflictKey],
+    () => downloadManager.cancelConflict(visibleConflictKey),
+    [visibleConflictKey],
   );
 
   const progress = useMemo<DownloadJobProgress | null>(

--- a/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
+++ b/studio/frontend/src/features/hub/download-manager/use-repo-download.ts
@@ -120,10 +120,10 @@ export function useRepoDownload(config: RepoDownloadConfig): DownloadJob {
   );
 
   // Chat and Video staging park this hook on an idle repo id when the queue
-  // clears. That is not leaving the download surface, so skip cancel there or
-  // Hub never sees the banner. A real unmount or a switch to another repo
-  // still clears: the ref already holds the next id when this cleanup runs.
+  // clears. Keep that conflict for Hub, but remember its key so a later real
+  // repo replacement clears the superseded request.
   const repoIdRef = useRef(repoId);
+  const preservedConflictKeyRef = useRef<string | null>(null);
   repoIdRef.current = repoId;
   useEffect(
     () => () => {
@@ -132,7 +132,12 @@ export function useRepoDownload(config: RepoDownloadConfig): DownloadJob {
         parked === "__staged_download_idle__" ||
         parked === "__hub_autoload_idle__"
       ) {
+        preservedConflictKeyRef.current = conflictKey;
         return;
+      }
+      if (preservedConflictKeyRef.current) {
+        downloadManager.cancelConflict(preservedConflictKeyRef.current);
+        preservedConflictKeyRef.current = null;
       }
       downloadManager.cancelConflict(conflictKey);
     },

--- a/studio/frontend/tests/download-transport-after-start.test.ts
+++ b/studio/frontend/tests/download-transport-after-start.test.ts
@@ -139,6 +139,13 @@ test("an explicit Xet preference still asks before throwing away HTTP bytes", ()
   );
 });
 
+test("an explicit Xet preference restarts an unresumable HTTP partial", () => {
+  assert.equal(
+    mismatchStartAction(TRANSPORT.XET, TRANSPORT.XET, TRANSPORT.HTTP, false),
+    TRANSPORT.XET,
+  );
+});
+
 test("unavailable Xet with an HTTP partial continues over HTTP", () => {
   // Preference is Xet, but the machine already demoted the resolved transport.
   assert.equal(
@@ -162,7 +169,10 @@ test("a transport mismatch start uses the mismatch helper", () => {
     ),
     "utf8",
   );
-  assert.match(source, /mismatchStartAction\(preferred, resolved, last\)/);
+  assert.match(
+    source,
+    /mismatchStartAction\(\s*preferred,\s*resolved,\s*last,\s*status\.resumable,\s*\)/,
+  );
 });
 
 test("staging an idle repo does not drop a recorded transport conflict", () => {

--- a/studio/frontend/tests/download-transport-after-start.test.ts
+++ b/studio/frontend/tests/download-transport-after-start.test.ts
@@ -4,9 +4,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { readFileSync } from "node:fs";
+
 import {
   adoptedTransports,
+  mismatchStartAction,
   probeDescribesCurrentRun,
+  TRANSPORT,
   transportAfterStart,
 } from "../src/features/hub/download-manager/constants.ts";
 
@@ -101,5 +105,79 @@ test("a reported null with nothing stored still holds no marker", () => {
   assert.deepEqual(
     adoptedTransports({ transport: "http", cancelTransport: null }, undefined),
     { transport: "http", cancelTransport: undefined },
+  );
+});
+
+test("auto continues over HTTP after a Xet stall leftover", () => {
+  // Health demotes Auto to HTTP while the .transport marker is still xet.
+  assert.equal(
+    mismatchStartAction(TRANSPORT.AUTO, TRANSPORT.HTTP, TRANSPORT.XET),
+    TRANSPORT.HTTP,
+  );
+});
+
+test("auto resumes an HTTP partial instead of restarting on Xet", () => {
+  // HTTP fallback already wrote the marker; Auto still resolving to Xet must
+  // not send the user to the Hub conflict banner.
+  assert.equal(
+    mismatchStartAction(TRANSPORT.AUTO, TRANSPORT.XET, TRANSPORT.HTTP),
+    TRANSPORT.HTTP,
+  );
+});
+
+test("an explicit HTTP preference discards a Xet partial without a dialog", () => {
+  assert.equal(
+    mismatchStartAction(TRANSPORT.HTTP, TRANSPORT.HTTP, TRANSPORT.XET),
+    TRANSPORT.HTTP,
+  );
+});
+
+test("an explicit Xet preference still asks before throwing away HTTP bytes", () => {
+  assert.equal(
+    mismatchStartAction(TRANSPORT.XET, TRANSPORT.XET, TRANSPORT.HTTP),
+    "conflict",
+  );
+});
+
+test("unavailable Xet with an HTTP partial continues over HTTP", () => {
+  // Preference is Xet, but the machine already demoted the resolved transport.
+  assert.equal(
+    mismatchStartAction(TRANSPORT.XET, TRANSPORT.HTTP, TRANSPORT.HTTP),
+    TRANSPORT.HTTP,
+  );
+});
+
+test("a matching pair is left alone", () => {
+  assert.equal(
+    mismatchStartAction(TRANSPORT.AUTO, TRANSPORT.XET, TRANSPORT.XET),
+    TRANSPORT.XET,
+  );
+});
+
+test("a transport mismatch start uses the mismatch helper", () => {
+  const source = readFileSync(
+    new URL(
+      "../src/features/hub/download-manager/transport-conflict.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(source, /mismatchStartAction\(preferred, resolved, last\)/);
+});
+
+test("staging an idle repo does not drop a recorded transport conflict", () => {
+  // useStagedDownload parks the hook on __staged_download_idle__ when the
+  // queue clears; cancelling on that key change wiped the conflict Chat/Video
+  // had just recorded, so the Hub card never saw it.
+  const source = readFileSync(
+    new URL(
+      "../src/features/hub/download-manager/use-repo-download.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.doesNotMatch(
+    source,
+    /useEffect\(\s*\(\)\s*=>\s*\(\)\s*=>\s*\{[\s\S]*?cancelConflict\(conflictKey\)/,
   );
 });

--- a/studio/frontend/tests/download-transport-after-start.test.ts
+++ b/studio/frontend/tests/download-transport-after-start.test.ts
@@ -173,9 +173,14 @@ test("a transport mismatch start uses the mismatch helper", () => {
     source,
     /mismatchStartAction\(\s*preferred,\s*resolved,\s*last,\s*status\.resumable,\s*\)/,
   );
+  assert.match(
+    source,
+    /siblingTransport !== mode &&\s*preferred !== TRANSPORT\.AUTO/,
+  );
+  assert.match(source, /mode = action;[\s\S]*?siblingTransport !== mode/);
 });
 
-test("staging preserves idle conflicts but clears them before a replacement", () => {
+test("staging owns cleanup while Hub resolves exact or scoped conflicts", () => {
   const source = readFileSync(
     new URL(
       "../src/features/hub/download-manager/use-repo-download.ts",
@@ -183,8 +188,22 @@ test("staging preserves idle conflicts but clears them before a replacement", ()
     ),
     "utf8",
   );
+  const exactIndex = source.indexOf(
+    "const exact = state.conflicts[conflictKey]",
+  );
+  const scopedIndex = source.indexOf(
+    "const scoped = Object.entries(state.conflicts)",
+  );
+  assert.ok(exactIndex >= 0 && scopedIndex > exactIndex);
   assert.match(source, /__staged_download_idle__/);
   assert.match(source, /__hub_autoload_idle__/);
   assert.match(source, /preservedConflictKeyRef\.current = conflictKey/);
   assert.match(source, /cancelConflict\(preservedConflictKeyRef\.current\)/);
+  assert.match(source, /resumeConflict\(visibleConflictKey\)/);
+  assert.match(source, /restartConflict\(visibleConflictKey\)/);
+  assert.match(source, /cancelConflict\(visibleConflictKey\)/);
+  assert.match(
+    source,
+    /downloadManager\.cancelConflict\(conflictKey\);\s*\},\s*\[conflictKey\]/,
+  );
 });

--- a/studio/frontend/tests/download-transport-after-start.test.ts
+++ b/studio/frontend/tests/download-transport-after-start.test.ts
@@ -168,7 +168,8 @@ test("a transport mismatch start uses the mismatch helper", () => {
 test("staging an idle repo does not drop a recorded transport conflict", () => {
   // useStagedDownload parks the hook on __staged_download_idle__ when the
   // queue clears; cancelling on that key change wiped the conflict Chat/Video
-  // had just recorded, so the Hub card never saw it.
+  // had just recorded, so the Hub card never saw it. Cleanup still runs for a
+  // real repo unmount or repo-id change.
   const source = readFileSync(
     new URL(
       "../src/features/hub/download-manager/use-repo-download.ts",
@@ -176,22 +177,10 @@ test("staging an idle repo does not drop a recorded transport conflict", () => {
     ),
     "utf8",
   );
-  assert.doesNotMatch(
-    source,
-    /useEffect\(\s*\(\)\s*=>\s*\(\)\s*=>\s*\{[\s\S]*?cancelConflict\(conflictKey\)/,
-  );
-});
-
-test("the Hub download card still clears a conflict on unmount or key change", () => {
-  const source = readFileSync(
-    new URL(
-      "../src/features/hub/catalog/download-card.tsx",
-      import.meta.url,
-    ),
-    "utf8",
-  );
+  assert.match(source, /__staged_download_idle__/);
+  assert.match(source, /__hub_autoload_idle__/);
   assert.match(
     source,
-    /useEffect\(\s*\(\)\s*=>\s*\(\)\s*=>\s*\{[\s\S]*?job\.cancelConflict\(\)/,
+    /useEffect\(\s*\(\)\s*=>\s*\(\)\s*=>\s*\{[\s\S]*?cancelConflict\(conflictKey\)/,
   );
 });

--- a/studio/frontend/tests/download-transport-after-start.test.ts
+++ b/studio/frontend/tests/download-transport-after-start.test.ts
@@ -175,11 +175,7 @@ test("a transport mismatch start uses the mismatch helper", () => {
   );
 });
 
-test("staging an idle repo does not drop a recorded transport conflict", () => {
-  // useStagedDownload parks the hook on __staged_download_idle__ when the
-  // queue clears; cancelling on that key change wiped the conflict Chat/Video
-  // had just recorded, so the Hub card never saw it. Cleanup still runs for a
-  // real repo unmount or repo-id change.
+test("staging preserves idle conflicts but clears them before a replacement", () => {
   const source = readFileSync(
     new URL(
       "../src/features/hub/download-manager/use-repo-download.ts",
@@ -189,8 +185,6 @@ test("staging an idle repo does not drop a recorded transport conflict", () => {
   );
   assert.match(source, /__staged_download_idle__/);
   assert.match(source, /__hub_autoload_idle__/);
-  assert.match(
-    source,
-    /useEffect\(\s*\(\)\s*=>\s*\(\)\s*=>\s*\{[\s\S]*?cancelConflict\(conflictKey\)/,
-  );
+  assert.match(source, /preservedConflictKeyRef\.current = conflictKey/);
+  assert.match(source, /cancelConflict\(preservedConflictKeyRef\.current\)/);
 });

--- a/studio/frontend/tests/download-transport-after-start.test.ts
+++ b/studio/frontend/tests/download-transport-after-start.test.ts
@@ -181,3 +181,17 @@ test("staging an idle repo does not drop a recorded transport conflict", () => {
     /useEffect\(\s*\(\)\s*=>\s*\(\)\s*=>\s*\{[\s\S]*?cancelConflict\(conflictKey\)/,
   );
 });
+
+test("the Hub download card still clears a conflict on unmount or key change", () => {
+  const source = readFileSync(
+    new URL(
+      "../src/features/hub/catalog/download-card.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /useEffect\(\s*\(\)\s*=>\s*\(\)\s*=>\s*\{[\s\S]*?job\.cancelConflict\(\)/,
+  );
+});


### PR DESCRIPTION
Fixes the desktop download loop reported in https://github.com/unslothai/unsloth/issues/10024.

After a Xet stall the watchdog falls back to HTTP, which leaves a `.transport` marker that no longer matches Auto/Xet. The next start from Chat, Video, or a staged Hub pick then returned `conflict` and showed *Resume this download from Models — An earlier partial download used a different transport*. Staging also parked the download hook on an idle repo id, which cancelled the conflict before the Hub card could show it.

This change:
- Continues over HTTP when Auto/HTTP hits a leftover Xet or HTTP partial (Xet cannot byte-resume; HTTP fallback progress is kept).
- Still asks only when the user explicitly chose Xet and a resumable HTTP partial exists.
- Stops dropping a recorded conflict when the staged-download hook goes idle.