### PR TITLE
Reuse the MLX prompt cache on hybrid recurrent models

### DIFF
--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -1018,11 +1018,20 @@ def _flatten_kv_entries(cache):
 
 
 def _kv_prefix_coverage(cache):
+    """Tokens the whole cache holds, or None when no entry can attest to it.
+
+    Hybrid models interleave recurrent layers with attention layers, and a
+    recurrent entry carries no offset because it holds a fixed-size state
+    rather than a token sequence. Every layer still consumes every token, so an
+    attention sibling's offset counts for the recurrent entries beside it. When
+    nothing carries an offset the cache stays unverifiable, which is what keeps
+    purely recurrent models out: their state cannot say how far it advanced.
+    """
     covered = None
     for entry in _flatten_kv_entries(cache):
         offset = getattr(entry, "offset", None)
         if offset is None:
-            return None
+            continue
         if getattr(entry, "start_position", 0):
             return None
         window = getattr(entry, "max_size", None)

--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -1017,11 +1017,6 @@ def _flatten_kv_entries(cache):
             yield from _flatten_kv_entries(nested)
 
 
-def _kv_entry_not_trimmable():
-    """Default for an entry that does not implement ``is_trimmable``."""
-    return False
-
-
 def _kv_prefix_coverage(cache):
     """Tokens the whole cache holds, or None when no entry can attest to it.
 
@@ -1037,11 +1032,9 @@ def _kv_prefix_coverage(cache):
     for entry in _flatten_kv_entries(cache):
         offset = getattr(entry, "offset", None)
         if offset is None:
-            # Upstream shortens a stored cache to a prefix as soon as every
-            # entry reports it can be trimmed. An opaque state cannot honour
-            # that, so one claiming it can is not something a sibling's offset
-            # is in any position to vouch for.
-            if getattr(entry, "is_trimmable", _kv_entry_not_trimmable)():
+            # Upstream trims a stored cache to a prefix once every entry says it
+            # can be. A sibling's offset only attests for state that cannot be.
+            if getattr(entry, "is_trimmable", lambda: False)():
                 return None
             continue
         if getattr(entry, "start_position", 0):

--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -1017,20 +1017,32 @@ def _flatten_kv_entries(cache):
             yield from _flatten_kv_entries(nested)
 
 
+def _kv_entry_not_trimmable():
+    """Default for an entry that does not implement ``is_trimmable``."""
+    return False
+
+
 def _kv_prefix_coverage(cache):
     """Tokens the whole cache holds, or None when no entry can attest to it.
 
     Hybrid models interleave recurrent layers with attention layers, and a
     recurrent entry carries no offset because it holds a fixed-size state
-    rather than a token sequence. Every layer still consumes every token, so an
-    attention sibling's offset counts for the recurrent entries beside it. When
-    nothing carries an offset the cache stays unverifiable, which is what keeps
-    purely recurrent models out: their state cannot say how far it advanced.
+    rather than a token sequence. An attention sibling's offset counts for the
+    entries beside it, because a state that cannot be rewound is only ever
+    served at the exact prefix it was built from. When nothing carries an
+    offset the cache stays unverifiable, which is what keeps purely recurrent
+    models out: their state cannot say how far it advanced.
     """
     covered = None
     for entry in _flatten_kv_entries(cache):
         offset = getattr(entry, "offset", None)
         if offset is None:
+            # Upstream shortens a stored cache to a prefix as soon as every
+            # entry reports it can be trimmed. An opaque state cannot honour
+            # that, so one claiming it can is not something a sibling's offset
+            # is in any position to vouch for.
+            if getattr(entry, "is_trimmable", _kv_entry_not_trimmable)():
+                return None
             continue
         if getattr(entry, "start_position", 0):
             return None

--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -1021,16 +1021,14 @@ def _kv_prefix_coverage(cache):
     """Tokens the whole cache holds, or None when no entry can attest to it.
 
     A recurrent entry has no offset: it holds fixed-size state, not a token
-    sequence. An attention sibling attests for it, because state that cannot be
-    rewound is only ever served at the prefix it was built from. Nothing
-    attesting leaves the cache unverifiable, which is what keeps mamba/rwkv out.
+    sequence. An attention sibling attests for it, since unrewindable state only
+    ever serves the prefix it was built from. Nothing attesting keeps mamba out.
     """
     covered = None
     for entry in _flatten_kv_entries(cache):
         offset = getattr(entry, "offset", None)
         if offset is None:
-            # Upstream trims once every entry says it can, so only state that
-            # cannot be rewound may be attested for.
+            # Upstream trims once all entries agree, so only unrewindable counts.
             if getattr(entry, "is_trimmable", lambda: False)():
                 return None
             continue

--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -1020,20 +1020,17 @@ def _flatten_kv_entries(cache):
 def _kv_prefix_coverage(cache):
     """Tokens the whole cache holds, or None when no entry can attest to it.
 
-    Hybrid models interleave recurrent layers with attention layers, and a
-    recurrent entry carries no offset because it holds a fixed-size state
-    rather than a token sequence. An attention sibling's offset counts for the
-    entries beside it, because a state that cannot be rewound is only ever
-    served at the exact prefix it was built from. When nothing carries an
-    offset the cache stays unverifiable, which is what keeps purely recurrent
-    models out: their state cannot say how far it advanced.
+    A recurrent entry has no offset: it holds fixed-size state, not a token
+    sequence. An attention sibling attests for it, because state that cannot be
+    rewound is only ever served at the prefix it was built from. Nothing
+    attesting leaves the cache unverifiable, which is what keeps mamba/rwkv out.
     """
     covered = None
     for entry in _flatten_kv_entries(cache):
         offset = getattr(entry, "offset", None)
         if offset is None:
-            # Upstream trims a stored cache to a prefix once every entry says it
-            # can be. A sibling's offset only attests for state that cannot be.
+            # Upstream trims once every entry says it can, so only state that
+            # cannot be rewound may be attested for.
             if getattr(entry, "is_trimmable", lambda: False)():
                 return None
             continue

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -1635,17 +1635,12 @@ def test_mlx_prompt_cache_covers_hybrid_recurrent_layouts(monkeypatch):
     nested = [CacheList(recurrent(), attention(KVCache(), 30))]
     assert _kv_prefix_coverage(nested) == 30
 
-    # Storing these is only safe because upstream can never shorten them: it
-    # trims a stored entry to a prefix once every entry is trimmable, and a
-    # recurrent state cannot be rewound. Pin that, so a future mlx-lm which
-    # made these trimmable fails here rather than reusing state at a position
-    # it never occupied.
+    # Storing these is only safe while upstream cannot shorten them, so pin it:
+    # an mlx-lm that made them trimmable must fail here, not reuse stale state.
     assert can_trim_prompt_cache(hybrid) is False
     assert can_trim_prompt_cache(nested) is False
-    assert not any(entry.is_trimmable() for entry in hybrid if not hasattr(entry, "offset"))
 
-    # An offsetless entry claiming it can be trimmed is refused outright: no
-    # sibling's offset can vouch for a state that says it can be rewound.
+    # An offsetless entry that says it can be trimmed is refused outright.
     class _TrimmableOpaqueState:
         def is_trimmable(self):
             return True

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -1618,8 +1618,7 @@ def test_mlx_prompt_cache_covers_hybrid_recurrent_layouts(monkeypatch):
         return entry
 
     def recurrent():
-        # A GatedDeltaNet layer keeps a convolution state and a recurrent state,
-        # neither of which grows with the prompt.
+        # A GatedDeltaNet layer: conv + recurrent state, neither grows with the prompt.
         entry = ArraysCache(size = 2)
         entry[0] = mx.zeros((1, 4, 4), dtype = mx.float16)
         entry[1] = mx.zeros((1, 2, 4, 4), dtype = mx.float16)
@@ -1635,12 +1634,10 @@ def test_mlx_prompt_cache_covers_hybrid_recurrent_layouts(monkeypatch):
     nested = [CacheList(recurrent(), attention(KVCache(), 30))]
     assert _kv_prefix_coverage(nested) == 30
 
-    # Storing these is only safe while upstream cannot shorten them, so pin it:
-    # an mlx-lm that made them trimmable must fail here, not reuse stale state.
+    # Pin it: an mlx-lm that made these trimmable must fail here, not reuse stale state.
     assert can_trim_prompt_cache(hybrid) is False
     assert can_trim_prompt_cache(nested) is False
 
-    # An offsetless entry that says it can be trimmed is refused outright.
     class _TrimmableOpaqueState:
         def is_trimmable(self):
             return True

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -1599,7 +1599,13 @@ def test_mlx_prompt_cache_only_stores_verifiable_prefix_coverage(monkeypatch):
 
 def test_mlx_prompt_cache_covers_hybrid_recurrent_layouts(monkeypatch):
     mx = pytest.importorskip("mlx.core")
-    from mlx_lm.models.cache import ArraysCache, CacheList, KVCache, RotatingKVCache
+    from mlx_lm.models.cache import (
+        ArraysCache,
+        CacheList,
+        KVCache,
+        RotatingKVCache,
+        can_trim_prompt_cache,
+    )
 
     _install_fake_prompt_cache_api(monkeypatch)
     from core.inference.mlx_inference import _kv_prefix_coverage, _MLXPromptCacheHistory
@@ -1626,7 +1632,25 @@ def test_mlx_prompt_cache_covers_hybrid_recurrent_layouts(monkeypatch):
     hybrid = [recurrent(), recurrent(), recurrent(), attention(KVCache(), 30)]
     assert _kv_prefix_coverage(hybrid) == 30
     # falcon_h1: both halves inside one CacheList.
-    assert _kv_prefix_coverage([CacheList(recurrent(), attention(KVCache(), 30))]) == 30
+    nested = [CacheList(recurrent(), attention(KVCache(), 30))]
+    assert _kv_prefix_coverage(nested) == 30
+
+    # Storing these is only safe because upstream can never shorten them: it
+    # trims a stored entry to a prefix once every entry is trimmable, and a
+    # recurrent state cannot be rewound. Pin that, so a future mlx-lm which
+    # made these trimmable fails here rather than reusing state at a position
+    # it never occupied.
+    assert can_trim_prompt_cache(hybrid) is False
+    assert can_trim_prompt_cache(nested) is False
+    assert not any(entry.is_trimmable() for entry in hybrid if not hasattr(entry, "offset"))
+
+    # An offsetless entry claiming it can be trimmed is refused outright: no
+    # sibling's offset can vouch for a state that says it can be rewound.
+    class _TrimmableOpaqueState:
+        def is_trimmable(self):
+            return True
+
+    assert _kv_prefix_coverage([_TrimmableOpaqueState(), attention(KVCache(), 30)]) is None
 
     # mamba/rwkv: nothing attests to a token count.
     assert _kv_prefix_coverage([recurrent(), recurrent()]) is None

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -1597,6 +1597,56 @@ def test_mlx_prompt_cache_only_stores_verifiable_prefix_coverage(monkeypatch):
     assert tuple(range(30)) in history._lru.entries["key"]
 
 
+def test_mlx_prompt_cache_covers_hybrid_recurrent_layouts(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+    from mlx_lm.models.cache import ArraysCache, CacheList, KVCache, RotatingKVCache
+
+    _install_fake_prompt_cache_api(monkeypatch)
+    from core.inference.mlx_inference import _kv_prefix_coverage, _MLXPromptCacheHistory
+
+    def attention(entry, n):
+        for _ in range(n):
+            block = mx.zeros((1, 2, 1, 4), dtype = mx.float16)
+            entry.update_and_fetch(block, block)
+        mx.eval(entry.state)
+        return entry
+
+    def recurrent():
+        # A GatedDeltaNet layer keeps a convolution state and a recurrent state,
+        # neither of which grows with the prompt.
+        entry = ArraysCache(size = 2)
+        entry[0] = mx.zeros((1, 4, 4), dtype = mx.float16)
+        entry[1] = mx.zeros((1, 2, 4, 4), dtype = mx.float16)
+        mx.eval(entry.state)
+        return entry
+
+    assert getattr(recurrent(), "offset", None) is None
+
+    # qwen3_5/qwen3_next: a full-attention layer every fourth layer.
+    hybrid = [recurrent(), recurrent(), recurrent(), attention(KVCache(), 30)]
+    assert _kv_prefix_coverage(hybrid) == 30
+    # falcon_h1: both halves inside one CacheList.
+    assert _kv_prefix_coverage([CacheList(recurrent(), attention(KVCache(), 30))]) == 30
+
+    # mamba/rwkv: nothing attests to a token count.
+    assert _kv_prefix_coverage([recurrent(), recurrent()]) is None
+
+    # A recurrent entry does not excuse an attention sibling that cannot attest.
+    windowed = attention(RotatingKVCache(max_size = 10, keep = 2), 30)
+    assert _kv_prefix_coverage([recurrent(), windowed]) is None
+    assert (
+        _kv_prefix_coverage([recurrent(), attention(KVCache(), 30), attention(KVCache(), 29)])
+        is None
+    )
+
+    history = _MLXPromptCacheHistory(6, 1 << 40)
+    history.insert("recurrent", list(range(40)), [recurrent(), recurrent()])
+    assert "recurrent" not in history._lru.entries
+
+    history.insert("hybrid", list(range(40)), hybrid)
+    assert tuple(range(30)) in history._lru.entries["hybrid"]
+
+
 # ── Tests: audio-input capability + generation ───────────────────────
 
 


### PR DESCRIPTION
Studio's MLX backend never reused a prompt cache for Qwen3.5 / Qwen3-Next class models. Every request re-prefilled the entire prompt and reported `"cached_tokens": 0`, so a long agent conversation paid a full prefill on every turn — around ten minutes per turn at 52K tokens on the reporting hardware.

## Root cause

`_kv_prefix_coverage()` decides how many tokens a finished cache can honestly claim to hold, and returns `None` for anything it cannot verify so the entry is never stored. It required *every* flattened entry to expose an `offset`.

These models do not build a uniform cache. `mlx_lm.models.qwen3_5.TextModel.make_cache()` returns an `ArraysCache` for each GatedDeltaNet linear-attention layer and a `KVCache` for each full-attention layer:

```python
return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
```

An `ArraysCache` holds a fixed-size recurrent state rather than a growing sequence of tokens, so it has no `offset` by construction — nothing is missing or uninitialized. With `full_attention_interval=4` and 64 layers, a Qwen3.8-27B cache is 48 `ArraysCache` plus 16 `KVCache`, so the refusal fired on every single cache and the LRU stayed empty for the life of the process.

Confirmed on the real model:

```text
cache layout: {'ArraysCache': 48, 'KVCache': 16}
_kv_prefix_coverage -> None
LRU entries after insert: 0
```

18 model families in mlx-lm 0.31.3 build caches containing `ArraysCache`, so this was not Qwen-specific: `qwen3_5`, `qwen3_next`, `lfm2`, `lfm2_moe`, `kimi_linear`, `plamo2`, `jamba`, `nemotron_h`, `falcon_h1`, `granitemoehybrid`, `bailing_moe_linear`, `baichuan_m1`, `longcat_flash_ngram`, `recurrent_gemma`, `mamba`, `mamba2`, `rwkv7`.

## What changed

An entry that carries no `offset` is now skipped instead of rejecting the whole cache, so a full-attention sibling's offset attests for the recurrent entries beside it. Every layer consumes every token, so that offset *is* the token count of the whole hybrid state.

`covered` is still only ever assigned from a real offset, so a cache where nothing carries one still returns `None` — that is what keeps purely recurrent models (`mamba`, `mamba2`, `rwkv7`) out, without naming them anywhere. The existing refusals are untouched: a shifted `start_position`, an offset past a `max_size` window, and two offsets that disagree all still return `None`.

## Why this cannot splice a recurrent state incorrectly

A recurrent state corresponds to one exact token count and cannot be rolled back, so the safety question is whether a stored hybrid cache can ever be reused at a point other than where its state actually sits. It cannot. `ArraysCache.is_trimmable()` inherits `False`, which makes the whole list untrimmable, and upstream `LRUPromptCache.fetch_nearest_cache()` only derives a shorter prefix from a longer stored entry after `can_trim_prompt_cache()` succeeds. A hybrid entry therefore serves an exact prefix or nothing at all.

Measured rather than assumed, on a randomly initialized `qwen3_5` so the numbers come from a real forward pass:

- a divergent query reused 0 tokens and produced bit-identical logits
- a genuine continuation reused its prefix with a max logit difference of 1.5e-06 against a full prefill, same argmax
- a `mamba2` cache still reports coverage `None`

## Validation

`mlx-community/Qwen3.8-27B-8bit`, Apple M3 Max, mlx 0.32.2 / mlx-lm 0.31.3, 16,384-token prompt, follow-up turn adding 256 tokens:

| | prompt | prefilled | rate | wall |
|---|---|---|---|---|
| turn 1, cold | 16,384 | 16,384 | 127.6 tok/s | 129.8s |
| turn 2, cache reused | 16,648 | 256 | 80.3 tok/s | 4.5s |
| turn 2, fresh cache (behavior before this change) | 16,648 | 16,648 | 117.6 tok/s | 142.7s |

Turn 2 reused 16,392 of 16,648 tokens: **31.8x faster, 138.2s saved on one turn**. Both turn-2 paths decoded identical tokens, so reuse does not change the output. The reused prefill runs at a lower tok/s than the cold one simply because a 256-token prefill is less efficient per token than a 16K one — the saving comes from prefilling less, not from prefilling faster.

Coverage reported `16392` (16,384 prompt + 8 decoded) instead of `None`, and the LRU held 1 entry where it previously held 0.

Test suite: `python -m pytest tests/test_mlx_inference_backend.py` from `studio/backend`, 117 passed.

Both directions of the new test were mutation-checked. Restoring the old rejection fails exactly the new test. Making coverage permissive when nothing attests (returning `0` instead of `None`) fails the new test and the pre-existing `test_mlx_prompt_cache_only_stores_verifiable_prefix_coverage`.

## Known limitation, deliberately not addressed here

Two *identical* back-to-back requests still re-prefill on these models, measured at 0 tokens reused. An entry is stored under the prompt plus the tokens generated from it, so it is always longer than the prompt that produced it, and serving a prompt-only query from it would require trimming — impossible for an untrimmable cache. This is pre-existing behavior already asserted by `test_mlx_prompt_cache_never_returns_empty_remainder` ("untrimmable entry must not be reused").

Closing it would mean deep-copying the full hybrid state at the end of prefill, which is multiple GB at 52K tokens against a budget of 15% of the recommended working set. That is a separate design decision with a real memory price, so it is left alone here. Conversations that extend a previous turn — which is what the cache exists for, and what the reported agent workload does — now reuse their prefix.

Fixes #10031

Related, but not fixed by this change and left open deliberately:

- #9177 — prefix caching lost because `{{$now}}` rewrites the prompt prefix every request. CUDA + GGUF/llama.cpp, and the prefix genuinely differs each time, so no cache implementation could match it.
- #9037 — reusable prompt state lost across a model reload. ROCm + GGUF/llama.cpp slot persistence, a different backend from the one changed here.
