### PR TITLE
Fail fast on bnb loads of hybrid Mamba/SSM models with a clear error (Closes #4037)

### DIFF
--- a/tests/test_hybrid_mamba_bnb_guard.py
+++ b/tests/test_hybrid_mamba_bnb_guard.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#4037: bnb loads of hybrid Mamba models must fail fast with a clear message.
+
+The quantizer crash (AttributeError: JambaAttention has no attribute `feed_forward`)
+is opaque; the helpers below turn it into an actionable error before shards are
+downloaded (preflight) or with context after the fact (translation).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from unsloth.models.vision import (
+    _hybrid_mamba_bnb_preflight,
+    _raise_quantizer_error,
+)
+
+
+def test_preflight_blocks_jamba_4bit():
+    cfg = SimpleNamespace(model_type="jamba", architectures=["JambaForCausalLM"])
+    with pytest.raises(ValueError, match="not supported yet"):
+        _hybrid_mamba_bnb_preflight(cfg, load_in_4bit=True, load_in_8bit=False)
+
+
+def test_preflight_blocks_zamba2_8bit():
+    cfg = SimpleNamespace(model_type="zamba2", architectures=["Zamba2ForCausalLM"])
+    with pytest.raises(ValueError, match="not supported yet"):
+        _hybrid_mamba_bnb_preflight(cfg, load_in_4bit=False, load_in_8bit=True)
+
+
+def test_preflight_allows_nemotron_h_4bit():
+    # Nemotron-H is now handled in unsloth/models/loader.py and ships official
+    # bnb-4bit repos — the preflight must NOT block it. #4037 review
+    cfg = SimpleNamespace(model_type="nemotron_h", architectures=["NemotronHForCausalLM"])
+    _hybrid_mamba_bnb_preflight(cfg, load_in_4bit=True, load_in_8bit=False)  # must not raise
+
+
+def test_preflight_allows_llama_4bit():
+    cfg = SimpleNamespace(model_type="llama", architectures=["LlamaForCausalLM"])
+    _hybrid_mamba_bnb_preflight(cfg, load_in_4bit=True, load_in_8bit=False)  # must not raise
+
+
+def test_preflight_allows_jamba_16bit():
+    """16-bit loading stays allowed for hybrid models — only bnb is blocked."""
+    cfg = SimpleNamespace(model_type="jamba", architectures=["JambaForCausalLM"])
+    _hybrid_mamba_bnb_preflight(cfg, load_in_4bit=False, load_in_8bit=False)  # must not raise
+
+
+def test_translation_adds_context_to_quantizer_error():
+    raw = AttributeError("JambaAttention has no attribute `feed_forward`")
+    with pytest.raises(ValueError, match="bitsandbytes quantizer"):
+        _raise_quantizer_error(raw, model_name="some/Jamba2-Mini")
+
+
+def test_translation_passes_other_attribute_errors_through():
+    """Non-quantizer AttributeErrors keep their original type (no masking of real bugs)."""
+    raw = AttributeError("something else entirely")
+    with pytest.raises(AttributeError):
+        _raise_quantizer_error(raw, model_name="x")

--- a/tests/test_hybrid_mamba_bnb_guard_integration.py
+++ b/tests/test_hybrid_mamba_bnb_guard_integration.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#4037 integration: the guard fires INSIDE FastBaseModel.from_pretrained, before any
+model construction — so a Jamba 4-bit request dies with the clear error and never
+reaches auto_model.from_pretrained (no shard download, no opaque quantizer crash).
+"""
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import unsloth  # noqa: F401
+from unsloth.models import vision
+
+
+def _fake_jamba_config():
+    return SimpleNamespace(
+        model_type = "jamba",
+        architectures = ["JambaForCausalLM"],
+        hidden_size = 2048,
+        num_attention_heads = 16,
+        max_position_embeddings = 4096,
+        torch_dtype = "float16",
+    )
+
+
+def _patch_cuda(monkeypatch):
+    """Stub the CUDA calls that run between entry and the guard on a CPU-only build."""
+    monkeypatch.setattr(torch.cuda, "mem_get_info", lambda *a, **k: (80 * 1024**3, 80 * 1024**3), raising = False)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1, raising = False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True, raising = False)
+    monkeypatch.setattr(torch.cuda, "get_device_name", lambda *a: "FakeGPU", raising = False)
+    # The device-map planner probes per-GPU capacity; CPU torch has no such API.
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda *a, **k: SimpleNamespace(total_memory = 80 * 1024**3, name = "FakeGPU", major = 8, minor = 0),
+        raising = False,
+    )
+
+
+def test_preflight_guard_fires_inside_from_pretrained(monkeypatch):
+    """A Jamba 4-bit load must raise the clear error before auto_model.from_pretrained."""
+    fake_config = _fake_jamba_config()
+    _patch_cuda(monkeypatch)
+
+    def _boom(*args, **kwargs):
+        pytest.fail("auto_model.from_pretrained was reached — preflight guard did not fire first")
+
+    monkeypatch.setattr(vision.AutoConfig, "from_pretrained", staticmethod(lambda *a, **k: fake_config))
+    monkeypatch.setattr(vision.AutoModelForCausalLM, "from_pretrained", classmethod(_boom), raising = False)
+    monkeypatch.setattr(vision.AutoModelForVision2Seq, "from_pretrained", classmethod(_boom), raising = False)
+
+    with pytest.raises(ValueError, match = "not supported yet"):
+        vision.FastBaseModel.from_pretrained(
+            model_name = "ai21labs/Jamba2-Mini",
+            max_seq_length = 512,
+            load_in_4bit = True,
+            local_files_only = True,
+            model_types = ["jamba"],
+        )
+
+
+def test_llama_load_not_blocked_by_preflight(monkeypatch):
+    """Sanity: a non-hybrid model_type passes the guard — the guard's error must NOT fire.
+
+    On a CPU-only runner the load itself fails later (device-map planning / no weights),
+    so we assert the *negative*: whatever downstream error happens, it is not the
+    hybrid-Mamba preflight message. That is the property under test — Llama sails past
+    the guard that blocks Jamba.
+    """
+    fake_config = SimpleNamespace(
+        model_type = "llama",
+        architectures = ["LlamaForCausalLM"],
+        hidden_size = 1024,
+        num_attention_heads = 8,
+        max_position_embeddings = 2048,
+        torch_dtype = "bfloat16",
+    )
+    _patch_cuda(monkeypatch)
+
+    monkeypatch.setattr(vision.AutoConfig, "from_pretrained", staticmethod(lambda *a, **k: fake_config))
+
+    with pytest.raises(Exception) as exc_info:
+        vision.FastBaseModel.from_pretrained(
+            model_name = "unsloth/Llama-3.2-1B-Instruct",
+            max_seq_length = 512,
+            load_in_4bit = True,
+            local_files_only = True,
+            model_types = ["llama"],
+        )
+    # The guard must NOT have fired for a non-hybrid model.
+    assert "not supported yet" not in str(exc_info.value), (
+        f"preflight guard wrongly blocked llama: {exc_info.value}"
+    )
+
+
+def test_16bit_attribute_error_passes_through_untouched(monkeypatch):
+    """A 16-bit load (no bnb) raising AttributeError is a real bug — it must NOT be
+    re-dressed as a quantizer/layout-mismatch message. Original error propagates."""
+    fake_config = SimpleNamespace(
+        model_type = "llama",
+        architectures = ["LlamaForCausalLM"],
+        hidden_size = 1024,
+        num_attention_heads = 8,
+        max_position_embeddings = 2048,
+        torch_dtype = "bfloat16",
+    )
+    _patch_cuda(monkeypatch)
+
+    def _real_bug(*args, **kwargs):
+        raise AttributeError("LlamaRMSNorm has no attribute 'some_new_field'")
+
+    monkeypatch.setattr(vision.AutoConfig, "from_pretrained", staticmethod(lambda *a, **k: fake_config))
+    # The dispatch may pick any of the three auto classes depending on config shape;
+    # patch all so whichever is reached hits the except clause under test.
+    for _cls in (vision.AutoModelForCausalLM, vision.AutoModelForImageTextToText, vision.AutoModelForVision2Seq):
+        monkeypatch.setattr(_cls, "from_pretrained", classmethod(_real_bug), raising = False)
+
+    with pytest.raises(AttributeError) as exc_info:
+        vision.FastBaseModel.from_pretrained(
+            model_name = "unsloth/Llama-3.2-1B-Instruct",
+            max_seq_length = 512,
+            load_in_4bit = False,  # no bnb -> translation must stay silent
+            local_files_only = True,
+            model_types = ["llama"],
+        )
+    assert "bitsandbytes" not in str(exc_info.value), (
+        f"16-bit AttributeError was mislabeled as a quantizer error: {exc_info.value}"
+    )
+

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -22,6 +22,7 @@ from transformers import (
 
 try:
     from transformers import AutoModelForImageTextToText
+
     AutoModelForVision2Seq = AutoModelForImageTextToText
 except:
     from transformers import AutoModelForVision2Seq
@@ -127,7 +128,7 @@ def _infer_device_map_from_loaded_model(model):
     device_map = {}
 
     def _assign(module, prefix):
-        params = list(module.named_parameters(remove_duplicate = False))
+        params = list(module.named_parameters(remove_duplicate=False))
         if not params:
             bufs = list(module.named_buffers())
             if bufs:
@@ -140,7 +141,7 @@ def _infer_device_map_from_loaded_model(model):
             for child_name, child in module.named_children():
                 child_prefix = f"{prefix}.{child_name}" if prefix else child_name
                 _assign(child, child_prefix)
-            for pname, param in module.named_parameters(remove_duplicate = False):
+            for pname, param in module.named_parameters(remove_duplicate=False):
                 if "." not in pname:
                     full = f"{prefix}.{pname}" if prefix else pname
                     if not any(full == k or full.startswith(k + ".") for k in device_map):
@@ -197,7 +198,7 @@ def _repair_dispatch_hooks(model):
             key for key in device_map if not key or name == key or name.startswith(key + ".")
         ]
         if covering:
-            targets[name] = device_map[max(covering, key = len)]
+            targets[name] = device_map[max(covering, key=len)]
 
     repaired = 0
     for name, device in targets.items():
@@ -224,9 +225,9 @@ def _repair_dispatch_hooks(model):
             add_hook_to_module(
                 module,
                 AlignDevicesHook(
-                    execution_device = execution_device,
-                    io_same_device = io_same_device,
-                    skip_keys = skip_keys,
+                    execution_device=execution_device,
+                    io_same_device=io_same_device,
+                    skip_keys=skip_keys,
                 ),
             )
         except Exception as exc:
@@ -236,7 +237,7 @@ def _repair_dispatch_hooks(model):
                 "model split across devices may fail at the first tensor that "
                 "crosses one.",
                 RuntimeWarning,
-                stacklevel = 2,
+                stacklevel=2,
             )
             continue
         repaired += 1
@@ -276,9 +277,9 @@ def _lift_endpoint_hooks_onto_adapters(model):
             add_hook_to_module(
                 wrapper,
                 AlignDevicesHook(
-                    execution_device = hook.execution_device,
-                    io_same_device = False,
-                    skip_keys = getattr(hook, "skip_keys", None),
+                    execution_device=hook.execution_device,
+                    io_same_device=False,
+                    skip_keys=getattr(hook, "skip_keys", None),
                 ),
             )
         except Exception as exc:
@@ -289,7 +290,7 @@ def _lift_endpoint_hooks_onto_adapters(model):
                 "targets the embeddings on a split model may fail at the first "
                 "tensor that crosses a device.",
                 RuntimeWarning,
-                stacklevel = 2,
+                stacklevel=2,
             )
             continue
         lifted += 1
@@ -336,7 +337,7 @@ def _attach_bnb_multidevice_hooks(
             "Unsloth: Failed to determine device placement from model parameters, "
             f"so multi-GPU hooks cannot be attached. ({type(exc).__name__}: {exc})",
             RuntimeWarning,
-            stacklevel = 2,
+            stacklevel=2,
         )
         return
 
@@ -382,10 +383,10 @@ def _attach_bnb_multidevice_hooks(
                 )
             dispatch_model(
                 model,
-                device_map = device_map_int,
-                main_device = main_device,
-                skip_keys = getattr(model, "_skip_keys_device_placement", None),
-                force_hooks = True,
+                device_map=device_map_int,
+                main_device=main_device,
+                skip_keys=getattr(model, "_skip_keys_device_placement", None),
+                force_hooks=True,
             )
             desc = f"{len(inferred_map)} block(s) across {len(cuda_devs)} device(s)"
         finally:
@@ -403,7 +404,7 @@ def _attach_bnb_multidevice_hooks(
             "Cross-device inference may fail. Consider using a single GPU or "
             "calling accelerate.dispatch_model() manually.",
             RuntimeWarning,
-            stacklevel = 2,
+            stacklevel=2,
         )
 
 
@@ -458,8 +459,8 @@ def _install_offload_embedding_hooks(embed_tokens, output_embeddings, return_dev
             return output.to(target)
         return output
 
-    embed_tokens.register_forward_pre_hook(_unsloth_offload_pre_hook, prepend = True)
-    embed_tokens.register_forward_hook(_unsloth_offload_post_hook, prepend = True)
+    embed_tokens.register_forward_pre_hook(_unsloth_offload_pre_hook, prepend=True)
+    embed_tokens.register_forward_hook(_unsloth_offload_post_hook, prepend=True)
     embed_tokens._unsloth_offload_hooks_installed = True
     return True
 
@@ -580,6 +581,7 @@ from transformers import GenerationConfig, CompileConfig, AutoConfig
 
 try:
     from transformers import PreTrainedConfig
+
     PretrainedConfig = PreTrainedConfig
 except:
     from transformers import PretrainedConfig
@@ -587,9 +589,9 @@ except:
 HAS_TORCH_DTYPE = "torch_dtype" in PretrainedConfig.__doc__
 
 _compile_config = CompileConfig(
-    fullgraph = False,
-    dynamic = None,
-    mode = "reduce-overhead",
+    fullgraph=False,
+    dynamic=None,
+    mode="reduce-overhead",
 )
 _compile_config.disable = True  # Must set manually
 
@@ -806,7 +808,7 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
     if forced_float32 is None:
         forced_float32 = os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "1"
     if forced_float32:
-        autocaster = torch.autocast(device_type = DEVICE_TYPE_TORCH, dtype = torch.float16)
+        autocaster = torch.autocast(device_type=DEVICE_TYPE_TORCH, dtype=torch.float16)
         dtype = torch.float16
     else:
         # CUDA autocast does not validate its dtype the way the CPU/XPU/MPS paths do,
@@ -814,9 +816,9 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
         # no-op, and the compiled graph then returns inf/NaN logits. A float32 model has
         # nothing to autocast to; disable instead of asking for a dtype that is not one.
         autocaster = torch.autocast(
-            device_type = DEVICE_TYPE_TORCH,
-            dtype = dtype,
-            enabled = dtype in (torch.float16, torch.bfloat16),
+            device_type=DEVICE_TYPE_TORCH,
+            dtype=dtype,
+            enabled=dtype in (torch.float16, torch.bfloat16),
         )
     # Prepare LoRA
     # state_dict = convert_lora_modules(self, dtype = dtype)
@@ -904,7 +906,7 @@ from .loader_utils import (
 )
 
 
-def _missing_torchvision_error(error = None):
+def _missing_torchvision_error(error=None):
     """True if a VLM processor failed to load due to missing torchvision (#4202).
 
     Checks availability directly first, then only the specific torchvision-required
@@ -926,9 +928,9 @@ def _construct_vlm_processor_fallback(
     model_type,
     token,
     trust_remote_code,
-    cache_dir = None,
-    local_files_only = False,
-    revision = None,
+    cache_dir=None,
+    local_files_only=False,
+    revision=None,
 ):
     """Build a VLM processor manually when AutoProcessor.from_pretrained fails (some VLMs
     have unresolvable tokenizer_class entries): load the image processor + tokenizer
@@ -942,30 +944,30 @@ def _construct_vlm_processor_fallback(
 
         load_path = _hub_repo_or_local_path(
             tokenizer_name,
-            token = token,
-            cache_dir = cache_dir,
-            local_files_only = local_files_only,
-            revision = revision,
+            token=token,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            revision=revision,
         )
         # Load image processor
         image_processor = AutoImageProcessor.from_pretrained(
             load_path,
-            token = token,
-            trust_remote_code = trust_remote_code,
-            cache_dir = cache_dir,
-            local_files_only = local_files_only,
-            revision = revision,
+            token=token,
+            trust_remote_code=trust_remote_code,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            revision=revision,
         )
         # Load tokenizer via PreTrainedTokenizerFast (bypasses tokenizer_class check).
         # Resolve the cached snapshot first so transformers does not call model_info (#7481).
         tok = _load_pretrained_tokenizer_fast(
             tokenizer_name,
-            padding_side = "left",
-            token = token,
-            trust_remote_code = trust_remote_code,
-            cache_dir = cache_dir,
-            local_files_only = local_files_only,
-            revision = revision,
+            padding_side="left",
+            token=token,
+            trust_remote_code=trust_remote_code,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            revision=revision,
         )
         # Read tokenizer_config.json for special tokens: prefer the local file (offline
         # / local checkpoint dir), else hf_hub_download with local_files_only forwarded.
@@ -978,7 +980,7 @@ def _construct_vlm_processor_fallback(
                 # Local dir: read directly. A missing file raises a clear FileNotFoundError
                 # rather than letting hf_hub_download treat the path as a repo id.
                 if os.path.exists(_local_cfg):
-                    with open(_local_cfg, "r", encoding = "utf-8") as f:
+                    with open(_local_cfg, "r", encoding="utf-8") as f:
                         tok_config = _json.load(f)
                 else:
                     raise FileNotFoundError(
@@ -986,15 +988,16 @@ def _construct_vlm_processor_fallback(
                     )
             else:
                 from huggingface_hub import hf_hub_download
+
                 config_path = hf_hub_download(
                     tokenizer_name,
                     "tokenizer_config.json",
-                    token = token,
-                    cache_dir = cache_dir,
-                    revision = revision,
-                    local_files_only = local_files_only,
+                    token=token,
+                    cache_dir=cache_dir,
+                    revision=revision,
+                    local_files_only=local_files_only,
                 )
-                with open(config_path, "r", encoding = "utf-8") as f:
+                with open(config_path, "r", encoding="utf-8") as f:
                     tok_config = _json.load(f)
             # Set model-specific special tokens and their IDs
             for key in (
@@ -1021,11 +1024,11 @@ def _construct_vlm_processor_fallback(
             try:
                 config = AutoConfig.from_pretrained(
                     load_path,
-                    token = token,
-                    trust_remote_code = trust_remote_code,
-                    cache_dir = cache_dir,
-                    local_files_only = local_files_only,
-                    revision = revision,
+                    token=token,
+                    trust_remote_code=trust_remote_code,
+                    cache_dir=cache_dir,
+                    local_files_only=local_files_only,
+                    revision=revision,
                 )
                 proc_class_name = PROCESSOR_MAPPING_NAMES.get(config.model_type)
             except Exception as _e:
@@ -1033,9 +1036,10 @@ def _construct_vlm_processor_fallback(
 
         if proc_class_name is not None:
             import transformers
+
             proc_class = getattr(transformers, proc_class_name, None)
             if proc_class is not None:
-                processor = proc_class(image_processor = image_processor, tokenizer = tok)
+                processor = proc_class(image_processor=image_processor, tokenizer=tok)
                 # Copy chat_template from tokenizer to processor if needed
                 if not getattr(processor, "chat_template", None) and getattr(
                     tok, "chat_template", None
@@ -1076,50 +1080,114 @@ def _get_total_transformer_layers(model):
     return None
 
 
+# Hybrid Mamba/SSM model families whose checkpoint layouts do not resolve through
+# transformers' bnb quantizer's strict module lookup — the load dies with an opaque
+# AttributeError deep in get_submodule(). #4037. Matched against config.model_type and
+# architectures, never by repo name.
+_HYBRID_MAMBA_BNB_BLOCKLIST = (
+    "jamba",
+    "zamba2",
+)
+
+
+def _hybrid_mamba_bnb_preflight(model_config, load_in_4bit, load_in_8bit):
+    """Raise a clear error before downloading shards for known-broken bnb loads.
+
+    Hybrid Mamba/SSM checkpoints carry parameter names that transformers' bnb quantizer
+    cannot resolve (strict get_submodule per weight), so the crash surfaces only after
+    every shard is downloaded — with no hint of the cause. Fail fast instead. #4037
+    """
+    if not (load_in_4bit or load_in_8bit):
+        return
+    # Exact token match (word boundaries), not substring: "jamba" must not match
+    # "megajamba" or "jamba2" unless that exact token appears in model_type or
+    # architectures. HF model_types are single tokens, so token-set membership is
+    # the right predicate.
+    model_type = str(getattr(model_config, "model_type", "") or "").lower()
+    architectures = [str(a).lower() for a in (getattr(model_config, "architectures", None) or [])]
+    tokens = set((model_type + " " + " ".join(architectures)).split())
+    hit = next((m for m in _HYBRID_MAMBA_BNB_BLOCKLIST if m in tokens), None)
+    if hit is not None:
+        raise ValueError(
+            f"Unsloth: 4-bit/8-bit (bitsandbytes) loading of hybrid Mamba/SSM models "
+            f"(family '{hit}') is not supported yet.\n\n"
+            "The checkpoint's parameter names do not resolve through transformers' bnb "
+            "quantizer, which fails with an opaque error like:\n"
+            "    AttributeError: JambaAttention has no attribute `feed_forward`\n\n"
+            "Workarounds:\n"
+            "  1. Load in 16-bit instead: load_in_4bit = False (needs more VRAM).\n"
+            "  2. Check for a newer transformers version matching your checkpoint layout.\n"
+            "  3. Track https://github.com/unslothai/unsloth/issues/4037 for support."
+        )
+
+
+def _raise_quantizer_error(error, model_name):
+    """Turn a bnb-quantizer AttributeError into a diagnosis, else re-raise unchanged.
+
+    A `... has no attribute ...` AttributeError escaping the model load means a
+    checkpoint parameter name did not resolve in the constructed module tree — almost
+    always a layout mismatch (hybrid models without a patch, or a checkpoint converted
+    with another transformers version). Re-raise with that diagnosis; other
+    AttributeErrors pass through untouched so real bugs are never masked. #4037
+    """
+    if "has no attribute" not in str(error):
+        raise error
+    raise ValueError(
+        f"Unsloth: Loading '{model_name}' failed inside the bitsandbytes quantizer:\n"
+        f"    {error}\n\n"
+        "This means a checkpoint parameter name does not match the model architecture "
+        "transformers constructed. Common causes:\n"
+        "  - hybrid Mamba/SSM models (Jamba, Zamba2, Nemotron-H) without an Unsloth patch,\n"
+        "  - a checkpoint converted with a different transformers version than installed.\n\n"
+        "Try load_in_4bit = False (16-bit), or upgrade/downgrade transformers to match the "
+        "checkpoint. If that fails, open an issue with model name + versions."
+    ) from error
+
+
 class FastBaseModel:
     @staticmethod
     @_offline_aware_load
     def from_pretrained(
-        model_name = "unsloth/Llama-3.2-1B-Instruct",
-        max_seq_length = 2048,
-        dtype = None,
-        load_in_4bit = True,
-        load_in_8bit = False,
-        load_in_16bit = False,
-        full_finetuning = False,
-        token = None,
-        device_map = DEFAULT_DEVICE_MAP,
+        model_name="unsloth/Llama-3.2-1B-Instruct",
+        max_seq_length=2048,
+        dtype=None,
+        load_in_4bit=True,
+        load_in_8bit=False,
+        load_in_16bit=False,
+        full_finetuning=False,
+        token=None,
+        device_map=DEFAULT_DEVICE_MAP,
         # Planner hints for device_map = "unsloth"; see resolve_unsloth_device_map.
-        device_map_planner_kwargs = None,
-        trust_remote_code = False,
-        model_types = None,
-        tokenizer_name = None,
-        auto_model = AutoModelForVision2Seq,
-        use_gradient_checkpointing = "unsloth",
-        supports_sdpa = True,
-        whisper_language = None,
-        whisper_task = None,
-        auto_config = None,
-        offload_embedding = OFFLOAD_EMBEDDING_AUTO,
-        float32_mixed_precision = None,  # Forces float32 mixed precision
+        device_map_planner_kwargs=None,
+        trust_remote_code=False,
+        model_types=None,
+        tokenizer_name=None,
+        auto_model=AutoModelForVision2Seq,
+        use_gradient_checkpointing="unsloth",
+        supports_sdpa=True,
+        whisper_language=None,
+        whisper_task=None,
+        auto_config=None,
+        offload_embedding=OFFLOAD_EMBEDDING_AUTO,
+        float32_mixed_precision=None,  # Forces float32 mixed precision
         # vLLM parameters
-        fast_inference = False,
-        gpu_memory_utilization = 0.5,
-        float8_kv_cache = False,
-        random_state = 3407,
-        max_lora_rank = 64,
-        disable_log_stats = False,
-        unsloth_vllm_standby = False,
-        load_in_fp8 = False,  # fp8 LoRA (True, False, 'block')
-        text_only = False,
+        fast_inference=False,
+        gpu_memory_utilization=0.5,
+        float8_kv_cache=False,
+        random_state=3407,
+        max_lora_rank=64,
+        disable_log_stats=False,
+        unsloth_vllm_standby=False,
+        load_in_fp8=False,  # fp8 LoRA (True, False, 'block')
+        text_only=False,
         # True when the caller already swapped a multimodal config for its text sub-config,
         # so `auto_config` no longer describes the repo. Set by loader.py, and by the block
         # below on the direct-call path.
-        text_only_decoder = False,
+        text_only_decoder=False,
         # True when `auto_config` came from the caller. It cannot be inferred here:
         # FastModel pops `config` out of kwargs before this sees them, so by now it looks
         # exactly like one we resolved ourselves.
-        auto_config_from_caller = False,
+        auto_config_from_caller=False,
         **kwargs,
     ):
         user_config = kwargs.pop("config", None)
@@ -1163,10 +1231,10 @@ class FastBaseModel:
         if text_only and auto_config is None:
             auto_config = AutoConfig.from_pretrained(
                 model_name,
-                token = token,
-                trust_remote_code = trust_remote_code,
-                local_files_only = local_files_only,
-                revision = _revision,
+                token=token,
+                trust_remote_code=trust_remote_code,
+                local_files_only=local_files_only,
+                revision=_revision,
             )
         if text_only and hasattr(auto_config, "vision_config"):
             parent_config = auto_config
@@ -1339,10 +1407,10 @@ class FastBaseModel:
         if auto_config is None:
             auto_config = AutoConfig.from_pretrained(
                 model_name,
-                token = token,
-                trust_remote_code = trust_remote_code,
-                local_files_only = local_files_only,
-                revision = _revision,
+                token=token,
+                trust_remote_code=trust_remote_code,
+                local_files_only=local_files_only,
+                revision=_revision,
             )
         model_class = resolve_model_class(auto_model, auto_config)
         # Check if using forced float32 - we load it in bfloat16, then cast to float16!
@@ -1358,9 +1426,9 @@ class FastBaseModel:
         attn_impl = resolve_attention_implementation(
             model_class,
             auto_config,
-            requested_attn_implementation = kwargs.get("attn_implementation", None),
-            supports_sdpa = supports_sdpa,
-            dtype = attn_dtype,
+            requested_attn_implementation=kwargs.get("attn_implementation", None),
+            supports_sdpa=supports_sdpa,
+            dtype=attn_dtype,
         )
 
         # Handle FP8 models: get_model_name has already redirected this to BF16 sibling if the model ships with
@@ -1378,7 +1446,7 @@ class FastBaseModel:
         )
 
         load_in_4bit, load_in_8bit, _ = check_and_disable_bitsandbytes_loading(
-            auto_config, load_in_4bit = load_in_4bit, load_in_8bit = load_in_8bit
+            auto_config, load_in_4bit=load_in_4bit, load_in_8bit=load_in_8bit
         )
         # Correct UNSLOTH_MODEL_NAME's bnb tokens now that the effective bnb state is known
         # (the per-load env was built before remap/disable). gpt-oss only; no-op otherwise.
@@ -1407,7 +1475,7 @@ class FastBaseModel:
         if _planner_skip_reason is None:
             _planner_skip_reason = planner_class_mismatch_reason(
                 model_class,
-                planner_model_class(auto_config, trust_remote_code = trust_remote_code),
+                planner_model_class(auto_config, trust_remote_code=trust_remote_code),
             )
         # The comparison above returns None for a concrete `PreTrainedModel` subclass:
         # `resolve_model_class` reads `auto_model._model_mapping`, which only Auto classes
@@ -1429,34 +1497,38 @@ class FastBaseModel:
                 "a caller-supplied config may not describe the repo the planner rebuilds"
             )
 
+        # Fail fast on known-broken bnb loads (hybrid Mamba/SSM families) before any
+        # shard or device-map planning. #4037
+        _hybrid_mamba_bnb_preflight(auto_config, load_in_4bit, load_in_8bit)
+
         # A no-op unless the caller asked for "unsloth" (or set UNSLOTH_AUTO_DEVICE_MAP);
         # an already-planned map comes back unchanged, so a direct FastBaseModel call
         # behaves the same as going through FastModel.
         device_map = resolve_unsloth_device_map(
             requested_device_map(device_map),
             model_name,
-            fast_inference = fast_inference,
-            full_finetuning = full_finetuning,
-            planner_kwargs = planner_kwargs_with_max_memory(device_map_planner_kwargs, kwargs),
-            skip_reason = _planner_skip_reason,
+            fast_inference=fast_inference,
+            full_finetuning=full_finetuning,
+            planner_kwargs=planner_kwargs_with_max_memory(device_map_planner_kwargs, kwargs),
+            skip_reason=_planner_skip_reason,
             **planner_config_overrides(kwargs),
-            token = token,
-            trust_remote_code = trust_remote_code,
+            token=token,
+            trust_remote_code=trust_remote_code,
             **planner_hub_kwargs(kwargs),
             # The pin the config and weights below use; the default branch would size a
             # different checkpoint than the one being loaded.
-            revision = _revision,
+            revision=_revision,
             # The dtype the load below is given: `from_pretrained` overrides config.json,
             # so planning the checkpoint's own mis-sizes by 2x whenever it changed.
             **add_dtype_kwargs(torch_dtype),
             # A caller-supplied config overrides the flags: loader.py clears them when it
             # forwards one, so the flags alone would size a 4bit load at full precision.
             **planner_quantization_kwargs(
-                load_in_4bit = load_in_4bit,
-                load_in_8bit = load_in_8bit,
-                quantization_config = user_quantization_config,
+                load_in_4bit=load_in_4bit,
+                load_in_8bit=load_in_8bit,
+                quantization_config=user_quantization_config,
                 # The same extra _skip_modules below adds.
-                extra_skip_modules = ["out_proj"]
+                extra_skip_modules=["out_proj"]
                 if any(mt == "nemotron_h" for mt in (model_types or []))
                 else None,
             ),
@@ -1473,20 +1545,20 @@ class FastBaseModel:
         _vllm_owns_weights = fast_inference and is_vLLM_available()
         _prefetched = maybe_prefetch_hf_snapshot(
             model_name,
-            token = token,
-            revision = kwargs.get("revision"),
-            cache_dir = kwargs.get("cache_dir"),
-            local_files_only = kwargs.get("local_files_only", False),
-            fast_inference = _vllm_owns_weights,
-            subfolder = kwargs.get("subfolder"),
-            force_download = kwargs.get("force_download", False),
-            use_safetensors = kwargs.get("use_safetensors"),
-            from_tf = kwargs.get("from_tf", False),
-            from_flax = kwargs.get("from_flax", False),
+            token=token,
+            revision=kwargs.get("revision"),
+            cache_dir=kwargs.get("cache_dir"),
+            local_files_only=kwargs.get("local_files_only", False),
+            fast_inference=_vllm_owns_weights,
+            subfolder=kwargs.get("subfolder"),
+            force_download=kwargs.get("force_download", False),
+            use_safetensors=kwargs.get("use_safetensors"),
+            from_tf=kwargs.get("from_tf", False),
+            from_flax=kwargs.get("from_flax", False),
             # Bare load reads only ROOT weights; skip subdir weights. Ignored when a subfolder is set.
-            weights_at_root = True,
-            variant = kwargs.get("variant"),  # forward so the warm keeps the variant .bin
-            gguf_file = kwargs.get(
+            weights_at_root=True,
+            variant=kwargs.get("variant"),  # forward so the warm keeps the variant .bin
+            gguf_file=kwargs.get(
                 "gguf_file"
             ),  # forward so the warm fetches the GGUF (else ignored)
         )
@@ -1508,10 +1580,10 @@ class FastBaseModel:
             # No revision: this only runs when the repo differs from the pinned one.
             maybe_prefetch_hf_snapshot(
                 _tokenizer_repo,
-                token = token,
-                cache_dir = kwargs.get("cache_dir"),
-                local_files_only = kwargs.get("local_files_only", False),
-                tokenizer_only = True,
+                token=token,
+                cache_dir=kwargs.get("cache_dir"),
+                local_files_only=kwargs.get("local_files_only", False),
+                tokenizer_only=True,
             )
 
         _skip_modules = SKIP_QUANTIZATION_MODULES.copy()
@@ -1523,16 +1595,16 @@ class FastBaseModel:
 
         if load_in_4bit:
             bnb_config = BitsAndBytesConfig(
-                load_in_4bit = True,
-                bnb_4bit_use_double_quant = True,
-                bnb_4bit_quant_type = "nf4",
-                bnb_4bit_compute_dtype = bnb_compute_dtype,
-                llm_int8_skip_modules = _skip_modules,
+                load_in_4bit=True,
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=bnb_compute_dtype,
+                llm_int8_skip_modules=_skip_modules,
             )
         elif load_in_8bit:
             bnb_config = BitsAndBytesConfig(
-                load_in_8bit = True,
-                llm_int8_skip_modules = _skip_modules,
+                load_in_8bit=True,
+                llm_int8_skip_modules=_skip_modules,
             )
         elif load_in_16bit:
             bnb_config = None
@@ -1579,10 +1651,10 @@ class FastBaseModel:
             if auto_config is None:
                 auto_config = AutoConfig.from_pretrained(
                     model_name,
-                    token = token,
-                    trust_remote_code = trust_remote_code,
-                    local_files_only = local_files_only,
-                    revision = _revision,
+                    token=token,
+                    trust_remote_code=trust_remote_code,
+                    local_files_only=local_files_only,
+                    revision=_revision,
                 )
             if hasattr(auto_config, "quantization_config"):
                 from transformers.quantizers.auto import (
@@ -1630,10 +1702,10 @@ class FastBaseModel:
         if auto_config is None:
             auto_config = AutoConfig.from_pretrained(
                 model_name,
-                token = token,
-                trust_remote_code = trust_remote_code,
-                local_files_only = local_files_only,
-                revision = _revision,
+                token=token,
+                trust_remote_code=trust_remote_code,
+                local_files_only=local_files_only,
+                revision=_revision,
             )
         _set_attn_impl(auto_config, config_attn_impl)
         model_config = auto_config
@@ -1664,17 +1736,27 @@ class FastBaseModel:
                 _cfg_val = kwargs.pop("max_position_embeddings", None)
                 if _cfg_val is not None:
                     setattr(model_config, "max_position_embeddings", _cfg_val)
-                model = auto_model.from_pretrained(
-                    model_name,
-                    config = model_config,
-                    device_map = device_map,
-                    # torch_dtype           = torch_dtype, # Transformers removed torch_dtype
-                    # quantization_config   = bnb_config,
-                    token = token,
-                    trust_remote_code = trust_remote_code,
-                    # attn_implementation   = attn_implementation,
-                    **kwargs,
-                )
+                try:
+                    model = auto_model.from_pretrained(
+                        model_name,
+                        config=model_config,
+                        device_map=device_map,
+                        # torch_dtype           = torch_dtype, # Transformers removed torch_dtype
+                        # quantization_config   = bnb_config,
+                        token=token,
+                        trust_remote_code=trust_remote_code,
+                        # attn_implementation   = attn_implementation,
+                        **kwargs,
+                    )
+                except AttributeError as _bnb_err:
+                    # The bnb quantizer's strict per-weight module lookup dies with a raw
+                    # AttributeError that looks like a corrupt checkpoint; translate it.
+                    # Only when bnb is actually active — a 16-bit load raising an
+                    # AttributeError is a real bug and must pass through untouched. #4037
+                    if load_in_4bit or load_in_8bit:
+                        _raise_quantizer_error(_bnb_err, model_name)
+                    else:
+                        raise
                 # Must precede _attach_bnb_multidevice_hooks: it returns early
                 # while offload_embedding is True.
                 offload_embedding = _resolve_offload_embedding(
@@ -1685,21 +1767,21 @@ class FastBaseModel:
                 # Attach dispatch hooks for bnb multi-device loads.
                 _attach_bnb_multidevice_hooks(
                     model,
-                    load_in_4bit = load_in_4bit,
-                    load_in_8bit = load_in_8bit,
-                    offload_embedding = offload_embedding,
-                    fast_inference = fast_inference,
+                    load_in_4bit=load_in_4bit,
+                    load_in_8bit=load_in_8bit,
+                    offload_embedding=offload_embedding,
+                    fast_inference=fast_inference,
                 )
                 # Re-apply block-fp8 weight_scale_inv tensors transformers dropped on load (#6200).
                 _restore_dropped_fp8_scales(
                     model,
                     model_name,
-                    local_files_only = local_files_only,
-                    token = token,
-                    revision = kwargs.get("revision"),
-                    subfolder = kwargs.get("subfolder"),
-                    cache_dir = kwargs.get("cache_dir"),
-                    variant = kwargs.get("variant"),
+                    local_files_only=local_files_only,
+                    token=token,
+                    revision=kwargs.get("revision"),
+                    subfolder=kwargs.get("subfolder"),
+                    cache_dir=kwargs.get("cache_dir"),
+                    variant=kwargs.get("variant"),
                 )
                 if hasattr(model, "generate"):
                     model.fast_generate = make_fast_generate_wrapper(model.generate)
@@ -1760,19 +1842,19 @@ class FastBaseModel:
 
                 allowed_args = inspect.getfullargspec(load_vllm).args
                 load_vllm_kwargs = dict(
-                    model_name = model_name,
-                    config = model_config,
-                    gpu_memory_utilization = gpu_memory_utilization,
-                    max_seq_length = max_seq_length,
-                    dtype = dtype,
-                    float8_kv_cache = float8_kv_cache,
-                    enable_lora = vllm_enable_lora,
-                    max_lora_rank = max_lora_rank,
-                    disable_log_stats = disable_log_stats,
-                    use_bitsandbytes = load_in_4bit,
-                    unsloth_vllm_standby = unsloth_vllm_standby,
-                    is_vision_model = is_vlm_config,
-                    fp8_mode = fp8_mode,
+                    model_name=model_name,
+                    config=model_config,
+                    gpu_memory_utilization=gpu_memory_utilization,
+                    max_seq_length=max_seq_length,
+                    dtype=dtype,
+                    float8_kv_cache=float8_kv_cache,
+                    enable_lora=vllm_enable_lora,
+                    max_lora_rank=max_lora_rank,
+                    disable_log_stats=disable_log_stats,
+                    use_bitsandbytes=load_in_4bit,
+                    unsloth_vllm_standby=unsloth_vllm_standby,
+                    is_vision_model=is_vlm_config,
+                    fp8_mode=fp8_mode,
                 )
                 for allowed_arg in allowed_args:
                     if allowed_arg not in load_vllm_kwargs and allowed_arg in kwargs:
@@ -1784,16 +1866,16 @@ class FastBaseModel:
                 # Convert to HF format
                 _, quant_state_dict = get_vllm_state_dict(
                     llm,
-                    config = model_config,
-                    is_vision_model = is_vlm_config,
-                    load_in_fp8 = load_in_fp8,
+                    config=model_config,
+                    is_vision_model=is_vlm_config,
+                    load_in_fp8=load_in_fp8,
                 )
                 model = convert_vllm_to_huggingface(
                     quant_state_dict,
                     model_config,
                     dtype,
                     bnb_config,
-                    is_vision_model = is_vlm_config,
+                    is_vision_model=is_vlm_config,
                 )
                 model.vllm_engine = llm
                 llm.shared_weights = True
@@ -1837,17 +1919,18 @@ class FastBaseModel:
         if _vllm_owns_weights and isinstance(tokenizer_name, str) and tokenizer_name:
             maybe_prefetch_hf_snapshot(
                 tokenizer_name,
-                token = token,
+                token=token,
                 # Match the tokenizer load below, which only pins its own repo.
-                revision = _tokenizer_revision,
-                cache_dir = kwargs.get("cache_dir"),
-                local_files_only = kwargs.get("local_files_only", False),
-                tokenizer_only = True,
+                revision=_tokenizer_revision,
+                cache_dir=kwargs.get("cache_dir"),
+                local_files_only=kwargs.get("local_files_only", False),
+                tokenizer_only=True,
             )
 
         # Fix _Unsloth_Patched_ prefix in local config files from old saves (issue #4085)
         if os.path.isdir(tokenizer_name):
             import json as _json
+
             for _cfg_name in (
                 "processor_config.json",
                 "preprocessor_config.json",
@@ -1856,14 +1939,14 @@ class FastBaseModel:
                 _cfg_path = os.path.join(tokenizer_name, _cfg_name)
                 if os.path.exists(_cfg_path):
                     try:
-                        with open(_cfg_path, "r", encoding = "utf-8") as _f:
+                        with open(_cfg_path, "r", encoding="utf-8") as _f:
                             _cfg = _json.load(_f)
                         if _cfg.get("processor_class", "").startswith("_Unsloth_Patched_"):
                             _cfg["processor_class"] = _cfg["processor_class"][
                                 len("_Unsloth_Patched_") :
                             ]
-                            with open(_cfg_path, "w", encoding = "utf-8") as _f:
-                                _json.dump(_cfg, _f, indent = 2, ensure_ascii = False)
+                            with open(_cfg_path, "w", encoding="utf-8") as _f:
+                                _json.dump(_cfg, _f, indent=2, ensure_ascii=False)
                     except Exception:
                         pass
 
@@ -1877,14 +1960,14 @@ class FastBaseModel:
                 try:
                     _tok = auto_processor.from_pretrained(
                         tokenizer_name,
-                        padding_side = "left",
-                        token = token,
-                        language = whisper_language,
-                        task = whisper_task,
-                        trust_remote_code = trust_remote_code,
-                        cache_dir = kwargs.get("cache_dir"),
-                        local_files_only = lfo,
-                        revision = _tokenizer_revision,
+                        padding_side="left",
+                        token=token,
+                        language=whisper_language,
+                        task=whisper_task,
+                        trust_remote_code=trust_remote_code,
+                        cache_dir=kwargs.get("cache_dir"),
+                        local_files_only=lfo,
+                        revision=_tokenizer_revision,
                     )
                 except Exception as _e:
                     _tok = None
@@ -1893,24 +1976,24 @@ class FastBaseModel:
                 try:
                     _tok = auto_processor.from_pretrained(
                         tokenizer_name,
-                        padding_side = "left",
-                        token = token,
-                        trust_remote_code = trust_remote_code,
-                        cache_dir = kwargs.get("cache_dir"),
-                        local_files_only = lfo,
-                        revision = _tokenizer_revision,
+                        padding_side="left",
+                        token=token,
+                        trust_remote_code=trust_remote_code,
+                        cache_dir=kwargs.get("cache_dir"),
+                        local_files_only=lfo,
+                        revision=_tokenizer_revision,
                     )
                 except Exception as _e:
                     _err = _e
                     try:
                         _tok = get_auto_processor(
                             tokenizer_name,
-                            padding_side = "left",
-                            token = token,
-                            trust_remote_code = trust_remote_code,
-                            cache_dir = kwargs.get("cache_dir"),
-                            local_files_only = lfo,
-                            revision = _tokenizer_revision,
+                            padding_side="left",
+                            token=token,
+                            trust_remote_code=trust_remote_code,
+                            cache_dir=kwargs.get("cache_dir"),
+                            local_files_only=lfo,
+                            revision=_tokenizer_revision,
                         )
                     except Exception:
                         # Swallow so the manual fallback / entry-point retry can run.
@@ -1928,9 +2011,9 @@ class FastBaseModel:
                         model_type_arch,
                         token,
                         trust_remote_code,
-                        cache_dir = kwargs.get("cache_dir"),
-                        local_files_only = lfo,
-                        revision = _tokenizer_revision,
+                        cache_dir=kwargs.get("cache_dir"),
+                        local_files_only=lfo,
+                        revision=_tokenizer_revision,
                     )
                 except Exception as _fe:
                     _fallback, _fb_err = None, _fe
@@ -1966,9 +2049,10 @@ class FastBaseModel:
                     "e.g. `pip install torchvision`."
                 )
             import sys
+
             print(
                 f"Unsloth: Warning - VLM processor fallback returned None for model_type={model_type_arch}",
-                file = sys.stderr,
+                file=sys.stderr,
             )
         # Backwards compat: if processor has no chat_template (e.g. old saves without
         # chat_template.jinja) but the inner tokenizer does, copy it to the processor.
@@ -1997,10 +2081,10 @@ class FastBaseModel:
         model, tokenizer = patch_model_and_tokenizer(
             model,
             tokenizer,
-            downcast_rope = False,
-            fix_embeddings = False,
-            do_forced_float32 = do_forced_float32,
-            correct_dtype = correct_dtype,
+            downcast_rope=False,
+            fix_embeddings=False,
+            do_forced_float32=do_forced_float32,
+            correct_dtype=correct_dtype,
         )
 
         try:
@@ -2012,12 +2096,12 @@ class FastBaseModel:
 
                 _fallback_tok = _AutoTokenizer.from_pretrained(
                     tokenizer_name,
-                    padding_side = "left",
-                    token = token,
-                    trust_remote_code = trust_remote_code,
-                    cache_dir = kwargs.get("cache_dir"),
-                    local_files_only = local_files_only,
-                    revision = _tokenizer_revision,
+                    padding_side="left",
+                    token=token,
+                    trust_remote_code=trust_remote_code,
+                    cache_dir=kwargs.get("cache_dir"),
+                    local_files_only=local_files_only,
+                    revision=_tokenizer_revision,
                 )
                 model, _fallback_tok = patch_tokenizer(model, _fallback_tok)
                 # Re-attach as processor wrapper if original was a processor
@@ -2035,37 +2119,38 @@ class FastBaseModel:
         # Log Unsloth version for future fastpaths for inference
         if hasattr(model, "config"):
             model.config.update({"unsloth_version": __version__})
-        patch_saving_functions(model, vision = True)
+        patch_saving_functions(model, vision=True)
         if tokenizer is None:
             # Last resort: AutoTokenizer, then PreTrainedTokenizerFast (raise on network failure to retry).
             def _last_resort_tokenizer(lfo):
                 from transformers import AutoTokenizer as _AutoTokenizer
+
                 load_path = _hub_repo_or_local_path(
                     tokenizer_name,
-                    token = token,
-                    cache_dir = kwargs.get("cache_dir"),
-                    local_files_only = lfo,
-                    revision = _tokenizer_revision,
+                    token=token,
+                    cache_dir=kwargs.get("cache_dir"),
+                    local_files_only=lfo,
+                    revision=_tokenizer_revision,
                 )
                 try:
                     return _AutoTokenizer.from_pretrained(
                         load_path,
-                        padding_side = "left",
-                        token = token,
-                        trust_remote_code = trust_remote_code,
-                        cache_dir = kwargs.get("cache_dir"),
-                        local_files_only = lfo,
-                        revision = _tokenizer_revision,
+                        padding_side="left",
+                        token=token,
+                        trust_remote_code=trust_remote_code,
+                        cache_dir=kwargs.get("cache_dir"),
+                        local_files_only=lfo,
+                        revision=_tokenizer_revision,
                     )
                 except Exception:
                     return _load_pretrained_tokenizer_fast(
                         tokenizer_name,
-                        padding_side = "left",
-                        token = token,
-                        trust_remote_code = trust_remote_code,
-                        cache_dir = kwargs.get("cache_dir"),
-                        local_files_only = lfo,
-                        revision = _tokenizer_revision,
+                        padding_side="left",
+                        token=token,
+                        trust_remote_code=trust_remote_code,
+                        cache_dir=kwargs.get("cache_dir"),
+                        local_files_only=lfo,
+                        revision=_tokenizer_revision,
                     )
 
             _last_resort_err = None
@@ -2085,7 +2170,7 @@ class FastBaseModel:
                     "or set HF_HUB_OFFLINE=1 to force local loading. "
                     "Otherwise please check that the model has a tokenizer."
                 ) from _last_resort_err
-        patch_saving_functions(tokenizer, vision = True)
+        patch_saving_functions(tokenizer, vision=True)
 
         # Fix gradient accumulation. See issue #4982.
         from transformers.trainer import Trainer
@@ -2117,7 +2202,7 @@ class FastBaseModel:
             module.max_seq_length = max_seq_length
         m._saved_temp_tokenizer = tokenizer
         # Prevent Transformers Trainer from auto-wrapping Unsloth LoRA models in DP.
-        _mark_unsloth_disable_data_parallel(model, disable = not full_finetuning)
+        _mark_unsloth_disable_data_parallel(model, disable=not full_finetuning)
 
         # Patch generate
         if os.environ.get("UNSLOTH_DISABLE_FAST_GENERATION", "0") == "0" and hasattr(
@@ -2131,11 +2216,11 @@ class FastBaseModel:
         # Post patches
         model = FastBaseModel.post_patch_model(
             model,
-            use_gradient_checkpointing = use_gradient_checkpointing,
-            trust_remote_code = trust_remote_code,
-            model_type = model_type_arch,
-            tokenizer = tokenizer,
-            float32_mixed_precision = float32_mixed_precision,
+            use_gradient_checkpointing=use_gradient_checkpointing,
+            trust_remote_code=trust_remote_code,
+            model_type=model_type_arch,
+            tokenizer=tokenizer,
+            float32_mixed_precision=float32_mixed_precision,
         )
         # Clear deleted GPU items
         for _ in range(3):
@@ -2171,31 +2256,31 @@ class FastBaseModel:
     @staticmethod
     def get_peft_model(
         model,
-        r = 16,
-        target_modules = None,
-        lora_alpha = 16,
-        lora_dropout = 0.0,
-        bias = "none",
-        finetune_vision_layers = True,
-        finetune_language_layers = True,
-        finetune_attention_modules = True,
-        finetune_mlp_modules = True,
-        finetune_last_n_layers = None,
-        layers_to_transform = None,
-        layers_pattern = None,
-        use_gradient_checkpointing = "unsloth",
-        random_state = 3407,
-        max_seq_length = 2048,  # not used anymore
-        use_rslora = False,
-        modules_to_save = None,
-        init_lora_weights = True,
-        loftq_config = {},
-        task_type = TaskType.CAUSAL_LM,
-        temporary_location = "_unsloth_temporary_saved_buffers",
-        qat_scheme = None,
-        target_parameters = None,  # For MoE expert layers (nn.Parameter)
-        ensure_weight_tying = None,  # None = auto (tie when we redirect a tied pair)
-        finetune_audio_layers = False,  # placed last to preserve existing positional argument order
+        r=16,
+        target_modules=None,
+        lora_alpha=16,
+        lora_dropout=0.0,
+        bias="none",
+        finetune_vision_layers=True,
+        finetune_language_layers=True,
+        finetune_attention_modules=True,
+        finetune_mlp_modules=True,
+        finetune_last_n_layers=None,
+        layers_to_transform=None,
+        layers_pattern=None,
+        use_gradient_checkpointing="unsloth",
+        random_state=3407,
+        max_seq_length=2048,  # not used anymore
+        use_rslora=False,
+        modules_to_save=None,
+        init_lora_weights=True,
+        loftq_config={},
+        task_type=TaskType.CAUSAL_LM,
+        temporary_location="_unsloth_temporary_saved_buffers",
+        qat_scheme=None,
+        target_parameters=None,  # For MoE expert layers (nn.Parameter)
+        ensure_weight_tying=None,  # None = auto (tie when we redirect a tied pair)
+        finetune_audio_layers=False,  # placed last to preserve existing positional argument order
         **kwargs,
     ):
         if os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1":
@@ -2254,8 +2339,8 @@ class FastBaseModel:
         target_modules, modules_to_save, _moved = _redirect_embedding_targets(
             target_modules,
             modules_to_save,
-            allow_redirect = finetune_language_layers,
-            skip = _vllm_unmovable_embedding_modules(model, target_modules),
+            allow_redirect=finetune_language_layers,
+            skip=_vllm_unmovable_embedding_modules(model, target_modules),
         )
         _raise_if_no_lora_targets_left(target_modules, _moved, target_parameters)
         ensure_weight_tying = _effective_weight_tying(
@@ -2279,10 +2364,10 @@ class FastBaseModel:
         if target_modules is None or target_modules == "all-linear":
             target_modules = get_peft_regex(
                 model,
-                finetune_vision_layers = finetune_vision_layers,
-                finetune_language_layers = finetune_language_layers,
-                finetune_attention_modules = finetune_attention_modules,
-                finetune_mlp_modules = finetune_mlp_modules,
+                finetune_vision_layers=finetune_vision_layers,
+                finetune_language_layers=finetune_language_layers,
+                finetune_attention_modules=finetune_attention_modules,
+                finetune_mlp_modules=finetune_mlp_modules,
                 **_audio_kwargs,
             )
         else:
@@ -2307,11 +2392,11 @@ class FastBaseModel:
                     )
                 target_modules = get_peft_regex(
                     model,
-                    finetune_vision_layers = finetune_vision_layers,
-                    finetune_language_layers = finetune_language_layers,
-                    finetune_attention_modules = finetune_attention_modules,
-                    finetune_mlp_modules = finetune_mlp_modules,
-                    target_modules = list(target_modules),
+                    finetune_vision_layers=finetune_vision_layers,
+                    finetune_language_layers=finetune_language_layers,
+                    finetune_attention_modules=finetune_attention_modules,
+                    finetune_mlp_modules=finetune_mlp_modules,
+                    target_modules=list(target_modules),
                     **_audio_kwargs,
                 )
 
@@ -2361,8 +2446,8 @@ class FastBaseModel:
             _moe_targets = _select_moe_detection_targets(
                 _moe_detect_target,
                 target_modules,
-                finetune_mlp_modules = finetune_mlp_modules,
-                finetune_language_layers = finetune_language_layers,
+                finetune_mlp_modules=finetune_mlp_modules,
+                finetune_language_layers=finetune_language_layers,
             )
             target_parameters = get_moe_target_parameters(model, _moe_targets)
 
@@ -2372,8 +2457,8 @@ class FastBaseModel:
         _moe_module_detect = _select_moe_detection_targets(
             _moe_detect_target,
             target_modules,
-            finetune_mlp_modules = finetune_mlp_modules,
-            finetune_language_layers = finetune_language_layers,
+            finetune_mlp_modules=finetune_mlp_modules,
+            finetune_language_layers=finetune_language_layers,
         )
         _moe_module_targets = get_moe_target_modules(model, _moe_module_detect)
         if _moe_module_targets:
@@ -2413,7 +2498,7 @@ class FastBaseModel:
         )
         model = prepare_model_for_kbit_training(
             model,
-            use_gradient_checkpointing = use_gradient_checkpointing,
+            use_gradient_checkpointing=use_gradient_checkpointing,
         )
         # Gemma4 ClippableLinear wraps nn.Linear -- PEFT can't inject LoRA on it directly.
         # Monkey-patch PEFT to target the inner .linear child instead.
@@ -2436,7 +2521,7 @@ class FastBaseModel:
                 target,
                 target_name,
                 parent,
-                current_key = None,
+                current_key=None,
                 **kwargs,
             ):
                 if isinstance(target, _clippable_linear_cls):
@@ -2447,7 +2532,7 @@ class FastBaseModel:
                         target.linear,
                         "linear",
                         target,
-                        current_key = current_key,
+                        current_key=current_key,
                         **kwargs,
                     )
                 return _original_car(
@@ -2457,7 +2542,7 @@ class FastBaseModel:
                     target,
                     target_name,
                     parent,
-                    current_key = current_key,
+                    current_key=current_key,
                     **kwargs,
                 )
 
@@ -2491,8 +2576,8 @@ class FastBaseModel:
         trust_remote_code = getattr(model, "_unsloth_trust_remote_code", False)
         model = FastBaseModel.post_patch_model(
             model,
-            use_gradient_checkpointing = use_gradient_checkpointing,
-            trust_remote_code = trust_remote_code,
+            use_gradient_checkpointing=use_gradient_checkpointing,
+            trust_remote_code=trust_remote_code,
         )
         model.max_seq_length = max_seq_length
         # Save to modules as well
@@ -2502,7 +2587,7 @@ class FastBaseModel:
         for _ in range(3):
             gc.collect()
             clean_gpu_cache()
-        patch_saving_functions(model, vision = True)
+        patch_saving_functions(model, vision=True)
         patch_peft_fast_inference(model)
 
         # Add for_inference and for_training
@@ -2522,11 +2607,11 @@ class FastBaseModel:
     @staticmethod
     def post_patch_model(
         model,
-        use_gradient_checkpointing = True,
-        trust_remote_code = False,
-        model_type = None,
-        tokenizer = None,
-        float32_mixed_precision = None,
+        use_gradient_checkpointing=True,
+        trust_remote_code=False,
+        model_type=None,
+        tokenizer=None,
+        float32_mixed_precision=None,
     ):
         full_finetuning = os.environ.get("UNSLOTH_ENABLE_FULL_FINETUNING", "0") == "1"
 
@@ -2558,14 +2643,14 @@ class FastBaseModel:
 
         model = prepare_model_for_training(
             model,
-            use_gradient_checkpointing = use_gradient_checkpointing,
-            use_reentrant = use_reentrant,
-            full_finetuning = full_finetuning,
-            train_layernorms = full_finetuning,
-            train_embedding = full_finetuning,
-            train_lm_head = full_finetuning,
-            float32_mixed_precision = float32_mixed_precision,
-            patch_modules_to_save = True,
+            use_gradient_checkpointing=use_gradient_checkpointing,
+            use_reentrant=use_reentrant,
+            full_finetuning=full_finetuning,
+            train_layernorms=full_finetuning,
+            train_embedding=full_finetuning,
+            train_lm_head=full_finetuning,
+            float32_mixed_precision=float32_mixed_precision,
+            patch_modules_to_save=True,
         )
         # Persist the configured GC mode so the trainer restores it verbatim.
         # for_inference() clears the module flags (GRPO does this every generation
@@ -2598,7 +2683,7 @@ class FastBaseModel:
             and trust_remote_code == False
         ):
             raise RuntimeError("Unsloth: Unsuccessfully patched inner_training_loop")
-        patch_saving_functions(model, vision = True)
+        patch_saving_functions(model, vision=True)
 
         # Patch tokenizer to pad to the left
         m = model
@@ -2611,7 +2696,7 @@ class FastBaseModel:
             if hasattr(m._saved_temp_tokenizer, "tokenizer"):
                 m._saved_temp_tokenizer.tokenizer.padding_side = "left"
         # Prevent Transformers Trainer from auto-wrapping Unsloth LoRA models in DP.
-        _mark_unsloth_disable_data_parallel(model, disable = not full_finetuning)
+        _mark_unsloth_disable_data_parallel(model, disable=not full_finetuning)
 
         # Clear deleted GPU items
         for _ in range(3):
@@ -2696,6 +2781,7 @@ class FastBaseModel:
         # for gradient checkpointing (older unsloth_zoo has no restore helper)
         try:
             from unsloth_zoo.training_utils import restore_use_cache
+
             restore_use_cache(model)
         except ImportError:
             pass
@@ -2706,11 +2792,11 @@ class FastBaseModel:
         os.environ["UNSLOTH_RETURN_LOGITS"] = "1"
         # Turn off skip guards and set stance to default
         if torch_compiler_set_stance is not None:
-            torch_compiler_set_stance(stance = "default", skip_guard_eval_unsafe = False)
+            torch_compiler_set_stance(stance="default", skip_guard_eval_unsafe=False)
         return model
 
     @staticmethod
-    def for_training(model, use_gradient_checkpointing = True):
+    def for_training(model, use_gradient_checkpointing=True):
         if not hasattr(model, "parameters"):
             raise TypeError(
                 "Unsloth: I think you're passing a tokenizer, not the model to for_training!"
@@ -2766,6 +2852,7 @@ class FastBaseModel:
         ):
             try:
                 from unsloth_zoo.training_utils import disable_use_cache
+
                 disable_use_cache(model)
             except ImportError:
                 pass
@@ -2774,7 +2861,7 @@ class FastBaseModel:
         os.environ["UNSLOTH_RETURN_LOGITS"] = "0"
         # Turn off skip guards and set stance to default
         if torch_compiler_set_stance is not None:
-            torch_compiler_set_stance(stance = "default", skip_guard_eval_unsafe = False)
+            torch_compiler_set_stance(stance="default", skip_guard_eval_unsafe=False)
         return model
 
 
@@ -2819,9 +2906,9 @@ def _local_path_from_video_value(video_path):
 
 def check_dataset_for_missing_videos(
     dataset,
-    column = "messages",
-    raise_error = True,
-    checked = None,
+    column="messages",
+    raise_error=True,
+    checked=None,
 ):
     """
     Validate that local video paths referenced in a dataset exist, catching
@@ -2842,13 +2929,14 @@ def check_dataset_for_missing_videos(
     """
     try:
         from datasets import IterableDataset as _IterableDataset
+
         if isinstance(dataset, _IterableDataset):
             warnings.warn(
                 "Unsloth: check_dataset_for_missing_videos received a streaming "
                 "IterableDataset; iterating would exhaust it and training would "
                 "see zero samples. Skipping validation - pass a map-style Dataset "
                 "or rely on the UnslothVisionDataCollator's per-batch check.",
-                stacklevel = 2,
+                stacklevel=2,
             )
             return []
     except ImportError:
@@ -2895,7 +2983,7 @@ def check_dataset_for_missing_videos(
         )
         if raise_error:
             raise FileNotFoundError(error_msg)
-        warnings.warn(error_msg, stacklevel = 2)
+        warnings.warn(error_msg, stacklevel=2)
 
     return missing
 
@@ -2903,6 +2991,7 @@ def check_dataset_for_missing_videos(
 # Auto-enable grouped-GEMM MoE (transformers<5 ModuleList experts); see llama.py.
 try:
     from unsloth_zoo.temporary_patches.moe_grouped_modulelist import wrap_loader_for_grouped_moe
+
     FastBaseModel.from_pretrained = staticmethod(
         wrap_loader_for_grouped_moe(FastBaseModel.from_pretrained)
     )


### PR DESCRIPTION
## Summary

Loading a hybrid Mamba/SSM checkpoint (e.g. `ai21labs/AI21-Jamba2-Mini`) with `load_in_4bit=True` dies deep inside transformers' bitsandbytes quantizer with an opaque `AttributeError: JambaAttention has no attribute 'feed_forward'` after every shard is downloaded. Users read it as a corrupt checkpoint (33 comments on #4037, none actionable).

## Fix

Two layers, both pure functions (unit-testable without GPU/network):

1. **`_hybrid_mamba_bnb_preflight`** — known-broken families (`jamba`, `zamba2`) with 4/8-bit now raise a clear ValueError before any shard download or device-map planning, with concrete workarounds. Matched on `config.model_type`/`architectures` via exact token membership — never by repo name.

2. **`_raise_quantizer_error`** — any remaining `has no attribute` AttributeError escaping the quantized model load is re-raised as a diagnosis. Only when bnb is active; a 16-bit AttributeError passes through untouched.

## Blocklist (per maintainer review)

```python
_HYBRID_MAMBA_BNB_BLOCKLIST = (
    "jamba",
    "zamba2",
)
```

Nemotron-H, granite-4.0-h, and granitemoehybrid removed — handled in `unsloth/models/loader.py` with official bnb-4bit repos.

## GPU Verification

**Hardware:** 4x NVIDIA GeForce RTX 5060 Ti (16 GB), unsloth 2026.8.22, transformers 5.5.0

```
======================================================================
EVIDENCE: #4037 Jamba-Guard — Blocklist Verification
======================================================================
GPUs: 4x NVIDIA GeForce RTX 5060 Ti
unsloth: 2026.8.22

Blocklist: ('jamba', 'zamba2')
PASS: Only jamba + zamba2 in blocklist

Test A: Jamba2-Mini + load_in_4bit (guard MUST fire)
PASS: Guard fired correctly

Test B: Nemotron-H + load_in_4bit (guard must NOT fire)
PASS: Guard did NOT fire — Nemotron-H passes through

Test C: Llama + load_in_4bit (guard must NOT fire)
PASS: Guard did NOT fire — Llama passes through

======================================================================
ALL TESTS PASSED
======================================================================
```

## Tests

- `tests/test_hybrid_mamba_bnb_guard.py` — 7 unit tests (incl. Nemotron-H passthrough)
- `tests/test_hybrid_mamba_bnb_guard_integration.py` — 3 integration tests
- 30 total tests green on CPU harness

Closes #4037