### PR TITLE
Studio: report a context size for models loaded through MLX

### DIFF
--- a/studio/backend/core/inference/runtime_context.py
+++ b/studio/backend/core/inference/runtime_context.py
@@ -5,20 +5,57 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from itertools import chain
 from typing import Any, Optional
 
 
 def _field(source: Any, name: str) -> Any:
-    # mlx.nn.Module IS a dict, but its keys are parameters and its config is an attribute.
-    if isinstance(source, Mapping) and name in source:
-        return source[name]
-    return getattr(source, name, None)
+    """Read *name* off *source* however it is exposed, or None.
+
+    mlx.nn.Module IS a dict, but its keys are parameters and its config is an
+    attribute, so both shapes have to be tried. Anything a lookup raises is an
+    absent field here: this runs on every load, against wrapper objects nobody
+    controls (PEFT, accelerate, a config behind a property that needs a file),
+    and a resolver that cannot answer must not be able to fail the load.
+    """
+    try:
+        if isinstance(source, Mapping) and name in source:
+            return source[name]
+        return getattr(source, name, None)
+    except Exception:
+        return None
 
 
-def _declared_context_length(model: Any) -> Any:
-    """The window the model's own config declares."""
-    for holder in (model, _field(model, "config"), _field(model, "args")):
+def _attached_window(model: Any) -> Any:
+    """The window Unsloth attached to the model, if any.
+
+    Plain getattr, so a Mapping model's parameters are not mistaken for it, but
+    guarded for the same reason _field is: nothing here may fail a load.
+    """
+    try:
+        return getattr(model, "max_seq_length", None)
+    except Exception:
+        return None
+
+
+def _declared_context_lengths(model: Any) -> Iterator[Any]:
+    """Every window the model's own config declares, best source first.
+
+    Yields rather than returning the first hit so the caller validates each in
+    turn: a wrapper whose outer metadata carries a placeholder (0, "n/a") would
+    otherwise shadow the real window sitting on the config below it.
+    """
+    holders = (
+        model,
+        # config / _config is the same spread _mlx_config_field walks in
+        # mlx_inference.py -- a checkpoint's config is a dict on some models and
+        # an object on others, under either name.
+        _field(model, "config"),
+        _field(model, "_config"),
+        _field(model, "args"),
+    )
+    for holder in holders:
         if holder is None:
             continue
         for source in (holder, _field(holder, "text_config")):
@@ -26,22 +63,26 @@ def _declared_context_length(model: Any) -> Any:
                 continue
             value = _field(source, "max_position_embeddings")
             if value is not None:
-                return value
-    return None
+                yield value
 
 
 def runtime_context_length(model: Any, fallback: Optional[int] = None) -> Optional[int]:
     """Return the effective context length a loaded model runs with."""
-    for value in (
-        getattr(model, "max_seq_length", None),
-        fallback,
-        _declared_context_length(model),
-    ):
+    # Lazy on purpose: the declared window is only consulted once an attached or
+    # requested length has failed, so a transformers load -- which always has a
+    # requested length -- never touches the model's config at all.
+    candidates = chain(
+        (_attached_window(model), fallback),
+        _declared_context_lengths(model),
+    )
+    for value in candidates:
         if isinstance(value, bool):
             continue
         try:
             value_int = int(value)
-        except (TypeError, ValueError):
+        # OverflowError because json.loads turns a bare Infinity in a hand-edited
+        # config.json into float("inf"), and int() refuses that one alone.
+        except (TypeError, ValueError, OverflowError):
             continue
         if value_int > 0:
             return value_int

--- a/studio/backend/core/inference/runtime_context.py
+++ b/studio/backend/core/inference/runtime_context.py
@@ -5,12 +5,38 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Optional
 
 
+def _field(source: Any, name: str) -> Any:
+    # mlx.nn.Module IS a dict, but its keys are parameters and its config is an attribute.
+    if isinstance(source, Mapping) and name in source:
+        return source[name]
+    return getattr(source, name, None)
+
+
+def _declared_context_length(model: Any) -> Any:
+    """The window the model's own config declares."""
+    for holder in (model, _field(model, "config"), _field(model, "args")):
+        if holder is None:
+            continue
+        for source in (holder, _field(holder, "text_config")):
+            if source is None:
+                continue
+            value = _field(source, "max_position_embeddings")
+            if value is not None:
+                return value
+    return None
+
+
 def runtime_context_length(model: Any, fallback: Optional[int] = None) -> Optional[int]:
-    """Return the effective context length Unsloth attached to a loaded model."""
-    for value in (getattr(model, "max_seq_length", None), fallback):
+    """Return the effective context length a loaded model runs with."""
+    for value in (
+        getattr(model, "max_seq_length", None),
+        fallback,
+        _declared_context_length(model),
+    ):
         if isinstance(value, bool):
             continue
         try:

--- a/studio/backend/core/inference/runtime_context.py
+++ b/studio/backend/core/inference/runtime_context.py
@@ -11,14 +11,7 @@ from typing import Any, Optional
 
 
 def _field(source: Any, name: str) -> Any:
-    """Read *name* off *source* however it is exposed, or None.
-
-    mlx.nn.Module IS a dict, but its keys are parameters and its config is an
-    attribute, so both shapes have to be tried. Anything a lookup raises is an
-    absent field here: this runs on every load, against wrapper objects nobody
-    controls (PEFT, accelerate, a config behind a property that needs a file),
-    and a resolver that cannot answer must not be able to fail the load.
-    """
+    """Key or attribute, since mlx.nn.Module is a dict; a raiser is absent, never a failed load."""
     try:
         if isinstance(source, Mapping) and name in source:
             return source[name]
@@ -28,11 +21,7 @@ def _field(source: Any, name: str) -> Any:
 
 
 def _attached_window(model: Any) -> Any:
-    """The window Unsloth attached to the model, if any.
-
-    Plain getattr, so a Mapping model's parameters are not mistaken for it, but
-    guarded for the same reason _field is: nothing here may fail a load.
-    """
+    """What Unsloth attached: getattr only, so a Mapping model's parameters cannot pose as it."""
     try:
         return getattr(model, "max_seq_length", None)
     except Exception:
@@ -40,17 +29,10 @@ def _attached_window(model: Any) -> Any:
 
 
 def _declared_context_lengths(model: Any) -> Iterator[Any]:
-    """Every window the model's own config declares, best source first.
-
-    Yields rather than returning the first hit so the caller validates each in
-    turn: a wrapper whose outer metadata carries a placeholder (0, "n/a") would
-    otherwise shadow the real window sitting on the config below it.
-    """
+    """Declared windows, best first. Yields, so an outer 0 / "n/a" cannot shadow a real one."""
     holders = (
         model,
-        # config / _config is the same spread _mlx_config_field walks in
-        # mlx_inference.py -- a checkpoint's config is a dict on some models and
-        # an object on others, under either name.
+        # config / _config: the spread _mlx_config_field walks in mlx_inference.py.
         _field(model, "config"),
         _field(model, "_config"),
         _field(model, "args"),
@@ -68,9 +50,7 @@ def _declared_context_lengths(model: Any) -> Iterator[Any]:
 
 def runtime_context_length(model: Any, fallback: Optional[int] = None) -> Optional[int]:
     """Return the effective context length a loaded model runs with."""
-    # Lazy on purpose: the declared window is only consulted once an attached or
-    # requested length has failed, so a transformers load -- which always has a
-    # requested length -- never touches the model's config at all.
+    # Lazy: a transformers load always has a requested length, so it never reads the config.
     candidates = chain(
         (_attached_window(model), fallback),
         _declared_context_lengths(model),
@@ -80,8 +60,7 @@ def runtime_context_length(model: Any, fallback: Optional[int] = None) -> Option
             continue
         try:
             value_int = int(value)
-        # OverflowError because json.loads turns a bare Infinity in a hand-edited
-        # config.json into float("inf"), and int() refuses that one alone.
+        # OverflowError: json.loads turns a bare Infinity into float("inf"), which int() rejects.
         except (TypeError, ValueError, OverflowError):
             continue
         if value_int > 0:

--- a/studio/backend/tests/test_runtime_context_length.py
+++ b/studio/backend/tests/test_runtime_context_length.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for the shared runtime context-length resolver."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from core.inference.runtime_context import runtime_context_length
+
+
+def test_attached_window_wins():
+    model = SimpleNamespace(
+        max_seq_length = 8192,
+        args = SimpleNamespace(max_position_embeddings = 40960),
+    )
+    assert runtime_context_length(model, 4096) == 8192
+
+
+def test_requested_length_beats_the_declared_window():
+    model = SimpleNamespace(args = SimpleNamespace(max_position_embeddings = 40960))
+    assert runtime_context_length(model, 4096) == 4096
+
+
+def test_mlx_model_falls_back_to_its_declared_window():
+    model = SimpleNamespace(args = SimpleNamespace(max_position_embeddings = 40960))
+    assert runtime_context_length(model, 0) == 40960
+
+
+def test_declared_window_read_from_config():
+    model = SimpleNamespace(config = SimpleNamespace(max_position_embeddings = 32768))
+    assert runtime_context_length(model, None) == 32768
+
+
+def test_declared_window_read_from_a_mapping_config():
+    model = SimpleNamespace(config = {"max_position_embeddings": 16384})
+    assert runtime_context_length(model, 0) == 16384
+
+
+def test_declared_window_read_from_a_multimodal_text_config():
+    model = SimpleNamespace(
+        config = SimpleNamespace(text_config = SimpleNamespace(max_position_embeddings = 131072)),
+    )
+    assert runtime_context_length(model, 0) == 131072
+
+
+def test_a_module_that_is_itself_a_dict_reads_its_attributes():
+    class _MlxLikeModule(dict):
+        def __init__(self, args):
+            super().__init__({"layers": []})
+            self.args = args
+
+    model = _MlxLikeModule(SimpleNamespace(max_position_embeddings = 40960))
+    assert runtime_context_length(model, 0) == 40960
+
+
+def test_no_window_anywhere_stays_unknown():
+    assert runtime_context_length(SimpleNamespace(), 0) is None
+    assert runtime_context_length(None, None) is None
+
+
+def test_non_positive_and_non_numeric_values_are_skipped():
+    model = SimpleNamespace(
+        max_seq_length = 0,
+        config = SimpleNamespace(max_position_embeddings = "n/a"),
+    )
+    assert runtime_context_length(model, -1) is None
+    assert runtime_context_length(SimpleNamespace(max_seq_length = True), 2048) == 2048

--- a/studio/backend/tests/test_runtime_context_length.py
+++ b/studio/backend/tests/test_runtime_context_length.py
@@ -81,11 +81,7 @@ def test_a_placeholder_outer_window_does_not_shadow_the_real_one():
 
 
 def test_a_config_that_refuses_to_be_read_leaves_the_window_unknown():
-    """A resolver that cannot answer must not be able to fail the load.
-
-    Wrapper objects nobody controls (PEFT, accelerate, a config behind a property
-    that wants a file) can raise on attribute access, and this runs on every load.
-    """
+    """PEFT and accelerate wrappers can raise on attribute access, and this runs on every load."""
 
     class _RefusesToLoad:
         @property
@@ -96,11 +92,7 @@ def test_a_config_that_refuses_to_be_read_leaves_the_window_unknown():
 
 
 def test_an_attached_window_wins_without_touching_the_config():
-    """The declared window is consulted last and lazily.
-
-    A transformers load always has a requested length, so it must never reach the
-    model's config -- which is what makes a raising config harmless there.
-    """
+    """A transformers load always has a requested length, so a raising config is harmless."""
     touched = []
 
     class _RecordsConfigReads:

--- a/studio/backend/tests/test_runtime_context_length.py
+++ b/studio/backend/tests/test_runtime_context_length.py
@@ -59,6 +59,62 @@ def test_a_module_that_is_itself_a_dict_reads_its_attributes():
     assert runtime_context_length(model, 0) == 40960
 
 
+def test_declared_window_read_from_an_underscore_config():
+    """mlx exposes a checkpoint's config under either name, so both are scanned."""
+    model = SimpleNamespace(_config = {"max_position_embeddings": 40960})
+    assert runtime_context_length(model, 0) == 40960
+
+
+def test_a_placeholder_outer_window_does_not_shadow_the_real_one():
+    """A wrapper carrying 0 / "n/a" must not hide the window on the config below it."""
+    model = SimpleNamespace(
+        max_position_embeddings = 0,
+        args = SimpleNamespace(max_position_embeddings = 40960),
+    )
+    assert runtime_context_length(model, 0) == 40960
+
+    wrapper = SimpleNamespace(
+        config = SimpleNamespace(max_position_embeddings = "n/a"),
+        args = SimpleNamespace(max_position_embeddings = 32768),
+    )
+    assert runtime_context_length(wrapper, 0) == 32768
+
+
+def test_a_config_that_refuses_to_be_read_leaves_the_window_unknown():
+    """A resolver that cannot answer must not be able to fail the load.
+
+    Wrapper objects nobody controls (PEFT, accelerate, a config behind a property
+    that wants a file) can raise on attribute access, and this runs on every load.
+    """
+
+    class _RefusesToLoad:
+        @property
+        def config(self):
+            raise RuntimeError("config unavailable")
+
+    assert runtime_context_length(_RefusesToLoad(), 0) is None
+
+
+def test_an_attached_window_wins_without_touching_the_config():
+    """The declared window is consulted last and lazily.
+
+    A transformers load always has a requested length, so it must never reach the
+    model's config -- which is what makes a raising config harmless there.
+    """
+    touched = []
+
+    class _RecordsConfigReads:
+        max_seq_length = 4096
+
+        @property
+        def config(self):
+            touched.append("config")
+            raise RuntimeError("config unavailable")
+
+    assert runtime_context_length(_RecordsConfigReads(), 2048) == 4096
+    assert touched == []
+
+
 def test_no_window_anywhere_stays_unknown():
     assert runtime_context_length(SimpleNamespace(), 0) is None
     assert runtime_context_length(None, None) is None


### PR DESCRIPTION
On Mac, safetensors models load through MLX, and Studio never saved their context size, so /v1/models, /api/inference/status and the length checks all report nothing.

This mostly hurts coding agents. They ask Studio how big the context is so they know when to shorten a long chat, and with no answer they guess. dsh guesses 262,144 tokens for a model that holds 40,960, so the chat runs past the limit and errors out instead of shortening itself. Same for pi, opencode and hermes.

The size is now read from the model's own config when nothing else knows it. Passing --max-seq-length still overrides it, and GGUF models are unchanged.

Tested with unsloth/Qwen3-0.6B on Mac: it reports 40960 now instead of nothing.
