### PR TITLE
Studio: drop MediaPageLink tooltip below titlebar controls on Windows

### DIFF
--- a/studio/frontend/src/components/media-page-link.tsx
+++ b/studio/frontend/src/components/media-page-link.tsx
@@ -65,7 +65,9 @@ export function MediaPageLink({
             />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{tooltip ?? `Go to ${label}`}</TooltipContent>
+        <TooltipContent side="bottom" sideOffset={6} className="tooltip-compact">
+          {tooltip ?? `Go to ${label}`}
+        </TooltipContent>
       </Tooltip>
     </>
   );

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -866,6 +866,16 @@ def test_compact_media_link_keeps_accessible_name_and_truncation():
     assert "arrowClassName" in button
 
 
+def test_media_page_link_tooltip_drops_below_titlebar_controls():
+    """unslothai/unsloth#10226: Images/Video park this link in the top-right header beside
+    Windows controls; a top tooltip blocks minimize/maximize/close."""
+    source = MEDIA_PAGE_LINK.read_text(encoding = "utf-8")
+    tooltip = source.split("<TooltipContent", 1)[1].split("</TooltipContent>", 1)[0]
+
+    assert 'side="bottom"' in tooltip
+    assert "sideOffset={6}" in tooltip
+
+
 def test_media_page_headers_out_stack_the_mac_drag_region():
     """macOS insets the media pages 0px, so their 48px header overlaps the navbar's 34px drag
     strip: the band must out-stack it yet stay click-through (controls click, gaps drag)."""


### PR DESCRIPTION
## Summary

Fixes #10226.

On the Images and Video pages, the cross-page `MediaPageLink` buttons sit in the top-right header beside the Windows minimize/maximize/close controls. Their tooltips defaulted to opening above the button, which covered the titlebar controls and blocked clicks.

This anchors the tooltip below the button, matching the temporary chat control.

## Changes

- `MediaPageLink`: set `side="bottom"`, `sideOffset={6}`, and `tooltip-compact` on the tooltip content
- Add a desktop reliability contract test so the placement stays below the titlebar

## Test plan

- [x] `pytest tests/studio/test_desktop_reliability_frontend_contract.py::test_media_page_link_tooltip_drops_below_titlebar_controls`
- [x] `pytest tests/studio/test_desktop_reliability_frontend_contract.py::test_compact_media_link_keeps_accessible_name_and_truncation`
