### PR TITLE
Studio: prefer the self-contained MTP head so llama-server's --fit can measure it

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -14344,6 +14344,7 @@ class LlamaCppBackend:
         label: str,
         cancel_event: Optional[threading.Event] = None,
         near_path: Optional[str] = None,
+        reuse_snapshot_sibling: bool = True,
         outcome: Optional[dict] = None,
         on_transient_failure: Optional[Callable[[], None]] = None,
     ) -> Optional[str]:
@@ -14363,6 +14364,13 @@ class LlamaCppBackend:
         then cannot open, so the load fell back to no speculation with nothing to
         show for the download -- and it disagreed with the local scan, which
         accepts a split drafter only when every shard is present.
+
+        ``reuse_snapshot_sibling=False`` skips only that first step, for a caller that
+        has already looked at the snapshot copy and rejected it. Without it the caller
+        cannot get past this reuse: it repeats the same lookup with the same
+        ``near_path`` and the same ``pick`` and hands the rejected file straight back,
+        so a fall-through here is a no-op. ``near_path`` is still passed, since it also
+        selects the cache directory the fetch writes into.
 
         ``on_transient_failure`` fires when the companion was lost to a listing that
         never completed or a download that dropped, the one None worth another attempt.
@@ -14384,7 +14392,7 @@ class LlamaCppBackend:
             return pick(available)
 
         # Keep companion files in the main GGUF's snapshot.
-        if near_path:
+        if near_path and reuse_snapshot_sibling:
             cached = _companion_snapshot_sibling(near_path, pick)
             if cached:
                 logger.info("Reusing cached %s: %s", label, cached)
@@ -14673,6 +14681,10 @@ class LlamaCppBackend:
 
         pick = _pick_mtp if allow_nested else _pick_mtp_root_only
 
+        # The borrowing head already in the snapshot, kept as the fallback: it is a
+        # working drafter, just an unmeasurable one, so a listing that never answers
+        # must not cost the load its speculation entirely.
+        borrowed_cached: Optional[str] = None
         if near_path:
             cached = _companion_snapshot_sibling(near_path, pick)
             if cached and _mtp_head_borrows(cached) and not _hf_env_offline():
@@ -14686,6 +14698,7 @@ class LlamaCppBackend:
                     "repo for a self-contained head: %s",
                     cached,
                 )
+                borrowed_cached = cached
             elif cached:
                 logger.info("Reusing cached MTP drafter: %s", cached)
                 return cached
@@ -14704,14 +14717,24 @@ class LlamaCppBackend:
                 logger.info(f"Reusing cached MTP drafter (offline): {cached}")
                 return cached
 
-        return self._download_companion_gguf(
+        fetched = self._download_companion_gguf(
             hf_repo = hf_repo,
             hf_token = hf_token,
             pick = pick,
             label = "MTP drafter",
             cancel_event = cancel_event,
             near_path = near_path,
+            # Suppressed only when this call is the fall-through: the helper would
+            # otherwise repeat the snapshot lookup above and return the same
+            # borrowing head before it ever lists the repo.
+            reuse_snapshot_sibling = borrowed_cached is None,
         )
+        if fetched is None and borrowed_cached is not None:
+            # The repo publishes nothing better, or the Hub never answered. An
+            # unmeasurable drafter still drafts; no drafter at all is the bigger loss.
+            logger.info("Keeping the cached borrowing MTP drafter: %s", borrowed_cached)
+            return borrowed_cached
+        return fetched
 
     def _cached_repo_dspark_drafter(
         self,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3269,6 +3269,11 @@ def _is_published_mtp_drafter_name(path: str) -> bool:
     return lower.startswith("mtp-") or stem.endswith("-mtp")
 
 
+def _mtp_head_borrows(path: str) -> bool:
+    """Is this the published ``-shared-`` form, which loads only under its target?"""
+    return "-shared-" in Path(path).name.lower()
+
+
 def _pick_mtp(candidates: list[str], *, allow_nested: bool = True) -> Optional[str]:
     """The MTP drafter a listing offers, or None. Module level for the same reason
     ``_pick_dspark`` is: both are handed a live repo listing as well as a snapshot,
@@ -14670,7 +14675,18 @@ class LlamaCppBackend:
 
         if near_path:
             cached = _companion_snapshot_sibling(near_path, pick)
-            if cached:
+            if cached and _mtp_head_borrows(cached) and not _hf_env_offline():
+                # The snapshot holds only a head the earlier picker chose, the
+                # borrowing form, which llama-server's --fit cannot measure
+                # (unsloth#10322). The live listing ranks the self-contained
+                # head above it, and hf_hub_download reuses this file if the
+                # repo turns out to publish nothing better.
+                logger.info(
+                    "Cached MTP drafter borrows the target's embeddings; checking the "
+                    "repo for a self-contained head: %s",
+                    cached,
+                )
+            elif cached:
                 logger.info("Reusing cached MTP drafter: %s", cached)
                 return cached
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -14365,12 +14365,9 @@ class LlamaCppBackend:
         show for the download -- and it disagreed with the local scan, which
         accepts a split drafter only when every shard is present.
 
-        ``reuse_snapshot_sibling=False`` skips only that first step, for a caller that
-        has already looked at the snapshot copy and rejected it. Without it the caller
-        cannot get past this reuse: it repeats the same lookup with the same
-        ``near_path`` and the same ``pick`` and hands the rejected file straight back,
-        so a fall-through here is a no-op. ``near_path`` is still passed, since it also
-        selects the cache directory the fetch writes into.
+        ``reuse_snapshot_sibling=False`` is for a caller that already rejected the
+        snapshot copy; without it this repeats the lookup and hands it back. ``near_path``
+        is still passed: it also selects the cache directory the fetch writes into.
 
         ``on_transient_failure`` fires when the companion was lost to a listing that
         never completed or a download that dropped, the one None worth another attempt.
@@ -14681,18 +14678,12 @@ class LlamaCppBackend:
 
         pick = _pick_mtp if allow_nested else _pick_mtp_root_only
 
-        # The borrowing head already in the snapshot, kept as the fallback: it is a
-        # working drafter, just an unmeasurable one, so a listing that never answers
-        # must not cost the load its speculation entirely.
         borrowed_cached: Optional[str] = None
         if near_path:
             cached = _companion_snapshot_sibling(near_path, pick)
             if cached and _mtp_head_borrows(cached) and not _hf_env_offline():
-                # The snapshot holds only a head the earlier picker chose, the
-                # borrowing form, which llama-server's --fit cannot measure
-                # (unsloth#10322). The live listing ranks the self-contained
-                # head above it, and hf_hub_download reuses this file if the
-                # repo turns out to publish nothing better.
+                # --fit cannot measure a borrowing head, so the MTP context OOMs
+                # (unsloth#10322). hf_hub_download reuses this file if nothing is better.
                 logger.info(
                     "Cached MTP drafter borrows the target's embeddings; checking the "
                     "repo for a self-contained head: %s",
@@ -14724,14 +14715,10 @@ class LlamaCppBackend:
             label = "MTP drafter",
             cancel_event = cancel_event,
             near_path = near_path,
-            # Suppressed only when this call is the fall-through: the helper would
-            # otherwise repeat the snapshot lookup above and return the same
-            # borrowing head before it ever lists the repo.
             reuse_snapshot_sibling = borrowed_cached is None,
         )
         if fetched is None and borrowed_cached is not None:
-            # The repo publishes nothing better, or the Hub never answered. An
-            # unmeasurable drafter still drafts; no drafter at all is the bigger loss.
+            # An unmeasurable drafter still drafts; no drafter at all is the bigger loss.
             logger.info("Keeping the cached borrowing MTP drafter: %s", borrowed_cached)
             return borrowed_cached
         return fetched

--- a/studio/backend/tests/test_kv_cache_estimate_route.py
+++ b/studio/backend/tests/test_kv_cache_estimate_route.py
@@ -277,19 +277,19 @@ class TestDrafterDiscoveryMatchesTheLoader:
         got, _ = models_routes._resolve_mtp_drafter(str(main))
         assert got == str(q8)
 
-    def test_nested_fallback_prefers_the_shared_head(self, tmp_path):
-        """A -shared- head borrows the target's token_embd/output instead of
-        carrying its own: 1.35 GB smaller at Q8_0 and no worse, accepting
-        identically to the full head (159 of 284) on the shipped prebuilt. Only
-        qwen4exp reaches this path, and its MTP graph and the borrow ship in the
-        same fork, so a build that can draft one carries the other."""
+    def test_nested_fallback_prefers_the_self_contained_head(self, tmp_path):
+        """A -shared- head borrows the target's token_embd/output and is 1.35 GB
+        smaller at Q8_0, but llama-server's --fit measures a draft by loading it
+        on its own, which the borrowing head cannot do. The fit then reserves
+        nothing for it, fills the card, and the MTP context fails to allocate
+        (unsloth#10322). So with both on disk the self-contained head wins."""
         snap = self._snapshot(tmp_path)
         main = _write_gguf(snap / "model-Q4_K_M.gguf", _MLA_NO_HEAD, arch = "qwen4exp")
-        _write_gguf(snap / "MTP" / "mtp-model-Q8_0.gguf", _MLA_NO_HEAD)
-        shared = _write_gguf(snap / "MTP" / "mtp-model-shared-Q8_0.gguf", _MLA_NO_HEAD)
+        full = _write_gguf(snap / "MTP" / "mtp-model-Q8_0.gguf", _MLA_NO_HEAD)
+        _write_gguf(snap / "MTP" / "mtp-model-shared-Q8_0.gguf", _MLA_NO_HEAD)
 
         got, _ = models_routes._resolve_mtp_drafter(str(main))
-        assert got == str(shared)
+        assert got == str(full)
 
     def test_precision_outranks_the_shared_preference(self, tmp_path):
         """Q8_0 first is the stronger rule: a shared bf16 head is both larger than

--- a/studio/backend/tests/test_kv_cache_estimate_route.py
+++ b/studio/backend/tests/test_kv_cache_estimate_route.py
@@ -278,11 +278,6 @@ class TestDrafterDiscoveryMatchesTheLoader:
         assert got == str(q8)
 
     def test_nested_fallback_prefers_the_self_contained_head(self, tmp_path):
-        """A -shared- head borrows the target's token_embd/output and is 1.35 GB
-        smaller at Q8_0, but llama-server's --fit measures a draft by loading it
-        on its own, which the borrowing head cannot do. The fit then reserves
-        nothing for it, fills the card, and the MTP context fails to allocate
-        (unsloth#10322). So with both on disk the self-contained head wins."""
         snap = self._snapshot(tmp_path)
         main = _write_gguf(snap / "model-Q4_K_M.gguf", _MLA_NO_HEAD, arch = "qwen4exp")
         full = _write_gguf(snap / "MTP" / "mtp-model-Q8_0.gguf", _MLA_NO_HEAD)

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -1494,8 +1494,10 @@ def test_cached_mtp_lookup_ranks_nested_copies_like_the_download(tmp_path, monke
     """Offline reuse must name the file the online picker names.
 
     Lexical order put mtp-Qwen3.8-Flash-Next-BF16.gguf first, so a cached user got
-    the 7.77 GB slowest head while a fresh install downloaded the 2.79 GB shared
-    Q8_0 one.
+    the 7.77 GB slowest head while a fresh install downloaded the Q8_0 one. Both
+    pickers now take the self-contained Q8_0 over the borrowing shared-Q8_0:
+    llama-server's --fit cannot measure a head that needs its target to load,
+    so it reserved nothing for it and the MTP context OOMed (unsloth#10322).
     """
     import core.inference.llama_cpp as llama_cpp_module
 
@@ -1515,7 +1517,7 @@ def test_cached_mtp_lookup_ranks_nested_copies_like_the_download(tmp_path, monke
 
     found = backend._cached_repo_mtp_drafter("unsloth/Qwen3.8-Flash-Next-GGUF")
     assert found is not None
-    assert Path(found).name == "mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf", (
+    assert Path(found).name == "mtp-Qwen3.8-Flash-Next-Q8_0.gguf", (
         f"offline reuse picked {Path(found).name}; the online picker takes "
         f"{llama_cpp_module._pick_mtp(published)}"
     )
@@ -1538,6 +1540,21 @@ def test_cached_mtp_lookup_rejects_non_drafters_parked_under_mtp(tmp_path, monke
     )
     backend = llama_cpp_module.LlamaCppBackend.__new__(llama_cpp_module.LlamaCppBackend)
     assert backend._cached_repo_mtp_drafter("some/repo") is None
+
+
+def test_local_scan_prefers_the_fit_measurable_head_over_the_smaller_shared_one(tmp_path):
+    """With both forms on disk the self-contained head wins even though it is
+    larger: --fit can measure it, and cannot measure the borrowing one."""
+    root = tmp_path / "local"
+    (root / "MTP").mkdir(parents = True)
+    for i in (1, 2, 3):
+        (root / f"Qwen3.8-Flash-Next-UD-IQ1_S-0000{i}-of-00003.gguf").write_bytes(b"x" * 64)
+    (root / "MTP" / "mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf").write_bytes(b"x" * 64)
+    (root / "MTP" / "mtp-Qwen3.8-Flash-Next-Q8_0.gguf").write_bytes(b"x" * 128)
+    found = detect_mtp_file(
+        str(root / "Qwen3.8-Flash-Next-UD-IQ1_S-00001-of-00003.gguf"), search_root = str(root)
+    )
+    assert found is not None and Path(found).name == "mtp-Qwen3.8-Flash-Next-Q8_0.gguf"
 
 
 def test_a_shared_head_pairs_with_its_target_in_the_local_scan(tmp_path):

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -755,6 +755,108 @@ def _seed_snapshot(tmp_path, names):
     return snap
 
 
+def _hub_snapshot(tmp_path, names):
+    """A snapshot in the layout _snapshot_dir_of recognises: .../snapshots/<rev>/."""
+    snap = tmp_path / "hub" / "models--unsloth--Qwen3.8-Flash-Next-GGUF" / "snapshots" / "abc"
+    for rel in names:
+        f = snap / rel
+        f.parent.mkdir(parents = True, exist_ok = True)
+        f.write_bytes(b"x")
+    return snap
+
+
+def _capture_companion_download(backend):
+    captured = {}
+
+    def _fake(
+        *,
+        hf_repo,
+        hf_token,
+        pick,
+        label,
+        cancel_event = None,
+        near_path = None,
+    ):
+        captured["pick"] = pick
+        captured["near_path"] = near_path
+        return "/downloaded/mtp-Qwen3.8-Flash-Next-Q8_0.gguf"
+
+    backend._download_companion_gguf = _fake
+    return captured
+
+
+def test_download_mtp_refetches_when_the_cache_holds_only_a_shared_head(tmp_path, monkeypatch):
+    """An install that downloaded before the picker changed holds only the
+    borrowing head. The snapshot sibling would hand it straight back and the
+    --fit under-reservation (unsloth#10322) would survive the upgrade, so
+    online a lone shared head falls through to the live listing."""
+    import utils.models.gguf_metadata as gm
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+    monkeypatch.setattr(gm, "read_gguf_nextn_predict_layers", lambda p: 0)
+    snap = _hub_snapshot(
+        tmp_path,
+        ["UD-IQ1_S/model.gguf", "MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"],
+    )
+    b = LlamaCppBackend()
+    captured = _capture_companion_download(b)
+
+    got = b._download_mtp(
+        hf_repo = "unsloth/Qwen3.8-Flash-Next-GGUF", near_path = str(snap / "UD-IQ1_S" / "model.gguf")
+    )
+    assert "pick" in captured, "a lone shared head was reused without consulting the repo"
+    assert got == "/downloaded/mtp-Qwen3.8-Flash-Next-Q8_0.gguf"
+
+
+def test_download_mtp_still_reuses_a_cached_self_contained_head(tmp_path, monkeypatch):
+    """The refetch is only for the borrowing form; a self-contained head on disk
+    is exactly what the picker would download, so no listing is needed."""
+    import utils.models.gguf_metadata as gm
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+    monkeypatch.setattr(gm, "read_gguf_nextn_predict_layers", lambda p: 0)
+    snap = _hub_snapshot(
+        tmp_path,
+        [
+            "UD-IQ1_S/model.gguf",
+            "MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf",
+            "MTP/mtp-Qwen3.8-Flash-Next-Q8_0.gguf",
+        ],
+    )
+    b = LlamaCppBackend()
+    captured = _capture_companion_download(b)
+
+    got = b._download_mtp(
+        hf_repo = "unsloth/Qwen3.8-Flash-Next-GGUF", near_path = str(snap / "UD-IQ1_S" / "model.gguf")
+    )
+    assert "pick" not in captured
+    assert got is not None and Path(got).name == "mtp-Qwen3.8-Flash-Next-Q8_0.gguf"
+
+
+def test_download_mtp_keeps_a_lone_shared_head_offline(tmp_path, monkeypatch):
+    """Offline there is nothing better to fetch, so the borrowing head is still
+    the drafter to launch rather than none at all."""
+    import utils.models.gguf_metadata as gm
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(gm, "read_gguf_nextn_predict_layers", lambda p: 0)
+    snap = _hub_snapshot(
+        tmp_path,
+        ["UD-IQ1_S/model.gguf", "MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"],
+    )
+    b = LlamaCppBackend()
+    captured = _capture_companion_download(b)
+
+    got = b._download_mtp(
+        hf_repo = "unsloth/Qwen3.8-Flash-Next-GGUF", near_path = str(snap / "UD-IQ1_S" / "model.gguf")
+    )
+    assert "pick" not in captured
+    assert got is not None and Path(got).name == "mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"
+
+
 def test_download_mtp_reuses_cached_root_drafter_offline(tmp_path, monkeypatch):
     import utils.models.model_config as mc
     from core.inference.llama_cpp import LlamaCppBackend
@@ -1365,14 +1467,16 @@ def test_detect_mtp_file_skips_incomplete_split_drafter(tmp_path):
 
 def test_detect_mtp_file_ranks_split_drafter_by_total_size(tmp_path):
     """Candidates collapse to shard 1, so a split copy must be summed or it
-    outranks a smaller single file."""
+    outranks a smaller single file. Same precision on both sides: precision
+    now ranks above size, as it does in the hub picker, so the size rule is
+    only reachable between copies of one tier."""
     weight = tmp_path / "model-Q4_0.gguf"
     weight.write_bytes(b"x")
     sub = tmp_path / "MTP"
     sub.mkdir()
     (sub / "mtp-model-Q8_0-00001-of-00002.gguf").write_bytes(b"x" * 90)
     (sub / "mtp-model-Q8_0-00002-of-00002.gguf").write_bytes(b"x" * 90)
-    smaller = sub / "mtp-model-BF16.gguf"
+    smaller = sub / "mtp-model-Q8_0.gguf"
     smaller.write_bytes(b"x" * 100)
 
     assert detect_mtp_file(str(weight)) == str(smaller.resolve())
@@ -1555,6 +1659,22 @@ def test_local_scan_prefers_the_fit_measurable_head_over_the_smaller_shared_one(
         str(root / "Qwen3.8-Flash-Next-UD-IQ1_S-00001-of-00003.gguf"), search_root = str(root)
     )
     assert found is not None and Path(found).name == "mtp-Qwen3.8-Flash-Next-Q8_0.gguf"
+
+
+def test_local_scan_keeps_precision_above_the_borrow_tiebreak(tmp_path):
+    """A self-contained bf16 head must not displace a shared Q8_0 one: the hub
+    picker ranks precision first, and reopening a downloaded model from disk
+    has to launch the same file the download chose."""
+    root = tmp_path / "local"
+    (root / "MTP").mkdir(parents = True)
+    for i in (1, 2, 3):
+        (root / f"Qwen3.8-Flash-Next-UD-IQ1_S-0000{i}-of-00003.gguf").write_bytes(b"x" * 64)
+    (root / "MTP" / "mtp-Qwen3.8-Flash-Next-BF16.gguf").write_bytes(b"x" * 512)
+    (root / "MTP" / "mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf").write_bytes(b"x" * 64)
+    found = detect_mtp_file(
+        str(root / "Qwen3.8-Flash-Next-UD-IQ1_S-00001-of-00003.gguf"), search_root = str(root)
+    )
+    assert found is not None and Path(found).name == "mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"
 
 
 def test_a_shared_head_pairs_with_its_target_in_the_local_scan(tmp_path):

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -689,6 +689,7 @@ def test_download_mtp_prefers_root_over_new_scheme_copies(monkeypatch):
         label,
         cancel_event = None,
         near_path = None,
+        reuse_snapshot_sibling = True,
     ):
         captured["pick"] = pick
         return None
@@ -776,9 +777,11 @@ def _capture_companion_download(backend):
         label,
         cancel_event = None,
         near_path = None,
+        reuse_snapshot_sibling = True,
     ):
         captured["pick"] = pick
         captured["near_path"] = near_path
+        captured["reuse_snapshot_sibling"] = reuse_snapshot_sibling
         return "/downloaded/mtp-Qwen3.8-Flash-Next-Q8_0.gguf"
 
     backend._download_companion_gguf = _fake
@@ -854,6 +857,89 @@ def test_download_mtp_keeps_a_lone_shared_head_offline(tmp_path, monkeypatch):
         hf_repo = "unsloth/Qwen3.8-Flash-Next-GGUF", near_path = str(snap / "UD-IQ1_S" / "model.gguf")
     )
     assert "pick" not in captured
+    assert got is not None and Path(got).name == "mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"
+
+
+def _stub_hub(monkeypatch, published, *, listing_fails = False):
+    """The live repo, without a network: listing plus the fetch, stubbed where
+    _download_companion_gguf really calls them, so the helper's own snapshot
+    lookup still runs against the files on disk."""
+    import huggingface_hub
+
+    import core.inference.llama_cpp as llama_cpp_module
+
+    def _list(repo, token = None):
+        if listing_fails:
+            raise ConnectionError("hub unreachable")
+        return list(published)
+
+    monkeypatch.setattr(huggingface_hub, "list_repo_files", _list)
+    monkeypatch.setattr(llama_cpp_module, "_hub_download_in_flight", lambda repo: False)
+    monkeypatch.setattr(
+        llama_cpp_module,
+        "hf_hub_download_with_xet_fallback",
+        lambda repo, fn, token, cancel_event = None, cache_dir = None: "/downloaded/" + fn,
+    )
+
+
+def test_download_mtp_lists_the_repo_past_the_helpers_own_snapshot_reuse(tmp_path, monkeypatch):
+    """The fall-through has to survive _download_companion_gguf.
+
+    The helper repeats _companion_snapshot_sibling with the same near_path and
+    the same pick before it lists anything, so passing the cached borrowing head
+    on to it returned that same file and the --fit under-reservation
+    (unsloth#10322) survived the upgrade untouched. Exercises the real helper
+    rather than replacing it, which is what hid this.
+    """
+    import utils.models.gguf_metadata as gm
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+    monkeypatch.setattr(gm, "read_gguf_nextn_predict_layers", lambda p: 0)
+    snap = _hub_snapshot(
+        tmp_path,
+        ["UD-IQ1_S/model.gguf", "MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"],
+    )
+    _stub_hub(
+        monkeypatch,
+        [
+            "UD-IQ1_S/model.gguf",
+            "MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf",
+            "MTP/mtp-Qwen3.8-Flash-Next-Q8_0.gguf",
+        ],
+    )
+
+    got = LlamaCppBackend()._download_mtp(
+        hf_repo = "unsloth/Qwen3.8-Flash-Next-GGUF",
+        near_path = str(snap / "UD-IQ1_S" / "model.gguf"),
+    )
+    assert got is not None and Path(got).name == "mtp-Qwen3.8-Flash-Next-Q8_0.gguf", (
+        f"the fall-through handed back {got}; the helper reused the snapshot copy "
+        f"before listing the repo"
+    )
+
+
+def test_download_mtp_keeps_the_borrowing_head_when_the_listing_never_answers(
+    tmp_path, monkeypatch
+):
+    """Suppressing the reuse must not cost the load its drafter: an unmeasurable
+    head still drafts, and a Hub that cannot be reached says nothing about what
+    the repo publishes."""
+    import utils.models.gguf_metadata as gm
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+    monkeypatch.setattr(gm, "read_gguf_nextn_predict_layers", lambda p: 0)
+    snap = _hub_snapshot(
+        tmp_path,
+        ["UD-IQ1_S/model.gguf", "MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"],
+    )
+    _stub_hub(monkeypatch, [], listing_fails = True)
+
+    got = LlamaCppBackend()._download_mtp(
+        hf_repo = "unsloth/Qwen3.8-Flash-Next-GGUF",
+        near_path = str(snap / "UD-IQ1_S" / "model.gguf"),
+    )
     assert got is not None and Path(got).name == "mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"
 
 
@@ -995,6 +1081,7 @@ def test_download_mtp_online_skips_cache_reuse(tmp_path, monkeypatch):
         label,
         cancel_event = None,
         near_path = None,
+        reuse_snapshot_sibling = True,
     ):
         reached["hit"] = True
         return None

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -789,10 +789,6 @@ def _capture_companion_download(backend):
 
 
 def test_download_mtp_refetches_when_the_cache_holds_only_a_shared_head(tmp_path, monkeypatch):
-    """An install that downloaded before the picker changed holds only the
-    borrowing head. The snapshot sibling would hand it straight back and the
-    --fit under-reservation (unsloth#10322) would survive the upgrade, so
-    online a lone shared head falls through to the live listing."""
     import utils.models.gguf_metadata as gm
     from core.inference.llama_cpp import LlamaCppBackend
 
@@ -813,8 +809,6 @@ def test_download_mtp_refetches_when_the_cache_holds_only_a_shared_head(tmp_path
 
 
 def test_download_mtp_still_reuses_a_cached_self_contained_head(tmp_path, monkeypatch):
-    """The refetch is only for the borrowing form; a self-contained head on disk
-    is exactly what the picker would download, so no listing is needed."""
     import utils.models.gguf_metadata as gm
     from core.inference.llama_cpp import LlamaCppBackend
 
@@ -839,8 +833,6 @@ def test_download_mtp_still_reuses_a_cached_self_contained_head(tmp_path, monkey
 
 
 def test_download_mtp_keeps_a_lone_shared_head_offline(tmp_path, monkeypatch):
-    """Offline there is nothing better to fetch, so the borrowing head is still
-    the drafter to launch rather than none at all."""
     import utils.models.gguf_metadata as gm
     from core.inference.llama_cpp import LlamaCppBackend
 
@@ -866,9 +858,7 @@ def _stub_hub(
     *,
     listing_fails = False,
 ):
-    """The live repo, without a network: listing plus the fetch, stubbed where
-    _download_companion_gguf really calls them, so the helper's own snapshot
-    lookup still runs against the files on disk."""
+    """The live repo without a network, stubbed below the helper's own snapshot lookup."""
     import huggingface_hub
 
     import core.inference.llama_cpp as llama_cpp_module
@@ -888,14 +878,8 @@ def _stub_hub(
 
 
 def test_download_mtp_lists_the_repo_past_the_helpers_own_snapshot_reuse(tmp_path, monkeypatch):
-    """The fall-through has to survive _download_companion_gguf.
-
-    The helper repeats _companion_snapshot_sibling with the same near_path and
-    the same pick before it lists anything, so passing the cached borrowing head
-    on to it returned that same file and the --fit under-reservation
-    (unsloth#10322) survived the upgrade untouched. Exercises the real helper
-    rather than replacing it, which is what hid this.
-    """
+    """The helper repeats _companion_snapshot_sibling before listing, so the caller's
+    fall-through returned the same borrowing head (unsloth#10322). Uses the real helper."""
     import utils.models.gguf_metadata as gm
     from core.inference.llama_cpp import LlamaCppBackend
 
@@ -927,9 +911,6 @@ def test_download_mtp_lists_the_repo_past_the_helpers_own_snapshot_reuse(tmp_pat
 def test_download_mtp_keeps_the_borrowing_head_when_the_listing_never_answers(
     tmp_path, monkeypatch
 ):
-    """Suppressing the reuse must not cost the load its drafter: an unmeasurable
-    head still drafts, and a Hub that cannot be reached says nothing about what
-    the repo publishes."""
     import utils.models.gguf_metadata as gm
     from core.inference.llama_cpp import LlamaCppBackend
 
@@ -1559,9 +1540,7 @@ def test_detect_mtp_file_skips_incomplete_split_drafter(tmp_path):
 
 def test_detect_mtp_file_ranks_split_drafter_by_total_size(tmp_path):
     """Candidates collapse to shard 1, so a split copy must be summed or it
-    outranks a smaller single file. Same precision on both sides: precision
-    now ranks above size, as it does in the hub picker, so the size rule is
-    only reachable between copies of one tier."""
+    outranks a smaller single file. Both sides are Q8_0: precision now outranks size."""
     weight = tmp_path / "model-Q4_0.gguf"
     weight.write_bytes(b"x")
     sub = tmp_path / "MTP"
@@ -1691,9 +1670,7 @@ def test_cached_mtp_lookup_ranks_nested_copies_like_the_download(tmp_path, monke
 
     Lexical order put mtp-Qwen3.8-Flash-Next-BF16.gguf first, so a cached user got
     the 7.77 GB slowest head while a fresh install downloaded the Q8_0 one. Both
-    pickers now take the self-contained Q8_0 over the borrowing shared-Q8_0:
-    llama-server's --fit cannot measure a head that needs its target to load,
-    so it reserved nothing for it and the MTP context OOMed (unsloth#10322).
+    pickers now take the self-contained head over the borrowing one (unsloth#10322).
     """
     import core.inference.llama_cpp as llama_cpp_module
 
@@ -1739,8 +1716,6 @@ def test_cached_mtp_lookup_rejects_non_drafters_parked_under_mtp(tmp_path, monke
 
 
 def test_local_scan_prefers_the_fit_measurable_head_over_the_smaller_shared_one(tmp_path):
-    """With both forms on disk the self-contained head wins even though it is
-    larger: --fit can measure it, and cannot measure the borrowing one."""
     root = tmp_path / "local"
     (root / "MTP").mkdir(parents = True)
     for i in (1, 2, 3):
@@ -1754,9 +1729,6 @@ def test_local_scan_prefers_the_fit_measurable_head_over_the_smaller_shared_one(
 
 
 def test_local_scan_keeps_precision_above_the_borrow_tiebreak(tmp_path):
-    """A self-contained bf16 head must not displace a shared Q8_0 one: the hub
-    picker ranks precision first, and reopening a downloaded model from disk
-    has to launch the same file the download chose."""
     root = tmp_path / "local"
     (root / "MTP").mkdir(parents = True)
     for i in (1, 2, 3):

--- a/studio/backend/tests/test_mtp_drafter_companion.py
+++ b/studio/backend/tests/test_mtp_drafter_companion.py
@@ -860,7 +860,12 @@ def test_download_mtp_keeps_a_lone_shared_head_offline(tmp_path, monkeypatch):
     assert got is not None and Path(got).name == "mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"
 
 
-def _stub_hub(monkeypatch, published, *, listing_fails = False):
+def _stub_hub(
+    monkeypatch,
+    published,
+    *,
+    listing_fails = False,
+):
     """The live repo, without a network: listing plus the fetch, stubbed where
     _download_companion_gguf really calls them, so the helper's own snapshot
     lookup still runs against the files on disk."""

--- a/studio/backend/tests/test_native_gguf_companion.py
+++ b/studio/backend/tests/test_native_gguf_companion.py
@@ -398,8 +398,10 @@ def test_status_provenance_survives_deleted_model_directory(tmp_path, monkeypatc
 
 
 def test_native_load_skips_rejected_mtp_candidate_for_next_one(tmp_path):
-    """MTP/ can hold several compatible copies. If the size-preferred one is
-    out of the grant, the next must be tried instead of disabling MTP."""
+    """MTP/ can hold several compatible copies. If the preferred one is out of
+    the grant, the next must be tried instead of disabling MTP. Both copies sit
+    at one precision, since precision ranks above size, so the smaller one is
+    the preferred candidate here."""
     quant_dir = tmp_path / "Q4_0"
     quant_dir.mkdir()
     weight = quant_dir / "model.gguf"
@@ -409,10 +411,10 @@ def test_native_load_skips_rejected_mtp_candidate_for_next_one(tmp_path):
     companion_dir = tmp_path / "MTP"
     companion_dir.mkdir()
     try:
-        (companion_dir / "mtp-model-Q4_0.gguf").symlink_to(outside)
+        (companion_dir / "mtp-model-Q8_0.gguf").symlink_to(outside)
     except OSError as exc:
         pytest.skip(f"symlinks unavailable: {exc}")
-    larger = companion_dir / "mtp-model-Q8_0.gguf"
+    larger = companion_dir / "mtp-model-Q8_0-00001-of-00001.gguf"
     larger.write_bytes(b"d" * 5000)
 
     def _usable(candidate: str) -> bool:

--- a/studio/backend/tests/test_native_gguf_companion.py
+++ b/studio/backend/tests/test_native_gguf_companion.py
@@ -398,10 +398,8 @@ def test_status_provenance_survives_deleted_model_directory(tmp_path, monkeypatc
 
 
 def test_native_load_skips_rejected_mtp_candidate_for_next_one(tmp_path):
-    """MTP/ can hold several compatible copies. If the preferred one is out of
-    the grant, the next must be tried instead of disabling MTP. Both copies sit
-    at one precision, since precision ranks above size, so the smaller one is
-    the preferred candidate here."""
+    """MTP/ can hold several copies: a preferred one out of the grant must not disable
+    MTP. Both are Q8_0 here, since precision now outranks size."""
     quant_dir = tmp_path / "Q4_0"
     quant_dir.mkdir()
     weight = quant_dir / "model.gguf"

--- a/studio/backend/utils/models/drafters/preference.py
+++ b/studio/backend/utils/models/drafters/preference.py
@@ -62,14 +62,9 @@ def mtp_precision_rank(name: str) -> int:
 def mtp_preference_key(name: str) -> tuple[int, int, str]:
     """Sort key picking the preferred MTP head by name alone.
 
-    The self-contained head wins the tie over the borrowing (``-shared-``) form.
-    llama-server's ``--fit`` budgets the draft by loading it on its own first,
-    and a head that borrows the target's token_embd/output refuses to load
-    without a target, so fit logs "failed to measure the memory of the extra
-    model, fitting without it", fills the device to its margin, and the MTP
-    context then fails to allocate (unsloth#10322, a 24 GB card with UD-Q3_K_XL
-    and UD-IQ1_M). The 1.35 GB the borrow saves at Q8_0 is not worth a launch
-    that only works when the card happens to have that much spare.
+    The self-contained head wins the tie over the borrowing (``-shared-``) form:
+    ``--fit`` budgets a draft by loading it alone, which a borrowing head cannot do,
+    so the MTP context OOMs (unsloth#10322). Worth the 1.35 GB it costs at Q8_0.
     """
     borrows = 1 if "shared" in Path(name).name.lower() else 0
     return mtp_precision_rank(name), borrows, Path(name).name.lower()

--- a/studio/backend/utils/models/drafters/preference.py
+++ b/studio/backend/utils/models/drafters/preference.py
@@ -62,12 +62,16 @@ def mtp_precision_rank(name: str) -> int:
 def mtp_preference_key(name: str) -> tuple[int, int, str]:
     """Sort key picking the preferred MTP head by name alone.
 
-    A head borrowing the target's token_embd/output wins the tie: 1.35 GB smaller
-    at Q8_0 and no worse, accepting identically (159 of 284) on the shipped
-    prebuilt. Only the qwen4exp path reaches a repo publishing both forms, and
-    qwen4exp MTP and the borrow ship in one fork, so the borrow always resolves.
+    The self-contained head wins the tie over the borrowing (``-shared-``) form.
+    llama-server's ``--fit`` budgets the draft by loading it on its own first,
+    and a head that borrows the target's token_embd/output refuses to load
+    without a target, so fit logs "failed to measure the memory of the extra
+    model, fitting without it", fills the device to its margin, and the MTP
+    context then fails to allocate (unsloth#10322, a 24 GB card with UD-Q3_K_XL
+    and UD-IQ1_M). The 1.35 GB the borrow saves at Q8_0 is not worth a launch
+    that only works when the card happens to have that much spare.
     """
-    borrows = 0 if "shared" in Path(name).name.lower() else 1
+    borrows = 1 if "shared" in Path(name).name.lower() else 0
     return mtp_precision_rank(name), borrows, Path(name).name.lower()
 
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1936,18 +1936,11 @@ def detect_mtp_file(
         return _drafter_split_is_complete(candidate)
 
     def _smallest_first(candidate: Path) -> tuple[int, int, int, int, str]:
-        # The same order the hub picker uses (mtp_preference_key), so a model
-        # reopened from its snapshot launches the head the download chose:
-        # precision first (Q8_0 drafts fastest, bf16 last), then the
-        # self-contained form over the borrowing (-shared-) one, then size,
-        # then name for stability. Split copies collapse to shard 1, so sum
-        # across their shards.
-        # The borrow tiebreak: a head that borrows the target's embeddings
-        # cannot be measured by llama-server's --fit, which loads the draft on
-        # its own; the fit then reserves nothing for it and the MTP context
-        # fails to allocate on a full card (unsloth#10322). It sits after
-        # precision so a self-contained bf16 head never displaces a shared
-        # Q8_0 one.
+        # The same order the hub picker uses (mtp_preference_key), so a snapshot
+        # reopen launches the head the download chose. --fit cannot measure a
+        # borrowing head, so it reserves nothing and the MTP context OOMs
+        # (unsloth#10322); that tiebreak sits after precision so a self-contained
+        # bf16 head never displaces a shared Q8_0 one. Sizes sum across shards.
         from utils.models.drafters.preference import mtp_precision_rank
 
         name = candidate.name.lower()

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1952,8 +1952,15 @@ def detect_mtp_file(
         # Family first, for the same reason as DSpark: both a base-family and a
         # release-specific sidecar prefix-match, and only the longer one is
         # really this weight's drafter.
+        # A head that borrows the target's embeddings (-shared-) cannot be
+        # measured by llama-server's --fit, which loads the draft on its own;
+        # the fit then reserves nothing for it and the MTP context fails to
+        # allocate on a full card (unsloth#10322). Prefer the self-contained
+        # form whenever both are on disk, before size.
+        borrows = 1 if "-shared-" in name else 0
         return (
             _drafter_stem_rank(candidate.name, kind = "mtp"),
+            borrows,
             _drafter_total_size(candidate),
             precision,
             name,

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1935,34 +1935,31 @@ def detect_mtp_file(
     def _launchable(candidate: Path) -> bool:
         return _drafter_split_is_complete(candidate)
 
-    def _smallest_first(candidate: Path) -> tuple[int, int, int, str]:
-        # Cheapest compatible copy wins. Size first: a fixed precision list ranked unknown quants
-        # behind BF16, so a small K-quant lost to a far larger BF16. Precision breaks size ties,
-        # name keeps it stable. Split copies collapse to shard 1, so sum across their shards.
-        # MTP prefers Q4_0 where DSpark prefers Q8_0, so the order is its own.
+    def _smallest_first(candidate: Path) -> tuple[int, int, int, int, str]:
+        # The same order the hub picker uses (mtp_preference_key), so a model
+        # reopened from its snapshot launches the head the download chose:
+        # precision first (Q8_0 drafts fastest, bf16 last), then the
+        # self-contained form over the borrowing (-shared-) one, then size,
+        # then name for stability. Split copies collapse to shard 1, so sum
+        # across their shards.
+        # The borrow tiebreak: a head that borrows the target's embeddings
+        # cannot be measured by llama-server's --fit, which loads the draft on
+        # its own; the fit then reserves nothing for it and the MTP context
+        # fails to allocate on a full card (unsloth#10322). It sits after
+        # precision so a self-contained bf16 head never displaces a shared
+        # Q8_0 one.
+        from utils.models.drafters.preference import mtp_precision_rank
+
         name = candidate.name.lower()
-        if "-q4_0" in name:
-            precision = 0
-        elif "-q8_0" in name:
-            precision = 1
-        elif "-bf16" in name or "-f16" in name:
-            precision = 2
-        else:
-            precision = 3
+        borrows = 1 if "-shared-" in name else 0
         # Family first, for the same reason as DSpark: both a base-family and a
         # release-specific sidecar prefix-match, and only the longer one is
         # really this weight's drafter.
-        # A head that borrows the target's embeddings (-shared-) cannot be
-        # measured by llama-server's --fit, which loads the draft on its own;
-        # the fit then reserves nothing for it and the MTP context fails to
-        # allocate on a full card (unsloth#10322). Prefer the self-contained
-        # form whenever both are on disk, before size.
-        borrows = 1 if "-shared-" in name else 0
         return (
             _drafter_stem_rank(candidate.name, kind = "mtp"),
+            mtp_precision_rank(name),
             borrows,
             _drafter_total_size(candidate),
-            precision,
             name,
         )
 


### PR DESCRIPTION
## Summary

Fixes #10322: MTP fails to load on a 24 GB card for Qwen3.8-Flash-Next with both the shared and the full head, and Studio then falls back to no speculative decoding.

The cause is an interaction between which head Studio picks and how llama-server's `--fit` prices a draft. `common/fit.cpp` measures the extra model by loading it standalone. The `mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf` head borrows `token_embd` and `output` from its target and cannot load on its own by design, so the fit logs

```
failed to measure the memory of the extra model, fitting without it: failed to load model
```

zeroes the draft's budget, fills VRAM to the margin, and the MTP context then fails to allocate its compute buffer. Studio's `mtp_preference_key` ranked the shared head first, so this was the default path for every Flash-Next user running with the fit on.

## Change

- `drafters/preference.py`: after precision, prefer the head whose name does not contain `shared`. Q8_0 still beats BF16 and a cached BF16 head still loses to a Q8_0 download.
- `models/model_config.py`: the local scan (`_smallest_first`) gets the same tiebreak before size, so a user with both heads on disk gets the same answer the hub picker gives.
- Tests updated to expect `mtp-Qwen3.8-Flash-Next-Q8_0.gguf`, plus a new local-scan test with both forms present.

The drafter's file size is already charged from the resolved path (`_get_gguf_size_bytes(_mtp_draft_for_budget)`), so the reserve follows the new choice without further change.

## Verification

Reproduced on a single B200 split into eight virtual devices (`GGML_CUDA_DEVICES=8`) to stand in for a 24 GB card. With the shared head the server log carries the `fitting without it` line above; with the self-contained head on the same device the draft loads and drafts (`draft acceptance = 0.51852 (28 accepted / 54 generated)`).

```
studio/backend: pytest tests/test_mtp_drafter_companion.py tests/test_llama_cpp_mtp_detection.py tests/test_kv_cache_estimate_route.py
638 passed
```

The shared head remains the right choice for a mainline llama.cpp that carries the borrow mechanism and is launched without `--fit`; that combination is not what Studio launches today.
