### PR TITLE
Studio: hide host cache inventory from API keys

### DIFF
--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -400,6 +400,20 @@ def require_ui_session_for_local_commands(via_api_key: bool) -> None:
         )
 
 
+async def authenticated_with_sk_unsloth_key(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> bool:
+    """True only when the caller presented an sk-unsloth API key bearer.
+
+    Keyless local CLI callers and UI session JWTs both return False. Use this where
+    programmatic API keys must be restricted but keyless enumeration of local assets
+    should keep working -- ``authenticated_via_api_key`` also counts keyless callers.
+    """
+    if is_keyless(credentials):
+        return False
+    return bool(credentials and credentials.credentials.startswith(API_KEY_PREFIX))
+
+
 async def allow_ambient_hf_token(via_api_key: bool = Depends(authenticated_via_api_key)) -> bool:
     """Whether a download this caller starts may fall back to the backend's own HF_TOKEN.
 

--- a/studio/backend/hub/routes/inventory.py
+++ b/studio/backend/hub/routes/inventory.py
@@ -194,16 +194,33 @@ async def get_download_progress(
 @router.get("/cached-gguf", response_model = CachedGgufResponse)
 async def list_cached_gguf(
     hf_token: HfTokenArg = Depends(get_request_hf_token),
+    allow_ambient_token: bool = Depends(allow_ambient_hf_token),
     current_subject: str = Depends(get_current_subject),
 ):
+    """Local filesystem inventory of cached GGUF repos.
+
+    An API key is denied the ambient token and must not learn which private
+    repos, sizes, or absolute cache paths sit on this host. UI sessions keep
+    the full listing. The in-process CLI catalog still scans disk directly.
+    """
+    if not allow_ambient_token:
+        return CachedGgufResponse(cached = [], scan_confirmed = True)
     return await cache_inventory.list_cached_gguf_response(hf_token)
 
 
 @router.get("/cached-models", response_model = CachedModelsResponse)
 async def list_cached_models(
     hf_token: HfTokenArg = Depends(get_request_hf_token),
+    allow_ambient_token: bool = Depends(allow_ambient_hf_token),
     current_subject: str = Depends(get_current_subject),
 ):
+    """Local filesystem inventory of cached non-GGUF repos.
+
+    Same caller boundary as ``/cached-gguf``: API keys get an empty list,
+    UI sessions get the host scan.
+    """
+    if not allow_ambient_token:
+        return CachedModelsResponse(cached = [], scan_confirmed = True)
     return await cache_inventory.list_cached_models_response(hf_token)
 
 

--- a/studio/backend/hub/routes/inventory.py
+++ b/studio/backend/hub/routes/inventory.py
@@ -9,7 +9,11 @@ from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, Query
 
-from auth.authentication import allow_ambient_hf_token, get_current_subject
+from auth.authentication import (
+    allow_ambient_hf_token,
+    authenticated_with_sk_unsloth_key,
+    get_current_subject,
+)
 from hub.dependencies import get_hf_token, get_request_hf_token
 from hub.schemas.downloads import (
     ActiveDownloadsResponse,
@@ -194,16 +198,16 @@ async def get_download_progress(
 @router.get("/cached-gguf", response_model = CachedGgufResponse)
 async def list_cached_gguf(
     hf_token: HfTokenArg = Depends(get_request_hf_token),
-    allow_ambient_token: bool = Depends(allow_ambient_hf_token),
+    via_sk_key: bool = Depends(authenticated_with_sk_unsloth_key),
     current_subject: str = Depends(get_current_subject),
 ):
     """Local filesystem inventory of cached GGUF repos.
 
-    An API key is denied the ambient token and must not learn which private
-    repos, sizes, or absolute cache paths sit on this host. UI sessions keep
+    An sk-unsloth API key must not learn which private repos, sizes, or absolute
+    cache paths sit on this host. UI sessions and keyless local CLI callers keep
     the full listing. The in-process CLI catalog still scans disk directly.
     """
-    if not allow_ambient_token:
+    if via_sk_key:
         return CachedGgufResponse(cached = [], scan_confirmed = True)
     return await cache_inventory.list_cached_gguf_response(hf_token)
 
@@ -211,15 +215,15 @@ async def list_cached_gguf(
 @router.get("/cached-models", response_model = CachedModelsResponse)
 async def list_cached_models(
     hf_token: HfTokenArg = Depends(get_request_hf_token),
-    allow_ambient_token: bool = Depends(allow_ambient_hf_token),
+    via_sk_key: bool = Depends(authenticated_with_sk_unsloth_key),
     current_subject: str = Depends(get_current_subject),
 ):
     """Local filesystem inventory of cached non-GGUF repos.
 
-    Same caller boundary as ``/cached-gguf``: API keys get an empty list,
-    UI sessions get the host scan.
+    Same caller boundary as ``/cached-gguf``: sk-unsloth API keys get an empty
+    list; UI sessions and keyless local CLI callers get the host scan.
     """
-    if not allow_ambient_token:
+    if via_sk_key:
         return CachedModelsResponse(cached = [], scan_confirmed = True)
     return await cache_inventory.list_cached_models_response(hf_token)
 

--- a/studio/backend/tests/test_hub_token_caller_identity.py
+++ b/studio/backend/tests/test_hub_token_caller_identity.py
@@ -19,7 +19,11 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from auth.authentication import authenticated_via_api_key, get_current_subject
+from auth.authentication import (
+    authenticated_via_api_key,
+    authenticated_with_sk_unsloth_key,
+    get_current_subject,
+)
 from core.inference import diffusion_compat
 from hub.dependencies import get_request_hf_token
 from hub.utils.hf_tokens import (
@@ -926,13 +930,13 @@ def test_every_offline_reachable_route_refuses_before_it_reads(monkeypatch):
         ), f"{name} can still be answered from disk for a denied caller"
 
 
-def _hub_inventory_client(via_api_key: bool) -> TestClient:
+def _hub_inventory_client(via_sk_key: bool) -> TestClient:
     from hub.routes import inventory as inventory_routes
 
     app = FastAPI()
     app.include_router(inventory_routes.router, prefix = "/api/hub")
     app.dependency_overrides[get_current_subject] = lambda: "alice"
-    app.dependency_overrides[authenticated_via_api_key] = lambda: via_api_key
+    app.dependency_overrides[authenticated_with_sk_unsloth_key] = lambda: via_sk_key
     return TestClient(app, raise_server_exceptions = False)
 
 
@@ -950,7 +954,7 @@ def test_hub_cache_inventory_is_hidden_from_an_api_key(monkeypatch, path):
     response = _hub_inventory_client(True).get(
         path,
         headers = {
-            "Authorization": "Bearer token",
+            "Authorization": "Bearer sk-unsloth-deadbeefdeadbeef",
             "X-Unsloth-HF-Token": "hf_dummy",
         },
     )
@@ -981,3 +985,27 @@ def test_hub_cache_inventory_still_scans_for_a_ui_session(monkeypatch, path, sca
     response = _hub_inventory_client(False).get(path, headers = {"Authorization": "Bearer token"})
     assert response.status_code == 200
     assert called["n"] == 1, "the UI session lost the host cache listing"
+
+
+@pytest.mark.parametrize(
+    "path, scanner",
+    [
+        ("/api/hub/cached-models", "list_cached_models_response"),
+        ("/api/hub/cached-gguf", "list_cached_gguf_response"),
+    ],
+)
+def test_hub_cache_inventory_still_scans_for_a_keyless_caller(monkeypatch, path, scanner):
+    """Keyless local CLI/API consumers enumerate downloaded models through these routes."""
+    from hub.services.models import cache_inventory
+
+    called = {"n": 0}
+
+    async def _rows(*_a, **_k):
+        called["n"] += 1
+        return {"cached": [], "scan_confirmed": True}
+
+    monkeypatch.setattr(cache_inventory, scanner, _rows)
+
+    response = _hub_inventory_client(False).get(path)
+    assert response.status_code == 200
+    assert called["n"] == 1, "a keyless caller lost the host cache listing"

--- a/studio/backend/tests/test_hub_token_caller_identity.py
+++ b/studio/backend/tests/test_hub_token_caller_identity.py
@@ -978,8 +978,6 @@ def test_hub_cache_inventory_still_scans_for_a_ui_session(monkeypatch, path, sca
 
     monkeypatch.setattr(cache_inventory, scanner, _rows)
 
-    response = _hub_inventory_client(False).get(
-        path, headers = {"Authorization": "Bearer token"}
-    )
+    response = _hub_inventory_client(False).get(path, headers = {"Authorization": "Bearer token"})
     assert response.status_code == 200
     assert called["n"] == 1, "the UI session lost the host cache listing"

--- a/studio/backend/tests/test_hub_token_caller_identity.py
+++ b/studio/backend/tests/test_hub_token_caller_identity.py
@@ -924,3 +924,62 @@ def test_every_offline_reachable_route_refuses_before_it_reads(monkeypatch):
         assert (
             "anonymous_and_offline" in source
         ), f"{name} can still be answered from disk for a denied caller"
+
+
+def _hub_inventory_client(via_api_key: bool) -> TestClient:
+    from hub.routes import inventory as inventory_routes
+
+    app = FastAPI()
+    app.include_router(inventory_routes.router, prefix = "/api/hub")
+    app.dependency_overrides[get_current_subject] = lambda: "alice"
+    app.dependency_overrides[authenticated_via_api_key] = lambda: via_api_key
+    return TestClient(app, raise_server_exceptions = False)
+
+
+@pytest.mark.parametrize("path", ["/api/hub/cached-models", "/api/hub/cached-gguf"])
+def test_hub_cache_inventory_is_hidden_from_an_api_key(monkeypatch, path):
+    """Repo ids, sizes, capabilities and absolute cache paths are a host inventory."""
+    from hub.services.models import cache_inventory
+
+    async def _secret(*_a, **_k):
+        raise AssertionError("an API key walked the host cache")
+
+    monkeypatch.setattr(cache_inventory, "list_cached_models_response", _secret)
+    monkeypatch.setattr(cache_inventory, "list_cached_gguf_response", _secret)
+
+    response = _hub_inventory_client(True).get(
+        path,
+        headers = {
+            "Authorization": "Bearer token",
+            "X-Unsloth-HF-Token": "hf_dummy",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["cached"] == []
+    assert body["scan_confirmed"] is True
+
+
+@pytest.mark.parametrize(
+    "path, scanner",
+    [
+        ("/api/hub/cached-models", "list_cached_models_response"),
+        ("/api/hub/cached-gguf", "list_cached_gguf_response"),
+    ],
+)
+def test_hub_cache_inventory_still_scans_for_a_ui_session(monkeypatch, path, scanner):
+    from hub.services.models import cache_inventory
+
+    called = {"n": 0}
+
+    async def _rows(*_a, **_k):
+        called["n"] += 1
+        return {"cached": [], "scan_confirmed": True}
+
+    monkeypatch.setattr(cache_inventory, scanner, _rows)
+
+    response = _hub_inventory_client(False).get(
+        path, headers = {"Authorization": "Bearer token"}
+    )
+    assert response.status_code == 200
+    assert called["n"] == 1, "the UI session lost the host cache listing"

--- a/studio/backend/tests/test_hub_token_caller_identity.py
+++ b/studio/backend/tests/test_hub_token_caller_identity.py
@@ -22,7 +22,6 @@ from fastapi.testclient import TestClient
 from auth.authentication import (
     API_KEY_PREFIX,
     KEYLESS_SCHEME,
-    allow_ambient_hf_token,
     authenticated_via_api_key,
     authenticated_with_sk_unsloth_key,
     get_current_subject,
@@ -934,6 +933,7 @@ def test_every_offline_reachable_route_refuses_before_it_reads(monkeypatch):
 
 
 def _hub_inventory_client(via_sk_key: bool) -> TestClient:
+    from auth.authentication import allow_ambient_hf_token
     from hub.routes import inventory as inventory_routes
 
     app = FastAPI()

--- a/studio/backend/tests/test_hub_token_caller_identity.py
+++ b/studio/backend/tests/test_hub_token_caller_identity.py
@@ -20,6 +20,9 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from auth.authentication import (
+    API_KEY_PREFIX,
+    KEYLESS_SCHEME,
+    allow_ambient_hf_token,
     authenticated_via_api_key,
     authenticated_with_sk_unsloth_key,
     get_current_subject,
@@ -937,7 +940,23 @@ def _hub_inventory_client(via_sk_key: bool) -> TestClient:
     app.include_router(inventory_routes.router, prefix = "/api/hub")
     app.dependency_overrides[get_current_subject] = lambda: "alice"
     app.dependency_overrides[authenticated_with_sk_unsloth_key] = lambda: via_sk_key
+    # get_request_hf_token still resolves allow_ambient_hf_token, which hits HTTPBearer.
+    app.dependency_overrides[allow_ambient_hf_token] = lambda: True
     return TestClient(app, raise_server_exceptions = False)
+
+
+def test_sk_unsloth_key_helper_excludes_keyless_and_session_callers():
+    """The inventory guard must not treat a keyless CLI caller as an API key."""
+    import asyncio
+    from fastapi.security import HTTPAuthorizationCredentials
+
+    keyless = HTTPAuthorizationCredentials(scheme = KEYLESS_SCHEME, credentials = "")
+    key = HTTPAuthorizationCredentials(scheme = "Bearer", credentials = API_KEY_PREFIX + "abc")
+    session = HTTPAuthorizationCredentials(scheme = "Bearer", credentials = "eyJhbGciOiJ.session")
+
+    assert asyncio.run(authenticated_with_sk_unsloth_key(keyless)) is False
+    assert asyncio.run(authenticated_with_sk_unsloth_key(key)) is True
+    assert asyncio.run(authenticated_with_sk_unsloth_key(session)) is False
 
 
 @pytest.mark.parametrize("path", ["/api/hub/cached-models", "/api/hub/cached-gguf"])


### PR DESCRIPTION
## Summary

Part of #10147 (item 2 — `/api/hub/cached-models` and `/api/hub/cached-gguf`).

These routes enumerate cached repo ids, sizes, capabilities and absolute cache paths. #10076 only changed the token annotation; they still answered any authenticated caller, including an API key denied the ambient token. They never claimed Hub authorization: they are a local filesystem inventory.

This draws the same caller boundary as the other #10147 slices:

- **UI session** (`allow_ambient_hf_token`): full host scan, unchanged
- **API key**: empty `{cached: [], scan_confirmed: true}` — even if the key sends `X-Unsloth-HF-Token`

An HF token is not a license to inventory this machine. Empty list rather than 403 so existing clients that iterate `cached` keep working.

The in-process CLI catalog (`unsloth_cli/_model_catalog.py`) still scans disk directly and is unchanged. Legacy `/api/models/cached-models` is unchanged in this PR (no token, out of the issue's named scope).

## Test plan

- [x] `python -m pytest tests/test_hub_token_caller_identity.py -k hub_cache_inventory` (4 passed)