### PR TITLE
Pin the auth mount gate to its behaviour, not one spelling of the guard

### DIFF
--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -168,6 +168,69 @@ def test_login_jsx_declares_exactly_one_password_input():
     ), f"login JSX must declare exactly one password-typed input; found {pw_ids!r}"
 
 
+def _at_depth_zero(condition: str):
+    """Every character of ``condition`` that sits outside any bracket."""
+    depth = 0
+    for index, char in enumerate(condition):
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif depth == 0:
+            yield index, char
+
+
+def _leading_disjunct(condition: str) -> str:
+    """The first operand of ``condition`` read as a `||` chain.
+
+    Split at depth zero, so `!active || !(a || b)` yields `!active` and the inner
+    `||` is left where it belongs.
+    """
+    for index, char in _at_depth_zero(condition):
+        if char == "|" and condition[index : index + 2] == "||":
+            return condition[:index]
+    return condition
+
+
+def _is_conditional(condition: str) -> bool:
+    """Whether ``condition`` is a ternary rather than the test it looks like.
+
+    `?:` binds looser than `||`, so `!active || mounted ? false : true` reads as
+    `(!active || mounted) ? false : true` and skips the return while inactive.
+    `?.` and `??` are not that.
+    """
+    for index, char in _at_depth_zero(condition):
+        if char != "?":
+            continue
+        if condition[index + 1 : index + 2] in (".", "?") or condition[index - 1 : index] == "?":
+            continue
+        return True
+    return False
+
+
+def _inactive_returns_null(body: str) -> bool:
+    """Whether some `if` in ``body`` returns null on EVERY inactive render.
+
+    Read as a parse and not as text: the condition has to be a disjunction whose
+    first operand is `!active`, because that is what makes an inactive render
+    short-circuit to the return no matter what the rest of the guard says.
+    """
+    for match in re.finditer(r"\bif \(", body):
+        start = match.end()
+        depth, index = 1, start
+        while index < len(body) and depth:
+            depth += (body[index] == "(") - (body[index] == ")")
+            index += 1
+        condition, tail = body[start : index - 1], body[index:]
+        if not tail.lstrip().startswith("return null;"):
+            continue
+        if _is_conditional(condition):
+            continue
+        if _leading_disjunct(condition).strip() == "!active":
+            return True
+    return False
+
+
 def test_auth_flow_routes_do_not_mount_global_settings():
     root = (FRONTEND / "app/routes/__root.tsx").read_text(encoding = "utf-8")
     mount = (FRONTEND / "features/settings/settings-dialog-mount.tsx").read_text(encoding = "utf-8")
@@ -175,10 +238,9 @@ def test_auth_flow_routes_do_not_mount_global_settings():
     assert "<CredentialBootstrapGate active={!isAuthFlowRoute}>" in root
     # The mount must render nothing whenever inactive, which is what keeps the auth routes
     # clear. The rest of the guard is lazy-mount bookkeeping that #10237 changed from one
-    # flag to two, so an exact spelling stopped matching. `|| ...` after `!active` is allowed,
-    # `&& ...` is not, because the return must happen on every inactive render.
+    # flag to two, so an exact spelling stopped matching.
     mount_body = mount[mount.index("export function SettingsDialogMount(") :]
-    assert re.search(r"if \(!active(\)|\s*\|\|[^\n]*\))\s*return null;", mount_body), (
+    assert _inactive_returns_null(mount_body), (
         "SettingsDialogMount no longer returns null while inactive, so the settings "
         "dialog can mount on the auth routes"
     )

--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -173,12 +173,10 @@ def test_auth_flow_routes_do_not_mount_global_settings():
     mount = (FRONTEND / "features/settings/settings-dialog-mount.tsx").read_text(encoding = "utf-8")
     assert "<SettingsDialogMount active={active && ready} />" in root
     assert "<CredentialBootstrapGate active={!isAuthFlowRoute}>" in root
-    # SettingsDialogMount must render nothing whenever it is not active, which is what
-    # keeps the auth routes clear. What ELSE the guard tests is the lazy-mount
-    # bookkeeping and not this test's business: #10237 gave the mount a second surface,
-    # so the one `mounted` flag became `settingsMounted || monitorMounted` and an exact
-    # spelling stopped matching. `|| ...` is allowed after `!active` and `&& ...` is not,
-    # because the return has to happen for EVERY inactive render, not just some.
+    # The mount must render nothing whenever inactive, which is what keeps the auth routes
+    # clear. The rest of the guard is lazy-mount bookkeeping that #10237 changed from one
+    # flag to two, so an exact spelling stopped matching. `|| ...` after `!active` is allowed,
+    # `&& ...` is not, because the return must happen on every inactive render.
     mount_body = mount[mount.index("export function SettingsDialogMount("):]
     assert re.search(r"if \(!active(\)|\s*\|\|[^\n]*\))\s*return null;", mount_body), (
         "SettingsDialogMount no longer returns null while inactive, so the settings "

--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -177,7 +177,7 @@ def test_auth_flow_routes_do_not_mount_global_settings():
     # clear. The rest of the guard is lazy-mount bookkeeping that #10237 changed from one
     # flag to two, so an exact spelling stopped matching. `|| ...` after `!active` is allowed,
     # `&& ...` is not, because the return must happen on every inactive render.
-    mount_body = mount[mount.index("export function SettingsDialogMount("):]
+    mount_body = mount[mount.index("export function SettingsDialogMount(") :]
     assert re.search(r"if \(!active(\)|\s*\|\|[^\n]*\))\s*return null;", mount_body), (
         "SettingsDialogMount no longer returns null while inactive, so the settings "
         "dialog can mount on the auth routes"

--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -173,7 +173,17 @@ def test_auth_flow_routes_do_not_mount_global_settings():
     mount = (FRONTEND / "features/settings/settings-dialog-mount.tsx").read_text(encoding = "utf-8")
     assert "<SettingsDialogMount active={active && ready} />" in root
     assert "<CredentialBootstrapGate active={!isAuthFlowRoute}>" in root
-    assert "if (!active || !mounted) return null;" in mount
+    # SettingsDialogMount must render nothing whenever it is not active, which is what
+    # keeps the auth routes clear. What ELSE the guard tests is the lazy-mount
+    # bookkeeping and not this test's business: #10237 gave the mount a second surface,
+    # so the one `mounted` flag became `settingsMounted || monitorMounted` and an exact
+    # spelling stopped matching. `|| ...` is allowed after `!active` and `&& ...` is not,
+    # because the return has to happen for EVERY inactive render, not just some.
+    mount_body = mount[mount.index("export function SettingsDialogMount("):]
+    assert re.search(r"if \(!active(\)|\s*\|\|[^\n]*\))\s*return null;", mount_body), (
+        "SettingsDialogMount no longer returns null while inactive, so the settings "
+        "dialog can mount on the auth routes"
+    )
     assert "useSettingsDialogStore.getState().closeDialog();" in root
     # The settings chord must stay inert on the auth routes. That used to be an
     # early return inside a hand-rolled keydown handler; once the chords became

--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -192,14 +192,17 @@ def _leading_disjunct(condition: str) -> str:
     return condition
 
 
-def _is_conditional(condition: str) -> bool:
-    """Whether ``condition`` is a ternary rather than the test it looks like.
+def _binds_looser_than_or(condition: str) -> bool:
+    """Whether something outside the `||` chain decides what ``condition`` is worth.
 
-    `?:` binds looser than `||`, so `!active || mounted ? false : true` reads as
-    `(!active || mounted) ? false : true` and skips the return while inactive.
-    `?.` and `??` are not that.
+    `?:` and `,` both bind looser than `||`, so `!active || mounted ? false : true`
+    and `!active || track(), active` each leave the disjunction as a sub-expression
+    whose value is then discarded, and both skip the return while inactive. `?.` and
+    `??` are neither.
     """
     for index, char in _at_depth_zero(condition):
+        if char == ",":
+            return True
         if char != "?":
             continue
         if condition[index + 1 : index + 2] in (".", "?") or condition[index - 1 : index] == "?":
@@ -208,23 +211,78 @@ def _is_conditional(condition: str) -> bool:
     return False
 
 
-def _inactive_returns_null(body: str) -> bool:
-    """Whether some `if` in ``body`` returns null on EVERY inactive render.
+def _blanked(source: str) -> str:
+    """A same-length copy of ``source`` with comment and string bodies blanked.
 
-    Read as a parse and not as text: the condition has to be a disjunction whose
-    first operand is `!active`, because that is what makes an inactive render
-    short-circuit to the return no matter what the rest of the guard says.
+    Bracket depth and token searches only mean anything once prose and literals can
+    no longer contribute brackets, or a guard that survives only as a commented-out
+    line still reads as the guard.
+    """
+    out, index, end = list(source), 0, len(source)
+    while index < end:
+        pair = source[index : index + 2]
+        if pair in ("//", "/*"):
+            stop = source.find("\n" if pair == "//" else "*/", index + 2)
+            stop = end if stop == -1 else stop + (0 if pair == "//" else 2)
+            out[index:stop] = " " * (stop - index)
+            index = stop
+        elif source[index] in "\"'`":
+            quote, stop = source[index], index + 1
+            while stop < end and source[stop] != quote:
+                stop += 2 if source[stop] == "\\" else 1
+            out[index + 1 : stop] = " " * max(0, stop - index - 1)
+            index = min(stop + 1, end)
+        else:
+            index += 1
+    return "".join(out)
+
+
+def _function_body(source: str, name: str) -> str:
+    """``name``'s body, from its opening brace to the matching close.
+
+    The parameter list is walked past rather than skipped by eye: the signature is
+    `({ active }: { active: boolean })`, so the first brace after the name belongs to
+    the destructuring and not to the body.
+    """
+    index = source.index("(", source.index(f"export function {name}("))
+    depth = 0
+    while index < len(source):
+        depth += (source[index] == "(") - (source[index] == ")")
+        index += 1
+        if depth == 0:
+            break
+    opening = source.index("{", index)
+    depth = 0
+    for index in range(opening, len(source)):
+        depth += (source[index] == "{") - (source[index] == "}")
+        if depth == 0:
+            return source[opening : index + 1]
+    return source[opening:]
+
+
+def _inactive_returns_null(body: str) -> bool:
+    """Whether ``body`` returns null from its OWN top level on every inactive render.
+
+    Read as a parse and not as text. The condition has to be a disjunction whose first
+    operand is `!active`, because that is what makes an inactive render short-circuit to
+    the return whatever the rest of the guard says. Only statements directly in the
+    component body count: `(active) => { if (!active) return null; }` returns from the
+    callback and leaves the component mounting.
     """
     for match in re.finditer(r"\bif \(", body):
+        before = body[: match.start()]
+        if before.count("{") - before.count("}") != 1:
+            continue
         start = match.end()
         depth, index = 1, start
         while index < len(body) and depth:
             depth += (body[index] == "(") - (body[index] == ")")
             index += 1
         condition, tail = body[start : index - 1], body[index:]
-        if not tail.lstrip().startswith("return null;"):
+        # Braced or not: `{ return null; }` is the same guard through a formatter.
+        if not re.match(r"\s*\{?\s*return null;", tail):
             continue
-        if _is_conditional(condition):
+        if _binds_looser_than_or(condition):
             continue
         if _leading_disjunct(condition).strip() == "!active":
             return True
@@ -239,7 +297,7 @@ def test_auth_flow_routes_do_not_mount_global_settings():
     # The mount must render nothing whenever inactive, which is what keeps the auth routes
     # clear. The rest of the guard is lazy-mount bookkeeping that #10237 changed from one
     # flag to two, so an exact spelling stopped matching.
-    mount_body = mount[mount.index("export function SettingsDialogMount(") :]
+    mount_body = _function_body(_blanked(mount), "SettingsDialogMount")
     assert _inactive_returns_null(mount_body), (
         "SettingsDialogMount no longer returns null while inactive, so the settings "
         "dialog can mount on the auth routes"


### PR DESCRIPTION
`Repo tests (CPU)` is red on `main` at `99a83f6a6` and `a2a4143ce`, and so on PRs branched from them, on one test out of 15,899:

```
FAILED tests/studio/test_auth_form_input_count.py::test_auth_flow_routes_do_not_mount_global_settings
  assert 'if (!active || !mounted) return null;' in mount
```

## #10237 is right, and it did not open the auth routes

That PR gave `SettingsDialogMount` a second surface, so the single lazy-mount flag became two:

```diff
-  const [mounted, setMounted] = useState(open || monitorOpen);
-  if (!active || !mounted) return null;
+  if (!active || !(settingsMounted || monitorMounted)) return null;
```

The auth gate is untouched. `!active` still short-circuits, so an inactive mount still renders nothing, which is the whole of what this test is named for. What changed is the lazy-mount bookkeeping beside it, and the assertion happened to quote both halves as one string.

The other two assertions in this test still match byte for byte: `<SettingsDialogMount active={active && ready} />` and `<CredentialBootstrapGate active={!isAuthFlowRoute}>`. So the chain the test actually cares about, auth route to `active={false}` to nothing rendered, is intact at every link.

## The change

Assert that `SettingsDialogMount` returns null whenever it is not active, without naming the rest of the condition.

```python
mount_body = mount[mount.index("export function SettingsDialogMount("):]
assert re.search(r"if \(!active(\)|\s*\|\|[^\n]*\))\s*return null;", mount_body)
```

Two details are deliberate:

- Scoped to the `SettingsDialogMount` body. `SettingsDialogLoading` above it also carries `if (!active) return null;`, so an unscoped search would still pass with this guard deleted outright.
- `|| ...` is accepted after `!active` and `&& ...` is not. The return has to happen on every inactive render, not just some, and `&&` would let an inactive mount render.

This is the same shape as #10267, #10231, #10289 and #10297: an assertion written as one exact literal over something that was never fixed. This file had already reached that conclusion twice on its own, once as "Lock the count, not the spelling, so a rename does not falsely fail" and once as "Lock the behaviour, not one spelling of it, so either form passes". This assertion is the one that did not get the treatment.

## Verified by breaking it

Eight edits to `settings-dialog-mount.tsx`, each run against the test, next to what a plain re-sync of the literal to today's guard would give:

| edit | re-synced literal | this change |
| --- | --- | --- |
| baseline | passed | passed |
| both mount flags renamed | **failed** | **passed** |
| a third surface joins the mount | **failed** | **passed** |
| the operands reordered | **failed** | **passed** |
| back to a single flag, as before #10237 | **failed** | **passed** |
| the `!active` half dropped | failed | failed |
| `||` becomes `&&`, so inactive can still render | failed | failed |
| the whole guard deleted | failed | failed |
| the gate inverted to `active` | failed | failed |

The first four rows are the point. A re-sync goes red on any of them, none of which touches the auth routes, and the next one is as likely as #10237 was. The last four confirm the test still fails for every way the gate can actually break, including the guard being deleted while the identical line in `SettingsDialogLoading` stays put.

`tests/studio`: no other test changes. No source changes.
