### PR TITLE
Scope the llama.cpp update test's Popen patch to the installer

### DIFF
--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -88,6 +88,7 @@ def _patch_installer_popen(
     that identity lookup shells out to `ps`, which would otherwise reach on_start
     and overwrite the installer argv a caller captured (#8170).
     """
+
     def _popen(cmd, **kw):
         if spawned is not None:
             spawned.append(list(cmd))

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -24,6 +24,7 @@ if str(_BACKEND) not in sys.path:
 
 import utils.llama_cpp_freshness as freshness  # noqa: E402
 import utils.llama_cpp_update as upd  # noqa: E402
+import utils.process_lifetime as process_lifetime  # noqa: E402
 
 MARKER = "UNSLOTH_PREBUILT_INFO.json"
 
@@ -58,6 +59,18 @@ class _FakeInstallerPopen:
     def kill(self):
         pass
 
+    # subprocess.run() uses `with Popen(...)`, and without these it raises into
+    # _pid_identity's bare except, silently disabling the identity check.
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _installer_command(cmd) -> bool:
+    return any("install_llama_prebuilt" in str(part) for part in cmd)
+
 
 def _patch_installer_popen(
     monkeypatch,
@@ -66,19 +79,29 @@ def _patch_installer_popen(
     lines = None,
     on_start = None,
     captured_kwargs = None,
+    spawned = None,
 ):
-    monkeypatch.setattr(
-        upd.subprocess,
-        "Popen",
-        lambda cmd, **kw: _FakeInstallerPopen(
+    """Replace Popen for the installer only.
+
+    subprocess is shared, so this patch catches every spawn in the process, and
+    _run_llama_phase adopts the installer pid right after starting it: on macOS
+    that identity lookup shells out to `ps`, which would otherwise reach on_start
+    and overwrite the installer argv a caller captured (#8170).
+    """
+    def _popen(cmd, **kw):
+        if spawned is not None:
+            spawned.append(list(cmd))
+        is_installer = _installer_command(cmd)
+        return _FakeInstallerPopen(
             cmd,
-            returncode = returncode,
-            lines = lines,
-            on_start = on_start,
-            captured_kwargs = captured_kwargs,
+            returncode = returncode if is_installer else 0,
+            lines = lines if is_installer else None,
+            on_start = on_start if is_installer else None,
+            captured_kwargs = captured_kwargs if is_installer else None,
             **kw,
-        ),
-    )
+        )
+
+    monkeypatch.setattr(upd.subprocess, "Popen", _popen)
 
 
 def _write_install(
@@ -470,6 +493,40 @@ def test_start_update_happy_path(monkeypatch, tmp_path):
     assert "unslothai/llama.cpp" in captured["cmd"]
     assert job["progress"] == 1.0
     assert popen_kwargs["env"]["UNSLOTH_PROGRESS_PERCENT_STEP"] == "5"
+
+
+def test_a_second_spawn_during_the_update_does_not_overwrite_the_installer_argv(
+    monkeypatch, tmp_path
+):
+    """The installer is not the only thing the phase spawns.
+
+    _run_llama_phase adopts the installer pid, and on a host with no /proc that
+    identity lookup runs `ps`. Forced here because CI runs this file on Linux
+    only, so the macOS ordering is otherwise never exercised.
+    """
+    install_dir = tmp_path / "llama.cpp"
+    binary = _write_install(install_dir, "b9493")
+    monkeypatch.setattr(upd, "_find_binary", lambda: binary)
+    monkeypatch.setattr(upd, "_installer_script", lambda: tmp_path / "install_llama_prebuilt.py")
+    monkeypatch.setattr(freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9518")
+    monkeypatch.setattr(process_lifetime.sys, "platform", "darwin", raising = False)
+
+    captured: dict = {}
+    spawned: list = []
+
+    def _on_start(cmd):
+        captured["cmd"] = cmd
+        _write_install(install_dir, "b9518")
+
+    _patch_installer_popen(monkeypatch, on_start = _on_start, spawned = spawned)
+
+    job = _run_start_update_to_completion()
+    assert job["state"] == "success", job
+    # Without the ps spawn the ordering this guards cannot happen, so a green
+    # run that never reached it would prove nothing.
+    assert any(cmd and cmd[0] == "ps" for cmd in spawned), spawned
+    assert "--install-dir" in captured["cmd"], captured["cmd"]
+    assert str(install_dir) in captured["cmd"], captured["cmd"]
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -11,6 +11,8 @@ the apply flow (job lifecycle, installer invocation, post-swap re-read).
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -59,13 +61,9 @@ class _FakeInstallerPopen:
     def kill(self):
         pass
 
-    # subprocess.run() uses `with Popen(...)`, and without these it raises into
-    # _pid_identity's bare except, silently disabling the identity check.
-    def __enter__(self):
-        return self
 
-    def __exit__(self, *exc):
-        return False
+# Bound before any patch, so a delegated spawn reaches the real one.
+_REAL_POPEN = subprocess.Popen
 
 
 def _installer_command(cmd) -> bool:
@@ -81,24 +79,27 @@ def _patch_installer_popen(
     captured_kwargs = None,
     spawned = None,
 ):
-    """Replace Popen for the installer only.
+    """Replace Popen for the installer only; everything else gets the real one.
 
     subprocess is shared, so this patch catches every spawn in the process, and
     _run_llama_phase adopts the installer pid right after starting it: on macOS
     that identity lookup shells out to `ps`, which would otherwise reach on_start
-    and overwrite the installer argv a caller captured (#8170).
+    and overwrite the installer argv a caller captured (#8170). Delegating rather
+    than faking keeps that lookup working, since a stand-in owes subprocess.run
+    the whole protocol and _pid_identity swallows whatever it does not get.
     """
 
     def _popen(cmd, **kw):
         if spawned is not None:
             spawned.append(list(cmd))
-        is_installer = _installer_command(cmd)
+        if not _installer_command(cmd):
+            return _REAL_POPEN(cmd, **kw)
         return _FakeInstallerPopen(
             cmd,
-            returncode = returncode if is_installer else 0,
-            lines = lines if is_installer else None,
-            on_start = on_start if is_installer else None,
-            captured_kwargs = captured_kwargs if is_installer else None,
+            returncode = returncode,
+            lines = lines,
+            on_start = on_start,
+            captured_kwargs = captured_kwargs,
             **kw,
         )
 
@@ -524,8 +525,11 @@ def test_a_second_spawn_during_the_update_does_not_overwrite_the_installer_argv(
     job = _run_start_update_to_completion()
     assert job["state"] == "success", job
     # Without the ps spawn the ordering this guards cannot happen, so a green
-    # run that never reached it would prove nothing.
+    # run that never reached it would prove nothing. It has to complete, not
+    # just start: a stand-in missing part of the Popen protocol raises into
+    # _pid_identity's bare except and disables the very lookup being exercised.
     assert any(cmd and cmd[0] == "ps" for cmd in spawned), spawned
+    assert process_lifetime._pid_identity(os.getpid()), "the ps lookup did not complete"
     assert "--install-dir" in captured["cmd"], captured["cmd"]
     assert str(install_dir) in captured["cmd"], captured["cmd"]
 


### PR DESCRIPTION
`test_start_update_happy_path` fails on macOS, and has since 2026-08-09:

```
AssertionError: assert '--install-dir' in ['ps', '-o', 'lstart=,comm=', '-p', '2770']
```

The update itself is fine. The same run logs the installer starting with the right arguments and finishing on the new tag:

```
llama update: installing  cmd='... install_llama_prebuilt.py --install-dir .../llama.cpp --llama-tag latest --published-repo unslothai/llama.cpp'
llama update: success     backend=None to_tag=b9518
```

Only the assertion is wrong.

## What happens

`_patch_installer_popen` does `monkeypatch.setattr(upd.subprocess, "Popen", ...)`. `subprocess` is a shared module object, so that replaces `Popen` for the whole process and the double fires `on_start` for every spawn. `on_start` writes `captured["cmd"] = cmd`, last one wins.

That was harmless when the phase spawned exactly one thing. #8170 changed it: `_run_llama_phase` now calls `adopt_pid(proc.pid)` right after starting the installer, which reaches `process_lifetime._pid_identity`. On Linux that reads `/proc/<pid>/stat` and spawns nothing, so the test passes. macOS has no `/proc` and shells out to `ps -o lstart=,comm= -p <pid>`, a second spawn, after the installer, which overwrites the capture.

| what | commit | PR | date |
| --- | --- | --- | --- |
| the test | `dab0b7767` | #6097 | 2026-06-10 |
| the process-wide `Popen` patch | `b2b1dcd6a` | #6196 | 2026-06-11 |
| `adopt_pid` plus the macOS `ps` branch | `c6ad59a7d` | #8170 | 2026-08-09 |

Nothing in CI runs `studio/backend/tests/` on macOS, so this only ever showed up running the suite locally on a Mac.

## Why the test, and not the code

`adopt_pid` and the `ps` identity check are right. A recorded pid has to be provably the same process before anything signals it, and on macOS `ps -o lstart=` is the only cheap source of that. Nothing there should change to suit a test double.

The fix is also already in the tree. `_patch_llama_installer` in `test_combined_update.py` gates on the installer command, added in #7095, a month before #8170 landed:

```python
# Only intercept the installer invocation: importing routes.inference inside
# the worker can Popen unrelated host probes (ldconfig etc).
is_installer = any("install_llama_prebuilt" in str(part) for part in cmd)
```

`test_llama_cpp_update.py` never got the same treatment. This applies it.

## Changes

- `_patch_installer_popen` only fires `on_start` and `captured_kwargs` for the installer command.
- `_FakeInstallerPopen` gains `__enter__` / `__exit__`. `subprocess.run` uses `with Popen(...)`, so without them a non-installer call raised `AttributeError` into `_pid_identity`'s bare `except Exception: return None`, silently disabling the identity check the fake had just intercepted.
- The helper can record every spawned argv, not just the last one. Last-wins capture is what let this hide for two months.
- A regression test that forces the macOS branch on a Linux host, so this is covered where CI actually runs.

No product code is touched.

## Verification

On `main`, with `process_lifetime.sys.platform` forced to `darwin`:

```
1 failed, 56 passed
```

After the change, forced and unforced:

```
57 passed
```

The new test was run against `main`'s unfixed helper first and fails there, so it is not a test that passes either way. It also asserts a `ps` spawn actually happened, so a green run cannot come from never reaching the ordering it guards.

`test_llama_cpp_update.py`, `test_combined_update.py` and `test_orphaned_children.py` together: 190 passed, 1 skipped.
