### PR TITLE
feat(chat): render on-disk sandbox images in chat markdown

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -122,9 +122,11 @@ if sys.platform != "win32":
     except ImportError:
         pass
 
-# Raster-image allowlist for sandbox file serving.
+# Raster-image allowlist for sandbox file serving; what a tool call reports inline (`__IMAGES__`)
+# and what the route serves inline (_SANDBOX_MEDIA_TYPES in routes/inference.py) are one set, pinned
+# equal by test_sandbox_files_and_storage_roots -- drift means a model's photo previews on one path only.
 # No .svg (XSS via embedded scripts), no .html, no .pdf.
-_IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"})
+_IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".avif"})
 
 
 def _env_int(name: str, default: int) -> int:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -24338,6 +24338,11 @@ _SANDBOX_MEDIA_TYPES = {
     ".gif": "image/gif",
     ".webp": "image/webp",
     ".bmp": "image/bmp",
+    # A raster codec, not a document type: `nosniff` below pins the type either way, and a model
+    # that writes `photo.avif` should get an image rather than an attachment it cannot see.
+    ".avif": "image/avif",
+    # `.svg` stays OUT on purpose. The filename is model-chosen, so an inline SVG would be
+    # same-origin script execution; it stays octet-stream + attachment (a download card).
 }
 
 

--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -157,7 +157,14 @@ def test_images_stay_inline_and_everything_else_downloads():
     image rather than an attachment it cannot see. `.svg` stays out for exactly
     that document-type reason: inline SVG is same-origin script execution.
     """
+    from core.inference import tools as _t
     from routes.inference import _SANDBOX_MEDIA_TYPES
+
+    # One set, two jobs: what the route serves inline and what a tool call reports inline must not
+    # drift apart, or a model's photo previews in chat but hides on the tool card (or vice versa).
+    assert set(_SANDBOX_MEDIA_TYPES) == _t._IMAGE_EXTS, (
+        "the route's inline map and the tool-result classifier drifted apart"
+    )
 
     for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".avif"):
         assert ext in _SANDBOX_MEDIA_TYPES

--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -151,10 +151,15 @@ def test_images_stay_inline_and_everything_else_downloads():
 
     The allowlist is deliberately NOT just widened: the model picks these
     filenames, so an inline text/html would be same-origin script execution.
+
+    `.avif` joined because it is a raster codec, not a document type -- `nosniff`
+    pins the type either way, and a model that writes `photo.avif` should get an
+    image rather than an attachment it cannot see. `.svg` stays out for exactly
+    that document-type reason: inline SVG is same-origin script execution.
     """
     from routes.inference import _SANDBOX_MEDIA_TYPES
 
-    for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"):
+    for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".avif"):
         assert ext in _SANDBOX_MEDIA_TYPES
     for ext in (".csv", ".txt", ".py", ".json", ".pdf", ".zip", ".html", ".svg"):
         assert ext not in _SANDBOX_MEDIA_TYPES, ext

--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -162,9 +162,9 @@ def test_images_stay_inline_and_everything_else_downloads():
 
     # One set, two jobs: what the route serves inline and what a tool call reports inline must not
     # drift apart, or a model's photo previews in chat but hides on the tool card (or vice versa).
-    assert set(_SANDBOX_MEDIA_TYPES) == _t._IMAGE_EXTS, (
-        "the route's inline map and the tool-result classifier drifted apart"
-    )
+    assert (
+        set(_SANDBOX_MEDIA_TYPES) == _t._IMAGE_EXTS
+    ), "the route's inline map and the tool-result classifier drifted apart"
 
     for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".avif"):
         assert ext in _SANDBOX_MEDIA_TYPES

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -149,6 +149,8 @@ const MarkdownImage = memo(function MarkdownImage(props: ComponentProps<"img">) 
     src,
     alt = "",
     className,
+    onLoad,
+    onError,
     node: _node,
     ...dom
   } = props as ComponentProps<"img"> & { node?: unknown };
@@ -165,7 +167,7 @@ const MarkdownImage = memo(function MarkdownImage(props: ComponentProps<"img">) 
       })
     : null;
   const sandbox = useSandboxImage(file);
-  const [failed, setFailed] = useState(false);
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
   // A sandbox src is renderable only once the authed fetch has produced a blob: until then it is
   // absent, never raw. `data:`/`blob:` keep going through exactly as they were.
   const resolved =
@@ -175,7 +177,8 @@ const MarkdownImage = memo(function MarkdownImage(props: ComponentProps<"img">) 
         ? sandbox.state.url
         : undefined;
   const failedNow =
-    failed || (file !== null && sandbox.state.status === "failed");
+    (resolved != null && failedSrc === resolved) ||
+    (file !== null && sandbox.state.status === "failed");
   // Hidden when it failed and has no intrinsic size to fall back on, as Streamdown's own renderer does.
   const sized = dom.width != null || dom.height != null;
   // Download naming follows the replaced renderer: a real extension on the path wins whole (alt must
@@ -210,7 +213,14 @@ const MarkdownImage = memo(function MarkdownImage(props: ComponentProps<"img">) 
         src={resolved}
         alt={alt}
         decoding="async"
-        onError={() => setFailed(true)}
+        onLoad={(event) => {
+          setFailedSrc(null);
+          onLoad?.(event);
+        }}
+        onError={(event) => {
+          setFailedSrc(resolved ?? null);
+          onError?.(event);
+        }}
         className={`max-w-full rounded-lg ${failedNow && !sized ? "hidden" : ""} ${className ?? ""}`}
         {...dom}
       />

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -3,7 +3,11 @@
 
 "use client";
 
-import { ArtifactCard, useChatRuntimeStore } from "@/features/chat";
+import {
+  ArtifactCard,
+  useChatProjectScope,
+  useChatRuntimeStore,
+} from "@/features/chat";
 import {
   getCodeFence,
   isFullHtmlDocument,
@@ -75,7 +79,9 @@ import {
 } from "./markdown-block-boundary";
 import "katex/dist/katex.min.css";
 import { AudioPlayer } from "./audio-player";
+import { markdownSandboxImageSrc } from "./sandbox-files";
 import { SearchImageElement, SearchImagesContext } from "./search-image";
+import { useSandboxImage } from "./use-sandbox-image";
 import { unslothDarkTheme, unslothLightTheme } from "./code-themes";
 import { stabilizeStreamingMarkdown } from "./streaming-markdown";
 import {
@@ -124,6 +130,119 @@ const STREAMDOWN_IMMEDIATE_UPDATES = {
   stagger: 0,
 } satisfies NonNullable<StreamdownProps["animated"]>;
 
+/*
+ * Registering `img` replaces Streamdown's own renderer WHOLESALE (its `Components` map is keyed by
+ * tag, so the default `img` is only a default), so everything that renderer did for a `data:` image
+ * is restated here: wrapper, hidden-when-failed, fallback text, hover download. What it could not do
+ * is the reason this exists -- an on-disk answer image arrives as
+ * `![plot](/api/inference/sandbox/<sid>/plot.png)`, survives sanitize() because it carries no scheme,
+ * and then reaches the DOM as a plain same-origin <img src>, with no Authorization header, 401s, and
+ * renders as "Image not available". That case is rewritten into an authed fetch -> object URL first
+ * (see `use-sandbox-image`); a `data:` URI keeps going straight through, untouched.
+ */
+const MarkdownImage = memo(function MarkdownImage(props: ComponentProps<"img">) {
+  // `node` is Streamdown's ExtraProps; it must not reach the DOM.
+  const {
+    src,
+    alt = "",
+    className,
+    node: _node,
+    ...dom
+  } = props as ComponentProps<"img"> & { node?: unknown };
+  // The same pair the adapter resolves a run's session from (`unstable_threadId ?? activeThreadId`),
+  // so an answer written inside a project reads the project's workspace, not the thread's.
+  const remoteId = useAuiState(({ threadListItem }) => threadListItem.remoteId);
+  const activeThreadId = useChatRuntimeStore((state) => state.activeThreadId);
+  const projectId = useChatProjectScope();
+  const file = src
+    ? markdownSandboxImageSrc(src, {
+        threadId: remoteId ?? activeThreadId ?? undefined,
+        projectId,
+      })
+    : null;
+  const sandbox = useSandboxImage(file);
+  const [failed, setFailed] = useState(false);
+  // A sandbox src is renderable only once the authed fetch has produced a blob: until then it is
+  // absent, never raw. `data:`/`blob:` keep going through exactly as they were.
+  const resolved =
+    file === null
+      ? src
+      : sandbox.state.status === "loaded"
+        ? sandbox.state.url
+        : undefined;
+  const failedNow =
+    failed || (file !== null && sandbox.state.status === "failed");
+  // Hidden when it failed and has no intrinsic size to fall back on, as Streamdown's own renderer does.
+  const sized = dom.width != null || dom.height != null;
+  // Download naming follows the replaced renderer: a real extension on the path wins whole (alt must
+  // never override a real filename); otherwise any extension in alt is STRIPPED and one inferred from the
+  // blob's type is appended -- so alt="plot" downloads "plot.png", not "plot".
+  const downloadName = (blobType: string): string => {
+    const tail = (file ?? src ?? "").split(/[?#]/)[0].split("/").pop() ?? "";
+    const dot = tail.lastIndexOf(".");
+    if (dot > -1 && tail.length - dot - 1 <= 4) return tail;
+    const ext = /jpe?g/.test(blobType)
+      ? "jpg"
+      : blobType.includes("svg")
+        ? "svg"
+        : blobType.includes("gif")
+          ? "gif"
+          : blobType.includes("webp")
+            ? "webp"
+            : "png";
+    return `${(alt || tail || "image").replace(/\.[^/.]+$/, "")}.${ext}`;
+  };
+  return (
+    <span
+      data-streamdown="image-wrapper"
+      className="group relative my-4 inline-block"
+    >
+      <img
+        ref={file === null ? undefined : sandbox.ref}
+        data-streamdown="image"
+        src={resolved}
+        alt={alt}
+        decoding="async"
+        onError={() => setFailed(true)}
+        className={`max-w-full rounded-lg ${failedNow && !sized ? "hidden" : ""} ${className ?? ""}`}
+        {...dom}
+      />
+      {failedNow && (
+        <span
+          data-streamdown="image-fallback"
+          className="text-muted-foreground text-xs italic"
+        >
+          Image not available
+        </span>
+      )}
+      {/* Kept from the replaced renderer: the hover tint over the image. */}
+      <div className="pointer-events-none absolute inset-0 hidden rounded-lg bg-black/10 group-hover:block" />
+      {!failedNow && resolved ? (
+        <button
+          type="button"
+          title="Download image"
+          className="absolute right-2 bottom-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border border-border bg-background/90 opacity-0 backdrop-blur-sm transition-all duration-200 group-hover:opacity-100"
+          onClick={async () => {
+            // By now the src is always blob:/data:, so a plain fetch carries it.
+            try {
+              const blob = await (await fetch(resolved)).blob();
+              await downloadFile(blob, downloadName(blob.type), blob.type);
+            } catch (error) {
+              if (!isDownloadCancelled(error)) toast.error("Could not save file.");
+            }
+          }}
+        >
+          <HugeiconsIcon
+            icon={Download01Icon}
+            strokeWidth={1.75}
+            className="size-icon"
+          />
+        </button>
+      ) : null}
+    </span>
+  );
+});
+
 const STREAMDOWN_COMPONENTS = {
   a: ({ href, children, ...props }: ComponentProps<"a">) => (
     <a
@@ -142,6 +261,7 @@ const STREAMDOWN_COMPONENTS = {
   ),
   // Module-scoped: Streamdown's memo comparator ignores `components`.
   [SEARCH_IMAGE_TAG]: SearchImageElement,
+  img: MarkdownImage,
 };
 // Through the sanitizer; the component drops tokens it cannot resolve.
 const STREAMDOWN_ALLOWED_TAGS = {

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -79,7 +79,10 @@ import {
 } from "./markdown-block-boundary";
 import "katex/dist/katex.min.css";
 import { AudioPlayer } from "./audio-player";
-import { markdownSandboxImageSrc } from "./sandbox-files";
+import {
+  decodeSegment,
+  markdownSandboxImageSrc,
+} from "./sandbox-files";
 import { SearchImageElement, SearchImagesContext } from "./search-image";
 import { useSandboxImage } from "./use-sandbox-image";
 import { unslothDarkTheme, unslothLightTheme } from "./code-themes";
@@ -149,8 +152,9 @@ const MarkdownImage = memo(function MarkdownImage(props: ComponentProps<"img">) 
     node: _node,
     ...dom
   } = props as ComponentProps<"img"> & { node?: unknown };
-  // The same pair the adapter resolves a run's session from (`unstable_threadId ?? activeThreadId`),
-  // so an answer written inside a project reads the project's workspace, not the thread's.
+  // The fallback scope, for a src that records no session of its own (a bare `plot.png`): the same
+  // pair the adapter resolves a run's session from (`unstable_threadId ?? activeThreadId`). A src
+  // that DOES record one keeps it -- the folder its files were written to is where they still are.
   const remoteId = useAuiState(({ threadListItem }) => threadListItem.remoteId);
   const activeThreadId = useChatRuntimeStore((state) => state.activeThreadId);
   const projectId = useChatProjectScope();
@@ -176,9 +180,12 @@ const MarkdownImage = memo(function MarkdownImage(props: ComponentProps<"img">) 
   const sized = dom.width != null || dom.height != null;
   // Download naming follows the replaced renderer: a real extension on the path wins whole (alt must
   // never override a real filename); otherwise any extension in alt is STRIPPED and one inferred from the
-  // blob's type is appended -- so alt="plot" downloads "plot.png", not "plot".
+  // blob's type is appended -- so alt="plot" downloads "plot.png", not "plot". Split before DECODING,
+  // so a raw `#`/`?` keeps its delimiter meaning, then decode: `loss curve #1.png` must save under its
+  // real name, not as `loss%20curve%20%231.png`.
   const downloadName = (blobType: string): string => {
-    const tail = (file ?? src ?? "").split(/[?#]/)[0].split("/").pop() ?? "";
+    const tail =
+      decodeSegment((file ?? src ?? "").split(/[?#]/)[0].split("/").pop() ?? "") || "";
     const dot = tail.lastIndexOf(".");
     if (dot > -1 && tail.length - dot - 1 <= 4) return tail;
     const ext = /jpe?g/.test(blobType)

--- a/studio/frontend/src/components/assistant-ui/sandbox-files.ts
+++ b/studio/frontend/src/components/assistant-ui/sandbox-files.ts
@@ -148,8 +148,11 @@ export const SANDBOX_INLINE_IMAGE_EXTS = new Set([
 const HAS_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+\-.]*:/;
 const PROTOCOL_RELATIVE_RE = /^[/\\]{2}/;
 
-/** `100%.png` is a real filename; a stray `%` must not throw on every render. */
-function decodeSegment(segment: string): string {
+/**
+ * `100%.png` is a real filename; a stray `%` must not throw on every render. Exported because the
+ * download name is cut from the ENCODED route path and must be decoded back before it names a file.
+ */
+export function decodeSegment(segment: string): string {
   try {
     return decodeURIComponent(segment);
   } catch {
@@ -158,34 +161,70 @@ function decodeSegment(segment: string): string {
 }
 
 /**
- * The file a model-written markdown `src` points at, or null when it does not point at this chat's
- * sandbox. A bare relative path (`outputs/plot.png`) counts: the sanitizer already dropped every
- * scheme-carrying src, so a scheme-less image path in an answer is this chat's file and nothing else.
+ * The FILE a model-written markdown `src` points at, or null when it does not point at a sandbox
+ * file at all. A bare relative path (`outputs/plot.png`) counts: the sanitizer already dropped every
+ * scheme-carrying src, so a scheme-less image path in an answer is this chat's file and nothing else
+ * -- and one carrying `..` points somewhere that is NOT this chat's folder, so it stays raw and fails
+ * honestly instead of silently fetching another chat's file (or another route).
  */
 export function sandboxFileForSrc(src: string): string | null {
   const trimmed = src.trim();
   if (!trimmed || HAS_SCHEME_RE.test(trimmed) || PROTOCOL_RELATIVE_RE.test(trimmed)) {
     return null;
   }
-  // The sid rides in `?session=` when it is not path-safe; either way we re-derive it, so drop it.
+  // The sid rides in `?session=` when it is not path-safe; either way the caller reads it back with
+  // sandboxSessionInSrc, so it never reaches the file path.
   const path = trimmed.split("?")[0].split("#")[0];
   if (path.startsWith("/") && !path.startsWith(SANDBOX_ROUTE_PREFIX)) {
     return null; // some other app route (`/assets/...`), not a sandbox file
   }
   const segments = path.startsWith(SANDBOX_ROUTE_PREFIX)
-    ? // The sid segment goes in the bin with the query: the caller re-derives it from this chat.
+    ? // The recorded sid is not part of the file path; sandboxSessionInSrc reads it back out.
       path.slice(SANDBOX_ROUTE_PREFIX.length).split("/").slice(1)
     : path.split("/");
-  const name = segments[segments.length - 1] ?? "";
+  // Decode FIRST, then judge: `%2e%2e` IS `..`, and a dot segment pops the scope segment the caller
+  // prepends -- one reads another chat's folder, two land on another route. A bare `.` is noise URL
+  // parsing drops anyway; drop it here so callers see one canonical shape.
+  const decoded = segments.map(decodeSegment);
+  if (decoded.some((segment) => segment === "..")) return null;
+  const parts = decoded.filter((segment) => segment !== ".");
+  const name = parts[parts.length - 1] ?? "";
   const ext = name.slice(name.lastIndexOf(".")).toLowerCase();
   // A `.csv` is a download card, not an `<img>`; leave it to the file cards.
   if (!SANDBOX_INLINE_IMAGE_EXTS.has(ext)) return null;
-  return segments.map(decodeSegment).join("/");
+  return parts.join("/");
 }
 
 /**
- * The URL to fetch for a sandbox `src`: the model's own session segment is DISCARDED and rebuilt
- * from this chat's scope, so an answer written in a project reads the project's workspace.
+ * The session a `src` records for itself: the segment after the route prefix (or the `?session=`
+ * query when the id was not path-safe at write time). A bare relative path records nothing: null.
+ */
+export function sandboxSessionInSrc(src: string): string | null {
+  const trimmed = src.trim();
+  if (!trimmed || HAS_SCHEME_RE.test(trimmed) || PROTOCOL_RELATIVE_RE.test(trimmed)) {
+    return null;
+  }
+  const [path, ...queryAndFragment] = trimmed.split("?");
+  // A bare relative path records nothing: the caller's fallback scope is all there is.
+  if (!path.startsWith(SANDBOX_ROUTE_PREFIX)) return null;
+  const segment = path.slice(SANDBOX_ROUTE_PREFIX.length).split("/")[0] ?? "";
+  // `sandboxRoutePrefix` carries a not-path-safe id in the query under `_`; mirror it back out.
+  if (queryAndFragment.length > 0) {
+    const session = new URLSearchParams(
+      queryAndFragment.join("?").split("#")[0] ?? "",
+    ).get("session");
+    if (session) return decodeSegment(session);
+  }
+  return segment ? decodeSegment(segment) : null;
+}
+
+/**
+ * The URL to fetch for a sandbox `src`. The session the src RECORDS wins when it names one: that is
+ * the folder the files landed in when the message was WRITTEN -- where a chat moved between projects
+ * still has its older files, and exactly what the tool card above the prose resolves from its own
+ * persisted envelope. A model echoes real workdir paths out of the stdout it saw; discarding that echo
+ * is what broke those answers' images after a move. Only a path that records nothing (a bare
+ * `outputs/plot.png`) falls back to this chat's CURRENT scope: `project-<id>` else threadId.
  */
 export function markdownSandboxImageSrc(
   src: string,
@@ -193,8 +232,9 @@ export function markdownSandboxImageSrc(
 ): string | null {
   const file = sandboxFileForSrc(src);
   if (file === null) return null;
-  const sessionId = sandboxSessionIdFor(ctx.threadId, ctx.projectId);
-  // No thread yet means no directory to read from; the raw src stays as it is.
+  const sessionId =
+    sandboxSessionInSrc(src) ?? sandboxSessionIdFor(ctx.threadId, ctx.projectId);
+  // No recorded session and no thread yet means no directory to read from; the raw src stays as it is.
   return sessionId ? sandboxFilePath(sessionId, file) : null;
 }
 

--- a/studio/frontend/src/components/assistant-ui/sandbox-files.ts
+++ b/studio/frontend/src/components/assistant-ui/sandbox-files.ts
@@ -93,6 +93,12 @@ export function isSandboxToolResult(
 /** Ids a path segment can carry: ASGI decodes %2F before it matches a route. */
 const PATH_SAFE_SESSION = /^[A-Za-z0-9_-]{1,64}$/;
 
+/**
+ * The route both sides spell: `sandboxRoutePrefix` builds it for the cards, and a model that
+ * writes `![plot](/api/inference/sandbox/<sid>/plot.png)` into its own markdown carries it back.
+ */
+export const SANDBOX_ROUTE_PREFIX = "/api/inference/sandbox/";
+
 /** Where this session's files live, as the routes expect to be asked. */
 export function sandboxRoutePrefix(sessionId: string): {
   prefix: string;
@@ -100,7 +106,7 @@ export function sandboxRoutePrefix(sessionId: string): {
 } {
   if (PATH_SAFE_SESSION.test(sessionId)) {
     return {
-      prefix: `/api/inference/sandbox/${encodeURIComponent(sessionId)}`,
+      prefix: `${SANDBOX_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`,
       query: "",
     };
   }
@@ -121,6 +127,75 @@ export function sandboxSessionIdFor(
   projectId: string | null | undefined,
 ): string | undefined {
   return projectId ? `project-${projectId}` : threadId;
+}
+
+/**
+ * Extensions the route serves inline as an image, mirroring `_SANDBOX_MEDIA_TYPES` in
+ * `backend/routes/inference.py`. `.svg` is absent on purpose: the filename is model-chosen, so an
+ * inline SVG would be same-origin script execution and the route keeps serving it as a download.
+ */
+export const SANDBOX_INLINE_IMAGE_EXTS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".bmp",
+  ".avif",
+]);
+
+/** Somebody else's URL: `data:`/`blob:` render as they are, `http(s)` is blocked by the sanitizer. */
+const HAS_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+\-.]*:/;
+const PROTOCOL_RELATIVE_RE = /^[/\\]{2}/;
+
+/** `100%.png` is a real filename; a stray `%` must not throw on every render. */
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+/**
+ * The file a model-written markdown `src` points at, or null when it does not point at this chat's
+ * sandbox. A bare relative path (`outputs/plot.png`) counts: the sanitizer already dropped every
+ * scheme-carrying src, so a scheme-less image path in an answer is this chat's file and nothing else.
+ */
+export function sandboxFileForSrc(src: string): string | null {
+  const trimmed = src.trim();
+  if (!trimmed || HAS_SCHEME_RE.test(trimmed) || PROTOCOL_RELATIVE_RE.test(trimmed)) {
+    return null;
+  }
+  // The sid rides in `?session=` when it is not path-safe; either way we re-derive it, so drop it.
+  const path = trimmed.split("?")[0].split("#")[0];
+  if (path.startsWith("/") && !path.startsWith(SANDBOX_ROUTE_PREFIX)) {
+    return null; // some other app route (`/assets/...`), not a sandbox file
+  }
+  const segments = path.startsWith(SANDBOX_ROUTE_PREFIX)
+    ? // The sid segment goes in the bin with the query: the caller re-derives it from this chat.
+      path.slice(SANDBOX_ROUTE_PREFIX.length).split("/").slice(1)
+    : path.split("/");
+  const name = segments[segments.length - 1] ?? "";
+  const ext = name.slice(name.lastIndexOf(".")).toLowerCase();
+  // A `.csv` is a download card, not an `<img>`; leave it to the file cards.
+  if (!SANDBOX_INLINE_IMAGE_EXTS.has(ext)) return null;
+  return segments.map(decodeSegment).join("/");
+}
+
+/**
+ * The URL to fetch for a sandbox `src`: the model's own session segment is DISCARDED and rebuilt
+ * from this chat's scope, so an answer written in a project reads the project's workspace.
+ */
+export function markdownSandboxImageSrc(
+  src: string,
+  ctx: { threadId: string | undefined; projectId: string | null | undefined },
+): string | null {
+  const file = sandboxFileForSrc(src);
+  if (file === null) return null;
+  const sessionId = sandboxSessionIdFor(ctx.threadId, ctx.projectId);
+  // No thread yet means no directory to read from; the raw src stays as it is.
+  return sessionId ? sandboxFilePath(sessionId, file) : null;
 }
 
 export function sandboxFilePath(sessionId: string, filename: string): string {

--- a/studio/frontend/src/components/assistant-ui/sandbox-files.ts
+++ b/studio/frontend/src/components/assistant-ui/sandbox-files.ts
@@ -186,7 +186,10 @@ export function sandboxFileForSrc(src: string): string | null {
   // prepends -- one reads another chat's folder, two land on another route. A bare `.` is noise URL
   // parsing drops anyway; drop it here so callers see one canonical shape.
   const decoded = segments.map(decodeSegment);
-  if (decoded.some((segment) => segment === "..")) return null;
+  // Encoded separators must not become new path segments after this check.
+  if (decoded.some((segment) => segment === ".." || /[/\\]/.test(segment))) {
+    return null;
+  }
   const parts = decoded.filter((segment) => segment !== ".");
   const name = parts[parts.length - 1] ?? "";
   const ext = name.slice(name.lastIndexOf(".")).toLowerCase();
@@ -204,16 +207,15 @@ export function sandboxSessionInSrc(src: string): string | null {
   if (!trimmed || HAS_SCHEME_RE.test(trimmed) || PROTOCOL_RELATIVE_RE.test(trimmed)) {
     return null;
   }
-  const [path, ...queryAndFragment] = trimmed.split("?");
+  const [path, ...query] = trimmed.split("#")[0].split("?");
   // A bare relative path records nothing: the caller's fallback scope is all there is.
   if (!path.startsWith(SANDBOX_ROUTE_PREFIX)) return null;
   const segment = path.slice(SANDBOX_ROUTE_PREFIX.length).split("/")[0] ?? "";
   // `sandboxRoutePrefix` carries a not-path-safe id in the query under `_`; mirror it back out.
-  if (queryAndFragment.length > 0) {
-    const session = new URLSearchParams(
-      queryAndFragment.join("?").split("#")[0] ?? "",
-    ).get("session");
-    if (session) return decodeSegment(session);
+  if (query.length > 0) {
+    const session = new URLSearchParams(query.join("?")).get("session");
+    // URLSearchParams has already decoded the query value.
+    if (session) return session;
   }
   return segment ? decodeSegment(segment) : null;
 }

--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -4,7 +4,6 @@
 "use client";
 
 import { Spinner } from "@/components/ui/spinner";
-import { authFetch } from "@/features/auth";
 
 import { SandboxFiles } from "./sandbox-files-view";
 import { isSandboxFileList, type SandboxFile } from "./sandbox-files";
@@ -20,8 +19,9 @@ import { stringifyToolResult } from "@/lib/strip-ansi";
 import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
 import { useToolArgsStatus } from "@assistant-ui/react";
 import { CodeIcon } from "lucide-react";
-import { memo, useEffect, useRef, useState } from "react";
+import { memo } from "react";
 import { pythonToolImagePath } from "./python-tool-image-path";
+import { useSandboxImage } from "./use-sandbox-image";
 import { CopyBtn, ToolCodeCell } from "./tool-code-cell";
 import { toolArgText } from "./tool-arg-text";
 import {
@@ -59,77 +59,16 @@ function PythonToolImage({
   sessionId: string;
   filename: string;
 }) {
-  const imageKey = `${sessionId}\0${filename}`;
-  const [image, setImage] = useState<{ key: string; url: string } | null>(null);
-  const imageRef = useRef<HTMLImageElement>(null);
-  const [nearViewport, setNearViewport] = useState(
-    () => typeof IntersectionObserver === "undefined",
-  );
-
-  useEffect(() => {
-    if (nearViewport) {
-      return;
-    }
-    const element = imageRef.current;
-    if (!element) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          setNearViewport(true);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: "200px" },
-    );
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [nearViewport]);
-
-  useEffect(() => {
-    if (!nearViewport) {
-      return;
-    }
-    const controller = new AbortController();
-    let objectUrl: string | null = null;
-
-    const load = async () => {
-      const response = await authFetch(
-        pythonToolImagePath(sessionId, filename),
-        {
-          signal: controller.signal,
-        },
-      );
-      if (!response.ok) {
-        return;
-      }
-
-      const blob = await response.blob();
-      if (controller.signal.aborted) {
-        return;
-      }
-
-      objectUrl = URL.createObjectURL(blob);
-      setImage({ key: imageKey, url: objectUrl });
-    };
-    load().catch(() => {
-      // A failed or cancelled image stays as its accessible alt text.
-    });
-
-    return () => {
-      controller.abort();
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
-    };
-  }, [filename, imageKey, nearViewport, sessionId]);
+  // The same hook assistant markdown uses for an on-disk image, so the authed fetch, the object URL
+  // and its revocation live in one place instead of two. A failed or cancelled image stays as its
+  // accessible alt text. Keyed by url inside the hook: a re-used element reads idle, not the
+  // previous file's blob, and a stale response cannot write state for a url it was not fetched for.
+  const { ref, state } = useSandboxImage(pythonToolImagePath(sessionId, filename));
 
   return (
     <img
-      ref={imageRef}
-      src={image?.key === imageKey ? image.url : undefined}
+      ref={ref}
+      src={state.status === "loaded" ? state.url : undefined}
       alt={filename}
       loading="lazy"
       className="max-w-full rounded border border-border"

--- a/studio/frontend/src/components/assistant-ui/use-sandbox-image.ts
+++ b/studio/frontend/src/components/assistant-ui/use-sandbox-image.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"use client";
+
+import { authFetch } from "@/features/auth";
+import { type RefObject, useEffect, useRef, useState } from "react";
+
+export type SandboxImageState =
+  | { status: "idle" }
+  | { status: "loaded"; url: string }
+  | { status: "failed" };
+
+const IDLE: SandboxImageState = { status: "idle" };
+
+/**
+ * Fetches one auth-protected sandbox file into an object URL.
+ *
+ * The route answers on the Authorization header (`_authenticate_header_or_query`), so a bare
+ * `<img src>` hitting it straight gets a 401 and the renderer's "Image not available" placeholder.
+ * Pass the URL from `sandboxFilePath()`/`markdownSandboxImageSrc()` and render what comes back.
+ *
+ * Keyed by url: an element that moves to another file reads idle rather than showing the previous
+ * file's blob, and a stale response can never write state for a url it was not fetched for.
+ */
+export function useSandboxImage(url: string | null): {
+  ref: RefObject<HTMLImageElement | null>;
+  state: SandboxImageState;
+} {
+  const ref = useRef<HTMLImageElement>(null);
+  const [state, setState] = useState<{ url: string | null; load: SandboxImageState }>({
+    url,
+    load: IDLE,
+  });
+  const [nearViewport, setNearViewport] = useState(
+    () => typeof IntersectionObserver === "undefined",
+  );
+
+  useEffect(() => {
+    if (nearViewport || !url) return;
+    const element = ref.current;
+    if (!element) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setNearViewport(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [nearViewport, url]);
+
+  useEffect(() => {
+    if (!url || !nearViewport) return;
+    const controller = new AbortController();
+    let objectUrl: string | null = null;
+
+    authFetch(url, { signal: controller.signal })
+      .then(async (response) => {
+        // Guarded on both arms: a late write for the url this element used to hold must not land.
+        if (!response.ok) {
+          if (!controller.signal.aborted) setState({ url, load: { status: "failed" } });
+          return;
+        }
+        const blob = await response.blob();
+        if (controller.signal.aborted) return;
+        objectUrl = URL.createObjectURL(blob);
+        setState({ url, load: { status: "loaded", url: objectUrl } });
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setState({ url, load: { status: "failed" } });
+      });
+
+    return () => {
+      controller.abort();
+      // The URL is ours to give up: an aborted fetch that had already made one would otherwise
+      // pin the bytes for the rest of the session.
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [url, nearViewport]);
+
+  return { ref, state: state.url === url ? state.load : IDLE };
+}

--- a/studio/frontend/src/components/assistant-ui/use-sandbox-image.ts
+++ b/studio/frontend/src/components/assistant-ui/use-sandbox-image.ts
@@ -28,7 +28,11 @@ export function useSandboxImage(url: string | null): {
   state: SandboxImageState;
 } {
   const ref = useRef<HTMLImageElement>(null);
-  const [state, setState] = useState<{ url: string | null; load: SandboxImageState }>({
+  const [state, setState] = useState<{
+    url: string | null;
+    load: SandboxImageState;
+    signal?: AbortSignal;
+  }>({
     url,
     load: IDLE,
   });
@@ -62,16 +66,30 @@ export function useSandboxImage(url: string | null): {
       .then(async (response) => {
         // Guarded on both arms: a late write for the url this element used to hold must not land.
         if (!response.ok) {
-          if (!controller.signal.aborted) setState({ url, load: { status: "failed" } });
+          if (!controller.signal.aborted)
+            setState({
+              url,
+              load: { status: "failed" },
+              signal: controller.signal,
+            });
           return;
         }
         const blob = await response.blob();
         if (controller.signal.aborted) return;
         objectUrl = URL.createObjectURL(blob);
-        setState({ url, load: { status: "loaded", url: objectUrl } });
+        setState({
+          url,
+          load: { status: "loaded", url: objectUrl },
+          signal: controller.signal,
+        });
       })
       .catch(() => {
-        if (!controller.signal.aborted) setState({ url, load: { status: "failed" } });
+        if (!controller.signal.aborted)
+          setState({
+            url,
+            load: { status: "failed" },
+            signal: controller.signal,
+          });
       });
 
     return () => {
@@ -82,5 +100,9 @@ export function useSandboxImage(url: string | null): {
     };
   }, [url, nearViewport]);
 
-  return { ref, state: state.url === url ? state.load : IDLE };
+  // Returning to the same URL must not reuse a result whose fetch was cleaned up.
+  return {
+    ref,
+    state: state.url === url && !state.signal?.aborted ? state.load : IDLE,
+  };
 }

--- a/studio/frontend/tests/markdown-image-recovery.test.ts
+++ b/studio/frontend/tests/markdown-image-recovery.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { runInNewContext } from "node:vm";
+import ts from "typescript";
+
+// Exercise production event handlers with a deterministic state seam.
+function renderer() {
+  const source = readFileSync(
+    new URL(
+      "../src/components/assistant-ui/markdown-text.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const parsed = ts.createSourceFile(
+    "markdown-text.tsx",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const statement = parsed.statements.find(
+    (node) =>
+      ts.isVariableStatement(node) &&
+      node.declarationList.declarations.some(
+        (decl) => decl.name.getText(parsed) === "MarkdownImage",
+      ),
+  );
+  assert.ok(statement, "production MarkdownImage declaration exists");
+  const code = ts.transpileModule(
+    statement.getText(parsed) + "\nexports.render = MarkdownImage;",
+    {
+      compilerOptions: {
+        jsx: ts.JsxEmit.React,
+        target: ts.ScriptTarget.ES2022,
+      },
+    },
+  ).outputText;
+  const slots: unknown[] = [];
+  let cursor = 0;
+  const context = {
+    exports: {} as { render: (props: Record<string, unknown>) => any },
+    memo: (fn: unknown) => fn,
+    React: {
+      createElement: (
+        type: unknown,
+        props: unknown,
+        ...children: unknown[]
+      ) => ({ type, props, children }),
+    },
+    useState: (initial: unknown) => {
+      const index = cursor++;
+      if (!(index in slots)) slots[index] = initial;
+      return [
+        slots[index],
+        (next: unknown) => {
+          slots[index] = next;
+        },
+      ];
+    },
+    useAuiState: () => "thread",
+    useChatRuntimeStore: () => "thread",
+    useChatProjectScope: () => null,
+    markdownSandboxImageSrc: () => null,
+    useSandboxImage: () => ({ state: { status: "idle" } }),
+    HugeiconsIcon: "icon",
+    Download01Icon: "download",
+  };
+  runInNewContext(code, context);
+  return (props: Record<string, unknown>) => {
+    cursor = 0;
+    return context.exports.render(props).children[0].props;
+  };
+}
+
+test("a replacement image is not hidden by the previous source's decode failure", () => {
+  const render = renderer();
+  render({ src: "data:image/png;base64,broken" }).onError({});
+  assert.match(
+    render({ src: "data:image/png;base64,broken" }).className,
+    /hidden/,
+  );
+  assert.doesNotMatch(
+    render({ src: "data:image/png;base64,replacement" }).className,
+    /hidden/,
+  );
+});
+
+test("successful image load clears decode failure and forwards image events", () => {
+  const render = renderer();
+  let errors = 0;
+  let loads = 0;
+  const props = {
+    src: "blob:test",
+    onError: () => {
+      errors++;
+    },
+    onLoad: () => {
+      loads++;
+    },
+  };
+  render(props).onError({});
+  assert.match(render(props).className, /hidden/);
+  render(props).onLoad({});
+  assert.doesNotMatch(render(props).className, /hidden/);
+  assert.equal(errors, 1);
+  assert.equal(loads, 1);
+});

--- a/studio/frontend/tests/markdown-sandbox-image.test.ts
+++ b/studio/frontend/tests/markdown-sandbox-image.test.ts
@@ -52,8 +52,9 @@ test("a scheme-less sandbox src is rewritten before it reaches the DOM, and rend
   );
   assert.ok(
     /markdownSandboxImageSrc\(src,\s*\{/.test(MARKDOWN_TEXT),
-    "the src is re-derived from this chat's scope (project-<id> else threadId), not passed through " +
-      "with whichever sid the model happened to be talking to",
+    "a src that RECORDS a session keeps it -- the folder its files were written to is where they " +
+      "still are after a move, and it is what the tool card above the prose already resolves from; " +
+      "only one that records nothing falls back to this chat's scope",
   );
   assert.ok(
     MARKDOWN_TEXT.includes("useSandboxImage(file)"),
@@ -64,8 +65,14 @@ test("a scheme-less sandbox src is rewritten before it reaches the DOM, and rend
   const imgNode = { tagName: "img" } as Parameters<typeof safeMarkdownUrl>[2];
   const written = "/api/inference/sandbox/__LOCALID_Y3VK67e/plot.png";
   assert.equal(safeMarkdownUrl(written, "src", imgNode), written);
+  // The recorded session wins (it is where the file was WRITTEN); a bare path records nothing and
+  // only then falls back to this chat's scope.
   assert.equal(
     markdownSandboxImageSrc(written, { threadId: "t-1", projectId: null }),
+    "/api/inference/sandbox/__LOCALID_Y3VK67e/plot.png",
+  );
+  assert.equal(
+    markdownSandboxImageSrc("plot.png", { threadId: "t-1", projectId: null }),
     "/api/inference/sandbox/t-1/plot.png",
   );
   assert.equal(markdownSandboxImageSrc("data:image/png;base64,AAAA", { threadId: "t-1", projectId: null }), null);
@@ -152,5 +159,10 @@ test("the img restatement keeps what the wholesale replacement silently dropped"
     MARKDOWN_TEXT.includes('.replace(/\\.[^/.]+$/'),
     'download names: a real extension on the path wins whole; otherwise alt\'s extension is stripped ' +
       'and one inferred from blob.type is appended -- alt="plot" downloads "plot.png", not "plot"',
+  );
+  assert.ok(
+    MARKDOWN_TEXT.includes("decodeSegment((file ?? src"),
+    "the tail is cut with raw delimiters split off FIRST, then decoded: `loss curve #1.png` must " +
+      "save under its real name, not as loss%20curve%20%231.png",
   );
 });

--- a/studio/frontend/tests/markdown-sandbox-image.test.ts
+++ b/studio/frontend/tests/markdown-sandbox-image.test.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  SANDBOX_INLINE_IMAGE_EXTS,
+  markdownSandboxImageSrc,
+  sandboxFileForSrc,
+} from "../src/components/assistant-ui/sandbox-files.ts";
+import { safeMarkdownUrl } from "../src/lib/safe-markdown-url.ts";
+
+/*
+ * THREE PIECES ONLY WORK TOGETHER, and nothing in the type system joins them:
+ *
+ *   1. the renderer has to resolve a scheme-less sandbox `src` through `markdownSandboxImageSrc`
+ *      before it reaches the DOM (the sanitizer keeps what carries no scheme -- see
+ *      `safe-markdown-url.ts` -- but keeping it was never the same as being able to fetch it);
+ *   2. the fetch has to carry the Authorization header, which is the only way the route authenticates
+ *      a header-auth client (`_authenticate_header_or_query`), and revoke what it created;
+ *   3. the extension set has to agree with the backend's `_SANDBOX_MEDIA_TYPES`, which decides
+ *      inline-image from attachment in a different language, two directories away.
+ *
+ * Each is checked against the real source, and where a check is a string search it says what it is
+ * defending, so a rename that breaks the join fails here by name rather than by measuring as a
+ * change that does nothing.
+ */
+
+const read = (relative: string): string =>
+  readFileSync(new URL(relative, import.meta.url), "utf8");
+
+const MARKDOWN_TEXT = read("../src/components/assistant-ui/markdown-text.tsx");
+const HOOK = read("../src/components/assistant-ui/use-sandbox-image.ts");
+const TOOL_UI = read("../src/components/assistant-ui/tool-ui-python.tsx");
+const BACKEND = read(
+  "../../backend/routes/inference.py",
+);
+
+test("a scheme-less sandbox src is rewritten before it reaches the DOM, and rendered from a blob:", () => {
+  // PRECONDITION: the renderer still relies on the sanitizer's deny rule rather than repeating it.
+  assert.ok(
+    MARKDOWN_TEXT.includes("urlTransform={safeMarkdownUrl}"),
+    "PRECONDITION: the chat renderer still passes the url transform",
+  );
+  assert.ok(
+    /img: MarkdownImage,/.test(MARKDOWN_TEXT),
+    "registering `img` replaces Streamdown's own renderer wholesale, so the swap has to live in the " +
+      "component it replaces -- an unregistered <img src> is the bug this file exists for",
+  );
+  assert.ok(
+    /markdownSandboxImageSrc\(src,\s*\{/.test(MARKDOWN_TEXT),
+    "the src is re-derived from this chat's scope (project-<id> else threadId), not passed through " +
+      "with whichever sid the model happened to be talking to",
+  );
+  assert.ok(
+    MARKDOWN_TEXT.includes("useSandboxImage(file)"),
+    "and it is fetched rather than rendered raw",
+  );
+
+  // ANTI-VACUITY: the rewrite really is what produces the src, and a data: URI really is untouched.
+  const imgNode = { tagName: "img" } as Parameters<typeof safeMarkdownUrl>[2];
+  const written = "/api/inference/sandbox/__LOCALID_Y3VK67e/plot.png";
+  assert.equal(safeMarkdownUrl(written, "src", imgNode), written);
+  assert.equal(
+    markdownSandboxImageSrc(written, { threadId: "t-1", projectId: null }),
+    "/api/inference/sandbox/t-1/plot.png",
+  );
+  assert.equal(markdownSandboxImageSrc("data:image/png;base64,AAAA", { threadId: "t-1", projectId: null }), null);
+});
+
+test("the fetch carries the header and gives the object URL back on cleanup", () => {
+  // The route answers on the Authorization header; a bare <img src> gets a 401 and the renderer's
+  // "Image not available" placeholder, which is what this whole file defends.
+  assert.ok(/authFetch\(url,\s*\{ signal: controller\.signal \}\)/.test(HOOK), "authenticated fetch");
+  assert.ok(HOOK.includes("URL.createObjectURL(blob)"), "into an object URL");
+  // Two assertions, because a comment sits between the two statements in the hook's cleanup.
+  assert.ok(HOOK.includes("controller.abort();"), "the in-flight fetch is cancelled");
+  assert.ok(
+    HOOK.includes("if (objectUrl) URL.revokeObjectURL(objectUrl);"),
+    "and an object URL a cancelled fetch had already built is revoked, or those bytes stay pinned " +
+      "for the rest of the session",
+  );
+
+  // ONE hook, not two. `tool-ui-python.tsx` was the only place this fetch existed; duplicating it is
+  // how the markdown path ended up without one in the first place.
+  assert.ok(TOOL_UI.includes("useSandboxImage(pythonToolImagePath(sessionId, filename))"));
+  assert.equal(
+    TOOL_UI.includes("createObjectURL"),
+    false,
+    "the Python card now goes through the shared hook instead of keeping its own copy",
+  );
+});
+
+test("the inline-image set matches what the backend actually serves inline", () => {
+  // Two lists in two languages. The frontend list decides what becomes an <img>; the backend map
+  // decides what the route serves inline at all, and everything else comes back as a download card.
+  const served = BACKEND.slice(
+    BACKEND.indexOf("_SANDBOX_MEDIA_TYPES = {"),
+    BACKEND.indexOf("_SANDBOX_MEDIA_TYPES = {") >= 0
+      ? BACKEND.indexOf("}", BACKEND.indexOf("_SANDBOX_MEDIA_TYPES = {"))
+      : 0,
+  );
+  assert.ok(served.length > 50, "PRECONDITION: the backend map was actually read");
+  for (const ext of SANDBOX_INLINE_IMAGE_EXTS) {
+    assert.ok(
+      served.includes(`"${ext}"`),
+      `${ext} is rendered as an <img> but the route would serve it as application/octet-stream`,
+    );
+  }
+  assert.ok(
+    !served.includes('".svg"'),
+    "SVG stays out on purpose: the filename is model-chosen, so inline SVG would be same-origin " +
+      "script execution",
+  );
+  assert.ok(
+    /X-Content-Type-Options"\s*=\s*"nosniff/.test(BACKEND) ||
+      BACKEND.includes('"X-Content-Type-Options": "nosniff"'),
+    "the pin that makes a raster codec safe to add",
+  );
+});
+
+test("a non-image stays a download card, and a scheme-carrying src is left alone", () => {
+  assert.equal(sandboxFileForSrc("report.csv"), null);
+  assert.equal(sandboxFileForSrc("diagram.svg"), null);
+  assert.equal(sandboxFileForSrc("/assets/logo.png"), null);
+  assert.equal(sandboxFileForSrc("//img.example.com/x.png"), null);
+  // The sid segment and the `?session=` form both go in the bin: the caller re-derives the session.
+  assert.equal(
+    sandboxFileForSrc("/api/inference/sandbox/_/loss%20curve%20%231.png?session=session%2Fid"),
+    "loss curve #1.png",
+  );
+});
+
+test("the img restatement keeps what the wholesale replacement silently dropped", () => {
+  // Registering `img` replaces Streamdown's renderer WHOLESALE, so some of its lines live here by name.
+  // The LOADED/SIZED gating machinery deliberately does NOT: a sandbox image is hidden until the authed
+  // fetch lands and fetch state already drives visibility, so nothing here needs a decode gate. What IS
+  // kept is what carries no machinery -- string checks, because that renderer is minified.
+  assert.ok(
+    MARKDOWN_TEXT.includes('data-streamdown="image"'),
+    "the <img> itself carries the attribute (wrapper and fallback had it; img silently did not)",
+  );
+  assert.ok(
+    MARKDOWN_TEXT.includes("bg-black/10") &&
+      MARKDOWN_TEXT.includes("pointer-events-none absolute inset-0"),
+    "the hover overlay div, dropped entirely by the wholesale replacement",
+  );
+  assert.ok(
+    MARKDOWN_TEXT.includes('.replace(/\\.[^/.]+$/'),
+    'download names: a real extension on the path wins whole; otherwise alt\'s extension is stripped ' +
+      'and one inferred from blob.type is appended -- alt="plot" downloads "plot.png", not "plot"',
+  );
+});

--- a/studio/frontend/tests/markdown-sandbox-image.test.ts
+++ b/studio/frontend/tests/markdown-sandbox-image.test.ts
@@ -10,6 +10,8 @@ import {
   SANDBOX_INLINE_IMAGE_EXTS,
   markdownSandboxImageSrc,
   sandboxFileForSrc,
+  sandboxFilePath,
+  sandboxSessionInSrc,
 } from "../src/components/assistant-ui/sandbox-files.ts";
 import { safeMarkdownUrl } from "../src/lib/safe-markdown-url.ts";
 
@@ -38,6 +40,47 @@ const TOOL_UI = read("../src/components/assistant-ui/tool-ui-python.tsx");
 const BACKEND = read(
   "../../backend/routes/inference.py",
 );
+
+test("decoded separators cannot bypass sandbox traversal checks", () => {
+  const context = { threadId: "current", projectId: null };
+  for (const src of [
+    "%2e%2e%2fother/plot.png",
+    "outputs/%2E%2E%2F%2E%2E%2Fother/plot.png",
+    "%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2foutside/plot.png",
+    "..%5cother/plot.png",
+    "..\\other/plot.png",
+    "/api/inference/sandbox/recorded/%2e%2e%2fother/plot.png",
+  ]) {
+    assert.equal(sandboxFileForSrc(src), null, src);
+    assert.equal(markdownSandboxImageSrc(src, context), null, src);
+  }
+  assert.equal(
+    markdownSandboxImageSrc("outputs/loss%20curve%20%231.png", context),
+    "/api/inference/sandbox/current/outputs/loss%20curve%20%231.png",
+  );
+});
+
+test("recorded session IDs round-trip without a second query decode", () => {
+  for (const session of ["api%2Fclient", "literal%23id", "literal%25id", "a+b", "session/id", "100%", "project-old"]) {
+    const src = sandboxFilePath(session, "plot.png");
+    assert.equal(sandboxSessionInSrc(src), session);
+    assert.equal(
+      markdownSandboxImageSrc(src, { threadId: "new-thread", projectId: "new-project" }),
+      src,
+    );
+  }
+});
+
+test("a fragment cannot override the recorded sandbox session", () => {
+  for (const session of ["original", "api%2Fclient"]) {
+    const src = sandboxFilePath(session, "plot.png");
+    assert.equal(sandboxSessionInSrc(`${src}#?session=other`), session);
+    assert.equal(
+      markdownSandboxImageSrc(`${src}#?session=other`, { threadId: "current", projectId: null }),
+      src,
+    );
+  }
+});
 
 test("a scheme-less sandbox src is rewritten before it reaches the DOM, and rendered from a blob:", () => {
   // PRECONDITION: the renderer still relies on the sanitizer's deny rule rather than repeating it.

--- a/studio/frontend/tests/sandbox-image-lifecycle.test.ts
+++ b/studio/frontend/tests/sandbox-image-lifecycle.test.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { runInNewContext } from "node:vm";
+import ts from "typescript";
+
+type Load = { status: string; url?: string };
+
+function imageHook() {
+  const source = readFileSync(
+    new URL(
+      "../src/components/assistant-ui/use-sandbox-image.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const code = ts.transpileModule(source.replace(/^import .*$/gm, ""), {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const slots: unknown[] = [];
+  const effects: { deps: unknown[]; cleanup?: () => void }[] = [];
+  const pending: (() => void)[] = [];
+  const requests: {
+    signal: AbortSignal;
+    resolve: (response: unknown) => void;
+  }[] = [];
+  const live = new Set<string>();
+  let cursor = 0;
+  let serial = 0;
+  const context = {
+    exports: {} as { useSandboxImage: (url: string | null) => { state: Load } },
+    AbortController,
+    URL: {
+      createObjectURL: () => {
+        const url = `blob:${++serial}`;
+        live.add(url);
+        return url;
+      },
+      revokeObjectURL: (url: string) => {
+        live.delete(url);
+      },
+    },
+    useRef: () => {
+      const i = cursor++;
+      return slots[i] ?? (slots[i] = { current: null });
+    },
+    useState: (initial: unknown) => {
+      const i = cursor++;
+      if (!(i in slots))
+        slots[i] = typeof initial === "function" ? initial() : initial;
+      return [
+        slots[i],
+        (value: unknown) => {
+          slots[i] = value;
+        },
+      ];
+    },
+    useEffect: (fn: () => (() => void) | undefined, deps: unknown[]) => {
+      const i = cursor++;
+      if (
+        !effects[i] ||
+        deps.some((value, j) => value !== effects[i].deps[j])
+      ) {
+        pending.push(() => {
+          effects[i]?.cleanup?.();
+          effects[i] = { deps, cleanup: fn() };
+        });
+      }
+    },
+    authFetch: (_url: string, init: { signal: AbortSignal }) =>
+      new Promise((resolve) => {
+        requests.push({ signal: init.signal, resolve });
+      }),
+  };
+  runInNewContext(code, context);
+  return {
+    live,
+    requests,
+    render(url: string | null) {
+      cursor = 0;
+      return context.exports.useSandboxImage(url).state;
+    },
+    commit() {
+      while (pending.length) pending.shift()!();
+    },
+    unmount() {
+      effects.forEach((effect) => effect.cleanup?.());
+    },
+  };
+}
+
+const flush = async () => {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+};
+const response = { ok: true, blob: async () => ({ type: "image/png" }) };
+
+for (const previous of ["loaded", "failed"] as const) {
+  test(`A to B to A does not reuse a cancelled ${previous} result`, async () => {
+    const hook = imageHook();
+    hook.render("A");
+    hook.commit();
+    hook.requests[0].resolve(previous === "loaded" ? response : { ok: false });
+    await flush();
+    const old = hook.render("A");
+    assert.equal(old.status, previous);
+    assert.equal(hook.render("B").status, "idle");
+    hook.commit();
+    assert.equal(hook.requests[0].signal.aborted, true);
+    assert.equal(hook.live.size, 0);
+    assert.equal(
+      hook.render("A").status,
+      "idle",
+      "a cancelled generation must not render during a fresh retry",
+    );
+    hook.commit();
+    hook.requests[1].resolve({ ok: false });
+    await flush();
+    assert.equal(
+      hook.render("A").status,
+      "idle",
+      "late B must not replace pending A",
+    );
+    hook.requests[2].resolve(response);
+    await flush();
+    const current = hook.render("A");
+    assert.equal(current.status, "loaded");
+    assert.ok(current.url && hook.live.has(current.url));
+    assert.notEqual(current.url, old.url);
+    hook.unmount();
+    assert.equal(hook.live.size, 0);
+  });
+}

--- a/studio/frontend/tests/search-images.test.ts
+++ b/studio/frontend/tests/search-images.test.ts
@@ -27,6 +27,10 @@ import {
   stripSearchImageTokens,
 } from "../src/features/chat/search-images/search-images.ts";
 import { toolArgText } from "../src/components/assistant-ui/tool-arg-text.ts";
+import {
+  markdownSandboxImageSrc,
+  sandboxFileForSrc,
+} from "../src/components/assistant-ui/sandbox-files.ts";
 import { safeMarkdownUrl } from "../src/lib/safe-markdown-url.ts";
 
 const ENTRY = {
@@ -602,6 +606,55 @@ test("thumbnails load from Unsloth's own endpoint, which the img policy allows",
     safeMarkdownUrl("//img.example.com/x.png", "src", imgNode),
     null,
   );
+});
+
+test("an on-disk image survives sanitize as a path, and is rewritten before it reaches the DOM", () => {
+  // The sanitizer's job ends at "carries no scheme, so keep it": what it cannot know is that the
+  // route answers on the Authorization header. So the surviving path must be re-derived per chat --
+  // the model writes whichever sid it happened to be talking to, and a project thread reads the
+  // PROJECT's workspace -- and fetched, not handed to an <img> unchanged.
+  const imgNode = { tagName: "img" } as Parameters<typeof safeMarkdownUrl>[2];
+  const written =
+    "/api/inference/sandbox/__LOCALID_Y3VK67e/outputs/loss%20curve%20%231.png";
+  assert.equal(safeMarkdownUrl(written, "src", imgNode), written);
+
+  // The sid the model wrote is discarded; this chat's scope decides. `project-<id>` else threadId,
+  // exactly as sandboxSessionIdFor resolves it for a tool call's own envelope.
+  assert.equal(
+    markdownSandboxImageSrc(written, { threadId: "t-1", projectId: null }),
+    "/api/inference/sandbox/t-1/outputs/loss%20curve%20%231.png",
+  );
+  assert.equal(
+    markdownSandboxImageSrc(written, { threadId: "t-1", projectId: "p1" }),
+    "/api/inference/sandbox/project-p1/outputs/loss%20curve%20%231.png",
+  );
+  // A bare relative path is the same file: every scheme-carrying src is already gone by now. It
+  // arrives percent-encoded, because in a URL a literal `#` starts a fragment and a raw space ends the
+  // destination -- so the decoded name comes back out encoded again, and the raw form below is not
+  // something markdown delivers here (it would have parsed as a fragment). Both are asserted so the
+  // two behaviours stay distinguishable.
+  assert.equal(
+    sandboxFileForSrc("outputs/loss%20curve%20%231.png"),
+    "outputs/loss curve #1.png",
+  );
+  assert.equal(
+    sandboxFileForSrc("outputs/loss curve #1.png"),
+    null,
+    "a raw `#` is a fragment delimiter, not part of the name",
+  );
+  // What the route serves inline and what it serves as an attachment are different questions, and
+  // only the first is an <img>: a .csv stays a download card rather than becoming a broken image.
+  assert.equal(sandboxFileForSrc("report.csv"), null);
+  assert.equal(sandboxFileForSrc("diagram.svg"), null);
+  assert.equal(
+    sandboxFileForSrc("photo.avif"),
+    "photo.avif",
+    "AVIF is inline on the backend too; the two lists must not drift",
+  );
+  // Somebody else's URL, left exactly as it was.
+  assert.equal(sandboxFileForSrc("/assets/logo.png"), null);
+  assert.equal(sandboxFileForSrc("data:image/png;base64,AAAA"), null);
+  assert.equal(sandboxFileForSrc("//img.example.com/x.png"), null);
 });
 
 test("extractListSubjects stays linear on a bullet padded with whitespace", () => {

--- a/studio/frontend/tests/search-images.test.ts
+++ b/studio/frontend/tests/search-images.test.ts
@@ -610,23 +610,43 @@ test("thumbnails load from Unsloth's own endpoint, which the img policy allows",
 
 test("an on-disk image survives sanitize as a path, and is rewritten before it reaches the DOM", () => {
   // The sanitizer's job ends at "carries no scheme, so keep it": what it cannot know is that the
-  // route answers on the Authorization header. So the surviving path must be re-derived per chat --
-  // the model writes whichever sid it happened to be talking to, and a project thread reads the
-  // PROJECT's workspace -- and fetched, not handed to an <img> unchanged.
+  // route answers on the Authorization header. So the surviving path must be resolved per chat --
+  // the session the src RECORDS wins (the model echoes real workdir paths out of the stdout it saw;
+  // a moved chat's older files still sit in the folder named there, which is what the tool card
+  // above the prose already resolves to) -- and fetched, not handed to an <img> unchanged.
   const imgNode = { tagName: "img" } as Parameters<typeof safeMarkdownUrl>[2];
   const written =
     "/api/inference/sandbox/__LOCALID_Y3VK67e/outputs/loss%20curve%20%231.png";
   assert.equal(safeMarkdownUrl(written, "src", imgNode), written);
 
-  // The sid the model wrote is discarded; this chat's scope decides. `project-<id>` else threadId,
-  // exactly as sandboxSessionIdFor resolves it for a tool call's own envelope.
+  // The recorded session survives a move: p1 is where this chat lives NOW, and the file it wrote
+  // while living under __LOCALID_Y3VK67e is still there -- which is also what the tool card above
+  // this prose resolves from its envelope, so prose and card must never disagree.
   assert.equal(
     markdownSandboxImageSrc(written, { threadId: "t-1", projectId: null }),
-    "/api/inference/sandbox/t-1/outputs/loss%20curve%20%231.png",
+    "/api/inference/sandbox/__LOCALID_Y3VK67e/outputs/loss%20curve%20%231.png",
   );
   assert.equal(
     markdownSandboxImageSrc(written, { threadId: "t-1", projectId: "p1" }),
-    "/api/inference/sandbox/project-p1/outputs/loss%20curve%20%231.png",
+    "/api/inference/sandbox/__LOCALID_Y3VK67e/outputs/loss%20curve%20%231.png",
+  );
+  // A bare path records nothing; only then does this chat's scope decide. `project-<id>` else
+  // threadId, exactly as sandboxSessionIdFor resolves it for a tool call's own envelope.
+  assert.equal(
+    markdownSandboxImageSrc("outputs/plot.png", { threadId: "t-1", projectId: "p1" }),
+    "/api/inference/sandbox/project-p1/outputs/plot.png",
+  );
+  assert.equal(
+    markdownSandboxImageSrc("outputs/plot.png", { threadId: "t-1", projectId: null }),
+    "/api/inference/sandbox/t-1/outputs/plot.png",
+  );
+  // The not-path-safe form records in the query instead of a path segment, and round-trips the same.
+  assert.equal(
+    markdownSandboxImageSrc("/api/inference/sandbox/_/plot.png?session=session%2Fid", {
+      threadId: "t-1",
+      projectId: null,
+    }),
+    "/api/inference/sandbox/_/plot.png?session=session%2Fid",
   );
   // A bare relative path is the same file: every scheme-carrying src is already gone by now. It
   // arrives percent-encoded, because in a URL a literal `#` starts a fragment and a raw space ends the
@@ -651,6 +671,12 @@ test("an on-disk image survives sanitize as a path, and is rewritten before it r
     "photo.avif",
     "AVIF is inline on the backend too; the two lists must not drift",
   );
+  // A `..` -- raw or `%2e%2e`-encoded -- pops the scope segment prepended above: one dot reads
+  // another chat's folder, two land on another route. It stays raw and fails honestly instead.
+  assert.equal(sandboxFileForSrc("../project-other/plot.png"), null);
+  assert.equal(sandboxFileForSrc("outputs/%2e%2e/other/plot.png"), null);
+  // A single `.` is noise URL parsing drops anyway; it changes nothing about which file this is.
+  assert.equal(sandboxFileForSrc("./plot.png"), "plot.png");
   // Somebody else's URL, left exactly as it was.
   assert.equal(sandboxFileForSrc("/assets/logo.png"), null);
   assert.equal(sandboxFileForSrc("data:image/png;base64,AAAA"), null);

--- a/tests/studio/test_tauri_python_tool_images.py
+++ b/tests/studio/test_tauri_python_tool_images.py
@@ -9,21 +9,27 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 PYTHON_TOOL_UI = REPO / "studio/frontend/src/components/assistant-ui/tool-ui-python.tsx"
+SANDBOX_IMAGE_HOOK = REPO / "studio/frontend/src/components/assistant-ui/use-sandbox-image.ts"
 TAURI_CONFIG = REPO / "studio/src-tauri/tauri.conf.json"
 PLAYWRIGHT_TEST = REPO / "tests/studio/playwright_tauri_python_tool_images.py"
 
 
 def test_python_tool_images_use_authenticated_blob_urls() -> None:
+    # The card now delegates the authed fetch to the shared hook markdown images also use, so the
+    # machinery pins read the hook and the card itself is pinned to exactly one thing: the delegation.
     source = PYTHON_TOOL_UI.read_text(encoding = "utf-8")
+    hook = SANDBOX_IMAGE_HOOK.read_text(encoding = "utf-8")
 
-    assert 'import { authFetch } from "@/features/auth";' in source
-    assert "authFetch(" in source
-    assert "pythonToolImagePath(sessionId, filename)" in source
-    assert "new AbortController()" in source
-    assert "new IntersectionObserver(" in source
-    assert "URL.createObjectURL(blob)" in source
-    assert "URL.revokeObjectURL(objectUrl)" in source
-    assert "controller.abort()" in source
+    assert "useSandboxImage(pythonToolImagePath(sessionId, filename))" in source
+    assert 'import { authFetch } from "@/features/auth";' in hook
+    assert "authFetch(url, { signal: controller.signal })" in hook
+    assert "new AbortController()" in hook
+    assert "new IntersectionObserver(" in hook
+    assert "URL.createObjectURL(blob)" in hook
+    assert "URL.revokeObjectURL(objectUrl)" in hook
+    assert "controller.abort()" in hook
+    # One hook, not two copies: the card must not re-inline the fetch it delegates.
+    assert "createObjectURL" not in source
     assert "apiUrl(`/api/inference/sandbox/" not in source
 
 


### PR DESCRIPTION
## TL;DR

A model writes `![plot](/api/inference/sandbox/<sid>/plot.png)` into its answer. The src carries no scheme, so sanitize **keeps** it — but keeping it was never the same as being able to fetch it: the route answers on the `Authorization` header (`_authenticate_header_or_query`), a bare `<img src>` 401s, and the answer renders "Image not available". Only tool cards had an authed fetch; markdown was the one path left.

## Scope after rebase (supersedes #10281)

#10281 was closed unmerged because its data-URI half landed on its own as #10269 (`a2a4143`). This branch is that PR rebased `--onto` current `main` with the merged commit dropped, so it now carries **only** the sandbox-image work: 9 files, +526/−81. No new commits were authored during the rebase; it applied clean.

## Fix

The src is re-derived from **this chat's** scope and fetched with auth into an object URL before it reaches the DOM:

- `sandboxFileForSrc` rewrites only scheme-less paths (sanitize dropped every scheme-carrying src already) and **discards the sid segment the model happened to write**; `markdownSandboxImageSrc` rebuilds it via `sandboxSessionIdFor` — `project-${projectId}` for project threads, else this thread's `remoteId`.
- One hook, `useSandboxImage`, does `authFetch` → `createObjectURL` for markdown **and** the Python card, which had its own copy; abort + `revokeObjectURL` on cleanup, keyed by url so a stale response can never write state for an old file.
- Registering `img` replaces Streamdown's default renderer WHOLESALE (its Components map is keyed by tag), so everything that renderer did is restated: wrapper, hidden-when-failed, fallback text, hover download. `downloadName` follows it exactly: a real extension on the path wins whole; otherwise any extension in alt is stripped and one inferred from the blob's type is appended (`alt="plot"` downloads `plot.png`).

## Why the scheme-less src survives sanitize (fact, read off the installed packages)

`hast-util-sanitize`'s `safeProtocol` returns true when the first `:` precedes no `/`-precedes-no-colon case — i.e. when `colon < 0 || colon > slash`, a scheme-less path is never protocol-checked. The bug was never sanitize; it was the missing auth header.

## The two extension lists agree, in two languages

`SANDBOX_INLINE_IMAGE_EXTS` mirrors `_SANDBOX_MEDIA_TYPES` (frontend test reads `inference.py` as text and pins it): `.avif` joins it (a raster codec; `nosniff` pins the type either way), `.svg` stays OUT on purpose — the filename is model-chosen, so inline SVG would be same-origin script execution; non-image extensions stay download cards.

## What was deliberately NOT ported

The replaced renderer's gating machinery (decoded state, mount-time `complete` check, `onLoad`/`onError` forwarding, loaded||sized gates): a sandbox image is hidden until the authed fetch lands and fetch state already drives visibility, so nothing here needs a decode gate. What WAS kept — string-level lines with no machinery, pinned by name in tests: `data-streamdown="image"`, the hover overlay div, the download-name regex.

## Verification / Tests

- `tsc -b` and `tsc -p tsconfig.test.json`: 0 errors (exit 0, no output). Frontend suite on the rebased branch: **6881 pass / 0 fail**. `tests/studio/test_tauri_python_tool_images.py`: 3 passed. The sandbox-roots backend suite shows pre-existing home-directory failures in this Windows sandbox — byte-identical counts (28F/241P/3S) on untouched `origin/main` in a throwaway worktree, so they are environmental and not introduced here.
- Pinned by tests: rewrite-before-DOM and authed-fetch/revoke (`markdown-sandbox-image.test.ts`); `%23` round-trips while a raw `#` is a fragment delimiter → null; project scope beats threadId (`search-images.test.ts`).

## Follow-up (not blocking)

Upstream, this is one line: Streamdown shipping its own `img` swap point. If that lands, the wholesale restatement shrinks back to just the resolve-and-fetch step.
