### PR TITLE
Widen model picker panel and header controls

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -621,6 +621,9 @@ function ModelSelectorContent({
               section={effectiveHubSection}
               sectionToggle={
                 <PillTabs
+                  // Wider tabs than the shared default. The panel reserves
+                  // --picker-tab-pad a pill, so keep the two in step.
+                  className="[&_[role=tab]]:px-[calc(0.75rem_+_var(--picker-tab-pad)/2)]"
                   ariaLabel={t("picker.hubSectionAriaLabel")}
                   tabs={hubSectionTabs}
                   value={effectiveHubSection}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -324,15 +324,24 @@
 	--ui-icon-size-sm: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1)));
 	/* Model picker header controls. Padding and gaps come from the pinned
 	   --spacing, the icons and label both scale, so reserve each separately.
-	   The trigger is 2.25rem of padding and gaps, two icons, then the label.
-	   All match the h-9 / w-[110px] / 506px they replace at the 16px default. */
+	   The trigger is 2.25rem of padding and gaps, two icons, then the label,
+	   plus --picker-control-pad. Height matches the h-9 it replaces at the
+	   16px default. */
 	--picker-control-h: calc(1.125rem + 1.125rem * var(--ui-font-scale, 1));
-	--picker-control-w: calc(2.25rem + 2 * var(--ui-icon-size-sm) + 2.875rem * var(--ui-font-scale, 1));
+	/* Padding added to Search Hub and the two dropdowns, 0.375rem a side. Pinned
+	   like the rest: it pads, and it stops the "Trending" label clipping. */
+	--picker-control-pad: 0.75rem;
+	/* Same per section pill (Recommended / On Device / Connected), 0.25rem a
+	   side, i.e. px-3 to px-4 on the tabs. */
+	--picker-tab-pad: 0.5rem;
+	--picker-control-w: calc(2.25rem + var(--picker-control-pad) + 2 * var(--ui-icon-size-sm) + 2.875rem * var(--ui-font-scale, 1));
 	/* Panel: pl-4, two gaps and pr-2, the pills' padding, their two icons and
-	   label, then the two dropdowns. */
-	--picker-panel-w: calc(6.25rem + 2 * var(--ui-icon-size-sm) + 9.875rem * var(--ui-font-scale, 1) + 2 * var(--picker-control-w));
-	/* Provider row adds one more control; split like the rest. */
-	--picker-panel-w-external: calc(var(--picker-panel-w) + 4rem + 2.75rem * var(--ui-font-scale, 1));
+	   label, then the two dropdowns. The control row fills this exactly, which
+	   keeps the last dropdown flush with Search Hub above it. Widening a
+	   control takes the difference from the search field, not the panel. */
+	--picker-panel-w: calc(6.25rem + 2 * var(--picker-tab-pad) + 2 * var(--ui-icon-size-sm) + 9.875rem * var(--ui-font-scale, 1) + 2 * var(--picker-control-w));
+	/* Provider row adds one more control and the Connected pill; split like the rest. */
+	--picker-panel-w-external: calc(var(--picker-panel-w) + var(--picker-tab-pad) + 4rem + 2.75rem * var(--ui-font-scale, 1));
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns


### PR DESCRIPTION
### What

The model picker panel is a little wider, and the header controls get more padding, so long repo names and the sort label stop running out of room.

Before, `Trending` clipped to `Trend...` in the sort trigger, and names like `DeepSeek-V4-Flash-Vision-Exp-GGUF` truncated earlier than they needed to.

### How

The panel width was already derived from the controls it holds, so this adds two pinned tokens to that arithmetic in `index.css` rather than hardcoding new widths:

- `--picker-control-pad` (`0.75rem`) widens Search Hub, the format dropdown and the sort dropdown, 0.375rem a side
- `--picker-tab-pad` (`0.5rem`) widens each section pill (Recommended / On Device / Connected), 0.25rem a side

`--picker-panel-w` picks up two tab pads and two control pads, and `--picker-panel-w-external` picks up the third pill. Both keep the property that the control row fills the panel exactly, which is what holds the last dropdown flush with Search Hub above it. Since the search field is the only `flex-1` in that row, the width Search Hub gains comes out of the search field rather than out of the panel.

Tab padding is set on the picker's own `PillTabs` instance, so the Images and Audio pages that share the component keep the current default.

### Numbers

At the default font scale (0.9375):

| | before | after |
| --- | --- | --- |
| Panel | 485.1px | 525.1px |
| Panel (with Connected) | 590.4px | 638.4px |
| Search Hub / All / sort | 105.4px | 117.4px |
| Section pill padding | 12px a side | 16px a side |
| Search field | 339.8px | 367.8px |

### Testing

- `npm run build` and `npx tsc -b` clean
- Measured the computed tokens in the browser: the last dropdown's right edge and Search Hub's right edge both land at 509.125px, so the two header rows stay aligned
- Checked the Connected variant, which widens by one extra tab pad for the third pill
