### PR TITLE
Studio: show what changed in llama.cpp updates

### DIFF
--- a/studio/backend/routes/llama.py
+++ b/studio/backend/routes/llama.py
@@ -196,9 +196,25 @@ async def llama_update(
 @router.get("/update-changelog", response_model = LlamaUpdateChangelogResponse)
 async def llama_update_changelog(
     force_refresh: bool = Query(False, description = "Retry the exact release lookups."),
+    installed_tag: Optional[str] = Query(
+        None,
+        max_length = 200,
+        description = "Installed tag the caller is displaying; ignored unless it still matches.",
+    ),
+    latest_tag: Optional[str] = Query(
+        None,
+        max_length = 200,
+        description = "Target the caller is displaying, so a newer one cached meanwhile "
+        "does not retarget the comparison.",
+    ),
     current_subject: str = Depends(get_current_subject),
 ) -> LlamaUpdateChangelogResponse:
-    result = await asyncio.to_thread(get_update_changelog, force_refresh = force_refresh)
+    result = await asyncio.to_thread(
+        get_update_changelog,
+        force_refresh = force_refresh,
+        installed_tag = installed_tag,
+        latest_tag = latest_tag,
+    )
     return LlamaUpdateChangelogResponse(**result)
 
 

--- a/studio/backend/routes/llama.py
+++ b/studio/backend/routes/llama.py
@@ -4,6 +4,7 @@
 """llama.cpp prebuilt update endpoints -- the single main update item.
 
 GET  /api/llama/update-status  -> is a newer prebuilt available + job state
+GET  /api/llama/update-changelog -> new carried changes since the installed build
 POST /api/llama/update         -> download + atomically swap to the latest
 
 Detection reuses utils.llama_cpp_freshness; the swap reuses
@@ -30,6 +31,7 @@ from auth.authentication import get_current_subject
 from loggers import get_logger
 from utils.llama_cpp_update import (
     get_backend_status,
+    get_update_changelog,
     get_update_status,
     start_backend_switch,
     start_update,
@@ -117,6 +119,30 @@ class LlamaUpdateStatusResponse(BaseModel):
     job: LlamaUpdateJob = Field(default_factory = LlamaUpdateJob)
 
 
+class LlamaUpdateChangeLink(BaseModel):
+    label: str
+    url: str
+
+
+class LlamaUpdateChange(BaseModel):
+    summary: str
+    links: list[LlamaUpdateChangeLink] = Field(default_factory = list)
+
+
+class LlamaUpdateChangelogResponse(BaseModel):
+    matched: bool = Field(
+        False,
+        description = "True when both releases were resolved and compared.",
+    )
+    installed_tag: Optional[str] = None
+    latest_tag: Optional[str] = None
+    changes: list[LlamaUpdateChange] = Field(default_factory = list)
+    total_changes: int = 0
+    truncated: bool = False
+    release_url: Optional[str] = None
+    error: Optional[str] = None
+
+
 class LlamaUpdateActionResponse(BaseModel):
     started: bool
     reason: Optional[str] = None
@@ -165,6 +191,15 @@ async def llama_update(
 ) -> LlamaUpdateActionResponse:
     action = await asyncio.to_thread(start_update)
     return LlamaUpdateActionResponse(**action)
+
+
+@router.get("/update-changelog", response_model = LlamaUpdateChangelogResponse)
+async def llama_update_changelog(
+    force_refresh: bool = Query(False, description = "Retry the exact release lookups."),
+    current_subject: str = Depends(get_current_subject),
+) -> LlamaUpdateChangelogResponse:
+    result = await asyncio.to_thread(get_update_changelog, force_refresh = force_refresh)
+    return LlamaUpdateChangelogResponse(**result)
 
 
 class LlamaBackendOption(BaseModel):

--- a/studio/backend/tests/test_llama_cpp_changelog.py
+++ b/studio/backend/tests/test_llama_cpp_changelog.py
@@ -320,6 +320,26 @@ def test_a_noncumulative_repo_is_never_compared(monkeypatch):
     )
 
 
+def test_a_case_variant_of_the_official_repo_is_still_official(monkeypatch):
+    # --published-repo UnslothAI/llama.cpp resolves to the same repository on
+    # GitHub and the installer persists that spelling, so a case-sensitive policy
+    # check would label the official repo custom and withhold the comparison.
+    releases = {"old": {"body": OLD_BODY}, "new": {"body": LATEST_BODY}}
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: releases.get(tag),
+    )
+
+    result = changes.changelog_for_update("UnslothAI/Llama.cpp", "old", "new")
+
+    assert result is not None
+    assert [item["summary"] for item in result["changes"]] == [
+        "model: add GLM-5-Next (GLM-5.3-Flash)",
+        "MTP for Qwen3.8-Flash-Next",
+    ]
+
+
 def test_a_bodyless_target_is_transient_not_permanent(monkeypatch):
     # Only the installed side can be permanently uncomparable. The target is the
     # newest release, so a missing body is a publishing gap that may be filled in,

--- a/studio/backend/tests/test_llama_cpp_changelog.py
+++ b/studio/backend/tests/test_llama_cpp_changelog.py
@@ -296,6 +296,30 @@ def test_unavailable_reason_separates_permanent_from_transient(monkeypatch):
     )
 
 
+def test_a_noncumulative_repo_is_never_compared(monkeypatch):
+    # --published-repo can point the install at upstream, whose notes are
+    # per-release. Diffing two of them omits every release in between: on real
+    # data, b10721 -> b10734 reported 5 "changes" (commit-message lines and an
+    # attestation URL) and dropped 324 bullets from the 9 releases between them.
+    upstream = {
+        "b10721": {"body": "<details open>\n\n- webgpu : avoid a crash (#28045)\n"},
+        "b10734": {"body": "<details open>\n\n- metal : enable Metal 4.0 (#27461)\n"},
+    }
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: upstream.get(tag),
+    )
+
+    assert changes.changelog_for_update("ggml-org/llama.cpp", "b10721", "b10734") is None
+    # Permanent: that repository will never publish cumulative notes, so the
+    # banner must not offer a Retry.
+    assert (
+        changes.unavailable_reason("ggml-org/llama.cpp", "b10721", "b10734")
+        == "notes_not_comparable"
+    )
+
+
 def test_a_bodyless_target_is_transient_not_permanent(monkeypatch):
     # Only the installed side can be permanently uncomparable. The target is the
     # newest release, so a missing body is a publishing gap that may be filled in,

--- a/studio/backend/tests/test_llama_cpp_changelog.py
+++ b/studio/backend/tests/test_llama_cpp_changelog.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import http.client
 import sys
+import time
 from pathlib import Path
 
 _BACKEND = Path(__file__).resolve().parents[1]
@@ -154,3 +156,194 @@ def test_cpp_identifiers_keep_literal_underscores():
     entry = changes._entry("ggml-cuda: keep ROCm_Host and GGML_CUDA_ENABLE_UNIFIED_MEMORY=0")
 
     assert entry["summary"] == ("ggml-cuda: keep ROCm_Host and GGML_CUDA_ENABLE_UNIFIED_MEMORY=0")
+
+
+def test_repo_with_a_dot_segment_never_reaches_github(monkeypatch):
+    # "." is inside the repo character class, so "owner/.." matched the shape check
+    # and would have walked out of /repos/ on any normalizing proxy.
+    called = False
+
+    def fail(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(changes.urllib.request, "urlopen", fail)
+
+    for repo in ("../etc", "owner/..", "..", "../rate_limit"):
+        assert changes._fetch_release(repo, "b1") is None
+    assert called is False
+
+
+def test_pull_and_issue_urls_share_one_identity_namespace():
+    # GitHub numbers issues and pull requests from the same sequence, so the same
+    # reference written three ways must match itself.
+    from_pull = changes._identities(
+        "Fix a crash ([ggml-org/llama.cpp#900](https://github.com/ggml-org/llama.cpp/pull/900))"
+    )
+    from_issue = changes._identities(
+        "Fix a crash ([the issue](https://github.com/ggml-org/llama.cpp/issues/900))"
+    )
+    from_text = changes._identities("Fix a crash, ggml-org#900")
+
+    assert from_pull & from_issue
+    assert from_issue & from_text
+
+
+def test_a_title_containing_the_metadata_delimiter_is_not_truncated():
+    entry = changes._entry(
+        "vulkan: handle ([a],[b]) tuples "
+        "([unslothai/llama.cpp#5](https://github.com/unslothai/llama.cpp/pull/5))"
+    )
+
+    assert entry["summary"] == "vulkan: handle ([a],[b]) tuples"
+    assert [link["url"] for link in entry["links"]] == [
+        "https://github.com/unslothai/llama.cpp/pull/5"
+    ]
+
+
+def test_a_bullet_with_no_summary_does_not_suppress_a_later_real_one(monkeypatch):
+    releases = {
+        "old": {"body": "Automated prebuild, merged with:\n\n- Unrelated carry\n"},
+        "new": {
+            "body": (
+                "Automated prebuild, merged with:\n\n"
+                "- Unrelated carry\n"
+                "- [ ](https://github.com/unslothai/llama.cpp/pull/900)\n"
+                "- Real change for PR 900 "
+                "([unslothai/llama.cpp#900](https://github.com/unslothai/llama.cpp/pull/900))\n"
+            ),
+        },
+    }
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: releases[tag],
+    )
+
+    result = changes.changelog_for_update("unslothai/llama.cpp", "old", "new")
+
+    assert [item["summary"] for item in result["changes"]] == [
+        "Real change for PR 900"
+    ]
+
+
+def test_a_missing_target_body_fails_closed(monkeypatch):
+    # Distinct from a prose-only target, which legitimately means "carries nothing".
+    releases = {"old": {"body": OLD_BODY}, "new": {}}
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: releases[tag],
+    )
+
+    assert changes.changelog_for_update("unslothai/llama.cpp", "old", "new") is None
+
+
+def test_forced_refresh_is_floored_to_one_fetch_per_interval(monkeypatch):
+    calls = []
+    monkeypatch.setattr(changes, "_release_memo", {})
+    monkeypatch.setattr(changes, "_release_failed_at", {})
+    monkeypatch.setattr(changes, "_release_forced_at", {})
+    monkeypatch.setattr(
+        changes,
+        "_fetch_release",
+        lambda _repo, tag, timeout = 5.0: calls.append(tag) or {"body": "- x"},
+    )
+
+    for _ in range(10):
+        changes._release_for_tag("unslothai/llama.cpp", "b1", force_refresh = True)
+
+    # Without the floor this was ten uncached GitHub round trips per ten clicks.
+    assert len(calls) == 1
+
+
+def test_an_expired_body_is_not_resurrected_by_a_recent_failure(monkeypatch):
+    key = ("unslothai/llama.cpp", "b1")
+    stale = time.monotonic() - (changes.RELEASE_CACHE_TTL_SECONDS * 2)
+    monkeypatch.setattr(changes, "_release_memo", {key: (stale, {"body": "- ancient"})})
+    monkeypatch.setattr(changes, "_release_failed_at", {key: time.monotonic()})
+    monkeypatch.setattr(changes, "_release_forced_at", {})
+
+    assert changes._release_for_tag(*key) is None
+
+
+def test_release_page_url_is_github_or_nothing():
+    assert changes.release_page_url("unslothai/llama.cpp", "b1/2") == (
+        "https://github.com/unslothai/llama.cpp/releases/tag/b1%2F2"
+    )
+    assert changes.release_page_url("owner/..", "b1") is None
+    assert changes.release_page_url("unslothai/llama.cpp", "") is None
+
+
+def test_unavailable_reason_separates_permanent_from_transient(monkeypatch):
+    # A release that predates the bullet format can never be compared, so the
+    # banner must not offer a Retry for it.
+    releases = {
+        "prose": {"body": "Automated Unsloth llama.cpp prebuild for upstream b9000."},
+        "itemised": {"body": OLD_BODY},
+    }
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: releases.get(tag),
+    )
+
+    assert changes.unavailable_reason(
+        "unslothai/llama.cpp", "prose", "itemised"
+    ) == "notes_not_itemised"
+    assert changes.unavailable_reason(
+        "unslothai/llama.cpp", "missing", "itemised"
+    ) == "release_notes_unavailable"
+
+
+def test_a_bodyless_target_is_transient_not_permanent(monkeypatch):
+    # Only the installed side can be permanently uncomparable. The target is the
+    # newest release, so a missing body is a publishing gap that may be filled in,
+    # and the banner must keep offering Retry for it.
+    releases = {"itemised": {"body": OLD_BODY}, "bodyless": {}}
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: releases.get(tag),
+    )
+
+    assert changes.unavailable_reason(
+        "unslothai/llama.cpp", "itemised", "bodyless"
+    ) == "release_notes_unavailable"
+
+
+def test_a_truncated_response_does_not_escape_to_the_caller(monkeypatch):
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, size = -1):
+            raise http.client.IncompleteRead(b"partial")
+
+    monkeypatch.setattr(
+        changes.urllib.request, "urlopen", lambda *_a, **_k: _Response()
+    )
+
+    # IncompleteRead is an HTTPException, not an OSError.
+    assert changes._fetch_release_blocking("unslothai/llama.cpp", "b1", 5.0) is None
+
+
+def test_an_oversized_release_body_is_rejected(monkeypatch):
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, size = -1):
+            return b"x" * (changes.MAX_RELEASE_BYTES + 1)
+
+    monkeypatch.setattr(
+        changes.urllib.request, "urlopen", lambda *_a, **_k: _Response()
+    )
+
+    assert changes._fetch_release_blocking("unslothai/llama.cpp", "b1", 5.0) is None

--- a/studio/backend/tests/test_llama_cpp_changelog.py
+++ b/studio/backend/tests/test_llama_cpp_changelog.py
@@ -222,9 +222,7 @@ def test_a_bullet_with_no_summary_does_not_suppress_a_later_real_one(monkeypatch
 
     result = changes.changelog_for_update("unslothai/llama.cpp", "old", "new")
 
-    assert [item["summary"] for item in result["changes"]] == [
-        "Real change for PR 900"
-    ]
+    assert [item["summary"] for item in result["changes"]] == ["Real change for PR 900"]
 
 
 def test_a_missing_target_body_fails_closed(monkeypatch):
@@ -288,12 +286,14 @@ def test_unavailable_reason_separates_permanent_from_transient(monkeypatch):
         lambda _repo, tag, *, force_refresh = False: releases.get(tag),
     )
 
-    assert changes.unavailable_reason(
-        "unslothai/llama.cpp", "prose", "itemised"
-    ) == "notes_not_itemised"
-    assert changes.unavailable_reason(
-        "unslothai/llama.cpp", "missing", "itemised"
-    ) == "release_notes_unavailable"
+    assert (
+        changes.unavailable_reason("unslothai/llama.cpp", "prose", "itemised")
+        == "notes_not_itemised"
+    )
+    assert (
+        changes.unavailable_reason("unslothai/llama.cpp", "missing", "itemised")
+        == "release_notes_unavailable"
+    )
 
 
 def test_a_bodyless_target_is_transient_not_permanent(monkeypatch):
@@ -307,9 +307,10 @@ def test_a_bodyless_target_is_transient_not_permanent(monkeypatch):
         lambda _repo, tag, *, force_refresh = False: releases.get(tag),
     )
 
-    assert changes.unavailable_reason(
-        "unslothai/llama.cpp", "itemised", "bodyless"
-    ) == "release_notes_unavailable"
+    assert (
+        changes.unavailable_reason("unslothai/llama.cpp", "itemised", "bodyless")
+        == "release_notes_unavailable"
+    )
 
 
 def test_a_truncated_response_does_not_escape_to_the_caller(monkeypatch):
@@ -323,9 +324,7 @@ def test_a_truncated_response_does_not_escape_to_the_caller(monkeypatch):
         def read(self, size = -1):
             raise http.client.IncompleteRead(b"partial")
 
-    monkeypatch.setattr(
-        changes.urllib.request, "urlopen", lambda *_a, **_k: _Response()
-    )
+    monkeypatch.setattr(changes.urllib.request, "urlopen", lambda *_a, **_k: _Response())
 
     # IncompleteRead is an HTTPException, not an OSError.
     assert changes._fetch_release_blocking("unslothai/llama.cpp", "b1", 5.0) is None
@@ -342,8 +341,6 @@ def test_an_oversized_release_body_is_rejected(monkeypatch):
         def read(self, size = -1):
             return b"x" * (changes.MAX_RELEASE_BYTES + 1)
 
-    monkeypatch.setattr(
-        changes.urllib.request, "urlopen", lambda *_a, **_k: _Response()
-    )
+    monkeypatch.setattr(changes.urllib.request, "urlopen", lambda *_a, **_k: _Response())
 
     assert changes._fetch_release_blocking("unslothai/llama.cpp", "b1", 5.0) is None

--- a/studio/backend/tests/test_llama_cpp_changelog.py
+++ b/studio/backend/tests/test_llama_cpp_changelog.py
@@ -159,8 +159,7 @@ def test_cpp_identifiers_keep_literal_underscores():
 
 
 def test_repo_with_a_dot_segment_never_reaches_github(monkeypatch):
-    # "." is inside the repo character class, so "owner/.." matched the shape check
-    # and would have walked out of /repos/ on any normalizing proxy.
+    # "." is in the repo character class, so "owner/.." passed the shape check.
     called = False
 
     def fail(*_args, **_kwargs):
@@ -175,8 +174,7 @@ def test_repo_with_a_dot_segment_never_reaches_github(monkeypatch):
 
 
 def test_pull_and_issue_urls_share_one_identity_namespace():
-    # GitHub numbers issues and pull requests from the same sequence, so the same
-    # reference written three ways must match itself.
+    # One number space, so the same reference written three ways must match itself.
     from_pull = changes._identities(
         "Fix a crash ([ggml-org/llama.cpp#900](https://github.com/ggml-org/llama.cpp/pull/900))"
     )
@@ -274,8 +272,7 @@ def test_release_page_url_is_github_or_nothing():
 
 
 def test_unavailable_reason_separates_permanent_from_transient(monkeypatch):
-    # A release that predates the bullet format can never be compared, so the
-    # banner must not offer a Retry for it.
+    # Predating the bullet format is permanent, so the banner offers no Retry.
     releases = {
         "prose": {"body": "Automated Unsloth llama.cpp prebuild for upstream b9000."},
         "itemised": {"body": OLD_BODY},
@@ -297,10 +294,9 @@ def test_unavailable_reason_separates_permanent_from_transient(monkeypatch):
 
 
 def test_a_noncumulative_repo_is_never_compared(monkeypatch):
-    # --published-repo can point the install at upstream, whose notes are
-    # per-release. Diffing two of them omits every release in between: on real
-    # data, b10721 -> b10734 reported 5 "changes" (commit-message lines and an
-    # attestation URL) and dropped 324 bullets from the 9 releases between them.
+    # Measured on real upstream releases: b10721 -> b10734 reported 5 "changes"
+    # (commit-message lines and an attestation URL) and dropped the 324 bullets in
+    # the 9 releases between them, because per-release notes are not cumulative.
     upstream = {
         "b10721": {"body": "<details open>\n\n- webgpu : avoid a crash (#28045)\n"},
         "b10734": {"body": "<details open>\n\n- metal : enable Metal 4.0 (#27461)\n"},
@@ -312,8 +308,7 @@ def test_a_noncumulative_repo_is_never_compared(monkeypatch):
     )
 
     assert changes.changelog_for_update("ggml-org/llama.cpp", "b10721", "b10734") is None
-    # Permanent: that repository will never publish cumulative notes, so the
-    # banner must not offer a Retry.
+    # Permanent: that repo will never publish cumulative notes, so no Retry.
     assert (
         changes.unavailable_reason("ggml-org/llama.cpp", "b10721", "b10734")
         == "notes_not_comparable"
@@ -321,9 +316,8 @@ def test_a_noncumulative_repo_is_never_compared(monkeypatch):
 
 
 def test_a_case_variant_of_the_official_repo_is_still_official(monkeypatch):
-    # --published-repo UnslothAI/llama.cpp resolves to the same repository on
-    # GitHub and the installer persists that spelling, so a case-sensitive policy
-    # check would label the official repo custom and withhold the comparison.
+    # GitHub resolves this to the same repository and the installer persists the
+    # spelling, so a case-sensitive check would label the official repo custom.
     releases = {"old": {"body": OLD_BODY}, "new": {"body": LATEST_BODY}}
     monkeypatch.setattr(
         changes,
@@ -341,9 +335,8 @@ def test_a_case_variant_of_the_official_repo_is_still_official(monkeypatch):
 
 
 def test_a_bodyless_target_is_transient_not_permanent(monkeypatch):
-    # Only the installed side can be permanently uncomparable. The target is the
-    # newest release, so a missing body is a publishing gap that may be filled in,
-    # and the banner must keep offering Retry for it.
+    # The target is the newest release, so a missing body is a publishing gap that
+    # may be filled in: keep the Retry.
     releases = {"itemised": {"body": OLD_BODY}, "bodyless": {}}
     monkeypatch.setattr(
         changes,

--- a/studio/backend/tests/test_llama_cpp_changelog.py
+++ b/studio/backend/tests/test_llama_cpp_changelog.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The llama.cpp banner shows a delta, never the cumulative release body."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parents[1]
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from utils import llama_cpp_changelog as changes  # noqa: E402
+
+
+OLD_BODY = """Automated prebuild, merged with:
+
+- DiffusionGemma ([#24423](https://github.com/ggml-org/llama.cpp/pull/24423), commit [old0000](https://github.com/ggml-org/llama.cpp/pull/24423/commits/old0000))
+- Add TML Inkling architecture ([#25731](https://github.com/ggml-org/llama.cpp/pull/25731), commit [old1111](https://github.com/ggml-org/llama.cpp/pull/25731/commits/old1111))
+- kimi-k3 loading fixes ([unslothai/llama.cpp#70](https://github.com/unslothai/llama.cpp/pull/70), commit [old2222](https://github.com/unslothai/llama.cpp/pull/70/commits/old2222))
+"""
+
+LATEST_BODY = """Automated prebuild, merged with:
+
+- Carry ggml-org#24423 (DiffusionGemma) ([unslothai/llama.cpp#107](https://github.com/unslothai/llama.cpp/pull/107), commit [new0000](https://github.com/unslothai/llama.cpp/pull/107/commits/new0000))
+- Add TML Inkling architecture, rebased ([#25731](https://github.com/ggml-org/llama.cpp/pull/25731), commit [new1111](https://github.com/ggml-org/llama.cpp/pull/25731/commits/new1111))
+- kimi-k3 loading fixes ([unslothai/llama.cpp#70](https://github.com/unslothai/llama.cpp/pull/70), commit [new2222](https://github.com/unslothai/llama.cpp/pull/70/commits/new2222))
+- model: add GLM-5-Next (GLM-5.3-Flash) ([#27754](https://github.com/ggml-org/llama.cpp/pull/27754), commit [949f7ef](https://github.com/ggml-org/llama.cpp/pull/27754/commits/949f7ef))
+- MTP for Qwen3.8-Flash-Next ([unslothai/llama.cpp#144](https://github.com/unslothai/llama.cpp/pull/144), commit [586b15e](https://github.com/unslothai/llama.cpp/pull/144/commits/586b15e))
+"""
+
+
+def test_delta_excludes_old_prs_after_rebase(monkeypatch):
+    releases = {
+        "b10698-mix-old": {"body": OLD_BODY},
+        "b10715-mix-new": {
+            "body": LATEST_BODY,
+            "html_url": "https://github.com/unslothai/llama.cpp/releases/tag/b10715-mix-new",
+        },
+    }
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: releases.get(tag),
+    )
+
+    result = changes.changelog_for_update(
+        "unslothai/llama.cpp", "b10698-mix-old", "b10715-mix-new"
+    )
+
+    assert result is not None
+    assert [item["summary"] for item in result["changes"]] == [
+        "model: add GLM-5-Next (GLM-5.3-Flash)",
+        "MTP for Qwen3.8-Flash-Next",
+    ]
+    assert result["changes"][0]["links"] == [
+        {"label": "#27754", "url": "https://github.com/ggml-org/llama.cpp/pull/27754"},
+        {
+            "label": "commit 949f7ef",
+            "url": "https://github.com/ggml-org/llama.cpp/pull/27754/commits/949f7ef",
+        },
+    ]
+    assert result["total_changes"] == 2
+    assert result["truncated"] is False
+
+
+def test_delta_fails_closed_when_either_release_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: (
+            {"body": LATEST_BODY} if tag == "latest" else None
+        ),
+    )
+
+    assert changes.changelog_for_update("unslothai/llama.cpp", "installed", "latest") is None
+
+
+def test_text_identity_filters_old_unlinked_bullets(monkeypatch):
+    releases = {
+        "old": {"body": "- Fix portable build\n"},
+        "new": {"body": "- Fix portable build\n- Add a new backend\n"},
+    }
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: releases[tag],
+    )
+
+    result = changes.changelog_for_update("unslothai/llama.cpp", "old", "new")
+
+    assert result is not None
+    assert result["changes"] == [{"summary": "Add a new backend", "links": []}]
+
+
+def test_invalid_repo_never_reaches_github(monkeypatch):
+    called = False
+
+    def fail(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(changes.urllib.request, "urlopen", fail)
+
+    assert changes._fetch_release("owner/repository/extra", "b1") is None
+    assert called is False
+
+
+def test_cpp_identifiers_keep_literal_underscores():
+    entry = changes._entry(
+        "ggml-cuda: keep ROCm_Host and GGML_CUDA_ENABLE_UNIFIED_MEMORY=0"
+    )
+
+    assert entry["summary"] == (
+        "ggml-cuda: keep ROCm_Host and GGML_CUDA_ENABLE_UNIFIED_MEMORY=0"
+    )

--- a/studio/backend/tests/test_llama_cpp_changelog.py
+++ b/studio/backend/tests/test_llama_cpp_changelog.py
@@ -93,6 +93,52 @@ def test_text_identity_filters_old_unlinked_bullets(monkeypatch):
     assert result["changes"] == [{"summary": "Add a new backend", "links": []}]
 
 
+def test_delta_fails_closed_when_installed_notes_have_no_bullets(monkeypatch):
+    # Every release published before b9625-mix-2d6bd50 (2026-06-14) describes its
+    # carried PRs in prose, so the bullet list is empty even though the build does
+    # carry them. Comparing against nothing would relabel #24423 as new.
+    releases = {
+        "b9596-mix-e6f2453": {
+            "body": (
+                "Automated Unsloth llama.cpp prebuild for upstream b9596 "
+                "+ PR #24423 @ 10a2613 (unslothai/llama.cpp@7bbfff8)."
+            )
+        },
+        "b10715-mix-new": {"body": LATEST_BODY},
+    }
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: releases[tag],
+    )
+
+    result = changes.changelog_for_update(
+        "unslothai/llama.cpp", "b9596-mix-e6f2453", "b10715-mix-new"
+    )
+
+    assert result is None
+
+
+def test_delta_reports_no_changes_when_target_drops_every_carried_pr(monkeypatch):
+    # The mirror case is NOT a failure: the target is always the newest release, so
+    # a bullet-less body there means the build carries nothing.
+    releases = {
+        "old": {"body": OLD_BODY},
+        "new": {"body": "Automated Unsloth llama.cpp prebuild for upstream b10800."},
+    }
+    monkeypatch.setattr(
+        changes,
+        "_release_for_tag",
+        lambda _repo, tag, *, force_refresh = False: releases[tag],
+    )
+
+    result = changes.changelog_for_update("unslothai/llama.cpp", "old", "new")
+
+    assert result is not None
+    assert result["changes"] == []
+    assert result["total_changes"] == 0
+
+
 def test_invalid_repo_never_reaches_github(monkeypatch):
     called = False
 

--- a/studio/backend/tests/test_llama_cpp_changelog.py
+++ b/studio/backend/tests/test_llama_cpp_changelog.py
@@ -94,9 +94,8 @@ def test_text_identity_filters_old_unlinked_bullets(monkeypatch):
 
 
 def test_delta_fails_closed_when_installed_notes_have_no_bullets(monkeypatch):
-    # Every release published before b9625-mix-2d6bd50 (2026-06-14) describes its
-    # carried PRs in prose, so the bullet list is empty even though the build does
-    # carry them. Comparing against nothing would relabel #24423 as new.
+    # Pre-b9625-mix-2d6bd50 (2026-06-14) releases name carried PRs in prose, so the
+    # bullet list is empty for a build that does carry #24423.
     releases = {
         "b9596-mix-e6f2453": {
             "body": (
@@ -120,8 +119,7 @@ def test_delta_fails_closed_when_installed_notes_have_no_bullets(monkeypatch):
 
 
 def test_delta_reports_no_changes_when_target_drops_every_carried_pr(monkeypatch):
-    # The mirror case is NOT a failure: the target is always the newest release, so
-    # a bullet-less body there means the build carries nothing.
+    # Not a failure: the target is always newest, so no bullets means no carries.
     releases = {
         "old": {"body": OLD_BODY},
         "new": {"body": "Automated Unsloth llama.cpp prebuild for upstream b10800."},

--- a/studio/backend/tests/test_llama_cpp_changelog.py
+++ b/studio/backend/tests/test_llama_cpp_changelog.py
@@ -46,9 +46,7 @@ def test_delta_excludes_old_prs_after_rebase(monkeypatch):
         lambda _repo, tag, *, force_refresh = False: releases.get(tag),
     )
 
-    result = changes.changelog_for_update(
-        "unslothai/llama.cpp", "b10698-mix-old", "b10715-mix-new"
-    )
+    result = changes.changelog_for_update("unslothai/llama.cpp", "b10698-mix-old", "b10715-mix-new")
 
     assert result is not None
     assert [item["summary"] for item in result["changes"]] == [
@@ -109,10 +107,6 @@ def test_invalid_repo_never_reaches_github(monkeypatch):
 
 
 def test_cpp_identifiers_keep_literal_underscores():
-    entry = changes._entry(
-        "ggml-cuda: keep ROCm_Host and GGML_CUDA_ENABLE_UNIFIED_MEMORY=0"
-    )
+    entry = changes._entry("ggml-cuda: keep ROCm_Host and GGML_CUDA_ENABLE_UNIFIED_MEMORY=0")
 
-    assert entry["summary"] == (
-        "ggml-cuda: keep ROCm_Host and GGML_CUDA_ENABLE_UNIFIED_MEMORY=0"
-    )
+    assert entry["summary"] == ("ggml-cuda: keep ROCm_Host and GGML_CUDA_ENABLE_UNIFIED_MEMORY=0")

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -1290,9 +1290,8 @@ def test_update_changelog_retry_keeps_the_banner_target(monkeypatch, tmp_path):
 
 
 def test_update_changelog_answers_the_pair_the_caller_asked_about(monkeypatch, tmp_path):
-    # Another Studio surface's forced status check advances the process-wide
-    # latest-release memo. Without honouring the caller's pair the panel answers
-    # about a target its own banner has not adopted, which it rejects.
+    # Another surface's forced status check advances the process-wide memo, so
+    # without the caller's pair the panel answers about a target it rejects.
     binary = _write_install(tmp_path, "b10698", release_tag = "b10698-mix-old")
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)
     monkeypatch.setattr(
@@ -1333,8 +1332,7 @@ def test_update_changelog_answers_the_pair_the_caller_asked_about(monkeypatch, t
 
 
 def test_update_changelog_ignores_a_pair_from_a_different_install(monkeypatch, tmp_path):
-    # The tree was swapped underneath the caller, so its pair is meaningless.
-    # Answer with the server's own view and let the frontend re-key on it.
+    # The tree was swapped underneath the caller: answer with the server's view.
     binary = _write_install(tmp_path, "b10698", release_tag = "b10698-mix-old")
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)
     monkeypatch.setattr(

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -1287,3 +1287,73 @@ def test_update_changelog_retry_keeps_the_banner_target(monkeypatch, tmp_path):
 
     assert result["latest_tag"] == "b10715-mix-new"
     assert result["matched"] is True
+
+
+def test_update_changelog_answers_the_pair_the_caller_asked_about(monkeypatch, tmp_path):
+    # Another Studio surface's forced status check advances the process-wide
+    # latest-release memo. Without honouring the caller's pair the panel answers
+    # about a target its own banner has not adopted, which it rejects.
+    binary = _write_install(tmp_path, "b10698", release_tag = "b10698-mix-old")
+    monkeypatch.setattr(upd, "_find_binary", lambda: binary)
+    monkeypatch.setattr(
+        freshness,
+        "_fetch_latest_release_tag",
+        lambda repo, timeout = 5.0: "b10800-mix-newer",
+    )
+    seen = {}
+
+    def fake_changelog(
+        repo,
+        installed,
+        latest,
+        *,
+        force_refresh = False,
+    ):
+        seen.update(installed = installed, latest = latest)
+        return {
+            "changes": [],
+            "total_changes": 0,
+            "truncated": False,
+            "release_url": "https://github.com/unslothai/llama.cpp/releases/tag/x",
+        }
+
+    monkeypatch.setattr(upd, "changelog_for_update", fake_changelog)
+
+    result = upd.get_update_changelog(installed_tag = "b10698", latest_tag = "b10715-mix-new")
+
+    assert result["latest_tag"] == "b10715-mix-new"
+    assert seen["latest"] == "b10715-mix-new"
+    assert result["matched"] is True
+
+    # The release page offered on the failure path points at that same target.
+    monkeypatch.setattr(upd, "changelog_for_update", lambda *_a, **_k: None)
+    failed = upd.get_update_changelog(installed_tag = "b10698", latest_tag = "b10715-mix-new")
+
+    assert failed["release_url"].endswith("b10715-mix-new")
+
+
+def test_update_changelog_ignores_a_pair_from_a_different_install(monkeypatch, tmp_path):
+    # The tree was swapped underneath the caller, so its pair is meaningless.
+    # Answer with the server's own view and let the frontend re-key on it.
+    binary = _write_install(tmp_path, "b10698", release_tag = "b10698-mix-old")
+    monkeypatch.setattr(upd, "_find_binary", lambda: binary)
+    monkeypatch.setattr(
+        freshness,
+        "_fetch_latest_release_tag",
+        lambda repo, timeout = 5.0: "b10800-mix-newer",
+    )
+    monkeypatch.setattr(
+        upd,
+        "changelog_for_update",
+        lambda *_args, **_kwargs: {
+            "changes": [],
+            "total_changes": 0,
+            "truncated": False,
+            "release_url": "https://github.com/unslothai/llama.cpp/releases/tag/x",
+        },
+    )
+
+    result = upd.get_update_changelog(installed_tag = "b9000", latest_tag = "b10715-mix-new")
+
+    assert result["installed_tag"] == "b10698"
+    assert result["latest_tag"] == "b10800-mix-newer"

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -1256,3 +1256,35 @@ def test_update_changelog_uses_full_installed_release_identity(monkeypatch, tmp_
         "latest": "b10715-mix-new",
         "force_refresh": True,
     }
+
+
+def test_update_changelog_retry_keeps_the_banner_target(monkeypatch, tmp_path):
+    # Retry must compare the pair the banner is showing. Refreshing the latest
+    # pointer moves it, and the frontend rejects any response whose tags differ
+    # from the ones it asked about, so the panel would stay stuck on the error.
+    binary = _write_install(tmp_path, "b10698", release_tag = "b10698-mix-old")
+    monkeypatch.setattr(upd, "_find_binary", lambda: binary)
+    published = {"tag": "b10715-mix-new"}
+    monkeypatch.setattr(
+        freshness,
+        "_fetch_latest_release_tag",
+        lambda repo, timeout = 5.0: published["tag"],
+    )
+    # The banner rendered this target on its last hourly status check.
+    assert freshness.latest_published_release("unslothai/llama.cpp") == "b10715-mix-new"
+    published["tag"] = "b10800-mix-newer"  # published while the banner sat open
+    monkeypatch.setattr(
+        upd,
+        "changelog_for_update",
+        lambda *_args, **_kwargs: {
+            "changes": [{"summary": "New model", "links": []}],
+            "total_changes": 1,
+            "truncated": False,
+            "release_url": "https://github.com/unslothai/llama.cpp/releases/tag/new",
+        },
+    )
+
+    result = upd.get_update_changelog(force_refresh = True)
+
+    assert result["latest_tag"] == "b10715-mix-new"
+    assert result["matched"] is True

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -1206,3 +1206,47 @@ def test_status_source_build_includes_update_size(monkeypatch, tmp_path):
     assert st["source_build"] is True
     assert st["update_available"] is True
     assert st["update_size_bytes"] == 77_000_000
+
+
+def test_update_changelog_uses_full_installed_release_identity(monkeypatch, tmp_path):
+    binary = _write_install(
+        tmp_path,
+        "b10698",
+        release_tag = "b10698-mix-old",
+    )
+    monkeypatch.setattr(upd, "_find_binary", lambda: binary)
+    monkeypatch.setattr(
+        freshness,
+        "_fetch_latest_release_tag",
+        lambda repo, timeout = 5.0: "b10715-mix-new",
+    )
+    seen = {}
+
+    def fake_changelog(repo, installed, latest, *, force_refresh = False):
+        seen.update(
+            repo = repo,
+            installed = installed,
+            latest = latest,
+            force_refresh = force_refresh,
+        )
+        return {
+            "changes": [{"summary": "New model", "links": []}],
+            "total_changes": 1,
+            "truncated": False,
+            "release_url": "https://github.com/unslothai/llama.cpp/releases/tag/new",
+        }
+
+    monkeypatch.setattr(upd, "changelog_for_update", fake_changelog)
+
+    result = upd.get_update_changelog(force_refresh = True)
+
+    assert result["matched"] is True
+    assert result["installed_tag"] == "b10698"
+    assert result["latest_tag"] == "b10715-mix-new"
+    assert result["changes"][0]["summary"] == "New model"
+    assert seen == {
+        "repo": "unslothai/llama.cpp",
+        "installed": "b10698-mix-old",
+        "latest": "b10715-mix-new",
+        "force_refresh": True,
+    }

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -1222,7 +1222,13 @@ def test_update_changelog_uses_full_installed_release_identity(monkeypatch, tmp_
     )
     seen = {}
 
-    def fake_changelog(repo, installed, latest, *, force_refresh = False):
+    def fake_changelog(
+        repo,
+        installed,
+        latest,
+        *,
+        force_refresh = False,
+    ):
         seen.update(
             repo = repo,
             installed = installed,

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -1259,9 +1259,8 @@ def test_update_changelog_uses_full_installed_release_identity(monkeypatch, tmp_
 
 
 def test_update_changelog_retry_keeps_the_banner_target(monkeypatch, tmp_path):
-    # Retry must compare the pair the banner is showing. Refreshing the latest
-    # pointer moves it, and the frontend rejects any response whose tags differ
-    # from the ones it asked about, so the panel would stay stuck on the error.
+    # Retry must compare the pair the banner shows: the frontend rejects a response
+    # whose tags differ from the ones it asked about, leaving the panel in error.
     binary = _write_install(tmp_path, "b10698", release_tag = "b10698-mix-old")
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)
     published = {"tag": "b10715-mix-new"}

--- a/studio/backend/tests/test_llama_route.py
+++ b/studio/backend/tests/test_llama_route.py
@@ -141,7 +141,11 @@ def test_changelog_response_exposes_structured_links():
 def test_changelog_handler_runs_off_event_loop(monkeypatch):
     seen = {}
 
-    def fake_changelog(force_refresh = False):
+    def fake_changelog(
+        force_refresh = False,
+        installed_tag = None,
+        latest_tag = None,
+    ):
         seen["thread"] = threading.current_thread()
         seen["refresh"] = force_refresh
         return {"matched": True, "installed_tag": "b1", "latest_tag": "b2"}

--- a/studio/backend/tests/test_llama_route.py
+++ b/studio/backend/tests/test_llama_route.py
@@ -147,9 +147,7 @@ def test_changelog_handler_runs_off_event_loop(monkeypatch):
         return {"matched": True, "installed_tag": "b1", "latest_tag": "b2"}
 
     monkeypatch.setattr(rl, "get_update_changelog", fake_changelog)
-    out = asyncio.run(
-        rl.llama_update_changelog(force_refresh = True, current_subject = "test")
-    )
+    out = asyncio.run(rl.llama_update_changelog(force_refresh = True, current_subject = "test"))
 
     assert out.matched is True
     assert seen == {"thread": seen["thread"], "refresh": True}

--- a/studio/backend/tests/test_llama_route.py
+++ b/studio/backend/tests/test_llama_route.py
@@ -115,6 +115,47 @@ def test_status_response_exposes_update_component():
     assert model.model_dump()["update_component"] == "whisper"
 
 
+def test_changelog_response_exposes_structured_links():
+    model = rl.LlamaUpdateChangelogResponse(
+        matched = True,
+        installed_tag = "b10698",
+        latest_tag = "b10715-mix-new",
+        changes = [
+            {
+                "summary": "MTP for Qwen",
+                "links": [
+                    {
+                        "label": "unslothai/llama.cpp#144",
+                        "url": "https://github.com/unslothai/llama.cpp/pull/144",
+                    }
+                ],
+            }
+        ],
+        total_changes = 1,
+        release_url = "https://github.com/unslothai/llama.cpp/releases/tag/new",
+    )
+
+    assert model.model_dump()["changes"][0]["links"][0]["label"].endswith("#144")
+
+
+def test_changelog_handler_runs_off_event_loop(monkeypatch):
+    seen = {}
+
+    def fake_changelog(force_refresh = False):
+        seen["thread"] = threading.current_thread()
+        seen["refresh"] = force_refresh
+        return {"matched": True, "installed_tag": "b1", "latest_tag": "b2"}
+
+    monkeypatch.setattr(rl, "get_update_changelog", fake_changelog)
+    out = asyncio.run(
+        rl.llama_update_changelog(force_refresh = True, current_subject = "test")
+    )
+
+    assert out.matched is True
+    assert seen == {"thread": seen["thread"], "refresh": True}
+    assert seen["thread"] is not threading.main_thread()
+
+
 def test_backend_status_response_exposes_selection_applied():
     model = rl.LlamaBackendStatusResponse(selection_applied = False)
 

--- a/studio/backend/utils/llama_cpp_changelog.py
+++ b/studio/backend/utils/llama_cpp_changelog.py
@@ -29,6 +29,13 @@ from utils.prebuilt.freshness_flow import (
 logger = structlog.get_logger(__name__)
 
 MAX_CHANGES = 50
+# The only repository whose notes this module can read. Its bodies are generated
+# (cumulative, one bullet per carried PR); --published-repo can point an install
+# at upstream or a mirror, whose per-release notes are a different document. On
+# ggml-org/llama.cpp, b10721 -> b10734 reported 5 "changes" -- commit-message
+# lines and an attestation URL -- and dropped 324 bullets from the 9 releases in
+# between, because a per-release body says nothing about what is still carried.
+CUMULATIVE_NOTES_REPO = "unslothai/llama.cpp"
 # 4 MiB. A release body is a few KB; the cap only stops an unbounded read if the
 # far side ever stops behaving like the GitHub API.
 MAX_RELEASE_BYTES = 4 * 1024 * 1024
@@ -220,13 +227,16 @@ def release_page_url(repo: str, tag: str) -> Optional[str]:
 def unavailable_reason(repo: str, installed_tag: str, latest_tag: str) -> str:
     """Why a comparison could not be made, for a caller holding ``None``.
 
-    ``notes_not_itemised`` is permanent for that pair -- the release predates the
-    bullet format and no retry can change it -- while ``release_notes_unavailable``
-    is a fetch that may succeed later. The banner uses this to decide whether
-    offering Retry is honest.
+    ``notes_not_itemised`` and ``notes_not_comparable`` are permanent -- the
+    release predates the bullet format, or the install tracks a repository whose
+    notes are not cumulative -- while ``release_notes_unavailable`` is a fetch
+    that may succeed later. The banner uses this to decide whether offering Retry
+    is honest.
     """
     if not _valid_repo(repo) or not installed_tag or not latest_tag:
         return "release_notes_unavailable"
+    if repo != CUMULATIVE_NOTES_REPO:
+        return "notes_not_comparable"
     # Both lookups are memoized, so this re-read costs nothing on the path that
     # has just performed them.
     installed = _release_for_tag(repo, installed_tag)
@@ -254,6 +264,8 @@ def changelog_for_update(
     None means no comparison was possible; do not fall back to the cumulative body.
     """
     if not repo or not installed_tag or not latest_tag or installed_tag == latest_tag:
+        return None
+    if repo != CUMULATIVE_NOTES_REPO:
         return None
     installed = _release_for_tag(repo, installed_tag, force_refresh = force_refresh)
     latest = _release_for_tag(repo, latest_tag, force_refresh = force_refresh)

--- a/studio/backend/utils/llama_cpp_changelog.py
+++ b/studio/backend/utils/llama_cpp_changelog.py
@@ -64,6 +64,13 @@ def _valid_repo(repo: str) -> bool:
     return not any(_DOT_SEGMENT.fullmatch(part) for part in repo.split("/"))
 
 
+def _is_cumulative_repo(repo: str) -> bool:
+    """Case-folded: GitHub owner/name is case-insensitive and --published-repo
+    persists whatever spelling was typed, so ``UnslothAI/llama.cpp`` is the same
+    official repository and must not be labelled a custom one."""
+    return repo.casefold() == CUMULATIVE_NOTES_REPO.casefold()
+
+
 def _fetch_release(
     repo: str,
     tag: str,
@@ -235,7 +242,7 @@ def unavailable_reason(repo: str, installed_tag: str, latest_tag: str) -> str:
     """
     if not _valid_repo(repo) or not installed_tag or not latest_tag:
         return "release_notes_unavailable"
-    if repo != CUMULATIVE_NOTES_REPO:
+    if not _is_cumulative_repo(repo):
         return "notes_not_comparable"
     # Both lookups are memoized, so this re-read costs nothing on the path that
     # has just performed them.
@@ -265,7 +272,7 @@ def changelog_for_update(
     """
     if not repo or not installed_tag or not latest_tag or installed_tag == latest_tag:
         return None
-    if repo != CUMULATIVE_NOTES_REPO:
+    if not _is_cumulative_repo(repo):
         return None
     installed = _release_for_tag(repo, installed_tag, force_refresh = force_refresh)
     latest = _release_for_tag(repo, latest_tag, force_refresh = force_refresh)

--- a/studio/backend/utils/llama_cpp_changelog.py
+++ b/studio/backend/utils/llama_cpp_changelog.py
@@ -137,10 +137,7 @@ def _release_for_tag(
         failed_at = _release_failed_at.get(key)
         cached = _release_memo.get(key)
         fresh = cached is not None and now - cached[0] < RELEASE_CACHE_TTL_SECONDS
-        if (
-            failed_at is not None
-            and now - failed_at < RELEASE_FAILURE_CACHE_TTL_SECONDS
-        ):
+        if failed_at is not None and now - failed_at < RELEASE_FAILURE_CACHE_TTL_SECONDS:
             # Suppress the retry, but an entry past its TTL is still expired: do
             # not let a recent failure resurrect a stale body as if it were fresh.
             return cached[1] if fresh else None

--- a/studio/backend/utils/llama_cpp_changelog.py
+++ b/studio/backend/utils/llama_cpp_changelog.py
@@ -9,6 +9,7 @@ bodies; showing the target body alone relabels old carried PRs as new.
 
 from __future__ import annotations
 
+import http.client
 import json
 import os
 import re
@@ -28,7 +29,16 @@ from utils.prebuilt.freshness_flow import (
 logger = structlog.get_logger(__name__)
 
 MAX_CHANGES = 50
+# 4 MiB. A release body is a few KB; the cap only stops an unbounded read if the
+# far side ever stops behaving like the GitHub API.
+MAX_RELEASE_BYTES = 4 * 1024 * 1024
+# A forced retry bypasses the memos, so without a floor a user holding down the
+# banner's Retry button issues two uncached GitHub calls per click.
+FORCE_REFRESH_MIN_INTERVAL_SECONDS = 30.0
 _REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+# "." and ".." are valid under _REPO because "." is in the class above, and
+# "owner/.." would walk out of /repos/ on any normalizing proxy.
+_DOT_SEGMENT = re.compile(r"^\.+$")
 _BULLET = re.compile(r"^ {0,3}[-*+]\s+(.+?)\s*$")
 _LINK = re.compile(r"\[([^\]]+)]\((https://github\.com/[^\s)]+)\)")
 _PR_URL = re.compile(r"^https://github\.com/([^/]+/[^/]+)/pull/(\d+)(?:/|$)", re.I)
@@ -37,6 +47,14 @@ _TEXT_REFERENCE = re.compile(r"(?<![\w./-])([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?
 
 _release_memo: dict[tuple[str, str], tuple[float, dict]] = {}
 _release_failed_at: dict[tuple[str, str], float] = {}
+_release_forced_at: dict[tuple[str, str], float] = {}
+
+
+def _valid_repo(repo: str) -> bool:
+    """``owner/name``, with no segment that is only dots."""
+    if not isinstance(repo, str) or not _REPO.fullmatch(repo):
+        return False
+    return not any(_DOT_SEGMENT.fullmatch(part) for part in repo.split("/"))
 
 
 def _fetch_release(
@@ -45,7 +63,7 @@ def _fetch_release(
     timeout: float = 5.0,
 ) -> Optional[dict]:
     """One exact GitHub release. None on invalid input or any failure."""
-    if not _REPO.fullmatch(repo) or not tag:
+    if not _valid_repo(repo) or not tag:
         return None
     from utils.utils import call_with_deadline
 
@@ -75,11 +93,20 @@ def _fetch_release_blocking(repo: str, tag: str, timeout: float) -> Optional[dic
     )
     try:
         with urllib.request.urlopen(request, timeout = timeout) as response:
-            payload = json.loads(response.read().decode("utf-8"))
+            # Bounded: read one byte past the cap so an oversized body is rejected
+            # rather than buffered in full.
+            raw = response.read(MAX_RELEASE_BYTES + 1)
+        if len(raw) > MAX_RELEASE_BYTES:
+            logger.debug("llama changelog release too large", repo = repo, tag = tag)
+            return None
+        payload = json.loads(raw.decode("utf-8"))
     except (
         urllib.error.URLError,
         urllib.error.HTTPError,
         OSError,
+        # IncompleteRead on a truncated response is an HTTPException, NOT an
+        # OSError, so without this a mid-read cut escapes to any direct caller.
+        http.client.HTTPException,
         UnicodeDecodeError,
         json.JSONDecodeError,
     ) as exc:
@@ -96,25 +123,41 @@ def _release_for_tag(
 ) -> Optional[dict]:
     """Exact release with 24h success and 60s failure memoization."""
     key = (repo, tag)
-    now = time.time()
+    # Memory-only, so monotonic throughout: a backward clock step must not be able
+    # to extend the TTL. freshness_flow uses wall time because it persists to disk.
+    now = time.monotonic()
+    if force_refresh:
+        # Honour the bypass, but not faster than once per key per interval.
+        forced_at = _release_forced_at.get(key)
+        if forced_at is not None and now - forced_at < FORCE_REFRESH_MIN_INTERVAL_SECONDS:
+            force_refresh = False
+        else:
+            _release_forced_at[key] = now
     if not force_refresh:
         failed_at = _release_failed_at.get(key)
+        cached = _release_memo.get(key)
+        fresh = cached is not None and now - cached[0] < RELEASE_CACHE_TTL_SECONDS
         if (
             failed_at is not None
-            and time.monotonic() - failed_at < RELEASE_FAILURE_CACHE_TTL_SECONDS
+            and now - failed_at < RELEASE_FAILURE_CACHE_TTL_SECONDS
         ):
-            cached = _release_memo.get(key)
-            return cached[1] if cached else None
-        cached = _release_memo.get(key)
-        if cached and now - cached[0] < RELEASE_CACHE_TTL_SECONDS:
+            # Suppress the retry, but an entry past its TTL is still expired: do
+            # not let a recent failure resurrect a stale body as if it were fresh.
+            return cached[1] if fresh else None
+        if fresh:
             return cached[1]
     release = _fetch_release(repo, tag)
     if release is None:
         _release_failed_at[key] = time.monotonic()
+        # Fall back to the last good body only while it is still within its TTL.
+        # An exact release that has become unreachable must not keep answering
+        # from an expired entry, or the panel presents a stale comparison as matched.
         cached = _release_memo.get(key)
-        return cached[1] if cached else None
+        if cached and time.monotonic() - cached[0] < RELEASE_CACHE_TTL_SECONDS:
+            return cached[1]
+        return None
     _release_failed_at.pop(key, None)
-    _release_memo[key] = (now, release)
+    _release_memo[key] = (time.monotonic(), release)
     return release
 
 
@@ -127,7 +170,10 @@ def _plain_text(markdown: str) -> str:
 
 def _entry(markdown: str) -> dict:
     # Metadata starts at " ([", so a title keeps its parens: GLM-5-Next (GLM-5.3-Flash).
-    metadata_at = markdown.find(" ([")
+    # rfind, not find: the generator always appends metadata as the final
+    # parenthesised group, and a PR title may itself contain " ([" -- with find,
+    # "vulkan: handle ([a],[b]) tuples ([#5](...))" renders as "vulkan: handle".
+    metadata_at = markdown.rfind(" ([")
     summary_markdown = markdown[:metadata_at] if metadata_at >= 0 else markdown
     links = []
     for label, url in _LINK.findall(markdown[metadata_at:] if metadata_at >= 0 else ""):
@@ -142,19 +188,19 @@ def _identities(markdown: str) -> set[str]:
     """Stable aliases for one carried change: a patch migrated to an Unsloth carry
     PR links that PR but still says ``ggml-org#24423``, and both must match."""
     identities = set()
+    # One namespace for all three notations. GitHub issues and pull requests share
+    # a repository's number space, so ``/issues/900``, ``/pull/900`` and the textual
+    # ``repo#900`` always denote the same object; giving them separate prefixes can
+    # only produce false negatives, never avoid a false positive.
     for _label, url in _LINK.findall(markdown):
-        match = _PR_URL.match(url)
+        match = _PR_URL.match(url) or _ISSUE_URL.match(url)
         if match:
-            identities.add(f"pr:{match.group(1).lower()}#{match.group(2)}")
-    for _label, url in _LINK.findall(markdown):
-        match = _ISSUE_URL.match(url)
-        if match:
-            identities.add(f"issue:{match.group(1).lower()}#{match.group(2)}")
+            identities.add(f"ref:{match.group(1).lower()}#{match.group(2)}")
     for repo, number in _TEXT_REFERENCE.findall(_plain_text(markdown)):
         # Shorthand omits the repo: ``ggml-org#24423`` is ``ggml-org/llama.cpp#24423``.
         if "/" not in repo:
             repo = f"{repo}/llama.cpp"
-        identities.add(f"pr:{repo.lower()}#{number}")
+        identities.add(f"ref:{repo.lower()}#{number}")
     if not identities:
         identities.add(f"text:{_entry(markdown)['summary'].casefold()}")
     return identities
@@ -164,6 +210,39 @@ def _bullets(body: object) -> list[str]:
     if not isinstance(body, str):
         return []
     return [match.group(1) for line in body.splitlines() if (match := _BULLET.match(line))]
+
+
+def release_page_url(repo: str, tag: str) -> Optional[str]:
+    """The human release page, so a failed comparison can still offer a way to
+    read the notes on GitHub. None when the repo is not a safe ``owner/name``."""
+    if not _valid_repo(repo) or not tag:
+        return None
+    return f"https://github.com/{repo}/releases/tag/{urllib.parse.quote(tag, safe = '')}"
+
+
+def unavailable_reason(repo: str, installed_tag: str, latest_tag: str) -> str:
+    """Why a comparison could not be made, for a caller holding ``None``.
+
+    ``notes_not_itemised`` is permanent for that pair -- the release predates the
+    bullet format and no retry can change it -- while ``release_notes_unavailable``
+    is a fetch that may succeed later. The banner uses this to decide whether
+    offering Retry is honest.
+    """
+    if not _valid_repo(repo) or not installed_tag or not latest_tag:
+        return "release_notes_unavailable"
+    # Both lookups are memoized, so this re-read costs nothing on the path that
+    # has just performed them.
+    installed = _release_for_tag(repo, installed_tag)
+    if installed is None:
+        return "release_notes_unavailable"
+    # Only the INSTALLED side can be permanently uncomparable: it is a release
+    # that shipped before the bullet format and will never gain one. A target
+    # without a usable body is the newest release, so it is a publishing gap that
+    # may be filled in -- calling that permanent would withhold a Retry that
+    # could actually succeed.
+    if not _bullets(installed.get("body")):
+        return "notes_not_itemised"
+    return "release_notes_unavailable"
 
 
 def changelog_for_update(
@@ -189,17 +268,28 @@ def changelog_for_update(
     installed_bullets = _bullets(installed.get("body"))
     if not installed_bullets:
         return None
+    # A prose-only target legitimately means "this build carries nothing", since
+    # the target is always the newest release. A MISSING or blank body is not the
+    # same statement: it carries no information at all, and answering "no new
+    # changes" would claim a comparison that never happened.
+    latest_body = latest.get("body")
+    if not isinstance(latest_body, str) or not latest_body.strip():
+        return None
+    latest_bullets = _bullets(latest_body)
     old_identities = set().union(*(_identities(item) for item in installed_bullets))
     new_items = []
     seen = set()
-    for item in _bullets(latest.get("body")):
+    for item in latest_bullets:
         identities = _identities(item)
         if identities & old_identities or identities & seen:
             continue
-        seen.update(identities)
         parsed = _entry(item)
-        if parsed["summary"]:
-            new_items.append(parsed)
+        if not parsed["summary"]:
+            # Claim nothing on behalf of a bullet that is never shown; updating
+            # `seen` here would let it suppress a later bullet for the same PR.
+            continue
+        seen.update(identities)
+        new_items.append(parsed)
 
     total = len(new_items)
     release_url = latest.get("html_url")

--- a/studio/backend/utils/llama_cpp_changelog.py
+++ b/studio/backend/utils/llama_cpp_changelog.py
@@ -29,22 +29,16 @@ from utils.prebuilt.freshness_flow import (
 logger = structlog.get_logger(__name__)
 
 MAX_CHANGES = 50
-# The only repository whose notes this module can read. Its bodies are generated
-# (cumulative, one bullet per carried PR); --published-repo can point an install
-# at upstream or a mirror, whose per-release notes are a different document. On
-# ggml-org/llama.cpp, b10721 -> b10734 reported 5 "changes" -- commit-message
-# lines and an attestation URL -- and dropped 324 bullets from the 9 releases in
-# between, because a per-release body says nothing about what is still carried.
+# The only repo whose notes this module can read: generated, cumulative, one
+# bullet per carried PR. --published-repo can point elsewhere, and a per-release
+# body says nothing about what is still carried.
 CUMULATIVE_NOTES_REPO = "unslothai/llama.cpp"
-# 4 MiB. A release body is a few KB; the cap only stops an unbounded read if the
-# far side ever stops behaving like the GitHub API.
+# A release body is a few KB; the cap only bounds a far side that misbehaves.
 MAX_RELEASE_BYTES = 4 * 1024 * 1024
-# A forced retry bypasses the memos, so without a floor a user holding down the
-# banner's Retry button issues two uncached GitHub calls per click.
+# Without a floor, a held-down Retry is two uncached GitHub calls per click.
 FORCE_REFRESH_MIN_INTERVAL_SECONDS = 30.0
 _REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
-# "." and ".." are valid under _REPO because "." is in the class above, and
-# "owner/.." would walk out of /repos/ on any normalizing proxy.
+# "." is in _REPO's class, so "owner/.." walks out of /repos/ on a normalizing proxy.
 _DOT_SEGMENT = re.compile(r"^\.+$")
 _BULLET = re.compile(r"^ {0,3}[-*+]\s+(.+?)\s*$")
 _LINK = re.compile(r"\[([^\]]+)]\((https://github\.com/[^\s)]+)\)")
@@ -66,8 +60,7 @@ def _valid_repo(repo: str) -> bool:
 
 def _is_cumulative_repo(repo: str) -> bool:
     """Case-folded: GitHub owner/name is case-insensitive and --published-repo
-    persists whatever spelling was typed, so ``UnslothAI/llama.cpp`` is the same
-    official repository and must not be labelled a custom one."""
+    persists whatever spelling was typed."""
     return repo.casefold() == CUMULATIVE_NOTES_REPO.casefold()
 
 
@@ -107,8 +100,7 @@ def _fetch_release_blocking(repo: str, tag: str, timeout: float) -> Optional[dic
     )
     try:
         with urllib.request.urlopen(request, timeout = timeout) as response:
-            # Bounded: read one byte past the cap so an oversized body is rejected
-            # rather than buffered in full.
+            # One byte past the cap: reject an oversized body without buffering it.
             raw = response.read(MAX_RELEASE_BYTES + 1)
         if len(raw) > MAX_RELEASE_BYTES:
             logger.debug("llama changelog release too large", repo = repo, tag = tag)
@@ -118,8 +110,7 @@ def _fetch_release_blocking(repo: str, tag: str, timeout: float) -> Optional[dic
         urllib.error.URLError,
         urllib.error.HTTPError,
         OSError,
-        # IncompleteRead on a truncated response is an HTTPException, NOT an
-        # OSError, so without this a mid-read cut escapes to any direct caller.
+        # A truncated read raises HTTPException, which is not an OSError.
         http.client.HTTPException,
         UnicodeDecodeError,
         json.JSONDecodeError,
@@ -141,7 +132,6 @@ def _release_for_tag(
     # to extend the TTL. freshness_flow uses wall time because it persists to disk.
     now = time.monotonic()
     if force_refresh:
-        # Honour the bypass, but not faster than once per key per interval.
         forced_at = _release_forced_at.get(key)
         if forced_at is not None and now - forced_at < FORCE_REFRESH_MIN_INTERVAL_SECONDS:
             force_refresh = False
@@ -152,17 +142,15 @@ def _release_for_tag(
         cached = _release_memo.get(key)
         fresh = cached is not None and now - cached[0] < RELEASE_CACHE_TTL_SECONDS
         if failed_at is not None and now - failed_at < RELEASE_FAILURE_CACHE_TTL_SECONDS:
-            # Suppress the retry, but an entry past its TTL is still expired: do
-            # not let a recent failure resurrect a stale body as if it were fresh.
+            # Suppress the retry, but never resurrect an entry past its TTL.
             return cached[1] if fresh else None
         if fresh:
             return cached[1]
     release = _fetch_release(repo, tag)
     if release is None:
         _release_failed_at[key] = time.monotonic()
-        # Fall back to the last good body only while it is still within its TTL.
-        # An exact release that has become unreachable must not keep answering
-        # from an expired entry, or the panel presents a stale comparison as matched.
+        # Last-good fallback only within the TTL, or an unreachable release keeps
+        # answering stale and the panel presents that as matched.
         cached = _release_memo.get(key)
         if cached and time.monotonic() - cached[0] < RELEASE_CACHE_TTL_SECONDS:
             return cached[1]
@@ -181,9 +169,8 @@ def _plain_text(markdown: str) -> str:
 
 def _entry(markdown: str) -> dict:
     # Metadata starts at " ([", so a title keeps its parens: GLM-5-Next (GLM-5.3-Flash).
-    # rfind, not find: the generator always appends metadata as the final
-    # parenthesised group, and a PR title may itself contain " ([" -- with find,
-    # "vulkan: handle ([a],[b]) tuples ([#5](...))" renders as "vulkan: handle".
+    # rfind, not find: metadata is the LAST parenthesised group, and a title may
+    # contain " ([" -- "vulkan: handle ([a],[b]) tuples ([#5](...))".
     metadata_at = markdown.rfind(" ([")
     summary_markdown = markdown[:metadata_at] if metadata_at >= 0 else markdown
     links = []
@@ -199,10 +186,8 @@ def _identities(markdown: str) -> set[str]:
     """Stable aliases for one carried change: a patch migrated to an Unsloth carry
     PR links that PR but still says ``ggml-org#24423``, and both must match."""
     identities = set()
-    # One namespace for all three notations. GitHub issues and pull requests share
-    # a repository's number space, so ``/issues/900``, ``/pull/900`` and the textual
-    # ``repo#900`` always denote the same object; giving them separate prefixes can
-    # only produce false negatives, never avoid a false positive.
+    # One namespace: GitHub numbers issues and PRs together, so ``/issues/900``,
+    # ``/pull/900`` and ``repo#900`` are the same object. Separate prefixes only miss.
     for _label, url in _LINK.findall(markdown):
         match = _PR_URL.match(url) or _ISSUE_URL.match(url)
         if match:
@@ -234,26 +219,20 @@ def release_page_url(repo: str, tag: str) -> Optional[str]:
 def unavailable_reason(repo: str, installed_tag: str, latest_tag: str) -> str:
     """Why a comparison could not be made, for a caller holding ``None``.
 
-    ``notes_not_itemised`` and ``notes_not_comparable`` are permanent -- the
-    release predates the bullet format, or the install tracks a repository whose
-    notes are not cumulative -- while ``release_notes_unavailable`` is a fetch
-    that may succeed later. The banner uses this to decide whether offering Retry
-    is honest.
+    ``notes_not_itemised`` (predates the bullet format) and
+    ``notes_not_comparable`` (non-cumulative repo) are permanent;
+    ``release_notes_unavailable`` may succeed later, so it keeps its Retry.
     """
     if not _valid_repo(repo) or not installed_tag or not latest_tag:
         return "release_notes_unavailable"
     if not _is_cumulative_repo(repo):
         return "notes_not_comparable"
-    # Both lookups are memoized, so this re-read costs nothing on the path that
-    # has just performed them.
+    # Memoized, so this re-read costs nothing after the comparison's own lookups.
     installed = _release_for_tag(repo, installed_tag)
     if installed is None:
         return "release_notes_unavailable"
-    # Only the INSTALLED side can be permanently uncomparable: it is a release
-    # that shipped before the bullet format and will never gain one. A target
-    # without a usable body is the newest release, so it is a publishing gap that
-    # may be filled in -- calling that permanent would withhold a Retry that
-    # could actually succeed.
+    # Only the INSTALLED side is permanent: it shipped before the bullet format and
+    # will never gain one. A bad target is the newest release, so it may yet be fixed.
     if not _bullets(installed.get("body")):
         return "notes_not_itemised"
     return "release_notes_unavailable"
@@ -284,10 +263,8 @@ def changelog_for_update(
     installed_bullets = _bullets(installed.get("body"))
     if not installed_bullets:
         return None
-    # A prose-only target legitimately means "this build carries nothing", since
-    # the target is always the newest release. A MISSING or blank body is not the
-    # same statement: it carries no information at all, and answering "no new
-    # changes" would claim a comparison that never happened.
+    # A prose-only target says "carries nothing"; a missing or blank one says
+    # nothing at all, and "no new changes" would claim a comparison never made.
     latest_body = latest.get("body")
     if not isinstance(latest_body, str) or not latest_body.strip():
         return None
@@ -301,8 +278,7 @@ def changelog_for_update(
             continue
         parsed = _entry(item)
         if not parsed["summary"]:
-            # Claim nothing on behalf of a bullet that is never shown; updating
-            # `seen` here would let it suppress a later bullet for the same PR.
+            # A bullet that is never shown must not suppress a later one via `seen`.
             continue
         seen.update(identities)
         new_items.append(parsed)

--- a/studio/backend/utils/llama_cpp_changelog.py
+++ b/studio/backend/utils/llama_cpp_changelog.py
@@ -195,7 +195,13 @@ def changelog_for_update(
     if installed is None or latest is None:
         return None
 
-    old_identities = set().union(*(_identities(item) for item in _bullets(installed.get("body"))))
+    # Releases before b9625-mix-2d6bd50 (2026-06-14) name their carried PRs in
+    # prose, so the bullet list is empty even for a build that carries them.
+    # Comparing against nothing would relabel every one of them as new.
+    installed_bullets = _bullets(installed.get("body"))
+    if not installed_bullets:
+        return None
+    old_identities = set().union(*(_identities(item) for item in installed_bullets))
     new_items = []
     seen = set()
     for item in _bullets(latest.get("body")):

--- a/studio/backend/utils/llama_cpp_changelog.py
+++ b/studio/backend/utils/llama_cpp_changelog.py
@@ -3,10 +3,8 @@
 
 """New carried changes between two published llama.cpp prebuilts.
 
-Unsloth's llama.cpp release body is cumulative: every build repeats the PRs
-that are still carried on top of upstream. The update banner must therefore
-compare the installed and target release bodies instead of displaying the
-target body verbatim, or an old carried PR looks new after every update.
+The release body is cumulative, so the banner must diff the installed and target
+bodies; showing the target body alone relabels old carried PRs as new.
 """
 
 from __future__ import annotations
@@ -46,7 +44,7 @@ def _fetch_release(
     tag: str,
     timeout: float = 5.0,
 ) -> Optional[dict]:
-    """Fetch one exact GitHub release. None on invalid input or any failure."""
+    """One exact GitHub release. None on invalid input or any failure."""
     if not _REPO.fullmatch(repo) or not tag:
         return None
     from utils.utils import call_with_deadline
@@ -122,15 +120,13 @@ def _release_for_tag(
 
 def _plain_text(markdown: str) -> str:
     text = _LINK.sub(lambda match: match.group(1), markdown)
-    # Release titles regularly contain C/C++ identifiers. Underscores in
-    # ROCm_Host or GGML_CUDA_ENABLE_UNIFIED_MEMORY are text, not emphasis.
+    # Underscores in ROCm_Host / GGML_CUDA_ENABLE_UNIFIED_MEMORY are text, not emphasis.
     text = text.replace("`", "").replace("**", "")
     return re.sub(r"\s+", " ", text).strip()
 
 
 def _entry(markdown: str) -> dict:
-    # Generated release bullets put link metadata after `` ([...``. Preserve
-    # parentheses in the title itself, such as ``GLM-5-Next (GLM-5.3-Flash)``.
+    # Metadata starts at " ([", so a title keeps its parens: GLM-5-Next (GLM-5.3-Flash).
     metadata_at = markdown.find(" ([")
     summary_markdown = markdown[:metadata_at] if metadata_at >= 0 else markdown
     links = []
@@ -143,12 +139,8 @@ def _entry(markdown: str) -> dict:
 
 
 def _identities(markdown: str) -> set[str]:
-    """Stable aliases for one carried change.
-
-    A patch can move from its original upstream PR to an Unsloth carry PR. The
-    newer bullet then links the carry PR but still says ``ggml-org#24423``.
-    Keeping both aliases stops that already-installed patch from becoming new.
-    """
+    """Stable aliases for one carried change: a patch migrated to an Unsloth carry
+    PR links that PR but still says ``ggml-org#24423``, and both must match."""
     identities = set()
     for _label, url in _LINK.findall(markdown):
         match = _PR_URL.match(url)
@@ -159,8 +151,7 @@ def _identities(markdown: str) -> set[str]:
         if match:
             identities.add(f"issue:{match.group(1).lower()}#{match.group(2)}")
     for repo, number in _TEXT_REFERENCE.findall(_plain_text(markdown)):
-        # Release shorthand omits the repository because every item is about
-        # llama.cpp: ``ggml-org#24423`` means ``ggml-org/llama.cpp#24423``.
+        # Shorthand omits the repo: ``ggml-org#24423`` is ``ggml-org/llama.cpp#24423``.
         if "/" not in repo:
             repo = f"{repo}/llama.cpp"
         identities.add(f"pr:{repo.lower()}#{number}")
@@ -184,9 +175,7 @@ def changelog_for_update(
 ) -> Optional[dict]:
     """Return only target bullets absent from the installed release.
 
-    None means the comparison could not be made. Callers must not display the
-    target body alone in that case, because it is cumulative and includes old
-    entries.
+    None means no comparison was possible; do not fall back to the cumulative body.
     """
     if not repo or not installed_tag or not latest_tag or installed_tag == latest_tag:
         return None
@@ -195,9 +184,8 @@ def changelog_for_update(
     if installed is None or latest is None:
         return None
 
-    # Releases before b9625-mix-2d6bd50 (2026-06-14) name their carried PRs in
-    # prose, so the bullet list is empty even for a build that carries them.
-    # Comparing against nothing would relabel every one of them as new.
+    # Releases before b9625-mix-2d6bd50 (2026-06-14) name carries in prose, so no
+    # bullets means unknown, not "carries nothing".
     installed_bullets = _bullets(installed.get("body"))
     if not installed_bullets:
         return None

--- a/studio/backend/utils/llama_cpp_changelog.py
+++ b/studio/backend/utils/llama_cpp_changelog.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""New carried changes between two published llama.cpp prebuilts.
+
+Unsloth's llama.cpp release body is cumulative: every build repeats the PRs
+that are still carried on top of upstream. The update banner must therefore
+compare the installed and target release bodies instead of displaying the
+target body verbatim, or an old carried PR looks new after every update.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+import structlog
+
+from utils.prebuilt.freshness_flow import (
+    RELEASE_CACHE_TTL_SECONDS,
+    RELEASE_FAILURE_CACHE_TTL_SECONDS,
+)
+
+logger = structlog.get_logger(__name__)
+
+MAX_CHANGES = 50
+_REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_BULLET = re.compile(r"^ {0,3}[-*+]\s+(.+?)\s*$")
+_LINK = re.compile(r"\[([^\]]+)]\((https://github\.com/[^\s)]+)\)")
+_PR_URL = re.compile(r"^https://github\.com/([^/]+/[^/]+)/pull/(\d+)(?:/|$)", re.I)
+_ISSUE_URL = re.compile(r"^https://github\.com/([^/]+/[^/]+)/issues/(\d+)(?:/|$)", re.I)
+_TEXT_REFERENCE = re.compile(
+    r"(?<![\w./-])([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?)#(\d+)\b"
+)
+
+_release_memo: dict[tuple[str, str], tuple[float, dict]] = {}
+_release_failed_at: dict[tuple[str, str], float] = {}
+
+
+def _fetch_release(repo: str, tag: str, timeout: float = 5.0) -> Optional[dict]:
+    """Fetch one exact GitHub release. None on invalid input or any failure."""
+    if not _REPO.fullmatch(repo) or not tag:
+        return None
+    from utils.utils import call_with_deadline
+
+    try:
+        return call_with_deadline(
+            lambda: _fetch_release_blocking(repo, tag, timeout),
+            timeout + 1,
+            name = "llama-changelog-fetch",
+        )
+    except TimeoutError as exc:
+        logger.debug("llama changelog fetch failed", repo = repo, tag = tag, error = str(exc))
+        return None
+
+
+def _fetch_release_blocking(repo: str, tag: str, timeout: float) -> Optional[dict]:
+    encoded_tag = urllib.parse.quote(tag, safe = "")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "unsloth-studio-llama-changelog",
+    }
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/releases/tags/{encoded_tag}",
+        headers = headers,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout = timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (
+        urllib.error.URLError,
+        urllib.error.HTTPError,
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ) as exc:
+        logger.debug("llama changelog fetch failed", repo = repo, tag = tag, error = str(exc))
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _release_for_tag(repo: str, tag: str, *, force_refresh: bool = False) -> Optional[dict]:
+    """Exact release with 24h success and 60s failure memoization."""
+    key = (repo, tag)
+    now = time.time()
+    if not force_refresh:
+        failed_at = _release_failed_at.get(key)
+        if (
+            failed_at is not None
+            and time.monotonic() - failed_at < RELEASE_FAILURE_CACHE_TTL_SECONDS
+        ):
+            cached = _release_memo.get(key)
+            return cached[1] if cached else None
+        cached = _release_memo.get(key)
+        if cached and now - cached[0] < RELEASE_CACHE_TTL_SECONDS:
+            return cached[1]
+    release = _fetch_release(repo, tag)
+    if release is None:
+        _release_failed_at[key] = time.monotonic()
+        cached = _release_memo.get(key)
+        return cached[1] if cached else None
+    _release_failed_at.pop(key, None)
+    _release_memo[key] = (now, release)
+    return release
+
+
+def _plain_text(markdown: str) -> str:
+    text = _LINK.sub(lambda match: match.group(1), markdown)
+    # Release titles regularly contain C/C++ identifiers. Underscores in
+    # ROCm_Host or GGML_CUDA_ENABLE_UNIFIED_MEMORY are text, not emphasis.
+    text = text.replace("`", "").replace("**", "")
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _entry(markdown: str) -> dict:
+    # Generated release bullets put link metadata after `` ([...``. Preserve
+    # parentheses in the title itself, such as ``GLM-5-Next (GLM-5.3-Flash)``.
+    metadata_at = markdown.find(" ([")
+    summary_markdown = markdown[:metadata_at] if metadata_at >= 0 else markdown
+    links = []
+    for label, url in _LINK.findall(markdown[metadata_at:] if metadata_at >= 0 else ""):
+        clean_label = _plain_text(label)
+        if "/commits/" in url and not clean_label.lower().startswith("commit"):
+            clean_label = f"commit {clean_label}"
+        links.append({"label": clean_label, "url": url})
+    return {"summary": _plain_text(summary_markdown), "links": links}
+
+
+def _identities(markdown: str) -> set[str]:
+    """Stable aliases for one carried change.
+
+    A patch can move from its original upstream PR to an Unsloth carry PR. The
+    newer bullet then links the carry PR but still says ``ggml-org#24423``.
+    Keeping both aliases stops that already-installed patch from becoming new.
+    """
+    identities = set()
+    for _label, url in _LINK.findall(markdown):
+        match = _PR_URL.match(url)
+        if match:
+            identities.add(f"pr:{match.group(1).lower()}#{match.group(2)}")
+    for _label, url in _LINK.findall(markdown):
+        match = _ISSUE_URL.match(url)
+        if match:
+            identities.add(f"issue:{match.group(1).lower()}#{match.group(2)}")
+    for repo, number in _TEXT_REFERENCE.findall(_plain_text(markdown)):
+        # Release shorthand omits the repository because every item is about
+        # llama.cpp: ``ggml-org#24423`` means ``ggml-org/llama.cpp#24423``.
+        if "/" not in repo:
+            repo = f"{repo}/llama.cpp"
+        identities.add(f"pr:{repo.lower()}#{number}")
+    if not identities:
+        identities.add(f"text:{_entry(markdown)['summary'].casefold()}")
+    return identities
+
+
+def _bullets(body: object) -> list[str]:
+    if not isinstance(body, str):
+        return []
+    return [match.group(1) for line in body.splitlines() if (match := _BULLET.match(line))]
+
+
+def changelog_for_update(
+    repo: str,
+    installed_tag: str,
+    latest_tag: str,
+    *,
+    force_refresh: bool = False,
+) -> Optional[dict]:
+    """Return only target bullets absent from the installed release.
+
+    None means the comparison could not be made. Callers must not display the
+    target body alone in that case, because it is cumulative and includes old
+    entries.
+    """
+    if not repo or not installed_tag or not latest_tag or installed_tag == latest_tag:
+        return None
+    installed = _release_for_tag(repo, installed_tag, force_refresh = force_refresh)
+    latest = _release_for_tag(repo, latest_tag, force_refresh = force_refresh)
+    if installed is None or latest is None:
+        return None
+
+    old_identities = set().union(
+        *(_identities(item) for item in _bullets(installed.get("body")))
+    )
+    new_items = []
+    seen = set()
+    for item in _bullets(latest.get("body")):
+        identities = _identities(item)
+        if identities & old_identities or identities & seen:
+            continue
+        seen.update(identities)
+        parsed = _entry(item)
+        if parsed["summary"]:
+            new_items.append(parsed)
+
+    total = len(new_items)
+    release_url = latest.get("html_url")
+    if not isinstance(release_url, str) or not release_url.startswith("https://github.com/"):
+        encoded_tag = urllib.parse.quote(latest_tag, safe = "")
+        release_url = f"https://github.com/{repo}/releases/tag/{encoded_tag}"
+    return {
+        "changes": new_items[:MAX_CHANGES],
+        "total_changes": total,
+        "truncated": total > MAX_CHANGES,
+        "release_url": release_url,
+    }

--- a/studio/backend/utils/llama_cpp_changelog.py
+++ b/studio/backend/utils/llama_cpp_changelog.py
@@ -35,15 +35,17 @@ _BULLET = re.compile(r"^ {0,3}[-*+]\s+(.+?)\s*$")
 _LINK = re.compile(r"\[([^\]]+)]\((https://github\.com/[^\s)]+)\)")
 _PR_URL = re.compile(r"^https://github\.com/([^/]+/[^/]+)/pull/(\d+)(?:/|$)", re.I)
 _ISSUE_URL = re.compile(r"^https://github\.com/([^/]+/[^/]+)/issues/(\d+)(?:/|$)", re.I)
-_TEXT_REFERENCE = re.compile(
-    r"(?<![\w./-])([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?)#(\d+)\b"
-)
+_TEXT_REFERENCE = re.compile(r"(?<![\w./-])([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?)#(\d+)\b")
 
 _release_memo: dict[tuple[str, str], tuple[float, dict]] = {}
 _release_failed_at: dict[tuple[str, str], float] = {}
 
 
-def _fetch_release(repo: str, tag: str, timeout: float = 5.0) -> Optional[dict]:
+def _fetch_release(
+    repo: str,
+    tag: str,
+    timeout: float = 5.0,
+) -> Optional[dict]:
     """Fetch one exact GitHub release. None on invalid input or any failure."""
     if not _REPO.fullmatch(repo) or not tag:
         return None
@@ -88,7 +90,12 @@ def _fetch_release_blocking(repo: str, tag: str, timeout: float) -> Optional[dic
     return payload if isinstance(payload, dict) else None
 
 
-def _release_for_tag(repo: str, tag: str, *, force_refresh: bool = False) -> Optional[dict]:
+def _release_for_tag(
+    repo: str,
+    tag: str,
+    *,
+    force_refresh: bool = False,
+) -> Optional[dict]:
     """Exact release with 24h success and 60s failure memoization."""
     key = (repo, tag)
     now = time.time()
@@ -188,9 +195,7 @@ def changelog_for_update(
     if installed is None or latest is None:
         return None
 
-    old_identities = set().union(
-        *(_identities(item) for item in _bullets(installed.get("body")))
-    )
+    old_identities = set().union(*(_identities(item) for item in _bullets(installed.get("body"))))
     new_items = []
     seen = set()
     for item in _bullets(latest.get("body")):

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -415,17 +415,14 @@ def get_update_changelog(
     empty["latest_tag"] = latest
     if not freshness.get("behind") or not installed_full or not latest:
         return empty
-    # Answer about the pair the caller is displaying, not whatever the shared
-    # latest-release memo now holds. Any other Studio surface's forced status
-    # check advances that memo process-wide, and the frontend rejects a response
-    # whose tags differ from the ones it asked about -- leaving an error whose
-    # Retry rereads the same memo and fails the same way, until that surface's
-    # own hourly recheck. Only honoured while the install itself still matches.
+    # Answer about the caller's pair, not whatever the shared latest-release memo
+    # now holds: any other surface's forced status check advances it process-wide,
+    # and the frontend rejects a mismatched answer, Retry included. Only while the
+    # install still matches.
     if latest_tag and installed_tag and installed_tag == empty["installed_tag"]:
         latest = latest_tag
         empty["latest_tag"] = latest
-    # Offer the release page even when the comparison fails. Most installs predate
-    # the itemised body, and the notes are readable on GitHub in every one of them.
+    # Offer the release page even when the comparison fails; GitHub can still show it.
     empty["release_url"] = release_page_url(repo, latest)
     try:
         result = changelog_for_update(

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -49,7 +49,11 @@ from utils.llama_cpp_freshness import (
     reset_caches,
     update_download_size_bytes,
 )
-from utils.llama_cpp_changelog import changelog_for_update
+from utils.llama_cpp_changelog import (
+    changelog_for_update,
+    release_page_url,
+    unavailable_reason,
+)
 from utils.prebuilt import update_flow as _flow
 from utils.prebuilt.llama_backend import (
     REQUESTABLE_BACKENDS,
@@ -405,6 +409,9 @@ def get_update_changelog(*, force_refresh: bool = False) -> dict:
     empty["latest_tag"] = latest
     if not freshness.get("behind") or not installed_full or not latest:
         return empty
+    # Offer the release page even when the comparison fails. Most installs predate
+    # the itemised body, and the notes are readable on GitHub in every one of them.
+    empty["release_url"] = release_page_url(repo, latest)
     try:
         result = changelog_for_update(
             repo,
@@ -416,7 +423,11 @@ def get_update_changelog(*, force_refresh: bool = False) -> dict:
         logger.debug("llama changelog comparison failed", error = str(exc))
         result = None
     if result is None:
-        empty["error"] = "release_notes_unavailable"
+        try:
+            empty["error"] = unavailable_reason(repo, installed_full, latest)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("llama changelog reason lookup failed", error = str(exc))
+            empty["error"] = "release_notes_unavailable"
         return empty
     return {**empty, **result, "matched": True}
 

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -377,11 +377,17 @@ def get_update_status(*, force_refresh: bool = False) -> dict:
     return _merge_whisper_status(status, force_refresh = force_refresh)
 
 
-def get_update_changelog(*, force_refresh: bool = False) -> dict:
+def get_update_changelog(
+    *,
+    force_refresh: bool = False,
+    installed_tag: Optional[str] = None,
+    latest_tag: Optional[str] = None,
+) -> dict:
     """Only carried changes added after the installed llama.cpp release.
 
     Separate from the polled status endpoint so opening the banner, not every
-    3s poll, pays for the two exact release lookups.
+    3s poll, pays for the two exact release lookups. installed_tag/latest_tag
+    name the pair the caller is displaying; see the target selection below.
     """
     empty = {
         "matched": False,
@@ -409,6 +415,15 @@ def get_update_changelog(*, force_refresh: bool = False) -> dict:
     empty["latest_tag"] = latest
     if not freshness.get("behind") or not installed_full or not latest:
         return empty
+    # Answer about the pair the caller is displaying, not whatever the shared
+    # latest-release memo now holds. Any other Studio surface's forced status
+    # check advances that memo process-wide, and the frontend rejects a response
+    # whose tags differ from the ones it asked about -- leaving an error whose
+    # Retry rereads the same memo and fails the same way, until that surface's
+    # own hourly recheck. Only honoured while the install itself still matches.
+    if latest_tag and installed_tag and installed_tag == empty["installed_tag"]:
+        latest = latest_tag
+        empty["latest_tag"] = latest
     # Offer the release page even when the comparison fails. Most installs predate
     # the itemised body, and the notes are readable on GitHub in every one of them.
     empty["release_url"] = release_page_url(repo, latest)

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -376,9 +376,8 @@ def get_update_status(*, force_refresh: bool = False) -> dict:
 def get_update_changelog(*, force_refresh: bool = False) -> dict:
     """Only carried changes added after the installed llama.cpp release.
 
-    This is separate from the polled status endpoint so opening the banner is
-    what pays for the two exact release lookups. Failure stays explicit and
-    empty: returning the latest cumulative body would relabel old PRs as new.
+    Separate from the polled status endpoint so opening the banner, not every
+    3s poll, pays for the two exact release lookups.
     """
     empty = {
         "matched": False,
@@ -398,10 +397,8 @@ def get_update_changelog(*, force_refresh: bool = False) -> dict:
         return empty
     repo = marker.get("published_repo") or DEFAULT_PUBLISHED_REPO
     installed_full = marker.get("release_tag") or marker.get("tag")
-    # force_refresh reaches only the two exact release lookups below. Refreshing
-    # the latest-release pointer would retarget the comparison at a release the
-    # banner has not adopted yet (its status check is hourly), and the frontend
-    # rejects any response whose tags differ from the ones it asked about.
+    # force_refresh reaches only the exact release lookups. Refreshing the latest
+    # pointer would retarget a release the banner has not adopted, which it rejects.
     freshness = check_prebuilt_freshness(binary)
     latest = freshness.get("latest_tag")
     empty["installed_tag"] = freshness.get("installed_tag")

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -49,6 +49,7 @@ from utils.llama_cpp_freshness import (
     reset_caches,
     update_download_size_bytes,
 )
+from utils.llama_cpp_changelog import changelog_for_update
 from utils.prebuilt import update_flow as _flow
 from utils.prebuilt.llama_backend import (
     REQUESTABLE_BACKENDS,
@@ -370,6 +371,58 @@ def get_update_status(*, force_refresh: bool = False) -> dict:
     """
     status = _llama_only_status(force_refresh = force_refresh)
     return _merge_whisper_status(status, force_refresh = force_refresh)
+
+
+def get_update_changelog(*, force_refresh: bool = False) -> dict:
+    """Only carried changes added after the installed llama.cpp release.
+
+    This is separate from the polled status endpoint so opening the banner is
+    what pays for the two exact release lookups. Failure stays explicit and
+    empty: returning the latest cumulative body would relabel old PRs as new.
+    """
+    empty = {
+        "matched": False,
+        "installed_tag": None,
+        "latest_tag": None,
+        "changes": [],
+        "total_changes": 0,
+        "truncated": False,
+        "release_url": None,
+        "error": None,
+    }
+    binary = _find_binary()
+    if _studio_custom_path_active() or _active_install_is_local_link(binary):
+        return empty
+    marker = read_install_marker(binary)
+    if not marker:
+        return empty
+    repo = marker.get("published_repo") or DEFAULT_PUBLISHED_REPO
+    installed_full = marker.get("release_tag") or marker.get("tag")
+    if force_refresh and repo:
+        try:
+            latest_published_release(repo, force_refresh = True)
+        except Exception as exc:  # pragma: no cover - network defensive
+            logger.debug("llama changelog refresh failed", error = str(exc))
+    freshness = check_prebuilt_freshness(binary)
+    latest = freshness.get("latest_tag")
+    empty["installed_tag"] = freshness.get("installed_tag")
+    empty["latest_tag"] = latest
+    if not freshness.get("behind") or not installed_full or not latest:
+        return empty
+    try:
+        result = changelog_for_update(
+            repo,
+            installed_full,
+            latest,
+            force_refresh = force_refresh,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("llama changelog comparison failed", error = str(exc))
+        result = None
+    if result is None:
+        empty["error"] = "release_notes_unavailable"
+        return empty
+    return {**empty, **result, "matched": True}
 
 
 def _llama_only_status(

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -398,11 +398,10 @@ def get_update_changelog(*, force_refresh: bool = False) -> dict:
         return empty
     repo = marker.get("published_repo") or DEFAULT_PUBLISHED_REPO
     installed_full = marker.get("release_tag") or marker.get("tag")
-    if force_refresh and repo:
-        try:
-            latest_published_release(repo, force_refresh = True)
-        except Exception as exc:  # pragma: no cover - network defensive
-            logger.debug("llama changelog refresh failed", error = str(exc))
+    # force_refresh reaches only the two exact release lookups below. Refreshing
+    # the latest-release pointer would retarget the comparison at a release the
+    # banner has not adopted yet (its status check is hourly), and the frontend
+    # rejects any response whose tags differ from the ones it asked about.
     freshness = check_prebuilt_freshness(binary)
     latest = freshness.get("latest_tag")
     empty["installed_tag"] = freshness.get("installed_tag")

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -201,7 +201,14 @@ export function LlamaUpdateBanner({
           </div>
         </div>
 
-        {!applying && changelogOpen && installedTag && latestTag ? (
+        {/* changelogAvailable, not just changelogOpen: if the install turns into
+            a source build while the panel is open, the toggle unmounts and the
+            panel would otherwise be left on screen with no way to close it. */}
+        {!applying &&
+        changelogAvailable &&
+        changelogOpen &&
+        installedTag &&
+        latestTag ? (
           <LlamaUpdateChangelogPanel
             installedTag={installedTag}
             latestTag={latestTag}

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -145,8 +145,7 @@ export function LlamaUpdateBanner({
       className={cn(
         positioned
           ? "fixed bottom-4 right-4 z-[9998] w-[calc(100vw-2rem)] max-w-[448px]"
-          : // Match the desktop updater's floor. In a capped stack, only the
-            // notes region gives up height while the header and actions remain.
+          : // The desktop updater's floor: in a capped stack only the notes give up height.
             "pointer-events-auto flex min-h-[calc(117px+93px*var(--ui-font-scale,1))] w-[calc(100vw-2rem)] max-w-[448px] flex-col max-[383px]:min-h-[calc(24px+224px*var(--ui-font-scale,1))]",
       )}
       data-testid="llama-update-banner"

--- a/studio/frontend/src/components/llama-update-banner.tsx
+++ b/studio/frontend/src/components/llama-update-banner.tsx
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { Button } from "@/components/ui/button";
+import { LlamaUpdateChangelogPanel } from "@/components/update/llama-update-changelog-panel";
 import { resyncInferenceStatusAfterServerModelChange } from "@/features/chat";
 import { useLlamaUpdateCheck } from "@/hooks/use-llama-update-check";
 import { useShowLlamaUpdateBanner } from "@/hooks/use-llama-update-pref";
@@ -82,6 +83,7 @@ export function LlamaUpdateBanner({
   positioned = true,
 }: LlamaUpdateBannerProps): ReactElement | null {
   const showBannerPref = useShowLlamaUpdateBanner();
+  const [changelogVersion, setChangelogVersion] = useState<string | null>(null);
   // Not gated on showBannerPref: this hook instance is the app-wide listener
   // for a cross-tab reload_required resync (the settings-sheet's own instance
   // only runs during an MTP-fallback rebuild), so muting the banner must not
@@ -115,6 +117,15 @@ export function LlamaUpdateBanner({
     (status.update_available || applying);
   const sizeBytes = status?.update_size_bytes ?? null;
   const component = status?.component ?? "llama.cpp";
+  const latestTag = status?.latest_tag ?? null;
+  const installedTag = status?.installed_tag ?? null;
+  const changelogKey =
+    component === "llama.cpp" && installedTag && latestTag
+      ? `${installedTag}\0${latestTag}`
+      : null;
+  const changelogAvailable = Boolean(changelogKey && !status?.source_build);
+  const changelogOpen =
+    changelogKey !== null && changelogVersion === changelogKey;
   const sizeLabel =
     sizeBytes && sizeBytes > 0
       ? `${Math.round(sizeBytes / (1024 * 1024))} MB`
@@ -133,14 +144,14 @@ export function LlamaUpdateBanner({
     <div
       className={cn(
         positioned
-          ? "fixed bottom-4 right-4 z-[9998] w-[calc(100vw-2rem)] max-w-[400px]"
-          : // shrink-0: nothing in this card can give up height, so a capped
-            // stack squeezing it only prints its text over its own buttons.
-            "pointer-events-auto w-[calc(100vw-2rem)] max-w-[400px] shrink-0",
+          ? "fixed bottom-4 right-4 z-[9998] w-[calc(100vw-2rem)] max-w-[448px]"
+          : // Match the desktop updater's floor. In a capped stack, only the
+            // notes region gives up height while the header and actions remain.
+            "pointer-events-auto flex min-h-[calc(117px+93px*var(--ui-font-scale,1))] w-[calc(100vw-2rem)] max-w-[448px] flex-col max-[383px]:min-h-[calc(24px+224px*var(--ui-font-scale,1))]",
       )}
       data-testid="llama-update-banner"
     >
-      <div className="relative overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
+      <div className="relative flex max-h-[calc(100dvh_-_2rem)] min-h-0 flex-col overflow-hidden rounded-[24px] bg-white px-5 pb-4 pt-5 shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:bg-card dark:shadow-[0_8px_28px_-6px_rgba(0,0,0,0.28)]">
         {applying ? null : (
           <button
             type="button"
@@ -166,7 +177,7 @@ export function LlamaUpdateBanner({
           </button>
         )}
 
-        <div className="flex min-w-0 items-start gap-4 pr-6">
+        <div className="flex min-w-0 shrink-0 items-start gap-4 pr-6">
           <Download
             aria-hidden="true"
             className="mt-1 size-5 shrink-0 text-foreground"
@@ -191,7 +202,15 @@ export function LlamaUpdateBanner({
           </div>
         </div>
 
+        {!applying && changelogOpen && installedTag && latestTag ? (
+          <LlamaUpdateChangelogPanel
+            installedTag={installedTag}
+            latestTag={latestTag}
+          />
+        ) : null}
+
         {applying ? (
+          // biome-ignore lint/a11y/useFocusableInteractive: a read-only progress indicator must not add a keyboard stop
           <div
             className="mb-1.5 mt-4 h-1 overflow-hidden rounded-full bg-muted"
             role="progressbar"
@@ -211,25 +230,46 @@ export function LlamaUpdateBanner({
             />
           </div>
         ) : (
-          <div className="mt-2 flex flex-wrap items-center justify-end gap-x-1 gap-y-2">
-            <Button
-              size="sm"
-              variant="ghost"
-              className="h-auto rounded-full px-3 py-2 text-ui-13 font-medium text-foreground"
-              onClick={snooze}
-              data-testid="llama-update-snooze-button"
-            >
-              Remind me later
-            </Button>
-            <Button
-              size="sm"
-              // Align pill edge with card padding.
-              className="-mr-1 h-auto rounded-full px-3.5 py-2 text-ui-13"
-              onClick={handleUpdate}
-              data-testid="llama-update-button"
-            >
-              Update
-            </Button>
+          <div
+            className={cn(
+              "mt-4 flex shrink-0 flex-wrap items-center gap-x-1 gap-y-2",
+              changelogAvailable ? "justify-between" : "justify-end",
+            )}
+          >
+            {changelogAvailable ? (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="-ml-2 h-auto whitespace-nowrap rounded-full px-2.5 py-2 text-ui-13 font-medium text-foreground"
+                onClick={() =>
+                  setChangelogVersion(changelogOpen ? null : changelogKey)
+                }
+                aria-expanded={changelogOpen}
+                data-testid="llama-update-changelog-toggle"
+              >
+                {changelogOpen ? "Hide what's new" : "Show what's new"}
+              </Button>
+            ) : null}
+            <div className="flex flex-wrap items-center justify-end gap-x-1 gap-y-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-auto whitespace-nowrap rounded-full px-2.5 py-2 text-ui-13 font-medium text-foreground"
+                onClick={snooze}
+                data-testid="llama-update-snooze-button"
+              >
+                Remind me later
+              </Button>
+              <Button
+                size="sm"
+                // Align pill edge with card padding.
+                className="-mr-1 h-auto whitespace-nowrap rounded-full px-3 py-2 text-ui-13"
+                onClick={handleUpdate}
+                data-testid="llama-update-button"
+              >
+                Update
+              </Button>
+            </div>
           </div>
         )}
       </div>

--- a/studio/frontend/src/components/tauri/update-banner.tsx
+++ b/studio/frontend/src/components/tauri/update-banner.tsx
@@ -304,7 +304,6 @@ export function UpdateBanner({
               <ReleaseNotesPanel
                 version={notesTargetVersion}
                 open={notesOpen}
-                className="min-h-0 flex-1"
                 releaseNotesUrl={releasePageUrl ?? manualReleaseUrl}
               />
             ) : null}

--- a/studio/frontend/src/components/update/llama-update-changelog-panel.tsx
+++ b/studio/frontend/src/components/update/llama-update-changelog-panel.tsx
@@ -12,10 +12,20 @@ import {
   UPDATE_NOTES_SURFACE_CLASS,
 } from "@/components/update/update-notes-layout";
 import { useLlamaUpdateChangelog } from "@/hooks/use-llama-update-changelog";
-import type { ReactElement, ReactNode } from "react";
+import { openLink } from "@/lib/open-link";
+import type { MouseEvent, ReactElement, ReactNode } from "react";
 
 const LINK_CLASS =
   "font-medium text-foreground underline decoration-foreground/30 underline-offset-2 hover:decoration-foreground/70";
+
+// A bare target="_blank" has nowhere to go in the Tauri webview, which creates no
+// window of its own. openLink() hands the URL to the system browser there and
+// falls back to window.open on the web, matching MarkdownPreview.
+function handleExternalClick(event: MouseEvent<HTMLAnchorElement>): void {
+  if (openLink(event.currentTarget.href)) {
+    event.preventDefault();
+  }
+}
 
 function Message({
   children,
@@ -50,6 +60,7 @@ export function LlamaUpdateChangelogPanel({
       href={changelog.releaseUrl}
       target="_blank"
       rel="noopener noreferrer"
+      onClick={handleExternalClick}
       className={UPDATE_NOTES_LINK_CLASS}
       data-testid="llama-update-release-link"
     >
@@ -66,6 +77,13 @@ export function LlamaUpdateChangelogPanel({
       <div className={UPDATE_NOTES_SURFACE_CLASS}>
         {state === "loading" || state === "idle" ? (
           <Message>Loading new changes...</Message>
+        ) : state === "unavailable" ? (
+          // Definitive, so no Retry: this build predates the itemised release
+          // notes and re-asking GitHub cannot change the answer.
+          <Message>
+            This build predates itemised release notes, so its changes cannot be
+            compared.
+          </Message>
         ) : state === "error" ? (
           <Message
             action={
@@ -105,12 +123,15 @@ export function LlamaUpdateChangelogPanel({
                     <span>
                       {" ("}
                       {change.links.map((link, linkIndex) => (
-                        <span key={link.url}>
+                        // A bullet can cite the same URL twice under different
+                        // labels, so the URL alone is not a unique key.
+                        <span key={`${linkIndex}-${link.url}`}>
                           {linkIndex > 0 ? ", " : ""}
                           <a
                             href={link.url}
                             target="_blank"
                             rel="noopener noreferrer"
+                            onClick={handleExternalClick}
                             className={LINK_CLASS}
                           >
                             {link.label}
@@ -134,7 +155,10 @@ export function LlamaUpdateChangelogPanel({
           <Message>No new carried changes are listed for this build.</Message>
         )}
       </div>
-      {state === "ready" && releaseLink ? (
+      {/* Also shown when the comparison failed: the release page is usually
+          readable even when the two bodies could not be diffed, and it is the
+          only way left to see what changed. */}
+      {state !== "loading" && state !== "idle" && releaseLink ? (
         <div className={UPDATE_NOTES_FOOTER_CLASS}>{releaseLink}</div>
       ) : null}
     </div>

--- a/studio/frontend/src/components/update/llama-update-changelog-panel.tsx
+++ b/studio/frontend/src/components/update/llama-update-changelog-panel.tsx
@@ -18,9 +18,8 @@ import type { MouseEvent, ReactElement, ReactNode } from "react";
 const LINK_CLASS =
   "font-medium text-foreground underline decoration-foreground/30 underline-offset-2 hover:decoration-foreground/70";
 
-// A bare target="_blank" has nowhere to go in the Tauri webview, which creates no
-// window of its own. openLink() hands the URL to the system browser there and
-// falls back to window.open on the web, matching MarkdownPreview.
+// target="_blank" has nowhere to go in the Tauri webview; openLink() hands the URL
+// to the system browser and falls back to window.open, matching MarkdownPreview.
 function handleExternalClick(event: MouseEvent<HTMLAnchorElement>): void {
   if (openLink(event.currentTarget.href)) {
     event.preventDefault();
@@ -123,8 +122,7 @@ export function LlamaUpdateChangelogPanel({
                     <span>
                       {" ("}
                       {change.links.map((link, linkIndex) => (
-                        // A bullet can cite the same URL twice under different
-                        // labels, so the URL alone is not a unique key.
+                        // A bullet can cite one URL twice under different labels.
                         <span key={`${linkIndex}-${link.url}`}>
                           {linkIndex > 0 ? ", " : ""}
                           <a

--- a/studio/frontend/src/components/update/llama-update-changelog-panel.tsx
+++ b/studio/frontend/src/components/update/llama-update-changelog-panel.tsx
@@ -78,11 +78,11 @@ export function LlamaUpdateChangelogPanel({
         {state === "loading" || state === "idle" ? (
           <Message>Loading new changes...</Message>
         ) : state === "unavailable" ? (
-          // Definitive, so no Retry: this build predates the itemised release
-          // notes and re-asking GitHub cannot change the answer.
+          // Definitive, so no Retry: re-asking GitHub cannot change the answer.
           <Message>
-            This build predates itemised release notes, so its changes cannot be
-            compared.
+            {changelog?.error === "notes_not_comparable"
+              ? "This install tracks a custom llama.cpp repository, so its changes cannot be compared."
+              : "This build predates itemised release notes, so its changes cannot be compared."}
           </Message>
         ) : state === "error" ? (
           <Message

--- a/studio/frontend/src/components/update/llama-update-changelog-panel.tsx
+++ b/studio/frontend/src/components/update/llama-update-changelog-panel.tsx
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  UPDATE_NOTES_BULLET_CLASS,
+  UPDATE_NOTES_EXPANDED_SCROLL_CLASS,
+  UPDATE_NOTES_FOOTER_CLASS,
+  UPDATE_NOTES_ITEM_CLASS,
+  UPDATE_NOTES_LEAD_CLASS,
+  UPDATE_NOTES_LINK_CLASS,
+  UPDATE_NOTES_ROOT_CLASS,
+  UPDATE_NOTES_SURFACE_CLASS,
+} from "@/components/update/update-notes-layout";
+import { useLlamaUpdateChangelog } from "@/hooks/use-llama-update-changelog";
+import type { ReactElement, ReactNode } from "react";
+
+const LINK_CLASS =
+  "font-medium text-foreground underline decoration-foreground/30 underline-offset-2 hover:decoration-foreground/70";
+
+function Message({
+  children,
+  action,
+}: {
+  children: ReactNode;
+  action?: ReactNode;
+}): ReactElement {
+  return (
+    <div className="flex items-center justify-between gap-2 px-1 py-2">
+      <p className="text-ui-11 text-muted-foreground">{children}</p>
+      {action}
+    </div>
+  );
+}
+
+export function LlamaUpdateChangelogPanel({
+  installedTag,
+  latestTag,
+}: {
+  installedTag: string;
+  latestTag: string;
+}): ReactElement {
+  const { state, changelog, retry } = useLlamaUpdateChangelog({
+    enabled: true,
+    installedTag,
+    latestTag,
+  });
+
+  const releaseLink = changelog?.releaseUrl ? (
+    <a
+      href={changelog.releaseUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={UPDATE_NOTES_LINK_CLASS}
+      data-testid="llama-update-release-link"
+    >
+      Open release
+    </a>
+  ) : null;
+
+  return (
+    <div
+      className={UPDATE_NOTES_ROOT_CLASS}
+      data-testid="llama-update-changelog-panel"
+      data-changelog-state={state}
+    >
+      <div className={UPDATE_NOTES_SURFACE_CLASS}>
+        {state === "loading" || state === "idle" ? (
+          <Message>Loading new changes...</Message>
+        ) : state === "error" ? (
+          <Message
+            action={
+              <button
+                type="button"
+                onClick={retry}
+                className={`shrink-0 text-ui-11 ${LINK_CLASS}`}
+                data-testid="llama-update-changelog-retry"
+              >
+                Retry
+              </button>
+            }
+          >
+            Could not compare these releases.
+          </Message>
+        ) : changelog && changelog.changes.length > 0 ? (
+          <ul
+            // biome-ignore lint/a11y/noNoninteractiveTabindex: keyboard-scrollable region
+            tabIndex={0}
+            aria-label={`New llama.cpp changes from ${installedTag} to ${latestTag}`}
+            className={`${UPDATE_NOTES_EXPANDED_SCROLL_CLASS} space-y-1`}
+            data-testid="llama-update-changelog-list"
+          >
+            {changelog.changes.map((change, index) => (
+              <li
+                key={`${index}-${change.summary}`}
+                className={UPDATE_NOTES_ITEM_CLASS}
+              >
+                <span aria-hidden="true" className={UPDATE_NOTES_BULLET_CLASS}>
+                  &bull;
+                </span>
+                <span className="min-w-0">
+                  <span className={UPDATE_NOTES_LEAD_CLASS}>
+                    {change.summary}
+                  </span>
+                  {change.links.length > 0 ? (
+                    <span>
+                      {" ("}
+                      {change.links.map((link, linkIndex) => (
+                        <span key={link.url}>
+                          {linkIndex > 0 ? ", " : ""}
+                          <a
+                            href={link.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={LINK_CLASS}
+                          >
+                            {link.label}
+                          </a>
+                        </span>
+                      ))}
+                      {")"}
+                    </span>
+                  ) : null}
+                </span>
+              </li>
+            ))}
+            {changelog.truncated ? (
+              <li className="pl-3 text-ui-10 text-muted-foreground/70">
+                Showing {changelog.changes.length} of {changelog.totalChanges}{" "}
+                changes
+              </li>
+            ) : null}
+          </ul>
+        ) : (
+          <Message>No new carried changes are listed for this build.</Message>
+        )}
+      </div>
+      {state === "ready" && releaseLink ? (
+        <div className={UPDATE_NOTES_FOOTER_CLASS}>{releaseLink}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/studio/frontend/src/components/update/release-notes-panel.tsx
+++ b/studio/frontend/src/components/update/release-notes-panel.tsx
@@ -2,10 +2,19 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { MarkdownPreview } from "@/components/markdown/markdown-preview";
+import {
+  UPDATE_NOTES_BULLET_CLASS,
+  UPDATE_NOTES_EXPANDED_SCROLL_CLASS,
+  UPDATE_NOTES_FOOTER_CLASS,
+  UPDATE_NOTES_ITEM_CLASS,
+  UPDATE_NOTES_LEAD_CLASS,
+  UPDATE_NOTES_LINK_CLASS,
+  UPDATE_NOTES_ROOT_CLASS,
+  UPDATE_NOTES_SURFACE_CLASS,
+} from "@/components/update/update-notes-layout";
 import { useReleaseNotes } from "@/hooks/use-release-notes";
 import { resolveReleaseBodyLinks } from "@/lib/release-body-links";
 import { releaseNotesPreview } from "@/lib/release-notes-preview";
-import { cn } from "@/lib/utils";
 import {
   type ReactElement,
   type ReactNode,
@@ -20,11 +29,7 @@ interface ReleaseNotesPanelProps {
   // Collapsed previews the top bullets; expanded scrolls the full notes.
   open: boolean;
   releaseNotesUrl?: string | null;
-  className?: string;
 }
-
-const NOTES_LINK_CLASS =
-  "shrink-0 whitespace-nowrap text-ui-11 font-medium text-foreground underline underline-offset-2";
 
 function NotesMessage({
   children,
@@ -53,7 +58,7 @@ function NotesLink({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className={NOTES_LINK_CLASS}
+      className={UPDATE_NOTES_LINK_CLASS}
       data-testid="update-release-notes-link"
     >
       {isRelease ? "Open release" : "Open changelog"}
@@ -65,7 +70,6 @@ export function ReleaseNotesPanel({
   version,
   open,
   releaseNotesUrl = null,
-  className,
 }: ReleaseNotesPanelProps): ReactElement | null {
   // Fetched with the popup: the collapsed preview needs the notes too.
   const { state, notes, retry } = useReleaseNotes({ version, enabled: true });
@@ -114,7 +118,7 @@ export function ReleaseNotesPanel({
     <div
       // Clipped, not just capped: this is the one part of the card allowed to
       // give up height, so its content must not paint over the buttons below.
-      className={cn("mt-3 flex min-h-0 flex-col overflow-hidden", className)}
+      className={UPDATE_NOTES_ROOT_CLASS}
       data-testid="update-release-notes-panel"
       data-notes-state={state}
       data-notes-version={version}
@@ -122,7 +126,7 @@ export function ReleaseNotesPanel({
       data-notes-open={open}
     >
       {/* borderless fill, lighter than the card in dark mode */}
-      <div className="flex min-h-0 flex-col rounded-[14px] bg-muted/40 px-3 py-1 dark:bg-white/[0.06]">
+      <div className={UPDATE_NOTES_SURFACE_CLASS}>
         {markdown ? (
           open ? (
             <section
@@ -131,7 +135,7 @@ export function ReleaseNotesPanel({
               tabIndex={0}
               aria-label={`Release notes for ${notes?.tag ?? `version ${version}`}`}
               // Long notes scroll here instead of pushing the buttons off screen.
-              className="hover-scrollbar max-h-64 min-h-0 flex-1 overflow-y-auto overscroll-contain py-3 pr-1"
+              className={UPDATE_NOTES_EXPANDED_SCROLL_CLASS}
               data-testid="update-release-notes-scroll"
             >
               <MarkdownPreview
@@ -159,7 +163,7 @@ export function ReleaseNotesPanel({
         )}
       </div>
       {open && markdown && link ? (
-        <div className="mt-2 flex justify-end px-1">{link}</div>
+        <div className={UPDATE_NOTES_FOOTER_CLASS}>{link}</div>
       ) : null}
     </div>
   );
@@ -191,14 +195,14 @@ function ReleaseNotesSummary({
         <li
           // Two releases can carry the same bullet text, so index is the key.
           key={`${index}-${item.lead}`}
-          className="flex gap-1.5 text-ui-11 leading-snug text-muted-foreground"
+          className={UPDATE_NOTES_ITEM_CLASS}
         >
-          <span aria-hidden="true" className="text-muted-foreground/60">
+          <span aria-hidden="true" className={UPDATE_NOTES_BULLET_CLASS}>
             &bull;
           </span>
           <span className="line-clamp-2 min-w-0">
             {/* lead sentence carries the change */}
-            <span className="font-medium text-foreground">{item.lead}</span>
+            <span className={UPDATE_NOTES_LEAD_CLASS}>{item.lead}</span>
             {item.rest ? <span> {item.rest}</span> : null}
           </span>
         </li>
@@ -237,7 +241,7 @@ function NotesStatus({
             <button
               type="button"
               onClick={retry}
-              className={NOTES_LINK_CLASS}
+              className={UPDATE_NOTES_LINK_CLASS}
               data-testid="update-release-notes-retry"
             >
               Retry

--- a/studio/frontend/src/components/update/update-notes-layout.ts
+++ b/studio/frontend/src/components/update/update-notes-layout.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export const UPDATE_NOTES_ROOT_CLASS =
+  "mt-3 flex min-h-0 flex-1 flex-col overflow-hidden";
+
+export const UPDATE_NOTES_SURFACE_CLASS =
+  "flex min-h-0 flex-col rounded-[14px] bg-muted/40 px-3 py-1 dark:bg-white/[0.06]";
+
+export const UPDATE_NOTES_EXPANDED_SCROLL_CLASS =
+  "hover-scrollbar max-h-64 min-h-0 flex-1 overflow-y-auto overscroll-contain py-3 pr-1";
+
+export const UPDATE_NOTES_ITEM_CLASS =
+  "flex gap-1.5 text-ui-11 leading-snug text-muted-foreground";
+
+export const UPDATE_NOTES_BULLET_CLASS = "text-muted-foreground/60";
+export const UPDATE_NOTES_LEAD_CLASS = "font-medium text-foreground";
+
+export const UPDATE_NOTES_FOOTER_CLASS = "mt-2 flex justify-end px-1";
+
+export const UPDATE_NOTES_LINK_CLASS =
+  "shrink-0 whitespace-nowrap text-ui-11 font-medium text-foreground underline underline-offset-2";

--- a/studio/frontend/src/components/web/update-banner.tsx
+++ b/studio/frontend/src/components/web/update-banner.tsx
@@ -157,7 +157,6 @@ export function WebUpdateBanner({
               version={status.latestVersion}
               open={notesOpen}
               releaseNotesUrl={RELEASE_NOTES_URL}
-              className="min-h-0 flex-1"
             />
 
             {/* one row at one type size; wraps only on narrow viewports, and

--- a/studio/frontend/src/hooks/use-llama-update-changelog.ts
+++ b/studio/frontend/src/hooks/use-llama-update-changelog.ts
@@ -119,8 +119,17 @@ export function useLlamaUpdateChangelog({
       const requestId = requestIdRef.current;
       setState("loading");
       setChangelog(null);
-      const query = refresh ? "?force_refresh=true" : "";
-      authFetch(`/api/llama/update-changelog${query}`)
+      // Name the pair being displayed. Another Studio surface's forced status
+      // check advances the backend's shared latest-release memo, and without
+      // this the answer would be about a target this banner has not adopted --
+      // which the check below then rejects, for up to an hour.
+      const query = new URLSearchParams();
+      query.set("installed_tag", installedTag);
+      query.set("latest_tag", latestTag);
+      if (refresh) {
+        query.set("force_refresh", "true");
+      }
+      authFetch(`/api/llama/update-changelog?${query}`)
         .then(async (response) => {
           if (!response.ok) {
             throw new Error(`Changelog request failed: ${response.status}`);

--- a/studio/frontend/src/hooks/use-llama-update-changelog.ts
+++ b/studio/frontend/src/hooks/use-llama-update-changelog.ts
@@ -25,7 +25,18 @@ interface LlamaUpdateChangelog {
   error: string | null;
 }
 
-export type LlamaUpdateChangelogState = "idle" | "loading" | "ready" | "error";
+// "unavailable" is a definitive answer, not a failure to get one: this pair of
+// releases cannot be compared and never will be, so the panel must not offer a
+// Retry that re-runs two GitHub lookups to reach the same conclusion.
+export type LlamaUpdateChangelogState =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "unavailable"
+  | "error";
+
+// The backend reports this when a release predates the itemised body format.
+const PERMANENT_ERRORS = new Set(["notes_not_itemised"]);
 
 function githubUrl(value: unknown): string | null {
   return typeof value === "string" && value.startsWith("https://github.com/")
@@ -121,7 +132,13 @@ export function useLlamaUpdateChangelog({
             return;
           }
           setChangelog(parsed);
-          setState(parsed.matched ? "ready" : "error");
+          setState(
+            parsed.matched
+              ? "ready"
+              : parsed.error && PERMANENT_ERRORS.has(parsed.error)
+                ? "unavailable"
+                : "error",
+          );
         })
         .catch(() => {
           if (requestIdRef.current !== requestId) {

--- a/studio/frontend/src/hooks/use-llama-update-changelog.ts
+++ b/studio/frontend/src/hooks/use-llama-update-changelog.ts
@@ -35,8 +35,13 @@ export type LlamaUpdateChangelogState =
   | "unavailable"
   | "error";
 
-// The backend reports this when a release predates the itemised body format.
-const PERMANENT_ERRORS = new Set(["notes_not_itemised"]);
+// notes_not_itemised: the installed release predates the itemised body format.
+// notes_not_comparable: --published-repo points the install at a repository whose
+// notes are per-release rather than cumulative, so there is nothing to diff.
+const PERMANENT_ERRORS = new Set([
+  "notes_not_itemised",
+  "notes_not_comparable",
+]);
 
 function githubUrl(value: unknown): string | null {
   return typeof value === "string" && value.startsWith("https://github.com/")

--- a/studio/frontend/src/hooks/use-llama-update-changelog.ts
+++ b/studio/frontend/src/hooks/use-llama-update-changelog.ts
@@ -25,9 +25,8 @@ interface LlamaUpdateChangelog {
   error: string | null;
 }
 
-// "unavailable" is a definitive answer, not a failure to get one: this pair of
-// releases cannot be compared and never will be, so the panel must not offer a
-// Retry that re-runs two GitHub lookups to reach the same conclusion.
+// "unavailable" is a definitive answer, not a failure to get one: this pair can
+// never be compared, so a Retry would spend two lookups on the same conclusion.
 export type LlamaUpdateChangelogState =
   | "idle"
   | "loading"
@@ -35,9 +34,7 @@ export type LlamaUpdateChangelogState =
   | "unavailable"
   | "error";
 
-// notes_not_itemised: the installed release predates the itemised body format.
-// notes_not_comparable: --published-repo points the install at a repository whose
-// notes are per-release rather than cumulative, so there is nothing to diff.
+// Predates the itemised body format; tracks a repo with per-release notes.
 const PERMANENT_ERRORS = new Set([
   "notes_not_itemised",
   "notes_not_comparable",
@@ -119,10 +116,9 @@ export function useLlamaUpdateChangelog({
       const requestId = requestIdRef.current;
       setState("loading");
       setChangelog(null);
-      // Name the pair being displayed. Another Studio surface's forced status
-      // check advances the backend's shared latest-release memo, and without
-      // this the answer would be about a target this banner has not adopted --
-      // which the check below then rejects, for up to an hour.
+      // Name the pair being displayed: another surface's forced status check
+      // advances the backend's shared memo, and the check below rejects the
+      // answer that would come back about a target this banner has not adopted.
       const query = new URLSearchParams();
       query.set("installed_tag", installedTag);
       query.set("latest_tag", latestTag);

--- a/studio/frontend/src/hooks/use-llama-update-changelog.ts
+++ b/studio/frontend/src/hooks/use-llama-update-changelog.ts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface LlamaUpdateChangeLink {
+  label: string;
+  url: string;
+}
+
+export interface LlamaUpdateChange {
+  summary: string;
+  links: LlamaUpdateChangeLink[];
+}
+
+interface LlamaUpdateChangelog {
+  matched: boolean;
+  installedTag: string | null;
+  latestTag: string | null;
+  changes: LlamaUpdateChange[];
+  totalChanges: number;
+  truncated: boolean;
+  releaseUrl: string | null;
+  error: string | null;
+}
+
+export type LlamaUpdateChangelogState = "idle" | "loading" | "ready" | "error";
+
+function githubUrl(value: unknown): string | null {
+  return typeof value === "string" && value.startsWith("https://github.com/")
+    ? value
+    : null;
+}
+
+function parseChangelog(value: unknown): LlamaUpdateChangelog | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const payload = value as Record<string, unknown>;
+  const rawChanges = Array.isArray(payload.changes) ? payload.changes : [];
+  const changes = rawChanges.flatMap((raw): LlamaUpdateChange[] => {
+    if (!raw || typeof raw !== "object") {
+      return [];
+    }
+    const item = raw as Record<string, unknown>;
+    if (typeof item.summary !== "string" || item.summary.length === 0) {
+      return [];
+    }
+    const rawLinks = Array.isArray(item.links) ? item.links : [];
+    const links = rawLinks.flatMap((rawLink): LlamaUpdateChangeLink[] => {
+      if (!rawLink || typeof rawLink !== "object") {
+        return [];
+      }
+      const link = rawLink as Record<string, unknown>;
+      const url = githubUrl(link.url);
+      return typeof link.label === "string" && link.label && url
+        ? [{ label: link.label, url }]
+        : [];
+    });
+    return [{ summary: item.summary, links }];
+  });
+  return {
+    matched: payload.matched === true,
+    installedTag:
+      typeof payload.installed_tag === "string" ? payload.installed_tag : null,
+    latestTag:
+      typeof payload.latest_tag === "string" ? payload.latest_tag : null,
+    changes,
+    totalChanges:
+      typeof payload.total_changes === "number"
+        ? Math.max(0, payload.total_changes)
+        : changes.length,
+    truncated: payload.truncated === true,
+    releaseUrl: githubUrl(payload.release_url),
+    error: typeof payload.error === "string" ? payload.error : null,
+  };
+}
+
+export function useLlamaUpdateChangelog({
+  enabled,
+  installedTag,
+  latestTag,
+}: {
+  enabled: boolean;
+  installedTag: string | null | undefined;
+  latestTag: string | null | undefined;
+}) {
+  const [state, setState] = useState<LlamaUpdateChangelogState>("idle");
+  const [changelog, setChangelog] = useState<LlamaUpdateChangelog | null>(null);
+  const requestKeyRef = useRef<string | null>(null);
+  const requestIdRef = useRef(0);
+  const key =
+    installedTag && latestTag ? `${installedTag}\0${latestTag}` : null;
+
+  const load = useCallback(
+    (refresh = false) => {
+      if (!(key && installedTag && latestTag)) {
+        return;
+      }
+      requestKeyRef.current = key;
+      requestIdRef.current += 1;
+      const requestId = requestIdRef.current;
+      setState("loading");
+      setChangelog(null);
+      const query = refresh ? "?force_refresh=true" : "";
+      authFetch(`/api/llama/update-changelog${query}`)
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`Changelog request failed: ${response.status}`);
+          }
+          const parsed = parseChangelog(await response.json());
+          if (
+            !parsed ||
+            parsed.installedTag !== installedTag ||
+            parsed.latestTag !== latestTag
+          ) {
+            throw new Error("Changelog response no longer matches this update");
+          }
+          if (requestIdRef.current !== requestId) {
+            return;
+          }
+          setChangelog(parsed);
+          setState(parsed.matched ? "ready" : "error");
+        })
+        .catch(() => {
+          if (requestIdRef.current !== requestId) {
+            return;
+          }
+          setChangelog(null);
+          setState("error");
+        });
+    },
+    [installedTag, key, latestTag],
+  );
+
+  useEffect(() => {
+    if (!(enabled && key) || requestKeyRef.current === key) {
+      return;
+    }
+    load();
+  }, [enabled, key, load]);
+
+  const retry = useCallback(() => {
+    requestKeyRef.current = null;
+    load(true);
+  }, [load]);
+
+  return { state, changelog, retry };
+}

--- a/studio/frontend/src/hooks/use-llama-update-check.ts
+++ b/studio/frontend/src/hooks/use-llama-update-check.ts
@@ -42,6 +42,7 @@ export interface LlamaUpdateJob {
 export interface LlamaUpdateStatus {
   supported: boolean;
   update_available: boolean;
+  source_build: boolean;
   component: "llama.cpp" | "whisper.cpp";
   installed_tag: string | null;
   latest_tag: string | null;
@@ -94,6 +95,7 @@ function parseStatus(value: unknown): LlamaUpdateStatus | null {
   return {
     supported: s.supported === true,
     update_available: s.update_available === true,
+    source_build: s.source_build === true,
     component,
     installed_tag:
       typeof details.installed_tag === "string" ? details.installed_tag : null,

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -23,6 +23,10 @@ function read(path: string): string {
 const TAURI = read("components/tauri/update-banner.tsx");
 const WEB = read("components/web/update-banner.tsx");
 const LLAMA = read("components/llama-update-banner.tsx");
+const LLAMA_CHANGELOG = read(
+  "components/update/llama-update-changelog-panel.tsx",
+);
+const NOTES_LAYOUT = read("components/update/update-notes-layout.ts");
 const NOTES = read("components/update/release-notes-panel.tsx");
 const PROVIDER = read("app/provider.tsx");
 const STORE = read("features/settings/stores/monitor-frame-store.ts");
@@ -144,18 +148,56 @@ test("the two update cards do not drift apart", () => {
   }
 });
 
+test("the llama.cpp card shares the desktop updater's responsive floor", () => {
+  const llamaRoot = classes(LLAMA, "pointer-events-auto flex ");
+  for (const floor of [
+    "min-h-[calc(117px+93px*var(--ui-font-scale,1))]",
+    "max-[383px]:min-h-[calc(24px+224px*var(--ui-font-scale,1))]",
+  ]) {
+    assert.ok(llamaRoot.includes(floor) && TAURI.includes(floor));
+  }
+  assert.doesNotMatch(llamaRoot, /\bshrink-0\b/);
+  assert.ok(LLAMA.includes("max-w-[448px]"));
+});
 
-test("the llama.cpp card keeps its full height in the rail", () => {
-  // Nothing inside it can give up height, so squeezing it only mangles it.
-  assert.match(
-    classes(LLAMA, "pointer-events-auto w-[calc(100vw-2rem)]"),
-    /\bshrink-0\b/,
-  );
+test("the llama.cpp changelog uses the desktop update notes layout", () => {
+  for (const sharedClass of [
+    "UPDATE_NOTES_ROOT_CLASS",
+    "UPDATE_NOTES_SURFACE_CLASS",
+    "UPDATE_NOTES_EXPANDED_SCROLL_CLASS",
+    "UPDATE_NOTES_ITEM_CLASS",
+    "UPDATE_NOTES_BULLET_CLASS",
+    "UPDATE_NOTES_LEAD_CLASS",
+    "UPDATE_NOTES_FOOTER_CLASS",
+    "UPDATE_NOTES_LINK_CLASS",
+  ]) {
+    assert.ok(
+      NOTES.includes(sharedClass) && LLAMA_CHANGELOG.includes(sharedClass),
+      `${sharedClass} is not shared by both update panels`,
+    );
+  }
+  assert.match(NOTES_LAYOUT, /\bmax-h-64\b/);
+  assert.match(NOTES_LAYOUT, /\boverflow-y-auto\b/);
+  assert.match(NOTES_LAYOUT, /\boverscroll-contain\b/);
+});
+
+test("the llama.cpp header and actions do not compress around its changelog", () => {
+  assert.match(classes(LLAMA, "flex min-w-0 "), /\bshrink-0\b/);
+  const footer = classes(LLAMA, "mt-4 flex shrink-0");
+  assert.match(footer, /\bflex-wrap\b/);
+  assert.match(footer, /\bshrink-0\b/);
+});
+
+test("the llama.cpp progress indicator is not a dead keyboard stop", () => {
+  const progress = LLAMA.indexOf('role="progressbar"');
+  assert.notEqual(progress, -1, "the progress indicator is missing");
+  const openingTag = LLAMA.slice(progress, LLAMA.indexOf(">", progress));
+  assert.doesNotMatch(openingTag, /\btabIndex=/);
 });
 
 test("the notes panel clips whatever height it gives up", () => {
   assert.match(
-    classes(NOTES, "mt-3 flex min-h-0 flex-col"),
+    classes(NOTES_LAYOUT, "mt-3 flex min-h-0 flex-1 flex-col"),
     /\boverflow-hidden\b/,
     "the panel shrinks but its content still paints past the panel",
   );
@@ -163,7 +205,7 @@ test("the notes panel clips whatever height it gives up", () => {
   // height: a scroll container there collapses the expanded notes to nothing,
   // because their scroller is a flex-basis-0 child of it.
   assert.ok(
-    !/overflow-hidden[^"]*rounded-\[14px\]/.test(NOTES),
+    !/overflow-hidden[^"]*rounded-\[14px\]/.test(NOTES_LAYOUT),
     "the inner surface clips, which empties the expanded notes",
   );
 });
@@ -174,7 +216,7 @@ test("the collapsed notes summary scrolls, like the expanded notes", () => {
   const summary = classes(NOTES, "hover-scrollbar min-h-0 flex-1 space-y-1");
   assert.match(summary, /\boverflow-y-auto\b/);
   assert.match(summary, /\boverscroll-contain\b/);
-  const expanded = classes(NOTES, "hover-scrollbar max-h-64");
+  const expanded = classes(NOTES_LAYOUT, "hover-scrollbar max-h-64");
   assert.match(expanded, /\boverflow-y-auto\b/);
   assert.match(expanded, /\boverscroll-contain\b/);
 });
@@ -194,7 +236,11 @@ test("the rail scrolls rather than spilling its cards", () => {
     // A cap without a scroller drops the overflow below the bottom of the
     // screen: at a large type size the two banner floors exceed the cap on
     // their own, and the cards under it cannot be reached.
-    assert.match(rules, /\boverflow-y-auto\b/, "a capped rail spills its cards");
+    assert.match(
+      rules,
+      /\boverflow-y-auto\b/,
+      "a capped rail spills its cards",
+    );
     // The scroller clips at the padding box, so without room reserved there the
     // cards lose their shadows; the negative margin puts the rail back where it
     // was.
@@ -240,7 +286,10 @@ test("the rail's block gutter costs the cards no room", () => {
   // A z-index on the toolbar would read as protection and give none: it sits inside a
   // positioned, numbered header, which is a stacking context.
   const toolbar = TITLEBAR.slice(
-    TITLEBAR.lastIndexOf("<div", TITLEBAR.indexOf('aria-label="Window controls"')),
+    TITLEBAR.lastIndexOf(
+      "<div",
+      TITLEBAR.indexOf('aria-label="Window controls"'),
+    ),
     TITLEBAR.indexOf('aria-label="Window controls"'),
   );
   assert.doesNotMatch(

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -115,6 +115,7 @@ LLAMA_STATUS = {
     "installed_tag": "b10333",
     "latest_tag": "b10333-mix-e34b418",
     "update_size_bytes": 28 * 1024 * 1024,
+    "source_build": False,
     "component": "llama.cpp",
     "whisper": {
         "update_available": False,
@@ -133,6 +134,40 @@ LLAMA_STATUS = {
         "progress": None,
         "finished_at": None,
     },
+}
+LLAMA_CHANGELOG = {
+    "matched": True,
+    "installed_tag": "b10333",
+    "latest_tag": "b10333-mix-e34b418",
+    "changes": [
+        {
+            "summary": "model: add GLM-5-Next (GLM-5.3-Flash)",
+            "links": [
+                {
+                    "label": "#27754",
+                    "url": "https://github.com/ggml-org/llama.cpp/pull/27754",
+                },
+                {
+                    "label": "commit 949f7ef",
+                    "url": "https://github.com/ggml-org/llama.cpp/pull/27754/commits/949f7ef",
+                },
+            ],
+        },
+        {
+            "summary": "llama: batched readahead for lazily read gather tables",
+            "links": [
+                {
+                    "label": "unslothai/llama.cpp#137",
+                    "url": "https://github.com/unslothai/llama.cpp/pull/137",
+                }
+            ],
+        },
+        {"summary": "MTP for Qwen3.8-Flash-Next", "links": []},
+    ],
+    "total_changes": 3,
+    "truncated": False,
+    "release_url": "https://github.com/unslothai/llama.cpp/releases/tag/b10333-mix-e34b418",
+    "error": None,
 }
 # The same card, renamed: whisper.cpp is not a second banner.
 WHISPER_STATUS = dict(
@@ -717,12 +752,90 @@ def boot(page, path: str) -> None:
         raise AssertionError(f"not authenticated: landed on {landed}")
 
 
+LLAMA_CHANGELOG_GEOMETRY = """
+() => {
+  const q = (selector) => document.querySelector(selector);
+  const rect = (element) => {
+    if (!element) return null;
+    const box = element.getBoundingClientRect();
+    return {top: box.top, bottom: box.bottom, left: box.left, right: box.right,
+            width: box.width, height: box.height};
+  };
+  const banner = q('[data-testid="llama-update-banner"]');
+  const surface = banner ? banner.firstElementChild : null;
+  const list = q('[data-testid="llama-update-changelog-list"]');
+  const toggle = q('[data-testid="llama-update-changelog-toggle"]');
+  const update = q('[data-testid="llama-update-button"]');
+  const footer = update ? update.closest('div').parentElement : null;
+  return {
+    surface: rect(surface), list: rect(list), toggle: rect(toggle),
+    update: rect(update), footer: rect(footer),
+    listScrolls: list ? list.scrollHeight > list.clientHeight : null,
+  };
+}
+"""
+
+
+def exercise_llama_changelog(page, label: str) -> None:
+    toggle = page.locator('[data-testid="llama-update-changelog-toggle"]')
+    check(
+        f"{label}: the llama.cpp changelog starts collapsed",
+        toggle.count() == 1 and toggle.get_attribute("aria-expanded") == "false",
+    )
+    if toggle.count() != 1:
+        return
+    with page.expect_response("**/api/llama/update-changelog*", timeout = 10_000):
+        toggle.click()
+    listing = page.locator('[data-testid="llama-update-changelog-list"]')
+    listing.wait_for(state = "visible", timeout = 10_000)
+    text = listing.inner_text()
+    check(
+        f"{label}: expansion shows only the new carried changes",
+        "GLM-5-Next" in text
+        and "MTP for Qwen3.8-Flash-Next" in text
+        and "Add TML Inkling" not in text,
+        f"list={text!r}",
+    )
+    check(
+        f"{label}: expansion exposes its state to assistive technology",
+        toggle.get_attribute("aria-expanded") == "true",
+    )
+    pull = listing.locator('a[href="https://github.com/ggml-org/llama.cpp/pull/27754"]')
+    check(
+        f"{label}: change references are safe external links",
+        pull.count() == 1
+        and pull.get_attribute("target") == "_blank"
+        and pull.get_attribute("rel") == "noopener noreferrer",
+    )
+    geometry = page.evaluate(LLAMA_CHANGELOG_GEOMETRY)
+    surface, body, footer = geometry["surface"], geometry["list"], geometry["footer"]
+    check(
+        f"{label}: the changelog stays inside its card and above its actions",
+        surface is not None
+        and body is not None
+        and footer is not None
+        and body["left"] >= surface["left"] - 1
+        and body["right"] <= surface["right"] + 1
+        and body["bottom"] <= footer["top"] + 1,
+        f"geometry={geometry}",
+    )
+    page.screenshot(path = str(ART / f"{label.replace(' ', '-')}-llama-expanded.png"))
+    toggle.click()
+    check(
+        f"{label}: the changelog collapses without dismissing the update",
+        toggle.get_attribute("aria-expanded") == "false"
+        and page.locator('[data-testid="llama-update-banner"]').count() == 1,
+    )
+
+
 def main() -> int:
     wait_for_health(BASE, timeout = 60.0, info = info)
     # OLD is already NEW on a rerun, or when an earlier suite in the same job
     # rotated it, and that login fails before the rotation below can be skipped.
     try:
-        token = api("/api/auth/login", {"username": "unsloth", "password": OLD})["access_token"]
+        token = api("/api/auth/login", {"username": "unsloth", "password": OLD})[
+            "access_token"
+        ]
     except urllib.error.HTTPError as exc:
         if exc.code not in (400, 401, 403):
             raise
@@ -812,6 +925,7 @@ def main() -> int:
                     body = json.dumps(llama_payload[0]),
                 ),
             )
+            context.route("**/api/llama/update-changelog*", stub(LLAMA_CHANGELOG))
             page = context.new_page()
             for name, path in ROUTES[:1] if SPOT else ROUTES:
                 size = f"{width}x{height}"
@@ -830,6 +944,9 @@ def main() -> int:
                     toggle.click()
                     page.wait_for_timeout(1500)
                     measure(page, f"{size} {name} expanded")
+                    toggle.click()
+                if path == "/":
+                    exercise_llama_changelog(page, f"{size} {name}")
 
             # whisper.cpp renames the same card rather than adding a second one.
             llama_payload[0] = WHISPER_STATUS
@@ -864,6 +981,7 @@ def main() -> int:
                 ("**/api/studio/update-status*", UPDATE_STATUS),
                 ("**/api/studio/release-notes*", RELEASE_NOTES),
                 ("**/api/llama/update-status*", LLAMA_STATUS),
+                ("**/api/llama/update-changelog*", LLAMA_CHANGELOG),
                 ("**/api/inference/status", CHAT_LOADED),
                 ("**/api/inference/images/status", NOTHING_DIFFUSION),
                 ("**/api/inference/video/status", NOTHING_VIDEO),
@@ -920,6 +1038,7 @@ def main() -> int:
             ("**/api/studio/update-status*", UPDATE_STATUS),
             ("**/api/studio/release-notes*", RELEASE_NOTES),
             ("**/api/llama/update-status*", LLAMA_STATUS),
+            ("**/api/llama/update-changelog*", LLAMA_CHANGELOG),
         ):
             context.route(pattern, stub(payload))
         page = context.new_page()
@@ -954,6 +1073,7 @@ def main() -> int:
                 ("**/api/studio/update-status*", UPDATE_STATUS),
                 ("**/api/studio/release-notes*", RELEASE_NOTES),
                 ("**/api/llama/update-status*", LLAMA_STATUS),
+                ("**/api/llama/update-changelog*", LLAMA_CHANGELOG),
             ):
                 fresh_context.route(pattern, stub(payload))
             fresh_page = fresh_context.new_page()
@@ -996,6 +1116,7 @@ def main() -> int:
                     ("**/api/studio/update-status*", UPDATE_STATUS),
                     ("**/api/studio/release-notes*", RELEASE_NOTES),
                     ("**/api/llama/update-status*", LLAMA_STATUS),
+                    ("**/api/llama/update-changelog*", LLAMA_CHANGELOG),
                 ):
                     context.route(pattern, stub(payload))
                 page = context.new_page()

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -833,9 +833,7 @@ def main() -> int:
     # OLD is already NEW on a rerun, or when an earlier suite in the same job
     # rotated it, and that login fails before the rotation below can be skipped.
     try:
-        token = api("/api/auth/login", {"username": "unsloth", "password": OLD})[
-            "access_token"
-        ]
+        token = api("/api/auth/login", {"username": "unsloth", "password": OLD})["access_token"]
     except urllib.error.HTTPError as exc:
         if exc.code not in (400, 401, 403):
             raise

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -28,6 +28,7 @@ FRONTEND = REPO / "studio/frontend/src"
 MODULE = BACKEND / "utils/release_notes.py"
 BODIES = Path(__file__).parent / "fixtures/release_bodies"
 PANEL = FRONTEND / "components/update/release-notes-panel.tsx"
+NOTES_LAYOUT = FRONTEND / "components/update/update-notes-layout.ts"
 NOTES_HOOK = FRONTEND / "hooks/use-release-notes.ts"
 PREVIEW = FRONTEND / "lib/release-notes-preview.ts"
 CODE_SPANS = FRONTEND / "lib/markdown-code-spans.ts"
@@ -705,9 +706,10 @@ def test_panel_is_scrollable_and_shows_only_the_stripped_notes():
 
 def test_notes_surface_is_borderless_and_lifts_in_dark_mode():
     src = PANEL.read_text(encoding = "utf-8")
+    layout = NOTES_LAYOUT.read_text(encoding = "utf-8")
     assert "border border-border" not in src, "the notes box is a fill, not a bordered box"
     # Lighter than the card behind it, rather than a darker inset.
-    assert "dark:bg-white/[0.06]" in src
+    assert "dark:bg-white/[0.06]" in layout
     # Streamdown's mt-6 clips the first heading against the scroller edge.
     assert "[&>*>*:first-child]:mt-0" in src
     # Shared utility: thumb hidden until the notes are hovered.
@@ -747,19 +749,21 @@ def test_preview_highlights_the_leading_sentence():
     assert "SENTENCE_BREAK" in preview and "(?=" in preview
 
     panel = PANEL.read_text(encoding = "utf-8")
-    assert '<span className="font-medium text-foreground">{item.lead}</span>' in panel
+    layout = NOTES_LAYOUT.read_text(encoding = "utf-8")
+    assert "UPDATE_NOTES_LEAD_CLASS" in panel
+    assert '"font-medium text-foreground"' in layout
     assert "item.rest" in panel
 
 
 @pytest.mark.parametrize("banner", [WEB_BANNER, TAURI_BANNER])
-def test_update_popup_is_wider_than_the_other_overlays(banner):
-    """Sized for three same-size buttons on one row. Width moved from the shared
-    stack onto each overlay, so this does not widen the other overlays."""
+def test_update_popups_share_the_notes_width(banner):
+    """Every update popup uses the same width for its notes and action rows."""
     assert "max-w-[448px]" in banner.read_text(encoding = "utf-8")
     provider = (FRONTEND / "app/provider.tsx").read_text(encoding = "utf-8")
     assert "max-w-[400px]" not in provider, "stack must not cap overlay width"
     llama = (FRONTEND / "components/llama-update-banner.tsx").read_text(encoding = "utf-8")
-    assert "max-w-[400px]" in llama, "unrelated overlays keep their width"
+    assert "max-w-[448px]" in llama
+    assert "max-w-[400px]" not in llama
 
 
 @pytest.mark.parametrize("banner", [WEB_BANNER, TAURI_BANNER])
@@ -1082,9 +1086,11 @@ def test_only_the_notes_region_scrolls(banner):
     """The dismiss control sits inside the card, so the card must not scroll."""
     src = banner.read_text(encoding = "utf-8")
     assert "flex max-h-[calc(100dvh_-_2rem)] min-h-0 flex-col overflow-hidden" in src
-    assert 'className="min-h-0 flex-1"' in src
+    layout = NOTES_LAYOUT.read_text(encoding = "utf-8")
+    assert "mt-3 flex min-h-0 flex-1 flex-col overflow-hidden" in layout
     panel = PANEL.read_text(encoding = "utf-8")
-    assert "max-h-64 min-h-0 flex-1 overflow-y-auto" in panel
+    assert "UPDATE_NOTES_EXPANDED_SCROLL_CLASS" in panel
+    assert "max-h-64 min-h-0 flex-1 overflow-y-auto" in layout
     # The collapsed summary scrolls too: without it the bullets were painted
     # over the row of buttons once the card's slot for them got small.
     assert "min-h-0 flex-1 space-y-1 overflow-y-auto" in panel


### PR DESCRIPTION
## Summary

Add an expandable "Show what's new" section to Studio's llama.cpp update banner.

Studio reads the exact installed and target tags, fetches their release descriptions from `unslothai/llama.cpp` by default, and compares the bullet entries. These release descriptions are cumulative, so showing the target release alone would repeat older carried patches. The banner displays only entries added in the newer build.

## Implementation

- Add an authenticated `GET /api/llama/update-changelog` endpoint, fetched only when the section opens and kept separate from the update status poll.
- Cache exact GitHub releases for 24 hours and failures for 60 seconds, with a cache-bypassing retry.
- Match entries by PRs, issues, and textual references so rebases and patches migrated to an Unsloth carry PR are not reported again. Preserve safe GitHub links in the displayed summaries.
- Fail closed when either release is unavailable instead of displaying the cumulative target body. The frontend covers loading, retry, empty, truncated, stale, and mismatched responses.
- Share the desktop updater's release-note layout, including its 448 px width, 16 rem notes cap, responsive height floor, scrollbar, spacing, typography, links, and footer.

## Screenshots

### Desktop

<img width="1200" height="800" alt="pr-llama-update-changelog-desktop" src="https://github.com/user-attachments/assets/781e085c-e854-4cbf-9064-56c4ee27417c" />


### Mobile

<img width="390" height="844" alt="pr-llama-update-changelog-mobile" src="https://github.com/user-attachments/assets/8c457a69-8c79-43b7-adcc-2807d8a35c92" />


The captures use a real seven-item comparison between published llama.cpp releases, not placeholder release notes.

## Verification

- 71 focused backend tests, 187 release-note contract tests, and 18 frontend layout tests passed.
- TypeScript type checking, the frontend production build, Ruff, and targeted Biome checks passed. Biome reports only the existing complexity warning on `LlamaUpdateBanner`.
- Playwright passed 239 responsive layout and interaction checks with zero failures.
- Live comparisons returned seven changes for a recent update and nine for an older update. The older comparison correctly excluded an already-carried DiffusionGemma patch after its migration to an Unsloth PR.

## Scope

- The changelog appears only for an available managed llama.cpp prebuilt update with both release identities available. Source builds, custom paths, local linked installs, and whisper.cpp updates are unchanged.
- It compares only the installed and target release descriptions. It does not reconstruct intermediate release history.
- Desktop app release-note behavior is unchanged. Its presentation constants are now shared with the llama.cpp panel.
