### PR TITLE
Studio: show progress during audio generation

### DIFF
--- a/studio/frontend/src/features/audio/audio-page-policy.ts
+++ b/studio/frontend/src/features/audio/audio-page-policy.ts
@@ -11,6 +11,54 @@ export type AudioBusy =
   | "transcribing"
   | null;
 
+export type AudioGenerationPhase =
+  | "preparing"
+  | "generating"
+  | "stopping"
+  | "finishing"
+  | null;
+
+export type AudioGenerationPresentation = {
+  status: string;
+  actionLabel: string;
+  canStop: boolean;
+};
+
+/** Project request-lifetime phases into truthful UI copy. Audio generation has no
+ * browser-visible numeric progress, so these labels never imply a fraction or ETA. */
+export function audioGenerationPresentation(
+  phase: AudioGenerationPhase,
+): AudioGenerationPresentation | null {
+  switch (phase) {
+    case "preparing":
+      return {
+        status: "Preparing audio…",
+        actionLabel: "Preparing…",
+        canStop: false,
+      };
+    case "generating":
+      return {
+        status: "Generating audio…",
+        actionLabel: "Stop",
+        canStop: true,
+      };
+    case "stopping":
+      return {
+        status: "Stopping audio…",
+        actionLabel: "Stopping…",
+        canStop: false,
+      };
+    case "finishing":
+      return {
+        status: "Finishing audio…",
+        actionLabel: "Finishing…",
+        canStop: false,
+      };
+    case null:
+      return null;
+  }
+}
+
 export type AudioPickTask = "tts" | "stt" | null;
 export type AudioCreateMode = "speak" | "transcribe";
 export type SttEngine = "transformers" | "gguf" | "mtmd";
@@ -185,8 +233,15 @@ export function resolveAudioPickTask(
 
 /** Generation can be cancelled as part of a mode transition. Model lifecycle
  * and transcription operations must settle before their controls disappear. */
-export function canTransitionAudioMode(busy: AudioBusy): boolean {
-  return busy === null || busy === "generating";
+export function canTransitionAudioMode(
+  busy: AudioBusy,
+  generationPhase: AudioGenerationPhase = busy === "generating"
+    ? "generating"
+    : null,
+): boolean {
+  return (
+    busy === null || (busy === "generating" && generationPhase === "generating")
+  );
 }
 
 /** A managed TTS completion owns auto-load only while the same staging generation is

--- a/studio/frontend/src/features/audio/audio-page.tsx
+++ b/studio/frontend/src/features/audio/audio-page.tsx
@@ -30,7 +30,6 @@ import {
 
 import { AdvancedDisclosure } from "@/components/advanced-disclosure";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -38,6 +37,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { usePlatformStore } from "@/config/env";
@@ -79,13 +80,13 @@ import type {
   ModelSelectorChangeMeta,
 } from "@/features/model-picker/components/model-selector/types";
 import { confirmRemoteCodeIfNeeded } from "@/features/security";
+import { useSettingsDialogStore } from "@/features/settings";
 import {
   isTrackingSttDownload,
   trackSttDownload,
 } from "@/features/settings/lib/stt-download-mirror";
 import { sttModelSize } from "@/features/settings/stores/stt-model-catalog";
 import { usePersistedToggle } from "@/hooks/use-persisted-toggle";
-import { useSettingsDialogStore } from "@/features/settings";
 import { useScrollFades } from "@/hooks/use-scroll-fades";
 import { fetchSystemInfo } from "@/hooks/use-system";
 import { BlobUrlCache } from "@/lib/blob-url-cache";
@@ -100,14 +101,22 @@ import {
   clearAudioGallery,
   deleteAudioClip,
   fetchClipObjectUrl,
-  getAudioDownloadPlan,
   generateAudio,
+  getAudioDownloadPlan,
   listAudioGallery,
   setAudioClipFlags,
 } from "./api";
 import {
   type AudioBusy,
+  type AudioGenerationPhase,
+  MINIMAX_MUSIC_DEFAULT_SECONDS,
+  MINIMAX_MUSIC_FRAMES_PER_SECOND,
+  MINIMAX_MUSIC_MAX_SECONDS,
+  MOSS_TTS_DEFAULT_SECONDS,
+  MOSS_TTS_FRAMES_PER_SECOND,
+  MOSS_TTS_MAX_FRAMES,
   type SttDownloadedArtifact,
+  audioGenerationPresentation,
   canTransitionAudioMode,
   exactGgufLoadSelector,
   expectedGgufDownloadBytes,
@@ -115,15 +124,9 @@ import {
   macTtsPickAction,
   mergeGalleryPage,
   micStreamRequestIsCurrent,
-  MOSS_TTS_DEFAULT_SECONDS,
-  MOSS_TTS_FRAMES_PER_SECOND,
-  MOSS_TTS_MAX_FRAMES,
-  MINIMAX_MUSIC_DEFAULT_SECONDS,
-  MINIMAX_MUSIC_FRAMES_PER_SECOND,
-  MINIMAX_MUSIC_MAX_SECONDS,
   minimaxMusicFramesForSeconds,
-  mossTtsMaxFrames,
   mossTtsFramesForSeconds,
+  mossTtsMaxFrames,
   nativeAudioInstructionsKind,
   persistedClipForGeneration,
   reconcileSttSelection,
@@ -131,10 +134,10 @@ import {
   resolveSttResidency,
   selectAutoGgufVariant,
   stagedTtsLoadIsOwned,
-  trainedTtsCheckpointIsLoadable,
-  trainedTtsCheckpointIsRunnableOnMac,
   sttDownloadedArtifacts,
   sttSelectionReady,
+  trainedTtsCheckpointIsLoadable,
+  trainedTtsCheckpointIsRunnableOnMac,
 } from "./audio-page-policy";
 import {
   audioCapabilityLine,
@@ -327,6 +330,9 @@ export function AudioPage({
   const [busy, setBusy] = useState<AudioBusy>(null);
   const busyRef = useRef<AudioBusy>(busy);
   busyRef.current = busy;
+  const [generationPhase, setGenerationPhase] =
+    useState<AudioGenerationPhase>(null);
+  const generationPresentation = audioGenerationPresentation(generationPhase);
 
   // --- TTS (main inference slot) -----------------------------------------
   const [status, setStatus] = useState<InferenceStatusResponse | null>(null);
@@ -351,6 +357,12 @@ export function AudioPage({
     MINIMAX_MUSIC_DEFAULT_SECONDS,
   );
   const generateAbort = useRef<AbortController | null>(null);
+  const handleStopGeneration = useCallback(() => {
+    const controller = generateAbort.current;
+    if (!controller || controller.signal.aborted) return;
+    setGenerationPhase("stopping");
+    controller.abort();
+  }, []);
   const ttsLoadInFlight = useRef(false);
   // A pick that lost the race with a load still settling. Replayed once it does.
   const pendingRoutedTtsPick = useRef<{
@@ -1073,7 +1085,7 @@ export function AudioPage({
         if (nextMode === "transcribe") invalidatePendingTtsSelection();
         return true;
       }
-      if (!canTransitionAudioMode(busyRef.current)) {
+      if (!canTransitionAudioMode(busyRef.current, generationPhase)) {
         toast.info(
           "Wait for the active audio task to finish before switching modes.",
         );
@@ -1081,7 +1093,7 @@ export function AudioPage({
       }
 
       if (nextMode === "transcribe") invalidatePendingTtsSelection();
-      if (busyRef.current === "generating") generateAbort.current?.abort();
+      if (busyRef.current === "generating") handleStopGeneration();
       stopAndDiscardRecording();
       setMode(nextMode);
       // Held through Generate, the sidecar keeps a dictation model in VRAM beside the speech one.
@@ -1116,6 +1128,8 @@ export function AudioPage({
     },
     [
       invalidatePendingTtsSelection,
+      generationPhase,
+      handleStopGeneration,
       mode,
       releaseTranscribeSelection,
       stopAndDiscardRecording,
@@ -1849,8 +1863,10 @@ export function AudioPage({
     if (busyRef.current) return;
     busyRef.current = "generating";
     setBusy("generating");
+    setGenerationPhase("preparing");
     const releaseInFlight = pendingTranscribeRelease.current;
     if (releaseInFlight && !(await releaseInFlight)) {
+      setGenerationPhase(null);
       busyRef.current = null;
       setBusy(null);
       setMode("transcribe");
@@ -1858,6 +1874,7 @@ export function AudioPage({
     }
     const instructions = audioInstructions.trim();
     if (musicGeneration && !instructions) {
+      setGenerationPhase(null);
       busyRef.current = null;
       setBusy(null);
       toast.error("Add a music description for MiniMax Music 3.");
@@ -1866,6 +1883,7 @@ export function AudioPage({
     const language = audioLanguage.trim();
     const controller = new AbortController();
     generateAbort.current = controller;
+    setGenerationPhase("generating");
     try {
       const generated = await generateAudio(text, {
         ...(!musicGeneration && temperatureEdited ? { temperature } : {}),
@@ -1882,6 +1900,7 @@ export function AudioPage({
           : {}),
         signal: controller.signal,
       });
+      setGenerationPhase("finishing");
       const refreshed = await refreshGallery();
       const generatedClip = persistedClipForGeneration(
         generated.clip_id,
@@ -1918,6 +1937,7 @@ export function AudioPage({
       }
     } catch (error) {
       if (!controller.signal.aborted) {
+        setGenerationPhase("finishing");
         toast.error(
           error instanceof Error ? error.message : "Audio generation failed.",
         );
@@ -1925,6 +1945,7 @@ export function AudioPage({
       }
     } finally {
       generateAbort.current = null;
+      setGenerationPhase(null);
       busyRef.current = null;
       setBusy(null);
       if (activeRef.current && modeRef.current === "speak")
@@ -1948,10 +1969,6 @@ export function AudioPage({
     replayQueuedTtsPick,
     selectClip,
   ]);
-
-  const handleStopGeneration = useCallback(() => {
-    generateAbort.current?.abort();
-  }, []);
 
   // Only unmount aborts. RootLayout keeps this page mounted precisely so leaving
   // the tab does not cancel synthesis, and the clip is persisted server-side, so
@@ -2721,30 +2738,52 @@ export function AudioPage({
           {mode === "speak" ? (
             /* The scroll mask provides the fade; leave the footer unpainted to avoid dark-mode banding. */
             <div className="relative z-10 flex shrink-0 justify-center px-10 pt-0.5 pb-4">
-              <Button
-                className="relative z-10 h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
-                onClick={
-                  busy === "generating" ? handleStopGeneration : handleGenerate
-                }
-                disabled={
-                  busy === "generating"
-                    ? false
-                    : busy !== null ||
-                      !ttsLoaded ||
-                      !prompt.trim() ||
-                      (musicGeneration && !audioInstructions.trim())
-                }
-                variant={busy === "generating" ? "destructive" : "default"}
-              >
-                {busy === "generating" ? (
+              <div className="flex w-full max-w-sm flex-col gap-2">
+                {busy === "generating" && generationPresentation ? (
                   <>
-                    <HugeiconsIcon icon={StopIcon} className="mr-2 size-4" />
-                    Stop
+                    <output
+                      aria-live="polite"
+                      aria-atomic="true"
+                      className="text-center text-ui-12 text-muted-foreground"
+                    >
+                      {generationPresentation.status}
+                    </output>
+                    <Progress
+                      indeterminate
+                      aria-label="Audio task in progress"
+                      className="h-1.5"
+                    />
                   </>
-                ) : (
-                  "Generate"
-                )}
-              </Button>
+                ) : null}
+                <Button
+                  className="relative z-10 mx-auto h-11 px-8 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100"
+                  onClick={
+                    generationPresentation?.canStop
+                      ? handleStopGeneration
+                      : handleGenerate
+                  }
+                  disabled={
+                    generationPresentation
+                      ? !generationPresentation.canStop
+                      : busy !== null ||
+                        !ttsLoaded ||
+                        !prompt.trim() ||
+                        (musicGeneration && !audioInstructions.trim())
+                  }
+                  variant={
+                    generationPresentation?.canStop ? "destructive" : "default"
+                  }
+                >
+                  {generationPresentation?.canStop ? (
+                    <>
+                      <HugeiconsIcon icon={StopIcon} className="mr-2 size-4" />
+                      Stop
+                    </>
+                  ) : (
+                    (generationPresentation?.actionLabel ?? "Generate")
+                  )}
+                </Button>
+              </div>
             </div>
           ) : null}
         </div>

--- a/studio/frontend/src/features/audio/audio-page.tsx
+++ b/studio/frontend/src/features/audio/audio-page.tsx
@@ -332,6 +332,14 @@ export function AudioPage({
   busyRef.current = busy;
   const [generationPhase, setGenerationPhase] =
     useState<AudioGenerationPhase>(null);
+  const generationPhaseRef = useRef<AudioGenerationPhase>(generationPhase);
+  const updateGenerationPhase = useCallback(
+    (nextPhase: AudioGenerationPhase) => {
+      generationPhaseRef.current = nextPhase;
+      setGenerationPhase(nextPhase);
+    },
+    [],
+  );
   const generationPresentation = audioGenerationPresentation(generationPhase);
 
   // --- TTS (main inference slot) -----------------------------------------
@@ -360,9 +368,9 @@ export function AudioPage({
   const handleStopGeneration = useCallback(() => {
     const controller = generateAbort.current;
     if (!controller || controller.signal.aborted) return;
-    setGenerationPhase("stopping");
+    updateGenerationPhase("stopping");
     controller.abort();
-  }, []);
+  }, [updateGenerationPhase]);
   const ttsLoadInFlight = useRef(false);
   // A pick that lost the race with a load still settling. Replayed once it does.
   const pendingRoutedTtsPick = useRef<{
@@ -1085,7 +1093,9 @@ export function AudioPage({
         if (nextMode === "transcribe") invalidatePendingTtsSelection();
         return true;
       }
-      if (!canTransitionAudioMode(busyRef.current, generationPhase)) {
+      if (
+        !canTransitionAudioMode(busyRef.current, generationPhaseRef.current)
+      ) {
         toast.info(
           "Wait for the active audio task to finish before switching modes.",
         );
@@ -1128,7 +1138,6 @@ export function AudioPage({
     },
     [
       invalidatePendingTtsSelection,
-      generationPhase,
       handleStopGeneration,
       mode,
       releaseTranscribeSelection,
@@ -1863,10 +1872,10 @@ export function AudioPage({
     if (busyRef.current) return;
     busyRef.current = "generating";
     setBusy("generating");
-    setGenerationPhase("preparing");
+    updateGenerationPhase("preparing");
     const releaseInFlight = pendingTranscribeRelease.current;
     if (releaseInFlight && !(await releaseInFlight)) {
-      setGenerationPhase(null);
+      updateGenerationPhase(null);
       busyRef.current = null;
       setBusy(null);
       setMode("transcribe");
@@ -1874,7 +1883,7 @@ export function AudioPage({
     }
     const instructions = audioInstructions.trim();
     if (musicGeneration && !instructions) {
-      setGenerationPhase(null);
+      updateGenerationPhase(null);
       busyRef.current = null;
       setBusy(null);
       toast.error("Add a music description for MiniMax Music 3.");
@@ -1883,7 +1892,7 @@ export function AudioPage({
     const language = audioLanguage.trim();
     const controller = new AbortController();
     generateAbort.current = controller;
-    setGenerationPhase("generating");
+    updateGenerationPhase("generating");
     try {
       const generated = await generateAudio(text, {
         ...(!musicGeneration && temperatureEdited ? { temperature } : {}),
@@ -1900,7 +1909,7 @@ export function AudioPage({
           : {}),
         signal: controller.signal,
       });
-      setGenerationPhase("finishing");
+      updateGenerationPhase("finishing");
       const refreshed = await refreshGallery();
       const generatedClip = persistedClipForGeneration(
         generated.clip_id,
@@ -1937,7 +1946,7 @@ export function AudioPage({
       }
     } catch (error) {
       if (!controller.signal.aborted) {
-        setGenerationPhase("finishing");
+        updateGenerationPhase("finishing");
         toast.error(
           error instanceof Error ? error.message : "Audio generation failed.",
         );
@@ -1945,7 +1954,7 @@ export function AudioPage({
       }
     } finally {
       generateAbort.current = null;
-      setGenerationPhase(null);
+      updateGenerationPhase(null);
       busyRef.current = null;
       setBusy(null);
       if (activeRef.current && modeRef.current === "speak")
@@ -1963,6 +1972,7 @@ export function AudioPage({
     instructionsKind,
     temperature,
     temperatureEdited,
+    updateGenerationPhase,
     maxTokens,
     refreshGallery,
     refreshStatus,

--- a/studio/frontend/tests/audio-generation-stop.test.ts
+++ b/studio/frontend/tests/audio-generation-stop.test.ts
@@ -13,7 +13,7 @@ const source = readFileSync(
 test("generation exposes Stop only while the request controller can abort", () => {
   assert.match(
     source,
-    /const handleStopGeneration[\s\S]*const controller = generateAbort\.current;[\s\S]*!controller \|\| controller\.signal\.aborted[\s\S]*setGenerationPhase\("stopping"\);[\s\S]*controller\.abort\(\)/,
+    /const handleStopGeneration[\s\S]*const controller = generateAbort\.current;[\s\S]*!controller \|\| controller\.signal\.aborted[\s\S]*updateGenerationPhase\("stopping"\);[\s\S]*controller\.abort\(\)/,
   );
   assert.match(
     source,
@@ -51,23 +51,34 @@ test("generation progress follows the request-owned lifecycle", () => {
   );
   assert.match(
     generation,
-    /busyRef\.current = "generating";\s*setBusy\("generating"\);\s*setGenerationPhase\("preparing"\);\s*const releaseInFlight/,
+    /busyRef\.current = "generating";\s*setBusy\("generating"\);\s*updateGenerationPhase\("preparing"\);\s*const releaseInFlight/,
   );
   assert.match(
     generation,
-    /generateAbort\.current = controller;\s*setGenerationPhase\("generating"\);\s*try \{\s*const generated = await generateAudio/,
+    /generateAbort\.current = controller;\s*updateGenerationPhase\("generating"\);\s*try \{\s*const generated = await generateAudio/,
   );
   assert.match(
     generation,
-    /const generated = await generateAudio[\s\S]*?\);\s*setGenerationPhase\("finishing"\);\s*const refreshed = await refreshGallery/,
+    /const generated = await generateAudio[\s\S]*?\);\s*updateGenerationPhase\("finishing"\);\s*const refreshed = await refreshGallery/,
   );
   assert.match(
     generation,
-    /catch \(error\) \{\s*if \(!controller\.signal\.aborted\) \{\s*setGenerationPhase\("finishing"\);[\s\S]*await refreshStatus\(\)/,
+    /catch \(error\) \{\s*if \(!controller\.signal\.aborted\) \{\s*updateGenerationPhase\("finishing"\);[\s\S]*await refreshStatus\(\)/,
   );
   assert.match(
     generation,
-    /finally \{\s*generateAbort\.current = null;\s*setGenerationPhase\(null\);\s*busyRef\.current = null;\s*setBusy\(null\)/,
+    /finally \{\s*generateAbort\.current = null;\s*updateGenerationPhase\(null\);\s*busyRef\.current = null;\s*setBusy\(null\)/,
+  );
+});
+
+test("mode transitions read the synchronously authoritative generation phase", () => {
+  assert.match(
+    source,
+    /const generationPhaseRef = useRef<AudioGenerationPhase>\(generationPhase\);\s*const updateGenerationPhase = useCallback\(\s*\(nextPhase: AudioGenerationPhase\) => \{\s*generationPhaseRef\.current = nextPhase;\s*setGenerationPhase\(nextPhase\)/,
+  );
+  assert.match(
+    source,
+    /canTransitionAudioMode\(busyRef\.current, generationPhaseRef\.current\)/,
   );
 });
 

--- a/studio/frontend/tests/audio-generation-stop.test.ts
+++ b/studio/frontend/tests/audio-generation-stop.test.ts
@@ -10,18 +10,64 @@ const source = readFileSync(
   "utf8",
 );
 
-test("generation exposes a clickable Stop action wired to the request abort", () => {
+test("generation exposes Stop only while the request controller can abort", () => {
   assert.match(
     source,
-    /const handleStopGeneration[\s\S]*generateAbort\.current\?\.abort\(\)/,
+    /const handleStopGeneration[\s\S]*const controller = generateAbort\.current;[\s\S]*!controller \|\| controller\.signal\.aborted[\s\S]*setGenerationPhase\("stopping"\);[\s\S]*controller\.abort\(\)/,
   );
   assert.match(
     source,
-    /onClick=\{\s*busy === "generating"\s*\?\s*handleStopGeneration\s*:\s*handleGenerate\s*\}/,
+    /generationPresentation\?\.canStop\s*\?\s*handleStopGeneration\s*:\s*handleGenerate/,
   );
   assert.match(
     source,
-    /busy === "generating"[\s\S]*icon=\{StopIcon\}[\s\S]*Stop/,
+    /disabled=\{[\s\S]*generationPresentation[\s\S]*!generationPresentation\.canStop/,
+  );
+});
+
+test("generation renders one accessible indeterminate task indicator", () => {
+  assert.match(
+    source,
+    /import \{ Progress \} from "@\/components\/ui\/progress"/,
+  );
+  assert.match(
+    source,
+    /busy === "generating" && generationPresentation[\s\S]*<Progress[\s\S]*indeterminate[\s\S]*aria-label="Audio task in progress"/,
+  );
+  assert.match(
+    source,
+    /<output[\s\S]*aria-live="polite"[\s\S]*aria-atomic="true"[\s\S]*generationPresentation\.status[\s\S]*<\/output>/,
+  );
+  assert.doesNotMatch(
+    source,
+    /<Progress[\s\S]{0,300}aria-valuenow|<Progress[\s\S]{0,300}value=/,
+  );
+});
+
+test("generation progress follows the request-owned lifecycle", () => {
+  const generation = source.slice(
+    source.indexOf("const handleGenerate = useCallback"),
+    source.indexOf("// --- Transcribe"),
+  );
+  assert.match(
+    generation,
+    /busyRef\.current = "generating";\s*setBusy\("generating"\);\s*setGenerationPhase\("preparing"\);\s*const releaseInFlight/,
+  );
+  assert.match(
+    generation,
+    /generateAbort\.current = controller;\s*setGenerationPhase\("generating"\);\s*try \{\s*const generated = await generateAudio/,
+  );
+  assert.match(
+    generation,
+    /const generated = await generateAudio[\s\S]*?\);\s*setGenerationPhase\("finishing"\);\s*const refreshed = await refreshGallery/,
+  );
+  assert.match(
+    generation,
+    /catch \(error\) \{\s*if \(!controller\.signal\.aborted\) \{\s*setGenerationPhase\("finishing"\);[\s\S]*await refreshStatus\(\)/,
+  );
+  assert.match(
+    generation,
+    /finally \{\s*generateAbort\.current = null;\s*setGenerationPhase\(null\);\s*busyRef\.current = null;\s*setBusy\(null\)/,
   );
 });
 

--- a/studio/frontend/tests/audio-page-policy.test.ts
+++ b/studio/frontend/tests/audio-page-policy.test.ts
@@ -652,12 +652,12 @@ test("generation is claimed before the transcribe release is awaited", () => {
   // each resumed into its own generateAudio while generateAbort tracked only the last.
   assert.match(
     audioPageSource,
-    /if \(busyRef\.current\) return;\s*busyRef\.current = "generating";\s*setBusy\("generating"\);\s*setGenerationPhase\("preparing"\);\s*const releaseInFlight = pendingTranscribeRelease\.current;\s*if \(releaseInFlight/,
+    /if \(busyRef\.current\) return;\s*busyRef\.current = "generating";\s*setBusy\("generating"\);\s*updateGenerationPhase\("preparing"\);\s*const releaseInFlight = pendingTranscribeRelease\.current;\s*if \(releaseInFlight/,
   );
   // And a release that failed hands the slot back rather than wedging the button.
   assert.match(
     audioPageSource,
-    /if \(releaseInFlight && !\(await releaseInFlight\)\) \{\s*setGenerationPhase\(null\);\s*busyRef\.current = null;\s*setBusy\(null\);\s*setMode\("transcribe"\);/,
+    /if \(releaseInFlight && !\(await releaseInFlight\)\) \{\s*updateGenerationPhase\(null\);\s*busyRef\.current = null;\s*setBusy\(null\);\s*setMode\("transcribe"\);/,
   );
 });
 

--- a/studio/frontend/tests/audio-page-policy.test.ts
+++ b/studio/frontend/tests/audio-page-policy.test.ts
@@ -6,15 +6,16 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  MINIMAX_MUSIC_DEFAULT_SECONDS,
+  MINIMAX_MUSIC_FRAMES_PER_SECOND,
+  MINIMAX_MUSIC_MAX_FRAMES,
+  MINIMAX_MUSIC_MAX_SECONDS,
+  audioGenerationPresentation,
   canTransitionAudioMode,
   exactGgufLoadSelector,
   expectedGgufDownloadBytes,
   isTtsAudioType,
   macTtsPickAction,
-  MINIMAX_MUSIC_DEFAULT_SECONDS,
-  MINIMAX_MUSIC_FRAMES_PER_SECOND,
-  MINIMAX_MUSIC_MAX_FRAMES,
-  MINIMAX_MUSIC_MAX_SECONDS,
   mergeGalleryPage,
   micStreamRequestIsCurrent,
   minimaxMusicFramesForSeconds,
@@ -39,10 +40,51 @@ const chatApiSource = readFileSync(
 
 test("mode transitions cancel generation but wait for non-cancellable work", () => {
   assert.equal(canTransitionAudioMode(null), true);
-  assert.equal(canTransitionAudioMode("generating"), true);
+  assert.equal(canTransitionAudioMode("generating", "generating"), true);
+  assert.equal(canTransitionAudioMode("generating", "preparing"), false);
+  assert.equal(canTransitionAudioMode("generating", "stopping"), false);
+  assert.equal(canTransitionAudioMode("generating", "finishing"), false);
   assert.equal(canTransitionAudioMode("loading"), false);
   assert.equal(canTransitionAudioMode("unloading"), false);
   assert.equal(canTransitionAudioMode("transcribing"), false);
+});
+
+test("audio generation phases expose truthful indeterminate presentation", () => {
+  assert.equal(audioGenerationPresentation(null), null);
+  assert.deepEqual(audioGenerationPresentation("preparing"), {
+    status: "Preparing audio…",
+    actionLabel: "Preparing…",
+    canStop: false,
+  });
+  assert.deepEqual(audioGenerationPresentation("generating"), {
+    status: "Generating audio…",
+    actionLabel: "Stop",
+    canStop: true,
+  });
+  assert.deepEqual(audioGenerationPresentation("stopping"), {
+    status: "Stopping audio…",
+    actionLabel: "Stopping…",
+    canStop: false,
+  });
+  assert.deepEqual(audioGenerationPresentation("finishing"), {
+    status: "Finishing audio…",
+    actionLabel: "Finishing…",
+    canStop: false,
+  });
+
+  for (const phase of [
+    "preparing",
+    "generating",
+    "stopping",
+    "finishing",
+  ] as const) {
+    const presentation = audioGenerationPresentation(phase);
+    assert.ok(presentation);
+    assert.doesNotMatch(
+      `${presentation.status} ${presentation.actionLabel}`,
+      /%|percent|eta|remaining/i,
+    );
+  }
 });
 
 test("staged TTS completion requires the same Speak ownership generation", () => {
@@ -565,7 +607,7 @@ test("generating waits for the transcribe release the mode switch started", () =
   // dictation model, which OOMs a device that fits either one alone.
   assert.match(
     audioPageSource,
-    /const handleGenerate = useCallback\(async \(\) => \{[\s\S]{0,900}?const releaseInFlight = pendingTranscribeRelease\.current;[\s\S]{0,200}?if \(releaseInFlight && !\(await releaseInFlight\)\) \{[\s\S]{0,80}?setMode\("transcribe"\);/,
+    /const handleGenerate = useCallback\(async \(\) => \{[\s\S]{0,1100}?const releaseInFlight = pendingTranscribeRelease\.current;[\s\S]{0,240}?if \(releaseInFlight && !\(await releaseInFlight\)\) \{[\s\S]{0,160}?setMode\("transcribe"\);/,
   );
 });
 
@@ -610,12 +652,12 @@ test("generation is claimed before the transcribe release is awaited", () => {
   // each resumed into its own generateAudio while generateAbort tracked only the last.
   assert.match(
     audioPageSource,
-    /if \(busyRef\.current\) return;\s*busyRef\.current = "generating";\s*setBusy\("generating"\);\s*const releaseInFlight = pendingTranscribeRelease\.current;\s*if \(releaseInFlight/,
+    /if \(busyRef\.current\) return;\s*busyRef\.current = "generating";\s*setBusy\("generating"\);\s*setGenerationPhase\("preparing"\);\s*const releaseInFlight = pendingTranscribeRelease\.current;\s*if \(releaseInFlight/,
   );
   // And a release that failed hands the slot back rather than wedging the button.
   assert.match(
     audioPageSource,
-    /if \(releaseInFlight && !\(await releaseInFlight\)\) \{\s*busyRef\.current = null;\s*setBusy\(null\);\s*setMode\("transcribe"\);/,
+    /if \(releaseInFlight && !\(await releaseInFlight\)\) \{\s*setGenerationPhase\(null\);\s*busyRef\.current = null;\s*setBusy\(null\);\s*setMode\("transcribe"\);/,
   );
 });
 

--- a/studio/frontend/tests/audio-tts-download-manager.test.ts
+++ b/studio/frontend/tests/audio-tts-download-manager.test.ts
@@ -81,7 +81,7 @@ test("a preflight that loses to generation queues its load until generation ends
   );
   assert.match(
     source,
-    /generateAbort\.current = null;\s*setGenerationPhase\(null\);\s*busyRef\.current = null;\s*setBusy\(null\);\s*if \(activeRef\.current && modeRef\.current === "speak"\)\s*replayQueuedTtsPick\(\)/,
+    /generateAbort\.current = null;\s*updateGenerationPhase\(null\);\s*busyRef\.current = null;\s*setBusy\(null\);\s*if \(activeRef\.current && modeRef\.current === "speak"\)\s*replayQueuedTtsPick\(\)/,
   );
 });
 
@@ -127,7 +127,7 @@ test("switching to Transcribe invalidates a pending staged TTS auto-load", () =>
   );
   assert.match(
     source,
-    /if \(nextMode === mode\)[\s\S]*return true;[\s\S]*if \(!canTransitionAudioMode\(busyRef\.current, generationPhase\)\)[\s\S]*return false;[\s\S]*if \(nextMode === "transcribe"\) invalidatePendingTtsSelection\(\)/,
+    /if \(nextMode === mode\)[\s\S]*return true;[\s\S]*if \(!canTransitionAudioMode\(busyRef\.current, generationPhaseRef\.current\)\)[\s\S]*return false;[\s\S]*if \(nextMode === "transcribe"\) invalidatePendingTtsSelection\(\)/,
     "a rejected mode switch must not discard the still-owned staged load",
   );
 });

--- a/studio/frontend/tests/audio-tts-download-manager.test.ts
+++ b/studio/frontend/tests/audio-tts-download-manager.test.ts
@@ -127,7 +127,7 @@ test("switching to Transcribe invalidates a pending staged TTS auto-load", () =>
   );
   assert.match(
     source,
-    /if \(nextMode === mode\)[\s\S]*return true;[\s\S]*if \(!canTransitionAudioMode\(busyRef\.current, generationPhaseRef\.current\)\)[\s\S]*return false;[\s\S]*if \(nextMode === "transcribe"\) invalidatePendingTtsSelection\(\)/,
+    /if \(nextMode === mode\)[\s\S]*return true;[\s\S]*if \(\s*!canTransitionAudioMode\(busyRef\.current, generationPhaseRef\.current\)\s*\)[\s\S]*return false;[\s\S]*if \(nextMode === "transcribe"\) invalidatePendingTtsSelection\(\)/,
     "a rejected mode switch must not discard the still-owned staged load",
   );
 });

--- a/studio/frontend/tests/audio-tts-download-manager.test.ts
+++ b/studio/frontend/tests/audio-tts-download-manager.test.ts
@@ -81,7 +81,7 @@ test("a preflight that loses to generation queues its load until generation ends
   );
   assert.match(
     source,
-    /generateAbort\.current = null;\s*busyRef\.current = null;\s*setBusy\(null\);\s*if \(activeRef\.current && modeRef\.current === "speak"\)\s*replayQueuedTtsPick\(\)/,
+    /generateAbort\.current = null;\s*setGenerationPhase\(null\);\s*busyRef\.current = null;\s*setBusy\(null\);\s*if \(activeRef\.current && modeRef\.current === "speak"\)\s*replayQueuedTtsPick\(\)/,
   );
 });
 
@@ -127,7 +127,7 @@ test("switching to Transcribe invalidates a pending staged TTS auto-load", () =>
   );
   assert.match(
     source,
-    /if \(nextMode === mode\)[\s\S]*return true;[\s\S]*if \(!canTransitionAudioMode\(busyRef\.current\)\)[\s\S]*return false;[\s\S]*if \(nextMode === "transcribe"\) invalidatePendingTtsSelection\(\)/,
+    /if \(nextMode === mode\)[\s\S]*return true;[\s\S]*if \(!canTransitionAudioMode\(busyRef\.current, generationPhase\)\)[\s\S]*return false;[\s\S]*if \(nextMode === "transcribe"\) invalidatePendingTtsSelection\(\)/,
     "a rejected mode switch must not discard the still-owned staged load",
   );
 });


### PR DESCRIPTION
## Summary

Adds an accessible indeterminate progress bar to the Studio Audio page while speech or music generation is active. The status moves through preparing, generating, stopping, and finishing without inventing a percentage or ETA.

## Motivation

Audio generation can take long enough that the page appears stuck. The existing button changes to Stop only after a request begins, but there was no explicit task indicator or announced phase.

## Changes

- Reuse the shared Progress component in the Speak footer and give it a stable accessible name.
- Keep the existing busy state as the task owner while projecting truthful presentation phases around request preparation, generation, cancellation, and gallery reconciliation.
- Enable Stop only while the request-local AbortController can still cancel the generation.
- Add policy and source-contract coverage for phase transitions, early exits, cancellation, error recovery, and existing queued-download behavior.

## How to test

```text
cd studio/frontend
node --experimental-strip-types --test tests/audio-page-policy.test.ts tests/audio-generation-stop.test.ts tests/audio-tts-download-manager.test.ts
npm run typecheck
npm test
npm run build
```

The focused Audio set passes 69 tests. The full frontend suite passes 6,090 tests, and the production build succeeds.

## Screenshots

<!-- paste Audio generation progress evidence here -->

## Notes for reviewers

The Audio generation endpoint returns a completed response rather than numeric progress events. The bar is intentionally indeterminate, and Stop stays disabled during preparation, cancellation settlement, and final gallery reconciliation.

A focused Biome comparison reports no new diagnostics: the target has 11 inherited errors across the five touched files versus 13 on the exact base.

## Related

Refs #8794

