### PR TITLE
Stop the kwarg-spacing post-pass dying on Python 3.11

### DIFF
--- a/scripts/enforce_kwargs_spacing.py
+++ b/scripts/enforce_kwargs_spacing.py
@@ -332,6 +332,15 @@ def _split_string_token(s: str) -> tuple[str, str, str] | None:
     return None
 
 
+# PEP 701 split f-strings into FSTRING_START/MIDDLE/END in 3.12. Before that one arrives
+# as a single STRING token, which the branch below already handles, so reading the names
+# unguarded raised AttributeError and killed the whole post-pass: `ruff format` had already
+# stripped the kwarg spacing this script exists to restore, so every file it touched came
+# back reformatted and the hook failed repo-wide. `t.type` is an int, so None never matches.
+_FSTRING_START = getattr(tokenize, "FSTRING_START", None)
+_FSTRING_END = getattr(tokenize, "FSTRING_END", None)
+
+
 # A "piece" is one string literal in source: a plain STRING token, or a whole
 # f-string spanning FSTRING_START..FSTRING_END. (kind, (row, col0), (row, col1), raw)
 def _string_pieces(
@@ -351,13 +360,13 @@ def _string_pieces(
         if t.type == tokenize.STRING:
             pieces.append(("str", t.start, t.end, raw_of(t.start, t.end)))
             i += 1
-        elif t.type == tokenize.FSTRING_START:
+        elif t.type == _FSTRING_START:
             depth = 0
             j = i
             while j < n:  # walk to the matching FSTRING_END (f-strings can nest)
-                if toks[j].type == tokenize.FSTRING_START:
+                if toks[j].type == _FSTRING_START:
                     depth += 1
-                elif toks[j].type == tokenize.FSTRING_END:
+                elif toks[j].type == _FSTRING_END:
                     depth -= 1
                     if depth == 0:
                         break


### PR DESCRIPTION
The `ruff-format-with-kwargs` hook has been failing on `main` itself, reporting around 1007 files reformatted and then "a conflict occurred when applying fixes to the pr", so pre-commit.ci can no longer self-heal any branch.

## Cause

`scripts/enforce_kwargs_spacing.py` reads `tokenize.FSTRING_START` and `tokenize.FSTRING_END`. Those names arrived in Python 3.12 with [PEP 701](https://peps.python.org/pep-0701/); on anything older the attribute lookup raises.

`scripts/run_ruff_format.py` runs `ruff format` first and the spacing post-pass second. When the post-pass dies, ruff has already stripped the spaced-kwarg style the post-pass exists to restore, so every file the hook touched comes back modified. The hook has no `language_version`, so it takes whatever interpreter the runner image defaults to.

Reproduced directly:

```
$ python3.11 scripts/run_ruff_format.py <120 files>
AttributeError: module 'tokenize' has no attribute 'FSTRING_START'
```

## Fix

Read the two names through `getattr` once. Before 3.12 an f-string arrives as a single `STRING` token, which the branch above already handles, so the merge is correctly left alone. `t.type` is an int, so comparing against `None` never matches.

## Measured

120 files under `studio/backend/core`, `studio/backend/routes` and `unsloth/kernels`, on Python 3.11:

| | files rewritten by the hook | `tests/test_enforce_kwargs_spacing.py` |
|---|---|---|
| before | 109 of 120 | 20 failed, 42 passed |
| after | 1 of 120 | 7 failed, 55 passed |

On Python 3.13 the suite is 62 passed before and after, so this changes nothing where the names already exist. The one remaining file is genuine drift on main, not a version artefact: 3.11 and 3.13 produce the identical edit for it.

## Not fixed here

The 7 remaining failures on 3.11 are the f-string merge and fold, which need the 3.12 token stream to locate the literal parts. That leaves the hook version-sensitive for f-strings specifically. Pinning `language_version` for the hook would make it deterministic, but that only works if the pre-commit.ci image ships that interpreter, which I cannot verify from here, so I have left the choice to you.