### PR TITLE
Studio: match the update banner tests on classes, not on file substrings

### DIFF
--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -109,6 +109,47 @@ def _class_const(source: str, name: str) -> str:
     return match.group(1)
 
 
+def _skip_literal(source: str, at: int) -> int:
+    """The index just past the string or template literal opening at `at`."""
+    quote = source[at]
+    index = at + 1
+    while index < len(source):
+        if source[index] == "\\":
+            index += 2
+            continue
+        if source[index] == quote:
+            return index + 1
+        index += 1
+    raise AssertionError(f"unterminated {quote} literal")
+
+
+def _opening_tag(source: str, at: int) -> tuple[int, int]:
+    """The bounds of the JSX opening tag containing the attribute at `at`.
+
+    Both ends, scanned with the brackets and string literals tracked, so the
+    `>` of an inline arrow (`onClick={() => ...}`) does not end the tag early.
+    Attributes are then searched over the whole tag rather than the part before
+    some other attribute, which is an order dependency of exactly the kind this
+    file is being fixed for.
+    """
+    start = source.rindex("<", 0, at)
+    depth = 0
+    index = start
+    while index < len(source):
+        char = source[index]
+        if char in "\"'`":
+            index = _skip_literal(source, index)
+            continue
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == ">" and depth == 0 and index > start:
+            return start, index
+        index += 1
+    raise AssertionError("unterminated JSX opening tag")
+
+
 def _class_on_testid(source: str, testid: str) -> str:
     """The literal class string of the element carrying `data-testid=testid`.
 
@@ -117,11 +158,11 @@ def _class_on_testid(source: str, testid: str) -> str:
     inserted or reordered, which is the failure this file is being fixed for,
     and it fails by raising rather than by reporting a missing rule.
     """
-    at = source.index(f'data-testid="{testid}"')
-    opening = source[source.rindex("<", 0, at) : at]
+    start, end = _opening_tag(source, source.index(f'data-testid="{testid}"'))
+    tag = source[start:end]
     key = 'className="'
-    assert key in opening, f"{testid} carries no literal class string"
-    at_class = source.rindex("<", 0, at) + opening.index(key) + len(key)
+    assert key in tag, f"{testid} carries no literal class string"
+    at_class = start + tag.index(key) + len(key)
     return source[at_class : source.index('"', at_class)]
 
 
@@ -1427,29 +1468,58 @@ _COMMENT = re.compile(r"//[^\n]*")
 _BANNER_ROOT = re.compile(r'data-testid="(?:web|tauri)-update-banner"')
 
 
+def _unpositioned_branch(text: str) -> str:
+    """The `: ...` arm of `positioned ? ... : ...`.
+
+    The two arms are two different elements: `positioned` is the standalone
+    banner, and the rail-facing card is the alternative. Reading both at once
+    would let a rule move from the card to the standalone banner and still
+    satisfy a check about the card. Split at the colon at bracket depth zero
+    and outside any literal, so a Tailwind variant in the first arm
+    (`dark:bg-card`) is not mistaken for the separator.
+    """
+    index = text.index("?", text.index("positioned"))
+    depth = 0
+    while index < len(text):
+        char = text[index]
+        if char in "\"'`":
+            index = _skip_literal(text, index)
+            continue
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == ":" and depth == 0 and text[index - 1] != "?":
+            return text[index + 1 :]
+        index += 1
+    raise AssertionError("the positioned card has no unpositioned branch")
+
+
 def _card_slot(source: str) -> str:
     """The rail-facing root of an update card, comments stripped.
 
     Not one string literal: the root is a `cn()` of several, so an assertion
     anchored on the first of them cannot see the floor at all. Anchored on the
-    `data-testid` that names the card and the `cn(` before it, so no class has
-    to keep its place for the root to be found. Comments go because both files
-    name the very classes under test in prose beside them, and a rule that a
-    comment can satisfy is not being tested.
+    `data-testid` that names the card, so no class has to keep its place for
+    the root to be found, and narrowed to the branch the overlay rail actually
+    renders. Comments go because both files name the very classes under test in
+    prose beside them, and a rule that a comment can satisfy is not tested.
     """
     match = _BANNER_ROOT.search(source)
     assert match, "the update card has lost its data-testid"
-    return _COMMENT.sub(
-        "", source[source.rindex("className={cn(", 0, match.start()) : match.start()]
-    )
+    start, _ = _opening_tag(source, match.start())
+    key = "className={cn("
+    at = source.index(key, start)
+    return _unpositioned_branch(_COMMENT.sub("", source[at : match.start()]))
 
 
 def _card_surface(source: str) -> str:
     """The painted surface: the first element inside the card's root."""
     match = _BANNER_ROOT.search(source)
     assert match, "the update card has lost its data-testid"
+    _, end = _opening_tag(source, match.start())
     key = 'className="'
-    at = source.index(key, match.end()) + len(key)
+    at = source.index(key, end) + len(key)
     return source[at : source.index('"', at)]
 
 
@@ -1515,6 +1585,22 @@ def test_the_class_matchers_tell_a_gated_rule_from_an_ungated_one():
     assert _applies("md:shrink-0", "shrink-0"), "the absence check must see a gated rule"
     assert _unconditional("md:shrink-0", "shrink-0") is False
     assert _unconditional("flex shrink-0 flex-col", "shrink-0")
+
+
+def test_the_class_anchors_do_not_depend_on_any_order():
+    """An anchor that needs an attribute or a branch to keep its place is the
+    same brittleness one level up, so both are read structurally."""
+    # An arrow function's `>` does not end the opening tag, and the attribute
+    # is found on either side of the one that names the element.
+    for tag in (
+        '<ul className="a b" data-testid="x" onClick={() => go()}>',
+        '<ul onClick={() => go()} data-testid="x" className="a b">',
+    ):
+        assert _class_on_testid(tag, "x") == "a b", tag
+    # The two arms of the ternary are two different elements. A variant in the
+    # first arm does not read as the separator, and only the second is returned.
+    branch = _unpositioned_branch('positioned ? "fixed dark:bg-card" : cn("rail shrink-0")')
+    assert "rail" in branch and "fixed" not in branch
 
 
 def test_the_overlay_stack_fits_the_viewport():

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -39,6 +39,9 @@ WEB_BANNER = FRONTEND / "components/web/update-banner.tsx"
 TAURI_BANNER = FRONTEND / "components/tauri/update-banner.tsx"
 
 
+_IMPORTANT = re.compile(r"^!|!$")
+
+
 def _split_variants(token: str) -> tuple[tuple[str, ...], str]:
     """A Tailwind class token as (variants, utility), split on top-level colons.
 
@@ -59,7 +62,11 @@ def _split_variants(token: str) -> tuple[tuple[str, ...], str]:
         else:
             current.append(char)
     parts.append("".join(current))
-    return tuple(parts[:-1]), parts[-1]
+    # `!min-h-0` and `min-h-0!` are `min-h-0`, at a weight that beats the floor.
+    # Left as written, an important rule would slip past a prohibition on the
+    # plain one while overriding it. The frontend already writes them, in
+    # `app/routes/__root.tsx` among others.
+    return tuple(parts[:-1]), _IMPORTANT.sub("", parts[-1])
 
 
 def _tokens(source: str) -> list[tuple[tuple[str, ...], str]]:
@@ -80,7 +87,7 @@ def _applies(source: str, utility: str, *variants: str) -> bool:
 
     Name no variants and this asks whether the utility is there under any gate
     or none, which is what a check for a rule's *absence* wants. A check that a
-    rule is in force needs `_unconditional`.
+    rule is in force needs `_only_under`.
     """
     for token_variants, token_utility in _tokens(source):
         if token_utility == utility and set(variants) <= set(token_variants):
@@ -88,18 +95,30 @@ def _applies(source: str, utility: str, *variants: str) -> bool:
     return False
 
 
-def _unconditional(source: str, utility: str) -> bool:
-    """Is `utility` written with no variant at all?
+def _only_under(source: str, utility: str, *variants: str) -> bool:
+    """Is `utility` written at least once, and every time under exactly these?
 
-    Not `_applies` with an empty variant list: that is a subset test, and the
-    empty set is a subset of every token's variants, so `max-[383px]:shrink-0`
-    would have answered a question about an ungated `shrink-0` and the card
-    would have been squeezable at every width but one.
+    What a positive layout guarantee needs, and neither half of it is a subset
+    test. An extra gate narrows when the rule is in force, so a floor written
+    `md:has-[...]:min-h-[...]` leaves every width from 384px to the `md`
+    breakpoint with none, the narrow override having stopped at 383px. A
+    second, ungated copy widens it the other way, back to the reserved empty
+    height the gate was added to stop. Both leave the utility present, so both
+    pass an existence check.
+
+    Named with no variants, this is "written, and never gated": an ungated
+    `shrink-0` is the whole guarantee when there are no notes, and
+    `max-[383px]:shrink-0` would satisfy an existence check while leaving the
+    card squeezable at every width but one.
     """
-    return any(
-        token_utility == utility and not token_variants
-        for token_variants, token_utility in _tokens(source)
-    )
+    found = False
+    for token_variants, token_utility in _tokens(source):
+        if token_utility != utility:
+            continue
+        if set(token_variants) != set(variants):
+            return False
+        found = True
+    return found
 
 
 def _class_const(source: str, name: str) -> str:
@@ -123,19 +142,20 @@ def _skip_literal(source: str, at: int) -> int:
     raise AssertionError(f"unterminated {quote} literal")
 
 
-def _opening_tag(source: str, at: int) -> tuple[int, int]:
-    """The bounds of the JSX opening tag containing the attribute at `at`.
+def _tag_end(source: str, start: int, at: int) -> int | None:
+    """The end of the tag opening at `start`, if `at` is one of its attributes.
 
-    Both ends, scanned with the brackets and string literals tracked, so the
-    `>` of an inline arrow (`onClick={() => ...}`) does not end the tag early.
-    Attributes are then searched over the whole tag rather than the part before
-    some other attribute, which is an order dependency of exactly the kind this
-    file is being fixed for.
+    `None` when it is not, which is how a `<` that opens no tag is rejected.
+    Brackets and string literals are tracked, so the `>` of an inline arrow
+    (`onClick={() => go()}`) does not end the tag early and a comparison inside
+    an attribute expression (`disabled={count < limit}`) runs out of depth.
     """
-    start = source.rindex("<", 0, at)
     depth = 0
-    index = start
+    index = start + 1
+    reached = False
     while index < len(source):
+        if index == at:
+            reached = depth == 0
         char = source[index]
         if char in "\"'`":
             index = _skip_literal(source, index)
@@ -144,10 +164,36 @@ def _opening_tag(source: str, at: int) -> tuple[int, int]:
             depth += 1
         elif char in ")]}":
             depth -= 1
-        elif char == ">" and depth == 0 and index > start:
-            return start, index
+            if depth < 0:
+                return None
+        elif char == ">" and depth == 0:
+            return index if reached else None
         index += 1
-    raise AssertionError("unterminated JSX opening tag")
+    return None
+
+
+def _opening_tag(source: str, at: int) -> tuple[int, int]:
+    """The bounds of the JSX opening tag whose attributes include index `at`.
+
+    Not simply the nearest `<` before it: an attribute expression may hold one
+    of its own, as `disabled={count < limit}` does, and starting the scan there
+    runs into an unmatched brace. Candidates are tried from the nearest
+    outwards and one is accepted only if the tag it opens actually reaches `at`
+    with the tag still open and at depth zero.
+
+    Both ends are returned so that attributes can be searched over the whole
+    tag rather than the part before some other attribute, which is an order
+    dependency of exactly the kind this file is being fixed for.
+    """
+    start = at
+    while True:
+        try:
+            start = source.rindex("<", 0, start)
+        except ValueError:
+            raise AssertionError("no JSX opening tag encloses this attribute") from None
+        end = _tag_end(source, start, at)
+        if end is not None:
+            return start, end
 
 
 def _class_on_testid(source: str, testid: str) -> str:
@@ -1507,10 +1553,12 @@ def _card_slot(source: str) -> str:
     """
     match = _BANNER_ROOT.search(source)
     assert match, "the update card has lost its data-testid"
-    start, _ = _opening_tag(source, match.start())
+    start, end = _opening_tag(source, match.start())
     key = "className={cn("
-    at = source.index(key, start)
-    return _unpositioned_branch(_COMMENT.sub("", source[at : match.start()]))
+    tag = source[start:end]
+    assert key in tag, "the card's root no longer builds its classes with cn()"
+    at = start + tag.index(key)
+    return _unpositioned_branch(_COMMENT.sub("", source[at:end]))
 
 
 def _card_surface(source: str) -> str:
@@ -1528,17 +1576,18 @@ def _assert_floored(source: str, scaled: str, narrow: str, card: str) -> None:
     # Read off the rail-facing root, so a floor written on some inner box, or
     # on the standalone `positioned` banner, does not answer for this one.
     root = _card_slot(source)
-    assert _applies(
+    # `_only_under` and not an existence check, in all four: a floor that gains
+    # a gate stops applying over part of its range, and one that gains an
+    # ungated twin reserves the empty height the gate was added to stop.
+    assert _only_under(
         root, scaled, _NOTES_GATE
-    ), f"the {card} card's floor is fixed or ungated, so it is wrong at other type sizes"
-    assert _applies(
+    ), f"the {card} card's floor is fixed, ungated, or gated more than its notes"
+    assert _only_under(
         root, narrow, _NOTES_GATE, _NARROW
     ), f"the {card} card's floor misses the narrow card's extra button row"
     # With no notes rendered there is no floor, so this is what holds the row.
-    assert _unconditional(
-        root, "shrink-0"
-    ), f"the rail can squeeze the {card} card with no notes open"
-    assert _applies(
+    assert _only_under(root, "shrink-0"), f"the rail can squeeze the {card} card with no notes open"
+    assert _only_under(
         root, "shrink", _NOTES_GATE
     ), f"the {card} card cannot give up its notes' height, so the rail clips its buttons"
     assert not _applies(
@@ -1583,8 +1632,20 @@ def test_the_class_matchers_tell_a_gated_rule_from_an_ungated_one():
     assert _applies("min-h-0", "h-0") is False
     # And a gate cannot answer for a rule that has to hold everywhere.
     assert _applies("md:shrink-0", "shrink-0"), "the absence check must see a gated rule"
-    assert _unconditional("md:shrink-0", "shrink-0") is False
-    assert _unconditional("flex shrink-0 flex-col", "shrink-0")
+    assert _only_under("md:shrink-0", "shrink-0") is False
+    assert _only_under("flex shrink-0 flex-col", "shrink-0")
+    # A positive guarantee takes the gates it names and no others, in either
+    # direction: one more narrows where the rule holds, and an ungated twin
+    # widens it back over the state the gate exists to exclude.
+    assert _only_under("has-[x]:min-h-4", "min-h-4", "has-[x]")
+    assert _only_under("md:has-[x]:min-h-4", "min-h-4", "has-[x]") is False
+    assert _only_under("has-[x]:min-h-4 min-h-4", "min-h-4", "has-[x]") is False
+    assert _only_under("flex", "min-h-4", "has-[x]") is False, "absent is not satisfied"
+    # An important rule is the same rule, at a weight that beats the floor, so
+    # it cannot slip past a prohibition on the plain one.
+    for important in ("!min-h-0", "min-h-0!"):
+        assert _split_variants(important)[1] == "min-h-0"
+        assert _applies(important, "min-h-0"), f"{important} escapes the prohibition"
 
 
 def test_the_class_anchors_do_not_depend_on_any_order():
@@ -1592,9 +1653,12 @@ def test_the_class_anchors_do_not_depend_on_any_order():
     same brittleness one level up, so both are read structurally."""
     # An arrow function's `>` does not end the opening tag, and the attribute
     # is found on either side of the one that names the element.
+    # A comparison inside an attribute expression is not the element's start.
     for tag in (
         '<ul className="a b" data-testid="x" onClick={() => go()}>',
         '<ul onClick={() => go()} data-testid="x" className="a b">',
+        '<ul disabled={count < limit} className="a b" data-testid="x">',
+        '<ul disabled={count < limit} data-testid="x" className="a b">',
     ):
         assert _class_on_testid(tag, "x") == "a b", tag
     # The two arms of the ternary are two different elements. A variant in the

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -122,8 +122,16 @@ def _only_under(source: str, utility: str, *variants: str) -> bool:
 
 
 def _class_const(source: str, name: str) -> str:
-    """The class string of an exported `const NAME = "..."`."""
-    match = re.search(rf'\b{re.escape(name)}\b\s*=\s*\n?\s*"([^"]*)"', source)
+    """The class string of an exported `const NAME = "..."`.
+
+    Comments blanked and anchored on the `export`, like the banner extractors:
+    an old declaration left commented out above the live one would otherwise
+    answer for it, and a stale copy that still reads correctly is exactly how a
+    regression in the live one goes unnoticed.
+    """
+    match = re.search(
+        rf'export const {re.escape(name)}\s*=\s*\n?\s*"([^"]*)"', _without_comments(source)
+    )
     assert match, f"{name} is not an exported class constant"
     return match.group(1)
 
@@ -1702,6 +1710,10 @@ def _card_surface(source: str) -> str:
     assert match, "the update card has lost its data-testid"
     _, end = _opening_tag(clean, match.start())
     child = clean.index("<", end)
+    # A fragment emits no element, so it is not the surface and its `<` is not
+    # the surface's. Wrapping the card in one changes no rendered class.
+    while clean[child + 1] == ">":
+        child = clean.index("<", child + 2)
     start, child_end = _opening_tag(clean, child + 1)
     return _class_value(clean[start:child_end], "the painted surface")
 

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -128,6 +128,27 @@ def _class_const(source: str, name: str) -> str:
     return match.group(1)
 
 
+_COMMENT_SPAN = re.compile(r"//[^\n]*|/\*.*?\*/", re.DOTALL)
+
+
+def _without_comments(source: str) -> str:
+    """`source` with every comment blanked, each index left where it was.
+
+    Blanked rather than removed so that the offsets the scanners hand around
+    stay valid. Both forms, and before any scan, for two reasons. Prose is not
+    code: an apostrophe in `// notes don't shrink` would open a string literal
+    that never closes, and a `}` written in a block comment would unbalance the
+    tag. Prose is not classes either: the comment beside these very rules says
+    "shrink-0 keeps the compact card at its natural height", so in block form
+    it would satisfy the assertion that the class is there after the class
+    itself had been deleted.
+    """
+    return _COMMENT_SPAN.sub(
+        lambda match: "".join(char if char == "\n" else " " for char in match.group()),
+        source,
+    )
+
+
 def _skip_literal(source: str, at: int) -> int:
     """The index just past the string or template literal opening at `at`."""
     quote = source[at]
@@ -204,12 +225,43 @@ def _class_on_testid(source: str, testid: str) -> str:
     inserted or reordered, which is the failure this file is being fixed for,
     and it fails by raising rather than by reporting a missing rule.
     """
-    start, end = _opening_tag(source, source.index(f'data-testid="{testid}"'))
-    tag = source[start:end]
-    key = 'className="'
-    assert key in tag, f"{testid} carries no literal class string"
-    at_class = start + tag.index(key) + len(key)
-    return source[at_class : source.index('"', at_class)]
+    clean = _without_comments(source)
+    start, end = _opening_tag(clean, clean.index(f'data-testid="{testid}"'))
+    return _class_value(clean[start:end], testid)
+
+
+def _class_value(tag: str, what: str) -> str:
+    """Every class named by the `className` of `tag`, joined.
+
+    A literal today. Wrapping one in the `cn()` this file already uses renders
+    the same DOM, so it has to read the same rather than being skipped, which
+    would have taken the next element's classes instead and reported every rule
+    on this one as missing.
+    """
+    key = "className="
+    assert key in tag, f"{what} carries no className"
+    at = tag.index(key) + len(key)
+    if tag[at] == '"':
+        return tag[at + 1 : _skip_literal(tag, at) - 1]
+    assert tag[at] == "{", f"{what}'s className is neither a literal nor an expression"
+    parts: list[str] = []
+    depth = 0
+    index = at
+    while index < len(tag):
+        char = tag[index]
+        if char in "\"'`":
+            end = _skip_literal(tag, index)
+            parts.append(tag[index + 1 : end - 1])
+            index = end
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        index += 1
+    return " ".join(parts)
 
 
 def _assert_classes(class_string: str, *rules: str) -> None:
@@ -1508,9 +1560,6 @@ _NARROW = "max-[383px]"
 _NOTES_GATE = "has-[[data-slot=update-release-notes]]"
 
 
-_COMMENT = re.compile(r"//[^\n]*")
-
-
 _BANNER_ROOT = re.compile(r'data-testid="(?:web|tauri)-update-banner"')
 
 
@@ -1551,24 +1600,30 @@ def _card_slot(source: str) -> str:
     renders. Comments go because both files name the very classes under test in
     prose beside them, and a rule that a comment can satisfy is not tested.
     """
-    match = _BANNER_ROOT.search(source)
+    clean = _without_comments(source)
+    match = _BANNER_ROOT.search(clean)
     assert match, "the update card has lost its data-testid"
-    start, end = _opening_tag(source, match.start())
+    start, end = _opening_tag(clean, match.start())
     key = "className={cn("
-    tag = source[start:end]
+    tag = clean[start:end]
     assert key in tag, "the card's root no longer builds its classes with cn()"
-    at = start + tag.index(key)
-    return _unpositioned_branch(_COMMENT.sub("", source[at:end]))
+    return _unpositioned_branch(clean[start + tag.index(key) : end])
 
 
 def _card_surface(source: str) -> str:
-    """The painted surface: the first element inside the card's root."""
-    match = _BANNER_ROOT.search(source)
+    """The painted surface: the class string of the card's first child.
+
+    Bounded to that child rather than taken as the next literal `className` in
+    the file, which is the dismiss button's the moment the surface writes its
+    own classes through `cn()` instead.
+    """
+    clean = _without_comments(source)
+    match = _BANNER_ROOT.search(clean)
     assert match, "the update card has lost its data-testid"
-    _, end = _opening_tag(source, match.start())
-    key = 'className="'
-    at = source.index(key, end) + len(key)
-    return source[at : source.index('"', at)]
+    _, end = _opening_tag(clean, match.start())
+    child = clean.index("<", end)
+    start, child_end = _opening_tag(clean, child + 1)
+    return _class_value(clean[start:child_end], "the painted surface")
 
 
 def _assert_floored(source: str, scaled: str, narrow: str, card: str) -> None:
@@ -1665,6 +1720,17 @@ def test_the_class_anchors_do_not_depend_on_any_order():
     # first arm does not read as the separator, and only the second is returned.
     branch = _unpositioned_branch('positioned ? "fixed dark:bg-card" : cn("rail shrink-0")')
     assert "rail" in branch and "fixed" not in branch
+    # A class expression renders the same DOM as a literal and must read the same.
+    assert _class_value('<div className={cn("a b", open && "c")}>', "x").split() == ["a", "b", "c"]
+    assert _class_value('<div className="a b">', "x") == "a b"
+    # Comments are neither code nor classes. Prose can hold an apostrophe or an
+    # unmatched brace, and the banners' own comment names `shrink-0`.
+    for comment in ("// notes don't shrink", "/* an unmatched } is prose */"):
+        tag = f'<ul {comment}\n className="a b" data-testid="x">'
+        assert _class_on_testid(tag, "x") == "a b", comment
+    blanked = _without_comments("/* shrink-0 */ flex")
+    assert blanked.split() == ["flex"], "a class named in prose still reads as a class"
+    assert len(blanked) == len("/* shrink-0 */ flex"), "blanking a comment moved every later index"
 
 
 def test_the_overlay_stack_fits_the_viewport():

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -62,8 +62,13 @@ def _split_variants(token: str) -> tuple[tuple[str, ...], str]:
     return tuple(parts[:-1]), parts[-1]
 
 
+def _tokens(source: str) -> list[tuple[tuple[str, ...], str]]:
+    """Every class token in `source`, as (variants, utility)."""
+    return [_split_variants(token) for token in re.findall(r"""[^\s"'`]+""", source)]
+
+
 def _applies(source: str, utility: str, *variants: str) -> bool:
-    """Is `utility` written anywhere in `source` under all of `variants`?
+    """Is `utility` written anywhere in `source` under at least `variants`?
 
     Token-wise, not as a substring. These assertions used to name a run of
     classes verbatim, so gating a rule (`max-[383px]:has-[...]:min-h-[calc]`)
@@ -72,18 +77,52 @@ def _applies(source: str, utility: str, *variants: str) -> bool:
     A utility is the last top-level segment, so a longer utility that merely
     ends with this one does not count, and variant order is Tailwind's business
     rather than this test's.
+
+    Name no variants and this asks whether the utility is there under any gate
+    or none, which is what a check for a rule's *absence* wants. A check that a
+    rule is in force needs `_unconditional`.
     """
-    for token in re.findall(r"""[^\s"'`]+""", source):
-        token_variants, token_utility = _split_variants(token)
+    for token_variants, token_utility in _tokens(source):
         if token_utility == utility and set(variants) <= set(token_variants):
             return True
     return False
 
 
-def _class_string(source: str, anchor: str) -> str:
-    """The class string opened by `anchor`, up to its closing quote."""
-    at = source.index(anchor)
-    return source[at : source.index('"', at + len(anchor))]
+def _unconditional(source: str, utility: str) -> bool:
+    """Is `utility` written with no variant at all?
+
+    Not `_applies` with an empty variant list: that is a subset test, and the
+    empty set is a subset of every token's variants, so `max-[383px]:shrink-0`
+    would have answered a question about an ungated `shrink-0` and the card
+    would have been squeezable at every width but one.
+    """
+    return any(
+        token_utility == utility and not token_variants
+        for token_variants, token_utility in _tokens(source)
+    )
+
+
+def _class_const(source: str, name: str) -> str:
+    """The class string of an exported `const NAME = "..."`."""
+    match = re.search(rf'\b{re.escape(name)}\b\s*=\s*\n?\s*"([^"]*)"', source)
+    assert match, f"{name} is not an exported class constant"
+    return match.group(1)
+
+
+def _class_on_testid(source: str, testid: str) -> str:
+    """The literal class string of the element carrying `data-testid=testid`.
+
+    Anchored on the attribute that names the element rather than on a run of
+    its classes. An anchor built from classes cannot survive one of them being
+    inserted or reordered, which is the failure this file is being fixed for,
+    and it fails by raising rather than by reporting a missing rule.
+    """
+    at = source.index(f'data-testid="{testid}"')
+    opening = source[source.rindex("<", 0, at) : at]
+    key = 'className="'
+    assert key in opening, f"{testid} carries no literal class string"
+    at_class = source.rindex("<", 0, at) + opening.index(key) + len(key)
+    return source[at_class : source.index('"', at_class)]
 
 
 def _assert_classes(class_string: str, *rules: str) -> None:
@@ -1143,7 +1182,7 @@ def test_only_the_notes_region_scrolls(banner):
     # The painted surface: capped, clipping, and able to give up height itself
     # so that the region inside it is the one that scrolls.
     _assert_classes(
-        _class_string(src, "relative flex max-h-[calc(100dvh_-_2rem)] "),
+        _card_surface(src),
         "flex",
         "max-h-[calc(100dvh_-_2rem)]",
         "min-h-0",
@@ -1152,7 +1191,7 @@ def test_only_the_notes_region_scrolls(banner):
     )
     layout = NOTES_LAYOUT.read_text(encoding = "utf-8")
     _assert_classes(
-        _class_string(layout, "mt-3 flex min-h-0 "),
+        _class_const(layout, "UPDATE_NOTES_ROOT_CLASS"),
         "flex",
         "min-h-0",
         "flex-1",
@@ -1162,7 +1201,7 @@ def test_only_the_notes_region_scrolls(banner):
     panel = PANEL.read_text(encoding = "utf-8")
     assert "UPDATE_NOTES_EXPANDED_SCROLL_CLASS" in panel
     _assert_classes(
-        _class_string(layout, "hover-scrollbar max-h-64 "),
+        _class_const(layout, "UPDATE_NOTES_EXPANDED_SCROLL_CLASS"),
         "max-h-64",
         "min-h-0",
         "flex-1",
@@ -1171,7 +1210,7 @@ def test_only_the_notes_region_scrolls(banner):
     # The collapsed summary scrolls too: without it the bullets were painted
     # over the row of buttons once the card's slot for them got small.
     _assert_classes(
-        _class_string(panel, "hover-scrollbar min-h-0 flex-1 space-y-1"),
+        _class_on_testid(panel, "update-release-notes-summary"),
         "min-h-0",
         "flex-1",
         "space-y-1",
@@ -1385,16 +1424,33 @@ _NOTES_GATE = "has-[[data-slot=update-release-notes]]"
 _COMMENT = re.compile(r"//[^\n]*")
 
 
+_BANNER_ROOT = re.compile(r'data-testid="(?:web|tauri)-update-banner"')
+
+
 def _card_slot(source: str) -> str:
     """The rail-facing root of an update card, comments stripped.
 
     Not one string literal: the root is a `cn()` of several, so an assertion
-    anchored on the first of them cannot see the floor at all. Comments go
-    because they name the very classes under test in prose, and a rule that a
+    anchored on the first of them cannot see the floor at all. Anchored on the
+    `data-testid` that names the card and the `cn(` before it, so no class has
+    to keep its place for the root to be found. Comments go because both files
+    name the very classes under test in prose beside them, and a rule that a
     comment can satisfy is not being tested.
     """
-    at = source.index("pointer-events-auto flex ")
-    return _COMMENT.sub("", source[at : source.index("data-testid", at)])
+    match = _BANNER_ROOT.search(source)
+    assert match, "the update card has lost its data-testid"
+    return _COMMENT.sub(
+        "", source[source.rindex("className={cn(", 0, match.start()) : match.start()]
+    )
+
+
+def _card_surface(source: str) -> str:
+    """The painted surface: the first element inside the card's root."""
+    match = _BANNER_ROOT.search(source)
+    assert match, "the update card has lost its data-testid"
+    key = 'className="'
+    at = source.index(key, match.end()) + len(key)
+    return source[at : source.index('"', at)]
 
 
 def _assert_floored(source: str, scaled: str, narrow: str, card: str) -> None:
@@ -1409,7 +1465,9 @@ def _assert_floored(source: str, scaled: str, narrow: str, card: str) -> None:
         root, narrow, _NOTES_GATE, _NARROW
     ), f"the {card} card's floor misses the narrow card's extra button row"
     # With no notes rendered there is no floor, so this is what holds the row.
-    assert _applies(root, "shrink-0"), f"the rail can squeeze the {card} card with no notes open"
+    assert _unconditional(
+        root, "shrink-0"
+    ), f"the rail can squeeze the {card} card with no notes open"
     assert _applies(
         root, "shrink", _NOTES_GATE
     ), f"the {card} card cannot give up its notes' height, so the rail clips its buttons"
@@ -1434,6 +1492,29 @@ def _capped_rails(provider: str) -> int:
     them, so the gutter is not spent on the cards. See overlay-shadow-gutter.
     """
     return sum(1 for rail in _corner_rails(provider) if "max-h-[calc(100dvh_-_8px)]" in rail)
+
+
+def test_the_class_matchers_tell_a_gated_rule_from_an_ungated_one():
+    """The floor assertions are only as strong as these, so they are tested.
+
+    A matcher that quietly says yes is how this file went wrong the first time:
+    the checks read as layout guarantees and were substring searches.
+    """
+    gated = "max-[383px]:has-[[data-slot=update-release-notes]]:min-h-[calc(1px+2px)]"
+    assert _split_variants(gated) == (
+        ("max-[383px]", "has-[[data-slot=update-release-notes]]"),
+        "min-h-[calc(1px+2px)]",
+    ), "a bracketed variant's own colon splits the token"
+    # A variant that is asked for must be there, and the rest may be in any order.
+    assert _applies(gated, "min-h-[calc(1px+2px)]", "max-[383px]")
+    assert _applies(gated, "min-h-[calc(1px+2px)]", "max-[383px]", "has-[[data-slot=x]]") is False
+    assert _applies("min-h-[calc(1px+2px)]", "min-h-[calc(1px+2px)]", "max-[383px]") is False
+    # A utility is the whole last segment, not a suffix of one.
+    assert _applies("min-h-0", "h-0") is False
+    # And a gate cannot answer for a rule that has to hold everywhere.
+    assert _applies("md:shrink-0", "shrink-0"), "the absence check must see a gated rule"
+    assert _unconditional("md:shrink-0", "shrink-0") is False
+    assert _unconditional("flex shrink-0 flex-col", "shrink-0")
 
 
 def test_the_overlay_stack_fits_the_viewport():

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -143,10 +143,30 @@ def _without_comments(source: str) -> str:
     it would satisfy the assertion that the class is there after the class
     itself had been deleted.
     """
-    return _COMMENT_SPAN.sub(
-        lambda match: "".join(char if char == "\n" else " " for char in match.group()),
-        source,
-    )
+    out = list(source)
+    index = 0
+    while index < len(source):
+        char = source[index]
+        # A literal first: `bg-[url(https://example.com/a.svg)]` is a class, and
+        # blanking from its `//` would eat the rest of the line and its quote.
+        if char in "\"'`":
+            index = _skip_literal(source, index)
+            continue
+        if source.startswith("//", index):
+            end = source.find("\n", index)
+            end = len(source) if end == -1 else end
+        elif source.startswith("/*", index):
+            end = source.find("*/", index)
+            assert end != -1, "unterminated block comment"
+            end += 2
+        else:
+            index += 1
+            continue
+        for blank in range(index, end):
+            if out[blank] != "\n":
+                out[blank] = " "
+        index = end
+    return "".join(out)
 
 
 def _skip_literal(source: str, at: int) -> int:
@@ -244,24 +264,82 @@ def _class_value(tag: str, what: str) -> str:
     if tag[at] == '"':
         return tag[at + 1 : _skip_literal(tag, at) - 1]
     assert tag[at] == "{", f"{what}'s className is neither a literal nor an expression"
+    return _always_rendered(tag[at + 1 : _balanced(tag, at) - 1])
+
+
+def _arguments(call: str) -> list[str]:
+    """The arguments of a call, split on its top-level commas."""
+    at = call.index("(")
     parts: list[str] = []
+    current: list[str] = []
     depth = 0
     index = at
-    while index < len(tag):
-        char = tag[index]
+    while index < len(call):
+        char = call[index]
         if char in "\"'`":
-            end = _skip_literal(tag, index)
-            parts.append(tag[index + 1 : end - 1])
+            end = _skip_literal(call, index)
+            current.append(call[index:end])
             index = end
             continue
-        if char == "{":
+        if char in "([{":
             depth += 1
-        elif char == "}":
+            if depth == 1:
+                index += 1
+                continue
+        elif char in ")]}":
             depth -= 1
             if depth == 0:
                 break
+        elif char == "," and depth == 1:
+            parts.append("".join(current))
+            current = []
+            index += 1
+            continue
+        current.append(char)
         index += 1
-    return " ".join(parts)
+    parts.append("".join(current))
+    return parts
+
+
+def _always_rendered(expression: str) -> str:
+    """The classes `expression` renders in every state, joined.
+
+    Only an argument that is a bare literal. `cn(open && "x")` renders `x`
+    sometimes and a rule the card must always carry is not satisfied by
+    sometimes; written against a constant, `cn(false && "x")` renders it never,
+    while the text of the class sits there in the file either way. Reading the
+    literals out of the whole expression would call all three the same.
+    """
+    text = expression.strip()
+    if text[:1] in ('"', "'", "`") and _skip_literal(text, 0) == len(text):
+        return text[1:-1]
+    if "(" not in text:
+        return ""
+    literals = []
+    for argument in _arguments(text):
+        part = argument.strip()
+        if part[:1] in ('"', "'", "`") and _skip_literal(part, 0) == len(part):
+            literals.append(part[1:-1])
+    return " ".join(literals)
+
+
+def _balanced(source: str, at: int) -> int:
+    """The index just past the bracket group opening at `at`."""
+    depth = 0
+    index = at
+    while index < len(source):
+        char = source[index]
+        if char in "\"'`":
+            index = _skip_literal(source, index)
+            continue
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    raise AssertionError("unbalanced brackets")
 
 
 def _assert_classes(class_string: str, *rules: str) -> None:
@@ -1607,7 +1685,9 @@ def _card_slot(source: str) -> str:
     key = "className={cn("
     tag = clean[start:end]
     assert key in tag, "the card's root no longer builds its classes with cn()"
-    return _unpositioned_branch(clean[start + tag.index(key) : end])
+    # The classes it always renders, not the text of the branch: a floor put
+    # behind a constant is still written in the file while reaching no DOM.
+    return _always_rendered(_unpositioned_branch(clean[start + tag.index(key) : end]))
 
 
 def _card_surface(source: str) -> str:
@@ -1720,9 +1800,15 @@ def test_the_class_anchors_do_not_depend_on_any_order():
     # first arm does not read as the separator, and only the second is returned.
     branch = _unpositioned_branch('positioned ? "fixed dark:bg-card" : cn("rail shrink-0")')
     assert "rail" in branch and "fixed" not in branch
-    # A class expression renders the same DOM as a literal and must read the same.
-    assert _class_value('<div className={cn("a b", open && "c")}>', "x").split() == ["a", "b", "c"]
+    # A class expression renders the same DOM as a literal and must read the
+    # same, but only what it renders in every state. A rule the card must
+    # always carry is not satisfied by one that renders sometimes, and a
+    # constant guard renders it never while leaving the text in the file.
     assert _class_value('<div className="a b">', "x") == "a b"
+    assert _class_value('<div className={cn("a b")}>', "x") == "a b"
+    assert _class_value('<div className={cn("a b", open && "c")}>', "x").split() == ["a", "b"]
+    assert _class_value('<div className={cn(false && "a", "b")}>', "x").split() == ["b"]
+    assert _class_value('<div className={cn(open ? "a" : "z", "b")}>', "x").split() == ["b"]
     # Comments are neither code nor classes. Prose can hold an apostrophe or an
     # unmatched brace, and the banners' own comment names `shrink-0`.
     for comment in ("// notes don't shrink", "/* an unmatched } is prose */"):
@@ -1731,6 +1817,10 @@ def test_the_class_anchors_do_not_depend_on_any_order():
     blanked = _without_comments("/* shrink-0 */ flex")
     assert blanked.split() == ["flex"], "a class named in prose still reads as a class"
     assert len(blanked) == len("/* shrink-0 */ flex"), "blanking a comment moved every later index"
+    # A `//` inside a literal is a URL, not a comment, so the rest of the line
+    # and its closing quote survive.
+    url = '"bg-[url(https://example.com/a.svg)] flex" // gone'
+    assert _without_comments(url).rstrip() == '"bg-[url(https://example.com/a.svg)] flex"'
 
 
 def test_the_overlay_stack_fits_the_viewport():

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -39,6 +39,16 @@ WEB_BANNER = FRONTEND / "components/web/update-banner.tsx"
 TAURI_BANNER = FRONTEND / "components/tauri/update-banner.tsx"
 
 
+# An apostrophe in JSX text is prose, not the start of a string: "We're ready"
+# in a banner's copy would otherwise run a scanner to the next apostrophe or off
+# the end of the file, and a copy edit would fail these tests. The frontend is
+# formatted to double quotes, so nothing here is delimited with `'`.
+# A set of characters, not a string: `"" in '"`'` is true for a substring, and
+# a trailing comma leaves an empty argument to test.
+_QUOTES = frozenset('"`')
+
+_CALL = re.compile(r"[A-Za-z_$][\w$]*\(")
+
 _IMPORTANT = re.compile(r"^!|!$")
 
 
@@ -157,7 +167,7 @@ def _without_comments(source: str) -> str:
         char = source[index]
         # A literal first: `bg-[url(https://example.com/a.svg)]` is a class, and
         # blanking from its `//` would eat the rest of the line and its quote.
-        if char in "\"'`":
+        if char in _QUOTES:
             index = _skip_literal(source, index)
             continue
         if source.startswith("//", index):
@@ -206,7 +216,7 @@ def _tag_end(source: str, start: int, at: int) -> int | None:
         if index == at:
             reached = depth == 0
         char = source[index]
-        if char in "\"'`":
+        if char in _QUOTES:
             index = _skip_literal(source, index)
             continue
         if char in "([{":
@@ -284,7 +294,7 @@ def _arguments(call: str) -> list[str]:
     index = at
     while index < len(call):
         char = call[index]
-        if char in "\"'`":
+        if char in _QUOTES:
             end = _skip_literal(call, index)
             current.append(call[index:end])
             index = end
@@ -319,15 +329,19 @@ def _always_rendered(expression: str) -> str:
     literals out of the whole expression would call all three the same.
     """
     text = expression.strip()
-    if text[:1] in ('"', "'", "`") and _skip_literal(text, 0) == len(text):
+    if text[:1] in _QUOTES and _skip_literal(text, 0) == len(text):
         return text[1:-1]
     if "(" not in text:
         return ""
     literals = []
     for argument in _arguments(text):
         part = argument.strip()
-        if part[:1] in ('"', "'", "`") and _skip_literal(part, 0) == len(part):
+        if part[:1] in _QUOTES and _skip_literal(part, 0) == len(part):
             literals.append(part[1:-1])
+        elif _CALL.match(part) and _balanced(part, part.index("(")) == len(part):
+            # Grouping the arguments in a nested `cn()` renders the same
+            # classes, so it has to read the same rather than as none at all.
+            literals.append(_always_rendered(part))
     return " ".join(literals)
 
 
@@ -337,7 +351,7 @@ def _balanced(source: str, at: int) -> int:
     index = at
     while index < len(source):
         char = source[index]
-        if char in "\"'`":
+        if char in _QUOTES:
             index = _skip_literal(source, index)
             continue
         if char in "([{":
@@ -1658,20 +1672,30 @@ def _unpositioned_branch(text: str) -> str:
     satisfy a check about the card. Split at the colon at bracket depth zero
     and outside any literal, so a Tailwind variant in the first arm
     (`dark:bg-card`) is not mistaken for the separator.
+
+    Ternary nesting is counted, not just brackets. A ternary inside the first
+    arm has a colon of its own at the same bracket depth, and taking that one
+    returns the tail of the `positioned` arm as though it were the card, so
+    every floor could be asserted against the wrong element.
     """
-    index = text.index("?", text.index("positioned"))
+    index = text.index("?", text.index("positioned")) + 1
+    pending = 1
     depth = 0
     while index < len(text):
         char = text[index]
-        if char in "\"'`":
+        if char in _QUOTES:
             index = _skip_literal(text, index)
             continue
         if char in "([{":
             depth += 1
         elif char in ")]}":
             depth -= 1
+        elif char == "?" and depth == 0 and text[index + 1 : index + 2] not in (".", "?"):
+            pending += 1
         elif char == ":" and depth == 0 and text[index - 1] != "?":
-            return text[index + 1 :]
+            pending -= 1
+            if pending == 0:
+                return text[index + 1 :]
         index += 1
     raise AssertionError("the positioned card has no unpositioned branch")
 

--- a/tests/studio/test_update_release_notes.py
+++ b/tests/studio/test_update_release_notes.py
@@ -38,6 +38,61 @@ INLINE_COMMENTS = FRONTEND / "lib/markdown-inline-comments.ts"
 WEB_BANNER = FRONTEND / "components/web/update-banner.tsx"
 TAURI_BANNER = FRONTEND / "components/tauri/update-banner.tsx"
 
+
+def _split_variants(token: str) -> tuple[tuple[str, ...], str]:
+    """A Tailwind class token as (variants, utility), split on top-level colons.
+
+    Depth-aware, because an arbitrary value may carry its own brackets and its
+    own colon: `has-[[data-slot=update-release-notes]]:min-h-[calc(...)]`.
+    """
+    parts: list[str] = []
+    current: list[str] = []
+    depth = 0
+    for char in token:
+        if char in "[(":
+            depth += 1
+        elif char in "])":
+            depth -= 1
+        if char == ":" and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    parts.append("".join(current))
+    return tuple(parts[:-1]), parts[-1]
+
+
+def _applies(source: str, utility: str, *variants: str) -> bool:
+    """Is `utility` written anywhere in `source` under all of `variants`?
+
+    Token-wise, not as a substring. These assertions used to name a run of
+    classes verbatim, so gating a rule (`max-[383px]:has-[...]:min-h-[calc]`)
+    or inserting an unrelated one beside it read as the rule being gone, and
+    #10229 went red on four of them while every rule it named was still there.
+    A utility is the last top-level segment, so a longer utility that merely
+    ends with this one does not count, and variant order is Tailwind's business
+    rather than this test's.
+    """
+    for token in re.findall(r"""[^\s"'`]+""", source):
+        token_variants, token_utility = _split_variants(token)
+        if token_utility == utility and set(variants) <= set(token_variants):
+            return True
+    return False
+
+
+def _class_string(source: str, anchor: str) -> str:
+    """The class string opened by `anchor`, up to its closing quote."""
+    at = source.index(anchor)
+    return source[at : source.index('"', at + len(anchor))]
+
+
+def _assert_classes(class_string: str, *rules: str) -> None:
+    """Every one of `rules` is its own class in `class_string`."""
+    present = set(class_string.split())
+    missing = [rule for rule in rules if rule not in present]
+    assert not missing, f"{missing} missing from {class_string!r}"
+
+
 # The scanners are the frontend half of the contract the parser implements, so they are
 # run rather than read. Node strips the types and nothing imports a package: no install.
 _TS_ALIAS = re.compile(r'"@/lib/([a-z-]+)"')
@@ -1085,15 +1140,43 @@ def test_notes_repair_the_shared_previews_width_reset():
 def test_only_the_notes_region_scrolls(banner):
     """The dismiss control sits inside the card, so the card must not scroll."""
     src = banner.read_text(encoding = "utf-8")
-    assert "flex max-h-[calc(100dvh_-_2rem)] min-h-0 flex-col overflow-hidden" in src
+    # The painted surface: capped, clipping, and able to give up height itself
+    # so that the region inside it is the one that scrolls.
+    _assert_classes(
+        _class_string(src, "relative flex max-h-[calc(100dvh_-_2rem)] "),
+        "flex",
+        "max-h-[calc(100dvh_-_2rem)]",
+        "min-h-0",
+        "flex-col",
+        "overflow-hidden",
+    )
     layout = NOTES_LAYOUT.read_text(encoding = "utf-8")
-    assert "mt-3 flex min-h-0 flex-1 flex-col overflow-hidden" in layout
+    _assert_classes(
+        _class_string(layout, "mt-3 flex min-h-0 "),
+        "flex",
+        "min-h-0",
+        "flex-1",
+        "flex-col",
+        "overflow-hidden",
+    )
     panel = PANEL.read_text(encoding = "utf-8")
     assert "UPDATE_NOTES_EXPANDED_SCROLL_CLASS" in panel
-    assert "max-h-64 min-h-0 flex-1 overflow-y-auto" in layout
+    _assert_classes(
+        _class_string(layout, "hover-scrollbar max-h-64 "),
+        "max-h-64",
+        "min-h-0",
+        "flex-1",
+        "overflow-y-auto",
+    )
     # The collapsed summary scrolls too: without it the bullets were painted
     # over the row of buttons once the card's slot for them got small.
-    assert "min-h-0 flex-1 space-y-1 overflow-y-auto" in panel
+    _assert_classes(
+        _class_string(panel, "hover-scrollbar min-h-0 flex-1 space-y-1"),
+        "min-h-0",
+        "flex-1",
+        "space-y-1",
+        "overflow-y-auto",
+    )
 
 
 def test_a_comment_marker_in_prose_cannot_swallow_later_releases(notes_module):
@@ -1285,9 +1368,54 @@ def test_code_span_closers_ignore_backslashes():
 _SCALED_FLOOR_WEB = "min-h-[calc(109px+80px*var(--ui-font-scale,1))]"
 # Below 384px the action pair wraps onto its own row and the card needs a
 # whole extra one: 259px at the 20px setting where the wide card needs 209.
-_NARROW_FLOOR_WEB = "max-[383px]:min-h-[calc(139px+96px*var(--ui-font-scale,1))]"
+# Named as the utility alone and asserted under `max-[383px]` through
+# `_applies`, because the floor also carries a `has-[...]` gate since #10229
+# and a run of variants has no fixed order.
+_NARROW_FLOOR_WEB = "min-h-[calc(139px+96px*var(--ui-font-scale,1))]"
 _SCALED_FLOOR_TAURI = "min-h-[calc(117px+93px*var(--ui-font-scale,1))]"
-_NARROW_FLOOR_TAURI = "max-[383px]:min-h-[calc(24px+224px*var(--ui-font-scale,1))]"
+_NARROW_FLOOR_TAURI = "min-h-[calc(24px+224px*var(--ui-font-scale,1))]"
+_NARROW = "max-[383px]"
+# A floor only has to exist while there are notes to give up, and gating it is
+# what stopped the card reserving height it painted nothing into (#10229). So
+# the guarantee under test is a pair: floored while the notes panel is there,
+# and not squeezable at all while it is not.
+_NOTES_GATE = "has-[[data-slot=update-release-notes]]"
+
+
+_COMMENT = re.compile(r"//[^\n]*")
+
+
+def _card_slot(source: str) -> str:
+    """The rail-facing root of an update card, comments stripped.
+
+    Not one string literal: the root is a `cn()` of several, so an assertion
+    anchored on the first of them cannot see the floor at all. Comments go
+    because they name the very classes under test in prose, and a rule that a
+    comment can satisfy is not being tested.
+    """
+    at = source.index("pointer-events-auto flex ")
+    return _COMMENT.sub("", source[at : source.index("data-testid", at)])
+
+
+def _assert_floored(source: str, scaled: str, narrow: str, card: str) -> None:
+    """The card keeps room for its header and buttons, in both of its states."""
+    # Read off the rail-facing root, so a floor written on some inner box, or
+    # on the standalone `positioned` banner, does not answer for this one.
+    root = _card_slot(source)
+    assert _applies(
+        root, scaled, _NOTES_GATE
+    ), f"the {card} card's floor is fixed or ungated, so it is wrong at other type sizes"
+    assert _applies(
+        root, narrow, _NOTES_GATE, _NARROW
+    ), f"the {card} card's floor misses the narrow card's extra button row"
+    # With no notes rendered there is no floor, so this is what holds the row.
+    assert _applies(root, "shrink-0"), f"the rail can squeeze the {card} card with no notes open"
+    assert _applies(
+        root, "shrink", _NOTES_GATE
+    ), f"the {card} card cannot give up its notes' height, so the rail clips its buttons"
+    assert not _applies(
+        root, "min-h-0"
+    ), f"min-h-0 lets the rail squeeze the {card} card past its floor"
 
 
 def _corner_rails(provider: str) -> list[str]:
@@ -1329,8 +1457,7 @@ def test_the_overlay_stack_fits_the_viewport():
     # The update card cannot: its header and buttons are fixed and only its
     # notes yield, so it floors instead.
     web = WEB_BANNER.read_text(encoding = "utf-8")
-    assert _SCALED_FLOOR_WEB in web, "the floor is fixed, so it is wrong at other type sizes"
-    assert _NARROW_FLOOR_WEB in web, "the floor misses the narrow card's extra button row"
+    _assert_floored(web, _SCALED_FLOOR_WEB, _NARROW_FLOOR_WEB, "browser")
     # Those floors can add up to more than the cap at a large type size, so the
     # rail scrolls. Without this the overflow lands below the bottom of the
     # screen with no way to reach it.
@@ -1343,8 +1470,7 @@ def test_the_desktop_stack_is_capped_like_the_browser_one():
     assert len(_corner_rails(provider)) == 2, "both rails sit in the bottom-right corner"
     assert _capped_rails(provider) == 2, "both stacks are capped"
     tauri = TAURI_BANNER.read_text(encoding = "utf-8")
-    assert _SCALED_FLOOR_TAURI in tauri, "the floor is fixed, so it is wrong at other type sizes"
-    assert _NARROW_FLOOR_TAURI in tauri, "the floor misses the narrow card's extra button row"
+    _assert_floored(tauri, _SCALED_FLOOR_TAURI, _NARROW_FLOOR_TAURI, "desktop")
 
 
 def test_the_rail_offset_is_not_computed():


### PR DESCRIPTION
`Repo tests (CPU)` is red on `main` at `8e26d2c2b`, and on #10247, #10257, #10263, #10264 and #10265, which is every open PR that has run it since. Four failures out of 15,833:

```
FAILED tests/studio/test_update_release_notes.py::test_only_the_notes_region_scrolls[banner0]
FAILED tests/studio/test_update_release_notes.py::test_only_the_notes_region_scrolls[banner1]
  AssertionError: assert 'flex max-h-[calc(100dvh_-_2rem)] min-h-0 flex-col overflow-hidden' in '...'
FAILED tests/studio/test_update_release_notes.py::test_the_overlay_stack_fits_the_viewport
FAILED tests/studio/test_update_release_notes.py::test_the_desktop_stack_is_capped_like_the_browser_one
  AssertionError: the floor misses the narrow card's extra button row
```

## The banner fix is right and every rule these tests name is still there

#10229 is what turned them red. It did not touch this file, and no source change is needed here.

The first pair assert one verbatim run of classes on the card's painted surface. #10229 inserted `grow` into the middle of it, so short notes paint the whole floor instead of leaving a gap. The cap, `min-h-0`, `flex-col` and `overflow-hidden` are all still on that element, in that order, with one class added between two of them.

The other two assert the floor:

```python
_NARROW_FLOOR_WEB = "max-[383px]:min-h-[calc(139px+96px*var(--ui-font-scale,1))]"
```

The floor constants are unchanged, as #10229 said. What changed is that the floor is now gated on the notes panel actually being rendered, which is the fix:

```
max-[383px]:has-[[data-slot=update-release-notes]]:min-h-[calc(139px+96px*var(--ui-font-scale,1))]
```

A second variant between `max-[383px]:` and the utility, and the contiguous substring is gone. Only `_NARROW_FLOOR_WEB` and `_NARROW_FLOOR_TAURI` fail, because they are the only two that name a variant; the scaled pair still match as a suffix. That asymmetry is the tell that these are string assertions, not layout assertions.

So the tests are the wrong half. This is the same shape as the `mklink` kwargs case in #10231: a check written as one exact literal over something that is a set, which then reports every legitimate edit as a regression and takes a green `main` with it.

## The change

Match Tailwind tokens instead of file substrings.

`_applies(source, utility, *variants)` splits each class token on its top-level colons, depth-aware so an arbitrary value keeps its own brackets, and asks whether that utility appears under all of the required variants. Order between variants is Tailwind's business, so an added gate no longer reads as a missing rule, and a longer utility that merely ends with this one no longer counts as one. `_assert_classes` does the same for a plain run of classes.

The floor constants drop the `max-[383px]:` prefix and it is passed as a variant instead.

## The assertions are stronger, not just looser

The floor pair now read off the rail-facing root, taken from the anchor to `data-testid` so the whole `cn()` is in scope and with `//` comments stripped, since both files describe these classes in prose right beside them. On top of the two floors they now also require:

- `shrink-0` on the root, which is what holds the button row when there is no floor because there are no notes
- `has-[[data-slot=update-release-notes]]:shrink`, so the notes can still give up their height once there are some
- no `min-h-0` on the root, which would let the rail squeeze the card past its floor
- the floors to be gated, so a card cannot reserve height it paints nothing into

The last four are #10229's contract. It pins them in `studio/frontend/tests/update-banner-flex-priority.test.ts`; this file asserted only the floors, and would have passed a card that was squeezable to nothing in the state the report was about.

## Verified by breaking it, not by watching it pass

Eight mutations of the two banners, each run against the four tests:

| mutation | result |
| --- | --- |
| baseline | 4 passed |
| narrow floor loses its `max-[383px]` gate | 2 failed |
| scaled floor deleted | 1 failed |
| floor value drifts 139px to 140px | 1 failed |
| root `shrink-0` becomes `min-h-0` | 2 failed |
| notes can no longer give up height | 1 failed |
| floor ungated, reserving unpainted height | 2 failed |
| surface stops clipping | 1 failed |
| surface loses `min-h-0` | 1 failed |

The last three rows are the point. Rows 5 and 7 are regressions the previous version of these tests did not catch at all, and row 7 is the exact bug #10229 fixed.

`tests/studio/test_update_release_notes.py`: 187 passed. No source file changes, and no other test in the file changes behaviour.
