### PR TITLE
Fix Studio preferring MTP sidecars over embedded heads

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -14657,7 +14657,6 @@ class LlamaCppBackend:
 
         if near_path:
             from utils.models.gguf_metadata import read_gguf_nextn_predict_layers
-
             if (read_gguf_nextn_predict_layers(near_path) or 0) > 0:
                 logger.info("Main GGUF contains an embedded MTP head; skipping separate drafter.")
                 return None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -13459,6 +13459,8 @@ class LlamaCppBackend:
             arch_keys: dict[str, str] = {}  # gguf_key -> attribute name
             arch = None
             pooling_by_arch: dict[str, int] = {}
+
+            nextn_by_arch: dict[str, int] = {}
             sliding_window_pattern_period: Optional[int] = None
             general: dict[str, str] = {}
 
@@ -13506,7 +13508,12 @@ class LlamaCppBackend:
                         break
 
                     try:
-                        if key in WANTED or key in arch_keys or key.endswith(".pooling_type"):
+                        if (
+                            key in WANTED
+                            or key in arch_keys
+                            or key.endswith(".pooling_type")
+                            or key.endswith(".nextn_predict_layers")
+                        ):
                             if vtype == 8:  # STRING
                                 slen = struct.unpack("<Q", f.read(8))[0]
                                 val_s = f.read(slen).decode("utf-8")
@@ -13554,6 +13561,9 @@ class LlamaCppBackend:
                                     canvas_seen = True
                                 if key.endswith(".pooling_type"):
                                     pooling_by_arch[key] = val_i
+
+                                if key.endswith(".nextn_predict_layers"):
+                                    nextn_by_arch[key] = val_i
                                 attr = arch_keys.get(key)
                                 if attr:
                                     if attr == "sliding_window_pattern":
@@ -13596,10 +13606,14 @@ class LlamaCppBackend:
                 else:
                     kv_complete = True
 
-            # GGUF metadata has no key-order contract. Pooling can precede
-            # general.architecture, so bind the buffered value after the sweep.
+            # GGUF metadata has no key-order contract. These keys can precede
+            # general.architecture, so bind their buffered values after the sweep.
             if arch is not None:
                 self._pooling_type = pooling_by_arch.get(f"{arch}.pooling_type", self._pooling_type)
+                self._nextn_predict_layers = nextn_by_arch.get(
+                    f"{arch}.nextn_predict_layers",
+                    self._nextn_predict_layers,
+                )
 
             # Decide diffusion routing before the SWA resolver below: it can raise on an arch transformers
             # does not know, which would otherwise drop a DiffusionGemma model to plain llama-server.
@@ -14640,6 +14654,13 @@ class LlamaCppBackend:
         cancel_event = cancel_event if cancel_event is not None else self._cancel_event
         if cancel_event.is_set():
             return None
+
+        if near_path:
+            from utils.models.gguf_metadata import read_gguf_nextn_predict_layers
+
+            if (read_gguf_nextn_predict_layers(near_path) or 0) > 0:
+                logger.info("Main GGUF contains an embedded MTP head; skipping separate drafter.")
+                return None
 
         pick = _pick_mtp if allow_nested else _pick_mtp_root_only
 
@@ -18609,6 +18630,17 @@ class LlamaCppBackend:
 
             # Read GGUF metadata (context_length, chat_template); header-only.
             self._read_gguf_metadata(model_path)
+
+            if (
+                self._nextn_predict_layers
+                and mtp_draft_path
+                and _spec_canon not in ("dspark", "dflash")
+            ):
+                # A discovered root mtp-*.gguf may be only an -hf compatibility
+                # mirror. llama.cpp's -md replaces the embedded head, so keep one
+                # authoritative MTP source before sizing and command construction.
+                logger.info("Main GGUF contains an embedded MTP head; ignoring separate drafter.")
+                mtp_draft_path = None
 
             if _load_cancelled():
                 logger.info("Load cancelled after download phase")
@@ -24828,6 +24860,16 @@ class LlamaCppBackend:
         # Canonical UI-facing requested mode (legacy values mapped via
         # _canonicalize_spec_mode).
         canonical_mode = _canonicalize_spec_mode(speculative_type)
+        user_owns_spec_type = _extra_args_set_spec_type(extra_args)
+        if (
+            not user_owns_spec_type
+            and canonical_mode in ("auto", "mtp", "mtp+ngram")
+            and self._nextn_predict_layers
+            and mtp_draft_path
+        ):
+            # Resolver-level backstop for callers that bypass load_model's
+            # discovery normalization. Raw extra args remain user-owned.
+            mtp_draft_path = None
         # MTP signals: head baked into the main GGUF (Qwen, via metadata or
         # name), or a separate drafter resolved from the repo (Gemma).
         is_mtp_model = (
@@ -24835,7 +24877,6 @@ class LlamaCppBackend:
             or _is_mtp_model_name(model_identifier, model_path)
             or bool(mtp_draft_path)
         )
-        user_owns_spec_type = _extra_args_set_spec_type(extra_args)
         _mtp_size_b = _extract_model_size_b(model_identifier)
         # The sub-3B regression is an embedded-head cost; a separate drafter
         # (Gemma) is a cheap standalone model that wins below 3B, so exempt it.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -13606,8 +13606,7 @@ class LlamaCppBackend:
                 else:
                     kv_complete = True
 
-            # GGUF metadata has no key-order contract. These keys can precede
-            # general.architecture, so bind their buffered values after the sweep.
+            # Bind buffered metadata after discovering the architecture namespace.
             if arch is not None:
                 self._pooling_type = pooling_by_arch.get(f"{arch}.pooling_type", self._pooling_type)
                 self._nextn_predict_layers = nextn_by_arch.get(
@@ -18635,9 +18634,7 @@ class LlamaCppBackend:
                 and mtp_draft_path
                 and _spec_canon not in ("dspark", "dflash")
             ):
-                # A discovered root mtp-*.gguf may be only an -hf compatibility
-                # mirror. llama.cpp's -md replaces the embedded head, so keep one
-                # authoritative MTP source before sizing and command construction.
+                # A root mtp-*.gguf may mirror the embedded head; -md would replace it.
                 logger.info("Main GGUF contains an embedded MTP head; ignoring separate drafter.")
                 mtp_draft_path = None
 
@@ -24866,8 +24863,7 @@ class LlamaCppBackend:
             and self._nextn_predict_layers
             and mtp_draft_path
         ):
-            # Resolver-level backstop for callers that bypass load_model's
-            # discovery normalization. Raw extra args remain user-owned.
+            # Backstop for callers that bypass load_model's discovery normalization.
             mtp_draft_path = None
         # MTP signals: head baked into the main GGUF (Qwen, via metadata or
         # name), or a separate drafter resolved from the repo (Gemma).

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -159,6 +159,34 @@ def is_mtp_drafter_path(path: str) -> bool:
     )
 
 
+_EMBEDDED_MTP_TOKEN_RE = re.compile(r"(?:^|[._-])mtp(?:[._-]|$)", re.IGNORECASE)
+
+
+def has_embedded_mtp_name_hint(path: str) -> bool:
+    """Whether a selectable quant filename advertises a baked-in MTP head.
+
+    Hub listings expose names and sizes, not GGUF headers. This bounded hint is
+    therefore only for avoiding an unnecessary compatibility-sidecar download;
+    local metadata remains authoritative at launch. MTP must be adjacent to the
+    quant token, so an ordinary name such as ``prompt-mtp-test-Q4_K_M.gguf``
+    does not suppress a real drafter.
+    """
+    name = path.replace("\\", "/").rsplit("/", 1)[-1]
+    if not is_gguf_filename(name) or is_mtp_drafter_path(path):
+        return False
+    stem = name.rsplit(".", 1)[0]
+    for quant in _GGUF_QUANT_RE.finditer(stem):
+        before = stem[: quant.start()].rstrip("._-")
+        after = stem[quant.end() :].lstrip("._-")
+        before_hint = _EMBEDDED_MTP_TOKEN_RE.search(before)
+        if (
+            (before_hint is not None and before_hint.end() == len(before))
+            or _EMBEDDED_MTP_TOKEN_RE.match(after)
+        ):
+            return True
+    return False
+
+
 def is_reclaimable_drafter_path(path: str) -> bool:
     """Drafters a repo's last-variant delete may reclaim: MTP, fetched with every
     variant, and DSpark, fetched on opt-in. Both are useless once no main GGUF is

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -159,33 +159,6 @@ def is_mtp_drafter_path(path: str) -> bool:
     )
 
 
-_EMBEDDED_MTP_TOKEN_RE = re.compile(r"(?:^|[._-])mtp(?:[._-]|$)", re.IGNORECASE)
-
-
-def has_embedded_mtp_name_hint(path: str) -> bool:
-    """Whether a selectable quant filename advertises a baked-in MTP head.
-
-    Hub listings expose names and sizes, not GGUF headers. This bounded hint is
-    therefore only for avoiding an unnecessary compatibility-sidecar download;
-    local metadata remains authoritative at launch. MTP must be adjacent to the
-    quant token, so an ordinary name such as ``prompt-mtp-test-Q4_K_M.gguf``
-    does not suppress a real drafter.
-    """
-    name = path.replace("\\", "/").rsplit("/", 1)[-1]
-    if not is_gguf_filename(name) or is_mtp_drafter_path(path):
-        return False
-    stem = name.rsplit(".", 1)[0]
-    for quant in _GGUF_QUANT_RE.finditer(stem):
-        before = stem[: quant.start()].rstrip("._-")
-        after = stem[quant.end() :].lstrip("._-")
-        before_hint = _EMBEDDED_MTP_TOKEN_RE.search(before)
-        if (
-            before_hint is not None and before_hint.end() == len(before)
-        ) or _EMBEDDED_MTP_TOKEN_RE.match(after):
-            return True
-    return False
-
-
 def is_reclaimable_drafter_path(path: str) -> bool:
     """Drafters a repo's last-variant delete may reclaim: MTP, fetched with every
     variant, and DSpark, fetched on opt-in. Both are useless once no main GGUF is

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -180,9 +180,8 @@ def has_embedded_mtp_name_hint(path: str) -> bool:
         after = stem[quant.end() :].lstrip("._-")
         before_hint = _EMBEDDED_MTP_TOKEN_RE.search(before)
         if (
-            (before_hint is not None and before_hint.end() == len(before))
-            or _EMBEDDED_MTP_TOKEN_RE.match(after)
-        ):
+            before_hint is not None and before_hint.end() == len(before)
+        ) or _EMBEDDED_MTP_TOKEN_RE.match(after):
             return True
     return False
 

--- a/studio/backend/hub/utils/gguf_plan.py
+++ b/studio/backend/hub/utils/gguf_plan.py
@@ -235,9 +235,7 @@ def build_gguf_variant_plans(siblings: Sequence) -> dict[str, GgufVariantPlan]:
     companion_expected = expected_file_from_sibling(companion) if companion is not None else None
     mtp_sibling = preferred_mtp_sibling(siblings)
     mtp_expected = expected_file_from_sibling(mtp_sibling) if mtp_sibling is not None else None
-    common_companions_expected = (
-        (companion_expected,) if companion_expected is not None else ()
-    )
+    common_companions_expected = (companion_expected,) if companion_expected is not None else ()
 
     for sibling in siblings:
         name = _gguf_rfilename(sibling)

--- a/studio/backend/hub/utils/gguf_plan.py
+++ b/studio/backend/hub/utils/gguf_plan.py
@@ -9,11 +9,12 @@ from typing import Optional, Sequence
 from hub.utils.download_manifest import ExpectedFile
 from hub.utils.gguf import (
     bare_quant_alias,
+    drop_shadowed_appledouble_siblings,
     extract_quant_label,
     gguf_variant_family,
     gguf_variant_key,
+    has_embedded_mtp_name_hint,
     is_big_endian_gguf_path,
-    drop_shadowed_appledouble_siblings,
     is_gguf_filename,
     is_imatrix_filename,
     is_mmproj_filename,
@@ -234,8 +235,8 @@ def build_gguf_variant_plans(siblings: Sequence) -> dict[str, GgufVariantPlan]:
     companion_expected = expected_file_from_sibling(companion) if companion is not None else None
     mtp_sibling = preferred_mtp_sibling(siblings)
     mtp_expected = expected_file_from_sibling(mtp_sibling) if mtp_sibling is not None else None
-    companions_expected = tuple(
-        file for file in (companion_expected, mtp_expected) if file is not None
+    common_companions_expected = (
+        (companion_expected,) if companion_expected is not None else ()
     )
 
     for sibling in siblings:
@@ -286,7 +287,21 @@ def build_gguf_variant_plans(siblings: Sequence) -> dict[str, GgufVariantPlan]:
             [n for n in all_weight_names if n != target_weight_name],
             max_bytes = sum(max(0, int(file.size or 0)) for file in kept_main),
         )
-        expected_files = (*main_expected, *companions_expected, *dflash_expected)
+        # A root mtp-*.gguf can be only an -hf compatibility mirror when this
+        # variant's own name advertises an embedded head. Header metadata makes
+        # the final launch decision; the listing-time hint avoids downloading a
+        # sidecar that would be discarded for the common published spelling.
+        variant_mtp_expected = (
+            None
+            if any(has_embedded_mtp_name_hint(file.path) for file in kept_main)
+            else mtp_expected
+        )
+        expected_files = (
+            *main_expected,
+            *common_companions_expected,
+            *((variant_mtp_expected,) if variant_mtp_expected is not None else ()),
+            *dflash_expected,
+        )
         plans[quant] = plan_from_expected_files(
             quant,
             expected_files,

--- a/studio/backend/hub/utils/gguf_plan.py
+++ b/studio/backend/hub/utils/gguf_plan.py
@@ -13,7 +13,6 @@ from hub.utils.gguf import (
     extract_quant_label,
     gguf_variant_family,
     gguf_variant_key,
-    has_embedded_mtp_name_hint,
     is_big_endian_gguf_path,
     is_gguf_filename,
     is_imatrix_filename,
@@ -285,16 +284,10 @@ def build_gguf_variant_plans(siblings: Sequence) -> dict[str, GgufVariantPlan]:
             [n for n in all_weight_names if n != target_weight_name],
             max_bytes = sum(max(0, int(file.size or 0)) for file in kept_main),
         )
-        # Skip the compatibility sidecar when this variant advertises an embedded head.
-        variant_mtp_expected = (
-            None
-            if any(has_embedded_mtp_name_hint(file.path) for file in kept_main)
-            else mtp_expected
-        )
         expected_files = (
             *main_expected,
             *common_companions_expected,
-            *((variant_mtp_expected,) if variant_mtp_expected is not None else ()),
+            *((mtp_expected,) if mtp_expected is not None else ()),
             *dflash_expected,
         )
         plans[quant] = plan_from_expected_files(

--- a/studio/backend/hub/utils/gguf_plan.py
+++ b/studio/backend/hub/utils/gguf_plan.py
@@ -285,10 +285,7 @@ def build_gguf_variant_plans(siblings: Sequence) -> dict[str, GgufVariantPlan]:
             [n for n in all_weight_names if n != target_weight_name],
             max_bytes = sum(max(0, int(file.size or 0)) for file in kept_main),
         )
-        # A root mtp-*.gguf can be only an -hf compatibility mirror when this
-        # variant's own name advertises an embedded head. Header metadata makes
-        # the final launch decision; the listing-time hint avoids downloading a
-        # sidecar that would be discarded for the common published spelling.
+        # Skip the compatibility sidecar when this variant advertises an embedded head.
         variant_mtp_expected = (
             None
             if any(has_embedded_mtp_name_hint(file.path) for file in kept_main)

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -3817,7 +3817,12 @@ def _resolve_mtp_drafter(
     and it rejects an incomplete split set. Never raises: a drafter we cannot
     find just costs a segment.
     """
+
     try:
+        from utils.models.gguf_metadata import read_gguf_nextn_predict_layers
+
+        if (read_gguf_nextn_predict_layers(main_gguf_path) or 0) > 0:
+            return None, 0
         from core.inference.llama_cpp import (
             LlamaCppBackend,
             _companion_snapshot_sibling,

--- a/studio/backend/tests/test_gguf_metadata.py
+++ b/studio/backend/tests/test_gguf_metadata.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from typing import Iterable, Mapping
 from unittest.mock import patch
 
+
+import pytest
+
 from utils.models.gguf_metadata import (
     is_gguf_embedding_architecture,
     is_gguf_embedding_model,
@@ -20,6 +23,7 @@ from utils.models.gguf_metadata import (
     read_gguf_architecture,
     read_gguf_context_length,
     read_gguf_general_metadata,
+    read_gguf_nextn_predict_layers,
     read_gguf_staged_dims,
     read_mmproj_audio_capability,
 )
@@ -166,6 +170,58 @@ def test_context_length_ignores_foreign_arch_key(tmp_path: Path):
         extra_uint32 = {"qwen2.context_length": 8192},
     )
     assert read_gguf_context_length(str(p)) is None
+
+
+def test_nextn_predict_layers_uses_the_active_architecture_namespace(
+    tmp_path: Path,
+    monkeypatch,
+):
+    embedded = _write_synthetic_gguf(
+        tmp_path / "embedded.gguf",
+        {"general.architecture": "qwen35"},
+        extra_uint32 = {
+            "qwen35.nextn_predict_layers": 1,
+            "qwen3.nextn_predict_layers": 9,
+        },
+    )
+    headless = _write_synthetic_gguf(
+        tmp_path / "headless.gguf",
+        {"general.architecture": "qwen35"},
+        extra_uint64 = {"qwen35.nextn_predict_layers": 0},
+    )
+    absent = _write_synthetic_gguf(
+        tmp_path / "absent.gguf",
+        {"general.architecture": "qwen35"},
+        extra_uint32 = {"qwen3.nextn_predict_layers": 7},
+    )
+    malformed = tmp_path / "malformed.gguf"
+    malformed.write_bytes(b"not a GGUF")
+
+    reversed_order = tmp_path / "reversed.gguf"
+    reversed_body = _enc_kv_uint32("qwen35.nextn_predict_layers", 2) + _enc_kv_string(
+        "general.architecture", "qwen35"
+    )
+    reversed_order.write_bytes(
+        struct.pack("<IIQQ", _GGUF_MAGIC, 3, 0, 2) + reversed_body
+    )
+
+    assert read_gguf_nextn_predict_layers(str(embedded)) == 1
+    assert read_gguf_nextn_predict_layers(str(headless)) == 0
+    assert read_gguf_nextn_predict_layers(str(absent)) is None
+    assert read_gguf_nextn_predict_layers(str(malformed)) is None
+
+    assert read_gguf_nextn_predict_layers(str(reversed_order)) == 2
+
+
+    # The second read must use the file-identity cache rather than parse again.
+    import utils.models.gguf_metadata as metadata
+
+    monkeypatch.setattr(
+        metadata,
+        "_parse_gguf_arch_uints",
+        lambda *_args, **_kwargs: pytest.fail("cached NextN metadata was reparsed"),
+    )
+    assert read_gguf_nextn_predict_layers(str(embedded)) == 1
 
 
 # --- read_gguf_staged_dims (one pass: context + layer + moe counts) ----

--- a/studio/backend/tests/test_gguf_metadata.py
+++ b/studio/backend/tests/test_gguf_metadata.py
@@ -172,10 +172,7 @@ def test_context_length_ignores_foreign_arch_key(tmp_path: Path):
     assert read_gguf_context_length(str(p)) is None
 
 
-def test_nextn_predict_layers_uses_the_active_architecture_namespace(
-    tmp_path: Path,
-    monkeypatch,
-):
+def test_nextn_predict_layers_uses_the_active_architecture_namespace(tmp_path: Path, monkeypatch):
     embedded = _write_synthetic_gguf(
         tmp_path / "embedded.gguf",
         {"general.architecture": "qwen35"},
@@ -201,9 +198,7 @@ def test_nextn_predict_layers_uses_the_active_architecture_namespace(
     reversed_body = _enc_kv_uint32("qwen35.nextn_predict_layers", 2) + _enc_kv_string(
         "general.architecture", "qwen35"
     )
-    reversed_order.write_bytes(
-        struct.pack("<IIQQ", _GGUF_MAGIC, 3, 0, 2) + reversed_body
-    )
+    reversed_order.write_bytes(struct.pack("<IIQQ", _GGUF_MAGIC, 3, 0, 2) + reversed_body)
 
     assert read_gguf_nextn_predict_layers(str(embedded)) == 1
     assert read_gguf_nextn_predict_layers(str(headless)) == 0
@@ -211,7 +206,6 @@ def test_nextn_predict_layers_uses_the_active_architecture_namespace(
     assert read_gguf_nextn_predict_layers(str(malformed)) is None
 
     assert read_gguf_nextn_predict_layers(str(reversed_order)) == 2
-
 
     # The second read must use the file-identity cache rather than parse again.
     import utils.models.gguf_metadata as metadata

--- a/studio/backend/tests/test_gguf_metadata.py
+++ b/studio/backend/tests/test_gguf_metadata.py
@@ -207,7 +207,7 @@ def test_nextn_predict_layers_uses_the_active_architecture_namespace(tmp_path: P
 
     assert read_gguf_nextn_predict_layers(str(reversed_order)) == 2
 
-    # The second read must use the file-identity cache rather than parse again.
+    # Verify the file-identity cache.
     import utils.models.gguf_metadata as metadata
 
     monkeypatch.setattr(

--- a/studio/backend/tests/test_kv_cache_estimate_route.py
+++ b/studio/backend/tests/test_kv_cache_estimate_route.py
@@ -343,12 +343,23 @@ class TestDrafterDiscoveryMatchesTheLoader:
         got, _ = models_routes._resolve_mtp_drafter(str(main))
         assert got == str(nested)
 
-    def test_a_root_mirror_is_taken_by_every_architecture(self, tmp_path):
-        """Only the nested fallback is gated. A root mtp- companion beside the
-        weights says it is the one to use, which is how Gemma 4 ships."""
+    def test_an_embedded_head_ignores_a_root_compatibility_mirror(self, tmp_path):
         snap = self._snapshot(tmp_path)
-        main = _write_gguf(snap / "model-Q4_K_M.gguf", {**_MLA_NO_HEAD, "nextn_predict_layers": 1})
-        companion = _write_gguf(snap / "mtp-model.gguf", _MLA_NO_HEAD)
+        main = _write_gguf(
+            snap / "RVN-Q6_K-mtp.gguf",
+            {**_MLA_NO_HEAD, "nextn_predict_layers": 1},
+            arch = "qwen35",
+        )
+        _write_gguf(snap / "mtp-RVN.gguf", _MLA_NO_HEAD)
+
+        got, size = models_routes._resolve_mtp_drafter(str(main))
+        assert got is None
+        assert size == 0
+
+    def test_a_headless_model_still_takes_a_root_drafter(self, tmp_path):
+        snap = self._snapshot(tmp_path)
+        main = _write_gguf(snap / "gemma-4-Q4_K_M.gguf", _MLA_NO_HEAD, arch = "gemma3")
+        companion = _write_gguf(snap / "mtp-gemma-4.gguf", _MLA_NO_HEAD)
 
         got, _ = models_routes._resolve_mtp_drafter(str(main))
         assert got == str(companion)

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -118,9 +118,7 @@ def _write_minimal_gguf(
     extra_uint32 = dict(extra_uint32 or {})
     arch_entry = _enc_kv_string("general.architecture", arch)
     nextn_entry = (
-        _enc_kv_uint32(f"{arch}.nextn_predict_layers", nextn)
-        if nextn is not None
-        else b""
+        _enc_kv_uint32(f"{arch}.nextn_predict_layers", nextn) if nextn is not None else b""
     )
     body = nextn_entry + arch_entry if nextn_first else arch_entry + nextn_entry
     kv_count = 1 + int(nextn is not None)
@@ -730,7 +728,6 @@ def test_read_gguf_metadata_captures_nextn_predict_layers(tmp_path, arch, nextn)
     backend = LlamaCppBackend()
     backend._read_gguf_metadata(str(gguf))
     assert backend._nextn_predict_layers == nextn
-
 
 
 def test_read_gguf_metadata_captures_nextn_before_architecture(tmp_path):
@@ -1972,6 +1969,7 @@ def test_auto_keeps_embedded_mtp(monkeypatch):
     assert parsed["--spec-type"] == "draft-mtp"
     assert backend.spec_fallback_reason is None
 
+
 @pytest.mark.parametrize(
     ("mode", "expected_spec_type"),
     [
@@ -1981,10 +1979,7 @@ def test_auto_keeps_embedded_mtp(monkeypatch):
     ],
 )
 def test_embedded_mtp_ignores_discovered_root_sidecar(
-    monkeypatch,
-    tmp_path,
-    mode,
-    expected_spec_type,
+    monkeypatch, tmp_path, mode, expected_spec_type
 ):
     backend = _resolver_backend(monkeypatch)
     backend._nextn_predict_layers = 1

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -112,14 +112,18 @@ def _write_minimal_gguf(
     arch: str,
     nextn: int | None,
     extra_uint32: dict[str, int] | None = None,
+    nextn_first: bool = False,
 ) -> Path:
     """Header-only GGUF with arch + optional nextn_predict_layers."""
     extra_uint32 = dict(extra_uint32 or {})
-    body = _enc_kv_string("general.architecture", arch)
-    kv_count = 1
-    if nextn is not None:
-        body += _enc_kv_uint32(f"{arch}.nextn_predict_layers", nextn)
-        kv_count += 1
+    arch_entry = _enc_kv_string("general.architecture", arch)
+    nextn_entry = (
+        _enc_kv_uint32(f"{arch}.nextn_predict_layers", nextn)
+        if nextn is not None
+        else b""
+    )
+    body = nextn_entry + arch_entry if nextn_first else arch_entry + nextn_entry
+    kv_count = 1 + int(nextn is not None)
     for k, v in extra_uint32.items():
         body += _enc_kv_uint32(k, v)
         kv_count += 1
@@ -726,6 +730,20 @@ def test_read_gguf_metadata_captures_nextn_predict_layers(tmp_path, arch, nextn)
     backend = LlamaCppBackend()
     backend._read_gguf_metadata(str(gguf))
     assert backend._nextn_predict_layers == nextn
+
+
+
+def test_read_gguf_metadata_captures_nextn_before_architecture(tmp_path):
+    gguf = _write_minimal_gguf(
+        tmp_path / "reversed.gguf",
+        arch = "qwen35",
+        nextn = 1,
+        nextn_first = True,
+    )
+    backend = LlamaCppBackend()
+    backend._read_gguf_metadata(str(gguf))
+    assert backend._architecture == "qwen35"
+    assert backend._nextn_predict_layers == 1
 
 
 def test_read_gguf_metadata_leaves_nextn_unset_for_non_mtp_arch(tmp_path):
@@ -1954,6 +1972,42 @@ def test_auto_keeps_embedded_mtp(monkeypatch):
     assert parsed["--spec-type"] == "draft-mtp"
     assert backend.spec_fallback_reason is None
 
+@pytest.mark.parametrize(
+    ("mode", "expected_spec_type"),
+    [
+        ("auto", "draft-mtp"),
+        ("mtp", "draft-mtp"),
+        ("mtp+ngram", "ngram-mod,draft-mtp"),
+    ],
+)
+def test_embedded_mtp_ignores_discovered_root_sidecar(
+    monkeypatch,
+    tmp_path,
+    mode,
+    expected_spec_type,
+):
+    backend = _resolver_backend(monkeypatch)
+    backend._nextn_predict_layers = 1
+    sidecar = tmp_path / "mtp-RVN.gguf"
+    sidecar.write_bytes(b"draft")
+
+    flags = backend._build_speculative_flags(
+        speculative_type = mode,
+        spec_draft_n_max = None,
+        extra_args = None,
+        model_identifier = "0bserverx/Qwen3.8-27B-GGUF",
+        model_path = str(tmp_path / "RVN-Q6_K-mtp.gguf"),
+        gpus = True,
+        binary = "/fake/llama-server",
+        mtp_draft_path = str(sidecar),
+        dspark_draft_path = None,
+    )
+
+    parsed = _flags_dict(flags)
+    assert parsed["--spec-type"] == expected_spec_type
+    assert "--model-draft" not in parsed
+    assert backend.spec_fallback_reason is None
+
 
 def test_auto_does_not_promote_dspark_on_a_binary_that_cannot_run_it(monkeypatch, tmp_path):
     """_download_dspark still reports a cached sidecar an incapable binary cannot
@@ -2200,10 +2254,10 @@ def test_auto_non_mla_embedded_mtp_keeps_draft_mtp(monkeypatch):
     assert backend.spec_fallback_reason is None
 
 
-def test_auto_mla_separate_drafter_keeps_mtp(monkeypatch):
-    # Auto + MLA + a separate drafter (mtp_draft_path) -> the drafter exemption
-    # wins over the MLA gate: still draft-mtp (Gemma-style external drafter is
-    # not the slow embedded MLA/DSA path).
+def test_auto_mla_embedded_head_ignores_separate_drafter(monkeypatch):
+    # Positive NextN metadata is authoritative even on MLA: a discovered -md
+    # sidecar would replace the embedded head and incorrectly bypass the MLA
+    # performance gate, so Auto keeps the embedded-MTP ngram fallback.
     backend = _mla_resolver_backend(monkeypatch)
     flags = backend._build_speculative_flags(
         speculative_type = "auto",
@@ -2216,9 +2270,10 @@ def test_auto_mla_separate_drafter_keeps_mtp(monkeypatch):
         mtp_draft_path = "/fake/mtp-draft.gguf",
     )
     parsed = _flags_dict(flags)
-    assert parsed.get("--spec-type") == "draft-mtp"
-    assert backend.speculative_type == "draft-mtp"
-    assert backend.spec_fallback_reason is None
+    assert parsed.get("--spec-type") == "ngram-mod"
+    assert "--model-draft" not in parsed
+    assert backend.speculative_type == "ngram-mod"
+    assert backend.spec_fallback_reason == "mla_mtp_disabled"
 
 
 def test_auto_non_mtp_mla_model_unaffected(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -2250,9 +2250,7 @@ def test_auto_non_mla_embedded_mtp_keeps_draft_mtp(monkeypatch):
 
 
 def test_auto_mla_embedded_head_ignores_separate_drafter(monkeypatch):
-    # Positive NextN metadata is authoritative even on MLA: a discovered -md
-    # sidecar would replace the embedded head and incorrectly bypass the MLA
-    # performance gate, so Auto keeps the embedded-MTP ngram fallback.
+    # Embedded NextN metadata wins: -md would replace the head and bypass MLA's gate.
     backend = _mla_resolver_backend(monkeypatch)
     flags = backend._build_speculative_flags(
         speculative_type = "auto",

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -162,7 +162,6 @@ def test_baked_in_repo_plans_unchanged():
     assert plans["q4_k_m"].target_filenames == ("Qwen3.6-27B-MTP-Q4_K_M.gguf",)
 
 
-
 @pytest.mark.parametrize(
     ("path", "expected"),
     [
@@ -175,7 +174,6 @@ def test_baked_in_repo_plans_unchanged():
 )
 def test_embedded_mtp_name_hint_is_bounded_to_the_quant(path, expected):
     assert has_embedded_mtp_name_hint(path) is expected
-
 
 
 def test_embedded_mtp_variant_omits_root_compatibility_sidecar():
@@ -218,7 +216,6 @@ def test_detect_mtp_file_finds_root_sibling(tmp_path):
     found = detect_mtp_file(str(tmp_path / "model-Q4_K_M.gguf"))
     assert found is not None
     assert found.endswith("mtp-model.gguf")
-
 
 
 def test_detect_mtp_file_ignores_sidecar_for_embedded_head(tmp_path, monkeypatch):
@@ -866,7 +863,6 @@ def test_download_mtp_prefers_main_snapshot_offline(tmp_path, monkeypatch):
     )
 
     assert got == str(old_drafter)
-
 
 
 def test_download_mtp_skips_discovery_for_embedded_head(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -24,7 +24,6 @@ if _BACKEND_DIR not in sys.path:
 
 from hub.utils.download_manifest import ExpectedFile
 from hub.utils.gguf import (
-    has_embedded_mtp_name_hint,
     is_mtp_drafter_path,
     list_local_gguf_variants as list_hub_local_gguf_variants,
 )
@@ -162,21 +161,7 @@ def test_baked_in_repo_plans_unchanged():
     assert plans["q4_k_m"].target_filenames == ("Qwen3.6-27B-MTP-Q4_K_M.gguf",)
 
 
-@pytest.mark.parametrize(
-    ("path", "expected"),
-    [
-        ("RVN-Q6_K-mtp.gguf", True),
-        ("Qwen3.6-27B-MTP-Q4_K_M.gguf", True),
-        ("prompt-mtp-test-Q4_K_M.gguf", False),
-        ("gemma-4-12b-it-Q4_K_M.gguf", False),
-        ("mtp-gemma-4-12b-it-Q8_0.gguf", False),
-    ],
-)
-def test_embedded_mtp_name_hint_is_bounded_to_the_quant(path, expected):
-    assert has_embedded_mtp_name_hint(path) is expected
-
-
-def test_embedded_mtp_variant_omits_root_compatibility_sidecar():
+def test_variant_plan_keeps_root_mtp_sidecar_until_metadata_is_available():
     siblings = [
         _sib("RVN-Q6_K-mtp.gguf", 4_000, "main"),
         _sib("mtp-RVN.gguf", 100, "drafter"),
@@ -185,10 +170,10 @@ def test_embedded_mtp_variant_omits_root_compatibility_sidecar():
 
     plan = build_gguf_variant_plans(siblings)["q6_k"]
 
-    assert plan.target_filenames == ("RVN-Q6_K-mtp.gguf", "mmproj-F16.gguf")
-    assert plan.companion_hashes == frozenset({"mmproj"})
-    assert plan.required_hashes == frozenset({"main", "mmproj"})
-    assert plan.download_size_bytes == 4_500
+    assert plan.target_filenames == ("RVN-Q6_K-mtp.gguf", "mmproj-F16.gguf", "mtp-RVN.gguf")
+    assert plan.companion_hashes == frozenset({"drafter", "mmproj"})
+    assert plan.required_hashes == frozenset({"drafter", "main", "mmproj"})
+    assert plan.download_size_bytes == 4_600
 
 
 def test_old_manifest_resume_reclassifies_drafter():

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -24,6 +24,7 @@ if _BACKEND_DIR not in sys.path:
 
 from hub.utils.download_manifest import ExpectedFile
 from hub.utils.gguf import (
+    has_embedded_mtp_name_hint,
     is_mtp_drafter_path,
     list_local_gguf_variants as list_hub_local_gguf_variants,
 )
@@ -161,6 +162,37 @@ def test_baked_in_repo_plans_unchanged():
     assert plans["q4_k_m"].target_filenames == ("Qwen3.6-27B-MTP-Q4_K_M.gguf",)
 
 
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("RVN-Q6_K-mtp.gguf", True),
+        ("Qwen3.6-27B-MTP-Q4_K_M.gguf", True),
+        ("prompt-mtp-test-Q4_K_M.gguf", False),
+        ("gemma-4-12b-it-Q4_K_M.gguf", False),
+        ("mtp-gemma-4-12b-it-Q8_0.gguf", False),
+    ],
+)
+def test_embedded_mtp_name_hint_is_bounded_to_the_quant(path, expected):
+    assert has_embedded_mtp_name_hint(path) is expected
+
+
+
+def test_embedded_mtp_variant_omits_root_compatibility_sidecar():
+    siblings = [
+        _sib("RVN-Q6_K-mtp.gguf", 4_000, "main"),
+        _sib("mtp-RVN.gguf", 100, "drafter"),
+        _sib("mmproj-F16.gguf", 500, "mmproj"),
+    ]
+
+    plan = build_gguf_variant_plans(siblings)["q6_k"]
+
+    assert plan.target_filenames == ("RVN-Q6_K-mtp.gguf", "mmproj-F16.gguf")
+    assert plan.companion_hashes == frozenset({"mmproj"})
+    assert plan.required_hashes == frozenset({"main", "mmproj"})
+    assert plan.download_size_bytes == 4_500
+
+
 def test_old_manifest_resume_reclassifies_drafter():
     # Pre-fix manifests could leak the drafter into a quant's expected
     # files; resume must classify it as a companion, not a main shard.
@@ -186,6 +218,19 @@ def test_detect_mtp_file_finds_root_sibling(tmp_path):
     found = detect_mtp_file(str(tmp_path / "model-Q4_K_M.gguf"))
     assert found is not None
     assert found.endswith("mtp-model.gguf")
+
+
+
+def test_detect_mtp_file_ignores_sidecar_for_embedded_head(tmp_path, monkeypatch):
+    weight = tmp_path / "RVN-Q6_K-mtp.gguf"
+    weight.write_bytes(b"main")
+    (tmp_path / "mtp-RVN.gguf").write_bytes(b"draft")
+    monkeypatch.setattr(
+        "utils.models.model_config.read_gguf_nextn_predict_layers",
+        lambda path: 1 if path == str(weight) else None,
+    )
+
+    assert detect_mtp_file(str(weight)) is None
 
 
 def test_detect_mtp_file_none_without_sibling(tmp_path):
@@ -821,6 +866,30 @@ def test_download_mtp_prefers_main_snapshot_offline(tmp_path, monkeypatch):
     )
 
     assert got == str(old_drafter)
+
+
+
+def test_download_mtp_skips_discovery_for_embedded_head(tmp_path, monkeypatch):
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    main = tmp_path / "RVN-Q6_K-mtp.gguf"
+    main.write_bytes(b"main")
+    reached = False
+
+    def _unexpected_download(**_kwargs):
+        nonlocal reached
+        reached = True
+        return str(tmp_path / "mtp-RVN.gguf")
+
+    monkeypatch.setattr(
+        "utils.models.gguf_metadata.read_gguf_nextn_predict_layers",
+        lambda path: 1 if path == str(main) else None,
+    )
+    backend = LlamaCppBackend()
+    backend._download_companion_gguf = _unexpected_download
+
+    assert backend._download_mtp(hf_repo = "org/repo", near_path = str(main)) is None
+    assert reached is False
 
 
 def test_download_mtp_online_skips_cache_reuse(tmp_path, monkeypatch):

--- a/studio/backend/utils/models/gguf_metadata.py
+++ b/studio/backend/utils/models/gguf_metadata.py
@@ -276,7 +276,6 @@ def _parse_gguf_arch_uints(path: str, wanted_suffixes: frozenset[str]) -> Option
     return found
 
 
-
 def read_gguf_nextn_predict_layers(path: str) -> Optional[int]:
     """Return the selected architecture's embedded NextN/MTP layer count.
 

--- a/studio/backend/utils/models/gguf_metadata.py
+++ b/studio/backend/utils/models/gguf_metadata.py
@@ -65,6 +65,11 @@ _CLASSIFIER_HEAD_CACHE: Dict[_CacheKey, Optional[bool]] = {}
 _DIMS_CACHE: Dict[_CacheKey, Optional[Dict[str, Optional[int]]]] = {}
 
 
+# The embedded speculative-head count is read by discovery, launch and sizing.
+# Cache it separately so those callers agree without widening the staged-dims API.
+_NEXTN_CACHE: Dict[_CacheKey, Optional[int]] = {}
+
+
 def _cache_key(path: str) -> Optional[_CacheKey]:
     try:
         st = os.stat(path)
@@ -183,13 +188,15 @@ def read_gguf_context_length(path: str) -> Optional[int]:
 
 
 def _parse_gguf_arch_uints(path: str, wanted_suffixes: frozenset[str]) -> Optional[Dict[str, int]]:
-    """Walk a GGUF header once and return the requested architecture-namespaced
-    uint (vtype 4/10) keys, e.g. ``{"block_count": 32}``. Keys are
-    ``{arch}.<suffix>``; the arch is learned from ``general.architecture`` (GGUF
-    writes general.* before arch.* keys, matching the loader's own parser).
-    Returns ``None`` if not a GGUF / unreadable, else a dict (possibly empty or
-    partial when some keys are absent)."""
+    """Walk a GGUF header once and return requested architecture-namespaced
+    uint (vtype 4/10) keys, e.g. ``{"block_count": 32}``.
+
+    GGUF does not guarantee KV order, so matching uints are buffered until
+    ``general.architecture`` identifies the active namespace. Returns ``None``
+    if the file is unreadable/not GGUF, otherwise a possibly partial dict.
+    """
     arch: Optional[str] = None
+    buffered: Dict[str, int] = {}
     found: Dict[str, int] = {}
     try:
         with open(path, "rb") as f:
@@ -228,24 +235,36 @@ def _parse_gguf_arch_uints(path: str, wanted_suffixes: frozenset[str]) -> Option
                         if len(sbytes) < slen:
                             break
                         arch = sbytes.decode("utf-8", "replace")
-                    elif (
-                        arch is not None
-                        and vtype in (4, 10)
-                        and key.startswith(f"{arch}.")
-                        and key[len(arch) + 1 :] in wanted_suffixes
-                    ):
+                        for suffix in wanted_suffixes:
+                            full_key = f"{arch}.{suffix}"
+                            if full_key in buffered:
+                                found[suffix] = buffered[full_key]
+                    elif vtype in (4, 10):
+                        suffix = next(
+                            (
+                                candidate
+                                for candidate in wanted_suffixes
+                                if key.endswith(f".{candidate}")
+                            ),
+                            None,
+                        )
+                        if suffix is None:
+                            if not _skip_gguf_value(f, vtype):
+                                break
+                            continue
                         width = 4 if vtype == 4 else 8
                         n_bytes = f.read(width)
                         if len(n_bytes) < width:
                             break
-                        found[key[len(arch) + 1 :]] = struct.unpack(
-                            "<I" if vtype == 4 else "<Q", n_bytes
-                        )[0]
-                        if len(found) == len(wanted_suffixes):
-                            break
+                        value = struct.unpack("<I" if vtype == 4 else "<Q", n_bytes)[0]
+                        buffered[key] = value
+                        if arch is not None and key == f"{arch}.{suffix}":
+                            found[suffix] = value
                     else:
                         if not _skip_gguf_value(f, vtype):
                             break
+                    if arch is not None and len(found) == len(wanted_suffixes):
+                        break
                 except (struct.error, UnicodeDecodeError):
                     break
     except OSError as e:
@@ -255,6 +274,32 @@ def _parse_gguf_arch_uints(path: str, wanted_suffixes: frozenset[str]) -> Option
         logger.debug(f"_parse_gguf_arch_uints: parse failure on {path}: {e}")
         return None
     return found
+
+
+
+def read_gguf_nextn_predict_layers(path: str) -> Optional[int]:
+    """Return the selected architecture's embedded NextN/MTP layer count.
+
+    ``0`` is a real headless verdict. ``None`` means the key is absent or the
+    header is unreadable, so callers that suppress a separate drafter can do so
+    only on a positive value.
+    """
+    key = _cache_key(path)
+    if key is None:
+        return None
+    with _CACHE_LOCK:
+        if key in _NEXTN_CACHE:
+            return _NEXTN_CACHE[key]
+    values = _parse_gguf_arch_uints(path, frozenset({"nextn_predict_layers"}))
+    result = values.get("nextn_predict_layers") if values is not None else None
+    with _CACHE_LOCK:
+        while len(_NEXTN_CACHE) >= _CACHE_MAX_ENTRIES:
+            try:
+                _NEXTN_CACHE.pop(next(iter(_NEXTN_CACHE)))
+            except StopIteration:
+                break
+        _NEXTN_CACHE[key] = result
+    return result
 
 
 def _parse_gguf_staged_dims(path: str) -> Optional[Dict[str, Optional[int]]]:

--- a/studio/backend/utils/models/gguf_metadata.py
+++ b/studio/backend/utils/models/gguf_metadata.py
@@ -65,8 +65,7 @@ _CLASSIFIER_HEAD_CACHE: Dict[_CacheKey, Optional[bool]] = {}
 _DIMS_CACHE: Dict[_CacheKey, Optional[Dict[str, Optional[int]]]] = {}
 
 
-# The embedded speculative-head count is read by discovery, launch and sizing.
-# Cache it separately so those callers agree without widening the staged-dims API.
+# Cache the embedded speculative-head count separately for discovery, launch, and sizing.
 _NEXTN_CACHE: Dict[_CacheKey, Optional[int]] = {}
 
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1929,6 +1929,7 @@ def detect_mtp_file(
         # A repo-root mtp-*.gguf can be a compatibility mirror for llama.cpp's
         # -hf discovery. Passing it as -md would replace, not augment, this head.
         return None
+
     def _matches_weight(candidate: Path) -> bool:
         return _drafter_matches_weight(candidate.name, weight_name, kind = "mtp")
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1926,8 +1926,7 @@ def detect_mtp_file(
     """
 
     if Path(path).is_file() and (read_gguf_nextn_predict_layers(path) or 0) > 0:
-        # A repo-root mtp-*.gguf can be a compatibility mirror for llama.cpp's
-        # -hf discovery. Passing it as -md would replace, not augment, this head.
+        # A root mtp-*.gguf may mirror an embedded head; -md would replace it.
         return None
 
     def _matches_weight(candidate: Path) -> bool:

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -38,6 +38,7 @@ from utils.models.gguf_metadata import (
     mmproj_accepts_image,
     pairing_score,
     read_gguf_general_metadata,
+    read_gguf_nextn_predict_layers,
 )
 import structlog
 from loggers import get_logger
@@ -1924,6 +1925,10 @@ def detect_mtp_file(
     rejection as no drafter at all.
     """
 
+    if Path(path).is_file() and (read_gguf_nextn_predict_layers(path) or 0) > 0:
+        # A repo-root mtp-*.gguf can be a compatibility mirror for llama.cpp's
+        # -hf discovery. Passing it as -md would replace, not augment, this head.
+        return None
     def _matches_weight(candidate: Path) -> bool:
         return _drafter_matches_weight(candidate.name, weight_name, kind = "mtp")
 


### PR DESCRIPTION
## Summary

- treat a positive architecture-scoped `nextn_predict_layers` value as authoritative proof that the selected GGUF embeds its MTP head
- suppress Studio-discovered MTP sidecars consistently across local resolution, launch construction, and memory estimates
- keep Hub-planned sidecars until the downloaded header can be inspected, preserving offline fallback for headless, zero-valued, or unreadable GGUFs

## Why

Some repositories publish both a main GGUF with an embedded NextN/MTP head and a root `mtp-*.gguf` compatibility artifact. Studio currently passes that artifact as `--model-draft`; llama.cpp then replaces the embedded head and can reject the load, silently disabling speculative decoding.

This keeps the behavior automatic and metadata-driven. Raw user-owned llama.cpp arguments and DSpark/DFlash modes remain unchanged.

## Verification

- exact head `ad61f96c3a0e9456c99daaa027ab7379903f6043`: targeted suites passed on [Ubuntu (699)](https://github.com/wasimysaid/unsloth/actions/runs/33616683290), [macOS (699)](https://github.com/wasimysaid/unsloth/actions/runs/33616683162), and [Windows (666 passed, 33 OS-specific skips)](https://github.com/wasimysaid/unsloth/actions/runs/33616683238)
- hermetic issue probe: `draft-mtp` remains enabled and `--model-draft` is absent
- real reported GGUF header: `qwen35.nextn_predict_layers = 1`
- live issue-specific Studio E2E on the exact reported revision (`RVN-Q6_K-mtp.gguf`, 20.99 GiB) with the 1.69 GiB `mtp-RVN.gguf` sidecar present: Playwright loaded the model and completed a real chat; llama-server launched with `--spec-type draft-mtp --spec-draft-n-max 2` and no `--model-draft`; runtime metrics recorded 36 drafted / 35 accepted tokens across 18 speculative verification steps
- focused pre-commit hooks, deterministic worktree checks, and pre-push gate pass
- latest Codex review: no major issues

## CI note

Backend CI has two pre-existing merge-base failures:

- Python 3.13: [base](https://github.com/unslothai/unsloth/actions/runs/33609380067/job/100180691675) and [PR](https://github.com/unslothai/unsloth/actions/runs/33616519500/job/100203573394) both fail only `test_non_gguf_reload_settings.py::TestNonGgufStatusReportsWhatTheLoadAskedFor`; this PR changes neither that test nor `routes/inference.py`.
- Repo tests (CPU): [base](https://github.com/unslothai/unsloth/actions/runs/33609380067/job/100180691657) and [PR](https://github.com/unslothai/unsloth/actions/runs/33616519500/job/100203573103) both fail only `test_model_picker_contracts.py::test_a_pinned_cached_row_loads_from_the_id_the_backend_pinned`; this PR changes neither that test nor the frontend.

Closes #10169
