### PR TITLE
Security audit: re-approve the huggingface-hub backoff loop for 1.30.0

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1828,6 +1828,14 @@
       "evidence": "Anti: L860:         time.sleep(3600)\nSubprocess: L212:         self.process = subprocess.Popen( sha256:62f622e5b17b6c6b1656b44c8ba27274f02c68c4f9d35502fb593f1d6a3af55d",
       "evidence_hash": "f760ab1ce9c086051291c29ac4e486575db6f2dac2eddba2ac31ef5c434609d8",
       "file_sha256": "695b5c1df7d0ae710451aa8904c5ef101e0c93de26a591f3e995bb9151d4c0e3"
+    },
+    {
+      "package": "huggingface-hub",
+      "file": "huggingface_hub/utils/_http.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L461:     while True: sha256:a8f95a987a45a8eb67ee78dd9d98674c7b88c97e7722f63dd446f77e3dcfe0e7",
+      "evidence_hash": "20a717b5faac68b3a57b11859f90d21959c29302e413bf3cd36e1263ccfbb00b"
     }
   ]
 }


### PR DESCRIPTION
`Security audit` is red on `main` at `568b73621`, on all three shards this time, `pip scan-packages :: studio`, `:: extras` and `:: hf-stack`:

```
[1] CRITICAL  C2 polling/beaconing loop detected
    Package:  huggingface-hub
    File:     huggingface_hub/utils/_http.py
    Evidence: L461:     while True: sha256:a8f95a987a45a8eb67ee78dd9d98674c7b88c97e7722f63dd446f77e3dcfe0e7
```

`hf-stack` is the tell. That shard is deliberately torch-free, so this is not the torch 2.14.0 reopen #10233 dealt with an hour ago. huggingface-hub **1.30.0** was published at 2026-09-03T10:05:12Z; the failing run started at 11:02. No commit in this repo caused it.

## It is the same loop, for the fifth time

`tests/security/test_scan_packages.py::test_the_hf_backoff_suppression_is_narrow` already documents this file at length, and the baseline already carries four entries for it, one per revision the hub has shipped: L298, L462, L461 and L461 again. This is the fifth.

`RE_C2_POLLING` is `while True .* sleep .* requests\.` under `re.DOTALL`, so it cannot tell a bounded retry apart from a real beacon. The L461 loop in 1.30.0 is `http_backoff`, unchanged in shape:

```python
    nb_tries = 0
    sleep_time = base_wait_time
    ratelimit_reset: int | None = None
    ...
    while True:
        nb_tries += 1
        ratelimit_reset = None
        client = get_session()
        try:
            ...
            def _should_retry(response: httpx.Response) -> bool:
                if response.status_code not in retry_on_status_codes:
                    return False  # Success, don't retry
                logger.warning(f"HTTP Error {response.status_code} thrown while requesting {method} {url}")
                if nb_tries > max_retries:
```

A retry that counts `nb_tries` against `max_retries`, sleeps with exponential backoff between attempts, and raises once the budget is spent. That is why the file is allowlisted rather than the check weakened, exactly as that docstring says.

I read it out of `huggingface_hub-1.30.0-py3-none-any.whl` itself rather than a GitHub tag, so it is the code the scanner actually sees.

## The patch

One additive, unpinned entry, matching how the other four are maintained. 227 entries to 228.

```json
{
  "package": "huggingface-hub",
  "file": "huggingface_hub/utils/_http.py",
  "check": "C2 polling/beaconing loop detected",
  "severity": "CRITICAL",
  "evidence": "L461:     while True: sha256:a8f95a987a45a8eb67ee78dd9d98674c7b88c97e7722f63dd446f77e3dcfe0e7",
  "evidence_hash": "20a717b5faac68b3a57b11859f90d21959c29302e413bf3cd36e1263ccfbb00b"
}
```

`evidence_hash` computed through the scanner's own `_evidence_hash`, not by hand.

Verified by running the scan both ways rather than by reasoning about it:

```
without the entry   Summary: 1 CRITICAL, 5 MEDIUM                  EXIT 1
with the entry      Summary: 5 MEDIUM
                    4 finding(s) suppressed by baseline (4 CRITICAL, 0 HIGH, 0 MEDIUM)   EXIT 0
```

`exit 0` is what the shard step propagates, so all three shards go green.

## This is the fourth one today

Between torch 2.14.0 and huggingface-hub 1.30.0, `Security audit` has gone red on `main` twice in one morning for reasons no commit here caused, and this file alone has now needed five entries.

The cause is the one I wrote up in #10233 and I will repeat it here because this occurrence is a cleaner example of it. The evidence span for a cross-line DOTALL check runs from the first atom in the file to the last, and `_render`'s long-span fallback digests everything it bridged. Here that is roughly 650 lines to bind a 30-line retry loop, so any edit anywhere in that region reopens a CRITICAL. The entry is not pinned to the reviewed code; it is pinned to most of the file.

The fix I measured is to give each cross-line regex a companion line-level atom pattern, and when `_render` falls back to a digest, digest only the atom-bearing lines. On this exact file that collapses 1.26.1, 1.27.0 and 1.28.0 to a single stable digest, while a beacon loop spliced into the same file still reopens it, because it adds `while True`, `requests.` and `sleep` atoms. It also keeps `test_the_hf_backoff_suppression_is_narrow` passing.

I am still not folding it in here, for the same reason: it rotates all 58 span-digest hashes at once and wants its own PR with each entry's code re-read, not a `--write-baseline` regeneration bolted onto an unblock. But this is now the second time in a morning that the cost has been paid, and it is worth doing.
