### PR TITLE
Give the unsloth_zoo pytest step a per-test timeout

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -232,7 +232,7 @@ jobs:
           pip install \
             python-multipart aiofiles sqlalchemy cryptography \
             pyyaml jinja2 mammoth unpdf requests typer \
-            'numpy<3' pytest==9.0.3 pytest-asyncio pytest-xdist httpx \
+            'numpy<3' pytest==9.0.3 pytest-asyncio pytest-xdist pytest-timeout httpx \
             protobuf sentencepiece triton \
             psutil packaging tqdm safetensors datasets \
             'peft>=0.18,<0.20' 'accelerate>=0.34,<2' \
@@ -464,6 +464,18 @@ jobs:
         # the test never stubbed; this fails on every platform regardless
         # of CUDA. Tracked upstream as an unsloth_zoo bug; deselecting
         # here unblocks unsloth CI until the loader fixture is fixed.
+        #
+        # A test that hangs rather than fails used to consume the whole 35 minute
+        # job budget and report nothing usable: the job ended as "cancelled", with
+        # no test name, no traceback, and every later step marked skipped. That is
+        # how unsloth_zoo's gather_qmm guard walking a chain forever under the mlx
+        # shim presented. PYTEST_TIMEOUT is read by pytest-timeout on every pytest
+        # invocation in this step, so one setting covers the xdist run and each
+        # serial file below. 10 minutes per test is far above the slowest honest
+        # CPU test here, so it only ever fires on a genuine hang, and when it does
+        # it names the test and dumps its stack.
+        env:
+          PYTEST_TIMEOUT: 600
         working-directory: ${{ runner.temp }}/unsloth-zoo
         run: |
           # Keep tests within each file on one worker. MLX shims contaminate sys.modules,

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -471,11 +471,20 @@ jobs:
         # how unsloth_zoo's gather_qmm guard walking a chain forever under the mlx
         # shim presented. PYTEST_TIMEOUT is read by pytest-timeout on every pytest
         # invocation in this step, so one setting covers the xdist run and each
-        # serial file below. 10 minutes per test is far above the slowest honest
-        # CPU test here, so it only ever fires on a genuine hang, and when it does
-        # it names the test and dumps its stack.
+        # serial file below, instead of the same flag on six command lines.
+        #
+        # 5 minutes. The slowest honest test in the suite is about 48s locally
+        # (test_fla_hopper_tile.py), and CI runs roughly 1.65x slower than that
+        # box, measured on the one test long enough to compare, so call it 80s
+        # here. That leaves well over 3x headroom, while a genuine hang is now
+        # named and stack-dumped in 5 minutes rather than silently eating all 35.
+        #
+        # This only became a sane number once unsloth_zoo stopped rebuilding
+        # dir(transformers.models) on every call (unsloth-zoo#1139): before that,
+        # test_every_shipped_model_type_accepted alone ran past 600s, so any
+        # useful timeout would have failed a passing test.
         env:
-          PYTEST_TIMEOUT: 600
+          PYTEST_TIMEOUT: 300
         working-directory: ${{ runner.temp }}/unsloth-zoo
         run: |
           # Keep tests within each file on one worker. MLX shims contaminate sys.modules,


### PR DESCRIPTION
## Problem

A test that hangs instead of failing consumes the entire 35 minute `Core` job budget and reports nothing usable. The job ends as `cancelled` rather than `failure`, with no test name, no traceback, and every later step marked `skipped`. The only evidence is a step that stops printing:

```
22:35:56  ......................................................  [ 13%]
22:48:25  ##[error]The operation was canceled.
```

This is live right now. Every `Core` job on `main` is timing out at 35m20s, because `unsloth_zoo`'s `gather_qmm` guard walks a wrapper chain until `getattr` returns `None`, which never happens under the mlx test shim (it answers every attribute with a fresh object). Fixed in unslothai/unsloth-zoo#1138, but the logs named neither the test nor the loop, which is the part this PR is about.

## Change

Install `pytest-timeout` and set `PYTEST_TIMEOUT` on the step.

The env var is read by every pytest invocation in the step, so one setting covers the xdist run and each of the serial files below it, and the flags stay out of six separate command lines.

At 10 minutes per test it sits far above the slowest honest CPU test here (the whole xdist run is about 14 minutes across 4 workers), so it only fires on a genuine hang. When it does, pytest names the test and dumps its stack, and the remaining tests still run.

## Verification

Against the live hang, with `PYTEST_TIMEOUT` set and nothing else changed:

```
FAILED tests/test_mlx_distributed_loader.py::test_from_pretrained_distributed_vlm_forwards_normalized_override
FAILED tests/test_mlx_distributed_loader.py::test_from_pretrained_uses_distributed_loader
2 failed, 5 passed in 120.12s
```

An indefinite stall becomes two named failures, and it surfaced a second affected test that the silent timeout had hidden.