### PR TITLE
Versioning: 2026.9.2

### DIFF
--- a/unsloth/_version.py
+++ b/unsloth/_version.py
@@ -19,4 +19,4 @@
 # and the torch-free MLX path in __init__.py imports it directly, which it cannot do for
 # models/_utils.py (torch, transformers, trl, peft, Triton). That is why the MLX branch
 # used to borrow unsloth_zoo's version, reporting a different package's number.
-__version__ = "2026.9.1"
+__version__ = "2026.9.2"


### PR DESCRIPTION
Bumps `unsloth/_version.py` to `2026.9.2` for the `v0.1.806-beta` desktop release.

`2026.9.1` is already on PyPI stamped `v0.1.806-beta`'s predecessor `v0.1.805-beta`, and PyPI files are immutable, so the desktop release stamp gate (`stamp_studio_release.py --verify-dist --expected`) cannot be satisfied by reusing it. A new backend version stamped `v0.1.806-beta` is required for the paired release.