### PR TITLE
Publish only the wheel to PyPI, not the sdist

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -114,6 +114,16 @@ _restore_studio_build_info
 trap - EXIT
 
 # 5. Optionally publish
+#
+# Wheel only. The sdist is still built above, because --verify-dist checks the
+# release stamp in every artifact and a local sdist is the cheapest way to catch
+# a packaging change that only shows up in the source tree. It is not uploaded.
+#
+# A release is ~169MB across both artifacts, and the PyPI project size limit is
+# 10GB; the sdist is the larger half. Uploading only the wheel halves what each
+# release costs against that limit. Nothing is lost for installers: the wheel is
+# py3-none-any, so pip and uv resolve to it on every platform and Python, and the
+# sdist is only reachable through --no-binary or a mirror that vendors sources.
 if [ "${1:-}" = "publish" ]; then
-    python -m twine upload dist/*
+    python -m twine upload dist/*.whl
 fi


### PR DESCRIPTION
## Summary

`./build.sh publish` uploaded `dist/*`, which is both the wheel and the sdist. It now uploads `dist/*.whl` only.

The `unsloth` project hit its PyPI 10 GB size limit during the `2026.9.2` release; the upload failed with:

```
400 Project size too large. Limit for project 'unsloth' total size is 10 GB.
```

Recent releases are about 169 MB across both artifacts, and the sdist is the larger half (86.6 MB vs 82.3 MB for `2026.9.2`). Uploading only the wheel roughly halves what each release costs against the limit.

## Why this is safe for installers

- Every `unsloth` wheel is `py3-none-any`, so pip and uv resolve to the wheel on every platform and Python version. A normal `pip install unsloth` never fetches the sdist.
- All 239 published releases have a wheel; none is sdist-only.
- What is lost: `pip install --no-binary :all: unsloth`, source builds, and mirrors that vendor sdists, for releases published from here on.

The sdist is still built locally. `stamp_studio_release.py --verify-dist` checks the release stamp in every artifact, and keeping the sdist in `dist/` means a packaging change that only shows up in the source tree still gets caught before upload.

## Follow-ups worth doing separately

- Request a PyPI project size limit increase. Even after reclaiming space this recurs at roughly 170 MB per release.
- Look at why a release is this large at all. The wheel currently ships `studio/frontend/src/**` `.tsx` sources alongside the compiled `studio/frontend/dist/`, which looks like avoidable weight.

## Test plan

- [ ] `./build.sh publish` on the next release uploads one `.whl` and no `.tar.gz`
- [ ] `pip install unsloth==<next version>` resolves the wheel on Linux, macOS and Windows