### PR TITLE
Move the studiobench attribution config in with the harness

### DIFF
--- a/tests/studio/studiobench/analysis/bridge_build.py
+++ b/tests/studio/studiobench/analysis/bridge_build.py
@@ -332,7 +332,7 @@ def assert_attribution_build(page: Any) -> dict[str, Any]:
     Catches the staleness failure: a shipping dist left in the directory handed
     to `unsloth studio --frontend <dir>` produces a perfectly healthy Unsloth
     serving the WRONG bundle, with no profiling renderer and therefore a React
-    stage that reads 0.00. `attribution/vite.studiobench.config.ts` defines
+    stage that reads 0.00. `../attribution/vite.studiobench.config.ts` defines
     `__STUDIOBENCH_ATTRIBUTION_BUILD__` for exactly this check.
     """
     marker = page.evaluate("globalThis.__STUDIOBENCH_ATTRIBUTION_BUILD__ === true")
@@ -341,7 +341,8 @@ def assert_attribution_build(page: Any) -> dict[str, Any]:
             "not_the_attribution_build",
             "__STUDIOBENCH_ATTRIBUTION_BUILD__ is not defined in the loaded bundle. The "
             "directory passed to `unsloth studio --frontend` is serving some other dist, most "
-            "likely a stale shipping build. Rebuild with attribution/vite.studiobench.config.ts.",
+            "likely a stale shipping build. Rebuild with "
+            "tests/studio/studiobench/attribution/vite.studiobench.config.ts.",
         )
     return {"attribution_build_verified": True}
 

--- a/tests/studio/studiobench/attribution/vite.studiobench.config.ts
+++ b/tests/studio/studiobench/attribution/vite.studiobench.config.ts
@@ -30,7 +30,7 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 
-const FRONTEND_ROOT = path.resolve(__dirname, "../studio/frontend");
+const FRONTEND_ROOT = path.resolve(__dirname, "../../../../studio/frontend");
 
 // The plugins are resolved from the FRONTEND package, not from this directory,
 // and that is not a stylistic preference. Vite bundles a `--config` file with
@@ -38,8 +38,8 @@ const FRONTEND_ROOT = path.resolve(__dirname, "../studio/frontend");
 // path.dirname(fileName)`) and then loads the bundle under the config file's
 // own path: CJS via `module._compile(code, <config path>)`, ESM via a temp file
 // in the nearest ancestor `node_modules`, of which this directory has none. So
-// Node starts its `node_modules` walk at `attribution/` and climbs to the
-// repository root, and NEITHER has a `node_modules` -- only
+// Node starts its `node_modules` walk here and climbs to the repository root,
+// and NOTHING on that path has a `node_modules` -- only
 // `studio/frontend/node_modules` does. Written with plain top-level imports
 // this config could not be loaded from any working directory, by any `vite`
 // binary: `Cannot find module '@tailwindcss/vite'`, and the same for the React
@@ -183,7 +183,7 @@ export default defineConfig({
         // Marks the bundle so the harness can prove it is measuring the
         // attribution build and not a stale shipping dist left in the
         // directory handed to `unsloth studio --frontend`. Read by
-        // `analysis/bridge_build.py:assert_attribution_build`.
+        // `../analysis/bridge_build.py:assert_attribution_build`.
         //
         // This is a BANNER and not a `define`, and the difference is not
         // cosmetic. `define` performs identifier SUBSTITUTION in source: it


### PR DESCRIPTION
## Why

A top-level `attribution/` directory holding a single file is repository clutter. The file is a Vite config used by exactly one thing, the studiobench harness under `tests/studio/studiobench`, whose `analysis/bridge_build.py` is its only referrer in the tree.

```
attribution/vite.studiobench.config.ts
  -> tests/studio/studiobench/attribution/vite.studiobench.config.ts
```

## Three things fall out of it

**It stops shipping.** `attribution/` was a tracked top-level directory, so setuptools-scm put the config in the sdist of every release. Under `tests/` the prune from #10060 covers it. The published sdist was carrying a build config whose consumer, after #10060, no longer ships alongside it.

**It gains CI.** `studiobench-ci.yml` triggers on `tests/studio/studiobench/**`, so a change to this config now runs the suite. Nothing in the repo triggered on `attribution/`, which is how this file managed to break twice inside its own introducing PR (#9296): once failing to build at all, once on `output.keepNames` producing 24 `MISSING_EXPORT` errors.

**Module resolution is unchanged.** The config resolves plugins through `createRequire` anchored at `studio/frontend/package.json` precisely because no ancestor of its own directory has a `node_modules`. That is still true at the new location, so the reason the anchoring exists survives intact.

`studio/frontend/` was the other obvious home and is the wrong one: `[tool.setuptools.package-data]` already globs `frontend/*.ts`, so parking it there would ship it inside the **wheel**, to every `pip install unsloth` user.

## Verification

Built the frontend with the config from both paths against the same `node_modules`:

| | js | maps | banner hits | sourceMappingURL | names kept |
| --- | --- | --- | --- | --- | --- |
| before (`attribution/`) | 525 | 509 | 522 | 0 | 2430 / 2506 |
| after (`tests/.../attribution/`) | 525 | 509 | 522 | 0 | 2430 / 2506 |

Identical, including the SHA over the emitted relative paths (`bc6adea431ca7c18` both). Vite names chunks by content hash, so an identical path set means identical bytes.

- built dist stays gitignored: the `dist/` rule at `.gitignore:27` is unanchored, confirmed with `git check-ignore`
- `python -m build`: both artifacts have no `attribution` entry and 0 test path segments
- `pytest tests/studio/studiobench`: 1400 passed, 155 skipped
- `ruff check tests/studio/studiobench`: clean

## Note

Only the two path strings in `bridge_build.py` and the `__dirname` depth changed. No behavioural change to the build.
