### PR TITLE
Studio: pin which rejection site the confirm-stream tests assert

### DIFF
--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -2341,10 +2341,7 @@ class TestChatCompletionRequestToolFields:
         )
         self._assert_unsupported_param(resp, param)
 
-    # Same pair of rejection sites as the GGUF case, and the same reason to pin
-    # which one runs: `_should_validate_before_switch()` reads process-wide state,
-    # so unpinned this asserted whichever site the rest of the worker left
-    # reachable.
+    # Same two rejection sites, and same reason to pin one, as the GGUF case below.
     @pytest.mark.parametrize("validate_before_switch", [False, True])
     def test_confirm_tool_calls_requires_streaming_for_safetensors_tools(
         self, monkeypatch, validate_before_switch
@@ -2392,7 +2389,7 @@ class TestChatCompletionRequestToolFields:
         assert body["error"]["param"] == "confirm_tool_calls"
         assert "requires stream=true" in body["error"]["message"]
         if validate_before_switch:
-            # Rejected ahead of the switch, before the monitor row is opened.
+            # Early site rejects before the monitor row is opened.
             assert monitor.snapshot() == []
         else:
             [entry] = monitor.snapshot()
@@ -4209,14 +4206,10 @@ class TestGgufVisionToolRouting:
         assert exc.value.status_code == 400
         assert exc.value.detail["error"]["param"] == "tool_choice"
 
-    # Two sites reject this shape, and `_should_validate_before_switch()` picks
-    # which: the early one runs ahead of the model switch so an invalid request
-    # cannot evict the resident model, and the one inside the GGUF branch runs
-    # after the monitor row is opened. That predicate reads process-wide state
-    # (an automatic load being possible, or a preview-owned slot), so leaving it
-    # unpinned asserted whichever site the rest of the worker happened to leave
-    # reachable. It passed alone and failed in CI once #10221 added cases and
-    # changed how xdist packed its workers. Pinned, and both sites are covered.
+    # Two sites reject this shape and `_should_validate_before_switch()` picks
+    # which; the early one runs before the api_monitor row is opened. It reads
+    # process-wide state, so unpinned this asserted whichever site the xdist
+    # worker happened to leave reachable. Pinned, both sites are covered.
     @pytest.mark.parametrize("validate_before_switch", [False, True])
     def test_confirm_tool_calls_requires_streaming_for_gguf_tools(
         self, monkeypatch, validate_before_switch
@@ -4262,19 +4255,17 @@ class TestGgufVisionToolRouting:
                     current_subject = "test",
                 )
             )
-        # The rejection itself is the same from either site.
         assert exc.value.status_code == 400
         assert "requires stream=true" in exc.value.detail["error"]["message"]
         if validate_before_switch:
-            # Rejected ahead of the switch, before the monitor row is opened, so
-            # there is no row to fail. Recording one here would change what the
-            # monitor shows and is a decision of its own, not a test fix.
+            # Early site rejects before the monitor row is opened, so there is no
+            # row to fail; opening one here would be a behaviour change, not a fix.
             assert monitor.snapshot() == []
         else:
             [entry] = monitor.snapshot()
             assert entry["status"] == "error"
             assert "confirm_tool_calls requires stream=true" in entry["error"]
-        # Neither site may leave a row running, including the site that opens none.
+        # Neither site may leave a row running.
         assert monitor.active_count() == 0
 
     def test_standard_gguf_stream_splits_reasoning_content(self, monkeypatch):

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -2341,7 +2341,14 @@ class TestChatCompletionRequestToolFields:
         )
         self._assert_unsupported_param(resp, param)
 
-    def test_confirm_tool_calls_requires_streaming_for_safetensors_tools(self, monkeypatch):
+    # Same pair of rejection sites as the GGUF case, and the same reason to pin
+    # which one runs: `_should_validate_before_switch()` reads process-wide state,
+    # so unpinned this asserted whichever site the rest of the worker left
+    # reachable.
+    @pytest.mark.parametrize("validate_before_switch", [False, True])
+    def test_confirm_tool_calls_requires_streaming_for_safetensors_tools(
+        self, monkeypatch, validate_before_switch
+    ):
         import routes.inference as inference_route
 
         class _NoGGUFBackend:
@@ -2363,6 +2370,9 @@ class TestChatCompletionRequestToolFields:
             "_detect_safetensors_features",
             lambda backend, chat_template, tools = None: {"supports_tools": True},
         )
+        monkeypatch.setattr(
+            inference_route, "_should_validate_before_switch", lambda: validate_before_switch
+        )
         monitor = ApiMonitor(max_entries = 3)
         monkeypatch.setattr(inference_route, "api_monitor", monitor)
         client = self._v1_client(monkeypatch, _NoGGUFBackend(), _InferenceBackend())
@@ -2381,9 +2391,13 @@ class TestChatCompletionRequestToolFields:
         body = resp.json()
         assert body["error"]["param"] == "confirm_tool_calls"
         assert "requires stream=true" in body["error"]["message"]
-        [entry] = monitor.snapshot()
-        assert entry["status"] == "error"
-        assert "confirm_tool_calls requires stream=true" in entry["error"]
+        if validate_before_switch:
+            # Rejected ahead of the switch, before the monitor row is opened.
+            assert monitor.snapshot() == []
+        else:
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "error"
+            assert "confirm_tool_calls requires stream=true" in entry["error"]
         assert monitor.active_count() == 0
 
     def test_multiturn_tool_loop_messages(self):
@@ -4195,7 +4209,18 @@ class TestGgufVisionToolRouting:
         assert exc.value.status_code == 400
         assert exc.value.detail["error"]["param"] == "tool_choice"
 
-    def test_confirm_tool_calls_requires_streaming_for_gguf_tools(self, monkeypatch):
+    # Two sites reject this shape, and `_should_validate_before_switch()` picks
+    # which: the early one runs ahead of the model switch so an invalid request
+    # cannot evict the resident model, and the one inside the GGUF branch runs
+    # after the monitor row is opened. That predicate reads process-wide state
+    # (an automatic load being possible, or a preview-owned slot), so leaving it
+    # unpinned asserted whichever site the rest of the worker happened to leave
+    # reachable. It passed alone and failed in CI once #10221 added cases and
+    # changed how xdist packed its workers. Pinned, and both sites are covered.
+    @pytest.mark.parametrize("validate_before_switch", [False, True])
+    def test_confirm_tool_calls_requires_streaming_for_gguf_tools(
+        self, monkeypatch, validate_before_switch
+    ):
         import routes.inference as inf_mod
 
         def _plain(**kwargs):
@@ -4214,6 +4239,9 @@ class TestGgufVisionToolRouting:
             generate_chat_completion_with_tools = _tools,
         )
         monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+        monkeypatch.setattr(
+            inf_mod, "_should_validate_before_switch", lambda: validate_before_switch
+        )
         monitor = ApiMonitor(max_entries = 3)
         monkeypatch.setattr(inf_mod, "api_monitor", monitor)
 
@@ -4234,11 +4262,19 @@ class TestGgufVisionToolRouting:
                     current_subject = "test",
                 )
             )
+        # The rejection itself is the same from either site.
         assert exc.value.status_code == 400
         assert "requires stream=true" in exc.value.detail["error"]["message"]
-        [entry] = monitor.snapshot()
-        assert entry["status"] == "error"
-        assert "confirm_tool_calls requires stream=true" in entry["error"]
+        if validate_before_switch:
+            # Rejected ahead of the switch, before the monitor row is opened, so
+            # there is no row to fail. Recording one here would change what the
+            # monitor shows and is a decision of its own, not a test fix.
+            assert monitor.snapshot() == []
+        else:
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "error"
+            assert "confirm_tool_calls requires stream=true" in entry["error"]
+        # Neither site may leave a row running, including the site that opens none.
         assert monitor.active_count() == 0
 
     def test_standard_gguf_stream_splits_reasoning_content(self, monkeypatch):


### PR DESCRIPTION
`(Python 3.13)` is red on `main` at `a12162ab5`, on one test out of 37,035:

```
FAILED tests/test_openai_tool_passthrough.py::TestGgufVisionToolRouting::test_confirm_tool_calls_requires_streaming_for_gguf_tools
  ValueError: not enough values to unpack (expected 1, got 0)

tests/test_openai_tool_passthrough.py:4239: [entry] = monitor.snapshot()
```

The status code and the message assertions pass. Only the API monitor row is missing.

## Two rejection sites, and nothing said which one runs

`produce_openai_chat_completions` refuses a `confirm_tool_calls` plus `stream=false` request in two places:

- early, inside `if _should_validate_before_switch():`, so an invalid request never evicts the resident model. This returns before the monitor row is opened, so there is no row.
- later, in the GGUF branch, through `_reject`, which fails the row that is already open.

`_should_validate_before_switch()` is `_automatic_model_load_may_run() or _preview_slot_is_owned()`. Both read process-wide state. The test never pinned it, so it asserted whichever site the rest of the xdist worker happened to leave reachable.

Forcing that predicate true reproduces the CI failure exactly, same line and same error:

```
tests/test_openai_tool_passthrough.py:4239: ValueError: not enough values to unpack (expected 1, got 0)
```

## #10221 is not at fault

Its change is confined to charset handling in `_fetch_url_raw`, and there is no path from that to whether a monitor row exists in the chat completions route. What it did was add 17 parametrized cases, which changes how xdist packs its four workers.

That fits every observation. The twelve `main` commits before it are green on this check, it is red exactly at that commit, and the test passes alone, passes with its file serially, passes with its file under `-n 4`, and did not fail in a full local `-n 4` run of the suite. It is a latent ordering flake that #10221 happened to shake loose.

## The change

Pin the predicate and parametrize over both values, so each site is asserted deliberately rather than by accident. Pinning it is what the rest of the suite already does: five times in `test_active_generations.py`, and again in `test_openai_auto_switch.py`.

This is not only a determinism fix. The early site was previously reached by luck, so half of this behaviour was never asserted on purpose. It is now.

A second test had the same fragility, `test_confirm_tool_calls_requires_streaming_for_safetensors_tools`. A regex scan of the file missed it and running the file with the predicate forced found it, so both are fixed the same way.

## Verification

The file, under both ambient conditions:

| | result |
| --- | --- |
| predicate left as the environment has it | 360 passed |
| predicate forced true, which is the CI condition | 360 passed |

360 rather than the previous 358, from the two added parametrizations. Before this change the second column was 1 failed.

I also ran the whole backend suite with the predicate forced against an unforced run of the same suite, to find any other test resting on it. These two are the only ones.

## One thing left alone

The two sites disagree about whether a rejected request is recorded at all, so the same 400 appears in the API monitor or does not, depending on whether an automatic load could have run. That is unrelated to #10221 and predates it. Recording a row at the early site changes what the monitor shows, which wants its own PR rather than being folded into an unblock, so this one documents the split instead of closing it.
