### PR TITLE
Fix pre-commit formatting drift after #10076

### DIFF
--- a/studio/backend/tests/test_hub_token_cache_isolation.py
+++ b/studio/backend/tests/test_hub_token_cache_isolation.py
@@ -130,9 +130,9 @@ def test_an_anonymous_denial_does_not_blank_a_later_ui_lookup(monkeypatch):
         "org/private-set", "hf_operator_token"
     )
 
-    assert size == 4096 and "sha-private" in hashes, (
-        "an API key's anonymous denial poisoned the UI session's cache slot"
-    )
+    assert (
+        size == 4096 and "sha-private" in hashes
+    ), "an API key's anonymous denial poisoned the UI session's cache slot"
 
 
 def test_the_same_caller_still_gets_a_cache_hit(monkeypatch):
@@ -173,9 +173,9 @@ def test_concurrent_callers_of_different_credentials_do_not_share_one_scan():
     ambient_result, anon_result = asyncio.run(_drive())
 
     assert ambient_result == "result-for-None"
-    assert anon_result == "result-for-False", (
-        "the anonymous caller received the scan computed under the ambient credential"
-    )
+    assert (
+        anon_result == "result-for-False"
+    ), "the anonymous caller received the scan computed under the ambient credential"
     assert sorted(map(str, computed)) == [
         "False",
         "None",

--- a/studio/backend/tests/test_hub_token_caller_identity.py
+++ b/studio/backend/tests/test_hub_token_caller_identity.py
@@ -229,9 +229,9 @@ def test_seed_inspection_derives_its_policy_from_the_caller(monkeypatch):
             json = {"dataset_name": "org/private-seed"},
             headers = {"Authorization": "Bearer token"},
         )
-        assert seen["token"] is (False if via_api_key else None), (
-            "hardcoding allow_ambient_token=False takes the fallback away from the UI too"
-        )
+        assert seen["token"] is (
+            False if via_api_key else None
+        ), "hardcoding allow_ambient_token=False takes the fallback away from the UI too"
 
 
 def test_an_explicit_seed_token_wins_for_either_caller(monkeypatch):
@@ -343,9 +343,9 @@ def test_the_audio_tokenizer_fallback_does_not_reach_for_the_ambient_token(monke
     monkeypatch.setattr(requests, "get", _get)
     mc._detect_audio_from_tokenizer("org/private", hf_token = False, revision = None)
 
-    assert "Authorization" not in (seen.get("headers") or {}), (
-        "an anonymous caller's tokenizer probe carried the operator's bearer"
-    )
+    assert "Authorization" not in (
+        seen.get("headers") or {}
+    ), "an anonymous caller's tokenizer probe carried the operator's bearer"
 
 
 def test_the_stt_sidecars_pass_the_sentinel_through_unchanged():
@@ -355,9 +355,9 @@ def test_the_stt_sidecars_pass_the_sentinel_through_unchanged():
     root = _Path(__file__).resolve().parent.parent / "core" / "inference"
     for name in ("stt_sidecar.py", "stt_ggml_sidecar.py", "stt_mtmd_sidecar.py"):
         source = (root / name).read_text()
-        assert "hf_token or None" not in source, (
-            f"{name} launders the sentinel into ambient access before the worker"
-        )
+        assert (
+            "hf_token or None" not in source
+        ), f"{name} launders the sentinel into ambient access before the worker"
 
 
 def test_an_anonymous_caller_does_not_get_the_unauthenticated_preview_cache(monkeypatch):
@@ -500,9 +500,9 @@ def test_an_anonymous_config_read_does_not_strip_the_process_credential(monkeypa
     model_config_module.load_model_config("org/private", token = False)
 
     assert seen["token"] is False, "the sentinel was not passed through to the hub"
-    assert seen["ambient"] == "ambient-operator-token", (
-        "the anonymous probe removed a credential another thread was still using"
-    )
+    assert (
+        seen["ambient"] == "ambient-operator-token"
+    ), "the anonymous probe removed a credential another thread was still using"
 
 
 @pytest.mark.parametrize(
@@ -718,13 +718,13 @@ def test_the_scan_route_derives_its_caller_rather_than_trusting_an_absent_body_t
 
     signature = inspect.signature(models_routes.scan_model_remote_code)
 
-    assert "allow_ambient_token" in signature.parameters, (
-        "the scan route cannot tell an api key from a ui session"
-    )
+    assert (
+        "allow_ambient_token" in signature.parameters
+    ), "the scan route cannot tell an api key from a ui session"
     source = inspect.getsource(models_routes.scan_model_remote_code)
-    assert "hf_token_arg(hf_token" in source, (
-        "the body token reaches the cache-backed scan target unresolved"
-    )
+    assert (
+        "hf_token_arg(hf_token" in source
+    ), "the body token reaches the cache-backed scan target unresolved"
 
 
 def test_an_anonymous_seed_preview_is_refused_while_offline(monkeypatch):
@@ -842,9 +842,9 @@ def test_a_public_model_keeps_its_size_when_the_cache_is_bypassed():
 
     source = inspect.getsource(models_routes.get_model_config)
 
-    assert "inspection_target != model_name" in source, (
-        "snapshot sizing is still chosen from the flag rather than the target"
-    )
+    assert (
+        "inspection_target != model_name" in source
+    ), "snapshot sizing is still chosen from the flag rather than the target"
 
 
 @pytest.mark.parametrize("hf_token", [None, "hf_tok", False])
@@ -881,9 +881,9 @@ def test_the_prefer_local_scan_branch_carries_the_anonymous_guard():
     marker = source.index("elif prefer_local_cache is True")
     branch = source[marker : marker + 200]
 
-    assert "not is_anonymous(hf_token)" in branch, (
-        "the prefer-local scan branch still resolves a cached snapshot for any caller"
-    )
+    assert (
+        "not is_anonymous(hf_token)" in branch
+    ), "the prefer-local scan branch still resolves a cached snapshot for any caller"
 
 
 @pytest.mark.parametrize(
@@ -921,6 +921,6 @@ def test_every_offline_reachable_route_refuses_before_it_reads(monkeypatch):
         (formatting.check_format_response, "check-format"),
     ):
         source = inspect.getsource(owner)
-        assert "anonymous_and_offline" in source, (
-            f"{name} can still be answered from disk for a denied caller"
-        )
+        assert (
+            "anonymous_and_offline" in source
+        ), f"{name} can still be answered from disk for a denied caller"

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -40,7 +40,6 @@ def hf_env_offline() -> bool:
     return False
 
 
-
 def anonymous_and_offline(hf_token) -> bool:
     """The one condition under which a Hub-reaching request can only be answered by disk.
 
@@ -56,8 +55,8 @@ def anonymous_and_offline(hf_token) -> bool:
     them run, so a path nobody has enumerated is covered too.
     """
     from hub.utils.hf_tokens import is_anonymous
-
     return is_anonymous(hf_token) and hf_env_offline()
+
 
 def canonical_model_repo_id(model_name: str) -> str:
     """Normalize a Hugging Face model repository ID selected in Unsloth."""


### PR DESCRIPTION
## Summary

- apply the repository formatter to the three Python files with formatting drift from #10076
- prevent unrelated formatting changes from being added to newly opened or updated PRs
- preserve behavior; the Python AST is identical before and after

## Verification

- full all-files pre-commit run
- Python byte-compilation of the three changed files
- deterministic worktree and pre-push safety gates