### PR TITLE
CI: stop grep -c || echo 0 producing a two-line count

### DIFF
--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -613,7 +613,11 @@ jobs:
 
           echo "::warning::bulk resolve failed (exit $rc), falling back to per-pin best effort"
           grep -E "^ERROR: (Could not find|No matching|Ignored)" /tmp/install_seed.log | head -20 || true
-          total=$(grep -c . /tmp/seed_pins.txt || echo 0)
+          # `|| true`: grep -c prints 0 and exits 1 on no match, so `|| echo 0`
+          # appended a second line and the annotations below became multi-line,
+          # which GitHub truncates after the first.
+          total=$(grep -c . /tmp/seed_pins.txt || true)
+          total=${total:-0}
           done_n=0; failed_n=0
           # Bounded, because an unbounded fallback is how this job spent 112 days
           # being scored `cancelled`. Running out of budget is a failure with a

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -182,11 +182,21 @@ jobs:
       - name: Built bundle must not contain Unsloth's unstable_Provider call site
         run: |
           set -e
-          JS=$(ls dist/assets/index-*.js | head -1)
-          HITS=$(grep -c 'unstable_Provider:' "$JS" || echo 0)
+          # `ls | head` takes its status from head, so a missed glob leaves JS
+          # empty and set -e never sees it. grep would then exit 2 on "" and the
+          # guard would pass on a bundle nobody looked at.
+          JS=$(ls dist/assets/index-*.js 2>/dev/null | head -1)
+          if [ ! -f "$JS" ]; then
+            echo "::error::no dist/assets/index-*.js to scan, so the build produced no main bundle"
+            exit 1
+          fi
+          # `|| true`, not `|| echo 0`: on no match grep -c PRINTS 0 and exits 1,
+          # so the fallback appended a second line and the -gt below died with
+          # "integer expression expected" on every green run.
+          HITS=$(grep -c 'unstable_Provider:' "$JS" || true)
           echo "main bundle: $JS"
-          echo "unstable_Provider: hits=$HITS (assistant-ui internals contribute up to 3)"
-          if [ "$HITS" -gt 3 ]; then
+          echo "unstable_Provider: hits=${HITS:-0} (assistant-ui internals contribute up to 3)"
+          if [ "${HITS:-0}" -gt 3 ]; then
             echo "::error file=studio/frontend/src/features/chat/runtime-provider.tsx::Unsloth bundle still passes unstable_Provider through useRemoteThreadListRuntime; this is the 2026.5.1 chat-history regression. Pass adapters directly into useLocalRuntime instead."
             exit 1
           fi


### PR DESCRIPTION
`grep -c` prints `0` **and** exits 1 when nothing matches, so `$(grep -c ... || echo 0)` appends a second line and the variable holds `0\n0`. Two places in the workflows do that.

## studio-frontend-ci.yml

```
JS=$(ls dist/assets/index-*.js | head -1)
HITS=$(grep -c 'unstable_Provider:' "$JS" || echo 0)
...
if [ "$HITS" -gt 3 ]; then
```

The bundle has zero hits today, so every run of `Frontend build + bundle sanity` logs

```
main bundle: dist/assets/index-Dn5EVPb7.js
unstable_Provider: hits=0
0 (assistant-ui internals contribute up to 3)
/home/runner/work/_temp/....sh: line 6: [: 0
0: integer expression expected
```

`set -e` does not catch it because the `[` is a condition, so the step stays green while printing a shell error and a mangled diagnostic. Visible on any recent run, for example https://github.com/unslothai/unsloth/actions/runs/33731460431.

The guard itself is not dead in the direction that matters: with real matches `grep -c` exits 0, `|| echo 0` never runs, and the comparison fires correctly. I checked that with a 4-match fixture.

What the noise was hiding is the line above it. `ls dist/assets/index-*.js | head -1` takes its exit status from `head`, so a missed glob leaves `$JS` empty and `set -e` never sees it. `grep -c PAT ""` then exits 2 printing nothing, `|| echo 0` yields a clean single-line `0`, and the step passes green on a bundle nobody looked at. That is a failure-open in a regression gate, and it is the reason to touch this at all.

So this now checks the bundle exists before scanning it, and uses `|| true` with a `${HITS:-0}` default, which also covers the grep exit-2 case where nothing is printed.

Verified all three paths in bash:

| case | before | after |
|---|---|---|
| zero matches | `[: 0\n0: integer expression expected`, step green | `hits=0`, pass, no error |
| four matches | fires correctly | fires correctly |
| no `index-*.js` | passes green without scanning | `::error::no dist/assets/index-*.js to scan`, exit 1 |

## notebooks-ci.yml

The seed-pin fallback counter has the same shape. That value is only interpolated into `::error::`/`::warning::` annotations, never into a numeric test, so the cost is a two-line annotation that GitHub truncates after the first line. Same one-line fix while it is open.

## Scope

I swept the tree for the pattern: those are the only two. `.github/workflows/cache-janitor.yml:187` and the `tests/sh/` suite already use `|| true`, and the remaining `|| echo 0` sites are non-counting commands whose failure prints nothing, so the fallback is sound there.

Nothing here changes what any check passes or fails on today.

## Unrelated, while I was in this job

`Frontend build + bundle sanity` was red on `main` and 15 open PRs for `over the startup budget: transfer 1568.0 KB > 1562.5 KB`. #10054 has since raised `BUDGET.transferBytes` to 1,620,000, so that is green again and this PR does not touch it.

Worth knowing where those bytes went, though. `assets/api-provider-logo-*.js` is 303.2 KB raw / 80.8 KB transfer on the eager startup path and is 96% `node-forge`: `x509.js` 56.9 KB, `tls.js` 55.8 KB, `util.js` 35.7 KB, `jsbn.js` 31.1 KB, `rsa.js` 30.2 KB, `ed25519.js` 23.1 KB. It arrives from two static imports, `studio/frontend/src/features/chat/api/providers-api.ts:4` and `studio/frontend/src/features/chat/utils/chat-attachment-events.ts:11`. Both call sites are already `async`: one encrypts a provider API key when you save one in Settings, the other is a fallback SHA-256 for when `crypto.subtle` is unavailable. `node-forge`'s default export is a non-tree-shakeable barrel, so one `md.sha256.create()` pulls the whole X.509/TLS/PKCS library onto the boot path.

Making both dynamic measures at 1495.9 KB transfer / 4984.4 KB raw against 1568.0 / 5259.1, so 72.1 KB of transfer back, no change in chunk count, and the eager path returns to roughly what it measured when the budget was first calibrated at `17363f8a2`. That is more than the 57.5 KB the ceiling was just raised by. I have left it out of this PR since it is a frontend change and not a CI one, but it is there if someone wants the headroom back rather than the raised ceiling.
