### PR TITLE
Studio: send tool results to the model in the right order

### DIFF
--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -189,6 +189,62 @@ def anthropic_messages_to_openai(
     return result
 
 
+def fold_tool_results_into_user(messages: list[dict]) -> list[dict]:
+    """Rewrite ``role="tool"`` messages as user turns for tool-less templates.
+
+    Templates with no tool support (Gemma 2, Gemma 3, Phi-3.5, SmolLM2, ...)
+    have no branch for a ``tool`` role. Gemma 2 and Gemma 3 additionally enforce
+    strict user/assistant alternation by index parity, so a ``tool`` message
+    landing on an even index raises "Conversation roles must alternate" and
+    llama-server turns that into a 400 -- the whole request fails instead of
+    merely losing the tool output. Which index a tool message lands on is pure
+    luck, so both message orders hit this for some histories.
+
+    Folding the result into a user turn keeps the tool output in the prompt and
+    leaves the roles alternating once ``_coalesce_consecutive_user_turns`` runs.
+    The content shape mirrors minja's own ``polyfill_tool_responses`` (a JSON
+    object under a ``tool_response`` key) so a tool-less template sees the same
+    text llama.cpp would have produced had its polyfill engaged.
+
+    Only ``tool`` messages are touched; every other message passes through
+    unchanged, and a history with no tool messages returns equal content.
+    """
+    out: list[dict] = []
+    # tool_call_id -> function name, from the assistant turns that requested them.
+    call_names: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                if not isinstance(tc, dict):
+                    continue
+                tc_id = tc.get("id")
+                fn = tc.get("function")
+                if isinstance(tc_id, str) and tc_id and isinstance(fn, dict):
+                    name = fn.get("name")
+                    if isinstance(name, str) and name:
+                        call_names[tc_id] = name
+
+        if msg.get("role") != "tool":
+            out.append(msg)
+            continue
+
+        response: dict[str, Any] = {}
+        tool_call_id = msg.get("tool_call_id")
+        name = msg.get("name") or call_names.get(tool_call_id or "")
+        if name:
+            response["tool"] = name
+        response["content"] = msg.get("content", "")
+        if tool_call_id:
+            response["tool_call_id"] = tool_call_id
+        out.append(
+            {
+                "role": "user",
+                "content": json.dumps({"tool_response": response}, indent = 2),
+            }
+        )
+    return out
+
+
 _ANTHROPIC_SCHEMA_CLIENT_TOOL_PARAMETERS = {
     "bash": {
         "type": "object",

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -175,6 +175,9 @@ def anthropic_messages_to_openai(
                         }
                     )
 
+            for tr in tool_results:
+                result.append(tr)
+
             if has_image:
                 result.append({"role": "user", "content": user_parts})
             else:
@@ -182,8 +185,6 @@ def anthropic_messages_to_openai(
                 text = "\n".join(p["text"] for p in user_parts)
                 if text:
                     result.append({"role": "user", "content": text})
-            for tr in tool_results:
-                result.append(tr)
 
     return result
 

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -190,27 +190,11 @@ def anthropic_messages_to_openai(
 
 
 def fold_tool_results_into_user(messages: list[dict]) -> list[dict]:
-    """Rewrite ``role="tool"`` messages as user turns for tool-less templates.
-
-    Templates with no tool support (Gemma 2, Gemma 3, Phi-3.5, SmolLM2, ...)
-    have no branch for a ``tool`` role. Gemma 2 and Gemma 3 additionally enforce
-    strict user/assistant alternation by index parity, so a ``tool`` message
-    landing on an even index raises "Conversation roles must alternate" and
-    llama-server turns that into a 400 -- the whole request fails instead of
-    merely losing the tool output. Which index a tool message lands on is pure
-    luck, so both message orders hit this for some histories.
-
-    Folding the result into a user turn keeps the tool output in the prompt and
-    leaves the roles alternating once ``_coalesce_consecutive_user_turns`` runs.
-    The content shape mirrors minja's own ``polyfill_tool_responses`` (a JSON
-    object under a ``tool_response`` key) so a tool-less template sees the same
-    text llama.cpp would have produced had its polyfill engaged.
-
-    Only ``tool`` messages are touched; every other message passes through
-    unchanged, and a history with no tool messages returns equal content.
+    """Rewrite ``role="tool"`` as user turns: Gemma 2 / 3 have no tool role and
+    check alternation by index parity, so one makes llama-server 400 the whole
+    request. Shape mirrors minja's ``polyfill_tool_responses``.
     """
     out: list[dict] = []
-    # tool_call_id -> function name, from the assistant turns that requested them.
     call_names: dict[str, str] = {}
     for msg in messages:
         if msg.get("role") == "assistant":

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2912,6 +2912,7 @@ from models.inference import (
 )
 from core.inference.anthropic_compat import (
     anthropic_messages_to_openai,
+    fold_tool_results_into_user,
     anthropic_schema_client_tool_kind,
     anthropic_tools_to_openai,
     anthropic_tool_choice_to_openai,
@@ -27393,12 +27394,7 @@ async def anthropic_count_tokens(
     # Apply the same sanitization /messages does before generation, so the count
     # matches the prompt the real request would build (otherwise empty-assistant
     # sentinels / synthetic tool history inflate the count or hit the fallback).
-    # Coalesce adjacent user turns left behind by dropping an empty / null assistant
-    # turn, so a strict GGUF chat template does not 400 on non-alternating roles
-    # (mirrors the GGUF chat path); a no-op for already-alternating histories.
-    openai_messages = _coalesce_consecutive_user_turns(
-        _strip_provider_synthetic_tool_history(_drop_empty_assistant_sentinels(openai_messages))
-    )
+    openai_messages = _sanitize_anthropic_openai_messages(openai_messages, llama_backend)
     openai_tools = anthropic_tools_to_openai(payload.tools or []) or None
     # Only the client-tool passthrough is forwarded verbatim, so reproduce /messages' own
     # routing rather than "any tools": a Studio server-tool alias, or a template without
@@ -27644,12 +27640,7 @@ async def anthropic_messages(
     # builders apply the same strip; without it an Anthropic /v1/messages caller
     # replaying a prior provider-side tool_use forwards fake builtin tool
     # history to a backend with no matching function declarations.
-    # Coalesce adjacent user turns left behind by dropping an empty / null assistant
-    # turn, so a strict GGUF chat template does not 400 on non-alternating roles
-    # (mirrors the GGUF chat path); a no-op for already-alternating histories.
-    openai_messages = _coalesce_consecutive_user_turns(
-        _strip_provider_synthetic_tool_history(_drop_empty_assistant_sentinels(openai_messages))
-    )
+    openai_messages = _sanitize_anthropic_openai_messages(openai_messages, llama_backend)
 
     # Enforce vision guard + re-encode embedded images to PNG so the Anthropic
     # endpoint matches /v1/chat/completions.
@@ -29864,6 +29855,41 @@ def _coalesce_consecutive_user_turns(messages: list[dict]) -> list[dict]:
             continue
         out.append(m)
     return out
+
+
+def _template_supports_tools(backend) -> bool:
+    """``backend.supports_tools``, defaulting to True when asking is not safe.
+
+    True is the conservative default here: it leaves the message list exactly as
+    the converter built it, so an unreadable backend never changes the prompt.
+    """
+    try:
+        return bool(getattr(backend, "supports_tools", True))
+    except Exception:
+        return True
+
+
+def _sanitize_anthropic_openai_messages(messages: list[dict], backend) -> list[dict]:
+    """The post-conversion chain shared by /v1/messages and its token counter.
+
+    Both endpoints must build the identical list or the advertised input_tokens
+    stops matching the prompt that generation actually sends, so the steps live
+    here rather than being repeated at each call site.
+
+    Steps, in order:
+      - drop Stop-button sentinels / normalize reasoning-only assistant turns;
+      - strip synthetic provider-side builtin tool history;
+      - on a template with no tool support, fold role=tool into user turns,
+        which must happen BEFORE the coalesce so a folded result and the note
+        that followed it merge into one turn;
+      - coalesce adjacent user turns, so a strict GGUF chat template does not
+        400 on non-alternating roles (mirrors the GGUF chat path); a no-op for
+        already-alternating histories.
+    """
+    messages = _strip_provider_synthetic_tool_history(_drop_empty_assistant_sentinels(messages))
+    if not _template_supports_tools(backend):
+        messages = fold_tool_results_into_user(messages)
+    return _coalesce_consecutive_user_turns(messages)
 
 
 _LOCAL_SERVER_BUILTIN_TOOL_NAMES = frozenset(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -29858,13 +29858,24 @@ def _coalesce_consecutive_user_turns(messages: list[dict]) -> list[dict]:
 
 
 def _template_supports_tools(backend) -> bool:
-    """``backend.supports_tools``, defaulting to True when asking is not safe.
+    """Whether the loaded chat template can render a ``role="tool"`` message.
 
-    True is the conservative default here: it leaves the message list exactly as
-    the converter built it, so an unreadable backend never changes the prompt.
+    ``supports_tool_passthrough`` is the raw template flag and is the question
+    being asked here. ``supports_tools`` is that same flag with DiffusionGemma
+    forced off so it never enters the agentic tool loop, which says nothing
+    about what its template renders: folding on it would strip native tool
+    framing from a client-tool passthrough request, which is dispatched on
+    exactly this predicate. Same order as that gate, so the two cannot disagree.
+
+    Defaults to True when the backend cannot answer, which leaves the message
+    list as the converter built it so an unreadable backend never changes the
+    prompt.
     """
     try:
-        return bool(getattr(backend, "supports_tools", True))
+        for attr in ("supports_tool_passthrough", "supports_tools"):
+            if hasattr(backend, attr):
+                return bool(getattr(backend, attr))
+        return True
     except Exception:
         return True
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -29858,18 +29858,10 @@ def _coalesce_consecutive_user_turns(messages: list[dict]) -> list[dict]:
 
 
 def _template_supports_tools(backend) -> bool:
-    """Whether the loaded chat template can render a ``role="tool"`` message.
-
-    ``supports_tool_passthrough`` is the raw template flag and is the question
-    being asked here. ``supports_tools`` is that same flag with DiffusionGemma
-    forced off so it never enters the agentic tool loop, which says nothing
-    about what its template renders: folding on it would strip native tool
-    framing from a client-tool passthrough request, which is dispatched on
-    exactly this predicate. Same order as that gate, so the two cannot disagree.
-
-    Defaults to True when the backend cannot answer, which leaves the message
-    list as the converter built it so an unreadable backend never changes the
-    prompt.
+    """Can the loaded template render a ``role="tool"`` message? Not
+    ``supports_tools``: same flag with DiffusionGemma forced out of the agentic
+    loop, so folding on it strips tool framing from a passthrough request. Same
+    order as the client-tool dispatch gate; unreadable backend -> True.
     """
     try:
         for attr in ("supports_tool_passthrough", "supports_tools"):
@@ -29881,21 +29873,9 @@ def _template_supports_tools(backend) -> bool:
 
 
 def _sanitize_anthropic_openai_messages(messages: list[dict], backend) -> list[dict]:
-    """The post-conversion chain shared by /v1/messages and its token counter.
-
-    Both endpoints must build the identical list or the advertised input_tokens
-    stops matching the prompt that generation actually sends, so the steps live
-    here rather than being repeated at each call site.
-
-    Steps, in order:
-      - drop Stop-button sentinels / normalize reasoning-only assistant turns;
-      - strip synthetic provider-side builtin tool history;
-      - on a template with no tool support, fold role=tool into user turns,
-        which must happen BEFORE the coalesce so a folded result and the note
-        that followed it merge into one turn;
-      - coalesce adjacent user turns, so a strict GGUF chat template does not
-        400 on non-alternating roles (mirrors the GGUF chat path); a no-op for
-        already-alternating histories.
+    """Post-conversion chain shared by /v1/messages and its token counter, so a
+    diverging list can never make input_tokens describe a different prompt.
+    Fold before coalesce: that is what merges a folded result with its note.
     """
     messages = _strip_provider_synthetic_tool_history(_drop_empty_assistant_sentinels(messages))
     if not _template_supports_tools(backend):

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -728,6 +728,50 @@ class TestAnthropicMessagesToOpenAI:
         assert result[0]["tool_call_id"] == "tu_1"
         assert result[0]["content"] == "Result text"
 
+    def test_tool_result_precedes_trailing_user_text(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "what files are here?"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Let me look."},
+                    {"type": "tool_use", "id": "tu_1", "name": "Bash", "input": {"command": "ls"}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu_1", "content": "README.md\nsrc/"},
+                    {"type": "text", "text": "<system-reminder>Keep going.</system-reminder>"},
+                ],
+            },
+        ]
+        result = anthropic_messages_to_openai(msgs)
+        assert [m["role"] for m in result] == ["user", "assistant", "tool", "user"]
+        assert result[2]["tool_call_id"] == "tu_1"
+        assert result[2]["content"] == "README.md\nsrc/"
+        assert result[3]["content"] == "<system-reminder>Keep going.</system-reminder>"
+
+    def test_tool_result_with_image_keeps_user_parts_after_tool(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu_1", "content": "ok"},
+                    {"type": "text", "text": "and this?"},
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": "image/jpeg", "data": "AAAA"},
+                    },
+                ],
+            }
+        ]
+        result = anthropic_messages_to_openai(msgs)
+        assert [m["role"] for m in result] == ["tool", "user"]
+        parts = result[1]["content"]
+        assert parts[0] == {"type": "text", "text": "and this?"}
+        assert parts[1]["type"] == "image_url"
+
     def test_mixed_text_and_tool_use_blocks(self):
         msgs = [
             {

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -809,7 +809,6 @@ class TestAnthropicMessagesToOpenAI:
 
     def test_folding_is_a_no_op_without_tool_messages(self):
         from core.inference.anthropic_compat import fold_tool_results_into_user
-
         msgs = [
             {"role": "user", "content": "hi"},
             {"role": "assistant", "content": "hello"},

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -772,6 +772,111 @@ class TestAnthropicMessagesToOpenAI:
         assert parts[0] == {"type": "text", "text": "and this?"}
         assert parts[1]["type"] == "image_url"
 
+    def test_tool_results_fold_into_user_turns_for_a_toolless_template(self):
+        """Gemma 2 / Gemma 3 have no `tool` role and enforce strict user/assistant
+        alternation, so a tool message makes llama-server 400 the whole request.
+        Folding keeps the output in the prompt and the roles alternating."""
+        from core.inference.anthropic_compat import fold_tool_results_into_user
+
+        msgs = [
+            {"role": "user", "content": "what files are here?"},
+            {
+                "role": "assistant",
+                "content": "Let me look.",
+                "tool_calls": [
+                    {
+                        "id": "tu_1",
+                        "type": "function",
+                        "function": {"name": "Bash", "arguments": '{"command": "ls"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tu_1", "content": "README.md"},
+            {"role": "user", "content": "keep going"},
+        ]
+        folded = fold_tool_results_into_user(msgs)
+        assert [m["role"] for m in folded] == ["user", "assistant", "user", "user"]
+        payload = json.loads(folded[2]["content"])
+        assert payload == {
+            "tool_response": {
+                "tool": "Bash",
+                "content": "README.md",
+                "tool_call_id": "tu_1",
+            }
+        }
+        # The assistant turn (and its tool_calls) is untouched.
+        assert folded[1] is msgs[1]
+
+    def test_folding_is_a_no_op_without_tool_messages(self):
+        from core.inference.anthropic_compat import fold_tool_results_into_user
+
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert fold_tool_results_into_user(msgs) == msgs
+
+    def test_folding_survives_an_orphan_tool_result(self):
+        """No assistant tool_calls to resolve the name against: the id is still
+        carried so the model can correlate, and nothing raises."""
+        from core.inference.anthropic_compat import fold_tool_results_into_user
+
+        msgs = [{"role": "tool", "tool_call_id": "nope", "content": "R"}]
+        folded = fold_tool_results_into_user(msgs)
+        assert [m["role"] for m in folded] == ["user"]
+        assert json.loads(folded[0]["content"]) == {
+            "tool_response": {"content": "R", "tool_call_id": "nope"}
+        }
+
+    def test_sanitizer_folds_only_when_the_template_lacks_tool_support(self):
+        """The route-level gate: a tool-capable template keeps role=tool exactly
+        as the converter emitted it, so PR #10091's ordering fix is preserved."""
+        from routes.inference import _sanitize_anthropic_openai_messages
+
+        class Backend:
+            def __init__(self, supports_tools):
+                self.supports_tools = supports_tools
+
+        anthropic = [
+            {"role": "user", "content": [{"type": "text", "text": "q"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "tu_1", "name": "Bash", "input": {"command": "ls"}}
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu_1", "content": "README.md"},
+                    {"type": "text", "text": "keep going"},
+                ],
+            },
+        ]
+        converted = anthropic_messages_to_openai(anthropic)
+
+        tool_capable = _sanitize_anthropic_openai_messages(converted, Backend(True))
+        assert [m["role"] for m in tool_capable] == ["user", "assistant", "tool", "user"]
+
+        toolless = _sanitize_anthropic_openai_messages(converted, Backend(False))
+        assert [m["role"] for m in toolless] == ["user", "assistant", "user"]
+        # Folded result and the note coalesce into one alternating user turn,
+        # and neither piece of content is lost.
+        assert "README.md" in toolless[-1]["content"]
+        assert "keep going" in toolless[-1]["content"]
+
+    def test_sanitizer_defaults_to_not_folding_when_the_backend_cannot_answer(self):
+        from routes.inference import _sanitize_anthropic_openai_messages
+
+        class Hostile:
+            @property
+            def supports_tools(self):
+                raise RuntimeError("backend not ready")
+
+        msgs = [{"role": "tool", "tool_call_id": "tu_1", "content": "R"}]
+        assert _sanitize_anthropic_openai_messages(msgs, Hostile()) == msgs
+        assert _sanitize_anthropic_openai_messages(msgs, object()) == msgs
+
     def test_mixed_text_and_tool_use_blocks(self):
         msgs = [
             {

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -885,7 +885,7 @@ class TestAnthropicMessagesToOpenAI:
         from routes.inference import _sanitize_anthropic_openai_messages, _template_supports_tools
 
         class DiffusionGemma:
-            supports_tools = False            # forced off: keeps it out of the tool loop
+            supports_tools = False  # forced off: keeps it out of the tool loop
             supports_tool_passthrough = True  # the real template capability
 
         class ToollessTemplate:
@@ -918,7 +918,6 @@ class TestAnthropicMessagesToOpenAI:
 
     def test_folding_gate_prefers_passthrough_even_when_supports_tools_raises(self):
         from routes.inference import _template_supports_tools
-
         class HalfReady:
             supports_tool_passthrough = False
 

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -803,7 +803,7 @@ class TestAnthropicMessagesToOpenAI:
                 "tool_call_id": "tu_1",
             }
         }
-        assert folded[1] is msgs[1]   # assistant turn untouched, tool_calls intact
+        assert folded[1] is msgs[1]  # assistant turn untouched, tool_calls intact
 
     def test_folding_is_a_no_op_without_tool_messages(self):
         from core.inference.anthropic_compat import fold_tool_results_into_user

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -773,9 +773,8 @@ class TestAnthropicMessagesToOpenAI:
         assert parts[1]["type"] == "image_url"
 
     def test_tool_results_fold_into_user_turns_for_a_toolless_template(self):
-        """Gemma 2 / Gemma 3 have no `tool` role and enforce strict user/assistant
-        alternation, so a tool message makes llama-server 400 the whole request.
-        Folding keeps the output in the prompt and the roles alternating."""
+        """Gemma 2 / 3 have no `tool` role and check alternation by parity, so a
+        tool message makes llama-server 400 the whole request."""
         from core.inference.anthropic_compat import fold_tool_results_into_user
 
         msgs = [
@@ -804,8 +803,7 @@ class TestAnthropicMessagesToOpenAI:
                 "tool_call_id": "tu_1",
             }
         }
-        # The assistant turn (and its tool_calls) is untouched.
-        assert folded[1] is msgs[1]
+        assert folded[1] is msgs[1]   # assistant turn untouched, tool_calls intact
 
     def test_folding_is_a_no_op_without_tool_messages(self):
         from core.inference.anthropic_compat import fold_tool_results_into_user
@@ -816,8 +814,7 @@ class TestAnthropicMessagesToOpenAI:
         assert fold_tool_results_into_user(msgs) == msgs
 
     def test_folding_survives_an_orphan_tool_result(self):
-        """No assistant tool_calls to resolve the name against: the id is still
-        carried so the model can correlate, and nothing raises."""
+        """No tool_calls to resolve the name against: the id still carries."""
         from core.inference.anthropic_compat import fold_tool_results_into_user
 
         msgs = [{"role": "tool", "tool_call_id": "nope", "content": "R"}]
@@ -828,8 +825,7 @@ class TestAnthropicMessagesToOpenAI:
         }
 
     def test_sanitizer_folds_only_when_the_template_lacks_tool_support(self):
-        """The route-level gate: a tool-capable template keeps role=tool exactly
-        as the converter emitted it, so PR #10091's ordering fix is preserved."""
+        """A tool-capable template keeps role=tool as the converter emitted it."""
         from routes.inference import _sanitize_anthropic_openai_messages
 
         class Backend:
@@ -859,8 +855,6 @@ class TestAnthropicMessagesToOpenAI:
 
         toolless = _sanitize_anthropic_openai_messages(converted, Backend(False))
         assert [m["role"] for m in toolless] == ["user", "assistant", "user"]
-        # Folded result and the note coalesce into one alternating user turn,
-        # and neither piece of content is lost.
         assert "README.md" in toolless[-1]["content"]
         assert "keep going" in toolless[-1]["content"]
 
@@ -877,11 +871,9 @@ class TestAnthropicMessagesToOpenAI:
         assert _sanitize_anthropic_openai_messages(msgs, object()) == msgs
 
     def test_folding_follows_the_passthrough_capability_not_the_tool_loop_one(self):
-        """DiffusionGemma reports supports_tools=False so it never enters the
-        agentic tool loop, but its template can still render a tool role and
-        client-tool requests are dispatched through passthrough on
-        supports_tool_passthrough. Folding on supports_tools would strip the
-        native framing out from under that path."""
+        """DiffusionGemma reports supports_tools=False to stay out of the agentic
+        loop, but its template renders tool roles and client tools dispatch on
+        supports_tool_passthrough; folding on the former strips that framing."""
         from routes.inference import _sanitize_anthropic_openai_messages, _template_supports_tools
 
         class DiffusionGemma:
@@ -925,8 +917,7 @@ class TestAnthropicMessagesToOpenAI:
             def supports_tools(self):
                 raise RuntimeError("not ready")
 
-        # The passthrough flag answers first, so a raising supports_tools never
-        # forces the conservative default and the fold still runs.
+        # Passthrough answers first, so a raising supports_tools cannot skip the fold.
         assert _template_supports_tools(HalfReady()) is False
 
     def test_mixed_text_and_tool_use_blocks(self):

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -876,6 +876,60 @@ class TestAnthropicMessagesToOpenAI:
         assert _sanitize_anthropic_openai_messages(msgs, Hostile()) == msgs
         assert _sanitize_anthropic_openai_messages(msgs, object()) == msgs
 
+    def test_folding_follows_the_passthrough_capability_not_the_tool_loop_one(self):
+        """DiffusionGemma reports supports_tools=False so it never enters the
+        agentic tool loop, but its template can still render a tool role and
+        client-tool requests are dispatched through passthrough on
+        supports_tool_passthrough. Folding on supports_tools would strip the
+        native framing out from under that path."""
+        from routes.inference import _sanitize_anthropic_openai_messages, _template_supports_tools
+
+        class DiffusionGemma:
+            supports_tools = False            # forced off: keeps it out of the tool loop
+            supports_tool_passthrough = True  # the real template capability
+
+        class ToollessTemplate:
+            supports_tools = False
+            supports_tool_passthrough = False
+
+        assert _template_supports_tools(DiffusionGemma()) is True
+        assert _template_supports_tools(ToollessTemplate()) is False
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "tu_1",
+                        "type": "function",
+                        "function": {"name": "Bash", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tu_1", "content": "README.md"},
+            {"role": "user", "content": "keep going"},
+        ]
+        kept = _sanitize_anthropic_openai_messages(msgs, DiffusionGemma())
+        assert [m["role"] for m in kept] == ["assistant", "tool", "user"]
+
+        folded = _sanitize_anthropic_openai_messages(msgs, ToollessTemplate())
+        assert [m["role"] for m in folded] == ["assistant", "user"]
+
+    def test_folding_gate_prefers_passthrough_even_when_supports_tools_raises(self):
+        from routes.inference import _template_supports_tools
+
+        class HalfReady:
+            supports_tool_passthrough = False
+
+            @property
+            def supports_tools(self):
+                raise RuntimeError("not ready")
+
+        # The passthrough flag answers first, so a raising supports_tools never
+        # forces the conservative default and the fold still runs.
+        assert _template_supports_tools(HalfReady()) is False
+
     def test_mixed_text_and_tool_use_blocks(self):
         msgs = [
             {


### PR DESCRIPTION
When a message from the client contains both a tool result and some text, Studio put the text first and the tool result after it. That order is wrong, and on the Gemma 4 templates that Studio ships it means the tool result never reaches the model at all. The model answers as if the tool never ran.

Both bundled Gemma 4 templates look for tool results by scanning forward from the message that called the tool, and they stop at the first message that is not a tool result. A text message in between ends the scan early.

This puts tool results before the text, which is also the order the OpenAI format expects.

Messages that only contain a tool result were already in the right order and come out unchanged, and so do messages with images.

**How to check:** send a message holding a tool result plus a short note, and confirm the tool output appears in the prompt the model receives.
