### PR TITLE
Anchor the settings mount check on the guard, not its exact condition

### DIFF
--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -181,11 +181,15 @@ def test_auth_flow_routes_do_not_mount_global_settings():
     # Scoped to the exported component on purpose. SettingsDialogLoading above it carries its own
     # `if (!active) return null;`, so searching the whole file passes even with the guard under
     # test deleted outright, which is how the first attempt at this assertion was vacuous.
+    #
+    # The condition must be `!active` alone or `!active || ...`, never `!active && ...`. Inactive
+    # has to be sufficient to bail out on its own; an AND would let a previously mounted panel keep
+    # rendering on an auth route, which is the regression this guards.
     mount_body = mount.split("export function SettingsDialogMount", 1)
     assert len(mount_body) == 2, "SettingsDialogMount is no longer declared here"
     assert re.search(
-        r"if \(!active\b[^\n]*\) return null;", mount_body[1]
-    ), "SettingsDialogMount must bail out while inactive"
+        r"if \(!active(?:\s*\|\|[^\n]*)?\) return null;", mount_body[1]
+    ), "SettingsDialogMount must bail out whenever it is inactive, on that alone"
     assert "useSettingsDialogStore.getState().closeDialog();" in root
     # The settings chord must stay inert on the auth routes. That used to be an
     # early return inside a hand-rolled keydown handler; once the chords became

--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -185,10 +185,19 @@ def test_auth_flow_routes_do_not_mount_global_settings():
     # The condition must be `!active` alone or `!active || ...`, never `!active && ...`. Inactive
     # has to be sufficient to bail out on its own; an AND would let a previously mounted panel keep
     # rendering on an auth route, which is the regression this guards.
+    #
+    # Narrowed twice more. The search stops at the component's own `return (` and the `if` has to
+    # begin a line at the body's own indent, so a guard nested in a callback cannot stand in for
+    # the pre-render bailout. The condition may still wrap across lines, since a test that pins a
+    # formatter's line breaks is the exact failure being repaired here; `[^;]*` keeps that wrap
+    # from running past the end of the statement into a later `return null;`.
     mount_body = mount.split("export function SettingsDialogMount", 1)
     assert len(mount_body) == 2, "SettingsDialogMount is no longer declared here"
+    before_render = mount_body[1].split("\n  return (", 1)[0]
     assert re.search(
-        r"if \(!active(?:\s*\|\|[^\n]*)?\) return null;", mount_body[1]
+        r"^  if \(\s*!active(?:\s*\|\|[^;]*?)?\) return null;",
+        before_render,
+        re.MULTILINE,
     ), "SettingsDialogMount must bail out whenever it is inactive, on that alone"
     assert "useSettingsDialogStore.getState().closeDialog();" in root
     # The settings chord must stay inert on the auth routes. That used to be an

--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -173,7 +173,19 @@ def test_auth_flow_routes_do_not_mount_global_settings():
     mount = (FRONTEND / "features/settings/settings-dialog-mount.tsx").read_text(encoding = "utf-8")
     assert "<SettingsDialogMount active={active && ready} />" in root
     assert "<CredentialBootstrapGate active={!isAuthFlowRoute}>" in root
-    assert "if (!active || !mounted) return null;" in mount
+    # SettingsDialogMount must refuse to render whenever it is inactive, whatever else it also
+    # checks. The spelling has already changed once: `mounted` became `settingsMounted ||
+    # monitorMounted` when the resource monitor moved in (#10237), and pinning the old literal left
+    # this red on main. Lock the `!active` guard, not the rest of the condition.
+    #
+    # Scoped to the exported component on purpose. SettingsDialogLoading above it carries its own
+    # `if (!active) return null;`, so searching the whole file passes even with the guard under
+    # test deleted outright, which is how the first attempt at this assertion was vacuous.
+    mount_body = mount.split("export function SettingsDialogMount", 1)
+    assert len(mount_body) == 2, "SettingsDialogMount is no longer declared here"
+    assert re.search(
+        r"if \(!active\b[^\n]*\) return null;", mount_body[1]
+    ), "SettingsDialogMount must bail out while inactive"
     assert "useSettingsDialogStore.getState().closeDialog();" in root
     # The settings chord must stay inert on the auth routes. That used to be an
     # early return inside a hand-rolled keydown handler; once the chords became


### PR DESCRIPTION
`Repo tests (CPU)` is red on main, and so on every PR branched from it. One failure: `tests/studio/test_auth_form_input_count.py::test_auth_flow_routes_do_not_mount_global_settings`.

The test asserts the source contains `if (!active || !mounted) return null;`. #10237 rewrote that guard to `if (!active || !(settingsMounted || monitorMounted)) return null;` when the resource monitor moved into the same mount. The behaviour being protected did not change, only the spelling of the condition.

This applies the fix the file already uses one assertion lower, where the settings chord accepts either the old early return or the `enabled` option: lock the behaviour, not one spelling of it. Here that is the `!active` bail-out, whatever else the condition also checks.

Scoped to the exported `SettingsDialogMount`. `SettingsDialogLoading` above it carries its own `if (!active) return null;`, so a whole-file search passes even with the guard under test deleted outright. My first version did exactly that; I caught it by deleting the guard and watching the test still pass.

Verified four ways against the real source:

| mutation | expected | result |
| --- | --- | --- |
| unmodified | pass | pass |
| `!active` dropped from the condition | fail | fail |
| whole guard deleted | fail | fail |
| rest of the condition renamed | pass | pass |

`tests/studio/test_auth_form_input_count.py`: 9 passed. Test file only, no source change.