### PR TITLE
Docker publish: verify the merged manifest against the arches' children

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -342,12 +342,22 @@ jobs:
           # pushed, because baking another run's base image is silent otherwise.
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
           CHILDREN="$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]?.digest')"
+          # A build leg does not push a bare image manifest: with provenance and SBOM
+          # on, buildx pushes each arch as an OCI index (image + attestation) and
+          # `imagetools create` flattens THOSE children into the merged index, so the
+          # per-arch index digest itself never appears there. Comparing at the wrong
+          # level failed the first publish runs on main against a correct manifest.
           missing=0
           for d in *; do
-              grep -qxF "sha256:$d" <<<"$CHILDREN" || {
-                  echo "::error::${TAG} resolved to ${DIGEST}, which does not contain the sha256:${d} this run pushed; another ref at this commit retagged it"
-                  missing=1
-              }
+              want="$(docker buildx imagetools inspect --raw "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:${d}" \
+                      | jq -r '.manifests[]?.digest')"
+              [ -n "$want" ] || want="sha256:${d}"
+              for w in $want; do
+                  grep -qxF "$w" <<<"$CHILDREN" || {
+                      echo "::error::${TAG} resolved to ${DIGEST}, which does not contain ${w} (from sha256:${d} this run pushed); another ref at this commit retagged it"
+                      missing=1
+                  }
+              done
           done
           test "$missing" = 0
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
@@ -497,12 +507,19 @@ jobs:
           test -n "$DIGEST"
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
           CHILDREN="$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]?.digest')"
+          # per-arch pushes are indexes (image + attestation) that the merge
+          # flattens, so compare their children, not the index digest; see the base merge
           missing=0
           for d in *; do
-              grep -qxF "sha256:$d" <<<"$CHILDREN" || {
-                  echo "::error::${TAG} resolved to ${DIGEST}, which does not contain the sha256:${d} this run pushed; another ref at this commit retagged it"
-                  missing=1
-              }
+              want="$(docker buildx imagetools inspect --raw "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:${d}" \
+                      | jq -r '.manifests[]?.digest')"
+              [ -n "$want" ] || want="sha256:${d}"
+              for w in $want; do
+                  grep -qxF "$w" <<<"$CHILDREN" || {
+                      echo "::error::${TAG} resolved to ${DIGEST}, which does not contain ${w} (from sha256:${d} this run pushed); another ref at this commit retagged it"
+                      missing=1
+                  }
+              done
           done
           test "$missing" = 0
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"

--- a/tests/python/test_docker_publish_ref_freeze.py
+++ b/tests/python/test_docker_publish_ref_freeze.py
@@ -309,6 +309,33 @@ def _raw_index(children = ARCH_DIGESTS) -> str:
     return '{\\"manifests\\":[' + inner + "]}"
 
 
+# What a build leg really pushes with provenance and SBOM on: not an image manifest
+# but an OCI index per arch, holding the image manifest and its attestation. The
+# merge flattens those children into the published index, so the per-arch index
+# digest (the artifact file name) never appears there. The first publish runs on main
+# failed on exactly that shape against a correct manifest.
+PER_ARCH_CHILDREN = {
+    ARCH_DIGESTS[0]: ("a1" * 32, "a2" * 32),
+    ARCH_DIGESTS[1]: ("c1" * 32, "c2" * 32),
+}
+FLATTENED = tuple(h for pair in PER_ARCH_CHILDREN.values() for h in pair)
+
+
+def _raw_case(merged_children) -> str:
+    """A `case` over the ref for `inspect --raw`: per-arch index digests answer with
+    their own children, anything else is the merged index."""
+    arms = "".join(
+        f'    *@sha256:{h}) printf "{_raw_index(kids)}" ;;\n'
+        for h, kids in PER_ARCH_CHILDREN.items()
+    )
+    return (
+        '  --raw) case "$5" in\n'
+        + arms
+        + f'    *) printf "{_raw_index(merged_children)}" ;;\n'
+        + "  esac ;;\n"
+    )
+
+
 @pytest.fixture(scope = "module")
 def manifest_digest_step() -> str:
     doc = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
@@ -392,12 +419,13 @@ def test_the_digest_export_refuses_another_runs_manifest(manifest_digest_step: s
     tag resolves to a manifest that does not contain the per-arch digests this run
     pushed, the step has to fail rather than hand build-studio another run's base."""
     bin_dir = tmp_path / "bin"
-    # the tag now resolves to a manifest built from somebody else's arches
+    # the tag now resolves to a manifest built from somebody else's arches, while
+    # this run's own per-arch indexes still answer with their real children
     _docker_stub(
         bin_dir,
         'case "$4" in\n'
-        f'  --raw) printf "{_raw_index(("d" * 64, "e" * 64))}" ;;\n'
-        f"  *) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
+        + _raw_case(("d" * 64, "e" * 64))
+        + f"  *) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
         "esac\n",
     )
     out = tmp_path / "github_output"
@@ -427,3 +455,46 @@ def test_the_digest_export_refuses_another_runs_manifest(manifest_digest_step: s
     assert "digest=" not in out.read_text(
         encoding = "utf-8"
     ), "a digest was exported despite the mismatch"
+
+
+@pytest.mark.skipif(shutil.which("jq") is None, reason = "needs jq")
+def test_the_digest_export_accepts_the_flattened_per_arch_indexes(
+    manifest_digest_step: str, tmp_path: Path
+):
+    """The real shape: each build leg pushed an index (image + attestation), and the
+    merged index carries those CHILDREN, never the per-arch index digests the
+    artifact files are named after. Runs 33935929946 and 33936467156 published a
+    correct :core and then failed here, which skipped the Studio build."""
+    bin_dir = tmp_path / "bin"
+    _docker_stub(
+        bin_dir,
+        'case "$4" in\n'
+        + _raw_case(FLATTENED)
+        + f"  *) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
+        "esac\n",
+    )
+    out = tmp_path / "github_output"
+    out.write_text("", encoding = "utf-8")
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
+    env["GITHUB_OUTPUT"] = str(out)
+    env["DOCKER_METADATA_OUTPUT_JSON"] = (
+        '{"tags":["' + IMAGE + ':core","' + IMAGE + ':core-sha-abc1234"]}'
+    )
+    path = tmp_path / "digest_step.sh"
+    path.write_text(_expand(manifest_digest_step), encoding = "utf-8")
+    res = subprocess.run(
+        ["bash", "-e", str(path)],
+        capture_output = True,
+        text = True,
+        env = env,
+        timeout = 60,
+        cwd = str(_digests_dir(tmp_path)),
+    )
+    assert res.returncode == 0, (
+        "the step rejected a merged index that holds every child of this run's "
+        "per-arch indexes, i.e. the manifest buildx actually produces:\n"
+        + res.stdout
+        + res.stderr
+    )
+    assert f"digest={THIS_RUN_DIGEST}" in out.read_text(encoding = "utf-8")

--- a/tests/python/test_docker_publish_ref_freeze.py
+++ b/tests/python/test_docker_publish_ref_freeze.py
@@ -468,9 +468,7 @@ def test_the_digest_export_accepts_the_flattened_per_arch_indexes(
     bin_dir = tmp_path / "bin"
     _docker_stub(
         bin_dir,
-        'case "$4" in\n'
-        + _raw_case(FLATTENED)
-        + f"  *) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
+        'case "$4" in\n' + _raw_case(FLATTENED) + f"  *) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
         "esac\n",
     )
     out = tmp_path / "github_output"
@@ -493,8 +491,6 @@ def test_the_digest_export_accepts_the_flattened_per_arch_indexes(
     )
     assert res.returncode == 0, (
         "the step rejected a merged index that holds every child of this run's "
-        "per-arch indexes, i.e. the manifest buildx actually produces:\n"
-        + res.stdout
-        + res.stderr
+        "per-arch indexes, i.e. the manifest buildx actually produces:\n" + res.stdout + res.stderr
     )
     assert f"digest={THIS_RUN_DIGEST}" in out.read_text(encoding = "utf-8")


### PR DESCRIPTION
## Summary

The two publish runs on main that got past the arm64 build (33935929946 at 7197da219 and 33936467156 at a4c815d6a) both failed in the `merge` job, after the multi-arch manifest had been created and inspected correctly. `unsloth/unsloth:core` and the two `core-sha-*` tags are on Docker Hub with `linux/amd64` and `linux/arm64`. `build-studio` and `merge-studio` were skipped, so there is no `:latest` or `:studio` yet.

## What failed

The "Export manifest digest" step confirms that the merged index really contains what this run's build legs pushed, so that a second ref at the same commit cannot silently retag `:core-sha-*` between the merge and the Studio build. It compared at the wrong level.

With provenance and SBOM enabled, each build leg pushes an OCI index per arch, holding the image manifest and its attestation manifest. `imagetools create` flattens those children into the merged index. The per-arch index digest, which is the name of the artifact file the step iterates over, never appears in the merged index. So the check reported a mismatch against a correct manifest:

```
core-sha-7197da2 resolved to sha256:e97cf2bf..., which does not contain the sha256:168b6969... this run pushed
```

`sha256:168b6969...` is the arm64 index; its children `80b93552` (linux/arm64) and `cf099821` (attestation) are both in `e97cf2bf`.

The existing tests modelled per-arch pushes as bare image manifests, which is why they passed while the run did not. Nothing exercised the real shape before merge because no PR-time workflow and no staging repo ever ran a publish.

## The change

For each pushed digest, resolve it with `imagetools inspect --raw`. If it is an index, require every one of its children to be in the merged index. If it is a bare image manifest, require the digest itself. The same change is applied to `merge-studio`.

Verified against the live registry, not only stubs:

- Run with the two real artifact digests from 33935929946 against `core-sha-7197da2`: exports `digest=sha256:e97cf2bf...`, exit 0.
- Run with the same digests against `core-sha-a4c815d` (the other run's manifest): four `::error::` lines, exit 1, nothing exported. The retag protection is intact.

## Tests

The docker stub now answers a per-arch ref with that arch's own children and any other ref with the merged index. The new acceptance test uses the flattened shape and fails against the previous step. The existing refusal test keeps passing on both.

## Side note

`:core` currently points at the 7197da219 image although a4c815d6a is newer: the older commit's run finished its merge nine minutes later and won the mutable tag. The next successful publish corrects this. It is the ref-keyed concurrency group doing what it is designed to do, and out of scope here.
