### PR TITLE
Studio: tell the browser about the bootstrap shutdown deadline

### DIFF
--- a/studio/backend/auth/bootstrap_timeout.py
+++ b/studio/backend/auth/bootstrap_timeout.py
@@ -18,9 +18,39 @@ key rather than the admin password, and never Colab). Configurable via
 import os
 import sys
 import threading
+import time
+from typing import Optional
 
 BOOTSTRAP_TIMEOUT_ENV_VAR = "UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT"
 DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS = 3600
+
+# When the armed deadline expires, as a monotonic timestamp, or None when nothing
+# is armed. The timer itself is not introspectable, and the browser has no other
+# way to learn that this launch is time-boxed: the warning goes to stderr, which
+# the launches that arm the deadline (--secure, external bind) usually detach.
+_deadline_at: Optional[float] = None
+
+
+def record_bootstrap_deadline(timeout_seconds: int) -> None:
+    global _deadline_at
+    _deadline_at = time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
+
+
+def clear_bootstrap_deadline() -> None:
+    global _deadline_at
+    _deadline_at = None
+
+
+def bootstrap_deadline_remaining_seconds() -> Optional[int]:
+    """Seconds until shutdown, or None when this launch is not time-boxed.
+
+    Floors at 0 rather than going negative: the timer and this clock are read
+    separately, so a caller can land here in the moment between expiry and the
+    shutdown completing.
+    """
+    if _deadline_at is None:
+        return None
+    return max(0, int(round(_deadline_at - time.monotonic())))
 
 
 def bootstrap_timeout_seconds(env = None) -> int:
@@ -134,6 +164,7 @@ def arm_bootstrap_timeout(
     logger = None,
 ) -> "threading.Timer":
     """Start a daemon timer that enforces the deadline. Returns the Timer."""
+    record_bootstrap_deadline(timeout_seconds)
     timer = threading.Timer(
         timeout_seconds,
         enforce_bootstrap_password_deadline,

--- a/studio/backend/auth/bootstrap_timeout.py
+++ b/studio/backend/auth/bootstrap_timeout.py
@@ -24,9 +24,8 @@ from typing import Optional
 BOOTSTRAP_TIMEOUT_ENV_VAR = "UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT"
 DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS = 3600
 
-# Expiry of the armed deadline, monotonic, or None when nothing is armed. The
-# browser has no other way to learn this launch is time-boxed: the warning goes to
-# stderr, which the launches that arm it (--secure, external bind) usually detach.
+# Monotonic expiry, or None when nothing is armed. Read back over HTTP because the
+# stderr warning is lost on the launches that arm it (--secure, external bind).
 _deadline_at: Optional[float] = None
 
 
@@ -42,10 +41,7 @@ def clear_bootstrap_deadline() -> None:
 
 def bootstrap_deadline_remaining_seconds() -> Optional[int]:
     """Seconds until shutdown, or None when this launch is not time-boxed.
-
-    Floors at 0: the timer and this clock are read separately, so a caller can land
-    between expiry and the shutdown completing.
-    """
+    Floors at 0: a caller can land between expiry and the shutdown completing."""
     if _deadline_at is None:
         return None
     return max(0, int(round(_deadline_at - time.monotonic())))

--- a/studio/backend/auth/bootstrap_timeout.py
+++ b/studio/backend/auth/bootstrap_timeout.py
@@ -24,10 +24,9 @@ from typing import Optional
 BOOTSTRAP_TIMEOUT_ENV_VAR = "UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT"
 DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS = 3600
 
-# When the armed deadline expires, as a monotonic timestamp, or None when nothing
-# is armed. The timer itself is not introspectable, and the browser has no other
-# way to learn that this launch is time-boxed: the warning goes to stderr, which
-# the launches that arm the deadline (--secure, external bind) usually detach.
+# Expiry of the armed deadline, monotonic, or None when nothing is armed. The
+# browser has no other way to learn this launch is time-boxed: the warning goes to
+# stderr, which the launches that arm it (--secure, external bind) usually detach.
 _deadline_at: Optional[float] = None
 
 
@@ -44,9 +43,8 @@ def clear_bootstrap_deadline() -> None:
 def bootstrap_deadline_remaining_seconds() -> Optional[int]:
     """Seconds until shutdown, or None when this launch is not time-boxed.
 
-    Floors at 0 rather than going negative: the timer and this clock are read
-    separately, so a caller can land here in the moment between expiry and the
-    shutdown completing.
+    Floors at 0: the timer and this clock are read separately, so a caller can land
+    between expiry and the shutdown completing.
     """
     if _deadline_at is None:
         return None

--- a/studio/backend/models/auth.py
+++ b/studio/backend/models/auth.py
@@ -41,6 +41,13 @@ class AuthStatusResponse(BaseModel):
         ...,
         description = "True if the seeded admin must still change the default password",
     )
+    bootstrap_deadline_seconds: Optional[int] = Field(
+        None,
+        description = (
+            "Seconds until this instance shuts down for leaving the default password "
+            "unchanged, or null when the launch is not time-boxed."
+        ),
+    )
 
 
 class DesktopInitialPasswordRequest(BaseModel):

--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -447,9 +447,7 @@ def auth_status() -> AuthStatusResponse:
         if storage.is_initialized()
         else True
     )
-    # Only while the default password stands, since that is the condition the
-    # deadline fires on; afterwards the timer is inert. Anonymous like the rest of
-    # this response, and implied by requires_password_change, which it already returns.
+    # Only while the default password stands: that is what the deadline fires on.
     return AuthStatusResponse(
         initialized = storage.is_initialized(),
         default_username = storage.DEFAULT_ADMIN_USERNAME,

--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -440,12 +440,24 @@ def identity(nonce: str, request: Request) -> dict:
 @router.get("/status", response_model = AuthStatusResponse)
 def auth_status() -> AuthStatusResponse:
     """Auth initialization state; ``default_username`` is exposed for first-boot UI prefill only."""
+    from auth.bootstrap_timeout import bootstrap_deadline_remaining_seconds
+
+    requires_change = (
+        storage.requires_password_change(storage.DEFAULT_ADMIN_USERNAME)
+        if storage.is_initialized()
+        else True
+    )
+    # Only while the default password stands: the deadline fires on that condition,
+    # so once it is changed the timer is inert and reporting it would be a lie.
+    # Unauthenticated by design, like the rest of this response, and it discloses
+    # nothing an anonymous caller cannot already read off requires_password_change.
     return AuthStatusResponse(
         initialized = storage.is_initialized(),
         default_username = storage.DEFAULT_ADMIN_USERNAME,
-        requires_password_change = storage.requires_password_change(storage.DEFAULT_ADMIN_USERNAME)
-        if storage.is_initialized()
-        else True,
+        requires_password_change = requires_change,
+        bootstrap_deadline_seconds = (
+            bootstrap_deadline_remaining_seconds() if requires_change else None
+        ),
     )
 
 

--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -447,10 +447,9 @@ def auth_status() -> AuthStatusResponse:
         if storage.is_initialized()
         else True
     )
-    # Only while the default password stands: the deadline fires on that condition,
-    # so once it is changed the timer is inert and reporting it would be a lie.
-    # Unauthenticated by design, like the rest of this response, and it discloses
-    # nothing an anonymous caller cannot already read off requires_password_change.
+    # Only while the default password stands, since that is the condition the
+    # deadline fires on; afterwards the timer is inert. Anonymous like the rest of
+    # this response, and implied by requires_password_change, which it already returns.
     return AuthStatusResponse(
         initialized = storage.is_initialized(),
         default_username = storage.DEFAULT_ADMIN_USERNAME,

--- a/studio/backend/tests/test_auth_status_bootstrap_deadline.py
+++ b/studio/backend/tests/test_auth_status_bootstrap_deadline.py
@@ -1,13 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""The shutdown deadline has to reach the browser, not just the terminal.
-
-The deadline arms only for an exposed web UI (`--secure`, or an external bind),
-and those are the launches run detached or tunneled, where nothing reads stderr.
-The UI then shows a plain "Failed to load auth status." after the fact, when
-there is no longer a server to ask.
-"""
+"""The shutdown deadline has to reach the browser: it arms only for an exposed web
+UI (`--secure`, external bind), and those launches run detached or tunneled, where
+nothing reads stderr."""
 
 import time
 
@@ -44,10 +40,9 @@ def _status(client):
 
 
 def _password_state(monkeypatch, *, requires_change: bool):
-    """Pin what the route reads. ``is_initialized`` goes with it because the route
-    answers True for an uninitialized instance without consulting the other call,
-    and a fresh checkout (CI) has no users, so patching one alone is a no-op there.
-    """
+    """Pin what the route reads. ``is_initialized`` goes with it: the route answers
+    True for an uninitialized instance without consulting the other call, and a fresh
+    checkout (CI) has no users."""
     monkeypatch.setattr(auth_routes.storage, "is_initialized", lambda: True)
     monkeypatch.setattr(
         auth_routes.storage, "requires_password_change", lambda _username: requires_change
@@ -56,8 +51,7 @@ def _password_state(monkeypatch, *, requires_change: bool):
 
 class TestTheFieldIsPresent:
     def test_absent_deadline_is_null_not_missing(self, client):
-        """The common case is a loopback launch, and a client that always reads the
-        key must not see undefined there."""
+        """A client that always reads the key must not find undefined there."""
         body = _status(client)
         assert "bootstrap_deadline_seconds" in body
         assert body["bootstrap_deadline_seconds"] is None
@@ -80,8 +74,7 @@ class TestTheFieldIsPresent:
 
 
 class TestItIsNotReportedWhenItCannotFire:
-    """Reporting a countdown after the password is changed would promise a shutdown
-    the handler explicitly declines to perform."""
+    """A countdown after the password changed would promise a shutdown the handler declines."""
 
     def test_a_changed_password_reports_no_deadline(self, client, monkeypatch):
         record_bootstrap_deadline(3600)
@@ -91,8 +84,7 @@ class TestItIsNotReportedWhenItCannotFire:
         assert body["bootstrap_deadline_seconds"] is None
 
     def test_the_timer_being_armed_is_not_enough_on_its_own(self, client, monkeypatch):
-        """Arming is never undone on a password change, so the timer alone cannot
-        answer this."""
+        """Arming is never undone on a password change, so the timer alone cannot answer this."""
         record_bootstrap_deadline(60)
         _password_state(monkeypatch, requires_change = False)
         assert _status(client)["bootstrap_deadline_seconds"] is None
@@ -111,8 +103,7 @@ class TestTheNumberIsUsable:
         assert _status(client)["bootstrap_deadline_seconds"] == 0
 
     def test_the_endpoint_stays_anonymous(self, client, monkeypatch):
-        """No auth header is sent anywhere in this file, and the deadline is implied
-        by requires_password_change, which this endpoint has always returned."""
+        """The deadline is implied by requires_password_change, already returned here."""
         _password_state(monkeypatch, requires_change = True)
         record_bootstrap_deadline(3600)
         response = client.get("/api/auth/status")

--- a/studio/backend/tests/test_auth_status_bootstrap_deadline.py
+++ b/studio/backend/tests/test_auth_status_bootstrap_deadline.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The shutdown deadline has to reach the browser, not just the terminal.
+
+`arm_bootstrap_timeout` only fires for an exposed web UI (`--secure`, or an
+external bind), and those are precisely the launches run detached or tunneled,
+where nothing reads stderr. So the one warning Unsloth prints goes to the one
+channel this feature guarantees is unattended, and the UI shows a plain "Failed
+to load auth status." after the fact, when there is no longer a server to ask.
+
+`/api/auth/status` is where the login page already learns it must change the
+password, so it is where the deadline belongs.
+"""
+
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth.bootstrap_timeout import (
+    clear_bootstrap_deadline,
+    record_bootstrap_deadline,
+)
+from routes import auth as auth_routes
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(auth_routes.router, prefix = "/api/auth")
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture(autouse = True)
+def _no_leaked_deadline():
+    clear_bootstrap_deadline()
+    yield
+    clear_bootstrap_deadline()
+
+
+def _status(client):
+    response = client.get("/api/auth/status")
+    assert response.status_code == 200
+    return response.json()
+
+
+class TestTheFieldIsPresent:
+    def test_absent_deadline_is_null_not_missing(self, client):
+        """A client that always reads the key must not see undefined on a normal
+        loopback launch, which is the common case."""
+        body = _status(client)
+        assert "bootstrap_deadline_seconds" in body
+        assert body["bootstrap_deadline_seconds"] is None
+
+    def test_an_armed_deadline_is_reported(self, client, monkeypatch):
+        monkeypatch.setattr(
+            auth_routes.storage, "requires_password_change", lambda _username: True
+        )
+        record_bootstrap_deadline(3600)
+        remaining = _status(client)["bootstrap_deadline_seconds"]
+        assert remaining is not None and 3590 <= remaining <= 3600
+
+    def test_it_counts_down_between_calls(self, client, monkeypatch):
+        monkeypatch.setattr(
+            auth_routes.storage, "requires_password_change", lambda _username: True
+        )
+        record_bootstrap_deadline(3600)
+        first = _status(client)["bootstrap_deadline_seconds"]
+        import auth.bootstrap_timeout as bt
+
+        bt._deadline_at = bt._deadline_at - 120
+        second = _status(client)["bootstrap_deadline_seconds"]
+        assert second < first
+
+
+class TestItIsNotReportedWhenItCannotFire:
+    """The deadline shuts down only while the seeded password stands. Reporting
+    a countdown after the password is changed would promise a shutdown that the
+    handler explicitly declines to perform."""
+
+    def test_a_changed_password_reports_no_deadline(self, client, monkeypatch):
+        record_bootstrap_deadline(3600)
+        monkeypatch.setattr(
+            auth_routes.storage, "requires_password_change", lambda _username: False
+        )
+        body = _status(client)
+        assert body["requires_password_change"] is False
+        assert body["bootstrap_deadline_seconds"] is None
+
+    def test_the_timer_being_armed_is_not_enough_on_its_own(self, client, monkeypatch):
+        """Arming happens once at startup and is never disarmed on a password
+        change, so the route cannot infer the answer from the timer alone."""
+        record_bootstrap_deadline(60)
+        monkeypatch.setattr(
+            auth_routes.storage, "requires_password_change", lambda _username: False
+        )
+        assert _status(client)["bootstrap_deadline_seconds"] is None
+        monkeypatch.setattr(
+            auth_routes.storage, "requires_password_change", lambda _username: True
+        )
+        assert _status(client)["bootstrap_deadline_seconds"] is not None
+
+
+class TestTheNumberIsUsable:
+    def test_an_expired_deadline_reads_zero_not_negative(self, client, monkeypatch):
+        """Rendered straight into a countdown, so a negative would print as
+        "shuts down in -12 minutes"."""
+        monkeypatch.setattr(
+            auth_routes.storage, "requires_password_change", lambda _username: True
+        )
+        record_bootstrap_deadline(1)
+        import auth.bootstrap_timeout as bt
+
+        bt._deadline_at = time.monotonic() - 5
+        assert _status(client)["bootstrap_deadline_seconds"] == 0
+
+    def test_the_endpoint_stays_anonymous(self, client, monkeypatch):
+        """No auth header is sent anywhere in this file. The deadline discloses
+        nothing an anonymous caller cannot already read off
+        requires_password_change, which this endpoint has always returned."""
+        monkeypatch.setattr(
+            auth_routes.storage, "requires_password_change", lambda _username: True
+        )
+        record_bootstrap_deadline(3600)
+        response = client.get("/api/auth/status")
+        assert response.status_code == 200
+        assert response.json()["bootstrap_deadline_seconds"] is not None

--- a/studio/backend/tests/test_auth_status_bootstrap_deadline.py
+++ b/studio/backend/tests/test_auth_status_bootstrap_deadline.py
@@ -43,6 +43,17 @@ def _status(client):
     return response.json()
 
 
+def _password_state(monkeypatch, *, requires_change: bool):
+    """Pin what the route reads. ``is_initialized`` goes with it because the route
+    answers True for an uninitialized instance without consulting the other call,
+    and a fresh checkout (CI) has no users, so patching one alone is a no-op there.
+    """
+    monkeypatch.setattr(auth_routes.storage, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        auth_routes.storage, "requires_password_change", lambda _username: requires_change
+    )
+
+
 class TestTheFieldIsPresent:
     def test_absent_deadline_is_null_not_missing(self, client):
         """The common case is a loopback launch, and a client that always reads the
@@ -52,13 +63,13 @@ class TestTheFieldIsPresent:
         assert body["bootstrap_deadline_seconds"] is None
 
     def test_an_armed_deadline_is_reported(self, client, monkeypatch):
-        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
+        _password_state(monkeypatch, requires_change = True)
         record_bootstrap_deadline(3600)
         remaining = _status(client)["bootstrap_deadline_seconds"]
         assert remaining is not None and 3590 <= remaining <= 3600
 
     def test_it_counts_down_between_calls(self, client, monkeypatch):
-        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
+        _password_state(monkeypatch, requires_change = True)
         record_bootstrap_deadline(3600)
         first = _status(client)["bootstrap_deadline_seconds"]
         import auth.bootstrap_timeout as bt
@@ -74,9 +85,7 @@ class TestItIsNotReportedWhenItCannotFire:
 
     def test_a_changed_password_reports_no_deadline(self, client, monkeypatch):
         record_bootstrap_deadline(3600)
-        monkeypatch.setattr(
-            auth_routes.storage, "requires_password_change", lambda _username: False
-        )
+        _password_state(monkeypatch, requires_change = False)
         body = _status(client)
         assert body["requires_password_change"] is False
         assert body["bootstrap_deadline_seconds"] is None
@@ -85,18 +94,16 @@ class TestItIsNotReportedWhenItCannotFire:
         """Arming is never undone on a password change, so the timer alone cannot
         answer this."""
         record_bootstrap_deadline(60)
-        monkeypatch.setattr(
-            auth_routes.storage, "requires_password_change", lambda _username: False
-        )
+        _password_state(monkeypatch, requires_change = False)
         assert _status(client)["bootstrap_deadline_seconds"] is None
-        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
+        _password_state(monkeypatch, requires_change = True)
         assert _status(client)["bootstrap_deadline_seconds"] is not None
 
 
 class TestTheNumberIsUsable:
     def test_an_expired_deadline_reads_zero_not_negative(self, client, monkeypatch):
         """A negative would print as "shuts down in -12 minutes"."""
-        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
+        _password_state(monkeypatch, requires_change = True)
         record_bootstrap_deadline(1)
         import auth.bootstrap_timeout as bt
 
@@ -106,7 +113,7 @@ class TestTheNumberIsUsable:
     def test_the_endpoint_stays_anonymous(self, client, monkeypatch):
         """No auth header is sent anywhere in this file, and the deadline is implied
         by requires_password_change, which this endpoint has always returned."""
-        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
+        _password_state(monkeypatch, requires_change = True)
         record_bootstrap_deadline(3600)
         response = client.get("/api/auth/status")
         assert response.status_code == 200

--- a/studio/backend/tests/test_auth_status_bootstrap_deadline.py
+++ b/studio/backend/tests/test_auth_status_bootstrap_deadline.py
@@ -3,14 +3,10 @@
 
 """The shutdown deadline has to reach the browser, not just the terminal.
 
-`arm_bootstrap_timeout` only fires for an exposed web UI (`--secure`, or an
-external bind), and those are precisely the launches run detached or tunneled,
-where nothing reads stderr. So the one warning Unsloth prints goes to the one
-channel this feature guarantees is unattended, and the UI shows a plain "Failed
-to load auth status." after the fact, when there is no longer a server to ask.
-
-`/api/auth/status` is where the login page already learns it must change the
-password, so it is where the deadline belongs.
+The deadline arms only for an exposed web UI (`--secure`, or an external bind),
+and those are the launches run detached or tunneled, where nothing reads stderr.
+The UI then shows a plain "Failed to load auth status." after the fact, when
+there is no longer a server to ask.
 """
 
 import time
@@ -49,8 +45,8 @@ def _status(client):
 
 class TestTheFieldIsPresent:
     def test_absent_deadline_is_null_not_missing(self, client):
-        """A client that always reads the key must not see undefined on a normal
-        loopback launch, which is the common case."""
+        """The common case is a loopback launch, and a client that always reads the
+        key must not see undefined there."""
         body = _status(client)
         assert "bootstrap_deadline_seconds" in body
         assert body["bootstrap_deadline_seconds"] is None
@@ -73,9 +69,8 @@ class TestTheFieldIsPresent:
 
 
 class TestItIsNotReportedWhenItCannotFire:
-    """The deadline shuts down only while the seeded password stands. Reporting
-    a countdown after the password is changed would promise a shutdown that the
-    handler explicitly declines to perform."""
+    """Reporting a countdown after the password is changed would promise a shutdown
+    the handler explicitly declines to perform."""
 
     def test_a_changed_password_reports_no_deadline(self, client, monkeypatch):
         record_bootstrap_deadline(3600)
@@ -87,8 +82,8 @@ class TestItIsNotReportedWhenItCannotFire:
         assert body["bootstrap_deadline_seconds"] is None
 
     def test_the_timer_being_armed_is_not_enough_on_its_own(self, client, monkeypatch):
-        """Arming happens once at startup and is never disarmed on a password
-        change, so the route cannot infer the answer from the timer alone."""
+        """Arming is never undone on a password change, so the timer alone cannot
+        answer this."""
         record_bootstrap_deadline(60)
         monkeypatch.setattr(
             auth_routes.storage, "requires_password_change", lambda _username: False
@@ -100,8 +95,7 @@ class TestItIsNotReportedWhenItCannotFire:
 
 class TestTheNumberIsUsable:
     def test_an_expired_deadline_reads_zero_not_negative(self, client, monkeypatch):
-        """Rendered straight into a countdown, so a negative would print as
-        "shuts down in -12 minutes"."""
+        """A negative would print as "shuts down in -12 minutes"."""
         monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
         record_bootstrap_deadline(1)
         import auth.bootstrap_timeout as bt
@@ -110,9 +104,8 @@ class TestTheNumberIsUsable:
         assert _status(client)["bootstrap_deadline_seconds"] == 0
 
     def test_the_endpoint_stays_anonymous(self, client, monkeypatch):
-        """No auth header is sent anywhere in this file. The deadline discloses
-        nothing an anonymous caller cannot already read off
-        requires_password_change, which this endpoint has always returned."""
+        """No auth header is sent anywhere in this file, and the deadline is implied
+        by requires_password_change, which this endpoint has always returned."""
         monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
         record_bootstrap_deadline(3600)
         response = client.get("/api/auth/status")

--- a/studio/backend/tests/test_auth_status_bootstrap_deadline.py
+++ b/studio/backend/tests/test_auth_status_bootstrap_deadline.py
@@ -56,17 +56,13 @@ class TestTheFieldIsPresent:
         assert body["bootstrap_deadline_seconds"] is None
 
     def test_an_armed_deadline_is_reported(self, client, monkeypatch):
-        monkeypatch.setattr(
-            auth_routes.storage, "requires_password_change", lambda _username: True
-        )
+        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
         record_bootstrap_deadline(3600)
         remaining = _status(client)["bootstrap_deadline_seconds"]
         assert remaining is not None and 3590 <= remaining <= 3600
 
     def test_it_counts_down_between_calls(self, client, monkeypatch):
-        monkeypatch.setattr(
-            auth_routes.storage, "requires_password_change", lambda _username: True
-        )
+        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
         record_bootstrap_deadline(3600)
         first = _status(client)["bootstrap_deadline_seconds"]
         import auth.bootstrap_timeout as bt
@@ -98,9 +94,7 @@ class TestItIsNotReportedWhenItCannotFire:
             auth_routes.storage, "requires_password_change", lambda _username: False
         )
         assert _status(client)["bootstrap_deadline_seconds"] is None
-        monkeypatch.setattr(
-            auth_routes.storage, "requires_password_change", lambda _username: True
-        )
+        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
         assert _status(client)["bootstrap_deadline_seconds"] is not None
 
 
@@ -108,9 +102,7 @@ class TestTheNumberIsUsable:
     def test_an_expired_deadline_reads_zero_not_negative(self, client, monkeypatch):
         """Rendered straight into a countdown, so a negative would print as
         "shuts down in -12 minutes"."""
-        monkeypatch.setattr(
-            auth_routes.storage, "requires_password_change", lambda _username: True
-        )
+        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
         record_bootstrap_deadline(1)
         import auth.bootstrap_timeout as bt
 
@@ -121,9 +113,7 @@ class TestTheNumberIsUsable:
         """No auth header is sent anywhere in this file. The deadline discloses
         nothing an anonymous caller cannot already read off
         requires_password_change, which this endpoint has always returned."""
-        monkeypatch.setattr(
-            auth_routes.storage, "requires_password_change", lambda _username: True
-        )
+        monkeypatch.setattr(auth_routes.storage, "requires_password_change", lambda _username: True)
         record_bootstrap_deadline(3600)
         response = client.get("/api/auth/status")
         assert response.status_code == 200

--- a/studio/backend/tests/test_bootstrap_timeout.py
+++ b/studio/backend/tests/test_bootstrap_timeout.py
@@ -190,9 +190,6 @@ def test_shutdown_message_uses_formatted_duration():
     assert not any("minute(s)" in m for m in logged)
 
 
-# ── deadline readback (what the browser is told) ────────────────────
-
-
 def test_no_deadline_reported_when_nothing_armed():
     clear_bootstrap_deadline()
     assert bootstrap_deadline_remaining_seconds() is None
@@ -210,14 +207,13 @@ def test_recorded_deadline_counts_down():
 
 
 def test_a_disabled_timeout_records_no_deadline():
-    """0 means the launch is not time-boxed, so there is nothing to display."""
+    """None means not time-boxed, which is a different answer from an expired 0."""
     record_bootstrap_deadline(0)
     assert bootstrap_deadline_remaining_seconds() is None
 
 
 def test_an_expired_deadline_floors_at_zero_rather_than_going_negative():
-    """The timer and this clock are read separately, so a caller can land in the
-    gap between expiry and the shutdown completing."""
+    """The timer and this clock are read separately, so a caller can land in the gap."""
     record_bootstrap_deadline(1)
     try:
         import auth.bootstrap_timeout as bt
@@ -228,8 +224,7 @@ def test_an_expired_deadline_floors_at_zero_rather_than_going_negative():
 
 
 def test_arming_publishes_the_deadline():
-    """Arming is the only thing that starts the clock, so it is what must record
-    it. A timer nobody can read is how this was invisible to the UI."""
+    """Arming is the only thing that starts the clock, so it must be what records it."""
     clear_bootstrap_deadline()
     timer = arm_bootstrap_timeout(
         _fake_storage(requires_change = True),

--- a/studio/backend/tests/test_bootstrap_timeout.py
+++ b/studio/backend/tests/test_bootstrap_timeout.py
@@ -8,13 +8,18 @@ handler (shut down iff the seeded admin password is still unchanged). The
 threading.Timer itself is not exercised; the handler is invoked directly.
 """
 
+import time
 from types import SimpleNamespace
 
 from auth.bootstrap_timeout import (
     DEFAULT_BOOTSTRAP_TIMEOUT_SECONDS,
     _format_duration,
+    arm_bootstrap_timeout,
+    bootstrap_deadline_remaining_seconds,
     bootstrap_timeout_seconds,
+    clear_bootstrap_deadline,
     enforce_bootstrap_password_deadline,
+    record_bootstrap_deadline,
     should_arm_bootstrap_timeout,
 )
 
@@ -183,3 +188,58 @@ def test_shutdown_message_uses_formatted_duration():
     )
     assert any("60 minutes" in m for m in logged)
     assert not any("minute(s)" in m for m in logged)
+
+
+# ── deadline readback (what the browser is told) ────────────────────
+
+
+def test_no_deadline_reported_when_nothing_armed():
+    clear_bootstrap_deadline()
+    assert bootstrap_deadline_remaining_seconds() is None
+
+
+def test_recorded_deadline_counts_down():
+    record_bootstrap_deadline(3600)
+    try:
+        remaining = bootstrap_deadline_remaining_seconds()
+        assert remaining is not None
+        # Allow for the clock moving between the two calls.
+        assert 3595 <= remaining <= 3600
+    finally:
+        clear_bootstrap_deadline()
+
+
+def test_a_disabled_timeout_records_no_deadline():
+    """0 means the launch is not time-boxed, so there is nothing to display."""
+    record_bootstrap_deadline(0)
+    assert bootstrap_deadline_remaining_seconds() is None
+
+
+def test_an_expired_deadline_floors_at_zero_rather_than_going_negative():
+    """The timer and this clock are read separately, so a caller can land in the
+    gap between expiry and the shutdown completing."""
+    record_bootstrap_deadline(1)
+    try:
+        import auth.bootstrap_timeout as bt
+
+        bt._deadline_at = time.monotonic() - 30
+        assert bootstrap_deadline_remaining_seconds() == 0
+    finally:
+        clear_bootstrap_deadline()
+
+
+def test_arming_publishes_the_deadline():
+    """Arming is the only thing that starts the clock, so it is what must record
+    it. A timer nobody can read is how this was invisible to the UI."""
+    clear_bootstrap_deadline()
+    timer = arm_bootstrap_timeout(
+        _fake_storage(requires_change = True),
+        lambda: None,
+        timeout_seconds = 1800,
+    )
+    try:
+        remaining = bootstrap_deadline_remaining_seconds()
+        assert remaining is not None and 1795 <= remaining <= 1800
+    finally:
+        timer.cancel()
+        clear_bootstrap_deadline()

--- a/studio/backend/tests/test_bootstrap_timeout.py
+++ b/studio/backend/tests/test_bootstrap_timeout.py
@@ -221,7 +221,6 @@ def test_an_expired_deadline_floors_at_zero_rather_than_going_negative():
     record_bootstrap_deadline(1)
     try:
         import auth.bootstrap_timeout as bt
-
         bt._deadline_at = time.monotonic() - 30
         assert bootstrap_deadline_remaining_seconds() == 0
     finally:

--- a/studio/frontend/src/features/auth/bootstrap-deadline.ts
+++ b/studio/frontend/src/features/auth/bootstrap-deadline.ts
@@ -1,19 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-/** Countdown shown while an exposed first-run Studio still has its default password.
- *
- * Split out of auth-form.tsx so the tests can reach it: the frontend runner is
- * `node --experimental-strip-types`, which strips types but does not transform
- * JSX, so nothing importable from a .tsx file is unit-testable.
- */
+/** Split out of auth-form.tsx so the tests can reach it: the runner is
+ * `node --experimental-strip-types`, which does not transform JSX, so nothing
+ * importable from a .tsx file is unit-testable. */
 
 /** Absolute expiry in epoch ms, or null when the launch is not time-boxed.
- *
  * Absolute rather than a stored countdown: a backgrounded tab stops firing timers
- * and must still render the right figure when it wakes. The `typeof` guard is what
- * makes a pre-deadline server (no such key) simply render nothing.
- */
+ * and must still render the right figure when it wakes. */
 export function deadlineFromStatus(
   seconds: number | null | undefined,
   now: number,
@@ -24,8 +18,7 @@ export function deadlineFromStatus(
   return now + seconds * 1000;
 }
 
-/** Coarse on purpose: the deadline is an hour, so ticking seconds would be noise
- * everywhere except the last minute. */
+/** Coarse on purpose: the deadline is an hour, so per-second ticks are noise. */
 export function formatCountdown(remainingMs: number): string {
   const totalSeconds = Math.max(0, Math.round(remainingMs / 1000));
   if (totalSeconds < 60) {
@@ -35,8 +28,7 @@ export function formatCountdown(remainingMs: number): string {
   return `${minutes} minute${minutes === 1 ? "" : "s"}`;
 }
 
-/** Past the deadline the wording has to change: "shuts down in 0 seconds" would
- * sit there indefinitely on a stale tab, describing a future that already happened. */
+/** A stale tab must not sit on "shuts down in 0 seconds" once the deadline passes. */
 export function hasExpired(remainingMs: number): boolean {
   return remainingMs <= 0;
 }

--- a/studio/frontend/src/features/auth/bootstrap-deadline.ts
+++ b/studio/frontend/src/features/auth/bootstrap-deadline.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** Countdown shown while an exposed first-run Studio still has its default password.
+ *
+ * Split out of auth-form.tsx so the tests can reach it: the frontend runner is
+ * `node --experimental-strip-types`, which strips types but does not transform
+ * JSX, so nothing importable from a .tsx file is unit-testable.
+ */
+
+/** Absolute expiry in epoch ms, or null when the launch is not time-boxed.
+ *
+ * Absolute rather than a stored countdown: a backgrounded tab stops firing timers
+ * and must still render the right figure when it wakes. The `typeof` guard is what
+ * makes a pre-deadline server (no such key) simply render nothing.
+ */
+export function deadlineFromStatus(
+  seconds: number | null | undefined,
+  now: number,
+): number | null {
+  if (typeof seconds !== "number" || !Number.isFinite(seconds)) {
+    return null;
+  }
+  return now + seconds * 1000;
+}
+
+/** Coarse on purpose: the deadline is an hour, so ticking seconds would be noise
+ * everywhere except the last minute. */
+export function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(0, Math.round(remainingMs / 1000));
+  if (totalSeconds < 60) {
+    return `${totalSeconds} second${totalSeconds === 1 ? "" : "s"}`;
+  }
+  const minutes = Math.round(totalSeconds / 60);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+
+/** Past the deadline the wording has to change: "shuts down in 0 seconds" would
+ * sit there indefinitely on a stale tab, describing a future that already happened. */
+export function hasExpired(remainingMs: number): boolean {
+  return remainingMs <= 0;
+}

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -42,7 +42,6 @@ type AuthMode = "login" | "change-password";
 type AuthStatusResponse = {
   initialized: boolean;
   requires_password_change: boolean;
-  /** Null or absent when the launch is not time-boxed. */
   bootstrap_deadline_seconds?: number | null;
 };
 
@@ -95,8 +94,6 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
   const [initialized, setInitialized] = useState<boolean | null>(null);
   const [requiresPasswordChange, setRequiresPasswordChange] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Absolute expiry, not a stored countdown: a backgrounded tab stops firing
-  // timers and must still render the right figure when it wakes.
   const [deadlineAt, setDeadlineAt] = useState<number | null>(null);
   const [nowMs, setNowMs] = useState<number>(() => Date.now());
   const reloadReadySent = useRef(false);
@@ -352,8 +349,7 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
         <h2 className="text-2xl font-semibold text-foreground">{title}</h2>
         <p className="text-muted-foreground">{subtitle}</p>
       </div>
-      {/* Not a live region: it re-renders every second, so announcing it would
-          read the countdown aloud on every tick. */}
+      {/* Not a live region: it re-renders every second, so it would be read aloud on every tick. */}
       {deadlineAt !== null && (
         <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-center text-sm text-amber-600">
           {hasExpired(deadlineAt - nowMs) ? (

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -12,6 +12,11 @@ import { useEffect, useRef, useState } from "react";
 import type { ReactElement } from "react";
 import type { SyntheticEvent } from "react";
 import { refreshSession } from "../api";
+import {
+  deadlineFromStatus,
+  formatCountdown,
+  hasExpired,
+} from "../bootstrap-deadline";
 
 // Bootstrap credentials injected into index.html by the backend (only present
 // while default admin must_change_password is true)
@@ -40,17 +45,6 @@ type AuthStatusResponse = {
   /** Null or absent when the launch is not time-boxed. */
   bootstrap_deadline_seconds?: number | null;
 };
-
-/** Coarse on purpose: the deadline is an hour, so ticking seconds would be noise
- * everywhere except the last minute. */
-function formatCountdown(remainingMs: number): string {
-  const totalSeconds = Math.max(0, Math.round(remainingMs / 1000));
-  if (totalSeconds < 60) {
-    return `${totalSeconds} second${totalSeconds === 1 ? "" : "s"}`;
-  }
-  const minutes = Math.round(totalSeconds / 60);
-  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
-}
 
 type TokenResponse = {
   access_token: string;
@@ -130,9 +124,7 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
           setInitialized(result.initialized);
           setRequiresPasswordChange(result.requires_password_change);
           setDeadlineAt(
-            typeof result.bootstrap_deadline_seconds === "number"
-              ? Date.now() + result.bootstrap_deadline_seconds * 1000
-              : null,
+            deadlineFromStatus(result.bootstrap_deadline_seconds, Date.now()),
           );
 
           // Server truth wins; keep localStorage in sync both ways.
@@ -364,9 +356,19 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
           read the countdown aloud on every tick. */}
       {deadlineAt !== null && (
         <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-center text-sm text-amber-600">
-          This instance is reachable on the network and still uses its default
-          password, so it shuts down in {formatCountdown(deadlineAt - nowMs)}.
-          Setting a password here keeps it running.
+          {hasExpired(deadlineAt - nowMs) ? (
+            <>
+              This instance is shutting down: it was reachable on the network
+              and its default password was never changed.
+            </>
+          ) : (
+            <>
+              This instance is reachable on the network and still uses its
+              default password, so it shuts down in{" "}
+              {formatCountdown(deadlineAt - nowMs)}. Setting a password here
+              keeps it running.
+            </>
+          )}
         </p>
       )}
       <form className="space-y-5" onSubmit={handleSubmit}>

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -120,8 +120,13 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
         if (!canceled) {
           setInitialized(result.initialized);
           setRequiresPasswordChange(result.requires_password_change);
+          // One clock sample for both: nowMs is otherwise still the mount time
+          // until the first tick, which adds the request duration to the figure
+          // and renders a 0 from the server as "shuts down in 0 seconds".
+          const sampledNow = Date.now();
+          setNowMs(sampledNow);
           setDeadlineAt(
-            deadlineFromStatus(result.bootstrap_deadline_seconds, Date.now()),
+            deadlineFromStatus(result.bootstrap_deadline_seconds, sampledNow),
           );
 
           // Server truth wins; keep localStorage in sync both ways.

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -37,13 +37,12 @@ type AuthMode = "login" | "change-password";
 type AuthStatusResponse = {
   initialized: boolean;
   requires_password_change: boolean;
-  /** Seconds until this instance shuts down for leaving the default password in
-   * place, or null/absent when the launch is not time-boxed. */
+  /** Null or absent when the launch is not time-boxed. */
   bootstrap_deadline_seconds?: number | null;
 };
 
-/** Coarse on purpose: the deadline is an hour by default, so a ticking seconds
- * readout would be noise everywhere except the last minute. */
+/** Coarse on purpose: the deadline is an hour, so ticking seconds would be noise
+ * everywhere except the last minute. */
 function formatCountdown(remainingMs: number): string {
   const totalSeconds = Math.max(0, Math.round(remainingMs / 1000));
   if (totalSeconds < 60) {
@@ -102,8 +101,8 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
   const [initialized, setInitialized] = useState<boolean | null>(null);
   const [requiresPasswordChange, setRequiresPasswordChange] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Absolute expiry rather than a stored countdown, so a backgrounded tab that
-  // stops firing timers still renders the right figure when it wakes.
+  // Absolute expiry, not a stored countdown: a backgrounded tab stops firing
+  // timers and must still render the right figure when it wakes.
   const [deadlineAt, setDeadlineAt] = useState<number | null>(null);
   const [nowMs, setNowMs] = useState<number>(() => Date.now());
   const reloadReadySent = useRef(false);
@@ -361,8 +360,8 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
         <h2 className="text-2xl font-semibold text-foreground">{title}</h2>
         <p className="text-muted-foreground">{subtitle}</p>
       </div>
-      {/* Deliberately not a live region: this re-renders every second, so
-          announcing it would read the countdown aloud on every tick. */}
+      {/* Not a live region: it re-renders every second, so announcing it would
+          read the countdown aloud on every tick. */}
       {deadlineAt !== null && (
         <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-center text-sm text-amber-600">
           This instance is reachable on the network and still uses its default

--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -37,7 +37,21 @@ type AuthMode = "login" | "change-password";
 type AuthStatusResponse = {
   initialized: boolean;
   requires_password_change: boolean;
+  /** Seconds until this instance shuts down for leaving the default password in
+   * place, or null/absent when the launch is not time-boxed. */
+  bootstrap_deadline_seconds?: number | null;
 };
+
+/** Coarse on purpose: the deadline is an hour by default, so a ticking seconds
+ * readout would be noise everywhere except the last minute. */
+function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(0, Math.round(remainingMs / 1000));
+  if (totalSeconds < 60) {
+    return `${totalSeconds} second${totalSeconds === 1 ? "" : "s"}`;
+  }
+  const minutes = Math.round(totalSeconds / 60);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
 
 type TokenResponse = {
   access_token: string;
@@ -88,7 +102,19 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
   const [initialized, setInitialized] = useState<boolean | null>(null);
   const [requiresPasswordChange, setRequiresPasswordChange] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Absolute expiry rather than a stored countdown, so a backgrounded tab that
+  // stops firing timers still renders the right figure when it wakes.
+  const [deadlineAt, setDeadlineAt] = useState<number | null>(null);
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
   const reloadReadySent = useRef(false);
+
+  useEffect(() => {
+    if (deadlineAt === null) {
+      return;
+    }
+    const id = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [deadlineAt]);
 
   useEffect(() => {
     let canceled = false;
@@ -104,6 +130,11 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
         if (!canceled) {
           setInitialized(result.initialized);
           setRequiresPasswordChange(result.requires_password_change);
+          setDeadlineAt(
+            typeof result.bootstrap_deadline_seconds === "number"
+              ? Date.now() + result.bootstrap_deadline_seconds * 1000
+              : null,
+          );
 
           // Server truth wins; keep localStorage in sync both ways.
           if (result.requires_password_change !== mustChangePassword()) {
@@ -330,6 +361,15 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
         <h2 className="text-2xl font-semibold text-foreground">{title}</h2>
         <p className="text-muted-foreground">{subtitle}</p>
       </div>
+      {/* Deliberately not a live region: this re-renders every second, so
+          announcing it would read the countdown aloud on every tick. */}
+      {deadlineAt !== null && (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-center text-sm text-amber-600">
+          This instance is reachable on the network and still uses its default
+          password, so it shuts down in {formatCountdown(deadlineAt - nowMs)}.
+          Setting a password here keeps it running.
+        </p>
+      )}
       <form className="space-y-5" onSubmit={handleSubmit}>
         {isLoginMode && (
           <div className="space-y-2">

--- a/studio/frontend/tests/auth-bootstrap-deadline.test.ts
+++ b/studio/frontend/tests/auth-bootstrap-deadline.test.ts
@@ -1,13 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-/**
- * The countdown shown while an exposed first-run Studio still has its default
- * password. The server shuts itself down on that deadline, and before this the
- * browser was never told, so the session died behind a generic "Failed to load
- * auth status."
- */
-
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
@@ -18,8 +11,7 @@ import {
 } from "../src/features/auth/bootstrap-deadline.ts";
 
 test("a server that does not send the field is not time-boxed", () => {
-  // A pre-deadline backend omits the key entirely. Rendering a countdown from
-  // undefined would print "NaN minutes".
+  // A pre-deadline backend omits the key; a countdown from undefined prints "NaN".
   assert.equal(deadlineFromStatus(undefined, 1_000_000), null);
   assert.equal(deadlineFromStatus(null, 1_000_000), null);
 });
@@ -34,7 +26,6 @@ test("seconds are turned into an absolute expiry", () => {
 });
 
 test("zero seconds is a real deadline, not an absent one", () => {
-  // 0 means "expired", which must still show the banner, unlike null.
   assert.equal(deadlineFromStatus(0, 500), 500);
 });
 
@@ -60,8 +51,7 @@ test("a minute or more reads in minutes", () => {
 });
 
 test("it never renders a negative", () => {
-  // The tab keeps ticking after the deadline passes; "-12 minutes" would be worse
-  // than saying nothing.
+  // The tab keeps ticking past the deadline; "-12 minutes" is worse than nothing.
   assert.equal(formatCountdown(-1), "0 seconds");
   assert.equal(formatCountdown(-10_000_000), "0 seconds");
 });
@@ -73,8 +63,6 @@ test("expiry is inclusive of zero", () => {
 });
 
 test("the boundary between the two messages is one tick wide", () => {
-  // At exactly 0 the wording must have already switched, so no render can show
-  // "shuts down in 0 seconds".
   assert.equal(hasExpired(0), true);
   assert.equal(formatCountdown(0), "0 seconds");
   assert.ok(

--- a/studio/frontend/tests/auth-bootstrap-deadline.test.ts
+++ b/studio/frontend/tests/auth-bootstrap-deadline.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * The countdown shown while an exposed first-run Studio still has its default
+ * password. The server shuts itself down on that deadline, and before this the
+ * browser was never told, so the session died behind a generic "Failed to load
+ * auth status."
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  deadlineFromStatus,
+  formatCountdown,
+  hasExpired,
+} from "../src/features/auth/bootstrap-deadline.ts";
+
+test("a server that does not send the field is not time-boxed", () => {
+  // A pre-deadline backend omits the key entirely. Rendering a countdown from
+  // undefined would print "NaN minutes".
+  assert.equal(deadlineFromStatus(undefined, 1_000_000), null);
+  assert.equal(deadlineFromStatus(null, 1_000_000), null);
+});
+
+test("a loopback launch sends null and gets no countdown", () => {
+  assert.equal(deadlineFromStatus(null, 0), null);
+});
+
+test("seconds are turned into an absolute expiry", () => {
+  // Absolute, so a backgrounded tab whose timers stopped still renders correctly.
+  assert.equal(deadlineFromStatus(3600, 1_000_000), 1_000_000 + 3_600_000);
+});
+
+test("zero seconds is a real deadline, not an absent one", () => {
+  // 0 means "expired", which must still show the banner, unlike null.
+  assert.equal(deadlineFromStatus(0, 500), 500);
+});
+
+test("a non-numeric or non-finite value is refused", () => {
+  assert.equal(deadlineFromStatus(Number.NaN, 0), null);
+  assert.equal(deadlineFromStatus(Number.POSITIVE_INFINITY, 0), null);
+  assert.equal(deadlineFromStatus("3600" as unknown as number, 0), null);
+});
+
+test("under a minute reads in seconds", () => {
+  assert.equal(formatCountdown(45_000), "45 seconds");
+  assert.equal(formatCountdown(59_400), "59 seconds");
+});
+
+test("one second is singular", () => {
+  assert.equal(formatCountdown(1000), "1 second");
+});
+
+test("a minute or more reads in minutes", () => {
+  assert.equal(formatCountdown(60_000), "1 minute");
+  assert.equal(formatCountdown(3_600_000), "60 minutes");
+  assert.equal(formatCountdown(2_520_000), "42 minutes");
+});
+
+test("it never renders a negative", () => {
+  // The tab keeps ticking after the deadline passes; "-12 minutes" would be worse
+  // than saying nothing.
+  assert.equal(formatCountdown(-1), "0 seconds");
+  assert.equal(formatCountdown(-10_000_000), "0 seconds");
+});
+
+test("expiry is inclusive of zero", () => {
+  assert.equal(hasExpired(1), false);
+  assert.equal(hasExpired(0), true);
+  assert.equal(hasExpired(-1), true);
+});
+
+test("the boundary between the two messages is one tick wide", () => {
+  // At exactly 0 the wording must have already switched, so no render can show
+  // "shuts down in 0 seconds".
+  assert.equal(hasExpired(0), true);
+  assert.equal(formatCountdown(0), "0 seconds");
+  assert.ok(
+    hasExpired(0),
+    "0 must select the shutting-down copy, not the countdown",
+  );
+});

--- a/studio/frontend/tests/auth-bootstrap-deadline.test.ts
+++ b/studio/frontend/tests/auth-bootstrap-deadline.test.ts
@@ -70,3 +70,18 @@ test("the boundary between the two messages is one tick wide", () => {
     "0 must select the shutting-down copy, not the countdown",
   );
 });
+
+test("the deadline and the clock it is compared against must be one sample", () => {
+  // A request that takes 30ms turns a server 0 back into a positive remainder,
+  // which selects the countdown copy and prints "shuts down in 0 seconds".
+  const mounted = 1_000_000;
+  const responded = mounted + 30;
+  const stale = deadlineFromStatus(0, responded);
+  assert.ok(stale !== null);
+  assert.equal(hasExpired(stale - mounted), false);
+  assert.equal(formatCountdown(stale - mounted), "0 seconds");
+
+  const sampled = deadlineFromStatus(0, responded);
+  assert.ok(sampled !== null);
+  assert.equal(hasExpired(sampled - responded), true);
+});


### PR DESCRIPTION
An exposed first-run Studio shuts itself down after an hour if the seeded admin password is never changed. That behaviour is right and this PR does not touch it. What it changes is that the browser is never told, so the shutdown arrives as an unexplained failure.

### The gap

`arm_bootstrap_timeout` fires only for an exposed web UI, which means `--secure` or an external bind. Those are precisely the launches run detached, tunneled or remote, where nothing is reading stderr. The single warning Studio prints therefore goes to the one channel this feature's own trigger condition makes unattended.

In the running tree today:

- `bootstrap_timeout` appears nowhere under `studio/backend/routes/`, so the deadline is never exposed over HTTP.
- `AuthStatusResponse` carries `initialized`, `default_username` and `requires_password_change`. There is no deadline field.
- Nothing in `studio/frontend/src` mentions the shutdown.

So the login page cannot know a deadline exists. There is no warning beforehand, and afterwards `auth-form.tsx` throws the generic `"Failed to load auth status."` that covers any fetch failure. By then the server is gone and genuinely cannot explain itself.

I hit this on a tunneled instance: the page loaded and `/api/auth/status` answered 200, then the deadline fired three seconds later. From the browser it was indistinguishable from a crash, and the natural response is to relaunch and hit the same wall an hour later.

### The change

Record the deadline when the timer is armed, report the remaining seconds on `/api/auth/status`, and render a countdown on the login and change-password screens:

> This instance is reachable on the network and still uses its default password, so it shuts down in 42 minutes. Setting a password here keeps it running.

`/api/auth/status` is already where the login page learns it must change the password, so the countdown lands exactly where the user is being asked to act.

Deliberate choices:

- **Reported only while `requires_password_change` is true.** The handler shuts down on that condition alone, so once the password is changed the timer is inert and a countdown would promise a shutdown that never comes. Arming is never undone on a password change, so the route cannot infer this from the timer.
- **Floors at 0.** The timer and the clock are read separately, so a caller can land between expiry and shutdown. Rendered straight into a countdown, a negative would print as "shuts down in -12 minutes".
- **Absolute expiry in the frontend, not a stored countdown**, so a backgrounded tab whose timers stop firing still renders the right figure when it wakes.
- **Not a live region.** It re-renders every second, so announcing it would read the countdown aloud on every tick.
- **No attempt to improve the post-mortem message.** With the server dead there is nothing left to query, so prevention is the only honest fix.
- Field is optional and defaults to `null`, so any existing client is unaffected.

### Verification

- 34 backend tests pass, 27 in `test_bootstrap_timeout.py` and 7 new route tests in `test_auth_status_bootstrap_deadline.py`.
- Mutation-checked rather than assumed: forcing `bootstrap_deadline_seconds = None` in the route fails 5 of the 7 new tests. The 2 that still pass are the ones asserting `null`, which is correct either way.
- Frontend `typecheck` and `build` clean, 6245 frontend tests pass.
- Biome on `auth-form.tsx` shows no new findings. The `useSimplifiedLogicExpression` and `useExhaustiveDependencies` hits sit on pre-existing lines my insertion shifted down, and the count of the latter is 4 before and after.
- `tests/test_chat_generation_run_lease.py::test_stopping_the_sweeper_does_not_spend_the_desktop_exit_budget` fails on this branch, but it fails identically on clean `main`, so it is not from this change.
