### PR TITLE
Prune an open PR's caches once nothing has read them

### DIFF
--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -74,6 +74,10 @@ on:
         description: 'Generations kept per prefix. 2 so an in-flight run cannot lose the cache it just resolved, and so a reverted dependency bump still hits.'
         type: string
         default: '2'
+      open_pr_idle_days:
+        description: 'Delete a cache on an OPEN pull request ref after this many days with no read. Nothing but that PR can reach it, so no read means no reader.'
+        type: string
+        default: '3'
 
 # Two sweeps would race on the same ids and spend their DELETEs on 404s.
 concurrency:
@@ -100,6 +104,7 @@ jobs:
           # `false` alike, so `inputs.mode == false` is true when unset.
           DELETE: ${{ (github.event_name == 'schedule' || inputs.mode == 'delete') && 'yes' || 'no' }}
           KEEP: ${{ inputs.keep || '2' }}
+          OPEN_PR_IDLE_DAYS: ${{ inputs.open_pr_idle_days || '3' }}
         run: |
           set -euo pipefail
           repo="$GITHUB_REPOSITORY"
@@ -113,14 +118,52 @@ jobs:
           # exit 0. All-digit is not enough, since a value past bash's integer
           # range fails the same way.
           case "$KEEP" in [1-9]|[1-9][0-9]) ;; *) echo "::warning::invalid keep=$KEEP, using 2"; KEEP=2 ;; esac
+          # Same whitelist, same reason: an unusable value must not silently
+          # become a cutoff of 0, which would treat every cache as idle.
+          case "$OPEN_PR_IDLE_DAYS" in
+            [1-9]|[1-9][0-9]) ;;
+            *) echo "::warning::invalid open_pr_idle_days=$OPEN_PR_IDLE_DAYS, using 3"; OPEN_PR_IDLE_DAYS=3 ;;
+          esac
+          open_pr_cutoff=$(date -u -d "$OPEN_PR_IDLE_DAYS days ago" +%s)
 
           gib() { awk -v b="${1:-0}" 'BEGIN { printf "%.1f", b / 1073741824 }'; }
+
+          # True when the cache has not been read since the cutoff, having
+          # re-read the timestamp immediately before acting on it.
+          #
+          # The inventory is minutes old by the time the loop reaches an entry,
+          # and a run that restored it in between resets the clock. Deciding on
+          # the stale copy would delete a cache that is back in use, and the
+          # whole point of this rule is that a read means a reader. An
+          # unparseable or missing timestamp is always a keep -- same direction
+          # as the PR lookup below, where an error must never free anything.
+          #
+          # The re-check runs in report mode too, even though it deletes
+          # nothing. Report mode exists to predict what delete mode will do, and
+          # the documented way to adopt a change here is to read the report
+          # first; a preview that lists candidates the real sweep would spare
+          # sends someone looking for bytes that were never going to be freed.
+          idle_since() {
+            local id="$1" accessed="$2" ref="$3" key="$4" cutoff="$5" seen
+            seen=$(date -u -d "$accessed" +%s 2>/dev/null || true)
+            [ -n "$seen" ] && [ "$seen" -lt "$cutoff" ] || return 1
+            seen=$(gh api -X GET "repos/$repo/actions/caches" \
+                     -f ref="$ref" -f key="$key" \
+                     -q ".actions_caches[] | select(.id == $id) | .last_accessed_at" \
+                     < /dev/null 2>/dev/null || true)
+            seen=$(date -u -d "$seen" +%s 2>/dev/null || true)
+            if [ -z "$seen" ] || [ "$seen" -ge "$cutoff" ]; then
+              echo "kept cache $id: read again since the inventory, or could not re-check"
+              return 1
+            fi
+            return 0
+          }
 
           # Report a failed inventory. Deleting nothing is the safe direction,
           # but silence means a broken janitor looks identical to a clean repo
           # and nothing notices until the ceiling does.
           if ! gh api --paginate "repos/$repo/actions/caches?per_page=100" \
-                 -q '.actions_caches[] | [.id, .created_at, .size_in_bytes, .ref, .version, .key] | @tsv' \
+                 -q '.actions_caches[] | [.id, .created_at, .size_in_bytes, .ref, .version, .key, .last_accessed_at] | @tsv' \
                  > "$all"; then
             echo "::warning::could not list caches for $repo; nothing pruned this run"
             exit 0
@@ -130,7 +173,7 @@ jobs:
           count=$(grep -c . "$all" || true)
           echo "$count caches, $(gib "$total") GiB, delete=$DELETE keep=$KEEP"
 
-          freed=0; deleted=0; stale_pr=0
+          freed=0; deleted=0; stale_pr=0; idle_open_pr=0
 
           # Pass 1: caches belonging to a PR that is no longer open. Unreachable
           # regardless of generation, so this runs before ranking and removes
@@ -138,7 +181,7 @@ jobs:
           # of their own (ref, version, prefix) group and shield each other.
           declare -A prstate=()
           : > "$live"
-          while IFS=$'\t' read -r id created size ref ver key; do
+          while IFS=$'\t' read -r id created size ref ver key accessed; do
             [ -z "${id:-}" ] && continue
             num=""
             case "$ref" in
@@ -152,12 +195,17 @@ jobs:
             fi
             if [ -n "$num" ]; then
               if [ -z "${prstate[$num]:-}" ]; then
-                # An error must not read as "closed". Default to open so a rate
-                # limit or a transient 5xx keeps the cache instead of freeing it.
-                prstate[$num]=$(gh api "repos/$repo/pulls/$num" -q '.state' < /dev/null 2>/dev/null || echo open)
-                [ -n "${prstate[$num]}" ] || prstate[$num]=open
+                # An error must not read as "closed". Anything that is not a
+                # state we recognise becomes `unknown`, which neither pass-1 rule
+                # matches, so a rate limit or a transient 5xx keeps the cache
+                # instead of freeing it. Previously this defaulted to `open`,
+                # which was the same outcome when `open` only ever meant keep;
+                # now that an open PR can also be pruned, the two have to differ.
+                state=$(gh api "repos/$repo/pulls/$num" -q '.state' < /dev/null 2>/dev/null || true)
+                case "$state" in open|closed) ;; *) state=unknown ;; esac
+                prstate[$num]=$state
               fi
-              if [ "${prstate[$num]}" != "open" ]; then
+              if [ "${prstate[$num]}" = "closed" ]; then
                 echo "stale PR #$num ($(gib "$size") GiB): $key"
                 stale_pr=$(( stale_pr + 1 ))
                 if [ "$DELETE" != "yes" ]; then
@@ -168,13 +216,37 @@ jobs:
                 fi
                 continue
               fi
+              # An OPEN PR whose cache nothing has read. PR state is not a
+              # liveness signal: lookup is scoped by ref, so only this PR's own
+              # runs can restore this entry, and if none of them has in
+              # OPEN_PR_IDLE_DAYS then it is holding budget for a reader that
+              # does not exist. Dependabot is the usual shape, since those PRs
+              # sit open for weeks or months in both repos, but the rule is
+              # deliberately by age and not by author: a stale human PR costs
+              # exactly the same, and a bot PR re-run this morning is live.
+              #
+              # This only brings the reclaim forward. GitHub already evicts an
+              # entry unread for 7 days; the budget is what cannot wait, since a
+              # week of overlap times every ref that ran exceeds it.
+              if [ "${prstate[$num]}" = "open" ] \
+                 && idle_since "$id" "$accessed" "$ref" "$key" "$open_pr_cutoff"; then
+                echo "idle open PR #$num ($(gib "$size") GiB, last read $accessed): $key"
+                idle_open_pr=$(( idle_open_pr + 1 ))
+                if [ "$DELETE" != "yes" ]; then
+                  freed=$(( freed + size )); deleted=$(( deleted + 1 )); continue
+                fi
+                if gh api -X DELETE "repos/$repo/actions/caches/$id" --silent < /dev/null 2>/dev/null; then
+                  freed=$(( freed + size )); deleted=$(( deleted + 1 ))
+                fi
+                continue
+              fi
             fi
-            printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$id" "$created" "$size" "$ref" "$ver" "$key" >> "$live"
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$id" "$created" "$size" "$ref" "$ver" "$key" "$accessed" >> "$live"
           done < "$all"
 
           # Pass 2: rank the survivors by generation within each family.
           : > "$grouped"
-          while IFS=$'\t' read -r id created size ref ver key; do
+          while IFS=$'\t' read -r id created size ref ver key accessed; do
             [ -z "${id:-}" ] && continue
             case "$key" in
               codeql-overlay-base-database-*)
@@ -230,6 +302,7 @@ jobs:
             echo "| kept per prefix | $KEEP |"
             echo "| caches total | $count |"
             echo "| closed-PR candidates | $stale_pr |"
+            echo "| idle open-PR candidates | $idle_open_pr |"
             echo "| superseded candidates | $superseded |"
             echo "| candidates $verb | $deleted |"
             echo "| freed | $(gib "$freed") GiB |"

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -16,13 +16,26 @@ name: Cache janitor
 #
 # Four families are pruned.
 #
-#   1. Caches on refs/pull/N/* whose PR is closed or merged. Lookup is scoped
-#      by ref and nothing but that PR's own runs can restore its merge ref, so
-#      once the PR is not open the entry is unreachable for good, and GitHub
-#      does not collect it on merge. Almost everything here already saves on
-#      main only, so this is a backstop rather than the main event. The PR state
-#      decides, not age: an open PR's caches are live no matter how old, and a
-#      lookup that errors keeps the cache.
+#   1. Caches on refs/pull/N/*, on two grounds. Lookup is scoped by ref and
+#      nothing but that PR's own runs can restore its merge ref, so once the PR
+#      is not open the entry is unreachable for good, and GitHub does not
+#      collect it on merge. Almost everything here already saves on main only,
+#      so that half is a backstop rather than the main event.
+#
+#      The second ground is idleness, and it applies while the PR is still OPEN:
+#      an entry no run has READ in open_pr_idle_days (default 3) is holding
+#      budget for a reader that does not exist, since only that PR's own runs
+#      could ever restore it. PR state alone is not a liveness signal -- a
+#      dependabot PR sits open for weeks here and its caches were never read
+#      once. This only brings forward a reclaim GitHub already performs at 7
+#      days idle; the budget is what cannot wait, since a week of overlap times
+#      every ref that ran exceeds it. The rule is by age and not by author: a
+#      stale human PR costs the same, and a bot PR re-run this morning is live.
+#
+#      Both grounds fail safe. last_accessed_at is re-read immediately before
+#      acting, so a run that restored the entry after the inventory keeps it,
+#      and an errored PR lookup, an unparseable timestamp or a failed re-check
+#      all keep the cache.
 #
 #   2. Superseded generations of families whose keys embed a build identity:
 #        codeql-overlay-base-database-*  keys embed commit SHA + run id
@@ -54,7 +67,8 @@ name: Cache janitor
 # still hit an older generation exactly. The pip and uv caches are the same
 # shape. keep is the dial, and it is set for hit rate, not for headroom: the budget exists to be
 # spent, so a generation that can still answer something stays. What goes is what
-# can answer nothing -- unreachable refs, and generations past keep.
+# can answer nothing -- unreachable refs, generations past keep, and entries on an
+# open PR that nothing has read in open_pr_idle_days.
 #
 # Everything else is left alone. The hf-* / *-gguf-* model caches use exact keys,
 # so an entry that looks superseded is the only one its key will ever match and


### PR DESCRIPTION
`cache-janitor.yml` pass 1 frees a cache when its pull request is no longer open and keeps it otherwise. That treats PR state as a liveness signal, which it is not. Lookup is scoped by ref, so only that PR's own runs can ever restore the entry. If none of them has in days, it is holding budget for a reader that does not exist, and whether the PR is still open says nothing about that either way.

The zoo shows the failure concretely: 6.18 GiB on `refs/pull/929/merge`, 30.9% of its 20 GiB ceiling, three of the four entries never read once since they were written on 2026-08-26. PR #929 is open, so the sweep spares them and reported `pruned 0 caches, 0.0 GiB` against a 16.9 GiB total that had already tripped the 80% warning. Dependabot PRs are the usual shape, staying open for weeks or months in both repos.

## The janitor could not see idleness at all

The inventory selected `id, created_at, size_in_bytes, ref, version, key`. `last_accessed_at` is returned by the API and was discarded, and `created_at` was used purely as a sort key for generation ranking, never against a clock. So there was no way to express "nothing has read this".

It now also selects `last_accessed_at`, which is the field GitHub's own eviction policy runs on.

## The rule

Prune a cache on an **open** PR's ref once it has not been read for `open_pr_idle_days`, default 3.

By age, not by author. A stale human PR costs exactly the same, and a bot PR whose CI ran this morning is genuinely live, so an author check would add API calls and failure modes without improving the decision.

This only brings the reclaim forward rather than freeing anything GitHub would keep. An entry unread for 7 days is evicted regardless; the budget is what cannot wait, since a week of overlap times every ref that ran is larger than it.

## Three guards against freeing something in use

- **`last_accessed_at` is re-read immediately before acting.** The inventory is minutes old by the time the loop reaches an entry, and a run that restored it in between resets the clock. Deciding on the stale copy would delete a cache that is back in use, which is exactly what this rule claims not to do.
- **The re-check runs in report mode too.** Report mode exists to predict what delete mode does, and the documented way to adopt a change here is to read the report first. A preview listing candidates the real sweep would spare sends someone looking for bytes that were never going to be freed.
- **PR state is now `open`, `closed` or `unknown`.** It previously defaulted to `open` on a lookup failure, which was the same outcome as unknown while `open` only ever meant keep. Now that an open PR can also be pruned, the two have to differ. An API error, an unparseable timestamp, or a failed revalidation all still keep the cache.

`open_pr_idle_days` is validated with the same `[1-9]|[1-9][0-9]` whitelist as `keep`, and for the same reason recorded there: an unusable value must not silently become a cutoff of 0, which would treat every cache as idle.

## Verification

Both repos get the byte-identical change, applied by one patch script rather than hand-edited twice.

Both janitors' embedded scripts were extracted and run against stubbed inventories with a stub `gh`, in report and delete mode, covering:

| case | expected |
| --- | --- |
| open PR, idle 4d | pruned |
| open PR, idle 2d | kept |
| open PR, lookup fails | kept |
| closed PR, read 0h ago | pruned regardless of age |
| open PR idle 4d, read again between inventory and delete | kept |
| open PR idle 4d, revalidation itself fails | kept |
| idle 500h cache on `refs/heads/main` | untouched by the PR rule |
| three `pip-v2-*` generations | oldest pruned, newest two kept |
| open PR idle 4d, two generations | both pruned by pass 1, not shielded by `keep` |

18 assertions, all passing on both files, with report and delete agreeing on every case. The harness lives outside the repo; say the word if it should be checked in.

Roll out by running `workflow_dispatch` in **report** mode first and diffing the candidate list against `gh api /repos/<repo>/actions/caches` before letting the schedule delete.

## Note for the zoo

The #929 residue expires on its own at approximately 2026-09-02T09:36Z, and the wider `setup-python-*` family (10 entries, 13.07 GiB, 77.5% of zoo usage) within about 33 hours of that measurement, since nothing writes that key scheme any more. Run report mode before then if you want to see it in the candidate list. That timing is why this PR adds no special case for retired key schemes: it would reclaim those bytes for roughly a day and then be dead code, and the janitor header already documents leaving that family to the 7-day timer.