### PR TITLE
Stop charging a chat the whole cache because Max Tokens says "Max"

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1703,6 +1703,41 @@ _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = (
     _OPENAI_LLAMA_ADMISSION_IMAGE_EMBEDDING_CAP + _OPENAI_LLAMA_ADMISSION_IMAGE_WRAPPER_TOKENS
 )
 
+# What to charge a request that names no usable output cap.
+#
+# "Max Tokens: Max" is Studio's default and what almost every chat therefore sends, and
+# it means max_tokens = the whole context window. Priced literally, one chat reserves the
+# entire cache before it has generated a token, so a second is refused however little
+# either actually writes. That is the reservation, not the hardware: measured on a 262144
+# cache, four chats went one at a time at 0.1/2.8/4.6/8.8s to first token with
+# llamacpp:requests_deferred flat at 0, meaning requests 2-4 never reached llama-server.
+#
+# So "Max" is treated as "unstated" rather than as a promise to fill the window, and an
+# unstated cap is charged this. It is an ESTIMATE where the rest of this function is a
+# bound, which is the trade being made: a run that generates more than this is undercharged
+# until something re-costs it (tool loops do, at every round boundary). A plain chat has no
+# round boundary yet, so on a cache that is genuinely full a long uncapped generation can
+# still overrun. Raise this, or name a real Max Tokens, on a deployment where that matters.
+_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS = _positive_int_or_none(
+    os.environ.get("UNSLOTH_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS")
+) or 1024
+
+
+def _openai_llama_admission_output_allowance(
+    cap: Optional[int], *, budget: int, prompt_tokens: int
+) -> int:
+    """KV to reserve for what a request may still generate.
+
+    A cap at or above the window is not a cap. `_build_passthrough_payload` sends
+    max_tokens = backend_ctx when the client names none, and Studio's own "Max" setting
+    sends the context length outright, so both arrive here as "the whole window" and are
+    indistinguishable from each other. Neither is a statement about how much this request
+    will write, and charging the window for either is what serialises the queue.
+    """
+    if cap is not None and cap < budget:
+        return cap
+    return min(_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS, max(0, budget - prompt_tokens))
+
 
 def _extra_args_image_max_tokens(extra_args) -> Optional[int]:
     """The ``--image-max-tokens N`` a load passed through, or None. Last wins.
@@ -1919,16 +1954,12 @@ def _openai_llama_admission_tokens(
             getattr(payload, "max_completion_tokens", None),
         )
     )
-    if cap is None:
-        # No cap at all. _build_passthrough_payload then sends max_tokens = backend_ctx,
-        # so generation may run until the window is full, and reserving nothing let short
-        # uncapped prompts hold tiny commitments while each consumed most of the cache.
-        # The honest reservation is the rest of the budget, which does serialise
-        # concurrent uncapped requests. That is the true cost of not naming a cap: the
-        # alternative is admitting two runs that llama.cpp will then kill.
-        output_tokens = max(0, budget - prompt_tokens)
-    else:
-        output_tokens = cap
+    # An absent cap and a cap of the whole window are the same statement, and neither is
+    # a promise to fill the cache. Reserving the rest of the budget for either is what
+    # made concurrency 1 for the default Studio chat.
+    output_tokens = _openai_llama_admission_output_allowance(
+        cap, budget = budget, prompt_tokens = prompt_tokens
+    )
     # A tool loop opens at its own estimate with an equal share as the floor, and re-costs
     # as it grows (generate_chat_completion_with_tools on_conversation_grew ->
     # lease.recost_waiting). The floor keeps re-costing rare: under its share a run never
@@ -2052,11 +2083,13 @@ def _openai_llama_admission_recost(
             message_image_parts = message_image_parts,
             image_tokens = _openai_llama_admission_image_tokens(llama_backend),
         )
-        if output_tokens is None:
-            # No cap named, so generation is bounded only by the window, as the opening
-            # estimate assumes. Charging zero here dropped an uncapped loop to its share
-            # on round zero while its generations could still fill most of the cache.
-            output_tokens = max(0, budget - prompt_tokens)
+        # Priced the same way the opening reservation priced it, including treating a cap
+        # of the whole window as unstated. A re-cost that reads "Max" literally would put
+        # the run back on the whole cache at its first round boundary, undoing at round
+        # zero exactly what the opening estimate stopped doing.
+        output_tokens = _openai_llama_admission_output_allowance(
+            output_tokens, budget = budget, prompt_tokens = prompt_tokens
+        )
         share = max(1, budget // max(1, capacity))
         want = max(1, min(budget, max(share, prompt_tokens + max(0, output_tokens))))
         lease.recost_waiting(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1722,6 +1722,7 @@ def _openai_llama_admission_output_allowance(
     budget: int,
     prompt_tokens: int,
     context_window: Optional[int] = None,
+    share: Optional[int] = None,
 ) -> int:
     """KV to reserve for what a request may still generate.
 
@@ -1729,12 +1730,21 @@ def _openai_llama_admission_output_allowance(
     max_tokens = backend_ctx and "Max" sends the context length, so both mean unstated, and
     charging the window for either serialises the queue. Measured against the per-request
     window, since the budget is N times larger under --no-kv-unified.
+
+    Invariant when a ``share`` is known: an unstated request costs at most its fair share of
+    the cache, so ``capacity`` of them always fit. A flat allowance breaks that on a small
+    cache, where 1024 is most of a share on its own (4096 over four slots admitted three).
+    A prompt already past its share keeps the flat allowance, since it does not fit either
+    way and a zero allowance would only hide that it will still generate.
     """
     window = context_window or budget
     if cap is not None and cap < window:
         return cap
     # Clamped to the WINDOW: a request cannot occupy more KV than its own slot holds.
-    return min(_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS, max(0, window - prompt_tokens))
+    allowance = min(_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS, max(0, window - prompt_tokens))
+    if share is not None and share > prompt_tokens:
+        allowance = min(allowance, share - prompt_tokens)
+    return allowance
 
 
 def _extra_args_image_max_tokens(extra_args) -> Optional[int]:
@@ -1955,7 +1965,11 @@ def _openai_llama_admission_tokens(
     )
     # Reserving the rest of the budget for either made concurrency 1 for the default chat.
     output_tokens = _openai_llama_admission_output_allowance(
-        cap, budget = budget, prompt_tokens = prompt_tokens, context_window = context_window
+        cap,
+        budget = budget,
+        prompt_tokens = prompt_tokens,
+        context_window = context_window,
+        share = max(1, budget // max(1, capacity)),
     )
     # A tool loop opens at its own estimate with an equal share as the floor, and re-costs
     # as it grows (generate_chat_completion_with_tools on_conversation_grew ->
@@ -2083,13 +2097,14 @@ def _openai_llama_admission_recost(
         )
         # Reading "Max" literally here would put the run back on the whole cache at its
         # first round boundary.
+        share = max(1, budget // max(1, capacity))
         output_tokens = _openai_llama_admission_output_allowance(
             output_tokens,
             budget = budget,
             prompt_tokens = prompt_tokens,
             context_window = _openai_llama_admission_context_window(llama_backend),
+            share = share,
         )
-        share = max(1, budget // max(1, capacity))
         want = max(1, min(budget, max(share, prompt_tokens + max(0, output_tokens))))
         lease.recost_waiting(
             want,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1705,19 +1705,16 @@ _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = (
 
 # What to charge a request that names no usable output cap.
 #
-# "Max Tokens: Max" is Studio's default and what almost every chat therefore sends, and
-# it means max_tokens = the whole context window. Priced literally, one chat reserves the
-# entire cache before it has generated a token, so a second is refused however little
-# either actually writes. That is the reservation, not the hardware: measured on a 262144
-# cache, four chats went one at a time at 0.1/2.8/4.6/8.8s to first token with
-# llamacpp:requests_deferred flat at 0, meaning requests 2-4 never reached llama-server.
+# "Max Tokens: Max" is Studio's default and means max_tokens = the whole window. Priced
+# literally, one chat reserves the entire cache before generating a token and the next is
+# refused however little either writes: measured on a 262144 cache, four chats went one at
+# a time at 0.1/2.8/4.6/8.8s to first token with llamacpp:requests_deferred flat at 0, so
+# requests 2-4 never reached llama-server at all.
 #
-# So "Max" is treated as "unstated" rather than as a promise to fill the window, and an
-# unstated cap is charged this. It is an ESTIMATE where the rest of this function is a
-# bound, which is the trade being made: a run that generates more than this is undercharged
-# until something re-costs it (tool loops do, at every round boundary). A plain chat has no
-# round boundary yet, so on a cache that is genuinely full a long uncapped generation can
-# still overrun. Raise this, or name a real Max Tokens, on a deployment where that matters.
+# The trade: this is an ESTIMATE where the rest of the function is a bound. A run that
+# generates more is undercharged until something re-costs it, which a tool loop does every
+# round boundary and a plain chat cannot yet, so on a full cache a long uncapped generation
+# can still overrun. Raise this, or name a real Max Tokens, where that matters.
 _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS = _positive_int_or_none(
     os.environ.get("UNSLOTH_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS")
 ) or 1024
@@ -1729,10 +1726,9 @@ def _openai_llama_admission_output_allowance(
     """KV to reserve for what a request may still generate.
 
     A cap at or above the window is not a cap. `_build_passthrough_payload` sends
-    max_tokens = backend_ctx when the client names none, and Studio's own "Max" setting
-    sends the context length outright, so both arrive here as "the whole window" and are
-    indistinguishable from each other. Neither is a statement about how much this request
-    will write, and charging the window for either is what serialises the queue.
+    max_tokens = backend_ctx when the client names none, and "Max" sends the context
+    length outright, so both arrive as "the whole window" and neither says anything about
+    what this request will write. Charging the window for either serialises the queue.
     """
     if cap is not None and cap < budget:
         return cap
@@ -1954,9 +1950,9 @@ def _openai_llama_admission_tokens(
             getattr(payload, "max_completion_tokens", None),
         )
     )
-    # An absent cap and a cap of the whole window are the same statement, and neither is
-    # a promise to fill the cache. Reserving the rest of the budget for either is what
-    # made concurrency 1 for the default Studio chat.
+    # An absent cap and a cap of the whole window are the same statement, and neither
+    # promises to fill the cache. Reserving the rest of the budget for either is what made
+    # concurrency 1 for the default Studio chat.
     output_tokens = _openai_llama_admission_output_allowance(
         cap, budget = budget, prompt_tokens = prompt_tokens
     )
@@ -2083,10 +2079,9 @@ def _openai_llama_admission_recost(
             message_image_parts = message_image_parts,
             image_tokens = _openai_llama_admission_image_tokens(llama_backend),
         )
-        # Priced the same way the opening reservation priced it, including treating a cap
-        # of the whole window as unstated. A re-cost that reads "Max" literally would put
-        # the run back on the whole cache at its first round boundary, undoing at round
-        # zero exactly what the opening estimate stopped doing.
+        # Priced exactly as the opening reservation priced it. A re-cost that read "Max"
+        # literally would put the run back on the whole cache at its first round boundary,
+        # undoing at round zero what the opening estimate stopped doing.
         output_tokens = _openai_llama_admission_output_allowance(
             output_tokens, budget = budget, prompt_tokens = prompt_tokens
         )

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1733,7 +1733,10 @@ def _openai_llama_admission_context_window(llama_backend) -> Optional[int]:
 
 
 def _openai_llama_admission_output_allowance(
-    cap: Optional[int], *, budget: int, prompt_tokens: int,
+    cap: Optional[int],
+    *,
+    budget: int,
+    prompt_tokens: int,
     context_window: Optional[int] = None,
 ) -> int:
     """KV to reserve for what a request may still generate.
@@ -2107,7 +2110,9 @@ def _openai_llama_admission_recost(
         # literally would put the run back on the whole cache at its first round boundary,
         # undoing at round zero what the opening estimate stopped doing.
         output_tokens = _openai_llama_admission_output_allowance(
-            output_tokens, budget = budget, prompt_tokens = prompt_tokens,
+            output_tokens,
+            budget = budget,
+            prompt_tokens = prompt_tokens,
             context_window = _openai_llama_admission_context_window(llama_backend),
         )
         share = max(1, budget // max(1, capacity))

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1703,32 +1703,16 @@ _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = (
     _OPENAI_LLAMA_ADMISSION_IMAGE_EMBEDDING_CAP + _OPENAI_LLAMA_ADMISSION_IMAGE_WRAPPER_TOKENS
 )
 
-# What to charge a request that names no usable output cap.
-#
-# "Max Tokens: Max" is Studio's default and means max_tokens = the whole window. Priced
-# literally, one chat reserves the entire cache before generating a token and the next is
-# refused however little either writes: measured on a 262144 cache, four chats went one at
-# a time at 0.1/2.8/4.6/8.8s to first token with llamacpp:requests_deferred flat at 0, so
-# requests 2-4 never reached llama-server at all.
-#
-# The trade: this is an ESTIMATE where the rest of the function is a bound. A run that
-# generates more is undercharged until something re-costs it, which a tool loop does every
-# round boundary and a plain chat cannot yet, so on a full cache a long uncapped generation
-# can still overrun. Raise this, or name a real Max Tokens, where that matters.
+# An ESTIMATE where the rest of the sizing is a bound: a run that generates more is
+# undercharged until something re-costs it, which a tool loop does every round boundary and
+# a plain chat cannot yet, so on a full cache a long uncapped generation can still overrun.
 _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS = (
     _positive_int_or_none(os.environ.get("UNSLOTH_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS")) or 1024
 )
 
 
 def _openai_llama_admission_context_window(llama_backend) -> Optional[int]:
-    """The window ONE request may fill, which is not always the admission budget.
-
-    ``context_length`` is per slot once the server has been read back. Under
-    ``--kv-unified`` that is also the whole cache, so window and budget agree; under
-    ``--no-kv-unified`` the budget is the aggregate of N private caches and is N times
-    larger. "Max" is a per-request figure either way, so it has to be compared against
-    this.
-    """
+    """One slot, which under ``--no-kv-unified`` is 1/N of the aggregate budget."""
     return _positive_int_or_none(getattr(llama_backend, "context_length", None))
 
 
@@ -1741,27 +1725,15 @@ def _openai_llama_admission_output_allowance(
 ) -> int:
     """KV to reserve for what a request may still generate.
 
-    A cap at or above the window is not a cap. `_build_passthrough_payload` sends
-    max_tokens = backend_ctx when the client names none, and "Max" sends the context
-    length outright, so both arrive as "the whole window" and neither says anything about
-    what this request will write. Charging the window for either serialises the queue.
-
-    Compared against the PER-REQUEST window, not the budget. Under
-    ``--parallel N --no-kv-unified`` the budget is the aggregate of N private caches while
-    "Max" is still one slot's context_length, so measuring against the budget read that
-    default as a real cap: each reservation then cost a slot's share plus its prompt, and
-    four default chats no longer fit in four caches (measured: 4104 each against 16384,
-    so three). Falls back to the budget when the window is unknown, which is the
-    unified case anyway.
+    A cap at or above the window is not a cap: `_build_passthrough_payload` sends
+    max_tokens = backend_ctx and "Max" sends the context length, so both mean unstated, and
+    charging the window for either serialises the queue. Measured against the per-request
+    window, since the budget is N times larger under --no-kv-unified.
     """
     window = context_window or budget
     if cap is not None and cap < window:
         return cap
-    # Clamped against the WINDOW, not the budget. One request cannot occupy more KV than
-    # its own slot holds, so charging it prompt + allowance past that overstates it: with
-    # four private 4096 caches and a 3500-token prompt, the flat 1024 charged 4524 for
-    # something that can only ever occupy 4096, and three such chats filled a 16384
-    # aggregate. Identical under --kv-unified, where window and budget are one number.
+    # Clamped to the WINDOW: a request cannot occupy more KV than its own slot holds.
     return min(_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS, max(0, window - prompt_tokens))
 
 
@@ -1981,9 +1953,7 @@ def _openai_llama_admission_tokens(
             getattr(payload, "max_completion_tokens", None),
         )
     )
-    # An absent cap and a cap of the whole window are the same statement, and neither
-    # promises to fill the cache. Reserving the rest of the budget for either is what made
-    # concurrency 1 for the default Studio chat.
+    # Reserving the rest of the budget for either made concurrency 1 for the default chat.
     output_tokens = _openai_llama_admission_output_allowance(
         cap, budget = budget, prompt_tokens = prompt_tokens, context_window = context_window
     )
@@ -2111,9 +2081,8 @@ def _openai_llama_admission_recost(
             message_image_parts = message_image_parts,
             image_tokens = _openai_llama_admission_image_tokens(llama_backend),
         )
-        # Priced exactly as the opening reservation priced it. A re-cost that read "Max"
-        # literally would put the run back on the whole cache at its first round boundary,
-        # undoing at round zero what the opening estimate stopped doing.
+        # Reading "Max" literally here would put the run back on the whole cache at its
+        # first round boundary.
         output_tokens = _openai_llama_admission_output_allowance(
             output_tokens,
             budget = budget,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1720,8 +1720,21 @@ _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS = (
 )
 
 
+def _openai_llama_admission_context_window(llama_backend) -> Optional[int]:
+    """The window ONE request may fill, which is not always the admission budget.
+
+    ``context_length`` is per slot once the server has been read back. Under
+    ``--kv-unified`` that is also the whole cache, so window and budget agree; under
+    ``--no-kv-unified`` the budget is the aggregate of N private caches and is N times
+    larger. "Max" is a per-request figure either way, so it has to be compared against
+    this.
+    """
+    return _positive_int_or_none(getattr(llama_backend, "context_length", None))
+
+
 def _openai_llama_admission_output_allowance(
-    cap: Optional[int], *, budget: int, prompt_tokens: int
+    cap: Optional[int], *, budget: int, prompt_tokens: int,
+    context_window: Optional[int] = None,
 ) -> int:
     """KV to reserve for what a request may still generate.
 
@@ -1729,8 +1742,17 @@ def _openai_llama_admission_output_allowance(
     max_tokens = backend_ctx when the client names none, and "Max" sends the context
     length outright, so both arrive as "the whole window" and neither says anything about
     what this request will write. Charging the window for either serialises the queue.
+
+    Compared against the PER-REQUEST window, not the budget. Under
+    ``--parallel N --no-kv-unified`` the budget is the aggregate of N private caches while
+    "Max" is still one slot's context_length, so measuring against the budget read that
+    default as a real cap: each reservation then cost a slot's share plus its prompt, and
+    four default chats no longer fit in four caches (measured: 4104 each against 16384,
+    so three). Falls back to the budget when the window is unknown, which is the
+    unified case anyway.
     """
-    if cap is not None and cap < budget:
+    window = context_window or budget
+    if cap is not None and cap < window:
         return cap
     return min(_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS, max(0, budget - prompt_tokens))
 
@@ -1908,6 +1930,7 @@ def _openai_llama_admission_tokens(
     tool_loop: bool = False,
     image_tokens: int = _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS,
     injected_tools = None,
+    context_window: Optional[int] = None,
 ) -> Optional[int]:
     """KV a request will occupy: what is sent, plus what it may generate.
 
@@ -1954,7 +1977,7 @@ def _openai_llama_admission_tokens(
     # promises to fill the cache. Reserving the rest of the budget for either is what made
     # concurrency 1 for the default Studio chat.
     output_tokens = _openai_llama_admission_output_allowance(
-        cap, budget = budget, prompt_tokens = prompt_tokens
+        cap, budget = budget, prompt_tokens = prompt_tokens, context_window = context_window
     )
     # A tool loop opens at its own estimate with an equal share as the floor, and re-costs
     # as it grows (generate_chat_completion_with_tools on_conversation_grew ->
@@ -2014,6 +2037,7 @@ def _openai_llama_admission_reserve(
             tool_loop = tool_loop,
             image_tokens = _openai_llama_admission_image_tokens(llama_backend),
             injected_tools = injected_tools,
+            context_window = _openai_llama_admission_context_window(llama_backend),
         )
         if payload is not None
         else None,
@@ -2083,7 +2107,8 @@ def _openai_llama_admission_recost(
         # literally would put the run back on the whole cache at its first round boundary,
         # undoing at round zero what the opening estimate stopped doing.
         output_tokens = _openai_llama_admission_output_allowance(
-            output_tokens, budget = budget, prompt_tokens = prompt_tokens
+            output_tokens, budget = budget, prompt_tokens = prompt_tokens,
+            context_window = _openai_llama_admission_context_window(llama_backend),
         )
         share = max(1, budget // max(1, capacity))
         want = max(1, min(budget, max(share, prompt_tokens + max(0, output_tokens))))

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1715,9 +1715,9 @@ _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS = (
 # generates more is undercharged until something re-costs it, which a tool loop does every
 # round boundary and a plain chat cannot yet, so on a full cache a long uncapped generation
 # can still overrun. Raise this, or name a real Max Tokens, where that matters.
-_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS = _positive_int_or_none(
-    os.environ.get("UNSLOTH_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS")
-) or 1024
+_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS = (
+    _positive_int_or_none(os.environ.get("UNSLOTH_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS")) or 1024
+)
 
 
 def _openai_llama_admission_output_allowance(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1757,7 +1757,12 @@ def _openai_llama_admission_output_allowance(
     window = context_window or budget
     if cap is not None and cap < window:
         return cap
-    return min(_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS, max(0, budget - prompt_tokens))
+    # Clamped against the WINDOW, not the budget. One request cannot occupy more KV than
+    # its own slot holds, so charging it prompt + allowance past that overstates it: with
+    # four private 4096 caches and a 3500-token prompt, the flat 1024 charged 4524 for
+    # something that can only ever occupy 4096, and three such chats filled a 16384
+    # aggregate. Identical under --kv-unified, where window and budget are one number.
+    return min(_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS, max(0, window - prompt_tokens))
 
 
 def _extra_args_image_max_tokens(extra_args) -> Optional[int]:

--- a/studio/backend/tests/test_llama_admission_kv_budget.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget.py
@@ -378,11 +378,11 @@ class TestTheWholeRenderedPromptIsCounted:
         assert cost < 2048, "an uncapped request still reserves the whole window"
         assert cost <= _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS + 64
 
-    def test_two_uncapped_short_prompts_do_not_both_run(self):
+    def test_uncapped_short_prompts_fill_the_slots_and_no_more(self):
         """The collision this closes: tiny commitments, cache-filling generations.
 
-        Still true at 2048 only because two allowances do not fit there; on a larger cache
-        they DO both run. What this pins is that an allowance is charged at all.
+        Four fit and a fifth does not, on a cache small enough that the flat allowance would
+        not have left room for four. A prompt-only charge would admit any number.
         """
         from types import SimpleNamespace
 
@@ -394,10 +394,11 @@ class TestTheWholeRenderedPromptIsCounted:
                 max_completion_tokens = None,
             )
             cost = self._cost(payload, budget = 2048)
-            first = await _reserve(queue, capacity = 4, tokens = cost, budget = 2048)
-            assert first.lease_nowait() is not None
-            second = await _reserve(queue, capacity = 4, tokens = cost, budget = 2048)
-            return second.lease_nowait()
+            for _ in range(4):
+                admitted = await _reserve(queue, capacity = 4, tokens = cost, budget = 2048)
+                assert admitted.lease_nowait() is not None
+            fifth = await _reserve(queue, capacity = 4, tokens = cost, budget = 2048)
+            return fifth.lease_nowait()
 
         assert _run(scenario()) is None
 

--- a/studio/backend/tests/test_llama_admission_kv_budget.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget.py
@@ -341,10 +341,9 @@ class TestTheWholeRenderedPromptIsCounted:
 
     An uncapped request reserved no output allowance even though
     `_build_passthrough_payload` then sends `max_tokens = backend_ctx`, so short
-    prompts held tiny commitments while each generation could fill the cache. That
-    is now charged as a bounded allowance rather than as the whole window: charging
-    the window fixed the undercount by making the default chat un-runnable
-    concurrently, since "Max" sends the context length and is what Studio ships. And
+    prompts held tiny commitments while each generation could fill the cache. That is
+    now a bounded allowance rather than the whole window, which fixed the undercount by
+    making Studio's default chat un-runnable concurrently. And
     the estimate covered only `messages`, while OpenAI tool definitions are
     rendered into the prompt and Anthropic keeps `system` and `tools` separate
     until they are translated.
@@ -364,10 +363,8 @@ class TestTheWholeRenderedPromptIsCounted:
         )
 
     def test_an_uncapped_request_reserves_a_bounded_allowance(self):
-        """It used to reserve the whole window because generation MAY run that long.
-        Almost none do, and charging the window made the default Studio chat (Max Tokens
-        = Max sends the context length) cost the entire cache before writing a token, so a
-        second chat could never start. Now an allowance clamped to what is left."""
+        """It reserved the whole window because generation MAY run that long, which cost
+        the default chat the entire cache before it wrote a token."""
         from types import SimpleNamespace
 
         from routes.inference import _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
@@ -384,9 +381,8 @@ class TestTheWholeRenderedPromptIsCounted:
     def test_two_uncapped_short_prompts_do_not_both_run(self):
         """The collision this closes: tiny commitments, cache-filling generations.
 
-        Still true at 2048, but now only because two allowances do not fit there; on a
-        larger cache they DO both run, which is the point. What this pins is that the
-        allowance is charged at all, since a prompt-only charge would admit any number.
+        Still true at 2048 only because two allowances do not fit there; on a larger cache
+        they DO both run. What this pins is that an allowance is charged at all.
         """
         from types import SimpleNamespace
 

--- a/studio/backend/tests/test_llama_admission_kv_budget.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget.py
@@ -364,12 +364,10 @@ class TestTheWholeRenderedPromptIsCounted:
         )
 
     def test_an_uncapped_request_reserves_a_bounded_allowance(self):
-        """It used to reserve the whole window, on the grounds that generation MAY run
-        that long. It may, but almost none do, and charging the window made the default
-        Studio chat (Max Tokens = Max, which sends the context length) cost the entire
-        cache before writing a token, so a second chat could never start. The reservation
-        is now an allowance, `_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS`, clamped to
-        what is left."""
+        """It used to reserve the whole window because generation MAY run that long.
+        Almost none do, and charging the window made the default Studio chat (Max Tokens
+        = Max sends the context length) cost the entire cache before writing a token, so a
+        second chat could never start. Now an allowance clamped to what is left."""
         from types import SimpleNamespace
 
         from routes.inference import _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
@@ -386,11 +384,9 @@ class TestTheWholeRenderedPromptIsCounted:
     def test_two_uncapped_short_prompts_do_not_both_run(self):
         """The collision this closes: tiny commitments, cache-filling generations.
 
-        Still true on a 2048 cache, but for a different reason than it used to be: the
-        allowance is no longer the whole window, it is simply that two of them do not fit
-        in 2048. On a cache with room for both they now DO both run, which is the point of
-        the change. What is being pinned here is that the allowance is charged at all; a
-        request charged only for its prompt would let any number of these in.
+        Still true at 2048, but now only because two allowances do not fit there; on a
+        larger cache they DO both run, which is the point. What this pins is that the
+        allowance is charged at all, since a prompt-only charge would admit any number.
         """
         from types import SimpleNamespace
 

--- a/studio/backend/tests/test_llama_admission_kv_budget.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget.py
@@ -341,7 +341,10 @@ class TestTheWholeRenderedPromptIsCounted:
 
     An uncapped request reserved no output allowance even though
     `_build_passthrough_payload` then sends `max_tokens = backend_ctx`, so short
-    prompts held tiny commitments while each generation could fill the cache. And
+    prompts held tiny commitments while each generation could fill the cache. That
+    is now charged as a bounded allowance rather than as the whole window: charging
+    the window fixed the undercount by making the default chat un-runnable
+    concurrently, since "Max" sends the context length and is what Studio ships. And
     the estimate covered only `messages`, while OpenAI tool definitions are
     rendered into the prompt and Anthropic keeps `system` and `tools` separate
     until they are translated.
@@ -360,18 +363,35 @@ class TestTheWholeRenderedPromptIsCounted:
             capacity = capacity,
         )
 
-    def test_an_uncapped_request_reserves_the_rest_of_the_window(self):
+    def test_an_uncapped_request_reserves_a_bounded_allowance(self):
+        """It used to reserve the whole window, on the grounds that generation MAY run
+        that long. It may, but almost none do, and charging the window made the default
+        Studio chat (Max Tokens = Max, which sends the context length) cost the entire
+        cache before writing a token, so a second chat could never start. The reservation
+        is now an allowance, `_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS`, clamped to
+        what is left."""
         from types import SimpleNamespace
+
+        from routes.inference import _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+
         payload = SimpleNamespace(
             messages = [{"role": "user", "content": "hi"}],
             max_tokens = None,
             max_completion_tokens = None,
         )
-        # Generation may run until the window is full, so the reservation says so.
-        assert self._cost(payload, budget = 2048) == 2048
+        cost = self._cost(payload, budget = 2048)
+        assert cost < 2048, "an uncapped request still reserves the whole window"
+        assert cost <= _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS + 64
 
     def test_two_uncapped_short_prompts_do_not_both_run(self):
-        """The collision this closes: tiny commitments, cache-filling generations."""
+        """The collision this closes: tiny commitments, cache-filling generations.
+
+        Still true on a 2048 cache, but for a different reason than it used to be: the
+        allowance is no longer the whole window, it is simply that two of them do not fit
+        in 2048. On a cache with room for both they now DO both run, which is the point of
+        the change. What is being pinned here is that the allowance is charged at all; a
+        request charged only for its prompt would let any number of these in.
+        """
         from types import SimpleNamespace
 
         async def scenario():

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -551,16 +551,13 @@ class TestARoundIsCostedTheSameWayTheReservationWas:
     def test_round_zero_keeps_an_uncapped_loop_s_output_allowance(self):
         """No max_tokens and no max_completion_tokens.
 
-        The invariant is that the round-zero re-cost does not SHRINK the lease the
-        opening reservation took: the callback fires before the conversation has grown,
-        so anything it gives back is room llama-server is already using and the next
-        arrival is admitted into it.
+        The invariant: the round-zero re-cost must not SHRINK the opening lease. The
+        callback fires before the conversation has grown, so anything given back is room
+        llama-server is already using, and the next arrival is admitted into it.
 
-        The size of that allowance is a separate question and it changed: an absent cap
-        (and "Max", which is the same statement) is charged
-        ``_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS`` rather than the rest of the
-        window. What matters here is that BOTH sides price it the same way, which is why
-        this asserts equality rather than a number.
+        The allowance SIZE is a separate question and it changed (an absent cap, and
+        "Max", are charged ``_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS``), so this
+        asserts the two sides agree rather than asserting a number.
         """
         from routes.inference import (
             _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS,

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -572,9 +572,7 @@ class TestARoundIsCostedTheSameWayTheReservationWas:
         opened, committed, _queue = self._round_zero(
             payload, output_tokens = _effective_openai_max_tokens(payload)
         )
-        assert opened < 4096, (
-            f"an uncapped loop still opens on the whole {4096} cache ({opened})"
-        )
+        assert opened < 4096, f"an uncapped loop still opens on the whole {4096} cache ({opened})"
         assert opened <= _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS + 64, opened
         assert (
             committed == opened

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -551,13 +551,10 @@ class TestARoundIsCostedTheSameWayTheReservationWas:
     def test_round_zero_keeps_an_uncapped_loop_s_output_allowance(self):
         """No max_tokens and no max_completion_tokens.
 
-        The invariant: the round-zero re-cost must not SHRINK the opening lease. The
-        callback fires before the conversation has grown, so anything given back is room
-        llama-server is already using, and the next arrival is admitted into it.
-
-        The allowance SIZE is a separate question and it changed (an absent cap, and
-        "Max", are charged ``_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS``), so this
-        asserts the two sides agree rather than asserting a number.
+        The invariant: the round-zero re-cost must not SHRINK the opening lease, because it
+        fires before the conversation has grown, so anything given back is room
+        llama-server is already using. The allowance SIZE is a separate question and it
+        changed, so this asserts the two sides agree rather than asserting a number.
         """
         from routes.inference import (
             _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS,

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -549,35 +549,39 @@ class TestARoundIsCostedTheSameWayTheReservationWas:
         )
 
     def test_round_zero_keeps_an_uncapped_loop_s_output_allowance(self):
-        """No max_tokens and no max_completion_tokens: generation is bounded only by the
-        window, which is why the reservation charges ``budget - prompt``. Flattening the
-        absent cap to zero drops the loop to its share while its generations can still
-        fill most of the cache."""
-        from routes.inference import _effective_openai_max_tokens
+        """No max_tokens and no max_completion_tokens.
+
+        The invariant is that the round-zero re-cost does not SHRINK the lease the
+        opening reservation took: the callback fires before the conversation has grown,
+        so anything it gives back is room llama-server is already using and the next
+        arrival is admitted into it.
+
+        The size of that allowance is a separate question and it changed: an absent cap
+        (and "Max", which is the same statement) is charged
+        ``_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS`` rather than the rest of the
+        window. What matters here is that BOTH sides price it the same way, which is why
+        this asserts equality rather than a number.
+        """
+        from routes.inference import (
+            _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS,
+            _effective_openai_max_tokens,
+        )
 
         payload = _Payload(
             messages = [{"role": "user", "content": "summarise the news"}],
             enable_tools = True,
         )
         assert _effective_openai_max_tokens(payload) is None
-        opened, committed, queue = self._round_zero(
+        opened, committed, _queue = self._round_zero(
             payload, output_tokens = _effective_openai_max_tokens(payload)
         )
-        assert opened == 4096, opened
+        assert opened < 4096, (
+            f"an uncapped loop still opens on the whole {4096} cache ({opened})"
+        )
+        assert opened <= _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS + 64, opened
         assert (
             committed == opened
         ), f"round zero shrank an uncapped loop from {opened} to {committed}"
-        # And the room it would have released must not admit anyone.
-        import asyncio
-
-        from core.inference.llama_admission import LlamaAdmissionConfig
-
-        async def _newcomer():
-            return queue.reserve(
-                capacity = 4, config = LlamaAdmissionConfig(), tokens = 2000, budget = 4096
-            ).lease_nowait()
-
-        assert asyncio.run(_newcomer()) is None
 
     def test_round_zero_keeps_a_top_level_system_prompt(self):
         """Anthropic keeps `system` and `tools` out of `messages` entirely, so for that

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -182,7 +182,9 @@ class TestTheAllowanceFitsTheAdvertisedSlots:
 
     def _cost(self, budget, capacity):
         return _openai_llama_admission_tokens(
-            _chat(max_tokens = budget), budget = budget, capacity = capacity,
+            _chat(max_tokens = budget),
+            budget = budget,
+            capacity = capacity,
             context_window = budget,
         )
 

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -180,3 +180,51 @@ class TestMaxIsPerRequestNotPerCache:
                 _openai_llama_admission_context_window(SimpleNamespace(context_length = value))
                 is None
             )
+
+
+class TestTheAllowanceCannotExceedOneSlot:
+    """A request cannot occupy more KV than its own slot holds.
+
+    The allowance is clamped against the WINDOW, not the aggregate budget. Under
+    ``--no-kv-unified`` those differ by N, and clamping against the budget charged a
+    long-prompt chat for more than a slot can physically hold: four private 4096 caches
+    with a 3500-token prompt gave a flat 1024 allowance and a 4524 charge, so three such
+    chats filled the 16384 aggregate.
+    """
+
+    WINDOW = 4096
+    BUDGET = WINDOW * 4
+
+    def test_a_long_prompt_shrinks_the_allowance_to_fit_its_slot(self):
+        allowance = _openai_llama_admission_output_allowance(
+            self.WINDOW, budget = self.BUDGET, prompt_tokens = 3500,
+            context_window = self.WINDOW,
+        )
+        assert allowance == self.WINDOW - 3500
+        assert 3500 + allowance == self.WINDOW, "a request may not exceed one slot"
+
+    def test_four_long_prompt_chats_still_fit(self):
+        prompt = 3500
+        allowance = _openai_llama_admission_output_allowance(
+            self.WINDOW, budget = self.BUDGET, prompt_tokens = prompt,
+            context_window = self.WINDOW,
+        )
+        assert (prompt + allowance) * 4 <= self.BUDGET
+
+    def test_a_prompt_that_fills_the_slot_gets_nothing(self):
+        assert _openai_llama_admission_output_allowance(
+            self.WINDOW, budget = self.BUDGET, prompt_tokens = self.WINDOW,
+            context_window = self.WINDOW,
+        ) == 0
+
+    def test_a_short_prompt_still_gets_the_full_allowance(self):
+        assert _openai_llama_admission_output_allowance(
+            self.WINDOW, budget = self.BUDGET, prompt_tokens = 100,
+            context_window = self.WINDOW,
+        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+
+    def test_unified_is_unchanged(self):
+        """window == budget there, so this clamp is the same arithmetic it always was."""
+        assert _openai_llama_admission_output_allowance(
+            2048, budget = 2048, prompt_tokens = 1800, context_window = 2048
+        ) == 248

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -4,14 +4,8 @@
 """A cap of the whole window is not a cap, and pricing it as one serialises the queue.
 
 Studio ships "Max Tokens: Max", which sends max_tokens = the context length, and a client
-that names nothing gets the same figure from `_build_passthrough_payload`. So the common
-request claims it may write the whole window, and the reservation believed it: one chat
-committed the entire cache before generating a token.
-
-Measured on a 262144 cache with --parallel 4 --kv-unified, four chats reached first token
-at 0.1 / 2.8 / 4.6 / 8.8s with llamacpp:requests_deferred flat at 0: llama-server had free
-slots and never saw requests 2 to 4. #10046 fixed the tool-loop half of this; these cover
-the other half, which is every plain chat.
+naming nothing gets the same figure from `_build_passthrough_payload`. #10046 fixed the
+tool-loop half of this; these cover the other half, which is every plain chat.
 """
 
 from routes.inference import (
@@ -114,11 +108,9 @@ class TestNothingChangesWhereThereIsNoBudget:
 
 
 class TestMaxIsPerRequestNotPerCache:
-    """Under ``--parallel N --no-kv-unified`` the budget is the aggregate of N private
-    caches while "Max" is still one slot's context_length, so the two are in different
-    units. Measuring the cap against the budget read that default as a real cap: each
-    reservation cost a slot's share plus its prompt, and four default chats no longer fit
-    in four caches (4104 each against 16384, so three).
+    """Under ``--no-kv-unified`` the budget is the aggregate of N private caches while "Max"
+    is still one slot's context_length, so measuring the cap against the budget reads that
+    default as a real cap and four default chats stop fitting in four caches.
     """
 
     WINDOW = 4096  # per slot, and what "Max" sends
@@ -183,13 +175,9 @@ class TestMaxIsPerRequestNotPerCache:
 
 
 class TestTheAllowanceCannotExceedOneSlot:
-    """A request cannot occupy more KV than its own slot holds.
-
-    The allowance is clamped against the WINDOW, not the aggregate budget. Under
-    ``--no-kv-unified`` those differ by N, and clamping against the budget charged a
-    long-prompt chat for more than a slot can physically hold: four private 4096 caches
-    with a 3500-token prompt gave a flat 1024 allowance and a 4524 charge, so three such
-    chats filled the 16384 aggregate.
+    """A request cannot occupy more KV than its own slot holds, so the allowance is clamped
+    against the WINDOW; clamping against the aggregate budget charged a long-prompt chat for
+    more than a slot can physically hold.
     """
 
     WINDOW = 4096

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -111,3 +111,59 @@ class TestNothingChangesWhereThereIsNoBudget:
         assert (
             _openai_llama_admission_tokens(_chat(max_tokens = 4096), budget = None, capacity = 4) is None
         )
+
+
+class TestMaxIsPerRequestNotPerCache:
+    """Under ``--parallel N --no-kv-unified`` the budget is the aggregate of N private
+    caches while "Max" is still one slot's context_length, so the two are in different
+    units. Measuring the cap against the budget read that default as a real cap: each
+    reservation cost a slot's share plus its prompt, and four default chats no longer fit
+    in four caches (4104 each against 16384, so three).
+    """
+
+    WINDOW = 4096          # per slot, and what "Max" sends
+    BUDGET = WINDOW * 4    # four private caches
+
+    def test_max_is_unstated_against_the_per_request_window(self):
+        assert _openai_llama_admission_output_allowance(
+            self.WINDOW, budget = self.BUDGET, prompt_tokens = 100,
+            context_window = self.WINDOW,
+        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+
+    def test_four_default_chats_fit_four_private_caches(self):
+        cost = _openai_llama_admission_tokens(
+            _chat(max_tokens = self.WINDOW), budget = self.BUDGET, capacity = 4,
+            context_window = self.WINDOW,
+        )
+        assert cost * 4 <= self.BUDGET, (
+            f"four default chats cost {cost * 4} against {self.BUDGET}, so the fourth waits"
+        )
+
+    def test_a_real_cap_under_the_window_is_still_a_cap(self):
+        assert _openai_llama_admission_output_allowance(
+            512, budget = self.BUDGET, prompt_tokens = 100, context_window = self.WINDOW
+        ) == 512
+
+    def test_an_unknown_window_falls_back_to_the_budget(self):
+        """Which is the unified case, where the two are the same number anyway."""
+        assert _openai_llama_admission_output_allowance(
+            self.BUDGET, budget = self.BUDGET, prompt_tokens = 100, context_window = None
+        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+
+    def test_the_window_is_read_off_the_backend(self):
+        from types import SimpleNamespace
+
+        from routes.inference import _openai_llama_admission_context_window
+
+        backend = SimpleNamespace(context_length = self.WINDOW, _kv_cache_context_total = self.BUDGET)
+        assert _openai_llama_admission_context_window(backend) == self.WINDOW
+
+    def test_an_unreadable_window_is_none(self):
+        from types import SimpleNamespace
+
+        from routes.inference import _openai_llama_admission_context_window
+
+        for value in (None, 0, -1, "nonsense"):
+            assert _openai_llama_admission_context_window(
+                SimpleNamespace(context_length = value)
+            ) is None

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -197,7 +197,9 @@ class TestTheAllowanceCannotExceedOneSlot:
 
     def test_a_long_prompt_shrinks_the_allowance_to_fit_its_slot(self):
         allowance = _openai_llama_admission_output_allowance(
-            self.WINDOW, budget = self.BUDGET, prompt_tokens = 3500,
+            self.WINDOW,
+            budget = self.BUDGET,
+            prompt_tokens = 3500,
             context_window = self.WINDOW,
         )
         assert allowance == self.WINDOW - 3500
@@ -206,25 +208,40 @@ class TestTheAllowanceCannotExceedOneSlot:
     def test_four_long_prompt_chats_still_fit(self):
         prompt = 3500
         allowance = _openai_llama_admission_output_allowance(
-            self.WINDOW, budget = self.BUDGET, prompt_tokens = prompt,
+            self.WINDOW,
+            budget = self.BUDGET,
+            prompt_tokens = prompt,
             context_window = self.WINDOW,
         )
         assert (prompt + allowance) * 4 <= self.BUDGET
 
     def test_a_prompt_that_fills_the_slot_gets_nothing(self):
-        assert _openai_llama_admission_output_allowance(
-            self.WINDOW, budget = self.BUDGET, prompt_tokens = self.WINDOW,
-            context_window = self.WINDOW,
-        ) == 0
+        assert (
+            _openai_llama_admission_output_allowance(
+                self.WINDOW,
+                budget = self.BUDGET,
+                prompt_tokens = self.WINDOW,
+                context_window = self.WINDOW,
+            )
+            == 0
+        )
 
     def test_a_short_prompt_still_gets_the_full_allowance(self):
-        assert _openai_llama_admission_output_allowance(
-            self.WINDOW, budget = self.BUDGET, prompt_tokens = 100,
-            context_window = self.WINDOW,
-        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        assert (
+            _openai_llama_admission_output_allowance(
+                self.WINDOW,
+                budget = self.BUDGET,
+                prompt_tokens = 100,
+                context_window = self.WINDOW,
+            )
+            == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        )
 
     def test_unified_is_unchanged(self):
         """window == budget there, so this clamp is the same arithmetic it always was."""
-        assert _openai_llama_admission_output_allowance(
-            2048, budget = 2048, prompt_tokens = 1800, context_window = 2048
-        ) == 248
+        assert (
+            _openai_llama_admission_output_allowance(
+                2048, budget = 2048, prompt_tokens = 1800, context_window = 2048
+            )
+            == 248
+        )

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -3,22 +3,16 @@
 
 """A cap of the whole window is not a cap, and pricing it as one serialises the queue.
 
-Studio ships "Max Tokens: Max", and Max sends ``max_tokens`` = the context length. A
-client that names nothing gets the same figure a different way: ``_build_passthrough_payload``
-fills in ``max_tokens = backend_ctx``. So the overwhelmingly common request arrives
-claiming it may write the entire window, and the reservation believed it: one chat
-committed the whole cache before generating a token, and the next was refused however
-little either actually wrote.
+Studio ships "Max Tokens: Max", which sends max_tokens = the context length, and a client
+that names nothing gets the same figure from `_build_passthrough_payload`. So the common
+request claims it may write the whole window, and the reservation believed it: one chat
+committed the entire cache before generating a token.
 
-That is a budgeting artefact, not the hardware. Measured on a 262144 cache with
-``--parallel 4 --kv-unified``, four chats reached first token at 0.1 / 2.8 / 4.6 / 8.8s
-with ``llamacpp:requests_deferred`` flat at 0 the whole time: llama-server had free
-slots and never saw requests 2 to 4, because Studio held them.
-
-#10046 fixed the tool-loop half of this (``if tool_loop: return budget``). These cover
+Measured on a 262144 cache with --parallel 4 --kv-unified, four chats reached first token
+at 0.1 / 2.8 / 4.6 / 8.8s with llamacpp:requests_deferred flat at 0: llama-server had free
+slots and never saw requests 2 to 4. #10046 fixed the tool-loop half of this; these cover
 the other half, which is every plain chat.
 """
-
 from routes.inference import (
     _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS,
     _openai_llama_admission_output_allowance,
@@ -61,15 +55,14 @@ class TestWhatCountsAsUnstated:
         ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
 
     def test_a_cap_just_under_the_window_is_still_a_cap(self):
-        """Only "the whole window" is read as unstated. A caller that deliberately asks
-        for nearly all of it has said something, and is charged for it."""
+        """Only the whole window reads as unstated; asking for nearly all of it is a
+        statement, and is charged."""
         assert _openai_llama_admission_output_allowance(
             32767, budget = 32768, prompt_tokens = 100
         ) == 32767
 
     def test_it_never_exceeds_what_is_left(self):
-        """On a cache smaller than the default allowance, the reservation stays inside the
-        budget rather than asking for room that does not exist."""
+        """On a cache smaller than the allowance, stay inside the budget."""
         assert _openai_llama_admission_output_allowance(
             None, budget = 2048, prompt_tokens = 1800
         ) == 248
@@ -93,8 +86,7 @@ class TestTheDefaultChatNoLongerTakesTheWholeCache:
         assert cost <= _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS + 100
 
     def test_four_default_chats_fit_at_once(self):
-        """The point of the change, stated as the thing the user sees. Four chats on
-        Max Tokens = Max have to fit in one cache together, or the fourth waits."""
+        """The change, as the user sees it: four chats on Max have to fit together."""
         cost = self._cost(_chat(max_tokens = self.BUDGET))
         assert cost * 4 <= self.BUDGET, (
             f"four default chats cost {cost * 4} against a {self.BUDGET} cache, so they "
@@ -106,14 +98,12 @@ class TestTheDefaultChatNoLongerTakesTheWholeCache:
         assert cost * 4 <= self.BUDGET
 
     def test_a_named_cap_is_unaffected(self):
-        """Backwards compatibility: a request that states a real cap is priced exactly as
-        it was before, prompt plus cap."""
+        """Backwards compatible: a stated cap is still priced prompt plus cap."""
         small = self._cost(_chat(max_tokens = 512))
         assert small < self._cost(_chat(max_tokens = 8192))
 
     def test_max_completion_tokens_spelling_counts_too(self):
-        """The supported spelling reaches the same resolver, so "Max" through it must be
-        read as unstated as well."""
+        """The supported spelling reaches the same resolver, so "Max" through it counts."""
         assert self._cost(_chat(max_completion_tokens = self.BUDGET)) < self.BUDGET
 
 

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -121,34 +121,47 @@ class TestMaxIsPerRequestNotPerCache:
     in four caches (4104 each against 16384, so three).
     """
 
-    WINDOW = 4096          # per slot, and what "Max" sends
-    BUDGET = WINDOW * 4    # four private caches
+    WINDOW = 4096  # per slot, and what "Max" sends
+    BUDGET = WINDOW * 4  # four private caches
 
     def test_max_is_unstated_against_the_per_request_window(self):
-        assert _openai_llama_admission_output_allowance(
-            self.WINDOW, budget = self.BUDGET, prompt_tokens = 100,
-            context_window = self.WINDOW,
-        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        assert (
+            _openai_llama_admission_output_allowance(
+                self.WINDOW,
+                budget = self.BUDGET,
+                prompt_tokens = 100,
+                context_window = self.WINDOW,
+            )
+            == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        )
 
     def test_four_default_chats_fit_four_private_caches(self):
         cost = _openai_llama_admission_tokens(
-            _chat(max_tokens = self.WINDOW), budget = self.BUDGET, capacity = 4,
+            _chat(max_tokens = self.WINDOW),
+            budget = self.BUDGET,
+            capacity = 4,
             context_window = self.WINDOW,
         )
-        assert cost * 4 <= self.BUDGET, (
-            f"four default chats cost {cost * 4} against {self.BUDGET}, so the fourth waits"
-        )
+        assert (
+            cost * 4 <= self.BUDGET
+        ), f"four default chats cost {cost * 4} against {self.BUDGET}, so the fourth waits"
 
     def test_a_real_cap_under_the_window_is_still_a_cap(self):
-        assert _openai_llama_admission_output_allowance(
-            512, budget = self.BUDGET, prompt_tokens = 100, context_window = self.WINDOW
-        ) == 512
+        assert (
+            _openai_llama_admission_output_allowance(
+                512, budget = self.BUDGET, prompt_tokens = 100, context_window = self.WINDOW
+            )
+            == 512
+        )
 
     def test_an_unknown_window_falls_back_to_the_budget(self):
         """Which is the unified case, where the two are the same number anyway."""
-        assert _openai_llama_admission_output_allowance(
-            self.BUDGET, budget = self.BUDGET, prompt_tokens = 100, context_window = None
-        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        assert (
+            _openai_llama_admission_output_allowance(
+                self.BUDGET, budget = self.BUDGET, prompt_tokens = 100, context_window = None
+            )
+            == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        )
 
     def test_the_window_is_read_off_the_backend(self):
         from types import SimpleNamespace
@@ -162,8 +175,8 @@ class TestMaxIsPerRequestNotPerCache:
         from types import SimpleNamespace
 
         from routes.inference import _openai_llama_admission_context_window
-
         for value in (None, 0, -1, "nonsense"):
-            assert _openai_llama_admission_context_window(
-                SimpleNamespace(context_length = value)
-            ) is None
+            assert (
+                _openai_llama_admission_context_window(SimpleNamespace(context_length = value))
+                is None
+            )

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A cap of the whole window is not a cap, and pricing it as one serialises the queue.
+
+Studio ships "Max Tokens: Max", and Max sends ``max_tokens`` = the context length. A
+client that names nothing gets the same figure a different way: ``_build_passthrough_payload``
+fills in ``max_tokens = backend_ctx``. So the overwhelmingly common request arrives
+claiming it may write the entire window, and the reservation believed it: one chat
+committed the whole cache before generating a token, and the next was refused however
+little either actually wrote.
+
+That is a budgeting artefact, not the hardware. Measured on a 262144 cache with
+``--parallel 4 --kv-unified``, four chats reached first token at 0.1 / 2.8 / 4.6 / 8.8s
+with ``llamacpp:requests_deferred`` flat at 0 the whole time: llama-server had free
+slots and never saw requests 2 to 4, because Studio held them.
+
+#10046 fixed the tool-loop half of this (``if tool_loop: return budget``). These cover
+the other half, which is every plain chat.
+"""
+
+from routes.inference import (
+    _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS,
+    _openai_llama_admission_output_allowance,
+    _openai_llama_admission_tokens,
+)
+
+
+class _Payload:
+    def __init__(self, **fields):
+        self.__dict__.update(fields)
+
+    def __getattr__(self, _name):
+        return None
+
+
+def _chat(**fields):
+    return _Payload(messages = [{"role": "user", "content": "hi"}], **fields)
+
+
+class TestWhatCountsAsUnstated:
+    def test_a_real_cap_is_charged_as_asked(self):
+        assert _openai_llama_admission_output_allowance(
+            512, budget = 32768, prompt_tokens = 100
+        ) == 512
+
+    def test_no_cap_is_unstated(self):
+        assert _openai_llama_admission_output_allowance(
+            None, budget = 32768, prompt_tokens = 100
+        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+
+    def test_a_cap_of_the_whole_window_is_unstated(self):
+        """This is the "Max" setting, and it is the default."""
+        assert _openai_llama_admission_output_allowance(
+            32768, budget = 32768, prompt_tokens = 100
+        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+
+    def test_a_cap_above_the_window_is_unstated(self):
+        assert _openai_llama_admission_output_allowance(
+            99999, budget = 32768, prompt_tokens = 100
+        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+
+    def test_a_cap_just_under_the_window_is_still_a_cap(self):
+        """Only "the whole window" is read as unstated. A caller that deliberately asks
+        for nearly all of it has said something, and is charged for it."""
+        assert _openai_llama_admission_output_allowance(
+            32767, budget = 32768, prompt_tokens = 100
+        ) == 32767
+
+    def test_it_never_exceeds_what_is_left(self):
+        """On a cache smaller than the default allowance, the reservation stays inside the
+        budget rather than asking for room that does not exist."""
+        assert _openai_llama_admission_output_allowance(
+            None, budget = 2048, prompt_tokens = 1800
+        ) == 248
+        assert _openai_llama_admission_output_allowance(
+            None, budget = 2048, prompt_tokens = 4000
+        ) == 0
+
+
+class TestTheDefaultChatNoLongerTakesTheWholeCache:
+    BUDGET = 32768
+    CAPACITY = 4
+
+    def _cost(self, payload):
+        return _openai_llama_admission_tokens(
+            payload, budget = self.BUDGET, capacity = self.CAPACITY
+        )
+
+    def test_max_tokens_max_does_not_reserve_the_budget(self):
+        cost = self._cost(_chat(max_tokens = self.BUDGET))
+        assert cost < self.BUDGET, "Max Tokens = Max still reserves the whole cache"
+        assert cost <= _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS + 100
+
+    def test_four_default_chats_fit_at_once(self):
+        """The point of the change, stated as the thing the user sees. Four chats on
+        Max Tokens = Max have to fit in one cache together, or the fourth waits."""
+        cost = self._cost(_chat(max_tokens = self.BUDGET))
+        assert cost * 4 <= self.BUDGET, (
+            f"four default chats cost {cost * 4} against a {self.BUDGET} cache, so they "
+            f"cannot decode together"
+        )
+
+    def test_an_uncapped_chat_fits_too(self):
+        cost = self._cost(_chat())
+        assert cost * 4 <= self.BUDGET
+
+    def test_a_named_cap_is_unaffected(self):
+        """Backwards compatibility: a request that states a real cap is priced exactly as
+        it was before, prompt plus cap."""
+        small = self._cost(_chat(max_tokens = 512))
+        assert small < self._cost(_chat(max_tokens = 8192))
+
+    def test_max_completion_tokens_spelling_counts_too(self):
+        """The supported spelling reaches the same resolver, so "Max" through it must be
+        read as unstated as well."""
+        assert self._cost(_chat(max_completion_tokens = self.BUDGET)) < self.BUDGET
+
+
+class TestNothingChangesWhereThereIsNoBudget:
+    def test_an_unknown_budget_still_declines_to_price(self):
+        assert _openai_llama_admission_tokens(
+            _chat(max_tokens = 4096), budget = None, capacity = 4
+        ) is None

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -174,6 +174,56 @@ class TestMaxIsPerRequestNotPerCache:
             )
 
 
+class TestTheAllowanceFitsTheAdvertisedSlots:
+    """A flat allowance is most of a share on a small cache, so it broke the very thing it
+    was added to fix: at 4096 over four slots a default chat cost 1032 and only three ran,
+    and at 2048 only one did. Clamped to the share, ``capacity`` of them always fit.
+    """
+
+    def _cost(self, budget, capacity):
+        return _openai_llama_admission_tokens(
+            _chat(max_tokens = budget), budget = budget, capacity = capacity,
+            context_window = budget,
+        )
+
+    def test_capacity_default_chats_fit_at_every_cache_size(self):
+        for budget in (2048, 4096, 8192, 32768, 262144):
+            cost = self._cost(budget, 4)
+            assert cost * 4 <= budget, f"{budget} cache admits only {budget // cost} of 4"
+
+    def test_a_large_cache_is_unchanged(self):
+        """The clamp must bite only where the share is the tighter of the two."""
+        assert self._cost(32768, 4) == self._cost(262144, 4)
+
+    def test_the_share_only_ever_lowers_the_allowance(self):
+        base = _openai_llama_admission_output_allowance(
+            None, budget = 4096, prompt_tokens = 100, context_window = 4096
+        )
+        assert (
+            _openai_llama_admission_output_allowance(
+                None, budget = 4096, prompt_tokens = 100, context_window = 4096, share = 1024
+            )
+            < base
+        )
+
+    def test_a_prompt_past_its_share_keeps_the_flat_allowance(self):
+        """Zeroing it would admit a request with no room to generate at all."""
+        assert (
+            _openai_llama_admission_output_allowance(
+                None, budget = 8192, prompt_tokens = 3000, context_window = 8192, share = 2048
+            )
+            == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        )
+
+    def test_a_named_cap_ignores_the_share(self):
+        assert (
+            _openai_llama_admission_output_allowance(
+                256, budget = 2048, prompt_tokens = 10, context_window = 2048, share = 512
+            )
+            == 256
+        )
+
+
 class TestTheAllowanceCannotExceedOneSlot:
     """A request cannot occupy more KV than its own slot holds, so the allowance is clamped
     against the WINDOW; clamping against the aggregate budget charged a long-prompt chat for

--- a/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
+++ b/studio/backend/tests/test_llama_admission_unstated_max_tokens.py
@@ -13,6 +13,7 @@ at 0.1 / 2.8 / 4.6 / 8.8s with llamacpp:requests_deferred flat at 0: llama-serve
 slots and never saw requests 2 to 4. #10046 fixed the tool-loop half of this; these cover
 the other half, which is every plain chat.
 """
+
 from routes.inference import (
     _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS,
     _openai_llama_admission_output_allowance,
@@ -34,41 +35,41 @@ def _chat(**fields):
 
 class TestWhatCountsAsUnstated:
     def test_a_real_cap_is_charged_as_asked(self):
-        assert _openai_llama_admission_output_allowance(
-            512, budget = 32768, prompt_tokens = 100
-        ) == 512
+        assert _openai_llama_admission_output_allowance(512, budget = 32768, prompt_tokens = 100) == 512
 
     def test_no_cap_is_unstated(self):
-        assert _openai_llama_admission_output_allowance(
-            None, budget = 32768, prompt_tokens = 100
-        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        assert (
+            _openai_llama_admission_output_allowance(None, budget = 32768, prompt_tokens = 100)
+            == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        )
 
     def test_a_cap_of_the_whole_window_is_unstated(self):
         """This is the "Max" setting, and it is the default."""
-        assert _openai_llama_admission_output_allowance(
-            32768, budget = 32768, prompt_tokens = 100
-        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        assert (
+            _openai_llama_admission_output_allowance(32768, budget = 32768, prompt_tokens = 100)
+            == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        )
 
     def test_a_cap_above_the_window_is_unstated(self):
-        assert _openai_llama_admission_output_allowance(
-            99999, budget = 32768, prompt_tokens = 100
-        ) == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        assert (
+            _openai_llama_admission_output_allowance(99999, budget = 32768, prompt_tokens = 100)
+            == _OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS
+        )
 
     def test_a_cap_just_under_the_window_is_still_a_cap(self):
         """Only the whole window reads as unstated; asking for nearly all of it is a
         statement, and is charged."""
-        assert _openai_llama_admission_output_allowance(
-            32767, budget = 32768, prompt_tokens = 100
-        ) == 32767
+        assert (
+            _openai_llama_admission_output_allowance(32767, budget = 32768, prompt_tokens = 100)
+            == 32767
+        )
 
     def test_it_never_exceeds_what_is_left(self):
         """On a cache smaller than the allowance, stay inside the budget."""
-        assert _openai_llama_admission_output_allowance(
-            None, budget = 2048, prompt_tokens = 1800
-        ) == 248
-        assert _openai_llama_admission_output_allowance(
-            None, budget = 2048, prompt_tokens = 4000
-        ) == 0
+        assert (
+            _openai_llama_admission_output_allowance(None, budget = 2048, prompt_tokens = 1800) == 248
+        )
+        assert _openai_llama_admission_output_allowance(None, budget = 2048, prompt_tokens = 4000) == 0
 
 
 class TestTheDefaultChatNoLongerTakesTheWholeCache:
@@ -76,9 +77,7 @@ class TestTheDefaultChatNoLongerTakesTheWholeCache:
     CAPACITY = 4
 
     def _cost(self, payload):
-        return _openai_llama_admission_tokens(
-            payload, budget = self.BUDGET, capacity = self.CAPACITY
-        )
+        return _openai_llama_admission_tokens(payload, budget = self.BUDGET, capacity = self.CAPACITY)
 
     def test_max_tokens_max_does_not_reserve_the_budget(self):
         cost = self._cost(_chat(max_tokens = self.BUDGET))
@@ -109,6 +108,6 @@ class TestTheDefaultChatNoLongerTakesTheWholeCache:
 
 class TestNothingChangesWhereThereIsNoBudget:
     def test_an_unknown_budget_still_declines_to_price(self):
-        assert _openai_llama_admission_tokens(
-            _chat(max_tokens = 4096), budget = None, capacity = 4
-        ) is None
+        assert (
+            _openai_llama_admission_tokens(_chat(max_tokens = 4096), budget = None, capacity = 4) is None
+        )


### PR DESCRIPTION
## What

Studio ships **Max Tokens: Max**, and Max sends `max_tokens` = the context length. A client that names nothing arrives the same way, because `_build_passthrough_payload` fills in `max_tokens = backend_ctx`. So the overwhelmingly common request claims it may write the entire window, and admission believed it: one chat committed the whole KV cache before generating a token, and the next was refused however little either actually wrote.

That is the reservation, not the hardware. Measured on a 262144 cache with `--parallel 4 --kv-unified`, four chats reached first token at 0.1 / 2.8 / 4.6 / 8.8s with `llamacpp:requests_deferred` flat at **0** the whole time. llama-server had free slots and never saw requests 2 to 4, because Studio was holding them.

#10046 fixed the tool-loop half of this, the `if tool_loop: return budget` branch. This is the other half, and it covers every plain chat.

## How

An absent cap and a cap of the whole window are the same statement, and neither is a promise to fill the cache. Both are now charged `_OPENAI_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS`, which is 1024, clamped to what is left of the budget and overridable with `UNSLOTH_LLAMA_ADMISSION_UNSTATED_OUTPUT_TOKENS`.

Only "the whole window" reads as unstated. A caller that deliberately asks for nearly all of it has said something, and is charged for it.

The opening estimate and the round re-cost call one helper, so a re-cost cannot read "Max" literally and put the run back on the whole cache at its first round boundary, undoing at round zero exactly what the opening stopped doing.

## Before and after

Measured through `_openai_llama_admission_tokens` on a 32768 cache with four slots, before and after on the same tree:

| request | before | after | four fit at once |
| --- | --- | --- | --- |
| Max Tokens = Max | 32768 | 1032 | no to yes |
| no cap named | 32768 | 1032 | no to yes |
| `max_tokens = 512` | 520 | 520 | unchanged |

A request that states a real cap is priced exactly as it was.

## The trade, stated plainly

This is an **estimate** where the rest of that function is a **bound**. A run that generates more than the allowance is undercharged until something re-costs it. A tool loop does that at every round boundary (#10046). A plain chat has no round boundary yet, so on a genuinely full cache a long uncapped generation can still overrun, which is the hazard the old "reserve the window" behaviour was closing.

It was closing it by making the default chat un-runnable concurrently, which is too high a price for a case almost nothing hits. The env knob is there for a deployment where it does, and mid-turn preemption is what removes the caveat properly.

## Tests

New `test_llama_admission_unstated_max_tokens.py`: what counts as unstated (absent, equal to the window, above it, and the boundary case one below it, which stays a real cap), that the allowance never exceeds what is left on a small cache, that four default chats now fit in one cache, that `max_completion_tokens` is read the same way, and that an unknown budget still declines to price.

Two existing tests pinned the old policy and are **updated rather than deleted**, since the policy is what changed:

- `test_an_uncapped_request_reserves_the_rest_of_the_window` becomes `..._reserves_a_bounded_allowance`.
- `test_round_zero_keeps_an_uncapped_loop_s_output_allowance` keeps the invariant it exists for, that the re-cost must not shrink the opening lease, and drops its assumption that the opening is the whole cache. It now asserts the two sides agree rather than asserting a number, which is the property that actually matters.

`test_two_uncapped_short_prompts_do_not_both_run` still passes, but for a different reason than before, and its docstring now says so: on a 2048 cache two of them simply do not fit. On a larger cache they now do both run, which is the point.

Affected suites: `test_llama_admission*.py`, `test_anthropic_admission.py`, `test_llama_cpp_tool_loop.py` -> **384 passed, 5 skipped**.
