### PR TITLE
Studio: share one Hub model_info read across the model-config probes

### DIFF
--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -2402,12 +2402,19 @@ async def get_model_config(
     )
     from core.inference.llama_cpp import _hf_offline_if_unreachable_for
     from utils.models.model_config import shared_hub_model_info
+    from utils.utils import pinned_hf_reachability
 
     def _resolve(model_name: str) -> ModelDetails:
         # Each probe below can reach the hub, so the guard wraps the whole handler: offline they
         # must all resolve from the HF cache. Local paths stay on disk and skip the probe.
         # The probes read one repo document between them, and each fetch of it costs a handshake.
-        with _hf_offline_if_unreachable_for(model_name), shared_hub_model_info():
+        # The reachability memo expires on wall-clock, and this handler outlives it on a slow
+        # link, so the guards it opens later would re-probe rather than reuse the verdict.
+        with (
+            pinned_hf_reachability(),
+            _hf_offline_if_unreachable_for(model_name),
+            shared_hub_model_info(),
+        ):
             # Inside the context, not before: the guard forces offline itself when the hub
             # is unreachable, and every probe below then resolves from disk.
             if anonymous_and_offline(hf_token) and not is_local_path(model_name):

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -2401,11 +2401,13 @@ async def get_model_config(
         allow_ambient_token = allow_ambient_token,
     )
     from core.inference.llama_cpp import _hf_offline_if_unreachable_for
+    from utils.models.model_config import shared_hub_model_info
 
     def _resolve(model_name: str) -> ModelDetails:
         # Each probe below can reach the hub, so the guard wraps the whole handler: offline they
         # must all resolve from the HF cache. Local paths stay on disk and skip the probe.
-        with _hf_offline_if_unreachable_for(model_name):
+        # The probes read one repo document between them, and each fetch of it costs a handshake.
+        with _hf_offline_if_unreachable_for(model_name), shared_hub_model_info():
             # Inside the context, not before: the guard forces offline itself when the hub
             # is unreachable, and every probe below then resolves from disk.
             if anonymous_and_offline(hf_token) and not is_local_path(model_name):

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -2407,9 +2407,7 @@ async def get_model_config(
     def _resolve(model_name: str) -> ModelDetails:
         # Each probe below can reach the hub, so the guard wraps the whole handler: offline they
         # must all resolve from the HF cache. Local paths stay on disk and skip the probe.
-        # The probes read one repo document between them, and each fetch of it costs a handshake.
-        # The reachability memo expires on wall-clock, and this handler outlives it on a slow
-        # link, so the guards it opens later would re-probe rather than reuse the verdict.
+        # One repo document between the probes, one verdict for a request that outlives the memo.
         with (
             pinned_hf_reachability(),
             _hf_offline_if_unreachable_for(model_name),

--- a/studio/backend/tests/test_audio_token_detection.py
+++ b/studio/backend/tests/test_audio_token_detection.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import pytest
 
 from utils.audio_tokens import AUDIO_TOKEN_PATTERNS
 from utils.models.model_config import (
@@ -333,3 +334,218 @@ def test_a_half_written_tokenizer_stays_unknown(tmp_path):
         None,
         True,
     )
+
+
+def _cached_snapshot(
+    tmp_path,
+    repo_id,
+    files,
+    sha = "abc123",
+):
+    """A repo laid out the way the HF hub cache lays one out."""
+    repo_dir = tmp_path / ("models--" + repo_id.replace("/", "--"))
+    snapshot = repo_dir / "snapshots" / sha
+    snapshot.mkdir(parents = True)
+    for name, text in files.items():
+        target = snapshot / name
+        target.parent.mkdir(parents = True, exist_ok = True)
+        target.write_text(text, encoding = "utf-8")
+    return repo_dir, snapshot
+
+
+def _detect_against_cache(
+    monkeypatch,
+    snapshot_repo_dir,
+    *,
+    sha = "abc123",
+    listed = ("tokenizer_config.json",),
+    responses = None,
+    **kwargs,
+):
+    """Drive the probe against a cached snapshot, recording the Hub reads it still makes.
+
+    Returns ``(result, file_reads, document_reads)``. ``listed`` is what the repo document
+    says the repo holds; None stands for no document being available.
+    """
+    import types as _types
+
+    from utils.models import model_config as mc
+
+    reads: list = []
+    documents: list = []
+    monkeypatch.setattr(mc, "_audio_detection_cache", {})
+    monkeypatch.setattr(mc, "_audio_offline_miss_cache", {})
+    monkeypatch.setattr(mc, "get_cache_path", lambda *a, **k: snapshot_repo_dir)
+    monkeypatch.setattr(mc, "_env_offline", lambda: False)
+
+    def _info(
+        model_name,
+        hf_token = None,
+        **kw,
+    ):
+        documents.append(model_name)
+        if listed is None:
+            raise ConnectionError("no repo document")
+        return _types.SimpleNamespace(
+            sha = sha,
+            siblings = [_types.SimpleNamespace(rfilename = name) for name in listed],
+        )
+
+    monkeypatch.setattr(mc, "_hub_model_info", _info)
+
+    import requests
+
+    def _get(url, **kw):
+        reads.append(url)
+        return (responses or []).pop(0)
+
+    monkeypatch.setattr(requests, "get", _get)
+    return mc.detect_audio_type_checked("acme/tts-model", **kwargs), reads, documents
+
+
+def _tokenizer(marker):
+    return json.dumps({"added_tokens_decoder": {"0": {"content": marker}}})
+
+
+@pytest.mark.parametrize("marker, expected", [("<bos>", None), ("<|audio|>", "audio_vlm")])
+def test_the_current_snapshot_answers_without_fetching_the_file(
+    monkeypatch, tmp_path, marker, expected
+):
+    """Every tokenizer path this repo has was read from disk, so a fetch would re-read it.
+
+    The repo document is still read -- that is what says which paths the repo has. What the
+    snapshot saves is fetching the files themselves.
+    """
+    repo_dir, _ = _cached_snapshot(
+        tmp_path, "acme/tts-model", {"tokenizer_config.json": _tokenizer(marker)}
+    )
+
+    (audio_type, definitive), reads, _documents = _detect_against_cache(monkeypatch, repo_dir)
+
+    assert audio_type == expected
+    assert definitive is True
+    assert reads == []
+
+
+def test_a_tokenizer_the_repo_has_but_the_cache_lacks_still_asks_the_hub(monkeypatch, tmp_path):
+    """Loadable weights do not mean every file arrived: the markers may be in the one that
+    did not, and a negative answer here is cached for the life of the process."""
+    repo_dir, _ = _cached_snapshot(
+        tmp_path, "acme/tts-model", {"tokenizer_config.json": _tokenizer("<bos>")}
+    )
+
+    (audio_type, definitive), reads, _documents = _detect_against_cache(
+        monkeypatch,
+        repo_dir,
+        listed = ("tokenizer_config.json", "LLM/tokenizer_config.json"),
+        responses = [_Resp(200, json.loads(_tokenizer("<|audio|>"))), _Resp(404)],
+    )
+
+    assert audio_type == "audio_vlm"
+    assert definitive is True
+    assert len(reads) == 1
+
+
+def test_a_snapshot_that_is_not_the_current_commit_still_asks_the_hub(monkeypatch, tmp_path):
+    """A repo re-downloaded at a new commit keeps the old snapshot beside the new one."""
+    repo_dir, _ = _cached_snapshot(
+        tmp_path, "acme/tts-model", {"tokenizer_config.json": _tokenizer("<bos>")}, sha = "old"
+    )
+
+    (audio_type, definitive), reads, _documents = _detect_against_cache(
+        monkeypatch,
+        repo_dir,
+        sha = "new",
+        responses = [_Resp(200, json.loads(_tokenizer("<|audio|>"))), _Resp(404)],
+    )
+
+    assert audio_type == "audio_vlm"
+    assert len(reads) == 1
+
+
+def test_an_older_snapshot_beside_the_current_one_cannot_answer_negatively(monkeypatch, tmp_path):
+    """Either may be read first, but only the current commit may answer negatively: the
+    older one predates the markers, and a negative here is cached for the process. A
+    positive match from any snapshot still stands, as it did before."""
+    repo_dir, _ = _cached_snapshot(
+        tmp_path, "acme/tts-model", {"tokenizer_config.json": _tokenizer("<bos>")}, sha = "old"
+    )
+    current = repo_dir / "snapshots" / "new"
+    current.mkdir()
+    (current / "tokenizer_config.json").write_text(_tokenizer("<|audio|>"), encoding = "utf-8")
+
+    (audio_type, definitive), reads, _documents = _detect_against_cache(
+        monkeypatch, repo_dir, sha = "new"
+    )
+
+    assert audio_type == "audio_vlm"
+    assert definitive is True
+    assert reads == []
+
+
+def test_without_a_repo_document_the_hub_still_answers(monkeypatch, tmp_path):
+    """Offline, or on any failed read, there is nothing to judge the snapshot against."""
+    repo_dir, _ = _cached_snapshot(
+        tmp_path, "acme/tts-model", {"tokenizer_config.json": _tokenizer("<bos>")}
+    )
+
+    (audio_type, _definitive), reads, _documents = _detect_against_cache(
+        monkeypatch,
+        repo_dir,
+        listed = None,
+        responses = [_Resp(200, json.loads(_tokenizer("<|audio|>"))), _Resp(404)],
+    )
+
+    assert audio_type == "audio_vlm"
+    assert len(reads) == 1
+
+
+def test_local_files_only_reads_no_repo_document(monkeypatch, tmp_path):
+    """The /loras filesystem scan asks for no network, and resolving the current commit
+    would be one. The local read still answers it, exactly as it did before."""
+    repo_dir, _ = _cached_snapshot(
+        tmp_path, "acme/tts-model", {"tokenizer_config.json": _tokenizer("<bos>")}
+    )
+
+    (audio_type, definitive), reads, documents = _detect_against_cache(
+        monkeypatch, repo_dir, local_files_only = True
+    )
+
+    assert (audio_type, definitive) == (None, True)
+    assert reads == []
+    assert documents == []
+
+
+def test_a_half_written_tokenizer_ending_in_a_brace_still_asks_the_hub(monkeypatch, tmp_path):
+    """The trailing brace tells a whole file from a half-written one only by luck. Standing
+    in for the Hub copy needs more than luck, since the markers may be in the missing tail."""
+    whole = json.dumps(
+        {"added_tokens_decoder": {"0": {"content": "<bos>"}, "1": {"content": "<|audio|>"}}}
+    )
+    truncated = whole[: whole.index('"1"')] + "}"
+    assert truncated.rstrip().endswith("}") and "<|audio|>" not in truncated
+
+    repo_dir, _ = _cached_snapshot(tmp_path, "acme/tts-model", {"tokenizer_config.json": truncated})
+
+    (audio_type, definitive), reads, _documents = _detect_against_cache(
+        monkeypatch, repo_dir, responses = [_Resp(200, json.loads(whole)), _Resp(404)]
+    )
+
+    assert audio_type == "audio_vlm"
+    assert definitive is True
+    assert len(reads) == 1
+
+
+def test_a_tokenizer_that_is_unreadable_still_asks_the_hub(monkeypatch, tmp_path):
+    """Nothing was read, so having the file says nothing: a truncated file is not a negative."""
+    whole = _tokenizer("<|audio|>")
+    repo_dir, _ = _cached_snapshot(
+        tmp_path, "acme/tts-model", {"tokenizer_config.json": whole[: len(whole) // 2]}
+    )
+
+    (audio_type, _definitive), reads, _documents = _detect_against_cache(
+        monkeypatch, repo_dir, responses = [_Resp(200, json.loads(whole)), _Resp(404)]
+    )
+
+    assert audio_type == "audio_vlm"
+    assert len(reads) == 1

--- a/studio/backend/tests/test_audio_token_detection.py
+++ b/studio/backend/tests/test_audio_token_detection.py
@@ -600,7 +600,9 @@ def test_a_marker_written_as_an_escape_is_still_found(monkeypatch, tmp_path):
     the miss becomes a definitive negative cached for the life of the process."""
     from utils.models.model_config import _may_hold_audio_tokens
 
-    escaped = _tokenizer("<|audio|>").replace("<", chr(92) + "u003c").replace(">", chr(92) + "u003e")
+    escaped = (
+        _tokenizer("<|audio|>").replace("<", chr(92) + "u003c").replace(">", chr(92) + "u003e")
+    )
     assert "<|audio|>" not in escaped and json.loads(escaped)
     assert not _may_hold_audio_tokens(escaped), "the raw scan is what misses it"
 

--- a/studio/backend/tests/test_audio_token_detection.py
+++ b/studio/backend/tests/test_audio_token_detection.py
@@ -590,3 +590,23 @@ def test_a_document_without_siblings_at_all_cannot_answer_negatively(monkeypatch
     )
 
     assert mc._current_cached_snapshot("acme/tts-model") is None
+
+
+def test_a_marker_written_as_an_escape_is_still_found(monkeypatch, tmp_path):
+    """The raw scan that decides whether a file is worth parsing reads the text, so a
+    content written as a JSON escape does not match it. Go's encoding/json escapes < and >
+    that way by default, so it is a shape real tooling uploads. The Hub fallback decodes
+    before it looks; standing in for it has to classify what it would have classified, or
+    the miss becomes a definitive negative cached for the life of the process."""
+    from utils.models.model_config import _may_hold_audio_tokens
+
+    escaped = _tokenizer("<|audio|>").replace("<", chr(92) + "u003c").replace(">", chr(92) + "u003e")
+    assert "<|audio|>" not in escaped and json.loads(escaped)
+    assert not _may_hold_audio_tokens(escaped), "the raw scan is what misses it"
+
+    repo_dir, _ = _cached_snapshot(tmp_path, "acme/tts-model", {"tokenizer_config.json": escaped})
+
+    (audio_type, definitive), reads, _documents = _detect_against_cache(monkeypatch, repo_dir)
+
+    assert (audio_type, definitive) == ("audio_vlm", True)
+    assert reads == [], "and the snapshot still answers it without a fetch"

--- a/studio/backend/tests/test_audio_token_detection.py
+++ b/studio/backend/tests/test_audio_token_detection.py
@@ -549,3 +549,44 @@ def test_a_tokenizer_that_is_unreadable_still_asks_the_hub(monkeypatch, tmp_path
 
     assert audio_type == "audio_vlm"
     assert len(reads) == 1
+
+
+def test_a_document_that_lists_no_files_cannot_answer_negatively(monkeypatch, tmp_path):
+    """The negative rests on having read every tokenizer path the repo lists. A document
+    that lists none satisfies that vacuously while proving nothing, and the answer here is
+    cached for the life of the process -- so the markers in LLM/tokenizer_config.json
+    would be missed for good. Nothing is answerable from it, so it answers nothing."""
+    repo_dir, _ = _cached_snapshot(
+        tmp_path, "acme/tts-model", {"tokenizer_config.json": _tokenizer("<bos>")}
+    )
+
+    (audio_type, definitive), reads, _documents = _detect_against_cache(
+        monkeypatch,
+        repo_dir,
+        listed = (),
+        responses = [_Resp(200, json.loads(_tokenizer("<|audio|>"))), _Resp(404)],
+    )
+
+    assert audio_type == "audio_vlm"
+    assert definitive is True
+    assert len(reads) == 1
+
+
+def test_a_document_without_siblings_at_all_cannot_answer_negatively(monkeypatch, tmp_path):
+    """``siblings`` is optional on the hub's model, so absent is a shape a response takes
+    and not only an empty list."""
+    import types as _types
+
+    from utils.models import model_config as mc
+
+    repo_dir, _ = _cached_snapshot(
+        tmp_path, "acme/tts-model", {"tokenizer_config.json": _tokenizer("<bos>")}
+    )
+    monkeypatch.setattr(mc, "get_cache_path", lambda *a, **k: repo_dir)
+    monkeypatch.setattr(
+        mc,
+        "_hub_model_info",
+        lambda *a, **k: _types.SimpleNamespace(sha = "abc123", siblings = None),
+    )
+
+    assert mc._current_cached_snapshot("acme/tts-model") is None

--- a/studio/backend/tests/test_offline_gguf_cache_fallback.py
+++ b/studio/backend/tests/test_offline_gguf_cache_fallback.py
@@ -1127,13 +1127,17 @@ class TestSharedHubModelInfo:
         _hub_model_info("org/repo", "tok")
         assert len(hub.calls) == 2
 
-    def test_the_config_route_shares_one_read_across_its_probes(self, hub, monkeypatch):
-        """The endpoint is what establishes the scope."""
+    def test_the_config_route_opens_the_shared_read_and_the_pin(self, hub, monkeypatch):
+        """The endpoint is what establishes both request scopes, not the helpers below it."""
         import asyncio
 
         import routes.models as models_route
+        import utils.utils as uu
+
+        pinned_inside: list = []
 
         def _embedding(model_name, hf_token = None):
+            pinned_inside.append(uu._hf_reachability_pin.get() is not None)
             return _hub_model_info(model_name, hf_token).tags == ["sentence-transformers"]
 
         def _from_identifier(
@@ -1166,6 +1170,8 @@ class TestSharedHubModelInfo:
 
         assert result.is_embedding is True
         assert len(hub.calls) == 1
+        # Dropping either scope from the handler leaves every probe below it unchanged.
+        assert pinned_inside == [True]
 
 
 # ---------------------------------------------------------------------------
@@ -3692,3 +3698,163 @@ class TestGuardsShareOneDnsLookup:
         assert _hf_unreachable() is True
         state["dead"] = False
         assert _hf_unreachable() is False  # no waiting out the TTL
+
+
+class TestPinnedReachability:
+    """One request, one reachability verdict, however long the request runs.
+
+    The memo expires on wall-clock, which is right between requests and wrong inside one: a
+    model-config request on a slow link outlives the TTL, so the guards it opens later
+    re-probe, and can reach a different verdict than the guard that admitted the request.
+    """
+
+    @pytest.fixture
+    def probe(self, monkeypatch, clean_offline_env):
+        """A reachability probe whose verdict is settable and whose calls are counted."""
+        import utils.transformers_version as tv
+        import utils.utils as uu
+
+        state = _types.SimpleNamespace(calls = 0, verdict = False)
+
+        def _probe(*_a, **_k):
+            state.calls += 1
+            return state.verdict
+
+        monkeypatch.setattr(tv, "hf_endpoint_unreachable", _probe)
+        # Zero TTL: every read after the first would re-probe were the pin not holding one.
+        monkeypatch.setattr(uu, "_HF_REACHABILITY_TTL_S", 0.0)
+        uu.reset_hf_reachability_cache()
+        return state
+
+    def test_the_opt_out_verdict_pins_like_any_other(self, probe, monkeypatch):
+        """Disabling the probe answers before it runs, and that answer is still this
+        request's verdict. An empty pin sends every later guard to its own DNS lookup, which
+        is most of what the opt-out exists to avoid."""
+        import utils.utils as uu
+
+        monkeypatch.setenv("UNSLOTH_OFFLINE_PROBE", "0")
+        with uu.pinned_hf_reachability():
+            assert uu.hf_unreachable() is False
+            assert uu.hf_reachability_memo() is False
+        assert probe.calls == 0
+
+    @pytest.mark.parametrize("verdict", [False, True])
+    def test_the_verdict_survives_the_memo_expiring_mid_request(self, probe, verdict):
+        import utils.utils as uu
+
+        probe.verdict = verdict
+        with uu.pinned_hf_reachability():
+            assert uu.hf_unreachable() is verdict
+            # Every later guard in this request, with the memo already stale.
+            assert uu.hf_unreachable() is verdict
+            assert uu.hf_reachability_memo() is verdict
+
+        assert probe.calls == 1
+
+    def test_a_memoised_verdict_fills_the_pin_too(self, probe, monkeypatch):
+        """The realistic entry state: the memo is warm when the request opens its first
+        guard, so nothing probes, and the pin would stay empty and let a later guard probe."""
+        import utils.utils as uu
+
+        monkeypatch.setattr(uu, "_HF_REACHABILITY_TTL_S", 60.0)
+        assert uu.hf_unreachable() is False
+        assert probe.calls == 1
+
+        with uu.pinned_hf_reachability():
+            assert uu.hf_unreachable() is False
+            # The memo goes stale mid-request, as it does on a slow link.
+            monkeypatch.setattr(uu, "_HF_REACHABILITY_TTL_S", 0.0)
+            probe.verdict = True
+            assert uu.hf_unreachable() is False
+
+        assert probe.calls == 1
+
+    def test_the_guard_the_route_opens_reads_the_pinned_verdict(self, probe, monkeypatch):
+        """The wrapper the handler actually goes through, not only ``hf_unreachable``: it
+        answers from the memo directly, so that path has to pin like every other."""
+        import core.inference.llama_cpp as llama_cpp
+        import utils.utils as uu
+
+        monkeypatch.setattr(uu, "_HF_REACHABILITY_TTL_S", 60.0)
+        monkeypatch.setattr(uu, "hf_dns_dead", lambda *_a, **_k: False, raising = False)
+        assert uu.hf_unreachable() is False
+        assert probe.calls == 1
+
+        with uu.pinned_hf_reachability():
+            assert llama_cpp._hf_unreachable() is False
+            monkeypatch.setattr(uu, "_HF_REACHABILITY_TTL_S", 0.0)
+            probe.verdict = True
+            assert llama_cpp._hf_unreachable() is False
+
+        assert probe.calls == 1
+
+    def test_a_later_request_probes_again(self, probe):
+        import utils.utils as uu
+
+        with uu.pinned_hf_reachability():
+            assert uu.hf_unreachable() is False
+        # Pinning must not outlive the request: the plug may have been pulled since.
+        probe.verdict = True
+        with uu.pinned_hf_reachability():
+            assert uu.hf_unreachable() is True
+
+        assert probe.calls == 2
+
+    def test_nothing_is_pinned_until_something_probes(self, probe):
+        import utils.utils as uu
+        with uu.pinned_hf_reachability():
+            # A block that never reaches the Hub pays nothing, and reports no verdict.
+            assert uu.hf_reachability_memo() is None
+
+        assert probe.calls == 0
+
+    def test_one_request_pinning_does_not_take_over_another_s(self, monkeypatch, probe):
+        """Sequenced, not raced: B pins while A holds a pin, then A reads its verdict again.
+
+        Module-global state would hand A request B's pin, and A would report B's verdict.
+        """
+        import threading
+
+        import utils.transformers_version as tv
+        import utils.utils as uu
+
+        verdicts = [False, True]
+        guard = threading.Lock()
+
+        def _probe(*_a, **_k):
+            with guard:
+                return verdicts.pop(0)
+
+        monkeypatch.setattr(tv, "hf_endpoint_unreachable", _probe)
+
+        a_probed = threading.Event()
+        b_pinned = threading.Event()
+        a_done = threading.Event()
+        seen: dict = {}
+        waited: list = []
+
+        def _request_a():
+            with uu.pinned_hf_reachability():
+                seen["a"] = uu.hf_unreachable()
+                a_probed.set()
+                waited.append(b_pinned.wait(timeout = 30))
+                seen["a_again"] = uu.hf_unreachable()
+                a_done.set()
+
+        def _request_b():
+            waited.append(a_probed.wait(timeout = 30))
+            with uu.pinned_hf_reachability():
+                seen["b"] = uu.hf_unreachable()
+                b_pinned.set()
+                waited.append(a_done.wait(timeout = 30))
+
+        threads = [threading.Thread(target = _request_a), threading.Thread(target = _request_b)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout = 60)
+
+        assert [thread.is_alive() for thread in threads] == [False, False]
+        assert waited == [True, True, True]
+        assert seen["a"] is False and seen["a_again"] is False
+        assert seen["b"] is True

--- a/studio/backend/tests/test_offline_gguf_cache_fallback.py
+++ b/studio/backend/tests/test_offline_gguf_cache_fallback.py
@@ -7,8 +7,9 @@ When ``huggingface.co`` is unreachable but the repo is cached, three failures
 hit: ``list_gguf_variants`` 500'd (empty dropdown), ``detect_gguf_model_remote``
 returned None (GGUF-only repo misrouted), and ``_download_gguf`` synthesised a
 name absent from cache. Follow-ups: the cache filter matches the snapshot-relative
-path (subdir layouts findable), and DNS auto-detect scopes ``HF_HUB_OFFLINE`` to
-one load so a transient hiccup can't pin the singleton offline.
+path (subdir layouts findable), DNS auto-detect scopes ``HF_HUB_OFFLINE`` to
+one load so a transient hiccup can't pin the singleton offline, and the probes above
+share a repo document within one request rather than each fetching it.
 
 No GPU, no network, no subprocess. Linux/macOS/Windows compatible.
 """
@@ -102,11 +103,14 @@ from core.inference.llama_cpp import (
 from utils.models.model_config import (
     _detect_gguf_from_hf_cache,
     _extract_quant_label,
+    _hub_model_info,
     _iter_hf_cache_snapshots,
     _list_gguf_variants_from_hf_cache,
     detect_gguf_model_remote,
     list_gguf_variants,
+    shared_hub_model_info,
 )
+import utils.models.model_config as mc
 
 
 # ---------------------------------------------------------------------------
@@ -925,6 +929,243 @@ class TestDetectGgufModelRemoteOffline:
             out = detect_gguf_model_remote("unsloth/a")
         # Early-return semantics preserved: 404 wins over a stale cache.
         assert out is None
+
+
+class TestSharedHubModelInfo:
+    """The probes above share an ``/api/models/<repo>`` read within a single request.
+
+    Scoped rather than cached, so the 404-beats-a-stale-cache rule the class above asserts
+    still holds between requests. Every read inside a scope asks for file sizes, so one
+    response serves the GGUF variant listing as well as the probes that ignore them.
+    """
+
+    @pytest.fixture(autouse = True)
+    def hub(self, monkeypatch):
+        """A fake hub whose every response identifies the call that produced it."""
+        monkeypatch.setattr(mc, "_env_offline", lambda: False)
+        state = _types.SimpleNamespace(calls = [], raises = None, siblings = ("model.safetensors",))
+
+        def _fake(repo_id, **kwargs):
+            state.calls.append(
+                (repo_id, kwargs.get("token"), kwargs.get("files_metadata"), kwargs.get("timeout"))
+            )
+            if state.raises is not None:
+                raise state.raises
+            return _types.SimpleNamespace(
+                served_for = (repo_id, kwargs.get("token")),
+                tags = ["sentence-transformers"],
+                pipeline_tag = "feature-extraction",
+                siblings = [
+                    _types.SimpleNamespace(
+                        rfilename = name, size = 7 if kwargs.get("files_metadata") else None
+                    )
+                    for name in state.siblings
+                ],
+            )
+
+        monkeypatch.setitem(
+            sys.modules, "huggingface_hub", _types.SimpleNamespace(model_info = _fake)
+        )
+        return state
+
+    def test_sharing_lasts_exactly_one_scope(self, hub):
+        with shared_hub_model_info():
+            first = _hub_model_info("org/repo", "tok")
+            assert _hub_model_info("org/repo", "tok") is first
+        with shared_hub_model_info():
+            _hub_model_info("org/repo", "tok")
+        _hub_model_info("org/repo", "tok")
+        _hub_model_info("org/repo", "tok")
+
+        assert len(hub.calls) == 4
+
+    def test_the_key_separates_by_repo_and_token(self, hub):
+        with shared_hub_model_info():
+            # ``None`` grants the ambient credential and ``False`` denies every credential.
+            served = {
+                repr(token): _hub_model_info(repo, token).served_for
+                for repo in ("org/one", "org/two")
+                for token in ("alice-token", None, False)
+            }
+
+        assert served[repr(False)] == ("org/two", False)
+        assert len(hub.calls) == 6
+        assert len({(r, t) for r, t, _fm, _to in hub.calls}) == 6
+
+    def test_a_sized_response_answers_a_plain_read(self, hub):
+        with shared_hub_model_info():
+            sized = _hub_model_info("org/repo", "tok", files_metadata = True)
+            assert _hub_model_info("org/repo", "tok") is sized
+
+        assert sized.siblings[0].size == 7
+        assert [fm for _r, _t, fm, _to in hub.calls] == [True]
+
+    def test_an_unscoped_read_asks_only_for_what_it_was_given(self, hub):
+        assert _hub_model_info("org/repo", "tok").siblings[0].size is None
+        assert _hub_model_info("org/repo", "tok", files_metadata = True).siblings[0].size == 7
+        assert [fm for _r, _t, fm, _to in hub.calls] == [False, True]
+
+    def test_failures_and_offline_reads_are_never_shared(self, hub, monkeypatch):
+        hub.raises = ConnectionError("hub down")
+        with shared_hub_model_info():
+            for _ in range(3):
+                with pytest.raises(ConnectionError):
+                    _hub_model_info("org/repo", "tok")
+        assert len(hub.calls) == 3
+
+        hub.raises = None
+        with shared_hub_model_info():
+            _hub_model_info("org/repo", "tok")
+            monkeypatch.setattr(mc, "_env_offline", lambda: True)
+            _hub_model_info("org/repo", "tok")
+
+        assert len(hub.calls) == 5
+
+    def test_the_plain_probes_share_one_read(self, hub, monkeypatch):
+        """The embedding probe also bounds the shared read, so a DNS-dead session fails fast."""
+        hub.siblings = ("adapter_config.json",)
+        monkeypatch.setattr(mc, "hf_env_offline", lambda: False, raising = False)
+        mc._embedding_detection_cache.clear()
+
+        with shared_hub_model_info():
+            assert mc.is_embedding_model("org/repo", hf_token = "tok") is True
+            assert detect_gguf_model_remote("org/repo", hf_token = "tok") is None
+            info = _hub_model_info("org/repo", "tok")
+
+        assert "adapter_config.json" in [s.rfilename for s in info.siblings]
+        assert [to for _r, _t, _fm, to in hub.calls] == [mc._HUB_MODEL_INFO_TIMEOUT]
+
+    def test_every_read_is_bounded(self, hub):
+        """The response is shared, so the first reader decides the bound the rest inherit:
+        an unbounded first read would leave the whole request able to hang."""
+        with shared_hub_model_info():
+            _hub_model_info("org/repo", "tok")
+        _hub_model_info("org/other", "tok")
+        _hub_model_info("org/other", "tok", timeout = 3.0)
+
+        assert [to for _r, _t, _fm, to in hub.calls] == [
+            mc._HUB_MODEL_INFO_TIMEOUT,
+            mc._HUB_MODEL_INFO_TIMEOUT,
+            3.0,
+        ]
+
+    def test_remote_lora_detection_reuses_the_shared_read(self, hub, tmp_path):
+        hub.siblings = ("adapter_config.json",)
+        adapter = tmp_path / "adapter_config.json"
+        adapter.write_text('{"base_model_name_or_path": "org/base"}', encoding = "utf-8")
+        sys.modules["huggingface_hub"].hf_hub_download = lambda *a, **k: str(adapter)
+
+        with shared_hub_model_info():
+            _hub_model_info("org/repo", "tok")
+            cfg = mc.ModelConfig.from_identifier("org/repo", hf_token = "tok")
+
+        # The classification, not only the count: deleting sibling-based detection would
+        # otherwise leave the count at one and pass.
+        assert cfg is not None and cfg.is_lora is True and cfg.base_model == "org/base"
+        assert len(hub.calls) == 1
+
+    def test_variant_listing_shares_its_sized_read(self, hub):
+        """A GGUF listing asks for sizes, and the probes after it read the same response."""
+        hub.siblings = ("a-Q4_K_M.gguf",)
+
+        with shared_hub_model_info():
+            variants, _ = list_gguf_variants("org/repo", hf_token = "tok")
+            shared = _hub_model_info("org/repo", "tok")
+
+        assert [v.size_bytes for v in variants] == [7]
+        assert shared.siblings[0].size == 7
+        assert [fm for _r, _t, fm, _to in hub.calls] == [True]
+
+    def test_one_request_entering_does_not_destroy_another_s_scope(self, hub):
+        """Sequenced, not raced: B opens a scope while A holds one, then A reads again.
+
+        Module-global state would hand A request B's scope, which lacks A's credential.
+        """
+        import threading
+
+        b_is_inside = threading.Event()
+        a_is_finished = threading.Event()
+        a_result: list = []
+        overlapped: list = []
+
+        def _request_a():
+            with shared_hub_model_info():
+                first = _hub_model_info("org/repo", "alice")
+                # Recorded, not merely awaited: a timeout would drop the overlap this test
+                # exists to create.
+                overlapped.append(b_is_inside.wait(timeout = 30))
+                a_result.append(_hub_model_info("org/repo", "alice") is first)
+                a_is_finished.set()
+
+        def _request_b():
+            with shared_hub_model_info():
+                _hub_model_info("org/repo", "bob")
+                b_is_inside.set()
+                overlapped.append(a_is_finished.wait(timeout = 30))
+
+        threads = [threading.Thread(target = _request_a), threading.Thread(target = _request_b)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout = 60)
+
+        assert [thread.is_alive() for thread in threads] == [False, False]
+        assert overlapped == [True, True]
+        assert a_result == [True]
+        assert sorted((r, t) for r, t, _fm, _to in hub.calls) == [
+            ("org/repo", "alice"),
+            ("org/repo", "bob"),
+        ]
+
+    def test_a_failed_request_leaves_no_scope_behind(self, hub):
+        with pytest.raises(RuntimeError):
+            with shared_hub_model_info():
+                _hub_model_info("org/repo", "tok")
+                raise RuntimeError("a probe blew up mid-request")
+
+        assert mc._hub_model_info_scope.get() is None
+        _hub_model_info("org/repo", "tok")
+        assert len(hub.calls) == 2
+
+    def test_the_config_route_shares_one_read_across_its_probes(self, hub, monkeypatch):
+        """The endpoint is what establishes the scope."""
+        import asyncio
+
+        import routes.models as models_route
+
+        def _embedding(model_name, hf_token = None):
+            return _hub_model_info(model_name, hf_token).tags == ["sentence-transformers"]
+
+        def _from_identifier(
+            cls,
+            model_name,
+            hf_token = None,
+        ):
+            _hub_model_info(model_name, hf_token)
+            return _types.SimpleNamespace(is_lora = False, base_model = None)
+
+        monkeypatch.setattr(models_route, "is_local_path", lambda _: False)
+        monkeypatch.setattr(models_route, "resolve_cached_repo_id_case", lambda name: name)
+        monkeypatch.setattr(models_route, "load_model_defaults", lambda _: {})
+        monkeypatch.setattr(models_route, "is_vision_model", lambda *a, **k: False)
+        monkeypatch.setattr(models_route, "is_embedding_model", _embedding)
+        monkeypatch.setattr(mc, "detect_audio_type_checked", lambda *a, **k: (None, True))
+        monkeypatch.setattr(
+            models_route.ModelConfig, "from_identifier", classmethod(_from_identifier)
+        )
+        monkeypatch.setattr(models_route, "_get_max_position_embeddings", lambda _: 4096)
+        monkeypatch.setattr(models_route, "_get_model_size_bytes", lambda *a, **k: None)
+
+        result = asyncio.run(
+            models_route.get_model_config(
+                model_name = "org/model",
+                hf_token = None,
+                current_subject = "test-subject",
+            )
+        )
+
+        assert result.is_embedding is True
+        assert len(hub.calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/studio/backend/tests/test_offline_gguf_cache_fallback.py
+++ b/studio/backend/tests/test_offline_gguf_cache_fallback.py
@@ -3726,16 +3726,36 @@ class TestPinnedReachability:
         uu.reset_hf_reachability_cache()
         return state
 
-    def test_the_opt_out_verdict_pins_like_any_other(self, probe, monkeypatch):
-        """Disabling the probe answers before it runs, and that answer is still this
-        request's verdict. An empty pin sends every later guard to its own DNS lookup, which
-        is most of what the opt-out exists to avoid."""
+    def test_the_opt_out_leaves_the_pin_open(self, probe, monkeypatch):
+        """Disabling the probe declines to answer rather than finding the hub reachable,
+        so it is not this request's verdict and the pin stays empty for one that is."""
         import utils.utils as uu
 
         monkeypatch.setenv("UNSLOTH_OFFLINE_PROBE", "0")
         with uu.pinned_hf_reachability():
             assert uu.hf_unreachable() is False
-            assert uu.hf_reachability_memo() is False
+            assert uu.hf_reachability_memo() is None
+        assert probe.calls == 0
+
+    def test_the_opt_out_leaves_the_dns_shortcut_to_every_guard(self, probe, monkeypatch):
+        """UNSLOTH_OFFLINE_PROBE turns off the TCP probe, not DNS, so the shortcut is the
+        only detector left and the pin must not answer for it. A link that drops after the
+        guard admitting the request has to be seen by the guards that follow."""
+        import utils.utils as uu
+        from core.inference.llama_cpp import _hf_unreachable
+
+        monkeypatch.setenv("UNSLOTH_OFFLINE_PROBE", "0")
+        lookups = []
+
+        def _dns_dead(*_a, **_k):
+            lookups.append(1)
+            return len(lookups) > 1  # alive for the first guard, then the link drops
+
+        monkeypatch.setattr(uu, "hf_dns_dead", _dns_dead)
+        with uu.pinned_hf_reachability():
+            verdicts = [_hf_unreachable() for _ in range(3)]
+
+        assert verdicts == [False, True, True]
         assert probe.calls == 0
 
     @pytest.mark.parametrize("verdict", [False, True])

--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -1071,3 +1071,207 @@ class TestEnvOfflineParsing:
         for val in ("", "0", "false", "no", "off", "2", "onn"):
             monkeypatch.setenv("HF_HUB_OFFLINE", val)
             assert mc._env_offline() is False, f"HF_HUB_OFFLINE={val!r} should not be offline"
+
+
+# --- The current cached snapshot answers the vision probe without fetching config.json ---
+
+
+def _hub_cached_repo(
+    tmp_path,
+    repo_id,
+    files,
+    sha = "abc123",
+):
+    """A repo laid out the way the HF hub cache lays one out."""
+    repo_dir = tmp_path / ("models--" + repo_id.replace("/", "--"))
+    snapshot = repo_dir / "snapshots" / sha
+    snapshot.mkdir(parents = True)
+    for name, text in files.items():
+        (snapshot / name).write_text(text, encoding = "utf-8")
+    return repo_dir, snapshot
+
+
+def _probe_against_cache(
+    monkeypatch,
+    repo_dir,
+    *,
+    sha = "abc123",
+    listed = ("config.json",),
+    remote_config = None,
+    **kwargs,
+):
+    """Drive the vision probe against a cached snapshot, recording any Hub read it makes.
+
+    ``listed`` is what the repo document says the repo holds; None stands for no document.
+    """
+    import huggingface_hub
+    import utils.hf_probe as hf_probe
+    import utils.models.model_config as mc
+
+    reads: list = []
+    monkeypatch.setattr(mc, "is_local_path", lambda *_a, **_k: False)
+    monkeypatch.setattr(mc, "get_cache_path", lambda *_a, **_k: repo_dir)
+
+    def _info(
+        model_name,
+        hf_token = None,
+        **kw,
+    ):
+        if listed is None:
+            raise ConnectionError("no repo document")
+        return _types.SimpleNamespace(
+            sha = sha,
+            siblings = [_types.SimpleNamespace(rfilename = name) for name in listed],
+        )
+
+    monkeypatch.setattr(mc, "_hub_model_info", _info)
+
+    def _absent(model_name, filename, **kw):
+        reads.append(("absent", filename))
+        return remote_config is None
+
+    def _download(**kw):
+        reads.append(("download", kw.get("filename")))
+        path = repo_dir / "remote-config.json"
+        path.write_text(_json.dumps(remote_config), encoding = "utf-8")
+        return str(path)
+
+    monkeypatch.setattr(hf_probe, "hf_file_definitely_absent", _absent)
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", _download)
+
+    return mc._raw_config_has_vision_config("acme/vlm", **kwargs), reads
+
+
+@pytest.mark.parametrize(
+    "cached, expected",
+    [({"vision_config": {"hidden_size": 8}}, True), ({"model_type": "llama"}, False)],
+)
+def test_the_current_snapshot_answers_without_fetching_the_file(
+    tmp_path, monkeypatch, cached, expected
+):
+    """The snapshot decides the answer -- it is read, not merely counted.
+
+    The repo document is still read, since it names the current commit. What the snapshot
+    saves is fetching config.json itself.
+    """
+    repo_dir, _ = _hub_cached_repo(tmp_path, "acme/vlm", {"config.json": _json.dumps(cached)})
+
+    answer, reads = _probe_against_cache(monkeypatch, repo_dir)
+
+    assert answer is expected
+    assert reads == []
+
+
+@pytest.mark.parametrize(
+    "case, files, kwargs",
+    [
+        # A repo re-downloaded at a new commit keeps the old snapshot beside the new one.
+        ("stale snapshot", {"config.json": '{"model_type": "llama"}'}, {"sha": "new"}),
+        # The repo has the file; this snapshot simply never downloaded it.
+        ("file not downloaded", {"modules.json": "[]"}, {}),
+        # Offline, or on any failed read, there is nothing to judge the snapshot against.
+        ("no repo document", {"config.json": '{"model_type": "llama"}'}, {"listed": None}),
+        # The cached snapshot is whichever was downloaded, not the revision asked for.
+        ("pinned revision", {"config.json": '{"model_type": "llama"}'}, {"revision": "commit-a"}),
+        # Reading the cache authorizes nothing, so a caller who forced anonymity keeps it.
+        ("anonymous", {"config.json": '{"model_type": "llama"}'}, {"hf_token": False}),
+    ],
+)
+def test_the_hub_still_answers_when_the_snapshot_may_not(
+    tmp_path, monkeypatch, case, files, kwargs
+):
+    repo_dir, _ = _hub_cached_repo(tmp_path, "acme/vlm", files)
+
+    answer, reads = _probe_against_cache(
+        monkeypatch, repo_dir, remote_config = {"vision_config": {"hidden_size": 8}}, **kwargs
+    )
+
+    assert answer is True, case
+    assert reads == [("absent", "config.json"), ("download", "config.json")], case
+
+
+def test_local_files_only_reads_no_repo_document(tmp_path, monkeypatch):
+    """The caller asked for no network; resolving the current commit would be one."""
+    import utils.models.model_config as mc
+
+    repo_dir, _ = _hub_cached_repo(
+        tmp_path, "acme/vlm", {"config.json": _json.dumps({"model_type": "llama"})}
+    )
+    reads: list = []
+
+    def _info(
+        model_name,
+        hf_token = None,
+        **kw,
+    ):
+        reads.append(model_name)
+        raise AssertionError("the repo document must not be read")
+
+    monkeypatch.setattr(mc, "is_local_path", lambda *_a, **_k: False)
+    monkeypatch.setattr(mc, "get_cache_path", lambda *_a, **_k: repo_dir)
+    monkeypatch.setattr(mc, "_hub_model_info", _info)
+
+    import huggingface_hub
+
+    downloads: list = []
+
+    def _download(**kw):
+        downloads.append(kw.get("local_files_only"))
+        return str(repo_dir / "snapshots" / "abc123" / "config.json")
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", _download)
+
+    assert mc._raw_config_has_vision_config("acme/vlm", local_files_only = True) is False
+    assert reads == []
+    # The download reads the same cache, without a network call of its own.
+    assert downloads == [True]
+
+
+def test_nothing_cached_costs_no_repo_document(tmp_path, monkeypatch):
+    """The document is only worth a round trip when there is a snapshot to judge with it."""
+    import utils.models.model_config as mc
+
+    empty = tmp_path / "models--acme--vlm"
+    empty.mkdir()
+    monkeypatch.setattr(mc, "is_local_path", lambda *_a, **_k: False)
+    monkeypatch.setattr(mc, "get_cache_path", lambda *_a, **_k: empty)
+
+    reads: list = []
+
+    def _info(
+        model_name,
+        hf_token = None,
+        **kw,
+    ):
+        reads.append(model_name)
+        raise AssertionError("the repo document must not be read")
+
+    monkeypatch.setattr(mc, "_hub_model_info", _info)
+
+    assert mc._current_cached_snapshot("acme/vlm") is None
+    assert reads == []
+
+
+def test_the_current_snapshot_is_the_one_the_repo_document_names(tmp_path, monkeypatch):
+    """The helper both probes rest on, exercised rather than stubbed."""
+    import utils.models.model_config as mc
+
+    repo_dir, snapshot = _hub_cached_repo(tmp_path, "acme/vlm", {"config.json": "{}"}, sha = "aaa")
+    (repo_dir / "snapshots" / "bbb").mkdir()
+    monkeypatch.setattr(mc, "is_local_path", lambda *_a, **_k: False)
+    monkeypatch.setattr(mc, "get_cache_path", lambda *_a, **_k: repo_dir)
+
+    def _info(
+        model_name,
+        hf_token = None,
+        **kw,
+    ):
+        return _types.SimpleNamespace(
+            sha = "aaa", siblings = [_types.SimpleNamespace(rfilename = "config.json")]
+        )
+
+    monkeypatch.setattr(mc, "_hub_model_info", _info)
+
+    assert mc._current_cached_snapshot("acme/vlm") == (snapshot, {"config.json"})
+    # Never authorizes, so a caller who forced anonymity is not served the cache.
+    assert mc._current_cached_snapshot("acme/vlm", False) is None

--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -1283,9 +1283,7 @@ def test_a_repo_that_publishes_no_config_is_settled_by_the_document(tmp_path, mo
     made a cached GGUF-only repo cost this caller two reads where main costs it one."""
     repo_dir, _ = _hub_cached_repo(tmp_path, "acme/vlm", {"model-Q4_K_M.gguf": "x"})
 
-    result, reads = _probe_against_cache(
-        monkeypatch, repo_dir, listed = ("model-Q4_K_M.gguf",)
-    )
+    result, reads = _probe_against_cache(monkeypatch, repo_dir, listed = ("model-Q4_K_M.gguf",))
 
     assert result is None
     assert reads == []

--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -1275,3 +1275,33 @@ def test_the_current_snapshot_is_the_one_the_repo_document_names(tmp_path, monke
     assert mc._current_cached_snapshot("acme/vlm") == (snapshot, {"config.json"})
     # Never authorizes, so a caller who forced anonymity is not served the cache.
     assert mc._current_cached_snapshot("acme/vlm", False) is None
+
+
+def test_a_repo_that_publishes_no_config_is_settled_by_the_document(tmp_path, monkeypatch):
+    """The document names the repo's files, so it already says config.json is not among
+    them. Probing the Hub for it spends a round trip to be told the same, and that is what
+    made a cached GGUF-only repo cost this caller two reads where main costs it one."""
+    repo_dir, _ = _hub_cached_repo(tmp_path, "acme/vlm", {"model-Q4_K_M.gguf": "x"})
+
+    result, reads = _probe_against_cache(
+        monkeypatch, repo_dir, listed = ("model-Q4_K_M.gguf",)
+    )
+
+    assert result is None
+    assert reads == []
+
+
+def test_a_config_the_repo_has_but_the_cache_lacks_still_asks(tmp_path, monkeypatch):
+    """Only a document that omits the file settles it. One that lists a file the snapshot
+    does not hold says the opposite: fetch it."""
+    repo_dir, _ = _hub_cached_repo(tmp_path, "acme/vlm", {"model-Q4_K_M.gguf": "x"})
+
+    result, reads = _probe_against_cache(
+        monkeypatch,
+        repo_dir,
+        listed = ("model-Q4_K_M.gguf", "config.json"),
+        remote_config = {"vision_config": {"hidden_size": 8}},
+    )
+
+    assert result is True
+    assert reads == [("absent", "config.json"), ("download", "config.json")]

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -766,8 +766,18 @@ def _raw_config_has_vision_config(
     revision: Optional[str] = None,
 ) -> Optional[bool]:
     try:
+        current = (
+            None
+            if revision is not None
+            else _current_cached_snapshot(model_name, hf_token, local_files_only)
+        )
         if is_local_path(model_name):
             config_path = Path(normalize_path(model_name)).expanduser() / "config.json"
+        elif current is not None and (current[0] / "config.json").is_file():
+            # This is the repo's current commit and the file is in it, so the fetch below
+            # would return what is already here. Saves both the absence probe and the
+            # download's own freshness check.
+            config_path = current[0] / "config.json"
         else:
             from huggingface_hub import hf_hub_download
             from utils.hf_probe import hf_file_definitely_absent

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -718,6 +718,47 @@ def _is_vlm(config) -> bool:
     )
 
 
+def _current_cached_snapshot(
+    model_name: str,
+    hf_token: HfTokenArg = None,
+    local_files_only: bool = False,
+):
+    """This repo's cached snapshot for its current commit, with the files the repo lists.
+
+    Returns ``(snapshot, filenames)``, or None when there is no such snapshot. The commit
+    and the file list both come from the repo document the request already reads, so a
+    snapshot accepted here is as current as a revalidating fetch would be, and callers can
+    tell a file the repo does not have from one that simply was not downloaded.
+
+    Learning the current commit is itself a network read, so a caller that asked for none
+    gets nothing here and falls back on paths that read the cache without one. Reading the
+    cache authorizes nothing, so an anonymous caller is refused it as elsewhere.
+    """
+    if local_files_only or is_anonymous(hf_token) or is_local_path(model_name):
+        return None
+    try:
+        repo_dir = get_cache_path(model_name)
+        # Cheap local check first: with nothing cached there is no snapshot to accept, and
+        # the repo document below would be a round trip spent to learn only that.
+        if repo_dir is None or not (Path(repo_dir) / "snapshots").is_dir():
+            return None
+        info = _hub_model_info(model_name, hf_token)
+        sha = getattr(info, "sha", None)
+        if not sha:
+            return None
+        snapshot = Path(repo_dir) / "snapshots" / str(sha)
+        if not snapshot.is_dir():
+            return None
+        listed = {
+            getattr(sibling, "rfilename", None)
+            for sibling in (getattr(info, "siblings", None) or ())
+        }
+        return snapshot, listed
+    except Exception as exc:
+        logger.debug("No current cached snapshot for '%s': %s", model_name, exc)
+        return None
+
+
 def _raw_config_has_vision_config(
     model_name: str,
     hf_token: Optional[str] = None,
@@ -1466,7 +1507,12 @@ def _detect_audio_from_tokenizer(
                     if snapshot is not None and snapshot.is_dir():
                         roots.append(snapshot)
 
+        current: list = []  # resolved lazily: only a negative answer needs it
+        # Whether a read here could stand in for the Hub copy, which is the only case that
+        # has to prove the file is whole rather than merely marker-free.
+        may_answer_for_hub = not local_files_only and not is_local_path(model_name)
         for root in roots:
+            root_read: set = set()
             for tok_path in _AUDIO_TOKENIZER_CONFIG_PATHS:
                 tok_file = root / tok_path
                 try:
@@ -1474,21 +1520,50 @@ def _detect_audio_from_tokenizer(
                         continue
                     raw = tok_file.read_text(encoding = "utf-8-sig")
                     if not _may_hold_audio_tokens(raw):
-                        # No marker anywhere, so no pattern can match. Counted as read
-                        # only when the file looks whole: a training run part-way through
-                        # writing its tokenizer would otherwise be a definitive "not
-                        # audio" and cached for the life of the process. A truncated file
-                        # stays unknown, exactly as it did when json.loads raised on it.
-                        if raw.rstrip().endswith("}"):
-                            read_any = True
+                        # No marker anywhere, so no pattern can match. Reading a local
+                        # checkpoint stops there: parsing these was the bulk of a cold
+                        # /loras scan, and the trailing "}" is enough to tell a whole file
+                        # from one a run is still writing. A read that will answer for the
+                        # Hub copy has to parse, since a half-written file ending in "}"
+                        # would otherwise be a definitive "not audio" cached for the life
+                        # of the process, with the markers in the part that never arrived.
+                        if may_answer_for_hub:
+                            try:
+                                json.loads(raw)
+                            except Exception:
+                                continue
+                        elif not raw.rstrip().endswith("}"):
+                            continue
+                        read_any = True
+                        root_read.add(tok_path)
                         continue
                     tok_config = json.loads(raw)
                     read_any = True
+                    root_read.add(tok_path)
                     result = _check_token_patterns(tok_config)
                     if result:
                         return result, True
                 except Exception as e:
                     logger.debug(f"Could not read {tok_file} for {model_name}: {e}")
+            # Every tokenizer path the repo actually has was read here, so re-fetching them
+            # only re-reads what was just read -- and a repo with no ``LLM/`` layout pays a
+            # round trip to be told so. Anything less may answer positively but never
+            # negatively: a path that was not read still has somewhere for the markers to
+            # hide, and the answer below is cached for the life of the process.
+            if root_read and not is_local_path(model_name):
+                if not current:
+                    current.append(_current_cached_snapshot(model_name, hf_token, local_files_only))
+                snapshot = current[0]
+                if (
+                    snapshot is not None
+                    and root == snapshot[0]
+                    and all(
+                        path in root_read
+                        for path in _AUDIO_TOKENIZER_CONFIG_PATHS
+                        if path in snapshot[1]
+                    )
+                ):
+                    return None, True
     except Exception as e:
         logger.debug(f"Could not check local cache for {model_name}: {e}")
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -43,6 +43,7 @@ from utils.models.gguf_metadata import (
 import structlog
 from loggers import get_logger
 import contextlib as _contextlib
+from contextvars import ContextVar
 import os
 import re
 import subprocess
@@ -1003,6 +1004,63 @@ def _token_fingerprint(token: HfTokenArg) -> Optional[str]:
     if token is None:
         return None
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+# Scoped to a request, not cached: a repo gated or deleted between requests is seen on the next.
+_HubModelInfoScope = Dict[Tuple[str, Optional[str]], Any]
+_hub_model_info_scope: ContextVar[Optional[_HubModelInfoScope]] = ContextVar(
+    "hub_model_info_scope", default = None
+)
+
+
+# Bound the Hub lookup so a DNS-dead session fails fast to the cache instead of hanging on retries.
+_HUB_MODEL_INFO_TIMEOUT = 15.0
+
+
+@_contextlib.contextmanager
+def shared_hub_model_info():
+    """Share a ``model_info`` response between the Hub probes here, per repo and credential."""
+    token = _hub_model_info_scope.set({})
+    try:
+        yield
+    finally:
+        _hub_model_info_scope.reset(token)
+
+
+def _hub_model_info(
+    repo_id: str,
+    hf_token: HfTokenArg = None,
+    *,
+    files_metadata: bool = False,
+    timeout: Optional[float] = None,
+):
+    from huggingface_hub import model_info as hf_model_info
+
+    # The remote-LoRA probe in ``ModelConfig.from_identifier`` reads this call raising rather
+    # than guarding itself, and ``_offline_while_reading`` can force offline mid-request.
+    scope = None if _env_offline() else _hub_model_info_scope.get()
+    # The forced-anonymous sentinel is a credential of its own, so key on its fingerprint.
+    key = (repo_id, _token_fingerprint(hf_token))
+    if scope is not None:
+        if key in scope:
+            return scope[key]
+        # File sizes measure as free to ask for even on a repo of many quants, and asking
+        # unconditionally is what lets one response serve every probe: the variant listing
+        # needs them, and a response without them could not be shared with it.
+        files_metadata = True
+
+    kwargs: Dict[str, Any] = {
+        "token": hf_token,
+        "files_metadata": files_metadata,
+        # The response is shared, so whichever probe reads first decides the bound every
+        # later one inherits. Default it here rather than per call site.
+        "timeout": _HUB_MODEL_INFO_TIMEOUT if timeout is None else timeout,
+    }
+    info = hf_model_info(repo_id, **kwargs)
+
+    if scope is not None:
+        scope[key] = info
+    return info
 
 
 # Revision-less entries keep the historical 3-part key; pinned entries append revision.
@@ -2732,10 +2790,8 @@ def list_gguf_variants(
         cached = _list_gguf_variants_from_hf_cache(repo_id)
         return cached if cached is not None else ([], False)
 
-    from huggingface_hub import model_info as hf_model_info
-
     try:
-        info = hf_model_info(repo_id, token = hf_token, files_metadata = True)
+        info = _hub_model_info(repo_id, hf_token, files_metadata = True)
     except Exception as e:
         # Permanent errors (deleted/gated/bad revision) must surface; stale cache would mask the
         # real cause. Matches the early return in ``detect_gguf_model_remote``.
@@ -3039,13 +3095,10 @@ def detect_gguf_model_remote(repo_id: str, hf_token: Optional[str] = None) -> Op
     if _env_offline():
         return _detect_gguf_from_hf_cache(repo_id)
 
-    import time
-    from huggingface_hub import model_info as hf_model_info
-
     last_err: Optional[Exception] = None
     for attempt in range(3):
         try:
-            info = hf_model_info(repo_id, token = hf_token)
+            info = _hub_model_info(repo_id, hf_token)
             repo_files = []
             for sibling in info.siblings:
                 fname = sibling.rfilename
@@ -3111,10 +3164,6 @@ def download_gguf_file(
 _embedding_detection_cache: Dict[tuple, bool] = {}
 
 
-# Bound the Hub lookup so a DNS-dead session fails fast to the cache instead of hanging on retries.
-_HUB_MODEL_INFO_TIMEOUT = 15.0
-
-
 def _embedding_marker_in_hf_cache(model_name: str) -> bool:
     """True when model_name's cached snapshot carries a modules.json (the ST marker).
     Cache-only, no network; used offline and as a fallback when the Hub lookup times out."""
@@ -3167,9 +3216,7 @@ def is_embedding_model(model_name: str, hf_token: Optional[str] = None) -> bool:
         return is_emb
 
     try:
-        from huggingface_hub import model_info as hf_model_info
-
-        info = hf_model_info(model_name, token = hf_token, timeout = _HUB_MODEL_INFO_TIMEOUT)
+        info = _hub_model_info(model_name, hf_token)
         tags = set(info.tags or [])
         pipeline_tag = info.pipeline_tag or ""
 
@@ -4047,9 +4094,7 @@ class ModelConfig:
         # Remote HF models: when offline, huggingface_hub raises OfflineModeIsEnabled in ~0ms.
         if not is_lora and not is_local:
             try:
-                from huggingface_hub import model_info as hf_model_info
-
-                info = hf_model_info(identifier, token = hf_token)
+                info = _hub_model_info(identifier, hf_token)
                 repo_files = [s.rfilename for s in info.siblings]
                 if "adapter_config.json" in repo_files:
                     is_lora = True

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -787,6 +787,12 @@ def _raw_config_has_vision_config(
             # would return what is already here. Saves both the absence probe and the
             # download's own freshness check.
             config_path = current[0] / "config.json"
+        elif current is not None and "config.json" not in current[1]:
+            # The repo does not publish one, which the document just said. The absence
+            # probe below spends a round trip to be told the same, and it is the reason a
+            # GGUF-only repo cost this caller two reads where it used to cost one.
+            logger.debug("'%s' has no config.json on the Hub", model_name)
+            return None
         else:
             from huggingface_hub import hf_hub_download
             from utils.hf_probe import hf_file_definitely_absent
@@ -1548,9 +1554,20 @@ def _detect_audio_from_tokenizer(
                         # of the process, with the markers in the part that never arrived.
                         if may_answer_for_hub:
                             try:
-                                json.loads(raw)
+                                decoded = json.loads(raw)
                             except Exception:
                                 continue
+                            # The scan above reads the raw text, so a content written as
+                            # an escape does not match it -- and Go's encoding/json
+                            # escapes < and > that way by default, so it is a shape real
+                            # tooling uploads. Standing in for the Hub copy means
+                            # classifying what that copy would have classified: the
+                            # fallback below decodes before it looks, and a miss here is
+                            # a definitive negative cached for the life of the process.
+                            # The parse is already paid for; only the lookup is new.
+                            result = _check_token_patterns(decoded)
+                            if result:
+                                return result, True
                         elif not raw.rstrip().endswith("}"):
                             continue
                         read_any = True

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -739,8 +739,7 @@ def _current_cached_snapshot(
         return None
     try:
         repo_dir = get_cache_path(model_name)
-        # Cheap local check first: with nothing cached there is no snapshot to accept, and
-        # the repo document below would be a round trip spent to learn only that.
+        # Cheap check first: with nothing cached, the document below buys only that answer.
         if repo_dir is None or not (Path(repo_dir) / "snapshots").is_dir():
             return None
         info = _hub_model_info(model_name, hf_token)
@@ -754,12 +753,9 @@ def _current_cached_snapshot(
             getattr(sibling, "rfilename", None)
             for sibling in (getattr(info, "siblings", None) or ())
         }
-        # A document that named no files cannot distinguish a file the repo does not have
-        # from one that was not downloaded, which is the whole reason a caller asks for the
-        # list. Read as complete it is worse than nothing: every membership test comes back
-        # false, so a caller looking for paths it has yet to read finds none and takes the
-        # answer it already holds for the repo's. ``siblings`` is optional on the hub's own
-        # model, so this is a shape a real response can take.
+        # A document naming no files cannot tell a file the repo lacks from one not
+        # downloaded, and every membership test then reads as proof of absence. ``siblings``
+        # is optional on the hub's own model, so this shape is real.
         if not listed:
             return None
         return snapshot, listed
@@ -783,14 +779,10 @@ def _raw_config_has_vision_config(
         if is_local_path(model_name):
             config_path = Path(normalize_path(model_name)).expanduser() / "config.json"
         elif current is not None and (current[0] / "config.json").is_file():
-            # This is the repo's current commit and the file is in it, so the fetch below
-            # would return what is already here. Saves both the absence probe and the
-            # download's own freshness check.
+            # The current commit's own copy: skips the absence probe and the freshness check.
             config_path = current[0] / "config.json"
         elif current is not None and "config.json" not in current[1]:
-            # The repo does not publish one, which the document just said. The absence
-            # probe below spends a round trip to be told the same, and it is the reason a
-            # GGUF-only repo cost this caller two reads where it used to cost one.
+            # The document just said the repo publishes none; the probe below re-asks.
             logger.debug("'%s' has no config.json on the Hub", model_name)
             return None
         else:
@@ -1102,24 +1094,21 @@ def _hub_model_info(
 ):
     from huggingface_hub import model_info as hf_model_info
 
-    # The remote-LoRA probe in ``ModelConfig.from_identifier`` reads this call raising rather
-    # than guarding itself, and ``_offline_while_reading`` can force offline mid-request.
+    # ``from_identifier``'s remote-LoRA probe reads this call raising rather than guarding
+    # itself, and ``_offline_while_reading`` can force offline mid-request.
     scope = None if _env_offline() else _hub_model_info_scope.get()
     # The forced-anonymous sentinel is a credential of its own, so key on its fingerprint.
     key = (repo_id, _token_fingerprint(hf_token))
     if scope is not None:
         if key in scope:
             return scope[key]
-        # File sizes measure as free to ask for even on a repo of many quants, and asking
-        # unconditionally is what lets one response serve every probe: the variant listing
-        # needs them, and a response without them could not be shared with it.
+        # Asked unconditionally so one response serves every probe; the listing needs sizes.
         files_metadata = True
 
     kwargs: Dict[str, Any] = {
         "token": hf_token,
         "files_metadata": files_metadata,
-        # The response is shared, so whichever probe reads first decides the bound every
-        # later one inherits. Default it here rather than per call site.
+        # Shared, so whichever probe reads first fixes the bound the rest inherit.
         "timeout": _HUB_MODEL_INFO_TIMEOUT if timeout is None else timeout,
     }
     info = hf_model_info(repo_id, **kwargs)
@@ -1533,8 +1522,7 @@ def _detect_audio_from_tokenizer(
                         roots.append(snapshot)
 
         current: list = []  # resolved lazily: only a negative answer needs it
-        # Whether a read here could stand in for the Hub copy, which is the only case that
-        # has to prove the file is whole rather than merely marker-free.
+        # Only a read standing in for the Hub copy has to prove the file whole.
         may_answer_for_hub = not local_files_only and not is_local_path(model_name)
         for root in roots:
             root_read: set = set()
@@ -1545,26 +1533,18 @@ def _detect_audio_from_tokenizer(
                         continue
                     raw = tok_file.read_text(encoding = "utf-8-sig")
                     if not _may_hold_audio_tokens(raw):
-                        # No marker anywhere, so no pattern can match. Reading a local
-                        # checkpoint stops there: parsing these was the bulk of a cold
-                        # /loras scan, and the trailing "}" is enough to tell a whole file
-                        # from one a run is still writing. A read that will answer for the
-                        # Hub copy has to parse, since a half-written file ending in "}"
-                        # would otherwise be a definitive "not audio" cached for the life
-                        # of the process, with the markers in the part that never arrived.
+                        # No marker, no pattern can match. A local checkpoint stops at the
+                        # trailing "}" (parsing these was the bulk of a cold /loras scan);
+                        # answering for the Hub copy must parse, or a half-written file
+                        # ending in "}" is a definitive "not audio" cached for the process.
                         if may_answer_for_hub:
                             try:
                                 decoded = json.loads(raw)
                             except Exception:
                                 continue
-                            # The scan above reads the raw text, so a content written as
-                            # an escape does not match it -- and Go's encoding/json
-                            # escapes < and > that way by default, so it is a shape real
-                            # tooling uploads. Standing in for the Hub copy means
-                            # classifying what that copy would have classified: the
-                            # fallback below decodes before it looks, and a miss here is
-                            # a definitive negative cached for the life of the process.
-                            # The parse is already paid for; only the lookup is new.
+                            # The scan above reads raw text, so a marker written as an
+                            # escape misses it, and Go's encoding/json writes them that way.
+                            # The fallback decodes before it looks; standing in for it must too.
                             result = _check_token_patterns(decoded)
                             if result:
                                 return result, True
@@ -1581,11 +1561,9 @@ def _detect_audio_from_tokenizer(
                         return result, True
                 except Exception as e:
                     logger.debug(f"Could not read {tok_file} for {model_name}: {e}")
-            # Every tokenizer path the repo actually has was read here, so re-fetching them
-            # only re-reads what was just read -- and a repo with no ``LLM/`` layout pays a
-            # round trip to be told so. Anything less may answer positively but never
-            # negatively: a path that was not read still has somewhere for the markers to
-            # hide, and the answer below is cached for the life of the process.
+            # Every tokenizer path the repo has was read, so a fetch re-reads what is here.
+            # Anything less may answer positively but never negatively: an unread path can
+            # still hide the markers, and the negative below is cached for the process.
             if root_read and not is_local_path(model_name):
                 if not current:
                     current.append(_current_cached_snapshot(model_name, hf_token, local_files_only))

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -725,7 +725,8 @@ def _current_cached_snapshot(
 ):
     """This repo's cached snapshot for its current commit, with the files the repo lists.
 
-    Returns ``(snapshot, filenames)``, or None when there is no such snapshot. The commit
+    Returns ``(snapshot, filenames)``, or None when there is no such snapshot or the
+    document named no files, which is the same thing to a caller reading it. The commit
     and the file list both come from the repo document the request already reads, so a
     snapshot accepted here is as current as a revalidating fetch would be, and callers can
     tell a file the repo does not have from one that simply was not downloaded.
@@ -753,6 +754,14 @@ def _current_cached_snapshot(
             getattr(sibling, "rfilename", None)
             for sibling in (getattr(info, "siblings", None) or ())
         }
+        # A document that named no files cannot distinguish a file the repo does not have
+        # from one that was not downloaded, which is the whole reason a caller asks for the
+        # list. Read as complete it is worse than nothing: every membership test comes back
+        # false, so a caller looking for paths it has yet to read finds none and takes the
+        # answer it already holds for the repo's. ``siblings`` is optional on the hub's own
+        # model, so this is a shape a real response can take.
+        if not listed:
+            return None
         return snapshot, listed
     except Exception as exc:
         logger.debug("No current cached snapshot for '%s': %s", model_name, exc)

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -6,6 +6,7 @@
 import os
 import structlog
 import threading
+from contextvars import ContextVar
 import time
 from loggers import get_logger
 from contextlib import contextmanager
@@ -284,15 +285,51 @@ def hf_probe_disabled() -> bool:
     }
 
 
+# The memo above expires on wall-clock, which is right between requests and wrong inside
+# one: on a slow link a single model-config request outlives the TTL, so its later guards
+# re-probe and can even reach a different verdict than the guard that opened the request.
+_hf_reachability_pin: "ContextVar[Optional[list]]" = ContextVar("hf_reachability_pin", default = None)
+
+
+@contextmanager
+def pinned_hf_reachability():
+    """Hold one reachability verdict for this block, however long it runs.
+
+    Every verdict this module reaches fills it -- probed, already memoised, or opted out
+    of -- and the rest read it. Nothing is pinned until something asks, so a block that
+    never touches the Hub pays nothing.
+    """
+    token = _hf_reachability_pin.set([])
+    try:
+        yield
+    finally:
+        _hf_reachability_pin.reset(token)
+
+
+def _pin_reachability(verdict: bool) -> bool:
+    """Record the first verdict this request reaches, so every later read returns it."""
+    pinned = _hf_reachability_pin.get()
+    if pinned is not None and not pinned:
+        pinned.append(verdict)
+    return verdict
+
+
 def hf_reachability_memo() -> Optional[bool]:
-    """The memoised verdict while still fresh, else None.
+    """The pinned or memoised verdict while still usable, else None.
 
     Lets a caller skip a cheaper-but-still-slow shortcut it has already effectively run:
     one request opens several guards, and repeating a 2s DNS lookup per guard adds up.
     Lock-free like force_hf_offline_active: the tuple read is atomic.
     """
+    pinned = _hf_reachability_pin.get()
+    if pinned:
+        return pinned[0]
     cached = _hf_reachability
-    return cached[1] if _reachability_fresh(cached) else None
+    if not _reachability_fresh(cached):
+        return None
+    # Answering from the memo is producing a verdict, so it pins like any other: this is
+    # the usual way a request gets its first one, the memo being warm when it opens.
+    return _pin_reachability(cached[1])
 
 
 def reset_hf_reachability_cache() -> None:
@@ -312,17 +349,23 @@ def hf_unreachable(timeout: int = 3) -> bool:
     reachable and the load decides as it does today.
     """
     if hf_probe_disabled():
-        return False
+        # Pins like any other verdict: the opt-out is what the rest of the request should
+        # see, and leaving the pin empty sends every later guard back to its own DNS probe.
+        return _pin_reachability(False)
+
+    pinned = _hf_reachability_pin.get()
+    if pinned:
+        return pinned[0]
 
     global _hf_reachability
     cached = _hf_reachability
     if _reachability_fresh(cached):
-        return cached[1]
+        return _pin_reachability(cached[1])
 
     with _hf_reachability_lock:
         cached = _hf_reachability
         if _reachability_fresh(cached):
-            return cached[1]
+            return _pin_reachability(cached[1])
         try:
             from utils.transformers_version import hf_endpoint_unreachable
 
@@ -335,7 +378,7 @@ def hf_unreachable(timeout: int = 3) -> bool:
         except Exception:
             unreachable = False
         _hf_reachability = (time.monotonic(), unreachable)
-        return unreachable
+        return _pin_reachability(unreachable)
 
 
 def _reset_hf_sessions() -> None:

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -285,9 +285,8 @@ def hf_probe_disabled() -> bool:
     }
 
 
-# The memo above expires on wall-clock, which is right between requests and wrong inside
-# one: on a slow link a single model-config request outlives the TTL, so its later guards
-# re-probe and can even reach a different verdict than the guard that opened the request.
+# The memo above expires on wall-clock, right between requests and wrong inside one: a slow
+# request outlives the TTL, so its later guards re-probe and can disagree with the first.
 _hf_reachability_pin: "ContextVar[Optional[list]]" = ContextVar("hf_reachability_pin", default = None)
 
 
@@ -327,8 +326,7 @@ def hf_reachability_memo() -> Optional[bool]:
     cached = _hf_reachability
     if not _reachability_fresh(cached):
         return None
-    # Answering from the memo is producing a verdict, so it pins like any other: this is
-    # the usual way a request gets its first one, the memo being warm when it opens.
+    # Answering from the memo produces a verdict, and a warm memo is the usual first one.
     return _pin_reachability(cached[1])
 
 
@@ -349,17 +347,10 @@ def hf_unreachable(timeout: int = 3) -> bool:
     reachable and the load decides as it does today.
     """
     if hf_probe_disabled():
-        # Not pinned, because this is not a verdict: the opt-out declines to answer rather
-        # than finding the hub reachable, and pinning the decline answers for the DNS
-        # shortcut as well. UNSLOTH_OFFLINE_PROBE turns off the TCP probe, not DNS, so that
-        # shortcut is the only detector the opt-out leaves standing and every guard has to
-        # reach it. Pinned, guards 2..N of a request read "reachable" from the pin and never
-        # look again -- a link dropping mid-request goes unnoticed for the whole request,
-        # where an unpinned decline catches it on the next guard.
-        #
-        # It costs no probe to leave it open: a dead lookup returns before the caller ever
-        # gets here, so the repeat only happens while DNS is answering, which is a resolver
-        # cache hit.
+        # A declination, not a verdict, so it does not pin. UNSLOTH_OFFLINE_PROBE turns off
+        # the TCP probe and not DNS, and pinning here answers for the DNS shortcut too:
+        # guards 2..N read "reachable" and never look again. Leaving it open costs no
+        # lookup, since a dead one returns above this and never reaches here.
         return False
 
     pinned = _hf_reachability_pin.get()

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -349,9 +349,18 @@ def hf_unreachable(timeout: int = 3) -> bool:
     reachable and the load decides as it does today.
     """
     if hf_probe_disabled():
-        # Pins like any other verdict: the opt-out is what the rest of the request should
-        # see, and leaving the pin empty sends every later guard back to its own DNS probe.
-        return _pin_reachability(False)
+        # Not pinned, because this is not a verdict: the opt-out declines to answer rather
+        # than finding the hub reachable, and pinning the decline answers for the DNS
+        # shortcut as well. UNSLOTH_OFFLINE_PROBE turns off the TCP probe, not DNS, so that
+        # shortcut is the only detector the opt-out leaves standing and every guard has to
+        # reach it. Pinned, guards 2..N of a request read "reachable" from the pin and never
+        # look again -- a link dropping mid-request goes unnoticed for the whole request,
+        # where an unpinned decline catches it on the next guard.
+        #
+        # It costs no probe to leave it open: a dead lookup returns before the caller ever
+        # gets here, so the repeat only happens while DNS is answering, which is a resolver
+        # cache hit.
+        return False
 
     pinned = _hf_reachability_pin.get()
     if pinned:


### PR DESCRIPTION
## Problem

`GET /api/models/config/{model}` takes tens of seconds for a Hugging Face Hub repo that is already fully present in the local cache, while the same endpoint answers in ~28ms for a local filesystem path:

```text
GET /api/models/config/unsloth/Qwen3-0.6B                        200  27172.70ms
GET /api/models/config//Volumes/.../Qwen3.8-Flash-Next-3bit      200     28.72ms
```

The handler asks the Hub the same questions repeatedly. For one fully-cached repo it made roughly fifteen sequential round trips: several probes each fetched the repo document independently, the reachability guard re-probed within a single request, the audio probe re-fetched tokenizer files it had just read from disk, and the vision probe fetched `config.json` twice over.

The absolute timings here come from a poor connection, where a single TLS handshake to huggingface.co costs about 1.5s (`tls=1.548 total=2.071`). That latency is the multiplier, not the cause — on a fast link the same redundancy is present and merely cheaper. What this PR removes is the round-trip *count*.

## What changed

Four self-contained commits:

1. **Share one `model_info` read across the probes.** A request-scoped `contextvars` scope holds the repo document, keyed by repo and by token identity, so the probes that each fetched it now read one response. Scoped rather than cached on purpose: a repo that is gated or deleted between requests is still seen on the next one, and a 404 still beats a stale cache. The forced-anonymous sentinel is keyed as a credential of its own, so an anonymous probe never reads a response fetched with a token.

2. **Let the current cached snapshot answer the audio probe.** The local phase short-circuited only on a positive match, so a definitive "no audio tokens" still cost two round trips — one of them a guaranteed 404 for a repo with no `LLM/` layout. The probe now records which tokenizer paths it actually read from the snapshot and answers negatively only when every path the repo lists was among them; anything less still goes to the Hub, since a path the cache lacks may be exactly where the markers are.

3. **Hold one reachability verdict per request.** The reachability memo expires on wall-clock, which is right between requests and wrong inside one: on a slow link a single model-config request outlives the TTL, so the guards it opens later re-probe and can even reach a different verdict than the guard that admitted the request. A request-scoped pin holds the first verdict for the length of the request. Nothing is pinned until something asks, so a request that never touches the Hub pays nothing.

4. **Answer the vision probe from the current cached snapshot.** `_raw_config_has_vision_config` fetched `config.json` twice — once through the absence pre-check and once through the download's own freshness check, four HEAD requests for one file. Reading it from the cache instead needs only the repo's current commit, which the request already knows.

The last two rest on one helper. `_current_cached_snapshot` takes the current commit and the repo's file list from the document the request is already reading, and looks only for the snapshot directory that commit names. Two things follow that a directory listing alone cannot establish: the snapshot is the current revision, so a stale one left behind by an earlier download cannot answer, and the file list distinguishes a file the repo does not have from one that simply was not downloaded. Learning the commit is itself a network read, so a caller under `local_files_only` gets nothing from it and falls back on paths that read the cache without one, an anonymous caller is refused it since reading the cache authorizes nothing, and a repo with nothing cached never triggers it at all.

## Impact

Measured on `unsloth/gemma-4-E2B-it-UD-MLX-4bit`, fully cached, on the slow connection described above:

| probe | before | after |
|---|---|---|
| reachability guard | 3.03s | one probe per request instead of several |
| `is_vision_model` | 5.87s | 0.50s |
| `is_embedding_model` | 0.48s | 0.00s |
| `detect_audio_type_checked` | 7.23s | 0.00s |
| `ModelConfig.from_identifier` | 1.92s | 0.00s |
| `_get_model_size_bytes` | 3.25s | unchanged — see below |

Every probe that reads the repo document now shares one response, so a single `/api/models/<repo>` request serves the handler. `_get_model_size_bytes` is the exception: it still makes its own `repo_info` call, exactly as on `main`.

## What this PR does not fix

`_get_model_size_bytes` sums `sibling.size` but calls `repo_info` without `files_metadata`, so every sibling reports `None` and the function returns `None` for **every** Hub repo — a round trip per request to produce a null `model_size_bytes`. That is a real bug and it is left alone here.

An earlier revision of this PR fixed it, and the fix was withdrawn. Asking for `files_metadata` is the easy half; deciding which files one load actually reads is not, and getting it wrong is worse than returning nothing, because the frontend picks LoRA or QLoRA from the number. Successive attempts each produced a wrong size for some real repository — subdirectory copies summed with the checkpoint (`FLUX.1-dev` at 58GB against the 24GB it loads), a whole `model.safetensors` summed with its own shards, `consolidated.safetensors` doubling `Mistral-7B-Instruct-v0.3`, fp32 variants tripling `whisper-large-v3`, a multi-component pipeline reported as one 498GB model, and finally an *undercount* when a stale shard sits beside a live index, which would choose LoRA for a model that does not fit.

They share one cause: which files a checkpoint comprises is knowable only from the index's `weight_map`, and reading that costs a file download per request — the exact round trip this PR exists to remove. Sizing therefore belongs in its own change, with its own measurements, not in a latency PR. Until then `model_size_bytes` stays null for Hub repos, as it is on `main` today.

## Risks and tradeoffs

- The shared scope is deliberately per-request. It does not persist, so it cannot serve a stale answer to a later request, and it is not shared between requests or threads.
- Commits 2 and 4 trust the local cache in place of a network read. They do so only for the snapshot the repo document names as the current commit, and only for files that document lists, so a stale snapshot and a never-downloaded file are both excluded.
- Every scoped read asks for `files_metadata` whether or not the caller wanted it, so one response serves the GGUF variant listing as well as the probes that ignore sizes. Asking costs nothing measurable even for a repo of many quants: 0.613s against 0.550s on the 31-file `unsloth/Qwen3-8B-GGUF`.
- Every scoped read is also bounded by a timeout at the shared reader rather than at each call site. The response is shared, so whichever probe reads first fixes the bound the rest inherit.
- The reachability pin narrows the guards' re-probing rather than removing it: the dead-DNS shortcut in the llama.cpp guard still answers for itself without filling the pin.
- Answering from the cache accepts one form of staleness that a fetch would not: the repo document names the current commit, but a commit pushed between that read and the answer is not seen. That window is the request itself, and the cached snapshot is what a subsequent load of the model would use.

## Validation

```bash
cd studio/backend
python -m pytest tests/test_offline_gguf_cache_fallback.py tests/test_audio_token_detection.py \
    tests/test_vision_cache.py tests/test_models_get_model_config_case_resolution.py \
    tests/test_offline_inference_parent.py tests/test_training_preflight_offline_guard.py \
    tests/test_hub_token_caller_identity.py tests/test_load_subdirs_stay_offline.py \
    tests/test_memory_estimate.py tests/test_gguf_variant_rows.py -q -p no:randomly
# 710 passed
```

Each commit was also verified to pass on its own (294 / 303 / 312 / 322). Every added test was mutation-checked: each guard was reverted in turn and exactly the covering test failed — the scope lookup, the token component of the scope key, the offline bypass, the read bound, both cache fast paths, selection by commit rather than directory order, the undownloaded-file check, the revision pin, the anonymity refusal, the `local_files_only` refusal, and the reachability pin including the memo-read and probe-disabled paths.
