### PR TITLE
Studio: unsloth chat loads the model you picked, not another GGUF in the same folder

### DIFF
--- a/unsloth_cli/_model_catalog.py
+++ b/unsloth_cli/_model_catalog.py
@@ -331,6 +331,24 @@ def _is_gguf_file(path: str) -> bool:
         return False
 
 
+def _is_loose_gguf_companion(path: str) -> bool:
+    """Whether a scan row names a GGUF SIDECAR rather than a model.
+
+    ``_scan_models_dir`` screens mmproj, MTP drafter and imatrix files when it decides a
+    directory is a model, and ``_local_dir_holds_a_payload`` requires a main GGUF inside one,
+    but a loose ``.gguf`` child is listed on its extension alone. Resolving through the folder
+    used to hide that by rewriting the sidecar row onto the real model; loading the file the row
+    names offers a projector the loader refuses, so apply the same rule the directories get.
+    """
+    if not _is_gguf_file(path):
+        return False
+    try:
+        from hub.services.models.common import _is_main_gguf_filename
+    except ImportError:
+        return False
+    return not _is_main_gguf_filename(Path(path).name)
+
+
 def _gguf_file_as_the_loader_opens_it(path: str) -> str:
     """*path*, collapsed to shard 1 when the LOADER reads it as a complete split family.
 
@@ -617,6 +635,8 @@ def local_folder_entries() -> List[ModelEntry]:
         if _local_model_can_chat(model) is False:
             continue
         if not _local_dir_holds_a_payload(Path(model.path)):
+            continue
+        if _is_loose_gguf_companion(model.path):
             continue
         if _local_is_a_diffusers_pipeline(model):
             continue

--- a/unsloth_cli/_model_catalog.py
+++ b/unsloth_cli/_model_catalog.py
@@ -331,51 +331,40 @@ def _is_gguf_file(path: str) -> bool:
         return False
 
 
-def _gguf_split_first_shard(path: Path) -> Optional[Path]:
-    """The shard-1 sibling of *path*'s own split family, or None when it is already first.
+def _gguf_file_as_the_loader_opens_it(path: str) -> str:
+    """*path*, collapsed to shard 1 when the LOADER reads it as a complete split family.
 
-    Same family rule as ``_gguf_file_is_loadable``: shared prefix and shard total.
+    Asked of ``_local_gguf_load_path`` rather than restated here, because the shard grammars
+    differ by layer: the scan's ``_GGUF_SPLIT_RE`` takes three or more digits and the loader's
+    ``_GGUF_SPLIT_FILE_RE`` exactly five. A local rule would rewrite ``model-002-of-003.gguf``
+    to a sibling that ``detect_gguf_model`` still opens as its own model, which is the
+    wrong-file selection this fix removes.
     """
     try:
-        from hub.utils.inventory_scan import _GGUF_SPLIT_RE
+        from utils.models.model_config import _local_gguf_load_path
     except ImportError:
-        return None
-    split = _GGUF_SPLIT_RE.search(path.name)
-    if split is None or int(split.group(1)) == 1:
-        return None
-    total = int(split.group(2))
-    prefix = path.name[: split.start()]
+        return path
     try:
-        for sibling in path.parent.iterdir():
-            match = _GGUF_SPLIT_RE.search(sibling.name)
-            if (
-                match is not None
-                and sibling.name[: match.start()] == prefix
-                and int(match.group(2)) == total
-                and int(match.group(1)) == 1
-                and sibling.is_file()
-            ):
-                return sibling
+        resolved = _local_gguf_load_path(Path(path))
+        return path if resolved.samefile(path) else str(resolved)
     except OSError:
-        return None
-    return None
+        return path
 
 
 def _gguf_load_target(target: str) -> str:
     """The GGUF a picker row should load.
 
     A row naming a ``.gguf`` loads that file: resolving it through its folder returned the best
-    quant across every unrelated single-file GGUF beside it (#10352). A later shard redirects to
-    shard 1, matching what detect_gguf_model does at load time, so _dedup_key sees one inode and
-    a split family is offered once instead of once per shard.
+    quant across every unrelated single-file GGUF beside it (#10352). Shard rows are the one
+    exception, collapsed to the shard the loader opens anyway so ``_dedup_key`` sees one inode
+    and a split family is offered once instead of once per shard.
 
     A FOLDER still resolves: detect_gguf_model takes the largest complete file, commonly the
     F16, while cached and exported rows resolve a Q4-class quant, so the same folder loads
     dramatically bigger by source alone, an OOM rather than a preference.
     """
     if _is_gguf_file(target):
-        first = _gguf_split_first_shard(Path(target))
-        return str(first) if first is not None else target
+        return _gguf_file_as_the_loader_opens_it(target)
     return _preferred_complete_gguf(target) or target
 
 

--- a/unsloth_cli/_model_catalog.py
+++ b/unsloth_cli/_model_catalog.py
@@ -334,11 +334,9 @@ def _is_gguf_file(path: str) -> bool:
 def _gguf_file_as_the_loader_opens_it(path: str) -> str:
     """*path*, collapsed to shard 1 when the LOADER reads it as a complete split family.
 
-    Asked of ``_local_gguf_load_path`` rather than restated here, because the shard grammars
-    differ by layer: the scan's ``_GGUF_SPLIT_RE`` takes three or more digits and the loader's
-    ``_GGUF_SPLIT_FILE_RE`` exactly five. A local rule would rewrite ``model-002-of-003.gguf``
-    to a sibling that ``detect_gguf_model`` still opens as its own model, which is the
-    wrong-file selection this fix removes.
+    Asked of _local_gguf_load_path, not restated: the scan's _GGUF_SPLIT_RE takes three or more
+    digits and the loader's _GGUF_SPLIT_FILE_RE exactly five, so a local rule would rewrite
+    model-002-of-003.gguf onto a sibling detect_gguf_model still opens as its own model.
     """
     try:
         from utils.models.model_config import _local_gguf_load_path
@@ -354,14 +352,12 @@ def _gguf_file_as_the_loader_opens_it(path: str) -> str:
 def _gguf_load_target(target: str) -> str:
     """The GGUF a picker row should load.
 
-    A row naming a ``.gguf`` loads that file: resolving it through its folder returned the best
-    quant across every unrelated single-file GGUF beside it (#10352). Shard rows are the one
-    exception, collapsed to the shard the loader opens anyway so ``_dedup_key`` sees one inode
-    and a split family is offered once instead of once per shard.
+    A row naming a .gguf loads that file: resolving it through the folder returned the best quant
+    across every unrelated GGUF beside it (#10352). Shards are the exception, collapsed to the
+    one the loader opens anyway so _dedup_key offers a split family once.
 
-    A FOLDER still resolves: detect_gguf_model takes the largest complete file, commonly the
-    F16, while cached and exported rows resolve a Q4-class quant, so the same folder loads
-    dramatically bigger by source alone, an OOM rather than a preference.
+    A FOLDER still resolves: detect_gguf_model takes the largest complete file, commonly the F16,
+    where cached and exported rows take a Q4-class quant. An OOM by source alone, not a taste.
     """
     if _is_gguf_file(target):
         return _gguf_file_as_the_loader_opens_it(target)

--- a/unsloth_cli/_model_catalog.py
+++ b/unsloth_cli/_model_catalog.py
@@ -324,6 +324,13 @@ def _gguf_file_is_loadable(path: Path) -> bool:
     return present >= set(range(1, total + 1))
 
 
+def _is_gguf_file(path: str) -> bool:
+    try:
+        return path.lower().endswith(".gguf") and Path(path).is_file()
+    except OSError:
+        return False
+
+
 def _preferred_complete_gguf(path: str) -> Optional[str]:
     model_path = Path(path)
     try:
@@ -581,10 +588,7 @@ def local_folder_entries() -> List[ModelEntry]:
         if _local_is_a_diffusers_pipeline(model):
             continue
         target = model.load_id or model.id
-        # A GGUF DIRECTORY goes through detect_gguf_model, which sorts by size and takes the largest
-        # complete file, commonly the F16, while cached and exported rows resolve a Q4-class quant. Same
-        # folder, dramatically bigger load by source alone, so an OOM rather than a preference.
-        if is_gguf:
+        if is_gguf and not _is_gguf_file(target):
             target = _preferred_complete_gguf(target) or target
         entries.append(
             ModelEntry(

--- a/unsloth_cli/_model_catalog.py
+++ b/unsloth_cli/_model_catalog.py
@@ -331,6 +331,54 @@ def _is_gguf_file(path: str) -> bool:
         return False
 
 
+def _gguf_split_first_shard(path: Path) -> Optional[Path]:
+    """The shard-1 sibling of *path*'s own split family, or None when it is already first.
+
+    Same family rule as ``_gguf_file_is_loadable``: shared prefix and shard total.
+    """
+    try:
+        from hub.utils.inventory_scan import _GGUF_SPLIT_RE
+    except ImportError:
+        return None
+    split = _GGUF_SPLIT_RE.search(path.name)
+    if split is None or int(split.group(1)) == 1:
+        return None
+    total = int(split.group(2))
+    prefix = path.name[: split.start()]
+    try:
+        for sibling in path.parent.iterdir():
+            match = _GGUF_SPLIT_RE.search(sibling.name)
+            if (
+                match is not None
+                and sibling.name[: match.start()] == prefix
+                and int(match.group(2)) == total
+                and int(match.group(1)) == 1
+                and sibling.is_file()
+            ):
+                return sibling
+    except OSError:
+        return None
+    return None
+
+
+def _gguf_load_target(target: str) -> str:
+    """The GGUF a picker row should load.
+
+    A row naming a ``.gguf`` loads that file: resolving it through its folder returned the best
+    quant across every unrelated single-file GGUF beside it (#10352). A later shard redirects to
+    shard 1, which the scan also lists as a row and which is the only one llama.cpp accepts
+    ("model must be loaded with the first split", llama-model-loader.cpp).
+
+    A FOLDER still resolves: detect_gguf_model takes the largest complete file, commonly the
+    F16, while cached and exported rows resolve a Q4-class quant, so the same folder loads
+    dramatically bigger by source alone, an OOM rather than a preference.
+    """
+    if _is_gguf_file(target):
+        first = _gguf_split_first_shard(Path(target))
+        return str(first) if first is not None else target
+    return _preferred_complete_gguf(target) or target
+
+
 def _preferred_complete_gguf(path: str) -> Optional[str]:
     model_path = Path(path)
     try:
@@ -588,8 +636,8 @@ def local_folder_entries() -> List[ModelEntry]:
         if _local_is_a_diffusers_pipeline(model):
             continue
         target = model.load_id or model.id
-        if is_gguf and not _is_gguf_file(target):
-            target = _preferred_complete_gguf(target) or target
+        if is_gguf:
+            target = _gguf_load_target(target)
         entries.append(
             ModelEntry(
                 "Downloaded",

--- a/unsloth_cli/_model_catalog.py
+++ b/unsloth_cli/_model_catalog.py
@@ -366,8 +366,8 @@ def _gguf_load_target(target: str) -> str:
 
     A row naming a ``.gguf`` loads that file: resolving it through its folder returned the best
     quant across every unrelated single-file GGUF beside it (#10352). A later shard redirects to
-    shard 1, which the scan also lists as a row and which is the only one llama.cpp accepts
-    ("model must be loaded with the first split", llama-model-loader.cpp).
+    shard 1, matching what detect_gguf_model does at load time, so _dedup_key sees one inode and
+    a split family is offered once instead of once per shard.
 
     A FOLDER still resolves: detect_gguf_model takes the largest complete file, commonly the
     F16, while cached and exported rows resolve a Q4-class quant, so the same folder loads

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -2493,6 +2493,44 @@ def test_catalog_loose_gguf_file_rows_load_their_own_file(monkeypatch, tmp_path)
     }
 
 
+def test_catalog_loose_gguf_shard_rows_load_the_first_split(monkeypatch, tmp_path):
+    """The scan lists every loose shard as its own row, and llama.cpp refuses a later one."""
+    from unsloth_cli._inference import ensure_studio_backend_path
+    from unsloth_cli import _model_catalog as cat
+
+    ensure_studio_backend_path()
+    folder = tmp_path / "models"
+    folder.mkdir()
+    shards = [folder / f"BigModel-Q4_K_M-0000{n}-of-00003.gguf" for n in (1, 2, 3)]
+    for shard in shards:
+        shard.write_bytes(b"GGUF" + b"\0" * 4096)
+    # An unrelated single-file GGUF beside them: no shard may resolve to it, and it stays itself.
+    loose = folder / "Unrelated-F16.gguf"
+    loose.write_bytes(b"GGUF" + b"\0" * 4096 * 10)
+
+    def row(path):
+        return SimpleNamespace(
+            source = "models_dir",
+            partial = False,
+            model_format = "gguf",
+            path = str(path),
+            display_name = path.stem,
+            load_id = str(path),
+            id = str(path),
+        )
+
+    monkeypatch.setattr(cat, "_local_catalog_rows", lambda: [row(p) for p in (*shards, loose)])
+    monkeypatch.setattr(cat, "_local_model_task", lambda m: None)
+    monkeypatch.setattr(cat, "_local_model_can_chat", lambda m: None)
+    monkeypatch.setattr(cat, "_local_is_a_diffusers_pipeline", lambda m: False)
+
+    loads = {e.name: e.model for e in cat.local_folder_entries()}
+    assert loads == {
+        **{shard.stem: str(shards[0]) for shard in shards},
+        loose.stem: str(loose),
+    }
+
+
 def test_catalog_pins_an_active_cache_adapter_to_its_snapshot(tmp_path):
     """A LoRA resolved by bare repo id takes the REMOTE branch of
     get_base_model_from_lora_identifier, which downloads adapter_config.json with no

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -2453,6 +2453,46 @@ def test_catalog_local_gguf_folder_picks_the_preferred_quant(monkeypatch, tmp_pa
     assert entries and entries[0].model.endswith("mymodel-Q4_K_M.gguf"), entries[0].model
 
 
+def test_catalog_loose_gguf_file_rows_load_their_own_file(monkeypatch, tmp_path):
+    from unsloth_cli._inference import ensure_studio_backend_path
+    from unsloth_cli import _model_catalog as cat
+
+    ensure_studio_backend_path()
+    folder = tmp_path / "models"
+    folder.mkdir()
+    ling = folder / "Ling-3.0-tiny-Uncensored-Abliterated.f16.gguf"
+    minimax = folder / "MiniMax-H3-ref2va-curve-zs05-Q8_0.gguf"
+    for file in (ling, minimax):
+        file.write_bytes(b"GGUF" + b"\0" * 4096)
+    multi = tmp_path / "multi"
+    multi.mkdir()
+    (multi / "mymodel-Q4_K_M.gguf").write_bytes(b"GGUF" + b"\0" * 4096)
+    (multi / "mymodel-F16.gguf").write_bytes(b"GGUF" + b"\0" * 4096 * 4)
+
+    def row(path):
+        return SimpleNamespace(
+            source = "models_dir",
+            partial = False,
+            model_format = "gguf",
+            path = str(path),
+            display_name = path.stem,
+            load_id = str(path),
+            id = str(path),
+        )
+
+    monkeypatch.setattr(cat, "_local_catalog_rows", lambda: [row(ling), row(minimax), row(multi)])
+    monkeypatch.setattr(cat, "_local_model_task", lambda m: None)
+    monkeypatch.setattr(cat, "_local_model_can_chat", lambda m: None)
+    monkeypatch.setattr(cat, "_local_is_a_diffusers_pipeline", lambda m: False)
+
+    loads = {e.name: e.model for e in cat.local_folder_entries()}
+    assert loads == {
+        ling.stem: str(ling),
+        minimax.stem: str(minimax),
+        "multi": str(multi / "mymodel-Q4_K_M.gguf"),
+    }
+
+
 def test_catalog_pins_an_active_cache_adapter_to_its_snapshot(tmp_path):
     """A LoRA resolved by bare repo id takes the REMOTE branch of
     get_base_model_from_lora_identifier, which downloads adapter_config.json with no

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -2529,10 +2529,7 @@ def test_catalog_loose_gguf_shard_rows_load_the_first_split(monkeypatch, tmp_pat
     monkeypatch.setattr(cat, "_local_is_a_diffusers_pipeline", lambda m: False)
 
     loads = {e.name: e.model for e in cat.local_folder_entries()}
-    assert loads == {
-        **{shard.stem: str(shards[0]) for shard in shards},
-        loose.stem: str(loose),
-    }
+    assert loads == {**{shard.stem: str(shards[0]) for shard in shards}, loose.stem: str(loose)}
 
     for source in ("trained_entries", "exported_entries", "cached_entries"):
         monkeypatch.setattr(cat, source, list)

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -2494,7 +2494,11 @@ def test_catalog_loose_gguf_file_rows_load_their_own_file(monkeypatch, tmp_path)
 
 
 def test_catalog_loose_gguf_shard_rows_load_the_first_split(monkeypatch, tmp_path):
-    """The scan lists every loose shard as its own row, and llama.cpp refuses a later one."""
+    """The scan lists every loose shard as its own row, and they are one model.
+
+    Every shard resolving to the first is what lets _dedup_key collapse them: it keys on the
+    inode, so three distinct shard paths would be offered as three identical picks.
+    """
     from unsloth_cli._inference import ensure_studio_backend_path
     from unsloth_cli import _model_catalog as cat
 
@@ -2529,6 +2533,10 @@ def test_catalog_loose_gguf_shard_rows_load_the_first_split(monkeypatch, tmp_pat
         **{shard.stem: str(shards[0]) for shard in shards},
         loose.stem: str(loose),
     }
+
+    for source in ("trained_entries", "exported_entries", "cached_entries"):
+        monkeypatch.setattr(cat, source, list)
+    assert sorted(e.model for e in cat.list_chat_models()) == [str(shards[0]), str(loose)]
 
 
 def test_catalog_pins_an_active_cache_adapter_to_its_snapshot(tmp_path):

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -2494,11 +2494,8 @@ def test_catalog_loose_gguf_file_rows_load_their_own_file(monkeypatch, tmp_path)
 
 
 def test_catalog_loose_gguf_shard_rows_load_the_first_split(monkeypatch, tmp_path):
-    """The scan lists every loose shard as its own row, and they are one model.
-
-    Every shard resolving to the first is what lets _dedup_key collapse them: it keys on the
-    inode, so three distinct shard paths would be offered as three identical picks.
-    """
+    """Loose shards are listed one row each; resolving them to the first is what lets
+    _dedup_key, which keys on the inode, offer a split family as a single pick."""
     from unsloth_cli._inference import ensure_studio_backend_path
     from unsloth_cli import _model_catalog as cat
 

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -2511,6 +2511,11 @@ def test_catalog_loose_gguf_shard_rows_load_the_first_split(monkeypatch, tmp_pat
     # An unrelated single-file GGUF beside them: no shard may resolve to it, and it stays itself.
     loose = folder / "Unrelated-F16.gguf"
     loose.write_bytes(b"GGUF" + b"\0" * 4096 * 10)
+    # Three digits is not the loader's -NNNNN-of-NNNNN, so detect_gguf_model opens each of these
+    # as its own model and collapsing them would be the wrong-file pick this fix removes.
+    unsplit = [folder / f"Other-00{n}-of-003.gguf" for n in (1, 2, 3)]
+    for file in unsplit:
+        file.write_bytes(b"GGUF" + b"\0" * 4096)
 
     def row(path):
         return SimpleNamespace(
@@ -2523,17 +2528,24 @@ def test_catalog_loose_gguf_shard_rows_load_the_first_split(monkeypatch, tmp_pat
             id = str(path),
         )
 
-    monkeypatch.setattr(cat, "_local_catalog_rows", lambda: [row(p) for p in (*shards, loose)])
+    listed = [*shards, loose, *unsplit]
+    monkeypatch.setattr(cat, "_local_catalog_rows", lambda: [row(p) for p in listed])
     monkeypatch.setattr(cat, "_local_model_task", lambda m: None)
     monkeypatch.setattr(cat, "_local_model_can_chat", lambda m: None)
     monkeypatch.setattr(cat, "_local_is_a_diffusers_pipeline", lambda m: False)
 
     loads = {e.name: e.model for e in cat.local_folder_entries()}
-    assert loads == {**{shard.stem: str(shards[0]) for shard in shards}, loose.stem: str(loose)}
+    assert loads == {
+        **{shard.stem: str(shards[0]) for shard in shards},
+        **{file.stem: str(file) for file in unsplit},
+        loose.stem: str(loose),
+    }
 
     for source in ("trained_entries", "exported_entries", "cached_entries"):
         monkeypatch.setattr(cat, source, list)
-    assert sorted(e.model for e in cat.list_chat_models()) == [str(shards[0]), str(loose)]
+    assert sorted(e.model for e in cat.list_chat_models()) == sorted(
+        [str(shards[0]), str(loose), *(str(file) for file in unsplit)]
+    )
 
 
 def test_catalog_pins_an_active_cache_adapter_to_its_snapshot(tmp_path):

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -2545,6 +2545,44 @@ def test_catalog_loose_gguf_shard_rows_load_the_first_split(monkeypatch, tmp_pat
     )
 
 
+def test_catalog_drops_loose_gguf_companions(monkeypatch, tmp_path):
+    """A vision repo copied into models/ lists its projector as its own scan row.
+
+    _local_dir_holds_a_payload already requires a main GGUF inside a DIRECTORY, so this is the
+    same rule; without it the picker offers a projector that detect_gguf_model refuses.
+    """
+    from unsloth_cli._inference import ensure_studio_backend_path
+    from unsloth_cli import _model_catalog as cat
+
+    ensure_studio_backend_path()
+    folder = tmp_path / "models"
+    folder.mkdir()
+    model = folder / "gemma-3-4b-it-UD-Q4_K_XL.gguf"
+    model.write_bytes(b"GGUF" + b"\0" * 4096)
+    companions = [folder / n for n in ("mmproj-F16.gguf", "mtp-gemma-3-4b-it.gguf")]
+    for companion in companions:
+        # Bigger, so a folder-wide resolve would have preferred one of them.
+        companion.write_bytes(b"GGUF" + b"\0" * 4096 * 10)
+
+    def row(path):
+        return SimpleNamespace(
+            source = "models_dir",
+            partial = False,
+            model_format = "gguf",
+            path = str(path),
+            display_name = path.stem,
+            load_id = str(path),
+            id = str(path),
+        )
+
+    monkeypatch.setattr(cat, "_local_catalog_rows", lambda: [row(model), *map(row, companions)])
+    monkeypatch.setattr(cat, "_local_model_task", lambda m: None)
+    monkeypatch.setattr(cat, "_local_model_can_chat", lambda m: None)
+    monkeypatch.setattr(cat, "_local_is_a_diffusers_pipeline", lambda m: False)
+
+    assert {e.name: e.model for e in cat.local_folder_entries()} == {model.stem: str(model)}
+
+
 def test_catalog_pins_an_active_cache_adapter_to_its_snapshot(tmp_path):
     """A LoRA resolved by bare repo id takes the REMOTE branch of
     get_base_model_from_lora_identifier, which downloads adapter_config.json with no


### PR DESCRIPTION
If a folder has several unrelated single-file GGUFs, the chat picker listed each one but could load a different file than the one selected (#10352). It resolved the load path by scanning the whole folder and picking the best quant across all of them.

A row that already points at a .gguf file is now loaded as is. Folder rows, exports, and cached models keep resolving to the preferred quant like before.