### PR TITLE
Stop the research cancellation tests failing on a busy CI runner

### DIFF
--- a/studio/backend/tests/test_research_runs_storage.py
+++ b/studio/backend/tests/test_research_runs_storage.py
@@ -3249,6 +3249,15 @@ def test_sustained_heartbeat_errors_stop_before_lease_expiry(research_home, monk
     assert supervisor._cancel_event("run-1").is_set()
 
 
+# A hang guard, not a latency assertion. These three cancellation tests used a fixed
+# 50ms sleep to "wait" for the request to start and then gave cancellation one second to
+# land. CI runs this suite in parallel with tens of thousands of other tests, so a busy
+# runner blew the bound and reported cancellation as broken. The waits below are now
+# signalled by the fake itself, and this bound only exists so a genuine hang fails
+# instead of running until the suite timeout.
+_CANCEL_TIMEOUT_S = 30.0
+
+
 def test_completion_cancellation_closes_loopback_request(research_home, monkeypatch):
     from core import research_runs as worker
 
@@ -3256,6 +3265,7 @@ def test_completion_cancellation_closes_loopback_request(research_home, monkeypa
     supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
     run = research_db.claim_next(supervisor.worker_id)
     request_cancelled = {"value": False}
+    in_flight = asyncio.Event()
 
     class FakeClient:
         def __init__(self, **kwargs):
@@ -3271,6 +3281,7 @@ def test_completion_cancellation_closes_loopback_request(research_home, monkeypa
             return object()
 
         async def send(self, request, *, stream):
+            in_flight.set()
             try:
                 await asyncio.Event().wait()
             finally:
@@ -3288,10 +3299,12 @@ def test_completion_cancellation_closes_loopback_request(research_home, monkeypa
         task = asyncio.create_task(
             supervisor._stream_completion(run, [{"role": "user", "content": "question"}])
         )
-        await asyncio.sleep(0.05)
+        # Wait for the request to actually be in flight rather than guessing how
+        # long that takes: cancelling before it starts tests nothing.
+        await asyncio.wait_for(in_flight.wait(), timeout = _CANCEL_TIMEOUT_S)
         supervisor.cancel("run-1")
         with pytest.raises(worker.RunCancelled):
-            await asyncio.wait_for(task, timeout = 1)
+            await asyncio.wait_for(task, timeout = _CANCEL_TIMEOUT_S)
 
     asyncio.run(scenario())
     assert request_cancelled["value"] is True
@@ -3304,9 +3317,11 @@ def test_stream_line_wait_is_interruptible_by_cancellation(research_home):
     supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
     research_db.claim_next(supervisor.worker_id)
     iterator_cancelled = {"value": False}
+    in_flight = asyncio.Event()
 
     class FakeResponse:
         async def _lines(self):
+            in_flight.set()
             try:
                 await asyncio.Event().wait()
                 yield "unreachable"
@@ -3322,10 +3337,12 @@ def test_stream_line_wait_is_interruptible_by_cancellation(research_home):
                 pass
 
         task = asyncio.create_task(consume())
-        await asyncio.sleep(0.05)
+        # Wait for the request to actually be in flight rather than guessing how
+        # long that takes: cancelling before it starts tests nothing.
+        await asyncio.wait_for(in_flight.wait(), timeout = _CANCEL_TIMEOUT_S)
         supervisor.cancel("run-1")
         with pytest.raises(worker.RunCancelled):
-            await asyncio.wait_for(task, timeout = 1)
+            await asyncio.wait_for(task, timeout = _CANCEL_TIMEOUT_S)
 
     asyncio.run(scenario())
     assert iterator_cancelled["value"] is True
@@ -3338,6 +3355,7 @@ def test_stream_open_wait_is_interruptible_by_cancellation(research_home, monkey
     supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
     run = research_db.claim_next(supervisor.worker_id)
     request_cancelled = {"value": False}
+    in_flight = asyncio.Event()
 
     class FakeClient:
         def __init__(self, **kwargs):
@@ -3353,6 +3371,7 @@ def test_stream_open_wait_is_interruptible_by_cancellation(research_home, monkey
             return object()
 
         async def send(self, request, *, stream):
+            in_flight.set()
             try:
                 await asyncio.Event().wait()
             finally:
@@ -3370,10 +3389,12 @@ def test_stream_open_wait_is_interruptible_by_cancellation(research_home, monkey
         task = asyncio.create_task(
             supervisor._stream_completion(run, [{"role": "user", "content": "question"}])
         )
-        await asyncio.sleep(0.05)
+        # Wait for the request to actually be in flight rather than guessing how
+        # long that takes: cancelling before it starts tests nothing.
+        await asyncio.wait_for(in_flight.wait(), timeout = _CANCEL_TIMEOUT_S)
         supervisor.cancel("run-1")
         with pytest.raises(worker.RunCancelled):
-            await asyncio.wait_for(task, timeout = 1)
+            await asyncio.wait_for(task, timeout = _CANCEL_TIMEOUT_S)
 
     asyncio.run(scenario())
     assert request_cancelled["value"] is True


### PR DESCRIPTION
`tests/test_research_runs_storage.py::test_completion_cancellation_closes_loopback_request` and `::test_stream_open_wait_is_interruptible_by_cancellation` fail on PR #10172's `(Python 3.13)` job with a bare `TimeoutError`. They are not caused by that PR.

## Attribution

- Both pass on `main` locally, 3 runs out of 3.
- Both pass on #10172's own branch, 3 runs out of 3, and its whole file passes twice under `-n 4`.
- #10172 changes llama.cpp SSE parsing and a prefill deadline. It touches no asyncio, no research runs, and nothing shared with these tests.
- Its new tests drive a fake clock rather than sleeping, so they add no wall-clock load either.
- `pytest-randomly` is not installed, so this is not a test-ordering effect.

What is left is load. The CI job runs 36,636 tests in parallel; these three tests sleep a fixed 50ms to "wait" for a request to start, then give cancellation one second to land. A busy runner blows that and reports cancellation as broken when it is not.

## The fix

Two separate problems, both in the tests:

**The sleep was a guess.** `await asyncio.sleep(0.05)` was standing in for "the request is now in flight". Each fake already blocks on an event, so it now sets an `in_flight` event first and the scenario waits on that. Cancelling before the request starts would test nothing, and this makes that ordering exact instead of probable.

**The bound was asserting latency.** These tests are about cancellation propagating, not about it landing inside one second. The one-second `wait_for` is now a named `_CANCEL_TIMEOUT_S = 30.0` hang guard, so a genuine hang still fails rather than running to the suite timeout, but a slow runner no longer does.

Applied to all three tests with this shape, including `test_stream_line_wait_is_interruptible_by_cancellation`, which has the same latent problem and simply has not failed yet.

## Checks

- `tests/test_research_runs_storage.py`: 147 passed.
- Mutation tested rather than just run green: with `ResearchSupervisor.cancel` stubbed to a no-op so cancellation never lands, all three still fail on the guard. Widening the bound did not make them vacuous.

Note that this does not make #10172 green on its own. It also inherits the two repo-wide failures on `main`, which #10185 fixes.