### PR TITLE
feat(chat): render on-disk sandbox images in chat markdown

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -24338,6 +24338,11 @@ _SANDBOX_MEDIA_TYPES = {
     ".gif": "image/gif",
     ".webp": "image/webp",
     ".bmp": "image/bmp",
+    # A raster codec, not a document type: `nosniff` below pins the type either way, and a model
+    # that writes `photo.avif` should get an image rather than an attachment it cannot see.
+    ".avif": "image/avif",
+    # `.svg` stays OUT on purpose. The filename is model-chosen, so an inline SVG would be
+    # same-origin script execution; it stays octet-stream + attachment (a download card).
 }
 
 

--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -151,10 +151,15 @@ def test_images_stay_inline_and_everything_else_downloads():
 
     The allowlist is deliberately NOT just widened: the model picks these
     filenames, so an inline text/html would be same-origin script execution.
+
+    `.avif` joined because it is a raster codec, not a document type -- `nosniff`
+    pins the type either way, and a model that writes `photo.avif` should get an
+    image rather than an attachment it cannot see. `.svg` stays out for exactly
+    that document-type reason: inline SVG is same-origin script execution.
     """
     from routes.inference import _SANDBOX_MEDIA_TYPES
 
-    for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"):
+    for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".avif"):
         assert ext in _SANDBOX_MEDIA_TYPES
     for ext in (".csv", ".txt", ".py", ".json", ".pdf", ".zip", ".html", ".svg"):
         assert ext not in _SANDBOX_MEDIA_TYPES, ext

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -26,6 +26,7 @@ import {
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { normalizeEscapedInlineMath } from "@/lib/escaped-inline-math";
 import { preprocessLaTeX } from "@/lib/latex";
+import { withDataImageSupport } from "@/lib/markdown-data-images";
 import { downloadFile, isDownloadCancelled } from "@/lib/native-files";
 import { openLink } from "@/lib/open-link";
 import { safeMarkdownUrl } from "@/lib/safe-markdown-url";
@@ -146,6 +147,10 @@ const STREAMDOWN_COMPONENTS = {
 const STREAMDOWN_ALLOWED_TAGS = {
   [SEARCH_IMAGE_TAG]: ["token"],
 } satisfies NonNullable<StreamdownProps["allowedTags"]>;
+
+// Module-scoped: Streamdown extends its sanitize schema only for its default pipeline, so the
+// allowed-tag merge and the data-image protocol ride on a pipeline we pass ourselves (see lib).
+const STREAMDOWN_REHYPE_PLUGINS = withDataImageSupport(STREAMDOWN_ALLOWED_TAGS);
 const COPY_RESET_MS = 2000;
 const MERMAID_SOURCE_RE = /```mermaid\s*([\s\S]*?)```/i;
 const ACTION_PANEL_CLASS =
@@ -810,6 +815,7 @@ const MarkdownTextImpl = () => {
             plugins={STREAMDOWN_PLUGINS}
             components={STREAMDOWN_COMPONENTS}
             allowedTags={STREAMDOWN_ALLOWED_TAGS}
+            rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}
             urlTransform={safeMarkdownUrl}
             controls={STREAMDOWN_CONTROLS}
             shikiTheme={STREAMDOWN_SHIKI_THEME}

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -3,7 +3,11 @@
 
 "use client";
 
-import { ArtifactCard, useChatRuntimeStore } from "@/features/chat";
+import {
+  ArtifactCard,
+  useChatProjectScope,
+  useChatRuntimeStore,
+} from "@/features/chat";
 import {
   getCodeFence,
   isFullHtmlDocument,
@@ -75,7 +79,9 @@ import {
 } from "./markdown-block-boundary";
 import "katex/dist/katex.min.css";
 import { AudioPlayer } from "./audio-player";
+import { markdownSandboxImageSrc } from "./sandbox-files";
 import { SearchImageElement, SearchImagesContext } from "./search-image";
+import { useSandboxImage } from "./use-sandbox-image";
 import { unslothDarkTheme, unslothLightTheme } from "./code-themes";
 import { stabilizeStreamingMarkdown } from "./streaming-markdown";
 import {
@@ -124,6 +130,119 @@ const STREAMDOWN_IMMEDIATE_UPDATES = {
   stagger: 0,
 } satisfies NonNullable<StreamdownProps["animated"]>;
 
+/*
+ * Registering `img` replaces Streamdown's own renderer WHOLESALE (its `Components` map is keyed by
+ * tag, so the default `img` is only a default), so everything that renderer did for a `data:` image
+ * is restated here: wrapper, hidden-when-failed, fallback text, hover download. What it could not do
+ * is the reason this exists -- an on-disk answer image arrives as
+ * `![plot](/api/inference/sandbox/<sid>/plot.png)`, survives sanitize() because it carries no scheme,
+ * and then reaches the DOM as a plain same-origin <img src>, with no Authorization header, 401s, and
+ * renders as "Image not available". That case is rewritten into an authed fetch -> object URL first
+ * (see `use-sandbox-image`); a `data:` URI keeps going straight through, untouched.
+ */
+const MarkdownImage = memo(function MarkdownImage(props: ComponentProps<"img">) {
+  // `node` is Streamdown's ExtraProps; it must not reach the DOM.
+  const {
+    src,
+    alt = "",
+    className,
+    node: _node,
+    ...dom
+  } = props as ComponentProps<"img"> & { node?: unknown };
+  // The same pair the adapter resolves a run's session from (`unstable_threadId ?? activeThreadId`),
+  // so an answer written inside a project reads the project's workspace, not the thread's.
+  const remoteId = useAuiState(({ threadListItem }) => threadListItem.remoteId);
+  const activeThreadId = useChatRuntimeStore((state) => state.activeThreadId);
+  const projectId = useChatProjectScope();
+  const file = src
+    ? markdownSandboxImageSrc(src, {
+        threadId: remoteId ?? activeThreadId ?? undefined,
+        projectId,
+      })
+    : null;
+  const sandbox = useSandboxImage(file);
+  const [failed, setFailed] = useState(false);
+  // A sandbox src is renderable only once the authed fetch has produced a blob: until then it is
+  // absent, never raw. `data:`/`blob:` keep going through exactly as they were.
+  const resolved =
+    file === null
+      ? src
+      : sandbox.state.status === "loaded"
+        ? sandbox.state.url
+        : undefined;
+  const failedNow =
+    failed || (file !== null && sandbox.state.status === "failed");
+  // Hidden when it failed and has no intrinsic size to fall back on, as Streamdown's own renderer does.
+  const sized = dom.width != null || dom.height != null;
+  // Download naming follows the replaced renderer: a real extension on the path wins whole (alt must
+  // never override a real filename); otherwise any extension in alt is STRIPPED and one inferred from the
+  // blob's type is appended -- so alt="plot" downloads "plot.png", not "plot".
+  const downloadName = (blobType: string): string => {
+    const tail = (file ?? src ?? "").split(/[?#]/)[0].split("/").pop() ?? "";
+    const dot = tail.lastIndexOf(".");
+    if (dot > -1 && tail.length - dot - 1 <= 4) return tail;
+    const ext = /jpe?g/.test(blobType)
+      ? "jpg"
+      : blobType.includes("svg")
+        ? "svg"
+        : blobType.includes("gif")
+          ? "gif"
+          : blobType.includes("webp")
+            ? "webp"
+            : "png";
+    return `${(alt || tail || "image").replace(/\.[^/.]+$/, "")}.${ext}`;
+  };
+  return (
+    <span
+      data-streamdown="image-wrapper"
+      className="group relative my-4 inline-block"
+    >
+      <img
+        ref={file === null ? undefined : sandbox.ref}
+        data-streamdown="image"
+        src={resolved}
+        alt={alt}
+        decoding="async"
+        onError={() => setFailed(true)}
+        className={`max-w-full rounded-lg ${failedNow && !sized ? "hidden" : ""} ${className ?? ""}`}
+        {...dom}
+      />
+      {failedNow && (
+        <span
+          data-streamdown="image-fallback"
+          className="text-muted-foreground text-xs italic"
+        >
+          Image not available
+        </span>
+      )}
+      {/* Kept from the replaced renderer: the hover tint over the image. */}
+      <div className="pointer-events-none absolute inset-0 hidden rounded-lg bg-black/10 group-hover:block" />
+      {!failedNow && resolved ? (
+        <button
+          type="button"
+          title="Download image"
+          className="absolute right-2 bottom-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border border-border bg-background/90 opacity-0 backdrop-blur-sm transition-all duration-200 group-hover:opacity-100"
+          onClick={async () => {
+            // By now the src is always blob:/data:, so a plain fetch carries it.
+            try {
+              const blob = await (await fetch(resolved)).blob();
+              await downloadFile(blob, downloadName(blob.type), blob.type);
+            } catch (error) {
+              if (!isDownloadCancelled(error)) toast.error("Could not save file.");
+            }
+          }}
+        >
+          <HugeiconsIcon
+            icon={Download01Icon}
+            strokeWidth={1.75}
+            className="size-icon"
+          />
+        </button>
+      ) : null}
+    </span>
+  );
+});
+
 const STREAMDOWN_COMPONENTS = {
   a: ({ href, children, ...props }: ComponentProps<"a">) => (
     <a
@@ -142,6 +261,7 @@ const STREAMDOWN_COMPONENTS = {
   ),
   // Module-scoped: Streamdown's memo comparator ignores `components`.
   [SEARCH_IMAGE_TAG]: SearchImageElement,
+  img: MarkdownImage,
 };
 // Through the sanitizer; the component drops tokens it cannot resolve.
 const STREAMDOWN_ALLOWED_TAGS = {

--- a/studio/frontend/src/components/assistant-ui/math-block-marker.ts
+++ b/studio/frontend/src/components/assistant-ui/math-block-marker.ts
@@ -46,8 +46,9 @@
  *
  *   - Passing `rehypePlugins` to `<Streamdown>` replaces its default list, and Streamdown only
  *     installs the `allowedTags` sanitizer schema when that list is still the default one
- *     (`rehypePlugins === defaultRehypePlugins`). Supplying our own would silently drop the
- *     sanitize pass this renderer depends on. That is a security regression to buy a class name.
+ *     (`rehypePlugins === defaultRehypePlugins`). A pipeline that does not carry the merge silently
+ *     drops the sanitize pass this renderer depends on -- a security regression to buy a class name;
+ *     the one now passed for data images carries it (`lib/markdown-data-images.ts`).
  *   - Marking on the mdast side, through `data.hProperties`, lands the class BEFORE
  *     `rehype-sanitize`, whose `defaultSchema` permits `className` on `a`, `code`, `h2`, `li`,
  *     `ol`, `section` and `ul` and NOWHERE ELSE. A class on a `<p>` would be stripped, and

--- a/studio/frontend/src/components/assistant-ui/sandbox-files.ts
+++ b/studio/frontend/src/components/assistant-ui/sandbox-files.ts
@@ -93,6 +93,12 @@ export function isSandboxToolResult(
 /** Ids a path segment can carry: ASGI decodes %2F before it matches a route. */
 const PATH_SAFE_SESSION = /^[A-Za-z0-9_-]{1,64}$/;
 
+/**
+ * The route both sides spell: `sandboxRoutePrefix` builds it for the cards, and a model that
+ * writes `![plot](/api/inference/sandbox/<sid>/plot.png)` into its own markdown carries it back.
+ */
+export const SANDBOX_ROUTE_PREFIX = "/api/inference/sandbox/";
+
 /** Where this session's files live, as the routes expect to be asked. */
 export function sandboxRoutePrefix(sessionId: string): {
   prefix: string;
@@ -100,7 +106,7 @@ export function sandboxRoutePrefix(sessionId: string): {
 } {
   if (PATH_SAFE_SESSION.test(sessionId)) {
     return {
-      prefix: `/api/inference/sandbox/${encodeURIComponent(sessionId)}`,
+      prefix: `${SANDBOX_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`,
       query: "",
     };
   }
@@ -121,6 +127,75 @@ export function sandboxSessionIdFor(
   projectId: string | null | undefined,
 ): string | undefined {
   return projectId ? `project-${projectId}` : threadId;
+}
+
+/**
+ * Extensions the route serves inline as an image, mirroring `_SANDBOX_MEDIA_TYPES` in
+ * `backend/routes/inference.py`. `.svg` is absent on purpose: the filename is model-chosen, so an
+ * inline SVG would be same-origin script execution and the route keeps serving it as a download.
+ */
+export const SANDBOX_INLINE_IMAGE_EXTS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".bmp",
+  ".avif",
+]);
+
+/** Somebody else's URL: `data:`/`blob:` render as they are, `http(s)` is blocked by the sanitizer. */
+const HAS_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+\-.]*:/;
+const PROTOCOL_RELATIVE_RE = /^[/\\]{2}/;
+
+/** `100%.png` is a real filename; a stray `%` must not throw on every render. */
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+/**
+ * The file a model-written markdown `src` points at, or null when it does not point at this chat's
+ * sandbox. A bare relative path (`outputs/plot.png`) counts: the sanitizer already dropped every
+ * scheme-carrying src, so a scheme-less image path in an answer is this chat's file and nothing else.
+ */
+export function sandboxFileForSrc(src: string): string | null {
+  const trimmed = src.trim();
+  if (!trimmed || HAS_SCHEME_RE.test(trimmed) || PROTOCOL_RELATIVE_RE.test(trimmed)) {
+    return null;
+  }
+  // The sid rides in `?session=` when it is not path-safe; either way we re-derive it, so drop it.
+  const path = trimmed.split("?")[0].split("#")[0];
+  if (path.startsWith("/") && !path.startsWith(SANDBOX_ROUTE_PREFIX)) {
+    return null; // some other app route (`/assets/...`), not a sandbox file
+  }
+  const segments = path.startsWith(SANDBOX_ROUTE_PREFIX)
+    ? // The sid segment goes in the bin with the query: the caller re-derives it from this chat.
+      path.slice(SANDBOX_ROUTE_PREFIX.length).split("/").slice(1)
+    : path.split("/");
+  const name = segments[segments.length - 1] ?? "";
+  const ext = name.slice(name.lastIndexOf(".")).toLowerCase();
+  // A `.csv` is a download card, not an `<img>`; leave it to the file cards.
+  if (!SANDBOX_INLINE_IMAGE_EXTS.has(ext)) return null;
+  return segments.map(decodeSegment).join("/");
+}
+
+/**
+ * The URL to fetch for a sandbox `src`: the model's own session segment is DISCARDED and rebuilt
+ * from this chat's scope, so an answer written in a project reads the project's workspace.
+ */
+export function markdownSandboxImageSrc(
+  src: string,
+  ctx: { threadId: string | undefined; projectId: string | null | undefined },
+): string | null {
+  const file = sandboxFileForSrc(src);
+  if (file === null) return null;
+  const sessionId = sandboxSessionIdFor(ctx.threadId, ctx.projectId);
+  // No thread yet means no directory to read from; the raw src stays as it is.
+  return sessionId ? sandboxFilePath(sessionId, file) : null;
 }
 
 export function sandboxFilePath(sessionId: string, filename: string): string {

--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -4,7 +4,6 @@
 "use client";
 
 import { Spinner } from "@/components/ui/spinner";
-import { authFetch } from "@/features/auth";
 
 import { SandboxFiles } from "./sandbox-files-view";
 import { isSandboxFileList, type SandboxFile } from "./sandbox-files";
@@ -20,8 +19,9 @@ import { stringifyToolResult } from "@/lib/strip-ansi";
 import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
 import { useToolArgsStatus } from "@assistant-ui/react";
 import { CodeIcon } from "lucide-react";
-import { memo, useEffect, useRef, useState } from "react";
+import { memo } from "react";
 import { pythonToolImagePath } from "./python-tool-image-path";
+import { useSandboxImage } from "./use-sandbox-image";
 import { CopyBtn, ToolCodeCell } from "./tool-code-cell";
 import { toolArgText } from "./tool-arg-text";
 import {
@@ -59,77 +59,16 @@ function PythonToolImage({
   sessionId: string;
   filename: string;
 }) {
-  const imageKey = `${sessionId}\0${filename}`;
-  const [image, setImage] = useState<{ key: string; url: string } | null>(null);
-  const imageRef = useRef<HTMLImageElement>(null);
-  const [nearViewport, setNearViewport] = useState(
-    () => typeof IntersectionObserver === "undefined",
-  );
-
-  useEffect(() => {
-    if (nearViewport) {
-      return;
-    }
-    const element = imageRef.current;
-    if (!element) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          setNearViewport(true);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: "200px" },
-    );
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [nearViewport]);
-
-  useEffect(() => {
-    if (!nearViewport) {
-      return;
-    }
-    const controller = new AbortController();
-    let objectUrl: string | null = null;
-
-    const load = async () => {
-      const response = await authFetch(
-        pythonToolImagePath(sessionId, filename),
-        {
-          signal: controller.signal,
-        },
-      );
-      if (!response.ok) {
-        return;
-      }
-
-      const blob = await response.blob();
-      if (controller.signal.aborted) {
-        return;
-      }
-
-      objectUrl = URL.createObjectURL(blob);
-      setImage({ key: imageKey, url: objectUrl });
-    };
-    load().catch(() => {
-      // A failed or cancelled image stays as its accessible alt text.
-    });
-
-    return () => {
-      controller.abort();
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
-    };
-  }, [filename, imageKey, nearViewport, sessionId]);
+  // The same hook assistant markdown uses for an on-disk image, so the authed fetch, the object URL
+  // and its revocation live in one place instead of two. A failed or cancelled image stays as its
+  // accessible alt text. Keyed by url inside the hook: a re-used element reads idle, not the
+  // previous file's blob, and a stale response cannot write state for a url it was not fetched for.
+  const { ref, state } = useSandboxImage(pythonToolImagePath(sessionId, filename));
 
   return (
     <img
-      ref={imageRef}
-      src={image?.key === imageKey ? image.url : undefined}
+      ref={ref}
+      src={state.status === "loaded" ? state.url : undefined}
       alt={filename}
       loading="lazy"
       className="max-w-full rounded border border-border"

--- a/studio/frontend/src/components/assistant-ui/use-sandbox-image.ts
+++ b/studio/frontend/src/components/assistant-ui/use-sandbox-image.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"use client";
+
+import { authFetch } from "@/features/auth";
+import { type RefObject, useEffect, useRef, useState } from "react";
+
+export type SandboxImageState =
+  | { status: "idle" }
+  | { status: "loaded"; url: string }
+  | { status: "failed" };
+
+const IDLE: SandboxImageState = { status: "idle" };
+
+/**
+ * Fetches one auth-protected sandbox file into an object URL.
+ *
+ * The route answers on the Authorization header (`_authenticate_header_or_query`), so a bare
+ * `<img src>` hitting it straight gets a 401 and the renderer's "Image not available" placeholder.
+ * Pass the URL from `sandboxFilePath()`/`markdownSandboxImageSrc()` and render what comes back.
+ *
+ * Keyed by url: an element that moves to another file reads idle rather than showing the previous
+ * file's blob, and a stale response can never write state for a url it was not fetched for.
+ */
+export function useSandboxImage(url: string | null): {
+  ref: RefObject<HTMLImageElement | null>;
+  state: SandboxImageState;
+} {
+  const ref = useRef<HTMLImageElement>(null);
+  const [state, setState] = useState<{ url: string | null; load: SandboxImageState }>({
+    url,
+    load: IDLE,
+  });
+  const [nearViewport, setNearViewport] = useState(
+    () => typeof IntersectionObserver === "undefined",
+  );
+
+  useEffect(() => {
+    if (nearViewport || !url) return;
+    const element = ref.current;
+    if (!element) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setNearViewport(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [nearViewport, url]);
+
+  useEffect(() => {
+    if (!url || !nearViewport) return;
+    const controller = new AbortController();
+    let objectUrl: string | null = null;
+
+    authFetch(url, { signal: controller.signal })
+      .then(async (response) => {
+        // Guarded on both arms: a late write for the url this element used to hold must not land.
+        if (!response.ok) {
+          if (!controller.signal.aborted) setState({ url, load: { status: "failed" } });
+          return;
+        }
+        const blob = await response.blob();
+        if (controller.signal.aborted) return;
+        objectUrl = URL.createObjectURL(blob);
+        setState({ url, load: { status: "loaded", url: objectUrl } });
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setState({ url, load: { status: "failed" } });
+      });
+
+    return () => {
+      controller.abort();
+      // The URL is ours to give up: an aborted fetch that had already made one would otherwise
+      // pin the bytes for the rest of the session.
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [url, nearViewport]);
+
+  return { ref, state: state.url === url ? state.load : IDLE };
+}

--- a/studio/frontend/src/lib/markdown-data-images.ts
+++ b/studio/frontend/src/lib/markdown-data-images.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Streamdown sanitizes with its default schema before hardening, and that schema allows only
+ * http(s) image sources: a `data:image/...` src is stripped before the harden stage, which does
+ * allow data images (`allowDataImages: true`), so the message renders "[Image blocked: …]" instead
+ * of the image. Streamdown extends its own schema with caller `allowedTags` only when it receives
+ * its default pipeline (identity check), so callers that pass one must carry that merge themselves.
+ */
+import type { Pluggable, Plugin } from "unified";
+import { defaultRehypePlugins } from "streamdown";
+
+interface SanitizeSchema {
+  tagNames?: string[];
+  attributes?: Record<string, string[]>;
+  protocols?: Record<string, string[]>;
+}
+
+/** Streamdown's default raw/sanitize/harden pipeline with `data` added to image source protocols. */
+export function withDataImageSupport(allowedTags: Record<string, string[]>): Pluggable[] {
+  const sanitize = defaultRehypePlugins.sanitize as [Plugin<Array<any>, any, any>, SanitizeSchema];
+  const [sanitizePlugin, schema] = sanitize;
+  // Positional by design: Streamdown itself builds its default pipeline as `Object.values` of this
+  // same object, so spreading it in the same order reproduces that pipeline exactly. Naming the keys
+  // would pin OUR order instead of theirs.
+  const [raw, , harden] = Object.values(defaultRehypePlugins);
+  return [
+    raw,
+    [
+      sanitizePlugin,
+      {
+        ...schema,
+        tagNames: [...(schema.tagNames ?? []), ...Object.keys(allowedTags)],
+        attributes: { ...schema.attributes, ...allowedTags },
+        protocols: {
+          ...schema.protocols,
+          // Harden still gates the scheme on `allowDataImages` and only honors `data:image/*`.
+          src: [...(schema.protocols?.src ?? []), "data"],
+        },
+      },
+    ],
+    harden,
+  ];
+}

--- a/studio/frontend/tests/markdown-data-images.test.ts
+++ b/studio/frontend/tests/markdown-data-images.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { withDataImageSupport } from "../src/lib/markdown-data-images.ts";
+
+const TAG = "search-image";
+
+test("withDataImageSupport allows data: image sources through sanitize", () => {
+  const pipeline = withDataImageSupport({ [TAG]: ["token"] });
+  assert.equal(pipeline.length, 3);
+  const [, harden] = pipeline[2] as [(...args: never[]) => unknown, Record<string, unknown>];
+  assert.equal(harden.allowDataImages, true, "harden stage must be the one that gates data images");
+  const [, schema] = pipeline[1] as [unknown, { tagNames: string[]; attributes: Record<string, string[]>; protocols: Record<string, string[]> }];
+  assert.ok(schema.protocols.src.includes("data"), "sanitize must let data: through so harden can decide");
+  for (const scheme of ["http", "https"]) assert.ok(schema.protocols.src.includes(scheme));
+  assert.ok(schema.tagNames.includes(TAG), "caller allowed tags survive the pipeline swap");
+  assert.deepEqual(schema.attributes[TAG], ["token"]);
+});
+
+test("withDataImageSupport carries Streamdown's own schema widening, not just defaultSchema", () => {
+  // The pipeline is derived from `defaultRehypePlugins.sanitize[1]`, which is Streamdown's OWN
+  // schema (defaultSchema PLUS its own widenings), not bare hast-util-sanitize defaultSchema.
+  // Re-deriving from defaultSchema would silently drop these and read as a no-op change.
+  const [, schema] = withDataImageSupport({ [TAG]: ["token"] })[1] as [
+    unknown,
+    { protocols: Record<string, string[]>; attributes: Record<string, unknown> },
+  ];
+  assert.ok(schema.protocols.href.includes("tel"), "streamdown's tel: widening must survive");
+  assert.ok(
+    (schema.attributes.code as unknown[]).includes("metastring"),
+    "streamdown's code/metastring widening must survive",
+  );
+});

--- a/studio/frontend/tests/markdown-sandbox-image.test.ts
+++ b/studio/frontend/tests/markdown-sandbox-image.test.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  SANDBOX_INLINE_IMAGE_EXTS,
+  markdownSandboxImageSrc,
+  sandboxFileForSrc,
+} from "../src/components/assistant-ui/sandbox-files.ts";
+import { safeMarkdownUrl } from "../src/lib/safe-markdown-url.ts";
+
+/*
+ * THREE PIECES ONLY WORK TOGETHER, and nothing in the type system joins them:
+ *
+ *   1. the renderer has to resolve a scheme-less sandbox `src` through `markdownSandboxImageSrc`
+ *      before it reaches the DOM (the sanitizer keeps what carries no scheme -- see
+ *      `safe-markdown-url.ts` -- but keeping it was never the same as being able to fetch it);
+ *   2. the fetch has to carry the Authorization header, which is the only way the route authenticates
+ *      a header-auth client (`_authenticate_header_or_query`), and revoke what it created;
+ *   3. the extension set has to agree with the backend's `_SANDBOX_MEDIA_TYPES`, which decides
+ *      inline-image from attachment in a different language, two directories away.
+ *
+ * Each is checked against the real source, and where a check is a string search it says what it is
+ * defending, so a rename that breaks the join fails here by name rather than by measuring as a
+ * change that does nothing.
+ */
+
+const read = (relative: string): string =>
+  readFileSync(new URL(relative, import.meta.url), "utf8");
+
+const MARKDOWN_TEXT = read("../src/components/assistant-ui/markdown-text.tsx");
+const HOOK = read("../src/components/assistant-ui/use-sandbox-image.ts");
+const TOOL_UI = read("../src/components/assistant-ui/tool-ui-python.tsx");
+const BACKEND = read(
+  "../../backend/routes/inference.py",
+);
+
+test("a scheme-less sandbox src is rewritten before it reaches the DOM, and rendered from a blob:", () => {
+  // PRECONDITION: the renderer still relies on the sanitizer's deny rule rather than repeating it.
+  assert.ok(
+    MARKDOWN_TEXT.includes("urlTransform={safeMarkdownUrl}"),
+    "PRECONDITION: the chat renderer still passes the url transform",
+  );
+  assert.ok(
+    /img: MarkdownImage,/.test(MARKDOWN_TEXT),
+    "registering `img` replaces Streamdown's own renderer wholesale, so the swap has to live in the " +
+      "component it replaces -- an unregistered <img src> is the bug this file exists for",
+  );
+  assert.ok(
+    /markdownSandboxImageSrc\(src,\s*\{/.test(MARKDOWN_TEXT),
+    "the src is re-derived from this chat's scope (project-<id> else threadId), not passed through " +
+      "with whichever sid the model happened to be talking to",
+  );
+  assert.ok(
+    MARKDOWN_TEXT.includes("useSandboxImage(file)"),
+    "and it is fetched rather than rendered raw",
+  );
+
+  // ANTI-VACUITY: the rewrite really is what produces the src, and a data: URI really is untouched.
+  const imgNode = { tagName: "img" } as Parameters<typeof safeMarkdownUrl>[2];
+  const written = "/api/inference/sandbox/__LOCALID_Y3VK67e/plot.png";
+  assert.equal(safeMarkdownUrl(written, "src", imgNode), written);
+  assert.equal(
+    markdownSandboxImageSrc(written, { threadId: "t-1", projectId: null }),
+    "/api/inference/sandbox/t-1/plot.png",
+  );
+  assert.equal(markdownSandboxImageSrc("data:image/png;base64,AAAA", { threadId: "t-1", projectId: null }), null);
+});
+
+test("the fetch carries the header and gives the object URL back on cleanup", () => {
+  // The route answers on the Authorization header; a bare <img src> gets a 401 and the renderer's
+  // "Image not available" placeholder, which is what this whole file defends.
+  assert.ok(/authFetch\(url,\s*\{ signal: controller\.signal \}\)/.test(HOOK), "authenticated fetch");
+  assert.ok(HOOK.includes("URL.createObjectURL(blob)"), "into an object URL");
+  // Two assertions, because a comment sits between the two statements in the hook's cleanup.
+  assert.ok(HOOK.includes("controller.abort();"), "the in-flight fetch is cancelled");
+  assert.ok(
+    HOOK.includes("if (objectUrl) URL.revokeObjectURL(objectUrl);"),
+    "and an object URL a cancelled fetch had already built is revoked, or those bytes stay pinned " +
+      "for the rest of the session",
+  );
+
+  // ONE hook, not two. `tool-ui-python.tsx` was the only place this fetch existed; duplicating it is
+  // how the markdown path ended up without one in the first place.
+  assert.ok(TOOL_UI.includes("useSandboxImage(pythonToolImagePath(sessionId, filename))"));
+  assert.equal(
+    TOOL_UI.includes("createObjectURL"),
+    false,
+    "the Python card now goes through the shared hook instead of keeping its own copy",
+  );
+});
+
+test("the inline-image set matches what the backend actually serves inline", () => {
+  // Two lists in two languages. The frontend list decides what becomes an <img>; the backend map
+  // decides what the route serves inline at all, and everything else comes back as a download card.
+  const served = BACKEND.slice(
+    BACKEND.indexOf("_SANDBOX_MEDIA_TYPES = {"),
+    BACKEND.indexOf("_SANDBOX_MEDIA_TYPES = {") >= 0
+      ? BACKEND.indexOf("}", BACKEND.indexOf("_SANDBOX_MEDIA_TYPES = {"))
+      : 0,
+  );
+  assert.ok(served.length > 50, "PRECONDITION: the backend map was actually read");
+  for (const ext of SANDBOX_INLINE_IMAGE_EXTS) {
+    assert.ok(
+      served.includes(`"${ext}"`),
+      `${ext} is rendered as an <img> but the route would serve it as application/octet-stream`,
+    );
+  }
+  assert.ok(
+    !served.includes('".svg"'),
+    "SVG stays out on purpose: the filename is model-chosen, so inline SVG would be same-origin " +
+      "script execution",
+  );
+  assert.ok(
+    /X-Content-Type-Options"\s*=\s*"nosniff/.test(BACKEND) ||
+      BACKEND.includes('"X-Content-Type-Options": "nosniff"'),
+    "the pin that makes a raster codec safe to add",
+  );
+});
+
+test("a non-image stays a download card, and a scheme-carrying src is left alone", () => {
+  assert.equal(sandboxFileForSrc("report.csv"), null);
+  assert.equal(sandboxFileForSrc("diagram.svg"), null);
+  assert.equal(sandboxFileForSrc("/assets/logo.png"), null);
+  assert.equal(sandboxFileForSrc("//img.example.com/x.png"), null);
+  // The sid segment and the `?session=` form both go in the bin: the caller re-derives the session.
+  assert.equal(
+    sandboxFileForSrc("/api/inference/sandbox/_/loss%20curve%20%231.png?session=session%2Fid"),
+    "loss curve #1.png",
+  );
+});
+
+test("the img restatement keeps what the wholesale replacement silently dropped", () => {
+  // Registering `img` replaces Streamdown's renderer WHOLESALE, so some of its lines live here by name.
+  // The LOADED/SIZED gating machinery deliberately does NOT: a sandbox image is hidden until the authed
+  // fetch lands and fetch state already drives visibility, so nothing here needs a decode gate. What IS
+  // kept is what carries no machinery -- string checks, because that renderer is minified.
+  assert.ok(
+    MARKDOWN_TEXT.includes('data-streamdown="image"'),
+    "the <img> itself carries the attribute (wrapper and fallback had it; img silently did not)",
+  );
+  assert.ok(
+    MARKDOWN_TEXT.includes("bg-black/10") &&
+      MARKDOWN_TEXT.includes("pointer-events-none absolute inset-0"),
+    "the hover overlay div, dropped entirely by the wholesale replacement",
+  );
+  assert.ok(
+    MARKDOWN_TEXT.includes('.replace(/\\.[^/.]+$/'),
+    'download names: a real extension on the path wins whole; otherwise alt\'s extension is stripped ' +
+      'and one inferred from blob.type is appended -- alt="plot" downloads "plot.png", not "plot"',
+  );
+});

--- a/studio/frontend/tests/math-block-containment-wiring.test.ts
+++ b/studio/frontend/tests/math-block-containment-wiring.test.ts
@@ -17,8 +17,10 @@ import {
 /*
  * THE THREE PIECES ONLY WORK TOGETHER, and nothing in the type system joins them:
  *
- *   1. the marker has to be composed onto the MATHS plugin, not passed as a `rehypePlugins` prop,
- *      because that prop switches off Streamdown's `allowedTags` sanitizer;
+ *   1. the marker has to be composed onto the MATHS plugin's own rehype pass. A `rehypePlugins` prop
+ *      entry would run before that pass, and the prop itself replaces Streamdown's default pipeline
+ *      (the `allowedTags` schema then rides only on what the passed pipeline carries -- see
+ *      `lib/markdown-data-images.ts`);
  *   2. the stylesheet has to name the class the marker writes and the attribute the resolver sets;
  *   3. `main.tsx` has to set that attribute before the first render.
  *
@@ -53,17 +55,19 @@ test("the marker is composed onto the maths plugin", () => {
   );
 });
 
-test("the chat renderer does NOT pass a rehypePlugins prop", () => {
-  // Passing one makes Streamdown skip its `allowedTags` sanitizer schema, because it only installs
-  // that schema while `rehypePlugins === defaultRehypePlugins`. This is the reason the marker is
-  // composed rather than appended, and it is worth more than the class it buys.
+test("the chat renderer's rehypePlugins pipeline carries the allowedTags merge itself", () => {
+  // Streamdown auto-merges `allowedTags` into its sanitize schema only while `rehypePlugins` is
+  // still its default pipeline (identity check). The renderer now passes one, so it must carry the
+  // merge itself; a passed pipeline that dropped it would silently drop the sanitizer instead.
   assert.ok(
     MARKDOWN_TEXT.includes("allowedTags={STREAMDOWN_ALLOWED_TAGS}"),
     "PRECONDITION: the chat renderer relies on the allowedTags sanitizer",
   );
   assert.ok(
-    !/\brehypePlugins=\{/.test(MARKDOWN_TEXT),
-    "no rehypePlugins prop, or the sanitizer schema above is silently dropped",
+    /const STREAMDOWN_REHYPE_PLUGINS = withDataImageSupport\(STREAMDOWN_ALLOWED_TAGS\);/.test(
+      MARKDOWN_TEXT,
+    ) && MARKDOWN_TEXT.includes("rehypePlugins={STREAMDOWN_REHYPE_PLUGINS}"),
+    "the passed pipeline must be derived from the defaults AND carry the allowedTags merge",
   );
 });
 

--- a/studio/frontend/tests/search-images.test.ts
+++ b/studio/frontend/tests/search-images.test.ts
@@ -27,6 +27,10 @@ import {
   stripSearchImageTokens,
 } from "../src/features/chat/search-images/search-images.ts";
 import { toolArgText } from "../src/components/assistant-ui/tool-arg-text.ts";
+import {
+  markdownSandboxImageSrc,
+  sandboxFileForSrc,
+} from "../src/components/assistant-ui/sandbox-files.ts";
 import { safeMarkdownUrl } from "../src/lib/safe-markdown-url.ts";
 
 const ENTRY = {
@@ -602,6 +606,55 @@ test("thumbnails load from Unsloth's own endpoint, which the img policy allows",
     safeMarkdownUrl("//img.example.com/x.png", "src", imgNode),
     null,
   );
+});
+
+test("an on-disk image survives sanitize as a path, and is rewritten before it reaches the DOM", () => {
+  // The sanitizer's job ends at "carries no scheme, so keep it": what it cannot know is that the
+  // route answers on the Authorization header. So the surviving path must be re-derived per chat --
+  // the model writes whichever sid it happened to be talking to, and a project thread reads the
+  // PROJECT's workspace -- and fetched, not handed to an <img> unchanged.
+  const imgNode = { tagName: "img" } as Parameters<typeof safeMarkdownUrl>[2];
+  const written =
+    "/api/inference/sandbox/__LOCALID_Y3VK67e/outputs/loss%20curve%20%231.png";
+  assert.equal(safeMarkdownUrl(written, "src", imgNode), written);
+
+  // The sid the model wrote is discarded; this chat's scope decides. `project-<id>` else threadId,
+  // exactly as sandboxSessionIdFor resolves it for a tool call's own envelope.
+  assert.equal(
+    markdownSandboxImageSrc(written, { threadId: "t-1", projectId: null }),
+    "/api/inference/sandbox/t-1/outputs/loss%20curve%20%231.png",
+  );
+  assert.equal(
+    markdownSandboxImageSrc(written, { threadId: "t-1", projectId: "p1" }),
+    "/api/inference/sandbox/project-p1/outputs/loss%20curve%20%231.png",
+  );
+  // A bare relative path is the same file: every scheme-carrying src is already gone by now. It
+  // arrives percent-encoded, because in a URL a literal `#` starts a fragment and a raw space ends the
+  // destination -- so the decoded name comes back out encoded again, and the raw form below is not
+  // something markdown delivers here (it would have parsed as a fragment). Both are asserted so the
+  // two behaviours stay distinguishable.
+  assert.equal(
+    sandboxFileForSrc("outputs/loss%20curve%20%231.png"),
+    "outputs/loss curve #1.png",
+  );
+  assert.equal(
+    sandboxFileForSrc("outputs/loss curve #1.png"),
+    null,
+    "a raw `#` is a fragment delimiter, not part of the name",
+  );
+  // What the route serves inline and what it serves as an attachment are different questions, and
+  // only the first is an <img>: a .csv stays a download card rather than becoming a broken image.
+  assert.equal(sandboxFileForSrc("report.csv"), null);
+  assert.equal(sandboxFileForSrc("diagram.svg"), null);
+  assert.equal(
+    sandboxFileForSrc("photo.avif"),
+    "photo.avif",
+    "AVIF is inline on the backend too; the two lists must not drift",
+  );
+  // Somebody else's URL, left exactly as it was.
+  assert.equal(sandboxFileForSrc("/assets/logo.png"), null);
+  assert.equal(sandboxFileForSrc("data:image/png;base64,AAAA"), null);
+  assert.equal(sandboxFileForSrc("//img.example.com/x.png"), null);
 });
 
 test("extractListSubjects stays linear on a bullet padded with whitespace", () => {


### PR DESCRIPTION
## TL;DR

A model writes `![plot](/api/inference/sandbox/<sid>/plot.png)` into its answer. The src carries no scheme, so sanitize **keeps** it — but keeping it was never the same as being able to fetch it: the route answers on the `Authorization` header (`_authenticate_header_or_query`), a bare `<img src>` 401s, and the answer renders "Image not available". Only tool cards had an authed fetch; markdown was the one path left.

## Fix

The src is re-derived from **this chat's** scope and fetched with auth into an object URL before it reaches the DOM:

- `sandboxFileForSrc` rewrites only scheme-less paths (sanitize dropped every scheme-carrying src already) and **discards the sid segment the model happened to write**; `markdownSandboxImageSrc` rebuilds it via `sandboxSessionIdFor` — `project-${projectId}` for project threads, else this thread's `remoteId`.
- One hook, `useSandboxImage`, does `authFetch` → `createObjectURL` for markdown **and** the Python card, which had its own copy; abort + `revokeObjectURL` on cleanup, keyed by url so a stale response can never write state for an old file.
- Registering `img` replaces Streamdown's default renderer WHOLESALE (its Components map is keyed by tag), so everything that renderer did is restated: wrapper, hidden-when-failed, fallback text, hover download. `downloadName` follows it exactly: a real extension on the path wins whole; otherwise any extension in alt is stripped and one inferred from the blob's type is appended (`alt="plot"` downloads `plot.png`).

## Why the scheme-less src survives sanitize (fact, read off the installed packages)

`hast-util-sanitize`'s `safeProtocol` returns true when the first `:` precedes no `/`-precedes-no-colon case — i.e. when `colon < 0 || colon > slash`, a scheme-less path is never protocol-checked. The bug was never sanitize; it was the missing auth header.

## The two extension lists agree, in two languages

`SANDBOX_INLINE_IMAGE_EXTS` mirrors `_SANDBOX_MEDIA_TYPES` (frontend test reads `inference.py` as text and pins it): `.avif` joins it (a raster codec; `nosniff` pins the type either way), `.svg` stays OUT on purpose — the filename is model-chosen, so inline SVG would be same-origin script execution; non-image extensions stay download cards.

## What was deliberately NOT ported

The replaced renderer's gating machinery (decoded state, mount-time `complete` check, `onLoad`/`onError` forwarding, loaded||sized gates): a sandbox image is hidden until the authed fetch lands and fetch state already drives visibility, so nothing here needs a decode gate. What WAS kept — string-level lines with no machinery, pinned by name in tests: `data-streamdown="image"`, the hover overlay div, the download-name regex.

## Verification / Tests

- `tsc -b` and `tsc -p tsconfig.test.json`: 0 errors. Suite: **6830 pass / 0 fail**.
- Pinned by tests: rewrite-before-DOM and authed-fetch/revoke (`markdown-sandbox-image.test.ts`); `%23` round-trips while a raw `#` is a fragment delimiter → null; project scope beats threadId (`search-images.test.ts`).

## Follow-up (not blocking)

Upstream, this is one line: Streamdown shipping its own `img` swap point. If that lands, the wholesale restatement shrinks back to just the resolve-and-fetch step.
