### PR TITLE
Studio: align Run Settings and titlebar controls

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -474,6 +474,7 @@ const MAC_NATIVE_CHROME_STYLE = {
   "--studio-titlebar-height": "0px",
   "--studio-mac-titlebar-height": "34px",
   "--studio-desktop-titlebar-height": "34px",
+  "--studio-titlebar-navigation-margin-top": "4px",
   "--studio-titlebar-navigation-offset-y": "4px",
   "--studio-mac-traffic-light-inset": "78px",
   "--studio-collapsed-chat-controls-inset": "188px",

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -4553,7 +4553,7 @@ export function AppSidebar() {
               type="button"
               aria-label={t("shell.navigation.settings")}
               onClick={() => useSettingsDialogStore.getState().openDialog()}
-              className="absolute right-2 top-1/2 flex size-[32px] -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/10 hover:text-foreground dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[collapsible=icon]:hidden"
+              className="absolute right-2 top-1/2 flex size-[32px] -translate-y-1/2 items-center justify-center rounded-[10px] text-muted-foreground transition-colors hover:bg-black/10 hover:text-foreground dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[collapsible=icon]:hidden"
             >
               <HugeiconsIcon
                 icon={Settings02Icon}

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -123,7 +123,7 @@ export function DesktopTitlebarNavigation({
   return (
     <div
       className={cn(
-        "flex mt-1 translate-y-[var(--studio-titlebar-navigation-offset-y,0px)] items-center gap-0.5",
+        "flex mt-[var(--studio-titlebar-navigation-margin-top,0px)] translate-y-[var(--studio-titlebar-navigation-offset-y,0px)] items-center gap-0.5",
         className,
       )}
       role="toolbar"

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1057,15 +1057,16 @@ export function ChatSettingsPanel({
   const settingsContent = (
     <>
       <div className="flex h-full min-h-0 flex-col">
-      {/* Header is outside the scroll area so the scrollbar never shifts the close button. */}
-      <div className="flex h-[48px] shrink-0 items-start gap-2 bg-panel-surface pl-[18px] pr-[16px] pt-[11px]">
+      {/* Header is outside the scroll area so the scrollbar never shifts the close button.
+          Reuse the chat header metrics so the toggle stays put when the panel opens. */}
+      <div className="flex h-[var(--studio-chat-header-height,48px)] shrink-0 items-start gap-2 bg-panel-surface pl-[18px] pr-[16px] pt-[var(--studio-chat-header-padding-top,11px)]">
         {isMobile ? (
-          <span className="flex h-[34px] flex-1 items-center text-ui-16 font-semibold tracking-[0em] dark:tracking-[0.015em] text-nav-fg">
+          <span className="flex h-[var(--studio-chat-control-height,34px)] flex-1 items-center text-ui-16 font-semibold tracking-[0em] dark:tracking-[0.015em] text-nav-fg">
             Run settings
           </span>
         ) : (
           <>
-            <span className="flex h-[34px] flex-1 items-center text-ui-16 font-semibold tracking-[0em] dark:tracking-[0.015em] text-nav-fg">
+            <span className="flex h-[var(--studio-chat-control-height,34px)] flex-1 items-center text-ui-16 font-semibold tracking-[0em] dark:tracking-[0.015em] text-nav-fg">
               Run settings
             </span>
             <Tooltip>
@@ -1073,7 +1074,7 @@ export function ChatSettingsPanel({
                 <button
                   type="button"
                   onClick={() => onOpenChange?.(false)}
-                  className="flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-full text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  className="flex size-[30px] cursor-pointer items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                   aria-label="Close run settings"
                 >
                   <HugeiconsIcon

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1059,7 +1059,7 @@ export function ChatSettingsPanel({
       <div className="flex h-full min-h-0 flex-col">
       {/* Header is outside the scroll area so the scrollbar never shifts the close button.
           Reuse the chat header metrics so the toggle stays put when the panel opens. */}
-      <div className="flex h-[var(--studio-chat-header-height,48px)] shrink-0 items-start gap-2 bg-panel-surface pl-[18px] pr-[16px] pt-[var(--studio-chat-header-padding-top,11px)]">
+      <div className="flex h-[var(--studio-chat-header-height,48px)] shrink-0 items-start gap-2 bg-panel-surface pl-[18px] pr-[18px] pt-[var(--studio-chat-header-padding-top,11px)]">
         {isMobile ? (
           <span className="flex h-[var(--studio-chat-control-height,34px)] flex-1 items-center text-ui-16 font-semibold tracking-[0em] dark:tracking-[0.015em] text-nav-fg">
             Run settings

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -581,7 +581,7 @@ export function SettingsDialog() {
               <button
                 type="button"
                 onClick={closeDialog}
-                className="absolute top-3 right-3 z-10 flex size-7 items-center justify-center rounded-full text-[#383835] dark:text-[#c7c7c4] transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="absolute top-3 right-3 z-10 flex size-[30px] items-center justify-center rounded-[10px] text-[#383835] dark:text-[#c7c7c4] transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 aria-label={t("settings.dialog.closeAriaLabel")}
               >
                 <HugeiconsIcon icon={Cancel01Icon} className="size-4" />

--- a/studio/frontend/tests/chrome-icon-button-consistency.test.ts
+++ b/studio/frontend/tests/chrome-icon-button-consistency.test.ts
@@ -7,10 +7,8 @@ const source = (path: string) =>
 
 const BUTTON_CLASS = /className="([^"]+)"/;
 const WHITESPACE = /\s+/;
-const RUN_SETTINGS_HEADER_HEIGHT =
-  /h-\[var\(--studio-chat-header-height,48px\)\]/;
-const RUN_SETTINGS_HEADER_PADDING =
-  /pt-\[var\(--studio-chat-header-padding-top,11px\)\]/;
+const RUN_SETTINGS_HEADER =
+  /<div className="([^"]*h-\[var\(--studio-chat-header-height,48px\)\][^"]*)"/;
 
 function buttonAtMarker(
   contents: string,
@@ -59,8 +57,13 @@ test("run settings uses one aligned toggle in both states", async () => {
     assert.ok(classes.has("rounded-[10px]"));
     assert.ok(!classes.has("rounded-full"));
   }
-  assert.match(panel, RUN_SETTINGS_HEADER_HEIGHT);
-  assert.match(panel, RUN_SETTINGS_HEADER_PADDING);
+  const header = RUN_SETTINGS_HEADER.exec(panel);
+  assert.ok(header);
+  const headerClasses = new Set(header[1].split(WHITESPACE));
+  assert.ok(
+    headerClasses.has("pt-[var(--studio-chat-header-padding-top,11px)]"),
+  );
+  assert.ok(headerClasses.has("pr-[18px]"));
 });
 
 test("settings chrome uses the titlebar rounded-square hover shape", async () => {

--- a/studio/frontend/tests/chrome-icon-button-consistency.test.ts
+++ b/studio/frontend/tests/chrome-icon-button-consistency.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = (path: string) =>
+  readFile(new URL(`../src/${path}`, import.meta.url), "utf8");
+
+const BUTTON_CLASS = /className="([^"]+)"/;
+const WHITESPACE = /\s+/;
+const RUN_SETTINGS_HEADER_HEIGHT =
+  /h-\[var\(--studio-chat-header-height,48px\)\]/;
+const RUN_SETTINGS_HEADER_PADDING =
+  /pt-\[var\(--studio-chat-header-padding-top,11px\)\]/;
+
+function buttonAtMarker(
+  contents: string,
+  marker: string,
+  occurrence = 0,
+): string {
+  let markerIndex = -1;
+  for (let index = 0; index <= occurrence; index += 1) {
+    markerIndex = contents.indexOf(marker, markerIndex + 1);
+  }
+  if (markerIndex === -1) {
+    throw new Error(`missing button marker: ${marker}`);
+  }
+  const start = contents.lastIndexOf("<button", markerIndex);
+  const end = contents.indexOf("</button>", markerIndex);
+  if (start === -1) {
+    throw new Error(`missing button start: ${marker}`);
+  }
+  if (end === -1) {
+    throw new Error(`missing button end: ${marker}`);
+  }
+  return contents.slice(start, end);
+}
+
+function buttonClasses(button: string): Set<string> {
+  const classes = BUTTON_CLASS.exec(button)?.[1];
+  if (!classes) {
+    throw new Error("button has no static className");
+  }
+  return new Set(classes.split(WHITESPACE));
+}
+
+test("run settings uses one aligned toggle in both states", async () => {
+  const [page, panel] = await Promise.all([
+    source("features/chat/chat-page.tsx"),
+    source("features/chat/chat-settings-sheet.tsx"),
+  ]);
+
+  const toggles = [
+    buttonAtMarker(page, 'aria-label="Open run settings"'),
+    buttonAtMarker(panel, 'aria-label="Close run settings"'),
+  ];
+  for (const toggle of toggles) {
+    const classes = buttonClasses(toggle);
+    assert.ok(classes.has("size-[30px]"));
+    assert.ok(classes.has("rounded-[10px]"));
+    assert.ok(!classes.has("rounded-full"));
+  }
+  assert.match(panel, RUN_SETTINGS_HEADER_HEIGHT);
+  assert.match(panel, RUN_SETTINGS_HEADER_PADDING);
+});
+
+test("settings chrome uses the titlebar rounded-square hover shape", async () => {
+  const [dialog, sidebar] = await Promise.all([
+    source("features/settings/settings-dialog.tsx"),
+    source("components/app-sidebar.tsx"),
+  ]);
+
+  const dialogMain = dialog.slice(dialog.indexOf("<main"));
+  const dialogClose = buttonClasses(
+    buttonAtMarker(
+      dialogMain,
+      'aria-label={t("settings.dialog.closeAriaLabel")}',
+    ),
+  );
+  assert.ok(dialogClose.has("size-[30px]"));
+  assert.ok(dialogClose.has("rounded-[10px]"));
+  assert.ok(!dialogClose.has("rounded-full"));
+
+  const settingsCog = sidebar.slice(sidebar.indexOf("settings cog; sibling"));
+  const settingsCogClasses = buttonClasses(
+    buttonAtMarker(settingsCog, 'aria-label={t("shell.navigation.settings")}'),
+  );
+  assert.ok(settingsCogClasses.has("size-[32px]"));
+  assert.ok(settingsCogClasses.has("rounded-[10px]"));
+  assert.ok(!settingsCogClasses.has("rounded-full"));
+});

--- a/studio/frontend/tests/mac-titlebar-optical-alignment.test.ts
+++ b/studio/frontend/tests/mac-titlebar-optical-alignment.test.ts
@@ -14,7 +14,12 @@ test("mac titlebar navigation shifts buttons with centered glyphs", async () => 
     /const MAC_NATIVE_CHROME_STYLE = \{[\s\S]*?\} as CSSProperties;/,
   )?.[0];
   assert.ok(macStyle);
+  assert.match(macStyle, /"--studio-titlebar-navigation-margin-top": "4px"/);
   assert.match(macStyle, /"--studio-titlebar-navigation-offset-y": "4px"/);
+  assert.match(
+    titlebar,
+    /mt-\[var\(--studio-titlebar-navigation-margin-top,0px\)\]/,
+  );
 
   const enlargedIconClass =
     'className="size-icon !size-[calc(var(--icon-size)+1px)]"';

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -619,6 +619,7 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
 
 
 def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
+    titlebar = TITLEBAR.read_text(encoding = "utf-8")
     app_sidebar = APP_SIDEBAR.read_text(encoding = "utf-8")
     primitive = SIDEBAR_PRIMITIVE.read_text(encoding = "utf-8")
     navbar = NAVBAR.read_text(encoding = "utf-8")
@@ -638,9 +639,14 @@ def test_tauri_collapse_removes_the_icon_rail_but_web_keeps_it():
         encoding = "utf-8"
     )
     # The nudge has to move the navigation without pushing it out of the titlebar it sits
-    # in, so the button box travels with it. The container's mt-1 is deliberately not in
-    # the sum: translate-y is visual, and the margin already seats the box in the row.
-    button = _titlebar_nav_button_px(TITLEBAR.read_text(encoding = "utf-8"))
+    # in, so the button box travels with it. The mac-only margin is deliberately not in the
+    # sum: translate-y is visual, and the margin already seats the box in the native row.
+    navigation = titlebar.split("export function DesktopTitlebarNavigation", 1)[1].split(
+        "export function WindowTitlebar", 1
+    )[0]
+    assert "mt-1" not in navigation
+    assert "mt-[var(--studio-titlebar-navigation-margin-top,0px)]" in navigation
+    button = _titlebar_nav_button_px(titlebar)
     assert button is not None, "navigation button size no longer readable from buttonClass"
     blocks = _chrome_style_blocks(APP_PROVIDER.read_text(encoding = "utf-8"))
     nudged = {


### PR DESCRIPTION
## Summary

- reuse the chat header metrics and 30 px rounded-square target for both Run Settings toggle states, removing the open/close jump
- match the Settings dialog close button and sidebar Settings cog to the existing rounded-square chrome controls
- remove the unconditional custom-titlebar navigation offset while preserving the native macOS optical seating
- add regression coverage for toggle geometry, hover shape consistency, and platform-specific titlebar alignment

## Tests

- `npm run typecheck`
- `npm test` (6,549 passed)
- `npm run build`
- `pytest -q tests/studio/test_desktop_reliability_frontend_contract.py` (36 passed)

Closes #10130