### PR TITLE
Fix the two stale source-text contract tests blocking every PR

### DIFF
--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -601,16 +601,11 @@ def test_the_status_route_reports_what_a_self_sizing_load_asked_for():
         encoding = "utf-8"
     )
     assert "requested_context_length = llama_backend.requested_n_ctx" in route_src
-    # 0 is "size it yourself"; None is "records no request", and the UI tells them apart.
-    # Either spelling of the recorded request, since the route stamps one and the MLX
-    # mirror carries the other, but always through the non-negative reader.
-    assert (
-        "requested_context_length = _nonnegative_int_or_none(\n"
-        '                model_info.get("requested_context_length")\n'
-        '                if model_info.get("requested_context_length") is not None\n'
-        '                else model_info.get("max_seq_length_requested")\n'
-        "            )," in route_src
-    )
+    # The non-GGUF branch is covered by behaviour instead, in
+    # test_non_gguf_reload_settings.py::TestNonGgufStatusReportsWhatTheLoadAskedFor: 0 is
+    # "size it yourself", None is "records no request", and the MLX mirror wins over the
+    # stamped spelling. Pinning that call's exact layout here only duplicated it, and the
+    # duplicate is what went stale when the reader gained the mirror.
     # The parent cannot recompute the group once the worker holds the model: it mirrors all.
     src = (Path(__file__).resolve().parents[1] / "core/inference/worker.py").read_text("utf-8")
     assert '"native_context_length",\n                "max_context_length",' in src

--- a/studio/backend/tests/test_non_gguf_reload_settings.py
+++ b/studio/backend/tests/test_non_gguf_reload_settings.py
@@ -37,6 +37,13 @@ class _Backend:
     def __init__(self, entry):
         self.active_model_name = RESIDENT
         self.models = {RESIDENT: entry}
+        self.loading_models: set = set()
+
+
+class _NoLlama:
+    """No llama-server resident, so status takes the non-GGUF branch."""
+
+    is_loaded = False
 
 
 class _Request:
@@ -134,18 +141,80 @@ class TestNonGgufStatusReportsWhatTheLoadAskedFor:
     def test_the_route_stamps_it_after_a_successful_load(self, field):
         assert field in self._stamp_block(), f"{field} is never recorded on the resident"
 
-    def test_the_non_gguf_status_branch_publishes_them(self):
-        import inspect
-        import routes.inference as ri
+    def _status_for(self, monkeypatch, entry):
+        """The non-GGUF status payload for a resident stamped with `entry`.
 
-        src = inspect.getsource(ri.get_status)
-        # The GGUF branch returns first, so the last occurrence is the non-GGUF return.
-        non_gguf = src[src.rindex("Non-GGUF: classify from the loaded template") :]
-        for wire, stamped in (
-            ("requested_context_length", "max_seq_length_requested"),
-            ("load_in_4bit", "load_in_4bit_requested"),
-            ("requested_gpu_ids", "gpu_ids_requested"),
-        ):
-            assert (
-                f'{wire} = model_info.get("{stamped}")' in non_gguf
-            ), f"non-GGUF status does not publish {wire}"
+        Driven through the route rather than read out of its source: the spelling of the
+        read is not the contract, the published field is. An earlier version asserted the
+        literal `model_info.get(...)` line and broke on #8125, which kept publishing the
+        same field from the same stamped key through a coercion helper.
+        """
+        import asyncio
+
+        backend = _Backend(entry)
+        monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _NoLlama())
+        monkeypatch.setattr(inference_route, "get_inference_backend", lambda: backend)
+        monkeypatch.setattr(inference_route, "_peek_inference_backend", lambda: backend)
+        monkeypatch.setattr(
+            inference_route, "_probe_llama_cpp_status", lambda _backend: (False, {})
+        )
+        monkeypatch.setattr(
+            inference_route,
+            "_detect_safetensors_features",
+            lambda *_a: {
+                "supports_reasoning": False,
+                "reasoning_style": "enable_thinking",
+                "reasoning_effort_levels": [],
+                "reasoning_always_on": False,
+                "supports_preserve_thinking": False,
+                "supports_tools": False,
+            },
+        )
+        monkeypatch.setattr(inference_route, "load_inference_config", lambda _model: None)
+        # Unrelated to the stamped settings, and it re-derives from the model card, which
+        # would put a Hub request in the middle of a status unit test.
+        monkeypatch.setattr(
+            inference_route, "_resolve_loaded_trust_remote_code", lambda *_a, **_k: False
+        )
+        monkeypatch.setattr(inference_route, "_running_load_attempt", None)
+        monkeypatch.setattr(inference_route, "_pending_load_attempts", {})
+        return asyncio.run(inference_route.get_status(current_subject = "test"))
+
+    def test_the_non_gguf_status_branch_publishes_them(self, monkeypatch):
+        response = self._status_for(
+            monkeypatch,
+            {
+                "max_seq_length_requested": 8192,
+                "load_in_4bit_requested": False,
+                "gpu_ids_requested": [0, 1],
+            },
+        )
+
+        assert response.requested_context_length == 8192
+        assert response.load_in_4bit is False
+        assert response.requested_gpu_ids == [0, 1]
+
+    def test_the_mlx_mirror_wins_over_the_stamped_spelling(self, monkeypatch):
+        """#8125: the MLX worker mirrors the real context back as requested_context_length."""
+        response = self._status_for(
+            monkeypatch,
+            {"requested_context_length": 4096, "max_seq_length_requested": 8192},
+        )
+
+        assert response.requested_context_length == 4096
+
+    @pytest.mark.parametrize(
+        "requested, published",
+        [(0, 0), (8192, 8192), ("8192", 8192), (-1, None), (True, None), ("", None), (None, None)],
+    )
+    def test_a_requested_context_length_is_published_only_when_it_is_a_count(
+        self, monkeypatch, requested, published
+    ):
+        """0 is an answer -- size it yourself -- so it must survive; junk must not.
+
+        A bool is not a count even though `int(True)` is 1, and a negative is not one
+        either; a numeric string still is, since the stamp is read back off JSON.
+        """
+        response = self._status_for(monkeypatch, {"max_seq_length_requested": requested})
+
+        assert response.requested_context_length == published

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -681,10 +681,19 @@ def test_a_pinned_cached_row_loads_from_the_id_the_backend_pinned():
     # loosely, so a new row that forgets it is a failure here rather than a load
     # that silently follows the default ref. #7736 added the third: the collapsed
     # single-quant GGUF row. #7880 added the fourth: the per-quant VRAM bar, which
-    # has to price the pinned snapshot rather than the default ref.
-    assert picker.count("loadId: c.load_id") == 4, (
+    # has to price the pinned snapshot rather than the default ref. #10128 put three of
+    # them behind a torn-snapshot guard, so the guard is matched rather than one spelling.
+    pins = re.findall(r"loadId:\s*(?:(\w+)\s*\?\s*undefined\s*:\s*)?c\.load_id", picker)
+    assert len(pins) == 4, (
         "a row or gear that can start a load is missing the pin, or a new one was "
         "added and this count needs to follow it"
+    )
+    # #10128: the three that can START a load withhold the pin for a part-downloaded
+    # snapshot, since audio-page.tsx reads a forwarded loadId as proof the weights are
+    # on disk. The VRAM bar only prices what is there, so it pins unconditionally.
+    assert sorted(pins) == ["", "isPartial", "isPartial", "isPartial"], (
+        "a row that can start a load lost its partial-snapshot guard, or the VRAM bar "
+        f"gained one: {sorted(pins)}"
     )
     block = re.search(r"onConfigure\(repoId, \{.*?\n\s*\}", picker, re.S)
     assert block and "loadId," in block.group(0), "the GGUF gear drops the pin"


### PR DESCRIPTION
`main` is red on `(Python 3.13)` and `Repo tests (CPU)`, and both failures are inherited by every open PR. Neither is a regression in production code. Both are contract tests that pin the *spelling* of a line rather than the behaviour it implements, and both went stale when a later PR refactored that line correctly.

## test_non_gguf_reload_settings.py

`test_the_non_gguf_status_branch_publishes_them` asserted the literal string `requested_context_length = model_info.get("max_seq_length_requested")` appeared in `inspect.getsource(get_status)`.

#8125 changed that read to prefer the MLX worker's mirrored `requested_context_length` and to coerce through `_nonnegative_int_or_none`. The field is still published, from the same stamped key, and the stamp side is untouched, which is why the sibling stamping test still passes. #8125 updated the *other* source-text test that pins this line (`test_native_context_length.py`) and missed this one, so main ended up holding two tests asserting mutually exclusive spellings of the same statement.

Replaced with behaviour: drive `get_status` against a stamped resident and assert the payload. The file already had `_Backend` / `_Request` scaffolding and the module's other tests are already behaviour based, so this follows the local pattern. The new tests also cover what #8125 actually added, which nothing covered before:

- the MLX mirror wins over the stamped spelling
- `0` survives as "size it yourself" while a negative, a bool or an empty string reads as "no request recorded"

Dropped the now-duplicated spelling assertion in `test_native_context_length.py` and left a pointer to the behaviour tests. Its GGUF-branch assertion stays.

## tests/studio/test_model_picker_contracts.py

`test_a_pinned_cached_row_loads_from_the_id_the_backend_pinned` asserted `picker.count("loadId: c.load_id") == 4`.

#10128 put three of those four sites behind a torn-snapshot guard, `loadId: isPartial ? undefined : c.load_id`, because `audio-page.tsx` has no `isDownloaded` field and infers it from a forwarded `loadId`, so a part-downloaded snapshot arrived there looking complete. All four sites still carry the pin. #10128 updated the JS test that pins this and missed the Python one.

The count is now a regex that matches a pin whether or not it is guarded, and there is a second assertion that exactly the three load-starting sites carry the guard while the VRAM bar does not. That encodes #10128's rule rather than merely tolerating it, so the test is now stricter than it was.

## Checks

Each rewritten assertion was mutation tested rather than just run green:

- removing `requested_context_length` from the status payload fails 5 of the new tests
- deleting one pin from `pickers.tsx` fails the count
- removing one `isPartial` guard fails the new guard assertion

Suites: `test_non_gguf_reload_settings.py`, `test_native_context_length.py` and `test_inference_status_route.py` are 71 passed; `tests/studio/` is 7442 passed, 197 skipped. The new status tests stub `_resolve_loaded_trust_remote_code`, which otherwise re-derives from the model card and puts a Hub request inside a unit test.

No production code is changed by this PR.