### PR TITLE
Docker: install nvidia-cublas==13.* for the arm64 llama.cpp bundle

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -530,9 +530,18 @@ RUN set -eux \
         want="$(ldd "$CUDA_SO" | sed -n 's/^[[:space:]]*\(libcublas\.so\.[0-9]*\)[[:space:]]*=> not found$/\1/p' | head -n1)"; \
         if [ -n "$want" ]; then \
             major="${want##*.}"; \
-            echo ">> $want missing, installing nvidia-cublas-cu${major}"; \
+            # CUDA 13 dropped the -cuNN suffix: nvidia-cublas-cu13 on PyPI is a stub
+            # whose sdist fails on purpose, and the real wheels (nvidia/cu13/lib, the
+            # path registered with the loader above) are nvidia-cublas==13.*. This is
+            # the arm64 bundle's case; the amd64 one wants cu12 and keeps the old name.
+            if [ "$major" -ge 13 ]; then \
+                pkg="nvidia-cublas==${major}.*"; \
+            else \
+                pkg="nvidia-cublas-cu${major}"; \
+            fi; \
+            echo ">> $want missing, installing $pkg"; \
             /opt/unsloth-venv/bin/uv pip install --python /opt/unsloth-venv/bin/python \
-                "nvidia-cublas-cu${major}"; \
+                "$pkg"; \
             ldconfig; \
         fi; \
         missing="$(ldd "$CUDA_SO" | grep 'not found' | grep -v 'libcuda\.so\.1 ' || true)"; \

--- a/tests/python/test_docker_llama_cuda_backend.py
+++ b/tests/python/test_docker_llama_cuda_backend.py
@@ -70,6 +70,84 @@ def test_guard_installs_the_matching_cublas_major(dockerfile: str):
     assert "libcublas" in guard
 
 
+def _guard_shell(dockerfile: str) -> str:
+    """The guard's RUN body as one shell script: strip the Dockerfile's `RUN set -eux`
+    prefix, drop comment lines, and join the backslash continuations."""
+    start = dockerfile.index("CUDA_SO=")
+    body = dockerfile[dockerfile.rindex("RUN set -eux", 0, start) + len("RUN set -eux") :]
+    # the Dockerfile parser drops comment lines and joins backslash continuations into
+    # one logical line; the instruction ends at the first line without a backslash
+    out = []
+    for line in body.splitlines():
+        if line.strip().startswith("#"):
+            continue
+        if line.endswith("\\"):
+            out.append(line[:-1])
+            continue
+        out.append(line)
+        break
+    return " ".join(out)
+
+
+@pytest.mark.parametrize(
+    "soname, expected",
+    [
+        # arm64: upstream ships a CUDA 13 arm64 llama.cpp; the -cu13 name on PyPI is a
+        # deprecated stub whose sdist fails on purpose (the first publish died there)
+        ("libcublas.so.13", "nvidia-cublas==13.*"),
+        # amd64: cu12, where the suffixed name is still the real package
+        ("libcublas.so.12", "nvidia-cublas-cu12"),
+    ],
+)
+def test_guard_uses_the_package_name_pypi_actually_serves(
+    dockerfile: str, soname: str, expected: str, tmp_path: Path
+):
+    """Drive the guard's own shell with ldd and uv stubbed, and check the spec it hands
+    to uv. Only the resolution is faked: the branch logic is the Dockerfile's."""
+    import os
+    import subprocess
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "ldd").write_text(
+        "#!/bin/sh\n"
+        f"printf '\\t%s => not found\\n' {soname}\n"
+        "printf '\\tlibcuda.so.1 => not found\\n'\n",
+        encoding = "utf-8",
+    )
+    (bin_dir / "ldconfig").write_text("#!/bin/sh\nexit 0\n", encoding = "utf-8")
+    venv_bin = tmp_path / "opt" / "unsloth-venv" / "bin"
+    venv_bin.mkdir(parents = True)
+    (venv_bin / "uv").write_text(
+        "#!/bin/sh\n"
+        f"printf '%s\\n' \"$@\" >> {tmp_path / 'uv_args'}\n"
+        # pretend the install resolved the library: rewrite what ldd reports
+        f"printf '#!/bin/sh\\nprintf \"\\\\tlibcuda.so.1 => not found\\\\n\"\\n' > {bin_dir / 'ldd'}\n",
+        encoding = "utf-8",
+    )
+    (venv_bin / "python").write_text("#!/bin/sh\n", encoding = "utf-8")
+    for f in (bin_dir / "ldd", bin_dir / "ldconfig", venv_bin / "uv", venv_bin / "python"):
+        f.chmod(0o755)
+    cuda_so = tmp_path / "opt" / "unsloth" / "llama.cpp" / "libggml-cuda.so"
+    cuda_so.parent.mkdir(parents = True)
+    cuda_so.write_bytes(b"")
+
+    script = _guard_shell(dockerfile).replace("/opt/", f"{tmp_path}/opt/")
+    res = subprocess.run(
+        ["sh", "-c", "set -eux " + script],
+        capture_output = True,
+        text = True,
+        env = dict(os.environ, PATH = f"{bin_dir}:{os.environ['PATH']}"),
+    )
+    assert res.returncode == 0, res.stderr
+    args = (tmp_path / "uv_args").read_text(encoding = "utf-8").splitlines()
+    assert args[-1] == expected, (
+        f"for {soname} the guard asked uv for {args[-1]!r}, expected {expected!r}; "
+        f"stderr={res.stderr!r}"
+    )
+    assert "OK: llama.cpp CUDA backend dependencies all resolve" in res.stdout
+
+
 def test_guard_runs_after_the_prebuilt_is_fetched(dockerfile: str):
     fetch = dockerfile.index("fetch_llama_prebuilt.py")
     guard = dockerfile.index("CUDA_SO=")


### PR DESCRIPTION
## Summary

The first `docker-publish` run on main (33929540221, at 58255747f) failed in the `build (linux/arm64)` leg and published nothing. This makes the arm64 build install the cuBLAS package that PyPI actually serves for CUDA 13.

## What happened

The arm64 llama.cpp prebuilt is a CUDA 13 build. The guard after the fetch runs `ldd` on `libggml-cuda.so`, sees `libcublas.so.13` unresolved, and installs `nvidia-cublas-cu13`. On PyPI that name is a deprecated stub: the only release is a `0.0.1` sdist whose build fails deliberately with "please use nvidia-cublas instead". CUDA 13 dropped the `-cuNN` suffix. The real wheels are `nvidia-cublas` 13.x and unpack to `nvidia/cu13/lib/libcublas.so.13`, which is the path the loader config in this Dockerfile already registers.

```
Building nvidia-cublas-cu13==0.0.1
  x Failed to build `nvidia-cublas-cu13==0.0.1`
      THIS PROJECT 'nvidia-cublas-cu13' IS DEPRECATED.
      Please use 'nvidia-cublas' instead.
```

`merge` needs `build` without `always()`, so the arm64 failure skipped `merge`, `build-studio` and `merge-studio`. Neither arch was published. The second run on main (33932609838) will fail the same way.

## The change

Pick the package name by CUDA major: `nvidia-cublas==<major>.*` from 13 on, `nvidia-cublas-cu<major>` below that. The amd64 bundle wants cu12, which torch's own wheels already provide, so that path does not change.

Verified without an arm64 host:

- `uv pip install --dry-run --python-platform aarch64-unknown-linux-gnu "nvidia-cublas==13.*"` resolves to `nvidia-cublas==13.6.1.10` (the stable release, not the 13.7 rc) plus `nvidia-cuda-nvrtc==13.3.33`.
- The aarch64 wheel's contents are `nvidia/cu13/lib/libcublas.so.13`, `libcublasLt.so.13` and `libnvblas.so.13`, matching the registered loader path.
- `docker buildx build --check` reports no warnings.

## Test

The new test extracts the guard's `RUN` body from the Dockerfile, runs it with `ldd` and `uv` stubbed, and checks the spec handed to `uv` for both majors. Only the resolution is faked; the branch logic under test is the Dockerfile's own. Against the previous Dockerfile the cu13 case fails with exactly the name the publish run used, and the cu12 case passes, since the suffixed name was correct there.

## Still unverified

This host has no arm64 emulation, so the full arm64 image build has not been run locally. The next publish run on main after this merges is the first real exercise of the fixed step.
