### PR TITLE
Make the credential probe actually delete its throwaway tag

### DIFF
--- a/.github/workflows/docker-credential-probe.yml
+++ b/.github/workflows/docker-credential-probe.yml
@@ -91,19 +91,23 @@ jobs:
             echo "::error::${IMAGE_NAME}:${PROBE_TAG} is still published. Delete it by hand."
             exit 1
           fi
+          # The organization token is only accepted on the namespace-scoped routes;
+          # /v2/repositories/{owner}/{repo}/tags/... answers it with 403 whatever
+          # its scopes.
+          HUB="https://hub.docker.com/v2/namespaces/${IMAGE_NAME%%/*}/repositories/${IMAGE_NAME#*/}"
           CODE="$(curl -s -o /dev/stderr -w '%{http_code}' -X DELETE \
-            "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/${PROBE_TAG}/" \
+            "${HUB}/tags/${PROBE_TAG}" \
             -H "Authorization: Bearer ${TOKEN}")"
           echo "delete returned HTTP ${CODE}"
 
           # Confirm against the API rather than trusting the status code.
           STILL="$(curl -s -o /dev/null -w '%{http_code}' \
-            "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/${PROBE_TAG}/")"
+            "${HUB}/tags/${PROBE_TAG}" -H "Authorization: Bearer ${TOKEN}")"
           if [ "$STILL" = "404" ]; then
             echo "DELETE OK: ${IMAGE_NAME}:${PROBE_TAG} is gone."
           else
             echo "::error::${IMAGE_NAME}:${PROBE_TAG} still resolves (HTTP ${STILL}) after a delete returning ${CODE}."
-            echo "::error::The token most likely lacks scope-tag-admin. Delete the tag by hand."
+            echo "::error::The token most likely lacks the tag delete permission. Delete the tag by hand."
             exit 1
           fi
 

--- a/.github/workflows/docker-credential-probe.yml
+++ b/.github/workflows/docker-credential-probe.yml
@@ -68,23 +68,43 @@ jobs:
           echo "PUSH OK: ${IMAGE_NAME}:${PROBE_TAG}"
 
       # Clean up so the throwaway tag does not linger on a public namespace.
+      #
+      # An organization access token cannot use /v2/users/login/: that endpoint
+      # rejects organization accounts, so the first version of this step silently
+      # got an empty token, warned, and exited 0 while the tag stayed published.
+      # OATs are exchanged at /v2/auth/token instead, and the resulting JWT is
+      # sent as Bearer.
+      #
+      # Deleting a tag needs scope-tag-admin (or scope-image-delete), which is a
+      # different scope from the push permission the step above proves, so this
+      # can legitimately fail on a push-only token. It still must not report
+      # success: the tag is verified gone, and the step fails if it is not.
       - name: Delete the probe tag
         if: always() && steps.push.outcome == 'success'
         run: |
-          TOKEN="$(curl -s -X POST https://hub.docker.com/v2/users/login/ \
+          TOKEN="$(curl -s -X POST https://hub.docker.com/v2/auth/token \
             -H 'Content-Type: application/json' \
-            -d "{\"username\": \"${REGISTRY_USERNAME}\", \"password\": \"${{ secrets.DOCKER_API_KEY }}\"}" \
-            | python3 -c 'import json,sys; print(json.load(sys.stdin).get("token",""))')"
+            -d "{\"identifier\": \"${REGISTRY_USERNAME}\", \"secret\": \"${{ secrets.DOCKER_API_KEY }}\"}" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))')"
           if [ -z "$TOKEN" ]; then
-            echo "::warning::Could not obtain a Hub API token to delete the probe tag. Delete ${IMAGE_NAME}:${PROBE_TAG} by hand."
-            exit 0
+            echo "::error::Could not exchange DOCKER_API_KEY for a Hub API token at /v2/auth/token."
+            echo "::error::${IMAGE_NAME}:${PROBE_TAG} is still published. Delete it by hand."
+            exit 1
           fi
           CODE="$(curl -s -o /dev/stderr -w '%{http_code}' -X DELETE \
             "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/${PROBE_TAG}/" \
-            -H "Authorization: JWT ${TOKEN}")"
+            -H "Authorization: Bearer ${TOKEN}")"
           echo "delete returned HTTP ${CODE}"
-          if [ "$CODE" != "204" ]; then
-            echo "::warning::Probe tag not deleted (HTTP ${CODE}). Remove ${IMAGE_NAME}:${PROBE_TAG} by hand."
+
+          # Confirm against the API rather than trusting the status code.
+          STILL="$(curl -s -o /dev/null -w '%{http_code}' \
+            "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/${PROBE_TAG}/")"
+          if [ "$STILL" = "404" ]; then
+            echo "DELETE OK: ${IMAGE_NAME}:${PROBE_TAG} is gone."
+          else
+            echo "::error::${IMAGE_NAME}:${PROBE_TAG} still resolves (HTTP ${STILL}) after a delete returning ${CODE}."
+            echo "::error::The token most likely lacks scope-tag-admin. Delete the tag by hand."
+            exit 1
           fi
 
       - name: Verdict

--- a/tests/python/test_docker_credential_probe.py
+++ b/tests/python/test_docker_credential_probe.py
@@ -23,12 +23,23 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker-credential-probe.yml"
 @pytest.fixture(scope = "module")
 def delete_step() -> str:
     doc = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
-    steps = [s for job in doc["jobs"].values() for s in job["steps"] if s.get("name") == "Delete the probe tag"]
+    steps = [
+        s
+        for job in doc["jobs"].values()
+        for s in job["steps"]
+        if s.get("name") == "Delete the probe tag"
+    ]
     assert len(steps) == 1, "the delete step disappeared or was renamed"
     return steps[0]["run"]
 
 
-def _run(step: str, tmp_path: Path, *, still_there: bool, token: str = "tok") -> tuple[subprocess.CompletedProcess, str]:
+def _run(
+    step: str,
+    tmp_path: Path,
+    *,
+    still_there: bool,
+    token: str = "tok",
+) -> tuple[subprocess.CompletedProcess, str]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "curl.log"
@@ -47,18 +58,32 @@ def _run(step: str, tmp_path: Path, *, still_there: bool, token: str = "tok") ->
     assert "${{" not in script, "unexpanded expression in the delete step"
     env = dict(os.environ)
     env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
-    env.update(REGISTRY_USERNAME = "unsloth", IMAGE_NAME = "unsloth/unsloth", PROBE_TAG = "credential-probe")
+    env.update(
+        REGISTRY_USERNAME = "unsloth", IMAGE_NAME = "unsloth/unsloth", PROBE_TAG = "credential-probe"
+    )
     res = subprocess.run(
-        ["bash", "-e", "-c", script], capture_output = True, text = True, env = env, cwd = str(tmp_path), timeout = 60
+        ["bash", "-e", "-c", script],
+        capture_output = True,
+        text = True,
+        env = env,
+        cwd = str(tmp_path),
+        timeout = 60,
     )
     return res, log.read_text(encoding = "utf-8") if log.exists() else ""
 
 
-def test_the_delete_uses_the_namespace_route_the_org_token_is_allowed_on(delete_step: str, tmp_path: Path):
+def test_the_delete_uses_the_namespace_route_the_org_token_is_allowed_on(
+    delete_step: str, tmp_path: Path
+):
     res, log = _run(delete_step, tmp_path, still_there = False)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert "-X DELETE https://hub.docker.com/v2/namespaces/unsloth/repositories/unsloth/tags/credential-probe" in log
-    assert "/v2/repositories/" not in log, "the legacy route answers every organization token with 403"
+    assert (
+        "-X DELETE https://hub.docker.com/v2/namespaces/unsloth/repositories/unsloth/tags/credential-probe"
+        in log
+    )
+    assert (
+        "/v2/repositories/" not in log
+    ), "the legacy route answers every organization token with 403"
     assert '"identifier": "unsloth"' in log
     assert "Authorization: Bearer tok" in log
 

--- a/tests/python/test_docker_credential_probe.py
+++ b/tests/python/test_docker_credential_probe.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-Present the Unsloth team. See /studio/LICENSE.AGPL-3.0
+
+"""The credential probe pushes a throwaway tag and must remove it again. Docker Hub
+rejects an organization access token on the legacy /v2/repositories/... routes
+with 403 whatever its scopes, and only the namespace-scoped routes accept it, so
+the delete step is run here with curl stubbed and its requests inspected.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker-credential-probe.yml"
+
+
+@pytest.fixture(scope = "module")
+def delete_step() -> str:
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
+    steps = [s for job in doc["jobs"].values() for s in job["steps"] if s.get("name") == "Delete the probe tag"]
+    assert len(steps) == 1, "the delete step disappeared or was renamed"
+    return steps[0]["run"]
+
+
+def _run(step: str, tmp_path: Path, *, still_there: bool, token: str = "tok") -> tuple[subprocess.CompletedProcess, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "curl.log"
+    (bin_dir / "curl").write_text(
+        "#!/usr/bin/env bash\n"
+        f"printf '%s\\n' \"$*\" >> {log}\n"
+        'case "$*" in\n'
+        f'  *auth/token*) printf \'{{"access_token": "{token}"}}\' ;;\n'
+        "  *-X\\ DELETE*) printf '204' ;;\n"
+        f"  *) printf '{200 if still_there else 404}' ;;\n"
+        "esac\n",
+        encoding = "utf-8",
+    )
+    (bin_dir / "curl").chmod(0o755)
+    script = step.replace("${{ secrets.DOCKER_API_KEY }}", "not-a-secret")
+    assert "${{" not in script, "unexpanded expression in the delete step"
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
+    env.update(REGISTRY_USERNAME = "unsloth", IMAGE_NAME = "unsloth/unsloth", PROBE_TAG = "credential-probe")
+    res = subprocess.run(
+        ["bash", "-e", "-c", script], capture_output = True, text = True, env = env, cwd = str(tmp_path), timeout = 60
+    )
+    return res, log.read_text(encoding = "utf-8") if log.exists() else ""
+
+
+def test_the_delete_uses_the_namespace_route_the_org_token_is_allowed_on(delete_step: str, tmp_path: Path):
+    res, log = _run(delete_step, tmp_path, still_there = False)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "-X DELETE https://hub.docker.com/v2/namespaces/unsloth/repositories/unsloth/tags/credential-probe" in log
+    assert "/v2/repositories/" not in log, "the legacy route answers every organization token with 403"
+    assert '"identifier": "unsloth"' in log
+    assert "Authorization: Bearer tok" in log
+
+
+def test_a_tag_that_survives_the_delete_fails_the_step(delete_step: str, tmp_path: Path):
+    res, _ = _run(delete_step, tmp_path, still_there = True)
+    assert res.returncode != 0
+    assert "still resolves" in res.stdout + res.stderr
+
+
+def test_no_token_means_no_delete_and_a_failure(delete_step: str, tmp_path: Path):
+    res, log = _run(delete_step, tmp_path, still_there = True, token = "")
+    assert res.returncode != 0
+    assert "DELETE" not in log


### PR DESCRIPTION
## Summary

The Docker Hub credential probe added in #7290 ran and answered its question. `DOCKER_API_KEY` authenticates as the `unsloth` organization and can push to `unsloth/unsloth`:

```
Login OK as unsloth.
PUSH OK: unsloth/unsloth:credential-probe
```

Its cleanup step then reported success while deleting nothing, and `unsloth/unsloth:credential-probe` is still published on the public namespace.

## The bug

An organization access token cannot authenticate at `/v2/users/login/`. That endpoint rejects organization accounts, so the token exchange returned an empty string, the step took its warning branch and exited 0, and the tag survived. The run went green with a warning nobody had to read.

This is the same shape of defect as the ones being fixed elsewhere in the Docker work: a step that cannot do its job reports success anyway.

## The change

- Exchange the token at `/v2/auth/token` with `identifier` and `secret`, and send the resulting JWT as `Bearer`. This is the documented flow for organization access tokens.
- Delete and read back on the namespace-scoped route `/v2/namespaces/{owner}/repositories/{repo}/tags/{tag}`. The legacy `/v2/repositories/...` path answers every organization token with 403 whatever its scopes, which is the same wall the Hub page sync hit in #10343. Verified live with a throwaway tag: legacy DELETE 403, namespace DELETE 204, tag gone afterwards.
- Stop reporting success when the tag is still there. The step re-queries the tag after the delete and fails if it still resolves, rather than trusting the returned status code.

Deleting a tag needs the tag delete permission on the token, which is separate from the push permission the probe proves, so this can still legitimately fail on a push-only token. That outcome is fine and is now visible rather than silent, with the error naming the likely cause.

## After this merges

Dispatch the workflow once to clear the leftover tag. If it fails on scope, the tag needs removing by hand from the Docker Hub UI, and the failure message says so.

The workflow is temporary by design and its header says to delete the file once the cutover is done.



## Tests

`tests/python/test_docker_credential_probe.py` runs the delete step with curl stubbed and pins the namespace route, the organization identifier, that the legacy path is never requested, and that a surviving tag or a missing token fails the step.