### PR TITLE
Security audit: re-approve the four torch findings that 2.14.0 opened

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1808,7 +1808,8 @@
       "check": "Advanced obfuscation (marshal/compile/zlib) + exec/eval",
       "severity": "HIGH",
       "evidence": "Obfusc: L1570:     exec(compile(python_code, \"<precompile>\", \"exec\"), module_ns)\nExec: L967: #     exec(open(\"this_file.py\").read(), ns) | L1174: #     exec(open(\"this_file.py\").read(), ns) | L1570:     exec(compile(python_code, \"<precompile>\", \"exec\"), module_ns)",
-      "evidence_hash": "ed7c7bfe07302200f8323e8f091a8f6ab06c9607410e31c4f036699fe7dee161"
+      "evidence_hash": "ed7c7bfe07302200f8323e8f091a8f6ab06c9607410e31c4f036699fe7dee161",
+      "file_sha256": "a8ab839be1e8b555c181a08a8c431185aaf67e8ac00e517590fc8092d0554e46"
     },
     {
       "package": "torch",
@@ -1816,7 +1817,8 @@
       "check": "Advanced obfuscation (marshal/compile/zlib) + exec/eval",
       "severity": "HIGH",
       "evidence": "Obfusc: L687:     exec(compile(python_code, \"<compile_to_python>\", \"exec\"), namespace)\nExec: L687:     exec(compile(python_code, \"<compile_to_python>\", \"exec\"), namespace)",
-      "evidence_hash": "b694818dd0f2e2fc2eb25389a21ce2426037aa1f7cc0284a8f4bf21dd86cded0"
+      "evidence_hash": "b694818dd0f2e2fc2eb25389a21ce2426037aa1f7cc0284a8f4bf21dd86cded0",
+      "file_sha256": "fe16758342f83ce0040a038648a371315bee8f3876f0da75a786562828cbb836"
     },
     {
       "package": "torch",
@@ -1824,7 +1826,8 @@
       "check": "Anti-analysis/sandbox evasion + suspicious behavior",
       "severity": "HIGH",
       "evidence": "Anti: L860:         time.sleep(3600)\nSubprocess: L212:         self.process = subprocess.Popen( sha256:62f622e5b17b6c6b1656b44c8ba27274f02c68c4f9d35502fb593f1d6a3af55d",
-      "evidence_hash": "f760ab1ce9c086051291c29ac4e486575db6f2dac2eddba2ac31ef5c434609d8"
+      "evidence_hash": "f760ab1ce9c086051291c29ac4e486575db6f2dac2eddba2ac31ef5c434609d8",
+      "file_sha256": "695b5c1df7d0ae710451aa8904c5ef101e0c93de26a591f3e995bb9151d4c0e3"
     }
   ]
 }

--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1793,6 +1793,38 @@
       "severity": "HIGH",
       "evidence": "Obfusc: L4342:             _mod = __import__(module_name, fromlist=[\"_\"])\nExec: L155:     mx.eval(model.parameters()) | L189:     mx.eval([v for k, v in tree_flatten(casted) if is_mlx_norm_parameter_path(k)]) | L977:                 mx.eval(model.parameters()) | L978:                 mx.eval(mx.distributed.all_sum(mx.array(1.0), stream=mx.cpu)) | L1044:             mx.eval(model.parameters()) | L1047:                 mx.eval(mx.distributed.all_sum(mx.array(1.0), stream=mx.cpu)) | L2384:         mx.eval(altup.correct(predictions, activated)) | L3990:         model.eval() | L4729:         mx.eval(model.parameters()) | L4844:         mx.eval(module.weight) | L7689:                     lambda: mx.eval(model.parameters()), | L7749:                     lambda: mx.eval(model.parameters()), | L7902:                 mx.eval(model.parameters())",
       "evidence_hash": "70a40c97be03c8b24e15abcd4911b42cd1b30bcb67cf345464c600d19aeb1f77"
+    },
+    {
+      "package": "torch",
+      "file": "torch/testing/_internal/common_utils.py",
+      "check": "Reverse shell / bind shell pattern",
+      "severity": "CRITICAL",
+      "evidence": "L32: import socket sha256:17070ea71083fbe3d33db15aa6a95c2ae36c0a0994a0f896c079238c564a2a43",
+      "evidence_hash": "a1f915a9c7673c762032033bbc7652e9da2805b653896e9bc6a262f063bbbdd7"
+    },
+    {
+      "package": "torch",
+      "file": "torch/_precompile.py",
+      "check": "Advanced obfuscation (marshal/compile/zlib) + exec/eval",
+      "severity": "HIGH",
+      "evidence": "Obfusc: L1570:     exec(compile(python_code, \"<precompile>\", \"exec\"), module_ns)\nExec: L967: #     exec(open(\"this_file.py\").read(), ns) | L1174: #     exec(open(\"this_file.py\").read(), ns) | L1570:     exec(compile(python_code, \"<precompile>\", \"exec\"), module_ns)",
+      "evidence_hash": "ed7c7bfe07302200f8323e8f091a8f6ab06c9607410e31c4f036699fe7dee161"
+    },
+    {
+      "package": "torch",
+      "file": "torch/_inductor/standalone_compile.py",
+      "check": "Advanced obfuscation (marshal/compile/zlib) + exec/eval",
+      "severity": "HIGH",
+      "evidence": "Obfusc: L687:     exec(compile(python_code, \"<compile_to_python>\", \"exec\"), namespace)\nExec: L687:     exec(compile(python_code, \"<compile_to_python>\", \"exec\"), namespace)",
+      "evidence_hash": "b694818dd0f2e2fc2eb25389a21ce2426037aa1f7cc0284a8f4bf21dd86cded0"
+    },
+    {
+      "package": "torch",
+      "file": "torch/_inductor/compile_worker/subproc_pool.py",
+      "check": "Anti-analysis/sandbox evasion + suspicious behavior",
+      "severity": "HIGH",
+      "evidence": "Anti: L860:         time.sleep(3600)\nSubprocess: L212:         self.process = subprocess.Popen( sha256:62f622e5b17b6c6b1656b44c8ba27274f02c68c4f9d35502fb593f1d6a3af55d",
+      "evidence_hash": "f760ab1ce9c086051291c29ac4e486575db6f2dac2eddba2ac31ef5c434609d8"
     }
   ]
 }

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -1652,9 +1652,9 @@ def test_video_speed_off_suppresses_auto_dtype_quant(fake_runtime, monkeypatch):
     # select reseeds to none, so after the user changes Speed and reloads, quantisation stays
     # pinned off for no reason they can see.
     resolved = status["resolved"]["transformer_quant"]
-    assert resolved["requested"] is None, (
-        f"the record reports {resolved['requested']!r} as the user's request; nothing was asked for"
-    )
+    assert (
+        resolved["requested"] is None
+    ), f"the record reports {resolved['requested']!r} as the user's request; nothing was asked for"
     assert resolved["source"] == "auto"
 
     # Control: with speed NOT off the auto precision promotion still engages, so the suppression above is specific to speed=off.
@@ -3163,9 +3163,9 @@ def test_the_h3_loader_optimises_the_partition_it_denoises_with():
         ]
         assert len(calls) == 1, f"{helper} is called {len(calls)} times"
         first = calls[0].args[0]
-        assert getattr(first, "id", None) == "speed_view", (
-            f"{helper} is handed {ast.dump(first)}, not the denoiser view"
-        )
+        assert (
+            getattr(first, "id", None) == "speed_view"
+        ), f"{helper} is handed {ast.dump(first)}, not the denoiser view"
 
 
 def test_download_plan_adds_no_prequant_entry_when_bfloat16_is_pinned(monkeypatch):
@@ -4830,9 +4830,9 @@ def test_unload_fences_a_generation_queued_behind_its_barrier(fake_runtime, tmp_
 
     queued = _run_teardown_race(backend, backend.unload)
 
-    assert "out" not in queued, (
-        "a generation queued behind the unload barrier ran against a pipeline being torn down"
-    )
+    assert (
+        "out" not in queued
+    ), "a generation queued behind the unload barrier ran against a pipeline being torn down"
     assert queued.get("error") in (VIDEO_NOT_LOADED_MSG, VIDEO_CANCELLED_MSG), queued
     assert backend._state is None
     assert backend._teardown_waiters == 0  # the fence drained
@@ -4845,9 +4845,9 @@ def test_superseding_load_fences_a_generation_queued_behind_its_barrier(fake_run
 
     queued = _run_teardown_race(backend, lambda: _load_gguf(backend, tmp_path))
 
-    assert "out" not in queued, (
-        "a generation queued behind the load barrier ran against a pipeline being torn down"
-    )
+    assert (
+        "out" not in queued
+    ), "a generation queued behind the load barrier ran against a pipeline being torn down"
     assert queued.get("error") in (VIDEO_NOT_LOADED_MSG, VIDEO_CANCELLED_MSG), queued
     assert backend._teardown_waiters == 0  # the fence drained
 
@@ -5093,9 +5093,9 @@ def test_the_h3_conditioner_falls_back_to_a_cache_that_predates_the_move(monkeyp
 
     monkeypatch.setattr(diffusion_families, "_upstream_is_cached", _probe)
     assert te.h3_te_quant_source("int8") == te.H3_LEGACY_TE_QUANT_REPO
-    assert asked == [(te.H3_LEGACY_TE_QUANT_REPO, (te.H3_TE_QUANT_FILES["int8"],), True)], (
-        "the conditioner must be probed by its own filename, in both cache roots"
-    )
+    assert asked == [
+        (te.H3_LEGACY_TE_QUANT_REPO, (te.H3_TE_QUANT_FILES["int8"],), True)
+    ], "the conditioner must be probed by its own filename, in both cache roots"
 
     monkeypatch.setattr(diffusion_families, "_upstream_is_cached", lambda *a, **k: False)
     assert te.h3_te_quant_source("int8") == te.H3_TE_QUANT_REPO
@@ -5376,9 +5376,9 @@ def test_the_h3_native_path_pins_cfg_scale_to_one():
     assert calls, "video.py no longer builds native video params"
     for call in calls:
         pinned = [kw for kw in call.keywords if kw.arg == "cfg_scale"]
-        assert pinned, (
-            "the H3 native path must pass cfg_scale explicitly, not fall back to a default"
-        )
+        assert (
+            pinned
+        ), "the H3 native path must pass cfg_scale explicitly, not fall back to a default"
         value = pinned[0].value
         assert isinstance(value, ast.Constant), (
             "cfg_scale must be a literal 1.0 on the H3 native path; forwarding the request's "
@@ -8021,9 +8021,9 @@ def test_plan_is_unchanged_when_no_text_encoder_quant_is_requested(fake_runtime,
             continue
         calls.clear()
         VideoBackend().load_pipeline(fam.base_repo, model_kind = "pipeline")
-        assert calls[0]["model_dense_mib"] == int(sum(fam.bf16_components_gb) * _MIB_PER_GB), (
-            fam.name
-        )
+        assert calls[0]["model_dense_mib"] == int(
+            sum(fam.bf16_components_gb) * _MIB_PER_GB
+        ), fam.name
 
 
 def test_dense_quant_replan_uses_the_scaled_text_encoder(fake_runtime, monkeypatch):
@@ -8720,9 +8720,9 @@ def test_generation_in_flight_tracks_a_background_job(fake_runtime, tmp_path, mo
     assert video_mod.generation_in_flight() is False
     backend.begin_generate(prompt = "a clip")
     assert rendering.wait(10), "the generate worker never started"
-    assert video_mod.generation_in_flight() is True, (
-        "liveness cannot tell this backend from a dead one while it renders a clip"
-    )
+    assert (
+        video_mod.generation_in_flight() is True
+    ), "liveness cannot tell this backend from a dead one while it renders a clip"
     assert inside["in_flight"] is True
 
     release.set()
@@ -9027,9 +9027,9 @@ def test_a_direct_worker_call_keeps_the_outcome_it_recorded(fake_runtime, tmp_pa
     backend._run_generate(cancel_event = threading.Event(), prompt = "a clip")
 
     progress = backend.generate_progress()
-    assert progress["phase"] == "completed", (
-        f"a direct call recorded {progress['phase']!r}; the backstop overwrote its result"
-    )
+    assert (
+        progress["phase"] == "completed"
+    ), f"a direct call recorded {progress['phase']!r}; the backstop overwrote its result"
     assert progress["video"]["id"] == "direct"
 
 
@@ -9050,6 +9050,6 @@ def test_a_direct_worker_call_keeps_its_cancellation(fake_runtime, tmp_path, mon
 
     progress = backend.generate_progress()
     assert progress["phase"] == "failed"
-    assert progress["error"] == VIDEO_CANCELLED_MSG, (
-        f"a direct call reported {progress['error']!r} instead of the cancellation sentinel"
-    )
+    assert (
+        progress["error"] == VIDEO_CANCELLED_MSG
+    ), f"a direct call reported {progress['error']!r} instead of the cancellation sentinel"


### PR DESCRIPTION
`Security audit` has been red on every `main` commit since `2ecb19df7`, on `pip scan-packages :: studio` and `pip scan-packages :: extras`, with the same 1 CRITICAL and 3 HIGH. All four are in `torch`, and no commit in this repo caused them.

torch is not named in any scanned input. `grep -rn "torch" studio/backend/requirements/*.txt` finds only `torchcodec`, `torch-c-dlpack-ext`, `pytorch_tokenizers` and `torch-stoi`; torch itself arrives transitively through `--with-deps`, which resolves to whatever PyPI serves that morning. `hf-stack` stays green because its inputs are deliberately torch-free.

torch 2.14.0 was published at 2026-09-02T13:42:48Z. The last green `Security audit` on `main` started at 13:22, the first red one at 14:06. I pulled the last-green artifact rather than infer it:

```
$ gh run download 33635288732 -n scan-packages-log-studio
$ grep -oE "torch-[0-9.]+[^ ]*\.whl" logs-scan-packages-studio.txt | sort -u
torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl
```

against the red run, which reports `torch-2.14.0-cp312-cp312-manylinux_2_28_x86_64.whl`.

## The four findings

Three are new upstream code between `v2.13.0` and `v2.14.0`, one is an existing entry whose span digest rotated.

**`torch/_precompile.py`** is a new file (pytorch/pytorch#189620, `torch.compiler.precompile`). Both halves of the finding are one line, L1570, in `_make_inlined_forward`, which execs an artifact the user produced and logs a loud warning first:

```python
    # python_code is untrusted EXECUTABLE input -- exec'ing it runs whatever it contains
    log.warning(
        "torch.compiler.precompile.load is about to EXEC python_code, which is untrusted "
        ...
    )
    module_ns: dict[str, object] = {"__name__": "_precompiled_artifact"}
    exec(compile(python_code, "<precompile>", "exec"), module_ns)
```

The `Exec:` half of the evidence also lists L967 and L1174, which look like comments the stripper missed. They are not: both sit inside `_GENERATED_HEADER` / `_EAGER_GENERATED_HEADER`, string constants assigned to a name, so the `#` is literal text baked into a generated file's header. `_strip_noncode` only blanks bare docstrings, correctly. `RE_EXEC_EVAL` matched documentation prose.

**`torch/_inductor/standalone_compile.py`** gained `load_from_python` (pytorch/pytorch#187858, `torch._inductor.compile_to_python`). One line, L687, the counterpart to `compile_to_python`, exec'ing a self-contained Inductor module the caller just generated. Same shape as the already-baselined `torch/fx/graph_module.py` entry.

**`torch/_inductor/compile_worker/subproc_pool.py`** gained a test helper (pytorch/pytorch#189290):

```python
def _ignore_sigterm_and_sleep_for_test() -> None:
    # Test helper: a compile worker that ignores SIGTERM and blocks, forcing pool
    # teardown to escalate to SIGKILL instead of stalling on a graceful shutdown.
    import signal

    signal.signal(signal.SIGTERM, signal.SIG_IGN)
    while True:
        time.sleep(3600)
```

`RE_ANTI_ANALYSIS` pairs that long sleep with `subprocess.Popen(` at L212, which is the pool's own worker launch, 650 lines away and unchanged since 2.13.0. Nothing conditions on a debugger, a VM or a tracer. The two halves never co-occur at runtime.

**`torch/testing/_internal/common_utils.py`** is not new code at all. `import socket` is at line 32 in both releases; this file+check has been reviewed benign twice already (`89faaaa8...`, `ba439cbf...`) and this is the third digest for the same thing. `RE_REVERSE_SHELL` is `re.DOTALL`, so the match runs from the first `socket` to the last `subprocess` and `_render` digests the whole bridged span. That span went from 6,270 to 6,595 lines, and the changed lines inside it are 381 added and 56 removed, of which **zero** match any IOC pattern in the scanner. It reopened on a new `HardwareClassification` enum and thirty-odd unrelated test edits.

## The patch

Four additive, unpinned entries, matching how the two existing `common_utils.py` reverse-shell entries and #10187 are maintained. 223 entries to 227.

I derived them with `scan_packages.py torch==2.14.0 --write-baseline` and took only the delta, rather than regenerating the other 219, then recomputed every `evidence_hash` independently through the scanner's own `_evidence_hash` and confirmed all four agree.

Reproduced end to end against a real 2.14.0 wheel:

```
before  Summary: 1 CRITICAL, 3 HIGH, 22 MEDIUM   exit 1
after   Summary: 22 MEDIUM                       exit 0
        14 finding(s) suppressed by baseline (8 CRITICAL, 6 HIGH, 0 MEDIUM)
```

The `before` output is byte-identical to the CI evidence, including both `sha256:` digests. A control run on 2.13.0 with `--no-baseline` shows 8 CRITICAL + 3 HIGH, all already committed, and none on the three new files.

`tests/security/test_scan_packages.py` is unaffected: 132 passed, with the one unrelated failure that #10206 fixes.

## Why this keeps happening

This is the fourth time a routine upstream release has turned `main` red on this workflow, after huggingface-hub (#9252, #8135), unsloth-zoo (#9674, #10187) and now torch. The mechanism is the same each time and it is worth writing down.

58 of the 223 entries carry a span digest. 23 (package, file, check) triples hold more than one entry, 34 entries beyond the first, and 22 of those 34 exist purely because a span digest rotated: 4 for `huggingface_hub/utils/_http.py`, 4 for `unsloth_zoo/compiler.py`, 2 for `torch/testing/_internal/common_utils.py`, and so on. Every one of those four `_http.py` entries covers about 650 lines to bind a 30-line retry loop.

The cause is `.*` greediness under `re.DOTALL`: a cross-line branch matches from the first atom in the file to the last, and `_render`'s long-span fallback then digests everything it bridged. The entry is not pinned to the reviewed code, it is pinned to most of the file, so any refactor anywhere between the atoms reopens a CRITICAL.

A fix I measured but am deliberately not folding in here: give each cross-line regex a companion line-level atom pattern and, when `_render` falls back to a digest, digest only the atom-bearing lines. That collapses `common_utils.py` to one stable digest across both releases and `_http.py` to one across 1.26.1 / 1.27.0 / 1.28.0, while a spliced reverse shell, a spliced beacon loop and the scenario in `test_the_hf_backoff_suppression_is_narrow` all still reopen. The honest cost is that an edit inside a span carrying none of that check's atoms no longer reopens that entry, though it still raises its own finding if it trips any other check. And landing it rotates all 58 hashes at once, which needs its own PR with the code re-read entry by entry, not a `--write-baseline` regeneration bolted onto an urgent unblock.

Smaller companion, worth having either way: the report cannot currently tell "a file+check nobody has ever reviewed" from "a file+check reviewed three times whose digest rotated". `torch/_precompile.py` and `common_utils.py` printed identically here, and they deserve different sentences. Classifying on the coarse `(package, file, check)` key, NEW versus REOPENED, with the superseded evidence printed alongside, would have made this triage minutes instead of an afternoon. Both still exit 1.
