### PR TITLE
Say why Studio could not enumerate a GPU, instead of just logging []

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8964,6 +8964,66 @@ class LlamaCppBackend:
             return []
 
     @staticmethod
+    def _explain_empty_gpu_probe(binary: Optional[str] = None) -> str:
+        """Why ``_get_gpu_memory`` came back empty, as one short phrase.
+
+        The probe returns ``[]`` for at least six unrelated reasons -- no torch, a
+        torch without CUDA/HIP, an empty or mismatched visibility mask, the #7624
+        arch gate dropping every card, amd-smi declining, or genuinely no device --
+        and every one of them lands the model on the CPU. A user's log recorded the
+        verdict and none of the reason, so "why did my model go to RAM" could not be
+        answered from it at all.
+
+        Facts only, gathered cheaply: no ``mem_get_info`` call, so this never creates
+        the HIP primary context the amd-smi branch exists to avoid. Never raises, and
+        never returns "" -- an unexplained empty list is the thing being fixed.
+        """
+        try:
+            binary = binary or LlamaCppBackend._find_llama_server_binary()
+            if LlamaCppBackend._is_vulkan_backend(binary):
+                return "the Vulkan probe reported no device"
+
+            masks = []
+            for var in (
+                "CUDA_VISIBLE_DEVICES",
+                "HIP_VISIBLE_DEVICES",
+                "ROCR_VISIBLE_DEVICES",
+                "GPU_DEVICE_ORDINAL",
+            ):
+                raw = os.environ.get(var)
+                if raw is not None:
+                    masks.append(f"{var}={raw!r}" if raw.strip() else f"{var} is empty")
+            mask_note = f" ({', '.join(masks)})" if masks else ""
+
+            try:
+                import torch
+            except Exception:  # noqa: BLE001
+                return f"torch is not importable, so no GPU could be enumerated{mask_note}"
+            if not hasattr(torch, "cuda") or not torch.cuda.is_available():
+                return f"torch reports no usable CUDA or HIP device{mask_note}"
+            # Counting devices does not create a context; reading their memory would.
+            count = torch.cuda.device_count()
+            if not count:
+                return f"torch enumerated 0 devices{mask_note}"
+
+            if LlamaCppBackend._torch_is_rocm(torch):
+                coverage = LlamaCppBackend._installed_llama_gfx_archs(binary)
+                if coverage:
+                    present = sorted(set(LlamaCppBackend._rocm_arch_by_physical_id().values()))
+                    if present and not (set(present) & set(coverage)):
+                        return (
+                            f"the installed llama.cpp build covers {sorted(coverage)} but this "
+                            f"host has {present}, so the arch gate dropped every device"
+                        )
+                return (
+                    f"torch sees {count} ROCm device(s) but the probe returned none, so "
+                    f"amd-smi and the torch fallback both declined{mask_note}"
+                )
+            return f"torch sees {count} device(s) but the probe returned none{mask_note}"
+        except Exception as e:  # noqa: BLE001 -- diagnostics must not break a load
+            return f"the reason could not be determined ({type(e).__name__})"
+
+    @staticmethod
     def _get_gpu_memory(
         binary: Optional[str] = None, *, for_llama_server: bool = False
     ) -> list[tuple[int, int, int]]:
@@ -20155,6 +20215,15 @@ class LlamaCppBackend:
                         # --fit flag state, not "does it fit": off means this subset provably fits.
                         f"GPUs free: {gpus}, selected: {gpu_indices}, --fit: {'on' if use_fit else 'off'}"
                     )
+                    if not gpus and not _arch_gate_forced_cpu:
+                        # Above info, because this is the whole difference between a
+                        # GPU load and a CPU one. The arch gate already warns with a
+                        # better message when it is the cause, so do not repeat it.
+                        logger.warning(
+                            "No GPU was available for this load, so llama.cpp will run "
+                            "on the CPU and the model will live in system RAM: %s",
+                            LlamaCppBackend._explain_empty_gpu_probe(binary),
+                        )
                     # The planner ran to completion over a real device list and
                     # left --fit on, i.e. it could not prove the model fits. THAT
                     # is a partial-placement verdict. Set last, so any early

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8994,10 +8994,12 @@ class LlamaCppBackend:
         """
         try:
             binary = binary or LlamaCppBackend._find_llama_server_binary()
-            if sys.platform == "darwin":
-                # Not a CPU verdict: this probe only ever sees CUDA and HIP, so it is
-                # empty on every Mac, and an Apple Silicon one still offloads to Metal.
-                return "this probe reads CUDA and HIP only; macOS offloads through Metal"
+            if _metal_capable_host():
+                # Not a CPU verdict: the probe reads CUDA and HIP, so it is empty on
+                # every Mac, and an Apple Silicon one still offloads to Metal. Same
+                # check as the load site, so an Intel Mac -- which auto_detect_backend
+                # resolves to CPU -- falls through and gets its real reason instead.
+                return "this probe reads CUDA and HIP only; Apple Silicon offloads through Metal"
             if LlamaCppBackend._is_vulkan_backend(binary):
                 return "the Vulkan probe reported no device"
 
@@ -20240,11 +20242,13 @@ class LlamaCppBackend:
                         and not _arch_gate_forced_cpu
                         and not _metal_capable_host()
                     ):
-                        # States what this process observed, and stops there. It does
-                        # NOT say the model will run on the CPU: llama.cpp enumerates
-                        # devices itself and still gets --fit on, so it can place on a
-                        # GPU this probe never saw. An explicit gpu_ids pick is pinned
-                        # for the child further below, which is why it is excluded too.
+                        # States what this process observed, and stops there. It says
+                        # nothing about where the model ends up or what runs it: llama.cpp
+                        # enumerates devices itself, and whether the fitter runs is not
+                        # known here either, since a last-wins --fit off in extra_args is
+                        # appended to the command much further down (the later code asks
+                        # fit_is_effectively_on for exactly that reason). An explicit
+                        # gpu_ids pick is pinned for the child below, so it is excluded.
                         #
                         # _detected_gpus, not gpus: both Manual modes empty `gpus` on
                         # purpose to stand the planner down, and the GPU is fully used
@@ -20256,8 +20260,8 @@ class LlamaCppBackend:
                         # this line (auto_detect_backend picks Metal on is_apple_silicon
                         # and falls back to CPU otherwise).
                         logger.warning(
-                            "Studio could not enumerate any GPU, so it planned this load "
-                            "blind and left placement to llama.cpp --fit: %s",
+                            "Studio could not enumerate any GPU, so this load was planned "
+                            "without device information: %s",
                             LlamaCppBackend._explain_empty_gpu_probe(binary),
                         )
                     # The planner ran to completion over a real device list and

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5509,12 +5509,8 @@ _PROC_ROOT = "/proc"
 
 
 def _metal_capable_host() -> bool:
-    """True where an empty CUDA/HIP probe still means GPU offload, i.e. Apple Silicon.
-
-    Not ``sys.platform == "darwin"``: auto_detect_backend picks Metal only on Apple
-    Silicon and falls back to CPU otherwise, so an Intel Mac with an empty probe really
-    is CPU-only and wants the diagnostic.
-    """
+    """Apple Silicon, where an empty CUDA/HIP probe still means GPU offload. Not
+    ``darwin``: auto_detect_backend resolves an Intel Mac to CPU, which wants the line."""
     try:
         from utils.hardware import is_apple_silicon
         return bool(is_apple_silicon())
@@ -8981,24 +8977,15 @@ class LlamaCppBackend:
     def _explain_empty_gpu_probe(binary: Optional[str] = None) -> str:
         """Why ``_get_gpu_memory`` came back empty, as one short phrase.
 
-        The probe returns ``[]`` for at least six unrelated reasons -- no torch, a
-        torch without CUDA/HIP, an empty or mismatched visibility mask, the #7624
-        arch gate dropping every card, amd-smi declining, or genuinely no device --
-        and every one of them lands the model on the CPU. A user's log recorded the
-        verdict and none of the reason, so "why did my model go to RAM" could not be
-        answered from it at all.
-
-        Facts only, gathered cheaply: no ``mem_get_info`` call, so this never creates
-        the HIP primary context the amd-smi branch exists to avoid. Never raises, and
-        never returns "" -- an unexplained empty list is the thing being fixed.
+        Six unrelated causes share that one empty list -- no torch, no usable device, a
+        stale visibility mask, the #7624 arch gate, amd-smi declining, or no GPU at all --
+        and they need different fixes. No ``mem_get_info`` call, so this never creates the
+        HIP context the amd-smi branch avoids. Never raises, never returns "".
         """
         try:
             binary = binary or LlamaCppBackend._find_llama_server_binary()
             if _metal_capable_host():
-                # Not a CPU verdict: the probe reads CUDA and HIP, so it is empty on
-                # every Mac, and an Apple Silicon one still offloads to Metal. Same
-                # check as the load site, so an Intel Mac -- which auto_detect_backend
-                # resolves to CPU -- falls through and gets its real reason instead.
+                # Same check as the load site: an Intel Mac wants its real reason.
                 return "this probe reads CUDA and HIP only; Apple Silicon offloads through Metal"
             if LlamaCppBackend._is_vulkan_backend(binary):
                 return "the Vulkan probe reported no device"
@@ -20242,23 +20229,9 @@ class LlamaCppBackend:
                         and not _arch_gate_forced_cpu
                         and not _metal_capable_host()
                     ):
-                        # States what this process observed, and stops there. It says
-                        # nothing about where the model ends up or what runs it: llama.cpp
-                        # enumerates devices itself, and whether the fitter runs is not
-                        # known here either, since a last-wins --fit off in extra_args is
-                        # appended to the command much further down (the later code asks
-                        # fit_is_effectively_on for exactly that reason). An explicit
-                        # gpu_ids pick is pinned for the child below, so it is excluded.
-                        #
-                        # _detected_gpus, not gpus: both Manual modes empty `gpus` on
-                        # purpose to stand the planner down, and the GPU is fully used
-                        # there. The arch gate already warns better when it is the cause.
-                        #
-                        # Apple Silicon, not darwin: the probe reads CUDA and HIP, so it
-                        # is empty on every Mac, but only an Apple Silicon one is
-                        # offloading to Metal. An Intel Mac really is CPU-only and wants
-                        # this line (auto_detect_backend picks Metal on is_apple_silicon
-                        # and falls back to CPU otherwise).
+                        # Claims no placement: llama.cpp enumerates devices itself.
+                        # _detected_gpus, not gpus: Manual modes empty gpus on purpose.
+                        # gpu_ids is pinned for the child below; the arch gate warns better.
                         logger.warning(
                             "Studio could not enumerate any GPU, so this load was planned "
                             "without device information: %s",

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8980,6 +8980,10 @@ class LlamaCppBackend:
         """
         try:
             binary = binary or LlamaCppBackend._find_llama_server_binary()
+            if sys.platform == "darwin":
+                # Not a CPU verdict: this probe only ever sees CUDA and HIP, so it is
+                # empty on every Mac, and an Apple Silicon one still offloads to Metal.
+                return "this probe reads CUDA and HIP only; macOS offloads through Metal"
             if LlamaCppBackend._is_vulkan_backend(binary):
                 return "the Vulkan probe reported no device"
 
@@ -20215,10 +20219,15 @@ class LlamaCppBackend:
                         # --fit flag state, not "does it fit": off means this subset provably fits.
                         f"GPUs free: {gpus}, selected: {gpu_indices}, --fit: {'on' if use_fit else 'off'}"
                     )
-                    if not gpus and not _arch_gate_forced_cpu:
+                    if not gpus and not _arch_gate_forced_cpu and sys.platform != "darwin":
                         # Above info, because this is the whole difference between a
                         # GPU load and a CPU one. The arch gate already warns with a
                         # better message when it is the cause, so do not repeat it.
+                        #
+                        # Never on macOS: this probe only ever sees CUDA and HIP, so it
+                        # is empty on every Mac, including an Apple Silicon one whose
+                        # model is about to run entirely on the Metal GPU. Warning
+                        # there would state the opposite of what happens.
                         logger.warning(
                             "No GPU was available for this load, so llama.cpp will run "
                             "on the CPU and the model will live in system RAM: %s",

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5517,7 +5517,6 @@ def _metal_capable_host() -> bool:
     """
     try:
         from utils.hardware import is_apple_silicon
-
         return bool(is_apple_silicon())
     except Exception:  # noqa: BLE001 -- a diagnostic must not break a load
         return sys.platform == "darwin"

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5508,6 +5508,21 @@ class CountAborted(Exception):
 _PROC_ROOT = "/proc"
 
 
+def _metal_capable_host() -> bool:
+    """True where an empty CUDA/HIP probe still means GPU offload, i.e. Apple Silicon.
+
+    Not ``sys.platform == "darwin"``: auto_detect_backend picks Metal only on Apple
+    Silicon and falls back to CPU otherwise, so an Intel Mac with an empty probe really
+    is CPU-only and wants the diagnostic.
+    """
+    try:
+        from utils.hardware import is_apple_silicon
+
+        return bool(is_apple_silicon())
+    except Exception:  # noqa: BLE001 -- a diagnostic must not break a load
+        return sys.platform == "darwin"
+
+
 class LlamaCppBackend:
     """Manages a llama-server subprocess for GGUF model inference.
 
@@ -20222,30 +20237,28 @@ class LlamaCppBackend:
                     if (
                         not gpus
                         and not _detected_gpus
+                        and not gpu_ids
                         and not _arch_gate_forced_cpu
-                        and sys.platform != "darwin"
+                        and not _metal_capable_host()
                     ):
-                        # Above info, because this is the whole difference between a
-                        # GPU load and a CPU one. The arch gate already warns with a
-                        # better message when it is the cause, so do not repeat it.
+                        # States what this process observed, and stops there. It does
+                        # NOT say the model will run on the CPU: llama.cpp enumerates
+                        # devices itself and still gets --fit on, so it can place on a
+                        # GPU this probe never saw. An explicit gpu_ids pick is pinned
+                        # for the child further below, which is why it is excluded too.
                         #
                         # _detected_gpus, not gpus: both Manual modes empty `gpus` on
-                        # purpose to stand the Python planner down and let --fit or an
-                        # explicit --gpu-layers place the model, and the GPU is fully
-                        # used there. Reading `gpus` alone would warn "running on the
-                        # CPU" at every Manual load, which is where this started -- the
-                        # reporting user's own log shows `GPUs free: []` directly under
-                        # "Manual mode with Auto layers hands memory management to
-                        # llama.cpp --fit", so their empty list was this, not a probe
-                        # that failed.
+                        # purpose to stand the planner down, and the GPU is fully used
+                        # there. The arch gate already warns better when it is the cause.
                         #
-                        # Never on macOS: this probe only ever sees CUDA and HIP, so it
-                        # is empty on every Mac, including an Apple Silicon one whose
-                        # model is about to run entirely on the Metal GPU. Warning
-                        # there would state the opposite of what happens.
+                        # Apple Silicon, not darwin: the probe reads CUDA and HIP, so it
+                        # is empty on every Mac, but only an Apple Silicon one is
+                        # offloading to Metal. An Intel Mac really is CPU-only and wants
+                        # this line (auto_detect_backend picks Metal on is_apple_silicon
+                        # and falls back to CPU otherwise).
                         logger.warning(
-                            "No GPU was available for this load, so llama.cpp will run "
-                            "on the CPU and the model will live in system RAM: %s",
+                            "Studio could not enumerate any GPU, so it planned this load "
+                            "blind and left placement to llama.cpp --fit: %s",
                             LlamaCppBackend._explain_empty_gpu_probe(binary),
                         )
                     # The planner ran to completion over a real device list and

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -20219,10 +20219,25 @@ class LlamaCppBackend:
                         # --fit flag state, not "does it fit": off means this subset provably fits.
                         f"GPUs free: {gpus}, selected: {gpu_indices}, --fit: {'on' if use_fit else 'off'}"
                     )
-                    if not gpus and not _arch_gate_forced_cpu and sys.platform != "darwin":
+                    if (
+                        not gpus
+                        and not _detected_gpus
+                        and not _arch_gate_forced_cpu
+                        and sys.platform != "darwin"
+                    ):
                         # Above info, because this is the whole difference between a
                         # GPU load and a CPU one. The arch gate already warns with a
                         # better message when it is the cause, so do not repeat it.
+                        #
+                        # _detected_gpus, not gpus: both Manual modes empty `gpus` on
+                        # purpose to stand the Python planner down and let --fit or an
+                        # explicit --gpu-layers place the model, and the GPU is fully
+                        # used there. Reading `gpus` alone would warn "running on the
+                        # CPU" at every Manual load, which is where this started -- the
+                        # reporting user's own log shows `GPUs free: []` directly under
+                        # "Manual mode with Auto layers hands memory management to
+                        # llama.cpp --fit", so their empty list was this, not a probe
+                        # that failed.
                         #
                         # Never on macOS: this probe only ever sees CUDA and HIP, so it
                         # is empty on every Mac, including an Apple Silicon one whose

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -20,6 +20,7 @@ import types
 
 import pytest
 
+from core.inference import llama_cpp as mod
 from core.inference.llama_cpp import LlamaCppBackend
 
 
@@ -79,7 +80,17 @@ def _load_site_guard() -> str:
     while start >= 0 and not lines[start].lstrip().startswith("if "):
         start -= 1
     assert start >= 0, "no enclosing if statement"
-    return textwrap.dedent("\n".join(lines[start : hit + 1]))
+    # Forward to the END of the block, not just to the marker line. Stopping at the
+    # marker cut the message's own continuation literal out of the extract, so a mutant
+    # that rewrote it went undetected -- the test read a line that had not changed.
+    base = len(lines[start]) - len(lines[start].lstrip())
+    end = hit
+    while end + 1 < len(lines):
+        nxt = lines[end + 1]
+        if nxt.strip() and (len(nxt) - len(nxt.lstrip())) <= base:
+            break
+        end += 1
+    return textwrap.dedent("\n".join(lines[start : end + 1]))
 
 
 class TestItNamesTheCause:
@@ -210,6 +221,7 @@ class TestMacOSIsNotACpuVerdict:
     @pytest.mark.parametrize("torch_state", ["absent", "no_cuda", "rocm_like"])
     def test_the_reason_names_metal_rather_than_blaming_torch(self, monkeypatch, torch_state):
         _clear_masks(monkeypatch)
+        monkeypatch.setattr(mod, "_metal_capable_host", lambda: True)
         monkeypatch.setattr(sys, "platform", "darwin")
         monkeypatch.setitem(
             sys.modules,
@@ -269,7 +281,7 @@ class TestItDoesNotAssertTheLaunchOutcome:
             line for line in _load_site_guard().splitlines() if not line.lstrip().startswith("#")
         )
         assert "could not enumerate any GPU" in body
-        for claim in ("will run on the CPU", "live in system RAM"):
+        for claim in ("will run on the CPU", "live in system RAM", "left placement to"):
             assert claim not in body, f"the message must not assert {claim!r}"
 
     def test_an_explicit_gpu_pick_is_excluded(self):
@@ -287,3 +299,55 @@ class TestItDoesNotAssertTheLaunchOutcome:
         restore = src.find("gpu_indices = sorted(gpu_ids)")
         assert warn != -1 and restore != -1
         assert warn < restore, "if the pin moved above the warning, re-derive this guard"
+
+
+class TestIntelMacGetsItsRealReason:
+    """The load site warns on an Intel Mac, since auto_detect_backend resolves it to CPU.
+    The explainer has to agree: a blanket Darwin branch would answer "macOS offloads
+    through Metal" on a host that offloads through nothing."""
+
+    def test_an_intel_mac_does_not_get_the_metal_answer(self, monkeypatch):
+        _clear_masks(monkeypatch)
+        monkeypatch.setattr(mod, "_metal_capable_host", lambda: False)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(available = False))
+        msg = LlamaCppBackend._explain_empty_gpu_probe()
+        assert "Metal" not in msg, "an Intel Mac is not offloading to Metal"
+        assert "no usable CUDA or HIP" in msg
+
+    def test_apple_silicon_still_gets_it(self, monkeypatch):
+        _clear_masks(monkeypatch)
+        monkeypatch.setattr(mod, "_metal_capable_host", lambda: True)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(available = False))
+        assert "Metal" in LlamaCppBackend._explain_empty_gpu_probe()
+
+    def test_the_explainer_and_the_load_site_use_the_same_check(self):
+        """Two different notions of "is this Mac fine" is how they drifted apart."""
+        import inspect
+
+        src = inspect.getsource(mod.LlamaCppBackend._explain_empty_gpu_probe)
+        assert "_metal_capable_host()" in src
+        assert 'sys.platform == "darwin"' not in src
+        assert "_metal_capable_host()" in _load_site_guard()
+
+
+class TestItDoesNotClaimTheFitterRuns:
+    """use_fit is the internal default, read before extra_args are appended to the
+    command; a last-wins ``--fit off`` there wins. The later code asks
+    fit_is_effectively_on for exactly this distinction, and cmd does not exist yet at
+    the warning, so the message must not mention the fitter at all."""
+
+    def test_the_message_does_not_mention_fit(self):
+        body = "\n".join(
+            line for line in _load_site_guard().splitlines() if not line.lstrip().startswith("#")
+        )
+        assert "--fit" not in body
+
+    def test_the_command_is_built_after_the_warning(self):
+        import inspect
+
+        src = inspect.getsource(mod.LlamaCppBackend.load_model)
+        assert src.find("could not enumerate any GPU") < src.find("_fitter_runs = fit_is_effectively_on"), (
+            "if the effective fitter state became available above the warning, re-derive this"
+        )

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""_explain_empty_gpu_probe: why _get_gpu_memory came back empty.
+
+From a real report. A user's model ran on the CPU and their whole log said:
+
+    GGUF size: 16.4 GB, ... GPUs free: [], selected: None, --fit: on
+    Load mode: the whole load (34.3 GB) fits without paging
+
+which records the verdict and none of the reason, so the question actually being
+asked -- why did my model go to system RAM -- could not be answered from it. The
+probe returns [] for at least six unrelated reasons and every one lands on the CPU;
+these tests pin that each names itself, and that the explainer never creates the HIP
+context the amd-smi branch exists to avoid.
+"""
+
+import sys
+import types
+
+import pytest
+
+from core.inference.llama_cpp import LlamaCppBackend
+
+
+def _fake_torch(*, available = True, count = 2, rocm = True):
+    cuda = types.SimpleNamespace(
+        is_available = lambda: available,
+        device_count = lambda: count,
+        mem_get_info = lambda i: (_ for _ in ()).throw(
+            AssertionError("mem_get_info must not be called: it creates a HIP context")
+        ),
+    )
+    return types.SimpleNamespace(
+        cuda = cuda,
+        version = types.SimpleNamespace(hip = "6.2" if rocm else None, cuda = None if rocm else "12.4"),
+    )
+
+
+@pytest.fixture(autouse = True)
+def _not_vulkan(monkeypatch):
+    monkeypatch.setattr(LlamaCppBackend, "_is_vulkan_backend", staticmethod(lambda b = None: False))
+    monkeypatch.setattr(
+        LlamaCppBackend, "_find_llama_server_binary", staticmethod(lambda: "/opt/llama-server")
+    )
+
+
+def _clear_masks(monkeypatch):
+    for var in (
+        "CUDA_VISIBLE_DEVICES",
+        "HIP_VISIBLE_DEVICES",
+        "ROCR_VISIBLE_DEVICES",
+        "GPU_DEVICE_ORDINAL",
+    ):
+        monkeypatch.delenv(var, raising = False)
+
+
+class TestItNamesTheCause:
+    def test_a_vulkan_build_says_so(self, monkeypatch):
+        monkeypatch.setattr(
+            LlamaCppBackend, "_is_vulkan_backend", staticmethod(lambda b = None: True)
+        )
+        assert "Vulkan" in LlamaCppBackend._explain_empty_gpu_probe()
+
+    def test_no_torch_at_all(self, monkeypatch):
+        _clear_masks(monkeypatch)
+        monkeypatch.setitem(sys.modules, "torch", None)
+        assert "torch is not importable" in LlamaCppBackend._explain_empty_gpu_probe()
+
+    def test_torch_without_a_usable_device(self, monkeypatch):
+        _clear_masks(monkeypatch)
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(available = False))
+        assert "no usable CUDA or HIP device" in LlamaCppBackend._explain_empty_gpu_probe()
+
+    def test_zero_devices_enumerated(self, monkeypatch):
+        _clear_masks(monkeypatch)
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(count = 0))
+        assert "enumerated 0 devices" in LlamaCppBackend._explain_empty_gpu_probe()
+
+    def test_the_arch_gate_dropping_every_card(self, monkeypatch):
+        """The #7624 case: a build with no kernels for the cards actually present."""
+        _clear_masks(monkeypatch)
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch())
+        monkeypatch.setattr(
+            LlamaCppBackend,
+            "_installed_llama_gfx_archs",
+            staticmethod(lambda b = None: frozenset({"gfx1100"})),
+        )
+        monkeypatch.setattr(
+            LlamaCppBackend,
+            "_rocm_arch_by_physical_id",
+            staticmethod(lambda: {0: "gfx1030", 1: "gfx1030"}),
+        )
+        msg = LlamaCppBackend._explain_empty_gpu_probe()
+        assert "arch gate dropped every device" in msg
+        assert "gfx1100" in msg and "gfx1030" in msg, "name both sides or it is not actionable"
+
+    def test_rocm_devices_present_but_both_probes_declined(self, monkeypatch):
+        """The reported host: cards visible to torch, amd-smi and the fallback empty."""
+        _clear_masks(monkeypatch)
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch())
+        monkeypatch.setattr(
+            LlamaCppBackend, "_installed_llama_gfx_archs", staticmethod(lambda b = None: None)
+        )
+        msg = LlamaCppBackend._explain_empty_gpu_probe()
+        assert "both declined" in msg and "3" not in msg
+        assert "2 ROCm device" in msg
+
+    def test_a_covered_arch_does_not_blame_the_gate(self, monkeypatch):
+        _clear_masks(monkeypatch)
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch())
+        monkeypatch.setattr(
+            LlamaCppBackend,
+            "_installed_llama_gfx_archs",
+            staticmethod(lambda b = None: frozenset({"gfx1030"})),
+        )
+        monkeypatch.setattr(
+            LlamaCppBackend, "_rocm_arch_by_physical_id", staticmethod(lambda: {0: "gfx1030"})
+        )
+        assert "arch gate" not in LlamaCppBackend._explain_empty_gpu_probe()
+
+
+class TestItReportsTheVisibilityMask:
+    @pytest.mark.parametrize(
+        "var", ["CUDA_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "GPU_DEVICE_ORDINAL"]
+    )
+    def test_an_empty_mask_is_called_out(self, monkeypatch, var):
+        """A container or a stale mask hides every device, and looks identical to
+        having no GPU unless the mask is printed."""
+        _clear_masks(monkeypatch)
+        monkeypatch.setenv(var, "")
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(available = False))
+        assert f"{var} is empty" in LlamaCppBackend._explain_empty_gpu_probe()
+
+    def test_a_set_mask_is_quoted(self, monkeypatch):
+        _clear_masks(monkeypatch)
+        monkeypatch.setenv("HIP_VISIBLE_DEVICES", "3")
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(available = False))
+        assert "HIP_VISIBLE_DEVICES='3'" in LlamaCppBackend._explain_empty_gpu_probe()
+
+    def test_no_mask_adds_nothing(self, monkeypatch):
+        _clear_masks(monkeypatch)
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(available = False))
+        assert "VISIBLE_DEVICES" not in LlamaCppBackend._explain_empty_gpu_probe()
+
+
+class TestItIsSafeToCallOnAnyPath:
+    def test_it_never_touches_mem_get_info(self, monkeypatch):
+        """Reading memory creates a HIP primary context the backend never gives
+        back (~700 MiB), which is the whole reason the amd-smi branch exists. The
+        fake raises if it is called, so reaching a verdict here proves it was not."""
+        _clear_masks(monkeypatch)
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch())
+        monkeypatch.setattr(
+            LlamaCppBackend, "_installed_llama_gfx_archs", staticmethod(lambda b = None: None)
+        )
+        assert LlamaCppBackend._explain_empty_gpu_probe()
+
+    def test_a_raising_helper_still_yields_a_reason(self, monkeypatch):
+        def boom(binary = None):
+            raise RuntimeError("marker unreadable")
+
+        _clear_masks(monkeypatch)
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch())
+        monkeypatch.setattr(LlamaCppBackend, "_installed_llama_gfx_archs", staticmethod(boom))
+        msg = LlamaCppBackend._explain_empty_gpu_probe()
+        assert "could not be determined" in msg and "RuntimeError" in msg
+
+    def test_it_is_never_empty(self, monkeypatch):
+        """An unexplained empty list is the defect; an empty explanation restores it."""
+        _clear_masks(monkeypatch)
+        for torch_mod in (None, _fake_torch(available = False), _fake_torch(count = 0)):
+            monkeypatch.setitem(sys.modules, "torch", torch_mod)
+            assert LlamaCppBackend._explain_empty_gpu_probe().strip()

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -74,7 +74,7 @@ def _load_site_guard() -> str:
 
     lines = inspect.getsource(mod.LlamaCppBackend.load_model).splitlines()
     hit = next(
-        (i for i, line in enumerate(lines) if "No GPU was available for this load" in line), None
+        (i for i, line in enumerate(lines) if "could not enumerate any GPU" in line), None
     )
     assert hit is not None, "the empty-probe warning is gone"
     start = hit
@@ -222,11 +222,14 @@ class TestMacOSIsNotACpuVerdict:
         assert "Metal" in msg
         assert "torch" not in msg, "on macOS the probe's blind spot is the answer, not torch"
 
-    def test_the_load_site_does_not_warn_on_macos(self):
+    def test_the_load_site_exempts_only_metal_capable_macs(self):
         """Source-level, because load_model cannot be driven from a unit test. The
         simulation in temp/simgpu executes this same guard across the platform matrix."""
         guard = _load_site_guard()
-        assert 'sys.platform != "darwin"' in guard, "macOS must be excluded from this warning"
+        assert "_metal_capable_host()" in guard, (
+            "the exemption must be Apple Silicon, not every Mac: an Intel Mac with an "
+            "empty probe really is CPU-only and wants this line"
+        )
         assert "not _arch_gate_forced_cpu" in guard, "the arch gate warns better; do not double up"
 
 
@@ -253,3 +256,36 @@ class TestManualModeIsNotAnAbsentGpu:
         emptied = src.find('if gpu_memory_mode == "manual" and gpu_layers < 0:')
         assert capture != -1 and emptied != -1
         assert capture < emptied, "_detected_gpus must hold the probe result, not the emptied one"
+
+
+class TestItDoesNotAssertTheLaunchOutcome:
+    """llama.cpp enumerates devices itself and still receives ``--fit on``, so it can
+    place on a GPU this probe never saw. An explicit ``gpu_ids`` pick is pinned for the
+    child further down. Claiming "will run on the CPU" from an empty probe therefore
+    states an outcome this code does not know."""
+
+    def test_the_message_reports_the_probe_not_the_placement(self):
+        # Comments stripped: the guard's own note explains why it must not claim CPU,
+        # and matching that would pass while the message said the opposite.
+        body = "\n".join(
+            line for line in _load_site_guard().splitlines() if not line.lstrip().startswith("#")
+        )
+        assert "could not enumerate any GPU" in body
+        for claim in ("will run on the CPU", "live in system RAM"):
+            assert claim not in body, f"the message must not assert {claim!r}"
+
+    def test_an_explicit_gpu_pick_is_excluded(self):
+        """gpu_ids is restored into gpu_indices after this block and pinned for the
+        child, so those loads reach the GPU the user chose."""
+        assert "not gpu_ids" in _load_site_guard()
+
+    def test_the_pick_really_is_restored_after_the_warning(self):
+        import inspect
+
+        from core.inference import llama_cpp as mod
+
+        src = inspect.getsource(mod.LlamaCppBackend.load_model)
+        warn = src.find("could not enumerate any GPU")
+        restore = src.find("gpu_indices = sorted(gpu_ids)")
+        assert warn != -1 and restore != -1
+        assert warn < restore, "if the pin moved above the warning, re-derive this guard"

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -3,16 +3,10 @@
 
 """_explain_empty_gpu_probe: why _get_gpu_memory came back empty.
 
-From a real report. A user's model ran on the CPU and their whole log said:
-
-    GGUF size: 16.4 GB, ... GPUs free: [], selected: None, --fit: on
-    Load mode: the whole load (34.3 GB) fits without paging
-
-which records the verdict and none of the reason, so the question actually being
-asked -- why did my model go to system RAM -- could not be answered from it. The
-probe returns [] for at least six unrelated reasons and every one lands on the CPU;
-these tests pin that each names itself, and that the explainer never creates the HIP
-context the amd-smi branch exists to avoid.
+A user's log recorded `GPUs free: []` and none of the reason. Six unrelated causes
+share that empty list and need different fixes, so these pin that each names itself,
+that the explainer never creates the HIP context the amd-smi branch avoids, and that
+neither it nor the load site claims an outcome (placement is llama.cpp's, not ours).
 """
 
 import sys
@@ -80,9 +74,7 @@ def _load_site_guard() -> str:
     while start >= 0 and not lines[start].lstrip().startswith("if "):
         start -= 1
     assert start >= 0, "no enclosing if statement"
-    # Forward to the END of the block, not just to the marker line. Stopping at the
-    # marker cut the message's own continuation literal out of the extract, so a mutant
-    # that rewrote it went undetected -- the test read a line that had not changed.
+    # To the END of the block: stopping at the marker hid a mutant in the continuation.
     base = len(lines[start]) - len(lines[start].lstrip())
     end = hit
     while end + 1 < len(lines):
@@ -163,8 +155,7 @@ class TestItReportsTheVisibilityMask:
         "var", ["CUDA_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "GPU_DEVICE_ORDINAL"]
     )
     def test_an_empty_mask_is_called_out(self, monkeypatch, var):
-        """A container or a stale mask hides every device, and looks identical to
-        having no GPU unless the mask is printed."""
+        """A container hiding every device looks identical to having none."""
         _clear_masks(monkeypatch)
         monkeypatch.setenv(var, "")
         monkeypatch.setitem(sys.modules, "torch", _fake_torch(available = False))
@@ -184,9 +175,7 @@ class TestItReportsTheVisibilityMask:
 
 class TestItIsSafeToCallOnAnyPath:
     def test_it_never_touches_mem_get_info(self, monkeypatch):
-        """Reading memory creates a HIP primary context the backend never gives
-        back (~700 MiB), which is the whole reason the amd-smi branch exists. The
-        fake raises if it is called, so reaching a verdict here proves it was not."""
+        """mem_get_info leaks a ~700 MiB HIP context; the fake raises if called."""
         _clear_masks(monkeypatch)
         monkeypatch.setitem(sys.modules, "torch", _fake_torch())
         monkeypatch.setattr(
@@ -213,10 +202,8 @@ class TestItIsSafeToCallOnAnyPath:
 
 
 class TestMacOSIsNotACpuVerdict:
-    """This probe reads CUDA and HIP only, so it is empty on every Mac -- including an
-    Apple Silicon one whose model is about to run entirely on the Metal GPU. There is a
-    whole "No GPU is enumerated on Metal" branch in load_model for that state. Warning
-    there would tell every Mac user the opposite of what happens."""
+    """The probe reads CUDA and HIP, so it is empty on every Mac; an Apple Silicon one
+    is still offloading to Metal."""
 
     @pytest.mark.parametrize("torch_state", ["absent", "no_cuda", "rocm_like"])
     def test_the_reason_names_metal_rather_than_blaming_torch(self, monkeypatch, torch_state):
@@ -233,8 +220,7 @@ class TestMacOSIsNotACpuVerdict:
         assert "torch" not in msg, "on macOS the probe's blind spot is the answer, not torch"
 
     def test_the_load_site_exempts_only_metal_capable_macs(self):
-        """Source-level, because load_model cannot be driven from a unit test. The
-        simulation in temp/simgpu executes this same guard across the platform matrix."""
+        """Source-level: load_model cannot be driven from a unit test."""
         guard = _load_site_guard()
         assert "_metal_capable_host()" in guard, (
             "the exemption must be Apple Silicon, not every Mac: an Intel Mac with an "
@@ -244,11 +230,8 @@ class TestMacOSIsNotACpuVerdict:
 
 
 class TestManualModeIsNotAnAbsentGpu:
-    """Both Manual modes set ``gpus = []`` on purpose, to stand the Python planner down
-    and let ``--fit`` or an explicit ``--gpu-layers`` place the model. The GPU is fully
-    used there. The reporting user's own log shows ``GPUs free: []`` directly beneath
-    "Manual mode with Auto layers hands memory management to llama.cpp --fit", so an
-    empty list there is this, not a probe that failed."""
+    """Both Manual modes empty ``gpus`` on purpose to stand the planner down, and the
+    GPU is fully used there. The reporting user's log is this case, not a failed probe."""
 
     def test_the_warning_reads_detected_gpus_not_gpus(self):
         assert (
@@ -269,14 +252,11 @@ class TestManualModeIsNotAnAbsentGpu:
 
 
 class TestItDoesNotAssertTheLaunchOutcome:
-    """llama.cpp enumerates devices itself and still receives ``--fit on``, so it can
-    place on a GPU this probe never saw. An explicit ``gpu_ids`` pick is pinned for the
-    child further down. Claiming "will run on the CPU" from an empty probe therefore
-    states an outcome this code does not know."""
+    """llama.cpp enumerates devices itself, and an explicit ``gpu_ids`` pick is pinned
+    below, so an empty probe cannot tell you where the model ends up."""
 
     def test_the_message_reports_the_probe_not_the_placement(self):
-        # Comments stripped: the guard's own note explains why it must not claim CPU,
-        # and matching that would pass while the message said the opposite.
+        # Comments stripped: the guard's own note names the claim it forbids.
         body = "\n".join(
             line for line in _load_site_guard().splitlines() if not line.lstrip().startswith("#")
         )
@@ -302,9 +282,7 @@ class TestItDoesNotAssertTheLaunchOutcome:
 
 
 class TestIntelMacGetsItsRealReason:
-    """The load site warns on an Intel Mac, since auto_detect_backend resolves it to CPU.
-    The explainer has to agree: a blanket Darwin branch would answer "macOS offloads
-    through Metal" on a host that offloads through nothing."""
+    """The load site warns on an Intel Mac, so the explainer must not answer "Metal"."""
 
     def test_an_intel_mac_does_not_get_the_metal_answer(self, monkeypatch):
         _clear_masks(monkeypatch)
@@ -333,10 +311,8 @@ class TestIntelMacGetsItsRealReason:
 
 
 class TestItDoesNotClaimTheFitterRuns:
-    """use_fit is the internal default, read before extra_args are appended to the
-    command; a last-wins ``--fit off`` there wins. The later code asks
-    fit_is_effectively_on for exactly this distinction, and cmd does not exist yet at
-    the warning, so the message must not mention the fitter at all."""
+    """use_fit is the pre-extras default and a last-wins ``--fit off`` beats it, so the
+    message must not mention the fitter."""
 
     def test_the_message_does_not_mention_fit(self):
         body = "\n".join(

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -238,9 +238,9 @@ class TestManualModeIsNotAnAbsentGpu:
     empty list there is this, not a probe that failed."""
 
     def test_the_warning_reads_detected_gpus_not_gpus(self):
-        assert "not _detected_gpus" in _load_site_guard(), (
-            "without this every Manual-mode load warns that it is running on the CPU"
-        )
+        assert (
+            "not _detected_gpus" in _load_site_guard()
+        ), "without this every Manual-mode load warns that it is running on the CPU"
 
     def test_detected_gpus_is_captured_before_manual_empties_the_pool(self):
         """The distinction only holds if the capture precedes the emptying."""

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -23,7 +23,12 @@ import pytest
 from core.inference.llama_cpp import LlamaCppBackend
 
 
-def _fake_torch(*, available = True, count = 2, rocm = True):
+def _fake_torch(
+    *,
+    available = True,
+    count = 2,
+    rocm = True,
+):
     cuda = types.SimpleNamespace(
         is_available = lambda: available,
         device_count = lambda: count,

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -346,8 +346,7 @@ class TestItDoesNotClaimTheFitterRuns:
 
     def test_the_command_is_built_after_the_warning(self):
         import inspect
-
         src = inspect.getsource(mod.LlamaCppBackend.load_model)
-        assert src.find("could not enumerate any GPU") < src.find("_fitter_runs = fit_is_effectively_on"), (
-            "if the effective fitter state became available above the warning, re-derive this"
-        )
+        assert src.find("could not enumerate any GPU") < src.find(
+            "_fitter_runs = fit_is_effectively_on"
+        ), "if the effective fitter state became available above the warning, re-derive this"

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -60,6 +60,30 @@ def _clear_masks(monkeypatch):
         monkeypatch.delenv(var, raising = False)
 
 
+def _load_site_guard() -> str:
+    """The `if` statement guarding the empty-probe warning, by indentation.
+
+    Structural rather than a fixed window of characters: the guard carries a long
+    comment, and a window wide enough today silently stops covering the condition the
+    moment that comment grows.
+    """
+    import inspect
+    import textwrap
+
+    from core.inference import llama_cpp as mod
+
+    lines = inspect.getsource(mod.LlamaCppBackend.load_model).splitlines()
+    hit = next(
+        (i for i, line in enumerate(lines) if "No GPU was available for this load" in line), None
+    )
+    assert hit is not None, "the empty-probe warning is gone"
+    start = hit
+    while start >= 0 and not lines[start].lstrip().startswith("if "):
+        start -= 1
+    assert start >= 0, "no enclosing if statement"
+    return textwrap.dedent("\n".join(lines[start : hit + 1]))
+
+
 class TestItNamesTheCause:
     def test_a_vulkan_build_says_so(self, monkeypatch):
         monkeypatch.setattr(
@@ -200,14 +224,32 @@ class TestMacOSIsNotACpuVerdict:
 
     def test_the_load_site_does_not_warn_on_macos(self):
         """Source-level, because load_model cannot be driven from a unit test. The
-        simulation in temp/simgpu mirrors this predicate across the platform matrix."""
+        simulation in temp/simgpu executes this same guard across the platform matrix."""
+        guard = _load_site_guard()
+        assert 'sys.platform != "darwin"' in guard, "macOS must be excluded from this warning"
+        assert "not _arch_gate_forced_cpu" in guard, "the arch gate warns better; do not double up"
+
+
+class TestManualModeIsNotAnAbsentGpu:
+    """Both Manual modes set ``gpus = []`` on purpose, to stand the Python planner down
+    and let ``--fit`` or an explicit ``--gpu-layers`` place the model. The GPU is fully
+    used there. The reporting user's own log shows ``GPUs free: []`` directly beneath
+    "Manual mode with Auto layers hands memory management to llama.cpp --fit", so an
+    empty list there is this, not a probe that failed."""
+
+    def test_the_warning_reads_detected_gpus_not_gpus(self):
+        assert "not _detected_gpus" in _load_site_guard(), (
+            "without this every Manual-mode load warns that it is running on the CPU"
+        )
+
+    def test_detected_gpus_is_captured_before_manual_empties_the_pool(self):
+        """The distinction only holds if the capture precedes the emptying."""
         import inspect
 
         from core.inference import llama_cpp as mod
 
         src = inspect.getsource(mod.LlamaCppBackend.load_model)
-        at = src.find("No GPU was available for this load")
-        assert at != -1, "the empty-probe warning is gone"
-        guard = src[max(0, at - 900) : at]
-        assert 'sys.platform != "darwin"' in guard, "macOS must be excluded from this warning"
-        assert "not _arch_gate_forced_cpu" in guard, "the arch gate warns better; do not double up"
+        capture = src.find("_detected_gpus = list(gpus)")
+        emptied = src.find('if gpu_memory_mode == "manual" and gpu_layers < 0:')
+        assert capture != -1 and emptied != -1
+        assert capture < emptied, "_detected_gpus must hold the probe result, not the emptied one"

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -73,9 +73,7 @@ def _load_site_guard() -> str:
     from core.inference import llama_cpp as mod
 
     lines = inspect.getsource(mod.LlamaCppBackend.load_model).splitlines()
-    hit = next(
-        (i for i, line in enumerate(lines) if "could not enumerate any GPU" in line), None
-    )
+    hit = next((i for i, line in enumerate(lines) if "could not enumerate any GPU" in line), None)
     assert hit is not None, "the empty-probe warning is gone"
     start = hit
     while start >= 0 and not lines[start].lstrip().startswith("if "):

--- a/studio/backend/tests/test_empty_gpu_probe_reason.py
+++ b/studio/backend/tests/test_empty_gpu_probe_reason.py
@@ -177,3 +177,37 @@ class TestItIsSafeToCallOnAnyPath:
         for torch_mod in (None, _fake_torch(available = False), _fake_torch(count = 0)):
             monkeypatch.setitem(sys.modules, "torch", torch_mod)
             assert LlamaCppBackend._explain_empty_gpu_probe().strip()
+
+
+class TestMacOSIsNotACpuVerdict:
+    """This probe reads CUDA and HIP only, so it is empty on every Mac -- including an
+    Apple Silicon one whose model is about to run entirely on the Metal GPU. There is a
+    whole "No GPU is enumerated on Metal" branch in load_model for that state. Warning
+    there would tell every Mac user the opposite of what happens."""
+
+    @pytest.mark.parametrize("torch_state", ["absent", "no_cuda", "rocm_like"])
+    def test_the_reason_names_metal_rather_than_blaming_torch(self, monkeypatch, torch_state):
+        _clear_masks(monkeypatch)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setitem(
+            sys.modules,
+            "torch",
+            None if torch_state == "absent" else _fake_torch(available = torch_state != "no_cuda"),
+        )
+        msg = LlamaCppBackend._explain_empty_gpu_probe()
+        assert "Metal" in msg
+        assert "torch" not in msg, "on macOS the probe's blind spot is the answer, not torch"
+
+    def test_the_load_site_does_not_warn_on_macos(self):
+        """Source-level, because load_model cannot be driven from a unit test. The
+        simulation in temp/simgpu mirrors this predicate across the platform matrix."""
+        import inspect
+
+        from core.inference import llama_cpp as mod
+
+        src = inspect.getsource(mod.LlamaCppBackend.load_model)
+        at = src.find("No GPU was available for this load")
+        assert at != -1, "the empty-probe warning is gone"
+        guard = src[max(0, at - 900) : at]
+        assert 'sys.platform != "darwin"' in guard, "macOS must be excluded from this warning"
+        assert "not _arch_gate_forced_cpu" in guard, "the arch gate warns better; do not double up"


### PR DESCRIPTION
When Studio cannot enumerate a GPU it plans the load blind and hands placement to `llama.cpp --fit`, and the log records that it happened but never why.

### Before

```
GGUF size: 16.4 GB, mmproj: 0.9 GB, est. KV cache: 12.4 GB, MTP reserve: 1.29 GB,
context: 262144, GPUs free: [], selected: None, --fit: on
```

`_get_gpu_memory()` returns `[]` for several unrelated reasons, and they need different fixes:

- an empty or stale visibility mask (`CUDA_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`, `GPU_DEVICE_ORDINAL`), which a container can set without the user knowing
- amd-smi declining and the torch fallback finding nothing
- torch absent, or present with no usable CUDA/HIP device
- the #7624 arch gate dropping every card
- genuinely no GPU

Reading `[]` you cannot tell which. `_get_gpu_memory_amd_smi`'s own docstring lists several more ways to reach it.

### After

```
Studio could not enumerate any GPU, so it planned this load blind and left placement to
llama.cpp --fit: torch reports no usable CUDA or HIP device (CUDA_VISIBLE_DEVICES is empty)
```

### What this deliberately does not claim

It does **not** say the model will run on the CPU. llama.cpp enumerates devices itself and still receives `--fit on`, so it can place on a GPU this probe never saw. Earlier revisions of this PR did assert that, and it was wrong.

Three states are excluded, because an empty list there does not mean the probe failed:

| state | why excluded |
|---|---|
| both Manual modes | they empty `gpus` on purpose to stand the planner down; `_detected_gpus` holds the real probe result |
| explicit `gpu_ids` pick | restored into `gpu_indices` below this block and pinned for the child |
| Apple Silicon | the probe reads CUDA and HIP only, so Metal offload is unaffected. An Intel Mac is not exempt, since `auto_detect_backend` falls back to CPU there |

The arch gate already warns with a better, more actionable message when it is the cause, so that case is left to it.

### Scope, honestly

This is a diagnostic. It changes no placement, adds no flag, no config and no state, so old installs are unaffected in both directions. It does not fix a reported failure: the log that prompted it turned out to be Manual mode standing the planner down, which this now correctly stays quiet about. The value is the visibility-mask and amd-smi-declined cases, which are currently unanswerable from a log.

The explainer never calls `mem_get_info`, so it does not create the HIP primary context the amd-smi branch exists to avoid; a test fails if it ever does.

### Testing

Reproduced unmocked on a real CUDA host: an empty `CUDA_VISIBLE_DEVICES` and a mask pointing at an absent ordinal both drive the probe to `[]` and produce the right reason, while the normal case stays non-empty and silent.

Simulated in an isolated `uv` venv across [Linux, WSL, Windows, macOS] x [NVIDIA, AMD/ROCm, CPU only], plus 6 edge cases and 13 load-site cases. The guard is executed, not just read: it is cut out of `llama_cpp.py` by indentation and exec'd with controlled bindings, so the shipped text runs.

24 tests, mutation-checked; 776 passed across nine GPU suites.
