### PR TITLE
Install the cublas wheel NVIDIA actually publishes for the bundle's CUDA major

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -525,13 +525,13 @@ RUN /opt/unsloth-venv/bin/python /tmp/fetch_llama_prebuilt.py \
 # by nvidia-container-toolkit at `docker run --gpus`, never present in the image.
 # ldd needs no GPU, so this keeps the build host-independent.
 #
-# The wheel name is not `nvidia-cublas-cu${major}` at every major. NVIDIA dropped
-# the suffix at CUDA 13: `nvidia-cublas-cu13` exists only as a 0.0.1 sdist whose
-# build backend exits 1 with "use nvidia-cublas instead", so the old spelling
-# fails the BUILD rather than the install. cu12 and earlier keep the suffix and
-# have no unsuffixed release, and the unsuffixed project publishes 13.x only, so
-# neither name covers both. Pin the major either way; the unresolved-library
-# check below is what proves the right wheel actually landed.
+# The name is not `nvidia-cublas-cu${major}` at every major: NVIDIA dropped the
+# suffix at CUDA 13, where `nvidia-cublas-cu13` is only a 0.0.1 sdist whose build
+# backend exits 1 with "use nvidia-cublas instead", failing the BUILD, not the
+# install. Neither project spans both majors: the unsuffixed one publishes 13.x
+# only, and nvidia-cublas-cu12 has no unsuffixed twin. Pin the major so a future
+# CUDA 14 cannot install over a 13 bundle; the unresolved-library check below is
+# what proves the right wheel landed.
 RUN set -eux \
  && CUDA_SO=/opt/unsloth/llama.cpp/libggml-cuda.so \
  && if [ -f "$CUDA_SO" ]; then \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -524,15 +524,28 @@ RUN /opt/unsloth-venv/bin/python /tmp/fetch_llama_prebuilt.py \
 # can never ship again. libcuda.so.1 is exempt: that is the driver stub, injected
 # by nvidia-container-toolkit at `docker run --gpus`, never present in the image.
 # ldd needs no GPU, so this keeps the build host-independent.
+#
+# The wheel name is not `nvidia-cublas-cu${major}` at every major. NVIDIA dropped
+# the suffix at CUDA 13: `nvidia-cublas-cu13` exists only as a 0.0.1 sdist whose
+# build backend exits 1 with "use nvidia-cublas instead", so the old spelling
+# fails the BUILD rather than the install. cu12 and earlier keep the suffix and
+# have no unsuffixed release, and the unsuffixed project publishes 13.x only, so
+# neither name covers both. Pin the major either way; the unresolved-library
+# check below is what proves the right wheel actually landed.
 RUN set -eux \
  && CUDA_SO=/opt/unsloth/llama.cpp/libggml-cuda.so \
  && if [ -f "$CUDA_SO" ]; then \
         want="$(ldd "$CUDA_SO" | sed -n 's/^[[:space:]]*\(libcublas\.so\.[0-9]*\)[[:space:]]*=> not found$/\1/p' | head -n1)"; \
         if [ -n "$want" ]; then \
             major="${want##*.}"; \
-            echo ">> $want missing, installing nvidia-cublas-cu${major}"; \
+            if [ "$major" -ge 13 ]; then \
+                pkg="nvidia-cublas==${major}.*"; \
+            else \
+                pkg="nvidia-cublas-cu${major}"; \
+            fi; \
+            echo ">> $want missing, installing ${pkg}"; \
             /opt/unsloth-venv/bin/uv pip install --python /opt/unsloth-venv/bin/python \
-                "nvidia-cublas-cu${major}"; \
+                "${pkg}"; \
             ldconfig; \
         fi; \
         missing="$(ldd "$CUDA_SO" | grep 'not found' | grep -v 'libcuda\.so\.1 ' || true)"; \

--- a/tests/python/test_docker_llama_cuda_backend.py
+++ b/tests/python/test_docker_llama_cuda_backend.py
@@ -40,9 +40,8 @@ def test_cublas_dir_is_registered_with_the_loader(dockerfile: str):
         "wheel copy; without this entry the CUDA backend fails to dlopen and GGUF "
         "silently runs on the CPU"
     )
-    # Both layouts, because the wheel moved as well as the name: nvidia-cublas-cu12
-    # unpacks to nvidia/cublas/lib, nvidia-cublas (13+) to nvidia/cu13/lib. Guarding
-    # only the first would leave a 13 bundle installed but still unresolvable.
+    # Both layouts, because the wheel moved with the name: nvidia-cublas-cu12
+    # unpacks to nvidia/cublas/lib, nvidia-cublas (13+) to nvidia/cu13/lib
     assert "$SP/nvidia/cu13/lib" in block, (
         "the CUDA 13 cublas wheel unpacks to nvidia/cu13/lib, so dropping this entry "
         "puts libcublas.so.13 off the loader path even after the guard installs it"
@@ -96,24 +95,24 @@ def _cublas_pkg_for(dockerfile: str, soname: str) -> str:
     ],
 )
 def test_guard_installs_the_matching_cublas_major(dockerfile: str, soname: str, expected: str):
-    # NVIDIA dropped the -cuXX suffix at CUDA 13, and neither project spans both:
-    # nvidia-cublas publishes 13.x only, nvidia-cublas-cu12 has no unsuffixed twin.
+    # NVIDIA dropped the -cuXX suffix at CUDA 13; neither project spans both majors:
+    # nvidia-cublas publishes 13.x only, nvidia-cublas-cu12 has no unsuffixed twin
     assert _cublas_pkg_for(dockerfile, soname) == expected
 
 
 def test_the_cublas_major_comes_from_the_bundle(dockerfile: str):
-    # The two arch bundles differ in CUDA major, so the name has to follow ldd.
-    # A hardcoded major satisfies any single expectation above on its own.
+    # The two arch bundles differ in CUDA major, so the name must follow ldd; a
+    # hardcoded major would satisfy any single case above on its own
     assert _cublas_pkg_for(dockerfile, "libcublas.so.12") != _cublas_pkg_for(
         dockerfile, "libcublas.so.13"
     )
 
 
 def test_the_guard_never_asks_for_a_retired_suffixed_wheel(dockerfile: str):
-    # This is the regression: the arm64 bundle links libcublas.so.13, the guard
-    # derived nvidia-cublas-cu13, and that project is a 0.0.1 sdist whose build
-    # backend exits 1 saying to use nvidia-cublas. It failed the build, not the
-    # install, so the fail-soft paths elsewhere in this file could not catch it.
+    # The regression: the arm64 bundle links libcublas.so.13, the guard derived
+    # nvidia-cublas-cu13, a 0.0.1 sdist whose build backend exits 1 saying to use
+    # nvidia-cublas. That fails the build, not the install, so the fail-soft paths
+    # elsewhere in this file could not catch it.
     for major in range(13, 20):
         assert f"-cu{major}" not in _cublas_pkg_for(dockerfile, f"libcublas.so.{major}")
 

--- a/tests/python/test_docker_llama_cuda_backend.py
+++ b/tests/python/test_docker_llama_cuda_backend.py
@@ -12,6 +12,8 @@ on the CPU. These pin the two Dockerfile halves that prevent it.
 from __future__ import annotations
 
 import re
+import shlex
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -38,6 +40,13 @@ def test_cublas_dir_is_registered_with_the_loader(dockerfile: str):
         "wheel copy; without this entry the CUDA backend fails to dlopen and GGUF "
         "silently runs on the CPU"
     )
+    # Both layouts, because the wheel moved as well as the name: nvidia-cublas-cu12
+    # unpacks to nvidia/cublas/lib, nvidia-cublas (13+) to nvidia/cu13/lib. Guarding
+    # only the first would leave a 13 bundle installed but still unresolvable.
+    assert "$SP/nvidia/cu13/lib" in block, (
+        "the CUDA 13 cublas wheel unpacks to nvidia/cu13/lib, so dropping this entry "
+        "puts libcublas.so.13 off the loader path even after the guard installs it"
+    )
 
 
 def test_loader_config_is_not_ld_library_path(dockerfile: str):
@@ -61,13 +70,52 @@ def test_build_fails_on_an_unresolved_cuda_backend(dockerfile: str):
     ), "libcuda.so.1 must be exempt from the guard or every build fails"
 
 
-def test_guard_installs_the_matching_cublas_major(dockerfile: str):
-    # the two arch bundles differ in CUDA major, so it must come from ldd
+def _cublas_pkg_for(dockerfile: str, soname: str) -> str:
+    """The wheel the guard installs for a bundle asking for ``soname``.
+
+    Runs the Dockerfile's own selection lines instead of matching them. A name
+    is only correct if it resolves on PyPI, which no string comparison can tell
+    you, so pinning one spelling is how this went wrong the first time.
+    """
     guard = dockerfile[dockerfile.index("CUDA_SO=") :]
-    assert (
-        "nvidia-cublas-cu${major}" in guard
-    ), "the guard must install the cublas major the bundle actually asks for"
-    assert "libcublas" in guard
+    start = guard.index('major="${want##*.}"')
+    snippet = guard[start : guard.index('echo ">> $want missing', start)]
+    lines = snippet.replace("\\\n", "\n")
+    script = "\n".join([f"want={shlex.quote(soname)}", lines, 'printf %s "$pkg"'])
+    return subprocess.run(
+        ["sh", "-eu", "-c", script], capture_output = True, text = True, check = True
+    ).stdout
+
+
+@pytest.mark.parametrize(
+    "soname, expected",
+    [
+        ("libcublas.so.12", "nvidia-cublas-cu12"),
+        ("libcublas.so.13", "nvidia-cublas==13.*"),
+        ("libcublas.so.14", "nvidia-cublas==14.*"),
+    ],
+)
+def test_guard_installs_the_matching_cublas_major(dockerfile: str, soname: str, expected: str):
+    # NVIDIA dropped the -cuXX suffix at CUDA 13, and neither project spans both:
+    # nvidia-cublas publishes 13.x only, nvidia-cublas-cu12 has no unsuffixed twin.
+    assert _cublas_pkg_for(dockerfile, soname) == expected
+
+
+def test_the_cublas_major_comes_from_the_bundle(dockerfile: str):
+    # The two arch bundles differ in CUDA major, so the name has to follow ldd.
+    # A hardcoded major satisfies any single expectation above on its own.
+    assert _cublas_pkg_for(dockerfile, "libcublas.so.12") != _cublas_pkg_for(
+        dockerfile, "libcublas.so.13"
+    )
+
+
+def test_the_guard_never_asks_for_a_retired_suffixed_wheel(dockerfile: str):
+    # This is the regression: the arm64 bundle links libcublas.so.13, the guard
+    # derived nvidia-cublas-cu13, and that project is a 0.0.1 sdist whose build
+    # backend exits 1 saying to use nvidia-cublas. It failed the build, not the
+    # install, so the fail-soft paths elsewhere in this file could not catch it.
+    for major in range(13, 20):
+        assert f"-cu{major}" not in _cublas_pkg_for(dockerfile, f"libcublas.so.{major}")
 
 
 def test_guard_runs_after_the_prebuilt_is_fetched(dockerfile: str):


### PR DESCRIPTION
`build (linux/arm64, ubuntu-24.04-arm)` fails on `main` at `58255747f`, in the `Publish Blackwell Docker image` workflow:

```
#30 0.046 + want=libcublas.so.13
#30 0.046 + echo >> libcublas.so.13 missing, installing nvidia-cublas-cu13
#30 0.249    Building nvidia-cublas-cu13==0.0.1
#30 0.918   Failed to build `nvidia-cublas-cu13==0.0.1`
#30 0.918   The build backend returned an error
#30 0.918   Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
#30 0.918       [stderr]
#30 0.918       THIS PROJECT 'nvidia-cublas-cu13' IS DEPRECATED.
#30 0.918       Please use 'nvidia-cublas' instead.
```

(uv's box drawing and warning glyph stripped; the wording is verbatim.)

## NVIDIA dropped the `-cuXX` suffix at CUDA 13

The guard reads the soname llama.cpp actually asks for and installs the matching wheel, which is the right shape. It just assumes the project is always named `nvidia-cublas-cu${major}`. On PyPI today:

| project | latest | wheels | unpacks to |
| --- | --- | --- | --- |
| `nvidia-cublas-cu12` | 12.9.2.10 | aarch64, x86_64, win_amd64 | `nvidia/cublas/lib/libcublas.so.12` |
| `nvidia-cublas-cu13` | 0.0.1 | sdist only, "DEPRECATED: Use nvidia-cublas instead" | nothing, the build exits 1 |
| `nvidia-cublas` | 13.6.1.10 | aarch64, x86_64 | `nvidia/cu13/lib/libcublas.so.13` |

So the amd64 bundle keeps working and the arm64 one cannot: it links `libcublas.so.13`, and there is no `-cu13` wheel to install. Note this fails the **build**, not the install, so it is not something the fail-soft paths elsewhere in the file could absorb.

Neither name spans both majors. `nvidia-cublas` publishes 13.x only (its sole other releases are `0.0.0a0` and two `0.0.1.dev` stubs), and `nvidia-cublas-cu12` has no unsuffixed twin. So this selects on the major:

```sh
if [ "$major" -ge 13 ]; then
    pkg="nvidia-cublas==${major}.*";
else
    pkg="nvidia-cublas-cu${major}";
fi;
```

The major is pinned in both branches, so a future CUDA 14 release under the unsuffixed name cannot install itself over a 13 bundle. And the unresolved-library check immediately below is unchanged, so it still has the last word: if the wrong wheel lands, the build fails there with the library named rather than shipping a silent CPU fallback.

## The loader already knew, the installer did not

`ld.so.conf.d/zz-unsloth-venv.conf` already lists both `$SP/nvidia/cublas/lib` and `$SP/nvidia/cu13/lib`, so the new layout was anticipated when that layer was written. Only the install name was left on the old convention. The test covering that layer asserted the `cublas/lib` entry and not the `cu13/lib` one, which this change makes load-bearing, so it now asserts both.

## The test pinned the spelling, so it accepted the bug

```python
assert (
    "nvidia-cublas-cu${major}" in guard
), "the guard must install the cublas major the bundle actually asks for"
```

The message states the property; the assertion states one spelling of it. A wheel name is only correct if it resolves on PyPI, which no string comparison can determine, so this passed happily on a name that cannot install.

It now runs the Dockerfile's own selection lines for a given soname and checks what comes out, rather than reading them:

```python
def _cublas_pkg_for(dockerfile: str, soname: str) -> str:
    guard = dockerfile[dockerfile.index("CUDA_SO=") :]
    start = guard.index('major="${want##*.}"')
    snippet = guard[start : guard.index('echo ">> $want missing', start)]
    ...
```

This is the same shape as #10267, #10231, #10289, #10297 and #10307.

## Verified by breaking it

`nvidia-cublas-cu13` was installed locally first to confirm the failure is the one in the log, and it reproduces byte for byte. `nvidia-cublas==13.*` resolves to 13.6.1.10, and its aarch64 wheel index lists `nvidia/cu13/lib/libcublas.so.13`.

Eight edits to the selection block, each run against the test module, next to what a re-sync of the literal to the new name would give:

| edit | re-synced literal | this change |
| --- | --- | --- |
| baseline | passed | passed |
| the pre-fix guard, always suffixed | **passed** | **failed** |
| hardcoded to 13, ignores the bundle | **passed** | **failed** |
| hardcoded to cu12, ignores the bundle | **passed** | **failed** |
| threshold off by one, so 13 stays suffixed | **passed** | **failed** |
| unsuffixed but unpinned, so CUDA 14 installs over 13 | **passed** | **failed** |
| comparison inverted | **passed** | **failed** |
| reformatted onto one line, same behaviour | passed | passed |

The re-synced literal passes every row including the unfixed guard, which is what it did here. Removing the `cu13/lib` loader entry fails the loader test.

`tests/python/test_docker_llama_cuda_backend.py` plus the other three modules that read this Dockerfile: 304 passed, 2 skipped.

One thing this cannot settle from here: CUDA 14's project name, since it does not exist yet. The change assumes NVIDIA keeps the unsuffixed name they moved to at 13. If they do not, the guard fails the build with the unresolved soname named, which is the same way it caught this one.
