### PR TITLE
fix(studio): align desktop titlebar buttons

### DIFF
--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -7,10 +7,10 @@ import { useSidebarWidth } from "@/hooks/use-sidebar-width";
 import { isTauri } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
 import { Z_LAYER } from "@/lib/z-layers";
-import { LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
+import { CopyIcon, LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Window as TauriWindow } from "@tauri-apps/api/window";
-import { ArrowLeft, ArrowRight, Copy, Minus, Square, X } from "lucide-react";
+import { ArrowLeft, ArrowRight, Minus, Square, X } from "lucide-react";
 import {
   type MouseEvent,
   type PointerEvent,
@@ -435,20 +435,15 @@ export function WindowTitlebar({
             }
           >
             {maximized ? (
-              <Copy
+              <HugeiconsIcon
+                icon={CopyIcon}
                 aria-hidden="true"
-                absoluteStrokeWidth
-                strokeWidth={1.5}
+                strokeWidth={1.75}
                 size={14}
                 className="rotate-180"
               />
             ) : (
-              <Square
-                aria-hidden="true"
-                absoluteStrokeWidth
-                strokeWidth={1.5}
-                size={14}
-              />
+              <Square aria-hidden="true" strokeWidth={1.75} size={14} />
             )}
           </WindowControlButton>
           <WindowControlButton

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -7,10 +7,10 @@ import { useSidebarWidth } from "@/hooks/use-sidebar-width";
 import { isTauri } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
 import { Z_LAYER } from "@/lib/z-layers";
-import { CopyIcon, LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
+import { LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Window as TauriWindow } from "@tauri-apps/api/window";
-import { ArrowLeft, ArrowRight, Minus, Square, X } from "lucide-react";
+import { ArrowLeft, ArrowRight, Copy, Minus, Square, X } from "lucide-react";
 import {
   type MouseEvent,
   type PointerEvent,
@@ -93,7 +93,7 @@ function WindowControlButton({
       title={label}
       onClick={onClick}
       className={cn(
-        "relative z-[80] inline-flex h-[26px] w-[30px] shrink-0 items-center justify-center rounded-md text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+        "relative z-[80] inline-flex h-[26px] w-[30px] shrink-0 items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-foreground dark:hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
         className,
       )}
     >
@@ -435,15 +435,20 @@ export function WindowTitlebar({
             }
           >
             {maximized ? (
-              <HugeiconsIcon
-                icon={CopyIcon}
+              <Copy
                 aria-hidden="true"
-                strokeWidth={1.75}
+                absoluteStrokeWidth
+                strokeWidth={1.5}
                 size={14}
                 className="rotate-180"
               />
             ) : (
-              <Square aria-hidden="true" strokeWidth={1.75} size={14} />
+              <Square
+                aria-hidden="true"
+                absoluteStrokeWidth
+                strokeWidth={1.5}
+                size={14}
+              />
             )}
           </WindowControlButton>
           <WindowControlButton
@@ -454,7 +459,7 @@ export function WindowTitlebar({
             // answer it before the user does. The wait this covers is the reap, and Rust's
             // app-closing arrives well ahead of that.
             onClick={() => runWindowAction((appWindow) => appWindow.close())}
-            className="hover:bg-destructive hover:text-white focus-visible:ring-destructive/70"
+            className="hover:bg-destructive/10 hover:text-destructive focus-visible:ring-destructive/70 dark:hover:bg-destructive/20 dark:hover:text-destructive"
           >
             <X
               aria-hidden="true"

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -93,7 +93,7 @@ function WindowControlButton({
       title={label}
       onClick={onClick}
       className={cn(
-        "relative z-[80] inline-flex h-[26px] w-[30px] shrink-0 items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-foreground dark:hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+        "relative z-[80] inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-foreground dark:hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
         className,
       )}
     >

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -7,10 +7,10 @@ import { useSidebarWidth } from "@/hooks/use-sidebar-width";
 import { isTauri } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
 import { Z_LAYER } from "@/lib/z-layers";
-import { CopyIcon, LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
+import { LayoutAlignLeftIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Window as TauriWindow } from "@tauri-apps/api/window";
-import { ArrowLeft, ArrowRight, Minus, Square, X } from "lucide-react";
+import { ArrowLeft, ArrowRight, Copy, Minus, Square, X } from "lucide-react";
 import {
   type MouseEvent,
   type PointerEvent,
@@ -93,7 +93,7 @@ function WindowControlButton({
       title={label}
       onClick={onClick}
       className={cn(
-        "relative z-[80] inline-flex size-[30px] items-center justify-center rounded-[10px] text-muted-foreground/90 transition-colors hover:bg-nav-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "relative z-[80] inline-flex h-[26px] w-[30px] shrink-0 items-center justify-center rounded-md text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
         className,
       )}
     >
@@ -389,7 +389,7 @@ export function WindowTitlebar({
           <div
             className={cn(
               "pointer-events-auto absolute left-0 top-0 flex h-full min-w-0 items-center",
-              "pl-3",
+              "pl-4",
             )}
             style={{ width: titlebarNavigationWidth }}
             onMouseDown={handleDragMouseDown}
@@ -406,18 +406,14 @@ export function WindowTitlebar({
           className="pointer-events-auto absolute top-0 h-full"
           style={{
             left: titlebarNavigationWidth,
-            right: "calc(var(--studio-window-control-inset,112px) + 0.5rem)",
+            right: "var(--studio-window-control-inset,112px)",
           }}
           onMouseDown={handleDragMouseDown}
           onDoubleClick={handleDragDoubleClick}
           aria-hidden="true"
         />
         <div
-          className="pointer-events-auto absolute right-1 top-0 flex h-full items-center gap-0.5 px-1"
-          // No z-index here: the header above is positioned and numbered, so it is a
-          // stacking context and anything written here is compared inside it, never against
-          // the grips. The overlap that invites one costs Close 92px and the other two 60px
-          // each, and is unchanged by the grips taking the named layer.
+          className="pointer-events-auto absolute right-1 top-0 flex h-full items-center gap-0.5"
           role="toolbar"
           aria-label="Window controls"
         >
@@ -425,7 +421,12 @@ export function WindowTitlebar({
             label="Minimize window"
             onClick={() => runWindowAction((appWindow) => appWindow.minimize())}
           >
-            <Minus aria-hidden="true" strokeWidth={1.75} className="w-[18px]" />
+            <Minus
+              aria-hidden="true"
+              absoluteStrokeWidth
+              strokeWidth={1.5}
+              size={16}
+            />
           </WindowControlButton>
           <WindowControlButton
             label={maximized ? "Restore window" : "Maximize window"}
@@ -434,16 +435,19 @@ export function WindowTitlebar({
             }
           >
             {maximized ? (
-              <HugeiconsIcon
-                icon={CopyIcon}
-                strokeWidth={1.75}
-                className="size-[17px] rotate-180"
+              <Copy
+                aria-hidden="true"
+                absoluteStrokeWidth
+                strokeWidth={1.5}
+                size={14}
+                className="rotate-180"
               />
             ) : (
               <Square
                 aria-hidden="true"
-                strokeWidth={1.75}
-                className="size-[16px]"
+                absoluteStrokeWidth
+                strokeWidth={1.5}
+                size={14}
               />
             )}
           </WindowControlButton>
@@ -455,9 +459,14 @@ export function WindowTitlebar({
             // answer it before the user does. The wait this covers is the reap, and Rust's
             // app-closing arrives well ahead of that.
             onClick={() => runWindowAction((appWindow) => appWindow.close())}
-            className="hover:bg-destructive/10 hover:text-destructive focus-visible:ring-destructive/70 dark:hover:bg-destructive/20"
+            className="hover:bg-destructive hover:text-white focus-visible:ring-destructive/70"
           >
-            <X aria-hidden="true" strokeWidth={1.75} className="size-[18px]" />
+            <X
+              aria-hidden="true"
+              absoluteStrokeWidth
+              strokeWidth={1.5}
+              size={20}
+            />
           </WindowControlButton>
         </div>
       </header>
@@ -467,15 +476,7 @@ export function WindowTitlebar({
         style={{ zIndex: Z_LAYER.WINDOW_RESIZE_EDGE }}
         onPointerDown={handleResizePointerDown("North")}
       />
-      {/* All eight carry a named layer rather than z-[70], because the overlay stack out-
-          ranks that band and hit-tests its whole box while it scrolls. Anchored to the
-          bottom-right it still reaches five of them: `-mx-3` puts its border box 4px from
-          the right edge, the bottom gutter drops it to the floor, the top gutter lifts it
-          to 8px from the ceiling, and a card is `w-[calc(100vw-2rem)]`, so on a narrow
-          window it spans nearly the full width and the left-hand corners come into range
-          too. Measured, not reasoned: south-west 80 of 144px, north-east and north-west 32
-          of 144px each. The controls move up with them so the north-east corner does not
-          cost Close any of its own hit area. */}
+      {/* resize grips stay above dialogs and notifications. */}
       <div
         aria-hidden="true"
         className="pointer-events-auto fixed inset-x-2 bottom-0 h-1 cursor-s-resize"
@@ -503,7 +504,12 @@ export function WindowTitlebar({
       <div
         aria-hidden="true"
         className="pointer-events-auto fixed right-0 top-0 size-3 cursor-ne-resize"
-        style={{ zIndex: Z_LAYER.WINDOW_RESIZE_EDGE }}
+        style={{
+          zIndex: Z_LAYER.WINDOW_RESIZE_EDGE,
+          // keep the resize corner outside the close button.
+          clipPath:
+            "polygon(0 0, 100% 0, 100% 100%, calc(100% - 0.25rem) 100%, calc(100% - 0.25rem) 0.25rem, 0 0.25rem)",
+        }}
         onPointerDown={handleResizePointerDown("NorthEast")}
       />
       <div


### PR DESCRIPTION
The custom desktop titlebar controls had uneven icon proportions and spacing. Move the navigation buttons 4px right and group the window controls 4px from the right edge. Use 26px square buttons with balanced 1.5px icon strokes and preserve the 34px toolbar height.

Keep the existing rounded-square hover backgrounds with 10px corners and the muted red close hover. Use compact Lucide icons, including a matching restore symbol. Clip the top-right resize grip around the close button so the new placement keeps its full click area available. Changes are confined to `window-titlebar.tsx`.

Validation:

- `npm run typecheck` passed.
- 21 focused tests passed in `titlebar-modal-layering.test.ts`, `mac-titlebar-optical-alignment.test.ts`, and `window-layout.test.ts`.
- Biome formatting and `git diff --check` passed.
- Built and opened the Linux Tauri app; visually checked the layout and hover states at 1440 × 890.
- Clicked maximize and restore in the native app and verified both window state transitions.

Before: installed Linux desktop app, 1440 × 890.

![Before: original desktop titlebar buttons](https://raw.githubusercontent.com/mahiatlinux/pr-screenshots/a5f63fb450cee45721f0d9e6286a68131a264534/studio-titlebar-buttons-2026-09-05/before.png)

After: local Tauri build with this change, 1440 × 890.

![After: aligned desktop titlebar buttons](https://raw.githubusercontent.com/mahiatlinux/pr-screenshots/6020048252bef0a32e0e0cc5018248604fa328d2/pr10321-narrow-buttons/after.png)

Hover states, captured in the same Linux Tauri window with the base and PR versions of `window-titlebar.tsx`:

| Control | Before | After |
| --- | --- | --- |
| Minimize | ![Before minimize hover](https://raw.githubusercontent.com/mahiatlinux/pr-screenshots/8fd14f3cbabbd1b6c43375b7bf84550e973f0b9f/studio-titlebar-buttons-2026-09-05/before-minimize-hover.png) | ![After minimize hover](https://raw.githubusercontent.com/mahiatlinux/pr-screenshots/cd267c293e77558115c12f55f2f471c6b834d67e/pr10321-narrow-buttons/after-minimize-hover.png) |
| Maximize | ![Before maximize hover](https://raw.githubusercontent.com/mahiatlinux/pr-screenshots/6c487d25825a7c01a14d00c6f4f1826235b77dbf/studio-titlebar-buttons-2026-09-05/before-maximize-hover.png) | ![After maximize hover](https://raw.githubusercontent.com/mahiatlinux/pr-screenshots/1b61eed746ddb41ec8747a9593a6793a4cc43561/pr10321-narrow-buttons/after-maximize-hover.png) |
| Close | ![Before close hover](https://raw.githubusercontent.com/mahiatlinux/pr-screenshots/aa0f51903cce135fb8eb458a1d3e405e63ffd670/studio-titlebar-buttons-2026-09-05/before-close-hover.png) | ![After close hover](https://raw.githubusercontent.com/mahiatlinux/pr-screenshots/26be55f37fb662f1b245fe7fd6e50032f506cfd8/pr10321-narrow-buttons/after-close-hover.png) |

Restore hover:

![After: restore icon with the preserved hover style](https://raw.githubusercontent.com/mahiatlinux/pr-screenshots/3a2a753fd27aa0015607bbbaaec34925394b5df2/pr10321-narrow-buttons/after-restore-hover.png)
