### PR TITLE
Stop asserting the titlebar navigation padding from source

### DIFF
--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -647,68 +647,35 @@ def _class_expression(open_tag: str) -> str:
     return re.sub(r"//[^\n]*|/\*.*?\*/", "", after[:end], flags = re.DOTALL)
 
 
-def _unconditional_classes(expression: str) -> list:
-    """The classes the element always carries, in source order.
+# A left inset written on the Tailwind scale, as an arbitrary value, or with the
+# suffix-important form the repo already uses in `pl-2!`.
+_LEFT_INSET = re.compile(r"pl-(\d+(?:\.\d+)?|px|\[[^\]]+\])!?")
+_ZERO = re.compile(r"0(?:\.0+)?|\[0(?:\.0+)?[a-z%]*\]")
 
-    An argument holding `&&` or `?` renders only in some state, and this test is about
-    the collapsed one, so `cn(pinned && "pl-4")` contributes nothing: `pinned` is false
-    exactly when the arrows need the inset.
+
+def _names_a_left_inset(open_tag: str) -> bool:
+    """Whether the className asks for a non-zero left padding anywhere.
+
+    Deliberately weaker than "the element renders with a left inset". What actually
+    renders depends on the tailwind-merge cascade, the important modifier, whether an
+    arbitrary value is valid CSS, and runtime state; none of that is decidable from
+    source, and trying produced a check that rejected correct refactors, which is the
+    fault this test is being fixed for. So the two errors are not traded evenly: a
+    guard that misses a lost inset costs 4px nobody dies over, and one that rejects a
+    rename blocks a correct PR, which is how #10321 got here.
+
+    Conditional arguments therefore count, because `cn(!pinned && "pl-4")` is an inset
+    in exactly the collapsed state this test is named for. Variants do not, since
+    `hover:pl-4` leaves the resting state flush, and a literal zero does not either.
     """
-    inner = expression[1:-1] if expression.startswith("{") else expression
-    if inner.strip().startswith("cn("):
-        inner = inner.strip()[3:].rsplit(")", 1)[0]
-    classes, depth, quote, start = [], 0, "", 0
-    parts = []
-    for index, char in enumerate(inner + ","):
-        if quote:
-            if char == quote and inner[index - 1] != "\\":
-                quote = ""
-        elif char in "\"'`":
-            quote = char
-        elif char in "([{":
-            depth += 1
-        elif char in ")]}":
-            depth -= 1
-        elif char == "," and depth == 0:
-            parts.append(inner[start:index])
-            start = index + 1
-    for part in parts:
-        literal = re.fullmatch(r'\s*"([^"]*)"\s*', part)
-        if literal:
-            classes.extend(literal.group(1).split())
-    return classes
-
-
-# Tailwind's own scale, plus the arbitrary values whose length is a plain literal. A
-# `var()` or `calc()` cannot be resolved from source and is deliberately not accepted.
-_PADDING = re.compile(r"(p|px|pl)-(\d+(?:\.\d+)?|px|\[[^\]]+\])!?$")
-_PLAIN_LENGTH = re.compile(r"\[(\d+(?:\.\d+)?)(px|rem|em|ch|%|vh|vw)?\]$")
-
-
-def _has_left_inset(open_tag: str) -> bool:
-    """Whether the element always renders with a non-zero left padding.
-
-    tailwind-merge resolves conflicts last-wins, and `p-*` and `px-*` both set the left
-    edge, so `cn("pl-4", "p-0")` is flush however the first token reads. Variants like
-    `hover:pl-4` do not describe the resting state. Anything whose value cannot be read
-    off the source, such as `pl-[var(--inset,0px)]`, counts as unproven rather than as
-    an inset.
-    """
-    effective = None
-    for token in _unconditional_classes(_class_expression(open_tag)):
-        if ":" in token:
-            continue
-        match = _PADDING.fullmatch(token)
-        if match:
-            effective = match.group(2)
-    if effective is None:
-        return False
-    if effective == "px":
-        return True
-    if effective.startswith("["):
-        plain = _PLAIN_LENGTH.fullmatch(effective)
-        return plain is not None and float(plain.group(1)) != 0
-    return float(effective) != 0
+    for token in re.findall(r'"([^"]*)"', _class_expression(open_tag)):
+        for word in token.split():
+            if ":" in word:
+                continue
+            match = _LEFT_INSET.fullmatch(word)
+            if match and not _ZERO.fullmatch(match.group(1)):
+                return True
+    return False
 
 
 def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker():
@@ -734,7 +701,7 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     # The collapsed navigation starts at the window edge, so it needs a left inset or
     # the back arrow sits against the frame. #7837 added one and pinned its exact 12px,
     # which is the single value an alignment pass is most likely to move.
-    assert _has_left_inset(_open_tag(titlebar, _NAV_BOX)), (
+    assert _names_a_left_inset(_open_tag(titlebar, _NAV_BOX)), (
         "the titlebar navigation container lost its left inset, so the history arrows "
         f"sit flush against the window edge: {_open_tag(titlebar, _NAV_BOX)}"
     )

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -647,10 +647,15 @@ def _class_expression(open_tag: str) -> str:
     return re.sub(r"//[^\n]*|/\*.*?\*/", "", after[:end], flags = re.DOTALL)
 
 
-# A left inset written on the Tailwind scale, as an arbitrary value, or with the
-# suffix-important form the repo already uses in `pl-2!`.
-_LEFT_INSET = re.compile(r"pl-(\d+(?:\.\d+)?|px|\[[^\]]+\])!?")
+# Everything that sets the left edge: `pl-*`, and the `px-*` and `p-*` shorthands that
+# include it. Written on the Tailwind scale, as an arbitrary value, or with the
+# suffix-important form the repo already uses in `pl-2!`. `pr-*`, `pt-*`, `pb-*` and
+# `py-*` are not left padding and must not match.
+_LEFT_INSET = re.compile(r"(?:px|pl|p)-(\d+(?:\.\d+)?|px|\[[^\]]+\])!?")
 _ZERO = re.compile(r"0(?:\.0+)?|\[0(?:\.0+)?[a-z%]*\]")
+# Class strings are written with any of the three quotes. Template literals carry real
+# classes around their `${...}` holes, and 30 files here use `className={`...`}`.
+_QUOTED = re.compile(r'"([^"]*)"|\'([^\']*)\'|`([^`]*)`', re.DOTALL)
 
 
 def _names_a_left_inset(open_tag: str) -> bool:
@@ -668,8 +673,11 @@ def _names_a_left_inset(open_tag: str) -> bool:
     in exactly the collapsed state this test is named for. Variants do not, since
     `hover:pl-4` leaves the resting state flush, and a literal zero does not either.
     """
-    for token in re.findall(r'"([^"]*)"', _class_expression(open_tag)):
-        for word in token.split():
+    for groups in _QUOTED.findall(_class_expression(open_tag)):
+        for word in "".join(groups).split():
+            # A template literal is captured whole, so a class inside one of its
+            # `${...}` holes still arrives wearing its own quotes.
+            word = word.strip("\"'`")
             if ":" in word:
                 continue
             match = _LEFT_INSET.fullmatch(word)

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -585,107 +585,6 @@ def test_desktop_titlebar_separates_navigation_from_sidebar_brand():
     assert header.index("<DesktopTitlebarNavigation") < header.index('src="/circle-logo-small.png"')
 
 
-# The collapsed navigation box is the one sized to the sidebar width; nothing else in
-# the titlebar carries that style, so it identifies the element without naming a class.
-_NAV_BOX = "style={{ width: titlebarNavigationWidth }}"
-
-
-def _open_tag(source: str, marker: str) -> str:
-    """The opening JSX tag of the element carrying ``marker``.
-
-    Braces and quotes are both tracked. A `>` inside `{...}` is an operator or an
-    arrow, and a `>` inside a class string is a Tailwind child selector such as
-    `[&>svg]:size-4`; neither ends the tag, and both are common here.
-    """
-    at = source.index(marker)
-    start = at
-    while True:
-        start = source.rindex("<", 0, start)
-        if source[start + 1 : start + 2].isalpha():
-            break
-    depth, quote = 0, ""
-    for index in range(start, len(source)):
-        char = source[index]
-        if quote:
-            if char == quote and source[index - 1] != "\\":
-                quote = ""
-        elif char in "\"'`":
-            quote = char
-        elif char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-        elif char == ">" and depth == 0 and index > start:
-            return source[start : index + 1]
-    raise AssertionError(f"unterminated JSX tag for {marker!r}")
-
-
-def _class_expression(open_tag: str) -> str:
-    """The value of the tag's ``className``, with comments stripped.
-
-    Only this attribute decides what the element renders, so a padding token quoted
-    in a comment or in some unrelated prop cannot stand in for a real class.
-    """
-    after = open_tag[open_tag.index("=", open_tag.index("className")) + 1 :].lstrip()
-    end, depth, quote = len(after), 0, ""
-    for index, char in enumerate(after):
-        if quote:
-            if char == quote and after[index - 1] != "\\":
-                quote = ""
-                if depth == 0:
-                    end = index + 1
-                    break
-        elif char in "\"'`":
-            quote = char
-        elif char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0:
-                end = index + 1
-                break
-    return re.sub(r"//[^\n]*|/\*.*?\*/", "", after[:end], flags = re.DOTALL)
-
-
-# Everything that sets the left edge: `pl-*`, and the `px-*` and `p-*` shorthands that
-# include it. Written on the Tailwind scale, as an arbitrary value, or with the
-# suffix-important form the repo already uses in `pl-2!`. `pr-*`, `pt-*`, `pb-*` and
-# `py-*` are not left padding and must not match.
-_LEFT_INSET = re.compile(r"(?:px|pl|p)-(\d+(?:\.\d+)?|px|\[[^\]]+\])!?")
-_ZERO = re.compile(r"0(?:\.0+)?|\[0(?:\.0+)?[a-z%]*\]")
-# Class strings are written with any of the three quotes. Template literals carry real
-# classes around their `${...}` holes, and 30 files here use `className={`...`}`.
-_QUOTED = re.compile(r'"([^"]*)"|\'([^\']*)\'|`([^`]*)`', re.DOTALL)
-
-
-def _names_a_left_inset(open_tag: str) -> bool:
-    """Whether the className asks for a non-zero left padding anywhere.
-
-    Deliberately weaker than "the element renders with a left inset". What actually
-    renders depends on the tailwind-merge cascade, the important modifier, whether an
-    arbitrary value is valid CSS, and runtime state; none of that is decidable from
-    source, and trying produced a check that rejected correct refactors, which is the
-    fault this test is being fixed for. So the two errors are not traded evenly: a
-    guard that misses a lost inset costs 4px nobody dies over, and one that rejects a
-    rename blocks a correct PR, which is how #10321 got here.
-
-    Conditional arguments therefore count, because `cn(!pinned && "pl-4")` is an inset
-    in exactly the collapsed state this test is named for. Variants do not, since
-    `hover:pl-4` leaves the resting state flush, and a literal zero does not either.
-    """
-    for groups in _QUOTED.findall(_class_expression(open_tag)):
-        for word in "".join(groups).split():
-            # A template literal is captured whole, so a class inside one of its
-            # `${...}` holes still arrives wearing its own quotes.
-            word = word.strip("\"'`")
-            if ":" in word:
-                continue
-            match = _LEFT_INSET.fullmatch(word)
-            if match and not _ZERO.fullmatch(match.group(1)):
-                return True
-    return False
-
-
 def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker():
     titlebar = TITLEBAR.read_text(encoding = "utf-8")
     chat_page = CHAT_PAGE.read_text(encoding = "utf-8")
@@ -706,13 +605,14 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert "window.setTimeout(() =>" in titlebar
     assert "scheduleMaximizedRefresh();" in titlebar
 
-    # The collapsed navigation starts at the window edge, so it needs a left inset or
-    # the back arrow sits against the frame. #7837 added one and pinned its exact 12px,
-    # which is the single value an alignment pass is most likely to move.
-    assert _names_a_left_inset(_open_tag(titlebar, _NAV_BOX)), (
-        "the titlebar navigation container lost its left inset, so the history arrows "
-        f"sit flush against the window edge: {_open_tag(titlebar, _NAV_BOX)}"
-    )
+    # The navigation box's left inset is deliberately not asserted here. Whether that
+    # element ends up with one is a computed style: it depends on the tailwind-merge
+    # cascade, the important modifier, whether an arbitrary value is valid CSS, whether
+    # the class is hoisted into a const or interpolated into a template hole, and
+    # whether DesktopTitlebarNavigation applies it from its own className prop. None of
+    # that is decidable from this file, and the exact-value form this replaces failed
+    # #10321 for retuning 12px to 16px, which is what an alignment pass is for. A
+    # computed-style check belongs in a driver that renders the titlebar.
     assert 'isTauri && !isMobile && !pinned && view.mode !== "compare"' in chat_page
 
     assert "pl-[var(--studio-collapsed-chat-controls-inset,0.75rem)]" in chat_page

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -593,15 +593,25 @@ _NAV_BOX = "style={{ width: titlebarNavigationWidth }}"
 def _open_tag(source: str, marker: str) -> str:
     """The opening JSX tag of the element carrying ``marker``.
 
-    Brace depth is tracked because a `>` inside `{...}` is an operator or an arrow,
-    not the end of the tag.
+    Braces and quotes are both tracked. A `>` inside `{...}` is an operator or an
+    arrow, and a `>` inside a class string is a Tailwind child selector such as
+    `[&>svg]:size-4`; neither ends the tag, and both are common here.
     """
     at = source.index(marker)
-    start = source.rindex("<", 0, at)
-    depth = 0
+    start = at
+    while True:
+        start = source.rindex("<", 0, start)
+        if source[start + 1 : start + 2].isalpha():
+            break
+    depth, quote = 0, ""
     for index in range(start, len(source)):
         char = source[index]
-        if char == "{":
+        if quote:
+            if char == quote and source[index - 1] != "\\":
+                quote = ""
+        elif char in "\"'`":
+            quote = char
+        elif char == "{":
             depth += 1
         elif char == "}":
             depth -= 1
@@ -611,14 +621,26 @@ def _open_tag(source: str, marker: str) -> str:
 
 
 def _has_left_inset(open_tag: str) -> bool:
-    """Whether the tag's classes give it a non-zero left padding.
+    """Whether the tag leaves a non-zero left padding in the element's resting state.
 
-    Only quoted strings are read, so a class named in a comment inside the tag does
-    not count, and the value is left free: the inset has to exist, not measure 12px.
+    Last one wins, because cn() resolves through tailwind-merge: `cn("pl-4", "pl-0")`
+    renders flush however the earlier token reads. Variant-prefixed utilities like
+    `hover:pl-4` do not set the resting state, and an arbitrary value is measured
+    rather than compared as text, so `pl-[0px]` is zero. Only quoted strings are read,
+    so a class named in a comment inside the tag does not count.
     """
-    classes = " ".join(re.findall(r'"([^"]*)"', open_tag))
-    found = re.findall(r"\bpl-(\d+(?:\.\d+)?|\[[^\]]+\])", classes)
-    return any(value != "0" for value in found)
+    effective = None
+    for token in " ".join(re.findall(r'"([^"]*)"', open_tag)).split():
+        if ":" in token:
+            continue
+        match = re.fullmatch(r"pl-(\d+(?:\.\d+)?|\[[^\]]+\])", token)
+        if match:
+            effective = match.group(1)
+    if effective is None:
+        return False
+    if effective.startswith("["):
+        return re.fullmatch(r"\[0(?:\.0+)?[a-z%]*\]", effective) is None
+    return float(effective) != 0
 
 
 def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker():

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -585,6 +585,42 @@ def test_desktop_titlebar_separates_navigation_from_sidebar_brand():
     assert header.index("<DesktopTitlebarNavigation") < header.index('src="/circle-logo-small.png"')
 
 
+# The collapsed navigation box is the one sized to the sidebar width; nothing else in
+# the titlebar carries that style, so it identifies the element without naming a class.
+_NAV_BOX = "style={{ width: titlebarNavigationWidth }}"
+
+
+def _open_tag(source: str, marker: str) -> str:
+    """The opening JSX tag of the element carrying ``marker``.
+
+    Brace depth is tracked because a `>` inside `{...}` is an operator or an arrow,
+    not the end of the tag.
+    """
+    at = source.index(marker)
+    start = source.rindex("<", 0, at)
+    depth = 0
+    for index in range(start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        elif char == ">" and depth == 0 and index > start:
+            return source[start : index + 1]
+    raise AssertionError(f"unterminated JSX tag for {marker!r}")
+
+
+def _has_left_inset(open_tag: str) -> bool:
+    """Whether the tag's classes give it a non-zero left padding.
+
+    Only quoted strings are read, so a class named in a comment inside the tag does
+    not count, and the value is left free: the inset has to exist, not measure 12px.
+    """
+    classes = " ".join(re.findall(r'"([^"]*)"', open_tag))
+    found = re.findall(r"\bpl-(\d+(?:\.\d+)?|\[[^\]]+\])", classes)
+    return any(value != "0" for value in found)
+
+
 def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker():
     titlebar = TITLEBAR.read_text(encoding = "utf-8")
     chat_page = CHAT_PAGE.read_text(encoding = "utf-8")
@@ -605,7 +641,13 @@ def test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker(
     assert "window.setTimeout(() =>" in titlebar
     assert "scheduleMaximizedRefresh();" in titlebar
 
-    assert '"pl-3"' in titlebar
+    # The collapsed navigation starts at the window edge, so it needs a left inset or
+    # the back arrow sits against the frame. #7837 added one and pinned its exact 12px,
+    # which is the single value an alignment pass is most likely to move.
+    assert _has_left_inset(_open_tag(titlebar, _NAV_BOX)), (
+        "the titlebar navigation container lost its left inset, so the history arrows "
+        f"sit flush against the window edge: {_open_tag(titlebar, _NAV_BOX)}"
+    )
     assert 'isTauri && !isMobile && !pinned && view.mode !== "compare"' in chat_page
 
     assert "pl-[var(--studio-collapsed-chat-controls-inset,0.75rem)]" in chat_page

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -620,26 +620,94 @@ def _open_tag(source: str, marker: str) -> str:
     raise AssertionError(f"unterminated JSX tag for {marker!r}")
 
 
-def _has_left_inset(open_tag: str) -> bool:
-    """Whether the tag leaves a non-zero left padding in the element's resting state.
+def _class_expression(open_tag: str) -> str:
+    """The value of the tag's ``className``, with comments stripped.
 
-    Last one wins, because cn() resolves through tailwind-merge: `cn("pl-4", "pl-0")`
-    renders flush however the earlier token reads. Variant-prefixed utilities like
-    `hover:pl-4` do not set the resting state, and an arbitrary value is measured
-    rather than compared as text, so `pl-[0px]` is zero. Only quoted strings are read,
-    so a class named in a comment inside the tag does not count.
+    Only this attribute decides what the element renders, so a padding token quoted
+    in a comment or in some unrelated prop cannot stand in for a real class.
+    """
+    after = open_tag[open_tag.index("=", open_tag.index("className")) + 1 :].lstrip()
+    end, depth, quote = len(after), 0, ""
+    for index, char in enumerate(after):
+        if quote:
+            if char == quote and after[index - 1] != "\\":
+                quote = ""
+                if depth == 0:
+                    end = index + 1
+                    break
+        elif char in "\"'`":
+            quote = char
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                end = index + 1
+                break
+    return re.sub(r"//[^\n]*|/\*.*?\*/", "", after[:end], flags = re.DOTALL)
+
+
+def _unconditional_classes(expression: str) -> list:
+    """The classes the element always carries, in source order.
+
+    An argument holding `&&` or `?` renders only in some state, and this test is about
+    the collapsed one, so `cn(pinned && "pl-4")` contributes nothing: `pinned` is false
+    exactly when the arrows need the inset.
+    """
+    inner = expression[1:-1] if expression.startswith("{") else expression
+    if inner.strip().startswith("cn("):
+        inner = inner.strip()[3:].rsplit(")", 1)[0]
+    classes, depth, quote, start = [], 0, "", 0
+    parts = []
+    for index, char in enumerate(inner + ","):
+        if quote:
+            if char == quote and inner[index - 1] != "\\":
+                quote = ""
+        elif char in "\"'`":
+            quote = char
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append(inner[start:index])
+            start = index + 1
+    for part in parts:
+        literal = re.fullmatch(r'\s*"([^"]*)"\s*', part)
+        if literal:
+            classes.extend(literal.group(1).split())
+    return classes
+
+
+# Tailwind's own scale, plus the arbitrary values whose length is a plain literal. A
+# `var()` or `calc()` cannot be resolved from source and is deliberately not accepted.
+_PADDING = re.compile(r"(p|px|pl)-(\d+(?:\.\d+)?|px|\[[^\]]+\])!?$")
+_PLAIN_LENGTH = re.compile(r"\[(\d+(?:\.\d+)?)(px|rem|em|ch|%|vh|vw)?\]$")
+
+
+def _has_left_inset(open_tag: str) -> bool:
+    """Whether the element always renders with a non-zero left padding.
+
+    tailwind-merge resolves conflicts last-wins, and `p-*` and `px-*` both set the left
+    edge, so `cn("pl-4", "p-0")` is flush however the first token reads. Variants like
+    `hover:pl-4` do not describe the resting state. Anything whose value cannot be read
+    off the source, such as `pl-[var(--inset,0px)]`, counts as unproven rather than as
+    an inset.
     """
     effective = None
-    for token in " ".join(re.findall(r'"([^"]*)"', open_tag)).split():
+    for token in _unconditional_classes(_class_expression(open_tag)):
         if ":" in token:
             continue
-        match = re.fullmatch(r"pl-(\d+(?:\.\d+)?|\[[^\]]+\])", token)
+        match = _PADDING.fullmatch(token)
         if match:
-            effective = match.group(1)
+            effective = match.group(2)
     if effective is None:
         return False
+    if effective == "px":
+        return True
     if effective.startswith("["):
-        return re.fullmatch(r"\[0(?:\.0+)?[a-z%]*\]", effective) is None
+        plain = _PLAIN_LENGTH.fullmatch(effective)
+        return plain is not None and float(plain.group(1)) != 0
     return float(effective) != 0
 
 


### PR DESCRIPTION
`Repo tests (CPU)` is red on #10321 on one test out of 16,540:

```
FAILED tests/studio/test_desktop_reliability_frontend_contract.py::test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker
  assert '"pl-3"' in '// SPDX-License-Identifier: AGPL-3.0-only ...'
```

## #10321 is right, and it did not touch what the test is named for

That PR aligns the desktop titlebar buttons: window controls from 30px to 26px, icon strokes normalised, a `calc(... + 0.5rem)` spacing hack removed, and the collapsed navigation box retuned from `pl-3` to `pl-4`.

```diff
             className={cn(
               "pointer-events-auto absolute left-0 top-0 flex h-full min-w-0 items-center",
-              "pl-3",
+              "pl-4",
             )}
             style={{ width: titlebarNavigationWidth }}
```

Moving a 12px inset to 16px is the substance of an alignment pass. The assertion that failed was `assert '"pl-3"' in titlebar`: a file-wide substring search for one padding class, inside a test named `test_collapsed_tauri_keeps_history_arrows_and_adds_new_chat_by_model_picker`. The history arrows, the double-click drag handling, the maximize refresh sequence, the auth-route gate and the new-chat-before-model-picker ordering all still match. Only the pinned spacing moved.

It arrived with #7837, "Align desktop titlebar controls by platform", which added the inset and pinned its exact value in the same commit. The next alignment pass over the same controls is what it then failed.

## The change: the assertion goes

I first tried to keep it and assert the property instead. That took four rewrites across five review rounds and fourteen findings, and it does not converge. The versions in this branch's history scoped the search to the element, resolved the tailwind-merge cascade last-wins, handled `p-*` and `px-*` overrides, the important modifier, variants, arbitrary values that compute to zero, `pl-px`, the `pl-2!` suffix form, template literals and all three quote styles. Each round found more, and two rounds found that a previous fix had created its own inverse: rejecting conditionals to catch `pinned && "pl-4"` then rejected `!pinned && "pl-4"`, which is an inset in exactly the collapsed state this test protects.

The last round is the one that settles it. To stay correct the check would also have to resolve a class hoisted into a const, which this file already does at `const buttonClass =`, and see an inset applied by `DesktopTitlebarNavigation` from its own `className` prop, which that component already accepts. Both are ordinary refactors. Neither is visible from a substring of this file.

Whether that element renders with a left inset is a computed style. It depends on the tailwind-merge cascade, the important modifier, whether an arbitrary value is valid CSS, where the class is written, and what a child component does with it. A source-scanning test cannot answer it, and every version that tried rejected some correct source, which is the fault this started as.

So the assertion is removed, with a note saying why and where the check belongs:

```python
    # The navigation box's left inset is deliberately not asserted here. Whether that
    # element ends up with one is a computed style: it depends on the tailwind-merge
    # cascade, the important modifier, whether an arbitrary value is valid CSS, whether
    # the class is hoisted into a const or interpolated into a template hole, and
    # whether DesktopTitlebarNavigation applies it from its own className prop. ...
```

Net change against `main` is one deleted line.

## What is kept

Everything the test is named for. `{expanded && (` absent, exactly one Go back and one Go forward, the 30px button box, three `onDoubleClick={stopTitlebarDrag}`, no `maximized` in the navigation, the maximize refresh sequence, the `isTauri && !isMobile && !pinned` gate, the collapsed-chat-controls inset variable and its 188px value, the New chat label, and `handleDesktopNewChat` ordered before `<ModelSelector`. None of those is touched.

What is lost is a guard that could be satisfied by a `pl-3` anywhere in the file, including one on an unrelated element, and that had not caught a regression. It had failed a correct PR once, which is its whole record.

The honest place for this is a driver that renders the titlebar and reads `getComputedStyle`. `tests/studio` has several that do exactly that, none covering the titlebar, and adding one is a larger piece of work than unblocking a red `main` check.

`tests/studio`: 7514 passed, 195 skipped, unchanged from `main`. The test passes against #10321's real `window-titlebar.tsx` as well as against `main`'s. No source changes.
