### PR TITLE
Studio: give a local GGUF one variant identity, so an API load applies its saved settings

### DIFF
--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -109,7 +109,10 @@ def _local_gguf_entry(loader_id: str, info) -> Optional[_LocalGgufEntry]:
     safetensors), listing only on-disk quants. ``load_path`` is a concrete local
     path so /load resolves the variant locally and never fetches a remote one."""
     from pathlib import Path
-    from utils.models.model_config import detect_gguf_model, list_local_gguf_variants
+
+    # The lister every stored per-model setting is keyed by, so one file has one identity.
+    from hub.utils.gguf import list_local_gguf_variants
+    from utils.models.model_config import detect_gguf_model
 
     path = getattr(info, "path", None)
     if not isinstance(path, str):
@@ -127,7 +130,9 @@ def _local_gguf_entry(loader_id: str, info) -> Optional[_LocalGgufEntry]:
                 return None
             return _LocalGgufEntry(loader_id, str(p), ())
         load_dir = _resolve_load_dir(p)
-        variants, _ = list_local_gguf_variants(str(load_dir))
+        # Asked of the lister, not filtered after: two checkpoints can share a quant, and
+        # grouping keeps one, so a dead file would take its readable namesake down with it.
+        variants, _ = list_local_gguf_variants(str(load_dir), require_existing_files = True)
         quants = tuple(v.quant for v in variants if getattr(v, "quant", None))
         if not quants:
             return None

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -32,11 +32,7 @@ class _LocalGgufEntry:
     load_path: str
     variants: tuple[str, ...]  # local quant labels; () for a standalone .gguf
     is_gguf: bool = True  # False routes the load to the inference orchestrator
-    # Spellings this entry ACCEPTS but no longer advertises, as ``(legacy, current)``
-    # pairs. Only the loader's own older label for a file whose current label differs,
-    # so a client pinned to what /v1/models used to publish keeps resolving. Never
-    # published, so nothing new can be pinned to one. See _legacy_variant_aliases.
-    aliases: tuple[tuple[str, str], ...] = ()
+    aliases: tuple[tuple[str, str], ...] = ()  # see _legacy_variant_aliases
 
 
 _CACHE_TTL_S = 5.0
@@ -110,52 +106,24 @@ def _resolve_load_dir(p):
 
 
 def _legacy_variant_aliases(variants) -> tuple[tuple[str, str], ...]:
-    """``(legacy label, current label)`` for each id this module used to publish and no
-    longer does.
+    """``(legacy label, current label)`` for each id this module used to publish and no longer does.
 
-    Until this module moved onto the shared lister, /v1/models published the loader's
-    label, and an API client pins whatever it was shown. The two listers disagree about
-    two kinds of name, and a pin on either one breaks -- differently, and the quieter
-    failure is the worse one:
+    /v1/models published the loader's label before the swap to the shared lister, and a client
+    pins what it was shown. ``DeepSeek-R1-BF16-Q4_K_M.gguf`` was ``BF16``, is ``Q4_K_M``: quant
+    shaped, so _resolve_from_index refuses it and the pin 404s. ``Meta-Llama-3-8B.gguf`` was
+    ``8B``, is the whole stem: not quant shaped, so it falls through to the Ollama-tag branch and
+    quietly serves the preferred quant instead. The quiet one is why quantless labels alias too.
 
-    * A stem carrying a float type before a K-quant, where the loader took the first
-      token and the shared lister takes the K-quant (``DeepSeek-R1-BF16-Q4_K_M.gguf``
-      was ``BF16``, is ``Q4_K_M``). ``BF16`` looks like a quant, so
-      :func:`_resolve_from_index` refuses it outright: the pin starts 404ing.
-    * A stem with no quant token at all -- the loader took its last hyphen segment, the
-      shared lister takes the whole stem (``Meta-Llama-3-8B.gguf`` was ``8B``). ``8B``
-      does not look like a quant, so that request does not fail; it falls through to the
-      Ollama-tag branch and is answered with the PREFERRED quant. Before the swap ``8B``
-      was an exact variant key and served the unquantized file, so without an alias the
-      same pin silently starts serving different, smaller weights. Aliased for exactly
-      that reason: a quiet quality change on an id a user already pinned is worse than
-      the 404, not better.
-
-    Accept-only: these are never advertised, so no NEW pin can be made to one and the
-    identity the picker and every saved setting use stays the only published spelling.
-    A bare repo id is unaffected either way -- it never reaches this, so ``preferred_quant``
-    still decides what an unqualified request loads.
-
-    A legacy label that collides with a current one is dropped, since the current
-    spelling names a file that really is that quant. One naming two files is dropped
-    too: the old ordering that picked between them is not reconstructible from grouped
-    rows, and guessing would serve weights nobody asked for.
-
-    Read from grouped rows, so it sees one file per quant. A repo holding two
-    checkpoints where the divergent file is not the one its group is named after
-    (``alpha-Q4_K_M.gguf`` beside ``zeta-BF16-Q4_K_M.gguf``) keeps the 404; covering it
-    would mean re-walking the tree the lister just walked, for a layout the picker has
-    always shown as one row.
-
-    Never raises: this runs inside ``_local_gguf_entry``'s blanket handler, so anything
-    escaping here would drop the whole repo out of /v1/models and auto-switch. A
-    compatibility shim must fail to no aliases, not to no model.
+    Accept-only, so nothing new can pin a legacy spelling and a bare id never reaches here.
+    Dropped rather than guessed: a legacy label equal to a current one, and one naming two files.
+    Grouped rows give one file per quant, so ``alpha-Q4_K_M.gguf`` beside
+    ``zeta-BF16-Q4_K_M.gguf`` keeps the 404. Never raises: _local_gguf_entry answers None on an
+    escape, which would drop the whole repo.
     """
     try:
         from utils.models.model_config import _extract_quant_label, _qualified_variant_name
 
-        # .lower(), not .casefold(): _resolve_from_index folds the requested variant that
-        # way, and a key it cannot spell is a key it can never hit.
+        # .lower() matches how _resolve_from_index folds the request
         current = {str(v.quant).lower() for v in variants if getattr(v, "quant", None)}
         seen: dict[str, Optional[str]] = {}
         for variant in variants:
@@ -167,7 +135,7 @@ def _legacy_variant_aliases(variants) -> tuple[tuple[str, str], ...]:
             key = str(legacy).lower()
             if not key or key in current:
                 continue
-            # None marks an ambiguous label: two files, so it can no longer name either.
+            # None = ambiguous: a second file claimed it, so it names neither.
             seen[key] = None if key in seen else str(quant)
         return tuple((legacy, quant) for legacy, quant in seen.items() if quant is not None)
     except Exception:
@@ -830,9 +798,8 @@ def _resolve_from_index(
         for v in entry.variants:
             if v.lower() == wanted:
                 return entry.load_path, v, entry.loader_id
-        # A spelling this entry no longer advertises but used to, answered with the label
-        # that names the same quant today. Ahead of both branches below, since one of them
-        # would refuse it and the other would quietly answer with a different quant.
+        # ahead of both branches below: one refuses a retired spelling, the other answers it
+        # with a different quant
         for legacy, current in entry.aliases:
             if legacy == wanted:
                 return entry.load_path, current, entry.loader_id

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -32,6 +32,11 @@ class _LocalGgufEntry:
     load_path: str
     variants: tuple[str, ...]  # local quant labels; () for a standalone .gguf
     is_gguf: bool = True  # False routes the load to the inference orchestrator
+    # Spellings this entry ACCEPTS but no longer advertises, as ``(legacy, current)``
+    # pairs. Only the loader's own older label for a file whose current label differs,
+    # so a client pinned to what /v1/models used to publish keeps resolving. Never
+    # published, so nothing new can be pinned to one. See _legacy_variant_aliases.
+    aliases: tuple[tuple[str, str], ...] = ()
 
 
 _CACHE_TTL_S = 5.0
@@ -104,6 +109,71 @@ def _resolve_load_dir(p):
     return p
 
 
+def _legacy_variant_aliases(variants) -> tuple[tuple[str, str], ...]:
+    """``(legacy label, current label)`` for each id this module used to publish and no
+    longer does.
+
+    Until this module moved onto the shared lister, /v1/models published the loader's
+    label, and an API client pins whatever it was shown. The two listers disagree about
+    two kinds of name, and a pin on either one breaks -- differently, and the quieter
+    failure is the worse one:
+
+    * A stem carrying a float type before a K-quant, where the loader took the first
+      token and the shared lister takes the K-quant (``DeepSeek-R1-BF16-Q4_K_M.gguf``
+      was ``BF16``, is ``Q4_K_M``). ``BF16`` looks like a quant, so
+      :func:`_resolve_from_index` refuses it outright: the pin starts 404ing.
+    * A stem with no quant token at all -- the loader took its last hyphen segment, the
+      shared lister takes the whole stem (``Meta-Llama-3-8B.gguf`` was ``8B``). ``8B``
+      does not look like a quant, so that request does not fail; it falls through to the
+      Ollama-tag branch and is answered with the PREFERRED quant. Before the swap ``8B``
+      was an exact variant key and served the unquantized file, so without an alias the
+      same pin silently starts serving different, smaller weights. Aliased for exactly
+      that reason: a quiet quality change on an id a user already pinned is worse than
+      the 404, not better.
+
+    Accept-only: these are never advertised, so no NEW pin can be made to one and the
+    identity the picker and every saved setting use stays the only published spelling.
+    A bare repo id is unaffected either way -- it never reaches this, so ``preferred_quant``
+    still decides what an unqualified request loads.
+
+    A legacy label that collides with a current one is dropped, since the current
+    spelling names a file that really is that quant. One naming two files is dropped
+    too: the old ordering that picked between them is not reconstructible from grouped
+    rows, and guessing would serve weights nobody asked for.
+
+    Read from grouped rows, so it sees one file per quant. A repo holding two
+    checkpoints where the divergent file is not the one its group is named after
+    (``alpha-Q4_K_M.gguf`` beside ``zeta-BF16-Q4_K_M.gguf``) keeps the 404; covering it
+    would mean re-walking the tree the lister just walked, for a layout the picker has
+    always shown as one row.
+
+    Never raises: this runs inside ``_local_gguf_entry``'s blanket handler, so anything
+    escaping here would drop the whole repo out of /v1/models and auto-switch. A
+    compatibility shim must fail to no aliases, not to no model.
+    """
+    try:
+        from utils.models.model_config import _extract_quant_label, _qualified_variant_name
+
+        # .lower(), not .casefold(): _resolve_from_index folds the requested variant that
+        # way, and a key it cannot spell is a key it can never hit.
+        current = {str(v.quant).lower() for v in variants if getattr(v, "quant", None)}
+        seen: dict[str, Optional[str]] = {}
+        for variant in variants:
+            quant = getattr(variant, "quant", None)
+            filename = getattr(variant, "filename", None)
+            if not quant or not filename:
+                continue
+            legacy = _qualified_variant_name(filename, _extract_quant_label(filename))
+            key = str(legacy).lower()
+            if not key or key in current:
+                continue
+            # None marks an ambiguous label: two files, so it can no longer name either.
+            seen[key] = None if key in seen else str(quant)
+        return tuple((legacy, quant) for legacy, quant in seen.items() if quant is not None)
+    except Exception:
+        return ()
+
+
 def _local_gguf_entry(loader_id: str, info) -> Optional[_LocalGgufEntry]:
     """Build an entry only when GGUF quants are on disk (not Transformers/
     safetensors), listing only on-disk quants. ``load_path`` is a concrete local
@@ -151,7 +221,9 @@ def _local_gguf_entry(loader_id: str, info) -> Optional[_LocalGgufEntry]:
         best = preferred_quant(unqualified or quants)
         if best and quants[0] != best:
             quants = (best, *(q for q in quants if q != best))
-        return _LocalGgufEntry(loader_id, str(load_dir), quants)
+        return _LocalGgufEntry(
+            loader_id, str(load_dir), quants, aliases = _legacy_variant_aliases(variants)
+        )
     except Exception:
         return None
 
@@ -758,6 +830,12 @@ def _resolve_from_index(
         for v in entry.variants:
             if v.lower() == wanted:
                 return entry.load_path, v, entry.loader_id
+        # A spelling this entry no longer advertises but used to, answered with the label
+        # that names the same quant today. Ahead of both branches below, since one of them
+        # would refuse it and the other would quietly answer with a different quant.
+        for legacy, current in entry.aliases:
+            if legacy == wanted:
+                return entry.load_path, current, entry.loader_id
         from core.inference.openai_auto_download import looks_like_quant
 
         if looks_like_quant(variant):

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -1408,8 +1408,19 @@ def _resolve_gguf_dir(path: Path) -> Optional[Path]:
     return None
 
 
+def _is_existing_file(path: Path) -> bool:
+    """Whether *path* exists: ``os.walk`` names a dangling link like any other file."""
+    try:
+        return path.is_file()
+    except OSError:
+        return False
+
+
 def list_local_gguf_variants(
-    directory: str, model_root: Optional[str] = None
+    directory: str,
+    model_root: Optional[str] = None,
+    *,
+    require_existing_files: bool = False,
 ) -> tuple[list[GgufVariantInfo], bool]:
     root = _resolve_gguf_dir(Path(directory))
     if root is None:
@@ -1435,6 +1446,10 @@ def list_local_gguf_variants(
     )
 
     for file in sorted(iter_gguf_files(root, recursive = True)):
+        # Off by default: the Hub lists the dangling link an evicted blob leaves, so a user
+        # can see and clean that quant. Only a caller advertising what it loads excludes it.
+        if require_existing_files and not _is_existing_file(file):
+            continue
         if h3_bundle_repo and not _is_selectable_repo_gguf(h3_bundle_repo, file.name):
             continue
         if is_imatrix_filename(file.name):

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -1440,14 +1440,9 @@ def list_local_gguf_variants(
     has_vision = False
     # Match the cache dir of ANY H3 bundle repo: the aggregation runs over whichever mirror the user
     # actually downloaded.
-    #
-    # A whole path SEGMENT, not a substring. A cache dir name only ever extends a repo id by more
-    # of that id, so "models--unsloth--MiniMax-H3-GGUF-mirror" (and -v2, -i1, -BF16, or a scan
-    # folder a user named that) contains the bundle's marker while being an ordinary chat repo.
-    # Substring matching kept only the bundle's own denoiser partitions in those, which names no
-    # file there, so the repo listed no quants at all. That was survivable while only the picker
-    # read this; the auto-switch index now does, and an empty quant list there means the entry is
-    # withheld, /v1/models drops a downloaded model and a request for it 404s.
+    # A whole SEGMENT, not a substring: "models--unsloth--MiniMax-H3-GGUF-mirror" (and -v2, -i1)
+    # contains the marker while being an ordinary chat repo, and the denoiser filter then left it
+    # with no quants -- which withholds the auto-switch entry, so a downloaded model 404s.
     segments = set(root.as_posix().lower().split("/"))
     h3_bundle_repo = next(
         (r for r in _H3_BUNDLE_REPOS if f"models--{r.replace('/', '--')}" in segments), None

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -1440,9 +1440,17 @@ def list_local_gguf_variants(
     has_vision = False
     # Match the cache dir of ANY H3 bundle repo: the aggregation runs over whichever mirror the user
     # actually downloaded.
-    root_key = root.as_posix().lower()
+    #
+    # A whole path SEGMENT, not a substring. A cache dir name only ever extends a repo id by more
+    # of that id, so "models--unsloth--MiniMax-H3-GGUF-mirror" (and -v2, -i1, -BF16, or a scan
+    # folder a user named that) contains the bundle's marker while being an ordinary chat repo.
+    # Substring matching kept only the bundle's own denoiser partitions in those, which names no
+    # file there, so the repo listed no quants at all. That was survivable while only the picker
+    # read this; the auto-switch index now does, and an empty quant list there means the entry is
+    # withheld, /v1/models drops a downloaded model and a request for it 404s.
+    segments = set(root.as_posix().lower().split("/"))
     h3_bundle_repo = next(
-        (r for r in _H3_BUNDLE_REPOS if f"models--{r.replace('/', '--')}" in root_key), None
+        (r for r in _H3_BUNDLE_REPOS if f"models--{r.replace('/', '--')}" in segments), None
     )
 
     for file in sorted(iter_gguf_files(root, recursive = True)):

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -601,6 +601,55 @@ def test_local_gguf_entry_filters_non_gguf_and_recurses(tmp_path):
     assert e2 is not None and e2.variants
 
 
+def test_local_gguf_entry_labels_a_quantless_filename_as_the_picker_does(tmp_path):
+    # No quant token in the name, so the picker and every saved setting key this variant by
+    # the stem. Labelling it "v2" here left an API load reading a key nothing wrote (#10227).
+    from types import SimpleNamespace
+
+    from utils.openai_auto_switch_settings import override_lookup_candidates
+
+    repo = tmp_path / "models--org--KAT-GGUF"
+    snapshot = repo / "snapshots" / "abc"
+    snapshot.mkdir(parents = True)
+    (snapshot / "KAT-Coder-V2.5-Dev-APEX-dynamic-v2.gguf").write_text("x")
+
+    entry = resolver._local_gguf_entry("org/KAT-GGUF", SimpleNamespace(path = str(repo)))
+    assert entry is not None
+    assert entry.variants == ("KAT-Coder-V2.5-Dev-APEX-dynamic-v2",)
+    assert "org/KAT-GGUF:KAT-Coder-V2.5-Dev-APEX-dynamic-v2" in override_lookup_candidates(
+        entry.load_path, entry.loader_id, entry.variants[0]
+    )
+
+
+def test_local_gguf_entry_skips_a_quant_whose_blob_is_gone(tmp_path):
+    # An evicted blob leaves a dangling link, and advertising it offers a quant no load can
+    # open. The twins repo is the other direction: one quant, two checkpoints, dead one first.
+    from types import SimpleNamespace
+
+    evicted = tmp_path / "models--org--evicted" / "snapshots" / "abc"
+    evicted.mkdir(parents = True)
+    (evicted / "m-Q8_0.gguf").write_text("x")
+    twins = tmp_path / "models--org--twins" / "snapshots" / "abc"
+    twins.mkdir(parents = True)
+    (twins / "z-BF16.gguf").write_text("x")
+    try:
+        (evicted / "m-Q4_K_M.gguf").symlink_to(tmp_path / "evicted-blob")
+        (twins / "a-BF16.gguf").symlink_to(tmp_path / "evicted-blob")
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks unavailable (Windows without developer mode)")
+
+    entry = resolver._local_gguf_entry(
+        "org/evicted", SimpleNamespace(path = str(evicted.parent.parent))
+    )
+    assert entry is not None and entry.variants == ("Q8_0",)
+    assert resolver._resolve_from_index("org/evicted", {"org/evicted": entry})[1] == "Q8_0"
+
+    twin_entry = resolver._local_gguf_entry(
+        "org/twins", SimpleNamespace(path = str(twins.parent.parent))
+    )
+    assert twin_entry is not None and twin_entry.variants == ("BF16",)
+
+
 def test_local_gguf_entry_rejects_standalone_companions(tmp_path, monkeypatch):
     # Codex P2: _scan_models_dir's standalone-.gguf pass emits an entry for a
     # bare mmproj projector (it only filters mmproj inside directory scans). A

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -650,6 +650,141 @@ def test_local_gguf_entry_skips_a_quant_whose_blob_is_gone(tmp_path):
     assert twin_entry is not None and twin_entry.variants == ("BF16",)
 
 
+def _one_gguf_repo(tmp_path, name, filenames):
+    """An HF-cache repo dir holding *filenames*, and the entry the index builds for it."""
+    from types import SimpleNamespace
+
+    snapshot = tmp_path / f"models--org--{name}" / "snapshots" / "abc"
+    snapshot.mkdir(parents = True)
+    for index, filename in enumerate(filenames):
+        (snapshot / filename).write_bytes(b"\0" * (4096 + index * 100))
+    return resolver._local_gguf_entry(
+        f"org/{name}", SimpleNamespace(path = str(snapshot.parent.parent))
+    )
+
+
+def test_a_quant_id_v1_models_used_to_publish_still_resolves(tmp_path):
+    # The two listers part on a float type sitting before a K-quant: the loader took the
+    # first token, the shared lister takes the K-quant. /v1/models published the loader's
+    # spelling, so an API client pinned "<repo>:BF16" -- and a label that LOOKS like a quant
+    # is refused outright, not treated as a repo tag, so the swap alone would 404 that pin.
+    entry = _one_gguf_repo(tmp_path, "float-then-k", ["DeepSeek-R1-BF16-Q4_K_M.gguf"])
+    assert entry is not None
+    # Advertised under the one identity the picker and every saved setting already use.
+    assert entry.variants == ("Q4_K_M",)
+    assert entry.aliases == (("bf16", "Q4_K_M"),)
+
+    index = {"org/float-then-k": entry}
+    for requested in ("org/float-then-k:BF16", "org/float-then-k:bf16"):
+        resolved = resolver._resolve_from_index(requested, index)
+        assert resolved is not None, requested
+        # Resolved to the CURRENT label, so the override lookup reads the key the UI wrote.
+        assert resolved[1] == "Q4_K_M"
+    # A quant that is genuinely not on disk still misses rather than serving other weights.
+    assert resolver._resolve_from_index("org/float-then-k:Q8_0", index) is None
+
+
+def test_a_legacy_quant_id_never_shadows_a_quant_that_is_really_there(tmp_path):
+    # b-BF16.gguf IS the BF16 file; a-BF16-Q4_K_M.gguf merely used to be called that. The
+    # real one keeps the name, so no alias is offered and no request changes weights.
+    entry = _one_gguf_repo(
+        tmp_path, "collide", ["a-BF16-Q4_K_M.gguf", "b-BF16.gguf"]
+    )
+    assert entry is not None
+    assert set(entry.variants) == {"Q4_K_M", "BF16"}
+    assert entry.aliases == ()
+
+    index = {"org/collide": entry}
+    assert resolver._resolve_from_index("org/collide:BF16", index)[1] == "BF16"
+    assert resolver._resolve_from_index("org/collide:Q4_K_M", index)[1] == "Q4_K_M"
+
+
+def test_an_ambiguous_legacy_quant_id_resolves_to_nothing(tmp_path):
+    # Two files whose old label was the same one. Guessing between them would serve weights
+    # nobody asked for, so it names neither -- the rule the override key folding already uses.
+    entry = _one_gguf_repo(
+        tmp_path, "ambiguous", ["x-BF16-Q4_K_M.gguf", "y-BF16-Q6_K.gguf"]
+    )
+    assert entry is not None
+    assert set(entry.variants) == {"Q4_K_M", "Q6_K"}
+    assert entry.aliases == ()
+    assert resolver._resolve_from_index("org/ambiguous:BF16", {"org/ambiguous": entry}) is None
+
+
+def test_a_quantless_pin_keeps_its_own_weights_instead_of_quietly_getting_the_quant(tmp_path):
+    # The loader labelled a quant-token-less stem by its last hyphen segment, so this repo
+    # published "8B" for the unquantized file and ":8b" loaded it. The shared lister calls it
+    # by its whole stem, and "8B" does not look like a quant, so the swap alone does not 404
+    # that pin -- it falls through to the Ollama-tag branch and answers with the PREFERRED
+    # quant, silently serving the Q4_K_M instead. A quiet quality change on an id someone
+    # already pinned is the worse failure, so this spelling is aliased too.
+    entry = _one_gguf_repo(
+        tmp_path, "quantless-pin", ["Meta-Llama-3-8B.gguf", "Meta-Llama-3-8B-Q4_K_M.gguf"]
+    )
+    assert entry is not None
+    assert entry.aliases == (("8b", "Meta-Llama-3-8B"),)
+    resolved = resolver._resolve_from_index("org/quantless-pin:8b", {"org/quantless-pin": entry})
+    assert resolved is not None and resolved[1] == "Meta-Llama-3-8B"
+    # The bare id never reaches an alias, so preferred_quant still decides what it means.
+    bare = resolver._resolve_from_index("org/quantless-pin", {"org/quantless-pin": entry})
+    assert bare[1] == entry.variants[0] == "Q4_K_M"
+
+
+def test_a_bundle_repos_mirror_is_not_emptied_by_the_h3_filter(tmp_path):
+    # _H3_BUNDLE_REPOS is matched against the cache dir, and a dir name only ever extends a
+    # repo id by more of that id: "MiniMax-H3-GGUF-mirror" (and -v2, -i1, -BF16) contains the
+    # marker while being an ordinary chat repo. Matched as a substring, the bundle's denoiser
+    # filter kept nothing there, and an empty quant list withholds the entry entirely -- so a
+    # fully downloaded model vanished from /v1/models and a request for it 404'd.
+    from types import SimpleNamespace
+
+    for name in ("MiniMax-H3-GGUF-mirror", "minimax-h3-gguf-i1", "MiniMax-H3-GGUF-BF16"):
+        snapshot = tmp_path / f"models--unsloth--{name}" / "snapshots" / "abc"
+        snapshot.mkdir(parents = True)
+        (snapshot / "m-Q4_K_M.gguf").write_bytes(b"\0" * 4096)
+        (snapshot / "m-Q8_0.gguf").write_bytes(b"\0" * 8192)
+        entry = resolver._local_gguf_entry(
+            f"unsloth/{name}", SimpleNamespace(path = str(snapshot.parent.parent))
+        )
+        assert entry is not None, f"{name} disappeared from the index"
+        assert set(entry.variants) == {"Q4_K_M", "Q8_0"}, name
+
+
+def test_a_broken_alias_helper_costs_the_aliases_and_not_the_model(tmp_path, monkeypatch):
+    # _local_gguf_entry catches everything and answers None, so a shim raising in here would
+    # drop the repo out of /v1/models and auto-switch entirely. Fail to no aliases instead.
+    monkeypatch.setattr(
+        resolver,
+        "_legacy_variant_aliases",
+        lambda variants: (_ for _ in ()).throw(RuntimeError("renamed private helper")),
+    )
+    entry = _one_gguf_repo(tmp_path, "shim-broke", ["DeepSeek-R1-BF16-Q4_K_M.gguf"])
+    assert entry is None, "a raising helper must not be what deletes the entry"
+
+    # And the real helper swallows its own failure rather than reaching that handler: it
+    # reaches into two private names in another module, which is exactly what a rename
+    # over there would break.
+    monkeypatch.undo()
+    from utils.models import model_config
+
+    def renamed_away(*_args, **_kwargs):
+        raise AttributeError("_qualified_variant_name")
+
+    monkeypatch.setattr(model_config, "_qualified_variant_name", renamed_away)
+    entry = _one_gguf_repo(tmp_path, "shim-renamed", ["DeepSeek-R1-BF16-Q4_K_M.gguf"])
+    assert entry is not None and entry.variants == ("Q4_K_M",)
+    assert entry.aliases == ()
+
+
+def test_a_repo_the_two_listers_agree_on_carries_no_aliases(tmp_path):
+    # The overwhelmingly common case: every alias is a cost, so a repo that needs none
+    # carries none, and an id naming no local quant keeps missing.
+    entry = _one_gguf_repo(tmp_path, "ordinary", ["m-Q4_K_M.gguf", "m-Q8_0.gguf"])
+    assert entry is not None
+    assert entry.aliases == ()
+    assert resolver._resolve_from_index("org/ordinary:BF16", {"org/ordinary": entry}) is None
+
+
 def test_local_gguf_entry_rejects_standalone_companions(tmp_path, monkeypatch):
     # Codex P2: _scan_models_dir's standalone-.gguf pass emits an entry for a
     # bare mmproj projector (it only filters mmproj inside directory scans). A

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -687,9 +687,7 @@ def test_a_quant_id_v1_models_used_to_publish_still_resolves(tmp_path):
 def test_a_legacy_quant_id_never_shadows_a_quant_that_is_really_there(tmp_path):
     # b-BF16.gguf IS the BF16 file; a-BF16-Q4_K_M.gguf merely used to be called that. The
     # real one keeps the name, so no alias is offered and no request changes weights.
-    entry = _one_gguf_repo(
-        tmp_path, "collide", ["a-BF16-Q4_K_M.gguf", "b-BF16.gguf"]
-    )
+    entry = _one_gguf_repo(tmp_path, "collide", ["a-BF16-Q4_K_M.gguf", "b-BF16.gguf"])
     assert entry is not None
     assert set(entry.variants) == {"Q4_K_M", "BF16"}
     assert entry.aliases == ()
@@ -702,9 +700,7 @@ def test_a_legacy_quant_id_never_shadows_a_quant_that_is_really_there(tmp_path):
 def test_an_ambiguous_legacy_quant_id_resolves_to_nothing(tmp_path):
     # Two files whose old label was the same one. Guessing between them would serve weights
     # nobody asked for, so it names neither -- the rule the override key folding already uses.
-    entry = _one_gguf_repo(
-        tmp_path, "ambiguous", ["x-BF16-Q4_K_M.gguf", "y-BF16-Q6_K.gguf"]
-    )
+    entry = _one_gguf_repo(tmp_path, "ambiguous", ["x-BF16-Q4_K_M.gguf", "y-BF16-Q6_K.gguf"])
     assert entry is not None
     assert set(entry.variants) == {"Q4_K_M", "Q6_K"}
     assert entry.aliases == ()
@@ -737,7 +733,6 @@ def test_a_bundle_repos_mirror_is_not_emptied_by_the_h3_filter(tmp_path):
     # filter kept nothing there, and an empty quant list withholds the entry entirely -- so a
     # fully downloaded model vanished from /v1/models and a request for it 404'd.
     from types import SimpleNamespace
-
     for name in ("MiniMax-H3-GGUF-mirror", "minimax-h3-gguf-i1", "MiniMax-H3-GGUF-BF16"):
         snapshot = tmp_path / f"models--unsloth--{name}" / "snapshots" / "abc"
         snapshot.mkdir(parents = True)

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -664,13 +664,11 @@ def _one_gguf_repo(tmp_path, name, filenames):
 
 
 def test_a_quant_id_v1_models_used_to_publish_still_resolves(tmp_path):
-    # The two listers part on a float type sitting before a K-quant: the loader took the
-    # first token, the shared lister takes the K-quant. /v1/models published the loader's
-    # spelling, so an API client pinned "<repo>:BF16" -- and a label that LOOKS like a quant
-    # is refused outright, not treated as a repo tag, so the swap alone would 404 that pin.
+    # /v1/models published the loader's spelling (first token, BF16) where the shared lister
+    # takes the K-quant, and a quant-looking label is refused rather than read as a repo tag,
+    # so the swap alone would 404 a client pinned to "<repo>:BF16".
     entry = _one_gguf_repo(tmp_path, "float-then-k", ["DeepSeek-R1-BF16-Q4_K_M.gguf"])
     assert entry is not None
-    # Advertised under the one identity the picker and every saved setting already use.
     assert entry.variants == ("Q4_K_M",)
     assert entry.aliases == (("bf16", "Q4_K_M"),)
 
@@ -678,15 +676,15 @@ def test_a_quant_id_v1_models_used_to_publish_still_resolves(tmp_path):
     for requested in ("org/float-then-k:BF16", "org/float-then-k:bf16"):
         resolved = resolver._resolve_from_index(requested, index)
         assert resolved is not None, requested
-        # Resolved to the CURRENT label, so the override lookup reads the key the UI wrote.
+        # the CURRENT label, so the override lookup reads the key the UI wrote
         assert resolved[1] == "Q4_K_M"
-    # A quant that is genuinely not on disk still misses rather than serving other weights.
+    # a quant genuinely not on disk still misses
     assert resolver._resolve_from_index("org/float-then-k:Q8_0", index) is None
 
 
 def test_a_legacy_quant_id_never_shadows_a_quant_that_is_really_there(tmp_path):
-    # b-BF16.gguf IS the BF16 file; a-BF16-Q4_K_M.gguf merely used to be called that. The
-    # real one keeps the name, so no alias is offered and no request changes weights.
+    # b-BF16.gguf IS the BF16 file; a-BF16-Q4_K_M.gguf merely used to be called that, so the
+    # real one keeps the name and no alias is offered.
     entry = _one_gguf_repo(tmp_path, "collide", ["a-BF16-Q4_K_M.gguf", "b-BF16.gguf"])
     assert entry is not None
     assert set(entry.variants) == {"Q4_K_M", "BF16"}
@@ -698,8 +696,7 @@ def test_a_legacy_quant_id_never_shadows_a_quant_that_is_really_there(tmp_path):
 
 
 def test_an_ambiguous_legacy_quant_id_resolves_to_nothing(tmp_path):
-    # Two files whose old label was the same one. Guessing between them would serve weights
-    # nobody asked for, so it names neither -- the rule the override key folding already uses.
+    # two files, one old label: it names neither, as the override key folding already does.
     entry = _one_gguf_repo(tmp_path, "ambiguous", ["x-BF16-Q4_K_M.gguf", "y-BF16-Q6_K.gguf"])
     assert entry is not None
     assert set(entry.variants) == {"Q4_K_M", "Q6_K"}
@@ -708,12 +705,9 @@ def test_an_ambiguous_legacy_quant_id_resolves_to_nothing(tmp_path):
 
 
 def test_a_quantless_pin_keeps_its_own_weights_instead_of_quietly_getting_the_quant(tmp_path):
-    # The loader labelled a quant-token-less stem by its last hyphen segment, so this repo
-    # published "8B" for the unquantized file and ":8b" loaded it. The shared lister calls it
-    # by its whole stem, and "8B" does not look like a quant, so the swap alone does not 404
-    # that pin -- it falls through to the Ollama-tag branch and answers with the PREFERRED
-    # quant, silently serving the Q4_K_M instead. A quiet quality change on an id someone
-    # already pinned is the worse failure, so this spelling is aliased too.
+    # This repo published "8B" for the unquantized file and ":8b" loaded it. "8B" does not look
+    # like a quant, so the swap does not 404 that pin: it falls through to the Ollama-tag branch
+    # and quietly serves the Q4_K_M instead. The quiet failure is why quantless labels alias too.
     entry = _one_gguf_repo(
         tmp_path, "quantless-pin", ["Meta-Llama-3-8B.gguf", "Meta-Llama-3-8B-Q4_K_M.gguf"]
     )
@@ -721,17 +715,15 @@ def test_a_quantless_pin_keeps_its_own_weights_instead_of_quietly_getting_the_qu
     assert entry.aliases == (("8b", "Meta-Llama-3-8B"),)
     resolved = resolver._resolve_from_index("org/quantless-pin:8b", {"org/quantless-pin": entry})
     assert resolved is not None and resolved[1] == "Meta-Llama-3-8B"
-    # The bare id never reaches an alias, so preferred_quant still decides what it means.
+    # the bare id never reaches an alias, so preferred_quant still decides it
     bare = resolver._resolve_from_index("org/quantless-pin", {"org/quantless-pin": entry})
     assert bare[1] == entry.variants[0] == "Q4_K_M"
 
 
 def test_a_bundle_repos_mirror_is_not_emptied_by_the_h3_filter(tmp_path):
-    # _H3_BUNDLE_REPOS is matched against the cache dir, and a dir name only ever extends a
-    # repo id by more of that id: "MiniMax-H3-GGUF-mirror" (and -v2, -i1, -BF16) contains the
-    # marker while being an ordinary chat repo. Matched as a substring, the bundle's denoiser
-    # filter kept nothing there, and an empty quant list withholds the entry entirely -- so a
-    # fully downloaded model vanished from /v1/models and a request for it 404'd.
+    # A cache dir name only ever extends a repo id by more of that id, so these contain the
+    # bundle marker while being ordinary chat repos. Matched as a substring, the denoiser filter
+    # left them with no quants, which withholds the entry and 404s a downloaded model.
     from types import SimpleNamespace
     for name in ("MiniMax-H3-GGUF-mirror", "minimax-h3-gguf-i1", "MiniMax-H3-GGUF-BF16"):
         snapshot = tmp_path / f"models--unsloth--{name}" / "snapshots" / "abc"
@@ -746,8 +738,7 @@ def test_a_bundle_repos_mirror_is_not_emptied_by_the_h3_filter(tmp_path):
 
 
 def test_a_broken_alias_helper_costs_the_aliases_and_not_the_model(tmp_path, monkeypatch):
-    # _local_gguf_entry catches everything and answers None, so a shim raising in here would
-    # drop the repo out of /v1/models and auto-switch entirely. Fail to no aliases instead.
+    # _local_gguf_entry answers None on any raise, so an escaping shim would drop the repo.
     monkeypatch.setattr(
         resolver,
         "_legacy_variant_aliases",
@@ -756,9 +747,7 @@ def test_a_broken_alias_helper_costs_the_aliases_and_not_the_model(tmp_path, mon
     entry = _one_gguf_repo(tmp_path, "shim-broke", ["DeepSeek-R1-BF16-Q4_K_M.gguf"])
     assert entry is None, "a raising helper must not be what deletes the entry"
 
-    # And the real helper swallows its own failure rather than reaching that handler: it
-    # reaches into two private names in another module, which is exactly what a rename
-    # over there would break.
+    # And it swallows its own failure: it reaches into two private names in another module.
     monkeypatch.undo()
     from utils.models import model_config
 


### PR DESCRIPTION
Fixes #10227 (and finishes #7477, which reported the same symptom and was fixed for the common case).

## What was broken

With "Remember for this model" ticked, a model loaded from the picker got the saved context length, KV cache dtype, GPU layers, cache RAM, chat template and pass-through flags. The same model loaded by an OpenAI-compatible API request (auto-switch) came up with app defaults instead. The settings were saved and did survive a restart, so from the outside this looked like the API path ignoring them.

It only happened to repos whose GGUF filename carries no recognized quant token, which is why the earlier fix looked complete: every well-formed quant name worked.

## Root cause

Two GGUF variant listers, disagreeing about what one file is called.

The picker, the Hub API and every per-model setting the UI persists key a variant with `hub/utils/gguf.py`, whose identity for a quantless name falls back to the file's stem. The auto-switch index labelled the same file with `utils/models/model_config.py`, which pulls a quant token out of the stem. For `KAT-Coder-V2.5-Dev-APEX-dynamic-v2.gguf` that is `KAT-Coder-V2.5-Dev-APEX-dynamic-v2` to the first and `v2` to the second.

So the row was stored as `<repo>:KAT-Coder-V2.5-Dev-APEX-dynamic-v2` and looked up as `<repo>:v2`. The lookup missed and the load launched with defaults.

## What changed

`_local_gguf_entry` now takes its variants from the shared lister, so one file has one identity across the picker, the Hub API, `/v1/models` and an auto-switch load. Rows already stored are keyed by that identity, so saved settings start resolving with no migration.

That lister walks recursively with `os.walk`, which names a dangling symlink like any other file, while the one it replaces answers with `is_file()`. Deleting a blob leaves such a link in every snapshot that pointed at it, so adopting the shared lister as-is would have advertised a quant no load can open and let a bare repo id prefer it over the quant that is actually there. Entries naming no file are therefore dropped, behind a new `require_existing_files`:

- **Off by default**, because the Hub deliberately lists a broken quant so a user can see and clean it. Listing and serving are different questions, and only the caller advertising what it can load asks for the stricter one.
- **Applied before variants are grouped**, because two checkpoints can share one quant (a repo shipping BF16 twice) and grouping keeps only the first. Filtering the grouped rows instead drops a readable family whose dead namesake sorted ahead of it, and when that is the repo's only quant the model disappears from `/v1/models` and auto-switch entirely.

## Behaviour change worth knowing

A repo that bundles several model roles now advertises only the roles that are servable on their own. Concretely, a MiniMax-H3 build no longer offers its text encoder as a `Q4_K_M` quant of the repo. The picker has never offered it; the auto-switch index did, so an API request naming that quant could evict the resident model to load a text encoder.

## Validation

Reproduced end to end against a running backend using the filename shape from the issue, in an HF-cache snapshot:

```
# before
llama-server ... -c 40960                     # model default, no --cache-type-k

# after, with 4096 / q8_0 remembered for that model
llama-server ... -c 4096 --cache-type-k q8_0 --cache-type-v q8_0
```

Also measured directly:

- Duplicate families sharing one quant, dead file sorting first: the readable family survives (`('Q4_K_M',)`).
- A quant whose only file is a dangling link: dropped, the clean quant kept (`('Q8_0',)`).
- Index build cost over a real local cache is unchanged (7 ms either lister, 16 snapshots).

Each of the two production changes was checked by reverting it and confirming exactly the test that covers it fails, including the "filter after grouping instead of before" variant. Suites run: `test_openai_auto_switch`, `test_hf_cache_dangling_refs`, `test_gguf_variants_local_resolution`, `test_cached_gguf_routes`, `test_local_model_dir_discovery`, `test_local_model_format`, `test_media_auto_switch`, `test_gguf_variant_rows`, `test_imatrix_gguf_filtering`, `test_gguf_bpw_variant_rows`, `test_resolve_quant_gguf`, `test_offline_gguf_cache_fallback`, `test_model_override_schema_compatibility`, `test_mtp_drafter_companion` — all green.

## Deliberately not in this change

- **Converging the two listers.** `list_local_gguf_variants` and the quant-label helpers still exist in both `hub/utils/gguf.py` and `utils/models/model_config.py`. This moves the auto-switch index onto the shared one; making them one implementation is a larger change and does not belong in a bug fix.
- **A related defect this does not fix:** a bare repo id resolves to whichever quant `preferred_quant` ranks best, not the one the user loaded or saved settings for. With two quants of one repo downloaded, settings remembered for the non-preferred one are still ignored on an API load, and `/v1/models` advertises no way for a client to name the other. Happy to open a separate issue for it.
