### PR TITLE
Studio: assert the write ordering, not what the write resolves to

### DIFF
--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2781,10 +2781,8 @@ def test_override_writes_are_ordered_per_model():
     requests with no sequencing, so the older response could commit last and resurrect
     the entry the newer one meant to replace."""
     src = " ".join(_read("features/model-picker/api/model-overrides.ts").split())
-    # One in-flight promise per key is the ordering. What that promise resolves
-    # TO is not: #10160 made it a ModelOverrideWriteResult so a forget can report
-    # removedKeys, and naming the old `void` here failed a change that reordered
-    # nothing.
+    # One in-flight promise per key is the ordering; what it resolves to is not,
+    # so pinning the old `void` failed #10160, which reordered nothing.
     assert (
         "const writesByKey = new Map<string, Promise<" in src
     ), "writes are no longer serialised through one in-flight promise per model"
@@ -2795,7 +2793,7 @@ def test_override_writes_are_ordered_per_model():
     )
     # Chained on the settled tail, so one failed write cannot cancel the next.
     assert "previous .catch(() => {}) .then(() => sendModelOverride(" in src
-    # And the tail is stored, or every writer chains on the same empty slot.
+    # The tail is stored, or every writer chains on the same empty slot.
     assert "writesByKey.set(key, write);" in src
     # Only the last writer clears the slot, or a queue still building loses order.
     assert "if (writesByKey.get(key) === write) { writesByKey.delete(key); }" in src

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2781,7 +2781,13 @@ def test_override_writes_are_ordered_per_model():
     requests with no sequencing, so the older response could commit last and resurrect
     the entry the newer one meant to replace."""
     src = " ".join(_read("features/model-picker/api/model-overrides.ts").split())
-    assert "const writesByKey = new Map<string, Promise<void>>();" in src
+    # One in-flight promise per key is the ordering. What that promise resolves
+    # TO is not: #10160 made it a ModelOverrideWriteResult so a forget can report
+    # removedKeys, and naming the old `void` here failed a change that reordered
+    # nothing.
+    assert (
+        "const writesByKey = new Map<string, Promise<" in src
+    ), "writes are no longer serialised through one in-flight promise per model"
     # Keyed by the same override key the server stores under.
     assert (
         "const key = modelOverrideKey( normalizeModelIdentity(modelId), normalizeGgufVariantIdentity(ggufVariant), );"
@@ -2789,6 +2795,8 @@ def test_override_writes_are_ordered_per_model():
     )
     # Chained on the settled tail, so one failed write cannot cancel the next.
     assert "previous .catch(() => {}) .then(() => sendModelOverride(" in src
+    # And the tail is stored, or every writer chains on the same empty slot.
+    assert "writesByKey.set(key, write);" in src
     # Only the last writer clears the slot, or a queue still building loses order.
     assert "if (writesByKey.get(key) === write) { writesByKey.delete(key); }" in src
 


### PR DESCRIPTION
`Repo tests (CPU)` is red on `main` at `2d346cce0`, on one test out of 15,843:

```
FAILED tests/studio/test_model_picker_contracts.py::test_override_writes_are_ordered_per_model
  assert 'const writesByKey = new Map<string, Promise<void>>();' in '...'
```

## #10160 is right, and reordered nothing

That PR lets the API load settings panel forget an entry, so `putModelOverride` now returns a `ModelOverrideWriteResult` carrying `removedKeys` instead of returning `void`. The queue it is stored in changed type with it:

```ts
const writesByKey = new Map<string, Promise<ModelOverrideWriteResult>>();
```

The ordering itself is untouched. Checked line by line against the source rather than assumed:

| what the test pins | still there |
| --- | --- |
| one in-flight promise per key | yes, `writesByKey` |
| key folded through `modelOverrideKey(normalizeModelIdentity, normalizeGgufVariantIdentity)` | yes, byte for byte |
| chained on the settled tail, `previous.catch(() => {}).then(() => sendModelOverride(` | yes, byte for byte |
| only the last writer clears the slot | yes, byte for byte |

Three of the four assertions still match unchanged. The one that broke names the promise's value type, and what a write resolves to has nothing to do with the order writes commit in.

## The change

Assert that writes are serialised through one in-flight promise per key, without naming what that promise resolves to.

The obvious alternative, re-syncing the literal to `Promise<ModelOverrideWriteResult>`, is worse than it looks: it leaves the test failing the next time the result type changes, which is a change that reorders nothing. This is the same shape as #10267 and #10231, an assertion written as one exact literal over something that is not fixed.

While here, one assertion is added rather than only relaxed: `writesByKey.set(key, write);`. Without the tail being stored, every writer chains on the same empty slot and the ordering is gone, and nothing in the test noticed.

## Verified by breaking it

Six edits to `model-overrides.ts`, each run against the test:

| edit | before, re-synced to the new type | after |
| --- | --- | --- |
| baseline | passed | passed |
| result type changes again, ordering untouched | **failed** | **passed** |
| the tail is never stored, a real ordering loss | **passed** | **failed** |
| serialisation removed entirely | failed | failed |
| writes no longer chain on the tail | failed | failed |
| any writer clears the slot, not just the last | failed | failed |
| the key stops folding the identity | failed | failed |

The middle two rows are the point. The first column is what a plain re-sync gives you: still brittle against a harmless change, and still blind to a real one.

`tests/studio/test_model_picker_contracts.py`: 191 passed. No source changes.
