### PR TITLE
Fix the frontend unit tests broken by a merge skew between #10161 and #10162

### DIFF
--- a/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
+++ b/studio/frontend/tests/edit-reply-keeps-tool-order.test.ts
@@ -51,8 +51,23 @@ function harness() {
           saved.push(record);
           return record;
         },
+        // delete-thread-message loads for real under the passthrough below, and it
+        // reads the thread back; nothing here drives that path.
+        listChatMessages: async () => [],
+      },
+      "@assistant-ui/core/internal": { MessageRepository: class {} },
+      // The persistence boundary. Cut here so the passthrough stops before db.ts and
+      // its IndexedDB driver, which no node test can load: this suite is about the
+      // record's shape and part order, not about storing it.
+      "./chat-history-storage": {
+        ensureStoredChatThread: async () => undefined,
+        syncStoredChatMessages: async () => undefined,
       },
     },
+    // The record this test asserts on is built by the real exportedItemToRecord, and
+    // the metadata it strips comes from the real RESEARCH_METADATA_KEYS, so those
+    // siblings load rather than being faked.
+    { relativePassthrough: true },
   );
   return { module, saved };
 }

--- a/studio/frontend/tests/helpers/module-stubs.ts
+++ b/studio/frontend/tests/helpers/module-stubs.ts
@@ -4,8 +4,8 @@
 // Kept out of kit.ts on purpose, like tsx-ast.ts: only the few tests that drive a
 // component or a hook directly should pay for loading the TypeScript compiler.
 
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import ts from "typescript";
 
@@ -15,6 +15,16 @@ export type StubElement = {
   props: Record<string, unknown>;
 };
 
+/** The sibling a relative specifier names, trying the extensions src actually uses. */
+function resolveSibling(fromPath: string, specifier: string): URL {
+  const base = new URL(specifier, pathToFileURL(fromPath));
+  for (const suffix of [".ts", ".tsx", "/index.ts", "/index.tsx", ""]) {
+    const candidate = new URL(base.href + suffix);
+    if (existsSync(fileURLToPath(candidate))) return candidate;
+  }
+  throw new Error(`cannot resolve import "${specifier}" from ${fromPath}`);
+}
+
 /**
  * Runs one shipped src module with every import replaced by a stub, so a test can
  * call the real source with dependencies it controls. Bare node cannot import a
@@ -23,6 +33,7 @@ export type StubElement = {
 export function loadWithStubs<T>(
   moduleUrl: URL,
   stubs: Record<string, unknown>,
+  options: { relativePassthrough?: boolean } = {},
 ): T {
   const path = fileURLToPath(moduleUrl);
   const { outputText } = ts.transpileModule(readFileSync(path, "utf8"), {
@@ -36,6 +47,14 @@ export function loadWithStubs<T>(
   const loaded = { exports: {} as T };
   const requireStub = (specifier: string): unknown => {
     if (specifier in stubs) return stubs[specifier];
+    // Opt-in: load a sibling source for real, with the same stubs, instead of failing.
+    // A stub map names the module's imports, so without this every import ADDED to the
+    // module under test breaks each test that loads it, even when the new import is
+    // irrelevant to what that test drives. Off by default: a test that means to cut a
+    // dependency off still wants the throw.
+    if (options.relativePassthrough && specifier.startsWith(".")) {
+      return loadWithStubs(resolveSibling(path, specifier), stubs, options);
+    }
     throw new Error(`no stub for import "${specifier}" in ${path}`);
   };
   new Function("require", "module", "exports", outputText)(


### PR DESCRIPTION
Both `Frontend build + bundle sanity` and `Frontend unit tests (Windows)` are red on `main` with 21 failures, all in `tests/edit-reply-keeps-tool-order.test.ts`, all the same error:

```
no stub for import "./delete-thread-message" in src/features/chat/utils/update-thread-message.ts
```

This is not a Windows problem. Both jobs fail identically on Ubuntu and on Windows, for the same reason.

## What happened

#10162 added `edit-reply-keeps-tool-order.test.ts`, whose harness passes `loadWithStubs` a stub map with a single entry. That was correct on its own branch: `update-thread-message.ts` had one runtime import at the time.

#10161 merged twelve seconds later and added two runtime imports to that same module, `exportedItemToRecord` and `RESEARCH_METADATA_KEYS`. Neither PR's CI ever saw the other's tree, and `requireStub` throws on any import it has no stub for, so main was red the moment both landed.

No production code is wrong here. The stub map is a hand-maintained list of a module's imports, so it goes stale whenever the module gains one.

## The fix

Rather than only adding the two missing entries, `loadWithStubs` gains an opt-in `relativePassthrough`: an unstubbed relative import loads the real sibling with the same stubs instead of throwing. Default behaviour is unchanged, so no other test is affected, and a test that deliberately cuts a dependency off still gets the throw.

This test opts in, which also makes it a better test than adding fakes would have. The record it asserts on is built by the real `exportedItemToRecord`, and the metadata it strips comes from the real `RESEARCH_METADATA_KEYS`; stubbing those would have meant asserting on the harness rather than on the code.

Two stubs remain, both deliberate:

- `@assistant-ui/core/internal`, a real package the module only needs a constructor from.
- `./chat-history-storage`, which is the persistence boundary. Cutting there stops the passthrough before `db.ts` and its IndexedDB driver, which no node test can load. This suite is about a record's shape and part order, not about storing it.

## Checks

- `tests/edit-reply-keeps-tool-order.test.ts`: 21 failed before, 21 pass after.
- Full `npm test`: 6601 tests, 0 failures. The shared helper change breaks nothing else.

The underlying cause is worth noting for whoever owns CI: two PRs can each be green and still leave main red, because neither is tested against the other's tree. The passthrough removes the most common way that shows up here, but it does not remove the general case.