### PR TITLE
fix(studio): floor automatic ROCm torch to BNB compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3843,6 +3843,21 @@ _detect_rocm_version_tag() {
     printf '%s\n' "$_rt_best"
 }
 
+# The generic bitsandbytes ROCm wheel is built for the rocm6.4 ABI. Keep the
+# published ROCm leaf mapping in get_torch_index_url intact for explicit and
+# legacy callers, but floor automatic generic selections to this compatible tag.
+_ROCM_BNB_GENERIC_FLOOR_TAG="rocm6.4"
+_rocm_bnb_compatible_generic_tag() {
+    case "$1" in
+        rocm6.0|rocm6.0.*|rocm6.1|rocm6.1.*|rocm6.2|rocm6.2.*|rocm6.3|rocm6.3.*)
+            printf '%s\n' "$_ROCM_BNB_GENERIC_FLOOR_TAG"
+            ;;
+        *)
+            printf '%s\n' "$1"
+            ;;
+    esac
+}
+
 # ── Detect GPU and choose PyTorch index URL ──
 # Mirrors Get-TorchIndexUrl in install.ps1.
 # On CPU-only machines this returns the cpu index, avoiding the solver
@@ -3957,25 +3972,35 @@ get_torch_index_url() {
                     echo "[WARN]   UNSLOTH_TORCH_INDEX_URL=<full index URL>   (takes precedence, used verbatim)" >&2
                     echo "$_base/cpu"; return ;;
             esac
-            # Supported tags; 6.5+ clips to rocm6.4, 7.3+ caps to rocm7.2.
+            # Supported tags; automatic generic 6.0-6.3 selections floor to rocm6.4
+            # for bitsandbytes compatibility, 6.5+ clips to rocm6.4, and 7.3+
+            # caps to rocm7.2.
             # PyTorch publishes major.minor URLs only (no patch level), so
             # rocm7.2.1 / rocm6.0.2 / etc. must normalise to rocm7.2 / rocm6.0.
             case "$_rocm_tag" in
-                rocm6.0|rocm6.0.*) echo "$_base/rocm6.0" ;;
-                rocm6.1|rocm6.1.*) echo "$_base/rocm6.1" ;;
-                rocm6.2|rocm6.2.*) echo "$_base/rocm6.2" ;;
-                rocm6.3|rocm6.3.*) echo "$_base/rocm6.3" ;;
-                rocm6.4|rocm6.4.*) echo "$_base/rocm6.4" ;;
-                rocm7.0|rocm7.0.*) echo "$_base/rocm7.0" ;;
-                rocm7.1|rocm7.1.*) echo "$_base/rocm7.1" ;;
-                rocm7.2|rocm7.2.*) echo "$_base/rocm7.2" ;;
+                rocm6.0|rocm6.0.*) _rocm_selected_tag=rocm6.0 ;;
+                rocm6.1|rocm6.1.*) _rocm_selected_tag=rocm6.1 ;;
+                rocm6.2|rocm6.2.*) _rocm_selected_tag=rocm6.2 ;;
+                rocm6.3|rocm6.3.*) _rocm_selected_tag=rocm6.3 ;;
+                rocm6.4|rocm6.4.*) _rocm_selected_tag=rocm6.4 ;;
+                rocm7.0|rocm7.0.*) _rocm_selected_tag=rocm7.0 ;;
+                rocm7.1|rocm7.1.*) _rocm_selected_tag=rocm7.1 ;;
+                rocm7.2|rocm7.2.*) _rocm_selected_tag=rocm7.2 ;;
                 rocm6.*)
                     # ROCm 6.5+ (no published PyTorch wheels): clip down
                     # to the last supported 6.x wheel set.
-                    echo "$_base/rocm6.4" ;;
+                    _rocm_selected_tag=rocm6.4 ;;
                 *)
                     # ROCm 7.3+ (future): cap to rocm7.2 (latest known)
-                    echo "$_base/rocm7.2" ;;
+                    _rocm_selected_tag=rocm7.2 ;;
+            esac
+            # gfx906 deliberately stays on the literal rocm6.0-6.3 selection: its
+            # later legacy block (when the chosen tag is newer than rocm6.3) and
+            # its prebuilt-BNB skip must remain unchanged. Other automatic generic
+            # targets use the shared BNB ABI floor.
+            case "$_amd_gfx_probe" in
+                gfx906) echo "$_base/$_rocm_selected_tag" ;;
+                *) echo "$_base/$(_rocm_bnb_compatible_generic_tag "$_rocm_selected_tag")" ;;
             esac
             return
         fi

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -109,6 +109,24 @@ def _generic_pytorch_rocm_tag(ver: tuple[int, int]) -> str | None:
     )
 
 
+# The generic bitsandbytes ROCm wheel is currently built for the rocm6.4 ABI. Keep
+# the published host-to-index mapping above literal (callers may still explicitly
+# select an older leaf), but floor automatic generic installs so torch and bnb agree.
+_GENERIC_ROCM_BNB_COMPAT_FLOOR = (6, 4)
+_GENERIC_ROCM_BNB_COMPAT_TAG = "rocm6.4"
+
+
+def _automatic_generic_pytorch_rocm_tag(ver: tuple[int, int]) -> str | None:
+    """Generic tag for an automatic install, floored to the BNB-compatible ABI."""
+    tag = _generic_pytorch_rocm_tag(ver)
+    if tag is None:
+        return None
+    key = next((k for k, candidate in _ROCM_TORCH_INDEX.items() if candidate == tag), None)
+    if key is not None and key < _GENERIC_ROCM_BNB_COMPAT_FLOOR:
+        return _GENERIC_ROCM_BNB_COMPAT_TAG
+    return tag
+
+
 _ROCM_ARCH_INDEX_FLOOR = (7, 13)  # AMD per-arch index ships torch 2.11+rocm7.13
 
 
@@ -4205,6 +4223,12 @@ def _amd_torch_needs_dependency_pass() -> bool:
     # floor still needs the 7.13 fixes, and a sole gfx906 above rocm6.3 has no BLAS kernels.
     if _rocm_compat_reroute_pending(_tail_gfx, _tail_ver, _version.lower()):
         return True
+    # The generic bitsandbytes wheel is built for the rocm6.4 ABI. An automatic host therefore
+    # needs a torch reinstall when its existing generic wheel still names an older ABI;
+    # explicit pins, per-arch wheels, and gfx906 are excluded by the helper so their
+    # established routing remains authoritative.
+    if _generic_rocm_bnb_floor_pending(_tail_gfx, _detect_rocm_version(), _version.lower()):
+        return True
     return _rocm_torch_family_needs_repair(_tail_gfx, _detect_rocm_version(), _tail_host)
 
 
@@ -4257,6 +4281,38 @@ def _installed_generic_rocm_tag() -> "tuple[int, int] | None":
         return None
     _m = re.search(r"\+rocm(\d+)\.(\d+)", (_ver or "").lower())
     return (int(_m.group(1)), int(_m.group(2))) if _m else None
+
+
+def _generic_rocm_bnb_floor_pending(
+    runtime_gfx: "str | None", host_ver: "tuple[int, int] | None", installed_ver: str
+) -> bool:
+    """Whether an automatic generic torch install predates the generic BNB ABI floor.
+
+    This is deliberately separate from ``_generic_pytorch_rocm_tag``: the latter is the
+    literal host-to-published-index resolver and remains authoritative for explicit pins.
+    Per-architecture AMD wheels own their ROCm runtime, and gfx906 keeps its legacy
+    rocm6.3-or-older path, so neither is subject to the generic BNB floor.
+    """
+    if (
+        not runtime_gfx
+        or runtime_gfx.lower() == "gfx906"
+        or host_ver is None
+        or _explicit_torch_index_url() is not None
+    ):
+        return False
+    if _torch_requires_rocm_sdk():
+        return False
+    selected = _generic_pytorch_rocm_tag(host_ver)
+    if selected is None:
+        return False
+    _selected_match = re.fullmatch(r"rocm(\d+)\.(\d+)", selected.lower())
+    if _selected_match is None:
+        return False
+    _installed_match = re.search(r"\+rocm(\d+)\.(\d+)", (installed_ver or "").lower())
+    if _installed_match is None:
+        return False
+    _installed_ver = (int(_installed_match.group(1)), int(_installed_match.group(2)))
+    return _installed_ver < _GENERIC_ROCM_BNB_COMPAT_FLOOR
 
 
 def _rocm_torch_family_needs_repair(
@@ -4553,6 +4609,10 @@ def _ensure_rocm_torch() -> None:
     # for an arch the generic wheel carries no kernels for at all.
     _arch_index_url: "str | None" = None
     _arch_index_pkgs: "tuple[str, str, str] | None" = None
+    _runtime_gfx: "str | None" = None
+    gfx_codes: list[str] = []
+    _physical_gfx: "str | None" = None
+    _host_codes: list[str] = []
     # An explicit ROCm pin wins; otherwise both reroutes share one hardware probe. Skipped
     # once the inferred-arch install above has run: it resolves the same index, so re-deriving
     # it here only force-reinstalls what was just downloaded.
@@ -4809,6 +4869,23 @@ def _ensure_rocm_torch() -> None:
     # normalization, so asking it alone loses nothing, and ORing the override back in would
     # walk the no-GPU mask guard it applies above that read.
     _runtime_is_gfx906 = _runtime_target_is_gfx906()
+    # The generic bitsandbytes ROCm wheel targets the rocm6.4 ABI. Re-run the automatic
+    # generic torch selection when an existing generic wheel below that ABI would otherwise
+    # be paired with it. This is intentionally after the per-arch/missing-kernel routing and
+    # excludes explicit pins and gfx906's legacy path.
+    if (
+        rocm_torch_ready
+        and _rocm_pin is None
+        and not _inferred_arch_installed
+        and _arch_index_url is None
+        and not _runtime_is_gfx906
+        and _generic_rocm_bnb_floor_pending(_runtime_gfx, ver, _installed_torch_ver)
+    ):
+        _safe_print(
+            "   installed generic ROCm torch is below the rocm6.4 bitsandbytes ABI floor "
+            "-- reinstalling from the compatible generic index."
+        )
+        rocm_torch_ready = False
     # Reroute torch to the last gfx906-capable wheel family (rocm6.3) only when the
     # host ROCm version would otherwise pick a newer, kernel-less index -- and never
     # over an explicit pin or an active Strix reroute (the pin/Strix path installs
@@ -4886,7 +4963,14 @@ def _ensure_rocm_torch() -> None:
             index_url = _override_idx
             tag = _torch_index_leaf(index_url)
         else:
-            tag = _generic_pytorch_rocm_tag(ver)
+            # Automatic generic installs must use the ABI floor required by the
+            # generic bitsandbytes wheel. gfx906 is intentionally exempt: its
+            # legacy path remains on the literal rocm6.0-6.3 resolver.
+            tag = (
+                _generic_pytorch_rocm_tag(ver)
+                if _runtime_is_gfx906
+                else _automatic_generic_pytorch_rocm_tag(ver)
+            )
         if tag is None:
             _safe_print(
                 f"   No PyTorch wheel for ROCm {ver[0]}.{ver[1]} -- skipping torch reinstall"

--- a/tests/sh/test_get_torch_index_url.sh
+++ b/tests/sh/test_get_torch_index_url.sh
@@ -75,6 +75,9 @@ _FAKE_ROCM_DIR=$(mktemp -d)
     echo ""
     sed -n '/^_detect_rocm_version_tag()/,/^}/p' "$INSTALL_SH"
     echo ""
+    sed -n '/^_ROCM_BNB_GENERIC_FLOOR_TAG=/p' "$INSTALL_SH"
+    sed -n '/^_rocm_bnb_compatible_generic_tag()/,/^}/p' "$INSTALL_SH"
+    echo ""
     sed -n '/^get_torch_index_url()/,/^}/p' "$INSTALL_SH"
 } | sed -e "s|/usr/bin/nvidia-smi|$_FAKE_SMI_DIR/nvidia-smi-absent|g" \
       -e "s|/opt/rocm|$_FAKE_ROCM_DIR|g" \
@@ -82,7 +85,7 @@ _FAKE_ROCM_DIR=$(mktemp -d)
 
 for _fn in _rocm_tag_from_amd_smi _rocm_tag_from_version_file _rocm_tag_from_hipconfig \
            _rocm_tag_from_dpkg _rocm_tag_from_rpm _highest_rocm_tag \
-           _detect_rocm_version_tag get_torch_index_url; do
+           _detect_rocm_version_tag _rocm_bnb_compatible_generic_tag get_torch_index_url; do
     if ! grep -q "^$_fn()" "$_FUNC_FILE"; then
         echo "FAIL: install.sh no longer defines $_fn() at column 0"
         exit 1
@@ -162,11 +165,12 @@ MOCK
 # the GPU presence check (amd-smi list) also succeeds in tests.
 make_mock_amd_smi() {
     _dir=$(mktemp -d)
+    _gfx_arch="${2:-gfx1100}"
     cat > "$_dir/amd-smi" <<MOCK
 #!/bin/sh
 case "\$1" in
     list)
-        printf 'GPU: 0\\n  BDF: 0000:03:00.0\\n  NAME: gfx1100\\n'
+        printf 'GPU: 0\\n  BDF: 0000:03:00.0\\n  NAME: $_gfx_arch\\n'
         ;;
     *)
         cat <<AMD_OUT
@@ -266,10 +270,10 @@ _result=$(run_func "$_dir")
 assert_eq "unparseable -> cu126" "https://download.pytorch.org/whl/cu126" "$_result"
 rm -rf "$_dir"
 
-# 9) ROCm 6.3 (no nvidia-smi) -> rocm6.3
+# 9) ROCm 6.3 (no nvidia-smi) -> rocm6.4 for the generic BNB ABI floor
 _dir=$(make_mock_amd_smi "6.3")
 _result=$(run_func "$_dir")
-assert_eq "ROCm 6.3 -> rocm6.3" "https://download.pytorch.org/whl/rocm6.3" "$_result"
+assert_eq "ROCm 6.3 automatic generic floor -> rocm6.4" "https://download.pytorch.org/whl/rocm6.4" "$_result"
 rm -rf "$_dir"
 
 # 10) ROCm 7.1 (no nvidia-smi) -> rocm7.1
@@ -298,10 +302,28 @@ rm -rf "$_cuda_dir" "$_amd_dir" "$_combined_dir"
 _result=$(run_func "none")
 assert_eq "no GPU -> cpu" "https://download.pytorch.org/whl/cpu" "$_result"
 
-# 14) ROCm 6.1 (no nvidia-smi) -> rocm6.1
+# 14) ROCm 6.1 (no nvidia-smi) -> rocm6.4 for the generic BNB ABI floor
 _dir=$(make_mock_amd_smi "6.1")
 _result=$(run_func "$_dir")
-assert_eq "ROCm 6.1 -> rocm6.1" "https://download.pytorch.org/whl/rocm6.1" "$_result"
+assert_eq "ROCm 6.1 automatic generic floor -> rocm6.4" "https://download.pytorch.org/whl/rocm6.4" "$_result"
+rm -rf "$_dir"
+
+# 14a) The other old supported tags share the same automatic generic floor.
+_dir=$(make_mock_amd_smi "6.0")
+_result=$(run_func "$_dir")
+assert_eq "ROCm 6.0 automatic generic floor -> rocm6.4" "https://download.pytorch.org/whl/rocm6.4" "$_result"
+rm -rf "$_dir"
+
+_dir=$(make_mock_amd_smi "6.2")
+_result=$(run_func "$_dir")
+assert_eq "ROCm 6.2 automatic generic floor -> rocm6.4" "https://download.pytorch.org/whl/rocm6.4" "$_result"
+rm -rf "$_dir"
+
+# gfx906 is intentionally exempt from the generic floor; its later installer block
+# keeps the legacy rocm6.3 route for hosts whose detected tag is newer than 6.3.
+_dir=$(make_mock_amd_smi "6.1" "gfx906")
+_result=$(run_func "$_dir")
+assert_eq "gfx906 ROCm 6.1 keeps its legacy generic tag" "https://download.pytorch.org/whl/rocm6.1" "$_result"
 rm -rf "$_dir"
 
 # 15) ROCm 6.4 (no nvidia-smi) -> rocm6.4
@@ -344,10 +366,10 @@ _result=$(run_func "$_dir")
 assert_eq "N/A amd-smi version -> cpu" "https://download.pytorch.org/whl/cpu" "$_result"
 rm -rf "$_dir"
 
-# 20) ROCm version with trailing text (e.g. "6.3.1-beta") -> rocm6.3
+# 20) ROCm version with trailing text (e.g. "6.3.1-beta") -> rocm6.4 floor
 _dir=$(make_mock_amd_smi "6.3.1-beta")
 _result=$(run_func "$_dir")
-assert_eq "ROCm 6.3.1-beta -> rocm6.3" "https://download.pytorch.org/whl/rocm6.3" "$_result"
+assert_eq "ROCm 6.3.1-beta automatic generic floor -> rocm6.4" "https://download.pytorch.org/whl/rocm6.4" "$_result"
 rm -rf "$_dir"
 
 # 22) CUDA 12.6 still works after ROCm changes (regression check)
@@ -562,6 +584,12 @@ assert_eq "url override trailing slash stripped" "https://mirror.example.com/whl
 # 44) URL override takes precedence over family override.
 _result=$(UNSLOTH_TORCH_INDEX_URL="https://mirror.example.com/whl/cu130" UNSLOTH_TORCH_INDEX_FAMILY="cu128" run_func "none")
 assert_eq "url override beats family override -> url" "https://mirror.example.com/whl/cu130" "$_result"
+
+# 44a) Explicit ROCm pins remain authoritative and are not floored.
+_result=$(UNSLOTH_TORCH_INDEX_FAMILY="rocm6.1" run_func "none")
+assert_eq "explicit ROCm family pin remains rocm6.1" "https://download.pytorch.org/whl/rocm6.1" "$_result"
+_result=$(UNSLOTH_TORCH_INDEX_URL="https://download.pytorch.org/whl/rocm6.1" run_func "none")
+assert_eq "explicit ROCm URL pin remains rocm6.1" "https://download.pytorch.org/whl/rocm6.1" "$_result"
 
 # 45) An empty override is ignored (falls through to normal detection).
 _result=$(UNSLOTH_TORCH_INDEX_FAMILY="" UNSLOTH_TORCH_INDEX_URL="" run_func "none")

--- a/tests/sh/test_rocm_no_version_arch_route.sh
+++ b/tests/sh/test_rocm_no_version_arch_route.sh
@@ -66,6 +66,9 @@ _FAKE_PROC_NV_DIR=$(mktemp -d)
     echo ""
     sed -n '/^_detect_rocm_version_tag()/,/^}/p' "$INSTALL_SH"
     echo ""
+    sed -n '/^_ROCM_BNB_GENERIC_FLOOR_TAG=/p' "$INSTALL_SH"
+    sed -n '/^_rocm_bnb_compatible_generic_tag()/,/^}/p' "$INSTALL_SH"
+    echo ""
     sed -n '/^get_torch_index_url()/,/^}/p' "$INSTALL_SH"
 } | sed -e "s|/usr/bin/nvidia-smi|$_FAKE_SMI_DIR/nvidia-smi-absent|g" \
       -e "s|/proc/driver/nvidia|$_FAKE_PROC_NV_DIR|g" \
@@ -73,7 +76,7 @@ _FAKE_PROC_NV_DIR=$(mktemp -d)
   > "$_FUNC_FILE"
 
 for _fn in _rocm_sdk_install_hint _rocm_tag_from_hipconfig _rocm_tag_from_rpm \
-           _detect_rocm_version_tag _amd_arch_index_family_for_gfx get_torch_index_url; do
+           _detect_rocm_version_tag _rocm_bnb_compatible_generic_tag _amd_arch_index_family_for_gfx get_torch_index_url; do
     if ! grep -q "^$_fn()" "$_FUNC_FILE"; then
         echo "  FAIL: install.sh no longer defines $_fn() at column 0"
         exit 1

--- a/tests/sh/test_rocm_version_source_disagreement.sh
+++ b/tests/sh/test_rocm_version_source_disagreement.sh
@@ -73,6 +73,9 @@ _FAKE_PROC_NV_DIR=$(mktemp -d)
     echo ""
     sed -n '/^_detect_rocm_version_tag()/,/^}/p' "$INSTALL_SH"
     echo ""
+    sed -n '/^_ROCM_BNB_GENERIC_FLOOR_TAG=/p' "$INSTALL_SH"
+    sed -n '/^_rocm_bnb_compatible_generic_tag()/,/^}/p' "$INSTALL_SH"
+    echo ""
     sed -n '/^get_torch_index_url()/,/^}/p' "$INSTALL_SH"
     echo ""
     sed -n '/^_radeon_host_ver_not_older()/,/^}/p' "$INSTALL_SH"
@@ -87,7 +90,7 @@ _FAKE_PROC_NV_DIR=$(mktemp -d)
 # below fail as a plain "cpu" with no hint why.
 for _fn in _rocm_tag_from_amd_smi _rocm_tag_from_version_file _rocm_tag_from_hipconfig \
            _rocm_tag_from_dpkg _rocm_tag_from_rpm _highest_rocm_tag \
-           _detect_rocm_version_tag get_torch_index_url get_radeon_wheel_url \
+           _detect_rocm_version_tag _rocm_bnb_compatible_generic_tag get_torch_index_url get_radeon_wheel_url \
            _radeon_host_ver_not_older; do
     if ! grep -q "^$_fn()" "$_FUNC_FILE"; then
         echo "  FAIL: install.sh no longer defines $_fn() at column 0"
@@ -364,7 +367,7 @@ echo "=== test_rocm_version_source_disagreement ==="
 reset_sources
 add_hipconfig "5.7.31921-0"
 add_dpkg_hsa_runtime "1:6.1.2-1"
-assert_eq "Debian 13 hipconfig 5.7 + HSA runtime 6.1 -> rocm6.1" "$_BASE/rocm6.1" "$(run_index)"
+assert_eq "Debian 13 hipconfig 5.7 + HSA runtime 6.1 -> automatic rocm6.4 floor" "$_BASE/rocm6.4" "$(run_index)"
 _warn=$(run_warnings)
 case "$_warn" in
     *"require ROCm 6.0+"*) assert_eq "the same host emits no 6.0+ gate warning" "" "$_warn" ;;
@@ -381,8 +384,8 @@ reset_sources
 add_dpkg_packages \
     "libhsa-runtime64-1|installed|6.4.3+dfsg-4" \
     "rocm-core|installed|1:6.1.2-2"
-assert_eq "installed rocm-core outranks a HIGHER distro HSA reading -> rocm6.1" \
-    "$_BASE/rocm6.1" "$(run_index)"
+assert_eq "installed rocm-core outranks a HIGHER distro HSA reading -> automatic rocm6.4 floor" \
+    "$_BASE/rocm6.4" "$(run_index)"
 assert_eq "and the outranked HSA reading is not named as a disagreement" "" "$(run_warnings)"
 
 reset_sources
@@ -395,21 +398,21 @@ assert_eq "Ubuntu + AMD repo warns about nothing" "" "$(run_warnings)"
 reset_sources
 add_hipconfig "5.7.31921-0"
 add_dpkg_hsa_runtime "1:6.1.2-1"
-assert_eq "no rocm-core, so the installed HSA runtime still votes -> rocm6.1" \
-    "$_BASE/rocm6.1" "$(run_index)"
+assert_eq "no rocm-core, so the installed HSA runtime still votes -> automatic rocm6.4 floor" \
+    "$_BASE/rocm6.4" "$(run_index)"
 
 # 2. Same shape from /opt/rocm/.info/version. This one already worked by position,
 #    so it is here to pin that the rewrite did not lose it.
 reset_sources
 add_hipconfig "5.7.31921-0"
 add_version_file "6.1.2-98"
-assert_eq "hipconfig 5.7 + version file 6.1 -> rocm6.1" "$_BASE/rocm6.1" "$(run_index)"
+assert_eq "hipconfig 5.7 + version file 6.1 -> automatic rocm6.4 floor" "$_BASE/rocm6.4" "$(run_index)"
 
 # 3. And from rpm, the last source in the order.
 reset_sources
 add_hipconfig "5.7.31921-0"
 add_rpm_rocm_core "6.3.0"
-assert_eq "hipconfig 5.7 + rocm-core 6.3 (rpm) -> rocm6.3" "$_BASE/rocm6.3" "$(run_index)"
+assert_eq "hipconfig 5.7 + rocm-core 6.3 (rpm) -> automatic rocm6.4 floor" "$_BASE/rocm6.4" "$(run_index)"
 
 # 4. Not only a floor problem: amd-smi answering first with a lower version must
 #    not shadow a newer runtime either.
@@ -436,15 +439,15 @@ assert_eq "agreeing sources emit no disagreement breadcrumb" "" "$(run_warnings)
 reset_sources
 add_hipconfig "6.1.40093-0"
 add_dpkg_rocm_core "1:7.0.0-1" config-files
-assert_eq "config-files rocm-core 7.0 on a 6.1 host -> rocm6.1, not rocm7.0" \
-    "$_BASE/rocm6.1" "$(run_index)"
+assert_eq "config-files rocm-core 7.0 on a 6.1 host -> automatic rocm6.4 floor, not rocm7.0" \
+    "$_BASE/rocm6.4" "$(run_index)"
 assert_eq "the dead dpkg entry is not even named as a disagreement" "" "$(run_warnings)"
 
 reset_sources
 add_hipconfig "6.1.40093-0"
 add_dpkg_hsa_runtime "1:7.0.0-1" config-files
-assert_eq "config-files HSA runtime 7.0 on a 6.1 host -> rocm6.1, not rocm7.0" \
-    "$_BASE/rocm6.1" "$(run_index)"
+assert_eq "config-files HSA runtime 7.0 on a 6.1 host -> automatic rocm6.4 floor, not rocm7.0" \
+    "$_BASE/rocm6.4" "$(run_index)"
 assert_eq "the dead HSA entry is not named as a disagreement" "" "$(run_warnings)"
 
 # 5c. The live entry still has to win, or the fix for the reported bug is gone.
@@ -452,8 +455,8 @@ assert_eq "the dead HSA entry is not named as a disagreement" "" "$(run_warnings
 reset_sources
 add_hipconfig "5.7.31921-0"
 add_dpkg_rocm_core "1:6.1.2-1" installed
-assert_eq "installed rocm-core 6.1 still beats hipconfig 5.7 -> rocm6.1" \
-    "$_BASE/rocm6.1" "$(run_index)"
+assert_eq "installed rocm-core 6.1 still beats hipconfig 5.7 -> automatic rocm6.4 floor" \
+    "$_BASE/rocm6.4" "$(run_index)"
 
 # 5d. The states an interrupted dpkg operation leaves behind are not "installed"
 #     either, and none of them describes a runtime the GPU can use.
@@ -461,8 +464,8 @@ for _dead in config-files half-installed unpacked half-configured; do
     reset_sources
     add_hipconfig "6.1.40093-0"
     add_dpkg_rocm_core "1:7.2.0-1" "$_dead"
-    assert_eq "dpkg state '$_dead' at 7.2 does not select wheels -> rocm6.1" \
-        "$_BASE/rocm6.1" "$(run_index)"
+    assert_eq "dpkg state '$_dead' at 7.2 does not select wheels -> automatic rocm6.4 floor" \
+        "$_BASE/rocm6.4" "$(run_index)"
 done
 
 # ── 5e. A stale-HIGH reading in each source position, one at a time ─────────
@@ -550,12 +553,13 @@ assert_contains "unparseable sources are treated as no version at all" \
 reset_sources
 add_hipconfig "0.0.0"
 add_version_file "6.2.0-1"
-assert_eq "major-0 source ignored, 6.2 wins -> rocm6.2" "$_BASE/rocm6.2" "$(run_index)"
+assert_eq "major-0 source ignored, 6.2 wins -> automatic rocm6.4 floor" "$_BASE/rocm6.4" "$(run_index)"
 
-# ── 12. Supported-tag normalisation is unchanged ────────────────────────────
+# ── 12. Supported-tag normalisation and the automatic BNB floor ─────────────
 # PyTorch publishes major.minor index leaves only, so patch levels normalise;
-# 6.5+ clips to the last 6.x wheel set and 7.3+ caps to the latest known.
-for _case in "6.0.2:rocm6.0" "6.1.3:rocm6.1" "6.2.4:rocm6.2" "6.3.1:rocm6.3" \
+# automatic generic 6.0-6.3 hosts floor to rocm6.4, while 6.5+ clips to the
+# last 6.x wheel set and 7.3+ caps to the latest known.
+for _case in "6.0.2:rocm6.4" "6.1.3:rocm6.4" "6.2.4:rocm6.4" "6.3.1:rocm6.4" \
              "6.4.1:rocm6.4" "7.0.1:rocm7.0" "7.1.0:rocm7.1" "7.2.1:rocm7.2" \
              "6.5.0:rocm6.4" "6.9.0:rocm6.4" "7.3.0:rocm7.2" "8.0.0:rocm7.2"; do
     _ver="${_case%%:*}"
@@ -590,7 +594,7 @@ reset_sources
 add_amd_smi_line "N/A"
 add_version_file "6.1.3-42"
 assert_eq "amd-smi N/A beside amdgpu 6.10 does not outvote a real 6.1" \
-    "$_BASE/rocm6.1" "$(run_index)"
+    "$_BASE/rocm6.4" "$(run_index)"
 
 # ── 14. A wedged rpmdb must not hang the installer ─────────────────────────
 # Highest-wins short-circuits nothing, so `rpm -q` now always runs where it used to

--- a/tests/studio/install/test_amd_fastpath_probe.py
+++ b/tests/studio/install/test_amd_fastpath_probe.py
@@ -141,6 +141,124 @@ def test_a_rocm_wheel_keeps_the_fast_path(monkeypatch, torch):
     assert _needs_pass() is False
 
 
+@pytest.mark.parametrize("rocm_ver", [(6, 0), (6, 1), (6, 2), (6, 3)])
+def test_automatic_generic_torch_uses_the_bnb_compatibility_floor(monkeypatch, rocm_ver):
+    """Fresh automatic generic installs floor old host ROCm tags to rocm6.4."""
+    _host(monkeypatch, torch = ("2.6.0+cpu", ""), gfx = ("gfx1100",), rocm_ver = rocm_ver)
+    installs = _repair_installs(monkeypatch)
+    assert installs == ["https://download.pytorch.org/whl/rocm6.4"]
+
+
+@pytest.mark.parametrize(
+    "rocm_ver, expected",
+    [
+        ((6, 4), "rocm6.4"),
+        ((7, 0), "rocm7.0"),
+        ((7, 1), "rocm7.1"),
+        ((7, 2), "rocm7.2"),
+    ],
+)
+def test_automatic_generic_torch_keeps_newer_published_families(monkeypatch, rocm_ver, expected):
+    _host(monkeypatch, torch = ("2.6.0+cpu", ""), gfx = ("gfx1100",), rocm_ver = rocm_ver)
+    installs = _repair_installs(monkeypatch)
+    assert installs == [f"https://download.pytorch.org/whl/{expected}"]
+
+
+@pytest.mark.parametrize("rocm_ver", [(6, 0), (6, 1), (6, 2), (6, 3)])
+def test_stale_automatic_generic_rocm_torch_escapes_the_update_fast_path(monkeypatch, rocm_ver):
+    _host(
+        monkeypatch,
+        torch = (f"2.6.0+rocm{rocm_ver[0]}.{rocm_ver[1]}", f"{rocm_ver[0]}.{rocm_ver[1]}"),
+        gfx = ("gfx1100",),
+        rocm_ver = rocm_ver,
+    )
+    assert _needs_pass() is True
+    installs = _repair_installs(monkeypatch)
+    assert installs == ["https://download.pytorch.org/whl/rocm6.4"]
+
+
+@pytest.mark.parametrize(
+    "rocm_ver, installed_tag",
+    [((6, 4), "6.3"), ((7, 0), "6.1")],
+)
+def test_old_generic_tag_is_repaired_even_when_host_selects_newer_rocm(
+    monkeypatch, rocm_ver, installed_tag
+):
+    _host(
+        monkeypatch,
+        torch = (f"2.6.0+rocm{installed_tag}", installed_tag),
+        gfx = ("gfx1100",),
+        rocm_ver = rocm_ver,
+    )
+    assert _needs_pass() is True
+
+
+@pytest.mark.parametrize(
+    "rocm_ver, installed",
+    [
+        ((6, 4), "2.6.0+rocm6.4"),
+        ((7, 0), "2.9.0+rocm7.0"),
+        ((7, 1), "2.10.0+rocm7.1"),
+        ((7, 2), "2.11.0+rocm7.2"),
+    ],
+)
+def test_compatible_automatic_generic_rocm_torch_keeps_the_fast_path(
+    monkeypatch, rocm_ver, installed
+):
+    _host(
+        monkeypatch,
+        torch = (installed, installed.split("+rocm", 1)[-1]),
+        gfx = ("gfx1100",),
+        rocm_ver = rocm_ver,
+    )
+    assert _needs_pass() is False
+    installs = _repair_installs(monkeypatch)
+    assert installs == []
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {"UNSLOTH_TORCH_INDEX_FAMILY": "rocm6.1"},
+        {"UNSLOTH_TORCH_INDEX_URL": "https://download.pytorch.org/whl/rocm6.1"},
+    ],
+)
+def test_explicit_rocm6_1_pins_remain_authoritative(monkeypatch, env):
+    _host(
+        monkeypatch,
+        torch = ("2.6.0+cpu", ""),
+        gfx = ("gfx1100",),
+        rocm_ver = (6, 1),
+        env = env,
+    )
+    installs = _repair_installs(monkeypatch)
+    assert installs == ["https://download.pytorch.org/whl/rocm6.1"]
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {"UNSLOTH_TORCH_INDEX_FAMILY": "rocm6.1"},
+        {"UNSLOTH_TORCH_INDEX_URL": "https://download.pytorch.org/whl/rocm6.1"},
+    ],
+)
+def test_explicit_rocm6_1_build_is_not_marked_stale(monkeypatch, env):
+    _host(
+        monkeypatch,
+        torch = ("2.6.0+rocm6.1", "6.1"),
+        gfx = ("gfx1100",),
+        rocm_ver = (6, 1),
+        env = env,
+    )
+    assert _needs_pass() is False
+
+
+def test_gfx906_legacy_torch_routing_is_not_floored_to_generic_bnb_rocm6_4(monkeypatch):
+    _host(monkeypatch, torch = ("2.6.0+cpu", ""), gfx = ("gfx906",), rocm_ver = (6, 4))
+    installs = _repair_installs(monkeypatch)
+    assert installs == ["https://download.pytorch.org/whl/rocm6.3"]
+
+
 @pytest.mark.parametrize("gfx", ["gfx1150", "gfx1151"])
 def test_a_strix_host_on_a_wheel_without_its_kernels_forces_the_pass(monkeypatch, gfx):
     """rocm6.4 does not carry gfx1150/gfx1151 (AMD dates support to 7.1), and

--- a/tests/studio/install/test_missing_kernel_arch_routing_9396.py
+++ b/tests/studio/install/test_missing_kernel_arch_routing_9396.py
@@ -1564,9 +1564,10 @@ def test_a_floor_leaf_still_repairs_a_sub_211_build_of_its_own_family():
 
 def test_a_generic_only_target_gets_its_tag_floor_on_a_fresh_install_too():
     """gfx950 has no AMD per-arch leaf, so the only way to give it kernels is a generic tag
-    that carries it (rocm7.0+). That floor was applied solely to a host already on ROCm wheels
-    that had to be demoted, so a fresh install or a CPU/CUDA torch walked past it and a stale
-    /opt/rocm put the card on rocm6.3. Which tag carries an arch is a fact about the arch."""
+    that carries it (rocm7.0+), so its architecture floor still chooses rocm7.2 on ROCm6.3.
+    Automatic generic installs for covered arches also honor the BNB floor: a fresh CPU/CUDA
+    install for gfx1100 on that host uses rocm6.4 instead of the stale rocm6.3 tag. Which tag
+    carries an arch is a fact about the arch."""
     for _probe in (_CPU_TORCH, None):
         calls = _run_install(
             gfx_devices = ("gfx950",),
@@ -1582,8 +1583,9 @@ def test_a_generic_only_target_gets_its_tag_floor_on_a_fresh_install_too():
         torch_probe = _CPU_TORCH,
         torch_owns_rocm = False,
     )
-    # An arch the generic wheel serves at every tag is untouched: no floor to apply.
-    assert f"{_GENERIC}6.3" in _run_install(
+    # An arch the generic wheel serves at every tag has no architecture floor, but automatic
+    # generic installs still honor the bitsandbytes compatibility floor.
+    assert f"{_GENERIC}6.4" in _run_install(
         gfx_devices = ("gfx1100",),
         rocm_version = (6, 3),
         torch_probe = _CPU_TORCH,
@@ -1705,10 +1707,9 @@ def test_a_generic_only_target_installs_when_the_rocm_version_is_unreadable():
 
 
 def test_a_generic_only_target_pinned_to_a_stale_tag_is_reinstalled():
-    """Forcing the pass is half a repair: a generic build names no family, so the family arm
-    declines, there is no per-arch index to move to, and torch.version.hip keeps the fallback
-    from running. A gfx950 pinned to rocm6.3 survived every update, and the preflight asked
-    for a pass the install refused."""
+    """An automatically selected generic +rocm6.3 build is below the bitsandbytes floor, so a
+    gfx1100 host on ROCm7.2 is repaired to the generic rocm7.2 family. Compatible generic
+    builds still remain untouched, including the generic-only gfx950 controls above."""
     for _ver in ((7, 2), None):
         assert f"{_GENERIC}7.2" in _run_install(
             gfx_devices = ("gfx950",),
@@ -1725,11 +1726,11 @@ def test_a_generic_only_target_pinned_to_a_stale_tag_is_reinstalled():
             torch_owns_rocm = False,
         )
         assert "torch" not in _kept, (_ver, _kept)
-    # So is an arch the generic wheel serves at every tag.
+    # An arch the generic wheel serves at every tag still repairs a stale generic ABI tag.
     _served = _run_install(
         gfx_devices = ("gfx1100",),
         rocm_version = (7, 2),
         torch_probe = _ROCM_GENERIC_TORCH_63,
         torch_owns_rocm = False,
     )
-    assert "torch" not in _served, _served
+    assert f"{_GENERIC}7.2" in _served, _served

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -1160,7 +1160,7 @@ class TestEnsureRocmTorch:
     @patch.object(stack_mod, "_has_rocm_gpu", return_value = True)
     @patch.object(stack_mod, "_detect_rocm_version", return_value = (6, 3))
     def test_rocm_63_selects_correct_tag(self, mock_ver, mock_gpu, mock_nvidia, mock_pip):
-        """ROCm 6.3 should select rocm6.3 tag."""
+        """Automatic generic ROCm 6.3 installs use the bitsandbytes-compatible floor."""
         mock_probe = MagicMock()
         mock_probe.returncode = 0
         mock_probe.stdout = "\n"
@@ -1168,7 +1168,7 @@ class TestEnsureRocmTorch:
             with patch("subprocess.run", return_value = mock_probe):
                 _ensure_rocm_torch()
         torch_call = mock_pip.call_args_list[0]
-        assert "rocm6.3" in str(torch_call)
+        assert "rocm6.4" in str(torch_call)
 
     @patch.object(stack_mod, "pip_install")
     @patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False)
@@ -2240,6 +2240,54 @@ class TestRocmTorchIndex:
         )
         assert tag == "rocm6.4"
 
+    @pytest.mark.parametrize(
+        "ver, published, automatic",
+        [
+            ((6, 0), "rocm6.0", "rocm6.4"),
+            ((6, 1), "rocm6.1", "rocm6.4"),
+            ((6, 2), "rocm6.2", "rocm6.4"),
+            ((6, 3), "rocm6.3", "rocm6.4"),
+            ((6, 4), "rocm6.4", "rocm6.4"),
+            ((7, 0), "rocm7.0", "rocm7.0"),
+            ((7, 1), "rocm7.1", "rocm7.1"),
+            ((7, 2), "rocm7.2", "rocm7.2"),
+        ],
+    )
+    def test_automatic_generic_tag_adds_only_the_bnb_floor(self, ver, published, automatic):
+        assert stack_mod._generic_pytorch_rocm_tag(ver) == published
+        assert stack_mod._automatic_generic_pytorch_rocm_tag(ver) == automatic
+
+    def test_shell_and_python_automatic_floor_are_in_parity(self):
+        """The install.sh helper must floor exactly the same old generic tags as Python."""
+        source = _INSTALL_SH_PATH.read_text(encoding = "utf-8")
+        constant = re.search(r"^_ROCM_BNB_GENERIC_FLOOR_TAG=.*$", source, re.M)
+        helper = _extract_sh_function_body(source, "_rocm_bnb_compatible_generic_tag")
+        assert constant and helper
+        shell = shutil.which("sh")
+        if not shell:
+            pytest.skip("POSIX shell needed for resolver parity")
+        tags = tuple(_ROCM_TORCH_INDEX.values())
+        script = (
+            "set -eu\n"
+            + constant.group(0)
+            + "\n"
+            + helper
+            + "\n"
+            + "for tag in "
+            + " ".join(tags)
+            + "; do _rocm_bnb_compatible_generic_tag \"$tag\"; done\n"
+        )
+        result = subprocess.run([shell, "-c", script], capture_output = True, text = True)
+        assert result.returncode == 0, result.stderr
+        shell_tags = result.stdout.splitlines()
+        python_tags = [
+            stack_mod._automatic_generic_pytorch_rocm_tag(ver)
+            for ver, tag in _ROCM_TORCH_INDEX.items()
+            if tag in tags
+        ]
+        # The dict is ordered newest-first, as is the shell input above.
+        assert shell_tags == python_tags
+
 
 # TEST: hardware.py -- IS_ROCM flag and detect_hardware
 
@@ -2720,7 +2768,8 @@ class TestInstallShStructure:
         """ROCm 7.2 should pass through directly; 7.3+ falls back to rocm7.2."""
         sh_path = PACKAGE_ROOT / "install.sh"
         source = sh_path.read_text(encoding = "utf-8")
-        assert 'echo "$_base/rocm7.2"' in source  # fallback for unknown future versions
+        assert "_rocm_selected_tag=rocm7.2" in source  # fallback for unknown future versions
+        assert "_rocm_bnb_compatible_generic_tag" in source
         assert "rocm6.*" in source
         assert "rocm7.0" in source
         assert "rocm7.1" in source
@@ -3111,6 +3160,8 @@ class TestInstallShStructure:
         fn = _extract_sh_function_body(source, "get_torch_index_url")
         probe_fn = _extract_sh_function_body(source, "_probe_amd_gfx_arch")
         family_fn = _extract_sh_function_body(source, "_amd_arch_index_family_for_gfx")
+        bnb_floor_constant = re.search(r"^_ROCM_BNB_GENERIC_FLOOR_TAG=.*$", source, re.M)
+        bnb_floor_fn = _extract_sh_function_body(source, "_rocm_bnb_compatible_generic_tag")
         arch_fns = "\n".join(
             _extract_sh_function_body(source, _n)
             for _n in (
@@ -3135,7 +3186,7 @@ class TestInstallShStructure:
                 "_detect_rocm_version_tag",
             )
         ]
-        assert fn and probe_fn and family_fn and arch_fns
+        assert fn and probe_fn and family_fn and arch_fns and bnb_floor_constant and bnb_floor_fn
         assert all(version_fns), "ROCm version helpers not found in install.sh"
         with tempfile.TemporaryDirectory() as d:
             # Neutralise the host's real ROCm: the version chain reads
@@ -3173,6 +3224,10 @@ class TestInstallShStructure:
                 + arch_fns
                 + "\n"
                 + "\n".join(version_fns)
+                + "\n"
+                + bnb_floor_constant.group(0)
+                + "\n"
+                + bnb_floor_fn
                 + "\n"
                 + fn
                 + "\n"

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -2275,7 +2275,7 @@ class TestRocmTorchIndex:
             + "\n"
             + "for tag in "
             + " ".join(tags)
-            + "; do _rocm_bnb_compatible_generic_tag \"$tag\"; done\n"
+            + '; do _rocm_bnb_compatible_generic_tag "$tag"; done\n'
         )
         result = subprocess.run([shell, "-c", script], capture_output = True, text = True)
         assert result.returncode == 0, result.stderr

--- a/tests/studio/install/test_unsupported_arch_routing_guards_8529.py
+++ b/tests/studio/install/test_unsupported_arch_routing_guards_8529.py
@@ -238,6 +238,11 @@ _detect_rocm_version_tag() { [ -n "${_STUB_ROCM_TAG:-}" ] && printf '%s\\n' "$_S
 def _run_sh_get_torch_index_url(arch: str, rocm_tag: str = "") -> "tuple[str, str]":
     """Run install.sh's real get_torch_index_url with UNSLOTH_ROCM_GFX_ARCH=arch."""
     src = _INSTALL_SH.read_text(encoding = "utf-8")
+    # The automatic generic arm in get_torch_index_url calls this production helper. Keep
+    # the isolated shell harness sourced from install.sh rather than copying its policy here.
+    bnb_floor_constant = re.search(r"^_ROCM_BNB_GENERIC_FLOOR_TAG=.*$", src, re.MULTILINE)
+    bnb_floor_fn = _sh_function_body(src, "_rocm_bnb_compatible_generic_tag")
+    assert bnb_floor_constant and bnb_floor_fn
     script = (
         _sh_function_body(src, "_amd_arch_index_family_for_gfx")
         + "\n"
@@ -246,6 +251,10 @@ def _run_sh_get_torch_index_url(arch: str, rocm_tag: str = "") -> "tuple[str, st
         + _sh_function_body(src, "_amd_agreed_index_family")
         + "\n"
         + _sh_function_body(src, "_amd_sole_index_arch")
+        + "\n"
+        + bnb_floor_constant.group(0)
+        + "\n"
+        + bnb_floor_fn
         + "\n"
         + _sh_function_body(src, "get_torch_index_url")
         + "\n"


### PR DESCRIPTION
## Summary

Fixes #10273.

On Linux x86_64 AMD hosts, Studio could automatically select a generic PyTorch ROCm 6.0–6.3 wheel family while the bitsandbytes package installed by Studio only carries generic ROCm native libraries starting at ROCm 6.4. In the reported gfx1100 case, Studio installed `torch 2.6.0+rocm6.1`; bitsandbytes then warned that no ROCm 6.1 binary existed and fell forward to its ROCm 6.4 library immediately before the training backend exited with SIGSEGV.

This patch keeps published PyTorch ROCm index availability separate from the bitsandbytes compatibility policy and floors only **automatic generic Linux AMD routing** to `rocm6.4` when the detected host ROCm version is 6.0–6.3.

It also makes `unsloth studio update` repair an already-installed automatic generic `+rocm6.0`–`+rocm6.3` torch environment instead of staying on the update fast path.

## Preserved behavior

- Explicit `UNSLOTH_TORCH_INDEX_FAMILY` and full index URL pins remain authoritative, including explicit `rocm6.1` pins.
- The published `rocm6.0`–`rocm6.3` mappings remain available rather than being removed globally.
- gfx906 keeps its intentional legacy `rocm6.3` route and generic bitsandbytes skip.
- Existing Strix/per-arch AMD routing is preserved.
- Windows behavior is unchanged.
- Automatic ROCm 6.4 / 7.0 / 7.1 / 7.2 routing remains unchanged.

## Regression coverage

Added Python, shell, and shell/Python parity coverage for:

- automatic gfx1100 ROCm 6.0–6.3 -> `rocm6.4`
- automatic 6.4+ routing remaining unchanged
- explicit ROCm 6.1 family and full-URL pins remaining authoritative
- gfx906 legacy routing and BNB skip
- stale generic `+rocm6.0`–`+rocm6.3` escaping the Studio update fast path
- the actual stale-wheel repair path installing from the `rocm6.4` family
- compatible `+rocm6.4` avoiding a pointless reinstall
- shell/Python policy parity

## Validation

- `tests/studio/install/test_amd_fastpath_probe.py`: **108 passed**
- targeted stale/compatible repair tests: **8 passed**
- ROCm shell suites: **69 passed**, **74 passed**, and no-version route **42 passed**
- full ROCm suite: **487 passed, 17 skipped**; 11 remaining failures are existing/mock-environment failures where `SKIP_STUDIO_BASE=1` leaves `unsloth` absent for the unchanged final core-package presence check
- syntax checks: passed
- `git diff --check`: passed

## Hardware evidence

The reported machine is a gfx1100 / RX 7900 XTX system. A prior successful training run on the same machine used `torch 2.10.0+rocm7.1` / HIP 7.1 and completed 36 steps / 2 epochs, while the broken 0.1.806-beta environment used `torch 2.6.0+rocm6.1` with a bitsandbytes wheel lacking `libbitsandbytes_rocm61.so`.

This patch addresses the installer/update compatibility mismatch. The secondary frontend behavior described in #10273, where the UI can remain waiting on a start request after a backend crash/restart, is intentionally not changed here.