### PR TITLE
Studio: two tests that read the runner instead of the tree under test

### DIFF
--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -136,6 +136,10 @@ def test_skips_torchao_on_windows_rocm(
     )
     monkeypatch.setattr(mod, "_bootstrap_uv", lambda: False)
     monkeypatch.setattr(mod, "_repair_bad_anyio", lambda: None)
+    # SKIP_STUDIO_BASE=1 leaves the core phase to the caller, and the post-phase gate
+    # then refuses a venv with no unsloth in it. This runner has none: it installs the
+    # backend's dependencies, not the package. Nothing here is about that gate.
+    monkeypatch.setattr(mod, "_repair_damaged_core_payload", lambda *args, **kwargs: True)
     monkeypatch.setattr(mod, "_ensure_rocm_torch", lambda: None)
     monkeypatch.setattr(mod, "_ensure_cuda_torch", lambda: None)
     monkeypatch.setattr(mod, "_has_usable_nvidia_gpu", lambda: True)

--- a/tests/studio/install/test_install_manifest_damage.py
+++ b/tests/studio/install/test_install_manifest_damage.py
@@ -686,9 +686,15 @@ def test_an_unimportable_helper_forces_the_dependency_pass(tmp_path, contents, e
     script_dir.mkdir()
     if contents is not None:
         (script_dir / "install_manifest.py").write_text(contents, encoding = "utf-8")
+    # Without PYTHONPATH: setup.sh runs this as the venv's own python, whose only
+    # source of install_manifest is the directory it passes in. Inherited, the repo's
+    # own studio/ answers the import the absent case is about, and the probe goes on
+    # to verify THIS checkout instead of the tree under test.
+    env = {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
     result = subprocess.run(
         [sys.executable, "-c", _installer_helper_probe(), str(script_dir)],
         capture_output = True,
+        env = env,
     )
     assert result.returncode == expected
 


### PR DESCRIPTION
Two tests on main fail on any runner where the conditions they read happen to be true. Both were invisible so far because every recent Backend CI run on main was cancelled before it finished; the first run that completed (on an unrelated PR) reported them.

Neither test is wrong about the code it covers. Each reads something about the runner and treats it as part of the tree under test.

### `tests/studio/install/test_install_manifest_damage.py::test_an_unimportable_helper_forces_the_dependency_pass[absent-keeps-the-fast-path]`

The test runs setup.sh's manifest-helper probe in a subprocess and passes it a temporary directory with no `install_manifest.py` in it, expecting exit 0. The Repo tests job sets `PYTHONPATH` to the repo's own `studio/`, the subprocess inherits it, and `import install_manifest` therefore succeeds from this checkout. The probe then runs `verify_install()` against the wrong tree, which is not ok, and exits 1.

Reproduced on plain `origin/main` with nothing else changed:

```
PYTHONPATH="$PWD/studio" pytest tests/studio/install/test_install_manifest_damage.py -q
FAILED ...[absent-keeps-the-fast-path]
```

Fixed by dropping `PYTHONPATH` from the child's environment. setup.sh runs this probe as the venv's own python, whose only source of `install_manifest` is the directory it passes in, so the child now matches what it is standing in for.

### `studio/backend/tests/test_torchao_select.py::test_skips_torchao_on_windows_rocm`

The test calls `install_python_stack()` with `SKIP_STUDIO_BASE=1`. The post-core presence gate added in #10053 refuses a venv that has no unsloth installed at all, and the backend job installs the backend's dependencies rather than the package, so the gate fires and the installer returns 1 before the assertion about torchao is ever reached.

The gate is right; the test simply does not stub it. Stubbed like the other repair helpers the test already stubs (`_repair_bad_anyio`, `_ensure_rocm_torch`, `_ensure_cuda_torch`), since nothing in this test is about payload repair.

### Verification

Both files pass on this branch with the CI's `PYTHONPATH` set, and the torchao file passes both with unsloth present and with `installed_versions` returning nothing, which is the runner's state:

```
PYTHONPATH="$PWD/studio" pytest tests/studio/install/test_install_manifest_damage.py -q   ->  51 passed
pytest studio/backend/tests/test_torchao_select.py -q                                     ->  29 passed
```

Tests only. No production code is touched.
