### PR TITLE
Format test_video_backend.py the way the pinned ruff wants

### DIFF
--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -1652,9 +1652,9 @@ def test_video_speed_off_suppresses_auto_dtype_quant(fake_runtime, monkeypatch):
     # select reseeds to none, so after the user changes Speed and reloads, quantisation stays
     # pinned off for no reason they can see.
     resolved = status["resolved"]["transformer_quant"]
-    assert resolved["requested"] is None, (
-        f"the record reports {resolved['requested']!r} as the user's request; nothing was asked for"
-    )
+    assert (
+        resolved["requested"] is None
+    ), f"the record reports {resolved['requested']!r} as the user's request; nothing was asked for"
     assert resolved["source"] == "auto"
 
     # Control: with speed NOT off the auto precision promotion still engages, so the suppression above is specific to speed=off.
@@ -3163,9 +3163,9 @@ def test_the_h3_loader_optimises_the_partition_it_denoises_with():
         ]
         assert len(calls) == 1, f"{helper} is called {len(calls)} times"
         first = calls[0].args[0]
-        assert getattr(first, "id", None) == "speed_view", (
-            f"{helper} is handed {ast.dump(first)}, not the denoiser view"
-        )
+        assert (
+            getattr(first, "id", None) == "speed_view"
+        ), f"{helper} is handed {ast.dump(first)}, not the denoiser view"
 
 
 def test_download_plan_adds_no_prequant_entry_when_bfloat16_is_pinned(monkeypatch):
@@ -4830,9 +4830,9 @@ def test_unload_fences_a_generation_queued_behind_its_barrier(fake_runtime, tmp_
 
     queued = _run_teardown_race(backend, backend.unload)
 
-    assert "out" not in queued, (
-        "a generation queued behind the unload barrier ran against a pipeline being torn down"
-    )
+    assert (
+        "out" not in queued
+    ), "a generation queued behind the unload barrier ran against a pipeline being torn down"
     assert queued.get("error") in (VIDEO_NOT_LOADED_MSG, VIDEO_CANCELLED_MSG), queued
     assert backend._state is None
     assert backend._teardown_waiters == 0  # the fence drained
@@ -4845,9 +4845,9 @@ def test_superseding_load_fences_a_generation_queued_behind_its_barrier(fake_run
 
     queued = _run_teardown_race(backend, lambda: _load_gguf(backend, tmp_path))
 
-    assert "out" not in queued, (
-        "a generation queued behind the load barrier ran against a pipeline being torn down"
-    )
+    assert (
+        "out" not in queued
+    ), "a generation queued behind the load barrier ran against a pipeline being torn down"
     assert queued.get("error") in (VIDEO_NOT_LOADED_MSG, VIDEO_CANCELLED_MSG), queued
     assert backend._teardown_waiters == 0  # the fence drained
 
@@ -5093,9 +5093,9 @@ def test_the_h3_conditioner_falls_back_to_a_cache_that_predates_the_move(monkeyp
 
     monkeypatch.setattr(diffusion_families, "_upstream_is_cached", _probe)
     assert te.h3_te_quant_source("int8") == te.H3_LEGACY_TE_QUANT_REPO
-    assert asked == [(te.H3_LEGACY_TE_QUANT_REPO, (te.H3_TE_QUANT_FILES["int8"],), True)], (
-        "the conditioner must be probed by its own filename, in both cache roots"
-    )
+    assert asked == [
+        (te.H3_LEGACY_TE_QUANT_REPO, (te.H3_TE_QUANT_FILES["int8"],), True)
+    ], "the conditioner must be probed by its own filename, in both cache roots"
 
     monkeypatch.setattr(diffusion_families, "_upstream_is_cached", lambda *a, **k: False)
     assert te.h3_te_quant_source("int8") == te.H3_TE_QUANT_REPO
@@ -5376,9 +5376,9 @@ def test_the_h3_native_path_pins_cfg_scale_to_one():
     assert calls, "video.py no longer builds native video params"
     for call in calls:
         pinned = [kw for kw in call.keywords if kw.arg == "cfg_scale"]
-        assert pinned, (
-            "the H3 native path must pass cfg_scale explicitly, not fall back to a default"
-        )
+        assert (
+            pinned
+        ), "the H3 native path must pass cfg_scale explicitly, not fall back to a default"
         value = pinned[0].value
         assert isinstance(value, ast.Constant), (
             "cfg_scale must be a literal 1.0 on the H3 native path; forwarding the request's "
@@ -8021,9 +8021,9 @@ def test_plan_is_unchanged_when_no_text_encoder_quant_is_requested(fake_runtime,
             continue
         calls.clear()
         VideoBackend().load_pipeline(fam.base_repo, model_kind = "pipeline")
-        assert calls[0]["model_dense_mib"] == int(sum(fam.bf16_components_gb) * _MIB_PER_GB), (
-            fam.name
-        )
+        assert calls[0]["model_dense_mib"] == int(
+            sum(fam.bf16_components_gb) * _MIB_PER_GB
+        ), fam.name
 
 
 def test_dense_quant_replan_uses_the_scaled_text_encoder(fake_runtime, monkeypatch):
@@ -8720,9 +8720,9 @@ def test_generation_in_flight_tracks_a_background_job(fake_runtime, tmp_path, mo
     assert video_mod.generation_in_flight() is False
     backend.begin_generate(prompt = "a clip")
     assert rendering.wait(10), "the generate worker never started"
-    assert video_mod.generation_in_flight() is True, (
-        "liveness cannot tell this backend from a dead one while it renders a clip"
-    )
+    assert (
+        video_mod.generation_in_flight() is True
+    ), "liveness cannot tell this backend from a dead one while it renders a clip"
     assert inside["in_flight"] is True
 
     release.set()
@@ -9027,9 +9027,9 @@ def test_a_direct_worker_call_keeps_the_outcome_it_recorded(fake_runtime, tmp_pa
     backend._run_generate(cancel_event = threading.Event(), prompt = "a clip")
 
     progress = backend.generate_progress()
-    assert progress["phase"] == "completed", (
-        f"a direct call recorded {progress['phase']!r}; the backstop overwrote its result"
-    )
+    assert (
+        progress["phase"] == "completed"
+    ), f"a direct call recorded {progress['phase']!r}; the backstop overwrote its result"
     assert progress["video"]["id"] == "direct"
 
 
@@ -9050,6 +9050,6 @@ def test_a_direct_worker_call_keeps_its_cancellation(fake_runtime, tmp_path, mon
 
     progress = backend.generate_progress()
     assert progress["phase"] == "failed"
-    assert progress["error"] == VIDEO_CANCELLED_MSG, (
-        f"a direct call reported {progress['error']!r} instead of the cancellation sentinel"
-    )
+    assert (
+        progress["error"] == VIDEO_CANCELLED_MSG
+    ), f"a direct call reported {progress['error']!r} instead of the cancellation sentinel"


### PR DESCRIPTION
`pre-commit run --all-files` on a clean `main` leaves one file modified:

```
$ git checkout main && pre-commit run --all-files
...
=== EXIT 1 ===
 M studio/backend/tests/test_video_backend.py
```

That is enough to reach every open PR, because pre-commit.ci runs over all files, not just the ones a branch touched. On a branch it can push to, it lands an unrelated autofix commit on someone else's PR; on a fork branch it cannot push, so the `pre-commit.ci - pr` check just goes red. Ten open PRs are red on it right now: #10204, #10184, #10183, #10150, #10138, #10094, #10075, #10054, #9850, #9814. Two of my own PRs picked up the autofix commit while I was working on something else, which is how I noticed.

## Where it came from

`4a108e0ca` (#10184, "Fix diffusion offload host RAM retention") added two asserts written in the style a current ruff formats to:

```python
    assert resolved["requested"] is None, (
        f"the record reports {resolved['requested']!r} as the user's request; nothing was asked for"
    )
```

The repo's formatter is not a current ruff. `.pre-commit-config.yaml` runs the lint hook at `ruff-pre-commit` v0.15.18, but `ruff-format-with-kwargs` pins `ruff==0.6.9` in its `additional_dependencies`, and 0.6.9 formats that as:

```python
    assert (
        resolved["requested"] is None
    ), f"the record reports {resolved['requested']!r} as the user's request; nothing was asked for"
```

#10184 comes from a fork, so pre-commit.ci could not push the fix to it and the check stayed red through the merge. Nothing else is wrong with that PR: it was formatted by a ruff newer than the one this repo pins, which is an easy thing to do and nothing tells you about it.

## This change

The one file, formatted the way the pinned formatter wants. Two hunks, 30 lines each side, and nothing else in the tree needs it.

Verified:

- `pre-commit run --all-files` now passes all three hooks with a clean tree
- running it again changes nothing, so this is the formatter's fixed point and not a step in an oscillation between the two ruff versions
- the parse trees before and after are identical, so this is purely how the asserts are wrapped:

```
$ python -c "compare ast.dump of HEAD~1 vs working copy"
AST identical: True
text identical: False
```

## The thing worth fixing next

Two ruff versions in one config is the actual defect here, and it will keep producing this. The lint hook rides `rev: v0.15.18` while the formatter is held at `0.6.9`, so anyone with a current ruff on their machine writes code the gate then rejects, and the only signal is a red check on a fork PR that nobody can push a fix to.

Moving the pin to 0.15.18 is the fix, but it reformats a large part of the tree in one commit, so it wants its own PR and its own decision rather than riding along with an unblock. Leaving it here as the note.
