### PR TITLE
Studio: split parallel tool-call arguments at JSON object boundaries

### DIFF
--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -226,6 +226,32 @@ def _chunk_payload(line: str) -> dict[str, Any] | None:
     return value if isinstance(value, dict) else None
 
 
+def _mint_streamed_card_id(taken: set[str], index: Any) -> str:
+    """The id the client painted this call's card under.
+
+    A call the provider gave no id to still needs one, and the client minted
+    its own the moment the delta arrived: ``tool_call_<delta index>`` for the
+    first call in a slot, then the lowest free ``tool_call_<n>`` for each call
+    split out of it. Both halves walk the same deltas in the same order, so
+    reproducing that rule here lands on the same spelling, and ``tool_start``
+    and ``tool_end`` reach the card the stream already drew instead of pushing
+    a second one beside it.
+
+    This is a card id and never a conversation id: what is stored and replayed
+    upstream stays ``call_<round>_<position>``, so threads written before this
+    keep resolving.
+    """
+    preferred = (
+        f"tool_call_{index}" if isinstance(index, int) and not isinstance(index, bool) else ""
+    )
+    if preferred and preferred not in taken:
+        return preferred
+    position = 0
+    while f"tool_call_{position}" in taken:
+        position += 1
+    return f"tool_call_{position}"
+
+
 def _normalized_call(call: dict[str, Any], fallback_id: str = "") -> dict[str, Any] | None:
     call_id = call.get("id")
     function = call.get("function")
@@ -351,6 +377,167 @@ class ToolLoopPolicy:
     nudge_tool_calls: bool | None = None
 
 
+def _reject_json_constant(name: str) -> Any:
+    """Refuse ``NaN`` / ``Infinity``, which ``json.loads`` takes and JSON does not.
+
+    ``JSON.parse`` has no such literals, so leaving them accepted here lets the
+    two scanners cut the same text in different places: the backend would run
+    two calls where the frontend shows one.
+    """
+    raise ValueError(f"{name} is not JSON")
+
+
+def _split_top_level_json_objects(text: str) -> tuple[list[str], str]:
+    """The top-level JSON objects in ``text``, and any object still unfinished.
+
+    A call's ``function.arguments`` is one JSON object, so a second top-level
+    ``{`` means one index slot took a second parallel call. Text that is not a
+    run of whole objects (top-level array or scalar, trailing junk, unbalanced
+    brace) comes back whole as the tail, so a stream this was never meant for
+    is left alone.
+
+    Mirrors ``splitTopLevelJsonObjects`` in
+    ``studio/frontend/src/features/chat/tool-call-arguments.ts``: the two see
+    the same deltas and have to agree on where a call ends.
+    """
+    unsplit: tuple[list[str], str] = ([], text)
+    complete: list[str] = []
+    depth = 0
+    start = -1
+    in_string = False
+    escaped = False
+
+    for i, ch in enumerate(text):
+        if in_string:
+            # A backslash escapes one character, so a run of them toggles.
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if depth == 0:
+            # Between objects only whitespace, "\r\n" as readily as "\n".
+            if ch == "{":
+                depth = 1
+                start = i
+                continue
+            if ch in " \t\n\r":
+                continue
+            return unsplit
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                segment = text[start : i + 1]
+                try:
+                    json.loads(
+                        segment,
+                        parse_constant = _reject_json_constant,
+                        # Validation only, so the numbers are never read: keeping
+                        # them as text sidesteps the 4300-digit cap on int
+                        # conversion, which JSON.parse does not have and which
+                        # would otherwise make the two disagree on where a call
+                        # ends over a literal that fits in an ordinary payload.
+                        parse_int = str,
+                    )
+                except (ValueError, TypeError):
+                    # Balanced but invalid, so the brace count was a
+                    # coincidence and cutting here would invent a call.
+                    return unsplit
+                except RecursionError:
+                    # Deeply nested but valid JSON blows the interpreter's stack
+                    # instead of failing to decode, and RecursionError is not a
+                    # ValueError. Uncaught it escapes the loop mid-stream, so
+                    # the segment counts as unsplittable and _normalized_call
+                    # downgrades it to _raw as it always has.
+                    return unsplit
+                complete.append(segment)
+                start = -1
+
+    return complete, ("" if start == -1 else text[start:])
+
+
+@dataclass
+class _BoundaryScan:
+    """``_split_top_level_json_objects`` over a string that only ever grows.
+
+    One call's arguments arrive as many small fragments, and rescanning the
+    whole accumulation per fragment makes streaming one argument of length N
+    cost O(N^2): a 10 KB argument delivered a character at a time took about
+    five seconds, which stalls the response. The scan resumes where it stopped
+    instead, so the same argument costs one pass in total.
+
+    ``feed`` must be given the same string extended, never a rewritten one --
+    a fork rewrites a slot's arguments, so ``_Turn`` drops the scan for the
+    keys it touches and lets the next fragment start a fresh one.
+    """
+
+    depth: int = 0
+    start: int = -1
+    in_string: bool = False
+    escaped: bool = False
+    scanned: int = 0
+    complete: list[str] = field(default_factory = list)
+    # Junk at depth 0 or a segment that does not parse makes the whole string
+    # unsplittable, and appending to it can never make it splittable again.
+    unsplittable: bool = False
+
+    def feed(self, text: str) -> tuple[list[str], str]:
+        if self.unsplittable:
+            return [], text
+        i = self.scanned
+        while i < len(text):
+            ch = text[i]
+            if self.in_string:
+                if self.escaped:
+                    self.escaped = False
+                elif ch == "\\":
+                    self.escaped = True
+                elif ch == '"':
+                    self.in_string = False
+                i += 1
+                continue
+            if self.depth == 0:
+                if ch == "{":
+                    self.depth = 1
+                    self.start = i
+                    i += 1
+                    continue
+                if ch in " \t\n\r":
+                    i += 1
+                    continue
+                self.unsplittable = True
+                return [], text
+            if ch == '"':
+                self.in_string = True
+            elif ch == "{":
+                self.depth += 1
+            elif ch == "}":
+                self.depth -= 1
+                if self.depth == 0:
+                    segment = text[self.start : i + 1]
+                    try:
+                        json.loads(
+                            segment,
+                            parse_constant = _reject_json_constant,
+                            parse_int = str,
+                        )
+                    except (ValueError, TypeError, RecursionError):
+                        self.unsplittable = True
+                        return [], text
+                    self.complete.append(segment)
+                    self.start = -1
+            i += 1
+        self.scanned = len(text)
+        return list(self.complete), ("" if self.start == -1 else text[self.start :])
+
+
 @dataclass
 class _Turn:
     """Accumulated state for one provider turn."""
@@ -358,9 +545,22 @@ class _Turn:
     by_index: dict[Any, dict[str, Any]] = field(default_factory = dict)
     order: list[Any] = field(default_factory = list)
     # call key each delta index maps to: the index itself until a second call
-    # forks off it, then (index, call_id).
+    # forks off it, then (index, call_id), or (index, "_split", n) for a call
+    # that had no id to fork on and was found on a JSON object boundary.
     open_key_by_index: dict[int, Any] = field(default_factory = dict)
     last_index: int | None = None
+    split_seq: int = 0
+    seq_by_key: dict[Any, int] = field(default_factory = dict)
+    seq_counter: int = 0
+    # Which call each id names, so a fragment repeating an id reaches its own
+    # call even when a later call at that index is the one currently open.
+    key_by_call_id: dict[str, Any] = field(default_factory = dict)
+    # Resumable boundary scan per call, keyed the same as ``by_index``.
+    scan_by_key: dict[Any, _BoundaryScan] = field(default_factory = dict)
+    # Split-born calls whose object had not closed when they were forked off.
+    # Reported only once it does: a stream cut short after "{\"a\":1}{" would
+    # otherwise run the tool a second time on half an argument.
+    open_tail_keys: set[Any] = field(default_factory = set)
     round: int = 0
     healed: list[dict[str, Any]] = field(default_factory = list)
     text: list[str] = field(default_factory = list)
@@ -479,31 +679,187 @@ class _Turn:
             # belong to the newer call.
             key: Any = self.open_key_by_index.get(index, index)
             if isinstance(call_id, str) and call_id:
-                open_id = self.by_index.get(key, {}).get("id")
-                if open_id and open_id != call_id:
+                # An id beats the latest-index mapping, which only places
+                # fragments carrying no id: a fragment repeating an id returns
+                # to the call wearing it wherever that call now sits. Matching
+                # the open call instead renamed a newer one and gave it a second
+                # copy of the id.
+                owner = self.key_by_call_id.get(call_id)
+                if owner is not None:
+                    key = owner
+                elif self.by_index.get(key, {}).get("id"):
                     # Two distinct calls reported at the same index. Merging them
                     # concatenates their argument JSON into one unparseable blob
                     # and loses an intent, so key the second on its own id.
-                    # A fragment that names the call this index opened first goes
-                    # back to it: an id beats the latest-index mapping, which only
-                    # exists to place the fragments that carry no id.
-                    first_id = self.by_index.get(index, {}).get("id")
-                    key = index if first_id == call_id else (index, call_id)
+                    key = (index, call_id)
+            # A closed object cannot take more content, so the next arguments to
+            # reach a slot already holding one whole object belong to the next
+            # parallel call. Forking on the accumulated text alone only catches
+            # this once those arguments glue on, and a delta carrying an id
+            # would claim the finished call and append to it (issue #9807).
+            held = self.by_index.get(key)
+            new_function = raw_call.get("function")
+            new_arguments = (
+                new_function.get("arguments") if isinstance(new_function, dict) else None
+            )
+            new_name = new_function.get("name") if isinstance(new_function, dict) else None
+            # A next call opens with the "{" of its own arguments object, so a
+            # fragment starting with anything else is not one: whitespace after
+            # a closing brace belongs to the object just closed, and forking on
+            # a stray scalar suffix would run the tool twice.
+            # An id names a call outright, so one naming a DIFFERENT call opens
+            # the next even before its arguments arrive. On its own, or
+            # repeating the name the slot holds, it is that call's id stamped
+            # late, and forking there strands the finished call under its
+            # provisional id beside an empty second one.
+            held_name_now = held["function"]["name"] if held is not None else ""
+            id_names_another_call = bool(
+                isinstance(call_id, str)
+                and call_id
+                and isinstance(new_name, str)
+                and new_name
+                and held_name_now
+                # Not a prefix test: an id is strong evidence of its own call,
+                # and a catalog holding both "web" and "web_search" would have
+                # the second claim the first and glue their arguments together.
+                # Only the same name, or none, reads as that call's id arriving
+                # late.
+                and new_name != held_name_now
+            )
+            # A snapshot-style provider repeats the finished call verbatim once
+            # it has an id for it. Same name and byte-identical arguments, with
+            # an id the slot does not hold yet, is that call arriving to be
+            # claimed; opening a second runs a side-effecting tool twice. Exact
+            # repeats of an id-less call only, so parallel calls differing
+            # anywhere still both run.
+            resends_this_call = bool(
+                held is not None
+                and isinstance(call_id, str)
+                and call_id
+                and not held.get("id")
+                and isinstance(new_name, str)
+                and new_name == held_name_now
+                and isinstance(new_arguments, str)
+                and new_arguments == held["function"]["arguments"]
+            )
+            # A name arriving at a slot whose object has closed announces the
+            # next call. A name grows across deltas only while it is being
+            # streamed, which is before the arguments, so once the object has
+            # closed there is nothing left for a fragment to extend and the
+            # only thing a name can mean is the next call. Testing for a shared
+            # prefix instead read "web" after "web_search" as that call's name
+            # resent and swallowed the second call. Without any of this, the
+            # reported stream delivered one character per delta merges two
+            # calls' names into "web_fetchweb_search", which matches no tool.
+            names_next_call = bool(
+                isinstance(new_name, str)
+                and new_name
+                and held_name_now
+                # The same name is that call's, resent: llama-server repeats it
+                # on every delta and vLLM has repeated the whole name too, so
+                # forking there would run one request twice.
+                and new_name != held_name_now
+            )
+            opens_next_call = (
+                bool(isinstance(new_arguments, str) and new_arguments.strip().startswith("{"))
+                or id_names_another_call
+                or names_next_call
+            ) and not resends_this_call
+            # A slot holding only an announcement has no object to close, so
+            # the rule above cannot reach it. A DIFFERENT name arriving there
+            # with an object of its own is the next call: a name still growing
+            # arrives on its own, before any arguments. Without this the
+            # announcement's name and the next call's glue into "A_longB",
+            # which matches no tool and silently never runs.
+            announces_over_announcement = (
+                held is not None
+                and (
+                    held.get("announced_only") is True
+                    or held.get("resend_suspect") is True
+                )
+                and not held["function"]["arguments"]
+                and isinstance(new_name, str)
+                and bool(new_name)
+                and new_name != held_name_now
+                and isinstance(new_arguments, str)
+                and new_arguments.strip().startswith("{")
+            )
+            # An id names its call, so a fragment repeating the id this slot
+            # already holds continues it however complete its arguments look --
+            # llama-server grows the name across deltas, and forking there gives
+            # two calls one id, with the arguments on the abandoned name.
+            names_this_call = (
+                held is not None
+                and isinstance(call_id, str)
+                and bool(call_id)
+                and held.get("id") == call_id
+            )
+            slot_is_closed = False
+            if held is not None and not names_this_call:
+                closed, unfinished = self._scan(key, held["function"]["arguments"])
+                slot_is_closed = bool(closed) and not unfinished
+            extra = raw_call.get("extra_content")
+            if (slot_is_closed and opens_next_call) or announces_over_announcement:
+                if announces_over_announcement and held is not None:
+                    # Another call took this slot over while it still held only
+                    # its name, so the announcement was never a call of its own.
+                    held["superseded"] = True
+                self.split_seq += 1
+                key = (index, "_split", self.split_seq)
             self.last_index = index
             self.open_key_by_index[index] = key
             if key not in self.by_index:
+                # An id-less provider reusing the index for another call to the
+                # same tool can leave the repeated name out, the first delta
+                # having given it. An empty name is no tool, so _normalized_call
+                # drops the call and the user is one result short; the call this
+                # slot just closed is the only name it can mean.
+                opening_name = new_name if isinstance(new_name, str) and new_name else held_name_now
                 self.by_index[key] = {
                     "id": "",
                     "type": "function",
-                    "function": {"name": "", "arguments": ""},
+                    "function": {"name": opening_name, "arguments": ""},
+                    # A name with no `arguments` field at all is a call the
+                    # stream said it was about to make. A tool that takes no
+                    # parameters sends an empty string rather than no field, so
+                    # this marks only the announcement, and `calls` drops one
+                    # still empty when the turn ends. Kept, it would run a tool
+                    # the model never actually asked for.
+                    "announced_only": new_arguments is None and bool(opening_name),
+                    # Whether this slot is a fork's guess or a slot the
+                    # provider opened itself. An announcement the provider
+                    # opened is a call it means to make, most likely to a tool
+                    # that takes no parameters; one a fork invented has no
+                    # such standing, and if nothing ever fills it there is
+                    # nothing to run.
+                    "from_fork": held is not None,
+                    # A name that extends the name of the call this fork just
+                    # left behind is most likely that call's, resent. It still
+                    # opens a slot, because a catalog holding both "web" and
+                    # "web_search" makes the prefix no proof either way, but
+                    # the slot gives way rather than gluing if another name
+                    # brings the object: "alpha_long" then "beta" was reported
+                    # as "alpha_longbeta", which matches no tool.
+                    "resend_suspect": bool(
+                        opening_name
+                        and held_name_now
+                        and opening_name != held_name_now
+                        and opening_name.startswith(held_name_now)
+                    ),
                 }
+                self.seq_by_key[key] = self._next_seq()
                 # First-seen order, so a negative or out-of-order index cannot
                 # reorder parallel calls against what the model actually sent.
                 self.order.append(key)
             current = self.by_index[key]
+            if new_arguments is not None:
+                current["announced_only"] = False
             if isinstance(call_id, str) and call_id:
                 current["id"] = call_id
-            extra = raw_call.get("extra_content")
+                self.key_by_call_id.setdefault(call_id, key)
+            # What the slot carried before this delta, so a fork below can hand
+            # this delta's metadata to the call it actually closes.
+            extra_before = current.get("extra_content")
             if isinstance(extra, dict) and extra:
                 # Gemini 3 stows this call's thoughtSignature here, and the
                 # native translator rejects a replayed functionCall without it.
@@ -520,31 +876,204 @@ class _Turn:
                 # starts with what we have is the whole name resent; anything
                 # else continues it.
                 fragment = function.get("name")
-                if isinstance(fragment, str) and fragment:
-                    accumulated = current["function"]["name"]
-                    if fragment.startswith(accumulated):
+                name_before = current["function"]["name"]
+                # Not once this call's object has closed AND it already has a
+                # name: the rule above has forked the next call, and rewriting
+                # a finished call's name would put arguments validated against
+                # one tool's schema under another tool's name. Naming a call
+                # that has none is not a rename, and some servers do send the
+                # arguments first and the name only in a later chunk.
+                if (
+                    isinstance(fragment, str)
+                    and fragment
+                    and not (slot_is_closed and name_before)
+                ):
+                    if fragment.startswith(name_before):
                         current["function"]["name"] = fragment
                     else:
-                        current["function"]["name"] = accumulated + fragment
-                if isinstance(function.get("arguments"), str):
+                        current["function"]["name"] = name_before + fragment
+                if isinstance(function.get("arguments"), str) and not resends_this_call:
                     current["function"]["arguments"] += function["arguments"]
+                    if not (isinstance(call_id, str) and call_id):
+                        # The id fork above cannot see this one: an id-less
+                        # stream has no ids to differ, so appending glued two
+                        # calls into one unparseable blob that then rides into
+                        # the next request verbatim (issue #9807).
+                        self._fork_glued_arguments(
+                            index,
+                            key,
+                            current,
+                            name_before,
+                            fragment if isinstance(fragment, str) else "",
+                            extra_before,
+                            extra if isinstance(extra, dict) and extra else None,
+                        )
 
-    def calls(self, taken: set[str] | None = None) -> list[dict[str, Any]]:
+    def _scan(self, key: Any, text: str) -> tuple[list[str], str]:
+        """``_split_top_level_json_objects(text)``, resuming the scan for ``key``.
+
+        The same answer as scanning from byte zero, at the cost of the bytes
+        this call added rather than of the whole accumulation.
+        """
+        scan = self.scan_by_key.get(key)
+        if scan is None:
+            scan = _BoundaryScan()
+            self.scan_by_key[key] = scan
+        return scan.feed(text)
+
+    def _fork_glued_arguments(
+        self,
+        index: int,
+        key: Any,
+        current: dict[str, Any],
+        name_before: str,
+        incoming_name: str,
+        extra_before: dict[str, Any] | None,
+        incoming_extra: dict[str, Any] | None,
+    ) -> None:
+        """Give every call after the first in one slot a call of its own."""
+        complete, tail = self._scan(key, current["function"]["arguments"])
+        segments = complete + ([tail] if tail else [])
+        if len(segments) < 2:
+            return
+        # Below rewrites this slot's arguments rather than extending them, so
+        # the resumable scan no longer describes the string it was reading.
+        self.scan_by_key.pop(key, None)
+        # The slot keeps the object it opened with, under the name and id it
+        # had. Nothing per-call rides along: extra_content carries this call's
+        # thoughtSignature, and two calls claiming it is a rejected turn.
+        current["function"]["arguments"] = segments[0]
+        # A name arriving with this delta names the calls it opened, so the slot
+        # goes back to its own. Without this the two dialects above merge them:
+        # "alpha" then "gamma" at one index becomes "alphagamma", matching no
+        # enabled tool and silently never running.
+        born_name = incoming_name or name_before
+        current["function"]["name"] = name_before or born_name
+        # The metadata this delta carried belongs to the call this delta closes,
+        # which is the last one, not to the object the slot already held. Gemini
+        # checks the opaque signature against the exact call it is replayed on,
+        # so leaving it here gets the follow-up rejected. Same placement as the
+        # frontend split.
+        if incoming_extra is not None:
+            if extra_before:
+                current["extra_content"] = extra_before
+            else:
+                current.pop("extra_content", None)
+        open_key: Any = key
+        for segment in segments[1:]:
+            self.split_seq += 1
+            born_key = (index, "_split", self.split_seq)
+            self.by_index[born_key] = {
+                "id": "",
+                "type": "function",
+                "function": {"name": born_name, "arguments": segment},
+            }
+            self.seq_by_key[born_key] = self._next_seq()
+            if tail and segment is segments[-1]:
+                self.open_tail_keys.add(born_key)
+            self.order.append(born_key)
+            open_key = born_key
+        if incoming_extra is not None:
+            self.by_index[open_key]["extra_content"] = dict(incoming_extra)
+        # Later id-less fragments continue the last call, finished or not.
+        self.open_key_by_index[index] = open_key
+
+    def _call_is_finished(self, key: Any) -> bool:
+        """Whether a call forked off an unfinished object has since closed it.
+
+        Only ``length`` and ``content_filter`` mark a turn truncated, so a
+        stream that stops after ``{"a":1}{`` looks complete; running the tool a
+        second time on that lone brace is worse than dropping a call the model
+        never finished writing.
+        """
+        if key not in self.open_tail_keys:
+            return True
+        closed, unfinished = _split_top_level_json_objects(
+            self.by_index[key]["function"]["arguments"]
+        )
+        return bool(closed) and not unfinished
+
+    def _next_seq(self) -> int:
+        self.seq_counter += 1
+        return self.seq_counter
+
+    def calls(
+        self,
+        taken: set[str] | None = None,
+        cards: set[str] | None = None,
+    ) -> list[dict[str, Any]]:
         """Every call this turn produced, with ids unique across the whole run.
 
         ``taken`` carries the ids already used by earlier turns. A provider that
         restarts its numbering each turn, and the healer (which always mints
         call_0 first), would otherwise put two different results under one id in
         the conversation replayed upstream.
+
+        ``cards`` carries the card ids already handed out. The client keeps one
+        list of cards for the whole response, so a second round has to keep
+        counting rather than start again at ``tool_call_0`` and reopen the first
+        round's cards.
         """
         seen: set[str] = taken if taken is not None else set()
+        painted: set[str] = cards if cards is not None else set()
         out: list[dict[str, Any]] = []
-        for position, call in enumerate(
-            [self.by_index[key] for key in self.order] + list(self.healed)
-        ):
+        # Ordered by when the stream announced each call, so one announced
+        # second is not run third because another index opened in between. Keyed
+        # on the sequence number alone: comparing the calls themselves to break
+        # a tie raises rather than sorts, and the sort is stable, so a shared
+        # number keeps the order the calls were found in.
+        numbered = [
+            (
+                self.seq_by_key.get(key, position),
+                key[0] if isinstance(key, tuple) else key,
+                self.by_index[key],
+            )
+            for position, key in enumerate(self.order)
+            if self._call_is_finished(key)
+        ]
+        ordered = [
+            (index, call) for _, index, call in sorted(numbered, key = lambda triple: triple[0])
+        ]
+        # An announcement another call took over, and a name that only ever
+        # looked like the closed call's resent, were never calls of their own.
+        # A lone announcement the provider opened itself is kept: a tool that
+        # takes no parameters is announced exactly that way and does have to
+        # run. Its
+        # metadata still belongs to this turn -- Gemini stows a thought
+        # signature there and the native translator rejects a replay without
+        # one -- so it goes to the call the announcement was mistaken for.
+        kept: list[tuple[Any, dict[str, Any]]] = []
+        for index, call in ordered:
+            never_ran = not call["function"]["arguments"]
+            if never_ran and (
+                call.get("superseded") is True
+                or call.get("resend_suspect") is True
+                or (call.get("announced_only") is True and call.get("from_fork") is True)
+            ):
+                extra = call.get("extra_content")
+                if isinstance(extra, dict) and extra and kept:
+                    previous = kept[-1][1]
+                    previous["extra_content"] = {**previous.get("extra_content", {}), **extra}
+                continue
+            kept.append((index, call))
+        ordered = kept
+        # A provider id the stream did carry is reserved, so a minted card id
+        # can never collide with one the client is already keying a card on.
+        painted.update(
+            call["id"] for _, call in ordered if isinstance(call.get("id"), str) and call["id"]
+        )
+        for position, (index, call) in enumerate(ordered + [(None, call) for call in self.healed]):
+            streamed_id = call.get("id")
             normalized = _normalized_call(call, fallback_id = f"call_{self.round}_{position}")
             if normalized is None:
                 continue
+            if not (isinstance(streamed_id, str) and streamed_id):
+                # No id on the wire, so the client minted one and drew a card
+                # under it. Mint the same one here and address the card events
+                # to it; the conversation id above is untouched.
+                card_id = _mint_streamed_card_id(painted, index)
+                painted.add(card_id)
+                normalized["card_id"] = card_id
             if normalized["id"] in seen:
                 # The client keyed the card it painted on the id the provider
                 # streamed, so keep that one for the events aimed at the card.
@@ -814,6 +1343,10 @@ async def stream_with_studio_tools(
     last_reprompt_text = ""
     provider_turns = 0
     used_call_ids: set[str] = _replayed_call_ids(conversation)
+    # Card ids handed out so far in this response. The client keeps one list of
+    # cards across every round, so the numbering has to keep going rather than
+    # restart and reopen a card an earlier round already closed.
+    painted_card_ids: set[str] = set()
     spent_budget_passes = 0
     fruitless_turns = 0
     # One provider call per possible execution, plus headroom for the no-op,
@@ -1037,7 +1570,11 @@ async def stream_with_studio_tools(
         # so the scraped web text in its prompts cannot reach python or terminal,
         # so a naive or compromised endpoint echoing a call back must not be able
         # to execute it here.
-        calls = [] if (truncated or tool_choice == "none") else turn.calls(used_call_ids)
+        calls = (
+            []
+            if (truncated or tool_choice == "none")
+            else turn.calls(used_call_ids, painted_card_ids)
+        )
         if not calls:
             # No tool this turn. A model that only said what it was about to do
             # gets one nudge to actually do it, the same recovery the local loops
@@ -1098,7 +1635,7 @@ async def stream_with_studio_tools(
                 # execute: the cap is a safety limit, not a hint to the provider.
                 for card_line in _unrun_call_card(
                     tool_name = call["function"]["name"],
-                    tool_call_id = call.get("stream_id") or call["id"],
+                    tool_call_id = call.get("card_id") or call.get("stream_id") or call["id"],
                     arguments = call.get("arguments"),
                     result = _TOOL_BUDGET_EXHAUSTED,
                     provenance = _unrun_provenance(call["function"]["name"], round_id),
@@ -1153,7 +1690,9 @@ async def stream_with_studio_tools(
                     continue
                 for card_line in _unrun_call_card(
                     tool_name = decision.tool_name,
-                    tool_call_id = call.get("stream_id") or decision.tool_call_id,
+                    tool_call_id = (
+                        call.get("card_id") or call.get("stream_id") or decision.tool_call_id
+                    ),
                     arguments = decision.arguments,
                     result = _TOOL_SKIPPED.get(decision.action, "Unsloth did not run this call."),
                     provenance = decision.provenance,
@@ -1171,6 +1710,11 @@ async def stream_with_studio_tools(
             name = decision.tool_name
             arguments = decision.arguments
             call_id = decision.tool_call_id
+            # What the conversation replays and what the card is addressed to
+            # are the same id for a call the provider named, and differ only
+            # for one it did not: the client drew that card under an id it
+            # minted itself, and an event sent to any other id opens a second.
+            card_id = decision.card_id
             needs_confirmation = (
                 confirm_tool_calls and not bypass_permissions and permission_mode != "off"
             )
@@ -1230,7 +1774,7 @@ async def stream_with_studio_tools(
                     {
                         "type": "tool_end",
                         "tool_name": name,
-                        "tool_call_id": call_id,
+                        "tool_call_id": card_id,
                         "result": TOOL_REJECTED_MESSAGE,
                         "provenance": decision.provenance,
                     }
@@ -1289,7 +1833,7 @@ async def stream_with_studio_tools(
             tool_stream = stream_tool_execution(
                 _invoke,
                 tool_name = name,
-                tool_call_id = call_id,
+                tool_call_id = card_id,
                 cancel_event = cancel_event,
             )
             outcome: dict[str, Any] = {}

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -227,19 +227,11 @@ def _chunk_payload(line: str) -> dict[str, Any] | None:
 
 
 def _mint_streamed_card_id(taken: set[str], index: Any) -> str:
-    """The id the client painted this call's card under.
+    """The id the client painted an id-less call's card under.
 
-    A call the provider gave no id to still needs one, and the client minted
-    its own the moment the delta arrived: ``tool_call_<delta index>`` for the
-    first call in a slot, then the lowest free ``tool_call_<n>`` for each call
-    split out of it. Both halves walk the same deltas in the same order, so
-    reproducing that rule here lands on the same spelling, and ``tool_start``
-    and ``tool_end`` reach the card the stream already drew instead of pushing
-    a second one beside it.
-
-    This is a card id and never a conversation id: what is stored and replayed
-    upstream stays ``call_<round>_<position>``, so threads written before this
-    keep resolving.
+    ``tool_call_<delta index>``, else the lowest free ``tool_call_<n>``: the
+    client's rule, reproduced so tool_start and tool_end reach the card the
+    stream drew. A card id only; the replayed id stays ``call_<round>_<pos>``.
     """
     preferred = (
         f"tool_call_{index}" if isinstance(index, int) and not isinstance(index, bool) else ""
@@ -378,27 +370,17 @@ class ToolLoopPolicy:
 
 
 def _reject_json_constant(name: str) -> Any:
-    """Refuse ``NaN`` / ``Infinity``, which ``json.loads`` takes and JSON does not.
-
-    ``JSON.parse`` has no such literals, so leaving them accepted here lets the
-    two scanners cut the same text in different places: the backend would run
-    two calls where the frontend shows one.
-    """
+    """Refuse ``NaN`` / ``Infinity``: ``json.loads`` takes them, ``JSON.parse`` does not."""
     raise ValueError(f"{name} is not JSON")
 
 
 def _split_top_level_json_objects(text: str) -> tuple[list[str], str]:
     """The top-level JSON objects in ``text``, and any object still unfinished.
 
-    A call's ``function.arguments`` is one JSON object, so a second top-level
-    ``{`` means one index slot took a second parallel call. Text that is not a
-    run of whole objects (top-level array or scalar, trailing junk, unbalanced
-    brace) comes back whole as the tail, so a stream this was never meant for
-    is left alone.
-
-    Mirrors ``splitTopLevelJsonObjects`` in
-    ``studio/frontend/src/features/chat/tool-call-arguments.ts``: the two see
-    the same deltas and have to agree on where a call ends.
+    A second top-level ``{`` means one slot took a second parallel call. Text
+    that is not a run of whole objects comes back whole, so a stream this was
+    never meant for is left alone. Must agree with
+    ``splitTopLevelJsonObjects`` in ``chat/tool-call-arguments.ts``.
     """
     unsplit: tuple[list[str], str] = ([], text)
     complete: list[str] = []
@@ -439,23 +421,14 @@ def _split_top_level_json_objects(text: str) -> tuple[list[str], str]:
                     json.loads(
                         segment,
                         parse_constant = _reject_json_constant,
-                        # Validation only, so the numbers are never read: keeping
-                        # them as text sidesteps the 4300-digit cap on int
-                        # conversion, which JSON.parse does not have and which
-                        # would otherwise make the two disagree on where a call
-                        # ends over a literal that fits in an ordinary payload.
+                        # As text: JSON.parse has no 4300-digit int cap.
                         parse_int = str,
                     )
                 except (ValueError, TypeError):
-                    # Balanced but invalid, so the brace count was a
-                    # coincidence and cutting here would invent a call.
+                    # Balanced but invalid: cutting here would invent a call.
                     return unsplit
                 except RecursionError:
-                    # Deeply nested but valid JSON blows the interpreter's stack
-                    # instead of failing to decode, and RecursionError is not a
-                    # ValueError. Uncaught it escapes the loop mid-stream, so
-                    # the segment counts as unsplittable and _normalized_call
-                    # downgrades it to _raw as it always has.
+                    # Valid but too deep to decode, and not a ValueError.
                     return unsplit
                 complete.append(segment)
                 start = -1
@@ -467,15 +440,9 @@ def _split_top_level_json_objects(text: str) -> tuple[list[str], str]:
 class _BoundaryScan:
     """``_split_top_level_json_objects`` over a string that only ever grows.
 
-    One call's arguments arrive as many small fragments, and rescanning the
-    whole accumulation per fragment makes streaming one argument of length N
-    cost O(N^2): a 10 KB argument delivered a character at a time took about
-    five seconds, which stalls the response. The scan resumes where it stopped
-    instead, so the same argument costs one pass in total.
-
-    ``feed`` must be given the same string extended, never a rewritten one --
-    a fork rewrites a slot's arguments, so ``_Turn`` drops the scan for the
-    keys it touches and lets the next fragment start a fresh one.
+    Rescanning per fragment is O(N^2); resuming is one pass. ``feed`` takes the
+    same string extended, never a rewritten one, so ``_Turn`` drops the scan
+    for any key a fork rewrites.
     """
 
     depth: int = 0
@@ -484,8 +451,7 @@ class _BoundaryScan:
     escaped: bool = False
     scanned: int = 0
     complete: list[str] = field(default_factory = list)
-    # Junk at depth 0 or a segment that does not parse makes the whole string
-    # unsplittable, and appending to it can never make it splittable again.
+    # Once unsplittable, appending can never make it splittable again.
     unsplittable: bool = False
 
     def feed(self, text: str) -> tuple[list[str], str]:
@@ -552,14 +518,12 @@ class _Turn:
     split_seq: int = 0
     seq_by_key: dict[Any, int] = field(default_factory = dict)
     seq_counter: int = 0
-    # Which call each id names, so a fragment repeating an id reaches its own
-    # call even when a later call at that index is the one currently open.
+    # Which call each id names: a fragment repeating one returns to its call.
     key_by_call_id: dict[str, Any] = field(default_factory = dict)
     # Resumable boundary scan per call, keyed the same as ``by_index``.
     scan_by_key: dict[Any, _BoundaryScan] = field(default_factory = dict)
-    # Split-born calls whose object had not closed when they were forked off.
-    # Reported only once it does: a stream cut short after "{\"a\":1}{" would
-    # otherwise run the tool a second time on half an argument.
+    # Forks whose object never closed: reported only once it does, or a stream
+    # cut short after '{"a":1}{' runs the tool again on half an argument.
     open_tail_keys: set[Any] = field(default_factory = set)
     round: int = 0
     healed: list[dict[str, Any]] = field(default_factory = list)
@@ -679,11 +643,8 @@ class _Turn:
             # belong to the newer call.
             key: Any = self.open_key_by_index.get(index, index)
             if isinstance(call_id, str) and call_id:
-                # An id beats the latest-index mapping, which only places
-                # fragments carrying no id: a fragment repeating an id returns
-                # to the call wearing it wherever that call now sits. Matching
-                # the open call instead renamed a newer one and gave it a second
-                # copy of the id.
+                # An id beats the latest-index mapping: a fragment repeating
+                # one returns to its own call wherever that call now sits.
                 owner = self.key_by_call_id.get(call_id)
                 if owner is not None:
                     key = owner
@@ -708,10 +669,8 @@ class _Turn:
             # a closing brace belongs to the object just closed, and forking on
             # a stray scalar suffix would run the tool twice.
             # An id names a call outright, so one naming a DIFFERENT call opens
-            # the next even before its arguments arrive. On its own, or
-            # repeating the name the slot holds, it is that call's id stamped
-            # late, and forking there strands the finished call under its
-            # provisional id beside an empty second one.
+            # the next even before its arguments arrive. Alone, or repeating
+            # the slot's name, it is that call's id stamped late.
             held_name_now = held["function"]["name"] if held is not None else ""
             id_names_another_call = bool(
                 isinstance(call_id, str)
@@ -719,19 +678,12 @@ class _Turn:
                 and isinstance(new_name, str)
                 and new_name
                 and held_name_now
-                # Not a prefix test: an id is strong evidence of its own call,
-                # and a catalog holding both "web" and "web_search" would have
-                # the second claim the first and glue their arguments together.
-                # Only the same name, or none, reads as that call's id arriving
-                # late.
+                # Not a prefix test: a catalog holds both "web" and
+                # "web_search", so only the same name reads as the same call.
                 and new_name != held_name_now
             )
-            # A snapshot-style provider repeats the finished call verbatim once
-            # it has an id for it. Same name and byte-identical arguments, with
-            # an id the slot does not hold yet, is that call arriving to be
-            # claimed; opening a second runs a side-effecting tool twice. Exact
-            # repeats of an id-less call only, so parallel calls differing
-            # anywhere still both run.
+            # A snapshot provider repeats the finished call verbatim once it
+            # has an id. Exact repeats only, so a second call still opens.
             resends_this_call = bool(
                 held is not None
                 and isinstance(call_id, str)
@@ -742,22 +694,15 @@ class _Turn:
                 and isinstance(new_arguments, str)
                 and new_arguments == held["function"]["arguments"]
             )
-            # A name arriving at a slot whose object has closed announces the
-            # next call. A name grows across deltas only while it is being
-            # streamed, which is before the arguments, so once the object has
-            # closed there is nothing left for a fragment to extend and the
-            # only thing a name can mean is the next call. Testing for a shared
-            # prefix instead read "web" after "web_search" as that call's name
-            # resent and swallowed the second call. Without any of this, the
-            # reported stream delivered one character per delta merges two
-            # calls' names into "web_fetchweb_search", which matches no tool.
+            # A name at a closed slot announces the next call: names grow
+            # before the arguments, so nothing is left to extend. A shared
+            # prefix is no proof ("web" after "web_search" is a second call).
             names_next_call = bool(
                 isinstance(new_name, str)
                 and new_name
                 and held_name_now
-                # The same name is that call's, resent: llama-server repeats it
-                # on every delta and vLLM has repeated the whole name too, so
-                # forking there would run one request twice.
+                # The same name is that call's, resent: llama-server and vLLM
+                # both repeat it, and forking runs one request twice.
                 and new_name != held_name_now
             )
             opens_next_call = (
@@ -765,12 +710,9 @@ class _Turn:
                 or id_names_another_call
                 or names_next_call
             ) and not resends_this_call
-            # A slot holding only an announcement has no object to close, so
-            # the rule above cannot reach it. A DIFFERENT name arriving there
-            # with an object of its own is the next call: a name still growing
-            # arrives on its own, before any arguments. Without this the
-            # announcement's name and the next call's glue into "A_longB",
-            # which matches no tool and silently never runs.
+            # An announcement has no object to close, so the rule above cannot
+            # reach it. A different name bringing an object is the next call;
+            # gluing gave "A_longB", which matches no tool.
             announces_over_announcement = (
                 held is not None
                 and (held.get("announced_only") is True or held.get("resend_suspect") is True)
@@ -781,10 +723,8 @@ class _Turn:
                 and isinstance(new_arguments, str)
                 and new_arguments.strip().startswith("{")
             )
-            # An id names its call, so a fragment repeating the id this slot
-            # already holds continues it however complete its arguments look --
-            # llama-server grows the name across deltas, and forking there gives
-            # two calls one id, with the arguments on the abandoned name.
+            # A fragment repeating the id this slot holds continues it however
+            # complete the arguments look, or two calls end up with one id.
             names_this_call = (
                 held is not None
                 and isinstance(call_id, str)
@@ -798,45 +738,29 @@ class _Turn:
             extra = raw_call.get("extra_content")
             if (slot_is_closed and opens_next_call) or announces_over_announcement:
                 if announces_over_announcement and held is not None:
-                    # Another call took this slot over while it still held only
-                    # its name, so the announcement was never a call of its own.
+                    # Taken over while it held only its name.
                     held["superseded"] = True
                 self.split_seq += 1
                 key = (index, "_split", self.split_seq)
             self.last_index = index
             self.open_key_by_index[index] = key
             if key not in self.by_index:
-                # An id-less provider reusing the index for another call to the
-                # same tool can leave the repeated name out, the first delta
-                # having given it. An empty name is no tool, so _normalized_call
-                # drops the call and the user is one result short; the call this
-                # slot just closed is the only name it can mean.
+                # A second call to the same tool can arrive with no name, the
+                # first delta having given it. Nameless is dropped, so inherit.
                 opening_name = new_name if isinstance(new_name, str) and new_name else held_name_now
                 self.by_index[key] = {
                     "id": "",
                     "type": "function",
                     "function": {"name": opening_name, "arguments": ""},
-                    # A name with no `arguments` field at all is a call the
-                    # stream said it was about to make. A tool that takes no
-                    # parameters sends an empty string rather than no field, so
-                    # this marks only the announcement, and `calls` drops one
-                    # still empty when the turn ends. Kept, it would run a tool
-                    # the model never actually asked for.
+                    # A name with no `arguments` field is an announcement; a
+                    # zero-parameter tool sends "" rather than no field.
                     "announced_only": new_arguments is None and bool(opening_name),
-                    # Whether this slot is a fork's guess or a slot the
-                    # provider opened itself. An announcement the provider
-                    # opened is a call it means to make, most likely to a tool
-                    # that takes no parameters; one a fork invented has no
-                    # such standing, and if nothing ever fills it there is
-                    # nothing to run.
+                    # A fork's guess, or a slot the provider opened itself.
+                    # Only the provider's own announcement runs unfilled.
                     "from_fork": held is not None,
-                    # A name that extends the name of the call this fork just
-                    # left behind is most likely that call's, resent. It still
-                    # opens a slot, because a catalog holding both "web" and
-                    # "web_search" makes the prefix no proof either way, but
-                    # the slot gives way rather than gluing if another name
-                    # brings the object: "alpha_long" then "beta" was reported
-                    # as "alpha_longbeta", which matches no tool.
+                    # A name extending the one this fork left behind is most
+                    # likely it, resent. It still opens a slot (the prefix is no
+                    # proof) but gives way rather than gluing "alpha_longbeta".
                     "resend_suspect": bool(
                         opening_name
                         and held_name_now
@@ -854,8 +778,7 @@ class _Turn:
             if isinstance(call_id, str) and call_id:
                 current["id"] = call_id
                 self.key_by_call_id.setdefault(call_id, key)
-            # What the slot carried before this delta, so a fork below can hand
-            # this delta's metadata to the call it actually closes.
+            # So a fork below can hand this delta's metadata to its own call.
             extra_before = current.get("extra_content")
             if isinstance(extra, dict) and extra:
                 # Gemini 3 stows this call's thoughtSignature here, and the
@@ -874,12 +797,10 @@ class _Turn:
                 # else continues it.
                 fragment = function.get("name")
                 name_before = current["function"]["name"]
-                # Not once this call's object has closed AND it already has a
-                # name: the rule above has forked the next call, and rewriting
-                # a finished call's name would put arguments validated against
-                # one tool's schema under another tool's name. Naming a call
-                # that has none is not a rename, and some servers do send the
-                # arguments first and the name only in a later chunk.
+                # Never once the object has closed AND a name is set: that
+                # would put one tool's arguments under another's name. Naming a
+                # call that has none is not a rename, and servers do send the
+                # arguments first.
                 if isinstance(fragment, str) and fragment and not (slot_is_closed and name_before):
                     if fragment.startswith(name_before):
                         current["function"]["name"] = fragment
@@ -888,10 +809,9 @@ class _Turn:
                 if isinstance(function.get("arguments"), str) and not resends_this_call:
                     current["function"]["arguments"] += function["arguments"]
                     if not (isinstance(call_id, str) and call_id):
-                        # The id fork above cannot see this one: an id-less
-                        # stream has no ids to differ, so appending glued two
-                        # calls into one unparseable blob that then rides into
-                        # the next request verbatim (issue #9807).
+                        # The id fork cannot see this: an id-less stream has no
+                        # ids to differ on, so appending glued two calls into
+                        # one unparsable blob (issue #9807).
                         self._fork_glued_arguments(
                             index,
                             key,
@@ -932,21 +852,15 @@ class _Turn:
         # Below rewrites this slot's arguments rather than extending them, so
         # the resumable scan no longer describes the string it was reading.
         self.scan_by_key.pop(key, None)
-        # The slot keeps the object it opened with, under the name and id it
-        # had. Nothing per-call rides along: extra_content carries this call's
-        # thoughtSignature, and two calls claiming it is a rejected turn.
+        # The slot keeps its first object, name and id. Nothing per-call rides
+        # along: two calls claiming one thoughtSignature is a rejected turn.
         current["function"]["arguments"] = segments[0]
-        # A name arriving with this delta names the calls it opened, so the slot
-        # goes back to its own. Without this the two dialects above merge them:
-        # "alpha" then "gamma" at one index becomes "alphagamma", matching no
-        # enabled tool and silently never running.
+        # A name on this delta names the calls it opened, so the slot keeps its
+        # own: merging gave "alphagamma", which matches no enabled tool.
         born_name = incoming_name or name_before
         current["function"]["name"] = name_before or born_name
-        # The metadata this delta carried belongs to the call this delta closes,
-        # which is the last one, not to the object the slot already held. Gemini
-        # checks the opaque signature against the exact call it is replayed on,
-        # so leaving it here gets the follow-up rejected. Same placement as the
-        # frontend split.
+        # This delta's metadata belongs to the call it closes, the last one:
+        # Gemini checks the signature against the call it is replayed on.
         if incoming_extra is not None:
             if extra_before:
                 current["extra_content"] = extra_before
@@ -968,7 +882,7 @@ class _Turn:
             open_key = born_key
         if incoming_extra is not None:
             self.by_index[open_key]["extra_content"] = dict(incoming_extra)
-        # Later id-less fragments continue the last call, finished or not.
+        # Later id-less fragments continue the last call.
         self.open_key_by_index[index] = open_key
 
     def _call_is_finished(self, key: Any) -> bool:
@@ -1010,11 +924,8 @@ class _Turn:
         seen: set[str] = taken if taken is not None else set()
         painted: set[str] = cards if cards is not None else set()
         out: list[dict[str, Any]] = []
-        # Ordered by when the stream announced each call, so one announced
-        # second is not run third because another index opened in between. Keyed
-        # on the sequence number alone: comparing the calls themselves to break
-        # a tie raises rather than sorts, and the sort is stable, so a shared
-        # number keeps the order the calls were found in.
+        # Announcement order, so an index opening in between cannot reorder
+        # them. On the sequence number alone: comparing calls raises.
         numbered = [
             (
                 self.seq_by_key.get(key, position),
@@ -1027,14 +938,11 @@ class _Turn:
         ordered = [
             (index, call) for _, index, call in sorted(numbered, key = lambda triple: triple[0])
         ]
-        # An announcement another call took over, and a name that only ever
-        # looked like the closed call's resent, were never calls of their own.
-        # A lone announcement the provider opened itself is kept: a tool that
-        # takes no parameters is announced exactly that way and does have to
-        # run. Its
-        # metadata still belongs to this turn -- Gemini stows a thought
-        # signature there and the native translator rejects a replay without
-        # one -- so it goes to the call the announcement was mistaken for.
+        # An announcement another call took over, and a name that only looked
+        # like the closed call's resent, were never calls. A lone announcement
+        # the provider opened is kept (a zero-parameter tool looks like that).
+        # Its metadata goes to the call it was mistaken for: Gemini stows a
+        # thought signature there and rejects a replay without one.
         kept: list[tuple[Any, dict[str, Any]]] = []
         for index, call in ordered:
             never_ran = not call["function"]["arguments"]
@@ -1050,8 +958,7 @@ class _Turn:
                 continue
             kept.append((index, call))
         ordered = kept
-        # A provider id the stream did carry is reserved, so a minted card id
-        # can never collide with one the client is already keying a card on.
+        # Provider ids reserved first, so a minted card id never collides.
         painted.update(
             call["id"] for _, call in ordered if isinstance(call.get("id"), str) and call["id"]
         )
@@ -1061,9 +968,8 @@ class _Turn:
             if normalized is None:
                 continue
             if not (isinstance(streamed_id, str) and streamed_id):
-                # No id on the wire, so the client minted one and drew a card
-                # under it. Mint the same one here and address the card events
-                # to it; the conversation id above is untouched.
+                # No id on the wire: mint the client's spelling for the card
+                # events. The conversation id above is untouched.
                 card_id = _mint_streamed_card_id(painted, index)
                 painted.add(card_id)
                 normalized["card_id"] = card_id
@@ -1336,9 +1242,8 @@ async def stream_with_studio_tools(
     last_reprompt_text = ""
     provider_turns = 0
     used_call_ids: set[str] = _replayed_call_ids(conversation)
-    # Card ids handed out so far in this response. The client keeps one list of
-    # cards across every round, so the numbering has to keep going rather than
-    # restart and reopen a card an earlier round already closed.
+    # Card ids handed out this response. The client keeps one list across all
+    # rounds, so the numbering carries rather than reopening an earlier card.
     painted_card_ids: set[str] = set()
     spent_budget_passes = 0
     fruitless_turns = 0
@@ -1703,10 +1608,8 @@ async def stream_with_studio_tools(
             name = decision.tool_name
             arguments = decision.arguments
             call_id = decision.tool_call_id
-            # What the conversation replays and what the card is addressed to
-            # are the same id for a call the provider named, and differ only
-            # for one it did not: the client drew that card under an id it
-            # minted itself, and an event sent to any other id opens a second.
+            # Same id for a call the provider named; for one it did not, the
+            # card answers to the id the client minted.
             card_id = decision.card_id
             needs_confirmation = (
                 confirm_tool_calls and not bypass_permissions and permission_mode != "off"

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -965,9 +965,7 @@ class _Turn:
         painted.update(
             call["id"]
             for _, call in ordered
-            if isinstance(call.get("id"), str)
-            and call["id"]
-            and _normalized_call(call) is not None
+            if isinstance(call.get("id"), str) and call["id"] and _normalized_call(call) is not None
         )
         for position, (index, call) in enumerate(ordered + [(None, call) for call in self.healed]):
             streamed_id = call.get("id")

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -523,12 +523,11 @@ class _Turn:
     # Resumable boundary scan per call, keyed the same as ``by_index``.
     scan_by_key: dict[Any, _BoundaryScan] = field(default_factory = dict)
     # Forks whose object never closed: reported only once it does, or a stream
-    # cut short after '{"a":1}{' runs the tool again on half an argument.
+    # cut short after '{"a":1}{' runs the tool on half an argument.
     open_tail_keys: set[Any] = field(default_factory = set)
-    # Metadata from a delta whose name repeated the one the slot holds. That
-    # name is either the call's, resent, or the next call to the same tool
-    # announcing itself, and only the object that follows tells them apart, so
-    # the metadata waits here rather than landing on the wrong call.
+    # Metadata from a delta repeating the slot's name. That name is either the
+    # call's, resent, or the next call to the same tool announcing itself, and
+    # only the object that follows tells them apart.
     pending_extra: dict[Any, dict[str, Any]] = field(default_factory = dict)
     round: int = 0
     healed: list[dict[str, Any]] = field(default_factory = list)
@@ -658,10 +657,9 @@ class _Turn:
                     # concatenates their argument JSON into one unparseable blob
                     # and loses an intent, so key the second on its own id.
                     key = (index, call_id)
-            # A closed object cannot take more content, so the next arguments to
-            # reach a slot already holding one whole object belong to the next
-            # parallel call. Forking on the accumulated text alone only catches
-            # this once those arguments glue on, and a delta carrying an id
+            # A closed object takes no more content, so the next arguments to reach the
+            # slot belong to the next parallel call. Forking on the accumulated text
+            # alone catches this only once they glue on, and a delta carrying an id
             # would claim the finished call and append to it (issue #9807).
             held = self.by_index.get(key)
             new_function = raw_call.get("function")
@@ -715,9 +713,9 @@ class _Turn:
                 or id_names_another_call
                 or names_next_call
             ) and not resends_this_call
-            # An announcement has no object to close, so the rule above cannot
-            # reach it. A different name bringing an object is the next call;
-            # gluing gave "A_longB", which matches no tool.
+            # An announcement has no object to close, so the rule above cannot reach
+            # it. A different name bringing an object is the next call; gluing gave
+            # "A_longB", which matches no tool.
             announces_over_announcement = (
                 held is not None
                 and (held.get("announced_only") is True or held.get("resend_suspect") is True)
@@ -741,10 +739,10 @@ class _Turn:
                 closed, unfinished = self._scan(key, held["function"]["arguments"])
                 slot_is_closed = bool(closed) and not unfinished
             extra = raw_call.get("extra_content")
-            # A name repeating the one a closed slot holds says nothing new
-            # about that call, so metadata riding it belongs to whichever call
-            # the next object opens; merged here it overwrites the signature the
-            # closed call arrived with and leaves the next call unsigned.
+            # A name repeating a closed slot's says nothing new about that call, so
+            # metadata riding it belongs to whichever call the next object opens.
+            # Merged here it overwrites that call's signature and leaves the next
+            # unsigned.
             extra_is_ambiguous = bool(
                 slot_is_closed
                 and isinstance(new_name, str)
@@ -779,9 +777,8 @@ class _Turn:
                     # A fork's guess, or a slot the provider opened itself.
                     # Only the provider's own announcement runs unfilled.
                     "from_fork": held is not None,
-                    # A name extending the one this fork left behind is most
-                    # likely it, resent. It still opens a slot (the prefix is no
-                    # proof) but gives way rather than gluing "alpha_longbeta".
+                    # A name extending the one this fork left behind is most likely it, resent.
+                    # It still opens a slot, but gives way rather than gluing "alpha_longbeta".
                     "resend_suspect": bool(
                         opening_name
                         and held_name_now
@@ -823,10 +820,9 @@ class _Turn:
                 # else continues it.
                 fragment = function.get("name")
                 name_before = current["function"]["name"]
-                # Never once the object has closed AND a name is set: that
-                # would put one tool's arguments under another's name. Naming a
-                # call that has none is not a rename, and servers do send the
-                # arguments first.
+                # Never once the object has closed AND a name is set: that puts one tool's
+                # arguments under another's name. Naming a call that has none is not a
+                # rename, and servers do send the arguments first.
                 if isinstance(fragment, str) and fragment and not (slot_is_closed and name_before):
                     if fragment.startswith(name_before):
                         current["function"]["name"] = fragment
@@ -835,9 +831,8 @@ class _Turn:
                 if isinstance(function.get("arguments"), str) and not resends_this_call:
                     current["function"]["arguments"] += function["arguments"]
                     if not (isinstance(call_id, str) and call_id):
-                        # The id fork cannot see this: an id-less stream has no
-                        # ids to differ on, so appending glued two calls into
-                        # one unparsable blob (issue #9807).
+                        # The id fork cannot see this: an id-less stream has no ids to differ on,
+                        # so appending glued two calls into one blob (issue #9807).
                         self._fork_glued_arguments(
                             index,
                             key,

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -958,9 +958,16 @@ class _Turn:
                 continue
             kept.append((index, call))
         ordered = kept
-        # Provider ids reserved first, so a minted card id never collides.
+        # Provider ids reserved first, so a minted card id never collides. Only
+        # the ones _normalized_call keeps: a call it rejects draws no card, the
+        # client releases the id it had minted for it, and an id held here that
+        # the client has given back puts the two out of step from the next round.
         painted.update(
-            call["id"] for _, call in ordered if isinstance(call.get("id"), str) and call["id"]
+            call["id"]
+            for _, call in ordered
+            if isinstance(call.get("id"), str)
+            and call["id"]
+            and _normalized_call(call) is not None
         )
         for position, (index, call) in enumerate(ordered + [(None, call) for call in self.healed]):
             streamed_id = call.get("id")
@@ -1442,16 +1449,17 @@ async def stream_with_studio_tools(
             # the rest of the response. Close it the way every other unrun call
             # is closed. Structured only: a healed call was never streamed, and
             # the span released just above is what tells the user about that one.
-            for raw_call in turn.by_index.values():
-                truncated_id = raw_call.get("id")
-                function = raw_call.get("function")
-                name = function.get("name") if isinstance(function, dict) else None
-                if not isinstance(truncated_id, str) or not truncated_id:
-                    continue
-                if not isinstance(name, str) or not name:
-                    # Not enough of the call arrived to name a tool, so there is
-                    # no card of ours to close.
-                    continue
+            # Through `calls`, which never executes anything: it is what mints
+            # the card id for a call the provider gave none, and the client drew
+            # its card under that same spelling. Reading the slots directly left
+            # every id-less call out, so the card the deltas painted spun for the
+            # rest of the response. Calls it drops -- nameless, or a fork whose
+            # object never closed -- have no card of ours to close either.
+            for raw_call in turn.calls(used_call_ids, painted_card_ids):
+                truncated_id = (
+                    raw_call.get("card_id") or raw_call.get("stream_id") or raw_call["id"]
+                )
+                name = raw_call["function"]["name"]
                 for card_line in _unrun_call_card(
                     tool_name = name,
                     tool_call_id = truncated_id,
@@ -1474,6 +1482,13 @@ async def stream_with_studio_tools(
             else turn.calls(used_call_ids, painted_card_ids)
         )
         if not calls:
+            # The badge clears between iterations, and this turn is over too.
+            # Without it a turn whose only call was refused never reaches the
+            # empty status below, so the client keeps the card it drew for that
+            # call open and a reprompted call merges into it: an upstream ending
+            # on [DONE] sends no finish_reason either, so there is no other
+            # boundary on this path.
+            yield _status_sse("")
             # No tool this turn. A model that only said what it was about to do
             # gets one nudge to actually do it, the same recovery the local loops
             # give a stalled small model, then the answer stands as written.

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -773,10 +773,7 @@ class _Turn:
             # which matches no tool and silently never runs.
             announces_over_announcement = (
                 held is not None
-                and (
-                    held.get("announced_only") is True
-                    or held.get("resend_suspect") is True
-                )
+                and (held.get("announced_only") is True or held.get("resend_suspect") is True)
                 and not held["function"]["arguments"]
                 and isinstance(new_name, str)
                 and bool(new_name)
@@ -883,11 +880,7 @@ class _Turn:
                 # one tool's schema under another tool's name. Naming a call
                 # that has none is not a rename, and some servers do send the
                 # arguments first and the name only in a later chunk.
-                if (
-                    isinstance(fragment, str)
-                    and fragment
-                    and not (slot_is_closed and name_before)
-                ):
+                if isinstance(fragment, str) and fragment and not (slot_is_closed and name_before):
                     if fragment.startswith(name_before):
                         current["function"]["name"] = fragment
                     else:

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -1485,8 +1485,11 @@ async def stream_with_studio_tools(
             # empty status below, so the client keeps the card it drew for that
             # call open and a reprompted call merges into it: an upstream ending
             # on [DONE] sends no finish_reason either, so there is no other
-            # boundary on this path.
-            yield _status_sse("")
+            # boundary on this path. Only when a call was streamed: a turn that
+            # said nothing at all left the client nothing to close, and a
+            # provider that sends no lines still ends the response silently.
+            if turn.by_index:
+                yield _status_sse("")
             # No tool this turn. A model that only said what it was about to do
             # gets one nudge to actually do it, the same recovery the local loops
             # give a stalled small model, then the answer stands as written.

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -525,6 +525,11 @@ class _Turn:
     # Forks whose object never closed: reported only once it does, or a stream
     # cut short after '{"a":1}{' runs the tool again on half an argument.
     open_tail_keys: set[Any] = field(default_factory = set)
+    # Metadata from a delta whose name repeated the one the slot holds. That
+    # name is either the call's, resent, or the next call to the same tool
+    # announcing itself, and only the object that follows tells them apart, so
+    # the metadata waits here rather than landing on the wrong call.
+    pending_extra: dict[Any, dict[str, Any]] = field(default_factory = dict)
     round: int = 0
     healed: list[dict[str, Any]] = field(default_factory = list)
     text: list[str] = field(default_factory = list)
@@ -736,12 +741,28 @@ class _Turn:
                 closed, unfinished = self._scan(key, held["function"]["arguments"])
                 slot_is_closed = bool(closed) and not unfinished
             extra = raw_call.get("extra_content")
+            # A name repeating the one a closed slot holds says nothing new
+            # about that call, so metadata riding it belongs to whichever call
+            # the next object opens; merged here it overwrites the signature the
+            # closed call arrived with and leaves the next call unsigned.
+            extra_is_ambiguous = bool(
+                slot_is_closed
+                and isinstance(new_name, str)
+                and new_name
+                and new_name == held_name_now
+                and isinstance(extra, dict)
+                and extra
+            )
             if (slot_is_closed and opens_next_call) or announces_over_announcement:
                 if announces_over_announcement and held is not None:
                     # Taken over while it held only its name.
                     held["superseded"] = True
                 self.split_seq += 1
+                waiting = self.pending_extra.pop(key, None)
                 key = (index, "_split", self.split_seq)
+                if waiting:
+                    # The object proved the repeated name announced this call.
+                    extra = {**waiting, **extra} if isinstance(extra, dict) else waiting
             self.last_index = index
             self.open_key_by_index[index] = key
             if key not in self.by_index:
@@ -780,7 +801,12 @@ class _Turn:
                 self.key_by_call_id.setdefault(call_id, key)
             # So a fork below can hand this delta's metadata to its own call.
             extra_before = current.get("extra_content")
-            if isinstance(extra, dict) and extra:
+            if extra_is_ambiguous:
+                self.pending_extra[key] = {
+                    **self.pending_extra.get(key, {}),
+                    **extra,
+                }
+            elif isinstance(extra, dict) and extra:
                 # Gemini 3 stows this call's thoughtSignature here, and the
                 # native translator rejects a replayed functionCall without it.
                 # Per call, so it cannot ride along on the delta-level slot.
@@ -943,6 +969,13 @@ class _Turn:
         # the provider opened is kept (a zero-parameter tool looks like that).
         # Its metadata goes to the call it was mistaken for: Gemini stows a
         # thought signature there and rejects a replay without one.
+        for key, waiting in self.pending_extra.items():
+            # No object ever came, so the repeated name was that call's after
+            # all and so is the metadata that rode it.
+            held = self.by_index.get(key)
+            if held is not None and waiting:
+                held["extra_content"] = {**held.get("extra_content", {}), **waiting}
+        self.pending_extra.clear()
         kept: list[tuple[Any, dict[str, Any]]] = []
         for index, call in ordered:
             never_ran = not call["function"]["arguments"]

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -190,6 +190,10 @@ class ToolCallDecision:
     tool_name: str
     arguments: dict[str, Any]
     tool_call_id: str = ""
+    # The id the card carries on screen. For a call the provider gave no id to
+    # this is the spelling the client already minted, which is not the id the
+    # conversation replays; for every other call the two are the same.
+    card_call_id: str = ""
     key: str = ""
     provenance: dict[str, Any] = field(default_factory = dict)
     status_text: str = ""
@@ -198,6 +202,11 @@ class ToolCallDecision:
     @property
     def should_execute(self) -> bool:
         return self.action == "execute"
+
+    @property
+    def card_id(self) -> str:
+        """The id every frontend-visible event for this call is addressed to."""
+        return self.card_call_id or self.tool_call_id
 
     @property
     def emit_visible_events(self) -> bool:
@@ -232,7 +241,7 @@ class ToolCallDecision:
         arguments = {"raw": fragment} if fragment is not None else self.arguments
         return {
             "tool_name": self.tool_name,
-            "tool_call_id": self.tool_call_id,
+            "tool_call_id": self.card_id,
             "arguments": arguments,
             "provenance": self.provenance,
         }
@@ -282,7 +291,7 @@ class ToolCallCompletion:
         """Build the payload fields for a real tool_end event."""
         return {
             "tool_name": self.decision.tool_name,
-            "tool_call_id": self.decision.tool_call_id,
+            "tool_call_id": self.decision.card_id,
             "result": self.result,
             "provenance": self.decision.provenance,
         }
@@ -723,6 +732,7 @@ class ToolLoopController:
             tool_name = tool_name,
             arguments = coerced.arguments,
             tool_call_id = str(tool_call.get("id") or ""),
+            card_call_id = str(tool_call.get("card_id") or ""),
             key = key,
             provenance = provenance,
             status_text = status_for_tool(tool_name, coerced.arguments),

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -190,9 +190,9 @@ class ToolCallDecision:
     tool_name: str
     arguments: dict[str, Any]
     tool_call_id: str = ""
-    # The id the card carries on screen. For a call the provider gave no id to
-    # this is the spelling the client already minted, which is not the id the
-    # conversation replays; for every other call the two are the same.
+    # The id the card carries on screen. For an id-less call that is the
+    # spelling the client minted, not the id the conversation replays;
+    # otherwise the two are the same.
     card_call_id: str = ""
     key: str = ""
     provenance: dict[str, Any] = field(default_factory = dict)

--- a/studio/backend/tests/test_external_tool_stream_abuse.py
+++ b/studio/backend/tests/test_external_tool_stream_abuse.py
@@ -329,7 +329,14 @@ def test_a_provider_cannot_forge_a_studio_control_frame(executed, forged):
     lines = _run(transport)
 
     assert not executed
-    assert _events(lines, forged["type"]) == []
+    relayed = [
+        event
+        for event in _events(lines, forged["type"])
+        # The loop clears the badge with an empty status of its own once a turn
+        # is over, so it is a status carrying text that would be the provider's.
+        if event.get("content") != ""
+    ]
+    assert relayed == []
     # The forged frame must not survive under any encoding either.
     assert not any("forged-1" in line for line in lines)
 
@@ -1081,3 +1088,62 @@ def test_a_forged_usage_only_chunk_cannot_multiply_the_count(executed):
     usage_chunks = [payload for payload in _payloads(lines) if "usage" in payload]
     assert len(usage_chunks) == 1
     assert usage_chunks[0]["usage"]["prompt_tokens"] == 50
+
+
+def test_a_truncated_turn_closes_the_card_an_id_less_call_painted(executed):
+    # The client draws a card the moment the delta arrives, keyed on an id it
+    # mints because the provider sent none. Reading the slots directly here left
+    # every id-less call out, so refusing to run it left that card spinning for
+    # the rest of the response.
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    delta = {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query":"a"}',
+                                },
+                            }
+                        ]
+                    }
+                ),
+                _sse(finish = "length"),
+                _DONE,
+            ]
+        ]
+    )
+    lines = _run(transport, tools = [WEB])
+
+    assert not executed
+    ends = _events(lines, "tool_end")
+    assert [event.get("tool_call_id") for event in ends] == ["tool_call_0"]
+
+
+def test_a_turn_whose_only_call_is_refused_still_ends(executed):
+    # A nameless call is dropped before it runs, and an upstream ending on
+    # [DONE] sends no finish_reason, so without this the client never reaches a
+    # turn boundary and keeps the card it drew for that call.
+    transport = FakeTransport(
+        [
+            [
+                _sse(
+                    delta = {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '{"query":"a"}'}}
+                        ]
+                    }
+                ),
+                _DONE,
+            ]
+        ]
+    )
+    lines = _run(transport, tools = [WEB])
+
+    assert not executed
+    assert any(
+        event.get("content") == "" for event in _events(lines, "tool_status")
+    )

--- a/studio/backend/tests/test_external_tool_stream_abuse.py
+++ b/studio/backend/tests/test_external_tool_stream_abuse.py
@@ -1131,11 +1131,7 @@ def test_a_turn_whose_only_call_is_refused_still_ends(executed):
         [
             [
                 _sse(
-                    delta = {
-                        "tool_calls": [
-                            {"index": 0, "function": {"arguments": '{"query":"a"}'}}
-                        ]
-                    }
+                    delta = {"tool_calls": [{"index": 0, "function": {"arguments": '{"query":"a"}'}}]}
                 ),
                 _DONE,
             ]
@@ -1144,6 +1140,4 @@ def test_a_turn_whose_only_call_is_refused_still_ends(executed):
     lines = _run(transport, tools = [WEB])
 
     assert not executed
-    assert any(
-        event.get("content") == "" for event in _events(lines, "tool_status")
-    )
+    assert any(event.get("content") == "" for event in _events(lines, "tool_status"))

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -646,8 +646,7 @@ def test_a_claim_on_a_split_born_card_leaves_every_call_its_own():
     turn.merge_structured([_delta(1, "beta", '{"d":4}', call_id = "tool_call_1")])
 
     reported = [
-        (call.get("card_id") or call["id"], call["function"]["arguments"])
-        for call in turn.calls()
+        (call.get("card_id") or call["id"], call["function"]["arguments"]) for call in turn.calls()
     ]
     assert reported == [
         ("tool_call_0", '{"a":1}'),

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -637,6 +637,26 @@ def test_a_provider_claiming_a_minted_id_displaces_the_id_less_call():
     assert reported == [("tool_call_1", "alpha"), ("tool_call_0", "beta")]
 
 
+def test_a_claim_on_a_split_born_card_leaves_every_call_its_own():
+    # The client renumbers its minted cards when a provider claims one of their
+    # spellings, so the numbering here is what it has to land on: the claim
+    # keeps tool_call_1 and the three id-less calls take 0, 2 and 3 in order.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}{"b":2}{"c":3}')])
+    turn.merge_structured([_delta(1, "beta", '{"d":4}', call_id = "tool_call_1")])
+
+    reported = [
+        (call.get("card_id") or call["id"], call["function"]["arguments"])
+        for call in turn.calls()
+    ]
+    assert reported == [
+        ("tool_call_0", '{"a":1}'),
+        ("tool_call_2", '{"b":2}'),
+        ("tool_call_3", '{"c":3}'),
+        ("tool_call_1", '{"d":4}'),
+    ]
+
+
 def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
     # Reading "web_search" as "web" grown gave the id to the completed call.
     turn = _Turn()

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -727,9 +727,7 @@ def test_a_repeated_names_metadata_waits_for_the_call_it_announced():
     # the closed call's and left the new call unsigned, and Gemini validates a
     # signature against the call it is replayed on.
     turn = _Turn()
-    turn.merge_structured(
-        [_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"sig": "A"}}]
-    )
+    turn.merge_structured([_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"sig": "A"}}])
     turn.merge_structured([_delta(0, "lookup", None) | {"extra_content": {"sig": "B"}}])
     turn.merge_structured([_delta(0, None, '{"q":"b"}')])
 
@@ -740,9 +738,7 @@ def test_a_repeated_names_metadata_waits_for_the_call_it_announced():
 
     # No object followed, so the repeated name really was that call's resent.
     kept = _Turn()
-    kept.merge_structured(
-        [_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"own": 1}}]
-    )
+    kept.merge_structured([_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"own": 1}}])
     kept.merge_structured([_delta(0, "lookup", None) | {"extra_content": {"sig": "B"}}])
     assert kept.calls()[0]["extra_content"] == {"own": 1, "sig": "B"}
 

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -665,6 +665,38 @@ def test_a_name_bringing_an_object_over_an_announcement_is_the_next_call():
         assert _reported(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
 
 
+def test_an_unfinished_fork_does_not_reserve_a_card_id():
+    # The client releases the card it drew for the fork this turn filters out,
+    # so the next round has to land on the number the client will mint. Holding
+    # one side's id back moves the two out of step and the tool_start draws a
+    # second card beside the one the deltas painted.
+    taken: set[str] = set()
+    cards: set[str] = set()
+    first = _Turn()
+    first.merge_structured([_delta(0, "alpha", '{"a":1}{')])
+    assert [call.get("card_id") for call in first.calls(taken, cards)] == ["tool_call_0"]
+
+    second = _Turn()
+    second.round = 1
+    second.merge_structured([_delta(0, "beta", '{"b":2}')])
+    assert [call.get("card_id") for call in second.calls(taken, cards)] == ["tool_call_1"]
+
+
+def test_a_provider_claiming_a_minted_id_displaces_the_id_less_call():
+    # Every id the provider sent is reserved before any card id is minted, so
+    # the id-less call moves to tool_call_1 and the claim keeps tool_call_0.
+    # The client reaches the same pair by displacing once the claim lands.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(1, "beta", '{"b":2}', call_id = "tool_call_0")])
+
+    reported = [
+        (call.get("card_id") or call["id"], call["function"]["name"])
+        for call in turn.calls()
+    ]
+    assert reported == [("tool_call_1", "alpha"), ("tool_call_0", "beta")]
+
+
 def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
     # A catalog can hold both "web" and "web_search". Reading the second name as
     # a growth of the first gave the id to the completed call, and the arguments

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -178,9 +178,6 @@ def test_a_name_arriving_in_fragments_is_unaffected():
 
 
 def test_a_name_only_delta_does_not_rename_the_finished_call():
-    # The name arrives before its arguments, so the accumulated text is still
-    # one whole object and there is nothing to fork on yet. Merging it into the
-    # finished call gives "alphabeta", which matches no enabled tool.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured([_delta(0, "beta", "")])
@@ -209,10 +206,6 @@ def test_an_id_after_a_closed_fork_opens_a_third_call():
 
 
 def test_nesting_deep_enough_to_exhaust_the_stack_is_unsplittable():
-    # json.loads raises RecursionError, which is a RuntimeError and not a
-    # ValueError. Uncaught it escapes the streaming loop mid-response, so the
-    # segment counts as unsplittable and _normalized_call downgrades it as
-    # it always has.
     payload = '{"x":' * 20000 + "null" + "}" * 20000
     assert _split_top_level_json_objects(payload) == ([], payload)
 
@@ -222,9 +215,7 @@ def test_nesting_deep_enough_to_exhaust_the_stack_is_unsplittable():
 
 
 def test_a_fragment_repeating_the_slots_id_continues_that_call():
-    # llama-server grows the name across deltas. An id names its call, so
-    # forking here would give two calls one id, with the arguments stranded on
-    # the abandoned name and the grown one running empty.
+    # llama-server grows the name across deltas; forking gives two calls one id.
     turn = _Turn()
     turn.merge_structured([_delta(0, "web", '{"q":"x"}', call_id = "call_a")])
     turn.merge_structured([_delta(0, "web_search", "", call_id = "call_a")])
@@ -247,9 +238,8 @@ def test_whitespace_chunked_after_a_closing_brace_is_not_a_new_call():
 
 
 def test_the_metadata_a_delta_carries_goes_to_the_call_it_closes():
-    # Gemini checks the opaque signature against the exact call it is replayed
-    # on, so it belongs to the last object this delta closed, not to the one
-    # the slot already held. Same placement as the frontend split.
+    # It belongs to the last object this delta closed, which is what Gemini
+    # validates the signature against.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":')])
     turn.merge_structured(
@@ -263,9 +253,7 @@ def test_the_metadata_a_delta_carries_goes_to_the_call_it_closes():
 
 
 def test_nonstandard_numeric_constants_are_not_object_boundaries():
-    # json.loads takes NaN and Infinity; JSON.parse does not. Accepting them
-    # here would cut text the frontend leaves whole, so the backend would run
-    # two calls where the UI shows one.
+    # json.loads takes NaN and Infinity; JSON.parse does not.
     assert _split_top_level_json_objects('{"a":NaN}{"b":2}') == ([], '{"a":NaN}{"b":2}')
     assert _split_top_level_json_objects('{"a":Infinity}{"b":2}') == (
         [],
@@ -279,10 +267,7 @@ def test_nonstandard_numeric_constants_are_not_object_boundaries():
 
 
 def test_an_opening_delta_after_a_closed_call_does_not_claim_it():
-    # The conventional opening delta carries the id and the name with empty
-    # arguments. Landing it on the finished call would put that call's id on it,
-    # so the arguments delta that follows would match and glue on, losing the
-    # call the delta was announcing.
+    # Landing the opening delta on the finished call glues what follows.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured([_delta(0, "beta", "", call_id = "call_b")])
@@ -295,10 +280,7 @@ def test_an_opening_delta_after_a_closed_call_does_not_claim_it():
 
 
 def test_a_name_held_for_the_next_call_grows_across_deltas():
-    # Both dialects the accumulator reconciles reach the held name too: OpenAI
-    # streams "web" then "_search", llama-server resends "web" then
-    # "web_search". Last-write-wins would open the call as "_search", which
-    # matches no enabled tool and silently never runs.
+    # OpenAI streams "web" then "_search"; llama-server resends the whole.
     for fragments in (("web", "_search"), ("web", "web_search")):
         turn = _Turn()
         turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
@@ -310,10 +292,7 @@ def test_a_name_held_for_the_next_call_grows_across_deltas():
 
 
 def test_whitespace_carrying_the_repeated_name_is_not_the_next_call():
-    # A provider that repeats the name on every delta and chunks the trailing
-    # whitespace separately is still writing to the call that closed, so its
-    # name is that call's resent. Parking it merged the two names into
-    # "alphabeta", which matches no enabled tool and silently never runs.
+    # The name is that call's, resent; parking it gave "alphabeta".
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured([_delta(0, "alpha", " ")])
@@ -323,9 +302,8 @@ def test_whitespace_carrying_the_repeated_name_is_not_the_next_call():
 
 
 def test_a_repeated_id_reaches_its_own_call_across_a_later_split():
-    # An id-less call opening after a stable-id call leaves the index pointing
-    # at the newer one. Matching the repeated id against only that call renamed
-    # it, gave it a second copy of the id and stranded the growth fragment.
+    # The index points at the newer call, so matching a repeated id there
+    # renamed it and gave it a second copy of the id.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}', call_id = "call_a")])
     turn.merge_structured([_delta(0, "beta", '{"b":')])
@@ -338,10 +316,8 @@ def test_a_repeated_id_reaches_its_own_call_across_a_later_split():
 
 
 def test_metadata_announced_with_a_name_waits_for_that_call():
-    # Gemini stows the thoughtSignature for the call being announced, so a
-    # name-only delta carrying one describes the next call, not the closed one.
-    # Left behind it gives the closed call another call's signature and the new
-    # call none, and native replay rejects both.
+    # The signature is for the call being announced, and native replay rejects
+    # a call wearing another's.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured(
@@ -356,9 +332,7 @@ def test_metadata_announced_with_a_name_waits_for_that_call():
 
 
 def test_the_resumable_scan_agrees_with_scanning_from_the_start():
-    # The accumulator resumes the boundary scan instead of restarting it, which
-    # is only safe while the two give the same answer for every string and every
-    # set of chunk boundaries.
+    # Only safe while it answers as restarting does, for every chunking.
     import random
 
     from core.inference.studio_tool_loop import _BoundaryScan
@@ -377,10 +351,8 @@ def test_the_resumable_scan_agrees_with_scanning_from_the_start():
 
 
 def test_one_argument_streamed_a_character_at_a_time_stays_linear():
-    # Rescanning the whole accumulation per fragment made a 10 KB argument cost
-    # seconds, which stalls the response for any tool that takes code or file
-    # content. Generous bound: this asserts the quadratic term is gone, not a
-    # particular machine's speed.
+    # Rescanning per fragment made a 10 KB argument cost seconds. The bound is
+    # generous: the quadratic term is asserted, not a machine's speed.
     import time
 
     payload = '{"code":"' + "x" * 20000 + '"}'
@@ -424,12 +396,9 @@ def test_a_call_announced_by_name_only_is_still_reported():
 
 
 def test_a_name_resent_or_grown_after_a_call_closed_invents_nothing():
-    # Indistinguishable from a second no-argument call to the same tool, so the
-    # conservative reading is the one that does not run a tool twice. A grown
-    # name opens a slot rather than being parked, since a catalog holding both
-    # "web" and "web_search" makes the shared prefix no proof either way, so
-    # the slot is there mid-stream; it never received arguments of its own, so
-    # `calls` does not report it and no tool runs for it.
+    # Indistinguishable from a second no-argument call to the same tool, so
+    # take the reading that does not run a tool twice. A grown name opens a
+    # slot (the prefix is no proof) but `calls` drops it unfilled.
     for resent in ("alpha", "alpha_long"):
         turn = _Turn()
         turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
@@ -442,9 +411,7 @@ def test_a_name_resent_or_grown_after_a_call_closed_invents_nothing():
 
 
 def test_a_pending_call_runs_where_the_stream_announced_it():
-    # The loop spends its budget down this list in order, so a call announced
-    # second must not run third: a finite budget would run the later call and
-    # reject the earlier one.
+    # The budget is spent down this list in order.
     turn = _Turn()
     turn.merge_structured([_delta(0, "A", '{"a":1}')])
     turn.merge_structured([_delta(0, "B", "")])
@@ -455,9 +422,8 @@ def test_a_pending_call_runs_where_the_stream_announced_it():
 
 
 def test_a_fragment_that_does_not_open_an_object_does_not_open_a_call():
-    # A next call begins with the "{" of its own arguments object. Forking on
-    # any non-whitespace text cut where the scanner deliberately leaves the text
-    # whole, so a stray scalar suffix ran the tool a second time.
+    # A next call begins with its own "{"; forking on anything else made a
+    # stray scalar suffix run the tool twice.
     turn = _Turn()
     turn.merge_structured([_delta(0, "q", '{"query":"a"}')])
     turn.merge_structured([_delta(0, "q", '"b"')])
@@ -467,10 +433,8 @@ def test_a_fragment_that_does_not_open_an_object_does_not_open_a_call():
 
 
 def test_an_integer_too_long_to_convert_is_still_a_boundary():
-    # json.loads raises ValueError past the 4300-digit cap on int conversion,
-    # where JSON.parse does not, and a 4301-digit literal is about 4 KB and fits
-    # in an ordinary payload. Validation never reads the numbers, so keeping
-    # them as text keeps the two scanners cutting in the same place.
+    # json.loads raises past the 4300-digit int cap where JSON.parse does not,
+    # and 4301 digits is 4 KB. Validation never reads them, so keep them text.
     big = '{"a":' + "1" * 4301 + "}"
     assert _split_top_level_json_objects(big + '{"b":2}') == ([big, '{"b":2}'], "")
 
@@ -494,9 +458,7 @@ def test_two_calls_announced_at_once_do_not_break_the_sort():
 
 
 def test_a_pending_call_keeps_its_place_when_it_later_opens():
-    # The call takes the moment it was announced at, not the moment its
-    # arguments arrived, so a finite budget cannot run the later call and
-    # reject the earlier one.
+    # A call takes the moment it was announced at.
     turn = _Turn()
     turn.merge_structured([_delta(0, "A", '{"a":1}')])
     turn.merge_structured([_delta(0, "B", "")])
@@ -509,10 +471,8 @@ def test_a_pending_call_keeps_its_place_when_it_later_opens():
 
 
 def test_a_resent_name_does_not_rename_the_call_it_closed():
-    # A parked name that extends the closed call's own is most likely that
-    # call's name resent, so a delta that names its call outright wins: seeding
-    # "alpha_long" and merging "beta" onto it gave "alpha_longbeta", which
-    # matches no enabled tool and never runs.
+    # A name extending the closed call's is most likely it, resent, so a delta
+    # naming its own call wins: merging gave "alpha_longbeta".
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured([_delta(0, "alpha_long", "")])
@@ -536,9 +496,7 @@ def test_a_resent_name_does_not_rename_the_call_it_closed():
 
 
 def test_metadata_on_a_resent_name_stays_with_the_closed_call():
-    # The metadata was announced alongside the name, so once that name is read
-    # as the closed call's resent, the metadata is the closed call's too.
-    # Handing it to the new call leaves one wearing another's signature.
+    # Once the name is read as the closed call's, so is the metadata.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}') | {"extra_content": {"own": "A"}}])
     turn.merge_structured([_delta(0, "alpha_long", None) | {"extra_content": {"resent": 1}}])
@@ -551,10 +509,8 @@ def test_metadata_on_a_resent_name_stays_with_the_closed_call():
 
 
 def test_a_discarded_resend_does_not_lend_its_place_to_the_next_call():
-    # The moment belongs to the announcement. Once the parked name is read as
-    # the closed call's resent, the call that opens here was not announced
-    # then, so keeping that moment would run it ahead of a call the stream
-    # really did open first, and a finite budget would reject the earlier one.
+    # The moment belongs to the announcement, and a name read as a resent
+    # announced nothing, so the call that opens takes its own arrival.
     turn = _Turn()
     turn.merge_structured([_delta(0, "A", '{"a":1}')])
     turn.merge_structured([_delta(0, "A_long", None)])
@@ -573,10 +529,7 @@ def test_a_discarded_resend_does_not_lend_its_place_to_the_next_call():
 
 
 def test_an_id_stamped_after_the_object_closed_claims_that_call():
-    # A provider that opens id-less and stamps the real id on a later delta.
-    # Reading the id as proof of another call left the finished call under a
-    # minted id, and when the delta repeated the name it ran a second empty
-    # invocation of the tool.
+    # Reading the late id as another call left the finished one minted.
     for late in ({}, {"name": "alpha"}):
         turn = _Turn()
         turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
@@ -597,11 +550,9 @@ def test_an_id_stamped_after_the_object_closed_claims_that_call():
 
 
 def test_a_new_name_arriving_with_whitespace_opens_its_own_call():
-    # A name sharing no prefix with the closed call's is a different tool, so
-    # it opens the next call rather than renaming the finished one, which left
-    # the closed call named "alphabeta" and the new one unnamed so neither ran.
-    # The whitespace rides the announcing delta, so it lands on the new call's
-    # arguments; leading whitespace is valid JSON, so both still parse.
+    # A different name opens the next call rather than renaming the finished
+    # one, which gave "alphabeta" and an unnamed second call. The whitespace
+    # rides the announcing delta and is valid JSON, so both still parse.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured([_delta(0, "beta", " ")])
@@ -619,9 +570,8 @@ def test_a_new_name_arriving_with_whitespace_opens_its_own_call():
 
 
 def test_metadata_on_a_resent_name_reaches_the_closed_call():
-    # No call is invented for a name read as the closed call's resent, so
-    # metadata announced on that delta has nowhere else to go. Dropping it cost
-    # the call its thought signature, and the provider rejects the replay.
+    # A name read as a resent invents no call, so its metadata has nowhere
+    # else to go.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}') | {"extra_content": {"own": "A"}}])
     turn.merge_structured([_delta(0, "alpha_long", None) | {"extra_content": {"sig": "S"}}])
@@ -636,10 +586,8 @@ def test_metadata_on_a_resent_name_reaches_the_closed_call():
 
 
 def test_a_catalog_holding_both_web_and_web_search_splits_either_way_round():
-    # Both names are in Studio's own catalog, and neither order can be read as
-    # one name growing: a shared prefix is no evidence when the tools really
-    # are called that. Reading it as evidence swallowed the second
-    # announcement, and the call it announced never ran.
+    # Both are in Studio's own catalog, so a shared prefix is no evidence
+    # either way; reading it as evidence swallowed the second announcement.
     for first, second in (("web_search", "web"), ("web", "web_search")):
         turn = _Turn()
         turn.merge_structured([_delta(0, first, '{"a":1}')])
@@ -650,15 +598,12 @@ def test_a_catalog_holding_both_web_and_web_search_splits_either_way_round():
 
 
 def test_a_name_bringing_an_object_over_an_announcement_is_the_next_call():
-    # An announcement holds a slot with no arguments, which the closed-object
-    # rule cannot reach, so the next call's name grew into it: "alpha_longbeta"
-    # and "zetabeta" match no enabled tool and silently never ran.
+    # An announcement has no object to close, so the next name grew into it.
     for announced in ("alpha_long", "zeta"):
         turn = _Turn()
         turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
-        # No `arguments` field at all, which is how a call announces itself;
-        # an empty string means the call has started, and a name after one is
-        # the fragment dialect that really does continue it.
+        # No `arguments` field: an empty string means the call has started,
+        # and a name after one is the fragment dialect.
         turn.merge_structured([_delta(0, announced, None)])
         turn.merge_structured([_delta(0, "beta", '{"b":2}')])
 
@@ -666,10 +611,7 @@ def test_a_name_bringing_an_object_over_an_announcement_is_the_next_call():
 
 
 def test_an_unfinished_fork_does_not_reserve_a_card_id():
-    # The client releases the card it drew for the fork this turn filters out,
-    # so the next round has to land on the number the client will mint. Holding
-    # one side's id back moves the two out of step and the tool_start draws a
-    # second card beside the one the deltas painted.
+    # The client releases the card it drew for the fork this turn filters out.
     taken: set[str] = set()
     cards: set[str] = set()
     first = _Turn()
@@ -683,9 +625,8 @@ def test_an_unfinished_fork_does_not_reserve_a_card_id():
 
 
 def test_a_provider_claiming_a_minted_id_displaces_the_id_less_call():
-    # Every id the provider sent is reserved before any card id is minted, so
-    # the id-less call moves to tool_call_1 and the claim keeps tool_call_0.
-    # The client reaches the same pair by displacing once the claim lands.
+    # Provider ids are reserved before any card id is minted, so the id-less
+    # call moves aside. The client displaces once the claim lands.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured([_delta(1, "beta", '{"b":2}', call_id = "tool_call_0")])
@@ -697,9 +638,7 @@ def test_a_provider_claiming_a_minted_id_displaces_the_id_less_call():
 
 
 def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
-    # A catalog can hold both "web" and "web_search". Reading the second name as
-    # a growth of the first gave the id to the completed call, and the arguments
-    # that followed glued onto it, losing the second intent entirely.
+    # Reading "web_search" as "web" grown gave the id to the completed call.
     turn = _Turn()
     turn.merge_structured([_delta(0, "web", '{"a":1}')])
     turn.merge_structured([_delta(0, "web_search", "", call_id = "call_b")])
@@ -713,10 +652,8 @@ def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
 
 
 def test_an_unfinished_split_tail_is_not_reported_as_a_call():
-    # Only "length" and "content_filter" mark a turn truncated, so a stream that
-    # stops after the start of a second object looks complete. Running the tool
-    # again on that lone brace is worse than dropping a call the model never
-    # finished writing.
+    # Nothing marks this truncated, and running the tool on half an argument
+    # is the worse failure.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}{')])
 
@@ -730,9 +667,7 @@ def test_an_unfinished_split_tail_is_not_reported_as_a_call():
 
 
 def test_a_second_call_to_the_same_tool_keeps_that_tools_name():
-    # The provider named the tool once and reused the index for the next call
-    # with arguments alone. An empty name is no tool at all, so the call was
-    # dropped by _normalized_call and the user was one result short.
+    # The index is reused with arguments alone, and nameless calls are dropped.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured([_delta(0, None, '{"a":2}')])
@@ -741,9 +676,7 @@ def test_a_second_call_to_the_same_tool_keeps_that_tools_name():
 
 
 def test_a_snapshot_repeated_to_carry_the_id_claims_the_call():
-    # Snapshot-style servers resend the whole call rather than fragments of it,
-    # so the id arrives on a verbatim repeat. Opening a second call there runs a
-    # side-effecting tool twice.
+    # The id arrives on a verbatim repeat; a second call runs the tool twice.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured([_delta(0, "alpha", '{"a":1}', call_id = "call_a")])
@@ -770,10 +703,8 @@ def test_a_second_call_that_differs_anywhere_still_opens_its_own():
 
 
 def test_an_id_less_call_carries_the_card_id_the_client_painted():
-    # The client draws a card the moment the delta arrives, keyed on an id it
-    # mints itself because the provider sent none. Without a card id here, the
-    # tool_start that follows is addressed to call_0_0, finds no card under
-    # that, and pushes a second one: eight cards for the four calls in #9807.
+    # Without the id the client minted, tool_start finds no card: eight cards
+    # for the four calls in #9807.
     turn = _Turn()
     for url in ("a", "b", "c", "d"):
         turn.merge_structured([_delta(0, "fetch", '{"url":"%s"}' % url)])
@@ -788,9 +719,8 @@ def test_an_id_less_call_carries_the_card_id_the_client_painted():
 
 
 def test_the_conversation_id_is_not_the_card_id():
-    # The card id is for the events the client draws with. What is stored and
-    # replayed upstream stays call_<round>_<position>, so a thread written
-    # before this still resolves its results to its calls.
+    # What is stored and replayed stays call_<round>_<position>, so a thread
+    # written before this still resolves.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
 
@@ -826,9 +756,7 @@ def test_a_second_round_keeps_numbering_where_the_first_stopped():
 
 
 def test_a_provider_id_in_the_minted_namespace_is_not_handed_out_twice():
-    # tool_call_<n> is not reserved to Unsloth, and a provider that spells one
-    # of its own ids that way keeps it: the card it already owns must not be
-    # taken from it by the call streamed beside it.
+    # tool_call_<n> is not reserved to Unsloth.
     turn = _Turn()
     turn.merge_structured([_delta(0, "alpha", '{"a":1}', call_id = "tool_call_0")])
     turn.merge_structured([_delta(1, "beta", '{"b":2}')])
@@ -838,9 +766,7 @@ def test_a_provider_id_in_the_minted_namespace_is_not_handed_out_twice():
 
 
 def test_a_slot_that_opens_late_keeps_its_own_index():
-    # The first call at index 3 is tool_call_3 on the client, because the slot
-    # names the card before any split has happened. Numbering from zero here
-    # would address it to a card that does not exist.
+    # The slot names the card before any split has happened.
     turn = _Turn()
     turn.merge_structured([_delta(3, "alpha", '{"a":1}')])
 

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -656,6 +656,42 @@ def test_a_claim_on_a_split_born_card_leaves_every_call_its_own():
     ]
 
 
+def test_a_nameless_call_reserves_no_card_id():
+    # The client drops the card it drew for a call that never got a name, so
+    # the next round has to land on the number this one leaves free.
+    taken: set[str] = set()
+    cards: set[str] = set()
+    first = _Turn()
+    first.merge_structured([_delta(0, None, '{"a":1}')])
+    assert first.calls(taken, cards) == []
+
+    second = _Turn()
+    second.round = 1
+    second.merge_structured([_delta(0, "beta", '{"b":2}')])
+    assert [call.get("card_id") for call in second.calls(taken, cards)] == ["tool_call_0"]
+
+
+def test_a_card_ledger_is_append_only_across_rounds():
+    # A round that carries tool_call_0 as a provider id does not take the card
+    # an earlier round already drew under that spelling, so the third round
+    # numbers from what both are holding.
+    taken: set[str] = set()
+    cards: set[str] = set()
+    first = _Turn()
+    first.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    assert [call.get("card_id") for call in first.calls(taken, cards)] == ["tool_call_0"]
+
+    second = _Turn()
+    second.round = 1
+    second.merge_structured([_delta(0, "beta", '{"b":2}', call_id = "tool_call_0")])
+    assert [call.get("card_id") for call in second.calls(taken, cards)] == [None]
+
+    third = _Turn()
+    third.round = 2
+    third.merge_structured([_delta(0, "gamma", '{"c":3}')])
+    assert [call.get("card_id") for call in third.calls(taken, cards)] == ["tool_call_1"]
+
+
 def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
     # Reading "web_search" as "web" grown gave the id to the completed call.
     turn = _Turn()

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -724,8 +724,7 @@ def test_a_nameless_claim_does_not_take_a_valid_call_s_card():
 def test_a_repeated_names_metadata_waits_for_the_call_it_announced():
     # The same tool twice on one slot, the second announced by a name-only
     # delta carrying its own signature. Merging it where it landed overwrote
-    # the closed call's and left the new call unsigned, and Gemini validates a
-    # signature against the call it is replayed on.
+    # the closed call's and left the new one unsigned.
     turn = _Turn()
     turn.merge_structured([_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"sig": "A"}}])
     turn.merge_structured([_delta(0, "lookup", None) | {"extra_content": {"sig": "B"}}])
@@ -744,9 +743,9 @@ def test_a_repeated_names_metadata_waits_for_the_call_it_announced():
 
 
 def test_parked_metadata_survives_a_late_id_landing_on_the_call():
-    # The slot key does not change when an id lands here, so the parked
-    # signature is still found. Pinned because the frontend keys the same wait
-    # by card id, which a late id does rename, and the two have to agree.
+    # The slot key does not change when an id lands, so the parked signature is
+    # still found. Pinned because the frontend keys the same wait by card id,
+    # which a late id does rename.
     turn = _Turn()
     turn.merge_structured([_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"sig": "A"}}])
     turn.merge_structured([_delta(0, "lookup", None) | {"extra_content": {"sig": "B"}}])

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -92,10 +92,7 @@ def _reported(turn: _Turn):
     Not every slot becomes one: a name that arrived with no arguments of its
     own opened a slot mid-stream, and it is dropped here rather than run.
     """
-    return [
-        (call["function"]["name"], call["function"]["arguments"])
-        for call in turn.calls()
-    ]
+    return [(call["function"]["name"], call["function"]["arguments"]) for call in turn.calls()]
 
 
 def _shape(turn: _Turn):
@@ -439,8 +436,7 @@ def test_a_name_resent_or_grown_after_a_call_closed_invents_nothing():
         turn.merge_structured([_delta(0, resent, "")])
 
         reported = [
-            (call["function"]["name"], call["function"]["arguments"])
-            for call in turn.calls()
+            (call["function"]["name"], call["function"]["arguments"]) for call in turn.calls()
         ]
         assert reported == [("alpha", '{"a":1}')]
 

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -1,0 +1,820 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Parallel tool calls that share one delta index (issue #9807).
+
+A server that streams parallel calls as id-less, index-based deltas reuses one
+slot for several calls. Appending their arguments glues them into one
+unparseable string, which then rides into the next request verbatim and the
+provider answers 400. The fork on a differing call id cannot catch this one:
+there are no ids to differ.
+
+The boundary between two calls is the end of a top-level JSON object, not a
+change of function name -- the reported stream calls the same tool three times.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.inference.studio_tool_loop import (
+    _Turn,
+    _split_top_level_json_objects,
+)
+
+
+# --------------------------------------------------------------------- scanner
+
+
+@pytest.mark.parametrize(
+    "text,complete,tail",
+    [
+        ("", [], ""),
+        ("{}", ["{}"], ""),
+        ('{"a":1}', ['{"a":1}'], ""),
+        ('{"a":1}{"b":2}', ['{"a":1}', '{"b":2}'], ""),
+        (
+            '{"a":1} {"b":2}\n{"c":3}\r\n{"d":4}',
+            ['{"a":1}', '{"b":2}', '{"c":3}', '{"d":4}'],
+            "",
+        ),
+        ('{"a":', [], '{"a":'),
+        ('{"a":1}{"b":', ['{"a":1}'], '{"b":'),
+        # Braces that are data, not structure.
+        ('{"a":"}{"}{"b":2}', ['{"a":"}{"}', '{"b":2}'], ""),
+        ('{"a":"say \\"}{\\" ok"}{"b":2}', ['{"a":"say \\"}{\\" ok"}', '{"b":2}'], ""),
+        ('{"p":"C:\\\\Users\\\\me"}{"b":2}', ['{"p":"C:\\\\Users\\\\me"}', '{"b":2}'], ""),
+        ('{"a":{"b":{"c":1}}}', ['{"a":{"b":{"c":1}}}'], ""),
+        ('{"a":[{"b":1},{"c":2}]}', ['{"a":[{"b":1},{"c":2}]}'], ""),
+        (
+            '{"q":"caf\u00e9 \u65e5\u672c\u8a9e \U0001f680"}',
+            ['{"q":"caf\u00e9 \u65e5\u672c\u8a9e \U0001f680"}'],
+            "",
+        ),
+        # Not a run of objects: left alone rather than cut somewhere meaningless.
+        ('[{"a":1}]', [], '[{"a":1}]'),
+        ('"hello"', [], '"hello"'),
+        ("42", [], "42"),
+        ("null", [], "null"),
+        ('{"a":1}junk{"b":2}', [], '{"a":1}junk{"b":2}'),
+        ('{"a":1}}', [], '{"a":1}}'),
+        ('{"a":1,}{"b":2}', [], '{"a":1,}{"b":2}'),
+        ('{"a":"unterminated', [], '{"a":"unterminated'),
+    ],
+)
+def test_split_top_level_json_objects(text, complete, tail):
+    assert _split_top_level_json_objects(text) == (complete, tail)
+
+
+# ----------------------------------------------------------------- accumulator
+
+
+def _delta(
+    index,
+    name = None,
+    arguments = "",
+    call_id = None,
+):
+    function: dict = {"arguments": arguments}
+    if name is not None:
+        function["name"] = name
+    call: dict = {"index": index, "function": function}
+    if call_id is not None:
+        call["id"] = call_id
+    return call
+
+
+def _reported(turn: _Turn):
+    """The calls the turn ends up making, which is what the loop executes.
+
+    Not every slot becomes one: a name that arrived with no arguments of its
+    own opened a slot mid-stream, and it is dropped here rather than run.
+    """
+    return [
+        (call["function"]["name"], call["function"]["arguments"])
+        for call in turn.calls()
+    ]
+
+
+def _shape(turn: _Turn):
+    return [
+        (turn.by_index[key]["function"]["name"], turn.by_index[key]["function"]["arguments"])
+        for key in turn.order
+    ]
+
+
+def test_the_stream_from_9807_becomes_one_call_per_object():
+    # Three fetches and a search, all id-less at index 0. The same tool repeats,
+    # so there is no name change to fork on.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "url", '{"url":"a"}')])
+    turn.merge_structured([_delta(0, "url", '{"url":"b"}')])
+    turn.merge_structured([_delta(0, "query", '{"q":"c"}')])
+    turn.merge_structured([_delta(0, "url", '{"url":"d"}')])
+
+    assert _shape(turn) == [
+        ("url", '{"url":"a"}'),
+        ("url", '{"url":"b"}'),
+        ("query", '{"q":"c"}'),
+        ("url", '{"url":"d"}'),
+    ]
+    for _name, arguments in _shape(turn):
+        assert isinstance(json.loads(arguments), dict)
+
+
+def test_every_forked_call_gets_an_id_of_its_own():
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "url", '{"url":"a"}{"url":"b"}')])
+    ids = [call["id"] for call in turn.calls()]
+    assert len(ids) == 2
+    assert len(set(ids)) == 2
+    assert all(ids)
+
+
+def test_a_call_at_another_index_survives_a_fork():
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(1, "beta", '{"b":2}')])
+    turn.merge_structured([_delta(0, "gamma", '{"c":3}')])
+
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}'), ("gamma", '{"c":3}')]
+
+
+def test_an_ordinary_fragmented_call_is_still_one_call():
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":')])
+    turn.merge_structured([_delta(0, None, "1")])
+    turn.merge_structured([_delta(0, None, "}")])
+
+    assert _shape(turn) == [("alpha", '{"a":1}')]
+
+
+def test_a_fragment_continues_the_call_still_being_written():
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}{"b":')])
+    turn.merge_structured([_delta(0, None, "2}")])
+
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("alpha", '{"b":2}')]
+
+
+def test_a_stream_that_carries_ids_forks_on_the_id_as_before():
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":', call_id = "call_a")])
+    turn.merge_structured([_delta(1, "beta", '{"b":', call_id = "call_b")])
+    turn.merge_structured([_delta(0, None, "1}", call_id = "call_a")])
+    turn.merge_structured([_delta(1, None, "2}", call_id = "call_b")])
+
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+    assert [call["id"] for call in turn.calls()] == ["call_a", "call_b"]
+
+
+def test_a_name_arriving_in_fragments_is_unaffected():
+    # llama-server resends the whole name as it grows; OpenAI streams it in
+    # pieces. Both still land on one call.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "web", '{"q":')])
+    turn.merge_structured([_delta(0, "web_search", '"x"}')])
+
+    assert _shape(turn) == [("web_search", '{"q":"x"}')]
+
+
+def test_a_name_only_delta_does_not_rename_the_finished_call():
+    # The name arrives before its arguments, so the accumulated text is still
+    # one whole object and there is nothing to fork on yet. Merging it into the
+    # finished call gives "alphabeta", which matches no enabled tool.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "beta", "")])
+    turn.merge_structured([_delta(0, None, '{"b":2}')])
+
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+
+
+def test_an_id_after_one_closed_object_opens_a_call_not_a_claim():
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "beta", '{"b":2}', call_id = "call_b")])
+
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+    assert [call["id"] for call in turn.calls()] == ["call_0_0", "call_b"]
+
+
+def test_an_id_after_a_closed_fork_opens_a_third_call():
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}{"b":2}')])
+    turn.merge_structured([_delta(0, "gamma", '{"c":3}', call_id = "call_c")])
+
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("alpha", '{"b":2}'), ("gamma", '{"c":3}')]
+    ids = [call["id"] for call in turn.calls()]
+    assert len(set(ids)) == len(ids)
+
+
+def test_nesting_deep_enough_to_exhaust_the_stack_is_unsplittable():
+    # json.loads raises RecursionError, which is a RuntimeError and not a
+    # ValueError. Uncaught it escapes the streaming loop mid-response, so the
+    # segment counts as unsplittable and _normalized_call downgrades it as
+    # it always has.
+    payload = '{"x":' * 20000 + "null" + "}" * 20000
+    assert _split_top_level_json_objects(payload) == ([], payload)
+
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "deep", payload)])
+    assert _shape(turn) == [("deep", payload)]
+
+
+def test_a_fragment_repeating_the_slots_id_continues_that_call():
+    # llama-server grows the name across deltas. An id names its call, so
+    # forking here would give two calls one id, with the arguments stranded on
+    # the abandoned name and the grown one running empty.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "web", '{"q":"x"}', call_id = "call_a")])
+    turn.merge_structured([_delta(0, "web_search", "", call_id = "call_a")])
+
+    assert _shape(turn) == [("web_search", '{"q":"x"}')]
+    assert [call["id"] for call in turn.calls()] == ["call_a"]
+
+
+def test_whitespace_chunked_after_a_closing_brace_is_not_a_new_call():
+    # Trailing whitespace is legal JSON and says nothing about another call.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "alpha", " ")])
+
+    assert _shape(turn) == [("alpha", '{"a":1} ')]
+
+    # ... and the call that really does follow it still forks.
+    turn.merge_structured([_delta(0, "alpha", '{"b":2}')])
+    assert _shape(turn) == [("alpha", '{"a":1} '), ("alpha", '{"b":2}')]
+
+
+def test_the_metadata_a_delta_carries_goes_to_the_call_it_closes():
+    # Gemini checks the opaque signature against the exact call it is replayed
+    # on, so it belongs to the last object this delta closed, not to the one
+    # the slot already held. Same placement as the frontend split.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":')])
+    turn.merge_structured(
+        [_delta(0, None, '1}{"b":2}') | {"extra_content": {"google": {"thought_signature": "SIG"}}}]
+    )
+
+    entries = [turn.by_index[key] for key in turn.order]
+    assert [e["function"]["arguments"] for e in entries] == ['{"a":1}', '{"b":2}']
+    assert entries[0].get("extra_content") is None
+    assert entries[1]["extra_content"] == {"google": {"thought_signature": "SIG"}}
+
+
+def test_nonstandard_numeric_constants_are_not_object_boundaries():
+    # json.loads takes NaN and Infinity; JSON.parse does not. Accepting them
+    # here would cut text the frontend leaves whole, so the backend would run
+    # two calls where the UI shows one.
+    assert _split_top_level_json_objects('{"a":NaN}{"b":2}') == ([], '{"a":NaN}{"b":2}')
+    assert _split_top_level_json_objects('{"a":Infinity}{"b":2}') == (
+        [],
+        '{"a":Infinity}{"b":2}',
+    )
+    # Ordinary numbers, exponents included, still split.
+    assert _split_top_level_json_objects('{"a":1.5e3}{"b":2}') == (
+        ['{"a":1.5e3}', '{"b":2}'],
+        "",
+    )
+
+
+def test_an_opening_delta_after_a_closed_call_does_not_claim_it():
+    # The conventional opening delta carries the id and the name with empty
+    # arguments. Landing it on the finished call would put that call's id on it,
+    # so the arguments delta that follows would match and glue on, losing the
+    # call the delta was announcing.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "beta", "", call_id = "call_b")])
+    turn.merge_structured([_delta(0, None, '{"b":2}', call_id = "call_b")])
+
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+    ids = [call["id"] for call in turn.calls()]
+    assert ids[1] == "call_b"
+    assert len(set(ids)) == len(ids)
+
+
+def test_a_name_held_for_the_next_call_grows_across_deltas():
+    # Both dialects the accumulator reconciles reach the held name too: OpenAI
+    # streams "web" then "_search", llama-server resends "web" then
+    # "web_search". Last-write-wins would open the call as "_search", which
+    # matches no enabled tool and silently never runs.
+    for fragments in (("web", "_search"), ("web", "web_search")):
+        turn = _Turn()
+        turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+        for fragment in fragments:
+            turn.merge_structured([_delta(0, fragment, "")])
+        turn.merge_structured([_delta(0, None, '{"q":"x"}')])
+
+        assert _shape(turn) == [("alpha", '{"a":1}'), ("web_search", '{"q":"x"}')]
+
+
+def test_whitespace_carrying_the_repeated_name_is_not_the_next_call():
+    # A provider that repeats the name on every delta and chunks the trailing
+    # whitespace separately is still writing to the call that closed, so its
+    # name is that call's resent. Parking it merged the two names into
+    # "alphabeta", which matches no enabled tool and silently never runs.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "alpha", " ")])
+    turn.merge_structured([_delta(0, "beta", '{"b":2}')])
+
+    assert _shape(turn) == [("alpha", '{"a":1} '), ("beta", '{"b":2}')]
+
+
+def test_a_repeated_id_reaches_its_own_call_across_a_later_split():
+    # An id-less call opening after a stable-id call leaves the index pointing
+    # at the newer one. Matching the repeated id against only that call renamed
+    # it, gave it a second copy of the id and stranded the growth fragment.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}', call_id = "call_a")])
+    turn.merge_structured([_delta(0, "beta", '{"b":')])
+    turn.merge_structured([_delta(0, "alpha_long", "", call_id = "call_a")])
+
+    assert _shape(turn) == [("alpha_long", '{"a":1}'), ("beta", '{"b":')]
+    ids = [call["id"] for call in turn.calls()]
+    assert ids[0] == "call_a"
+    assert len(set(ids)) == len(ids)
+
+
+def test_metadata_announced_with_a_name_waits_for_that_call():
+    # Gemini stows the thoughtSignature for the call being announced, so a
+    # name-only delta carrying one describes the next call, not the closed one.
+    # Left behind it gives the closed call another call's signature and the new
+    # call none, and native replay rejects both.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured(
+        [_delta(0, "beta", None) | {"extra_content": {"google": {"thought_signature": "SIG"}}}]
+    )
+    turn.merge_structured([_delta(0, None, '{"b":2}')])
+
+    entries = [turn.by_index[key] for key in turn.order]
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+    assert entries[0].get("extra_content") is None
+    assert entries[1]["extra_content"] == {"google": {"thought_signature": "SIG"}}
+
+
+def test_the_resumable_scan_agrees_with_scanning_from_the_start():
+    # The accumulator resumes the boundary scan instead of restarting it, which
+    # is only safe while the two give the same answer for every string and every
+    # set of chunk boundaries.
+    import random
+
+    from core.inference.studio_tool_loop import _BoundaryScan
+
+    pieces = list('{}"\\ abc:,1[]') + ['\\"', '"a"', "NaN", "\n", "\r\n", "\t", '{"a":1}', "}{"]
+    rng = random.Random(20260827)
+    for _ in range(4000):
+        text = "".join(rng.choice(pieces) for _ in range(rng.randint(0, 16)))
+        scan = _BoundaryScan()
+        cut = 0
+        result = scan.feed("")
+        while cut < len(text):
+            cut = min(len(text), cut + rng.randint(1, 4))
+            result = scan.feed(text[:cut])
+        assert result == _split_top_level_json_objects(text), text
+
+
+def test_one_argument_streamed_a_character_at_a_time_stays_linear():
+    # Rescanning the whole accumulation per fragment made a 10 KB argument cost
+    # seconds, which stalls the response for any tool that takes code or file
+    # content. Generous bound: this asserts the quadratic term is gone, not a
+    # particular machine's speed.
+    import time
+
+    payload = '{"code":"' + "x" * 20000 + '"}'
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "write", "")])
+    started = time.perf_counter()
+    for ch in payload:
+        turn.merge_structured([_delta(0, None, ch)])
+    assert time.perf_counter() - started < 2.0
+    assert _shape(turn) == [("write", payload)]
+
+
+def test_metadata_arriving_alone_stays_on_the_call_that_closed():
+    # No name, so nothing announces another call: the signature is this call's.
+    # Parking it lost it outright when no further call followed.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([{"index": 0, "extra_content": {"google": {"thought_signature": "SIG"}}}])
+
+    assert _shape(turn) == [("alpha", '{"a":1}')]
+    entries = [turn.by_index[key] for key in turn.order]
+    assert entries[0]["extra_content"] == {"google": {"thought_signature": "SIG"}}
+
+
+def test_a_call_announced_by_name_only_is_still_reported():
+    # A tool that takes no parameters can be announced and then simply end, and
+    # _normalized_call already reads empty arguments as {}.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "beta", "")])
+
+    reported = [(call["function"]["name"], call["function"]["arguments"]) for call in turn.calls()]
+    assert reported == [("alpha", '{"a":1}'), ("beta", "{}")]
+    ids = [call["id"] for call in turn.calls()]
+    assert len(set(ids)) == len(ids)
+
+    # And a later fragment that does open it opens it, rather than adding a
+    # second call beside the one this reported.
+    turn.merge_structured([_delta(0, None, '{"b":2}')])
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+
+
+def test_a_name_resent_or_grown_after_a_call_closed_invents_nothing():
+    # Indistinguishable from a second no-argument call to the same tool, so the
+    # conservative reading is the one that does not run a tool twice. A grown
+    # name opens a slot rather than being parked, since a catalog holding both
+    # "web" and "web_search" makes the shared prefix no proof either way, so
+    # the slot is there mid-stream; it never received arguments of its own, so
+    # `calls` does not report it and no tool runs for it.
+    for resent in ("alpha", "alpha_long"):
+        turn = _Turn()
+        turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+        turn.merge_structured([_delta(0, resent, "")])
+
+        reported = [
+            (call["function"]["name"], call["function"]["arguments"])
+            for call in turn.calls()
+        ]
+        assert reported == [("alpha", '{"a":1}')]
+
+
+def test_a_pending_call_runs_where_the_stream_announced_it():
+    # The loop spends its budget down this list in order, so a call announced
+    # second must not run third: a finite budget would run the later call and
+    # reject the earlier one.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "A", '{"a":1}')])
+    turn.merge_structured([_delta(0, "B", "")])
+    turn.merge_structured([_delta(1, "C", '{"c":3}')])
+
+    reported = [(call["function"]["name"], call["function"]["arguments"]) for call in turn.calls()]
+    assert reported == [("A", '{"a":1}'), ("B", "{}"), ("C", '{"c":3}')]
+
+
+def test_a_fragment_that_does_not_open_an_object_does_not_open_a_call():
+    # A next call begins with the "{" of its own arguments object. Forking on
+    # any non-whitespace text cut where the scanner deliberately leaves the text
+    # whole, so a stray scalar suffix ran the tool a second time.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "q", '{"query":"a"}')])
+    turn.merge_structured([_delta(0, "q", '"b"')])
+
+    assert _shape(turn) == [("q", '{"query":"a"}"b"')]
+    assert _split_top_level_json_objects('{"query":"a"}"b"') == ([], '{"query":"a"}"b"')
+
+
+def test_an_integer_too_long_to_convert_is_still_a_boundary():
+    # json.loads raises ValueError past the 4300-digit cap on int conversion,
+    # where JSON.parse does not, and a 4301-digit literal is about 4 KB and fits
+    # in an ordinary payload. Validation never reads the numbers, so keeping
+    # them as text keeps the two scanners cutting in the same place.
+    big = '{"a":' + "1" * 4301 + "}"
+    assert _split_top_level_json_objects(big + '{"b":2}') == ([big, '{"b":2}'], "")
+
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", big)])
+    turn.merge_structured([_delta(0, "beta", '{"b":2}')])
+    assert _shape(turn) == [("alpha", big), ("beta", '{"b":2}')]
+
+
+def test_two_calls_announced_at_once_do_not_break_the_sort():
+    # Two announcements can share a moment. Breaking the tie by comparing the
+    # calls themselves raises TypeError and takes the whole turn with it.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "A", '{"a":1}')])
+    turn.merge_structured([_delta(1, "B", '{"b":1}')])
+    turn.merge_structured([_delta(0, "C", "")])
+    turn.merge_structured([_delta(1, "D", "")])
+
+    reported = [(call["function"]["name"], call["function"]["arguments"]) for call in turn.calls()]
+    assert reported == [("A", '{"a":1}'), ("B", '{"b":1}'), ("C", "{}"), ("D", "{}")]
+
+
+def test_a_pending_call_keeps_its_place_when_it_later_opens():
+    # The call takes the moment it was announced at, not the moment its
+    # arguments arrived, so a finite budget cannot run the later call and
+    # reject the earlier one.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "A", '{"a":1}')])
+    turn.merge_structured([_delta(0, "B", "")])
+    turn.merge_structured([_delta(1, "C", '{"c":3}')])
+    turn.merge_structured([_delta(0, None, '{"b":2}')])
+
+    # calls() is the list the loop spends its budget down.
+    reported = [(call["function"]["name"], call["function"]["arguments"]) for call in turn.calls()]
+    assert reported == [("A", '{"a":1}'), ("B", '{"b":2}'), ("C", '{"c":3}')]
+
+
+def test_a_resent_name_does_not_rename_the_call_it_closed():
+    # A parked name that extends the closed call's own is most likely that
+    # call's name resent, so a delta that names its call outright wins: seeding
+    # "alpha_long" and merging "beta" onto it gave "alpha_longbeta", which
+    # matches no enabled tool and never runs.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "alpha_long", "")])
+    turn.merge_structured([_delta(0, "beta", '{"b":2}')])
+
+    assert _reported(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+
+    # The second no-argument call to the same tool still works, and so does a
+    # name streamed in fragments: neither has an opening name that disagrees.
+    same = _Turn()
+    same.merge_structured([_delta(0, "no_args", "{}")])
+    same.merge_structured([_delta(0, "no_args", "")])
+    same.merge_structured([_delta(0, None, "{}")])
+    assert _reported(same) == [("no_args", "{}"), ("no_args", "{}")]
+
+    grown = _Turn()
+    grown.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    grown.merge_structured([_delta(0, "web", "")])
+    grown.merge_structured([_delta(0, "_search", '{"q":1}')])
+    assert _reported(grown) == [("alpha", '{"a":1}'), ("web_search", '{"q":1}')]
+
+
+def test_metadata_on_a_resent_name_stays_with_the_closed_call():
+    # The metadata was announced alongside the name, so once that name is read
+    # as the closed call's resent, the metadata is the closed call's too.
+    # Handing it to the new call leaves one wearing another's signature.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}') | {"extra_content": {"own": "A"}}])
+    turn.merge_structured([_delta(0, "alpha_long", None) | {"extra_content": {"resent": 1}}])
+    turn.merge_structured([_delta(0, "beta", '{"b":2}')])
+
+    reported = turn.calls()
+    assert _reported(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+    assert reported[0]["extra_content"] == {"own": "A", "resent": 1}
+    assert reported[1].get("extra_content") is None
+
+
+def test_a_discarded_resend_does_not_lend_its_place_to_the_next_call():
+    # The moment belongs to the announcement. Once the parked name is read as
+    # the closed call's resent, the call that opens here was not announced
+    # then, so keeping that moment would run it ahead of a call the stream
+    # really did open first, and a finite budget would reject the earlier one.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "A", '{"a":1}')])
+    turn.merge_structured([_delta(0, "A_long", None)])
+    turn.merge_structured([_delta(1, "C", '{"c":3}')])
+    turn.merge_structured([_delta(0, "B", '{"b":2}')])
+
+    assert [call["function"]["name"] for call in turn.calls()] == ["A", "C", "B"]
+
+    # An announcement that is accepted still keeps its place.
+    kept = _Turn()
+    kept.merge_structured([_delta(0, "A", '{"a":1}')])
+    kept.merge_structured([_delta(0, "B", None)])
+    kept.merge_structured([_delta(1, "C", '{"c":3}')])
+    kept.merge_structured([_delta(0, None, '{"b":2}')])
+    assert [call["function"]["name"] for call in kept.calls()] == ["A", "B", "C"]
+
+
+def test_an_id_stamped_after_the_object_closed_claims_that_call():
+    # A provider that opens id-less and stamps the real id on a later delta.
+    # Reading the id as proof of another call left the finished call under a
+    # minted id, and when the delta repeated the name it ran a second empty
+    # invocation of the tool.
+    for late in ({}, {"name": "alpha"}):
+        turn = _Turn()
+        turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+        turn.merge_structured([{"index": 0, "id": "call_a", "function": late}])
+
+        reported = [
+            (call["id"], call["function"]["name"], call["function"]["arguments"])
+            for call in turn.calls()
+        ]
+        assert reported == [("call_a", "alpha", '{"a":1}')]
+
+    # An id that names a different call is still the next call opening.
+    opened = _Turn()
+    opened.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    opened.merge_structured([_delta(0, "beta", "", call_id = "call_b")])
+    opened.merge_structured([_delta(0, None, '{"b":2}', call_id = "call_b")])
+    assert _shape(opened) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+
+
+def test_a_new_name_arriving_with_whitespace_opens_its_own_call():
+    # A name sharing no prefix with the closed call's is a different tool, so
+    # it opens the next call rather than renaming the finished one, which left
+    # the closed call named "alphabeta" and the new one unnamed so neither ran.
+    # The whitespace rides the announcing delta, so it lands on the new call's
+    # arguments; leading whitespace is valid JSON, so both still parse.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "beta", " ")])
+    turn.merge_structured([_delta(0, None, '{"b":2}')])
+
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("beta", ' {"b":2}')]
+
+    # And a name repeated with the whitespace is still that call's, resent, so
+    # the call that really opens next takes its own name.
+    resent = _Turn()
+    resent.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    resent.merge_structured([_delta(0, "alpha", " ")])
+    resent.merge_structured([_delta(0, "beta", '{"b":2}')])
+    assert _shape(resent) == [("alpha", '{"a":1} '), ("beta", '{"b":2}')]
+
+
+def test_metadata_on_a_resent_name_reaches_the_closed_call():
+    # No call is invented for a name read as the closed call's resent, so
+    # metadata announced on that delta has nowhere else to go. Dropping it cost
+    # the call its thought signature, and the provider rejects the replay.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}') | {"extra_content": {"own": "A"}}])
+    turn.merge_structured([_delta(0, "alpha_long", None) | {"extra_content": {"sig": "S"}}])
+
+    reported = turn.calls()
+    assert [(c["function"]["name"], c["function"]["arguments"]) for c in reported] == [
+        ("alpha", '{"a":1}')
+    ]
+    assert reported[0]["extra_content"] == {"own": "A", "sig": "S"}
+    # Read twice, so a second read cannot double anything or lose it.
+    assert turn.calls()[0]["extra_content"] == {"own": "A", "sig": "S"}
+
+
+def test_a_catalog_holding_both_web_and_web_search_splits_either_way_round():
+    # Both names are in Studio's own catalog, and neither order can be read as
+    # one name growing: a shared prefix is no evidence when the tools really
+    # are called that. Reading it as evidence swallowed the second
+    # announcement, and the call it announced never ran.
+    for first, second in (("web_search", "web"), ("web", "web_search")):
+        turn = _Turn()
+        turn.merge_structured([_delta(0, first, '{"a":1}')])
+        turn.merge_structured([_delta(0, second)])
+        turn.merge_structured([_delta(0, None, '{"b":2}')])
+
+        assert _reported(turn) == [(first, '{"a":1}'), (second, '{"b":2}')]
+
+
+def test_a_name_bringing_an_object_over_an_announcement_is_the_next_call():
+    # An announcement holds a slot with no arguments, which the closed-object
+    # rule cannot reach, so the next call's name grew into it: "alpha_longbeta"
+    # and "zetabeta" match no enabled tool and silently never ran.
+    for announced in ("alpha_long", "zeta"):
+        turn = _Turn()
+        turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+        # No `arguments` field at all, which is how a call announces itself;
+        # an empty string means the call has started, and a name after one is
+        # the fragment dialect that really does continue it.
+        turn.merge_structured([_delta(0, announced, None)])
+        turn.merge_structured([_delta(0, "beta", '{"b":2}')])
+
+        assert _reported(turn) == [("alpha", '{"a":1}'), ("beta", '{"b":2}')]
+
+
+def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
+    # A catalog can hold both "web" and "web_search". Reading the second name as
+    # a growth of the first gave the id to the completed call, and the arguments
+    # that followed glued onto it, losing the second intent entirely.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "web", '{"a":1}')])
+    turn.merge_structured([_delta(0, "web_search", "", call_id = "call_b")])
+    turn.merge_structured([_delta(0, None, '{"b":2}', call_id = "call_b")])
+
+    reported = [
+        (call["id"], call["function"]["name"], call["function"]["arguments"])
+        for call in turn.calls()
+    ]
+    assert reported == [("call_0_0", "web", '{"a":1}'), ("call_b", "web_search", '{"b":2}')]
+
+
+def test_an_unfinished_split_tail_is_not_reported_as_a_call():
+    # Only "length" and "content_filter" mark a turn truncated, so a stream that
+    # stops after the start of a second object looks complete. Running the tool
+    # again on that lone brace is worse than dropping a call the model never
+    # finished writing.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}{')])
+
+    assert [(call["function"]["name"], call["function"]["arguments"]) for call in turn.calls()] == [
+        ("alpha", '{"a":1}')
+    ]
+
+    # It is held, not discarded: the rest of the object still opens the call.
+    turn.merge_structured([_delta(0, None, '"b":2}')])
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("alpha", '{"b":2}')]
+
+
+def test_a_second_call_to_the_same_tool_keeps_that_tools_name():
+    # The provider named the tool once and reused the index for the next call
+    # with arguments alone. An empty name is no tool at all, so the call was
+    # dropped by _normalized_call and the user was one result short.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, None, '{"a":2}')])
+
+    assert _shape(turn) == [("alpha", '{"a":1}'), ("alpha", '{"a":2}')]
+
+
+def test_a_snapshot_repeated_to_carry_the_id_claims_the_call():
+    # Snapshot-style servers resend the whole call rather than fragments of it,
+    # so the id arrives on a verbatim repeat. Opening a second call there runs a
+    # side-effecting tool twice.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}', call_id = "call_a")])
+
+    reported = [
+        (call["id"], call["function"]["name"], call["function"]["arguments"])
+        for call in turn.calls()
+    ]
+    assert reported == [("call_a", "alpha", '{"a":1}')]
+
+
+def test_a_second_call_that_differs_anywhere_still_opens_its_own():
+    # The claim above is an exact repeat only: a call whose arguments differ is
+    # a parallel call of its own however alike the two look.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(0, "alpha", '{"a":2}', call_id = "call_b")])
+
+    reported = [(call["id"], call["function"]["arguments"]) for call in turn.calls()]
+    assert reported == [("call_0_0", '{"a":1}'), ("call_b", '{"a":2}')]
+
+
+# ------------------------------------------------------------------- card ids
+
+
+def test_an_id_less_call_carries_the_card_id_the_client_painted():
+    # The client draws a card the moment the delta arrives, keyed on an id it
+    # mints itself because the provider sent none. Without a card id here, the
+    # tool_start that follows is addressed to call_0_0, finds no card under
+    # that, and pushes a second one: eight cards for the four calls in #9807.
+    turn = _Turn()
+    for url in ("a", "b", "c", "d"):
+        turn.merge_structured([_delta(0, "fetch", '{"url":"%s"}' % url)])
+
+    reported = [(call["id"], call.get("card_id")) for call in turn.calls()]
+    assert reported == [
+        ("call_0_0", "tool_call_0"),
+        ("call_0_1", "tool_call_1"),
+        ("call_0_2", "tool_call_2"),
+        ("call_0_3", "tool_call_3"),
+    ]
+
+
+def test_the_conversation_id_is_not_the_card_id():
+    # The card id is for the events the client draws with. What is stored and
+    # replayed upstream stays call_<round>_<position>, so a thread written
+    # before this still resolves its results to its calls.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+
+    call = turn.calls()[0]
+    assert call["id"] == "call_0_0"
+    assert call["card_id"] == "tool_call_0"
+
+
+def test_a_call_the_provider_named_gets_no_card_id():
+    # An id on the wire is already the card's id on both sides, so minting a
+    # second spelling for it would be the very mismatch this exists to close.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}', call_id = "call_a")])
+
+    call = turn.calls()[0]
+    assert call["id"] == "call_a"
+    assert "card_id" not in call
+
+
+def test_a_second_round_keeps_numbering_where_the_first_stopped():
+    # One list of cards spans the whole response, so restarting at tool_call_0
+    # would address the second round's events to the first round's cards.
+    first = _Turn()
+    first.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    painted: set[str] = set()
+    taken: set[str] = set()
+    assert [call["card_id"] for call in first.calls(taken, painted)] == ["tool_call_0"]
+
+    second = _Turn()
+    second.round = 1
+    second.merge_structured([_delta(0, "beta", '{"b":2}')])
+    assert [call["card_id"] for call in second.calls(taken, painted)] == ["tool_call_1"]
+
+
+def test_a_provider_id_in_the_minted_namespace_is_not_handed_out_twice():
+    # tool_call_<n> is not reserved to Unsloth, and a provider that spells one
+    # of its own ids that way keeps it: the card it already owns must not be
+    # taken from it by the call streamed beside it.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}', call_id = "tool_call_0")])
+    turn.merge_structured([_delta(1, "beta", '{"b":2}')])
+
+    reported = [(call["id"], call.get("card_id")) for call in turn.calls()]
+    assert reported == [("tool_call_0", None), ("call_0_1", "tool_call_1")]
+
+
+def test_a_slot_that_opens_late_keeps_its_own_index():
+    # The first call at index 3 is tool_call_3 on the client, because the slot
+    # names the card before any split has happened. Numbering from zero here
+    # would address it to a card that does not exist.
+    turn = _Turn()
+    turn.merge_structured([_delta(3, "alpha", '{"a":1}')])
+
+    assert [call.get("card_id") for call in turn.calls()] == ["tool_call_3"]

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -717,9 +717,7 @@ def test_a_nameless_claim_does_not_take_a_valid_call_s_card():
     turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
     turn.merge_structured([_delta(1, None, '{"b":2}', call_id = "tool_call_0")])
 
-    reported = [
-        (call.get("card_id"), call["function"]["name"]) for call in turn.calls()
-    ]
+    reported = [(call.get("card_id"), call["function"]["name"]) for call in turn.calls()]
     assert reported == [("tool_call_0", "alpha")]
 
 

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -743,6 +743,22 @@ def test_a_repeated_names_metadata_waits_for_the_call_it_announced():
     assert kept.calls()[0]["extra_content"] == {"own": 1, "sig": "B"}
 
 
+def test_parked_metadata_survives_a_late_id_landing_on_the_call():
+    # The slot key does not change when an id lands here, so the parked
+    # signature is still found. Pinned because the frontend keys the same wait
+    # by card id, which a late id does rename, and the two have to agree.
+    turn = _Turn()
+    turn.merge_structured(
+        [_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"sig": "A"}}]
+    )
+    turn.merge_structured([_delta(0, "lookup", None) | {"extra_content": {"sig": "B"}}])
+    turn.merge_structured([_delta(0, None, "") | {"id": "call_x"}])
+
+    reported = turn.calls()
+    assert _reported(turn) == [("lookup", '{"q":"a"}')]
+    assert reported[0]["extra_content"] == {"sig": "B"}
+
+
 def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
     # Reading "web_search" as "web" grown gave the id to the completed call.
     turn = _Turn()

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -691,8 +691,7 @@ def test_a_provider_claiming_a_minted_id_displaces_the_id_less_call():
     turn.merge_structured([_delta(1, "beta", '{"b":2}', call_id = "tool_call_0")])
 
     reported = [
-        (call.get("card_id") or call["id"], call["function"]["name"])
-        for call in turn.calls()
+        (call.get("card_id") or call["id"], call["function"]["name"]) for call in turn.calls()
     ]
     assert reported == [("tool_call_1", "alpha"), ("tool_call_0", "beta")]
 

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -748,9 +748,7 @@ def test_parked_metadata_survives_a_late_id_landing_on_the_call():
     # signature is still found. Pinned because the frontend keys the same wait
     # by card id, which a late id does rename, and the two have to agree.
     turn = _Turn()
-    turn.merge_structured(
-        [_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"sig": "A"}}]
-    )
+    turn.merge_structured([_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"sig": "A"}}])
     turn.merge_structured([_delta(0, "lookup", None) | {"extra_content": {"sig": "B"}}])
     turn.merge_structured([_delta(0, None, "") | {"id": "call_x"}])
 

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -721,6 +721,32 @@ def test_a_nameless_claim_does_not_take_a_valid_call_s_card():
     assert reported == [("tool_call_0", "alpha")]
 
 
+def test_a_repeated_names_metadata_waits_for_the_call_it_announced():
+    # The same tool twice on one slot, the second announced by a name-only
+    # delta carrying its own signature. Merging it where it landed overwrote
+    # the closed call's and left the new call unsigned, and Gemini validates a
+    # signature against the call it is replayed on.
+    turn = _Turn()
+    turn.merge_structured(
+        [_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"sig": "A"}}]
+    )
+    turn.merge_structured([_delta(0, "lookup", None) | {"extra_content": {"sig": "B"}}])
+    turn.merge_structured([_delta(0, None, '{"q":"b"}')])
+
+    reported = turn.calls()
+    assert _reported(turn) == [("lookup", '{"q":"a"}'), ("lookup", '{"q":"b"}')]
+    assert reported[0]["extra_content"] == {"sig": "A"}
+    assert reported[1]["extra_content"] == {"sig": "B"}
+
+    # No object followed, so the repeated name really was that call's resent.
+    kept = _Turn()
+    kept.merge_structured(
+        [_delta(0, "lookup", '{"q":"a"}') | {"extra_content": {"own": 1}}]
+    )
+    kept.merge_structured([_delta(0, "lookup", None) | {"extra_content": {"sig": "B"}}])
+    assert kept.calls()[0]["extra_content"] == {"own": 1, "sig": "B"}
+
+
 def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
     # Reading "web_search" as "web" grown gave the id to the completed call.
     turn = _Turn()

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -709,6 +709,20 @@ def test_a_rejected_call_reserves_no_card_id():
     assert [call.get("card_id") for call in second.calls(taken, cards)] == ["tool_call_0"]
 
 
+def test_a_nameless_claim_does_not_take_a_valid_call_s_card():
+    # The client displaces the card holding a spelling the moment a provider
+    # claims it, so a claim that turns out not to be a call has to give the
+    # number back. Nothing is reserved for it here, so the valid call keeps it.
+    turn = _Turn()
+    turn.merge_structured([_delta(0, "alpha", '{"a":1}')])
+    turn.merge_structured([_delta(1, None, '{"b":2}', call_id = "tool_call_0")])
+
+    reported = [
+        (call.get("card_id"), call["function"]["name"]) for call in turn.calls()
+    ]
+    assert reported == [("tool_call_0", "alpha")]
+
+
 def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
     # Reading "web_search" as "web" grown gave the id to the completed call.
     turn = _Turn()

--- a/studio/backend/tests/test_parallel_tool_call_arguments.py
+++ b/studio/backend/tests/test_parallel_tool_call_arguments.py
@@ -692,6 +692,23 @@ def test_a_card_ledger_is_append_only_across_rounds():
     assert [call.get("card_id") for call in third.calls(taken, cards)] == ["tool_call_1"]
 
 
+def test_a_rejected_call_reserves_no_card_id():
+    # A provider id on a call that never gets a name draws no card: the client
+    # releases the id it had minted, so holding it here would put the two out of
+    # step from the next round on.
+    taken: set[str] = set()
+    cards: set[str] = set()
+    first = _Turn()
+    first.merge_structured([_delta(0, None, '{"a":1}', call_id = "tool_call_0")])
+    first.merge_structured([_delta(1, "beta", '{"b":2}')])
+    assert [call.get("card_id") for call in first.calls(taken, cards)] == ["tool_call_1"]
+
+    second = _Turn()
+    second.round = 1
+    second.merge_structured([_delta(0, "gamma", '{"c":3}')])
+    assert [call.get("card_id") for call in second.calls(taken, cards)] == ["tool_call_0"]
+
+
 def test_a_stable_id_naming_a_longer_tool_opens_its_own_call():
     # Reading "web_search" as "web" grown gave the id to the completed call.
     turn = _Turn()

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5308,6 +5308,11 @@ export function createOpenAIStreamAdapter(
       // `{"a":1}{` is not marked truncated, so the lone brace would persist as
       // a card nothing completes. Kept while the turn runs, to be written to.
       const openTailIds = new Set<string>();
+      // Metadata from a delta whose name repeated the one a closed card holds.
+      // That name is either the call's, resent, or the next call to the same
+      // tool announcing itself, and only the object that follows tells them
+      // apart, so it waits here rather than landing on the wrong call.
+      const pendingExtraByPartId = new Map<string, Record<string, unknown>>();
       const endProviderTurn = (): boolean => {
         let changed = false;
         // _call_is_finished, on the arguments alone: the backend holds the
@@ -5360,6 +5365,22 @@ export function createOpenAIStreamAdapter(
           releaseStreamedCard(part.toolCallId);
           changed = true;
         }
+        for (const [partId, waiting] of pendingExtraByPartId) {
+          // No object ever came, so the repeated name was that call's after all
+          // and so is the metadata that rode it.
+          const at = toolCallParts.findIndex((part) => part.toolCallId === partId);
+          if (at === -1) continue;
+          const part = toolCallParts[at] as PositionedToolCallPart;
+          toolCallParts[at] = {
+            ...part,
+            extra_content: {
+              ...(isPlainRecord(part.extra_content) ? part.extra_content : {}),
+              ...waiting,
+            },
+          };
+          changed = true;
+        }
+        pendingExtraByPartId.clear();
         // Numbering is the backend's pass, and it runs over the calls that
         // survive: a card dropped above leaves a gap, and a claim displaced one
         // for a call that turned out not to be one at all. Both are settled
@@ -7310,6 +7331,17 @@ export function createOpenAIStreamAdapter(
                   if (announcesOverAnnouncement && matched) {
                     (matched as PositionedToolCallPart)._superseded = true;
                   }
+                  // A name repeating the one a closed card holds says nothing
+                  // new about that call, so metadata riding it belongs to
+                  // whichever call the next object opens; merged now it
+                  // overwrites the signature the closed call arrived with and
+                  // leaves the next call unsigned.
+                  const extraIsAmbiguous =
+                    closedSlot &&
+                    !!call.function?.name &&
+                    !!matched?.toolName &&
+                    call.function.name === matched.toolName &&
+                    isPlainRecord(call.extra_content);
                   const opensNextCall =
                     (closedSlot &&
                       (bringsArgs || idNamesAnotherCall || namesNextCall) &&
@@ -7383,8 +7415,15 @@ export function createOpenAIStreamAdapter(
                     // Merged, not replaced: a signature announced with the
                     // name and one arriving with the arguments are different
                     // fields of one call.
-                    const incomingExtra =
-                      isPlainRecord(prevExtra) && isPlainRecord(call.extra_content)
+                    if (extraIsAmbiguous && isPlainRecord(call.extra_content)) {
+                      pendingExtraByPartId.set(existing.toolCallId, {
+                        ...(pendingExtraByPartId.get(existing.toolCallId) ?? {}),
+                        ...call.extra_content,
+                      });
+                    }
+                    const incomingExtra = extraIsAmbiguous
+                      ? prevExtra
+                      : isPlainRecord(prevExtra) && isPlainRecord(call.extra_content)
                         ? { ...prevExtra, ...call.extra_content }
                         : call.extra_content;
                     if (
@@ -7482,12 +7521,25 @@ export function createOpenAIStreamAdapter(
                     const freshName = nameFragment || heldName;
                     // Across several calls the metadata belongs to the one
                     // this delta closes, the last. Same as the backend.
-                    const freshOwnExtra = freshIsSplit
-                      ? undefined
-                      : call.extra_content;
-                    const bornExtra = freshIsSplit
-                      ? call.extra_content
+                    // The object proved the repeated name announced this call,
+                    // so what was waiting on the card it reached is this one's.
+                    const waiting = matched
+                      ? pendingExtraByPartId.get(matched.toolCallId)
                       : undefined;
+                    if (waiting && matched) {
+                      pendingExtraByPartId.delete(matched.toolCallId);
+                    }
+                    const withWaiting =
+                      waiting === undefined
+                        ? call.extra_content
+                        : {
+                            ...waiting,
+                            ...(isPlainRecord(call.extra_content)
+                              ? call.extra_content
+                              : {}),
+                          };
+                    const freshOwnExtra = freshIsSplit ? undefined : withWaiting;
+                    const bornExtra = freshIsSplit ? withWaiting : undefined;
                     const argsText = freshIsSplit
                       ? freshSegments[0]
                       : argsFragment;

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5328,6 +5328,7 @@ export function createOpenAIStreamAdapter(
           const scanned = splitTopLevelJsonObjects(part.argsText ?? "");
           if (scanned.complete.length > 0 && !scanned.tail) continue;
           toolCallParts.splice(at, 1);
+          releaseStreamedCard(part.toolCallId);
           changed = true;
         }
         // An announcement another call took over, and a name that only ever
@@ -5357,6 +5358,7 @@ export function createOpenAIStreamAdapter(
             };
           }
           toolCallParts.splice(at, 1);
+          releaseStreamedCard(part.toolCallId);
           changed = true;
         }
         openTailIds.clear();
@@ -5386,6 +5388,40 @@ export function createOpenAIStreamAdapter(
       const paintStreamedCard = (partId: string): void => {
         reservedToolCallIds.add(partId);
         bindStreamedToolCallCard(toolPartIdByBackendId, partId);
+      };
+      // Raw tool_args accumulator per card: the backend forwards arguments while
+      // the model is still WRITING them, and the partial parse below feeds the
+      // card's args so the code renders live.
+      const liveArgsTextById = new Map<string, string>();
+      // A card that is dropped gives its id back. The backend never reserved
+      // it -- the call it stood for is filtered out of `calls` -- so holding it
+      // here makes the next round's mint skip a number the backend then reuses,
+      // and the tool_start addressed to it draws a second card beside the one
+      // the deltas already painted.
+      const releaseStreamedCard = (partId: string): void => {
+        reservedToolCallIds.delete(partId);
+        toolPartIdByBackendId.delete(partId);
+        boundaryScans.delete(partId);
+        openTailIds.delete(partId);
+        liveArgsTextById.delete(partId);
+      };
+      // A provider id can be spelled like a minted one. The backend reserves
+      // every id the provider sent before it mints any, so the id-less call
+      // moves aside; the client mints while the response is still arriving and
+      // can only move it aside once the claim lands.
+      const renameStreamedCard = (from: string, to: string): void => {
+        reservedToolCallIds.delete(from);
+        toolPartIdByBackendId.delete(from);
+        const scan = boundaryScans.get(from);
+        if (scan) boundaryScans.set(to, scan);
+        boundaryScans.delete(from);
+        if (openTailIds.delete(from)) openTailIds.add(to);
+        const live = liveArgsTextById.get(from);
+        if (live !== undefined) liveArgsTextById.set(to, live);
+        liveArgsTextById.delete(from);
+        const at = codexRoundToolCallIds.indexOf(from);
+        if (at !== -1) codexRoundToolCallIds[at] = to;
+        paintStreamedCard(to);
       };
       /**
        * Parts for the calls after the first, in a slot holding several. Nothing
@@ -5429,10 +5465,6 @@ export function createOpenAIStreamAdapter(
             ...(deltaIndex !== undefined ? { _delta_index: deltaIndex } : {}),
           };
         });
-      // Raw tool_args accumulator per card: the backend forwards arguments while
-      // the model is still WRITING them, and the partial parse below feeds the
-      // card's args so the code renders live.
-      const liveArgsTextById = new Map<string, string>();
       // Backend tool ids ("call_0", ...) restart every response, so a bare id as
       // store key lets a later turn's stream overwrite the preserved output an
       // earlier still-mounted finished card reads (the tool_start stale-clear
@@ -7135,6 +7167,24 @@ export function createOpenAIStreamAdapter(
                   // tool_start/tool_end events. Resolve the backend id now so all three
                   // event shapes update one run-unique card instead of leaving the raw
                   // provisional card beside a second execution card.
+                  // Before resolving: an id-less call drawn earlier answers to
+                  // its own minted id, so a provider claiming that spelling
+                  // would resolve onto that card and this call would be merged
+                  // into it, name and arguments both. Move the minted card to
+                  // the next free id, which is where the backend's
+                  // reserve-then-mint order puts it too.
+                  if (stableId && !toolCallParts.some((part) => part.toolCallId === stableId && part._has_stable_id)) {
+                    const clash = toolCallParts.findIndex(
+                      (part) => part.toolCallId === stableId,
+                    );
+                    if (clash !== -1) {
+                      reservedToolCallIds.add(stableId);
+                      const part = toolCallParts[clash] as PositionedToolCallPart;
+                      const renamed = mintStreamedCardId(part._delta_index);
+                      renameStreamedCard(part.toolCallId, renamed);
+                      toolCallParts[clash] = { ...part, toolCallId: renamed };
+                    }
+                  }
                   const stablePartId = stableId
                     ? resolveToolPartId(stableId)
                     : undefined;
@@ -7379,11 +7429,18 @@ export function createOpenAIStreamAdapter(
                       // Appended, not inserted beside the slot, so a call the
                       // stream opened third reads third whichever index it
                       // reused. Where the branch below puts one, too.
+                      // This delta's own metadata, not the merge: the merge
+                      // exists to keep a signature announced with the name
+                      // beside one arriving with the arguments, and both of
+                      // those belong to the call the slot was already holding.
+                      // Carried onto a born call it puts one call's signature
+                      // on another, and Gemini validates the signature against
+                      // the functionCall part it is returned on.
                       const born = bornSplitToolCalls(
                         segments.slice(1),
                         nextName,
                         idx,
-                        incomingExtra,
+                        call.extra_content,
                       );
                       // The last one is the object still being written, if one
                       // is: kept so later fragments have somewhere to go, and

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5349,6 +5349,17 @@ export function createOpenAIStreamAdapter(
           releaseStreamedCard(part.toolCallId);
           changed = true;
         }
+        // A call needs a name to run: _normalized_call drops a nameless one
+        // before it reserves a card id, so a card kept here holds a number the
+        // backend hands to the next round's call, and its events land on this
+        // blank card instead.
+        for (let at = toolCallParts.length - 1; at >= 0; at -= 1) {
+          const part = toolCallParts[at] as PositionedToolCallPart;
+          if (part.toolName || part._delta_index === undefined) continue;
+          toolCallParts.splice(at, 1);
+          releaseStreamedCard(part.toolCallId);
+          changed = true;
+        }
         openTailIds.clear();
         // The next round opens at index 0 again, and without this "B" then
         // "C" across the boundary named one call "BC".
@@ -5384,6 +5395,16 @@ export function createOpenAIStreamAdapter(
       const releaseStreamedCard = (partId: string): void => {
         reservedToolCallIds.delete(partId);
         toolPartIdByBackendId.delete(partId);
+        // A card that took a late provider id answers to a run-unique part id,
+        // so the id the provider sent is a separate key pointing at it. Left
+        // behind, that reservation makes the next round's mint skip a number
+        // the backend, which never reserved it for a call it filtered, reuses.
+        for (const [backendId, mapped] of [...toolPartIdByBackendId]) {
+          if (mapped !== partId) continue;
+          toolPartIdByBackendId.delete(backendId);
+          reservedToolCallIds.delete(backendId);
+          providerSentToolCallIds.delete(backendId);
+        }
         boundaryScans.delete(partId);
         openTailIds.delete(partId);
         liveArgsTextById.delete(partId);
@@ -5412,7 +5433,12 @@ export function createOpenAIStreamAdapter(
       // and third calls' results off each other's cards.
       const renumberMintedCards = (claimed: string): void => {
         const minted = toolCallParts.filter(
-          (part) => !providerSentToolCallIds.has(part.toolCallId),
+          (part) =>
+            !providerSentToolCallIds.has(part.toolCallId) &&
+            // This round's cards only. An earlier round's are complete, may
+            // already carry a result, and the backend's card ledger is
+            // append-only: it never renumbers one, so neither may this.
+            (part as PositionedToolCallPart)._delta_index !== undefined,
         ) as PositionedToolCallPart[];
         const carried = minted.map((part) => ({
           part,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5293,6 +5293,11 @@ export function createOpenAIStreamAdapter(
       // A card is minted before its part joins `toolCallParts`, so without
       // this a batch opening three calls mints one id three times.
       const reservedToolCallIds = new Set<string>();
+      // Of those, the ones the provider itself sent. A minted card holds its
+      // id only until the provider claims that spelling; `_has_stable_id` does
+      // not say which is which, since a split marks every card but the last
+      // with it to keep a late id off the calls already spoken for.
+      const providerSentToolCallIds = new Set<string>();
       const boundaryScans = new Map<
         string,
         ReturnType<typeof createBoundaryScan>
@@ -5398,6 +5403,52 @@ export function createOpenAIStreamAdapter(
         const at = codexRoundToolCallIds.indexOf(from);
         if (at !== -1) codexRoundToolCallIds[at] = to;
         paintStreamedCard(to);
+      };
+      // The backend reserves every id the provider sent before it mints any
+      // card id, so a claim arriving mid-response moves every card the client
+      // had already numbered. Renumber them all, in the order the backend
+      // walks them, or its tool_start reaches the wrong card: with three calls
+      // in one delta and a later `tool_call_1`, the two sides read the second
+      // and third calls' results off each other's cards.
+      const renumberMintedCards = (claimed: string): void => {
+        const minted = toolCallParts.filter(
+          (part) => !providerSentToolCallIds.has(part.toolCallId),
+        ) as PositionedToolCallPart[];
+        const carried = minted.map((part) => ({
+          part,
+          from: part.toolCallId,
+          scan: boundaryScans.get(part.toolCallId),
+          live: liveArgsTextById.get(part.toolCallId),
+          openTail: openTailIds.has(part.toolCallId),
+        }));
+        for (const held of carried) {
+          reservedToolCallIds.delete(held.from);
+          toolPartIdByBackendId.delete(held.from);
+          boundaryScans.delete(held.from);
+          liveArgsTextById.delete(held.from);
+          openTailIds.delete(held.from);
+          // Cleared before any of them is minted again: the mint reads the ids
+          // the parts are holding, and a stale one makes the first card skip
+          // the number the backend gives it.
+          const at = toolCallParts.indexOf(held.part);
+          if (at !== -1) toolCallParts[at] = { ...held.part, toolCallId: "" };
+        }
+        // Held back only now: the loop above frees every minted id, and one of
+        // them is the spelling being claimed.
+        reservedToolCallIds.add(claimed);
+        for (const held of carried) {
+          const to = mintStreamedCardId(held.part._delta_index);
+          paintStreamedCard(to);
+          if (held.scan) boundaryScans.set(to, held.scan);
+          if (held.live !== undefined) liveArgsTextById.set(to, held.live);
+          if (held.openTail) openTailIds.add(to);
+          const at = codexRoundToolCallIds.indexOf(held.from);
+          if (at !== -1) codexRoundToolCallIds[at] = to;
+          const index = toolCallParts.findIndex((part) => part.toolCallId === "");
+          if (index !== -1) {
+            toolCallParts[index] = { ...held.part, toolCallId: to };
+          }
+        }
       };
       /**
        * Parts for the calls after the first in a slot holding several. Nothing
@@ -7131,24 +7182,28 @@ export function createOpenAIStreamAdapter(
                   // Before resolving: a provider claiming a minted spelling
                   // would resolve onto that card and merge the two calls. The
                   // backend's reserve-then-mint order lands on the same pair.
-                  if (stableId && !toolCallParts.some((part) => part.toolCallId === stableId && part._has_stable_id)) {
-                    const clash = toolCallParts.findIndex(
-                      (part) => part.toolCallId === stableId,
-                    );
-                    if (clash !== -1) {
-                      reservedToolCallIds.add(stableId);
-                      const part = toolCallParts[clash] as PositionedToolCallPart;
-                      const renamed = mintStreamedCardId(part._delta_index);
-                      renameStreamedCard(part.toolCallId, renamed);
-                      toolCallParts[clash] = { ...part, toolCallId: renamed };
-                    }
+                  if (
+                    stableId &&
+                    !providerSentToolCallIds.has(stableId) &&
+                    toolCallParts.some((part) => part.toolCallId === stableId)
+                  ) {
+                    // Renumber first: the claimed spelling is held by a minted
+                    // card until this runs, and marking it provider-sent any
+                    // earlier would exempt that very card from the move.
+                    renumberMintedCards(stableId);
+                    providerSentToolCallIds.add(stableId);
+                    reservedToolCallIds.add(stableId);
                   }
                   const stablePartId = stableId
                     ? resolveToolPartId(stableId)
                     : undefined;
                   // Reserved before any card id is minted, so a provider that
                   // happens to spell an id `tool_call_0` keeps it to itself.
-                  if (stableId) reservedToolCallIds.add(stableId);
+                  if (stableId) {
+                    reservedToolCallIds.add(stableId);
+                    providerSentToolCallIds.add(stableId);
+                  }
+                  if (stablePartId) providerSentToolCallIds.add(stablePartId);
                   // match by resolved id when the fragment carries one, else by
                   // index slot; streams that send neither get a minted
                   // tool_call_<n> id.
@@ -7335,10 +7390,13 @@ export function createOpenAIStreamAdapter(
                           true && !slotText,
                     };
                     toolCallParts[existingIndex] = updated;
-                    // A fork whose object is still open answers to its late id
-                    // from here on, so it stays held back under that one.
-                    if (stablePartId && openTailIds.delete(existing.toolCallId)) {
-                      openTailIds.add(stablePartId);
+                    // The card answers to its late id from here on, so what was
+                    // keyed on the provisional one moves and the id itself goes
+                    // back: the backend never reserved it for a call the
+                    // provider went on to name, and holding it makes the next
+                    // mint skip the number the backend hands out.
+                    if (stablePartId && stablePartId !== existing.toolCallId) {
+                      renameStreamedCard(existing.toolCallId, stablePartId);
                     }
                     if (isSplit) {
                       // The slot keeps one segment, not the whole string, so

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5278,9 +5278,7 @@ export function createOpenAIStreamAdapter(
         textCursor?: number;
         _delta_index?: number;
         _has_stable_id?: boolean;
-        // Opened by a delta that named a tool and carried no `arguments` field
-        // at all. A tool that takes none sends an empty string, so this marks
-        // the announcement of a call whose arguments have not started.
+        // No `arguments` field at all; a zero-parameter tool sends """".
         _announced_only?: boolean;
         _resend_suspect?: boolean;
         _superseded?: boolean;
@@ -5290,37 +5288,25 @@ export function createOpenAIStreamAdapter(
       };
       // Tool call parts, cumulative; result lands on tool_end.
       const toolCallParts: PositionedToolCallPart[] = [];
-      // An id for a call the stream never gave one: a slot that turned out to
-      // hold several parallel calls (issue #9807). Counted, not random, so a
+      // An id for a call the stream gave none (issue #9807). Counted, so a
       // rerun of the same stream reads the same way in a log.
-      // Ids already spoken for this response: the ones the provider sent, and
-      // the ones minted for cards drawn from a delta that carried none. A card
-      // is minted before its part joins `toolCallParts`, so without holding
-      // them here a batch that opens three calls at once mints one id three
-      // times and the three cards collect each other's results.
+      // A card is minted before its part joins `toolCallParts`, so without
+      // this a batch opening three calls mints one id three times.
       const reservedToolCallIds = new Set<string>();
-      // Resumable boundary scan per card, so an argument streamed in many
-      // fragments is scanned once rather than once per fragment.
       const boundaryScans = new Map<
         string,
         ReturnType<typeof createBoundaryScan>
       >();
-      // extra_content is typed `unknown` because it is whatever the provider
-      // hung off the call, so merging two of them has to check first.
       const isPlainRecord = (v: unknown): v is Record<string, unknown> =>
         typeof v === "object" && v !== null && !Array.isArray(v);
-      // Cards forked off a slot whose last object had not closed. The backend
-      // holds the same ones in open_tail_keys: a stream stopping after
+      // Forks whose last object never closed, the backend's open_tail_keys.
       // `{"a":1}{` is not marked truncated, so the lone brace would persist as
-      // a card nothing can complete. Kept while the turn runs, since later
-      // id-less fragments are written to it.
+      // a card nothing completes. Kept while the turn runs, to be written to.
       const openTailIds = new Set<string>();
       const endProviderTurn = (): boolean => {
         let changed = false;
-        // Same test as _call_is_finished, and on the arguments alone: the
-        // backend holds the fork back whether or not a later fragment stamped
-        // an id on it, so a card kept for the id would be one no tool_start or
-        // tool_end can ever reach.
+        // _call_is_finished, on the arguments alone: the backend holds the
+        // fork back whatever id reached it.
         for (const tailId of openTailIds) {
           const at = toolCallParts.findIndex((p) => p.toolCallId === tailId);
           if (at === -1) continue;
@@ -5331,11 +5317,9 @@ export function createOpenAIStreamAdapter(
           releaseStreamedCard(part.toolCallId);
           changed = true;
         }
-        // An announcement another call took over, and a name that only ever
-        // looked like the closed call's resent, were never calls of their own,
-        // and a card for one is a card no tool will ever run. A lone
-        // announcement the provider opened itself stays: a tool that takes no
-        // parameters is announced exactly that way and does run.
+        // An announcement another call took over, and a name that only looked
+        // like the closed call's resent, were never calls. A lone announcement
+        // the provider opened stays: a zero-parameter tool looks like that.
         for (let at = toolCallParts.length - 1; at >= 0; at -= 1) {
           const part = toolCallParts[at] as PositionedToolCallPart;
           if (
@@ -5345,9 +5329,8 @@ export function createOpenAIStreamAdapter(
             part.argsText
           )
             continue;
-          // Its metadata still belongs to this turn -- Gemini stows a thought
-          // signature there and the native translator rejects a replay without
-          // one -- so it goes to the call the announcement was mistaken for.
+          // Its metadata goes to the call it was mistaken for: Gemini stows a
+          // thought signature there and rejects a replay without one.
           const previous = toolCallParts[at - 1] as
             | PositionedToolCallPart
             | undefined;
@@ -5362,10 +5345,8 @@ export function createOpenAIStreamAdapter(
           changed = true;
         }
         openTailIds.clear();
-        // A round's cards belong to that round. The next one opens at index 0
-        // again, and without this a name fragment it sends continues the call
-        // this round left open at that index, so "B" then "C" across the
-        // boundary named one call "BC" and neither tool ran.
+        // The next round opens at index 0 again, and without this "B" then
+        // "C" across the boundary named one call "BC".
         for (let at = 0; at < toolCallParts.length; at += 1) {
           const part = toolCallParts[at] as PositionedToolCallPart;
           if (part._delta_index === undefined) continue;
@@ -5393,11 +5374,8 @@ export function createOpenAIStreamAdapter(
       // the model is still WRITING them, and the partial parse below feeds the
       // card's args so the code renders live.
       const liveArgsTextById = new Map<string, string>();
-      // A card that is dropped gives its id back. The backend never reserved
-      // it -- the call it stood for is filtered out of `calls` -- so holding it
-      // here makes the next round's mint skip a number the backend then reuses,
-      // and the tool_start addressed to it draws a second card beside the one
-      // the deltas already painted.
+      // A dropped card gives its id back: the backend never reserved it, so
+      // holding it makes the next round's mint skip a number it then reuses.
       const releaseStreamedCard = (partId: string): void => {
         reservedToolCallIds.delete(partId);
         toolPartIdByBackendId.delete(partId);
@@ -5405,10 +5383,8 @@ export function createOpenAIStreamAdapter(
         openTailIds.delete(partId);
         liveArgsTextById.delete(partId);
       };
-      // A provider id can be spelled like a minted one. The backend reserves
-      // every id the provider sent before it mints any, so the id-less call
-      // moves aside; the client mints while the response is still arriving and
-      // can only move it aside once the claim lands.
+      // The backend reserves provider ids before it mints; the client can
+      // only move a card aside once the claim lands.
       const renameStreamedCard = (from: string, to: string): void => {
         reservedToolCallIds.delete(from);
         toolPartIdByBackendId.delete(from);
@@ -5424,9 +5400,8 @@ export function createOpenAIStreamAdapter(
         paintStreamedCard(to);
       };
       /**
-       * Parts for the calls after the first, in a slot holding several. Nothing
-       * per-call is copied across: no result, no provenance, and the thought
-       * signature goes only to the call this delta closes, the last one.
+       * Parts for the calls after the first in a slot holding several. Nothing
+       * per-call is copied: the thought signature goes only to the last.
        */
       const bornSplitToolCalls = (
         extraSegments: string[],
@@ -5457,10 +5432,7 @@ export function createOpenAIStreamAdapter(
             ...(isLast && extraContent !== undefined
               ? { extra_content: extraContent }
               : {}),
-            // Every segment but the last is spoken for, so a late id cannot
-            // reach back past the newest call in the slot. The last stays
-            // claimable even when closed: a provider bundling several calls
-            // into one delta can stamp that one's real id in a delta of its own.
+            // All but the last are spoken for; the last stays claimable.
             ...(isLast ? {} : { _has_stable_id: true }),
             ...(deltaIndex !== undefined ? { _delta_index: deltaIndex } : {}),
           };
@@ -6444,11 +6416,8 @@ export function createOpenAIStreamAdapter(
                 chunk as unknown as { _toolStatus?: string }
               )._toolStatus;
               if (toolStatusText !== undefined) {
-                // The empty status between iterations, the one boundary every
-                // round has. A round whose calls were all rejected as disabled
-                // emits no tool card, and a [DONE] or EOF upstream sends no
-                // finish_reason, so without it the next round's first name
-                // fragment continues whatever this one left open at index 0.
+                // The one boundary every round has: only-disabled rounds emit
+                // no card and a [DONE] upstream sends no finish_reason.
                 if (!toolStatusText) {
                   endProviderTurn();
                 }
@@ -6536,15 +6505,9 @@ export function createOpenAIStreamAdapter(
                 chunk as unknown as { _toolEvent?: Record<string, unknown> }
               )._toolEvent;
               if (toolEvent !== undefined) {
-                // One of Unsloth's own tool events ends the provider turn that
-                // asked for it. finish_reason alone is not enough: a [DONE] or
-                // EOF upstream never sends one, and the next request restarts
-                // the delta indices. Before the queue below is read, so this
-                // turn's announcements reach it.
-                //
-                // A hosted tool runs INSIDE the turn, though, and
-                // note_hosted_tool_event leaves the _Turn open. Hosted events
-                // ride a whole chat.completion.chunk, `choices` and all;
+                // Unsloth's own tool events end the turn that asked for them;
+                // finish_reason alone is not enough. A hosted tool runs INSIDE
+                // the turn and rides a whole chunk, `choices` and all, where
                 // Unsloth's are bare {"type": "tool_start"} frames.
                 if (!chunk.choices) {
                   endProviderTurn();
@@ -7156,9 +7119,7 @@ export function createOpenAIStreamAdapter(
                     typeof call.index === "number" ? call.index : undefined;
                   const stableId = call.id;
                   // The chunk is cast, not validated, and llama-server has
-                  // shipped `arguments` as a decoded object rather than the
-                  // string the API specifies. Reading it as a string aborted the
-                  // adapter; the backend guards the same way with isinstance.
+                  // shipped `arguments` as a decoded object.
                   const deltaArgs =
                     typeof call.function?.arguments === "string"
                       ? call.function.arguments
@@ -7167,12 +7128,9 @@ export function createOpenAIStreamAdapter(
                   // tool_start/tool_end events. Resolve the backend id now so all three
                   // event shapes update one run-unique card instead of leaving the raw
                   // provisional card beside a second execution card.
-                  // Before resolving: an id-less call drawn earlier answers to
-                  // its own minted id, so a provider claiming that spelling
-                  // would resolve onto that card and this call would be merged
-                  // into it, name and arguments both. Move the minted card to
-                  // the next free id, which is where the backend's
-                  // reserve-then-mint order puts it too.
+                  // Before resolving: a provider claiming a minted spelling
+                  // would resolve onto that card and merge the two calls. The
+                  // backend's reserve-then-mint order lands on the same pair.
                   if (stableId && !toolCallParts.some((part) => part.toolCallId === stableId && part._has_stable_id)) {
                     const clash = toolCallParts.findIndex(
                       (part) => part.toolCallId === stableId,
@@ -7203,10 +7161,9 @@ export function createOpenAIStreamAdapter(
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
-                  // A closed object takes no more content, so a delta bringing
-                  // a name or arguments to a slot holding one whole object opens
-                  // the next parallel call. Splitting the text catches that only
-                  // once the arguments land, too late for a name or a late id.
+                  // A closed object takes no more content, so a name or
+                  // arguments reaching it open the next call. Splitting the
+                  // text alone is too late for a name or an id.
                   const slotIsClosed = (() => {
                     if (!matched?.argsText) return false;
                     const held = scanArgsText(
@@ -7215,69 +7172,44 @@ export function createOpenAIStreamAdapter(
                     );
                     return held.complete.length > 0 && !held.tail;
                   })();
-                  // An id names its call, so a fragment repeating the id this
-                  // part already holds continues it however complete its
-                  // arguments look. llama-server grows the name across deltas,
-                  // and opening a call there gives two cards one id.
+                  // A fragment repeating the id this part holds continues it
+                  // however complete the arguments look.
                   const namesThisCall =
                     !!stablePartId && matched?.toolCallId === stablePartId;
-                  // Whitespace after a closing brace says nothing about another
-                  // call, and a next call opens with the "{" of its own
-                  // arguments. Cutting on anything else would turn a stray
-                  // scalar suffix into a second call and run the tool twice.
+                  // A next call opens with its own "{"; cutting on anything
+                  // else runs the tool twice on a stray scalar suffix.
                   const bringsArgs = deltaArgs.trim().startsWith("{");
                   const closedSlot = slotIsClosed && !namesThisCall;
-                  // A name reaching a closed slot cannot be read yet: a second
-                  // call to the same tool announces itself exactly as
-                  // llama-server resends a name it is growing. An id names its
-                  // call outright, so one naming a DIFFERENT call opens the next
-                  // even before its arguments arrive. On its own, or repeating
-                  // the held name, it is that call's id stamped late, and
-                  // forking there strands the finished card under a provisional
-                  // id beside an empty second one.
+                  // An id naming a DIFFERENT call opens the next even before
+                  // its arguments arrive; alone it is that call's, stamped late.
                   const idNamesAnotherCall =
                     !!stablePartId &&
                     !!call.function?.name &&
                     !!matched?.toolName &&
-                    // Not a prefix test: an id is strong evidence of its own
-                    // call, and a catalog holding both "web" and "web_search"
-                    // would have the second claim the first. Only the same
-                    // name, or none, reads as that call's id arriving late.
+                    // Not a prefix test: a catalog holds both "web" and
+                    // "web_search".
                     call.function.name !== matched.toolName;
-                  // A snapshot-style provider repeats the finished call
-                  // verbatim once it has an id for it. Same name and
-                  // byte-identical arguments, on a card with no id of its own,
-                  // is that call arriving to be claimed; a second card runs a
-                  // side-effecting tool twice. Exact repeats only, so parallel
-                  // calls differing anywhere still open separately.
+                  // A snapshot provider repeats the finished call verbatim
+                  // once it has an id. Exact repeats only, so parallel calls
+                  // differing anywhere still open separately.
                   const resendsThisCall =
                     !!stablePartId &&
                     !!matched &&
                     !matched._has_stable_id &&
                     call.function?.name === matched.toolName &&
                     deltaArgs === matched.argsText;
-                  // A name arriving at a closed slot announces the next call.
-                  // A name grows across deltas only while it is being streamed,
-                  // which is before the arguments, so once the object has closed
-                  // there is nothing for a fragment to extend and a name can
-                  // only mean the next call. Testing for a shared prefix instead
-                  // read "web" after "web_search" as that call's name resent and
-                  // swallowed the second call. Without any of this, the reported
-                  // stream delivered one character per delta merges two calls'
-                  // names into "web_fetchweb_search", which matches no tool.
-                  // The same name is that call's, resent: llama-server repeats
-                  // it on every delta and vLLM has repeated the whole name too,
-                  // so opening a call there would run one request twice.
+                  // A name at a closed slot announces the next call: names
+                  // grow before the arguments, so nothing is left to extend. A
+                  // shared prefix is no proof ("web" after "web_search" is a
+                  // second call), but the SAME name is that call's, resent, and
+                  // llama-server and vLLM both resend it.
                   const namesNextCall =
                     !!call.function?.name &&
                     !!matched?.toolName &&
                     call.function.name !== matched.toolName;
-                  // A slot holding only an announcement has no object to
-                  // close, so the rule above cannot reach it. A DIFFERENT name
-                  // arriving there with an object of its own is the next call:
-                  // a name still growing arrives on its own, before any
-                  // arguments. Without this the announcement's name and the
-                  // next call's glue into "A_longB", which matches no tool.
+                  // An announcement has no object to close, so the rule above
+                  // cannot reach it. A different name bringing an object is the
+                  // next call; gluing gave "A_longB", which matches no tool.
                   const announcesOverAnnouncement =
                     ((matched as PositionedToolCallPart | undefined)
                       ?._announced_only === true ||
@@ -7309,43 +7241,35 @@ export function createOpenAIStreamAdapter(
                     argsFragment.length + (call.function?.name?.length ?? 0);
                   if (existing) {
                     const prevName = existing.toolName ?? "";
-                    // Two provider dialects, and picking either alone breaks
-                    // the other. llama-server re-sends the whole name as it
-                    // grows ("web" then "web_search"), so appending yields
-                    // "webweb_search"; OpenAI streams it in fragments ("web"
-                    // then "_search"), so assigning yields "_search". Either
-                    // way the call is named something no tool declares and
-                    // never runs. Same rule the backend accumulator uses.
+                    // Two dialects, and either alone breaks the other:
+                    // llama-server resends the whole name as it grows, OpenAI
+                    // streams it in fragments. Same rule as the backend.
                     const nameFragment = call.function?.name ?? "";
-                    // Not once this card's object has closed AND it already
-                    // has a name: the rule above has opened the next call, and
-                    // renaming a finished card would put arguments validated
-                    // against one tool's schema under another tool's name.
-                    // Naming a card that has none is not a rename, and some
-                    // servers send the arguments first and the name later.
+                    // Never once the object has closed AND a name is set: that
+                    // would put one tool's arguments under another's name.
+                    // Naming a card that has none is not a rename, and servers
+                    // do send the arguments first.
                     const nextName =
                       !nameFragment || (closedSlot && prevName)
                         ? prevName
                         : nameFragment.startsWith(prevName)
                           ? nameFragment
                           : prevName + nameFragment;
-                    // A snapshot repeated to carry the id says nothing new
-                    // about the arguments; appending it would give the card
-                    // `{"a":1}{"a":1}` and split it back into two calls.
+                    // A snapshot repeated to carry the id adds nothing;
+                    // appending gives `{"a":1}{"a":1}` and splits it in two.
                     const merged = resendsThisCall
                       ? (existing.argsText ?? "")
                       : (existing.argsText ?? "") + argsFragment;
-                    // A call's arguments are one JSON object, so a slot holding
-                    // two is holding two calls: the stream reused this index,
-                    // which is how vLLM's id-less deltas glue `{"url":"a"}` and
+                    // A slot holding two objects is holding two calls: this is
+                    // how vLLM's id-less deltas glue `{"url":"a"}` and
                     // `{"url":"b"}` into one unparsable string (issue #9807).
                     // Cut on the object boundary, since the same tool twice has
                     // no name to cut on; a delta with an id addresses its own.
                     const split = stablePartId
                       ? { complete: [], tail: "" }
                       : scanArgsText(existing.toolCallId, merged);
-                    // Whether the last segment is still being written decides
-                    // who may go on writing to it.
+                    // Whether the last segment is still open decides who may
+                    // go on writing to it.
                     const splitTailIsOpen = split.tail.length > 0;
                     const segments = splitTailIsOpen
                       ? [...split.complete, split.tail]
@@ -7369,9 +7293,9 @@ export function createOpenAIStreamAdapter(
                     }
                     const prevExtra = (existing as PositionedToolCallPart)
                       .extra_content;
-                    // Merged, not replaced: a signature announced with the name
-                    // and one arriving with the arguments are different fields
-                    // of one call, and dropping either fails replay.
+                    // Merged, not replaced: a signature announced with the
+                    // name and one arriving with the arguments are different
+                    // fields of one call.
                     const incomingExtra =
                       isPlainRecord(prevExtra) && isPlainRecord(call.extra_content)
                         ? { ...prevExtra, ...call.extra_content }
@@ -7400,16 +7324,12 @@ export function createOpenAIStreamAdapter(
                           ? { extra_content: prevExtra }
                           : {}),
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
-                      // Any arguments field, empty string included, means the
-                      // call has started: a tool that takes no parameters
-                      // sends exactly that, and the card has to survive the
-                      // turn boundary sweep.
+                      // Any arguments field, "" included, means the call has
+                      // started, so the card survives the boundary sweep.
                       _announced_only:
                         (existing as PositionedToolCallPart)._announced_only ===
                           true && call.function?.arguments === undefined,
-                      // Cleared the moment the slot accumulates anything: a
-                      // name that turned out to carry its own arguments was
-                      // never a resend.
+                      // A name that brought its own arguments was no resend.
                       _resend_suspect:
                         (existing as PositionedToolCallPart)._resend_suspect ===
                           true && !slotText,
@@ -7421,30 +7341,24 @@ export function createOpenAIStreamAdapter(
                       openTailIds.add(stablePartId);
                     }
                     if (isSplit) {
-                      // The slot keeps one segment rather than the whole string
-                      // it accumulated, so the resumable scan no longer
-                      // describes what it was reading.
+                      // The slot keeps one segment, not the whole string, so
+                      // the resumable scan no longer describes it.
                       boundaryScans.delete(existing.toolCallId);
                       boundaryScans.delete(updated.toolCallId);
-                      // Appended, not inserted beside the slot, so a call the
-                      // stream opened third reads third whichever index it
-                      // reused. Where the branch below puts one, too.
-                      // This delta's own metadata, not the merge: the merge
-                      // exists to keep a signature announced with the name
-                      // beside one arriving with the arguments, and both of
-                      // those belong to the call the slot was already holding.
-                      // Carried onto a born call it puts one call's signature
-                      // on another, and Gemini validates the signature against
-                      // the functionCall part it is returned on.
+                      // Appended, not inserted beside the slot, so a call
+                      // opened third reads third whichever index it reused.
+                      // This delta's own metadata, not the merge: the merged
+                      // fields belong to the call the slot was holding, and
+                      // Gemini validates a signature against the functionCall
+                      // part it was returned on.
                       const born = bornSplitToolCalls(
                         segments.slice(1),
                         nextName,
                         idx,
                         call.extra_content,
                       );
-                      // The last one is the object still being written, if one
-                      // is: kept so later fragments have somewhere to go, and
-                      // dropped at the end of the turn if it never closed.
+                      // The last is the object still being written, if one is:
+                      // kept for later fragments, dropped if it never closes.
                       if (splitTailIsOpen && born.length > 0) {
                         openTailIds.add(born[born.length - 1].toolCallId);
                       }
@@ -7461,9 +7375,8 @@ export function createOpenAIStreamAdapter(
                     if (!codexRoundToolCallIds.includes(callId)) {
                       codexRoundToolCallIds.push(callId);
                     }
-                    // A slot can arrive already holding several calls in one
-                    // fragment: vLLM bundles them into a single delta when the
-                    // model writes them in one pass. Same boundary as above.
+                    // vLLM bundles several calls into one delta when the model
+                    // writes them in one pass. Same boundary as above.
                     const freshSplit = stablePartId
                       ? { complete: [], tail: "" }
                       : splitTopLevelJsonObjects(argsFragment);
@@ -7474,15 +7387,11 @@ export function createOpenAIStreamAdapter(
                     const freshIsSplit = freshSegments.length > 1;
                     const nameFragment = call.function?.name ?? "";
                     const heldName = matched?.toolName ?? "";
-                    // An id-less provider reusing the index for another call
-                    // to the same tool can leave the repeated name out, the
-                    // first delta having given it. A blank name is no tool at
-                    // all, and the card would name nothing the backend runs.
+                    // A second call to the same tool can arrive with no name,
+                    // the first delta having given it; blank names nothing.
                     const freshName = nameFragment || heldName;
-                    // When this delta opened several calls the metadata it
-                    // carried belongs to the call it closes, which is the last
-                    // one. _fork_glued_arguments divides them the same way, and
-                    // a misplaced signature fails replay.
+                    // Across several calls the metadata belongs to the one
+                    // this delta closes, the last. Same as the backend.
                     const freshOwnExtra = freshIsSplit
                       ? undefined
                       : call.extra_content;
@@ -7519,21 +7428,13 @@ export function createOpenAIStreamAdapter(
                       ...(call.function?.arguments === undefined && freshName
                         ? { _announced_only: true }
                         : {}),
-                      // Whether this card is a fork's guess or a slot the
-                      // provider opened itself. An announcement the provider
-                      // opened is a call it means to make, most likely to a
-                      // tool that takes no parameters; one a fork invented has
-                      // no such standing, and if nothing fills it there is
-                      // nothing to run.
+                      // A fork's guess, or a slot the provider opened itself.
+                      // Only the provider's own announcement runs unfilled.
                       ...(matched ? { _from_fork: true } : {}),
-                      // A name that extends the name of the call this fork
-                      // just left behind is most likely that call's, resent.
-                      // It still opens a card, because a catalog holding both
-                      // "web" and "web_search" makes the prefix no proof
-                      // either way, but the card gives way rather than gluing
-                      // if another name brings the object: "alpha_long" then
-                      // "beta" was shown as "alpha_longbeta", which matches no
-                      // tool, and is dropped if nothing ever fills it.
+                      // A name extending the one this fork left behind is most
+                      // likely it, resent. It still opens a card (the prefix is
+                      // no proof) but gives way rather than gluing
+                      // "alpha_longbeta".
                       ...(freshName &&
                       heldName &&
                       freshName !== heldName &&
@@ -7558,14 +7459,11 @@ export function createOpenAIStreamAdapter(
                     addedToolCall = true;
                   }
                 }
-                // After this chunk's deltas, not before them: a provider can
-                // put finish_reason on the same chunk as the turn's last
-                // name-only delta, and closing the turn first would let that
-                // call cross into the next one.
+                // After this chunk's deltas: a provider can put finish_reason
+                // on the same chunk as the turn's last name-only delta.
                 if (chunk.choices?.[0]?.finish_reason) {
-                  // Ending the turn drops a call announced but never opened
-                  // and a fork whose object never closed, so the publish below
-                  // has to see it rather than wait for the pacing gate.
+                  // Ending the turn drops cards, so the publish below has to
+                  // see it rather than wait for the pacing gate.
                   replayStateChanged ||= endProviderTurn();
                 }
                 if (

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5360,6 +5360,12 @@ export function createOpenAIStreamAdapter(
           releaseStreamedCard(part.toolCallId);
           changed = true;
         }
+        // Numbering is the backend's pass, and it runs over the calls that
+        // survive: a card dropped above leaves a gap, and a claim displaced one
+        // for a call that turned out not to be one at all. Both are settled
+        // here, where the backend settles them, rather than left a number apart
+        // for the rest of the response.
+        if (changed) renumberMintedCards();
         openTailIds.clear();
         // The next round opens at index 0 again, and without this "B" then
         // "C" across the boundary named one call "BC".
@@ -5431,7 +5437,7 @@ export function createOpenAIStreamAdapter(
       // walks them, or its tool_start reaches the wrong card: with three calls
       // in one delta and a later `tool_call_1`, the two sides read the second
       // and third calls' results off each other's cards.
-      const renumberMintedCards = (claimed: string): void => {
+      const renumberMintedCards = (claimed?: string): void => {
         const minted = toolCallParts.filter(
           (part) =>
             !providerSentToolCallIds.has(part.toolCallId) &&
@@ -5461,7 +5467,7 @@ export function createOpenAIStreamAdapter(
         }
         // Held back only now: the loop above frees every minted id, and one of
         // them is the spelling being claimed.
-        reservedToolCallIds.add(claimed);
+        if (claimed !== undefined) reservedToolCallIds.add(claimed);
         for (const held of carried) {
           const to = mintStreamedCardId(held.part._delta_index);
           paintStreamedCard(to);

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -106,9 +106,15 @@ import {
   type CodexReasoningLedger,
 } from "../codex-reasoning";
 
-import { toolCallReplayArguments } from "../tool-call-arguments";
 import {
+  createBoundaryScan,
+  splitTopLevelJsonObjects,
+  toolCallReplayArguments,
+} from "../tool-call-arguments";
+import {
+  bindStreamedToolCallCard,
   findStreamedToolCallPartIndex,
+  mintStreamedToolCallId,
   resolveToolCallPartId,
 } from "../tool-call-id";
 
@@ -5272,11 +5278,157 @@ export function createOpenAIStreamAdapter(
         textCursor?: number;
         _delta_index?: number;
         _has_stable_id?: boolean;
+        // Opened by a delta that named a tool and carried no `arguments` field
+        // at all. A tool that takes none sends an empty string, so this marks
+        // the announcement of a call whose arguments have not started.
+        _announced_only?: boolean;
+        _resend_suspect?: boolean;
+        _superseded?: boolean;
+        _from_fork?: boolean;
         extra_content?: unknown;
         provenance?: ToolCallProvenance;
       };
       // Tool call parts, cumulative; result lands on tool_end.
       const toolCallParts: PositionedToolCallPart[] = [];
+      // An id for a call the stream never gave one: a slot that turned out to
+      // hold several parallel calls (issue #9807). Counted, not random, so a
+      // rerun of the same stream reads the same way in a log.
+      // Ids already spoken for this response: the ones the provider sent, and
+      // the ones minted for cards drawn from a delta that carried none. A card
+      // is minted before its part joins `toolCallParts`, so without holding
+      // them here a batch that opens three calls at once mints one id three
+      // times and the three cards collect each other's results.
+      const reservedToolCallIds = new Set<string>();
+      // Resumable boundary scan per card, so an argument streamed in many
+      // fragments is scanned once rather than once per fragment.
+      const boundaryScans = new Map<
+        string,
+        ReturnType<typeof createBoundaryScan>
+      >();
+      // extra_content is typed `unknown` because it is whatever the provider
+      // hung off the call, so merging two of them has to check first.
+      const isPlainRecord = (v: unknown): v is Record<string, unknown> =>
+        typeof v === "object" && v !== null && !Array.isArray(v);
+      // Cards forked off a slot whose last object had not closed. The backend
+      // holds the same ones in open_tail_keys: a stream stopping after
+      // `{"a":1}{` is not marked truncated, so the lone brace would persist as
+      // a card nothing can complete. Kept while the turn runs, since later
+      // id-less fragments are written to it.
+      const openTailIds = new Set<string>();
+      const endProviderTurn = (): boolean => {
+        let changed = false;
+        // Same test as _call_is_finished, and on the arguments alone: the
+        // backend holds the fork back whether or not a later fragment stamped
+        // an id on it, so a card kept for the id would be one no tool_start or
+        // tool_end can ever reach.
+        for (const tailId of openTailIds) {
+          const at = toolCallParts.findIndex((p) => p.toolCallId === tailId);
+          if (at === -1) continue;
+          const part = toolCallParts[at];
+          const scanned = splitTopLevelJsonObjects(part.argsText ?? "");
+          if (scanned.complete.length > 0 && !scanned.tail) continue;
+          toolCallParts.splice(at, 1);
+          changed = true;
+        }
+        // An announcement another call took over, and a name that only ever
+        // looked like the closed call's resent, were never calls of their own,
+        // and a card for one is a card no tool will ever run. A lone
+        // announcement the provider opened itself stays: a tool that takes no
+        // parameters is announced exactly that way and does run.
+        for (let at = toolCallParts.length - 1; at >= 0; at -= 1) {
+          const part = toolCallParts[at] as PositionedToolCallPart;
+          if (
+            (!part._superseded &&
+              !part._resend_suspect &&
+              !(part._announced_only && part._from_fork)) ||
+            part.argsText
+          )
+            continue;
+          // Its metadata still belongs to this turn -- Gemini stows a thought
+          // signature there and the native translator rejects a replay without
+          // one -- so it goes to the call the announcement was mistaken for.
+          const previous = toolCallParts[at - 1] as
+            | PositionedToolCallPart
+            | undefined;
+          if (part.extra_content !== undefined && previous) {
+            previous.extra_content = {
+              ...(previous.extra_content ?? {}),
+              ...part.extra_content,
+            };
+          }
+          toolCallParts.splice(at, 1);
+          changed = true;
+        }
+        openTailIds.clear();
+        // A round's cards belong to that round. The next one opens at index 0
+        // again, and without this a name fragment it sends continues the call
+        // this round left open at that index, so "B" then "C" across the
+        // boundary named one call "BC" and neither tool ran.
+        for (let at = 0; at < toolCallParts.length; at += 1) {
+          const part = toolCallParts[at] as PositionedToolCallPart;
+          if (part._delta_index === undefined) continue;
+          const closed = { ...part };
+          delete closed._delta_index;
+          toolCallParts[at] = closed;
+        }
+        return changed;
+      };
+      const scanArgsText = (partId: string, text: string) => {
+        let scan = boundaryScans.get(partId);
+        if (!scan) {
+          scan = createBoundaryScan();
+          boundaryScans.set(partId, scan);
+        }
+        return scan.feed(text);
+      };
+      const mintStreamedCardId = (deltaIndex: number | undefined): string =>
+        mintStreamedToolCallId(toolCallParts, deltaIndex, reservedToolCallIds);
+      const paintStreamedCard = (partId: string): void => {
+        reservedToolCallIds.add(partId);
+        bindStreamedToolCallCard(toolPartIdByBackendId, partId);
+      };
+      /**
+       * Parts for the calls after the first, in a slot holding several. Nothing
+       * per-call is copied across: no result, no provenance, and the thought
+       * signature goes only to the call this delta closes, the last one.
+       */
+      const bornSplitToolCalls = (
+        extraSegments: string[],
+        toolName: string,
+        deltaIndex: number | undefined,
+        extraContent: unknown,
+      ): PositionedToolCallPart[] =>
+        extraSegments.map((segment, n) => {
+          const isLast = n === extraSegments.length - 1;
+          let segmentArgs: ToolCallMessagePart["args"] = {};
+          try {
+            segmentArgs = JSON.parse(segment) as ToolCallMessagePart["args"];
+          } catch {
+            segmentArgs = { _raw: segment } as ToolCallMessagePart["args"];
+          }
+          const bornId = mintStreamedCardId(deltaIndex);
+          paintStreamedCard(bornId);
+          if (!codexRoundToolCallIds.includes(bornId)) {
+            codexRoundToolCallIds.push(bornId);
+          }
+          return {
+            type: "tool-call" as const,
+            toolCallId: bornId,
+            toolName,
+            argsText: segment,
+            args: segmentArgs,
+            textCursor: cumulativeText.length,
+            ...(isLast && extraContent !== undefined
+              ? { extra_content: extraContent }
+              : {}),
+            // Every segment but the last is spoken for, so a late id cannot
+            // reach back past the newest call in the slot. The last stays
+            // claimable even when closed: a provider bundling several calls
+            // into one delta can stamp that one's real id in a delta of its own.
+            ...(isLast ? {} : { _has_stable_id: true }),
+            ...(deltaIndex !== undefined ? { _delta_index: deltaIndex } : {}),
+          };
+        });
       // Raw tool_args accumulator per card: the backend forwards arguments while
       // the model is still WRITING them, and the partial parse below feeds the
       // card's args so the code renders live.
@@ -6260,6 +6412,14 @@ export function createOpenAIStreamAdapter(
                 chunk as unknown as { _toolStatus?: string }
               )._toolStatus;
               if (toolStatusText !== undefined) {
+                // The empty status between iterations, the one boundary every
+                // round has. A round whose calls were all rejected as disabled
+                // emits no tool card, and a [DONE] or EOF upstream sends no
+                // finish_reason, so without it the next round's first name
+                // fragment continues whatever this one left open at index 0.
+                if (!toolStatusText) {
+                  endProviderTurn();
+                }
                 runtime.setToolStatus(
                   liveThreadKey(serverCancel),
                   toolStatusText || null,
@@ -6344,6 +6504,19 @@ export function createOpenAIStreamAdapter(
                 chunk as unknown as { _toolEvent?: Record<string, unknown> }
               )._toolEvent;
               if (toolEvent !== undefined) {
+                // One of Unsloth's own tool events ends the provider turn that
+                // asked for it. finish_reason alone is not enough: a [DONE] or
+                // EOF upstream never sends one, and the next request restarts
+                // the delta indices. Before the queue below is read, so this
+                // turn's announcements reach it.
+                //
+                // A hosted tool runs INSIDE the turn, though, and
+                // note_hosted_tool_event leaves the _Turn open. Hosted events
+                // ride a whole chat.completion.chunk, `choices` and all;
+                // Unsloth's are bare {"type": "tool_start"} frames.
+                if (!chunk.choices) {
+                  endProviderTurn();
+                }
                 // Deep Research is an ordinary tool to every loop that runs it, so the handoff
                 // is read off the events they all publish rather than a bespoke frame. An
                 // ungated pair is not rendered: the research card is the reply, a tool pill
@@ -6950,6 +7123,14 @@ export function createOpenAIStreamAdapter(
                   const idx =
                     typeof call.index === "number" ? call.index : undefined;
                   const stableId = call.id;
+                  // The chunk is cast, not validated, and llama-server has
+                  // shipped `arguments` as a decoded object rather than the
+                  // string the API specifies. Reading it as a string aborted the
+                  // adapter; the backend guards the same way with isinstance.
+                  const deltaArgs =
+                    typeof call.function?.arguments === "string"
+                      ? call.function.arguments
+                      : "";
                   // Unsloth's local Codex loop follows the OpenAI tool-call delta with
                   // tool_start/tool_end events. Resolve the backend id now so all three
                   // event shapes update one run-unique card instead of leaving the raw
@@ -6957,6 +7138,9 @@ export function createOpenAIStreamAdapter(
                   const stablePartId = stableId
                     ? resolveToolPartId(stableId)
                     : undefined;
+                  // Reserved before any card id is minted, so a provider that
+                  // happens to spell an id `tool_call_0` keeps it to itself.
+                  if (stableId) reservedToolCallIds.add(stableId);
                   // match by resolved id when the fragment carries one, else by
                   // index slot; streams that send neither get a minted
                   // tool_call_<n> id.
@@ -6965,10 +7149,104 @@ export function createOpenAIStreamAdapter(
                     stablePartId,
                     idx,
                   );
-                  const existing =
+                  const matched =
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
+                  // A closed object takes no more content, so a delta bringing
+                  // a name or arguments to a slot holding one whole object opens
+                  // the next parallel call. Splitting the text catches that only
+                  // once the arguments land, too late for a name or a late id.
+                  const slotIsClosed = (() => {
+                    if (!matched?.argsText) return false;
+                    const held = scanArgsText(
+                      matched.toolCallId,
+                      matched.argsText,
+                    );
+                    return held.complete.length > 0 && !held.tail;
+                  })();
+                  // An id names its call, so a fragment repeating the id this
+                  // part already holds continues it however complete its
+                  // arguments look. llama-server grows the name across deltas,
+                  // and opening a call there gives two cards one id.
+                  const namesThisCall =
+                    !!stablePartId && matched?.toolCallId === stablePartId;
+                  // Whitespace after a closing brace says nothing about another
+                  // call, and a next call opens with the "{" of its own
+                  // arguments. Cutting on anything else would turn a stray
+                  // scalar suffix into a second call and run the tool twice.
+                  const bringsArgs = deltaArgs.trim().startsWith("{");
+                  const closedSlot = slotIsClosed && !namesThisCall;
+                  // A name reaching a closed slot cannot be read yet: a second
+                  // call to the same tool announces itself exactly as
+                  // llama-server resends a name it is growing. An id names its
+                  // call outright, so one naming a DIFFERENT call opens the next
+                  // even before its arguments arrive. On its own, or repeating
+                  // the held name, it is that call's id stamped late, and
+                  // forking there strands the finished card under a provisional
+                  // id beside an empty second one.
+                  const idNamesAnotherCall =
+                    !!stablePartId &&
+                    !!call.function?.name &&
+                    !!matched?.toolName &&
+                    // Not a prefix test: an id is strong evidence of its own
+                    // call, and a catalog holding both "web" and "web_search"
+                    // would have the second claim the first. Only the same
+                    // name, or none, reads as that call's id arriving late.
+                    call.function.name !== matched.toolName;
+                  // A snapshot-style provider repeats the finished call
+                  // verbatim once it has an id for it. Same name and
+                  // byte-identical arguments, on a card with no id of its own,
+                  // is that call arriving to be claimed; a second card runs a
+                  // side-effecting tool twice. Exact repeats only, so parallel
+                  // calls differing anywhere still open separately.
+                  const resendsThisCall =
+                    !!stablePartId &&
+                    !!matched &&
+                    !matched._has_stable_id &&
+                    call.function?.name === matched.toolName &&
+                    deltaArgs === matched.argsText;
+                  // A name arriving at a closed slot announces the next call.
+                  // A name grows across deltas only while it is being streamed,
+                  // which is before the arguments, so once the object has closed
+                  // there is nothing for a fragment to extend and a name can
+                  // only mean the next call. Testing for a shared prefix instead
+                  // read "web" after "web_search" as that call's name resent and
+                  // swallowed the second call. Without any of this, the reported
+                  // stream delivered one character per delta merges two calls'
+                  // names into "web_fetchweb_search", which matches no tool.
+                  // The same name is that call's, resent: llama-server repeats
+                  // it on every delta and vLLM has repeated the whole name too,
+                  // so opening a call there would run one request twice.
+                  const namesNextCall =
+                    !!call.function?.name &&
+                    !!matched?.toolName &&
+                    call.function.name !== matched.toolName;
+                  // A slot holding only an announcement has no object to
+                  // close, so the rule above cannot reach it. A DIFFERENT name
+                  // arriving there with an object of its own is the next call:
+                  // a name still growing arrives on its own, before any
+                  // arguments. Without this the announcement's name and the
+                  // next call's glue into "A_longB", which matches no tool.
+                  const announcesOverAnnouncement =
+                    ((matched as PositionedToolCallPart | undefined)
+                      ?._announced_only === true ||
+                      (matched as PositionedToolCallPart | undefined)
+                        ?._resend_suspect === true) &&
+                    !matched?.argsText &&
+                    !!call.function?.name &&
+                    !!matched?.toolName &&
+                    call.function.name !== matched.toolName &&
+                    bringsArgs;
+                  if (announcesOverAnnouncement && matched) {
+                    (matched as PositionedToolCallPart)._superseded = true;
+                  }
+                  const opensNextCall =
+                    (closedSlot &&
+                      (bringsArgs || idNamesAnotherCall || namesNextCall) &&
+                      !resendsThisCall) ||
+                    announcesOverAnnouncement;
+                  const existing = opensNextCall ? undefined : matched;
 
                   if (
                     stablePartId &&
@@ -6976,32 +7254,81 @@ export function createOpenAIStreamAdapter(
                   ) {
                     codexRoundToolCallIds.push(stablePartId);
                   }
-                  const argsFragment = call.function?.arguments ?? "";
+                  const argsFragment = deltaArgs;
                   streamedChars +=
                     argsFragment.length + (call.function?.name?.length ?? 0);
                   if (existing) {
                     const prevName = existing.toolName ?? "";
-                    const nextName = call.function?.name ?? prevName;
-                    const merged = (existing.argsText ?? "") + argsFragment;
+                    // Two provider dialects, and picking either alone breaks
+                    // the other. llama-server re-sends the whole name as it
+                    // grows ("web" then "web_search"), so appending yields
+                    // "webweb_search"; OpenAI streams it in fragments ("web"
+                    // then "_search"), so assigning yields "_search". Either
+                    // way the call is named something no tool declares and
+                    // never runs. Same rule the backend accumulator uses.
+                    const nameFragment = call.function?.name ?? "";
+                    // Not once this card's object has closed AND it already
+                    // has a name: the rule above has opened the next call, and
+                    // renaming a finished card would put arguments validated
+                    // against one tool's schema under another tool's name.
+                    // Naming a card that has none is not a rename, and some
+                    // servers send the arguments first and the name later.
+                    const nextName =
+                      !nameFragment || (closedSlot && prevName)
+                        ? prevName
+                        : nameFragment.startsWith(prevName)
+                          ? nameFragment
+                          : prevName + nameFragment;
+                    // A snapshot repeated to carry the id says nothing new
+                    // about the arguments; appending it would give the card
+                    // `{"a":1}{"a":1}` and split it back into two calls.
+                    const merged = resendsThisCall
+                      ? (existing.argsText ?? "")
+                      : (existing.argsText ?? "") + argsFragment;
+                    // A call's arguments are one JSON object, so a slot holding
+                    // two is holding two calls: the stream reused this index,
+                    // which is how vLLM's id-less deltas glue `{"url":"a"}` and
+                    // `{"url":"b"}` into one unparsable string (issue #9807).
+                    // Cut on the object boundary, since the same tool twice has
+                    // no name to cut on; a delta with an id addresses its own.
+                    const split = stablePartId
+                      ? { complete: [], tail: "" }
+                      : scanArgsText(existing.toolCallId, merged);
+                    // Whether the last segment is still being written decides
+                    // who may go on writing to it.
+                    const splitTailIsOpen = split.tail.length > 0;
+                    const segments = splitTailIsOpen
+                      ? [...split.complete, split.tail]
+                      : split.complete;
+                    const isSplit = segments.length > 1;
+                    // The slot keeps the object it opened with, under the name
+                    // and id it had; the rest are calls this delta introduced.
+                    const slotText = isSplit ? segments[0] : merged;
                     let parsedArgs: ToolCallMessagePart["args"] =
                       existing.args ?? {};
-                    if (merged) {
+                    if (slotText) {
                       try {
                         parsedArgs = JSON.parse(
-                          merged,
+                          slotText,
                         ) as ToolCallMessagePart["args"];
                       } catch {
                         parsedArgs = {
-                          _raw: merged,
+                          _raw: slotText,
                         } as ToolCallMessagePart["args"];
                       }
                     }
                     const prevExtra = (existing as PositionedToolCallPart)
                       .extra_content;
+                    // Merged, not replaced: a signature announced with the name
+                    // and one arriving with the arguments are different fields
+                    // of one call, and dropping either fails replay.
+                    const incomingExtra =
+                      isPlainRecord(prevExtra) && isPlainRecord(call.extra_content)
+                        ? { ...prevExtra, ...call.extra_content }
+                        : call.extra_content;
                     if (
-                      call.extra_content !== undefined &&
-                      JSON.stringify(call.extra_content) !==
-                        JSON.stringify(prevExtra)
+                      incomingExtra !== undefined &&
+                      JSON.stringify(incomingExtra) !== JSON.stringify(prevExtra)
                     ) {
                       // Gemini puts the thought signature on the call, and
                       // the next turn is rejected without it.
@@ -7014,26 +7341,100 @@ export function createOpenAIStreamAdapter(
                       ...(stablePartId
                         ? { toolCallId: stablePartId, _has_stable_id: true }
                         : {}),
-                      toolName: nextName,
-                      argsText: merged,
+                      toolName: isSplit ? prevName || nextName : nextName,
+                      argsText: slotText,
                       args: parsedArgs,
-                      ...(call.extra_content !== undefined
-                        ? { extra_content: call.extra_content }
+                      ...(incomingExtra !== undefined && !isSplit
+                        ? { extra_content: incomingExtra }
                         : prevExtra !== undefined
                           ? { extra_content: prevExtra }
                           : {}),
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
+                      // Any arguments field, empty string included, means the
+                      // call has started: a tool that takes no parameters
+                      // sends exactly that, and the card has to survive the
+                      // turn boundary sweep.
+                      _announced_only:
+                        (existing as PositionedToolCallPart)._announced_only ===
+                          true && call.function?.arguments === undefined,
+                      // Cleared the moment the slot accumulates anything: a
+                      // name that turned out to carry its own arguments was
+                      // never a resend.
+                      _resend_suspect:
+                        (existing as PositionedToolCallPart)._resend_suspect ===
+                          true && !slotText,
                     };
                     toolCallParts[existingIndex] = updated;
+                    // A fork whose object is still open answers to its late id
+                    // from here on, so it stays held back under that one.
+                    if (stablePartId && openTailIds.delete(existing.toolCallId)) {
+                      openTailIds.add(stablePartId);
+                    }
+                    if (isSplit) {
+                      // The slot keeps one segment rather than the whole string
+                      // it accumulated, so the resumable scan no longer
+                      // describes what it was reading.
+                      boundaryScans.delete(existing.toolCallId);
+                      boundaryScans.delete(updated.toolCallId);
+                      // Appended, not inserted beside the slot, so a call the
+                      // stream opened third reads third whichever index it
+                      // reused. Where the branch below puts one, too.
+                      const born = bornSplitToolCalls(
+                        segments.slice(1),
+                        nextName,
+                        idx,
+                        incomingExtra,
+                      );
+                      // The last one is the object still being written, if one
+                      // is: kept so later fragments have somewhere to go, and
+                      // dropped at the end of the turn if it never closed.
+                      if (splitTailIsOpen && born.length > 0) {
+                        openTailIds.add(born[born.length - 1].toolCallId);
+                      }
+                      toolCallParts.push(...born);
+                      // New calls are state, so they never wait on the gate.
+                      addedToolCall = true;
+                    }
                   } else {
                     const callId =
                       stablePartId ||
-                      `tool_call_${idx ?? toolCallParts.length}`;
+                      mintStreamedCardId(idx ?? toolCallParts.length);
+                    if (!stablePartId) paintStreamedCard(callId);
 
                     if (!codexRoundToolCallIds.includes(callId)) {
                       codexRoundToolCallIds.push(callId);
                     }
-                    const argsText = argsFragment;
+                    // A slot can arrive already holding several calls in one
+                    // fragment: vLLM bundles them into a single delta when the
+                    // model writes them in one pass. Same boundary as above.
+                    const freshSplit = stablePartId
+                      ? { complete: [], tail: "" }
+                      : splitTopLevelJsonObjects(argsFragment);
+                    const freshTailIsOpen = freshSplit.tail.length > 0;
+                    const freshSegments = freshTailIsOpen
+                      ? [...freshSplit.complete, freshSplit.tail]
+                      : freshSplit.complete;
+                    const freshIsSplit = freshSegments.length > 1;
+                    const nameFragment = call.function?.name ?? "";
+                    const heldName = matched?.toolName ?? "";
+                    // An id-less provider reusing the index for another call
+                    // to the same tool can leave the repeated name out, the
+                    // first delta having given it. A blank name is no tool at
+                    // all, and the card would name nothing the backend runs.
+                    const freshName = nameFragment || heldName;
+                    // When this delta opened several calls the metadata it
+                    // carried belongs to the call it closes, which is the last
+                    // one. _fork_glued_arguments divides them the same way, and
+                    // a misplaced signature fails replay.
+                    const freshOwnExtra = freshIsSplit
+                      ? undefined
+                      : call.extra_content;
+                    const bornExtra = freshIsSplit
+                      ? call.extra_content
+                      : undefined;
+                    const argsText = freshIsSplit
+                      ? freshSegments[0]
+                      : argsFragment;
                     let parsedArgs: ToolCallMessagePart["args"] = {};
                     if (argsText) {
                       try {
@@ -7049,19 +7450,66 @@ export function createOpenAIStreamAdapter(
                     const fresh: PositionedToolCallPart = {
                       type: "tool-call" as const,
                       toolCallId: callId,
-                      toolName: call.function?.name ?? "",
+                      toolName: freshName,
                       argsText,
                       args: parsedArgs,
                       textCursor: cumulativeText.length,
-                      ...(call.extra_content !== undefined
-                        ? { extra_content: call.extra_content }
+                      ...(freshOwnExtra !== undefined
+                        ? { extra_content: freshOwnExtra }
                         : {}),
                       ...(stablePartId ? { _has_stable_id: true } : {}),
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
+                      ...(call.function?.arguments === undefined && freshName
+                        ? { _announced_only: true }
+                        : {}),
+                      // Whether this card is a fork's guess or a slot the
+                      // provider opened itself. An announcement the provider
+                      // opened is a call it means to make, most likely to a
+                      // tool that takes no parameters; one a fork invented has
+                      // no such standing, and if nothing fills it there is
+                      // nothing to run.
+                      ...(matched ? { _from_fork: true } : {}),
+                      // A name that extends the name of the call this fork
+                      // just left behind is most likely that call's, resent.
+                      // It still opens a card, because a catalog holding both
+                      // "web" and "web_search" makes the prefix no proof
+                      // either way, but the card gives way rather than gluing
+                      // if another name brings the object: "alpha_long" then
+                      // "beta" was shown as "alpha_longbeta", which matches no
+                      // tool, and is dropped if nothing ever fills it.
+                      ...(freshName &&
+                      heldName &&
+                      freshName !== heldName &&
+                      freshName.startsWith(heldName)
+                        ? { _resend_suspect: true }
+                        : {}),
                     };
-                    toolCallParts.push(fresh);
+                    const born = freshIsSplit
+                      ? bornSplitToolCalls(
+                          freshSegments.slice(1),
+                          freshName,
+                          idx,
+                          bornExtra,
+                        )
+                      : [];
+                    // As above: the fork whose object is still open is held
+                    // only for the rest of the turn.
+                    if (freshTailIsOpen && born.length > 0) {
+                      openTailIds.add(born[born.length - 1].toolCallId);
+                    }
+                    toolCallParts.push(fresh, ...born);
                     addedToolCall = true;
                   }
+                }
+                // After this chunk's deltas, not before them: a provider can
+                // put finish_reason on the same chunk as the turn's last
+                // name-only delta, and closing the turn first would let that
+                // call cross into the next one.
+                if (chunk.choices?.[0]?.finish_reason) {
+                  // Ending the turn drops a call announced but never opened
+                  // and a fork whose object never closed, so the publish below
+                  // has to see it rather than wait for the pacing gate.
+                  replayStateChanged ||= endProviderTurn();
                 }
                 if (
                   addedToolCall ||
@@ -7081,6 +7529,9 @@ export function createOpenAIStreamAdapter(
                   };
                 }
                 continue;
+              }
+              if (chunk.choices?.[0]?.finish_reason) {
+                replayStateChanged ||= endProviderTurn();
               }
               // extra_content can arrive with no content at all: a Gemini
               // thoughtSignature fragment, or the codex reasoning ledger on a

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5435,6 +5435,7 @@ export function createOpenAIStreamAdapter(
         boundaryScans.delete(partId);
         openTailIds.delete(partId);
         liveArgsTextById.delete(partId);
+        pendingExtraByPartId.delete(partId);
       };
       // The backend reserves provider ids before it mints; the client can
       // only move a card aside once the claim lands.
@@ -5448,6 +5449,12 @@ export function createOpenAIStreamAdapter(
         const live = liveArgsTextById.get(from);
         if (live !== undefined) liveArgsTextById.set(to, live);
         liveArgsTextById.delete(from);
+        // Metadata parked on this card is claimed at the turn boundary by the
+        // part id the card holds then, so it has to travel with the rename or
+        // the sweep looks for a part id nothing answers to and drops it.
+        const pending = pendingExtraByPartId.get(from);
+        if (pending) pendingExtraByPartId.set(to, pending);
+        pendingExtraByPartId.delete(from);
         const at = codexRoundToolCallIds.indexOf(from);
         if (at !== -1) codexRoundToolCallIds[at] = to;
         paintStreamedCard(to);
@@ -5473,6 +5480,7 @@ export function createOpenAIStreamAdapter(
           scan: boundaryScans.get(part.toolCallId),
           live: liveArgsTextById.get(part.toolCallId),
           openTail: openTailIds.has(part.toolCallId),
+          pending: pendingExtraByPartId.get(part.toolCallId),
         }));
         for (const held of carried) {
           reservedToolCallIds.delete(held.from);
@@ -5480,6 +5488,7 @@ export function createOpenAIStreamAdapter(
           boundaryScans.delete(held.from);
           liveArgsTextById.delete(held.from);
           openTailIds.delete(held.from);
+          pendingExtraByPartId.delete(held.from);
           // Cleared before any of them is minted again: the mint reads the ids
           // the parts are holding, and a stale one makes the first card skip
           // the number the backend gives it.
@@ -5495,6 +5504,7 @@ export function createOpenAIStreamAdapter(
           if (held.scan) boundaryScans.set(to, held.scan);
           if (held.live !== undefined) liveArgsTextById.set(to, held.live);
           if (held.openTail) openTailIds.add(to);
+          if (held.pending) pendingExtraByPartId.set(to, held.pending);
           const at = codexRoundToolCallIds.indexOf(held.from);
           if (at !== -1) codexRoundToolCallIds[at] = to;
           const index = toolCallParts.findIndex((part) => part.toolCallId === "");

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5288,15 +5288,13 @@ export function createOpenAIStreamAdapter(
       };
       // Tool call parts, cumulative; result lands on tool_end.
       const toolCallParts: PositionedToolCallPart[] = [];
-      // An id for a call the stream gave none (issue #9807). Counted, so a
-      // rerun of the same stream reads the same way in a log.
-      // A card is minted before its part joins `toolCallParts`, so without
-      // this a batch opening three calls mints one id three times.
+      // Ids for calls the stream gave none (issue #9807). A card is minted
+      // before its part joins `toolCallParts`, so without this a batch opening
+      // three calls mints one id three times.
       const reservedToolCallIds = new Set<string>();
-      // Of those, the ones the provider itself sent. A minted card holds its
-      // id only until the provider claims that spelling; `_has_stable_id` does
-      // not say which is which, since a split marks every card but the last
-      // with it to keep a late id off the calls already spoken for.
+      // Of those, the ones the provider sent. `_has_stable_id` cannot say which:
+      // a split marks every card but the last with it, to keep a late id off the
+      // calls already spoken for.
       const providerSentToolCallIds = new Set<string>();
       const boundaryScans = new Map<
         string,
@@ -5305,13 +5303,12 @@ export function createOpenAIStreamAdapter(
       const isPlainRecord = (v: unknown): v is Record<string, unknown> =>
         typeof v === "object" && v !== null && !Array.isArray(v);
       // Forks whose last object never closed, the backend's open_tail_keys.
-      // `{"a":1}{` is not marked truncated, so the lone brace would persist as
-      // a card nothing completes. Kept while the turn runs, to be written to.
+      // `{"a":1}{` is not marked truncated, so the lone brace would persist as a
+      // card nothing completes.
       const openTailIds = new Set<string>();
-      // Metadata from a delta whose name repeated the one a closed card holds.
-      // That name is either the call's, resent, or the next call to the same
-      // tool announcing itself, and only the object that follows tells them
-      // apart, so it waits here rather than landing on the wrong call.
+      // Metadata from a delta repeating a closed card's name. That name is
+      // either that call's, resent, or the next call to the same tool announcing
+      // itself, and only the object that follows tells them apart.
       const pendingExtraByPartId = new Map<string, Record<string, unknown>>();
       const endProviderTurn = (): boolean => {
         let changed = false;
@@ -5327,9 +5324,9 @@ export function createOpenAIStreamAdapter(
           releaseStreamedCard(part.toolCallId);
           changed = true;
         }
-        // An announcement another call took over, and a name that only looked
-        // like the closed call's resent, were never calls. A lone announcement
-        // the provider opened stays: a zero-parameter tool looks like that.
+        // An announcement another call took over, and a name that only looked like
+        // a resent, were never calls. A lone announcement stays: a zero-parameter
+        // tool looks like that.
         for (let at = toolCallParts.length - 1; at >= 0; at -= 1) {
           const part = toolCallParts[at] as PositionedToolCallPart;
           if (
@@ -5354,10 +5351,9 @@ export function createOpenAIStreamAdapter(
           releaseStreamedCard(part.toolCallId);
           changed = true;
         }
-        // A call needs a name to run: _normalized_call drops a nameless one
-        // before it reserves a card id, so a card kept here holds a number the
-        // backend hands to the next round's call, and its events land on this
-        // blank card instead.
+        // _normalized_call drops a nameless call before reserving a card id, so a
+        // card kept here holds a number the backend gives the next round, whose
+        // events then land on this blank card.
         for (let at = toolCallParts.length - 1; at >= 0; at -= 1) {
           const part = toolCallParts[at] as PositionedToolCallPart;
           if (part.toolName || part._delta_index === undefined) continue;
@@ -5381,11 +5377,9 @@ export function createOpenAIStreamAdapter(
           changed = true;
         }
         pendingExtraByPartId.clear();
-        // Numbering is the backend's pass, and it runs over the calls that
-        // survive: a card dropped above leaves a gap, and a claim displaced one
-        // for a call that turned out not to be one at all. Both are settled
-        // here, where the backend settles them, rather than left a number apart
-        // for the rest of the response.
+        // The backend numbers the calls that survive: a card dropped above leaves
+        // a gap, and a claim displaced one for what turned out not to be a call.
+        // Both are settled here, where the backend settles them.
         if (changed) renumberMintedCards();
         openTailIds.clear();
         // The next round opens at index 0 again, and without this "B" then
@@ -5422,10 +5416,9 @@ export function createOpenAIStreamAdapter(
       const releaseStreamedCard = (partId: string): void => {
         reservedToolCallIds.delete(partId);
         toolPartIdByBackendId.delete(partId);
-        // A card that took a late provider id answers to a run-unique part id,
-        // so the id the provider sent is a separate key pointing at it. Left
-        // behind, that reservation makes the next round's mint skip a number
-        // the backend, which never reserved it for a call it filtered, reuses.
+        // A card that took a late id answers to a run-unique part id, so the id
+        // the provider sent is a separate key pointing at it. Left behind, it makes
+        // the next round's mint skip a number the backend reuses.
         for (const [backendId, mapped] of [...toolPartIdByBackendId]) {
           if (mapped !== partId) continue;
           toolPartIdByBackendId.delete(backendId);
@@ -5449,9 +5442,8 @@ export function createOpenAIStreamAdapter(
         const live = liveArgsTextById.get(from);
         if (live !== undefined) liveArgsTextById.set(to, live);
         liveArgsTextById.delete(from);
-        // Metadata parked on this card is claimed at the turn boundary by the
-        // part id the card holds then, so it has to travel with the rename or
-        // the sweep looks for a part id nothing answers to and drops it.
+        // The turn-end sweep claims parked metadata by the part id the card holds
+        // then, so it has to travel with the rename or the sweep finds nothing.
         const pending = pendingExtraByPartId.get(from);
         if (pending) pendingExtraByPartId.set(to, pending);
         pendingExtraByPartId.delete(from);
@@ -5459,19 +5451,16 @@ export function createOpenAIStreamAdapter(
         if (at !== -1) codexRoundToolCallIds[at] = to;
         paintStreamedCard(to);
       };
-      // The backend reserves every id the provider sent before it mints any
-      // card id, so a claim arriving mid-response moves every card the client
-      // had already numbered. Renumber them all, in the order the backend
-      // walks them, or its tool_start reaches the wrong card: with three calls
-      // in one delta and a later `tool_call_1`, the two sides read the second
-      // and third calls' results off each other's cards.
+      // The backend reserves provider ids before minting any card id, so a claim
+      // mid-response moves every card already numbered. Renumber in the order the
+      // backend walks them, or tool_start reaches the wrong card: three calls in
+      // one delta and a later `tool_call_1` cross-wire the second and third.
       const renumberMintedCards = (claimed?: string): void => {
         const minted = toolCallParts.filter(
           (part) =>
             !providerSentToolCallIds.has(part.toolCallId) &&
-            // This round's cards only. An earlier round's are complete, may
-            // already carry a result, and the backend's card ledger is
-            // append-only: it never renumbers one, so neither may this.
+            // This round's cards only. Earlier ones may carry a result, and the
+            // backend's ledger is append-only: it never renumbers, so neither may this.
             (part as PositionedToolCallPart)._delta_index !== undefined,
         ) as PositionedToolCallPart[];
         const carried = minted.map((part) => ({
@@ -5489,9 +5478,8 @@ export function createOpenAIStreamAdapter(
           liveArgsTextById.delete(held.from);
           openTailIds.delete(held.from);
           pendingExtraByPartId.delete(held.from);
-          // Cleared before any of them is minted again: the mint reads the ids
-          // the parts are holding, and a stale one makes the first card skip
-          // the number the backend gives it.
+          // Cleared before any is minted again: the mint reads the ids the parts
+          // hold, and a stale one makes the first card skip the backend's number.
           const at = toolCallParts.indexOf(held.part);
           if (at !== -1) toolCallParts[at] = { ...held.part, toolCallId: "" };
         }
@@ -6619,10 +6607,9 @@ export function createOpenAIStreamAdapter(
                 chunk as unknown as { _toolEvent?: Record<string, unknown> }
               )._toolEvent;
               if (toolEvent !== undefined) {
-                // Unsloth's own tool events end the turn that asked for them;
-                // finish_reason alone is not enough. A hosted tool runs INSIDE
-                // the turn and rides a whole chunk, `choices` and all, where
-                // Unsloth's are bare {"type": "tool_start"} frames.
+                // Unsloth's own tool events end the turn that asked for them; finish_reason
+                // alone is not enough. A hosted tool runs INSIDE the turn and rides a whole
+                // chunk, where Unsloth's are bare {"type": "tool_start"} frames.
                 if (!chunk.choices) {
                   endProviderTurn();
                 }
@@ -7250,9 +7237,8 @@ export function createOpenAIStreamAdapter(
                     !providerSentToolCallIds.has(stableId) &&
                     toolCallParts.some((part) => part.toolCallId === stableId)
                   ) {
-                    // Renumber first: the claimed spelling is held by a minted
-                    // card until this runs, and marking it provider-sent any
-                    // earlier would exempt that very card from the move.
+                    // Renumber first: a minted card holds the claimed spelling until this runs,
+                    // and marking it provider-sent earlier would exempt it from the move.
                     renumberMintedCards(stableId);
                     providerSentToolCallIds.add(stableId);
                     reservedToolCallIds.add(stableId);
@@ -7279,9 +7265,8 @@ export function createOpenAIStreamAdapter(
                     existingIndex === -1
                       ? undefined
                       : toolCallParts[existingIndex];
-                  // A closed object takes no more content, so a name or
-                  // arguments reaching it open the next call. Splitting the
-                  // text alone is too late for a name or an id.
+                  // A closed object takes no more content, so a name or arguments reaching it
+                  // open the next call. Splitting the text alone is too late.
                   const slotIsClosed = (() => {
                     if (!matched?.argsText) return false;
                     const held = scanArgsText(

--- a/studio/frontend/src/features/chat/tool-call-arguments.ts
+++ b/studio/frontend/src/features/chat/tool-call-arguments.ts
@@ -15,10 +15,10 @@ function isSingleJsonObject(text: string): boolean {
  * One slot's accumulated argument text, cut into the top-level JSON objects it
  * holds: `complete` closed, `tail` is still being written.
  *
- * A second top-level `{` means the stream reused the slot for a second parallel
+ * A second top-level `{` means the stream reused the slot for another parallel
  * call, which is what turns two calls into `{"url":"a"}{"url":"b"}`. Text that
- * is not a run of whole objects comes back whole in `tail`, so a stream this
- * was never meant for is left alone.
+ * is not a run of whole objects comes back whole in `tail`, leaving streams
+ * this was never meant for alone.
  */
 export function splitTopLevelJsonObjects(text: string): {
   complete: string[];
@@ -78,12 +78,11 @@ export function splitTopLevelJsonObjects(text: string): {
 }
 
 /**
- * `splitTopLevelJsonObjects` over a string that only ever grows.
- *
- * Rescanning per fragment is O(N^2), and a 20 KB argument sent a character at a
- * time took about a second and a half on the thread that paints the stream.
- * `feed` takes the same string extended, never a rewritten one, so a caller
- * that splits a slot drops its scan.
+ * `splitTopLevelJsonObjects` over a string that only ever grows. Rescanning per
+ * fragment is O(N^2): a 20 KB argument sent a character at a time took about a
+ * second and a half on the thread that paints the stream. `feed` takes the same
+ * string extended, never a rewritten one, so a caller that splits a slot drops
+ * its scan.
  */
 export function createBoundaryScan(): {
   feed: (text: string) => { complete: string[]; tail: string };
@@ -166,7 +165,7 @@ export function toolCallReplayArguments(
     typeof argsText === "string" &&
     argsText.length > 0 &&
     // One object, because that is what `function.arguments` is. A run of them,
-    // an array, a scalar or a half-written object all get the whole request
+    // an array, a scalar or a half-written object gets the whole request
     // rejected, not just the one call.
     isSingleJsonObject(argsText)
   ) {
@@ -179,25 +178,20 @@ export function toolCallReplayArguments(
   }
   const parsed = JSON.parse(serialized) as Record<string, unknown>;
   const keys = Object.keys(parsed);
-  // The adapter writes `{ _raw }` holding the exact text it could not parse, so
-  // a lone `_raw` whose value IS that text is the marker and replaying it would
-  // send a parameter no tool declares. `_raw` is not reserved, though, and an
-  // MCP server's schema is its own, so a tool that really takes one keeps it.
-  //
-  // Only when the surviving text proves it. A thread stored before `argsText`
-  // was kept carries the marker with nothing to compare it to, and guessing
-  // from the shape of the value -- a run of whole JSON objects -- would also
-  // discard the argument of a tool that really takes one, since a leading
-  // underscore is a legal property name and MCP reserves nothing. Guessing
-  // buys little either way: the wrapped form is one JSON object, so replaying
-  // it does not raise the `Extra data` this file exists to prevent.
+  // The adapter writes `{ _raw }` holding the exact text it could not parse,
+  // so a lone `_raw` whose value IS that text is the marker, and replaying it
+  // would send a parameter no tool declares. `_raw` is not reserved and an
+  // MCP server's schema is its own, so recognise it only when the surviving
+  // text proves it: a thread stored before `argsText` was kept has nothing to
+  // compare against, and guessing from the value's shape would discard the
+  // argument of a tool that really takes one. Guessing buys little anyway,
+  // since the wrapped form is one JSON object and raises no `Extra data`.
   if (
     keys.length === 1 &&
     keys[0] === "_raw" &&
     typeof parsed._raw === "string" &&
     // Non-empty, or the equality proves nothing: the adapter only writes the
-    // marker for text it tried to parse, so `{ _raw: "" }` is an argument a
-    // tool was really given rather than anything this file produced.
+    // marker for parsed text, so `{ _raw: "" }` is a real argument.
     parsed._raw.length > 0 &&
     parsed._raw === argsText
   ) {

--- a/studio/frontend/src/features/chat/tool-call-arguments.ts
+++ b/studio/frontend/src/features/chat/tool-call-arguments.ts
@@ -12,17 +12,13 @@ function isSingleJsonObject(text: string): boolean {
 }
 
 /**
- * One streaming slot's accumulated argument text, cut into the top-level JSON
- * objects it holds: `complete` are the ones that closed, `tail` is the one
- * still being written.
+ * One slot's accumulated argument text, cut into the top-level JSON objects it
+ * holds: `complete` closed, `tail` is still being written.
  *
- * A call's `function.arguments` is one JSON object, so a second top-level `{`
- * means the stream reused this slot for a second parallel call, which is what
- * turns two calls into the unparsable `{"url":"a"}{"url":"b"}`.
- *
- * Text that is not a run of whole objects (top-level array or scalar, trailing
- * junk, an unbalanced brace) comes back whole in `tail` with `complete` empty,
- * so a stream this was never meant for is left alone.
+ * A second top-level `{` means the stream reused the slot for a second parallel
+ * call, which is what turns two calls into `{"url":"a"}{"url":"b"}`. Text that
+ * is not a run of whole objects comes back whole in `tail`, so a stream this
+ * was never meant for is left alone.
  */
 export function splitTopLevelJsonObjects(text: string): {
   complete: string[];
@@ -38,16 +34,14 @@ export function splitTopLevelJsonObjects(text: string): {
   for (let i = 0; i < text.length; i += 1) {
     const ch = text[i];
     if (inString) {
-      // A backslash escapes one character, so a run of them toggles rather
-      // than accumulates and `\\"` really does end the string.
+      // A backslash escapes one character, so a run of them toggles.
       if (escaped) escaped = false;
       else if (ch === "\\") escaped = true;
       else if (ch === '"') inString = false;
       continue;
     }
     if (depth === 0) {
-      // Between objects only whitespace, "\r\n" as readily as "\n". Anything
-      // else, a quote included, means this is not a run of objects at all.
+      // Between objects only whitespace, "\r\n" as readily as "\n".
       if (ch === "{") {
         depth = 1;
         start = i;
@@ -68,8 +62,7 @@ export function splitTopLevelJsonObjects(text: string): {
         try {
           JSON.parse(segment);
         } catch {
-          // Balanced but invalid, so the brace count was a coincidence and
-          // cutting here would invent a call the model never made.
+          // Balanced but invalid: cutting here would invent a call.
           return unsplit;
         }
         complete.push(segment);
@@ -87,15 +80,10 @@ export function splitTopLevelJsonObjects(text: string): {
 /**
  * `splitTopLevelJsonObjects` over a string that only ever grows.
  *
- * One call's arguments arrive as many small fragments, and rescanning the whole
- * accumulation per fragment makes streaming one argument of length N cost
- * O(N^2): a 20 KB argument delivered a character at a time took about a second
- * and a half on the thread that also paints the stream. The scan resumes where
- * it stopped instead, so the same argument costs one pass in total.
- *
- * `feed` must be given the same string extended, never a rewritten one. A split
- * rewrites a slot's `argsText`, so the caller drops the scan for the parts it
- * touches and lets the next fragment start a fresh one.
+ * Rescanning per fragment is O(N^2), and a 20 KB argument sent a character at a
+ * time took about a second and a half on the thread that paints the stream.
+ * `feed` takes the same string extended, never a rewritten one, so a caller
+ * that splits a slot drops its scan.
  */
 export function createBoundaryScan(): {
   feed: (text: string) => { complete: string[]; tail: string };
@@ -105,8 +93,7 @@ export function createBoundaryScan(): {
   let inString = false;
   let escaped = false;
   let scanned = 0;
-  // Junk at depth 0 or a segment that does not parse makes the whole string
-  // unsplittable, and appending to it can never make it splittable again.
+  // Once unsplittable, appending can never make it splittable again.
   let unsplittable = false;
   const complete: string[] = [];
 
@@ -168,9 +155,8 @@ export function createBoundaryScan(): {
  * in the thread, and strict chat templates reject the whole request rather than
  * one call, so it falls back to the structured args the part already carries.
  *
- * `{ _raw }` is the adapter's own marker for text it could not parse, not a
- * parameter any tool declares, so threads stored before arguments were split
- * per call replay as `{}` rather than as a blob.
+ * `{ _raw }` is the adapter's marker for text it could not parse, so a thread
+ * carrying one replays as `{}` rather than as the blob.
  */
 export function toolCallReplayArguments(
   argsText: string | undefined,

--- a/studio/frontend/src/features/chat/tool-call-arguments.ts
+++ b/studio/frontend/src/features/chat/tool-call-arguments.ts
@@ -1,6 +1,165 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+/** `true` when `text` is exactly one JSON object and nothing else. */
+function isSingleJsonObject(text: string): boolean {
+  try {
+    const value = JSON.parse(text);
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * One streaming slot's accumulated argument text, cut into the top-level JSON
+ * objects it holds: `complete` are the ones that closed, `tail` is the one
+ * still being written.
+ *
+ * A call's `function.arguments` is one JSON object, so a second top-level `{`
+ * means the stream reused this slot for a second parallel call, which is what
+ * turns two calls into the unparsable `{"url":"a"}{"url":"b"}`.
+ *
+ * Text that is not a run of whole objects (top-level array or scalar, trailing
+ * junk, an unbalanced brace) comes back whole in `tail` with `complete` empty,
+ * so a stream this was never meant for is left alone.
+ */
+export function splitTopLevelJsonObjects(text: string): {
+  complete: string[];
+  tail: string;
+} {
+  const unsplit = { complete: [] as string[], tail: text };
+  const complete: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      // A backslash escapes one character, so a run of them toggles rather
+      // than accumulates and `\\"` really does end the string.
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (depth === 0) {
+      // Between objects only whitespace, "\r\n" as readily as "\n". Anything
+      // else, a quote included, means this is not a run of objects at all.
+      if (ch === "{") {
+        depth = 1;
+        start = i;
+        continue;
+      }
+      if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") continue;
+      return unsplit;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        const segment = text.slice(start, i + 1);
+        try {
+          JSON.parse(segment);
+        } catch {
+          // Balanced but invalid, so the brace count was a coincidence and
+          // cutting here would invent a call the model never made.
+          return unsplit;
+        }
+        complete.push(segment);
+        start = -1;
+      }
+    }
+  }
+
+  return {
+    complete,
+    tail: start === -1 ? "" : text.slice(start),
+  };
+}
+
+/**
+ * `splitTopLevelJsonObjects` over a string that only ever grows.
+ *
+ * One call's arguments arrive as many small fragments, and rescanning the whole
+ * accumulation per fragment makes streaming one argument of length N cost
+ * O(N^2): a 20 KB argument delivered a character at a time took about a second
+ * and a half on the thread that also paints the stream. The scan resumes where
+ * it stopped instead, so the same argument costs one pass in total.
+ *
+ * `feed` must be given the same string extended, never a rewritten one. A split
+ * rewrites a slot's `argsText`, so the caller drops the scan for the parts it
+ * touches and lets the next fragment start a fresh one.
+ */
+export function createBoundaryScan(): {
+  feed: (text: string) => { complete: string[]; tail: string };
+} {
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  let scanned = 0;
+  // Junk at depth 0 or a segment that does not parse makes the whole string
+  // unsplittable, and appending to it can never make it splittable again.
+  let unsplittable = false;
+  const complete: string[] = [];
+
+  return {
+    feed(text: string) {
+      if (unsplittable) return { complete: [], tail: text };
+      for (let i = scanned; i < text.length; i += 1) {
+        const ch = text[i];
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === "\\") escaped = true;
+          else if (ch === '"') inString = false;
+          continue;
+        }
+        if (depth === 0) {
+          if (ch === "{") {
+            depth = 1;
+            start = i;
+            continue;
+          }
+          if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") continue;
+          unsplittable = true;
+          return { complete: [], tail: text };
+        }
+        if (ch === '"') {
+          inString = true;
+          continue;
+        }
+        if (ch === "{") depth += 1;
+        else if (ch === "}") {
+          depth -= 1;
+          if (depth === 0) {
+            const segment = text.slice(start, i + 1);
+            try {
+              JSON.parse(segment);
+            } catch {
+              unsplittable = true;
+              return { complete: [], tail: text };
+            }
+            complete.push(segment);
+            start = -1;
+          }
+        }
+      }
+      scanned = text.length;
+      return {
+        complete: [...complete],
+        tail: start === -1 ? "" : text.slice(start),
+      };
+    },
+  };
+}
+
 /**
  * The `function.arguments` string to replay for a stored tool call.
  *
@@ -8,18 +167,47 @@
  * byte-exact. Text that does not parse would be replayed on every later request
  * in the thread, and strict chat templates reject the whole request rather than
  * one call, so it falls back to the structured args the part already carries.
+ *
+ * `{ _raw }` is the adapter's own marker for text it could not parse, not a
+ * parameter any tool declares, so threads stored before arguments were split
+ * per call replay as `{}` rather than as a blob.
  */
 export function toolCallReplayArguments(
   argsText: string | undefined,
   args: unknown,
 ): string {
-  if (typeof argsText === "string" && argsText.length > 0) {
-    try {
-      JSON.parse(argsText);
-      return argsText;
-    } catch {
-      // unparsable, so the structured args below stand in for it
+  if (
+    typeof argsText === "string" &&
+    argsText.length > 0 &&
+    // One object, because that is what `function.arguments` is. A run of them,
+    // an array, a scalar or a half-written object all get the whole request
+    // rejected, not just the one call.
+    isSingleJsonObject(argsText)
+  ) {
+    return argsText;
+  }
+  const serialized = JSON.stringify(args ?? {});
+  // Not a set of named parameters, whatever else it might be.
+  if (serialized === undefined || !isSingleJsonObject(serialized)) {
+    return "{}";
+  }
+  const parsed = JSON.parse(serialized) as Record<string, unknown>;
+  const keys = Object.keys(parsed);
+  // The adapter writes `{ _raw }` holding the exact text it could not parse, so
+  // a lone `_raw` whose value IS that text is the marker and replaying it would
+  // send a parameter no tool declares. `_raw` is not reserved, though, and an
+  // MCP server's schema is its own, so a tool that really takes one keeps it.
+  //
+  // A thread stored before `argsText` was kept, and one rebuilt by the importer,
+  // carry the marker with no text to compare it to. Held text that is itself a
+  // run of whole JSON objects is the concatenation this file exists to undo, and
+  // no tool declares a parameter shaped like that, so it is the marker whether
+  // or not the argument text survived alongside it.
+  if (keys.length === 1 && keys[0] === "_raw" && typeof parsed._raw === "string") {
+    const held = parsed._raw;
+    if (held === argsText || splitTopLevelJsonObjects(held).complete.length > 1) {
+      return "{}";
     }
   }
-  return JSON.stringify(args ?? {});
+  return serialized;
 }

--- a/studio/frontend/src/features/chat/tool-call-arguments.ts
+++ b/studio/frontend/src/features/chat/tool-call-arguments.ts
@@ -195,6 +195,10 @@ export function toolCallReplayArguments(
     keys.length === 1 &&
     keys[0] === "_raw" &&
     typeof parsed._raw === "string" &&
+    // Non-empty, or the equality proves nothing: the adapter only writes the
+    // marker for text it tried to parse, so `{ _raw: "" }` is an argument a
+    // tool was really given rather than anything this file produced.
+    parsed._raw.length > 0 &&
     parsed._raw === argsText
   ) {
     return "{}";

--- a/studio/frontend/src/features/chat/tool-call-arguments.ts
+++ b/studio/frontend/src/features/chat/tool-call-arguments.ts
@@ -198,16 +198,20 @@ export function toolCallReplayArguments(
   // send a parameter no tool declares. `_raw` is not reserved, though, and an
   // MCP server's schema is its own, so a tool that really takes one keeps it.
   //
-  // A thread stored before `argsText` was kept, and one rebuilt by the importer,
-  // carry the marker with no text to compare it to. Held text that is itself a
-  // run of whole JSON objects is the concatenation this file exists to undo, and
-  // no tool declares a parameter shaped like that, so it is the marker whether
-  // or not the argument text survived alongside it.
-  if (keys.length === 1 && keys[0] === "_raw" && typeof parsed._raw === "string") {
-    const held = parsed._raw;
-    if (held === argsText || splitTopLevelJsonObjects(held).complete.length > 1) {
-      return "{}";
-    }
+  // Only when the surviving text proves it. A thread stored before `argsText`
+  // was kept carries the marker with nothing to compare it to, and guessing
+  // from the shape of the value -- a run of whole JSON objects -- would also
+  // discard the argument of a tool that really takes one, since a leading
+  // underscore is a legal property name and MCP reserves nothing. Guessing
+  // buys little either way: the wrapped form is one JSON object, so replaying
+  // it does not raise the `Extra data` this file exists to prevent.
+  if (
+    keys.length === 1 &&
+    keys[0] === "_raw" &&
+    typeof parsed._raw === "string" &&
+    parsed._raw === argsText
+  ) {
+    return "{}";
   }
   return serialized;
 }

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -24,6 +24,48 @@ export interface StreamedToolCallPart {
 }
 
 /**
+ * The id for a card drawn from a delta the provider gave no id to.
+ *
+ * The slot's own `tool_call_<index>` when that is free, then the lowest
+ * `tool_call_<n>` that is not. `_mint_streamed_card_id` in the backend loop
+ * walks the same deltas in the same order under the same rule, so it lands on
+ * the same spelling and its `tool_start` and `tool_end` reach the card this
+ * stream already drew rather than opening a second one beside it.
+ *
+ * `reserved` holds the ids the provider itself sent, so a provider that spells
+ * one `tool_call_0` keeps it. No colon, because a replayed id has to satisfy
+ * `^[a-zA-Z0-9_-]+$`.
+ */
+export function mintStreamedToolCallId(
+  parts: StreamedToolCallPart[],
+  deltaIndex: number | undefined,
+  reserved: Set<string>,
+): string {
+  const isTaken = (candidate: string) =>
+    reserved.has(candidate) || parts.some((part) => part.toolCallId === candidate);
+  const preferred = deltaIndex === undefined ? "" : `tool_call_${deltaIndex}`;
+  if (preferred && !isTaken(preferred)) return preferred;
+  let position = 0;
+  while (isTaken(`tool_call_${position}`)) position += 1;
+  return `tool_call_${position}`;
+}
+
+/**
+ * Let a card drawn by the deltas answer to its own id.
+ *
+ * Without this `resolveToolCallPartId` mints `<backend id>:<uuid>` the first
+ * time the backend names an id-less call, `tool_start` finds no card under
+ * that and pushes one, and the turn ends holding two cards and persisting two
+ * tool-call parts for every call the stream drew.
+ */
+export function bindStreamedToolCallCard(
+  ids: Map<string, string>,
+  partId: string,
+): void {
+  if (!ids.has(partId)) ids.set(partId, partId);
+}
+
+/**
  * Newest part holding `deltaIndex`, or -1. `unownedOnly` restricts the match to
  * a slot no provider id has claimed yet.
  */

--- a/studio/frontend/src/features/chat/tool-call-id.ts
+++ b/studio/frontend/src/features/chat/tool-call-id.ts
@@ -24,17 +24,12 @@ export interface StreamedToolCallPart {
 }
 
 /**
- * The id for a card drawn from a delta the provider gave no id to.
- *
- * The slot's own `tool_call_<index>` when that is free, then the lowest
- * `tool_call_<n>` that is not. `_mint_streamed_card_id` in the backend loop
- * walks the same deltas in the same order under the same rule, so it lands on
- * the same spelling and its `tool_start` and `tool_end` reach the card this
- * stream already drew rather than opening a second one beside it.
- *
- * `reserved` holds the ids the provider itself sent, so a provider that spells
- * one `tool_call_0` keeps it. No colon, because a replayed id has to satisfy
- * `^[a-zA-Z0-9_-]+$`.
+ * The id for a card drawn from a delta the provider gave no id to: the slot's
+ * own `tool_call_<index>` when free, else the lowest `tool_call_<n>` that is.
+ * The backend's `_mint_streamed_card_id` walks the same deltas under the same
+ * rule, so its `tool_start` reaches this card instead of opening a second one.
+ * `reserved` holds ids the provider sent, so one spelled `tool_call_0` keeps
+ * it. No colon: a replayed id must satisfy `^[a-zA-Z0-9_-]+$`.
  */
 export function mintStreamedToolCallId(
   parts: StreamedToolCallPart[],
@@ -51,12 +46,10 @@ export function mintStreamedToolCallId(
 }
 
 /**
- * Let a card drawn by the deltas answer to its own id.
- *
- * Without this `resolveToolCallPartId` mints `<backend id>:<uuid>` the first
- * time the backend names an id-less call, `tool_start` finds no card under
- * that and pushes one, and the turn ends holding two cards and persisting two
- * tool-call parts for every call the stream drew.
+ * Let a card drawn by the deltas answer to its own id. Without it,
+ * `resolveToolCallPartId` mints `<backend id>:<uuid>` when the backend first
+ * names an id-less call, `tool_start` finds no card and pushes one, and the
+ * turn persists two parts per call.
  */
 export function bindStreamedToolCallCard(
   ids: Map<string, string>,

--- a/studio/frontend/tests/chat-adapter-scan-cost.test.ts
+++ b/studio/frontend/tests/chat-adapter-scan-cost.test.ts
@@ -452,7 +452,7 @@ const FLAG_NEXT_TO_APPEND =
   /streamedChars \+= reasoning\.length \+ delta\.length;\s*producedReplyText = true;/;
 
 /** The adapter between two anchors, without its comments. */
-function regionOf(from: string, to: string, maxChars = 60_000): string {
+function regionOf(from: string, to: string, maxChars = 75_000): string {
   const start = ADAPTER.indexOf(from);
   assert.notEqual(start, -1, `"${from}" is gone; this test needs rewriting`);
   const end = ADAPTER.indexOf(to, start);

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -267,14 +267,16 @@ function withoutComments(source: string): string {
 }
 
 /** The adapter between two anchors, without its comments. */
-function regionOf(from: string, to: string, maxChars = 60_000): string {
+function regionOf(from: string, to: string, maxChars = 75_000): string {
   const start = ADAPTER.indexOf(from);
   assert.notEqual(start, -1, `"${from}" is gone; this test needs rewriting`);
   const end = ADAPTER.indexOf(to, start);
   assert.notEqual(end, -1, `"${to}" is gone; this test needs rewriting`);
   // Without this, editing the end anchor's line (even adding a space) silently
   // slides the region to the next match hundreds of lines away, and the
-  // ordering assertions below go on passing against the wrong slice.
+  // ordering assertions below go on passing against the wrong slice. A ceiling
+  // on drift, not a budget: raise it when the loop legitimately grows, after
+  // checking the anchors still land where they should.
   assert.ok(
     end - start < maxChars,
     `the region from "${from}" to "${to}" is ${end - start} chars; ` +
@@ -642,8 +644,12 @@ test("a per-call thought signature forces a publish", () => {
     window.includes("replayStateChanged = true"),
     "a changed per-call extra_content does not force a publish",
   );
+  // Read off `incomingExtra`, which merges what the delta carried into what
+  // the card already held rather than replacing it: a signature announced with
+  // the name and metadata arriving with the arguments are different fields of
+  // one call, and dropping either gets the replayed turn rejected.
   assert.ok(
-    window.includes("call.extra_content !== undefined"),
+    window.includes("incomingExtra !== undefined"),
     "the latch fires on calls that carry no extra_content at all",
   );
 

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -639,7 +639,10 @@ test("a per-call thought signature forces a publish", () => {
   // cannot be replayed.
   const update = source.indexOf("const prevExtra =");
   assert.notEqual(update, -1, "the existing-call update path is gone");
-  const window = source.slice(update, update + 700);
+  // Wide enough for the parking branch that now sits between the anchor and
+  // the latch: the ambiguous metadata of a repeated name waits rather than
+  // landing on the closed call.
+  const window = source.slice(update, update + 1400);
   assert.ok(
     window.includes("replayStateChanged = true"),
     "a changed per-call extra_content does not force a publish",

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -180,7 +180,7 @@ function liftSplitHelpers(): string {
   const lifted = liftBetween(
     "split helpers",
     "// Ids already spoken for this response",
-    "// Raw tool_args accumulator per card",
+    "// Backend tool ids (\"call_0\", ...) restart every response",
   );
   assert.ok(
     lifted.includes("bornSplitToolCalls"),
@@ -1033,6 +1033,72 @@ test("a name bringing an object over an announcement is the next call", () => {
   }
 });
 
+test("a dropped card gives its id back to the next round", () => {
+  // The backend filters the unfinished fork out of `calls` and never reserves
+  // its card id, so holding it here made the next round mint tool_call_2 while
+  // the backend addressed tool_call_1, and the tool_start drew a second card
+  // beside the one the deltas had already painted.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}{' } }]);
+  stream.feed([], true);
+  stream.feed([{ index: 0, function: { name: "beta", arguments: '{"b":2}' } }]);
+
+  assert.deepEqual(
+    stream.parts.map((p) => [p.toolCallId, p.toolName]),
+    [
+      ["tool_call_0", "alpha"],
+      ["tool_call_1", "beta"],
+    ],
+  );
+});
+
+test("a provider claiming a minted id displaces the card holding it", () => {
+  // tool_call_<n> is not reserved to Unsloth. Resolving the claim through the
+  // binding the id-less call already had merged the two calls into one card,
+  // giving "alphabeta" and a glued argument string and losing a call. The
+  // backend reserves every provider id before it mints, so the id-less call
+  // moves to tool_call_1 there; do the same once the claim lands.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
+  stream.feed([
+    { id: "tool_call_0", index: 1, function: { name: "beta", arguments: '{"b":2}' } },
+  ]);
+
+  assert.deepEqual(
+    stream.parts.map((p) => [p.toolCallId, p.toolName, p.argsText]),
+    [
+      ["tool_call_1", "alpha", '{"a":1}'],
+      ["tool_call_0", "beta", '{"b":2}'],
+    ],
+  );
+});
+
+test("a born call carries only the metadata of the delta that opened it", () => {
+  // The merge keeps a signature announced with the name beside one arriving
+  // with the arguments, and both belong to the call the slot was holding.
+  // Carried onto a call born from the same delta it puts one call's signature
+  // on another, and Gemini validates the signature against the functionCall
+  // part it was returned on.
+  const stream = makeStream();
+  stream.feed([
+    { index: 0, function: { name: "alpha" }, extra_content: { parked: 1 } },
+  ]);
+  stream.feed([
+    {
+      index: 0,
+      function: { arguments: '{"a":1}{"b":2}' },
+      extra_content: { delta: 2 },
+    },
+  ]);
+
+  assert.deepEqual(shape(stream.parts), [
+    ["alpha", '{"a":1}'],
+    ["alpha", '{"b":2}'],
+  ]);
+  assert.deepEqual(stream.parts[0].extra_content, { parked: 1 });
+  assert.deepEqual(stream.parts[1].extra_content, { delta: 2 });
+});
+
 test("a stable id naming a longer tool opens its own call", () => {
   // A catalog can hold both "web" and "web_search". Reading the second name as
   // a growth of the first gave the id to the completed card, and the arguments
@@ -1303,13 +1369,23 @@ test("several calls opened by one delta each get their own card id", () => {
 // F. Legacy threads whose marker lost its argument text
 // ---------------------------------------------------------------------------
 
-test("the marker is recognised even with no argument text beside it", () => {
-  // Threads written before argsText was kept, and threads rebuilt by the
-  // importer, carry { _raw } with nothing to compare it to. Replaying it sends
-  // a parameter no tool declares and the provider rejects the whole request.
+test("the marker is only recognised by the text that proves it", () => {
+  // Threads written before argsText was kept carry { _raw } with nothing to
+  // compare it to. Reading the value's shape instead -- a run of whole JSON
+  // objects -- would also discard the argument of a tool that really takes a
+  // _raw parameter, since a leading underscore is a legal property name and
+  // MCP reserves nothing. Nothing is lost by keeping it: the wrapped form is
+  // one JSON object, so it does not raise the Extra data this guards against.
   const glued = '{"url":"https://example.com/1"}{"query":"search"}';
-  assert.equal(toolCallReplayArguments(undefined, { _raw: glued }), "{}");
-  assert.equal(toolCallReplayArguments("", { _raw: glued }), "{}");
+  assert.equal(toolCallReplayArguments(glued, { _raw: glued }), "{}");
+  assert.equal(
+    toolCallReplayArguments(undefined, { _raw: glued }),
+    JSON.stringify({ _raw: glued }),
+  );
+  assert.equal(
+    toolCallReplayArguments("", { _raw: glued }),
+    JSON.stringify({ _raw: glued }),
+  );
 });
 
 test("a tool that really takes a _raw parameter keeps it either way", () => {

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -638,30 +638,62 @@ test("the resumable scan agrees with scanning from the start", () => {
   }
 });
 
-test("one argument streamed a character at a time stays linear", () => {
+test("one argument streamed a character at a time is scanned once", () => {
   // Rescanning per fragment made a 20 KB argument cost over a second on the
-  // thread that paints the stream. A ratio, not a deadline: four times the
-  // argument must cost four times the work, so a slow runner moves both.
-  const timeFeed = (size: number): number => {
-    const payload = '{"code":"' + "x".repeat(size) + '"}';
-    const stream = makeStream();
-    stream.feed([{ index: 0, function: { name: "write", arguments: "" } }]);
-    const started = performance.now();
-    for (const ch of payload) {
-      stream.feed([{ index: 0, function: { arguments: ch } }]);
+  // thread that paints the stream. Counted, not timed: the scan parses a
+  // segment when it closes one, so a resumable scan parses once per object
+  // however many deltas it arrived in, and a restarting one parses every
+  // object again on every delta after it closed. A wall-clock ratio said the
+  // same thing with about 25 percent of margin, which is not enough on a
+  // loaded runner.
+  const parses = (size: number, feed: (text: string) => unknown): number => {
+    const real = JSON.parse;
+    let calls = 0;
+    (JSON as { parse: typeof JSON.parse }).parse = ((
+      text: string,
+      reviver?: unknown,
+    ) => {
+      calls += 1;
+      return (real as (t: string, r?: unknown) => unknown)(text, reviver);
+    }) as typeof JSON.parse;
+    try {
+      const payload = '{"a":1}{"code":"' + "x".repeat(size) + '"}';
+      let text = "";
+      for (const ch of payload) {
+        text += ch;
+        feed(text);
+      }
+      return calls;
+    } finally {
+      (JSON as { parse: typeof JSON.parse }).parse = real;
     }
-    const elapsed = performance.now() - started;
-    assert.deepEqual(shape(stream.parts), [["write", payload]]);
-    return elapsed;
   };
-  timeFeed(4000);
-  const small = timeFeed(4000);
-  const large = timeFeed(16000);
-  // Linear is 4x and quadratic 16x, so the line between them is 8x.
+
+  for (const size of [500, 2000]) {
+    const scan = createBoundaryScan();
+    assert.equal(
+      parses(size, (text) => scan.feed(text)),
+      2,
+      "the scan is parsing more than once per object it closes",
+    );
+  }
+
+  // The shape it replaces, measured the same way, so the test says what it
+  // guards against rather than only asserting a number.
+  const restarting = parses(2000, splitTopLevelJsonObjects);
   assert.ok(
-    large < small * 8,
-    `four times the payload cost ${(large / small).toFixed(1)}x the time`,
+    restarting > 2000,
+    `restarting from the beginning parsed ${restarting} times, so this test is no longer measuring the difference it was written for`,
   );
+
+  // And the loop still reads it as one call, whatever the scan costs.
+  const stream = makeStream();
+  const payload = '{"code":"' + "x".repeat(400) + '"}';
+  stream.feed([{ index: 0, function: { name: "write", arguments: "" } }]);
+  for (const ch of payload) {
+    stream.feed([{ index: 0, function: { arguments: ch } }]);
+  }
+  assert.deepEqual(shape(stream.parts), [["write", payload]]);
 });
 
 test("metadata arriving alone stays on the call that closed", () => {
@@ -1164,6 +1196,54 @@ test("a claim that turns out not to be a call gives the number back", () => {
     stream.parts.map((p) => [p.toolCallId, p.toolName]),
     [["tool_call_0", "alpha"]],
   );
+});
+
+test("a repeated name's metadata waits for the call it announced", () => {
+  // The same tool twice on one slot, the second announced by a name-only delta
+  // carrying its own signature. Merging it where it landed both overwrote the
+  // closed call's signature and left the new call unsigned, and Gemini
+  // validates a signature against the call it is replayed on, so the turn was
+  // rejected either way round.
+  const stream = makeStream();
+  stream.feed([
+    {
+      index: 0,
+      function: { name: "lookup", arguments: '{"q":"a"}' },
+      extra_content: { sig: "A" },
+    },
+  ]);
+  stream.feed([
+    { index: 0, function: { name: "lookup" }, extra_content: { sig: "B" } },
+  ]);
+  stream.feed([{ index: 0, function: { arguments: '{"q":"b"}' } }]);
+  stream.feed([], true);
+
+  assert.deepEqual(shape(stream.parts), [
+    ["lookup", '{"q":"a"}'],
+    ["lookup", '{"q":"b"}'],
+  ]);
+  assert.deepEqual(stream.parts[0].extra_content, { sig: "A" });
+  assert.deepEqual(stream.parts[1].extra_content, { sig: "B" });
+});
+
+test("a repeated name that announced nothing keeps its metadata", () => {
+  // No object followed, so the repeated name really was that call's resent and
+  // the signature riding it is that call's too.
+  const stream = makeStream();
+  stream.feed([
+    {
+      index: 0,
+      function: { name: "lookup", arguments: '{"q":"a"}' },
+      extra_content: { own: 1 },
+    },
+  ]);
+  stream.feed([
+    { index: 0, function: { name: "lookup" }, extra_content: { sig: "B" } },
+  ]);
+  stream.feed([], true);
+
+  assert.deepEqual(shape(stream.parts), [["lookup", '{"q":"a"}']]);
+  assert.deepEqual(stream.parts[0].extra_content, { own: 1, sig: "B" });
 });
 
 test("a stable id naming a longer tool opens its own call", () => {

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Issue #9807: a backend streaming parallel tool calls as id-less, index-based
-// deltas reuses one slot for several calls, and the adapter used to append
-// their arguments into one unparsable `{"url":"a"}{"url":"b"}`.
-//
-// The boundary is the end of a top-level JSON object, not a change of function
-// name: the reported stream calls the same tool three times. These cover the
-// scanner, the replay guard behind it, and the accumulation loop itself.
+// Issue #9807: a backend streaming id-less, index-based deltas reuses one slot
+// for several calls, so the adapter glued their arguments into an unparsable
+// `{"url":"a"}{"url":"b"}`. The boundary is the end of a top-level JSON object,
+// not a change of name: the reported stream calls one tool three times.
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -27,10 +24,6 @@ import {
   mintStreamedToolCallId,
   resolveToolCallPartId,
 } from "../src/features/chat/tool-call-id.ts";
-
-// ---------------------------------------------------------------------------
-// A. The scanner
-// ---------------------------------------------------------------------------
 
 test("a slot holding one object is left as one object", () => {
   assert.deepEqual(splitTopLevelJsonObjects('{"url":"a"}'), {
@@ -66,8 +59,6 @@ test("the object still being written is the tail, not a call", () => {
 });
 
 test("braces that are data, not structure, are not boundaries", () => {
-  // A brace in a string, an escaped quote that does not end it, an even run
-  // of backslashes that does, a Windows path, and nesting.
   assert.deepEqual(splitTopLevelJsonObjects('{"a":"}{"}{"b":2}'), {
     complete: ['{"a":"}{"}', '{"b":2}'],
     tail: "",
@@ -94,7 +85,6 @@ test("braces that are data, not structure, are not boundaries", () => {
 });
 
 test("text that is not a run of objects is handed back untouched", () => {
-  // Cutting any of these would invent a call the model never made.
   for (const text of [
     '[{"a":1}]',
     '"hello"',
@@ -113,10 +103,6 @@ test("text that is not a run of objects is handed back untouched", () => {
   }
 });
 
-// ---------------------------------------------------------------------------
-// B. Replay
-// ---------------------------------------------------------------------------
-
 test("a healthy call replays byte for byte", () => {
   assert.equal(
     toolCallReplayArguments('{"query":"first"}', { query: "first" }),
@@ -129,9 +115,7 @@ test("a healthy call replays byte for byte", () => {
 });
 
 test("the _raw marker never reaches a backend as a tool parameter", () => {
-  // Threads stored before the split still hold these, as do threads imported
-  // through chat-import.ts. `_raw` is the adapter's own marker for text it
-  // could not parse; no tool declares it.
+  // `_raw` is the adapter's marker for text it could not parse.
   assert.equal(
     toolCallReplayArguments('{"query":"a"}{"query":"b"}', {
       _raw: '{"query":"a"}{"query":"b"}',
@@ -152,14 +136,10 @@ test("arguments that are not one JSON object fall back rather than replay", () =
   assert.equal(toolCallReplayArguments(undefined, undefined), "{}");
 });
 
-// ---------------------------------------------------------------------------
-// C. The accumulation loop, as shipped
-// ---------------------------------------------------------------------------
-
-// chat-adapter.ts reaches the stores and a JSX barrel and cannot be imported,
-// so lift the loop the way tests/pr9057-video-simulation.test.ts lifts its
-// extractor. A re-implementation would pass while the adapter stayed broken,
-// which is how this defect survived tool-call-delta-index.test.ts.
+// chat-adapter.ts cannot be imported, so lift the loop as
+// tests/pr9057-video-simulation.test.ts does: a re-implementation passes while
+// the adapter stays broken, which is how this defect survived
+// tool-call-delta-index.test.ts.
 const adapterSource = readFileSync(
   fileURLToPath(
     new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
@@ -179,8 +159,8 @@ function liftBetween(what: string, from: string, to: string): string {
 function liftSplitHelpers(): string {
   const lifted = liftBetween(
     "split helpers",
-    "// Ids already spoken for this response",
-    "// Backend tool ids (\"call_0\", ...) restart every response",
+    "const reservedToolCallIds = new Set<string>();",
+    "const toolPartIdByBackendId = new Map<string, string>();",
   );
   assert.ok(
     lifted.includes("bornSplitToolCalls"),
@@ -261,8 +241,7 @@ function makeStream(mintPartIds = false): {
       );
     let addedToolCall = false;
     let replayStateChanged = false;
-    // The chunk the lifted loop reads finish_reason off, so the provider-turn
-    // reset it performs is the shipped one.
+    // What the lifted loop reads finish_reason off.
     let chunk = { choices: [{}] };
     function feed(rawDeltaToolCalls, finished) {
       chunk = { choices: [finished ? { finish_reason: "tool_calls" } : {}] };
@@ -307,8 +286,6 @@ function run(batches: DeltaCall[][]): LoopPart[] {
 const shape = (parts: LoopPart[]) => parts.map((p) => [p.toolName, p.argsText]);
 
 test("the stream from #9807 becomes one call per JSON object", () => {
-  // Three fetches and a search, all id-less at index 0. The same tool repeats,
-  // so there is no name change to cut on.
   const parts = run([
     [{ index: 0, function: { name: "url", arguments: '{"url":"a"}' } }],
     [{ index: 0, function: { name: "url", arguments: '{"url":"b"}' } }],
@@ -327,8 +304,7 @@ test("the stream from #9807 becomes one call per JSON object", () => {
 });
 
 test("a call at another index is not overwritten when a slot splits", () => {
-  // The split slot sits before the neighbour, so removing it and writing back
-  // through the old position would delete that neighbour.
+  // Writing back through the old position deleted the neighbour.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ index: 1, function: { name: "beta", arguments: '{"b":2}' } }],
@@ -380,8 +356,7 @@ test("a call born from a split is state, so it does not wait to publish", () => 
     ]),
     true,
   );
-  // Otherwise the pacing gate holds the second call back and Stop persists a
-  // snapshot without it.
+  // Or the pacing gate holds it back and Stop persists without it.
   assert.equal(
     stream.feed([
       { index: 0, function: { name: "beta", arguments: '{"b":2}' } },
@@ -445,9 +420,8 @@ test("an id stamped on a later fragment still claims its own slot", () => {
 });
 
 test("a fragment repeating the slot's id continues that call", () => {
-  // llama-server grows the name across deltas. An id names its call, so
-  // opening a new one here would give two cards one id, and tool_end files a
-  // result against the first that carries it.
+  // llama-server grows the name across deltas, so opening a call here gives
+  // two cards one id.
   const parts = run([
     [{ id: "call_a", index: 0, function: { name: "web", arguments: '{"q":"x"}' } }],
     [{ id: "call_a", index: 0, function: { name: "web_search" } }],
@@ -458,7 +432,6 @@ test("a fragment repeating the slot's id continues that call", () => {
 });
 
 test("whitespace chunked after a closing brace is not a new call", () => {
-  // Trailing whitespace is legal JSON and says nothing about another call.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ index: 0, function: { name: "alpha", arguments: " " } }],
@@ -472,9 +445,8 @@ test("whitespace chunked after a closing brace is not a new call", () => {
 });
 
 test("a late id claims the call still being written, never a closed one", () => {
-  // The slot splits, leaving a half-written third call, then an id arrives. It
-  // has to land on that unfinished call: appending to either of the two that
-  // closed is the gluing this whole change is about.
+  // The id has to land on the half-written third call; appending to either of
+  // the closed ones is the gluing this change is about.
   const parts = run([
     [
       {
@@ -496,8 +468,7 @@ test("a late id claims the call still being written, never a closed one", () => 
 });
 
 test("a name-only delta for the next call does not rename the finished one", () => {
-  // The name arrives before its arguments, so the accumulated text is still one
-  // whole object and there is nothing to split on yet.
+  // The name arrives before its arguments, so there is nothing to split on.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ index: 0, function: { name: "beta" } }],
@@ -513,8 +484,7 @@ test("a name-only delta for the next call does not rename the finished one", () 
 });
 
 test("an id arriving after one closed object opens a call, not a claim", () => {
-  // A late id claims the slot its id-less opening fragment created, but only
-  // while that call is still being written. This one has closed.
+  // A late id claims its slot only while that call is still being written.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ id: "call_b", index: 0, function: { name: "beta", arguments: '{"b":2}' } }],
@@ -549,10 +519,8 @@ test("a late id opens its own call when every call in the slot has closed", () =
 });
 
 test("an opening delta after a closed call does not claim it", () => {
-  // The conventional opening delta carries the id and the name with empty
-  // arguments. Landing it on the finished card stamps that card with the id, so
-  // the arguments delta that follows matches and glues on, losing the call the
-  // delta was announcing.
+  // The conventional opening delta: id and name, empty arguments. Landing it
+  // on the finished card glues the arguments that follow onto that one.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ id: "call_b", index: 0, function: { name: "beta", arguments: "" } }],
@@ -569,9 +537,8 @@ test("an opening delta after a closed call does not claim it", () => {
 });
 
 test("a name held for the next call grows across deltas", () => {
-  // OpenAI streams a name as "web" then "_search"; llama-server resends "web"
-  // then "web_search". Last-write-wins opens the call as "_search", which
-  // matches no enabled tool and silently never runs.
+  // OpenAI streams "web" then "_search"; llama-server resends "web" then
+  // "web_search". Last-write-wins opens the call as "_search".
   for (const fragments of [
     ["web", "_search"],
     ["web", "web_search"],
@@ -590,9 +557,8 @@ test("a name held for the next call grows across deltas", () => {
 });
 
 test("whitespace carrying the repeated name is not the next call", () => {
-  // A provider that repeats the name on every delta and chunks the trailing
-  // whitespace separately is still writing to the call that closed, so its name
-  // is that call's resent. Parking it merged the two into "alphabeta".
+  // A repeated name with the trailing whitespace chunked separately is still
+  // that call's; parking it merged the two into "alphabeta".
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ index: 0, function: { name: "alpha", arguments: " " } }],
@@ -631,9 +597,7 @@ test("metadata announced with a name waits for that call", () => {
 });
 
 test("the resumable scan agrees with scanning from the start", () => {
-  // The accumulator resumes the boundary scan instead of restarting it, which
-  // is only safe while the two agree for every string and every set of chunk
-  // boundaries.
+  // Only safe while it agrees with restarting, for every chunking.
   const pieces = [
     ..."{}\"\\ abc:,1[]".split(""),
     '\\"',
@@ -645,7 +609,6 @@ test("the resumable scan agrees with scanning from the start", () => {
     '{"a":1}',
     "}{",
   ];
-  // Deterministic, so a failure names one string rather than a mood.
   let seed = 20260827;
   const next = (n: number) => {
     seed = (seed * 1103515245 + 12345) % 2147483648;
@@ -666,11 +629,9 @@ test("the resumable scan agrees with scanning from the start", () => {
 });
 
 test("one argument streamed a character at a time stays linear", () => {
-  // Rescanning the whole accumulation per fragment made a 20 KB argument cost
-  // over a second on the thread that also paints the stream. Timed as a ratio
-  // between two payload sizes rather than against a deadline: what has to hold
-  // is that four times the argument costs four times the work, and a slow or
-  // contended runner moves both measurements together instead of failing.
+  // Rescanning per fragment made a 20 KB argument cost over a second on the
+  // thread that paints the stream. A ratio, not a deadline: four times the
+  // argument must cost four times the work, so a slow runner moves both.
   const timeFeed = (size: number): number => {
     const payload = '{"code":"' + "x".repeat(size) + '"}';
     const stream = makeStream();
@@ -694,8 +655,7 @@ test("one argument streamed a character at a time stays linear", () => {
 });
 
 test("metadata arriving alone stays on the call that closed", () => {
-  // No name, so nothing announces another call: the signature is this card's.
-  // Parking it lost it outright when no further call followed.
+  // No name, so nothing announces another call: the signature is this one's.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ index: 0, extra_content: { google: { thought_signature: "SIG" } } }],
@@ -708,12 +668,10 @@ test("metadata arriving alone stays on the call that closed", () => {
 });
 
 test("a name resent or grown after a call closed invents nothing", () => {
-  // Indistinguishable from a second no-argument call to the same tool, so the
-  // conservative reading is the one that does not run a tool twice. A grown
-  // name is read as the next call announcing itself, since a catalog holding
-  // both "web" and "web_search" makes a shared prefix no evidence either way,
-  // so a provisional card is visible while the turn runs. It brought no
-  // arguments field, so the turn boundary reaps it and nothing is executed.
+  // Indistinguishable from a second no-argument call to the same tool, so take
+  // the reading that does not run a tool twice. A grown name announces the next
+  // call (the prefix is no evidence), so a provisional card is visible while
+  // the turn runs and the boundary reaps it unfilled.
   for (const resent of ["alpha", "alpha_long"]) {
     const stream = makeStream();
     stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
@@ -743,9 +701,8 @@ test("an argument fragment that is not a string does not abort the stream", () =
 });
 
 test("a fragment that does not open an object does not open a call", () => {
-  // A next call begins with the "{" of its own arguments object. Forking on any
-  // non-whitespace text cut where the scanner deliberately leaves the text
-  // whole, so a stray scalar suffix ran the tool a second time.
+  // A next call begins with its own "{"; forking on anything else made a stray
+  // scalar suffix run the tool twice.
   const parts = run([
     [{ index: 0, function: { name: "q", arguments: '{"query":"a"}' } }],
     [{ index: 0, function: { name: "q", arguments: '"b"' } }],
@@ -755,9 +712,7 @@ test("a fragment that does not open an object does not open a call", () => {
 });
 
 test("metadata announced with a name is merged, not replaced", () => {
-  // A signature parked with the name and metadata arriving with the arguments
-  // are different fields of one call, and the replayed turn is rejected
-  // without either.
+  // Two fields of one call, and replay needs both.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [
@@ -787,9 +742,7 @@ test("metadata announced with a name is merged, not replaced", () => {
 });
 
 test("an MCP tool that really takes _raw keeps it", () => {
-  // The adapter writes `{ _raw }` holding the exact text it could not parse, so
-  // that pairing is the marker. `_raw` is not reserved, and an MCP server's
-  // schema is its own, so a tool that declares one must still be callable.
+  // The marker is the pairing, not the key: `_raw` is not reserved.
   assert.equal(
     toolCallReplayArguments('{"url":"a"}{"url":"b"}', {
       _raw: '{"url":"a"}{"url":"b"}',
@@ -807,9 +760,7 @@ test("an MCP tool that really takes _raw keeps it", () => {
 });
 
 test("a name waiting for arguments does not cross a turn boundary", () => {
-  // The backend starts the next provider turn on the same response with the
-  // delta index restarted at 0, so a name left over would be prepended to
-  // whatever opens there.
+  // The next turn restarts the delta index at 0.
   const stream = makeStream();
   stream.feed([{ index: 0, function: { name: "A", arguments: '{"a":1}' } }]);
   // The name-only delta rides the same chunk as finish_reason, which is how a
@@ -824,8 +775,7 @@ test("a name waiting for arguments does not cross a turn boundary", () => {
 });
 
 test("metadata on several name fragments is merged, not replaced", () => {
-  // The name is accumulated across the fragments, so the metadata they carry
-  // has to be too: replacing drops the signature an earlier fragment brought.
+  // The name accumulates across fragments, so the metadata has to as well.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [
@@ -850,9 +800,8 @@ test("metadata on several name fragments is merged, not replaced", () => {
 });
 
 test("a resent name does not rename the call it closed", () => {
-  // Concatenating gave "alphabeta", a name the backend never executes, so the
-  // card disagreed with the call that ran. The metadata parked with that name
-  // is the closed call's too, once the name is read as its.
+  // Concatenating gave "alphabeta", which the backend never executes. Once the
+  // name is read as the closed call's, so is the metadata beside it.
   const stream = makeStream();
   stream.feed([
     {
@@ -877,9 +826,7 @@ test("a resent name does not rename the call it closed", () => {
 });
 
 test("an id stamped after the object closed claims that call", () => {
-  // A provider that opens id-less and stamps the real id on a later delta.
-  // Reading the id as proof of another call left the finished one under its
-  // provisional id beside an empty second card.
+  // Reading the late id as another call left the finished one provisional.
   for (const late of [
     { id: "call_a", index: 0 },
     { id: "call_a", index: 0, function: { name: "alpha" } },
@@ -894,7 +841,6 @@ test("an id stamped after the object closed claims that call", () => {
     );
   }
 
-  // An id that names a different call is still the next call opening.
   const opened = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ id: "call_b", index: 0, function: { name: "beta", arguments: "" } }],
@@ -907,11 +853,9 @@ test("an id stamped after the object closed claims that call", () => {
 });
 
 test("a new name arriving with whitespace opens its own call", () => {
-  // A name sharing no prefix with the closed card's is a different tool, so it
-  // opens the next call rather than renaming the finished one, which used to
-  // leave the closed card named "alphabeta" and the new one unnamed. The
-  // whitespace rides the announcing delta, so it lands on the new call's
-  // arguments; leading whitespace is valid JSON, so both still parse.
+  // A different name opens the next call rather than renaming the finished
+  // one, which gave "alphabeta" and an unnamed second card. The whitespace
+  // rides the announcing delta and is valid JSON, so both still parse.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ index: 0, function: { name: "beta", arguments: " " } }],
@@ -942,9 +886,8 @@ test("a call announced by name is placed where it was announced", () => {
 });
 
 test("a late id claims the last call a bundled delta opened", () => {
-  // A provider that writes several calls in one delta can stamp the last one's
-  // real id in a delta of its own. Marking that card owned sent the id to a
-  // third empty card, while the backend put it on the split call.
+  // A provider bundling several calls can stamp the last one's real id later;
+  // marking that card owned sent the id to a third, empty card.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}{"b":2}' } }],
     [{ id: "call_b", index: 0 }],
@@ -960,8 +903,7 @@ test("a late id claims the last call a bundled delta opened", () => {
 });
 
 test("two calls announced at once keep the order they were announced in", () => {
-  // Both announcements record the same position, so splicing each at that one
-  // mark put the later one first.
+  // Both record the same position, so splicing at it put the later first.
   const parts = run([
     [{ index: 0, function: { name: "A", arguments: '{"a":1}' } }],
     [{ index: 1, function: { name: "B", arguments: '{"b":1}' } }],
@@ -978,9 +920,8 @@ test("two calls announced at once keep the order they were announced in", () => 
 });
 
 test("a rejected resend gives up its place too", () => {
-  // The place goes with the announcement: a name read as the closed call's
-  // resent announced nothing, so the call that opens takes its arrival
-  // position, which is what the backend records for the same stream.
+  // The place goes with the announcement, and a name read as a resent
+  // announced nothing, so the call that opens takes its own arrival.
   const stream = makeStream();
   stream.feed([{ index: 0, function: { name: "A", arguments: '{"a":1}' } }]);
   stream.feed([{ index: 0, function: { name: "A_long" } }]);
@@ -996,10 +937,8 @@ test("a rejected resend gives up its place too", () => {
 });
 
 test("a catalog holding both web and web_search splits either way round", () => {
-  // Both names are in Studio's own catalog, and neither order can be read as
-  // one name growing: a shared prefix is no evidence when the tools really are
-  // called that. Reading it as evidence swallowed the second announcement, and
-  // the call it announced never ran.
+  // Both are in Studio's own catalog, so a shared prefix is no evidence either
+  // way; reading it as evidence swallowed the second announcement.
   for (const [first, second] of [
     ["web_search", "web"],
     ["web", "web_search"],
@@ -1017,9 +956,8 @@ test("a catalog holding both web and web_search splits either way round", () => 
 });
 
 test("a name bringing an object over an announcement is the next call", () => {
-  // An announcement holds a card with no arguments, which the closed-object
-  // rule cannot reach, so the next call's name grew into it: "alpha_longbeta"
-  // and "zetabeta" match no tool and silently never ran.
+  // An announcement has no object to close, so the next call's name grew into
+  // it: "alpha_longbeta" and "zetabeta" match no tool.
   for (const announced of ["alpha_long", "zeta"]) {
     const stream = makeStream();
     stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
@@ -1034,10 +972,8 @@ test("a name bringing an object over an announcement is the next call", () => {
 });
 
 test("a dropped card gives its id back to the next round", () => {
-  // The backend filters the unfinished fork out of `calls` and never reserves
-  // its card id, so holding it here made the next round mint tool_call_2 while
-  // the backend addressed tool_call_1, and the tool_start drew a second card
-  // beside the one the deltas had already painted.
+  // The backend never reserves the filtered fork's card id, so holding it here
+  // made the next round mint tool_call_2 against the backend's tool_call_1.
   const stream = makeStream();
   stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}{' } }]);
   stream.feed([], true);
@@ -1054,10 +990,8 @@ test("a dropped card gives its id back to the next round", () => {
 
 test("a provider claiming a minted id displaces the card holding it", () => {
   // tool_call_<n> is not reserved to Unsloth. Resolving the claim through the
-  // binding the id-less call already had merged the two calls into one card,
-  // giving "alphabeta" and a glued argument string and losing a call. The
-  // backend reserves every provider id before it mints, so the id-less call
-  // moves to tool_call_1 there; do the same once the claim lands.
+  // id-less call's binding merged the two into one card, losing a call. The
+  // backend reserves provider ids before minting; do the same on the claim.
   const stream = makeStream();
   stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
   stream.feed([
@@ -1074,11 +1008,9 @@ test("a provider claiming a minted id displaces the card holding it", () => {
 });
 
 test("a born call carries only the metadata of the delta that opened it", () => {
-  // The merge keeps a signature announced with the name beside one arriving
-  // with the arguments, and both belong to the call the slot was holding.
-  // Carried onto a call born from the same delta it puts one call's signature
-  // on another, and Gemini validates the signature against the functionCall
-  // part it was returned on.
+  // The merged fields belong to the call the slot was holding; carried onto a
+  // born call they put one call's signature on another, and Gemini validates a
+  // signature against the functionCall part it was returned on.
   const stream = makeStream();
   stream.feed([
     { index: 0, function: { name: "alpha" }, extra_content: { parked: 1 } },
@@ -1100,9 +1032,7 @@ test("a born call carries only the metadata of the delta that opened it", () => 
 });
 
 test("a stable id naming a longer tool opens its own call", () => {
-  // A catalog can hold both "web" and "web_search". Reading the second name as
-  // a growth of the first gave the id to the completed card, and the arguments
-  // that followed glued onto it.
+  // Reading "web_search" as "web" grown gave the id to the completed card.
   const parts = run([
     [{ index: 0, function: { name: "web", arguments: '{"a":1}' } }],
     [{ id: "call_b", index: 0, function: { name: "web_search", arguments: "" } }],
@@ -1119,9 +1049,8 @@ test("a stable id naming a longer tool opens its own call", () => {
 });
 
 test("a fork whose object never closed is dropped when the turn ends", () => {
-  // A stream that stops after `{"a":1}{` is not marked truncated, so the lone
-  // brace would persist as a card no execution event can complete and replay
-  // would send as `{}`. The backend holds the same fork back in open_tail_keys.
+  // A stream stopping after `{"a":1}{` is not marked truncated, so the lone
+  // brace persists as a card nothing completes. The backend holds it too.
   const stream = makeStream();
   stream.feed([{ index: 0, function: { name: "a", arguments: '{"a":1}{' } }]);
   assert.deepEqual(shape(stream.parts), [
@@ -1144,10 +1073,8 @@ test("a fork that does close its object is kept", () => {
 });
 
 test("metadata from a resent name goes to the call that runs", () => {
-  // "alpha_long" at a closed slot reads as "alpha" grown, so no second call is
-  // invented for it and _announced_but_unopened hangs the signature on the held
-  // call. Queued under the fragment it would never be read: the tool_start that
-  // follows is named "alpha", and the card would replay without it.
+  // No call is invented for a name read as a resent, so its signature has
+  // nowhere else to go and the card would replay without it.
   const stream = makeStream();
   stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
   stream.feed([
@@ -1160,10 +1087,8 @@ test("metadata from a resent name goes to the call that runs", () => {
 });
 
 test("a provider-hosted tool event does not end the provider turn", () => {
-  // The backend records those with note_hosted_tool_event and leaves its _Turn
-  // open, so an argument-only delta after one still opens the parked name.
-  // Hosted events ride a whole chunk, `choices` and all; Unsloth's own tool
-  // frames arrive as a bare {"type": "tool_start"} that chat-api wraps alone.
+  // Hosted events ride a whole chunk, `choices` and all, and leave the turn
+  // open; Unsloth's are bare {"type": "tool_start"}.
   const guarded = liftBetween(
     "the hosted-event guard",
     "const toolEvent = (",
@@ -1190,9 +1115,8 @@ test("a late id does not rescue a fork whose object never closed", () => {
 });
 
 test("only the announced call takes the place reserved for it", () => {
-  // B was announced before C opened, so B goes ahead of C. The calls B's
-  // arguments introduce were never announced: _fork_glued_arguments numbers
-  // them as the arguments arrive, which is after C.
+  // B was announced before C opened. The calls B's arguments introduce were
+  // never announced, so they are numbered as the arguments arrive.
   const parts = run([
     [{ index: 0, function: { name: "A", arguments: '{"a":1}' } }],
     [{ index: 0, function: { name: "B" } }],
@@ -1209,9 +1133,8 @@ test("only the announced call takes the place reserved for it", () => {
 });
 
 test("the empty status between rounds ends the provider turn", () => {
-  // A round whose calls were all rejected as disabled emits no tool_start or
-  // tool_end, and an upstream ending its turns with [DONE] sends no
-  // finish_reason, so the empty tool_status is the only boundary there is.
+  // A round of only disabled calls emits no tool_start, and a [DONE] upstream
+  // sends no finish_reason, so this is the only boundary there is.
   const branch = liftBetween(
     "the tool_status branch",
     "const toolStatusText = (",
@@ -1221,9 +1144,8 @@ test("the empty status between rounds ends the provider turn", () => {
 });
 
 test("the announced call keeps its own metadata when its delta splits", () => {
-  // The signature parked with the announcement is B's; the one riding the
-  // arguments belongs to the call that delta closes, which is the last of
-  // them. _take_parked and _fork_glued_arguments divide them the same way.
+  // The parked signature is B's; the one riding the arguments belongs to the
+  // call that delta closes, the last. The backend divides them the same way.
   const parts = run([
     [{ index: 0, function: { name: "A", arguments: '{"a":1}' } }],
     [{ index: 0, function: { name: "B" }, extra_content: { sig: "parked" } }],
@@ -1246,9 +1168,8 @@ test("the announced call keeps its own metadata when its delta splits", () => {
 });
 
 test("a second call to the same tool keeps that tool's name", () => {
-  // The provider gave the name once and reused the index for the next call
-  // with arguments alone. A blank name is no tool: _normalized_call drops the
-  // call on the backend and the card here would name nothing.
+  // The index is reused with arguments alone, and a blank name is no tool:
+  // the backend drops the call and the card here names nothing.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ index: 0, function: { arguments: '{"a":2}' } }],
@@ -1261,9 +1182,8 @@ test("a second call to the same tool keeps that tool's name", () => {
 });
 
 test("a snapshot repeated to carry the id claims the call", () => {
-  // Snapshot-style servers resend the whole call rather than fragments of it,
-  // so the id arrives on a verbatim repeat. Opening a second call there runs a
-  // side-effecting tool twice.
+  // Snapshot servers resend the whole call, so the id arrives on a verbatim
+  // repeat and opening a second call runs the tool twice.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ id: "call_a", index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
@@ -1276,8 +1196,7 @@ test("a snapshot repeated to carry the id claims the call", () => {
 });
 
 test("a second call that differs anywhere still opens its own", () => {
-  // The claim above is an exact repeat only, so genuine parallel calls with
-  // ids of their own are not collapsed into one.
+  // The claim above is exact repeats only.
   const parts = run([
     [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
     [{ id: "call_b", index: 0, function: { name: "alpha", arguments: '{"a":2}' } }],
@@ -1292,15 +1211,10 @@ test("a second call that differs anywhere still opens its own", () => {
   );
 });
 
-// ---------------------------------------------------------------------------
-// E. The card the deltas drew
-// ---------------------------------------------------------------------------
-
 test("an id-less card answers to the id the backend mints for it", () => {
-  // The backend mints tool_call_<n> for a call the provider gave no id to and
-  // addresses tool_start and tool_end there. Without the binding,
-  // resolveToolPartId mints "<id>:<uuid>", tool_start finds no card under that
-  // and pushes one, and #9807's four calls end the turn holding eight cards.
+  // The backend addresses tool_start at tool_call_<n>. Without the binding,
+  // resolveToolPartId mints "<id>:<uuid>" and no card is found: #9807's four
+  // calls ended the turn holding eight cards.
   const stream = makeStream(true);
   for (const url of ["a", "b", "c", "d"]) {
     stream.feed([{ index: 0, function: { name: "fetch", arguments: `{"url":"${url}"}` } }]);
@@ -1324,8 +1238,7 @@ test("an id-less card answers to the id the backend mints for it", () => {
 });
 
 test("a call the provider named still resolves through the minted part id", () => {
-  // Unchanged for every stream that carries ids: the card is keyed on the
-  // run-unique "<id>:<uuid>" the resolver mints, exactly as before.
+  // Unchanged for streams that carry ids: still keyed on "<id>:<uuid>".
   const stream = makeStream(true);
   stream.feed([{ id: "call_a", index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
 
@@ -1352,9 +1265,8 @@ test("a provider id spelled tool_call_0 keeps its own card", () => {
 });
 
 test("several calls opened by one delta each get their own card id", () => {
-  // A slot can arrive already holding several calls in one fragment. The cards
-  // are minted before any of them joins the parts array, so the ids have to be
-  // reserved as they are handed out or all three collide.
+  // The cards are minted before any joins the parts array, so the ids have to
+  // be reserved as they are handed out or all three collide.
   const stream = makeStream(true);
   stream.feed([
     { index: 0, function: { name: "fetch", arguments: '{"a":1}{"b":2}{"c":3}' } },
@@ -1365,17 +1277,11 @@ test("several calls opened by one delta each get their own card id", () => {
   assert.equal(new Set(ids).size, 3);
 });
 
-// ---------------------------------------------------------------------------
-// F. Legacy threads whose marker lost its argument text
-// ---------------------------------------------------------------------------
-
 test("the marker is only recognised by the text that proves it", () => {
   // Threads written before argsText was kept carry { _raw } with nothing to
-  // compare it to. Reading the value's shape instead -- a run of whole JSON
-  // objects -- would also discard the argument of a tool that really takes a
-  // _raw parameter, since a leading underscore is a legal property name and
-  // MCP reserves nothing. Nothing is lost by keeping it: the wrapped form is
-  // one JSON object, so it does not raise the Extra data this guards against.
+  // compare it to. Reading the value's shape instead would discard the argument
+  // of a tool that really takes a _raw parameter, and nothing is gained: the
+  // wrapped form is one JSON object, so it raises no Extra data.
   const glued = '{"url":"https://example.com/1"}{"query":"search"}';
   assert.equal(toolCallReplayArguments(glued, { _raw: glued }), "{}");
   assert.equal(
@@ -1389,8 +1295,7 @@ test("the marker is only recognised by the text that proves it", () => {
 });
 
 test("a tool that really takes a _raw parameter keeps it either way", () => {
-  // _raw is not reserved and an MCP server's schema is its own. Held text that
-  // is not a run of whole JSON objects is an argument, not the corruption.
+  // _raw is not reserved and an MCP server's schema is its own.
   assert.equal(
     toolCallReplayArguments('{"_raw":"hello"}', { _raw: "hello" }),
     '{"_raw":"hello"}',

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -1,0 +1,1330 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Issue #9807: a backend streaming parallel tool calls as id-less, index-based
+// deltas reuses one slot for several calls, and the adapter used to append
+// their arguments into one unparsable `{"url":"a"}{"url":"b"}`.
+//
+// The boundary is the end of a top-level JSON object, not a change of function
+// name: the reported stream calls the same tool three times. These cover the
+// scanner, the replay guard behind it, and the accumulation loop itself.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+import {
+  createBoundaryScan,
+  splitTopLevelJsonObjects,
+  toolCallReplayArguments,
+} from "../src/features/chat/tool-call-arguments.ts";
+import {
+  bindStreamedToolCallCard,
+  findStreamedToolCallPartIndex,
+  mintStreamedToolCallId,
+  resolveToolCallPartId,
+} from "../src/features/chat/tool-call-id.ts";
+
+// ---------------------------------------------------------------------------
+// A. The scanner
+// ---------------------------------------------------------------------------
+
+test("a slot holding one object is left as one object", () => {
+  assert.deepEqual(splitTopLevelJsonObjects('{"url":"a"}'), {
+    complete: ['{"url":"a"}'],
+    tail: "",
+  });
+  assert.deepEqual(splitTopLevelJsonObjects("{}"), {
+    complete: ["{}"],
+    tail: "",
+  });
+  assert.deepEqual(splitTopLevelJsonObjects(""), { complete: [], tail: "" });
+});
+
+test("adjacent objects are cut apart, however they are spaced", () => {
+  assert.deepEqual(
+    splitTopLevelJsonObjects('{"a":1}{"b":2} {"c":3}\n{"d":4}\r\n{"e":5}'),
+    {
+      complete: ['{"a":1}', '{"b":2}', '{"c":3}', '{"d":4}', '{"e":5}'],
+      tail: "",
+    },
+  );
+});
+
+test("the object still being written is the tail, not a call", () => {
+  assert.deepEqual(splitTopLevelJsonObjects('{"a":1}{"b":'), {
+    complete: ['{"a":1}'],
+    tail: '{"b":',
+  });
+  assert.deepEqual(splitTopLevelJsonObjects('{"a":'), {
+    complete: [],
+    tail: '{"a":',
+  });
+});
+
+test("braces that are data, not structure, are not boundaries", () => {
+  // A brace in a string, an escaped quote that does not end it, an even run
+  // of backslashes that does, a Windows path, and nesting.
+  assert.deepEqual(splitTopLevelJsonObjects('{"a":"}{"}{"b":2}'), {
+    complete: ['{"a":"}{"}', '{"b":2}'],
+    tail: "",
+  });
+  assert.deepEqual(splitTopLevelJsonObjects('{"a":"say \\"}{\\" ok"}{"b":2}'), {
+    complete: ['{"a":"say \\"}{\\" ok"}', '{"b":2}'],
+    tail: "",
+  });
+  assert.deepEqual(
+    splitTopLevelJsonObjects('{"p":"C:\\\\Users\\\\me"}{"b":2}'),
+    {
+      complete: ['{"p":"C:\\\\Users\\\\me"}', '{"b":2}'],
+      tail: "",
+    },
+  );
+  assert.deepEqual(splitTopLevelJsonObjects('{"a":{"b":{"c":1}}}'), {
+    complete: ['{"a":{"b":{"c":1}}}'],
+    tail: "",
+  });
+  assert.deepEqual(splitTopLevelJsonObjects('{"a":[{"b":1},{"c":2}]}'), {
+    complete: ['{"a":[{"b":1},{"c":2}]}'],
+    tail: "",
+  });
+});
+
+test("text that is not a run of objects is handed back untouched", () => {
+  // Cutting any of these would invent a call the model never made.
+  for (const text of [
+    '[{"a":1}]',
+    '"hello"',
+    "42",
+    "null",
+    '{"a":1}junk{"b":2}',
+    '{"a":1}}',
+    '{"a":1,}{"b":2}',
+    '{"a":"unterminated',
+  ]) {
+    assert.deepEqual(
+      splitTopLevelJsonObjects(text),
+      { complete: [], tail: text },
+      text,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// B. Replay
+// ---------------------------------------------------------------------------
+
+test("a healthy call replays byte for byte", () => {
+  assert.equal(
+    toolCallReplayArguments('{"query":"first"}', { query: "first" }),
+    '{"query":"first"}',
+  );
+  assert.equal(
+    toolCallReplayArguments("", { query: "first" }),
+    '{"query":"first"}',
+  );
+});
+
+test("the _raw marker never reaches a backend as a tool parameter", () => {
+  // Threads stored before the split still hold these, as do threads imported
+  // through chat-import.ts. `_raw` is the adapter's own marker for text it
+  // could not parse; no tool declares it.
+  assert.equal(
+    toolCallReplayArguments('{"query":"a"}{"query":"b"}', {
+      _raw: '{"query":"a"}{"query":"b"}',
+    }),
+    "{}",
+  );
+  assert.equal(
+    toolCallReplayArguments('{"query":', { _raw: '{"query":' }),
+    "{}",
+  );
+});
+
+test("arguments that are not one JSON object fall back rather than replay", () => {
+  assert.equal(toolCallReplayArguments("[1,2]", { url: "a" }), '{"url":"a"}');
+  assert.equal(toolCallReplayArguments(undefined, [1, 2]), "{}");
+  assert.equal(toolCallReplayArguments(undefined, "nope"), "{}");
+  assert.equal(toolCallReplayArguments(undefined, null), "{}");
+  assert.equal(toolCallReplayArguments(undefined, undefined), "{}");
+});
+
+// ---------------------------------------------------------------------------
+// C. The accumulation loop, as shipped
+// ---------------------------------------------------------------------------
+
+// chat-adapter.ts reaches the stores and a JSX barrel and cannot be imported,
+// so lift the loop the way tests/pr9057-video-simulation.test.ts lifts its
+// extractor. A re-implementation would pass while the adapter stayed broken,
+// which is how this defect survived tool-call-delta-index.test.ts.
+const adapterSource = readFileSync(
+  fileURLToPath(
+    new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
+  ),
+  "utf8",
+);
+
+function liftBetween(what: string, from: string, to: string): string {
+  const start = adapterSource.indexOf(from);
+  assert.ok(start >= 0, `${what}: "${from}" is gone from chat-adapter.ts`);
+  const end = adapterSource.indexOf(to, start);
+  assert.ok(end > start, `${what}: "${to}" is gone from chat-adapter.ts`);
+  return adapterSource.slice(start, end);
+}
+
+/** The two helpers the loop calls, declared beside `toolCallParts`. */
+function liftSplitHelpers(): string {
+  const lifted = liftBetween(
+    "split helpers",
+    "// Ids already spoken for this response",
+    "// Raw tool_args accumulator per card",
+  );
+  assert.ok(
+    lifted.includes("bornSplitToolCalls"),
+    "the split helpers moved in chat-adapter.ts",
+  );
+  return lifted;
+}
+
+function liftDeltaLoop(): string {
+  const loopStart = adapterSource.indexOf(
+    "for (const tc of rawDeltaToolCalls) {",
+  );
+  assert.ok(
+    loopStart >= 0,
+    "the delta.tool_calls loop moved in chat-adapter.ts",
+  );
+  const gate = adapterSource.lastIndexOf(
+    "if (",
+    adapterSource.indexOf("addedToolCall ||", loopStart),
+  );
+  assert.ok(gate > loopStart, "the publish gate moved in chat-adapter.ts");
+  const lifted = adapterSource.slice(loopStart, gate);
+  assert.ok(
+    lifted.includes("splitTopLevelJsonObjects"),
+    "the loop no longer splits on JSON object boundaries",
+  );
+  return lifted;
+}
+
+interface DeltaCall {
+  id?: string;
+  index?: number;
+  function?: { name?: string; arguments?: string };
+  extra_content?: unknown;
+}
+
+interface LoopPart {
+  toolCallId: string;
+  toolName?: string;
+  argsText?: string;
+  args?: Record<string, unknown>;
+  _delta_index?: number;
+  _has_stable_id?: boolean;
+  extra_content?: unknown;
+}
+
+/**
+ * The lifted loop, with the locals it closes over supplied by hand.
+ *
+ * `mintPartIds` picks which `resolveToolPartId` the loop closes over. The
+ * accumulation tests want the identity, because they assert which call an id
+ * lands on and the spelling is noise. The card tests want the shipped mint,
+ * `<backend id>:<uuid>`, because whether the backend's id finds the card the
+ * deltas drew is the whole question there, and under the identity every id
+ * finds one whether or not the two halves ever agreed.
+ */
+function makeStream(mintPartIds = false): {
+  feed: (batch: DeltaCall[], finished?: boolean) => boolean;
+  parts: LoopPart[];
+  resolveToolPartId: (backendId: string) => string;
+} {
+  const body = `
+    const toolCallParts = [];
+    let codexRoundToolCallIds = [];
+    const toolPartIdByBackendId = new Map();
+    const cumulativeText = "";
+    let streamedChars = 0;
+    ${liftSplitHelpers()}
+    let mintedPartIds = 0;
+    const resolveToolPartId = (backendId) =>
+      resolveToolCallPartId(
+        toolPartIdByBackendId,
+        backendId,
+        undefined,
+        toolCallParts[toolCallParts.length - 1]?.toolCallId ?? "",
+        () =>
+          mintPartIds ? backendId + ":uuid-" + (mintedPartIds += 1) : backendId,
+      );
+    let addedToolCall = false;
+    let replayStateChanged = false;
+    // The chunk the lifted loop reads finish_reason off, so the provider-turn
+    // reset it performs is the shipped one.
+    let chunk = { choices: [{}] };
+    function feed(rawDeltaToolCalls, finished) {
+      chunk = { choices: [finished ? { finish_reason: "tool_calls" } : {}] };
+      addedToolCall = false;
+      replayStateChanged = false;
+      ${liftDeltaLoop()}
+      return addedToolCall;
+    }
+    return { feed, parts: toolCallParts, resolveToolPartId };
+  `;
+  const js = ts.transpileModule(`const mintPartIds = ${mintPartIds};` + body, {
+    compilerOptions: { target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+  return new Function(
+    "splitTopLevelJsonObjects",
+    "createBoundaryScan",
+    "findStreamedToolCallPartIndex",
+    "mintStreamedToolCallId",
+    "bindStreamedToolCallCard",
+    "resolveToolCallPartId",
+    js,
+  )(
+    splitTopLevelJsonObjects,
+    createBoundaryScan,
+    findStreamedToolCallPartIndex,
+    mintStreamedToolCallId,
+    bindStreamedToolCallCard,
+    resolveToolCallPartId,
+  ) as {
+    feed: (batch: DeltaCall[], finished?: boolean) => boolean;
+    parts: LoopPart[];
+    resolveToolPartId: (backendId: string) => string;
+  };
+}
+
+function run(batches: DeltaCall[][]): LoopPart[] {
+  const stream = makeStream();
+  for (const batch of batches) stream.feed(batch);
+  return stream.parts;
+}
+
+const shape = (parts: LoopPart[]) => parts.map((p) => [p.toolName, p.argsText]);
+
+test("the stream from #9807 becomes one call per JSON object", () => {
+  // Three fetches and a search, all id-less at index 0. The same tool repeats,
+  // so there is no name change to cut on.
+  const parts = run([
+    [{ index: 0, function: { name: "url", arguments: '{"url":"a"}' } }],
+    [{ index: 0, function: { name: "url", arguments: '{"url":"b"}' } }],
+    [{ index: 0, function: { name: "query", arguments: '{"q":"c"}' } }],
+    [{ index: 0, function: { name: "url", arguments: '{"url":"d"}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["url", '{"url":"a"}'],
+    ["url", '{"url":"b"}'],
+    ["query", '{"q":"c"}'],
+    ["url", '{"url":"d"}'],
+  ]);
+  const ids = parts.map((p) => p.toolCallId);
+  assert.equal(new Set(ids).size, ids.length, `ids collide: ${ids.join(",")}`);
+});
+
+test("a call at another index is not overwritten when a slot splits", () => {
+  // The split slot sits before the neighbour, so removing it and writing back
+  // through the old position would delete that neighbour.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ index: 1, function: { name: "beta", arguments: '{"b":2}' } }],
+    [{ index: 0, function: { name: "gamma", arguments: '{"c":3}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["beta", '{"b":2}'],
+    ["gamma", '{"c":3}'],
+  ]);
+});
+
+test("a call opened third reads third, whichever index it reused", () => {
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ index: 1, function: { name: "beta", arguments: '{"b":2}' } }],
+    [{ index: 1, function: { name: "gamma", arguments: '{"c":3}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["beta", '{"b":2}'],
+    ["gamma", '{"c":3}'],
+  ]);
+});
+
+test("several objects inside one fragment split just the same", () => {
+  const parts = run([
+    [
+      {
+        index: 0,
+        function: { name: "url", arguments: '{"url":"a"}{"url":"b"}' },
+      },
+    ],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["url", '{"url":"a"}'],
+    ["url", '{"url":"b"}'],
+  ]);
+});
+
+test("a call born from a split is state, so it does not wait to publish", () => {
+  const stream = makeStream();
+  assert.equal(
+    stream.feed([
+      { index: 0, function: { name: "alpha", arguments: '{"a":1}' } },
+    ]),
+    true,
+  );
+  // Otherwise the pacing gate holds the second call back and Stop persists a
+  // snapshot without it.
+  assert.equal(
+    stream.feed([
+      { index: 0, function: { name: "beta", arguments: '{"b":2}' } },
+    ]),
+    true,
+  );
+});
+
+test("an ordinary fragmented call is still one call", () => {
+  assert.deepEqual(
+    shape(
+      run([
+        [{ index: 0, function: { name: "alpha", arguments: '{"a":' } }],
+        [{ index: 0, function: { arguments: "1" } }],
+        [{ index: 0, function: { arguments: "}" } }],
+      ]),
+    ),
+    [["alpha", '{"a":1}']],
+  );
+});
+
+test("a stream that carries ids is left exactly as it was", () => {
+  const parts = run([
+    [
+      {
+        id: "call_a",
+        index: 0,
+        function: { name: "alpha", arguments: '{"a":' },
+      },
+      {
+        id: "call_b",
+        index: 1,
+        function: { name: "beta", arguments: '{"b":' },
+      },
+    ],
+    [
+      { id: "call_a", index: 0, function: { arguments: "1}" } },
+      { id: "call_b", index: 1, function: { arguments: "2}" } },
+    ],
+  ]);
+
+  assert.deepEqual(
+    parts.map((p) => [p.toolCallId, p.toolName, p.argsText]),
+    [
+      ["call_a", "alpha", '{"a":1}'],
+      ["call_b", "beta", '{"b":2}'],
+    ],
+  );
+});
+
+test("an id stamped on a later fragment still claims its own slot", () => {
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":' } }],
+    [{ id: "call_a", index: 0, function: { arguments: "1}" } }],
+  ]);
+
+  assert.deepEqual(
+    parts.map((p) => [p.toolCallId, p.argsText]),
+    [["call_a", '{"a":1}']],
+  );
+});
+
+test("a fragment repeating the slot's id continues that call", () => {
+  // llama-server grows the name across deltas. An id names its call, so
+  // opening a new one here would give two cards one id, and tool_end files a
+  // result against the first that carries it.
+  const parts = run([
+    [{ id: "call_a", index: 0, function: { name: "web", arguments: '{"q":"x"}' } }],
+    [{ id: "call_a", index: 0, function: { name: "web_search" } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [["web_search", '{"q":"x"}']]);
+  assert.equal(parts.length, 1);
+});
+
+test("whitespace chunked after a closing brace is not a new call", () => {
+  // Trailing whitespace is legal JSON and says nothing about another call.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ index: 0, function: { name: "alpha", arguments: " " } }],
+    [{ index: 0, function: { name: "alpha", arguments: '{"b":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1} '],
+    ["alpha", '{"b":2}'],
+  ]);
+});
+
+test("a late id claims the call still being written, never a closed one", () => {
+  // The slot splits, leaving a half-written third call, then an id arrives. It
+  // has to land on that unfinished call: appending to either of the two that
+  // closed is the gluing this whole change is about.
+  const parts = run([
+    [
+      {
+        index: 0,
+        function: { name: "alpha", arguments: '{"a":1}{"b":2}{"c":' },
+      },
+    ],
+    [{ id: "call_c", index: 0, function: { arguments: "3}" } }],
+  ]);
+
+  assert.deepEqual(
+    parts.map((p) => [p.toolCallId, p.argsText]),
+    [
+      ["tool_call_0", '{"a":1}'],
+      ["tool_call_1", '{"b":2}'],
+      ["call_c", '{"c":3}'],
+    ],
+  );
+});
+
+test("a name-only delta for the next call does not rename the finished one", () => {
+  // The name arrives before its arguments, so the accumulated text is still one
+  // whole object and there is nothing to split on yet.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ index: 0, function: { name: "beta" } }],
+    [{ index: 0, function: { arguments: '{"b":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["beta", '{"b":2}'],
+  ]);
+  const ids = parts.map((p) => p.toolCallId);
+  assert.equal(new Set(ids).size, ids.length, `ids collide: ${ids.join(",")}`);
+});
+
+test("an id arriving after one closed object opens a call, not a claim", () => {
+  // A late id claims the slot its id-less opening fragment created, but only
+  // while that call is still being written. This one has closed.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ id: "call_b", index: 0, function: { name: "beta", arguments: '{"b":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["beta", '{"b":2}'],
+  ]);
+});
+
+test("a late id opens its own call when every call in the slot has closed", () => {
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}{"b":2}' } }],
+    [
+      {
+        id: "call_c",
+        index: 0,
+        function: { name: "gamma", arguments: '{"c":3}' },
+      },
+    ],
+  ]);
+
+  assert.deepEqual(
+    parts.map((p) => [p.toolCallId, p.argsText]),
+    [
+      ["tool_call_0", '{"a":1}'],
+      ["tool_call_1", '{"b":2}'],
+      ["call_c", '{"c":3}'],
+    ],
+  );
+});
+
+test("an opening delta after a closed call does not claim it", () => {
+  // The conventional opening delta carries the id and the name with empty
+  // arguments. Landing it on the finished card stamps that card with the id, so
+  // the arguments delta that follows matches and glues on, losing the call the
+  // delta was announcing.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ id: "call_b", index: 0, function: { name: "beta", arguments: "" } }],
+    [{ id: "call_b", index: 0, function: { arguments: '{"b":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["beta", '{"b":2}'],
+  ]);
+  const ids = parts.map((p) => p.toolCallId);
+  assert.equal(ids[1], "call_b");
+  assert.equal(new Set(ids).size, ids.length, `ids collide: ${ids.join(",")}`);
+});
+
+test("a name held for the next call grows across deltas", () => {
+  // OpenAI streams a name as "web" then "_search"; llama-server resends "web"
+  // then "web_search". Last-write-wins opens the call as "_search", which
+  // matches no enabled tool and silently never runs.
+  for (const fragments of [
+    ["web", "_search"],
+    ["web", "web_search"],
+  ]) {
+    const parts = run([
+      [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+      ...fragments.map((name) => [{ index: 0, function: { name } }]),
+      [{ index: 0, function: { arguments: '{"q":"x"}' } }],
+    ]);
+
+    assert.deepEqual(shape(parts), [
+      ["alpha", '{"a":1}'],
+      ["web_search", '{"q":"x"}'],
+    ]);
+  }
+});
+
+test("whitespace carrying the repeated name is not the next call", () => {
+  // A provider that repeats the name on every delta and chunks the trailing
+  // whitespace separately is still writing to the call that closed, so its name
+  // is that call's resent. Parking it merged the two into "alphabeta".
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ index: 0, function: { name: "alpha", arguments: " " } }],
+    [{ index: 0, function: { name: "beta", arguments: '{"b":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1} '],
+    ["beta", '{"b":2}'],
+  ]);
+});
+
+test("metadata announced with a name waits for that call", () => {
+  // Gemini stows the thought signature for the call being announced, so a
+  // name-only delta carrying one describes the next call, not the closed one.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [
+      {
+        index: 0,
+        function: { name: "beta" },
+        extra_content: { google: { thought_signature: "SIG" } },
+      },
+    ],
+    [{ index: 0, function: { arguments: '{"b":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["beta", '{"b":2}'],
+  ]);
+  assert.equal(parts[0].extra_content, undefined);
+  assert.deepEqual(parts[1].extra_content, {
+    google: { thought_signature: "SIG" },
+  });
+});
+
+test("the resumable scan agrees with scanning from the start", () => {
+  // The accumulator resumes the boundary scan instead of restarting it, which
+  // is only safe while the two agree for every string and every set of chunk
+  // boundaries.
+  const pieces = [
+    ..."{}\"\\ abc:,1[]".split(""),
+    '\\"',
+    '"a"',
+    "NaN",
+    "\n",
+    "\r\n",
+    "\t",
+    '{"a":1}',
+    "}{",
+  ];
+  // Deterministic, so a failure names one string rather than a mood.
+  let seed = 20260827;
+  const next = (n: number) => {
+    seed = (seed * 1103515245 + 12345) % 2147483648;
+    return seed % n;
+  };
+  for (let trial = 0; trial < 4000; trial += 1) {
+    let text = "";
+    for (let i = next(17); i > 0; i -= 1) text += pieces[next(pieces.length)];
+    const scan = createBoundaryScan();
+    let cut = 0;
+    let result = scan.feed("");
+    while (cut < text.length) {
+      cut = Math.min(text.length, cut + 1 + next(4));
+      result = scan.feed(text.slice(0, cut));
+    }
+    assert.deepEqual(result, splitTopLevelJsonObjects(text), text);
+  }
+});
+
+test("one argument streamed a character at a time stays linear", () => {
+  // Rescanning the whole accumulation per fragment made a 20 KB argument cost
+  // over a second on the thread that also paints the stream. Timed as a ratio
+  // between two payload sizes rather than against a deadline: what has to hold
+  // is that four times the argument costs four times the work, and a slow or
+  // contended runner moves both measurements together instead of failing.
+  const timeFeed = (size: number): number => {
+    const payload = '{"code":"' + "x".repeat(size) + '"}';
+    const stream = makeStream();
+    stream.feed([{ index: 0, function: { name: "write", arguments: "" } }]);
+    const started = performance.now();
+    for (const ch of payload) {
+      stream.feed([{ index: 0, function: { arguments: ch } }]);
+    }
+    const elapsed = performance.now() - started;
+    assert.deepEqual(shape(stream.parts), [["write", payload]]);
+    return elapsed;
+  };
+  timeFeed(4000);
+  const small = timeFeed(4000);
+  const large = timeFeed(16000);
+  // Linear is 4x and quadratic 16x, so the line between them is 8x.
+  assert.ok(
+    large < small * 8,
+    `four times the payload cost ${(large / small).toFixed(1)}x the time`,
+  );
+});
+
+test("metadata arriving alone stays on the call that closed", () => {
+  // No name, so nothing announces another call: the signature is this card's.
+  // Parking it lost it outright when no further call followed.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ index: 0, extra_content: { google: { thought_signature: "SIG" } } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [["alpha", '{"a":1}']]);
+  assert.deepEqual(parts[0].extra_content, {
+    google: { thought_signature: "SIG" },
+  });
+});
+
+test("a name resent or grown after a call closed invents nothing", () => {
+  // Indistinguishable from a second no-argument call to the same tool, so the
+  // conservative reading is the one that does not run a tool twice. A grown
+  // name is read as the next call announcing itself, since a catalog holding
+  // both "web" and "web_search" makes a shared prefix no evidence either way,
+  // so a provisional card is visible while the turn runs. It brought no
+  // arguments field, so the turn boundary reaps it and nothing is executed.
+  for (const resent of ["alpha", "alpha_long"]) {
+    const stream = makeStream();
+    stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
+    stream.feed([{ index: 0, function: { name: resent } }]);
+    stream.feed([], true);
+    assert.deepEqual(shape(stream.parts), [["alpha", '{"a":1}']]);
+  }
+});
+
+test("an argument fragment that is not a string does not abort the stream", () => {
+  // llama-server has shipped `arguments` as a decoded object rather than the
+  // string the API specifies, and the chunk is cast rather than validated.
+  const parts = run([
+    [
+      {
+        index: 0,
+        function: {
+          name: "alpha",
+          arguments: { a: 1 } as unknown as string,
+        },
+      },
+    ],
+    [{ index: 0, function: { arguments: '{"a":1}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [["alpha", '{"a":1}']]);
+});
+
+test("a fragment that does not open an object does not open a call", () => {
+  // A next call begins with the "{" of its own arguments object. Forking on any
+  // non-whitespace text cut where the scanner deliberately leaves the text
+  // whole, so a stray scalar suffix ran the tool a second time.
+  const parts = run([
+    [{ index: 0, function: { name: "q", arguments: '{"query":"a"}' } }],
+    [{ index: 0, function: { name: "q", arguments: '"b"' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [["q", '{"query":"a"}"b"']]);
+});
+
+test("metadata announced with a name is merged, not replaced", () => {
+  // A signature parked with the name and metadata arriving with the arguments
+  // are different fields of one call, and the replayed turn is rejected
+  // without either.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [
+      {
+        index: 0,
+        function: { name: "beta" },
+        extra_content: { google: { thought_signature: "SIG" } },
+      },
+    ],
+    [
+      {
+        index: 0,
+        function: { arguments: '{"b":2}' },
+        extra_content: { openai: { x: 1 } },
+      },
+    ],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["beta", '{"b":2}'],
+  ]);
+  assert.deepEqual(parts[1].extra_content, {
+    google: { thought_signature: "SIG" },
+    openai: { x: 1 },
+  });
+});
+
+test("an MCP tool that really takes _raw keeps it", () => {
+  // The adapter writes `{ _raw }` holding the exact text it could not parse, so
+  // that pairing is the marker. `_raw` is not reserved, and an MCP server's
+  // schema is its own, so a tool that declares one must still be callable.
+  assert.equal(
+    toolCallReplayArguments('{"url":"a"}{"url":"b"}', {
+      _raw: '{"url":"a"}{"url":"b"}',
+    }),
+    "{}",
+  );
+  assert.equal(
+    toolCallReplayArguments(undefined, { _raw: "a legitimate value" }),
+    '{"_raw":"a legitimate value"}',
+  );
+  assert.equal(
+    toolCallReplayArguments('{"url":"a"}{"url":"b"}', { _raw: 42 }),
+    '{"_raw":42}',
+  );
+});
+
+test("a name waiting for arguments does not cross a turn boundary", () => {
+  // The backend starts the next provider turn on the same response with the
+  // delta index restarted at 0, so a name left over would be prepended to
+  // whatever opens there.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "A", arguments: '{"a":1}' } }]);
+  // The name-only delta rides the same chunk as finish_reason, which is how a
+  // clear placed before the deltas let the name through.
+  stream.feed([{ index: 0, function: { name: "B" } }], true);
+  stream.feed([{ index: 0, function: { name: "C", arguments: '{"c":3}' } }]);
+
+  assert.deepEqual(shape(stream.parts), [
+    ["A", '{"a":1}'],
+    ["C", '{"c":3}'],
+  ]);
+});
+
+test("metadata on several name fragments is merged, not replaced", () => {
+  // The name is accumulated across the fragments, so the metadata they carry
+  // has to be too: replacing drops the signature an earlier fragment brought.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [
+      {
+        index: 0,
+        function: { name: "web" },
+        extra_content: { google: { thought_signature: "SIG" } },
+      },
+    ],
+    [{ index: 0, function: { name: "_search" }, extra_content: { seq: 2 } }],
+    [{ index: 0, function: { arguments: '{"q":1}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["web_search", '{"q":1}'],
+  ]);
+  assert.deepEqual(parts[1].extra_content, {
+    google: { thought_signature: "SIG" },
+    seq: 2,
+  });
+});
+
+test("a resent name does not rename the call it closed", () => {
+  // Concatenating gave "alphabeta", a name the backend never executes, so the
+  // card disagreed with the call that ran. The metadata parked with that name
+  // is the closed call's too, once the name is read as its.
+  const stream = makeStream();
+  stream.feed([
+    {
+      index: 0,
+      function: { name: "alpha", arguments: '{"a":1}' },
+      extra_content: { own: "A" },
+    },
+  ]);
+  stream.feed([
+    { index: 0, function: { name: "alpha_long" }, extra_content: { resent: 1 } },
+  ]);
+  stream.feed([{ index: 0, function: { name: "beta", arguments: '{"b":2}' } }]);
+  stream.feed([], true);
+  const parts = stream.parts;
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["beta", '{"b":2}'],
+  ]);
+  assert.deepEqual(parts[0].extra_content, { own: "A", resent: 1 });
+  assert.equal(parts[1].extra_content, undefined);
+});
+
+test("an id stamped after the object closed claims that call", () => {
+  // A provider that opens id-less and stamps the real id on a later delta.
+  // Reading the id as proof of another call left the finished one under its
+  // provisional id beside an empty second card.
+  for (const late of [
+    { id: "call_a", index: 0 },
+    { id: "call_a", index: 0, function: { name: "alpha" } },
+  ]) {
+    const parts = run([
+      [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+      [late],
+    ]);
+    assert.deepEqual(
+      parts.map((p) => [p.toolCallId, p.toolName, p.argsText]),
+      [["call_a", "alpha", '{"a":1}']],
+    );
+  }
+
+  // An id that names a different call is still the next call opening.
+  const opened = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ id: "call_b", index: 0, function: { name: "beta", arguments: "" } }],
+    [{ id: "call_b", index: 0, function: { arguments: '{"b":2}' } }],
+  ]);
+  assert.deepEqual(shape(opened), [
+    ["alpha", '{"a":1}'],
+    ["beta", '{"b":2}'],
+  ]);
+});
+
+test("a new name arriving with whitespace opens its own call", () => {
+  // A name sharing no prefix with the closed card's is a different tool, so it
+  // opens the next call rather than renaming the finished one, which used to
+  // leave the closed card named "alphabeta" and the new one unnamed. The
+  // whitespace rides the announcing delta, so it lands on the new call's
+  // arguments; leading whitespace is valid JSON, so both still parse.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ index: 0, function: { name: "beta", arguments: " " } }],
+    [{ index: 0, function: { arguments: '{"b":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["beta", ' {"b":2}'],
+  ]);
+});
+
+test("a call announced by name is placed where it was announced", () => {
+  // The backend orders by when a call was announced, so a card appended where
+  // its arguments turned up reads C before B while the backend runs B first.
+  const parts = run([
+    [{ index: 0, function: { name: "A", arguments: '{"a":1}' } }],
+    [{ index: 0, function: { name: "B" } }],
+    [{ index: 1, function: { name: "C", arguments: '{"c":3}' } }],
+    [{ index: 0, function: { arguments: '{"b":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["A", '{"a":1}'],
+    ["B", '{"b":2}'],
+    ["C", '{"c":3}'],
+  ]);
+});
+
+test("a late id claims the last call a bundled delta opened", () => {
+  // A provider that writes several calls in one delta can stamp the last one's
+  // real id in a delta of its own. Marking that card owned sent the id to a
+  // third empty card, while the backend put it on the split call.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}{"b":2}' } }],
+    [{ id: "call_b", index: 0 }],
+  ]);
+
+  assert.deepEqual(
+    parts.map((p) => [p.toolCallId, p.toolName, p.argsText]),
+    [
+      ["tool_call_0", "alpha", '{"a":1}'],
+      ["call_b", "alpha", '{"b":2}'],
+    ],
+  );
+});
+
+test("two calls announced at once keep the order they were announced in", () => {
+  // Both announcements record the same position, so splicing each at that one
+  // mark put the later one first.
+  const parts = run([
+    [{ index: 0, function: { name: "A", arguments: '{"a":1}' } }],
+    [{ index: 1, function: { name: "B", arguments: '{"b":1}' } }],
+    [{ index: 0, function: { name: "C" } }],
+    [{ index: 1, function: { name: "D" } }],
+    [{ index: 0, function: { arguments: '{"c":1}' } }],
+    [{ index: 1, function: { arguments: '{"d":1}' } }],
+  ]);
+
+  assert.deepEqual(
+    parts.map((p) => p.toolName),
+    ["A", "B", "C", "D"],
+  );
+});
+
+test("a rejected resend gives up its place too", () => {
+  // The place goes with the announcement: a name read as the closed call's
+  // resent announced nothing, so the call that opens takes its arrival
+  // position, which is what the backend records for the same stream.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "A", arguments: '{"a":1}' } }]);
+  stream.feed([{ index: 0, function: { name: "A_long" } }]);
+  stream.feed([{ index: 1, function: { name: "C", arguments: '{"c":1}' } }]);
+  stream.feed([{ index: 0, function: { name: "B", arguments: '{"b":1}' } }]);
+  stream.feed([], true);
+  const parts = stream.parts;
+
+  assert.deepEqual(
+    parts.map((p) => p.toolName),
+    ["A", "C", "B"],
+  );
+});
+
+test("a catalog holding both web and web_search splits either way round", () => {
+  // Both names are in Studio's own catalog, and neither order can be read as
+  // one name growing: a shared prefix is no evidence when the tools really are
+  // called that. Reading it as evidence swallowed the second announcement, and
+  // the call it announced never ran.
+  for (const [first, second] of [
+    ["web_search", "web"],
+    ["web", "web_search"],
+  ]) {
+    const stream = makeStream();
+    stream.feed([{ index: 0, function: { name: first, arguments: '{"a":1}' } }]);
+    stream.feed([{ index: 0, function: { name: second } }]);
+    stream.feed([{ index: 0, function: { arguments: '{"b":2}' } }]);
+    stream.feed([], true);
+    assert.deepEqual(shape(stream.parts), [
+      [first, '{"a":1}'],
+      [second, '{"b":2}'],
+    ]);
+  }
+});
+
+test("a name bringing an object over an announcement is the next call", () => {
+  // An announcement holds a card with no arguments, which the closed-object
+  // rule cannot reach, so the next call's name grew into it: "alpha_longbeta"
+  // and "zetabeta" match no tool and silently never ran.
+  for (const announced of ["alpha_long", "zeta"]) {
+    const stream = makeStream();
+    stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
+    stream.feed([{ index: 0, function: { name: announced } }]);
+    stream.feed([{ index: 0, function: { name: "beta", arguments: '{"b":2}' } }]);
+    stream.feed([], true);
+    assert.deepEqual(shape(stream.parts), [
+      ["alpha", '{"a":1}'],
+      ["beta", '{"b":2}'],
+    ]);
+  }
+});
+
+test("a stable id naming a longer tool opens its own call", () => {
+  // A catalog can hold both "web" and "web_search". Reading the second name as
+  // a growth of the first gave the id to the completed card, and the arguments
+  // that followed glued onto it.
+  const parts = run([
+    [{ index: 0, function: { name: "web", arguments: '{"a":1}' } }],
+    [{ id: "call_b", index: 0, function: { name: "web_search", arguments: "" } }],
+    [{ id: "call_b", index: 0, function: { arguments: '{"b":2}' } }],
+  ]);
+
+  assert.deepEqual(
+    parts.map((p) => [p.toolCallId, p.toolName, p.argsText]),
+    [
+      ["tool_call_0", "web", '{"a":1}'],
+      ["call_b", "web_search", '{"b":2}'],
+    ],
+  );
+});
+
+test("a fork whose object never closed is dropped when the turn ends", () => {
+  // A stream that stops after `{"a":1}{` is not marked truncated, so the lone
+  // brace would persist as a card no execution event can complete and replay
+  // would send as `{}`. The backend holds the same fork back in open_tail_keys.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "a", arguments: '{"a":1}{' } }]);
+  assert.deepEqual(shape(stream.parts), [
+    ["a", '{"a":1}'],
+    ["a", "{"],
+  ]);
+  stream.feed([], true);
+  assert.deepEqual(shape(stream.parts), [["a", '{"a":1}']]);
+});
+
+test("a fork that does close its object is kept", () => {
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "a", arguments: '{"a":1}{' } }]);
+  stream.feed([{ index: 0, function: { arguments: '"b":2}' } }]);
+  stream.feed([], true);
+  assert.deepEqual(shape(stream.parts), [
+    ["a", '{"a":1}'],
+    ["a", '{"b":2}'],
+  ]);
+});
+
+test("metadata from a resent name goes to the call that runs", () => {
+  // "alpha_long" at a closed slot reads as "alpha" grown, so no second call is
+  // invented for it and _announced_but_unopened hangs the signature on the held
+  // call. Queued under the fragment it would never be read: the tool_start that
+  // follows is named "alpha", and the card would replay without it.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
+  stream.feed([
+    { index: 0, function: { name: "alpha_long" }, extra_content: { sig: "s" } },
+  ]);
+  stream.feed([], true);
+
+  assert.deepEqual(shape(stream.parts), [["alpha", '{"a":1}']]);
+  assert.deepEqual(stream.parts[0].extra_content, { sig: "s" });
+});
+
+test("a provider-hosted tool event does not end the provider turn", () => {
+  // The backend records those with note_hosted_tool_event and leaves its _Turn
+  // open, so an argument-only delta after one still opens the parked name.
+  // Hosted events ride a whole chunk, `choices` and all; Unsloth's own tool
+  // frames arrive as a bare {"type": "tool_start"} that chat-api wraps alone.
+  const guarded = liftBetween(
+    "the hosted-event guard",
+    "const toolEvent = (",
+    "// Deep Research is an ordinary tool",
+  );
+  assert.match(guarded, /if \(!chunk\.choices\) \{\s*endProviderTurn\(\);/);
+});
+
+test("a late id does not rescue a fork whose object never closed", () => {
+  // _call_is_finished holds the fork back on its arguments alone, so a card
+  // kept because an id reached it is one no tool_start or tool_end can reach.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "a", arguments: '{}{"x":' } }]);
+  stream.feed([{ id: "call_z", index: 0, function: { arguments: "" } }]);
+  assert.deepEqual(
+    stream.parts.map((p) => [p.toolCallId, p.argsText]),
+    [
+      ["tool_call_0", "{}"],
+      ["call_z", '{"x":'],
+    ],
+  );
+  stream.feed([], true);
+  assert.deepEqual(shape(stream.parts), [["a", "{}"]]);
+});
+
+test("only the announced call takes the place reserved for it", () => {
+  // B was announced before C opened, so B goes ahead of C. The calls B's
+  // arguments introduce were never announced: _fork_glued_arguments numbers
+  // them as the arguments arrive, which is after C.
+  const parts = run([
+    [{ index: 0, function: { name: "A", arguments: '{"a":1}' } }],
+    [{ index: 0, function: { name: "B" } }],
+    [{ index: 1, function: { name: "C", arguments: '{"c":1}' } }],
+    [{ index: 0, function: { arguments: '{"b":1}{"b2":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["A", '{"a":1}'],
+    ["B", '{"b":1}'],
+    ["C", '{"c":1}'],
+    ["B", '{"b2":2}'],
+  ]);
+});
+
+test("the empty status between rounds ends the provider turn", () => {
+  // A round whose calls were all rejected as disabled emits no tool_start or
+  // tool_end, and an upstream ending its turns with [DONE] sends no
+  // finish_reason, so the empty tool_status is the only boundary there is.
+  const branch = liftBetween(
+    "the tool_status branch",
+    "const toolStatusText = (",
+    "if (chunk.context_truncated) {",
+  );
+  assert.match(branch, /if \(!toolStatusText\) \{\s*endProviderTurn\(\);/);
+});
+
+test("the announced call keeps its own metadata when its delta splits", () => {
+  // The signature parked with the announcement is B's; the one riding the
+  // arguments belongs to the call that delta closes, which is the last of
+  // them. _take_parked and _fork_glued_arguments divide them the same way.
+  const parts = run([
+    [{ index: 0, function: { name: "A", arguments: '{"a":1}' } }],
+    [{ index: 0, function: { name: "B" }, extra_content: { sig: "parked" } }],
+    [
+      {
+        index: 0,
+        function: { arguments: '{"b":1}{"b2":2}' },
+        extra_content: { sig: "incoming" },
+      },
+    ],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["A", '{"a":1}'],
+    ["B", '{"b":1}'],
+    ["B", '{"b2":2}'],
+  ]);
+  assert.deepEqual(parts[1].extra_content, { sig: "parked" });
+  assert.deepEqual(parts[2].extra_content, { sig: "incoming" });
+});
+
+test("a second call to the same tool keeps that tool's name", () => {
+  // The provider gave the name once and reused the index for the next call
+  // with arguments alone. A blank name is no tool: _normalized_call drops the
+  // call on the backend and the card here would name nothing.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ index: 0, function: { arguments: '{"a":2}' } }],
+  ]);
+
+  assert.deepEqual(shape(parts), [
+    ["alpha", '{"a":1}'],
+    ["alpha", '{"a":2}'],
+  ]);
+});
+
+test("a snapshot repeated to carry the id claims the call", () => {
+  // Snapshot-style servers resend the whole call rather than fragments of it,
+  // so the id arrives on a verbatim repeat. Opening a second call there runs a
+  // side-effecting tool twice.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ id: "call_a", index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+  ]);
+
+  assert.deepEqual(
+    parts.map((p) => [p.toolCallId, p.toolName, p.argsText]),
+    [["call_a", "alpha", '{"a":1}']],
+  );
+});
+
+test("a second call that differs anywhere still opens its own", () => {
+  // The claim above is an exact repeat only, so genuine parallel calls with
+  // ids of their own are not collapsed into one.
+  const parts = run([
+    [{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }],
+    [{ id: "call_b", index: 0, function: { name: "alpha", arguments: '{"a":2}' } }],
+  ]);
+
+  assert.deepEqual(
+    parts.map((p) => [p.toolCallId, p.argsText]),
+    [
+      ["tool_call_0", '{"a":1}'],
+      ["call_b", '{"a":2}'],
+    ],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// E. The card the deltas drew
+// ---------------------------------------------------------------------------
+
+test("an id-less card answers to the id the backend mints for it", () => {
+  // The backend mints tool_call_<n> for a call the provider gave no id to and
+  // addresses tool_start and tool_end there. Without the binding,
+  // resolveToolPartId mints "<id>:<uuid>", tool_start finds no card under that
+  // and pushes one, and #9807's four calls end the turn holding eight cards.
+  const stream = makeStream(true);
+  for (const url of ["a", "b", "c", "d"]) {
+    stream.feed([{ index: 0, function: { name: "fetch", arguments: `{"url":"${url}"}` } }]);
+  }
+
+  assert.deepEqual(
+    stream.parts.map((p) => p.toolCallId),
+    ["tool_call_0", "tool_call_1", "tool_call_2", "tool_call_3"],
+  );
+
+  const painted = stream.parts.length;
+  for (const backendId of ["tool_call_0", "tool_call_1", "tool_call_2", "tool_call_3"]) {
+    const partId = stream.resolveToolPartId(backendId);
+    assert.equal(partId, backendId, `${backendId} did not resolve to its own card`);
+    assert.ok(
+      stream.parts.some((p) => p.toolCallId === partId),
+      `${backendId} found no card to update`,
+    );
+  }
+  assert.equal(stream.parts.length, painted, "a backend event opened a second card");
+});
+
+test("a call the provider named still resolves through the minted part id", () => {
+  // Unchanged for every stream that carries ids: the card is keyed on the
+  // run-unique "<id>:<uuid>" the resolver mints, exactly as before.
+  const stream = makeStream(true);
+  stream.feed([{ id: "call_a", index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
+
+  const partId = stream.resolveToolPartId("call_a");
+  assert.match(partId, /^call_a:uuid-\d+$/);
+  assert.deepEqual(
+    stream.parts.map((p) => p.toolCallId),
+    [partId],
+  );
+});
+
+test("a provider id spelled tool_call_0 keeps its own card", () => {
+  // tool_call_<n> is not reserved to Unsloth. A provider using that spelling
+  // must not have the card taken from it by the id-less call beside it.
+  const stream = makeStream(true);
+  stream.feed([
+    { id: "tool_call_0", index: 0, function: { name: "alpha", arguments: '{"a":1}' } },
+  ]);
+  stream.feed([{ index: 1, function: { name: "beta", arguments: '{"b":2}' } }]);
+
+  const ids = stream.parts.map((p) => p.toolCallId);
+  assert.equal(new Set(ids).size, ids.length, "two cards share one id");
+  assert.ok(!ids.includes("tool_call_0"), "the minted id took the provider's spelling");
+});
+
+test("several calls opened by one delta each get their own card id", () => {
+  // A slot can arrive already holding several calls in one fragment. The cards
+  // are minted before any of them joins the parts array, so the ids have to be
+  // reserved as they are handed out or all three collide.
+  const stream = makeStream(true);
+  stream.feed([
+    { index: 0, function: { name: "fetch", arguments: '{"a":1}{"b":2}{"c":3}' } },
+  ]);
+
+  const ids = stream.parts.map((p) => p.toolCallId);
+  assert.deepEqual(ids, ["tool_call_0", "tool_call_1", "tool_call_2"]);
+  assert.equal(new Set(ids).size, 3);
+});
+
+// ---------------------------------------------------------------------------
+// F. Legacy threads whose marker lost its argument text
+// ---------------------------------------------------------------------------
+
+test("the marker is recognised even with no argument text beside it", () => {
+  // Threads written before argsText was kept, and threads rebuilt by the
+  // importer, carry { _raw } with nothing to compare it to. Replaying it sends
+  // a parameter no tool declares and the provider rejects the whole request.
+  const glued = '{"url":"https://example.com/1"}{"query":"search"}';
+  assert.equal(toolCallReplayArguments(undefined, { _raw: glued }), "{}");
+  assert.equal(toolCallReplayArguments("", { _raw: glued }), "{}");
+});
+
+test("a tool that really takes a _raw parameter keeps it either way", () => {
+  // _raw is not reserved and an MCP server's schema is its own. Held text that
+  // is not a run of whole JSON objects is an argument, not the corruption.
+  assert.equal(
+    toolCallReplayArguments('{"_raw":"hello"}', { _raw: "hello" }),
+    '{"_raw":"hello"}',
+  );
+  assert.equal(
+    toolCallReplayArguments(undefined, { _raw: "hello" }),
+    '{"_raw":"hello"}',
+  );
+  assert.equal(
+    toolCallReplayArguments(undefined, { _raw: '{"one":1}' }),
+    '{"_raw":"{\\"one\\":1}"}',
+  );
+});

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -640,12 +640,10 @@ test("the resumable scan agrees with scanning from the start", () => {
 
 test("one argument streamed a character at a time is scanned once", () => {
   // Rescanning per fragment made a 20 KB argument cost over a second on the
-  // thread that paints the stream. Counted, not timed: the scan parses a
-  // segment when it closes one, so a resumable scan parses once per object
-  // however many deltas it arrived in, and a restarting one parses every
-  // object again on every delta after it closed. A wall-clock ratio said the
-  // same thing with about 25 percent of margin, which is not enough on a
-  // loaded runner.
+  // thread that paints the stream. Counted, not timed: a resumable scan
+  // parses once per object however many deltas it arrived in, a restarting
+  // one parses every closed object again on every delta. A wall-clock ratio
+  // agreed, with too little margin for a loaded runner.
   const parses = (size: number, feed: (text: string) => unknown): number => {
     const real = JSON.parse;
     let calls = 0;
@@ -710,10 +708,9 @@ test("metadata arriving alone stays on the call that closed", () => {
 });
 
 test("a name resent or grown after a call closed invents nothing", () => {
-  // Indistinguishable from a second no-argument call to the same tool, so take
-  // the reading that does not run a tool twice. A grown name announces the next
-  // call (the prefix is no evidence), so a provisional card is visible while
-  // the turn runs and the boundary reaps it unfilled.
+  // Indistinguishable from a second no-argument call to the same tool, so
+  // take the reading that does not run a tool twice. A grown name announces
+  // the next call, so its provisional card is reaped unfilled at the boundary.
   for (const resent of ["alpha", "alpha_long"]) {
     const stream = makeStream();
     stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
@@ -1068,12 +1065,10 @@ test("a card taking a late provider id gives its minted id back", () => {
 });
 
 test("a claim on a split-born card renumbers every minted card", () => {
-  // A split marks every born card but the last _has_stable_id, to keep a late
-  // id off the calls already spoken for, so reading that as provider-owned let
-  // the claim merge into one: "alphabeta" with the arguments glued. The
-  // backend reserves the claim and then numbers the id-less calls in order, so
-  // matching it means renumbering all of them, not just the one displaced;
-  // otherwise its tool_start for the second call reaches the third's card.
+  // A split marks every born card but the last _has_stable_id, so reading
+  // that as provider-owned let the claim merge them: "alphabeta", arguments
+  // glued. The backend reserves the claim then numbers the id-less calls in
+  // order, so matching it means renumbering all of them.
   const stream = makeStream();
   stream.feed([
     { index: 0, function: { name: "alpha", arguments: '{"a":1}{"b":2}{"c":3}' } },
@@ -1144,11 +1139,10 @@ test("a claim in a later round leaves an earlier round's card alone", () => {
 });
 
 test("a dropped card gives back the provider id that aliased it", () => {
-  // A card that took a late provider id answers to a run-unique part id, so
-  // the id the provider sent is a second key pointing at it. Releasing only
-  // the part id left tool_call_1 reserved, and the next round minted
-  // tool_call_2 where the backend, which filters the unfinished call and never
-  // reserved it, minted tool_call_1.
+  // A card that took a late id answers to a run-unique part id, so the id the
+  // provider sent is a second key pointing at it. Releasing only the part id
+  // left tool_call_1 reserved, and the next round minted tool_call_2 where
+  // the backend minted tool_call_1.
   const stream = makeStream(true);
   stream.feed([{ index: 0, function: { name: "alpha", arguments: '{}{"x":' } }]);
   stream.feed([{ id: "tool_call_1", index: 0, function: { arguments: "" } }]);
@@ -1199,11 +1193,10 @@ test("a claim that turns out not to be a call gives the number back", () => {
 });
 
 test("a repeated name's metadata waits for the call it announced", () => {
-  // The same tool twice on one slot, the second announced by a name-only delta
-  // carrying its own signature. Merging it where it landed both overwrote the
-  // closed call's signature and left the new call unsigned, and Gemini
-  // validates a signature against the call it is replayed on, so the turn was
-  // rejected either way round.
+  // The same tool twice on one slot, the second announced by a name-only
+  // delta carrying its own signature. Merging it where it landed overwrote
+  // the closed call's and left the new one unsigned, and Gemini validates a
+  // signature against the call it is replayed on.
   const stream = makeStream();
   stream.feed([
     {
@@ -1247,10 +1240,8 @@ test("a repeated name that announced nothing keeps its metadata", () => {
 });
 
 test("parked metadata follows the card a late id renames", () => {
-  // The signature waits under the id the card was minted with; the late claim
-  // moves the card, so the entry has to move with it or the turn-end sweep
-  // looks for a part id nothing answers to and drops the signature the
-  // backend keeps.
+  // The signature waits under the id the card was minted with, so it has to
+  // move with the card or the turn-end sweep drops what the backend keeps.
   const stream = makeStream(true);
   stream.feed([
     {
@@ -1544,9 +1535,8 @@ test("several calls opened by one delta each get their own card id", () => {
 
 test("the marker is only recognised by the text that proves it", () => {
   // Threads written before argsText was kept carry { _raw } with nothing to
-  // compare it to. Reading the value's shape instead would discard the argument
-  // of a tool that really takes a _raw parameter, and nothing is gained: the
-  // wrapped form is one JSON object, so it raises no Extra data.
+  // compare against. Reading the value's shape instead would discard a real
+  // _raw argument and gain nothing: the wrapped form raises no Extra data.
   const glued = '{"url":"https://example.com/1"}{"query":"search"}';
   assert.equal(toolCallReplayArguments(glued, { _raw: glued }), "{}");
   assert.equal(
@@ -1560,10 +1550,8 @@ test("the marker is only recognised by the text that proves it", () => {
 });
 
 test("an empty _raw is an argument, not the marker", () => {
-  // The adapter only writes the marker for text it tried to parse, and both
-  // writers are guarded on non-empty text, so `{ _raw: "" }` beside an empty
-  // argsText is a value a tool was really given. Equality alone read it as the
-  // marker and replayed {}.
+  // Both writers are guarded on non-empty text, so `{ _raw: "" }` beside an
+  // empty argsText is a real argument. Equality alone read it as the marker.
   assert.equal(toolCallReplayArguments("", { _raw: "" }), '{"_raw":""}');
   assert.equal(toolCallReplayArguments(undefined, { _raw: "" }), '{"_raw":""}');
 });

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -1246,6 +1246,56 @@ test("a repeated name that announced nothing keeps its metadata", () => {
   assert.deepEqual(stream.parts[0].extra_content, { own: 1, sig: "B" });
 });
 
+test("parked metadata follows the card a late id renames", () => {
+  // The signature waits under the id the card was minted with; the late claim
+  // moves the card, so the entry has to move with it or the turn-end sweep
+  // looks for a part id nothing answers to and drops the signature the
+  // backend keeps.
+  const stream = makeStream(true);
+  stream.feed([
+    {
+      index: 0,
+      function: { name: "lookup", arguments: '{"q":"a"}' },
+      extra_content: { sig: "A" },
+    },
+  ]);
+  stream.feed([
+    { index: 0, function: { name: "lookup" }, extra_content: { sig: "B" } },
+  ]);
+  stream.feed([{ index: 0, id: "call_x", function: { arguments: "" } }], true);
+
+  assert.deepEqual(shape(stream.parts), [["lookup", '{"q":"a"}']]);
+  assert.deepEqual(stream.parts[0].extra_content, { sig: "B" });
+  assert.equal(stream.parts[0].toolCallId, "call_x:uuid-1");
+});
+
+test("parked metadata follows the card a claim renumbers", () => {
+  // Same entry, other mover: a provider claiming the spelling a minted card
+  // holds renumbers every minted card in the round.
+  const stream = makeStream(true);
+  stream.feed([
+    {
+      index: 0,
+      function: { name: "lookup", arguments: '{"q":"a"}' },
+      extra_content: { sig: "A" },
+    },
+  ]);
+  stream.feed([
+    { index: 0, function: { name: "lookup" }, extra_content: { sig: "B" } },
+  ]);
+  stream.feed(
+    [{ index: 1, id: "tool_call_0", function: { name: "beta", arguments: '{"b":2}' } }],
+    true,
+  );
+
+  assert.deepEqual(shape(stream.parts), [
+    ["lookup", '{"q":"a"}'],
+    ["beta", '{"b":2}'],
+  ]);
+  assert.deepEqual(stream.parts[0].extra_content, { sig: "B" });
+  assert.equal(stream.parts[1].extra_content, undefined);
+});
+
 test("a stable id naming a longer tool opens its own call", () => {
   // Reading "web_search" as "web" grown gave the id to the completed card.
   const parts = run([

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -221,6 +221,7 @@ function makeStream(mintPartIds = false): {
   feed: (batch: DeltaCall[], finished?: boolean) => boolean;
   parts: LoopPart[];
   resolveToolPartId: (backendId: string) => string;
+  endRound: () => void;
 } {
   const body = `
     const toolCallParts = [];
@@ -250,7 +251,15 @@ function makeStream(mintPartIds = false): {
       ${liftDeltaLoop()}
       return addedToolCall;
     }
-    return { feed, parts: toolCallParts, resolveToolPartId };
+    // Production drops a backend id's binding on tool_end, so an id the
+    // provider reuses in a later round reaches a card of its own. That branch
+    // is outside the lifted loop, so a test that spans rounds does it here.
+    const endRound = () => {
+      for (const part of toolCallParts) {
+        toolPartIdByBackendId.delete(part.toolCallId);
+      }
+    };
+    return { feed, parts: toolCallParts, resolveToolPartId, endRound };
   `;
   const js = ts.transpileModule(`const mintPartIds = ${mintPartIds};` + body, {
     compilerOptions: { target: ts.ScriptTarget.ES2022 },
@@ -274,6 +283,7 @@ function makeStream(mintPartIds = false): {
     feed: (batch: DeltaCall[], finished?: boolean) => boolean;
     parts: LoopPart[];
     resolveToolPartId: (backendId: string) => string;
+    endRound: () => void;
   };
 }
 
@@ -1075,6 +1085,71 @@ test("a born call carries only the metadata of the delta that opened it", () => 
   assert.deepEqual(stream.parts[1].extra_content, { delta: 2 });
 });
 
+test("a claim in a later round leaves an earlier round's card alone", () => {
+  // The backend's card ledger is append-only, so a card from a finished round
+  // keeps its number however a later round spells its ids. Renumbering it put
+  // the two sides one apart from the third round on, and the backend's events
+  // for the renamed card reached whatever had taken its old id.
+  const stream = makeStream(true);
+  stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
+  stream.feed([], true);
+  stream.endRound();
+  stream.feed([
+    { id: "tool_call_0", index: 0, function: { name: "beta", arguments: '{"b":2}' } },
+  ]);
+  stream.feed([], true);
+  stream.endRound();
+  stream.feed([{ index: 0, function: { name: "gamma", arguments: '{"c":3}' } }]);
+
+  assert.deepEqual(
+    stream.parts.map((p) => [p.toolCallId, p.toolName]),
+    [
+      ["tool_call_0", "alpha"],
+      ["tool_call_0:uuid-1", "beta"],
+      ["tool_call_1", "gamma"],
+    ],
+  );
+});
+
+test("a dropped card gives back the provider id that aliased it", () => {
+  // A card that took a late provider id answers to a run-unique part id, so
+  // the id the provider sent is a second key pointing at it. Releasing only
+  // the part id left tool_call_1 reserved, and the next round minted
+  // tool_call_2 where the backend, which filters the unfinished call and never
+  // reserved it, minted tool_call_1.
+  const stream = makeStream(true);
+  stream.feed([{ index: 0, function: { name: "alpha", arguments: '{}{"x":' } }]);
+  stream.feed([{ id: "tool_call_1", index: 0, function: { arguments: "" } }]);
+  stream.feed([], true);
+  stream.endRound();
+  stream.feed([{ index: 0, function: { name: "beta", arguments: '{"b":2}' } }]);
+
+  assert.deepEqual(
+    stream.parts.map((p) => [p.toolCallId, p.toolName]),
+    [
+      ["tool_call_0", "alpha"],
+      ["tool_call_1", "beta"],
+    ],
+  );
+});
+
+test("a card that never got a name is dropped when the turn ends", () => {
+  // _normalized_call rejects a nameless call before it reserves a card id, so
+  // a card kept for one holds a number the backend gives the next round, and
+  // that round's events land on the blank card instead.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { arguments: '{"a":1}' } }]);
+  assert.equal(stream.parts.length, 1);
+  stream.feed([], true);
+  assert.deepEqual(stream.parts, []);
+
+  stream.feed([{ index: 0, function: { name: "beta", arguments: '{"b":2}' } }]);
+  assert.deepEqual(
+    stream.parts.map((p) => [p.toolCallId, p.toolName]),
+    [["tool_call_0", "beta"]],
+  );
+});
+
 test("a stable id naming a longer tool opens its own call", () => {
   // Reading "web_search" as "web" grown gave the id to the completed card.
   const parts = run([
@@ -1336,6 +1411,15 @@ test("the marker is only recognised by the text that proves it", () => {
     toolCallReplayArguments("", { _raw: glued }),
     JSON.stringify({ _raw: glued }),
   );
+});
+
+test("an empty _raw is an argument, not the marker", () => {
+  // The adapter only writes the marker for text it tried to parse, and both
+  // writers are guarded on non-empty text, so `{ _raw: "" }` beside an empty
+  // argsText is a value a tool was really given. Equality alone read it as the
+  // marker and replayed {}.
+  assert.equal(toolCallReplayArguments("", { _raw: "" }), '{"_raw":""}');
+  assert.equal(toolCallReplayArguments(undefined, { _raw: "" }), '{"_raw":""}');
 });
 
 test("a tool that really takes a _raw parameter keeps it either way", () => {

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -1141,7 +1141,7 @@ test("a card that never got a name is dropped when the turn ends", () => {
   stream.feed([{ index: 0, function: { arguments: '{"a":1}' } }]);
   assert.equal(stream.parts.length, 1);
   stream.feed([], true);
-  assert.deepEqual(stream.parts, []);
+  assert.equal(stream.parts.length, 0);
 
   stream.feed([{ index: 0, function: { name: "beta", arguments: '{"b":2}' } }]);
   assert.deepEqual(

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -1007,6 +1007,50 @@ test("a provider claiming a minted id displaces the card holding it", () => {
   );
 });
 
+test("a card taking a late provider id gives its minted id back", () => {
+  // The backend never reserves a minted id for a call the provider went on to
+  // name, so holding it made the next call at that index mint tool_call_1
+  // against the backend's tool_call_0.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
+  stream.feed([{ id: "call_a", index: 0, function: { arguments: "" } }]);
+  stream.feed([{ index: 0, function: { name: "beta", arguments: '{"b":2}' } }]);
+
+  assert.deepEqual(
+    stream.parts.map((p) => [p.toolCallId, p.toolName]),
+    [
+      ["call_a", "alpha"],
+      ["tool_call_0", "beta"],
+    ],
+  );
+});
+
+test("a claim on a split-born card renumbers every minted card", () => {
+  // A split marks every born card but the last _has_stable_id, to keep a late
+  // id off the calls already spoken for, so reading that as provider-owned let
+  // the claim merge into one: "alphabeta" with the arguments glued. The
+  // backend reserves the claim and then numbers the id-less calls in order, so
+  // matching it means renumbering all of them, not just the one displaced;
+  // otherwise its tool_start for the second call reaches the third's card.
+  const stream = makeStream();
+  stream.feed([
+    { index: 0, function: { name: "alpha", arguments: '{"a":1}{"b":2}{"c":3}' } },
+  ]);
+  stream.feed([
+    { id: "tool_call_1", index: 1, function: { name: "beta", arguments: '{"d":4}' } },
+  ]);
+
+  assert.deepEqual(
+    stream.parts.map((p) => [p.toolCallId, p.toolName, p.argsText]),
+    [
+      ["tool_call_0", "alpha", '{"a":1}'],
+      ["tool_call_2", "alpha", '{"b":2}'],
+      ["tool_call_3", "alpha", '{"c":3}'],
+      ["tool_call_1", "beta", '{"d":4}'],
+    ],
+  );
+});
+
 test("a born call carries only the metadata of the delta that opened it", () => {
   // The merged fields belong to the call the slot was holding; carried onto a
   // born call they put one call's signature on another, and Gemini validates a

--- a/studio/frontend/tests/parallel-tool-call-arguments.test.ts
+++ b/studio/frontend/tests/parallel-tool-call-arguments.test.ts
@@ -1150,6 +1150,22 @@ test("a card that never got a name is dropped when the turn ends", () => {
   );
 });
 
+test("a claim that turns out not to be a call gives the number back", () => {
+  // The displacement happens as the claim lands, but a nameless call is not a
+  // call: the backend reserves nothing for it and keeps tool_call_0 for the
+  // valid one, so a card left at tool_call_1 is one its execution events miss.
+  const stream = makeStream();
+  stream.feed([{ index: 0, function: { name: "alpha", arguments: '{"a":1}' } }]);
+  stream.feed([{ id: "tool_call_0", index: 1, function: { arguments: '{"b":2}' } }]);
+  assert.equal(stream.parts.length, 2);
+  stream.feed([], true);
+
+  assert.deepEqual(
+    stream.parts.map((p) => [p.toolCallId, p.toolName]),
+    [["tool_call_0", "alpha"]],
+  );
+});
+
 test("a stable id naming a longer tool opens its own call", () => {
   // Reading "web_search" as "web" grown gave the id to the completed card.
   const parts = run([

--- a/studio/frontend/tests/tool-call-delta-index.test.ts
+++ b/studio/frontend/tests/tool-call-delta-index.test.ts
@@ -150,11 +150,15 @@ test("replayed arguments keep parsable text and fall back otherwise", () => {
     toolCallReplayArguments('{"query":"first"}', { query: "first" }),
     '{"query":"first"}',
   );
+  // Two calls glued into one slot. The stream adapter no longer produces this
+  // (see tests/parallel-tool-call-arguments.test.ts), but threads stored before
+  // it split them still hold it, and `_raw` is the adapter's own marker rather
+  // than a parameter any tool declares, so it must not go back on the wire.
   assert.equal(
     toolCallReplayArguments('{"query":"first"}{"query":"second"}', {
       _raw: '{"query":"first"}{"query":"second"}',
     }),
-    '{"_raw":"{\\"query\\":\\"first\\"}{\\"query\\":\\"second\\"}"}',
+    "{}",
   );
   assert.equal(
     toolCallReplayArguments("", { query: "first" }),


### PR DESCRIPTION
## What

Fixes #9807. A server that streams parallel tool calls as id-less, index-based deltas reuses one slot for several calls. Both accumulators appended their argument JSON into one string, so the four calls in the report became one unparseable `{"url":"a"}{"url":"b"}...`, the three tool names became `web_fetchweb_searchweb_fetch` which matches no enabled tool and silently never runs, and the blob was persisted and replayed on every later turn until the provider answered `Extra data: line 1 column 51 (char 50)`. The thread stays unusable until the user starts a new chat.

That stream shape is not hypothetical: LiteLLM's Responses bridge emits every parallel call on `index=0` ([BerriAI/litellm#21331](https://github.com/BerriAI/litellm/issues/21331)) and several vLLM tool parsers omit the streamed `id` ([vllm-project/vllm#18412](https://github.com/vllm-project/vllm/issues/18412)).

This is #9817 rebuilt as one commit on current `main`. #9817 carried the same change over 29 commits, which is too much history to review; the trees are identical. It also supersedes #9909 and #9983, which fixed the same issue; the card-id design here is #9983's, and both are credited on their own threads.

## How

**The boundary is the end of a top-level JSON object, not a change of function name** — the reported stream calls the same tool three times, so there is no name change to cut on. `splitTopLevelJsonObjects` (frontend) and `_split_top_level_json_objects` (backend) are a string- and escape-aware brace scan, resumable so an argument arriving in N fragments costs one pass rather than N. Text that is not a run of whole objects (top-level array or scalar, trailing junk, unbalanced brace, balanced but invalid JSON) comes back untouched, and the split runs only for a delta with no id, so streams that carry ids are byte-identical.

**The two halves have to agree**, or the backend runs a tool the card never shows. `json.loads` accepts `NaN` and `Infinity` where `JSON.parse` does not, and rejects integers past CPython's 4300-digit conversion cap where `JSON.parse` has no cap, so the Python scanner passes `parse_constant` and `parse_int = str`.

**Cards.** A call with no provider id has its card drawn by the delta, under an id the client mints. The backend mints the same spelling from the same deltas, the slot's own `tool_call_<index>` then the lowest free `tool_call_<n>`, with provider ids reserved, and addresses `tool_start`/`tool_end` there. The card id rides beside the conversation id and never replaces it: what is stored and replayed upstream is still `call_<round>_<position>`.

**Replay** requires a single JSON object and recognises the adapter's own `{ _raw }` marker whether or not the argument text survived beside it, so a thread already poisoned by this replays `{}` rather than a blob no tool declares. A tool that genuinely takes a `_raw` parameter keeps it.

## Reproduced, then fixed

The 400 lands on the turn *after* the one that streamed the calls, so that is where it is measured: the calls the accumulator produces, serialised the way the loop stores them, with every historical `function.arguments` parsed strictly the way a generic OpenAI-compatible provider parses it.

```
merge base  1 call   name web_fetchweb_searchweb_fetch
                     Extra data: line 1 column 32 (char 31)
this branch 4 calls  web_fetch, web_fetch, web_search, web_fetch   0 rejected
```

## Verification

995 argument strings (digest `8099a8ad209e596b`) and 26 delta streams, run against this branch and its merge base.

| | merge base | this branch |
|---|---|---|
| #9807 stream | 1 glued call | 4 clean calls |
| cards for those 4 calls | 2 for 1 call | 4 |
| stored shapes replaying a single JSON object | 9 of 13 | 13 of 13 |
| scanner contract, 995 cases | no scanner | 995 |
| frontend vs backend split disagreements | n/a | 0 |

Controls unchanged: stable ids at distinct indices, an id-less call fragmented across deltas, a late id claiming its own call, empty arguments, one delta per character. A stable-id delta whose arguments happen to hold two documents stays **one** call, because that is one malformed provider call and splitting it would run a tool the model never asked for.

Scanner cost, characters examined for one argument delivered a character at a time, at 1000 through 16000 characters: `1.0 1.0 1.0 1.0 1.0` times the argument length, on both a plain and a delimiter-heavy payload.

The scanner is pure string and JSON work, so the engine is the only axis that can disagree. The production module over the whole corpus:

| engine | version | result digest | errors |
|---|---|---|---|
| Chromium (Chrome, Edge) | 151.0.7922.34 | `d22f61dbafeb` | 0 |
| Firefox | 153.0 | `d22f61dbafeb` | 0 |
| WebKit (Safari) | 26.5 | `d22f61dbafeb` | 0 |

Identical, and identical again to node, 2985 comparisons with 0 mismatches. That is evidence about the three engines, not a claim about every shipping Safari build.

Gates on this head: frontend 6124 pass 0 fail, typecheck clean, build clean, bundle within budget; backend 682 pass 0 fail over the tool-loop, controller, exception-contract, stream-abuse, id-replay, llama.cpp and safetensors suites. `eslint` on the changed files reports the same pre-existing errors it reports on `main` and adds none.

Not run by me: Windows and macOS, which come from this repo's own matrix on this branch. No live vLLM or LiteLLM endpoint was involved; the reporter's stream is replayed from the issue verbatim.

## Compatibility

No schema change, no migration, no persisted field removed or renamed. A legacy part holding `args: {_raw: ...}` still loads, renders, searches and exports; a thread written by this build is ordinary tool-call parts an older bundle reads. Minted ids carry no colon and satisfy the Anthropic and Mistral id rules through the existing remapper.

## Known limits, on purpose

`name:"web"` with arguments, then `name:"_search"`, opens a second call named `_search`. A name suffix arriving after the arguments closed is indistinguishable on the wire from the next call announcing itself, so that needs a provider-dialect rule rather than a boundary rule.

Adjacent top-level arrays stay one call. `function.arguments` is specified as an object, and cutting on a shape no tool schema accepts would invent calls that cannot run either way.
