### PR TITLE
Studio: add account-aware workspace storage roots

### DIFF
--- a/studio/backend/tests/test_workspace_storage_roots.py
+++ b/studio/backend/tests/test_workspace_storage_roots.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Compatibility and isolation contract for account-aware storage roots."""
+
+import re
+
+import pytest
+
+from utils.paths import storage_roots
+from utils.workspace_context import (
+    LEGACY_WORKSPACE_SUBJECT,
+    current_workspace_subject,
+    reset_workspace_subject,
+    run_in_workspace,
+    set_workspace_subject,
+    workspace_key,
+    workspace_thread,
+)
+
+
+def test_legacy_subject_keeps_every_historical_root(tmp_path, monkeypatch):
+    studio_home = tmp_path / "studio"
+    documents_home = tmp_path / "documents"
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(studio_home))
+    monkeypatch.setenv("UNSLOTH_STUDIO_DOCUMENTS_HOME", str(documents_home))
+
+    assert current_workspace_subject() == LEGACY_WORKSPACE_SUBJECT
+    assert storage_roots.workspace_root() == studio_home
+    assert storage_roots.assets_root() == studio_home / "assets"
+    assert storage_roots.outputs_root() == studio_home / "outputs"
+    assert storage_roots.exports_root() == studio_home / "exports"
+    assert storage_roots.studio_db_path() == studio_home / "studio.db"
+    assert storage_roots.rag_root() == studio_home / "rag"
+    assert storage_roots.tensorboard_root() == studio_home / "runs"
+    assert storage_roots.project_workspaces_root() == documents_home / "Unsloth Studio" / "Projects"
+
+
+def test_managed_subject_roots_share_one_stable_key(tmp_path, monkeypatch):
+    studio_home = tmp_path / "studio"
+    documents_home = tmp_path / "documents"
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(studio_home))
+    monkeypatch.setenv("UNSLOTH_STUDIO_DOCUMENTS_HOME", str(documents_home))
+    monkeypatch.setattr(storage_roots.tempfile, "gettempdir", lambda: str(tmp_path / "tmp"))
+
+    token = set_workspace_subject("Alice.Example")
+    try:
+        key = workspace_key()
+        private_root = studio_home / "workspaces" / key
+        assert storage_roots.workspace_root() == private_root
+        assert storage_roots.assets_root() == private_root / "assets"
+        assert storage_roots.outputs_root() == private_root / "outputs"
+        assert storage_roots.exports_root() == private_root / "exports"
+        assert storage_roots.studio_db_path() == private_root / "studio.db"
+        assert storage_roots.rag_root() == private_root / "rag"
+        assert storage_roots.tensorboard_root() == private_root / "runs"
+        assert storage_roots.project_workspaces_root() == (
+            documents_home / "Unsloth Studio" / "Users" / key / "Projects"
+        )
+        assert storage_roots.tmp_root() == tmp_path / "tmp" / "unsloth-studio" / "workspaces" / key
+    finally:
+        reset_workspace_subject(token)
+
+
+@pytest.mark.parametrize("subject", ["con.txt", "NUL.tar.gz", "a/b", "...", "Alice Example"])
+def test_workspace_key_is_one_windows_safe_component(subject):
+    key = workspace_key(subject)
+    assert re.fullmatch(r"[a-z0-9_-]+-[0-9a-f]{12}", key)
+    assert "." not in key
+    assert "/" not in key
+    assert "\\" not in key
+    assert key == workspace_key(subject)
+
+
+def test_sanitised_prefix_collisions_keep_distinct_digests():
+    assert workspace_key("a.b") != workspace_key("a-b")
+
+
+def test_nested_binding_restores_the_previous_subject():
+    outer = set_workspace_subject("alice")
+    try:
+        assert run_in_workspace("bob", current_workspace_subject) == "bob"
+        assert current_workspace_subject() == "alice"
+    finally:
+        reset_workspace_subject(outer)
+
+
+def test_workspace_thread_carries_the_subject_without_leaking_it():
+    seen = []
+    token = set_workspace_subject("alice")
+    try:
+        thread = workspace_thread(target=lambda: seen.append(current_workspace_subject()))
+    finally:
+        reset_workspace_subject(token)
+    thread.start()
+    thread.join(timeout = 5)
+
+    assert seen == ["alice"]
+    assert current_workspace_subject() == LEGACY_WORKSPACE_SUBJECT

--- a/studio/backend/tests/test_workspace_storage_roots.py
+++ b/studio/backend/tests/test_workspace_storage_roots.py
@@ -89,7 +89,7 @@ def test_workspace_thread_carries_the_subject_without_leaking_it():
     seen = []
     token = set_workspace_subject("alice")
     try:
-        thread = workspace_thread(target=lambda: seen.append(current_workspace_subject()))
+        thread = workspace_thread(target = lambda: seen.append(current_workspace_subject()))
     finally:
         reset_workspace_subject(token)
     thread.start()

--- a/studio/backend/utils/paths/__init__.py
+++ b/studio/backend/utils/paths/__init__.py
@@ -15,6 +15,7 @@ from .path_utils import (
 )
 from .storage_roots import (
     studio_root,
+    workspace_root,
     assets_root,
     dataset_files_in_dir,
     datasets_root,
@@ -66,6 +67,7 @@ __all__ = [
     "reset_cache_case_resolution_state",
     "reveal_in_file_manager",
     "studio_root",
+    "workspace_root",
     "assets_root",
     "dataset_files_in_dir",
     "datasets_root",

--- a/studio/backend/utils/paths/storage_roots.py
+++ b/studio/backend/utils/paths/storage_roots.py
@@ -14,6 +14,11 @@ import tempfile
 
 from loggers import get_logger
 from utils.paths.path_utils import drop_appledouble_metadata, host_normalize_path
+from utils.workspace_context import (
+    LEGACY_WORKSPACE_SUBJECT,
+    current_workspace_subject,
+    workspace_key,
+)
 
 logger = get_logger(__name__)
 
@@ -68,6 +73,20 @@ def cache_root() -> Path:
     return studio_root() / "cache"
 
 
+def workspace_root() -> Path:
+    """Private persistent root for the active Studio account.
+
+    The original ``unsloth`` account deliberately retains the historical
+    install-root layout, so enabling account-aware roots never hides or moves
+    an existing single-user installation. Other subjects are isolated below
+    ``workspaces/``.
+    """
+    subject = current_workspace_subject()
+    if subject == LEGACY_WORKSPACE_SUBJECT:
+        return studio_root()
+    return studio_root() / "workspaces" / workspace_key(subject)
+
+
 def llama_slot_cache_root() -> Path:
     """Dir llama-server saves/restores slot KV state in across idle unloads."""
     return cache_root() / "llama-slots"
@@ -79,7 +98,7 @@ def studio_bin_root() -> Path:
 
 
 def assets_root() -> Path:
-    return studio_root() / "assets"
+    return workspace_root() / "assets"
 
 
 def datasets_root() -> Path:
@@ -95,11 +114,11 @@ def recipe_datasets_root() -> Path:
 
 
 def outputs_root() -> Path:
-    return studio_root() / "outputs"
+    return workspace_root() / "outputs"
 
 
 def exports_root() -> Path:
-    return studio_root() / "exports"
+    return workspace_root() / "exports"
 
 
 def auth_root() -> Path:
@@ -111,12 +130,12 @@ def auth_db_path() -> Path:
 
 
 def studio_db_path() -> Path:
-    return studio_root() / "studio.db"
+    return workspace_root() / "studio.db"
 
 
 def rag_root() -> Path:
     """Root directory for retrieval-augmented-generation state (db + uploads)."""
-    return studio_root() / "rag"
+    return workspace_root() / "rag"
 
 
 def rag_db_path() -> Path:
@@ -195,12 +214,21 @@ def documents_root() -> Path:
 def project_workspaces_root() -> Path:
     override = (os.environ.get("UNSLOTH_STUDIO_PROJECTS_HOME") or "").strip()
     if override:
-        return Path(override).expanduser()
-    return documents_root() / "Unsloth Studio" / "Projects"
+        root = Path(override).expanduser()
+    else:
+        root = documents_root() / "Unsloth Studio"
+    subject = current_workspace_subject()
+    if subject == LEGACY_WORKSPACE_SUBJECT:
+        return root / "Projects" if not override else root
+    return root / "Users" / workspace_key(subject) / "Projects"
 
 
 def tmp_root() -> Path:
-    return Path(tempfile.gettempdir()) / "unsloth-studio"
+    root = Path(tempfile.gettempdir()) / "unsloth-studio"
+    subject = current_workspace_subject()
+    if subject == LEGACY_WORKSPACE_SUBJECT:
+        return root
+    return root / "workspaces" / workspace_key(subject)
 
 
 def seed_uploads_root() -> Path:
@@ -220,7 +248,7 @@ def oxc_validator_tmp_root() -> Path:
 
 
 def tensorboard_root() -> Path:
-    return studio_root() / "runs"
+    return workspace_root() / "runs"
 
 
 def ensure_dir(path: Path) -> Path:

--- a/studio/backend/utils/workspace_context.py
+++ b/studio/backend/utils/workspace_context.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Authenticated workspace identity for request-scoped storage routing."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import threading
+from contextvars import ContextVar, Token
+from typing import Any, Callable
+
+
+LEGACY_WORKSPACE_SUBJECT = "unsloth"
+
+_workspace_subject: ContextVar[str] = ContextVar(
+    "unsloth_workspace_subject",
+    default = LEGACY_WORKSPACE_SUBJECT,
+)
+
+
+def current_workspace_subject() -> str:
+    """Return the authenticated subject whose private workspace is active."""
+    return _workspace_subject.get()
+
+
+def set_workspace_subject(subject: str) -> Token[str]:
+    """Bind storage lookups in the current async/thread context to ``subject``."""
+    if not subject:
+        raise ValueError("Workspace subject cannot be empty")
+    return _workspace_subject.set(subject)
+
+
+def reset_workspace_subject(token: Token[str]) -> None:
+    """Restore a previous workspace binding (primarily useful to tests)."""
+    _workspace_subject.reset(token)
+
+
+def run_in_workspace(subject: str, target: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+    """Run ``target`` with an explicit workspace binding.
+
+    Context variables follow async tasks but not newly-created threads, so
+    long-running work carries the account name as data and binds it at the
+    execution boundary.
+    """
+    token = set_workspace_subject(subject)
+    try:
+        return target(*args, **kwargs)
+    finally:
+        reset_workspace_subject(token)
+
+
+def workspace_thread(
+    *,
+    target: Callable[..., Any],
+    subject: str | None = None,
+    args: tuple[Any, ...] = (),
+    kwargs: dict[str, Any] | None = None,
+    **thread_kwargs: Any,
+) -> threading.Thread:
+    """Create a thread pinned to one authenticated workspace."""
+    bound_subject = subject or current_workspace_subject()
+    return threading.Thread(
+        target = run_in_workspace,
+        args = (bound_subject, target, *args),
+        kwargs = kwargs or {},
+        **thread_kwargs,
+    )
+
+
+def workspace_key(subject: str | None = None) -> str:
+    """Return a filesystem-safe, stable key for a non-legacy account.
+
+    The readable prefix helps operators identify a workspace. The digest keeps
+    differently-spelled subjects distinct after sanitisation. Dots are folded
+    away because Windows treats device names such as ``con.txt`` as reserved.
+    """
+    value = subject or current_workspace_subject()
+    readable = re.sub(r"[^a-z0-9_-]+", "-", value.casefold()).strip("-")
+    readable = (readable or "user")[:32]
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+    return f"{readable}-{digest}"


### PR DESCRIPTION
## Summary

This is the first, deliberately small layer extracted from #10102.

- Add a stable, filesystem-safe workspace key for an authenticated subject.
- Resolve private Studio storage beneath a subject-specific workspace root.
- Keep the existing `unsloth` owner's historical paths exactly unchanged.
- Scope project and temporary roots by the same key while leaving shared caches and install-wide authentication storage shared.
- Add focused compatibility, collision, Windows-path, nested-context, and thread-propagation tests.

This PR does not add account-management endpoints, the Accounts UI, request binding, or route-specific authorization gates. Those remain in the backed-up upper-layer branch and can be reviewed after this foundation lands.

## Validation

- `282 passed` across the focused workspace-root and existing storage-root suites.
- Ruff passed on all changed Python files.
- Deterministic worktree checks: clean, 0 findings.
- Pre-push gate: no stray tracked files; AGPL headers valid.
