### PR TITLE
fix(studio): probe torch._dynamo import in compile-runtime gate

### DIFF
--- a/studio/backend/core/inference/diffusion_speed.py
+++ b/studio/backend/core/inference/diffusion_speed.py
@@ -152,7 +152,16 @@ def torch_compile_runtime_available() -> bool:
 
     ``TORCHDYNAMO_DISABLE`` is honored on every platform: a compile under it is a silent no-op that
     would otherwise be recorded as an engaged optimisation. Cached, since neither answer can change
-    inside a process and this runs on every load."""
+    inside a process and this runs on every load.
+
+    On Windows, the first real ``import torch._dynamo`` in the process can lose a race against
+    another in-flight ``torch`` import on a different thread (the SERVER process handles requests
+    on a pool, unlike the three single-purpose workers above) and come back partially initialized
+    (``partially initialized module 'torch._dynamo' has no attribute 'utils'``). Left alone, that
+    surfaces mid-generation on the first compiled forward instead of here. Probing it eagerly,
+    inside this already-cached gate, either finishes the import cleanly on whichever thread asks
+    first or fails the gate up front -- same "decide it here instead" contract as the Triton/MSVC
+    checks below."""
     if os.environ.get("TORCHDYNAMO_DISABLE", "").strip() not in ("", "0"):
         return False
     if sys.platform != "win32":
@@ -160,6 +169,11 @@ def torch_compile_runtime_available() -> bool:
     try:
         import triton  # noqa: F401, PLC0415
     except Exception:  # noqa: BLE001 -- absent or broken Triton means eager, never a failed load
+        return False
+    try:
+        import torch._dynamo  # noqa: PLC0415
+        import torch._dynamo.utils  # noqa: F401, PLC0415
+    except Exception:  # noqa: BLE001 -- a partially-initialized dynamo means eager, never a crashed load
         return False
     try:
         from .._msvc_env import crt_headers_reachable  # noqa: PLC0415

--- a/studio/backend/core/inference/diffusion_speed.py
+++ b/studio/backend/core/inference/diffusion_speed.py
@@ -163,22 +163,20 @@ def _compile_toolchain_available() -> bool:
 
 
 def _dynamo_reachable() -> bool:
-    """Whether ``torch._dynamo.utils`` resolves BY ATTRIBUTE, which is how torch's own compile
-    stack reaches it (``_functorch/aot_autograd.py``, ``_inductor/pattern_matcher.py``, ...).
+    """Whether ``torch._dynamo.utils`` resolves BY ATTRIBUTE, the way torch's own compile stack
+    reaches it (``_functorch/aot_autograd.py``, ``_inductor/pattern_matcher.py``).
 
-    The SERVER process answers requests on a pool, unlike the three single-purpose workers, so two
-    threads can enter torch's dynamo/inductor import cycle at once; CPython breaks the resulting
-    deadlock by handing both a partially initialized module (``_lock_unlock_module``, CPython
-    importlib/_bootstrap.py). Left alone that surfaces as the reported ``partially initialized
-    module 'torch._dynamo' has no attribute 'utils'`` on the first compiled forward, mid-generation,
-    instead of here.
+    Two threads on the SERVER's pool can enter torch's dynamo/inductor import cycle at once, and
+    CPython breaks the deadlock by handing both a partially initialized module
+    (``_lock_unlock_module``, importlib/_bootstrap.py), which is the reported ``partially
+    initialized module 'torch._dynamo' has no attribute 'utils'`` on the first compiled forward.
 
-    The import alone does not prove it: a submodule already in ``sys.modules`` is returned WITHOUT
+    Importing is NOT enough to prove it: a submodule already in ``sys.modules`` comes back without
     being bound on its parent, and ``from torch._dynamo import utils`` falls back to ``sys.modules``
-    too, so both succeed in exactly the broken state. Only the attribute access sees it.
+    as well, so both succeed in exactly the broken state.
 
-    NOT cached, unlike the toolchain above: this answer is a race outcome, so one lost race must
-    not run the rest of the process eager. After the first success it is a ``sys.modules`` hit."""
+    Uncached, unlike the toolchain: a race outcome, so one lost race must not run the rest of the
+    process eager. A repeat call is a ``sys.modules`` hit."""
     if sys.platform != "win32":
         return True
     try:

--- a/studio/backend/core/inference/diffusion_speed.py
+++ b/studio/backend/core/inference/diffusion_speed.py
@@ -142,28 +142,13 @@ def resolve_speed_mode(
 
 
 @lru_cache(maxsize = 1)
-def torch_compile_runtime_available() -> bool:
-    """Whether THIS process can actually run an inductor compile.
-
-    Inductor needs Triton, and Windows is the one supported platform whose normal install has no
-    Triton wheel. The three Unsloth workers (inference / training / export) already gate on this
-    import and set ``TORCHDYNAMO_DISABLE=1`` when it fails, but the diffusion and video backends
-    run in the SERVER process, which those gates never reach, so ask it once here.
-
-    ``TORCHDYNAMO_DISABLE`` is honored on every platform: a compile under it is a silent no-op that
-    would otherwise be recorded as an engaged optimisation. Cached, since neither answer can change
-    inside a process and this runs on every load.
-
-    On Windows, the first real ``import torch._dynamo`` in the process can lose a race against
-    another in-flight ``torch`` import on a different thread (the SERVER process handles requests
-    on a pool, unlike the three single-purpose workers above) and come back partially initialized
-    (``partially initialized module 'torch._dynamo' has no attribute 'utils'``). Left alone, that
-    surfaces mid-generation on the first compiled forward instead of here. Probing it eagerly,
-    inside this already-cached gate, either finishes the import cleanly on whichever thread asks
-    first or fails the gate up front -- same "decide it here instead" contract as the Triton/MSVC
-    checks below."""
-    if os.environ.get("TORCHDYNAMO_DISABLE", "").strip() not in ("", "0"):
-        return False
+def _compile_toolchain_available() -> bool:
+    """Whether the INSTALL carries an inductor toolchain: Triton, plus reachable MSVC CRT headers
+    on Windows, the one supported platform whose normal install has no Triton wheel. The three
+    Unsloth workers (inference / training / export) already gate on this import and set
+    ``TORCHDYNAMO_DISABLE=1`` when it fails, but the diffusion and video backends run in the SERVER
+    process, which those gates never reach, so ask it once here. Cached: neither can change inside
+    a process and this runs on every load."""
     if sys.platform != "win32":
         return True
     try:
@@ -171,15 +156,47 @@ def torch_compile_runtime_available() -> bool:
     except Exception:  # noqa: BLE001 -- absent or broken Triton means eager, never a failed load
         return False
     try:
-        import torch._dynamo  # noqa: PLC0415
-        import torch._dynamo.utils  # noqa: F401, PLC0415
-    except Exception:  # noqa: BLE001 -- a partially-initialized dynamo means eager, never a crashed load
-        return False
-    try:
         from .._msvc_env import crt_headers_reachable  # noqa: PLC0415
         return crt_headers_reachable()
     except Exception:  # noqa: BLE001 -- this runs during load; never fail it over a probe
         return True
+
+
+def _dynamo_reachable() -> bool:
+    """Whether ``torch._dynamo.utils`` resolves BY ATTRIBUTE, which is how torch's own compile
+    stack reaches it (``_functorch/aot_autograd.py``, ``_inductor/pattern_matcher.py``, ...).
+
+    The SERVER process answers requests on a pool, unlike the three single-purpose workers, so two
+    threads can enter torch's dynamo/inductor import cycle at once; CPython breaks the resulting
+    deadlock by handing both a partially initialized module (``_lock_unlock_module``, CPython
+    importlib/_bootstrap.py). Left alone that surfaces as the reported ``partially initialized
+    module 'torch._dynamo' has no attribute 'utils'`` on the first compiled forward, mid-generation,
+    instead of here.
+
+    The import alone does not prove it: a submodule already in ``sys.modules`` is returned WITHOUT
+    being bound on its parent, and ``from torch._dynamo import utils`` falls back to ``sys.modules``
+    too, so both succeed in exactly the broken state. Only the attribute access sees it.
+
+    NOT cached, unlike the toolchain above: this answer is a race outcome, so one lost race must
+    not run the rest of the process eager. After the first success it is a ``sys.modules`` hit."""
+    if sys.platform != "win32":
+        return True
+    try:
+        import torch._dynamo  # noqa: PLC0415
+        import torch._dynamo.utils  # noqa: F401, PLC0415
+        return torch._dynamo.utils is not None
+    except Exception:  # noqa: BLE001 -- a partially-initialized dynamo means eager, never a crashed load
+        return False
+
+
+def torch_compile_runtime_available() -> bool:
+    """Whether THIS process can actually run an inductor compile.
+
+    ``TORCHDYNAMO_DISABLE`` is honored on every platform: a compile under it is a silent no-op that
+    would otherwise be recorded as an engaged optimisation."""
+    if os.environ.get("TORCHDYNAMO_DISABLE", "").strip() not in ("", "0"):
+        return False
+    return _compile_toolchain_available() and _dynamo_reachable()
 
 
 def compile_eligible(target: Any, *, is_gguf: bool, family: Any) -> bool:

--- a/studio/backend/tests/test_diffusion_speed.py
+++ b/studio/backend/tests/test_diffusion_speed.py
@@ -77,6 +77,23 @@ def _compile_runtime_independent_of_the_host(monkeypatch):
     ds_mod.torch_compile_runtime_available.cache_clear()
 
 
+def _stub_dynamo(monkeypatch):
+    """torch_compile_runtime_available's Windows probe does `import torch._dynamo` /
+    `import torch._dynamo.utils` for real, which needs a top-level `torch` package in
+    ``sys.modules`` too (the import system resolves the parent first). Give it a fully
+    initialized pair -- and a minimal top-level `torch` if the host has no real one -- so a
+    test that doesn't otherwise need torch doesn't fail this probe for a reason unrelated to
+    what it checks. Any test exercising the probe's OWN failure path overrides this after."""
+    dynamo = types.ModuleType("torch._dynamo")
+    dynamo.utils = types.ModuleType("torch._dynamo.utils")
+    if "torch" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "torch", types.ModuleType("torch"))
+    monkeypatch.setattr(sys.modules["torch"], "_dynamo", dynamo, raising = False)
+    monkeypatch.setitem(sys.modules, "torch._dynamo", dynamo)
+    monkeypatch.setitem(sys.modules, "torch._dynamo.utils", dynamo.utils)
+    return dynamo
+
+
 def _stub_torch(monkeypatch):
     torch = types.ModuleType("torch")
     torch.bfloat16 = "bfloat16"  # _is_bfloat16 compares by identity then str fallback
@@ -88,6 +105,7 @@ def _stub_torch(monkeypatch):
     # The VAE-decode compile wraps a bound method; identity wrap is enough for tests.
     torch.compile = lambda fn, **kwargs: fn
     monkeypatch.setitem(sys.modules, "torch", torch)
+    torch._dynamo = _stub_dynamo(monkeypatch)
     return torch
 
 
@@ -783,6 +801,7 @@ def test_windows_without_triton_falls_back_to_eager(monkeypatch):
     assert ds_mod.compile_eligible(_target(), is_gguf = False, family = _family()) is False
 
     monkeypatch.setitem(sys.modules, "triton", types.ModuleType("triton"))
+    _stub_dynamo(monkeypatch)
     _set_crt_headers(monkeypatch, True)
     _clear_runtime_cache()
     assert ds_mod.torch_compile_runtime_available() is True
@@ -795,6 +814,7 @@ def test_windows_with_triton_but_no_msvc_falls_back_to_eager(monkeypatch):
     monkeypatch.delenv("TORCHDYNAMO_DISABLE", raising = False)
     monkeypatch.setattr(ds_mod.sys, "platform", "win32")
     monkeypatch.setitem(sys.modules, "triton", types.ModuleType("triton"))
+    _stub_dynamo(monkeypatch)
 
     _set_crt_headers(monkeypatch, False)
     _clear_runtime_cache()
@@ -803,6 +823,36 @@ def test_windows_with_triton_but_no_msvc_falls_back_to_eager(monkeypatch):
     _set_crt_headers(monkeypatch, True)
     _clear_runtime_cache()
     assert ds_mod.torch_compile_runtime_available() is True
+    _clear_runtime_cache()
+
+
+def test_windows_partially_initialized_dynamo_falls_back_to_eager(monkeypatch):
+    """Regression for #10350: a circular import can hand back a `torch._dynamo` that exists in
+    `sys.modules` but has no `.utils` yet (mirroring the real
+    `partially initialized module 'torch._dynamo' has no attribute 'utils'` failure). The gate
+    must decide eager here rather than let a GGUF load discover it mid-generation."""
+    from core.inference import diffusion_speed as ds_mod
+
+    monkeypatch.delenv("TORCHDYNAMO_DISABLE", raising = False)
+    monkeypatch.setattr(ds_mod.sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "triton", types.ModuleType("triton"))
+
+    # A partially initialized module: present, but the submodule import that would populate
+    # `.utils` never finished -- so `import torch._dynamo.utils` raises, exactly like the report.
+    partial_dynamo = types.ModuleType("torch._dynamo")
+    monkeypatch.setitem(sys.modules, "torch._dynamo", partial_dynamo)
+    monkeypatch.delitem(sys.modules, "torch._dynamo.utils", raising = False)
+    _set_crt_headers(monkeypatch, True)
+    _clear_runtime_cache()
+    assert ds_mod.torch_compile_runtime_available() is False
+    assert ds_mod.compile_eligible(_target(), is_gguf = False, family = _family()) is False
+
+    # And the gate recovers once dynamo is genuinely importable, same shape as the Triton/MSVC
+    # positive controls above.
+    _stub_dynamo(monkeypatch)
+    _clear_runtime_cache()
+    assert ds_mod.torch_compile_runtime_available() is True
+    assert ds_mod.compile_eligible(_target(), is_gguf = False, family = _family()) is True
     _clear_runtime_cache()
 
 

--- a/studio/backend/tests/test_diffusion_speed.py
+++ b/studio/backend/tests/test_diffusion_speed.py
@@ -78,12 +78,9 @@ def _compile_runtime_independent_of_the_host(monkeypatch):
 
 
 def _stub_dynamo(monkeypatch):
-    """torch_compile_runtime_available's Windows probe does `import torch._dynamo` /
-    `import torch._dynamo.utils` for real, which needs a top-level `torch` package in
-    ``sys.modules`` too (the import system resolves the parent first). Give it a fully
-    initialized pair -- and a minimal top-level `torch` if the host has no real one -- so a
-    test that doesn't otherwise need torch doesn't fail this probe for a reason unrelated to
-    what it checks. Any test exercising the probe's OWN failure path overrides this after."""
+    """A fully initialized `torch._dynamo` / `.utils` pair (plus a top-level `torch` if the host
+    has none), so the Windows probe passes in tests that are not about it. The import system
+    resolves the parent first, hence the top-level entry. Failure-path tests override this."""
     dynamo = types.ModuleType("torch._dynamo")
     dynamo.utils = types.ModuleType("torch._dynamo.utils")
     if "torch" not in sys.modules:
@@ -849,10 +846,9 @@ def test_windows_partially_initialized_dynamo_falls_back_to_eager(monkeypatch):
     assert ds_mod.torch_compile_runtime_available() is False
     assert ds_mod.compile_eligible(_target(), is_gguf = False, family = _family()) is False
 
-    # The state an `import` cannot see: `torch._dynamo.utils` IS in sys.modules, so both import
-    # statements return it straight from there -- but the deadlock fallback never bound it on the
-    # parent, and `torch._dynamo.utils.<x>` is how the compile stack reads it. Only the attribute
-    # access catches this one.
+    # The state an `import` cannot see: `torch._dynamo.utils` is in sys.modules, so the import
+    # returns it straight from there, but the deadlock fallback never bound it on the parent --
+    # which is how the compile stack reads it. Only the attribute access catches this one.
     orphaned_utils = types.ModuleType("torch._dynamo.utils")
     monkeypatch.setitem(sys.modules, "torch._dynamo.utils", orphaned_utils)
     assert not hasattr(partial_dynamo, "utils")

--- a/studio/backend/tests/test_diffusion_speed.py
+++ b/studio/backend/tests/test_diffusion_speed.py
@@ -71,10 +71,10 @@ def _compile_runtime_independent_of_the_host(monkeypatch):
     ``windows-latest`` runner, all green on Linux and macOS). Pin the non-Windows branch; the
     tests that are *about* Windows set ``sys.platform`` themselves and a later setattr wins.
     The lru_cache is dropped either side so one test's answer is never another test's."""
-    ds_mod.torch_compile_runtime_available.cache_clear()
+    ds_mod._compile_toolchain_available.cache_clear()
     monkeypatch.setattr(ds_mod.sys, "platform", "linux")
     yield
-    ds_mod.torch_compile_runtime_available.cache_clear()
+    ds_mod._compile_toolchain_available.cache_clear()
 
 
 def _stub_dynamo(monkeypatch):
@@ -750,8 +750,8 @@ def test_regional_compile_arms_cache_hook_inners(monkeypatch):
 
 
 def _clear_runtime_cache():
-    from core.inference.diffusion_speed import torch_compile_runtime_available
-    torch_compile_runtime_available.cache_clear()
+    from core.inference.diffusion_speed import _compile_toolchain_available
+    _compile_toolchain_available.cache_clear()
 
 
 def _set_crt_headers(monkeypatch, reachable: bool):
@@ -849,6 +849,17 @@ def test_windows_partially_initialized_dynamo_falls_back_to_eager(monkeypatch):
     assert ds_mod.torch_compile_runtime_available() is False
     assert ds_mod.compile_eligible(_target(), is_gguf = False, family = _family()) is False
 
+    # The state an `import` cannot see: `torch._dynamo.utils` IS in sys.modules, so both import
+    # statements return it straight from there -- but the deadlock fallback never bound it on the
+    # parent, and `torch._dynamo.utils.<x>` is how the compile stack reads it. Only the attribute
+    # access catches this one.
+    orphaned_utils = types.ModuleType("torch._dynamo.utils")
+    monkeypatch.setitem(sys.modules, "torch._dynamo.utils", orphaned_utils)
+    assert not hasattr(partial_dynamo, "utils")
+    _clear_runtime_cache()
+    assert ds_mod.torch_compile_runtime_available() is False
+    assert ds_mod.compile_eligible(_target(), is_gguf = False, family = _family()) is False
+
     # And the gate recovers once dynamo is genuinely importable, same shape as the Triton/MSVC
     # positive controls above.
     _stub_dynamo(monkeypatch)
@@ -856,6 +867,29 @@ def test_windows_partially_initialized_dynamo_falls_back_to_eager(monkeypatch):
     assert ds_mod.torch_compile_runtime_available() is True
     assert ds_mod.compile_eligible(_target(), is_gguf = False, family = _family()) is True
     _clear_runtime_cache()
+
+
+def test_dynamo_probe_is_not_cached_so_one_lost_race_is_not_permanent(monkeypatch):
+    """The dynamo probe answers a RACE, not a property of the install, so a load that loses it
+    must not run the rest of the process eager. Only the Triton/MSVC toolchain answer is cached."""
+    from core.inference import diffusion_speed as ds_mod
+
+    torch = _stub_torch(monkeypatch)
+    monkeypatch.delenv("TORCHDYNAMO_DISABLE", raising = False)
+    monkeypatch.setattr(ds_mod.sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "triton", types.ModuleType("triton"))
+    _set_crt_headers(monkeypatch, True)
+
+    partial_dynamo = types.ModuleType("torch._dynamo")
+    monkeypatch.setattr(torch, "_dynamo", partial_dynamo)
+    monkeypatch.setitem(sys.modules, "torch._dynamo", partial_dynamo)
+    monkeypatch.delitem(sys.modules, "torch._dynamo.utils", raising = False)
+    _clear_runtime_cache()
+    assert ds_mod.torch_compile_runtime_available() is False
+
+    # The next load re-probes: no cache_clear, which a real process could not call either.
+    _stub_dynamo(monkeypatch)
+    assert ds_mod.torch_compile_runtime_available() is True
 
 
 def test_gguf_dequant_respects_the_runtime_gate(monkeypatch):


### PR DESCRIPTION
Related to #10350 

`torch_compile_runtime_available()` gates whether the Studio server turns on torch.compile for GGUF loads. On Windows it currently checks Triton and MSVC reachability, but never verifies that `torch._dynamo` itself imports cleanly.
That's a real gap on its own: the server handles requests on a thread pool (unlike the three single-purpose workers, which already gate this import), so the first real `import torch._dynamo` can in principle lose a race against another in-flight torch import elsewhere in the process and come back partially initialized.

This adds an eager `torch._dynamo` / `torch._dynamo.utils` probe to the existing (already-cached) gate, so that failure mode is decided up front instead of surfacing wherever the first real dynamo access happens to be - same pattern the gate already uses for the Triton/MSVC checks.

Added a regression test simulating the partially-initialized-module case, and updated the existing torch stub so the positive-control tests exercise the new probe honestly. Local run: 49/49 passing.


