### PR TITLE
Studio: fix clipped settings scrollbar on Windows WebView2

### DIFF
--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -456,7 +456,7 @@ export function SettingsDialog() {
                 )}
               </div>
               {results ? (
-                <div className="hover-scrollbar flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto px-1 pb-1 max-sm:hidden">
+                <div className="hover-scrollbar flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto px-1 py-1 max-sm:hidden">
                   {results.length === 0 ? (
                     <p className="px-3 py-2 text-sm text-muted-foreground">
                       {t("settings.dialog.searchNoResults")}
@@ -508,8 +508,8 @@ export function SettingsDialog() {
                   // The tab list is the sidebar's flexible row: a short window
                   // leaves it taller than the sidebar, and the dialog clips its
                   // overflow, so scroll it rather than losing the last tabs.
-                  "hover-scrollbar flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-1 pb-1",
-                  "max-sm:flex-none max-sm:flex-row max-sm:overflow-x-auto max-sm:pb-0",
+                  "hover-scrollbar flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-1 py-1",
+                  "max-sm:flex-none max-sm:flex-row max-sm:overflow-x-auto max-sm:py-0",
                   results !== null && "max-sm:flex hidden",
                 )}
               >

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2972,13 +2972,8 @@ html[data-chat-font] .aui-root {
 	background: oklch(0.72 0 0 / 0.4);
 }
 
-/* Chromium ignores every ::-webkit-scrollbar rule on an element whose
-   scrollbar-width/scrollbar-color are set, so on Windows these surfaces drew
-   the native rail: flush to the box, its squared top cap clipping against the
-   rounded pills. Reset both properties there (including :hover, which would
-   otherwise re-set scrollbar-color and flip the rail back to native) so the
-   webkit styling above applies. The @supports guard keeps Firefox, which has
-   no webkit scrollbar styling to fall back on, on the standard properties. */
+/* Chromium ignores ::-webkit-scrollbar styling while scrollbar-width/color are
+   set; on Windows reset both (:hover too, or it flips back) to restore it. */
 @supports selector(::-webkit-scrollbar) {
 	:root.client-windows .sidebar-scroll-fade,
 	:root.client-windows .sidebar-scroll-fade:hover,

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2972,6 +2972,25 @@ html[data-chat-font] .aui-root {
 	background: oklch(0.72 0 0 / 0.4);
 }
 
+/* Chromium ignores every ::-webkit-scrollbar rule on an element whose
+   scrollbar-width/scrollbar-color are set, so on Windows these surfaces drew
+   the native rail: flush to the box, its squared top cap clipping against the
+   rounded pills. Reset both properties there (including :hover, which would
+   otherwise re-set scrollbar-color and flip the rail back to native) so the
+   webkit styling above applies. The @supports guard keeps Firefox, which has
+   no webkit scrollbar styling to fall back on, on the standard properties. */
+@supports selector(::-webkit-scrollbar) {
+	:root.client-windows .sidebar-scroll-fade,
+	:root.client-windows .sidebar-scroll-fade:hover,
+	:root.client-windows .run-settings-scroll,
+	:root.client-windows .run-settings-scroll:hover,
+	:root.client-windows .hover-scrollbar,
+	:root.client-windows .hover-scrollbar:hover {
+		scrollbar-width: auto;
+		scrollbar-color: auto;
+	}
+}
+
 /* Run settings: always reserve the scrollbar gutter so the header close
    button keeps its position whether or not the scrollbar is showing. */
 .run-settings-scroll {

--- a/studio/frontend/src/main.tsx
+++ b/studio/frontend/src/main.tsx
@@ -32,9 +32,7 @@ if (uaLower.includes("linux") && !uaLower.includes("android")) {
   document.documentElement.classList.add("render-linux");
 }
 
-// Chromium draws the native scrollbar wherever the standard scrollbar
-// properties are set; index.css keys off this class to hand hover scrollbars
-// on Windows back to the ::-webkit-scrollbar styling.
+// index.css keys off this to restore ::-webkit-scrollbar styling on Windows.
 if (uaLower.includes("windows")) {
   document.documentElement.classList.add("client-windows");
 }

--- a/studio/frontend/src/main.tsx
+++ b/studio/frontend/src/main.tsx
@@ -32,6 +32,13 @@ if (uaLower.includes("linux") && !uaLower.includes("android")) {
   document.documentElement.classList.add("render-linux");
 }
 
+// Chromium draws the native scrollbar wherever the standard scrollbar
+// properties are set; index.css keys off this class to hand hover scrollbars
+// on Windows back to the ::-webkit-scrollbar styling.
+if (uaLower.includes("windows")) {
+  document.documentElement.classList.add("client-windows");
+}
+
 // Whether off-screen maths takes containment. ON by default, subject to a feature detect for the
 // engine's find-in-page, so on a recent engine this normally SETS the attribute and arms the rule;
 // on an older one it removes an attribute that was never there. Before the first render, because

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -152,9 +152,15 @@ test("the sidebar list measures its scroll rail", async () => {
     new URL("../src/index.css", import.meta.url),
     "utf8",
   );
-  // No width override: the rail keeps the width the rest of the app uses, and
-  // hiding it outright is what took the scrollbar away.
-  assert.equal(/\.sidebar-scroll-fade[^{]*\{[^}]*scrollbar-width/.test(css), false);
+  // The one allowed width declaration is the Windows reset back to the browser
+  // default, which hands the rail to the same ::-webkit-scrollbar styling the
+  // other lists use. Anything else (thin, none, a px width) shrinks or hides
+  // the rail, and hiding it outright is what took the scrollbar away.
+  const railWidthDecls = (
+    css.match(/\.sidebar-scroll-fade[^{]*\{[^}]*scrollbar-width:\s*[^;}]+/g) ?? []
+  ).map((rule) => /scrollbar-width:\s*([^;}]+)/.exec(rule)?.[1].trim());
+  assert.deepEqual(railWidthDecls, ["auto"]);
+  assert.match(css, /:root\.client-windows \.sidebar-scroll-fade,/);
   assert.equal(
     /\.sidebar-scroll-fade::-webkit-scrollbar \{/.test(css),
     false,

--- a/studio/frontend/tests/sidebar-action-rows-inert.test.ts
+++ b/studio/frontend/tests/sidebar-action-rows-inert.test.ts
@@ -152,10 +152,8 @@ test("the sidebar list measures its scroll rail", async () => {
     new URL("../src/index.css", import.meta.url),
     "utf8",
   );
-  // The one allowed width declaration is the Windows reset back to the browser
-  // default, which hands the rail to the same ::-webkit-scrollbar styling the
-  // other lists use. Anything else (thin, none, a px width) shrinks or hides
-  // the rail, and hiding it outright is what took the scrollbar away.
+  // Only the Windows auto reset may set a width; hiding the rail is what a
+  // width override caused before.
   const railWidthDecls = (
     css.match(/\.sidebar-scroll-fade[^{]*\{[^}]*scrollbar-width:\s*[^;}]+/g) ?? []
   ).map((rule) => /scrollbar-width:\s*([^;}]+)/.exec(rule)?.[1].trim());


### PR DESCRIPTION
The settings tab list scrollbar added in #9696 renders as a classic scrollbar on Windows WebView2, running flush to the container edges with its top cap clipped and overlapping the tab pills. 