### PR TITLE
Studio: line up On Device rows, and list partial downloads

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -504,6 +504,9 @@ export interface CachedGgufRepo {
    * for older-backend compatibility. */
   has_variant_state?: boolean;
   partial?: boolean;
+  /** Whether that partial can be continued byte for byte. False on a GGUF repo row by design:
+   *  transport is per quant, so the repo cannot answer for all of them. */
+  partial_resumable?: boolean;
   capabilities?: CachedRepoCapabilities | null;
 }
 
@@ -643,6 +646,8 @@ export interface CachedModelRepo {
   audio_type?: string | null;
   /** True when the snapshot is incomplete (a cancelled/partial download): such a repo must not count as downloaded, or a click re-downloads the full weights. */
   partial?: boolean;
+  /** Whether that partial can be continued byte for byte, rather than restarting its file. */
+  partial_resumable?: boolean;
   /** True for a diffusion repo with no model_index.json: a single-file checkpoint loadable only via from_single_file, so task pickers must not offer it as a pipeline load unless the curated catalog carries its artifact. */
   single_file?: boolean;
   /** True for an sd.cpp companion mirror (VAE / text encoders, no denoiser): listed so it can be seen and deleted, never offered as a load. */

--- a/studio/frontend/src/features/hub/catalog/models-catalog-rows.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-catalog-rows.tsx
@@ -796,21 +796,7 @@ export const InventoryRow = memo(function InventoryRow({
               );
               // Deleted repos can't stay pinned: drop the repo pin and any of
               // its per-quant pins so stale rows don't linger up top.
-              const { pinned, togglePinned: toggle } =
-                usePinnedModelsStore.getState();
-              for (const key of pinned) {
-                if (
-                  key === pinKey(deletableRepoId) ||
-                  key.startsWith(`${deletableRepoId}::`)
-                ) {
-                  toggle(
-                    deletableRepoId,
-                    key.includes("::")
-                      ? key.slice(key.indexOf("::") + 2)
-                      : undefined,
-                  );
-                }
-              }
+              usePinnedModelsStore.getState().unpinRepo(deletableRepoId);
             }
           },
           onDeleted: onChange,

--- a/studio/frontend/src/features/hub/index.ts
+++ b/studio/frontend/src/features/hub/index.ts
@@ -80,6 +80,7 @@ export {
   normalizeModelFormat,
   normalizeRuntime,
   normalizeTimestamp,
+  partialSetFromRows,
   removeScanFolder,
   resolveInventoryResource,
   useDeviceInventorySources,

--- a/studio/frontend/src/features/hub/inventory/index.ts
+++ b/studio/frontend/src/features/hub/inventory/index.ts
@@ -62,6 +62,7 @@ export {
 export {
   dedupeSameSourceHubCacheRows,
   findCompleteHfCacheLocalRow,
+  partialSetFromRows,
 } from "./inventory-dedupe";
 export {
   fetchInventorySource,

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -542,7 +542,12 @@ function ModelSelectorContent({
       className={cn(
         "unsloth-model-selector-menu menu-soft-surface ring-0 max-w-[calc(100vw-1rem)] min-w-0 gap-0",
         visibleConfigTarget
-          ? "max-h-[var(--radix-popover-content-available-height)] w-[min(468px,calc(100vw-1rem))] overflow-y-auto px-4 pt-4 pb-4"
+          ? // The surface stays the surface: it clips to its own radius and never scrolls. Making
+            // the rounded box the scroller put the scrollbar inside it, running the full height
+            // and straight through the top and bottom right corners, which squared them off on
+            // any machine set to show scrollbars always. The padding moves in with the scroller so
+            // the bar sits beside the content instead of on the edge.
+            "max-h-[var(--radix-popover-content-available-height)] w-[min(468px,calc(100vw-1rem))] overflow-hidden p-0"
           : cn(
               "pt-4 pb-0 pl-4",
               // Sized so the left-packed row keeps uniform gaps and the last dropdown's right gap matches the
@@ -564,7 +569,8 @@ function ModelSelectorContent({
         disableHoverableContent={true}
       >
         {visibleConfigTarget ? (
-          <ModelConfigPage
+          <div className="min-h-0 w-full overflow-y-auto px-4 pt-4 pb-4">
+            <ModelConfigPage
             key={`${visibleConfigTarget.id}::${visibleConfigTarget.ggufVariant ?? ""}`}
             target={visibleConfigTarget}
             onBack={() => setConfigTarget(null)}
@@ -597,7 +603,8 @@ function ModelSelectorContent({
                 ? (selectedConfig ?? null)
                 : null
             }
-          />
+            />
+          </div>
         ) : (
           <>
             <HubModelPicker

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -948,9 +948,10 @@ const META_COLUMN = {
   badge: "min-w-min min-[560px]:w-[24px]",
   // One glyph plus the disk mark (18 + 4 + 14).
   badgeMid: "min-w-min min-[560px]:w-[36px]",
-  // On Device draws the vision badge and no disk mark: 26px is that badge measured, so rows with
-  // and without one still line up. One slot sized for both lists left ~44px empty on every row.
-  badgeDevice: "min-w-min min-[560px]:w-[26px]",
+  // On Device draws the vision badge (26px) and, since partials are listed, the partial mark
+  // (14px) beside it. 44px is that pair with its gap: reserving only the badge let a row drawing
+  // both grow past the slot and carry its quant chip 18px left of every other row.
+  badgeDevice: "min-w-min min-[560px]:w-[44px]",
   // Hub draws the disk mark and no vision badge (18+4+14). A second glyph grows it via min-w-min.
   badgeWide: "min-w-min min-[560px]:w-[36px]",
   // The fit mark (Hub rows), one 18px glyph.
@@ -5650,7 +5651,10 @@ export function HubModelPicker({
                 onConfigure(c.repo_id, {
                   source: "hub",
                   isLora: false,
-                  loadId: c.load_id,
+                  // Run spreads this meta straight back into a select, so it carries the
+                  // row's rule: no load identity for a snapshot that is not all there.
+                  // The config page keys its settings off the repo id, not this field.
+                  loadId: isPartial ? undefined : c.load_id,
                   isDownloaded: !isPartial,
                   isGguf: false,
                   pipelineTag: c.task ?? null,

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -645,7 +645,7 @@ function DownloadedBadge() {
  *  these with the same warning dot, and the row it sits on selects with isDownloaded: false so
  *  the click opens the download instead of handing incomplete weights to the runtime. Same box
  *  as DownloadedBadge, since the two are alternatives -- a row is complete or it is not. */
-function PartialBadge() {
+function PartialBadge({ resumable }: { resumable?: boolean }) {
   return (
     <Tooltip delayDuration={0}>
       <TooltipTrigger asChild={true}>
@@ -660,7 +660,9 @@ function PartialBadge() {
         </span>
       </TooltipTrigger>
       <TooltipContent side="top" className="tooltip-compact">
-        Partial download. Select to resume, or delete it
+        {resumable
+          ? "Partial download. Select to resume it, or delete it."
+          : "Partial download. Select to continue it, or delete it. The interrupted file starts over."}
       </TooltipContent>
     </Tooltip>
   );
@@ -1002,6 +1004,7 @@ function ModelRow({
   hideOwner,
   downloaded,
   partial,
+  partialResumable,
   showVision,
   quantChip,
   tags,
@@ -1035,6 +1038,9 @@ function ModelRow({
   /** Mark a row whose snapshot is incomplete. Mutually exclusive with `downloaded`: the bytes
    *  are there or they are not, and the caller routes the click to the download either way. */
   partial?: boolean;
+  /** Whether that partial continues byte for byte. Undefined reads as "no", which is what keeps
+   *  the mark from promising a resume the transport cannot deliver. */
+  partialResumable?: boolean;
   /** Show a Vision badge on the name (On Device, read from GGUF metadata). */
   showVision?: boolean;
   /** Grey chip beside the name, for rows that load one specific quant. */
@@ -1223,7 +1229,7 @@ function ModelRow({
             >
               {showCaps && <CapabilityIcons caps={caps} />}
               {showVision && <VisionBadge />}
-              {partial ? <PartialBadge /> : null}
+              {partial ? <PartialBadge resumable={partialResumable} /> : null}
               {downloaded && !partial && !loaded ? <DownloadedBadge /> : null}
             </span>
           ) : (
@@ -1238,7 +1244,7 @@ function ModelRow({
                   dotClassName="size-[5px]"
                 />
               )}
-              {partial ? <PartialBadge /> : null}
+              {partial ? <PartialBadge resumable={partialResumable} /> : null}
               {downloaded && !partial && !loaded ? <DownloadedBadge /> : null}
             </>
           )}
@@ -3225,6 +3231,18 @@ export function HubModelPicker({
   const partialSet = useMemo(
     () =>
       partialSetFromRows([...cachedGguf, ...cachedModels], (c) => c.repo_id),
+    [cachedGguf, cachedModels],
+  );
+
+  // Which of those continue byte for byte, so a Hub row's mark promises what the On Device row's
+  // does. An id partialSet dropped never draws the mark, so a spare entry here costs nothing.
+  const partialResumableSet = useMemo(
+    () =>
+      new Set(
+        [...cachedGguf, ...cachedModels]
+          .filter((c) => c.partial === true && c.partial_resumable === true)
+          .map((c) => c.repo_id.toLowerCase()),
+      ),
     [cachedGguf, cachedModels],
   );
 
@@ -5385,6 +5403,10 @@ export function HubModelPicker({
             meta={`GGUF · ${formatBytes(variant.size_bytes)}`}
             quantChip={ggufQuantChipLabel(variant.quant)}
             partial={isPartial}
+            // No verdict to pass, so the mark takes its cautious wording:
+            // /api/models/gguf-variants builds models.models.GgufVariantDetail, which carries no
+            // partial_resumable. A sole-quant row is never partial anyway -- readSoleQuant only
+            // picks a clean quant -- so this mark is defensive to begin with.
             // Only for models the llama.cpp path actually loads. The Images and
             // Video pickers deliberately keep diffusion GGUFs listed, and those
             // run on the diffusion planner with different runtime buffers, on a
@@ -5489,6 +5511,7 @@ export function HubModelPicker({
               showVision={c.has_vision ?? visionByRepo[c.repo_id]}
               alignMeta="device"
               partial={isPartialRepo}
+              partialResumable={c.partial_resumable}
               selected={isSelected}
               loaded={isRuntimeLoadedModel(
                 loadedModelId,
@@ -5617,6 +5640,7 @@ export function HubModelPicker({
             selected={isSelected}
             alignMeta="device"
             partial={isPartial}
+            partialResumable={c.partial_resumable}
             loaded={isRuntimeLoadedModel(
               loadedModelId,
               activeGgufVariant,
@@ -6790,6 +6814,9 @@ export function HubModelPicker({
                               hideOwner={isUnslothOwned(id)}
                               downloaded={downloadedSet.has(id.toLowerCase())}
                               partial={partialSet.has(id.toLowerCase())}
+                              partialResumable={partialResumableSet.has(
+                                id.toLowerCase(),
+                              )}
                               capabilities={capsById.get(id)}
                               meta={
                                 info?.meta ??
@@ -6896,6 +6923,9 @@ export function HubModelPicker({
                             showSize={hubRowsShowSize}
                             downloaded={downloadedSet.has(id.toLowerCase())}
                             partial={partialSet.has(id.toLowerCase())}
+                            partialResumable={partialResumableSet.has(
+                              id.toLowerCase(),
+                            )}
                             capabilities={capsById.get(id)}
                             // Same meta the unfiltered Recommended row shows, so a
                             // model does not lose its size chip just because it was
@@ -7015,6 +7045,9 @@ export function HubModelPicker({
                               // half-downloaded is marked here too. Without it the row reads
                               // as never fetched while the click resumes a download.
                               partial={partialSet.has(id.toLowerCase())}
+                              partialResumable={partialResumableSet.has(
+                                id.toLowerCase(),
+                              )}
                               capabilities={capsById.get(id)}
                               meta={
                                 isSearchGguf

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -662,7 +662,7 @@ function PartialBadge({ resumable }: { resumable?: boolean }) {
       <TooltipContent side="top" className="tooltip-compact">
         {resumable
           ? "Partial download. Select to resume it, or delete it."
-          : "Partial download. Select to continue it, or delete it. The interrupted file starts over."}
+          : "Partial download. Select to continue it, or delete it."}
       </TooltipContent>
     </Tooltip>
   );
@@ -4358,6 +4358,7 @@ export function HubModelPicker({
   // repos pin whole and leave the Unsloth / Other models groups.
   const pinnedIds = usePinnedModelsStore((s) => s.pinned);
   const togglePinned = usePinnedModelsStore((s) => s.togglePinned);
+  const unpinRepo = usePinnedModelsStore((s) => s.unpinRepo);
   const pinnedSet = useMemo(() => new Set(pinnedIds), [pinnedIds]);
 
   // Candidate pins whose repo still exists in the cache. Per-quant validation
@@ -5565,9 +5566,8 @@ export function HubModelPicker({
                       hfToken || undefined,
                       c.cache_path || undefined,
                     );
-                    if (pinnedSet.has(pinKey(c.repo_id))) {
-                      togglePinned(c.repo_id);
-                    }
+                    // Every quant goes with the repo, so every quant pin goes too.
+                    unpinRepo(c.repo_id);
                   },
                   onDeleted: refreshCachedLists,
                 }}
@@ -5717,9 +5717,9 @@ export function HubModelPicker({
                   hfToken || undefined,
                   c.cache_path || undefined,
                 );
-                if (pinnedSet.has(pinKey(c.repo_id))) {
-                  togglePinned(c.repo_id);
-                }
+                // Repo-wide, so the quant pins go too: one id can hold a GGUF copy as well,
+                // and this delete takes that with it.
+                unpinRepo(c.repo_id);
               },
               onDeleted: refreshCachedLists,
             }}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -660,7 +660,7 @@ function PartialBadge() {
         </span>
       </TooltipTrigger>
       <TooltipContent side="top" className="tooltip-compact">
-        Partial download &mdash; select to resume, or delete it
+        Partial download. Select to resume, or delete it
       </TooltipContent>
     </Tooltip>
   );
@@ -5357,7 +5357,10 @@ export function HubModelPicker({
     const selectMeta: ModelSelectorChangeMeta = {
       source: "hub",
       isLora: false,
-      loadId: c.load_id,
+      // Only for a complete snapshot, as the variant select already does. A loadId names a
+      // revision on disk, and the Audio route carries no isDownloaded field, so a forwarded
+      // one is read there as proof the weights are present.
+      loadId: isPartial ? undefined : c.load_id,
       ggufVariant: variant.quant,
       ggufFilename: variant.filename,
       isDownloaded: !isPartial,
@@ -5514,15 +5517,18 @@ export function HubModelPicker({
                 ariaLabel={`More options for ${c.repo_id}`}
                 cachePath={{ repoId: c.repo_id }}
                 del={{
-                  title: "Delete partial download?",
+                  title: "Delete cached model?",
                   impact: { repoId: c.repo_id },
+                  // Repo-wide, like every other repo-level delete: no variant is passed, and
+                  // one repo id can also hold a complete copy in another format. Saying
+                  // "the partial download" would name a smaller scope than the one that runs.
                   description: (
                     <>
-                      This will remove the partly downloaded{" "}
+                      This will remove{" "}
                       <span className="font-medium text-foreground">
                         {c.repo_id}
                       </span>{" "}
-                      from disk. It is incomplete and cannot be loaded; you can
+                      and everything downloaded under it from disk. You can
                       download it again later.
                     </>
                   ),
@@ -5621,7 +5627,10 @@ export function HubModelPicker({
               onSelect(c.repo_id, {
                 source: "hub",
                 isLora: false,
-                loadId: c.load_id,
+                // Dropped on a torn snapshot: the Audio route has no isDownloaded field and
+                // reads a forwarded loadId as proof the weights are there, so a TTS pick
+                // routed with one skips the download it needs.
+                loadId: isPartial ? undefined : c.load_id,
                 isDownloaded: !isPartial,
                 pipelineTag: c.task ?? null,
                 audioType: c.audio_type ?? null,
@@ -6998,6 +7007,10 @@ export function HubModelPicker({
                               hubUrl={hubRepoUrl(id)}
                               alignMeta="hub"
                               showSize={hubRowsShowSize}
+                              // Typed results are Hub rows like any other, so a repo left
+                              // half-downloaded is marked here too. Without it the row reads
+                              // as never fetched while the click resumes a download.
+                              partial={partialSet.has(id.toLowerCase())}
                               capabilities={capsById.get(id)}
                               meta={
                                 isSearchGguf

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -2447,11 +2447,16 @@ let _scanFoldersCache: ScanFolderInfo[] = [];
 
 /** True when any on-device model (downloaded GGUF, cached repo, LM Studio, or
  * custom-folder model) is known. Reads the module caches, which persist across
- * popover mounts, so the selector can default to the On Device tab. */
+ * popover mounts, so the selector can default to the On Device tab.
+ *
+ * Partials do not count. The cached lists carry them so they can be seen and
+ * removed, but a machine whose only cached row is a cancelled download has
+ * nothing to load, and opening on that tab shows one unusable row instead of
+ * the list that would get the user a model. */
 export function hasDownloadedModels(): boolean {
   return (
-    _cachedGgufCache.length > 0 ||
-    _cachedModelsCache.length > 0 ||
+    _cachedGgufCache.some((c) => !c.partial) ||
+    _cachedModelsCache.some((c) => !c.partial) ||
     _lmStudioCache.length > 0 ||
     _localDirCache.length > 0 ||
     _customFolderCache.length > 0

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -2151,6 +2151,10 @@ function GgufVariantExpander({
                     </span>
                   ) : null}
                 </>
+              ) : v.partial === true ? (
+                <span className="ml-1.5 text-ui-9 font-sans font-medium text-amber-700 dark:text-amber-300">
+                  partial
+                </span>
               ) : isRecommended ? (
                 <span className="ml-1.5 text-ui-9 font-sans font-medium text-primary/70">
                   recommended
@@ -2224,7 +2228,7 @@ function GgufVariantExpander({
                 }
               />
             )}
-            {v.downloaded &&
+            {(v.downloaded || v.partial === true) &&
               (allowPin ||
                 (v.update_available && onUpdateVariant) ||
                 onDeleteVariant ||
@@ -2236,7 +2240,7 @@ function GgufVariantExpander({
                     isLocalPath ? undefined : { repoId, variant: v.quant }
                   }
                   pin={
-                    allowPin
+                    allowPin && v.downloaded
                       ? {
                           pinned: pinnedKeys.includes(pinKey(repoId, v.quant)),
                           pinLabel: "Pin to top",

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3197,12 +3197,31 @@ export function HubModelPicker({
 
   // Hide downloaded models from the recommended list. Case-insensitive
   // since the HF cache lowercases repo IDs.
-  const downloadedSet = useMemo(() => {
-    const s = new Set<string>();
-    for (const c of cachedGguf) s.add(c.repo_id.toLowerCase());
-    for (const c of cachedModels) s.add(c.repo_id.toLowerCase());
-    return s;
-  }, [cachedGguf, cachedModels]);
+  // Complete downloads only. This set answers "can this id load right now": it decides
+  // isDownloaded on a search pick, which is what skips download staging, and it paints the
+  // on-disk dot. A partial is on disk but not loadable, so admitting one here would send a
+  // torn snapshot straight to the loader from the Hub and Recommended lists.
+  const downloadedSet = useMemo(
+    () =>
+      new Set(
+        [...cachedGguf, ...cachedModels]
+          .filter((c) => !c.partial)
+          .map((c) => c.repo_id.toLowerCase()),
+      ),
+    [cachedGguf, cachedModels],
+  );
+
+  // The torn ones, kept apart so a Hub row can mark a partial rather than show it as complete
+  // or as absent. Same split the Hub page keeps.
+  const partialSet = useMemo(
+    () =>
+      new Set(
+        [...cachedGguf, ...cachedModels]
+          .filter((c) => c.partial === true)
+          .map((c) => c.repo_id.toLowerCase()),
+      ),
+    [cachedGguf, cachedModels],
+  );
 
   const chatOnly = usePlatformStore((s) => s.isChatOnly());
   const deviceType = usePlatformStore((s) => s.deviceType);
@@ -6753,6 +6772,7 @@ export function HubModelPicker({
                               // unsloth upload, and two publishers would collide.
                               hideOwner={isUnslothOwned(id)}
                               downloaded={downloadedSet.has(id.toLowerCase())}
+                              partial={partialSet.has(id.toLowerCase())}
                               capabilities={capsById.get(id)}
                               meta={
                                 info?.meta ??
@@ -6858,6 +6878,7 @@ export function HubModelPicker({
                             alignMeta="hub"
                             showSize={hubRowsShowSize}
                             downloaded={downloadedSet.has(id.toLowerCase())}
+                            partial={partialSet.has(id.toLowerCase())}
                             capabilities={capsById.get(id)}
                             // Same meta the unfiltered Recommended row shows, so a
                             // model does not lose its size chip just because it was

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -573,7 +573,12 @@ function VisionBadge() {
 /** Parameter count chip ("27B"). */
 function ParamChip({ label }: { label: string }) {
   return (
-    <span className="whitespace-nowrap rounded-md border border-border/60 px-1.5 py-px text-ui-10 font-medium text-muted-foreground tabular-nums">
+    // h-[18px], the height every other chip in the row band already pins (quant, vision, the disk
+    // mark, the Loaded tag). py-px left this one sized by its line box instead, which is the only
+    // height here that scales with --ui-font-scale: at 1.0 it stood 1px PROUDER than the quant and
+    // vision chips beside it and at 0.8125 it sat 1.8px shorter, so the row only looked level at
+    // the one scale where the two happened to cross. A shared height is level at every scale.
+    <span className="inline-flex h-[18px] shrink-0 items-center whitespace-nowrap rounded-md border border-border/60 px-1.5 text-ui-10 font-medium text-muted-foreground tabular-nums">
       {label}
     </span>
   );
@@ -630,6 +635,31 @@ function DownloadedBadge() {
       </TooltipTrigger>
       <TooltipContent side="top" className="tooltip-compact">
         On device
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** A cancelled or interrupted download: some bytes on disk, not enough to load. The Hub marks
+ *  these with the same warning dot, and the row it sits on selects with isDownloaded: false so
+ *  the click opens the download instead of handing incomplete weights to the runtime. Same box
+ *  as DownloadedBadge, since the two are alternatives -- a row is complete or it is not. */
+function PartialBadge() {
+  return (
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild={true}>
+        <span
+          aria-label="Partial download"
+          className="flex h-[18px] w-[14px] shrink-0 items-center justify-center"
+        >
+          <span
+            aria-hidden="true"
+            className="size-[5px] rounded-full bg-status-warning"
+          />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="tooltip-compact">
+        Partial download &mdash; select to resume, or delete it
       </TooltipContent>
     </Tooltip>
   );
@@ -924,10 +954,14 @@ const META_COLUMN = {
   badgeWide: "min-w-min min-[560px]:w-[36px]",
   // The fit mark (Hub rows), one 18px glyph.
   vram: "min-w-min min-[560px]:w-[18px]",
-  // Device rows hug the chip. A column sized for "235B" spends 6.1px in front of a "30B", and that
-  // leftover IS the gap to the modality mark; -ml-0.5 against the cluster's gap-1 makes it 2px. In
-  // exchange a wider label pulls that row's name and quant chip left. Hub keeps its "2779.5B".
-  param: "min-w-min -ml-0.5",
+  // Device rows reserve the slot rather than hug the chip. This is the last variable column on the
+  // right, so hugging it let each row's meta cluster set its own width: a "1B" row, and more so a
+  // row with no param at all, gave its name group the leftover and carried its quant chip that much
+  // further right, leaving the quant column ragged down the list. 4.4em is the widest these lists
+  // draw, measured at text-ui-10 -- "235B" is 38.4px, a 5-char "0.35B" 40.9px -- so nothing routine
+  // trips min-w-min and shifts the row back out of line. The slack now sits in front of the chip,
+  // as its gap to the modality mark. Hub keeps its own width for "2779.5B".
+  param: "min-w-min min-[560px]:w-[4.4em]",
   paramWide: "min-w-min min-[560px]:w-[5.2em]",
   // formatBytes writes no space ("536MB"), so the widest this holds is 29.5px, not the ~40px a
   // spaced "536 MB" needs. The surplus sat between the parameter chip and the size.
@@ -941,6 +975,13 @@ const META_COLUMN = {
 // the gutter stays open so nothing moves as they appear.
 const ROW_ACTIONS_CLASS =
   "mr-0.5 flex w-[38px] shrink-0 items-center justify-end -space-x-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 has-[[data-state=open]]:opacity-100 [@media(hover:none)]:opacity-100";
+
+// Partial rows keep their buttons on screen. Everywhere else the gutter hides until the row is
+// hovered because the row itself is the action -- click it and the model loads, so the menu is a
+// secondary path. A partial cannot be loaded at all: the menu IS the row's only affordance, and
+// hiding the one control that reaches a stalled multi-GB download behind a hover reads as the
+// download having no controls at all.
+const ROW_ACTIONS_PINNED_CLASS = cn(ROW_ACTIONS_CLASS, "opacity-100");
 
 function ModelRow({
   label,
@@ -958,6 +999,7 @@ function ModelRow({
   capabilities,
   hideOwner,
   downloaded,
+  partial,
   showVision,
   quantChip,
   tags,
@@ -988,6 +1030,9 @@ function ModelRow({
   hideOwner?: boolean;
   /** Mark a row already on disk (shown in Recommended instead of being hidden). */
   downloaded?: boolean;
+  /** Mark a row whose snapshot is incomplete. Mutually exclusive with `downloaded`: the bytes
+   *  are there or they are not, and the caller routes the click to the download either way. */
+  partial?: boolean;
   /** Show a Vision badge on the name (On Device, read from GGUF metadata). */
   showVision?: boolean;
   /** Grey chip beside the name, for rows that load one specific quant. */
@@ -1127,17 +1172,7 @@ function ModelRow({
               dotClassName="size-[5px]"
             />
           )}
-          {alignMeta === "device" ? (
-            <span
-              className={cn(
-                // ml-0.5: the chip carries px-1 of its own, so 2px still leaves 6px of air.
-                "ml-0.5 flex shrink-0 items-center self-center text-ui-9",
-                META_COLUMN.quant,
-              )}
-            >
-              {quantChip ? <QuantChip label={quantChip} /> : null}
-            </span>
-          ) : quantChip ? (
+          {alignMeta !== "device" && quantChip ? (
             <span className="ml-2 shrink-0 rounded-md bg-black/[0.06] px-1.5 py-px font-mono text-ui-10 text-muted-foreground dark:bg-white/[0.1]">
               {quantChip}
             </span>
@@ -1156,6 +1191,24 @@ function ModelRow({
             aligned ? "gap-1" : "gap-1.5",
           )}
         >
+          {/* The quant chip sits in the meta cluster, not at the end of the name, so one
+              items-center rule lines it up with the vision mark, the parameter chip, the size and
+              the row's buttons. Inside the name group it was centred against THAT box instead --
+              a baseline box sized by the name's own line height -- so it only agreed with the rest
+              of the row for as long as the two boxes happened to share a centre. */}
+          {alignMeta === "device" ? (
+            <span
+              className={cn(
+                // justify-end: the slot is sized for the longest quant, so left-aligning ended a
+                // "Q8_0" and a "UD-Q4_K_XL" at different x even once the slot itself stopped
+                // moving. Flush right is what makes the chips read as one column.
+                "flex shrink-0 items-center justify-end text-ui-9",
+                META_COLUMN.quant,
+              )}
+            >
+              {quantChip ? <QuantChip label={quantChip} /> : null}
+            </span>
+          ) : null}
           {/* Capabilities, vision and the Hub lists' "on disk" mark share one
               column; two of them widen the slot rather than overlap. */}
           {aligned ? (
@@ -1168,7 +1221,8 @@ function ModelRow({
             >
               {showCaps && <CapabilityIcons caps={caps} />}
               {showVision && <VisionBadge />}
-              {downloaded && !loaded ? <DownloadedBadge /> : null}
+              {partial ? <PartialBadge /> : null}
+              {downloaded && !partial && !loaded ? <DownloadedBadge /> : null}
             </span>
           ) : (
             <>
@@ -1182,7 +1236,8 @@ function ModelRow({
                   dotClassName="size-[5px]"
                 />
               )}
-              {downloaded && !loaded ? <DownloadedBadge /> : null}
+              {partial ? <PartialBadge /> : null}
+              {downloaded && !partial && !loaded ? <DownloadedBadge /> : null}
             </>
           )}
           {alignMeta === "hub" ? (
@@ -1200,8 +1255,16 @@ function ModelRow({
           {aligned ? (
             <span
               className={cn(
-                "flex shrink-0 justify-end text-ui-10",
-                alignMeta === "hub" ? META_COLUMN.paramWide : META_COLUMN.param,
+                // Device leads the chip, Hub trails it. Both columns are fixed, so the choice is
+                // only where the column's slack falls: trailing it put the slack in FRONT of the
+                // chip, where it read as part of the gap to the modality mark and grew or shrank
+                // with the label -- 6.9px after a "217B", 19px after a "1B". Leading the chip
+                // leaves that gap as the cluster's own gap-1, the same 4px the quant chip keeps
+                // to the same mark, and the slack falls back toward the size instead.
+                "flex shrink-0 items-center text-ui-10",
+                alignMeta === "hub"
+                  ? cn("justify-end", META_COLUMN.paramWide)
+                  : cn("justify-start", META_COLUMN.param),
               )}
             >
               {paramLabel ? <ParamChip label={paramLabel} /> : null}
@@ -3797,8 +3860,10 @@ export function HubModelPicker({
       sortCachedRepos(
         cachedModels.filter(
           (c) =>
-            // A partially-downloaded snapshot is not on-device: listing it as loadable errors or triggers a silent multi-GB re-fetch.
-            !c.partial &&
+            // Partial snapshots are listed, not loaded. Dropping them here hid a cancelled
+            // multi-GB download from the only list that could delete it; the row instead carries
+            // a partial mark and selects with isDownloaded: false, so the click opens the
+            // download rather than erroring or triggering a silent re-fetch.
             passesTaskGate(
               c.task,
               c.repo_id,
@@ -5258,13 +5323,17 @@ export function HubModelPicker({
     const isSelected = rowState.selected;
     const expectedBytes = ggufVariantExpectedBytes(variant);
     const isPinned = pinnedSet.has(pinKey(c.repo_id, variant.quant));
+    // A repo only flags partial once no quant is clean, so a sole-quant row should never BE one.
+    // Carried anyway: if that ever stops holding, the row states what is on disk instead of
+    // handing a torn file to the loader.
+    const isPartial = c.partial === true;
     const selectMeta: ModelSelectorChangeMeta = {
       source: "hub",
       isLora: false,
       loadId: c.load_id,
       ggufVariant: variant.quant,
       ggufFilename: variant.filename,
-      isDownloaded: true,
+      isDownloaded: !isPartial,
       expectedBytes,
       isGguf: true,
       pipelineTag: c.task ?? null,
@@ -5284,6 +5353,7 @@ export function HubModelPicker({
             )}
             meta={`GGUF · ${formatBytes(variant.size_bytes)}`}
             quantChip={ggufQuantChipLabel(variant.quant)}
+            partial={isPartial}
             // Only for models the llama.cpp path actually loads. The Images and
             // Video pickers deliberately keep diffusion GGUFs listed, and those
             // run on the diffusion planner with different runtime buffers, on a
@@ -5375,6 +5445,8 @@ export function HubModelPicker({
       autoExpand: expandQuantizations && !reopenedGguf.has(c.repo_id),
       soleQuantsPending: soleQuants.pending.has(c.repo_id),
     });
+    // No quant of this repo is clean, so nothing inside the expander can carry the row's actions.
+    const isPartialRepo = c.partial === true;
     return (
       <div key={c.repo_id}>
         <div className={downloadedRowShellClassName(isSelected)}>
@@ -5385,6 +5457,7 @@ export function HubModelPicker({
               meta="GGUF"
               showVision={c.has_vision ?? visionByRepo[c.repo_id]}
               alignMeta="device"
+              partial={isPartialRepo}
               selected={isSelected}
               loaded={isRuntimeLoadedModel(
                 loadedModelId,
@@ -5403,8 +5476,49 @@ export function HubModelPicker({
               className={downloadedRowButtonClassName}
             />
           </div>
-          {/* Stands in for the other rows' buttons, so the tags line up. */}
-          <span aria-hidden="true" className={cn(ROW_ACTIONS_CLASS, "h-6")} />
+          {/* A complete repo keeps its actions on the quant rows inside the expander -- delete
+              targets one quant, not the repo -- so this row only reserves the gutter, to keep the
+              tags lined up. A partial repo has no complete quant to carry them: expanding it just
+              to reach a menu is a step with nothing at the end of it, and before this the torn
+              bytes could be seen but never removed. */}
+          {isPartialRepo ? (
+            <span className={ROW_ACTIONS_PINNED_CLASS}>
+              <ModelRowMenu
+                ariaLabel={`More options for ${c.repo_id}`}
+                cachePath={{ repoId: c.repo_id }}
+                del={{
+                  title: "Delete partial download?",
+                  impact: { repoId: c.repo_id },
+                  description: (
+                    <>
+                      This will remove the partly downloaded{" "}
+                      <span className="font-medium text-foreground">
+                        {c.repo_id}
+                      </span>{" "}
+                      from disk. It is incomplete and cannot be loaded; you can
+                      download it again later.
+                    </>
+                  ),
+                  successMessage: `Deleted ${c.repo_id}`,
+                  disabled: deleteDisabled,
+                  onConfirm: async () => {
+                    await deleteCachedModel(
+                      c.repo_id,
+                      undefined,
+                      hfToken || undefined,
+                      c.cache_path || undefined,
+                    );
+                    if (pinnedSet.has(pinKey(c.repo_id))) {
+                      togglePinned(c.repo_id);
+                    }
+                  },
+                  onDeleted: refreshCachedLists,
+                }}
+              />
+            </span>
+          ) : (
+            <span aria-hidden="true" className={cn(ROW_ACTIONS_CLASS, "h-6")} />
+          )}
         </div>
         {expanderOpen && (
           <GgufVariantExpander
@@ -5453,6 +5567,10 @@ export function HubModelPicker({
   ) => {
     const optionKey = makeModelOptionKey("downloaded-model", c.repo_id);
     const isSelected = value === c.repo_id;
+    // Some bytes on disk, not enough to load. Claiming it is downloaded skips straight to a load
+    // that fails on the missing shards, so the pick reports what is actually there and the
+    // download flow picks it up from the same place the Hub would.
+    const isPartial = c.partial === true;
     return (
       <div key={c.repo_id} className={downloadedRowShellClassName(isSelected)}>
         <div className="min-w-0 flex-1">
@@ -5464,6 +5582,7 @@ export function HubModelPicker({
             )}`}
             selected={isSelected}
             alignMeta="device"
+            partial={isPartial}
             loaded={isRuntimeLoadedModel(
               loadedModelId,
               activeGgufVariant,
@@ -5476,7 +5595,7 @@ export function HubModelPicker({
                 source: "hub",
                 isLora: false,
                 loadId: c.load_id,
-                isDownloaded: true,
+                isDownloaded: !isPartial,
                 pipelineTag: c.task ?? null,
                 audioType: c.audio_type ?? null,
               })
@@ -5485,7 +5604,9 @@ export function HubModelPicker({
             className={downloadedRowButtonClassName}
           />
         </div>
-        <span className={ROW_ACTIONS_CLASS}>
+        <span
+          className={isPartial ? ROW_ACTIONS_PINNED_CLASS : ROW_ACTIONS_CLASS}
+        >
           {onConfigure && (
             <ModelLoadSettingsAction
               ariaLabel={`Inference settings for ${c.repo_id}`}
@@ -5494,7 +5615,7 @@ export function HubModelPicker({
                   source: "hub",
                   isLora: false,
                   loadId: c.load_id,
-                  isDownloaded: true,
+                  isDownloaded: !isPartial,
                   isGguf: false,
                   pipelineTag: c.task ?? null,
                   audioType: c.audio_type ?? null,

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -57,6 +57,7 @@ import {
   hfApiToken,
   isHiddenModelId,
   jobKeyOf,
+  partialSetFromRows,
   scanFolderStatusCopy,
   useDownloadManagerStore,
   useHfTokenStore,
@@ -3217,14 +3218,12 @@ export function HubModelPicker({
   );
 
   // The torn ones, kept apart so a Hub row can mark a partial rather than show it as complete
-  // or as absent. Same split the Hub page keeps.
+  // or as absent. Same split, and the same helper, the Hub page uses. One repo id can hold both a
+  // complete GGUF copy and a torn safetensors one, since the cache keys by repo AND format, so an
+  // id with any complete row is left out: it loads, and the mark would contradict that.
   const partialSet = useMemo(
     () =>
-      new Set(
-        [...cachedGguf, ...cachedModels]
-          .filter((c) => c.partial === true)
-          .map((c) => c.repo_id.toLowerCase()),
-      ),
+      partialSetFromRows([...cachedGguf, ...cachedModels], (c) => c.repo_id),
     [cachedGguf, cachedModels],
   );
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/pinned-models.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pinned-models.ts
@@ -85,6 +85,10 @@ function sameOrder(a: readonly string[], b: readonly string[]): boolean {
 interface PinnedModelsState {
   pinned: string[];
   togglePinned: (repoId: string, quant?: string) => void;
+  /** Drop a repo's own pin and every per-quant pin under it. A whole-repo delete takes the quants
+   *  with it, and a `repoId::quant` pin outlives the row that showed it: nothing lists it, so
+   *  nothing can unpin it, and it reappears the day that quant is downloaded again. */
+  unpinRepo: (repoId: string) => void;
   /**
    * Move `fromKey` into `toKey`'s slot. Both keys must already be pinned;
    * anything else is a no-op. Outside a drag session the new order is
@@ -111,6 +115,16 @@ export const usePinnedModelsStore = create<PinnedModelsState>((set) => ({
       const next = state.pinned.includes(key)
         ? state.pinned.filter((id) => id !== key)
         : [key, ...state.pinned];
+      writePinned(next);
+      return { pinned: next };
+    }),
+  unpinRepo: (repoId) =>
+    set((state) => {
+      const prefix = `${pinKey(repoId)}::`;
+      const next = state.pinned.filter(
+        (key) => key !== pinKey(repoId) && !key.startsWith(prefix),
+      );
+      if (next.length === state.pinned.length) return state;
       writePinned(next);
       return { pinned: next };
     }),

--- a/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
+++ b/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
@@ -44,6 +44,8 @@ function toCachedGgufRepo(row: CachedInventoryRow): CachedGgufRepo {
     has_vision: row.capabilities.supportsVision,
     // Listed but not loadable: the row renders a partial mark and its click opens the download.
     partial: row.partial,
+    // What that mark is allowed to promise: a restart-only partial must not be called a resume.
+    partial_resumable: row.partialResumable,
     task: row.task ?? null,
     audio_type: row.audioType ?? null,
     has_variant_state: row.hasVariantState ?? false,
@@ -60,6 +62,8 @@ function toCachedModelRepo(row: CachedInventoryRow): CachedModelRepo {
     last_modified: epochMillisecondsToSeconds(row.lastModified),
     // Listed but not loadable: the row renders a partial mark and its click opens the download.
     partial: row.partial,
+    // What that mark is allowed to promise: a restart-only partial must not be called a resume.
+    partial_resumable: row.partialResumable,
     task: row.task ?? null,
     audio_type: row.audioType ?? null,
     tags: row.tags,

--- a/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
+++ b/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
@@ -25,8 +25,12 @@ const PICKER_LOCAL_SOURCES: ReadonlySet<LocalSource> = new Set([
   "custom",
 ]);
 
-function isCompleteCachedRow(row: CachedInventoryRow): boolean {
-  return !row.partial && !row.liveDownload;
+/** A row the picker lists. Partial snapshots stay: like the Hub, the picker shows them so they can
+ *  be seen and deleted, and carries `partial` through so a click opens the download instead of
+ *  claiming the weights are there. A live download is still dropped -- bytes are moving and the
+ *  Downloads panel owns that row until they stop. */
+function isListableCachedRow(row: CachedInventoryRow): boolean {
+  return !row.liveDownload;
 }
 
 function toCachedGgufRepo(row: CachedInventoryRow): CachedGgufRepo {
@@ -38,6 +42,8 @@ function toCachedGgufRepo(row: CachedInventoryRow): CachedGgufRepo {
     cache_path: row.cachePath ?? "",
     last_modified: epochMillisecondsToSeconds(row.lastModified),
     has_vision: row.capabilities.supportsVision,
+    // Listed but not loadable: the row renders a partial mark and its click opens the download.
+    partial: row.partial,
     task: row.task ?? null,
     audio_type: row.audioType ?? null,
     has_variant_state: row.hasVariantState ?? false,
@@ -52,6 +58,8 @@ function toCachedModelRepo(row: CachedInventoryRow): CachedModelRepo {
     cache_path: row.cachePath,
     size_bytes: row.bytes,
     last_modified: epochMillisecondsToSeconds(row.lastModified),
+    // Listed but not loadable: the row renders a partial mark and its click opens the download.
+    partial: row.partial,
     task: row.task ?? null,
     audio_type: row.audioType ?? null,
     tags: row.tags,
@@ -103,7 +111,7 @@ export function useChatPickerInventory(
         .filter(
           (row) =>
             row.modelFormat === "gguf" &&
-            isCompleteCachedRow(row) &&
+            isListableCachedRow(row) &&
             (!isHiddenModelId(row.repoId) ||
               allowedHiddenModelIdMatches(
                 options.allowedHiddenModelIds,
@@ -119,7 +127,7 @@ export function useChatPickerInventory(
         .filter(
           (row) =>
             row.modelFormat !== "gguf" &&
-            isCompleteCachedRow(row) &&
+            isListableCachedRow(row) &&
             // An sd.cpp companion mirror holds a VAE / text encoders and no denoiser. It has no
             // task, and a task of null is what every unclassified CHAT repo carries, so without
             // this it lands in the chat On Device list as a load that cannot succeed.

--- a/studio/frontend/tests/model-config-popover-scroller.test.ts
+++ b/studio/frontend/tests/model-config-popover-scroller.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The config page scrolls inside the popover rather than making the popover the scroller, so the
+// rounded surface keeps its corners when the OS draws scrollbars always. That splits one box into
+// two, and the split only holds while the outer one is a height-capped flex column: measured in a
+// browser against the built CSS, a non-flex parent leaves the inner box at its full content height
+// with nothing scrollable and Run below the clip. Both halves of the contract are pinned here.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+function read(path: string): string {
+  return readFileSync(fileURLToPath(new URL(path, import.meta.url)), "utf-8");
+}
+
+const SELECTOR = read(
+  "../src/features/model-picker/components/model-selector.tsx",
+);
+const POPOVER = read("../src/components/ui/popover.tsx");
+
+test("the popover surface clips and caps, so it never scrolls itself", () => {
+  // Scrolling the rounded box put the bar inside it, running through the top and bottom right
+  // corners and squaring them off.
+  assert.match(
+    SELECTOR,
+    /max-h-\[var\(--radix-popover-content-available-height\)\][^"]*overflow-hidden p-0/,
+    "capped and clipped, with the padding handed to the scroller",
+  );
+});
+
+test("the config page gets its own scroller inside that surface", () => {
+  assert.ok(
+    SELECTOR.includes(
+      '<div className="min-h-0 w-full overflow-y-auto px-4 pt-4 pb-4">',
+    ),
+    "the inner box scrolls and carries the padding the surface gave up",
+  );
+});
+
+test("the surface is a flex column, which is what gives the scroller a height", () => {
+  // The inner box sets no height of its own. It gets one by being a shrinkable flex item in a
+  // capped column: drop `flex flex-col` here and it stays at full content height, nothing
+  // scrolls, and the bottom of the config page including Run is clipped and unreachable.
+  const content = POPOVER.slice(POPOVER.indexOf("function PopoverContent"));
+  const base = content.slice(0, content.indexOf("{...props}"));
+  assert.match(base, /\bflex flex-col\b/, "the base class is the constraint");
+  // Overriding it from the call site would break the same way, quietly.
+  const configClass = SELECTOR.slice(
+    SELECTOR.indexOf("max-h-[var(--radix-popover-content-available-height)]"),
+  ).slice(0, 200);
+  assert.ok(
+    !/\b(block|grid|inline-flex)\b/.test(configClass),
+    "and the config-target branch does not replace it",
+  );
+});

--- a/studio/frontend/tests/model-picker-partial-downloads.test.ts
+++ b/studio/frontend/tests/model-picker-partial-downloads.test.ts
@@ -81,11 +81,18 @@ test("the mark promises a resume only when the transport can give one", () => {
     /resumable\n?\s*\? "Partial download\. Select to resume it/,
   );
   assert.ok(
-    badge.includes("The interrupted file starts over."),
-    "and the other branch says what continuing costs",
+    badge.includes('"Partial download. Select to continue it, or delete it."'),
+    "and the other branch neither promises nor forbids reusing the bytes",
   );
+  // False is not the same as "restart": a GGUF repo row reports false because transport is per
+  // quant, and an older backend without the field collapses to it too. Neither is grounds to
+  // tell the user a multi-GB file starts over, so that claim stays out of the picker.
+  assert.ok(!badge.includes("starts over"));
   // Undefined has to read as the cautious branch, since that is what an unplumbed row passes.
   assert.ok(!badge.includes("resumable === false"));
+  // The reason false cannot be read as a verdict, kept where it is documented.
+  const chatApi = read("../src/features/chat/api/chat-api.ts");
+  assert.ok(chatApi.includes("False on a GGUF repo row by design:"));
   // The Hub's split is where this wording comes from, so it is pinned too.
   const hub = read("../src/features/hub/catalog/use-download-card-state.ts");
   assert.ok(hub.includes('return partialResumable ? "Resume" : "Continue";'));

--- a/studio/frontend/tests/model-picker-partial-downloads.test.ts
+++ b/studio/frontend/tests/model-picker-partial-downloads.test.ts
@@ -53,26 +53,86 @@ test("the flag survives the mapping, or no row downstream could tell", () => {
 });
 
 test("a partial is marked the way the Hub marks one", () => {
-  const start = PICKERS.indexOf("function PartialBadge()");
+  const start = PICKERS.indexOf("function PartialBadge(");
   assert.ok(start > 0, "the picker has a partial mark");
   const badge = PICKERS.slice(start, PICKERS.indexOf("\n}", start));
   assert.match(badge, /size-\[5px\] rounded-full bg-status-warning/);
   assert.match(badge, /aria-label="Partial download"/);
   assert.ok(
-    !PICKERS.includes("&mdash;"),
-    "no em dash in the tooltip, or anywhere else here",
-  );
-  assert.ok(
     MODELS_TABLE.includes('aria-label="Partial download"') &&
       MODELS_TABLE.includes("bg-status-warning"),
     "and the Hub still uses that dot, so the two agree",
+  );
+  assert.ok(
+    !PICKERS.includes("&mdash;"),
+    "no em dash in the tooltip, or anywhere else here",
+  );
+});
+
+test("the mark promises a resume only when the transport can give one", () => {
+  // A restart-only partial refetches the interrupted file, which for a one-file quant is every
+  // byte. The Hub already splits these two ("Resume" against "Continue"), so the picker cannot
+  // say "resume" on a row whose bytes will not be reused.
+  const start = PICKERS.indexOf("function PartialBadge(");
+  const badge = PICKERS.slice(start, PICKERS.indexOf("\n}", start));
+  assert.ok(badge.includes("{ resumable }: { resumable?: boolean }"));
+  assert.match(
+    badge,
+    /resumable\n?\s*\? "Partial download\. Select to resume it/,
+  );
+  assert.ok(
+    badge.includes("The interrupted file starts over."),
+    "and the other branch says what continuing costs",
+  );
+  // Undefined has to read as the cautious branch, since that is what an unplumbed row passes.
+  assert.ok(!badge.includes("resumable === false"));
+  // The Hub's split is where this wording comes from, so it is pinned too.
+  const hub = read("../src/features/hub/catalog/use-download-card-state.ts");
+  assert.ok(hub.includes('return partialResumable ? "Resume" : "Continue";'));
+
+  // The verdict reaches the row: through the picker adapter, onto every marked row.
+  const inventory = read(
+    "../src/features/model-picker/inventory/use-chat-picker-inventory.ts",
+  );
+  assert.equal(
+    inventory.split("partial_resumable: row.partialResumable,").length - 1,
+    2,
+    "both cached repo shapes carry it",
+  );
+  assert.equal(
+    PICKERS.split("<PartialBadge resumable={partialResumable} />").length - 1,
+    2,
+    "aligned and unaligned branches alike",
+  );
+  // On Device reads its own row; Hub rows read the same cached rows partialSet is built from.
+  assert.equal(
+    PICKERS.split("partialResumable={c.partial_resumable}").length - 1,
+    2,
+  );
+  // Not the sole-quant row: /api/models/gguf-variants builds a schema with no
+  // partial_resumable, so claiming one there would be inventing a verdict.
+  assert.ok(!PICKERS.includes("partialResumable={variant."));
+  const chatVariant = read("../src/features/chat/types/api.ts");
+  const detail = chatVariant.slice(
+    chatVariant.indexOf("export interface GgufVariantDetail"),
+  );
+  assert.ok(
+    !detail.slice(0, detail.indexOf("\n}")).includes("partial_resumable"),
+    "and the chat variant type does not claim the field either",
+  );
+  assert.equal(
+    PICKERS.split("partialResumable={partialResumableSet.has(").length - 1,
+    3,
+    "all three Hub row renderers",
   );
 });
 
 test("complete and partial are alternatives, never both dots on one row", () => {
   // The bytes are there or they are not; two dots would say both.
   assert.equal(
-    PICKERS.split("{partial ? <PartialBadge /> : null}").length - 1,
+    PICKERS.split(
+      "{partial ? <PartialBadge resumable={partialResumable} /> : null}",
+    ).length - 1,
     2,
     "drawn in the aligned and unaligned branches alike",
   );

--- a/studio/frontend/tests/model-picker-partial-downloads.test.ts
+++ b/studio/frontend/tests/model-picker-partial-downloads.test.ts
@@ -163,8 +163,8 @@ test("a partial pick carries no load identity", () => {
   // snapshot told that page the weights were there and skipped the download.
   assert.equal(
     PICKERS.split("loadId: isPartial ? undefined : c.load_id,").length - 1,
-    2,
-    "both cached row selects drop it when the snapshot is torn",
+    3,
+    "every cached-row pick drops it when the snapshot is torn",
   );
   // The GGUF variant select set this rule first; the two must not diverge.
   assert.ok(
@@ -180,6 +180,24 @@ test("a partial pick carries no load identity", () => {
   );
   // And the route still forwards whatever the pick gives it.
   assert.ok(PICKERS.includes("loadId: meta.loadId ?? undefined,"));
+});
+
+test("configure carries the same rule, because Run replays its metadata", () => {
+  // The settings page keys itself off the repo id, but onRun spreads this meta straight back
+  // into a select, so a loadId left on it would reach the load path the row click already drops.
+  // The sole-quant row shares one meta between its click and its gear, so it is covered once.
+  assert.equal(
+    PICKERS.split("onConfigure(c.repo_id, selectMeta)").length - 1,
+    1,
+  );
+  // What makes it load bearing: Run reuses the stored meta verbatim.
+  const selector = read(
+    "../src/features/model-picker/components/model-selector.tsx",
+  );
+  assert.match(
+    selector,
+    /onRun=\{\(config, isDiffusion\) =>\n\s*onSelect\(visibleConfigTarget\.id, \{\n\s*\.\.\.visibleConfigTarget\.meta,/,
+  );
 });
 
 test("a partial row keeps its buttons on screen instead of hiding them behind hover", () => {

--- a/studio/frontend/tests/model-picker-partial-downloads.test.ts
+++ b/studio/frontend/tests/model-picker-partial-downloads.test.ts
@@ -163,6 +163,42 @@ test("a partial row keeps its buttons on screen instead of hiding them behind ho
   );
 });
 
+test("a partial never reaches the complete-download lookup", () => {
+  // downloadedSet decides isDownloaded on a search pick, and isDownloaded: true is what skips
+  // download staging. Listing partials in cachedGguf / cachedModels put their ids in this set,
+  // so a partial reached from Recommended or Hub search (which use handleModelClick, not the
+  // On Device renderer) went straight to the loader with an incomplete snapshot.
+  const start = PICKERS.indexOf("const downloadedSet = useMemo(");
+  assert.ok(start > 0, "downloadedSet exists");
+  const set = PICKERS.slice(start, PICKERS.indexOf("const partialSet", start));
+  assert.match(
+    set,
+    /\[\.\.\.cachedGguf, \.\.\.cachedModels\]\n\s*\.filter\(\(c\) => !c\.partial\)/,
+    "both cached lists are filtered before the ids land in the set",
+  );
+  // The search pick still reads that set, which is what makes the guard above load bearing.
+  assert.ok(
+    PICKERS.includes("isDownloaded: downloadedSet.has(id.toLowerCase()),"),
+  );
+});
+
+test("Hub rows can still tell a partial apart from an absent model", () => {
+  // Splitting partials out of downloadedSet would otherwise leave them looking like something
+  // never fetched, so the mark comes from its own set rather than from the on-disk one.
+  assert.ok(PICKERS.includes("const partialSet = useMemo("));
+  assert.equal(
+    PICKERS.split("partial={partialSet.has(id.toLowerCase())}").length - 1,
+    2,
+    "both Hub row renderers mark a partial",
+  );
+  // A partial must never take the green on-disk dot; ModelRow already yields one to the other.
+  assert.ok(
+    PICKERS.includes(
+      "{downloaded && !partial && !loaded ? <DownloadedBadge /> : null}",
+    ),
+  );
+});
+
 test("a torn quant inside the expander keeps its own menu", () => {
   // The expander lists torn quants, but the menu was gated on v.downloaded, so the one row that
   // holds bytes you might want back had no reveal and no delete. A partial still occupies disk.

--- a/studio/frontend/tests/model-picker-partial-downloads.test.ts
+++ b/studio/frontend/tests/model-picker-partial-downloads.test.ts
@@ -199,6 +199,39 @@ test("Hub rows can still tell a partial apart from an absent model", () => {
   );
 });
 
+test("an id with a complete copy is never also marked partial", () => {
+  // The cache keys by repo AND format, so one id survives as two rows: a complete GGUF copy and a
+  // torn safetensors one. Marking on `partial` alone put that id in both sets, and since the click
+  // reads downloadedSet it loaded fine while the row showed a warning dot and offered a resume.
+  assert.ok(
+    PICKERS.includes(
+      "partialSetFromRows([...cachedGguf, ...cachedModels], (c) => c.repo_id)",
+    ),
+    "the picker builds the set through the shared helper",
+  );
+  // That helper is the whole guarantee, so its exclusion rule is asserted here too.
+  const dedupe = read("../src/features/hub/inventory/inventory-dedupe.ts");
+  const start = dedupe.indexOf("export function partialSetFromRows");
+  assert.ok(start > 0, "the helper exists");
+  const body = dedupe.slice(start, dedupe.indexOf("\n}", start));
+  assert.match(body, /if \(repoId && !row\.partial\) complete\.add/);
+  assert.match(
+    body,
+    /if \(row\.partial && !complete\.has\(key\)\) partial\.add\(key\)/,
+  );
+  // Both barrels have to carry it or the import above cannot resolve.
+  assert.ok(
+    read("../src/features/hub/inventory/index.ts").includes(
+      "partialSetFromRows",
+    ) && read("../src/features/hub/index.ts").includes("partialSetFromRows"),
+  );
+  // Two rows for one id is the case being guarded, so the key that allows it is pinned.
+  assert.ok(
+    dedupe.includes('return `${normalizedRepo}\\0${modelFormat ?? "unknown"}`'),
+    "repo plus format, which is what lets one id be both",
+  );
+});
+
 test("a partial alone does not open the picker on the On Device tab", () => {
   // hasDownloadedModels picks the first run tab. The cached lists carry partials so they can be
   // seen and removed, but a machine whose only cached row is a cancelled download has nothing to

--- a/studio/frontend/tests/model-picker-partial-downloads.test.ts
+++ b/studio/frontend/tests/model-picker-partial-downloads.test.ts
@@ -59,6 +59,10 @@ test("a partial is marked the way the Hub marks one", () => {
   assert.match(badge, /size-\[5px\] rounded-full bg-status-warning/);
   assert.match(badge, /aria-label="Partial download"/);
   assert.ok(
+    !PICKERS.includes("&mdash;"),
+    "no em dash in the tooltip, or anywhere else here",
+  );
+  assert.ok(
     MODELS_TABLE.includes('aria-label="Partial download"') &&
       MODELS_TABLE.includes("bg-status-warning"),
     "and the Hub still uses that dot, so the two agree",
@@ -128,7 +132,54 @@ test("a partial GGUF repo carries its own menu, not an empty gutter", () => {
   );
   // Reveal and delete are the two the row owes; resume stays per-quant in the expander.
   assert.ok(row.includes("cachePath={{ repoId: c.repo_id }}"), "reveal");
-  assert.ok(row.includes('title: "Delete partial download?"'), "delete");
+  assert.ok(row.includes('title: "Delete cached model?"'), "delete");
+});
+
+test("the partial repo delete says it removes the repo, because it does", () => {
+  // No variant is passed, and the backend treats an absent variant as a whole-repo delete. One
+  // repo id can also hold a complete copy in another format, which that delete takes with it, so
+  // wording it as "the partial download" named a smaller scope than the one that runs.
+  const start = PICKERS.indexOf("const renderDownloadedGgufRow");
+  const row = PICKERS.slice(start, PICKERS.indexOf("\n  };", start));
+  assert.ok(
+    row.includes("and everything downloaded under it from disk"),
+    "the copy states the real scope",
+  );
+  assert.ok(
+    !row.includes("This will remove the partly downloaded"),
+    "and no longer implies only the torn bytes go",
+  );
+  // The scope claim is only true while the call stays repo-wide, so pin the call too.
+  assert.match(
+    row,
+    /await deleteCachedModel\(\n\s*c\.repo_id,\n\s*undefined,/,
+    "still a repo-wide delete, matching the Hub row",
+  );
+});
+
+test("a partial pick carries no load identity", () => {
+  // The Chat-to-Audio route has no isDownloaded field: audio-page.tsx infers it from the
+  // forwarded loadId. A loadId names a revision already on disk, so sending one for a torn
+  // snapshot told that page the weights were there and skipped the download.
+  assert.equal(
+    PICKERS.split("loadId: isPartial ? undefined : c.load_id,").length - 1,
+    2,
+    "both cached row selects drop it when the snapshot is torn",
+  );
+  // The GGUF variant select set this rule first; the two must not diverge.
+  assert.ok(
+    PICKERS.includes("loadId: downloaded === true ? loadId : undefined,"),
+    "the variant select still drops it the same way",
+  );
+  // What made the omission load bearing, in the page that reads it.
+  const audio = read("../src/features/audio/audio-page.tsx");
+  assert.match(
+    audio,
+    /isDownloaded: routeSearch\.loadId\n?\s*\? true/,
+    "a routed loadId is still read as downloaded",
+  );
+  // And the route still forwards whatever the pick gives it.
+  assert.ok(PICKERS.includes("loadId: meta.loadId ?? undefined,"));
 });
 
 test("a partial row keeps its buttons on screen instead of hiding them behind hover", () => {
@@ -188,8 +239,17 @@ test("Hub rows can still tell a partial apart from an absent model", () => {
   assert.ok(PICKERS.includes("const partialSet = useMemo("));
   assert.equal(
     PICKERS.split("partial={partialSet.has(id.toLowerCase())}").length - 1,
-    2,
-    "both Hub row renderers mark a partial",
+    3,
+    "Recommended, its filtered twin, and the typed search list alike",
+  );
+  // The typed list is the one that was missed: it renders from searchRowIds, not from the
+  // curated ids, so a partial reached by typing its name showed nothing at all.
+  const search = PICKERS.slice(PICKERS.indexOf("searchRowIds.map((id) => {"));
+  assert.ok(
+    search
+      .slice(0, search.indexOf("</ModelRow>") + 1 || 4000)
+      .includes("partial={partialSet.has(id.toLowerCase())}"),
+    "the live search row marks one too",
   );
   // A partial must never take the green on-disk dot; ModelRow already yields one to the other.
   assert.ok(

--- a/studio/frontend/tests/model-picker-partial-downloads.test.ts
+++ b/studio/frontend/tests/model-picker-partial-downloads.test.ts
@@ -163,6 +163,33 @@ test("a partial row keeps its buttons on screen instead of hiding them behind ho
   );
 });
 
+test("a torn quant inside the expander keeps its own menu", () => {
+  // The expander lists torn quants, but the menu was gated on v.downloaded, so the one row that
+  // holds bytes you might want back had no reveal and no delete. A partial still occupies disk.
+  assert.match(
+    PICKERS,
+    /\{\(v\.downloaded \|\| v\.partial === true\) &&\n\s*\(allowPin \|\|/,
+    "the menu follows disk, not completeness",
+  );
+  // Pinning an unloadable quant would put a dead row at the top of the list.
+  assert.match(
+    PICKERS,
+    /pin=\{\n\s*allowPin && v\.downloaded\n\s*\? \{/,
+    "pin stays for complete quants only",
+  );
+  // Settings still need a loadable file, so the gear is untouched.
+  assert.ok(PICKERS.includes("{v.downloaded && onConfigure && ("));
+});
+
+test("a torn quant is labelled, not left looking undownloaded", () => {
+  // Without a label the row reads as a quant you have not fetched yet, which is the opposite of
+  // what it is. Local paths already said "incomplete"; cached repos said nothing at all.
+  assert.match(
+    PICKERS,
+    /\) : v\.partial === true \? \(\n\s*<span className="ml-1\.5 text-ui-9 font-sans font-medium text-amber-700 dark:text-amber-300">\n\s*partial\n/,
+  );
+});
+
 test("the expander still lists torn quants, which is where resume lives", () => {
   // The repo row deletes the whole partial; resuming targets one quant, so it belongs to the
   // variant rows. If this filter ever drops partials there is no resume path left anywhere.

--- a/studio/frontend/tests/model-picker-partial-downloads.test.ts
+++ b/studio/frontend/tests/model-picker-partial-downloads.test.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// A cancelled multi-GB download used to be invisible in the picker: filtered out of the inventory
+// before any list saw it, so the one screen that could delete it never showed it. The Hub always
+// listed these -- marked, and opening their download rather than a load -- and the picker now
+// matches. The rule that makes that safe is that a partial is listed, never loaded.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+function read(path: string): string {
+  return readFileSync(fileURLToPath(new URL(path, import.meta.url)), "utf-8");
+}
+
+const PICKERS = read(
+  "../src/features/model-picker/components/model-selector/pickers.tsx",
+);
+const INVENTORY = read(
+  "../src/features/model-picker/inventory/use-chat-picker-inventory.ts",
+);
+const CHAT_ADAPTER = read("../src/features/chat/api/chat-adapter.ts");
+const MODELS_TABLE = read("../src/features/hub/catalog/models-table.tsx");
+
+test("the picker inventory lists partial snapshots instead of dropping them", () => {
+  // The filter that hid them. Live downloads still go: bytes are moving and the Downloads panel
+  // owns that row until they stop.
+  assert.ok(!INVENTORY.includes("isCompleteCachedRow"), "old filter is gone");
+  assert.match(
+    INVENTORY,
+    /function isListableCachedRow\(row: CachedInventoryRow\): boolean \{\n\s*return !row\.liveDownload;\n\}/,
+  );
+  assert.ok(
+    INVENTORY.includes("isListableCachedRow(row) &&"),
+    "and both cached lists use it",
+  );
+  assert.equal(
+    INVENTORY.split("isListableCachedRow(row) &&").length - 1,
+    2,
+    "gguf and non-gguf alike",
+  );
+});
+
+test("the flag survives the mapping, or no row downstream could tell", () => {
+  // toCachedGgufRepo / toCachedModelRepo are the only things the picker sees.
+  assert.equal(
+    INVENTORY.split("partial: row.partial,").length - 1,
+    2,
+    "carried onto both cached repo shapes",
+  );
+});
+
+test("a partial is marked the way the Hub marks one", () => {
+  const start = PICKERS.indexOf("function PartialBadge()");
+  assert.ok(start > 0, "the picker has a partial mark");
+  const badge = PICKERS.slice(start, PICKERS.indexOf("\n}", start));
+  assert.match(badge, /size-\[5px\] rounded-full bg-status-warning/);
+  assert.match(badge, /aria-label="Partial download"/);
+  assert.ok(
+    MODELS_TABLE.includes('aria-label="Partial download"') &&
+      MODELS_TABLE.includes("bg-status-warning"),
+    "and the Hub still uses that dot, so the two agree",
+  );
+});
+
+test("complete and partial are alternatives, never both dots on one row", () => {
+  // The bytes are there or they are not; two dots would say both.
+  assert.equal(
+    PICKERS.split("{partial ? <PartialBadge /> : null}").length - 1,
+    2,
+    "drawn in the aligned and unaligned branches alike",
+  );
+  assert.equal(
+    PICKERS.split(
+      "{downloaded && !partial && !loaded ? <DownloadedBadge /> : null}",
+    ).length - 1,
+    2,
+    "and the on-device dot yields to it in both",
+  );
+});
+
+test("selecting a partial opens its download instead of claiming the weights", () => {
+  // isDownloaded is what the load path reads. Hard-coding true on these rows sent a torn snapshot
+  // straight to a load that fails on the missing shards -- the reason they were hidden at all.
+  assert.ok(
+    PICKERS.includes("isDownloaded: !isPartial,"),
+    "the pick reports what is actually on disk",
+  );
+  // Hub reaches the same answer from the same field.
+  assert.ok(
+    read("../src/features/hub/hub-page.tsx").includes(
+      "isDownloaded: !row.partial",
+    ),
+  );
+});
+
+test("listing a partial never makes it auto-loadable", () => {
+  // The picker lists them; the background pick must still refuse them. This guard is what makes
+  // widening the inventory safe, so it is not free to drift.
+  assert.match(
+    CHAT_ADAPTER,
+    /function isChattableCachedRepo\([\s\S]*?repo\.partial !== true/,
+  );
+  assert.ok(
+    CHAT_ADAPTER.includes("row.partial !== true"),
+    "and the local scan-folder rule agrees",
+  );
+});
+
+test("a partial GGUF repo carries its own menu, not an empty gutter", () => {
+  // A complete GGUF repo keeps delete on the quant rows inside the expander, so its own row only
+  // reserves the gutter. A partial repo has no complete quant to hold those actions, so that
+  // reservation left the torn bytes visible and unreachable: no delete, no reveal.
+  const start = PICKERS.indexOf("const renderDownloadedGgufRow");
+  const row = PICKERS.slice(start, PICKERS.indexOf("\n  };", start));
+  assert.ok(row.includes("const isPartialRepo = c.partial === true;"));
+  assert.match(
+    row,
+    /\{isPartialRepo \? \(\n\s*<span className=\{ROW_ACTIONS_PINNED_CLASS\}>\n\s*<ModelRowMenu/,
+    "the partial branch draws real buttons",
+  );
+  assert.match(
+    row,
+    /\) : \(\n\s*<span aria-hidden="true" className=\{cn\(ROW_ACTIONS_CLASS, "h-6"\)\}/,
+    "and a complete repo still only reserves the gutter",
+  );
+  // Reveal and delete are the two the row owes; resume stays per-quant in the expander.
+  assert.ok(row.includes("cachePath={{ repoId: c.repo_id }}"), "reveal");
+  assert.ok(row.includes('title: "Delete partial download?"'), "delete");
+});
+
+test("a partial row keeps its buttons on screen instead of hiding them behind hover", () => {
+  // Every other row hides the gutter until hover because the row itself is the action: click it
+  // and the model loads. A partial cannot be loaded, so the menu is its ONLY affordance -- hidden,
+  // the row reads as a stalled download with no controls at all.
+  assert.ok(
+    PICKERS.includes(
+      'const ROW_ACTIONS_PINNED_CLASS = cn(ROW_ACTIONS_CLASS, "opacity-100");',
+    ),
+    "the pinned variant exists and is built from the shared one",
+  );
+  // Both partial rows use it: the GGUF repo row and the cached non-GGUF row.
+  const gguf = PICKERS.slice(PICKERS.indexOf("const renderDownloadedGgufRow"));
+  assert.ok(
+    gguf
+      .slice(0, gguf.indexOf("\n  };"))
+      .includes("<span className={ROW_ACTIONS_PINNED_CLASS}>"),
+    "GGUF partial repo row",
+  );
+  assert.ok(
+    PICKERS.includes(
+      "isPartial ? ROW_ACTIONS_PINNED_CLASS : ROW_ACTIONS_CLASS",
+    ),
+    "non-GGUF row pins only when the snapshot is torn",
+  );
+  // The base class must keep hiding itself, or every row grows a permanent button strip.
+  assert.match(
+    PICKERS,
+    /const ROW_ACTIONS_CLASS =\n\s*"[^"]*\bopacity-0\b/,
+    "the default gutter still hides",
+  );
+});
+
+test("the expander still lists torn quants, which is where resume lives", () => {
+  // The repo row deletes the whole partial; resuming targets one quant, so it belongs to the
+  // variant rows. If this filter ever drops partials there is no resume path left anywhere.
+  const vis = read(
+    "../src/features/model-picker/components/model-selector/variant-visibility.ts",
+  );
+  assert.ok(
+    vis.includes("v.downloaded === true || v.partial === true"),
+    "torn quants stay listed on device",
+  );
+});
+
+test("the stale reason for hiding partials is gone from the picker", () => {
+  // It justified a filter that no longer exists; left in place it reads as the current rule.
+  assert.ok(
+    !PICKERS.includes(
+      "A partially-downloaded snapshot is not on-device: listing it as loadable errors",
+    ),
+  );
+});

--- a/studio/frontend/tests/model-picker-partial-downloads.test.ts
+++ b/studio/frontend/tests/model-picker-partial-downloads.test.ts
@@ -199,6 +199,19 @@ test("Hub rows can still tell a partial apart from an absent model", () => {
   );
 });
 
+test("a partial alone does not open the picker on the On Device tab", () => {
+  // hasDownloadedModels picks the first run tab. The cached lists carry partials so they can be
+  // seen and removed, but a machine whose only cached row is a cancelled download has nothing to
+  // load, and that tab would open on one unusable row.
+  const start = PICKERS.indexOf("export function hasDownloadedModels()");
+  assert.ok(start > 0, "hasDownloadedModels exists");
+  const body = PICKERS.slice(start, PICKERS.indexOf("\n}", start));
+  assert.match(body, /_cachedGgufCache\.some\(\(c\) => !c\.partial\)/);
+  assert.match(body, /_cachedModelsCache\.some\(\(c\) => !c\.partial\)/);
+  // Local sources have no partial concept, so they stay a plain emptiness check.
+  assert.match(body, /_lmStudioCache\.length > 0/);
+});
+
 test("a torn quant inside the expander keeps its own menu", () => {
   // The expander lists torn quants, but the menu was gated on v.downloaded, so the one row that
   // holds bytes you might want back had no reveal and no delete. A partial still occupies disk.

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -69,7 +69,7 @@ test("the unscoped badge column is sized per list, not to the union of both", ()
   // And they sit in that one slot rather than overlapping.
   assert.match(
     PICKERS,
-    /\{showVision && <VisionBadge \/>\}\n\s*\{partial \? <PartialBadge \/> : null\}/,
+    /\{showVision && <VisionBadge \/>\}\n\s*\{partial \? <PartialBadge resumable=\{partialResumable\} \/> : null\}/,
   );
   assert.match(
     PICKERS,

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -54,10 +54,23 @@ test("the scoped badge column reserves the wider on-device marker", () => {
 });
 
 test("the unscoped badge column is sized per list, not to the union of both", () => {
-  // One slot sized for both lists left ~44px of empty column on every On Device row. 26px is the
-  // vision badge measured, so rows with and without one keep the same column positions.
-  assert.ok(PICKERS.includes('badgeDevice: "min-w-min min-[560px]:w-[26px]"'));
+  // Sized to the widest set each list can draw, not to both lists at once. On Device is the vision
+  // badge (26px), a gap-1 (4px) and the partial mark (14px): a GGUF repo can show vision and be
+  // half-downloaded at once, and at 26px that row alone grew and carried its quant chip 18px left
+  // of every other row -- the exact drift the fixed columns exist to stop.
+  assert.ok(PICKERS.includes('badgeDevice: "min-w-min min-[560px]:w-[44px]"'));
   assert.ok(PICKERS.includes('badgeWide: "min-w-min min-[560px]:w-[36px]"'));
+  // Both marks really can land on one On Device row, which is what makes 44 the right number.
+  const gguf = PICKERS.slice(PICKERS.indexOf("const renderDownloadedGgufRow"));
+  const row = gguf.slice(0, gguf.indexOf("\n  };"));
+  assert.ok(row.includes('alignMeta="device"'));
+  assert.ok(row.includes("showVision={c.has_vision"));
+  assert.ok(row.includes("partial={isPartialRepo}"));
+  // And they sit in that one slot rather than overlapping.
+  assert.match(
+    PICKERS,
+    /\{showVision && <VisionBadge \/>\}\n\s*\{partial \? <PartialBadge \/> : null\}/,
+  );
   assert.match(
     PICKERS,
     /alignMeta === "device"\n\s*\? META_COLUMN\.badgeDevice\n\s*: META_COLUMN\.badgeWide/,

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -91,12 +91,74 @@ test("the parameter and size columns are sized to the ink they hold", () => {
   );
 });
 
-test("the parameter chip hugs its label so the gap to the modality mark is the row's own", () => {
-  // A fixed right-aligned column spends its leftover in front of the chip, and that leftover is
-  // the gap to the modality mark, which no gap setting can undo. Hugging plus -ml-0.5 gives 2px.
-  assert.ok(PICKERS.includes('param: "min-w-min -ml-0.5"'));
-  // Hub keeps a column: its labels run to "2779.5B".
+test("the parameter column is fixed, so the quant column cannot drift row to row", () => {
+  // It is the last variable width to the right of the name group, and the name group is flex-1:
+  // hugging the chip handed a "1B" row -- and more so a row with no param at all -- the leftover,
+  // which carried that row's quant chip further right. 4.4em holds the widest label these lists
+  // draw at text-ui-10 ("235B" is 38.4px, a 5-char "0.35B" 40.9px), so nothing routine trips
+  // min-w-min and shifts the row back out of line.
+  assert.ok(PICKERS.includes('param: "min-w-min min-[560px]:w-[4.4em]"'));
+  // Hub keeps its own column: its labels run to "2779.5B".
   assert.ok(PICKERS.includes('paramWide: "min-w-min min-[560px]:w-[5.2em]"'));
+});
+
+test("the parameter chip leads its column, so the modality gap is the cluster's own", () => {
+  // Trailing the chip spends the column's leftover in FRONT of it, where it reads as part of the
+  // gap to the modality mark and grows with the label: 6.9px after a "217B", 19px after a "1B".
+  // Leading it leaves that gap as gap-1 -- the same 4px the quant chip keeps to the same mark.
+  assert.match(
+    PICKERS,
+    /alignMeta === "hub"\n\s*\? cn\("justify-end", META_COLUMN\.paramWide\)\n\s*: cn\("justify-start", META_COLUMN\.param\)/,
+  );
+});
+
+test("the quant chip is flush right in its slot, so the chips read as one column", () => {
+  // The slot is sized for the longest quant, so left-aligning ended a "Q8_0" and a "UD-Q4_K_XL"
+  // at different x even once the slot itself stopped moving.
+  assert.ok(PICKERS.includes('quant: "min-[560px]:w-[7.2em]"'));
+  assert.match(PICKERS, /"flex shrink-0 items-center justify-end text-ui-9"/);
+});
+
+test("the quant chip rides in the meta cluster, not on the end of the name", () => {
+  // The name group is items-baseline and sized by the name's own line box; a chip centred against
+  // THAT agrees with the rest of the row only while the two boxes happen to share a centre. In the
+  // meta cluster one items-center rule lines the chip up with the vision mark, the parameter chip,
+  // the size and the row's buttons, so the agreement is structural.
+  const meta = PICKERS.slice(
+    PICKERS.indexOf('"ml-auto flex shrink-0 items-center"'),
+  );
+  const quantSlot = meta.indexOf("META_COLUMN.quant");
+  const badgeSlot = meta.indexOf("badgeColumn");
+  assert.ok(quantSlot > 0, "the quant slot sits inside the meta cluster");
+  assert.ok(quantSlot < badgeSlot, "and leads the badge column");
+  // self-center was what compensated for the baseline box; in an items-center row it is noise.
+  assert.ok(
+    !PICKERS.includes("justify-end self-center text-ui-9"),
+    "no leftover baseline compensation",
+  );
+});
+
+test("every chip in the row band pins the same height", () => {
+  // ParamChip sized itself from its line box, the one height here that scales with
+  // --ui-font-scale: at 1.0 it stood 1px prouder than the quant and vision chips beside it and at
+  // 0.8125 it sat 1.8px shorter, so the row was only level at the scale where the two crossed.
+  for (const chip of ["QuantChip", "VisionBadge", "ParamChip"]) {
+    const start = PICKERS.indexOf(`function ${chip}(`);
+    assert.ok(start > 0, `${chip} exists`);
+    const body = PICKERS.slice(start, PICKERS.indexOf("\n}", start));
+    assert.ok(body.includes("h-[18px]"), `${chip} pins the band height`);
+  }
+  // The height is what centres the label now, so the padding that used to set it is gone. Read
+  // the class list, not the body: the comment above it names py-px as the thing it replaced.
+  const paramStart = PICKERS.indexOf("function ParamChip(");
+  const param = PICKERS.slice(paramStart, PICKERS.indexOf("\n}", paramStart));
+  const paramClasses = /className="([^"]*)"/.exec(param)?.[1] ?? "";
+  assert.ok(paramClasses.length > 0, "ParamChip has a class list");
+  assert.ok(!paramClasses.includes("py-px"), "no leftover vertical padding");
+  assert.ok(
+    paramClasses.includes("items-center"),
+    "label centres in the fixed box",
+  );
 });
 
 test("an over budget row dims instead of putting a pill on every line", () => {
@@ -189,12 +251,12 @@ test("chat and the Hub answer the fit question with one formula", () => {
     ),
   );
   assert.ok(
-    PICKERS.includes(
-      "diffusionLoad || !r.isGguf ? rowGpu : rowInferenceGpu",
-    ),
+    PICKERS.includes("diffusionLoad || !r.isGguf ? rowGpu : rowInferenceGpu"),
   );
   assert.ok(
-    PICKERS.includes("const expanderBudgetGpu = diffusionLoad ? gpu : inferenceGpu;"),
+    PICKERS.includes(
+      "const expanderBudgetGpu = diffusionLoad ? gpu : inferenceGpu;",
+    ),
   );
   // And every expander reads that one budget, rather than reaching for inferenceGpu itself.
   assert.ok(
@@ -273,15 +335,11 @@ test("chat and the Hub answer the fit question with one formula", () => {
     "both Hub fit gates",
   );
   assert.ok(
-    HUB_PAGE.includes(
-      "mediaRow || !result.isGguf ? gpu : inferenceGpu,",
-    ),
+    HUB_PAGE.includes("mediaRow || !result.isGguf ? gpu : inferenceGpu,"),
   );
   assert.ok(HUB_PAGE.includes("mediaLoad: mediaRow,"));
   assert.ok(
-    HUB_PAGE.includes(
-      "studioPageForTask(result.pipelineTag) !== undefined",
-    ),
+    HUB_PAGE.includes("studioPageForTask(result.pipelineTag) !== undefined"),
   );
   // The count is narrowed WITH the capacity, so it can never describe a different inventory than
   // the gpuGb beside it. A task page puts the load on one device; charging the per-card reserve
@@ -289,7 +347,9 @@ test("chat and the Hub answer the fit question with one formula", () => {
   // offers the selected card's 23.5.
   assert.ok(RECOMMENDED.includes("deviceCount: 1,"), "scoped to one device");
   assert.ok(PICKERS.includes("gpuCount: rowInferenceGpu.deviceCount"));
-  assert.ok(RECOMMENDED.includes("gpuCount: source.deviceCount ?? opts.gpuCount"));
+  assert.ok(
+    RECOMMENDED.includes("gpuCount: source.deviceCount ?? opts.gpuCount"),
+  );
   assert.ok(
     !PICKERS.includes("gpuCount={inferenceGpu.deviceCount}"),
     "never the unscoped host count",
@@ -404,10 +464,11 @@ test("each fit verdict is an info mark that explains itself", () => {
   assert.ok(PICKERS.includes("aria-label={verdict.label}"));
   // An over-budget figure is a TOTAL: `partial` splits across VRAM and RAM, and the number is
   // weights plus activations plus KV, so "Needs ~47GB VRAM" argued with the offload verdict.
+  assert.ok(PICKERS.includes("`Needs ~${vramEst}GB memory (GPU: ${gpuGb}GB)`"));
   assert.ok(
-    PICKERS.includes("`Needs ~${vramEst}GB memory (GPU: ${gpuGb}GB)`"),
+    !PICKERS.includes("GB VRAM (GPU:"),
+    "no VRAM wording on an overage",
   );
-  assert.ok(!PICKERS.includes("GB VRAM (GPU:"), "no VRAM wording on an overage");
   // A load that stays on the card still says VRAM, which is what it means there.
   assert.ok(PICKERS.includes("GB VRAM (tight fit on"));
   // A marginal row is a full GPU load, so it is not dimmed with the over budget ones.
@@ -423,7 +484,9 @@ test("a GGUF row takes the GGUF verdict, not the torch refusal", () => {
   // This branch used to set "exceeds", the one verdict that says a model will not load. A GGUF is
   // offloaded by llama-server rather than refused, so the row said the opposite of what happens,
   // and it is the verdict shown on the Recommended list where most rows are over budget.
-  assert.ok(PICKERS.includes("status: ggufRowFit(sizeBytes, rowInferenceGpu),"));
+  assert.ok(
+    PICKERS.includes("status: ggufRowFit(sizeBytes, rowInferenceGpu),"),
+  );
   // A boolean here collapsed marginal and partial into "no badge", so a repo whose smallest quant
   // already needed offload rendered as a clean fit beside variant rows saying otherwise.
   assert.ok(!PICKERS.includes("exceedsSize"));

--- a/studio/frontend/tests/pinned-models-reorder.test.ts
+++ b/studio/frontend/tests/pinned-models-reorder.test.ts
@@ -501,3 +501,83 @@ test("the hub's pinned grid never makes a dataset row draggable", async () => {
     /pin=\{\s*isDataset \|\| !deletableRepoId\s*\?\s*undefined/,
   );
 });
+
+test("deleting a repo drops its quant pins, not just the repo's own", () => {
+  // A pin is keyed `repoId::quant`. A whole-repo delete removes every quant, but only the plain
+  // repo key was being cleared, so the quant pins stayed in localStorage with no row left to
+  // unpin them -- and came back pinned the day that quant was downloaded again.
+  setPinned([
+    "unsloth/Qwen3-8B-GGUF::Q4_K_M",
+    "unsloth/Qwen3-8B-GGUF",
+    "unsloth/Qwen3-8B-GGUF::UD-Q4_K_XL",
+    "unsloth/Gemma-3-4B-GGUF::Q8_0",
+    "unsloth/Gemma-3-4B-GGUF",
+  ]);
+  usePinnedModelsStore.getState().unpinRepo("unsloth/Qwen3-8B-GGUF");
+  const left = usePinnedModelsStore.getState().pinned;
+  assert.deepEqual(left, [
+    "unsloth/Gemma-3-4B-GGUF::Q8_0",
+    "unsloth/Gemma-3-4B-GGUF",
+  ]);
+  // One write, and the survivors keep their order.
+  assert.deepEqual(storedPinned(), left);
+});
+
+test("unpinning a repo leaves a longer repo id that merely starts the same", () => {
+  // Prefix matching on the bare id would take "unsloth/Qwen3-8B-GGUF-128K" with it. The `::`
+  // is what makes the boundary, so it belongs in the filter rather than beside it.
+  setPinned([
+    "unsloth/Qwen3-8B-GGUF-128K",
+    "unsloth/Qwen3-8B-GGUF-128K::Q4_K_M",
+    "unsloth/Qwen3-8B-GGUF",
+  ]);
+  usePinnedModelsStore.getState().unpinRepo("unsloth/Qwen3-8B-GGUF");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "unsloth/Qwen3-8B-GGUF-128K",
+    "unsloth/Qwen3-8B-GGUF-128K::Q4_K_M",
+  ]);
+});
+
+test("unpinning a repo that was never pinned writes nothing", () => {
+  // Every repo-level delete calls this, pinned or not; a write per delete would churn the
+  // record and wake every other window's storage listener for no change.
+  setPinned(["unsloth/Gemma-3-4B-GGUF"]);
+  usePinnedModelsStore.getState().unpinRepo("unsloth/Nothing-Here");
+  assert.deepEqual(usePinnedModelsStore.getState().pinned, [
+    "unsloth/Gemma-3-4B-GGUF",
+  ]);
+  assert.equal(storedPinned(), null, "no write, so the record is untouched");
+});
+
+test("both repo-level deletes clear pins through that one action", async () => {
+  // The picker's partial repo row and the Hub's cache row do the same delete, so they must not
+  // drift into two answers about what a pin outlives.
+  const pickers = await readFile(
+    new URL(
+      "../src/features/model-picker/components/model-selector/pickers.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.equal(
+    pickers.split("unpinRepo(c.repo_id);").length - 1,
+    2,
+    "the partial GGUF repo row and the cached model row alike",
+  );
+  assert.ok(
+    !pickers.includes("if (pinnedSet.has(pinKey(c.repo_id))) {"),
+    "and neither clears by toggling the bare repo key",
+  );
+  const rows = await readFile(
+    new URL(
+      "../src/features/hub/catalog/models-catalog-rows.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.ok(
+    rows.includes(
+      "usePinnedModelsStore.getState().unpinRepo(deletableRepoId);",
+    ),
+  );
+});


### PR DESCRIPTION
The model picker's On Device rows drifted column to column, and a cancelled download was invisible in the one list that could remove it.

## Row alignment

The quant chips sat at a different x on every row. The cause was the parameter column: it hugged its label, which made it the last variable width to the right of the name group. Since the name group is `flex-1`, a `1B` row (and more so a row with no parameter at all, like `embeddinggemma-300m-GGUF`) handed the leftover to the name and carried that row's quant chip further right.

- `META_COLUMN.param` is now a fixed `4.4em`, sized for the widest label these lists draw. Measured at `text-ui-10`, `235B` is 38.4px and a five character `0.35B` is 40.9px, so nothing routine trips `min-w-min`.
- The parameter chip leads its column instead of trailing it. Trailing spent the column's slack in front of the chip, where it read as the gap to the modality mark and grew with the label: 6.9px after `217B`, 19px after `1B`. That gap is now the cluster's own 4px, the same the quant chip keeps.
- `ParamChip` sized itself from its line box, the one height in the row band that scales with `--ui-font-scale`. At scale 1.0 it stood 1px prouder than the quant and vision chips and at 0.8125 it sat 1.8px shorter, so the row only looked level at the scale where the two happened to cross. It now pins the same 18px as everything else in the band.
- The quant chip moved into the meta cluster. At the end of the name group it was centred against a baseline box sized by the name's own line height, so it agreed with the rest of the row only while the two boxes shared a centre. One `items-center` rule now governs the whole cluster.

Measured against the real stylesheet at five UI font scales (0.8125 through 1.125), the spread of vertical centres, chip heights, quant right edges and parameter left edges is 0px in every case. Before the change the quant right edges spread 37.4px.

## Partial downloads

`use-chat-picker-inventory` dropped partial snapshots before any list saw them, so a cancelled multi-GB download could not be found or deleted from the picker. The Hub always listed them.

- Partials are listed, marked with the Hub's own warning dot, and select with `isDownloaded: false`, so a click opens the download rather than handing torn weights to the loader. Live downloads are still excluded; the Downloads panel owns those while bytes are moving.
- Auto load is unaffected. `isChattableCachedRepo` already guards on `repo.partial !== true`, which is what makes widening the inventory safe, and there is now a test pinning that.
- A partial GGUF repo row carries its own menu (reveal, delete). A complete repo keeps delete on the quant rows inside the expander because delete targets one quant, but a partial has no complete quant to hold those actions, so the torn bytes could be seen and never removed. Resume stays per quant in the expander, which already lists torn quants for exactly that reason.
- Partial rows keep their buttons on screen rather than revealing on hover. Every other row hides the gutter because the row itself is the action, but a partial cannot be loaded, so the menu is its only affordance.

## Run settings popover

The rounded surface was also the scroller, so on a machine set to always show scrollbars the bar ran the full height at the very edge and squared off both right hand corners. The surface now clips with `overflow-hidden` and an inner box scrolls, carrying the padding with it.

## Testing

- `npm run typecheck` clean
- `npm run test`: 6289 passing, 0 failing
- `npm run build` clean
- Biome diagnostics unchanged from baseline on every touched file

Tests were added for the fixed parameter column, the chip alignment, the shared 18px band, and the partial download rules. One existing test asserted the old hugging parameter column and was rewritten for the new invariant.
