### PR TITLE
Studio: keep tool cards in place when you edit a reply

### DIFF
--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -8,9 +8,18 @@ type ThreadImportExport = {
 
 type ContentPart = { type: "text" | "reasoning" | "tool"; text: string };
 
+export function isEditablePart(part: any): boolean {
+  return part?.type === 'text' || part?.type === 'reasoning';
+}
+
+function toolLabel(part: any): string {
+  if (typeof part?.toolName === 'string' && part.toolName) return part.toolName;
+  return typeof part?.type === 'string' && part.type ? part.type : "tool";
+}
+
 /**
- * Extracts only the editable text and reasoning from a message,
- * ignoring structured parts like tool calls that cannot be edited as plain text.
+ * Extracts the editable text and reasoning from a message, with a placeholder tag
+ * recording where each non-editable part sat among the prose.
  */
 export function extractTaggedText(content: any): string {
   if (typeof content === 'string') return content;
@@ -24,21 +33,19 @@ export function extractTaggedText(content: any): string {
       if (typeof part === 'string') return part;
       if (!part) return "";
 
-      // Only extract text from 'text' or 'reasoning' parts.
-      // Tool calls/responses are ignored here so they aren't accidentally
-      // deleted or corrupted by the user in the textarea.
+      if (!isEditablePart(part)) {
+        return `${open}TOOL${close}${toolLabel(part)}${open}/TOOL${close}`;
+      }
+
       const text = part.text || part.content || "";
       if (!text) return "";
 
-      switch (part.type) {
-        case 'reasoning':
-          // Trim the text first so we don't accumulate newlines
-          // around the tags on every save.
-          return `${open}THINK${close}\n${text.trim()}\n${open}/THINK${close}`;
-        case 'text':
-        default:
-          return text;
+      // Trim the text first so we don't accumulate newlines
+      // around the tags on every save.
+      if (part.type === 'reasoning') {
+        return `${open}THINK${close}\n${text.trim()}\n${open}/THINK${close}`;
       }
+      return text;
     })
     .filter(Boolean)
     .join('\n\n');
@@ -101,22 +108,20 @@ export async function updateThreadMessage(args: {
     let finalContent: any[] = [];
 
     if (Array.isArray(originalContent)) {
-      const firstEditableIndex = originalContent.findIndex((part: any) =>
-        part.type === 'text' || part.type === 'reasoning'
+      const nonEditableParts = originalContent.filter(
+        (part: any) => !isEditablePart(part)
       );
-
-      if (firstEditableIndex === -1) {
-        const nonEditableParts = originalContent.filter((part: any) =>
-          part.type !== 'text' && part.type !== 'reasoning'
-        );
-        finalContent = [...parsedEditableContent, ...nonEditableParts];
-      } else {
-        const before = originalContent.slice(0, firstEditableIndex);
-        const after = originalContent.slice(firstEditableIndex + 1).filter((part: any) =>
-          part.type !== 'text' && part.type !== 'reasoning'
-        );
-        finalContent = [...before, ...parsedEditableContent, ...after];
+      let restored = 0;
+      for (const part of parsedEditableContent) {
+        if (part.type === 'tool') {
+          if (restored < nonEditableParts.length) {
+            finalContent.push(nonEditableParts[restored++]);
+          }
+          continue;
+        }
+        finalContent.push(part);
       }
+      finalContent.push(...nonEditableParts.slice(restored));
     } else {
       finalContent = parsedEditableContent;
     }

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -8,8 +8,11 @@ type ThreadImportExport = {
 
 type ContentPart = { type: "text" | "reasoning" | "tool"; text: string; slot?: number };
 
+// A raw string is prose that extractTaggedText emits as-is, without a marker. It has to
+// count as editable here too, or the restoration list gains a slot the editor never
+// numbered and every marker after it restores the wrong part.
 export function isEditablePart(part: any): boolean {
-  return part?.type === 'text' || part?.type === 'reasoning';
+  return typeof part === 'string' || part?.type === 'text' || part?.type === 'reasoning';
 }
 
 function toolLabel(part: any): string {
@@ -46,7 +49,7 @@ export function extractTaggedText(content: any): string {
 
   return content
     .map((part: any) => {
-      if (typeof part === 'string') return part;
+      if (typeof part === 'string') return escapeMarkers(part);
       if (!part) return "";
 
       if (!isEditablePart(part)) {
@@ -68,6 +71,16 @@ export function extractTaggedText(content: any): string {
     .join('\n\n');
 }
 
+// extractTaggedText joins parts with a blank line and puts a newline inside the THINK
+// tags. Only that separator may be removed: trimming instead would eat a reply's own
+// leading whitespace, and four spaces are an indented code block, not padding.
+function stripSeparators(text: string, afterTag: boolean, beforeTag: boolean): string {
+  let out = text;
+  if (afterTag) out = out.replace(/^\n\n?/, "");
+  if (beforeTag) out = out.replace(/\n\n?$/, "");
+  return out;
+}
+
 function parseTaggedTextToContent(text: string): ContentPart[] {
   const parts: ContentPart[] = [];
   // A tool marker is one whole token carrying its slot number. Requiring the number
@@ -76,6 +89,7 @@ function parseTaggedTextToContent(text: string): ContentPart[] {
   const tagRegex = /<\/?THINK>|<TOOL (\d+): ([^<>\n]*)>/g;
   let lastIndex = 0;
   let match;
+  let sawTag = false;
   let currentType: ContentPart["type"] = "text";
 
   while ((match = tagRegex.exec(text)) !== null) {
@@ -83,11 +97,12 @@ function parseTaggedTextToContent(text: string): ContentPart[] {
     const index = match.index;
 
     if (index > lastIndex) {
-      // Trim the extracted content to remove any leading/trailing
-      // newlines created by the tag wrapping process.
-      const content = text.substring(lastIndex, index).trim();
+      const content = stripSeparators(
+        text.substring(lastIndex, index), sawTag, true,
+      );
       if (content) parts.push({ type: currentType, text: unescapeMarkers(content) });
     }
+    sawTag = true;
     lastIndex = index + fullTag.length;
 
     if (match[1] !== undefined) {
@@ -98,7 +113,7 @@ function parseTaggedTextToContent(text: string): ContentPart[] {
   }
 
   if (lastIndex < text.length) {
-    const remainingText = text.substring(lastIndex).trim();
+    const remainingText = stripSeparators(text.substring(lastIndex), sawTag, false);
     if (remainingText) parts.push({ type: currentType, text: unescapeMarkers(remainingText) });
   }
 

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -40,7 +40,7 @@ function unescapeMarkers(text: string): string {
  * marker recording where each non-editable part sat among the prose.
  */
 export function extractTaggedText(content: any): string {
-  if (typeof content === 'string') return content;
+  if (typeof content === 'string') return escapeMarkers(content);
   if (!Array.isArray(content)) return "";
 
   const open = "\u003C"; // <

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -11,7 +11,7 @@ type ContentPart = { type: "text" | "reasoning" | "tool"; text: string; slot?: n
 // A raw string is prose that extractTaggedText emits as-is, without a marker. It has to
 // count as editable here too, or the restoration list gains a slot the editor never
 // numbered and every marker after it restores the wrong part.
-export function isEditablePart(part: any): boolean {
+function isEditablePart(part: any): boolean {
   return typeof part === 'string' || part?.type === 'text' || part?.type === 'reasoning';
 }
 

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -6,20 +6,23 @@ type ThreadImportExport = {
   import: (data: ExportedMessageRepository) => void;
 };
 
-type ContentPart = { type: "text" | "reasoning" | "tool"; text: string };
+type ContentPart = { type: "text" | "reasoning" | "tool"; text: string; slot?: number };
 
 export function isEditablePart(part: any): boolean {
   return part?.type === 'text' || part?.type === 'reasoning';
 }
 
 function toolLabel(part: any): string {
-  if (typeof part?.toolName === 'string' && part.toolName) return part.toolName;
-  return typeof part?.type === 'string' && part.type ? part.type : "tool";
+  const name = typeof part?.toolName === 'string' && part.toolName ? part.toolName : part?.type;
+  // The marker is one line delimited by angle brackets, so a label carrying
+  // either would not survive the round trip.
+  const label = typeof name === 'string' ? name.replace(/[<>\n]+/g, ' ').trim() : "";
+  return label || "tool";
 }
 
 /**
- * Extracts the editable text and reasoning from a message, with a placeholder tag
- * recording where each non-editable part sat among the prose.
+ * Extracts the editable text and reasoning from a message, with a numbered placeholder
+ * marker recording where each non-editable part sat among the prose.
  */
 export function extractTaggedText(content: any): string {
   if (typeof content === 'string') return content;
@@ -27,6 +30,7 @@ export function extractTaggedText(content: any): string {
 
   const open = "\u003C"; // <
   const close = "\u003E"; // >
+  let slot = 0;
 
   return content
     .map((part: any) => {
@@ -34,7 +38,8 @@ export function extractTaggedText(content: any): string {
       if (!part) return "";
 
       if (!isEditablePart(part)) {
-        return `${open}TOOL${close}${toolLabel(part)}${open}/TOOL${close}`;
+        slot += 1;
+        return `${open}TOOL ${slot}: ${toolLabel(part)}${close}`;
       }
 
       const text = part.text || part.content || "";
@@ -53,14 +58,16 @@ export function extractTaggedText(content: any): string {
 
 function parseTaggedTextToContent(text: string): ContentPart[] {
   const parts: ContentPart[] = [];
-  const tagRegex = /(<\/?(THINK|TOOL)>)/g;
+  // A tool marker is one whole token carrying its slot number. Requiring the number
+  // keeps a reply that merely writes <TOOL>name</TOOL> in its prose, and a marker the
+  // user half-deleted, from being read as a marker.
+  const tagRegex = /<\/?THINK>|<TOOL (\d+): ([^<>\n]*)>/g;
   let lastIndex = 0;
   let match;
   let currentType: ContentPart["type"] = "text";
 
   while ((match = tagRegex.exec(text)) !== null) {
     const fullTag = match[0];
-    const tagName = match[2];
     const index = match.index;
 
     if (index > lastIndex) {
@@ -69,9 +76,13 @@ function parseTaggedTextToContent(text: string): ContentPart[] {
       const content = text.substring(lastIndex, index).trim();
       if (content) parts.push({ type: currentType, text: content });
     }
-
-    currentType = fullTag.startsWith("</") ? "text" : (tagName === "THINK" ? "reasoning" : "tool");
     lastIndex = index + fullTag.length;
+
+    if (match[1] !== undefined) {
+      parts.push({ type: "tool", text: fullTag, slot: Number(match[1]) });
+      continue;
+    }
+    currentType = fullTag.startsWith("</") ? "text" : "reasoning";
   }
 
   if (lastIndex < text.length) {
@@ -105,25 +116,50 @@ export async function updateThreadMessage(args: {
     if (m.message.id !== messageId) return m;
 
     const originalContent = m.message.content;
-    let finalContent: any[] = [];
+    const finalContent: any[] = [];
+
+    // Text the editor produced, appended to the run before it rather than opening a
+    // second text part, so a save never multiplies the parts of a reply.
+    const pushText = (text: string) => {
+      const last = finalContent[finalContent.length - 1];
+      if (last && last.type === 'text') {
+        last.text = `${last.text}\n\n${text}`;
+        return;
+      }
+      finalContent.push({ type: 'text', text });
+    };
 
     if (Array.isArray(originalContent)) {
       const nonEditableParts = originalContent.filter(
         (part: any) => !isEditablePart(part)
       );
-      let restored = 0;
+      const restored = new Set<number>();
+
       for (const part of parsedEditableContent) {
-        if (part.type === 'tool') {
-          if (restored < nonEditableParts.length) {
-            finalContent.push(nonEditableParts[restored++]);
-          }
+        if (part.type !== 'tool') {
+          if (part.type === 'text') pushText(part.text);
+          else finalContent.push(part);
           continue;
         }
-        finalContent.push(part);
+        const slot = (part.slot ?? 0) - 1;
+        if (nonEditableParts[slot] && !restored.has(slot)) {
+          restored.add(slot);
+          finalContent.push(nonEditableParts[slot]);
+        } else {
+          // No part of this reply answers to that marker, so it is prose: keep it.
+          pushText(part.text);
+        }
       }
-      finalContent.push(...nonEditableParts.slice(restored));
+
+      // A card whose marker the user deleted still belongs to the reply.
+      nonEditableParts.forEach((part, i) => {
+        if (!restored.has(i)) finalContent.push(part);
+      });
     } else {
-      finalContent = parsedEditableContent;
+      for (const part of parsedEditableContent) {
+        if (part.type === 'text' || part.type === 'tool') pushText(part.text);
+        else finalContent.push(part);
+      }
     }
 
     return {

--- a/studio/frontend/src/features/chat/utils/update-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/update-thread-message.ts
@@ -20,6 +20,18 @@ function toolLabel(part: any): string {
   return label || "tool";
 }
 
+// Prose can itself spell a marker -- a reply explaining this very syntax. Escaping it
+// on the way into the editor, and undoing that on the way out, keeps the parser from
+// reading the reply's own words as the card's placeholder. The backslash count carries
+// through, so text that already contains an escaped marker round-trips too.
+function escapeMarkers(text: string): string {
+  return text.replace(/<(\\*)TOOL (\d+: )/g, "<\\$1TOOL $2");
+}
+
+function unescapeMarkers(text: string): string {
+  return text.replace(/<\\(\\*)TOOL (\d+: )/g, "<$1TOOL $2");
+}
+
 /**
  * Extracts the editable text and reasoning from a message, with a numbered placeholder
  * marker recording where each non-editable part sat among the prose.
@@ -48,9 +60,9 @@ export function extractTaggedText(content: any): string {
       // Trim the text first so we don't accumulate newlines
       // around the tags on every save.
       if (part.type === 'reasoning') {
-        return `${open}THINK${close}\n${text.trim()}\n${open}/THINK${close}`;
+        return `${open}THINK${close}\n${escapeMarkers(text.trim())}\n${open}/THINK${close}`;
       }
-      return text;
+      return escapeMarkers(text);
     })
     .filter(Boolean)
     .join('\n\n');
@@ -74,7 +86,7 @@ function parseTaggedTextToContent(text: string): ContentPart[] {
       // Trim the extracted content to remove any leading/trailing
       // newlines created by the tag wrapping process.
       const content = text.substring(lastIndex, index).trim();
-      if (content) parts.push({ type: currentType, text: content });
+      if (content) parts.push({ type: currentType, text: unescapeMarkers(content) });
     }
     lastIndex = index + fullTag.length;
 
@@ -87,7 +99,7 @@ function parseTaggedTextToContent(text: string): ContentPart[] {
 
   if (lastIndex < text.length) {
     const remainingText = text.substring(lastIndex).trim();
-    if (remainingText) parts.push({ type: currentType, text: remainingText });
+    if (remainingText) parts.push({ type: currentType, text: unescapeMarkers(remainingText) });
   }
 
   return parts;

--- a/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
+++ b/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
@@ -345,6 +345,28 @@ test("prose that mentions the marker tag is not mistaken for one", async () => {
   assert.deepEqual(out, content);
 });
 
+test("prose that spells a real marker is not mistaken for that card's marker", async () => {
+  // A reply explaining the marker syntax, that itself used the tool it names: the
+  // literal occurrence sits BEFORE the card's own marker and reads exactly like it.
+  const content = [
+    { type: "text", text: "Your edit box shows <TOOL 1: web_search> where the card sits." },
+    SEARCH,
+    { type: "text", text: "That is all it means." },
+  ];
+
+  assert.deepEqual(await roundTrip(content), content);
+});
+
+test("text that already contains an escaped marker round-trips too", async () => {
+  const content = [
+    { type: "text", text: "Write <\\TOOL 1: web_search> to show the escape." },
+    SEARCH,
+    { type: "text", text: "Done." },
+  ];
+
+  assert.deepEqual(await roundTrip(content), content);
+});
+
 test("a code block quoting the marker syntax survives a no-op save", async () => {
   const content = [
     { type: "text", text: "```xml\n<TOOL>read_file</TOOL>\n```" },

--- a/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
+++ b/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadWithStubs } from "./helpers/module-stubs.ts";
+
+type Exported = {
+  headId: string | null;
+  messages: { parentId: string | null; message: Record<string, unknown> }[];
+};
+
+type Part = Record<string, unknown>;
+
+type Module = {
+  extractTaggedText: (content: unknown) => string;
+  updateThreadMessage: (args: {
+    thread: { export: () => Exported; import: (data: Exported) => void };
+    messageId: string;
+    remoteId: string | undefined;
+    newText: string;
+    isIncognito: boolean;
+  }) => Promise<Part[]>;
+};
+
+const SEARCH: Part = {
+  type: "tool-call",
+  toolCallId: "call-1",
+  toolName: "web_search",
+  args: { query: "unsloth" },
+  result: { ok: true },
+};
+const PYTHON: Part = {
+  type: "tool-call",
+  toolCallId: "call-2",
+  toolName: "python",
+  args: { code: "print(1)" },
+};
+
+function harness() {
+  const saved: Record<string, unknown>[] = [];
+  const module = loadWithStubs<Module>(
+    new URL(
+      "../src/features/chat/utils/update-thread-message.ts",
+      import.meta.url,
+    ),
+    {
+      "../api/chat-api": {
+        saveChatMessage: async (record: Record<string, unknown>) => {
+          saved.push(record);
+          return record;
+        },
+      },
+    },
+  );
+  return { module, saved };
+}
+
+function thread(content: Part[]): Exported {
+  return {
+    headId: "a0",
+    messages: [
+      {
+        parentId: null,
+        message: {
+          id: "u0",
+          role: "user",
+          content: [{ type: "text", text: "search for it" }],
+          createdAt: new Date(1000),
+        },
+      },
+      {
+        parentId: "u0",
+        message: {
+          id: "a0",
+          role: "assistant",
+          content,
+          createdAt: new Date(2000),
+        },
+      },
+    ],
+  };
+}
+
+async function save(content: Part[], newText?: string) {
+  const h = harness();
+  const exported = thread(content);
+  const text = newText ?? h.module.extractTaggedText(content);
+  const result = await h.module.updateThreadMessage({
+    thread: { export: () => exported, import: () => {} },
+    messageId: "a0",
+    remoteId: "remote-1",
+    newText: text,
+    isIncognito: false,
+  });
+  return { result, saved: h.saved[0], text };
+}
+
+test("a no-op Save leaves the tool card between the two sentences", async () => {
+  const content = [
+    { type: "text", text: "Let me look that up." },
+    SEARCH,
+    { type: "text", text: "Here is what I found." },
+  ];
+
+  const { result } = await save(content);
+
+  assert.deepEqual(
+    result.map((part) => part.type),
+    ["text", "tool-call", "text"],
+  );
+  assert.equal(result[0].text, "Let me look that up.");
+  assert.equal(result[1], SEARCH);
+  assert.equal(result[2].text, "Here is what I found.");
+});
+
+test("what is written to the server is what the thread shows", async () => {
+  const content = [
+    { type: "text", text: "Let me look that up." },
+    SEARCH,
+    { type: "text", text: "Here is what I found." },
+  ];
+
+  const { result, saved } = await save(content);
+
+  assert.deepEqual(saved.content, result);
+});
+
+test("several cards keep their order and the prose between them", async () => {
+  const content = [
+    { type: "text", text: "First I search." },
+    SEARCH,
+    { type: "text", text: "Then I compute." },
+    PYTHON,
+    { type: "text", text: "Done." },
+  ];
+
+  const { result } = await save(content);
+
+  assert.deepEqual(
+    result.map((part) => part.type),
+    ["text", "tool-call", "text", "tool-call", "text"],
+  );
+  assert.equal(result[1], SEARCH);
+  assert.equal(result[3], PYTHON);
+});
+
+test("reasoning still round-trips alongside a card", async () => {
+  const content = [
+    { type: "reasoning", text: "The user wants a lookup." },
+    SEARCH,
+    { type: "text", text: "Here is what I found." },
+  ];
+
+  const { result } = await save(content);
+
+  assert.deepEqual(
+    result.map((part) => part.type),
+    ["reasoning", "tool-call", "text"],
+  );
+});
+
+test("an edit that rewrites the prose still keeps the card where it was", async () => {
+  const content = [
+    { type: "text", text: "Let me look that up." },
+    SEARCH,
+    { type: "text", text: "Here is what I found." },
+  ];
+  const { text } = await save(content);
+
+  const { result } = await save(
+    content,
+    text.replace("Here is what I found.", "Rewritten answer."),
+  );
+
+  assert.deepEqual(
+    result.map((part) => part.type),
+    ["text", "tool-call", "text"],
+  );
+  assert.equal(result[2].text, "Rewritten answer.");
+});
+
+test("deleting a marker keeps the call rather than dropping it", async () => {
+  const content = [
+    { type: "text", text: "Let me look that up." },
+    SEARCH,
+    { type: "text", text: "Here is what I found." },
+  ];
+
+  const { result } = await save(
+    content,
+    "Let me look that up.\n\nHere is what I found.",
+  );
+
+  assert.equal(
+    result.filter((part) => part.type === "tool-call").length,
+    1,
+    "the call must survive an edit that removed its marker",
+  );
+});
+
+test("a reply that is only a tool card keeps it", async () => {
+  const { result } = await save([SEARCH]);
+
+  assert.deepEqual(result, [SEARCH]);
+});
+
+function tool(id: string, name = "web_search"): Part {
+  return { type: "tool-call", toolCallId: id, toolName: name, args: {}, result: {} };
+}
+
+async function roundTrip(content: Part[]): Promise<Part[]> {
+  const { result } = await save(content);
+  return result;
+}
+
+const shapes: any[][] = [
+  [{ type: "text", text: "A" }, tool("1"), { type: "text", text: "B" }],
+  [tool("1"), { type: "text", text: "A" }],
+  [{ type: "text", text: "A" }, tool("1")],
+  [tool("1"), tool("2")],
+  [{ type: "text", text: "A" }, tool("1"), { type: "text", text: "B" }, tool("2"),
+   { type: "text", text: "C" }],
+  [{ type: "reasoning", text: "R" }, tool("1"), { type: "text", text: "A" }],
+  [{ type: "text", text: "A" }, { type: "source", title: "S", url: "u" },
+   { type: "text", text: "B" }],
+  [{ type: "text", text: "A" }, tool("1"), tool("2"), { type: "text", text: "B" }],
+  [{ type: "reasoning", text: "R" }],
+  [tool("1")],
+];
+
+test("a no-op save preserves the part sequence for every shape", async () => {
+  for (const shape of shapes) {
+    const out = await roundTrip(shape);
+    assert.deepEqual(out.map((p: any) => p.type), shape.map((p: any) => p.type),
+      `shape ${JSON.stringify(shape.map((p: any) => p.type))}`);
+    assert.deepEqual(
+      out.filter((p: any) => p.type === "tool-call").map((p: any) => p.toolCallId),
+      shape.filter((p: any) => p.type === "tool-call").map((p: any) => p.toolCallId));
+  }
+});
+
+test("a second no-op save changes nothing further (idempotent)", async () => {
+  for (const shape of shapes) {
+    const once = await roundTrip(shape);
+    const twice = await roundTrip(once);
+    assert.deepEqual(twice.map((p: any) => p.type), once.map((p: any) => p.type));
+  }
+});
+
+test("prose that mentions the marker tag is not mistaken for one", async () => {
+  const content = [
+    { type: "text", text: "Write <TOOL>web_search</TOOL> to call it." },
+    tool("1"),
+    { type: "text", text: "Done." },
+  ];
+  const out = await roundTrip(content);
+  assert.equal(out.filter((p: any) => p.type === "tool-call").length, 1,
+    "the call must not be consumed by prose that looks like a marker");
+});
+
+test("no tool part is ever dropped, whatever the edit", async () => {
+  for (const shape of shapes) {
+    const { result } = await save(shape, "the user deleted everything");
+    const before = shape.filter((p) => p.type !== "text" && p.type !== "reasoning");
+    const after = result.filter((p) => p.type !== "text" && p.type !== "reasoning");
+    assert.equal(
+      after.length,
+      before.length,
+      `non-text parts lost for ${JSON.stringify(shape.map((p) => p.type))}`,
+    );
+  }
+});

--- a/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
+++ b/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
@@ -392,6 +392,18 @@ test("a raw string part is prose, and does not consume a card's slot", async () 
   ]);
 });
 
+test("a reply stored as one plain string round-trips, markers and all", async () => {
+  // Legacy and imported rows can hold the whole reply as a top-level string, which
+  // takes its own path out of extractTaggedText and has to be escaped there too.
+  const content = "Use <TOOL 1: web_search> literally" as unknown as Part[];
+
+  const { result } = await save(content);
+
+  assert.deepEqual(result, [
+    { type: "text", text: "Use <TOOL 1: web_search> literally" },
+  ]);
+});
+
 test("a code block quoting the marker syntax survives a no-op save", async () => {
   const content = [
     { type: "text", text: "```xml\n<TOOL>read_file</TOOL>\n```" },

--- a/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
+++ b/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
@@ -367,6 +367,31 @@ test("text that already contains an escaped marker round-trips too", async () =>
   assert.deepEqual(await roundTrip(content), content);
 });
 
+test("an indented code block after a card keeps its indentation", async () => {
+  // Four leading spaces are a Markdown code block, not padding: trimming them at the
+  // marker boundary would render the reply differently after a no-op Save.
+  const content = [
+    { type: "text", text: "Here is the fix:" },
+    SEARCH,
+    { type: "text", text: "    const x = 1;\n    return x;" },
+  ];
+
+  assert.deepEqual(await roundTrip(content), content);
+});
+
+test("a raw string part is prose, and does not consume a card's slot", async () => {
+  // Legacy and imported rows can hold a bare string. extractTaggedText emits it as
+  // prose without numbering it, so restoration must not count it as a card either.
+  const legacy = ["intro", SEARCH, { type: "text", text: "answer" }] as unknown as Part[];
+  const { result } = await save(legacy);
+
+  assert.deepEqual(result, [
+    { type: "text", text: "intro" },
+    SEARCH,
+    { type: "text", text: "answer" },
+  ]);
+});
+
 test("a code block quoting the marker syntax survives a no-op save", async () => {
   const content = [
     { type: "text", text: "```xml\n<TOOL>read_file</TOOL>\n```" },

--- a/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
+++ b/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
@@ -193,11 +193,95 @@ test("deleting a marker keeps the call rather than dropping it", async () => {
     "Let me look that up.\n\nHere is what I found.",
   );
 
-  assert.equal(
-    result.filter((part) => part.type === "tool-call").length,
-    1,
-    "the call must survive an edit that removed its marker",
+  assert.deepEqual(result, [
+    { type: "text", text: "Let me look that up.\n\nHere is what I found." },
+    SEARCH,
+  ]);
+});
+
+test("deleting one marker leaves the other card where its own marker is", async () => {
+  const content = [
+    { type: "text", text: "First I search." },
+    SEARCH,
+    { type: "text", text: "Then I compute." },
+    PYTHON,
+    { type: "text", text: "Done." },
+  ];
+  const shown = await save(content).then((r) => r.text);
+
+  const { result } = await save(
+    content,
+    shown.replace(/<TOOL 1:[^>]*>\n\n/, ""),
   );
+
+  // The python card is still the one between "Then I compute." and "Done."; only the
+  // card whose marker went away is moved, and it is moved to the end rather than lost.
+  assert.deepEqual(result, [
+    { type: "text", text: "First I search.\n\nThen I compute." },
+    PYTHON,
+    { type: "text", text: "Done." },
+    SEARCH,
+  ]);
+});
+
+test("moving a marker moves that card and no other", async () => {
+  const content = [
+    { type: "text", text: "First I search." },
+    SEARCH,
+    { type: "text", text: "Then I compute." },
+    PYTHON,
+    { type: "text", text: "Done." },
+  ];
+
+  const { result } = await save(
+    content,
+    "First I search.\n\n<TOOL 2: python>\n\nThen I compute.\n\n<TOOL 1: web_search>\n\nDone.",
+  );
+
+  assert.deepEqual(result, [
+    { type: "text", text: "First I search." },
+    PYTHON,
+    { type: "text", text: "Then I compute." },
+    SEARCH,
+    { type: "text", text: "Done." },
+  ]);
+});
+
+test("a half-deleted marker keeps the prose that follows it", async () => {
+  const head = "Here is the plan.";
+  const tail = "I searched and found three papers.";
+  const content = [
+    { type: "text", text: head },
+    SEARCH,
+    { type: "text", text: tail },
+  ];
+  const shown = await save(content).then((r) => r.text);
+  // Whatever the marker looks like, it is what sits between the two sentences.
+  const marker = shown.slice(head.length + 2, shown.length - tail.length - 2);
+
+  // Backspacing into the marker used to turn every following sentence into a part the
+  // save silently dropped, and the loss was written to the server.
+  const broken = [
+    marker.slice(0, -1),
+    marker.slice(1),
+    marker.slice(0, Math.ceil(marker.length / 2)),
+  ];
+  for (const half of broken) {
+    const { result } = await save(content, `${head}\n\n${half}\n\n${tail}`);
+    const text = result
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n\n");
+    assert.ok(
+      text.includes(head) && text.includes(tail),
+      `prose lost for ${JSON.stringify(half)}`,
+    );
+    assert.equal(
+      result.filter((part) => part.type === "tool-call").length,
+      1,
+      `card lost for ${JSON.stringify(half)}`,
+    );
+  }
 });
 
 test("a reply that is only a tool card keeps it", async () => {
@@ -256,8 +340,26 @@ test("prose that mentions the marker tag is not mistaken for one", async () => {
     { type: "text", text: "Done." },
   ];
   const out = await roundTrip(content);
-  assert.equal(out.filter((p: any) => p.type === "tool-call").length, 1,
-    "the call must not be consumed by prose that looks like a marker");
+  // Not just the count: the sentence has to come back whole, with the card still
+  // between it and "Done." rather than wedged into the middle of it.
+  assert.deepEqual(out, content);
+});
+
+test("a code block quoting the marker syntax survives a no-op save", async () => {
+  const content = [
+    { type: "text", text: "```xml\n<TOOL>read_file</TOOL>\n```" },
+    tool("1"),
+    { type: "text", text: "Done." },
+  ];
+
+  assert.deepEqual(await roundTrip(content), content);
+});
+
+test("a no-op save returns the very same text, part for part", async () => {
+  for (const shape of shapes) {
+    assert.deepEqual(await roundTrip(shape), shape,
+      `shape ${JSON.stringify(shape.map((p: any) => p.type))}`);
+  }
 });
 
 test("no tool part is ever dropped, whatever the edit", async () => {


### PR DESCRIPTION
Open "Edit response" on a reply where the model used a tool, press Save without changing anything, and the reply comes back rearranged. All the text runs together at the top and the tool card drops to the bottom, instead of sitting between the sentence that announces it and the sentence that reports the result. This gets saved, so it survives a reload.

The editor only ever showed the text, so when the reply was put back together there was no way to tell which sentences came before the card and which came after.

The editor now shows a small tag where each card sits, so the order can be put back exactly. Deleting a tag keeps the card rather than losing it. Note this changes what you see in the edit box.
