### PR TITLE
unsloth_cli tests: stop the mklink kwargs assertion breaking on an unrelated keyword

### DIFF
--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1144,12 +1144,22 @@ def test_create_directory_junction_uses_windows_mklink(tmp_path, monkeypatch):
         str(target),
         str(source),
     ]
-    assert captured["kwargs"] == {
+    # Whole-dict equality made this a tripwire for any unrelated keyword. #10192
+    # added encoding/errors so a localized Windows console cannot lose the child's
+    # whole output stream, and this assertion went red on a change that had nothing
+    # to do with junctions. Pin the values the call has to keep, and separately
+    # refuse a shell, instead of forbidding every future keyword.
+    kwargs = captured["kwargs"]
+    for key, value in {
         "capture_output": True,
         "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
         "timeout": 30,
         "check": False,
-    }
+    }.items():
+        assert kwargs[key] == value, f"{key} = {kwargs.get(key)!r}"
+    assert not kwargs.get("shell", False), "mklink must not go through a shell"
 
 
 @pytest.mark.skipif(os.name == "nt", reason = "WSL scenario")


### PR DESCRIPTION
`Repo tests (CPU)` runs `unsloth_cli/tests` as its last step, so nothing there reports while an earlier step is red. With the `tests/` step failing on `test_context_dependent_unsloth_zoo_findings_are_digest_pinned` (#10206), this has been hidden:

```
FAILED unsloth_cli/tests/test_start.py::test_create_directory_junction_uses_windows_mklink
E   AssertionError: assert {'capture_out...replace', ...} == {'capture_out...check': False}
E     Full diff:
E       {
E           'capture_output': True,
E           'text': True,
E     +     'encoding': 'utf-8',
E     +     'errors': 'replace',
E           'timeout': 30,
E           'check': False,
E       }
```

#10192 added `encoding = "utf-8", errors = "replace"` to `_create_directory_junction`'s `subprocess.run` so a localized Windows console cannot lose the child's whole output stream. That change is right. The test was the problem: it asserted whole-dict equality on the captured kwargs, so it is a tripwire for any keyword the call gains, related or not.

This pins the values the call has to keep, and refuses a shell separately, rather than forbidding every future keyword:

- dropping `encoding`/`errors` still fails, so the decode fix #10192 made stays guarded
- so does flipping `check`, `capture_output`, `text`, or the timeout
- adding an unrelated keyword no longer fails
- `shell = True` fails on its own assertion with its own message

Once #10206 lands and the `tests/` step goes green, this is what `Repo tests (CPU)` fails on next, on every open PR. Verified locally on `origin/main`: `unsloth_cli/tests/test_start.py` goes from 1 failed / 601 passed to 602 passed / 3 skipped.
