### PR TITLE
studio: keep MTP on for GLM-5.3-Flash

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3376,20 +3376,10 @@ def _auto_mode_drops_mtp(
     return req_mode == "auto" and size_b is not None and size_b < _MTP_MIN_SIZE_B
 
 
-# MLA architectures whose MTP context runs the NextN block against a cache of just
-# that block's layers instead of duplicating the trunk's KV. Named individually, so
-# a new MLA arch keeps the conservative default until someone reads its filter.
-#
-# One fact, two consequences: not paying for the duplicate is why Auto keeps MTP
-# here (the gate below) and why the fit must not reserve for it (_estimate_mtp_
-# overhead_bytes). glm5next (GLM-5.3-Flash) at n_ctx 4096 allocates 4+3 MiB over one
-# layer where the trunk holds 48+36 MiB over twelve.
-# unslothai/llama.cpp b10715-mix-86bd2d3, UD-IQ1_S on one B200, --spec-draft-n-max 3:
-# 61.1 -> 80.2 tok/s (1.31x), draft acceptance 0.634.
-#
-# Only the unhyphenated spelling. A second upstream port of the same model uses the
-# arch name "glm5-next" and does not implement the NextN graph at all (it loads the
-# blk.45 tensors and logs them as unused), so Auto must not promote MTP there.
+# MLA archs whose MTP context covers only the NextN block instead of duplicating the
+# trunk KV: glm5next holds 4+3 MiB over one layer where its trunk holds 48+36 over
+# twelve. That one fact is why Auto keeps MTP (gate below) and why the fit must not
+# reserve the copy (_estimate_mtp_overhead_bytes). Not "glm5-next": no NextN graph.
 _MLA_MTP_FAST_ARCHS = frozenset({"glm5next"})
 
 
@@ -4095,9 +4085,7 @@ _TARGET_KV_EXCLUDES_NEXTN_ARCHS = frozenset(
         # MLA/DSA trunk with a dense MTP head, llama-model.cpp:2129
         "glm-dsa",
         "deepseek32",
-        # Hybrid KDA + DSA trunk, filtered in the same block as the Qwen hybrids.
-        # Both upstream spellings of GLM-5.3-Flash keep blk.45 out of the trunk cache,
-        # so the sizing is the same either way even though only glm5next runs NextN.
+        # Hybrid KDA + DSA trunk; both GLM-5.3-Flash ports filter blk.45 out
         "glm5next",
         "glm5-next",
         # Plain attention trunk with an explicit nextn filter, llama-model.cpp:2356
@@ -11869,9 +11857,8 @@ class LlamaCppBackend:
         # separate-drafter spec modes (draft-simple/draft-eagle3) load a small
         # distinct drafter with its own KV -- already counted in draft_kv/weights --
         # rather than duplicating the target, so they must not be charged for it.
-        # Third gate: an MLA arch whose MTP context covers only the NextN layers
-        # never allocates that copy, so charging it shrinks the fitted context or
-        # trips drafter_no_vram, which drops the MTP the fit was reserving for.
+        # Third gate: a NextN-only MTP context never allocates the copy, and
+        # charging it trips drafter_no_vram, losing the MTP being reserved for.
         target_ctx_copy = 0
         if (
             mtp_keeps_target_ctx

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -11880,9 +11880,14 @@ class LlamaCppBackend:
         # drafter file pays it exactly like the embedded head: ``target_rollback``
         # decides, not ``drafter_path`` (see _TARGET_ROLLBACK_SPEC_TYPES). The
         # dominant hidden cost on Qwen3.5/3.8 at multiple parallel slots.
+        # Linear-attention hybrids (KDA) pay the same per-token rollback and are
+        # sized by the other helper, so fall through to it rather than pricing
+        # them at zero. llama.cpp logs the sum as `1 seqs N rs_seq`.
         target_recurrent_copies = 0
         if target_rollback and spec_draft_n_max > 0:
-            base_recurrent = self._mamba_recurrent_state_bytes(n_parallel)
+            base_recurrent = self._mamba_recurrent_state_bytes(
+                n_parallel
+            ) or self._recurrent_state_bytes(n_parallel)
             target_recurrent_copies = base_recurrent * spec_draft_n_max
         if draft_kv is None:
             # KV unsized (exotic/remote drafter): still reserve known weights + any

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3376,13 +3376,14 @@ def _auto_mode_drops_mtp(
     return req_mode == "auto" and size_b is not None and size_b < _MTP_MIN_SIZE_B
 
 
-# MLA architectures whose embedded MTP path is measured FASTER than no speculation,
-# so Auto keeps it despite the gate below. Named individually rather than widening
-# the gate: a new MLA arch still defaults to the safe side until someone benches it.
+# MLA architectures whose MTP context runs the NextN block against a cache of just
+# that block's layers instead of duplicating the trunk's KV. Named individually, so
+# a new MLA arch keeps the conservative default until someone reads its filter.
 #
-# glm5next (GLM-5.3-Flash) runs its NextN block as an ordinary DSA layer against its
-# own one-layer KV cache, so it does not pay the duplicated target-KV and per-draft
-# indexer recompute the gate describes.
+# One fact, two consequences: not paying for the duplicate is why Auto keeps MTP
+# here (the gate below) and why the fit must not reserve for it (_estimate_mtp_
+# overhead_bytes). glm5next (GLM-5.3-Flash) at n_ctx 4096 allocates 4+3 MiB over one
+# layer where the trunk holds 48+36 MiB over twelve.
 # unslothai/llama.cpp b10715-mix-86bd2d3, UD-IQ1_S on one B200, --spec-draft-n-max 3:
 # 61.1 -> 80.2 tok/s (1.31x), draft acceptance 0.634.
 #
@@ -3395,6 +3396,11 @@ _MLA_MTP_FAST_ARCHS = frozenset({"glm5next"})
 def _arch_has_fast_mla_mtp(architecture: Optional[str]) -> bool:
     """Whether this MLA architecture's embedded MTP head is worth promoting in Auto."""
     return bool(architecture) and str(architecture).strip().lower() in _MLA_MTP_FAST_ARCHS
+
+
+def _arch_mtp_skips_target_kv_copy(architecture: Optional[str]) -> bool:
+    """Whether this MLA architecture's MTP context skips the duplicated target KV."""
+    return _arch_has_fast_mla_mtp(architecture)
 
 
 def _mla_mtp_auto_enabled() -> bool:
@@ -11863,8 +11869,15 @@ class LlamaCppBackend:
         # separate-drafter spec modes (draft-simple/draft-eagle3) load a small
         # distinct drafter with its own KV -- already counted in draft_kv/weights --
         # rather than duplicating the target, so they must not be charged for it.
+        # Third gate: an MLA arch whose MTP context covers only the NextN layers
+        # never allocates that copy, so charging it shrinks the fitted context or
+        # trips drafter_no_vram, which drops the MTP the fit was reserving for.
         target_ctx_copy = 0
-        if mtp_keeps_target_ctx and self._kv_lora_rank is not None:
+        if (
+            mtp_keeps_target_ctx
+            and self._kv_lora_rank is not None
+            and not _arch_mtp_skips_target_kv_copy(getattr(self, "_architecture", None))
+        ):
             target_ctx_copy = self._estimate_kv_cache_bytes(
                 n_ctx,
                 "f16",

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -11355,6 +11355,17 @@ class LlamaCppBackend:
         n_embd_s = head_dim * head_dim * n_head
         return int(n_recurrent * (n_embd_r + n_embd_s) * 4 * max(1, n_parallel))
 
+    def _rollback_state_bytes(self, n_parallel: int = 1) -> int:
+        """One target-context rollback snapshot, whichever recurrent family this is.
+
+        Both callers price the same thing (llama.cpp's `1 seqs N rs_seq`) and both
+        used to reach for the Mamba helper alone, which answers 0 for a KDA hybrid
+        and silently dropped the reserve. Route every caller through here.
+        """
+        return self._mamba_recurrent_state_bytes(n_parallel) or self._recurrent_state_bytes(
+            n_parallel
+        )
+
     def _target_kv_excludes_nextn(self) -> bool:
         """Whether this model's TARGET KV cache skips the embedded MTP blocks.
 
@@ -11880,15 +11891,9 @@ class LlamaCppBackend:
         # drafter file pays it exactly like the embedded head: ``target_rollback``
         # decides, not ``drafter_path`` (see _TARGET_ROLLBACK_SPEC_TYPES). The
         # dominant hidden cost on Qwen3.5/3.8 at multiple parallel slots.
-        # Linear-attention hybrids (KDA) pay the same per-token rollback and are
-        # sized by the other helper, so fall through to it rather than pricing
-        # them at zero. llama.cpp logs the sum as `1 seqs N rs_seq`.
         target_recurrent_copies = 0
         if target_rollback and spec_draft_n_max > 0:
-            base_recurrent = self._mamba_recurrent_state_bytes(
-                n_parallel
-            ) or self._recurrent_state_bytes(n_parallel)
-            target_recurrent_copies = base_recurrent * spec_draft_n_max
+            target_recurrent_copies = self._rollback_state_bytes(n_parallel) * spec_draft_n_max
         if draft_kv is None:
             # KV unsized (exotic/remote drafter): still reserve known weights + any
             # MLA target copy so a large config can't launch over budget (the small
@@ -19079,9 +19084,9 @@ class LlamaCppBackend:
                         # displaced does not run. The flat fraction below is gated on
                         # this; the byte-accurate callback was not, so the fit went on
                         # charging VRAM no drafter allocates.
-                        # One term survives: a Hybrid Mamba target's recurrent rollback
-                        # snapshots sit in the TARGET context, so pinning the drafter to
-                        # CPU does not move them. Charge those alone. Flat in ctx (the
+                        # One term survives: a recurrent target's rollback snapshots sit
+                        # in the TARGET context, so pinning the drafter to CPU does not
+                        # move them. Charge those alone. Flat in ctx (the
                         # state is per-slot), hence the same _np/_n_ubatch keywords the
                         # replaced callback takes, so _mtp_bytes can still re-price slots.
                         def _cpu_draft_target_state(
@@ -19093,7 +19098,7 @@ class LlamaCppBackend:
                         ) -> int:
                             if not _rollback or _n <= 0:
                                 return 0
-                            return self._mamba_recurrent_state_bytes(_np) * _n
+                            return self._rollback_state_bytes(_np) * _n
 
                         mtp_overhead_fn = (
                             _cpu_draft_target_state

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3376,6 +3376,27 @@ def _auto_mode_drops_mtp(
     return req_mode == "auto" and size_b is not None and size_b < _MTP_MIN_SIZE_B
 
 
+# MLA architectures whose embedded MTP path is measured FASTER than no speculation,
+# so Auto keeps it despite the gate below. Named individually rather than widening
+# the gate: a new MLA arch still defaults to the safe side until someone benches it.
+#
+# glm5next (GLM-5.3-Flash) runs its NextN block as an ordinary DSA layer against its
+# own one-layer KV cache, so it does not pay the duplicated target-KV and per-draft
+# indexer recompute the gate describes.
+# unslothai/llama.cpp b10715-mix-86bd2d3, UD-IQ1_S on one B200, --spec-draft-n-max 3:
+# 61.1 -> 80.2 tok/s (1.31x), draft acceptance 0.634.
+#
+# Only the unhyphenated spelling. A second upstream port of the same model uses the
+# arch name "glm5-next" and does not implement the NextN graph at all (it loads the
+# blk.45 tensors and logs them as unused), so Auto must not promote MTP there.
+_MLA_MTP_FAST_ARCHS = frozenset({"glm5next"})
+
+
+def _arch_has_fast_mla_mtp(architecture: Optional[str]) -> bool:
+    """Whether this MLA architecture's embedded MTP head is worth promoting in Auto."""
+    return bool(architecture) and str(architecture).strip().lower() in _MLA_MTP_FAST_ARCHS
+
+
 def _mla_mtp_auto_enabled() -> bool:
     """Whether Auto may pick embedded MTP for an MLA model (GLM-5.2/DeepSeek/Kimi).
 
@@ -4068,6 +4089,11 @@ _TARGET_KV_EXCLUDES_NEXTN_ARCHS = frozenset(
         # MLA/DSA trunk with a dense MTP head, llama-model.cpp:2129
         "glm-dsa",
         "deepseek32",
+        # Hybrid KDA + DSA trunk, filtered in the same block as the Qwen hybrids.
+        # Both upstream spellings of GLM-5.3-Flash keep blk.45 out of the trunk cache,
+        # so the sizing is the same either way even though only glm5next runs NextN.
+        "glm5next",
+        "glm5-next",
         # Plain attention trunk with an explicit nextn filter, llama-model.cpp:2356
         "step35",
         "hy_v3",
@@ -24149,6 +24175,7 @@ class LlamaCppBackend:
             and self._kv_lora_rank is not None
             and not bool(mtp_draft_path)
             and not _mla_mtp_auto_enabled()
+            and not _arch_has_fast_mla_mtp(getattr(self, "_architecture", None))
         )
 
         if user_owns_spec_type:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -11868,8 +11868,8 @@ class LlamaCppBackend:
         # separate-drafter spec modes (draft-simple/draft-eagle3) load a small
         # distinct drafter with its own KV -- already counted in draft_kv/weights --
         # rather than duplicating the target, so they must not be charged for it.
-        # Third gate: a NextN-only MTP context never allocates the copy, and
-        # charging it trips drafter_no_vram, losing the MTP being reserved for.
+        # Third gate: a NextN-only MTP context allocates no copy, and charging one
+        # trips drafter_no_vram, losing the MTP being reserved for.
         target_ctx_copy = 0
         if (
             mtp_keeps_target_ctx

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -2280,12 +2280,7 @@ def test_reload_forced_mtp_bounces_auto_mla():
     )
 
 
-# ── The MLA archs exempt from that gate (measured faster, not slower) ──
-#
-# glm5next (GLM-5.3-Flash) is MLA with an embedded NextN head, so it matches the
-# gate above on metadata alone, but its MTP path is 1.31x FASTER rather than 2x
-# slower: it runs the NextN block against its own one-layer KV cache instead of
-# duplicating the trunk's. Auto must therefore keep draft-mtp for it.
+# glm5next matches the MLA gate on metadata, but its MTP is 1.31x faster, not slower.
 _GLM5NEXT_MODEL = "unsloth/GLM-5.3-Flash-GGUF"
 
 
@@ -2308,8 +2303,7 @@ def test_auto_glm5next_keeps_draft_mtp(monkeypatch):
 
 
 def test_auto_glm5next_hyphenated_arch_still_gated(monkeypatch):
-    # A second upstream port spells the same model "glm5-next" and never builds
-    # the NextN graph, so the exemption must not spill onto that spelling.
+    # The "glm5-next" port never builds the NextN graph: no spillover.
     backend = _mla_resolver_backend(monkeypatch)
     backend._architecture = "glm5-next"
     flags = backend._build_speculative_flags(
@@ -2335,10 +2329,7 @@ def test_arch_has_fast_mla_mtp_is_case_and_space_tolerant():
 
 
 def test_glm5next_target_kv_excludes_nextn():
-    # Both upstream ports install a trunk filter (llama-model.cpp) returning
-    # il < n_layer() && !is_recr(il), so blk.45 gets no target KV and reserving
-    # for it would cost context. The KV sizing is shared even though only the
-    # unhyphenated port runs the NextN graph.
+    # Both ports filter il < n_layer() && !is_recr(il), so blk.45 gets no target KV.
     assert "glm5next" in _TARGET_KV_EXCLUDES_NEXTN_ARCHS
     assert "glm5-next" in _TARGET_KV_EXCLUDES_NEXTN_ARCHS
 

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -75,6 +75,8 @@ from core.inference.llama_cpp import (
     _extra_args_set_spec_type,
     _is_mtp_model_name,
     _kv_unified_from_args,
+    _TARGET_KV_EXCLUDES_NEXTN_ARCHS,
+    _arch_has_fast_mla_mtp,
     _mla_mtp_auto_enabled,
     _swa_full_from_args_or_env,
 )
@@ -2276,6 +2278,69 @@ def test_reload_forced_mtp_bounces_auto_mla():
         )
         is False
     )
+
+
+# ── The MLA archs exempt from that gate (measured faster, not slower) ──
+#
+# glm5next (GLM-5.3-Flash) is MLA with an embedded NextN head, so it matches the
+# gate above on metadata alone, but its MTP path is 1.31x FASTER rather than 2x
+# slower: it runs the NextN block against its own one-layer KV cache instead of
+# duplicating the trunk's. Auto must therefore keep draft-mtp for it.
+_GLM5NEXT_MODEL = "unsloth/GLM-5.3-Flash-GGUF"
+
+
+def test_auto_glm5next_keeps_draft_mtp(monkeypatch):
+    backend = _mla_resolver_backend(monkeypatch)
+    backend._architecture = "glm5next"
+    flags = backend._build_speculative_flags(
+        speculative_type = "auto",
+        spec_draft_n_max = None,
+        extra_args = None,
+        model_identifier = _GLM5NEXT_MODEL,
+        model_path = None,
+        gpus = True,
+        binary = "/fake/llama-server",
+    )
+    parsed = _flags_dict(flags)
+    assert parsed.get("--spec-type") == "draft-mtp"
+    assert backend.speculative_type == "draft-mtp"
+    assert backend.spec_fallback_reason != "mla_mtp_disabled"
+
+
+def test_auto_glm5next_hyphenated_arch_still_gated(monkeypatch):
+    # A second upstream port spells the same model "glm5-next" and never builds
+    # the NextN graph, so the exemption must not spill onto that spelling.
+    backend = _mla_resolver_backend(monkeypatch)
+    backend._architecture = "glm5-next"
+    flags = backend._build_speculative_flags(
+        speculative_type = "auto",
+        spec_draft_n_max = None,
+        extra_args = None,
+        model_identifier = _GLM5NEXT_MODEL,
+        model_path = None,
+        gpus = True,
+        binary = "/fake/llama-server",
+    )
+    assert _flags_dict(flags).get("--spec-type") != "draft-mtp"
+    assert backend.spec_fallback_reason == "mla_mtp_disabled"
+
+
+def test_arch_has_fast_mla_mtp_is_case_and_space_tolerant():
+    assert _arch_has_fast_mla_mtp("glm5next")
+    assert _arch_has_fast_mla_mtp("  GLM5Next  ")
+    assert not _arch_has_fast_mla_mtp("glm5-next")
+    assert not _arch_has_fast_mla_mtp("glm-dsa")
+    assert not _arch_has_fast_mla_mtp(None)
+    assert not _arch_has_fast_mla_mtp("")
+
+
+def test_glm5next_target_kv_excludes_nextn():
+    # Both upstream ports install a trunk filter (llama-model.cpp) returning
+    # il < n_layer() && !is_recr(il), so blk.45 gets no target KV and reserving
+    # for it would cost context. The KV sizing is shared even though only the
+    # unhyphenated port runs the NextN graph.
+    assert "glm5next" in _TARGET_KV_EXCLUDES_NEXTN_ARCHS
+    assert "glm5-next" in _TARGET_KV_EXCLUDES_NEXTN_ARCHS
 
 
 # ── Full named-repo resolver matrix (the shipping Unsloth families) ─────

--- a/studio/backend/tests/test_mtp_mla_target_ctx.py
+++ b/studio/backend/tests/test_mtp_mla_target_ctx.py
@@ -200,12 +200,68 @@ class TestMlaTargetCtxReserve:
         assert other._estimate_mtp_overhead_bytes(ctx) == (
             b._mtp_draft_kv_bytes(ctx) + b._estimate_kv_cache_bytes(ctx, "f16")
         )
-        # The hyphenated port builds no NextN graph, so it keeps the safe default.
+        # The "glm5-next" port builds no NextN graph, so it keeps the safe default.
         hyphenated = _make_mla_backend()
         hyphenated._architecture = "glm5-next"
         assert hyphenated._estimate_mtp_overhead_bytes(ctx) == other._estimate_mtp_overhead_bytes(
             ctx
         )
+
+
+class TestKdaRollbackReserve:
+    """A KDA hybrid pays draft rollback copies the Mamba helper cannot see.
+
+    Dims are GLM-5.3-Flash UD-IQ1_S as shipped (34 recurrent layers of 46,
+    kda.head_dim 128, head_count 64, ssm.conv_kernel 4). llama.cpp allocates
+    582.25 MiB for `1 seqs 3 rs_seq`, i.e. 4 x 145.5625 MiB, so the MTP share
+    is the 3 extra copies and the reserve must carry them.
+    """
+
+    MIB = 1024**2
+    PER_SEQ = 145.5625  # MiB, and the size llama.cpp logs per context checkpoint
+
+    def _kda(self):
+        b = _make_mla_backend()
+        b._architecture = "glm5next"
+        # Every 4th block is DSA, and so is blk.45 (NextN): 34 recurrent of 46.
+        b._n_kv_heads_by_layer = [1 if ((i + 1) % 4 == 0 or i == 45) else 0 for i in range(46)]
+        b._n_layers = 46
+        b._n_heads = 64
+        b._kda_head_dim = 128
+        b._ssm_conv_kernel = 4
+        return b
+
+    def test_base_state_matches_llama_cpp(self):
+        b = self._kda()
+        assert b._mamba_recurrent_state_bytes(1) == 0  # no SSM fields: the gap
+        assert b._recurrent_state_bytes(1) / self.MIB == pytest.approx(self.PER_SEQ)
+
+    def test_rollback_copies_are_reserved(self):
+        b = self._kda()
+        base = b._estimate_mtp_overhead_bytes(65536, spec_draft_n_max = 0)
+        with_draft = b._estimate_mtp_overhead_bytes(65536, spec_draft_n_max = 3)
+        assert (with_draft - base) / self.MIB == pytest.approx(3 * self.PER_SEQ)
+
+    def test_rollback_scales_with_slots(self):
+        b = self._kda()
+        one = b._estimate_mtp_overhead_bytes(65536, spec_draft_n_max = 3, n_parallel = 1)
+        four = b._estimate_mtp_overhead_bytes(65536, spec_draft_n_max = 3, n_parallel = 4)
+        assert four > one
+
+    def test_mamba_path_unchanged(self):
+        # A Mamba hybrid still prices rollback with its own helper; the KDA
+        # fallback must not double-count or shadow it.
+        b = _make_mla_backend()
+        b._ssm_inner_size = 6144
+        b._ssm_state_size = 128
+        b._ssm_group_count = 1
+        b._ssm_conv_kernel = 4
+        b._full_attention_interval = 4
+        assert b._mamba_recurrent_state_bytes(1) > 0
+        delta = b._estimate_mtp_overhead_bytes(
+            65536, spec_draft_n_max = 2
+        ) - b._estimate_mtp_overhead_bytes(65536, spec_draft_n_max = 0)
+        assert delta == 2 * b._mamba_recurrent_state_bytes(1)
 
 
 class TestMlaFitPreventsOom:

--- a/studio/backend/tests/test_mtp_mla_target_ctx.py
+++ b/studio/backend/tests/test_mtp_mla_target_ctx.py
@@ -189,8 +189,7 @@ class TestMlaTargetCtxReserve:
         assert mtp > separate
 
     def test_one_layer_mtp_arch_drops_target_copy(self):
-        # A NextN-only MTP context allocates no copy, and charging one trips
-        # drafter_no_vram, dropping the very MTP the reserve is priced for.
+        # Charging the absent copy trips drafter_no_vram, dropping the MTP itself.
         b = _make_mla_backend()
         b._architecture = "glm5next"
         other = _make_mla_backend()
@@ -249,10 +248,8 @@ class TestKdaRollbackReserve:
         assert four > one
 
     def test_cpu_pinned_drafter_keeps_target_rollback(self):
-        # Pinning a separate drafter to the CPU moves the drafter, not the target's
-        # rollback snapshots. The loader replaces the reserve with a rollback-only
-        # callback and drops it entirely when that reads 0, so a KDA target must
-        # not report 0 here or the whole reserve disappears.
+        # Pinning the drafter to CPU does not move the target's snapshots, and the
+        # loader drops its whole rollback-only callback when this reads 0.
         b = self._kda()
         assert b._rollback_state_bytes(1) / self.MIB == pytest.approx(self.PER_SEQ)
         assert b._rollback_state_bytes(4) == 4 * b._rollback_state_bytes(1)
@@ -267,8 +264,7 @@ class TestKdaRollbackReserve:
         assert b._rollback_state_bytes(1) == b._mamba_recurrent_state_bytes(1)
 
     def test_mamba_path_unchanged(self):
-        # A Mamba hybrid still prices rollback with its own helper; the KDA
-        # fallback must not double-count or shadow it.
+        # The KDA fallback must not shadow or double-count the Mamba helper.
         b = _make_mla_backend()
         b._ssm_inner_size = 6144
         b._ssm_state_size = 128

--- a/studio/backend/tests/test_mtp_mla_target_ctx.py
+++ b/studio/backend/tests/test_mtp_mla_target_ctx.py
@@ -188,6 +188,28 @@ class TestMlaTargetCtxReserve:
         assert mtp == separate + b._estimate_kv_cache_bytes(ctx, "f16")
         assert mtp > separate
 
+    def test_one_layer_mtp_arch_drops_target_copy(self):
+        # glm5next's MTP context covers only the NextN block, so llama.cpp
+        # allocates one layer of cache instead of copying the trunk's: measured
+        # 4+3 MiB against 48+36 MiB over 12 layers at n_ctx 4096. Charging the
+        # copy would shrink the fitted context or set drafter_no_vram, and Auto
+        # would then fall back to ngram for the arch this reserve is priced for.
+        b = _make_mla_backend()
+        b._architecture = "glm5next"
+        other = _make_mla_backend()
+        other._architecture = "glm-dsa"  # same dims, still pays the copy
+        ctx = 262144
+        assert b._estimate_mtp_overhead_bytes(ctx) == b._mtp_draft_kv_bytes(ctx)
+        assert other._estimate_mtp_overhead_bytes(ctx) == (
+            b._mtp_draft_kv_bytes(ctx) + b._estimate_kv_cache_bytes(ctx, "f16")
+        )
+        # The hyphenated port builds no NextN graph, so it keeps the safe default.
+        hyphenated = _make_mla_backend()
+        hyphenated._architecture = "glm5-next"
+        assert hyphenated._estimate_mtp_overhead_bytes(ctx) == other._estimate_mtp_overhead_bytes(
+            ctx
+        )
+
 
 class TestMlaFitPreventsOom:
     """The corrected reserve must actually lower the auto-fit context so the

--- a/studio/backend/tests/test_mtp_mla_target_ctx.py
+++ b/studio/backend/tests/test_mtp_mla_target_ctx.py
@@ -248,6 +248,24 @@ class TestKdaRollbackReserve:
         four = b._estimate_mtp_overhead_bytes(65536, spec_draft_n_max = 3, n_parallel = 4)
         assert four > one
 
+    def test_cpu_pinned_drafter_keeps_target_rollback(self):
+        # Pinning a separate drafter to the CPU moves the drafter, not the target's
+        # rollback snapshots. The loader replaces the reserve with a rollback-only
+        # callback and drops it entirely when that reads 0, so a KDA target must
+        # not report 0 here or the whole reserve disappears.
+        b = self._kda()
+        assert b._rollback_state_bytes(1) / self.MIB == pytest.approx(self.PER_SEQ)
+        assert b._rollback_state_bytes(4) == 4 * b._rollback_state_bytes(1)
+
+    def test_rollback_helper_prefers_mamba(self):
+        b = _make_mla_backend()
+        b._ssm_inner_size = 6144
+        b._ssm_state_size = 128
+        b._ssm_group_count = 1
+        b._ssm_conv_kernel = 4
+        b._full_attention_interval = 4
+        assert b._rollback_state_bytes(1) == b._mamba_recurrent_state_bytes(1)
+
     def test_mamba_path_unchanged(self):
         # A Mamba hybrid still prices rollback with its own helper; the KDA
         # fallback must not double-count or shadow it.

--- a/studio/backend/tests/test_mtp_mla_target_ctx.py
+++ b/studio/backend/tests/test_mtp_mla_target_ctx.py
@@ -189,11 +189,8 @@ class TestMlaTargetCtxReserve:
         assert mtp > separate
 
     def test_one_layer_mtp_arch_drops_target_copy(self):
-        # glm5next's MTP context covers only the NextN block, so llama.cpp
-        # allocates one layer of cache instead of copying the trunk's: measured
-        # 4+3 MiB against 48+36 MiB over 12 layers at n_ctx 4096. Charging the
-        # copy would shrink the fitted context or set drafter_no_vram, and Auto
-        # would then fall back to ngram for the arch this reserve is priced for.
+        # A NextN-only MTP context allocates no copy, and charging one trips
+        # drafter_no_vram, dropping the very MTP the reserve is priced for.
         b = _make_mla_backend()
         b._architecture = "glm5next"
         other = _make_mla_backend()


### PR DESCRIPTION
Auto currently turns embedded MTP off for GLM-5.3-Flash. The prebuilt supports it and it is a real speedup, so this exempts the architecture from that gate.

## Why the gate catches it

`_auto_mla_embedded_mtp` drops MTP for any model with an embedded NextN head and `kv_lora_rank` set:

```python
_auto_mla_embedded_mtp = (
    bool(self._nextn_predict_layers)      # GLM-5.3-Flash: 1
    and self._kv_lora_rank is not None    # GLM-5.3-Flash: 512
    and not bool(mtp_draft_path)
    and not _mla_mtp_auto_enabled()
)
```

Both keys are in the shipped GGUFs, so all four conditions hold and Auto falls back to `ngram-mod`.

The gate is right about what it was measured on. llama.cpp's MLA/DSA MTP path keeps a duplicated full target-KV context and recomputes the sparse indexer every draft step, which is where the GLM-5.2 figure of 27 vs 45 tok/s comes from.

glm5next does not do that. Its NextN block is an ordinary DSA layer and the MTP context gets a cache for that one layer rather than a copy of the trunk's, so neither cost applies.

## Measurement

`unslothai/llama.cpp` prebuilt `b10715-mix-86bd2d3`, `linux-x64-cuda13-newer`, GLM-5.3-Flash UD-IQ1_S on a single B200, greedy, same GPU for both arms:

| arm | generation |
|---|---|
| Auto today (MTP dropped) | 61.1 tok/s |
| `--spec-type draft-mtp --spec-draft-n-max 3` | 80.2 tok/s |

1.31x, draft acceptance 0.634, mean accepted run 2.87 tokens. `n-max` 2 and 3 are the useful settings; at 5 the gain collapses to 1.03x because rejected drafts still cost a verify.

## What changed

Named exemptions rather than a wider gate, so an MLA architecture nobody has benchmarked keeps defaulting to the safe side:

```python
_MLA_MTP_FAST_ARCHS = frozenset({"glm5next"})
```

Second change: both upstream spellings of this model join `_TARGET_KV_EXCLUDES_NEXTN_ARCHS`. There are two ports of GLM-5.3-Flash in flight upstream, one using the arch name `glm5next` and one using `glm5-next`, and both install a trunk filter returning `il < n_layer() && !is_recr(il)`, so `blk.45` gets no target KV and reserving for it only costs context. That list is deliberately fail-closed, so these are additions made after reading each filter rather than inferring them from the nextn key.

The two spellings are treated differently on the MTP side on purpose. Only `glm5next` builds the NextN graph; the `glm5-next` port raises `GLM5-Next NextN graph not implemented yet`, so it stays gated and Auto will not promote MTP for it. If that port later gains the graph, adding the name to `_MLA_MTP_FAST_ARCHS` is the whole change.

## Tests

Five new assertions in `test_llama_cpp_mtp_detection.py`: Auto keeps `draft-mtp` for `glm5next`, the hyphenated spelling stays gated, the arch predicate is case and whitespace tolerant, and the KV list contains both spellings.

Reverting the source change fails the two behavioural ones:

```
FAILED test_auto_glm5next_keeps_draft_mtp
FAILED test_glm5next_target_kv_excludes_nextn
```

With the change, the file passes 338 of 338.

## Notes

Nothing here changes forced modes. Picking `mtp` in the dropdown, passing `--spec-type` directly, or setting `UNSLOTH_MLA_MTP_ENABLED=1` already bypassed the gate; this only fixes what Auto chooses on its own.

MTP for this model is available in `unslothai/llama.cpp` prebuilts from `b10715-mix-86bd2d3` onward. Older prebuilts pinned the architecture at a commit predating the NextN graph, so Auto selecting `draft-mtp` there would have been rejected by the binary rather than silently slow.
