### PR TITLE
Repin linuxdeploy-plugin-appimage after the 2026-09-01 upstream rebuild

### DIFF
--- a/studio/src-tauri/linux/prepare-complete-appimage-tools.sh
+++ b/studio/src-tauri/linux/prepare-complete-appimage-tools.sh
@@ -31,7 +31,7 @@ GTK_PLUGIN_SHA256="cb379f9b0733e9ad9f8bd78f8c2fa038aef2478523bb7d4c8e64ff6a1ea35
 GSTREAMER_PLUGIN_URL="https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gstreamer/2a2e67491c32995a3f279ad0ecbe77abd512b42a/linuxdeploy-plugin-gstreamer.sh"
 GSTREAMER_PLUGIN_SHA256="c107b49d84edbffc6ab226ed1007e0626a4f7aa2c3a36b7782bef62351d49e94"
 APPIMAGE_PLUGIN_URL="https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
-APPIMAGE_PLUGIN_SHA256="a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79"
+APPIMAGE_PLUGIN_SHA256="0441769ab38009504d2678c38cd7e526955388dd30a215b4a20afaa5471652f2"
 
 fetch() {
   local url="$1" digest="$2" name="$3"


### PR DESCRIPTION
## Summary

The `v0.1.805-beta` desktop release run ([33630003433](https://github.com/unslothai/unsloth/actions/runs/33630003433)) failed in `Build Linux (x64)` at `Pin complete AppImage toolchain`:

```
/home/runner/work/_temp/tauri-tools-cache/tauri/linuxdeploy-plugin-appimage.AppImage: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
```

`APPIMAGE_PLUGIN_URL` points at the `continuous` tag of `linuxdeploy/linuxdeploy-plugin-appimage`, which is a rolling tag. Upstream re-published the asset at the same URL, so the pinned digest no longer matched.

| | |
|---|---|
| pinned | `a45d3e227bc7f397e9cf6bfa4c9507494efa2293357b6e86690a3de2ca992e79` |
| current | `0441769ab38009504d2678c38cd7e526955388dd30a215b4a20afaa5471652f2` |

This bumps the pin to the current digest.

## Why the new binary is a benign rebuild, not a substitution

- The asset `updated_at` is `2026-09-01T03:53:12Z`. Upstream CI run [33467741325](https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/actions/runs/33467741325) (`event=schedule`, branch `master`) completed `2026-09-01T03:53:19Z` - the same run, seconds apart.
- That run built from head SHA `536b0687`, the same commit as the Jun 7, Jul 1 and Aug 1 builds. The newest commit in the repo is from 2026-05-03, so no source changed; the bytes differ because the build is not reproducible.
- The repo runs this schedule monthly (Mar 1, Apr 1, May 1, Jun 1, Jul 1, Aug 1, Sep 1), all on GitHub-hosted runners, all successful.
- The downloaded artifact is a 16484856-byte stripped static-pie x86-64 ELF with the expected AppImage runtime strings, matching the size the releases API reports.

Caveat: the upstream repo publishes no build attestations (`/attestations/sha256:0441769a...` returns 404), so this rests on run metadata and timing rather than cryptographic provenance. The previous binary was overwritten at the same URL and cannot be diffed.

## Follow-up worth doing separately

A correct pin here has roughly a 30-day shelf life: the monthly rebuild will invalidate it again around 2026-10-01. The other three downloads in this script do not have the problem - the GTK and GStreamer plugins are pinned to immutable commit SHAs, and `linuxdeploy-x86_64.AppImage` comes from `tauri-apps/binary-releases` under a non-rotating tag. Mirroring this plugin the same way would end the recurrence. Not done here to keep the release unblocked.

## Test plan

- [ ] `Build Linux (x64)` reaches past `Pin complete AppImage toolchain` on the next desktop release run