### PR TITLE
fix(frontend): render data-URI images in chat markdown

### DIFF
--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -26,6 +26,7 @@ import {
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { normalizeEscapedInlineMath } from "@/lib/escaped-inline-math";
 import { preprocessLaTeX } from "@/lib/latex";
+import { withDataImageSupport } from "@/lib/markdown-data-images";
 import { downloadFile, isDownloadCancelled } from "@/lib/native-files";
 import { openLink } from "@/lib/open-link";
 import { safeMarkdownUrl } from "@/lib/safe-markdown-url";
@@ -146,6 +147,10 @@ const STREAMDOWN_COMPONENTS = {
 const STREAMDOWN_ALLOWED_TAGS = {
   [SEARCH_IMAGE_TAG]: ["token"],
 } satisfies NonNullable<StreamdownProps["allowedTags"]>;
+
+// Module-scoped: Streamdown extends its sanitize schema only for its default pipeline, so the
+// allowed-tag merge and the data-image protocol ride on a pipeline we pass ourselves (see lib).
+const STREAMDOWN_REHYPE_PLUGINS = withDataImageSupport(STREAMDOWN_ALLOWED_TAGS);
 const COPY_RESET_MS = 2000;
 const MERMAID_SOURCE_RE = /```mermaid\s*([\s\S]*?)```/i;
 const ACTION_PANEL_CLASS =
@@ -810,6 +815,7 @@ const MarkdownTextImpl = () => {
             plugins={STREAMDOWN_PLUGINS}
             components={STREAMDOWN_COMPONENTS}
             allowedTags={STREAMDOWN_ALLOWED_TAGS}
+            rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}
             urlTransform={safeMarkdownUrl}
             controls={STREAMDOWN_CONTROLS}
             shikiTheme={STREAMDOWN_SHIKI_THEME}

--- a/studio/frontend/src/components/assistant-ui/math-block-marker.ts
+++ b/studio/frontend/src/components/assistant-ui/math-block-marker.ts
@@ -46,8 +46,9 @@
  *
  *   - Passing `rehypePlugins` to `<Streamdown>` replaces its default list, and Streamdown only
  *     installs the `allowedTags` sanitizer schema when that list is still the default one
- *     (`rehypePlugins === defaultRehypePlugins`). Supplying our own would silently drop the
- *     sanitize pass this renderer depends on. That is a security regression to buy a class name.
+ *     (`rehypePlugins === defaultRehypePlugins`). A pipeline that does not carry the merge silently
+ *     drops the sanitize pass this renderer depends on -- a security regression to buy a class name;
+ *     the one now passed for data images carries it (`lib/markdown-data-images.ts`).
  *   - Marking on the mdast side, through `data.hProperties`, lands the class BEFORE
  *     `rehype-sanitize`, whose `defaultSchema` permits `className` on `a`, `code`, `h2`, `li`,
  *     `ol`, `section` and `ul` and NOWHERE ELSE. A class on a `<p>` would be stripped, and

--- a/studio/frontend/src/lib/markdown-data-images.ts
+++ b/studio/frontend/src/lib/markdown-data-images.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Streamdown sanitizes with its default schema before hardening, and that schema allows only
+ * http(s) image sources: a `data:image/...` src is stripped before the harden stage, which does
+ * allow data images (`allowDataImages: true`), so the message renders "[Image blocked: …]" instead
+ * of the image. Streamdown extends its own schema with caller `allowedTags` only when it receives
+ * its default pipeline (identity check), so callers that pass one must carry that merge themselves.
+ */
+import type { Pluggable, Plugin } from "unified";
+import { defaultRehypePlugins } from "streamdown";
+
+interface SanitizeSchema {
+  tagNames?: string[];
+  attributes?: Record<string, string[]>;
+  protocols?: Record<string, string[]>;
+}
+
+/** Streamdown's default raw/sanitize/harden pipeline with `data` added to image source protocols. */
+export function withDataImageSupport(allowedTags: Record<string, string[]>): Pluggable[] {
+  const sanitize = defaultRehypePlugins.sanitize as [Plugin<Array<any>, any, any>, SanitizeSchema];
+  const [sanitizePlugin, schema] = sanitize;
+  // Positional by design: Streamdown itself builds its default pipeline as `Object.values` of this
+  // same object, so spreading it in the same order reproduces that pipeline exactly. Naming the keys
+  // would pin OUR order instead of theirs.
+  const [raw, , harden] = Object.values(defaultRehypePlugins);
+  return [
+    raw,
+    [
+      sanitizePlugin,
+      {
+        ...schema,
+        tagNames: [...(schema.tagNames ?? []), ...Object.keys(allowedTags)],
+        attributes: { ...schema.attributes, ...allowedTags },
+        protocols: {
+          ...schema.protocols,
+          // Harden still gates the scheme on `allowDataImages` and only honors `data:image/*`.
+          src: [...(schema.protocols?.src ?? []), "data"],
+        },
+      },
+    ],
+    harden,
+  ];
+}

--- a/studio/frontend/src/lib/markdown-data-images.ts
+++ b/studio/frontend/src/lib/markdown-data-images.ts
@@ -19,7 +19,7 @@ interface SanitizeSchema {
 
 /** Streamdown's default raw/sanitize/harden pipeline with `data` added to image source protocols. */
 export function withDataImageSupport(allowedTags: Record<string, string[]>): Pluggable[] {
-  const sanitize = defaultRehypePlugins.sanitize as [Plugin<Array<any>, any, any>, SanitizeSchema];
+  const sanitize = defaultRehypePlugins.sanitize as [Plugin<[SanitizeSchema]>, SanitizeSchema];
   const [sanitizePlugin, schema] = sanitize;
   // Positional by design: Streamdown itself builds its default pipeline as `Object.values` of this
   // same object, so spreading it in the same order reproduces that pipeline exactly. Naming the keys

--- a/studio/frontend/tests/markdown-data-images.test.ts
+++ b/studio/frontend/tests/markdown-data-images.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { withDataImageSupport } from "../src/lib/markdown-data-images.ts";
+
+const TAG = "search-image";
+
+test("withDataImageSupport allows data: image sources through sanitize", () => {
+  const pipeline = withDataImageSupport({ [TAG]: ["token"] });
+  assert.equal(pipeline.length, 3);
+  const [, harden] = pipeline[2] as [(...args: never[]) => unknown, Record<string, unknown>];
+  assert.equal(harden.allowDataImages, true, "harden stage must be the one that gates data images");
+  const [, schema] = pipeline[1] as [unknown, { tagNames: string[]; attributes: Record<string, string[]>; protocols: Record<string, string[]> }];
+  assert.ok(schema.protocols.src.includes("data"), "sanitize must let data: through so harden can decide");
+  for (const scheme of ["http", "https"]) assert.ok(schema.protocols.src.includes(scheme));
+  assert.ok(schema.tagNames.includes(TAG), "caller allowed tags survive the pipeline swap");
+  assert.deepEqual(schema.attributes[TAG], ["token"]);
+});
+
+test("withDataImageSupport carries Streamdown's own schema widening, not just defaultSchema", () => {
+  // The pipeline is derived from `defaultRehypePlugins.sanitize[1]`, which is Streamdown's OWN
+  // schema (defaultSchema PLUS its own widenings), not bare hast-util-sanitize defaultSchema.
+  // Re-deriving from defaultSchema would silently drop these and read as a no-op change.
+  const [, schema] = withDataImageSupport({ [TAG]: ["token"] })[1] as [
+    unknown,
+    { protocols: Record<string, string[]>; attributes: Record<string, unknown> },
+  ];
+  assert.ok(schema.protocols.href.includes("tel"), "streamdown's tel: widening must survive");
+  assert.ok(
+    (schema.attributes.code as unknown[]).includes("metastring"),
+    "streamdown's code/metastring widening must survive",
+  );
+});

--- a/studio/frontend/tests/math-block-containment-wiring.test.ts
+++ b/studio/frontend/tests/math-block-containment-wiring.test.ts
@@ -17,8 +17,10 @@ import {
 /*
  * THE THREE PIECES ONLY WORK TOGETHER, and nothing in the type system joins them:
  *
- *   1. the marker has to be composed onto the MATHS plugin, not passed as a `rehypePlugins` prop,
- *      because that prop switches off Streamdown's `allowedTags` sanitizer;
+ *   1. the marker has to be composed onto the MATHS plugin's own rehype pass. A `rehypePlugins` prop
+ *      entry would run before that pass, and the prop itself replaces Streamdown's default pipeline
+ *      (the `allowedTags` schema then rides only on what the passed pipeline carries -- see
+ *      `lib/markdown-data-images.ts`);
  *   2. the stylesheet has to name the class the marker writes and the attribute the resolver sets;
  *   3. `main.tsx` has to set that attribute before the first render.
  *
@@ -53,17 +55,19 @@ test("the marker is composed onto the maths plugin", () => {
   );
 });
 
-test("the chat renderer does NOT pass a rehypePlugins prop", () => {
-  // Passing one makes Streamdown skip its `allowedTags` sanitizer schema, because it only installs
-  // that schema while `rehypePlugins === defaultRehypePlugins`. This is the reason the marker is
-  // composed rather than appended, and it is worth more than the class it buys.
+test("the chat renderer's rehypePlugins pipeline carries the allowedTags merge itself", () => {
+  // Streamdown auto-merges `allowedTags` into its sanitize schema only while `rehypePlugins` is
+  // still its default pipeline (identity check). The renderer now passes one, so it must carry the
+  // merge itself; a passed pipeline that dropped it would silently drop the sanitizer instead.
   assert.ok(
     MARKDOWN_TEXT.includes("allowedTags={STREAMDOWN_ALLOWED_TAGS}"),
     "PRECONDITION: the chat renderer relies on the allowedTags sanitizer",
   );
   assert.ok(
-    !/\brehypePlugins=\{/.test(MARKDOWN_TEXT),
-    "no rehypePlugins prop, or the sanitizer schema above is silently dropped",
+    /const STREAMDOWN_REHYPE_PLUGINS = withDataImageSupport\(STREAMDOWN_ALLOWED_TAGS\);/.test(
+      MARKDOWN_TEXT,
+    ) && MARKDOWN_TEXT.includes("rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}"),
+    "the passed pipeline must be derived from the defaults AND carry the allowedTags merge",
   );
 });
 


### PR DESCRIPTION
## TL;DR

Base64 images in assistant messages rendered as `[Image blocked: ...]`. Streamdown strips `data:` image sources during **sanitize**, before the **harden** stage that actually allows them. One derived pipeline restores them without changing anything else about how chat markdown is sanitized.

## Problem

Assistant messages containing inline base64 images (`![alt](data:image/png;base64,...)`) rendered as `[Image blocked: ...]` instead of the image.

## Root cause

Streamdown sanitizes **before** hardening, and sanitize wins:

```js
// hast-util-sanitize/lib/schema.js  (installed 2.5.0)
protocols.src: ["http", "https"]        // no "data" -> src is dropped HERE
```

`harden` does allow data images (`allowDataImages: true`) — but it runs second, so by the time it decides, the `src` attribute is already gone. The flag is effectively dead for data URIs as shipped.

Why we can't just pass a pipeline and forget about it: Streamdown folds caller `allowedTags` into its schema **only while it still holds its own default pipeline** (an identity check):

```js
// streamdown/dist/chunk-BO2N2NFS.js  (de-minified)
gn = Object.values(xt)                    // the default pipeline
if (allowedTags && Object.keys(allowedTags).length > 0 && rehypePlugins === gn) {
  const K = { ...Ze, tagNames: [...Ze.tagNames ?? [], ...Object.keys(allowedTags)],
              attributes: { ...Ze.attributes, ...allowedTags } };
  pipeline = [xt.raw, [sanitize, K], xt.harden];   // merge happens ONLY here
}
```

So a caller-supplied pipeline silently opts out of the `allowedTags` merge unless it carries that merge itself.

## Fix

Pass an explicit pipeline **derived** from Streamdown's exported defaults, adding `"data"` to image source protocols:

- Derived, not hand-rolled, so the default-pipeline merge above is carried unchanged.
- Destructuring the *exported* schema (not bare `defaultSchema`) also preserves Streamdown's own widenings, which a hand-rolled schema would silently drop: `protocols.href += ["tel"]`, `attributes.code += ["metastring"]`. Both are now pinned by tests.
- Positional destructuring of `Object.values` is deliberate: upstream builds its default pipeline from `Object.values` of that same object, so the same order reproduces upstream exactly, instead of pinning ours against theirs.
- Harden still gates the scheme itself (`allowDataImages` + `data:image/*` only), so widening `src` does not widen *what* may be embedded.

## What else touches this path (checked, unchanged)

| Site | Props | Effect |
|---|---|---|
| `assistant-ui/markdown-text.tsx` | `allowedTags` + new `rehypePlugins` | the fix |
| `hub/catalog/model-readme.tsx:536` | `allowedTags`, no `rehypePlugins` | identity still holds internally; merge still fires |
| `markdown/markdown-preview.tsx:96` | neither | untouched |

Nothing downstream is lost either: the `literalTagContent` append and the math/mermaid plugin appends both run **after** the identity branch unconditionally, and `withoutStreamdownAnimationPlugin` filters by function identity, so it is order-agnostic.

## Verification

- Facts above read out of the installed `streamdown@2.5.0` chunk and `hast-util-sanitize/lib/schema.js`, not inferred.
- SSR probe through real `<Streamdown mode="static">`: default pipeline renders the blocked pill and keeps no `src`; this pipeline emits `<img ... src="data:image/png;base64,...">`; a custom allowed tag survives via the carried merge; non-image `data:text/html` stays blocked.
- `npm run typecheck` -> 0 errors. Suite -> **6824 pass / 0 fail**.

## Tests

`tests/markdown-data-images.test.ts` — data + http(s) survive sanitize, harden entry unchanged, caller `allowedTags` survive the pipeline swap, and Streamdown's own widenings (`tel`, `metastring`) survive derivation. `tests/math-block-containment-wiring.test.ts` guard retargeted from "no `rehypePlugins` prop" to "the passed pipeline carries the merge".

## Follow-up (not blocking)

Upstream, this is one line: `"data"` in Streamdown's own `protocols.src`. If that lands, this shim and the pipeline swap both become deletable. Unrelated note found nearby: `safeMarkdownUrl` returns `null` for any scheme'd `<img>` URL including `https:`, so remote images lose `src` too — byte-identical before/after this PR, i.e. pre-existing and out of scope here.