### PR TITLE
Add a dispatch-only Docker Hub credential probe

### DIFF
--- a/.github/workflows/docker-credential-probe.yml
+++ b/.github/workflows/docker-credential-probe.yml
@@ -1,0 +1,94 @@
+# Answers one question before the Docker Hub cutover: does DOCKER_API_KEY actually
+# authenticate as REGISTRY_USERNAME, and does that account have push rights on the
+# unsloth/unsloth repository?
+#
+# docker-publish.yml has no pull_request trigger, so no PR run can ever exercise the
+# login. Without this probe the first real test would be a push to main, i.e. after
+# the publish workflow has already started building.
+#
+# workflow_dispatch only, so it never fires on its own. It pushes a scratch image of a
+# few hundred bytes to a throwaway tag, then deletes that tag again. Delete this file
+# once the cutover is done.
+name: Docker credential probe
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: unsloth/unsloth
+  # The account DOCKER_API_KEY belongs to. Not a secret.
+  REGISTRY_USERNAME: danielhanc
+  PROBE_TAG: credential-probe
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report what will be attempted
+        run: |
+          echo "registry:  ${REGISTRY}"
+          echo "image:     ${IMAGE_NAME}"
+          echo "username:  ${REGISTRY_USERNAME}"
+          echo "tag:       ${PROBE_TAG}"
+          if [ -z "${{ secrets.DOCKER_API_KEY }}" ]; then
+            echo "::error::DOCKER_API_KEY is empty or not visible to this workflow."
+            exit 1
+          fi
+          echo "DOCKER_API_KEY is present (value not printed)."
+
+      # Step 1: does the token authenticate at all?
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_API_KEY }}
+
+      - name: Confirm login succeeded
+        run: echo "Login OK as ${REGISTRY_USERNAME}."
+
+      # Step 2: authentication is not authorisation. Only a real push proves write
+      # access to THIS repository, so push a minimal scratch image.
+      - name: Build a scratch probe image
+        run: |
+          mkdir -p probe
+          printf 'FROM scratch\nLABEL org.unsloth.probe="credential-check"\n' > probe/Dockerfile
+          docker build -t "${IMAGE_NAME}:${PROBE_TAG}" probe/
+          docker image inspect "${IMAGE_NAME}:${PROBE_TAG}" --format 'built {{.Id}}'
+
+      - name: Push the probe tag
+        id: push
+        run: |
+          docker push "${IMAGE_NAME}:${PROBE_TAG}"
+          echo "PUSH OK: ${IMAGE_NAME}:${PROBE_TAG}"
+
+      # Clean up so the throwaway tag does not linger on a public namespace.
+      - name: Delete the probe tag
+        if: always() && steps.push.outcome == 'success'
+        run: |
+          TOKEN="$(curl -s -X POST https://hub.docker.com/v2/users/login/ \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\": \"${REGISTRY_USERNAME}\", \"password\": \"${{ secrets.DOCKER_API_KEY }}\"}" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin).get("token",""))')"
+          if [ -z "$TOKEN" ]; then
+            echo "::warning::Could not obtain a Hub API token to delete the probe tag. Delete ${IMAGE_NAME}:${PROBE_TAG} by hand."
+            exit 0
+          fi
+          CODE="$(curl -s -o /dev/stderr -w '%{http_code}' -X DELETE \
+            "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/${PROBE_TAG}/" \
+            -H "Authorization: JWT ${TOKEN}")"
+          echo "delete returned HTTP ${CODE}"
+          if [ "$CODE" != "204" ]; then
+            echo "::warning::Probe tag not deleted (HTTP ${CODE}). Remove ${IMAGE_NAME}:${PROBE_TAG} by hand."
+          fi
+
+      - name: Verdict
+        if: always()
+        run: |
+          echo "login:  ${{ job.status }}"
+          echo "push:   ${{ steps.push.outcome }}"
+          echo "If push is 'success', DOCKER_API_KEY authenticates as ${REGISTRY_USERNAME} and that account can write to ${IMAGE_NAME}."


### PR DESCRIPTION
Add a dispatch-only Docker Hub credential probe

Before taking over the unsloth/unsloth namespace on Docker Hub we need to know
that DOCKER_API_KEY authenticates as danielhanc and that the account can push to
that repository. Neither is currently testable: docker-publish.yml has no
pull_request trigger, so no PR run exercises the login, and the first real test
would otherwise be a push to main after the publish workflow has already begun
building.

This adds a workflow_dispatch-only probe that logs in, pushes a scratch image of
a few hundred bytes to a throwaway tag, and then deletes that tag again. It never
fires on its own and touches nothing else.

Authentication is checked separately from authorisation, because a valid token
does not imply write access to this particular repository, and only a real push
proves the second.

Delete this file once the cutover is done.
