### PR TITLE
Add Open WebUI unload compatibility

### DIFF
--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -5,8 +5,9 @@
 
 Probes for engine endpoints used to land on main.py's SPA catch-all, so ``GET /props``
 returned 200 and a page of HTML. That is worse than a 404: a probe reads the status
-before the body. Served here: ``/props``, ``/v1/props``, ``/version``. Everything else
-in llama-server's table gets an explicit 404, on its real method as well as GET.
+before the body. Served here: ``/props``, ``/v1/props``, ``/version`` and
+``/models/unload``. Everything else in llama-server's table gets an explicit 404,
+on its real method as well as GET.
 
 Deliberately NOT served: Ollama's ``/api/tags`` and ``/api/show``. Answering them makes
 a client select Ollama and then fail on ``/api/chat``, which Studio does not implement;
@@ -21,6 +22,7 @@ import functools
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
 
 from auth.authentication import get_current_subject
 from loggers import get_logger
@@ -51,7 +53,6 @@ _ENGINE_PROBE_PATHS = frozenset(
         "models",
         "models/load",
         "models/sse",
-        "models/unload",
         "rerank",
         "reranking",
         "responses",
@@ -187,6 +188,23 @@ async def studio_version(current_subject: str = Depends(get_current_subject)):
     of claiming to be Ollama."""
     # Threaded like /props: the first call resolves the version.
     return {"version": await asyncio.to_thread(_studio_version)}
+
+
+class _LlamaUnloadRequest(BaseModel):
+    model: str = Field(..., min_length = 1)
+
+
+@router.post("/models/unload", include_in_schema = False)
+@router.post("/models/unload/", include_in_schema = False)
+async def llama_unload(
+    request: _LlamaUnloadRequest, current_subject: str = Depends(get_current_subject)
+):
+    """llama-server-compatible unload used by Open WebUI's llama.cpp provider."""
+    from models.inference import UnloadRequest
+    return await _inference().unload_model(
+        UnloadRequest(model_path = request.model),
+        current_subject,
+    )
 
 
 async def _probe_not_found():

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2674,7 +2674,9 @@ class TestAnthropicMessagesToolRouting:
         )
         monitor = ApiMonitor(max_entries = 3)
         monkeypatch.setattr(inf_mod, "api_monitor", monitor)
-        fields = {"tools": [{"name": "x", "input_schema": {"type": "object"}}]} if with_tools else {}
+        fields = (
+            {"tools": [{"name": "x", "input_schema": {"type": "object"}}]} if with_tools else {}
+        )
 
         response = _drive(
             anthropic_messages(

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -271,6 +271,38 @@ def test_version_answers_on_the_bare_path_only():
     assert prefixed.status_code == 404
 
 
+@pytest.mark.parametrize("path", ["/models/unload", "/models/unload/"])
+def test_open_webui_unload_translates_the_llama_cpp_payload(path):
+    """Open WebUI sends llama.cpp's ``model`` field to the bare engine route."""
+    mod = _load()
+    calls = []
+
+    async def _unload(request, current_subject):
+        calls.append((request.model_path, current_subject))
+        return {"status": "unloaded", "model": request.model_path}
+
+    mod._inference().unload_model = _unload
+    with _client(mod) as c:
+        response = c.post(path, json = {"model": "unsloth/Qwen3.8-27B-GGUF"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "unloaded", "model": "unsloth/Qwen3.8-27B-GGUF"}
+    assert calls == [("unsloth/Qwen3.8-27B-GGUF", "test")]
+
+
+def test_open_webui_unload_keeps_the_canonical_auth_boundary():
+    mod = _load()
+    routes = {route.path: route for route in mod.router.routes}
+    for path in ("/models/unload", "/models/unload/"):
+        dependencies = [dependency.call for dependency in routes[path].dependant.dependencies]
+        assert mod.get_current_subject in dependencies
+
+    # Match /v1/unload: model teardown is never admitted by keyless inference scope.
+    from utils.keyless_api_access import _INFERENCE_ROUTES
+
+    assert ("POST", "/models/unload") not in _INFERENCE_ROUTES
+
+
 # ── platform and robustness, from the sandbox run ─────────────────────────────
 
 
@@ -524,7 +556,7 @@ def test_the_deny_list_matches_llama_servers_own_route_table():
         "tokenize",
         "tools",
     }
-    served = {"props"}
+    served = {"props", "models/unload"}
     for route in bare_llama_routes - served:
         assert mod.is_engine_probe_path(route), route
     assert not mod.is_engine_probe_path("props"), "Studio serves /props"


### PR DESCRIPTION
## Summary

Open WebUI’s llama.cpp provider sends unload requests to `POST /models/unload`, which Studio currently denies as an unsupported engine endpoint. This change serves `/models/unload` and `/models/unload/`, translating `{"model": "<id>"}` into `UnloadRequest(model_path = ...)` and delegating to the existing unload handler.

Both routes require `get_current_subject` authentication and remain outside the keyless inference grant.

## Test coverage

Added route tests cover payload translation and response forwarding for both URL forms, the authentication dependency, and exclusion from keyless inference access. The engine probe deny-list test is updated to recognize the served unload route.

## Relationship to #10693

#10693 also implements these unload routes, alongside model listing, explicit loading, and catalog residency reporting for #10610. Its unload handler adds model-ID resolution and a different response shape, so the implementations need consolidation.

The proposed approach is to retain #10693 as the combined implementation, preserve this PR’s unload regression coverage, and mark this PR superseded once #10693 lands. Open WebUI behavior with unsupported download/delete/SSE endpoints remains a separate validation question on #10693.

