### PR TITLE
Compare the merged index against what the pushed digests contain

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -341,6 +341,9 @@ jobs:
           # manifest we are about to hand to build-studio really is the one this run
           # pushed, because baking another run's base image is silent otherwise.
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
+          # Without pipefail a failed inspect feeds jq nothing, jq exits 0, and the
+          # variable is silently empty, which turns every check below into a no-op.
+          set -o pipefail
           CHILDREN="$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]?.digest')"
           # What a build job reports is the digest of an INDEX, not of a manifest:
           # build-push-action attaches a provenance attestation, so one push covers the
@@ -510,6 +513,9 @@ jobs:
           DIGEST="$(docker buildx imagetools inspect "$TAG" --format '{{json .Manifest.Digest}}' | tr -d '"')"
           test -n "$DIGEST"
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
+          # Without pipefail a failed inspect feeds jq nothing, jq exits 0, and the
+          # variable is silently empty, which turns every check below into a no-op.
+          set -o pipefail
           CHILDREN="$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]?.digest')"
           # What a build job reports is the digest of an INDEX, not of a manifest:
           # build-push-action attaches a provenance attestation, so one push covers the

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -342,12 +342,26 @@ jobs:
           # pushed, because baking another run's base image is silent otherwise.
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
           CHILDREN="$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]?.digest')"
+          # What a build job reports is the digest of an INDEX, not of a manifest:
+          # build-push-action attaches a provenance attestation, so one push covers the
+          # image manifest and the attestation together. `imagetools create` copies
+          # those CHILDREN into the merged index and never the source index digests, so
+          # looking for the pushed digests themselves matches nothing and fails every
+          # run. Compare what they contain. With attestations off a build pushes a bare
+          # manifest, which is then its own only child.
           missing=0
           for d in *; do
-              grep -qxF "sha256:$d" <<<"$CHILDREN" || {
-                  echo "::error::${TAG} resolved to ${DIGEST}, which does not contain the sha256:${d} this run pushed; another ref at this commit retagged it"
-                  missing=1
-              }
+              PUSHED="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:${d}"
+              EXPECT="$(docker buildx imagetools inspect --raw "$PUSHED" \
+                  | jq -r --arg self "sha256:${d}" \
+                      'if (.manifests | length) > 0 then .manifests[].digest else $self end')"
+              while read -r child; do
+                  [ -n "$child" ] || continue
+                  grep -qxF "$child" <<<"$CHILDREN" || {
+                      echo "::error::${TAG} resolved to ${DIGEST}, which is missing ${child} from the sha256:${d} this run pushed; another ref at this commit retagged it"
+                      missing=1
+                  }
+              done <<<"$EXPECT"
           done
           test "$missing" = 0
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
@@ -497,12 +511,26 @@ jobs:
           test -n "$DIGEST"
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
           CHILDREN="$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]?.digest')"
+          # What a build job reports is the digest of an INDEX, not of a manifest:
+          # build-push-action attaches a provenance attestation, so one push covers the
+          # image manifest and the attestation together. `imagetools create` copies
+          # those CHILDREN into the merged index and never the source index digests, so
+          # looking for the pushed digests themselves matches nothing and fails every
+          # run. Compare what they contain. With attestations off a build pushes a bare
+          # manifest, which is then its own only child.
           missing=0
           for d in *; do
-              grep -qxF "sha256:$d" <<<"$CHILDREN" || {
-                  echo "::error::${TAG} resolved to ${DIGEST}, which does not contain the sha256:${d} this run pushed; another ref at this commit retagged it"
-                  missing=1
-              }
+              PUSHED="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:${d}"
+              EXPECT="$(docker buildx imagetools inspect --raw "$PUSHED" \
+                  | jq -r --arg self "sha256:${d}" \
+                      'if (.manifests | length) > 0 then .manifests[].digest else $self end')"
+              while read -r child; do
+                  [ -n "$child" ] || continue
+                  grep -qxF "$child" <<<"$CHILDREN" || {
+                      echo "::error::${TAG} resolved to ${DIGEST}, which is missing ${child} from the sha256:${d} this run pushed; another ref at this commit retagged it"
+                      missing=1
+                  }
+              done <<<"$EXPECT"
           done
           test "$missing" = 0
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"

--- a/tests/python/test_docker_publish_ref_freeze.py
+++ b/tests/python/test_docker_publish_ref_freeze.py
@@ -392,11 +392,18 @@ def test_the_digest_export_refuses_another_runs_manifest(manifest_digest_step: s
     tag resolves to a manifest that does not contain the per-arch digests this run
     pushed, the step has to fail rather than hand build-studio another run's base."""
     bin_dir = tmp_path / "bin"
-    # the tag now resolves to a manifest built from somebody else's arches
+    # the tag now resolves to a manifest built from somebody else's arches. The pushed
+    # digests answer for themselves: what a build job pushes is an index over its own
+    # arch manifest, so the step reads those to learn what the merge should contain.
     _docker_stub(
         bin_dir,
         'case "$4" in\n'
-        f'  --raw) printf "{_raw_index(("d" * 64, "e" * 64))}" ;;\n'
+        '  --raw)\n'
+        '    case "$5" in\n'
+        f'      *@sha256:{ARCH_DIGESTS[0]}) printf "{_raw_index(("1" * 64,))}" ;;\n'
+        f'      *@sha256:{ARCH_DIGESTS[1]}) printf "{_raw_index(("2" * 64,))}" ;;\n'
+        f'      *) printf "{_raw_index(("d" * 64, "e" * 64))}" ;;\n'
+        '    esac ;;\n'
         f"  *) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
         "esac\n",
     )
@@ -427,3 +434,96 @@ def test_the_digest_export_refuses_another_runs_manifest(manifest_digest_step: s
     assert "digest=" not in out.read_text(
         encoding = "utf-8"
     ), "a digest was exported despite the mismatch"
+
+
+@pytest.mark.skipif(shutil.which("jq") is None, reason = "needs jq")
+def test_the_digest_export_accepts_an_attested_merge(manifest_digest_step: str, tmp_path: Path):
+    """build-push-action attaches a provenance attestation, so what a build job pushes
+    is an INDEX over the arch manifest and the attestation, not a bare manifest.
+    `imagetools create` copies those children into the merged index and never the
+    source index digests, so a guard that looks for the pushed digests themselves
+    matches nothing and fails every run. That is what took `merge` down at 7197da219,
+    where it had never once passed."""
+    bin_dir = tmp_path / "bin"
+    attested = {
+        ARCH_DIGESTS[0]: ("1" * 64, "2" * 64),
+        ARCH_DIGESTS[1]: ("3" * 64, "4" * 64),
+    }
+    merged = _raw_index(tuple(c for pair in attested.values() for c in pair))
+    _docker_stub(
+        bin_dir,
+        'case "$4" in\n'
+        '  --raw)\n'
+        '    case "$5" in\n'
+        + "".join(
+            f'      *@sha256:{pushed}) printf "{_raw_index(children)}" ;;\n'
+            for pushed, children in attested.items()
+        )
+        + f'      *) printf "{merged}" ;;\n'
+        '    esac ;;\n'
+        f"  *) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
+        "esac\n",
+    )
+    out = tmp_path / "github_output"
+    out.write_text("", encoding = "utf-8")
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
+    env["GITHUB_OUTPUT"] = str(out)
+    env["DOCKER_METADATA_OUTPUT_JSON"] = (
+        '{"tags":["' + IMAGE + ':core","' + IMAGE + ':core-sha-abc1234"]}'
+    )
+    path = tmp_path / "digest_step.sh"
+    path.write_text(_expand(manifest_digest_step), encoding = "utf-8")
+    res = subprocess.run(
+        ["bash", "-e", str(path)],
+        capture_output = True,
+        text = True,
+        env = env,
+        timeout = 60,
+        cwd = str(_digests_dir(tmp_path)),
+    )
+    assert res.returncode == 0, (
+        "the step rejected a correctly merged index because it looked for the pushed "
+        "index digests rather than what they contain:\n" + res.stdout + res.stderr
+    )
+    assert out.read_text(encoding = "utf-8").strip() == f"digest={THIS_RUN_DIGEST}"
+
+
+@pytest.mark.skipif(shutil.which("jq") is None, reason = "needs jq")
+def test_the_digest_export_fails_when_an_inspection_fails(
+    manifest_digest_step: str, tmp_path: Path
+):
+    """A failed inspect feeds jq nothing, and jq exits 0 on empty input. Without
+    pipefail the variable is silently empty and every check below becomes a no-op,
+    so a retagged manifest would be exported as this run's own."""
+    bin_dir = tmp_path / "bin"
+    _docker_stub(
+        bin_dir,
+        'case "$4" in\n'
+        f'  --raw) case "$5" in *@sha256:{ARCH_DIGESTS[0]}) exit 1 ;; esac\n'
+        f'         printf "{_raw_index()}" ;;\n'
+        f"  *) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
+        "esac\n",
+    )
+    out = tmp_path / "github_output"
+    out.write_text("", encoding = "utf-8")
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
+    env["GITHUB_OUTPUT"] = str(out)
+    env["DOCKER_METADATA_OUTPUT_JSON"] = (
+        '{"tags":["' + IMAGE + ':core","' + IMAGE + ':core-sha-abc1234"]}'
+    )
+    path = tmp_path / "digest_step.sh"
+    path.write_text(_expand(manifest_digest_step), encoding = "utf-8")
+    res = subprocess.run(
+        ["bash", "-e", str(path)],
+        capture_output = True,
+        text = True,
+        env = env,
+        timeout = 60,
+        cwd = str(_digests_dir(tmp_path)),
+    )
+    assert res.returncode != 0, (
+        "a failed inspection was swallowed, so the guard silently checked nothing:\n"
+        + res.stdout + res.stderr
+    )

--- a/tests/python/test_docker_publish_ref_freeze.py
+++ b/tests/python/test_docker_publish_ref_freeze.py
@@ -453,14 +453,14 @@ def test_the_digest_export_accepts_an_attested_merge(manifest_digest_step: str, 
     _docker_stub(
         bin_dir,
         'case "$4" in\n'
-        '  --raw)\n'
+        "  --raw)\n"
         '    case "$5" in\n'
         + "".join(
             f'      *@sha256:{pushed}) printf "{_raw_index(children)}" ;;\n'
             for pushed, children in attested.items()
         )
         + f'      *) printf "{merged}" ;;\n'
-        '    esac ;;\n'
+        "    esac ;;\n"
         f"  *) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
         "esac\n",
     )
@@ -525,5 +525,6 @@ def test_the_digest_export_fails_when_an_inspection_fails(
     )
     assert res.returncode != 0, (
         "a failed inspection was swallowed, so the guard silently checked nothing:\n"
-        + res.stdout + res.stderr
+        + res.stdout
+        + res.stderr
     )


### PR DESCRIPTION
The `merge` job has never passed. It has run twice since the workflow landed, at `7197da219` and `a4c815d6a`, and both times failed `Export manifest digest`:

```
::error::docker.io/unsloth/unsloth:core-sha-7197da2 resolved to sha256:e97cf2bf..., which does not
contain the sha256:168b6969... this run pushed; another ref at this commit retagged it
```

`build-studio` and `smoke-test` both sit behind it, so nothing publishes.

## There was no other ref

The message names a race the guard's own comment predicts: a branch push and a lightweight `v*` tag at one commit produce the same short sha, and the concurrency group is keyed on the ref, so the two runs are never serialised. That is a real hazard and worth guarding. It is not what happened here.

- `docker-publish` has exactly one run per commit: `58255747f`, `55418be5e`, `7197da219`, `a4c815d6a`, all `push` on `main`.
- No `v*` tag points at either failing commit.

## What a build job pushes is an index, not a manifest

`build-push-action` attaches a provenance attestation by default, so one push covers the image manifest and the attestation together, and the digest it reports is the digest of the index holding both. `imagetools create` given such an index copies its **children** into the merged index; it does not reference the source index. So the merged index never contains the digests the guard looks for, and `grep -qxF "sha256:$d"` matches nothing on every run.

Read back from Docker Hub for the failing run at `7197da219`:

| digest | what it is | children |
| --- | --- | --- |
| `sha256:168b6969` | pushed by the arm64 job, an OCI index | `sha256:80b93552` linux/arm64, `sha256:cf099821` unknown/unknown |
| `sha256:1a3565b6` | pushed by the amd64 job, an OCI index | `sha256:d66f6eb5` linux/amd64, `sha256:5582e459` unknown/unknown |
| `sha256:e97cf2bf` | the merged index the run created | exactly those four |

The merge is correct. The guard was asking whether the merged index contains the two indexes, and the answer is structurally no. The two `unknown/unknown` entries are the attestations.

## The change

Compare against what each pushed digest contains, rather than against the digest itself:

```sh
for d in *; do
    PUSHED="${REGISTRY}/${IMAGE_NAME}@sha256:${d}"
    EXPECT="$(docker buildx imagetools inspect --raw "$PUSHED" \
        | jq -r --arg self "sha256:${d}" \
            'if (.manifests | length) > 0 then .manifests[].digest else $self end')"
    ...
done
```

The `else` branch matters: with attestations off a build pushes a bare manifest, and then the digest really is its own only child. Both copies of the step are fixed, base and studio, which were byte identical.

The guard keeps its purpose. It still fails if the tag resolves to a manifest missing anything this run pushed, which is what a competing retag looks like.

Two further points came out of review and are fixed here rather than left:

- Both steps now `set -o pipefail`. `jq` exits 0 on empty input, so without it a failed `inspect` leaves the variable empty and the loop iterates over nothing: the guard would report success having checked nothing, which is the outcome it exists to prevent. This also tightens the two inspections that predate this change.
- `test_the_digest_export_refuses_another_runs_manifest` stubbed a single `--raw` answer for every ref, so under the new lookups the pushed digests reported the competing index as their own content and the step accepted it. That was a real break of an existing test. The stub now answers per ref, which is what a registry does.

## Verified by breaking it

The workflow's own shell was run against a stubbed `imagetools` backed by the manifests Docker Hub actually served for the failing run, so the reproduction is the registry's bytes and not a mock-up:

| scenario | should | old guard | this change |
| --- | --- | --- | --- |
| the real failing run, attested per-arch indexes | accept | **reject** | **accept** |
| a competing retag really did drop an arch | reject | reject | reject |
| an unattested build, whose digest is its own child | accept | accept | accept |

Row one reproduces the CI failure exactly. Row two is the case the guard exists for, still caught. Row three is the path the `else` branch covers.

Two tests are added, and both were checked to fail against the guard as it stands on `main` rather than assumed to bite:

- `test_the_digest_export_accepts_an_attested_merge` builds the real shape, per-arch indexes over (arch manifest, attestation) and a merged index holding all four.
- `test_the_digest_export_fails_when_an_inspection_fails` makes one inspection exit 1 and requires the step to fail.

`tests/python/test_docker_publish_ref_freeze.py`: 18 passed. `bash -n` clean on both steps, workflow parses, and `tests/studio/test_playwright_suites_run_in_ci.py` plus `test_workflow_guards_run_unfiltered.py` pass.

One thing this cannot settle from here: whether the whole publish then succeeds end to end, since `build-studio` and `smoke-test` have never run. They are unblocked by this, not proven by it.
