### PR TITLE
Docker publish: sync the Hub page with DOCKER_API_KEY on the namespace route

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -530,6 +530,13 @@ jobs:
   # hand. Synced from docker/DOCKERHUB.md whenever :latest moved, i.e. the same
   # condition as the stable tags above. Verified by reading it back, and a token
   # that cannot edit the description fails the job rather than warning.
+  #
+  # DOCKER_API_KEY cannot do this: the Hub answers a PATCH made with a JWT from an
+  # organization access token with 403 "token issued from organization access
+  # token is not allowed" (run 33943728004). Editing the description needs a
+  # PERSONAL access token of a user who owns or edits the repository, so it uses
+  # DOCKERHUB_README_USERNAME + DOCKERHUB_README_TOKEN and skips, visibly, until
+  # those are set.
   hub-readme:
     needs: merge-studio
     if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '' }}
@@ -544,14 +551,16 @@ jobs:
         run: |
           README=docker/DOCKERHUB.md
           test -s "$README"
-          # Organization access tokens are exchanged at /v2/auth/token, not
-          # /v2/users/login/, which rejects organization accounts.
+          if [ -z "${{ secrets.DOCKERHUB_README_TOKEN }}" ] || [ -z "${{ secrets.DOCKERHUB_README_USERNAME }}" ]; then
+            echo "::notice::DOCKERHUB_README_USERNAME / DOCKERHUB_README_TOKEN are not set, so the Docker Hub page was NOT updated from ${README}. Add a personal access token of a user who can edit ${IMAGE_NAME}; the organization token cannot."
+            exit 0
+          fi
           TOKEN="$(curl -sS -X POST https://hub.docker.com/v2/auth/token \
             -H 'Content-Type: application/json' \
-            -d "{\"identifier\": \"${REGISTRY_USERNAME}\", \"secret\": \"${{ secrets.DOCKER_API_KEY }}\"}" \
+            -d "{\"identifier\": \"${{ secrets.DOCKERHUB_README_USERNAME }}\", \"secret\": \"${{ secrets.DOCKERHUB_README_TOKEN }}\"}" \
             | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))')"
           if [ -z "$TOKEN" ]; then
-            echo "::error::Could not exchange DOCKER_API_KEY for a Hub API token; the Hub page was not updated."
+            echo "::error::Could not exchange DOCKERHUB_README_TOKEN for a Hub API token; the Hub page was not updated."
             exit 1
           fi
           BODY="$(python3 -c 'import json,sys; print(json.dumps({"full_description": open(sys.argv[1], encoding="utf-8").read()}))' "$README")"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -531,12 +531,11 @@ jobs:
   # condition as the stable tags above. Verified by reading it back, and a token
   # that cannot edit the description fails the job rather than warning.
   #
-  # DOCKER_API_KEY cannot do this: the Hub answers a PATCH made with a JWT from an
-  # organization access token with 403 "token issued from organization access
-  # token is not allowed" (run 33943728004). Editing the description needs a
-  # PERSONAL access token of a user who owns or edits the repository, so it uses
-  # DOCKERHUB_README_USERNAME + DOCKERHUB_README_TOKEN and skips, visibly, until
-  # those are set.
+  # Uses DOCKER_API_KEY on the namespace-scoped route. The legacy
+  # /v2/repositories/{owner}/{repo}/ path answers every organization access token
+  # with 403 "token issued from organization access token is not allowed" (run
+  # 33943728004), which is what failed this job on each publish before; the token
+  # also needs the repository edit permission.
   hub-readme:
     needs: merge-studio
     if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '' }}
@@ -551,29 +550,30 @@ jobs:
         run: |
           README=docker/DOCKERHUB.md
           test -s "$README"
-          if [ -z "${{ secrets.DOCKERHUB_README_TOKEN }}" ] || [ -z "${{ secrets.DOCKERHUB_README_USERNAME }}" ]; then
-            echo "::notice::DOCKERHUB_README_USERNAME / DOCKERHUB_README_TOKEN are not set, so the Docker Hub page was NOT updated from ${README}. Add a personal access token of a user who can edit ${IMAGE_NAME}; the organization token cannot."
-            exit 0
-          fi
+          # The organization token is only accepted on the namespace-scoped routes.
+          # The legacy /v2/repositories/{owner}/{repo}/ path answers every
+          # organization token with 403 "token issued from organization access token
+          # is not allowed", whatever its scopes. The token needs the repository
+          # edit permission on ${IMAGE_NAME}.
+          HUB="https://hub.docker.com/v2/namespaces/${IMAGE_NAME%%/*}/repositories/${IMAGE_NAME#*/}"
           TOKEN="$(curl -sS -X POST https://hub.docker.com/v2/auth/token \
             -H 'Content-Type: application/json' \
-            -d "{\"identifier\": \"${{ secrets.DOCKERHUB_README_USERNAME }}\", \"secret\": \"${{ secrets.DOCKERHUB_README_TOKEN }}\"}" \
+            -d "{\"identifier\": \"${{ env.REGISTRY_USERNAME }}\", \"secret\": \"${{ secrets.DOCKER_API_KEY }}\"}" \
             | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))')"
           if [ -z "$TOKEN" ]; then
-            echo "::error::Could not exchange DOCKERHUB_README_TOKEN for a Hub API token; the Hub page was not updated."
+            echo "::error::Could not exchange DOCKER_API_KEY for a Hub API token; the Hub page was not updated."
             exit 1
           fi
           BODY="$(python3 -c 'import json,sys; print(json.dumps({"full_description": open(sys.argv[1], encoding="utf-8").read()}))' "$README")"
-          CODE="$(curl -sS -o /tmp/hub_patch.json -w '%{http_code}' -X PATCH \
-            "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/" \
+          CODE="$(curl -sS -o /tmp/hub_patch.json -w '%{http_code}' -X PATCH "$HUB" \
             -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
             --data-binary "$BODY")"
           echo "PATCH returned HTTP ${CODE}"
           # Read it back rather than trusting the status code.
-          LIVE="$(curl -sS "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/" \
+          LIVE="$(curl -sS -H "Authorization: Bearer ${TOKEN}" "$HUB" \
             | python3 -c 'import json,sys; print(json.load(sys.stdin).get("full_description",""))')"
           if [ "$LIVE" != "$(cat "$README")" ]; then
-            echo "::error::The Hub page does not match ${README} after PATCH ${CODE}. The token most likely lacks permission to edit the repository description."
+            echo "::error::The Hub page does not match ${README} after PATCH ${CODE}. DOCKER_API_KEY most likely lacks the repository edit permission on ${IMAGE_NAME}."
             head -c 400 /tmp/hub_patch.json; echo
             exit 1
           fi

--- a/tests/python/test_docker_hub_readme.py
+++ b/tests/python/test_docker_hub_readme.py
@@ -80,6 +80,7 @@ def _run_sync(
     *,
     live_after_patch: str,
     token: str = "tok",
+    secret: str = "not-a-secret",
 ):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -101,7 +102,11 @@ def _run_sync(
     (bin_dir / "curl").chmod(0o755)
     (tmp_path / "docker").mkdir()
     shutil.copy(HUB_README, tmp_path / "docker" / "DOCKERHUB.md")
-    script = step.replace("${{ secrets.DOCKER_API_KEY }}", "not-a-secret")
+    # the secrets are GitHub expressions; the test decides whether they are "set"
+    script = (
+        step.replace("${{ secrets.DOCKERHUB_README_TOKEN }}", secret)
+        .replace("${{ secrets.DOCKERHUB_README_USERNAME }}", "readme-user" if secret else "")
+    )
     assert "${{" not in script, "unexpanded expression in the sync step"
     env = dict(os.environ)
     env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
@@ -140,3 +145,16 @@ def test_the_sync_fails_without_a_token(sync_job: dict, tmp_path: Path):
     res, log = _run_sync(step, tmp_path, live_after_patch = "", token = "")
     assert res.returncode != 0
     assert "PATCH" not in log, "a PATCH was attempted with an empty token"
+
+
+def test_the_sync_skips_visibly_without_the_personal_token(sync_job: dict, tmp_path: Path):
+    """The organization token cannot edit the page (403 "token issued from
+    organization access token is not allowed"), so the sync needs a personal token.
+    Until one is configured the job must not fail the publish, and must not stay
+    silent either: a notice names the secrets, and no PATCH is attempted."""
+    step = sync_job["steps"][-1]["run"]
+    res, log = _run_sync(step, tmp_path, live_after_patch = "# the old page", secret = "")
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "::notice::" in res.stdout and "DOCKERHUB_README_TOKEN" in res.stdout
+    assert "PATCH" not in log, "a PATCH was attempted without a personal token"
+    assert "auth/token" not in log

--- a/tests/python/test_docker_hub_readme.py
+++ b/tests/python/test_docker_hub_readme.py
@@ -155,4 +155,3 @@ def test_the_sync_fails_without_a_token(sync_job: dict, tmp_path: Path):
     res, log = _run_sync(step, tmp_path, live_after_patch = "", token = "")
     assert res.returncode != 0
     assert "PATCH" not in log, "a PATCH was attempted with an empty token"
-

--- a/tests/python/test_docker_hub_readme.py
+++ b/tests/python/test_docker_hub_readme.py
@@ -103,9 +103,8 @@ def _run_sync(
     (tmp_path / "docker").mkdir()
     shutil.copy(HUB_README, tmp_path / "docker" / "DOCKERHUB.md")
     # the secrets are GitHub expressions; the test decides whether they are "set"
-    script = (
-        step.replace("${{ secrets.DOCKERHUB_README_TOKEN }}", secret)
-        .replace("${{ secrets.DOCKERHUB_README_USERNAME }}", "readme-user" if secret else "")
+    script = step.replace("${{ secrets.DOCKERHUB_README_TOKEN }}", secret).replace(
+        "${{ secrets.DOCKERHUB_README_USERNAME }}", "readme-user" if secret else ""
     )
     assert "${{" not in script, "unexpanded expression in the sync step"
     env = dict(os.environ)

--- a/tests/python/test_docker_hub_readme.py
+++ b/tests/python/test_docker_hub_readme.py
@@ -102,9 +102,8 @@ def _run_sync(
     (bin_dir / "curl").chmod(0o755)
     (tmp_path / "docker").mkdir()
     shutil.copy(HUB_README, tmp_path / "docker" / "DOCKERHUB.md")
-    # the secrets are GitHub expressions; the test decides whether they are "set"
-    script = step.replace("${{ secrets.DOCKERHUB_README_TOKEN }}", secret).replace(
-        "${{ secrets.DOCKERHUB_README_USERNAME }}", "readme-user" if secret else ""
+    script = step.replace("${{ secrets.DOCKER_API_KEY }}", secret).replace(
+        "${{ env.REGISTRY_USERNAME }}", "unsloth"
     )
     assert "${{" not in script, "unexpanded expression in the sync step"
     env = dict(os.environ)
@@ -126,8 +125,20 @@ def test_the_sync_patches_the_readme_and_confirms_it(sync_job: dict, tmp_path: P
     step = sync_job["steps"][-1]["run"]
     res, log = _run_sync(step, tmp_path, live_after_patch = HUB_README.read_text(encoding = "utf-8"))
     assert res.returncode == 0, res.stdout + res.stderr
-    assert "-X PATCH https://hub.docker.com/v2/repositories/unsloth/unsloth/" in log
+    assert "-X PATCH https://hub.docker.com/v2/namespaces/unsloth/repositories/unsloth" in log
     assert "Authorization: Bearer tok" in log
+    assert '"identifier": "unsloth"' in log, "the organization token authenticates as the org"
+
+
+def test_the_sync_never_touches_the_legacy_repository_route(sync_job: dict, tmp_path: Path):
+    """Docker Hub rejects every organization access token on
+    /v2/repositories/{owner}/{repo}/ with 403 "token issued from organization access
+    token is not allowed", whatever its scopes; only the namespace-scoped route
+    accepts it. That 403 failed the sync on every publish before this test existed."""
+    step = sync_job["steps"][-1]["run"]
+    _, log = _run_sync(step, tmp_path, live_after_patch = HUB_README.read_text(encoding = "utf-8"))
+    assert "/v2/repositories/" not in log
+    assert "/v2/namespaces/unsloth/repositories/unsloth" in log
 
 
 def test_the_sync_fails_when_the_page_did_not_change(sync_job: dict, tmp_path: Path):
@@ -145,15 +156,3 @@ def test_the_sync_fails_without_a_token(sync_job: dict, tmp_path: Path):
     assert res.returncode != 0
     assert "PATCH" not in log, "a PATCH was attempted with an empty token"
 
-
-def test_the_sync_skips_visibly_without_the_personal_token(sync_job: dict, tmp_path: Path):
-    """The organization token cannot edit the page (403 "token issued from
-    organization access token is not allowed"), so the sync needs a personal token.
-    Until one is configured the job must not fail the publish, and must not stay
-    silent either: a notice names the secrets, and no PATCH is attempted."""
-    step = sync_job["steps"][-1]["run"]
-    res, log = _run_sync(step, tmp_path, live_after_patch = "# the old page", secret = "")
-    assert res.returncode == 0, res.stdout + res.stderr
-    assert "::notice::" in res.stdout and "DOCKERHUB_README_TOKEN" in res.stdout
-    assert "PATCH" not in log, "a PATCH was attempted without a personal token"
-    assert "auth/token" not in log


### PR DESCRIPTION
## Summary

The `hub-readme` job added in #10334 failed on every publish, including run 33943728004 (the one that published `:latest`), with:

```
403 {"message":"token issued from organization access token is not allowed"}
```

The cause is the route, not the token. Docker Hub rejects every organization access token on the legacy `/v2/repositories/{owner}/{repo}/` path regardless of its scopes. The namespace-scoped path `/v2/namespaces/{owner}/repositories/{repo}` accepts the same token once it has the repository edit permission. Verified against the live repository: GET 200, PATCH 200, and the page at hub.docker.com/r/unsloth/unsloth now shows `docker/DOCKERHUB.md`.

## The change

- The job keeps using `DOCKER_API_KEY`, exchanged at `/v2/auth/token` as the organization, and PATCHes the namespace route.
- The read-back that guards against a green job with a stale page goes through the same route with the same token.
- No new secrets. The personal-token secrets and the exit-0 skip notice from the earlier revision of this PR are gone; a token that cannot edit the page fails the job, as #10334 intended.

## Tests

The stubbed-curl tests assert the namespace route, the organization identifier in the token exchange, and that the legacy repository path is never requested. 24 of 24 pass together with the existing workflow tests.
