### PR TITLE
Trim comments in studio/backend routes, utils and installers

### DIFF
--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -678,8 +678,6 @@ async def change_password(
     )
 
 
-
-
 # API key management
 # ---------------------------------------------------------------------------
 def _row_to_api_key_response(row: dict) -> ApiKeyResponse:

--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -82,8 +82,7 @@ def _cli_is_inside(prefix: str) -> bool:
         spec = importlib.util.find_spec("unsloth_cli")
         origin = getattr(spec, "origin", None)
         if not origin:
-            # A namespace package, or nothing found. Either way there is no
-            # location to compare, so do not claim isolation would work.
+            # A namespace package, or nothing found.
             return False
         return Path(origin).resolve().is_relative_to(Path(prefix).resolve())
     except (ImportError, OSError, ValueError, AttributeError):
@@ -153,17 +152,11 @@ _LOGIN_LOCKOUT_SECONDS = 60
 _LOGIN_MAX_BUCKETS = 4096
 # Last full stale-sweep time; rate-limits the O(n) sweep under a burst of new IPs.
 _LAST_IP_PRUNE = 0.0
-# Sharded overflow for per-IP failures that can't get their own bucket while the
-# dict is saturated. Each shard is a small fixed-capacity dict ``ip -> [count,
-# window_start]``: a per-IP count (so a source is throttled, and cleared on
-# success, by its own failures -- no cross-IP collateral) with hard-bounded
-# memory and O(1) lookups. When a shard is full a new IP evicts the lowest-count
-# entry (and starts clean, never inheriting its count) rather than growing without
-# bound, so a high-cardinality spray can't blow memory/CPU the way a per-failure
-# deque could; a persistent attacker keeps a high count and is never the one
-# evicted.
+# Sharded overflow for per-IP failures that can't get their own bucket
+# Each shard is a fixed-capacity dict ``ip -> [count, window_start]``; when full, a new IP evicts the lowest-count entry
+# and starts clean.
 _LOGIN_IP_OVERFLOW_SHARDS = 256
-_LOGIN_IP_OVERFLOW_MAX = 64  # distinct IPs tracked per shard
+_LOGIN_IP_OVERFLOW_MAX = 64
 _LOGIN_IP_OVERFLOW: list[dict] = [dict() for _ in range(_LOGIN_IP_OVERFLOW_SHARDS)]
 
 
@@ -179,19 +172,12 @@ def _overflow_record(ip: str, now: float) -> int:
         if now - entry[1] > _LOGIN_WINDOW_SECONDS:
             entry[0], entry[1] = 1, now
         else:
-            # Only "at or above the per-IP threshold" matters for blocking, so cap
-            # the count there. This also keeps the migration into a per-IP bucket
-            # bounded -- without the cap a saturated source could accrue an
-            # unbounded count, then materialize one deque entry per failure
-            # (``[start] * carried``) on the next attempt, allocating an arbitrarily
-            # large deque while holding the login lock.
+            # Cap the count at the threshold: uncapped, a saturated source materializes one deque entry per failure
+            # (`[start] * carried`) while holding the login lock.
             entry[0] = min(entry[0] + 1, _LOGIN_IP_MAX_FAILS)
         return entry[0]
     if len(shard) >= _LOGIN_IP_OVERFLOW_MAX:
-        # Make room by dropping the lowest-count entry, but the new source starts
-        # clean -- never inherit the evicted IP's failures, or an unrelated source
-        # could be 429'd after one attempt. Worst case under a saturated shard is
-        # that a heavy hitter briefly resets, not that a bystander is blocked.
+        # Make room by dropping the lowest-count entry.
         del shard[min(shard, key = lambda k: shard[k][0])]
     shard[ip] = [1, now]
     return 1
@@ -217,9 +203,8 @@ def _overflow_take(ip: str, now: float) -> tuple[int, float]:
     entry = _overflow_shard(ip).pop(ip, None)
     if entry is None or now - entry[1] > _LOGIN_WINDOW_SECONDS:
         return 0, now
-    # Cap the carried count so the bucket migration never allocates more than the
-    # per-IP threshold worth of deque entries (defensive; _overflow_record already
-    # clamps, but keep the bound at the consumption site too).
+    # Cap the carried count so the bucket migration never allocates more than the per-IP threshold
+    # worth of deque entries (defensive; _overflow_record already clamps).
     return min(entry[0], _LOGIN_IP_MAX_FAILS), entry[1]
 
 
@@ -385,11 +370,7 @@ def _login_blocked(key: tuple[str, str]) -> int:
     now = time.monotonic()
     ip, _username = key
     with _LOGIN_BUCKETS_LOCK:
-        # Honor the IP's overflow shard regardless of current dict capacity: a
-        # source counted there during saturation must stay throttled until those
-        # failures age out, even if a bucket later frees up -- otherwise a fresh
-        # bucket would reset it. Shards are empty outside saturation, so this is a
-        # no-op in the common case.
+        # Honor the IP's overflow shard regardless of current dict capacity
         ip_blocked = max(
             _blocked_for(_LOGIN_IP_BUCKETS.get(ip), now, _LOGIN_IP_MAX_FAILS),
             _overflow_blocked(ip, now),
@@ -427,9 +408,9 @@ def identity(nonce: str, request: Request) -> dict:
         raise HTTPException(
             status_code = status.HTTP_400_BAD_REQUEST, detail = "nonce must decode to 16-128 bytes"
         )
-    # The address + port the connection actually landed on, from the socket
-    # (request.scope is getsockname, so it is the real local address even when
-    # bound to 0.0.0.0), never the client-controlled Host header.
+    # The address + port the connection actually landed on.
+    # request.scope is getsockname, so this is the real local address even when bound to 0.0.0.0, never the client-
+    # controlled Host header.
     server = request.scope.get("server") or ("", 0)
     host = server[0] or ""
     port = server[1] if server[1] is not None else 0
@@ -467,8 +448,7 @@ async def login(payload: AuthLoginRequest, request: Request) -> Token:
     if blocked_for > 0:
         raise HTTPException(
             status_code = status.HTTP_429_TOO_MANY_REQUESTS,
-            # IP not interpolated into the body; behind a proxy/NAT it's
-            # misleading or an info leak.
+            # IP not interpolated into the body: behind a proxy/NAT it is misleading or an info leak.
             detail = (f"Too many failed login attempts. " f"Try again in {blocked_for} seconds."),
             headers = {"Retry-After": str(blocked_for)},
         )
@@ -493,8 +473,7 @@ async def login(payload: AuthLoginRequest, request: Request) -> Token:
 
     _clear_login_bucket(key)
     _clear_login_bucket(unknown_key)
-    # Issue against the credential version just verified, not whatever is in the DB
-    # now: a concurrent reset-password must not hand this login a post-reset session.
+    # Issue against the credential version just verified.
     access_token = create_access_token(subject = payload.username, secret = jwt_secret)
     refresh_token = create_refresh_token(subject = payload.username, secret = jwt_secret)
     return Token(
@@ -605,9 +584,8 @@ async def set_desktop_initial_password(
             detail = "New password cannot contain spaces",
         )
 
-    # Conditional on the credential just read: a web password change or a
-    # reset-password landing while this request is in flight must not be
-    # overwritten by a caller that verified no password at all.
+    # Conditional on the credential just read: a concurrent web password change or reset-password
+    # must not be overwritten by a caller that verified no password at all.
     new_secret = storage.update_password(
         current_subject,
         payload.new_password,
@@ -667,13 +645,9 @@ async def change_password(
             detail = "New password must be different from the current password",
         )
 
-    # Single transaction: a separate refresh-token purge could fail after the
-    # password commit, leaving pre-change tokens able to mint access tokens.
-    # Conditional on the hash just verified: a reset-password that landed while
-    # this request was in flight must not be overwritten by it.
-    # The desktop app authenticates with a local secret rather than this
-    # password; revoking that secret would break its auto-auth over a change it
-    # made itself. A browser session still revokes it.
+    # Single transaction: a separate refresh-token purge could fail after the password commit,
+    # leaving pre-change tokens able to mint access tokens. Conditional on the hash just
+    # verified, so a concurrent reset-password cannot be overwritten by it.
     new_secret = storage.update_password(
         current_subject,
         payload.new_password,
@@ -704,11 +678,9 @@ async def change_password(
     )
 
 
-# ---------------------------------------------------------------------------
+
+
 # API key management
-# ---------------------------------------------------------------------------
-
-
 def _row_to_api_key_response(row: dict) -> ApiKeyResponse:
     return ApiKeyResponse(
         id = row["id"],

--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -681,6 +681,7 @@ async def change_password(
 
 
 # API key management
+# ---------------------------------------------------------------------------
 def _row_to_api_key_response(row: dict) -> ApiKeyResponse:
     return ApiKeyResponse(
         id = row["id"],

--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -681,6 +681,7 @@ async def change_password(
 # API key management
 # ---------------------------------------------------------------------------
 
+
 def _row_to_api_key_response(row: dict) -> ApiKeyResponse:
     return ApiKeyResponse(
         id = row["id"],

--- a/studio/backend/routes/auth.py
+++ b/studio/backend/routes/auth.py
@@ -680,6 +680,7 @@ async def change_password(
 
 # API key management
 # ---------------------------------------------------------------------------
+
 def _row_to_api_key_response(row: dict) -> ApiKeyResponse:
     return ApiKeyResponse(
         id = row["id"],

--- a/studio/backend/routes/chat_generation_runs.py
+++ b/studio/backend/routes/chat_generation_runs.py
@@ -171,11 +171,8 @@ def _sanitize_request(payload: CreateChatGenerationRun) -> dict[str, Any]:
             status_code = 400,
             detail = "Durable chat runs are available only for local inference",
         )
-    # Recovery rebuilds text and reasoning deltas. A media turn has neither the same
-    # chunk shape nor a replayable transcript, and its payload is persisted verbatim,
-    # so a base64 blob would live in request_json for the life of the thread. Studio's
-    # own composer already keeps these on the legacy stream; keep the server in step so
-    # a stale tab or a direct caller cannot open a path nothing replays.
+    # A media turn has no replayable transcript and its payload persists verbatim, so a base64 blob would live in
+    # request_json for the life of the thread.
     if any(raw.get(field) not in (None, "") for field in _MEDIA_FIELDS):
         raise HTTPException(
             status_code = 400,
@@ -242,10 +239,8 @@ async def create_chat_generation_run(
     current_subject: str = Depends(get_current_subject),
 ):
     sanitized = _sanitize_request(payload)
-    # Serialize the off-loop commit with model lifecycle work. If create wins,
-    # the run is registered before the gate opens; if unload/swap wins, the run
-    # is admitted afterward. SSE and unrelated requests stay responsive while
-    # SQLite waits on a lock.
+    # Serialize the off-loop commit with model lifecycle work, so a run is registered either before the gate opens or
+    # after an unload/swap, never mid-swap.
     async with inference_lifecycle_gate():
         try:
             run, created = await asyncio.to_thread(
@@ -317,11 +312,8 @@ async def chat_generation_events(
     async def stream():
         nonlocal cursor
         loop = asyncio.get_running_loop()
-        # A client that reconnects already caught up on a settled run has nothing to replay,
-        # and wait_for_events would hold it for the full timeout: the finished answer reads
-        # as still generating and an event-wait worker is tied up meanwhile. Only the first
-        # wait needs this guard, since every later pass already returns on the same test
-        # against the snapshot it read after waiting.
+        # A reconnect to an already-settled run has nothing to replay, and wait_for_events would hold it for the full
+        # timeout and tie up an event-wait worker.
         opening = await asyncio.to_thread(db.get_run, run_id)
         if opening is None:
             return
@@ -357,12 +349,10 @@ async def chat_generation_events(
             if await request.is_disconnected():
                 return
             if not events:
-                # Carries the run's progress stamp, which the lease renewals move. A bare
-                # keep-alive is proof the CONNECTION is healthy and nothing more, so a
-                # follower that rearmed its no-progress deadline on one could never settle
-                # a wedged run while the socket stayed up, which is the one case that
-                # fallback exists for. Comment framing, so _SSEDecoder still drops it and
-                # no client parsing it as an event is affected.
+                # Carries the run's progress stamp, which the lease renewals move.
+                # A bare keep-alive proves only that the CONNECTION is healthy, so a follower rearming its no-progress
+                # deadline on one could never settle a wedged run while the socket stayed up, the one case that fallback
+                # exists for.
                 yield f": keep-alive {int(snapshot['updatedAt'])}\n\n"
 
     return StreamingResponse(

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -612,7 +612,7 @@ class ChatImportLedgerRecordResponse(BaseModel):
 
 
 # Both conflicts are 409 and mean opposite things (protected: stop resending; thread
-    # collision: surface the failure), so they are told apart by a header, not by `detail`.
+# collision: surface the failure), so they are told apart by a header, not by `detail`.
 # main.py must expose the header for a cross-origin Studio to read it.
 CONFLICT_KIND_HEADER = "X-Unsloth-Conflict-Kind"
 
@@ -1308,7 +1308,7 @@ async def delete_project(
             )
             if not idle:
                 # Nothing else comes back to it: the collection would otherwise wait for a later delete
-            # that may never happen.
+                # that may never happen.
                 finish_workspace_delete_when_idle(project_id)
     # Each member chat had its own sandbox for anything it wrote before joining
     # the project, and deleting the project removes the only records of them.
@@ -1533,7 +1533,7 @@ async def clear_history(
         reapable_image_ids,
     ) = await run_in_threadpool(_clear_rows)
     # A chat started between the listing and the transaction is in `cleared` but was never
-        # cancelled, so its live generation could rebuild the sandbox this call removes.
+    # cancelled, so its live generation could rebuild the sandbox this call removes.
     listed = set(thread_ids)
     late = [thread_id for thread_id in cleared if thread_id not in listed]
     _cancel_active_generations(thread_ids)

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -116,8 +116,8 @@ class ChatRagKnowledgeBaseSource(BaseModel):
 class ChatThreadSettings(BaseModel):
     """The chat settings captured per thread; a thread storing none uses the global ones."""
 
-    # allow_inf_nan as in ChatInferenceSettings: json.loads and pydantic both take
-    # a bare NaN, which is then stored as a token no strict reader can parse back.
+    # allow_inf_nan as in ChatInferenceSettings: json.loads and pydantic both take a bare NaN, stored as a token no
+    # strict reader can parse back.
     model_config = ConfigDict(extra = "forbid", allow_inf_nan = False)
 
     reasoningEnabled: Optional[bool] = None
@@ -303,9 +303,9 @@ class ChatThreadPatch(BaseModel):
     # Applies just the fields it names. For the writer that knows what changed but not
     # what else the row holds, which is any write made before the row has been read.
     settingsPatch: Optional[ChatThreadSettings] = None
-    # Orders this writer's snapshot writes against its OWN earlier ones, so a keepalive
-    # sent on unload cannot be undone by a PATCH the server already had in hand. Never
-    # compared across writers: two browsers' counters mean nothing to each other.
+    # Orders this writer's snapshot writes against its OWN earlier ones.
+    # So a keepalive sent on unload cannot be undone by a PATCH the server already had in hand. Never compared across
+    # writers: two browsers' counters mean nothing to each other.
     settingsSeq: Optional[int] = None
     settingsWriter: Optional[str] = None
 
@@ -393,12 +393,9 @@ class ChatExportResponse(BaseModel):
 
 
 class ChatInferenceSettings(BaseModel):
-    # allow_inf_nan: json.loads accepts bare NaN and Infinity, and pydantic takes them
-    # for a float, so `{"temperature": NaN}` used to be stored as a bare NaN token in
-    # value_json. Python reads that back, so the row is never quarantined, while the
-    # response model renders it as null: the value is silently lost and the row is not
-    # valid JSON for any strict reader. Refuse it at the door instead, the way
-    # models/training.py already does for every numeric training field.
+    # allow_inf_nan: json.loads accepts bare NaN and Infinity.
+    # A bare NaN token in value_json reads back fine but renders as null, so refuse it at the door the way
+    # models/training.py does.
     model_config = ConfigDict(extra = "forbid", allow_inf_nan = False)
 
     temperature: Optional[float] = None
@@ -528,9 +525,8 @@ class ChatSettingsPayload(BaseModel):
     expandQuantizations: Optional[bool] = None
     showAllQuantizations: Optional[bool] = None
     fitOnDeviceOnly: Optional[bool] = None
-    # Local GGUF auto-compaction. Off omits context_overflow so a full window
-    # errors instead of silently dropping history. contextPolicy/headroom are
-    # the per-request overrides for UNSLOTH_CONTEXT_POLICY and
+    # Off omits context_overflow, so a full window errors instead of silently dropping history.
+    # contextPolicy/headroom are the per-request overrides for UNSLOTH_CONTEXT_POLICY and
     # ROLLING_COMPACTION_HEADROOM_RATIO.
     autoCompactEnabled: Optional[bool] = None
     contextPolicy: Optional[Literal["inherit", "checkpoint", "rolling"]] = None
@@ -615,9 +611,9 @@ class ChatImportLedgerRecordResponse(BaseModel):
     inserted: int
 
 
-# Both conflicts are 409 and mean opposite things: protected means stop resending, a thread
-# collision means surface the failure. In a header, not the body, so `detail` stays a plain
-# string for existing clients; main.py must expose it for a cross-origin Studio to read it.
+# Both conflicts are 409 and mean opposite things (protected: stop resending; thread
+    # collision: surface the failure), so they are told apart by a header, not by `detail`.
+# main.py must expose the header for a cross-origin Studio to read it.
 CONFLICT_KIND_HEADER = "X-Unsloth-Conflict-Kind"
 
 
@@ -782,7 +778,7 @@ def _cancel_research_runs(request: Request, run_ids: list[str]) -> None:
         try:
             research_runs_db.request_cancel(run_id)
         except Exception:  # noqa: BLE001
-            pass  # no row to update, which is the ordinary case after a delete
+            pass
 
 
 def _cancel_active_generations(thread_ids: list[str]) -> None:
@@ -842,10 +838,8 @@ async def delete_threads(
     _cancel_research_runs(request, deleted_research_run_ids)
     _cancel_chat_generation_runs(request, deleted_chat_run_ids)
     _cancel_active_generations(payload.ids)
-    # Keyed by thread id, so nothing can reference the folder once the thread
-    # is gone. Clean it up rather than leaking one per chat.
-    # In a worker: right after an upgrade this also runs the legacy move, and a
-    # cross-filesystem copy on the event loop stops every other request.
+    # Keyed by thread id, so the folder is unreachable once the thread is gone; done in a worker because the
+    # post-upgrade legacy move can be a cross-filesystem copy.
     removed, kept = await _remove_sandboxes(payload.ids, payload.delete_files)
     # Archived turns are keyed by thread id and unreferenced once the thread is gone, so
     # drop them rather than leaking a scope per deleted chat.
@@ -866,13 +860,9 @@ def _remove_conversation_archives(thread_ids, *, cutoff: "str | None" = None) ->
     except Exception:
         return
     for thread_id in thread_ids or []:
-        # As next to the sandbox removal: the rows went first and the sandbox pass ran in
-        # between, so another tab can have recreated this id and already be archiving
-        # turns under it. That chat is alive, and its memory is not this delete's to take
-        # -- but the conversation the user DID delete is, and skipping the scope kept it
-        # too, recallable under the live id with nothing left to sweep it. So cut at the
-        # instant the delete was accepted instead of skipping: everything archived before
-        # it belongs to the deleted conversation, everything after to the new one.
+        # Cut at the instant the delete was accepted, not on recreation: another tab can have recreated this id, and
+        # skipping the scope left the deleted conversation recallable.
+        # Everything archived before that instant belongs to the deleted conversation, everything after to the new one.
         recreated = get_chat_thread(str(thread_id)) is not None
         if recreated and not cutoff:
             continue
@@ -1099,10 +1089,8 @@ def save_project(payload: ChatProject, current_subject: str = Depends(get_curren
     try:
         return ChatProject(**upsert_chat_project(payload.model_dump()))
     except ProjectWorkspaceError as exc:
-        # A project is the only thing Unsloth writes to Documents, so a folder it
-        # cannot create there fails here and nowhere else. Only this error, and
-        # only its own path: the same upsert also opens the database, which
-        # lives somewhere else entirely.
+        # A project is the only thing Unsloth writes to Documents, so only this error and only its own path: the same
+        # upsert also opens the database, which lives elsewhere.
         raise log_and_http_error(
             exc,
             500,
@@ -1181,8 +1169,6 @@ async def delete_project(
             lambda: delete_chat_project(project_id, delete_files = False)
         )
     except Exception:
-        # the row transaction may still have committed, and an ownerless scope has to be
-        # retired by someone; periodic reconciliation is the fallback if this also fails
         try:
             if await run_in_threadpool(get_chat_project, project_id) is None:
                 await run_in_threadpool(_delete_project_rag_sources, project_id)
@@ -1205,8 +1191,7 @@ async def delete_project(
         list(project.get("activeChatGenerationRunIds") or []),
     )
     _cancel_active_generations(member_ids)
-    # before any workspace work: the row is already gone, so a later failure must not
-    # leave the scope owned by nothing
+    # before any workspace work: the row is already gone.
     try:
         await run_in_threadpool(_delete_project_rag_sources, project_id)
     except Exception:  # noqa: BLE001 - source cleanup must not block project deletion
@@ -1322,8 +1307,8 @@ async def delete_project(
                 project.get("rootPath"),
             )
             if not idle:
-                # Nothing else would come back to it: the collection otherwise
-                # waits for some later delete that may never happen.
+                # Nothing else comes back to it: the collection would otherwise wait for a later delete
+            # that may never happen.
                 finish_workspace_delete_when_idle(project_id)
     # Each member chat had its own sandbox for anything it wrote before joining
     # the project, and deleting the project removes the only records of them.
@@ -1514,10 +1499,10 @@ async def clear_history(
                 False,
                 snapshot_and_fence_registrations(),
             )
-        # Answered by the transaction itself. Read separately beforehand it is a guess:
-        # a concurrent retry of the same operation id sees the same unrecorded ledger,
-        # and the one BEGIN IMMEDIATE puts second replays while still believing it
-        # cleared. `replayed` here is whichever the transaction actually did.
+        # Answered by the transaction itself: read beforehand it is a guess, and a concurrent retry of the same
+        # operation id would replay while believing it cleared.
+        # The one BEGIN IMMEDIATE puts second replays while still believing it cleared; `replayed` is whichever the
+        # transaction actually did.
         cleared, cleared_runs, cleared_chat_runs, replayed = clear_chat_history_with_replay_status(
             payload.ids,
             operation_id = payload.operationId,
@@ -1535,14 +1520,11 @@ async def clear_history(
                 unreaped_clear_operation_image_ids(payload.operationId),
             )
         snapshot = snapshot_and_fence_registrations()
-        # Recorded before the reap runs, so a crash in the seconds of cleanup that follow
-        # leaves a retry able to finish exactly this set and nothing wider.
+        # Recorded before the reap runs.
         record_clear_operation_reap_scope(payload.operationId, snapshot)
         return cleared, cleared_runs, cleared_chat_runs, False, snapshot
 
-    # The clear reports what it deleted, which is what gets cleaned up: a thread
-    # added between the listing above and the delete is gone too, and its
-    # sandbox would otherwise be stranded.
+    # The clear reports what it deleted.
     (
         cleared,
         cleared_runs,
@@ -1550,9 +1532,8 @@ async def clear_history(
         replayed,
         reapable_image_ids,
     ) = await run_in_threadpool(_clear_rows)
-    # A chat started between the listing and the transaction is in `cleared`
-    # but was never cancelled, and a generation still running would dispatch a
-    # tool and rebuild the sandbox this call is about to remove.
+    # A chat started between the listing and the transaction is in `cleared` but was never
+        # cancelled, so its live generation could rebuild the sandbox this call removes.
     listed = set(thread_ids)
     late = [thread_id for thread_id in cleared if thread_id not in listed]
     _cancel_active_generations(thread_ids)
@@ -1566,29 +1547,12 @@ async def clear_history(
     await run_in_threadpool(
         _remove_conversation_archives, list(dict.fromkeys(thread_ids + cleared)), cutoff = cutoff
     )
-    # "Clear all chats" is the common bulk delete, so it has to clean up the
-    # same folders DELETE /threads does; otherwise every sandbox is stranded.
-    # delete_files matches DELETE /threads: off by default, since the files are
-    # the user's, but a caller clearing everything can ask for them too.
+    # "Clear all chats" is the common bulk delete.
+    # delete_files matches DELETE /threads: off by default, since the files are the user's.
     removed, kept = await _remove_sandboxes(list(dict.fromkeys(thread_ids + cleared)), delete_files)
-    # Search thumbnails are keyed by id, not thread, so this is the one place they
-    # can be reaped; they reveal what was searched for. Runs for both _clear_rows
-    # branches -- each drops every thread -- so this
-    # is NOT gated on `payload is None`, which the frontend never sends and which
-    # therefore meant the reap never ran.
-    #
-    # A REPLAY must not reap the registry wholesale: the transaction above deliberately keeps
-    # chats created since the original clear, and this registry is global, so wiping it takes
-    # the images of a chat this call is not deleting and leaves its cards 404ing out of
-    # thumbnail_bytes. Ordinarily it has nothing to do -- the request that recorded the
-    # operation reaps them, and Starlette does not cancel a handler when the client hangs up,
-    # so the attempt this retry replaces still runs to here.
-    #
-    # The exception is a process that DIED in between. The operation is recorded and the
-    # thumbnails of every deleted chat are still on disk, saying what was searched for, and
-    # only a replay is left to notice. `reapable_image_ids` is then the original clear's own
-    # snapshot, read back off the ledger, so finishing its reap is bounded to exactly what it
-    # was responsible for and cannot reach a newer chat's images.
+    # Search thumbnails are keyed by id, not thread.
+    # reapable_image_ids is the original clear's own snapshot off the ledger, so a replay's reap cannot reach a newer
+    # chat's images.
     if not replayed or reapable_image_ids:
         from core.inference.search_images import clear_cache
         await run_in_threadpool(clear_cache, reapable_image_ids)
@@ -1641,11 +1605,8 @@ def put_settings(payload: dict[str, Any], current_subject: str = Depends(get_cur
     try:
         parsed = ChatSettingsPayload.model_validate(payload)
     except ValidationError as exc:
-        # safe_validation_errors, not exc.errors(): the raw errors echo the offending
-        # input, and Starlette's JSONResponse dumps with allow_nan = False, so a
-        # rejected NaN or Infinity made the 400 handler itself unrenderable and the
-        # caller got a 500 for a request the validator had already refused. It also
-        # bounds a multi-megabyte value being quoted back.
+        # safe_validation_errors, not exc.errors(): raw errors echo the input, and Starlette dumps with allow_nan=False,
+        # so a rejected NaN made the 400 handler itself 500.
         raise HTTPException(status_code = 400, detail = safe_validation_errors(exc.errors())) from exc
     # Atomic read + deep-merge + write in one BEGIN IMMEDIATE so concurrent updates don't clobber.
     try:
@@ -1723,11 +1684,7 @@ def fork_thread(
         # threadpool lets run concurrently. Report it gone rather than as a server fault.
         raise HTTPException(status_code = 404, detail = f"Thread {thread_id} not found")
     messages = list_chat_messages(payload.newThreadId)
-    # Best-effort OpenAI container snapshot. Stub: a follow-up patch can
-    # call /v1/containers list+download / create+upload here and patch
-    # the new openaiCodeExecContainerId. For v1 we always start clean
-    # and surface the same warning regardless of provider so the UI can
-    # show a consistent "sandbox starts fresh" toast.
+    # Stub: v1 always starts a fresh container and surfaces the same warning for every provider.
     warning: Optional[str] = None
     if source.get("openaiCodeExecContainerId") or source.get("anthropicCodeExecContainerId"):
         warning = "Sandbox starts fresh in fork; files from parent are not carried over."

--- a/studio/backend/routes/data_recipe/jobs.py
+++ b/studio/backend/routes/data_recipe/jobs.py
@@ -246,12 +246,10 @@ def _inject_local_structured_response_format(
         if not isinstance(params, dict):
             params = {}
             clone["inference_parameters"] = params
-        # BaseInferenceParams is extra="forbid", so response_format can't sit at
-        # the top level. Its `extra_body` passthrough is spread into the request
-        # body top level by the OpenAI client, where llama-server reads
-        # response_format. Per tools/server/README.md the schema sits directly
-        # under response_format (not nested in a json_schema object as OpenAI
-        # expects) and is converted to a GBNF grammar for sampling.
+        # BaseInferenceParams is extra="forbid", so response_format rides `extra_body`; llama-server reads the schema
+        # directly under it, not nested in a json_schema object.
+        # Per tools/server/README.md the schema sits directly under response_format and is converted to a GBNF grammar
+        # for sampling.
         extra_body = params.get("extra_body")
         if not isinstance(extra_body, dict):
             extra_body = {}
@@ -259,11 +257,9 @@ def _inject_local_structured_response_format(
             "type": "json_schema",
             "schema": output_format,
         }
-        # The OpenAI chat endpoint now returns raw JSON by default for
-        # response_format requests (spec compliance for public clients). This
-        # internal opt-in flag rides through the OpenAI SDK's extra_body
-        # passthrough alongside response_format and re-enables the ```json
-        # markdown fence that data_designer's structured-output parser expects.
+        # Internal opt-in that re-enables the ```json fence data_designer's structured-output parser expects, which the
+        # spec-compliant default now omits.
+        # The flag rides through the OpenAI SDK's extra_body passthrough alongside response_format.
         extra_body["_unsloth_guided_fence"] = True
         params["extra_body"] = extra_body
         new_configs.append(clone)
@@ -288,8 +284,8 @@ def _inject_local_providers(
     if not providers:
         return None
 
-    # Collect local providers and pop is_local from ALL dicts. Strict `is True`
-    # guard so malformed payloads (1, "true") don't trigger the loopback rewrite.
+    # Strict `is True` so malformed payloads (1, "true") do not trigger the loopback rewrite.
+    # Collect local providers and pop is_local from ALL dicts.
     local_indices: list[int] = []
     for i, provider in enumerate(providers):
         if not isinstance(provider, dict):
@@ -303,9 +299,8 @@ def _inject_local_providers(
 
     endpoint = _resolve_local_v1_endpoint(request)
 
-    # Only gate on model-loaded if a local provider is reachable from an LLM
-    # column via a model_config. Orphan model_config nodes shouldn't block runs;
-    # the recipe never calls /v1 for them.
+    # Gate on model-loaded only for a local provider reachable from an LLM column: orphan
+    # model_config nodes never reach /v1 and must not block runs.
     local_names = {providers[i].get("name") for i in local_indices if providers[i].get("name")}
     used_aliases = _used_llm_model_aliases(recipe)
     referenced_providers = {
@@ -322,7 +317,7 @@ def _inject_local_providers(
         # the model is unloaded or swapped before the subprocess calls it.
         _ensure_selected_local_model_loaded(recipe, local_names)
 
-        from auth import storage  # deferred: avoids circular import
+        from auth import storage
 
         # Mint an internal sk-unsloth-* key scoped to this run via the unified
         # API-key path. Marked internal so it's hidden from the user's key list;
@@ -337,9 +332,8 @@ def _inject_local_providers(
         )
         internal_key_id = int(row["id"])
 
-    # Strip stale "external"-only fields (extra_headers/extra_body/api_key_env)
-    # the frontend may have serialized; a provider flipped from external to local
-    # could otherwise carry invalid JSON or rogue auth headers into the /v1 call.
+    # Strip stale external-only fields (extra_headers/extra_body/api_key_env): a provider
+    # flipped external -> local would carry invalid JSON or rogue auth headers into /v1.
     for i in local_indices:
         providers[i]["endpoint"] = endpoint
         providers[i]["api_key"] = token
@@ -348,21 +342,18 @@ def _inject_local_providers(
         providers[i].pop("extra_headers", None)
         providers[i].pop("extra_body", None)
 
-    # Force skip_health_check on local model_configs. llama-server's /v1/models
-    # response can differ from the selected id (cache aliases, GGUF variants),
-    # and we already gated on a loaded backend, so the health check would be
-    # redundant and could reject valid local selections.
+    # llama-server's /v1/models can differ from the selected id (cache aliases, GGUF variants), and a loaded backend was
+    # already gated on, so the health check only mis-rejects.
+    # Force skip_health_check on local model_configs.
     for mc in recipe.get("model_configs", []):
         if not isinstance(mc, dict):
             continue
         if mc.get("provider") in local_names:
             mc["skip_health_check"] = True
-            # Disable thinking for local data-recipe inference. The
-            # <think>...</think> preamble roughly doubles tokens per row and
-            # pushes answers past data_designer's json-fence regex. Forward
-            # chat_template_kwargs={enable_thinking: False} via extra_body so
-            # llama-server renders the template without it: llm-text columns get
-            # the latency cut, structured columns stop leaking think tags.
+            # Disable thinking for local recipe inference: the <think> preamble roughly doubles tokens per row and
+            # pushes answers past data_designer's json-fence regex.
+            # Forwarded as chat_template_kwargs={enable_thinking: False} via extra_body so llama-server renders the
+            # template without it.
             params = mc.get("inference_parameters")
             if not isinstance(params, dict):
                 params = {}
@@ -448,9 +439,8 @@ def create_job(
             log = logger,
         ) from exc
 
-    # Single try over get_job_manager() AND mgr.start() so a minted key never
-    # outlives the request on an unexpected exception; without the bare except it
-    # would live until its 24h TTL.
+    # One try over get_job_manager() AND mgr.start(), so an unexpected exception cannot leave
+    # a minted key alive for its full 24h TTL.
     try:
         mgr = get_job_manager()
         job_id = mgr.start(
@@ -489,7 +479,7 @@ def create_job(
 def _revoke_internal_api_key_safe(key_id: int) -> None:
     """Best-effort revoke of a workflow-minted key; never mask the caller's error."""
     try:
-        from auth import storage  # deferred: avoids circular import
+        from auth import storage
         storage.revoke_internal_api_key(key_id)
     except Exception:
         pass

--- a/studio/backend/routes/data_recipe/seed.py
+++ b/studio/backend/routes/data_recipe/seed.py
@@ -70,8 +70,8 @@ UNSTRUCTURED_ALLOWED_EXTS = {".pdf", ".docx", ".txt", ".md"}
 SEED_UPLOAD_DIR = seed_uploads_root()
 UNSTRUCTURED_UPLOAD_ROOT = unstructured_uploads_root()
 _SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
-# Frontend-generated upload namespace (UUID4 hex). Legacy node ids (n1, ...)
-# never match: those directories can be shared by several recipes.
+# Frontend-generated upload namespace (UUID4 hex); legacy node ids (n1, ...) never match,
+# since those directories can be shared by several recipes.
 _UPLOAD_UID_RE = re.compile(r"^[0-9a-f]{32}$")
 
 
@@ -456,8 +456,7 @@ def _get_block_total_size(block_dir: Path) -> int:
             continue
         if f.name.endswith(".extracted.txt") or f.name.endswith(".meta.json"):
             continue
-        # remove_unstructured_file keys on the name up to the first dot, which is empty for a
-        # "._" name, so a counted companion could never be removed and the quota never freed.
+        # remove_unstructured_file keys on the name up to the first dot.
         if is_appledouble_metadata(f):
             continue
         total += f.stat().st_size
@@ -543,16 +542,15 @@ async def upload_unstructured_file(
     # an upload that is about to be refused.
     budget = UNSTRUCTURED_RECIPE_UPLOAD_TOTAL_MAX_BYTES - _get_block_total_size(block_dir)
 
-    # Desktop drops arrive as a signed path, not multipart bytes: Tauri hands
-    # the webview a path, never a File (#9036). isinstance, not a truth test:
-    # called outside FastAPI, an unfilled param is still a truthy Form marker.
+    # Desktop drops arrive as a signed path.
+    # Tauri hands the webview a path, never a File (#9036); isinstance, not a truth test, since an unfilled Form param
+    # is still truthy.
     lease = native_path_lease if isinstance(native_path_lease, str) else None
     if lease:
         original_filename, content = _read_native_drop(lease, budget)
     elif file is not None and hasattr(file, "read"):
         original_filename = file.filename or "upload"
-        # Before the read, as it was: a rejected 500 MB upload must not be
-        # pulled into memory first.
+        # Before the read: a rejected 500 MB upload must not be pulled into memory first.
         _require_unstructured_ext(original_filename)
         content = await file.read()
     else:

--- a/studio/backend/routes/data_recipe/validate.py
+++ b/studio/backend/routes/data_recipe/validate.py
@@ -161,10 +161,8 @@ def validate(payload: RecipePayload, via_api_key: ViaApiKey = False) -> Validate
         try:
             build_config_builder(recipe)
         except ModuleNotFoundError as exc:
-            # data_designer is an optional runtime dep; static validation passed
-            # and full validation is deferred to run start, so a missing import
-            # shouldn't block the recipe. Restrict the bypass to data_designer so
-            # other ImportErrors still surface as failures.
+            # data_designer is an optional runtime dep and full validation is deferred to run start, so only ITS
+            # ImportError is bypassed; others still fail.
             if not (exc.name or "").startswith("data_designer"):
                 raise
             logger.debug(

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -483,17 +483,12 @@ async def export_lora_adapter(
         )
 
 
-# Live export log stream (Server-Sent Events).
-#
-# The export worker's stdout/stderr is piped to the orchestrator as log
-# entries (core/export/worker.py, orchestrator.py); this endpoint streams
-# them to the browser for a live terminal panel during export operations.
-#
-# Shape follows routes/training.py::stream_training_progress: each event
-# carries id/event/data, the stream starts with a `retry:` directive, and
-# `Last-Event-ID` is honored on reconnect.
 
 
+# Live export log SSE. Same shape as stream_training_progress: id/event/data, a leading `retry:`, and Last-Event-ID
+# honoured on reconnect.
+# Worker stdout/stderr reaches the orchestrator as log entries (core/export/worker.py, orchestrator.py); shape follows
+# routes/training.py.
 def _format_sse(
     data: str,
     event: str,

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -483,8 +483,6 @@ async def export_lora_adapter(
         )
 
 
-
-
 # Live export log SSE. Same shape as stream_training_progress: id/event/data, a leading `retry:`, and Last-Event-ID
 # honoured on reconnect.
 # Worker stdout/stderr reaches the orchestrator as log entries (core/export/worker.py, orchestrator.py); shape follows

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -16380,7 +16380,7 @@ async def _generate_tts_wav(
     _audio_cancel = threading.Event()
     prompt_for_budget = text
 
-    # Pick backend — both return (wav_bytes, sample_rate)
+    # Pick backend - both return (wav_bytes, sample_rate)
     llama_backend = get_llama_cpp_backend()
     # GGUF TTS goes straight to llama-server /completion, holding a slot with no
     # admission lease, so only the direct counter can show it in the slot readout.
@@ -17870,7 +17870,7 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
         # ── User / assistant messages ─────────────────────────
         combined_text: Optional[str] = None
         if isinstance(msg.content, str):
-            # Plain string content — pass through
+            # Plain string content - pass through
             combined_text = msg.content
         elif isinstance(msg.content, list):
             # Multimodal content parts

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -16325,6 +16325,7 @@ async def get_load_progress(current_subject: str = Depends(get_current_subject))
 
 
 # =====================================================================
+
 # Audio (TTS) Generation  (/audio/generate)
 # =====================================================================
 
@@ -17033,6 +17034,7 @@ async def openai_audio_transcriptions(
 
 
 # =====================================================================
+
 # Speech-to-text (STT) sidecar  (/audio/transcribe, /audio/stt/*)
 # =====================================================================
 
@@ -17584,6 +17586,7 @@ async def transcribe_audio_raw(
 
 
 # =====================================================================
+
 # OpenAI-Compatible Chat Completions  (/chat/completions)
 # =====================================================================
 
@@ -23529,6 +23532,7 @@ async def produce_openai_chat_completions(
 
 
 # =====================================================================
+
 # Sandbox file serving  (/sandbox/{session_id}/{filename})
 # =====================================================================
 
@@ -23854,6 +23858,7 @@ async def serve_sandbox_file(
 
 
 # =====================================================================
+
 # OpenAI-Compatible Models Listing  (/models → /v1/models)
 # =====================================================================
 
@@ -24596,6 +24601,7 @@ async def openai_retrieve_model(model_id: str, current_subject: str = Depends(ge
 
 
 # =====================================================================
+
 # OpenAI-Compatible Completions Proxy  (/completions → /v1/completions)
 # =====================================================================
 
@@ -24919,6 +24925,7 @@ async def openai_completions(request: Request, current_subject: str = Depends(ge
 
 
 # =====================================================================
+
 # OpenAI-Compatible Embeddings Proxy  (/embeddings → /v1/embeddings)
 # =====================================================================
 
@@ -25075,6 +25082,7 @@ async def openai_embeddings(request: Request, current_subject: str = Depends(get
 
 
 # =====================================================================
+
 # OpenAI Responses API  (/responses → /v1/responses)
 # =====================================================================
 
@@ -27143,6 +27151,7 @@ async def openai_responses(
 
 
 # =====================================================================
+
 # Anthropic-Compatible Messages API  (/messages → /v1/messages)
 # =====================================================================
 
@@ -29434,6 +29443,7 @@ async def _anthropic_plain_non_streaming(
 
 
 # =====================================================================
+
 # Client-side tool pass-through (Anthropic-native tools field)
 # =====================================================================
 
@@ -30285,6 +30295,7 @@ async def _anthropic_passthrough_non_streaming(
 
 
 # =====================================================================
+
 # Client-side tool pass-through (OpenAI-native /v1/chat/completions)
 # =====================================================================
 
@@ -32201,6 +32212,7 @@ async def _openai_passthrough_non_streaming_upstream(
 
 
 # ──────────────────────────────────────────────────────────────────────────
+
 # Diffusion (local text-to-image). Unsloth-only routes (studio_router is not mounted under /v1); the backend is in-process and
 # synchronous, so blocking calls are offloaded with asyncio.to_thread. Single error boundary: the backend raises, we map to HTTP.
 # ──────────────────────────────────────────────────────────────────────────
@@ -33215,6 +33227,7 @@ async def cancel_diffusion_generation(current_subject: str = Depends(get_current
 
 
 # ──────────────────────────────────────────────────────────────────────────
+
 # OpenAI-compatible images API (POST /v1/images/generations). The inference router is mounted at both /api/inference and /v1, so this
 # also answers /v1/images/generations for OpenAI clients. The Unsloth Image tab uses the richer /images/generate above; this is the spec shape.
 # ──────────────────────────────────────────────────────────────────────────

--- a/studio/backend/routes/llama.py
+++ b/studio/backend/routes/llama.py
@@ -141,7 +141,7 @@ def _log_llama_update_progress(job: LlamaUpdateJob) -> None:
             return
         _last_llama_update_step = step
         if step < prev:
-            return  # new update; resync without logging
+            return
     logger.info("llama_update_progress", to_tag = job.to_tag or "", percent = step * 10)
 
 

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -158,7 +158,6 @@ def _server_props() -> dict:
             if n_ctx:
                 settings["n_ctx"] = int(n_ctx)
         if "total_slots" not in props:
-            # Not zero beside a model this response advertises as loaded.
             try:
                 slots = int(getattr(llama_backend, "effective_parallel_slots", 0) or 0)
             except Exception:  # noqa: BLE001
@@ -170,8 +169,8 @@ def _server_props() -> dict:
     return props
 
 
-# Slash forms too: FastAPI's redirect never fires, since the catch-all fully matches
-# "/props/" and returns index.html. routes/inference.py registers "/v1/models/" likewise.
+# Slash forms too: FastAPI's redirect never fires.
+# The catch-all fully matches "/props/" and returns index.html; routes/inference.py registers "/v1/models/" likewise.
 @router.get("/props", include_in_schema = False)
 @router.get("/props/", include_in_schema = False)
 @router.get("/v1/props", include_in_schema = False)
@@ -186,8 +185,7 @@ async def llama_props(current_subject: str = Depends(get_current_subject)):
 async def studio_version(current_subject: str = Depends(get_current_subject)):
     """Bare /version only: Ollama spells it /api/version, and answering there is part
     of claiming to be Ollama."""
-    # Threaded like /props: the first call resolves the version, which shells out to git
-    # twice on a source checkout, and that must not sit on the event loop.
+    # Threaded like /props: the first call resolves the version.
     return {"version": await asyncio.to_thread(_studio_version)}
 
 
@@ -195,16 +193,13 @@ async def _probe_not_found():
     raise HTTPException(status_code = 404, detail = "API endpoint not found")
 
 
-# Without these a POST hit the GET-only catch-all and returned 405, reading as "exists,
-# wrong method". HEAD is here because Starlette does not admit it on a GET route
-# (measured, fastapi 0.141.1). GET stays with the catch-all so its asset lookup wins;
-# OPTIONS is untouched for CORS preflight.
+# Without these a POST hit the GET-only catch-all and returned 405, reading as "exists, wrong method". HEAD is here
+# because Starlette does not admit it on a GET route (measured, fastapi 0.141.1); GET stays with the catch-all so its
+# asset lookup wins, and OPTIONS is untouched for CORS preflight.
 _PROBE_DENIED_METHODS = ["HEAD", "POST", "PUT", "PATCH", "DELETE"]
 
 
-# Both forms of every path: no redirect rescues "POST /completion/", because the
-# catch-all is GET-only, so the slash form was a method mismatch and returned the 405
-# these routes exist to prevent.
+# Both forms of every path: no redirect rescues "POST /completion/"
 def _both_forms(path: str) -> tuple:
     return (path, path + "/")
 

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -359,7 +359,7 @@ async def refresh_mcp_server_tools(
             timeout = probe_timeout(server["url"], use_oauth),
             use_oauth = use_oauth,
         )
-    except Exception as exc:  # noqa: BLE001 — surface transport+timeout errors to UI
+    except Exception as exc:  # noqa: BLE001 - surface transport+timeout errors to UI
         logger.error(
             "mcp_servers.refresh_failed",
             server_id = server_id,

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -298,25 +298,18 @@ async def update_mcp_server(
         and "headers_json" not in changes
     ):
         changes["headers_json"] = None
-    # Clear persisted OAuth tokens when the URL changes or OAuth is disabled;
-    # fastmcp keys tokens by URL and would otherwise let a re-pointed server
-    # silently inherit the old account's credentials.
+    # Clear persisted OAuth tokens when the URL changes or OAuth is disabled
     if bool(old.get("use_oauth")) and (
         ("url" in changes and changes["url"] != old["url"]) or changes.get("use_oauth") is False
     ):
         await clear_oauth_tokens_async(old["url"])
-        # That await hands the loop to other requests, so re-read and re-gate
-        # before writing: a UI conversion to stdio landing in the window would
-        # otherwise let an API key's headers become the command's env.
+        # That await hands the loop to other requests.
         current = mcp_servers_db.get_server(server_id)
         if current is not None and (
             is_stdio(current["url"]) or is_stdio(changes.get("url", current["url"]))
         ):
             require_ui_session_for_local_commands(via_api_key)
-    # A new endpoint/auth makes cached tools wrong and disabling makes them unreachable, so drop
-    # them and let the next send re-probe; a rename leaves them valid. Live stdio sessions for the
-    # old endpoint close too. Gate on a real value change, not mere presence: the edit dialog
-    # resends url/headers/oauth unchanged on a rename, which must not drop the session.
+    # A new endpoint/auth makes cached tools wrong and disabling makes them unreachable.
     invalidates_tools = any(
         changes[k] != old.get(k) for k in changes.keys() & TOOL_CACHE_INVALIDATING_FIELDS
     )
@@ -352,8 +345,7 @@ async def refresh_mcp_server_tools(
     server = mcp_servers_db.get_server(server_id)
     if not server:
         raise HTTPException(status_code = 404, detail = "MCP server not found")
-    # Refresh uses the stored address, so re-check the stdio gate here too: a
-    # stdio row from a desktop DB must not spawn on a hosted/network host.
+    # Refresh uses the stored address.
     if is_stdio(server["url"]):
         require_ui_session_for_local_commands(via_api_key)
         if not stdio_mcp_enabled():
@@ -378,14 +370,11 @@ async def refresh_mcp_server_tools(
         if current is not None and not any(
             current.get(k) != server.get(k) for k in TOOL_CACHE_INVALIDATING_FIELDS
         ):
-            # Start the cool-off so the next chat send doesn't immediately re-hang
-            # on this server's timeout. If the row changed while the probe was
-            # awaiting, the failure belongs to the old config and must not park
-            # the newly edited server.
+            # Start the cool-off so the next chat send does not re-hang on this server's timeout; a row
+        # that changed mid-probe belongs to the old config and must not be parked.
             record_probe_failure(server_id, use_oauth)
         return McpServerProbeResult(ok = False, error = safe_curated_detail(exc))
 
-    # Warm the chat-path cache so the next send skips re-probing.
     current = mcp_servers_db.get_server(server_id)
     if current is not None and not any(
         current.get(k) != server.get(k) for k in TOOL_CACHE_INVALIDATING_FIELDS
@@ -446,9 +435,7 @@ async def test_mcp_server(
     current_subject: str = Depends(get_current_subject),
     via_api_key: ViaApiKey = False,
 ):
-    # URL/header validation must surface as 400 like create/update so the
-    # frontend's create-form pre-flight gets the same error semantics as the
-    # save call. Only catch transport/timeout errors below.
+    # URL/header validation must surface as 400 like create/update
     url = _validate_url(payload.url)
     # Caller-supplied and unstored, so the gate has to land before
     # list_tools_async -- after it the process has already started.

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -370,8 +370,9 @@ async def refresh_mcp_server_tools(
         if current is not None and not any(
             current.get(k) != server.get(k) for k in TOOL_CACHE_INVALIDATING_FIELDS
         ):
-            # Start the cool-off so the next chat send does not re-hang on this server's timeout; a row
-            # that changed mid-probe belongs to the old config and must not be parked.
+            # Start the cool-off so the next chat send does not re-hang on this server's timeout. If the row
+            # changed while the probe was awaiting, the FAILURE belongs to the old config and must not park
+            # the newly edited server.
             record_probe_failure(server_id, use_oauth)
         return McpServerProbeResult(ok = False, error = safe_curated_detail(exc))
 

--- a/studio/backend/routes/mcp_servers.py
+++ b/studio/backend/routes/mcp_servers.py
@@ -371,7 +371,7 @@ async def refresh_mcp_server_tools(
             current.get(k) != server.get(k) for k in TOOL_CACHE_INVALIDATING_FIELDS
         ):
             # Start the cool-off so the next chat send does not re-hang on this server's timeout; a row
-        # that changed mid-probe belongs to the old config and must not be parked.
+            # that changed mid-probe belongs to the old config and must not be parked.
             record_probe_failure(server_id, use_oauth)
         return McpServerProbeResult(ok = False, error = safe_curated_detail(exc))
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -2940,7 +2940,7 @@ def _scan_loras_sync(
             )
         )
 
-    # Scan exported models (merged, LoRA, base — skips GGUF)
+    # Scan exported models (merged, LoRA, base - skips GGUF)
     exported = scan_exported_models(exports_dir = resolved_exports_dir)
     for display_name, model_path, export_type, base_model in exported:
         lora_list.append(

--- a/studio/backend/routes/openai_codex_auth.py
+++ b/studio/backend/routes/openai_codex_auth.py
@@ -141,8 +141,7 @@ async def cancel_oauth(
     _provider(provider_id)
     try:
         flow = codex_auth.get_flow(provider_id, flow_id)
-        # Closing a loopback server can wait for an in-flight callback. Do not
-        # hold the credential guard while waiting for that handler to finish.
+        # Closing a loopback server can wait for an in-flight callback.
         await codex_auth.cancel_flow(flow.id)
         async with codex_auth.provider_oauth_write_guard(provider_id):
             with current_credential_write(credential):
@@ -179,11 +178,10 @@ async def list_subscription_models(
             provider_id, token, account_id, force = refresh
         )
     except (codex_auth.CodexAuthError, codex_client.CodexReauthorizationError) as exc:
-        # resolve_access has already marked the connection as needing reauthorization, so
-        # say so in the answer rather than through a 401: the client's authFetch reads
-        # every 401 as an expired Unsloth session, refreshes it and retries, and the retry
-        # would come back as a plain curated list with the connection looking healthy.
-        # A source the picker does not treat as authoritative carries the signal instead.
+        # Say it in the answer rather than through a 401: the client's authFetch reads every 401 as an expired Unsloth
+        # session and retries, and the retry looks healthy.
+        # resolve_access has already marked the connection as needing reauthorization, so a source the picker does not
+        # treat as authoritative carries the signal instead.
         logger.info(
             "openai_codex.model_list_reauthorization_required",
             provider_id = provider_id,

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -253,7 +253,7 @@ class SearchRequest(BaseModel):
     project_id: str | None = None
     top_k: int = Field(default = config.TOP_K_HYBRID, ge = 1, le = 50)
     min_score: float = 0.0
-    mode: str = "hybrid"  # hybrid | lexical | dense
+    mode: str = "hybrid"
 
 
 class LinkFolderRequest(BaseModel):
@@ -387,14 +387,11 @@ def list_knowledge_bases(subject: str = Depends(get_current_subject)) -> dict:
     try:
         conn = rag_db.get_connection()
     except rag_db.RagExtensionUnavailable:
-        # RAG_AVAILABLE only covers the import; the native library can still fail to
-        # load per connection (a missing vec0 binary in the venv). The UI polls this
-        # list, so 500ing here costs a traceback every few seconds for a condition that
-        # never changes within a session. rag_db has warned once; an empty list is what
-        # a machine without RAG has anyway. The marker is what keeps that honest: it is
-        # the difference between "no knowledge bases yet" and "RAG cannot run here", and
-        # without it the empty page looks ready to use. Only the unavailable case
-        # degrades: a locked or corrupt database still raises.
+        # RAG_AVAILABLE only covers the import; the native library can still fail to load per connection (a missing vec0
+        # binary in the venv). The UI polls this list, so 500ing costs a traceback every few seconds for a condition
+        # that never changes in a session, and rag_db has warned once. The marker is the difference between "no
+        # knowledge bases yet" and "RAG cannot run here". Only the unavailable case degrades: a locked or corrupt
+        # database still raises.
         return {"knowledgeBases": [], **_availability(False)}
     try:
         kbs = store.list_kbs(conn)
@@ -953,15 +950,15 @@ def search(payload: SearchRequest, subject: str = Depends(get_current_subject)) 
 # Per-process secret so pdf.js range requests fetch the file without a bearer
 # header; tokens only work on this server instance.
 _PREVIEW_SECRET = secrets.token_bytes(32)
-_PREVIEW_TTL = 600  # seconds
+_PREVIEW_TTL = 600
 
 _CONTENT_TYPES = {
     ".pdf": "application/pdf",
     ".txt": "text/plain; charset=utf-8",
     ".md": "text/markdown; charset=utf-8",
     ".markdown": "text/markdown; charset=utf-8",
-    # Served as plain text, never text/html: an uploaded HTML document rendered
-    # same-origin would execute its scripts with access to the app's storage.
+    # Served as plain text, never text/html: an uploaded HTML document rendered same-origin would
+    # execute its scripts with access to the app's storage.
     ".html": "text/plain; charset=utf-8",
     ".htm": "text/plain; charset=utf-8",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -248,14 +248,10 @@ def _sanitize_config(
         provider = providers_db.get_provider(provider_id)
         if provider is None:
             raise HTTPException(status_code = 404, detail = "Provider config not found")
-        # The saved row is the source of truth for routing, so validate against
-        # it rather than against the type the client sent. A self-hosted
-        # connection is stored under the backend "openai" type but surfaced to
-        # the UI as "custom" / "vllm" / "ollama" / "llama_cpp", and the composer
-        # offers research for those aliases because their registry entries
-        # declare Unsloth tools. Comparing the two for equality therefore 400s
-        # exactly the connections this path exists to serve, while the ordinary
-        # inference route already overrides the type from the row.
+        # The saved row is the source of truth for routing, so validate against it rather than the type the client sent:
+        # a self-hosted connection is stored under the backend "openai" type but surfaced as "custom" / "vllm" /
+        # "ollama" / "llama_cpp", so comparing the two for equality 400s exactly the connections this path exists to
+        # serve.
         saved_provider_type = provider["provider_type"]
         if not provider_runs_local_tools(saved_provider_type) or not provider["is_enabled"]:
             raise HTTPException(
@@ -391,10 +387,9 @@ def create_research_run(
         raise HTTPException(
             status_code = 400, detail = "userMessageId must identify a user message in the thread"
         )
-    # A handed-off question counts as the text. An image-, audio- or video-only send is a
-    # normal composer turn, and a multimodal model that reads one and calls deep_research
-    # passes the question it wrote; the worker researches config.question, so refusing here
-    # on the message's own (empty) text ends an otherwise complete handoff in a toast.
+    # A handed-off question counts as the text. The worker researches config.question, so a multimodal turn that reads
+    # an image and calls deep_research passes the question it wrote, and refusing on the message's own empty text ends a
+    # complete handoff in a toast.
     if not message_text_with_pastes(user_message).strip() and not (payload.question or "").strip():
         raise HTTPException(
             status_code = 400,

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -2669,7 +2669,7 @@ def update_embedding_model(
             local_only_load = local_only_load,
         ).blocked:
             # 403, not 409: the client routes every 409 into the forceable "save anyway" flow, but this is a
-    # hard, non-forceable security refusal.
+            # hard, non-forceable security refusal.
             if local_only_load:
                 detail = (
                     f"{model!r} has cached pickle weights that cannot be security-scanned "
@@ -2724,7 +2724,7 @@ def update_embedding_model(
         # it out also prevents a later runtime fallback from mislabelling it.
         trusted_gguf_repo = plan.download_repo if destination_is_llama else None
         # The setting may activate so both settings surfaces stay in sync, but its loader stays
-    # cache-only until the transfer completes, or a close/cancel becomes an implicit download.
+        # cache-only until the transfer completes, or a close/cancel becomes an implicit download.
         trusted_download_pending = bool(plan.download_repo and not plan.cached)
     else:
         # Save anyway, over a failed plan: nothing validated to record, but the

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -412,10 +412,7 @@ def _get_generation_preset_settings(kind, schema):
         response, _ = _validated_without_invalid_fields(
             schema, {**state, "customPresets": readable}
         )
-    # Saved means the store owns the CURRENT recipe, not merely that something is stored. A blob
-    # holding named presets but no recipe -- a preset write that landed while the state write did
-    # not -- would otherwise hand back schema defaults dressed as the user's own choice, and the
-    # client suppresses the resident model's defaults for exactly as long as it believes that.
+    # Saved means the store owns the CURRENT recipe, not merely that something is stored.
     response.saved = isinstance(stored.get("currentParams"), dict)
     return response
 
@@ -661,17 +658,14 @@ class ModelMemoryResponse(BaseModel):
 
 
 class VramBudgetPayload(BaseModel):
-    # None clears the stored budget so env/default applies again; it cannot also
-    # mean "leave untouched" as the model-memory switches do, since there is one
-    # field. Hence required, not defaulted: with a default, {} would mean "clear it"
-    # and a client that dropped the field would silently discard the stored budget.
+    # None clears the stored budget so env/default applies again; it cannot also mean "leave
+    # untouched", hence required rather than defaulted: with a default, a client that dropped the
+    # field would silently discard the stored budget.
     fraction: Optional[float] = Field(ge = VRAM_FRACTION_MIN, le = VRAM_FRACTION_MAX)
 
     @field_validator("fraction", mode = "before")
     @classmethod
     def _reject_bool(cls, value: object) -> object:
-        # bool subclasses int, so non-strict parsing turns True into 1.0 and stores
-        # the max budget instead of 422; pydantic coerces before the util's guard.
         if isinstance(value, bool):
             raise ValueError("fraction must be a number, not a boolean")
         return value
@@ -754,19 +748,19 @@ class OpenAIAutoSwitchResponse(BaseModel):
     media_auto_switch_model: bool = DEFAULT_MEDIA_AUTO_SWITCH_ENABLED
 
 
-# A quant suffix, as modelOverrideKey builds it. Matched against the loader's quant pattern,
-# not a length heuristic: a POSIX path may hold a colon and inherit another model's flags.
+# A quant suffix as modelOverrideKey builds it, matched against the loader's quant pattern rather
+# than a length heuristic: a POSIX path may hold a colon and inherit another model's flags.
 _MAX_VARIANT_SUFFIX_LEN = 64
 
-# A local id is a path plus an optional quant suffix, and LoadRequest.model_path is unbounded.
-# A limit under PATH_MAX would 422 the server sync while the local save succeeded.
+# A local id is a path plus an optional quant suffix, and LoadRequest.model_path is unbounded: a
+# limit under PATH_MAX would 422 the server sync while the local save succeeded.
 MAX_MODEL_OVERRIDE_KEY_LEN = 4096 + 1 + _MAX_VARIANT_SUFFIX_LEN
 
 # GgufVariantDetail.quant may be a path-qualified variant key, not just a quant suffix.
 MAX_GGUF_VARIANT_KEY_LEN = 4096
 
-# A list longer than MAX_GPU_ID cannot name a device the normalizer would store, so bound it
-# here and reject an oversized array at the boundary instead of walking it.
+# A list longer than MAX_GPU_ID cannot name a device the normalizer would store, so reject an
+# oversized array at the boundary instead of walking it.
 MAX_GPU_IDS = MAX_GPU_ID + 1
 
 
@@ -796,24 +790,18 @@ class ModelOverridePayload(BaseModel):
     # prompt batch sizes (--batch-size / --ubatch-size), gguf-only; none = llama.cpp defaults
     n_batch: Optional[int] = Field(default = None, ge = BATCH_SIZE_MIN, le = BATCH_SIZE_MAX)
     n_ubatch: Optional[int] = Field(default = None, ge = BATCH_SIZE_MIN, le = BATCH_SIZE_MAX)
-    # The remaining llama-server tuning the picker remembers. model_override_load_kwargs
-    # already applies all four off a stored row, so a route that drops them leaves the
-    # setting reaching a picker load and nothing else, and the panel reads the gap back
-    # as unset. Load mode is a discrete set, left to the normalizer like the KV dtype.
+    # model_override_load_kwargs already applies all four off a stored row, so a route that drops them leaves the
+    # setting reaching a picker load and nothing else.
     load_mode: Optional[str] = Field(default = None, max_length = 32)
     spec_draft_cache_type: Optional[str] = Field(default = None, max_length = 32)
     # Stored on "is not None", not on truth: 0 checkpoints and a 0 or -1 cache are
     # meaningful values (none kept; cache disabled; no limit). Bounds mirror LoadRequest.
     ctx_checkpoints: Optional[int] = Field(default = None, ge = 0, le = CTX_CHECKPOINTS_MAX)
     cache_ram: Optional[int] = Field(default = None, ge = CACHE_RAM_MIN_MIB, le = CACHE_RAM_MAX_MIB)
-    # Does this client know the four above exist? A save REPLACES the entry, so an
-    # omission from a build that predates them is indistinguishable from a user
-    # clearing them, and during an upgrade -- a cached bundle, or another LAN client
-    # still on the old build -- that silently deletes settings it never sent. Only a
-    # client that sets this may clear by omission; for anyone else the stored values
-    # are carried over. Default False so an old payload, which cannot set it, is the
-    # safe case. Not a blanket carry-over: that would make clearing impossible for
-    # everyone, trading a mixed-version window for a permanent bug.
+    # Does this client know the four above exist? A save REPLACES the entry, so an omission from a build that predates
+    # them is indistinguishable from a user clearing them. Only a client that sets this may clear by omission; default
+    # False, so an old payload is the safe case. Not a blanket carry-over: that would make clearing impossible for
+    # everyone.
     mirrors_server_tuning: bool = False
     tensor_parallel: bool = False
     disable_vision: bool = False
@@ -826,9 +814,7 @@ class ModelOverridePayload(BaseModel):
     gpu_ids: Optional[list[int]] = Field(default = None, max_length = MAX_GPU_IDS)
     # An all-default save carries no fields, like a forget; None keeps the legacy contract.
     remove: Optional[bool] = None
-    # Fill in, don't replace: the backfill reads the map once then writes each model, so another
-    # tab's save was overwritten by this browser's older copy. Field level, not entry level: a
-    # legacy entry holds only some fields, and skipping it would strand the rest.
+    # Fill in, don't replace: the backfill reads the map once then writes each model.
     fill_absent_fields: bool = False
 
     @field_validator("chat_template_override")
@@ -860,9 +846,7 @@ class ModelOverridePayload(BaseModel):
     )
     @classmethod
     def _no_booleans(cls, value: Any) -> Any:
-        # bool subclasses int and pydantic parses non-strictly, so `true` arrives as 1: a
-        # payload could pin GPU 1 or set a one-token context. _bounded_int rejects bools but
-        # never sees one, since coercion happens here first. Only bools, so lax parsing stays.
+        # bool subclasses int and pydantic parses non-strictly.
         if isinstance(value, bool):
             raise ValueError("Expected a number, got a boolean.")
         if isinstance(value, list) and any(isinstance(item, bool) for item in value):
@@ -872,10 +856,9 @@ class ModelOverridePayload(BaseModel):
 
 class ModelOverridesResponse(BaseModel):
     overrides: dict[str, dict]
-    # Filled only when the caller named a model: the entry ITS load would apply,
-    # resolved here rather than in the browser. The folding rules are Python's
-    # (casefold is not toLowerCase, and an ambiguous fold matches nothing on
-    # purpose), so a client mirroring them can only approximate.
+    # Filled only when the caller named a model, resolved here rather than in the browser: the folding rules are
+    # Python's, so a client mirroring them can only approximate.
+    # casefold is not toLowerCase, and an ambiguous fold matches nothing on purpose.
     resolved: Optional[dict] = None
     resolved_key: Optional[str] = None
 
@@ -960,8 +943,7 @@ def _model_memory_reload_required() -> bool:
     if state is _NO_LAUNCH:
         return False
 
-    # Same predicate the duplicate-load comparator uses, so the reload hint and
-    # the reload path can never disagree.
+    # Same predicate the duplicate-load comparator uses.
     from core.inference.llama_server_args import memory_state_satisfies_settings
 
     return not memory_state_satisfies_settings(state, policy_active, mlock_applicable)
@@ -1019,8 +1001,7 @@ def _vram_budget_reload_required(fraction: float) -> bool:
         if not backend.is_active:
             return False
         launched = getattr(backend, "_vram_fraction_launched", None)
-        # A child predating this field, or from a path that never set it, cannot be
-        # compared; say no rather than nagging on every save.
+        # A child predating this field cannot be compared, so say no rather than nagging on every save.
         if launched is None:
             return False
         return float(launched) != float(fraction)
@@ -1300,8 +1281,9 @@ class LastLocalModelPayload(BaseModel):
     gguf_variant: Optional[str] = Field(default = None, max_length = MAX_GGUF_VARIANT_KEY_LEN)
     # Epoch ms of the load; orders writes from surfaces that keep their own local shadow.
     loaded_at: Optional[int] = Field(default = None, ge = 0)
-    # The client clock when the request was sent: the skew (server_now - client_now)
-    # translates loaded_at into the server frame. Never persisted.
+    # The client clock when the request was sent: the skew translates loaded_at into the server
+    # frame. Never persisted.
+    # The skew is server_now - client_now.
     client_now: Optional[int] = Field(default = None, ge = 0)
 
 
@@ -1452,8 +1434,7 @@ def update_openai_auto_switch(
         ) from exc
     idle_unload_active = get_auto_unload_idle_seconds() > 0
     if not keep_kv or not idle_unload_is_configured():
-        # Drop already-saved chat context too. Configured, not effective: residency
-        # zeroes the TTL, and that must not discard KV the user still wants.
+        # Drop already-saved chat context too.
         from core.inference.llama_keepwarm import purge_kv_resume
         purge_kv_resume()
     return OpenAIAutoSwitchResponse(
@@ -1608,14 +1589,7 @@ def _fill_target_id(target_id: str) -> str:
     return target_id
 
 
-# One override write at a time. A save stores its target key and then reads the map back to
-# retire the other spelling of the same cached repo, and a remove clears up to four keys, each
-# its own transaction: atomic on their own, but not as a sequence. This route is a plain `def`,
-# so FastAPI runs it in a threadpool, and two clients saving one quant under both spellings (the
-# repo id the picker sends and the snapshot path an upgraded install still holds) could each
-# write before either cleanup ran and then retire the other's row, leaving no override at all
-# from two saves that both returned 200. Serialize the whole handler instead: overrides are
-# written by a settings edit, never on a hot path, and the server runs one process.
+# One override write at a time. A save stores its target key and then reads the map back
 _override_write_lock = threading.Lock()
 
 
@@ -1648,9 +1622,9 @@ def update_openai_auto_switch_override(
             raise ValueError("fill_absent_fields cannot be combined with remove.")
         # Only model_id is the documented "remove"; otherwise omitted flags carry over.
         requested_extra_args = payload.llama_extra_args
-        # fill_absent_fields and mirrors_server_tuning are write modes, not saved fields:
-        # leaving either in would make every payload look non-empty (they are bools, so
-        # exclude_none does not drop them) and break the legacy "no fields means remove".
+        # fill_absent_fields and mirrors_server_tuning are write modes.
+        # Leaving either in would make every payload look non-empty (they are bools, so exclude_none does not drop them)
+        # and break the legacy "no fields means remove".
         saved_fields = payload.model_dump(
             exclude = {
                 "model_id",
@@ -1664,9 +1638,7 @@ def update_openai_auto_switch_override(
         if payload.remove is not None:
             is_removal = payload.remove
         else:
-            # Both booleans are carried, not just counted: they are stored only when
-            # true, so an override whose one setting is either of them has no other
-            # saved field and would otherwise read as a removal and be deleted.
+            # Both booleans are carried.
             is_removal = (
                 not payload.tensor_parallel
                 and not payload.disable_vision
@@ -1683,7 +1655,6 @@ def update_openai_auto_switch_override(
             if not (payload.fill_absent_fields and stored):
                 requested_extra_args = stored.get("llama_extra_args")
                 if requested_extra_args is None:
-                    # First per-quant save for flags under the bare repo id; carry them over.
                     bare_id = _bare_model_id(payload.model_id)
                     if bare_id:
                         requested_extra_args = get_model_override(bare_id).get("llama_extra_args")
@@ -1705,10 +1676,8 @@ def update_openai_auto_switch_override(
         if payload.remove is True:
             extra_args = []
         elif payload.llama_extra_args is None:
-            # Carried over, not sent: the caller is saving some other field and this
-            # value predates the request. A flag denylisted since it was written is
-            # dropped rather than refused, or an unrelated save fails naming a flag
-            # the user may not remember writing (and cannot fix from this payload).
+            # Carried over, not sent: a flag denylisted since it was written is dropped rather than refused, or an
+            # unrelated save fails naming a flag the user cannot fix from this payload.
             extra_args, dropped_flags = drop_managed_flags(requested_extra_args)
             if dropped_flags:
                 logger.warning(
@@ -1718,22 +1687,14 @@ def update_openai_auto_switch_override(
                 )
         else:
             extra_args = validate_extra_args(requested_extra_args)
-        # Same shape as the extra-args carry-over above, for the same reason: a save
-        # replaces the entry, so a field the caller never knew about must survive it.
-        # A client that declares it mirrors these clears by omission as usual; an
-        # older one keeps whatever is stored. On a remove the whole entry goes, so
-        # there is nothing to preserve.
-        # Gated on is_removal, not on payload.remove: the documented legacy contract is a
-        # payload carrying only model_id, which leaves remove None while is_removal is
-        # true. Carrying anything over there would rebuild a non-empty row and the clear
-        # would silently do nothing.
+        # Same shape as the extra-args carry-over above, for the same reason: a save replaces the entry, so a field the
+        # caller never knew about must survive it. Gated on is_removal, not on payload.remove: the documented legacy
+        # contract is a payload carrying only model_id, which leaves remove None while is_removal is true.
         _tuning_fields = ("load_mode", "spec_draft_cache_type", "ctx_checkpoints", "cache_ram")
         _kept_tuning = {name: getattr(payload, name) for name in _tuning_fields}
         if not payload.mirrors_server_tuning and not is_removal:
-            # The same spellings the extra-args carry-over walks, and in the same order.
-            # A cached repo is not an ordinary folded match, so a save under the repo id
-            # while the row sits under the snapshot path finds nothing here and then
-            # retires that alias below, taking the tuning with it.
+            # The same spellings the extra-args carry-over walks: a cached repo is not an ordinary folded match, so a
+            # save under the repo id would find nothing and retire the alias with its tuning.
             _alias_ids = [payload.model_id]
             for _candidate in (
                 _bare_model_id(payload.model_id),
@@ -1742,19 +1703,12 @@ def update_openai_auto_switch_override(
             ):
                 if _candidate and _candidate not in _alias_ids:
                     _alias_ids.append(_candidate)
-            # Load order, not the order they were collected in. A lookup reads the
-            # concrete load path before the advertised repo id, so on a cache upgraded
-            # from a build that keyed rows by path, the snapshot row is the one that
-            # applies and the one the retirement block below clears. Reading the repo
-            # row first would adopt tuning no load has ever used and drop the tuning
-            # that was live. Stable, so every other spelling keeps its position.
+            # Load order, not collection order: a lookup reads the concrete load path before the advertised repo id, so
+            # reading the repo row first adopts tuning no load has used.
             _alias_ids.sort(key = lambda _key: not is_cache_load_path_key(_key))
-            # Taken as a unit from the first row that exists, not field by field down
-            # the list. A load stops at the first non-empty row (resolve_override_for_load)
-            # rather than merging, so tuning in a row that never wins is dormant, and
-            # filling a gap in the winner from a loser would switch it on as a side effect
-            # of saving something unrelated. Single-valued above, so the distinction only
-            # shows up here.
+            # Taken as a unit from the first row that exists.
+            # A load stops at the first non-empty row (resolve_override_for_load) rather than merging, so filling a gap
+            # in the winner from a loser would switch dormant tuning on.
             for _alias_id in _alias_ids:
                 _stored_tuning = get_model_override(_alias_id)
                 if not _stored_tuning:
@@ -1781,12 +1735,7 @@ def update_openai_auto_switch_override(
                     llama_extra_args = [],
                     max_seq_length = None,
                 )
-            # The mirror image of the carry-over above: a save under repo:QUANT copies the
-            # flags off a legacy bare `repo` entry and leaves it in place, and the loader falls
-            # back to it when the qualified key misses, so clearing only the qualified key hands
-            # the same flags straight back and the forget does nothing. Nothing in the UI can
-            # reach that bare entry. Only once it is nobody else's fallback, though: it backs
-            # every quant with no entry of its own, so forgetting Q4 must not strip Q8.
+            # The mirror image of the carry-over above: a save under repo:QUANT copies
             bare_id = _bare_model_id(payload.model_id)
             if (
                 bare_id
@@ -1810,13 +1759,9 @@ def update_openai_auto_switch_override(
             # id would leave two keys for one model, making every other casing ambiguous.
             target_id = resolve_model_override_key(payload.model_id) or payload.model_id
             if payload.fill_absent_fields:
-                # A fill retires nothing below, so it must not create the higher-priority
-                # spelling of a row the server already holds.
+                # A fill retires nothing below.
                 target_id = _fill_target_id(target_id)
-            # An explicit clear keeps a row even when nothing else is set, so long as a
-            # fallback would otherwise answer for this model: "no launch flags" and
-            # "nothing stored" are the same thing everywhere else, and different here.
-            # Written on the quant's own key, so no other quant is touched.
+            # An explicit clear keeps a row even when nothing else is set.
             keep_empty = (
                 payload.llama_extra_args == []
                 and not payload.fill_absent_fields
@@ -1848,12 +1793,7 @@ def update_openai_auto_switch_override(
                 gpu_ids = payload.gpu_ids,
                 fill_absent_fields = payload.fill_absent_fields,
             )
-            # A repo cached outside the active HF cache is keyed here by its repo id, while the
-            # loader reads the snapshot path first and an older release keyed the row by that
-            # path, so an upgrade can hold both. Retire the spelling this save supersedes (its
-            # flags were carried over above), or the leftover outranks the key just written.
-            # After the write, so a rejected save deletes nothing. Not on a fill: that pass only
-            # adds, and the migration mirroring both spellings must not delete either.
+            # A repo cached outside the active HF cache is keyed here by its repo id
             if not payload.fill_absent_fields:
                 for alias_id in cached_repo_alias_keys(target_id):
                     set_model_override(alias_id, llama_extra_args = [], max_seq_length = None)
@@ -1888,8 +1828,7 @@ class EmbeddingModelResponse(BaseModel):
     is_custom: bool
     # Whether THIS model is held in memory right now, for the status line.
     loaded: bool = False
-    # Whether ANY embedder is resident, for the Unload action: saving a new model
-    # does not release the old one, so the selected model is the wrong question.
+    # Whether ANY embedder is resident.
     backend_loaded: bool = False
 
 
@@ -1991,9 +1930,8 @@ def _local_gguf_backend_error(model: str) -> str | None:
 
     from utils.paths import normalize_path
 
-    # Normalized as _resolve_local_gguf normalizes it, or a WSL drive-letter dir
-    # reads as "not a directory" here and the 409 that would have explained it
-    # never fires.
+    # Normalized as _resolve_local_gguf normalizes it, or a WSL drive-letter dir reads as "not a
+    # directory" and the 409 that would have explained it never fires.
     if not Path(normalize_path(model)).expanduser().is_dir():
         return None
     from core.rag.embed_llama_server import LlamaServerBackend
@@ -2021,7 +1959,7 @@ def _hf_gguf_backend_error(model: str, hf_token: Optional[str]) -> str | None:
     from pathlib import Path
 
     if Path(model).expanduser().exists():
-        return None  # local paths are handled by the local checks
+        return None
     if not _llama_backend_active(model):
         return None
     candidates = _embedding_gguf_candidates(model)
@@ -2071,8 +2009,7 @@ def _embedding_gguf_candidates(model: str) -> list[str]:
     """Repos the loader would try for ``model``'s GGUF, in its order."""
     from core.rag import config as rag_config
 
-    # An env override is the loader's only source. A stored mirror from an older
-    # selection must not outrank it, and discovery must not replace it later.
+    # An env override is the loader's only source.
     if rag_config.gguf_repo_is_explicit():
         return rag_config.gguf_repo_candidates(model)
     try:
@@ -2085,8 +2022,7 @@ def _embedding_gguf_candidates(model: str) -> list[str]:
     )
 
 
-# A GGUF conversion must come from the same owner as the model. Repo names are
-# not proof of provenance, so an unsloth/ pick only ever downloads from unsloth.
+# A GGUF conversion must come from the same owner as the model.
 _GGUF_MIRROR_SEARCH_LIMIT = 25
 _GGUF_LIST_DEADLINE_S = 20.0
 _EMBEDDING_RESOLVE_DEADLINE: ContextVar[float | None] = ContextVar(
@@ -2173,8 +2109,8 @@ def _search_hub_for_gguf(model: str, hf_token: Optional[str]) -> Optional[tuple[
     re-upload, and picking unsloth/X must download unsloth's own weights."""
     from core.rag import config as rag_config
 
-    # The loader cannot open a discovered mirror while an explicit repo override
-    # is active, so returning one would create a download that can never satisfy it.
+    # The loader cannot open a discovered mirror while an explicit repo override is active, so
+    # returning one would create a download that can never satisfy it.
     if rag_config.gguf_repo_is_explicit():
         return None
     owner, _, name = model.rpartition("/")
@@ -2453,15 +2389,12 @@ def _local_sentence_transformer_is_present(model: str) -> bool:
         # A directory has to hold a checkpoint, not merely exist: modules.json
         # alone also passes is_embedding_model's local-path check.
         if not p.is_dir():
-            # SentenceTransformer takes a directory or a repo id, never a bare
-            # checkpoint file.
+            # SentenceTransformer takes a directory or a repo id, never a bare checkpoint file.
             return False
         if not any(_is_st_weight_name(child.name) and child.is_file() for child in p.rglob("*")):
             return False
-        # And a WHOLE one: half a shard family, or a module modules.json declares
-        # and the directory lacks, read as ready and failed at the first index.
-        # Same completeness test a Hub snapshot gets, so a local copy of a model
-        # is judged the way the downloaded one is.
+        # And a WHOLE one: half a shard family, or a module modules.json declares and the directory lacks, reads as
+        # ready and fails at the first index.
         from utils.utils import checkpoint_directory_is_complete
 
         return checkpoint_directory_is_complete(p)
@@ -2478,9 +2411,7 @@ def _resolve_embedding_model_plan(
     The PUT must not persist a client assertion that the GET never validated,
     so both routes use this exact resolver.
     """
-    # Resolve for the model being selected, not the backend still serving the
-    # previous model. A model-scoped runtime fallback must not force the next
-    # selection onto llama-server.
+    # Resolve for the model being selected.
     on_llama = _llama_backend_active(resolved)
     backend: Literal["llama", "sentence-transformers"] = (
         "llama" if on_llama else "sentence-transformers"
@@ -2493,22 +2424,14 @@ def _resolve_embedding_model_plan(
             return EmbeddingModelResolveResponse(
                 embedding_model = resolved, backend = backend, cached = True
             )
-        # The alias-aware predicate alone: it already pairs the ST file family with
-        # the loadable check PER CANDIDATE. Conjoining the generic one asked it
-        # about whichever cache directory matched first, so a stale literal entry
-        # beside a complete sentence-transformers/ snapshot reported uncached.
-        # The repo the cache hit came from, not just whether there was one: the
-        # PUT verifies and scans whatever this names, and for a slashless alias
-        # that is the sentence-transformers/ candidate. The literal id sent both
-        # at a repo that usually does not exist, 409ing a model already on disk.
+        # The alias-aware predicate alone, which already pairs the ST file family with the loadable check per candidate;
+        # the repo the cache hit came from is what the PUT verifies and scans.
         cached_source = _cached_st_source(resolved)
         cached = cached_source is not None
         source = None if cached else _st_weight_source(resolved, token)
         if not cached and source is None:
-            # is_embedding_model gates on tags, so a feature-extraction repo
-            # publishing no loadable checkpoint reaches here and would be offered
-            # as a download ST cannot open. The llama-to-ST fallback already
-            # proves the weights exist; this path did not.
+            # is_embedding_model gates on tags, so a feature-extraction repo publishing no loadable checkpoint would be
+            # offered as a download ST cannot open.
             return EmbeddingModelResolveResponse(
                 embedding_model = resolved,
                 backend = backend,
@@ -2535,10 +2458,8 @@ def _resolve_embedding_model_plan(
         )
 
     local_gguf = _resolves_as_local_gguf(resolved)
-    # Routing a model here does not make the backend runnable: without a binary
-    # the plan is advertised as valid and the transfer persisted, and the first
-    # warm fails in _resolve_binary. Scoped to models only llama can serve, since
-    # one with safetensors still has the usable ST fallback further down.
+    # Routing a model here does not make the backend runnable: without a binary the plan is advertised as valid and the
+    # first warm fails in _resolve_binary.
     llama_only = (
         local_gguf
         or _model_names_gguf_repo(resolved)
@@ -2601,8 +2522,7 @@ def _resolve_embedding_model_plan(
             return EmbeddingModelResolveResponse(
                 embedding_model = resolved,
                 backend = backend,
-                # Every remote/cache/fallback probe above has already failed;
-                # do not repeat the bounded Hub calls merely to format an error.
+                # Every remote/cache/fallback probe above has already failed
                 error = _no_embedding_weights_error(candidates),
             )
         st_repo, _st_files = st_plan
@@ -2702,11 +2622,9 @@ def update_embedding_model(
             detail = "The embedding download repository was not validated for this model.",
         )
     destination_is_llama = plan.backend == "llama"
-    # Verify and scan the repo the loader will actually open. A slashless alias
-    # resolves under sentence-transformers/, so checking the literal name scanned a
-    # repo that usually does not exist (failing open, or a forceable 409) or, worse,
-    # a different top-level repo that does. Only the ST path can diverge: a llama
-    # download_repo is the GGUF companion, which is not what is scanned here.
+    # Verify and scan the repo the loader will actually open: a slashless alias resolves under sentence-transformers/,
+    # so the literal name scans a repo that usually does not exist.
+    # Only the ST path can diverge: a llama download_repo is the GGUF companion, which is not what is scanned here.
     verify_target = model
     if not destination_is_llama and plan.download_repo and plan.download_repo != model:
         verify_target = plan.download_repo
@@ -2714,27 +2632,23 @@ def update_embedding_model(
     # A local GGUF on the llama-server backend is accepted as-is: it is exactly
     # what the backend loads, and HF metadata cannot verify a local path.
     is_local_gguf = destination_is_llama and _resolves_as_local_gguf(model)
-    # The pickle gate only matters for the sentence-transformers backend, which is what
-    # deserializes pickles. On the llama-server backend the embedder loads GGUF files
-    # (inert) from effective_gguf_repo(), so scanning the ST repo's pickle here would
-    # wrongly reject a custom repo whose GGUF companion is clean; the GGUF availability
-    # checks below cover that path instead.
+    # The pickle gate matters only for the sentence-transformers backend; on llama-server the embedder loads inert
+    # GGUFs, so scanning the ST pickle wrongly rejects a clean companion.
+    # On the llama-server backend the embedder loads GGUF files from effective_gguf_repo().
     scan_st_pickle = (
         model != default_embedding_model() and not is_local_gguf and not destination_is_llama
     )
     if scan_st_pickle:
-        # Malware/pickle gate before we persist a repo the embedder later loads with
-        # SentenceTransformer. Runs even under force (force only skips the is-embedding
-        # type check for offline/local repos HF cannot verify); local paths and
-        # unreachable scans fail open inside evaluate_file_security.
+        # Malware/pickle gate before persisting a repo the embedder later loads; runs even under force, which only skips
+        # the is-embedding type check for repos HF cannot verify.
+        # Local paths and unreachable scans fail open inside evaluate_file_security.
         from utils.security import evaluate_file_security, security_load_subdirs
         from core.rag.embeddings import _st_module_subdirs
 
         # Fall back to the loader's own token so a gated/private repo is actually scanned
         # (a token-less scan fails open for exactly the repo that would still load).
         scan_token = hf_token or _ambient_hf_token()
-        # Offline: subdir probes would hit the network and hang; the offline gate walks the
-        # whole cached snapshot, so no load-subdir hints are needed.
+        # Offline: subdir probes would hit the network and hang; the offline gate walks
         if local_only_load:
             load_subdirs = ()
         else:
@@ -2754,8 +2668,8 @@ def update_embedding_model(
             load_subdirs = load_subdirs,
             local_only_load = local_only_load,
         ).blocked:
-            # 403, not 409: the client routes every 409 into the forceable "save anyway"
-            # flow, but this block is a hard, non-forceable security refusal.
+            # 403, not 409: the client routes every 409 into the forceable "save anyway" flow, but this is a
+    # hard, non-forceable security refusal.
             if local_only_load:
                 detail = (
                     f"{model!r} has cached pickle weights that cannot be security-scanned "
@@ -2771,16 +2685,13 @@ def update_embedding_model(
     if model != default_embedding_model() and not payload.force and not is_local_gguf:
         from core.rag import config as rag_config
 
-        # A GGUF-named repo on the llama-server backend is loaded from its .gguf
-        # files, which rarely carry sentence-transformers metadata; verify the
-        # GGUF is available (below) rather than the ST embedding-metadata gate,
-        # which would wrongly 409 a valid online GGUF embedder.
+        # A GGUF-named repo on llama-server is loaded from its .gguf files, which rarely carry ST metadata, so verify
+        # GGUF availability instead of the embedding-metadata gate.
         gguf_named = destination_is_llama and rag_config._names_gguf(model)
         if not gguf_named and not is_embedding_model(verify_target, hf_token = hf_token):
-            # Offline, is_embedding_model can only confirm the ST layout (modules.json); a
-            # transformers-native embedder (e.g. gte-modernbert) is unverifiable without Hub
-            # metadata. If already cached and loadable, accept it rather than raising a 409 that
-            # online would not (ST can load any cached encoder). Uncached -> 409.
+            # Offline, is_embedding_model can only confirm the ST layout, so a cached and loadable transformers-native
+            # embedder is accepted rather than 409'd where online would not.
+            # The unverifiable case is a transformers-native embedder such as gte-modernbert; uncached still 409s.
             from utils.utils import hf_cache_snapshot_is_loadable
 
             # Require a genuinely loadable cache (config + weights), not just a resolved refs/main,
@@ -2795,10 +2706,8 @@ def update_embedding_model(
                         "you may be offline)."
                     ),
                 )
-        # The shared resolver already applied the bounded listing and the exact
-        # destination backend, so PUT and GET cannot disagree. Any plan error
-        # counts, not just llama ones: is_embedding_model gates on tags, so a repo
-        # with no loadable checkpoint passes it and would be persisted anyway.
+        # Any plan error counts, not just llama ones: is_embedding_model gates on tags, so a repo with no loadable
+        # checkpoint passes it and would be persisted anyway.
         if plan.error:
             raise HTTPException(status_code = 409, detail = plan.error)
     trusted_backend = None
@@ -2807,19 +2716,15 @@ def update_embedding_model(
     trusted_download_pending = False
     if plan.error is None:
         trusted_backend = "llama-server" if destination_is_llama else "sentence-transformers"
-        # The exact family this transfer delivers. A repo publishing no
-        # RAG_EMBED_GGUF_VARIANT is served another quant on purpose, which the
-        # loader's variant lookup cannot recognize as what was downloaded, so
-        # without this the model stays cache-only and an eviction reads as
-        # "never downloaded" though the transfer finished.
+        # The exact family this transfer delivers.
+        # A repo publishing no RAG_EMBED_GGUF_VARIANT is served another quant on purpose, which the loader's variant
+        # lookup cannot recognize as what was downloaded, so the model would stay cache-only.
         trusted_gguf_files = plan.files if destination_is_llama else None
         # A sentence-transformers download repo is not a GGUF source. Keeping
         # it out also prevents a later runtime fallback from mislabelling it.
         trusted_gguf_repo = plan.download_repo if destination_is_llama else None
-        # The setting may be activated so both mounted settings surfaces stay
-        # in sync, but its loader must remain cache-only until this transfer is
-        # complete. That prevents a close/cancel from becoming an implicit
-        # first-index download.
+        # The setting may activate so both settings surfaces stay in sync, but its loader stays
+    # cache-only until the transfer completes, or a close/cancel becomes an implicit download.
         trusted_download_pending = bool(plan.download_repo and not plan.cached)
     else:
         # Save anyway, over a failed plan: nothing validated to record, but the
@@ -3261,18 +3166,16 @@ class PersonalizationCustomColorModes(BaseModel):
 
 
 MAX_IMPORTED_FONTS = 3
-# ~1.5 MB font file as base64; matches MAX_IMPORTED_FONT_DATA_URL_LENGTH in
-# the frontend appearance-custom-store.
+# ~1.5 MB font file as base64; matches MAX_IMPORTED_FONT_DATA_URL_LENGTH in the frontend.
 MAX_FONT_DATA_URL_LENGTH = 2_200_000
-# Aggregate cap across all imported fonts; matches
-# MAX_TOTAL_IMPORTED_FONT_DATA_URL_LENGTH in the frontend so a synced payload
-# always fits the browser's localStorage quota.
+# Aggregate cap across all imported fonts, matching the frontend so a synced payload always fits
+# the browser's localStorage quota.
+# Matches MAX_TOTAL_IMPORTED_FONT_DATA_URL_LENGTH in the frontend.
 MAX_TOTAL_FONT_DATA_URL_LENGTH = 4_400_000
 
-# Characters that could terminate a CSS declaration, escape the quoted
-# font-family value (backslash), or smuggle extra fallbacks/comments (comma,
-# slash) if a stored name ever reached a stylesheet. The server is the
-# authoritative gate; the frontend strips the same set before use.
+# Characters that could terminate a CSS declaration, escape the quoted font-family value or smuggle
+# extra fallbacks/comments if a stored name reached a stylesheet. The server is the authoritative
+# gate; the frontend strips the same set.
 _FONT_NAME_FORBIDDEN = set(";{}()<>\"'\\/,`")
 
 
@@ -3311,8 +3214,8 @@ class PersonalizationImportedFont(BaseModel):
         return value
 
 
-# Optional user-menu items; the boolean is each id's default visibility.
-# Settings-tab shortcuts ship hidden.
+# Optional user-menu items; the boolean is each id's default visibility. Settings-tab shortcuts
+# ship hidden.
 SIDEBAR_MENU_ITEM_DEFAULTS = {
     "api": True,
     "darkMode": True,
@@ -3325,10 +3228,11 @@ SIDEBAR_MENU_ITEM_DEFAULTS = {
 }
 
 # Navigable sidebar rows the user can pin/reorder; the boolean is each id's default pin state.
-# Order and pin state MUST match the frontend's shipped layout (SIDEBAR_NAV_ITEM_IDS /
-# SIDEBAR_NAV_DEFAULT_PINNED in features/settings/stores/appearance-custom-store.ts): the client
-# sends every id on each save, so a missing id 422s the whole personalization PUT, and a legacy
-# record that predates sidebarNav is served this default as if it were an explicit remote choice.
+# Order and pin state MUST match the frontend's shipped layout: the client sends every id on each save, so a missing id
+# 422s the whole personalization PUT.
+# The frontend constants are SIDEBAR_NAV_ITEM_IDS / SIDEBAR_NAV_DEFAULT_PINNED in features/settings/stores/appearance-
+# custom-store.ts, and a legacy record predating sidebarNav is served this default as if it were an explicit remote
+# choice.
 SIDEBAR_NAV_ITEM_DEFAULTS = {
     "hub": True,
     "projects": True,
@@ -3343,12 +3247,7 @@ SIDEBAR_NAV_ITEM_DEFAULTS = {
 
 MAX_SIDEBAR_NAV_INPUT_ITEMS = 4 * len(SIDEBAR_NAV_ITEM_DEFAULTS)
 
-# The sidebarMenu validator below dedupes ids and re-fills any missing ones, so
-# the stored list is always exactly one entry per id. Cap the *incoming* list at
-# a generous multiple rather than len(defaults): a stale or duplicated payload
-# (more items than distinct ids) must reach the validator so it can normalize,
-# instead of being rejected by the length constraint before dedupe runs. A
-# pathologically long list is still refused.
+# The sidebarMenu validator below dedupes ids and re-fills any missing ones
 MAX_SIDEBAR_MENU_INPUT_ITEMS = 4 * len(SIDEBAR_MENU_ITEM_DEFAULTS)
 
 
@@ -3550,11 +3449,13 @@ def update_personalization_settings(
     return PersonalizationPayload.model_validate(merged)
 
 
+# Backs Settings > Logs: the session log always existed, but its path was only printed to a
+# console the desktop user never sees.
+
+
 # ── Logs: read the log files from inside the app ─────────────────────────────
 # Backs the Settings > Logs tab. The session log always existed, but its
 # path was only printed to a console the desktop user never sees.
-
-
 class DebugLogSourceModel(BaseModel):
     id: str
     family: str
@@ -3582,13 +3483,11 @@ class DebugLogResponse(BaseModel):
     reset_reason: Optional[str] = None
     dropped_bytes: int = 0
     truncated_head: bool = False
-    # The reader stopped at the response cap and the rest arrives on the next
-    # poll. Without this the caller cannot tell a complete answer from a partial
-    # one, which is invisible in manual mode because no next poll is coming.
+    # The reader stopped at the response cap, and without saying so the caller cannot tell a complete
+    # answer from a partial one, which is invisible in manual mode where no next poll is coming.
     more_pending: bool = False
-    # File logging is off, so anything readable here is a PREVIOUS session and
-    # will never grow. The status stays "ok" because the content is real and
-    # worth reading; saying nothing made a stale log look live.
+    # File logging is off, so anything readable here is a PREVIOUS session and will never grow. The status stays "ok"
+    # because the content is real and worth reading; saying nothing made a stale log look live.
     file_logging_disabled: bool = False
     size_bytes: int = 0
 

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -1759,9 +1759,12 @@ def update_openai_auto_switch_override(
             # id would leave two keys for one model, making every other casing ambiguous.
             target_id = resolve_model_override_key(payload.model_id) or payload.model_id
             if payload.fill_absent_fields:
-                # A fill retires nothing below.
+                # A fill retires nothing below, so it must not create the higher-priority spelling of a row
+                # the server already holds.
                 target_id = _fill_target_id(target_id)
-            # An explicit clear keeps a row even when nothing else is set.
+            # An explicit clear keeps a row even when nothing else is set, so long as a fallback would
+            # otherwise answer for this model: "no launch flags" and "nothing stored" are the same thing
+            # everywhere else, and different here. Written on the quant's own key, so no other quant moves.
             keep_empty = (
                 payload.llama_extra_args == []
                 and not payload.fill_absent_fields

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -210,9 +210,9 @@ class _ModelPreflightResult:
     cached_model_pin: Optional[tuple[str, str]]
 
 
-# Consecutive 1s polls without a step update that count as a stall. Applied only once
+# Consecutive 1s polls without a step update that count as a stall (~30 min). Applied only once
 # stepping: the model-load + tokenization phase can take far longer without being stuck.
-_PROGRESS_STALL_TIMEOUT_POLLS = 1800  # ~30 min at 1 poll/sec
+_PROGRESS_STALL_TIMEOUT_POLLS = 1800
 
 
 def _stop_training_if_active(
@@ -779,7 +779,7 @@ def _reject_untrainable_model_request(
     if path is None:
         try:
             # Raised inside the try on purpose: the except HTTPException handler still runs
-            # _resolve_model_snapshot, so a cached snapshot pins as before without the remote budget.
+        # _resolve_model_snapshot, so a cached snapshot pins as before without the remote budget.
             if _hub_unreachable():
                 raise _hf_preflight_error(
                     503,
@@ -1055,7 +1055,8 @@ async def get_hardware_utilization(current_subject: str = Depends(get_current_su
 async def get_visible_hardware_utilization(current_subject: str = Depends(get_current_subject)):
     from utils.hardware import get_visible_gpu_utilization
 
-    # Off the event loop: the ROCm fallbacks shell out (Windows perf counters, sysfs) and the System view polls this route.
+    # Off the event loop: the ROCm fallbacks shell out (Windows perf counters, sysfs) and the System view polls this
+    # route.
     return await asyncio.to_thread(get_visible_gpu_utilization)
 
 
@@ -1170,19 +1171,16 @@ async def start_training(
         backend = get_training_backend()
         job_id = f"job_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{_uuid.uuid4().hex[:8]}"
         if request.start_request_id:
-            # A retry of an id that already resolved replays its stored outcome even when the
-            # guard below would refuse a NEW start: the caller asked what happened to THIS
-            # start. Peeking also refreshes a cancellation tombstone, so a retry cannot outlive
-            # it and go on to spawn the run the user cancelled.
+            # A retry of an already-resolved id replays its stored outcome even when a NEW start would be refused;
+            # peeking also refreshes a cancellation tombstone so a retry cannot outlive it.
             existing_record = backend.peek_start_request(request.start_request_id)
             if existing_record is not None:
                 return _start_request_response(existing_record)
 
-        # When Unsloth is driven as an inference API (API-key auth), refuse to start training while
-        # a request is in flight: training frees VRAM by unloading the chat model, killing the
-        # stream. The UI (session auth) still starts and coexists. Mixed UI+API is not special-cased.
-        # Checked BEFORE reserving start_request_id: this refusal is transient, so resolving the
-        # idempotency key to "rejected" would make every retry replay a stale rejection forever.
+        # Under API-key auth refuse to start training while a request is in flight, since training unloads the chat
+        # model. Checked BEFORE reserving the id, or every retry replays a stale rejection.
+        # Checked BEFORE reserving start_request_id, since a transient refusal resolved to "rejected" would make every
+        # retry replay it forever. Mixed UI+API is not special-cased.
         if via_api_key is True:
             from core.inference.llama_keepwarm import other_inference_request_count
             if (
@@ -1208,8 +1206,8 @@ async def start_training(
                 return _start_request_response(record)
             reserved_start_request_id = request.start_request_id
 
-        # No in-process ensure_transformers_version(): worker.py activates it before ML imports.
 
+        # No in-process ensure_transformers_version(): worker.py activates it before ML imports.
         # A consented latest-transformers install stage-and-swaps .venv_t5_latest mid-spawn.
         from utils.transformers_latest import is_install_in_progress
 
@@ -1219,8 +1217,7 @@ async def start_training(
                 detail = ("A transformers installation is in progress. Retry when it completes."),
             )
 
-        # S3 dataset loading needs the optional boto3 dependency. Reject early so credentials are
-        # never accepted and then silently dropped on a host without boto3.
+        # S3 dataset loading needs the optional boto3 dependency.
         if request.s3_config is not None and not request.resume_from_checkpoint:
             from core.training.s3_dataset import boto3_available
             if not boto3_available():
@@ -1288,10 +1285,9 @@ async def start_training(
             )
             if not resume_run or not await asyncio.to_thread(can_resume_run, resume_run):
                 detail = "Resume checkpoint must belong to a stopped or errored run with complete saved trainer state."
-                # Only when the checkpoint itself is intact. can_resume_run refuses for several reasons and
-                # the blocker is computed independently of which one fired, so asking unconditionally would
-                # answer a provenance sentence even when the checkpoint is what is missing. has_resume_state
-                # is the discriminator can_resume_run itself short-circuits on.
+                # Only when the checkpoint itself is intact: can_resume_run refuses for several reasons, so asking
+                # unconditionally answers a provenance sentence when the checkpoint is what is missing.
+                # has_resume_state is the discriminator can_resume_run itself short-circuits on.
                 if resume_run and await asyncio.to_thread(
                     has_resume_state, resume_run.get("output_dir")
                 ):
@@ -1504,8 +1500,7 @@ async def start_training(
             "s3_config": request.s3_config.model_dump() if request.s3_config else None,
         }
 
-        # Latest-sidecar models size and train 16-bit (same flip as chat load): 4-bit is disabled for
-        # brand-new architectures, so VRAM checks must not underestimate a load the worker refuses.
+        # Latest-sidecar models size and train 16-bit (same flip as chat load): 4-bit is disabled
         from core.training.provenance import (
             ExactResumeResourcesUnavailable,
             effective_training_load_in_4bit,
@@ -1539,8 +1534,7 @@ async def start_training(
                     model_load_target,
                 )
 
-        # Training page has no trust_remote_code toggle, so honor the YAML default -- but only for
-        # genuine first-party (unsloth/nvidia) Hub repos, never a local path or a lookalike name.
+        # Training page has no trust_remote_code toggle.
         if not training_kwargs["trust_remote_code"]:
             from utils.security.trusted_org import is_trusted_org_repo
 
@@ -1558,8 +1552,8 @@ async def start_training(
                     request.model_name,
                 )
 
-        # Free VRAM for training: stop export, unload chat unless it can coexist. A before_spawn
-        # hook, so it runs only after start_training's guards pass and never for a refused start.
+        # Free VRAM for training: stop export, unload chat unless it can coexist.
+        # A before_spawn hook, so it runs only after start_training's guards pass and never for a refused start.
         def _free_vram_for_training() -> None:
             try:
                 from core.export import get_export_backend
@@ -1576,14 +1570,13 @@ async def start_training(
                 logger.warning("Could not shut down export subprocess: %s", e)
 
             try:
-                # A resident or in-flight Images pipeline holds GPU memory the run needs and cannot be
-                # cheaply sized, so tear it down unconditionally and release the arbiter. Before the chat block.
                 from core.inference import gpu_arbiter
                 from core.inference.diffusion_engine_router import (
                     get_active_diffusion_engine,
                 )
 
-                # The ACTIVE engine, not the diffusers singleton: on a native (sd_cpp) selection the diffusers backend reports unloaded while the native engine still holds state.
+                # The ACTIVE engine, not the diffusers singleton: on a native (sd_cpp) selection the diffusers backend
+                # reports unloaded while the native engine still holds state.
                 diffusion = get_active_diffusion_engine()
                 if diffusion.is_loaded:
                     logger.info(
@@ -1595,7 +1588,8 @@ async def start_training(
                 logger.warning("Could not unload diffusion model for training: %s", e)
 
             try:
-                # A resident Video pipeline holds GPU memory too and loads under the VIDEO arbiter owner the teardown above never touches. Tear it down the same way and release VIDEO. Must precede the chat block.
+                # A resident Video pipeline holds GPU memory too and loads under the VIDEO arbiter owner the teardown
+                # above never touches. Tear it down the same way and release VIDEO. Must precede the chat block.
                 from core.inference import gpu_arbiter
                 from core.inference.video import get_video_backend
 
@@ -1679,7 +1673,7 @@ async def start_training(
         def _run_backend_start() -> bool:
             try:
                 # Keep the diffusion admission in the worker thread across the whole spawn: a disconnected
-                # request must not release it while the shielded start is still freeing VRAM.
+        # request must not release it while the shielded start is still freeing VRAM.
                 with _diffusion_gpu_admission():
                     return _run_backend_start_without_admission()
             except _DiffusionStartInFlight as exc:
@@ -2173,8 +2167,8 @@ async def stream_training_progress(
                 lines.append(f"id: {event_id}")
             lines.append(f"event: {event}")
             lines.append(f"data: {data}")
-            lines.append("")  # trailing blank line
-            lines.append("")  # double newline terminates the event
+            lines.append("")
+            lines.append("")
             return "\n".join(lines)
 
         if not is_current_job():
@@ -2287,9 +2281,7 @@ async def stream_training_progress(
         # ── Live polling loop ────────────────────────────────────
         last_step = resume_from_step if resume_from_step is not None else -1
         no_update_count = 0
-        # The stall timeout applies only once the run is stepping (pre-step prep may legitimately
-        # emit no step for a long time). On reconnect to an already-stepping run, seed from the
-        # resume point / history, else a worker that hangs after step N never times out.
+        # The stall timeout applies only once the run is stepping
         seen_live_step = (resume_from_step is not None and resume_from_step > 0) or bool(
             backend.step_history
         )
@@ -2302,8 +2294,7 @@ async def stream_training_progress(
                 return
             if not is_active:
                 break
-            # Client gone: end the generator without the final "complete" frame, which a buffered
-            # consumer could otherwise read as a finished run while training is still active.
+            # Client gone: end the generator without the final "complete" frame.
             if await request.is_disconnected():
                 return
             if not is_current_job():
@@ -2404,7 +2395,7 @@ async def stream_training_progress(
                     )
                     return
 
-                await asyncio.sleep(1)  # Poll every second
+                await asyncio.sleep(1)
 
             except Exception as e:
                 if not is_current_job():
@@ -2463,10 +2454,10 @@ async def stream_training_progress(
     )
 
 
-# ── Diffusion (SDXL) LoRA training ────────────────────────────────────────────
-# A separate, lightweight job path: diffusion runs use DiffusionTrainingService (its own subprocess + event pump), not the LLM TrainingBackend.
 
 
+# ── Diffusion (SDXL) LoRA training ──────────────────────────────────────────── A separate, lightweight job path:
+# diffusion runs use DiffusionTrainingService (its own subprocess + event pump), not the LLM TrainingBackend.
 def _diffusion_training_active() -> bool:
     """Whether a diffusion (SDXL) LoRA job is currently running. Best-effort so the
     interlock never blocks a start just because the service could not be imported."""
@@ -2580,30 +2571,31 @@ def _free_gpu_for_diffusion_training() -> None:
         from core.inference import gpu_arbiter
         from core.inference.diffusion_engine_router import get_active_diffusion_engine
 
-        # The ACTIVE engine, not the diffusers singleton: on a native (sd_cpp) selection the resident sd-server still holds the GPU, so unloading only the singleton is a no-op.
+        # The ACTIVE engine, not the diffusers singleton: on a native (sd_cpp) selection the resident sd-server still
+        # holds the GPU, so unloading only the singleton is a no-op.
         diffusion = get_active_diffusion_engine()
         if diffusion.is_loaded:
             logger.info("Unloading resident Images pipeline to free GPU memory for training")
-        diffusion.unload()  # no-op when nothing is loaded; also preempts an in-flight load
+        diffusion.unload()
         gpu_arbiter.release(gpu_arbiter.DIFFUSION)
     except Exception as e:  # noqa: BLE001
         logger.warning("Could not unload Images pipeline for diffusion training: %s", e)
 
     try:
-        # A resident Video pipeline loads under the VIDEO arbiter owner the Images teardown does not free; unload it too and release VIDEO.
         from core.inference import gpu_arbiter
         from core.inference.video import get_video_backend
 
         video = get_video_backend()
         if video.status().get("loaded"):
             logger.info("Unloading resident Video pipeline to free GPU memory for training")
-        video.unload()  # no-op when nothing is loaded; also preempts an in-flight load
+        video.unload()
         gpu_arbiter.release(gpu_arbiter.VIDEO)
     except Exception as e:  # noqa: BLE001
         logger.warning("Could not unload Video pipeline for diffusion training: %s", e)
 
     try:
-        # The SDXL trainer footprint cannot be cheaply sized against a resident chat model, so free chat unconditionally rather than risk an OOM.
+        # The SDXL trainer footprint cannot be cheaply sized against a resident chat model, so free chat unconditionally
+        # rather than risk an OOM.
         from routes.training_vram import free_chat_models_for_training, summarize_resident_chat
         if summarize_resident_chat()["any"]:
             freed = free_chat_models_for_training(reason = "diffusion training starting")
@@ -2623,9 +2615,8 @@ def _preflight_gated_base(base_model: str, hf_token: Optional[str]) -> None:
     from core.inference.diffusion_families import _is_local_path
 
     repo = (base_model or "").strip()
-    # Only remote 'org/name' repos are gated; skip local paths and single-file names. A RELATIVE
-    # clone counts: a directory named exactly like the vendor id is what the loaders and the
-    # mirror override both resolve on disk, and it carries one slash and no leading marker, so
+    # Only remote 'org/name' repos are gated; skip local paths and single-file names.
+    # A RELATIVE clone counts: a directory named exactly like the vendor id carries one slash and no leading marker, so
     # without the existence test this HEADs the gated repo and 400s a run that never leaves disk.
     if (
         not repo
@@ -2650,7 +2641,8 @@ def _preflight_gated_base(base_model: str, hf_token: Optional[str]) -> None:
                     f"try again."
                 ),
             )
-        # 404 (e.g. a repo without a root model_index.json) and other codes are not an access problem; let the trainer surface any genuine load error.
+        # 404 (e.g. a repo without a root model_index.json) and other codes are not an access problem; let the trainer
+        # surface any genuine load error.
     except Exception:  # noqa: BLE001 -- network/DNS hiccup must not block a start
         return
 
@@ -2673,7 +2665,8 @@ def _resolve_diffusion_data_dir(raw: str) -> Path:
         # A single component that is not "..", so joining under datasets_root() cannot escape it.
         if not p.is_absolute() and len(p.parts) == 1 and p.parts[0] != "..":
             direct = datasets_root() / value
-            # Route a bare name through the same protected resolver the CRUD routes use, so a symlink to an external directory is rejected here too. A broken symlink is included so it is rejected, not passed on.
+            # Route a bare name through the same protected resolver the CRUD routes use, so a symlink to an external
+            # directory is rejected here too. A broken symlink is included so it is rejected, not passed on.
             if direct.is_dir() or direct.is_symlink():
                 return _resolve_dataset_folder(value)
     return resolve_dataset_path(raw)
@@ -2717,7 +2710,8 @@ async def start_diffusion_training(
     """Start an SDXL LoRA training job from an image + caption dataset."""
     from core.training.diffusion_training_service import get_diffusion_training_service
 
-    # Under API-key auth, refuse to start training while a request is in flight: _free_gpu_for_diffusion_training() below unloads the chat backends, killing the stream. Mirrors start_training.
+    # Under API-key auth, refuse to start training while a request is in flight: _free_gpu_for_diffusion_training()
+    # below unloads the chat backends, killing the stream. Mirrors start_training.
     if via_api_key is True:
         from core.inference.llama_keepwarm import other_inference_request_count
         if (
@@ -2733,7 +2727,8 @@ async def start_diffusion_training(
                 ),
             )
 
-    # Interlock: refuse while an LLM training run holds the GPU (symmetric with the diffusion check in start_training), so the two trainers never contend for VRAM.
+    # Interlock: refuse while an LLM training run holds the GPU (symmetric with the diffusion check in start_training),
+    # so the two trainers never contend for VRAM.
     try:
         if get_training_backend().is_training_active():
             raise HTTPException(
@@ -2748,13 +2743,15 @@ async def start_diffusion_training(
     except Exception:  # noqa: BLE001 -- backend import/health issue must not block a start
         pass
 
-    # Resolve + contain the dataset and output paths BEFORE spawning: the trainer subprocess would otherwise resolve them relative to its own cwd.
+    # Resolve + contain the dataset and output paths BEFORE spawning: the trainer subprocess would otherwise resolve
+    # them relative to its own cwd.
     config = body.model_dump()
     try:
         from utils.paths import outputs_root, resolve_output_dir
 
         config["data_dir"] = str(_resolve_diffusion_data_dir(config["data_dir"]))
-        # A name that cleans away to nothing ("." / "outputs" / "./.") resolves to the outputs ROOT, where the trainer would write the adapter flat and the is_dir()-filtered listings could never see it.
+        # A name that cleans away to nothing ("." / "outputs" / "./.") resolves to the outputs ROOT, where the trainer
+        # would write the adapter flat and the is_dir()-filtered listings could never see it.
         root = outputs_root().resolve()
         out_dir = resolve_output_dir(config["output_dir"])
         if Path(out_dir).resolve() == root:
@@ -2766,17 +2763,20 @@ async def start_diffusion_training(
                 ),
             )
         config["output_dir"] = str(out_dir)
-        # The persistent conditioning cache is another trainer-written directory, so it gets the same containment. Blank/None means the in-memory cache, so it must not resolve to the outputs root.
+        # The persistent conditioning cache is another trainer-written directory, so it gets the same containment.
+        # Blank/None means the in-memory cache, so it must not resolve to the outputs root.
         cond_cache = str(config.get("cond_cache_dir") or "").strip()
         cond_cache_dir = resolve_output_dir(cond_cache) if cond_cache else None
-        # Same collapse, but the cache has an honest "off" to fall back to: one flat safetensors per cached latent in the trained-models directory is never what was meant.
+        # Same collapse, but the cache has an honest "off" to fall back to: one flat safetensors per cached latent in
+        # the trained-models directory is never what was meant.
         if cond_cache_dir is not None and Path(cond_cache_dir).resolve() == root:
             cond_cache_dir = None
         config["cond_cache_dir"] = str(cond_cache_dir) if cond_cache_dir is not None else None
     except ValueError as e:
         raise HTTPException(status_code = 400, detail = str(e))
 
-    # Validate the config BEFORE freeing resident GPU workloads, so a refused start never tears down the user's chat/Images model. service.start() re-runs this before spawn.
+    # Validate the config BEFORE freeing resident GPU workloads, so a refused start never tears down the user's
+    # chat/Images model. service.start() re-runs this before spawn.
     from core.training.diffusion_lora_trainer import _config_from_dict
 
     try:
@@ -2797,10 +2797,10 @@ async def start_diffusion_training(
             ),
         )
 
-    # Same rule for the MiniMax-H3 trainer's own restrictions, which are config-only and so
-    # answerable here: a batch > 1, a non-bf16 precision, a weighting scheme, a compile
-    # request or a conditioning-cache directory used to reach the worker and 400 there, with
-    # the user's resident models already evicted for a run that never started.
+    # Same rule for the MiniMax-H3 trainer's own restrictions.
+    # Those config-only restrictions are a batch > 1, a non-bf16 precision, a weighting scheme, a compile request or a
+    # conditioning-cache directory, each of which used to reach the worker and 400 there with the user's models already
+    # evicted.
     from core.training.diffusion_train_common import h3_train_unsupported_reason
 
     _h3_reason = h3_train_unsupported_reason(normalized_cfg)
@@ -2826,10 +2826,10 @@ async def start_diffusion_training(
     if _pipeline_reason:
         raise HTTPException(status_code = 400, detail = _pipeline_reason)
 
-    # Preflight a resume request in the same place and for the same reason: a checkpoint from a
-    # different family / base / LoRA shape / precision must 400 BEFORE the resident GPU model is
-    # evicted, not fail in the child once the user's Images pipeline is already gone. The dataset
-    # half of the identity needs the discovery pass, so it runs below (still before eviction).
+    # Preflight a resume request in the same place and for the same reason: a checkpoint
+    # A checkpoint from a different family / base / LoRA shape / precision must 400 BEFORE the resident GPU model is
+    # evicted, not fail in the child. The dataset half of the identity needs the discovery pass, so it runs below, still
+    # before eviction.
     from core.training.diffusion_checkpoint import (
         ResumeError,
         dataset_fingerprint,
@@ -2843,23 +2843,19 @@ async def start_diffusion_training(
     resume_identity = identity_for_config(normalized_cfg) if resuming else None
     if resuming:
         try:
-            # Resolve + contain it here, like data_dir / output_dir: the trainer subprocess would
-            # otherwise resolve a relative name against its own cwd.
+            # Resolve + contain it here.
+            # Like data_dir / output_dir: the trainer subprocess would otherwise resolve a relative name against its own
+            # cwd.
             config["resume_from_checkpoint"] = str(
                 resolve_resume_dir(normalized_cfg.resume_from_checkpoint)
             )
-            # In epochs mode the real target is only known once the dataset size is; skip the
-            # "already finished" check here and make it below, with the resolved step count.
-            # Offloaded like the other preflights: validating a bundle parses a safetensors
-            # header and walks two torch-zip pickles, which must not block the event loop.
+            # In epochs mode the real target is only known once the dataset size is; skip
             await asyncio.to_thread(
                 _preflight_diffusion_resume,
                 config,
                 resume_identity,
-                # No target either. The "already at the target" refusal is TERMINAL, and this
-                # pass has no dataset fingerprint -- so a newest bundle belonging to a different
-                # dataset, already at the count, aborted the scan before the dataset-aware pass
-                # could find the older checkpoint that does match the requested images.
+                # The "already at the target" refusal is TERMINAL and this pass has no dataset fingerprint, so a newest
+                # bundle from another dataset aborted the scan before the matching one was found.
                 0,
                 # And leave the request pointing at what the user gave, for the same reason:
                 # that pass is the one that may need to scan the directory.
@@ -2868,7 +2864,8 @@ async def start_diffusion_training(
         except ResumeError as e:
             raise HTTPException(status_code = 400, detail = str(e))
 
-    # Run the trainers' trust gate here too, so an untrusted/typoed base 400s BEFORE freeing GPU residents rather than failing in the child.
+    # Run the trainers' trust gate here too, so an untrusted/typoed base 400s BEFORE freeing GPU residents rather than
+    # failing in the child.
     from core.training.diffusion_train_common import (
         MODULAR_BASE_FAMILIES,
         _assert_trusted_base_model,
@@ -2885,9 +2882,9 @@ async def start_diffusion_training(
     except ValueError as e:
         raise HTTPException(status_code = 400, detail = str(e))
 
-    # Preflight the repo the trainer will actually fetch, not the canonical id retained in its
-    # metadata. A gated canonical base may normalize to a byte-identical public mirror.
-    # In a worker thread: blocking urlopen HEAD (5s).
+    # Preflight the repo the trainer will actually fetch, not the canonical id retained in its metadata: a gated
+    # canonical base may normalize to a byte-identical public mirror. In a worker thread, since the urlopen HEAD blocks
+    # for 5s.
     await asyncio.to_thread(
         _preflight_gated_base,
         normalized_cfg.fetch_base_model or normalized_cfg.base_model,
@@ -2897,29 +2894,23 @@ async def start_diffusion_training(
     from core.training import diffusion_train_common as _dtc
 
     service = get_diffusion_training_service()
-    # Reserve the training slot BEFORE the dataset preflight: is_active() otherwise flips true
-    # only at service.start(), so a concurrent upload/delete could mutate the dataset meanwhile.
+    # Reserve the training slot BEFORE the dataset preflight: is_active() otherwise flips true only
+    # at service.start(), so a concurrent upload/delete could mutate the dataset meanwhile.
     reserved = False
     try:
         service.reserve()
         reserved = True
-        # Fail closed on clips BEFORE that discovery, which cannot see them: clip-only it
-        # reports the folder as uncaptioned, and mixed it succeeds on the images and trains on
-        # that subset without saying so.
-        # For the IMAGE-trained families only. A clip-trained family is the case this refusal
-        # was written to protect against, so leaving it unconditional rejected every valid
-        # MiniMax-H3 request with "training from clips is not supported yet" -- the trainer this
-        # branch adds, unreachable through its own route. discover_training_pairs below already
-        # branches on the family; this is the same question asked one step earlier.
-        # In a worker thread like the discovery below it, and for the same reason: the scan stats
-        # every file and reads the caption sidecars, which on a large or network-mounted dataset
-        # would hold the event loop and stall status/stop alongside it.
+        # Fail closed on clips BEFORE a discovery that cannot see them, but for the IMAGE-trained families only, or
+        # every valid MiniMax-H3 request is rejected by the refusal written to protect it.
+        # discover_training_pairs below already branches on the family, so this is the same question one step earlier;
+        # run in a worker thread because the scan stats every file and reads the caption sidecars.
         mixed_refusal = await asyncio.to_thread(
             _mixed_media_refusal, config["data_dir"], normalized_cfg.resolved_family
         )
         if mixed_refusal is not None:
             raise HTTPException(status_code = 400, detail = mixed_refusal)
-        # Preflight the dataset: a missing/empty/uncaptionable data_dir otherwise fails inside the trainer AFTER eviction. Same discovery the trainer runs, so the two cannot disagree.
+        # Preflight the dataset: a missing/empty/uncaptionable data_dir otherwise fails inside the trainer AFTER
+        # eviction. Same discovery the trainer runs, so the two cannot disagree.
         try:
             pairs = await asyncio.to_thread(
                 _dtc.discover_training_pairs,
@@ -2927,14 +2918,13 @@ async def start_diffusion_training(
                 config["data_dir"],
                 instance_prompt = config.get("instance_prompt") or None,
                 caption_column = config.get("caption_column") or "text",
-                # Decode-probe every image now (cheap PIL header check) so a corrupt/zero-byte upload 400s BEFORE the GPU teardown.
+                # Decode-probe every image now (cheap PIL header check) so a corrupt/zero-byte upload 400s BEFORE the
+                # GPU teardown.
                 verify_images = True,
             )
         except (FileNotFoundError, ValueError) as e:
             raise HTTPException(status_code = 400, detail = str(e))
         if resuming:
-            # The dataset half of the resume identity, now that the images are known -- and the
-            # step target, which epochs mode only resolves here. Still before the GPU teardown.
             try:
                 await asyncio.to_thread(
                     _preflight_diffusion_resume,
@@ -2944,13 +2934,15 @@ async def start_diffusion_training(
                 )
             except ResumeError as e:
                 raise HTTPException(status_code = 400, detail = str(e))
-        # Free resident GPU workloads before the trainer loads its own pipeline. Offloaded: the teardown blocks on generation locks and a subprocess join.
+        # Free resident GPU workloads before the trainer loads its own pipeline. Offloaded: the teardown blocks on
+        # generation locks and a subprocess join.
         await asyncio.to_thread(_free_gpu_for_diffusion_training)
         job_id = service.start(config)
     except ValueError as e:
         raise HTTPException(status_code = 400, detail = str(e))
     except RuntimeError as e:
-        # A job is already running (or a start is already reserved), or a dataset mutation is open (DatasetMutationInFlight) -- the same interlock from the other side, so also a 409.
+        # A job is already running (or a start is already reserved), or a dataset mutation is open
+        # (DatasetMutationInFlight) -- the same interlock from the other side, so also a 409.
         raise HTTPException(status_code = 409, detail = str(e))
     except HTTPException:
         raise
@@ -2963,7 +2955,8 @@ async def start_diffusion_training(
             log = logger,
         )
     finally:
-        # On success the live proc keeps is_active() true; on failure this clears the reservation. Only the request that reserved clears it.
+        # On success the live proc keeps is_active() true; on failure this clears the reservation. Only the request that
+        # reserved clears it.
         if reserved:
             service.unreserve()
     return DiffusionTrainingStartResponse(job_id = job_id, status = "running")
@@ -3010,12 +3003,12 @@ async def list_diffusion_training_runs(
     per-run records. Summaries only; fetch one run for its config + metric logs."""
     from core.training.diffusion_training_service import list_diffusion_runs
 
-    # Offloaded: each record's can_resume is re-derived by validating the checkpoint bundles on
-    # disk (safetensors header + torch-zip pickle walk per file), which must not block the loop.
+    # Offloaded: each record's can_resume is re-derived by validating the checkpoint bundles
     records = await asyncio.to_thread(list_diffusion_runs, limit = limit)
     summaries: list[DiffusionTrainingRunSummary] = []
     for r in records:
-        # list_diffusion_runs skips non-dict / missing-id records, but a wrong-typed field would still raise here; catch per record so one bad file never breaks the panel.
+        # list_diffusion_runs skips non-dict / missing-id records, but a wrong-typed field would still raise here; catch
+        # per record so one bad file never breaks the panel.
         try:
             summaries.append(DiffusionTrainingRunSummary(**r))
         except ValidationError:
@@ -3033,30 +3026,28 @@ async def get_diffusion_training_run(
 
     # Offloaded for the same reason as the listing: the read re-validates the run's checkpoints.
     rec = await asyncio.to_thread(get_diffusion_run, job_id)
-    # A valid-JSON file that is not an object makes DiffusionTrainingRunDetail(**rec) raise TypeError, not the ValidationError caught below. Treat any non-dict record as absent.
+    # A valid-JSON file that is not an object makes DiffusionTrainingRunDetail(**rec) raise TypeError, not the
+    # ValidationError caught below. Treat any non-dict record as absent.
     if not isinstance(rec, dict):
         raise HTTPException(status_code = 404, detail = "No such training run.")
     try:
         return DiffusionTrainingRunDetail(**rec)
     except ValidationError:
-        # A malformed on-disk record (hand-edited / older shape) reads as absent rather than 500 the endpoint, like the list route skips bad records.
+        # A malformed on-disk record (hand-edited / older shape) reads as absent rather than 500 the endpoint, like the
+        # list route skips bad records.
         raise HTTPException(status_code = 404, detail = "No such training run.")
 
 
-# Extensions accepted into a diffusion-training dataset folder: the media the trainer reads, plus its caption sources (per-item sidecars and metadata/captions jsonl).
+# Extensions accepted into a diffusion-training dataset folder: the media the trainer reads, plus its caption sources
+# (per-item sidecars and metadata/captions jsonl).
 _DIFFUSION_DATASET_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
 # Video containers, for the families that train from clips rather than stills. Read from the one
 # shared definition so the trainer's discovery and this endpoint cannot drift apart.
 _DIFFUSION_DATASET_CLIP_EXTS = set(_CLIP_EXTS)
-# The trainable unit of a dataset, whichever kind it is. Every rule that is about "an item and its
-# caption" -- the upload allowlist, the shared-sidecar check, the delete -- keys off this set, and
-# only the rules that are genuinely about pixels (the decompression-bomb check, the labeling grid's
-# thumbnails) stay on _DIFFUSION_DATASET_IMAGE_EXTS.
-#
-# The two halves are DISJOINT and the caption rules over them are IDENTICAL (a <stem>.txt /
-# <stem>.caption sidecar wins, then a metadata.jsonl / captions.jsonl row, then the trigger
-# prompt), which is what makes clip support purely additive: no path an image dataset can take
-# through this file changes. test_diffusion_dataset_clips.py asserts both of those properties.
+# The trainable unit of a dataset, whichever kind: only rules genuinely about pixels stay on
+# _DIFFUSION_DATASET_IMAGE_EXTS. The two halves are disjoint with identical caption rules.
+# The identical caption rules are a <stem>.txt / <stem>.caption sidecar, then a metadata.jsonl / captions.jsonl row,
+# then the trigger prompt; test_diffusion_dataset_clips.py asserts both properties.
 _DIFFUSION_DATASET_MEDIA_EXTS = _DIFFUSION_DATASET_IMAGE_EXTS | _DIFFUSION_DATASET_CLIP_EXTS
 _DIFFUSION_DATASET_TEXT_EXTS = {".txt", ".caption", ".jsonl"}
 
@@ -3131,9 +3122,10 @@ def _import_response(
 
 
 def _diffusion_dataset_summary(folder: Path) -> DiffusionDatasetSummary:
-    # Count an item as captioned only when it resolves to a NON-EMPTY caption via the trainer's sidecar-over-metadata precedence: an empty tombstone makes the trainer skip the item.
-    # Images and clips are counted separately (the UI names them differently and only one family
-    # kind can read each), but captions are one folder total: the resolution rule is the same.
+    # Count an item as captioned only when it resolves to a NON-EMPTY caption via the trainer's sidecar-over-metadata
+    # precedence: an empty tombstone makes the trainer skip the item. Images and clips are counted separately (the UI
+    # names them differently and only one family kind can read each), but captions are one folder total: the resolution
+    # rule is the same.
     meta_captions = _load_metadata_captions(folder)
     images = clips = captions = 0
     for f in drop_appledouble_metadata(list(folder.iterdir())):
@@ -3229,7 +3221,7 @@ def _listed_dataset_clip_count(summary: DiffusionDatasetSummary) -> int:
     starts returning them, with no edit here."""
     try:
         return int(getattr(summary, "clip_count", 0) or 0)
-    except (TypeError, ValueError):  # a non-numeric count is no evidence of a clip dataset
+    except (TypeError, ValueError):
         return 0
 
 
@@ -3244,7 +3236,7 @@ def _listed_dataset_trains_clips(summary: DiffusionDatasetSummary) -> bool:
         return False
     try:
         return int(getattr(summary, "image_count", 0) or 0) <= 0
-    except (TypeError, ValueError):  # a non-numeric count is no evidence either way; be strict
+    except (TypeError, ValueError):
         return False
 
 
@@ -3298,11 +3290,13 @@ async def diffusion_training_info(current_subject: str = Depends(get_current_sub
         root = datasets_root()
         found: list[DiffusionDatasetSummary] = []
         try:
-            # Skip hidden dirs: never user datasets, and an in-progress example import stages into a dot-prefixed sibling.
+            # Skip hidden dirs: never user datasets, and an in-progress example import stages into a dot-prefixed
+            # sibling.
             children = sorted(
                 p
                 for p in root.iterdir()
-                # Skip symlinked dirs: the CRUD resolver rejects them, so discovery must not advertise one as selectable.
+                # Skip symlinked dirs: the CRUD resolver rejects them, so discovery must not advertise one as
+                # selectable.
                 if p.is_dir() and not p.is_symlink() and not p.name.startswith(".")
             )
         except OSError:
@@ -3326,10 +3320,11 @@ async def diffusion_training_info(current_subject: str = Depends(get_current_sub
     return await asyncio.to_thread(scan)
 
 
-_DATASET_NAME_RE = None  # compiled lazily; module keeps its import block torch-free
+_DATASET_NAME_RE = None
 
 
-# Reserved in EVERY directory on Windows, with or without an extension (NUL.txt is NUL). The superscript COM/LPT digits count as digits to Win32 and are reserved too.
+# Reserved in EVERY directory on Windows, with or without an extension (NUL.txt is NUL). The superscript COM/LPT digits
+# count as digits to Win32 and are reserved too.
 _WINDOWS_RESERVED_NAMES = frozenset(
     {"con", "prn", "aux", "nul"}
     | {f"com{d}" for d in "123456789¹²³"}
@@ -3420,7 +3415,8 @@ async def upload_diffusion_dataset(
 
     _require_diffusion_dataset_mutable()
     cleaned = _clean_diffusion_dataset_name(name)
-    # Run the same symlink + root-containment check as the read/caption/delete endpoints before any write, so a symlinked name cannot make the upload write outside root.
+    # Run the same symlink + root-containment check as the read/caption/delete endpoints before any write, so a
+    # symlinked name cannot make the upload write outside root.
     folder = _resolve_dataset_folder(name, must_exist = False)
     folder.mkdir(parents = True, exist_ok = True)
     # Serialize against a concurrent import into the SAME folder: the training interlock counts
@@ -3439,7 +3435,8 @@ async def upload_diffusion_dataset(
         total_bytes = 0
         uploaded = 0
         allowed = _DIFFUSION_DATASET_MEDIA_EXTS | _DIFFUSION_DATASET_TEXT_EXTS
-        # Validate every filename up front so a valid file ahead of a bad one is not left on disk when the 400 fires; the upload is all-or-nothing.
+        # Validate every filename up front so a valid file ahead of a bad one is not left on disk when the 400 fires;
+        # the upload is all-or-nothing.
         names: list[str] = []
         # Indexes over `names` so the three batch-local duplicate checks below are hash
         # lookups, not scans over every earlier filename (O(N^2) at the 1000-file cap). First
@@ -3470,10 +3467,9 @@ async def upload_diffusion_dataset(
                         "uploading."
                     ),
                 )
-            # Reject a second ITEM sharing this stem but differing by extension (sample.png vs .jpg,
-            # or sample.png vs sample.mp4): both resolve to the same <stem>.txt sidecar. Caption
-            # files are exempt. Images and clips are compared together, not per kind, because the
-            # sidecar they would collide on is keyed on the stem alone and knows nothing of kind.
+            # Reject a second ITEM sharing this stem but differing by extension (sample.png vs .jpg, or sample.png vs
+            # sample.mp4): both resolve to the same <stem>.txt sidecar. Caption files are exempt. Images and clips are
+            # compared together, not per kind, because the sidecar is keyed on the stem alone.
             if ext in _DIFFUSION_DATASET_MEDIA_EXTS:
                 stem = Path(filename).stem
                 # Compare stems case-insensitively: on case-insensitive filesystems two stems differing only
@@ -3488,7 +3484,8 @@ async def upload_diffusion_dataset(
                         or other.stem.casefold() != stem_cf
                     ):
                         return False
-                    # A casefold-equal full name is exempt unless the stems match EXACTLY (extension-case variants collide on one sidecar on case-sensitive filesystems).
+                    # A casefold-equal full name is exempt unless the stems match EXACTLY (extension-case variants
+                    # collide on one sidecar on case-sensitive filesystems).
                     return other.stem == stem or other_name.casefold() != fname_cf
 
                 clash = next(
@@ -3511,10 +3508,10 @@ async def upload_diffusion_dataset(
                             f"caption. Rename one before uploading."
                         ),
                     )
-            # Reject a CASE variant of a name already in this batch, but only where the filesystem folds
-            # case: there 'Cat.png' and 'cat.png' are ONE destination, so the commit would replace the
-            # first staged part with the second while `uploaded` counted both. The same-name exemption
-            # above is for a SEPARATE repeat upload; on a case-sensitive filesystem both stay allowed.
+            # Reject a CASE variant already in this batch only where the filesystem folds case: there the commit
+            # replaces the first staged part with the second while `uploaded` counts both.
+            # There 'Cat.png' and 'cat.png' are ONE destination. The same-name exemption above is for a SEPARATE repeat
+            # upload; on a case-sensitive filesystem both stay allowed.
             clash_cf = first_name_by_casefold.get(fname_cf)
             if clash_cf is not None and _dataset_folder_is_case_insensitive(folder):
                 raise HTTPException(
@@ -3532,13 +3529,15 @@ async def upload_diffusion_dataset(
                     filename
                 )
             names.append(filename)
-        # Stage each file to a temp name and move it in only once the whole batch is written, so a mid-batch failure leaves the dataset untouched, including any same-name file a direct write would truncate.
-        staged: list[tuple[Path, Path]] = []  # (temp, final)
+        staged: list[tuple[Path, Path]] = []
+        # Stage each file to a temp name and move it in only once the whole batch is written, so a mid-batch failure
+        # leaves the dataset untouched, including any same-name file a direct write would truncate.
         committed = False
         try:
             for f, filename in zip(files, names):
                 dest = folder / filename
-                # A filename-independent temp name so a long (but valid) filename cannot overflow NAME_MAX with the staging suffix.
+                # A filename-independent temp name so a long (but valid) filename cannot overflow NAME_MAX with the
+                # staging suffix.
                 tmp = folder / f".upload-{_uuid.uuid4().hex}.part"
                 staged.append((tmp, dest))
                 with open(tmp, "wb") as out:
@@ -3554,18 +3553,18 @@ async def upload_diffusion_dataset(
                                 ),
                             )
                         out.write(chunk)
-                # Reject a decompression bomb before commit: a small PNG can pass the byte limit yet decode to huge pixels and OOM the trainer's latent cache.
-                # Images only. A clip's frames are bounded by the canvas the video trainer resizes
-                # to, not by the container, so there is no equivalent still to decode here.
+                # Reject a decompression bomb before commit: a small PNG can pass the byte limit yet decode to huge
+                # pixels and OOM the trainer's latent cache. Images only. A clip's frames are bounded by the canvas the
+                # video trainer resizes to, not by the container, so there is no equivalent still to decode here.
                 if Path(filename).suffix.lower() in _DIFFUSION_DATASET_IMAGE_EXTS:
                     _validate_uploaded_training_image(tmp, filename)
                 uploaded += 1
             # Re-check the interlock immediately before the commit: the entry guard only saw the
             # pre-upload state, so a /diffusion/start could have reserved the slot while we streamed.
             _require_diffusion_dataset_mutable()
+            backups: list[tuple[Path, Optional[Path]]] = []
             # Commit every staged file as one transaction: a plain replace loop is not atomic. Back up
             # each pre-existing destination first and restore them all on any failure.
-            backups: list[tuple[Path, Optional[Path]]] = []  # (dest, backup path or None)
             installed: list[Path] = []
             try:
                 for tmp, dest in staged:
@@ -3574,7 +3573,7 @@ async def upload_diffusion_dataset(
                         backup = folder / f".upload-backup-{_uuid.uuid4().hex}.part"
                         dest.replace(backup)
                     backups.append((dest, backup))
-                    tmp.replace(dest)  # atomic on the same filesystem
+                    tmp.replace(dest)
                     installed.append(dest)
                 committed = True
             except BaseException:
@@ -3619,8 +3618,8 @@ async def upload_diffusion_dataset(
         _lock.release()
 
 
-# ── Dataset labeling (per-image caption editing) + one-click example imports ──
-# Thumbnails live in a hidden subdir so they never appear in dataset listings or the trainer's image discovery.
+# Thumbnails live in a hidden subdir so they never appear in dataset listings or the trainer's
+# image discovery.
 _THUMBS_DIRNAME = ".thumbs"
 _MAX_CAPTION_CHARS = 2000
 
@@ -3633,7 +3632,8 @@ def _resolve_dataset_folder(name: str, *, must_exist: bool = True) -> Path:
     cleaned = _clean_diffusion_dataset_name(name)
     root = datasets_root().resolve()
     folder = root / cleaned
-    # Reject a symlinked dataset directory and prove the resolved folder stays under root: _safe_dataset_image_path only checks each image path, not the folder.
+    # Reject a symlinked dataset directory and prove the resolved folder stays under root: _safe_dataset_image_path only
+    # checks each image path, not the folder.
     if folder.is_symlink():
         raise HTTPException(
             status_code = 400,
@@ -3667,7 +3667,8 @@ def _validate_uploaded_training_image(path: Path, original_name: str) -> None:
         with Image.open(path) as image:
             width, height = image.size
     except Image.DecompressionBombError:
-        # Past Pillow's ~179 MP limit Image.open() raises before .size can be read, with an error deriving straight from Exception, so letting it escape would 500 the upload.
+        # Past Pillow's ~179 MP limit Image.open() raises before .size can be read, with an error deriving straight from
+        # Exception, so letting it escape would 500 the upload.
         raise HTTPException(
             status_code = 400,
             detail = (
@@ -3676,7 +3677,7 @@ def _validate_uploaded_training_image(path: Path, original_name: str) -> None:
             ),
         )
     except (OSError, UnidentifiedImageError, ValueError):
-        return  # not a decodable image -> not a bomb; leave the existing contract
+        return
     if width > _MAX_TRAINING_IMAGE_SIDE or height > _MAX_TRAINING_IMAGE_SIDE:
         raise HTTPException(
             status_code = 400,
@@ -3767,7 +3768,8 @@ def _image_record(
                 source = "sidecar"
             break
     if caption is None and not sidecar_present:
-        # Basename first, then the relative path as written in the jsonl (as_posix so Windows paths match): discover_image_caption_pairs order.
+        # Basename first, then the relative path as written in the jsonl (as_posix so Windows paths match):
+        # discover_image_caption_pairs order.
         meta = meta_captions.get(image_path.name)
         if meta is None:
             try:
@@ -3849,7 +3851,8 @@ async def get_diffusion_dataset_image(
 
         thumbs_dir = folder / _THUMBS_DIRNAME
         thumbs_dir.mkdir(exist_ok = True)
-        # Key on the full filename, not the stem: two images sharing a stem would collide on one cache file and the mtime-newer entry would be served for both.
+        # Key on the full filename, not the stem: two images sharing a stem would collide on one cache file and the
+        # mtime-newer entry would be served for both.
         thumb_path = thumbs_dir / f"{image_path.name}_{size}.jpg"
         src_mtime = image_path.stat().st_mtime
         if thumb_path.is_file() and thumb_path.stat().st_mtime >= src_mtime:
@@ -3899,8 +3902,8 @@ async def set_diffusion_dataset_caption(
             sidecar.write_text(caption, encoding = "utf-8")
             image_path.with_suffix(".caption").unlink(missing_ok = True)
             return _image_record(folder, image_path, _load_metadata_captions(folder))
-        # Blank must actually clear. Unlinking alone would resurface this image's metadata caption,
-        # so write an EMPTY sidecar: reader and trainer treat it as an authoritative tombstone.
+        # Blank must actually clear. Unlinking alone would resurface this image's metadata caption
+        # Write an EMPTY sidecar: reader and trainer treat it as an authoritative tombstone.
         meta = _load_metadata_captions(folder)
         try:
             rel = image_path.relative_to(folder).as_posix()
@@ -3934,13 +3937,10 @@ async def delete_diffusion_dataset_image(
         import glob as _glob
 
         image_path.unlink(missing_ok = True)
-        # Sidecars are keyed on the STEM, so cat.jpg and cat.png share cat.txt: deleting it with one
-        # would strip the survivor's caption. New collisions are refused at upload; legacy ones exist.
-        # Fold stems only where the filesystem folds them, off the same probe the upload's case
-        # checks use. Where it folds, CAT.mp4 reads the very file cat.png calls cat.txt, so an
-        # exact compare would not see the survivor and would unlink its caption. Where it does
-        # not, those are two separate sidecars, and folding would strand cat.txt for whatever
-        # later takes the cat stem to inherit.
+        # Sidecars are keyed on the STEM, so fold stems only where the filesystem folds them: an exact compare would
+        # unlink a survivor's caption, and folding elsewhere strands cat.txt.
+        # cat.jpg and cat.png share cat.txt, and where the filesystem folds, CAT.mp4 reads the very file cat.png calls
+        # cat.txt. New collisions are refused at upload; legacy ones exist.
         folds_case = _dataset_folder_is_case_insensitive(folder)
 
         def same_stem(p: Path) -> bool:
@@ -3965,7 +3965,8 @@ async def delete_diffusion_dataset_image(
                 image_path.with_suffix(ext).unlink(missing_ok = True)
         thumbs_dir = folder / _THUMBS_DIRNAME
         if thumbs_dir.is_dir():
-            # Thumbs are keyed on the full filename, so match that here; a stem-only glob would strand this image's thumbs or delete a sibling's. Escape the name so a glob metacharacter cannot match siblings.
+            # Thumbs are keyed on the full filename, so match that here; a stem-only glob would strand this image's
+            # thumbs or delete a sibling's. Escape the name so a glob metacharacter cannot match siblings.
             for t in thumbs_dir.glob(f"{_glob.escape(image_path.name)}_*.jpg"):
                 t.unlink(missing_ok = True)
         return {"deleted": image_path.name}
@@ -4019,7 +4020,8 @@ _DATASET_EXAMPLES: list[dict] = [
         "description": "100 butterfly photos. No captions, so use the trigger prompt.",
         "license": "CC0",
         "image_cap": 100,
-        # The metadata columns are species names / boilerplate alt-text, not captions, so train it as a subject set with the trigger prompt instead.
+        # The metadata columns are species names / boilerplate alt-text, not captions, so train it as a subject set with
+        # the trigger prompt instead.
         "suggested_trigger": "a photo of a sks butterfly",
         "loader": "hf_dataset",
         "caption_column": None,
@@ -4112,15 +4114,14 @@ def _materialize_hf_dataset(entry: dict, dest: Path, cap: int) -> int:
     kwargs = {"split": "train"}
     if entry.get("no_checks"):
         kwargs["verification_mode"] = "no_checks"
-    # Stream rather than prepare the whole split: the loop keeps at most `cap` rows while these
-    # curated repos run to tens of thousands. A repo that cannot stream falls back to prepared.
     try:
         ds = load_dataset(entry["repo"], streaming = True, **kwargs)
         features = ds.features
     except Exception:  # noqa: BLE001 -- not streamable; the prepared load is the fallback
         ds = load_dataset(entry["repo"], **kwargs)
         features = ds.features
-    # Streaming can hand back a dataset whose features are only known once a row is read, so resolve the columns from the first row then.
+    # Streaming can hand back a dataset whose features are only known once a row is read, so resolve the columns from
+    # the first row then.
     image_col = _detect_image_column(features) if features else None
     if image_col is None and features:
         raise HTTPException(
@@ -4243,8 +4244,9 @@ async def import_diffusion_dataset_example(
         summary = _diffusion_dataset_summary(folder)
         if summary.image_count > 0 or summary.clip_count > 0:
             return _import_response(entry, folder, imported = 0)
-        # One import at a time per dataset folder: the training interlock COUNTS mutations rather than excluding them, so two
-        # imports into the same empty name both passed the emptiness check and merged. Refusing the second is honest.
+        # One import at a time per dataset folder: the training interlock COUNTS mutations rather than excluding them,
+        # so two imports into the same empty name both passed the emptiness check and merged. Refusing the second is
+        # honest.
         lock = _dataset_import_lock(folder)
         if not lock.acquire(blocking = False):
             raise HTTPException(
@@ -4265,14 +4267,17 @@ async def import_diffusion_dataset_example(
         import tempfile
 
         imported = 0
-        # Re-read under the lock: a winner may have promoted its staging dir while this request was checking, so returning the folder as-is matches the idempotent path.
+        # Re-read under the lock: a winner may have promoted its staging dir while this request was checking, so
+        # returning the folder as-is matches the idempotent path.
         existing = _diffusion_dataset_summary(folder)
         if existing.image_count == 0 and existing.clip_count == 0:
             cap = int(entry["image_cap"])
-            # Materialize into a private staging dir and promote only after the whole import succeeds, so a partial materialize
-            # leaves only that dir. Staged as a hidden same-filesystem sibling so promotion is an atomic rename.
+            # Materialize into a private staging dir and promote only after the whole import succeeds, so a partial
+            # materialize leaves only that dir. Staged as a hidden same-filesystem sibling so promotion is an atomic
+            # rename.
             staging = Path(tempfile.mkdtemp(dir = folder.parent, prefix = f".{folder.name}.import-"))
-            # Superseded same-name entries are parked here rather than deleted, so a failed promotion can put them back too.
+            # Superseded same-name entries are parked here rather than deleted, so a failed promotion can put them back
+            # too.
             rescue = Path(tempfile.mkdtemp(dir = folder.parent, prefix = f".{folder.name}.rescue-"))
             # (entry's new home, where it came from) for every pre-existing entry moved out of the folder.
             folded: list[tuple[Path, Path]] = []
@@ -4306,18 +4311,23 @@ async def import_diffusion_dataset_example(
                         status_code = 502,
                         detail = f"No images found in '{entry['repo']}'.",
                     )
-                # Promote the fully-materialized staging dir as a UNIT: a same-filesystem rename is atomic, so a hard process death
-                # leaves either the old folder or the finished import. rmdir needs an empty target, so fold any pre-existing files (a .thumbs cache, an older metadata.jsonl) INTO staging first and keep one atomic promotion.
+                # Promote the fully-materialized staging dir as a UNIT: a same-filesystem rename is atomic, so a hard
+                # process death leaves either the old folder or the finished import. rmdir needs an empty target, so
+                # fold any pre-existing files (a .thumbs cache, an older metadata.jsonl) INTO staging first and keep one
+                # atomic promotion.
                 try:
                     for p in sorted(folder.iterdir()):
-                        # Same name in both: the imported file wins, as the previous per-file move did. Park the old one in the rescue dir so the folder can be emptied for the rename without destroying it.
+                        # Same name in both: the imported file wins, as the previous per-file move did. Park the old one
+                        # in the rescue dir so the folder can be emptied for the rename without destroying it.
                         dest = (rescue if (staging / p.name).exists() else staging) / p.name
                         shutil.move(str(p), str(dest))
                         folded.append((dest, p))
                     os.rmdir(folder)
                     os.replace(str(staging), str(folder))
                 except (OSError, shutil.Error) as e:
-                    # Every step here can fail (an unmovable entry, a folder that gained a file, a rename held by antivirus), and by then the folder's entries live only in the staging/rescue dirs the finally deletes.
+                    # Every step here can fail (an unmovable entry, a folder that gained a file, a rename held by
+                    # antivirus), and by then the folder's entries live only in the staging/rescue dirs the finally
+                    # deletes.
                     restore_folded()
                     raise HTTPException(
                         status_code = 409,

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -779,7 +779,7 @@ def _reject_untrainable_model_request(
     if path is None:
         try:
             # Raised inside the try on purpose: the except HTTPException handler still runs
-        # _resolve_model_snapshot, so a cached snapshot pins as before without the remote budget.
+            # _resolve_model_snapshot, so a cached snapshot pins as before without the remote budget.
             if _hub_unreachable():
                 raise _hf_preflight_error(
                     503,
@@ -1205,7 +1205,6 @@ async def start_training(
             if reservation == "conflict":
                 return _start_request_response(record)
             reserved_start_request_id = request.start_request_id
-
 
         # No in-process ensure_transformers_version(): worker.py activates it before ML imports.
         # A consented latest-transformers install stage-and-swaps .venv_t5_latest mid-spawn.
@@ -1673,7 +1672,7 @@ async def start_training(
         def _run_backend_start() -> bool:
             try:
                 # Keep the diffusion admission in the worker thread across the whole spawn: a disconnected
-        # request must not release it while the shielded start is still freeing VRAM.
+                # request must not release it while the shielded start is still freeing VRAM.
                 with _diffusion_gpu_admission():
                     return _run_backend_start_without_admission()
             except _DiffusionStartInFlight as exc:
@@ -2452,8 +2451,6 @@ async def stream_training_progress(
             "X-Accel-Buffering": "no",
         },
     )
-
-
 
 
 # ── Diffusion (SDXL) LoRA training ──────────────────────────────────────────── A separate, lightweight job path:

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -2458,6 +2458,7 @@ async def stream_training_progress(
 
 # ── Diffusion (SDXL) LoRA training ──────────────────────────────────────────── A separate, lightweight job path:
 # diffusion runs use DiffusionTrainingService (its own subprocess + event pump), not the LLM TrainingBackend.
+# ── Diffusion (SDXL) LoRA training ────────────────────────────────────────────
 def _diffusion_training_active() -> bool:
     """Whether a diffusion (SDXL) LoRA job is currently running. Best-effort so the
     interlock never blocks a start just because the service could not be imported."""
@@ -3620,6 +3621,7 @@ async def upload_diffusion_dataset(
 
 # Thumbnails live in a hidden subdir so they never appear in dataset listings or the trainer's
 # image discovery.
+# ── Dataset labeling (per-image caption editing) + one-click example imports ──
 _THUMBS_DIRNAME = ".thumbs"
 _MAX_CAPTION_CHARS = 2000
 

--- a/studio/backend/routes/training_history.py
+++ b/studio/backend/routes/training_history.py
@@ -425,8 +425,7 @@ async def delete_training_run(
     try:
         delete_run(run_id)
     except Exception as delete_error:
-        # The artifacts are only staged, so the whole operation rolls back. Destroying them first would
-        # leave a row whose artifacts are silently gone, looking like a deliberate "kept history".
+        # The artifacts are only staged, so the whole operation rolls back.
         if staged_original is not None and staged_path is not None:
             restored = await asyncio.to_thread(
                 _restore_staged_output_dir, staged_original, staged_path

--- a/studio/backend/routes/training_vram.py
+++ b/studio/backend/routes/training_vram.py
@@ -187,7 +187,7 @@ def can_keep_chat_during_training(
             aggregate_fits = usable_gb >= required_gb * SAFETY_MARGIN + KEEP_FLOOR_GB
 
             # Activations don't shard: enforce a per-GPU floor so an uneven split (free [45, 10]) cannot be
-    # kept into an OOM the aggregate misses.
+            # kept into an OOM the aggregate misses.
             per_gpu_fits = True
             min_free_gb = min(free_vals) if free_vals else 0.0
             if len(resolved) > 1:
@@ -358,8 +358,8 @@ def can_load_chat_during_training(
                     raise ValueError
             except (TypeError, ValueError):
                 # A non-numeric device token (CUDA UUID / MIG handle) has no free-VRAM index, but the runner
-            # still drives ONE device: size against the worst-case visible device, never the aggregate
-            # pool, or a single-device load is OK'd on capacity it cannot use.
+                # still drives ONE device: size against the worst-case visible device, never the aggregate
+                # pool, or a single-device load is OK'd on capacity it cannot use.
                 free_vals = [min(free_by_index.values())] if free_by_index else []
             else:
                 free_vals = [free_by_index.get(selected_gpu, 0.0)]

--- a/studio/backend/routes/training_vram.py
+++ b/studio/backend/routes/training_vram.py
@@ -62,7 +62,7 @@ def summarize_resident_chat() -> Dict[str, Any]:
         # A confirmed CPU-only server (_gpu_offload_active is False) holds no VRAM.
         if llama.is_active and getattr(llama, "_gpu_offload_active", None) is not False:
             gguf_name = llama.model_identifier or "gguf"
-            if not getattr(llama, "is_loaded", False):  # still loading -> size unknown
+            if not getattr(llama, "is_loaded", False):
                 loading = True
     except Exception as e:
         logger.warning("Could not inspect GGUF backend: %s", e)
@@ -85,11 +85,10 @@ def summarize_resident_stt() -> Dict[str, Any]:
         model = sidecar.loaded_model
         device = sidecar.device
         loading = sidecar.is_loading()
-        # whisper.cpp holds GPU memory via its subprocess, and both engines can be
-        # live at once (engine switch or direct /audio/stt/load). Always fold the
-        # GGUF sidecar in: a resident Transformers model must not mask a GGUF
-        # server still binding its backend, or admission lets training launch into
-        # that startup and OOM.
+        # whisper.cpp holds GPU memory via its subprocess.
+        # Both engines can be live at once (engine switch or direct /audio/stt/load), so always fold the GGUF sidecar
+        # in: a resident Transformers model must not mask a GGUF server still binding its backend, or admission lets
+        # training launch into that startup and OOM.
         ggml = get_ggml_stt_sidecar()
         if not model:
             model = ggml.loaded_model
@@ -99,9 +98,6 @@ def summarize_resident_stt() -> Dict[str, Any]:
         logger.warning("Could not inspect STT sidecar: %s", e)
         return {"model": None, "device": None, "loading": False, "any": False}
 
-    # Same reasoning for mtmd: its llama-server holds VRAM too, so admission has
-    # to see it. Its own boundary, so an mtmd import failure cannot discard what
-    # the other two engines just reported.
     try:
         from core.inference.stt_mtmd_sidecar import get_mtmd_stt_sidecar
 
@@ -170,7 +166,6 @@ def can_keep_chat_during_training(
         )
 
         if gpu_ids:
-            # Explicit GPUs: the selector does no VRAM math, so size it here.
             try:
                 resolved = resolve_requested_gpu_ids(gpu_ids)
             except ValueError:
@@ -191,8 +186,8 @@ def can_keep_chat_during_training(
             )
             aggregate_fits = usable_gb >= required_gb * SAFETY_MARGIN + KEEP_FLOOR_GB
 
-            # Activations don't shard: enforce a per-GPU floor so an uneven split
-            # (e.g. free [45, 10]) can't be kept into an OOM the aggregate misses.
+            # Activations don't shard: enforce a per-GPU floor so an uneven split (free [45, 10]) cannot be
+    # kept into an OOM the aggregate misses.
             per_gpu_fits = True
             min_free_gb = min(free_vals) if free_vals else 0.0
             if len(resolved) > 1:
@@ -271,14 +266,13 @@ def can_load_chat_during_training(
 
         est_kwargs = dict(
             hf_token = hf_token or None,
-            training_type = None,  # inference sizing of the chat model itself
+            training_type = None,
             load_in_4bit = load_in_4bit,
             max_seq_length = max_seq_length or 2048,
         )
 
-        # A native-audio switch may carry one atomic post-handoff capacity
-        # snapshot. It already combines live free memory with only the outgoing
-        # Studio backend, so do not re-read and add those values here.
+        # A native-audio switch's post-handoff snapshot already combines live free memory with the
+        # outgoing Studio backend, so do not re-read and add those values here.
         if not requested_gpu_ids and not is_gguf and post_handoff_free_gpu_vram_gb is not None:
             required_gb = required_override_gb
             if required_gb is None:
@@ -354,20 +348,18 @@ def can_load_chat_during_training(
         elif single_device_gpu is not None:
             token = str(single_device_gpu).strip()
             if not token:
-                # Empty token = a CPU-only single-device runner (e.g. a CPU
-                # diffusion GGUF): it uses no GPU VRAM, so it never threatens
-                # active training and can always load.
+                # Empty token = a CPU-only single-device runner
+                # For example a CPU diffusion GGUF: it uses no GPU VRAM, so it never threatens active training and can
+                # always load.
                 return True, {"mode": "single_device", "reason": "cpu_only"}
             try:
                 selected_gpu = int(token)
                 if selected_gpu < 0:
                     raise ValueError
             except (TypeError, ValueError):
-                # A non-numeric device token (e.g. a CUDA UUID / MIG handle)
-                # can't be mapped to a free-VRAM index, but the runner still
-                # drives ONE device. Size against the worst-case visible device
-                # (min free), never the aggregate pool, so a single-device load
-                # is never OK'd on capacity it can't use and OOMs training.
+                # A non-numeric device token (CUDA UUID / MIG handle) has no free-VRAM index, but the runner
+            # still drives ONE device: size against the worst-case visible device, never the aggregate
+            # pool, or a single-device load is OK'd on capacity it cannot use.
                 free_vals = [min(free_by_index.values())] if free_by_index else []
             else:
                 free_vals = [free_by_index.get(selected_gpu, 0.0)]
@@ -490,8 +482,7 @@ def free_stt_model_for_training(reason: str) -> List[str]:
     except Exception as e:
         logger.warning("Could not unload Transformers STT model: %s", e)
 
-    # Check the GGUF sidecar even after a cancelled/failed Transformers unload;
-    # both engines can hold memory at once (engine switch or direct load).
+    # Check the GGUF sidecar even after a cancelled or failed Transformers unload; both engines can hold memory at once.
     try:
         from core.inference.stt_ggml_sidecar import get_ggml_stt_sidecar
         ggml = get_ggml_stt_sidecar()
@@ -513,8 +504,6 @@ def free_stt_model_for_training(reason: str) -> List[str]:
     except Exception as e:
         logger.warning("Could not unload GGUF STT model: %s", e)
 
-    # The mtmd sidecar serves Qwen3-ASR through llama-server at -ngl 99, so it
-    # holds VRAM exactly like the other two and has to be freed as well.
     try:
         from core.inference.stt_mtmd_sidecar import get_mtmd_stt_sidecar
         mtmd = get_mtmd_stt_sidecar()

--- a/studio/backend/routes/video.py
+++ b/studio/backend/routes/video.py
@@ -772,6 +772,7 @@ async def clear_gallery_videos(current_subject: str = Depends(get_current_subjec
 
 
 # ── OpenAI-compatible videos API (/v1/videos) ──
+
 _VIDEO_SIZE_RE = _re.compile(r"^(\d{1,5})\s*x\s*(\d{1,5})$")
 _VIDEO_SECONDS_MAX = 120.0
 _VIDEO_JOB_ID_PREFIX = "video_"

--- a/studio/backend/routes/video.py
+++ b/studio/backend/routes/video.py
@@ -152,28 +152,18 @@ async def video_download_plan(
             family_override = request.family_override,
             model_kind = kind,
             base_repo = request.base_repo,
-            # Validation is quant-keyed: a scheme this family can serve only from a hosted
-            # pre-quantized checkpoint has to be refused HERE, on the route that stages the
-            # download, or the panel fetches ~98.7 GB before /video/load can say no.
             transformer_quant = request.transformer_quant,
-            # And the partition, because one of those quant-keyed refusals is task-keyed: the
-            # hosted pre-quantized H3 checkpoints are fl2va denoisers, so a quantized ref2va is
-            # rejected. /video/load passes this and refuses; without it here the plan below staged
-            # the 66 GB dense transformer_ref/ AND the incompatible fl2va quant first.
+            # And the partition, because one of those quant-keyed refusals is task-keyed
+            # Without it here the plan below staged the 66 GB dense transformer_ref/ AND the incompatible fl2va quant
+            # first: the hosted pre-quantized H3 checkpoints are fl2va denoisers, so a quantized ref2va is rejected.
             h3_task = request.h3_task,
         )
-        # BEFORE the plan is staged, as on the images side: /video/load refuses a precision this
-        # host cannot honour, but the UI plans and downloads first, so an explicit FP8 on an
-        # unsupported host paid for tens of GB of weights to be told afterwards. Network-free.
-        #
-        # Skipped while a trainer holds the GPU: an uncached scheme takes this into a
-        # quantise-and-matmul smoke probe that initialises CUDA in the Unsloth process, and the
-        # plan runs before the load's training guard can refuse. Staging needs no GPU.
-        # Ranking opens a CUDA context per candidate, which the training guard exists to prevent,
-        # so the RANKING waits until training is known idle. Validating and translating the ids
-        # does not, so that happens either way: a plan that skipped it accepted a GPU the load
-        # would refuse and sized its file set for the wrong card. ONE resolution, reused by
-        # preflight and plan.
+        # BEFORE the plan is staged, as on the images side: /video/load refuses a precision this host cannot honour, but
+        # the UI plans and downloads first, so an explicit FP8 on an unsupported host paid for tens of GB of weights to
+        # be told afterwards. Network-free. Skipped while a trainer holds the GPU: an uncached scheme takes this into a
+        # quantise-and-matmul smoke probe that initialises CUDA. RANKING opens a CUDA context per candidate, so it waits
+        # until training is known idle, while validating and translating the ids happens either way. ONE resolution,
+        # reused by preflight and plan.
         gpu_ordinal = None
         training = fam is not None and await asyncio.to_thread(_training_is_active)
         if fam is not None:
@@ -198,15 +188,16 @@ async def video_download_plan(
             family_override = request.family_override,
             model_kind = kind,
             hf_token = request.hf_token,
-            # The plan must see the encoder policy the load will use: an fp8 request takes a hosted pre-cast encoder, so staging the dense one wastes ~49 GB on LTX-2.
+            # The plan must see the encoder policy the load will use: an fp8 request takes a hosted pre-cast encoder, so
+            # staging the dense one wastes ~49 GB on LTX-2.
             text_encoder_quant = request.text_encoder_quant,
-            # And the denoiser policy, for the same reason: a scheme with a hosted pre-quantized
-            # checkpoint replaces the dense DiT, so without this the plan stages 66.3 GB of shards
-            # the load never opens.
+            # And the denoiser policy.
+            # A scheme with a hosted pre-quantized checkpoint replaces the dense DiT, so without this the plan stages
+            # 66.3 GB of shards the load never opens.
             transformer_quant = request.transformer_quant,
-            # And the MiniMax-H3 partition, because the two denoisers live in separate 66.28 GB
-            # subfolders: a ref2va load opens transformer_ref/, which the plan would otherwise
-            # miss entirely while staging the fl2va transformer/ it never opens.
+            # And the MiniMax-H3 partition.
+            # The two denoisers live in separate 66.28 GB subfolders: a ref2va load opens transformer_ref/, which the
+            # plan would otherwise miss entirely while staging the fl2va transformer/ it never opens.
             h3_task = request.h3_task,
         )
         return DiffusionDownloadPlanResponse(**plan)
@@ -253,9 +244,11 @@ async def load_video_model_gated(
 
     backend = get_video_backend()
     try:
-        # Resolve the load kind once (gguf / single_file / pipeline) so validation and the load agree; a bad kind raises here, so a 400.
+        # Resolve the load kind once (gguf / single_file / pipeline) so validation and the load agree; a bad kind raises
+        # here, so a 400.
         kind = resolve_video_model_kind(request.gguf_filename, request.model_kind)
-        # A local On-Device pick can be a bare single-file .safetensors dir the picker starts as a pipeline; if it holds exactly one checkpoint, load it as single_file. Mirrors images.
+        # A local On-Device pick can be a bare single-file .safetensors dir the picker starts as a pipeline; if it holds
+        # exactly one checkpoint, load it as single_file. Mirrors images.
         if kind == "pipeline" and not request.gguf_filename:
             sole = await asyncio.to_thread(resolve_local_single_file, request.model_path)
             if sole is not None:
@@ -273,19 +266,13 @@ async def load_video_model_gated(
             text_encoder_quant = request.text_encoder_quant,
             h3_task = request.h3_task,
         )
-        # Refuse while training is running (VRAM competition) BEFORE the precision check below:
-        # that check runs an uncached quantise+matmul probe on the GPU, which would initialise a
-        # CUDA context and allocate alongside the training subprocess for a load that is about to
-        # be rejected anyway. Mirrors the image-load route, which already guards first.
+        # Refuse while training is running BEFORE the precision check, which runs a GPU probe that would initialise a
+        # CUDA context alongside the training subprocess for a load about to be rejected.
         _guard_video_load_against_training()
-        # Same bar for an EXPLICIT precision this host can never honor. begin_load makes the
-        # identical network-free check, but it runs inside acquire_for, which evicts chat under the
-        # arbiter lock BEFORE the register callback -- so a refusal raised there arrives having
-        # already taken the GPU away from the model it was meant to preserve. `auto` is never
-        # refused, so a caller that left the precision to the backend cannot reach this.
-        # Ahead of the precision gate, which has to judge the card this pick would load on.
-        # Refused here too, before anything is evicted or staged; begin_load re-checks, but only
-        # after the arbiter has taken the GPU.
+        # Same bar for an EXPLICIT precision this host can never honor. begin_load makes the identical network-free
+        # check, but it runs inside acquire_for, which evicts chat under the arbiter lock BEFORE the register callback,
+        # so a refusal raised there arrives having already taken the GPU away from the model it was meant to preserve.
+        # `auto` is never refused.
         gpu_ordinal = await _selected_gpu_ordinal(request.gpu_ids)
         await asyncio.to_thread(
             assert_video_precision_available,
@@ -298,11 +285,10 @@ async def load_video_model_gated(
             memory_mode = request.memory_mode,
             gpu_ordinal = gpu_ordinal,
         )
-        # Same bar again, for a speech GGUF picked out of a mixed video repo. The backend's own
-        # assertion runs on the load worker, INSIDE acquire_for, so a refusal there arrives
-        # having already evicted the chat model this gate exists to preserve. Off-thread because
-        # the probe reads a header, and cache-only when the load is not user-initiated, matching
-        # the locality promise begin_load makes below.
+        # Same bar again, for a speech GGUF picked out of a mixed video repo.
+        # The backend's own assertion runs on the load worker, INSIDE acquire_for, so a refusal there arrives having
+        # already evicted the chat model. Off-thread because the probe reads a header, and cache-only when the load is
+        # not user-initiated.
         from core.inference.diffusion_compat import assert_pick_is_not_speech
 
         await asyncio.to_thread(
@@ -312,11 +298,13 @@ async def load_video_model_gated(
             request.hf_token,
             user_initiated,
         )
-        # Take the GPU from chat only for a non-CPU load. Release stale VIDEO ownership on a CPU load (owner-guarded no-op).
+        # Take the GPU from chat only for a non-CPU load. Release stale VIDEO ownership on a CPU load (owner-guarded
+        # no-op).
         device = await asyncio.to_thread(lambda: resolve_diffusion_device_target().device)
 
         def _begin_load():
-            # Kicks the (slow) load onto a background thread and returns at once; begin_load itself validates network-free.
+            # Kicks the (slow) load onto a background thread and returns at once; begin_load itself validates
+            # network-free.
             return backend.begin_load(
                 request.model_path,
                 # a load nobody asked for may not reach the hub: the switch verified locality
@@ -342,8 +330,7 @@ async def load_video_model_gated(
             )
 
         if device != "cpu":
-            # Register the in-flight load UNDER the arbiter lock: otherwise a competing acquire in that gap evicts VIDEO before the
-            # load is marked, finds nothing to cancel, and both allocate at once. The training admission wraps the same span.
+            # Register the in-flight load UNDER the arbiter lock: otherwise a competing acquire in that gap evicts VIDEO
             from routes.inference import _diffusion_training_admission
             def _acquire_and_begin():
                 with _diffusion_training_admission():
@@ -353,8 +340,7 @@ async def load_video_model_gated(
         else:
             await asyncio.to_thread(release, VIDEO)
             status_dict = await asyncio.to_thread(_begin_load)
-        # Keyed to the target: this load can still fail with the previous model resident, and
-        # its origin must not be read off that model.
+        # Keyed to the target: this load can still fail with the previous model resident
         note_load_origin(
             VIDEO,
             request.model_path,
@@ -459,12 +445,10 @@ async def generate_video(
         raise HTTPException(status_code = 400, detail = str(exc))
 
     backend = get_video_backend()
-    # The request bounds on VideoGenerateRequest are a coarse outer guard; the real rule is the LOADED
-    # family's (its presets and frame lattice), and begin_generate applies it under the same lock that
-    # reserves the state the job will run against, so a load committing concurrently cannot leave the
-    # shape judged against one family and denoised by another. Unloaded still falls through to the
-    # not-loaded 409; a family with no declared presets keeps the old SIZE snapping, though its frame
-    # lattice is enforced either way (frame_step is declared regardless).
+    # The real rule is the LOADED family's, applied by begin_generate under the same lock that reserves the state, so a
+    # concurrent load cannot leave the shape judged against one family and denoised by another.
+    # Unloaded still falls through to the not-loaded 409, and a family with no declared presets keeps the old SIZE
+    # snapping, though frame_step is declared regardless.
     try:
         await asyncio.to_thread(
             backend.begin_generate,
@@ -488,14 +472,14 @@ async def generate_video(
             audio_flow_shift = request.audio_flow_shift,
         )
     except VideoShapeError as exc:
-        # 422 before the 400 below, and it must stay first: VideoShapeError IS a ValueError. The body
-        # parses and is in range, but the shape is not one this model can render.
+        # 422 before the 400 below, and it must stay first: VideoShapeError IS a ValueError.
         raise HTTPException(status_code = 422, detail = str(exc))
     except ValueError as exc:
         # Bad client input -- a 400 with the reason, not a generic 500.
         raise HTTPException(status_code = 400, detail = str(exc))
     except RuntimeError as exc:
-        # Only the not-loaded / busy sentinels are client-state (409); match exactly so an unrelated failure cannot leak its message.
+        # Only the not-loaded / busy sentinels are client-state (409); match exactly so an unrelated failure cannot leak
+        # its message.
         msg = str(exc)
         if msg in (VIDEO_NOT_LOADED_MSG, VIDEO_GENERATION_BUSY_MSG):
             raise HTTPException(status_code = 409, detail = msg)
@@ -531,7 +515,8 @@ async def unload_video_model(current_subject: str = Depends(get_current_subject)
 
     backend = get_video_backend()
     status_dict = await asyncio.to_thread(backend.unload)
-    # Drop VIDEO ownership only if nothing is resident AND no load is in flight; the check and release must be ATOMIC (release_if). Mirrors images.
+    # Drop VIDEO ownership only if nothing is resident AND no load is in flight; the check and release must be ATOMIC
+    # (release_if). Mirrors images.
     await asyncio.to_thread(
         release_if,
         VIDEO,
@@ -552,7 +537,8 @@ async def list_gallery_videos(
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
 
-    # Validate inside the pager so offset / limit / has_more count over the accepted domain: dropping bad records only after slicing stalled infinite scroll at offset 0.
+    # Validate inside the pager so offset / limit / has_more count over the accepted domain: dropping bad records only
+    # after slicing stalled infinite scroll at offset 0.
     def _valid_gallery_video(record: dict) -> bool:
         try:
             GalleryVideo(**record)
@@ -579,13 +565,13 @@ async def get_gallery_video_file(
 ):
     from core.inference import video_gallery
 
-    # Ownership-gate the serve like delete/clear: resolve only an Unsloth-owned MP4, so a guessed stem cannot stream out a foreign clip.
+    # Ownership-gate the serve like delete/clear: resolve only an Unsloth-owned MP4, so a guessed stem cannot stream out
+    # a foreign clip.
     path = await asyncio.to_thread(video_gallery.owned_video_path, video_id)
     if path is None:
         raise HTTPException(status_code = 404, detail = "Video not found.")
     from fastapi.responses import FileResponse
 
-    # FileResponse streams from disk and serves range requests. Immutable per id, so let the browser cache it.
     return FileResponse(
         path,
         media_type = "video/mp4",
@@ -593,8 +579,9 @@ async def get_gallery_video_file(
     )
 
 
-# A clip is tens to hundreds of MB, so the gallery cannot fetch it into a blob like a PNG: that buffers the whole MP4, defeats seeking and
-# pins the bytes in the webview. The /file route streams ranges but is bearer-gated, so mint a 12-hour HMAC link (<video> re-requests on seek).
+# A clip is tens to hundreds of MB, so the gallery cannot fetch it into a blob like a PNG: that buffers the whole MP4,
+# defeats seeking and pins the bytes in the webview. The /file route streams ranges but is bearer-gated, so mint a
+# 12-hour HMAC link (<video> re-requests on seek).
 _VIDEO_LINK_TTL = 12 * 3600
 _VIDEO_LINK_SECRET = _secrets.token_bytes(32)
 
@@ -742,8 +729,7 @@ async def update_gallery_video_flags(
         raise HTTPException(status_code = 500, detail = "Could not save the change to this video.")
     if record is None:
         raise HTTPException(status_code = 404, detail = "Video not found.")
-    # Archiving takes the clip off the strip, so the completed-job record must go with it: the page
-    # merges that snapshot on mount, which would keep resurrecting the clip it just archived.
+    # Archiving takes the clip off the strip.
     if patch.archived:
         _forget_terminal_video(video_id)
     return GalleryVideo(**record)
@@ -785,8 +771,8 @@ async def clear_gallery_videos(current_subject: str = Depends(get_current_subjec
     return {"removed": len(cleared)}
 
 
-# ── OpenAI-compatible videos API (/v1/videos) ──
 
+# ── OpenAI-compatible videos API (/v1/videos) ──
 _VIDEO_SIZE_RE = _re.compile(r"^(\d{1,5})\s*x\s*(\d{1,5})$")
 _VIDEO_SECONDS_MAX = 120.0
 _VIDEO_JOB_ID_PREFIX = "video_"
@@ -1458,10 +1444,9 @@ async def _create_openai_video(
         presets = defaults.get("resolution_presets") or []
         if size is None and presets:
             width, height = int(presets[0][0]), int(presets[0][1])
-    # Describe the job from what begin_generate reserved, falling back to the status()
-    # snapshot only where it said nothing. A load committing between that snapshot and
-    # the reservation swaps the family underneath, and the snapshot's fps would then
-    # date a frame count the new model never used.
+    # Describe the job from what begin_generate reserved, falling back to the status() snapshot only
+    # where it said nothing: a load committing in between swaps the family, and the snapshot's fps
+    # would then date a frame count the new model never used.
     reserved = resolved if isinstance(resolved, dict) else {}
     run_frames = reserved.get("num_frames") or num_frames
     fps = reserved.get("fps") or defaults.get("fps")
@@ -1558,7 +1543,7 @@ async def openai_download_video_content(
             thumbnail = await asyncio.to_thread(video_gallery.thumbnail, video_id)
         except RuntimeError as exc:
             raise _openai_video_error(501, str(exc), code = "video_thumbnail_unavailable") from exc
-        if thumbnail is None:  # The clip was deleted between the ownership check and decode.
+        if thumbnail is None:
             raise _not_found(video_id)
         return Response(
             content = thumbnail,
@@ -1588,11 +1573,7 @@ async def openai_delete_video(video_id: str, current_subject: str = Depends(get_
         raise _not_found(video_id)
     if video.status in ("queued", "in_progress"):
         await asyncio.to_thread(get_video_backend().cancel_generate, video_id)
-        # The run can reach its terminal state between the lookup and the cancel, so a
-        # refused cancellation is not proof that nothing was written. Let the worker
-        # settle, then fall through to the same delete the completed branch performs --
-        # otherwise the clip persists and the "deleted" job reappears through
-        # retrieve/list on the very next call.
+        # The run can reach its terminal state between the lookup and the cancel
         if not await asyncio.to_thread(_await_generate_settled, video_id):
             raise _openai_video_error(
                 409,

--- a/studio/backend/routes/video.py
+++ b/studio/backend/routes/video.py
@@ -771,7 +771,6 @@ async def clear_gallery_videos(current_subject: str = Depends(get_current_subjec
     return {"removed": len(cleared)}
 
 
-
 # ── OpenAI-compatible videos API (/v1/videos) ──
 _VIDEO_SIZE_RE = _re.compile(r"^(\d{1,5})\s*x\s*(\d{1,5})$")
 _VIDEO_SECONDS_MAX = 120.0

--- a/studio/backend/utils/api_errors.py
+++ b/studio/backend/utils/api_errors.py
@@ -190,19 +190,11 @@ def _summarize_validation_errors(errors) -> tuple:
     return summary, param
 
 
-# A validation error carries the offending value under "input". For a JSON-body route
-# handed a non-JSON body (a multipart upload posted to /api/inference/audio/transcribe
-# is the case that surfaced this) that value is the whole raw payload, and
-# jsonable_encoder renders bytes with ``o.decode()``, which raises UnicodeDecodeError on
-# any binary. The handler then failed, turning a 422 into a 500 whose traceback embedded
-# the escaped payload: one 531 KB upload produced a single 2.2 MB log line.
-#
-# Clients only need loc/msg/type, so the input is summarized rather than echoed. That
-# also stops a large but perfectly decodable body from being mirrored back and logged.
+# jsonable_encoder renders the offending "input" with o.decode(), which raises on binary and turned a 422 into a 500
+# whose traceback embedded the payload: one 531 KB upload logged 2.2 MB.
 _MAX_ECHOED_INPUT_CHARS = 200
-# A body that is a huge container of small values is just as unbounded as one huge
-# string: a JSON route handed an array of 200k integers would otherwise have every
-# element copied into the 422 body. Keep enough to identify the payload, drop the rest.
+# A huge container of small values is as unbounded as one huge string (an array of 200k ints
+    # would have every element copied into the 422 body), so keep only enough to identify it.
 _MAX_ECHOED_ITEMS = 20
 _MAX_ECHOED_DEPTH = 4
 
@@ -218,8 +210,8 @@ def _truncate_text(value: str) -> str:
     return value
 
 
-# Digits, not characters: str() on a very large int raises above sys.get_int_max_str_digits(),
-# and json.dumps would emit every digit otherwise.
+# Digits, not characters: str() on a very large int raises above sys.get_int_max_str_digits()
+# json.dumps would emit every digit otherwise.
 _MAX_ECHOED_INT_DIGITS = 100
 _LONE_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
 
@@ -347,8 +339,8 @@ def install_api_error_handlers(app) -> None:
     async def _handle_http_exception(request, exc):
         path = request.url.path
         headers = getattr(exc, "headers", None)
-        # Statuses like 204/304/1xx must not carry a body — mirror FastAPI's
-        # default http_exception_handler, which returns a bodiless Response.
+        # Statuses like 204/304/1xx must not carry a body, mirroring FastAPI's default
+        # http_exception_handler, which returns a bodiless Response.
         if not is_body_allowed_for_status_code(exc.status_code):
             return Response(status_code = exc.status_code, headers = headers)
         if wants_api_error_envelope(path):

--- a/studio/backend/utils/api_errors.py
+++ b/studio/backend/utils/api_errors.py
@@ -194,7 +194,7 @@ def _summarize_validation_errors(errors) -> tuple:
 # whose traceback embedded the payload: one 531 KB upload logged 2.2 MB.
 _MAX_ECHOED_INPUT_CHARS = 200
 # A huge container of small values is as unbounded as one huge string (an array of 200k ints
-    # would have every element copied into the 422 body), so keep only enough to identify it.
+# would have every element copied into the 422 body), so keep only enough to identify it.
 _MAX_ECHOED_ITEMS = 20
 _MAX_ECHOED_DEPTH = 4
 

--- a/studio/backend/utils/audio_tokens.py
+++ b/studio/backend/utils/audio_tokens.py
@@ -50,9 +50,8 @@ def _count_prefix_exceeds(tokens, prefix: str, threshold: int) -> bool:
     return False
 
 
-# ORDER MATTERS: first match wins, so codec fingerprints precede the generic audio_vlm
-# marker. Orpheus carries 28k <custom_token_N> SNAC codes AND a stray <|audio|>, and
-# audio_vlm first typed it as audio-input.
+# ORDER MATTERS: first match wins, so codec fingerprints precede the generic audio_vlm marker. Orpheus carries 28k
+# <custom_token_N> SNAC codes AND a stray <|audio|>, and audio_vlm first typed it as audio-input.
 AUDIO_TOKEN_PATTERNS = {
     "csm": lambda tokens: "<|AUDIO|>" in tokens and "<|audio_eos|>" in tokens,
     "whisper": lambda tokens: "<|startoftranscript|>" in tokens,
@@ -68,19 +67,18 @@ AUDIO_TOKEN_PATTERNS = {
     "audio_vlm": lambda tokens: "<audio_soft_token>" in tokens or "<|audio|>" in tokens,
 }
 
-# Every substring a pattern needs, so text holding none of them is settled without a
-# parse -- json.loads of an ordinary large tokenizer_config was the bulk of a cold /loras
-# scan. The patterns are lambdas, so this cannot be derived from them; a codec added
-# there without its marker here would silently stop being detected, and
-# test_audio_token_detection.py fails when the two drift.
+# Every substring a pattern needs, so text holding none is settled without a parse. The patterns are lambdas, so a codec
+# added there without its marker here silently stops being detected.
+# json.loads of an ordinary large tokenizer_config was the bulk of a cold /loras scan, and test_audio_token_detection.py
+# fails when the two drift.
 AUDIO_TOKEN_MARKERS = (
-    "<|AUDIO|>",  # csm
-    "<|startoftranscript|>",  # whisper
-    "<|bicodec_",  # bicodec
-    "<|audio_start|>",  # dac
-    "<custom_token_",  # snac
-    "<audio_soft_token>",  # audio_vlm (Gemma 3n)
-    "<|audio|>",  # audio_vlm (Gemma 4)
+    "<|AUDIO|>",
+    "<|startoftranscript|>",
+    "<|bicodec_",
+    "<|audio_start|>",
+    "<custom_token_",
+    "<audio_soft_token>",
+    "<|audio|>",
 )
 
 AUDIO_TOKENIZER_CONFIG_PATHS = (

--- a/studio/backend/utils/cache_cleanup.py
+++ b/studio/backend/utils/cache_cleanup.py
@@ -20,10 +20,10 @@ from typing import List, Optional
 
 logger = get_logger(__name__)
 
-# Possible locations where unsloth_compiled_cache may appear
-_BACKEND_DIR = Path(__file__).resolve().parent.parent  # studio/backend
-_PROJECT_ROOT = _BACKEND_DIR.parent.parent  # repo root
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+_PROJECT_ROOT = _BACKEND_DIR.parent.parent
 
+# Possible locations where unsloth_compiled_cache may appear
 _CACHE_DIRS = [
     _BACKEND_DIR / "unsloth_compiled_cache",
     _PROJECT_ROOT / "unsloth_compiled_cache",
@@ -77,9 +77,9 @@ CACHE_MARKER = ".unsloth_compiled_cache"
 import re as _re
 
 _GENERATED_NAME_RE = _re.compile(r"\A(unsloth_compiled_module_.+|Unsloth.+Trainer)\.py\Z")
-# What may be deleted from a directory we do not own. Narrower on purpose:
-# Unsloth*Trainer.py is a convention a user's own subclass can match, and there
-# the marker is the only thing that would say we wrote it.
+# What may be deleted from a directory we do not own.
+# Unsloth*Trainer.py is a convention a user's own subclass can match, and there the marker is the only thing that would
+# say we wrote it.
 _OWNED_DELETE_RE = _re.compile(r"\Aunsloth_compiled_module_.+\.py\Z")
 
 
@@ -178,13 +178,10 @@ def register_compiled_cache_on_path() -> None:
     pypath = os.environ.get("PYTHONPATH", "")
     pypath_entries = [p for p in pypath.split(os.pathsep) if p]
 
-    # Iterate in reverse so earlier _CACHE_DIRS entries (higher priority) are
-    # inserted last and thus end up first in sys.path / PYTHONPATH.
-    # Same ownership test as cleanup: a directory in the launch dir that merely
-    # has the name would otherwise shadow real dependencies for every worker.
-    # A directory in the launch dir needs a file only the compiler writes:
-    # Unsloth*Trainer.py is a name a user's own subclass can carry, and that
-    # directory goes on sys.path. Where we put it is ours anyway.
+    # Iterate in reverse so earlier _CACHE_DIRS entries (higher priority) are inserted last and thus end up first in
+    # sys.path / PYTHONPATH. Same ownership test as cleanup: a directory in the launch dir needs a file only the
+    # compiler writes, since Unsloth*Trainer.py is a name a user's own subclass can carry and that directory goes on
+    # sys.path.
     trusted = _trusted_cache_paths()
     registrable = [
         d
@@ -216,9 +213,8 @@ def cache_coordination_dir() -> Path:
 
 
 # Held: we may probe and clear. Busy: someone else is in that critical section.
-# Unavailable: no lock could be taken at all (unwritable studio home, a
-# filesystem without flock), which must not mean "never clear the cache again",
-# so the caller falls back to the unserialized probe it did before this lock.
+# Unavailable means no lock could be taken at all, which must not mean "never clear the cache again", so the caller
+# falls back to the unserialized probe it used before this lock.
 LOCK_HELD = "held"
 LOCK_BUSY = "busy"
 LOCK_UNAVAILABLE = "unavailable"
@@ -228,10 +224,9 @@ LOCK_UNAVAILABLE = "unavailable"
 _LOCK_TIMEOUT = 10.0
 
 
-# flock/msvcrt report contention through these; anything else (ENOSYS,
-# EOPNOTSUPP on a network mount) is the lock being unsupported, and retrying it
-# for ten seconds only to answer "busy" would pin the cache forever, since busy
-# is read as proof of a sibling.
+# flock/msvcrt report contention through these; anything else is the lock being unsupported, and retrying for ten
+# seconds to answer "busy" pins the cache forever, since busy proves a sibling.
+# Anything else is ENOSYS, or EOPNOTSUPP on a network mount.
 _CONTENTION_ERRNOS = frozenset(
     code
     for code in (
@@ -409,11 +404,9 @@ def clear_unsloth_compiled_cache(preserve_patterns: Optional[List[str]] = None) 
             # a symlink, and ignore_errors would leave the whole cache in place.
             logger.info(f"Removing unsloth compiled cache: {cache_dir}")
             shutil.rmtree(Path(os.path.realpath(cache_dir)), ignore_errors = True)
-        # The marker goes with whatever was cleared and nothing rewrites it
-        # (setup_cache_env writes it only when it first sets the variable), so
-        # the next cleanup would demote our own cache to "shared".
-        # A built-in path needs no marker, so no restoring either, unless it
-        # is a link: the clear removed the target and left it dangling.
+        # The marker goes with whatever was cleared and nothing rewrites it, so the next cleanup would demote our own
+        # cache to "shared". A built-in path needs none unless it is a dangling link.
+        # setup_cache_env writes the marker only when it first sets the variable.
         if dedicated and (str(cache_dir) not in _builtin_cache_paths() or cache_dir.is_symlink()):
             try:
                 restored = Path(os.path.realpath(cache_dir))

--- a/studio/backend/utils/child_stdio.py
+++ b/studio/backend/utils/child_stdio.py
@@ -20,10 +20,8 @@ def utf8_child_env(env: Optional[Mapping[str, str]] = None) -> dict[str, str]:
     child = dict(os.environ if env is None else env)
     child["PYTHONIOENCODING"] = "utf-8"
     if env is None and child.get("UNSLOTH_ZOO_DISABLE_GPU_INIT") == "1":
-        # The Xet shim sets this process-wide for one optional import; a child spawned in that
-        # window inherits it for life, and unsloth_zoo injects triton and bitsandbytes STUBS when it
-        # is set, so a training child would run against no-ops. Only the loader's own transient
-        # value is dropped, so an operator who set it deliberately is unaffected.
+        # The Xet shim sets this process-wide for one optional import, and a child spawned in that window inherits it
+        # for life, running against unsloth_zoo's triton/bitsandbytes STUBS.
         try:
             from utils.hf_xet_fallback import gpu_init_override_active
             if gpu_init_override_active():

--- a/studio/backend/utils/client_ip.py
+++ b/studio/backend/utils/client_ip.py
@@ -42,9 +42,9 @@ def _normalize_addr(value: str | None) -> str | None:
     raw = (value or "").strip().strip('"')
     if not raw:
         return None
-    if raw.startswith("["):  # [ipv6]:port
+    if raw.startswith("["):
         raw = raw[1:].split("]", 1)[0]
-    elif raw.count(":") == 1:  # ipv4:port
+    elif raw.count(":") == 1:
         raw = raw.split(":", 1)[0]
     try:
         return ipaddress.ip_address(raw).compressed

--- a/studio/backend/utils/coding_agents.py
+++ b/studio/backend/utils/coding_agents.py
@@ -12,18 +12,15 @@ default to one the user can run immediately.
 
 import shutil
 
-# Keep in sync with the `unsloth start <agent>` subcommands defined in
-# unsloth_cli/commands/start.py. Each entry is the exact executable name that
-# subcommand launches, so a hit here means `unsloth start <agent>` can find the
-# binary on PATH without the user installing anything first.
+# Keep in sync with the `unsloth start <agent>` subcommands defined in unsloth_cli/commands/start.py. Each entry is the
+# exact executable name that subcommand launches, so a hit here means the binary is on PATH without the user installing
+# anything first.
 CODING_AGENTS: tuple[str, ...] = ("claude", "codex", "openclaw", "opencode", "hermes", "pi")
 
 
 def _is_on_path(agent: str) -> bool:
-    # shutil.which is documented to return None on a miss, but PATH lookups can
-    # still raise (e.g. a permission error while probing a directory entry);
-    # this is an advisory check, so a lookup failure should read as "not
-    # installed" instead of breaking the settings endpoint.
+    # shutil.which returns None on a miss but PATH lookups can still raise, and this is advisory, so a lookup failure
+    # reads as "not installed" rather than breaking the endpoint.
     try:
         return shutil.which(agent) is not None
     except OSError:

--- a/studio/backend/utils/datasets/audio_decode.py
+++ b/studio/backend/utils/datasets/audio_decode.py
@@ -22,11 +22,7 @@ logger = get_logger(__name__)
 
 _installed = False
 _ORIGINAL_ENCODE = None
-# The read-and-patch below must happen once. Two first-time callers (two dataset
-# format checks land on the threadpool together) can both pass the _installed
-# check, and the second then captures the already-installed shim as
-# _ORIGINAL_ENCODE, so its fallback branch recurses into itself until
-# RecursionError.
+# The read-and-patch below must happen once.
 _install_lock = threading.Lock()
 
 
@@ -161,9 +157,9 @@ def ensure_audio_decoding() -> bool:
         return True
     if config.TORCHCODEC_AVAILABLE and not _installed:
         try:
-            # config only ran find_spec, and an installed torchcodec whose native libraries
-            # cannot dlopen still passes that. The API process never imports unsloth, so
-            # disable_torchcodec_if_broken has not corrected the flag here.
+            # config only ran find_spec, and an installed torchcodec whose native libraries cannot dlopen still passes
+            # that. The API process never imports unsloth, so disable_torchcodec_if_broken has not corrected the flag
+            # here.
             from datasets.features._torchcodec import AudioDecoder  # noqa: F401
         except (ImportError, OSError, RuntimeError) as exc:
             logger.info("torchcodec is installed but unusable (%s)", exc)

--- a/studio/backend/utils/datasets/cache_safe.py
+++ b/studio/backend/utils/datasets/cache_safe.py
@@ -60,7 +60,7 @@ def _disable_hf_symlinks_for_process() -> None:
     # added this constant; older installs decide purely from the mapping below.
     try:
         from huggingface_hub import constants, file_download
-    except ImportError:  # never mask the load error we are recovering from
+    except ImportError:  # never mask the load error we are recovering
         return
 
     if hasattr(constants, "HF_HUB_DISABLE_SYMLINKS"):
@@ -83,9 +83,7 @@ def load_dataset_cache_safe(*args, **kwargs):
     """Load a dataset with narrow retries for known cache permission failures."""
     from datasets import load_dataset
 
-    # datasets is in sys.modules exactly now, which is what lets its bar class be
-    # patched; the server never imports it at boot, so this shared entry point is
-    # where its "Generating train split" bar stops reaching the structured log.
+    # datasets is in sys.modules exactly now.
     from loggers.config import quiet_third_party_progress_bars
 
     quiet_third_party_progress_bars()

--- a/studio/backend/utils/datasets/completion_masking.py
+++ b/studio/backend/utils/datasets/completion_masking.py
@@ -109,11 +109,8 @@ def apply_completion_masking(
 
     template, instruction_part, response_part = lookup_manual_markers(model_name)
 
-    # gpt-oss goes auto-first: quantized/BF16 checkpoints ship a channel-less
-    # template, so the manual markers match nothing (zero tokens trained). Auto
-    # derives markers from whichever template ships, and per the harmony format
-    # only the final terminator carries stop supervision. Renamed checkpoints
-    # miss the exact-name table, so give the fallback the gpt-oss markers.
+    # gpt-oss goes auto-first: quantized/BF16 checkpoints ship a channel-less template, so the manual markers match
+    # nothing and zero tokens are trained.
     if is_gpt_oss_model_name(model_name) and not (instruction_part and response_part):
         markers = TEMPLATE_TO_RESPONSES_MAPPER.get("gpt-oss")
         if markers:

--- a/studio/backend/utils/datasets/data_collators.py
+++ b/studio/backend/utils/datasets/data_collators.py
@@ -46,7 +46,7 @@ class DeepSeekOCRDataCollator:
     instruction fine-tuning.
     """
 
-    processor: Any  # Qwen2VLProcessor or similar
+    processor: Any
     max_length: int = 2048
     ignore_index: int = -100
 
@@ -76,7 +76,7 @@ class DeepSeekOCRDataCollator:
                     for item in content:
                         if isinstance(item, dict) and item.get("type") == "image":
                             img = item.get("image")
-                            if img is not None and hasattr(img, "size"):  # PIL Image
+                            if img is not None and hasattr(img, "size"):
                                 all_images.append(img)
 
         try:
@@ -115,7 +115,7 @@ class VLMDataCollator:
     processor: Any
     max_length: int = 2048
     ignore_index: int = -100
-    mask_input_tokens: bool = True  # Mask user tokens in labels
+    mask_input_tokens: bool = True
 
     def __call__(self, batch: List[dict]) -> dict:
         """Collate a batch of VLM samples."""

--- a/studio/backend/utils/datasets/dataset_none_detect.py
+++ b/studio/backend/utils/datasets/dataset_none_detect.py
@@ -22,10 +22,8 @@ add a FORMAT_REGISTRY entry only for a genuinely new column/turn shape.
 
 from datasets import Dataset
 
-# ---------------------------------------------------------------------------
-# Conversation column probing (shared by detection + scanning)
-# ---------------------------------------------------------------------------
 
+# Conversation column probing (shared by detection + scanning)
 # Candidate column names for conversational datasets, checked in priority order.
 CONVERSATION_COLUMNS = ("messages", "conversations", "texts")
 
@@ -50,8 +48,7 @@ def _probe_conversation(dataset: Dataset, candidates = None):
     if candidates is None:
         candidates = CONVERSATION_COLUMNS
     columns = set(dataset.column_names)
-    # Remember the first all-corrupt candidate, but keep probing: a later column
-    # may be healthy and win (e.g. bad messages, good conversations).
+    # Remember the first all-corrupt candidate.
     all_corrupt_fallback = None
     for col in candidates:
         if col not in columns:
@@ -108,11 +105,9 @@ def _probe_conversation(dataset: Dataset, candidates = None):
                         r = t.get("role") or t.get("from")
                         if r:
                             roles.add(str(r))
-        # Column lacks a full chat key pair. If it has a conversational key
-        # (role/from/content/value) it is a corrupt-but-real chat column, so
-        # save a plausible fallback for find_none_chatml to flag. Pure metadata
-        # (e.g. [{"id":1}]) is not plausible, so a later real-but-corrupt column
-        # (e.g. conversations=None) can still win.
+        # Column lacks a full chat key pair. If it has a conversational key (role/from/content/value) it is a corrupt-
+        # but-real chat column, so save a plausible fallback for find_none_chatml to flag. Pure metadata is not
+        # plausible, so a later real-but-corrupt column can still win.
         _CONV_KEYS = {"role", "from", "content", "value"}
         if not any(keys <= turn_keys for keys in _CHAT_KEY_SETS):
             schema_less_plausible = bool(turn_keys & _CONV_KEYS)
@@ -130,10 +125,9 @@ def _probe_conversation(dataset: Dataset, candidates = None):
     return all_corrupt_fallback
 
 
+
+
 # None-detection helpers
-# ---------------------------------------------------------------------------
-
-
 def is_none_or_empty(value) -> bool:
     """True if value is None, empty string, whitespace-only, or an empty/whitespace-only VLM content block list."""
     if value is None:
@@ -146,10 +140,9 @@ def is_none_or_empty(value) -> bool:
         if not stripped:
             return True
     if isinstance(value, list):
-        # VLM content blocks, e.g. [{"type":"text",...}, {"type":"image",...}].
-        # Empty list -> empty. A non-text block (image/audio/tool) is real
-        # content; only flag when every text block is blank and no such block
-        # exists (an image-only turn is valid).
+        # A non-text block (image/audio/tool) is real content, so flag only when every text block is blank and no such
+        # block exists: an image-only turn is valid.
+        # VLM content blocks, e.g. [{"type":"text",...}, {"type":"image",...}]; an empty list is empty.
         if len(value) == 0:
             return True
         # No dict blocks (e.g. [None], ['  ']) -> malformed/empty.
@@ -189,11 +182,9 @@ def _classify_empty(value) -> str:
     return "valid"  # unreachable if is_none_or_empty was True
 
 
-# ---------------------------------------------------------------------------
+
+
 # Alpaca detection
-# ---------------------------------------------------------------------------
-
-
 def find_none_alpaca(dataset: Dataset) -> dict:
     """
     Scan alpaca dataset for None/empty instruction or output fields.
@@ -204,7 +195,7 @@ def find_none_alpaca(dataset: Dataset) -> dict:
         "none_instruction": 0,
         "none_output": 0,
         "bad_row_indices": [],
-        "findings": [],  # [{row, field, value_type, raw_value}, ...]
+        "findings": [],
     }
 
     for i, row in enumerate(dataset):
@@ -228,11 +219,9 @@ def find_none_alpaca(dataset: Dataset) -> dict:
     return stats
 
 
-# ---------------------------------------------------------------------------
+
+
 # ChatML / conversational detection
-# ---------------------------------------------------------------------------
-
-
 def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
     """
     Scan chatml/sharegpt/gptoss dataset for turns with None/empty content.
@@ -258,11 +247,11 @@ def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
         "column": col,
         "rows_with_none_turns": 0,
         "total_none_turns": 0,
-        "none_by_role": {},  # role -> count of None turns
-        "none_by_type": {},  # "None" | "empty_string" | "whitespace_only" -> count
-        "rows_all_none": 0,  # rows where every turn is bad
-        "bad_row_indices": [],  # every row index that has at least one bad turn
-        "findings": [],  # detailed per-turn list
+        "none_by_role": {},
+        "none_by_type": {},
+        "rows_all_none": 0,
+        "bad_row_indices": [],
+        "findings": [],
     }
 
     for i, row in enumerate(dataset):
@@ -375,16 +364,14 @@ def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
     return stats
 
 
-# ---------------------------------------------------------------------------
+
+
 # Convenience wrappers per format (all delegate to the same scan logic)
-# ---------------------------------------------------------------------------
-
-
 def find_none_sharegpt(dataset: Dataset, col: str = None) -> dict:
     """ShareGPT uses 'from'/'value' keys - same scan logic handles both."""
     if col is None:
-        # ShareGPT lives in 'conversations'; probe only that column so a corrupt
-        # one is still scanned, not replaced by healthy 'messages' (P1 fix).
+        # ShareGPT lives in 'conversations': probe only that column so a corrupt one is still scanned,
+        # not replaced by a healthy 'messages'.
         conv_info = _probe_conversation(dataset, candidates = ("conversations",))
         if conv_info is None:
             raise ValueError(
@@ -398,8 +385,7 @@ def find_none_sharegpt(dataset: Dataset, col: str = None) -> dict:
 def find_none_gptoss(dataset: Dataset, col: str = None) -> dict:
     """gptoss: role/content plus optional thinking/tool_calls. Only content checked."""
     if col is None:
-        # gptoss lives in 'messages': target it whenever present (even if
-        # corrupt); fall back to 'conversations' only if 'messages' is absent.
+        # gptoss lives in 'messages': target it whenever present
         if "messages" in dataset.column_names:
             conv_info = _probe_conversation(dataset, candidates = ("messages",))
         else:
@@ -413,22 +399,16 @@ def find_none_gptoss(dataset: Dataset, col: str = None) -> dict:
     return find_none_chatml(dataset, col = col)
 
 
-# ---------------------------------------------------------------------------
-# Format registry - first match wins; detect_format() auto-scales.
-# Each entry: name (label/--format value), match(dataset, conv_info) -> bool,
-# scan (find_none_* function). Put specific formats before general ones
-# (gptoss before chatml, since gptoss is chatml with a 'developer' role).
-# To add a format: write find_none_<name>() (or reuse find_none_chatml) and
-# append an entry; detect_format(), --format, and scan_dataset() pick it up.
-# ---------------------------------------------------------------------------
 
+# Format registry, first match wins: put specific formats before general ones (gptoss before chatml, since gptoss is
+# chatml with a 'developer' role).
+# Each entry is name, match(dataset, conv_info) -> bool, scan (find_none_* function); to add one write
+# find_none_<name>() or reuse find_none_chatml, and detect_format(), --format and scan_dataset() pick it up.
 FORMAT_REGISTRY = [
     {
         "name": "alpaca",
-        # instruction/output present and no usable chat column: either none
-        # exists, or the only one is fully corrupt (e.g. a stray all-None or
-        # metadata `messages` column). A healthy chat column falls through to
-        # the conversational scanners below.
+        # instruction/output present and no usable chat column, meaning none exists or the only one is
+        # fully corrupt; a healthy chat column falls through to the conversational scanners below.
         "match": lambda ds, conv: (
             {"instruction", "output"}.issubset(ds.column_names)
             and (conv is None or conv.get("all_corrupt"))
@@ -500,10 +480,9 @@ def scan_dataset(dataset: Dataset, fmt: str = "auto") -> dict:
     Returns the stats dict with an added 'format' key.
     Raises ValueError if the format is unknown or unsupported.
     """
-    # Reject a DatasetDict / IterableDatasetDict (load_dataset without split):
-    # its column_names is a split map and would yield a confusing "unknown
-    # format". Check both (IterableDatasetDict is not a DatasetDict subclass);
-    # import locally so this module never hard-requires them.
+    # Reject a DatasetDict / IterableDatasetDict (load_dataset without split)
+    # Its column_names is a split map and would yield a confusing "unknown format". Check both, since
+    # IterableDatasetDict is not a DatasetDict subclass, and import locally so this module never hard-requires them.
     _dict_types = []
     try:
         from datasets import DatasetDict as _DatasetDict
@@ -563,10 +542,7 @@ def scan_dataset(dataset: Dataset, fmt: str = "auto") -> dict:
     scanner = get_scanner(fmt)
     if scanner is None:
         raise ValueError(f"Unknown or unsupported format: '{fmt}'")
-    # Column forwarding: on auto-detect pass the probed column (the best
-    # choice). On an explicit format let that scanner pick its own column, so
-    # e.g. fmt='sharegpt' always scans 'conversations', not 'messages' (P1 fix);
-    # gptoss has its own messages-first rule. alpaca never takes a column.
+    # Column forwarding: on auto-detect pass the probed column
     use_probed_col = conv_info is not None and fmt != "alpaca" and was_auto
     if use_probed_col:
         stats = scanner(dataset, col = conv_info["column"])
@@ -576,11 +552,9 @@ def scan_dataset(dataset: Dataset, fmt: str = "auto") -> dict:
     return stats
 
 
-# ---------------------------------------------------------------------------
+
+
 # Report printing
-# ---------------------------------------------------------------------------
-
-
 def _print_summary_header(stats: dict, fmt: str) -> bool:
     """Print the top-level stats block (shared by all report modes). Returns True if findings exist."""
     total = stats["total_rows"]
@@ -739,7 +713,6 @@ def show_row(
                 print(f"  {col}: {len(conversation)} turns ({none_count} None)")
                 print(f"  {'-' * 60}")
                 for i, turn in enumerate(conversation):
-                    # Non-dict turn - can't extract role/content normally.
                     if not isinstance(turn, dict):
                         label = "None" if turn is None else "invalid_type"
                         print(f"  [{i:>3d}] {'unknown':<12s} [{label}]  << NONE")
@@ -766,7 +739,7 @@ def show_row(
                     if content is None:
                         preview = "None"
                     else:
-                        preview_str = str(content)  # cast: content may not be a string
+                        preview_str = str(content)
                         if len(preview_str) > 150:
                             preview = preview_str[:150].replace("\n", "\\n") + "..."
                         else:
@@ -776,10 +749,8 @@ def show_row(
         print(f"{'=' * 64}")
 
 
-# ---------------------------------------------------------------------------
-# CLI entry point
-# ---------------------------------------------------------------------------
 
+# CLI entry point
 if __name__ == "__main__":
     import argparse
     import os

--- a/studio/backend/utils/datasets/dataset_none_detect.py
+++ b/studio/backend/utils/datasets/dataset_none_detect.py
@@ -126,8 +126,6 @@ def _probe_conversation(dataset: Dataset, candidates = None):
     return all_corrupt_fallback
 
 
-
-
 # None-detection helpers
 # ---------------------------------------------------------------------------
 def is_none_or_empty(value) -> bool:
@@ -184,8 +182,6 @@ def _classify_empty(value) -> str:
     return "valid"  # unreachable if is_none_or_empty was True
 
 
-
-
 # Alpaca detection
 # ---------------------------------------------------------------------------
 def find_none_alpaca(dataset: Dataset) -> dict:
@@ -220,8 +216,6 @@ def find_none_alpaca(dataset: Dataset) -> dict:
             stats["bad_row_indices"].append(i)
 
     return stats
-
-
 
 
 # ChatML / conversational detection
@@ -368,8 +362,6 @@ def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
     return stats
 
 
-
-
 # Convenience wrappers per format (all delegate to the same scan logic)
 # ---------------------------------------------------------------------------
 def find_none_sharegpt(dataset: Dataset, col: str = None) -> dict:
@@ -402,7 +394,6 @@ def find_none_gptoss(dataset: Dataset, col: str = None) -> dict:
             )
         col = conv_info["column"]
     return find_none_chatml(dataset, col = col)
-
 
 
 # Format registry, first match wins: put specific formats before general ones (gptoss before chatml, since gptoss is
@@ -556,8 +547,6 @@ def scan_dataset(dataset: Dataset, fmt: str = "auto") -> dict:
         stats = scanner(dataset)
     stats["format"] = fmt
     return stats
-
-
 
 
 # Report printing
@@ -754,7 +743,6 @@ def show_row(
                     print(f"  [{i:>3d}] {role:<12s} {preview}{status}")
 
         print(f"{'=' * 64}")
-
 
 
 # CLI entry point

--- a/studio/backend/utils/datasets/dataset_none_detect.py
+++ b/studio/backend/utils/datasets/dataset_none_detect.py
@@ -25,6 +25,7 @@ from datasets import Dataset
 
 # Conversation column probing (shared by detection + scanning)
 # Candidate column names for conversational datasets, checked in priority order.
+# ---------------------------------------------------------------------------
 CONVERSATION_COLUMNS = ("messages", "conversations", "texts")
 
 # Minimum turn key sets identifying a column as conversational (not e.g. messages=[{"id":1}]).
@@ -128,6 +129,7 @@ def _probe_conversation(dataset: Dataset, candidates = None):
 
 
 # None-detection helpers
+# ---------------------------------------------------------------------------
 def is_none_or_empty(value) -> bool:
     """True if value is None, empty string, whitespace-only, or an empty/whitespace-only VLM content block list."""
     if value is None:
@@ -185,6 +187,7 @@ def _classify_empty(value) -> str:
 
 
 # Alpaca detection
+# ---------------------------------------------------------------------------
 def find_none_alpaca(dataset: Dataset) -> dict:
     """
     Scan alpaca dataset for None/empty instruction or output fields.
@@ -222,6 +225,7 @@ def find_none_alpaca(dataset: Dataset) -> dict:
 
 
 # ChatML / conversational detection
+# ---------------------------------------------------------------------------
 def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
     """
     Scan chatml/sharegpt/gptoss dataset for turns with None/empty content.
@@ -367,6 +371,7 @@ def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
 
 
 # Convenience wrappers per format (all delegate to the same scan logic)
+# ---------------------------------------------------------------------------
 def find_none_sharegpt(dataset: Dataset, col: str = None) -> dict:
     """ShareGPT uses 'from'/'value' keys - same scan logic handles both."""
     if col is None:
@@ -404,6 +409,7 @@ def find_none_gptoss(dataset: Dataset, col: str = None) -> dict:
 # chatml with a 'developer' role).
 # Each entry is name, match(dataset, conv_info) -> bool, scan (find_none_* function); to add one write
 # find_none_<name>() or reuse find_none_chatml, and detect_format(), --format and scan_dataset() pick it up.
+# ---------------------------------------------------------------------------
 FORMAT_REGISTRY = [
     {
         "name": "alpaca",
@@ -555,6 +561,7 @@ def scan_dataset(dataset: Dataset, fmt: str = "auto") -> dict:
 
 
 # Report printing
+# ---------------------------------------------------------------------------
 def _print_summary_header(stats: dict, fmt: str) -> bool:
     """Print the top-level stats block (shared by all report modes). Returns True if findings exist."""
     total = stats["total_rows"]
@@ -751,6 +758,7 @@ def show_row(
 
 
 # CLI entry point
+# ---------------------------------------------------------------------------
 if __name__ == "__main__":
     import argparse
     import os

--- a/studio/backend/utils/datasets/dataset_none_detect.py
+++ b/studio/backend/utils/datasets/dataset_none_detect.py
@@ -130,6 +130,7 @@ def _probe_conversation(dataset: Dataset, candidates = None):
 # None-detection helpers
 # ---------------------------------------------------------------------------
 
+
 def is_none_or_empty(value) -> bool:
     """True if value is None, empty string, whitespace-only, or an empty/whitespace-only VLM content block list."""
     if value is None:
@@ -187,6 +188,7 @@ def _classify_empty(value) -> str:
 # Alpaca detection
 # ---------------------------------------------------------------------------
 
+
 def find_none_alpaca(dataset: Dataset) -> dict:
     """
     Scan alpaca dataset for None/empty instruction or output fields.
@@ -223,6 +225,7 @@ def find_none_alpaca(dataset: Dataset) -> dict:
 
 # ChatML / conversational detection
 # ---------------------------------------------------------------------------
+
 
 def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
     """
@@ -368,6 +371,7 @@ def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
 
 # Convenience wrappers per format (all delegate to the same scan logic)
 # ---------------------------------------------------------------------------
+
 
 def find_none_sharegpt(dataset: Dataset, col: str = None) -> dict:
     """ShareGPT uses 'from'/'value' keys - same scan logic handles both."""
@@ -557,6 +561,7 @@ def scan_dataset(dataset: Dataset, fmt: str = "auto") -> dict:
 
 # Report printing
 # ---------------------------------------------------------------------------
+
 
 def _print_summary_header(stats: dict, fmt: str) -> bool:
     """Print the top-level stats block (shared by all report modes). Returns True if findings exist."""

--- a/studio/backend/utils/datasets/dataset_none_detect.py
+++ b/studio/backend/utils/datasets/dataset_none_detect.py
@@ -26,6 +26,7 @@ from datasets import Dataset
 # Conversation column probing (shared by detection + scanning)
 # Candidate column names for conversational datasets, checked in priority order.
 # ---------------------------------------------------------------------------
+
 CONVERSATION_COLUMNS = ("messages", "conversations", "texts")
 
 # Minimum turn key sets identifying a column as conversational (not e.g. messages=[{"id":1}]).
@@ -128,6 +129,7 @@ def _probe_conversation(dataset: Dataset, candidates = None):
 
 # None-detection helpers
 # ---------------------------------------------------------------------------
+
 def is_none_or_empty(value) -> bool:
     """True if value is None, empty string, whitespace-only, or an empty/whitespace-only VLM content block list."""
     if value is None:
@@ -184,6 +186,7 @@ def _classify_empty(value) -> str:
 
 # Alpaca detection
 # ---------------------------------------------------------------------------
+
 def find_none_alpaca(dataset: Dataset) -> dict:
     """
     Scan alpaca dataset for None/empty instruction or output fields.
@@ -220,6 +223,7 @@ def find_none_alpaca(dataset: Dataset) -> dict:
 
 # ChatML / conversational detection
 # ---------------------------------------------------------------------------
+
 def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
     """
     Scan chatml/sharegpt/gptoss dataset for turns with None/empty content.
@@ -364,6 +368,7 @@ def find_none_chatml(dataset: Dataset, col: str = None) -> dict:
 
 # Convenience wrappers per format (all delegate to the same scan logic)
 # ---------------------------------------------------------------------------
+
 def find_none_sharegpt(dataset: Dataset, col: str = None) -> dict:
     """ShareGPT uses 'from'/'value' keys - same scan logic handles both."""
     if col is None:
@@ -401,6 +406,7 @@ def find_none_gptoss(dataset: Dataset, col: str = None) -> dict:
 # Each entry is name, match(dataset, conv_info) -> bool, scan (find_none_* function); to add one write
 # find_none_<name>() or reuse find_none_chatml, and detect_format(), --format and scan_dataset() pick it up.
 # ---------------------------------------------------------------------------
+
 FORMAT_REGISTRY = [
     {
         "name": "alpaca",
@@ -551,6 +557,7 @@ def scan_dataset(dataset: Dataset, fmt: str = "auto") -> dict:
 
 # Report printing
 # ---------------------------------------------------------------------------
+
 def _print_summary_header(stats: dict, fmt: str) -> bool:
     """Print the top-level stats block (shared by all report modes). Returns True if findings exist."""
     total = stats["total_rows"]
@@ -747,6 +754,7 @@ def show_row(
 
 # CLI entry point
 # ---------------------------------------------------------------------------
+
 if __name__ == "__main__":
     import argparse
     import os

--- a/studio/backend/utils/datasets/dataset_utils.py
+++ b/studio/backend/utils/datasets/dataset_utils.py
@@ -173,7 +173,6 @@ def check_dataset_format(dataset, is_vlm: bool = False) -> dict:
                 **audio_fields,
             }
 
-    # Known format detected
     return {
         "requires_manual_mapping": False,
         "detected_format": detected["format"],
@@ -664,7 +663,6 @@ def format_dataset(
                 except Exception as e:
                     warnings.append(f"Could not standardize: {e}. Passing dataset as-is.")
 
-            # Return as-is with warnings
             return {
                 "dataset": dataset,
                 "detected_format": "unknown",
@@ -869,8 +867,8 @@ def format_and_template_dataset(
     tokenizer,
     is_vlm = False,
     format_type = "auto",
+    vlm_instruction = None,
     # VLM-specific parameters
-    vlm_instruction = None,  # Now optional - will auto-generate
     vlm_text_column = None,
     vlm_image_column = None,
     dataset_name = None,
@@ -986,7 +984,7 @@ def format_and_template_dataset(
                         f"falling back to auto-detection"
                     )
                     logger.info(f"⚠️ User VLM mapping failed, falling back to auto-detection...")
-                    custom_format_mapping = None  # so auto-detection runs below
+                    custom_format_mapping = None
             else:
                 errors.append(
                     f"Invalid VLM mapping: need 'image' and 'text' roles. Got: {custom_format_mapping}"
@@ -1133,7 +1131,6 @@ def format_and_template_dataset(
             dataset = [sample for sample in dataset]
             warnings.append("Dataset already in standard VLM messages format")
 
-        # Return as list
         return {
             "dataset": dataset,
             "detected_format": vlm_structure["format"],
@@ -1234,7 +1231,7 @@ def format_and_template_dataset(
             "detected_format": dataset_info["detected_format"],
             "final_format": final_format,
             "chat_column": dataset_info.get("chat_column"),
-            "is_vlm": False,  # LLM flow
+            "is_vlm": False,
             "success": template_result["success"],
             "requires_manual_mapping": requires_manual,
             "warnings": all_warnings,

--- a/studio/backend/utils/datasets/dataset_utils.py
+++ b/studio/backend/utils/datasets/dataset_utils.py
@@ -121,7 +121,7 @@ def check_dataset_format(dataset, is_vlm: bool = False) -> dict:
         }
 
     if is_audio:
-        # Audio dataset — require manual mapping only when columns aren't auto-detected
+        # Audio dataset - require manual mapping only when columns aren't auto-detected
         detected_audio = multimodal_info.get("detected_audio_column")
         detected_text = multimodal_info.get("detected_text_column")
         needs_mapping = not detected_audio or not detected_text
@@ -156,7 +156,7 @@ def check_dataset_format(dataset, is_vlm: bool = False) -> dict:
                 **audio_fields,
             }
         else:
-            # Heuristic failed — user must map manually (or use AI Assist)
+            # Heuristic failed - user must map manually (or use AI Assist)
             return {
                 "requires_manual_mapping": True,
                 "detected_format": "unknown",

--- a/studio/backend/utils/datasets/format_conversion.py
+++ b/studio/backend/utils/datasets/format_conversion.py
@@ -69,7 +69,7 @@ def standardize_chat_format(
     elif "texts" in column_names:
         chat_column = "texts"
     else:
-        return dataset  # No chat column found
+        return dataset
 
     def _iter_probe_rows():
         try:
@@ -92,7 +92,7 @@ def standardize_chat_format(
                 continue
             for key, value in message.items():
                 if type(value) is not str:
-                    continue  # Skip non-strings
+                    continue
                 uniques[key].append(value)
 
     if "from" in uniques and "value" in uniques:
@@ -234,10 +234,10 @@ def convert_chatml_to_alpaca(
                 # First assistant message -> output
                 elif role in ["assistant", "gpt", "output"] and not output:
                     output = content
-                    break  # Stop after first assistant response
+                    break
 
             instructions.append(instruction)
-            inputs.append("")  # Alpaca input usually empty
+            inputs.append("")
             outputs.append(output)
 
         return {"instruction": instructions, "input": inputs, "output": outputs}
@@ -448,7 +448,7 @@ def convert_to_vlm_format(
                 "role": "user",
                 "content": [
                     {"type": "text", "text": current_instruction},
-                    {"type": "image", "image": image_data},  # PIL object
+                    {"type": "image", "image": image_data},
                 ],
             },
             {"role": "assistant", "content": [{"type": "text", "text": text_data}]},
@@ -787,7 +787,7 @@ def convert_sharegpt_with_images_to_vlm_format(
     def _resolve_image(image_data):
         """Resolve image data to a PIL Image."""
         if hasattr(image_data, "size") and hasattr(image_data, "mode"):
-            return image_data  # Already PIL
+            return image_data
         if isinstance(image_data, str):
             if image_data.startswith(("http://", "https://")):
                 import fsspec

--- a/studio/backend/utils/datasets/format_detection.py
+++ b/studio/backend/utils/datasets/format_detection.py
@@ -810,15 +810,15 @@ def detect_vlm_dataset_structure(dataset):
         """Probe whether an image candidate is reachable (True unless definitely broken)."""
         import os
 
-        # PIL / dict — already loaded.
+        # PIL / dict - already loaded.
         if not isinstance(sample_value, str):
             return True
 
-        # Local file — check it exists.
+        # Local file - check it exists.
         if not sample_value.startswith(("http://", "https://")):
             return os.path.exists(sample_value)
 
-        # URL — quick HEAD with short timeout.
+        # URL - quick HEAD with short timeout.
         try:
             import urllib.request
 
@@ -857,17 +857,17 @@ def detect_vlm_dataset_structure(dataset):
 
         candidates.sort(key = lambda x: x[1], reverse = True)
 
-        # Single candidate or top is PIL/dict — no probing needed.
+        # Single candidate or top is PIL/dict - no probing needed.
         if len(candidates) == 1 or candidates[0][1] >= 75:
             return candidates[0][0]
 
-        # Multiple string candidates — probe for one that works.
+        # Multiple string candidates - probe for one that works.
         for col, score in candidates:
             sample_value = sample[col]
             if _probe_image_candidate(col, sample_value):
                 return col
 
-        # None probed OK — return highest-scored; conversion may still resolve it.
+        # None probed OK - return highest-scored; conversion may still resolve it.
         return candidates[0][0]
 
     def find_text_column():
@@ -890,7 +890,7 @@ def detect_vlm_dataset_structure(dataset):
                     and len(sample_value) > 0
                     and isinstance(sample_value[0], str)
                 ):
-                    # List of strings (e.g. captions) — lower priority than plain str.
+                    # List of strings (e.g. captions) - lower priority than plain str.
                     priority = min(len(sample_value[0]), 1000) // 2
                     candidates.append((col, priority))
 

--- a/studio/backend/utils/datasets/format_detection.py
+++ b/studio/backend/utils/datasets/format_detection.py
@@ -213,7 +213,7 @@ def detect_custom_format_heuristic(dataset):
         "problem",
         "exercise",
     ]
-    user_words_low_priority = ["task"]  # Ambiguous - can be user OR system
+    user_words_low_priority = ["task"]
     user_words = user_words_high_priority + user_words_low_priority
 
     system_words = [
@@ -223,7 +223,7 @@ def detect_custom_format_heuristic(dataset):
         "persona",
         "role",
         "template",
-        "task",  # also a system keyword
+        "task",
     ]
 
     # Metadata columns to ignore.
@@ -557,7 +557,7 @@ def _is_image_value(value) -> bool:
     # Exclude audio dicts (decoded audio has "array" + "sampling_rate").
     if isinstance(value, dict):
         if "array" in value and "sampling_rate" in value:
-            return False  # audio, not image
+            return False
         if "bytes" in value and "path" in value:
             # Use path extension to exclude audio files.
             path = value.get("path") or ""
@@ -620,15 +620,15 @@ def _has_image_header(data: bytes) -> bool:
     """Quick magic-byte check for common image formats."""
     if len(data) < 4:
         return False
-    if data[:2] == b"\xff\xd8":  # JPEG
+    if data[:2] == b"\xff\xd8":
         return True
-    if data[:4] == b"\x89PNG":  # PNG
+    if data[:4] == b"\x89PNG":
         return True
-    if data[:3] == b"GIF":  # GIF
+    if data[:3] == b"GIF":
         return True
-    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":  # WebP
+    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
         return True
-    if data[:2] == b"BM":  # BMP
+    if data[:2] == b"BM":
         return True
     return False
 
@@ -798,9 +798,9 @@ def detect_vlm_dataset_structure(dataset):
             return 75
 
         if isinstance(sample_value, str):
-            if sample_value.startswith(("http://", "https://")):  # URL
+            if sample_value.startswith(("http://", "https://")):
                 return 70 if not is_metadata_column(col) else 55
-            if is_metadata_column(col):  # bare file path
+            if is_metadata_column(col):
                 return 30
             return 50
 
@@ -816,7 +816,7 @@ def detect_vlm_dataset_structure(dataset):
 
         # Local file — check it exists.
         if not sample_value.startswith(("http://", "https://")):
-            return os.path.exists(sample_value)  # bare filenames return False, that's OK
+            return os.path.exists(sample_value)
 
         # URL — quick HEAD with short timeout.
         try:

--- a/studio/backend/utils/datasets/llm_assist.py
+++ b/studio/backend/utils/datasets/llm_assist.py
@@ -140,11 +140,11 @@ def _run_with_helper(prompt: str, max_tokens: int = 256) -> Optional[str]:
             top_k = 20,
             max_tokens = max_tokens,
             repetition_penalty = 1.0,
-            enable_thinking = False,  # Always disable thinking for AI Assist
+            enable_thinking = False,
         ):
             if isinstance(chunk, dict):
-                continue  # skip metadata events
-            cumulative = chunk  # last value is full text
+                continue
+            cumulative = chunk
 
         result = cumulative.strip()
         result = _strip_think_tags(result)
@@ -164,9 +164,9 @@ def _run_with_helper(prompt: str, max_tokens: int = 256) -> Optional[str]:
                 pass
 
 
+
+
 # ─── Public API ───────────────────────────────────────────────────────
-
-
 def llm_generate_vlm_instruction(
     column_names: list[str],
     samples: list[dict],
@@ -327,9 +327,9 @@ def llm_generate_dataset_warning(
     return warning
 
 
+
+
 # ─── Dataset Conversion Advisor ──────────────────────────────────────
-
-
 def _parse_json_response(text: str) -> Optional[dict]:
     """Parse JSON from LLM response, handling markdown fences and noise."""
     if not text:
@@ -379,10 +379,10 @@ def _generate_with_backend(
         top_k = 20,
         max_tokens = max_tokens,
         repetition_penalty = 1.0,
-        enable_thinking = False,  # disable thinking for AI Assist
+        enable_thinking = False,
     ):
         if isinstance(chunk, dict):
-            continue  # skip metadata events
+            continue
         cumulative = chunk
     result = cumulative.strip()
     result = _strip_think_tags(result)
@@ -675,13 +675,13 @@ def _run_multi_pass_advisor(
 
         # ── Extract and validate column roles from Pass 2 ──
         column_roles = pass2.get("column_roles", {})
-        label_map = pass2.get("label_mapping") or {}  # may be null
+        label_map = pass2.get("label_mapping") or {}
 
         # Must have at least one user AND one assistant
         roles_present = set(column_roles.values())
         if "user" not in roles_present or "assistant" not in roles_present:
             logger.warning(f"Pass 2 sanity fail: missing user or assistant role: {column_roles}")
-            return None  # falls back to simple classification
+            return None
 
         # ── Pass 3: System prompt (non-conversational datasets only) ──
         sys_prompt = ""

--- a/studio/backend/utils/datasets/llm_assist.py
+++ b/studio/backend/utils/datasets/llm_assist.py
@@ -164,8 +164,6 @@ def _run_with_helper(prompt: str, max_tokens: int = 256) -> Optional[str]:
                 pass
 
 
-
-
 # ─── Public API ───────────────────────────────────────────────────────
 def llm_generate_vlm_instruction(
     column_names: list[str],
@@ -325,8 +323,6 @@ def llm_generate_dataset_warning(
 
     logger.info(f"LLM-generated warning: {warning}")
     return warning
-
-
 
 
 # ─── Dataset Conversion Advisor ──────────────────────────────────────

--- a/studio/backend/utils/datasets/llm_assist.py
+++ b/studio/backend/utils/datasets/llm_assist.py
@@ -166,6 +166,7 @@ def _run_with_helper(prompt: str, max_tokens: int = 256) -> Optional[str]:
 
 # ─── Public API ───────────────────────────────────────────────────────
 
+
 def llm_generate_vlm_instruction(
     column_names: list[str],
     samples: list[dict],
@@ -327,6 +328,7 @@ def llm_generate_dataset_warning(
 
 
 # ─── Dataset Conversion Advisor ──────────────────────────────────────
+
 
 def _parse_json_response(text: str) -> Optional[dict]:
     """Parse JSON from LLM response, handling markdown fences and noise."""

--- a/studio/backend/utils/datasets/llm_assist.py
+++ b/studio/backend/utils/datasets/llm_assist.py
@@ -165,6 +165,7 @@ def _run_with_helper(prompt: str, max_tokens: int = 256) -> Optional[str]:
 
 
 # ─── Public API ───────────────────────────────────────────────────────
+
 def llm_generate_vlm_instruction(
     column_names: list[str],
     samples: list[dict],
@@ -326,6 +327,7 @@ def llm_generate_dataset_warning(
 
 
 # ─── Dataset Conversion Advisor ──────────────────────────────────────
+
 def _parse_json_response(text: str) -> Optional[dict]:
     """Parse JSON from LLM response, handling markdown fences and noise."""
     if not text:

--- a/studio/backend/utils/datasets/model_mappings.py
+++ b/studio/backend/utils/datasets/model_mappings.py
@@ -527,9 +527,8 @@ TEMPLATE_TO_RESPONSES_MAPPER = {
         "instruction": "<|im_start|>user<|im_sep|>",
         "response": "<|im_start|>assistant<|im_sep|>",
     },
-    # No surrounding spaces: in Mistral v0.3 they fold into neighbouring text
-    # tokens ("[INST]"/"[/INST]" are single special tokens), so padded strings
-    # never match and everything masks. Same for Llama-2's SentencePiece.
+    # No surrounding spaces: "[INST]"/"[/INST]" are single special tokens in Mistral v0.3, so a
+    # padded string never matches and everything masks. Same for Llama-2's SentencePiece.
     "mistral": {
         "instruction": "[INST]",
         "response": "[/INST]",
@@ -545,10 +544,7 @@ TEMPLATE_TO_RESPONSES_MAPPER = {
         "instruction": "<|im_start|>user\n",
         "response": "<|im_start|>assistant\n",
     },
-    # Leading newline required: Zephyr's role tags are plain text, and
-    # SentencePiece tokenizes "<|assistant|>" differently at text start than
-    # after "</s>\n". Without the "\n" anchor the markers never match real
-    # turns, so every assistant token masks.
+    # Leading newline required: Zephyr's role tags are plain text
     "zephyr": {
         "instruction": "\n<|user|>\n",
         "response": "\n<|assistant|>\n",
@@ -585,8 +581,8 @@ TEMPLATE_TO_RESPONSES_MAPPER = {
         "instruction": "<|im_start|>user\n",
         "response": "<|im_start|>assistant\n",
     },
-    # No trailing space: SentencePiece folds it into the next content token
-    # ("▁Hello"), so the padded marker never matches and masks everything.
+    # No trailing space: SentencePiece folds it into the next content token ("_Hello"), so the
+    # padded marker never matches and masks everything.
     "starling": {
         "instruction": "GPT4 Correct User:",
         "response": "GPT4 Correct Assistant:",
@@ -595,9 +591,9 @@ TEMPLATE_TO_RESPONSES_MAPPER = {
         "instruction": "<|im_start|>user\n",
         "response": "<|im_start|>assistant\n",
     },
-    # "[gMASK]<sop>" appears once at text start, so a marker holding it matches
-    # no later user turn; "<think>" is scaffolding GLM-4.x renders as a lone
-    # "</think>" on non-final turns, so "<|assistant|><think>" never matches.
+    # "[gMASK]<sop>" appears once at text start.
+    # "<think>" is scaffolding GLM-4.x renders as a lone "</think>" on non-final turns, so "<|assistant|><think>" never
+    # matches.
     "glm": {
         "instruction": "<|user|>",
         "response": "<|assistant|>",

--- a/studio/backend/utils/datasets/online_tokenization.py
+++ b/studio/backend/utils/datasets/online_tokenization.py
@@ -226,7 +226,7 @@ def model_needs_token_type_ids(model: Any, processing_class: Any) -> bool:
             if module is not None and hasattr(module, marker):
                 return True
     except Exception:  # noqa: BLE001
-        return True  # unprobeable reads as "needs them", i.e. stay eager
+        return True
 
     try:
         for base in type(processing_class).__mro__:
@@ -366,7 +366,6 @@ def decide_online_tokenization(
     if override is False:
         return veto(f"{ENV_FLAG}=0")
 
-    # ---- correctness gates: never overridable ----
     if not platform_supports_dataloader_workers():
         if sys.platform in ("win32", "darwin"):
             return veto(f"{sys.platform} spawns DataLoader workers")
@@ -428,7 +427,6 @@ def decide_online_tokenization(
         return veto("not enough CPU workers to stay ahead of the GPU")
     checks.append(("correctness gates", True))
 
-    # ---- cost gates: the escape hatch may override these ----
     forced = override is True
 
     if row_count is None:
@@ -444,10 +442,9 @@ def decide_online_tokenization(
         if resolved_max_steps_epochs is not None
         else _epoch_count(num_train_epochs, max_steps)
     )
-    # The lazy view re-tokenizes every pass: +2.9% of steady-state time measured
-    # over 2.4 epochs (237.2s eager vs 244.1s online, identical loss).  One pass
-    # pays that once against a 97s map; each extra epoch pays again while the
-    # saving stays fixed, so anything past a single pass keeps the Arrow cache.
+    # The lazy view re-tokenizes every pass: +2.9% of steady-state time measured over 2.4 epochs, paid per epoch against
+    # a one-off 97s map, so anything past a single pass keeps the Arrow cache.
+    # Measured 237.2s eager against 244.1s online, identical loss.
     if not forced and epochs > 1.0:
         detail = (
             "step-capped run of unknown length"
@@ -688,11 +685,10 @@ def release_train_dataloader(trainer: Any) -> int:
     shut: list = []
     released += _shutdown_loader_workers(loader, shut)
 
-    # Worker count is a TrainingArguments setting, so the EVAL loader gets the
-    # same workers and `persistent_workers = True`; transformers keeps it in
-    # `_eval_dataloaders` (unchanged 4.51.3 through 5.5.0) and torch keeps its
-    # `_iterator` alive once iterated, so eval workers outlive train() just as
-    # the train ones do.  Drop the memo too, so a later eval rebuilds.
+    # The EVAL loader inherits the same workers and persistent_workers, and torch keeps its _iterator alive once
+    # iterated, so eval workers outlive train() just as the train ones do.
+    # Worker count is a TrainingArguments setting and transformers keeps the eval loader in `_eval_dataloaders`
+    # (unchanged 4.51.3 through 5.5.0). Drop the memo too, so a later eval rebuilds.
     memo = getattr(trainer, "_eval_dataloaders", None)
     if isinstance(memo, dict):
         for key in list(memo.keys()):

--- a/studio/backend/utils/datasets/online_tokenization.py
+++ b/studio/backend/utils/datasets/online_tokenization.py
@@ -427,6 +427,7 @@ def decide_online_tokenization(
         return veto("not enough CPU workers to stay ahead of the GPU")
     checks.append(("correctness gates", True))
 
+    # ---- cost gates: the escape hatch may override these ----
     forced = override is True
 
     if row_count is None:

--- a/studio/backend/utils/datasets/vlm_processing.py
+++ b/studio/backend/utils/datasets/vlm_processing.py
@@ -39,6 +39,7 @@ def generate_smart_vlm_instruction(
     sample = next(iter(dataset))
 
     # Columns that hold per-sample instructions
+    # ===== LEVEL 1: Explicit Instruction Columns =====
     question_columns = ["question", "query", "prompt", "instruction", "user_prompt"]
 
     for col in question_columns:
@@ -54,6 +55,7 @@ def generate_smart_vlm_instruction(
                     "confidence": 1.0,
                 }
 
+    # ===== LEVEL 2: Infer from Column Names + Content =====
     text_col_lower = text_column.lower()
 
     text_sample = str(sample.get(text_column, ""))[:500]
@@ -152,6 +154,7 @@ def generate_smart_vlm_instruction(
             "confidence": min(best_score, best_match["confidence"]),
         }
 
+    # ===== LEVEL 3: Analyze Dataset Name =====
     if dataset_name:
         name_lower = dataset_name.lower()
 
@@ -173,6 +176,7 @@ def generate_smart_vlm_instruction(
                 "confidence": 0.75,
             }
 
+    # ===== LEVEL 4: LLM-Assisted Instruction Generation =====
     try:
         from .llm_assist import llm_generate_vlm_instruction
 

--- a/studio/backend/utils/datasets/vlm_processing.py
+++ b/studio/backend/utils/datasets/vlm_processing.py
@@ -38,7 +38,6 @@ def generate_smart_vlm_instruction(
     column_names = set(next(iter(dataset)).keys())
     sample = next(iter(dataset))
 
-    # ===== LEVEL 1: Explicit Instruction Columns =====
     # Columns that hold per-sample instructions
     question_columns = ["question", "query", "prompt", "instruction", "user_prompt"]
 
@@ -48,31 +47,30 @@ def generate_smart_vlm_instruction(
             sample_content = sample[col]
             if sample_content and str(sample_content).strip():
                 return {
-                    "instruction": None,  # use column content
+                    "instruction": None,
                     "instruction_column": col,
                     "instruction_type": "explicit",
                     "uses_dynamic_instruction": True,
                     "confidence": 1.0,
                 }
 
-    # ===== LEVEL 2: Infer from Column Names + Content =====
     text_col_lower = text_column.lower()
 
-    text_sample = str(sample.get(text_column, ""))[:500]  # First 500 chars
+    text_sample = str(sample.get(text_column, ""))[:500]
 
     # Task-specific keywords and their instructions
     task_patterns = {
         # OCR / Transcription
         "ocr": {
             "keywords": ["ocr", "transcribe", "transcript"],
-            "content_hints": [r"[A-Za-z\u0600-\u06FF]{10,}"],  # Long Latin/Arabic passages
+            "content_hints": [r"[A-Za-z\u0600-\u06FF]{10,}"],
             "instruction": "Transcribe all the text shown in this image.",
             "confidence": 0.9,
         },
         # LaTeX / Math
         "latex": {
             "keywords": ["latex", "math", "formula", "equation"],
-            "content_hints": [r"\\[a-z]+\{", r"\^", r"_", r"\\frac"],  # LaTeX commands
+            "content_hints": [r"\\[a-z]+\{", r"\^", r"_", r"\\frac"],
             "instruction": "Convert this image to LaTeX notation.",
             "confidence": 0.95,
         },
@@ -115,7 +113,7 @@ def generate_smart_vlm_instruction(
         # Document / Text Recognition
         "document": {
             "keywords": ["document", "page", "paragraph", "article"],
-            "content_hints": [r"\n.*\n.*\n"],  # Multi-line text
+            "content_hints": [r"\n.*\n.*\n"],
             "instruction": "Extract and transcribe the text from this document image.",
             "confidence": 0.85,
         },
@@ -145,7 +143,7 @@ def generate_smart_vlm_instruction(
             best_score = score
             best_match = task_info
 
-    if best_match and best_score > 0.5:  # Confidence threshold
+    if best_match and best_score > 0.5:
         return {
             "instruction": best_match["instruction"],
             "instruction_column": None,
@@ -154,7 +152,6 @@ def generate_smart_vlm_instruction(
             "confidence": min(best_score, best_match["confidence"]),
         }
 
-    # ===== LEVEL 3: Analyze Dataset Name =====
     if dataset_name:
         name_lower = dataset_name.lower()
 
@@ -176,7 +173,6 @@ def generate_smart_vlm_instruction(
                 "confidence": 0.75,
             }
 
-    # ===== LEVEL 4: LLM-Assisted Instruction Generation =====
     try:
         from .llm_assist import llm_generate_vlm_instruction
 
@@ -185,7 +181,7 @@ def generate_smart_vlm_instruction(
             row = {}
             for col in s:
                 val = s[col]
-                if hasattr(val, "size") and hasattr(val, "mode"):  # PIL Image
+                if hasattr(val, "size") and hasattr(val, "mode"):
                     row[col] = "<image>"
                 elif isinstance(val, list):
                     row[col] = str(val)[:300]
@@ -215,7 +211,6 @@ def generate_smart_vlm_instruction(
         import logging
         logging.getLogger(__name__).debug(f"LLM-assisted instruction skipped: {e}")
 
-    # ===== LEVEL 5: Generic Fallback =====
     return {
         "instruction": "Describe this image in detail.",
         "instruction_column": None,

--- a/studio/backend/utils/debug_log_reader.py
+++ b/studio/backend/utils/debug_log_reader.py
@@ -49,11 +49,8 @@ class ReadResult:
 
 
 def _file_key(stat: os.stat_result, name: str) -> str:
-    # Identity only: nothing here may change on append. st_ctime_ns does (on
-    # Linux it is the metadata change time), which made every poll look like a
-    # rotation and resend the whole tail. st_ino can be 0 on some Windows
-    # filesystems, so name and device carry the identity there; truncation is
-    # caught separately by the offset > size check.
+    # Identity only: st_ctime_ns changes on append on Linux, which made every poll look like a rotation and resend the
+    # whole tail; st_ino can be 0 on Windows, so name and device carry it there.
     return f"{name}|{stat.st_dev}|{stat.st_ino}"
 
 
@@ -86,12 +83,10 @@ def _split_lines(data: bytes, *, drop_partial_head: bool) -> tuple[list[str], bo
         first = data.find(b"\n")
         remainder = b"" if first == -1 else data[first + 1 :]
         if not remainder:
-            # The whole window sits inside ONE record (no line break, or only
-            # the terminator at the end), so dropping the partial head left
-            # nothing: a record bigger than the window (native dump, \r-only
-            # progress run, giant JSON line) rendered an EMPTY pane on a
-            # megabyte log while the cursor still advanced past it. Keep the
-            # record's tail, which is the end everyone is reading for.
+            # The whole window sits inside ONE record (no line break, or only the terminator at the end), so dropping
+            # the partial head left nothing: a record bigger than the window (native dump, \r-only progress run, giant
+            # JSON line) rendered an EMPTY pane on a megabyte log while the cursor still advanced past it. Keep the
+            # record's tail.
             body = data if first == -1 else data[:first]
             remainder = body[-MAX_LINE_BYTES:]
         data = remainder
@@ -192,10 +187,7 @@ def read_since(
         handle.seek(start)
         data = handle.read(size - start)
 
-    # Stop at the last newline and leave the cursor before the partial line, so a
-    # half-written record is never emitted twice. An unterminated remainder past
-    # a line's worth is flushed, else a writer that never emits a newline stalls
-    # the viewer for good.
+    # Stop at the last newline and leave the cursor before the partial line
     last_newline = data.rfind(b"\n")
     if last_newline == -1:
         if len(data) < MAX_LINE_BYTES:
@@ -207,11 +199,10 @@ def read_since(
         consumed = last_newline + 1
         body = data[:consumed]
 
-    # Cap by BYTES, before decoding, so the cursor stops where the response
-    # stops. Slicing decoded lines instead threw away the oldest of a burst while
-    # advancing the cursor past them, so a model load logging more than
-    # MAX_LINES_PER_RESPONSE lines between polls lost the head of its own failure
-    # and still reported dropped_bytes = 0. The remainder now arrives next poll.
+    # Cap by BYTES before decoding so the cursor stops where the response stops: slicing decoded lines threw away the
+    # oldest of a burst while advancing past them, reporting dropped_bytes = 0.
+    # A model load logging more than MAX_LINES_PER_RESPONSE lines between polls lost the head of its own failure; the
+    # remainder now arrives next poll.
     newline_count = body.count(b"\n")
     if newline_count > MAX_LINES_PER_RESPONSE:
         cut = -1

--- a/studio/backend/utils/debug_log_sources.py
+++ b/studio/backend/utils/debug_log_sources.py
@@ -17,14 +17,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-# (subdirectory under a studio home, filename glob).
-#
-# Python writers: run.py:_setup_server_disk_logging and the llama / diffusion
-# runners in core/inference/llama_cpp.py. The desktop families come from the
-# Tauri shell (src-tauri/src/diagnostics/phase_log.rs) and land in the logs
-# directory ITSELF, with tauri.log at the home root (rotates to tauri.log.1).
-# backend-* is the shell's capture of backend stdout, and the only record that
-# exists when the backend dies BEFORE _setup_server_disk_logging runs.
+# (subdirectory under a studio home, filename glob). backend-* is the Tauri shell's capture of backend stdout, and the
+# only record that exists when the backend dies before disk logging starts.
+# Python writers are run.py:_setup_server_disk_logging and the llama / diffusion runners in core/inference/llama_cpp.py;
+# the desktop families come from src-tauri/src/diagnostics/phase_log.rs and land in the logs directory ITSELF, with
+# tauri.log at the home root.
 FAMILIES: dict[str, tuple[str, str]] = {
     "server": ("logs/server", "server-*.log"),
     "llama-server": ("logs/llama-server", "llama-*.log"),
@@ -83,18 +80,15 @@ def candidate_roots() -> list[Path]:
     except Exception:
         pass
 
-    # Mirror _swa_cache_path exactly: env override if set, else the legacy home,
-    # never both. Both would pull a DIFFERENT installation's logs into this one.
+    # Mirror _swa_cache_path exactly: env override if set, else the legacy home
+    # Both would pull a DIFFERENT installation's logs into this one.
     env_home = (
         os.environ.get("UNSLOTH_STUDIO_HOME") or os.environ.get("STUDIO_HOME") or ""
     ).strip()
     if env_home:
-        # Both spellings, because writer and reader disagree about the tilde:
-        # _swa_cache_path builds Path(home) raw, so an unexpanded value (systemd
-        # EnvironmentFile, dotenv) makes the runners write to a directory NAMED
-        # "~" while expanduser looks in the real home. Safe unlike the
-        # env-versus-legacy case above: one value, two spellings, so neither can
-        # be another installation's home.
+        # Both spellings, because writer and reader disagree about the tilde: _swa_cache_path builds Path(home) raw, so
+        # an unexpanded value (systemd EnvironmentFile, dotenv) makes the runners write to a directory NAMED "~" while
+        # expanduser looks in the real home. Safe unlike the env-versus-legacy case above: one value, two spellings.
         for spelling in (Path(env_home).expanduser(), Path(env_home)):
             try:
                 _add(spelling)
@@ -153,21 +147,17 @@ def _family_files(family: str) -> list[Path]:
             entries = list(directory.glob(pattern))
         except OSError:
             continue
-        # Nothing prunes logs/llama-server and one file is written per load
-        # ATTEMPT, so a real install reaches five figures (this host: 11,794)
-        # and realpath + stat on every one cost ~356ms, at a 1 Hz poll. Every
-        # family's filename embeds its creation time (server-YYYYmmdd-HHMMSS,
-        # llama-<epoch>, diffusion-<epoch>, desktop ms epoch), so name order
-        # tracks time order and this presort leaves a handful to stat. Survivors
-        # are still ordered by real mtime below, and the slice is wide enough to
-        # keep a file whose mtime moved after it was written.
+        # Nothing prunes logs/llama-server and one file is written per load ATTEMPT (11,794 on this host), so a filename
+        # presort, which tracks time order, leaves a handful to stat.
+        # Every family's filename embeds its creation time (server-YYYYmmdd-HHMMSS, llama-<epoch>, diffusion-<epoch>,
+        # desktop ms epoch), and realpath + stat on every file cost ~356ms at a 1 Hz poll.
         entries.sort(key = lambda entry: entry.name, reverse = True)
         entries = entries[: MAX_SOURCES_PER_FAMILY * 3]
         for entry in entries:
             try:
                 real = Path(os.path.realpath(entry))
-                # The TARGET must stay inside, so a symlink dropped into the log
-                # directory cannot become a reader for ~/.ssh/id_rsa.
+                # The TARGET must stay inside.
+                # A symlink dropped into the log directory must not become a reader for ~/.ssh/id_rsa.
                 if not _is_inside(real, real_dir):
                     continue
                 if not real.is_file():
@@ -187,10 +177,9 @@ def _family_files(family: str) -> list[Path]:
 
 def _is_current(family: str, path: Path, newest: Optional[Path]) -> bool:
     if family == "server":
-        # uvicorn is single process here, so our own pid is in the active
-        # session's filename: an exact match, not a newest-file guess. Anchored
-        # on the suffix because a substring test for "pid1234" would also match
-        # a retained ...-pid12345.log.
+        # uvicorn is single process here, so our own pid is in the active session's filename: an exact match, not a
+        # newest-file guess. Anchored on the suffix because a substring test for "pid1234" would also match a retained
+        # ...-pid12345.log.
         return path.name.endswith(f"-pid{os.getpid()}.log")
     return newest is not None and path == newest
 
@@ -245,10 +234,9 @@ def default_source_id() -> Optional[str]:
     for source in sources:
         if source.family == "server" and source.is_current:
             return source.id
-    # No live session: the newest file across every family, NOT any retained
-    # server log. Preferring a stale server log opened the tab on a previous run
-    # while the llama log holding the failure sat one entry down, which is the
-    # state after UNSLOTH_STUDIO_NO_FILE_LOG=1 or a failed log setup.
+    # No live session: the newest file across every family, NOT any retained server log, which would open the tab on a
+    # previous run while the llama log holding the failure sat one entry down.
+    # That is the state after UNSLOTH_STUDIO_NO_FILE_LOG=1 or a failed log setup.
     return max(sources, key = lambda s: s.modified_at).id
 
 

--- a/studio/backend/utils/embedding_model_settings.py
+++ b/studio/backend/utils/embedding_model_settings.py
@@ -28,10 +28,8 @@ EMBEDDING_BACKEND_SETTING_KEY = "rag_embedding_backend"
 EMBEDDING_RESOLUTION_SETTING_KEY = "rag_embedding_resolution"
 MAX_EMBEDDING_MODEL_LENGTH = 512
 
-# The effective model is consulted on the embedder hot path (once per embed /
-# tokenize call during ingestion), so the stored value is cached briefly instead
-# of hitting sqlite each time. Writes invalidate immediately in-process; other
-# readers converge within the TTL.
+# Consulted on the embedder hot path once per embed/tokenize call during ingestion, so the stored value is cached
+# briefly; writes invalidate in-process, other readers converge within the TTL.
 _CACHE_TTL_S = 2.0
 # typing.Optional, not `str | None`: the future import defers annotations, but a
 # type ALIAS is evaluated at import, and PEP 604 needs 3.10 over a 3.9 floor.
@@ -39,9 +37,8 @@ _StoredState = tuple[
     Optional[str], Optional[str], Optional[str], Optional[str], bool, Optional[dict]
 ]
 # (override model, resolved model, GGUF repo, backend, download pending, raw record).
-# The raw record is carried so a conditional write compares against exactly what
-# is stored: a reconstruction never matches a record written by a build with one
-# field fewer.
+# The raw record is carried so a conditional write compares against exactly what is stored: a reconstruction never
+# matches a record written by a build with one field fewer.
 _cached: tuple[float, _StoredState] | None = None
 # Bumped on every write/invalidate. A reader captures it before the DB read and
 # only fills the cache if it is unchanged afterward, so a read that overlapped a
@@ -209,10 +206,9 @@ def clear_stored_download_pending(model: str) -> bool:
         return False
     from storage.studio_db import compare_and_set_app_setting
 
-    # Conditional, not a plain upsert: a save for another model committing between
-    # the read and this write would otherwise be reverted onto this resolution.
-    # Comparing the record as read, rather than a rebuilt one, keeps that guard
-    # working across a record whose field set this build does not know about.
+    # Conditional, not a plain upsert, or a save for another model committing between the read and
+    # this write is reverted. Compared as read, not rebuilt, so the guard survives fields this
+    # build does not know about.
     if not compare_and_set_app_setting(
         EMBEDDING_RESOLUTION_SETTING_KEY, expected, {**expected, "download_pending": False}
     ):
@@ -280,9 +276,8 @@ def _get_stored_state() -> _StoredState:
     raw = resolution if isinstance(resolution, dict) else None
     value: _StoredState = (override, resolved_model, repo, backend, download_pending, raw)
     with _lock:
-        # Only cache when no save landed while we were reading; otherwise this
-        # value may be pre-save, and caching it would mask the new one for the
-        # TTL. The next reader re-reads the committed value.
+        # Only cache when no save landed while reading: a pre-save value would mask the new one for the
+        # whole TTL.
         if _generation == gen:
             _cached = (time.monotonic(), value)
     return value
@@ -292,10 +287,8 @@ def get_rag_embedding_model() -> str:
     """Effective embedding model: persisted override, else env/default."""
     stored = _get_stored_state()
     model = stored[0] or default_embedding_model()
-    # Reading this is how a job pins its model, so record the resolution here: the
-    # memo only protects a pinned job if it was populated before another model's
-    # save takes the one stored record, and the repo/backend getters alone left a
-    # worker that pinned A, scanned, then embedded with nothing memoized.
+    # Reading this is how a job pins its model, so record the resolution here: the memo protects a pinned job only if it
+    # was populated before another model's save takes the stored record.
     if stored[1] == model:
         _remember_resolution(model, stored)
     return model
@@ -346,11 +339,8 @@ def reset_rag_embedding_model() -> str:
     from storage.studio_db import upsert_app_settings
 
     restored = default_embedding_model()
-    # The memo survives a reset: it is per model and consulted only when the store
-    # has nothing, so it is what a job still pinned to a model reads. The restored
-    # default is not a running job, though -- new work resolves through it too, and
-    # a process-only answer would change identity on the next restart. So write any
-    # remembered resolution for it back durably rather than leave it in memory.
+    # The memo survives a reset, but the restored default is not a running job, so write any remembered resolution back
+    # durably rather than leave a process-only answer that changes on restart.
     remembered = _remembered(restored)
     resolution = None
     # The pending flag counts as much as a repo or a backend: a default saved over

--- a/studio/backend/utils/gguf_archs.py
+++ b/studio/backend/utils/gguf_archs.py
@@ -18,12 +18,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-# ``general.architecture`` values naming a speech or neural-codec checkpoint that no Unsloth
-# runtime can decode: llama.cpp has no CSM decoder (still an unmerged upstream PR) and no
-# media backend reads one either. Published CSM GGUFs do not agree on a spelling, so all four
-# on the Hub today are listed: ggml-org "llama-csm", cartesia "csm", cstr "csm-tts", and a
-# bundle's Mimi vocoder half "mimi". Named once so the chat gate, the listing classifier and
-# the media preflight cannot drift apart.
+# ``general.architecture`` values no Unsloth runtime can decode (llama.cpp has no CSM decoder).
+# Published CSM GGUFs disagree on spelling, so all four on the Hub are listed. Named once so the
+# chat gate, the listing classifier and the media preflight cannot drift apart.
 SPEECH_GGUF_ARCHS = frozenset({"llama-csm", "csm", "csm-tts", "mimi"})
 
 # The Mimi vocoder in ggml-org/sesame-csm-1b-GGUF puts a whole SENTENCE in general.architecture

--- a/studio/backend/utils/hardware/amd.py
+++ b/studio/backend/utils/hardware/amd.py
@@ -42,8 +42,7 @@ def _path_inside_venv(path: str) -> bool:
     try:
         # realpath (not abspath): resolve symlinks/8.3 names so an aliased venv matches.
         root = os.path.normcase(os.path.realpath(sys.prefix))
-        # Guard a root-dir prefix (C:\ or /): commonpath would match every path on
-        # it. A venv is never at root, so treat that as outside.
+        # Guard a root-dir prefix (C:\ or /): commonpath would match every path
         if os.path.dirname(root) == root:
             return False
         return os.path.normcase(os.path.commonpath([os.path.realpath(path), root])) == root
@@ -119,10 +118,8 @@ def _run_amd_smi(
     if _amd_smi_disabled:
         return None
     if not _amd_smi_allowed():
-        # Permanently skip amd-smi on Windows w/o a HIP SDK: every call would
-        # pop a UAC/DiskPart prompt (see _amd_smi_allowed). VRAM polling is then
-        # unavailable, but that beats the prompt. Opt back in with
-        # UNSLOTH_ENABLE_AMD_SMI=1.
+        # Permanently skip amd-smi on Windows without a HIP SDK: every call pops a UAC/DiskPart prompt. VRAM polling is
+        # then unavailable, which beats the prompt (UNSLOTH_ENABLE_AMD_SMI=1 opts back in).
         if not _amd_smi_disabled:
             logger.info(
                 "amd-smi disabled on Windows (no HIP SDK detected) to avoid a "
@@ -132,11 +129,9 @@ def _run_amd_smi(
             _amd_smi_disabled = True
         return None
     if shutil.which("amd-smi") is None:
-        # amd-smi does not exist on Windows (neither Adrenalin nor the HIP SDK
-        # ship a CLI) and can be absent on minimal Linux installs. Disable the
-        # poller in one step instead of burning the 3-strike circuit breaker
-        # on guaranteed FileNotFoundError spawns. Unsloth's VRAM display falls
-        # back to torch mem_get_info.
+        # amd-smi does not exist on Windows and can be absent on minimal Linux, so disable the poller in one step
+        # instead of burning the 3-strike breaker on guaranteed FileNotFoundError spawns.
+        # Unsloth's VRAM display falls back to torch mem_get_info.
         if not _amd_smi_disabled:
             logger.info(
                 "amd-smi not found on PATH; GPU utilization polling via "
@@ -190,11 +185,10 @@ def _run_amd_smi(
             _amd_smi_disabled = True
         return None
     if not result.stdout.strip():
-        # Exit 0 with no output (no GPUs visible, or a version emitting nothing
-        # for --json). Not a tool failure, so don't trip the circuit breaker.
+        # Exit 0 with no output
         logger.debug("amd-smi exited 0 but returned no output")
         return None
-    _amd_smi_consecutive_failures = 0  # reset on success
+    _amd_smi_consecutive_failures = 0
     try:
         return json.loads(result.stdout)
     except json.JSONDecodeError:
@@ -260,8 +254,8 @@ def _parse_memory_mb(value: Any) -> Optional[float]:
         return num / (1024 * 1024)
 
     # No explicit unit: default to MB (the amd-smi convention for bare numbers).
-    # A bytes-above-~10M heuristic was dropped because it misclassified small
-    # VRAM allocations; modern amd-smi always ships explicit units.
+    # A bytes-above-~10M heuristic was dropped because it misclassified small VRAM allocations; modern amd-smi always
+    # ships explicit units.
     return num
 
 
@@ -452,8 +446,7 @@ def get_gpu_vram_report() -> tuple[dict[int, tuple[int, int]], list[int]]:
         used_mb, total_mb = _vram_used_total_mb(gpu_data)
         if used_mb is None or total_mb is None or total_mb <= 0:
             continue
-        # Clamp: a used reading above total (seen when a card reports a stale
-        # figure mid-reset) must not become negative free.
+        # Clamp: a used reading above total
         out[idx] = (int(max(0.0, total_mb - used_mb)), int(total_mb))
     return out, enumerated
 
@@ -541,10 +534,7 @@ def get_primary_gpu_utilization() -> dict[str, Any]:
     if data is None:
         return {"available": False}
 
-    # amd-smi may return:
-    #   - a list of GPU dicts (older versions)
-    #   - a dict with a "gpu_data" key wrapping a list (newer versions)
-    #   - a single GPU dict (rare)
+    # amd-smi may return a list of GPU dicts, a dict wrapping one under "gpu_data", or a single GPU dict.
     if isinstance(data, dict) and "gpu_data" in data:
         data = data["gpu_data"]
     if isinstance(data, list):

--- a/studio/backend/utils/hardware/apple.py
+++ b/studio/backend/utils/hardware/apple.py
@@ -41,6 +41,7 @@ _ENERGY_UNIT_DIVISORS = {"mJ": 1e3, "uJ": 1e6, "nJ": 1e9}
 
 
 # ========== Pure helpers ==========
+
 def _fourcc(key: str) -> int:
     """Encode a 4-char SMC key/type name as a big-endian integer."""
     return int.from_bytes(key.encode("ascii"), "big")
@@ -72,6 +73,7 @@ def _is_gpu_energy_channel(name: str) -> bool:
 
 
 # ========== AppleSMC structs (layout must match the kernel exactly) ==========
+
 class _SMCKeyDataVers(ctypes.Structure):
     _fields_ = [
         ("major", ctypes.c_uint8),
@@ -115,6 +117,7 @@ class _SMCKeyData(ctypes.Structure):
 
 
 # ========== Library loaders ==========
+
 def _load_iokit() -> ctypes.CDLL:
     iokit = ctypes.CDLL(_IOKIT_PATH)
     iokit.IOServiceMatching.restype = ctypes.c_void_p
@@ -211,6 +214,7 @@ def _from_cfstr(cf: ctypes.CDLL, ref: Optional[int]) -> str:
 
 
 # ========== SMC connection (GPU temperature) ==========
+
 class _SMCConnection:
     """Connection to AppleSMCKeysEndpoint; discovers "Tg*" GPU temp keys once."""
 
@@ -320,6 +324,7 @@ class _SMCConnection:
 
 
 # ========== IOReport subscription (GPU power) ==========
+
 class _IOReportEnergy:
     """Persistent subscription to the "Energy Model" group for GPU wattage."""
 
@@ -382,6 +387,7 @@ class _IOReportEnergy:
 
 
 # ========== Public API (module singletons, failure-latched) ==========
+
 _smc: Optional[_SMCConnection] = None
 _smc_failed = False
 _energy: Optional[_IOReportEnergy] = None

--- a/studio/backend/utils/hardware/apple.py
+++ b/studio/backend/utils/hardware/apple.py
@@ -40,7 +40,6 @@ _CF_STRING_ENCODING_UTF8 = 0x08000100
 _ENERGY_UNIT_DIVISORS = {"mJ": 1e3, "uJ": 1e6, "nJ": 1e9}
 
 
-# ========== Pure helpers ==========
 
 
 def _fourcc(key: str) -> int:
@@ -73,7 +72,6 @@ def _is_gpu_energy_channel(name: str) -> bool:
     return name.endswith("GPU Energy") and "SRAM" not in name
 
 
-# ========== AppleSMC structs (layout must match the kernel exactly) ==========
 
 
 class _SMCKeyDataVers(ctypes.Structure):
@@ -118,7 +116,6 @@ class _SMCKeyData(ctypes.Structure):
     ]
 
 
-# ========== Library loaders ==========
 
 
 def _load_iokit() -> ctypes.CDLL:
@@ -216,7 +213,6 @@ def _from_cfstr(cf: ctypes.CDLL, ref: Optional[int]) -> str:
     return buf.value.decode("utf-8", errors = "replace").strip()
 
 
-# ========== SMC connection (GPU temperature) ==========
 
 
 class _SMCConnection:
@@ -327,7 +323,6 @@ class _SMCConnection:
         return _average_valid_temps(value for value in readings if value is not None)
 
 
-# ========== IOReport subscription (GPU power) ==========
 
 
 class _IOReportEnergy:
@@ -351,7 +346,7 @@ class _IOReportEnergy:
         # group (matches macmon); fall back if the OS leaves it unset.
         self._sample_channels = subscribed if subscribed else self._channels
         self._channels_key = _cfstr(self._cf, "IOReportChannels")
-        self._prev: Optional[tuple[int, float]] = None  # (sample ref, monotonic s)
+        self._prev: Optional[tuple[int, float]] = None
 
     def gpu_power_w(self) -> Optional[float]:
         sample = self._ior.IOReportCreateSamples(self._sub, self._sample_channels, None)
@@ -386,12 +381,11 @@ class _IOReportEnergy:
             watts = _watts(energy, unit, elapsed_s)
             if watts is not None:
                 total = (total or 0.0) + watts
-        if total is None or total < 0:  # negative = counter reset; show -- not a bogus draw
+        if total is None or total < 0:
             return None
         return round(total, 1)
 
 
-# ========== Public API (module singletons, failure-latched) ==========
 
 _smc: Optional[_SMCConnection] = None
 _smc_failed = False

--- a/studio/backend/utils/hardware/apple.py
+++ b/studio/backend/utils/hardware/apple.py
@@ -42,6 +42,7 @@ _ENERGY_UNIT_DIVISORS = {"mJ": 1e3, "uJ": 1e6, "nJ": 1e9}
 
 # ========== Pure helpers ==========
 
+
 def _fourcc(key: str) -> int:
     """Encode a 4-char SMC key/type name as a big-endian integer."""
     return int.from_bytes(key.encode("ascii"), "big")
@@ -73,6 +74,7 @@ def _is_gpu_energy_channel(name: str) -> bool:
 
 
 # ========== AppleSMC structs (layout must match the kernel exactly) ==========
+
 
 class _SMCKeyDataVers(ctypes.Structure):
     _fields_ = [
@@ -117,6 +119,7 @@ class _SMCKeyData(ctypes.Structure):
 
 
 # ========== Library loaders ==========
+
 
 def _load_iokit() -> ctypes.CDLL:
     iokit = ctypes.CDLL(_IOKIT_PATH)
@@ -214,6 +217,7 @@ def _from_cfstr(cf: ctypes.CDLL, ref: Optional[int]) -> str:
 
 
 # ========== SMC connection (GPU temperature) ==========
+
 
 class _SMCConnection:
     """Connection to AppleSMCKeysEndpoint; discovers "Tg*" GPU temp keys once."""
@@ -324,6 +328,7 @@ class _SMCConnection:
 
 
 # ========== IOReport subscription (GPU power) ==========
+
 
 class _IOReportEnergy:
     """Persistent subscription to the "Energy Model" group for GPU wattage."""

--- a/studio/backend/utils/hardware/apple.py
+++ b/studio/backend/utils/hardware/apple.py
@@ -42,6 +42,7 @@ _ENERGY_UNIT_DIVISORS = {"mJ": 1e3, "uJ": 1e6, "nJ": 1e9}
 
 
 
+# ========== Pure helpers ==========
 def _fourcc(key: str) -> int:
     """Encode a 4-char SMC key/type name as a big-endian integer."""
     return int.from_bytes(key.encode("ascii"), "big")
@@ -74,6 +75,7 @@ def _is_gpu_energy_channel(name: str) -> bool:
 
 
 
+# ========== AppleSMC structs (layout must match the kernel exactly) ==========
 class _SMCKeyDataVers(ctypes.Structure):
     _fields_ = [
         ("major", ctypes.c_uint8),
@@ -118,6 +120,7 @@ class _SMCKeyData(ctypes.Structure):
 
 
 
+# ========== Library loaders ==========
 def _load_iokit() -> ctypes.CDLL:
     iokit = ctypes.CDLL(_IOKIT_PATH)
     iokit.IOServiceMatching.restype = ctypes.c_void_p
@@ -215,6 +218,7 @@ def _from_cfstr(cf: ctypes.CDLL, ref: Optional[int]) -> str:
 
 
 
+# ========== SMC connection (GPU temperature) ==========
 class _SMCConnection:
     """Connection to AppleSMCKeysEndpoint; discovers "Tg*" GPU temp keys once."""
 
@@ -325,6 +329,7 @@ class _SMCConnection:
 
 
 
+# ========== IOReport subscription (GPU power) ==========
 class _IOReportEnergy:
     """Persistent subscription to the "Energy Model" group for GPU wattage."""
 
@@ -387,6 +392,7 @@ class _IOReportEnergy:
 
 
 
+# ========== Public API (module singletons, failure-latched) ==========
 _smc: Optional[_SMCConnection] = None
 _smc_failed = False
 _energy: Optional[_IOReportEnergy] = None

--- a/studio/backend/utils/hardware/apple.py
+++ b/studio/backend/utils/hardware/apple.py
@@ -40,8 +40,6 @@ _CF_STRING_ENCODING_UTF8 = 0x08000100
 _ENERGY_UNIT_DIVISORS = {"mJ": 1e3, "uJ": 1e6, "nJ": 1e9}
 
 
-
-
 # ========== Pure helpers ==========
 def _fourcc(key: str) -> int:
     """Encode a 4-char SMC key/type name as a big-endian integer."""
@@ -71,8 +69,6 @@ def _is_gpu_energy_channel(name: str) -> bool:
     # Exact "GPU Energy" plus "DIE_N_GPU Energy" on Ultra chips; the separate
     # "GPU SRAM*" channels are not GPU core power.
     return name.endswith("GPU Energy") and "SRAM" not in name
-
-
 
 
 # ========== AppleSMC structs (layout must match the kernel exactly) ==========
@@ -116,8 +112,6 @@ class _SMCKeyData(ctypes.Structure):
         ("data32", ctypes.c_uint32),
         ("bytes", ctypes.c_uint8 * 32),
     ]
-
-
 
 
 # ========== Library loaders ==========
@@ -214,8 +208,6 @@ def _from_cfstr(cf: ctypes.CDLL, ref: Optional[int]) -> str:
     if not cf.CFStringGetCString(ref, buf, len(buf), _CF_STRING_ENCODING_UTF8):
         return ""
     return buf.value.decode("utf-8", errors = "replace").strip()
-
-
 
 
 # ========== SMC connection (GPU temperature) ==========
@@ -327,8 +319,6 @@ class _SMCConnection:
         return _average_valid_temps(value for value in readings if value is not None)
 
 
-
-
 # ========== IOReport subscription (GPU power) ==========
 class _IOReportEnergy:
     """Persistent subscription to the "Energy Model" group for GPU wattage."""
@@ -389,7 +379,6 @@ class _IOReportEnergy:
         if total is None or total < 0:
             return None
         return round(total, 1)
-
 
 
 # ========== Public API (module singletons, failure-latched) ==========

--- a/studio/backend/utils/hardware/vram_estimation.py
+++ b/studio/backend/utils/hardware/vram_estimation.py
@@ -16,8 +16,8 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional
 
 QUANT_4BIT_FACTOR = 16 / 5
-DOUBLE_QUANT_4BIT_FACTOR = 3.6  # bnb_4bit_use_double_quant; see VRAM_ESTIMATION.md section 1
-CUDA_OVERHEAD_BYTES = int(1.4 * 1024**3)  # calibrated on RTX 5070 Ti
+DOUBLE_QUANT_4BIT_FACTOR = 3.6
+CUDA_OVERHEAD_BYTES = int(1.4 * 1024**3)
 NON_FLASH_ATTENTION_FACTOR = (
     12.0  # eager attention score+workspace overhead; see VRAM_ESTIMATION.md section 5
 )
@@ -49,11 +49,11 @@ MLP_TARGET_MODULES = {"gate_proj", "up_proj", "down_proj"}
 
 # Empirically calibrated bytes/param — see VRAM_ESTIMATION.md for rationale.
 OPTIMIZER_BYTES_PER_PARAM: Dict[str, int] = {
-    "adamw_8bit": 4,  # BNB upcasts to fp32 during step
+    "adamw_8bit": 4,
     "paged_adamw_8bit": 4,
     "adamw_bnb_8bit": 4,
     "paged_adamw_32bit": 8,
-    "adamw_torch": 6,  # fused, no master copy
+    "adamw_torch": 6,
     "adamw_torch_fused": 6,
     "sgd": 4,
 }
@@ -298,7 +298,7 @@ def extract_arch_config(hf_config) -> Optional[ModelArchConfig]:
     if shared_expert_intermediate_size and n_shared_experts == 0:
         n_shared_experts = 1
     # DBRX moe_top_k; Hunyuan-V1-MoE moe_topk (may be a per-layer list).
-    # _max_scalar normalizes lists to the worst case so int(...) can't crash.
+    # _max_scalar normalizes lists to the worst case so int(...) cannot crash.
     num_experts_per_tok = (
         _max_scalar(_moe_attr("num_experts_per_tok"))
         or _max_scalar(_moe_attr("top_k_experts"))
@@ -388,8 +388,7 @@ def extract_arch_config(hf_config) -> Optional[ModelArchConfig]:
 
 
 def _targets_all_linear(target_modules) -> bool:
-    # peft LoraConfig accepts target_modules="all-linear" as a bare string;
-    # iterating a string yields chars and never matches the set.
+    # peft LoraConfig accepts target_modules="all-linear" as a bare string
     if isinstance(target_modules, str):
         target_modules = [target_modules]
     normalized = {str(module).lower().replace("_", "-") for module in target_modules}
@@ -407,9 +406,8 @@ def _layer_types(arch: ModelArchConfig) -> list:
 
 
 def _uses_structured_layer_shapes(arch: ModelArchConfig) -> bool:
-    # MLA configs have their own q/kv low-rank projection shape formulas in
-    # _compute_attn_elements / _lora_attn_elements; do not let head_dim or
-    # other structured fields override that path.
+    # MLA configs have their own q/kv low-rank projection shape formulas
+    # Do not let head_dim or other structured fields override that path.
     if arch.q_lora_rank is not None:
         return False
     return bool(
@@ -427,9 +425,9 @@ def _is_kv_shared_layer(arch: ModelArchConfig, layer_idx: int) -> bool:
     if arch.num_kv_shared_layers <= 0:
         return False
     first_shared = arch.num_hidden_layers - arch.num_kv_shared_layers
-    # Gemma4 (modeling_gemma4.py:1031, modular_gemma4.py:863) uses the same
-    # `> 0` guard so a fully-shared config raises at model construction;
-    # matching upstream avoids estimating a shape the model code rejects.
+    # Gemma4 uses the same `> 0` guard, so a fully-shared config raises at model construction:
+            # matching upstream avoids estimating a shape the model code rejects.
+    # Gemma4's guard is at modeling_gemma4.py:1031 / modular_gemma4.py:863.
     return layer_idx >= first_shared > 0
 
 
@@ -590,8 +588,8 @@ def _module_path_matches(skip_module: str, alias: str) -> bool:
     prefix_parts = skip_parts[: len(skip_parts) - len(alias_parts)]
     if not prefix_parts:
         return True
-    # Bound the prefix to text-tower roots so VLM skips like
-    # vision_tower.model.layers... don't shadow the text alias.
+    # Bound the prefix to text-tower roots so VLM keys like vision_tower.model.layers do not shadow
+        # the text alias.
     return ".".join(prefix_parts) in _SKIP_MODULE_TEXT_PREFIXES
 
 
@@ -1016,10 +1014,9 @@ def compute_lora_params(arch: ModelArchConfig, lora_rank: int, target_modules: l
         if n_experts > 1:
             n_dense = arch.num_dense_layers
             n_moe = n_layers - n_dense
-            # peft "all-linear" attaches LoRA to nn.Linear only; routed experts
-            # are nn.Parameter and need explicit gate_proj/up_proj/down_proj
-            # naming via Unsloth's get_moe_target_parameters. Shared experts are
-            # nn.Linear, picked up by get_peft_regex.
+            # peft "all-linear" attaches LoRA to nn.Linear only; routed experts are nn.Parameter and need explicit
+            # naming, while shared experts are nn.Linear and get_peft_regex picks them up.
+            # Routed experts need explicit gate_proj/up_proj/down_proj naming via Unsloth's get_moe_target_parameters.
             routed_moe = (
                 0
                 if all_linear
@@ -1061,10 +1058,10 @@ def compute_lora_params(arch: ModelArchConfig, lora_rank: int, target_modules: l
         attn_total = _lora_attn_elements(arch, r, selected_modules) * n_layers
         n_dense = arch.num_dense_layers
         n_moe = n_layers - n_dense
-        # Routed and shared experts may use different intermediate sizes
-        # (Qwen3.5-MoE: routed mlp_size != shared_expert_intermediate_size).
-        # See structured branch for the all-linear exclusion rationale; only
-        # routed (nn.Parameter) experts are excluded under all-linear.
+        # Routed and shared experts may use different intermediate sizes (Qwen3.5-MoE), and only routed nn.Parameter
+        # experts are excluded under all-linear.
+        # Qwen3.5-MoE has routed mlp_size != shared_expert_intermediate_size; see the structured branch for the all-
+        # linear exclusion rationale.
         routed_moe = (
             0
             if all_linear

--- a/studio/backend/utils/hardware/vram_estimation.py
+++ b/studio/backend/utils/hardware/vram_estimation.py
@@ -47,7 +47,7 @@ DEFAULT_TARGET_MODULES = [
 ATTENTION_TARGET_MODULES = {"q_proj", "k_proj", "v_proj", "o_proj"}
 MLP_TARGET_MODULES = {"gate_proj", "up_proj", "down_proj"}
 
-# Empirically calibrated bytes/param — see VRAM_ESTIMATION.md for rationale.
+# Empirically calibrated bytes/param - see VRAM_ESTIMATION.md for rationale.
 OPTIMIZER_BYTES_PER_PARAM: Dict[str, int] = {
     "adamw_8bit": 4,
     "paged_adamw_8bit": 4,
@@ -58,7 +58,7 @@ OPTIMIZER_BYTES_PER_PARAM: Dict[str, int] = {
     "sgd": 4,
 }
 
-# (full_ft_multiplier, lora_multiplier) — fraction of num_layers.
+# (full_ft_multiplier, lora_multiplier) - fraction of num_layers.
 # LoRA: frozen layers skip activation storage, but ~1 is in flight during backprop.
 GC_LAYER_MULTIPLIERS = {
     "none": (None, None),

--- a/studio/backend/utils/hardware/vram_estimation.py
+++ b/studio/backend/utils/hardware/vram_estimation.py
@@ -426,7 +426,7 @@ def _is_kv_shared_layer(arch: ModelArchConfig, layer_idx: int) -> bool:
         return False
     first_shared = arch.num_hidden_layers - arch.num_kv_shared_layers
     # Gemma4 uses the same `> 0` guard, so a fully-shared config raises at model construction:
-            # matching upstream avoids estimating a shape the model code rejects.
+    # matching upstream avoids estimating a shape the model code rejects.
     # Gemma4's guard is at modeling_gemma4.py:1031 / modular_gemma4.py:863.
     return layer_idx >= first_shared > 0
 
@@ -589,7 +589,7 @@ def _module_path_matches(skip_module: str, alias: str) -> bool:
     if not prefix_parts:
         return True
     # Bound the prefix to text-tower roots so VLM keys like vision_tower.model.layers do not shadow
-        # the text alias.
+    # the text alias.
     return ".".join(prefix_parts) in _SKIP_MODULE_TEXT_PREFIXES
 
 

--- a/studio/backend/utils/hf_cache_settings.py
+++ b/studio/backend/utils/hf_cache_settings.py
@@ -64,8 +64,7 @@ class HuggingFaceCachePaths:
         from utils.utils import hf_environment_for_spawn, hf_environment_scrubbed
 
         env = hf_environment_for_spawn() if base is None else hf_environment_scrubbed(base)
-        # Do not rewrite HF_HOME. It also owns HF's token path, and credentials
-        # must not be moved onto a removable cache volume.
+        # Do not rewrite HF_HOME. It also owns HF's token path.
         env["HF_HUB_CACHE"] = str(self.hub_cache)
         env["HF_XET_CACHE"] = str(self.xet_cache)
         env.pop("HUGGINGFACE_HUB_CACHE", None)
@@ -113,7 +112,7 @@ def _stored_cache_home() -> Optional[Path]:
     try:
         from storage.studio_db import get_app_setting
         value = get_app_setting(CACHE_HOME_SETTING_KEY, None)
-    except Exception:
+    except Exception:  # noqa: BLE001 - the shim is optional; a spawn must never depend on it
         return None
     if not isinstance(value, str) or not value.strip():
         return None
@@ -181,7 +180,7 @@ def _xet_loader_barrier() -> Iterator[None]:
     try:
         from utils.hf_xet_fallback import env_override_barrier
         barrier = env_override_barrier()
-    except Exception:  # noqa: BLE001 - the shim is optional; a spawn must never depend on it
+    except Exception:  # noqa: BLE001 - the shim is optional; a spawn must never depend
         yield
         return
     with barrier:
@@ -199,10 +198,8 @@ def child_environment_for_spawn(environment: Mapping[str, str]) -> Iterator[None
 
     from utils.utils import hf_environment_restored_for_spawn
 
-    # Also exclude the Xet shim's GPU-init override window: a child spawned inside it inherits the
-    # flag for life, whereupon unsloth_zoo hands it STUB triton and bitsandbytes and the run
-    # silently produces nothing. Filtering a child env dict cannot help here, since spawn copies the
-    # live environment and takes no env argument.
+    # Exclude the Xet shim's GPU-init override window: a child spawned inside it inherits the flag for life and
+    # unsloth_zoo hands it STUB triton and bitsandbytes, so the run produces nothing.
     with _spawn_env_lock, _xet_loader_barrier(), hf_environment_restored_for_spawn():
         missing = object()
         saved_environment: dict[str, str | object] = {}
@@ -223,8 +220,8 @@ def initialize_hf_cache_environment() -> HuggingFaceCachePaths:
     """Seed import-time HF variables once during backend startup."""
 
     paths = get_hf_cache_paths()
-    # Preserve an explicit HF_HOME, otherwise keep credentials at the platform
-    # default while routing cache bytes through the selected home.
+    # Preserve an explicit HF_HOME, else keep credentials at the platform default while routing
+    # cache bytes through the selected home.
     if not os.environ.get("HF_HOME", "").strip():
         os.environ["HF_HOME"] = str(_default_cache_home())
     os.environ["HF_HUB_CACHE"] = str(paths.hub_cache)

--- a/studio/backend/utils/hf_xet_fallback.py
+++ b/studio/backend/utils/hf_xet_fallback.py
@@ -42,6 +42,7 @@ DEFAULT_HTTP_STALL_TIMEOUT = 180.0
 # The worker runs snapshot_download(max_workers=1), so every finished shard is already a blob and is skipped.
 DEFAULT_XET_ATTEMPTS = 2
 
+# --- lazy shared-backend loader ----------------------------------------------------------------
 _shared: Any = None
 _shared_available: Optional[bool] = None
 _shared_import_error: Optional[BaseException] = None
@@ -343,6 +344,7 @@ def _as_int(value: str) -> "Optional[int]":
 # would each read the same untouched `available` and promise the whole machine. Reservations bridge
 # that window, counting only the unmaterialized remainder: once buffers are resident `available` has
 # already dropped by them, and charging the promise again would double-count for the worker's life.
+# --- concurrent-worker budget ledger -------------------------------------------------------------
 _budget_lock = threading.RLock()
 # token -> [bytes, pid or None, monotonic stamp]
 _budget_reservations: "dict[int, list]" = {}
@@ -655,6 +657,7 @@ def xet_attempts() -> int:
 
 
 # Degraded stubs, used only when unsloth_zoo is unavailable.
+# --- degraded stubs (used only when unsloth_zoo is unavailable) -------------------------------
 class _DegradedDownloadStallError(RuntimeError):
     """Stub mirror so callers' ``except`` clauses resolve; never raised in degraded mode."""
 
@@ -766,6 +769,7 @@ def _degraded_snapshot_download_with_xet_fallback(
 # Resolved via PEP 562 so importing them triggers the heavy load and the light names do not.
 # The light names, `child_should_disable_xet` / `DEFAULT_*`, are importable from utils.hf_xet_fallback without
 # triggering the load.
+# --- lazy attribute access for the heavy shared API -------------------------------------------
 _DEGRADED_ATTRS = {
     "DownloadStallError": _DegradedDownloadStallError,
     "get_hf_download_state": _degraded_get_hf_download_state,

--- a/studio/backend/utils/hf_xet_fallback.py
+++ b/studio/backend/utils/hf_xet_fallback.py
@@ -27,30 +27,27 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-# Defaults mirror unsloth_zoo.hf_xet_fallback; plain literals so they resolve (including as
-# default args below) without importing unsloth_zoo/transformers.
+# Defaults mirror unsloth_zoo.hf_xet_fallback; plain literals so they resolve without importing
+# unsloth_zoo/transformers.
 DEFAULT_GRACE_PERIOD = 10.0
 DEFAULT_HEARTBEAT_INTERVAL = 30.0
 # Xet gets 30s of zero progress before the HTTP retry; HTTP, the last resort, keeps 180s. The
-# wrappers pass None so the shared layer picks per transport; these literals are for callers that
-# want an explicit value without the heavy import.
+# wrappers pass None so the shared layer picks per transport; these literals are for callers
+# wanting an explicit value without the heavy import.
 DEFAULT_STALL_TIMEOUT = 30.0
 DEFAULT_CONNECT_TIMEOUT = 90.0
 DEFAULT_HTTP_STALL_TIMEOUT = 180.0
-# Xet workers spent per download before the transport changes. A wedged transfer usually clears on a
-# fresh process, and the retry replays only the in-flight file: the worker runs
-# snapshot_download(max_workers=1), so every finished shard is already a blob and is skipped.
+# Xet workers spent per download before the transport changes. A wedged transfer usually clears on
+# a fresh process, and the retry replays only the in-flight file.
+# The worker runs snapshot_download(max_workers=1), so every finished shard is already a blob and is skipped.
 DEFAULT_XET_ATTEMPTS = 2
 
-# --- lazy shared-backend loader ----------------------------------------------------------------
 _shared: Any = None
-_shared_available: Optional[bool] = None  # None = not yet attempted
+_shared_available: Optional[bool] = None
 _shared_import_error: Optional[BaseException] = None
-# Guards _shared_available AND every UNSLOTH_ZOO_DISABLE_GPU_INIT save/set/restore here. Both
-# loaders mutate that one process-wide variable, so they must serialize against each other: two
-# locks would still allow A-saves-unset / B-saves-"1" / A-restores-unset / B-restores-"1", leaving
-# it set for the life of the process. RLock because child_environment_for_spawn holds it across a
-# spawn and legitimately nests (its own _spawn_env_lock is an RLock for the same reason).
+# Guards _shared_available AND every UNSLOTH_ZOO_DISABLE_GPU_INIT save/set/restore here.
+# Two locks would still allow A-saves-unset / B-saves-"1" / A-restores-unset / B-restores-"1", leaving it set for the
+# life of the process. RLock because child_environment_for_spawn holds it across a spawn and legitimately nests.
 _load_lock = threading.RLock()
 
 
@@ -100,8 +97,9 @@ def _load_shared() -> bool:
             _shared_import_error = exc
             import os as _os
 
-            # ...but ONLY on a host that really has no accelerator. That flag makes unsloth_zoo take its MLX/CPU path, injecting triton and bitsandbytes
-            # STUBS into sys.modules for the process. On a working GPU box those stubs raise from the first CUDA-only kernel, turning a healthy GPU into 500s.
+            # ...but ONLY on a host that really has no accelerator. That flag makes unsloth_zoo take its MLX/CPU path,
+            # injecting triton and bitsandbytes STUBS into sys.modules for the process. On a working GPU box those stubs
+            # raise from the first CUDA-only kernel, turning a healthy GPU into 500s.
             if _gpu_present():
                 _shared_available = False
                 import logging as _logging
@@ -118,7 +116,7 @@ def _load_shared() -> bool:
             global _gpu_init_override_depth
             _prev_gpu_init = _os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT")
             _ours = _prev_gpu_init != "1"
-            _gpu_init_override_depth += _ours  # claimed before the write, released after
+            _gpu_init_override_depth += _ours
             _os.environ["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
             try:
                 import unsloth_zoo.hf_xet_fallback as shared
@@ -147,10 +145,11 @@ def _load_shared() -> bool:
                 _gpu_init_override_depth -= _ours
 
 
-# _load_optional results by module name. Memoising the FAILURE is the point: on a zoo that predates
-# these modules the import can never start succeeding, so without this every xet_health /
-# record_xet_outcome / xet_env_overrides call re-ran the GPU-init retry, re-opening the
-# process-wide env window on every download. With it the window opens once per module per process.
+# Memoising the FAILURE is the point: on a zoo predating these modules the import can never start
+# succeeding, so without this every call re-ran the GPU-init retry and reopened the process-wide
+# env window on every download.
+# The calls are xet_health / record_xet_outcome / xet_env_overrides, and with this the window opens once per module per
+# process.
 _UNTRIED = object()
 _optional_modules: "dict[str, Any]" = {}
 
@@ -193,9 +192,7 @@ def _load_optional(module_name: str) -> Any:
         global _gpu_init_override_depth
         previous = _os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT")
         ours = previous != "1"
-        # Claim BEFORE the write, release AFTER the restore, so the set window sits strictly inside
-        # the window where a spawning thread can see the flag is ours. The other order leaves a gap
-        # at each end where a child inherits an unclaimed flag and never clears it.
+        # Claim BEFORE the write, release AFTER the restore.
         _gpu_init_override_depth += ours
         try:
             _os.environ["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
@@ -326,9 +323,10 @@ def apply_xet_env(env: dict, cache_dir: "Optional[str]" = None) -> "Optional[dic
 
 
 # Share of free RAM a download may turn into buffers. A quarter of AVAILABLE always exceeds the
-# zoo's eighth of TOTAL on an idle machine, so the clamp is unreachable unless RAM is actually held.
+# zoo's eighth of TOTAL on an idle machine, so the clamp is unreachable unless RAM is held.
 _AVAILABLE_RAM_SHARE = 4
-# Integer arithmetic converges in one or two passes; the bound only guards a future non-monotonic zoo.
+# Integer arithmetic converges in one or two passes; the bound only guards a future non-monotonic
+# zoo.
 _CLAMP_MAX_PASSES = 3
 _BUFFER_LIMIT_KEY = "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"
 
@@ -341,15 +339,10 @@ def _as_int(value: str) -> "Optional[int]":
         return None
 
 
-# --- concurrent-worker budget ledger -------------------------------------------------------------
-# A worker allocates inside the child, after Popen returns, so free RAM does not drop until well
-# after we sized it. Four downloads starting together would each read the same untouched `available`
-# and each take a quarter of it, promising the whole machine. Reservations bridge that window:
-# sizing subtracts what live siblings were already promised but have not yet taken. Only the
-# unmaterialized remainder, because once a worker's buffers are resident `available` has ALREADY
-# dropped by them: charging the whole promise on top of that reading counts the same bytes twice,
-# for the worker's entire lifetime, and talks the next download out of RAM that is genuinely free.
-# RLock: the clamp holds this across its whole decide-and-reserve region, and the reserve retakes it.
+# A worker allocates inside the child, after Popen returns, so four downloads starting together
+# would each read the same untouched `available` and promise the whole machine. Reservations bridge
+# that window, counting only the unmaterialized remainder: once buffers are resident `available` has
+# already dropped by them, and charging the promise again would double-count for the worker's life.
 _budget_lock = threading.RLock()
 # token -> [bytes, pid or None, monotonic stamp]
 _budget_reservations: "dict[int, list]" = {}
@@ -424,7 +417,7 @@ def _live_reserved_locked() -> int:
             if now - stamp > _UNBOUND_RESERVATION_TTL:
                 _budget_reservations.pop(token, None)
             else:
-                total += nbytes  # nothing spawned yet, so nothing of it is resident
+                total += nbytes
             continue
         if now - stamp > _BOUND_RESERVATION_TTL or not _pid_alive(pid):
             _budget_reservations.pop(token, None)
@@ -506,12 +499,7 @@ def clamp_to_available_ram(
             return sized
         floor = int(getattr(module, "_MIN_BUFFER_LIMIT", 1_000_000_000))
         limit = int(sized[_BUFFER_LIMIT_KEY])
-        # Reading the ledger and reserving against it is ONE decision. Split across two critical
-        # sections, concurrent workers all read the same total before any of them wrote, which is
-        # the very overcommit the ledger exists to stop. The recompute inside is pure arithmetic on
-        # a frozen profile, so holding the lock across it costs microseconds; the RAM/disk reading
-        # above stays outside. `_budget_lock` is an RLock because `_reserve_worker_budget` retakes
-        # it here.
+        # Reading the ledger and reserving against it is ONE decision.
         with _budget_lock:
             unclaimed = max(0, available - _live_reserved_locked())
             budget = max(floor, unclaimed // _AVAILABLE_RAM_SHARE)
@@ -543,11 +531,9 @@ def clamp_to_available_ram(
                 # Monotonic in total RAM, so scaling by the overshoot converges.
                 synthetic = max(floor, synthetic * budget // new_limit)
 
-            # Reduce-only: keep a value the recompute would RAISE. `xet_env_overrides` is called raw
-            # here, without the throttled flag `apply_xet_env` threads through after a 429, so an
-            # un-throttled recompute could otherwise hand back the stream ceiling that backoff
-            # lowered. Every derived number is monotonic in total RAM, so taking the smaller of the
-            # two is always a coherent config.
+            # Reduce-only: keep a value the recompute would RAISE.
+            # `xet_env_overrides` is called raw here, without the throttled flag `apply_xet_env` threads through after a
+            # 429, and every derived number is monotonic in total RAM, so the smaller of the two is always coherent.
             written = {}
             for key, value in clamped.items():
                 if key not in sized:
@@ -668,7 +654,7 @@ def xet_attempts() -> int:
     return min(value, 8)
 
 
-# --- degraded stubs (used only when unsloth_zoo is unavailable) -------------------------------
+# Degraded stubs, used only when unsloth_zoo is unavailable.
 class _DegradedDownloadStallError(RuntimeError):
     """Stub mirror so callers' ``except`` clauses resolve; never raised in degraded mode."""
 
@@ -775,11 +761,11 @@ def _degraded_snapshot_download_with_xet_fallback(
     return path
 
 
-# --- lazy attribute access for the heavy shared API -------------------------------------------
 # ``DownloadStallError`` (class identity matters for ``except``), ``start_watchdog`` and
 # ``get_hf_download_state`` come from the shared backend when available, else the degraded stubs.
-# Resolved via PEP 562 ``__getattr__`` so ``from utils.hf_xet_fallback import X`` triggers the load
-# only for these heavy names, not for ``child_should_disable_xet`` / ``DEFAULT_*``.
+# Resolved via PEP 562 so importing them triggers the heavy load and the light names do not.
+# The light names, `child_should_disable_xet` / `DEFAULT_*`, are importable from utils.hf_xet_fallback without
+# triggering the load.
 _DEGRADED_ATTRS = {
     "DownloadStallError": _DegradedDownloadStallError,
     "get_hf_download_state": _degraded_get_hf_download_state,
@@ -787,9 +773,9 @@ _DEGRADED_ATTRS = {
 
 
 # Nonzero while a loader has UNSLOTH_ZOO_DISABLE_GPU_INIT set process-wide for its retry. Read by
-# utf8_child_env so a child spawned in that window does not inherit it: unsloth_zoo injects triton
-# and bitsandbytes STUBS when it is set, so a training child would silently run against no-ops.
 # Only counted when the loader introduced the value; an operator who exported it keeps it.
+# utf8_child_env so a child does not inherit it: the zoo injects triton and bitsandbytes STUBS when
+# it is set, so a training child would silently run against no-ops.
 _gpu_init_override_depth = 0
 
 
@@ -995,10 +981,8 @@ def hf_hub_download_with_xet_fallback(
         except Exception:  # noqa: BLE001 — a cache we cannot read just keeps the live root
             pass
     if local_files_only:
-        # Straight to huggingface_hub, after the root switch above (which is pure cache lookups and
-        # is exactly what lets an offline caller reach a file left under the import-time root).
-        # Cancellation is still honoured either side, as the fallback path does it. ``force_download``
-        # is not forwarded: there is nothing to re-fetch offline, and huggingface_hub rejects the pair.
+        # Straight to huggingface_hub after the root switch, which is what lets an offline caller reach a file under the
+        # import-time root. ``force_download`` is not forwarded: hub rejects the pair.
         from huggingface_hub import hf_hub_download
 
         if cancel_event is not None and cancel_event.is_set():
@@ -1015,9 +999,7 @@ def hf_hub_download_with_xet_fallback(
         if cancel_event is not None and cancel_event.is_set():
             raise RuntimeError("Cancelled")
         return path
-    # Omit rather than forward None: an older unsloth_zoo hands `interval` straight to Event.wait(),
-    # where None blocks forever and a hung Xet download never falls back. Omitting also lets the
-    # shared layer pick its per-transport defaults.
+    # Omit rather than forward None: an older unsloth_zoo hands `interval` straight to Event.wait()
     optional: dict[str, Any] = {}
     if stall_timeout is not None:
         optional["stall_timeout"] = stall_timeout

--- a/studio/backend/utils/hf_xet_fallback.py
+++ b/studio/backend/utils/hf_xet_fallback.py
@@ -978,7 +978,7 @@ def hf_hub_download_with_xet_fallback(
                 )
                 if isinstance(elsewhere, str) and Path(elsewhere).is_file():
                     cache_dir = None
-        except Exception:  # noqa: BLE001 — a cache we cannot read just keeps the live root
+        except Exception:  # noqa: BLE001 - a cache we cannot read just keeps the live root
             pass
     if local_files_only:
         # Straight to huggingface_hub after the root switch, which is what lets an offline caller reach a file under the

--- a/studio/backend/utils/hf_xet_fallback.py
+++ b/studio/backend/utils/hf_xet_fallback.py
@@ -656,7 +656,6 @@ def xet_attempts() -> int:
     return min(value, 8)
 
 
-# Degraded stubs, used only when unsloth_zoo is unavailable.
 # --- degraded stubs (used only when unsloth_zoo is unavailable) -------------------------------
 class _DegradedDownloadStallError(RuntimeError):
     """Stub mirror so callers' ``except`` clauses resolve; never raised in degraded mode."""

--- a/studio/backend/utils/hidden_models.py
+++ b/studio/backend/utils/hidden_models.py
@@ -28,17 +28,12 @@ _DEFAULT_EMBEDDING_REPO_IDS = {
     "unsloth/bge-small-en-v1.5",
     "unsloth/bge-small-en-v1.5-GGUF",
 }
-# Local copies do not always retain the repo id. Keep a narrow basename
-# fallback for Unsloth's static default embedder only; configured custom repos
-# remain exact-match-only.
+# Local copies do not always retain the repo id.
 _DEFAULT_EMBEDDING_PATH_BASENAMES = {"bge-small-en-v1.5"}
-# Curated dictation checkpoints (STT, never chat), hidden from the chat
-# inventory and pickers: Transformers safetensors repos (unsloth/whisper-*) and
-# their GGUF companions (unslothai/whisper-*-GGUF). Custom checkpoints are caught
-# by config below, but the GGUF companions carry a raw .bin (no config.json), so
-# they must be listed here by id or they leak into chat pickers. The Qwen3-ASR
-# GGUFs are listed for the same reason: llama.cpp will happily load one as a
-# chat model, where it only answers with transcripts.
+# Curated dictation checkpoints (STT, never chat), hidden from chat inventory and pickers. The
+# GGUF companions carry a raw .bin with no config.json, so config sniffing cannot catch them and
+# they must be listed by id; the Qwen3-ASR GGUFs likewise, since llama.cpp loads one as a chat
+# model that only answers with transcripts.
 _HIDDEN_STT_REPO_IDS = frozenset(
     {
         "unsloth/whisper-tiny",
@@ -57,11 +52,10 @@ _HIDDEN_STT_REPO_IDS = frozenset(
 )
 _HIDDEN_STT_REPO_IDS_LOWER = frozenset(repo_id.lower() for repo_id in _HIDDEN_STT_REPO_IDS)
 
-# Curated Audio-page TTS checkpoints. Unlike the STT set these stay VISIBLE -- the Audio
-# page is where they belong -- but a chat turn on one comes back as synthesized speech,
-# so they must not be chat-loadable. Config sniffing cannot catch them (Orpheus and
-# OuteTTS are LlamaForCausalLM, Spark is Qwen2ForCausalLM) and a GGUF companion carries
-# no tokenizer_config for the codec probe, so the ids answer for those.
+# Curated Audio-page TTS checkpoints, which stay VISIBLE but must not be chat-loadable: a chat
+# turn on one comes back as synthesized speech. Listed by id because config sniffing cannot catch
+# them (Orpheus/OuteTTS are LlamaForCausalLM, Spark is Qwen2ForCausalLM) and a GGUF companion
+# carries no tokenizer_config for the codec probe.
 _CURATED_TTS_REPO_IDS = frozenset(
     {
         "unsloth/orpheus-3b-0.1-ft",
@@ -215,16 +209,13 @@ def is_hidden_model(*values: str | None) -> bool:
             continue
         low = v.lower()
         if _HF_REPO_ID_RE.match(v):
-            # A repo id ("owner/name"): match the hidden set exactly. It is
-            # never a filesystem path, so skip the path/filename checks.
+            # A repo id ("owner/name"): match the hidden set exactly.
             if low in hidden_repo_ids:
                 return True
             continue
-        # Anything else is treated as a filesystem path (the cached snapshot
-        # path, or a local model id). Match the probe by its exact filename and
-        # any configured local-path embedder by exact resolved path. Split on
-        # both separators so a Windows-style path ("...\\stories260K.gguf") is
-        # matched even when this runs on a POSIX interpreter (and vice versa).
+        # Split on both separators so a Windows-style path is matched on a POSIX interpreter and vice versa.
+        # Anything else is a filesystem path: the probe is matched by its exact filename (stories260K.gguf) and a
+        # configured local-path embedder by exact resolved path.
         if low.replace("\\", "/").rsplit("/", 1)[-1] == _PROBE_FILENAME:
             return True
         if _path_basename_is_default_embedder(v):

--- a/studio/backend/utils/host_policy.py
+++ b/studio/backend/utils/host_policy.py
@@ -18,16 +18,14 @@ import ipaddress
 import os
 import socket
 
-# Loopback aliases; any other bind address is treated as network-reachable. Only
-# the exact aliases the rest of the stack assumes for loopback (health checks,
-# banner URLs, run.py all hard-code 127.0.0.1), so other 127.0.0.0/8 addresses
-# are deliberately left out -- they are not supported launch hosts.
+# Only the exact aliases the rest of the stack hard-codes for loopback: other 127.0.0.0/8 addresses are deliberately
+# left out, since they are not supported launch hosts.
+# Health checks, banner URLs and run.py all hard-code 127.0.0.1.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
-# Whether a loopback launch in THIS process auto-enabled the gate. run_server
-# normally runs once per process, but if it is reused with a different host
-# (embedders, tests) a stale loopback default must not carry into a later
-# public bind, so we only ever take back a value we set ourselves.
+# Whether a loopback launch in THIS process auto-enabled the gate.
+# run_server normally runs once per process, but if it is reused with a different host (embedders, tests) we only ever
+# take back a value we set ourselves.
 _auto_enabled = False
 _remote_connector_active = False
 _lan_connector_active = False
@@ -182,11 +180,11 @@ def wildcard_loopback_host(host: str) -> "str | None":
 # Tauri desktop webview origins. api-only serving (the desktop app calling a
 # local backend) locks CORS to these.
 _TAURI_CORS_ORIGINS = (
-    "tauri://localhost",  # Linux/macOS Tauri webview
-    "http://tauri.localhost",  # Windows Tauri webview
-    "http://localhost",  # dev fallback
-    "http://localhost:5173",  # Tauri dev/Vite
-    "http://127.0.0.1:5173",  # Tauri dev/Vite fallback
+    "tauri://localhost",
+    "http://tauri.localhost",
+    "http://localhost",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
 )
 
 
@@ -213,10 +211,8 @@ def apply_stdio_mcp_loopback_default(host: str, *, is_colab: bool = False) -> No
     """
     global _auto_enabled
     current = os.environ.get("UNSLOTH_STUDIO_ALLOW_STDIO_MCP")
-    # If our prior auto-default was changed out from under us (in-process reuse),
-    # relinquish ownership: an explicit =0 is then honored below as a sticky
-    # force-disable, while a cleared var falls back to the host default like a
-    # fresh process.
+    # If our prior auto-default was changed out from under us, relinquish ownership: an explicit =0 is then a sticky
+    # force-disable, while a cleared var falls back to the host default.
     if _auto_enabled and current != "1":
         _auto_enabled = False
     # An explicit operator value is one we did not set; never touch it.

--- a/studio/backend/utils/inference/inference_config.py
+++ b/studio/backend/utils/inference/inference_config.py
@@ -156,6 +156,7 @@ def load_inference_config(model_identifier: str) -> Dict[str, Any]:
 # field -> (env var, static default, min, max, is_int)
 # Precedence per field: an operator pin via UNSLOTH_SAMPLING_* wins even over an explicit client value, then the client
 # value, then the per-model recommendation, then the static schema default.
+# ── Effective sampling resolution for `unsloth run` / `unsloth start` ──────────
 _SAMPLING_FIELDS = {
     "temperature": ("UNSLOTH_SAMPLING_TEMPERATURE", 0.6, 0.0, 2.0, False),
     "top_p": ("UNSLOTH_SAMPLING_TOP_P", 0.95, 0.0, 1.0, False),

--- a/studio/backend/utils/inference/inference_config.py
+++ b/studio/backend/utils/inference/inference_config.py
@@ -17,8 +17,8 @@ from utils.models.model_config import load_model_defaults
 
 logger = get_logger(__name__)
 
-# ── Family-based inference defaults (loaded once, cached) ──────────────
 
+# ── Family-based inference defaults (loaded once, cached) ──────────────
 _FAMILY_DEFAULTS: Optional[Dict[str, Any]] = None
 _FAMILY_PATTERNS: Optional[list] = None
 
@@ -152,16 +152,10 @@ def load_inference_config(model_identifier: str) -> Dict[str, Any]:
     return inference_config
 
 
-# ── Effective sampling resolution for `unsloth run` / `unsloth start` ──────────
-#
-# Per-model recommended sampling is applied to a request only for the fields the
-# client omitted; an operator can pin a field from the CLI via UNSLOTH_SAMPLING_*
-# (a hard override that wins even over an explicit client value). Precedence per
-# field: operator pin -> client explicit -> per-model recommendation -> the static
-# schema default (mirroring ChatCompletionRequest, so behavior is unchanged when
-# nothing is recommended or pinned).
 
 # field -> (env var, static default, min, max, is_int)
+# Precedence per field: an operator pin via UNSLOTH_SAMPLING_* wins even over an explicit client value, then the client
+# value, then the per-model recommendation, then the static schema default.
 _SAMPLING_FIELDS = {
     "temperature": ("UNSLOTH_SAMPLING_TEMPERATURE", 0.6, 0.0, 2.0, False),
     "top_p": ("UNSLOTH_SAMPLING_TOP_P", 0.95, 0.0, 1.0, False),
@@ -174,12 +168,11 @@ _SAMPLING_FIELDS = {
 # Public, ordered tuple of the sampling fields callers resolve.
 SAMPLING_FIELD_NAMES = tuple(_SAMPLING_FIELDS)
 
-# Fields the Unsloth Chat UI adopts as *per-model recommendations* from the backend
-# `.inference` block. Its frontend `mergeBackendRecommendedInference`
-# (presets/preset-policy.ts) seeds exactly these five and never reads repetition_penalty,
-# so the server auto-recommends the same five for request parity. repetition_penalty stays a
-# manual-only knob (client-sent or an UNSLOTH_SAMPLING_REPETITION_PENALTY operator pin),
-# matching the UI where it is never auto-filled per model.
+# The five fields the Chat UI's mergeBackendRecommendedInference seeds, auto-recommended here for
+# request parity. repetition_penalty stays manual-only (client-sent or an operator pin), matching
+# the UI where it is never auto-filled per model.
+# The frontend seeder is mergeBackendRecommendedInference in presets/preset-policy.ts, and the manual pin is
+# UNSLOTH_SAMPLING_REPETITION_PENALTY.
 _UI_RECOMMENDED_FIELDS = ("temperature", "top_p", "top_k", "min_p", "presence_penalty")
 
 

--- a/studio/backend/utils/inference/inference_config.py
+++ b/studio/backend/utils/inference/inference_config.py
@@ -19,6 +19,7 @@ logger = get_logger(__name__)
 
 
 # ── Family-based inference defaults (loaded once, cached) ──────────────
+
 _FAMILY_DEFAULTS: Optional[Dict[str, Any]] = None
 _FAMILY_PATTERNS: Optional[list] = None
 

--- a/studio/backend/utils/inference/inference_config.py
+++ b/studio/backend/utils/inference/inference_config.py
@@ -152,7 +152,6 @@ def load_inference_config(model_identifier: str) -> Dict[str, Any]:
     return inference_config
 
 
-
 # field -> (env var, static default, min, max, is_int)
 # Precedence per field: an operator pin via UNSLOTH_SAMPLING_* wins even over an explicit client value, then the client
 # value, then the per-model recommendation, then the static schema default.

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -452,7 +452,7 @@ def _browser_initiated_elsewhere(request: Any) -> bool:
     try:
         site = request.headers.get("sec-fetch-site")
     except Exception:
-        return True  # unreadable headers: deny
+        return True
     if site is None:
         return False
     return site.strip().lower() != "same-origin"
@@ -506,7 +506,7 @@ def _host_authority_is_direct(request: Any, scope: str) -> bool:
     try:
         host = request.headers.get("host")
     except Exception:
-        return False  # unreadable headers: deny
+        return False
     if not host:
         return True
     host = host.strip()
@@ -526,11 +526,9 @@ def _host_authority_is_direct(request: Any, scope: str) -> bool:
         if separator and not _port_suffix_is_numeric(":" + suffix):
             return False
         literal = literal.lower()
-        # Exactly `localhost`, no trailing root-label dot. Secure Contexts lists
-        # `localhost.` as trustworthy, but WebKit's check is a plain string compare: measured
-        # on WebKit 26.5 a page dialling `http://localhost.:<port>` sends no `Sec-Fetch-*`
-        # while Chromium 151 and Firefox 153 send `cross-site`, so admitting the dotted form
-        # would reopen the absence gap on Safari alone. No client spells it.
+        # Exactly `localhost`, no trailing root-label dot.
+        # Measured on WebKit 26.5, a page dialling `http://localhost.:<port>` sends no `Sec-Fetch-*` while Chromium 151
+        # and Firefox 153 send `cross-site`. No client spells it.
         if literal == "localhost":
             return True
         try:
@@ -696,12 +694,8 @@ def asgi_request_is_keyless(asgi_scope, settings: Optional[tuple[str, bool]] = N
         return True
     if len(authorization) != 1:
         return False
-    # The same parser the dependency uses, not a second hand-rolled split. They disagreed on
-    # `Authorization: bearer  not-needed`: `partition(" ")` left the token as " not-needed"
-    # and reported not-keyless, while the dependency collapsed the space and admitted the
-    # dummy. That shape was therefore keyless to every route but not-keyless to
-    # `KeylessToolPolicyMiddleware`, which decides whether to clamp the tool grant, so it
-    # reached keyless admission with an unclamped tool policy.
+    # The same parser the dependency uses, not a second hand-rolled split: they disagreed on `bearer  not-needed`,
+    # making a shape keyless to every route but not-keyless to the middleware that clamps the tool grant.
     from fastapi.security.utils import get_authorization_scheme_param
 
     scheme, token = get_authorization_scheme_param(authorization[0])

--- a/studio/backend/utils/lan_access_settings.py
+++ b/studio/backend/utils/lan_access_settings.py
@@ -280,8 +280,8 @@ def configure_lan_access(
     resolved_loopback = bool(app_state.lan_access_launch_addresses) and all(
         _normalized_ip(address).is_loopback for address in app_state.lan_access_launch_addresses
     )
-    # An unresolved hostname is launch-managed but never trusted for keyless LAN
-    # admission: request_on_lan_access requires its resolved address set.
+    # An unresolved hostname is launch-managed but never trusted for keyless LAN admission:
+    # request_on_lan_access requires its resolved address set.
     app_state.lan_access_launch_managed = (
         app_state.lan_access_wildcard_bind or not resolved_loopback
     )
@@ -489,7 +489,6 @@ def stop_lan_access(app) -> dict:
     status = lan_access_status(app)
     if status["managed_by"] == "launch":
         raise RuntimeError("launch_managed")
-    # a stop that could not confirm the port is closed leaves the host reachable
     # a stop that could not confirm the port is closed leaves the host reachable,
     # and lan_access keeps the trust flag with the listener state it describes
     if stop_lan_listener():
@@ -504,7 +503,7 @@ def maybe_auto_start_lan_access(app) -> bool:
     try:
         start_lan_access(app)
     except Exception as exc:
-        # an optional preference must never take the whole server down with it
+        # an optional preference must never take the whole server down
         logger.info("LAN access auto-start skipped: %s", exc)
         return False
     return True

--- a/studio/backend/utils/llama_cpp_freshness.py
+++ b/studio/backend/utils/llama_cpp_freshness.py
@@ -121,14 +121,12 @@ def update_download_size_bytes(
     installed_asset = marker.get("asset")
     if not isinstance(installed_asset, str):
         return None
-    # Tag-independent platform suffix: accept the fork's "app-*" bundles and the
-    # upstream ggml-org "ubuntu-*"/"win-*" prebuilts ("windows" before "win").
+    # Tag-independent platform suffix: accept the fork's "app-*" bundles
     m = re.search(r"-((?:linux|ubuntu|windows|win|macos|darwin)-.*)$", installed_asset)
     if not m:
         return None
     suffix = m.group(1)
-    # Upstream ubuntu/win assets live in the marker's binary_repo, not the fork
-    # publish repo; try the publish repo first, then it.
+    # Upstream ubuntu/win assets live in the marker's binary_repo.
     repos = [repo]
     binary_repo = marker.get("binary_repo")
     if isinstance(binary_repo, str) and binary_repo and binary_repo != repo:
@@ -183,8 +181,7 @@ def is_behind(installed: Optional[str], latest: Optional[str]) -> bool:
         return True
     if lb != ib:
         return lb > ib
-    # Same base build, different tags: offer a mix (latest carries a suffix), but
-    # never offer a bare base over a mix install at the same base.
+    # Same base build, different tags: offer a mix (latest carries a suffix)
     return latest != f"b{lb}"
 
 
@@ -199,12 +196,10 @@ def check_prebuilt_freshness(
     behind = installed genuinely older than latest (see is_behind).
     stale = behind AND age >= threshold.
     Fails open on missing data (behind/stale stay False)."""
-    # The marker records both a normalized base tag ("tag", e.g. b9596) and the
-    # full release tag ("release_tag", e.g. b9596-mix-<sha>). Display prefers the
-    # normalized base; comparison uses the FULL identity, since GitHub
-    # /releases/latest returns the full tag_name -- comparing the normalized base
-    # against the full latest is what produced the permanent "downgrade" banner
-    # on every mix release. Deliberately opposite fallbacks.
+    # Display prefers the normalized base tag, comparison uses the FULL identity, since /releases/latest returns the
+    # full tag_name: comparing the two produced a permanent "downgrade" banner.
+    # The marker records a normalized base tag ("tag", e.g. b9596) and the full "release_tag" (b9596-mix-<sha>), with
+    # deliberately opposite fallbacks.
     return _flow.check_freshness(
         binary_path,
         threshold_days = threshold_days,

--- a/studio/backend/utils/llama_cpp_freshness.py
+++ b/studio/backend/utils/llama_cpp_freshness.py
@@ -181,7 +181,8 @@ def is_behind(installed: Optional[str], latest: Optional[str]) -> bool:
         return True
     if lb != ib:
         return lb > ib
-    # Same base build, different tags: offer a mix (latest carries a suffix)
+    # Same base build, different tags: offer a mix (latest carries a suffix), but never offer a bare base
+    # over a mix install at the same base.
     return latest != f"b{lb}"
 
 

--- a/studio/backend/utils/log_redaction.py
+++ b/studio/backend/utils/log_redaction.py
@@ -20,42 +20,36 @@ import re
 
 REDACTED = "<redacted>"
 
-# Terminal control sequences, stripped BEFORE anything is matched. A colorized
-# writer puts an escape between the key and its value (ConsoleRenderer emits
-# "\x1b[36mapi_key\x1b[0m=\x1b[35m<secret>\x1b[0m", and colors default on even
-# off-terminal); the "m" ending "\x1b[36m" is a word character, so every anchored
-# rule below stops matching and the credential goes out untouched.
-#
-# Order matters: OSC (\x1b]) comes before the single-character Fe class, which
-# covers 0x5C-0x5F and would otherwise swallow the "]" and leave the payload.
-# ECMA-48 5.4 (CSI) and 5.6 (OSC / DCS / SOS / PM / APC).
+# Terminal control sequences, stripped BEFORE anything is matched.
+# Order matters: OSC (\x1b]) comes before the single-character Fe class, which covers 0x5C-0x5F and would otherwise
+# swallow the "]". ECMA-48 5.4 (CSI) and 5.6 (OSC / DCS / SOS / PM / APC). A colorized writer puts an escape between key
+# and value, and the "m" ending "\x1b[36m" is a word character, so every anchored rule below stops matching.
 _ANSI_RE = re.compile(
-    r"\x1b\][\s\S]*?(?:\x07|\x1b\\|\x9c)"  # OSC ... BEL / ST
-    r"|\x1b[P^_X][\s\S]*?(?:\x1b\\|\x9c)"  # DCS / PM / APC / SOS ... ST
-    r"|\x1b\[[0-?]*[ -/]*[@-~]"  # CSI (colors, cursor moves)
-    r"|\x1b[@-Z\\-_]"  # other two-character Fe escapes
-    r"|\x9b[0-?]*[ -/]*[@-~]"  # 8-bit CSI
-    r"|[\x9d\x90\x98\x9e\x9f][\s\S]*?(?:\x07|\x9c)"  # 8-bit OSC / DCS / SOS / PM / APC
+    r"\x1b\][\s\S]*?(?:\x07|\x1b\\|\x9c)"
+    r"|\x1b[P^_X][\s\S]*?(?:\x1b\\|\x9c)"
+    r"|\x1b\[[0-?]*[ -/]*[@-~]"
+    r"|\x1b[@-Z\\-_]"
+    r"|\x9b[0-?]*[ -/]*[@-~]"
+    r"|[\x9d\x90\x98\x9e\x9f][\s\S]*?(?:\x07|\x9c)"
 )
 _ANSI_INTRODUCER_RE = re.compile(r"[\x1b\x90\x98\x9b\x9d-\x9f]")
 
-# Key names whose VALUE is a secret. "token" alone is absent on purpose, so
-# n_tokens = 4096 and token_id=128009 survive.
+# Key names whose VALUE is a secret.
+# "token" alone is absent on purpose, so n_tokens = 4096 and token_id=128009 survive.
 _SECRET_KEYS = (
     "authorization|x-api-key|api[-_]?key|apikey|hf[-_]?token|access[-_]?token|"
     "refresh[-_]?token|auth[-_]?token|bearer[-_]?token|client[-_]?secret|"
     "aws_secret_access_key|aws_session_token|wandb[-_]?token|hub[-_]?token|"
-    # Unsloth's own S3 field (models/training.py:60) and its camelCase alias.
-    # Neither is reachable through the bare "secret" alternative (the trailing \b
-    # cannot fire before "_access" or "Access"), and an AWS secret key has no
-    # prefix of its own for a shape rule to catch.
+    # Unsloth's own S3 field and its camelCase alias: neither is reachable through the bare "secret" alternative, and an
+    # AWS secret key has no prefix of its own for a shape rule to catch.
+    # The field is models/training.py:60.
     "secret[-_]?access[-_]?key|"
     "password|passwd|secret"
 )
 
-# No leading \b: "_" is a word character, so \b never fires inside
-# OPENAI_API_KEY / db_password, the shape an env dump or argv line carries. The
-# trailing \b stays, so eos_token_id and secret_sauce_path are left alone.
+# No leading \b: "_" is a word character.
+# \b never fires inside OPENAI_API_KEY / db_password, the shape an env dump or argv line carries; the trailing \b stays,
+# so eos_token_id and secret_sauce_path are left alone.
 _KEY_START = r"(?<![A-Za-z0-9])"
 
 _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
@@ -93,16 +87,10 @@ _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     ),
 )
 
-# key = value / "key": "value" / --api-key value
-#
-# The QUOTED branch wins whenever an opening quote is there, so a quoted
-# credential is consumed to its CLOSING quote. Stopping at whitespace turned
-# password="correct horse battery staple" into password="<redacted> horse
-# battery staple", which reads as masked while leaking all but the first word.
-#
-# "[^\"'\\\n]|\\." rather than a lazy ".*?" so an escaped quote does not end the
-# value early; \n is excluded so an unterminated quote cannot run the mask past
-# its own line.
+# The QUOTED branch wins whenever an opening quote is there: stopping at whitespace turned password="correct horse
+# battery staple" into a mask that leaked all but the first word.
+# The value pattern is "[^\"'\\\n]|\\." rather than a lazy ".*?", so an escaped quote does not end the value early, and
+# \n is excluded so an unterminated quote cannot run the mask past its own line.
 _QUOTED_VALUE = r"(?:[^\"'\\\n]|\\.){6,}"
 _KV_RE = re.compile(
     r"(?i)" + _KEY_START + r"(?P<key>" + _SECRET_KEYS + r")\b"
@@ -115,18 +103,13 @@ _FLAG_RE = re.compile(
     r"(?P<val>(?(q)" + _QUOTED_VALUE + r"|[^\s\"']{6,}))"
 )
 
-# An Authorization value, whatever the scheme. The key/value rule cannot reach
-# it: for "Authorization: Basic dXNlcjpwdw==" the value it captures is "Basic",
-# leaving the credential behind it. Same for a Cookie, which for Unsloth is the
-# UI session that gates these very endpoints.
+# An Authorization value whatever the scheme: the key/value rule captures only "Basic" and leaves the credential behind
+# it. Same for a Cookie, which for Unsloth is the UI session.
 _SCHEMES = ("bearer", "basic", "digest", "token", "apikey")
-# A scheme word only introduces a credential when an Authorization header put it
-# there. Bare "digest sha256:..." and "token hf_..." are ordinary log content,
-# and firing on the word alone blanked the digest a user came here to read.
-# The credential stops at a quote or a structural delimiter, not at the next
-# space: \S+ swallowed the closing quote and every field behind it, so a compact
-# header dict came back as {"Authorization":"Bearer <redacted> with the request
-# id and status gone with it.
+# A scheme word only introduces a credential when an Authorization header put it there, and the credential stops at a
+# quote or structural delimiter: \S+ swallowed the rest of the dict.
+# Bare "digest sha256:..." and "token hf_..." are ordinary log content, and firing on the word alone blanked the digest
+# a user came here to read.
 _CREDENTIAL = r"[^\s\"',}\]]+"
 _AUTH_HEADER_RE = re.compile(
     r"(?i)((?:proxy-)?authorization[\"']?\s*[:=]\s*[\"']?"
@@ -135,10 +118,7 @@ _AUTH_HEADER_RE = re.compile(
 # Bearer is not an English word that shows up in a log on its own, so it keeps
 # a header-less rule; the shape guard still spares "Bearer credentials expired".
 _SCHEME_RE = re.compile(r"(?i)\b(Bearer)(\s+)(" + _CREDENTIAL + r")")
-# MULTILINE: this also runs over exception text, where the header is not on the
-# last line. The optional quote matters: headers are usually logged as a dict,
-# and the pair test never matched a value that opened with a quote, so the
-# session cookie gating these very endpoints went out in the clear.
+# MULTILINE: this also runs over exception text.
 _COOKIE_RE = re.compile(
     r"(?i)\b(?P<key>(?:set-)?cookie)(?P<sep>[\"']?\s*[:=]\s*(?P<q>[\"'])?)(?P<val>\S.*)$",
     re.MULTILINE,
@@ -189,9 +169,7 @@ def _redact_shaped(match: re.Match[str]) -> str:
     return f"{match.group(1)}{match.group(2)}{REDACTED}"
 
 
-# A cookie header is name=value pairs. _COOKIE_RE takes the rest of the line, so
-# without this the length shortcut reads "Cookie: not sent because the origin is
-# cross-site" as a token and masks the diagnosis.
+# A cookie header is name=value pairs.
 _COOKIE_PAIR_RE = re.compile(r"^[A-Za-z0-9_.\-]+=\S")
 
 

--- a/studio/backend/utils/log_retention.py
+++ b/studio/backend/utils/log_retention.py
@@ -64,8 +64,7 @@ def prune_log_dir(
                 saw_protected = True
                 continue
         except OSError:
-            # Dangling symlink, vanished file, or an unreadable directory. Skip the entry
-            # only: one bad name must not disable retention for the whole directory.
+            # Dangling symlink, vanished file, or an unreadable directory.
             continue
         entries.append((stat.st_mtime, path))
 

--- a/studio/backend/utils/mlx_repair.py
+++ b/studio/backend/utils/mlx_repair.py
@@ -536,8 +536,8 @@ def start_mlx_autorepair_if_needed() -> bool:
     epoch = _hw.current_detection_epoch()
     if mlx_stack_available():
         # Asked as the warm's first stage, early enough to race another thread's first transformers
-    # import: CPython hands the loser a partially initialised module, so mlx_lm's chain raises on a
-    # healthy install (#9120).
+        # import: CPython hands the loser a partially initialised module, so mlx_lm's chain raises on a
+        # healthy install (#9120).
         if _hw.overturn_the_mlx_verdict(epoch):
             logger.info(
                 "MLX stack measures usable after the warm, against a chat-only verdict "

--- a/studio/backend/utils/mlx_repair.py
+++ b/studio/backend/utils/mlx_repair.py
@@ -43,36 +43,24 @@ from utils.uv_path_safety import uv_safe_path
 logger = structlog.get_logger(__name__)
 
 DISABLE_ENV_VAR = "UNSLOTH_DISABLE_MLX_AUTOREPAIR"
-# uv's wording when --python names a path it will not install into. Matched on the
-# stable leading clause only: uv appends the offending path and a "run `uv venv`"
-# hint, and has reworded the tail across releases.
+# uv's wording when --python names a path it will not install into, matched on the stable leading
+# clause only: uv appends the offending path and has reworded the tail across releases.
 _UNRESOLVED_PYTHON_MARKER = "No virtual environment or system Python installation found"
-# Minimum versions unsloth-zoo requires on Apple Silicon (its pyproject darwin
-# deps). mlx-vlm especially must be >=0.4.4: an older one still imports but
-# breaks VLM Train/Export, so installing it would wrongly clear chat-only.
-# mlx-lm's floor tracks unsloth-zoo, which needs GenerationBatch.Response and
-# BatchGenerator.next_generated from 0.31.2; it read 0.22.0 here, which would
-# have let a stack too old for batched generation clear the chat-only gate.
+# Minimum versions unsloth-zoo requires on Apple Silicon (its pyproject darwin deps). mlx-vlm especially must be
+# >=0.4.4: an older one still imports but breaks VLM Train/Export, so installing it would wrongly clear chat-only. mlx-
+# lm's floor tracks unsloth-zoo, which needs GenerationBatch.Response and BatchGenerator.next_generated from 0.31.2; it
+# read 0.22.0 here, which would have let a stack too old for batched generation clear the chat-only gate.
 _MLX_MIN_VERSIONS = {"mlx": "0.22.0", "mlx-lm": "0.31.2", "mlx-vlm": "0.4.4"}
 _MLX_PACKAGE_NAMES = tuple(_MLX_MIN_VERSIONS)
 _MLX_RUNTIME_IMPORTS = ("mlx.core", "mlx_lm", "mlx_lm.sample_utils", "mlx_vlm")
-# What the self-heal INSTALLS, as opposed to the floors above, which judge a
-# stack that is already there. Pinned rather than floored because this install is
-# unattended and default-on, and mlx ships breaking changes in patch releases:
-# 0.32.1 broke model loading here (unslothai/unsloth#9466). A floor would fetch
-# whatever shipped since the user last opened Unsloth, unasked.
-#
-# Keep in sync with unsloth-zoo's pyproject darwin deps. mlx-vlm stays a range so
-# the resolver can pick 0.6.15 here, where the installer overrides mlx-vlm's
-# transformers requirement, and 0.6.4 under the plain cap.
-#
-# 0.32.1 is chosen with its known defect, not in ignorance of it: it segfaults at
-# interpreter finalization when a fused Metal custom kernel is the last work a
-# process did, which unsloth-zoo measured and works around in
-# tests/_run_then_exit_hard.py. Staying on 0.32.0 to dodge that would give back
-# mlx#3833, where two fast.metal_kernel instances sharing a name but not a source
-# silently run the first kernel's code for the second. A noisy exit after the work
-# is finished beats wrong numbers from the fused kernels this stack is built on.
+# What the self-heal INSTALLS, as opposed to the floors above, which judge a stack that is already there. Pinned rather
+# than floored because this install is unattended and default-on and mlx ships breaking changes in patch releases:
+# 0.32.1 broke model loading here (unslothai/unsloth#9466). Keep in sync with unsloth-zoo's pyproject darwin deps; mlx-
+# vlm stays a range so the resolver can pick 0.6.15, where the installer overrides mlx-vlm's transformers requirement,
+# and 0.6.4 under the plain cap. 0.32.1 is chosen with its known defect: it segfaults at interpreter finalization when a
+# fused Metal custom kernel is the last work a process did, worked around in tests/_run_then_exit_hard.py, while staying
+# on 0.32.0 would give back mlx#3833, where two fast.metal_kernel instances sharing a name but not a source run the
+# first kernel's code for the second.
 _MLX_INSTALL_SPECS = {
     "mlx": "==0.32.1",
     "mlx-lm": "==0.31.3",
@@ -82,29 +70,18 @@ MLX_PACKAGES = tuple(f"{name}{spec}" for name, spec in _MLX_INSTALL_SPECS.items(
 _MLX_REINSTALL_ARGS = tuple(
     arg for name in _MLX_PACKAGE_NAMES for arg in ("--reinstall-package", name)
 )
-# Require pre-built wheels for the unattended self-heal. A source distribution's
-# PEP 517 build backend runs arbitrary code at install time, and this install is
-# default-on, resolver-driven, and runs before the post-install stack check can
-# reject anything. mlx/mlx-metal ship wheels only (no sdist on PyPI) and
-# mlx-lm/mlx-vlm publish py3-none-any wheels, so requiring wheels does not break a
-# healthy self-heal; if a wheel is genuinely unavailable the install fails and
-# Unsloth stays chat-only (the existing safe fallback) until `unsloth studio update`.
+# Require pre-built wheels for the unattended self-heal: a source distribution's PEP 517 build backend runs arbitrary
+# code at install time, and this install is default-on and runs before the post-install stack check can reject anything.
+# mlx/mlx-metal ship wheels only (no sdist on PyPI) and mlx-lm/mlx-vlm publish py3-none-any wheels, so requiring wheels
+# does not break a healthy self-heal; if a wheel is genuinely unavailable the install fails and Unsloth stays chat-only.
 _ONLY_BINARY_ARG = "--only-binary=:all:"
-# Allowlist of environment variables forwarded to the install subprocess. The
-# self-heal runs without confirmation on the default startup path, so it must not
-# hand resolver/build code the full Unsloth environment. Everything outside this
-# set is dropped, which excludes three dangerous classes by construction:
-#   * secrets (HF_TOKEN, AWS_*, WANDB_API_KEY, ...) that a malicious wheel/sdist
-#     build hook would otherwise read straight out of os.environ;
-#   * package-source redirects (UV_INDEX*, UV_DEFAULT_INDEX, UV_FIND_LINKS,
-#     PIP_INDEX_URL, ...) so a poisoned process env cannot silently repoint the
-#     install at an attacker-controlled index/find-links;
-#   * cache-dir redirects (UV_CACHE_DIR, XDG_CACHE_HOME) so a poisoned env cannot
-#     point uv at an attacker-staged cache (cache poisoning / symlink writes). uv
-#     falls back to its safe user-owned default cache, reused across runs anyway.
-# uv still honours on-disk config (uv.toml / pip.conf), so a corporate mirror
-# configured there keeps working; only process-env redirects are dropped. We set
-# UV_OVERRIDE ourselves in _mlx_install_env, so a poisoned one here is ignored.
+# Allowlist of environment variables forwarded to the install subprocess. The self-heal runs without confirmation on the
+# default startup path, so it must not hand resolver/build code the full Unsloth environment. Dropping everything else
+# excludes three classes by construction: secrets (HF_TOKEN, AWS_*, WANDB_API_KEY) a malicious wheel/sdist build hook
+# would read out of os.environ; package-source redirects (UV_INDEX*, UV_DEFAULT_INDEX, UV_FIND_LINKS, PIP_INDEX_URL)
+# that could repoint the install at an attacker-controlled index; and cache-dir redirects (UV_CACHE_DIR, XDG_CACHE_HOME)
+# that could point uv at an attacker-staged cache. uv still honours on-disk config (uv.toml / pip.conf), so a corporate
+# mirror keeps working, and UV_OVERRIDE is set in _mlx_install_env, so a poisoned one here is ignored.
 _MLX_ENV_ALLOWLIST = frozenset(
     {
         "PATH",
@@ -137,29 +114,24 @@ _MLX_ENV_ALLOWLIST = frozenset(
 )
 _REPAIR_TIMEOUT_S = 900
 
-# Attempt at most once per process; success is sticky (mlx then imports and the
-# guard short-circuits on the next boot).
+# Attempt at most once per process; success is sticky, since mlx then imports and the guard
+# short-circuits on the next boot.
 _attempted = False
 _attempted_lock = threading.Lock()
-# The worker started by start_mlx_autorepair_if_needed, so callers can tell "still
-# installing" from "done, whichever way it went". Written under _attempted_lock together
-# with the latch above, since mlx_repair_in_flight() reads the pair as one state.
+# The worker started by start_mlx_autorepair_if_needed, so callers can tell "still installing" from
+# "done". Written under _attempted_lock with the latch above, which mlx_repair_in_flight() reads as
+# one state.
 _repair_thread: Optional[threading.Thread] = None
-# When that worker started, and the total it is allowed. attempt_mlx_repair times the uv
-# subprocess, but not the mlx_stack_available() imports that verify the install nor the
-# detect_hardware() pass after it -- and those import mlx.core, mlx_lm and mlx_vlm, the
-# imports this module already assumes can park indefinitely on a broken stack. An alive
-# thread was therefore an unbounded answer: a worker parked in them would hold the verdict
-# provisional for the whole session, spinning Train and Video instead of settling into the
-# chat-only state a broken stack has earned. The subprocess keeps its full timeout; this
-# adds the post-install work on top.
+# attempt_mlx_repair times the uv subprocess but not the imports that verify the install, and those
+# can park indefinitely on a broken stack, so an alive thread alone was an unbounded answer: a
+# parked worker would hold the verdict provisional for the whole session.
+# Those imports are mlx.core, mlx_lm and mlx_vlm, reached through mlx_stack_available() and the detect_hardware() pass;
+# the subprocess keeps its full timeout and this adds the post-install work on top.
 _repair_started_at: Optional[float] = None
 _WORKER_BUDGET_S = _REPAIR_TIMEOUT_S + 300
 # Indirected so the tests can drive the budget without sleeping through it.
 _repair_clock = time.monotonic
-# True once the install subprocess has actually run, which is what tells a repair that
-# changed the environment and then failed its own validation apart from one that never
-# touched it. Single-writer: the _attempted latch allows one repair per process.
+# True once the install subprocess has actually run.
 _environment_mutated = False
 
 
@@ -175,14 +147,7 @@ def mlx_available() -> bool:
         return False
 
 
-# An import error is free-form and can be a paragraph: a compiled-against-the-wrong-
-# transformers ImportError carries the hint text, and a dyld failure carries a list of
-# paths tried, and an interrupted install can leave malformed version metadata behind.
-# The blocker line ends up in /api/health and in the Train row's native tooltip, neither
-# of which can render a paragraph, so everything read from outside is folded and cut.
-# Each piece read from outside, and the finished line. Both, because a blocker can hold
-# two of them: a malformed version and the error parsing it are individually short enough
-# and together are not.
+# An import error is free-form and can be a paragraph: a compiled-against-the-wrong
 _BLOCKER_PART_CAP = 80
 _BLOCKER_LINE_CAP = 200
 
@@ -305,9 +270,7 @@ def mlx_repair_in_flight() -> bool:
         return True
     if thread is None or not thread.is_alive():
         return False
-    # Alive is not the same as making progress. See _WORKER_BUDGET_S: the uv call is timed,
-    # the imports that follow it are not, so a worker parked in them would otherwise answer
-    # True for the rest of the process.
+    # Alive is not the same as making progress.
     if started_at is not None and _repair_clock() - started_at >= _WORKER_BUDGET_S:
         return False
     return True
@@ -445,9 +408,9 @@ def attempt_mlx_repair(*, timeout: int = _REPAIR_TIMEOUT_S) -> bool:
     (so a backtracked old mlx-vlm is rejected, not accepted). transformers is held
     at its pinned version so the install can never upgrade it underneath Unsloth."""
     global _environment_mutated
-    # Prepare the constraint inside the try: this runs on a daemon thread, so an
-    # exception here (e.g. tempfile.mkstemp failing on a full disk or bad TMPDIR)
-    # must leave Unsloth chat-only, not crash the background self-heal thread.
+    # Prepare the constraint inside the try: this runs on a daemon thread
+    # An exception here (e.g. tempfile.mkstemp failing on a full disk or a bad TMPDIR) must leave Unsloth chat-only, not
+    # crash the background self-heal thread.
     constraint_path = None
     try:
         constraint_args, constraint_path = _transformers_constraint_args()
@@ -465,10 +428,8 @@ def attempt_mlx_repair(*, timeout: int = _REPAIR_TIMEOUT_S) -> bool:
             )
             return False
         logger.info("MLX self-heal: installing %s", ", ".join(MLX_PACKAGES))
-        # Before the wait, not after it. Every package is passed with
-        # --reinstall-package, so uv removes and replaces them as it goes: a timeout or a
-        # non-zero exit part way through leaves a stack neither the one detection measured
-        # nor the one asked for. Nothing before this line touches the environment.
+        # Before the wait, not after: every package is passed with --reinstall-package, so a timeout part way through
+        # leaves a stack neither the one detection measured nor the one asked for.
         _environment_mutated = True
         result = subprocess.run(
             cmd,
@@ -495,18 +456,6 @@ def attempt_mlx_repair(*, timeout: int = _REPAIR_TIMEOUT_S) -> bool:
     if result.returncode != 0:
         tail = (result.stdout or "")[-2000:]
         if _UNRESOLVED_PYTHON_MARKER in (result.stdout or ""):
-            # uv will not install into this environment at all, so the venv is broken
-            # rather than merely missing MLX, and no install flag recovers it from in
-            # here: `--python <venv>/bin/python`, `--python <venv>` and a bare
-            # VIRTUAL_ENV all report the same error against an interpreter uv cannot
-            # resolve. Only rebuilding the environment fixes it, so name the command
-            # that does. uv's own text says to run `uv venv`, which would build an
-            # environment Unsloth does not manage.
-            #
-            # uv gave up before resolving an interpreter, so it installed nothing and the
-            # stack is exactly as detection last measured it. Take the mark back: a
-            # re-detect here would re-run the mlx imports for a verdict that cannot have
-            # changed, on a host where those imports are already suspect.
             _environment_mutated = False
             logger.warning(
                 "MLX self-heal could not use the Unsloth environment at %s: uv did not "
@@ -536,12 +485,7 @@ def attempt_mlx_repair(*, timeout: int = _REPAIR_TIMEOUT_S) -> bool:
 
 def _run_repair_and_redetect(epoch: Optional[int] = None) -> None:
     repaired = attempt_mlx_repair()
-    # Re-detect after a failed validation too, as long as the install ran. That path has
-    # already changed the environment, and the verdict beside it was measured before the
-    # change: its detail can name a package the install has since put there, or an import
-    # error the install has since replaced. The verdict itself stays chat-only, correctly.
-    # A repair that never ran (opted out, uv refused, subprocess died) is skipped, since
-    # re-detecting there would re-run the mlx imports on a stack nothing has touched.
+    # Re-detect after a failed validation too, as long as the install ran.
     if not repaired and not _environment_mutated:
         return
     try:
@@ -550,12 +494,10 @@ def _run_repair_and_redetect(epoch: Optional[int] = None) -> None:
         # A pip install, so shutdown can land anywhere inside it. Scoping to the epoch read
         # before start() discards the re-detect rather than republish for a dead lifespan.
         with hw.owning_detection_epoch(epoch):
-            hw.detect_hardware()  # flips CHAT_ONLY / DEVICE now that mlx imports
+            hw.detect_hardware()
         if epoch is not None and hw.current_detection_epoch() != epoch:
-            # The scoped pass declined: this repair outlived its lifespan. The install
-            # still succeeded, so the live lifespan holds a verdict measured before mlx
-            # existed and the _attempted latch blocks any later repair. Re-detect under
-            # the live epoch, or a now-capable Mac stays chat-only until a restart.
+            # The scoped pass declined, so this repair outlived its lifespan while the install succeeded: re-detect
+            # under the live epoch or a now-capable Mac stays chat-only until a restart.
             hw.detect_hardware()
         if repaired:
             logger.info(
@@ -593,10 +535,9 @@ def start_mlx_autorepair_if_needed() -> bool:
     # the strength of it. The repair worker shares this epoch rather than a later one.
     epoch = _hw.current_detection_epoch()
     if mlx_stack_available():
-        # Detection asks this as the warm's first stage, early enough to race another thread's
-        # first transformers import: CPython hands the loser a partially initialised module, so
-        # mlx_lm's chain raises on a healthy install (#9120). Usable here means the verdict was
-        # raced. Only the warm's is reachable; with the warm off, a later one stands unreconciled.
+        # Asked as the warm's first stage, early enough to race another thread's first transformers
+    # import: CPython hands the loser a partially initialised module, so mlx_lm's chain raises on a
+    # healthy install (#9120).
         if _hw.overturn_the_mlx_verdict(epoch):
             logger.info(
                 "MLX stack measures usable after the warm, against a chat-only verdict "
@@ -610,22 +551,17 @@ def start_mlx_autorepair_if_needed() -> bool:
         if _attempted:
             return False
         _attempted = True
-        # Built and started inside the lock that claims the latch, so the pair is never
-        # half-published: a reader landing between the two sees "attempted, nothing alive"
-        # and settles the very verdict this repair is about to overturn. The worker never
-        # takes this lock, so the start() handshake cannot deadlock against it.
+        # Built and started inside the lock that claims the latch.
         _repair_thread = threading.Thread(
             target = _run_repair_and_redetect,
             args = (epoch,),
             daemon = True,
             name = "mlx-autorepair",
         )
-        # Stamped before start() so the budget covers the worker's whole life, and under the
-        # same lock as the pair above so a reader never sees a live thread with no deadline.
+        # Stamped before start() so the budget covers the worker's whole life
         _repair_started_at = _repair_clock()
         _repair_thread.start()
-    # Logged outside the lock: a blocked stdout must not hold up mlx_repair_in_flight(),
-    # which /api/health calls on the event loop.
+    # Logged outside the lock: a blocked stdout must not hold up mlx_repair_in_flight()
     logger.warning(
         "Apple Silicon without a usable MLX stack; attempting a one-time background "
         "reinstall of mlx/mlx-lm/mlx-vlm to re-enable Train/Export. "

--- a/studio/backend/utils/model_memory_settings.py
+++ b/studio/backend/utils/model_memory_settings.py
@@ -30,9 +30,7 @@ DEFAULT_NO_RAM_RESERVE = False
 _CACHE_TTL_S = 2.0
 _cache_lock = threading.Lock()
 _cache: dict[str, tuple[float, Any]] = {}
-# Bumped on every write. A read that began before a write must not fill the
-# cache with the value it already fetched, or the new setting would appear to
-# revert for the rest of the TTL and a load could launch contradicting it.
+# Bumped on every write. A read that began before a write must not fill
 _generation: dict[str, int] = {}
 
 

--- a/studio/backend/utils/models/drafters/common.py
+++ b/studio/backend/utils/models/drafters/common.py
@@ -15,13 +15,13 @@ import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
-# model_config imports this module, so the split and quant naming helpers below
-# are pulled in per call rather than at module import time. They are constants
-# and pure functions shared with non-drafter code (gguf_variants, the auto
-# download paths), which is why they stay where they are rather than moving
-# here: this package must not become a second home for the GGUF naming rules.
+# model_config imports this module.
 
 
+# model_config imports this module, so the naming helpers are pulled in per call rather than at import; they stay where
+# they are so this package does not become a second home for them.
+# They are constants and pure functions shared with non-drafter code (gguf_variants, the auto download paths), so the
+# GGUF naming rules keep one home.
 def _drafter_pairing_stem(name: str, *, kind: str) -> str:
     """The model family a drafter filename names, stripped of its own markers.
 
@@ -174,10 +174,8 @@ def split_listing_is_complete(names: Iterable[str], name: str) -> bool:
         r"^" + re.escape(stem) + r"-(\d{5})-of-" + re.escape(match.group(3)) + r"\.gguf$",
         re.IGNORECASE,
     )
-    # Distinct indices inside 1..total, not a count: a mid-publication listing can
-    # hold 00001-of-00002 beside a stray 00003-of-00002, and counting would call
-    # that pair whole while shard 2 is still missing and llama-server cannot open
-    # the set. _drafter_split_is_complete answers the on-disk version the same way.
+    # Distinct indices inside 1..total, not a count: a mid-publication listing can hold 00001-of-00002 beside a stray
+    # 00003-of-00002, and counting would call that pair whole.
     seen = set()
     for other in names:
         if Path(other).parent != parent:

--- a/studio/backend/utils/models/drafters/dflash.py
+++ b/studio/backend/utils/models/drafters/dflash.py
@@ -122,16 +122,11 @@ def detect_dflash_file(
             lower = candidate.name.lower()
             if not lower.endswith(".gguf"):
                 continue
-            # Prefix form only, deliberately. The shared companion predicates
-            # (_drafter_path_kind, is_mtp_drafter_path) know DFlash by the
-            # dflash- prefix, so accepting <model>-dflash.gguf here would let one
-            # file be a drafter for discovery AND a selectable Q8_0 main model in
-            # the quant picker, and choosing that variant would hand llama-server
-            # the drafter as the target. Teaching the predicate the suffix
-            # instead would hide a real model whose name merely ends in DFlash,
-            # which is the case #7811 exists to protect, so detection gives the
-            # form up rather than the picker giving up a model. No published
-            # DFlash sidecar uses it; the shipped one is dflash-kquant.gguf.
+            # Prefix form only: the shared predicates know DFlash by the dflash- prefix, so accepting
+            # <model>-dflash.gguf would make one file both a drafter and a selectable main model (#7811).
+            # The predicates are _drafter_path_kind / is_mtp_drafter_path, and the accepted file would also be a
+            # selectable Q8_0 main model. No published DFlash sidecar uses the suffix form; the shipped one is dflash-
+            # kquant.gguf.
             if not lower.startswith("dflash-"):
                 # Every other GGUF in the folder is a weight some sidecar could
                 # be naming. Recorded so a sidecar belonging to a NEIGHBOUR can
@@ -141,11 +136,9 @@ def detect_dflash_file(
             try:
                 # Collapse a split copy to shard 1 before ranking.
                 launch = _local_gguf_load_path(candidate)
-                # is_file() follows the link, so this also drops a dangling
-                # snapshot symlink and a directory named like a sidecar. Without
-                # it --model-draft gets a path llama-server cannot open, which
-                # fails the whole load rather than falling back to no
-                # speculation (detect_dspark_file guards the same way).
+                # is_file() follows the link, so this also drops a dangling snapshot symlink and a directory named like
+                # a sidecar, which --model-draft cannot open and which fails the whole load.
+                # detect_dspark_file guards the same way.
                 if not (launch.is_file() and _drafter_split_is_complete(launch)):
                     continue
                 resolved = launch.resolve()
@@ -156,18 +149,11 @@ def detect_dflash_file(
             seen.add(resolved)
             candidates.append(launch)
 
-    # A sidecar naming a family that belongs to a NEIGHBOUR weight is that
-    # neighbour's drafter, not a generic one. _drafter_matches_weight is False
-    # both for it and for a sidecar naming no family (dflash-kquant.gguf), so
-    # ranking alone bucketed the two together and precision could float the
-    # foreign one to the top: loading model B beside dflash-model-A-Q8_0.gguf
-    # and dflash-kquant.gguf launched model A's drafter for model B. Both carry
-    # a real dflash header, so the architecture check behind the ranking cannot
-    # catch it. _drafter_names_other_weight decides against the weights actually
-    # present, which keeps the published unpaired sidecar eligible (its stem,
-    # "kquant", names no file here) without hardcoding which stems are precision
-    # tokens. Shared with the remote paths through dflash_repo_preference_key,
-    # so a download and a local scan agree on which sidecar belongs here.
+    # A sidecar naming a NEIGHBOUR weight's family is that neighbour's drafter: ranking alone floated the foreign one to
+    # the top, launching model A's drafter for model B.
+    # Loading model B beside dflash-model-A-Q8_0.gguf and dflash-kquant.gguf launched model A's drafter for model B, and
+    # both carry a real dflash header, so the architecture check cannot catch it. _drafter_names_other_weight decides
+    # against the weights actually present and is shared with the remote paths through dflash_repo_preference_key.
     if weight_name is not None and other_weights:
         kept: list[Path] = []
         for candidate in candidates:
@@ -181,12 +167,8 @@ def detect_dflash_file(
         candidates = kept
 
     for candidate in sorted(candidates, key = _rank):
-        # Resolve and validate before opening anything. A dflash-*.gguf in a
-        # directory reached through a native grant can be a symlink whose target
-        # sits outside the lease, and ``accept`` is what decides that; reading the
-        # header first opened the target before the answer arrived, which a later
-        # rejection cannot undo. Callers without a grant pass accept = None and
-        # see the same candidates in the same order as before.
+        # Resolve and validate before opening anything: a dflash-*.gguf reached through a native grant can be a symlink
+        # outside the lease, and reading the header first cannot be undone.
         try:
             launch = _drafter_launch_path(candidate)
         except OSError:

--- a/studio/backend/utils/models/gguf_metadata.py
+++ b/studio/backend/utils/models/gguf_metadata.py
@@ -56,12 +56,10 @@ _STRING_CACHE: Dict[Tuple[_CacheKey, str], Optional[str]] = {}
 # means the file could not be read or parsed, so callers can fail closed.
 _CLASSIFIER_HEAD_CACHE: Dict[_CacheKey, Optional[bool]] = {}
 
-# GGUF header dims for the staged/deferred-load UI: context_length, layer_count
-# (block_count), and moe_layer_count (block_count minus leading dense layers; 0
-# if not MoE). One cached pass fills all three so the staged sheet can size every
-# slider before the model loads. None = unreadable / not a GGUF. The native
-# training context length (``{arch}.context_length``) the UI shows before a model
-# loads is read from here via read_gguf_context_length.
+# GGUF header dims for the staged UI in one cached pass (context_length, layer_count, moe_layer_count) so the staged
+# sheet can size every slider before the model loads.
+# None = unreadable / not a GGUF, and the native ``{arch}.context_length`` the UI shows before a load is read from here
+# via read_gguf_context_length.
 _DIMS_CACHE: Dict[_CacheKey, Optional[Dict[str, Optional[int]]]] = {}
 
 
@@ -116,7 +114,7 @@ def _parse_gguf_header(path: str) -> Optional[Dict[str, str]]:
                     if len(klen_bytes) < 8:
                         break
                     klen = struct.unpack("<Q", klen_bytes)[0]
-                    if klen > 1 << 20:  # 1 MB sanity bound
+                    if klen > 1 << 20:
                         break
                     kbytes = f.read(klen)
                     if len(kbytes) < klen:
@@ -132,7 +130,7 @@ def _parse_gguf_header(path: str) -> Optional[Dict[str, str]]:
                         if len(slen_bytes) < 8:
                             break
                         slen = struct.unpack("<Q", slen_bytes)[0]
-                        if slen > 1 << 22:  # 4 MB sanity bound
+                        if slen > 1 << 22:
                             break
                         sbytes = f.read(slen)
                         if len(sbytes) < slen:
@@ -206,7 +204,7 @@ def _parse_gguf_arch_uints(path: str, wanted_suffixes: frozenset[str]) -> Option
                     if len(klen_bytes) < 8:
                         break
                     klen = struct.unpack("<Q", klen_bytes)[0]
-                    if klen > 1 << 20:  # 1 MB sanity bound
+                    if klen > 1 << 20:
                         break
                     kbytes = f.read(klen)
                     if len(kbytes) < klen:
@@ -222,7 +220,7 @@ def _parse_gguf_arch_uints(path: str, wanted_suffixes: frozenset[str]) -> Option
                         if len(slen_bytes) < 8:
                             break
                         slen = struct.unpack("<Q", slen_bytes)[0]
-                        if slen > 1 << 22:  # 4 MB sanity bound
+                        if slen > 1 << 22:
                             break
                         sbytes = f.read(slen)
                         if len(sbytes) < slen:
@@ -273,8 +271,7 @@ def _parse_gguf_staged_dims(path: str) -> Optional[Dict[str, Optional[int]]]:
         return None
     ctx = vals.get("context_length")
     block = vals.get("block_count")
-    # A real context/layer count is positive; treat 0/garbage as absent so the
-    # UI never builds a slider with max < min.
+    # A real context/layer count is positive; treat 0/garbage as absent
     context_length = ctx if ctx and ctx > 0 else None
     layer_count = block if block and block > 0 else None
     # MoE layer count = block_count - leading dense layers, only when experts
@@ -293,17 +290,17 @@ def _parse_gguf_staged_dims(path: str) -> Optional[Dict[str, Optional[int]]]:
 
 # Strings (8) and arrays (9) are handled inline.
 _FIXED_VTYPE_SIZES: Dict[int, int] = {
-    0: 1,  # uint8
-    1: 1,  # int8
-    2: 2,  # uint16
-    3: 2,  # int16
-    4: 4,  # uint32
-    5: 4,  # int32
-    6: 4,  # float32
-    7: 1,  # bool
-    10: 8,  # uint64
-    11: 8,  # int64
-    12: 8,  # float64
+    0: 1,
+    1: 1,
+    2: 2,
+    3: 2,
+    4: 4,
+    5: 4,
+    6: 4,
+    7: 1,
+    10: 8,
+    11: 8,
+    12: 8,
 }
 
 
@@ -316,7 +313,7 @@ def _skip_gguf_value(f, vtype: int) -> bool:
         if len(slen_bytes) < 8:
             return False
         slen = struct.unpack("<Q", slen_bytes)[0]
-        if slen > 1 << 30:  # 1 GB sanity bound
+        if slen > 1 << 30:
             return False
         f.seek(slen, 1)
         return True
@@ -452,7 +449,7 @@ def _parse_gguf_bool(path: str, wanted_key: str) -> Optional[bool]:
                     if len(klen_bytes) < 8:
                         break
                     klen = struct.unpack("<Q", klen_bytes)[0]
-                    if klen > 1 << 20:  # 1 MB sanity bound
+                    if klen > 1 << 20:
                         break
                     kbytes = f.read(klen)
                     if len(kbytes) < klen:
@@ -767,11 +764,10 @@ def pairing_score(
     return 0
 
 
-# GGUF ``general.architecture`` values that intrinsically identify embedding
-# models in llama.cpp. Generic ``bert`` is deliberately absent: without
-# pooling_type its required CLS/MEAN pooling cannot be recovered safely.
-# A ``cls.*`` tensor makes an encoder a sequence-classification/reranker model
-# instead, so architecture matches are gated on the tensor table below.
+# GGUF architectures that intrinsically identify embedding models. Generic ``bert`` is
+# deliberately absent: without pooling_type its required CLS/MEAN pooling cannot be recovered. A
+# ``cls.*`` tensor makes an encoder a reranker instead, so matches are gated on the tensor table.
+# The values are GGUF ``general.architecture`` strings, as llama.cpp defines them.
 GGUF_EMBEDDING_ARCHITECTURES: frozenset[str] = frozenset(
     {
         "modern-bert",
@@ -840,9 +836,8 @@ def is_gguf_embedding_model(
 
     arch = (architecture or meta.get("general.architecture") or "").strip().lower()
     if arch == "bert":
-        # A classifier head can prove that generic BERT is a reranker, but its
-        # absence cannot recover the missing pooling strategy. llama-server
-        # otherwise defaults to NONE and /v1/embeddings returns HTTP 400.
+        # A classifier head can prove that generic BERT is a reranker
+        # llama-server otherwise defaults to NONE and /v1/embeddings returns HTTP 400.
         return False
     if is_gguf_embedding_architecture(arch):
         # Generic BERT-family architectures also back cross-encoder rerankers.
@@ -852,9 +847,7 @@ def is_gguf_embedding_model(
     return any(_has_embedding_name_hint(value) for value in name_candidates)
 
 
-# ── speech / codec architectures ────────────────────────────────────────────
 
-# Not defined here, and deliberately not re-exported either: they live in the leaf module
-# ``utils.gguf_archs``, because importing anything from THIS package runs
-# ``utils.models.__init__``, which pulls in ``model_config`` and therefore PyYAML, and
-# ``core.inference.llama_cpp`` needs the verdict at import time. Import it from there.
+# Deliberately not re-exported: importing anything from THIS package runs utils.models.__init__,
+# which pulls in model_config and therefore PyYAML, while core.inference.llama_cpp needs the
+# verdict at import time. Import it from utils.gguf_archs.

--- a/studio/backend/utils/models/gguf_metadata.py
+++ b/studio/backend/utils/models/gguf_metadata.py
@@ -847,7 +847,6 @@ def is_gguf_embedding_model(
     return any(_has_embedding_name_hint(value) for value in name_candidates)
 
 
-
 # Deliberately not re-exported: importing anything from THIS package runs utils.models.__init__,
 # which pulls in model_config and therefore PyYAML, while core.inference.llama_cpp needs the
 # verdict at import time. Import it from utils.gguf_archs.

--- a/studio/backend/utils/models/model_identity.py
+++ b/studio/backend/utils/models/model_identity.py
@@ -81,10 +81,9 @@ def restore_hf_cache_repo_identity(
         "_name_or_path",
         repo_id,
     )
-    # PreTrainedModel.__init__ copies config.name_or_path onto the instance, so updating the config
-    # alone leaves this stale. PEFT reads exactly this slot (mapping_func.py) and overwrites
-    # base_model_name_or_path with it, which is how a pinned snapshot path ends up in
-    # adapter_config.json, the checkpoints, the run card and every export.
+    # PreTrainedModel.__init__ copies config.name_or_path onto the instance, and PEFT reads exactly this slot, which is
+    # how a pinned snapshot path reaches adapter_config.json and every export.
+    # PEFT reads exactly this slot (mapping_func.py) and overwrites base_model_name_or_path with it.
     changed = _set_standard_identity(model, "name_or_path", repo_id) or changed
     changed = _set_standard_identity(model, "_hf_repo", repo_id) or changed
 

--- a/studio/backend/utils/native_path_leases.py
+++ b/studio/backend/utils/native_path_leases.py
@@ -119,11 +119,10 @@ def run_without_native_path_secret(
 ) -> Any:
     """Run a multiprocessing child target without the native path lease secret."""
 
-    # Runs in the spawned child: bind it to the parent's death (Linux), since
-    # multiprocessing children cannot be given a preexec_fn by the parent. Shared
-    # entrypoint for the inference/export/training/data-recipe workers.
-    # Two try blocks, not one: allow_child_processes is the newer name, so on an
-    # older process_lifetime.py a combined import would lose the binding as well.
+    # Runs in the spawned child to bind it to the parent's death, since multiprocessing children get no
+    # preexec_fn. Shared entrypoint for the inference/export/training/data-recipe workers. Two try
+    # blocks, because allow_child_processes is the newer name: on an older process_lifetime.py a
+    # combined import would lose the binding as well.
     try:
         from utils.process_lifetime import bind_current_process_to_parent_lifetime
         bind_current_process_to_parent_lifetime()

--- a/studio/backend/utils/native_tls.py
+++ b/studio/backend/utils/native_tls.py
@@ -47,8 +47,8 @@ _DEFAULT_ON_PLATFORMS = ("darwin", "win32")
 _TRUTHY = ("1", "true", "yes")
 _FALSEY = ("0", "false", "no")
 
-# Resolved from this file so it is right in a checkout and an installed wheel
-# alike. Never build it from the cwd or a hardcoded "studio/backend".
+# Resolved from this file so it is right in a checkout and an installed wheel alike; never built
+# from the cwd or a hardcoded "studio/backend".
 _VENDOR_DIR = str(Path(__file__).resolve().parent.parent / "vendor")
 
 _logger = logging.getLogger(__name__)
@@ -65,11 +65,10 @@ def native_tls_enabled() -> bool:
     return sys.platform in _DEFAULT_ON_PLATFORMS
 
 
-# Children that cannot import this module (the `python -c` probes,
-# prebuilt_core.py) carry the gate as source; generating it from the same
-# constants stops it drifting from native_tls_enabled(). The child supplies os,
-# sys and _TRUSTSTORE_VENDOR itself, which is what keeps the gate identical
-# everywhere despite each child locating the vendor directory differently.
+# Children that cannot import this module carry the gate as source, generated from the same constants so it cannot drift
+# from native_tls_enabled().
+# The children that cannot import it are the `python -c` probes and prebuilt_core.py, and each supplies os, sys and
+# _TRUSTSTORE_VENDOR itself.
 _INLINE_GATE = """\
 _flag = os.environ.get({env!r}, '').strip().lower()
 if _flag in {truthy!r} or (_flag not in {falsey!r} and sys.platform in {platforms!r}):
@@ -113,9 +112,8 @@ def activate_native_tls() -> bool:
         return True
     if not native_tls_enabled():
         return False
-    # uv's rustls ignores in-process injection (uv >= 0.11 reads UV_SYSTEM_CERTS,
-    # older reads UV_NATIVE_TLS). Mirror one value across both: uv takes either as
-    # an opt-in, so an opt-out in one spelling must carry to the other.
+    # uv's rustls ignores in-process injection (uv >= 0.11 reads UV_SYSTEM_CERTS, older reads UV_NATIVE_TLS). Mirror one
+    # value across both: uv takes either as an opt-in, so an opt-out in one spelling must carry to the other.
     os.environ.setdefault("UV_SYSTEM_CERTS", os.environ.get("UV_NATIVE_TLS", "1"))
     os.environ.setdefault("UV_NATIVE_TLS", os.environ["UV_SYSTEM_CERTS"])
     # append, not insert(0): a user-installed truststore must win over the vendored copy.

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -25,10 +25,9 @@ _NODE_VERSION_PROBE_TIMEOUT_SECONDS = 10
 _IS_WINDOWS = os.name == "nt"
 
 
-# Keep in sync with the setup scripts' Node floor: Get-NodeDecision (setup.ps1) /
-# decide_node_source (setup.sh). Vite 8 needs Node ^20.19 || >=22.12 || >=23.
-# Keep in sync with decide_node_source (setup.sh) / Get-NodeDecision (setup.ps1): both
-# require npm >= 11 before accepting a system runtime.
+# Keep in sync with the setup scripts' floors, decide_node_source (setup.sh) / Get-NodeDecision
+# (setup.ps1): Vite 8 needs Node ^20.19 || >=22.12 || >=23, and both require npm >= 11 before
+# accepting a system runtime.
 _NPM_MAJOR_FLOOR = 11
 
 
@@ -95,8 +94,7 @@ def managed_node_bin_dir() -> Path | None:
         return None
 
 
-# Success-only memoization, like _resolved_node: the installer may finish after the
-# first probe, so a negative verdict must not stick until restart.
+# Success-only memoization, like _resolved_node: the installer may finish
 _managed_node_ok: bool = False
 _usable_node_cache: dict[tuple[str, str | None], bool] = {}
 
@@ -210,8 +208,8 @@ def path_with_managed_node(
     # An empty component means the working directory on POSIX; dropping it loses it.
     entries = current.split(os.pathsep) if current else []
     normalized = os.path.normcase(os.path.normpath(bin_str))
-    # Drop any existing occurrence rather than keep it: we only get here when the PATH
-    # resolves no usable runtime, so a managed dir sitting behind a stale one must move up.
+    # Drop any existing occurrence rather than keep it: this runs only when PATH resolves no usable
+    # runtime, so a managed dir sitting behind a stale one must move up.
     kept = [
         entry
         for entry in entries
@@ -256,9 +254,8 @@ def _probe_version(
     return meets_floor(result.stdout)
 
 
-# Memoize ONLY a confirmed version-adequate executable: the installer runs in a
-# separate process and may finish after the first probe here, so a negative /
-# last-resort result must not be cached (it would stick until a backend restart).
+# Memoize ONLY a confirmed version-adequate executable: the installer runs in a separate process
+# and may finish after the first probe, so a negative result must not stick until a restart.
 _resolved_node: str | None = None
 
 

--- a/studio/backend/utils/openai_auto_switch_settings.py
+++ b/studio/backend/utils/openai_auto_switch_settings.py
@@ -404,6 +404,7 @@ def set_openai_auto_switch(
 # Legacy entries hold just {llama_extra_args, max_seq_length}, and a write replaces the fields it expresses, so the
 # route carries `llama_extra_args` over. Known gap: the picker's global fallbacks for GPU memory mode and speculative
 # decoding live in browser localStorage, so an API load following the global gets the default.
+# --- Per-model launch config -------------------------------------------------
 VALID_KV_CACHE_DTYPES = frozenset(
     {"f16", "bf16", "q8_0", "q4_0", "q4_1", "q5_0", "q5_1", "iq4_nl", "f32"}
 )

--- a/studio/backend/utils/openai_auto_switch_settings.py
+++ b/studio/backend/utils/openai_auto_switch_settings.py
@@ -397,16 +397,13 @@ def set_openai_auto_switch(
     )
 
 
-# --- Per-model launch config -------------------------------------------------
-#
-# An override is the server-side twin of the UI's per-model config, mirrored on every save
-# so an API load applies the same launch settings the picker would. Legacy entries hold just
-# {llama_extra_args, max_seq_length}. Every field is optional and absent means "app default";
-# a write replaces the fields it expresses, so the route carries `llama_extra_args` over.
-# Known gap: the picker's global fallbacks for GPU memory mode and speculative decoding live
-# in browser localStorage, so an API load of a model following the global gets the default.
 
-# Mirrors _valid_cache_types in core/inference/llama_cpp.py.
+# An override is the server-side twin of the UI's per-model config, mirrored on every save so an API
+# load applies the same launch settings the picker would; every field is optional and absent means
+# "app default". Mirrors _valid_cache_types in core/inference/llama_cpp.py.
+# Legacy entries hold just {llama_extra_args, max_seq_length}, and a write replaces the fields it expresses, so the
+# route carries `llama_extra_args` over. Known gap: the picker's global fallbacks for GPU memory mode and speculative
+# decoding live in browser localStorage, so an API load following the global gets the default.
 VALID_KV_CACHE_DTYPES = frozenset(
     {"f16", "bf16", "q8_0", "q4_0", "q4_1", "q5_0", "q5_1", "iq4_nl", "f32"}
 )
@@ -437,11 +434,11 @@ VALID_SPECULATIVE_TYPES = frozenset(
 DRAFT_N_MAX_SPEC_TYPES = frozenset(
     {"mtp", "mtp+ngram", "draft-mtp", "dspark", "draft-dspark", "dflash", "draft-dflash"}
 )
-# Only these load a separate draft model, and so a draft context for the dtype to
-# apply to (mirrors SEPARATE_DRAFT_MODEL_SPEC_TYPES in the UI).
+# Only these load a separate draft model, and so a draft context for the dtype to apply to.
+# Mirrors SEPARATE_DRAFT_MODEL_SPEC_TYPES in the UI.
 SEPARATE_DRAFT_MODEL_SPEC_TYPES = frozenset({"dspark", "draft-dspark", "dflash", "draft-dflash"})
-# Mirrors _LOAD_MODE_VALUES in llama_server_args.py. "auto" is the llama.cpp
-# default and is not stored: an entry holding it would pin what a build may redefine.
+# Mirrors _LOAD_MODE_VALUES in llama_server_args.py. "auto" is the llama.cpp default and is not
+# stored: an entry holding it would pin what a build may redefine.
 VALID_LOAD_MODES = frozenset({"none", "mmap", "mlock", "mmap+mlock", "dio"})
 # Mirrors CTX_CHECKPOINTS_MAX / CACHE_RAM_MAX_MIB in llama_server_args.py.
 CTX_CHECKPOINTS_MAX = 256
@@ -451,8 +448,7 @@ VALID_GPU_MEMORY_MODES = frozenset({"auto", "manual"})
 # Mirrors MLX_KV_BITS_CHOICES in core/inference/mlx_inference.py; a set, not a range.
 VALID_MLX_KV_BITS = frozenset({8, 6, 5, 4, 3, 2})
 
-# Mirrors PARALLEL_MIN/MAX in llama_server_args.py. Mirrored not imported: that module owns
-# the extra-args allow-list this one must stay out of.
+# Mirrors PARALLEL_MIN/MAX in llama_server_args.py.
 PARALLEL_SLOTS_MIN = 1
 PARALLEL_SLOTS_MAX = 64
 
@@ -534,8 +530,8 @@ def normalize_model_override(
     speculative_type = _clean_str(payload.get("speculative_type"), VALID_SPECULATIVE_TYPES)
     if speculative_type:
         entry["speculative_type"] = speculative_type
-        # Only the modes that launch a drafter with a configurable depth (MTP,
-        # DSpark and DFlash); storing it otherwise shows an edit the loader ignores.
+        # Only the modes that launch a drafter with a configurable depth
+        # Those modes are MTP, DSpark and DFlash; storing it otherwise shows an edit the loader ignores.
         if speculative_type in DRAFT_N_MAX_SPEC_TYPES:
             spec_draft_n_max = _bounded_int(payload.get("spec_draft_n_max"), minimum = 1, maximum = 16)
             if spec_draft_n_max:
@@ -583,8 +579,9 @@ def normalize_model_override(
     if _coerce_bool(payload.get("tensor_parallel")):
         entry["tensor_parallel"] = True
 
-    # Stored only when set, like tensor_parallel: absent means the default, so an
-    # override that never touched the switch does not pin it off for a later load.
+    # Stored only when set.
+    # Like tensor_parallel: absent means the default, so an override that never touched the switch does not pin it off
+    # for a later load.
     if _coerce_bool(payload.get("disable_vision")):
         entry["disable_vision"] = True
 
@@ -666,11 +663,7 @@ def model_override_load_kwargs(override: dict[str, Any], *, is_gguf: bool) -> di
         kwargs["max_seq_length"] = max_seq_length
     stored_extra_args = override.get("llama_extra_args")
     if stored_extra_args:
-        # Sanitized here because this is where stored data becomes a request: the
-        # load treats an explicit list as the caller's own and refuses a managed
-        # flag with a 400, so an override written before a name was denylisted would
-        # break every auto-switch and idle reload of that model until someone
-        # rewrote it by hand. The inheritance and settings-save paths do the same.
+        # Sanitized here because this is where stored data becomes a request
         from core.inference.llama_server_args import drop_managed_flags
 
         kept, dropped = drop_managed_flags(stored_extra_args)
@@ -718,26 +711,19 @@ def model_override_load_kwargs(override: dict[str, Any], *, is_gguf: bool) -> di
             kwargs["gpu_ids"] = override["gpu_ids"]
 
     if kwargs.get("llama_extra_args"):
-        # One entry can hold a pass-through flag *and* the first-class field it shadows: the
-        # settings page has no control for flags, so a save carries the stored ones over
-        # (routes/settings.py) while writing the field just edited, and a legacy or
-        # API-authored entry can start out that way. Sending both explicitly puts the flag
-        # after Unsloth's own on the command line, where llama.cpp's last-wins parse hands it
-        # the load, so a stale "--ctx-size 8192" would quietly outrank a freshly saved 32768.
-        # The /load route strips exactly these groups off inherited extras
-        # (_resolve_inherited_extra_args); the stripper is imported rather than mirrored so
-        # the two paths cannot drift over which flag belongs to which group -- the allow-list
-        # this module stays out of is validate_extra_args, which remains the caller's job.
+        # One entry can hold a pass-through flag AND the field it shadows, and llama.cpp's last-wins parse would hand
+        # the load the stale flag, so the /load stripper is imported, not mirrored.
+        # The settings page has no control for flags, so a save carries the stored ones over (routes/settings.py); the
+        # imported stripper is _resolve_inherited_extra_args, and the allow-list this module stays out of is
+        # validate_extra_args.
         from core.inference.llama_server_args import (
             matches_explicit_ctx_override,
             strip_shadowing_flags,
         )
 
-        # Context's load-time value is a VRAM-fit target, not an allocation, so a
-        # MATCHING -c/--ctx-size is the user's opt-in to exceed the safe threshold
-        # and survives; /props then publishes what was really allocated. Stale and
-        # malformed flags are still stripped. The test lives beside the stripper
-        # because /load's inheritance path asks it too and must not drift.
+        # Context's load-time value is a VRAM-fit target.
+        # A MATCHING -c/--ctx-size is the user's opt-in to exceed the safe threshold and survives, while stale and
+        # malformed flags are still stripped; /props then publishes what was really allocated.
         matching_explicit_ctx = matches_explicit_ctx_override(
             kwargs["llama_extra_args"], kwargs.get("max_seq_length")
         )
@@ -771,8 +757,7 @@ def _looks_like_filesystem_path(model_id: str) -> bool:
     return len(model_id) >= 3 and model_id[1] == ":" and model_id[2] in ("\\", "/")
 
 
-# The case-insensitive path shapes. Must stay in step with features/hub/lib/model-identity.ts,
-# which folds these before storing, or a stored key becomes unreachable.
+# The case-insensitive path shapes. Must stay in step with features/hub/lib/model-identity.ts
 _WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
 _WSL_DRIVE_PATH = re.compile(r"^/mnt/[A-Za-z](?:/|$)")
 
@@ -800,8 +785,7 @@ def _fold_case_insensitive_path(model_id: str) -> Optional[str]:
     return trimmed.casefold()
 
 
-# A quant label may carry a bits-per-weight modifier ("IQ4_XS-3.53bpw"). The two label helpers
-# disagree on keeping it, so readers of a stored key must accept both forms.
+# A quant label may carry a bits-per-weight modifier ("IQ4_XS-3.53bpw").
 _BPW_SUFFIX = re.compile(r"-[0-9]+(?:\.[0-9]+)?bpw$", re.IGNORECASE)
 _MAX_QUANT_SUFFIX_LEN = 64
 
@@ -887,8 +871,9 @@ def _folded_override_matches(model_id: str, overrides: dict) -> list[str]:
             def fold(key: str) -> Optional[str]:
                 return _fold_case_insensitive_path(key)
         else:
-            # POSIX: the path stays case-sensitive, but the browser lowercases the quant, so
-            # "/models/Foo:q4_k_m" must be reachable from the scanner's "/models/Foo:Q4_K_M".
+            # POSIX: the path stays case-sensitive.
+            # The browser lowercases the quant, so "/models/Foo:q4_k_m" must be reachable from the scanner's
+            # "/models/Foo:Q4_K_M".
             folded = _fold_posix_path_variant(model_id)
 
             def fold(key: str) -> Optional[str]:

--- a/studio/backend/utils/openai_auto_switch_settings.py
+++ b/studio/backend/utils/openai_auto_switch_settings.py
@@ -397,7 +397,6 @@ def set_openai_auto_switch(
     )
 
 
-
 # An override is the server-side twin of the UI's per-model config, mirrored on every save so an API
 # load applies the same launch settings the picker would; every field is optional and absent means
 # "app default". Mirrors _valid_cache_types in core/inference/llama_cpp.py.

--- a/studio/backend/utils/parent_watchdog.py
+++ b/studio/backend/utils/parent_watchdog.py
@@ -2,7 +2,7 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 # Exits a desktop-owned backend when the app that spawned it dies without
-# running its cleanup. The orphan would otherwise keep the port and make the
+# running its cleanup. The orphan would otherwise keep the port and make
 # next launch's preflight refuse to start.
 
 from __future__ import annotations
@@ -28,11 +28,8 @@ def _fire(on_parent_exit: Callable[[], None]) -> None:
 
 
 def _watch_unix(parent_pid, on_parent_exit, stop, poll_seconds) -> None:
-    # The app spawns the backend as its direct child on Unix, so "my parent is
-    # no longer the owner pid" is the death signal: kernel truth, immune to pid
-    # reuse, and indifferent to whether the corpse was reaped (a kill-0 probe
-    # would count an unreaped zombie as alive). Checked before the first wait
-    # so an owner that died during backend startup is caught immediately.
+    # "My parent is no longer the owner pid" is the death signal: kernel truth, immune to pid reuse, and indifferent to
+    # reaping, which a kill-0 probe is not. Checked before the first wait.
     while True:
         if os.getppid() != parent_pid:
             _fire(on_parent_exit)
@@ -59,8 +56,7 @@ def _watch_windows(parent_pid, on_parent_exit, stop, poll_seconds) -> None:
     WAIT_OBJECT_0 = 0
     handle = kernel32.OpenProcess(SYNCHRONIZE, False, parent_pid)
     if not handle:
-        # A same-user owner is always openable, so failure means the parent
-        # already died and its pid went stale: exit, don't abandon the watch.
+        # A same-user owner is always openable.
         _fire(on_parent_exit)
         return
     try:

--- a/studio/backend/utils/paths/external_media.py
+++ b/studio/backend/utils/paths/external_media.py
@@ -186,7 +186,7 @@ def _readable_dirs_within(paths: Iterable[str], timeout: float) -> set[str]:
     threads are never joined past the deadline, so a stuck OS call cannot delay
     interpreter exit or block the caller (``os.path.isdir`` releases the GIL).
     """
-    paths = list(paths)  # fixed input we can iterate twice; one probe per path
+    paths = list(paths)
     results: dict[str, bool] = {}
 
     def _probe(path: str) -> None:

--- a/studio/backend/utils/paths/path_utils.py
+++ b/studio/backend/utils/paths/path_utils.py
@@ -42,6 +42,7 @@ def file_contents_available_locally(path, stat_result = None) -> bool:
 # way the real file does; only the magic bytes settle it.
 # The volumes are exFAT, FAT, most SMB and NFS, and nothing may be refused for the prefix alone: a user's own
 # "._model.gguf" is a real model.
+# ── macOS Finder metadata companions ───────────────────────────
 _MAGIC = b"\x00\x05\x16\x07"
 
 PathLike = TypeVar("PathLike", str, Path)

--- a/studio/backend/utils/paths/path_utils.py
+++ b/studio/backend/utils/paths/path_utils.py
@@ -17,9 +17,9 @@ logger = get_logger(__name__)
 # Opening a cloud placeholder for data recalls it. These attributes are available through
 # ``stat_result.st_file_attributes`` on Windows without reading file contents.
 _WINDOWS_CONTENT_RECALL_ATTRIBUTES = (
-    0x00001000  # FILE_ATTRIBUTE_OFFLINE
-    | 0x00040000  # FILE_ATTRIBUTE_RECALL_ON_OPEN
-    | 0x00400000  # FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
+    0x00001000
+    | 0x00040000
+    | 0x00400000
 )
 
 
@@ -37,12 +37,11 @@ def file_contents_available_locally(path, stat_result = None) -> bool:
     return not bool(attributes & _WINDOWS_CONTENT_RECALL_ATTRIBUTES)
 
 
-# ── macOS Finder metadata companions ───────────────────────────
-# A volume without native xattrs (exFAT, FAT, most SMB and NFS) makes macOS keep a file's xattrs
-# in a "._" companion carrying the same extension, so it answers every name-shaped question the
-# way the real file does and sorts ahead of it. Nothing may be refused for the prefix alone: a
-# user's own "._model.gguf" is a real model, and only the magic bytes settle it.
 
+# A volume without native xattrs makes macOS keep them in a "._" companion that answers every name-shaped question the
+# way the real file does; only the magic bytes settle it.
+# The volumes are exFAT, FAT, most SMB and NFS, and nothing may be refused for the prefix alone: a user's own
+# "._model.gguf" is a real model.
 _MAGIC = b"\x00\x05\x16\x07"
 
 PathLike = TypeVar("PathLike", str, Path)
@@ -238,14 +237,14 @@ def is_local_path(path: str) -> bool:
 
     # Obvious HF patterns
     if path.count("/") == 1 and not path.startswith(("/", ".", "~")):
-        return False  # Looks like org/model format
+        return False
 
     # Filesystem indicators
     return (
-        path.startswith(("/", ".", "~"))  # Unix absolute/relative
-        or ":" in path  # Windows drive or URL
-        or "\\" in path  # Windows separator
-        or os.path.isabs(path)  # System-absolute
+        path.startswith(("/", ".", "~"))
+        or ":" in path
+        or "\\" in path
+        or os.path.isabs(path)
     )
 
 
@@ -404,7 +403,7 @@ def reveal_in_file_manager(path: Path, expect_dir: bool = False) -> None:
 
     if expect_dir:
         try:
-            entry = os.lstat(path)  # No-follow, and the only stat here.
+            entry = os.lstat(path)
         except OSError as exc:
             raise FileNotFoundError(str(path)) from exc
         if not stat_module.S_ISDIR(entry.st_mode):

--- a/studio/backend/utils/paths/path_utils.py
+++ b/studio/backend/utils/paths/path_utils.py
@@ -16,11 +16,7 @@ logger = get_logger(__name__)
 
 # Opening a cloud placeholder for data recalls it. These attributes are available through
 # ``stat_result.st_file_attributes`` on Windows without reading file contents.
-_WINDOWS_CONTENT_RECALL_ATTRIBUTES = (
-    0x00001000
-    | 0x00040000
-    | 0x00400000
-)
+_WINDOWS_CONTENT_RECALL_ATTRIBUTES = 0x00001000 | 0x00040000 | 0x00400000
 
 
 def file_contents_available_locally(path, stat_result = None) -> bool:
@@ -35,7 +31,6 @@ def file_contents_available_locally(path, stat_result = None) -> bool:
         return False
     attributes = int(getattr(info, "st_file_attributes", 0) or 0)
     return not bool(attributes & _WINDOWS_CONTENT_RECALL_ATTRIBUTES)
-
 
 
 # A volume without native xattrs makes macOS keep them in a "._" companion that answers every name-shaped question the
@@ -241,12 +236,7 @@ def is_local_path(path: str) -> bool:
         return False
 
     # Filesystem indicators
-    return (
-        path.startswith(("/", ".", "~"))
-        or ":" in path
-        or "\\" in path
-        or os.path.isabs(path)
-    )
+    return path.startswith(("/", ".", "~")) or ":" in path or "\\" in path or os.path.isabs(path)
 
 
 def get_cache_path(model_name: str) -> Optional[Path]:

--- a/studio/backend/utils/paths/scan_folder_health.py
+++ b/studio/backend/utils/paths/scan_folder_health.py
@@ -22,11 +22,9 @@ STATUS_PERMISSION_DENIED = "permission_denied"
 STATUS_MISSING = "missing"
 # Any other OSError: I/O error, dead network mount, symlink loop.
 STATUS_UNREADABLE = "unreadable"
-# The folder works, but something inside it is refused, so models are missing
-# from the list without the list looking wrong.
+# The folder works, but something inside it is refused.
 STATUS_PARTIAL = "partial"
-# Internal only: the probe ran out of budget before it saw everything, so it
-# proved nothing. Never recorded and never sent to the UI.
+# Internal only: the probe ran out of budget before it saw everything
 STATUS_UNKNOWN = "unknown"
 
 
@@ -34,12 +32,8 @@ STATUS_UNKNOWN = "unknown"
 _PROBE_DEPTH = 2
 # Total opens for one probe, whatever the shape. Bounds the cost; the depth does not.
 _PROBE_OPEN_LIMIT = 64
-# A huggingface_hub cache keeps the files one level below that, in
-# <root>/models--org--name/snapshots/<commit>/, and that commit directory is the
-# only place the weights are. Refuse it and every directory above it still lists
-# fine, while the cache scan drops the model without raising, so the folder looks
-# healthy and empty at once. Costs one extra open per cached revision, and only in
-# a directory actually named this, so no other layout pays for it.
+# A huggingface_hub cache keeps the weights only in <root>/models--org--name/snapshots/<commit>/, so refusing that
+# directory leaves the folder looking healthy and empty at once.
 _HF_SNAPSHOTS_DIR = "snapshots"
 
 
@@ -77,17 +71,13 @@ def _probe_dir(path: str, *, depth: int, budget: list[int]) -> tuple[str, Option
     for name, subdir in subdirs:
         child_depth = depth - 1
         if child_depth <= 0 and name == _HF_SNAPSHOTS_DIR:
-            # Spend one more level here rather than raising the depth everywhere:
-            # a diffusers pipeline keeps component directories under each model, so
-            # a blanket extra level would burn the budget on folders shaped
-            # <root>/<publisher>/<model>/<component>.
+            # Spend one more level here rather than raising the depth everywhere: a diffusers pipeline's component
+            # directories would otherwise burn the budget.
             child_depth = 1
         status, cause = _probe_dir(subdir, depth = child_depth, budget = budget)
         if status == STATUS_MISSING:
-            # It was in the listing a moment ago and is gone now: a model being
-            # deleted, or a download renaming its temp directory away mid-walk.
-            # That says nothing about the folder the user registered. The folder
-            # itself disappearing is still caught by the scandir above.
+            # It was in the listing a moment ago and is gone now (a model being deleted, or a download renaming its temp
+            # directory), which says nothing about the folder the user registered.
             continue
         if status != STATUS_OK:
             return status, cause or subdir
@@ -123,10 +113,9 @@ def is_readable_dir(path: str) -> bool:
     return probe_status(path) == STATUS_OK
 
 
-# Windows reports the real reason in ``winerror``; ``errno`` is a lossy translation of
-# it, and CPython's PC/errmap.h folds ERROR_NOT_READY, ERROR_CRC, ERROR_GEN_FAILURE and
-# every other media or device failure onto EACCES. Without this, an ejected card reader
-# or an unmounted volume tells the user to go and fix the folder's permissions.
+# Windows reports the real reason in ``winerror``: CPython folds ERROR_NOT_READY, ERROR_CRC and every media failure onto
+# EACCES, so an ejected card reader reads as a permissions problem.
+# ``errno`` is a lossy translation, and CPython's PC/errmap.h folds ERROR_GEN_FAILURE onto EACCES as well.
 _WINDOWS_PERMISSION = frozenset((5, 65, 1314))
 _WINDOWS_MISSING = frozenset((2, 3, 15, 20, 21, 53, 55, 67, 161, 206, 267))
 
@@ -147,8 +136,8 @@ def classify_scan_error(error: OSError) -> str:
 
 
 # Read on every folder list, written only when a probe finds something wrong.
-# Each value is (status, the directory that refused), so a recheck can settle a
-# folder in one open instead of walking it again. Bounded by the folder count.
+# Each value is (status, the directory that refused), so a recheck can settle a folder in one open instead of walking it
+# again. Bounded by the folder count.
 _MAX_TRACKED = 256
 _failed: dict[str, tuple[str, str]] = {}
 
@@ -243,12 +232,7 @@ def refresh_failed_scan_folders(folders: list[dict]) -> None:
             and cause is not None
             and cause != path
         ):
-            # The probe cannot see that models were found, so keep the wording
-            # the scan chose. A folder that is gone still replaces it below.
-            # Only while the refusal is still something inside the folder: when
-            # the registered root itself is the one refusing, nothing can be
-            # scanned any more, and "some models could not be read" would be
-            # telling the user the wrong half of the problem.
+            # The probe cannot see that models were found.
             status = STATUS_PARTIAL
         _record(path, status, cause or path)
 

--- a/studio/backend/utils/paths/storage_roots.py
+++ b/studio/backend/utils/paths/storage_roots.py
@@ -166,7 +166,7 @@ def _windows_documents_dir() -> Path | None:
     if os.name != "nt":
         return None
     try:
-        import winreg  # Windows-only, and absent from some stripped builds.
+        import winreg
     except ImportError:
         return None
     try:
@@ -361,21 +361,18 @@ def _setup_cache_env() -> None:
     defaults: dict[str, str] = {
         "UV_CACHE_DIR": str(root / "uv"),
         "VLLM_CACHE_ROOT": str(root / "vllm"),
-        # unsloth_zoo defaults this to a bare relative name, which resolves
-        # against the CWD, and the Windows launcher runs Unsloth with
-        # WorkingDirectory=%USERPROFILE%, so the cache landed in the user home.
-        # Must be set before unsloth_zoo.compiler imports: it reads the value
-        # at import time and puts it on sys.path.
+        # unsloth_zoo defaults this to a bare relative name.
+        # It resolves against the CWD and the Windows launcher runs Unsloth with WorkingDirectory=%USERPROFILE%, so the
+        # cache landed in the user home. Must be set before unsloth_zoo.compiler imports: it reads the value at import
+        # time and puts it on sys.path.
         "UNSLOTH_COMPILE_LOCATION": str(root.parent / "compiled_cache"),
     }
     for key, value in defaults.items():
-        # Blank counts as unset: an inherited KEY= would otherwise pin the
-        # cache to "", which puts an empty entry on sys.path and sends the
-        # compiler to the system temp directory instead.
+        # Blank counts as unset: an inherited KEY= would otherwise pin the cache to "", which puts an empty entry on
+        # sys.path and sends the compiler to the system temp directory instead.
         if not (os.environ.get(key) or "").strip():
             os.environ[key] = value
-            # Best-effort: a non-writable custom HF_HOME must not crash startup;
-            # HF surfaces a clear error at download time instead.
+            # Best-effort: a non-writable custom HF_HOME must not crash startup
             try:
                 created = True
                 try:
@@ -496,10 +493,9 @@ def resolve_under_root(
 
 
 def default_run_dir_name(model_name: str) -> str:
-    # Folder-safe run name for an auto-created output dir. Repo ids keep their
-    # namespace (org/model -> org_model); local paths (incl. G:\dir\model)
-    # collapse to their final component so an absolute source can't escape
-    # outputs_root. Length-capped to stay under the filesystem name limit.
+    # Repo ids keep their namespace while local paths collapse to their final component, so an absolute source cannot
+    # escape outputs_root; length-capped to the filesystem name limit.
+    # Repo ids keep their namespace (org/model -> org_model).
     raw = str(model_name or "").strip()
     is_path = (
         "\\" in raw

--- a/studio/backend/utils/prebuilt/child_env.py
+++ b/studio/backend/utils/prebuilt/child_env.py
@@ -82,10 +82,10 @@ def scrub_env(env: Mapping[str, str]) -> dict[str, str]:
     }
 
 
-# Filesystem pointers a downloaded binary could follow to on-disk credential
-# stores (token caches under $HF_HOME, ~/.netrc, XDG config). Dropped, not
-# repointed; the offline inference server needs none. Mirrors the cred-location
-# list of the tools bypass env (core/inference/tools.py).
+# Filesystem pointers a downloaded binary could follow to on-disk credential stores. Dropped, not repointed: the offline
+# inference server needs none.
+# Those pointers are token caches under $HF_HOME, ~/.netrc and XDG config. Mirrors the cred-location list of the tools
+# bypass env (core/inference/tools.py).
 CRED_LOCATION_ENV_NAMES = frozenset(
     {
         "HF_HOME",
@@ -107,8 +107,7 @@ CRED_LOCATION_ENV_NAMES = frozenset(
         "HOMEPATH",
     }
 )
-# Home dirs are repointed (not dropped): loaders and SDKs expect them present,
-# but they must not resolve to the user's real profile with its token caches.
+# Home dirs are repointed (not dropped): loaders and SDKs expect them present
 HOME_ENV_NAMES = ("HOME", "USERPROFILE", "APPDATA", "LOCALAPPDATA")
 
 

--- a/studio/backend/utils/prebuilt/freshness_flow.py
+++ b/studio/backend/utils/prebuilt/freshness_flow.py
@@ -379,5 +379,5 @@ def reset_caches(
         import shutil
 
         # cache_dir() is a freshness-only subdir re-created on the next save_disk_cache, and
-    # ignore_errors so a missing or locked dir cannot break an otherwise successful install.
+        # ignore_errors so a missing or locked dir cannot break an otherwise successful install.
         shutil.rmtree(cache_dir(), ignore_errors = True)

--- a/studio/backend/utils/prebuilt/freshness_flow.py
+++ b/studio/backend/utils/prebuilt/freshness_flow.py
@@ -24,8 +24,7 @@ logger = structlog.get_logger(__name__)
 
 # 24h TTL keeps the GitHub call off the hot path and within rate limits.
 RELEASE_CACHE_TTL_SECONDS = 24 * 60 * 60
-# Briefly memoize failed lookups so recurring status reads do not retry an
-# unreachable GitHub endpoint on every request.
+# Briefly memoize failed lookups so recurring status reads do not retry
 RELEASE_FAILURE_CACHE_TTL_SECONDS = 60
 
 
@@ -379,7 +378,6 @@ def reset_caches(
     if drop_disk:
         import shutil
 
-        # cache_dir() is a dedicated freshness-only subdir, re-created on the next
-        # save_disk_cache. ignore_errors so a missing/locked dir is a no-op rather
-        # than breaking an otherwise successful install.
+        # cache_dir() is a freshness-only subdir re-created on the next save_disk_cache, and
+    # ignore_errors so a missing or locked dir cannot break an otherwise successful install.
         shutil.rmtree(cache_dir(), ignore_errors = True)

--- a/studio/backend/utils/prebuilt/llama_backend.py
+++ b/studio/backend/utils/prebuilt/llama_backend.py
@@ -26,8 +26,8 @@ INSTALL_KIND_BACKENDS: dict[str, str] = {
     "macos-x64": "metal",
 }
 
-# Backends a user may ask for. "metal" is absent on purpose: it is the only macOS
-# build, so there is nothing to choose.
+# Backends a user may ask for. "metal" is absent on purpose: it is the only macOS build, so
+# there is nothing to choose.
 REQUESTABLE_BACKENDS = ("auto", "cpu", "cuda", "rocm", "vulkan")
 
 # Longest-token-first, so "cuda13-older" cannot read as something else.

--- a/studio/backend/utils/prebuilt/runtime_libs.py
+++ b/studio/backend/utils/prebuilt/runtime_libs.py
@@ -60,11 +60,11 @@ def python_runtime_dirs() -> list[str]:
                 continue
         except (OSError, ValueError):
             continue
-        candidates.extend(root.glob("nvidia/*/lib"))  # Linux convention
-        candidates.extend(root.glob("nvidia/*/bin"))  # legacy modular Windows wheels
+        candidates.extend(root.glob("nvidia/*/lib"))
+        candidates.extend(root.glob("nvidia/*/bin"))
         candidates.extend(root.glob("nvidia/*/bin/x86_64"))  # CUDA 13 Windows wheel layout
         candidates.extend(root.glob("nvidia/*/bin/x64"))
-        candidates.extend(root.glob("nvidia/*/Library/bin"))  # conda-style repacks
+        candidates.extend(root.glob("nvidia/*/Library/bin"))
         candidates.extend(root.glob("nvidia/*/Library/bin/x86_64"))
         candidates.extend(root.glob("nvidia/*/Library/bin/x64"))
         candidates.extend(root.glob("torch/lib"))

--- a/studio/backend/utils/prebuilt/update_flow.py
+++ b/studio/backend/utils/prebuilt/update_flow.py
@@ -362,7 +362,7 @@ def managed_install_root(
     if not binary:
         return None
     # The server-path pin is an explicit user choice that wins in discovery, so never auto-replace
-        # its tree, even the user's own checkout.
+    # its tree, even the user's own checkout.
     if os.environ.get(server_path_var):
         return None
     p = Path(binary)
@@ -657,8 +657,8 @@ def run_chained_update(phases: list[dict], *, job: dict, job_lock: threading.Loc
         if result.get("message"):
             done_messages.append(result["message"])
         # Only phases affecting the primary llama server may raise the job-level reload flag: the
-    # frontend resyncs chat model state off it, and a whisper-only sidecar reload must not clear
-    # the chat checkpoint. Per-phase reload_required stays visible under job["phases"].
+        # frontend resyncs chat model state off it, and a whisper-only sidecar reload must not clear
+        # the chat checkpoint. Per-phase reload_required stays visible under job["phases"].
         if phase.get("affects_job_reload", True):
             reload_required = reload_required or bool(result.get("reload_required"))
             # The legacy job-level to_tag means "the llama build now installed"

--- a/studio/backend/utils/prebuilt/update_flow.py
+++ b/studio/backend/utils/prebuilt/update_flow.py
@@ -36,9 +36,7 @@ RESOLVE_TTL_SECONDS = 24 * 60 * 60
 # Matches the installer's download progress lines, e.g.
 # "Downloading x.zip:  35.0% (12.3 MiB/35.1 MiB) at 8.2 MiB/s".
 PROGRESS_LINE_RE = re.compile(r"(\d+(?:\.\d+)?)%\s*\(")
-# The installer announces each server it starts to validate a build. They are
-# grandchildren, so a parent-death signal or a sweep of the installer pid alone
-# never reaches them, and one left running holds the GPU and the staged files.
+# The installer announces each server it starts to validate a build.
 CHILD_PID_LINE_RE = re.compile(r"\AUNSLOTH_INSTALLER_CHILD (started|stopped) (\d+)\Z")
 # The download dominates the update; extract/validate fill the last slice.
 DOWNLOAD_PROGRESS_CEILING = 0.95
@@ -304,7 +302,7 @@ def resolve_prebuilt_for_host(
     except Exception as exc:  # pragma: no cover - subprocess/json defensive
         logger.debug(log_message, error = str(exc))
         value = None
-    if value is not None:  # cache real answers; let failures retry next poll
+    if value is not None:
         memo.update(at = now, key = cache_key, value = value)
     return value
 
@@ -363,8 +361,8 @@ def managed_install_root(
         return marker_root
     if not binary:
         return None
-    # The server-path pin is an explicit user choice that wins in discovery; never
-    # auto-replace its tree (even the user's own checkout).
+    # The server-path pin is an explicit user choice that wins in discovery, so never auto-replace
+        # its tree, even the user's own checkout.
     if os.environ.get(server_path_var):
         return None
     p = Path(binary)
@@ -470,10 +468,8 @@ def stream_installer(
         errors = "replace",
         # Make the Python child emit the UTF-8 we decode above.
         env = utf8_child_env(env),
-        # Deliberately NOT start_new_session: the desktop stop path force-kills
-        # this backend's process group, and a session of its own would take the
-        # installer out of it, leaving it rewriting files after the app reports
-        # the backend stopped.
+        # Deliberately NOT start_new_session: the desktop stop path force-kills this process group, and a session of its
+        # own would leave the installer rewriting files after the app reports stopped.
         **child_popen_kwargs(),
     )
     # The kwargs above are empty on macOS, so record it: an installer that
@@ -484,10 +480,8 @@ def stream_installer(
     announced = AnnouncedChildren()
 
     def _stop_announced() -> None:
-        # This process keeps running after an installer error, so no startup
-        # sweep is coming and its own record shields these from one anyway: a
-        # validation server left here holds the GPU and the staged files
-        # through the retry that follows.
+        # This process keeps running after an installer error, so no startup sweep is coming: a validation server left
+        # here holds the GPU and the staged files through the retry.
         while True:
             pid = announced.take()
             if pid is None:
@@ -534,8 +528,7 @@ def stream_installer(
                 hint_lines.append(line)
             child = child_line
             if child is not None:
-                # Recorded while it runs and dropped when the installer says it
-                # stopped; one it never got to report stays for the sweep.
+                # Recorded while it runs and dropped when the installer says
                 started, child_pid = child.group(1) == "started", int(child.group(2))
                 if started:
                     adopt_pid(child_pid)
@@ -553,8 +546,8 @@ def stream_installer(
         watchdog.cancel()
         if proc.poll() is not None:
             forget_pid(proc.pid)
-        # Anything it started and never reported as stopped, whether it timed
-        # out, exited nonzero, or died mid-line.
+        # Anything it started and never reported as stopped, whether it timed out, exited nonzero, or
+        # died mid-line.
         _stop_announced()
     if timed_out.is_set():
         raise RuntimeError(f"installer timed out after {timeout_seconds}s")
@@ -649,8 +642,7 @@ def run_chained_update(phases: list[dict], *, job: dict, job_lock: threading.Loc
         offset += weight
         with job_lock:
             if result.get("skipped"):
-                # Skipped with a reason, not a success with no message: deciding late
-                # must not mean explaining less.
+                # Skipped with a reason.
                 job["phases"][name].update(
                     state = PHASE_SKIPPED,
                     reason = result.get("skip_reason") or "up_to_date",
@@ -664,15 +656,12 @@ def run_chained_update(phases: list[dict], *, job: dict, job_lock: threading.Loc
                 )
         if result.get("message"):
             done_messages.append(result["message"])
-        # Only phases affecting the primary (llama) server may raise the job-level
-        # reload flag: the frontend resyncs chat model state off it, and a
-        # whisper-only sidecar reload must not clear the chat checkpoint. Per-phase
-        # reload_required stays visible under job["phases"].
+        # Only phases affecting the primary llama server may raise the job-level reload flag: the
+    # frontend resyncs chat model state off it, and a whisper-only sidecar reload must not clear
+    # the chat checkpoint. Per-phase reload_required stays visible under job["phases"].
         if phase.get("affects_job_reload", True):
             reload_required = reload_required or bool(result.get("reload_required"))
-            # The legacy job-level to_tag means "the llama build now installed";
-            # a whisper-only round must leave it unset or the UI reports a llama
-            # update that never ran (per-phase to_tag remains under phases).
+            # The legacy job-level to_tag means "the llama build now installed"
             if primary_to_tag is None:
                 primary_to_tag = result.get("to_tag")
 

--- a/studio/backend/utils/preview_token.py
+++ b/studio/backend/utils/preview_token.py
@@ -25,7 +25,7 @@ _PREVIEW_TOKEN_VERSION = "v1"
 
 def _canonical_payload(ref: str) -> bytes:
     # Sign the canonical ref only, never host/path, so links stay portable across localhost / LAN IP
-# / tunnel host changes.
+    # / tunnel host changes.
     return f"preview:{_PREVIEW_TOKEN_VERSION}:{ref}".encode("utf-8")
 
 

--- a/studio/backend/utils/preview_token.py
+++ b/studio/backend/utils/preview_token.py
@@ -24,8 +24,8 @@ _PREVIEW_TOKEN_VERSION = "v1"
 
 
 def _canonical_payload(ref: str) -> bytes:
-    # Sign the canonical ref only (never host/path) so links stay portable across
-    # localhost / LAN IP / tunnel host changes.
+    # Sign the canonical ref only, never host/path, so links stay portable across localhost / LAN IP
+# / tunnel host changes.
     return f"preview:{_PREVIEW_TOKEN_VERSION}:{ref}".encode("utf-8")
 
 

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -760,6 +760,7 @@ def _group_member_pids(pgid: int) -> "Optional[list[int]]":
 
 # macOS has neither PR_SET_PDEATHSIG nor job objects, so a crash leaves every sidecar running: record children as they
 # are adopted and sweep the previous run's leftovers at startup.
+# ── Crash-survivable child record ──
 def _breadcrumb_dir():
     from pathlib import Path
 

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -130,6 +130,7 @@ def _is_windows() -> bool:
 
 
 # ── Parent setup ──
+
 def initialize_parent_lifetime() -> None:
     """Install the parent-death reaper once, as early as possible at startup.
 
@@ -264,6 +265,7 @@ def _install_windows_job() -> None:
 
 
 # ── Child binding ──
+
 def _pdeathsig_preexec(owner_pid: Optional[int] = None) -> None:
     # Runs in the forked child before exec (PR_SET_PDEATHSIG does not survive the fork); the getppid check closes the
     # race where the parent died first, against owner_pid, the spawner's pid read pre-fork. A bare `getppid() == 1` also

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -37,25 +37,10 @@ _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
 _JobObjectExtendedLimitInformation = 9
 
 # The lowest pid this module will ever record or signal.
-#
-# kill(2) gives 0, 1 and negatives a different meaning to every other value, and
-# each of those meanings is catastrophic here:
-#
-#   kill(0, sig)     this process's entire group, i.e. Unsloth and its siblings
-#   killpg(1, sig)   the same call as kill(-1, sig): EVERY process the caller
-#                    has permission to signal, not "process group 1"
-#   kill(-n, sig)    process group n
-#
-# The middle one is not hypothetical. A record naming pid 1 as a child reaches
-# _posix_terminate, getpgid(1) == 1 makes it look like a group leader, and the
-# killpg branch then SIGTERMs every process belonging to the user, waits the
-# grace period, and SIGKILLs them too. Nothing rejected it on the way: the
-# identity check compares recorded start-time against current, and init's start
-# time never changes, so a recorded pid 1 matches forever.
-#
-# Guarded at both ends. Nothing below this is recorded, so the bad record cannot
-# be created, and nothing below this is signalled, so records written by an
-# older build cannot fire.
+# `killpg(1, sig)` is `kill(-1, sig)`: EVERY process the caller may signal, not process group 1. A record naming pid 1
+# reaches _posix_terminate, looks like a group leader, and SIGKILLs everything the user owns, and the identity check can
+# never reject it because init's start time never changes. Guarded at both ends: nothing below this is recorded, and
+# nothing below this is signalled.
 _LOWEST_SIGNALABLE_PID = 2
 
 
@@ -93,8 +78,7 @@ _tracked_pgids: "dict[int, int]" = {}
 _record_lock = threading.Lock()
 
 
-# Whether cleanup-on-abnormal-exit is in force, and why not. A silent failure
-# here leaks every child on a crash, so record it and log it.
+# Whether cleanup-on-abnormal-exit is in force, and why not.
 _win_job_status: "tuple[bool, str]" = (False, "not attempted")
 
 
@@ -145,9 +129,9 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
+
+
 # ── Parent setup ──
-
-
 def initialize_parent_lifetime() -> None:
     """Install the parent-death reaper once, as early as possible at startup.
 
@@ -275,22 +259,20 @@ def _install_windows_job() -> None:
             _record_job_status(False, "AssignProcessToJobObject failed", _last_error(ctypes))
             kernel32.CloseHandle(job)
             return
-        _win_job_handle = job  # hold the handle so the job is not closed early
+        _win_job_handle = job
         _record_job_status(True, "kill-on-close job installed")
     except Exception as error:
         _record_job_status(False, f"{type(error).__name__}: {error}")
 
 
+
+
 # ── Child binding ──
-
-
 def _pdeathsig_preexec(owner_pid: Optional[int] = None) -> None:
-    # Runs in the forked child before exec (PR_SET_PDEATHSIG does not survive the
-    # fork); the getppid check closes the race where the parent died first.
-    # owner_pid is the spawner's pid, read pre-fork. A bare `getppid() == 1` also
-    # matches a parent that legitimately IS pid 1, which is how Unsloth runs as a
-    # container entrypoint: it killed every llama-server before exec (#7886). It
-    # also misses reparenting to a subreaper, whose pid is not 1.
+    # Runs in the forked child before exec (PR_SET_PDEATHSIG does not survive the fork); the getppid check closes the
+    # race where the parent died first, against owner_pid, the spawner's pid read pre-fork. A bare `getppid() == 1` also
+    # matches a parent that legitimately IS pid 1, which is how Unsloth runs as a container entrypoint: it killed every
+    # llama-server before exec (#7886). It also misses reparenting to a subreaper, whose pid is not 1.
     try:
         import ctypes
 
@@ -320,12 +302,11 @@ def bind_current_process_to_parent_lifetime() -> None:
         # bare getppid() == 1 test would kill a parent-is-pid-1 process (#7886).
         _pdeathsig_preexec(os.getppid())
         return
-    # PDEATHSIG binds to the kernel parent; "orphaned" comes from the creator's
-    # sentinel, not a pid compare, since under forkserver the kernel parent is the
-    # fork server and comparing would kill every healthy worker. The sentinel is
-    # exact under spawn and forkserver; under fork a sibling can inherit the
-    # creator's write end and read stale-alive, but PDEATHSIG covers fork. A
-    # forkserver creator dying later stays uncovered, as on main.
+    # "Orphaned" comes from the creator's sentinel, not a pid compare: under forkserver the kernel parent is the fork
+    # server, and comparing would kill every healthy worker.
+    # PDEATHSIG binds to the kernel parent. The sentinel is exact under spawn and forkserver; under fork a sibling can
+    # inherit the creator's write end and read stale-alive, but PDEATHSIG covers fork. A forkserver creator dying later
+    # stays uncovered, as on main.
     _pdeathsig_preexec(os.getppid())
     try:
         if not parent.is_alive():
@@ -377,15 +358,12 @@ def _reset_after_fork() -> None:
     _spawner whose thread does not exist here. Start clean instead of deadlocking."""
     global _spawner, _spawner_lock, _record_lock, _owner_identity
     _spawner_lock = threading.Lock()
-    # A different pid here, so the parent's identity is not this process's, and
-    # the parent's children are not this process's either: adopting anything
-    # would otherwise write a record claiming them, and a later startup would
-    # reap them out from under the parent that is still running.
+    # A different pid here.
     _owner_identity = None
     _tracked_pids.clear()
     _tracked_pgids.clear()
-    # A fork while another thread was inside adopt_pid / forget_pid leaves this
-    # held here with nobody to release it, and the first adoption blocks forever.
+    # A fork while another thread was inside adopt_pid / forget_pid leaves this held here with nobody to release it, and
+    # the first adoption blocks forever.
     _record_lock = threading.Lock()
     _spawner = None
 
@@ -399,7 +377,7 @@ def _adopt_fork_reset() -> None:
     _fork_reset_installed = True
     try:
         os.register_at_fork(after_in_child = _reset_after_fork)
-    except (AttributeError, RuntimeError):  # no fork support; nothing to guard
+    except (AttributeError, RuntimeError):
         pass
 
 
@@ -508,8 +486,7 @@ def _same_identity(recorded: str, current: str) -> bool:
 
 
 def _pid_identity(pid: int) -> Optional[str]:
-    # Start time pins identity so a reused pid is never signalled later. None
-    # (unreadable, or a platform with no cheap source) disables the check.
+    # Start time pins identity so a reused pid is never signalled later.
     if _is_linux():
         try:
             with open(f"/proc/{pid}/stat", encoding = "utf-8") as fh:
@@ -521,8 +498,7 @@ def _pid_identity(pid: int) -> Optional[str]:
         except Exception:
             return None
     if _is_windows():
-        # Creation time, so a recycled pid is never mistaken for the child that
-        # was recorded. Same purpose as starttime on Linux.
+        # Creation time, so a recycled pid is never mistaken for the child
         try:
             import ctypes
             from ctypes import wintypes
@@ -553,13 +529,10 @@ def _pid_identity(pid: int) -> Optional[str]:
         except Exception:
             return None
     if sys.platform == "darwin":
-        # No /proc; `ps -o lstart` is enough to spot a recycled pid.
         try:
             import subprocess
 
-            # TZ pinned: lstart is formatted in local time, so a machine that
-            # changes timezone between adopt and check would otherwise read as a
-            # different process.
+            # TZ pinned: lstart is formatted in local time.
             out = subprocess.run(
                 ["ps", "-o", "lstart=,comm=", "-p", str(pid)],
                 capture_output = True,
@@ -602,11 +575,8 @@ def _group_has_members(pgid: object) -> bool:
     not been waited on is still a member, so a group whose every member is a
     zombie would read as alive and keep its record forever.
     """
-    # `killpg(1, 0)` is `kill(-1, 0)`, which always succeeds, so without the floor
-    # this answers True for group 1 unconditionally. That delivers no signal, but
-    # it pins the record as unresolved: a legacy entry pairing a real pid with a
-    # poisoned pgid would then be retried on every launch forever, which is the
-    # opposite of what the reaper's drop-on-poison path is for.
+    # `killpg(1, 0)` is `kill(-1, 0)`, which always succeeds, so without the floor a legacy entry pairing a real pid
+    # with a poisoned pgid is retried on every launch forever.
     if not _signalable(pgid) or _is_windows() or not hasattr(os, "killpg"):
         return False
     try:
@@ -620,7 +590,7 @@ def _group_has_members(pgid: object) -> bool:
         return True
     members = _group_member_pids(pgid)
     if members is None:
-        return True  # cannot enumerate, so keep the record rather than lose it
+        return True
     return any(not _pid_is_zombie(pid) for pid in members)
 
 
@@ -657,7 +627,7 @@ def _child_pid_map() -> "Optional[dict[int, list[int]]]":
                 timeout = 5,
             )
             if out.returncode != 0:
-                return None  # a failed query is not an answer, as above
+                return None
             table = {}
             for line in (out.stdout or "").splitlines():
                 parts = line.split()
@@ -774,10 +744,8 @@ def _group_member_pids(pgid: int) -> "Optional[list[int]]":
                 errors = "replace",
                 timeout = 5,
             )
-            # ps exits nonzero when the group is gone AND when the call itself
-            # failed, and the two are not the same answer: reporting "empty"
-            # for a failure lets forget_pid drop the only record of a live
-            # descendant. Only a clean exit is an answer.
+            # ps exits nonzero when the group is gone AND when the call itself failed, and reporting "empty" for a
+            # failure lets forget_pid drop the only record of a live descendant.
             if out.returncode != 0:
                 return None
             return [int(x) for x in (out.stdout or "").split()]
@@ -786,13 +754,12 @@ def _group_member_pids(pgid: int) -> "Optional[list[int]]":
     return None
 
 
-# ── Crash-survivable child record ──
-#
-# macOS has neither PR_SET_PDEATHSIG nor job objects, so a crash leaves every
-# sidecar running. Record children as they are adopted; sweep the previous
-# run's leftovers at startup.
+# macOS has neither PR_SET_PDEATHSIG nor job objects, so a crash leaves every sidecar running:
+# record children as they are adopted and sweep the previous run's leftovers at startup.
 
 
+# macOS has neither PR_SET_PDEATHSIG nor job objects, so a crash leaves every sidecar running: record children as they
+# are adopted and sweep the previous run's leftovers at startup.
 def _breadcrumb_dir():
     from pathlib import Path
 
@@ -881,8 +848,8 @@ def clear_breadcrumb() -> None:
         if _tracked_pids:
             _write_breadcrumb()
             return
-        # Inside the lock: a spawn landing between the check and the unlink
-        # would otherwise write a record we then delete.
+        # Inside the lock: a spawn landing between the check and the unlink would write a record this
+        # then deletes.
         path = _breadcrumb_file()
         if path is not None:
             _unlink(path)
@@ -894,8 +861,7 @@ def _identity_or_none(pid) -> "Optional[str]":
 
 def _pid_alive(pid: int) -> bool:
     if _is_windows():
-        # NOT os.kill(pid, 0): that is TerminateProcess here, so the probe
-        # would kill the process it is asking about.
+        # NOT os.kill(pid, 0): that is TerminateProcess here, so the probe would kill the process it is asking about.
         try:
             import ctypes
             from ctypes import wintypes
@@ -976,7 +942,7 @@ def _identity_for_record(pid: int, attempts: int = 3) -> Optional[str]:
         if identity is not None:
             return identity
         if not _pid_alive(pid):
-            break  # already gone: there is nothing left to identify
+            break
         if attempt + 1 < attempts:
             time.sleep(0.05 * (attempt + 1))
     return None
@@ -1039,7 +1005,7 @@ def terminate_all(timeout: float = 5.0) -> "list[int]":
             _tracked_pids.pop(pid, None)
             pgid = _tracked_pgids.pop(pid, None)
         if not _signalable(pid):
-            continue  # dropped, not kept: see _LOWEST_SIGNALABLE_PID
+            continue
         current = _pid_identity(pid)
         if not _pid_alive(pid):
             # Same as the startup sweep: a leader that exited first can still
@@ -1052,10 +1018,9 @@ def terminate_all(timeout: float = 5.0) -> "list[int]":
                         _tracked_pgids[pid] = pgid
             continue
         if current is not None and identity is not None and not _same_identity(identity, current):
-            continue  # definitely recycled by something else; drop it
+            continue
         if identity is None or current is None:
-            # Cannot prove this is still our child, so do not signal it. Keep it
-            # recorded while it is alive: the startup sweep runs the same test.
+            # Cannot prove this is still our child, so do not signal it.
             if _pid_alive(pid) and not _pid_is_zombie(pid):
                 with _record_lock:
                     _tracked_pids[pid] = identity
@@ -1099,10 +1064,8 @@ def terminate_pid(pid: "Optional[int]", timeout: float = 5.0) -> None:
     For an owner that has to give up on a child before its own shutdown, and
     cannot leave it for a sweep that will not run while this process lives.
     """
-    # The public entry point, so the floor goes here rather than only in the
-    # POSIX helper below: `_windows_terminate_tree` is reached without passing
-    # through it, and a caller should not have to know which platform's path
-    # happens to carry the check.
+    # The public entry point, so the floor goes here: `_windows_terminate_tree` is reached without passing through the
+    # POSIX helper that would otherwise carry the check.
     if not _signalable(pid):
         return
     with _record_lock:
@@ -1138,7 +1101,7 @@ def terminate_pid(pid: "Optional[int]", timeout: float = 5.0) -> None:
         pass
     if tree_stands:
         return
-    forget_pid(pid)  # keeps the record if its group is still up
+    forget_pid(pid)
 
 
 def reap_recorded_children(timeout: float = 5.0) -> "list[int]":
@@ -1153,10 +1116,8 @@ def reap_recorded_children(timeout: float = 5.0) -> "list[int]":
     if directory is None or not directory.is_dir():
         return []
     killed: "list[int]" = []
-    # A record is skipped while its owner is alive, and that owner may be
-    # terminated later in the same sweep by the record of the backend that
-    # spawned it. Only those deferred records are revisited, so nothing is
-    # signalled twice.
+    # A record skipped while its owner is alive may have that owner terminated later in the same sweep, so only those
+    # deferred records are revisited and nothing is signalled twice.
     pending = sorted(directory.glob("*.json"))
     for _pass in range(4):
         deferred: "list" = []
@@ -1191,10 +1152,7 @@ def _reap_one_record(path, timeout: float) -> "tuple[list[int], bool]":
     # Anything that is not the string this wrote is no identity at all, and is
     # treated like a missing one rather than trusted or crashed on.
     owner_identity = _recorded_identity(record.get("owner_identity"))
-    # Identity decides, not the pid: pids recycle, and this process may have
-    # inherited the pid of the Unsloth that wrote the record.
-    # Inconclusive counts as a match: a `ps` that failed for a moment must not
-    # make a live Unsloth look gone and cost it its running sidecars.
+    # Identity decides, not the pid: pids recycle.
     current_owner = _identity_or_none(owner_pid)
     owner_matches = (
         owner_identity is None
@@ -1202,7 +1160,7 @@ def _reap_one_record(path, timeout: float) -> "tuple[list[int], bool]":
         or _same_identity(owner_identity, current_owner)
     )
     if owner_pid == os.getpid() and owner_matches:
-        return killed, False  # our own record
+        return killed, False
     if (
         isinstance(owner_pid, int)
         and owner_matches
@@ -1211,18 +1169,15 @@ def _reap_one_record(path, timeout: float) -> "tuple[list[int], bool]":
         # on yet is still a dead one whose sidecars are orphans.
         and not _pid_is_zombie(owner_pid)
     ):
-        return killed, True  # that Unsloth is still running; its children are its own
+        return killed, True
 
     unresolved = False
     children = record.get("children")
     for entry in children if isinstance(children, list) else []:
         pid = entry.get("pid") if isinstance(entry, dict) else None
         if not _signalable(pid):
-            # Records written by a build without the guard can name pid 1, and
-            # signalling that is a kill of everything the user owns. Dropped
-            # rather than deferred: leaving `unresolved` alone lets the record be
-            # unlinked, so a poisoned one is gone after a single startup instead
-            # of being retried on every launch forever.
+            # Records written by a build without the guard can name pid 1, and signalling that kills everything the user
+            # owns. Dropped rather than deferred, so a poisoned one is gone after one startup.
             continue
         # A zombie is a dead leader nobody has waited on: it holds nothing, and
         # signalling it would burn the whole grace period answering probes.
@@ -1234,7 +1189,6 @@ def _reap_one_record(path, timeout: float) -> "tuple[list[int], bool]":
             if _reap_orphaned_group(pgid, pid, timeout):
                 killed.append(pid)
             elif _group_has_members(pgid):
-                # Still there, so this record is the only handle on it.
                 unresolved = True
             continue
         identity = _recorded_identity(entry.get("identity"))
@@ -1244,7 +1198,7 @@ def _reap_one_record(path, timeout: float) -> "tuple[list[int], bool]":
             unresolved = True
             continue
         if not _same_identity(identity, current):
-            continue  # recycled by an unrelated process
+            continue
         tree_stands = False
         if _is_windows():
             # The tree, not the leader: this fallback runs when the Job Object
@@ -1255,17 +1209,10 @@ def _reap_one_record(path, timeout: float) -> "tuple[list[int], bool]":
             _posix_terminate(pid, timeout = timeout)
         killed.append(pid)
         if tree_stands:
-            # Workers may still be running with nothing else naming them, so
-            # this record has to survive for the next launch to retry.
             unresolved = True
-        # These belong to a process that is gone, so they cannot be our zombies;
-        # one still running means the kill did not take, and the record is the
-        # only handle the next launch would have on it.
         if _pid_alive(pid) and not _pid_is_zombie(pid):
             unresolved = True
         elif _group_has_members(entry.get("pgid")):
-            # The leader died but its group did not, which is the same loss of
-            # the only handle, just one step later.
             unresolved = True
 
     if not unresolved:
@@ -1296,7 +1243,7 @@ def _own_process_group(pid: int) -> Optional[int]:
     except Exception:
         return None
     if not _signalable(pgid):
-        return None  # killpg(1) is a broadcast, killpg(0) is our own group
+        return None
     return pgid if pgid == pid else None
 
 
@@ -1309,9 +1256,9 @@ def _reap_orphaned_group(pgid: object, pid: int, timeout: float) -> bool:
     members remain.
     """
     if not _signalable(pgid) or pgid != pid or _is_windows() or not hasattr(os, "killpg"):
-        return False  # killpg(1) is kill(-1); see _LOWEST_SIGNALABLE_PID
+        return False
     try:
-        os.killpg(pgid, 0)  # the group is still there
+        os.killpg(pgid, 0)
     except Exception:
         return False
     # A zombie answers that probe, and where pid 1 does not reap it stays that
@@ -1344,8 +1291,8 @@ def _reap_orphaned_group(pgid: object, pid: int, timeout: float) -> bool:
         os.killpg(pgid, signal.SIGKILL)
     except Exception:
         pass
-    # Only gone counts: a SIGKILL that could not be delivered leaves this record
-    # as the last handle on whatever is still holding the GPU.
+    # Only gone counts: a SIGKILL that could not be delivered leaves this record as the last handle on whatever is still
+    # holding the GPU.
     try:
         os.killpg(pgid, 0)
         return False
@@ -1396,16 +1343,14 @@ def _posix_terminate(pid: int, timeout: float = 5.0) -> None:
     # belongs to the child's owner (or init for orphans). Prefer the group
     # (covers grandchildren) when pid leads its own group.
     if not _signalable(pid):
-        return  # see _LOWEST_SIGNALABLE_PID
+        return
     group_leader = False
     try:
         group_leader = os.getpgid(pid) == pid
     except Exception:
         pass
-    # A child sharing this process's group cannot be reached with killpg, so its
-    # own children have to be named individually -- and named now, while the
-    # parent that links them is still alive. Always run, so a return out of the
-    # signalling below still takes the tree.
+    # A child sharing this process's group cannot be reached with killpg, so its own children are named individually,
+    # and named NOW while the parent that links them is alive.
     descendants = [] if group_leader else collect_descendants(pid)
     try:
         _posix_terminate_one(pid, group_leader, timeout)
@@ -1430,17 +1375,15 @@ def _posix_terminate_one(pid: int, group_leader: bool, timeout: float) -> None:
     next_state_check = 0.0
     while time.monotonic() < deadline:
         try:
-            killer(pid, 0)  # still alive?
+            killer(pid, 0)
         except ProcessLookupError:
             return
         except Exception:
             break
         now = time.monotonic()
         if now >= next_state_check:
-            # An exited child nobody has waited on answers signal 0 exactly like
-            # a live one, so without this the whole timeout is spent on a process
-            # that is already gone. Reading the state costs a fork off Linux,
-            # hence twice a second rather than at the poll rate.
+            # An exited child nobody has waited on answers signal 0 exactly like a live one, so the whole timeout would
+            # be spent on a process already gone; the state read costs a fork off Linux.
             next_state_check = now + 0.5
             gone = (not _group_has_members(pid)) if group_leader else _pid_is_zombie(pid)
             if gone:

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -131,6 +131,7 @@ def _is_windows() -> bool:
 
 # ── Parent setup ──
 
+
 def initialize_parent_lifetime() -> None:
     """Install the parent-death reaper once, as early as possible at startup.
 
@@ -265,6 +266,7 @@ def _install_windows_job() -> None:
 
 
 # ── Child binding ──
+
 
 def _pdeathsig_preexec(owner_pid: Optional[int] = None) -> None:
     # Runs in the forked child before exec (PR_SET_PDEATHSIG does not survive the fork); the getppid check closes the

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -129,8 +129,6 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
-
-
 # ── Parent setup ──
 def initialize_parent_lifetime() -> None:
     """Install the parent-death reaper once, as early as possible at startup.
@@ -263,8 +261,6 @@ def _install_windows_job() -> None:
         _record_job_status(True, "kill-on-close job installed")
     except Exception as error:
         _record_job_status(False, f"{type(error).__name__}: {error}")
-
-
 
 
 # ── Child binding ──

--- a/studio/backend/utils/release_notes.py
+++ b/studio/backend/utils/release_notes.py
@@ -26,9 +26,8 @@ from packaging.version import InvalidVersion, Version
 
 from .update_status import DISABLE_ENV_VAR, RELEASE_NOTES_URL
 
-# A release entry carries its whole body, about 40 KiB lately, so the endpoint's
-# maximum of 100 would be near 4 MiB, twice the cap below, and the fetch would
-# fail outright. 30 is about 1.2 MiB, and the newest release is at the top.
+# A release entry carries its whole body (~40 KiB lately), so per_page=100 would be ~4 MiB, twice
+# the cap below, and the fetch would fail outright. 30 is ~1.2 MiB, newest first.
 RELEASES_API_URL = "https://api.github.com/repos/unslothai/unsloth/releases?per_page=30"
 RELEASES_URL_ENV_VAR = "UNSLOTH_RELEASES_URL"
 RELEASES_TIMEOUT_SECONDS = 3
@@ -37,23 +36,21 @@ _RELEASES_CHUNK_BYTES = 64 * 1024
 _RELEASES_MIN_READ_SECONDS = 0.05
 RELEASES_SUCCESS_TTL_SECONDS = 30 * 60
 RELEASES_FAILURE_TTL_SECONDS = 5 * 60
-# Unauthenticated callers get 60 requests an hour per IP, so an address that has
-# spent them backs off rather than retrying every 5 minutes. Used when the
-# response carries no reset to wait for.
+# Unauthenticated callers get 60 requests an hour per IP, so a spent address backs off instead of
+# retrying every 5 minutes. Used when the response carries no reset to wait for.
 RELEASES_RATE_LIMITED_TTL_SECONDS = 15 * 60
-# GitHub says not to request again before X-RateLimit-Reset, so its reset wins
-# over the back-off above. The window is an hour, so a skewed or proxied header
-# is held to that ceiling rather than trusted outright.
+# GitHub's X-RateLimit-Reset wins over the back-off above, but the window is an hour, so a skewed
+# or proxied header is held to that ceiling rather than trusted outright.
 RELEASES_RATE_LIMIT_MAX_SECONDS = 60 * 60
 RELEASE_NOTES_MAX_CHARS = 20_000
 
-# The repo also publishes llama.cpp prebuilts (`b8475`), legacy month tags
-# (`February-2026`) and `desktop-v...` drafts. Only an Unsloth version tag is an
-# announcement the popup should show.
+# The repo also publishes llama.cpp prebuilts, legacy month tags and desktop drafts; only an
+# Unsloth version tag is an announcement the popup should show.
+# The prebuilt tags look like `b8475` and the legacy month tags like `February-2026`.
 _RELEASE_TAG_PATTERN = re.compile(r"^v\d+(?:\.\d+)+")
 
-# CommonMark needs a space, tab or line end after the hashes: a non-breaking
-# space is text, a bare `##` an empty heading that still ends the section above.
+# CommonMark needs a space, tab or line end after the hashes: a non-breaking space is text, and a
+# bare `##` is an empty heading that still ends the section above.
 _HEADING_PATTERN = re.compile(r"^ {0,3}(?P<hashes>#{1,6})(?:[ \t]+(?P<title>.*?))?[ \t]*$")
 # A heading may close with its own run of hashes, which is not part of the title.
 _CLOSING_SEQUENCE = re.compile(r"(?:^|[ \t])#+[ \t]*$")
@@ -61,12 +58,12 @@ _CLOSING_SEQUENCE = re.compile(r"(?:^|[ \t])#+[ \t]*$")
 _TITLE_MARKUP = re.compile(r"[`*_~]|\[|\]\([^)]*\)|<[^>]*>")
 _FULL_CHANGELOG_LINE = re.compile(r"^ {0,3}\*{0,2}full changelog\*{0,2}\s*:", re.IGNORECASE)
 _FENCE_PATTERN = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})(?P<rest>.*)$")
-# CommonMark type 1 HTML blocks: literal until a closing tag, which the spec
-# says need not be the one that opened the block.
+# CommonMark type 1 HTML blocks: literal until a closing tag, which the spec says need not be the
+# one that opened the block.
 _RAW_HTML_OPEN = re.compile(r"^ {0,3}<(pre|script|style|textarea)(?=[\s>]|$)", re.IGNORECASE)
 _RAW_HTML_CLOSE = re.compile(r"</(pre|script|style|textarea)\s*>", re.IGNORECASE)
-# Types 3 to 5 are literal too, each ending on its own delimiter. Comments open
-# mid-line, so they are handled separately.
+# Types 3 to 5 are literal too, each ending on its own delimiter; comments open mid-line, so they
+# are handled separately.
 _RAW_BLOCKS = (
     (_RAW_HTML_OPEN, _RAW_HTML_CLOSE),
     (re.compile(r"^ {0,3}<\?"), re.compile(r"\?>")),
@@ -74,8 +71,8 @@ _RAW_BLOCKS = (
     # A declaration needs an uppercase letter, so `<!note` stays ordinary text.
     (re.compile(r"^ {0,3}<![A-Z]"), re.compile(r">")),
 )
-# Type 6 runs to the next blank line, so `<details>` holds Markdown only after
-# one. Open and close tags both start a block.
+# Type 6 runs to the next blank line, so `<details>` holds Markdown only after one. Open and close
+# tags both start a block.
 _HTML_BLOCK_OPEN = re.compile(r"^ {0,3}</?([a-zA-Z][a-zA-Z0-9-]*)(?=[\s/>]|$)")
 # Blocks that break into an open paragraph, closing it rather than continuing it.
 _INTERRUPTS = re.compile(
@@ -90,12 +87,12 @@ _SETEXT_UNDERLINE = re.compile(r"^ {0,3}(=+|-+)[ \t]*$")
 # A quoted paragraph continues on unmarked lines, which belong to the quote.
 _BLOCK_QUOTE = re.compile(r"^ {0,3}>")
 _QUOTE_MARKER = re.compile(r"^ {0,3}>[ \t]?")
-# A heading at an item's content column belongs to that item. The marker needs
-# whitespace after it, so `2.0` is a version, not an item.
+# A heading at an item's content column belongs to that item. The marker needs whitespace after
+# it, so `2.0` is a version, not an item.
 _LIST_ITEM = re.compile(r"^[ \t]*(?P<marker>[-*+]|\d{1,9}[.)])(?P<space>[ \t]+|$)")
 _THEMATIC_BREAK = re.compile(r"^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$")
-# Past this the content after a marker is indented code, so the item's content
-# starts one column past the marker instead.
+# Past this the content after a marker is indented code, so the item's content starts one column
+# past the marker instead.
 _MAX_ITEM_PADDING = 4
 _HTML_BLOCK_TAGS = frozenset(
     """
@@ -116,29 +113,23 @@ _HTML_TAG_ONLY_LINE = re.compile(
 _COMMENT_BLOCK_OPEN = re.compile(r"^ {0,3}<!--")
 _COMMENT_OPEN = "<!--"
 _COMMENT_CLOSE = "-->"
-# Stands in for a line the renderer hides: `#` is a block of its own, so list
-# tracking never reads it as a marker or a lazy continuation.
+# Stands in for a line the renderer hides: `#` is a block of its own.
 _HIDDEN_BLOCK = "#"
 _SAFE_VERSION_PATTERN = re.compile(r"^[0-9A-Za-z][0-9A-Za-z.!+-]{0,63}$")
 
-# Sections GitHub or the release workflow generates. Matched on the normalised
-# title, so `## What's Changed in Unsloth-Zoo` and a curly apostrophe still
-# match. Narrow rather than a substring sweep: "What changed in Gemma 4" is an
-# announcement one apostrophe away.
+# Sections GitHub or the release workflow generates, matched on the normalised title. Narrow
+# rather than a substring sweep: "What changed in Gemma 4" is an announcement one apostrophe away.
 _GENERATED_TITLES = frozenset({"what's changed", "whats changed", "new contributors"})
 _GENERATED_PREFIXES = ("what's changed in ", "whats changed in ")
 _GENERATED_SUFFIXES = ("zoo changes", "notebooks changes", "changelog")
-# The install block, worded differently in almost every release ("Updating /
-# installing Unsloth", "To update Unsloth", "Update Unsloth via `pip install`").
-# Naming Unsloth or Unsloth separates those from "Updating models is now 2x
-# faster", which is a change and not instructions.
+# The install block, worded differently in almost every release. Naming Unsloth separates those
+# from "Updating models is now 2x faster", which is a change and not instructions.
 _UPGRADE_PREFIXES = ("update", "updating", "to update", "how to update")
 _UPGRADE_SUBJECTS = ("unsloth", "studio")
 _UPGRADE_TITLES = frozenset({"update instructions", "install instructions"})
 _PROVENANCE = "build provenance"
-# Platform headings the install block splits its commands across, written as its
-# siblings as often as its children, so level alone does not end the block. The
-# separator is a slash or a comma, however it is spaced.
+# Platform headings the install block splits its commands across, written as its siblings as often
+# as its children, so level alone does not end the block.
 _PLATFORM_SEPARATOR = re.compile(r"\s*[/,]\s*")
 _PLATFORM_TITLES = frozenset(
     {
@@ -436,8 +427,7 @@ def scan_blocks(text: str):
             and paragraph != []
             and _SETEXT_UNDERLINE.match(visible) is not None
             and (visible.strip()[:1] == "-")
-            # Never a boundary in a list item: dedented the dashes are a break,
-            # at the content column the heading is nested.
+            # Never a boundary in a list item: dedented the dashes are a break
             and not lists.columns
         )
         if setext:
@@ -616,15 +606,15 @@ def get_latest_release(refresh: bool = False) -> ReleaseSource:
     global _remote_cache, _remote_fetching
 
     if refresh:
-        # Only a cached failure is dropped, never a rate-limit lockout: retrying
-        # into one spends nothing and only delays the reset.
+        # Only a cached failure is dropped, never a rate-limit lockout: retrying into one spends nothing
+    # and only delays the reset.
         with _cache_condition:
             rate_limited = _rate_limited_until > time.time()
             if _remote_cache and _remote_cache.source.release is None and not rate_limited:
                 _remote_cache = None
 
-    # A caller waits only as long as a fetch may take, then answers without notes
-    # rather than holding a worker behind a stalled upstream.
+    # A caller waits only as long as a fetch may take, then answers without notes rather than
+# holding a worker behind a stalled upstream.
     deadline = time.monotonic() + RELEASES_TIMEOUT_SECONDS + 1
     while True:
         now = time.monotonic()
@@ -657,8 +647,6 @@ def get_latest_release(refresh: bool = False) -> ReleaseSource:
             _remote_cache = _ReleaseCacheEntry(source = source, expires_at = time.monotonic() + ttl)
         return source
     finally:
-        # Released here, not on the Exception path: stranding the single-flight
-        # flag on BaseException makes every later caller wait out the deadline.
         with _cache_condition:
             _remote_fetching = False
             _cache_condition.notify_all()

--- a/studio/backend/utils/release_notes.py
+++ b/studio/backend/utils/release_notes.py
@@ -607,14 +607,14 @@ def get_latest_release(refresh: bool = False) -> ReleaseSource:
 
     if refresh:
         # Only a cached failure is dropped, never a rate-limit lockout: retrying into one spends nothing
-    # and only delays the reset.
+        # and only delays the reset.
         with _cache_condition:
             rate_limited = _rate_limited_until > time.time()
             if _remote_cache and _remote_cache.source.release is None and not rate_limited:
                 _remote_cache = None
 
     # A caller waits only as long as a fetch may take, then answers without notes rather than
-# holding a worker behind a stalled upstream.
+    # holding a worker behind a stalled upstream.
     deadline = time.monotonic() + RELEASES_TIMEOUT_SECONDS + 1
     while True:
         now = time.monotonic()

--- a/studio/backend/utils/remote_access_settings.py
+++ b/studio/backend/utils/remote_access_settings.py
@@ -222,9 +222,7 @@ def remote_access_status(app_state) -> dict:
         "Cloudflare URL was not reachable",
         "cloudflared did not register a connection",
         "cloudflared exited",
-        # Why Start is blocked: the connector's exit was never confirmed, so it
-        # still holds the runtime slot. The generic text hides the one reason
-        # the user can act on.
+        # Why Start is blocked: the connector's exit was never confirmed
         "cloudflared could not be stopped",
     }:
         error = "Cloudflare tunnel failed"
@@ -324,10 +322,7 @@ def stop_remote_access(app_state) -> dict:
         global _stop_worker_admission
         from cloudflare_tunnel import get_studio_tunnel_status, stop_studio_tunnel
 
-        # A stop can beat the newly-created start worker to the controller. Wait
-        # until it claims settings ownership, then cancel that generation. Bounded:
-        # a start that never claims it (foreign owner, bailed on admission) must
-        # not defer the user's Stop for the probe deadline.
+        # A stop can beat the newly-created start worker to the controller.
         deadline = time.monotonic() + _STOP_OWNERSHIP_WAIT
         while _worker_alive(_start_worker) and time.monotonic() < deadline:
             if get_studio_tunnel_status()["managed_by"] == "settings":
@@ -337,9 +332,8 @@ def stop_remote_access(app_state) -> dict:
         if current[0] != admission[0]:
             return
         if get_studio_tunnel_status()["managed_by"] == "settings":
-            # Every Stop admitted before this teardown decision must finish
-            # traversing cloudflared. Closing admission at the end of the drain
-            # prevents a later request from creating an unobserved lease.
+            # Every Stop admitted before this teardown decision must finish traversing cloudflared, so
+    # admission closes at the end of the drain, else a later request creates an unobserved lease.
             _drain_and_close_remote_access_stop_responses()
             current = get_studio_tunnel_control_token()
             if current[0] != admission[0] or get_studio_tunnel_status()["managed_by"] != "settings":

--- a/studio/backend/utils/remote_access_settings.py
+++ b/studio/backend/utils/remote_access_settings.py
@@ -333,7 +333,7 @@ def stop_remote_access(app_state) -> dict:
             return
         if get_studio_tunnel_status()["managed_by"] == "settings":
             # Every Stop admitted before this teardown decision must finish traversing cloudflared, so
-    # admission closes at the end of the drain, else a later request creates an unobserved lease.
+            # admission closes at the end of the drain, else a later request creates an unobserved lease.
             _drain_and_close_remote_access_stop_responses()
             current = get_studio_tunnel_control_token()
             if current[0] != admission[0] or get_studio_tunnel_status()["managed_by"] != "settings":

--- a/studio/backend/utils/security/consent.py
+++ b/studio/backend/utils/security/consent.py
@@ -51,7 +51,7 @@ class RemoteCodeDecision:
     max_severity: Optional[str]
     findings_summary: str
     reason: str
-    findings: list = field(default_factory = list)  # structured [{severity,file,check,evidence}]
+    findings: list = field(default_factory = list)
     approvable: bool = True  # False only for CRITICAL (user cannot override)
 
     def response_payload(self) -> dict:
@@ -166,7 +166,7 @@ def _load_remote_code_configs(
                     cache_dir = active_hf_hub_cache(),
                 )
             except EntryNotFoundError:
-                continue  # genuine 404 -> truly absent
+                continue
             except Exception:
                 # Transient/auth failure is not "absent" -> fail closed to "unknown" so the caller scans.
                 return None
@@ -244,10 +244,10 @@ def evaluate_remote_code_consent_for_targets(
             primary, False, False, None, None, "", "trust_remote_code disabled"
         )
 
-    # Persistent per-user approval: seed the stored fingerprint so the authoritative scan below
-    # auto-approves an unchanged repo (skips only the prompt, never the scan). Gated so it cannot
-    # weaken the scan: the approval must match the current ruleset, and a resolvable commit SHA must
-    # match the approved revision. The fingerprint and the CRITICAL block still apply.
+    # Persistent per-user approval seeds the stored fingerprint so the scan below auto-approves an
+    # unchanged repo, skipping the prompt but never the scan. Gated so it cannot weaken the scan:
+    # the approval must match the current ruleset and a resolvable commit SHA the approved revision.
+    # The fingerprint and the CRITICAL block still apply.
     caller_approved_fingerprint = approved_fingerprint
     if subject:
         from utils.security import remote_code_approvals
@@ -328,8 +328,7 @@ def evaluate_remote_code_consent_for_targets(
     elif approved:
         blocked, reason = False, "approved by fingerprint"
     elif sev == HIGH:
-        # HIGH is user-approvable but must pin the fingerprint via the dialog, for every repo including
-        # first-party (a compromised trusted repo still needs review).
+        # HIGH is user-approvable but must pin the fingerprint via the dialog.
         blocked, reason = True, "blocked: scan found HIGH patterns; approval required"
     elif sev == MEDIUM:
         # MEDIUM (e.g. a big embedded base64 blob) also pins approval like HIGH, so a direct API caller

--- a/studio/backend/utils/security/file_security.py
+++ b/studio/backend/utils/security/file_security.py
@@ -468,8 +468,8 @@ def _cached_pickle_weight_files(snapshot: Path, load_subdirs = ()) -> list:
         # A torch weight index makes from_pretrained load nested shards iterdir never sees, torch.loading
         # Probe the canonical index name with the loader's own lookup so an oddly-cased artifact it would never open
         # does not block. model.safetensors wins over both.
-    # any not ending in .safetensors, so probe the canonical index name with the loader's own lookup
-    # (an oddly-cased artifact it would never open must not block). model.safetensors wins over both.
+        # any not ending in .safetensors, so probe the canonical index name with the loader's own lookup
+        # (an oddly-cased artifact it would never open must not block). model.safetensors wins over both.
         for index_name in _TORCH_INDEX_FILES:
             if not _loader_resolves(root, index_name):
                 continue

--- a/studio/backend/utils/security/file_security.py
+++ b/studio/backend/utils/security/file_security.py
@@ -197,9 +197,9 @@ def _indexed_shard_paths(
                     cache_dir = active_hf_hub_cache(),
                 )
             except EntryNotFoundError:
-                continue  # definitively absent, not an error
+                continue
             except Exception:
-                inconclusive = True  # transient: an index that might exist could not be read
+                inconclusive = True
                 continue
             try:
                 weight_map = (json.loads(open(index_path, encoding = "utf-8-sig").read()) or {}).get(
@@ -231,7 +231,7 @@ class FileSecurityDecision:
 
     model_name: str
     blocked: bool
-    unsafe_files: list = field(default_factory = list)  # [{"path", "level"}]
+    unsafe_files: list = field(default_factory = list)
     reason: str = ""
 
     def response_payload(self) -> dict:
@@ -321,7 +321,7 @@ def _fetch_security_status(
                 timeout = timeout,
             )
             return getattr(info, "security_repo_status", None)
-        except Exception as exc:  # network/offline/gated/404/unsupported-client
+        except Exception as exc:
             last_exc = exc
             if attempt == 0:
                 continue
@@ -354,7 +354,7 @@ def _st_load_roots(snapshot: Path, load_subdirs = ()) -> list:
         import json
         modules = json.loads((snapshot / "modules.json").read_text(encoding = "utf-8-sig"))
     except (OSError, ValueError):
-        return roots  # no / invalid modules.json -> only declared load roots apply
+        return roots
     for module in modules if isinstance(modules, list) else ():
         if not isinstance(module, dict):
             continue
@@ -410,7 +410,8 @@ def _indexed_pickle_shards(index_path: Path, root: Path, snapshot: Path) -> list
         if joined != snapshot_norm and not joined.startswith(snapshot_norm + os.sep):
             raise OSError(f"weight index escapes the snapshot: {index_path}")
         shard_path = Path(joined)
-        # Case-SENSITIVE, mirroring load_state_dict's own endswith(".safetensors"): payload.SAFETENSORS falls to torch.load.
+        # Case-SENSITIVE, mirroring load_state_dict's own endswith(".safetensors"): payload.SAFETENSORS falls to
+        # torch.load.
         if not shard_path.name.endswith(".safetensors") and shard_path.is_file():
             shards.append(shard_path)
     return shards
@@ -447,10 +448,11 @@ def _cached_pickle_weight_files(snapshot: Path, load_subdirs = ()) -> list:
             entries = [p for p in root.iterdir() if p.is_file()]
         except OSError:
             if root == snapshot:
-                raise  # top-level unreadable -> fail closed
-            continue  # unreadable module subdir: nothing loadable to attest here
-        # Safetensors alternatives the loader would actually resolve (never a bare name-fold, which fails
-        # OPEN). A base pickle is replaced only by a base safetensors; model.safetensors outranks both indexes.
+                raise
+            continue
+        # Safetensors alternatives the loader would actually resolve
+        # Never a bare name-fold, which fails OPEN. A base pickle is replaced only by a base safetensors, and
+        # model.safetensors outranks both indexes.
         has_direct_base_safetensors = _loader_resolves(root, "model.safetensors")
         has_base_safetensors = has_direct_base_safetensors or _loader_resolves(
             root, "model.safetensors.index.json"
@@ -464,8 +466,10 @@ def _cached_pickle_weight_files(snapshot: Path, load_subdirs = ()) -> list:
             if not has_alternative:
                 _add(path)
         # A torch weight index makes from_pretrained load nested shards iterdir never sees, torch.loading
-        # any not ending in .safetensors. Probe the canonical index name with the loader's own lookup so
-        # an oddly-cased artifact it would never open does not block. model.safetensors wins over both.
+        # Probe the canonical index name with the loader's own lookup so an oddly-cased artifact it would never open
+        # does not block. model.safetensors wins over both.
+    # any not ending in .safetensors, so probe the canonical index name with the loader's own lookup
+    # (an oddly-cased artifact it would never open must not block). model.safetensors wins over both.
         for index_name in _TORCH_INDEX_FILES:
             if not _loader_resolves(root, index_name):
                 continue
@@ -637,13 +641,13 @@ def evaluate_file_security(
                 load_subdirs = load_subdirs,
             )
 
-    # Block a non-``safe`` flagged file scoped to the load-path RCE vector (root-level,
-    # code-executing). Not gated on ``scansDone`` (often false even when clean). Unknown levels fail
-    # closed. Subdir pickles and inert formats are not loaded by from_pretrained and do not block; an
-    # unavailable status is fail-open only for an unresolved remote ref.
+    # Block a non-``safe`` flagged file scoped to the load-path RCE vector
+    # Not gated on ``scansDone`` (often false even when clean), and unknown levels fail closed. Subdir pickles and inert
+    # formats are not loaded by from_pretrained and do not block; an unavailable status is fail-open only for an
+    # unresolved remote ref.
     unsafe = []
-    skipped = []  # flagged, but not a load-path RCE vector (subdir artifact / inert)
-    maybe_shard = []  # flagged subdir pickle: a load vector ONLY if a root index lists it
+    skipped = []
+    maybe_shard = []
     for entry in status.get("filesWithIssues") or []:
         if not isinstance(entry, dict):
             continue
@@ -659,7 +663,7 @@ def evaluate_file_security(
             # Inert formats cannot execute on load; source code is the consent gate's domain (auto_map).
             skipped.append({"path": path, "level": level})
         elif "/" not in load_rel:
-            unsafe.append({"path": path, "level": level})  # root pickle -> load vector
+            unsafe.append({"path": path, "level": level})
         else:
             # Subdir pickle: deserialized only if a weight index references it.
             maybe_shard.append({"path": path, "level": level, "norm": norm})

--- a/studio/backend/utils/security/remote_code_approvals.py
+++ b/studio/backend/utils/security/remote_code_approvals.py
@@ -71,8 +71,8 @@ def _load() -> dict:
     try:
         with open(_store_path(), encoding = "utf-8-sig") as f:
             data = json.load(f)
-        # Validate the shape, not just the version: a hand-edited ``subjects`` that is not a
-        # dict (e.g. ``[]``) would otherwise crash lookup/record instead of failing safe.
+        # Validate the shape, not just the version: a hand-edited ``subjects`` that is not a dict would
+        # crash lookup/record instead of failing safe.
         if (
             isinstance(data, dict)
             and data.get("version") == _SCHEMA_VERSION
@@ -130,7 +130,7 @@ def _file_lock():
                 import fcntl
                 fcntl.flock(fd, fcntl.LOCK_EX)
         except Exception:
-            pass  # locking unavailable; the thread lock still applies
+            pass
         yield
     finally:
         try:
@@ -182,7 +182,7 @@ def record(
         data = _load()
         subjects = data.setdefault("subjects", {})
         subj = subjects.get(subject)
-        if not isinstance(subj, dict):  # tolerate a hand-edited non-dict entry
+        if not isinstance(subj, dict):
             subj = subjects[subject] = {}
         subj[target_key] = {
             "commit_sha": commit_sha,

--- a/studio/backend/utils/security/remote_code_scan.py
+++ b/studio/backend/utils/security/remote_code_scan.py
@@ -739,8 +739,8 @@ def _add_external_refs(files: dict, refs, hf_token, model_name: str) -> bool:
             )
             return False
         # The loader's executable closure is every present .py plus any referenced entry file. With a
-    # non-empty listing, an entry ref absent from present_py is stale and is dropped; with an EMPTY
-    # listing staleness cannot be proven, so keep fetching and fail closed. Never under-scan.
+        # non-empty listing, an entry ref absent from present_py is stale and is dropped; with an EMPTY
+        # listing staleness cannot be proven, so keep fetching and fail closed. Never under-scan.
         # A PRESENT file that cannot be fetched still fails closed below.
         repo_file_set = set(repo_files)
         present_py = {f for f in repo_files if f.endswith(".py")}

--- a/studio/backend/utils/security/remote_code_scan.py
+++ b/studio/backend/utils/security/remote_code_scan.py
@@ -49,8 +49,8 @@ _SEVERITY_ORDER = {CRITICAL: 0, HIGH: 1, MEDIUM: 2}
 SCAN_RULES_VERSION = 1
 
 # Configs that can carry an ``auto_map`` pointing at executable repo ``.py``.
-# ``trust_remote_code`` runs code from ANY of these, so scanner and gate must read the
-# same set (scanning only config.json/tokenizer would miss a custom-processor VLM).
+# ``trust_remote_code`` runs code from ANY of these, so scanner and gate must read the same set: scanning only
+# config.json/tokenizer would miss a custom-processor VLM.
 REMOTE_CODE_CONFIG_FILES = (
     "config.json",
     "tokenizer_config.json",
@@ -295,10 +295,9 @@ def _load_canonical_scanner():
     return module
 
 
-# Model-context-strict patterns. The canonical scanner only flags bare
-# ``subprocess``/``eval`` in combinations (common in package build scripts), but a
-# model's modeling_*.py never legitimately shells out, so the gate flags them alone
-# (e.g. a bare ``subprocess.Popen`` in a config ``__init__``).
+# Model-context-strict patterns: the canonical scanner flags bare ``subprocess``/``eval`` only in
+# combinations, but a model's modeling_*.py never legitimately shells out, so these flag alone.
+# For example a bare ``subprocess.Popen`` in a config ``__init__``.
 _MODEL_STRICT_PATTERNS: tuple[tuple[re.Pattern, str, str], ...] = (
     (
         re.compile(
@@ -470,12 +469,10 @@ def repo_remote_code_files(
         if is_local_path(model_name):
             root = Path(normalize_path(model_name)).expanduser()
 
-            # Walk ALL .py, not just the auto_map entry's static import closure. This is
-            # DELIBERATE (see the remote-branch note): the entry can reach a sibling via
-            # an absolute import, importlib, or exec, which a relative-import closure
-            # misses, so closure-only scanning is a real bypass. Broad scan never
-            # under-scans; the cost is a benign script can over-block, the safe direction
-            # for an RCE gate (HIGH stays approvable; only CRITICAL hard-blocks).
+            # Walk ALL .py, not just the auto_map entry's static import closure. This is DELIBERATE: the entry can reach
+            # a sibling via an absolute import, importlib, or exec, which a relative-import closure misses, so closure-
+            # only scanning is a real bypass. A broad scan never under-scans; the cost is that a benign script can over-
+            # block, the safe direction for an RCE gate (HIGH stays approvable; only CRITICAL hard-blocks).
             def raise_walk_error(error):
                 raise error
 
@@ -503,10 +500,9 @@ def repo_remote_code_files(
                             f"{model_name}: Python source {p.relative_to(root)} is unreadable"
                         )
                     files[str(p.relative_to(root))] = _read_python_source(p)
-            # A local config can still point auto_map at an EXTERNAL Hub repo
-            # (owner/name--module.Class) that executes on load, so fetch it. Every config
-            # that can declare auto_map is checked, so a custom processor's external code
-            # is not missed.
+            # A local config can still point auto_map at an EXTERNAL Hub repo that executes on load, so fetch it; every
+            # config that can declare auto_map is checked.
+            # The external form is owner/name--module.Class.
             ext_refs = set()
             for name in remote_code_config_paths(load_subdirs):
                 p = root.joinpath(*pathlib.PurePosixPath(name).parts)
@@ -557,18 +553,13 @@ def repo_remote_code_files(
         except Exception as exc:
             raise RemoteCodeUnscannable(f"{model_name}: could not list repo files ({exc})") from exc
         repo_file_set = set(repo_files)
-        # Scan every present .py PLUS own-repo auto_map targets that ACTUALLY EXIST in
-        # this revision. Scanning EVERY .py (not just the closure) is DELIBERATE: the
-        # entry can reach a sibling via absolute import / importlib / exec, which a
-        # relative-import closure misses, so closure-only scanning is a real bypass.
-        # Broad scan never under-scans; the cost is a benign script can over-block, the
-        # safe direction for an RCE gate (HIGH approvable; only CRITICAL hard-blocks). An
-        # auto_map target absent from the listing is a STALE ref (an older config naming a
-        # since-removed file, e.g. unsloth/PaddleOCR-VL names processing_ppocrvl.py but
-        # ships processing_paddleocr_vl.py). transformers cannot execute an absent file,
-        # so drop the stale ref rather than fail closed; present .py are still fully
-        # scanned. This also absorbs a mis-derived dotted name (sub.mod.py vs sub/mod.py):
-        # the bad name drops as stale while the real present file is scanned.
+        # Scan every present .py PLUS own-repo auto_map targets that ACTUALLY EXIST in this revision. Scanning every .py
+        # rather than the closure is DELIBERATE: the entry can reach a sibling via absolute import / importlib / exec,
+        # so closure-only scanning is a real bypass, and over-blocking is the safe direction for an RCE gate (HIGH
+        # approvable; only CRITICAL hard-blocks). An auto_map target absent from the listing is a STALE ref
+        # (unsloth/PaddleOCR-VL names processing_ppocrvl.py but ships processing_paddleocr_vl.py); transformers cannot
+        # execute an absent file, so drop the stale ref rather than fail closed. This also absorbs a mis-derived dotted
+        # name (sub.mod.py vs sub/mod.py).
         present_py = {f for f in repo_files if f.endswith(".py")}
         stale_refs = own_refs - repo_file_set
         for fn in sorted(stale_refs):
@@ -588,10 +579,8 @@ def repo_remote_code_files(
                     cache_dir = active_hf_hub_cache(),
                 )
             except Exception as exc:
-                # A .py CONFIRMED PRESENT could not be fetched. A partial set would
-                # fingerprint "clean" while transformers later runs this file, so fail
-                # closed. (Stale/absent refs were dropped above, so this only fires on a
-                # present-file fetch failure.)
+                # A .py CONFIRMED PRESENT could not be fetched: a partial set would fingerprint "clean" while
+                # transformers later runs the file, so fail closed.
                 raise RemoteCodeUnscannable(
                     f"{model_name}: present file {fn} could not be fetched ({exc})"
                 ) from exc
@@ -643,7 +632,7 @@ def _auto_map_refs(cfg: dict) -> set:
                 # ref like "modeling_deepseekocr.Cls" or "owner/name--modeling.Cls"
                 if "." not in ref:
                     continue
-                module = ref.rsplit(".", 1)[0]  # drop trailing .ClassName
+                module = ref.rsplit(".", 1)[0]
                 if "--" in module:
                     repo, mod = module.split("--", 1)
                     out.add((repo or None, mod + ".py"))
@@ -749,12 +738,10 @@ def _add_external_refs(files: dict, refs, hf_token, model_name: str) -> bool:
                 exc,
             )
             return False
-        # The loader's executable closure = every present .py plus any referenced entry
-        # file. With a REAL (non-empty) listing, present_py covers the code, so an entry
-        # ref absent from it is stale/mis-derived and is dropped rather than failing
-        # closed (like the own-repo path). With an EMPTY listing we cannot prove the ref
-        # stale, so keep fetching it and fail closed if unreachable; never under-scan. A
-        # PRESENT file that cannot be fetched still fails closed below.
+        # The loader's executable closure is every present .py plus any referenced entry file. With a
+    # non-empty listing, an entry ref absent from present_py is stale and is dropped; with an EMPTY
+    # listing staleness cannot be proven, so keep fetching and fail closed. Never under-scan.
+        # A PRESENT file that cannot be fetched still fails closed below.
         repo_file_set = set(repo_files)
         present_py = {f for f in repo_files if f.endswith(".py")}
         if repo_file_set:

--- a/studio/backend/utils/security/trusted_org.py
+++ b/studio/backend/utils/security/trusted_org.py
@@ -23,8 +23,8 @@ logger = get_logger(__name__)
 # Orgs we auto-enable remote code for.
 TRUSTED_ORGS: frozenset[str] = frozenset({"unsloth", "nvidia"})
 
-# Keyed on (name, verify_remote, token) so an unauthenticated failure can't poison
-# a later authenticated lookup; token is hashed, never stored raw.
+# Keyed on (name, verify_remote, token) so an unauthenticated failure cannot poison a later
+# authenticated lookup; the token is hashed, never stored raw.
 _verdict_cache: dict[tuple[str, bool, str], bool] = {}
 
 
@@ -88,7 +88,6 @@ def _evaluate(name: str, hf_token: Optional[str], verify_remote: bool) -> bool:
     if not verify_remote or _env_offline():
         return True
 
-    # Online: confirm the id resolves to a trusted-org repo.
     try:
         from huggingface_hub import HfApi
 
@@ -106,7 +105,7 @@ def _evaluate(name: str, hf_token: Optional[str], verify_remote: bool) -> bool:
             resolved_id,
         )
         return False
-    except Exception as exc:  # network/404/auth -> fail closed
+    except Exception as exc:
         logger.warning(
             "is_trusted_org_repo(%s): Hub verification failed (%s) -> not trusted",
             name,

--- a/studio/backend/utils/ssm_runtime.py
+++ b/studio/backend/utils/ssm_runtime.py
@@ -405,7 +405,7 @@ def _install_kernel(
         "env": utf8_child_env(),
     }
     if is_hip:
-        run_kwargs["timeout"] = 1800  # ROCm builds can take 10-30 min
+        run_kwargs["timeout"] = 1800
         existing = os.environ.get("HIPCC_COMPILE_FLAGS_APPEND", "")
         if "--gcc-install-dir" not in existing:
             gcc_dir = _hipcc_gcc_install_dir()

--- a/studio/backend/utils/third_party_source.py
+++ b/studio/backend/utils/third_party_source.py
@@ -107,10 +107,7 @@ _ARCHIVE_MAX_TAR_BYTES = 160 * 1024 * 1024
 _ARCHIVE_SOCKET_TIMEOUT_SECONDS = 15
 _ARCHIVE_DOWNLOAD_DEADLINE_SECONDS = 300
 
-# Git for Windows still enforces MAX_PATH (260) unless told otherwise, and the pinned cache
-# nests a 40-char revision, a staging dir and .git/objects under the studio home; a
-# venv-inferred home already reaches ~253 chars, so a slightly longer one fails the
-# checkout with "Filename too long". Passed per-invocation so no user config is touched.
+# Git for Windows still enforces MAX_PATH (260) unless told otherwise.
 _GIT_LONG_PATHS = ["-c", "core.longpaths=true"]
 
 
@@ -442,9 +439,7 @@ def _valid_checkout(path: Path, spec: PinnedSource) -> bool:
 
 
 def _clear_read_only(function, path, _error) -> None:
-    # Git marks .git/objects read-only, and Windows refuses to delete a read-only file, so
-    # replacing a checkout dies with WinError 5. Only retry when the path really is not
-    # writable: an open handle (WinError 32) must still surface rather than spin.
+    # Git marks .git/objects read-only.
     if os.access(path, os.W_OK):
         raise
     os.chmod(path, os.stat(path).st_mode | stat.S_IWRITE)
@@ -939,8 +934,8 @@ def ensure_dac_speech_weights(legacy_path: Path | str | None = None) -> Path:
                 expected_size = _DAC_SIZE,
                 expected_sha256 = _DAC_SHA256,
             ):
-                # Same as the download branch below: the copy is an optimisation, so a full
-                # disk must not reject weights that already passed the size and sha256 check.
+                # Same as the download branch below: the copy is an optimisation.
+                # A full disk must not reject weights that already passed the size and sha256 check.
                 try:
                     _install_verified_artifact(legacy, destination)
                 except OSError:
@@ -968,10 +963,9 @@ def ensure_dac_speech_weights(legacy_path: Path | str | None = None) -> Path:
                 expected_size = _DAC_SIZE,
                 expected_sha256 = _DAC_SHA256,
             ):
-                # Populate the pinned destination so later loads hit the fast path above
-                # instead of re-downloading and re-hashing 295 MB under the install lock.
-                # The copy is an optimisation, so a full disk must not fail a verified
-                # download; fall back to the hub path the caller used before.
+                # Populate the pinned destination so later loads hit the fast path instead of re-downloading and
+        # re-hashing 295 MB under the install lock. The copy is an optimisation, so a full disk falls
+        # back to the hub path rather than failing a verified download.
                 try:
                     _install_verified_artifact(downloaded, destination)
                 except OSError:
@@ -984,8 +978,6 @@ def ensure_dac_speech_weights(legacy_path: Path | str | None = None) -> Path:
                 ) from download_error
             raise RuntimeError("The downloaded DAC speech weights failed integrity validation")
     except OSError:
-        # Same reasoning as the mkdir above: taking the lock needs a writable cache, and
-        # verified weights we already hold are a better answer than failing the load.
         fallback = _verified_legacy()
         if fallback is None:
             raise
@@ -1012,10 +1004,7 @@ def _module_is_inside(module: ModuleType, package_root: Path) -> bool:
 
 
 def _purge_package_bytecode(package_root: Path) -> None:
-    # This is the only thing stopping a stale or planted .pyc from shadowing a verified .py:
-    # the manifest skips __pycache__ entirely, and the origin audit reads __file__, which
-    # still names the .py. So only the concurrent-purge race is tolerated (another worker
-    # deleting the same tree without the install lock); a PermissionError must stay fatal.
+    # This is the only thing stopping a stale or planted .pyc from shadowing a verified .py
     for directory, child_directories, files in os.walk(package_root, topdown = True):
         directory_path = Path(directory)
         for name in tuple(child_directories):
@@ -1064,15 +1053,15 @@ def import_pinned_module(module_name: str, *, package: str, source: Path | str) 
             sys.path.remove(source_value)
         sys.path.insert(0, source_value)
         try:
-            # Inside the try: anything raising here would otherwise strand the cache dir at
-            # sys.path[0] for the process lifetime, with nothing imported and no rollback.
+            # Inside the try: anything raising here would otherwise strand the cache dir at sys.path[0] for the process
+            # lifetime, with nothing imported and no rollback.
             _purge_package_bytecode(package_root)
             importlib.invalidate_caches()
             module = importlib.import_module(module_name)
             invalid_modules = sorted(
                 name
-                # Snapshot: another thread importing here would otherwise raise
-                # "dictionary changed size during iteration" out of a good codec load.
+                # Snapshot: another thread importing here would otherwise raise "dictionary changed size during
+        # iteration" out of a good codec load.
                 for name, loaded_module in list(sys.modules.items())
                 if (name == package or name.startswith(f"{package}."))
                 and not _module_is_inside(loaded_module, package_root)

--- a/studio/backend/utils/third_party_source.py
+++ b/studio/backend/utils/third_party_source.py
@@ -964,8 +964,8 @@ def ensure_dac_speech_weights(legacy_path: Path | str | None = None) -> Path:
                 expected_sha256 = _DAC_SHA256,
             ):
                 # Populate the pinned destination so later loads hit the fast path instead of re-downloading and
-        # re-hashing 295 MB under the install lock. The copy is an optimisation, so a full disk falls
-        # back to the hub path rather than failing a verified download.
+                # re-hashing 295 MB under the install lock. The copy is an optimisation, so a full disk falls
+                # back to the hub path rather than failing a verified download.
                 try:
                     _install_verified_artifact(downloaded, destination)
                 except OSError:
@@ -1061,7 +1061,7 @@ def import_pinned_module(module_name: str, *, package: str, source: Path | str) 
             invalid_modules = sorted(
                 name
                 # Snapshot: another thread importing here would otherwise raise "dictionary changed size during
-        # iteration" out of a good codec load.
+                # iteration" out of a good codec load.
                 for name, loaded_module in list(sys.modules.items())
                 if (name == package or name.startswith(f"{package}."))
                 and not _module_is_inside(loaded_module, package_root)

--- a/studio/backend/utils/torch_device_probe.py
+++ b/studio/backend/utils/torch_device_probe.py
@@ -48,11 +48,10 @@ _SIGALRM_NUMBER = 14
 # ._is_abort_exit already matches for GGML_ASSERT deaths.
 _WINDOWS_ABORT_EXIT_STATUS = 3
 
-# Anything that changes which physical device a device string names, or which kernels the
-# runtime emits for it. A change invalidates a cached verdict, since the same "cuda" or
-# "xpu" would then be a different piece of silicon: a stale pass could skip the probe on an
-# untested device, and a stale failure could pin a working one to CPU. The XPU selectors
-# matter because _TORCH_DEVICE maps DeviceType.XPU to "xpu", so this probe runs there too.
+# Anything that changes which physical device a device string names, or which kernels the runtime emits for it. A change
+# invalidates a cached verdict: a stale pass could skip the probe on an untested device, and a stale failure could pin a
+# working one to CPU. The XPU selectors matter because _TORCH_DEVICE maps DeviceType.XPU to "xpu", so this probe runs
+# there too.
 _DEVICE_IDENTITY_ENV_VARS = (
     "CUDA_VISIBLE_DEVICES",
     "HIP_VISIBLE_DEVICES",
@@ -63,10 +62,9 @@ _DEVICE_IDENTITY_ENV_VARS = (
     "ONEAPI_DEVICE_SELECTOR",
 )
 
-# The matmul tests allocation and vendor BLAS initialization. item() synchronizes
-# the result so an asynchronous driver fault cannot escape after the child exits.
-# Windows DLL directories must be registered before importing torch because those
-# registrations are process-local and are not inherited by this interpreter.
+# The matmul tests allocation and vendor BLAS initialization.
+# item() synchronizes the result so an asynchronous driver fault cannot escape after the child exits, and Windows DLL
+# directories must be registered before importing torch, since those registrations are process-local.
 _PROBE_SCRIPT = """
 import os
 import signal
@@ -249,8 +247,7 @@ def _device_can_allocate_cached(device: str, _identity: tuple[str | None, ...]) 
             encoding = "utf-8",
             errors = "replace",
             env = utf8_child_env(env),
-            # No child_popen_kwargs() here. Its Linux preexec_fn can deadlock when
-            # this multithreaded backend forks and executes Python before exec.
+            # No child_popen_kwargs() here. Its Linux preexec_fn can deadlock
             **windows_hidden_subprocess_kwargs(),
         )
     except Exception:  # noqa: BLE001 - no child ran, so nothing was proven
@@ -297,12 +294,8 @@ def _device_can_allocate_cached(device: str, _identity: tuple[str | None, ...]) 
             return False
 
         if process.returncode < 0:
-            # Killed by something that is not a hard fault: an OOM kill, a container stop,
-            # an operator. That is not evidence against the device, but it is not the clean
-            # run this returns true for either, and importing torch and building its device
-            # context is itself enough to trip a cgroup limit. Reading it as a pass would
-            # send _load_device() on to a much larger load in this process, which is the
-            # death the probe exists to prevent, so it takes the no-verdict path instead.
+            # An OOM kill or container stop is not evidence against the device but is not a clean run either, and
+            # reading it as a pass would send _load_device() into the death the probe prevents.
             return _unknown_verdict(
                 device,
                 f"was killed by signal {-process.returncode} without faulting",
@@ -335,12 +328,11 @@ def _terminate_and_drain(process: subprocess.Popen) -> str:
             _, stderr = process.communicate(timeout = _TERMINATE_GRACE_SECONDS)
             return stderr or ""
         except subprocess.TimeoutExpired:
-            continue  # still alive, escalate
+            continue
         except OSError:
-            break  # pipes are unusable, so there is nothing left to drain
+            break
 
-    # Not confirmed dead, whether it outlived SIGKILL or could not be read. Either way the
-    # last reference must not simply be dropped.
+    # Not confirmed dead, whether it outlived SIGKILL or could not be read.
     _reap_later(process)
     return stderr or ""
 

--- a/studio/backend/utils/torch_warmup.py
+++ b/studio/backend/utils/torch_warmup.py
@@ -127,9 +127,6 @@ def purge_partial_import(package: str) -> list:
         return []
     prefix = package + "."
     stale = [name for name in list(sys.modules) if name.startswith(prefix)]
-    # Re-check before touching anything: a retrying importer publishes the parent as soon
-    # as its __init__ begins, and popping submodules out from under it produces the very
-    # half-initialised package this prevents. Narrows the window; CPython's lock is private.
     if package in sys.modules:
         logger.info(
             "not purging %s: another importer republished it while collecting its "
@@ -181,10 +178,8 @@ _STAGE_PACKAGE = {
     "datasets": "datasets",
 }
 
-# Hold the import lock across a bare import and its failure cleanup. Locking only
-# the purge leaves a window where a queued importer can reuse stale submodules.
-# Hardware and transformers acquire additional locks, so exclude them to avoid
-# lock-order inversions.
+# Hold the import lock across a bare import AND its failure cleanup: locking only the purge leaves a window where a
+# queued importer reuses stale submodules.
 _BARE_IMPORT_STAGES = frozenset({"datasets"})
 
 
@@ -218,9 +213,7 @@ def _run_stage(name: str, fn) -> None:
 
 
 def _warm_hardware(epoch: Optional[int] = None) -> None:
-    # Requests hit the same call, so they reuse the cache or block on this thread's lock,
-    # never race a second detection. The epoch rides along: a shutdown landing between
-    # _warm()'s check and _DETECT_LOCK would else publish for the lifespan that just ended.
+    # Requests hit the same call.
     from utils.hardware import ensure_hardware_detected
     ensure_hardware_detected(epoch)
 

--- a/studio/backend/utils/transformers_dtype.py
+++ b/studio/backend/utils/transformers_dtype.py
@@ -33,10 +33,9 @@ def _has_torch_dtype_kwarg() -> bool:
         import transformers
         from packaging.version import Version
 
-        # Compare on the release tuple so a pre-release of the rename version
-        # (``4.56.0.dev0``/``rc1``, which sort *below* ``4.56.0``) still counts as
-        # new and picks ``dtype`` -- those builds already accept it, and picking
-        # ``torch_dtype`` there would re-emit the very warning this suppresses.
+        # Compare on the release tuple so a pre-release of the rename version (4.56.0.dev0, which sorts BELOW 4.56.0)
+        # still picks ``dtype``, which those builds already accept.
+        # ``rc1`` sorts below as well, and picking ``torch_dtype`` there would re-emit the very warning this suppresses.
         return Version(transformers.__version__).release < (4, 56, 0)
     except Exception:
         return False

--- a/studio/backend/utils/transformers_latest.py
+++ b/studio/backend/utils/transformers_latest.py
@@ -509,6 +509,7 @@ def check_upgrade_for_model(model_name: str, hf_token: str | None = None) -> dic
 
 # Sidecars install transformers --no-deps atop the base env. Before installing, compare
 # requires_dist: unsatisfied shadowable deps become exact --target pins, anything else blocks.
+# --- Dependency compatibility preflight ------------------------------------------------------
 _SHADOWABLE_DEPS = frozenset({"tokenizers", "safetensors"})
 # Provided by the sidecar recipe; checked against its pin, not the base env.
 _SIDECAR_PROVIDED = {"huggingface-hub": "1.8.0", "hf-xet": "1.4.2"}

--- a/studio/backend/utils/transformers_latest.py
+++ b/studio/backend/utils/transformers_latest.py
@@ -506,7 +506,6 @@ def check_upgrade_for_model(model_name: str, hf_token: str | None = None) -> dic
         return None
 
 
-
 # Sidecars install transformers --no-deps atop the base env. Before installing, compare
 # requires_dist: unsatisfied shadowable deps become exact --target pins, anything else blocks.
 # --- Dependency compatibility preflight ------------------------------------------------------

--- a/studio/backend/utils/transformers_latest.py
+++ b/studio/backend/utils/transformers_latest.py
@@ -69,10 +69,9 @@ _AUTO_FILES = ("configuration_auto.py", "auto_mappings.py")
 
 _FETCH_TIMEOUT_SECONDS = 5.0
 _FETCH_RETRIES = 1
-# urlopen's timeout bounds each individual read, never the whole transfer, so a mirror
-# dribbling a few bytes just inside it keeps resp.read() alive indefinitely (measured:
-# 12 chunks 1s apart read in 12.0s under timeout=5.0). The transfer gets its own
-# wall-clock budget instead: one timeout for the connect, one for the body.
+# urlopen's timeout bounds each individual read, never the whole transfer.
+# Measured: 12 chunks 1s apart read in 12.0s under timeout=5.0. The transfer gets its own wall-clock budget instead, one
+# for the connect and one for the body.
 _FETCH_DEADLINE_SECONDS = 2 * _FETCH_TIMEOUT_SECONDS
 # One attempt's true worst case: the budget, plus the single socket read already blocking
 # when it runs out (the deadline is only tested between reads).
@@ -94,13 +93,10 @@ _is_fetching: bool = False
 # fetch's answer instead of reporting "no answer" (see _get_snapshot).
 _fetch_done: threading.Event = threading.Event()
 _fetch_done.set()
-# Backstop for that wait, bounded by the refresh's OWN worst case: the PyPI version plus
-# both auto files at each of the two refs, each allowed its retry at _FETCH_ATTEMPT_SECONDS.
-# Derived rather than a literal, so tuning a timeout, a retry or the transfer budget cannot
-# silently shrink it below what it bounds. Only a backstop: giving up early is not graceful
-# here, since the answer it falls through to reads as "no upgrade needed" all the way to the
-# Start button, launching the run on the architecture this gate exists to stop. So the
-# waiter re-waits while the refresh is genuinely in flight (_get_snapshot).
+# Derived rather than a literal, so tuning a timeout or retry cannot silently shrink the backstop below what it bounds;
+# giving up early reads as "no upgrade needed" at the Start button.
+# Bounded by the refresh's OWN worst case: the PyPI version plus both auto files at each of the two refs, each allowed
+# its retry at _FETCH_ATTEMPT_SECONDS. The waiter re-waits while the refresh is genuinely in flight (_get_snapshot).
 _REFRESH_URL_COUNT = 1 + 2 * len(_AUTO_FILES)
 _INFLIGHT_WAIT_SECONDS = _REFRESH_URL_COUNT * (1 + _FETCH_RETRIES) * _FETCH_ATTEMPT_SECONDS + 5.0
 
@@ -315,11 +311,8 @@ def _get_snapshot() -> dict | None:
             _is_fetching = True
             _fetch_done = done = threading.Event()
     if in_flight is not None:
-        # Wait for the refresh's actual completion, not for a clock. An expiry here is
-        # not "no upgrade needed", it is "the answer is still being fetched", and the
-        # callers above cannot tell those apart. So re-wait while this same refresh is
-        # running; the winner clears _is_fetching and sets the event in one locked
-        # finally, so either condition means it is done.
+        # Wait for the refresh's actual completion, not a clock: an expiry here means "still being fetched", which the
+        # callers above cannot tell from "no upgrade needed".
         while not in_flight.wait(_INFLIGHT_WAIT_SECONDS):
             with _lock:
                 if not _is_fetching or _fetch_done is not in_flight:
@@ -481,8 +474,8 @@ def check_upgrade_for_model(model_name: str, hf_token: str | None = None) -> dic
         ]
         if not missing:
             return None
-        # Latest must load EVERY missing type (wrappers build nested sub-configs
-        # through CONFIG_MAPPING) or the load still fails.
+        # Latest must load EVERY missing type (wrappers build nested sub-configs through CONFIG_MAPPING) or the load
+        # still fails.
         supports = [latest_transformers_supports(candidate) for candidate in missing]
         if any(
             s is None or not (s["supported_in_pypi"] or s["supported_in_main"]) for s in supports
@@ -513,11 +506,9 @@ def check_upgrade_for_model(model_name: str, hf_token: str | None = None) -> dic
         return None
 
 
-# --- Dependency compatibility preflight ------------------------------------------------------
+
 # Sidecars install transformers --no-deps atop the base env. Before installing, compare
 # requires_dist: unsatisfied shadowable deps become exact --target pins, anything else blocks.
-
-# Safe to shadow inside the sidecar dir (pure wheels, no torch coupling).
 _SHADOWABLE_DEPS = frozenset({"tokenizers", "safetensors"})
 # Provided by the sidecar recipe; checked against its pin, not the base env.
 _SIDECAR_PROVIDED = {"huggingface-hub": "1.8.0", "hf-xet": "1.4.2"}

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -383,7 +383,7 @@ TRANSFORMERS_DEFAULT_VERSION = "5.5.0" if sys.version_info >= (3, 10) else "4.57
 # TRANSFORMERS_550_VERSION / TRANSFORMERS_530_VERSION.
 TRANSFORMERS_5_VERSION = TRANSFORMERS_510_VERSION
 
-# Pre-installed directories — created by setup.sh / setup.ps1.
+# Pre-installed directories - created by setup.sh / setup.ps1.
 from utils.paths.storage_roots import studio_root as _studio_root  # noqa: E402
 
 _VENV_T5_530_DIR = str(_studio_root() / ".venv_t5_530")
@@ -3168,7 +3168,7 @@ def ensure_transformers_version(model_name: str) -> None:
         # Different 5.x -> need to switch (e.g. 5.3.0 loaded but need 5.10.x).
         in_memory_major = int(in_memory.split(".")[0])
         if in_memory_major == target_major and venv_dir is None:
-            # Both are default (4.x) — close enough.
+            # Both are default (4.x) - close enough.
             logger.info(
                 "transformers %s already loaded — correct for '%s'",
                 in_memory,

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -19,9 +19,11 @@ from utils.paths.path_utils import is_appledouble_metadata
 logger = get_logger(__name__)
 
 
+# An offline load must never touch the network (a DNS-dead session hangs on hub retries), so
+# these read the local HF cache.
+
 # ── Offline / HF-cache helpers ──────────────────────────────────
 # An offline load must never touch the network (a DNS-dead session hangs on hub retries); these read the local HF cache.
-
 _HF_OFFLINE_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 
 
@@ -96,7 +98,7 @@ def _stdlib_proxy_for_url(url: str) -> Optional[str]:
         if proxy_bypass(host):
             return None
     except Exception:
-        pass  # a bypass lookup that fails is not a bypass
+        pass
     proxies = {k.lower(): v for k, v in getproxies().items()}
     scheme = (parsed.scheme or "https").lower()
     # select_proxy order: scheme://host, then scheme, then the all catch-all.
@@ -237,7 +239,7 @@ def hf_tcp_reachable(timeout: float = 3.0, endpoint: Optional[str] = None) -> bo
 
     host, port = hf_connect_target(endpoint)
     if not host:
-        return True  # no target to test: a config problem, not a dead network
+        return True
     try:
         with _socket.create_connection((host, port), timeout = timeout):
             return True
@@ -246,7 +248,7 @@ def hf_tcp_reachable(timeout: float = 3.0, endpoint: Optional[str] = None) -> bo
     except OSError:
         return False
     except Exception:
-        return True  # not a socket answer (bad port, None host): inconclusive, fail open
+        return True
 
 
 def hf_dns_dead(timeout: float = 2.0) -> bool:
@@ -324,9 +326,7 @@ def hf_unreachable(timeout: int = 3) -> bool:
         try:
             from utils.transformers_version import hf_endpoint_unreachable
 
-            # Both flags off for the same reason: an ambiguous answer must not force offline. Through a proxy
-            # a clean timeout only means slow and the hub client's longer request may succeed, so an uncached
-            # load must not be turned cache-only here. Matches the worker's call.
+            # Both flags off for the same reason: an ambiguous answer must not force offline.
             unreachable = hf_endpoint_unreachable(
                 timeout,
                 gateway_errors_offline = False,
@@ -713,11 +713,8 @@ def checkpoint_directory_is_complete(root: Path, weights = None) -> bool:
             if relative.is_absolute() or ".." in relative.parts:
                 continue
             module_root = root.joinpath(*relative.parts)
-            # A declared module the directory does not have at all is a torn
-            # checkpoint, whatever the others hold: checking only roots that
-            # carry weights passed one missing 0_Transformer entirely.
-            # Existence is the whole test, since config-only modules such as
-            # Pooling have no weight family.
+            # A declared module the directory lacks entirely is a torn checkpoint whatever the others hold; existence is
+            # the whole test, since config-only modules have no weight family.
             if module_root != root and not module_root.is_dir():
                 return False
             if any(path == module_root or module_root in path.parents for path in weights):
@@ -789,10 +786,8 @@ def snapshot_is_loadable(snapshot, model_name: str) -> bool:
             # unrelated .incomplete blob left under the repository by another
             # revision or scoped GGUF job.
             return download_manifest.verify_against_disk(manifest, snapshot).ok
-        # No manifest: every model on disk before this build is such a cache.
-        # Judge THIS snapshot's own links, not every blob in the cache directory it
-        # shares, or a stray .incomplete from another revision condemns a model
-        # that is fully present.
+        # Judge THIS snapshot's own links, not every blob in the shared cache directory, or a stray .incomplete from
+        # another revision condemns a model that is fully present.
         if snapshot_has_broken_symlinks(snapshot):
             return False
 
@@ -800,25 +795,23 @@ def snapshot_is_loadable(snapshot, model_name: str) -> bool:
     except OSError:
         return False
     except Exception:
-        # Completeness is a safety property here: an unprovable partial must keep
-        # the pending marker so the loader cannot silently reach the network.
+        # Completeness is a safety property here: an unprovable partial must keep the pending marker so
+        # the loader cannot silently reach the network.
         return False
+
+
+# Never return raw exception text to clients: log server-side, return generic.
 
 
 # ── Client-safe error helpers ───────────────────────────────────
 # Never return raw exception text to clients; log server-side, return generic.
-
-
 def safe_error_detail(error: Exception, fallback: str = "An internal error occurred") -> str:
     """Map an exception to a generic, client-safe message (never raw
     ``str(error)``, which can leak paths). Log the real exception server-side.
     """
-    # A mid-stream llama-server failure carries a message that was written to be shown,
-    # so the leak this function guards against does not apply to it. Without this the
-    # non-streaming paths reduced it to the fallback while streaming clients got the
-    # cause, which is the same "reaches the user stripped of its reason" defect one layer
-    # further out. Imported lazily: utils is low level and must not depend on
-    # core.inference at import time.
+    # A mid-stream llama-server failure carries a message that was written to be shown
+    # Without this the non-streaming paths reduced it to the fallback while streaming clients got the cause. Imported
+    # lazily: utils is low level and must not depend on core.inference at import time.
     try:
         from core.inference.stream_errors import LlamaStreamError  # noqa: PLC0415
         if isinstance(error, LlamaStreamError) and error.friendly:
@@ -866,9 +859,9 @@ def log_and_http_error(
     """
     from fastapi import HTTPException
 
-    # A 4xx is a normal outcome the caller handles, so one warning line and no traceback:
-    # at error with exc_info, one generation buried the log under 54 rejected saves. 5xx
-    # keeps the traceback, since that is a server bug. exc_info works for structlog too.
+    # A 4xx is a normal outcome the caller handles.
+    # One warning line and no traceback: at error with exc_info, one generation buried the log under 54 rejected saves.
+    # 5xx keeps the traceback, and exc_info works for structlog too.
     emitter = log or logger
     if 400 <= status_code < 500:
         emitter.warning(f"{event}: {error}")
@@ -975,12 +968,12 @@ def format_error_message(error: Exception, model_name: str) -> str:
     if (
         "out of memory" in error_str
         or "out of device memory" in error_str
-        or "out_of_device_memory" in error_str  # ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
-        or "out_of_host_memory" in error_str  # ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
+        or "out_of_device_memory" in error_str
+        or "out_of_host_memory" in error_str
         or "not enough memory" in error_str
         or "cannot allocate memory" in error_str
         or "memory allocation failed" in error_str
-        or "cublas_status_alloc_failed" in error_str  # cuBLAS workspace OOM
+        or "cublas_status_alloc_failed" in error_str
         or ("cuda error" in error_str and "alloc" in error_str)
         or ("xpu" in error_str and ("alloc" in error_str or "memory" in error_str))
         or isinstance(error, MemoryError)

--- a/studio/backend/utils/uv_path_safety.py
+++ b/studio/backend/utils/uv_path_safety.py
@@ -52,7 +52,7 @@ def uv_safe_path(path: object) -> str:
         if not os.path.isfile(s):
             return s
         tmp_dir = tempfile.mkdtemp(prefix = "unsloth_uv_")
-        if " " in tmp_dir:  # e.g. TMPDIR itself has a space
+        if " " in tmp_dir:
             shutil.rmtree(tmp_dir, ignore_errors = True)
             return s
         source_name = os.path.basename(s) or "uv_args.txt"

--- a/studio/backend/utils/uvicorn_h11_shutdown.py
+++ b/studio/backend/utils/uvicorn_h11_shutdown.py
@@ -65,28 +65,15 @@ def _shutdown_quiet_h11_protocol() -> Union[type, None]:
         # Any uvicorn/h11 layout we do not recognise: leave uvicorn untouched.
         return None
 
-    # our_state CLOSED means we already sent h11.ConnectionClosed(); ERROR means
-    # a previous send violated the state machine; MUST_CLOSE means h11 will let
-    # us send nothing but ConnectionClosed. In all three uvicorn can no longer
-    # write a response on this connection, so feeding it more inbound bytes can
-    # only produce the spurious 400 attempt described above.
-    #
-    # MUST_CLOSE matters because send_400_response() never sends
-    # ConnectionClosed: it writes the 400 and closes the transport, and h11's
-    # (ERROR, DONE) state-triggered rule then leaves the server at MUST_CLOSE
-    # until connection_lost(). A second proactor read in that window reaches the
-    # same unguarded send_400_response() and raises the same LocalProtocolError,
-    # only with state=MUST_CLOSE. Any non-HTTP bytes spanning more than one read
-    # get there, a browser sent to https://127.0.0.1:<port> included.
-    #
-    # This deliberately reads our_state and never their_state. A malformed
-    # request from a live client is a *remote* violation: h11's next_event()
-    # calls _process_error(their_role), which moves their_state to ERROR and
-    # leaves our_state at IDLE or SEND_RESPONSE, exactly so that a server can
-    # still answer 400 (h11 docs, "error handling"). So the guard cannot fire
-    # on a request uvicorn is still able to reject properly, and h11 only ever
-    # reaches CLOSED or MUST_CLOSE from IDLE or DONE, meaning a response is
-    # either finished or was never started.
+    # In our_state CLOSED / ERROR / MUST_CLOSE uvicorn can no longer write a response, so feeding h11
+    # more inbound bytes only produces the spurious 400 attempt above. MUST_CLOSE matters because
+    # send_400_response() closes the transport without sending ConnectionClosed, and a second
+    # proactor read in that window raises the same LocalProtocolError. Reads our_state and never
+    # their_state on purpose: a malformed request from a live client leaves our_state at IDLE or
+    # SEND_RESPONSE precisely so the server can still answer 400 (h11 docs, "error handling").
+    # h11 only ever reaches CLOSED or MUST_CLOSE from IDLE or DONE, so a response is either finished or was never
+    # started, while next_event() calls _process_error(their_role) and leaves our_state answerable. Any non-HTTP bytes
+    # spanning more than one read get there, a browser sent to https://127.0.0.1:<port> included.
     terminal_states = (h11.MUST_CLOSE, h11.CLOSED, h11.ERROR)
 
     class _ShutdownQuietH11Protocol(H11Protocol):  # type: ignore[misc, valid-type]

--- a/studio/backend/utils/vram_budget_settings.py
+++ b/studio/backend/utils/vram_budget_settings.py
@@ -45,8 +45,8 @@ VRAM_FRACTION_DECIMALS = 3
 _CACHE_TTL_S = 2.0
 _cache_lock = threading.Lock()
 _cache: dict[str, tuple[float, Any]] = {}
-# Bumped on every write: a read that began before it must not cache its stale
-# value, or the new budget would appear to revert for the rest of the TTL.
+# Bumped on every write: a read that began before it must not cache its stale value, or the new
+# budget appears to revert for the rest of the TTL.
 _generation: dict[str, int] = {}
 
 # Retries converge; the bound only stops a write storm spinning here forever.
@@ -90,12 +90,10 @@ def coerce_fraction(value: Any) -> Optional[float]:
         # bool is an int subclass, and True would otherwise read as 1.0.
         return None
     try:
-        fraction = float(value)  # None -> TypeError, "" / "  " -> ValueError
+        fraction = float(value)
     except (TypeError, ValueError):
         return None
-    # Two-sided on purpose: NaN loses every comparison, so this rejects it; the
-    # one-sided form would let NaN through and NaN every per-GPU budget. Mirrors
-    # _parse_mem_fraction_env.
+    # Two-sided on purpose: NaN loses every comparison.
     if not VRAM_FRACTION_MIN <= fraction <= VRAM_FRACTION_MAX:
         return None
     return round(fraction, VRAM_FRACTION_DECIMALS)

--- a/studio/backend/utils/vram_budget_settings.py
+++ b/studio/backend/utils/vram_budget_settings.py
@@ -93,7 +93,8 @@ def coerce_fraction(value: Any) -> Optional[float]:
         fraction = float(value)
     except (TypeError, ValueError):
         return None
-    # Two-sided on purpose: NaN loses every comparison.
+    # Two-sided on purpose: NaN loses every comparison, so this rejects it; the one-sided form would let
+    # NaN through and NaN every per-GPU budget. Mirrors _parse_mem_fraction_env.
     if not VRAM_FRACTION_MIN <= fraction <= VRAM_FRACTION_MAX:
         return None
     return round(fraction, VRAM_FRACTION_DECIMALS)

--- a/studio/backend/utils/wheel_utils.py
+++ b/studio/backend/utils/wheel_utils.py
@@ -169,6 +169,7 @@ def direct_wheel_url(
 # directory, so torch 2.10.0+cu129 on Linux resolves to nothing. torch 2.11+ maps to 0.0.35, compiled against 2.10.0 and
 # compatible with any later version since xFormers moved to the stable API/ABI in 0.0.34. Keep in step with
 # $script:XformersWheelVersions in install.ps1 and the matrix in tests/python/test_windows_xformers_wheel_match.py.
+# ── xFormers ──────────────────────────────────────────────────────────────────
 PYTORCH_WHEEL_INDEX_BASE_URL = "https://download.pytorch.org/whl"
 
 

--- a/studio/backend/utils/wheel_utils.py
+++ b/studio/backend/utils/wheel_utils.py
@@ -362,8 +362,8 @@ def redact_url_credentials(url: str) -> str:
 def flash_attn_package_version(torch_mm: str) -> str | None:
     if torch_mm == "2.10":
         # Newest flash-attn release still carrying the full torch2.10 asset matrix. Do not bump to "the
-    # latest release": v2.8.3 publishes only cu13/cp312 for torch2.10 and v2.8.3.post1 dropped every
-    # torch2.10 asset, 404ing most users into a source build.
+        # latest release": v2.8.3 publishes only cu13/cp312 for torch2.10 and v2.8.3.post1 dropped every
+        # torch2.10 asset, 404ing most users into a source build.
         # The full matrix is cu12 + cu13, cp312 + cp313, x86_64 + aarch64, and post1's newest tag is torch2.9, which
         # will not load here at all.
         return "2.8.1"

--- a/studio/backend/utils/wheel_utils.py
+++ b/studio/backend/utils/wheel_utils.py
@@ -24,13 +24,16 @@ _logger = logging.getLogger(__name__)
 FLASH_ATTN_RELEASE_BASE_URL = "https://github.com/Dao-AILab/flash-attention/releases/download"
 
 
-# No arch gate here, deliberately. has_blackwell_gpu() skipped flash-attn when upstream
-# published no sm_100+ wheels (#5420), then became the bug once it did, denying B200 hosts
-# a working wheel (#6961). An arch gate encodes a snapshot of what upstream ships and goes
-# stale silently both ways; the callers' post-install import check catches a wheel that
-# will not load whatever the cause.
+# No arch gate here, deliberately: has_blackwell_gpu() skipped flash-attn while upstream shipped
+# no sm_100+ wheels (#5420), then became the bug once it did (#6961). A gate encodes a snapshot of
+# what upstream ships and goes stale silently both ways; the post-install import check catches a
+# wheel that will not load whatever the cause.
 
 
+# No arch gate, deliberately: has_blackwell_gpu() skipped flash-attn before sm_100+ wheels existed (#5420) and became
+# the bug once they did (#6961). The import check catches a bad wheel.
+# #6961 was B200 hosts denied a working wheel, and an arch gate encodes a snapshot of what upstream ships and goes stale
+# silently both ways.
 def wheel_platform_tag() -> str | None:
     """pip platform tag for this host, or None where nothing we resolve is published.
 
@@ -81,10 +84,9 @@ def probe_torch_wheel_env(
                     "print(json.dumps({"
                     "'python_tag': f'cp{sys.version_info.major}{sys.version_info.minor}', "
                     "'torch_mm': torch_mm, "
-                    # Full release + full CUDA version: xFormers publishes one wheel per
-                    # exact torch PATCH and per CUDA MINOR (cu126 and cu128 are different
-                    # builds of the same version string), so 'torch_mm' / 'cuda_major'
-                    # cannot pick between them.
+                    # xFormers publishes one wheel per exact torch PATCH and per CUDA MINOR, so 'torch_mm' /
+                    # 'cuda_major' cannot pick between them.
+                    # Full release + full CUDA version: cu126 and cu128 are different builds of the same version string.
                     "'torch_version': str(torch.__version__), "
                     "'cuda_version': str(torch.version.cuda) if torch.version.cuda else '', "
                     "'cuda_major': str(int(str(torch.version.cuda).split('.', 1)[0])) if torch.version.cuda else '', "
@@ -116,18 +118,13 @@ def probe_torch_wheel_env(
     return env
 
 
-# torch 2.11 and 2.12 ship no native prebuilt wheels for flash-attn /
-# causal-conv1d / mamba-ssm, but the torch2.10 CUDA wheels load and pass each
-# project's own suite on both (B200, py3.12, torch 2.12.1+cu130: causal-conv1d
-# 9412 passed / 3888 skipped / 0 failed, mamba tests/ops 20 passed, flash-attn
-# splitkv+qkvpacked 848 passed; pass/fail/skip counts and the failing test-ID
-# sets are identical to a torch 2.10 control). Reuse them so a 2.11 / 2.12
-# install still gets prebuilt accelerators instead of building from source.
-#
-# The window is bounded, not open ended: torch broke extension ABI between 2.9
-# and 2.10, and the torch2.9 flash-attn .so raises "undefined symbol" on torch
-# 2.10 and on 2.12 alike. A wheel cannot skip a torch minor backwards, so every
-# new key here must be measured against the real wheels before it is added.
+# torch 2.11/2.12 ship no native prebuilt flash-attn / causal-conv1d / mamba-ssm wheels, but the
+# torch2.10 CUDA wheels load and pass each project's own suite on both, so they are reused. The
+# window is bounded, not open ended: torch broke extension ABI between 2.9 and 2.10, so every new
+# key here must be measured against the real wheels before it is added.
+# Measured on B200, py3.12, torch 2.12.1+cu130: causal-conv1d 9412 passed / 3888 skipped / 0 failed, mamba tests/ops 20
+# passed, flash-attn splitkv+qkvpacked 848 passed, identical to a torch 2.10 control. The torch2.9 flash-attn .so raises
+# "undefined symbol" on torch 2.10 and 2.12 alike.
 _PREBUILT_WHEEL_TORCH_MM = {"2.11": "2.10", "2.12": "2.10"}
 
 
@@ -156,58 +153,22 @@ def direct_wheel_url(
     return f"{release_base_url}/{release_tag}/{filename}"
 
 
-# ── xFormers ──────────────────────────────────────────────────────────────────
-# xformers/_C.pyd (_C.so on Linux) is linked against ONE exact (torch, CUDA) pair.
-# Loaded beside any other pair torch.ops.load_library raises, and xformers/_cpp_lib.py
-# turns that into a log warning rather than an error -- so the import "succeeds" and
-# memory-efficient attention, SwiGLU and the sparse ops are silently gone. PyPI publishes
-# exactly one win_amd64 flavour, and today that is the CUDA-12.8 one (0.0.34's win_amd64
-# cpp_lib.json reads torch 2.10.0+cu128), which is why `pip install xformers` next to a
-# cu130 torch reports "xFormers was built for PyTorch 2.10.0+cu128 with CUDA 1208 (you
-# have 2.10.0+cu130)". WHICH flavour that is is not stable and must not be assumed: across
-# releases the PyPI win wheel has been cu124 (0.0.29.post2), cu126 (0.0.30), cu128
-# (0.0.32), cu130 (0.0.33) and cu128 again (0.0.33.post1 onward). That churn is the
-# argument for resolving a URL rather than pinning a version.
-#
-# Note also that cpp_lib.json's `cuda` is the NVCC TOOLKIT version, not torch's CUDA
-# family: download.pytorch.org's cu126 0.0.34 also reports 1208. Only the `torch` field
-# ("2.10.0+cu128") separates the flavours, which is the field this resolver keys on and
-# the field xFormers' own error message does not lead with.
-#
-# download.pytorch.org publishes one wheel per (CUDA family, torch patch), so resolve
-# the exact URL instead. torch release -> {CUDA family: xFormers version}. Every row was
-# HEAD-verified live and its xformers/cpp_lib.json read back, e.g.
-# cu130/xformers-0.0.34-cp39-abi3-win_amd64.whl reports {"torch": "2.10.0+cu130"}.
-#
-# Rows are exact, never interpolated: xFormers' extension ABI does not survive a torch
-# minor bump (unlike the flash-attn window above, which was measured), and no cu130 build
-# exists for torch <= 2.8. An unlisted pair means "install nothing", the safe answer.
-#
-# cu118 / cu121 / cu124 are absent for a different reason, and not because those families
-# publish nothing on Windows -- they do, e.g. cu124/xformers-0.0.28.post1-cp312-cp312-
-# win_amd64.whl is live. They all stop BEFORE the cp39-abi3 switch at 0.0.31, so their
-# wheels are one file per interpreter and the single filename template below cannot name
-# them; expressing those rows needs a per-interpreter gate here and a second one in
-# install.ps1, for CUDA families no supported torch install pulls any more.
-#
-# Two deliberate over-approximations, recorded so nobody "fixes" them by interpolating:
-#
-# * Keying on the CUDA MINOR is stricter than the ABI needs. The cu126 and cu128 _C.so
-#   have identical undefined-symbol sets and both link libcudart.so.12, so either loads
-#   against either runtime; only a MAJOR bump changes the interface (cu130 links
-#   libcudart.so.13). The minor is in the key because it names a real directory on
-#   download.pytorch.org, so an exact hit guarantees the URL exists. The cost is that a
-#   family with no row of its own resolves to nothing even when a sibling would work --
-#   torch 2.10.0+cu129 on Linux is the live example.
-# * torch 2.11+ maps to 0.0.35, which is compiled against 2.10.0 and works there by
-#   design rather than by luck: xFormers moved to the PyTorch stable API/ABI in 0.0.34,
-#   and its notes state that "binary builds targeting PyTorch 2.10+ will be compatible
-#   with any later version". So one 0.0.35 row per CUDA family covers every later torch,
-#   and the rows below are exact only up to 2.10.0, where upstream still shipped an
-#   exact-pinned wheel per torch release.
-#
-# Keep in step with $script:XformersWheelVersions in install.ps1 and the matrix in
-# tests/python/test_windows_xformers_wheel_match.py.
+# xformers/_C is linked against ONE exact (torch, CUDA) pair, and a mismatch is only a log
+# warning, so the import "succeeds" with memory-efficient attention silently gone. PyPI publishes
+# one win_amd64 flavour whose CUDA family churns across releases, which is why this resolves an
+# exact download.pytorch.org URL instead of pinning a version. Keyed on the `torch` field of
+# cpp_lib.json, not `cuda`, which is the NVCC toolkit version and does not separate flavours.
+# Rows are exact, never interpolated: the extension ABI does not survive a torch minor bump, and
+# an unlisted pair means "install nothing", the safe answer. cu118/cu121/cu124 are absent because
+# they stop before the cp39-abi3 switch at 0.0.31, so one filename template cannot name them.
+# The PyPI win wheel has been cu124 (0.0.29.post2), cu126 (0.0.30), cu128 (0.0.32), cu130 (0.0.33) and cu128 again
+# (0.0.33.post1 onward); download.pytorch.org's cu126 0.0.34 also reports 1208, so only the `torch` field
+# ("2.10.0+cu128") separates flavours. Every row was HEAD-verified live, e.g.
+# cu130/xformers-0.0.34-cp39-abi3-win_amd64.whl reports {"torch": "2.10.0+cu130"}. Keying on the CUDA MINOR is stricter
+# than the ABI needs (cu126 and cu128 both link libcudart.so.12; only a major bump changes it), but it names a real
+# directory, so torch 2.10.0+cu129 on Linux resolves to nothing. torch 2.11+ maps to 0.0.35, compiled against 2.10.0 and
+# compatible with any later version since xFormers moved to the stable API/ABI in 0.0.34. Keep in step with
+# $script:XformersWheelVersions in install.ps1 and the matrix in tests/python/test_windows_xformers_wheel_match.py.
 PYTORCH_WHEEL_INDEX_BASE_URL = "https://download.pytorch.org/whl"
 
 
@@ -225,11 +186,10 @@ def pytorch_wheel_index_base_url() -> str:
 
 
 _XFORMERS_WHEEL_VERSIONS: dict[str, dict[str, str]] = {
-    # torch 2.7.0 (xFormers 0.0.30) is deliberately absent: it predates the stable-ABI
-    # switch, so it publishes one wheel per interpreter and stops at cp312, and Unsloth's
-    # default interpreter is 3.13. Supporting it would mean a per-interpreter gate here
-    # and a second one in install.ps1 for a four-year-old torch that resolves to nothing
-    # on the default install anyway.
+    # torch 2.7.0 is deliberately absent: it predates the stable-ABI switch, so it ships one wheel per interpreter and
+    # stops at cp312, while Unsloth's default interpreter is 3.13.
+    # Supporting it would mean a per-interpreter gate here and a second one in install.ps1, for a torch that resolves to
+    # nothing on the default install anyway (xFormers 0.0.30).
     "2.7.1": {"cu126": "0.0.31.post1", "cu128": "0.0.31.post1"},
     "2.8.0": {"cu126": "0.0.32.post2", "cu128": "0.0.32.post2", "cu129": "0.0.32.post2"},
     "2.9.0": {"cu126": "0.0.33.post1", "cu128": "0.0.33.post1", "cu130": "0.0.33.post1"},
@@ -243,43 +203,28 @@ _XFORMERS_WHEEL_VERSIONS: dict[str, dict[str, str]] = {
     "2.13.0": {"cu126": "0.0.35", "cu128": "0.0.35", "cu130": "0.0.35"},
 }
 
-# The stable-ABI floor and what serves it: every torch STRICTLY ABOVE this maps to this
-# release, per CUDA family. Exact rows above still win, so a future exact-pinned wheel
-# displaces the fallback for its own release.
-#
-# An exact-key table alone refuses the patch releases: 2.10.1, 2.11.1 and 2.12.1 are all
-# supported resident builds this file names elsewhere, and each of them missed and left
-# Unsloth on native attention. Enumerating patches is not an option -- they are published
-# after this code ships -- and 0.0.35 is compiled against 2.10.0 by design, with upstream
-# stating that "binary builds targeting PyTorch 2.10+ will be compatible with any later
-# version". So above 2.10.0 the answer is known without a table.
-#
-# Still bounded, not open-ended in the other direction: below the floor there is no stable
-# ABI and an unlisted pair must keep resolving to nothing rather than guessing.
+# The stable-ABI floor and what serves it: every torch STRICTLY ABOVE this maps to this release,
+# per CUDA family, with exact rows above still winning. An exact-key table alone refused the patch
+# releases (2.10.1, 2.11.1, 2.12.1), which cannot be enumerated because they ship after this code;
+# 0.0.35 targets 2.10.0 and upstream states later versions stay compatible. Below the floor there
+# is no stable ABI, so an unlisted pair must keep resolving to nothing.
 _XFORMERS_STABLE_ABI_FLOOR: tuple[int, ...] = (2, 10, 0)
 _XFORMERS_STABLE_ABI_VERSIONS = {"cu126": "0.0.35", "cu128": "0.0.35", "cu130": "0.0.35"}
 
-# The interpreter tag in the wheel FILENAME, which xFormers has changed twice: 0.0.30 and
-# earlier ship one wheel per cpXY (and stop at cp312), 0.0.31..0.0.34 ship a single
-# cp39-abi3 wheel, and 0.0.35 switched to py39-none. That last switch is a PACKAGING
-# change, not an architectural one: 0.0.35's setup.py drops py_limited_api=True and
-# force-tags the wheel through a custom bdist_wheel, on the grounds that the extension
-# never bound the CPython ABI in the first place -- it is loaded by
-# torch.ops.load_library, and its _C.so defines no PyInit and references no Py* symbol.
-# The wheel still carries a per-CUDA _C.pyd; it just dropped the bundled flash_attn_3
-# kernels, which is the whole 103 MB -> 2.6 MB difference. Verified by reading the WHEEL
-# metadata, setup.py and the extension's symbol table out of each.
-#
-# Ranges, not an open-ended floor: guessing the tag for an unreleased version is how a
-# resolver starts emitting URLs that 404, so an unknown release resolves to nothing until
-# somebody checks the real filename.
+# The interpreter tag in the wheel FILENAME, which xFormers has changed twice: 0.0.30 and earlier ship one wheel per
+# cpXY (and stop at cp312), 0.0.31..0.0.34 ship a single cp39-abi3 wheel, and 0.0.35 switched to py39-none. That last
+# switch is a PACKAGING change, not an architectural one: 0.0.35's setup.py drops py_limited_api=True and force-tags the
+# wheel through a custom bdist_wheel, since the extension is loaded by torch.ops.load_library and its _C.so defines no
+# PyInit. The wheel still carries a per-CUDA _C.pyd; it just dropped the bundled flash_attn_3 kernels, the whole 103 MB
+# -> 2.6 MB difference. Ranges, not an open-ended floor: an unknown release resolves to nothing until somebody checks
+# the real filename.
 _XFORMERS_FILENAME_PYTHON_TAGS: tuple[tuple[tuple[int, ...], tuple[int, ...], str], ...] = (
     ((0, 0, 31), (0, 0, 34), "cp39-abi3"),
     ((0, 0, 35), (0, 0, 35), "py39-none"),
 )
 
-# platform_tag from wheel_platform_tag() -> the leaf in the wheel filename. aarch64 and
-# macOS are absent because download.pytorch.org publishes no xFormers wheel for them.
+# platform_tag from wheel_platform_tag() -> the leaf in the wheel filename.
+# aarch64 and macOS are absent because download.pytorch.org publishes no xFormers wheel for them.
 _XFORMERS_PLATFORM_LEAVES = {
     "linux_x86_64": "manylinux_2_28_x86_64",
     "win_amd64": "win_amd64",
@@ -415,12 +360,11 @@ def redact_url_credentials(url: str) -> str:
 
 def flash_attn_package_version(torch_mm: str) -> str | None:
     if torch_mm == "2.10":
-        # Newest flash-attn release still carrying the full torch2.10 asset
-        # matrix (cu12 + cu13, cp312 + cp313, x86_64 + aarch64). Do not bump
-        # this to "the latest release": v2.8.3 publishes only cu13/cp312 for
-        # torch2.10 and v2.8.3.post1 dropped every torch2.10 asset, so both
-        # 404 most users back to a source build, and post1's newest tag is
-        # torch2.9, which will not load here at all.
+        # Newest flash-attn release still carrying the full torch2.10 asset matrix. Do not bump to "the
+    # latest release": v2.8.3 publishes only cu13/cp312 for torch2.10 and v2.8.3.post1 dropped every
+    # torch2.10 asset, 404ing most users into a source build.
+        # The full matrix is cu12 + cu13, cp312 + cp313, x86_64 + aarch64, and post1's newest tag is torch2.9, which
+        # will not load here at all.
         return "2.8.1"
     try:
         major, minor = (int(part) for part in torch_mm.split(".", 1))

--- a/studio/backend/utils/whisper_cpp_update.py
+++ b/studio/backend/utils/whisper_cpp_update.py
@@ -53,7 +53,7 @@ from utils.whisper_cpp_freshness import (
 logger = structlog.get_logger(__name__)
 
 DEFAULT_PUBLISHED_REPO = "unslothai/whisper.cpp"
-_INSTALL_TIMEOUT_SECONDS = 1800  # 30 min ceiling for download + extract/validate
+_INSTALL_TIMEOUT_SECONDS = 1800
 
 # Always-idle job payload: whisper applies run inside the chained llama job, so
 # nothing flips this to running. Kept so status payload shapes stay stable.
@@ -171,8 +171,8 @@ def _source_build_status(binary: str, *, force_refresh: bool) -> Optional[dict]:
     release_tag = res.get("release_tag")
     if not release_tag:
         return None
-    # No resolvable install root (e.g. a pinned WHISPER_SERVER_PATH we cannot
-    # manage) means an apply would not take effect, so do not offer it.
+    # No resolvable install root (e.g. a pinned WHISPER_SERVER_PATH we cannot manage) means an apply would not take
+    # effect, so do not offer it.
     if _whisper_install_root(binary) is None:
         return None
     installed_tag = _installed_whisper_version(binary)
@@ -232,8 +232,7 @@ def get_update_status(*, force_refresh: bool = False) -> dict:
     force_refresh bypasses the 24h release cache for an explicit "check now".
     """
     binary = _find_binary()
-    # A locally-linked whisper.cpp dir is the user's own tree; never offer to
-    # replace it. Bail before any network/freshness work.
+    # A locally-linked whisper.cpp dir is the user's own tree; never offer
     if _active_install_is_local_link(binary):
         return _local_link_status()
     marker = read_install_marker(binary)
@@ -259,10 +258,6 @@ def get_update_status(*, force_refresh: bool = False) -> dict:
     latest = freshness.get("latest_tag")
     compatible_override = False
     if sys.platform == "darwin" and marker is not None:
-        # The newest published release may require a newer macOS. Ask the same
-        # host-aware resolver the installer uses so the banner compares against
-        # the newest release this host can actually install, avoiding a repeated
-        # offer of an incompatible release after walkback.
         resolved = _resolve_prebuilt_for_host(
             force_refresh = force_refresh,
             backend = marker.get("backend") if isinstance(marker.get("backend"), str) else None,
@@ -372,10 +367,7 @@ def _install_latest_while_blocked(
         "--published-repo",
         repo,
     ]
-    # Preserve the installed accelerator across updates. Left unpinned the
-    # installer re-detects the host, fine on unchanged hardware but able to
-    # reroute a deliberate choice (e.g. cpu on a GPU box); forwarding the marker's
-    # backend keeps the same slice.
+    # Preserve the installed accelerator across updates.
     if isinstance(backend, str) and backend:
         cmd.extend(["--backend", backend])
     if pin_release_tag:
@@ -383,9 +375,7 @@ def _install_latest_while_blocked(
     cmd.extend(_rocm_install_args(asset))
     logger.info("whisper update: installing", cmd = " ".join(cmd))
     env = dict(os.environ, UNSLOTH_PROGRESS_PERCENT_STEP = "5")
-    # Every nonzero exit is a failed phase. In particular, exit 2 means the
-    # requested release was incompatible and no install happened, so reporting
-    # success would hide the banner and toast an update that never landed.
+    # Every nonzero exit is a failed phase.
     _flow.stream_installer(
         cmd,
         env,
@@ -558,19 +548,15 @@ def chained_phase_plan(
     status = get_update_status(force_refresh = force_refresh)
     plan: dict = {"status": status, "update_available": False, "skip_reason": None, "phase": None}
     if not status.get("update_available"):
-        # Skew note: when llama just updated but whisper is already latest, a slim
-        # install keeps hardlinks to the OLD llama ggml inodes -- still the exact
-        # build whisper was installed against, so skipping is correct and needs no
-        # re-wiring. A whisper phase that does run re-wires via the installer
-        # (prepare_runtime_payload).
+        # Skew note: a slim install keeps hardlinks to the OLD llama ggml inodes, still the exact build whisper was
+        # installed against, so skipping is correct and needs no re-wiring.
+        # A whisper phase that does run re-wires via the installer (prepare_runtime_payload).
         plan["skip_reason"] = "up_to_date"
         return plan
     if marker.get("install_kind") == "slim" and not paired_llama_will_update:
-        # A slim install can only be refreshed from a completed managed llama
-        # prebuilt. Ask the installer through its read-only resolver so local
-        # links, markerless/current source builds, and incomplete managed trees
-        # never produce an Update button that can only fail. When the llama
-        # phase will run first, it supplies the repaired pairing instead.
+        # A slim install can only be refreshed from a COMPLETED managed llama prebuilt, so ask the
+        # installer's read-only resolver: local links, markerless source builds and incomplete managed
+        # trees must not produce an Update button that can only fail.
         resolved = _resolve_prebuilt_for_host(
             force_refresh = force_refresh,
             backend = marker.get("backend") if isinstance(marker.get("backend"), str) else None,
@@ -593,14 +579,10 @@ def chained_phase_plan(
         "asset": marker.get("asset"),
         "backend": marker.get("backend"),
         "script": script,
-        # Install exactly the release the check offered: the installer's unpinned
-        # "latest" prefers the download-host /releases/latest pointer, which sorts
-        # by commit date and can lag the published_at pick the freshness check
-        # used, reinstalling an older build in a loop (the #6219 class the llama
-        # phase pins against). Not on macOS: the llama phase is unpinned there
-        # (walk-back to an os-compatible release), so pinning whisper to the
-        # newest tag could be an impossible pairing (min_os / requires_llama_tag)
-        # on every retry.
+        # Install exactly the release the check offered: the unpinned "latest" sorts by commit date and can lag the
+        # published_at pick, reinstalling an older build in a loop (#6219).
+        # Not on macOS: the llama phase is unpinned there (walk-back to an os-compatible release), so pinning whisper to
+        # the newest tag could be an impossible pairing (min_os / requires_llama_tag) on every retry.
         "pin_release_tag": None if sys.platform == "darwin" else status.get("latest_tag"),
     }
     return plan
@@ -629,10 +611,9 @@ def run_chained_phase_after_llama(phase: dict, set_progress) -> dict:
     except Exception as exc:
         logger.debug("whisper pairing pre-flight failed", error = str(exc))
         resolved = None
-    # A POSITIVE incompatibility only: an unreachable API reports prebuilt_available
-    # false too, and a pre-flight that cannot answer must fail towards the install.
-    # Deliberately no test on the INSTALLED kind -- a fat marker carries no
-    # install_kind, so gating on it skips the host most likely to meet a pairing gap.
+    # A POSITIVE incompatibility only: an unreachable API also reports prebuilt_available false, and
+    # a pre-flight that cannot answer must fail towards the install. Deliberately no test on the
+    # INSTALLED kind: a fat marker carries no install_kind, so gating on it skips the likeliest host.
     if (resolved or {}).get("unavailable_reason") == "incompatible":
         return {"skipped": True, "skip_reason": "paired_llama_unavailable"}
     return run_chained_phase(phase, set_progress)

--- a/studio/install_manifest.py
+++ b/studio/install_manifest.py
@@ -33,11 +33,10 @@ MANIFEST_SCHEMA = 1
 # Canonical truthy set for UNSLOTH_NO_TORCH, matching install.ps1 / install.sh.
 NO_TORCH_TRUTHY: Tuple[str, ...] = ("1", "true", "yes", "on")
 
-# Companion to the no_torch manifest key, next to setup.ps1's .unsloth-studio-owned.
-# The manifest is deliberately dropped before every dependency pass, so it cannot
-# answer for a run killed mid-pass; this marker is written before that pass and
-# outlives it. Without it an interrupted GGUF-only install reads as a stale venv on
-# the next update, which then tries to delete the venv it is running out of.
+# The manifest is dropped before every dependency pass, so it cannot answer for a run killed mid-pass; this marker
+# outlives it, or an interrupted GGUF-only install reads as a stale venv.
+# Companion to the no_torch manifest key, next to setup.ps1's .unsloth-studio-owned; the next update then tries to
+# delete the venv it is running out of.
 NO_TORCH_MARKER = ".unsloth-no-torch"
 
 # Fingerprinted into the manifest, relative to studio/backend/requirements/.
@@ -288,24 +287,17 @@ def write_manifest(
         "platform": f"{sys.platform}-{platform.machine()}",
         "prefix": str(venv_root()),
         "steps_total": steps_total,
-        # The venv's own copy wins over the caller's. `verify_install` reads the
-        # installed package's requirements, so recording the installer's would
-        # compare two different trees and call a finished install stale. An
-        # editable / source install has no copy under site-packages, and there
-        # the caller's root is already the tree both sides read.
+        # The venv's own copy wins over the caller's: verify_install reads the installed package's requirements, so
+        # recording the installer's would compare two trees and call a finished install stale.
         "requirement_files": requirement_digests(installed_requirements_root(root) or req_root),
     }
-    # Additive, so MANIFEST_SCHEMA does not move and every existing manifest stays
-    # valid. Absent means "unknown", which is NOT False: only a manifest written by
-    # a build that knew about the key can answer, and callers fall back to their own
-    # detection otherwise. Recorded because install.ps1 / install.sh export
-    # UNSLOTH_NO_TORCH for their own run only -- a later `unsloth studio update`
-    # exports nothing and would otherwise reinstall torch into a GGUF-only venv.
+    # Additive, so MANIFEST_SCHEMA does not move and existing manifests stay valid. Absent means
+# "unknown", NOT False: only a manifest written by a build that knew the key can answer. Recorded
+# because install.ps1 / install.sh export UNSLOTH_NO_TORCH for their own run only, so a later
+# `unsloth studio update` would otherwise reinstall torch into a GGUF-only venv.
     if no_torch is not None:
         payload["no_torch"] = bool(no_torch)
-    # The FLAVOR, never the index URL it came from: a pinned index can carry a token in
-    # its userinfo, query or fragment, and this file lives in the venv and is read back
-    # by verify-install, desktop-capabilities and the setup fast path.
+    # The FLAVOR, never the index URL it came from: a pinned index can carry a token
     if expected_torch_tag:
         payload["expected_torch_tag"] = str(expected_torch_tag).strip().lower()
     # Whether that flavor was NAMED by whoever ran the install, or merely what the selection
@@ -327,11 +319,7 @@ def write_manifest(
 def read_manifest(root: Optional[Path] = None) -> Optional[dict]:
     try:
         raw = manifest_path(root).read_text(encoding = "utf-8")
-    # UnicodeDecodeError is a ValueError, not an OSError: a manifest re-saved as
-    # ANSI by an editor (the payload embeds the user profile path, so non-ASCII
-    # names show up there) or truncated mid-write must read as "no manifest", not
-    # raise. install_python_stack.py resolves no-torch mode through here at import,
-    # so anything escaping aborts the whole install.
+    # UnicodeDecodeError is a ValueError.
     except (OSError, ValueError):
         return None
     try:
@@ -705,8 +693,7 @@ def _scan_payload_files(
                 anchor = _venv_anchor(Path(dist.locate_file("")))
             except Exception:
                 anchor = None
-            # csv, not splitlines: a quoted field may hold a newline, and
-            # splitlines also breaks on \v, \f and the Unicode separators.
+            # csv, not splitlines: a quoted field may hold a newline
             for row in csv.reader(io.StringIO(record, newline = "")):
                 # Every row: batching this let one slow mount overrun 5s by a minute.
                 if deadline is not None and time.monotonic() > deadline:
@@ -829,8 +816,7 @@ def verify_install(
         # Install finished but the boot deps are gone: venv edited afterwards.
         reason = "studio_deps_missing"
 
-    # Last: the only check that touches the filesystem, so it must not divert a
-    # reason above. `installed` without `scan_paths` is a venv we cannot stat.
+    # Last: the only check that touches the filesystem.
     if manifest_ok and deps_ok and deep and (installed is None or scan_paths):
         # Reused, not re-read: a manifest rewritten mid-run would make the scan
         # disagree with the checks that already passed.

--- a/studio/install_manifest.py
+++ b/studio/install_manifest.py
@@ -292,9 +292,9 @@ def write_manifest(
         "requirement_files": requirement_digests(installed_requirements_root(root) or req_root),
     }
     # Additive, so MANIFEST_SCHEMA does not move and existing manifests stay valid. Absent means
-# "unknown", NOT False: only a manifest written by a build that knew the key can answer. Recorded
-# because install.ps1 / install.sh export UNSLOTH_NO_TORCH for their own run only, so a later
-# `unsloth studio update` would otherwise reinstall torch into a GGUF-only venv.
+    # "unknown", NOT False: only a manifest written by a build that knew the key can answer. Recorded
+    # because install.ps1 / install.sh export UNSLOTH_NO_TORCH for their own run only, so a later
+    # `unsloth studio update` would otherwise reinstall torch into a GGUF-only venv.
     if no_torch is not None:
         payload["no_torch"] = bool(no_torch)
     # The FLAVOR, never the index URL it came from: a pinned index can carry a token

--- a/studio/install_node_prebuilt.py
+++ b/studio/install_node_prebuilt.py
@@ -610,7 +610,7 @@ def _run_node(
     node_bin = node_binary_path(install_dir, host)
     env = os.environ.copy()
     # Keep any `npm -g` writes inside the isolated prefix: Windows npm otherwise defaults its global
-        # prefix to %APPDATA%\npm and touches the system install.
+    # prefix to %APPDATA%\npm and touches the system install.
     env["NPM_CONFIG_PREFIX"] = str(install_dir)
     env["npm_config_prefix"] = str(install_dir)
     env.pop("NODE_PATH", None)

--- a/studio/install_node_prebuilt.py
+++ b/studio/install_node_prebuilt.py
@@ -97,6 +97,7 @@ def log(message: str) -> None:
     print(f"[node-prebuilt] {message}", file = sys.stdout if _LOG_TO_STDOUT else sys.stderr)
 
 
+# ── Host detection ──
 @dataclass(frozen = True)
 class HostInfo:
     system: str

--- a/studio/install_node_prebuilt.py
+++ b/studio/install_node_prebuilt.py
@@ -867,7 +867,9 @@ def install_prebuilt(install_dir: Path, *, channel: str, min_major: int, force: 
             # A policy refusal, not a transient failure: fail closed, never keep-existing.
             raise
         except Exception as exc:  # noqa: BLE001
-            # Transient download/verify failure: keep an existing usable Node
+            # Transient download/verify failure: keep an existing usable Node, but never keep a same-version
+            # install whose recorded digest is not the pin (the artifact the short-circuit above just
+            # rejected). A different usable version is still kept for offline resilience.
             meta = load_metadata(install_dir)
             pin_mismatch = (
                 pin is not None

--- a/studio/install_node_prebuilt.py
+++ b/studio/install_node_prebuilt.py
@@ -97,13 +97,12 @@ def log(message: str) -> None:
     print(f"[node-prebuilt] {message}", file = sys.stdout if _LOG_TO_STDOUT else sys.stderr)
 
 
-# ── Host detection ──
 @dataclass(frozen = True)
 class HostInfo:
-    system: str  # platform.system()
-    machine: str  # lowered platform.machine()
-    node_os: str  # nodejs.org token: linux | darwin | win
-    node_arch: str  # nodejs.org token: x64 | arm64 | armv7l
+    system: str
+    machine: str
+    node_os: str
+    node_arch: str
     archive_ext: str  # .tar.gz | .zip
     is_windows: bool
 
@@ -474,7 +473,7 @@ def _extract_tar_safely(source: Path, base: Path) -> None:
             target.unlink()
         if member.issym():
             target.symlink_to(link_name)
-        else:  # hard link
+        else:
             shutil.copy2(resolved, target)
 
 
@@ -609,8 +608,8 @@ def _run_node(
 ) -> str:
     node_bin = node_binary_path(install_dir, host)
     env = os.environ.copy()
-    # Keep any `npm -g` writes inside the isolated prefix; Windows npm otherwise
-    # defaults its global prefix to %APPDATA%\npm and touches the system install.
+    # Keep any `npm -g` writes inside the isolated prefix: Windows npm otherwise defaults its global
+        # prefix to %APPDATA%\npm and touches the system install.
     env["NPM_CONFIG_PREFIX"] = str(install_dir)
     env["npm_config_prefix"] = str(install_dir)
     env.pop("NODE_PATH", None)
@@ -749,8 +748,8 @@ def _swap_into_place(extracted_root: Path, install_dir: Path) -> None:
         _replace_with_retry(extracted_root, install_dir)
     except OSError:
         # The forward rename retries ~16s, ample time for a scanner to grab the backup too.
-        # A plain os.replace would then raise over the original error and leave no
-        # install_dir at all, so the rollback gets the same backoff and never masks it.
+        # A plain os.replace would raise over the original error and leave no install_dir at all, so the rollback gets
+        # the same backoff and never masks it.
         if backup is not None and not install_dir.exists():
             try:
                 _replace_with_retry(backup, install_dir)
@@ -867,10 +866,7 @@ def install_prebuilt(install_dir: Path, *, channel: str, min_major: int, force: 
             # A policy refusal, not a transient failure: fail closed, never keep-existing.
             raise
         except Exception as exc:  # noqa: BLE001
-            # Transient download/verify failure: keep an existing usable Node, but
-            # never keep a same-version install whose recorded digest is not the pin
-            # (the artifact the short-circuit above just rejected). A different usable
-            # version is still kept for offline resilience.
+            # Transient download/verify failure: keep an existing usable Node
             meta = load_metadata(install_dir)
             pin_mismatch = (
                 pin is not None

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5175,7 +5175,7 @@ def _stdout_supports_color() -> bool:
 _HAS_COLOR = _stdout_supports_color()
 
 
-# Column layout — matches setup.sh step() helper:
+# Column layout - matches setup.sh step() helper:
 #   2-space indent, 15-char label (dim), then value.
 _LABEL = "deps"
 _COL = 15

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -39,21 +39,15 @@ import zipfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Optional, Sequence
 
-# Default source: the Unsloth mirror's CPU/Apple prebuilts (override with UNSLOTH_SD_CPP_REPO). GPU hosts run diffusers, so only CPU/Apple assets are needed.
+# Default source: the Unsloth mirror's CPU/Apple prebuilts (override with UNSLOTH_SD_CPP_REPO). GPU hosts run diffusers,
+# so only CPU/Apple assets are needed.
 DEFAULT_REPO = "unslothai/stable-diffusion.cpp"
 # Fallback when the mirror cannot serve this host (release missing, or a host we do not build).
 UPSTREAM_FALLBACK_REPO = "leejet/stable-diffusion.cpp"
 # Pinned for reproducibility; UNSLOTH_SD_CPP_TAG overrides (empty tracks latest). A missing tag falls back to latest.
-#
-# The -u<id> suffix means the mirror built upstream master-813-bfbef5b plus the patch set in its
-# patches/ directory, and the id is the hash of that set. MiniMax-H3 needs it: an unpatched build
-# aborts on the default --cfg-scale, aborts again on --vae-on-cpu, and quantizes H3's 1-D norms
-# into an output uncorrelated with its own bf16 reference. All three fixes are open upstream
-# (leejet/stable-diffusion.cpp#1861, #1862, #1863) and the patches are deleted once they ship
-# there, at which point this pin goes back to a plain upstream tag.
-#
-# leejet has no release under this name, so the upstream fallback cannot match the pin and drops
-# to leejet's latest, which is the documented behaviour for a mirror-only tag.
+# The -u<id> suffix is the mirror's patch set: an unpatched build aborts on the default --cfg-scale and on --vae-on-cpu,
+# and quantizes MiniMax-H3's 1-D norms into an output uncorrelated with its own bf16 reference
+# (leejet/stable-diffusion.cpp#1861, #1862, #1863).
 DEFAULT_TAG = "master-813-bfbef5b-u13b9d92"
 
 # Back-compat alias (some callers/tests import REPO).
@@ -114,12 +108,11 @@ def installed_accelerator(root: Path) -> Optional[str]:
     return val if isinstance(val, str) and val else None
 
 
-# Set ONLY when the on-disk record could not be written: install root -> (accelerator, the raw
-# record bytes seen at that moment). An unwritable record (a read-only file, a directory in its
-# place) otherwise means the accelerator reads as the PREVIOUS one, or as unknown, forever -- and
-# either is a mismatch for a GPU target, so every later engine selection re-downloads the same
-# multi-GB bundle. Keyed on the snapshot so it only speaks for the record it saw: once anything
-# else updates that file (the installer CLI, another Unsloth), the file is newer and wins again.
+# Set ONLY when the on-disk record could not be written: install root ->
+# An unwritable record (a read-only file, a directory in its place) otherwise means the accelerator reads as the
+# PREVIOUS one, or as unknown, forever, and either is a mismatch for a GPU target, so every later engine selection re-
+# downloads the same multi-GB bundle. Keyed on the snapshot, so once anything else updates that file it is newer and
+# wins again.
 _INSTALLED_ACCELERATOR_MEMO: dict[str, tuple[str, Optional[str]]] = {}
 
 
@@ -177,8 +170,7 @@ def _write_install_record(
         rec["ships_server"] = ships_server
         _INSTALLED_SHIPS_SERVER_MEMO[str(root)] = ships_server
     else:
-        # An install that did not report the capability must not leave an older memo standing in
-        # for this one -- the tree is now whatever this bundle put there.
+        # An install that did not report the capability must not leave an older memo standing
         _INSTALLED_SHIPS_SERVER_MEMO.pop(str(root), None)
     try:
         with open(root / INSTALL_RECORD, "w", encoding = "utf-8") as f:
@@ -214,8 +206,7 @@ def is_mirror_only_tag(tag: Optional[str]) -> bool:
     return bool(tag) and bool(_MIRROR_ONLY_TAG_RE.match(tag))
 
 
-# A mirror release built on top of an upstream one carries a "-u<short sha>" suffix naming the
-# fork commit (master-813-bfbef5b-u13b9d92 is upstream master-813-bfbef5b plus fork commit 13b9d92).
+# A mirror release built on top of an upstream one carries a "-u<short sha>" suffix naming
 _MIRROR_TAG_SUFFIX = re.compile(r"-u[0-9a-f]{7,}$")
 
 
@@ -285,13 +276,15 @@ def resolve_release_asset(
         return pool[0] if pool else None
 
     if system == "windows":
-        # Filter by host arch: an arm64 host must not install an unrunnable x64 sd-cli. No match returns None so the caller falls back.
+        # Filter by host arch: an arm64 host must not install an unrunnable x64 sd-cli. No match returns None so the
+        # caller falls back.
         pool = [a for a in zips if "bin-win" in a.lower() and any(t in a.lower() for t in arch)]
         token = _WINDOWS_ACCEL_TOKEN.get(accel, accel)
         sel = [a for a in pool if token in a.lower()]
         if sel:
             return sel[0]
-        # An explicit GPU accelerator with no asset returns None, so the caller falls back instead of installing a CPU build.
+        # An explicit GPU accelerator with no asset returns None, so the caller falls back instead of installing a CPU
+        # build.
         if accel in ("cuda", "vulkan", "rocm"):
             return None
         # auto / cpu -> a plain avx2 CPU build, else any windows build.
@@ -304,7 +297,7 @@ def resolve_release_asset(
         # Explicit GPU accelerator: require its marker, never hand back a plain CPU build.
         marker = _LINUX_ACCEL_TOKEN.get(accel, accel)
         sel = [a for a in pool if marker in a.lower()]
-    else:  # auto / cpu -> the plain build with no accelerator marker
+    else:
         sel = [a for a in pool if not any(m in a.lower() for m in _LINUX_ACCEL_MARKERS)]
     return sel[0] if sel else None
 
@@ -337,7 +330,7 @@ def _fetch_release(
     if tag:
         try:
             return _get(f"{base}/tags/{tag}")
-        except urllib.error.HTTPError as exc:  # pinned tag removed -> maybe latest
+        except urllib.error.HTTPError as exc:
             if exc.code != 404:
                 raise
             if not allow_latest:
@@ -537,9 +530,7 @@ _MAX_LINK_TARGET_BYTES = 4096
 _MAX_LINK_DEPTH = 40
 
 
-# Creators whose ``external_attr`` high bits are a Unix ``st_mode``: 3 (Info-ZIP, CPython) and
-# 19 (Apple's ditto, same layout). FAT and NTFS keep DOS attribute flags there, so reading a mode
-# out of one would invent symlinks the archive never described.
+# Creators whose ``external_attr`` high bits are a Unix ``st_mode``: 3 (Info-ZIP, CPython)
 _UNIX_CREATORS = (3, 19)
 
 
@@ -631,12 +622,10 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     plain: list[zipfile.ZipInfo] = []
     written: list[tuple[Path, str]] = []
     for member in zf.infolist():
-        # extractall DROPS ".." instead of cancelling the component before it, so "a/.." is "a" to
-        # it and normalising here would check a path it never writes. No release ships one.
+        # extractall DROPS ".." instead of cancelling the component before it, so "a/.." is "a"
         if ".." in PurePosixPath(member.filename).parts:
             raise RuntimeError(f"unsafe path in archive: {member.filename!r}")
-        # Lexical, never resolve()d: extraction MERGES, and resolving would follow the previous
-        # install's link and leave the real library replaced by a link to itself.
+        # Lexical, never resolve()d: extraction MERGES.
         dest = Path(os.path.normpath(base / member.filename))
         checked = dest.resolve()
         if (dest != base and base not in dest.parents) or (
@@ -659,8 +648,7 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
                 raise RuntimeError(
                     f"unsafe path in archive: {filename!r} is under a symlink member"
                 )
-    # Every destination this archive writes becomes its own member, so a stale link at one must
-    # not be followed.
+    # Every destination this archive writes becomes its own member.
     replaced = {str(d) for d, _ in written}
     archive = {str(d): t for d, t, _ in links}
     replaced |= {str(_plan_key(d, base, replaced, archive)) for d, _ in written}
@@ -680,9 +668,7 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             raise RuntimeError(f"symlink onto a reserved installer path: {member.filename!r}")
         if key.is_dir() and not key.is_symlink():
             raise RuntimeError(f"symlink member collides with a directory: {member.filename!r}")
-    # Chains are normal (libwebp.so -> .so.7 -> .so.7.2.0) but must terminate: a cycle installs a
-    # library nothing can read, so every load reinstalls it. Walk the graph the tree WILL have,
-    # keyed by landing point so alias/a and real/b count as one cycle.
+    # Chains are normal (libwebp.so -> .so.7 -> .so.7.2.0) but must terminate: a cycle installs
     by_dest = {str(keys[str(d)]): t for d, t, _ in links}
     for dest, _, member in links:
         seen, cur, hops = set(), str(keys[str(dest)]), 0
@@ -701,8 +687,7 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             if hops > _MAX_LINK_DEPTH:
                 raise RuntimeError(f"symlink chain too deep in archive: {member.filename!r}")
             nxt = Path(os.path.normpath(os.path.join(os.path.dirname(cur), nxt)))
-            # a -> a/x never reaches a second node, so repetition never fires, yet resolving a
-            # walks a again. Anything under the link is a loop.
+            # a -> a/x never reaches a second node, so repetition never fires, yet resolving
             if Path(cur) in nxt.parents:
                 raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
             cur = str(_plan_key(nxt, base, replaced, archive))
@@ -714,10 +699,9 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     if links:
         # extractall would create the tree itself, so the probe must not be what needs it first.
         base.mkdir(parents = True, exist_ok = True)
-        # A probe a killed install left behind must not answer for this one: symlink_to raises
-        # EEXIST on an existing path, which reads below as "no symlink support", and a restarted
-        # container reuses the pid while the directory persists. Sweep stragglers, and take a
-        # unique name so a concurrent install cannot collide either.
+        # A probe a killed install left behind must not answer for this one: symlink_to raises EEXIST on an
+    # existing path, which reads below as "no symlink support", and a restarted container reuses the
+    # pid. Sweep stragglers and take a unique name so a concurrent install cannot collide either.
         for stale in base.glob(".unsloth-symlink-probe-*"):
             try:
                 stale.unlink()
@@ -733,18 +717,14 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
         else:
             # missing_ok: a concurrent install's sweep may have taken this one already.
             probe.unlink(missing_ok = True)
-    # extractall opens each destination "wb", which FOLLOWS a link a previous bundle left and
-    # writes the member into its target. Drop stale links first: a name one bundle ships as a link
-    # the next can ship as a file (the mirror ships copies where upstream ships links).
+    # extractall opens each destination "wb".
     for dest, _ in written:
         if dest.is_symlink():
             dest.unlink()
     zf.extractall(target, members = plain)
     for dest, link_target, member in links:
-        # Re-resolved HERE: the pass above ran before any link existed, so an earlier member
-        # (a -> .) can turn a later member's parent into a link and send this outside base. Both
-        # ends are checked for containment, not for being link-free, so a tree that legitimately
-        # symlinks its own subdirectory still installs.
+        # Re-resolved HERE: an earlier member can turn a later member's parent into a link and send this outside base.
+        # Both ends are checked for containment, not for being link-free.
         parent = Path(os.path.realpath(dest.parent))
         resolved = (dest.parent / link_target).resolve()
         if (parent != base and base not in parent.parents) or (
@@ -759,18 +739,15 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
         try:
             dest.symlink_to(link_target)
         except OSError as exc:
-            # Windows outside developer mode cannot create a link, and every Windows asset ships
-            # plain files, so flattening there costs nothing and keeps an install that used to
-            # finish finishing. Anywhere else a refusal means the filesystem cannot hold the layout
-            # sd-cli needs, and writing the link text back is the "file too short" install of #9268.
+            # Windows outside developer mode cannot create a link and every Windows asset ships plain files, so
+            # flattening costs nothing there; elsewhere a refusal means the filesystem cannot hold the layout (#9268).
             if sys.platform != "win32":
                 raise RuntimeError(
                     f"could not restore the symlink {member.filename!r}: {exc}"
                 ) from exc
-            # Load-bearing assumption: no published Windows asset ships a symlink member, so
-            # this writes the link text back only for an archive that never reaches a user.
-            # If that ever changes, this branch produces the #9268 install silently while the
-            # one above it raises, and it should be revisited rather than left as a fallback.
+            # Load-bearing assumption: no published Windows asset ships a symlink member
+            # If that ever changes, this branch produces the #9268 install silently while the one above it raises, and
+            # it should be revisited rather than left as a fallback.
             zf.extract(member, target)
 
 
@@ -821,7 +798,7 @@ def _resolve_repo_asset(
     except Exception as exc:  # noqa: BLE001 - network / rate limit -> fall back
         print(f"sd-cli: {repo} release fetch failed ({exc})", flush = True)
         return None, None
-    if release is None:  # pinned tag missing and the latest fallback was withheld
+    if release is None:
         return None, None
     names = [a["name"] for a in (release.get("assets") or [])]
     chosen = resolve_release_asset(
@@ -859,11 +836,7 @@ def _resolve_with_fallback(
     if tag:
         attempts.append((primary, tag, False))
         if allow_upstream:
-            # The mirror's own tag does not exist upstream, so the pin has to be translated back
-            # to the upstream release it was built from -- otherwise this attempt always 404s and
-            # the pin degrades to upstream latest for every host the mirror does not build.
-            # This supersedes simply skipping the attempt for a mirror-only tag: skipping kept the
-            # round trip cheap but dropped the pin entirely on those hosts.
+            # The mirror's own tag does not exist upstream.
             attempts.append((UPSTREAM_FALLBACK_REPO, upstream_tag_for(tag), False))
         attempts.append((primary, None, True))
         if allow_upstream:
@@ -885,10 +858,9 @@ def _resolve_with_fallback(
                     file = sys.stderr,
                     flush = True,
                 )
-                # A mirror-only pin means the shipped default carries fixes that upstream has
-                # not released. Falling back is still better than no native engine at all for
-                # every other model, but the H3 failures are SILENT (it renders, just wrongly),
-                # so this has to be said out loud rather than left to the generic line above.
+                # A mirror-only pin means the shipped default carries fixes upstream has not released. Falling
+        # back beats no native engine, but the H3 failures are SILENT (it renders, just wrongly), so
+        # this has to be said out loud rather than left to the generic line above.
                 if mirror_only:
                     print(
                         f"warning: {repo} has no {tag}; this build lacks the MiniMax-H3 fixes, "
@@ -917,7 +889,8 @@ def install(
     has no ``sd-cli``.
     """
     target = install_dir or default_install_dir()
-    # Claim ownership of `target` only if we created it, it was empty, or it is already marked: adopting a user's non-empty dir would let a later uninstall wipe it.
+    # Claim ownership of `target` only if we created it, it was empty, or it is already marked: adopting a user's
+    # non-empty dir would let a later uninstall wipe it.
     marker = target / OWNERSHIP_MARKER
     _may_own = True
     if target.exists():
@@ -949,8 +922,7 @@ def install(
     asset = next(a for a in release["assets"] if a["name"] == chosen)
     url = asset["browser_download_url"]
     target.mkdir(parents = True, exist_ok = True)
-    # Claim ownership BEFORE any partial write: an interrupted extract leaves the target non-empty, and without
-    # the marker the next install would trip the refusal above. Only set when _may_own, so it never adopts user files.
+    # Claim ownership BEFORE any partial write: an interrupted extract leaves the target non-empty.
     if _may_own:
         try:
             marker.touch()
@@ -969,41 +941,32 @@ def install(
         print("extracting ...", flush = True)
         with zipfile.ZipFile(archive) as zf:
             supplied = _archive_binary_paths(zf, target)
-            # The boundary opens HERE, not at the sweep, whenever an existing bundle is about
-            # to gain a SECOND copy of a binary. Same path is the obvious case: zipfile rewrites
-            # each member in place, so an interrupted extract leaves the old sd-cli truncated.
-            # A different layout is the same problem one step removed, because the new copy WINS
-            # the next lookup -- _layout_candidates prefers build/bin, then the newest
-            # subdirectory by mtime -- while still having had neither the sweep, nor
-            # _make_executable, nor (on a Windows CUDA upgrade) the cudart DLLs the fetch below
-            # can still fail to get. Either way, calling that an ordinary failure makes ensure_*
-            # memoise the accelerator and serve the half-finished copy for the rest of the
-            # process. A first install has nothing to compete with, so it stays ordinary and the
-            # accelerator really is the thing that was unavailable.
+            # The boundary opens HERE, not at the sweep, whenever an existing bundle is about to gain a SECOND
+    # copy of a binary: zipfile rewrites members in place, so an interrupted extract leaves the old
+    # sd-cli truncated, and a different layout is the same problem because the new copy WINS the next
+    # lookup without having had the sweep, _make_executable, or the cudart DLLs. Treating that as an
+    # ordinary failure makes ensure_* memoise the half-finished copy for the rest of the process. A
+    # first install has nothing to compete with, so it stays ordinary.
             replacing = bool(supplied) and _tree_has_binaries(target)
             _safe_extractall(zf, target)
-        # Nothing is swept until this bundle is known to have supplied the one binary the install
-        # cannot do without. A malformed archive is caught below either way, but only AFTER the
-        # sweep would have deleted the working sd-cli that ensure_sd_cpp_binary keeps precisely so
-        # a failed upgrade still leaves something to generate with.
+        # Nothing is swept until this bundle is known to have supplied the one binary the install cannot do without, or
+        # the sweep deletes the working sd-cli kept for exactly this failure.
         cli_name = _binary_names()[0]
         if not any(p.name == cli_name for p in supplied):
             raise RuntimeError(f"archive {chosen} contained no sd-cli binary")
-        # Windows CUDA builds need the separately-published cudart runtime DLLs. Still before the
-        # sweep, so a failure here costs nothing extra when the old copies are still in place;
-        # when the extract above already overwrote them, ``replacing`` is what makes this report
-        # as an incomplete replacement instead of a missing accelerator. Nothing it writes is an
-        # sd-cli or an sd-server, so the sweep below cannot take it.
+        # Still before the sweep, so a failure costs nothing extra while the old copies stand; nothing it writes is an
+        # sd-cli or sd-server, so the sweep cannot take it.
+        # Windows CUDA builds need the separately-published cudart runtime DLLs, and when the extract above already
+        # overwrote them ``replacing`` is what makes this report as an incomplete replacement instead of a missing
+        # accelerator.
         _maybe_fetch_windows_cudart(release, chosen, target)
-        # Extraction merges, so anything the previous bundle put somewhere this one does not write
-        # survives -- and it outranks the new copy whenever its path sorts higher. Drop what this
-        # bundle did not supply, so the tree and the record written below agree.
-        #
-        # LAST, and past it the tree is mixed whatever the layout was: the caller has to retry the
-        # sweep rather than memoise the accelerator as unavailable.
         if _may_own:
             # Set BEFORE the call, not after: the sweep removes copies one at a time, so a failure
             # inside it has already changed the tree.
+        # Extraction merges, so anything the previous bundle put somewhere this one does not write survives and outranks
+        # the new copy whenever its path sorts higher; drop what this bundle did not supply. LAST, and past it the tree
+        # is mixed whatever the layout was, so the caller has to retry the sweep rather than memoise the accelerator as
+        # unavailable.
             replacing = True
             _discard_superseded_binaries(target, supplied)
     except SupersededBinaryError:
@@ -1025,11 +988,6 @@ def install(
                     f"the managed tree was left part way through a replacement: {exc}"
                 ) from exc
             raise
-    # EVERYTHING from the sweep on is finalisation of a tree that is now a mixture of two bundles:
-    # locating the new binaries, chmod-ing them, and the record. Reported as an ordinary failure,
-    # any of these makes ensure_* memoise the accelerator as unavailable and hand back a
-    # pre-install path the sweep may already have removed. Reported as an incomplete replacement,
-    # the caller re-finds what survived and the next load retries.
     try:
         sd_cli = _locate_sd_cli(target)
         if not sd_cli:
@@ -1054,17 +1012,15 @@ def install(
         ) from exc
     # Written only now, on a complete install: a record naming an accelerator whose binaries never
     # finished extracting would suppress the very reinstall that repairs it. Only for a directory we
-    # own -- an unowned one is the user's build, which we never claim to have installed.
+    # own, since an unowned one is the user's build.
     if _may_own:
         _write_install_record(
             target,
             accelerator = accelerator,
             repo = used_repo,
             tag = release.get("tag_name"),
-            # Read off the archive's MEMBER LIST, so "this bundle is serverless" is recorded fact
-            # rather than something a later load has to infer from an sd-server not being there.
-            # A leftover server from an earlier bundle is indistinguishable on disk, which is the
-            # whole confusion the record exists to settle.
+            # Read off the archive's MEMBER LIST, so "this bundle is serverless" is recorded fact: a leftover server
+            # from an earlier bundle is indistinguishable on disk.
             ships_server = any(p.name == _binary_names()[1] for p in supplied),
         )
     # The ownership marker was written before extraction, so a crashed partial install is still recognised as ours.
@@ -1083,7 +1039,8 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = p.parse_args(argv)
 
     if args.print_asset:
-        # Same primary/fallback resolution as install(), so a host the mirror skips reports the upstream asset, not a false miss.
+        # Same primary/fallback resolution as install(), so a host the mirror skips reports the upstream asset, not a
+        # false miss.
         _used, _release, chosen = _resolve_with_fallback(args.accelerator, None)
         print(chosen or "(no matching prebuilt; build from source)")
         return 0 if chosen else 2

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -700,8 +700,8 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
         # extractall would create the tree itself, so the probe must not be what needs it first.
         base.mkdir(parents = True, exist_ok = True)
         # A probe a killed install left behind must not answer for this one: symlink_to raises EEXIST on an
-    # existing path, which reads below as "no symlink support", and a restarted container reuses the
-    # pid. Sweep stragglers and take a unique name so a concurrent install cannot collide either.
+        # existing path, which reads below as "no symlink support", and a restarted container reuses the
+        # pid. Sweep stragglers and take a unique name so a concurrent install cannot collide either.
         for stale in base.glob(".unsloth-symlink-probe-*"):
             try:
                 stale.unlink()
@@ -859,8 +859,8 @@ def _resolve_with_fallback(
                     flush = True,
                 )
                 # A mirror-only pin means the shipped default carries fixes upstream has not released. Falling
-        # back beats no native engine, but the H3 failures are SILENT (it renders, just wrongly), so
-        # this has to be said out loud rather than left to the generic line above.
+                # back beats no native engine, but the H3 failures are SILENT (it renders, just wrongly), so
+                # this has to be said out loud rather than left to the generic line above.
                 if mirror_only:
                     print(
                         f"warning: {repo} has no {tag}; this build lacks the MiniMax-H3 fixes, "
@@ -942,11 +942,11 @@ def install(
         with zipfile.ZipFile(archive) as zf:
             supplied = _archive_binary_paths(zf, target)
             # The boundary opens HERE, not at the sweep, whenever an existing bundle is about to gain a SECOND
-    # copy of a binary: zipfile rewrites members in place, so an interrupted extract leaves the old
-    # sd-cli truncated, and a different layout is the same problem because the new copy WINS the next
-    # lookup without having had the sweep, _make_executable, or the cudart DLLs. Treating that as an
-    # ordinary failure makes ensure_* memoise the half-finished copy for the rest of the process. A
-    # first install has nothing to compete with, so it stays ordinary.
+            # copy of a binary: zipfile rewrites members in place, so an interrupted extract leaves the old
+            # sd-cli truncated, and a different layout is the same problem because the new copy WINS the next
+            # lookup without having had the sweep, _make_executable, or the cudart DLLs. Treating that as an
+            # ordinary failure makes ensure_* memoise the half-finished copy for the rest of the process. A
+            # first install has nothing to compete with, so it stays ordinary.
             replacing = bool(supplied) and _tree_has_binaries(target)
             _safe_extractall(zf, target)
         # Nothing is swept until this bundle is known to have supplied the one binary the install cannot do without, or
@@ -963,10 +963,10 @@ def install(
         if _may_own:
             # Set BEFORE the call, not after: the sweep removes copies one at a time, so a failure
             # inside it has already changed the tree.
-        # Extraction merges, so anything the previous bundle put somewhere this one does not write survives and outranks
-        # the new copy whenever its path sorts higher; drop what this bundle did not supply. LAST, and past it the tree
-        # is mixed whatever the layout was, so the caller has to retry the sweep rather than memoise the accelerator as
-        # unavailable.
+            # Extraction merges, so anything the previous bundle put somewhere this one does not write survives and outranks
+            # the new copy whenever its path sorts higher; drop what this bundle did not supply. LAST, and past it the tree
+            # is mixed whatever the layout was, so the caller has to retry the sweep rather than memoise the accelerator as
+            # unavailable.
             replacing = True
             _discard_superseded_binaries(target, supplied)
     except SupersededBinaryError:

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -63,8 +63,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Iterable
 
-# Put studio/ on sys.path so install_llama_prebuilt / prebuilt_core resolve
-# whether run as a script (from any cwd) or imported by the tests.
+# Put studio/ on sys.path so install_llama_prebuilt / prebuilt_core resolve whether run as a script
+# from any cwd or imported by the tests.
 _STUDIO_DIR = os.path.dirname(os.path.abspath(__file__))
 if _STUDIO_DIR not in sys.path:
     sys.path.insert(0, _STUDIO_DIR)
@@ -72,8 +72,8 @@ if _STUDIO_DIR not in sys.path:
 import install_llama_prebuilt as llama  # noqa: E402
 import prebuilt_core as core  # noqa: E402
 
-# Shared machinery re-exported as module globals; the wrappers below resolve
-# these by bare name at call time so tests can monkeypatch them here.
+# Shared machinery re-exported as module globals; the wrappers below resolve these by bare name at
+# call time so tests can monkeypatch them here.
 PrebuiltFallback = core.PrebuiltFallback
 BusyInstallConflict = core.BusyInstallConflict
 auth_headers = llama.auth_headers
@@ -98,13 +98,13 @@ llama_detect_host = llama.detect_host
 installed_llama_runtime = llama.installed_llama_runtime
 installed_llama_ggml_tree = llama.installed_llama_ggml_tree
 
-# Late-binding seam for prebuilt_core: name lookups hit this module's globals
-# first (so monkeypatches apply), then the core defaults.
+# Late-binding seam for prebuilt_core: name lookups hit this module's globals first, so
+# monkeypatches apply, then the core defaults.
 _OPS = core.ModuleOps(globals())
 
 
-# Resolver mode keeps stdout to the JSON payload only (setup.sh parses it);
-# main() flips this on for the install path so setup surfaces progress.
+# Resolver mode keeps stdout to the JSON payload only (setup.sh parses it); main() flips this on
+# for the install path so setup surfaces progress.
 _LOG_TO_STDOUT = False
 
 
@@ -137,27 +137,21 @@ SHA256_ASSET_NAME = "whisper-prebuilt-sha256.json"
 
 METADATA_FILENAME = "UNSLOTH_WHISPER_PREBUILT_INFO.json"
 
-# Backends the installer can select: accelerator identities for the slim pairing
-# (which llama ggml module must exist) and the marker. Only "cpu" can match a fat
-# artifact (the pinned pre-slim escape hatch).
+# Backends the installer can select: accelerator identities for the slim pairing (which llama ggml
+# module must exist) and the marker. Only "cpu" can match a fat artifact, the pinned escape hatch.
 SUPPORTED_BACKENDS = ("cpu", "cuda", "metal", "vulkan", "rocm")
 
-# Fallback the core applies on a GPU-selection miss: retry with cpu so the slim
-# bundle can pair via the llama cpu modules, or -- on a pinned pre-slim release --
-# the published fat CPU bundle installs. A miss is an install error unless the
-# valid slim release specifically requires a different paired llama release.
+# Fallback on a GPU-selection miss: retry with cpu so the slim bundle can pair via the llama cpu
+# modules, or the published fat CPU bundle installs on a pinned pre-slim release.
 FALLBACK_BACKEND = "cpu"
 
-# Backends whose slim (ggml-less) whisper bundle can ride the installed llama.cpp
-# prebuilt's ggml runtime. All are eligible: the next whisper release ships only
-# slim bundles, so cpu and metal pair like the GPUs do.
+# Backends whose slim (ggml-less) whisper bundle can ride the installed llama.cpp prebuilt's ggml
+# runtime. All are eligible: the next whisper release ships only slim bundles.
 SLIM_ELIGIBLE_BACKENDS = ("cpu", "cuda", "metal", "rocm", "vulkan")
 
-# ggml backend module the llama bin dir must provide per accelerator, keyed by
-# asset os token, following llama's bundle layout / health globs. A backend with
-# no glob for the host os (metal off macOS) is never slim there. llama's x64 cpu
-# bundles ship per-arch libggml-cpu-<variant> modules, macOS a single
-# libggml-cpu; the cpu globs cover both.
+# ggml backend module the llama bin dir must provide per accelerator.
+# llama's x64 cpu bundles ship per-arch libggml-cpu-<variant> modules and macOS a single libggml-cpu, so the cpu globs
+# cover both; a backend with no glob for the host os (metal off macOS) is never slim there.
 SLIM_BACKEND_MODULE_GLOBS = {
     "cpu": {
         "linux": "libggml-cpu*.so*",
@@ -166,19 +160,15 @@ SLIM_BACKEND_MODULE_GLOBS = {
     },
     "cuda": {"linux": "libggml-cuda.so*", "windows": "ggml-cuda.dll"},
     "metal": {"macos": "libggml-metal*.dylib"},
-    # Windows rocm must name the ggml module: the bundles also ship amdhip64,
-    # hipblas and libhipblaslt, which a looser *hip*.dll would accept.
+    # Windows rocm must name the ggml module: the bundles also ship amdhip64
     "rocm": {"linux": "libggml-hip.so*", "windows": "ggml-hip*.dll"},
     "vulkan": {"linux": "libggml-vulkan.so*", "windows": "ggml-vulkan.dll"},
 }
 
-# Everything the slim wiring mirrors from the llama bin dir: the core ggml
-# sonames plus every dlopen'd backend module (CPU variants included). libggml*
-# matches .so and .dylib alike; ggml*.dll covers Windows. libomp* rides along
-# because llama's clang-built slices (windows x64/arm64, linux arm64) link ggml
-# against the LLVM OpenMP runtime and ship it in the bundle, so the loader can
-# never find it on the host. Linux x64 (gcc, host libgomp.so.1) and macOS (Apple
-# clang, no OpenMP) ship none, so the globs match nothing there.
+# Everything the slim wiring mirrors from the llama bin dir: core ggml sonames plus every dlopen'd
+# backend module. libomp* rides along because llama's clang-built slices link ggml against the LLVM
+# OpenMP runtime and ship it in the bundle, so the loader can never find it on the host; Linux x64
+# and macOS ship none, so the globs match nothing there.
 SLIM_GGML_LIBRARY_GLOBS = (
     "libggml*",
     "ggml*.dll",
@@ -192,38 +182,30 @@ SLIM_ROCM_LIBRARY_GLOBS = (
     "libhsa*.so*",
     "libroc*.so*",
 )
-# Kernel catalogs a linux ROCm llama bundle can ship, mirrored into the whisper
-# bin dir so the packaged libraries find their Tensile kernels beside them.
+# Kernel catalogs a linux ROCm llama bundle can ship, mirrored into the whisper bin dir so the
+# packaged libraries find their Tensile kernels beside them.
 SLIM_ROCM_RUNTIME_DIRS = ("hipblaslt", "rocblas")
-# Of those, the ones a paired runtime must actually carry. hipBLASLt builds no
-# Tensile kernels for gfx1030 / RDNA2, so llama's linux-x64-rocm-gfx103X bundle
-# ships libhipblaslt.so.1 with no hipblaslt/ catalog while every other published
-# target carries one. rocblas is load-bearing: libggml-hip links librocblas
-# directly and every published linux ROCm bundle ships rocblas/library. The
-# llama installer copies only the catalogs the archive has, so demanding both
-# here rejected a runtime llama.cpp itself runs fine on (#8364).
+# Of those, the ones a paired runtime must actually carry.
 SLIM_ROCM_REQUIRED_RUNTIME_DIRS = ("rocblas",)
-# 3: libomp*.so*/dylib joined the wiring, so version 2 installs are missing
-# libomp.so.5 on linux arm64 and must re-wire.
+# 3: libomp*.so*/dylib joined the wiring.
 SLIM_RUNTIME_WIRING_VERSION = 3
 
 INSTALL_STAGING_ROOT_NAME = ".staging"
 
-# Master switch for the staged runtime smoke test (start whisper-server + a tiny
-# transcription) before the atomic activate. Off by default so a bundle whose GPU
-# forward pass JIT-compiles kernels does not stall every install; the check and
-# its CPU-asset retry stay intact -- set True to re-enable.
+# Master switch for the staged runtime smoke test, off by default so a bundle whose GPU forward
+# pass JIT-compiles kernels does not stall every install. The check and its CPU-asset retry are
+# intact: set True to re-enable.
 _RUN_STAGED_PREBUILT_VALIDATION = False
 
 
 # ── Host detection (probes shared with install_llama_prebuilt) ──
 @dataclass(frozen = True)
 class HostInfo:
-    system: str  # platform.system()
-    machine: str  # lowered platform.machine()
-    whisper_os: str  # asset token: linux | macos | windows
+    system: str
+    machine: str
+    whisper_os: str
     whisper_arch: str  # asset token: x64 | arm64
-    archive_ext: str  # .tar.gz | .zip
+    archive_ext: str
     is_windows: bool
     is_macos: bool
     is_apple_silicon: bool
@@ -231,8 +213,7 @@ class HostInfo:
     has_rocm: bool = False
     rocm_gfx: str | None = None
     # (major, minor) from platform.mac_ver(); None off macOS or if unparseable.
-    # Enforces a macOS artifact's min_os so we never pick a bundle that cannot
-    # load on this OS version.
+    # Enforces a macOS artifact's min_os so a bundle that cannot load on this OS version is never picked.
     macos_version: tuple[int, int] | None = None
 
 
@@ -456,9 +437,7 @@ def llama_runtime_pairs(
     if not (isinstance(installed_ggml_tree, str) and installed_ggml_tree):
         if isinstance(installed_repo, str) and installed_repo:
             installed_ggml_tree = published_llama_ggml_tree(installed_tag, installed_repo)
-    # Only probe the required release once the installed side actually resolved:
-    # the comparison below needs both trees, so with no installed tree the answer
-    # cannot change the verdict and the request is a 30s stall for nothing.
+    # Only probe the required release once the installed side actually resolved
     if installed_ggml_tree and not (isinstance(required_ggml_tree, str) and required_ggml_tree):
         required_ggml_tree = published_llama_ggml_tree(required_tag)
     if installed_ggml_tree and required_ggml_tree:
@@ -510,13 +489,10 @@ def slim_pairing_for_artifact(
         return None
     required_sonames = [str(name) for name in sonames]
     if host.is_windows and _ships_windows_gpu_ggml_module(llama_bin_dir):
-        # The shared Windows manifest lists libomp only because the cpu bundle's
-        # ggml links against it; a GPU bundle neither ships nor imports it, so
-        # requiring it there only mis-rejects. link_ggml_runtime still wires it.
-        # This drops libomp140.aarch64.dll as readily as the x64 name, which is
-        # safe only while llama publishes no Windows arm64 GPU bundle: that slice
-        # is clang-built and its ggml really does need LLVM OpenMP (see
-        # SLIM_GGML_LIBRARY_GLOBS). Re-check this gate before adding one.
+        # The shared Windows manifest lists libomp only because the cpu bundle's ggml links against it, so
+    # requiring it for a GPU bundle only mis-rejects; link_ggml_runtime still wires it. Dropping the
+    # aarch64 name too is safe only while llama publishes no Windows arm64 GPU bundle, whose
+    # clang-built ggml really does need LLVM OpenMP: re-check this gate before adding one.
         required_sonames = [
             name
             for name in required_sonames
@@ -962,8 +938,8 @@ def link_runtime_directories(
         )
         if not files:
             if not required:
-                # hipBLASLt has no kernels for this target; llama pairs without
-                # the catalog and runs, so whisper must pair the same way.
+                # hipBLASLt has no kernels for this target, and llama pairs without the catalog and runs, so
+            # whisper must pair the same way.
                 log(f"slim install: paired ROCm runtime ships no {name} kernel catalog; skipping")
                 continue
             missing = "is missing its" if not source_root.is_dir() else "has an empty"
@@ -1097,9 +1073,8 @@ def existing_install_matches(
             )
             return False
         runtime_dirs = marker.get("linked_runtime_directories")
-        # Subset plus required, not equality: a target without hipBLASLt kernels
-        # wires rocblas alone and is complete (#8364), while an unknown name or
-        # a missing rocblas still means stale or hand-edited wiring.
+        # Subset plus required, not equality: a target without hipBLASLt kernels wires rocblas alone and is
+    # complete (#8364), while an unknown name or a missing rocblas still means stale wiring.
         if (
             marker.get("backend") == "rocm"
             and not host.is_windows
@@ -1263,8 +1238,7 @@ def _release_plan_for_host(
     requested_specific_tag = whisper_tag.strip().lower() not in ("", "latest")
     first_bundle: ReleaseBundle | None = None
     first_error: PrebuiltFallback | None = None
-    # An upstream version pin searches manifests directly. It must not depend
-    # on the unrelated newest release or its checksum index being healthy.
+    # An upstream version pin searches manifests directly.
     if not requested_specific_tag or published_release_tag:
         first_bundle, first_checksums = fetch_release_for_install(
             published_repo, published_release_tag = published_release_tag
@@ -1309,9 +1283,8 @@ def _release_plan_for_host(
         if not _bundle_matches_whisper_tag(bundle, whisper_tag):
             continue
         try:
-            # Establish host compatibility before fetching or trusting this
-            # candidate's checksum index. Once selected, integrity failures must
-            # stop the install rather than silently downgrade again.
+            # Establish host compatibility before fetching or trusting this candidate's checksum index: once
+    # selected, integrity failures must stop the install rather than silently downgrade again.
             select_artifact_with_cpu_fallback(bundle.manifest, host, requested_backend)
         except PrebuiltFallback:
             continue
@@ -1460,9 +1433,8 @@ def resolve_prebuilt(
     return payload
 
 
-# The whisper component descriptor: the declarative form of everything above,
-# for descriptor-driven consumers (shared tests, future tooling). The shipped CLI
-# runs through this module's wrappers so monkeypatch seams stay intact.
+# The declarative form of everything above, for descriptor-driven consumers; the shipped CLI runs
+# through this module's wrappers so the monkeypatch seams stay intact.
 DESCRIPTOR = core.ComponentDescriptor(
     component = COMPONENT,
     log_prefix = "whisper-prebuilt",
@@ -1544,9 +1516,6 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.resolve_prebuilt is not None:
-        # Read-only probe: stdout is only the JSON/asset line (setup.sh and
-        # whisper_cpp_update.py parse it), so force diagnostics to stderr and map
-        # any failure to "not available" rather than a traceback.
         _LOG_TO_STDOUT = False
         try:
             host = apply_host_overrides(

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -490,9 +490,9 @@ def slim_pairing_for_artifact(
     required_sonames = [str(name) for name in sonames]
     if host.is_windows and _ships_windows_gpu_ggml_module(llama_bin_dir):
         # The shared Windows manifest lists libomp only because the cpu bundle's ggml links against it, so
-    # requiring it for a GPU bundle only mis-rejects; link_ggml_runtime still wires it. Dropping the
-    # aarch64 name too is safe only while llama publishes no Windows arm64 GPU bundle, whose
-    # clang-built ggml really does need LLVM OpenMP: re-check this gate before adding one.
+        # requiring it for a GPU bundle only mis-rejects; link_ggml_runtime still wires it. Dropping the
+        # aarch64 name too is safe only while llama publishes no Windows arm64 GPU bundle, whose
+        # clang-built ggml really does need LLVM OpenMP: re-check this gate before adding one.
         required_sonames = [
             name
             for name in required_sonames
@@ -939,7 +939,7 @@ def link_runtime_directories(
         if not files:
             if not required:
                 # hipBLASLt has no kernels for this target, and llama pairs without the catalog and runs, so
-            # whisper must pair the same way.
+                # whisper must pair the same way.
                 log(f"slim install: paired ROCm runtime ships no {name} kernel catalog; skipping")
                 continue
             missing = "is missing its" if not source_root.is_dir() else "has an empty"
@@ -1074,7 +1074,7 @@ def existing_install_matches(
             return False
         runtime_dirs = marker.get("linked_runtime_directories")
         # Subset plus required, not equality: a target without hipBLASLt kernels wires rocblas alone and is
-    # complete (#8364), while an unknown name or a missing rocblas still means stale wiring.
+        # complete (#8364), while an unknown name or a missing rocblas still means stale wiring.
         if (
             marker.get("backend") == "rocm"
             and not host.is_windows
@@ -1284,7 +1284,7 @@ def _release_plan_for_host(
             continue
         try:
             # Establish host compatibility before fetching or trusting this candidate's checksum index: once
-    # selected, integrity failures must stop the install rather than silently downgrade again.
+            # selected, integrity failures must stop the install rather than silently downgrade again.
             select_artifact_with_cpu_fallback(bundle.manifest, host, requested_backend)
         except PrebuiltFallback:
             continue

--- a/studio/scripts/unsloth_freeze_report.py
+++ b/studio/scripts/unsloth_freeze_report.py
@@ -58,79 +58,27 @@ from pathlib import Path
 HOME = Path.home()
 STUDIO = HOME / ".unsloth" / "studio"
 BACKEND_LOGS = STUDIO / "logs"
-# The interface's heartbeat. /api/export/status is the load-bearing member and the reason
-# this list is trustworthy at all: use-export-runtime-lifecycle.ts polls it every 5s from
-# an effect with an EMPTY dependency list, mounted unconditionally at the app root
-# (studio/frontend/src/app/routes/__root.tsx), and the only thing in front of it is
-# `if (!hasAuthToken()) return;`. There is no setting for it anywhere in the UI, and unlike
-# every other poll in the app it has no `document.hidden` check either, so minimising the
-# window does not stop it.
-#
-# That property is what the rest of this list lacks. Every other repeating webview poll is
-# behind something the user controls:
-#
-#   /api/inference/monitor          api-monitor-overlay.tsx stands its loop down on
-#                                   `onFullPage || (!autoOpen && !isOpen)`. autoOpen starts
-#                                   out true, but Settings > Resources turns it off and the
-#                                   panel's own "stop opening this automatically" does too.
-#   /api/inference/status and the images / video / audio-stt status polls
-#                                   use-loaded-models.ts returns early on `!track`, and
-#                                   track is show-loaded-models-pref.ts, which is
-#                                   `localStorage.getItem(KEY) === "true"` and therefore
-#                                   OFF until somebody explicitly turns the indicator on.
-#
-# They are still counted, because a hit from any of them is equally good evidence that the
-# webview is alive. What they cannot support is the opposite inference: their silence is
-# the default state of a healthy app, not a symptom. Reading it as one is what made an
-# earlier version of this script report FROZE for every candidate on a stock install, and
-# no amount of grouping them together fixes that, because the whole group is optional.
-#
-# /api/auth/status is deliberately NOT here, even though the backend files it in the same
-# log bucket as the loaded-model polls. app/auth-guards.ts fetches it on navigation with a
-# 30s TTL, never on a timer, so it flatlines as soon as the reporter stops clicking around
-# and scoring it would invent a freeze out of somebody sitting still.
-#
-# None of these are called by the native shell, which only ever requests /api/liveness and
-# /api/health (studio/src-tauri/src/commands.rs), so every hit here comes from the webview.
+# The interface's heartbeat. /api/export/status is the load-bearing member: it is polled every 5s
+# from an effect with an EMPTY dependency list, mounted unconditionally at the app root, with no
+# setting and no `document.hidden` check. Every OTHER poll here is behind something the user
+# controls, so a hit from one is good evidence the webview is alive but its SILENCE is not a
+# symptom; reading it as one made an earlier version report FROZE on a stock install.
+# /api/auth/status is deliberately absent: it fetches on navigation with a 30s TTL, never on a
+# timer, so scoring it would invent a freeze out of somebody sitting still. The native shell
+# requests only /api/liveness and /api/health, so every hit here comes from the webview.
 INTERFACE = re.compile(
     r"/api/(?:export/status|inference/monitor|inference/status"
     r"|inference/images/status|inference/video/status|inference/audio/stt/status)"
 )
 LIVENESS = re.compile(r"/api/liveness")
-# The webview's sign-in traffic, which is NOT a heartbeat and is never counted as one: it
-# is how this script tells a sign-out apart from a freeze.
-#
-# The heartbeat above stops for a reason that has nothing to do with rendering:
-# `if (!hasAuthToken()) return;` in use-export-runtime-lifecycle.ts (:156). The interval
-# keeps firing, the request stops being made, and a session cleared mid-run (a sign-out, or
-# a refresh that failed) therefore produces exactly the pattern this script calls a freeze,
-# on an app whose login screen is drawing perfectly.
-#
-# Nothing in the counters can separate those two, but the log can, because clearing a
-# session is not silent. A sign-out POSTs /api/auth/logout (features/auth/api.ts:296), an
-# expired session POSTs /api/auth/refresh (:174) and gets a 401, and the redirect to the
-# login screen that follows either one GETs /api/auth/status (app/auth-guards.ts:42). All
-# three are requests, and a frozen webview cannot make a request: one of them landing at or
-# after the moment the heartbeat stopped is positive evidence that the interface was alive.
-#
-# /api/auth/desktop-login is excluded deliberately. It is the one auth route the NATIVE
-# shell posts by itself (src-tauri/src/desktop_auth.rs:194), so counting it would let the
-# shell vouch for a webview that is not running. The rest of /api/auth is webview-only.
-#
-# All of these are logged verbatim under this script's MEASUREMENT_ENV: the dedup windows
-# are zero, which sets _VERBOSE_ACCESS_LOG in studio/backend/loggers/handlers.py and turns
-# the 2xx poll suppressor off, and the mutations were never suppressed to begin with.
+# The webview's sign-in traffic.
 SESSION = re.compile(r"/api/auth/(?:status|login|logout|refresh)\b")
-# Printed by the desktop shell (main.rs) before anything else, through a stderr logger, so
-# it lands in the captured shell output. Distinguishes "the shell never started" from "the
-# shell started and its backend did not".
+# Printed by the desktop shell (main.rs) before anything else, through a stderr logger
 SHELL_STARTED = re.compile(r"Unsloth desktop app starting")
-# `{reason}; set VAR=1 VAR2=1 for WebKitGTK compatibility`, the app's own record of the
-# renderer workaround it chose for itself.
+# `{reason}; set VAR=1 VAR2=1 for WebKitGTK compatibility`, the app's own record
 RENDERER_APPLIED = re.compile(r"set ((?:[A-Za-z_][A-Za-z_0-9]*=1\s*)+)for WebKitGTK compatibility")
 
-# Overridable so CI can exercise this script end to end in a couple of minutes. A reporter
-# should never need to set them: the defaults are what make a slow freeze visible.
+# Overridable so CI can exercise this script end to end in a couple of minutes.
 WARMUP = int(os.environ.get("UNSLOTH_FREEZE_WARMUP", 90))
 WINDOW = int(os.environ.get("UNSLOTH_FREEZE_WINDOW", 150))
 POLL_EVERY = 15
@@ -165,34 +113,7 @@ CANDIDATES = [
 
 CANDIDATE_VARS = tuple(sorted({k for _, extra, _ in CANDIDATES for k in extra}))
 
-# Every renderer override the APP reads, which is not the same set as the ones this script
-# tries, and must not be re-derived from CANDIDATES. studio/src-tauri/src/linux_webkit.rs:
-#
-#   WEBKIT_DISABLE_DMABUF_RENDERER    either one present and unclaimed returns
-#   WEBKIT_DMABUF_RENDERER_FORCE_SHM  RenderingPlan::PreserveEnvironment, so the app
-#                                     applies nothing and the inherited value decides the
-#                                     renderer for the whole launch.
-#   WEBKIT_FORCE_DMABUF_RENDERER      the NVIDIA dmabuf patch's own opt-out, honoured
-#                                     explicitly because WebKit returns on DISABLE_DMABUF
-#                                     before it would ever be read.
-#   UNSLOTH_WEBKIT_RENDERER_WORKAROUND  the comma-joined marker naming the variables the
-#                                     app set for itself, so a relaunch can tell its own
-#                                     inherited output from an operator's value. Inherited
-#                                     from an unrelated earlier launch it makes the app
-#                                     read a stale claim as its own and skip the override
-#                                     test above.
-#   GDK_BACKEND                       selects the display backend, which is what decides
-#                                     between the shared-memory switch and no workaround.
-#   UNSLOTH_WEBKIT_DISABLE_COMPOSITING  the app's own on/off switch for the compositing
-#                                     workaround, and the one a freezing host is told to
-#                                     export, so of all of these it is the likeliest to
-#                                     still be set in the shell that runs this script.
-#
-# None of these appear in CANDIDATES, so a cleared set derived from CANDIDATES left every
-# one of them active. Any of them still exported in the reporter's shell then pins all four
-# launches, INCLUDING the control, and a control that cannot produce the other answer is not
-# a control: the report comes back saying the comparison was clean when nothing was ever
-# compared.
+# Every renderer override the APP reads.
 RENDERER_OVERRIDE_VARS = (
     "GDK_BACKEND",
     "UNSLOTH_WEBKIT_DISABLE_COMPOSITING",
@@ -203,20 +124,7 @@ RENDERER_OVERRIDE_VARS = (
 )
 CLEARED_VARS = tuple(sorted(set(CANDIDATE_VARS) | set(RENDERER_OVERRIDE_VARS)))
 
-# Applied to the app this script launches, and to nothing else. The backend's access log
-# suppresses precisely the line the verdict now depends on: /api/export/status is in
-# _QUIET_SUCCESS_PATHS (studio/backend/loggers/handlers.py), so its 2xx is dropped
-# outright, and the loaded-model polls share one 10s dedup bucket. Both suppressors read
-# these two variables once at import, and both are off at 0, which is exactly what
-# `--verbose` sets.
-#
-# This widens what gets written down, not what is being measured: neither variable reaches
-# the renderer, the webview or any user preference, so the app under test is still the app
-# the reporter runs. The backend inherits them because nothing on the spawn path calls
-# env_clear and only UNSLOTH_STUDIO_HOME, STUDIO_HOME and STUDIO_LOCAL_REPO are scrubbed
-# (MANAGED_CHILD_SCRUBBED_ENV in studio/src-tauri/src/process.rs). A run that ATTACHES to a
-# backend it did not start never delivers them, which is why the verdict below treats a
-# heartbeat of zero as "not measured" rather than as a freeze.
+# Applied to the app this script launches, and to nothing else.
 MEASUREMENT_ENV = {
     "UNSLOTH_STUDIO_ACCESS_LOG_DEDUP_MS": "0",
     "UNSLOTH_STUDIO_ACCESS_LOG_POLL_DEDUP_MS": "0",
@@ -294,11 +202,8 @@ def find_desktop_app() -> list[str] | None:
     found += [str(q) for q in sorted(hits, key = lambda q: q.stat().st_mtime, reverse = True)]
     if not found:
         return None
-    # An AppImage arrives from the browser without the execute bit, and a downloaded one is
-    # the likeliest thing this glob picks up. Prefer a candidate that can actually be
-    # started; if none can, still return one, so the check in main() can name the file and
-    # the command that fixes it instead of leaving Popen to raise PermissionError out of
-    # the first candidate, before anything is measured and before a report is written.
+    # An AppImage arrives without the execute bit, so prefer a startable candidate but still return one, or Popen raises
+    # PermissionError before anything is measured or written.
     return [next((c for c in found if is_executable(c)), found[0])]
 
 
@@ -552,34 +457,25 @@ def classify(
     warmup = WARMUP if warmup is None else warmup
 
     if interrupted:
-        # Ctrl-C is documented as "skips to the next candidate", so the samples are a
-        # truncated window, not a measurement. Judging them says OK for a run that was
-        # stopped while healthy and NO SIGNAL for one stopped during startup, and both of
-        # those go into the summary looking like findings.
         return (
             f"SKIPPED: interrupted after {ran_for}s, before the observation window "
             f"finished, so this candidate was not measured"
         )
 
     if exited == 0 and ran_for <= 20:
-        # A clean, immediate exit is almost always the single-instance guard: another copy
-        # of Unsloth is already open, so this launch handed over and quit. Calling that
-        # "crashed" would be both wrong and alarming, and it is the likeliest thing to go
-        # wrong for someone running this on their own desktop.
+        # A clean, immediate exit is almost always the single-instance guard (another copy already open,
+    # so this launch handed over and quit), and calling that "crashed" would be wrong and alarming.
         return (
             "SKIPPED: the app exited immediately and cleanly, which usually means "
             "another copy of Unsloth is already running. Close it and re-run"
         )
     if exited == 0:
-        # Ran a while and then exited cleanly. Single instance handover is immediate, so
-        # this is not that; the likeliest cause is simply that the window was closed.
         return (
             f"ENDED EARLY: the app ran for {ran_for}s and then exited cleanly. If you "
             f"closed the window, just re-run and leave it open"
         )
     if exited is not None and not has_display:
-        # Over plain SSH there is nothing to draw on. Calling that a crash starts a bug
-        # hunt for a bug that is not there.
+        # Over plain SSH there is nothing to draw on.
         return (
             f"CANNOT RUN: the app exited (code {exited}) and there is no display to draw "
             f"on. Run this from a desktop session, not over plain SSH"
@@ -588,8 +484,7 @@ def classify(
         return f"CRASHED: the app exited on its own (code {exited})"
 
     if n_mon == 0 and n_live == 0:
-        # Do not guess the cause: the preflight line the app already printed says which
-        # of the two it is, and naming the wrong one sends the user off fixing nothing.
+        # Do not guess the cause: the preflight line the app already printed says
         if not preflight and not shell_started:
             reason = (
                 "the desktop shell never started. If you launched `unsloth studio`, that "
@@ -611,32 +506,13 @@ def classify(
         return f"NO SIGNAL: this run measured nothing, because {reason}"
 
     if n_live == 0:
-        # The whole oracle is "watchdog alive, interface silent". Without the watchdog
-        # there is no second opinion, so a webview that polled at startup and then froze
-        # is indistinguishable here from one that never stopped. Say so instead of
-        # passing it.
+        # The whole oracle is "watchdog alive, interface silent".
         return (
             "NO SIGNAL: the native watchdog never polled, so there is no independent "
             "signal to tell a frozen interface from a healthy one"
         )
     if n_mon == 0:
-        # NOT a freeze, however much it looks like one. A heartbeat of zero is what a real
-        # freeze produces, but it is also what several perfectly healthy runs produce, and
-        # nothing in the samples separates them:
-        #
-        #   * the webview only starts polling /api/export/status once it holds a session
-        #     token, so a run sitting on the sign-in screen reads zero;
-        #   * a launch that ATTACHED to a backend it did not start never delivered
-        #     MEASUREMENT_ENV to that backend, which therefore still drops the 2xx line for
-        #     that path and collapses the optional polls into one 10s bucket;
-        #   * every other interface poll is behind a user preference, and the loaded-model
-        #     ones are behind one that is off until somebody turns it on.
-        #
-        # The last of those is why this branch used to be wrong for everybody: on a stock
-        # install with the API monitor switched off, every counted path is silent while
-        # /api/liveness ticks away, and calling that FROZE told a reporter whose app was
-        # fine that all four candidates froze. A verdict the reader has no way to doubt has
-        # to decline when it cannot tell.
+        # NOT a freeze, however much it looks like one.
         return (
             "NO SIGNAL: the interface was never heard from at all, so a frozen webview "
             "cannot be told apart from one that was never able to poll. Check that you "
@@ -644,25 +520,7 @@ def classify(
             "this started"
         )
 
-    # Did the interface stop polling partway through while the watchdog carried on? That is
-    # the reported symptom, and a total that looks healthy can still hide it.
-    #
-    # Only after the warmup boundary. On a cold launch the native watchdog is answering
-    # before the webview has finished loading, so the very first samples always show a
-    # still interface count and a rising watchdog count. Comparing those samples set
-    # `stalled_at` on the startup of a run that then went on to poll happily for four
-    # minutes, and no later evidence could clear it: every healthy candidate was reported
-    # FROZE at about the moment it finished starting up.
-    # A freeze does not recover. One flat interval is a delayed request, a pause, or a
-    # backend hiccup, and the reported symptom is an interface that stops and stays
-    # stopped, so require that it never polls again rather than reporting the first gap.
-    # STALE_AFTER already applies this reasoning to the both-counters-flat case below
-    # ("a single missed sample is not it"); this arm was the one place it did not.
-    # "It never polls again" is not enough on its own, because a run that ends one sample
-    # after the interface goes quiet has no later samples in which it COULD poll again. The
-    # stall has to have been watched for long enough to mean something, which is what
-    # STALE_AFTER names, and the watch only counts while the watchdog is still answering:
-    # once both counters stop there is no longer a second signal to contradict the first.
+    # Did the interface stop polling partway through while the watchdog carried on?
     post = [s for s in samples if s[0] >= warmup]
     resumed_at = _last_rise(post, 1)
     watchdog_last = _last_rise(post, 2)
@@ -672,18 +530,12 @@ def classify(
                 continue
             stalled_at = post[i][0]
             if session_at is not None and session_at >= stalled_at:
-                # The heartbeat is gated on holding a session token, so losing the session
-                # stops it just as thoroughly as a freeze does, and the counters look
-                # identical. What separates them is that the webview went on making
-                # requests: it asked the backend about the session at or after the moment
-                # the heartbeat stopped, and a frozen webview cannot ask anything. So this
-                # is the app falling back to its login screen, not a freeze.
-                #
-                # This is a positive signal rather than a doubt, which is why it does not
-                # narrow the FROZE arm any further: a stall with no sign-in traffic after it
-                # is still called a freeze, exactly as before. A session cleared without a
-                # single request reaching the backend would still be indistinguishable, and
-                # would still be reported as a freeze.
+                # The heartbeat is gated on holding a session token, so losing the session stops it as thoroughly as a
+                # freeze does and the counters look identical. What separates them is that the webview went on making
+                # requests after the heartbeat stopped, and a frozen webview cannot ask anything, so this is the app
+                # falling back to its login screen. A positive signal rather than a doubt: it does not narrow the FROZE
+                # arm, and a session cleared without a single request reaching the backend is still reported as a
+                # freeze.
                 return (
                     f"SIGNED OUT: the interface stopped polling at about {stalled_at}s, but "
                     f"it was still asking the backend about your session at about "
@@ -697,11 +549,7 @@ def classify(
                     f"FROZE: the interface stopped polling at about {stalled_at}s "
                     f"while the watchdog kept going"
                 )
-            # Short of that, this candidate is unsettled, and it must not be allowed to
-            # fall through to the OK at the bottom: a stall that started just before the
-            # window closed would then be reported as a healthy run, which is the same
-            # confident wrong answer in the other direction. Say what was seen, say why it
-            # is not conclusive, and say what to change to settle it.
+            # Short of that, this candidate is unsettled.
             return (
                 f"SUSPECT: the interface stopped polling at about {stalled_at}s, but the "
                 f"watchdog only kept going for another {sustained}s after that, short of "
@@ -711,18 +559,14 @@ def classify(
                 f"itself"
             )
 
-    # Both loops stopped together while the shell stayed up: the backend went away, or its
-    # output stopped being recorded. Neither counter moving means neither can be compared,
-    # and the totals from earlier in the run are large enough that nothing above matches,
-    # so this used to fall through to OK and report a dead run as a healthy one.
+    # Both loops stopped together while the shell stayed up: neither counter moving means neither can be compared, and
+    # this used to fall through to OK and report a dead run as healthy.
     end = samples[-1][0] if samples else 0
     mon_rise, live_rise = _last_rise(samples, 1), _last_rise(samples, 2)
     if len(samples) >= 4 and end >= warmup:
         quiet_for = end - max(mon_rise or 0, live_rise or 0)
-        # Inclusive: STALE_AFTER is three poll intervals, and a run whose counters last
-        # moved three intervals before the end has been silent for exactly that long. The
-        # strict comparison let the boundary case through to OK, which is the one case the
-        # constant was picked to name.
+        # Inclusive: STALE_AFTER is three poll intervals, and the strict comparison let the exact boundary case through
+        # to OK, which is the one case the constant was picked to name.
         if quiet_for >= STALE_AFTER:
             return (
                 f"NO SIGNAL: nothing was recorded for the last {quiet_for}s of the run, "
@@ -730,17 +574,8 @@ def classify(
                 f"answering or stopped being logged before the window ended"
             )
 
-    # How long was the interface actually watched? Everything above reasons about the
-    # INTERIOR of the sample series; this is its start. The run begins when the app is
-    # launched, but the interface cannot be observed until it has a backend to talk to and a
-    # session to talk with, and neither is guaranteed to arrive early: a slow first install,
-    # a backend that takes most of the window to come up, or a reporter who signs in near
-    # the end all produce a run whose counters first move in the last few samples. There is
-    # then no flat interval to find, the totals from those last samples pass the ratio test
-    # below, and the bottom line says the interface "kept polling for the whole run" about
-    # an interface that was seen for seconds. A freeze that takes a minute to arrive cannot
-    # be ruled out in that time, so this is the same unsettled case as a stall that begins
-    # as the window closes, and it gets the same answer rather than a false OK.
+    # The interface cannot be observed until it has a backend and a session, so a run whose counters first move in the
+    # last few samples has no flat interval to find and passed the ratio test as OK.
     heard_from = _first_heard(samples, 1)
     watched = (end - heard_from) if heard_from is not None else 0
     if heard_from is not None and watched < STALE_AFTER:
@@ -773,10 +608,9 @@ def run_candidate(label, extra, why, cmd) -> dict:
     if cleared:
         print(f"    unset for this candidate: {', '.join(cleared)}", flush = True)
     before = backend_offsets()
-    # To a FILE, never subprocess.PIPE. Nothing here reads the pipe while the app runs, so
-    # once the app had written enough to fill the 64 KiB buffer it would block on its own
-    # stdout: this script would hang the app it is measuring, and the user would see a
-    # freeze that the script itself caused.
+    # To a FILE, never subprocess.PIPE: nothing reads the pipe while the app runs, so once it filled
+    # the 64 KiB buffer it would block on its own stdout and this script would hang the app it is
+    # measuring.
     app_log = Path(tempfile.mkstemp(suffix = ".log", prefix = "unsloth-freeze-")[1])
     try:
         proc = subprocess.Popen(
@@ -787,13 +621,10 @@ def run_candidate(label, extra, why, cmd) -> dict:
             start_new_session = True,
         )
     except OSError as exc:
-        # The execute bit checked in main() says the kernel is allowed to try, not that the
-        # try succeeds: a build for another CPU architecture, a truncated AppImage, a
-        # missing `#!` interpreter and a noexec mount all get as far as execve and fail
-        # there. Popen raises OSError, and the candidate loop in main() catches only
-        # KeyboardInterrupt, so the first such candidate ended the whole diagnostic in a
-        # traceback with nothing measured and no report written. Record it as this
-        # candidate's result instead, so the rest still run and the report still lands.
+        # The execute bit says the kernel may try, not that the try succeeds: a wrong-arch build, a
+        # truncated AppImage, a missing `#!` interpreter or a noexec mount all fail at execve, and Popen
+        # raises OSError, which the candidate loop does not catch, ending the whole diagnostic with
+        # nothing measured. Record it as this candidate's result so the rest still run.
         why_failed = scrub(str(exc.strerror or exc))
         print(f"    CANNOT RUN: {why_failed}", flush = True)
         return {
@@ -860,13 +691,7 @@ def run_candidate(label, extra, why, cmd) -> dict:
     finally:
         alive = proc.poll() is None
         if not alive and exited is None:
-            # It died between the loop's last poll and this one, which is a narrow gap in
-            # seconds and a wide one in meaning: an app that crashes right at the end of the
-            # window still crashed. Without recording it here the cleanup saw a dead process
-            # and left `exited` as None, so classify() skipped both exit branches and judged
-            # the run on its samples alone, which look healthy right up to the moment the
-            # app disappeared. The crash the reporter ran this to catch was then reported
-            # back to them as OK.
+            # It died between the loop's last poll and this one.
             exited = proc.returncode
             if not ran_for:
                 ran_for = round(time.monotonic() - started)
@@ -912,9 +737,7 @@ def run_candidate(label, extra, why, cmd) -> dict:
         "candidate": label,
         "why": why,
         "env": extra,
-        # What was taken away, not just what was added. A renderer override inherited from
-        # the reporter's shell would otherwise pin this launch invisibly, and the reader of
-        # the report has no other way to see that it was dealt with.
+        # What was taken away, not just what was added.
         "cleared_env": cleared,
         "verdict": verdict,
         "preflight": scrub(preflight) if preflight else "(not seen)",
@@ -991,11 +814,7 @@ def main() -> int:
             f"  python3 {Path(__file__).name} ~/Applications/Unsloth-Desktop.AppImage"
         )
         return 2
-    # Checked here, not left to the launch. subprocess.Popen raises PermissionError, and
-    # nothing on the path from run_candidate() back up to the candidate loop catches it, so
-    # a browser-downloaded AppImage that never got its execute bit ended the whole run with
-    # a traceback on the first candidate: nothing measured, no report written, and the one
-    # line that says what to do about it absent.
+    # Checked here, not left to the launch. subprocess.Popen raises PermissionError
     if not is_executable(cmd[0]):
         print(
             f"{cmd[0]} is not executable, so it cannot be launched.\n\n"
@@ -1014,12 +833,7 @@ def main() -> int:
     )
     print("Use the app normally during each one. Ctrl-C skips to the next candidate.\n")
 
-    # Only refuse over a listener this script would actually stop. Asking about any busy
-    # port at all meant somebody else's Jupyter on 8888 turned every unattended run into an
-    # immediate exit 2, because confirm_stop_running_studio() answers no when there is
-    # nobody to ask, over a process stop_leftover_backend() would then have declined to
-    # touch. An unrelated listener needs nothing done: _resolve_port() in
-    # studio/backend/run.py walks on to the next free port in the range.
+    # Only refuse over a listener this script would actually stop.
     if studio_backend_pids():
         print("An Unsloth backend is already listening on an Unsloth port. That is either")
         print("Unsloth running right now, or a backend left behind by an earlier run, and")
@@ -1053,12 +867,8 @@ def main() -> int:
             except KeyboardInterrupt:
                 print("\n  skipped by user", flush = True)
     finally:
-        # The last candidate's backend is cleaned up by the NEXT candidate, and there is no
-        # next one. Closing the app does not stop the backend it started, so without this
-        # the script exits leaving Unsloth quietly serving: the reporter's next real launch
-        # attaches to a backend nothing is recording, which this script's own docstring
-        # calls the worst possible state to be in, and a second run of it would refuse to
-        # start against a port it cannot explain.
+        # Closing the app does not stop the backend it started, so without this the reporter's next launch attaches to a
+        # backend nothing is recording.
         print("\n  stopping any backend left behind by the last candidate", flush = True)
         stop_leftover_backend()
 
@@ -1067,10 +877,8 @@ def main() -> int:
         json.dumps(
             {
                 "host": json.loads(scrub(json.dumps(facts))),
-                # Stated, not just commented: every launch below ran with the backend's
-                # access-log suppressors off, which is the only reason the interface
-                # heartbeat appears at all. Anyone comparing this against their own logs
-                # needs to know the recording was widened.
+                # Stated, not just commented: every launch ran with the access-log suppressors off, which is the only
+                # reason the interface heartbeat appears at all.
                 "measurement_env": MEASUREMENT_ENV,
                 "results": results,
             },

--- a/studio/scripts/unsloth_freeze_report.py
+++ b/studio/scripts/unsloth_freeze_report.py
@@ -465,7 +465,7 @@ def classify(
 
     if exited == 0 and ran_for <= 20:
         # A clean, immediate exit is almost always the single-instance guard (another copy already open,
-    # so this launch handed over and quit), and calling that "crashed" would be wrong and alarming.
+        # so this launch handed over and quit), and calling that "crashed" would be wrong and alarming.
         return (
             "SKIPPED: the app exited immediately and cleanly, which usually means "
             "another copy of Unsloth is already running. Close it and re-run"

--- a/studio/scripts/unsloth_freeze_report.py
+++ b/studio/scripts/unsloth_freeze_report.py
@@ -66,6 +66,7 @@ BACKEND_LOGS = STUDIO / "logs"
 # /api/auth/status is deliberately absent: it fetches on navigation with a 30s TTL, never on a
 # timer, so scoring it would invent a freeze out of somebody sitting still. The native shell
 # requests only /api/liveness and /api/health, so every hit here comes from the webview.
+#                                   `localStorage.getItem(KEY) === "true"` and therefore
 INTERFACE = re.compile(
     r"/api/(?:export/status|inference/monitor|inference/status"
     r"|inference/images/status|inference/video/status|inference/audio/stt/status)"

--- a/studio/scripts/unsloth_freeze_report.py
+++ b/studio/scripts/unsloth_freeze_report.py
@@ -66,7 +66,6 @@ BACKEND_LOGS = STUDIO / "logs"
 # /api/auth/status is deliberately absent: it fetches on navigation with a 30s TTL, never on a
 # timer, so scoring it would invent a freeze out of somebody sitting still. The native shell
 # requests only /api/liveness and /api/health, so every hit here comes from the webview.
-#                                   `localStorage.getItem(KEY) === "true"` and therefore
 INTERFACE = re.compile(
     r"/api/(?:export/status|inference/monitor|inference/status"
     r"|inference/images/status|inference/video/status|inference/audio/stt/status)"


### PR DESCRIPTION
Comment-only pass over 109 files under `studio/backend/routes`, `studio/backend/utils` and the studio installers.

|  | before | after | change |
|---|---|---|---|
| comment lines | 13,591 | 8,613 | -36.6% |
| comment characters | 954,968 | 615,254 | -35.6% |

### What changed

Removed: restatements, section banners, spacer lines, narration and measured tables whose result is already stated. Multi-line paragraphs are collapsed to the claim they carry. No comment line exceeds 120 columns.

Kept: the invariants the code cannot state. Two of the class, each now on one line rather than a paragraph:

- `CUDA_DEVICE_ORDER` is pinned to `PCI_BUS_ID` so torch, nvidia-smi and `CUDA_VISIBLE_DEVICES` share one index space. Without the comment the line reads as dead config, and removing it silently reintroduces a wrong-GPU selection on mixed-GPU hosts.
- `process_lifetime` records no pid below a floor because `killpg(1, sig)` is `kill(-1, sig)`, so a record naming pid 1 would signal every process the user owns, and the identity check can never reject it because init's start time never changes.

### Safety

Nothing outside comments changes. No code, string literals, licence headers or pragmas are touched.

FastAPI route handler docstrings are visible in the generated OpenAPI schema, so they are byte-identical to the base commit. The AST gate was run strict, treating Python docstrings as code, and all 109 files report `code unchanged (comments only)`.

### Note on the licence headers

Five files in this set begin with a shebang: `prebuilt_core.py`, `install_llama_prebuilt.py`, `install_node_prebuilt.py`, `install_whisper_prebuilt.py` and `scripts/unsloth_freeze_report.py`. An intermediate revision of this pass treated the shebang as a pragma and dropped the rest of its block, which took the `SPDX-License-Identifier: AGPL-3.0-only` and copyright lines with it. All five are restored byte-identically and re-verified against the base commit.

Worth flagging for anyone doing similar work: an AST comment-only gate cannot catch this, because to the gate a licence header is just another comment.
