### PR TITLE
Anchor studio source slices on declarations, not on comment text

### DIFF
--- a/tests/studio/_node_harness.py
+++ b/tests/studio/_node_harness.py
@@ -41,10 +41,9 @@ def read(path: Path) -> str:
 def require_code_anchor(marker: str, role: str) -> None:
     """Refuse a comment as a slice anchor.
 
-    A comment is prose about the code, not the code, so it can be reworded or dropped
-    without a line of behaviour moving. #10114 trimmed comments across studio/frontend
-    and took 93 tests here down with it, none of which were about anything it changed.
-    Anchor on the declaration or statement the comment sits above instead.
+    Comments are prose, so rewording one moves no behaviour but still breaks the slice:
+    #10114 trimmed studio/frontend comments and failed 93 tests here over nothing it
+    changed. Anchor on the declaration the comment sits above instead.
     """
     if marker.lstrip().startswith(("//", "/*")):
         raise AssertionError(

--- a/tests/studio/_node_harness.py
+++ b/tests/studio/_node_harness.py
@@ -45,7 +45,7 @@ def require_code_anchor(marker: str, role: str) -> None:
     #10114 trimmed studio/frontend comments and failed 93 tests here over nothing it
     changed. Anchor on the declaration the comment sits above instead.
     """
-    if marker.lstrip().startswith(("//", "/*")):
+    if marker.lstrip().startswith(("//", "/*", "{/*")):
         raise AssertionError(
             f"{role} anchor is a comment, so rewording it breaks this test: {marker!r}"
         )

--- a/tests/studio/_node_harness.py
+++ b/tests/studio/_node_harness.py
@@ -38,8 +38,24 @@ def read(path: Path) -> str:
     return path.read_text(encoding = "utf-8")
 
 
+def require_code_anchor(marker: str, role: str) -> None:
+    """Refuse a comment as a slice anchor.
+
+    A comment is prose about the code, not the code, so it can be reworded or dropped
+    without a line of behaviour moving. #10114 trimmed comments across studio/frontend
+    and took 93 tests here down with it, none of which were about anything it changed.
+    Anchor on the declaration or statement the comment sits above instead.
+    """
+    if marker.lstrip().startswith(("//", "/*")):
+        raise AssertionError(
+            f"{role} anchor is a comment, so rewording it breaks this test: {marker!r}"
+        )
+
+
 def slice_between(text: str, start_marker: str, end_marker: str) -> str:
     """The source from ``start_marker`` up to (not including) ``end_marker``."""
+    require_code_anchor(start_marker, "start")
+    require_code_anchor(end_marker, "end")
     start = text.index(start_marker)
     end = text.index(end_marker, start + len(start_marker))
     return text[start:end]

--- a/tests/studio/test_cancelled_turn_history_prune.py
+++ b/tests/studio/test_cancelled_turn_history_prune.py
@@ -112,7 +112,7 @@ def _harness_source() -> str:
         HARNESS
         + _adapter_slice("function collectTextParts(", "function normalizeOpenAIReasoningItem(")
         + _adapter_slice(
-            "// Refusal flag stamped on assistant metadata",
+            "function isAnthropicRefusalMessage(",
             "type SerializedMessage = {",
         )
         + _adapter_slice(
@@ -130,7 +130,7 @@ def _harness_source() -> str:
         )
         + slice_between(
             read(CONTINUATION),
-            "/** Why a turn ended before the model was done. */",
+            "export type IncompleteReason =",
             "const INCOMPLETE_LABELS",
         )
         + """

--- a/tests/studio/test_chat_mount_cli_load_adoption.py
+++ b/tests/studio/test_chat_mount_cli_load_adoption.py
@@ -256,8 +256,8 @@ def _build_harness(run_dir: Path) -> None:
     assert "async function waitForServerModel(" in poll
     sync = _between(
         source,
-        "// Prevent older concurrent status reads",
-        "/**\n * Reconcile the UI after the SERVER unloaded",
+        "let syncGeneration = 0;",
+        "export async function resyncInferenceStatusAfterServerModelChange(",
     )
     assert "async function syncInferenceStatusToStore(" in sync
     # The sequencing IS the bug, so refresh runs for real rather than being re-typed here.

--- a/tests/studio/test_chat_thinking_compact_layout.py
+++ b/tests/studio/test_chat_thinking_compact_layout.py
@@ -23,7 +23,7 @@ def test_narrow_composer_collapses_thinking_to_the_bulb():
     # Query the composer width instead of the full viewport.
     assert css.count("container-type: inline-size;") >= 2
     compact_start = css.index("@container (max-width: 36rem)")
-    compact_end = css.index("/* Smaller tick", compact_start)
+    compact_end = css.index("\t.unsloth-tick {", compact_start)
     compact_rule = css[compact_start:compact_end]
 
     assert ".unsloth-thinking-pill" in compact_rule

--- a/tests/studio/test_chat_thread_read_consolidation.py
+++ b/tests/studio/test_chat_thread_read_consolidation.py
@@ -27,7 +27,9 @@ def test_chat_run_reuses_one_thread_metadata_read() -> None:
 
     # The first shared read must sit after the model-ready wait, so a chat moved
     # to another project mid-load is still seen by the reads that follow.
-    model_ready_boundary = run.index(squash("// Re-read store after auto-load / model-ready wait."))
+    model_ready_boundary = run.index(
+        squash("      const liveRuntime = useChatRuntimeStore.getState();")
+    )
     first_shared_read = run.index(squash("const sandboxSessionId = await resolveSandboxSessionId("))
     assert first_shared_read > model_ready_boundary
 

--- a/tests/studio/test_deep_research_frontend_contract.py
+++ b/tests/studio/test_deep_research_frontend_contract.py
@@ -431,7 +431,7 @@ def test_the_handoff_uses_the_turn_that_asked_for_it() -> None:
 def test_a_local_model_without_tools_cannot_consume_research_without_classifying() -> None:
     adapter = source("features/chat/api/chat-adapter.ts")
     fallback = adapter.split("if (\n        deepResearchArmed &&", 1)[1].split(
-        "// Project sources auto-scope", 1
+        "      const ragProjectId = await resolveProjectId(", 1
     )[0]
 
     assert "!supportsTools" in fallback

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -903,9 +903,9 @@ def test_images_header_tracks_preview_and_preserves_titlebar_controls():
     before, marker, after = source.partition("h-[48px] shrink-0")
     assert marker
     opening = before.rsplit("<div", 1)[1] + marker + after.split(">", 1)[0]
-    header = opening + after.split(
-        '      {pageMode === "train" ? (\n        <DiffusionTrainPanel', 1
-    )[0]
+    header = (
+        opening + after.split('      {pageMode === "train" ? (\n        <DiffusionTrainPanel', 1)[0]
+    )
 
     assert "const { isMobile, pinned } = useSidebar();" in source
     assert "grid-cols-[minmax(0,408px)_minmax(13rem,1fr)]" in opening

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -903,7 +903,9 @@ def test_images_header_tracks_preview_and_preserves_titlebar_controls():
     before, marker, after = source.partition("h-[48px] shrink-0")
     assert marker
     opening = before.rsplit("<div", 1)[1] + marker + after.split(">", 1)[0]
-    header = opening + after.split("{/* Train mode", 1)[0]
+    header = opening + after.split(
+        '      {pageMode === "train" ? (\n        <DiffusionTrainPanel', 1
+    )[0]
 
     assert "const { isMobile, pinned } = useSidebar();" in source
     assert "grid-cols-[minmax(0,408px)_minmax(13rem,1fr)]" in opening

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1272,7 +1272,7 @@ def test_model_config_prepares_hf_token_before_gguf_metadata_preflight():
     """Settings classification must use the same stale-token recovery as load."""
     page = _read("features/model-picker/components/model-config-page.tsx")
     assert 'import { prepareHfTokenForUse } from "@/features/hf-auth";' in page
-    effect = page.split("// Fetch GGUF header dims", 1)[1]
+    effect = page.split("  const contextFetchKey = target.isGguf", 1)[1]
     effect = effect.split("const stagedDims =", 1)[0]
     prepare = effect.index("prepareHfTokenForUse(hfToken || null)")
     metadata = effect.index("fetchGgufStagedMetadata({", prepare)
@@ -2193,9 +2193,9 @@ def test_parallel_slots_control_cleared_when_the_load_never_sent_them():
     assert "nParallel: null," in non_gguf_branch
     assert "loadedNParallel: null," in non_gguf_branch
 
-    fresh_default = adapter.split("// Nothing on the device:", 1)[1].split(
-        "showAutoLoadSuccess(\n          `Loaded ${DEFAULT_CHAT_MODEL_LABEL}", 1
-    )[0]
+    fresh_default = adapter.split(
+        "      return { loaded: false, blockedByTrustRemoteCode: false };", 1
+    )[1].split("showAutoLoadSuccess(\n          `Loaded ${DEFAULT_CHAT_MODEL_LABEL}", 1)[0]
     # The fresh-default download omits the slots, so its success state clears both,
     # or the control reads as an unapplied edit against the seeded baseline.
     assert "n_parallel" not in fresh_default.split("saveSpeculativeType", 1)[0]
@@ -3533,7 +3533,9 @@ def test_default_model_download_is_visible_and_cancellable():
     assert "loadModel(" not in helper
 
     auto_load = src.split("async function autoLoadSmallestModel", 1)[1]
-    fallback = auto_load.split("// Nothing on the device:", 1)[1]
+    fallback = auto_load.split(
+        "      return { loaded: false, blockedByTrustRemoteCode: false };", 1
+    )[1]
     assert 'if (download !== "ready") {' in fallback
     # Cancelling leaves the user with actionable next steps, not a dead end.
     assert "Pick one from the top bar" in fallback
@@ -3641,7 +3643,7 @@ def test_a_failed_quant_is_marked_tried_so_the_repo_continues():
     """One corrupt quant must not cost a repo that holds a valid one."""
     src = _read("features/chat/api/chat-adapter.ts")
     cascade = src.split("for (const source of sources)", 1)[1]
-    cascade = cascade.split("// Nothing on the device:", 1)[0]
+    cascade = cascade.split("    try {\n      const rt = useChatRuntimeStore.getState();", 1)[0]
     assert "while (!autoLoadCancelled && loadAttempts < MAX_AUTO_LOAD_ATTEMPTS)" in cascade
     assert "skippedAutoLoadCandidates.add(" in cascade
 
@@ -3679,7 +3681,9 @@ def test_sources_dedupe_on_the_load_target_alone():
     assert "filter(" not in order
     # The skip is keyed on a candidate having been resolved, not on merely visiting.
     body = src.split("const candidateResolvedFor = new Set<string>();", 1)[1]
-    body = body.split("\n    // Cap also gates", 1)[0]
+    body = body.split(
+        "\n    if (loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS || loadFailure.current) {", 1
+    )[0]
     assert body.index("if (candidateResolvedFor.has(sourceKey)) continue;") < body.index(
         "candidateResolvedFor.add(sourceKey);"
     )
@@ -3817,7 +3821,7 @@ def test_the_default_is_preflighted_before_the_managed_download():
     """A refusal from the training or placement guard must not cost gigabytes
     first."""
     src = _read("features/chat/api/chat-adapter.ts")
-    fallback = src.split("// Nothing on the device:", 1)[1]
+    fallback = src.split("      return { loaded: false, blockedByTrustRemoteCode: false };", 1)[1]
     fallback = fallback.split("export function createOpenAIStreamAdapter", 1)[0]
     assert fallback.index("canAutoLoad({") < fallback.index("ensureDefaultModelDownloaded(")
     # One GPU snapshot feeds both, so the load sends what was cleared.
@@ -4020,7 +4024,7 @@ def test_the_diffusion_gpu_choices_are_memoized():
     """
     src = " ".join(_read("hooks/use-gpu-info.ts").split())
     choices = src[src.index("export function useDiffusionGpuChoices") :]
-    choices = choices[: choices.index("/** Whether device discovery")]
+    choices = choices[: choices.index("export function gpuDeviceCacheReady(")]
     assert "return useMemo(() => {" in choices
     # Keyed on the device list, which useGpuDevices only replaces when the inventory changes.
     assert "}, [devices]);" in choices

--- a/tests/studio/test_multi_chat_prompt_queue_contract.py
+++ b/tests/studio/test_multi_chat_prompt_queue_contract.py
@@ -325,8 +325,8 @@ def test_a_send_parked_on_the_settings_gate_queues_if_a_run_started_meanwhile():
     """
     release = _between(
         THREAD,
-        "// Fire the parked send once indexing clears",
-        "// Drop any queued send + toast on unmount",
+        "      parkIfWaitingOnAttachments,\n    ],\n  );",
+        "  useEffect(\n    () => () => {\n      pendingSendRef.current = false;",
     )
     code = re.sub(r"//[^\n]*", "", release)
     assert "const waitForCurrentRun =" in code
@@ -468,7 +468,7 @@ def test_queued_settings_are_thread_scoped_without_cross_chat_fallback():
     assert "...queuedRunSettings" in research
     auto_load_merge = _between(
         CHAT_ADAPTER,
-        "// Re-read store after auto-load / model-ready wait.",
+        "      const liveRuntime = useChatRuntimeStore.getState();",
         "const { params } = runtime",
     )
     assert "...queuedRunSettings.params" in auto_load_merge
@@ -652,15 +652,15 @@ def test_queued_settings_are_thread_scoped_without_cross_chat_fallback():
     assert "useChatRuntimeStore.subscribe(" not in compare_handle
     gpu_discovery = _between(
         SHARED_COMPOSER,
-        "// Warm the device cache before the snapshot below",
-        "// The GPU/offload knobs both compare loads must use",
+        "      try {\n        if (store.selectedGpuIds != null) {",
+        "      const compareLoadKnobs = {",
     )
     assert "await ensureGpuDeviceCache();" in gpu_discovery
     assert "catch (error) {\n        releaseCompareModelLifecycle();" in gpu_discovery
     side_one = _between(
         SHARED_COMPOSER,
-        "// Side 1: load → generate → wait",
-        "// Side 2: load → generate → wait",
+        "        if (handle1 && model1?.id) {",
+        "        if (handle2 && model2?.id) {",
     )
     assert (
         side_one.index("const status1 = await ensureModelLoaded(model1)")
@@ -669,7 +669,7 @@ def test_queued_settings_are_thread_scoped_without_cross_chat_fallback():
     )
     side_two = _between(
         SHARED_COMPOSER,
-        "// Side 2: load → generate → wait",
+        "        if (handle2 && model2?.id) {",
         "compareStepSucceededRef.current = true",
     )
     assert (
@@ -779,7 +779,7 @@ def test_queued_settings_are_thread_scoped_without_cross_chat_fallback():
     apply_compare_stop = _between(
         send_flow,
         "const applyCompareStopDecision = () => {",
-        "// Helper: load a model and update store checkpoint",
+        "      async function ensureModelLoaded(",
     )
     assert "cancelPreStreamRunReservations(" in apply_compare_stop
     assert "compareStopDecision?.preStreamRunTokens ?? []" in apply_compare_stop
@@ -788,7 +788,7 @@ def test_queued_settings_are_thread_scoped_without_cross_chat_fallback():
     ensure_compare_model = _between(
         send_flow,
         "async function ensureModelLoaded(",
-        "// Side 1: load",
+        "        if (handle1 && model1?.id) {",
     )
     already_active = _between(
         ensure_compare_model,
@@ -901,8 +901,8 @@ def test_compare_prompt_list_resets_when_preflight_never_starts_a_run():
 
     failed_gpu_discovery = _between(
         send_flow,
-        "// Warm the device cache before the snapshot below",
-        "// The GPU/offload knobs both compare loads must use",
+        "      try {\n        if (store.selectedGpuIds != null) {",
+        "      const compareLoadKnobs = {",
     )
     assert "resetPromptQueue();" in failed_gpu_discovery
 

--- a/tests/studio/test_multi_chat_prompt_queue_contract.py
+++ b/tests/studio/test_multi_chat_prompt_queue_contract.py
@@ -1083,7 +1083,7 @@ def test_the_history_adapters_publish_stands_down_with_the_autosaves():
     append = _between(
         RUNTIME_PROVIDER,
         "      append({ parentId, message }: ExportedMessageRepositoryItem) {",
-        "\n  // Always register the adapter so the mic stays clickable",
+        "\n  const dictation = useMemo(() => new StudioDictationAdapter(), []);",
     )
 
     assert (

--- a/tests/studio/test_new_chat_context_recount.py
+++ b/tests/studio/test_new_chat_context_recount.py
@@ -106,7 +106,7 @@ def _new_chat_effects() -> list[tuple[list[str], str]]:
 def _thread_recount_effects() -> list[tuple[list[str], str]]:
     return _component_effects(
         "function ThreadContextUsageRecount(",
-        "\n// Exposes the current thread's cancelRun()",
+        "\nfunction CancelRegistrar(",
     )
 
 
@@ -116,7 +116,7 @@ def _store_reducers() -> str:
     checkpoint = slice_between(
         text,
         "setCheckpoint: (modelId, ggufVariant, options) =>",
-        "  // Re-apply the incoming thread's own usage",
+        "  setActiveThreadId: (activeThreadId) =>",
     )
     active = slice_between(
         text, "setActiveThreadId: (activeThreadId) =>", "applyThreadScopedSettings:"
@@ -148,7 +148,7 @@ def _resident_fast_path() -> str:
     return slice_between(
         read(RUNTIME),
         "          const confirmedStatus = await getInferenceStatus().catch(() => null);",
-        "      // Block queue materialization before taking the cancellation snapshot.",
+        "      const lifecycleLease = useChatRuntimeStore",
     )
 
 
@@ -156,8 +156,8 @@ def _history_usage_restore() -> str:
     """The history loader's saved-usage restore and its recount call, verbatim."""
     return slice_between(
         read(PROVIDER),
-        "        // Window check applies only when a local GGUF window is known; external",
-        "        // If any message has a stored parentId, reconstruct the tree so",
+        "        const localLimit = store.loadedIsGguf ? store.loadedContextLength : null;",
+        "        const hasParentIds = msgs.some((m) => m.parentId != null);",
     )
 
 
@@ -1985,7 +1985,7 @@ def test_the_count_is_retried_once_the_run_finishes():
     recount = slice_between(
         src,
         "function ThreadContextUsageRecount(",
-        "\n// Exposes the current thread's cancelRun()",
+        "\nfunction CancelRegistrar(",
     )
     assert "runningByThreadId" in recount, "the effect must observe decoding"
     deps = re.search(r"\}, \[([^\]]*)\]\);", recount, re.S)

--- a/tests/studio/test_nonce_chat_resume_restore.py
+++ b/tests/studio/test_nonce_chat_resume_restore.py
@@ -40,7 +40,7 @@ def _restore_effect() -> str:
     component = slice_between(
         read(PROVIDER),
         "function NonceThreadResumeRestore(",
-        "\n// A thread read that fails leaves the chat unpaired",
+        "\nconst THREAD_READ_RETRY_MS =",
     )
     match = re.search(r"useEffect\(\(\) => \{\n(.*?)\n  \}, \[([^\]]*)\]\);", component, re.S)
     assert match, "NonceThreadResumeRestore effect not found"

--- a/tests/studio/test_project_chat_view_switch.py
+++ b/tests/studio/test_project_chat_view_switch.py
@@ -127,7 +127,7 @@ def _provider_jsx() -> str:
     return slice_between(
         read(PROVIDER),
         "      <ToolPaneScopeContext.Provider",
-        "        {/* The view stays mounted",
+        "        {children}",
     )
 
 

--- a/tests/studio/test_token_count_prompt_parity.py
+++ b/tests/studio/test_token_count_prompt_parity.py
@@ -51,7 +51,7 @@ def _prune_helpers() -> str:
     """isAbandonedAssistantTurn + pruneOutboundHistory, which the outbound builder calls."""
     return slice_between(
         read(ADAPTER),
-        "/** Payload the turn carries in its own parts",
+        "function assistantTurnCarriesPayload(",
         "function extractImageBase64(",
     )
 
@@ -60,7 +60,7 @@ def _outbound_builder() -> str:
     return slice_between(
         read(ADAPTER),
         "export async function buildLocalTokenCountHistory(",
-        "/**\n * The reasoning fields a completion would send",
+        "export function buildLocalTokenCountReasoning(",
     )
 
 
@@ -82,7 +82,7 @@ def _extras_builder() -> str:
         slice_between(
             read(ADAPTER),
             "function resolveAutoInject(",
-            "\n\n/** Server-side usage data",
+            "\ninterface ServerUsage {",
         ),
         slice_between(
             read(ADAPTER),
@@ -98,12 +98,12 @@ def _reasoning_builder() -> str:
     clamp = slice_between(
         read(CAPABILITIES),
         "export function clampReasoningEffortToLevels(",
-        "\n/**",
+        "\nexport const EXTERNAL_MAX_OUTPUT_TOKENS =",
     )
     builder = slice_between(
         read(ADAPTER),
         "export function buildLocalTokenCountReasoning(",
-        "/**\n * The tool flags a completion would send",
+        "export async function buildLocalTokenCountExtras(",
     )
     return clamp + "\n" + builder
 

--- a/tests/studio/test_usage_examples_model_source_contract.py
+++ b/tests/studio/test_usage_examples_model_source_contract.py
@@ -15,8 +15,7 @@ API_KEYS_TAB_TSX = SETTINGS / "tabs/api-keys-tab.tsx"
 KEYLESS_SECTION_TSX = SETTINGS / "components/keyless-api-access-section.tsx"
 KEYLESS_ELIGIBILITY_TS = SETTINGS / "components/keyless-example-eligibility.ts"
 
-# The declaration below the hook, so the slice ends where the hook does. Not the comment
-# above it: prose moves without the code moving.
+# Ends the hook slice on the declaration below it, not a comment: prose can move alone.
 AFTER_HOOK = "function canUseLocalAgentDetection(base: string): boolean {"
 
 

--- a/tests/studio/test_usage_examples_model_source_contract.py
+++ b/tests/studio/test_usage_examples_model_source_contract.py
@@ -15,13 +15,17 @@ API_KEYS_TAB_TSX = SETTINGS / "tabs/api-keys-tab.tsx"
 KEYLESS_SECTION_TSX = SETTINGS / "components/keyless-api-access-section.tsx"
 KEYLESS_ELIGIBILITY_TS = SETTINGS / "components/keyless-example-eligibility.ts"
 
+# The declaration below the hook, so the slice ends where the hook does. Not the comment
+# above it: prose moves without the code moving.
+AFTER_HOOK = "function canUseLocalAgentDetection(base: string): boolean {"
+
 
 def test_examples_name_a_model_the_server_can_serve():
     # A hardcoded repo id made copied curls 404; read the servable ids from /v1/models.
     src = USAGE_EXAMPLES_TSX.read_text(encoding = "utf-8")
     assert 'from "../api/openai-models"' in src
     assert "function useExampleModelName(keylessOnly: boolean): string" in src
-    hook = src[src.find("function useExampleModelName") : src.find("// Backend PATH detection")]
+    hook = src[src.find("function useExampleModelName") : src.find(AFTER_HOOK)]
     assert "listOpenAIModels()" in hook
     # Precedence: live checkpoint, then a loaded entry, then any entry if switching is on.
     assert "catalog?.find((m) => m.loaded) ??" in hook
@@ -57,7 +61,7 @@ def test_catalog_refresh_follows_the_loaded_model():
     # name. Nor may it be gated on having no checkpoint: the store keeps one across an
     # idle unload, which changes nothing React can see.
     src = USAGE_EXAMPLES_TSX.read_text(encoding = "utf-8")
-    hook = src[src.find("function useExampleModelName") : src.find("// Backend PATH detection")]
+    hook = src[src.find("function useExampleModelName") : src.find(AFTER_HOOK)]
     assert "}, [checkpoint, ggufVariant]);" in hook
     assert "needsCatalog" not in hook
     # A finishing download moves no store state, so the fetch retries on a timer too,
@@ -73,7 +77,7 @@ def test_a_stored_checkpoint_needs_catalog_evidence():
     # preferring it on the switch setting alone named a model /v1/models had proved
     # absent, and the snippets 404d instead of falling back.
     src = USAGE_EXAMPLES_TSX.read_text(encoding = "utf-8")
-    hook = src[src.find("function useExampleModelName") : src.find("// Backend PATH detection")]
+    hook = src[src.find("function useExampleModelName") : src.find(AFTER_HOOK)]
     assert 'const entry = catalog?.find((m) => sameBaseModelId(m.id, checkpoint ?? ""));' in hook
     # resident, or downloaded with switching able to load this exact catalog entry.
     assert "entry.loaded || (!keylessOnly && autoSwitch)" in hook
@@ -83,7 +87,7 @@ def test_a_stored_checkpoint_needs_catalog_evidence():
 def test_idle_unload_does_not_guess_the_stashed_checkpoint():
     # the idle stash is process-wide, but the browser checkpoint is not.
     src = USAGE_EXAMPLES_TSX.read_text(encoding = "utf-8")
-    hook = src[src.find("function useExampleModelName") : src.find("// Backend PATH detection")]
+    hook = src[src.find("function useExampleModelName") : src.find(AFTER_HOOK)]
     assert "idleReload" not in hook
     assert "idleUnloadActive" not in hook
 
@@ -93,7 +97,7 @@ def test_a_failed_refresh_does_not_erase_what_the_server_holds():
     # a still-servable model and printed "No model". The catalog is deliberately
     # tri-state, and a failure must stay the unknown state.
     src = USAGE_EXAMPLES_TSX.read_text(encoding = "utf-8")
-    hook = src[src.find("function useExampleModelName") : src.find("// Backend PATH detection")]
+    hook = src[src.find("function useExampleModelName") : src.find(AFTER_HOOK)]
     assert "listOpenAIModels().catch(() => null)" in hook
     assert ".catch(() => null)," in hook
     assert "if (models !== null) setCatalog(models);" in hook
@@ -109,7 +113,7 @@ def test_the_pinned_quant_comes_from_the_catalog():
     # a file deleted while another quant remains, so pinning it 404d on a missing quant
     # with a runnable one listed.
     src = USAGE_EXAMPLES_TSX.read_text(encoding = "utf-8")
-    hook = src[src.find("function useExampleModelName") : src.find("// Backend PATH detection")]
+    hook = src[src.find("function useExampleModelName") : src.find(AFTER_HOOK)]
     assert "const quant = catalog === null ? ggufVariant : entry?.quant;" in hook
     assert "`${checkpoint}:${ggufVariant}`" not in hook
 


### PR DESCRIPTION
`Repo tests (CPU)` is red on `main` at `553fdf8b6`, and so on every PR branched from it, with 93 failures out of 15,899:

```
93 failed, 15806 passed, 366 skipped in 682.76s

56  tests/studio/test_new_chat_context_recount.py
18  tests/studio/test_cancelled_turn_history_prune.py
13  tests/studio/test_token_count_prompt_parity.py
 3  tests/studio/test_model_picker_contracts.py
 1  tests/studio/test_multi_chat_prompt_queue_contract.py
 1  tests/studio/test_deep_research_frontend_contract.py
 1  tests/studio/test_chat_thread_read_consolidation.py
```

Almost all of them are one line in the harness:

```
tests/studio/_node_harness.py:44: in slice_between
    end = text.index(end_marker, start + len(start_marker))
E   ValueError: substring not found
    end_marker = '      // Block queue materialization before taking the cancellation snapshot.'
```

## #10114 is right, and it changed no behaviour at all

`studio/frontend` carries no JS test runner, so these tests slice the real source verbatim into a node harness and run it. The slices are delimited by markers, and a lot of those markers were comments.

#10114 trimmed comments across 245 frontend files. That comment now reads

```
// Block queue materialization before taking the cancellation snapshot: a queue that appears while
```

and four others the tests named were removed outright. Not one line of behaviour moved, and 93 tests went red.

A comment is prose about the code, not the code. It is exactly the thing a maintainer is free to reword, and a comment-only PR is the clearest possible case of a change these tests should not be able to see. They failed the one kind of edit they should have been blind to.

## The change

Anchor the slices on the declaration or statement the comment sat above, not on the comment. 29 anchors across 12 files, including ones that still happen to match today and would have broken on the next trim.

```diff
     return slice_between(
         read(RUNTIME),
         "          const confirmedStatus = await getInferenceStatus().catch(() => null);",
-        "      // Block queue materialization before taking the cancellation snapshot.",
+        "      const lifecycleLease = useChatRuntimeStore",
     )
```

Each replacement was checked against the source as it stood immediately before #10114, where the old markers still resolve, and required to sit on the same side of the same code with nothing but comments and whitespace between it and the marker it replaces. So every slice covers the same statements it covered before, and each new anchor occurs exactly once in the file it is read from.

`slice_between` now refuses a comment as an anchor rather than failing later with `substring not found` several frames away:

```python
if marker.lstrip().startswith(("//", "/*")):
    raise AssertionError(
        f"{role} anchor is a comment, so rewording it breaks this test: {marker!r}"
    )
```

Re-syncing the literals is the obvious alternative and it is what the table below argues against: it gets `main` green today and goes red again on the next comment edit, which is the same edit #10114 made.

## Verified by breaking it

Thirteen edits to `studio/frontend`, each run against the test file that reads it. Comment-only edits must pass, real regressions must still fail:

| edit | expected | result |
| --- | --- | --- |
| trim the anchor's own comment again | pass | pass |
| delete the anchor's comment entirely | pass | pass |
| delete the docblock above a slice end | pass | pass |
| add a new comment above an anchor | pass | pass |
| reword the compare-composer comment | pass | pass |
| delete the deep-research comment | pass | pass |
| reword the usage-examples comment | pass | pass |
| resident fast path stops recounting | fail | fail |
| refusal detection always returns false | fail | fail |
| fresh default keeps the slot count | fail | fail |
| deep research drops the tools gate | fail | fail |
| compare side 2 loses its lifecycle acquire | fail | fail |
| the compact thinking rule stops hiding | fail | fail |

Three of those started out as bad mutations of mine that passed when they should have failed, which is the check working.

Next to what a plain re-sync of the literal would give, on the anchor that took 56 of the 93 down:

| | re-synced literal | this change |
| --- | --- | --- |
| baseline | 58 passed | 58 passed |
| that comment trimmed again | **56 failed, 2 passed** | **58 passed** |

`tests/studio`: 7483 passed, 195 skipped. No source changes.
