### PR TITLE
Stop two installer tests answering about the runner instead of the code

### DIFF
--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -134,6 +134,13 @@ def test_skips_torchao_on_windows_rocm(
     monkeypatch.setattr(
         mod, "_installed_torch_is_windows_rocm", lambda: installed_torch_is_windows_rocm
     )
+    # #10053 added a require_present gate to install_python_stack: after the core phase
+    # it refuses when a managed distribution is not installed at all, which SKIP_STUDIO_BASE
+    # guarantees here. Unstubbed, this test asks whether unsloth happens to be installed in
+    # whatever environment runs it -- it passes on a developer machine that has it and fails
+    # in CI, which is not what the test is about. Stubbed like every other installer side
+    # effect below.
+    monkeypatch.setattr(mod, "_repair_damaged_core_payload", lambda *a, **k: True)
     monkeypatch.setattr(mod, "_bootstrap_uv", lambda: False)
     monkeypatch.setattr(mod, "_repair_bad_anyio", lambda: None)
     monkeypatch.setattr(mod, "_ensure_rocm_torch", lambda: None)

--- a/tests/studio/install/test_install_manifest_damage.py
+++ b/tests/studio/install/test_install_manifest_damage.py
@@ -686,8 +686,15 @@ def test_an_unimportable_helper_forces_the_dependency_pass(tmp_path, contents, e
     script_dir.mkdir()
     if contents is not None:
         (script_dir / "install_manifest.py").write_text(contents, encoding = "utf-8")
+    # -I -S so `script_dir` is the ONLY place install_manifest can come from. The probe
+    # imports it off sys.path, and an install_manifest reachable from site-packages or
+    # PYTHONPATH satisfies that import even when the directory under test is empty: the
+    # "absent" case then falls through to a real verify_install against whatever tree the
+    # runner happens to have, and answers about that instead. -I drops PYTHONPATH and the
+    # user site, -S drops site-packages. Neither is needed by the probe, whose only
+    # imports are os, sys and the file being tested.
     result = subprocess.run(
-        [sys.executable, "-c", _installer_helper_probe(), str(script_dir)],
+        [sys.executable, "-I", "-S", "-c", _installer_helper_probe(), str(script_dir)],
         capture_output = True,
     )
     assert result.returncode == expected


### PR DESCRIPTION
## What

`Backend CI` and `Repo tests (CPU)` have been red on `main` since #10053, and therefore on **every open branch**, because both jobs clone `main`. Neither failure is a product bug: both tests read ambient state that #10053 gave meaning to.

Confirmed on a staging replica rather than inferred. Staging `main` at `1400031e2` fails exactly these:

```
FAILED tests/test_torchao_select.py::test_skips_torchao_on_windows_rocm[True-False] - AssertionError: assert 1 == 0
FAILED tests/test_torchao_select.py::test_skips_torchao_on_windows_rocm[False-True] - AssertionError: assert 1 == 0
FAILED tests/studio/install/test_install_manifest_damage.py::test_an_unimportable_helper_forces_the_dependency_pass[absent-keeps-the-fast-path] - assert 1 == 0
```

and the previous main it ran, `10fe27154`, was green.

## The two causes

**`test_skips_torchao_on_windows_rocm`.** #10053 added a `require_present` gate to `install_python_stack`: after the core phase it refuses when a managed distribution is not installed at all. The test sets `SKIP_STUDIO_BASE=1`, so that phase never runs, and it does not stub the new gate. Unstubbed, the test asks whether `unsloth` happens to be installed wherever it runs, which is why it passes on a developer machine and fails in CI.

Reproduced directly, with `installed_versions` empty:

```
   unsloth is not installed, so this environment cannot run. Rerun the installer with the package index available.
dists absent -> _repair_damaged_core_payload: False
=> install_python_stack() returns 1
```

That is the observed `assert 1 == 0`. It is now stubbed alongside `_repair_bad_anyio`, `_ensure_rocm_torch` and the other installer side effects the test already neutralises.

**`test_an_unimportable_helper_forces_the_dependency_pass`.** #10053 also added `deep = True` to `setup.sh`'s manifest probe. The probe does `sys.path.insert(0, sys.argv[1])` and then `import install_manifest`, so an `install_manifest` reachable from site-packages or `PYTHONPATH` satisfies that import even when the directory under test is empty. The `absent` case then falls through to a real `verify_install` against whatever tree the runner has, and answers about that instead.

The subprocess now runs with `-I -S`, so `script_dir` is the only place the module can come from. Measured with an ambient `install_manifest`:

| | absent | truncated | raises |
| --- | --- | --- | --- |
| before | **1, expected 0** | 1 | 1 |
| `-I -S` | 0 | 1 | 1 |

Reverting just this hunk reproduces the CI failure locally and nothing else. Neither flag costs the probe anything: its only imports are `os`, `sys` and the file under test.

## #10053 itself is correct and is unchanged

Worth stating, since the fix is on the test side. `verify_install(deep = True)` was checked against a real installed tree: `damaged_payload_files` reports **0**, and the not-ok is the pre-existing `studio_install_incomplete`, so the new payload scan is not false-positiving. The `require_present` refusal is right for a real install too. Both stay exactly as they are.

## Not fixed here, but worth knowing

`tests/studio/install/test_rocm_support.py` drives `install_python_stack()` to `== 0` under `SKIP_STUDIO_BASE=1` twice and does not stub the new gate either. It passes today only because the job that runs it has `unsloth` installed. It is latently exposed to the same thing, and I left it alone rather than churn a passing 494-test file on a hypothetical.

## Verification

`tests/studio/install/` plus `tests/python/test_install_python_stack.py`: **3437 passed, 3 skipped**. `tests/test_torchao_select.py` and `tests/test_install_resolve_prebuilt.py`: **228 passed, 1 skipped**.
