### PR TITLE
Reduce the comments added by PR #9979

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -630,9 +630,7 @@ def _apply_seeded_llama_request(payload: dict, seed: Optional[int]) -> None:
     if seed is None:
         return
     payload["seed"] = seed
-    # llama.cpp reads the seed as uint32 and LLAMA_DEFAULT_SEED is 0xFFFFFFFF, so -1 and
-    # 4294967295 are the same "pick one at random" and both keep cache reuse. Compared in
-    # that domain rather than against the -1 literal, which the schemas also accept above.
+    # Compared as uint32: the schemas also accept 4294967295, the same "pick at random".
     if (seed & 0xFFFFFFFF) != _LLAMA_RANDOM_SEED:
         payload["cache_prompt"] = False
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -627,15 +627,12 @@ def _choice_seed(
     """A seed of its own per choice, so a seeded request samples n times rather
     than repeating one run. Shared by both drains so they cannot disagree.
 
-    llama-server reads the seed as a uint32 and draws at random for exactly one
-    value, LLAMA_DEFAULT_SEED (0xFFFFFFFF). Every seed congruent to it is that
-    sentinel, not just ``-1``: the schemas above also accept ``4294967295`` and
-    ``2**64-1``. Tested in that domain to match ``_apply_seeded_llama_request``,
-    since a literal ``-1`` left choice 0 random and cached while choice 1 was
-    offset into a fixed, uncached seed. Every other negative is an ordinary fixed
-    seed and must be offset, or all n choices repeat one run; offsetting in the
-    same domain cannot land on the sentinel. MLX maps every seed onto its key
-    domain, so nothing is exempt there.
+    llama-server reads the seed as a uint32 and draws at random for exactly one value,
+    LLAMA_DEFAULT_SEED (0xFFFFFFFF), so every congruent seed is that sentinel, not just
+    ``-1`` (the schemas above also accept ``4294967295``); testing a literal ``-1`` left
+    choice 0 random and cached while choice 1 was offset into a fixed, uncached seed. Every
+    other negative is an ordinary fixed seed and must be offset, and offsetting in the same
+    domain cannot land on the sentinel. MLX maps every seed onto its key domain.
     """
     if seed is None or not choice_index:
         return seed

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -197,8 +197,7 @@ def test_plain_fixed_seed_disables_slot_prompt_cache_reuse(monkeypatch):
 
 
 def test_the_uint32_random_seed_sentinel_also_keeps_cache_reuse(monkeypatch):
-    """llama.h defines LLAMA_DEFAULT_SEED as 0xFFFFFFFF and the seed is read as uint32, so
-    4294967295 is the same "pick one at random" as -1 and must keep prompt-cache reuse."""
+    """llama.h defines LLAMA_DEFAULT_SEED as 0xFFFFFFFF read as uint32, so 4294967295 is the same "pick one at random" as -1 and must keep prompt-cache reuse."""
     payloads: list[dict] = []
     backend = _make_backend(
         monkeypatch,

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -676,8 +676,7 @@ def test_an_update_that_kept_the_existing_install_does_not_claim_a_new_release(
         lambda repo, timeout = 5.0: "b9596-mix-e6f2453",
     )
 
-    # macOS is the reachable case: start_update passes no pin there, so the pinned-tag
-    # mismatch guard that catches this elsewhere does not run.
+    # macOS is the reachable case: no pin is passed there, so the mismatch guard is silent.
     monkeypatch.setattr(upd.sys, "platform", "darwin")
 
     # Exit 0 having changed nothing, which is what the keep path does.

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -658,14 +658,10 @@ def test_start_update_reports_full_release_tag(monkeypatch, tmp_path):
 def test_an_update_that_kept_the_existing_install_does_not_claim_a_new_release(
     monkeypatch, tmp_path
 ):
-    """Exit 0 no longer implies the release changed.
-
-    The installer answers a transient failure by keeping the tree on disk and
-    exiting 0, so "Updated llama.cpp to <tag>" would name the release the user
-    already had. The phase only starts when a newer release was offered, so
-    reporting the kept release as current would be just as wrong: the update is
-    still pending and the user has to retry.
-    """
+    """Exit 0 no longer implies the release changed: the installer answers a transient
+    failure by keeping the tree and exiting 0, so "Updated llama.cpp to <tag>" would name
+    the release the user already had. Reporting it as current is just as wrong, since the
+    phase only starts when a newer release was offered and the retry is still pending."""
     install_dir = tmp_path / "llama.cpp"
     binary = _write_install(install_dir, "b9595", release_tag = "b9595-mix-aaaaaaa")
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -10299,14 +10299,10 @@ def test_every_gguf_choice_gets_a_seed_of_its_own():
 
 
 def test_the_two_seed_helpers_agree_on_which_seeds_are_random():
-    """``-1`` is not the only request seed that reaches LLAMA_DEFAULT_SEED.
-
-    The seed is a uint32 there, so ``-1``, ``4294967295`` and ``2**64-1`` are all
-    the sentinel and all draw at random; the schemas accept all three. Both
-    helpers must agree, or one request disagrees with itself: choice 0 keeps the
-    caller's random seed while choice 1 is offset into a fixed one, so half the
-    choices are reproducible and only half disable prompt caching.
-    """
+    """``-1`` is not the only request seed that reaches LLAMA_DEFAULT_SEED: the seed is a
+    uint32 there, so ``-1``, ``4294967295`` and ``2**64-1`` are all the sentinel and the
+    schemas accept all three. Both helpers must agree, or choice 0 keeps the caller's random
+    seed while choice 1 is offset into a fixed one, half reproducible and half uncached."""
     from core.inference.llama_cpp import _LLAMA_RANDOM_SEED, _apply_seeded_llama_request
     from routes.inference import _choice_seed
 

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -10314,14 +10314,11 @@ def test_the_two_seed_helpers_agree_on_which_seeds_are_random():
         served = [_choice_seed(seed, i, negative_is_random = True) for i in range(3)]
         assert all((v & 0xFFFFFFFF) == _LLAMA_RANDOM_SEED for v in served), (seed, served)
 
-        # And the cache policy must reach the same verdict for every choice.
         for value in served:
             payload: dict = {}
             _apply_seeded_llama_request(payload, value)
             assert "cache_prompt" not in payload, (seed, value, payload)
 
-    # The converse: a fixed seed stays fixed for every choice, and every choice
-    # turns the cache off.
     for seed in (0, 5, 4294967294):
         served = [_choice_seed(seed, i, negative_is_random = True) for i in range(3)]
         assert all((v & 0xFFFFFFFF) != _LLAMA_RANDOM_SEED for v in served), (seed, served)

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -613,10 +613,8 @@ def _run_llama_phase(
     backend = None
     model_was_active = False
     mtmd_guard = ExitStack()
-    # The installer now exits 0 for a transient failure it answered by keeping the
-    # existing tree, so success no longer implies the release changed. Read the same way
-    # as the post-install check so the two tags compare. Mainly a macOS case: the update
-    # path passes no pin there, so it does not disqualify itself from the keep branch.
+    # The installer exits 0 for a transient failure it answered by keeping the tree, so
+    # success no longer implies a new release. Read as the post-install check reads it.
     prior_marker = read_install_marker(_find_binary())
     prior_tag = (prior_marker or {}).get("release_tag") or (prior_marker or {}).get("tag")
     try:
@@ -733,10 +731,8 @@ def _run_llama_phase(
         if backend_request is not None:
             message = f"llama.cpp is now running on {new_backend or backend_request}.{reload_hint}"
         elif kept_existing:
-            # The phase only runs when a newer release was offered, so this is a failed
-            # update the installer answered by keeping the tree, not a current install.
-            # Naming the old release either way sends the user looking for a fix that
-            # shipped in the new one.
+            # The phase only runs when a newer release was offered, so naming the kept
+            # release as current would send the user looking for a fix it does not have.
             message = (
                 f"llama.cpp could not be updated right now, so the existing {new_tag} "
                 "install was kept. Try again later."

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -241,7 +241,6 @@ export function McpComposerButton({
     }
   }
 
-  // Keep the tooltip anchor pointer-events-none so it cannot swallow row clicks.
   const renderRow = (opts: {
     key: string;
     label: string;
@@ -285,6 +284,7 @@ export function McpComposerButton({
           <TooltipTrigger asChild={true}>
             <span
               aria-hidden={true}
+              // pointer-events-none so the anchor cannot swallow row clicks.
               className="pointer-events-none absolute inset-y-0 right-0 w-0"
             />
           </TooltipTrigger>
@@ -400,10 +400,8 @@ export function McpComposerButton({
 export function McpServersDialogMount() {
   const open = useMcpServersDialogStore((s) => s.open);
   const setOpen = useMcpServersDialogStore((s) => s.setOpen);
-  // Server configuration does not require tool support from the loaded model.
   const chatActive = useChatActive();
   useShortcut("openMcpServers", () => setOpen(true), { enabled: chatActive });
-  // Clear the shared open state when leaving chat.
   useEffect(() => {
     if (!chatActive && open) setOpen(false);
   }, [chatActive, open, setOpen]);

--- a/studio/frontend/tests/mcp-server-arguments.test.ts
+++ b/studio/frontend/tests/mcp-server-arguments.test.ts
@@ -387,7 +387,6 @@ test("MCP configuration remains reachable when the loaded model lacks tools", ()
 
   assert.doesNotMatch(composer, /aria-disabled=\{true\}/);
   assert.match(composer, /The loaded model cannot use MCP tools/);
-  // Presets remain configurable without a loaded model.
   assert.doesNotMatch(composer, /disabled=\{[^}]*!usable/);
   assert.match(
     composer,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6920,6 +6920,7 @@ def _kept_install_payload_is_healthy(install_dir: Path, host: HostInfo) -> bool:
         kind for kind in install_kinds_for_backend(backend) if kind.startswith(platform_prefix)
     )
     if not kinds:
+        # An unknown backend still owes the payload every kind on this platform shares.
         kinds = sorted(kind for kind in INSTALL_KIND_BACKENDS if kind.startswith(platform_prefix))
     if not kinds:
         return True
@@ -6957,17 +6958,14 @@ def _binary_image_runs(
     host: HostInfo,
     runtime_line: str | None = None,
 ) -> bool:
-    """Whether the OS will actually start ``path``.
-
-    ``os.access`` asks "may I execute this", not "is this an executable": a truncated file
-    keeps its mode bits and ``ldd`` on a non-ELF only says it is not a dynamic executable.
-    execve sees it -- measured on Linux, zero-byte and non-ELF both raise ENOEXEC.
-
-    The exit code is NOT the verdict: llama-quantize answers ``--version`` by printing its
-    table and exiting non-zero, the same reason ``macos_dyld_load_issues`` reads output. So
-    a timeout, a failed spawn or an ordinary non-zero exit all read as healthy, because a
-    false positive here spends a source build on a working install.
-    """
+    """Whether the OS will actually start ``path``. ``os.access`` asks "may I execute this", not
+    "is this an executable": a truncated file keeps its mode bits and ``ldd`` on a non-ELF only
+    says it is not a dynamic executable, while execve raises ENOEXEC (measured on Linux, for
+    zero-byte and non-ELF alike). The exit code is NOT the verdict: llama-quantize answers
+    ``--version`` by printing its table and exiting non-zero, the same reason
+    ``macos_dyld_load_issues`` reads output. So a timeout, a failed spawn or an ordinary
+    non-zero exit all read as healthy, since a false positive spends a source build on a
+    working install."""
     try:
         result = run_capture(
             [str(path), "--version"],
@@ -7999,8 +7997,9 @@ def install_prebuilt(
         normalized_requested_llama_tag(llama_tag) != "latest"
         or bool((published_release_tag or "").strip())
         or (bool((published_repo or "").strip()) and published_repo != DEFAULT_PUBLISHED_REPO)
-        # --has-rocm and --rocm-gfx deliberately do not count: both setup entrypoints
-        # forward their DETECTED GPU on every AMD host, so counting them loses them all.
+        # --cpu-fallback is setup.sh's deliberate arm64 recovery, so it counts. --has-rocm
+        # and --rocm-gfx do not: both entrypoints forward a DETECTED GPU on every AMD host,
+        # so counting them would take the keep path away from all of them.
         or force_cpu
     )
     # The failure handler can run before selection assigns these.

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6467,7 +6467,6 @@ def write_prebuilt_metadata(
         # the arch, and a stale copy would outlive its GPU.
         **({"rocm_gfx": rocm_gfx} if rocm_gfx and _persisted_backend == "auto" else {}),
         "asset_sha256": choice.expected_sha256,
-        # Records whether this install includes the paired Windows cudart archive.
         "runtime_asset": choice.runtime_name,
         "source": choice.source_label,
         # Binary-side repo/tag for non-fork sources (e.g. the ggml-org upstream
@@ -6635,10 +6634,7 @@ def _marker_selection_patch(
     sms = [str(s).strip() for s in (choice.supported_sms or []) if str(s).strip()]
     if sms and marker.get("supported_sms") != sms:
         patch["supported_sms"] = sms
-    # Same shape as the targets above: the paired cudart archive is in the fingerprint but
-    # not readable back out of it, so an install predating the field only gains it here.
-    # Set, never cleared: reuse requires a fingerprint match, so a bundle with no pair is
-    # one the marker already describes as pair-less.
+    # Set, never cleared: reuse needs a fingerprint match, so a pair-less bundle matches.
     if choice.runtime_name and marker.get("runtime_asset") != choice.runtime_name:
         patch["runtime_asset"] = choice.runtime_name
     return patch
@@ -6924,7 +6920,6 @@ def _kept_install_payload_is_healthy(install_dir: Path, host: HostInfo) -> bool:
         kind for kind in install_kinds_for_backend(backend) if kind.startswith(platform_prefix)
     )
     if not kinds:
-        # Unknown markers still owe the payload shared by every kind on this platform.
         kinds = sorted(kind for kind in INSTALL_KIND_BACKENDS if kind.startswith(platform_prefix))
     if not kinds:
         return True
@@ -6945,16 +6940,14 @@ def _kept_install_payload_is_healthy(install_dir: Path, host: HostInfo) -> bool:
     return _runtime_payload_has(install_dir, host, [list(group) for group in sorted(shared)])
 
 
-# Broken image, not something intervening: SIGKILL is absent because it is an OOM.
+# SIGKILL is absent: that is an OOM, not a broken image.
 _BROKEN_IMAGE_SIGNALS = frozenset(
     {signal.SIGSEGV, signal.SIGILL, signal.SIGFPE}
     | ({signal.SIGBUS} if hasattr(signal, "SIGBUS") else set())
 )
 # Windows' "%1 is not a valid Win32 application", its answer to a corrupt image.
 _ERROR_BAD_EXE_FORMAT = 193
-# A Windows loader failure is not a signal: CreateProcess succeeds and the process exits
-# the NTSTATUS (0xC0000135 missing DLL), which Python reports as a large POSITIVE code.
-# Unreachable on POSIX, where an exit status is 0-255, so no host guard is needed.
+# A Windows loader failure is not a signal: it exits the NTSTATUS (0xC0000135) positive.
 _NTSTATUS_FAILURE_FLOOR = 0xC0000000
 
 
@@ -6979,8 +6972,8 @@ def _binary_image_runs(
         result = run_capture(
             [str(path), "--version"],
             timeout = 60,
-            # runtime_line as validate_prebuilt_choice passes it: it is what puts the
-            # CUDA toolkit on PATH, and a pair-less Windows install dies 0xC0000135 without it.
+            # runtime_line puts the CUDA toolkit on PATH; a pair-less Windows install
+            # cannot start without it.
             env = binary_env(path, install_dir, host, runtime_line = runtime_line),
         )
     except OSError as exc:
@@ -7019,9 +7012,8 @@ def _existing_install_runs(install_dir: Path, host: HostInfo) -> bool:
         preflight_macos_installed_binaries(binaries, install_dir, host)
     except Exception:
         return False
-    # Root copies first: _find_llama_server_binary searches <install>/llama-server BEFORE
-    # build/bin, so that is what inference launches. resolve() collapses the usual symlink;
-    # when symlinking was unavailable it is a separate file that can rot alone.
+    # Root copies first: _find_llama_server_binary reaches them first, and without a
+    # symlink they can rot alone.
     probes: list[Path] = []
     seen: set[Path] = set()
     for binary in [install_dir / p.name for p in binaries] + binaries:
@@ -7035,8 +7027,6 @@ def _existing_install_runs(install_dir: Path, host: HostInfo) -> bool:
             continue
         seen.add(key)
         probes.append(binary)
-    # Last, because it is the only check that spawns anything: neither preflight runs on
-    # Windows, and on Linux ldd cannot see a file that is not an executable image at all.
     return all(
         _binary_image_runs(binary, install_dir, host, recorded_runtime_line) for binary in probes
     )
@@ -8004,18 +7994,13 @@ def install_prebuilt(
 ) -> None:
     choice: AssetChoice | None = None
     # Anything this RUN asked for that keeping the old tree would silently ignore. Read
-    # from the parameters before the body mutates them (force_cpu becomes True further
-    # down for a stored "cpu" choice, which is the opposite of a request made here).
-    # backend_mandatory joins it in the handler, because it is only known after the
-    # marker is read; it starts False, so a failure before that keeps today's behaviour.
+    # before the body mutates force_cpu, which it sets True for a stored "cpu" choice.
     explicit_version_request = (
         normalized_requested_llama_tag(llama_tag) != "latest"
         or bool((published_release_tag or "").strip())
         or (bool((published_repo or "").strip()) and published_repo != DEFAULT_PUBLISHED_REPO)
-        # --cpu-fallback only ever arrives from setup.sh's deliberate arm64 recovery, so
-        # it is a mechanism this run chose. --has-rocm and --rocm-gfx are NOT: both setup
-        # entrypoints forward their DETECTED GPU on every AMD host, so counting them here
-        # would take the keep path away from essentially every AMD update.
+        # --has-rocm and --rocm-gfx deliberately do not count: both setup entrypoints
+        # forward their DETECTED GPU on every AMD host, so counting them loses them all.
         or force_cpu
     )
     # The failure handler can run before selection assigns these.
@@ -8284,8 +8269,7 @@ def install_prebuilt(
         # A stored choice that could not be served was already replaced by "auto"
         # above, so a concrete name here is one this run must not walk away from.
         preserve_backend = backend in CONCRETE_BACKENDS and host is not None and not host.is_macos
-        # A stored preference may reuse a matching install. A backend requested on this
-        # run must still be satisfied by this run.
+        # A stored preference may reuse a matching install; one requested on this run may not.
         satisfied_stored_backend = (
             preserve_backend
             and not backend_mandatory
@@ -8294,9 +8278,7 @@ def install_prebuilt(
         if (
             (not preserve_backend or satisfied_stored_backend)
             and not explicit_version_request
-            # A backend named on this run is a live instruction even when it is "auto":
-            # that asks for re-detection, and answering it with the tree already on disk
-            # leaves both the old backend and its marker exactly as they were.
+            # Even "auto" is a live instruction: it asks for re-detection.
             and not backend_mandatory
             and host is not None
             and _existing_install_runs(install_dir, host)

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -5603,7 +5603,6 @@ def test_release_listing_failure_exits_fallback_not_error(tmp_path, monkeypatch,
     assert caught.value.code == INSTALL_LLAMA_PREBUILT.EXIT_FALLBACK
 
 
-# Shared platform payload plus any files required by a named backend.
 _SHARED_PAYLOAD = {
     "linux": [
         "libllama-common.so",
@@ -5619,8 +5618,6 @@ _BACKEND_PAYLOAD = {
     ("windows", "cuda"): ["ggml-cuda.dll"],
     ("linux", "vulkan"): ["libggml-vulkan.so"],
 }
-# Only a published bundle owes this one, which is why the marker's source label has to
-# reach runtime_payload_health_groups.
 _PUBLISHED_PAYLOAD = {"linux": ["llama-diffusion-gemma-visual-server"]}
 
 
@@ -5671,24 +5668,19 @@ def _complete_existing_llama_install(
         elif path.name == "UNSLOTH_PREBUILT_INFO.json":
             path.write_text(json.dumps(marker) + "\n", encoding = "utf-8")
         elif path.name.startswith("llama-"):
-            # The root copy is what _find_llama_server_binary reaches first, and it can
-            # rot alone when symlinking was unavailable.
             ok = (
                 runnable
                 if path.parent != install_dir
                 else (runnable if runnable_root is None else runnable_root)
             )
-            # A runnable stub, not an empty file: the kept-install check execs these, and
-            # a zero-byte file that kept its mode bits is the ENOEXEC case below.
+            # These get exec'd; a zero-byte file that kept its mode bits is ENOEXEC.
             path.write_text("#!/bin/sh\nexit 0\n" if ok else "", encoding = "utf-8")
-            # Match setup.sh's executable reuse gate.
             os.chmod(path, 0o755 if executable else 0o644)
         else:
             path.write_text("", encoding = "utf-8")
             os.chmod(path, 0o755 if executable else 0o644)
     platform = "windows" if windows else "linux"
     if payload:
-        # Complete installs always carry the shared platform payload.
         for name in _SHARED_PAYLOAD[platform]:
             (runtime_dir / name).write_text("", encoding = "utf-8")
         for name in _BACKEND_PAYLOAD.get((platform, backend), ()):
@@ -5994,8 +5986,7 @@ def test_the_probe_gets_the_runtime_line_the_marker_recorded(tmp_path, monkeypat
 
     install_prebuilt(install_dir, "latest", "unslothai/llama.cpp", "")
 
-    # preflight_linux_installed_binaries also builds an env and correctly passes none,
-    # since it only matters on Windows; what is asserted is that the probe kept it.
+    # preflight_linux_installed_binaries also builds an env and correctly passes none.
     assert (
         "cuda-12.4" in seen
     ), f"the kept-install probe built its env without the marker's runtime_line: {seen}"

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3083,13 +3083,10 @@ def test_every_reuse_path_syncs_the_arch_coverage():
 
 @pytest.mark.parametrize("visual_server", [True, False], ids = ["present", "missing"])
 def test_a_published_bundle_owes_its_visual_server(tmp_path, monkeypatch, visual_server):
-    """The marker's source label decides, exactly as it does on the canonical reuse path.
-
-    runtime_payload_health_groups only adds llama-diffusion-gemma-visual-server for a
-    published bundle, so omitting the label let an incomplete published Vulkan tree read
-    as validated. setup.sh's source build has its own target for the binary, so exit 2 is
-    a recovery here rather than a detour.
-    """
+    """The marker's source label decides, exactly as on the canonical reuse path.
+    runtime_payload_health_groups only adds llama-diffusion-gemma-visual-server for a published
+    bundle, so omitting the label let an incomplete published Vulkan tree read as validated.
+    setup.sh's source build has its own target for the binary, so exit 2 is a recovery here."""
     _listing_failure(monkeypatch, linux_host)
     install_dir = _complete_existing_llama_install(
         tmp_path, backend = "vulkan", source = "published", visual_server = visual_server
@@ -3116,12 +3113,10 @@ def test_an_upstream_bundle_does_not_owe_a_visual_server(tmp_path, monkeypatch):
 
 
 def test_a_reused_install_backfills_the_paired_runtime_asset(tmp_path: Path):
-    """An install predating runtime_asset only gains it on the reuse path.
-
-    The pairing is in install_fingerprint, but that is a hash: the kept-install payload
-    check reads the field, so without this backfill a paired Windows CUDA tree stays
-    "pair-less" forever and its cudart trio is never required.
-    """
+    """An install predating runtime_asset only gains it on the reuse path. The pairing is in
+    install_fingerprint, but that is a hash: the kept-install payload check reads the field, so
+    without this backfill a paired Windows CUDA tree stays "pair-less" forever and its cudart
+    trio is never required."""
     install_dir = tmp_path / "llama.cpp"
     install_dir.mkdir()
     marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"

--- a/tests/studio/install/test_keep_install_backcompat_9979.py
+++ b/tests/studio/install/test_keep_install_backcompat_9979.py
@@ -142,7 +142,6 @@ _BACKEND_PAYLOAD = {
     ("windows", "rocm"): ["ggml-hip.dll"],
     ("windows", "vulkan"): ["ggml-vulkan.dll"],
 }
-# Only a published bundle owes the visual server.
 _PUBLISHED_PAYLOAD = {
     "linux": ["llama-diffusion-gemma-visual-server"],
     "windows": ["llama-diffusion-gemma-visual-server.exe"],
@@ -194,9 +193,8 @@ def build_install(
             if path.parent != install_dir
             else (runnable if runnable_root is None else runnable_root)
         )
-        # A real runnable stub: the keep path execs these. The not-ok file is the bad
-        # image case, ENOEXEC on POSIX and a genuine ERROR_BAD_EXE_FORMAT on Windows,
-        # where an empty file is instead a valid do-nothing program.
+        # The keep path execs these. The not-ok file has to be a bad image: ENOEXEC on
+        # POSIX, a non-PE on Windows, where an empty file is a valid do-nothing program.
         if WINDOWS_HOST:
             path.write_bytes(RUNNABLE_STUB if ok else b"not a PE image\n")
         else:
@@ -229,8 +227,7 @@ def build_install(
     return install_dir
 
 
-# The twelve marker shapes, oldest first, as write_prebuilt_metadata wrote them,
-# trimmed to the keys the keep path reads.
+# The shipped marker shapes, oldest first, trimmed to the keys the keep path reads.
 
 S1 = {  # 2026-03-25 #4562: no release_tag, no backend, no asset_sha256
     "requested_tag": "b6099",
@@ -560,14 +557,6 @@ def test_the_stored_backend_choice_reads_the_same_from_every_shape(tmp_path, mar
     assert ILP.persisted_backend_request(install_dir) == expected
 
 
-# ---------------------------------------------------------------------------
-# The [Windows, Linux, WSL, macOS] x [NVIDIA, AMD, CPU-only] product, through the
-# same two deciders. Hosts are simulated by HostInfo, which is what the deciders
-# branch on, so these prove the payload tables and the platform-prefix filtering,
-# not the Windows loader or macOS dyld. WSL gets its own row because "WSL is just
-# Linux here" is the claim worth pinning.
-# ---------------------------------------------------------------------------
-
 ARM64_LINUX = _host(machine = "aarch64", is_x86_64 = False, is_arm64 = True)
 MACOS_X64 = _host(
     system = "Darwin",
@@ -613,7 +602,6 @@ WINDOWS_ROCM = _host(
     rocm_gfx_target = "gfx1151",
 )
 
-# (id, host, marker backend, the payload the tree must carry to be kept)
 MATRIX = [
     ("linux-nvidia", LINUX_NVIDIA, "cuda", "cuda"),
     ("linux-arm64-nvidia", ARM64_LINUX, "cuda", "cuda"),
@@ -755,10 +743,6 @@ def test_an_install_whose_keys_were_backfilled_onto_an_old_marker_is_kept(tmp_pa
     assert ILP._existing_install_runs(install_dir, LINUX) is True
 
 
-# Forwards compatibility through install_prebuilt, so the exit code the setup
-# scripts branch on is what is under test.
-
-
 def _transient_listing_failure(monkeypatch, host = LINUX):
     """Make the release listing fail the way a flaky network does."""
     import urllib.error
@@ -786,7 +770,6 @@ def test_a_marker_from_a_newer_unsloth_refuses_rather_than_keeping(tmp_path, mon
     with pytest.raises(SystemExit) as caught:
         ILP.install_prebuilt(install_dir, "latest", "unslothai/llama.cpp", "")
     assert caught.value.code == ILP.EXIT_ERROR
-    # And the install is left alone for a newer Unsloth to find.
     assert (install_dir / "llama-server").exists()
 
 

--- a/tests/studio/install/test_keep_install_backcompat_9979.py
+++ b/tests/studio/install/test_keep_install_backcompat_9979.py
@@ -4,13 +4,10 @@
 """Back-compat for the kept-install path against every marker shape that has shipped.
 
 ``UNSLOTH_PREBUILT_INFO.json`` is append-only across twelve shapes with no version field
-and no migration, so an absent key is the normal case for anything installed before the
-release that added it. The existing keep-path tests drive ``install_prebuilt`` with a
-hand-built two-key marker; these call the deciders directly with the shapes real installs
-carry.
-
-Platforms are simulated through ``HostInfo`` as the rest of this suite does. That covers
-the path decisions and payload tables, not macOS dyld.
+and no migration, so an absent key is normal for anything older. These call the deciders
+directly with the shapes real installs carry, rather than driving ``install_prebuilt``
+with a hand-built two-key marker. Platforms are simulated through ``HostInfo``: that
+covers the path decisions and payload tables, not macOS dyld.
 
 Run natively on Windows too (the parity workflow's windows-latest row), where the loader
 answers for real: ``_binary_image_runs`` sees an actual ``ERROR_BAD_EXE_FORMAT`` instead of
@@ -167,11 +164,9 @@ def build_install(
     cudart = False,
     visual_server = True,
 ):
-    """Write an install tree. ``marker`` is the literal object to serialise.
-
-    ``marker="default"`` writes a minimal current-shape marker; ``marker=None`` writes no
-    marker file at all (a source build); a ``str`` is written verbatim (corrupt markers).
-    """
+    """Write an install tree. ``marker`` is the literal object to serialise: ``"default"``
+    writes a minimal current-shape marker, ``None`` writes no marker file at all (a source
+    build), and a ``str`` is written verbatim (corrupt markers)."""
     install_dir = tmp_path / "llama.cpp"
     platform = _platform_of(host)
     runtime_dir = (
@@ -312,11 +307,8 @@ ALL_SHAPES = [
 
 @pytest.mark.parametrize(("name", "marker", "backend"), ALL_SHAPES, ids = [s[0] for s in ALL_SHAPES])
 def test_every_shipped_marker_shape_keeps_a_complete_linux_install(tmp_path, name, marker, backend):
-    """Kept whatever release wrote the marker.
-
-    S1-S8 have no ``backend`` key, so it comes back out of the asset name; S1's upstream
-    CPU asset names none either and must fail open.
-    """
+    """Kept whatever release wrote the marker. S1-S8 have no ``backend`` key, so it comes back
+    out of the asset name; S1's upstream CPU asset names none either and must fail open."""
     install_dir = build_install(tmp_path, marker = marker, payload_backend = backend)
     assert ILP._kept_install_payload_is_healthy(install_dir, LINUX) is True
     assert ILP._existing_install_runs(install_dir, LINUX) is True
@@ -336,11 +328,8 @@ def test_no_shipped_marker_shape_is_kept_once_its_backend_payload_is_gutted(
 
 
 def test_a_pre_runtime_asset_windows_cuda_install_is_not_asked_for_the_cudart_trio(tmp_path):
-    """S11 and older cannot record a pairing, so demanding one would loop forever.
-
-    Every Windows CUDA install today predates ``runtime_asset``, and would be rejected on
-    every run if the trio were required of a marker that cannot say it was paired.
-    """
+    """S11 and older cannot record a pairing, so demanding one would loop forever: every
+    Windows CUDA install today predates ``runtime_asset`` and would be rejected on every run."""
     install_dir = build_install(
         tmp_path,
         host = WINDOWS,
@@ -373,11 +362,8 @@ def test_a_paired_windows_cuda_install_still_owes_its_cudart_trio(tmp_path):
 
 
 def test_a_source_build_is_never_kept_because_it_has_no_marker(tmp_path):
-    """The keep path is for prebuilts only.
-
-    ``confirm_install_tree`` requires the marker, so a source build never reaches the
-    payload check and falls through to the source-build fallback as before.
-    """
+    """The keep path is for prebuilts only: ``confirm_install_tree`` requires the marker, so a
+    source build never reaches the payload check and falls through to the fallback as before."""
     install_dir = build_install(tmp_path, marker = None, payload_backend = "cuda")
     assert (install_dir / "llama-server").exists()
     assert not (install_dir / "UNSLOTH_PREBUILT_INFO.json").exists()
@@ -401,11 +387,9 @@ def test_a_source_build_is_never_kept_because_it_has_no_marker(tmp_path):
     ],
 )
 def test_a_corrupt_marker_is_still_kept_but_owes_the_whole_platform_payload(tmp_path, corrupt):
-    """An unreadable marker cannot name a backend, so it owes every kind's shared set.
-
-    The asymmetry with the test above: present-but-unreadable still satisfies
-    ``confirm_install_tree``, so the tree stays eligible and is judged on what is on disk.
-    """
+    """An unreadable marker cannot name a backend, so it owes every kind's shared set. Unlike a
+    missing one it still satisfies ``confirm_install_tree``, so the tree stays eligible and is
+    judged on what is on disk."""
     install_dir = build_install(tmp_path, marker = corrupt, payload_backend = "cuda")
     assert ILP._kept_install_payload_is_healthy(install_dir, LINUX) is True
     assert ILP._existing_install_runs(install_dir, LINUX) is True
@@ -424,12 +408,9 @@ def test_a_marker_from_a_newer_unsloth_is_ignored_key_by_key(tmp_path):
 
 
 def test_a_backend_this_unsloth_does_not_know_falls_back_to_the_asset_name(tmp_path):
-    """An unrecognised ``backend`` is not the end of the derivation.
-
-    ``marker_backend`` tries the recorded backend, then the install kind, then the asset
-    name, so a backend this build has never heard of is still held to what the asset name
-    says. Asserted both ways so the fallback order is pinned.
-    """
+    """An unrecognised ``backend`` is not the end of the derivation: ``marker_backend`` tries
+    the recorded backend, then the install kind, then the asset name. Asserted both ways so the
+    fallback order is pinned."""
     named = {**S12, "backend": "sycl"}  # asset is ...linux-x64-cuda12.tar.gz
     assert ILP.marker_backend(named) == "cuda"
 
@@ -450,10 +431,8 @@ def test_a_backend_no_source_can_name_falls_open_to_the_shared_payload(tmp_path)
 
 
 def test_the_macos_keep_path_requires_the_dylibs(tmp_path):
-    """macOS reaches the same decider and owes its own shared payload.
-
-    Simulated through ``HostInfo``: this covers the path and the payload table, not dyld.
-    """
+    """macOS reaches the same decider and owes its own shared payload. Simulated through
+    ``HostInfo``: this covers the path and the payload table, not dyld."""
     install_dir = build_install(tmp_path / "ok", host = MACOS, marker = S12)
     assert ILP._kept_install_payload_is_healthy(install_dir, MACOS) is True
 
@@ -463,11 +442,9 @@ def test_the_macos_keep_path_requires_the_dylibs(tmp_path):
 
 
 def test_a_legacy_published_vulkan_install_without_the_visual_server_is_refused(tmp_path):
-    """``source`` has been recorded since the first shape, so this reaches old installs.
-
-    A published Vulkan install predating ``ensure_diffusion_visual_server`` is held to a
-    file it never had. The one case where an old install is rebuilt rather than kept.
-    """
+    """``source`` has been recorded since the first shape, so this reaches old installs: a
+    published Vulkan install predating ``ensure_diffusion_visual_server`` is held to a file it
+    never had. The one case where an old install is rebuilt rather than kept."""
     install_dir = build_install(
         tmp_path,
         marker = S6 | {"source": "published"},
@@ -673,11 +650,9 @@ def test_a_gutted_install_is_refused_in_every_os_and_accelerator_cell(
 def test_an_accelerator_install_missing_its_own_backend_library_is_refused(
     tmp_path, cell, host, backend
 ):
-    """The shared payload alone must not be enough for a CUDA/ROCm/Vulkan tree.
-
-    The partial-extraction case: everything generic is present and only the accelerator
-    library is gone, so the binaries start and fail once a model loads.
-    """
+    """The shared payload alone must not be enough for a CUDA/ROCm/Vulkan tree. The partial
+    extraction case: everything generic is present and only the accelerator library is gone, so
+    the binaries start and fail once a model loads."""
     marker = {**S12, "backend": backend, "asset": f"app-b1-{cell}.tar.gz"}
     install_dir = build_install(
         tmp_path,
@@ -689,11 +664,8 @@ def test_an_accelerator_install_missing_its_own_backend_library_is_refused(
 
 
 def test_wsl_is_treated_exactly_like_linux_by_the_keep_path(tmp_path):
-    """Pin the assumption rather than leaving it implicit.
-
-    ``HostInfo`` has no WSL flag and the WSL2 ROCDXG handling is upstream of here, so a
-    WSL install is judged by the Linux tables.
-    """
+    """Pin the assumption rather than leaving it implicit: ``HostInfo`` has no WSL flag and the
+    WSL2 ROCDXG handling is upstream of here, so a WSL install is judged by the Linux tables."""
     marker = {**S12, "backend": "rocm", "asset": "app-b1-linux-x64-rocm-gfx1151.tar.gz"}
     for host in (LINUX_ROCM, WSL_ROCM):
         ok = build_install(
@@ -713,11 +685,9 @@ def test_wsl_is_treated_exactly_like_linux_by_the_keep_path(tmp_path):
 
 
 def test_a_marker_naming_another_platforms_backend_falls_open(tmp_path):
-    """A tree carried between machines must not be judged by the wrong table.
-
-    "metal" on a Linux host filters to no linux kind, so the decider falls back to every
-    kind this platform has rather than refusing a payload that is actually complete.
-    """
+    """A tree carried between machines must not be judged by the wrong table: "metal" on a Linux
+    host filters to no linux kind, so the decider falls back to every kind this platform has
+    rather than refusing a payload that is actually complete."""
     marker = {**S12, "backend": "metal", "asset": "app-b1-macos-arm64.tar.gz"}
     install_dir = build_install(tmp_path, host = LINUX, marker = marker, payload_backend = None)
     assert ILP.marker_backend(marker) == "metal"
@@ -725,11 +695,9 @@ def test_a_marker_naming_another_platforms_backend_falls_open(tmp_path):
 
 
 def test_an_install_whose_keys_were_backfilled_onto_an_old_marker_is_kept(tmp_path):
-    """Real markers are not the clean shapes: ``sync_marker_selection`` grafts.
-
-    An install made at S2 and reused since carries an S2 base with later keys grafted on,
-    which is where a reader would expect the shapes to disagree.
-    """
+    """Real markers are not the clean shapes: ``sync_marker_selection`` grafts, so an install
+    made at S2 and reused since carries an S2 base with later keys added, which is where a
+    reader would expect the shapes to disagree."""
     grafted = {
         **S2,
         "backend": "cuda",
@@ -756,11 +724,9 @@ def _transient_listing_failure(monkeypatch, host = LINUX):
 
 
 def test_a_marker_from_a_newer_unsloth_refuses_rather_than_keeping(tmp_path, monkeypatch):
-    """A backend choice this build cannot read must stop the install, not be kept.
-
+    """A backend choice this build cannot read must stop the install, not be kept:
     ``effective_backend_request`` raises ``UnknownBackendRequest`` and the handler exits
-    ``EXIT_ERROR`` before the keep branch runs. That ordering was unasserted.
-    """
+    ``EXIT_ERROR`` before the keep branch runs. That ordering was unasserted."""
     _transient_listing_failure(monkeypatch)
     install_dir = build_install(
         tmp_path,
@@ -788,11 +754,9 @@ def test_a_transient_failure_keeps_each_shipped_shape_and_returns_exit_zero(tmp_
 
 
 def test_a_transient_failure_still_falls_back_when_the_tree_is_not_runnable(tmp_path, monkeypatch):
-    """The other half: a broken tree must still reach the source-build fallback.
-
-    Exit 2 is what tells setup.sh it may build from source; swallowing it would leave a
-    user with a half-deleted install told everything was fine.
-    """
+    """The other half: a broken tree must still reach the source-build fallback. Exit 2 is what
+    tells setup.sh it may build from source; swallowing it would leave a user with a
+    half-deleted install told everything was fine."""
     _transient_listing_failure(monkeypatch)
     install_dir = build_install(tmp_path, marker = S12, payload_backend = None)
     with pytest.raises(SystemExit) as caught:

--- a/tests/studio/test_zoo_suite_parallel_isolation.py
+++ b/tests/studio/test_zoo_suite_parallel_isolation.py
@@ -177,12 +177,9 @@ def test_the_mlx_group_runs_serially_and_skips_the_per_file_three() -> None:
 
 
 def test_an_empty_mlx_group_stops_the_step_instead_of_collecting_everything() -> None:
-    """The group is passed unquoted, so an empty list is not an empty run.
-
-    With nothing in ``mlx_group`` the command collects the whole rootdir instead:
-    green, far slower, and not this group. The glob only has to stop matching
-    once, upstream renaming the family for instance.
-    """
+    """The group is passed unquoted, so an empty list is not an empty run: with nothing
+    in ``mlx_group`` the command collects the whole rootdir instead, green and far
+    slower. The glob only has to stop matching once, upstream renaming the family say."""
     text = WORKFLOW.read_text(encoding = "utf-8")
     assert 'if [ -z "$mlx_group" ]' in text, (
         "nothing checks that the mlx group glob matched anything, so an empty glob "
@@ -191,11 +188,9 @@ def test_an_empty_mlx_group_stops_the_step_instead_of_collecting_everything() ->
 
 
 def test_a_skipped_isolated_file_is_named_in_the_log() -> None:
-    """Exit 5 is tolerated, so the file that produced it has to be identifiable.
-
-    An expected module-level skip and a file that stopped collecting for a new
-    reason both exit 5 and both stay green.
-    """
+    """Exit 5 is tolerated, so the file that produced it has to be identifiable: an
+    expected module-level skip and a file that stopped collecting for a new reason both
+    exit 5 and both stay green."""
     text = WORKFLOW.read_text(encoding = "utf-8")
     for path, _ in ISOLATED:
         assert f'_keep "$?" {path}' in text, (

--- a/tests/studio/test_zoo_suite_parallel_isolation.py
+++ b/tests/studio/test_zoo_suite_parallel_isolation.py
@@ -20,7 +20,6 @@ ISOLATED = [
         "tests/test_moe_bnb4bit_per_expert_conversions.py",
         "6 failures under xdist that serial does not produce",
     ),
-    # This test has sub-second wall-clock assertions that fail under CPU contention.
     ("tests/test_hf_xet_fallback.py", "sub-second wall-clock margins under CPU contention"),
     # MLX shims alter sys.modules, so these files each need a fresh process.
     ("tests/test_mlx_neftune_quant_map.py", "the mlx shim un-skips it and the stub then raises"),
@@ -31,7 +30,6 @@ ISOLATED = [
     ),
 ]
 
-# Identify the cloned zoo's parallel pytest command independently of step ordering.
 ZOO_MARKER = "--dist loadfile tests/"
 
 # Deselected because it needs a GPU. It rides whichever command owns its file.
@@ -88,7 +86,6 @@ def test_the_zoo_suite_actually_runs_in_parallel() -> None:
 @pytest.mark.parametrize("path,reason", ISOLATED, ids = lambda v: v.split("/")[-1])
 def test_an_isolated_file_is_ignored_by_the_parallel_run(path: str, reason: str) -> None:
     cmd = _zoo_parallel()
-    # The family glob automatically covers newly added MLX tests.
     covered = f"--ignore={path}" in cmd or (
         path.rsplit("/", 1)[-1].startswith("test_mlx_")
         and "--ignore-glob='tests/test_mlx_*.py'" in cmd


### PR DESCRIPTION
Comment and docstring reduction over the code #9979 added. Two passes, prepared while that PR was open and finished just after it merged, so they missed the merge.

Behaviour-free by construction: 102 insertions against 221 deletions, and every hunk is a comment, a docstring or whitespace.

## Numbers

| | before | after | cut |
| --- | --- | --- | --- |
| line comments | 111 | 54 | 51% |
| docstrings | 197 | 136 | 31% |

No docstring is deleted. Every function that had one still has one; the reduction is entirely from collapsing multi-line rationale blocks. The longest surviving docstring in the set is 8 lines, down from 11, and the rest are 1 to 4.

## AST gate

`comment_tools.py check --changed --base origin/main --strip-docstrings` reports 12/12 OK, exit 0. Every extension in the diff is `.py`, `.ts` or `.tsx`, all of which the tool parses, so nothing is skipped past the gate.

Worth recording for the next pass: with `--strip-docstrings` a docstring edit compares equal but a deletion does not, because the helper blanks the string value and keeps the `Expr` node. That is why this pass shortens docstrings and never removes them.

## What was deliberately kept

Shorter was not the goal where a comment carried a fact the code does not state:

- `_choice_seed` and its test keep the note that matching a literal `-1` alone left choice 0 random and cached while choice 1 was offset into a fixed, uncached seed. That is the reason the comparison masks to uint32, and it is the alternative-is-wrong fact.
- `_binary_image_runs` keeps the whole "exit code is not the verdict" half. `llama-quantize` answering `--version` with a non-zero exit is a live trap, and the deliberate fail-open on a timeout or failed spawn is an invariant nothing else records.
- The `S1`..`S12` marker shapes keep their date and PR citations. Nothing else records when each key arrived, which is the entire premise of a back-compat matrix.
- `test_a_pre_runtime_asset_windows_cuda_install_is_not_asked_for_the_cudart_trio` keeps "every Windows CUDA install today predates `runtime_asset`". Without it the test reads as hypothetical rather than as a regression that would loop forever.

## Verification

- backend files touched: 553 passed
- `tests/studio/install/` and the zoo isolation suite: 3270 passed

The 11 failures in `test_rocm_support.py` visible in a local full run are unrelated and reproduce identically on `main`; they need an importable `unsloth` that the sandbox lacks.

## Note

Touches `tests/studio/install/test_keep_install_backcompat_9979.py`, which #10106 also edits. Whichever lands second needs a trivial rebase.
