### PR TITLE
Studio: use plain arrow icons for up, down, left and right

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -74,9 +74,6 @@ import { isTauri } from "@/lib/api-base";
 import { useWebUpdateCheck } from "@/hooks/use-web-update-check";
 import {
   Archive03Icon,
-  ArrowDown01Icon,
-  ArrowRight02Icon,
-  ArrowUp01Icon,
   BadgeInfoIcon,
   BookOpen01Icon,
   BubbleChatIcon,
@@ -123,7 +120,13 @@ import {
 } from "@/components/ui/tooltip";
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ChevronDown, Moon } from "lucide-react";
+import {
+  ArrowRightIcon,
+  ChevronDown,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  Moon,
+} from "lucide-react";
 import {
   Link,
   useNavigate,
@@ -1760,14 +1763,14 @@ export function AppSidebar() {
     return (
       <>
         <DropdownMenuItem disabled={at <= 0} onSelect={() => move(-1)}>
-          <HugeiconsIcon icon={ArrowUp01Icon} strokeWidth={1.75} className="size-icon" />
+          <ChevronUpIcon strokeWidth={1.75} className="size-icon" />
           <span>{t("shell.organize.moveUp")}</span>
         </DropdownMenuItem>
         <DropdownMenuItem
           disabled={at === -1 || at >= orderedIds.length - 1}
           onSelect={() => move(1)}
         >
-          <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.75} className="size-icon" />
+          <ChevronDownIcon strokeWidth={1.75} className="size-icon" />
           <span>{t("shell.organize.moveDown")}</span>
         </DropdownMenuItem>
       </>
@@ -4331,8 +4334,7 @@ export function AppSidebar() {
                   aria-hidden="true"
                   className="ml-auto flex size-[32px] shrink-0 items-center justify-center text-muted-foreground group-data-[collapsible=icon]:hidden"
                 >
-                  <HugeiconsIcon
-                    icon={ArrowRight02Icon}
+                  <ArrowRightIcon
                     className="size-[17px]"
                     strokeWidth={1.75}
                   />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -291,12 +291,13 @@ import { useNavigate } from "@tanstack/react-router";
 import {
   ArrowDownIcon,
   ArrowUpIcon,
+  ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   Columns2Icon,
   CornerDownRightIcon,
-  GitBranchIcon,
   FastForwardIcon,
+  GitBranchIcon,
   GlobeIcon,
   HeadphonesIcon,
   Loader2Icon,
@@ -5155,22 +5156,6 @@ function useImeComposerInputHandlers({
 }
 
 // HugeIcons arrow-down-01 (stroke-standard): straight-line chevron.
-const ArrowDownStandardIcon: FC<{ className?: string }> = ({ className }) => (
-  <svg
-    className={className}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden={true}
-  >
-    <path d="M5.99977 9.00005L11.9998 15L17.9998 9" />
-  </svg>
-);
-
 // svgrepo.com lightbulb (filled, with base).
 const BulbIcon: FC<{ className?: string }> = ({ className }) => (
   <svg
@@ -5318,7 +5303,7 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
                 {isEffort ? `Thinking · ${effortLabel}` : "Thinking"}
               </span>
             ) : null}
-            <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
+            <ChevronDownIcon strokeWidth={1.5} className="unsloth-thinking-caret size-[15px]" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/studio/frontend/src/components/media-page-link.tsx
+++ b/studio/frontend/src/components/media-page-link.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { ArrowRight02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { IconSvgElement } from "@hugeicons/react";
 import { useNavigate } from "@tanstack/react-router";
@@ -12,6 +11,9 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import {
+  ArrowRightIcon,
+} from "lucide-react";
 
 /** The link out to another page's workspace (Images, Video, Audio, image training).
  *  Kept out of the mode strip and parked past a divider so it reads as leaving. */
@@ -58,8 +60,7 @@ export function MediaPageLink({
           >
             <HugeiconsIcon icon={icon} className="size-4 shrink-0" />
             <span className={cn("min-w-0 truncate", labelClassName)}>{label}</span>
-            <HugeiconsIcon
-              icon={ArrowRight02Icon}
+            <ArrowRightIcon
               className={cn("size-3.5 shrink-0 opacity-60", arrowClassName)}
             />
           </button>

--- a/studio/frontend/src/components/resource-picker/picker-shell.tsx
+++ b/studio/frontend/src/components/resource-picker/picker-shell.tsx
@@ -11,10 +11,12 @@ import { Spinner } from "@/components/ui/spinner";
 import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import {
-  ArrowRight01Icon,
   FolderSearchIcon,
   Search01Icon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronRightIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   type KeyboardEvent,
@@ -396,8 +398,7 @@ export function PickerShell({
                     {useThisLabel}
                   </span>
                 </span>
-                <HugeiconsIcon
-                  icon={ArrowRight01Icon}
+                <ChevronRightIcon
                   strokeWidth={1.5}
                   className="size-3.5 shrink-0 text-muted-foreground/70"
                 />

--- a/studio/frontend/src/components/ui/breadcrumb.tsx
+++ b/studio/frontend/src/components/ui/breadcrumb.tsx
@@ -6,9 +6,11 @@ import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 import {
-  ArrowRight01Icon,
   MoreHorizontalCircle01Icon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronRightIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
@@ -89,7 +91,7 @@ function BreadcrumbSeparator({
       className={cn("[&>svg]:size-3.5", className)}
       {...props}
     >
-      {children ?? <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} />}
+      {children ?? <ChevronRightIcon strokeWidth={2} />}
     </li>
   );
 }

--- a/studio/frontend/src/components/ui/context-menu.tsx
+++ b/studio/frontend/src/components/ui/context-menu.tsx
@@ -8,8 +8,10 @@ import type * as React from "react";
 
 import { Tick02Icon } from "@/lib/tick-icon";
 import { cn } from "@/lib/utils";
-import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ChevronRightIcon,
+} from "lucide-react";
 
 function ContextMenu({
   ...props
@@ -125,8 +127,7 @@ function ContextMenuSubTrigger({
       {...props}
     >
       {children}
-      <HugeiconsIcon
-        icon={ArrowRight01Icon}
+      <ChevronRightIcon
         strokeWidth={2}
         className="ml-auto size-[12px]"
       />

--- a/studio/frontend/src/components/ui/pagination.tsx
+++ b/studio/frontend/src/components/ui/pagination.tsx
@@ -6,10 +6,12 @@ import type * as React from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
-  ArrowLeft01Icon,
-  ArrowRight01Icon,
   MoreHorizontalCircle01Icon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
@@ -79,8 +81,7 @@ function PaginationPrevious({
       className={cn("pl-2!", className)}
       {...props}
     >
-      <HugeiconsIcon
-        icon={ArrowLeft01Icon}
+      <ChevronLeftIcon
         strokeWidth={2}
         data-icon="inline-start"
       />
@@ -101,8 +102,7 @@ function PaginationNext({
       {...props}
     >
       <span className="hidden sm:block">Next</span>
-      <HugeiconsIcon
-        icon={ArrowRight01Icon}
+      <ChevronRightIcon
         strokeWidth={2}
         data-icon="inline-end"
       />

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -25,14 +25,17 @@ import { Switch } from "@/components/ui/switch";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import {
-  ArrowLeft02Icon,
   Delete02Icon,
   Edit03Icon,
   PlusSignIcon,
   Wifi02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Eye, EyeOff } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  Eye,
+  EyeOff,
+} from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -1311,7 +1314,7 @@ export function ChatProvidersSettings({
             aria-label="Back to connections"
             title="Back to connections"
           >
-            <HugeiconsIcon icon={ArrowLeft02Icon} className="size-4" />
+            <ArrowLeftIcon className="size-4" />
           </Button>
           <div className="flex min-w-0 items-center gap-2 leading-none">
             <span className="text-xs font-medium text-muted-foreground">

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -4,8 +4,11 @@
 import { Tick02Icon } from "@/lib/tick-icon";
 import { McpServerIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { XIcon } from "lucide-react";
-import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import {
+  ChevronDownIcon,
+  XIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import {
@@ -36,22 +39,6 @@ import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import { useMcpServersDialogStore } from "./stores/mcp-servers-dialog-store";
 
 // Matches the Thinking pill chevron so the affordance reads the same.
-const ArrowDownStandardIcon: FC<{ className?: string }> = ({ className }) => (
-  <svg
-    className={className}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden={true}
-  >
-    <path d="M5.99977 9.00005L11.9998 15L17.9998 9" />
-  </svg>
-);
-
 type McpPreset = {
   id: string;
   displayName: string; // stored row name
@@ -341,7 +328,7 @@ export function McpComposerButton({
               <XIcon className="composer-pill-x" />
             </span>
             <span>MCP</span>
-            <ArrowDownStandardIcon className="composer-pill-caret size-[15px]" />
+            <ChevronDownIcon strokeWidth={1.5} className="composer-pill-caret size-[15px]" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -66,6 +66,7 @@ import type { ModelLifecycleLease } from "./utils/model-lifecycle-gate";
 import { useAui } from "@assistant-ui/react";
 import {
   ArrowUpIcon,
+  ChevronDownIcon,
   Columns2Icon,
   GlobeIcon,
   HeadphonesIcon,
@@ -169,7 +170,6 @@ import {
   type CompositionEvent,
   type ClipboardEvent,
   type DragEvent as ReactDragEvent,
-  type FC,
   type KeyboardEvent,
   type MutableRefObject,
   type ReactElement,
@@ -205,22 +205,6 @@ const IMAGE_ACCEPT = "image/jpeg,image/png,image/webp,image/gif";
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024;
 
 // Inlined to avoid a new icon dep. Kept in sync with the main composer.
-const ArrowDownStandardIcon: FC<{ className?: string }> = ({ className }) => (
-  <svg
-    className={className}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden={true}
-  >
-    <path d="M5.99977 9.00005L11.9998 15L17.9998 9" />
-  </svg>
-);
-
 function isNativeComposing(event: Event) {
   return "isComposing" in event && (event as InputEvent).isComposing === true;
 }
@@ -2629,7 +2613,7 @@ export function SharedComposer({
                           : "Thinking"}
                       </span>
                     ) : null}
-                    <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
+                    <ChevronDownIcon strokeWidth={1.5} className="unsloth-thinking-caret size-[15px]" />
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent

--- a/studio/frontend/src/features/dataset-picker/components/dataset-selector.tsx
+++ b/studio/frontend/src/features/dataset-picker/components/dataset-selector.tsx
@@ -38,7 +38,12 @@ import {
 import { useT } from "@/i18n";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
-import { ArrowDown01Icon, Database02Icon } from "@hugeicons/core-free-icons";
+import {
+  Database02Icon,
+} from "@hugeicons/core-free-icons";
+import {
+  ChevronDownIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
@@ -379,8 +384,7 @@ export function DatasetSelector() {
               {display ?? t("studio.datasetPicker.selectDataset")}
             </span>
           </span>
-          <HugeiconsIcon
-            icon={ArrowDown01Icon}
+          <ChevronDownIcon
             strokeWidth={1.25}
             className="size-3.5 shrink-0 text-muted-foreground"
           />

--- a/studio/frontend/src/features/export/components/export-run-panel.tsx
+++ b/studio/frontend/src/features/export/components/export-run-panel.tsx
@@ -27,12 +27,14 @@ import { FolderBrowser } from "@/features/model-picker";
 import { cn } from "@/lib/utils";
 import {
   AlertCircleIcon,
-  ArrowRight01Icon,
   CancelCircleIcon,
   CheckmarkCircle02Icon,
   FolderSearchIcon,
   Key01Icon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronRightIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -468,7 +470,7 @@ export function ExportRunPanel(props: ExportRunPanelProps) {
                         className="flex items-center gap-1 text-ui-11 text-emerald-600 hover:text-emerald-700 transition-colors"
                       >
                         Get token
-                        <HugeiconsIcon icon={ArrowRight01Icon} className="size-3" />
+                        <ChevronRightIcon className="size-3" />
                       </a>
                     </div>
                     <InputGroup>

--- a/studio/frontend/src/features/hub/catalog/card-carousel.tsx
+++ b/studio/frontend/src/features/hub/catalog/card-carousel.tsx
@@ -2,8 +2,6 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { cn } from "@/lib/utils";
-import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import {
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
@@ -13,6 +11,10 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react";
 
 export const CARD_GAP_PX = 16;
 const CAROUSEL_TOP_PADDING_PX = 8;
@@ -44,11 +46,11 @@ export function CarouselArrow({
           : "pointer-events-none opacity-0",
       )}
     >
-      <HugeiconsIcon
-        icon={side === "left" ? ArrowLeft01Icon : ArrowRight01Icon}
-        strokeWidth={2}
-        className="size-4"
-      />
+      {side === "left" ? (
+        <ChevronLeftIcon strokeWidth={2} className="size-4" />
+      ) : (
+        <ChevronRightIcon strokeWidth={2} className="size-4" />
+      )}
     </button>
   );
 }

--- a/studio/frontend/src/features/hub/catalog/hub-detail-view.tsx
+++ b/studio/frontend/src/features/hub/catalog/hub-detail-view.tsx
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { cn } from "@/lib/utils";
 import { type ComponentProps, useEffect, useRef, useState } from "react";
 import { ModelInspector } from "./model-inspector";
+import {
+  ChevronLeftIcon,
+} from "lucide-react";
 
 type InspectorProps = ComponentProps<typeof ModelInspector>;
 
@@ -71,8 +72,7 @@ export function HubDetailView({
               onClick={onBack}
               className="-ml-1.5 inline-flex h-8 cursor-pointer select-none items-center gap-1.5 rounded-full pl-1.5 pr-2.5 text-ui-12p5 font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.05] hover:text-foreground dark:hover:bg-white/[0.06]"
             >
-              <HugeiconsIcon
-                icon={ArrowLeft01Icon}
+              <ChevronLeftIcon
                 strokeWidth={1.75}
                 className="size-3.5"
               />

--- a/studio/frontend/src/features/hub/catalog/hub-model-settings-view.tsx
+++ b/studio/frontend/src/features/hub/catalog/hub-model-settings-view.tsx
@@ -11,7 +11,12 @@ import {
 } from "@/features/model-picker";
 import type { PerModelConfig } from "@/features/model-picker";
 import { cn } from "@/lib/utils";
-import { ArrowLeft01Icon, Globe02Icon } from "@hugeicons/core-free-icons";
+import {
+  Globe02Icon,
+} from "@hugeicons/core-free-icons";
+import {
+  ChevronLeftIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useRef, useState } from "react";
 
@@ -78,8 +83,7 @@ export function HubModelSettingsView({
               onClick={onBack}
               className="-ml-1.5 inline-flex h-8 cursor-pointer select-none items-center gap-1.5 rounded-full pl-1.5 pr-2.5 text-ui-12p5 font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.05] hover:text-foreground dark:hover:bg-white/[0.06]"
             >
-              <HugeiconsIcon
-                icon={ArrowLeft01Icon}
+              <ChevronLeftIcon
                 strokeWidth={1.75}
                 className="size-3.5"
               />

--- a/studio/frontend/src/features/hub/catalog/hub-section-row.tsx
+++ b/studio/frontend/src/features/hub/catalog/hub-section-row.tsx
@@ -2,8 +2,6 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { Skeleton } from "@/components/ui/skeleton";
-import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { memo } from "react";
 import type { DiscoverRow } from "../types";
 import { CardCarousel } from "./card-carousel";
@@ -12,6 +10,9 @@ import {
   MODEL_CARD_WIDTH_PX,
   ModelCard,
 } from "./model-card";
+import {
+  ChevronRightIcon,
+} from "lucide-react";
 
 const SKELETON_KEYS = ["s0", "s1", "s2", "s3", "s4"] as const;
 
@@ -61,8 +62,7 @@ export const HubSectionRow = memo(function HubSectionRow({
           className="hub-section-title group/section -mx-1 inline-flex cursor-pointer items-center gap-1.5 rounded-md px-1 text-ui-18 font-semibold tracking-[-0.02em] text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
           {title}
-          <HugeiconsIcon
-            icon={ArrowRight01Icon}
+          <ChevronRightIcon
             strokeWidth={2}
             className="hub-section-chevron size-4 text-muted-foreground"
           />

--- a/studio/frontend/src/features/hub/catalog/models-table.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-table.tsx
@@ -28,7 +28,6 @@ import {
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { cn, formatCompact } from "@/lib/utils";
 import {
-  ArrowLeft01Icon,
   ArrowUpDownIcon,
   Copy01Icon,
   Download01Icon,
@@ -40,6 +39,9 @@ import {
   Refresh01Icon,
   ViewSidebarLeftIcon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronLeftIcon,
+} from "lucide-react";
 import type { IconSvgElement } from "@hugeicons/react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Fragment, type ReactNode, memo, useMemo } from "react";
@@ -220,8 +222,7 @@ export function HubListHeader({
             // avatars below, just inside the row hover's left edge.
             className="hub-section-chevron -ml-3 inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground"
           >
-            <HugeiconsIcon
-              icon={ArrowLeft01Icon}
+            <ChevronLeftIcon
               strokeWidth={2}
               className="size-4"
             />

--- a/studio/frontend/src/features/images/train/dataset-labeling-grid.tsx
+++ b/studio/frontend/src/features/images/train/dataset-labeling-grid.tsx
@@ -4,12 +4,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
-  ArrowLeft01Icon,
-  ArrowRight01Icon,
   Cancel01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ChevronDown } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -266,7 +268,7 @@ export function DatasetLabelingGrid({
               onClick={() => setPage((p) => Math.max(0, p - 1))}
               aria-label="Previous images"
             >
-              <HugeiconsIcon icon={ArrowLeft01Icon} className="size-3.5" />
+              <ChevronLeftIcon className="size-3.5" />
             </Button>
             <Button
               type="button"
@@ -277,7 +279,7 @@ export function DatasetLabelingGrid({
               onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
               aria-label="Next images"
             >
-              <HugeiconsIcon icon={ArrowRight01Icon} className="size-3.5" />
+              <ChevronRightIcon className="size-3.5" />
             </Button>
           </div>
         )}

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -52,7 +52,6 @@ import {
 } from "@/hooks/gpu-vram";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { toast } from "@/lib/toast";
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   type ReactNode,
@@ -153,6 +152,9 @@ import {
   NumericValueInput,
   type NumericValueInputHandle,
 } from "./numeric-value-input";
+import {
+  ChevronLeftIcon,
+} from "lucide-react";
 
 const ROW_CLASS = "flex min-h-8 items-center justify-between gap-3";
 const LABEL_CLASS =
@@ -3177,8 +3179,7 @@ export function ModelConfigPage({
               className="nav-icon-btn shrink-0 text-nav-icon-idle hover:bg-panel-surface-hover hover:text-black dark:hover:text-white"
               aria-label="Back to model list"
             >
-              <HugeiconsIcon
-                icon={ArrowLeft01Icon}
+              <ChevronLeftIcon
                 className="size-4"
                 strokeWidth={1.75}
               />

--- a/studio/frontend/src/features/rag/components/knowledge-base-composer-button.tsx
+++ b/studio/frontend/src/features/rag/components/knowledge-base-composer-button.tsx
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { XIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  XIcon,
+} from "lucide-react";
 import { Tick02Icon } from "@/lib/tick-icon";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FileDatabaseIcon } from "@hugeicons/core-free-icons";
-import { type FC, useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import {
   DropdownMenu,
@@ -23,22 +26,6 @@ import type { KnowledgeBase } from "../types/rag";
 import { KnowledgeBaseDialog } from "./knowledge-base-dialog";
 
 // Matches the Thinking/MCP pill chevron.
-const ArrowDownStandardIcon: FC<{ className?: string }> = ({ className }) => (
-  <svg
-    className={className}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden={true}
-  >
-    <path d="M5.99977 9.00005L11.9998 15L17.9998 9" />
-  </svg>
-);
-
 // Picks the retrieval source. Shown whenever retrieval is on; dims but stays
 // interactive (so it can be turned off) while the loaded model can't run it.
 export function KnowledgeBaseComposerButton({
@@ -132,7 +119,7 @@ export function KnowledgeBaseComposerButton({
               <XIcon className="composer-pill-x" />
             </span>
             <span>RAG</span>
-            <ArrowDownStandardIcon className="composer-pill-caret size-[15px]" />
+            <ChevronDownIcon strokeWidth={1.5} className="composer-pill-caret size-[15px]" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
@@ -12,8 +12,6 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import {
-  ArrowLeft02Icon,
-  ArrowRight01Icon,
   CodeIcon,
   Copy02Icon,
   type Database02Icon,
@@ -23,6 +21,10 @@ import {
   Search01Icon,
   Upload01Icon,
 } from "@hugeicons/core-free-icons";
+import {
+  ArrowLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react";
 import { Tick02Icon } from "@/lib/tick-icon";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
@@ -215,8 +217,7 @@ function BlockSheetButton({
         </p>
       </div>
       {trailing === "chevron" ? (
-        <HugeiconsIcon
-          icon={ArrowRight01Icon}
+        <ChevronRightIcon
           className="size-3.5 text-muted-foreground"
         />
       ) : trailing === "drag" ? (
@@ -434,7 +435,7 @@ export function BlockSheet({
                   aria-label="Back to step groups"
                   title="Back to step groups"
                 >
-                  <HugeiconsIcon icon={ArrowLeft02Icon} className="size-4" />
+                  <ArrowLeftIcon className="size-4" />
                 </Button>
               )}
               <SheetTitle>{sheetTitle}</SheetTitle>

--- a/studio/frontend/src/features/recipe-studio/components/executions/publish-execution-dialog.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/executions/publish-execution-dialog.tsx
@@ -2,7 +2,14 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { useEffect, useMemo, useState, type ReactElement } from "react";
-import { ArrowRight01Icon, CheckmarkCircle02Icon, Copy01Icon, Key01Icon } from "@hugeicons/core-free-icons";
+import {
+  CheckmarkCircle02Icon,
+  Copy01Icon,
+  Key01Icon,
+} from "@hugeicons/core-free-icons";
+import {
+  ChevronRightIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
 import {
@@ -194,7 +201,7 @@ export function PublishExecutionDialog({
               <Button asChild={true}>
                 <a href={publishedUrl} target="_blank" rel="noreferrer">
                   Open repo
-                  <HugeiconsIcon icon={ArrowRight01Icon} className="ml-2 size-4" />
+                  <ChevronRightIcon className="ml-2 size-4" />
                 </a>
               </Button>
               <Button variant="ghost" onClick={() => onOpenChange(false)}>

--- a/studio/frontend/src/features/recipe-studio/dialogs/llm/general-tab.tsx
+++ b/studio/frontend/src/features/recipe-studio/dialogs/llm/general-tab.tsx
@@ -23,8 +23,6 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { type ReactElement, type RefObject, useMemo, useRef } from "react";
 import { useRecipeStudioStore } from "../../stores/recipe-studio";
 import type { LlmConfig } from "../../types";
@@ -35,6 +33,9 @@ import { CollapsibleSectionTriggerButton } from "../shared/collapsible-section-t
 import { AvailableVariables } from "../shared/available-variables";
 import { FieldLabel } from "../shared/field-label";
 import { NameField } from "../shared/name-field";
+import {
+  ChevronRightIcon,
+} from "lucide-react";
 
 const CODE_LANG_OPTIONS = [
   "python",
@@ -186,8 +187,7 @@ export function LlmGeneralTab({
           <div className="mt-2 space-y-1.5">
             {!hasModelProviders && (
               <p className="flex items-start gap-2">
-                <HugeiconsIcon
-                  icon={ArrowRight01Icon}
+                <ChevronRightIcon
                   className="mt-0.5 size-3.5 shrink-0 text-primary"
                 />
                 <span>Add a Provider connection step in AI generation → Setup.</span>
@@ -195,8 +195,7 @@ export function LlmGeneralTab({
             )}
             {!hasModelConfigs && (
               <p className="flex items-start gap-2">
-                <HugeiconsIcon
-                  icon={ArrowRight01Icon}
+                <ChevronRightIcon
                   className="mt-0.5 size-3.5 shrink-0 text-primary"
                 />
                 <span>Add a Model preset step, connect it, then choose it below.</span>

--- a/studio/frontend/src/features/recipe-studio/dialogs/tool-profile/tool-profile-dialog.tsx
+++ b/studio/frontend/src/features/recipe-studio/dialogs/tool-profile/tool-profile-dialog.tsx
@@ -12,10 +12,12 @@ import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toastError } from "@/shared/toast";
 import {
-  ArrowRight01Icon,
   Delete02Icon,
   PlusSignIcon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronRightIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
 import { listMcpTools } from "../../api";
@@ -124,8 +126,7 @@ function McpServerCard({
               type="button"
               className="flex min-w-0 flex-1 items-start gap-3 text-left"
             >
-              <HugeiconsIcon
-                icon={ArrowRight01Icon}
+              <ChevronRightIcon
                 className={`mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform ${
                   open ? "rotate-90" : ""
                 }`}

--- a/studio/frontend/src/features/settings/components/dictation-dictionary-view.tsx
+++ b/studio/frontend/src/features/settings/components/dictation-dictionary-view.tsx
@@ -5,10 +5,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useT } from "@/i18n";
 import {
-  ArrowLeft01Icon,
   Delete02Icon,
   PlusSignIcon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronLeftIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
 import { useVoiceSettingsStore } from "../stores/voice-settings-store";
@@ -46,7 +48,7 @@ export function DictationDictionaryView({ onBack }: { onBack: () => void }) {
           aria-label={t("settings.voice.dictionary.backToVoice")}
           className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+          <ChevronLeftIcon className="size-4" />
         </button>
         <h1 className="font-heading text-xl font-semibold">
           {t("settings.voice.title")}

--- a/studio/frontend/src/features/settings/components/monitor-link.tsx
+++ b/studio/frontend/src/features/settings/components/monitor-link.tsx
@@ -10,7 +10,12 @@ import { useApiMonitorOverlayStore } from "@/features/api-monitor/overlay-store"
 import { getApiMonitor } from "@/features/chat/api/chat-api";
 import type { ApiMonitorResponse } from "@/features/chat/types/api";
 import { useLocale, useT } from "@/i18n";
-import { ActivityIcon, ArrowRight02Icon } from "@hugeicons/core-free-icons";
+import {
+  ActivityIcon,
+} from "@hugeicons/core-free-icons";
+import {
+  ArrowRightIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { type ReactElement, useEffect, useState } from "react";
@@ -76,8 +81,7 @@ export function MonitorLink(): ReactElement {
                 })}
           </span>
         </span>
-        <HugeiconsIcon
-          icon={ArrowRight02Icon}
+        <ArrowRightIcon
           strokeWidth={1.75}
           className="ml-auto size-4 shrink-0 text-muted-foreground"
         />

--- a/studio/frontend/src/features/settings/components/recent-dictations-view.tsx
+++ b/studio/frontend/src/features/settings/components/recent-dictations-view.tsx
@@ -35,13 +35,15 @@ import { useT } from "@/i18n";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { toast } from "@/lib/toast";
 import {
-  ArrowLeft01Icon,
   Copy01Icon,
   Delete02Icon,
   Message01Icon,
   Search01Icon,
   ViewIcon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronLeftIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
@@ -206,7 +208,7 @@ export function RecentDictationsView({
           }
           className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+          <ChevronLeftIcon className="size-4" />
         </button>
         <h1 className="font-heading text-xl font-semibold">
           {t("settings.voice.title")}

--- a/studio/frontend/src/features/settings/tabs/data-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/data-tab.tsx
@@ -60,12 +60,14 @@ import { isDownloadCancelled, pickNativeChatImport } from "@/lib/native-files";
 import { toast } from "@/lib/toast";
 import {
   Archive02Icon,
-  ArrowLeft01Icon,
   Delete02Icon,
   Download01Icon,
   Tick02Icon,
   Upload01Icon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronLeftIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
@@ -497,7 +499,7 @@ export function DataTab() {
             aria-label={t("settings.data.backToData")}
             className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
-            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+            <ChevronLeftIcon className="size-4" />
           </button>
           <h1 className="text-xl font-semibold font-heading">
             {t("settings.data.title")}
@@ -526,7 +528,7 @@ export function DataTab() {
             aria-label={t("settings.data.backToData")}
             className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
-            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+            <ChevronLeftIcon className="size-4" />
           </button>
           <h1 className="text-xl font-semibold font-heading">
             {t("settings.data.title")}
@@ -599,7 +601,7 @@ export function DataTab() {
             aria-label={t("settings.data.backToData")}
             className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
-            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+            <ChevronLeftIcon className="size-4" />
           </button>
           <h1 className="text-xl font-semibold font-heading">
             {t("settings.data.title")}
@@ -627,7 +629,7 @@ export function DataTab() {
             aria-label={t("settings.data.backToData")}
             className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
-            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+            <ChevronLeftIcon className="size-4" />
           </button>
           <h1 className="text-xl font-semibold font-heading">
             {t("settings.data.title")}

--- a/studio/frontend/src/features/studio/sections/document-upload-redirect-dialog.tsx
+++ b/studio/frontend/src/features/studio/sections/document-upload-redirect-dialog.tsx
@@ -13,9 +13,11 @@ import {
 } from "@/components/ui/dialog";
 import { useT } from "@/i18n";
 import {
-  ArrowRight01Icon,
   DocumentAttachmentIcon,
 } from "@hugeicons/core-free-icons";
+import {
+  ChevronRightIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { ReactElement } from "react";
 
@@ -83,7 +85,7 @@ export function DocumentUploadRedirectDialog({
           </Button>
           <Button type="button" onClick={onOpenLearningRecipes}>
             {t("studio.dataset.documentRedirect.openAction")}
-            <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+            <ChevronRightIcon className="size-4" />
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/studio/frontend/src/features/studio/studio-page.tsx
+++ b/studio/frontend/src/features/studio/studio-page.tsx
@@ -17,8 +17,12 @@ import {
 import { useT } from "@/i18n";
 import { MediaPageLink } from "@/components/media-page-link";
 import { useImageWorkflowStore } from "@/features/images/stores/image-workflow-store";
-import { ArrowLeft01Icon, Image03Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Image03Icon,
+} from "@hugeicons/core-free-icons";
+import {
+  ChevronLeftIcon,
+} from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   type ReactElement,
@@ -205,7 +209,7 @@ export function StudioPage(): ReactElement {
                     onClick={clearHistorySelection}
                     aria-label={t("studio.backToHistory")}
                   >
-                    <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+                    <ChevronLeftIcon className="size-4" />
                   </Button>
                 )}
                 <TrainSubNav

--- a/studio/frontend/src/features/tour/components/guided-tour.tsx
+++ b/studio/frontend/src/features/tour/components/guided-tour.tsx
@@ -4,7 +4,14 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ArrowLeft01Icon, ArrowRight01Icon, Cancel01Icon, CheckmarkCircle01Icon } from "@hugeicons/core-free-icons";
+import {
+  Cancel01Icon,
+  CheckmarkCircle01Icon,
+} from "@hugeicons/core-free-icons";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -356,7 +363,7 @@ export function GuidedTour({
                           disabled={idx === 0}
                           onClick={() => setIdx((i) => Math.max(0, i - 1))}
                         >
-                          <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+                          <ChevronLeftIcon className="size-4" />
                           Back
                         </Button>
                         {isLast ? (
@@ -375,7 +382,7 @@ export function GuidedTour({
                             onClick={() => setIdx((i) => Math.min(total - 1, i + 1))}
                           >
                             Next
-                            <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+                            <ChevronRightIcon className="size-4" />
                           </Button>
                         )}
                       </div>

--- a/studio/frontend/src/features/train-model-picker/components/train-model-selector.tsx
+++ b/studio/frontend/src/features/train-model-picker/components/train-model-selector.tsx
@@ -59,7 +59,12 @@ import { toast } from "@/lib/toast";
 import { cn, formatCompact } from "@/lib/utils";
 import { buildModelVramMap } from "@/lib/vram";
 import type { ModelType, TrainingMethod } from "@/types/training";
-import { ArrowDown01Icon, ChipIcon } from "@hugeicons/core-free-icons";
+import {
+  ChipIcon,
+} from "@hugeicons/core-free-icons";
+import {
+  ChevronDownIcon,
+} from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -789,8 +794,7 @@ export function TrainModelSelector({
               {display ?? t("studio.modelPicker.selectModel")}
             </span>
           </span>
-          <HugeiconsIcon
-            icon={ArrowDown01Icon}
+          <ChevronDownIcon
             strokeWidth={1.25}
             className="size-3.5 shrink-0 text-muted-foreground"
           />


### PR DESCRIPTION
The single direction arrows came from two places and neither was a plain arrow.

## The curved hugeicons chevrons

The hugeicons set draws its chevrons as bezier curves rather than two straight segments meeting at a point, so they bow outward:

```
ArrowLeft01Icon   M15 6C15 6 9.00001 10.4189 9 12C8.99999 13.5812 15 18 15 18
ArrowRight01Icon  M9.00005 6C9.00005 6 15 10.4189 15 12C15 13.5812 9 18 9 18
```

`ArrowLeft02Icon` and `ArrowRight02Icon` do the same with a shaft attached. Those six are now the lucide equivalents, which the codebase already used elsewhere for the same job, so this is aligning on the plainer of two conventions already in the tree rather than introducing a third:

```
ArrowLeft01Icon  -> ChevronLeftIcon
ArrowRight01Icon -> ChevronRightIcon
ArrowUp01Icon    -> ChevronUpIcon
ArrowDown01Icon  -> ChevronDownIcon
ArrowLeft02Icon  -> ArrowLeftIcon
ArrowRight02Icon -> ArrowRightIcon
```

37 tag sites across 27 files, including one conditional (`icon={side === "left" ? ... : ...}` in the hub card carousel) which became a ternary over two elements.

## The hand rolled caret

`ArrowDownStandardIcon` was a local svg component with the same path copied into four files:

- `features/chat/mcp-composer-button.tsx`
- `features/chat/shared-composer.tsx`
- `features/rag/components/knowledge-base-composer-button.tsx`
- `components/assistant-ui/thread.tsx`

All four are gone in favour of `ChevronDownIcon`, keeping `strokeWidth={1.5}` so the caret weight is unchanged.

## Not touched

Only single direction arrows changed. Diagonal and bidirectional icons keep their current shape because they are not up, down, left or right: `ArrowUpRight01Icon` still marks external links, `ArrowUpDownIcon` still marks sort, and `ArrowLeftRightIcon`, `ArrowExpand01Icon`, `ArrowReloadHorizontalIcon` and `ArrowTurnBackwardIcon` are left as they are.

`HugeiconsIcon` and `type FC` imports that this left unused were dropped.

## Testing

- `npm run typecheck` clean
- `npm run test`: 6275 passing, 0 failing
- `npm run build` clean
- Biome diagnostics identical to baseline across all 32 touched files (751 before, 751 after)
- No references to the six replaced names or to `ArrowDownStandardIcon` remain in `src`
- The curved path above no longer appears in the built bundle
