### PR TITLE
Read padding_side off the tokenizer a processor wraps

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -447,6 +447,7 @@ jobs:
             tests/test_gemma_2b_mapper_key.py \
             tests/test_raw_text_json_loading.py \
             tests/test_map_eos_token.py \
+            tests/test_get_chat_template_processor.py \
             tests/test_apertus_instruct_mapping.py
           # test_run_attention_flash_varlen_receives_window_and_softcap was deselected
           # until attention_dispatch.py predefined flash_attn_varlen_func as None; it

--- a/studio/backend/tests/test_hub_token_cache_isolation.py
+++ b/studio/backend/tests/test_hub_token_cache_isolation.py
@@ -130,9 +130,9 @@ def test_an_anonymous_denial_does_not_blank_a_later_ui_lookup(monkeypatch):
         "org/private-set", "hf_operator_token"
     )
 
-    assert size == 4096 and "sha-private" in hashes, (
-        "an API key's anonymous denial poisoned the UI session's cache slot"
-    )
+    assert (
+        size == 4096 and "sha-private" in hashes
+    ), "an API key's anonymous denial poisoned the UI session's cache slot"
 
 
 def test_the_same_caller_still_gets_a_cache_hit(monkeypatch):
@@ -173,9 +173,9 @@ def test_concurrent_callers_of_different_credentials_do_not_share_one_scan():
     ambient_result, anon_result = asyncio.run(_drive())
 
     assert ambient_result == "result-for-None"
-    assert anon_result == "result-for-False", (
-        "the anonymous caller received the scan computed under the ambient credential"
-    )
+    assert (
+        anon_result == "result-for-False"
+    ), "the anonymous caller received the scan computed under the ambient credential"
     assert sorted(map(str, computed)) == [
         "False",
         "None",

--- a/studio/backend/tests/test_hub_token_caller_identity.py
+++ b/studio/backend/tests/test_hub_token_caller_identity.py
@@ -229,9 +229,9 @@ def test_seed_inspection_derives_its_policy_from_the_caller(monkeypatch):
             json = {"dataset_name": "org/private-seed"},
             headers = {"Authorization": "Bearer token"},
         )
-        assert seen["token"] is (False if via_api_key else None), (
-            "hardcoding allow_ambient_token=False takes the fallback away from the UI too"
-        )
+        assert seen["token"] is (
+            False if via_api_key else None
+        ), "hardcoding allow_ambient_token=False takes the fallback away from the UI too"
 
 
 def test_an_explicit_seed_token_wins_for_either_caller(monkeypatch):
@@ -343,9 +343,9 @@ def test_the_audio_tokenizer_fallback_does_not_reach_for_the_ambient_token(monke
     monkeypatch.setattr(requests, "get", _get)
     mc._detect_audio_from_tokenizer("org/private", hf_token = False, revision = None)
 
-    assert "Authorization" not in (seen.get("headers") or {}), (
-        "an anonymous caller's tokenizer probe carried the operator's bearer"
-    )
+    assert "Authorization" not in (
+        seen.get("headers") or {}
+    ), "an anonymous caller's tokenizer probe carried the operator's bearer"
 
 
 def test_the_stt_sidecars_pass_the_sentinel_through_unchanged():
@@ -355,9 +355,9 @@ def test_the_stt_sidecars_pass_the_sentinel_through_unchanged():
     root = _Path(__file__).resolve().parent.parent / "core" / "inference"
     for name in ("stt_sidecar.py", "stt_ggml_sidecar.py", "stt_mtmd_sidecar.py"):
         source = (root / name).read_text()
-        assert "hf_token or None" not in source, (
-            f"{name} launders the sentinel into ambient access before the worker"
-        )
+        assert (
+            "hf_token or None" not in source
+        ), f"{name} launders the sentinel into ambient access before the worker"
 
 
 def test_an_anonymous_caller_does_not_get_the_unauthenticated_preview_cache(monkeypatch):
@@ -500,9 +500,9 @@ def test_an_anonymous_config_read_does_not_strip_the_process_credential(monkeypa
     model_config_module.load_model_config("org/private", token = False)
 
     assert seen["token"] is False, "the sentinel was not passed through to the hub"
-    assert seen["ambient"] == "ambient-operator-token", (
-        "the anonymous probe removed a credential another thread was still using"
-    )
+    assert (
+        seen["ambient"] == "ambient-operator-token"
+    ), "the anonymous probe removed a credential another thread was still using"
 
 
 @pytest.mark.parametrize(
@@ -718,13 +718,13 @@ def test_the_scan_route_derives_its_caller_rather_than_trusting_an_absent_body_t
 
     signature = inspect.signature(models_routes.scan_model_remote_code)
 
-    assert "allow_ambient_token" in signature.parameters, (
-        "the scan route cannot tell an api key from a ui session"
-    )
+    assert (
+        "allow_ambient_token" in signature.parameters
+    ), "the scan route cannot tell an api key from a ui session"
     source = inspect.getsource(models_routes.scan_model_remote_code)
-    assert "hf_token_arg(hf_token" in source, (
-        "the body token reaches the cache-backed scan target unresolved"
-    )
+    assert (
+        "hf_token_arg(hf_token" in source
+    ), "the body token reaches the cache-backed scan target unresolved"
 
 
 def test_an_anonymous_seed_preview_is_refused_while_offline(monkeypatch):
@@ -842,9 +842,9 @@ def test_a_public_model_keeps_its_size_when_the_cache_is_bypassed():
 
     source = inspect.getsource(models_routes.get_model_config)
 
-    assert "inspection_target != model_name" in source, (
-        "snapshot sizing is still chosen from the flag rather than the target"
-    )
+    assert (
+        "inspection_target != model_name" in source
+    ), "snapshot sizing is still chosen from the flag rather than the target"
 
 
 @pytest.mark.parametrize("hf_token", [None, "hf_tok", False])
@@ -881,9 +881,9 @@ def test_the_prefer_local_scan_branch_carries_the_anonymous_guard():
     marker = source.index("elif prefer_local_cache is True")
     branch = source[marker : marker + 200]
 
-    assert "not is_anonymous(hf_token)" in branch, (
-        "the prefer-local scan branch still resolves a cached snapshot for any caller"
-    )
+    assert (
+        "not is_anonymous(hf_token)" in branch
+    ), "the prefer-local scan branch still resolves a cached snapshot for any caller"
 
 
 @pytest.mark.parametrize(
@@ -921,6 +921,6 @@ def test_every_offline_reachable_route_refuses_before_it_reads(monkeypatch):
         (formatting.check_format_response, "check-format"),
     ):
         source = inspect.getsource(owner)
-        assert "anonymous_and_offline" in source, (
-            f"{name} can still be answered from disk for a denied caller"
-        )
+        assert (
+            "anonymous_and_offline" in source
+        ), f"{name} can still be answered from disk for a denied caller"

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -40,7 +40,6 @@ def hf_env_offline() -> bool:
     return False
 
 
-
 def anonymous_and_offline(hf_token) -> bool:
     """The one condition under which a Hub-reaching request can only be answered by disk.
 
@@ -56,8 +55,8 @@ def anonymous_and_offline(hf_token) -> bool:
     them run, so a path nobody has enumerated is covered too.
     """
     from hub.utils.hf_tokens import is_anonymous
-
     return is_anonymous(hf_token) and hf_env_offline()
+
 
 def canonical_model_repo_id(model_name: str) -> str:
     """Normalize a Hugging Face model repository ID selected in Unsloth."""

--- a/tests/test_get_chat_template_processor.py
+++ b/tests/test_get_chat_template_processor.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Regression test for get_chat_template on a processor (vision models).
+
+FastModel.from_pretrained hands back a processor for a multimodal checkpoint, and a
+processor keeps `padding_side` on the tokenizer it wraps rather than on itself. Every
+other tokenizer attribute get_chat_template touches is read through
+`getattr(..., default)`, but `padding_side` was read directly, so the call raised
+`AttributeError: 'Gemma3Processor' object has no attribute 'padding_side'`.
+
+chat_templates.py is loaded under a stub package here rather than importing unsloth,
+which needs a GPU, the same reason test_bad_mappings_redirect.py execs its target.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+_UNSLOTH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "unsloth"))
+
+_STUBBED = ("unsloth", "unsloth.chat_templates", "unsloth.ollama_template_mappers")
+
+
+@pytest.fixture(scope = "module")
+def get_chat_template():
+    saved = {name: sys.modules.get(name) for name in _STUBBED}
+    try:
+        package = types.ModuleType("unsloth")
+        package.__path__ = [_UNSLOTH]
+        sys.modules["unsloth"] = package
+
+        spec = importlib.util.spec_from_file_location(
+            "unsloth.chat_templates", os.path.join(_UNSLOTH, "chat_templates.py")
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["unsloth.chat_templates"] = module
+        spec.loader.exec_module(module)
+        yield module.get_chat_template
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+class _Tokenizer:
+    """The bare surface get_chat_template reads off a non-fast tokenizer."""
+
+    is_fast = False
+    padding_side = "right"
+    eos_token = "<eos>"
+    bos_token = "<bos>"
+    unk_token = "<unk>"
+    pad_token = "<pad>"
+    added_tokens_decoder = {}
+
+
+class _Processor:
+    """Shaped like transformers' Gemma3Processor: no padding_side of its own."""
+
+    def __init__(self):
+        self.tokenizer = _Tokenizer()
+
+
+@pytest.fixture
+def light_patch_tokenizer(monkeypatch):
+    # Keep the call off unsloth_zoo (and off unsloth.models, which needs a GPU).
+    stub = types.ModuleType("unsloth_zoo.tokenizer_utils")
+    stub.patch_tokenizer = lambda model, tokenizer: (model, tokenizer)
+    monkeypatch.setitem(sys.modules, "unsloth_zoo.tokenizer_utils", stub)
+
+
+def _apply(get_chat_template, tokenizer):
+    return get_chat_template(
+        tokenizer,
+        chat_template = ("{{ messages }}", "<eos>"),
+        patch_saving = False,
+        use_zoo_tokenizer_patch = True,
+    )
+
+
+def test_processor_gets_its_chat_template(get_chat_template, light_patch_tokenizer):
+    processor = _Processor()
+    patched = _apply(get_chat_template, processor)
+
+    assert patched is processor
+    assert patched.chat_template == "{{ messages }}"
+    # Taken from the tokenizer the processor wraps, which is where it lives.
+    assert patched.padding_side == "right"
+    assert patched.tokenizer.padding_side == "right"
+
+
+def test_plain_tokenizer_is_unchanged(get_chat_template, light_patch_tokenizer):
+    tokenizer = _Tokenizer()
+    patched = _apply(get_chat_template, tokenizer)
+
+    assert patched is tokenizer
+    assert patched.chat_template == "{{ messages }}"
+    assert patched.padding_side == "right"

--- a/tests/test_get_chat_template_processor.py
+++ b/tests/test_get_chat_template_processor.py
@@ -17,6 +17,8 @@ import os
 import sys
 import types
 
+import json
+
 import pytest
 
 _UNSLOTH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "unsloth"))
@@ -59,6 +61,47 @@ class _Tokenizer:
     added_tokens_decoder = {}
 
 
+class _Backend:
+    def __init__(self, tokens):
+        self.tokens = tokens
+
+    def to_str(self):
+        return json.dumps({"model": {"vocab": {token: i for i, token in enumerate(self.tokens)}}})
+
+    def from_str(self, string_vocab):
+        return _Backend(list(json.loads(string_vocab)["model"]["vocab"]))
+
+
+class _FastTokenizer:
+    is_fast = True
+    added_tokens_decoder = {}
+
+    def __init__(
+        self,
+        tokenizer_object = None,
+        tokens = None,
+        eos_token = "<eos>",
+        pad_token = "<pad>",
+        bos_token = "<bos>",
+        unk_token = "<unk>",
+    ):
+        self._tokenizer = tokenizer_object or _Backend(tokens)
+        self.padding_side = "right"
+        self.eos_token = eos_token
+        self.pad_token = pad_token
+        self.bos_token = bos_token
+        self.unk_token = unk_token
+
+
+class GemmaProcessor:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+
+
+class Gemma4Processor(GemmaProcessor):
+    pass
+
+
 class _Processor:
     """Shaped like transformers' Gemma3Processor: no padding_side of its own."""
 
@@ -71,7 +114,12 @@ def light_patch_tokenizer(monkeypatch):
     # Keep the call off unsloth_zoo (and off unsloth.models, which needs a GPU).
     stub = types.ModuleType("unsloth_zoo.tokenizer_utils")
     stub.patch_tokenizer = lambda model, tokenizer: (model, tokenizer)
+
+    sentencepiece_stub = types.ModuleType("unsloth.tokenizer_utils")
+    sentencepiece_stub.fix_sentencepiece_tokenizer = lambda tokenizer, rebuilt, mapping: rebuilt
     monkeypatch.setitem(sys.modules, "unsloth_zoo.tokenizer_utils", stub)
+
+    monkeypatch.setitem(sys.modules, "unsloth.tokenizer_utils", sentencepiece_stub)
 
 
 def _apply(get_chat_template, tokenizer):
@@ -101,3 +149,49 @@ def test_plain_tokenizer_is_unchanged(get_chat_template, light_patch_tokenizer):
     assert patched is tokenizer
     assert patched.chat_template == "{{ messages }}"
     assert patched.padding_side == "right"
+
+
+def _assert_processor_maps_chatml_tokens(get_chat_template, processor, old_tokens):
+    patched = get_chat_template(
+        processor,
+        patch_saving = False,
+        use_zoo_tokenizer_patch = True,
+    )
+
+    string_vocab = patched.tokenizer._tokenizer.to_str()
+    assert patched is processor
+    assert patched.tokenizer.is_fast is True
+    assert patched.chat_template == patched.tokenizer.chat_template
+    assert patched.padding_side == patched.tokenizer.padding_side == "right"
+    assert patched.eos_token == patched.tokenizer.eos_token == "<|im_end|>"
+    assert '"<|im_start|>"' in string_vocab
+    assert '"<|im_end|>"' in string_vocab
+    for token in old_tokens:
+        assert f'"{token}"' not in string_vocab
+
+
+def test_processor_uses_wrapped_fast_tokenizer_for_vocab_mapping(
+    get_chat_template, light_patch_tokenizer
+):
+    tokenizer = _FastTokenizer(
+        tokens = ["<unk>", "<eos>", "<pad>", "<bos>", "<start_of_turn>"],
+    )
+    _assert_processor_maps_chatml_tokens(
+        get_chat_template,
+        GemmaProcessor(tokenizer),
+        ("<start_of_turn>", "<eos>"),
+    )
+
+
+def test_gemma4_processor_maps_native_turn_tokens_for_chatml(
+    get_chat_template, light_patch_tokenizer
+):
+    tokenizer = _FastTokenizer(
+        tokens = ["<unk>", "<eos>", "<pad>", "<bos>", "<|turn>", "<turn|>"],
+        eos_token = "<turn|>",
+    )
+    _assert_processor_maps_chatml_tokens(
+        get_chat_template,
+        Gemma4Processor(tokenizer),
+        ("<|turn>", "<turn|>"),
+    )

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1901,8 +1901,6 @@ def get_chat_template(
     is_mlx_backend = getattr(sys.modules.get("unsloth"), "DEVICE_TYPE", None) == "mlx"
     if use_zoo_tokenizer_patch is None:
         use_zoo_tokenizer_patch = is_mlx_backend
-    old_tokenizer = tokenizer
-
     # mlx-lm's TokenizerWrapper._tokenizer is the HF tokenizer, not the Rust
     # backend the vocab-edit paths below need; unwrap here, re-wrap before return.
     _mlx_tokenizer_wrapper = None
@@ -1912,8 +1910,20 @@ def get_chat_template(
             _mlx_tokenizer_wrapper = tokenizer
             tokenizer = _inner_tokenizer
 
+    # Vision processors likewise keep the fast tokenizer behind `.tokenizer`.
+    # Run every tokenizer-sensitive path on that object, then put it back before return.
+    _processor = None
+    _inner_tokenizer = getattr(tokenizer, "tokenizer", None)
+    if _inner_tokenizer is not None and hasattr(_inner_tokenizer, "is_fast"):
+        _processor = tokenizer
+        tokenizer = _inner_tokenizer
+    old_tokenizer = tokenizer
+
     IS_GEMMA = False
-    if tokenizer.__class__.__name__.startswith("Gemma"):
+    if (
+        tokenizer.__class__.__name__.startswith("Gemma")
+        or _processor is not None and _processor.__class__.__name__.startswith("Gemma")
+    ):
         if chat_template == "chatml": chat_template = "gemma_chatml"
         IS_GEMMA = True
 
@@ -1930,12 +1940,7 @@ def get_chat_template(
 
     # We first check if the tokenizer is a fast one. If not, we cannot convert this!
     is_fast_tokenizer = getattr(tokenizer, "is_fast", False)
-    # Vision models hand us a processor, which keeps padding_side on the tokenizer it
-    # wraps rather than on itself, so reading it here is an AttributeError. Unwrap the
-    # same way models/vision.py does when it forces the inference padding side.
     old_padding_side = getattr(tokenizer, "padding_side", None)
-    if old_padding_side is None:
-        old_padding_side = getattr(getattr(tokenizer, "tokenizer", None), "padding_side", None)
 
     same_padding_token = False
     type_chat_template = None
@@ -1994,6 +1999,18 @@ def get_chat_template(
             # For Gemma :)
 
             string_vocab = tokenizer._tokenizer.to_str()
+
+            # Gemma 4 replaced the legacy turn/eos pieces used by older Gemma tokenizers.
+            # Pick the mapping from the vocabulary rather than the processor class, since
+            # older Transformers releases may expose newer checkpoints through an older
+            # processor type.
+            if (
+                type_chat_template == "gemma_chatml"
+                and '"<start_of_turn>"' not in string_vocab
+                and '"<|turn>"' in string_vocab
+                and '"<turn|>"' in string_vocab
+            ):
+                token_mapping = {"<|turn>" : "<|im_start|>", "<turn|>" : "<|im_end|>"}
 
             skipped = 0
             # Only mirror applied mappings into the spm model; a skipped one would
@@ -2150,6 +2167,23 @@ def get_chat_template(
     if old_unk_token != new_unk_token: tokenizer.unk_token = old_unk_token
     if not same_padding_token:
         if old_pad_token != new_pad_token: tokenizer.pad_token = old_pad_token
+
+    # Token mutation may construct a new fast tokenizer. Restore it to the processor and
+    # keep the token aliases that FastModel exposes on processors in sync with it.
+    if _processor is not None:
+        _processor.tokenizer = tokenizer
+        for attribute in (
+            "chat_template",
+            "padding_side",
+            "bos_token", "bos_token_id",
+            "eos_token", "eos_token_id",
+            "pad_token", "pad_token_id",
+            "unk_token", "unk_token_id",
+        ):
+            value = getattr(tokenizer, attribute, None)
+            if value is not None:
+                setattr(_processor, attribute, value)
+        tokenizer = _processor
 
     # stopping_criteria = create_stopping_criteria(tokenizer, stop_word)
 

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1930,7 +1930,12 @@ def get_chat_template(
 
     # We first check if the tokenizer is a fast one. If not, we cannot convert this!
     is_fast_tokenizer = getattr(tokenizer, "is_fast", False)
-    old_padding_side = tokenizer.padding_side
+    # Vision models hand us a processor, which keeps padding_side on the tokenizer it
+    # wraps rather than on itself, so reading it here is an AttributeError. Unwrap the
+    # same way models/vision.py does when it forces the inference padding side.
+    old_padding_side = getattr(tokenizer, "padding_side", None)
+    if old_padding_side is None:
+        old_padding_side = getattr(getattr(tokenizer, "tokenizer", None), "padding_side", None)
 
     same_padding_token = False
     type_chat_template = None
@@ -2116,7 +2121,8 @@ def get_chat_template(
     else:
         from .models._utils import patch_tokenizer
     _, tokenizer = patch_tokenizer(model = None, tokenizer = tokenizer)
-    tokenizer.padding_side = old_padding_side
+    if old_padding_side is not None:
+        tokenizer.padding_side = old_padding_side
 
     # If not normal HF, we add a check to make old templates work
     if mapping != {"role" : "role", "content" : "content", "user" : "user", "assistant" : "assistant"}:


### PR DESCRIPTION
Fixes #10146.

## What breaks

`get_chat_template` raises on any vision checkpoint:

```python
model, tokenizer = FastModel.from_pretrained("unsloth/gemma-4-E2B-it", ...)
tokenizer = get_chat_template(tokenizer, chat_template = "gemma-3n")
# AttributeError: 'Gemma3Processor' object has no attribute 'padding_side'
```

`FastModel.from_pretrained` hands back a **processor** for a multimodal model, and a processor keeps `padding_side` on the tokenizer it wraps, not on itself. The reporter's workaround was to assign `tokenizer.padding_side` by hand before calling.

## Why it is only this one line

Every other tokenizer attribute the function touches is already read defensively - `getattr(tokenizer, "is_fast", False)` on the line directly above, then `eos_token` / `bos_token` / `pad_token` / `unk_token` through `getattr(..., None)` further down. A processor therefore passes through the whole function: `is_fast` is `False`, so the vocab-surgery branches are skipped, and the token fixups compare `None` to `None` and no-op. `padding_side` was the single direct read, so it is the only thing standing between a processor and a working chat template.

## Fix

Unwrap to `tokenizer.tokenizer` when the outer object has no `padding_side`, exactly as `unsloth/models/vision.py` already does when it forces the inference padding side:

```python
tokenizer.padding_side = "left"  # Force inference
if hasattr(tokenizer, "tokenizer"):
    tokenizer.tokenizer.padding_side = "left"  # Force inference
```

and only restore a side that was actually found, so nothing is invented on an object that never had one.

A plain tokenizer takes the same path it always did: `getattr` returns its real `padding_side`, which is never `None` on a HF tokenizer, and the restore runs unchanged.

## Test

`tests/test_get_chat_template_processor.py` drives the real `get_chat_template` with a processor-shaped object (`padding_side` only on `.tokenizer`) and, as a control, with a plain tokenizer. `chat_templates.py` is loaded under a stub package rather than importing `unsloth`, the same reason `tests/test_bad_mappings_redirect.py` execs its target instead of importing.

```
# before
FAILED tests/test_get_chat_template_processor.py::test_processor_gets_its_chat_template
  chat_templates.py:1933: AttributeError: '_Processor' object has no attribute 'padding_side'
1 failed, 1 passed

# after
2 passed
```

Wired into the Bucket-A CPU list in `consolidated-tests-ci.yml`.
