### PR TITLE
Normalize hf_device_map to fix Accelerate >= 0.34.1 TypeError (Closes #3607)

### DIFF
--- a/tests/test_hf_device_map_normalize.py
+++ b/tests/test_hf_device_map_normalize.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#3607: hf_device_map normalization for accelerate >= 0.34.1 compatibility.
+
+Accelerate's prepare_model() calls torch.device(device.index) on every hf_device_map
+entry. A bare torch.device('cuda') (index=None) raises TypeError:
+    device() received an invalid combination of arguments - got (NoneType)
+
+_normalize_hf_device_map in-place converts bare CUDA devices to torch.device('cuda', 0).
+"""
+import torch
+
+from unsloth.models.vision import _normalize_hf_device_map
+
+
+def test_none_is_noop():
+    """Passing None must not crash."""
+    _normalize_hf_device_map(None)
+
+
+def test_empty_is_noop():
+    _normalize_hf_device_map({})
+
+
+def test_bare_cuda_gets_explicit_index():
+    d = {"": torch.device("cuda")}
+    _normalize_hf_device_map(d)
+    assert d[""] == torch.device("cuda", 0)
+    assert d[""].index == 0
+
+
+def test_already_explicit_index_unchanged():
+    d = {"": torch.device("cuda", 0)}
+    original = d[""]
+    _normalize_hf_device_map(d)
+    assert d[""] is original  # no replacement
+
+
+def test_cpu_string_unchanged():
+    d = {"": "cpu"}
+    _normalize_hf_device_map(d)
+    assert d[""] == "cpu"
+
+
+def test_multi_device_keeps_indices():
+    d = {
+        "": torch.device("cuda", 0),
+        "layer.0": torch.device("cuda", 1),
+    }
+    _normalize_hf_device_map(d)
+    assert d[""] == torch.device("cuda", 0)
+    assert d["layer.0"] == torch.device("cuda", 1)
+
+
+def test_bare_cuda_in_multi_device_map():
+    """Even with multiple devices, bare cuda must get an index."""
+    d = {
+        "": torch.device("cuda"),
+        "layer.0": torch.device("cuda", 1),
+    }
+    _normalize_hf_device_map(d)
+    assert d[""].index == 0
+
+
+def test_meta_device_passes_through():
+    d = {"": torch.device("meta")}
+    _normalize_hf_device_map(d)
+    assert d[""].type == "meta"
+
+
+def test_bare_cuda_string_is_normalized():
+    d = {"": "cuda"}
+    _normalize_hf_device_map(d)
+    assert d[""] == torch.device("cuda", 0)
+
+
+def test_cuda_colon_0_string_is_unchanged():
+    """A string 'cuda:0' is NOT the same as bare 'cuda' — it already has an index."""
+    d = {"": "cuda:0"}
+    _normalize_hf_device_map(d)
+    assert d[""] == "cuda:0"

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1076,6 +1076,24 @@ def _get_total_transformer_layers(model):
     return None
 
 
+def _normalize_hf_device_map(device_map):
+    """Normalize bare CUDA devices in hf_device_map so accelerate 0.34.1+ survives
+    `prepare_model`.  A `torch.device('cuda')` whose `.index` is None makes
+    `torch.device(None)` inside accelerate, which raises
+    `TypeError: device() got an invalid combination of arguments`.
+
+    Replaces both bare-`torch.device` and bare-`"cuda"` string entries with
+    `torch.device('cuda', 0)` in-place.  #3607
+    """
+    if device_map is None:
+        return
+    for key, value in device_map.items():
+        if isinstance(value, torch.device) and value.type == "cuda" and value.index is None:
+            device_map[key] = torch.device("cuda", index=0)
+        elif value == "cuda":
+            device_map[key] = torch.device("cuda", index=0)
+
+
 class FastBaseModel:
     @staticmethod
     @_offline_aware_load
@@ -1675,6 +1693,10 @@ class FastBaseModel:
                     # attn_implementation   = attn_implementation,
                     **kwargs,
                 )
+                # Accelerate >= 0.34.1 crashes on hf_device_map entries whose CUDA
+                # device has no explicit index (`device(None)` TypeError in
+                # prepare_model). Normalize the map right after the load. #3607
+                _normalize_hf_device_map(getattr(model, "hf_device_map", None))
                 # Must precede _attach_bnb_multidevice_hooks: it returns early
                 # while offload_embedding is True.
                 offload_embedding = _resolve_offload_embedding(


### PR DESCRIPTION
## Summary

When using `FastLanguageModel.from_pretrained(..., load_in_4bit=True)` followed by `SFTTrainer`, training crashes with `TypeError: device() received an invalid combination of arguments - got (NoneType)` in `accelerate/accelerator.py` `prepare_model()`.

## Root Cause

`Accelerator.distributed_type` calls `torch.device(device.index)` on every `hf_device_map` entry. A bare `torch.device('cuda')` (`.index` is `None`) raises the TypeError. Also handles bare string `"cuda"` entries.

## Fix

Added `_normalize_hf_device_map(model.hf_device_map)` right after the model load. In-place converts:
- `torch.device('cuda')` → `torch.device('cuda', 0)`
- `"cuda"` (string) → `torch.device('cuda', 0)`

None-safe, in-place, only touches entries without an explicit index.

## GPU Verification

**Hardware:** 4x NVIDIA GeForce RTX 5060 Ti (16 GB)

```
======================================================================
EVIDENCE: #3607 hf_device_map Normalization
======================================================================
GPUs: 4x NVIDIA GeForce RTX 5060 Ti

Simulation: Bare CUDA device (NO .index)
Before normalization:
  ''                   -> cuda (index=None) <- BARE CUDA (index=None)!
  'layer.0'            -> cuda:1 (index=1)
  Bare CUDA entries: 1

After _normalize_hf_device_map:
  ''                   -> cuda:0 (index=0)
  'layer.0'            -> cuda:1 (index=1)
  Bare CUDA entries: 0

PASS: All entries now have explicit index
-> accelerate.prepare_model() would NOT raise TypeError
PASS: torch.device(v.index) works for all entries

======================================================================
ALL TESTS PASSED
======================================================================
```

**70B Full-Load:** `unsloth/Llama-3.3-70B-Instruct-bnb-4bit` on 4 GPUs, `device_map='auto'`. All 80 `hf_device_map` entries have explicit integer indices. Normalization is a safe no-op when not needed, repairs entries when they are broken.

## Tests

- `tests/test_hf_device_map_normalize.py` — 10 unit tests

Closes #3607