### PR TITLE
Bump install.sh / install.ps1 pin to unsloth>=2026.9.2

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -5663,7 +5663,7 @@ exit 0
 
     $_desktopMinVer = if ($env:UNSLOTH_DESKTOP_BACKEND_VERSION) { $env:UNSLOTH_DESKTOP_BACKEND_VERSION.Trim() } else { "" }
     $_unslothDesktopInstallSpec = if ($_desktopMinVer) { "unsloth>=$_desktopMinVer" } else { $null }
-    $_unslothReleaseInstallSpec = if ($_unslothDesktopInstallSpec) { $_unslothDesktopInstallSpec } else { "unsloth>=2026.9.1" }
+    $_unslothReleaseInstallSpec = if ($_unslothDesktopInstallSpec) { $_unslothDesktopInstallSpec } else { "unsloth>=2026.9.2" }
 
     if ($_Migrated) {
         # Migrated env: force-reinstall unsloth+unsloth-zoo for a clean state, preserving

--- a/install.sh
+++ b/install.sh
@@ -5489,7 +5489,7 @@ _unsloth_desktop_install_spec=""
 if [ -n "${UNSLOTH_DESKTOP_BACKEND_VERSION:-}" ]; then
     _unsloth_desktop_install_spec="unsloth>=${UNSLOTH_DESKTOP_BACKEND_VERSION}"
 fi
-_unsloth_release_install_spec="${_unsloth_desktop_install_spec:-unsloth>=2026.9.1}"
+_unsloth_release_install_spec="${_unsloth_desktop_install_spec:-unsloth>=2026.9.2}"
 
 if [ "$_MIGRATED" = true ]; then
     # Migrated env: force-reinstall unsloth+unsloth-zoo for a clean state, preserving


### PR DESCRIPTION
## Summary

- PyPI release [unsloth 2026.9.2](https://pypi.org/project/unsloth/2026.9.2/) is now live.
- Bumps the pinned `unsloth` floor in `install.sh` and `install.ps1` from `unsloth>=2026.9.1` to `unsloth>=2026.9.2`.
- Tagged on main as `v0.1.806-beta`.

`unsloth-zoo` is left at `unsloth-zoo>=2026.9.1`, which is still the current PyPI release of that package. Only the `unsloth` floor moved, so this is a 1-line change in each file rather than the usual 6.

## Why this matters even though the floor already resolves

`>=2026.9.1` already resolves to `2026.9.2` for an unconstrained fresh install, so nothing is broken today. But a floor is a minimum: a constrained environment or a stale index can legitimately land on `2026.9.1`, and `2026.9.1` carries the Studio stamp `v0.1.805-beta`, not the `v0.1.806-beta` desktop build being released. Raising the floor makes the backend/desktop pairing enforced rather than incidental.

Follows the same pattern as #5716 and #10195.

## Test plan

- [ ] Sanity-run `install.sh` on a clean Linux host
- [ ] Sanity-run `install.ps1` on a clean Windows host
- [ ] Confirm `uv pip install "unsloth>=2026.9.2"` resolves cleanly