### PR TITLE
Kaggle: fix the nightly, which has never once got as far as Kaggle

### DIFF
--- a/.github/workflows/kaggle-t4-notebook-ci.yml
+++ b/.github/workflows/kaggle-t4-notebook-ci.yml
@@ -955,9 +955,6 @@ jobs:
           if [ "${{ inputs.studio_concurrent }}" = "false" ]; then
             STUDIO_CONCURRENT=''
           fi
-          if [ -n "$STUDIO_CONCURRENT" ]; then
-            echo "::notice title=Studio shares a card::the Studio GPU half is pinned to one T4 beside a small leg, so this run does NOT cover Studio's own choice between two cards. The report records tensor_split_over_two_cards=false rather than claiming it."
-          fi
           # A leg list REPLACES --all-kernels rather than filtering it: the
           # kernel plan and the payload count both come out of the same call,
           # so a filter applied afterwards would leave the launcher expecting
@@ -968,6 +965,43 @@ jobs:
           else
             KERNEL_SELECT="--all-kernels"
           fi
+          # STUDIO RIDES THE WIRED SET ONLY, and this is a refusal rather than a
+          # preference. build_kernel.py exits on `--with-studio` without
+          # `--all-kernels`, because --legs builds one deliberately narrowed
+          # kernel and hanging a ten-minute Studio install off it defeats the
+          # point of narrowing it.
+          #
+          # Both of those were emitted unconditionally, so the nightly asked for
+          # a leg list AND for Studio and never got as far as Kaggle: runs
+          # 33587255856 and 33716011285, every scheduled run there has ever
+          # been, died in this step on
+          #
+          #     --with-studio requires --all-kernels
+          #
+          # The two halves landed separately and each was guarded on its own --
+          # that a leg list replaces --all-kernels, and that the build step
+          # packs Studio in -- so nothing asserted the command line they compose
+          # together is one the parser accepts. That is what
+          # test_grpo_nightly.py's parser rules now do, on both triggers.
+          STUDIO=()
+          if [ -z "$LEG_LIST" ]; then
+            STUDIO=(--with-studio --studio-args "--max-steps 8")
+            if [ -n "$STUDIO_CONCURRENT" ]; then
+              STUDIO+=("$STUDIO_CONCURRENT")
+              echo "::notice title=Studio shares a card::the Studio GPU half is pinned to one T4 beside a small leg, so this run does NOT cover Studio's own choice between two cards. The report records tensor_split_over_two_cards=false rather than claiming it."
+            fi
+            echo "studio=true" >> "$GITHUB_OUTPUT"
+          else
+            # Said out loud, because a nightly quietly dropping Studio and one
+            # that quietly stopped running it look identical in the summary.
+            echo "::notice title=Studio is not in this kernel::this run selects legs explicitly, and the Studio payload rides the wired set only. Its coverage comes from the per-PR runs."
+            # And the Studio reporter is told, rather than left to work it out
+            # from an absence. With no `studio-gpu` report to filter down to,
+            # own_verdict answers `partial` and renders "Unsloth GPU smoke:
+            # PARTIAL" carrying the NOTEBOOK kernel's reason -- a section
+            # describing a payload that was never aboard, on every nightly.
+            echo "studio=false" >> "$GITHUB_OUTPUT"
+          fi
           python .github/scripts/kaggle_t4_ci/build_kernel.py \
             --payload-dir tests/kaggle/t4_smoke \
             --out kernel \
@@ -975,10 +1009,8 @@ jobs:
             --unsloth-ref '${{ steps.ref.outputs.ref }}' \
             --zoo-ref '${{ steps.pins.outputs.zoo_ref }}' \
             --smoke-args "--max-steps $MAX_STEPS" \
-            --with-studio \
-            --studio-args "--max-steps 8" \
+            "${STUDIO[@]}" \
             --per-run-timeout 3900 \
-            $STUDIO_CONCURRENT \
             $SHARED_WHEELS \
             $SKIP
 
@@ -1148,8 +1180,12 @@ jobs:
       #
       # Its exit code is the same contract as the T4 reporter's: red only for a
       # payload that ran and failed its assertions.
+      # Only when the kernel actually carried Studio. A leg-list dispatch does
+      # not, and this reporter answers an empty report set with `partial`
+      # rather than silence, so without the gate every nightly would print an
+      # "Unsloth GPU smoke: PARTIAL" section about a payload it never ran.
       - name: Report Studio
-        if: always() && steps.recheck.outputs.should_run == 'true'
+        if: always() && steps.recheck.outputs.should_run == 'true' && steps.build.outputs.studio == 'true'
         run: |
           python .github/scripts/kaggle_studio_ci/report.py \
             --evidence kaggle_evidence

--- a/.github/workflows/kaggle-t4-notebook-ci.yml
+++ b/.github/workflows/kaggle-t4-notebook-ci.yml
@@ -965,24 +965,16 @@ jobs:
           else
             KERNEL_SELECT="--all-kernels"
           fi
-          # STUDIO RIDES THE WIRED SET ONLY, and this is a refusal rather than a
-          # preference. build_kernel.py exits on `--with-studio` without
+          # STUDIO RIDES THE WIRED SET ONLY, and that is a refusal rather than a
+          # preference: build_kernel.py exits on `--with-studio` without
           # `--all-kernels`, because --legs builds one deliberately narrowed
-          # kernel and hanging a ten-minute Studio install off it defeats the
-          # point of narrowing it.
+          # kernel and a ten-minute Studio install defeats narrowing it.
           #
-          # Both of those were emitted unconditionally, so the nightly asked for
-          # a leg list AND for Studio and never got as far as Kaggle: runs
-          # 33587255856 and 33716011285, every scheduled run there has ever
-          # been, died in this step on
-          #
-          #     --with-studio requires --all-kernels
-          #
-          # The two halves landed separately and each was guarded on its own --
-          # that a leg list replaces --all-kernels, and that the build step
-          # packs Studio in -- so nothing asserted the command line they compose
-          # together is one the parser accepts. That is what
-          # test_grpo_nightly.py's parser rules now do, on both triggers.
+          # Both were emitted unconditionally, so runs 33587255856 and
+          # 33716011285 -- every scheduled run there has ever been -- died here
+          # on `--with-studio requires --all-kernels` without reaching Kaggle.
+          # Each half was guarded alone and neither guard could see the other;
+          # test_grpo_nightly.py now runs this body and parses the argv.
           STUDIO=()
           if [ -z "$LEG_LIST" ]; then
             STUDIO=(--with-studio --studio-args "--max-steps 8")
@@ -992,14 +984,13 @@ jobs:
             fi
             echo "studio=true" >> "$GITHUB_OUTPUT"
           else
-            # Said out loud, because a nightly quietly dropping Studio and one
-            # that quietly stopped running it look identical in the summary.
+            # Said out loud: a nightly that drops Studio and one whose Studio
+            # silently stopped being packed look identical in the summary.
             echo "::notice title=Studio is not in this kernel::this run selects legs explicitly, and the Studio payload rides the wired set only. Its coverage comes from the per-PR runs."
-            # And the Studio reporter is told, rather than left to work it out
-            # from an absence. With no `studio-gpu` report to filter down to,
-            # own_verdict answers `partial` and renders "Unsloth GPU smoke:
-            # PARTIAL" carrying the NOTEBOOK kernel's reason -- a section
-            # describing a payload that was never aboard, on every nightly.
+            # And the reporter is told rather than left to infer it. With no
+            # `studio-gpu` report to filter to, own_verdict answers `partial`
+            # and renders "Unsloth GPU smoke: PARTIAL" carrying the NOTEBOOK
+            # kernel's reason, about a payload that was never aboard.
             echo "studio=false" >> "$GITHUB_OUTPUT"
           fi
           python .github/scripts/kaggle_t4_ci/build_kernel.py \
@@ -1180,10 +1171,9 @@ jobs:
       #
       # Its exit code is the same contract as the T4 reporter's: red only for a
       # payload that ran and failed its assertions.
-      # Only when the kernel actually carried Studio. A leg-list dispatch does
-      # not, and this reporter answers an empty report set with `partial`
-      # rather than silence, so without the gate every nightly would print an
-      # "Unsloth GPU smoke: PARTIAL" section about a payload it never ran.
+      # Only when the kernel carried Studio. This reporter answers an empty
+      # report set with `partial` rather than silence, so ungated it would print
+      # a PARTIAL section on every leg-list run about a payload it never ran.
       - name: Report Studio
         if: always() && steps.recheck.outputs.should_run == 'true' && steps.build.outputs.studio == 'true'
         run: |

--- a/tests/kaggle/test_grpo_nightly.py
+++ b/tests/kaggle/test_grpo_nightly.py
@@ -171,20 +171,13 @@ def test_the_leg_list_default_survives_a_schedule_event():
 
 # ------------------------------------------------- the command line it composes
 
-# Every rule above reads the workflow as TEXT: that a leg list is selected, that
-# it replaces --all-kernels, that the schedule forces the gate. Each was true
-# and the nightly still never ran, because the build step also emitted
-# --with-studio unconditionally and build_kernel.py refuses that combination:
-#
-#     ::notice::running grpo,multi_gpu,latest_compile instead of the wired set
-#     --with-studio requires --all-kernels
-#     ##[error]Process completed with exit code 1
-#
-# Runs 33587255856 and 33716011285, which is every scheduled run there has ever
-# been. Both halves were guarded separately and neither guard could see the
-# other, so the rules below take the step's own shell body, run it, and hand the
-# argv it composes to the real parser. A pair of flags that cannot be passed
-# together is then a red on CPU rather than a nightly that quietly never fires.
+# Every rule above reads the workflow as TEXT, each was true, and the nightly
+# still never ran: the build step also emitted --with-studio unconditionally,
+# which build_kernel.py refuses next to --legs, so runs 33587255856 and
+# 33716011285 (every scheduled run there has ever been) died on
+# `--with-studio requires --all-kernels`. Two guards, neither able to see the
+# other. So the rules below run the step's own shell body and hand the argv it
+# composes to the real parser.
 
 
 def _build_step():
@@ -205,9 +198,9 @@ def _compose_argv(
 ):
     """Run the build step's shell body and return the argv it would invoke.
 
-    The body is executed by bash, not pattern-matched, so the branches decide
-    what is emitted exactly as they do on a runner. `python` is a stub on PATH
-    that records its arguments and exits 0, which is the only substitution.
+    Executed by bash, not pattern-matched, so the branches decide what is
+    emitted exactly as on a runner. The only substitution is `python`, a stub
+    on PATH that records its arguments.
     """
     import json
     import os
@@ -216,9 +209,8 @@ def _compose_argv(
 
     step = _build_step()
     # `inputs` is null on push and on a schedule, so every input expression is
-    # the empty string on both of the triggers modelled here. The one value
-    # that differs between them is LEG_LIST, and it comes from the workflow's
-    # own fallback rather than from a copy of the leg names kept here.
+    # empty on both triggers modelled here. Only LEG_LIST differs, and it comes
+    # from the workflow's own fallback rather than a copy kept here.
     nightly = ",".join(_nightly_legs())
     env_values = {
         "LEG_LIST": legs_input or (nightly if event == "schedule" else ""),
@@ -230,10 +222,7 @@ def _compose_argv(
         assert key in env_values, f"the build step gained {key}, which this rule does not model"
 
     body = step["run"]
-    # Interpolations left in the body itself. `steps.*.outputs.*` are refs the
-    # builder only echoes into the kernel, so any hex will do; the input
-    # expressions are empty for both triggers, which is what puts the run on
-    # the default branch of each `if`.
+    # `steps.*.outputs.*` are refs the builder only echoes, so any hex will do.
     body = body.replace("${{ steps.ref.outputs.ref }}", "0" * 40)
     body = body.replace("${{ steps.pins.outputs.zoo_ref }}", "1" * 40)
     body = body.replace("${{ inputs.shared_wheels }}", "")
@@ -252,8 +241,7 @@ def _compose_argv(
     (bindir / "python").chmod(0o755)
 
     env = dict(os.environ, PATH = f"{bindir}{os.pathsep}{os.environ['PATH']}", **env_values)
-    # The step writes its `studio` output here. Pointed at a real file so
-    # the rules can read what it published rather than what it printed.
+    # A real file, so the rules read what the step published, not what it printed.
     env["GITHUB_OUTPUT"] = github_output or str(tmp_path / "github_output")
     # `bash -e`, which is what GitHub runs a `run:` block under on Linux.
     proc = subprocess.run(
@@ -287,9 +275,8 @@ def _run_builder(argv, tmp_path):
 def test_the_nightly_command_line_is_one_the_builder_accepts(tmp_path):
     """THE RULE THAT WOULD HAVE CAUGHT IT.
 
-    Not "the flags look right" -- the step's own shell composes the argv and the
-    real builder is handed it. A nightly that cannot be built is a nightly that
-    does not exist, and it costs a scheduled run to find out.
+    Not "the flags look right": the step's own shell composes the argv and the
+    real builder is handed it.
     """
     argv, log, printed = _compose_argv("schedule", tmp_path)
     proc = _run_builder(argv, tmp_path)
@@ -302,10 +289,8 @@ def test_the_nightly_command_line_is_one_the_builder_accepts(tmp_path):
 
 
 def test_the_per_pr_command_line_is_one_the_builder_accepts(tmp_path):
-    """The same rule for the trigger that was working, so a fix for the nightly
-    cannot be a regression for everything else. This is the pair: narrowing one
-    branch until it parses while breaking the other would satisfy the test
-    above on its own."""
+    """The pair to the rule above: narrowing one branch until it parses while
+    breaking the other would satisfy that one on its own."""
     argv, log, printed = _compose_argv("push", tmp_path)
     proc = _run_builder(argv, tmp_path)
     assert proc.returncode == 0, (
@@ -317,13 +302,9 @@ def test_the_per_pr_command_line_is_one_the_builder_accepts(tmp_path):
 
 
 def test_studio_rides_the_wired_set_and_only_the_wired_set(tmp_path):
-    """The specific pair that was mutually exclusive.
-
-    Asserted in BOTH directions. Dropping Studio from the nightly is only a fix
-    if the per-PR kernel still carries it -- otherwise the Studio payload is
-    covered by nothing at all, which is the failure
-    test_the_build_step_actually_packs_studio_in was written for.
-    """
+    """The pair that was mutually exclusive, asserted in BOTH directions:
+    dropping Studio from the nightly is only a fix if the per-PR kernel still
+    carries it, else the payload is covered by nothing."""
     nightly, _, _ = _compose_argv("schedule", tmp_path)
     assert "--with-studio" not in nightly, (
         "the nightly still asks for Studio alongside a leg list, which "
@@ -337,9 +318,9 @@ def test_studio_rides_the_wired_set_and_only_the_wired_set(tmp_path):
 
 
 def test_studio_concurrent_still_reaches_the_builder_on_the_per_pr_run(tmp_path):
-    """`--studio-concurrent` moved inside the Studio branch, and a flag that
-    stops being passed is exactly the failure run 32674263571 shipped: the
-    variant of an A/B ran the control's schedule and nothing was red."""
+    """The flag moved inside the Studio branch. One that stops being passed is
+    the failure run 32674263571 shipped: the variant of an A/B ran the
+    control's schedule and nothing was red."""
     argv, _, _ = _compose_argv("push", tmp_path)
     assert "--studio-concurrent" in argv, (
         "the default per-PR build no longer shares a card, so Studio waits for "
@@ -355,9 +336,8 @@ def test_a_leg_list_dispatch_is_told_studio_is_not_aboard(tmp_path):
 
 
 def test_an_explicit_leg_dispatch_takes_the_same_path_as_the_nightly(tmp_path):
-    """`legs` is a workflow_dispatch input as well as a schedule fallback, and
-    it reaches the same branch. A hand dispatch naming one leg hit the identical
-    build failure."""
+    """`legs` is a dispatch input as well as a schedule fallback and reaches
+    the same branch, so a hand dispatch hit the identical build failure."""
     argv, _, printed = _compose_argv("workflow_dispatch", tmp_path, legs_input = "grpo")
     assert "--with-studio" not in argv, printed
     proc = _run_builder(argv, tmp_path)
@@ -365,18 +345,12 @@ def test_an_explicit_leg_dispatch_takes_the_same_path_as_the_nightly(tmp_path):
 
 
 def test_studio_concurrent_false_actually_removes_the_flag(tmp_path):
-    """The OTHER half of the input, and the text rules cannot see it.
+    """The OTHER half of the input, which the text rules cannot see.
 
-    `--studio-concurrent` moved into a branch, and a branch that hardcodes the
-    flag rather than reading the variable still contains every string the
-    workflow-text rules look for: STUDIO_CONCURRENT is still assigned from the
-    input, the input is still declared, and the flag still reaches the builder.
-    Only running it with the input set to `false` and finding the flag gone
-    says the switch works.
-
-    Reaching for it is not hypothetical either. Studio seeing both cards is the
-    only way its own device selection is under test at all, and that dispatch
-    is the one this input exists to make possible.
+    A branch that hardcoded the flag instead of reading the variable would
+    still contain every string they look for. Only running it with the input
+    `false` and finding the flag gone says the switch works, and that dispatch
+    is the only way Studio's own two-card device selection is under test.
     """
     off, _, printed = _compose_argv("workflow_dispatch", tmp_path, studio_concurrent = "false")
     assert "--studio-concurrent" not in off, (
@@ -394,15 +368,13 @@ def test_studio_concurrent_false_actually_removes_the_flag(tmp_path):
 
 
 def test_the_studio_reporter_is_told_when_studio_is_not_aboard(tmp_path):
-    """The build step publishes whether it packed Studio, and the reporter is
-    gated on it.
+    """The build step publishes whether it packed Studio; the reporter gates
+    on it.
 
-    `kaggle_studio_ci/report.py` filters the launcher's reports down to the
-    `studio-gpu` label and `own_verdict` answers an EMPTY set with `partial`,
-    carrying the notebook kernel's own reason. So an ungated reporter renders
-    "Unsloth GPU smoke: PARTIAL" on every leg-list run, describing a payload
-    that was never in the kernel and quoting a reason belonging to the other
-    half. Not red, which is worse: it is a section that reads like a result.
+    `own_verdict` answers an EMPTY `studio-gpu` report set with `partial`,
+    carrying the notebook kernel's reason, so an ungated reporter renders
+    "Unsloth GPU smoke: PARTIAL" on every leg-list run about a payload that was
+    never aboard. Not red, which is worse: it reads like a result.
     """
     for event, expected in (("schedule", "false"), ("push", "true")):
         outfile = tmp_path / f"out_{event}"

--- a/tests/kaggle/test_grpo_nightly.py
+++ b/tests/kaggle/test_grpo_nightly.py
@@ -196,7 +196,13 @@ def _build_step():
     raise AssertionError("the build step is gone, so nothing here can be true")
 
 
-def _compose_argv(event, tmp_path, legs_input = "", studio_concurrent = "", github_output = ""):
+def _compose_argv(
+    event,
+    tmp_path,
+    legs_input = "",
+    studio_concurrent = "",
+    github_output = "",
+):
     """Run the build step's shell body and return the argv it would invoke.
 
     The body is executed by bash, not pattern-matched, so the branches decide
@@ -252,7 +258,10 @@ def _compose_argv(event, tmp_path, legs_input = "", studio_concurrent = "", gith
     # `bash -e`, which is what GitHub runs a `run:` block under on Linux.
     proc = subprocess.run(
         ["bash", "-e", "-c", body],
-        cwd = ROOT, env = env, capture_output = True, text = True,
+        cwd = ROOT,
+        env = env,
+        capture_output = True,
+        text = True,
     )
     assert proc.returncode == 0, f"the step body itself failed:\n{proc.stderr}"
     assert argvfile.exists(), f"the body never invoked python:\n{proc.stdout}\n{proc.stderr}"
@@ -268,7 +277,10 @@ def _run_builder(argv, tmp_path):
     out = [str(tmp_path / "kernel") if a == "kernel" else a for a in argv]
     assert out != argv, "the step no longer writes to `kernel`, so this rule writes into the repo"
     return subprocess.run(
-        [sys.executable, *out], cwd = ROOT, capture_output = True, text = True,
+        [sys.executable, *out],
+        cwd = ROOT,
+        capture_output = True,
+        text = True,
     )
 
 
@@ -319,8 +331,7 @@ def test_studio_rides_the_wired_set_and_only_the_wired_set(tmp_path):
     )
     per_pr, _, _ = _compose_argv("push", tmp_path)
     assert "--with-studio" in per_pr, (
-        "no trigger packs Studio in any more, so the whole Studio payload runs "
-        "nowhere"
+        "no trigger packs Studio in any more, so the whole Studio payload runs nowhere"
     )
     assert "--studio-args" in per_pr, per_pr
 
@@ -377,7 +388,9 @@ def test_studio_concurrent_false_actually_removes_the_flag(tmp_path):
     assert proc.returncode == 0, f"{printed}\n{proc.stdout}\n{proc.stderr}"
 
     on, _, _ = _compose_argv("workflow_dispatch", tmp_path)
-    assert "--studio-concurrent" in on, "the default stopped sharing, which is a makespan regression"
+    assert (
+        "--studio-concurrent" in on
+    ), "the default stopped sharing, which is a makespan regression"
 
 
 def test_the_studio_reporter_is_told_when_studio_is_not_aboard(tmp_path):
@@ -395,11 +408,14 @@ def test_the_studio_reporter_is_told_when_studio_is_not_aboard(tmp_path):
         outfile = tmp_path / f"out_{event}"
         outfile.write_text("", encoding = "utf-8")
         argv, log, _ = _compose_argv(
-            event, tmp_path / event, github_output = str(outfile),
+            event,
+            tmp_path / event,
+            github_output = str(outfile),
         )
         written = dict(
-            line.split("=", 1) for line in
-            outfile.read_text(encoding = "utf-8").splitlines() if "=" in line
+            line.split("=", 1)
+            for line in outfile.read_text(encoding = "utf-8").splitlines()
+            if "=" in line
         )
         assert written.get("studio") == expected, (
             f"{event} publishes studio={written.get('studio')!r}, so the "

--- a/tests/kaggle/test_grpo_nightly.py
+++ b/tests/kaggle/test_grpo_nightly.py
@@ -167,3 +167,252 @@ def test_the_leg_list_default_survives_a_schedule_event():
     """``inputs`` is null on a schedule, so an input default cannot supply the
     value; it has to come from the fallback."""
     assert "inputs.legs || (github.event_name == 'schedule'" in TEXT
+
+
+# ------------------------------------------------- the command line it composes
+
+# Every rule above reads the workflow as TEXT: that a leg list is selected, that
+# it replaces --all-kernels, that the schedule forces the gate. Each was true
+# and the nightly still never ran, because the build step also emitted
+# --with-studio unconditionally and build_kernel.py refuses that combination:
+#
+#     ::notice::running grpo,multi_gpu,latest_compile instead of the wired set
+#     --with-studio requires --all-kernels
+#     ##[error]Process completed with exit code 1
+#
+# Runs 33587255856 and 33716011285, which is every scheduled run there has ever
+# been. Both halves were guarded separately and neither guard could see the
+# other, so the rules below take the step's own shell body, run it, and hand the
+# argv it composes to the real parser. A pair of flags that cannot be passed
+# together is then a red on CPU rather than a nightly that quietly never fires.
+
+
+def _build_step():
+    """The `Build the kernel notebooks` step, off the parsed YAML."""
+    for job in DOC["jobs"].values():
+        for step in job.get("steps") or []:
+            if step.get("name") == "Build the kernel notebooks":
+                return step
+    raise AssertionError("the build step is gone, so nothing here can be true")
+
+
+def _compose_argv(event, tmp_path, legs_input = "", studio_concurrent = "", github_output = ""):
+    """Run the build step's shell body and return the argv it would invoke.
+
+    The body is executed by bash, not pattern-matched, so the branches decide
+    what is emitted exactly as they do on a runner. `python` is a stub on PATH
+    that records its arguments and exits 0, which is the only substitution.
+    """
+    import json
+    import os
+    import shlex
+    import subprocess
+
+    step = _build_step()
+    # `inputs` is null on push and on a schedule, so every input expression is
+    # the empty string on both of the triggers modelled here. The one value
+    # that differs between them is LEG_LIST, and it comes from the workflow's
+    # own fallback rather than from a copy of the leg names kept here.
+    nightly = ",".join(_nightly_legs())
+    env_values = {
+        "LEG_LIST": legs_input or (nightly if event == "schedule" else ""),
+        "SKIP_BAND": "",
+        "MAX_STEPS": "10",
+        "REF_STEPS": "10",
+    }
+    for key in step.get("env") or {}:
+        assert key in env_values, f"the build step gained {key}, which this rule does not model"
+
+    body = step["run"]
+    # Interpolations left in the body itself. `steps.*.outputs.*` are refs the
+    # builder only echoes into the kernel, so any hex will do; the input
+    # expressions are empty for both triggers, which is what puts the run on
+    # the default branch of each `if`.
+    body = body.replace("${{ steps.ref.outputs.ref }}", "0" * 40)
+    body = body.replace("${{ steps.pins.outputs.zoo_ref }}", "1" * 40)
+    body = body.replace("${{ inputs.shared_wheels }}", "")
+    body = body.replace("${{ inputs.studio_concurrent }}", studio_concurrent)
+    assert "${{" not in body, f"an unmodelled expression survives: {body}"
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents = True, exist_ok = True)
+    argvfile = tmp_path / "argv.json"
+    (bindir / "python").write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        f"open({str(argvfile)!r}, 'w').write(json.dumps(sys.argv[1:]))\n",
+        encoding = "utf-8",
+    )
+    (bindir / "python").chmod(0o755)
+
+    env = dict(os.environ, PATH = f"{bindir}{os.pathsep}{os.environ['PATH']}", **env_values)
+    # The step writes its `studio` output here. Pointed at a real file so
+    # the rules can read what it published rather than what it printed.
+    env["GITHUB_OUTPUT"] = github_output or str(tmp_path / "github_output")
+    # `bash -e`, which is what GitHub runs a `run:` block under on Linux.
+    proc = subprocess.run(
+        ["bash", "-e", "-c", body],
+        cwd = ROOT, env = env, capture_output = True, text = True,
+    )
+    assert proc.returncode == 0, f"the step body itself failed:\n{proc.stderr}"
+    assert argvfile.exists(), f"the body never invoked python:\n{proc.stdout}\n{proc.stderr}"
+    argv = json.loads(argvfile.read_text(encoding = "utf-8"))
+    assert argv and argv[0].endswith("build_kernel.py"), argv
+    return argv, proc.stdout + proc.stderr, shlex.join(argv)
+
+
+def _run_builder(argv, tmp_path):
+    import subprocess
+    import sys
+
+    out = [str(tmp_path / "kernel") if a == "kernel" else a for a in argv]
+    assert out != argv, "the step no longer writes to `kernel`, so this rule writes into the repo"
+    return subprocess.run(
+        [sys.executable, *out], cwd = ROOT, capture_output = True, text = True,
+    )
+
+
+def test_the_nightly_command_line_is_one_the_builder_accepts(tmp_path):
+    """THE RULE THAT WOULD HAVE CAUGHT IT.
+
+    Not "the flags look right" -- the step's own shell composes the argv and the
+    real builder is handed it. A nightly that cannot be built is a nightly that
+    does not exist, and it costs a scheduled run to find out.
+    """
+    argv, log, printed = _compose_argv("schedule", tmp_path)
+    proc = _run_builder(argv, tmp_path)
+    assert proc.returncode == 0, (
+        f"the nightly builds nothing:\n  {printed}\n"
+        f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    assert "--legs" in argv, argv
+    assert "--all-kernels" not in argv, argv
+
+
+def test_the_per_pr_command_line_is_one_the_builder_accepts(tmp_path):
+    """The same rule for the trigger that was working, so a fix for the nightly
+    cannot be a regression for everything else. This is the pair: narrowing one
+    branch until it parses while breaking the other would satisfy the test
+    above on its own."""
+    argv, log, printed = _compose_argv("push", tmp_path)
+    proc = _run_builder(argv, tmp_path)
+    assert proc.returncode == 0, (
+        f"the per-PR run builds nothing:\n  {printed}\n"
+        f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    assert "--all-kernels" in argv, argv
+    assert "--legs" not in argv, argv
+
+
+def test_studio_rides_the_wired_set_and_only_the_wired_set(tmp_path):
+    """The specific pair that was mutually exclusive.
+
+    Asserted in BOTH directions. Dropping Studio from the nightly is only a fix
+    if the per-PR kernel still carries it -- otherwise the Studio payload is
+    covered by nothing at all, which is the failure
+    test_the_build_step_actually_packs_studio_in was written for.
+    """
+    nightly, _, _ = _compose_argv("schedule", tmp_path)
+    assert "--with-studio" not in nightly, (
+        "the nightly still asks for Studio alongside a leg list, which "
+        "build_kernel.py refuses outright"
+    )
+    per_pr, _, _ = _compose_argv("push", tmp_path)
+    assert "--with-studio" in per_pr, (
+        "no trigger packs Studio in any more, so the whole Studio payload runs "
+        "nowhere"
+    )
+    assert "--studio-args" in per_pr, per_pr
+
+
+def test_studio_concurrent_still_reaches_the_builder_on_the_per_pr_run(tmp_path):
+    """`--studio-concurrent` moved inside the Studio branch, and a flag that
+    stops being passed is exactly the failure run 32674263571 shipped: the
+    variant of an A/B ran the control's schedule and nothing was red."""
+    argv, _, _ = _compose_argv("push", tmp_path)
+    assert "--studio-concurrent" in argv, (
+        "the default per-PR build no longer shares a card, so Studio waits for "
+        "both to drain and the makespan claim in this workflow's header is gone"
+    )
+
+
+def test_a_leg_list_dispatch_is_told_studio_is_not_aboard(tmp_path):
+    """A run that drops Studio and a run whose Studio silently stopped being
+    packed look identical in the summary, so the first one says so."""
+    _, log, _ = _compose_argv("schedule", tmp_path)
+    assert "Studio is not in this kernel" in log, log
+
+
+def test_an_explicit_leg_dispatch_takes_the_same_path_as_the_nightly(tmp_path):
+    """`legs` is a workflow_dispatch input as well as a schedule fallback, and
+    it reaches the same branch. A hand dispatch naming one leg hit the identical
+    build failure."""
+    argv, _, printed = _compose_argv("workflow_dispatch", tmp_path, legs_input = "grpo")
+    assert "--with-studio" not in argv, printed
+    proc = _run_builder(argv, tmp_path)
+    assert proc.returncode == 0, f"{printed}\n{proc.stdout}\n{proc.stderr}"
+
+
+def test_studio_concurrent_false_actually_removes_the_flag(tmp_path):
+    """The OTHER half of the input, and the text rules cannot see it.
+
+    `--studio-concurrent` moved into a branch, and a branch that hardcodes the
+    flag rather than reading the variable still contains every string the
+    workflow-text rules look for: STUDIO_CONCURRENT is still assigned from the
+    input, the input is still declared, and the flag still reaches the builder.
+    Only running it with the input set to `false` and finding the flag gone
+    says the switch works.
+
+    Reaching for it is not hypothetical either. Studio seeing both cards is the
+    only way its own device selection is under test at all, and that dispatch
+    is the one this input exists to make possible.
+    """
+    off, _, printed = _compose_argv("workflow_dispatch", tmp_path, studio_concurrent = "false")
+    assert "--studio-concurrent" not in off, (
+        f"studio_concurrent=false still shares a card, so the two-card Studio "
+        f"dispatch is unreachable: {printed}"
+    )
+    assert "--with-studio" in off, "turning sharing off must not drop Studio itself"
+    proc = _run_builder(off, tmp_path)
+    assert proc.returncode == 0, f"{printed}\n{proc.stdout}\n{proc.stderr}"
+
+    on, _, _ = _compose_argv("workflow_dispatch", tmp_path)
+    assert "--studio-concurrent" in on, "the default stopped sharing, which is a makespan regression"
+
+
+def test_the_studio_reporter_is_told_when_studio_is_not_aboard(tmp_path):
+    """The build step publishes whether it packed Studio, and the reporter is
+    gated on it.
+
+    `kaggle_studio_ci/report.py` filters the launcher's reports down to the
+    `studio-gpu` label and `own_verdict` answers an EMPTY set with `partial`,
+    carrying the notebook kernel's own reason. So an ungated reporter renders
+    "Unsloth GPU smoke: PARTIAL" on every leg-list run, describing a payload
+    that was never in the kernel and quoting a reason belonging to the other
+    half. Not red, which is worse: it is a section that reads like a result.
+    """
+    for event, expected in (("schedule", "false"), ("push", "true")):
+        outfile = tmp_path / f"out_{event}"
+        outfile.write_text("", encoding = "utf-8")
+        argv, log, _ = _compose_argv(
+            event, tmp_path / event, github_output = str(outfile),
+        )
+        written = dict(
+            line.split("=", 1) for line in
+            outfile.read_text(encoding = "utf-8").splitlines() if "=" in line
+        )
+        assert written.get("studio") == expected, (
+            f"{event} publishes studio={written.get('studio')!r}, so the "
+            f"reporter gate reads the wrong answer"
+        )
+        assert ("--with-studio" in argv) is (expected == "true"), argv
+
+
+def test_the_studio_report_step_reads_that_output():
+    """The output above is only worth publishing if something gates on it."""
+    for job in DOC["jobs"].values():
+        for step in job.get("steps") or []:
+            if step.get("name") == "Report Studio":
+                assert "steps.build.outputs.studio == 'true'" in step["if"], step["if"]
+                return
+    raise AssertionError("the Studio reporter step is gone")

--- a/tests/kaggle/test_grpo_nightly.py
+++ b/tests/kaggle/test_grpo_nightly.py
@@ -330,9 +330,9 @@ def test_studio_rides_the_wired_set_and_only_the_wired_set(tmp_path):
         "build_kernel.py refuses outright"
     )
     per_pr, _, _ = _compose_argv("push", tmp_path)
-    assert "--with-studio" in per_pr, (
-        "no trigger packs Studio in any more, so the whole Studio payload runs nowhere"
-    )
+    assert (
+        "--with-studio" in per_pr
+    ), "no trigger packs Studio in any more, so the whole Studio payload runs nowhere"
     assert "--studio-args" in per_pr, per_pr
 
 

--- a/tests/kaggle/test_t4_ci_transport.py
+++ b/tests/kaggle/test_t4_ci_transport.py
@@ -2532,6 +2532,20 @@ def test_two_dispatches_can_hold_the_two_kaggle_slots_at_once():
         assert block["cancel-in-progress"] is False, scope
 
 
+def _build_step_body(source):
+    """The `Build the kernel notebooks` step, sliced by its NAME.
+
+    This used to slice from the first occurrence of the string
+    "build_kernel.py" anywhere in the file, which meant a comment mentioning
+    the script by name moved the window and the rules below started reading a
+    block of prose. That is a rule going red on a comment while the behaviour
+    it guards is untouched, and it is the shape that gets a check deleted
+    rather than read. The step's name is the stable anchor, and it is what
+    test_the_build_step_actually_packs_studio_in already uses.
+    """
+    return source.split("- name: Build the kernel notebooks")[1].split("- name:")[0]
+
+
 def test_the_shared_wheel_build_is_opt_in():
     """Measured once, attributable to nothing, so it ships behind a flag.
 
@@ -2546,7 +2560,7 @@ def test_the_shared_wheel_build_is_opt_in():
     workflow = yaml.safe_load(source)
     inputs = workflow[True]["workflow_dispatch"]["inputs"]
     assert inputs["shared_wheels"].get("default") is False, inputs["shared_wheels"]
-    build = source.split("build_kernel.py")[1].split("- name:")[0]
+    build = _build_step_body(source)
     assert "$SHARED_WHEELS" in build, build
     assert "'--shared-wheels'" in source
 
@@ -2600,7 +2614,7 @@ def test_the_workflow_can_actually_reach_studio_concurrent():
         "asking for the two-card coverage would silently get the shared shape"
     )
 
-    build = source.split("build_kernel.py")[1].split("- name:")[0]
+    build = _build_step_body(source)
     assert "$STUDIO_CONCURRENT" in build, (
         "the build command does not interpolate STUDIO_CONCURRENT, so the "
         "input cannot reach the kernel no matter what it is set to"

--- a/tests/kaggle/test_t4_ci_transport.py
+++ b/tests/kaggle/test_t4_ci_transport.py
@@ -2535,13 +2535,9 @@ def test_two_dispatches_can_hold_the_two_kaggle_slots_at_once():
 def _build_step_body(source):
     """The `Build the kernel notebooks` step, sliced by its NAME.
 
-    This used to slice from the first occurrence of the string
-    "build_kernel.py" anywhere in the file, which meant a comment mentioning
-    the script by name moved the window and the rules below started reading a
-    block of prose. That is a rule going red on a comment while the behaviour
-    it guards is untouched, and it is the shape that gets a check deleted
-    rather than read. The step's name is the stable anchor, and it is what
-    test_the_build_step_actually_packs_studio_in already uses.
+    Slicing from the first `build_kernel.py` in the file instead meant a
+    comment naming the script moved the window, and these rules went red on a
+    comment while the behaviour they guard was untouched.
     """
     return source.split("- name: Build the kernel notebooks")[1].split("- name:")[0]
 


### PR DESCRIPTION
## The nightly has never run

Every scheduled run of `kaggle-t4-notebook-ci.yml` that has ever existed failed in the same place, before touching Kaggle at all.

| run | when | died in |
|---|---|---|
| 33587255856 | 2026-09-02 03:29Z | `Build the kernel notebooks` |
| 33716011285 | 2026-09-03 04:42Z | `Build the kernel notebooks` |

```
::notice::running grpo,multi_gpu,latest_compile instead of the wired set
--with-studio requires --all-kernels
##[error]Process completed with exit code 1
```

The build step sets `LEG_LIST` on a schedule (`:906`), a leg list makes `KERNEL_SELECT="--legs ..."` (`:966`), and `--with-studio` was passed unconditionally (`:978`). `build_kernel.py:1792` refuses that pair outright, and it is right to: `--legs` builds one deliberately narrowed kernel, and hanging a ten-minute Studio install off it defeats the point of narrowing it.

So the schedule trigger and the hardcoded flag were mutually exclusive by construction. Nothing was red on any PR, because the combination only ever arises on a schedule.

## What was not running because of it

The nightly is where three legs live, each moved off the per-PR kernel for its own measured reason:

- **grpo** - an intermittent illegal memory access in vLLM's standby sleep on Turing, in 4 of 9 T4 sessions. A 44% red in front of every PR, for a race no reader can act on, is how a check gets switched off before the day it is right.
- **multi_gpu** - the only thing in either repo that exercises unsloth's `DEVICE_COUNT > 1` bindings. Every other leg is pinned to one card, so without it `torch_gpu_device`, the per-device rotary caches and the `CUDA_STREAMS` arrays are covered by nothing.
- **latest_compile** - gemma-4-E2B-it on the newest transformers and trl, which is the pairing that found unsloth-zoo #1103. At 12.73 GB peak it admits no co-tenant and its DONE record is 1323.0s, so it does not fit in the per-PR kernel's 776.3s of slack.

## The change

Studio is emitted only when no leg list is selected:

```bash
STUDIO=()
if [ -z "$LEG_LIST" ]; then
  STUDIO=(--with-studio --studio-args "--max-steps 8")
  if [ -n "$STUDIO_CONCURRENT" ]; then
    STUDIO+=("$STUDIO_CONCURRENT")
    echo "::notice title=Studio shares a card::..."
  fi
  echo "studio=true" >> "$GITHUB_OUTPUT"
else
  echo "::notice title=Studio is not in this kernel::..."
  echo "studio=false" >> "$GITHUB_OUTPUT"
fi
```

An array rather than a string, because `--studio-args "--max-steps 8"` is one argument with a space in it and word splitting would break it into two.

The per-PR path is byte for byte what it was: `--with-studio --studio-args "--max-steps 8" --studio-concurrent`, all three still passed, all three still switchable by their inputs.

## The Studio reporter is now told when Studio was not aboard

`kaggle_studio_ci/report.py` filters the launcher's reports down to the `studio-gpu` label, and `own_verdict` answers an EMPTY set with `partial`, carrying the notebook kernel's own reason. So an ungated reporter would print

```
### Unsloth GPU smoke: PARTIAL
```

on every nightly, describing a payload that was never in the kernel and quoting a reason belonging to the other half. That is not red, which is worse: it is a section that reads like a result. The build step publishes `studio` and `Report Studio` gates on it.

## Guards

Every existing rule in `tests/kaggle/test_grpo_nightly.py` reads the workflow as TEXT. Each was true the whole time the nightly did not run:

- a leg list replaces `--all-kernels` rather than filtering after it: true
- the build step packs Studio in: true
- the schedule bypasses the sampling gate: true

The two halves landed separately and no rule could see the other, so nothing asserted that the command line they compose TOGETHER is one the parser accepts. The new rules execute the build step's own shell body under `bash -e`, with `python` stubbed to record its argv, and then hand that argv to the real builder:

- the nightly command line is one the builder accepts
- the per-PR command line is one the builder accepts (the pair matters: narrowing one branch until it parses while breaking the other would satisfy the first rule alone)
- Studio rides the wired set and only the wired set, asserted in both directions
- `--studio-concurrent` still reaches the builder on the per-PR run
- `--studio-concurrent=false` actually removes the flag
- a leg-list dispatch is told Studio is not aboard
- an explicit `--legs` dispatch takes the same path as the nightly
- the build step publishes `studio`, and the reporter gates on it

Nine mutations, each reintroducing a distinct bug, all caught: the original unconditional `--with-studio`; Studio dropped from the per-PR run too; `--studio-concurrent` never added; the notice removed; the branch keyed on the wrong variable; the off switch bypassed; sharing off by default; the output not published; the output published as `true` on the nightly; the reporter gate dropped.

One further mutation was written and SURVIVED, correctly. Hoisting the flag literal out of the variable (`STUDIO+=(--studio-concurrent)`) leaves the same `[ -n "$STUDIO_CONCURRENT" ]` gate in front of it, so it is behaviour-preserving and a guard catching it would be asserting a spelling.

## One unrelated fragility fixed on the way

`test_t4_ci_transport.py` had two rules slicing the build step out of the workflow starting from the first occurrence of the string `build_kernel.py` ANYWHERE in the file. Adding a comment that names the script moved the window, and `test_the_shared_wheel_build_is_opt_in` started asserting against a block of prose. Both now slice by the step's NAME, which is the anchor the third rule in the same file already used. A rule that goes red on a comment while the behaviour it guards is untouched is one that gets deleted rather than read.

## Verification

- `python3 -m pytest tests/kaggle/ -q` - **921 passed**
- `actionlint .github/workflows/kaggle-t4-notebook-ci.yml` - clean, and clean on `main` for comparison
- `scripts/lint_workflow_triggers.py` - OK, 42 workflows
- `prepush_gate.py --worktree wt_nightlylegs` - PASS

A green tick on this PR does not prove the fix, since the failure only happens on a schedule. The proof is the guards building the nightly's real command line on CPU, plus the next 03:17 run getting past the build step.
