### PR TITLE
Say when the fit shortened the context, and from what

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -20155,6 +20155,18 @@ class LlamaCppBackend:
                         # --fit flag state, not "does it fit": off means this subset provably fits.
                         f"GPUs free: {gpus}, selected: {gpu_indices}, --fit: {'on' if use_fit else 'off'}"
                     )
+                    if 0 < effective_ctx < requested_ctx:
+                        # The line above reports the context that WILL run, and a user
+                        # who asked for more sees only the smaller number and concludes
+                        # their setting did not apply. Name both, so a shortened window
+                        # reads as a decision with a cause rather than a lost setting.
+                        logger.warning(
+                            "Context length was reduced from the requested %d to %d to fit "
+                            "this machine. Lower the context, free VRAM, or pick a smaller "
+                            "quant to keep the full window.",
+                            requested_ctx,
+                            effective_ctx,
+                        )
                     # The planner ran to completion over a real device list and
                     # left --fit on, i.e. it could not prove the model fits. THAT
                     # is a partial-placement verdict. Set last, so any early

--- a/studio/backend/tests/test_context_fit_down_is_reported.py
+++ b/studio/backend/tests/test_context_fit_down_is_reported.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A context the fit shortened must say so, naming the value that was asked for.
+
+From a user report. They set Context Length to 512000, the load came up smaller, and
+they hand-added ``--rope-scaling yarn --yarn-orig-ctx 32768`` to Extra Arguments --
+what someone does when a setting looks ignored. Nothing in the backend said the
+context had been reduced: the placement line reports ``context: <effective>`` only, so
+the requested value appears nowhere and a fit-down is indistinguishable from a lost
+setting.
+
+Structural, like test_gpu_memory_mode.py's checks on the same region: load_model is
+not callable in a unit test, so these read the source of the branch. They pin the
+condition and the two values in the message, which is what makes the line useful.
+"""
+
+import inspect
+
+import pytest
+
+from core.inference import llama_cpp as llama_cpp_module
+
+pytest.importorskip("fastapi")
+
+
+def _load_model_source() -> str:
+    return inspect.getsource(llama_cpp_module.LlamaCppBackend.load_model)
+
+
+def _fit_down_block() -> str:
+    src = _load_model_source()
+    at = src.find("Context length was reduced from the requested")
+    assert at != -1, "a shortened context must be reported; see the report in this file's docstring"
+    return src[max(0, at - 700) : at + 500]
+
+
+def test_the_report_is_guarded_by_an_actual_reduction():
+    """Only when the fit really shortened it. requested_ctx is 0 for Auto, and
+    effective_ctx is 0 where the context is not yet known, so an unguarded compare
+    would warn on loads that reduced nothing."""
+    assert "0 < effective_ctx < requested_ctx" in _fit_down_block()
+
+
+def test_it_names_both_the_requested_and_the_effective_value():
+    """The whole point: the placement line already prints the effective context. A
+    message that repeats only that adds nothing a user could act on."""
+    block = _fit_down_block()
+    assert "requested_ctx," in block and "effective_ctx," in block
+
+
+def test_it_is_a_warning_not_an_info():
+    """The reporting user's entire log was info-level, which is why a silently
+    shortened window read as a broken setting."""
+    assert "logger.warning(" in _fit_down_block()
+
+
+def test_it_tells_the_user_what_to_do():
+    block = _fit_down_block()
+    assert any(word in block for word in ("Lower the context", "free VRAM", "smaller")), (
+        "a reduction the user cannot act on is only half the message"
+    )
+
+
+def test_it_sits_with_the_placement_decision_it_explains():
+    """Beside the GPUs-free line, so one read of the log shows the placement and the
+    context it forced, rather than the two being pages apart."""
+    src = _load_model_source()
+    assert src.find("GPUs free:") < src.find("Context length was reduced from the requested")

--- a/studio/backend/tests/test_context_fit_down_is_reported.py
+++ b/studio/backend/tests/test_context_fit_down_is_reported.py
@@ -57,9 +57,9 @@ def test_it_is_a_warning_not_an_info():
 
 def test_it_tells_the_user_what_to_do():
     block = _fit_down_block()
-    assert any(word in block for word in ("Lower the context", "free VRAM", "smaller")), (
-        "a reduction the user cannot act on is only half the message"
-    )
+    assert any(
+        word in block for word in ("Lower the context", "free VRAM", "smaller")
+    ), "a reduction the user cannot act on is only half the message"
 
 
 def test_it_sits_with_the_placement_decision_it_explains():


### PR DESCRIPTION
From the same user report as #10056. They set Context Length to 512000 on a DeepSeek-V4-Flash UD-Q4_K_XL, the load came up smaller, and they then hand-added `--rope-scaling yarn --yarn-orig-ctx 32768` to Extra Arguments. That is what someone does when a setting looks ignored.

### It was not ignored

`effective_ctx = min(_fit_ctx(target_ctx), max_available_ctx)`, so a request larger than the machine can hold is fitted down deliberately. The problem is that nothing says so. The placement line prints:

```
GGUF size: ..., context: 262144, GPUs free: [...], selected: ..., --fit: on
```

That is the context that will run. The value the user asked for appears nowhere in the log, at any level, and there is no message anywhere in the backend naming a reduction. So a deliberate fit-down and a setting that failed to apply are indistinguishable, and the user's next move is to fight the UI with raw llama.cpp flags, which is exactly what happened.

The model-picker does warn beforehand ("the context will be fitted down to what fits"), but that is a prediction shown before the load. Afterwards there is nothing that says it actually happened, or by how much.

### After

```
Context length was reduced from the requested 512000 to 262144 to fit this machine.
Lower the context, free VRAM, or pick a smaller quant to keep the full window.
```

Warning level, because the reporting user's entire 1002-line log was info and this is the line that would have answered their question. Placed beside the placement decision that forced it, so one read of the log shows both.

Guarded on `0 < effective_ctx < requested_ctx`: `requested_ctx` is 0 under Auto and `effective_ctx` is 0 before the context is known, so an unguarded compare would fire on loads that reduced nothing. No behaviour change, this only reports a decision already being made.

### Testing

Structural, matching `test_gpu_memory_mode.py`'s existing checks on this same region, because `load_model` cannot be driven from a unit test. I would rather say that plainly than imply a behavioural test.

| mutant | tests that fail |
|---|---|
| unguarded comparison | 1 |
| downgraded to info | 1 |
| requested value dropped from the message | 1 |

274 passed across `test_gpu_memory_mode` and `test_kv_cache_estimation`.