### PR TITLE
Studio: skip the thread fetch for ids the client knows are local-only

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -49,6 +49,7 @@ import {
 } from "./gguf-variants-request";
 import { assertCompletedPaddedBody } from "./padded-response";
 import { maxTokensIsTheLimit } from "./generation-length.ts";
+import { isAssistantLocalThreadId } from "../utils/thread-ids";
 
 export const CHAT_HISTORY_UPDATED_EVENT = "unsloth-chat-history-updated";
 // Bumped alongside that event so other tabs, which never receive it, can drop caches
@@ -856,6 +857,12 @@ export async function getChatThread(
   threadId: string,
   options: { bounded?: boolean; timeoutMs?: number; signal?: AbortSignal } = {},
 ): Promise<ThreadRecord | null> {
+  // A `__LOCALID_` thread has never been written to the server, so asking for it is a
+  // guaranteed 404. The 404 was already handled below and nothing broke -- but the browser
+  // still logs "Failed to load resource: 404" for every draft thread, and a console that
+  // cries wolf on a normal path is a console people stop reading. Answering `null` here is
+  // the same result the round-trip produced, minus the request and the noise.
+  if (isAssistantLocalThreadId(threadId)) return null;
   // Bounded for the delete reconciliation: an unbounded read there would hang the delete that
   // the write timeout exists to keep moving. Callers on a render path stay unbounded.
   // `timeoutMs` is for a caller with a deadline of its own: the settings pairing gives up


### PR DESCRIPTION
A `__LOCALID_` thread id is generated client side and has never been written to the server, so `getChatThread` asking for one is a guaranteed 404.

Nothing was broken by this. The 404 is already handled further down the function and returns `null` correctly. The cost is console noise: the browser logs `Failed to load resource: the server responded with a status of 404` for every draft thread, on a completely normal path. A console that cries wolf during ordinary use is a console people stop reading, which is what makes a real error easy to miss.

Return `null` up front for those ids. That is the same result the round trip produced, without the request and without the log line.

Reuses the existing `isAssistantLocalThreadId` helper from `../utils/thread-ids`, so the prefix stays defined in exactly one place.

No behaviour change for server backed threads.