### PR TITLE
Studio: stop sleeping in the API-key expiry cache test

### DIFF
--- a/studio/backend/tests/test_api_key_expiry.py
+++ b/studio/backend/tests/test_api_key_expiry.py
@@ -164,15 +164,24 @@ def test_cache_does_not_bypass_revocation():
     assert storage.validate_api_key(raw) is None  # cache hit still re-checks is_active
 
 
-def test_cache_does_not_bypass_expiry():
+def test_cache_does_not_bypass_expiry(monkeypatch):
     seed_user()
-    # Expires between the two calls: the first warms the cache, the second is still rejected.
-    near = (datetime.now(timezone.utc) + timedelta(milliseconds = 600)).isoformat()
-    raw = make_key(near)
-    assert storage.validate_api_key(raw) == storage.DEFAULT_ADMIN_USERNAME
-    import time
+    # Wall-clock sleep made this flake under parallel CI: a 600 ms TTL could
+    # already have elapsed before the first assertion (#10147). Drive the
+    # storage clock instead so the cache still re-checks expires_at.
+    t0 = datetime(2026, 9, 3, 12, 0, 0, tzinfo = timezone.utc)
+    raw = make_key((t0 + timedelta(hours = 1)).isoformat())
 
-    time.sleep(0.8)
+    class Clock(datetime):
+        current = t0
+
+        @classmethod
+        def now(cls, tz = None):
+            return cls.current if tz is None else cls.current.astimezone(tz)
+
+    monkeypatch.setattr(storage, "datetime", Clock)
+    assert storage.validate_api_key(raw) == storage.DEFAULT_ADMIN_USERNAME
+    Clock.current = t0 + timedelta(hours = 2)
     assert storage.validate_api_key(raw) is None
 
 


### PR DESCRIPTION
## Summary

Part of #10147 (the flaky-test follow-up from #10076).

`tests/test_api_key_expiry.py::test_cache_does_not_bypass_expiry` minted a key that expired in 600 ms, asserted it was still valid, then slept 0.8 s. Under parallel CI that window can already have elapsed before the first assertion, which is the flake recorded on the issue.

This drives `storage.datetime.now` instead of wall-clock sleep. The hash cache is still warmed on the first call and the second call still re-checks `expires_at`.

## Changes

- Replace the 600 ms TTL + `time.sleep` with a frozen clock around the two `validate_api_key` calls

## Test plan

- [x] `python -m pytest tests/test_api_key_expiry.py -q --tb=short` (15 passed)