### PR TITLE
Stop the torchao ROCm test from depending on the host's GPU

### DIFF
--- a/studio/backend/tests/test_mcp_training_start_guard.py
+++ b/studio/backend/tests/test_mcp_training_start_guard.py
@@ -351,8 +351,14 @@ def test_the_mcp_tool_surfaces_the_409_as_a_tool_error_not_a_dict(monkeypatch):
 
     # The tool body raises rather than returning the {"status": ...} dict that
     # stop_training / get_training_status return.
+    # Public fastmcp API only. The private equivalents (_get_tool/_call_tool_mcp)
+    # work too, but _call_tool_mcp was dropped in fastmcp 4.0.0 while the pin is an
+    # open ">=3.0.2", so a private call here breaks the suite on an upstream major
+    # that the product itself is unaffected by. get_tool/call_tool are present with
+    # these same signatures on both 3.0.2 (the floor) and 4.x.
     async def run_tool_body():
-        tool = await server._get_tool("start_training")
+        tool = await server.get_tool("start_training")
+        assert tool is not None, "start_training must be registered on the studio MCP server"
         return await tool.fn(config = _config())
 
     with pytest.raises(HTTPException) as excinfo:
@@ -362,11 +368,13 @@ def test_the_mcp_tool_surfaces_the_409_as_a_tool_error_not_a_dict(monkeypatch):
     from fastmcp.exceptions import ToolError
 
     with pytest.raises(ToolError) as tool_error:
-        asyncio.run(server._call_tool_mcp("start_training", {"config": _config()}))
+        asyncio.run(server.call_tool("start_training", {"config": _config()}))
 
     # mask_error_details defaults False, so the 409 detail survives to the client
     # (as the text of an isError CallToolResult, not a JSON-RPC protocol error).
-    assert server._mask_error_details is False
+    # Asserted through the surfaced message rather than the server's private
+    # _mask_error_details flag: the detail reaching the caller is the property that
+    # matters, and it stays true however that flag is spelled upstream.
     assert "inference request is in progress" in str(tool_error.value)
     assert "Error calling tool 'start_training'" in str(tool_error.value)
 

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -100,6 +100,9 @@ def test_windows_first_hop_uses_einx_wheel_without_shared_test_tree():
     [
         (True, False),
         (False, True),
+        # Both signals agree: the ordinary Windows ROCm host, and the case a
+        # two-mixed-only parametrization never covered.
+        (True, True),
     ],
 )
 def test_skips_torchao_on_windows_rocm(
@@ -138,13 +141,34 @@ def test_skips_torchao_on_windows_rocm(
     monkeypatch.setattr(mod, "_repair_bad_anyio", lambda: None)
     monkeypatch.setattr(mod, "_ensure_rocm_torch", lambda: None)
     monkeypatch.setattr(mod, "_ensure_cuda_torch", lambda: None)
-    monkeypatch.setattr(mod, "_has_usable_nvidia_gpu", lambda: True)
+    # A Windows ROCm box has no usable NVIDIA GPU. Claiming one here described a
+    # machine that cannot exist, and _expected_torch_flavor_tag reads exactly this
+    # flag to decide whether a CUDA expectation exists at all: with it True, the
+    # Windows flavor invariant demanded a cu* build, found the runner's CPU torch,
+    # and failed the whole install long after the torchao branch under test.
+    monkeypatch.setattr(mod, "_has_usable_nvidia_gpu", lambda: False)
+    # The installed torch is ambient, so leaving it unpatched made the verdict depend
+    # on the developer's machine: a CUDA workstation passed and a CPU-only CI runner
+    # failed, on identical code.
+    monkeypatch.setattr(mod, "_RECORDED_TORCH_TAG", "")
+    monkeypatch.setattr(
+        mod, "_probe_torch_runtime", lambda *args, **kwargs: (True, True, "2.9.1+cpu", "", "")
+    )
     monkeypatch.setattr(mod, "run", lambda *args, **kwargs: None)
     monkeypatch.setattr(mod, "pip_install", _record_pip_install)
     monkeypatch.setattr(mod, "_progress", lambda label: progress_labels.append(label))
     monkeypatch.setattr(mod, "LOCAL_DD_UNSTRUCTURED_PLUGIN", unstructured_plugin)
     monkeypatch.setattr(mod, "LOCAL_DD_GITHUB_PLUGIN", github_plugin)
     monkeypatch.setattr(mod.subprocess, "run", lambda *args, **kwargs: subprocess_result)
+
+    # Checked BEFORE the install so a regression names its cause here rather than as
+    # an opaque `assert 1 == 0` on the line below, which is how this surfaced: the run
+    # returned 1 on a CPU-only runner and 0 on a CUDA workstation, on identical code.
+    assert mod._expected_torch_flavor_tag() == "", (
+        "no CUDA expectation may exist on a Windows ROCm host: a non-empty tag means "
+        "the Windows flavor invariant will demand a cu* build, not find one, and fail "
+        "the install long after the torchao branch this test is about"
+    )
 
     assert mod.install_python_stack() == 0
 


### PR DESCRIPTION
`test_skips_torchao_on_windows_rocm` is failing on main. It fails on CI and passes on a CUDA workstation, on identical code.

## Why

The fixture describes a machine that cannot exist: a Windows host with ROCm torch installed **and** a usable NVIDIA GPU.

```python
monkeypatch.setattr(mod, "_rocm_windows_torch_installed", True)   # a ROCm box
monkeypatch.setattr(mod, "_has_usable_nvidia_gpu", lambda: True)  # ... with an NVIDIA GPU
```

That second flag is exactly the input `_expected_torch_flavor_tag` uses to decide whether a CUDA expectation exists at all:

```python
if _explicit_torch_index_url() is None and not _has_usable_nvidia_gpu():
    return ""
return _torch_index_leaf(_detect_cuda_torch_index_url())
```

So the test asked for a `cu*` build on a box it had just called ROCm.

That was inert until #9857 added the Windows torch flavor invariant (step 13w), the first step in `install_python_stack` that reads the **real** installed torch. Combined with the CPU-only torch `studio-backend-ci.yml` installs, the invariant correctly refused the install and returned 1, so a test about torchao selection failed on an assertion about the whole installer:

```
FAILED tests/test_torchao_select.py::test_skips_torchao_on_windows_rocm[True-False]
  AssertionError: assert 1 == 0
```

Reproduced by pinning the probe to the CPU torch CI installs: with the NVIDIA flag `True` the installer emits "PyTorch is CPU-only but a cu126 GPU build was expected for this machine" and returns 1; with it `False` it returns 0 and the torchao assertions hold.

## #9857 is correct and is unchanged

On a real Windows ROCm host `_has_usable_nvidia_gpu()` is False, so the expected tag is empty and the invariant returns early. No ROCm user is affected, and a Windows box that expected a GPU build but holds CPU-only torch *should* fail the install rather than report success. The fixture was wrong, not the code.

## What changed

- The host is coherent again: no usable NVIDIA GPU on a ROCm box.
- The installed torch is pinned through `_probe_torch_runtime` and `_RECORDED_TORCH_TAG`, so the verdict no longer depends on whichever torch the developer happens to have. This is what made it green locally and red on CI.
- A precondition assertion on `_expected_torch_flavor_tag() == ""` runs **before** the install, so the next time a later step reaches back into real hardware the failure names its cause instead of surfacing as `assert 1 == 0`.
- Adds the `(True, True)` case. Both signals agreeing is the ordinary Windows ROCm state and the parametrization only covered the two mixed ones.

No coverage is lost: #9857's invariant keeps its own tests in `tests/studio/install/test_windows_torch_flavor_invariant.py`.

## Verification

- `studio/backend/tests/test_torchao_select.py`: 30 passed (29 before, plus the new case).
- Passes both on a CUDA host and under `CUDA_VISIBLE_DEVICES=""`, where it used to be host-dependent.
- `tests/studio/install/` + `tests/python/test_install_python_stack.py`: 3460 passed, 3 skipped.
- Mutation check: restoring `_has_usable_nvidia_gpu -> True` reproduces the original CI failure, and the new precondition reports it with the reason.