### PR TITLE
Stop a localized Windows console from losing a child's whole output stream

### DIFF
--- a/studio/backend/lan_access.py
+++ b/studio/backend/lan_access.py
@@ -151,6 +151,7 @@ def _wsl_networking_mode() -> Optional[str]:
                 check = False,
                 text = True,
                 encoding = "utf-8",
+                errors = "replace",
                 timeout = 1,
             )
         except (OSError, subprocess.SubprocessError):

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -2388,6 +2388,8 @@ def run_capture(
         command,
         capture_output = True,
         text = True,
+        encoding = "utf-8",
+        errors = "replace",
         timeout = timeout,
         env = env,
         **windows_hidden_subprocess_kwargs(),
@@ -2561,8 +2563,8 @@ def detect_host(*, probe_rocm_with_nvidia: bool = False) -> HostInfo:
                     int(cuda_match.group(1)),
                     int(cuda_match.group(2)),
                 )
-        except Exception:
-            pass
+        except Exception as exc:
+            log(f"nvidia-smi driver probe failed: {exc}")
 
         try:
             caps = run_capture(
@@ -3384,6 +3386,8 @@ def _detect_host_rocm_version() -> tuple[int, int] | None:
                 stdout = subprocess.PIPE,
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 5,
             )
             if result.returncode == 0:
@@ -3409,6 +3413,8 @@ def _detect_host_rocm_version() -> tuple[int, int] | None:
                 stdout = subprocess.PIPE,
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 5,
             )
         except Exception:
@@ -5725,6 +5731,8 @@ def validate_quantize(
         command,
         capture_output = True,
         text = True,
+        encoding = "utf-8",
+        errors = "replace",
         timeout = 120,
         env = binary_env(quantize_path, install_dir, host, runtime_line = runtime_line),
         **windows_hidden_subprocess_kwargs(),
@@ -5815,6 +5823,8 @@ def validate_server(
                     stdout = log_handle,
                     stderr = subprocess.STDOUT,
                     text = True,
+                    encoding = "utf-8",
+                    errors = "replace",
                     env = binary_env(server_path, install_dir, host, runtime_line = runtime_line),
                     **_validation_server_kwargs(),
                     **windows_hidden_subprocess_kwargs(),

--- a/studio/install_node_prebuilt.py
+++ b/studio/install_node_prebuilt.py
@@ -503,6 +503,8 @@ def _pid_is_alive(pid: int) -> bool:
                 ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
                 capture_output = True,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 5,
                 **_windows_hidden_kwargs(),
             )
@@ -618,6 +620,8 @@ def _run_node(
         [str(node_bin), *args],
         capture_output = True,
         text = True,
+        encoding = "utf-8",
+        errors = "replace",
         timeout = timeout,
         env = env,
         **_windows_hidden_kwargs(),

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -751,6 +751,8 @@ def _detect_rocm_version_uncached() -> tuple[int, int] | None:
                 stdout = subprocess.PIPE,
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 5,
                 env = _amd_smi_env(),
             )
@@ -804,6 +806,8 @@ def _detect_rocm_version_uncached() -> tuple[int, int] | None:
                 stdout = subprocess.PIPE,
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 5,
             )
             # dpkg-query exits nonzero when either package is absent but still prints
@@ -845,6 +849,8 @@ def _detect_rocm_version_uncached() -> tuple[int, int] | None:
                 stdout = subprocess.PIPE,
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 5,
             )
             if result.returncode == 0 and result.stdout.strip():
@@ -1354,6 +1360,8 @@ def _linux_amd_gfx_from_lspci() -> "str | None":
             stdout = subprocess.PIPE,
             stderr = subprocess.DEVNULL,
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 10,
         )
     except Exception:
@@ -1736,6 +1744,8 @@ def _has_rocm_gpu() -> bool:
                 stdout = subprocess.PIPE,
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 10,
                 env = _amd_smi_env() if cmd[0] == "amd-smi" else None,
             )
@@ -1808,6 +1818,8 @@ def _has_usable_nvidia_gpu() -> bool:
                 stdout = subprocess.PIPE,
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 10,
             )
             if result.returncode == 0 and "GPU " in result.stdout:
@@ -1917,6 +1929,8 @@ def _detect_amd_gfx_codes(
                 stdout = subprocess.PIPE,
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 15,
                 env = _env,
             )
@@ -2615,6 +2629,8 @@ def _nvidia_compute_sms(exe: str) -> "list[int] | None":
             stdout = subprocess.PIPE,
             stderr = subprocess.DEVNULL,
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 10,
         )
     except Exception:
@@ -2721,6 +2737,8 @@ def _detect_cuda_torch_index_url() -> str:
                 stdout = subprocess.PIPE,
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 10,
             )
             if result.returncode == 0:
@@ -6878,6 +6896,8 @@ def patch_package_file(package_name: str, relative_path: str, url: str) -> None:
         [sys.executable, "-m", "pip", "show", package_name],
         capture_output = True,
         text = True,
+        encoding = "utf-8",
+        errors = "replace",
         **_windows_hidden_subprocess_kwargs(),
     )
     if result.returncode != 0:
@@ -6950,6 +6970,8 @@ def _report_mlx_stack_health() -> None:
             [sys.executable, "-c", _MLX_HEALTH_PROBE, backend],
             capture_output = True,
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 180,
             **_windows_hidden_subprocess_kwargs(),
         )
@@ -7241,6 +7263,8 @@ def install_python_stack() -> int:
                     stdout = subprocess.PIPE,
                     stderr = subprocess.DEVNULL,
                     text = True,
+                    encoding = "utf-8",
+                    errors = "replace",
                     timeout = 10,
                     env = _amd_smi_env() if _wcmd[0] == "amd-smi" else None,
                 )

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -789,6 +789,8 @@ def _validate_staged_server(staged_root: Path, host: HostInfo) -> None:
             [str(server), "--help"],
             capture_output = True,
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 60,
             env = env,
             **llama.windows_hidden_subprocess_kwargs(),
@@ -812,7 +814,12 @@ def _elf_needed(path: Path) -> set[str] | None:
     for command in commands:
         try:
             result = subprocess.run(
-                [*command, str(path)], capture_output = True, text = True, timeout = 10
+                [*command, str(path)],
+                capture_output = True,
+                text = True,
+                encoding = "utf-8",
+                errors = "replace",
+                timeout = 10,
             )
         except (OSError, subprocess.SubprocessError):
             continue

--- a/studio/prebuilt_core.py
+++ b/studio/prebuilt_core.py
@@ -2197,6 +2197,8 @@ def validate_staged_server(ops: ModuleOps, staged_root: Path, host: Any) -> None
             [str(server), "--help"],
             capture_output = True,
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 60,
             env = env,
             **ops.windows_hidden_subprocess_kwargs(),

--- a/studio/scripts/unsloth_freeze_report.py
+++ b/studio/scripts/unsloth_freeze_report.py
@@ -213,7 +213,14 @@ def is_executable(path) -> bool:
 
 def sh(args, timeout = 20):
     try:
-        r = subprocess.run(args, capture_output = True, text = True, timeout = timeout)
+        r = subprocess.run(
+            args,
+            capture_output = True,
+            text = True,
+            encoding = "utf-8",
+            errors = "replace",
+            timeout = timeout,
+        )
         return (r.stdout or r.stderr).strip()
     except (OSError, subprocess.SubprocessError):
         return ""

--- a/tests/studio/install/test_cuda_repair.py
+++ b/tests/studio/install/test_cuda_repair.py
@@ -2194,3 +2194,36 @@ class TestARepairedTorchThatCannotImport:
         monkeypatch.setattr(stack_mod, "pip_install", _pip)
         assert stack_mod._ensure_expected_torch_flavor() is False
         assert any("cannot be imported" in ln for ln in lines), lines
+
+
+# What a localized nvidia-smi writes, which -X utf8 decodes as UTF-8 (#10173).
+_LOCALIZED_NVIDIA_SMI = (
+    "import sys\n"
+    "if sys.argv[1:] == ['--query-gpu=compute_cap', '--format=csv,noheader,nounits']:\n"
+    "    sys.stdout.buffer.write(b'8.6\\n')\n"
+    "else:\n"
+    "    sys.stdout.buffer.write(b'| NVIDIA-SMI 591.86    CUDA Version: 13.1 |\\n')\n"
+    "    sys.stdout.buffer.write('\\u4e02\\u4fdd\\u7559\\u6240\\u6709\\u6743\\u5229\\u3002\\n'.encode('gbk'))\n"
+)
+
+
+def test_detect_index_url_reads_a_localized_nvidia_smi_banner(monkeypatch, tmp_path):
+    fake = tmp_path / "nvidia-smi.py"
+    fake.write_text(_LOCALIZED_NVIDIA_SMI, encoding = "utf-8")
+    real_run = subprocess.run
+
+    def run_fake_nvidia_smi(command, *args, **kwargs):
+        if command and command[0] == "nvidia-smi":
+            command = [sys.executable, str(fake), *command[1:]]
+        kwargs.setdefault("encoding", "utf-8")  # what the launcher's -X utf8 does
+        return real_run(command, *args, **kwargs)
+
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_URL", raising = False)
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY", raising = False)
+    monkeypatch.setattr(stack_mod.subprocess, "run", run_fake_nvidia_smi)
+    monkeypatch.setattr(
+        stack_mod.shutil,
+        "which",
+        lambda name, *a, **k: "nvidia-smi" if name == "nvidia-smi" else None,
+    )
+    assert _detect_cuda_torch_index_url() == f"{stack_mod._PYTORCH_WHL_BASE}/cu130"

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -6700,3 +6700,51 @@ def test_a_non_cuda_bundle_declares_no_supported_sms(tmp_path: Path, install_kin
     )
     marker = json.loads((install_dir / "UNSLOTH_PREBUILT_INFO.json").read_text())
     assert marker["supported_sms"] == []
+
+
+# What a localized nvidia-smi writes, which -X utf8 decodes as UTF-8 (#10173). The
+# banner leads with GBK 0x81 0x40 so a cp1252 host cannot decode it either.
+_LOCALIZED_NVIDIA_SMI = (
+    "import sys\n"
+    "a = sys.argv[1:]\n"
+    "if a == ['-L']:\n"
+    "    sys.stdout.buffer.write(b'GPU 0: NVIDIA GeForce RTX 3090 (UUID: GPU-a)\\n')\n"
+    "elif a and a[0].startswith('--query-gpu'):\n"
+    "    sys.stdout.buffer.write(b'0, GPU-a, 8.6\\n')\n"
+    "else:\n"
+    "    sys.stdout.buffer.write(b'| NVIDIA-SMI 591.86    CUDA Version: 13.1 |\\n')\n"
+    "    sys.stdout.buffer.write('\\u4e02\\u4fdd\\u7559\\u6240\\u6709\\u6743\\u5229\\u3002\\n'.encode('gbk'))\n"
+)
+
+
+def test_run_capture_keeps_ascii_lines_when_a_child_writes_another_code_page():
+    result = INSTALL_LLAMA_PREBUILT.run_capture(
+        [sys.executable, "-c", _LOCALIZED_NVIDIA_SMI], timeout = 30
+    )
+    assert "CUDA Version: 13.1" in result.stdout
+    assert "\ufffd" in result.stdout
+
+
+def test_detect_host_reads_the_driver_cuda_version_from_a_localized_nvidia_smi(
+    monkeypatch, tmp_path
+):
+    fake = tmp_path / "nvidia-smi.py"
+    fake.write_text(_LOCALIZED_NVIDIA_SMI, encoding = "utf-8")
+    real_run = subprocess.run
+
+    def run_fake_nvidia_smi(command, *args, **kwargs):
+        if command and command[0] == "nvidia-smi":
+            command = [sys.executable, str(fake), *command[1:]]
+        kwargs.setdefault("encoding", "utf-8")  # what the launcher's -X utf8 does
+        return real_run(command, *args, **kwargs)
+
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising = False)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.subprocess, "run", run_fake_nvidia_smi)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.shutil,
+        "which",
+        lambda name, *a, **k: "nvidia-smi" if name == "nvidia-smi" else None,
+    )
+    host = INSTALL_LLAMA_PREBUILT.detect_host()
+    assert host.compute_caps == ["86"]
+    assert host.driver_cuda_version == (13, 1)

--- a/tests/studio/test_cli_studio_stop_windows.py
+++ b/tests/studio/test_cli_studio_stop_windows.py
@@ -5,7 +5,9 @@
 
 `stop` once used `os.kill(pid, 0)`, which raises WinError 87 on Windows before
 reaching taskkill; the fix adds cross-platform `_pid_alive` (tasklist on Windows,
-signal-0 elsewhere). AST + mock-only; no real processes, no Unsloth deps imported.
+signal-0 elsewhere). AST + mock-only, except the two code-page tests, which run a real
+Python child in place of the Windows command they read. The second of those covers
+`unsloth start`: #10173 is one defect across both helpers.
 """
 
 import ast
@@ -16,6 +18,9 @@ import types
 from pathlib import Path
 
 import pytest
+import typer
+
+import unsloth_cli.commands.start as start_cli
 
 _STUDIO_CMD_PY = Path(__file__).resolve().parents[2] / "unsloth_cli" / "commands" / "studio.py"
 _SOURCE = _STUDIO_CMD_PY.read_text(encoding = "utf-8")
@@ -31,8 +36,8 @@ def _func_source(name: str) -> str:
 
 
 def _load_pid_alive(platform: str, fake_run = None):
-    """Exec just `_pid_alive` with injectable sys/subprocess to drive the win32
-    branch on any host without importing unsloth_cli."""
+    """Exec just `_pid_alive` with injectable sys/subprocess, so the win32 branch runs
+    on any host."""
     src = _func_source("_pid_alive")
     fake_sys = types.SimpleNamespace(platform = platform)
     fake_sub = types.SimpleNamespace(run = fake_run) if fake_run is not None else subprocess
@@ -91,6 +96,7 @@ def _fake_tasklist(returns_pid: int | None, *, raises: bool = False):
         capture_output = False,
         text = False,
         timeout = None,
+        **decode_kwargs,
     ):
         assert cmd[0] == "tasklist"
         assert "/FI" in cmd  # filtered by PID
@@ -129,3 +135,44 @@ def test_pid_alive_posix_true_for_self_false_for_dead():
     pid_alive = _load_pid_alive("linux")
     assert pid_alive(os.getpid()) is True
     assert pid_alive(2_000_000_000) is False
+
+
+# What a localized tasklist writes, which -X utf8 decodes as UTF-8 (#10173).
+_LOCALIZED_TASKLIST = (
+    "import sys\n"
+    "sys.stdout.buffer.write('\\u4fe1\\u606f: \\u6ca1\\u6709\\u8fd0\\u884c\\u7684\\u4efb\\u52a1\\u5339\\u914d\\u6307\\u5b9a\\u6807\\u51c6\\u3002\\n'.encode('gbk'))\n"
+)
+
+
+def test_pid_alive_reads_a_localized_tasklist_notice(tmp_path):
+    fake = tmp_path / "tasklist.py"
+    fake.write_text(_LOCALIZED_TASKLIST, encoding = "utf-8")
+
+    def run_fake_tasklist(command, *args, **kwargs):
+        assert command[0] == "tasklist"
+        kwargs.setdefault("encoding", "utf-8")  # what the launcher's -X utf8 does
+        return subprocess.run([sys.executable, str(fake), *command[1:]], *args, **kwargs)
+
+    pid_alive = _load_pid_alive("win32", fake_run = run_fake_tasklist)
+    assert pid_alive(43210) is False
+
+
+def test_a_profile_that_does_not_decode_fails_loudly(monkeypatch, tmp_path, capsys):
+    fake = tmp_path / "cmd.py"
+    fake.write_text(
+        "import sys\nsys.stdout.buffer.write('C:\\\\Users\\\\\\u4e02\\u5f20\\u4e09\\n'.encode('gbk'))\n",
+        encoding = "utf-8",
+    )
+    real_check_output = subprocess.check_output
+
+    def run_fake_cmd(command, *args, **kwargs):
+        if command[0] != "cmd.exe":
+            return real_check_output(command, *args, **kwargs)
+        kwargs.setdefault("encoding", "utf-8")  # what the launcher's -X utf8 does
+        return real_check_output([sys.executable, str(fake)], *args, **kwargs)
+
+    monkeypatch.delenv("USERPROFILE", raising = False)
+    monkeypatch.setattr(start_cli.subprocess, "check_output", run_fake_cmd)
+    with pytest.raises(typer.Exit):
+        start_cli._wsl_windows_user_profile(sys.executable)
+    assert "set USERPROFILE" in capsys.readouterr().err

--- a/unsloth_cli/_studio_deps.py
+++ b/unsloth_cli/_studio_deps.py
@@ -169,6 +169,8 @@ def _venv_site_packages(root: Path) -> List[Path]:
                 [str(executable), "-I", "-c", probe],
                 stderr = subprocess.DEVNULL,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 5,
             )
             values = json.loads(output)
@@ -275,6 +277,8 @@ def _requirements_root_in(root: Path) -> Optional[Path]:
                         [str(executable), "-I", "-c", probe],
                         stderr = subprocess.DEVNULL,
                         text = True,
+                        encoding = "utf-8",
+                        errors = "replace",
                         timeout = 5,
                     )
                 )

--- a/unsloth_cli/_studio_stage.py
+++ b/unsloth_cli/_studio_stage.py
@@ -72,7 +72,13 @@ def _copy_command(source: Path, destination: Path) -> Optional[list[str]]:
 def clone_tree(source: Path, destination: Path) -> None:
     command = _copy_command(source, destination)
     if command is not None:
-        result = subprocess.run(command, capture_output = True, text = True)
+        result = subprocess.run(
+            command,
+            capture_output = True,
+            text = True,
+            encoding = "utf-8",
+            errors = "replace",
+        )
         if result.returncode == 0:
             return
         shutil.rmtree(destination, ignore_errors = True)
@@ -136,6 +142,8 @@ def _run(command: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.Co
         env = env,
         capture_output = True,
         text = True,
+        encoding = "utf-8",
+        errors = "replace",
         timeout = PROBE_TIMEOUT_SECONDS,
     )
 

--- a/unsloth_cli/claude_subagent_mcp.py
+++ b/unsloth_cli/claude_subagent_mcp.py
@@ -203,6 +203,8 @@ def run_local_agent(
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
     }
     if os.name == "nt":
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP

--- a/unsloth_cli/codex_subagent_mcp.py
+++ b/unsloth_cli/codex_subagent_mcp.py
@@ -131,6 +131,8 @@ def run_local_agent(task: str, cancel_event: threading.Event | None = None) -> s
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
     }
     if os.name == "nt":
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -444,6 +444,8 @@ def _opencode_supports_native_auto(command: str = "opencode") -> bool:
         output = subprocess.check_output(
             [executable, "--version"],
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 10,
             stderr = subprocess.DEVNULL,
             env = _probe_env(),
@@ -2875,7 +2877,13 @@ def _claude_version() -> Optional[tuple]:
         return None
     try:
         result = subprocess.run(
-            [executable, "--version"], capture_output = True, text = True, timeout = 10, env = _probe_env()
+            [executable, "--version"],
+            capture_output = True,
+            text = True,
+            encoding = "utf-8",
+            errors = "replace",
+            timeout = 10,
+            env = _probe_env(),
         )
         # Pull the X.Y.Z out of the output rather than assuming it is the first token.
         # claude prints it first today ("2.1.98 (Claude Code)"), but a format change
@@ -2990,6 +2998,8 @@ def _codex_executable_version(executable: str) -> Optional[tuple[int, int, int]]
         output = subprocess.check_output(
             [executable, "--version"],
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 10,
             stderr = subprocess.DEVNULL,
             env = _probe_env(),
@@ -3116,9 +3126,17 @@ def _wsl_windows_user_profile(executable: str) -> Path:
             profile = subprocess.check_output(
                 ["cmd.exe", "/d", "/c", "echo %USERPROFILE%"],
                 text = True,
+                encoding = "utf-8",
+                # The path is the value: a corrupted home is worse than a loud failure.
+                errors = "strict",
                 stderr = subprocess.DEVNULL,
                 cwd = str(Path(executable).parent),
             ).strip()
+        except UnicodeDecodeError as exc:
+            _fail(
+                f"Could not read the Windows user profile for Codex ({exc}); "
+                "set USERPROFILE in the WSL environment, for example through WSLENV."
+            )
         except (OSError, subprocess.CalledProcessError) as exc:
             _fail(f"Could not find the Windows user profile for Codex: {exc}")
     if not profile or profile == "%USERPROFILE%":
@@ -3129,6 +3147,8 @@ def _wsl_windows_user_profile(executable: str) -> Path:
         translated = subprocess.check_output(
             ["wslpath", "-u", profile],
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             stderr = subprocess.DEVNULL,
         ).strip()
     except (OSError, subprocess.CalledProcessError) as exc:
@@ -3147,6 +3167,8 @@ def _codex_source_home(*, ignore_configured: bool = False) -> Path:
                     configured = subprocess.check_output(
                         ["wslpath", "-u", configured],
                         text = True,
+                        encoding = "utf-8",
+                        errors = "replace",
                         stderr = subprocess.DEVNULL,
                     ).strip()
                 except (OSError, subprocess.CalledProcessError) as exc:
@@ -3180,6 +3202,8 @@ def _create_directory_junction(source: Path, target: Path) -> bool:
             ["cmd.exe", "/d", "/c", "mklink", "/J", str(target), str(source)],
             capture_output = True,
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
             timeout = 30,
             check = False,
         )
@@ -3357,6 +3381,8 @@ def _opencode_subagent_inline_config(
                 [executable, "debug", "config"],
                 capture_output = True,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 15,
                 env = env,
             )
@@ -3569,7 +3595,9 @@ def _wsl_windows_executable(command: list) -> Optional[str]:
 
 def _wsl_windows_path(path: Path) -> str:
     try:
-        translated = subprocess.check_output(["wslpath", "-w", str(path)], text = True).strip()
+        translated = subprocess.check_output(
+            ["wslpath", "-w", str(path)], text = True, encoding = "utf-8", errors = "replace"
+        ).strip()
     except (OSError, subprocess.CalledProcessError) as exc:
         _fail(f"Could not translate WSL path {path}: {exc}")
     if not translated:

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3045,6 +3045,8 @@ def _pid_alive(pid: int) -> bool:
                 ["tasklist", "/FI", f"PID eq {int(pid)}", "/NH", "/FO", "CSV"],
                 capture_output = True,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 10,
             ).stdout
         except Exception:


### PR DESCRIPTION
Fixes #10173.

## What happens today

On a non-English Windows the llama.cpp prebuilt update fails with `installer exited 2` before it downloads anything. The installer reports no CUDA driver on a machine that has one, and there is nothing in the log that points at the cause.

## Root cause

Studio starts its children under UTF-8 mode, through `PYTHONUTF8=1` in `setup.ps1` and `-X utf8` on the CLI's respawn. In that mode `text = True` decodes a child's pipes as UTF-8 no matter what the system ANSI code page is. A localized `nvidia-smi` writes that code page, so its banner is not valid UTF-8.

What makes this silent is the Windows path in CPython's `subprocess`. Output is read on a helper thread, and a `UnicodeDecodeError` raised there is swallowed, leaving `stdout` as `None` instead of propagating. POSIX raises, so this reproduces only on Windows.

The driver probe then reads `None`, `driver_cuda_version` becomes `None`, and the installer refuses the wheel it was about to fetch and exits 2.

The same shape reaches further than the installer. `_pid_alive` is the sharpest case: a localized `tasklist` prints its no-match notice in the code page, `stdout` comes back `None`, and `"PID" in None` raises `TypeError` past an `except` that only expects `OSError`, `ValueError` and `SubprocessError`, so `unsloth studio stop` fails rather than reporting the process gone.

## What changed

Every text-mode subprocess capture under `studio/` and `unsloth_cli/` now passes `encoding = "utf-8", errors = "replace"`. Those two trees are exactly what runs under UTF-8 mode. This is the idiom the backend already uses at more than fifty call sites; the installers and the CLI had been missed. Undecodable bytes become U+FFFD and the surrounding ASCII survives, which is all these callers parse: a CUDA version, a PID, a package name.

One call decodes strictly on purpose. `_wsl_windows_user_profile` reads a path out of `cmd.exe /c echo %USERPROFILE%`, and there the decoded text *is* the value rather than a field inside it. Replacement would turn a localized profile into a corrupted path, `wslpath` would translate it into a directory that does not exist, and Codex's state would silently go missing. That call keeps `errors = "strict"` and a `UnicodeDecodeError` now fails with a message naming the `USERPROFILE` override the function already honours.

## Risks and tradeoffs

`errors = "replace"` cannot fail, so a caller that needs the exact bytes would be given mojibake instead of an error. Every site changed here parses ASCII out of the stream, and the one site whose value is the whole string was deliberately left strict, which is the distinction to check when reviewing.

Making a localized profile *work*, rather than fail clearly, would mean forcing the console to UTF-8 with `chcp 65001` or setting PowerShell's `OutputEncoding`. That is a larger change and is left out of this one.

## Validation

Reproduced first, with a real child writing GBK bytes in place of `nvidia-smi`, including the Windows `_communicate` path grafted in so the `stdout = None` behaviour appears on a POSIX host. Regression tests drive the real `subprocess` against fake children that write GBK, rather than asserting on keyword arguments, and each one fails when its production change is reverted:

```
tests/studio/install/test_install_llama_prebuilt_logic.py   run_capture keeps the ASCII CUDA line; detect_host reads the driver version
tests/studio/install/test_cuda_repair.py                    the python-stack CUDA-tag probe reads cu130 from a localized banner
tests/studio/test_cli_studio_stop_windows.py                _pid_alive reads a localized tasklist notice; a profile that does not decode fails loudly
```

The tests set the child's decoding explicitly rather than inheriting the host's, so they behave the same on a runner in any locale.

```
495 passed, 1 skipped
```
