### PR TITLE
Fix Hub GGUF fit estimates for companion files

### DIFF
--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -23,10 +23,10 @@ import {
 import { usePlatformStore } from "@/config/env";
 import { getCachedModelPath, revealCachedModel } from "@/features/chat";
 import { pinKey, usePinnedModelsStore } from "@/features/model-picker";
+import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
-import { type GgufFitClass, classifyGgufFit } from "@/lib/gguf-fit";
-import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
+import type { GgufFitClass } from "@/lib/gguf-fit";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import {
@@ -65,6 +65,7 @@ import {
   ggufSelectionOverrideMatchesIntent,
 } from "../lib/gguf-filename";
 import {
+  classifyGgufVariantFit,
   ggufVariantDisplayLabel,
   ggufVariantTransferLabel,
   sortDownloadableGgufVariants,
@@ -269,7 +270,7 @@ function createGgufVariantMenuItems(
     key: normalizeGgufVariantIdentity(variant.quant),
     quant: variant.quant,
     label: ggufVariantDisplayLabel(variant),
-    fit: classifyGgufFit(variant.size_bytes, resources),
+    fit: classifyGgufVariantFit(variant, resources),
     downloaded: Boolean(variant.downloaded),
     partial: Boolean(variant.partial),
     downloadSizeLabel: ggufVariantTransferLabel(variant),
@@ -783,18 +784,14 @@ export function GgufDownloadCard({
   // No verdict beats a wrong one: a media repo's fit is the diffusion planner's question, and
   // this card only knows how to answer llama.cpp's. The picker still badges those rows.
   const showFitInfo = !mediaRuntime && (Boolean(gpuGb) || Boolean(systemRamGb));
-  const selectedFit = useMemo(
-    () =>
-      selected
-        ? classifyGgufFit(selected.size_bytes, {
-            gpuGb,
-            gpuCount,
-            systemRamGb,
-            budgetFraction,
-          })
-        : null,
-    [gpuGb, gpuCount, selected?.size_bytes, systemRamGb, budgetFraction],
-  );
+  const selectedFit = selected
+    ? classifyGgufVariantFit(selected, {
+        gpuGb,
+        gpuCount,
+        systemRamGb,
+        budgetFraction,
+      })
+    : null;
   const selectedDownloadSizeLabel = selected
     ? ggufVariantTransferLabel(selected)
     : null;

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -26,7 +26,7 @@ import { pinKey, usePinnedModelsStore } from "@/features/model-picker";
 import { useVramBudgetFraction } from "@/hooks/use-vram-budget-fraction";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
-import type { GgufFitClass } from "@/lib/gguf-fit";
+import { type GgufFitClass, classifyGgufVariantFit } from "@/lib/gguf-fit";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import {
@@ -65,7 +65,6 @@ import {
   ggufSelectionOverrideMatchesIntent,
 } from "../lib/gguf-filename";
 import {
-  classifyGgufVariantFit,
   ggufVariantDisplayLabel,
   ggufVariantTransferLabel,
   sortDownloadableGgufVariants,

--- a/studio/frontend/src/features/hub/lib/gguf-variant-sort.ts
+++ b/studio/frontend/src/features/hub/lib/gguf-variant-sort.ts
@@ -3,10 +3,10 @@
 
 import type { GgufVariantDetail } from "@/features/hub/inventory";
 import { formatBytes } from "@/features/hub/lib/format";
-import { classifyGgufFit } from "@/lib/gguf-fit";
 import { ggufVariantsMatch } from "@/features/hub/lib/model-identity";
+import { classifyGgufFit } from "@/lib/gguf-fit";
 
-type GgufVariantResources = {
+export type GgufVariantResources = {
   gpuGb?: number;
   systemRamGb?: number;
   /** The saved VRAM Budget, so the sort ranks against the line the loader will
@@ -27,6 +27,34 @@ export function ggufVariantDownloadSizeBytes(
   variant: Pick<GgufVariantDetail, "download_size_bytes" | "size_bytes">,
 ): number {
   return variant.download_size_bytes ?? variant.size_bytes;
+}
+
+/** Conservative byte basis for a pre-download fit verdict.
+ *
+ * Before a quant is on disk the load planner cannot inspect its GGUF headers,
+ * so the Hub's fit badge has to work from the variant listing. `size_bytes`
+ * names only the main weights, while `download_size_bytes` also includes the
+ * projector and drafter GGUFs a default launch can open beside them. It can
+ * also contain small support files that are not resident, so it is deliberately
+ * a conservative proxy rather than a replacement for the on-disk planner.
+ * Scoring only the main weights called a Muse Glimmer Q3 load a full 16 GiB GPU
+ * fit even though its required projector pushed the launch well over the card.
+ *
+ * Take the larger figure rather than trusting `download_size_bytes` blindly:
+ * old or incomplete listings may report it as zero, and a fit estimate must
+ * never become smaller than the weights themselves. */
+export function ggufVariantFitSizeBytes(
+  variant: Pick<GgufVariantDetail, "download_size_bytes" | "size_bytes">,
+): number {
+  return Math.max(variant.size_bytes, variant.download_size_bytes ?? 0);
+}
+
+/** The Hub-wide fit verdict for a concrete GGUF variant. */
+export function classifyGgufVariantFit(
+  variant: Pick<GgufVariantDetail, "download_size_bytes" | "size_bytes">,
+  resources: GgufVariantResources,
+) {
+  return classifyGgufFit(ggufVariantFitSizeBytes(variant), resources);
 }
 
 type GgufVariantTransfer = Pick<
@@ -56,7 +84,7 @@ export function ggufVariantFitRank(
   variant: GgufVariantDetail,
   resources: GgufVariantResources,
 ): number {
-  switch (classifyGgufFit(variant.size_bytes, resources)) {
+  switch (classifyGgufVariantFit(variant, resources)) {
     case "fits":
       return 0;
     case "marginal":

--- a/studio/frontend/src/features/hub/lib/gguf-variant-sort.ts
+++ b/studio/frontend/src/features/hub/lib/gguf-variant-sort.ts
@@ -4,18 +4,7 @@
 import type { GgufVariantDetail } from "@/features/hub/inventory";
 import { formatBytes } from "@/features/hub/lib/format";
 import { ggufVariantsMatch } from "@/features/hub/lib/model-identity";
-import { classifyGgufFit } from "@/lib/gguf-fit";
-
-export type GgufVariantResources = {
-  gpuGb?: number;
-  systemRamGb?: number;
-  /** The saved VRAM Budget, so the sort ranks against the line the loader will
-   *  actually admit at rather than against the default. */
-  budgetFraction?: number;
-  /** GPUs gpuGb sums, so the sort charges the loader's per-card VRAM reserve as
-   *  many times as the loader does. */
-  gpuCount?: number;
-};
+import { type GgufFitInput, classifyGgufVariantFit } from "@/lib/gguf-fit";
 
 export function ggufVariantDisplayLabel(
   variant: Pick<GgufVariantDetail, "display_label" | "quant">,
@@ -27,34 +16,6 @@ export function ggufVariantDownloadSizeBytes(
   variant: Pick<GgufVariantDetail, "download_size_bytes" | "size_bytes">,
 ): number {
   return variant.download_size_bytes ?? variant.size_bytes;
-}
-
-/** Conservative byte basis for a pre-download fit verdict.
- *
- * Before a quant is on disk the load planner cannot inspect its GGUF headers,
- * so the Hub's fit badge has to work from the variant listing. `size_bytes`
- * names only the main weights, while `download_size_bytes` also includes the
- * projector and drafter GGUFs a default launch can open beside them. It can
- * also contain small support files that are not resident, so it is deliberately
- * a conservative proxy rather than a replacement for the on-disk planner.
- * Scoring only the main weights called a Muse Glimmer Q3 load a full 16 GiB GPU
- * fit even though its required projector pushed the launch well over the card.
- *
- * Take the larger figure rather than trusting `download_size_bytes` blindly:
- * old or incomplete listings may report it as zero, and a fit estimate must
- * never become smaller than the weights themselves. */
-export function ggufVariantFitSizeBytes(
-  variant: Pick<GgufVariantDetail, "download_size_bytes" | "size_bytes">,
-): number {
-  return Math.max(variant.size_bytes, variant.download_size_bytes ?? 0);
-}
-
-/** The Hub-wide fit verdict for a concrete GGUF variant. */
-export function classifyGgufVariantFit(
-  variant: Pick<GgufVariantDetail, "download_size_bytes" | "size_bytes">,
-  resources: GgufVariantResources,
-) {
-  return classifyGgufFit(ggufVariantFitSizeBytes(variant), resources);
 }
 
 type GgufVariantTransfer = Pick<
@@ -82,7 +43,7 @@ export function ggufVariantTransferLabel(variant: GgufVariantTransfer): string {
 
 export function ggufVariantFitRank(
   variant: GgufVariantDetail,
-  resources: GgufVariantResources,
+  resources: GgufFitInput,
 ): number {
   switch (classifyGgufVariantFit(variant, resources)) {
     case "fits":
@@ -100,7 +61,7 @@ export function ggufVariantFitRank(
 export function compareGgufVariantFitAndSize(
   a: GgufVariantDetail,
   b: GgufVariantDetail,
-  resources: GgufVariantResources,
+  resources: GgufFitInput,
 ): number {
   const aFit = ggufVariantFitRank(a, resources);
   const bFit = ggufVariantFitRank(b, resources);
@@ -118,7 +79,7 @@ export function ggufVariantDownloadStatusRank(
 
 export function sortDownloadableGgufVariants(
   variants: readonly GgufVariantDetail[],
-  resources: GgufVariantResources,
+  resources: GgufFitInput,
 ): GgufVariantDetail[] {
   return [...variants].sort((a, b) => {
     const statusDelta =
@@ -130,7 +91,7 @@ export function sortDownloadableGgufVariants(
 
 export function sortLocalGgufVariants(
   variants: readonly GgufVariantDetail[],
-  options: GgufVariantResources & {
+  options: GgufFitInput & {
     activeGgufVariant?: string | null;
     defaultVariant?: string | null;
   },

--- a/studio/frontend/src/lib/gguf-fit.ts
+++ b/studio/frontend/src/lib/gguf-fit.ts
@@ -125,3 +125,34 @@ export function classifyGgufFit(
   if (required <= combined) return "partial";
   return "oom";
 }
+
+/** Structural rather than the Hub's `GgufVariantDetail`, so this module stays below
+ *  the features that own it. */
+export interface GgufVariantSizes {
+  size_bytes: number;
+  download_size_bytes?: number;
+}
+
+/** Byte basis for a fit verdict on a listed variant.
+ *
+ * `size_bytes` is the main weights; `download_size_bytes` also covers the companion
+ * GGUFs fetched beside them — a vision model's mmproj, and the MTP or DFlash drafter
+ * `auto` speculation may promote to.
+ *
+ * Leans high on purpose. One aggregate cannot say which of those stay resident, while
+ * the load planner charges a projector at a multiple of its file size, skips it with
+ * vision off, and prices a drafter only when one would open (`/kv-cache-estimate` in
+ * routes/models.py).
+ *
+ * The larger of the two, never the total alone: the offline listing path reports it as
+ * the weights and an older backend as zero (hub/services/models/gguf_variants.py). */
+export function ggufVariantFitSizeBytes(variant: GgufVariantSizes): number {
+  return Math.max(variant.size_bytes, variant.download_size_bytes ?? 0);
+}
+
+export function classifyGgufVariantFit(
+  variant: GgufVariantSizes,
+  input: GgufFitInput,
+): GgufFitClass {
+  return classifyGgufFit(ggufVariantFitSizeBytes(variant), input);
+}

--- a/studio/frontend/tests/gguf-variant-transfer-size.test.ts
+++ b/studio/frontend/tests/gguf-variant-transfer-size.test.ts
@@ -12,9 +12,12 @@ import { registerBundlerResolver } from "./helpers/kit.ts";
 
 registerBundlerResolver();
 
-const { ggufVariantTransferBytes, ggufVariantTransferLabel } = await import(
-  "../src/features/hub/lib/gguf-variant-sort.ts"
-);
+const {
+  classifyGgufVariantFit,
+  ggufVariantFitSizeBytes,
+  ggufVariantTransferBytes,
+  ggufVariantTransferLabel,
+} = await import("../src/features/hub/lib/gguf-variant-sort.ts");
 
 const GB = 1000 ** 3;
 
@@ -75,4 +78,30 @@ test("a partial with nothing left reads as zero rather than the total", () => {
   };
 
   assert.equal(ggufVariantTransferBytes(variant), 0);
+});
+
+test("fit includes required companion files rather than only the main weights", () => {
+  // Bartowski Muse Glimmer Q3_K_S is a 12.79 GB quant plus a 3.85 GB
+  // projector and a 1.45 GB DFlash drafter. The main file alone fits the
+  // loader's 97% budget on a 16 GiB card; the variant that actually gets
+  // installed and loaded does not.
+  const variant = {
+    size_bytes: 12_789_199_648,
+    download_size_bytes: 12_789_199_648 + 3_849_173_920 + 1_451_094_176,
+  };
+
+  assert.equal(ggufVariantFitSizeBytes(variant), variant.download_size_bytes);
+  assert.equal(
+    classifyGgufVariantFit(variant, { gpuGb: 16, systemRamGb: 32 }),
+    "partial",
+  );
+});
+
+test("fit never trusts a missing or zero total below the main weights", () => {
+  const sizeBytes = 12 * GB;
+  assert.equal(ggufVariantFitSizeBytes({ size_bytes: sizeBytes }), sizeBytes);
+  assert.equal(
+    ggufVariantFitSizeBytes({ size_bytes: sizeBytes, download_size_bytes: 0 }),
+    sizeBytes,
+  );
 });

--- a/studio/frontend/tests/gguf-variant-transfer-size.test.ts
+++ b/studio/frontend/tests/gguf-variant-transfer-size.test.ts
@@ -12,12 +12,8 @@ import { registerBundlerResolver } from "./helpers/kit.ts";
 
 registerBundlerResolver();
 
-const {
-  classifyGgufVariantFit,
-  ggufVariantFitSizeBytes,
-  ggufVariantTransferBytes,
-  ggufVariantTransferLabel,
-} = await import("../src/features/hub/lib/gguf-variant-sort.ts");
+const { ggufVariantFitRank, ggufVariantTransferBytes, ggufVariantTransferLabel } =
+  await import("../src/features/hub/lib/gguf-variant-sort.ts");
 
 const GB = 1000 ** 3;
 
@@ -80,28 +76,24 @@ test("a partial with nothing left reads as zero rather than the total", () => {
   assert.equal(ggufVariantTransferBytes(variant), 0);
 });
 
-test("fit includes required companion files rather than only the main weights", () => {
-  // Bartowski Muse Glimmer Q3_K_S is a 12.79 GB quant plus a 3.85 GB
-  // projector and a 1.45 GB DFlash drafter. The main file alone fits the
-  // loader's 97% budget on a 16 GiB card; the variant that actually gets
-  // installed and loaded does not.
-  const variant = {
-    size_bytes: 12_789_199_648,
-    download_size_bytes: 12_789_199_648 + 3_849_173_920 + 1_451_094_176,
-  };
+test("the menu is ranked by the footprint the rows are badged by", () => {
+  // Ranking on the weights while badging the total put a "partial" row above "fits".
+  const resources = { gpuGb: 16, systemRamGb: 32 };
+  const main = 12_789_199_648;
+  const row = (over: { download_size_bytes?: number }) => ({
+    quant: "Q3_K_S",
+    filename: "muse-Q3_K_S.gguf",
+    size_bytes: main,
+    download_size_bytes: main,
+    ...over,
+  });
 
-  assert.equal(ggufVariantFitSizeBytes(variant), variant.download_size_bytes);
+  assert.equal(ggufVariantFitRank(row({}), resources), 0);
   assert.equal(
-    classifyGgufVariantFit(variant, { gpuGb: 16, systemRamGb: 32 }),
-    "partial",
-  );
-});
-
-test("fit never trusts a missing or zero total below the main weights", () => {
-  const sizeBytes = 12 * GB;
-  assert.equal(ggufVariantFitSizeBytes({ size_bytes: sizeBytes }), sizeBytes);
-  assert.equal(
-    ggufVariantFitSizeBytes({ size_bytes: sizeBytes, download_size_bytes: 0 }),
-    sizeBytes,
+    ggufVariantFitRank(
+      row({ download_size_bytes: main + 3_849_173_920 + 1_451_094_176 }),
+      resources,
+    ),
+    2,
   );
 });

--- a/studio/frontend/tests/memory-shared-core.test.ts
+++ b/studio/frontend/tests/memory-shared-core.test.ts
@@ -384,3 +384,41 @@ test("the budget read is shared, not one request per mounted card", async () => 
     "the change event must refresh the cache, or a save never reaches the cards",
   );
 });
+
+// ---------------------------------------------------------------------------
+// A verdict on a VARIANT scores the whole footprint the download plan fetches
+
+test("a variant's fit counts the companions fetched with it", async () => {
+  // Bartowski Muse Glimmer Q3_K_S: 12.79 GB of weights, a 3.85 GB projector and a
+  // 1.45 GB DFlash drafter. Only the weights clear a 16 GiB card.
+  const { classifyGgufVariantFit, ggufVariantFitSizeBytes } = await import(
+    "../src/lib/gguf-fit.ts"
+  );
+  const weights = 12_789_199_648;
+  const variant = {
+    size_bytes: weights,
+    download_size_bytes: weights + 3_849_173_920 + 1_451_094_176,
+  };
+  const budget = { gpuGb: 16, systemRamGb: 32 };
+
+  assert.equal(ggufVariantFitSizeBytes(variant), variant.download_size_bytes);
+  assert.equal(
+    classifyGgufVariantFit({ size_bytes: weights }, budget),
+    "fits",
+    "the fixture only proves anything while the weights alone still fit",
+  );
+  assert.equal(classifyGgufVariantFit(variant, budget), "partial");
+});
+
+test("a total below the weights never lowers the estimate", async () => {
+  // A positive-but-smaller total is the case a `??` or `||` fallback lets through.
+  const { ggufVariantFitSizeBytes } = await import("../src/lib/gguf-fit.ts");
+  const bytes = 12 * GIB;
+  for (const download_size_bytes of [undefined, 0, bytes - 1, 1]) {
+    assert.equal(
+      ggufVariantFitSizeBytes({ size_bytes: bytes, download_size_bytes }),
+      bytes,
+      `a total of ${download_size_bytes} must not score below the weights`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- include the full GGUF variant footprint when the Hub estimates fit, including projector and drafter companions
- use one variant-level fit helper for card badges and variant sorting
- keep a conservative fallback so missing or zero aggregate sizes never undercut the main weights

## Reproduction

Muse Glimmer Q3_K_S has 12.79 GB of main weights plus a 3.85 GB projector and 1.45 GB drafter, for 18.09 GB total. On a 16 GiB GPU the previous Hub path classified only the main file as fits, while the full variant is partial.

Hosted A/B proof using the same assertion:

- before / fix reverted: https://github.com/Imagineer99/unsloth/actions/runs/33749452558 — main-file-only returned fits and failed against partial
- after: https://github.com/Imagineer99/unsloth/actions/runs/33749423587 — full-variant returned partial

## Validation

- npm run typecheck
- node --experimental-strip-types --test tests/gguf-variant-transfer-size.test.ts — 7 passed
- npm test — 6,823 passed
- deterministic worktree safety and pre-push gates passed