### PR TITLE
studio: KV preemption by slot checkpointing, an experiment beside #10301

### DIFF
--- a/studio/backend/core/inference/kv_swap.py
+++ b/studio/backend/core/inference/kv_swap.py
@@ -559,3 +559,37 @@ def reset_kv_swap_controllers() -> None:
         _CONTROLLERS.clear()
     for controller in controllers:
         controller.sweep()
+
+
+def make_http_post(
+    base_url: str,
+    auth_headers: Optional[dict] = None,
+    timeout: float = 30.0,
+) -> Callable[..., object]:
+    """Build the ``http_post`` a controller uses to drive ``/slots/{id}?action=...``.
+
+    Kept out of :class:`KvSwapController` so the controller stays importable and testable
+    without httpx, and so the tests can drive it with a fake server.
+    """
+    import httpx  # noqa: WPS433 - deferred exactly as the rest of this backend does
+
+    def _post(*, slot: int, action: str, body: dict):
+        response = httpx.post(
+            f"{base_url}/slots/{int(slot)}",
+            params = {"action": action},
+            json = body or {},
+            headers = auth_headers,
+            timeout = timeout,
+            trust_env = False,
+        )
+        if response.status_code != 200:
+            raise KvSwapError(
+                f"slot {slot} {action} returned HTTP {response.status_code}: "
+                f"{response.text[:200]}"
+            )
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise KvSwapError(f"slot {slot} {action} returned a non-JSON body") from exc
+
+    return _post

--- a/studio/backend/core/inference/kv_swap.py
+++ b/studio/backend/core/inference/kv_swap.py
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""KV-cache checkpoint swapping for local llama-server generation requests.
+
+Admission control (``llama_admission``) decides how many chats may hold a slot.
+This module decides what happens when the chats that already hold one no longer
+fit together in the shared KV cache: instead of failing the newest with
+"Context size has been exceeded", one chat keeps decoding and the others have
+their KV written out with llama-server's slot state API, freeing the cells until
+there is room again.
+
+The mechanism, and why it is shaped this way, rests on four measured facts about
+llama-server b10715 (see ``plans/impl_v2_slot_swap.md`` for the probes):
+
+1. ``POST /slots/{id}?action=save`` writes the slot's sequence to
+   ``--slot-save-path``; ``erase`` frees the cells; ``restore`` reads it back into
+   ANY free slot, not only the one it came from.
+2. After restoring an N-token save, a resume prompt hits the restored cells only
+   if its first N tokens are the saved sequence AND it is at least N+1 tokens
+   long. Exactly N tokens, or fewer, re-prefills from scratch: this build has no
+   prefix-truncation reuse.
+3. A request that ends cleanly leaves the caller holding exactly KV+1 tokens,
+   because the last sampled token is not fed until the next decode. So a clean
+   generation boundary is the only place where (2) is satisfied for free.
+4. A stream aborted mid-flight leaves the KV 4-5 tokens AHEAD of the caller (the
+   in-flight speculative batch), and draining does not close the gap. Preempting
+   mid-generation therefore cannot resume without recompute, and falls back.
+
+So generation is issued in bounded chunks and the chunk boundary is the
+preemption point. Nothing here knows about FastAPI, SSE or the route shape; it
+coordinates state and talks to llama-server over HTTP.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+
+# Mirrors llama_admission: dataclass(slots=True) is 3.10+, this package declares >=3.9.
+_SLOTS = {"slots": True} if sys.version_info >= (3, 10) else {}
+
+
+KV_SWAP_ENV = "UNSLOTH_LLAMA_KV_SWAP"
+KV_SWAP_CHUNK_ENV = "UNSLOTH_LLAMA_KV_SWAP_CHUNK"
+KV_SWAP_BUFFER_ENV = "UNSLOTH_LLAMA_KV_SWAP_BUFFER"
+KV_SWAP_EVERY_ENV = "UNSLOTH_LLAMA_KV_SWAP_EVERY"
+
+# 512 costs +0.86% on a 1536-token generation, 1024 +0.72%, 256 +3.41%. 512 keeps the
+# pause granularity useful without paying for it; and chunking is armed only when more
+# than one chat is active, so a solo chat runs unbounded and pays nothing at all.
+DEFAULT_CHUNK_TOKENS = 512
+
+# Per slot, the KV runs 4-5 tokens ahead of what the client has seen while a speculative
+# batch is in flight. Three tokens of margin on top of the configured draft depth covers
+# the observed lead; the total is multiplied by the slot count because every slot can be
+# mid-batch at once. Raise only on an observed failure, and record the failure.
+DEFAULT_DRAFT_MARGIN = 3
+
+# llama_state_seq_save_file header, verified byte-for-byte against the token ids the
+# server streamed back: magic, version, then n_token_count at offset 20 and the ids at 24.
+SLOT_FILE_MAGIC = 0x67677371  # 'ggsq'
+SLOT_FILE_VERSIONS = (3,)
+_SLOT_FILE_COUNT_OFFSET = 20
+_SLOT_FILE_TOKENS_OFFSET = 24
+
+# States a swappable chat moves through.
+RUNNING = "running"
+PAUSED = "paused"
+RESTORING = "restoring"
+DONE = "done"
+
+# A chat that has been swapped this many times in a row is protected while any other
+# candidate exists, so one unlucky chat cannot be starved by a steady stream of rivals.
+SWAP_STREAK_PROTECT = 3
+
+
+class KvSwapError(RuntimeError):
+    """A swap could not be completed; the caller falls back to re-prefill."""
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if value in ("1", "true", "yes", "on"):
+        return True
+    if value in ("0", "false", "no", "off"):
+        return False
+    return default
+
+
+def _int_env(name: str, default: int, minimum: int = 0) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+    return value if value >= minimum else default
+
+
+def kv_swap_enabled() -> bool:
+    """Rollout switch. Default on; ``UNSLOTH_LLAMA_KV_SWAP=0`` restores plain admission."""
+    return _bool_env(KV_SWAP_ENV, True)
+
+
+def kv_swap_chunk_tokens() -> int:
+    """Upstream ``max_tokens`` per generation chunk. 0 disables chunking entirely."""
+    return _int_env(KV_SWAP_CHUNK_ENV, DEFAULT_CHUNK_TOKENS, minimum = 0)
+
+
+def kv_swap_force_every() -> int:
+    """Test knob: force a swap every N generated tokens. 0 (default) means never."""
+    return _int_env(KV_SWAP_EVERY_ENV, 0, minimum = 0)
+
+
+def default_buffer_tokens(n_parallel: int, draft_n_max: int) -> int:
+    """Smallest buffer that covers the in-flight speculative lead on every slot.
+
+    The KV runs ahead of the caller by the draft batch that is mid-flight. Every slot can
+    be mid-batch simultaneously, so the reserve is per-slot and summed. An explicit
+    ``UNSLOTH_LLAMA_KV_SWAP_BUFFER`` overrides it.
+    """
+    override = _int_env(KV_SWAP_BUFFER_ENV, -1, minimum = 0)
+    if override >= 0:
+        return override
+    slots = max(1, int(n_parallel or 1))
+    draft = max(0, int(draft_n_max or 0))
+    return slots * (draft + DEFAULT_DRAFT_MARGIN)
+
+
+def parse_slot_file_tokens(path) -> List[int]:
+    """Return the exact token ids a saved slot file holds.
+
+    The saved sequence, not what the client saw, is what the restored cells contain, and
+    fact (2) above means the resume prompt has to line up with it exactly. Raises
+    :class:`KvSwapError` on anything unexpected so the caller can fall back rather than
+    resume onto a mismatched cache.
+    """
+    try:
+        with open(path, "rb") as handle:
+            head = handle.read(_SLOT_FILE_TOKENS_OFFSET)
+            if len(head) < _SLOT_FILE_TOKENS_OFFSET:
+                raise KvSwapError(f"slot file {path} is truncated ({len(head)} bytes)")
+            magic, version = struct.unpack_from("<II", head, 0)
+            if magic != SLOT_FILE_MAGIC:
+                raise KvSwapError(f"slot file {path} has magic 0x{magic:08x}, expected 0x{SLOT_FILE_MAGIC:08x}")
+            if version not in SLOT_FILE_VERSIONS:
+                raise KvSwapError(f"slot file {path} has version {version}, expected one of {SLOT_FILE_VERSIONS}")
+            (count,) = struct.unpack_from("<I", head, _SLOT_FILE_COUNT_OFFSET)
+            if count <= 0:
+                raise KvSwapError(f"slot file {path} reports {count} tokens")
+            raw = handle.read(4 * count)
+            if len(raw) < 4 * count:
+                raise KvSwapError(f"slot file {path} holds {len(raw) // 4} of {count} tokens")
+            return list(struct.unpack(f"<{count}i", raw))
+    except KvSwapError:
+        raise
+    except OSError as exc:
+        raise KvSwapError(f"slot file {path} could not be read: {exc}") from exc
+
+
+def resume_prompt_is_valid(saved: Sequence[int], resume: Sequence[int]) -> bool:
+    """Whether ``resume`` will land on cells restored from ``saved`` instead of re-prefilling.
+
+    Fact (2): the saved sequence must be a PROPER prefix of the resume prompt. Equal
+    length re-prefills just as surely as a mismatch does, which is the trap this guards.
+    """
+    if not saved or len(resume) <= len(saved):
+        return False
+    return list(resume[:len(saved)]) == list(saved)
+
+
+@dataclass(**_SLOTS)
+class KvSwapChat:
+    """One admitted chat's swap state."""
+
+    chat_id: str
+    slot: Optional[int] = None
+    prompt_tokens: int = 0
+    generated_tokens: int = 0
+    state: str = RUNNING
+    swap_streak: int = 0
+    swaps_total: int = 0
+    filename: Optional[str] = None
+    saved_tokens: int = 0
+    admitted_at: float = field(default_factory = time.monotonic)
+    last_restore_ms: float = 0.0
+    last_resume_prompt_n: Optional[int] = None
+
+    @property
+    def resident(self) -> int:
+        """Cells this chat occupies: its prompt plus everything generated so far."""
+        if self.state in (PAUSED, DONE):
+            return 0
+        return max(0, self.prompt_tokens) + max(0, self.generated_tokens)
+
+    @property
+    def size(self) -> int:
+        """Cells it needs when running, whether or not it currently holds them."""
+        return max(0, self.prompt_tokens) + max(0, self.generated_tokens)
+
+
+@dataclass(**_SLOTS)
+class KvSwapDecision:
+    """What the controller wants done at one pressure check."""
+
+    victims: List[str] = field(default_factory = list)
+    keep: Optional[str] = None
+    resident: int = 0
+    budget: int = 0
+    reason: str = ""
+
+
+class KvSwapController:
+    """Live KV accounting and the swap policy for one llama-server backend.
+
+    Thread-safe: the tool loop drives generation from an executor thread while the route
+    runs on the event loop, so every mutation takes ``_lock``. Nothing here blocks on I/O
+    while holding it - the HTTP calls are made by the caller through the injected
+    ``http_post``, outside the lock.
+    """
+
+    def __init__(
+        self,
+        key: str,
+        *,
+        n_ctx: int,
+        n_parallel: int,
+        draft_n_max: int = 0,
+        save_dir: Optional[str] = None,
+        http_post: Optional[Callable[..., object]] = None,
+    ) -> None:
+        self.key = key
+        self._lock = threading.Lock()
+        self._chats: Dict[str, KvSwapChat] = {}
+        self.n_ctx = max(0, int(n_ctx or 0))
+        self.n_parallel = max(1, int(n_parallel or 1))
+        self.draft_n_max = max(0, int(draft_n_max or 0))
+        self.save_dir = save_dir
+        self._http_post = http_post
+        self._token = uuid.uuid4().hex[:8]
+        self.swaps_out = 0
+        self.swaps_in = 0
+        self.fallbacks = 0
+
+    # ---------------------------------------------------------------- accounting
+
+    @property
+    def buffer_tokens(self) -> int:
+        return default_buffer_tokens(self.n_parallel, self.draft_n_max)
+
+    @property
+    def budget(self) -> int:
+        """Cells the chats may share: the context minus the smallest safe reserve."""
+        return max(0, self.n_ctx - self.buffer_tokens)
+
+    def admit(self, chat_id: str, *, prompt_tokens: int = 0, slot: Optional[int] = None) -> KvSwapChat:
+        with self._lock:
+            chat = self._chats.get(chat_id)
+            if chat is None:
+                chat = KvSwapChat(chat_id = chat_id)
+                self._chats[chat_id] = chat
+            chat.prompt_tokens = max(0, int(prompt_tokens or 0))
+            chat.slot = slot
+            chat.state = RUNNING
+            return chat
+
+    def update(self, chat_id: str, *, prompt_tokens: Optional[int] = None,
+               generated_tokens: Optional[int] = None) -> None:
+        with self._lock:
+            chat = self._chats.get(chat_id)
+            if chat is None:
+                return
+            if prompt_tokens is not None:
+                chat.prompt_tokens = max(0, int(prompt_tokens))
+            if generated_tokens is not None:
+                chat.generated_tokens = max(0, int(generated_tokens))
+
+    def finish(self, chat_id: str) -> None:
+        with self._lock:
+            chat = self._chats.pop(chat_id, None)
+        if chat is not None:
+            chat.state = DONE
+
+    def get(self, chat_id: str) -> Optional[KvSwapChat]:
+        with self._lock:
+            return self._chats.get(chat_id)
+
+    def resident_total(self) -> int:
+        with self._lock:
+            return sum(chat.resident for chat in self._chats.values())
+
+    def active_count(self) -> int:
+        """Chats holding cells right now. Chunking is armed only above one."""
+        with self._lock:
+            return sum(1 for chat in self._chats.values() if chat.state == RUNNING)
+
+    def reconcile(self, slots_payload: Sequence[dict]) -> None:
+        """Correct the running totals against llama-server's own ``/slots`` readout.
+
+        The stream tells us what was emitted; the server knows what it actually holds, and
+        the two differ by the in-flight speculative batch. Ground truth wins.
+        """
+        by_slot: Dict[int, int] = {}
+        for entry in slots_payload or []:
+            try:
+                by_slot[int(entry.get("id"))] = max(0, int(entry.get("n_prompt_tokens") or 0))
+            except (TypeError, ValueError):
+                continue
+        with self._lock:
+            for chat in self._chats.values():
+                if chat.state != RUNNING or chat.slot is None:
+                    continue
+                held = by_slot.get(chat.slot)
+                if held is None or held <= 0:
+                    continue
+                # Keep the split between prompt and generated, but make the sum truthful.
+                drift = held - chat.size
+                if drift:
+                    chat.generated_tokens = max(0, chat.generated_tokens + drift)
+
+    # ------------------------------------------------------------------- policy
+
+    def plan(self, *, incoming: int = 0, incoming_id: Optional[str] = None) -> KvSwapDecision:
+        """Choose who keeps decoding and who is swapped out.
+
+        Keep the chat with the most tokens: it is furthest from done and the costliest to
+        move. Swap the others newest-first, never the last one standing, and skip a chat
+        that has been swapped ``SWAP_STREAK_PROTECT`` times running while another
+        candidate is available.
+        """
+        with self._lock:
+            running = [c for c in self._chats.values() if c.state == RUNNING]
+            resident = sum(c.resident for c in running)
+            budget = self.budget
+            need = resident + max(0, int(incoming or 0))
+            decision = KvSwapDecision(resident = resident, budget = budget)
+            if budget <= 0 or need <= budget or len(running) <= 1:
+                decision.reason = "fits" if need <= budget else "single-chat"
+                if running:
+                    decision.keep = max(running, key = lambda c: c.size).chat_id
+                return decision
+
+            keeper = max(running, key = lambda c: (c.size, -c.admitted_at))
+            decision.keep = keeper.chat_id
+            # Newest first: the youngest chat has the least invested and the least to lose.
+            candidates = [c for c in running if c.chat_id != keeper.chat_id]
+            candidates.sort(key = lambda c: c.admitted_at, reverse = True)
+
+            protected = [c for c in candidates if c.swap_streak >= SWAP_STREAK_PROTECT]
+            preferred = [c for c in candidates if c.swap_streak < SWAP_STREAK_PROTECT]
+            # Protected chats are only touched once nothing else is left to give.
+            ordered = preferred + protected
+
+            freed = 0
+            for chat in ordered:
+                if need - freed <= budget:
+                    break
+                if len(running) - len(decision.victims) <= 1:
+                    break
+                decision.victims.append(chat.chat_id)
+                freed += chat.resident
+            decision.reason = "pressure" if decision.victims else "no-candidate"
+            return decision
+
+    # -------------------------------------------------------------------- swaps
+
+    def _post(self, slot: int, action: str, filename: Optional[str] = None):
+        if self._http_post is None:
+            raise KvSwapError("no HTTP transport configured for slot state calls")
+        body = {"filename": filename} if filename else {}
+        return self._http_post(slot = slot, action = action, body = body)
+
+    def swap_out(self, chat_id: str) -> KvSwapChat:
+        """Write the chat's KV out and free its cells.
+
+        Save first, erase only once the save is known good: an erase after a failed save
+        would throw the conversation away, and the fallback is meant to cost recompute,
+        never content.
+        """
+        chat = self.get(chat_id)
+        if chat is None:
+            raise KvSwapError(f"unknown chat {chat_id}")
+        if chat.slot is None:
+            raise KvSwapError(f"chat {chat_id} is not pinned to a slot")
+        if chat.state != RUNNING:
+            raise KvSwapError(f"chat {chat_id} is {chat.state}, not {RUNNING}")
+
+        filename = f"kvswap-{self._token}-{chat_id}-{uuid.uuid4().hex[:6]}.bin"
+        saved = self._post(chat.slot, "save", filename)
+        n_saved = 0
+        if isinstance(saved, dict):
+            try:
+                n_saved = int(saved.get("n_saved") or 0)
+            except (TypeError, ValueError):
+                n_saved = 0
+        if n_saved <= 0:
+            self._discard(filename)
+            raise KvSwapError(f"chat {chat_id} saved {n_saved} tokens")
+
+        self._post(chat.slot, "erase")
+        with self._lock:
+            chat.state = PAUSED
+            chat.filename = filename
+            chat.saved_tokens = n_saved
+            chat.swap_streak += 1
+            chat.swaps_total += 1
+            chat.slot = None
+            self.swaps_out += 1
+        return chat
+
+    def swap_in(self, chat_id: str, slot: int) -> KvSwapChat:
+        """Read the chat's KV back into ``slot``.
+
+        ``restore`` accepts any free slot id, so a chat does not have to wait for the one
+        it left. The caller must still re-issue with ``id_slot = slot`` and a resume prompt
+        that satisfies :func:`resume_prompt_is_valid`.
+        """
+        chat = self.get(chat_id)
+        if chat is None:
+            raise KvSwapError(f"unknown chat {chat_id}")
+        if chat.state != PAUSED or not chat.filename:
+            raise KvSwapError(f"chat {chat_id} is {chat.state} with no checkpoint")
+        with self._lock:
+            chat.state = RESTORING
+        started = time.monotonic()
+        try:
+            restored = self._post(slot, "restore", chat.filename)
+        except Exception:
+            with self._lock:
+                chat.state = PAUSED
+            raise
+        n_restored = 0
+        if isinstance(restored, dict):
+            try:
+                n_restored = int(restored.get("n_restored") or 0)
+            except (TypeError, ValueError):
+                n_restored = 0
+        if n_restored != chat.saved_tokens:
+            with self._lock:
+                chat.state = PAUSED
+            raise KvSwapError(
+                f"chat {chat_id} restored {n_restored} of {chat.saved_tokens} tokens"
+            )
+        with self._lock:
+            chat.state = RUNNING
+            chat.slot = slot
+            chat.last_restore_ms = (time.monotonic() - started) * 1000.0
+            self.swaps_in += 1
+        return chat
+
+    def note_resume(self, chat_id: str, prompt_n: Optional[int]) -> None:
+        """Record the prefill the resume actually cost. 1 means the checkpoint paid off."""
+        with self._lock:
+            chat = self._chats.get(chat_id)
+            if chat is not None:
+                chat.last_resume_prompt_n = prompt_n
+
+    def note_progress(self, chat_id: str) -> None:
+        """A chat that ran a full chunk without being swapped is no longer on a streak."""
+        with self._lock:
+            chat = self._chats.get(chat_id)
+            if chat is not None:
+                chat.swap_streak = 0
+
+    def fall_back(self, chat_id: str) -> None:
+        """Give up the checkpoint for this chat; resume will re-prefill instead."""
+        with self._lock:
+            chat = self._chats.get(chat_id)
+            self.fallbacks += 1
+            if chat is None:
+                return
+            filename = chat.filename
+            chat.filename = None
+            chat.saved_tokens = 0
+            if chat.state in (PAUSED, RESTORING):
+                chat.state = PAUSED
+        if filename:
+            self._discard(filename)
+
+    def _discard(self, filename: str) -> None:
+        if not self.save_dir or not filename:
+            return
+        try:
+            Path(self.save_dir, filename).unlink()
+        except OSError:
+            pass
+
+    def sweep(self) -> int:
+        """Delete every checkpoint this controller still owns. Returns the count."""
+        with self._lock:
+            names = [c.filename for c in self._chats.values() if c.filename]
+            for chat in self._chats.values():
+                chat.filename = None
+                chat.saved_tokens = 0
+        for name in names:
+            self._discard(name)
+        return len(names)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "key": self.key,
+                "n_ctx": self.n_ctx,
+                "n_parallel": self.n_parallel,
+                "buffer": self.buffer_tokens,
+                "budget": self.budget,
+                "resident": sum(c.resident for c in self._chats.values()),
+                "running": sum(1 for c in self._chats.values() if c.state == RUNNING),
+                "paused": sum(1 for c in self._chats.values() if c.state == PAUSED),
+                "swaps_out": self.swaps_out,
+                "swaps_in": self.swaps_in,
+                "fallbacks": self.fallbacks,
+            }
+
+
+_CONTROLLERS: Dict[str, KvSwapController] = {}
+_CONTROLLERS_LOCK = threading.Lock()
+
+
+def get_kv_swap_controller(key: str, **kwargs) -> KvSwapController:
+    """Process-wide registry, keyed like ``get_llama_admission_queue`` on the base URL.
+
+    A model reload relaunches llama-server on a fresh ephemeral port, so a new key means a
+    new controller and the old one is dropped along with its (already unlinked) files.
+    """
+    with _CONTROLLERS_LOCK:
+        controller = _CONTROLLERS.get(key)
+        if controller is None:
+            controller = KvSwapController(key, **kwargs)
+            _CONTROLLERS[key] = controller
+        else:
+            for name in ("n_ctx", "n_parallel", "draft_n_max", "save_dir"):
+                if name in kwargs and kwargs[name] is not None:
+                    setattr(controller, name, kwargs[name])
+        return controller
+
+
+def peek_kv_swap_controller(key: str) -> Optional[KvSwapController]:
+    with _CONTROLLERS_LOCK:
+        return _CONTROLLERS.get(key)
+
+
+def reset_kv_swap_controllers() -> None:
+    with _CONTROLLERS_LOCK:
+        controllers = list(_CONTROLLERS.values())
+        _CONTROLLERS.clear()
+    for controller in controllers:
+        controller.sweep()

--- a/studio/backend/core/inference/kv_swap.py
+++ b/studio/backend/core/inference/kv_swap.py
@@ -109,7 +109,11 @@ def _bool_env(name: str, default: bool) -> bool:
     return default
 
 
-def _int_env(name: str, default: int, minimum: int = 0) -> int:
+def _int_env(
+    name: str,
+    default: int,
+    minimum: int = 0,
+) -> int:
     raw = os.environ.get(name)
     if raw is None:
         return default
@@ -165,9 +169,13 @@ def parse_slot_file_tokens(path) -> List[int]:
                 raise KvSwapError(f"slot file {path} is truncated ({len(head)} bytes)")
             magic, version = struct.unpack_from("<II", head, 0)
             if magic != SLOT_FILE_MAGIC:
-                raise KvSwapError(f"slot file {path} has magic 0x{magic:08x}, expected 0x{SLOT_FILE_MAGIC:08x}")
+                raise KvSwapError(
+                    f"slot file {path} has magic 0x{magic:08x}, expected 0x{SLOT_FILE_MAGIC:08x}"
+                )
             if version not in SLOT_FILE_VERSIONS:
-                raise KvSwapError(f"slot file {path} has version {version}, expected one of {SLOT_FILE_VERSIONS}")
+                raise KvSwapError(
+                    f"slot file {path} has version {version}, expected one of {SLOT_FILE_VERSIONS}"
+                )
             (count,) = struct.unpack_from("<I", head, _SLOT_FILE_COUNT_OFFSET)
             if count <= 0:
                 raise KvSwapError(f"slot file {path} reports {count} tokens")
@@ -189,7 +197,7 @@ def resume_prompt_is_valid(saved: Sequence[int], resume: Sequence[int]) -> bool:
     """
     if not saved or len(resume) <= len(saved):
         return False
-    return list(resume[:len(saved)]) == list(saved)
+    return list(resume[: len(saved)]) == list(saved)
 
 
 @dataclass(**_SLOTS)
@@ -276,7 +284,13 @@ class KvSwapController:
         """Cells the chats may share: the context minus the smallest safe reserve."""
         return max(0, self.n_ctx - self.buffer_tokens)
 
-    def admit(self, chat_id: str, *, prompt_tokens: int = 0, slot: Optional[int] = None) -> KvSwapChat:
+    def admit(
+        self,
+        chat_id: str,
+        *,
+        prompt_tokens: int = 0,
+        slot: Optional[int] = None,
+    ) -> KvSwapChat:
         with self._lock:
             chat = self._chats.get(chat_id)
             if chat is None:
@@ -287,8 +301,13 @@ class KvSwapController:
             chat.state = RUNNING
             return chat
 
-    def update(self, chat_id: str, *, prompt_tokens: Optional[int] = None,
-               generated_tokens: Optional[int] = None) -> None:
+    def update(
+        self,
+        chat_id: str,
+        *,
+        prompt_tokens: Optional[int] = None,
+        generated_tokens: Optional[int] = None,
+    ) -> None:
         with self._lock:
             chat = self._chats.get(chat_id)
             if chat is None:
@@ -350,7 +369,12 @@ class KvSwapController:
 
     # ------------------------------------------------------------------- policy
 
-    def plan(self, *, incoming: int = 0, incoming_id: Optional[str] = None) -> KvSwapDecision:
+    def plan(
+        self,
+        *,
+        incoming: int = 0,
+        incoming_id: Optional[str] = None,
+    ) -> KvSwapDecision:
         """Choose who keeps decoding and who is swapped out.
 
         Keep the chat with the most tokens: it is furthest from done and the costliest to
@@ -404,14 +428,17 @@ class KvSwapController:
             chat = self._chats.get(chat_id)
             if chat is None:
                 return False
-            resident = sum(
-                c.resident for c in self._chats.values() if c.chat_id != chat_id
-            )
+            resident = sum(c.resident for c in self._chats.values() if c.chat_id != chat_id)
             return resident + chat.size <= self.budget
 
     # -------------------------------------------------------------------- swaps
 
-    def _post(self, slot: int, action: str, filename: Optional[str] = None):
+    def _post(
+        self,
+        slot: int,
+        action: str,
+        filename: Optional[str] = None,
+    ):
         if self._http_post is None:
             raise KvSwapError("no HTTP transport configured for slot state calls")
         body = {"filename": filename} if filename else {}
@@ -485,9 +512,7 @@ class KvSwapController:
         if n_restored != chat.saved_tokens:
             with self._lock:
                 chat.state = PAUSED
-            raise KvSwapError(
-                f"chat {chat_id} restored {n_restored} of {chat.saved_tokens} tokens"
-            )
+            raise KvSwapError(f"chat {chat_id} restored {n_restored} of {chat.saved_tokens} tokens")
         with self._lock:
             chat.state = RUNNING
             chat.slot = slot

--- a/studio/backend/core/inference/kv_swap.py
+++ b/studio/backend/core/inference/kv_swap.py
@@ -334,10 +334,17 @@ class KvSwapController:
                 if chat.state != RUNNING or chat.slot is None:
                     continue
                 held = by_slot.get(chat.slot)
-                if held is None or held <= 0:
+                if held is None:
+                    continue
+                if held <= 0:
+                    # The server released the slot: whatever this chat was holding is
+                    # gone. Skipping here instead would leave a finished chat counted as
+                    # resident and push the running total past the context for ever.
+                    chat.prompt_tokens = 0
+                    chat.generated_tokens = 0
                     continue
                 # Keep the split between prompt and generated, but make the sum truthful.
-                drift = held - chat.size
+                drift = min(held, self.n_ctx) - chat.size
                 if drift:
                     chat.generated_tokens = max(0, chat.generated_tokens + drift)
 

--- a/studio/backend/core/inference/kv_swap.py
+++ b/studio/backend/core/inference/kv_swap.py
@@ -87,6 +87,16 @@ class KvSwapError(RuntimeError):
     """A swap could not be completed; the caller falls back to re-prefill."""
 
 
+class KvSwapNothingToSave(KvSwapError):
+    """The slot held no cells, so there is nothing to free and nothing to pause for.
+
+    Not a failure. llama-server clears an idle slot into its own prompt cache when
+    --cache-idle-slots is on under a unified KV, which is the default, so a slot can
+    legitimately be empty at a round boundary. Pausing the chat then would make it
+    wait for room it is not using.
+    """
+
+
 def _bool_env(name: str, default: bool) -> bool:
     raw = os.environ.get(name)
     if raw is None:
@@ -375,6 +385,23 @@ class KvSwapController:
             decision.reason = "pressure" if decision.victims else "no-candidate"
             return decision
 
+    def can_resume(self, chat_id: str) -> bool:
+        """Whether the cells this chat needs are free right now.
+
+        Deliberately NOT "is the system unpressured": a paused chat that waits for every
+        other chat to fit as well waits for the whole queue to drain, which is how a
+        300 s resume timeout was first observed. It only has to fit ALONGSIDE what is
+        currently resident.
+        """
+        with self._lock:
+            chat = self._chats.get(chat_id)
+            if chat is None:
+                return False
+            resident = sum(
+                c.resident for c in self._chats.values() if c.chat_id != chat_id
+            )
+            return resident + chat.size <= self.budget
+
     # -------------------------------------------------------------------- swaps
 
     def _post(self, slot: int, action: str, filename: Optional[str] = None):
@@ -408,7 +435,7 @@ class KvSwapController:
                 n_saved = 0
         if n_saved <= 0:
             self._discard(filename)
-            raise KvSwapError(f"chat {chat_id} saved {n_saved} tokens")
+            raise KvSwapNothingToSave(f"chat {chat_id} holds no cells to free")
 
         self._post(chat.slot, "erase")
         with self._lock:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -625,6 +625,30 @@ _SPEC_KIND_CAPABILITY: dict[str, str] = {
 _LLAMA_RANDOM_SEED = 0xFFFFFFFF
 
 
+def _resolve_id_slot(id_slot) -> "Optional[int]":
+    """Resolve a slot pin that may be a plain id or a callable that supplies one.
+
+    The OpenAI route builds its generator before admission returns, so the slot is not
+    known at call time; passing a callable lets the payload builders read it on the first
+    round, by which point the lease exists. A callable that raises is treated as "no pin"
+    rather than failing the request: an unpinned run still generates, it just cannot be
+    checkpointed.
+    """
+    if id_slot is None:
+        return None
+    if callable(id_slot):
+        try:
+            id_slot = id_slot()
+        except Exception:
+            return None
+    if id_slot is None:
+        return None
+    try:
+        return int(id_slot)
+    except (TypeError, ValueError):
+        return None
+
+
 def _apply_seeded_llama_request(payload: dict, seed: Optional[int]) -> None:
     """Disable prompt caching for fixed seeds so repeated requests stay reproducible."""
     if seed is None:
@@ -26933,6 +26957,63 @@ class LlamaCppBackend:
         env = (os.environ.get("LLAMA_ARG_CACHE_PROMPT") or "").strip().lower()
         return env in _LLAMA_ARG_FALSE_VALUES
 
+    def read_slots_snapshot(self) -> list:
+        """What llama-server says each slot is holding right now, or [] if it will not say.
+
+        Ground truth for the KV ledger. The stream tells us what was emitted; the server
+        knows what it actually holds, and the two differ by the speculative batch that is
+        in flight. Never raises: a missing readout only costs accuracy.
+        """
+        if not self.is_loaded:
+            return []
+        try:
+            import httpx  # noqa: WPS433
+
+            response = httpx.get(
+                f"{self.base_url}/slots",
+                headers = self._auth_headers,
+                timeout = 5.0,
+                trust_env = False,
+            )
+            if response.status_code != 200:
+                return []
+            payload = response.json()
+            return payload if isinstance(payload, list) else []
+        except Exception:
+            return []
+
+    def kv_swap_controller(self):
+        """The KV checkpoint controller for this server, or None when it cannot be used.
+
+        Distinct from save_slots_for_resume() below, which snapshots every slot once so a
+        model reload can come back warm. This one moves a single chat's cells in and out
+        while other chats keep decoding, so it needs the live geometry: the context it is
+        sharing, how many slots share it, and how far the speculative draft runs ahead
+        (the buffer is sized from that lead).
+        """
+        from core.inference.kv_swap import (  # noqa: WPS433
+            get_kv_swap_controller,
+            kv_swap_enabled,
+            make_http_post,
+        )
+
+        if not kv_swap_enabled() or not self.is_loaded or not self._slot_save_dir:
+            return None
+        n_ctx = self._kv_cache_context_total or self.context_length
+        if not n_ctx:
+            return None
+        controller = get_kv_swap_controller(
+            self.base_url,
+            n_ctx = int(n_ctx),
+            n_parallel = self.effective_parallel_slots,
+            draft_n_max = int(self.spec_draft_n_max or 0),
+            save_dir = self._slot_save_dir,
+        )
+        # Rebound every call: a reload can relaunch llama-server with new auth on the
+        # same URL, and a stale header would fail every save with a 401.
+        controller._http_post = make_http_post(self.base_url, self._auth_headers)
+        return controller
+
     def save_slots_for_resume(
         self, should_abort: Optional[Callable[[], bool]] = None
     ) -> Optional[dict]:
@@ -28043,6 +28124,8 @@ class LlamaCppBackend:
         thread_id: Optional[str] = None,
         tools_withheld: bool = False,
         _allow_respawn_retry: bool = True,
+        # Pins this run to one llama-server slot, so a KV checkpoint can name it.
+        id_slot: Optional[int] = None,
     ) -> Generator[Union[str, dict], None, None]:
         """
         Send a chat completion to llama-server and stream tokens back.
@@ -28100,6 +28183,9 @@ class LlamaCppBackend:
             # llama-server applies the template; it rejects both flags set true.
             payload["continue_final_message"] = True
             payload["add_generation_prompt"] = False
+        _pinned_slot = _resolve_id_slot(id_slot)
+        if _pinned_slot is not None:
+            payload["id_slot"] = _pinned_slot
         # Default cap to the model context when known.
         payload["max_tokens"] = (
             max_tokens
@@ -28462,6 +28548,9 @@ class LlamaCppBackend:
         # MAY BLOCK: recost_waiting waits for cache room. Safe at the top of a round,
         # where the previous round's request has completed.
         on_conversation_grew: Optional[Callable[[list], None]] = None,
+        # Pins this run to one llama-server slot. Without it the server picks by LRU, and
+        # a KV checkpoint cannot know which slot to save. See core/inference/kv_swap.py.
+        id_slot: Optional[int] = None,
     ) -> Generator[dict, None, None]:
         """
         Agentic loop: let the model call tools, execute them, and continue.
@@ -29157,6 +29246,11 @@ class LlamaCppBackend:
                 "frequency_penalty": frequency_penalty,
             }
 
+            # Pinning is what makes a KV checkpoint addressable: the saver has to name a
+            # slot, and llama-server's own LRU would move this run between rounds.
+            _pinned_slot = _resolve_id_slot(id_slot)
+            if _pinned_slot is not None:
+                payload["id_slot"] = _pinned_slot
             # Progress events feed the first-token deadline; timings stay opt-in.
             payload["return_progress"] = True
             if perf_callback is not None:
@@ -31653,6 +31747,9 @@ class LlamaCppBackend:
             "presence_penalty": presence_penalty,
             "frequency_penalty": frequency_penalty,
         }
+        _pinned_slot = _resolve_id_slot(id_slot)
+        if _pinned_slot is not None:
+            stream_payload["id_slot"] = _pinned_slot
         if logit_bias:
             stream_payload["logit_bias"] = logit_bias
         if _reasoning_kw is not None:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -97,6 +97,7 @@ from core.inference.orchestrator import (
 )
 from core.inference.kv_swap import (
     KvSwapError,
+    KvSwapNothingToSave,
     peek_kv_swap_controller,
 )
 from core.inference.llama_admission import (
@@ -1711,7 +1712,7 @@ _OPENAI_LLAMA_ADMISSION_POLL_S = 0.25
 # How long a swapped-out chat waits for cells before giving up and re-prefilling, and how
 # often it re-checks. The poll is coarse because a swap-in costs ~11 ms: a tighter loop
 # would only burn the executor thread the tool loop needs back.
-_KV_SWAP_MAX_WAIT_S = 300.0
+_KV_SWAP_MAX_WAIT_S = 900.0
 _KV_SWAP_POLL_S = 0.25
 # SSE comments the chat UI already renders as "Paused while another chat finishes".
 _OPENAI_KV_SWAP_SSE_PAUSED = ": preempt-paused\n\n"
@@ -21531,27 +21532,68 @@ async def produce_openai_chat_completions(
                         controller.note_progress(_kv_swap_chat_id)
                         return
 
+                    chat = controller.get(_kv_swap_chat_id)
                     controller.swap_out(_kv_swap_chat_id)
                     _kv_swap_state["paused"] = True
                     _kv_swap_state["swaps"] += 1
+                    logger.info(
+                        "llama kv swap paused: chat=%s slot=%s saved=%d resident=%d "
+                        "budget=%d keep=%s",
+                        _kv_swap_chat_id, slot,
+                        chat.saved_tokens if chat is not None else -1,
+                        decision.resident, decision.budget, decision.keep,
+                    )
+                    _swap_started = time.monotonic()
                     try:
                         # Blocking, and deliberately so: this runs on the tool loop's
                         # executor thread, exactly where recost_waiting already waits for
                         # cache room. The event loop keeps serving the client, which is
                         # what turns this into "waiting" in the UI instead of a stall.
                         deadline = time.monotonic() + _KV_SWAP_MAX_WAIT_S
+                        _fits = False
                         while time.monotonic() < deadline:
                             if cancel_event is not None and cancel_event.is_set():
                                 break
-                            if not controller.plan(incoming = 0).victims:
+                            # This chat's own fit, not the whole queue's: waiting for
+                            # everyone to fit means waiting for the queue to drain.
+                            if controller.can_resume(_kv_swap_chat_id):
+                                _fits = True
                                 break
+                            try:
+                                controller.reconcile(llama_backend.read_slots_snapshot())
+                            except Exception:
+                                pass
                             time.sleep(_KV_SWAP_POLL_S)
-                        controller.swap_in(_kv_swap_chat_id, slot)
+                        if _fits:
+                            controller.swap_in(_kv_swap_chat_id, slot)
+                        else:
+                            # Restoring into a cache with no room returns HTTP 400 and
+                            # loses the checkpoint anyway. Drop it deliberately instead
+                            # and let the round re-prefill, which always works.
+                            logger.info(
+                                "llama kv swap gave up waiting: chat=%s after %.1fs; "
+                                "resuming by re-prefill",
+                                _kv_swap_chat_id, time.monotonic() - _swap_started,
+                            )
+                            controller.fall_back(_kv_swap_chat_id)
+                        _chat_now = controller.get(_kv_swap_chat_id) if _fits else None
+                        if _fits:
+                            logger.info(
+                                "llama kv swap resumed: chat=%s slot=%s waited=%.1fs "
+                                "restore=%.1fms swaps=%d",
+                                _kv_swap_chat_id, slot,
+                                time.monotonic() - _swap_started,
+                                _chat_now.last_restore_ms if _chat_now is not None else -1.0,
+                                _kv_swap_state["swaps"],
+                            )
                     finally:
                         # Cleared even on a failed restore: the fallback path re-prefills,
                         # so the client is no longer waiting either way.
                         _kv_swap_state["paused"] = False
                         _kv_swap_state["resumed"] = True
+                except KvSwapNothingToSave:
+                    # No cells to free, so no reason to make this chat wait.
+                    return
                 except Exception as exc:
                     # Fall back to plain admission: slower to resume, never an error.
                     try:
@@ -21560,7 +21602,7 @@ async def produce_openai_chat_completions(
                             controller.fall_back(_kv_swap_chat_id)
                     except Exception:
                         pass
-                    logger.debug(f"KV swap skipped for {_kv_swap_chat_id}: {exc}")
+                    logger.info(f"llama kv swap fell back for {_kv_swap_chat_id}: {exc}")
 
             def _gguf_recost(conversation) -> None:
                 _kv_swap_round(conversation)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1712,7 +1712,7 @@ _OPENAI_LLAMA_ADMISSION_POLL_S = 0.25
 # How long a swapped-out chat waits for cells before giving up and re-prefilling, and how
 # often it re-checks. The poll is coarse because a swap-in costs ~11 ms: a tighter loop
 # would only burn the executor thread the tool loop needs back.
-_KV_SWAP_MAX_WAIT_S = 900.0
+_KV_SWAP_MAX_WAIT_S = 300.0
 _KV_SWAP_POLL_S = 0.25
 # SSE comments the chat UI already renders as "Paused while another chat finishes".
 _OPENAI_KV_SWAP_SSE_PAUSED = ": preempt-paused\n\n"
@@ -22008,6 +22008,18 @@ async def produce_openai_chat_completions(
                 finally:
                     # A disconnect mid-approval must not leave a slot parked.
                     await _park_admission(False, wait = False)
+                    # Drop this chat from the KV ledger. Without it a finished chat stays
+                    # counted as resident for ever, the running total climbs past the
+                    # context with every request, and then EVERY chat is a victim at its
+                    # first round and no wait can ever be satisfied. That is exactly what
+                    # a 4-chat run did: resident 14134 against a 8192 pool, 120 pauses for
+                    # 4800 tokens, and not one successful resume.
+                    try:
+                        _kv_controller = peek_kv_swap_controller(llama_backend.base_url)
+                        if _kv_controller is not None:
+                            _kv_controller.finish(_kv_swap_chat_id)
+                    except Exception:
+                        pass
                     try:
                         if not stream_completed:
                             cancel_event.set()

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -95,6 +95,10 @@ from core.inference.orchestrator import (
     MOSS_TTS_MAX_FRAMES,
     _summed_tool_loop_stats,
 )
+from core.inference.kv_swap import (
+    KvSwapError,
+    peek_kv_swap_controller,
+)
 from core.inference.llama_admission import (
     LlamaAdmissionCancelled,
     LlamaAdmissionConfig,
@@ -1704,6 +1708,14 @@ _OPENAI_ADMISSION_SSE_WAIT = ": admission-wait\n\n"
 # Paired with the above: the slot is ours, so a suspended client clock starts now.
 _OPENAI_ADMISSION_SSE_DONE = ": admission-done\n\n"
 _OPENAI_LLAMA_ADMISSION_POLL_S = 0.25
+# How long a swapped-out chat waits for cells before giving up and re-prefilling, and how
+# often it re-checks. The poll is coarse because a swap-in costs ~11 ms: a tighter loop
+# would only burn the executor thread the tool loop needs back.
+_KV_SWAP_MAX_WAIT_S = 300.0
+_KV_SWAP_POLL_S = 0.25
+# SSE comments the chat UI already renders as "Paused while another chat finishes".
+_OPENAI_KV_SWAP_SSE_PAUSED = ": preempt-paused\n\n"
+_OPENAI_KV_SWAP_SSE_RESUMED = ": preempt-resumed\n\n"
 # Cap on waiting for a cancelled teardown task. Request.is_disconnected() can swallow
 # cancel() (#7617), so teardown abandons the task rather than hold the response, and
 # the process-wide slot, open forever.
@@ -21475,7 +21487,83 @@ async def produce_openai_chat_completions(
             # a reservation by the time a round can call it.
             _gguf_admission_hold: dict = {"reservation": None}
 
+            def _gguf_pinned_slot():
+                # The lease carries the slot admission handed out, which is the same slot
+                # llama-server will use once `id_slot` is in the payload. Read late: the
+                # generator is built before the reservation exists.
+                reservation = _gguf_admission_hold["reservation"]
+                if reservation is None:
+                    return None
+                lease = reservation.lease_nowait()
+                return None if lease is None else lease.slot
+
+            # Swap state for this chat, so the stream wrapper can tell the client it is
+            # waiting rather than stalled.
+            _kv_swap_state: dict = {"paused": False, "resumed": False, "swaps": 0}
+            _kv_swap_chat_id = f"{completion_id}"
+
+            def _kv_swap_round(conversation) -> None:
+                """Relieve KV pressure at a round boundary, before the next round starts.
+
+                A round boundary is the one place a checkpoint is free: the previous
+                request finished cleanly, so the caller holds exactly the cells the server
+                does plus the token it has not fed yet, which is what a resume needs to
+                land on restored cells instead of re-prefilling. Mid-round the KV runs
+                ahead of us and this is skipped entirely.
+
+                Never raises: a swap that cannot be taken leaves the run exactly as it was,
+                which is the old behaviour, not an error.
+                """
+                try:
+                    controller = llama_backend.kv_swap_controller()
+                    if controller is None:
+                        return
+                    slot = _gguf_pinned_slot()
+                    if slot is None:
+                        return
+                    controller.admit(_kv_swap_chat_id, slot = slot)
+                    try:
+                        controller.reconcile(llama_backend.read_slots_snapshot())
+                    except Exception:
+                        pass
+                    decision = controller.plan()
+                    if _kv_swap_chat_id not in decision.victims:
+                        controller.note_progress(_kv_swap_chat_id)
+                        return
+
+                    controller.swap_out(_kv_swap_chat_id)
+                    _kv_swap_state["paused"] = True
+                    _kv_swap_state["swaps"] += 1
+                    try:
+                        # Blocking, and deliberately so: this runs on the tool loop's
+                        # executor thread, exactly where recost_waiting already waits for
+                        # cache room. The event loop keeps serving the client, which is
+                        # what turns this into "waiting" in the UI instead of a stall.
+                        deadline = time.monotonic() + _KV_SWAP_MAX_WAIT_S
+                        while time.monotonic() < deadline:
+                            if cancel_event is not None and cancel_event.is_set():
+                                break
+                            if not controller.plan(incoming = 0).victims:
+                                break
+                            time.sleep(_KV_SWAP_POLL_S)
+                        controller.swap_in(_kv_swap_chat_id, slot)
+                    finally:
+                        # Cleared even on a failed restore: the fallback path re-prefills,
+                        # so the client is no longer waiting either way.
+                        _kv_swap_state["paused"] = False
+                        _kv_swap_state["resumed"] = True
+                except Exception as exc:
+                    # Fall back to plain admission: slower to resume, never an error.
+                    try:
+                        controller = peek_kv_swap_controller(llama_backend.base_url)
+                        if controller is not None:
+                            controller.fall_back(_kv_swap_chat_id)
+                    except Exception:
+                        pass
+                    logger.debug(f"KV swap skipped for {_kv_swap_chat_id}: {exc}")
+
             def _gguf_recost(conversation) -> None:
+                _kv_swap_round(conversation)
                 _openai_llama_admission_recost(
                     _gguf_admission_hold["reservation"],
                     conversation,
@@ -21557,6 +21645,7 @@ async def produce_openai_chat_completions(
                     permission_mode = payload.permission_mode,
                     perf_callback = _gguf_perf_callback,
                     on_conversation_grew = _gguf_recost,
+                    id_slot = _gguf_pinned_slot,
                     context_overflow = _rolling_context_policy(payload),
                     context_policy = _request_context_policy(payload),
                     compaction_headroom_ratio = _request_compaction_headroom_ratio(payload),
@@ -21703,7 +21792,16 @@ async def produce_openai_chat_completions(
                                 )
                                 if done_tasks:
                                     break
-                                yield _OPENAI_PASSTHROUGH_SSE_KEEPALIVE
+                                # A swapped-out chat is waiting for cache room, not stalled.
+                                # The UI renders this as "Paused while another chat
+                                # finishes"; a bare keep-alive would look like a hang.
+                                if _kv_swap_state["paused"]:
+                                    yield _OPENAI_KV_SWAP_SSE_PAUSED
+                                else:
+                                    if _kv_swap_state["resumed"]:
+                                        _kv_swap_state["resumed"] = False
+                                        yield _OPENAI_KV_SWAP_SSE_RESUMED
+                                    yield _OPENAI_PASSTHROUGH_SSE_KEEPALIVE
                                 approval_flush_pending = False
                                 wait_timeout = _LOCAL_TOOL_STREAM_STALL_KEEPALIVE_S
                             event = next_task.result()

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -98,6 +98,8 @@ from core.inference.orchestrator import (
 from core.inference.kv_swap import (
     KvSwapError,
     KvSwapNothingToSave,
+    kv_swap_enabled,
+    kv_swap_force_every,
     peek_kv_swap_controller,
 )
 from core.inference.llama_admission import (
@@ -21492,6 +21494,13 @@ async def produce_openai_chat_completions(
                 # The lease carries the slot admission handed out, which is the same slot
                 # llama-server will use once `id_slot` is in the payload. Read late: the
                 # generator is built before the reservation exists.
+                #
+                # Gated on the feature switch, not just on the swap firing: pinning
+                # overrides llama-server's own slot choice (--slot-prompt-similarity picks
+                # the slot whose cache best matches), so with the feature off the request
+                # has to go out exactly as it did before, or the off arm is not a control.
+                if not kv_swap_enabled():
+                    return None
                 reservation = _gguf_admission_hold["reservation"]
                 if reservation is None:
                     return None
@@ -21528,7 +21537,11 @@ async def produce_openai_chat_completions(
                     except Exception:
                         pass
                     decision = controller.plan()
-                    if _kv_swap_chat_id not in decision.victims:
+                    # UNSLOTH_LLAMA_KV_SWAP_EVERY forces a swap at every round whatever
+                    # the pressure, so the checkpoint path can be exercised and timed on a
+                    # machine that is not actually short of cache. Test knob, default off.
+                    _forced = kv_swap_force_every() > 0
+                    if not _forced and _kv_swap_chat_id not in decision.victims:
                         controller.note_progress(_kv_swap_chat_id)
                         return
 
@@ -21550,7 +21563,7 @@ async def produce_openai_chat_completions(
                         # cache room. The event loop keeps serving the client, which is
                         # what turns this into "waiting" in the UI instead of a stall.
                         deadline = time.monotonic() + _KV_SWAP_MAX_WAIT_S
-                        _fits = False
+                        _fits = _forced
                         while time.monotonic() < deadline:
                             if cancel_event is not None and cancel_event.is_set():
                                 break

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -21552,9 +21552,12 @@ async def produce_openai_chat_completions(
                     logger.info(
                         "llama kv swap paused: chat=%s slot=%s saved=%d resident=%d "
                         "budget=%d keep=%s",
-                        _kv_swap_chat_id, slot,
+                        _kv_swap_chat_id,
+                        slot,
                         chat.saved_tokens if chat is not None else -1,
-                        decision.resident, decision.budget, decision.keep,
+                        decision.resident,
+                        decision.budget,
+                        decision.keep,
                     )
                     _swap_started = time.monotonic()
                     try:
@@ -21586,7 +21589,8 @@ async def produce_openai_chat_completions(
                             logger.info(
                                 "llama kv swap gave up waiting: chat=%s after %.1fs; "
                                 "resuming by re-prefill",
-                                _kv_swap_chat_id, time.monotonic() - _swap_started,
+                                _kv_swap_chat_id,
+                                time.monotonic() - _swap_started,
                             )
                             controller.fall_back(_kv_swap_chat_id)
                         _chat_now = controller.get(_kv_swap_chat_id) if _fits else None
@@ -21594,7 +21598,8 @@ async def produce_openai_chat_completions(
                             logger.info(
                                 "llama kv swap resumed: chat=%s slot=%s waited=%.1fs "
                                 "restore=%.1fms swaps=%d",
-                                _kv_swap_chat_id, slot,
+                                _kv_swap_chat_id,
+                                slot,
                                 time.monotonic() - _swap_started,
                                 _chat_now.last_restore_ms if _chat_now is not None else -1.0,
                                 _kv_swap_state["swaps"],

--- a/studio/backend/tests/test_kv_swap.py
+++ b/studio/backend/tests/test_kv_swap.py
@@ -36,14 +36,22 @@ from core.inference.kv_swap import (
 
 # --------------------------------------------------------------------------- helpers
 
-def write_slot_file(path, tokens, *, magic = SLOT_FILE_MAGIC, version = 3, count = None,
-                    truncate_tokens = False):
+
+def write_slot_file(
+    path,
+    tokens,
+    *,
+    magic = SLOT_FILE_MAGIC,
+    version = 3,
+    count = None,
+    truncate_tokens = False,
+):
     """Write a slot file in llama-server's ``ggsq`` layout."""
     count = len(tokens) if count is None else count
     blob = struct.pack("<IIIiI I", magic, version, len(tokens) + 4, -1, 1, count)
     body = struct.pack(f"<{len(tokens)}i", *tokens) if tokens else b""
     if truncate_tokens:
-        body = body[:len(body) // 2]
+        body = body[: len(body) // 2]
     path.write_bytes(blob + body + b"\x00" * 64)
     return path
 
@@ -81,6 +89,7 @@ def make_controller(server = None, **kwargs):
 
 
 # ----------------------------------------------------------------- the file header
+
 
 def test_parse_slot_file_returns_exact_tokens(tmp_path):
     tokens = [248045, 846, 198, 814, 20139]
@@ -121,6 +130,7 @@ def test_parse_slot_file_rejects_missing_file(tmp_path):
 
 # ------------------------------------------------------------------- the resume rule
 
+
 def test_resume_prompt_must_strictly_extend_the_save():
     saved = [1, 2, 3, 4]
     # A proper extension is the only shape that lands on the restored cells.
@@ -133,6 +143,7 @@ def test_resume_prompt_must_strictly_extend_the_save():
 
 
 # ------------------------------------------------------------------------- the buffer
+
 
 def test_default_buffer_covers_the_speculative_lead_on_every_slot():
     assert default_buffer_tokens(4, 2) == 4 * (2 + DEFAULT_DRAFT_MARGIN) == 20
@@ -155,6 +166,7 @@ def test_budget_is_context_minus_buffer():
 
 # --------------------------------------------------------------------------- env knobs
 
+
 def test_env_knobs(monkeypatch):
     monkeypatch.delenv("UNSLOTH_LLAMA_KV_SWAP", raising = False)
     assert kv_swap_enabled() is True
@@ -175,6 +187,7 @@ def test_env_knobs(monkeypatch):
 
 
 # --------------------------------------------------------------------------- accounting
+
 
 def test_resident_counts_prompt_plus_generated_and_drops_when_paused():
     controller = make_controller()
@@ -226,6 +239,7 @@ def test_active_count_arms_chunking_only_above_one():
 
 # ------------------------------------------------------------------------------ policy
 
+
 def _four_chats(controller, sizes):
     for i, (name, size) in enumerate(sizes):
         controller.admit(name, prompt_tokens = size, slot = i)
@@ -241,18 +255,18 @@ def test_plan_does_nothing_while_it_fits():
 
 
 def test_plan_keeps_the_largest_and_swaps_newest_first():
-    controller = make_controller(n_ctx = 1000)   # budget 980
+    controller = make_controller(n_ctx = 1000)  # budget 980
     for i, (name, size) in enumerate([("a", 500), ("b", 300), ("c", 300)]):
         controller.admit(name, prompt_tokens = size, slot = i)
-        controller.get(name).admitted_at = 100.0 + i   # a oldest, c newest
+        controller.get(name).admitted_at = 100.0 + i  # a oldest, c newest
     decision = controller.plan()
-    assert decision.keep == "a"                 # most tokens
-    assert decision.victims == ["c"]            # newest first, and one is enough
+    assert decision.keep == "a"  # most tokens
+    assert decision.victims == ["c"]  # newest first, and one is enough
     assert decision.reason == "pressure"
 
 
 def test_plan_never_swaps_the_last_one_standing():
-    controller = make_controller(n_ctx = 100)   # budget 80, nothing fits
+    controller = make_controller(n_ctx = 100)  # budget 80, nothing fits
     controller.admit("a", prompt_tokens = 500, slot = 0)
     controller.get("a").admitted_at = 1.0
     controller.admit("b", prompt_tokens = 400, slot = 1)
@@ -273,9 +287,9 @@ def test_plan_protects_a_chat_on_a_swap_streak_while_another_candidate_exists():
         controller.get(name).admitted_at = 100.0 + i
     # "streak" is the newest-but-one; make it the one that has been hit repeatedly.
     controller.get("streak").swap_streak = SWAP_STREAK_PROTECT
-    controller.get("streak").admitted_at = 200.0   # newest, so normally chosen first
+    controller.get("streak").admitted_at = 200.0  # newest, so normally chosen first
     decision = controller.plan()
-    assert decision.victims == ["fresh"]           # protection pushed "streak" behind it
+    assert decision.victims == ["fresh"]  # protection pushed "streak" behind it
 
 
 def test_plan_uses_a_protected_chat_when_it_is_the_only_candidate():
@@ -289,12 +303,12 @@ def test_plan_uses_a_protected_chat_when_it_is_the_only_candidate():
 
 
 def test_plan_accounts_for_an_incoming_chat():
-    controller = make_controller(n_ctx = 1000)   # budget 980
+    controller = make_controller(n_ctx = 1000)  # budget 980
     controller.admit("a", prompt_tokens = 500, slot = 0)
     controller.get("a").admitted_at = 1.0
     controller.admit("b", prompt_tokens = 400, slot = 1)
     controller.get("b").admitted_at = 2.0
-    assert controller.plan().victims == []       # 900 fits
+    assert controller.plan().victims == []  # 900 fits
     assert controller.plan(incoming = 300).victims == ["b"]
 
 
@@ -305,10 +319,11 @@ def test_plan_swaps_several_when_one_is_not_enough():
         controller.get(name).admitted_at = 100.0 + i
     decision = controller.plan()
     assert decision.keep == "a"
-    assert decision.victims == ["d", "c"]        # newest first until it fits
+    assert decision.victims == ["d", "c"]  # newest first until it fits
 
 
 # ------------------------------------------------------------------------- swap moves
+
 
 def test_swap_out_saves_then_erases_and_frees_the_slot():
     server = FakeServer()
@@ -322,7 +337,7 @@ def test_swap_out_saves_then_erases_and_frees_the_slot():
     assert chat.slot is None
     assert chat.saved_tokens == 140
     assert chat.swap_streak == 1 and chat.swaps_total == 1
-    assert controller.resident_total() == 0      # the cells are free
+    assert controller.resident_total() == 0  # the cells are free
     assert controller.swaps_out == 1
 
 
@@ -335,7 +350,7 @@ def test_swap_out_does_not_erase_when_the_save_reports_nothing():
     # clears idle slots itself under a unified KV, and pausing then would be pointless.
     with pytest.raises(KvSwapNothingToSave, match = "no cells to free"):
         controller.swap_out("a")
-    assert [c[1] for c in server.calls] == ["save"]     # no erase: content is never lost
+    assert [c[1] for c in server.calls] == ["save"]  # no erase: content is never lost
     assert controller.get("a").state == RUNNING
     assert issubclass(KvSwapNothingToSave, KvSwapError)
 
@@ -363,7 +378,7 @@ def test_swap_in_restores_into_any_free_slot():
     controller = make_controller(server)
     controller.admit("a", prompt_tokens = 100, slot = 2)
     controller.swap_out("a")
-    chat = controller.swap_in("a", 0)            # a different id than it left
+    chat = controller.swap_in("a", 0)  # a different id than it left
     assert server.calls[-1][0] == 0
     assert server.calls[-1][1] == "restore"
     assert chat.state == RUNNING and chat.slot == 0
@@ -375,10 +390,10 @@ def test_swap_in_rejects_a_short_restore_and_stays_paused():
     controller = make_controller(server)
     controller.admit("a", prompt_tokens = 100, slot = 2)
     controller.swap_out("a")
-    server.saved[controller.get("a").filename] = 3     # server came back with fewer cells
+    server.saved[controller.get("a").filename] = 3  # server came back with fewer cells
     with pytest.raises(KvSwapError, match = "restored 3 of 140"):
         controller.swap_in("a", 0)
-    assert controller.get("a").state == PAUSED         # still recoverable via fallback
+    assert controller.get("a").state == PAUSED  # still recoverable via fallback
 
 
 def test_swap_in_keeps_the_checkpoint_when_the_call_raises():
@@ -408,6 +423,7 @@ def test_controller_without_transport_raises_rather_than_silently_skipping():
 
 
 # ---------------------------------------------------------------------------- fallback
+
 
 def test_fall_back_drops_the_checkpoint_and_unlinks_the_file(tmp_path):
     server = FakeServer()
@@ -441,6 +457,7 @@ def test_sweep_unlinks_every_checkpoint(tmp_path):
 
 # ------------------------------------------------------------------- progress + streaks
 
+
 def test_a_full_chunk_without_a_swap_clears_the_streak():
     controller = make_controller()
     controller.admit("a", prompt_tokens = 100, slot = 0)
@@ -457,6 +474,7 @@ def test_note_resume_records_the_prefill_the_resume_cost():
 
 
 # ---------------------------------------------------------------------------- registry
+
 
 def test_registry_reuses_and_updates(monkeypatch):
     reset_kv_swap_controllers()
@@ -482,8 +500,9 @@ def test_snapshot_reports_the_live_shape():
 
 # ------------------------------------------------------------------------ can_resume
 
+
 def test_can_resume_asks_only_whether_this_chat_fits():
-    controller = make_controller(n_ctx = 1020)      # budget 1000
+    controller = make_controller(n_ctx = 1020)  # budget 1000
     controller.admit("big", prompt_tokens = 700, slot = 0)
     controller.admit("me", prompt_tokens = 400, slot = 1)
     controller.swap_out("me")
@@ -522,7 +541,7 @@ def test_finished_chats_do_not_hold_the_budget_down():
     controller = make_controller(n_ctx = 8192)
     for i, name in enumerate(["a", "b", "c", "d"]):
         controller.admit(name, prompt_tokens = 3500, slot = i)
-    assert controller.resident_total() == 14000        # over the pool: the live symptom
+    assert controller.resident_total() == 14000  # over the pool: the live symptom
     for name in ["a", "b", "c"]:
         controller.finish(name)
     assert controller.resident_total() == 3500

--- a/studio/backend/tests/test_kv_swap.py
+++ b/studio/backend/tests/test_kv_swap.py
@@ -22,6 +22,7 @@ from core.inference.kv_swap import (
     SWAP_STREAK_PROTECT,
     KvSwapController,
     KvSwapError,
+    KvSwapNothingToSave,
     default_buffer_tokens,
     get_kv_swap_controller,
     kv_swap_chunk_tokens,
@@ -329,10 +330,13 @@ def test_swap_out_does_not_erase_when_the_save_reports_nothing():
     server.save_returns = 0
     controller = make_controller(server)
     controller.admit("a", prompt_tokens = 100, slot = 1)
-    with pytest.raises(KvSwapError, match = "saved 0 tokens"):
+    # An empty slot is signalled distinctly, because it is not a failure: llama-server
+    # clears idle slots itself under a unified KV, and pausing then would be pointless.
+    with pytest.raises(KvSwapNothingToSave, match = "no cells to free"):
         controller.swap_out("a")
     assert [c[1] for c in server.calls] == ["save"]     # no erase: content is never lost
     assert controller.get("a").state == RUNNING
+    assert issubclass(KvSwapNothingToSave, KvSwapError)
 
 
 def test_swap_out_propagates_a_failed_save_without_erasing():
@@ -473,3 +477,24 @@ def test_snapshot_reports_the_live_shape():
     assert snap["resident"] == 300
     assert snap["budget"] == 8192 - 20
     assert snap["swaps_out"] == 0
+
+
+# ------------------------------------------------------------------------ can_resume
+
+def test_can_resume_asks_only_whether_this_chat_fits():
+    controller = make_controller(n_ctx = 1020)      # budget 1000
+    controller.admit("big", prompt_tokens = 700, slot = 0)
+    controller.admit("me", prompt_tokens = 400, slot = 1)
+    controller.swap_out("me")
+    # 700 resident + 400 wanted = 1100 > 1000, so not yet.
+    assert controller.can_resume("me") is False
+    controller.update("big", prompt_tokens = 500)
+    # 500 + 400 = 900 <= 1000, even though "big" is still running.
+    assert controller.can_resume("me") is True
+
+
+def test_can_resume_ignores_the_chats_own_residency():
+    controller = make_controller(n_ctx = 1020)
+    controller.admit("me", prompt_tokens = 400, slot = 0)
+    assert controller.can_resume("me") is True
+    assert controller.can_resume("ghost") is False

--- a/studio/backend/tests/test_kv_swap.py
+++ b/studio/backend/tests/test_kv_swap.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Unit tests for KV-cache checkpoint swapping (``core.inference.kv_swap``).
+
+The numbers asserted here are the ones measured against llama-server b10715 and written
+down in ``plans/impl_v2_slot_swap.md``; the header layout and the resume rule in
+particular are properties of that build, not guesses.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from core.inference.kv_swap import (
+    DEFAULT_DRAFT_MARGIN,
+    PAUSED,
+    RUNNING,
+    SLOT_FILE_MAGIC,
+    SWAP_STREAK_PROTECT,
+    KvSwapController,
+    KvSwapError,
+    default_buffer_tokens,
+    get_kv_swap_controller,
+    kv_swap_chunk_tokens,
+    kv_swap_enabled,
+    kv_swap_force_every,
+    parse_slot_file_tokens,
+    reset_kv_swap_controllers,
+    resume_prompt_is_valid,
+)
+
+
+# --------------------------------------------------------------------------- helpers
+
+def write_slot_file(path, tokens, *, magic = SLOT_FILE_MAGIC, version = 3, count = None,
+                    truncate_tokens = False):
+    """Write a slot file in llama-server's ``ggsq`` layout."""
+    count = len(tokens) if count is None else count
+    blob = struct.pack("<IIIiI I", magic, version, len(tokens) + 4, -1, 1, count)
+    body = struct.pack(f"<{len(tokens)}i", *tokens) if tokens else b""
+    if truncate_tokens:
+        body = body[:len(body) // 2]
+    path.write_bytes(blob + body + b"\x00" * 64)
+    return path
+
+
+class FakeServer:
+    """Stands in for llama-server's slot state endpoints."""
+
+    def __init__(self):
+        self.calls = []
+        self.saved = {}
+        self.fail_on = set()
+        self.save_returns = None
+
+    def post(self, *, slot, action, body):
+        self.calls.append((slot, action, dict(body)))
+        if action in self.fail_on:
+            raise RuntimeError(f"{action} failed")
+        if action == "save":
+            name = body.get("filename")
+            n = self.save_returns if self.save_returns is not None else 140
+            self.saved[name] = n
+            return {"id_slot": slot, "filename": name, "n_saved": n}
+        if action == "erase":
+            return {"id_slot": slot, "n_erased": 140}
+        if action == "restore":
+            name = body.get("filename")
+            return {"id_slot": slot, "filename": name, "n_restored": self.saved.get(name, 0)}
+        raise AssertionError(action)
+
+
+def make_controller(server = None, **kwargs):
+    params = dict(n_ctx = 8192, n_parallel = 4, draft_n_max = 2, save_dir = None)
+    params.update(kwargs)
+    return KvSwapController("http://test", http_post = (server or FakeServer()).post, **params)
+
+
+# ----------------------------------------------------------------- the file header
+
+def test_parse_slot_file_returns_exact_tokens(tmp_path):
+    tokens = [248045, 846, 198, 814, 20139]
+    path = write_slot_file(tmp_path / "ok.bin", tokens)
+    assert parse_slot_file_tokens(path) == tokens
+
+
+def test_parse_slot_file_rejects_bad_magic(tmp_path):
+    path = write_slot_file(tmp_path / "bad.bin", [1, 2, 3], magic = 0xDEADBEEF)
+    with pytest.raises(KvSwapError, match = "magic"):
+        parse_slot_file_tokens(path)
+
+
+def test_parse_slot_file_rejects_unknown_version(tmp_path):
+    path = write_slot_file(tmp_path / "v9.bin", [1, 2, 3], version = 9)
+    with pytest.raises(KvSwapError, match = "version"):
+        parse_slot_file_tokens(path)
+
+
+def test_parse_slot_file_rejects_truncated_token_block(tmp_path):
+    path = tmp_path / "short.bin"
+    path.write_bytes(struct.pack("<IIIiII", SLOT_FILE_MAGIC, 3, 104, -1, 1, 100) + b"\x00" * 8)
+    with pytest.raises(KvSwapError, match = "of 100 tokens"):
+        parse_slot_file_tokens(path)
+
+
+def test_parse_slot_file_rejects_short_header(tmp_path):
+    path = tmp_path / "tiny.bin"
+    path.write_bytes(b"\x00" * 8)
+    with pytest.raises(KvSwapError, match = "truncated"):
+        parse_slot_file_tokens(path)
+
+
+def test_parse_slot_file_rejects_missing_file(tmp_path):
+    with pytest.raises(KvSwapError, match = "could not be read"):
+        parse_slot_file_tokens(tmp_path / "nope.bin")
+
+
+# ------------------------------------------------------------------- the resume rule
+
+def test_resume_prompt_must_strictly_extend_the_save():
+    saved = [1, 2, 3, 4]
+    # A proper extension is the only shape that lands on the restored cells.
+    assert resume_prompt_is_valid(saved, [1, 2, 3, 4, 5]) is True
+    # Equal length re-prefills on the real server, so it is not "valid" here either.
+    assert resume_prompt_is_valid(saved, [1, 2, 3, 4]) is False
+    assert resume_prompt_is_valid(saved, [1, 2, 3]) is False
+    assert resume_prompt_is_valid(saved, [1, 2, 9, 4, 5]) is False
+    assert resume_prompt_is_valid([], [1, 2]) is False
+
+
+# ------------------------------------------------------------------------- the buffer
+
+def test_default_buffer_covers_the_speculative_lead_on_every_slot():
+    assert default_buffer_tokens(4, 2) == 4 * (2 + DEFAULT_DRAFT_MARGIN) == 20
+    assert default_buffer_tokens(1, 0) == DEFAULT_DRAFT_MARGIN
+    assert default_buffer_tokens(0, 0) == DEFAULT_DRAFT_MARGIN
+
+
+def test_buffer_env_override(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_LLAMA_KV_SWAP_BUFFER", "64")
+    assert default_buffer_tokens(4, 2) == 64
+    monkeypatch.setenv("UNSLOTH_LLAMA_KV_SWAP_BUFFER", "0")
+    assert default_buffer_tokens(4, 2) == 0
+
+
+def test_budget_is_context_minus_buffer():
+    controller = make_controller()
+    assert controller.buffer_tokens == 20
+    assert controller.budget == 8192 - 20
+
+
+# --------------------------------------------------------------------------- env knobs
+
+def test_env_knobs(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_LLAMA_KV_SWAP", raising = False)
+    assert kv_swap_enabled() is True
+    monkeypatch.setenv("UNSLOTH_LLAMA_KV_SWAP", "0")
+    assert kv_swap_enabled() is False
+    monkeypatch.setenv("UNSLOTH_LLAMA_KV_SWAP", "nonsense")
+    assert kv_swap_enabled() is True
+
+    monkeypatch.delenv("UNSLOTH_LLAMA_KV_SWAP_CHUNK", raising = False)
+    assert kv_swap_chunk_tokens() == 512
+    monkeypatch.setenv("UNSLOTH_LLAMA_KV_SWAP_CHUNK", "1024")
+    assert kv_swap_chunk_tokens() == 1024
+
+    monkeypatch.delenv("UNSLOTH_LLAMA_KV_SWAP_EVERY", raising = False)
+    assert kv_swap_force_every() == 0
+    monkeypatch.setenv("UNSLOTH_LLAMA_KV_SWAP_EVERY", "200")
+    assert kv_swap_force_every() == 200
+
+
+# --------------------------------------------------------------------------- accounting
+
+def test_resident_counts_prompt_plus_generated_and_drops_when_paused():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 100, slot = 0)
+    controller.update("a", generated_tokens = 50)
+    chat = controller.get("a")
+    assert chat.resident == 150
+    assert controller.resident_total() == 150
+    chat.state = PAUSED
+    assert chat.resident == 0
+    assert chat.size == 150
+    assert controller.resident_total() == 0
+
+
+def test_finish_removes_the_chat():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 10, slot = 0)
+    controller.finish("a")
+    assert controller.get("a") is None
+    assert controller.resident_total() == 0
+
+
+def test_reconcile_trusts_the_server_over_the_stream():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 100, slot = 1)
+    controller.update("a", generated_tokens = 111)
+    # The server holds 4 more than the stream emitted: the in-flight speculative batch.
+    controller.reconcile([{"id": 1, "n_prompt_tokens": 215}])
+    assert controller.get("a").resident == 215
+    assert controller.get("a").generated_tokens == 115
+
+
+def test_reconcile_ignores_slots_it_does_not_own():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 100, slot = 1)
+    controller.reconcile([{"id": 3, "n_prompt_tokens": 900}, {"id": 1, "n_prompt_tokens": 0}])
+    assert controller.get("a").resident == 100
+
+
+def test_active_count_arms_chunking_only_above_one():
+    controller = make_controller()
+    assert controller.active_count() == 0
+    controller.admit("a", prompt_tokens = 10, slot = 0)
+    assert controller.active_count() == 1
+    controller.admit("b", prompt_tokens = 10, slot = 1)
+    assert controller.active_count() == 2
+
+
+# ------------------------------------------------------------------------------ policy
+
+def _four_chats(controller, sizes):
+    for i, (name, size) in enumerate(sizes):
+        controller.admit(name, prompt_tokens = size, slot = i)
+
+
+def test_plan_does_nothing_while_it_fits():
+    controller = make_controller(n_ctx = 8192)
+    _four_chats(controller, [("a", 100), ("b", 200)])
+    decision = controller.plan()
+    assert decision.victims == []
+    assert decision.reason == "fits"
+    assert decision.keep == "b"
+
+
+def test_plan_keeps_the_largest_and_swaps_newest_first():
+    controller = make_controller(n_ctx = 1000)   # budget 980
+    for i, (name, size) in enumerate([("a", 500), ("b", 300), ("c", 300)]):
+        controller.admit(name, prompt_tokens = size, slot = i)
+        controller.get(name).admitted_at = 100.0 + i   # a oldest, c newest
+    decision = controller.plan()
+    assert decision.keep == "a"                 # most tokens
+    assert decision.victims == ["c"]            # newest first, and one is enough
+    assert decision.reason == "pressure"
+
+
+def test_plan_never_swaps_the_last_one_standing():
+    controller = make_controller(n_ctx = 100)   # budget 80, nothing fits
+    controller.admit("a", prompt_tokens = 500, slot = 0)
+    controller.get("a").admitted_at = 1.0
+    controller.admit("b", prompt_tokens = 400, slot = 1)
+    controller.get("b").admitted_at = 2.0
+    decision = controller.plan()
+    assert decision.victims == ["b"]
+    assert decision.keep == "a"
+    # And with a single chat there is nobody to swap at all.
+    controller.finish("b")
+    assert controller.plan().victims == []
+    assert controller.plan().reason == "single-chat"
+
+
+def test_plan_protects_a_chat_on_a_swap_streak_while_another_candidate_exists():
+    controller = make_controller(n_ctx = 1000)  # budget 980
+    for i, (name, size) in enumerate([("keep", 500), ("streak", 300), ("fresh", 300)]):
+        controller.admit(name, prompt_tokens = size, slot = i)
+        controller.get(name).admitted_at = 100.0 + i
+    # "streak" is the newest-but-one; make it the one that has been hit repeatedly.
+    controller.get("streak").swap_streak = SWAP_STREAK_PROTECT
+    controller.get("streak").admitted_at = 200.0   # newest, so normally chosen first
+    decision = controller.plan()
+    assert decision.victims == ["fresh"]           # protection pushed "streak" behind it
+
+
+def test_plan_uses_a_protected_chat_when_it_is_the_only_candidate():
+    controller = make_controller(n_ctx = 1000)
+    controller.admit("keep", prompt_tokens = 700, slot = 0)
+    controller.get("keep").admitted_at = 1.0
+    controller.admit("streak", prompt_tokens = 400, slot = 1)
+    controller.get("streak").admitted_at = 2.0
+    controller.get("streak").swap_streak = SWAP_STREAK_PROTECT + 5
+    assert controller.plan().victims == ["streak"]
+
+
+def test_plan_accounts_for_an_incoming_chat():
+    controller = make_controller(n_ctx = 1000)   # budget 980
+    controller.admit("a", prompt_tokens = 500, slot = 0)
+    controller.get("a").admitted_at = 1.0
+    controller.admit("b", prompt_tokens = 400, slot = 1)
+    controller.get("b").admitted_at = 2.0
+    assert controller.plan().victims == []       # 900 fits
+    assert controller.plan(incoming = 300).victims == ["b"]
+
+
+def test_plan_swaps_several_when_one_is_not_enough():
+    controller = make_controller(n_ctx = 1000)
+    for i, name in enumerate(["a", "b", "c", "d"]):
+        controller.admit(name, prompt_tokens = 400 if name == "a" else 300, slot = i)
+        controller.get(name).admitted_at = 100.0 + i
+    decision = controller.plan()
+    assert decision.keep == "a"
+    assert decision.victims == ["d", "c"]        # newest first until it fits
+
+
+# ------------------------------------------------------------------------- swap moves
+
+def test_swap_out_saves_then_erases_and_frees_the_slot():
+    server = FakeServer()
+    controller = make_controller(server)
+    controller.admit("a", prompt_tokens = 100, slot = 2)
+    controller.update("a", generated_tokens = 40)
+    chat = controller.swap_out("a")
+    assert [c[1] for c in server.calls] == ["save", "erase"]
+    assert server.calls[0][0] == 2 and server.calls[1][0] == 2
+    assert chat.state == PAUSED
+    assert chat.slot is None
+    assert chat.saved_tokens == 140
+    assert chat.swap_streak == 1 and chat.swaps_total == 1
+    assert controller.resident_total() == 0      # the cells are free
+    assert controller.swaps_out == 1
+
+
+def test_swap_out_does_not_erase_when_the_save_reports_nothing():
+    server = FakeServer()
+    server.save_returns = 0
+    controller = make_controller(server)
+    controller.admit("a", prompt_tokens = 100, slot = 1)
+    with pytest.raises(KvSwapError, match = "saved 0 tokens"):
+        controller.swap_out("a")
+    assert [c[1] for c in server.calls] == ["save"]     # no erase: content is never lost
+    assert controller.get("a").state == RUNNING
+
+
+def test_swap_out_propagates_a_failed_save_without_erasing():
+    server = FakeServer()
+    server.fail_on.add("save")
+    controller = make_controller(server)
+    controller.admit("a", prompt_tokens = 100, slot = 1)
+    with pytest.raises(RuntimeError):
+        controller.swap_out("a")
+    assert [c[1] for c in server.calls] == ["save"]
+    assert controller.get("a").state == RUNNING
+
+
+def test_swap_out_requires_a_pinned_slot():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 10, slot = None)
+    with pytest.raises(KvSwapError, match = "not pinned"):
+        controller.swap_out("a")
+
+
+def test_swap_in_restores_into_any_free_slot():
+    server = FakeServer()
+    controller = make_controller(server)
+    controller.admit("a", prompt_tokens = 100, slot = 2)
+    controller.swap_out("a")
+    chat = controller.swap_in("a", 0)            # a different id than it left
+    assert server.calls[-1][0] == 0
+    assert server.calls[-1][1] == "restore"
+    assert chat.state == RUNNING and chat.slot == 0
+    assert controller.swaps_in == 1
+
+
+def test_swap_in_rejects_a_short_restore_and_stays_paused():
+    server = FakeServer()
+    controller = make_controller(server)
+    controller.admit("a", prompt_tokens = 100, slot = 2)
+    controller.swap_out("a")
+    server.saved[controller.get("a").filename] = 3     # server came back with fewer cells
+    with pytest.raises(KvSwapError, match = "restored 3 of 140"):
+        controller.swap_in("a", 0)
+    assert controller.get("a").state == PAUSED         # still recoverable via fallback
+
+
+def test_swap_in_keeps_the_checkpoint_when_the_call_raises():
+    server = FakeServer()
+    controller = make_controller(server)
+    controller.admit("a", prompt_tokens = 100, slot = 2)
+    controller.swap_out("a")
+    server.fail_on.add("restore")
+    with pytest.raises(RuntimeError):
+        controller.swap_in("a", 0)
+    assert controller.get("a").state == PAUSED
+    assert controller.get("a").filename is not None
+
+
+def test_swap_in_requires_a_checkpoint():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 10, slot = 0)
+    with pytest.raises(KvSwapError, match = "no checkpoint"):
+        controller.swap_in("a", 1)
+
+
+def test_controller_without_transport_raises_rather_than_silently_skipping():
+    controller = KvSwapController("k", n_ctx = 100, n_parallel = 1)
+    controller.admit("a", prompt_tokens = 10, slot = 0)
+    with pytest.raises(KvSwapError, match = "no HTTP transport"):
+        controller.swap_out("a")
+
+
+# ---------------------------------------------------------------------------- fallback
+
+def test_fall_back_drops_the_checkpoint_and_unlinks_the_file(tmp_path):
+    server = FakeServer()
+    controller = make_controller(server, save_dir = str(tmp_path))
+    controller.admit("a", prompt_tokens = 100, slot = 1)
+    controller.swap_out("a")
+    name = controller.get("a").filename
+    (tmp_path / name).write_bytes(b"x")
+    controller.fall_back("a")
+    assert controller.get("a").filename is None
+    assert not (tmp_path / name).exists()
+    assert controller.fallbacks == 1
+
+
+def test_fall_back_on_an_unknown_chat_is_counted_and_harmless():
+    controller = make_controller()
+    controller.fall_back("ghost")
+    assert controller.fallbacks == 1
+
+
+def test_sweep_unlinks_every_checkpoint(tmp_path):
+    server = FakeServer()
+    controller = make_controller(server, save_dir = str(tmp_path))
+    for i, name in enumerate(["a", "b"]):
+        controller.admit(name, prompt_tokens = 100, slot = i)
+        controller.swap_out(name)
+        (tmp_path / controller.get(name).filename).write_bytes(b"x")
+    assert controller.sweep() == 2
+    assert list(tmp_path.iterdir()) == []
+
+
+# ------------------------------------------------------------------- progress + streaks
+
+def test_a_full_chunk_without_a_swap_clears_the_streak():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 100, slot = 0)
+    controller.get("a").swap_streak = 2
+    controller.note_progress("a")
+    assert controller.get("a").swap_streak == 0
+
+
+def test_note_resume_records_the_prefill_the_resume_cost():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 100, slot = 0)
+    controller.note_resume("a", 1)
+    assert controller.get("a").last_resume_prompt_n == 1
+
+
+# ---------------------------------------------------------------------------- registry
+
+def test_registry_reuses_and_updates(monkeypatch):
+    reset_kv_swap_controllers()
+    first = get_kv_swap_controller("http://a", n_ctx = 4096, n_parallel = 2)
+    again = get_kv_swap_controller("http://a", n_ctx = 8192, n_parallel = 4)
+    assert first is again
+    assert again.n_ctx == 8192 and again.n_parallel == 4
+    other = get_kv_swap_controller("http://b", n_ctx = 4096, n_parallel = 2)
+    assert other is not first
+    reset_kv_swap_controllers()
+
+
+def test_snapshot_reports_the_live_shape():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 100, slot = 0)
+    controller.admit("b", prompt_tokens = 200, slot = 1)
+    snap = controller.snapshot()
+    assert snap["running"] == 2
+    assert snap["resident"] == 300
+    assert snap["budget"] == 8192 - 20
+    assert snap["swaps_out"] == 0

--- a/studio/backend/tests/test_kv_swap.py
+++ b/studio/backend/tests/test_kv_swap.py
@@ -210,7 +210,8 @@ def test_reconcile_trusts_the_server_over_the_stream():
 def test_reconcile_ignores_slots_it_does_not_own():
     controller = make_controller()
     controller.admit("a", prompt_tokens = 100, slot = 1)
-    controller.reconcile([{"id": 3, "n_prompt_tokens": 900}, {"id": 1, "n_prompt_tokens": 0}])
+    # Another chat's slot says 900; a readout that omits ours leaves ours alone.
+    controller.reconcile([{"id": 3, "n_prompt_tokens": 900}])
     assert controller.get("a").resident == 100
 
 
@@ -498,3 +499,31 @@ def test_can_resume_ignores_the_chats_own_residency():
     controller.admit("me", prompt_tokens = 400, slot = 0)
     assert controller.can_resume("me") is True
     assert controller.can_resume("ghost") is False
+
+
+def test_reconcile_clears_a_chat_whose_slot_the_server_released():
+    controller = make_controller()
+    controller.admit("a", prompt_tokens = 1000, slot = 1)
+    controller.update("a", generated_tokens = 2000)
+    assert controller.resident_total() == 3000
+    # The slot came back empty: the run ended and the cells went with it.
+    controller.reconcile([{"id": 1, "n_prompt_tokens": 0}])
+    assert controller.resident_total() == 0
+
+
+def test_reconcile_clamps_a_readout_larger_than_the_pool():
+    controller = make_controller(n_ctx = 8192)
+    controller.admit("a", prompt_tokens = 100, slot = 1)
+    controller.reconcile([{"id": 1, "n_prompt_tokens": 99999}])
+    assert controller.get("a").resident == 8192
+
+
+def test_finished_chats_do_not_hold_the_budget_down():
+    controller = make_controller(n_ctx = 8192)
+    for i, name in enumerate(["a", "b", "c", "d"]):
+        controller.admit(name, prompt_tokens = 3500, slot = i)
+    assert controller.resident_total() == 14000        # over the pool: the live symptom
+    for name in ["a", "b", "c"]:
+        controller.finish(name)
+    assert controller.resident_total() == 3500
+    assert controller.plan().victims == []


### PR DESCRIPTION
## Summary

An experiment, opened as a draft so it can be tested beside #10301 and not as a candidate to replace it. It keeps preemption in Studio but pauses a chat by checkpointing its llama-server slot (`POST /slots/{id}?action=save`, then `erase`) and resumes it by `restore` plus a request whose prompt has the saved sequence as a proper prefix, so the whole sequence is reused from the cache and one token is recomputed. #10301 resumes by re-prefilling the partial instead.

New module `studio/backend/core/inference/kv_swap.py` (the controller, the slot-file header parser, the resume-rule guard, every fallback) with 44 unit tests, wired to the GGUF tool loop at its round boundaries. Rollout switch `UNSLOTH_LLAMA_KV_SWAP`, default on.

## What was measured first

On the bundled llama-server build (b10715), before anything was built on it:

* Slot save, erase and restore work under `--kv-unified`, and `restore` accepts any free slot id, not only the one saved from.
* A resume hits the restored cells only when the saved sequence is a proper prefix of the new prompt. Exactly the same tokens re-prefills; there is no prefix-truncation reuse in this build. Every design decision below follows from this rule.
* A generation that ends cleanly leaves the caller holding exactly the cached tokens plus one, which satisfies the rule for free. An aborted stream leaves the cache 4 to 5 tokens ahead of what the client saw, the in-flight speculative batch, and draining the socket does not close that gap. So a pause in the middle of a generation cannot be resumed without recompute; only a request boundary can.
* Exactness: with speculation off, one request, the same text split into two requests, and save-erase-restore-resume are byte-identical in 10 of 10 variants. With the MTP head on, the swap adds no divergence of its own, but the request boundary itself diverges deterministically. That applies equally to the re-prefill resume in #10301.
* Chunk-boundary cost when a generation is split: 0.72 percent at 1024 tokens, 0.86 percent at 512, 3.41 percent at 256.

## Results

Qwen3.5-4B UD-Q4_K_XL with its MTP head, Studio at `-c 8192` with four slots, on a GPU shared with another tenant (raw llama-server 33 tok/s at the time against 296 tok/s on the same GPU earlier in the day, so only the on/off pairs are comparable, not the absolute rates).

Through Studio on a 2322-token conversation (123 MiB checkpoint): save 39.1 ms, erase 9.3 ms, restore 25.0 ms, and the resume reports `cache_n 2322, prompt_n 1`. Checkpoints are 123 to 321 MiB and write at 3.3 GB/s to disk.

| run | completed | wall | aggregate tok/s | first token mean / max | pauses | errors |
|---|---|---|---|---|---|---|
| solo, swap on | 1 of 1 | 35.3 s | 34.0 | 0.72 s | 0 | 0 |
| solo, swap off | 1 of 1 | 35.0 s | 34.3 | 0.39 s | 0 | 0 |
| four chats, swap on | 4 of 4 | 77.3 s | 62.1 | 21.1 s / 42.1 s | 0 | 0 |
| four chats, swap off | 4 of 4 | 79.9 s | 60.1 | 21.1 s / 42.0 s | 0 | 0 |

A run containing one real swap is byte-identical to the same run without one, and to a repeat of the baseline (`scripts/v2_exactness.py`). Arming costs nothing.

Four browser chats through Playwright: 4 of 4 finished, 3 error boxes, 6 speculative sub-batch errors, 0 swaps.

## Why it is not the shipping design

Coverage. The swap can only fire at request boundaries, which in this integration are the tool-round boundaries, and Studio chats spend most of their time inside one long generation. Under real pressure the swap does not fire and the chats reach the cache limit the old way, which is what the browser run shows and what #10301 prevents.

Three integration bugs were found and fixed on the way, each with its measurement: the resume wait asked whether the whole queue fit rather than the one chat; a slot emptied by `--cache-idle-slots` at a round boundary was read as a failed swap; and no lifecycle end, which left finished chats resident at 14134 of 8192 cells and produced a run with 120 pauses and no successful resume.

## What to take from it

The mechanism, not the integration. Slot checkpointing beats re-prefill by a margin that grows with conversation length (25 ms flat against 0.8 to 8.4 s), and it is exact. It needs a chunked generation driver, bounding `max_tokens` per upstream request at about 512 when more than one chat is active, so that pauses land on clean request boundaries; the pressure check then moves to the chunk boundary. Until that driver exists #10301 covers strictly more cases.

## Relation to the other branches

#10301 is the Studio-side design that ships. unslothai/llama.cpp#184, #185 and #186 move the pause into the server, where a token boundary is always clean and the in-flight draft is not a problem; with one of those merged into Studio's bundled build, this module's checkpointing becomes unnecessary.
