### PR TITLE
Use the plain download icon in the Hub On Device views

### DIFF
--- a/studio/frontend/src/features/hub/catalog/models-catalog-lists.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-catalog-lists.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/features/model-picker";
 import {
   CubeIcon,
-  DownloadCircle02Icon,
+  Download01Icon,
   PinIcon,
   Search01Icon,
 } from "@hugeicons/core-free-icons";
@@ -453,7 +453,7 @@ export function DownloadedList({
     }
     return (
       <EmptyState
-        icon={query.trim() ? Search01Icon : DownloadCircle02Icon}
+        icon={query.trim() ? Search01Icon : Download01Icon}
         title={query.trim() ? "No matches on device" : "Nothing on device yet"}
         body={
           query.trim()

--- a/studio/frontend/src/features/hub/catalog/on-device-folders-dialog.tsx
+++ b/studio/frontend/src/features/hub/catalog/on-device-folders-dialog.tsx
@@ -38,7 +38,7 @@ import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import {
   Delete02Icon,
-  DownloadCircle01Icon,
+  Download01Icon,
   FileSearchIcon,
   FolderAddIcon,
   FolderExportIcon,
@@ -276,7 +276,7 @@ export function OnDeviceFoldersDialog({
             <div className="rounded-[14px] border border-border/70 bg-muted/20 p-3">
               <div className="mb-2 flex items-center gap-2 text-ui-12 font-medium text-foreground">
                 <HugeiconsIcon
-                  icon={DownloadCircle01Icon}
+                  icon={Download01Icon}
                   strokeWidth={1.75}
                   className="size-3.5 text-muted-foreground"
                 />


### PR DESCRIPTION
## What

Swaps two enclosed-circle download icons in the Hub On Device area for `Download01Icon`, the plain tray-and-arrow icon the rest of the app uses.

- `models-catalog-lists.tsx` : the "Nothing on device yet" empty state, was `DownloadCircle02Icon`
- `on-device-folders-dialog.tsx` : the small icon on the "Download location" row, was `DownloadCircle01Icon`

## Why

`Download01Icon` is used in roughly seventy places across the app. These two circle variants were the only ones of their kind, and the empty state in particular reads as a different icon family from everything around it.

That is now every enclosed-circle download icon in the codebase; none remain.

## Left alone

`DownloadSquare01Icon` on the **Export** sidebar entry, in the two places that have to stay in sync (`app-sidebar.tsx` and `sidebar-nav-customizer.tsx`).

That one is a navigation identity for the Export page, sitting in a set where every sibling is its own distinct pictogram (dashboard, image, test tube, film slate, audio wave, chef hat, globe), rather than a download affordance like the two above. Changing it would alter the sidebar's look, which felt out of scope here. Happy to fold it in if we would rather it match.

Separately, the `DownloadIcon` references in `prompt-storage-dialog.tsx` and `tool-code-cell.tsx` come from lucide-react rather than Hugeicons, so they are unrelated.

## Tests

Typecheck clean. eslint unchanged from baseline on both files (2 pre-existing errors, untouched).
