### PR TITLE
Studio: let Deep Research write longer reports on saved connections

### DIFF
--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -462,9 +462,7 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
 def _provider_output_floor(provider_type: object) -> int:
     if not isinstance(provider_type, str):
         return _EXTERNAL_MIN_OUTPUT_TOKENS
-    return _EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER.get(
-        provider_type, _EXTERNAL_MIN_OUTPUT_TOKENS
-    )
+    return _EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER.get(provider_type, _EXTERNAL_MIN_OUTPUT_TOKENS)
 
 
 def _saved_connection_cap(provider_id: object) -> int | None:

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -84,6 +84,7 @@ _SYNTHESIS_EVIDENCE_CHARS_PER_TOKEN = 3.0
 _SYNTHESIS_CONTEXT_RESERVE_TOKENS = 4_096
 _SYNTHESIS_MAX_TOKENS = 16_384
 # Streaming progress is persisted as a full row snapshot; these bound how often that happens.
+_CAP_UNREADABLE = object()
 _PROGRESS_FLUSH_CHARS = 512
 _PROGRESS_FLUSH_SECONDS = 0.25
 _PROGRESS_FLUSH_CHARS_PER_SECOND = 1_048_576
@@ -439,7 +440,12 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
     """
     if not inference.get("providerType"):
         return _SYNTHESIS_MAX_TOKENS
+    floor = _provider_output_floor(inference.get("providerType"))
     saved = _saved_connection_cap(inference.get("providerId"))
+    if saved is _CAP_UNREADABLE:
+        # The current cap could not be confirmed, so the client's older ceiling is not
+        # spendable; the default is the only budget known to have been allowed before.
+        return max(_SYNTHESIS_MAX_TOKENS, floor)
     resolved = _positive_int_or_none(inference.get("maxOutputTokens"))
     if resolved:
         # The client resolved this against the run's own model, but the run is durable: the
@@ -458,7 +464,7 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
     # The chat path never hands a connection less than its provider's floor, because below it
     # a thinking answer is cut off before the report starts. A saved cap is allowed to lower
     # the budget, but not past that.
-    return max(budget, _provider_output_floor(inference.get("providerType")))
+    return max(budget, floor)
 
 
 def _provider_output_floor(provider_type: object) -> int:
@@ -467,15 +473,20 @@ def _provider_output_floor(provider_type: object) -> int:
     return _EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER.get(provider_type, _EXTERNAL_MIN_OUTPUT_TOKENS)
 
 
-def _saved_connection_cap(provider_id: object) -> int | None:
-    """The connection's currently saved Max Output Tokens, or None if it has none."""
+def _saved_connection_cap(provider_id: object) -> int | None | object:
+    """The connection's saved Max Output Tokens, None if it has none, else _CAP_UNREADABLE.
+
+    A caller cannot treat an unreadable row as an uncapped connection: the cap may have been
+    lowered since this durable run was created, and spending the client's older ceiling would
+    be exactly the request the user capped away.
+    """
     if not isinstance(provider_id, str):
         return None
     try:
         provider = providers_db.get_provider(provider_id) or {}
     except Exception:
         logger.debug("research.provider_cap_probe_failed", exc_info = True)
-        return None
+        return _CAP_UNREADABLE
     return _positive_int_or_none(provider.get("max_output_tokens"))
 
 

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -83,9 +83,10 @@ _MIN_QUESTION_CHARS = 800
 _SYNTHESIS_EVIDENCE_CHARS_PER_TOKEN = 3.0
 _SYNTHESIS_CONTEXT_RESERVE_TOKENS = 4_096
 _SYNTHESIS_MAX_TOKENS = 16_384
-# What the client sends for a model it has no published cap for
-# (EXTERNAL_MAX_OUTPUT_TOKENS in features/chat/provider-capabilities.ts).
-_EXTERNAL_MAX_OUTPUT_TOKENS = 32_768
+# Streaming progress is persisted as a full row snapshot; these bound how often that happens.
+_PROGRESS_FLUSH_CHARS = 512
+_PROGRESS_FLUSH_SECONDS = 0.25
+_PROGRESS_FLUSH_CHARS_PER_SECOND = 1_048_576
 # Providers whose thinking answers truncate below a floor; mirrors
 # EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER in the same client module.
 _EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER = {"kimi": 16_000}
@@ -448,11 +449,12 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
     else:
         # A run created before the client sent its resolved ceiling falls back to here. The
         # saved cap belongs to the connection, not to this run's model -- one connection
-        # fronts many models, and the client bounds it by that model's documented ceiling
-        # before sending it, using a table this side does not have. Bound it instead by what
-        # the client itself sends for a model nothing documents, so a cap set for a
-        # 256k-output model cannot become this run's budget.
-        budget = min(saved, _EXTERNAL_MAX_OUTPUT_TOKENS) if saved else _SYNTHESIS_MAX_TOKENS
+        # fronts many models, and only the client has the table that bounds it by the
+        # selected model's documented ceiling (claude-opus-4-1 stops at 32_000 while a
+        # connection may be saved at 32_768). Without that table this side cannot raise the
+        # budget safely at all, so a legacy run keeps the default it already had; the saved
+        # cap may still lower it.
+        budget = min(saved, _SYNTHESIS_MAX_TOKENS) if saved else _SYNTHESIS_MAX_TOKENS
     # The chat path never hands a connection less than its provider's floor, because below it
     # a thinking answer is cut off before the report starts. A saved cap is allowed to lower
     # the budget, but not past that.
@@ -1730,10 +1732,21 @@ class ResearchSupervisor:
                                     run["id"], phase, call_id, report, emitted_labels
                                 )
                         pending_chars = len(pending_reasoning) + len(pending_report)
+                        # Every flush rewrites the whole report row, so a fixed threshold
+                        # makes persistence quadratic in the report length. That was cheap
+                        # while the report stopped at 16k tokens; at the ceilings a saved
+                        # connection unlocks it is gigabytes through the shared writer. Both
+                        # triggers therefore slow down as the report grows.
+                        written = len(report) + len(reasoning)
+                        flush_chars = max(_PROGRESS_FLUSH_CHARS, written // 64)
+                        flush_seconds = max(
+                            _PROGRESS_FLUSH_SECONDS, written / _PROGRESS_FLUSH_CHARS_PER_SECOND
+                        )
                         if (
-                            pending_chars >= 512
+                            pending_chars >= flush_chars
                             or pending_chars > 0
-                            and asyncio.get_running_loop().time() - last_progress_flush >= 0.25
+                            and asyncio.get_running_loop().time() - last_progress_flush
+                            >= flush_seconds
                         ):
                             await flush_progress()
                     if semantic_output_at is None:

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -86,6 +86,10 @@ _SYNTHESIS_MAX_TOKENS = 16_384
 # What the client sends for a model it has no published cap for
 # (EXTERNAL_MAX_OUTPUT_TOKENS in features/chat/provider-capabilities.ts).
 _EXTERNAL_MAX_OUTPUT_TOKENS = 32_768
+# Providers whose thinking answers truncate below a floor; mirrors
+# EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER in the same client module.
+_EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER = {"kimi": 16_000}
+_EXTERNAL_MIN_OUTPUT_TOKENS = 64
 # Below this loaded context the prompt scaffolding alone fills the window, so grounding is skipped.
 _AUTO_SCRAPE_MIN_CONTEXT_TOKENS = 8_192
 # OFF by default (UNSLOTH_RESEARCH_AUTO_SCRAPE=1): benchmarking showed no reliable accuracy gain
@@ -440,14 +444,27 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
         # The client resolved this against the run's own model, but the run is durable: the
         # connection's cap can have been lowered since it was created, and the saved row is
         # the current truth about what the user allows this connection to spend.
-        return min(resolved, saved) if saved else resolved
-    # A run created before the client sent its resolved ceiling falls back to here. The saved
-    # cap belongs to the connection, not to this run's model -- one connection fronts many
-    # models, and the client bounds it by that model's documented ceiling before sending it,
-    # using a table this side does not have. Bound it instead by what the client itself sends
-    # for a model nothing documents, so a cap set for a 256k-output model cannot become this
-    # run's budget.
-    return min(saved, _EXTERNAL_MAX_OUTPUT_TOKENS) if saved else _SYNTHESIS_MAX_TOKENS
+        budget = min(resolved, saved) if saved else resolved
+    else:
+        # A run created before the client sent its resolved ceiling falls back to here. The
+        # saved cap belongs to the connection, not to this run's model -- one connection
+        # fronts many models, and the client bounds it by that model's documented ceiling
+        # before sending it, using a table this side does not have. Bound it instead by what
+        # the client itself sends for a model nothing documents, so a cap set for a
+        # 256k-output model cannot become this run's budget.
+        budget = min(saved, _EXTERNAL_MAX_OUTPUT_TOKENS) if saved else _SYNTHESIS_MAX_TOKENS
+    # The chat path never hands a connection less than its provider's floor, because below it
+    # a thinking answer is cut off before the report starts. A saved cap is allowed to lower
+    # the budget, but not past that.
+    return max(budget, _provider_output_floor(inference.get("providerType")))
+
+
+def _provider_output_floor(provider_type: object) -> int:
+    if not isinstance(provider_type, str):
+        return _EXTERNAL_MIN_OUTPUT_TOKENS
+    return _EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER.get(
+        provider_type, _EXTERNAL_MIN_OUTPUT_TOKENS
+    )
 
 
 def _saved_connection_cap(provider_id: object) -> int | None:

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -11,6 +11,7 @@ import os
 import re
 import sqlite3
 import threading
+import time
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -85,6 +86,8 @@ _SYNTHESIS_CONTEXT_RESERVE_TOKENS = 4_096
 _SYNTHESIS_MAX_TOKENS = 16_384
 # Streaming progress is persisted as a full row snapshot; these bound how often that happens.
 _CAP_UNREADABLE = object()
+_CAP_LOOKUP_ATTEMPTS = 3
+_CAP_LOOKUP_RETRY_SECONDS = 0.2
 _PROGRESS_FLUSH_CHARS = 512
 _PROGRESS_FLUSH_SECONDS = 0.25
 _PROGRESS_FLUSH_CHARS_PER_SECOND = 1_048_576
@@ -443,9 +446,13 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
     floor = _provider_output_floor(inference.get("providerType"))
     saved = _saved_connection_cap(inference.get("providerId"))
     if saved is _CAP_UNREADABLE:
-        # The current cap could not be confirmed, so the client's older ceiling is not
-        # spendable; the default is the only budget known to have been allowed before.
-        return max(_SYNTHESIS_MAX_TOKENS, floor)
+        # The cap could not be confirmed even after retrying, so neither signal can be
+        # trusted on its own: take the smaller of the client's ceiling and the budget every
+        # run spent before any of this existed. A saved cap lower than that is unknowable
+        # here, and failing a run that has already done all of its research over a transient
+        # lock costs the user far more than one report at the previous default.
+        unconfirmed = _positive_int_or_none(inference.get("maxOutputTokens"))
+        return max(min(unconfirmed or _SYNTHESIS_MAX_TOKENS, _SYNTHESIS_MAX_TOKENS), floor)
     resolved = _positive_int_or_none(inference.get("maxOutputTokens"))
     if resolved:
         # The client resolved this against the run's own model, but the run is durable: the
@@ -482,12 +489,19 @@ def _saved_connection_cap(provider_id: object) -> int | None | object:
     """
     if not isinstance(provider_id, str):
         return None
-    try:
-        provider = providers_db.get_provider(provider_id) or {}
-    except Exception:
-        logger.debug("research.provider_cap_probe_failed", exc_info = True)
-        return _CAP_UNREADABLE
-    return _positive_int_or_none(provider.get("max_output_tokens"))
+    for attempt in range(_CAP_LOOKUP_ATTEMPTS):
+        try:
+            provider = providers_db.get_provider(provider_id) or {}
+        except Exception:
+            logger.debug("research.provider_cap_probe_failed", exc_info = True)
+            # A read that lost a writer lock is transient, and this runs off the loop in a
+            # thread, so a short retry is worth more than a guess about the user's cap.
+            if attempt + 1 < _CAP_LOOKUP_ATTEMPTS:
+                time.sleep(_CAP_LOOKUP_RETRY_SECONDS)
+                continue
+            return _CAP_UNREADABLE
+        return _positive_int_or_none(provider.get("max_output_tokens"))
+    return _CAP_UNREADABLE
 
 
 def _normalize_completion_usage(raw: Any) -> dict[str, int] | None:

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -83,6 +83,9 @@ _MIN_QUESTION_CHARS = 800
 _SYNTHESIS_EVIDENCE_CHARS_PER_TOKEN = 3.0
 _SYNTHESIS_CONTEXT_RESERVE_TOKENS = 4_096
 _SYNTHESIS_MAX_TOKENS = 16_384
+# What the client sends for a model it has no published cap for
+# (EXTERNAL_MAX_OUTPUT_TOKENS in features/chat/provider-capabilities.ts).
+_EXTERNAL_MAX_OUTPUT_TOKENS = 32_768
 # Below this loaded context the prompt scaffolding alone fills the window, so grounding is skipped.
 _AUTO_SCRAPE_MIN_CONTEXT_TOKENS = 8_192
 # OFF by default (UNSLOTH_RESEARCH_AUTO_SCRAPE=1): benchmarking showed no reliable accuracy gain
@@ -423,10 +426,9 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
     """The report's output budget: what the connection actually accepts, else the default.
 
     The client resolves the same per-model ceiling the chat path already sends to this
-    connection, so the value is one the provider is known to take; a run created before that
-    field existed falls back to the connection's saved cap. Nothing is raised on a guess,
-    because a provider that rejects an over-limit max_output_tokens rather than clamping it
-    would fail the run outright.
+    connection, so the value is one the provider is known to take. Nothing is raised on a
+    guess, because a provider that rejects an over-limit max_output_tokens rather than
+    clamping it would fail the run outright.
     """
     if not inference.get("providerType"):
         return _SYNTHESIS_MAX_TOKENS
@@ -441,7 +443,14 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
     except Exception:
         logger.debug("research.provider_cap_probe_failed", exc_info = True)
         provider = {}
-    return _positive_int_or_none(provider.get("max_output_tokens")) or _SYNTHESIS_MAX_TOKENS
+    saved = _positive_int_or_none(provider.get("max_output_tokens"))
+    # A run created before the client sent its resolved ceiling falls back to here. The saved
+    # cap belongs to the connection, not to this run's model -- one connection fronts many
+    # models, and the client bounds it by that model's documented ceiling before sending it,
+    # using a table this side does not have. Bound it instead by what the client itself sends
+    # for a model nothing documents, so a cap set for a 256k-output model cannot become this
+    # run's budget.
+    return min(saved, _EXTERNAL_MAX_OUTPUT_TOKENS) if saved else _SYNTHESIS_MAX_TOKENS
 
 
 def _normalize_completion_usage(raw: Any) -> dict[str, int] | None:

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -417,8 +417,10 @@ def _resolve_max_tokens(
         # No second ceiling on an explicit budget: the caller already resolved one the
         # connection accepts, and re-capping it here is what truncated the report.
         requested = int(max_tokens)
-    # main's clamp skips the local context window for a run carrying a providerType, which
-    # is the same exemption this needed -- the report generates on the provider's hardware.
+    # A saved connection generates on the provider's own hardware, so the resident local model
+    # bounds nothing about it. main's clamp already makes that exemption -- _loaded_context_length
+    # returns None for a run carrying a providerType -- so this defers to it rather than
+    # short-circuiting, and a local run still gets clamped as before.
     return _clamp_max_tokens_for_context(requested, messages, inference = inference)
 
 
@@ -432,18 +434,13 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
     """
     if not inference.get("providerType"):
         return _SYNTHESIS_MAX_TOKENS
+    saved = _saved_connection_cap(inference.get("providerId"))
     resolved = _positive_int_or_none(inference.get("maxOutputTokens"))
     if resolved:
-        return resolved
-    provider_id = inference.get("providerId")
-    if not isinstance(provider_id, str):
-        return _SYNTHESIS_MAX_TOKENS
-    try:
-        provider = providers_db.get_provider(provider_id) or {}
-    except Exception:
-        logger.debug("research.provider_cap_probe_failed", exc_info = True)
-        provider = {}
-    saved = _positive_int_or_none(provider.get("max_output_tokens"))
+        # The client resolved this against the run's own model, but the run is durable: the
+        # connection's cap can have been lowered since it was created, and the saved row is
+        # the current truth about what the user allows this connection to spend.
+        return min(resolved, saved) if saved else resolved
     # A run created before the client sent its resolved ceiling falls back to here. The saved
     # cap belongs to the connection, not to this run's model -- one connection fronts many
     # models, and the client bounds it by that model's documented ceiling before sending it,
@@ -451,6 +448,18 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
     # for a model nothing documents, so a cap set for a 256k-output model cannot become this
     # run's budget.
     return min(saved, _EXTERNAL_MAX_OUTPUT_TOKENS) if saved else _SYNTHESIS_MAX_TOKENS
+
+
+def _saved_connection_cap(provider_id: object) -> int | None:
+    """The connection's currently saved Max Output Tokens, or None if it has none."""
+    if not isinstance(provider_id, str):
+        return None
+    try:
+        provider = providers_db.get_provider(provider_id) or {}
+    except Exception:
+        logger.debug("research.provider_cap_probe_failed", exc_info = True)
+        return None
+    return _positive_int_or_none(provider.get("max_output_tokens"))
 
 
 def _normalize_completion_usage(raw: Any) -> dict[str, int] | None:

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -2746,8 +2746,8 @@ class ResearchSupervisor:
                 synthesis_usage = recovery_usage
             else:
                 requested_max_tokens = _resolve_max_tokens(
-                synthesis_max_tokens,
-                _run_inference_request(run),
+                    synthesis_max_tokens,
+                    _run_inference_request(run),
                     synthesis_messages,
                 )
             await self._check_active(run["id"])

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -55,6 +55,7 @@ from core.research.prompts import (
     _system_prompt_with_instructions,
 )
 from loggers import get_logger
+from storage import providers_db
 from storage import research_runs_db as db
 from storage.studio_db import (
     get_chat_message,
@@ -81,6 +82,7 @@ _MIN_SYNTHESIS_EVIDENCE_CHARS = 1_500
 _MIN_QUESTION_CHARS = 800
 _SYNTHESIS_EVIDENCE_CHARS_PER_TOKEN = 3.0
 _SYNTHESIS_CONTEXT_RESERVE_TOKENS = 4_096
+_SYNTHESIS_MAX_TOKENS = 16_384
 # Below this loaded context the prompt scaffolding alone fills the window, so grounding is skipped.
 _AUTO_SCRAPE_MIN_CONTEXT_TOKENS = 8_192
 # OFF by default (UNSLOTH_RESEARCH_AUTO_SCRAPE=1): benchmarking showed no reliable accuracy gain
@@ -406,10 +408,40 @@ def _clamp_max_tokens_for_context(
 def _resolve_max_tokens(
     max_tokens: int | None, inference: dict[str, Any], messages: list[dict]
 ) -> int:
-    requested = int(max_tokens or inference.get("maxTokens") or 4096)
-    ceiling = 16384 if max_tokens is not None else 8192
-    capped = min(requested, ceiling)
-    return _clamp_max_tokens_for_context(capped, messages, inference = inference)
+    if max_tokens is None:
+        requested = min(int(inference.get("maxTokens") or 4096), 8192)
+    else:
+        # No second ceiling on an explicit budget: the caller already resolved one the
+        # connection accepts, and re-capping it here is what truncated the report.
+        requested = int(max_tokens)
+    # main's clamp skips the local context window for a run carrying a providerType, which
+    # is the same exemption this needed -- the report generates on the provider's hardware.
+    return _clamp_max_tokens_for_context(requested, messages, inference = inference)
+
+
+def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
+    """The report's output budget: what the connection actually accepts, else the default.
+
+    The client resolves the same per-model ceiling the chat path already sends to this
+    connection, so the value is one the provider is known to take; a run created before that
+    field existed falls back to the connection's saved cap. Nothing is raised on a guess,
+    because a provider that rejects an over-limit max_output_tokens rather than clamping it
+    would fail the run outright.
+    """
+    if not inference.get("providerType"):
+        return _SYNTHESIS_MAX_TOKENS
+    resolved = _positive_int_or_none(inference.get("maxOutputTokens"))
+    if resolved:
+        return resolved
+    provider_id = inference.get("providerId")
+    if not isinstance(provider_id, str):
+        return _SYNTHESIS_MAX_TOKENS
+    try:
+        provider = providers_db.get_provider(provider_id) or {}
+    except Exception:
+        logger.debug("research.provider_cap_probe_failed", exc_info = True)
+        provider = {}
+    return _positive_int_or_none(provider.get("max_output_tokens")) or _SYNTHESIS_MAX_TOKENS
 
 
 def _normalize_completion_usage(raw: Any) -> dict[str, int] | None:
@@ -2557,6 +2589,9 @@ class ResearchSupervisor:
                 ),
             },
         ]
+        synthesis_max_tokens = await asyncio.to_thread(
+            _synthesis_max_tokens, run["config"].get("inferenceRequest") or {}
+        )
         (
             report,
             synthesis_reasoning,
@@ -2566,7 +2601,7 @@ class ResearchSupervisor:
             run,
             synthesis_messages,
             phase = "synthesis",
-            max_tokens = 16384,
+            max_tokens = synthesis_max_tokens,
         )
         await self._check_active(run["id"])
         report = _select_synthesis_report(report, synthesis_reasoning)
@@ -2602,7 +2637,7 @@ class ResearchSupervisor:
                 synthesis_messages[1],
             ]
             recovery_max_tokens = _resolve_max_tokens(
-                16384,
+                synthesis_max_tokens,
                 _run_inference_request(run),
                 recovery_messages,
             )
@@ -2615,7 +2650,7 @@ class ResearchSupervisor:
                 run,
                 recovery_messages,
                 phase = "synthesis_recovery",
-                max_tokens = 16384,
+                max_tokens = synthesis_max_tokens,
                 enable_thinking = False,
             )
             synthesis_reasoning += recovery_reasoning
@@ -2640,8 +2675,8 @@ class ResearchSupervisor:
                 synthesis_usage = recovery_usage
             else:
                 requested_max_tokens = _resolve_max_tokens(
-                    16384,
-                    _run_inference_request(run),
+                synthesis_max_tokens,
+                _run_inference_request(run),
                     synthesis_messages,
                 )
             await self._check_active(run["id"])

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -84,23 +84,17 @@ _MIN_QUESTION_CHARS = 800
 _SYNTHESIS_EVIDENCE_CHARS_PER_TOKEN = 3.0
 _SYNTHESIS_CONTEXT_RESERVE_TOKENS = 4_096
 _SYNTHESIS_MAX_TOKENS = 16_384
-# The most the report may ask for however large a ceiling the connection reports. The
-# documented per-model caps reach 384_000, nothing between here and the provider bounds what
-# is sent, and a request the connection refuses or cannot finish in time costs the whole run.
+# Nothing between here and the provider bounds what is sent, and published caps reach 384_000.
 _SYNTHESIS_MAX_TOKENS_CEILING = 65_536
-# Conservative sustained decode rate for a saved connection, used only to keep the report
-# budget inside the run's own wall clock. Deliberately low: overshooting here loses the run.
+# Deliberately pessimistic: overshooting the wall clock loses the run, undershooting shortens it.
 _SYNTHESIS_TOKENS_PER_SECOND = 50
-# Streaming progress is persisted as a full row snapshot; these bound how often that happens.
 _CAP_UNREADABLE = object()
 _CAP_LOOKUP_ATTEMPTS = 3
 _CAP_LOOKUP_RETRY_SECONDS = 0.2
 _PROGRESS_FLUSH_CHARS = 512
 _PROGRESS_FLUSH_SECONDS = 0.25
-# _PROGRESS_FLUSH_CHARS / _PROGRESS_FLUSH_SECONDS * 64, so both triggers start scaling from the
-# same written length. A larger divisor puts the time arm's knee at 262_144 chars, which is
-# where a 65_536-token report ENDS, so across the whole range this change unlocks the character
-# scaling never binds and the row is still rewritten four times a second.
+# _PROGRESS_FLUSH_CHARS / _PROGRESS_FLUSH_SECONDS * 64: both arms must scale from the same
+# written length, or the time arm's knee lands where a 65_536-token report ENDS and only it binds.
 _PROGRESS_FLUSH_CHARS_PER_SECOND = 131_072
 # Providers whose thinking answers truncate below a floor; mirrors
 # EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER in the same client module.
@@ -434,66 +428,39 @@ def _resolve_max_tokens(
     if max_tokens is None:
         requested = min(int(inference.get("maxTokens") or 4096), 8192)
     else:
-        # No second ceiling on an explicit budget: the caller already resolved one the
-        # connection accepts, and re-capping it here is what truncated the report. The floor
-        # stays, though: main's `max_tokens or ...` made a 0 impossible to send, and the
-        # route rejects a request that asks for one.
+        # Re-capping a budget the caller already resolved is what truncated the report.
         requested = max(1, int(max_tokens))
-    # A saved connection generates on the provider's own hardware, so the resident local model
-    # bounds nothing about it. main's clamp already makes that exemption -- _loaded_context_length
-    # returns None for a run carrying a providerType -- so this defers to it rather than
-    # short-circuiting, and a local run still gets clamped as before.
+    # Defers rather than short-circuits: _loaded_context_length is already None for a run
+    # carrying a providerType.
     return _clamp_max_tokens_for_context(requested, messages, inference = inference)
 
 
 def _synthesis_max_tokens(inference: dict[str, Any], model_timeout_seconds: Any = None) -> int:
-    """The report's output budget: what the connection accepts, bounded, else the default.
+    """The report's output budget, between `_report_floor` and `_synthesis_budget_ceiling`.
 
-    The client resolves the selected model's documented output limit, or the ceiling the user
-    saved on the connection itself. That is a limit the provider publishes rather than one any
-    request has been observed to survive, so nothing here treats it as unconditionally safe:
-    `_synthesis_budget_ceiling` bounds it, and the value is never raised on a guess, because a
-    provider that rejects an over-limit max_output_tokens rather than clamping it would fail
-    the run outright at its most expensive step.
-
-    The budget never falls below `_SYNTHESIS_MAX_TOKENS`, which is what every run spent before
-    any of this existed, unless the client's own ceiling is lower -- that one is the model's
-    documented limit, so asking past it would be refused.
+    The client's ceiling is a limit the provider PUBLISHES, not one any request has survived.
     """
     if not inference.get("providerType"):
         return _SYNTHESIS_MAX_TOKENS
     floor = _provider_output_floor(inference.get("providerType"))
     saved = _saved_connection_cap(inference.get("providerId"))
     if saved is _CAP_UNREADABLE:
-        # The cap could not be confirmed even after retrying, so neither signal can be
-        # trusted on its own: take the smaller of the client's ceiling and the budget every
-        # run spent before any of this existed. A saved cap lower than that is unknowable
-        # here, and failing a run that has already done all of its research over a transient
-        # lock costs the user far more than one report at the previous default.
+        # Neither signal is confirmable, so spend the smaller: losing a finished run to a
+        # transient lock costs far more.
         unconfirmed = _positive_int_or_none(inference.get("maxOutputTokens"))
         return max(min(unconfirmed or _SYNTHESIS_MAX_TOKENS, _SYNTHESIS_MAX_TOKENS), floor)
     resolved = _positive_int_or_none(inference.get("maxOutputTokens"))
     if resolved and not saved and inference.get("maxOutputTokensFromSavedCap") is True:
-        # Nothing documents this model, so the connection's own cap was the only thing holding
-        # that number up, and the user has since cleared it. Blanking the field is an ordinary
-        # edit -- for an undocumented model it is what the Max Tokens limit is FOR -- and a run
-        # created now would not ask for the removed ceiling either, so this one stops too.
+        # The cap was the only thing holding this number up, and clearing it is what that
+        # field is FOR on an undocumented model.
         resolved = None
     if resolved:
-        # The client resolved this against the run's own model, but the run is durable: the
-        # connection's cap can have been lowered since it was created, and the saved row is
-        # the current truth about what the user allows this connection to spend.
+        # The run is durable, so the cap can have been lowered since the client resolved this.
         budget = min(resolved, saved) if saved else resolved
     else:
-        # A run created before the client sent its resolved ceiling falls back to here. The
-        # saved cap belongs to the connection, not to this run's model -- one connection
-        # fronts many models, and only the client has the table that bounds it by the
-        # selected model's documented ceiling (claude-opus-4-1 stops at 32_000 while a
-        # connection may be saved at 32_768). Without that table this side cannot raise the
-        # budget safely at all, so a legacy run keeps exactly the default it already had.
+        # Legacy run: the saved cap is connection-wide, so raising on it would be a guess.
         budget = _SYNTHESIS_MAX_TOKENS
-    # The chat path never hands a connection less than its provider's floor, because below it
-    # a thinking answer is cut off before the report starts.
+    # Below its provider floor a thinking answer is cut off before the report starts.
     return max(
         min(budget, _synthesis_budget_ceiling(model_timeout_seconds)),
         _report_floor(inference),
@@ -504,13 +471,8 @@ def _synthesis_max_tokens(inference: dict[str, Any], model_timeout_seconds: Any 
 def _report_floor(inference: dict[str, Any]) -> int:
     """The budget every run had before a connection ceiling was read at all.
 
-    Only the model's own published limit may pull the report below it. A connection override
-    may not: that column sizes the chat Max Tokens slider, and a user who capped a connection
-    at 8_192 for cost was not asking for a shorter report than Deep Research has been writing
-    them all along. The distinction is invisible in `maxOutputTokens`, which already has the
-    override folded into the published cap -- min(65_536, 8_192) and a model that genuinely
-    stops at 8_192 are the same number by the time it arrives -- so the published limit is
-    carried separately and read here.
+    Only a model's own published limit may go below it, never an override sizing the chat
+    slider -- and `maxOutputTokens` arrives with the override already folded in.
     """
     published = _positive_int_or_none(inference.get("maxOutputTokensPublished"))
     if published:
@@ -519,24 +481,16 @@ def _report_floor(inference: dict[str, Any]) -> int:
 
 
 def _synthesis_budget_ceiling(model_timeout_seconds: Any = None) -> int:
-    """The most this run can usefully ask the connection for, whatever ceiling it reports.
+    """The most this run can usefully ask for, never below the previous default.
 
-    Two bounds, neither of which may pull the budget below the previous default:
-
-    - The run's own wall clock. `_stream_completion` aborts the synthesis call at
-      `modelTimeoutSeconds` and does NOT return the report it has already streamed, while a
-      report that merely runs out of budget comes back truncated under a notice. Handing a
-      connection more tokens than it can decode inside that window therefore trades a report
-      the user can read for a failed run at the last and most expensive step.
-    - An absolute ceiling, for a run whose wall clock is unlimited and for a documented cap
-      or connection override that is simply too large: nothing between here and the provider
-      bounds what is sent, and the published caps go as high as 384_000.
+    `_stream_completion` aborts at `modelTimeoutSeconds` WITHOUT returning the report it has
+    already streamed, while running out of budget merely truncates it under a notice.
     """
     ceiling = _SYNTHESIS_MAX_TOKENS_CEILING
     timeout = model_timeout_seconds
     if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
         timeout = None
-    # 0 is "unlimited" in the budgets schema, so only a positive one bounds anything.
+    # 0 is "unlimited" in the budgets schema.
     if timeout and timeout > 0:
         ceiling = min(ceiling, int(timeout * _SYNTHESIS_TOKENS_PER_SECOND))
     return max(ceiling, _SYNTHESIS_MAX_TOKENS)
@@ -551,9 +505,8 @@ def _provider_output_floor(provider_type: object) -> int:
 def _saved_connection_cap(provider_id: object) -> int | None | object:
     """The connection's saved Max Output Tokens, None if it has none, else _CAP_UNREADABLE.
 
-    A caller cannot treat an unreadable row as an uncapped connection: the cap may have been
-    lowered since this durable run was created, and spending the client's older ceiling would
-    be exactly the request the user capped away.
+    An unreadable row is not an uncapped connection: the cap may have been lowered since this
+    durable run was created, and spending the older ceiling is the request the user capped away.
     """
     if not isinstance(provider_id, str):
         return None
@@ -562,8 +515,7 @@ def _saved_connection_cap(provider_id: object) -> int | None | object:
             provider = providers_db.get_provider(provider_id) or {}
         except Exception:
             logger.debug("research.provider_cap_probe_failed", exc_info = True)
-            # A read that lost a writer lock is transient, and this runs off the loop in a
-            # thread, so a short retry is worth more than a guess about the user's cap.
+            # A read that lost the writer lock is transient, and this runs off the loop.
             if attempt + 1 < _CAP_LOOKUP_ATTEMPTS:
                 time.sleep(_CAP_LOOKUP_RETRY_SECONDS)
                 continue
@@ -1676,12 +1628,8 @@ class ResearchSupervisor:
                             and inference.get("providerType")
                             and phase in ("synthesis", "synthesis_recovery")
                         ):
-                            # The run is durable and this loop re-sends after a queue or a
-                            # rate-limit wait, so the budget the caller resolved can be
-                            # minutes old by now. Re-read the saved cap here, where the
-                            # request is actually built: the recovery pass and every retry
-                            # are bounded by the ceiling in force when they go out, not by
-                            # the one that was in force when synthesis started.
+                            # This loop re-sends after a queue or rate-limit wait, so recovery
+                            # and every retry are bounded by the cap in force when they go out.
                             max_tokens = min(
                                 max_tokens,
                                 await asyncio.to_thread(
@@ -1842,11 +1790,7 @@ class ResearchSupervisor:
                                     run["id"], phase, call_id, report, emitted_labels
                                 )
                         pending_chars = len(pending_reasoning) + len(pending_report)
-                        # Every flush rewrites the whole report row, so a fixed threshold
-                        # makes persistence quadratic in the report length. That was cheap
-                        # while the report stopped at 16k tokens; at the ceilings a saved
-                        # connection unlocks it is gigabytes through the shared writer. Both
-                        # triggers therefore slow down as the report grows.
+                        # Every flush rewrites the whole row: quadratic in report length.
                         written = len(report) + len(reasoning)
                         flush_chars = max(_PROGRESS_FLUSH_CHARS, written // 64)
                         flush_seconds = max(
@@ -2767,13 +2711,8 @@ class ResearchSupervisor:
         except Exception:
             if synthesis_max_tokens <= _SYNTHESIS_MAX_TOKENS:
                 raise
-            # The raised budget is the only thing this call does differently from the one
-            # every run made before it, and the ways a connection can refuse it are not all
-            # knowable from here: a per-endpoint limit below the model's published cap, a
-            # router fronting several of them, or a self-hosted server whose context window
-            # has to hold the synthesis prompt as well. Failing here would discard a run
-            # that has already done all of its research, so the last attempt is made at the
-            # budget that has always worked.
+            # The ways a connection can refuse a raised budget are not enumerable here, and
+            # failing would discard a run that already finished its research.
             logger.warning(
                 "research.synthesis_budget_refused run_id=%s budget=%s",
                 run["id"],
@@ -2847,13 +2786,8 @@ class ResearchSupervisor:
             except (RunCancelled, LeaseLost):
                 raise
             except Exception:
-                # Recovery exists to improve on a draft that is already in hand, so failing
-                # the run here would discard the very thing it was called to rescue -- and
-                # its prompt carries instructions the first one did not, so an endpoint that
-                # counts prompt plus requested output against one window can refuse the
-                # second request at a budget the first fit inside. The first draft goes out
-                # under its incomplete-report notice, which is what it would have done had
-                # recovery merely come back empty.
+                # Failing would discard the draft recovery was called to rescue, and its
+                # larger prompt can be refused at a budget the first request fit inside.
                 logger.warning(
                     "research.synthesis_recovery_failed run_id=%s budget=%s",
                     run["id"],

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -97,7 +97,11 @@ _CAP_LOOKUP_ATTEMPTS = 3
 _CAP_LOOKUP_RETRY_SECONDS = 0.2
 _PROGRESS_FLUSH_CHARS = 512
 _PROGRESS_FLUSH_SECONDS = 0.25
-_PROGRESS_FLUSH_CHARS_PER_SECOND = 1_048_576
+# _PROGRESS_FLUSH_CHARS / _PROGRESS_FLUSH_SECONDS * 64, so both triggers start scaling from the
+# same written length. A larger divisor puts the time arm's knee at 262_144 chars, which is
+# where a 65_536-token report ENDS, so across the whole range this change unlocks the character
+# scaling never binds and the row is still rewritten four times a second.
+_PROGRESS_FLUSH_CHARS_PER_SECOND = 131_072
 # Providers whose thinking answers truncate below a floor; mirrors
 # EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER in the same client module.
 _EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER = {"kimi": 16_000}
@@ -2827,18 +2831,38 @@ class ResearchSupervisor:
                 _run_inference_request(run),
                 recovery_messages,
             )
-            (
-                recovered_report,
-                recovery_reasoning,
-                recovery_finish_reason,
-                recovery_usage,
-            ) = await self._stream_completion(
-                run,
-                recovery_messages,
-                phase = "synthesis_recovery",
-                max_tokens = synthesis_max_tokens,
-                enable_thinking = False,
-            )
+            try:
+                (
+                    recovered_report,
+                    recovery_reasoning,
+                    recovery_finish_reason,
+                    recovery_usage,
+                ) = await self._stream_completion(
+                    run,
+                    recovery_messages,
+                    phase = "synthesis_recovery",
+                    max_tokens = synthesis_max_tokens,
+                    enable_thinking = False,
+                )
+            except (RunCancelled, LeaseLost):
+                raise
+            except Exception:
+                # Recovery exists to improve on a draft that is already in hand, so failing
+                # the run here would discard the very thing it was called to rescue -- and
+                # its prompt carries instructions the first one did not, so an endpoint that
+                # counts prompt plus requested output against one window can refuse the
+                # second request at a budget the first fit inside. The first draft goes out
+                # under its incomplete-report notice, which is what it would have done had
+                # recovery merely come back empty.
+                logger.warning(
+                    "research.synthesis_recovery_failed run_id=%s budget=%s",
+                    run["id"],
+                    synthesis_max_tokens,
+                    exc_info = True,
+                )
+                await self._check_active(run["id"])
+                recovered_report, recovery_reasoning = "", ""
+                recovery_finish_reason, recovery_usage = None, None
             synthesis_reasoning += recovery_reasoning
             recovered = _select_synthesis_report(recovered_report, recovery_reasoning)
             # A second attempt at the SAME report under the same budget, not a correction of

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -84,6 +84,13 @@ _MIN_QUESTION_CHARS = 800
 _SYNTHESIS_EVIDENCE_CHARS_PER_TOKEN = 3.0
 _SYNTHESIS_CONTEXT_RESERVE_TOKENS = 4_096
 _SYNTHESIS_MAX_TOKENS = 16_384
+# The most the report may ask for however large a ceiling the connection reports. The
+# documented per-model caps reach 384_000, nothing between here and the provider bounds what
+# is sent, and a request the connection refuses or cannot finish in time costs the whole run.
+_SYNTHESIS_MAX_TOKENS_CEILING = 65_536
+# Conservative sustained decode rate for a saved connection, used only to keep the report
+# budget inside the run's own wall clock. Deliberately low: overshooting here loses the run.
+_SYNTHESIS_TOKENS_PER_SECOND = 50
 # Streaming progress is persisted as a full row snapshot; these bound how often that happens.
 _CAP_UNREADABLE = object()
 _CAP_LOOKUP_ATTEMPTS = 3
@@ -424,8 +431,10 @@ def _resolve_max_tokens(
         requested = min(int(inference.get("maxTokens") or 4096), 8192)
     else:
         # No second ceiling on an explicit budget: the caller already resolved one the
-        # connection accepts, and re-capping it here is what truncated the report.
-        requested = int(max_tokens)
+        # connection accepts, and re-capping it here is what truncated the report. The floor
+        # stays, though: main's `max_tokens or ...` made a 0 impossible to send, and the
+        # route rejects a request that asks for one.
+        requested = max(1, int(max_tokens))
     # A saved connection generates on the provider's own hardware, so the resident local model
     # bounds nothing about it. main's clamp already makes that exemption -- _loaded_context_length
     # returns None for a run carrying a providerType -- so this defers to it rather than
@@ -433,13 +442,19 @@ def _resolve_max_tokens(
     return _clamp_max_tokens_for_context(requested, messages, inference = inference)
 
 
-def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
-    """The report's output budget: what the connection actually accepts, else the default.
+def _synthesis_max_tokens(inference: dict[str, Any], model_timeout_seconds: Any = None) -> int:
+    """The report's output budget: what the connection accepts, bounded, else the default.
 
-    The client resolves the same per-model ceiling the chat path already sends to this
-    connection, so the value is one the provider is known to take. Nothing is raised on a
-    guess, because a provider that rejects an over-limit max_output_tokens rather than
-    clamping it would fail the run outright.
+    The client resolves the selected model's documented output limit, or the ceiling the user
+    saved on the connection itself. That is a limit the provider publishes rather than one any
+    request has been observed to survive, so nothing here treats it as unconditionally safe:
+    `_synthesis_budget_ceiling` bounds it, and the value is never raised on a guess, because a
+    provider that rejects an over-limit max_output_tokens rather than clamping it would fail
+    the run outright at its most expensive step.
+
+    The budget never falls below `_SYNTHESIS_MAX_TOKENS`, which is what every run spent before
+    any of this existed, unless the client's own ceiling is lower -- that one is the model's
+    documented limit, so asking past it would be refused.
     """
     if not inference.get("providerType"):
         return _SYNTHESIS_MAX_TOKENS
@@ -458,20 +473,48 @@ def _synthesis_max_tokens(inference: dict[str, Any]) -> int:
         # The client resolved this against the run's own model, but the run is durable: the
         # connection's cap can have been lowered since it was created, and the saved row is
         # the current truth about what the user allows this connection to spend.
-        budget = min(resolved, saved) if saved else resolved
+        #
+        # It lowers the budget only as far as the previous default. That column caps the chat
+        # Max Tokens slider, and a user who set it to 4_096 for cost was not asking for a
+        # report shorter than the one Deep Research already wrote them at 16_384 -- a PR that
+        # exists to make reports longer must not shorten anybody's.
+        budget = min(resolved, max(saved, _SYNTHESIS_MAX_TOKENS)) if saved else resolved
     else:
         # A run created before the client sent its resolved ceiling falls back to here. The
         # saved cap belongs to the connection, not to this run's model -- one connection
         # fronts many models, and only the client has the table that bounds it by the
         # selected model's documented ceiling (claude-opus-4-1 stops at 32_000 while a
         # connection may be saved at 32_768). Without that table this side cannot raise the
-        # budget safely at all, so a legacy run keeps the default it already had; the saved
-        # cap may still lower it.
-        budget = min(saved, _SYNTHESIS_MAX_TOKENS) if saved else _SYNTHESIS_MAX_TOKENS
+        # budget safely at all, so a legacy run keeps exactly the default it already had.
+        budget = _SYNTHESIS_MAX_TOKENS
     # The chat path never hands a connection less than its provider's floor, because below it
     # a thinking answer is cut off before the report starts. A saved cap is allowed to lower
     # the budget, but not past that.
-    return max(budget, floor)
+    return max(min(budget, _synthesis_budget_ceiling(model_timeout_seconds)), floor)
+
+
+def _synthesis_budget_ceiling(model_timeout_seconds: Any = None) -> int:
+    """The most this run can usefully ask the connection for, whatever ceiling it reports.
+
+    Two bounds, neither of which may pull the budget below the previous default:
+
+    - The run's own wall clock. `_stream_completion` aborts the synthesis call at
+      `modelTimeoutSeconds` and does NOT return the report it has already streamed, while a
+      report that merely runs out of budget comes back truncated under a notice. Handing a
+      connection more tokens than it can decode inside that window therefore trades a report
+      the user can read for a failed run at the last and most expensive step.
+    - An absolute ceiling, for a run whose wall clock is unlimited and for a documented cap
+      or connection override that is simply too large: nothing between here and the provider
+      bounds what is sent, and the published caps go as high as 384_000.
+    """
+    ceiling = _SYNTHESIS_MAX_TOKENS_CEILING
+    timeout = model_timeout_seconds
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+        timeout = None
+    # 0 is "unlimited" in the budgets schema, so only a positive one bounds anything.
+    if timeout and timeout > 0:
+        ceiling = min(ceiling, int(timeout * _SYNTHESIS_TOKENS_PER_SECOND))
+    return max(ceiling, _SYNTHESIS_MAX_TOKENS)
 
 
 def _provider_output_floor(provider_type: object) -> int:
@@ -1603,6 +1646,23 @@ class ResearchSupervisor:
                 attempt = 0
                 try:
                     while True:
+                        if (
+                            max_tokens is not None
+                            and inference.get("providerType")
+                            and phase in ("synthesis", "synthesis_recovery")
+                        ):
+                            # The run is durable and this loop re-sends after a queue or a
+                            # rate-limit wait, so the budget the caller resolved can be
+                            # minutes old by now. Re-read the saved cap here, where the
+                            # request is actually built: the recovery pass and every retry
+                            # are bounded by the ceiling in force when they go out, not by
+                            # the one that was in force when synthesis started.
+                            max_tokens = min(
+                                max_tokens,
+                                await asyncio.to_thread(
+                                    _synthesis_max_tokens, inference, model_timeout
+                                ),
+                            )
                         payload["max_tokens"] = _resolve_max_tokens(
                             max_tokens,
                             inference,
@@ -2661,19 +2721,53 @@ class ResearchSupervisor:
             },
         ]
         synthesis_max_tokens = await asyncio.to_thread(
-            _synthesis_max_tokens, run["config"].get("inferenceRequest") or {}
+            _synthesis_max_tokens,
+            run["config"].get("inferenceRequest") or {},
+            (run["config"].get("budgets") or {}).get("modelTimeoutSeconds"),
         )
-        (
-            report,
-            synthesis_reasoning,
-            synthesis_finish_reason,
-            synthesis_usage,
-        ) = await self._stream_completion(
-            run,
-            synthesis_messages,
-            phase = "synthesis",
-            max_tokens = synthesis_max_tokens,
-        )
+        try:
+            (
+                report,
+                synthesis_reasoning,
+                synthesis_finish_reason,
+                synthesis_usage,
+            ) = await self._stream_completion(
+                run,
+                synthesis_messages,
+                phase = "synthesis",
+                max_tokens = synthesis_max_tokens,
+            )
+        except (RunCancelled, LeaseLost, httpx.ReadTimeout):
+            raise
+        except Exception:
+            if synthesis_max_tokens <= _SYNTHESIS_MAX_TOKENS:
+                raise
+            # The raised budget is the only thing this call does differently from the one
+            # every run made before it, and the ways a connection can refuse it are not all
+            # knowable from here: a per-endpoint limit below the model's published cap, a
+            # router fronting several of them, or a self-hosted server whose context window
+            # has to hold the synthesis prompt as well. Failing here would discard a run
+            # that has already done all of its research, so the last attempt is made at the
+            # budget that has always worked.
+            logger.warning(
+                "research.synthesis_budget_refused run_id=%s budget=%s",
+                run["id"],
+                synthesis_max_tokens,
+                exc_info = True,
+            )
+            await self._check_active(run["id"])
+            synthesis_max_tokens = _SYNTHESIS_MAX_TOKENS
+            (
+                report,
+                synthesis_reasoning,
+                synthesis_finish_reason,
+                synthesis_usage,
+            ) = await self._stream_completion(
+                run,
+                synthesis_messages,
+                phase = "synthesis",
+                max_tokens = synthesis_max_tokens,
+            )
         await self._check_active(run["id"])
         report = _select_synthesis_report(report, synthesis_reasoning)
         truncation_notice = ""

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -469,6 +469,12 @@ def _synthesis_max_tokens(inference: dict[str, Any], model_timeout_seconds: Any 
         unconfirmed = _positive_int_or_none(inference.get("maxOutputTokens"))
         return max(min(unconfirmed or _SYNTHESIS_MAX_TOKENS, _SYNTHESIS_MAX_TOKENS), floor)
     resolved = _positive_int_or_none(inference.get("maxOutputTokens"))
+    if resolved and not saved and inference.get("maxOutputTokensFromSavedCap") is True:
+        # Nothing documents this model, so the connection's own cap was the only thing holding
+        # that number up, and the user has since cleared it. Blanking the field is an ordinary
+        # edit -- for an undocumented model it is what the Max Tokens limit is FOR -- and a run
+        # created now would not ask for the removed ceiling either, so this one stops too.
+        resolved = None
     if resolved:
         # The client resolved this against the run's own model, but the run is durable: the
         # connection's cap can have been lowered since it was created, and the saved row is

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -479,12 +479,7 @@ def _synthesis_max_tokens(inference: dict[str, Any], model_timeout_seconds: Any 
         # The client resolved this against the run's own model, but the run is durable: the
         # connection's cap can have been lowered since it was created, and the saved row is
         # the current truth about what the user allows this connection to spend.
-        #
-        # It lowers the budget only as far as the previous default. That column caps the chat
-        # Max Tokens slider, and a user who set it to 4_096 for cost was not asking for a
-        # report shorter than the one Deep Research already wrote them at 16_384 -- a PR that
-        # exists to make reports longer must not shorten anybody's.
-        budget = min(resolved, max(saved, _SYNTHESIS_MAX_TOKENS)) if saved else resolved
+        budget = min(resolved, saved) if saved else resolved
     else:
         # A run created before the client sent its resolved ceiling falls back to here. The
         # saved cap belongs to the connection, not to this run's model -- one connection
@@ -494,9 +489,29 @@ def _synthesis_max_tokens(inference: dict[str, Any], model_timeout_seconds: Any 
         # budget safely at all, so a legacy run keeps exactly the default it already had.
         budget = _SYNTHESIS_MAX_TOKENS
     # The chat path never hands a connection less than its provider's floor, because below it
-    # a thinking answer is cut off before the report starts. A saved cap is allowed to lower
-    # the budget, but not past that.
-    return max(min(budget, _synthesis_budget_ceiling(model_timeout_seconds)), floor)
+    # a thinking answer is cut off before the report starts.
+    return max(
+        min(budget, _synthesis_budget_ceiling(model_timeout_seconds)),
+        _report_floor(inference),
+        floor,
+    )
+
+
+def _report_floor(inference: dict[str, Any]) -> int:
+    """The budget every run had before a connection ceiling was read at all.
+
+    Only the model's own published limit may pull the report below it. A connection override
+    may not: that column sizes the chat Max Tokens slider, and a user who capped a connection
+    at 8_192 for cost was not asking for a shorter report than Deep Research has been writing
+    them all along. The distinction is invisible in `maxOutputTokens`, which already has the
+    override folded into the published cap -- min(65_536, 8_192) and a model that genuinely
+    stops at 8_192 are the same number by the time it arrives -- so the published limit is
+    carried separately and read here.
+    """
+    published = _positive_int_or_none(inference.get("maxOutputTokensPublished"))
+    if published:
+        return min(_SYNTHESIS_MAX_TOKENS, published)
+    return _SYNTHESIS_MAX_TOKENS
 
 
 def _synthesis_budget_ceiling(model_timeout_seconds: Any = None) -> int:

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -285,8 +285,13 @@ def _sanitize_config(
             if not 1 <= request["maxTokens"] <= 8192:
                 raise ValueError
         if "maxOutputTokens" in request:
-            request["maxOutputTokens"] = int(request["maxOutputTokens"])
-            if not 1 <= request["maxOutputTokens"] <= MAX_JSON_SAFE_INTEGER:
+            # Strict, like the saved-connection schema this mirrors: bool is an int subclass,
+            # and int() would silently truncate a float or raise OverflowError on a non-finite
+            # one, which is a 500 rather than the 400 an invalid field deserves.
+            budget = request["maxOutputTokens"]
+            if isinstance(budget, bool) or not isinstance(budget, int):
+                raise ValueError
+            if not 1 <= budget <= MAX_JSON_SAFE_INTEGER:
                 raise ValueError
         if "enableThinking" in request and not isinstance(request["enableThinking"], bool):
             raise ValueError

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -22,6 +22,7 @@ from core.inference.message_content import message_text_with_pastes
 from core.inference.web_access_policy import normalize_website_policy
 from storage import research_runs_db as db
 from core.inference.providers import provider_runs_local_tools
+from models.providers import MAX_JSON_SAFE_INTEGER
 from storage import providers_db
 from storage.studio_db import get_chat_message, get_chat_thread, upsert_chat_message
 from utils.current_date_prompt_settings import current_date_prompt_line
@@ -215,6 +216,7 @@ def _sanitize_config(
         "temperature",
         "topP",
         "maxTokens",
+        "maxOutputTokens",
         "enableThinking",
         "reasoningEffort",
     }
@@ -281,6 +283,10 @@ def _sanitize_config(
         if "maxTokens" in request:
             request["maxTokens"] = int(request["maxTokens"])
             if not 1 <= request["maxTokens"] <= 8192:
+                raise ValueError
+        if "maxOutputTokens" in request:
+            request["maxOutputTokens"] = int(request["maxOutputTokens"])
+            if not 1 <= request["maxOutputTokens"] <= MAX_JSON_SAFE_INTEGER:
                 raise ValueError
         if "enableThinking" in request and not isinstance(request["enableThinking"], bool):
             raise ValueError

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -287,9 +287,8 @@ def _sanitize_config(
             if not 1 <= request["maxTokens"] <= 8192:
                 raise ValueError
         if "maxOutputTokens" in request:
-            # Strict, like the saved-connection schema this mirrors: bool is an int subclass,
-            # and int() would silently truncate a float or raise OverflowError on a non-finite
-            # one, which is a 500 rather than the 400 an invalid field deserves.
+            # Strict like the saved-connection schema: bool is an int subclass, and int()
+            # would truncate a float or raise OverflowError, turning a 400 into a 500.
             budget = request["maxOutputTokens"]
             if isinstance(budget, bool) or not isinstance(budget, int):
                 raise ValueError

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -217,6 +217,7 @@ def _sanitize_config(
         "topP",
         "maxTokens",
         "maxOutputTokens",
+        "maxOutputTokensFromSavedCap",
         "enableThinking",
         "reasoningEffort",
     }
@@ -293,6 +294,10 @@ def _sanitize_config(
                 raise ValueError
             if not 1 <= budget <= MAX_JSON_SAFE_INTEGER:
                 raise ValueError
+        if "maxOutputTokensFromSavedCap" in request and not isinstance(
+            request["maxOutputTokensFromSavedCap"], bool
+        ):
+            raise ValueError
         if "enableThinking" in request and not isinstance(request["enableThinking"], bool):
             raise ValueError
         if "reasoningEffort" in request:

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -218,6 +218,7 @@ def _sanitize_config(
         "maxTokens",
         "maxOutputTokens",
         "maxOutputTokensFromSavedCap",
+        "maxOutputTokensPublished",
         "enableThinking",
         "reasoningEffort",
     }
@@ -298,6 +299,12 @@ def _sanitize_config(
             request["maxOutputTokensFromSavedCap"], bool
         ):
             raise ValueError
+        if "maxOutputTokensPublished" in request:
+            published = request["maxOutputTokensPublished"]
+            if isinstance(published, bool) or not isinstance(published, int):
+                raise ValueError
+            if not 1 <= published <= MAX_JSON_SAFE_INTEGER:
+                raise ValueError
         if "enableThinking" in request and not isinstance(request["enableThinking"], bool):
             raise ValueError
         if "reasoningEffort" in request:

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -430,23 +430,35 @@ def test_a_saved_connection_cap_below_the_default_is_honoured(monkeypatch):
     assert _synthesis_max_tokens(inference) == 8_192
 
 
-def test_a_saved_connection_reports_its_own_budget(monkeypatch):
+def test_a_saved_cap_above_the_default_does_not_raise_a_legacy_run(monkeypatch):
     monkeypatch.setattr(
         research_runs.providers_db,
         "get_provider",
         lambda _id: {"max_output_tokens": 32_768},
     )
     inference = {"providerType": "ollama", "providerId": "p1", "externalModel": "glm-5.3-flash"}
+    assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_a_client_ceiling_is_what_actually_raises_the_report_budget(monkeypatch):
+    """The mainstream path: the client resolved this against the run's own model."""
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {
+        "providerType": "ollama",
+        "providerId": "p1",
+        "externalModel": "glm-5.3-flash",
+        "maxOutputTokens": 32_768,
+    }
     assert _synthesis_max_tokens(inference) == 32_768
 
 
-def test_a_saved_connection_cap_cannot_exceed_an_undocumented_model_ceiling(monkeypatch):
+def test_a_legacy_run_keeps_the_default_rather_than_guessing_upwards(monkeypatch):
     """The saved cap is connection-wide, so for this run's model it is a guess.
 
-    One connection fronts many models: a cap set for a 256k-output model must not become the
-    budget for a smaller one. The client bounds it by that model's documented ceiling, using a
-    table the worker does not have, so the worker bounds it by what the client sends for a
-    model nothing documents.
+    Only the client holds the table that bounds a connection by the selected model's
+    documented ceiling, so without a ceiling from the client this side cannot raise the
+    budget at all: claude-opus-4-1 stops at 32_000 while its connection may be saved at
+    32_768, and a provider that rejects an over-limit request fails the finished run.
     """
     monkeypatch.setattr(
         research_runs.providers_db,
@@ -454,7 +466,7 @@ def test_a_saved_connection_cap_cannot_exceed_an_undocumented_model_ceiling(monk
         lambda _id: {"max_output_tokens": 256_000},
     )
     inference = {"providerType": "gemini", "providerId": "p1", "externalModel": "gemini-3.6-flash"}
-    assert _synthesis_max_tokens(inference) == research_runs._EXTERNAL_MAX_OUTPUT_TOKENS
+    assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -410,9 +410,7 @@ def test_an_external_truncation_is_not_blamed_on_the_local_context(monkeypatch):
     """The loaded local window explains nothing about a report a connection generated."""
     monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 8_192)
     usage = {"prompt_tokens": 5_000, "completion_tokens": 4_000, "total_tokens": 9_000}
-    notice = _synthesis_length_limit_error(
-        usage, requested_max_tokens = 32_768, external = True
-    )
+    notice = _synthesis_length_limit_error(usage, requested_max_tokens = 32_768, external = True)
     assert "Context Length" not in notice
     assert "Local model" not in notice
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -346,14 +346,21 @@ def test_a_saved_connection_budget_ignores_the_resident_local_model(monkeypatch)
     The synthesis prompt is already fitted to the local window, so clamping against it spends
     the report's budget down to the leftover reserve and undoes the ceiling just resolved.
     """
-    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 8_192)
+    # main reads the window off the local backend only for a local run; a run carrying a
+    # providerType reports None. Model that contract rather than a flat value, or the stub
+    # itself would clamp what the real call never reaches.
+    monkeypatch.setattr(
+        research_runs,
+        "_loaded_context_length",
+        lambda _inf = None: None if (_inf or {}).get("providerType") else 8_192,
+    )
     inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 32_768}
     messages = [{"role": "user", "content": "x" * 30_000}]
     assert _resolve_max_tokens(32_768, inference, messages) == 32_768
 
 
 def test_a_local_run_still_clamps_to_the_loaded_context(monkeypatch):
-    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 8_192)
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda _inf = None: 8_192)
     messages = [{"role": "user", "content": "x" * 30_000}]
     assert _resolve_max_tokens(16_384, {}, messages) < 16_384
 
@@ -438,15 +445,19 @@ def test_a_transient_cap_lookup_failure_is_retried(monkeypatch):
 
 def test_an_external_truncation_is_not_blamed_on_the_local_context(monkeypatch):
     """The loaded local window explains nothing about a report a connection generated."""
-    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 8_192)
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda _inf = None: 8_192)
     usage = {"prompt_tokens": 5_000, "completion_tokens": 4_000, "total_tokens": 9_000}
-    notice = _synthesis_length_limit_error(usage, requested_max_tokens = 32_768, external = True)
+    notice = _synthesis_length_limit_error(
+        usage,
+        requested_max_tokens = 32_768,
+        inference = {"providerType": "gemini", "providerId": "p1"},
+    )
     assert "Context Length" not in notice
     assert "Local model" not in notice
 
 
 def test_a_local_truncation_still_names_the_context_window(monkeypatch):
-    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 8_192)
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda _inf = None: 8_192)
     usage = {"prompt_tokens": 5_000, "completion_tokens": 4_000, "total_tokens": 9_000}
     notice = _synthesis_length_limit_error(usage, requested_max_tokens = 16_384)
     assert "Context Length" in notice

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import json
+import sqlite3
 import sys
 import time
 from pathlib import Path
@@ -35,6 +36,7 @@ from core.research_runs import (
     _estimate_prompt_tokens,
     _resolve_max_tokens,
     _synthesis_length_limit_error,
+    _synthesis_max_tokens,
 )
 from routes.research_runs import CreateResearchRun, _is_sensitive_key, _sanitize_config
 
@@ -324,6 +326,72 @@ def test_a_saved_connection_run_is_not_blamed_on_the_loaded_context(monkeypatch)
     assert "Increase Context Length" not in message
     assert "Local model" not in message
     assert "output limit" in message
+
+def test_resolve_max_tokens_honours_a_budget_above_the_old_ceiling(monkeypatch):
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda *a, **k: None)
+    assert _resolve_max_tokens(32_768, {}, [{"role": "user", "content": "x"}]) == 32_768
+
+
+def test_resolve_max_tokens_still_caps_a_thread_setting_at_8192(monkeypatch):
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda *a, **k: None)
+    messages = [{"role": "user", "content": "x"}]
+    assert _resolve_max_tokens(None, {"maxTokens": 100_000}, messages) == 8_192
+    assert _resolve_max_tokens(None, {}, messages) == 4_096
+
+
+def test_a_local_run_keeps_the_default_report_budget():
+    assert _synthesis_max_tokens({"model": "local-model"}) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_a_client_resolved_ceiling_is_used_verbatim(monkeypatch):
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {
+        "providerType": "gemini",
+        "providerId": "p1",
+        "externalModel": "gemini-3.6-flash",
+        "maxOutputTokens": 65_536,
+    }
+    assert _synthesis_max_tokens(inference) == 65_536
+
+
+def test_a_ceiling_below_the_default_is_respected(monkeypatch):
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {"providerType": "openai", "providerId": "p1", "maxOutputTokens": 8_192}
+    assert _synthesis_max_tokens(inference) == 8_192
+
+
+def test_a_local_run_ignores_a_stray_ceiling():
+    assert _synthesis_max_tokens({"maxOutputTokens": 65_536}) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_a_saved_connection_reports_its_own_budget(monkeypatch):
+    monkeypatch.setattr(
+        research_runs.providers_db,
+        "get_provider",
+        lambda _id: {"max_output_tokens": 120_000},
+    )
+    inference = {"providerType": "ollama", "providerId": "p1", "externalModel": "glm-5.3-flash"}
+    assert _synthesis_max_tokens(inference) == 120_000
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [None, {}, {"max_output_tokens": None}, {"max_output_tokens": 0}],
+    ids = ["missing", "unset", "null", "zero"],
+)
+def test_a_connection_without_a_saved_cap_keeps_the_default(monkeypatch, provider):
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: provider)
+    inference = {"providerType": "ollama", "providerId": "p1"}
+    assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_an_unreadable_provider_row_does_not_fail_the_run(monkeypatch):
+    def explode(_id):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", explode)
+    inference = {"providerType": "ollama", "providerId": "p1"}
+    assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
 
 
 def test_completion_hit_context_wall_matches_live_probe():

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -339,6 +339,44 @@ def test_resolve_max_tokens_still_caps_a_thread_setting_at_8192(monkeypatch):
     assert _resolve_max_tokens(None, {}, messages) == 4_096
 
 
+def test_a_saved_connection_budget_ignores_the_resident_local_model(monkeypatch):
+    """A connection generates on the provider's hardware; the local window bounds nothing.
+
+    The synthesis prompt is already fitted to the local window, so clamping against it spends
+    the report's budget down to the leftover reserve and undoes the ceiling just resolved.
+    """
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 8_192)
+    inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 32_768}
+    messages = [{"role": "user", "content": "x" * 30_000}]
+    assert _resolve_max_tokens(32_768, inference, messages) == 32_768
+
+
+def test_a_local_run_still_clamps_to_the_loaded_context(monkeypatch):
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 8_192)
+    messages = [{"role": "user", "content": "x" * 30_000}]
+    assert _resolve_max_tokens(16_384, {}, messages) < 16_384
+
+
+def test_a_lowered_connection_cap_bounds_a_stale_client_ceiling(monkeypatch):
+    """The run is durable, so the cap can have been lowered after the client resolved it."""
+    monkeypatch.setattr(
+        research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_192}
+    )
+    inference = {
+        "providerType": "gemini",
+        "providerId": "p1",
+        "externalModel": "gemini-3.6-flash",
+        "maxOutputTokens": 65_536,
+    }
+    assert _synthesis_max_tokens(inference) == 8_192
+
+
+def test_a_client_ceiling_stands_when_the_connection_has_no_cap(monkeypatch):
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 65_536}
+    assert _synthesis_max_tokens(inference) == 65_536
+
+
 def test_a_local_run_keeps_the_default_report_budget():
     assert _synthesis_max_tokens({"model": "local-model"}) == research_runs._SYNTHESIS_MAX_TOKENS
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -328,6 +328,7 @@ def test_a_saved_connection_run_is_not_blamed_on_the_loaded_context(monkeypatch)
     assert "Local model" not in message
     assert "output limit" in message
 
+
 def test_resolve_max_tokens_honours_a_budget_above_the_old_ceiling(monkeypatch):
     monkeypatch.setattr(research_runs, "_loaded_context_length", lambda *a, **k: None)
     assert _resolve_max_tokens(32_768, {}, [{"role": "user", "content": "x"}]) == 32_768

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -395,6 +395,35 @@ def test_a_provider_without_a_floor_keeps_the_saved_cap(monkeypatch):
     assert _synthesis_max_tokens(inference) == 8_000
 
 
+def test_an_unreadable_cap_does_not_let_a_stale_client_ceiling_through(monkeypatch):
+    """A locked row is not an uncapped connection; the cap may have been lowered since."""
+
+    def explode(_id):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", explode)
+    inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 65_536}
+    assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_an_external_truncation_is_not_blamed_on_the_local_context(monkeypatch):
+    """The loaded local window explains nothing about a report a connection generated."""
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 8_192)
+    usage = {"prompt_tokens": 5_000, "completion_tokens": 4_000, "total_tokens": 9_000}
+    notice = _synthesis_length_limit_error(
+        usage, requested_max_tokens = 32_768, external = True
+    )
+    assert "Context Length" not in notice
+    assert "Local model" not in notice
+
+
+def test_a_local_truncation_still_names_the_context_window(monkeypatch):
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda: 8_192)
+    usage = {"prompt_tokens": 5_000, "completion_tokens": 4_000, "total_tokens": 9_000}
+    notice = _synthesis_length_limit_error(usage, requested_max_tokens = 16_384)
+    assert "Context Length" in notice
+
+
 def test_a_local_run_keeps_the_default_report_budget():
     assert _synthesis_max_tokens({"model": "local-model"}) == research_runs._SYNTHESIS_MAX_TOKENS
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -364,14 +364,41 @@ def test_a_local_run_ignores_a_stray_ceiling():
     assert _synthesis_max_tokens({"maxOutputTokens": 65_536}) == research_runs._SYNTHESIS_MAX_TOKENS
 
 
+def test_a_saved_connection_cap_below_the_default_is_honoured(monkeypatch):
+    monkeypatch.setattr(
+        research_runs.providers_db,
+        "get_provider",
+        lambda _id: {"max_output_tokens": 8_192},
+    )
+    inference = {"providerType": "ollama", "providerId": "p1", "externalModel": "glm-5.3-flash"}
+    assert _synthesis_max_tokens(inference) == 8_192
+
+
 def test_a_saved_connection_reports_its_own_budget(monkeypatch):
     monkeypatch.setattr(
         research_runs.providers_db,
         "get_provider",
-        lambda _id: {"max_output_tokens": 120_000},
+        lambda _id: {"max_output_tokens": 32_768},
     )
     inference = {"providerType": "ollama", "providerId": "p1", "externalModel": "glm-5.3-flash"}
-    assert _synthesis_max_tokens(inference) == 120_000
+    assert _synthesis_max_tokens(inference) == 32_768
+
+
+def test_a_saved_connection_cap_cannot_exceed_an_undocumented_model_ceiling(monkeypatch):
+    """The saved cap is connection-wide, so for this run's model it is a guess.
+
+    One connection fronts many models: a cap set for a 256k-output model must not become the
+    budget for a smaller one. The client bounds it by that model's documented ceiling, using a
+    table the worker does not have, so the worker bounds it by what the client sends for a
+    model nothing documents.
+    """
+    monkeypatch.setattr(
+        research_runs.providers_db,
+        "get_provider",
+        lambda _id: {"max_output_tokens": 256_000},
+    )
+    inference = {"providerType": "gemini", "providerId": "p1", "externalModel": "gemini-3.6-flash"}
+    assert _synthesis_max_tokens(inference) == research_runs._EXTERNAL_MAX_OUTPUT_TOKENS
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+from fastapi import HTTPException
 
 from core import research_runs
 from core.research.citations import (
@@ -377,6 +378,23 @@ def test_a_client_ceiling_stands_when_the_connection_has_no_cap(monkeypatch):
     assert _synthesis_max_tokens(inference) == 65_536
 
 
+def test_a_saved_cap_cannot_drop_a_connection_below_its_provider_floor(monkeypatch):
+    """Kimi truncates a thinking answer below 16k, so the chat path never asks for less."""
+    monkeypatch.setattr(
+        research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_000}
+    )
+    inference = {"providerType": "kimi", "providerId": "p1", "maxOutputTokens": 32_768}
+    assert _synthesis_max_tokens(inference) == 16_000
+
+
+def test_a_provider_without_a_floor_keeps_the_saved_cap(monkeypatch):
+    monkeypatch.setattr(
+        research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_000}
+    )
+    inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 32_768}
+    assert _synthesis_max_tokens(inference) == 8_000
+
+
 def test_a_local_run_keeps_the_default_report_budget():
     assert _synthesis_max_tokens({"model": "local-model"}) == research_runs._SYNTHESIS_MAX_TOKENS
 
@@ -619,6 +637,23 @@ def test_budgets_reject_a_boolean_instead_of_reading_it_as_unlimited():
     assert _make_payload(budgets = {"modelTimeoutSeconds": 0}).budgets == {
         "modelTimeoutSeconds": 0,
     }
+
+
+def test_sanitize_config_rejects_a_non_integer_report_ceiling():
+    for bad in (True, 64.9, float("inf"), float("nan"), "32768"):
+        with pytest.raises(HTTPException):
+            _sanitize_config(
+                _make_payload(inferenceRequest = {"model": "m", "maxOutputTokens": bad}),
+                {"modelId": "m"},
+            )
+
+
+def test_sanitize_config_keeps_a_strict_integer_report_ceiling():
+    config = _sanitize_config(
+        _make_payload(inferenceRequest = {"model": "m", "maxOutputTokens": 32_768}),
+        {"modelId": "m"},
+    )
+    assert config["inferenceRequest"]["maxOutputTokens"] == 32_768
 
 
 def test_sanitize_config_rejects_nested_inference_credential():

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -401,9 +401,39 @@ def test_an_unreadable_cap_does_not_let_a_stale_client_ceiling_through(monkeypat
     def explode(_id):
         raise sqlite3.OperationalError("database is locked")
 
+    monkeypatch.setattr(research_runs, "_CAP_LOOKUP_RETRY_SECONDS", 0)
     monkeypatch.setattr(research_runs.providers_db, "get_provider", explode)
     inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 65_536}
     assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_an_unreadable_cap_still_honours_a_lower_client_ceiling(monkeypatch):
+    """Neither signal is confirmable, so the smaller of the two is what gets spent."""
+
+    def explode(_id):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(research_runs, "_CAP_LOOKUP_RETRY_SECONDS", 0)
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", explode)
+    inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 4_096}
+    assert _synthesis_max_tokens(inference) == 4_096
+
+
+def test_a_transient_cap_lookup_failure_is_retried(monkeypatch):
+    """A read that lost the writer lock is transient; one retry beats guessing."""
+    calls = {"n": 0}
+
+    def flaky(_id):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise sqlite3.OperationalError("database is locked")
+        return {"max_output_tokens": 65_536}
+
+    monkeypatch.setattr(research_runs, "_CAP_LOOKUP_RETRY_SECONDS", 0)
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", flaky)
+    inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 65_536}
+    assert _synthesis_max_tokens(inference) == 65_536
+    assert calls["n"] == 2
 
 
 def test_an_external_truncation_is_not_blamed_on_the_local_context(monkeypatch):

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -392,25 +392,89 @@ def test_a_saved_cap_cannot_drop_a_connection_below_its_provider_floor(monkeypat
         research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_000}
     )
     inference = {"providerType": "kimi", "providerId": "p1", "maxOutputTokens": 32_768}
-    # The default floor gets there first here; the provider floor is what holds a connection
-    # whose own client ceiling is below it.
+    # The report floor gets there first here; the provider floor is what holds a connection
+    # whose model genuinely publishes a lower limit.
     assert _synthesis_max_tokens(inference) == 16_384
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
-    assert _synthesis_max_tokens({**inference, "maxOutputTokens": 4_096}) == 16_000
+    published_low = {
+        **inference,
+        "maxOutputTokens": 4_096,
+        "maxOutputTokensPublished": 4_096,
+    }
+    assert _synthesis_max_tokens(published_low) == 16_000
 
 
 def test_a_saved_cap_below_the_previous_default_does_not_shorten_the_report(monkeypatch):
     """The cap sizes the chat slider. It may not make a report shorter than it used to be.
 
     Before the connection ceiling was read at all, every run got _SYNTHESIS_MAX_TOKENS, this
-    one included. A user who capped a connection at 8_000 to control chat cost did not ask
+    one included. A user who capped a connection at 8_192 to control chat cost did not ask
     for a shorter report than the one Deep Research has been writing them all along.
+
+    The override arrives ALREADY FOLDED into maxOutputTokens -- getExternalMaxOutputTokens
+    sends min(published, override) -- so 8_192 here is what the client really sends for a
+    65_536 model on a connection capped at 8_192, not a hypothetical.
     """
+    monkeypatch.setattr(
+        research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_192}
+    )
+    inference = {
+        "providerType": "gemini",
+        "providerId": "p1",
+        "externalModel": "gemini-3.6-flash",
+        "maxOutputTokens": 8_192,
+        "maxOutputTokensPublished": 65_536,
+        "maxOutputTokensFromSavedCap": False,
+    }
+    assert _synthesis_max_tokens(inference, 900) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_a_model_that_genuinely_stops_low_still_lowers_the_report(monkeypatch):
+    """The one thing that may go below the old floor is the model's own published limit.
+
+    Asking a 4_096-token model for 16_384 is refused, so the floor cannot be blind to it.
+    """
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {
+        "providerType": "openai",
+        "providerId": "p1",
+        "externalModel": "gpt-4-turbo",
+        "maxOutputTokens": 4_096,
+        "maxOutputTokensPublished": 4_096,
+        "maxOutputTokensFromSavedCap": False,
+    }
+    assert _synthesis_max_tokens(inference, 900) == 4_096
+
+
+def test_an_undocumented_model_capped_low_keeps_the_old_floor(monkeypatch):
+    """Same rule with nothing published: only a model's own limit may go below the floor."""
     monkeypatch.setattr(
         research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_000}
     )
-    inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 32_768}
-    assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
+    inference = {
+        "providerType": "custom",
+        "providerId": "p1",
+        "externalModel": "some-self-hosted-model",
+        "maxOutputTokens": 8_000,
+        "maxOutputTokensFromSavedCap": True,
+    }
+    assert _synthesis_max_tokens(inference, 900) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_a_cap_between_the_floor_and_the_ceiling_still_binds(monkeypatch):
+    """The floor is a floor, not a bypass: a cap above it still lowers a stale ceiling."""
+    monkeypatch.setattr(
+        research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 20_000}
+    )
+    inference = {
+        "providerType": "gemini",
+        "providerId": "p1",
+        "externalModel": "gemini-3.6-flash",
+        "maxOutputTokens": 32_768,
+        "maxOutputTokensPublished": 65_536,
+        "maxOutputTokensFromSavedCap": False,
+    }
+    assert _synthesis_max_tokens(inference, 900) == 20_000
 
 
 def test_clearing_the_saved_cap_invalidates_a_ceiling_only_it_grounded(monkeypatch):
@@ -461,9 +525,18 @@ def test_a_run_created_before_the_grounding_flag_is_unchanged(monkeypatch):
 
 
 def test_a_client_ceiling_below_the_default_still_lowers_the_budget(monkeypatch):
-    """That one is the model's documented limit, not a preference: asking past it is refused."""
+    """A published limit is the model's own, not a preference: asking past it is refused.
+
+    It has to be the PUBLISHED one. maxOutputTokens alone cannot say whether 8_192 is the
+    model's limit or a connection the user capped, and only the first may go below the floor.
+    """
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
-    inference = {"providerType": "openai", "providerId": "p1", "maxOutputTokens": 8_192}
+    inference = {
+        "providerType": "openai",
+        "providerId": "p1",
+        "maxOutputTokens": 8_192,
+        "maxOutputTokensPublished": 8_192,
+    }
     assert _synthesis_max_tokens(inference) == 8_192
 
 
@@ -545,8 +618,24 @@ def test_a_client_resolved_ceiling_is_used_verbatim(monkeypatch):
 
 def test_a_ceiling_below_the_default_is_respected(monkeypatch):
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
-    inference = {"providerType": "openai", "providerId": "p1", "maxOutputTokens": 8_192}
+    inference = {
+        "providerType": "openai",
+        "providerId": "p1",
+        "maxOutputTokens": 8_192,
+        "maxOutputTokensPublished": 8_192,
+    }
     assert _synthesis_max_tokens(inference) == 8_192
+
+
+def test_a_legacy_ceiling_below_the_default_keeps_the_old_budget(monkeypatch):
+    """Without a published limit the number is ambiguous, so it does not lower the report.
+
+    Such a run asked for _SYNTHESIS_MAX_TOKENS before any of this existed and the provider
+    took it, so keeping that is the no-regression answer.
+    """
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {"providerType": "openai", "providerId": "p1", "maxOutputTokens": 8_192}
+    assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
 
 
 def test_the_provider_floor_table_matches_the_client_one_it_mirrors():

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -519,7 +519,6 @@ def test_a_client_ceiling_below_the_default_still_lowers_the_budget(monkeypatch)
 
 
 def test_an_unreadable_cap_does_not_let_a_stale_client_ceiling_through(monkeypatch):
-
     def explode(_id):
         raise sqlite3.OperationalError("database is locked")
 
@@ -530,7 +529,6 @@ def test_an_unreadable_cap_does_not_let_a_stale_client_ceiling_through(monkeypat
 
 
 def test_an_unreadable_cap_still_honours_a_lower_client_ceiling(monkeypatch):
-
     def explode(_id):
         raise sqlite3.OperationalError("database is locked")
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -413,6 +413,53 @@ def test_a_saved_cap_below_the_previous_default_does_not_shorten_the_report(monk
     assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
 
 
+def test_clearing_the_saved_cap_invalidates_a_ceiling_only_it_grounded(monkeypatch):
+    """Blanking the Max Tokens limit is what that field is FOR on an undocumented model.
+
+    Nothing documents a self-hosted id, so the connection's own cap is the only thing holding
+    the run's ceiling up. Once it is cleared a run created now would not ask for that number,
+    and neither may this one.
+    """
+    inference = {
+        "providerType": "custom",
+        "providerId": "p1",
+        "externalModel": "some-self-hosted-model",
+        "maxOutputTokens": 30_000,
+        "maxOutputTokensFromSavedCap": True,
+    }
+    monkeypatch.setattr(
+        research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 30_000}
+    )
+    assert _synthesis_max_tokens(inference, 900) == 30_000
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    assert _synthesis_max_tokens(inference, 900) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_clearing_the_saved_cap_leaves_a_published_ceiling_standing(monkeypatch):
+    """The table still documents this model, so the override was never what grounded it."""
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {
+        "providerType": "gemini",
+        "providerId": "p1",
+        "externalModel": "gemini-3.6-flash",
+        "maxOutputTokens": 32_768,
+        "maxOutputTokensFromSavedCap": False,
+    }
+    assert _synthesis_max_tokens(inference, 900) == 32_768
+
+
+def test_a_run_created_before_the_grounding_flag_is_unchanged(monkeypatch):
+    """A durable run from the release before this field keeps the ceiling it was given."""
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {
+        "providerType": "custom",
+        "providerId": "p1",
+        "externalModel": "some-self-hosted-model",
+        "maxOutputTokens": 30_000,
+    }
+    assert _synthesis_max_tokens(inference, 900) == 30_000
+
+
 def test_a_client_ceiling_below_the_default_still_lowers_the_budget(monkeypatch):
     """That one is the model's documented limit, not a preference: asking past it is refused."""
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
@@ -871,6 +918,28 @@ def test_sanitize_config_keeps_a_strict_integer_report_ceiling():
         {"modelId": "m"},
     )
     assert config["inferenceRequest"]["maxOutputTokens"] == 32_768
+
+
+def test_sanitize_config_keeps_the_grounding_flag_and_refuses_a_non_boolean():
+    config = _sanitize_config(
+        _make_payload(
+            inferenceRequest = {
+                "model": "m",
+                "maxOutputTokens": 32_768,
+                "maxOutputTokensFromSavedCap": True,
+            }
+        ),
+        {"modelId": "m"},
+    )
+    assert config["inferenceRequest"]["maxOutputTokensFromSavedCap"] is True
+    for bad in (1, 0, "true", None, []):
+        with pytest.raises(HTTPException):
+            _sanitize_config(
+                _make_payload(
+                    inferenceRequest = {"model": "m", "maxOutputTokensFromSavedCap": bad}
+                ),
+                {"modelId": "m"},
+            )
 
 
 def test_sanitize_config_rejects_nested_inference_credential():

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -761,14 +761,22 @@ def test_the_flush_triggers_scale_from_the_same_written_length():
     of the range this change unlocks leaves the row being rewritten four times a second for
     an entire 65_536-token report.
     """
-    knee = int(research_runs._PROGRESS_FLUSH_SECONDS * research_runs._PROGRESS_FLUSH_CHARS_PER_SECOND)
+    knee = int(
+        research_runs._PROGRESS_FLUSH_SECONDS * research_runs._PROGRESS_FLUSH_CHARS_PER_SECOND
+    )
     assert knee == research_runs._PROGRESS_FLUSH_CHARS * 64
     # A 65_536-token report is roughly 262_144 chars, and the time arm has to have started
     # scaling well before it, not at it.
     assert knee < 262_144 // 2
     # Short reports are untouched: both arms sit at the previous constants.
     assert max(research_runs._PROGRESS_FLUSH_CHARS, 1_000 // 64) == 512
-    assert max(research_runs._PROGRESS_FLUSH_SECONDS, 1_000 / research_runs._PROGRESS_FLUSH_CHARS_PER_SECOND) == 0.25
+    assert (
+        max(
+            research_runs._PROGRESS_FLUSH_SECONDS,
+            1_000 / research_runs._PROGRESS_FLUSH_CHARS_PER_SECOND,
+        )
+        == 0.25
+    )
 
 
 def test_an_explicit_zero_budget_is_never_put_on_the_wire(monkeypatch):

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -342,14 +342,8 @@ def test_resolve_max_tokens_still_caps_a_thread_setting_at_8192(monkeypatch):
 
 
 def test_a_saved_connection_budget_ignores_the_resident_local_model(monkeypatch):
-    """A connection generates on the provider's hardware; the local window bounds nothing.
-
-    The synthesis prompt is already fitted to the local window, so clamping against it spends
-    the report's budget down to the leftover reserve and undoes the ceiling just resolved.
-    """
-    # main reads the window off the local backend only for a local run; a run carrying a
-    # providerType reports None. Model that contract rather than a flat value, or the stub
-    # itself would clamp what the real call never reaches.
+    """A connection generates on the provider's hardware; the local window bounds nothing."""
+    # Model _loaded_context_length's contract, not a flat value, or the stub itself clamps.
     monkeypatch.setattr(
         research_runs,
         "_loaded_context_length",
@@ -367,7 +361,6 @@ def test_a_local_run_still_clamps_to_the_loaded_context(monkeypatch):
 
 
 def test_a_lowered_connection_cap_bounds_a_stale_client_ceiling(monkeypatch):
-    """The run is durable, so the cap can have been lowered after the client resolved it."""
     monkeypatch.setattr(
         research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 20_000}
     )
@@ -392,8 +385,7 @@ def test_a_saved_cap_cannot_drop_a_connection_below_its_provider_floor(monkeypat
         research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_000}
     )
     inference = {"providerType": "kimi", "providerId": "p1", "maxOutputTokens": 32_768}
-    # The report floor gets there first here; the provider floor is what holds a connection
-    # whose model genuinely publishes a lower limit.
+    # The report floor gets there first; the provider floor holds a lower published limit.
     assert _synthesis_max_tokens(inference) == 16_384
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
     published_low = {
@@ -405,15 +397,10 @@ def test_a_saved_cap_cannot_drop_a_connection_below_its_provider_floor(monkeypat
 
 
 def test_a_saved_cap_below_the_previous_default_does_not_shorten_the_report(monkeypatch):
-    """The cap sizes the chat slider. It may not make a report shorter than it used to be.
+    """A cap set for chat cost may not shorten a report the user was already getting.
 
-    Before the connection ceiling was read at all, every run got _SYNTHESIS_MAX_TOKENS, this
-    one included. A user who capped a connection at 8_192 to control chat cost did not ask
-    for a shorter report than the one Deep Research has been writing them all along.
-
-    The override arrives ALREADY FOLDED into maxOutputTokens -- getExternalMaxOutputTokens
-    sends min(published, override) -- so 8_192 here is what the client really sends for a
-    65_536 model on a connection capped at 8_192, not a hypothetical.
+    The override arrives ALREADY FOLDED into maxOutputTokens, so 8_192 here is what the client
+    really sends for a 65_536 model on a connection capped at 8_192, not a hypothetical.
     """
     monkeypatch.setattr(
         research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_192}
@@ -430,10 +417,7 @@ def test_a_saved_cap_below_the_previous_default_does_not_shorten_the_report(monk
 
 
 def test_a_model_that_genuinely_stops_low_still_lowers_the_report(monkeypatch):
-    """The one thing that may go below the old floor is the model's own published limit.
-
-    Asking a 4_096-token model for 16_384 is refused, so the floor cannot be blind to it.
-    """
+    """Asking a 4_096-token model for 16_384 is refused, so the floor cannot be blind to it."""
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
     inference = {
         "providerType": "openai",
@@ -447,7 +431,6 @@ def test_a_model_that_genuinely_stops_low_still_lowers_the_report(monkeypatch):
 
 
 def test_an_undocumented_model_capped_low_keeps_the_old_floor(monkeypatch):
-    """Same rule with nothing published: only a model's own limit may go below the floor."""
     monkeypatch.setattr(
         research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_000}
     )
@@ -462,7 +445,6 @@ def test_an_undocumented_model_capped_low_keeps_the_old_floor(monkeypatch):
 
 
 def test_a_cap_between_the_floor_and_the_ceiling_still_binds(monkeypatch):
-    """The floor is a floor, not a bypass: a cap above it still lowers a stale ceiling."""
     monkeypatch.setattr(
         research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 20_000}
     )
@@ -480,9 +462,8 @@ def test_a_cap_between_the_floor_and_the_ceiling_still_binds(monkeypatch):
 def test_clearing_the_saved_cap_invalidates_a_ceiling_only_it_grounded(monkeypatch):
     """Blanking the Max Tokens limit is what that field is FOR on an undocumented model.
 
-    Nothing documents a self-hosted id, so the connection's own cap is the only thing holding
-    the run's ceiling up. Once it is cleared a run created now would not ask for that number,
-    and neither may this one.
+    It was the only thing holding the ceiling up, so once cleared this run must stop asking
+    for a number a run created now would not ask for either.
     """
     inference = {
         "providerType": "custom",
@@ -500,7 +481,6 @@ def test_clearing_the_saved_cap_invalidates_a_ceiling_only_it_grounded(monkeypat
 
 
 def test_clearing_the_saved_cap_leaves_a_published_ceiling_standing(monkeypatch):
-    """The table still documents this model, so the override was never what grounded it."""
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
     inference = {
         "providerType": "gemini",
@@ -513,7 +493,6 @@ def test_clearing_the_saved_cap_leaves_a_published_ceiling_standing(monkeypatch)
 
 
 def test_a_run_created_before_the_grounding_flag_is_unchanged(monkeypatch):
-    """A durable run from the release before this field keeps the ceiling it was given."""
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
     inference = {
         "providerType": "custom",
@@ -527,8 +506,7 @@ def test_a_run_created_before_the_grounding_flag_is_unchanged(monkeypatch):
 def test_a_client_ceiling_below_the_default_still_lowers_the_budget(monkeypatch):
     """A published limit is the model's own, not a preference: asking past it is refused.
 
-    It has to be the PUBLISHED one. maxOutputTokens alone cannot say whether 8_192 is the
-    model's limit or a connection the user capped, and only the first may go below the floor.
+    It has to be the PUBLISHED one; maxOutputTokens alone cannot say which of the two it is.
     """
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
     inference = {
@@ -541,7 +519,6 @@ def test_a_client_ceiling_below_the_default_still_lowers_the_budget(monkeypatch)
 
 
 def test_an_unreadable_cap_does_not_let_a_stale_client_ceiling_through(monkeypatch):
-    """A locked row is not an uncapped connection; the cap may have been lowered since."""
 
     def explode(_id):
         raise sqlite3.OperationalError("database is locked")
@@ -553,7 +530,6 @@ def test_an_unreadable_cap_does_not_let_a_stale_client_ceiling_through(monkeypat
 
 
 def test_an_unreadable_cap_still_honours_a_lower_client_ceiling(monkeypatch):
-    """Neither signal is confirmable, so the smaller of the two is what gets spent."""
 
     def explode(_id):
         raise sqlite3.OperationalError("database is locked")
@@ -565,7 +541,6 @@ def test_an_unreadable_cap_still_honours_a_lower_client_ceiling(monkeypatch):
 
 
 def test_a_transient_cap_lookup_failure_is_retried(monkeypatch):
-    """A read that lost the writer lock is transient; one retry beats guessing."""
     calls = {"n": 0}
 
     def flaky(_id):
@@ -582,7 +557,6 @@ def test_a_transient_cap_lookup_failure_is_retried(monkeypatch):
 
 
 def test_an_external_truncation_is_not_blamed_on_the_local_context(monkeypatch):
-    """The loaded local window explains nothing about a report a connection generated."""
     monkeypatch.setattr(research_runs, "_loaded_context_length", lambda _inf = None: 8_192)
     usage = {"prompt_tokens": 5_000, "completion_tokens": 4_000, "total_tokens": 9_000}
     notice = _synthesis_length_limit_error(
@@ -628,22 +602,16 @@ def test_a_ceiling_below_the_default_is_respected(monkeypatch):
 
 
 def test_a_legacy_ceiling_below_the_default_keeps_the_old_budget(monkeypatch):
-    """Without a published limit the number is ambiguous, so it does not lower the report.
-
-    Such a run asked for _SYNTHESIS_MAX_TOKENS before any of this existed and the provider
-    took it, so keeping that is the no-regression answer.
-    """
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
     inference = {"providerType": "openai", "providerId": "p1", "maxOutputTokens": 8_192}
     assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
 
 
 def test_the_provider_floor_table_matches_the_client_one_it_mirrors():
-    """Two copies of the same table, in two languages, with nothing tying them together.
+    """A hand copy of the client's table, in another language, with nothing tying them together.
 
-    _EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER is a hand copy of the client's table, and drift
-    would be silent: the report would ask a provider for a budget its thinking answer is cut
-    off below, which is exactly what the floor exists to prevent.
+    Drift is silent: the report would ask for a budget the provider truncates a thinking answer
+    below, which is what the floor exists to prevent.
     """
     import re
 
@@ -681,14 +649,12 @@ def test_a_local_run_ignores_a_stray_ceiling():
 def test_a_budget_the_run_cannot_stream_in_time_is_bounded_by_its_wall_clock(monkeypatch):
     """A wall-clock stop loses the report; running out of budget only truncates it.
 
-    _stream_completion re-raises ModelWallClockTimeout without returning the text it has
-    already streamed, so a budget larger than the run's own deadline can deliver trades a
-    readable truncated report for a failed run at the last and most expensive step.
+    _stream_completion re-raises without returning the text it already streamed.
     """
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
     inference = {"providerType": "deepseek", "providerId": "p1", "maxOutputTokens": 384_000}
     assert _synthesis_max_tokens(inference, 900) == 900 * research_runs._SYNTHESIS_TOKENS_PER_SECOND
-    # Never below what the run would have got anyway, however short the deadline.
+    # Never below what the run would have got anyway.
     assert _synthesis_max_tokens(inference, 60) == research_runs._SYNTHESIS_MAX_TOKENS
     assert _synthesis_max_tokens({**inference, "maxOutputTokens": 32_768}, 120) == 16_384
 
@@ -719,7 +685,6 @@ def test_an_absurd_saved_ceiling_cannot_reach_the_provider(monkeypatch):
 
 
 def test_the_report_budget_never_falls_below_what_a_run_used_to_get(monkeypatch):
-    """The whole no-regression rule, over the combinations that reach it."""
     for saved in (None, 64, 8_000, 16_384, 32_768, 256_000):
         monkeypatch.setattr(
             research_runs.providers_db,
@@ -736,11 +701,7 @@ def test_the_report_budget_never_falls_below_what_a_run_used_to_get(monkeypatch)
 
 
 def test_a_cap_lowered_mid_run_bounds_the_request_that_actually_goes_out(monkeypatch):
-    """The budget is resolved once, but the loop re-sends after a queue or rate-limit wait.
-
-    Recovery and every transport retry rebuild the request minutes later, so what bounds the
-    body is the ceiling in force when it is built, not the one that was in force at the start.
-    """
+    """Recovery and every retry rebuild the request later, so the cap is re-read at build."""
     caps = iter([65_536, 32_768])
     monkeypatch.setattr(
         research_runs.providers_db,
@@ -749,26 +710,22 @@ def test_a_cap_lowered_mid_run_bounds_the_request_that_actually_goes_out(monkeyp
     )
     inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 65_536}
     assert _synthesis_max_tokens(inference, 0) == 65_536
-    # The second call is the one the retry loop makes, and it sees the lowered row.
+    # The second call is the one the retry loop makes.
     assert _synthesis_max_tokens(inference, 0) == 32_768
 
 
 def test_the_flush_triggers_scale_from_the_same_written_length():
     """Both arms must start scaling together, or the character one never binds.
 
-    Every flush rewrites the whole report row through the shared SQLite writer, and the same
-    wake-ups drive a full-report read per follower, so a time arm whose knee sits at the END
-    of the range this change unlocks leaves the row being rewritten four times a second for
-    an entire 65_536-token report.
+    A time arm whose knee sits at the END of the unlocked range leaves the row rewritten four
+    times a second through the shared writer for an entire 65_536-token report.
     """
     knee = int(
         research_runs._PROGRESS_FLUSH_SECONDS * research_runs._PROGRESS_FLUSH_CHARS_PER_SECOND
     )
     assert knee == research_runs._PROGRESS_FLUSH_CHARS * 64
-    # A 65_536-token report is roughly 262_144 chars, and the time arm has to have started
-    # scaling well before it, not at it.
+    # A 65_536-token report is roughly 262_144 chars; the arm must scale well before it.
     assert knee < 262_144 // 2
-    # Short reports are untouched: both arms sit at the previous constants.
     assert max(research_runs._PROGRESS_FLUSH_CHARS, 1_000 // 64) == 512
     assert (
         max(
@@ -787,7 +744,6 @@ def test_an_explicit_zero_budget_is_never_put_on_the_wire(monkeypatch):
 
 
 def test_a_saved_connection_cap_does_not_shorten_a_legacy_run(monkeypatch):
-    """A run this old was written at the default before the cap was ever consulted."""
     monkeypatch.setattr(
         research_runs.providers_db,
         "get_provider",
@@ -808,7 +764,6 @@ def test_a_saved_cap_above_the_default_does_not_raise_a_legacy_run(monkeypatch):
 
 
 def test_a_client_ceiling_is_what_actually_raises_the_report_budget(monkeypatch):
-    """The mainstream path: the client resolved this against the run's own model."""
     monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
     inference = {
         "providerType": "ollama",
@@ -820,13 +775,8 @@ def test_a_client_ceiling_is_what_actually_raises_the_report_budget(monkeypatch)
 
 
 def test_a_legacy_run_keeps_the_default_rather_than_guessing_upwards(monkeypatch):
-    """The saved cap is connection-wide, so for this run's model it is a guess.
-
-    Only the client holds the table that bounds a connection by the selected model's
-    documented ceiling, so without a ceiling from the client this side cannot raise the
-    budget at all: claude-opus-4-1 stops at 32_000 while its connection may be saved at
-    32_768, and a provider that rejects an over-limit request fails the finished run.
-    """
+    """The saved cap is connection-wide, so for this run's model it is a guess: claude-opus-4-1
+    stops at 32_000 while its connection may be saved at 32_768."""
     monkeypatch.setattr(
         research_runs.providers_db,
         "get_provider",

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -369,7 +369,7 @@ def test_a_local_run_still_clamps_to_the_loaded_context(monkeypatch):
 def test_a_lowered_connection_cap_bounds_a_stale_client_ceiling(monkeypatch):
     """The run is durable, so the cap can have been lowered after the client resolved it."""
     monkeypatch.setattr(
-        research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_192}
+        research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 20_000}
     )
     inference = {
         "providerType": "gemini",
@@ -377,7 +377,7 @@ def test_a_lowered_connection_cap_bounds_a_stale_client_ceiling(monkeypatch):
         "externalModel": "gemini-3.6-flash",
         "maxOutputTokens": 65_536,
     }
-    assert _synthesis_max_tokens(inference) == 8_192
+    assert _synthesis_max_tokens(inference) == 20_000
 
 
 def test_a_client_ceiling_stands_when_the_connection_has_no_cap(monkeypatch):
@@ -392,15 +392,32 @@ def test_a_saved_cap_cannot_drop_a_connection_below_its_provider_floor(monkeypat
         research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_000}
     )
     inference = {"providerType": "kimi", "providerId": "p1", "maxOutputTokens": 32_768}
-    assert _synthesis_max_tokens(inference) == 16_000
+    # The default floor gets there first here; the provider floor is what holds a connection
+    # whose own client ceiling is below it.
+    assert _synthesis_max_tokens(inference) == 16_384
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    assert _synthesis_max_tokens({**inference, "maxOutputTokens": 4_096}) == 16_000
 
 
-def test_a_provider_without_a_floor_keeps_the_saved_cap(monkeypatch):
+def test_a_saved_cap_below_the_previous_default_does_not_shorten_the_report(monkeypatch):
+    """The cap sizes the chat slider. It may not make a report shorter than it used to be.
+
+    Before the connection ceiling was read at all, every run got _SYNTHESIS_MAX_TOKENS, this
+    one included. A user who capped a connection at 8_000 to control chat cost did not ask
+    for a shorter report than the one Deep Research has been writing them all along.
+    """
     monkeypatch.setattr(
         research_runs.providers_db, "get_provider", lambda _id: {"max_output_tokens": 8_000}
     )
     inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 32_768}
-    assert _synthesis_max_tokens(inference) == 8_000
+    assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
+
+
+def test_a_client_ceiling_below_the_default_still_lowers_the_budget(monkeypatch):
+    """That one is the model's documented limit, not a preference: asking past it is refused."""
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {"providerType": "openai", "providerId": "p1", "maxOutputTokens": 8_192}
+    assert _synthesis_max_tokens(inference) == 8_192
 
 
 def test_an_unreadable_cap_does_not_let_a_stale_client_ceiling_through(monkeypatch):
@@ -485,18 +502,137 @@ def test_a_ceiling_below_the_default_is_respected(monkeypatch):
     assert _synthesis_max_tokens(inference) == 8_192
 
 
+def test_the_provider_floor_table_matches_the_client_one_it_mirrors():
+    """Two copies of the same table, in two languages, with nothing tying them together.
+
+    _EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER is a hand copy of the client's table, and drift
+    would be silent: the report would ask a provider for a budget its thinking answer is cut
+    off below, which is exactly what the floor exists to prevent.
+    """
+    import re
+
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "frontend"
+        / "src"
+        / "features"
+        / "chat"
+        / "provider-capabilities.ts"
+    ).read_text(encoding = "utf-8")
+    table = re.search(
+        r"const EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER: Record<string, number> = \{(.*?)\};",
+        source,
+        re.S,
+    )
+    assert table, "the client table was renamed; the copy in research_runs.py needs the same"
+    assert research_runs._EXTERNAL_MIN_OUTPUT_TOKENS_BY_PROVIDER == {
+        name: int(value.replace("_", ""))
+        for name, value in re.findall(r"(\w+)\s*:\s*([\d_]+)", table.group(1))
+    }
+    default = re.search(
+        r"export function getExternalMinOutputTokens\(.*?\)\s*:\s*number\s*\{.*?"
+        r"if \(!providerType\) return (\d+);",
+        source,
+        re.S,
+    )
+    assert default and research_runs._EXTERNAL_MIN_OUTPUT_TOKENS == int(default.group(1))
+
+
 def test_a_local_run_ignores_a_stray_ceiling():
     assert _synthesis_max_tokens({"maxOutputTokens": 65_536}) == research_runs._SYNTHESIS_MAX_TOKENS
 
 
-def test_a_saved_connection_cap_below_the_default_is_honoured(monkeypatch):
+def test_a_budget_the_run_cannot_stream_in_time_is_bounded_by_its_wall_clock(monkeypatch):
+    """A wall-clock stop loses the report; running out of budget only truncates it.
+
+    _stream_completion re-raises ModelWallClockTimeout without returning the text it has
+    already streamed, so a budget larger than the run's own deadline can deliver trades a
+    readable truncated report for a failed run at the last and most expensive step.
+    """
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {"providerType": "deepseek", "providerId": "p1", "maxOutputTokens": 384_000}
+    assert _synthesis_max_tokens(inference, 900) == 900 * research_runs._SYNTHESIS_TOKENS_PER_SECOND
+    # Never below what the run would have got anyway, however short the deadline.
+    assert _synthesis_max_tokens(inference, 60) == research_runs._SYNTHESIS_MAX_TOKENS
+    assert _synthesis_max_tokens({**inference, "maxOutputTokens": 32_768}, 120) == 16_384
+
+
+def test_a_ceiling_bounds_a_budget_even_without_a_wall_clock(monkeypatch):
+    """0 is unlimited in the budgets schema, and a documented cap can still be wrong."""
+    monkeypatch.setattr(research_runs.providers_db, "get_provider", lambda _id: None)
+    inference = {"providerType": "deepseek", "providerId": "p1", "maxOutputTokens": 384_000}
+    for unlimited in (0, None):
+        assert _synthesis_max_tokens(inference, unlimited) == (
+            research_runs._SYNTHESIS_MAX_TOKENS_CEILING
+        )
+
+
+def test_an_absurd_saved_ceiling_cannot_reach_the_provider(monkeypatch):
+    """The route accepts up to MAX_JSON_SAFE_INTEGER, and nothing downstream bounds it."""
+    monkeypatch.setattr(
+        research_runs.providers_db,
+        "get_provider",
+        lambda _id: {"max_output_tokens": 9_007_199_254_740_991},
+    )
+    inference = {
+        "providerType": "openai",
+        "providerId": "p1",
+        "maxOutputTokens": 9_007_199_254_740_991,
+    }
+    assert _synthesis_max_tokens(inference, 900) <= research_runs._SYNTHESIS_MAX_TOKENS_CEILING
+
+
+def test_the_report_budget_never_falls_below_what_a_run_used_to_get(monkeypatch):
+    """The whole no-regression rule, over the combinations that reach it."""
+    for saved in (None, 64, 8_000, 16_384, 32_768, 256_000):
+        monkeypatch.setattr(
+            research_runs.providers_db,
+            "get_provider",
+            lambda _id, cap = saved: {"max_output_tokens": cap} if cap else None,
+        )
+        for client in (None, 32_768, 65_536, 384_000):
+            inference = {"providerType": "gemini", "providerId": "p1"}
+            if client:
+                inference["maxOutputTokens"] = client
+            budget = _synthesis_max_tokens(inference, 900)
+            assert budget >= research_runs._SYNTHESIS_MAX_TOKENS, (saved, client, budget)
+            assert budget <= research_runs._SYNTHESIS_MAX_TOKENS_CEILING, (saved, client, budget)
+
+
+def test_a_cap_lowered_mid_run_bounds_the_request_that_actually_goes_out(monkeypatch):
+    """The budget is resolved once, but the loop re-sends after a queue or rate-limit wait.
+
+    Recovery and every transport retry rebuild the request minutes later, so what bounds the
+    body is the ceiling in force when it is built, not the one that was in force at the start.
+    """
+    caps = iter([65_536, 32_768])
+    monkeypatch.setattr(
+        research_runs.providers_db,
+        "get_provider",
+        lambda _id: {"max_output_tokens": next(caps, 32_768)},
+    )
+    inference = {"providerType": "gemini", "providerId": "p1", "maxOutputTokens": 65_536}
+    assert _synthesis_max_tokens(inference, 0) == 65_536
+    # The second call is the one the retry loop makes, and it sees the lowered row.
+    assert _synthesis_max_tokens(inference, 0) == 32_768
+
+
+def test_an_explicit_zero_budget_is_never_put_on_the_wire(monkeypatch):
+    """main's `max_tokens or ...` made 0 impossible; the route rejects a request for one."""
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda *a, **k: None)
+    assert _resolve_max_tokens(0, {}, [{"role": "user", "content": "x"}]) == 1
+    assert _resolve_max_tokens(-5, {}, [{"role": "user", "content": "x"}]) == 1
+
+
+def test_a_saved_connection_cap_does_not_shorten_a_legacy_run(monkeypatch):
+    """A run this old was written at the default before the cap was ever consulted."""
     monkeypatch.setattr(
         research_runs.providers_db,
         "get_provider",
         lambda _id: {"max_output_tokens": 8_192},
     )
     inference = {"providerType": "ollama", "providerId": "p1", "externalModel": "glm-5.3-flash"}
-    assert _synthesis_max_tokens(inference) == 8_192
+    assert _synthesis_max_tokens(inference) == research_runs._SYNTHESIS_MAX_TOKENS
 
 
 def test_a_saved_cap_above_the_default_does_not_raise_a_legacy_run(monkeypatch):

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -935,9 +935,7 @@ def test_sanitize_config_keeps_the_grounding_flag_and_refuses_a_non_boolean():
     for bad in (1, 0, "true", None, []):
         with pytest.raises(HTTPException):
             _sanitize_config(
-                _make_payload(
-                    inferenceRequest = {"model": "m", "maxOutputTokensFromSavedCap": bad}
-                ),
+                _make_payload(inferenceRequest = {"model": "m", "maxOutputTokensFromSavedCap": bad}),
                 {"modelId": "m"},
             )
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -753,6 +753,24 @@ def test_a_cap_lowered_mid_run_bounds_the_request_that_actually_goes_out(monkeyp
     assert _synthesis_max_tokens(inference, 0) == 32_768
 
 
+def test_the_flush_triggers_scale_from_the_same_written_length():
+    """Both arms must start scaling together, or the character one never binds.
+
+    Every flush rewrites the whole report row through the shared SQLite writer, and the same
+    wake-ups drive a full-report read per follower, so a time arm whose knee sits at the END
+    of the range this change unlocks leaves the row being rewritten four times a second for
+    an entire 65_536-token report.
+    """
+    knee = int(research_runs._PROGRESS_FLUSH_SECONDS * research_runs._PROGRESS_FLUSH_CHARS_PER_SECOND)
+    assert knee == research_runs._PROGRESS_FLUSH_CHARS * 64
+    # A 65_536-token report is roughly 262_144 chars, and the time arm has to have started
+    # scaling well before it, not at it.
+    assert knee < 262_144 // 2
+    # Short reports are untouched: both arms sit at the previous constants.
+    assert max(research_runs._PROGRESS_FLUSH_CHARS, 1_000 // 64) == 512
+    assert max(research_runs._PROGRESS_FLUSH_SECONDS, 1_000 / research_runs._PROGRESS_FLUSH_CHARS_PER_SECOND) == 0.25
+
+
 def test_an_explicit_zero_budget_is_never_put_on_the_wire(monkeypatch):
     """main's `max_tokens or ...` made 0 impossible; the route rejects a request for one."""
     monkeypatch.setattr(research_runs, "_loaded_context_length", lambda *a, **k: None)

--- a/studio/backend/tests/test_research_synthesis_recovery.py
+++ b/studio/backend/tests/test_research_synthesis_recovery.py
@@ -43,7 +43,7 @@ def research_home(tmp_path, monkeypatch):
     return tmp_path
 
 
-def _claimed_run(supervisor) -> dict:
+def _claimed_run(supervisor, external: bool = False) -> dict:
     research_db.create_run(
         run_id = "run-1",
         owner_subject = "alice",
@@ -52,14 +52,24 @@ def _claimed_run(supervisor) -> dict:
         assistant_message_id = None,
         config = {
             "model": "local-model",
-            "inferenceRequest": {"model": "local-model"},
+            "inferenceRequest": (
+                {
+                    "model": "local-model",
+                    "providerType": "gemini",
+                    "providerId": "p1",
+                    "externalModel": "gemini-3.6-flash",
+                    "maxOutputTokens": 32_768,
+                }
+                if external
+                else {"model": "local-model"}
+            ),
             "ragScope": None,
             "instructions": "",
             "question": "what happened?",
             "budgets": {
                 "maxSteps": 1,
                 "maxSources": 5,
-                "modelTimeoutSeconds": 30,
+                "modelTimeoutSeconds": 900,
                 "toolTimeoutSeconds": 10,
             },
         },
@@ -283,3 +293,63 @@ def test_a_recovery_padded_with_invented_citations_does_not_win_on_length(
     assert len(SHORTER_DRAFT + "\n\n" + invented) > len(FIRST_DRAFT)
     assert finished["status"] == "completed"
     assert FIRST_DRAFT in finished["report"]
+
+
+def test_a_refused_report_budget_falls_back_rather_than_losing_the_run(research_home, monkeypatch):
+    """A connection that refuses the raised budget must not discard finished research.
+
+    A per-endpoint limit below the model's published cap, a router fronting several of them,
+    or a self-hosted context window that has to hold the synthesis prompt as well: none of
+    those is knowable when the budget is resolved. Failing here would throw away every step
+    and source the run gathered, so the last attempt is made at the budget every run had
+    before the connection ceiling was read at all.
+    """
+    from core import research_runs as worker
+
+    supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
+    monkeypatch.setattr(
+        worker.providers_db, "get_provider", lambda _id: {"max_output_tokens": 32_768}
+    )
+    claimed = _claimed_run(supervisor, external = True)
+    asked: list[int | None] = []
+
+    async def refuse_the_raised_budget(run, messages, **kwargs):
+        if kwargs.get("phase") != "synthesis":
+            return "not json", "", "stop", None
+        budget = kwargs.get("max_tokens")
+        asked.append(budget)
+        if budget and budget > worker._SYNTHESIS_MAX_TOKENS:
+            raise ValueError("max_tokens is too large for this model")
+        return FIRST_DRAFT, "", "stop", None
+
+    monkeypatch.setattr(supervisor, "_stream_completion", refuse_the_raised_budget)
+    asyncio.run(supervisor._research(claimed))
+
+    assert asked == [32_768, worker._SYNTHESIS_MAX_TOKENS]
+    finished = research_db.get_run("run-1")
+    assert finished["status"] == "completed"
+    assert FIRST_DRAFT in finished["report"]
+
+
+def test_a_cancelled_run_is_not_retried_at_the_old_budget(research_home, monkeypatch):
+    """The fallback covers a refused budget, not a run the user stopped."""
+    from core import research_runs as worker
+
+    supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
+    monkeypatch.setattr(
+        worker.providers_db, "get_provider", lambda _id: {"max_output_tokens": 32_768}
+    )
+    claimed = _claimed_run(supervisor, external = True)
+    calls = {"n": 0}
+
+    async def cancel_during_synthesis(run, messages, **kwargs):
+        if kwargs.get("phase") != "synthesis":
+            return "not json", "", "stop", None
+        calls["n"] += 1
+        raise worker.RunCancelled()
+
+    monkeypatch.setattr(supervisor, "_stream_completion", cancel_during_synthesis)
+    with pytest.raises(worker.RunCancelled):
+        asyncio.run(supervisor._research(claimed))
+
+    assert calls["n"] == 1

--- a/studio/backend/tests/test_research_synthesis_recovery.py
+++ b/studio/backend/tests/test_research_synthesis_recovery.py
@@ -296,14 +296,8 @@ def test_a_recovery_padded_with_invented_citations_does_not_win_on_length(
 
 
 def test_a_refused_report_budget_falls_back_rather_than_losing_the_run(research_home, monkeypatch):
-    """A connection that refuses the raised budget must not discard finished research.
-
-    A per-endpoint limit below the model's published cap, a router fronting several of them,
-    or a self-hosted context window that has to hold the synthesis prompt as well: none of
-    those is knowable when the budget is resolved. Failing here would throw away every step
-    and source the run gathered, so the last attempt is made at the budget every run had
-    before the connection ceiling was read at all.
-    """
+    """None of the ways a connection can refuse are knowable when the budget is resolved, so
+    the last attempt is made at the budget every run had before the ceiling was read."""
     from core import research_runs as worker
 
     supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
@@ -356,12 +350,8 @@ def test_a_cancelled_run_is_not_retried_at_the_old_budget(research_home, monkeyp
 
 
 def test_a_failed_recovery_keeps_the_draft_it_was_called_to_rescue(research_home, monkeypatch):
-    """Recovery improves on a draft already in hand, so failing it must not discard that.
-
-    Its prompt carries instructions the first one did not, so an endpoint that counts prompt
-    plus requested output against a single window can refuse the second request at a budget
-    the first fit inside. Losing the run there would throw away a readable report.
-    """
+    """Its prompt carries instructions the first did not, so an endpoint counting prompt plus
+    output against one window can refuse it at a budget the first request fit inside."""
     from core import research_runs as worker
 
     supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))

--- a/studio/backend/tests/test_research_synthesis_recovery.py
+++ b/studio/backend/tests/test_research_synthesis_recovery.py
@@ -353,3 +353,61 @@ def test_a_cancelled_run_is_not_retried_at_the_old_budget(research_home, monkeyp
         asyncio.run(supervisor._research(claimed))
 
     assert calls["n"] == 1
+
+
+def test_a_failed_recovery_keeps_the_draft_it_was_called_to_rescue(research_home, monkeypatch):
+    """Recovery improves on a draft already in hand, so failing it must not discard that.
+
+    Its prompt carries instructions the first one did not, so an endpoint that counts prompt
+    plus requested output against a single window can refuse the second request at a budget
+    the first fit inside. Losing the run there would throw away a readable report.
+    """
+    from core import research_runs as worker
+
+    supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
+    monkeypatch.setattr(
+        worker.providers_db, "get_provider", lambda _id: {"max_output_tokens": 32_768}
+    )
+    claimed = _claimed_run(supervisor, external = True)
+    phases: list[str] = []
+
+    async def refuse_only_the_recovery(run, messages, **kwargs):
+        phase = kwargs.get("phase")
+        phases.append(phase)
+        if phase == "synthesis":
+            return FIRST_DRAFT, "", "length", {"completion_tokens": 32_768}
+        if phase == "synthesis_recovery":
+            raise ValueError("max_tokens plus prompt exceeds the model's context window")
+        return "not json", "", "stop", None
+
+    monkeypatch.setattr(supervisor, "_stream_completion", refuse_only_the_recovery)
+    asyncio.run(supervisor._research(claimed))
+
+    assert "synthesis_recovery" in phases
+    finished = research_db.get_run("run-1")
+    assert finished["status"] == "completed"
+    assert FIRST_DRAFT in finished["report"]
+    assert "Incomplete report." in finished["report"]
+
+
+def test_a_cancel_during_recovery_still_stops_the_run(research_home, monkeypatch):
+    """The rescue covers a refused request, not a run the user stopped."""
+    from core import research_runs as worker
+
+    supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
+    monkeypatch.setattr(
+        worker.providers_db, "get_provider", lambda _id: {"max_output_tokens": 32_768}
+    )
+    claimed = _claimed_run(supervisor, external = True)
+
+    async def cancel_during_recovery(run, messages, **kwargs):
+        phase = kwargs.get("phase")
+        if phase == "synthesis":
+            return FIRST_DRAFT, "", "length", {"completion_tokens": 32_768}
+        if phase == "synthesis_recovery":
+            raise worker.RunCancelled()
+        return "not json", "", "stop", None
+
+    monkeypatch.setattr(supervisor, "_stream_completion", cancel_during_recovery)
+    with pytest.raises(worker.RunCancelled):
+        asyncio.run(supervisor._research(claimed))

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -140,6 +140,7 @@ import { syncModelCapabilities } from "../hooks/use-chat-model-runtime";
 import {
   clampReasoningEffortToLevels,
   getExternalMaxOutputTokens,
+  getGroundedExternalMaxOutputTokens,
   getExternalMinOutputTokens,
   getExternalReasoningCapabilities,
   getProviderCapabilities,
@@ -4156,7 +4157,7 @@ export function createOpenAIStreamAdapter(
                   providerId: researchExternalProvider.id,
                   providerType: researchExternalProvider.providerType,
                   modelId: researchExternalSelection.modelId,
-                  maxOutputTokens: getExternalMaxOutputTokens(
+                  maxOutputTokens: getGroundedExternalMaxOutputTokens(
                     researchExternalProvider.providerType,
                     researchExternalSelection.modelId,
                     researchExternalProvider.maxOutputTokens,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4156,6 +4156,11 @@ export function createOpenAIStreamAdapter(
                   providerId: researchExternalProvider.id,
                   providerType: researchExternalProvider.providerType,
                   modelId: researchExternalSelection.modelId,
+                  maxOutputTokens: getExternalMaxOutputTokens(
+                    researchExternalProvider.providerType,
+                    researchExternalSelection.modelId,
+                    researchExternalProvider.maxOutputTokens,
+                  ),
                 }
               : undefined,
           temperature: params.temperature,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -141,6 +141,7 @@ import {
   clampReasoningEffortToLevels,
   externalMaxOutputTokensNeedsConnectionCap,
   getExternalMaxOutputTokens,
+  getPublishedExternalMaxOutputTokens,
   getGroundedExternalMaxOutputTokens,
   getExternalMinOutputTokens,
   getExternalReasoningCapabilities,
@@ -4164,6 +4165,10 @@ export function createOpenAIStreamAdapter(
                     researchExternalProvider.maxOutputTokens,
                   ),
                   maxOutputTokensFromSavedCap: externalMaxOutputTokensNeedsConnectionCap(
+                    researchExternalProvider.providerType,
+                    researchExternalSelection.modelId,
+                  ),
+                  maxOutputTokensPublished: getPublishedExternalMaxOutputTokens(
                     researchExternalProvider.providerType,
                     researchExternalSelection.modelId,
                   ),

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -139,6 +139,7 @@ import {
 import { syncModelCapabilities } from "../hooks/use-chat-model-runtime";
 import {
   clampReasoningEffortToLevels,
+  externalMaxOutputTokensNeedsConnectionCap,
   getExternalMaxOutputTokens,
   getGroundedExternalMaxOutputTokens,
   getExternalMinOutputTokens,
@@ -4161,6 +4162,10 @@ export function createOpenAIStreamAdapter(
                     researchExternalProvider.providerType,
                     researchExternalSelection.modelId,
                     researchExternalProvider.maxOutputTokens,
+                  ),
+                  maxOutputTokensFromSavedCap: externalMaxOutputTokensNeedsConnectionCap(
+                    researchExternalProvider.providerType,
+                    researchExternalSelection.modelId,
                   ),
                 }
               : undefined,

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -165,8 +165,31 @@ export function getExternalMaxOutputTokens(
   return Math.max(resolved, getExternalMinOutputTokens(providerType));
 }
 
-/** The published per-model cap, or null when nothing documents this id. Generic Custom
- *  connections always read undocumented. OpenRouter `provider/model` prefixes are stripped. */
+/**
+ * The ceiling only when something actually grounds it: a published per-model cap, or the
+ * user's own connection override. Null otherwise.
+ *
+ * `getExternalMaxOutputTokens` falls back to `EXTERNAL_MAX_OUTPUT_TOKENS` for a model nothing
+ * documents, which is fine for a slider the user can see and lower, but it is a guess to send
+ * as a request budget: a self-hosted 32k-context server has to fit the prompt in that same
+ * window, so asking it for 32768 output tokens fails the call outright.
+ */
+export function getGroundedExternalMaxOutputTokens(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+  connectionMaxOutputTokens?: number | null,
+): number | null {
+  const override = normalizeProviderMaxOutputTokens(connectionMaxOutputTokens);
+  const documented = _documentedMaxOutputTokens(providerType, modelId);
+  if (override == null && documented == null) return null;
+  return getExternalMaxOutputTokens(providerType, modelId, connectionMaxOutputTokens);
+}
+
+/**
+ * The published per-model cap, or null when nothing documents this id. No table entry
+ * targets a generic Custom connection, so those always read as undocumented. OpenRouter
+ * `provider/model` ids have the prefix stripped before matching.
+ */
 function _documentedMaxOutputTokens(
   providerType: string | null | undefined,
   modelId: string | null | undefined,

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -180,15 +180,38 @@ export function getGroundedExternalMaxOutputTokens(
   connectionMaxOutputTokens?: number | null,
 ): number | null {
   const override = normalizeProviderMaxOutputTokens(connectionMaxOutputTokens);
-  // An OpenRouter id resolves through the direct provider's table, and a router endpoint is
-  // not that provider: `deepseek/deepseek-r1` reads as the direct API's 384000 while the
-  // router serves it at a fraction of that. Good enough for a slider maximum, not for a
-  // budget sent unattended, so a router connection is grounded only by the user's own
-  // override.
-  const documented =
-    providerType === "openrouter" ? null : _documentedMaxOutputTokens(providerType, modelId);
-  if (override == null && documented == null) return null;
+  if (override == null && _publishedMaxOutputTokens(providerType, modelId) == null) return null;
   return getExternalMaxOutputTokens(providerType, modelId, connectionMaxOutputTokens);
+}
+
+/**
+ * True when the connection's own override is the ONLY thing that can ground this model's
+ * ceiling, so clearing that override leaves nothing behind it.
+ *
+ * A durable research run carries the ceiling it was created with. The backend can tell that
+ * the saved cap is gone, but not whether anything else was holding the number up, so it is
+ * told here.
+ */
+export function externalMaxOutputTokensNeedsConnectionCap(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+): boolean {
+  return _publishedMaxOutputTokens(providerType, modelId) == null;
+}
+
+/**
+ * `_documentedMaxOutputTokens`, minus the entries that do not survive being sent unattended.
+ *
+ * An OpenRouter id resolves through the direct provider's table, and a router endpoint is not
+ * that provider: `deepseek/deepseek-r1` reads as the direct API's 384000 while the router
+ * serves it at a fraction of that. Good enough for a slider maximum, not for a request budget.
+ */
+function _publishedMaxOutputTokens(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+): number | null {
+  if (providerType === "openrouter") return null;
+  return _documentedMaxOutputTokens(providerType, modelId);
 }
 
 /**

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -180,7 +180,13 @@ export function getGroundedExternalMaxOutputTokens(
   connectionMaxOutputTokens?: number | null,
 ): number | null {
   const override = normalizeProviderMaxOutputTokens(connectionMaxOutputTokens);
-  const documented = _documentedMaxOutputTokens(providerType, modelId);
+  // An OpenRouter id resolves through the direct provider's table, and a router endpoint is
+  // not that provider: `deepseek/deepseek-r1` reads as the direct API's 384000 while the
+  // router serves it at a fraction of that. Good enough for a slider maximum, not for a
+  // budget sent unattended, so a router connection is grounded only by the user's own
+  // override.
+  const documented =
+    providerType === "openrouter" ? null : _documentedMaxOutputTokens(providerType, modelId);
   if (override == null && documented == null) return null;
   return getExternalMaxOutputTokens(providerType, modelId, connectionMaxOutputTokens);
 }

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -200,6 +200,21 @@ export function externalMaxOutputTokensNeedsConnectionCap(
 }
 
 /**
+ * The model's own published output limit, before any connection override is folded in.
+ *
+ * `getGroundedExternalMaxOutputTokens` returns the override-folded number, which is the right
+ * thing to spend but the wrong thing to reason about: it cannot tell a model that genuinely
+ * stops at 8192 from a 65536 model on a connection the user capped at 8192. Deep Research
+ * needs the difference, because the first may lower its report budget and the second may not.
+ */
+export function getPublishedExternalMaxOutputTokens(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+): number | null {
+  return _publishedMaxOutputTokens(providerType, modelId);
+}
+
+/**
  * `_documentedMaxOutputTokens`, minus the entries that do not survive being sent unattended.
  *
  * An OpenRouter id resolves through the direct provider's table, and a router endpoint is not

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -166,13 +166,9 @@ export function getExternalMaxOutputTokens(
 }
 
 /**
- * The ceiling only when something actually grounds it: a published per-model cap, or the
- * user's own connection override. Null otherwise.
- *
- * `getExternalMaxOutputTokens` falls back to `EXTERNAL_MAX_OUTPUT_TOKENS` for a model nothing
- * documents, which is fine for a slider the user can see and lower, but it is a guess to send
- * as a request budget: a self-hosted 32k-context server has to fit the prompt in that same
- * window, so asking it for 32768 output tokens fails the call outright.
+ * The ceiling only when a published cap or the user's own override grounds it, else null.
+ * `getExternalMaxOutputTokens` guesses for an undocumented model, which is fine for a slider
+ * but not as a budget: a 32k-context self-hosted server holds the prompt in the same window.
  */
 export function getGroundedExternalMaxOutputTokens(
   providerType: string | null | undefined,
@@ -185,12 +181,9 @@ export function getGroundedExternalMaxOutputTokens(
 }
 
 /**
- * True when the connection's own override is the ONLY thing that can ground this model's
- * ceiling, so clearing that override leaves nothing behind it.
- *
- * A durable research run carries the ceiling it was created with. The backend can tell that
- * the saved cap is gone, but not whether anything else was holding the number up, so it is
- * told here.
+ * True when the connection's override is the ONLY thing that can ground this model's ceiling.
+ * A durable run carries the ceiling it was created with, and the backend can see the cap is
+ * gone but not whether anything else was holding the number up.
  */
 export function externalMaxOutputTokensNeedsConnectionCap(
   providerType: string | null | undefined,
@@ -200,12 +193,9 @@ export function externalMaxOutputTokensNeedsConnectionCap(
 }
 
 /**
- * The model's own published output limit, before any connection override is folded in.
- *
- * `getGroundedExternalMaxOutputTokens` returns the override-folded number, which is the right
- * thing to spend but the wrong thing to reason about: it cannot tell a model that genuinely
- * stops at 8192 from a 65536 model on a connection the user capped at 8192. Deep Research
- * needs the difference, because the first may lower its report budget and the second may not.
+ * The model's own published output limit, before any connection override is folded in. The
+ * folded number cannot tell a model that stops at 8192 from a 65536 model capped at 8192,
+ * and only the first may lower the report budget.
  */
 export function getPublishedExternalMaxOutputTokens(
   providerType: string | null | undefined,
@@ -215,11 +205,9 @@ export function getPublishedExternalMaxOutputTokens(
 }
 
 /**
- * `_documentedMaxOutputTokens`, minus the entries that do not survive being sent unattended.
- *
- * An OpenRouter id resolves through the direct provider's table, and a router endpoint is not
- * that provider: `deepseek/deepseek-r1` reads as the direct API's 384000 while the router
- * serves it at a fraction of that. Good enough for a slider maximum, not for a request budget.
+ * `_documentedMaxOutputTokens`, minus entries that do not survive being sent unattended: an
+ * OpenRouter id resolves through the DIRECT provider's table, so `deepseek/deepseek-r1` reads
+ * as 384000 while the router serves it far below that.
  */
 function _publishedMaxOutputTokens(
   providerType: string | null | undefined,

--- a/studio/frontend/src/features/chat/research-inference-request.ts
+++ b/studio/frontend/src/features/chat/research-inference-request.ts
@@ -30,8 +30,8 @@ export function buildResearchInferenceRequest(input: {
     providerId: string;
     providerType: string;
     modelId: string;
-    /** The connection's resolved per-model output ceiling. */
-    maxOutputTokens: number;
+    /** The connection's resolved output ceiling, or null when nothing grounds one. */
+    maxOutputTokens: number | null;
   };
   temperature: number;
   topP: number;
@@ -53,7 +53,8 @@ export function buildResearchInferenceRequest(input: {
           providerId: input.external.providerId,
           providerType: input.external.providerType,
           externalModel: input.external.modelId,
-          ...(Number.isFinite(input.external.maxOutputTokens) &&
+          ...(input.external.maxOutputTokens != null &&
+          Number.isFinite(input.external.maxOutputTokens) &&
           input.external.maxOutputTokens > 0
             ? { maxOutputTokens: Math.floor(input.external.maxOutputTokens) }
             : {}),

--- a/studio/frontend/src/features/chat/research-inference-request.ts
+++ b/studio/frontend/src/features/chat/research-inference-request.ts
@@ -19,13 +19,20 @@ export interface ResearchInferenceRequest {
   temperature?: number;
   topP?: number;
   maxTokens?: number;
+  maxOutputTokens?: number;
   enableThinking?: boolean;
   reasoningEffort?: string;
 }
 
 export function buildResearchInferenceRequest(input: {
   checkpoint: string;
-  external?: { providerId: string; providerType: string; modelId: string };
+  external?: {
+    providerId: string;
+    providerType: string;
+    modelId: string;
+    /** The connection's resolved per-model output ceiling. */
+    maxOutputTokens: number;
+  };
   temperature: number;
   topP: number;
   maxTokens: number;
@@ -46,6 +53,10 @@ export function buildResearchInferenceRequest(input: {
           providerId: input.external.providerId,
           providerType: input.external.providerType,
           externalModel: input.external.modelId,
+          ...(Number.isFinite(input.external.maxOutputTokens) &&
+          input.external.maxOutputTokens > 0
+            ? { maxOutputTokens: Math.floor(input.external.maxOutputTokens) }
+            : {}),
         }
       : {}),
   };

--- a/studio/frontend/src/features/chat/research-inference-request.ts
+++ b/studio/frontend/src/features/chat/research-inference-request.ts
@@ -64,11 +64,10 @@ export function buildResearchInferenceRequest(input: {
           input.external.maxOutputTokens > 0
             ? {
                 maxOutputTokens: Math.floor(input.external.maxOutputTokens),
-                // The run outlives the connection edit that grounded it, so the backend is
-                // told whether clearing the saved cap leaves this number standing on nothing.
+                // The run outlives the connection edit that grounded it.
                 maxOutputTokensFromSavedCap: input.external.maxOutputTokensFromSavedCap,
-                // The ceiling above already has the override folded in, so it cannot say
-                // whether the model itself stops there. The report floor turns on that.
+                // The ceiling above has the override folded in, so it cannot say whether the
+                // model itself stops there, which is what the report floor turns on.
                 ...(input.external.maxOutputTokensPublished != null &&
                 Number.isFinite(input.external.maxOutputTokensPublished) &&
                 input.external.maxOutputTokensPublished > 0

--- a/studio/frontend/src/features/chat/research-inference-request.ts
+++ b/studio/frontend/src/features/chat/research-inference-request.ts
@@ -20,6 +20,7 @@ export interface ResearchInferenceRequest {
   topP?: number;
   maxTokens?: number;
   maxOutputTokens?: number;
+  maxOutputTokensFromSavedCap?: boolean;
   enableThinking?: boolean;
   reasoningEffort?: string;
 }
@@ -32,6 +33,8 @@ export function buildResearchInferenceRequest(input: {
     modelId: string;
     /** The connection's resolved output ceiling, or null when nothing grounds one. */
     maxOutputTokens: number | null;
+    /** True when the connection's saved cap is the only thing grounding that ceiling. */
+    maxOutputTokensFromSavedCap: boolean;
   };
   temperature: number;
   topP: number;
@@ -56,7 +59,12 @@ export function buildResearchInferenceRequest(input: {
           ...(input.external.maxOutputTokens != null &&
           Number.isFinite(input.external.maxOutputTokens) &&
           input.external.maxOutputTokens > 0
-            ? { maxOutputTokens: Math.floor(input.external.maxOutputTokens) }
+            ? {
+                maxOutputTokens: Math.floor(input.external.maxOutputTokens),
+                // The run outlives the connection edit that grounded it, so the backend is
+                // told whether clearing the saved cap leaves this number standing on nothing.
+                maxOutputTokensFromSavedCap: input.external.maxOutputTokensFromSavedCap,
+              }
             : {}),
         }
       : {}),

--- a/studio/frontend/src/features/chat/research-inference-request.ts
+++ b/studio/frontend/src/features/chat/research-inference-request.ts
@@ -21,6 +21,7 @@ export interface ResearchInferenceRequest {
   maxTokens?: number;
   maxOutputTokens?: number;
   maxOutputTokensFromSavedCap?: boolean;
+  maxOutputTokensPublished?: number;
   enableThinking?: boolean;
   reasoningEffort?: string;
 }
@@ -35,6 +36,8 @@ export function buildResearchInferenceRequest(input: {
     maxOutputTokens: number | null;
     /** True when the connection's saved cap is the only thing grounding that ceiling. */
     maxOutputTokensFromSavedCap: boolean;
+    /** The model's own published limit, before the connection override is folded in. */
+    maxOutputTokensPublished: number | null;
   };
   temperature: number;
   topP: number;
@@ -64,6 +67,17 @@ export function buildResearchInferenceRequest(input: {
                 // The run outlives the connection edit that grounded it, so the backend is
                 // told whether clearing the saved cap leaves this number standing on nothing.
                 maxOutputTokensFromSavedCap: input.external.maxOutputTokensFromSavedCap,
+                // The ceiling above already has the override folded in, so it cannot say
+                // whether the model itself stops there. The report floor turns on that.
+                ...(input.external.maxOutputTokensPublished != null &&
+                Number.isFinite(input.external.maxOutputTokensPublished) &&
+                input.external.maxOutputTokensPublished > 0
+                  ? {
+                      maxOutputTokensPublished: Math.floor(
+                        input.external.maxOutputTokensPublished,
+                      ),
+                    }
+                  : {}),
               }
             : {}),
         }

--- a/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
+++ b/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
@@ -26,6 +26,7 @@ const {
   EXTERNAL_MAX_OUTPUT_TOKENS,
   getExternalMaxOutputTokens,
   getExternalMinOutputTokens,
+  getGroundedExternalMaxOutputTokens,
   resolveExternalMaxTokensClamp,
 } = await import("../src/features/chat/provider-capabilities.ts");
 
@@ -258,5 +259,28 @@ test("every clamp site waits for a resolved provider", () => {
   assert.match(
     store,
     /if \(provider\) \{\s*const cap = getExternalMaxOutputTokens\(\s*provider\.providerType/,
+  );
+});
+
+
+test("a grounded ceiling is only sent when something documents or overrides it", () => {
+  // Nothing documents a self-hosted model, and the generic 32768 fallback is a guess: a
+  // 32k-context server has to fit the prompt in the same window, so asking for it fails.
+  assert.equal(getExternalMaxOutputTokens("custom", "some-self-hosted-model", null), 32768);
+  assert.equal(
+    getGroundedExternalMaxOutputTokens("custom", "some-self-hosted-model", null),
+    null,
+  );
+
+  // The user's own connection override grounds it.
+  assert.equal(
+    getGroundedExternalMaxOutputTokens("custom", "some-self-hosted-model", 20000),
+    20000,
+  );
+
+  // So does a published per-model cap.
+  assert.equal(
+    getGroundedExternalMaxOutputTokens("gemini", "gemini-3.6-flash", null),
+    getExternalMaxOutputTokens("gemini", "gemini-3.6-flash", null),
   );
 });

--- a/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
+++ b/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
@@ -26,6 +26,7 @@ const {
   EXTERNAL_MAX_OUTPUT_TOKENS,
   getExternalMaxOutputTokens,
   getExternalMinOutputTokens,
+  externalMaxOutputTokensNeedsConnectionCap,
   getGroundedExternalMaxOutputTokens,
   resolveExternalMaxTokensClamp,
 } = await import("../src/features/chat/provider-capabilities.ts");
@@ -303,4 +304,21 @@ test("an openrouter model is not grounded by the direct provider's published cap
     getGroundedExternalMaxOutputTokens("openrouter", "deepseek/deepseek-r1-0528", 32000),
     32000,
   );
+});
+
+test("the grounding of a ceiling is reported alongside it", () => {
+  // Nothing documents a self-hosted id, so only the connection's own cap can ground it, and
+  // a durable run has to be told that: clearing the cap leaves the number standing on nothing.
+  assert.equal(
+    externalMaxOutputTokensNeedsConnectionCap("custom", "some-self-hosted-model"),
+    true,
+  );
+  // A router id resolves through the direct provider's table, which does not describe the
+  // endpoint, so it counts as undocumented here too.
+  assert.equal(
+    externalMaxOutputTokensNeedsConnectionCap("openrouter", "deepseek/deepseek-r1-0528"),
+    true,
+  );
+  // A published cap keeps standing on its own after the override goes.
+  assert.equal(externalMaxOutputTokensNeedsConnectionCap("gemini", "gemini-3.6-flash"), false);
 });

--- a/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
+++ b/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
@@ -266,21 +266,18 @@ test("every clamp site waits for a resolved provider", () => {
 
 
 test("a grounded ceiling is only sent when something documents or overrides it", () => {
-  // Nothing documents a self-hosted model, and the generic 32768 fallback is a guess: a
-  // 32k-context server has to fit the prompt in the same window, so asking for it fails.
+  // The generic 32768 fallback is a guess: a 32k-context server holds the prompt too.
   assert.equal(getExternalMaxOutputTokens("custom", "some-self-hosted-model", null), 32768);
   assert.equal(
     getGroundedExternalMaxOutputTokens("custom", "some-self-hosted-model", null),
     null,
   );
 
-  // The user's own connection override grounds it.
   assert.equal(
     getGroundedExternalMaxOutputTokens("custom", "some-self-hosted-model", 20000),
     20000,
   );
 
-  // So does a published per-model cap.
   assert.equal(
     getGroundedExternalMaxOutputTokens("gemini", "gemini-3.6-flash", null),
     getExternalMaxOutputTokens("gemini", "gemini-3.6-flash", null),
@@ -288,9 +285,7 @@ test("a grounded ceiling is only sent when something documents or overrides it",
 });
 
 test("an openrouter model is not grounded by the direct provider's published cap", () => {
-  // The id resolves through the direct provider's table, and a router endpoint is not that
-  // provider: OpenRouter serves deepseek at a fraction of the direct API's ceiling. Fine as
-  // a slider maximum, wrong as a budget sent unattended.
+  // The id resolves through the DIRECT provider's table; the router serves it far below.
   assert.equal(
     getExternalMaxOutputTokens("openrouter", "deepseek/deepseek-r1-0528", null),
     384000,
@@ -300,7 +295,6 @@ test("an openrouter model is not grounded by the direct provider's published cap
     null,
   );
 
-  // The user's own override still grounds a router connection.
   assert.equal(
     getGroundedExternalMaxOutputTokens("openrouter", "deepseek/deepseek-r1-0528", 32000),
     32000,
@@ -308,25 +302,20 @@ test("an openrouter model is not grounded by the direct provider's published cap
 });
 
 test("the grounding of a ceiling is reported alongside it", () => {
-  // Nothing documents a self-hosted id, so only the connection's own cap can ground it, and
-  // a durable run has to be told that: clearing the cap leaves the number standing on nothing.
   assert.equal(
     externalMaxOutputTokensNeedsConnectionCap("custom", "some-self-hosted-model"),
     true,
   );
-  // A router id resolves through the direct provider's table, which does not describe the
-  // endpoint, so it counts as undocumented here too.
+  // A router id resolves through a table that does not describe the endpoint.
   assert.equal(
     externalMaxOutputTokensNeedsConnectionCap("openrouter", "deepseek/deepseek-r1-0528"),
     true,
   );
-  // A published cap keeps standing on its own after the override goes.
   assert.equal(externalMaxOutputTokensNeedsConnectionCap("gemini", "gemini-3.6-flash"), false);
 });
 
 test("the published ceiling is reported without the override folded in", () => {
-  // The number the report floor turns on: a 65536 model on a connection capped at 8192 must
-  // stay distinguishable from a model that genuinely stops at 8192.
+  // A 65536 model capped at 8192 must stay distinguishable from one that stops at 8192.
   assert.equal(getPublishedExternalMaxOutputTokens("gemini", "gemini-3.6-flash"), 65536);
   assert.equal(
     getExternalMaxOutputTokens("gemini", "gemini-3.6-flash", 8192),

--- a/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
+++ b/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
@@ -28,6 +28,7 @@ const {
   getExternalMinOutputTokens,
   externalMaxOutputTokensNeedsConnectionCap,
   getGroundedExternalMaxOutputTokens,
+  getPublishedExternalMaxOutputTokens,
   resolveExternalMaxTokensClamp,
 } = await import("../src/features/chat/provider-capabilities.ts");
 
@@ -321,4 +322,19 @@ test("the grounding of a ceiling is reported alongside it", () => {
   );
   // A published cap keeps standing on its own after the override goes.
   assert.equal(externalMaxOutputTokensNeedsConnectionCap("gemini", "gemini-3.6-flash"), false);
+});
+
+test("the published ceiling is reported without the override folded in", () => {
+  // The number the report floor turns on: a 65536 model on a connection capped at 8192 must
+  // stay distinguishable from a model that genuinely stops at 8192.
+  assert.equal(getPublishedExternalMaxOutputTokens("gemini", "gemini-3.6-flash"), 65536);
+  assert.equal(
+    getExternalMaxOutputTokens("gemini", "gemini-3.6-flash", 8192),
+    8192,
+  );
+  assert.equal(getPublishedExternalMaxOutputTokens("custom", "some-self-hosted-model"), null);
+  assert.equal(
+    getPublishedExternalMaxOutputTokens("openrouter", "deepseek/deepseek-r1-0528"),
+    null,
+  );
 });

--- a/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
+++ b/studio/frontend/tests/provider-max-output-tokens-guards.test.ts
@@ -284,3 +284,23 @@ test("a grounded ceiling is only sent when something documents or overrides it",
     getExternalMaxOutputTokens("gemini", "gemini-3.6-flash", null),
   );
 });
+
+test("an openrouter model is not grounded by the direct provider's published cap", () => {
+  // The id resolves through the direct provider's table, and a router endpoint is not that
+  // provider: OpenRouter serves deepseek at a fraction of the direct API's ceiling. Fine as
+  // a slider maximum, wrong as a budget sent unattended.
+  assert.equal(
+    getExternalMaxOutputTokens("openrouter", "deepseek/deepseek-r1-0528", null),
+    384000,
+  );
+  assert.equal(
+    getGroundedExternalMaxOutputTokens("openrouter", "deepseek/deepseek-r1-0528", null),
+    null,
+  );
+
+  // The user's own override still grounds a router connection.
+  assert.equal(
+    getGroundedExternalMaxOutputTokens("openrouter", "deepseek/deepseek-r1-0528", 32000),
+    32000,
+  );
+});

--- a/studio/frontend/tests/research-inference-request.test.ts
+++ b/studio/frontend/tests/research-inference-request.test.ts
@@ -17,6 +17,7 @@ test("Codex research keeps provider routing and clamps generation settings", () 
         providerId: "provider",
         providerType: "openai_codex",
         modelId: "gpt-5.6-sol",
+        maxOutputTokens: 128000,
       },
       temperature: 0.2,
       topP: 0.9,
@@ -32,6 +33,7 @@ test("Codex research keeps provider routing and clamps generation settings", () 
       providerId: "provider",
       providerType: "openai_codex",
       externalModel: "gpt-5.6-sol",
+      maxOutputTokens: 128000,
       temperature: 0.2,
       topP: 0.9,
       maxTokens: 8192,
@@ -55,4 +57,27 @@ test("invalid optional settings do not leak into a local research request", () =
     }),
     { model: "local/model.gguf", enableThinking: false },
   );
+});
+
+test("the report ceiling the connection resolved reaches the run config", () => {
+  const request = buildResearchInferenceRequest({
+    checkpoint: "external::provider::gemini-3.6-flash",
+    external: {
+      providerId: "provider",
+      providerType: "gemini",
+      modelId: "gemini-3.6-flash",
+      maxOutputTokens: 65536,
+    },
+    temperature: 0.2,
+    topP: 0.9,
+    maxTokens: 4096,
+    reasoningRequested: false,
+    reasoningStyle: "none",
+    reasoningEffort: "low",
+    reasoningEffortLevels: ["low", "medium", "high"],
+    clampReasoningEffort: clamp,
+  });
+
+  assert.equal(request.maxOutputTokens, 65536);
+  assert.equal(request.maxTokens, 4096);
 });

--- a/studio/frontend/tests/research-inference-request.test.ts
+++ b/studio/frontend/tests/research-inference-request.test.ts
@@ -81,3 +81,36 @@ test("the report ceiling the connection resolved reaches the run config", () => 
   assert.equal(request.maxOutputTokens, 65536);
   assert.equal(request.maxTokens, 4096);
 });
+
+test("an undocumented model with no connection override sends no ceiling", () => {
+  const request = buildResearchInferenceRequest({
+    checkpoint: "local-model",
+    external: {
+      providerId: "provider",
+      providerType: "custom",
+      modelId: "some-self-hosted-model",
+      // What getGroundedExternalMaxOutputTokens returns when nothing documents the model.
+      maxOutputTokens: null,
+    },
+    temperature: 0.2,
+    topP: 0.9,
+    maxTokens: 4096,
+  });
+  assert.equal("maxOutputTokens" in request, false);
+});
+
+test("an explicit connection override is still sent", () => {
+  const request = buildResearchInferenceRequest({
+    checkpoint: "local-model",
+    external: {
+      providerId: "provider",
+      providerType: "custom",
+      modelId: "some-self-hosted-model",
+      maxOutputTokens: 20000,
+    },
+    temperature: 0.2,
+    topP: 0.9,
+    maxTokens: 4096,
+  });
+  assert.equal(request.maxOutputTokens, 20000);
+});

--- a/studio/frontend/tests/research-inference-request.test.ts
+++ b/studio/frontend/tests/research-inference-request.test.ts
@@ -95,6 +95,11 @@ test("an undocumented model with no connection override sends no ceiling", () =>
     temperature: 0.2,
     topP: 0.9,
     maxTokens: 4096,
+    reasoningRequested: false,
+    reasoningStyle: "none",
+    reasoningEffort: "low",
+    reasoningEffortLevels: ["low", "medium", "high"],
+    clampReasoningEffort: clamp,
   });
   assert.equal("maxOutputTokens" in request, false);
 });
@@ -111,6 +116,11 @@ test("an explicit connection override is still sent", () => {
     temperature: 0.2,
     topP: 0.9,
     maxTokens: 4096,
+    reasoningRequested: false,
+    reasoningStyle: "none",
+    reasoningEffort: "low",
+    reasoningEffortLevels: ["low", "medium", "high"],
+    clampReasoningEffort: clamp,
   });
   assert.equal(request.maxOutputTokens, 20000);
 });

--- a/studio/frontend/tests/research-inference-request.test.ts
+++ b/studio/frontend/tests/research-inference-request.test.ts
@@ -18,7 +18,8 @@ test("Codex research keeps provider routing and clamps generation settings", () 
         providerType: "openai_codex",
         modelId: "gpt-5.6-sol",
         maxOutputTokens: 128000,
-      maxOutputTokensFromSavedCap: false,
+        maxOutputTokensFromSavedCap: false,
+        maxOutputTokensPublished: null,
       },
       temperature: 0.2,
       topP: 0.9,
@@ -70,6 +71,7 @@ test("the report ceiling the connection resolved reaches the run config", () => 
       modelId: "gemini-3.6-flash",
       maxOutputTokens: 65536,
       maxOutputTokensFromSavedCap: false,
+      maxOutputTokensPublished: null,
     },
     temperature: 0.2,
     topP: 0.9,
@@ -95,6 +97,7 @@ test("an undocumented model with no connection override sends no ceiling", () =>
       // What getGroundedExternalMaxOutputTokens returns when nothing documents the model.
       maxOutputTokens: null,
       maxOutputTokensFromSavedCap: false,
+      maxOutputTokensPublished: null,
     },
     temperature: 0.2,
     topP: 0.9,
@@ -117,6 +120,7 @@ test("an explicit connection override is still sent", () => {
       modelId: "some-self-hosted-model",
       maxOutputTokens: 20000,
       maxOutputTokensFromSavedCap: false,
+      maxOutputTokensPublished: null,
     },
     temperature: 0.2,
     topP: 0.9,
@@ -140,6 +144,7 @@ test("the request says whether the saved cap is what grounded its ceiling", () =
         modelId: "some-self-hosted-model",
         maxOutputTokens,
         maxOutputTokensFromSavedCap,
+        maxOutputTokensPublished: null,
       },
       temperature: 0.2,
       topP: 0.9,
@@ -155,4 +160,32 @@ test("the request says whether the saved cap is what grounded its ceiling", () =
   assert.equal(build(false, 30000).maxOutputTokensFromSavedCap, false);
   // No ceiling to qualify, so the flag has nothing to say and is left off entirely.
   assert.equal("maxOutputTokensFromSavedCap" in build(true, null), false);
+});
+
+test("the published ceiling rides along, unfolded, when the model has one", () => {
+  const request = buildResearchInferenceRequest({
+    checkpoint: "external::p1::gemini-3.6-flash",
+    external: {
+      providerId: "p1",
+      providerType: "gemini",
+      modelId: "gemini-3.6-flash",
+      // What the connection actually spends: the override folded into the published cap.
+      maxOutputTokens: 8192,
+      maxOutputTokensFromSavedCap: false,
+      maxOutputTokensPublished: 65536,
+    },
+    temperature: 0.2,
+    topP: 0.9,
+    maxTokens: 4096,
+    reasoningRequested: false,
+    reasoningStyle: "none",
+    reasoningEffort: "low",
+    reasoningEffortLevels: ["low", "medium", "high"],
+    clampReasoningEffort: clamp,
+  });
+
+  // Both numbers survive: the backend needs the pair to tell a capped connection from a
+  // model that genuinely stops at 8192.
+  assert.equal(request.maxOutputTokens, 8192);
+  assert.equal(request.maxOutputTokensPublished, 65536);
 });

--- a/studio/frontend/tests/research-inference-request.test.ts
+++ b/studio/frontend/tests/research-inference-request.test.ts
@@ -184,8 +184,7 @@ test("the published ceiling rides along, unfolded, when the model has one", () =
     clampReasoningEffort: clamp,
   });
 
-  // Both numbers survive: the backend needs the pair to tell a capped connection from a
-  // model that genuinely stops at 8192.
+  // The backend needs the pair to tell a capped connection from a 8192-token model.
   assert.equal(request.maxOutputTokens, 8192);
   assert.equal(request.maxOutputTokensPublished, 65536);
 });

--- a/studio/frontend/tests/research-inference-request.test.ts
+++ b/studio/frontend/tests/research-inference-request.test.ts
@@ -18,6 +18,7 @@ test("Codex research keeps provider routing and clamps generation settings", () 
         providerType: "openai_codex",
         modelId: "gpt-5.6-sol",
         maxOutputTokens: 128000,
+      maxOutputTokensFromSavedCap: false,
       },
       temperature: 0.2,
       topP: 0.9,
@@ -34,6 +35,7 @@ test("Codex research keeps provider routing and clamps generation settings", () 
       providerType: "openai_codex",
       externalModel: "gpt-5.6-sol",
       maxOutputTokens: 128000,
+      maxOutputTokensFromSavedCap: false,
       temperature: 0.2,
       topP: 0.9,
       maxTokens: 8192,
@@ -67,6 +69,7 @@ test("the report ceiling the connection resolved reaches the run config", () => 
       providerType: "gemini",
       modelId: "gemini-3.6-flash",
       maxOutputTokens: 65536,
+      maxOutputTokensFromSavedCap: false,
     },
     temperature: 0.2,
     topP: 0.9,
@@ -91,6 +94,7 @@ test("an undocumented model with no connection override sends no ceiling", () =>
       modelId: "some-self-hosted-model",
       // What getGroundedExternalMaxOutputTokens returns when nothing documents the model.
       maxOutputTokens: null,
+      maxOutputTokensFromSavedCap: false,
     },
     temperature: 0.2,
     topP: 0.9,
@@ -112,6 +116,7 @@ test("an explicit connection override is still sent", () => {
       providerType: "custom",
       modelId: "some-self-hosted-model",
       maxOutputTokens: 20000,
+      maxOutputTokensFromSavedCap: false,
     },
     temperature: 0.2,
     topP: 0.9,
@@ -123,4 +128,31 @@ test("an explicit connection override is still sent", () => {
     clampReasoningEffort: clamp,
   });
   assert.equal(request.maxOutputTokens, 20000);
+});
+
+test("the request says whether the saved cap is what grounded its ceiling", () => {
+  const build = (maxOutputTokensFromSavedCap: boolean, maxOutputTokens: number | null) =>
+    buildResearchInferenceRequest({
+      checkpoint: "external::p1::some-self-hosted-model",
+      external: {
+        providerId: "p1",
+        providerType: "custom",
+        modelId: "some-self-hosted-model",
+        maxOutputTokens,
+        maxOutputTokensFromSavedCap,
+      },
+      temperature: 0.2,
+      topP: 0.9,
+      maxTokens: 4096,
+      reasoningRequested: false,
+      reasoningStyle: "none",
+      reasoningEffort: "medium",
+      reasoningEffortLevels: ["low", "medium", "high"],
+      clampReasoningEffort: clamp,
+    });
+
+  assert.equal(build(true, 30000).maxOutputTokensFromSavedCap, true);
+  assert.equal(build(false, 30000).maxOutputTokensFromSavedCap, false);
+  // No ceiling to qualify, so the flag has nothing to say and is left off entirely.
+  assert.equal("maxOutputTokensFromSavedCap" in build(true, null), false);
 });


### PR DESCRIPTION
Deep Research always asks for at most 16384 tokens when it writes the report. That number is fixed in the code. If you run it on a saved connection whose model can write far more, the report still stops at 16384 and you get an "Incomplete report" note above it. Nothing in the app lets you raise it. The Max Tokens setting in chat does not apply to this step either.

The report now uses the limit of the connection it runs on. The app already works out that limit for normal chat, so the number is one the provider is known to accept. Older runs fall back to the Max Output Tokens saved on the connection. Runs on a local model keep the old 16384.

The limit is never raised on a guess. Some providers reject a request that asks for more than the model allows instead of trimming it, and that would fail the whole run.

Tested with two separate installs against a stand in connection that stops at whatever limit it is given. Before, the report cut off in the middle of a code block with the "Incomplete report" note. After, it finished. The request went from 16384 to 32768.

Fixes #10245
