### PR TITLE
Studio: take GGML_CUDA_ENABLE_UNIFIED_MEMORY only when the weights outgrow the APU carve-out

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8715,17 +8715,25 @@ class LlamaCppBackend:
             return None
 
     @staticmethod
-    def _unified_memory_would_help(gpu_indices = None) -> bool:
-        """Whether managed allocation is the larger pool for the selected APUs.
+    def _unified_memory_would_help(gpu_indices = None, need_bytes = None) -> bool:
+        """Whether managed allocation is worth taking for the selected APUs.
 
-        On HIP it draws host RAM instead of the selected APUs' carve-outs, so the
-        decision is a direct comparison of the two pools. Available host RAM against
-        the carve-out's TOTAL is deliberate: a carve-out another process is holding
-        is not credited back to the host side, because the two pools fail
-        differently. Over-asking the carve-out returns hipErrorOutOfMemory and the
+        Two conditions, both required. On HIP it draws host RAM instead of the
+        selected APUs' carve-outs, so it pays only when host RAM is the larger
+        pool: available host RAM against the carve-out's TOTAL, deliberately,
+        because a carve-out another process is holding is not credited back to the
+        host side. Over-asking the carve-out returns hipErrorOutOfMemory and the
         load fails cleanly, while over-asking host RAM is the OOM kill this gate
-        exists to stop, so both halves of the asymmetry lean toward the pool a miss
-        is recoverable in. Missing data and mixed-device selections fail closed.
+        exists to stop.
+
+        And the weights must not fit the carve-out on their own. Managed pages are
+        a measured correctness risk on Linux ROCm: Qwen3.8-Flash-Next faults in
+        k_set_rows on gfx1151 with the variable set and is clean without it, on
+        b10715 and b10798 alike, while the same builds are clean on Windows and on
+        Vulkan (HF Qwen3.8-Flash-Next-GGUF discussion 30, #10330). So the swap is
+        taken only when the alternative is a load the carve-out cannot hold.
+        need_bytes is the GPU-resident weight size; None (not priced) fails closed,
+        as do missing data and mixed-device selections.
         """
         try:
             pool_mib = LlamaCppBackend._rocm_selected_pool_mib(gpu_indices)
@@ -8734,7 +8742,11 @@ class LlamaCppBackend:
             host_mib = LlamaCppBackend._available_system_memory_mib()
             if not host_mib:
                 return False
-            return int(host_mib) > int(pool_mib)
+            if int(host_mib) <= int(pool_mib):
+                return False
+            if need_bytes is None:
+                return False
+            return int(need_bytes) // (1024 * 1024) > int(pool_mib)
         except Exception:
             return False
 
@@ -8876,6 +8888,31 @@ class LlamaCppBackend:
             return str(value).strip().lower() in LlamaCppBackend._UNIFIED_MEMORY_OFF
         except Exception:
             return False
+
+    @staticmethod
+    def _unified_memory_opted_in(env = None) -> bool:
+        """True when UNSLOTH_ENABLE_UNIFIED_MEMORY=1 asks for managed allocation on a
+        selected APU even though the weights fit its carve-out. Exact "1", like the
+        disable switch, which wins when both are set. Fails closed (False)."""
+        try:
+            source = os.environ if env is None else env
+            return str(source.get("UNSLOTH_ENABLE_UNIFIED_MEMORY", "")).strip() == "1"
+        except Exception:
+            return False
+
+    @staticmethod
+    def _unified_memory_for_launch(
+        gpu_indices,
+        need_bytes,
+        *,
+        opted_in = False,
+    ) -> bool:
+        """The launch-time decision behind GGML_CUDA_ENABLE_UNIFIED_MEMORY: the opt-in
+        takes it on any selected APU, otherwise only when it pays and is needed
+        (_unified_memory_would_help). Never on a discrete card."""
+        if opted_in and LlamaCppBackend._amd_apu_wants_unified_memory(gpu_indices):
+            return True
+        return LlamaCppBackend._unified_memory_would_help(gpu_indices, need_bytes = need_bytes)
 
     # Datacenter / professional NVIDIA parts that benefit from the llama.cpp
     # FP32-accum / P2P tunings. Whole-word (\b) so short markers don't match
@@ -22817,6 +22854,7 @@ class LlamaCppBackend:
                 # preserve inherited values.
                 _unified_env_applied = False
                 _unified_opt_out = self._unified_memory_opted_out(env)
+                _unified_opt_in = self._unified_memory_opted_in(env)
                 if _unified_opt_out:
                     # ggml tests presence, so passing a user's "0" through would
                     # ENABLE what they turned off (#8651). Only absence is off.
@@ -22824,12 +22862,16 @@ class LlamaCppBackend:
                         logger.info(
                             "Unified memory opted out: unset GGML_CUDA_ENABLE_UNIFIED_MEMORY"
                         )
-                elif not is_vulkan_backend and self._unified_memory_would_help(gpu_indices):
+                elif not is_vulkan_backend and self._unified_memory_for_launch(
+                    gpu_indices, model_size, opted_in = _unified_opt_in
+                ):
                     _unified_env_applied = "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
                     env.setdefault("GGML_CUDA_ENABLE_UNIFIED_MEMORY", "1")
                     logger.info(
-                        "AMD unified-memory APU whose carve-out is smaller than host "
-                        "RAM: set GGML_CUDA_ENABLE_UNIFIED_MEMORY=1"
+                        "AMD unified-memory APU: set GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 (%s)",
+                        "UNSLOTH_ENABLE_UNIFIED_MEMORY=1"
+                        if _unified_opt_in
+                        else "the weights outgrow the carve-out and host RAM is the larger pool",
                     )
 
                 # DC NVIDIA GPUs: FP32 accum (+ P2P / launch queues for multi-GPU).
@@ -22981,7 +23023,9 @@ class LlamaCppBackend:
                         self._clear_split_placement_env(env)
                         # The setting is process-wide, so recompute it after changing
                         # the selected devices. Ownership protects inherited values.
-                        _survivors_gain_unified = self._unified_memory_would_help(_survivors)
+                        _survivors_gain_unified = self._unified_memory_for_launch(
+                            _survivors, model_size, opted_in = _unified_opt_in
+                        )
                         if _unified_env_applied and not _survivors_gain_unified:
                             env.pop("GGML_CUDA_ENABLE_UNIFIED_MEMORY", None)
                             _unified_env_applied = False
@@ -22999,7 +23043,7 @@ class LlamaCppBackend:
                             _unified_env_applied = True
                             logger.info(
                                 "Arch gate narrowed the launch onto a unified-memory "
-                                "APU whose carve-out is smaller than host RAM; set "
+                                "APU the weights outgrow; set "
                                 "GGML_CUDA_ENABLE_UNIFIED_MEMORY=1."
                             )
                         self._emit_child_gpu_visibility(
@@ -23824,7 +23868,9 @@ class LlamaCppBackend:
                         # APU presence controls the RAM guard; relative pool sizes
                         # determine whether managed allocations help.
                         _retry_wants_unified = self._amd_apu_wants_unified_memory(_remaining)
-                        _retry_unified_helps = self._unified_memory_would_help(_remaining)
+                        _retry_unified_helps = self._unified_memory_for_launch(
+                            _remaining, model_size, opted_in = _unified_opt_in
+                        )
                         # Everything recorded so far priced the CRASHED selection, and
                         # that placement is gone: the canonical #7624 shape pins the APU
                         # whose shared-pool "free memory" outranked the dGPU, warns that
@@ -23901,8 +23947,8 @@ class LlamaCppBackend:
                             env["GGML_CUDA_ENABLE_UNIFIED_MEMORY"] = "1"
                             _unified_env_applied = True
                             logger.info(
-                                "Arch-crash retry targets a unified-memory APU whose "
-                                "carve-out is smaller than host RAM; set "
+                                "Arch-crash retry targets a unified-memory APU the "
+                                "weights outgrow; set "
                                 "GGML_CUDA_ENABLE_UNIFIED_MEMORY=1 for the respawn."
                             )
                         self._emit_child_gpu_visibility(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -10374,7 +10374,9 @@ class LlamaCppBackend:
         already set by user" and the caller downgrades it to a warning, see
         ``_env_fixes_gpu_layers``), so a concrete count above the block count, or an
         inherited LLAMA_ARG_N_GPU_LAYERS that says so, is a forced full offload even
-        under ``--fit on``. An unknown block count or CPU placement answers False.
+        under ``--fit on``. So is no count at all once the fitter is off: llama.cpp's
+        default is ``-1``, every layer, and nothing is left to lower it. An unknown
+        block count for a concrete count, or CPU placement, answers False.
         """
         args = [str(a) for a in argv or ()]
         if self._argv_offloads_every_layer(args, env):
@@ -10382,9 +10384,6 @@ class LlamaCppBackend:
         if _device_selection_is_cpu(args, env):
             return False
         if _args_place_tensors_on_cpu(args) or _env_places_tensors_on_cpu(env):
-            return False
-        n_layers = self.n_layers
-        if not n_layers:
             return False
         try:
             requested = parse_gpu_layers_override(args)
@@ -10398,8 +10397,15 @@ class LlamaCppBackend:
                 requested = int(raw)
             except ValueError:
                 return False
+        if requested is None:
+            # No count anywhere: the default -1 stands, so only an active fitter
+            # can make this anything but a full offload.
+            return not fit_is_effectively_on(args, env)
+        n_layers = self.n_layers
+        if not n_layers:
+            return False
         # -1 is the default the fitter is free to lower; a concrete count stands.
-        return requested is not None and requested > n_layers
+        return requested > n_layers
 
     @staticmethod
     def _rows_the_child_can_reach(detected_gpus, pinned_ids) -> list:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -19129,6 +19129,7 @@ class LlamaCppBackend:
                 total_by_idx: dict[int, int] = {}
                 _gpu_mem: list[tuple[int, int, int]] = []
                 model_size = None  # set in the fit try; used by the APU RAM guard
+                _mtp_will_engage = False  # set in the fit try; read by the unified-memory price
                 # "none" once the fit proves the load needs no demand paging, else None
                 # for llama.cpp's own default. Bound before the try like the verdict
                 # flags above: the except path falls through to the launch, which reads it.
@@ -22905,11 +22906,29 @@ class LlamaCppBackend:
                 _unified_env_applied = False
                 _unified_opt_out = self._unified_memory_opted_out(env)
                 _unified_opt_in = self._unified_memory_opted_in(env)
+
                 # Price only what a forced full offload puts on the device. With the
                 # fitter or an explicit partial placement owning the layer count, the
                 # load fits by spilling, so the whole-file size would overstate the
                 # need and take managed pages for a launch the carve-out holds.
-                _unified_need = model_size if self._launch_forces_full_offload(cmd, env) else None
+                def _unified_need_now():
+                    """Bytes a forced full offload puts on the device, or None."""
+                    if model_size is None or not self._launch_forces_full_offload(cmd, env):
+                        return None
+                    need = int(model_size)
+                    # Trailing NextN/MTP blocks stay unloaded unless a draft engages
+                    # (offload_layout: an -ot naming them moves nothing), but
+                    # model_size counts them, and a base that fits its carve-out
+                    # must not take managed pages on their account. A table that
+                    # cannot be read cannot price them, so it does not take them.
+                    if not _mtp_will_engage and self._nextn_predict_layers:
+                        layout = self._tensor_spill_layout(model_path)
+                        if layout is None:
+                            return None
+                        need -= int(layout.excluded_block_bytes or 0)
+                    return need
+
+                _unified_need = _unified_need_now()
                 if _unified_opt_out:
                     # ggml tests presence, so passing a user's "0" through would
                     # ENABLE what they turned off (#8651). Only absence is off.
@@ -23079,9 +23098,7 @@ class LlamaCppBackend:
                         # The setting is process-wide, so recompute it after changing
                         # the selected devices. Ownership protects inherited values.
                         _survivors_gain_unified = self._unified_memory_for_launch(
-                            _survivors,
-                            model_size if self._launch_forces_full_offload(cmd, env) else None,
-                            opted_in = _unified_opt_in,
+                            _survivors, _unified_need_now(), opted_in = _unified_opt_in
                         )
                         if _unified_env_applied and not _survivors_gain_unified:
                             env.pop("GGML_CUDA_ENABLE_UNIFIED_MEMORY", None)
@@ -23926,9 +23943,7 @@ class LlamaCppBackend:
                         # determine whether managed allocations help.
                         _retry_wants_unified = self._amd_apu_wants_unified_memory(_remaining)
                         _retry_unified_helps = self._unified_memory_for_launch(
-                            _remaining,
-                            model_size if self._launch_forces_full_offload(cmd, env) else None,
-                            opted_in = _unified_opt_in,
+                            _remaining, _unified_need_now(), opted_in = _unified_opt_in
                         )
                         # Everything recorded so far priced the CRASHED selection, and
                         # that placement is gone: the canonical #7624 shape pins the APU

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4788,6 +4788,23 @@ def _paravirtual_draft_ngl_flag(server_caps: Mapping[str, object]) -> Optional[s
     return None
 
 
+def _argv_keeps_projector_on_gpu(
+    args: Sequence[str], env: Optional[Mapping[str, str]] = None
+) -> bool:
+    """Whether *args* still load a projector onto the device.
+
+    The text-only retry strips ``--mmproj`` and the CPU-projector retry appends
+    ``--no-mmproj-offload``; either leaves the base alone on the carve-out."""
+    tokens = [str(a) for a in args]
+
+    def _flag(token: str) -> str:
+        return token.split("=", 1)[0].replace("_", "-").lower()
+
+    if not any(_flag(a) in ("--mmproj", "-mm") for a in tokens):
+        return False
+    return _resolved_mmproj_offload(tokens, env or {}) is not False
+
+
 def _paravirtual_mmproj_pinnable(server_caps: Mapping[str, object]) -> bool:
     """True when --no-mmproj-offload can be emitted, including on an unanswered probe."""
     return bool(
@@ -22923,17 +22940,50 @@ class LlamaCppBackend:
                     if model_size is None or not self._launch_forces_full_offload(run_argv, env):
                         return None
                     need = int(model_size)
-                    # Trailing NextN/MTP blocks stay unloaded unless a draft engages
-                    # (offload_layout: an -ot naming them moves nothing), but
-                    # model_size counts them, and a base that fits its carve-out
-                    # must not take managed pages on their account. A table that
-                    # cannot be read cannot price them, so it does not take them.
+                    # The projector was priced onto the device; a retry that pins
+                    # it to the CPU or strips it loads the base alone.
+                    if mmproj_size and not _argv_keeps_projector_on_gpu(run_argv, env):
+                        need -= int(mmproj_size)
+                    # The file overstates the device: dev_input is CPU-pinned even
+                    # at full offload (offload_layout), so token_embd and the
+                    # per-layer table sharing its name never reach the carve-out.
+                    # A tied file duplicates the matrix onto the device instead, so
+                    # only an untied one subtracts it. Trailing NextN/MTP blocks
+                    # stay unloaded unless a draft engages. A table that cannot be
+                    # read cannot price either, so it takes nothing.
+                    layout = self._tensor_spill_layout(model_path)
+                    if layout is None or not getattr(layout, "complete", True):
+                        return None
+                    if int(getattr(layout, "lm_head_bytes", 0) or 0):
+                        need -= int(getattr(layout, "token_embd_bytes", 0) or 0)
                     if not engages and self._nextn_predict_layers:
-                        layout = self._tensor_spill_layout(model_path)
-                        if layout is None:
-                            return None
-                        need -= int(layout.excluded_block_bytes or 0)
+                        need -= int(getattr(layout, "excluded_block_bytes", 0) or 0)
                     return need
+
+                def _unified_withdraw_if_unneeded(
+                    run_cmd,
+                    *,
+                    mtp_engages = None,
+                    why = "",
+                ):
+                    """Drop the variable this launch set once a respawn no longer
+                    needs it; an inherited or opted-in value is left alone."""
+                    nonlocal _unified_env_applied
+                    if not _unified_env_applied:
+                        return
+                    if self._unified_memory_for_launch(
+                        gpu_indices,
+                        _unified_need_now(argv = run_cmd, mtp_engages = mtp_engages),
+                        opted_in = _unified_opt_in,
+                    ):
+                        return
+                    env.pop("GGML_CUDA_ENABLE_UNIFIED_MEMORY", None)
+                    _unified_env_applied = False
+                    logger.info(
+                        "%s no longer needs managed memory; dropped "
+                        "GGML_CUDA_ENABLE_UNIFIED_MEMORY.",
+                        why or "The retry",
+                    )
 
                 _unified_need = _unified_need_now()
                 if _unified_opt_out:
@@ -24419,21 +24469,13 @@ class LlamaCppBackend:
                             strip_split_mode = False,
                         )
                     fallback_cmd = cmd[:_spec_at] + ["--spec-default"] + _fb_tail
-                    # The managed-memory price counted the MTP blocks a draft would
-                    # have loaded; this retry loads none. Re-price the base alone and
-                    # withdraw only what this launch set, so a base the carve-out
-                    # holds does not carry managed pages into the drafterless server.
-                    if _unified_env_applied and not self._unified_memory_for_launch(
-                        gpu_indices,
-                        _unified_need_now(argv = fallback_cmd, mtp_engages = False),
-                        opted_in = _unified_opt_in,
-                    ):
-                        env.pop("GGML_CUDA_ENABLE_UNIFIED_MEMORY", None)
-                        _unified_env_applied = False
-                        logger.info(
-                            "Retry without speculative decoding no longer needs managed "
-                            "memory; dropped GGML_CUDA_ENABLE_UNIFIED_MEMORY."
-                        )
+                    # The price counted the MTP blocks a draft would have loaded;
+                    # this retry loads none.
+                    _unified_withdraw_if_unneeded(
+                        fallback_cmd,
+                        mtp_engages = False,
+                        why = "The retry without speculative decoding",
+                    )
                     healthy = _spawn_and_wait(fallback_cmd, label = "-retry")
                     if healthy:
                         self._speculative_type = "default"
@@ -24517,6 +24559,10 @@ class LlamaCppBackend:
                                 "projector on CPU to preserve image input."
                             )
                             cmd = _cpu_projector_cmd
+                            # The projector's bytes leave the device with it.
+                            _unified_withdraw_if_unneeded(
+                                cmd, why = "The retry with the projector on CPU"
+                            )
                             healthy = _spawn_and_wait(cmd, label = "-mmproj-cpu")
                             if healthy:
                                 self._mmproj_fallback_reason = "cpu_offload"
@@ -24590,6 +24636,7 @@ class LlamaCppBackend:
                                 )
                                 self._mmproj_fallback_reason = "projector_startup_failure"
                             cmd = self._strip_mmproj_args(_vision_gpu_cmd)
+                            _unified_withdraw_if_unneeded(cmd, why = "The text-only retry")
                             # This retry bypasses _spawn_and_wait, so refresh the
                             # launched-argv snapshot itself -- the zero-offload
                             # classification below must not see the stripped --mmproj.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4791,12 +4791,8 @@ def _paravirtual_draft_ngl_flag(server_caps: Mapping[str, object]) -> Optional[s
 def _argv_keeps_projector_on_gpu(
     args: Sequence[str], env: Optional[Mapping[str, str]] = None
 ) -> bool:
-    """Whether *args* still load a projector onto the device.
-
-    The text-only retry strips ``--mmproj`` and the CPU-projector retry appends
-    ``--no-mmproj-offload``; either leaves the base alone on the carve-out. An
-    inherited ``LLAMA_ARG_MMPROJ`` / ``LLAMA_ARG_MMPROJ_URL`` outlives the argv
-    strip, and arg.cpp applies it before argv, so that projector still loads."""
+    """Whether *args* still load a projector onto the device. arg.cpp applies
+    ``LLAMA_ARG_MMPROJ(_URL)`` before argv, so the env alone still loads one."""
     tokens = [str(a) for a in args]
     env_map = env or {}
 
@@ -8743,24 +8739,10 @@ class LlamaCppBackend:
     def _unified_memory_would_help(gpu_indices = None, need_bytes = None) -> bool:
         """Whether managed allocation is worth taking for the selected APUs.
 
-        Two conditions, both required. On HIP it draws host RAM instead of the
-        selected APUs' carve-outs, so it pays only when host RAM is the larger
-        pool: available host RAM against the carve-out's TOTAL, deliberately,
-        because a carve-out another process is holding is not credited back to the
-        host side. Over-asking the carve-out returns hipErrorOutOfMemory and the
-        load fails cleanly, while over-asking host RAM is the OOM kill this gate
-        exists to stop.
-
-        And the weights must not fit the carve-out on their own. Managed pages are
-        a measured correctness risk on Linux ROCm: Qwen3.8-Flash-Next faults in
-        k_set_rows on gfx1151 with the variable set and is clean without it, on
-        b10715 and b10798 alike, while the same builds are clean on Windows and on
-        Vulkan (HF Qwen3.8-Flash-Next-GGUF discussion 30, #10330). So the swap is
-        taken only when the alternative is a load the carve-out cannot hold.
-        need_bytes is what a forced full offload puts on the device; the caller
-        passes None when the fitter or an explicit partial placement owns the
-        layer count, because a load that spills to the CPU fits without managed
-        pages. None fails closed, as do missing data and mixed-device selections.
+        Host RAM must be the larger pool, against the carve-out's TOTAL (over-asking
+        the carve-out fails cleanly, over-asking host RAM is an OOM kill), AND the
+        weights must not fit that carve-out: managed pages fault in k_set_rows on
+        Linux ROCm gfx1151 (HF Qwen3.8-Flash-Next-GGUF discussion 30, #10330).
         """
         try:
             pool_mib = LlamaCppBackend._rocm_selected_pool_mib(gpu_indices)
@@ -8918,9 +8900,8 @@ class LlamaCppBackend:
 
     @staticmethod
     def _unified_memory_opted_in(env = None) -> bool:
-        """True when UNSLOTH_ENABLE_UNIFIED_MEMORY=1 asks for managed allocation on a
-        selected APU even though the weights fit its carve-out. Exact "1", like the
-        disable switch, which wins when both are set. Fails closed (False)."""
+        """True when UNSLOTH_ENABLE_UNIFIED_MEMORY=1 asks for managed allocation even
+        though the weights fit. Exact "1"; the opt-out wins over it."""
         try:
             source = os.environ if env is None else env
             return str(source.get("UNSLOTH_ENABLE_UNIFIED_MEMORY", "")).strip() == "1"
@@ -8934,11 +8915,8 @@ class LlamaCppBackend:
         *,
         opted_in = False,
     ) -> bool:
-        """The launch-time decision behind GGML_CUDA_ENABLE_UNIFIED_MEMORY: the opt-in
-        takes it when every selected device is a unified-memory APU, otherwise only
-        when it pays and is needed (_unified_memory_would_help). The setting is
-        process-wide and hurts discrete cards, so a mixed selection answers False
-        on both routes."""
+        """The launch-time decision behind GGML_CUDA_ENABLE_UNIFIED_MEMORY. It is
+        process-wide and hurts discrete cards, so a mixed selection is always False."""
         if opted_in and LlamaCppBackend._rocm_selected_pool_mib(gpu_indices) is not None:
             return True
         return LlamaCppBackend._unified_memory_would_help(gpu_indices, need_bytes = need_bytes)
@@ -10391,18 +10369,11 @@ class LlamaCppBackend:
         argv: Iterable[str],
         env: Optional[Mapping[str, str]] = None,
     ) -> bool:
-        """Whether the child puts every layer on a GPU whatever the fitter says.
-
-        ``_argv_offloads_every_layer`` defers to an active fitter, which is right
-        for crediting VRAM: the fitter may lower llama.cpp's default ``-1``. It
-        cannot lower a count the user fixed (common/fit.cpp throws "n_gpu_layers
-        already set by user" and the caller downgrades it to a warning, see
-        ``_env_fixes_gpu_layers``), so a concrete count above the block count, or an
-        inherited LLAMA_ARG_N_GPU_LAYERS that says so, is a forced full offload even
-        under ``--fit on``. So is no count at all once the fitter is off: llama.cpp's
-        default is ``-1``, every layer, and nothing is left to lower it. An unknown
-        block count for a concrete count, or CPU placement, answers False.
-        """
+        """Whether the child puts every layer on a GPU whatever the fitter says. The
+        fitter cannot lower a count the user fixed (common/fit.cpp "n_gpu_layers
+        already set by user", downgraded to a warning), so a count above the block
+        count stands under ``--fit on``, as does no count at all with the fitter off
+        (llama.cpp's default is ``-1``)."""
         args = [str(a) for a in argv or ()]
         if self._argv_offloads_every_layer(args, env):
             return True
@@ -10423,13 +10394,10 @@ class LlamaCppBackend:
             except ValueError:
                 return False
         if requested is None:
-            # No count anywhere: the default -1 stands, so only an active fitter
-            # can make this anything but a full offload.
             return not fit_is_effectively_on(args, env)
         n_layers = self.n_layers
         if not n_layers:
             return False
-        # -1 is the default the fitter is free to lower; a concrete count stands.
         return requested > n_layers
 
     @staticmethod
@@ -19154,8 +19122,8 @@ class LlamaCppBackend:
                 total_by_idx: dict[int, int] = {}
                 _gpu_mem: list[tuple[int, int, int]] = []
                 model_size = None  # set in the fit try; used by the APU RAM guard
-                _mtp_will_engage = False  # set in the fit try; read by the unified-memory price
-                _separate_draft_launches = False  # same; a sidecar displaces an embedded head
+                _mtp_will_engage = False
+                _separate_draft_launches = False  # a sidecar displaces an embedded head
                 # "none" once the fit proves the load needs no demand paging, else None
                 # for llama.cpp's own default. Bound before the try like the verdict
                 # flags above: the except path falls through to the launch, which reads it.
@@ -22932,26 +22900,14 @@ class LlamaCppBackend:
                 _unified_env_applied = False
                 _unified_opt_out = self._unified_memory_opted_out(env)
                 _unified_opt_in = self._unified_memory_opted_in(env)
-                # The selection the setting was priced for. The arch gate and the
-                # arch-crash retry re-select without rebinding gpu_indices, and a
-                # later respawn must re-price against what the child actually sees.
+                # The arch gate and arch-crash retry re-select without rebinding gpu_indices.
                 _unified_gpu_indices = gpu_indices
 
-                # Price only what a forced full offload puts on the device. With the
-                # fitter or an explicit partial placement owning the layer count, the
-                # load fits by spilling, so the whole-file size would overstate the
-                # need and take managed pages for a launch the carve-out holds.
                 def _unified_need_now(argv = None, mtp_engages = None):
-                    """Bytes a forced full offload puts on the device, or None.
-
-                    ``argv`` is the command about to be spawned (``cmd`` by default)
-                    and ``mtp_engages`` whether a draft will load the trailing MTP
-                    blocks (``_mtp_will_engage`` by default); a retry that drops the
-                    drafter passes both."""
+                    """Bytes a forced full offload puts on the device, or None."""
                     run_argv = cmd if argv is None else argv
                     # The trailing blocks load only when the EMBEDDED head drafts: a
-                    # sidecar wins over it (llama.cpp loads the draft model on
-                    # has_dft()), whichever device the sidecar lands on.
+                    # sidecar wins over it (llama.cpp has_dft()), wherever it lands.
                     if mtp_engages is None:
                         engages = _mtp_will_engage and not _separate_draft_launches
                     else:
@@ -22959,17 +22915,10 @@ class LlamaCppBackend:
                     if model_size is None or not self._launch_forces_full_offload(run_argv, env):
                         return None
                     need = int(model_size)
-                    # The projector was priced onto the device; a retry that pins
-                    # it to the CPU or strips it loads the base alone.
                     if mmproj_size and not _argv_keeps_projector_on_gpu(run_argv, env):
                         need -= int(mmproj_size)
-                    # The file overstates the device: dev_input is CPU-pinned even
-                    # at full offload (offload_layout), so token_embd and the
-                    # per-layer table sharing its name never reach the carve-out.
-                    # A tied file duplicates the matrix onto the device instead, so
-                    # only an untied one subtracts it. Trailing NextN/MTP blocks
-                    # stay unloaded unless a draft engages. A table that cannot be
-                    # read cannot price either, so it takes nothing.
+                    # dev_input is CPU-pinned even at full offload, so token_embd never
+                    # reaches the device; a tied file duplicates the matrix onto it instead.
                     layout = self._tensor_spill_layout(model_path, all_shards = True)
                     if layout is None or not getattr(layout, "complete", True):
                         return None
@@ -22985,8 +22934,7 @@ class LlamaCppBackend:
                     mtp_engages = None,
                     why = "",
                 ):
-                    """Drop the variable this launch set once a respawn no longer
-                    needs it; an inherited or opted-in value is left alone."""
+                    """Drop the variable THIS launch set once a respawn stops needing it."""
                     nonlocal _unified_env_applied
                     if not _unified_env_applied:
                         return
@@ -24490,8 +24438,6 @@ class LlamaCppBackend:
                             strip_split_mode = False,
                         )
                     fallback_cmd = cmd[:_spec_at] + ["--spec-default"] + _fb_tail
-                    # The price counted the MTP blocks a draft would have loaded;
-                    # this retry loads none.
                     _unified_withdraw_if_unneeded(
                         fallback_cmd,
                         mtp_engages = False,
@@ -24580,7 +24526,6 @@ class LlamaCppBackend:
                                 "projector on CPU to preserve image input."
                             )
                             cmd = _cpu_projector_cmd
-                            # The projector's bytes leave the device with it.
                             _unified_withdraw_if_unneeded(
                                 cmd, why = "The retry with the projector on CPU"
                             )

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -10361,6 +10361,46 @@ class LlamaCppBackend:
         n_layers = self.n_layers
         return requested == -1 or (bool(n_layers) and requested > n_layers)
 
+    def _launch_forces_full_offload(
+        self,
+        argv: Iterable[str],
+        env: Optional[Mapping[str, str]] = None,
+    ) -> bool:
+        """Whether the child puts every layer on a GPU whatever the fitter says.
+
+        ``_argv_offloads_every_layer`` defers to an active fitter, which is right
+        for crediting VRAM: the fitter may lower llama.cpp's default ``-1``. It
+        cannot lower a count the user fixed (common/fit.cpp throws "n_gpu_layers
+        already set by user" and the caller downgrades it to a warning, see
+        ``_env_fixes_gpu_layers``), so a concrete count above the block count, or an
+        inherited LLAMA_ARG_N_GPU_LAYERS that says so, is a forced full offload even
+        under ``--fit on``. An unknown block count or CPU placement answers False.
+        """
+        args = [str(a) for a in argv or ()]
+        if self._argv_offloads_every_layer(args, env):
+            return True
+        if _device_selection_is_cpu(args, env):
+            return False
+        if _args_place_tensors_on_cpu(args) or _env_places_tensors_on_cpu(env):
+            return False
+        n_layers = self.n_layers
+        if not n_layers:
+            return False
+        try:
+            requested = parse_gpu_layers_override(args)
+        except ValueError:
+            return False
+        if requested is None and env and _env_fixes_gpu_layers(env):
+            raw = str(env.get("LLAMA_ARG_N_GPU_LAYERS", "")).strip().lower()
+            if raw == "all":
+                return True
+            try:
+                requested = int(raw)
+            except ValueError:
+                return False
+        # -1 is the default the fitter is free to lower; a concrete count stands.
+        return requested is not None and requested > n_layers
+
     @staticmethod
     def _rows_the_child_can_reach(detected_gpus, pinned_ids) -> list:
         """``detected_gpus`` narrowed to the cards THIS launch pinned the child to.
@@ -22863,7 +22903,7 @@ class LlamaCppBackend:
                 # fitter or an explicit partial placement owning the layer count, the
                 # load fits by spilling, so the whole-file size would overstate the
                 # need and take managed pages for a launch the carve-out holds.
-                _unified_need = model_size if self._argv_offloads_every_layer(cmd, env) else None
+                _unified_need = model_size if self._launch_forces_full_offload(cmd, env) else None
                 if _unified_opt_out:
                     # ggml tests presence, so passing a user's "0" through would
                     # ENABLE what they turned off (#8651). Only absence is off.
@@ -23034,7 +23074,7 @@ class LlamaCppBackend:
                         # the selected devices. Ownership protects inherited values.
                         _survivors_gain_unified = self._unified_memory_for_launch(
                             _survivors,
-                            model_size if self._argv_offloads_every_layer(cmd, env) else None,
+                            model_size if self._launch_forces_full_offload(cmd, env) else None,
                             opted_in = _unified_opt_in,
                         )
                         if _unified_env_applied and not _survivors_gain_unified:
@@ -23881,7 +23921,7 @@ class LlamaCppBackend:
                         _retry_wants_unified = self._amd_apu_wants_unified_memory(_remaining)
                         _retry_unified_helps = self._unified_memory_for_launch(
                             _remaining,
-                            model_size if self._argv_offloads_every_layer(cmd, env) else None,
+                            model_size if self._launch_forces_full_offload(cmd, env) else None,
                             opted_in = _unified_opt_in,
                         )
                         # Everything recorded so far priced the CRASHED selection, and

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4794,15 +4794,23 @@ def _argv_keeps_projector_on_gpu(
     """Whether *args* still load a projector onto the device.
 
     The text-only retry strips ``--mmproj`` and the CPU-projector retry appends
-    ``--no-mmproj-offload``; either leaves the base alone on the carve-out."""
+    ``--no-mmproj-offload``; either leaves the base alone on the carve-out. An
+    inherited ``LLAMA_ARG_MMPROJ`` / ``LLAMA_ARG_MMPROJ_URL`` outlives the argv
+    strip, and arg.cpp applies it before argv, so that projector still loads."""
     tokens = [str(a) for a in args]
+    env_map = env or {}
 
     def _flag(token: str) -> str:
         return token.split("=", 1)[0].replace("_", "-").lower()
 
-    if not any(_flag(a) in ("--mmproj", "-mm") for a in tokens):
+    from_argv = any(_flag(a) in ("--mmproj", "-mm") for a in tokens)
+    from_env = any(
+        str(env_map.get(name) or "").strip()
+        for name in ("LLAMA_ARG_MMPROJ", "LLAMA_ARG_MMPROJ_URL")
+    )
+    if not from_argv and not from_env:
         return False
-    return _resolved_mmproj_offload(tokens, env or {}) is not False
+    return _resolved_mmproj_offload(tokens, env_map) is not False
 
 
 def _paravirtual_mmproj_pinnable(server_caps: Mapping[str, object]) -> bool:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -22911,9 +22911,16 @@ class LlamaCppBackend:
                 # fitter or an explicit partial placement owning the layer count, the
                 # load fits by spilling, so the whole-file size would overstate the
                 # need and take managed pages for a launch the carve-out holds.
-                def _unified_need_now():
-                    """Bytes a forced full offload puts on the device, or None."""
-                    if model_size is None or not self._launch_forces_full_offload(cmd, env):
+                def _unified_need_now(argv = None, mtp_engages = None):
+                    """Bytes a forced full offload puts on the device, or None.
+
+                    ``argv`` is the command about to be spawned (``cmd`` by default)
+                    and ``mtp_engages`` whether a draft will load the trailing MTP
+                    blocks (``_mtp_will_engage`` by default); a retry that drops the
+                    drafter passes both."""
+                    run_argv = cmd if argv is None else argv
+                    engages = _mtp_will_engage if mtp_engages is None else mtp_engages
+                    if model_size is None or not self._launch_forces_full_offload(run_argv, env):
                         return None
                     need = int(model_size)
                     # Trailing NextN/MTP blocks stay unloaded unless a draft engages
@@ -22921,7 +22928,7 @@ class LlamaCppBackend:
                     # model_size counts them, and a base that fits its carve-out
                     # must not take managed pages on their account. A table that
                     # cannot be read cannot price them, so it does not take them.
-                    if not _mtp_will_engage and self._nextn_predict_layers:
+                    if not engages and self._nextn_predict_layers:
                         layout = self._tensor_spill_layout(model_path)
                         if layout is None:
                             return None
@@ -24412,6 +24419,21 @@ class LlamaCppBackend:
                             strip_split_mode = False,
                         )
                     fallback_cmd = cmd[:_spec_at] + ["--spec-default"] + _fb_tail
+                    # The managed-memory price counted the MTP blocks a draft would
+                    # have loaded; this retry loads none. Re-price the base alone and
+                    # withdraw only what this launch set, so a base the carve-out
+                    # holds does not carry managed pages into the drafterless server.
+                    if _unified_env_applied and not self._unified_memory_for_launch(
+                        gpu_indices,
+                        _unified_need_now(argv = fallback_cmd, mtp_engages = False),
+                        opted_in = _unified_opt_in,
+                    ):
+                        env.pop("GGML_CUDA_ENABLE_UNIFIED_MEMORY", None)
+                        _unified_env_applied = False
+                        logger.info(
+                            "Retry without speculative decoding no longer needs managed "
+                            "memory; dropped GGML_CUDA_ENABLE_UNIFIED_MEMORY."
+                        )
                     healthy = _spawn_and_wait(fallback_cmd, label = "-retry")
                     if healthy:
                         self._speculative_type = "default"

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8732,8 +8732,10 @@ class LlamaCppBackend:
         b10715 and b10798 alike, while the same builds are clean on Windows and on
         Vulkan (HF Qwen3.8-Flash-Next-GGUF discussion 30, #10330). So the swap is
         taken only when the alternative is a load the carve-out cannot hold.
-        need_bytes is the GPU-resident weight size; None (not priced) fails closed,
-        as do missing data and mixed-device selections.
+        need_bytes is what a forced full offload puts on the device; the caller
+        passes None when the fitter or an explicit partial placement owns the
+        layer count, because a load that spills to the CPU fits without managed
+        pages. None fails closed, as do missing data and mixed-device selections.
         """
         try:
             pool_mib = LlamaCppBackend._rocm_selected_pool_mib(gpu_indices)
@@ -8746,7 +8748,7 @@ class LlamaCppBackend:
                 return False
             if need_bytes is None:
                 return False
-            return int(need_bytes) // (1024 * 1024) > int(pool_mib)
+            return int(need_bytes) > int(pool_mib) * 1024 * 1024
         except Exception:
             return False
 
@@ -8908,9 +8910,11 @@ class LlamaCppBackend:
         opted_in = False,
     ) -> bool:
         """The launch-time decision behind GGML_CUDA_ENABLE_UNIFIED_MEMORY: the opt-in
-        takes it on any selected APU, otherwise only when it pays and is needed
-        (_unified_memory_would_help). Never on a discrete card."""
-        if opted_in and LlamaCppBackend._amd_apu_wants_unified_memory(gpu_indices):
+        takes it when every selected device is a unified-memory APU, otherwise only
+        when it pays and is needed (_unified_memory_would_help). The setting is
+        process-wide and hurts discrete cards, so a mixed selection answers False
+        on both routes."""
+        if opted_in and LlamaCppBackend._rocm_selected_pool_mib(gpu_indices) is not None:
             return True
         return LlamaCppBackend._unified_memory_would_help(gpu_indices, need_bytes = need_bytes)
 
@@ -22855,6 +22859,11 @@ class LlamaCppBackend:
                 _unified_env_applied = False
                 _unified_opt_out = self._unified_memory_opted_out(env)
                 _unified_opt_in = self._unified_memory_opted_in(env)
+                # Price only what a forced full offload puts on the device. With the
+                # fitter or an explicit partial placement owning the layer count, the
+                # load fits by spilling, so the whole-file size would overstate the
+                # need and take managed pages for a launch the carve-out holds.
+                _unified_need = model_size if self._argv_offloads_every_layer(cmd, env) else None
                 if _unified_opt_out:
                     # ggml tests presence, so passing a user's "0" through would
                     # ENABLE what they turned off (#8651). Only absence is off.
@@ -22863,7 +22872,7 @@ class LlamaCppBackend:
                             "Unified memory opted out: unset GGML_CUDA_ENABLE_UNIFIED_MEMORY"
                         )
                 elif not is_vulkan_backend and self._unified_memory_for_launch(
-                    gpu_indices, model_size, opted_in = _unified_opt_in
+                    gpu_indices, _unified_need, opted_in = _unified_opt_in
                 ):
                     _unified_env_applied = "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
                     env.setdefault("GGML_CUDA_ENABLE_UNIFIED_MEMORY", "1")
@@ -23024,7 +23033,9 @@ class LlamaCppBackend:
                         # The setting is process-wide, so recompute it after changing
                         # the selected devices. Ownership protects inherited values.
                         _survivors_gain_unified = self._unified_memory_for_launch(
-                            _survivors, model_size, opted_in = _unified_opt_in
+                            _survivors,
+                            model_size if self._argv_offloads_every_layer(cmd, env) else None,
+                            opted_in = _unified_opt_in,
                         )
                         if _unified_env_applied and not _survivors_gain_unified:
                             env.pop("GGML_CUDA_ENABLE_UNIFIED_MEMORY", None)
@@ -23869,7 +23880,9 @@ class LlamaCppBackend:
                         # determine whether managed allocations help.
                         _retry_wants_unified = self._amd_apu_wants_unified_memory(_remaining)
                         _retry_unified_helps = self._unified_memory_for_launch(
-                            _remaining, model_size, opted_in = _unified_opt_in
+                            _remaining,
+                            model_size if self._argv_offloads_every_layer(cmd, env) else None,
+                            opted_in = _unified_opt_in,
                         )
                         # Everything recorded so far priced the CRASHED selection, and
                         # that placement is gone: the canonical #7624 shape pins the APU

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -19147,6 +19147,7 @@ class LlamaCppBackend:
                 _gpu_mem: list[tuple[int, int, int]] = []
                 model_size = None  # set in the fit try; used by the APU RAM guard
                 _mtp_will_engage = False  # set in the fit try; read by the unified-memory price
+                _separate_draft_launches = False  # same; a sidecar displaces an embedded head
                 # "none" once the fit proves the load needs no demand paging, else None
                 # for llama.cpp's own default. Bound before the try like the verdict
                 # flags above: the except path falls through to the launch, which reads it.
@@ -22923,6 +22924,10 @@ class LlamaCppBackend:
                 _unified_env_applied = False
                 _unified_opt_out = self._unified_memory_opted_out(env)
                 _unified_opt_in = self._unified_memory_opted_in(env)
+                # The selection the setting was priced for. The arch gate and the
+                # arch-crash retry re-select without rebinding gpu_indices, and a
+                # later respawn must re-price against what the child actually sees.
+                _unified_gpu_indices = gpu_indices
 
                 # Price only what a forced full offload puts on the device. With the
                 # fitter or an explicit partial placement owning the layer count, the
@@ -22936,7 +22941,13 @@ class LlamaCppBackend:
                     blocks (``_mtp_will_engage`` by default); a retry that drops the
                     drafter passes both."""
                     run_argv = cmd if argv is None else argv
-                    engages = _mtp_will_engage if mtp_engages is None else mtp_engages
+                    # The trailing blocks load only when the EMBEDDED head drafts: a
+                    # sidecar wins over it (llama.cpp loads the draft model on
+                    # has_dft()), whichever device the sidecar lands on.
+                    if mtp_engages is None:
+                        engages = _mtp_will_engage and not _separate_draft_launches
+                    else:
+                        engages = mtp_engages
                     if model_size is None or not self._launch_forces_full_offload(run_argv, env):
                         return None
                     need = int(model_size)
@@ -22951,7 +22962,7 @@ class LlamaCppBackend:
                     # only an untied one subtracts it. Trailing NextN/MTP blocks
                     # stay unloaded unless a draft engages. A table that cannot be
                     # read cannot price either, so it takes nothing.
-                    layout = self._tensor_spill_layout(model_path)
+                    layout = self._tensor_spill_layout(model_path, all_shards = True)
                     if layout is None or not getattr(layout, "complete", True):
                         return None
                     if int(getattr(layout, "lm_head_bytes", 0) or 0):
@@ -22972,7 +22983,7 @@ class LlamaCppBackend:
                     if not _unified_env_applied:
                         return
                     if self._unified_memory_for_launch(
-                        gpu_indices,
+                        _unified_gpu_indices,
                         _unified_need_now(argv = run_cmd, mtp_engages = mtp_engages),
                         opted_in = _unified_opt_in,
                     ):
@@ -23154,6 +23165,7 @@ class LlamaCppBackend:
                         self._clear_split_placement_env(env)
                         # The setting is process-wide, so recompute it after changing
                         # the selected devices. Ownership protects inherited values.
+                        _unified_gpu_indices = _survivors
                         _survivors_gain_unified = self._unified_memory_for_launch(
                             _survivors, _unified_need_now(), opted_in = _unified_opt_in
                         )
@@ -24056,6 +24068,7 @@ class LlamaCppBackend:
                         )
                         self._kill_process()
                         gpu_indices = _remaining
+                        _unified_gpu_indices = _remaining
                         # GGML_CUDA_ENABLE_UNIFIED_MEMORY was decided for the CRASHED
                         # set. The canonical #7624 shape crashes on the APU and retries
                         # on the dGPU, where it is harmful, so withdraw it, but only
@@ -26904,7 +26917,12 @@ class LlamaCppBackend:
         logger.info("Tensor spill: dropping the plan for the %s retry; %s", why, "using --fit on")
         return [*stripped, "--fit", "on"]
 
-    def _tensor_spill_layout(self, model_path: "Optional[str]") -> "Optional[ModelLayout]":
+    def _tensor_spill_layout(
+        self,
+        model_path: "Optional[str]",
+        *,
+        all_shards: bool = False,
+    ) -> "Optional[ModelLayout]":
         """The GGUF's placement buckets, read once per path and cached.
 
         Per BLOCK, not per bucket total, so the planner can spill the minimum set
@@ -26926,14 +26944,18 @@ class LlamaCppBackend:
         # (size, mtime_ns) stat identity _slot_launch_fingerprint uses.
         try:
             st = os.stat(model_path)
-            key = (model_path, st.st_size, st.st_mtime_ns)
+            key = (model_path, st.st_size, st.st_mtime_ns, all_shards)
         except OSError:
-            key = (model_path, None, None)
+            key = (model_path, None, None, all_shards)
         cached = getattr(self, "_spill_layout_cache", None)
         if cached is not None and cached[0] == key:
             return cached[1]
         try:
-            layout = layout_from_gguf(model_path)
+            layout = (
+                layout_from_gguf(model_path, all_shards = True)
+                if all_shards
+                else layout_from_gguf(model_path)
+            )
         except Exception as e:  # unreadable, truncated, or an arch we cannot bucket
             logger.debug("Tensor spill: cannot read layout from %s (%s)", model_path, e)
             layout = None

--- a/studio/backend/core/inference/offload_layout.py
+++ b/studio/backend/core/inference/offload_layout.py
@@ -147,9 +147,7 @@ def layout_from_gguf(path: str, *, all_shards: bool = False) -> ModelLayout:
     Returns an incomplete layout (``complete = False``) rather than raising when
     anything required is missing, so a surprising GGUF makes the planner abstain
     instead of failing a load that llama.cpp would have handled.
-
-    ``all_shards`` reads a split model's sibling shards too, so the buckets cover
-    the whole file set llama.cpp loads; every shard has to be present.
+    ``all_shards`` reads every sibling shard; all of them must be present.
     """
     try:
         from gguf import GGUFReader

--- a/studio/backend/core/inference/offload_layout.py
+++ b/studio/backend/core/inference/offload_layout.py
@@ -14,6 +14,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from typing import Optional
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -123,33 +124,65 @@ def _field(
         return default
 
 
-def layout_from_gguf(path: str) -> ModelLayout:
+_SPLIT_SHARD_RE = re.compile(r"^(.*)-(\d{5})-of-(\d{5})\.gguf$", re.IGNORECASE)
+
+
+def split_shard_paths(path: str) -> Optional[list[str]]:
+    """Every shard of the split *path* belongs to, in order, or None when the name
+    is not llama.cpp's ``<prefix>-NNNNN-of-MMMMM.gguf`` (llama_split_path)."""
+    directory, name = os.path.split(path)
+    match = _SPLIT_SHARD_RE.match(name)
+    if not match:
+        return None
+    prefix, _index, total = match.groups()
+    return [
+        os.path.join(directory, f"{prefix}-{i:05d}-of-{int(total):05d}.gguf")
+        for i in range(1, int(total) + 1)
+    ]
+
+
+def layout_from_gguf(path: str, *, all_shards: bool = False) -> ModelLayout:
     """Read ``path`` into a :class:`ModelLayout`.
 
     Returns an incomplete layout (``complete = False``) rather than raising when
     anything required is missing, so a surprising GGUF makes the planner abstain
     instead of failing a load that llama.cpp would have handled.
+
+    ``all_shards`` reads a split model's sibling shards too, so the buckets cover
+    the whole file set llama.cpp loads; every shard has to be present.
     """
     try:
         from gguf import GGUFReader
-        reader = GGUFReader(path)
+        readers = [GGUFReader(path)]
+        if all_shards and int(_field(readers[0], "split.count") or 0) > 1:
+            shards = split_shard_paths(path)
+            if not shards or not all(os.path.isfile(p) for p in shards):
+                logger.debug("offload layout: split %s is missing a shard", path)
+                return ModelLayout()
+            readers = [GGUFReader(p) for p in shards]
     except Exception as exc:
         logger.debug("offload layout: cannot read %s (%s)", path, exc)
         return ModelLayout()
 
     try:
-        return _layout_from_reader(reader)
+        return _layout_from_readers(readers)
     except Exception as exc:
         logger.debug("offload layout: cannot interpret %s (%s)", path, exc)
         return ModelLayout()
 
 
 def _layout_from_reader(reader) -> ModelLayout:
+    return _layout_from_readers([reader])
+
+
+def _layout_from_readers(readers) -> ModelLayout:
+    """One reader per shard, the first carrying the metadata."""
+    reader = readers[0]
     # Split GGUF: llama.cpp loads every sibling shard (llama-model-loader.cpp:590-618), but GGUFReader memmaps only the
     # ONE path it was given. Shard 1 still carries the metadata, so the layout would look complete while undercounting
     # resident and spillable by most of the model -- an overstated fit, too few -ot patterns, and a startup OOM with
-    # --fit off. Abstain instead; the seam then reproduces --fit on exactly.
-    if int(_field(reader, "split.count") or 0) > 1:
+    # --fit off. Abstain unless every shard was handed over; the seam then reproduces --fit on exactly.
+    if (int(_field(reader, "split.count") or 0) or 1) != len(readers):
         return ModelLayout()
 
     arch = str(_field(reader, "general.architecture") or "")
@@ -213,7 +246,7 @@ def _layout_from_reader(reader) -> ModelLayout:
     token_embd = 0
     other_resident = 0
 
-    for tensor in reader.tensors:
+    for tensor in (t for r in readers for t in r.tensors):
         name = str(tensor.name)
         nbytes = int(tensor.n_bytes)
         match = _BLOCK_RE.match(name)

--- a/studio/backend/tests/test_amd_apu_unified_memory.py
+++ b/studio/backend/tests/test_amd_apu_unified_memory.py
@@ -420,9 +420,8 @@ _GIB = 1024**3
 
 
 class TestTheUnifiedMemorySwapIsOnlyTakenWhenItPays:
-    """Managed allocation is enabled only when host RAM is the larger pool. Every
-    arm prices weights that outgrow the carve-out, so the pool comparison is the
-    only thing each answer can turn on."""
+    """Managed allocation is enabled only when host RAM is the larger pool. Every arm
+    prices weights that outgrow the carve-out, so only the pools decide."""
 
     def _host(self, monkeypatch, specs, ram_mib):
         monkeypatch.setitem(sys.modules, "torch", _fake_torch_sized(specs))
@@ -497,10 +496,8 @@ class TestTheUnifiedMemorySwapIsOnlyTakenWhenItPays:
 
 
 class TestManagedMemoryIsTakenOnlyWhenTheWeightsOutgrowTheCarveOut:
-    """The second condition. On Linux ROCm managed pages are a measured correctness
-    risk (Qwen3.8-Flash-Next faults in k_set_rows on gfx1151 with the variable set
-    and is clean without it, b10715 and b10798 alike; HF Qwen3.8-Flash-Next-GGUF
-    discussion 30, #10330), so a launch the carve-out can hold never takes them."""
+    """The second condition: managed pages fault in k_set_rows on Linux ROCm gfx1151
+    (HF Qwen3.8-Flash-Next-GGUF discussion 30, #10330), so a fitting load never takes them."""
 
     def _strix_halo(
         self,
@@ -531,20 +528,17 @@ class TestManagedMemoryIsTakenOnlyWhenTheWeightsOutgrowTheCarveOut:
         assert LlamaCppBackend._unified_memory_would_help(need_bytes = 64 * _GIB + 1) is True
 
     def test_unpriced_weights_fail_closed(self, monkeypatch):
-        """None is "not priced yet", and a risk is not taken on a guess."""
         self._strix_halo(monkeypatch)
         assert LlamaCppBackend._unified_memory_would_help() is False
         assert LlamaCppBackend._unified_memory_would_help(need_bytes = None) is False
 
     def test_the_pool_comparison_still_comes_first(self, monkeypatch):
-        """Outgrowing a carve-out that is itself larger than host RAM buys nothing."""
         self._strix_halo(monkeypatch, carve_out = 96 * _GIB, ram_mib = 30_000)
         assert LlamaCppBackend._unified_memory_would_help(need_bytes = 120 * _GIB) is False
 
 
 class TestTheEnableSwitch:
-    """UNSLOTH_ENABLE_UNIFIED_MEMORY=1 takes managed allocation on a selected APU
-    even when the weights fit, for the user who has measured their own model."""
+    """UNSLOTH_ENABLE_UNIFIED_MEMORY=1 takes managed allocation even when weights fit."""
 
     @pytest.mark.parametrize(
         "env, expected",
@@ -552,7 +546,7 @@ class TestTheEnableSwitch:
             ({"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1"}, True),
             ({"UNSLOTH_ENABLE_UNIFIED_MEMORY": " 1 "}, True),
             ({"UNSLOTH_ENABLE_UNIFIED_MEMORY": "0"}, False),
-            ({"UNSLOTH_ENABLE_UNIFIED_MEMORY": "yes"}, False),  # exact "1", like the disable switch
+            ({"UNSLOTH_ENABLE_UNIFIED_MEMORY": "yes"}, False),
             ({}, False),
         ],
     )
@@ -591,7 +585,6 @@ class TestTheEnableSwitch:
         assert LlamaCppBackend._unified_memory_for_launch([0], 45 * _GIB, opted_in = True) is False
 
     def test_the_switch_refuses_a_mixed_selection(self, monkeypatch):
-        """Process-wide setting: one discrete card in the selection is a veto."""
         monkeypatch.setitem(
             sys.modules,
             "torch",

--- a/studio/backend/tests/test_amd_apu_unified_memory.py
+++ b/studio/backend/tests/test_amd_apu_unified_memory.py
@@ -420,7 +420,9 @@ _GIB = 1024**3
 
 
 class TestTheUnifiedMemorySwapIsOnlyTakenWhenItPays:
-    """Managed allocation is enabled only when host RAM is the larger pool."""
+    """Managed allocation is enabled only when host RAM is the larger pool. Every
+    arm prices weights that outgrow the carve-out, so the pool comparison is the
+    only thing each answer can turn on."""
 
     def _host(self, monkeypatch, specs, ram_mib):
         monkeypatch.setitem(sys.modules, "torch", _fake_torch_sized(specs))
@@ -430,23 +432,23 @@ class TestTheUnifiedMemorySwapIsOnlyTakenWhenItPays:
 
     def test_a_small_carve_out_still_gets_it(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 16 * _GIB)], 117_000)
-        assert LlamaCppBackend._unified_memory_would_help() is True
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is True
 
     def test_a_carve_out_larger_than_host_ram_does_not(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 64 * _GIB)], 58_880)
-        assert LlamaCppBackend._unified_memory_would_help() is False
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is False
 
     def test_an_exact_tie_does_not(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 32 * _GIB)], 32 * 1024)
-        assert LlamaCppBackend._unified_memory_would_help() is False
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is False
 
     def test_a_discrete_card_is_never_offered_it(self, monkeypatch):
         self._host(monkeypatch, [("gfx1100", 16 * _GIB)], 117_000)
-        assert LlamaCppBackend._unified_memory_would_help() is False
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is False
 
     def test_unreadable_host_ram_fails_closed(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 16 * _GIB)], None)
-        assert LlamaCppBackend._unified_memory_would_help() is False
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is False
 
     def test_an_unreported_pool_size_fails_closed(self, monkeypatch):
         monkeypatch.setitem(sys.modules, "torch", _fake_torch("6.2.0", ["gfx1151"]))
@@ -454,41 +456,136 @@ class TestTheUnifiedMemorySwapIsOnlyTakenWhenItPays:
             LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 117_000)
         )
         assert LlamaCppBackend._rocm_selected_pool_mib() is None
-        assert LlamaCppBackend._unified_memory_would_help() is False
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is False
 
     def test_a_missing_torch_fails_closed(self, monkeypatch):
         monkeypatch.setitem(sys.modules, "torch", None)
         assert LlamaCppBackend._rocm_selected_pool_mib() is None
-        assert LlamaCppBackend._unified_memory_would_help() is False
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is False
 
     def test_two_apus_are_weighed_together(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 8 * _GIB), ("gfx1150", 24 * _GIB)], 40_000)
         assert LlamaCppBackend._rocm_selected_pool_mib() == 32 * 1024
-        assert LlamaCppBackend._unified_memory_would_help() is True
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is True
         self._host(monkeypatch, [("gfx1151", 8 * _GIB), ("gfx1150", 24 * _GIB)], 30_000)
-        assert LlamaCppBackend._unified_memory_would_help() is False
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is False
 
     def test_the_answer_is_scoped_to_the_selected_gpu(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 8 * _GIB), ("gfx1150", 64 * _GIB)], 40_000)
-        assert LlamaCppBackend._unified_memory_would_help([0]) is True
-        assert LlamaCppBackend._unified_memory_would_help([1]) is False
+        assert LlamaCppBackend._unified_memory_would_help([0], need_bytes = 100 * _GIB) is True
+        assert LlamaCppBackend._unified_memory_would_help([1], need_bytes = 100 * _GIB) is False
 
     def test_a_discrete_card_in_the_selection_fails_closed(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 8 * _GIB), ("gfx1100", 64 * _GIB)], 40_000)
         assert LlamaCppBackend._rocm_selected_pool_mib() is None
-        assert LlamaCppBackend._unified_memory_would_help() is False
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is False
 
     def test_the_same_mixed_host_pinned_to_the_apu_still_gains(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 8 * _GIB), ("gfx1100", 64 * _GIB)], 40_000)
         assert LlamaCppBackend._rocm_selected_pool_mib([0]) == 8 * 1024
-        assert LlamaCppBackend._unified_memory_would_help([0]) is True
+        assert LlamaCppBackend._unified_memory_would_help([0], need_bytes = 100 * _GIB) is True
 
     def test_an_id_this_host_does_not_enumerate_fails_closed(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 8 * _GIB)], 117_000)
         assert LlamaCppBackend._rocm_selected_pool_mib([0, 3]) is None
-        assert LlamaCppBackend._unified_memory_would_help([0, 3]) is False
+        assert LlamaCppBackend._unified_memory_would_help([0, 3], need_bytes = 100 * _GIB) is False
 
     def test_an_empty_selection_fails_closed(self, monkeypatch):
         self._host(monkeypatch, [("gfx1151", 8 * _GIB)], 117_000)
         assert LlamaCppBackend._rocm_selected_pool_mib([]) is None
-        assert LlamaCppBackend._unified_memory_would_help([]) is False
+        assert LlamaCppBackend._unified_memory_would_help([], need_bytes = 100 * _GIB) is False
+
+
+class TestManagedMemoryIsTakenOnlyWhenTheWeightsOutgrowTheCarveOut:
+    """The second condition. On Linux ROCm managed pages are a measured correctness
+    risk (Qwen3.8-Flash-Next faults in k_set_rows on gfx1151 with the variable set
+    and is clean without it, b10715 and b10798 alike; HF Qwen3.8-Flash-Next-GGUF
+    discussion 30, #10330), so a launch the carve-out can hold never takes them."""
+
+    def _strix_halo(
+        self,
+        monkeypatch,
+        carve_out = 64 * _GIB,
+        ram_mib = 117_000,
+    ):
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch_sized([("gfx1151", carve_out)]))
+        monkeypatch.setattr(
+            LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: ram_mib)
+        )
+
+    def test_weights_that_fit_the_carve_out_do_not_get_it(self, monkeypatch):
+        self._strix_halo(monkeypatch)
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 45 * _GIB) is False
+
+    def test_weights_that_outgrow_it_do(self, monkeypatch):
+        self._strix_halo(monkeypatch)
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 100 * _GIB) is True
+
+    def test_weights_exactly_the_carve_out_do_not(self, monkeypatch):
+        self._strix_halo(monkeypatch)
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 64 * _GIB) is False
+
+    def test_unpriced_weights_fail_closed(self, monkeypatch):
+        """None is "not priced yet", and a risk is not taken on a guess."""
+        self._strix_halo(monkeypatch)
+        assert LlamaCppBackend._unified_memory_would_help() is False
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = None) is False
+
+    def test_the_pool_comparison_still_comes_first(self, monkeypatch):
+        """Outgrowing a carve-out that is itself larger than host RAM buys nothing."""
+        self._strix_halo(monkeypatch, carve_out = 96 * _GIB, ram_mib = 30_000)
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 120 * _GIB) is False
+
+
+class TestTheEnableSwitch:
+    """UNSLOTH_ENABLE_UNIFIED_MEMORY=1 takes managed allocation on a selected APU
+    even when the weights fit, for the user who has measured their own model."""
+
+    @pytest.mark.parametrize(
+        "env, expected",
+        [
+            ({"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1"}, True),
+            ({"UNSLOTH_ENABLE_UNIFIED_MEMORY": " 1 "}, True),
+            ({"UNSLOTH_ENABLE_UNIFIED_MEMORY": "0"}, False),
+            ({"UNSLOTH_ENABLE_UNIFIED_MEMORY": "yes"}, False),  # exact "1", like the disable switch
+            ({}, False),
+        ],
+    )
+    def test_opt_in_decisions(self, env, expected):
+        assert LlamaCppBackend._unified_memory_opted_in(env) is expected
+
+    def test_none_reads_the_process_env(self, monkeypatch):
+        monkeypatch.delenv("UNSLOTH_ENABLE_UNIFIED_MEMORY", raising = False)
+        assert LlamaCppBackend._unified_memory_opted_in() is False
+        monkeypatch.setenv("UNSLOTH_ENABLE_UNIFIED_MEMORY", "1")
+        assert LlamaCppBackend._unified_memory_opted_in() is True
+
+    def test_a_hostile_env_fails_closed(self):
+        class _Exploding:
+            def get(self, *_a, **_k):
+                raise RuntimeError("no")
+
+        assert LlamaCppBackend._unified_memory_opted_in(_Exploding()) is False
+
+    def _strix_halo(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch_sized([("gfx1151", 64 * _GIB)]))
+        monkeypatch.setattr(
+            LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 117_000)
+        )
+
+    def test_the_switch_takes_it_for_weights_that_fit(self, monkeypatch):
+        self._strix_halo(monkeypatch)
+        assert LlamaCppBackend._unified_memory_for_launch([0], 45 * _GIB) is False
+        assert LlamaCppBackend._unified_memory_for_launch([0], 45 * _GIB, opted_in = True) is True
+
+    def test_the_switch_never_reaches_a_discrete_card(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch_sized([("gfx1100", 16 * _GIB)]))
+        monkeypatch.setattr(
+            LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 117_000)
+        )
+        assert LlamaCppBackend._unified_memory_for_launch([0], 45 * _GIB, opted_in = True) is False
+
+    def test_without_the_switch_the_priced_gate_decides(self, monkeypatch):
+        self._strix_halo(monkeypatch)
+        assert LlamaCppBackend._unified_memory_for_launch([0], 100 * _GIB) is True
+        assert LlamaCppBackend._unified_memory_for_launch([0], None) is False

--- a/studio/backend/tests/test_amd_apu_unified_memory.py
+++ b/studio/backend/tests/test_amd_apu_unified_memory.py
@@ -525,6 +525,11 @@ class TestManagedMemoryIsTakenOnlyWhenTheWeightsOutgrowTheCarveOut:
         self._strix_halo(monkeypatch)
         assert LlamaCppBackend._unified_memory_would_help(need_bytes = 64 * _GIB) is False
 
+    def test_one_byte_over_does(self, monkeypatch):
+        """Bytes against bytes: flooring the need to MiB hid a sub-MiB overrun."""
+        self._strix_halo(monkeypatch)
+        assert LlamaCppBackend._unified_memory_would_help(need_bytes = 64 * _GIB + 1) is True
+
     def test_unpriced_weights_fail_closed(self, monkeypatch):
         """None is "not priced yet", and a risk is not taken on a guess."""
         self._strix_halo(monkeypatch)
@@ -584,6 +589,20 @@ class TestTheEnableSwitch:
             LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 117_000)
         )
         assert LlamaCppBackend._unified_memory_for_launch([0], 45 * _GIB, opted_in = True) is False
+
+    def test_the_switch_refuses_a_mixed_selection(self, monkeypatch):
+        """Process-wide setting: one discrete card in the selection is a veto."""
+        monkeypatch.setitem(
+            sys.modules,
+            "torch",
+            _fake_torch_sized([("gfx1151", 64 * _GIB), ("gfx1100", 16 * _GIB)]),
+        )
+        monkeypatch.setattr(
+            LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 117_000)
+        )
+        assert LlamaCppBackend._unified_memory_for_launch([0, 1], 45 * _GIB, opted_in = True) is False
+        assert LlamaCppBackend._unified_memory_for_launch(None, 45 * _GIB, opted_in = True) is False
+        assert LlamaCppBackend._unified_memory_for_launch([0], 45 * _GIB, opted_in = True) is True
 
     def test_without_the_switch_the_priced_gate_decides(self, monkeypatch):
         self._strix_halo(monkeypatch)

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -841,7 +841,7 @@ def _run_auto_load(
     # nothing (the unified-memory gate fails closed on it). Hand the load a
     # readable one unless the test brought its own.
     if "_tensor_spill_layout" not in vars(backend):
-        backend._tensor_spill_layout = lambda _path: _priced_layout()
+        backend._tensor_spill_layout = lambda _path, **_kw: _priced_layout()
     # Off by default: the APU RAM preflight is not what most of these cells are
     # about. A test that IS about it passes its own recording stub.
     backend._apu_ram_shortfall_message = apu_ram_stub or (lambda *_args, **_kwargs: None)
@@ -2142,7 +2142,7 @@ class TestUnifiedMemoryOptOut:
         the file size but never loaded."""
         backend = LlamaCppBackend()
         backend._nextn_predict_layers = 1
-        backend._tensor_spill_layout = lambda _path: (
+        backend._tensor_spill_layout = lambda _path, **_kw: (
             None
             if excluded_bytes is None
             else types.SimpleNamespace(excluded_block_bytes = excluded_bytes)
@@ -2186,7 +2186,7 @@ class TestUnifiedMemoryOptOut:
 
     def _with_layout(self, **fields):
         backend = LlamaCppBackend()
-        backend._tensor_spill_layout = lambda _path: _priced_layout(**fields)
+        backend._tensor_spill_layout = lambda _path, **_kw: _priced_layout(**fields)
         return backend
 
     def test_cpu_pinned_embeddings_are_not_priced(self, tmp_path, monkeypatch, probe_env):
@@ -2262,6 +2262,20 @@ class TestUnifiedMemoryOptOut:
         text_only = [e for c, e in launches if "--mmproj" not in c]
         assert text_only, [c for c, _e in launches]
         assert all("GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in e for e in text_only)
+
+    def test_a_sidecar_drafter_displaces_the_embedded_head(self, tmp_path, monkeypatch, probe_env):
+        """A draft requested with a sidecar loads the sidecar, not the file's
+        trailing blocks (llama.cpp loads the draft model on has_dft()), so the
+        30 GiB base is what reaches the carve-out."""
+        sidecar = tmp_path / "draft.gguf"
+        sidecar.write_bytes(b"GGUF")
+        _cmd, env = self._load(
+            tmp_path,
+            monkeypatch,
+            backend = self._with_unloaded_mtp_blocks(10 * GIB),
+            extra_args = ["--spec-type", "draft-mtp", "-md", str(sidecar)],
+        )[0]
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     def test_an_unreadable_tensor_table_cannot_price_the_blocks(
         self, tmp_path, monkeypatch, probe_env
@@ -3376,6 +3390,33 @@ class TestTheCarveOutDecidesTheUnifiedMemoryEnv:
         _cmd, env = launches[0]
         assert _visibility(env) == {"ROCR_VISIBLE_DEVICES": "0", "CUDA_VISIBLE_DEVICES": "0"}
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_the_narrowed_selection_is_what_a_later_retry_reprices(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """After the gate narrows onto the APU, a drafterless retry must price
+        against that APU, not the pre-gate mixed pair the swap cannot help."""
+        torch = self._apu_and_dgpu(monkeypatch, 40_000)
+        backend = LlamaCppBackend()
+        backend._nextn_predict_layers = 1
+        backend._tensor_spill_layout = lambda _path, **_kw: _priced_layout()
+        launches = _run_auto_load(
+            monkeypatch,
+            tmp_path,
+            torch,
+            ["gfx1151"],
+            returncode = 1,
+            output = "failed to create llama_context",
+            model_bytes = 400 * GIB,
+            env_extra = {"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1"},
+            intent_kwargs = {"extra_args": ["--spec-type", "draft-mtp"]},
+            backend = backend,
+        )
+        first_cmd, first_env = launches[0]
+        assert "draft-mtp" in first_cmd and first_env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+        retries = [(c, e) for c, e in launches if "--spec-default" in c and "draft-mtp" not in c]
+        assert retries, [c for c, _e in launches]
+        assert all(e.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1" for _c, e in retries)
 
     def test_the_opt_out_survives_that_narrowing(self, tmp_path, monkeypatch, probe_env):
         torch = self._apu_and_dgpu(monkeypatch, 40_000)

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -1961,11 +1961,12 @@ class TestUnifiedMemoryOptOut:
         monkeypatch,
         env_extra = None,
         model_bytes = 40 * GIB,  # outgrows the fake 32 GiB carve-out
+        backend = None,
     ):
         # A forced full offload (manual mode at the picker's maximum, above the
         # block count) is the launch that can only fit with managed pages; under
         # the fitter the file would spill instead and never ask for them.
-        backend = LlamaCppBackend()
+        backend = backend or LlamaCppBackend()
         backend._n_layers = 8
         return _run_auto_load(
             monkeypatch,
@@ -2098,6 +2099,42 @@ class TestUnifiedMemoryOptOut:
         self, tmp_path, monkeypatch, probe_env
     ):
         _cmd, env = self._auto_mode_with(tmp_path, monkeypatch, extra_args = ["--gpu-layers", "4"])
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    def _with_unloaded_mtp_blocks(self, excluded_bytes):
+        """A NextN GGUF with no draft engaged: the trailing blocks are counted in
+        the file size but never loaded."""
+        backend = LlamaCppBackend()
+        backend._nextn_predict_layers = 1
+        backend._tensor_spill_layout = lambda _path: (
+            None
+            if excluded_bytes is None
+            else types.SimpleNamespace(excluded_block_bytes = excluded_bytes)
+        )
+        return backend
+
+    def test_unloaded_mtp_blocks_are_not_priced(self, tmp_path, monkeypatch, probe_env):
+        """40 GiB file, 10 GiB of it trailing MTP blocks: the 30 GiB base fits."""
+        _cmd, env = self._load(
+            tmp_path, monkeypatch, backend = self._with_unloaded_mtp_blocks(10 * GIB)
+        )[0]
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    def test_unloaded_mtp_blocks_still_leave_an_oversized_base(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        _cmd, env = self._load(
+            tmp_path, monkeypatch, backend = self._with_unloaded_mtp_blocks(4 * GIB)
+        )[0]
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_an_unreadable_tensor_table_cannot_price_the_blocks(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """Unpriced is not "take it": the unsafe direction is the measured fault."""
+        _cmd, env = self._load(tmp_path, monkeypatch, backend = self._with_unloaded_mtp_blocks(None))[
+            0
+        ]
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     def test_the_disable_switch_beats_the_enable_switch(self, tmp_path, monkeypatch, probe_env):

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -771,8 +771,7 @@ class TestArchStringRobustness:
 
 
 def _priced_layout(**fields):
-    """A readable tensor layout: untied embeddings, nothing CPU-pinned, no MTP
-    blocks, unless a test says otherwise."""
+    """A readable layout: untied embeddings, nothing CPU-pinned, no MTP blocks."""
     from core.inference.offload_layout import ModelLayout
 
     values = {"complete": True, "lm_head_bytes": 1}
@@ -837,9 +836,7 @@ def _run_auto_load(
     else:
         backend._mmproj_vram_bytes = lambda _path: 0
         backend._resolve_launch_mmproj_path = lambda **_kwargs: None
-    # The header-only GGUF has no tensor table, and an unreadable layout prices
-    # nothing (the unified-memory gate fails closed on it). Hand the load a
-    # readable one unless the test brought its own.
+    # A header-only GGUF prices nothing, so hand the load a readable layout.
     if "_tensor_spill_layout" not in vars(backend):
         backend._tensor_spill_layout = lambda _path, **_kw: _priced_layout()
     # Off by default: the APU RAM preflight is not what most of these cells are
@@ -1187,7 +1184,7 @@ class TestArchCrashRetryEnv:
             None,  # no marker: the proactive gate fails open, so the crash path runs
             returncode = 1,
             output = "ROCm error: device kernel image is invalid",
-            model_bytes = 10 * GIB,  # outgrows the APU's 8 GiB carve-out without moving the placement
+            model_bytes = 10 * GIB,  # outgrows the APU's 8 GiB carve-out
         )
         # The APU is pinned first, so the crashed spawn carries the env and the
         # respawns are masked onto the discrete card. The unrelated --fit off retry
@@ -1950,7 +1947,7 @@ class TestArchCrashRetryOntoAnApu:
             None,  # no marker: the proactive gate fails open, so the crash path runs
             returncode = 1,
             output = "ROCm error: device kernel image is invalid",
-            model_bytes = 10 * GIB,  # outgrows the APU's 8 GiB carve-out without moving the placement
+            model_bytes = 10 * GIB,  # outgrows the APU's 8 GiB carve-out
         )
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in launches[0][1]
         _retry = [env for _c, env in launches if env.get("ROCR_VISIBLE_DEVICES") == "1"]
@@ -1992,9 +1989,7 @@ class TestUnifiedMemoryOptOut:
         mmproj_bytes = 0,
         server_caps = None,
     ):
-        # A forced full offload (manual mode at the picker's maximum, above the
-        # block count) is the launch that can only fit with managed pages; under
-        # the fitter the file would spill instead and never ask for them.
+        # Manual mode above the block count: the only launch that needs managed pages.
         backend = backend or LlamaCppBackend()
         backend._n_layers = 8
         intent_kwargs = {"gpu_memory_mode": "manual", "gpu_layers": 9}
@@ -2019,15 +2014,13 @@ class TestUnifiedMemoryOptOut:
     def test_a_forced_full_offload_that_outgrows_the_carve_out_gets_it(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """Baseline: #5301 added the variable for exactly this hardware, for the
-        load its carve-out cannot hold any other way."""
+        """Baseline: #5301 added the variable for exactly this hardware."""
         _cmd, env = self._load(tmp_path, monkeypatch)[0]
         assert "--gpu-layers" in _cmd and _cmd[_cmd.index("--gpu-layers") + 1] == "9"
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
 
     def test_weights_that_fit_the_carve_out_keep_it_unset(self, tmp_path, monkeypatch, probe_env):
-        """Managed pages fault Qwen3.8-Flash-Next on Linux gfx1151 (b10715 and b10798,
-        clean with the variable unset), so a load the carve-out holds never takes them."""
+        """Managed pages fault Qwen3.8-Flash-Next on Linux gfx1151 (#10330)."""
         _cmd, env = self._load(tmp_path, monkeypatch, model_bytes = 20 * GIB)[0]
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
@@ -2038,8 +2031,6 @@ class TestUnifiedMemoryOptOut:
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
 
     def test_a_manual_partial_placement_never_takes_it(self, tmp_path, monkeypatch, probe_env):
-        """The whole file outgrows the carve-out, but only one layer is going to
-        the device, so the launch fits without managed pages."""
         launches = _run_auto_load(
             monkeypatch,
             tmp_path,
@@ -2056,7 +2047,6 @@ class TestUnifiedMemoryOptOut:
     def test_the_fitter_owning_the_layer_count_never_takes_it(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """A file the carve-out cannot hold spills under --fit on and fits that way."""
         launches = _run_auto_load(
             monkeypatch,
             tmp_path,
@@ -2077,8 +2067,6 @@ class TestUnifiedMemoryOptOut:
         extra_args = None,
         env_extra = None,
     ):
-        """Auto mode keeps --fit on for an oversized file; a user-fixed layer
-        count is what decides whether the fitter can still spill it."""
         backend = LlamaCppBackend()
         backend._n_layers = 8
         return _run_auto_load(
@@ -2096,8 +2084,6 @@ class TestUnifiedMemoryOptOut:
     def test_a_user_count_above_the_block_count_stands_under_the_fitter(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """llama.cpp's fitter refuses to lower a count the user set, so this is
-        a forced full offload even with --fit on."""
         _cmd, env = self._auto_mode_with(tmp_path, monkeypatch, extra_args = ["--gpu-layers", "9"])
         assert "--fit" in _cmd and _cmd[_cmd.index("--fit") + 1] == "on"
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
@@ -2113,13 +2099,10 @@ class TestUnifiedMemoryOptOut:
     def test_a_user_minus_one_still_leaves_the_fitter_in_charge(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """-1 is llama.cpp's default, which the fitter may lower, so the file spills."""
         _cmd, env = self._auto_mode_with(tmp_path, monkeypatch, extra_args = ["-ngl", "-1"])
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     def test_a_user_fit_off_with_no_count_is_a_full_offload(self, tmp_path, monkeypatch, probe_env):
-        """Auto mode emits no count on the fitting path; a trailing --fit off
-        leaves llama.cpp's default -1 with nothing to lower it."""
         _cmd, env = self._auto_mode_with(tmp_path, monkeypatch, extra_args = ["--fit", "off"])
         assert "--gpu-layers" not in _cmd and "-ngl" not in _cmd
         assert _cmd[len(_cmd) - 1 - _cmd[::-1].index("--fit") + 1] == "off"
@@ -2138,8 +2121,6 @@ class TestUnifiedMemoryOptOut:
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     def _with_unloaded_mtp_blocks(self, excluded_bytes):
-        """A NextN GGUF with no draft engaged: the trailing blocks are counted in
-        the file size but never loaded."""
         backend = LlamaCppBackend()
         backend._nextn_predict_layers = 1
         backend._tensor_spill_layout = lambda _path, **_kw: (
@@ -2150,7 +2131,6 @@ class TestUnifiedMemoryOptOut:
         return backend
 
     def test_unloaded_mtp_blocks_are_not_priced(self, tmp_path, monkeypatch, probe_env):
-        """40 GiB file, 10 GiB of it trailing MTP blocks: the 30 GiB base fits."""
         _cmd, env = self._load(
             tmp_path, monkeypatch, backend = self._with_unloaded_mtp_blocks(10 * GIB)
         )[0]
@@ -2167,8 +2147,6 @@ class TestUnifiedMemoryOptOut:
     def test_the_drafterless_retry_reprices_without_the_mtp_blocks(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """MTP engaged, so the first launch priced the blocks and took managed
-        memory; the retry without the drafter loads a base the carve-out holds."""
         launches = self._load(
             tmp_path,
             monkeypatch,
@@ -2190,15 +2168,12 @@ class TestUnifiedMemoryOptOut:
         return backend
 
     def test_cpu_pinned_embeddings_are_not_priced(self, tmp_path, monkeypatch, probe_env):
-        """40 GiB file, 10 GiB of it token_embd (the PLE table shares that name):
-        dev_input stays on the CPU at full offload, so the 30 GiB on the device fit."""
         _cmd, env = self._load(
             tmp_path, monkeypatch, backend = self._with_layout(token_embd_bytes = 10 * GIB)
         )[0]
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     def test_tied_embeddings_still_reach_the_device(self, tmp_path, monkeypatch, probe_env):
-        """No output.weight: llama.cpp duplicates the matrix onto the device."""
         _cmd, env = self._load(
             tmp_path,
             monkeypatch,
@@ -2227,8 +2202,7 @@ class TestUnifiedMemoryOptOut:
         monkeypatch,
         server_caps = None,
     ):
-        """30 GiB base plus a 4 GiB projector outgrow the 32 GiB carve-out; the
-        base alone does not. The GPU-projector launch fails on memory."""
+        """30 GiB base + 4 GiB projector outgrow the 32 GiB carve-out; the base does not."""
         launches = self._load(
             tmp_path,
             monkeypatch,
@@ -2257,7 +2231,6 @@ class TestUnifiedMemoryOptOut:
     def test_the_text_only_retry_reprices_without_the_projector(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """A build without --no-mmproj-offload goes straight to stripping --mmproj."""
         launches = self._vision_launches(tmp_path, monkeypatch)
         text_only = [e for c, e in launches if "--mmproj" not in c]
         assert text_only, [c for c, _e in launches]
@@ -2266,9 +2239,6 @@ class TestUnifiedMemoryOptOut:
     def test_an_inherited_projector_outlives_the_text_only_retry(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """Stripping --mmproj does not clear LLAMA_ARG_MMPROJ, and arg.cpp applies
-        the variable before argv, so the retry still loads a projector onto the
-        device and must keep managed memory."""
         inherited = tmp_path / "inherited-mmproj.gguf"
         inherited.write_bytes(b"GGUF")
         launches = self._load(
@@ -2290,9 +2260,6 @@ class TestUnifiedMemoryOptOut:
         assert all(e.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1" for e in text_only)
 
     def test_a_sidecar_drafter_displaces_the_embedded_head(self, tmp_path, monkeypatch, probe_env):
-        """A draft requested with a sidecar loads the sidecar, not the file's
-        trailing blocks (llama.cpp loads the draft model on has_dft()), so the
-        30 GiB base is what reaches the carve-out."""
         sidecar = tmp_path / "draft.gguf"
         sidecar.write_bytes(b"GGUF")
         _cmd, env = self._load(
@@ -2306,7 +2273,6 @@ class TestUnifiedMemoryOptOut:
     def test_an_unreadable_tensor_table_cannot_price_the_blocks(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """Unpriced is not "take it": the unsafe direction is the measured fault."""
         _cmd, env = self._load(tmp_path, monkeypatch, backend = self._with_unloaded_mtp_blocks(None))[
             0
         ]
@@ -3304,7 +3270,6 @@ class TestTheCarveOutDecidesTheUnifiedMemoryEnv:
         env_extra = None,
         model_bytes = 40 * GIB,  # outgrows every carve-out below
     ):
-        # Forced full offload, so the carve-out is the only thing that can decide.
         backend = LlamaCppBackend()
         backend._n_layers = 8
         return _run_auto_load(
@@ -3409,8 +3374,6 @@ class TestTheCarveOutDecidesTheUnifiedMemoryEnv:
             ["gfx1151"],  # covers the APU, not the discrete gfx1100
             returncode = None,
             model_bytes = 400 * GIB,
-            # The fitter owns the layer count for a file this size, so the swap
-            # is asked for; the narrowing is what is under test.
             env_extra = {"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1"},
         )
         _cmd, env = launches[0]
@@ -3420,8 +3383,6 @@ class TestTheCarveOutDecidesTheUnifiedMemoryEnv:
     def test_the_narrowed_selection_is_what_a_later_retry_reprices(
         self, tmp_path, monkeypatch, probe_env
     ):
-        """After the gate narrows onto the APU, a drafterless retry must price
-        against that APU, not the pre-gate mixed pair the swap cannot help."""
         torch = self._apu_and_dgpu(monkeypatch, 40_000)
         backend = LlamaCppBackend()
         backend._nextn_predict_layers = 1

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -2032,6 +2032,60 @@ class TestUnifiedMemoryOptOut:
         assert "--fit" in _cmd and _cmd[_cmd.index("--fit") + 1] == "on"
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
+    def _auto_mode_with(
+        self,
+        tmp_path,
+        monkeypatch,
+        *,
+        extra_args = None,
+        env_extra = None,
+    ):
+        """Auto mode keeps --fit on for an oversized file; a user-fixed layer
+        count is what decides whether the fitter can still spill it."""
+        backend = LlamaCppBackend()
+        backend._n_layers = 8
+        return _run_auto_load(
+            monkeypatch,
+            tmp_path,
+            self._strix_halo(monkeypatch),
+            None,
+            returncode = None,
+            model_bytes = 40 * GIB,
+            backend = backend,
+            intent_kwargs = {"extra_args": list(extra_args or [])},
+            env_extra = env_extra,
+        )[0]
+
+    def test_a_user_count_above_the_block_count_stands_under_the_fitter(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """llama.cpp's fitter refuses to lower a count the user set, so this is
+        a forced full offload even with --fit on."""
+        _cmd, env = self._auto_mode_with(tmp_path, monkeypatch, extra_args = ["--gpu-layers", "9"])
+        assert "--fit" in _cmd and _cmd[_cmd.index("--fit") + 1] == "on"
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_an_inherited_count_above_the_block_count_stands_too(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        _cmd, env = self._auto_mode_with(
+            tmp_path, monkeypatch, env_extra = {"LLAMA_ARG_N_GPU_LAYERS": "9"}
+        )
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_a_user_minus_one_still_leaves_the_fitter_in_charge(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """-1 is llama.cpp's default, which the fitter may lower, so the file spills."""
+        _cmd, env = self._auto_mode_with(tmp_path, monkeypatch, extra_args = ["-ngl", "-1"])
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    def test_a_user_count_below_the_block_count_never_takes_it(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        _cmd, env = self._auto_mode_with(tmp_path, monkeypatch, extra_args = ["--gpu-layers", "4"])
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
     def test_the_disable_switch_beats_the_enable_switch(self, tmp_path, monkeypatch, probe_env):
         _cmd, env = self._load(
             tmp_path,

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -2263,6 +2263,32 @@ class TestUnifiedMemoryOptOut:
         assert text_only, [c for c, _e in launches]
         assert all("GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in e for e in text_only)
 
+    def test_an_inherited_projector_outlives_the_text_only_retry(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """Stripping --mmproj does not clear LLAMA_ARG_MMPROJ, and arg.cpp applies
+        the variable before argv, so the retry still loads a projector onto the
+        device and must keep managed memory."""
+        inherited = tmp_path / "inherited-mmproj.gguf"
+        inherited.write_bytes(b"GGUF")
+        launches = self._load(
+            tmp_path,
+            monkeypatch,
+            env_extra = {"LLAMA_ARG_MMPROJ": str(inherited)},
+            model_bytes = 30 * GIB,
+            mmproj_bytes = 4 * GIB,
+            intent_extra = {"is_vision": True, "mmproj_path": str(tmp_path / "mmproj.gguf")},
+            returncode = 1,
+            output = self._PROJECTOR_OOM,
+        )
+        first_cmd, first_env = launches[0]
+        assert "--mmproj" in first_cmd, first_cmd
+        assert first_env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+        text_only = [e for c, e in launches if "--mmproj" not in c]
+        assert text_only, [c for c, _e in launches]
+        assert all(e.get("LLAMA_ARG_MMPROJ") == str(inherited) for e in text_only)
+        assert all(e.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1" for e in text_only)
+
     def test_a_sidecar_drafter_displaces_the_embedded_head(self, tmp_path, monkeypatch, probe_env):
         """A draft requested with a sidecar loads the sidecar, not the file's
         trailing blocks (llama.cpp loads the draft model on has_dft()), so the

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -770,6 +770,16 @@ class TestArchStringRobustness:
         ) == frozenset({"gfx1030"})
 
 
+def _priced_layout(**fields):
+    """A readable tensor layout: untied embeddings, nothing CPU-pinned, no MTP
+    blocks, unless a test says otherwise."""
+    from core.inference.offload_layout import ModelLayout
+
+    values = {"complete": True, "lm_head_bytes": 1}
+    values.update(fields)
+    return ModelLayout(**values)
+
+
 def _run_auto_load(
     monkeypatch,
     tmp_path,
@@ -785,6 +795,8 @@ def _run_auto_load(
     apu_ram_stub = None,
     host_offload_stub = None,
     backend = None,
+    mmproj_bytes = 0,
+    server_caps = None,
 ):
     """Drive a real automatic (no explicit GPU pick) llama-server load with the real
     ``_get_gpu_memory`` behind it, and return the spawned (cmd, env) list.
@@ -817,8 +829,19 @@ def _run_auto_load(
     # model_bytes drives the placement decision: a model no GPU can hold makes
     # _select_gpus return (None, True), so `--fit on` owns placement.
     backend._get_gguf_size_bytes = lambda _path: model_bytes
-    backend._mmproj_vram_bytes = lambda _path: 0
-    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+    if mmproj_bytes:
+        mmproj = tmp_path / "mmproj.gguf"
+        mmproj.write_bytes(b"GGUF")
+        backend._mmproj_vram_bytes = lambda _path: mmproj_bytes
+        backend._resolve_launch_mmproj_path = lambda **_kwargs: str(mmproj)
+    else:
+        backend._mmproj_vram_bytes = lambda _path: 0
+        backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+    # The header-only GGUF has no tensor table, and an unreadable layout prices
+    # nothing (the unified-memory gate fails closed on it). Hand the load a
+    # readable one unless the test brought its own.
+    if "_tensor_spill_layout" not in vars(backend):
+        backend._tensor_spill_layout = lambda _path: _priced_layout()
     # Off by default: the APU RAM preflight is not what most of these cells are
     # about. A test that IS about it passes its own recording stub.
     backend._apu_ram_shortfall_message = apu_ram_stub or (lambda *_args, **_kwargs: None)
@@ -826,7 +849,7 @@ def _run_auto_load(
     backend._host_offload_shortfall_message = host_offload_stub or (lambda *_args, **_kwargs: None)
     backend._find_llama_server_binary = lambda include_denied = False: binary
     backend._fit_off_retry_eligible = lambda *_args, **_kwargs: False
-    backend.probe_server_capabilities = lambda _binary: {"found": True}
+    backend.probe_server_capabilities = lambda _binary: {"found": True, **(server_caps or {})}
     backend._record_server_pid = lambda _pid: None
     backend._clear_server_pid = lambda: None
     # env_extra seeds the child env the way an inherited / user-set variable
@@ -1965,6 +1988,9 @@ class TestUnifiedMemoryOptOut:
         extra_args = None,
         returncode = None,
         output = "",
+        intent_extra = None,
+        mmproj_bytes = 0,
+        server_caps = None,
     ):
         # A forced full offload (manual mode at the picker's maximum, above the
         # block count) is the launch that can only fit with managed pages; under
@@ -1974,6 +2000,7 @@ class TestUnifiedMemoryOptOut:
         intent_kwargs = {"gpu_memory_mode": "manual", "gpu_layers": 9}
         if extra_args:
             intent_kwargs["extra_args"] = list(extra_args)
+        intent_kwargs.update(intent_extra or {})
         return _run_auto_load(
             monkeypatch,
             tmp_path,
@@ -1985,6 +2012,8 @@ class TestUnifiedMemoryOptOut:
             model_bytes = model_bytes,
             backend = backend,
             intent_kwargs = intent_kwargs,
+            mmproj_bytes = mmproj_bytes,
+            server_caps = server_caps,
         )
 
     def test_a_forced_full_offload_that_outgrows_the_carve_out_gets_it(
@@ -2154,6 +2183,85 @@ class TestUnifiedMemoryOptOut:
         retries = [(c, e) for c, e in launches if "--spec-default" in c and "draft-mtp" not in c]
         assert retries, [c for c, _e in launches]
         assert all("GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in e for _c, e in retries)
+
+    def _with_layout(self, **fields):
+        backend = LlamaCppBackend()
+        backend._tensor_spill_layout = lambda _path: _priced_layout(**fields)
+        return backend
+
+    def test_cpu_pinned_embeddings_are_not_priced(self, tmp_path, monkeypatch, probe_env):
+        """40 GiB file, 10 GiB of it token_embd (the PLE table shares that name):
+        dev_input stays on the CPU at full offload, so the 30 GiB on the device fit."""
+        _cmd, env = self._load(
+            tmp_path, monkeypatch, backend = self._with_layout(token_embd_bytes = 10 * GIB)
+        )[0]
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    def test_tied_embeddings_still_reach_the_device(self, tmp_path, monkeypatch, probe_env):
+        """No output.weight: llama.cpp duplicates the matrix onto the device."""
+        _cmd, env = self._load(
+            tmp_path,
+            monkeypatch,
+            backend = self._with_layout(token_embd_bytes = 10 * GIB, lm_head_bytes = 0),
+        )[0]
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_small_embeddings_leave_an_oversized_base(self, tmp_path, monkeypatch, probe_env):
+        _cmd, env = self._load(
+            tmp_path, monkeypatch, backend = self._with_layout(token_embd_bytes = 4 * GIB)
+        )[0]
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_an_incomplete_layout_cannot_price_the_file(self, tmp_path, monkeypatch, probe_env):
+        _cmd, env = self._load(tmp_path, monkeypatch, backend = self._with_layout(complete = False))[0]
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    _PROJECTOR_OOM = (
+        "ggml_backend_cuda_buffer_type_alloc_buffer: allocating 4096.00 MiB on "
+        "device 0: cudaMalloc failed: out of memory"
+    )
+
+    def _vision_launches(
+        self,
+        tmp_path,
+        monkeypatch,
+        server_caps = None,
+    ):
+        """30 GiB base plus a 4 GiB projector outgrow the 32 GiB carve-out; the
+        base alone does not. The GPU-projector launch fails on memory."""
+        launches = self._load(
+            tmp_path,
+            monkeypatch,
+            model_bytes = 30 * GIB,
+            mmproj_bytes = 4 * GIB,
+            intent_extra = {"is_vision": True, "mmproj_path": str(tmp_path / "mmproj.gguf")},
+            server_caps = server_caps,
+            returncode = 1,
+            output = self._PROJECTOR_OOM,
+        )
+        first_cmd, first_env = launches[0]
+        assert "--mmproj" in first_cmd and "--no-mmproj-offload" not in first_cmd, first_cmd
+        assert first_env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+        return launches
+
+    def test_the_cpu_projector_retry_reprices_without_its_bytes(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        launches = self._vision_launches(
+            tmp_path, monkeypatch, server_caps = {"supports_no_mmproj_offload": True}
+        )
+        cpu_pinned = [e for c, e in launches if "--no-mmproj-offload" in c]
+        assert cpu_pinned, [c for c, _e in launches]
+        assert all("GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in e for e in cpu_pinned)
+
+    def test_the_text_only_retry_reprices_without_the_projector(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """A build without --no-mmproj-offload goes straight to stripping --mmproj."""
+        launches = self._vision_launches(tmp_path, monkeypatch)
+        text_only = [e for c, e in launches if "--mmproj" not in c]
+        assert text_only, [c for c, _e in launches]
+        assert all("GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in e for e in text_only)
 
     def test_an_unreadable_tensor_table_cannot_price_the_blocks(
         self, tmp_path, monkeypatch, probe_env

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -1144,7 +1144,7 @@ class TestArchCrashRetryEnv:
         )
         return _fake_torch(
             [
-                _device("gfx1151", free_mib = 40000, is_integrated = 1),
+                _device("gfx1151", free_mib = 40000, total_bytes = 8 * GIB, is_integrated = 1),
                 _device("gfx1030", free_mib = 12049),
             ],
             vendor = "amd",
@@ -1164,6 +1164,7 @@ class TestArchCrashRetryEnv:
             None,  # no marker: the proactive gate fails open, so the crash path runs
             returncode = 1,
             output = "ROCm error: device kernel image is invalid",
+            model_bytes = 10 * GIB,  # outgrows the APU's 8 GiB carve-out without moving the placement
         )
         # The APU is pinned first, so the crashed spawn carries the env and the
         # respawns are masked onto the discrete card. The unrelated --fit off retry
@@ -1911,7 +1912,7 @@ class TestArchCrashRetryOntoAnApu:
         return _fake_torch(
             [
                 _device("gfx1030", free_mib = 40000),
-                _device("gfx1151", free_mib = 12000, is_integrated = 1),
+                _device("gfx1151", free_mib = 12000, total_bytes = 8 * GIB, is_integrated = 1),
             ],
             vendor = "amd",
         )
@@ -1925,6 +1926,7 @@ class TestArchCrashRetryOntoAnApu:
             None,  # no marker: the proactive gate fails open, so the crash path runs
             returncode = 1,
             output = "ROCm error: device kernel image is invalid",
+            model_bytes = 10 * GIB,  # outgrows the APU's 8 GiB carve-out without moving the placement
         )
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in launches[0][1]
         _retry = [env for _c, env in launches if env.get("ROCR_VISIBLE_DEVICES") == "1"]
@@ -1957,6 +1959,7 @@ class TestUnifiedMemoryOptOut:
         tmp_path,
         monkeypatch,
         env_extra = None,
+        model_bytes = 40 * GIB,  # outgrows the fake 32 GiB carve-out
     ):
         return _run_auto_load(
             monkeypatch,
@@ -1965,12 +1968,36 @@ class TestUnifiedMemoryOptOut:
             None,
             returncode = None,
             env_extra = env_extra,
+            model_bytes = model_bytes,
         )
 
-    def test_the_apu_still_gets_it_by_default(self, tmp_path, monkeypatch, probe_env):
-        """Baseline: #5301 added the variable for exactly this hardware."""
+    def test_the_apu_gets_it_when_the_weights_outgrow_the_carve_out(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """Baseline: #5301 added the variable for exactly this hardware, for the
+        load its carve-out cannot hold."""
         _cmd, env = self._load(tmp_path, monkeypatch)[0]
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_weights_that_fit_the_carve_out_keep_it_unset(self, tmp_path, monkeypatch, probe_env):
+        """Managed pages fault Qwen3.8-Flash-Next on Linux gfx1151 (b10715 and b10798,
+        clean with the variable unset), so a load the carve-out holds never takes them."""
+        _cmd, env = self._load(tmp_path, monkeypatch, model_bytes = 20 * GIB)[0]
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    def test_the_enable_switch_takes_it_for_a_fitting_model(self, tmp_path, monkeypatch, probe_env):
+        _cmd, env = self._load(
+            tmp_path, monkeypatch, {"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1"}, model_bytes = 20 * GIB
+        )[0]
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_the_disable_switch_beats_the_enable_switch(self, tmp_path, monkeypatch, probe_env):
+        _cmd, env = self._load(
+            tmp_path,
+            monkeypatch,
+            {"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1", "UNSLOTH_DISABLE_UNIFIED_MEMORY": "1"},
+        )[0]
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     @pytest.mark.parametrize("value", ["0", "", "false", "FALSE", "no", "off", " 0 "])
     def test_a_falsy_user_value_is_not_passed_through(
@@ -2954,9 +2981,16 @@ class TestTheCarveOutDecidesTheUnifiedMemoryEnv:
         monkeypatch,
         torch,
         env_extra = None,
+        model_bytes = 40 * GIB,  # outgrows every carve-out below
     ):
         return _run_auto_load(
-            monkeypatch, tmp_path, torch, None, returncode = None, env_extra = env_extra
+            monkeypatch,
+            tmp_path,
+            torch,
+            None,
+            returncode = None,
+            env_extra = env_extra,
+            model_bytes = model_bytes,
         )
 
     def test_a_small_carve_out_gets_it(self, tmp_path, monkeypatch, probe_env):

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -2080,6 +2080,20 @@ class TestUnifiedMemoryOptOut:
         _cmd, env = self._auto_mode_with(tmp_path, monkeypatch, extra_args = ["-ngl", "-1"])
         assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
+    def test_a_user_fit_off_with_no_count_is_a_full_offload(self, tmp_path, monkeypatch, probe_env):
+        """Auto mode emits no count on the fitting path; a trailing --fit off
+        leaves llama.cpp's default -1 with nothing to lower it."""
+        _cmd, env = self._auto_mode_with(tmp_path, monkeypatch, extra_args = ["--fit", "off"])
+        assert "--gpu-layers" not in _cmd and "-ngl" not in _cmd
+        assert _cmd[len(_cmd) - 1 - _cmd[::-1].index("--fit") + 1] == "off"
+        assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_a_user_fit_off_with_a_partial_count_is_not(self, tmp_path, monkeypatch, probe_env):
+        _cmd, env = self._auto_mode_with(
+            tmp_path, monkeypatch, extra_args = ["--fit", "off", "--gpu-layers", "4"]
+        )
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
     def test_a_user_count_below_the_block_count_never_takes_it(
         self, tmp_path, monkeypatch, probe_env
     ):

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -1962,22 +1962,29 @@ class TestUnifiedMemoryOptOut:
         env_extra = None,
         model_bytes = 40 * GIB,  # outgrows the fake 32 GiB carve-out
         backend = None,
+        extra_args = None,
+        returncode = None,
+        output = "",
     ):
         # A forced full offload (manual mode at the picker's maximum, above the
         # block count) is the launch that can only fit with managed pages; under
         # the fitter the file would spill instead and never ask for them.
         backend = backend or LlamaCppBackend()
         backend._n_layers = 8
+        intent_kwargs = {"gpu_memory_mode": "manual", "gpu_layers": 9}
+        if extra_args:
+            intent_kwargs["extra_args"] = list(extra_args)
         return _run_auto_load(
             monkeypatch,
             tmp_path,
             self._strix_halo(monkeypatch),
             None,
-            returncode = None,
+            returncode = returncode,
+            output = output,
             env_extra = env_extra,
             model_bytes = model_bytes,
             backend = backend,
-            intent_kwargs = {"gpu_memory_mode": "manual", "gpu_layers": 9},
+            intent_kwargs = intent_kwargs,
         )
 
     def test_a_forced_full_offload_that_outgrows_the_carve_out_gets_it(
@@ -2127,6 +2134,26 @@ class TestUnifiedMemoryOptOut:
             tmp_path, monkeypatch, backend = self._with_unloaded_mtp_blocks(4 * GIB)
         )[0]
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_the_drafterless_retry_reprices_without_the_mtp_blocks(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """MTP engaged, so the first launch priced the blocks and took managed
+        memory; the retry without the drafter loads a base the carve-out holds."""
+        launches = self._load(
+            tmp_path,
+            monkeypatch,
+            backend = self._with_unloaded_mtp_blocks(10 * GIB),
+            extra_args = ["--spec-type", "draft-mtp"],
+            returncode = 1,
+            output = "failed to create llama_context",
+        )
+        first_cmd, first_env = launches[0]
+        assert "draft-mtp" in first_cmd, first_cmd
+        assert first_env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+        retries = [(c, e) for c, e in launches if "--spec-default" in c and "draft-mtp" not in c]
+        assert retries, [c for c, _e in launches]
+        assert all("GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in e for _c, e in retries)
 
     def test_an_unreadable_tensor_table_cannot_price_the_blocks(
         self, tmp_path, monkeypatch, probe_env

--- a/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
+++ b/studio/backend/tests/test_gpu_arch_gate_os_matrix_7624.py
@@ -1716,6 +1716,7 @@ class TestGatedNarrowingDropsUnifiedMemory:
             ["gfx1151"],  # covers the APU, not the gfx1200 dGPU
             returncode = None,
             model_bytes = 400 * 1024**3,
+            env_extra = {"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1"},  # the fitter owns the layers
         )
         _cmd, env = launches[0]
         assert _visibility(env) == {"ROCR_VISIBLE_DEVICES": "0", "CUDA_VISIBLE_DEVICES": "0"}
@@ -1961,6 +1962,11 @@ class TestUnifiedMemoryOptOut:
         env_extra = None,
         model_bytes = 40 * GIB,  # outgrows the fake 32 GiB carve-out
     ):
+        # A forced full offload (manual mode at the picker's maximum, above the
+        # block count) is the launch that can only fit with managed pages; under
+        # the fitter the file would spill instead and never ask for them.
+        backend = LlamaCppBackend()
+        backend._n_layers = 8
         return _run_auto_load(
             monkeypatch,
             tmp_path,
@@ -1969,14 +1975,17 @@ class TestUnifiedMemoryOptOut:
             returncode = None,
             env_extra = env_extra,
             model_bytes = model_bytes,
+            backend = backend,
+            intent_kwargs = {"gpu_memory_mode": "manual", "gpu_layers": 9},
         )
 
-    def test_the_apu_gets_it_when_the_weights_outgrow_the_carve_out(
+    def test_a_forced_full_offload_that_outgrows_the_carve_out_gets_it(
         self, tmp_path, monkeypatch, probe_env
     ):
         """Baseline: #5301 added the variable for exactly this hardware, for the
-        load its carve-out cannot hold."""
+        load its carve-out cannot hold any other way."""
         _cmd, env = self._load(tmp_path, monkeypatch)[0]
+        assert "--gpu-layers" in _cmd and _cmd[_cmd.index("--gpu-layers") + 1] == "9"
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
 
     def test_weights_that_fit_the_carve_out_keep_it_unset(self, tmp_path, monkeypatch, probe_env):
@@ -1990,6 +1999,38 @@ class TestUnifiedMemoryOptOut:
             tmp_path, monkeypatch, {"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1"}, model_bytes = 20 * GIB
         )[0]
         assert env.get("GGML_CUDA_ENABLE_UNIFIED_MEMORY") == "1"
+
+    def test_a_manual_partial_placement_never_takes_it(self, tmp_path, monkeypatch, probe_env):
+        """The whole file outgrows the carve-out, but only one layer is going to
+        the device, so the launch fits without managed pages."""
+        launches = _run_auto_load(
+            monkeypatch,
+            tmp_path,
+            self._strix_halo(monkeypatch),
+            None,
+            returncode = None,
+            model_bytes = 400 * GIB,
+            intent_kwargs = {"gpu_memory_mode": "manual", "gpu_layers": 1},
+        )
+        _cmd, env = launches[0]
+        assert "--gpu-layers" in _cmd and _cmd[_cmd.index("--gpu-layers") + 1] == "1"
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
+    def test_the_fitter_owning_the_layer_count_never_takes_it(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        """A file the carve-out cannot hold spills under --fit on and fits that way."""
+        launches = _run_auto_load(
+            monkeypatch,
+            tmp_path,
+            self._strix_halo(monkeypatch),
+            None,
+            returncode = None,
+            model_bytes = 400 * GIB,
+        )
+        _cmd, env = launches[0]
+        assert "--fit" in _cmd and _cmd[_cmd.index("--fit") + 1] == "on"
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
 
     def test_the_disable_switch_beats_the_enable_switch(self, tmp_path, monkeypatch, probe_env):
         _cmd, env = self._load(
@@ -2983,6 +3024,9 @@ class TestTheCarveOutDecidesTheUnifiedMemoryEnv:
         env_extra = None,
         model_bytes = 40 * GIB,  # outgrows every carve-out below
     ):
+        # Forced full offload, so the carve-out is the only thing that can decide.
+        backend = LlamaCppBackend()
+        backend._n_layers = 8
         return _run_auto_load(
             monkeypatch,
             tmp_path,
@@ -2991,6 +3035,8 @@ class TestTheCarveOutDecidesTheUnifiedMemoryEnv:
             returncode = None,
             env_extra = env_extra,
             model_bytes = model_bytes,
+            backend = backend,
+            intent_kwargs = {"gpu_memory_mode": "manual", "gpu_layers": 9},
         )
 
     def test_a_small_carve_out_gets_it(self, tmp_path, monkeypatch, probe_env):
@@ -3035,6 +3081,26 @@ class TestTheCarveOutDecidesTheUnifiedMemoryEnv:
             vendor = "amd",
         )
 
+    def test_the_enable_switch_cannot_reach_a_mixed_selection(
+        self, tmp_path, monkeypatch, probe_env
+    ):
+        torch = self._apu_and_dgpu(monkeypatch, 40_000)
+        _cmd, env = _run_auto_load(
+            monkeypatch,
+            tmp_path,
+            torch,
+            None,
+            returncode = None,
+            intent_kwargs = {
+                "gpu_ids": (0, 1),
+                "gpu_memory_mode": "manual",
+                "gpu_layers": 1,
+            },
+            env_extra = {"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1"},
+        )[0]
+        assert _visibility(env) == {"ROCR_VISIBLE_DEVICES": "0,1", "CUDA_VISIBLE_DEVICES": "0,1"}
+        assert "GGML_CUDA_ENABLE_UNIFIED_MEMORY" not in env
+
     def test_a_discrete_card_in_the_launch_keeps_it_off(self, tmp_path, monkeypatch, probe_env):
         torch = self._apu_and_dgpu(monkeypatch, 40_000)
         _cmd, env = _run_auto_load(
@@ -3063,6 +3129,9 @@ class TestTheCarveOutDecidesTheUnifiedMemoryEnv:
             ["gfx1151"],  # covers the APU, not the discrete gfx1100
             returncode = None,
             model_bytes = 400 * GIB,
+            # The fitter owns the layer count for a file this size, so the swap
+            # is asked for; the narrowing is what is under test.
+            env_extra = {"UNSLOTH_ENABLE_UNIFIED_MEMORY": "1"},
         )
         _cmd, env = launches[0]
         assert _visibility(env) == {"ROCR_VISIBLE_DEVICES": "0", "CUDA_VISIBLE_DEVICES": "0"}

--- a/studio/backend/tests/test_offload_planner.py
+++ b/studio/backend/tests/test_offload_planner.py
@@ -1495,9 +1495,7 @@ def test_a_wrong_length_vector_is_ignored_rather_than_trusted():
 
 
 def test_every_shard_handed_over_prices_the_whole_split():
-    """The unified-memory price needs the whole file set: two readers carrying
-    split.count = 2 sum to one complete layout, and token_embd lands in its
-    CPU-pinned bucket whichever shard holds it."""
+    """Two readers summing to one layout, token_embd in its bucket whichever shard holds it."""
     first = _StubReader(
         _shard_fields(**{"split.count": 2, "split.no": 0}),
         _shard_tensors(range(32)) + [_StubTensor("output.weight", GIB)],
@@ -1514,7 +1512,6 @@ def test_every_shard_handed_over_prices_the_whole_split():
 
 
 def test_a_partial_shard_set_still_abstains():
-    """Two of three shards would undercount exactly like one of two."""
     readers = [
         _StubReader(_shard_fields(**{"split.count": 3}), _shard_tensors(range(32))),
         _StubReader(_shard_fields(**{"split.count": 3}), _shard_tensors(range(32, 64))),
@@ -1533,8 +1530,6 @@ def test_split_shard_paths_follow_llama_cpp_naming():
 
 
 def test_layout_from_gguf_reads_the_sibling_shards_only_when_asked(tmp_path, monkeypatch):
-    """Default reads stay one-shard and abstain; all_shards opens every sibling
-    and refuses when one is missing, since llama.cpp would too."""
     import gguf
 
     shards = [tmp_path / f"m-{i:05d}-of-00002.gguf" for i in (1, 2)]

--- a/studio/backend/tests/test_offload_planner.py
+++ b/studio/backend/tests/test_offload_planner.py
@@ -22,7 +22,9 @@ from core.inference.offload_layout import (
     BlockLayout,
     ModelLayout,
     _layout_from_reader,
+    _layout_from_readers,
     layout_from_gguf,
+    split_shard_paths,
     spill_pattern_for,
 )
 from core.inference.offload_cost_model import HostProfile
@@ -1490,3 +1492,65 @@ def test_a_wrong_length_vector_is_ignored_rather_than_trusted():
         kv_layer_weights = [1, 2, 3],
     )
     assert got is not None and "sliding-window" in got
+
+
+def test_every_shard_handed_over_prices_the_whole_split():
+    """The unified-memory price needs the whole file set: two readers carrying
+    split.count = 2 sum to one complete layout, and token_embd lands in its
+    CPU-pinned bucket whichever shard holds it."""
+    first = _StubReader(
+        _shard_fields(**{"split.count": 2, "split.no": 0}),
+        _shard_tensors(range(32)) + [_StubTensor("output.weight", GIB)],
+    )
+    second = _StubReader(
+        _shard_fields(**{"split.count": 2, "split.no": 1}),
+        _shard_tensors(range(32, 64)) + [_StubTensor("token_embd.weight", 3 * GIB)],
+    )
+    layout = _layout_from_readers([first, second])
+    assert layout.complete
+    assert len(layout.blocks) == 64
+    assert layout.token_embd_bytes == 3 * GIB
+    assert layout.lm_head_bytes == GIB
+
+
+def test_a_partial_shard_set_still_abstains():
+    """Two of three shards would undercount exactly like one of two."""
+    readers = [
+        _StubReader(_shard_fields(**{"split.count": 3}), _shard_tensors(range(32))),
+        _StubReader(_shard_fields(**{"split.count": 3}), _shard_tensors(range(32, 64))),
+    ]
+    assert not _layout_from_readers(readers).complete
+
+
+def test_split_shard_paths_follow_llama_cpp_naming():
+    paths = split_shard_paths("/m/model-Q4-00002-of-00003.gguf")
+    assert paths == [
+        "/m/model-Q4-00001-of-00003.gguf",
+        "/m/model-Q4-00002-of-00003.gguf",
+        "/m/model-Q4-00003-of-00003.gguf",
+    ]
+    assert split_shard_paths("/m/model-Q4.gguf") is None
+
+
+def test_layout_from_gguf_reads_the_sibling_shards_only_when_asked(tmp_path, monkeypatch):
+    """Default reads stay one-shard and abstain; all_shards opens every sibling
+    and refuses when one is missing, since llama.cpp would too."""
+    import gguf
+
+    shards = [tmp_path / f"m-{i:05d}-of-00002.gguf" for i in (1, 2)]
+    for shard in shards:
+        shard.write_bytes(b"GGUF")
+    by_path = {
+        str(shards[0]): _StubReader(_shard_fields(**{"split.count": 2}), _shard_tensors(range(32))),
+        str(shards[1]): _StubReader(
+            _shard_fields(**{"split.count": 2}), _shard_tensors(range(32, 64))
+        ),
+    }
+    monkeypatch.setattr(gguf, "GGUFReader", lambda path: by_path[str(path)])
+
+    assert not layout_from_gguf(str(shards[0])).complete
+    whole = layout_from_gguf(str(shards[0]), all_shards = True)
+    assert whole.complete and len(whole.blocks) == 64
+
+    shards[1].unlink()
+    assert not layout_from_gguf(str(shards[0]), all_shards = True).complete


### PR DESCRIPTION
## Summary

Studio sets `GGML_CUDA_ENABLE_UNIFIED_MEMORY=1` on every AMD unified-memory APU whose carve-out is smaller than host RAM, whatever the model. On Linux ROCm that variable is a measured correctness risk, so the swap is now taken only when it is needed as well as when it pays: the GPU-resident weights must outgrow the selected carve-out. A launch the carve-out can hold never risks managed pages.

Fixes the Strix Halo reports in #10330, HF `unsloth/Qwen3.8-Flash-Next-GGUF` discussion 30 and ggml-org/llama.cpp#27797 for any model that fits the carve-out, which is every published Qwen3.8-Flash-Next quant on a 128 GB Strix Halo with the usual 64 GB carve-out.

## What was measured

Qwen3.8-Flash-Next UD-IQ1_S on a Radeon 8060S (gfx1151) under Linux ROCm, the unsloth prebuilt tarballs users actually run, same prompts in every arm, a known-good sentinel model clean before and after each state:

| build | backend | `GGML_CUDA_ENABLE_UNIFIED_MEMORY` | result |
|---|---|---|---|
| b10715-mix | ROCm | `=1` | HSA memory fault in `k_set_rows` on the first decode, server dead |
| b10798-mix | ROCm | `=1` | same fault, same kernel |
| b10798-mix | ROCm | absent | clean |
| b10798-mix | ROCm | `=0` | clean, no managed-memory notice |
| b10798-mix | Vulkan | n/a | clean |
| b10687-mix | ROCm | `=1` | killed while loading the model on a 62 GB host |

The same six arms on Windows (HIP SDK) are clean throughout, so this is specific to the Linux ROCm managed-memory path. The fault is in the QSA top-k mask write, one op after the copy that unslothai/llama.cpp#157 patches, so the ROCm fixes in b10715 and later do not cover it.

## The change

- `_unified_memory_would_help` gains `need_bytes`: after the existing pool comparison (available host RAM must exceed the carve-out total), the bytes must exceed the carve-out. The launch site prices only what a forced full offload puts on the device, decided by `_argv_offloads_every_layer` on the final argv; when the fitter or an explicit partial placement owns the layer count the load fits by spilling, so it passes `None`, which fails closed like missing data and mixed selections.
- `_unified_memory_for_launch` is the launch-time decision, used at the initial launch, the arch-gate narrowing and the arch-crash respawn, so a respawn onto an APU cannot re-add the variable for a model that fits.
- `UNSLOTH_ENABLE_UNIFIED_MEMORY=1` is a new opt-in for a user who has measured their own model on their own host. It applies only when every selected device is a unified-memory APU, since the variable is process-wide and hurts a discrete card. `UNSLOTH_DISABLE_UNIFIED_MEMORY=1` still wins when both are set; a user-supplied `GGML_CUDA_ENABLE_UNIFIED_MEMORY` value passes through as before.
- `model_size` at the launch site already includes a GPU-loaded projector, so the price is the bytes the carve-out has to hold.

## What it does not change

A model larger than the carve-out still takes managed memory, because the alternative is a load that cannot fit (that is the DeepSeek-V4 case on ggml-org/llama.cpp#25436). The opt-out remains the answer there.

## Tests

- The pool-comparison arms now price weights that outgrow the carve-out, so each answer turns on the pool alone.
- New arms: weights that fit, that outgrow, that exactly equal the carve-out, one byte over, unpriced weights, a manual partial placement and a fitter-owned placement of an oversized file (neither takes it), the enable switch, the disable switch beating the enable switch, the opt-in on a mixed selection, and the launch-time decision on a discrete card.
- The two crash-retry fixtures give the fake APU an 8 GiB carve-out so a 10 GiB model outgrows it without moving the free-memory ranking those tests are about.
- `test_amd_apu_unified_memory.py`, `test_gpu_arch_gate_os_matrix_7624.py`, `test_gpu_arch_gate_7624.py`, `test_gpu_arch_gate_consumers_7624.py`, `test_model_memory_settings.py`, `test_gpu_init_crash_message.py` and the eleven other suites that reference the variable pass. `test_offload_planner_seam.py::test_oversubscribed_decode_threads_decline_spill_planning` fails identically on `main` on this host and is unrelated.
