### PR TITLE
Point unsloth start openclaw memory search at the Unsloth embeddings API

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -4689,6 +4689,7 @@ def write_openclaw_config(
         {
             "provider": "openai-compatible",
             "model": embedding_model,
+            "fallback": "none",
             "remote": {"baseUrl": f"{base}/v1", "apiKey": key},
         }
     )

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -4645,13 +4645,29 @@ def _session_config(
         yield path
 
 
-def _studio_embedding_model(base: str, key: str) -> str:
+def _studio_embedding_model(base: str, key: str) -> Optional[str]:
+    """Studio's configured embedding model, or None when this server cannot say.
+
+    None is not a model name on purpose. Naming a model the server will not serve, and
+    pinning fallback to "none" next to it, is the one combination OpenClaw cannot degrade
+    out of: every memory request then fails against Studio with no keyword path left. The
+    caller turns None into `provider: "none"` instead, which is OpenClaw's own value for
+    keyword-only memory search -- still local, still no OpenAI, and it still returns hits.
+    """
     try:
         info = _http_json("GET", f"{base}/api/settings/embedding-model", key, timeout = 10)
+    # A CLI abort is a decision, not a transport failure; typer.Exit is a RuntimeError
+    # subclass, so the broad catch below would otherwise turn it into a silent fallback.
+    except (typer.Exit, typer.Abort, click.exceptions.Exit, click.exceptions.Abort):
+        raise
     except Exception:  # noqa: BLE001 - an older or unreachable server still gets a working config
-        return "default"
+        return None
     name = info.get("embedding_model") if isinstance(info, dict) else None
-    return name if isinstance(name, str) and name.strip() else "default"
+    if not isinstance(name, str) or not name.strip():
+        return None
+    # Studio stores what was typed into Settings; OpenClaw sends this string to
+    # /v1/embeddings verbatim, so strip here rather than shipping the padding.
+    return name.strip()
 
 
 def write_openclaw_config(
@@ -4661,7 +4677,7 @@ def write_openclaw_config(
     path: Path,
     yolo: bool = False,
     workspace_path: Optional[str] = None,
-    embedding_model: str = "default",
+    embedding_model: Optional[str] = None,
 ) -> None:
     config = _read_json_object(path)
     if config is None:
@@ -4685,14 +4701,27 @@ def write_openclaw_config(
         "api": "openai-completions",
         "models": [provider_model],
     }
-    _subdict(_subdict(config, "memory"), "search").update(
-        {
-            "provider": "openai-compatible",
-            "model": embedding_model,
-            "fallback": "none",
-            "remote": {"baseUrl": f"{base}/v1", "apiKey": key},
-        }
-    )
+    # Memory search is on by default in OpenClaw and its default provider is openai, so a
+    # session meant to stay local reaches OpenAI unless this block is written.
+    search = _subdict(_subdict(config, "memory"), "search")
+    if embedding_model:
+        search.update(
+            {
+                "provider": "openai-compatible",
+                "model": embedding_model,
+                "fallback": "none",
+                "remote": {"baseUrl": f"{base}/v1", "apiKey": key},
+            }
+        )
+    else:
+        # No model name to point at (an older server, or one that would not answer). Ask
+        # for keyword-only memory search rather than for embeddings this server cannot
+        # serve: "none" is OpenClaw's documented value for that, it makes no network call,
+        # and `openclaw memory search` still returns ranked hits. Clear the remote so a
+        # reused --persist config does not keep aiming at an endpoint we just gave up on.
+        search.update({"provider": "none", "fallback": "none"})
+        search.pop("model", None)
+        search.pop("remote", None)
     # Pin a default model, else OpenClaw drops into its setup agent ("no models available").
     agents = _subdict(config, "agents")
     defaults = _subdict(agents, "defaults")

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -4648,16 +4648,12 @@ def _session_config(
 def _studio_embedding_model(base: str, key: str) -> Optional[str]:
     """Studio's configured embedding model, or None when this server cannot say.
 
-    None is not a model name on purpose. Naming a model the server will not serve, and
-    pinning fallback to "none" next to it, is the one combination OpenClaw cannot degrade
-    out of: every memory request then fails against Studio with no keyword path left. The
-    caller turns None into `provider: "none"` instead, which is OpenClaw's own value for
-    keyword-only memory search -- still local, still no OpenAI, and it still returns hits.
+    Not a model name: a name this server will not serve, beside fallback "none", is the one
+    combination OpenClaw cannot degrade out of. The caller writes provider "none" instead.
     """
     try:
         info = _http_json("GET", f"{base}/api/settings/embedding-model", key, timeout = 10)
-    # A CLI abort is a decision, not a transport failure; typer.Exit is a RuntimeError
-    # subclass, so the broad catch below would otherwise turn it into a silent fallback.
+    # typer.Exit is a RuntimeError subclass: the broad catch would swallow a deliberate abort.
     except (typer.Exit, typer.Abort, click.exceptions.Exit, click.exceptions.Abort):
         raise
     except Exception:  # noqa: BLE001 - an older or unreachable server still gets a working config
@@ -4665,8 +4661,7 @@ def _studio_embedding_model(base: str, key: str) -> Optional[str]:
     name = info.get("embedding_model") if isinstance(info, dict) else None
     if not isinstance(name, str) or not name.strip():
         return None
-    # Studio stores what was typed into Settings; OpenClaw sends this string to
-    # /v1/embeddings verbatim, so strip here rather than shipping the padding.
+    # OpenClaw sends this to /v1/embeddings verbatim; Settings stores what was typed.
     return name.strip()
 
 
@@ -4701,8 +4696,8 @@ def write_openclaw_config(
         "api": "openai-completions",
         "models": [provider_model],
     }
-    # Memory search is on by default in OpenClaw and its default provider is openai, so a
-    # session meant to stay local reaches OpenAI unless this block is written.
+    # Memory search is on by default and defaults to openai, so a local session reaches
+    # OpenAI unless this block is written.
     search = _subdict(_subdict(config, "memory"), "search")
     if embedding_model:
         search.update(
@@ -4714,11 +4709,8 @@ def write_openclaw_config(
             }
         )
     else:
-        # No model name to point at (an older server, or one that would not answer). Ask
-        # for keyword-only memory search rather than for embeddings this server cannot
-        # serve: "none" is OpenClaw's documented value for that, it makes no network call,
-        # and `openclaw memory search` still returns ranked hits. Clear the remote so a
-        # reused --persist config does not keep aiming at an endpoint we just gave up on.
+        # "none" is OpenClaw's keyword-only mode: no network call, and search still returns
+        # hits. Clearing the remote stops a reused --persist config aiming at a dead endpoint.
         search.update({"provider": "none", "fallback": "none"})
         search.pop("model", None)
         search.pop("remote", None)

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -4645,6 +4645,15 @@ def _session_config(
         yield path
 
 
+def _studio_embedding_model(base: str, key: str) -> str:
+    try:
+        info = _http_json("GET", f"{base}/api/settings/embedding-model", key, timeout = 10)
+    except Exception:  # noqa: BLE001 - an older or unreachable server still gets a working config
+        return "default"
+    name = info.get("embedding_model") if isinstance(info, dict) else None
+    return name if isinstance(name, str) and name.strip() else "default"
+
+
 def write_openclaw_config(
     base: str,
     key: str,
@@ -4652,6 +4661,7 @@ def write_openclaw_config(
     path: Path,
     yolo: bool = False,
     workspace_path: Optional[str] = None,
+    embedding_model: str = "default",
 ) -> None:
     config = _read_json_object(path)
     if config is None:
@@ -4678,7 +4688,7 @@ def write_openclaw_config(
     _subdict(_subdict(config, "memory"), "search").update(
         {
             "provider": "openai-compatible",
-            "model": "default",
+            "model": embedding_model,
             "remote": {"baseUrl": f"{base}/v1", "apiKey": key},
         }
     )
@@ -5371,6 +5381,7 @@ def openclaw(
             config_path,
             yolo = yolo,
             workspace_path = "${OPENCLAW_WORKSPACE_DIR}",
+            embedding_model = _studio_embedding_model(base, key),
         )
         # Scope both config and state so OpenClaw never touches the user's ~/.openclaw.
         env = {"OPENCLAW_CONFIG_PATH": str(config_path), "OPENCLAW_STATE_DIR": str(cfg)}

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -4675,6 +4675,13 @@ def write_openclaw_config(
         "api": "openai-completions",
         "models": [provider_model],
     }
+    _subdict(_subdict(config, "memory"), "search").update(
+        {
+            "provider": "openai-compatible",
+            "model": "default",
+            "remote": {"baseUrl": f"{base}/v1", "apiKey": key},
+        }
+    )
     # Pin a default model, else OpenClaw drops into its setup agent ("no models available").
     agents = _subdict(config, "agents")
     defaults = _subdict(agents, "defaults")

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4716,6 +4716,7 @@ def test_connect_openclaw_no_launch(fake_studio, tmp_path, monkeypatch):
     assert config["memory"]["search"] == {
         "provider": "openai-compatible",
         "model": "unsloth/bge-small-en-v1.5",
+        "fallback": "none",
         "remote": {"baseUrl": f"{BASE}/v1", "apiKey": "sk-unsloth-feedfacefeedface"},
     }
     _assert_env_cwd(result.output, "OPENCLAW_WORKSPACE_DIR")
@@ -8756,4 +8757,16 @@ def test_openclaw_memory_search_falls_back_to_default_without_the_settings_route
     assert result.exit_code == 0, result.output
     config = json.loads((tmp_path / "agents" / "openclaw" / "openclaw.json").read_text())
     assert config["memory"]["search"]["model"] == "default"
+    assert config["memory"]["search"]["provider"] == "openai-compatible"
+
+
+def test_openclaw_memory_search_clears_a_stale_external_fallback(fake_studio, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "agents" / "openclaw" / "openclaw.json"
+    config_path.parent.mkdir(parents = True)
+    config_path.write_text(json.dumps({"memory": {"search": {"fallback": "openai"}}}))
+    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
+    assert result.exit_code == 0, result.output
+    config = json.loads(config_path.read_text())
+    assert config["memory"]["search"]["fallback"] == "none"
     assert config["memory"]["search"]["provider"] == "openai-compatible"

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -8777,12 +8777,23 @@ def test_openclaw_memory_search_drops_a_stale_remote_when_the_route_is_gone(
     monkeypatch.chdir(tmp_path)
     config_path = tmp_path / "agents" / "openclaw" / "openclaw.json"
     config_path.parent.mkdir(parents = True)
-    config_path.write_text(json.dumps({"memory": {"search": {
-        "provider": "openai-compatible",
-        "model": "unsloth/bge-small-en-v1.5",
-        "fallback": "none",
-        "remote": {"baseUrl": "http://127.0.0.1:8888/v1", "apiKey": "sk-unsloth-old"},
-    }}}))
+    config_path.write_text(
+        json.dumps(
+            {
+                "memory": {
+                    "search": {
+                        "provider": "openai-compatible",
+                        "model": "unsloth/bge-small-en-v1.5",
+                        "fallback": "none",
+                        "remote": {
+                            "baseUrl": "http://127.0.0.1:8888/v1",
+                            "apiKey": "sk-unsloth-old",
+                        },
+                    }
+                }
+            }
+        )
+    )
     result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
     assert result.exit_code == 0, result.output
     search = json.loads(config_path.read_text())["memory"]["search"]
@@ -8807,9 +8818,7 @@ def test_openclaw_memory_search_model_is_stripped(fake_studio, tmp_path, monkeyp
     assert config["memory"]["search"]["model"] == "unsloth/bge-small-en-v1.5"
 
 
-def test_openclaw_memory_search_does_not_swallow_a_cli_abort(
-    fake_studio, tmp_path, monkeypatch
-):
+def test_openclaw_memory_search_does_not_swallow_a_cli_abort(fake_studio, tmp_path, monkeypatch):
     # typer.Exit is a RuntimeError subclass, so a bare `except Exception` around the
     # probe would turn a deliberate abort into a silently degraded config.
     _openclaw_without_the_settings_route(monkeypatch, exc = typer.Exit(2))

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -8741,23 +8741,81 @@ def test_a_status_body_without_is_gguf_still_launches(fake_studio, monkeypatch, 
     assert "needs a GGUF model" not in result.output
 
 
-def test_openclaw_memory_search_falls_back_to_default_without_the_settings_route(
-    fake_studio, tmp_path, monkeypatch
-):
+def _openclaw_without_the_settings_route(monkeypatch, exc = RuntimeError("404")):
     real = start._http_json
 
     def older_server(method, url, *args, **kwargs):
         if url.endswith("/api/settings/embedding-model"):
-            raise RuntimeError("404")
+            raise exc
         return real(method, url, *args, **kwargs)
 
     monkeypatch.setattr(start, "_http_json", older_server)
+
+
+def test_openclaw_memory_search_asks_for_keyword_only_without_the_settings_route(
+    fake_studio, tmp_path, monkeypatch
+):
+    # A server that cannot name its embedding model cannot serve embeddings for it
+    # either. Pointing memory search at it anyway, with fallback pinned to "none",
+    # is the one shape OpenClaw cannot degrade out of. Ask for its own keyword-only
+    # mode instead: no network call, no OpenAI, and searches still return hits.
+    _openclaw_without_the_settings_route(monkeypatch)
     monkeypatch.chdir(tmp_path)
     result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
     assert result.exit_code == 0, result.output
     config = json.loads((tmp_path / "agents" / "openclaw" / "openclaw.json").read_text())
-    assert config["memory"]["search"]["model"] == "default"
-    assert config["memory"]["search"]["provider"] == "openai-compatible"
+    search = config["memory"]["search"]
+    assert search == {"provider": "none", "fallback": "none"}
+
+
+def test_openclaw_memory_search_drops_a_stale_remote_when_the_route_is_gone(
+    fake_studio, tmp_path, monkeypatch
+):
+    # Downgrading Studio after a --persist run must not leave the previous run's
+    # endpoint and key behind for a provider that is no longer pointed at it.
+    _openclaw_without_the_settings_route(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "agents" / "openclaw" / "openclaw.json"
+    config_path.parent.mkdir(parents = True)
+    config_path.write_text(json.dumps({"memory": {"search": {
+        "provider": "openai-compatible",
+        "model": "unsloth/bge-small-en-v1.5",
+        "fallback": "none",
+        "remote": {"baseUrl": "http://127.0.0.1:8888/v1", "apiKey": "sk-unsloth-old"},
+    }}}))
+    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
+    assert result.exit_code == 0, result.output
+    search = json.loads(config_path.read_text())["memory"]["search"]
+    assert search == {"provider": "none", "fallback": "none"}
+
+
+def test_openclaw_memory_search_model_is_stripped(fake_studio, tmp_path, monkeypatch):
+    # OpenClaw sends memory.search.model to /v1/embeddings verbatim, so padding that
+    # Studio's Settings field happens to hold would travel all the way to the request.
+    real = start._http_json
+
+    def padded(method, url, *args, **kwargs):
+        if url.endswith("/api/settings/embedding-model"):
+            return {"embedding_model": "  unsloth/bge-small-en-v1.5\n"}
+        return real(method, url, *args, **kwargs)
+
+    monkeypatch.setattr(start, "_http_json", padded)
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
+    assert result.exit_code == 0, result.output
+    config = json.loads((tmp_path / "agents" / "openclaw" / "openclaw.json").read_text())
+    assert config["memory"]["search"]["model"] == "unsloth/bge-small-en-v1.5"
+
+
+def test_openclaw_memory_search_does_not_swallow_a_cli_abort(
+    fake_studio, tmp_path, monkeypatch
+):
+    # typer.Exit is a RuntimeError subclass, so a bare `except Exception` around the
+    # probe would turn a deliberate abort into a silently degraded config.
+    _openclaw_without_the_settings_route(monkeypatch, exc = typer.Exit(2))
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
+    assert result.exit_code == 2, result.output
 
 
 def test_openclaw_memory_search_clears_a_stale_external_fallback(

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -8755,10 +8755,8 @@ def _openclaw_without_the_settings_route(monkeypatch, exc = RuntimeError("404"))
 def test_openclaw_memory_search_asks_for_keyword_only_without_the_settings_route(
     fake_studio, tmp_path, monkeypatch
 ):
-    # A server that cannot name its embedding model cannot serve embeddings for it
-    # either. Pointing memory search at it anyway, with fallback pinned to "none",
-    # is the one shape OpenClaw cannot degrade out of. Ask for its own keyword-only
-    # mode instead: no network call, no OpenAI, and searches still return hits.
+    # A server that cannot name its embedder will not serve it either, and that name
+    # beside fallback "none" is the one shape OpenClaw cannot degrade out of.
     _openclaw_without_the_settings_route(monkeypatch)
     monkeypatch.chdir(tmp_path)
     result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
@@ -8771,8 +8769,7 @@ def test_openclaw_memory_search_asks_for_keyword_only_without_the_settings_route
 def test_openclaw_memory_search_drops_a_stale_remote_when_the_route_is_gone(
     fake_studio, tmp_path, monkeypatch
 ):
-    # Downgrading Studio after a --persist run must not leave the previous run's
-    # endpoint and key behind for a provider that is no longer pointed at it.
+    # A --persist config must not keep the old endpoint and key for a dropped provider.
     _openclaw_without_the_settings_route(monkeypatch)
     monkeypatch.chdir(tmp_path)
     config_path = tmp_path / "agents" / "openclaw" / "openclaw.json"
@@ -8801,8 +8798,7 @@ def test_openclaw_memory_search_drops_a_stale_remote_when_the_route_is_gone(
 
 
 def test_openclaw_memory_search_model_is_stripped(fake_studio, tmp_path, monkeypatch):
-    # OpenClaw sends memory.search.model to /v1/embeddings verbatim, so padding that
-    # Studio's Settings field happens to hold would travel all the way to the request.
+    # The model goes to /v1/embeddings verbatim, so padding would reach the request.
     real = start._http_json
 
     def padded(method, url, *args, **kwargs):
@@ -8819,8 +8815,7 @@ def test_openclaw_memory_search_model_is_stripped(fake_studio, tmp_path, monkeyp
 
 
 def test_openclaw_memory_search_does_not_swallow_a_cli_abort(fake_studio, tmp_path, monkeypatch):
-    # typer.Exit is a RuntimeError subclass, so a bare `except Exception` around the
-    # probe would turn a deliberate abort into a silently degraded config.
+    # typer.Exit is a RuntimeError subclass: a bare except would degrade the config silently.
     _openclaw_without_the_settings_route(monkeypatch, exc = typer.Exit(2))
     monkeypatch.chdir(tmp_path)
     result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -8760,7 +8760,9 @@ def test_openclaw_memory_search_falls_back_to_default_without_the_settings_route
     assert config["memory"]["search"]["provider"] == "openai-compatible"
 
 
-def test_openclaw_memory_search_clears_a_stale_external_fallback(fake_studio, tmp_path, monkeypatch):
+def test_openclaw_memory_search_clears_a_stale_external_fallback(
+    fake_studio, tmp_path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     config_path = tmp_path / "agents" / "openclaw" / "openclaw.json"
     config_path.parent.mkdir(parents = True)

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1510,6 +1510,8 @@ def fake_studio(tmp_path, monkeypatch):
             return {"is_gguf": True, "model_identifier": state["models"][0]["id"]}
         if url.endswith("/api/auth/api-keys"):
             return {"key": "sk-unsloth-feedfacefeedface"}
+        if url.endswith("/api/settings/embedding-model"):
+            return {"embedding_model": "unsloth/bge-small-en-v1.5"}
         if url.endswith("/api/inference/load"):
             already_loaded = state["models"][0]["id"] == payload["model_path"]
             state["models"] = [{"id": payload["model_path"], "context_length": 4096}]
@@ -4713,7 +4715,7 @@ def test_connect_openclaw_no_launch(fake_studio, tmp_path, monkeypatch):
     assert config["agents"]["defaults"]["workspace"] == "${OPENCLAW_WORKSPACE_DIR}"
     assert config["memory"]["search"] == {
         "provider": "openai-compatible",
-        "model": "default",
+        "model": "unsloth/bge-small-en-v1.5",
         "remote": {"baseUrl": f"{BASE}/v1", "apiKey": "sk-unsloth-feedfacefeedface"},
     }
     _assert_env_cwd(result.output, "OPENCLAW_WORKSPACE_DIR")
@@ -8736,3 +8738,22 @@ def test_a_status_body_without_is_gguf_still_launches(fake_studio, monkeypatch, 
     result = CliRunner().invoke(start.start_app, [agent, "--no-launch"])
     assert result.exit_code == 0, result.output
     assert "needs a GGUF model" not in result.output
+
+
+def test_openclaw_memory_search_falls_back_to_default_without_the_settings_route(
+    fake_studio, tmp_path, monkeypatch
+):
+    real = start._http_json
+
+    def older_server(method, url, *args, **kwargs):
+        if url.endswith("/api/settings/embedding-model"):
+            raise RuntimeError("404")
+        return real(method, url, *args, **kwargs)
+
+    monkeypatch.setattr(start, "_http_json", older_server)
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
+    assert result.exit_code == 0, result.output
+    config = json.loads((tmp_path / "agents" / "openclaw" / "openclaw.json").read_text())
+    assert config["memory"]["search"]["model"] == "default"
+    assert config["memory"]["search"]["provider"] == "openai-compatible"

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4711,6 +4711,11 @@ def test_connect_openclaw_no_launch(fake_studio, tmp_path, monkeypatch):
     assert config["agents"]["defaults"]["model"]["primary"] == f"unsloth/{MODEL['id']}"
     assert config["agents"]["defaults"]["skipBootstrap"] is True
     assert config["agents"]["defaults"]["workspace"] == "${OPENCLAW_WORKSPACE_DIR}"
+    assert config["memory"]["search"] == {
+        "provider": "openai-compatible",
+        "model": "default",
+        "remote": {"baseUrl": f"{BASE}/v1", "apiKey": "sk-unsloth-feedfacefeedface"},
+    }
     _assert_env_cwd(result.output, "OPENCLAW_WORKSPACE_DIR")
     assert _launch_command(result.output) == ["openclaw", "tui", "--local"]
     # OpenAI /v1/chat/completions works on either backend — no GGUF gate.


### PR DESCRIPTION
The config that `unsloth start openclaw` generates never set `memory.search`, so OpenClaw fell back to its own default embedding provider, `openai`. Memory search is on by default, so a session that is meant to run entirely on a local model was reaching for OpenAI embeddings.

This points memory search at Studio instead: provider `openai-compatible`, the same base URL and session key already written for the chat provider, and Studio's own embedding model name as the model, read from Studio at connect time so the string changes when the Settings model changes. It falls back to `default` on a server without that route.

Memory embeddings then run on the local embedding model through Studio's `/v1/embeddings`.

**Depends on #10315 and must merge after it.** That PR makes `/v1/embeddings` serve from the configured embedding model when the loaded GGUF cannot, and accepts that model's own name in the request. Against `main` today the route still answers 501, so this stays a draft until #10315 lands.

Related: #10316 stops the openclaw session from inheriting `OPENAI_API_KEY`.
