### PR TITLE
Studio: stop converting the model twice when exporting GGUF to the Hub

### DIFF
--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -414,8 +414,8 @@ This {model_type} model was trained 2x faster with [Unsloth](https://github.com/
 """
 
 
-# Both llama.cpp spellings: the Hub filters on the exact string, and upstream ends up
-# with each -- "llama.cpp" from its card, "llama-cpp" from its add_tags call.
+# Both llama.cpp spellings: the Hub filters on the exact string. Upstream wants both but its
+# add_tags call is a no-op (HfApi has no add_tags, and it sits under a bare `except: pass`).
 GGUF_MODEL_CARD = """---
 tags:
 - gguf
@@ -435,6 +435,33 @@ This model was converted to GGUF format using [Unsloth](https://github.com/unslo
 ## Available model files:
 {files}
 """
+
+
+def _ensure_hub_repo_private(hf_api, repo_id):
+    """Make an existing repo private before uploading to it, or refuse.
+
+    create_repo only applies `private` to a repo it creates, so pushing into an existing
+    public one would publish the GGUFs; update_repo_settings is the only call that changes
+    visibility. repo_info is the fallback so a token without `write:repo_settings` still
+    works against an already-private repo. Mirrors the guard this path replaced on macOS,
+    unsloth_zoo.mlx.utils._ensure_hub_repo_visibility.
+    """
+    try:
+        hf_api.update_repo_settings(repo_id = repo_id, private = True, repo_type = "model")
+        return
+    except Exception as exception:
+        try:
+            info = hf_api.repo_info(repo_id = repo_id, repo_type = "model")
+            if bool(getattr(info, "private", False)):
+                return
+        except Exception:
+            pass
+        raise RuntimeError(
+            f"private=True was requested but {repo_id!r} could not be confirmed private "
+            "(the token likely lacks `write:repo_settings`, or the repository belongs to "
+            "someone else). Refusing to upload rather than publish the GGUF files to a "
+            "public repository."
+        ) from exception
 
 
 class ExportBackend:
@@ -1167,6 +1194,7 @@ class ExportBackend:
         # here because the temp root holding it is deleted before the upload.
         exported_ggufs: List[str] = []
         exported_modelfile = False
+        exported_modelfile_bytes: Optional[bytes] = None
         exported_is_vlm = False
         exported_config: Optional[bytes] = None
         try:
@@ -1254,8 +1282,19 @@ class ExportBackend:
                             f"{abs_save_dir}"
                         )
                     exported_ggufs = [str(f) for f in drop_appledouble_metadata(relocated_ggufs)]
-                    # The Hub filters on this tag, and only the exporter knows.
-                    exported_is_vlm = bool(reported.get("is_vlm"))
+                    if not exported_ggufs:
+                        # Only Finder metadata. final_ggufs below still passes on a .gguf an
+                        # earlier export left here, so without this the Hub leg publishes
+                        # nothing and reports success.
+                        raise RuntimeError(
+                            "GGUF conversion produced only AppleDouble metadata companions "
+                            f"and no usable .gguf file for {abs_save_dir}"
+                        )
+                    # The Hub filters on this tag. The exporter wins when it says anything;
+                    # the MLX binding returns None, so fall back to Studio's own detection.
+                    exported_is_vlm = bool(
+                        reported.get("is_vlm", getattr(self, "is_vision", False))
+                    )
                     # Kept in memory, not relocated: a config.json in the export folder
                     # would make _is_model_dir read it as a checkpoint directory.
                     merged_config = (
@@ -1281,6 +1320,15 @@ class ExportBackend:
                             logger.info(f"Relocated Modelfile → {abs_save_dir}/")
                         except OSError as exception:
                             logger.warning(f"Could not relocate the Modelfile: {exception}")
+                            # This run produced it and the old path uploaded it, so keep the
+                            # bytes rather than lose it to a read-only destination. Before
+                            # the `finally` below removes the temp root.
+                            try:
+                                exported_modelfile_bytes = modelfile.read_bytes()
+                            except OSError as read_exception:
+                                logger.warning(
+                                    f"Could not read the Modelfile to upload it: {read_exception}"
+                                )
                 finally:
                     # The imatrix is an input, so counting it would retain the merged checkpoint on every such export.
                     unrelocated = []
@@ -1341,6 +1389,9 @@ class ExportBackend:
                     hf_api = HfApi(token = hf_token)
                     repo_url = hf_api.create_repo(repo_id, private = private, exist_ok = True)
                     repo_id = getattr(repo_url, "repo_id", repo_id)
+                    # Tightening only: unticking private is not a request to open a repo.
+                    if private:
+                        _ensure_hub_repo_private(hf_api, repo_id)
                     # Allow-list over exported_ggufs, not the folder: the save directory is
                     # user-picked, so it can hold unrelated files, a _tmp_model_* merge a
                     # failed export kept, or GGUFs from an earlier export of another model.
@@ -1363,15 +1414,31 @@ class ExportBackend:
                             repo_type = "model",
                             commit_message = "Unsloth config.json",
                         )
-                    # Last: the card advertises files, so it must not land before them.
-                    ModelCard(
-                        GGUF_MODEL_CARD.format(
-                            name = repo_id.split("/")[-1],
+                    if exported_modelfile_bytes is not None:
+                        # Produced by this run but not placeable in the export folder.
+                        hf_api.upload_file(
+                            path_or_fileobj = exported_modelfile_bytes,
+                            path_in_repo = "Modelfile",
                             repo_id = repo_id,
-                            vlm_tag = "\n- vision-language-model" if exported_is_vlm else "",
-                            files = "\n".join(f"- `{os.path.basename(f)}`" for f in exported_ggufs),
+                            repo_type = "model",
+                            commit_message = "Unsloth Ollama Modelfile",
                         )
-                    ).push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
+                    # Last, because the card advertises files. Best-effort, because they are
+                    # already committed and RepoCard.push_to_hub validates against a
+                    # hardcoded huggingface.co that a private HF_ENDPOINT cannot serve.
+                    try:
+                        ModelCard(
+                            GGUF_MODEL_CARD.format(
+                                name = repo_id.split("/")[-1],
+                                repo_id = repo_id,
+                                vlm_tag = "\n- vision-language-model" if exported_is_vlm else "",
+                                files = "\n".join(
+                                    f"- `{os.path.basename(f)}`" for f in exported_ggufs
+                                ),
+                            )
+                        ).push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
+                    except Exception as exception:
+                        logger.warning(f"Could not publish the model card: {exception}")
                 else:
                     self.current_model.push_to_hub_gguf(
                         repo_id,
@@ -1395,6 +1462,14 @@ class ExportBackend:
             import traceback
 
             logger.error(traceback.format_exc())
+            if output_path:
+                # Only the Hub leg can raise once output_path is set, so the files are on
+                # disk. Return the directory rather than imply the conversion must be re-run.
+                return (
+                    False,
+                    f"GGUF files were saved to {output_path}, but the Hub upload failed: {e}",
+                    output_path,
+                )
             return False, f"GGUF export failed: {str(e)}", None
 
     def export_lora_adapter(

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1364,9 +1364,7 @@ class ExportBackend:
                         GGUF_MODEL_CARD.format(
                             name = repo_id.split("/")[-1],
                             repo_id = repo_id,
-                            files = "\n".join(
-                                f"- `{os.path.basename(f)}`" for f in exported_ggufs
-                            ),
+                            files = "\n".join(f"- `{os.path.basename(f)}`" for f in exported_ggufs),
                         )
                     ).push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
                 else:

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1327,12 +1327,16 @@ class ExportBackend:
                             files = "\n".join(f"- `{os.path.basename(f)}`" for f in final_ggufs),
                         )
                     ).push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
+                    # Allow-list, not ignore_patterns: the save directory is user-picked and
+                    # may hold unrelated files, or a _tmp_model_* merge a failed export kept.
                     hf_api.upload_folder(
                         folder_path = output_path,
                         repo_id = repo_id,
                         repo_type = "model",
-                        # Studio-local discovery data, and it can carry a local base-model path.
-                        ignore_patterns = ["export_metadata.json"],
+                        allow_patterns = [
+                            *(os.path.basename(f) for f in final_ggufs),
+                            "Modelfile",
+                        ],
                     )
                 else:
                     self.current_model.push_to_hub_gguf(

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -3,6 +3,7 @@
 
 """Export backend - exports models in various formats."""
 
+import glob
 import json
 import structlog
 import tempfile
@@ -1333,8 +1334,11 @@ class ExportBackend:
                         folder_path = output_path,
                         repo_id = repo_id,
                         repo_type = "model",
+                        # glob.escape: these are literal names, and a folder named e.g.
+                        # "model[v2]" makes a pattern that skips its own file, while one
+                        # holding "*" would match files this export never made.
                         allow_patterns = [
-                            *(os.path.basename(f) for f in final_ggufs),
+                            *(glob.escape(os.path.basename(f)) for f in final_ggufs),
                             "Modelfile",
                         ],
                     )

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1249,9 +1249,7 @@ class ExportBackend:
                             "GGUF conversion produced no files: no .gguf outputs for "
                             f"{abs_save_dir}"
                         )
-                    exported_ggufs = [
-                        str(f) for f in drop_appledouble_metadata(relocated_ggufs)
-                    ]
+                    exported_ggufs = [str(f) for f in drop_appledouble_metadata(relocated_ggufs)]
                     # Kept in memory, not relocated: a config.json in the export folder
                     # would make _is_model_dir read it as a checkpoint directory.
                     merged_config = (

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -413,6 +413,26 @@ This {model_type} model was trained 2x faster with [Unsloth](https://github.com/
 """
 
 
+GGUF_MODEL_CARD = """---
+tags:
+- gguf
+- llama.cpp
+- unsloth
+---
+
+# {name} : GGUF
+
+This model was converted to GGUF format using [Unsloth](https://github.com/unslothai/unsloth).
+
+**Example usage**:
+- For text only LLMs:    `llama-cli -hf {repo_id} --jinja`
+- For multimodal models: `llama-mtmd-cli -hf {repo_id} --jinja`
+
+## Available model files:
+{files}
+"""
+
+
 class ExportBackend:
     """Handles model export operations"""
 
@@ -1116,7 +1136,7 @@ class ExportBackend:
         shard_hooks = []
         if save_directory:
             shard_hooks.append(self.current_model.save_pretrained_gguf)
-        if push_to_hub:
+        elif push_to_hub:
             shard_hooks.append(self.current_model.push_to_hub_gguf)
         if gguf_shard_size is not None and not all(
             _gguf_shard_export_supported(hook) for hook in shard_hooks
@@ -1294,15 +1314,38 @@ class ExportBackend:
 
                 logger.info(f"Pushing GGUF model to Hub: {repo_id}")
 
-                self.current_model.push_to_hub_gguf(
-                    repo_id,
-                    self.current_tokenizer,
-                    quantization_method = quant_method,
-                    token = hf_token,
-                    private = private,
-                    **imatrix_kw,
-                    **shard_kw,
-                )
+                if output_path and Path(output_path).is_dir():
+                    # push_to_hub_gguf re-runs the whole merge + convert + quantize into the
+                    # system temp directory; these files are already built.
+                    hf_api = HfApi(token = hf_token)
+                    repo_url = hf_api.create_repo(repo_id, private = private, exist_ok = True)
+                    repo_id = getattr(repo_url, "repo_id", repo_id)
+                    ModelCard(
+                        GGUF_MODEL_CARD.format(
+                            name = repo_id.split("/")[-1],
+                            repo_id = repo_id,
+                            files = "\n".join(
+                                f"- `{os.path.basename(f)}`" for f in final_ggufs
+                            ),
+                        )
+                    ).push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
+                    hf_api.upload_folder(
+                        folder_path = output_path,
+                        repo_id = repo_id,
+                        repo_type = "model",
+                        # Studio-local discovery data, and it can carry a local base-model path.
+                        ignore_patterns = ["export_metadata.json"],
+                    )
+                else:
+                    self.current_model.push_to_hub_gguf(
+                        repo_id,
+                        self.current_tokenizer,
+                        quantization_method = quant_method,
+                        token = hf_token,
+                        private = private,
+                        **imatrix_kw,
+                        **shard_kw,
+                    )
                 logger.info(f"GGUF model pushed successfully to {repo_id}")
 
             return (

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1251,7 +1251,9 @@ class ExportBackend:
                     exported_ggufs = list(relocated_ggufs)
                     # Kept in memory, not relocated: a config.json in the export folder
                     # would make _is_model_dir read it as a checkpoint directory.
-                    merged_config = Path(_model_tmp) / "config.json"
+                    merged_config = (
+                        Path(reported.get("save_directory") or _model_tmp) / "config.json"
+                    )
                     if merged_config.is_file():
                         exported_config = merged_config.read_bytes()
 

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -418,7 +418,7 @@ GGUF_MODEL_CARD = """---
 tags:
 - gguf
 - llama.cpp
-- unsloth
+- unsloth{vlm_tag}
 ---
 
 # {name} : GGUF
@@ -1164,6 +1164,7 @@ class ExportBackend:
         # here because the temp root holding it is deleted before the upload.
         exported_ggufs: List[str] = []
         exported_modelfile = False
+        exported_is_vlm = False
         exported_config: Optional[bytes] = None
         try:
             # Normalize to a lowercased list so multiple quants come from one model load.
@@ -1250,6 +1251,8 @@ class ExportBackend:
                             f"{abs_save_dir}"
                         )
                     exported_ggufs = [str(f) for f in drop_appledouble_metadata(relocated_ggufs)]
+                    # The Hub filters on this tag, and only the exporter knows.
+                    exported_is_vlm = bool(reported.get("is_vlm"))
                     # Kept in memory, not relocated: a config.json in the export folder
                     # would make _is_model_dir read it as a checkpoint directory.
                     merged_config = (
@@ -1362,6 +1365,7 @@ class ExportBackend:
                         GGUF_MODEL_CARD.format(
                             name = repo_id.split("/")[-1],
                             repo_id = repo_id,
+                            vlm_tag = "\n- vision-language-model" if exported_is_vlm else "",
                             files = "\n".join(f"- `{os.path.basename(f)}`" for f in exported_ggufs),
                         )
                     ).push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1306,12 +1306,17 @@ class ExportBackend:
                                 "GGUF conversion produced a symlinked Modelfile, "
                                 f"refusing to relocate it: {modelfile}"
                             )
-                        # Optional artifact: a locked or read-only destination must not fail an export whose GGUFs all
-                        # landed.
-                        # Optional artifact: unsloth generates it best-effort, so a locked or read-only
-                        # destination must not fail an export whose GGUFs all landed.
+                        # Optional artifact: a locked or read-only destination must not fail an
+                        # export whose GGUFs all landed. It is published from memory instead.
+                        modelfile_dest = os.path.join(abs_save_dir, "Modelfile")
                         try:
-                            shutil.move(str(modelfile), os.path.join(abs_save_dir, "Modelfile"))
+                            if os.path.isdir(modelfile_dest):
+                                # move would nest it at Modelfile/Modelfile, which the
+                                # allow-list never matches.
+                                raise OSError(
+                                    f"a directory named Modelfile is already in {abs_save_dir}"
+                                )
+                            shutil.move(str(modelfile), modelfile_dest)
                             exported_modelfile = True
                             logger.info(f"Relocated Modelfile → {abs_save_dir}/")
                         except OSError as exception:

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1265,6 +1265,13 @@ class ExportBackend:
                                 f"GGUF conversion produced a symlink, refusing to relocate it: {src}"
                             )
                         dest = os.path.join(abs_save_dir, src.name)
+                        if os.path.isdir(dest):
+                            # move would put the file INSIDE it and we would record the
+                            # directory, so the allow-list would match neither.
+                            raise RuntimeError(
+                                f"Cannot relocate {src.name}: a directory of that name is "
+                                f"already in {abs_save_dir}"
+                            )
                         shutil.move(str(src), dest)
                         relocated_ggufs.append(dest)
                         logger.info(f"Relocated GGUF: {src.name} → {abs_save_dir}/")

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1163,6 +1163,7 @@ class ExportBackend:
         # What this run actually produced, for the Hub leg: the merged config.json is read
         # here because the temp root holding it is deleted before the upload.
         exported_ggufs: List[str] = []
+        exported_modelfile = False
         exported_config: Optional[bytes] = None
         try:
             # Normalize to a lowercased list so multiple quants come from one model load.
@@ -1248,7 +1249,9 @@ class ExportBackend:
                             "GGUF conversion produced no files: no .gguf outputs for "
                             f"{abs_save_dir}"
                         )
-                    exported_ggufs = list(relocated_ggufs)
+                    exported_ggufs = [
+                        str(f) for f in drop_appledouble_metadata(relocated_ggufs)
+                    ]
                     # Kept in memory, not relocated: a config.json in the export folder
                     # would make _is_model_dir read it as a checkpoint directory.
                     merged_config = (
@@ -1270,6 +1273,7 @@ class ExportBackend:
                         # destination must not fail an export whose GGUFs all landed.
                         try:
                             shutil.move(str(modelfile), os.path.join(abs_save_dir, "Modelfile"))
+                            exported_modelfile = True
                             logger.info(f"Relocated Modelfile → {abs_save_dir}/")
                         except OSError as exception:
                             logger.warning(f"Could not relocate the Modelfile: {exception}")
@@ -1344,7 +1348,7 @@ class ExportBackend:
                         repo_type = "model",
                         allow_patterns = [
                             *(glob.escape(os.path.basename(f)) for f in exported_ggufs),
-                            "Modelfile",
+                            *(["Modelfile"] if exported_modelfile else []),
                         ],
                     )
                     if exported_config is not None:

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1160,6 +1160,10 @@ class ExportBackend:
         )
 
         output_path: Optional[str] = None
+        # What this run actually produced, for the Hub leg: the merged config.json is read
+        # here because the temp root holding it is deleted before the upload.
+        exported_ggufs: List[str] = []
+        exported_config: Optional[bytes] = None
         try:
             # Normalize to a lowercased list so multiple quants come from one model load.
             if isinstance(quantization_method, (list, tuple)):
@@ -1244,6 +1248,12 @@ class ExportBackend:
                             "GGUF conversion produced no files: no .gguf outputs for "
                             f"{abs_save_dir}"
                         )
+                    exported_ggufs = list(relocated_ggufs)
+                    # Kept in memory, not relocated: a config.json in the export folder
+                    # would make _is_model_dir read it as a checkpoint directory.
+                    merged_config = Path(_model_tmp) / "config.json"
+                    if merged_config.is_file():
+                        exported_config = merged_config.read_bytes()
 
                     if modelfiles:
                         modelfile = sorted(modelfiles)[0]
@@ -1321,27 +1331,38 @@ class ExportBackend:
                     hf_api = HfApi(token = hf_token)
                     repo_url = hf_api.create_repo(repo_id, private = private, exist_ok = True)
                     repo_id = getattr(repo_url, "repo_id", repo_id)
-                    ModelCard(
-                        GGUF_MODEL_CARD.format(
-                            name = repo_id.split("/")[-1],
-                            repo_id = repo_id,
-                            files = "\n".join(f"- `{os.path.basename(f)}`" for f in final_ggufs),
-                        )
-                    ).push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
-                    # Allow-list, not ignore_patterns: the save directory is user-picked and
-                    # may hold unrelated files, or a _tmp_model_* merge a failed export kept.
+                    # Allow-list over exported_ggufs, not the folder: the save directory is
+                    # user-picked, so it can hold unrelated files, a _tmp_model_* merge a
+                    # failed export kept, or GGUFs from an earlier export of another model.
+                    # glob.escape keeps a name like "model[v2].gguf" a literal, which
+                    # otherwise neither matches itself nor stays confined to itself.
                     hf_api.upload_folder(
                         folder_path = output_path,
                         repo_id = repo_id,
                         repo_type = "model",
-                        # glob.escape: these are literal names, and a folder named e.g.
-                        # "model[v2]" makes a pattern that skips its own file, while one
-                        # holding "*" would match files this export never made.
                         allow_patterns = [
-                            *(glob.escape(os.path.basename(f)) for f in final_ggufs),
+                            *(glob.escape(os.path.basename(f)) for f in exported_ggufs),
                             "Modelfile",
                         ],
                     )
+                    if exported_config is not None:
+                        hf_api.upload_file(
+                            path_or_fileobj = exported_config,
+                            path_in_repo = "config.json",
+                            repo_id = repo_id,
+                            repo_type = "model",
+                            commit_message = "Unsloth config.json",
+                        )
+                    # Last: the card advertises files, so it must not land before them.
+                    ModelCard(
+                        GGUF_MODEL_CARD.format(
+                            name = repo_id.split("/")[-1],
+                            repo_id = repo_id,
+                            files = "\n".join(
+                                f"- `{os.path.basename(f)}`" for f in exported_ggufs
+                            ),
+                        )
+                    ).push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
                 else:
                     self.current_model.push_to_hub_gguf(
                         repo_id,

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -414,8 +414,7 @@ This {model_type} model was trained 2x faster with [Unsloth](https://github.com/
 """
 
 
-# Both llama.cpp spellings: the Hub filters on the exact string. Upstream wants both but its
-# add_tags call is a no-op (HfApi has no add_tags, and it sits under a bare `except: pass`).
+# Both llama.cpp spellings: the Hub filters on the exact string, and upstream's add_tags is a no-op.
 GGUF_MODEL_CARD = """---
 tags:
 - gguf
@@ -438,13 +437,8 @@ This model was converted to GGUF format using [Unsloth](https://github.com/unslo
 
 
 def _ensure_hub_repo_private(hf_api, repo_id):
-    """Make an existing repo private before uploading to it, or refuse.
-
-    create_repo only applies `private` to a repo it creates, so pushing into an existing
-    public one would publish the GGUFs; update_repo_settings is the only call that changes
-    visibility. repo_info is the fallback so a token without `write:repo_settings` still
-    works against an already-private repo. Mirrors the guard this path replaced on macOS,
-    unsloth_zoo.mlx.utils._ensure_hub_repo_visibility.
+    """Make an existing repo private before uploading, or refuse: create_repo only applies
+    `private` on creation, and repo_info covers a token without `write:repo_settings`.
     """
     try:
         hf_api.update_repo_settings(repo_id = repo_id, private = True, repo_type = "model")
@@ -1190,8 +1184,6 @@ class ExportBackend:
         )
 
         output_path: Optional[str] = None
-        # What this run actually produced, for the Hub leg: the merged config.json is read
-        # here because the temp root holding it is deleted before the upload.
         exported_ggufs: List[str] = []
         exported_modelfile = False
         exported_modelfile_bytes: Optional[bytes] = None
@@ -1283,20 +1275,17 @@ class ExportBackend:
                         )
                     exported_ggufs = [str(f) for f in drop_appledouble_metadata(relocated_ggufs)]
                     if not exported_ggufs:
-                        # Only Finder metadata. final_ggufs below still passes on a .gguf an
-                        # earlier export left here, so without this the Hub leg publishes
-                        # nothing and reports success.
+                        # final_ggufs below would pass on an earlier export's .gguf left here.
                         raise RuntimeError(
                             "GGUF conversion produced only AppleDouble metadata companions "
                             f"and no usable .gguf file for {abs_save_dir}"
                         )
-                    # The Hub filters on this tag. The exporter wins when it says anything;
-                    # the MLX binding returns None, so fall back to Studio's own detection.
+                    # The exporter wins when it says anything; the MLX binding returns None.
                     exported_is_vlm = bool(
                         reported.get("is_vlm", getattr(self, "is_vision", False))
                     )
-                    # Kept in memory, not relocated: a config.json in the export folder
-                    # would make _is_model_dir read it as a checkpoint directory.
+                    # Kept in memory: the temp root is deleted before the upload, and a config.json
+                    # in the export folder would make _is_model_dir read it as a checkpoint.
                     merged_config = (
                         Path(reported.get("save_directory") or _model_tmp) / "config.json"
                     )
@@ -1320,9 +1309,7 @@ class ExportBackend:
                             logger.info(f"Relocated Modelfile → {abs_save_dir}/")
                         except OSError as exception:
                             logger.warning(f"Could not relocate the Modelfile: {exception}")
-                            # This run produced it and the old path uploaded it, so keep the
-                            # bytes rather than lose it to a read-only destination. Before
-                            # the `finally` below removes the temp root.
+                            # Keep the bytes before the `finally` below removes the temp root.
                             try:
                                 exported_modelfile_bytes = modelfile.read_bytes()
                             except OSError as read_exception:
@@ -1384,19 +1371,15 @@ class ExportBackend:
                 logger.info(f"Pushing GGUF model to Hub: {repo_id}")
 
                 if output_path and Path(output_path).is_dir():
-                    # push_to_hub_gguf re-runs the whole merge + convert + quantize into the
-                    # system temp directory; these files are already built.
+                    # push_to_hub_gguf would re-run the whole merge + convert + quantize.
                     hf_api = HfApi(token = hf_token)
                     repo_url = hf_api.create_repo(repo_id, private = private, exist_ok = True)
                     repo_id = getattr(repo_url, "repo_id", repo_id)
                     # Tightening only: unticking private is not a request to open a repo.
                     if private:
                         _ensure_hub_repo_private(hf_api, repo_id)
-                    # Allow-list over exported_ggufs, not the folder: the save directory is
-                    # user-picked, so it can hold unrelated files, a _tmp_model_* merge a
-                    # failed export kept, or GGUFs from an earlier export of another model.
-                    # glob.escape keeps a name like "model[v2].gguf" a literal, which
-                    # otherwise neither matches itself nor stays confined to itself.
+                    # Allow-list, not the folder: the user-picked directory can hold unrelated
+                    # files. glob.escape keeps a name like "model[v2].gguf" a literal.
                     hf_api.upload_folder(
                         folder_path = output_path,
                         repo_id = repo_id,
@@ -1415,7 +1398,6 @@ class ExportBackend:
                             commit_message = "Unsloth config.json",
                         )
                     if exported_modelfile_bytes is not None:
-                        # Produced by this run but not placeable in the export folder.
                         hf_api.upload_file(
                             path_or_fileobj = exported_modelfile_bytes,
                             path_in_repo = "Modelfile",
@@ -1423,9 +1405,8 @@ class ExportBackend:
                             repo_type = "model",
                             commit_message = "Unsloth Ollama Modelfile",
                         )
-                    # Last, because the card advertises files. Best-effort, because they are
-                    # already committed and RepoCard.push_to_hub validates against a
-                    # hardcoded huggingface.co that a private HF_ENDPOINT cannot serve.
+                    # Last, because the card advertises the files. Best-effort: RepoCard.push_to_hub
+                    # validates against a hardcoded huggingface.co a private HF_ENDPOINT cannot serve.
                     try:
                         ModelCard(
                             GGUF_MODEL_CARD.format(
@@ -1463,8 +1444,7 @@ class ExportBackend:
 
             logger.error(traceback.format_exc())
             if output_path:
-                # Only the Hub leg can raise once output_path is set, so the files are on
-                # disk. Return the directory rather than imply the conversion must be re-run.
+                # Only the Hub leg can raise once output_path is set, so the files are on disk.
                 return (
                     False,
                     f"GGUF files were saved to {output_path}, but the Hub upload failed: {e}",

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1324,9 +1324,7 @@ class ExportBackend:
                         GGUF_MODEL_CARD.format(
                             name = repo_id.split("/")[-1],
                             repo_id = repo_id,
-                            files = "\n".join(
-                                f"- `{os.path.basename(f)}`" for f in final_ggufs
-                            ),
+                            files = "\n".join(f"- `{os.path.basename(f)}`" for f in final_ggufs),
                         )
                     ).push_to_hub(repo_id, token = hf_token, commit_message = "Unsloth Model Card")
                     hf_api.upload_folder(

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -414,10 +414,13 @@ This {model_type} model was trained 2x faster with [Unsloth](https://github.com/
 """
 
 
+# Both llama.cpp spellings: the Hub filters on the exact string, and upstream ends up
+# with each -- "llama.cpp" from its card, "llama-cpp" from its add_tags call.
 GGUF_MODEL_CARD = """---
 tags:
 - gguf
 - llama.cpp
+- llama-cpp
 - unsloth{vlm_tag}
 ---
 

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -437,9 +437,7 @@ This model was converted to GGUF format using [Unsloth](https://github.com/unslo
 
 
 def _ensure_hub_repo_private(hf_api, repo_id):
-    """Make an existing repo private before uploading, or refuse: create_repo only applies
-    `private` on creation, and repo_info covers a token without `write:repo_settings`.
-    """
+    """Tighten an existing repo to private: create_repo sets `private` only at creation."""
     try:
         hf_api.update_repo_settings(repo_id = repo_id, private = True, repo_type = "model")
         return
@@ -1266,8 +1264,7 @@ class ExportBackend:
                             )
                         dest = os.path.join(abs_save_dir, src.name)
                         if os.path.isdir(dest):
-                            # move would put the file INSIDE it and we would record the
-                            # directory, so the allow-list would match neither.
+                            # move would nest the file, and the allow-list would match neither.
                             raise RuntimeError(
                                 f"Cannot relocate {src.name}: a directory of that name is "
                                 f"already in {abs_save_dir}"
@@ -1287,12 +1284,10 @@ class ExportBackend:
                             "GGUF conversion produced only AppleDouble metadata companions "
                             f"and no usable .gguf file for {abs_save_dir}"
                         )
-                    # The exporter wins when it says anything; the MLX binding returns None.
                     exported_is_vlm = bool(
                         reported.get("is_vlm", getattr(self, "is_vision", False))
                     )
-                    # Kept in memory: the temp root is deleted before the upload, and a config.json
-                    # in the export folder would make _is_model_dir read it as a checkpoint.
+                    # In memory: the temp root goes, and a config.json here reads as a checkpoint.
                     merged_config = (
                         Path(reported.get("save_directory") or _model_tmp) / "config.json"
                     )
@@ -1306,13 +1301,10 @@ class ExportBackend:
                                 "GGUF conversion produced a symlinked Modelfile, "
                                 f"refusing to relocate it: {modelfile}"
                             )
-                        # Optional artifact: a locked or read-only destination must not fail an
-                        # export whose GGUFs all landed. It is published from memory instead.
+                        # Optional: a blocked destination publishes from memory, never fails.
                         modelfile_dest = os.path.join(abs_save_dir, "Modelfile")
                         try:
                             if os.path.isdir(modelfile_dest):
-                                # move would nest it at Modelfile/Modelfile, which the
-                                # allow-list never matches.
                                 raise OSError(
                                     f"a directory named Modelfile is already in {abs_save_dir}"
                                 )
@@ -1321,7 +1313,6 @@ class ExportBackend:
                             logger.info(f"Relocated Modelfile → {abs_save_dir}/")
                         except OSError as exception:
                             logger.warning(f"Could not relocate the Modelfile: {exception}")
-                            # Keep the bytes before the `finally` below removes the temp root.
                             try:
                                 exported_modelfile_bytes = modelfile.read_bytes()
                             except OSError as read_exception:
@@ -1383,15 +1374,13 @@ class ExportBackend:
                 logger.info(f"Pushing GGUF model to Hub: {repo_id}")
 
                 if output_path and Path(output_path).is_dir():
-                    # push_to_hub_gguf would re-run the whole merge + convert + quantize.
+                    # These are already built; push_to_hub_gguf would convert the model again.
                     hf_api = HfApi(token = hf_token)
                     repo_url = hf_api.create_repo(repo_id, private = private, exist_ok = True)
                     repo_id = getattr(repo_url, "repo_id", repo_id)
-                    # Tightening only: unticking private is not a request to open a repo.
                     if private:
                         _ensure_hub_repo_private(hf_api, repo_id)
-                    # Allow-list, not the folder: the user-picked directory can hold unrelated
-                    # files. glob.escape keeps a name like "model[v2].gguf" a literal.
+                    # Allow-list, not the folder; glob.escape keeps "model[v2].gguf" a literal.
                     hf_api.upload_folder(
                         folder_path = output_path,
                         repo_id = repo_id,
@@ -1417,8 +1406,7 @@ class ExportBackend:
                             repo_type = "model",
                             commit_message = "Unsloth Ollama Modelfile",
                         )
-                    # Last, because the card advertises the files. Best-effort: RepoCard.push_to_hub
-                    # validates against a hardcoded huggingface.co a private HF_ENDPOINT cannot serve.
+                    # Last (advertises the files), best-effort: RepoCard hardcodes huggingface.co.
                     try:
                         ModelCard(
                             GGUF_MODEL_CARD.format(

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -81,6 +81,7 @@ def _hub_doubles(export_mod, monkeypatch, calls: dict):
             folder_path,
             repo_id,
             repo_type,
+            allow_patterns = None,
             ignore_patterns = None,
         ):
             calls["upload"] = folder_path

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -57,6 +57,34 @@ def _backend(
     return export_mod, backend, save_dir, cwd
 
 
+def _hub_doubles(export_mod, monkeypatch, calls: dict):
+    """Record the Hub leg: token, repo creation and the folder uploaded."""
+
+    class _RepoUrl(str):
+        repo_id = "org/model"
+
+    class _HfApi:
+        def __init__(self, token = None):
+            calls["token"] = token
+
+        def create_repo(self, repo_id, private = False, exist_ok = False):
+            calls["repo"] = {"repo_id": repo_id, "private": private}
+            return _RepoUrl("https://huggingface.co/org/model")
+
+        def upload_folder(self, folder_path, repo_id, repo_type, ignore_patterns = None):
+            calls["upload"] = folder_path
+
+    class _ModelCard:
+        def __init__(self, content):
+            calls["card"] = content
+
+        def push_to_hub(self, repo_id, token = None, commit_message = None):
+            calls["card_repo"] = repo_id
+
+    monkeypatch.setattr(export_mod, "HfApi", _HfApi)
+    monkeypatch.setattr(export_mod, "ModelCard", _ModelCard)
+
+
 def _gguf(path: Path, payload: bytes = b"GGUF") -> Path:
     path.parent.mkdir(parents = True, exist_ok = True)
     path.write_bytes(payload)
@@ -487,12 +515,15 @@ def test_local_gguf_export_forwards_the_token_for_the_upstream_imatrix(monkeypat
     assert calls["save"] == {"imatrix_file": True, "token": "hf_secret"}
 
 
-def test_hub_push_with_an_imatrix_passes_the_token_exactly_once(monkeypatch, tmp_path):
-    """push_to_hub_gguf already names token=, so the local extra must not reach it as well."""
+def test_hub_push_uploads_the_local_export_instead_of_converting_again(monkeypatch, tmp_path):
+    """push_to_hub_gguf would re-run the whole conversion into the system temp dir."""
     calls: dict = {}
-    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _imatrix_model(True, calls))
+    export_mod, backend, save_dir, _cwd = _backend(
+        monkeypatch, tmp_path, _imatrix_model(True, calls)
+    )
+    _hub_doubles(export_mod, monkeypatch, calls)
 
-    success, message, _p = backend.export_gguf(
+    success, message, output_path = backend.export_gguf(
         str(save_dir),
         "iq2_xxs",
         push_to_hub = True,
@@ -502,20 +533,20 @@ def test_hub_push_with_an_imatrix_passes_the_token_exactly_once(monkeypatch, tmp
     )
 
     assert success is True, message
-    assert calls["push"] == {
-        "repo_id": "org/model",
-        "token": "hf_secret",
-        "imatrix_file": True,
-        "private": False,
-    }
+    assert "push" not in calls
+    assert calls["token"] == "hf_secret"
+    assert calls["upload"] == output_path == str(save_dir.resolve())
 
 
 @pytest.mark.parametrize("imatrix_file", [None, False, True])
 @pytest.mark.parametrize("private", [True, False])
 def test_hub_push_gguf_forwards_private_flag(monkeypatch, tmp_path, imatrix_file, private):
-    """push_to_hub_gguf receives the requested private flag for both standard and imatrix exports."""
+    """The created repo receives the requested private flag for standard and imatrix exports."""
     calls: dict = {}
-    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _imatrix_model(True, calls))
+    export_mod, backend, save_dir, _cwd = _backend(
+        monkeypatch, tmp_path, _imatrix_model(True, calls)
+    )
+    _hub_doubles(export_mod, monkeypatch, calls)
 
     success, message, _p = backend.export_gguf(
         str(save_dir),
@@ -528,7 +559,7 @@ def test_hub_push_gguf_forwards_private_flag(monkeypatch, tmp_path, imatrix_file
     )
 
     assert success is True, message
-    assert calls["push"]["private"] is private
+    assert calls["repo"] == {"repo_id": "org/model", "private": private}
 
 
 def test_gguf_export_without_an_imatrix_does_not_forward_the_token(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -76,6 +76,21 @@ def _hub_doubles(export_mod, monkeypatch, calls: dict):
             calls["repo"] = {"repo_id": repo_id, "private": private}
             return _RepoUrl("https://huggingface.co/org/model")
 
+        def update_repo_settings(
+            self,
+            repo_id,
+            private = None,
+            repo_type = None,
+        ):
+            calls["visibility"] = {"repo_id": repo_id, "private": private}
+
+        def repo_info(
+            self,
+            repo_id,
+            repo_type = None,
+        ):
+            return None
+
         def upload_folder(
             self,
             folder_path,

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -67,18 +67,34 @@ def _hub_doubles(export_mod, monkeypatch, calls: dict):
         def __init__(self, token = None):
             calls["token"] = token
 
-        def create_repo(self, repo_id, private = False, exist_ok = False):
+        def create_repo(
+            self,
+            repo_id,
+            private = False,
+            exist_ok = False,
+        ):
             calls["repo"] = {"repo_id": repo_id, "private": private}
             return _RepoUrl("https://huggingface.co/org/model")
 
-        def upload_folder(self, folder_path, repo_id, repo_type, ignore_patterns = None):
+        def upload_folder(
+            self,
+            folder_path,
+            repo_id,
+            repo_type,
+            ignore_patterns = None,
+        ):
             calls["upload"] = folder_path
 
     class _ModelCard:
         def __init__(self, content):
             calls["card"] = content
 
-        def push_to_hub(self, repo_id, token = None, commit_message = None):
+        def push_to_hub(
+            self,
+            repo_id,
+            token = None,
+            commit_message = None,
+        ):
             calls["card_repo"] = repo_id
 
     monkeypatch.setattr(export_mod, "HfApi", _HfApi)

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -91,6 +91,16 @@ def _hub_doubles(export_mod, monkeypatch, calls: dict):
         ):
             return None
 
+        def upload_file(
+            self,
+            path_or_fileobj,
+            path_in_repo,
+            repo_id,
+            repo_type = None,
+            commit_message = None,
+        ):
+            calls[path_in_repo] = path_or_fileobj
+
         def upload_folder(
             self,
             folder_path,

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -58,8 +58,6 @@ def _backend(
 
 
 def _hub_doubles(export_mod, monkeypatch, calls: dict):
-    """Record the Hub leg: token, repo creation and the folder uploaded."""
-
     class _RepoUrl(str):
         repo_id = "org/model"
 

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -4,11 +4,16 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import types
 from fnmatch import fnmatchcase
 from pathlib import Path
 
 import pytest
+
+
+# "*" is a reserved character in a Windows filename, so only POSIX can hold one.
+_STAR_IN_NAME_IS_LEGAL = os.name != "nt"
 
 
 _HELPERS_SPEC = importlib.util.spec_from_file_location(
@@ -253,7 +258,8 @@ def test_gguf_hub_export_allow_list_treats_gguf_names_literally(tmp_path, monkey
             calls.append("convert")
             output = Path(f"{model_save_path}_gguf")
             output.mkdir(parents = True)
-            (output / "a*.gguf").write_bytes(b"GGUF")
+            if _STAR_IN_NAME_IS_LEGAL:
+                (output / "a*.gguf").write_bytes(b"GGUF")
             (output / "llama-3[8b].Q4_K_M.gguf").write_bytes(b"GGUF")
 
         def push_to_hub_gguf(self, *args, **kwargs):
@@ -281,7 +287,10 @@ def test_gguf_hub_export_allow_list_treats_gguf_names_literally(tmp_path, monkey
     assert success is True, message
     # The bracketed name is published rather than skipped, and "a*.gguf" is matched as a
     # literal, so it neither misses itself nor sweeps in the earlier export's file.
-    assert seen["uploaded"] == ["a*.gguf", "llama-3[8b].Q4_K_M.gguf"]
+    expected = ["llama-3[8b].Q4_K_M.gguf"]
+    if _STAR_IN_NAME_IS_LEGAL:
+        expected = ["a*.gguf"] + expected
+    assert seen["uploaded"] == expected
 
 
 def test_gguf_hub_export_skips_an_earlier_export_left_in_the_folder(tmp_path, monkeypatch):
@@ -898,7 +907,8 @@ def test_gguf_hub_export_uploads_a_modelfile_it_could_not_place_locally(tmp_path
             output = Path(f"{model_save_path}_gguf")
             output.mkdir(parents = True)
             (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
-            (output / "Modelfile").write_text("FROM ./model.Q4_K_M.gguf\n")
+            # write_bytes, not write_text: text mode turns "\n" into "\r\n" on Windows.
+            (output / "Modelfile").write_bytes(b"FROM ./model.Q4_K_M.gguf\n")
 
         def push_to_hub_gguf(self, *args, **kwargs):
             calls.append("push_to_hub_gguf")

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -27,11 +27,22 @@ def _hub_doubles(calls, seen):
         def __init__(self, token = None):
             seen["token"] = token
 
-        def create_repo(self, repo_id, private = False, exist_ok = False):
+        def create_repo(
+            self,
+            repo_id,
+            private = False,
+            exist_ok = False,
+        ):
             seen["repo"] = {"repo_id": repo_id, "private": private, "exist_ok": exist_ok}
             return _RepoUrl("https://huggingface.co/owner/model")
 
-        def upload_folder(self, folder_path, repo_id, repo_type, ignore_patterns = None):
+        def upload_folder(
+            self,
+            folder_path,
+            repo_id,
+            repo_type,
+            ignore_patterns = None,
+        ):
             calls.append("upload_folder")
             seen["folder"] = folder_path
             ignored = set(ignore_patterns or ())
@@ -43,7 +54,12 @@ def _hub_doubles(calls, seen):
         def __init__(self, content):
             seen["card"] = content
 
-        def push_to_hub(self, repo_id, token = None, commit_message = None):
+        def push_to_hub(
+            self,
+            repo_id,
+            token = None,
+            commit_message = None,
+        ):
             seen["card_repo"] = repo_id
 
     return _HfApi, _ModelCard

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -310,3 +310,100 @@ def test_gguf_hub_export_skips_an_earlier_export_left_in_the_folder(tmp_path, mo
     assert not (Path(output_path) / "config.json").exists()
     # The card advertises the files, so it must land after them.
     assert calls.index("model_card") > calls.index("upload_folder")
+
+
+def test_gguf_hub_export_leaves_a_stale_modelfile_behind(tmp_path, monkeypatch):
+    """A Modelfile from an earlier export points at another model; only a fresh one ships."""
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_stale_modelfile_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    save_dir = tmp_path / "shared-export-folder"
+    save_dir.mkdir()
+    (save_dir / "Modelfile").write_text("FROM some-other-model.Q8_0.gguf")
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
+            # This conversion produces no Modelfile.
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, output_path = backend.export_gguf(
+        str(save_dir),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert seen["uploaded"] == ["model.Q4_K_M.gguf"]
+    assert (Path(output_path) / "Modelfile").is_file()
+
+
+def test_gguf_hub_export_does_not_publish_appledouble_companions(tmp_path, monkeypatch):
+    """A ._ companion beside a GGUF is Finder metadata, not a model file."""
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_appledouble_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    save_dir = tmp_path / "export"
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
+            (output / "._model.Q4_K_M.gguf").write_bytes(b"\x00\x05\x16\x07")
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, _path = backend.export_gguf(
+        str(save_dir),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert seen["uploaded"] == ["model.Q4_K_M.gguf"]
+    assert "._model.Q4_K_M.gguf" not in seen["card"]

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -7,6 +7,8 @@ import importlib.util
 from fnmatch import fnmatch
 from pathlib import Path
 
+import pytest
+
 
 _HELPERS_SPEC = importlib.util.spec_from_file_location(
     "export_gguf_hub_upload_helpers",
@@ -407,3 +409,59 @@ def test_gguf_hub_export_does_not_publish_appledouble_companions(tmp_path, monke
     assert success is True, message
     assert seen["uploaded"] == ["model.Q4_K_M.gguf"]
     assert "._model.Q4_K_M.gguf" not in seen["card"]
+
+
+@pytest.mark.parametrize("is_vlm", [True, False])
+def test_gguf_hub_export_card_carries_the_vlm_tag(tmp_path, monkeypatch, is_vlm):
+    """The Hub filters on vision-language-model, and only the exporter knows."""
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        f"test_export_gguf_hub_upload_vlm_{is_vlm}_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    save_dir = tmp_path / "export"
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            gguf = output / "model.Q4_K_M.gguf"
+            gguf.write_bytes(b"GGUF")
+            return {"gguf_files": [str(gguf)], "is_vlm": is_vlm}
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, _path = backend.export_gguf(
+        str(save_dir),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert ("- vision-language-model" in seen["card"]) is is_vlm
+    # The front matter stays valid either way.
+    assert seen["card"].startswith("---\ntags:\n")
+    assert (
+        seen["card"]
+        .split("---")[1]
+        .strip()
+        .endswith("vision-language-model" if is_vlm else "unsloth")
+    )

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -37,6 +37,17 @@ def _hub_doubles(calls, seen):
             seen["repo"] = {"repo_id": repo_id, "private": private, "exist_ok": exist_ok}
             return _RepoUrl("https://huggingface.co/owner/model")
 
+        def upload_file(
+            self,
+            path_or_fileobj,
+            path_in_repo,
+            repo_id,
+            repo_type = None,
+            commit_message = None,
+        ):
+            calls.append(f"upload_file:{path_in_repo}")
+            seen[path_in_repo] = path_or_fileobj
+
         def upload_folder(
             self,
             folder_path,
@@ -66,6 +77,7 @@ def _hub_doubles(calls, seen):
             token = None,
             commit_message = None,
         ):
+            calls.append("model_card")
             seen["card_repo"] = repo_id
 
     return _HfApi, _ModelCard
@@ -113,7 +125,8 @@ def test_gguf_hub_export_uploads_the_built_files_instead_of_reconverting(tmp_pat
     )
 
     assert success is True, message
-    assert calls == ["convert", "upload_folder"]
+    # One conversion, and the card lands after the files it advertises.
+    assert calls == ["convert", "upload_folder", "model_card"]
     assert seen["folder"] == output_path
     assert seen["repo"] == {"repo_id": "owner/model", "private": True, "exist_ok": True}
     assert "model.Q4_K_M.gguf" in seen["uploaded"]
@@ -195,7 +208,7 @@ def test_gguf_hub_export_allow_list_treats_gguf_names_literally(tmp_path, monkey
 
     save_dir = tmp_path / "llama-3[8b]"
     save_dir.mkdir()
-    # An earlier quant in the same folder, named so a bare "a*.gguf" would sweep it in.
+    # An earlier export's file, named so a bare "a*.gguf" pattern would sweep it in.
     (save_dir / "a-previous-quant.gguf").write_bytes(b"GGUF")
 
     calls: list[str] = []
@@ -232,7 +245,68 @@ def test_gguf_hub_export_allow_list_treats_gguf_names_literally(tmp_path, monkey
     )
 
     assert success is True, message
-    # The bracketed name is published, and "a*.gguf" matches only itself.
-    # Every .gguf in the export folder is published, as the model card lists them, but
-    # "a*.gguf" is matched literally rather than as a pattern.
-    assert seen["uploaded"] == ["a*.gguf", "a-previous-quant.gguf", "llama-3[8b].Q4_K_M.gguf"]
+    # The bracketed name is published rather than skipped, and "a*.gguf" is matched as a
+    # literal, so it neither misses itself nor sweeps in the earlier export's file.
+    assert seen["uploaded"] == ["a*.gguf", "llama-3[8b].Q4_K_M.gguf"]
+
+
+def test_gguf_hub_export_skips_an_earlier_export_left_in_the_folder(tmp_path, monkeypatch):
+    """Only this run's GGUFs are published, even when the folder holds an older one."""
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_stale_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    save_dir = tmp_path / "shared-export-folder"
+    save_dir.mkdir()
+    # A different model, exported here earlier. It must not ride along.
+    (save_dir / "some-other-model.Q8_0.gguf").write_bytes(b"GGUF")
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            merged = Path(model_save_path)
+            merged.mkdir(parents = True)
+            (merged / "config.json").write_text('{"model_type": "llama"}')
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
+            (output / "Modelfile").write_text("FROM model.Q4_K_M.gguf")
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, output_path = backend.export_gguf(
+        str(save_dir),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert seen["uploaded"] == ["Modelfile", "model.Q4_K_M.gguf"]
+    assert "some-other-model.Q8_0.gguf" not in seen["card"]
+    # Still on disk, just not republished under this repo.
+    assert (Path(output_path) / "some-other-model.Q8_0.gguf").is_file()
+    # config.json comes from the merged directory, which is deleted before the upload,
+    # and it is never written into the export folder.
+    assert seen["config.json"] == b'{"model_type": "llama"}'
+    assert not (Path(output_path) / "config.json").exists()
+    # The card advertises the files, so it must land after them.
+    assert calls.index("model_card") > calls.index("upload_folder")

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -465,3 +465,8 @@ def test_gguf_hub_export_card_carries_the_vlm_tag(tmp_path, monkeypatch, is_vlm)
         .strip()
         .endswith("vision-language-model" if is_vlm else "unsloth")
     )
+    # The Hub filters on the exact string, and upstream's repos end up with both
+    # spellings: "llama.cpp" from its card, "llama-cpp" from its add_tags call.
+    tags = [line[2:] for line in seen["card"].split("---")[1].strip().splitlines()[1:]]
+    assert "llama.cpp" in tags
+    assert "llama-cpp" in tags

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -1080,3 +1080,33 @@ def test_gguf_hub_export_trusts_the_exporter_over_studios_guess(tmp_path, monkey
 
     assert success is True, message
     assert "- vision-language-model" not in seen["card"]
+
+
+def test_gguf_hub_export_rejects_a_directory_where_a_gguf_should_land(tmp_path, monkeypatch):
+    """shutil.move would put the file inside it and the allow-list would match nothing."""
+    save_dir = tmp_path / "export"
+    save_dir.mkdir(parents = True)
+    # A reused folder holding a directory named like the file this run produces, plus a
+    # stale .gguf so the directory-wide success gate would still pass.
+    (save_dir / "model.Q4_K_M.gguf").mkdir()
+    (save_dir / "an-earlier-export.Q8_0.gguf").write_bytes(b"GGUF")
+
+    _module, backend, calls, seen = _visibility_backend(
+        tmp_path, monkeypatch, "test_export_gguf_hub_upload_dir_collision_backend"
+    )
+
+    success, message, _path = backend.export_gguf(
+        str(save_dir),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is False
+    assert "a directory of that name" in message
+    assert "upload_folder" not in calls
+    # The new file is not buried inside the directory, and the stale one is untouched.
+    assert list((save_dir / "model.Q4_K_M.gguf").iterdir()) == []
+    assert (save_dir / "an-earlier-export.Q8_0.gguf").is_file()

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -84,7 +84,6 @@ def _hub_doubles(calls, seen):
         ):
             calls.append("upload_folder")
             seen["folder"] = folder_path
-            # Mirror filter_repo_objects: case-sensitive fnmatchcase over repo-relative paths.
             root = Path(folder_path)
             paths = [p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()]
             if allow_patterns is not None:
@@ -165,7 +164,6 @@ def test_gguf_hub_export_uploads_the_built_files_instead_of_reconverting(tmp_pat
     assert seen["visibility"] == {"repo_id": "owner/model", "private": True}
     assert "model.Q4_K_M.gguf" in seen["uploaded"]
     assert "Modelfile" in seen["uploaded"]
-    # Studio-local, and push_to_hub_gguf never published it.
     assert "export_metadata.json" not in seen["uploaded"]
     assert Path(output_path, "export_metadata.json").is_file()
     assert "`model.Q4_K_M.gguf`" in seen["card"]
@@ -185,7 +183,6 @@ def test_gguf_hub_export_uploads_only_the_export_artifacts(tmp_path, monkeypatch
     save_dir.mkdir()
     (save_dir / "notes.txt").write_text("unrelated")
     (save_dir / "dataset.jsonl").write_text('{"a": 1}')
-    # A relocation failure keeps the merged checkpoint behind, by design.
     leftover = save_dir / "_tmp_model_earlier" / "model"
     leftover.mkdir(parents = True)
     (leftover / "model-00001-of-00002.safetensors").write_bytes(b"weights")
@@ -241,7 +238,6 @@ def test_gguf_hub_export_allow_list_treats_gguf_names_literally(tmp_path, monkey
 
     save_dir = tmp_path / "llama-3[8b]"
     save_dir.mkdir()
-    # An earlier export's file, named so a bare "a*.gguf" pattern would sweep it in.
     (save_dir / "a-previous-quant.gguf").write_bytes(b"GGUF")
 
     calls: list[str] = []
@@ -337,10 +333,8 @@ def test_gguf_hub_export_skips_an_earlier_export_left_in_the_folder(tmp_path, mo
     assert seen["uploaded"] == ["Modelfile", "model.Q4_K_M.gguf"]
     assert "some-other-model.Q8_0.gguf" not in seen["card"]
     assert (Path(output_path) / "some-other-model.Q8_0.gguf").is_file()
-    # config.json comes from the merged directory, deleted before the upload.
     assert seen["config.json"] == b'{"model_type": "llama"}'
     assert not (Path(output_path) / "config.json").exists()
-    # The card advertises the files, so it must land after them.
     assert calls.index("model_card") > calls.index("upload_folder")
 
 
@@ -365,7 +359,6 @@ def test_gguf_hub_export_leaves_a_stale_modelfile_behind(tmp_path, monkeypatch):
             output = Path(f"{model_save_path}_gguf")
             output.mkdir(parents = True)
             (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
-            # This conversion produces no Modelfile.
 
         def push_to_hub_gguf(self, *args, **kwargs):
             calls.append("push_to_hub_gguf")
@@ -494,7 +487,6 @@ def test_gguf_hub_export_card_carries_the_vlm_tag(tmp_path, monkeypatch, is_vlm)
         .strip()
         .endswith("vision-language-model" if is_vlm else "unsloth")
     )
-    # The Hub filters on the exact string, so both spellings must ship.
     tags = [line[2:] for line in seen["card"].split("---")[1].strip().splitlines()[1:]]
     assert "llama.cpp" in tags
     assert "llama-cpp" in tags
@@ -506,7 +498,6 @@ def _visibility_backend(
     name,
     gguf_names = ("model.Q4_K_M.gguf",),
 ):
-    """A backend wired to the Hub doubles, for the visibility and failure-path tests."""
     _install_export_backend_stubs(monkeypatch)
     export_module = _load_module(name, "core/export/export.py", monkeypatch)
 
@@ -521,7 +512,6 @@ def _visibility_backend(
             produced = []
             for gguf_name in gguf_names:
                 gguf = output / gguf_name
-                # A "._" name is only Finder metadata if it carries the magic too.
                 gguf.write_bytes(b"\x00\x05\x16\x07" if gguf_name.startswith("._") else b"GGUF")
                 produced.append(str(gguf))
             return {"gguf_files": produced}
@@ -576,7 +566,6 @@ def test_gguf_hub_export_refuses_to_upload_when_privacy_cannot_be_confirmed(tmp_
         raise RuntimeError("403 Forbidden: write:repo_settings missing")
 
     monkeypatch.setattr(module.HfApi, "update_repo_settings", _denied)
-    # repo_info reports a public repo, so the refusal stands.
     seen["repo_info_result"] = types.SimpleNamespace(private = False)
 
     success, message, output_path = backend.export_gguf(
@@ -715,7 +704,6 @@ def test_gguf_hub_export_fails_when_only_appledouble_companions_were_produced(
     """A run that produced only Finder metadata has produced nothing publishable."""
     save_dir = tmp_path / "export"
     save_dir.mkdir(parents = True)
-    # An earlier export of a different model, which the directory-wide gate would pass on.
     (save_dir / "some-other-model.Q8_0.gguf").write_bytes(b"GGUF")
 
     _module, backend, calls, seen = _visibility_backend(
@@ -823,7 +811,6 @@ def test_gguf_hub_export_reads_config_from_the_directory_the_exporter_reports(
             output.mkdir(parents = True)
             gguf = output / "model.Q4_K_M.gguf"
             gguf.write_bytes(b"GGUF")
-            # Deliberately no config.json under model_save_path.
             return {"gguf_files": [str(gguf)], "save_directory": str(elsewhere)}
 
         def push_to_hub_gguf(self, *args, **kwargs):
@@ -850,7 +837,6 @@ def test_gguf_hub_export_reads_config_from_the_directory_the_exporter_reports(
 
     assert success is True, message
     assert seen["config.json"] == b'{"model_type": "qwen2"}'
-    # Still not written into the export folder: _is_model_dir would read it as a checkpoint.
     assert not Path(output_path, "config.json").exists()
 
 
@@ -1006,7 +992,7 @@ def test_gguf_hub_export_falls_back_to_studios_own_vlm_detection(tmp_path, monke
             output = Path(f"{model_save_path}_gguf")
             output.mkdir(parents = True)
             (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
-            return None  # what the MLX exporter returns
+            return None
 
         def push_to_hub_gguf(self, *args, **kwargs):
             calls.append("push_to_hub_gguf")
@@ -1086,8 +1072,6 @@ def test_gguf_hub_export_rejects_a_directory_where_a_gguf_should_land(tmp_path, 
     """shutil.move would put the file inside it and the allow-list would match nothing."""
     save_dir = tmp_path / "export"
     save_dir.mkdir(parents = True)
-    # A reused folder holding a directory named like the file this run produces, plus a
-    # stale .gguf so the directory-wide success gate would still pass.
     (save_dir / "model.Q4_K_M.gguf").mkdir()
     (save_dir / "an-earlier-export.Q8_0.gguf").write_bytes(b"GGUF")
 
@@ -1107,7 +1091,6 @@ def test_gguf_hub_export_rejects_a_directory_where_a_gguf_should_land(tmp_path, 
     assert success is False
     assert "a directory of that name" in message
     assert "upload_folder" not in calls
-    # The new file is not buried inside the directory, and the stale one is untouched.
     assert list((save_dir / "model.Q4_K_M.gguf").iterdir()) == []
     assert (save_dir / "an-earlier-export.Q8_0.gguf").is_file()
 
@@ -1155,9 +1138,7 @@ def test_gguf_hub_export_publishes_a_modelfile_blocked_by_a_directory(tmp_path, 
         private = False,
     )
 
-    # The GGUFs landed, so the optional Modelfile must not fail the export...
     assert success is True, message
     assert seen["uploaded"] == ["model.Q4_K_M.gguf"]
-    # ...and it is published from memory rather than silently dropped or nested.
     assert seen["Modelfile"] == b"FROM ./model.Q4_K_M.gguf\n"
     assert list((Path(output_path) / "Modelfile").iterdir()) == []

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -51,10 +51,7 @@ def _hub_doubles(calls, seen):
             root = Path(folder_path)
             paths = [str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()]
             if allow_patterns is not None:
-                paths = [
-                    p for p in paths
-                    if any(fnmatch(p, pattern) for pattern in allow_patterns)
-                ]
+                paths = [p for p in paths if any(fnmatch(p, pattern) for pattern in allow_patterns)]
             for pattern in ignore_patterns or ():
                 paths = [p for p in paths if not fnmatch(p, pattern)]
             seen["uploaded"] = sorted(paths)

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -84,10 +84,7 @@ def _hub_doubles(calls, seen):
         ):
             calls.append("upload_folder")
             seen["folder"] = folder_path
-            # Mirror huggingface_hub: fnmatchcase over repo-relative posix paths, whole
-            # tree. fnmatchcase, not fnmatch, because that is what filter_repo_objects uses
-            # -- matching is case-sensitive on every platform, so a Windows run selects the
-            # same files a Linux one does.
+            # Mirror filter_repo_objects: case-sensitive fnmatchcase over repo-relative paths.
             root = Path(folder_path)
             paths = [p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()]
             if allow_patterns is not None:
@@ -156,8 +153,6 @@ def test_gguf_hub_export_uploads_the_built_files_instead_of_reconverting(tmp_pat
     )
 
     assert success is True, message
-    # One conversion, visibility settled before anything is uploaded, and the card lands
-    # after the files it advertises.
     assert calls == [
         "convert",
         "create_repo",
@@ -230,7 +225,6 @@ def test_gguf_hub_export_uploads_only_the_export_artifacts(tmp_path, monkeypatch
 
     assert success is True, message
     assert seen["uploaded"] == ["Modelfile", "model.Q4_K_M.gguf"]
-    # Still on disk where the user put them, just not published.
     assert (Path(output_path) / "notes.txt").is_file()
     assert (Path(output_path) / "dataset.jsonl").is_file()
     assert (leftover / "model-00001-of-00002.safetensors").is_file()
@@ -285,8 +279,6 @@ def test_gguf_hub_export_allow_list_treats_gguf_names_literally(tmp_path, monkey
     )
 
     assert success is True, message
-    # The bracketed name is published rather than skipped, and "a*.gguf" is matched as a
-    # literal, so it neither misses itself nor sweeps in the earlier export's file.
     expected = ["llama-3[8b].Q4_K_M.gguf"]
     if _STAR_IN_NAME_IS_LEGAL:
         expected = ["a*.gguf"] + expected
@@ -304,7 +296,6 @@ def test_gguf_hub_export_skips_an_earlier_export_left_in_the_folder(tmp_path, mo
 
     save_dir = tmp_path / "shared-export-folder"
     save_dir.mkdir()
-    # A different model, exported here earlier. It must not ride along.
     (save_dir / "some-other-model.Q8_0.gguf").write_bytes(b"GGUF")
 
     calls: list[str] = []
@@ -345,10 +336,8 @@ def test_gguf_hub_export_skips_an_earlier_export_left_in_the_folder(tmp_path, mo
     assert success is True, message
     assert seen["uploaded"] == ["Modelfile", "model.Q4_K_M.gguf"]
     assert "some-other-model.Q8_0.gguf" not in seen["card"]
-    # Still on disk, just not republished under this repo.
     assert (Path(output_path) / "some-other-model.Q8_0.gguf").is_file()
-    # config.json comes from the merged directory, which is deleted before the upload,
-    # and it is never written into the export folder.
+    # config.json comes from the merged directory, deleted before the upload.
     assert seen["config.json"] == b'{"model_type": "llama"}'
     assert not (Path(output_path) / "config.json").exists()
     # The card advertises the files, so it must land after them.
@@ -498,7 +487,6 @@ def test_gguf_hub_export_card_carries_the_vlm_tag(tmp_path, monkeypatch, is_vlm)
 
     assert success is True, message
     assert ("- vision-language-model" in seen["card"]) is is_vlm
-    # The front matter stays valid either way.
     assert seen["card"].startswith("---\ntags:\n")
     assert (
         seen["card"]
@@ -506,7 +494,7 @@ def test_gguf_hub_export_card_carries_the_vlm_tag(tmp_path, monkeypatch, is_vlm)
         .strip()
         .endswith("vision-language-model" if is_vlm else "unsloth")
     )
-    # The Hub filters on the exact string, and upstream means to carry both spellings.
+    # The Hub filters on the exact string, so both spellings must ship.
     tags = [line[2:] for line in seen["card"].split("---")[1].strip().splitlines()[1:]]
     assert "llama.cpp" in tags
     assert "llama-cpp" in tags
@@ -554,10 +542,7 @@ def _visibility_backend(
 
 
 def test_gguf_hub_export_makes_an_existing_repo_private_before_uploading(tmp_path, monkeypatch):
-    """create_repo ignores private on a repo that already exists, so it is settled here.
-
-    Without this the GGUFs of a "private" export land in an existing public repository.
-    """
+    """create_repo ignores private on an existing repo, so a "private" export would land public."""
     _module, backend, calls, seen = _visibility_backend(
         tmp_path, monkeypatch, "test_export_gguf_hub_upload_visibility_backend"
     )
@@ -573,7 +558,6 @@ def test_gguf_hub_export_makes_an_existing_repo_private_before_uploading(tmp_pat
 
     assert success is True, message
     assert seen["visibility"] == {"repo_id": "owner/model", "private": True}
-    # Settled before a single byte is published, not after.
     assert calls.index("update_repo_settings") < calls.index("upload_folder")
 
 
@@ -607,8 +591,6 @@ def test_gguf_hub_export_refuses_to_upload_when_privacy_cannot_be_confirmed(tmp_
     assert success is False
     assert "could not be confirmed private" in message
     assert "upload_folder" not in calls
-    # The conversion did happen, so the user is pointed at the files rather than sent
-    # back to re-run it.
     assert output_path is not None
     assert Path(output_path, "model.Q4_K_M.gguf").is_file()
 
@@ -664,11 +646,7 @@ def test_gguf_hub_export_leaves_an_existing_private_repo_alone(tmp_path, monkeyp
 
 
 def test_gguf_hub_export_survives_a_model_card_failure(tmp_path, monkeypatch):
-    """The GGUFs are already committed by then; losing the card must not fail the export.
-
-    RepoCard.push_to_hub validates against a hardcoded huggingface.co, which a private
-    HF_ENDPOINT deployment cannot serve.
-    """
+    """The GGUFs are already committed by then, so losing the card must not fail the export."""
     module, backend, calls, seen = _visibility_backend(
         tmp_path, monkeypatch, "test_export_gguf_hub_upload_card_fails_backend"
     )
@@ -734,14 +712,10 @@ def test_gguf_hub_export_reports_the_local_path_when_the_upload_fails(tmp_path, 
 def test_gguf_hub_export_fails_when_only_appledouble_companions_were_produced(
     tmp_path, monkeypatch
 ):
-    """A run that produced only Finder metadata has produced nothing publishable.
-
-    The directory-wide success gate would otherwise pass on a .gguf left by an earlier
-    export, and the Hub leg would create a repo, publish no model file, and report success.
-    """
+    """A run that produced only Finder metadata has produced nothing publishable."""
     save_dir = tmp_path / "export"
     save_dir.mkdir(parents = True)
-    # An earlier export of a different model, still sitting in the reused folder.
+    # An earlier export of a different model, which the directory-wide gate would pass on.
     (save_dir / "some-other-model.Q8_0.gguf").write_bytes(b"GGUF")
 
     _module, backend, calls, seen = _visibility_backend(
@@ -763,16 +737,11 @@ def test_gguf_hub_export_fails_when_only_appledouble_companions_were_produced(
     assert success is False
     assert "AppleDouble" in message
     assert "upload_folder" not in calls
-    # The stale file is left exactly where it was, not published and not deleted.
     assert (save_dir / "some-other-model.Q8_0.gguf").is_file()
 
 
 def test_gguf_hub_export_uses_the_canonical_repo_id_the_hub_returns(tmp_path, monkeypatch):
-    """A bare repo id is namespaced by the Hub, and the card must use the resolved one.
-
-    Upstream interpolates the id it was handed, so a bare name yields an unusable
-    `llama-cli -hf model-gguf`.
-    """
+    """The card must use the Hub-resolved repo id, else it advertises `llama-cli -hf model-gguf`."""
     _install_export_backend_stubs(monkeypatch)
     export_module = _load_module(
         "test_export_gguf_hub_upload_canonical_backend", "core/export/export.py", monkeypatch
@@ -825,7 +794,6 @@ def test_gguf_hub_export_uses_the_canonical_repo_id_the_hub_returns(tmp_path, mo
     )
 
     assert success is True, message
-    # Created under the name the user gave, then everything downstream uses the resolved id.
     assert seen["repo"]["repo_id"] == "model-gguf"
     assert seen["card_repo"] == "resolved-owner/model-gguf"
     assert "# model-gguf : GGUF" in seen["card"]
@@ -836,11 +804,7 @@ def test_gguf_hub_export_uses_the_canonical_repo_id_the_hub_returns(tmp_path, mo
 def test_gguf_hub_export_reads_config_from_the_directory_the_exporter_reports(
     tmp_path, monkeypatch
 ):
-    """The merged checkpoint is not always under our temp root.
-
-    A Kaggle disk redirect or the non-PEFT "reuse the existing checkpoint" branch makes
-    unsloth report a save_directory elsewhere, and that is where config.json lives.
-    """
+    """The merged checkpoint is not always under our temp root; unsloth reports where it went."""
     _install_export_backend_stubs(monkeypatch)
     export_module = _load_module(
         "test_export_gguf_hub_upload_reported_dir_backend", "core/export/export.py", monkeypatch
@@ -942,19 +906,13 @@ def test_gguf_hub_export_uploads_a_modelfile_it_could_not_place_locally(tmp_path
     )
 
     assert success is True, message
-    # Not on disk, because it could not be placed there, but still published.
     assert not Path(output_path, "Modelfile").exists()
     assert "Modelfile" not in seen["uploaded"]
     assert seen["Modelfile"] == b"FROM ./model.Q4_K_M.gguf\n"
 
 
 def test_push_only_gguf_export_still_delegates_to_push_to_hub_gguf(tmp_path, monkeypatch):
-    """Without a local save directory there is nothing built to upload.
-
-    The API rejects an empty save_directory today, so this pins the defensive fallback --
-    including that the token reaches it exactly once, which is why local_token_kw is kept
-    out of imatrix_kw.
-    """
+    """Nothing built to upload, so push_to_hub_gguf stands and must get the token exactly once."""
     _install_export_backend_stubs(monkeypatch)
     export_module = _load_module(
         "test_export_gguf_hub_upload_push_only_backend", "core/export/export.py", monkeypatch
@@ -1017,7 +975,6 @@ def test_push_only_gguf_export_still_delegates_to_push_to_hub_gguf(tmp_path, mon
 
     assert success is True, message
     assert output_path is None
-    # No local export, so no folder upload and no repo of our own making.
     assert "save_pretrained_gguf" not in calls
     assert "upload_folder" not in calls
     assert calls == ["push_to_hub_gguf"]
@@ -1033,11 +990,7 @@ def test_push_only_gguf_export_still_delegates_to_push_to_hub_gguf(tmp_path, mon
 
 @pytest.mark.parametrize("is_vision", [True, False])
 def test_gguf_hub_export_falls_back_to_studios_own_vlm_detection(tmp_path, monkeypatch, is_vision):
-    """The MLX binding returns None, so `reported` says nothing about is_vlm.
-
-    Without a fallback every Apple Silicon vision export is published untagged and drops
-    out of the Hub's vision-language-model filter.
-    """
+    """The MLX binding returns None, so without a fallback vision exports publish untagged."""
     _install_export_backend_stubs(monkeypatch)
     export_module = _load_module(
         f"test_export_gguf_hub_upload_vlm_fallback_{is_vision}_backend",

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+from fnmatch import fnmatch
 from pathlib import Path
 
 
@@ -41,14 +42,22 @@ def _hub_doubles(calls, seen):
             folder_path,
             repo_id,
             repo_type,
+            allow_patterns = None,
             ignore_patterns = None,
         ):
             calls.append("upload_folder")
             seen["folder"] = folder_path
-            ignored = set(ignore_patterns or ())
-            seen["uploaded"] = sorted(
-                p.name for p in Path(folder_path).iterdir() if p.name not in ignored
-            )
+            # Mirror huggingface_hub: fnmatch over repo-relative paths, whole tree.
+            root = Path(folder_path)
+            paths = [str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()]
+            if allow_patterns is not None:
+                paths = [
+                    p for p in paths
+                    if any(fnmatch(p, pattern) for pattern in allow_patterns)
+                ]
+            for pattern in ignore_patterns or ():
+                paths = [p for p in paths if not fnmatch(p, pattern)]
+            seen["uploaded"] = sorted(paths)
 
     class _ModelCard:
         def __init__(self, content):
@@ -117,3 +126,62 @@ def test_gguf_hub_export_uploads_the_built_files_instead_of_reconverting(tmp_pat
     assert Path(output_path, "export_metadata.json").is_file()
     assert "`model.Q4_K_M.gguf`" in seen["card"]
     assert seen["card_repo"] == "owner/model"
+
+
+def test_gguf_hub_export_uploads_only_the_export_artifacts(tmp_path, monkeypatch):
+    """The save directory is user-chosen, so its other contents must stay off the Hub."""
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_scoped_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    save_dir = tmp_path / "picked-in-the-folder-browser"
+    save_dir.mkdir()
+    (save_dir / "notes.txt").write_text("unrelated")
+    (save_dir / "dataset.jsonl").write_text('{"a": 1}')
+    # A relocation failure keeps the merged checkpoint behind, by design.
+    leftover = save_dir / "_tmp_model_earlier" / "model"
+    leftover.mkdir(parents = True)
+    (leftover / "model-00001-of-00002.safetensors").write_bytes(b"weights")
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            calls.append("convert")
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
+            (output / "Modelfile").write_text("FROM model.Q4_K_M.gguf")
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, output_path = backend.export_gguf(
+        str(save_dir),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert seen["uploaded"] == ["Modelfile", "model.Q4_K_M.gguf"]
+    # Still on disk where the user put them, just not published.
+    assert (Path(output_path) / "notes.txt").is_file()
+    assert (Path(output_path) / "dataset.jsonl").is_file()
+    assert (leftover / "model-00001-of-00002.safetensors").is_file()

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 import importlib.util
-from fnmatch import fnmatch
+import types
+from fnmatch import fnmatchcase
 from pathlib import Path
 
 import pytest
@@ -36,8 +37,26 @@ def _hub_doubles(calls, seen):
             private = False,
             exist_ok = False,
         ):
+            calls.append("create_repo")
             seen["repo"] = {"repo_id": repo_id, "private": private, "exist_ok": exist_ok}
             return _RepoUrl("https://huggingface.co/owner/model")
+
+        def update_repo_settings(
+            self,
+            repo_id,
+            private = None,
+            repo_type = None,
+        ):
+            calls.append("update_repo_settings")
+            seen["visibility"] = {"repo_id": repo_id, "private": private}
+
+        def repo_info(
+            self,
+            repo_id,
+            repo_type = None,
+        ):
+            calls.append("repo_info")
+            return seen.get("repo_info_result")
 
         def upload_file(
             self,
@@ -60,13 +79,18 @@ def _hub_doubles(calls, seen):
         ):
             calls.append("upload_folder")
             seen["folder"] = folder_path
-            # Mirror huggingface_hub: fnmatch over repo-relative paths, whole tree.
+            # Mirror huggingface_hub: fnmatchcase over repo-relative posix paths, whole
+            # tree. fnmatchcase, not fnmatch, because that is what filter_repo_objects uses
+            # -- matching is case-sensitive on every platform, so a Windows run selects the
+            # same files a Linux one does.
             root = Path(folder_path)
-            paths = [str(p.relative_to(root)) for p in root.rglob("*") if p.is_file()]
+            paths = [p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()]
             if allow_patterns is not None:
-                paths = [p for p in paths if any(fnmatch(p, pattern) for pattern in allow_patterns)]
+                paths = [
+                    p for p in paths if any(fnmatchcase(p, pattern) for pattern in allow_patterns)
+                ]
             for pattern in ignore_patterns or ():
-                paths = [p for p in paths if not fnmatch(p, pattern)]
+                paths = [p for p in paths if not fnmatchcase(p, pattern)]
             seen["uploaded"] = sorted(paths)
 
     class _ModelCard:
@@ -127,10 +151,18 @@ def test_gguf_hub_export_uploads_the_built_files_instead_of_reconverting(tmp_pat
     )
 
     assert success is True, message
-    # One conversion, and the card lands after the files it advertises.
-    assert calls == ["convert", "upload_folder", "model_card"]
+    # One conversion, visibility settled before anything is uploaded, and the card lands
+    # after the files it advertises.
+    assert calls == [
+        "convert",
+        "create_repo",
+        "update_repo_settings",
+        "upload_folder",
+        "model_card",
+    ]
     assert seen["folder"] == output_path
     assert seen["repo"] == {"repo_id": "owner/model", "private": True, "exist_ok": True}
+    assert seen["visibility"] == {"repo_id": "owner/model", "private": True}
     assert "model.Q4_K_M.gguf" in seen["uploaded"]
     assert "Modelfile" in seen["uploaded"]
     # Studio-local, and push_to_hub_gguf never published it.
@@ -465,8 +497,623 @@ def test_gguf_hub_export_card_carries_the_vlm_tag(tmp_path, monkeypatch, is_vlm)
         .strip()
         .endswith("vision-language-model" if is_vlm else "unsloth")
     )
-    # The Hub filters on the exact string, and upstream's repos end up with both
-    # spellings: "llama.cpp" from its card, "llama-cpp" from its add_tags call.
+    # The Hub filters on the exact string, and upstream means to carry both spellings.
     tags = [line[2:] for line in seen["card"].split("---")[1].strip().splitlines()[1:]]
     assert "llama.cpp" in tags
     assert "llama-cpp" in tags
+
+
+def _visibility_backend(
+    tmp_path,
+    monkeypatch,
+    name,
+    gguf_names = ("model.Q4_K_M.gguf",),
+):
+    """A backend wired to the Hub doubles, for the visibility and failure-path tests."""
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(name, "core/export/export.py", monkeypatch)
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            calls.append("convert")
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            produced = []
+            for gguf_name in gguf_names:
+                gguf = output / gguf_name
+                # A "._" name is only Finder metadata if it carries the magic too.
+                gguf.write_bytes(b"\x00\x05\x16\x07" if gguf_name.startswith("._") else b"GGUF")
+                produced.append(str(gguf))
+            return {"gguf_files": produced}
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+    return export_module, backend, calls, seen
+
+
+def test_gguf_hub_export_makes_an_existing_repo_private_before_uploading(tmp_path, monkeypatch):
+    """create_repo ignores private on a repo that already exists, so it is settled here.
+
+    Without this the GGUFs of a "private" export land in an existing public repository.
+    """
+    _module, backend, calls, seen = _visibility_backend(
+        tmp_path, monkeypatch, "test_export_gguf_hub_upload_visibility_backend"
+    )
+
+    success, message, _path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = True,
+    )
+
+    assert success is True, message
+    assert seen["visibility"] == {"repo_id": "owner/model", "private": True}
+    # Settled before a single byte is published, not after.
+    assert calls.index("update_repo_settings") < calls.index("upload_folder")
+
+
+def test_gguf_hub_export_refuses_to_upload_when_privacy_cannot_be_confirmed(tmp_path, monkeypatch):
+    """A private=True export must fail rather than publish to a repo it cannot close."""
+    module, backend, calls, seen = _visibility_backend(
+        tmp_path, monkeypatch, "test_export_gguf_hub_upload_visibility_denied_backend"
+    )
+
+    def _denied(
+        self,
+        repo_id,
+        private = None,
+        repo_type = None,
+    ):
+        raise RuntimeError("403 Forbidden: write:repo_settings missing")
+
+    monkeypatch.setattr(module.HfApi, "update_repo_settings", _denied)
+    # repo_info reports a public repo, so the refusal stands.
+    seen["repo_info_result"] = types.SimpleNamespace(private = False)
+
+    success, message, output_path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = True,
+    )
+
+    assert success is False
+    assert "could not be confirmed private" in message
+    assert "upload_folder" not in calls
+    # The conversion did happen, so the user is pointed at the files rather than sent
+    # back to re-run it.
+    assert output_path is not None
+    assert Path(output_path, "model.Q4_K_M.gguf").is_file()
+
+
+def test_gguf_hub_export_uploads_when_the_repo_is_already_private(tmp_path, monkeypatch):
+    """A token without write:repo_settings still works against an already-private repo."""
+    module, backend, calls, seen = _visibility_backend(
+        tmp_path, monkeypatch, "test_export_gguf_hub_upload_visibility_ok_backend"
+    )
+
+    def _denied(
+        self,
+        repo_id,
+        private = None,
+        repo_type = None,
+    ):
+        raise RuntimeError("403 Forbidden: write:repo_settings missing")
+
+    monkeypatch.setattr(module.HfApi, "update_repo_settings", _denied)
+    seen["repo_info_result"] = types.SimpleNamespace(private = True)
+
+    success, message, _path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = True,
+    )
+
+    assert success is True, message
+    assert seen["uploaded"] == ["model.Q4_K_M.gguf"]
+
+
+def test_gguf_hub_export_leaves_an_existing_private_repo_alone(tmp_path, monkeypatch):
+    """private=False only means "do not create it private", never "publish this repo"."""
+    _module, backend, calls, seen = _visibility_backend(
+        tmp_path, monkeypatch, "test_export_gguf_hub_upload_visibility_public_backend"
+    )
+
+    success, message, _path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert "update_repo_settings" not in calls
+    assert "visibility" not in seen
+
+
+def test_gguf_hub_export_survives_a_model_card_failure(tmp_path, monkeypatch):
+    """The GGUFs are already committed by then; losing the card must not fail the export.
+
+    RepoCard.push_to_hub validates against a hardcoded huggingface.co, which a private
+    HF_ENDPOINT deployment cannot serve.
+    """
+    module, backend, calls, seen = _visibility_backend(
+        tmp_path, monkeypatch, "test_export_gguf_hub_upload_card_fails_backend"
+    )
+
+    def _boom(
+        self,
+        repo_id,
+        token = None,
+        commit_message = None,
+    ):
+        raise RuntimeError("connection refused: api/validate-yaml")
+
+    monkeypatch.setattr(module.ModelCard, "push_to_hub", _boom)
+
+    success, message, output_path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert seen["uploaded"] == ["model.Q4_K_M.gguf"]
+    assert output_path is not None
+
+
+def test_gguf_hub_export_reports_the_local_path_when_the_upload_fails(tmp_path, monkeypatch):
+    """A failed upload must not read as "re-run the hour-long conversion"."""
+    module, backend, calls, seen = _visibility_backend(
+        tmp_path, monkeypatch, "test_export_gguf_hub_upload_upload_fails_backend"
+    )
+
+    def _boom(
+        self,
+        folder_path,
+        repo_id,
+        repo_type,
+        allow_patterns = None,
+        ignore_patterns = None,
+    ):
+        raise RuntimeError("504 Gateway Timeout")
+
+    monkeypatch.setattr(module.HfApi, "upload_folder", _boom)
+
+    success, message, output_path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is False
+    assert "504 Gateway Timeout" in message
+    assert "saved to" in message
+    assert output_path is not None
+    assert Path(output_path, "model.Q4_K_M.gguf").is_file()
+
+
+def test_gguf_hub_export_fails_when_only_appledouble_companions_were_produced(
+    tmp_path, monkeypatch
+):
+    """A run that produced only Finder metadata has produced nothing publishable.
+
+    The directory-wide success gate would otherwise pass on a .gguf left by an earlier
+    export, and the Hub leg would create a repo, publish no model file, and report success.
+    """
+    save_dir = tmp_path / "export"
+    save_dir.mkdir(parents = True)
+    # An earlier export of a different model, still sitting in the reused folder.
+    (save_dir / "some-other-model.Q8_0.gguf").write_bytes(b"GGUF")
+
+    _module, backend, calls, seen = _visibility_backend(
+        tmp_path,
+        monkeypatch,
+        "test_export_gguf_hub_upload_only_appledouble_backend",
+        gguf_names = ("._model.Q4_K_M.gguf",),
+    )
+
+    success, message, _path = backend.export_gguf(
+        str(save_dir),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is False
+    assert "AppleDouble" in message
+    assert "upload_folder" not in calls
+    # The stale file is left exactly where it was, not published and not deleted.
+    assert (save_dir / "some-other-model.Q8_0.gguf").is_file()
+
+
+def test_gguf_hub_export_uses_the_canonical_repo_id_the_hub_returns(tmp_path, monkeypatch):
+    """A bare repo id is namespaced by the Hub, and the card must use the resolved one.
+
+    Upstream interpolates the id it was handed, so a bare name yields an unusable
+    `llama-cli -hf model-gguf`.
+    """
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_canonical_backend", "core/export/export.py", monkeypatch
+    )
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class _CanonicalRepoUrl(str):
+        repo_id = "resolved-owner/model-gguf"
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+
+    def _create_repo(
+        self,
+        repo_id,
+        private = False,
+        exist_ok = False,
+    ):
+        calls.append("create_repo")
+        seen["repo"] = {"repo_id": repo_id, "private": private, "exist_ok": exist_ok}
+        return _CanonicalRepoUrl("https://huggingface.co/resolved-owner/model-gguf")
+
+    hf_api.create_repo = _create_repo
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, _path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "model-gguf",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    # Created under the name the user gave, then everything downstream uses the resolved id.
+    assert seen["repo"]["repo_id"] == "model-gguf"
+    assert seen["card_repo"] == "resolved-owner/model-gguf"
+    assert "# model-gguf : GGUF" in seen["card"]
+    assert "llama-cli -hf resolved-owner/model-gguf --jinja" in seen["card"]
+    assert "llama-mtmd-cli -hf resolved-owner/model-gguf --jinja" in seen["card"]
+
+
+def test_gguf_hub_export_reads_config_from_the_directory_the_exporter_reports(
+    tmp_path, monkeypatch
+):
+    """The merged checkpoint is not always under our temp root.
+
+    A Kaggle disk redirect or the non-PEFT "reuse the existing checkpoint" branch makes
+    unsloth report a save_directory elsewhere, and that is where config.json lives.
+    """
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_reported_dir_backend", "core/export/export.py", monkeypatch
+    )
+
+    elsewhere = tmp_path / "somewhere-else"
+    elsewhere.mkdir()
+    (elsewhere / "config.json").write_bytes(b'{"model_type": "qwen2"}')
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            gguf = output / "model.Q4_K_M.gguf"
+            gguf.write_bytes(b"GGUF")
+            # Deliberately no config.json under model_save_path.
+            return {"gguf_files": [str(gguf)], "save_directory": str(elsewhere)}
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, output_path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert seen["config.json"] == b'{"model_type": "qwen2"}'
+    # Still not written into the export folder: _is_model_dir would read it as a checkpoint.
+    assert not Path(output_path, "config.json").exists()
+
+
+def test_gguf_hub_export_uploads_a_modelfile_it_could_not_place_locally(tmp_path, monkeypatch):
+    """A read-only destination must not silently drop an artifact this run produced."""
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_modelfile_move_fails_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
+            (output / "Modelfile").write_text("FROM ./model.Q4_K_M.gguf\n")
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    real_move = export_module.shutil.move
+
+    def _refuse_the_modelfile(src, dst, *args, **kwargs):
+        if Path(str(dst)).name == "Modelfile":
+            raise OSError("read-only file system")
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(export_module.shutil, "move", _refuse_the_modelfile)
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, output_path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    # Not on disk, because it could not be placed there, but still published.
+    assert not Path(output_path, "Modelfile").exists()
+    assert "Modelfile" not in seen["uploaded"]
+    assert seen["Modelfile"] == b"FROM ./model.Q4_K_M.gguf\n"
+
+
+def test_push_only_gguf_export_still_delegates_to_push_to_hub_gguf(tmp_path, monkeypatch):
+    """Without a local save directory there is nothing built to upload.
+
+    The API rejects an empty save_directory today, so this pins the defensive fallback --
+    including that the token reaches it exactly once, which is why local_token_kw is kept
+    out of imatrix_kw.
+    """
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_push_only_backend", "core/export/export.py", monkeypatch
+    )
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(
+            self,
+            model_save_path,
+            tokenizer,
+            quantization_method,
+            imatrix_file = None,
+            token = None,
+            gguf_shard_size = None,
+        ):
+            calls.append("save_pretrained_gguf")
+
+        def push_to_hub_gguf(
+            self,
+            repo_id,
+            tokenizer,
+            quantization_method = None,
+            token = None,
+            private = None,
+            imatrix_file = None,
+            gguf_shard_size = None,
+        ):
+            calls.append("push_to_hub_gguf")
+            seen["push"] = {
+                "repo_id": repo_id,
+                "quantization_method": quantization_method,
+                "token": token,
+                "private": private,
+                "imatrix_file": imatrix_file,
+                "gguf_shard_size": gguf_shard_size,
+            }
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, output_path = backend.export_gguf(
+        "",
+        "iq2_xxs",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = True,
+        imatrix_file = True,
+        gguf_shard_size = "512MB",
+    )
+
+    assert success is True, message
+    assert output_path is None
+    # No local export, so no folder upload and no repo of our own making.
+    assert "save_pretrained_gguf" not in calls
+    assert "upload_folder" not in calls
+    assert calls == ["push_to_hub_gguf"]
+    assert seen["push"] == {
+        "repo_id": "owner/model",
+        "quantization_method": "iq2_xxs",
+        "token": "token",
+        "private": True,
+        "imatrix_file": True,
+        "gguf_shard_size": "512MB",
+    }
+
+
+@pytest.mark.parametrize("is_vision", [True, False])
+def test_gguf_hub_export_falls_back_to_studios_own_vlm_detection(tmp_path, monkeypatch, is_vision):
+    """The MLX binding returns None, so `reported` says nothing about is_vlm.
+
+    Without a fallback every Apple Silicon vision export is published untagged and drops
+    out of the Hub's vision-language-model filter.
+    """
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        f"test_export_gguf_hub_upload_vlm_fallback_{is_vision}_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
+            return None  # what the MLX exporter returns
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+    backend.is_vision = is_vision
+
+    success, message, _path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert ("- vision-language-model" in seen["card"]) is is_vision
+
+
+def test_gguf_hub_export_trusts_the_exporter_over_studios_guess(tmp_path, monkeypatch):
+    """A CUDA exporter that reports is_vlm=False wins, even if Studio loaded it as vision."""
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_vlm_reported_wins_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            gguf = output / "model.Q4_K_M.gguf"
+            gguf.write_bytes(b"GGUF")
+            return {"gguf_files": [str(gguf)], "is_vlm": False}
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+    backend.is_vision = True
+
+    success, message, _path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    assert "- vision-language-model" not in seen["card"]

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -182,3 +182,57 @@ def test_gguf_hub_export_uploads_only_the_export_artifacts(tmp_path, monkeypatch
     assert (Path(output_path) / "notes.txt").is_file()
     assert (Path(output_path) / "dataset.jsonl").is_file()
     assert (leftover / "model-00001-of-00002.safetensors").is_file()
+
+
+def test_gguf_hub_export_allow_list_treats_gguf_names_literally(tmp_path, monkeypatch):
+    """A glob character in the model name must not skip its file or match another."""
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_glob_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    save_dir = tmp_path / "llama-3[8b]"
+    save_dir.mkdir()
+    # An earlier quant in the same folder, named so a bare "a*.gguf" would sweep it in.
+    (save_dir / "a-previous-quant.gguf").write_bytes(b"GGUF")
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            calls.append("convert")
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "a*.gguf").write_bytes(b"GGUF")
+            (output / "llama-3[8b].Q4_K_M.gguf").write_bytes(b"GGUF")
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, _path = backend.export_gguf(
+        str(save_dir),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    assert success is True, message
+    # The bracketed name is published, and "a*.gguf" matches only itself.
+    # Every .gguf in the export folder is published, as the model card lists them, but
+    # "a*.gguf" is matched literally rather than as a pattern.
+    assert seen["uploaded"] == ["a*.gguf", "a-previous-quant.gguf", "llama-3[8b].Q4_K_M.gguf"]

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -1110,3 +1110,54 @@ def test_gguf_hub_export_rejects_a_directory_where_a_gguf_should_land(tmp_path, 
     # The new file is not buried inside the directory, and the stale one is untouched.
     assert list((save_dir / "model.Q4_K_M.gguf").iterdir()) == []
     assert (save_dir / "an-earlier-export.Q8_0.gguf").is_file()
+
+
+def test_gguf_hub_export_publishes_a_modelfile_blocked_by_a_directory(tmp_path, monkeypatch):
+    """A directory named Modelfile would nest it where the allow-list cannot match."""
+    save_dir = tmp_path / "export"
+    save_dir.mkdir(parents = True)
+    (save_dir / "Modelfile").mkdir()
+
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_modelfile_dir_backend", "core/export/export.py", monkeypatch
+    )
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
+            (output / "Modelfile").write_bytes(b"FROM ./model.Q4_K_M.gguf\n")
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, output_path = backend.export_gguf(
+        str(save_dir),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = False,
+    )
+
+    # The GGUFs landed, so the optional Modelfile must not fail the export...
+    assert success is True, message
+    assert seen["uploaded"] == ["model.Q4_K_M.gguf"]
+    # ...and it is published from memory rather than silently dropped or nested.
+    assert seen["Modelfile"] == b"FROM ./model.Q4_K_M.gguf\n"
+    assert list((Path(output_path) / "Modelfile").iterdir()) == []

--- a/studio/backend/tests/test_export_gguf_hub_upload.py
+++ b/studio/backend/tests/test_export_gguf_hub_upload.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_HELPERS_SPEC = importlib.util.spec_from_file_location(
+    "export_gguf_hub_upload_helpers",
+    Path(__file__).with_name("test_export_absolute_paths.py"),
+)
+assert _HELPERS_SPEC is not None and _HELPERS_SPEC.loader is not None
+_HELPERS = importlib.util.module_from_spec(_HELPERS_SPEC)
+_HELPERS_SPEC.loader.exec_module(_HELPERS)
+_install_export_backend_stubs = _HELPERS._install_export_backend_stubs
+_load_module = _HELPERS._load_module
+
+
+class _RepoUrl(str):
+    repo_id = "owner/model"
+
+
+def _hub_doubles(calls, seen):
+    class _HfApi:
+        def __init__(self, token = None):
+            seen["token"] = token
+
+        def create_repo(self, repo_id, private = False, exist_ok = False):
+            seen["repo"] = {"repo_id": repo_id, "private": private, "exist_ok": exist_ok}
+            return _RepoUrl("https://huggingface.co/owner/model")
+
+        def upload_folder(self, folder_path, repo_id, repo_type, ignore_patterns = None):
+            calls.append("upload_folder")
+            seen["folder"] = folder_path
+            ignored = set(ignore_patterns or ())
+            seen["uploaded"] = sorted(
+                p.name for p in Path(folder_path).iterdir() if p.name not in ignored
+            )
+
+    class _ModelCard:
+        def __init__(self, content):
+            seen["card"] = content
+
+        def push_to_hub(self, repo_id, token = None, commit_message = None):
+            seen["card_repo"] = repo_id
+
+    return _HfApi, _ModelCard
+
+
+def test_gguf_hub_export_uploads_the_built_files_instead_of_reconverting(tmp_path, monkeypatch):
+    _install_export_backend_stubs(monkeypatch)
+    export_module = _load_module(
+        "test_export_gguf_hub_upload_backend",
+        "core/export/export.py",
+        monkeypatch,
+    )
+
+    calls: list[str] = []
+    seen: dict = {}
+
+    class Model:
+        def save_pretrained_gguf(self, model_save_path, tokenizer, quantization_method):
+            calls.append("convert")
+            output = Path(f"{model_save_path}_gguf")
+            output.mkdir(parents = True)
+            (output / "model.Q4_K_M.gguf").write_bytes(b"GGUF")
+            (output / "Modelfile").write_text("FROM model.Q4_K_M.gguf")
+
+        def push_to_hub_gguf(self, *args, **kwargs):
+            calls.append("push_to_hub_gguf")
+
+    hf_api, model_card = _hub_doubles(calls, seen)
+    monkeypatch.setattr(export_module, "HfApi", hf_api)
+    monkeypatch.setattr(export_module, "ModelCard", model_card)
+    monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
+
+    backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
+    backend.current_model = Model()
+    backend.current_tokenizer = object()
+    backend.current_checkpoint = None
+
+    success, message, output_path = backend.export_gguf(
+        str(tmp_path / "export"),
+        "Q4_K_M",
+        push_to_hub = True,
+        repo_id = "owner/model",
+        hf_token = "token",
+        private = True,
+    )
+
+    assert success is True, message
+    assert calls == ["convert", "upload_folder"]
+    assert seen["folder"] == output_path
+    assert seen["repo"] == {"repo_id": "owner/model", "private": True, "exist_ok": True}
+    assert "model.Q4_K_M.gguf" in seen["uploaded"]
+    assert "Modelfile" in seen["uploaded"]
+    # Studio-local, and push_to_hub_gguf never published it.
+    assert "export_metadata.json" not in seen["uploaded"]
+    assert Path(output_path, "export_metadata.json").is_file()
+    assert "`model.Q4_K_M.gguf`" in seen["card"]
+    assert seen["card_repo"] == "owner/model"

--- a/studio/backend/tests/test_export_gguf_sharding.py
+++ b/studio/backend/tests/test_export_gguf_sharding.py
@@ -151,6 +151,7 @@ def test_backend_forwards_shard_size_to_the_local_export_it_then_uploads(tmp_pat
             folder_path,
             repo_id,
             repo_type,
+            allow_patterns = None,
             ignore_patterns = None,
         ):
             seen["upload"] = folder_path

--- a/studio/backend/tests/test_export_gguf_sharding.py
+++ b/studio/backend/tests/test_export_gguf_sharding.py
@@ -137,18 +137,34 @@ def test_backend_forwards_shard_size_to_the_local_export_it_then_uploads(tmp_pat
         def __init__(self, token = None):
             seen["token"] = token
 
-        def create_repo(self, repo_id, private = False, exist_ok = False):
+        def create_repo(
+            self,
+            repo_id,
+            private = False,
+            exist_ok = False,
+        ):
             seen["repo"] = {"repo_id": repo_id, "private": private}
             return _RepoUrl("https://huggingface.co/owner/model")
 
-        def upload_folder(self, folder_path, repo_id, repo_type, ignore_patterns = None):
+        def upload_folder(
+            self,
+            folder_path,
+            repo_id,
+            repo_type,
+            ignore_patterns = None,
+        ):
             seen["upload"] = folder_path
 
     class _ModelCard:
         def __init__(self, content):
             pass
 
-        def push_to_hub(self, repo_id, token = None, commit_message = None):
+        def push_to_hub(
+            self,
+            repo_id,
+            token = None,
+            commit_message = None,
+        ):
             pass
 
     monkeypatch.setattr(export_module, "HfApi", _HfApi)

--- a/studio/backend/tests/test_export_gguf_sharding.py
+++ b/studio/backend/tests/test_export_gguf_sharding.py
@@ -102,7 +102,7 @@ def test_worker_passes_shard_size_to_backend():
     assert queue.items[-1]["success"] is True
 
 
-def test_backend_forwards_shard_size_to_local_and_hub_exports(tmp_path, monkeypatch):
+def test_backend_forwards_shard_size_to_the_local_export_it_then_uploads(tmp_path, monkeypatch):
     _install_export_backend_stubs(monkeypatch)
     export_module = _load_module(
         "test_export_gguf_shard_backend",
@@ -127,21 +127,32 @@ def test_backend_forwards_shard_size_to_local_and_hub_exports(tmp_path, monkeypa
             shard.write_bytes(b"GGUF")
             return {"gguf_files": [str(shard)]}
 
-        def push_to_hub_gguf(
-            self,
-            repo_id,
-            tokenizer,
-            quantization_method,
-            token,
-            private,
-            gguf_shard_size = None,
-        ):
-            seen["hub"] = {
-                "repo_id": repo_id,
-                "private": private,
-                "gguf_shard_size": gguf_shard_size,
-            }
+        def push_to_hub_gguf(self, *args, **kwargs):
+            seen["hub"] = kwargs
 
+    class _RepoUrl(str):
+        repo_id = "owner/model"
+
+    class _HfApi:
+        def __init__(self, token = None):
+            seen["token"] = token
+
+        def create_repo(self, repo_id, private = False, exist_ok = False):
+            seen["repo"] = {"repo_id": repo_id, "private": private}
+            return _RepoUrl("https://huggingface.co/owner/model")
+
+        def upload_folder(self, folder_path, repo_id, repo_type, ignore_patterns = None):
+            seen["upload"] = folder_path
+
+    class _ModelCard:
+        def __init__(self, content):
+            pass
+
+        def push_to_hub(self, repo_id, token = None, commit_message = None):
+            pass
+
+    monkeypatch.setattr(export_module, "HfApi", _HfApi)
+    monkeypatch.setattr(export_module, "ModelCard", _ModelCard)
     monkeypatch.setattr(export_module, "resolve_export_write_dir", lambda value: Path(value))
     backend = export_module.ExportBackend.__new__(export_module.ExportBackend)
     backend.current_model = Model()
@@ -161,7 +172,9 @@ def test_backend_forwards_shard_size_to_local_and_hub_exports(tmp_path, monkeypa
     assert success is True, message
     assert output_path == str(save_directory.resolve())
     assert seen["local"] == "512MB"
-    assert seen["hub"] == {"repo_id": "owner/model", "private": True, "gguf_shard_size": "512MB"}
+    assert "hub" not in seen
+    assert seen["upload"] == output_path
+    assert seen["repo"] == {"repo_id": "owner/model", "private": True}
 
 
 def test_backend_rejects_old_exporter_only_when_option_is_set(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_export_gguf_sharding.py
+++ b/studio/backend/tests/test_export_gguf_sharding.py
@@ -146,6 +146,21 @@ def test_backend_forwards_shard_size_to_the_local_export_it_then_uploads(tmp_pat
             seen["repo"] = {"repo_id": repo_id, "private": private}
             return _RepoUrl("https://huggingface.co/owner/model")
 
+        def update_repo_settings(
+            self,
+            repo_id,
+            private = None,
+            repo_type = None,
+        ):
+            seen["visibility"] = {"repo_id": repo_id, "private": private}
+
+        def repo_info(
+            self,
+            repo_id,
+            repo_type = None,
+        ):
+            return None
+
         def upload_folder(
             self,
             folder_path,


### PR DESCRIPTION
Exporting to GGUF with Hugging Face Hub as the destination runs the whole merge, convert and quantize sequence twice. The first run writes the files to your save folder. The second run happens inside `push_to_hub_gguf`, which converts everything again into the system temp folder instead of uploading the files that already exist.

That doubles the wait, needs a second full size copy of the model in temp, and can push a run past the export timeout, which is one hour per quantization.

Now the Hub upload sends the files that were already built. Tested against a real Hub repo. Before: two conversion calls, and nothing from the local folder reached the Hub. After: one conversion call, and the repo gets the `.gguf` file, the Modelfile and a model card.
