### PR TITLE
Run the llama.cpp keep-install back-compat tests on Windows

### DIFF
--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -67,6 +67,9 @@ on:
       - 'tests/python/test_cross_platform_parity.py'
       - 'tests/python/test_windows_python_venv_hardening.py'
       - 'tests/python/test_windows_setup_output_encoding.py'
+      # studio-backend-ci runs tests/studio/install on ubuntu only, so the windows
+      # row here is the sole place the keep path meets a real loader.
+      - 'tests/studio/install/test_keep_install_backcompat_9979.py'
       - 'tests/sh/test_install_rollback_lifecycle.sh'
       - 'tests/studio/test_install_rollback_lifecycle.ps1'
       - 'tests/studio/test_intel_registry_fallback.ps1'
@@ -124,6 +127,9 @@ on:
       - 'tests/python/test_cross_platform_parity.py'
       - 'tests/python/test_windows_python_venv_hardening.py'
       - 'tests/python/test_windows_setup_output_encoding.py'
+      # studio-backend-ci runs tests/studio/install on ubuntu only, so the windows
+      # row here is the sole place the keep path meets a real loader.
+      - 'tests/studio/install/test_keep_install_backcompat_9979.py'
       - 'tests/sh/test_install_rollback_lifecycle.sh'
       - 'tests/studio/test_install_rollback_lifecycle.ps1'
       - 'tests/studio/test_intel_registry_fallback.ps1'
@@ -212,6 +218,7 @@ jobs:
           tests/test_installer_system32_guard.py
           tests/test_installer_interactive_prompts.py
           tests/test_installer_profile_hardening.py
+          tests/studio/install/test_keep_install_backcompat_9979.py
           -q -rs
       - name: PowerShell rollback lifecycle tests
         if: runner.os == 'Windows'

--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -68,8 +68,11 @@ on:
       - 'tests/python/test_windows_python_venv_hardening.py'
       - 'tests/python/test_windows_setup_output_encoding.py'
       # studio-backend-ci runs tests/studio/install on ubuntu only, so the windows
-      # row here is the sole place the keep path meets a real loader.
+      # row here is the sole place the keep path meets a real loader. install_*.py
+      # above is only the entrypoint; these two are the rest of what it loads.
       - 'tests/studio/install/test_keep_install_backcompat_9979.py'
+      - 'studio/prebuilt_core.py'
+      - 'studio/backend/utils/prebuilt/llama_backend.py'
       - 'tests/sh/test_install_rollback_lifecycle.sh'
       - 'tests/studio/test_install_rollback_lifecycle.ps1'
       - 'tests/studio/test_intel_registry_fallback.ps1'
@@ -128,8 +131,11 @@ on:
       - 'tests/python/test_windows_python_venv_hardening.py'
       - 'tests/python/test_windows_setup_output_encoding.py'
       # studio-backend-ci runs tests/studio/install on ubuntu only, so the windows
-      # row here is the sole place the keep path meets a real loader.
+      # row here is the sole place the keep path meets a real loader. install_*.py
+      # above is only the entrypoint; these two are the rest of what it loads.
       - 'tests/studio/install/test_keep_install_backcompat_9979.py'
+      - 'studio/prebuilt_core.py'
+      - 'studio/backend/utils/prebuilt/llama_backend.py'
       - 'tests/sh/test_install_rollback_lifecycle.sh'
       - 'tests/studio/test_install_rollback_lifecycle.ps1'
       - 'tests/studio/test_intel_registry_fallback.ps1'

--- a/tests/studio/install/test_keep_install_backcompat_9979.py
+++ b/tests/studio/install/test_keep_install_backcompat_9979.py
@@ -10,18 +10,66 @@ hand-built two-key marker; these call the deciders directly with the shapes real
 carry.
 
 Platforms are simulated through ``HostInfo`` as the rest of this suite does. That covers
-the path decisions and payload tables, not the Windows loader or macOS dyld.
+the path decisions and payload tables, not macOS dyld.
+
+Run natively on Windows too (the parity workflow's windows-latest row), where the loader
+answers for real: ``_binary_image_runs`` sees an actual ``ERROR_BAD_EXE_FORMAT`` instead of
+a stubbed ``run_capture``. Two things stay POSIX-only there and are skipped rather than
+weakened: ``os.chmod`` cannot clear an execute bit Windows does not have, and
+``os.access(X_OK)`` is true for any file that exists.
 """
 
 import importlib.util
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
+
+WINDOWS_HOST = os.name == "nt"
+# os.access(path, os.X_OK) answers "does this exist" on Windows, so the executable=False
+# trees below are indistinguishable from healthy ones there.
+SKIP_X_OK = pytest.mark.skipif(
+    WINDOWS_HOST,
+    reason = "os.access(X_OK) is always true on Windows, so the guard is POSIX only",
+)
+
+
+def _windows_runnable_stub() -> bytes | None:
+    """Bytes of a real .exe that still starts after being copied somewhere else.
+
+    The keep path execs what it finds, so a Windows row needs a genuine PE. Copying
+    python.exe alone loses python3xx.dll and dies 0xC0000135, hence a System32 tool
+    whose imports are all KnownDLLs. Verified by running the copy, not assumed: an
+    unverifiable stub skips the module instead of reporting the loader's refusal as
+    a back-compat failure.
+    """
+    for name in ("where.exe", "hostname.exe"):
+        source = Path(os.environ.get("SystemRoot", r"C:\Windows")) / "System32" / name
+        if not source.is_file():
+            continue
+        with tempfile.TemporaryDirectory() as probe_dir:
+            copy = Path(probe_dir) / "llama-server.exe"
+            try:
+                shutil.copyfile(source, copy)
+                subprocess.run([str(copy)], capture_output = True, timeout = 30)
+            except Exception:
+                continue
+        return source.read_bytes()
+    return None
+
+
+RUNNABLE_STUB = _windows_runnable_stub() if WINDOWS_HOST else None
+if WINDOWS_HOST and RUNNABLE_STUB is None:
+    pytest.skip(
+        "no self-contained System32 .exe to stand in for llama-server",
+        allow_module_level = True,
+    )
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[3]
@@ -141,9 +189,13 @@ def build_install(
             if path.parent != install_dir
             else (runnable if runnable_root is None else runnable_root)
         )
-        # A real runnable stub: the keep path execs these, and an empty file that kept
-        # its mode bits is the ENOEXEC case.
-        path.write_text("#!/bin/sh\nexit 0\n" if ok else "", encoding = "utf-8")
+        # A real runnable stub: the keep path execs these. The not-ok file is the bad
+        # image case, ENOEXEC on POSIX and a genuine ERROR_BAD_EXE_FORMAT on Windows,
+        # where an empty file is instead a valid do-nothing program.
+        if WINDOWS_HOST:
+            path.write_bytes(RUNNABLE_STUB if ok else b"not a PE image\n")
+        else:
+            path.write_text("#!/bin/sh\nexit 0\n" if ok else "", encoding = "utf-8")
         os.chmod(path, 0o755 if executable else 0o644)
     (install_dir / "convert_hf_to_gguf.py").write_text("", encoding = "utf-8")
     (install_dir / "gguf-py").mkdir()
@@ -461,6 +513,7 @@ def test_a_windows_loader_failure_is_rejected_even_though_it_exits_zero_ish(tmp_
     assert ILP._existing_install_runs(install_dir, WINDOWS) is False
 
 
+@SKIP_X_OK
 def test_a_non_executable_tree_fails_the_same_gate_setup_sh_uses(tmp_path):
     """setup.sh reuses on ``[ -x build/bin/llama-server ]``; the keep path must agree."""
     install_dir = build_install(

--- a/tests/studio/install/test_keep_install_backcompat_9979.py
+++ b/tests/studio/install/test_keep_install_backcompat_9979.py
@@ -57,8 +57,13 @@ def _windows_runnable_stub() -> bytes | None:
             copy = Path(probe_dir) / "llama-server.exe"
             try:
                 shutil.copyfile(source, copy)
-                subprocess.run([str(copy)], capture_output = True, timeout = 30)
+                probe = subprocess.run([str(copy)], capture_output = True, timeout = 30)
             except Exception:
+                continue
+            # A loader failure returns rather than raises, so an unchecked run would
+            # accept the very missing-DLL image this is picking a candidate to avoid,
+            # and every healthy fixture after it would inherit it.
+            if probe.returncode >= 0xC0000000:
                 continue
         return source.read_bytes()
     return None


### PR DESCRIPTION
`studio-backend-ci.yml` runs `tests/studio/install/` on `ubuntu-latest` only, both jobs. The keep-path back-compat matrix added in #9979 simulates Windows by injecting `HostInfo(is_windows=True)` on Linux, which is the right pattern for the path decisions and payload tables but proves nothing about the Windows loader. So the installer keep path is currently unverified on Windows rather than verified working.

Running those files on a real `windows-latest` runner produced 76 failures: 43 in `test_install_llama_prebuilt_logic.py` and 33 in `test_keep_install_backcompat_9979.py`.

## The two failure classes are not the same thing

**A fixture artifact.** `build_install` writes `#!/bin/sh\nexit 0\n` into a file named `llama-server.exe`. Windows refuses it with `ERROR_BAD_EXE_FORMAT`, `_binary_image_runs` correctly reports "not an executable image", and every healthy-install case fails. The fixture is wrong here, not the product.

**A real platform difference.** `os.access(path, os.X_OK)` returns true for any file that exists on Windows, and `os.chmod` cannot clear an execute bit Windows does not have. So the `executable=False` trees are indistinguishable from healthy ones there, and the `X_OK` gate in `_existing_install_runs` does nothing on that platform. That gets labelled, not silently skipped.

## Changes

`tests/studio/install/test_keep_install_backcompat_9979.py`:

- On Windows, healthy binaries are a real PE copied from System32 and bad ones are deliberate non-PE bytes. `_binary_image_runs` then sees a genuine `ERROR_BAD_EXE_FORMAT` from `CreateProcess` instead of a stubbed `run_capture`. That branch and the `0xC0000135` one are structurally unreachable on Linux: `OSError.winerror` does not exist there, and a POSIX exit status cannot reach `0xC0000000`.
- The stub is verified by running the copy at import rather than assumed. Copying `python.exe` alone would lose `python3xx.dll` and die `0xC0000135`, hence a System32 tool whose imports are all KnownDLLs. If no candidate starts, the module skips with a clear reason instead of reporting the loader's refusal as a back-compat failure.
- The one `executable=False` case is skipped on Windows, reusing the reason already in `test_install_whisper_prebuilt_logic.py`:

```python
reason = "os.access(X_OK) is always true on Windows, so the guard is POSIX only"
```

`.github/workflows/cross-platform-parity-ci.yml`:

- adds the file to the pytest list and to both `paths:` blocks.

## Why this workflow, and why only this file

The parity job is already `windows-latest`, already capped at 10 minutes, already installs a superset of what these tests need, already runs with `-rs` so a silently skipped case is visible, and its `paths:` filter already includes `studio/install_*.py`, so the module under test triggers it today. Its Windows row runs in about 1m40s. Every other Windows job in the repo is a full-install smoke test measured in tens of minutes.

`test_install_llama_prebuilt_logic.py` is deliberately left out. It has 11 symlink sites, 22 shebangs and tests that shell out to `bash` (which on `windows-latest` resolves to a WSL stub), and it already carries per-case Windows guards. It is POSIX by design and forcing it onto Windows is a large fight for little signal.

## What this still does not prove

Worth being precise, because the point of the change is to stop overstating coverage. Still unverified on real Windows after this: DLL and cudart loading and the `0xC0000135` path, ACL and denied-file semantics, `binary_env`'s `PATH` construction (on Linux `os.pathsep` is `":"`, so the Windows branch builds a colon-joined PATH and asserts nothing about the real one), NTFS case-insensitive `glob` in `_runtime_payload_has`, and long-path `.exists()` behaviour.

The narrow claim: the keep-path back-compat matrix runs for real on Windows, and bad-image rejection is genuinely exercised there.

## Verification

Linux is unchanged, 96 passed before and after with zero new skips. The parity job's own suite plus this file: 174 passed.

The Windows row wants reading rather than trusting once this is up. A green job with the file silently skipped is a failure, not a pass; the `-rs` summary should show only the labelled `X_OK` case.
