### PR TITLE
Use the public fastmcp call_tool so the MCP guard test survives fastmcp 4

### DIFF
--- a/studio/backend/tests/test_mcp_training_start_guard.py
+++ b/studio/backend/tests/test_mcp_training_start_guard.py
@@ -361,8 +361,10 @@ def test_the_mcp_tool_surfaces_the_409_as_a_tool_error_not_a_dict(monkeypatch):
 
     from fastmcp.exceptions import ToolError
 
+    # call_tool, not the private _call_tool_mcp fastmcp 4 dropped: requirements
+    # floor it at 3.0.2 and never cap it, so a test may only use the public API.
     with pytest.raises(ToolError) as tool_error:
-        asyncio.run(server._call_tool_mcp("start_training", {"config": _config()}))
+        asyncio.run(server.call_tool("start_training", {"config": _config()}))
 
     # mask_error_details defaults False, so the 409 detail survives to the client
     # (as the text of an isError CallToolResult, not a JSON-RPC protocol error).


### PR DESCRIPTION
`Backend CI` job `(Python 3.13)` is failing on `main`, and on every PR branched from it:

```
AttributeError: 'FastMCP' object has no attribute '_call_tool_mcp'
FAILED tests/test_mcp_training_start_guard.py::test_the_mcp_tool_surfaces_the_409_as_a_tool_error_not_a_dict
```

Nothing in the repo changed. `fastmcp 4.0.0` was published, `studio/backend/requirements/studio.txt` floors the dependency at `fastmcp>=3.0.2` with no cap, so CI resolves 4.0.0, and v4 drops the private `_call_tool_mcp` the test reaches into. The upgrade guide is explicit that anything marked "Removed in v4" no longer works.

The test is at fault, not the library. `call_tool` is documented in v4 as "the public API for executing tools", and it was already public in 3.x, so one line moves the assertion off a private method that was never ours to depend on.

## Verification

The substantive point is that this is not a version-swap that trades one breakage for another. `call_tool` raises the same error with the same message on both the floor-compatible version and the new one:

| fastmcp | `call_tool` result |
| --- | --- |
| 3.4.7 | `ToolError: Error calling tool 'start_training': inference request is in progress` |
| 4.0.0 | `ToolError: Error calling tool 'start_training': inference request is in progress` |

Both assertions in the test still hold on both, and `_mask_error_details` is present and `False` on both.

Reproduced CI's failure and the fix in a full backend environment with `fastmcp==4.0.0` installed:

```
before:  1 failed, 16 passed
after:   17 passed
```

And on 3.4.7, unchanged: `17 passed`.

## Note

This does not pin the dependency. Pinning would stop the next v4 removal from reaching CI, but it would also silently hold the backend on an old major, which is a bigger decision than a red test warrants and belongs in its own change. Worth deciding separately whether `studio.txt` should cap `fastmcp` below the next major.
