### PR TITLE
Stop pinning the flag name in the settings-mount guard assertion

### DIFF
--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -173,7 +173,15 @@ def test_auth_flow_routes_do_not_mount_global_settings():
     mount = (FRONTEND / "features/settings/settings-dialog-mount.tsx").read_text(encoding = "utf-8")
     assert "<SettingsDialogMount active={active && ready} />" in root
     assert "<CredentialBootstrapGate active={!isAuthFlowRoute}>" in root
-    assert "if (!active || !mounted) return null;" in mount
+    # The mount must refuse to render anything on the auth routes, and it says so with
+    # an early `return null` guarded on `!active`. Lock that guard, not the name of the
+    # flag beside it: #10237 renamed `mounted` to `settingsMounted || monitorMounted`
+    # when it added the resource monitor, which left this assertion failing against a
+    # file that still had exactly the property it was written to protect.
+    assert re.search(r"if \(!active \|\| !.*\) return null;", mount), (
+        "settings-dialog-mount.tsx no longer refuses to render while inactive, so the "
+        "settings dialog can mount on the login and change-password routes"
+    )
     assert "useSettingsDialogStore.getState().closeDialog();" in root
     # The settings chord must stay inert on the auth routes. That used to be an
     # early return inside a hand-rolled keydown handler; once the chords became


### PR DESCRIPTION
### Before

`Repo tests (CPU)` fails on main:

```
tests/studio/test_auth_form_input_count.py:176: in test_auth_flow_routes_do_not_mount_global_settings
    assert "if (!active || !mounted) return null;" in mount
E   AssertionError
```

### Why

The assertion arrived with #10236, which introduced `SettingsDialogMount` and its early
`return null`. #10237 then added the persisted resource monitor, which needs a second
mounted flag, so the guard became:

```tsx
if (!active || !(settingsMounted || monitorMounted)) return null;
```

That is the same property the test exists to protect. #10237 is correct; the assertion
pinned one spelling of the condition rather than the condition.

### After

The test matches the guard with `if \(!active \|\| !.*\) return null;`, so it passes on the
current file and on the pre-#10237 one.

### Verification

- `tests/studio/test_auth_form_input_count.py`: 9 passed on this branch, 1 failed on main.
- Negative check: dropping `!active` from the condition in `settings-dialog-mount.tsx`
  still fails the test, so it has not become vacuous.

No product code changes, so nothing to break for existing installs.