### PR TITLE
Wait for the idle batch flush instead of racing a fixed sleep

### DIFF
--- a/studio/backend/tests/test_chat_generation_supervisor.py
+++ b/studio/backend/tests/test_chat_generation_supervisor.py
@@ -4,13 +4,18 @@
 import asyncio
 import json
 import threading
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from core.inference import llama_keepwarm
-from core.inference.chat_generation_runs import ChatGenerationSupervisor
+from core.inference.chat_generation_runs import (
+    _EVENT_BATCH_SECONDS,
+    _EVENT_SINGLE_FLUSH_SECONDS,
+    ChatGenerationSupervisor,
+)
 from models.inference import ChatCompletionRequest
 from routes import chat_generation_runs as run_routes
 from routes import inference
@@ -279,6 +284,20 @@ async def test_subscribers_detach_then_replay_the_same_engine_run(durable_run, m
     assert [text for text in deltas if text] == ["A", "B"]
 
 
+async def _await_chunk_payloads(run_id: str, count: int, deadline_s: float) -> list:
+    """Chunk payloads once `count` of them are durable, or whatever arrived by the deadline.
+
+    Returned rather than asserted so the caller owns the comparison and pytest still
+    shows the payload diff on failure.
+    """
+    started = time.monotonic()
+    while True:
+        stored = [e["payload"] for e in runs_db.list_events(run_id) if e["type"] == "chunk"]
+        if len(stored) >= count or time.monotonic() - started >= deadline_s:
+            return stored
+        await asyncio.sleep(0.005)
+
+
 @pytest.mark.asyncio
 async def test_event_batch_flushes_while_upstream_is_idle(durable_run, monkeypatch):
     release = asyncio.Event()
@@ -299,8 +318,14 @@ async def test_event_batch_flushes_while_upstream_is_idle(durable_run, monkeypat
     monkeypatch.setattr(inference, "produce_openai_chat_completions", fake)
     supervisor = ChatGenerationSupervisor(SimpleNamespace(state = SimpleNamespace()))
     task = asyncio.create_task(supervisor._produce("run-1"))
-    await asyncio.sleep(0.2)
-    stored = [e["payload"] for e in runs_db.list_events("run-1") if e["type"] == "chunk"]
+    # Poll rather than sleep a fixed span. The flush costs the batch timer plus a
+    # thread hop and a SQLite write, which measures ~0.11s on an idle machine, so
+    # the old bare sleep(0.2) left under 2x headroom and lost the race on a loaded
+    # runner. The budget is still bounded well below _EVENT_SINGLE_FLUSH_SECONDS,
+    # so a regression that drops these two events onto the single-event timer, or
+    # never flushes them at all, still fails here rather than passing slowly.
+    deadline = (_EVENT_BATCH_SECONDS + _EVENT_SINGLE_FLUSH_SECONDS) / 2
+    stored = await _await_chunk_payloads("run-1", len(chunks), deadline)
     assert stored == chunks
     release.set()
     await task


### PR DESCRIPTION
The Backend tests lane failed on `test_event_batch_flushes_while_upstream_is_idle` with `assert [] == [two deltas]`, while the other 35,482 tests passed. This is a test timing bug, not a regression.

## Why it fails

The test slept a flat 0.2s and then asserted the two chunks were durable. What it is waiting for is `_EVENT_BATCH_SECONDS` (0.1s) plus an `asyncio.to_thread` hop and a SQLite write in `db.append_events`.

I measured that end to end over twelve runs on a completely idle 192-core machine:

```
0.107 0.105 0.106 0.105 0.106 0.106 0.105 0.106 0.107 0.104 0.128 0.116
min=0.104  max=0.128  mean=0.108
```

So the best case already consumed more than half the budget, and one sample left only 1.56x headroom before it ever reached a shared runner. CPU contention alone does not push it over, which fits the failure being I/O rather than scheduling: the flush needs a free executor thread and the SQLite writer lock, and the lane runs the full suite.

## Whose fault it is

Neither of the two commits that shaped this code.

- #9187 added the test, with the margin it has had since.
- #9997 later touched the same producer loop, but the work it added inside the loop (`_try_touch_progress`) only runs on `: admission-wait` / `: admission-done` markers, and this test stream emits neither. It also starts a sweeper, which this test never starts because it calls `_produce` directly.

The production behaviour is correct: with at least `_EVENT_BATCH_MIN_SIZE` pending and an idle upstream, the batch flushes after `_EVENT_BATCH_SECONDS`. The test was measuring it wrongly.

## The change

Poll until the events land instead of sleeping a fixed span, in the same idiom `test_subscribers_detach_then_replay_the_same_engine_run` already uses a few lines above. The bound is the midpoint between `_EVENT_BATCH_SECONDS` and `_EVENT_SINGLE_FLUSH_SECONDS`, both imported from the module so it tracks the code rather than a copied literal.

That is deliberately not "just wait longer". A plain generous timeout would let a regression that drops these two events onto the 1.0s single-event timer pass silently. The midpoint keeps the test strictly below that path, so the discrimination survives while the margin goes from under 2x to roughly 5x.

## Verification

Mutation tested, because a robustified test is only worth having if it still fails for the right reasons:

| | Result |
|---|---|
| unmodified | passes |
| `_EVENT_BATCH_MIN_SIZE` 2 to 3, dropping the pair onto the 1.0s timer | **fails** |
| idle flush branch deleted outright | **fails** |

Also `test_chat_generation_supervisor.py` 24/24, and the test 40/40 pinned to a single CPU shared with six busy loops.

I checked the rest of the file for the same pattern. This was the only sleep-then-assert gate; the other `sleep(0.01)` calls pace producer bodies and are not assertion timing.