### PR TITLE
Docker: retry the deadsnakes PPA add so a Launchpad 504 does not fail the build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update && apt-get install -y --no-install-recommends \
         software-properties-common ca-certificates curl git build-essential \
         ninja-build cmake pkg-config \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && for i in 1 2 3 4 5; do add-apt-repository -y ppa:deadsnakes/ppa && break; \
+         [ "$i" = 5 ] && exit 1; echo "add-apt-repository failed (attempt $i), retrying in 30s"; sleep 30; done \
     && apt-get update && apt-get install -y --no-install-recommends \
         python${PYTHON_VERSION} python${PYTHON_VERSION}-venv python${PYTHON_VERSION}-dev \
     && ln -sf /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python \
@@ -431,7 +432,8 @@ RUN CUDA_PKG="$(echo "${CUDA_VERSION}" | awk -F. '{print $1"-"$2}')" \
         software-properties-common ca-certificates curl wget git libgomp1 \
         gcc g++ zstd ffmpeg ninja-build \
         "cuda-nvcc-${CUDA_PKG}" "cuda-cudart-dev-${CUDA_PKG}" \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && for i in 1 2 3 4 5; do add-apt-repository -y ppa:deadsnakes/ppa && break; \
+         [ "$i" = 5 ] && exit 1; echo "add-apt-repository failed (attempt $i), retrying in 30s"; sleep 30; done \
     && apt-get update && apt-get install -y --no-install-recommends \
         python${PYTHON_VERSION} python${PYTHON_VERSION}-venv python${PYTHON_VERSION}-dev \
     && ln -sf /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python \

--- a/tests/python/test_docker_ppa_retry.py
+++ b/tests/python/test_docker_ppa_retry.py
@@ -23,7 +23,9 @@ DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
 def _retry_loops() -> list[str]:
     text = DOCKERFILE.read_text(encoding = "utf-8")
     joined = re.sub(r"\\\n\s*", " ", text)  # backslash continuations into one line
-    loops = re.findall(r"for i in [^;]*; do add-apt-repository -y ppa:deadsnakes/ppa .*?; done", joined)
+    loops = re.findall(
+        r"for i in [^;]*; do add-apt-repository -y ppa:deadsnakes/ppa .*?; done", joined
+    )
     return loops
 
 
@@ -33,7 +35,9 @@ def test_both_apt_stages_retry_the_ppa_add():
     assert len(_retry_loops()) == 2, "an add-apt-repository call lost its retry loop"
 
 
-def _run_loop(loop: str, tmp_path: Path, *, failures: int) -> tuple[subprocess.CompletedProcess, int]:
+def _run_loop(
+    loop: str, tmp_path: Path, *, failures: int
+) -> tuple[subprocess.CompletedProcess, int]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     counter = tmp_path / "calls"

--- a/tests/python/test_docker_ppa_retry.py
+++ b/tests/python/test_docker_ppa_retry.py
@@ -1,11 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-Present the Unsloth team. See /studio/LICENSE.AGPL-3.0
 
-"""Launchpad answers `add-apt-repository ppa:deadsnakes/ppa` with a 504 now and then,
-and every push to main builds the image, so a short outage turned into a red publish
-twice in one day. Both apt stages retry the call; the loop is cut out of the
-Dockerfile and run with a stubbed add-apt-repository.
-"""
+"""Both apt stages must retry `add-apt-repository ppa:deadsnakes/ppa`, since Launchpad
+intermittently 504s and every push to main builds the image."""
 
 from __future__ import annotations
 
@@ -22,7 +19,7 @@ DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
 
 def _retry_loops() -> list[str]:
     text = DOCKERFILE.read_text(encoding = "utf-8")
-    joined = re.sub(r"\\\n\s*", " ", text)  # backslash continuations into one line
+    joined = re.sub(r"\\\n\s*", " ", text)
     loops = re.findall(
         r"for i in [^;]*; do add-apt-repository -y ppa:deadsnakes/ppa .*?; done", joined
     )

--- a/tests/python/test_docker_ppa_retry.py
+++ b/tests/python/test_docker_ppa_retry.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-Present the Unsloth team. See /studio/LICENSE.AGPL-3.0
+
+"""Launchpad answers `add-apt-repository ppa:deadsnakes/ppa` with a 504 now and then,
+and every push to main builds the image, so a short outage turned into a red publish
+twice in one day. Both apt stages retry the call; the loop is cut out of the
+Dockerfile and run with a stubbed add-apt-repository.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
+
+
+def _retry_loops() -> list[str]:
+    text = DOCKERFILE.read_text(encoding = "utf-8")
+    joined = re.sub(r"\\\n\s*", " ", text)  # backslash continuations into one line
+    loops = re.findall(r"for i in [^;]*; do add-apt-repository -y ppa:deadsnakes/ppa .*?; done", joined)
+    return loops
+
+
+def test_both_apt_stages_retry_the_ppa_add():
+    text = DOCKERFILE.read_text(encoding = "utf-8")
+    assert text.count("add-apt-repository -y ppa:deadsnakes/ppa") == 2
+    assert len(_retry_loops()) == 2, "an add-apt-repository call lost its retry loop"
+
+
+def _run_loop(loop: str, tmp_path: Path, *, failures: int) -> tuple[subprocess.CompletedProcess, int]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    counter = tmp_path / "calls"
+    counter.write_text("0", encoding = "utf-8")
+    (bin_dir / "add-apt-repository").write_text(
+        "#!/usr/bin/env bash\n"
+        f"n=$(cat {counter}); n=$((n + 1)); echo $n > {counter}\n"
+        f"[ $n -gt {failures} ] || {{ echo '504 Gateway Time-out' >&2; exit 1; }}\n",
+        encoding = "utf-8",
+    )
+    (bin_dir / "add-apt-repository").chmod(0o755)
+    (bin_dir / "sleep").write_text("#!/usr/bin/env bash\nexit 0\n", encoding = "utf-8")
+    (bin_dir / "sleep").chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
+    res = subprocess.run(["sh", "-c", loop], capture_output = True, text = True, env = env, timeout = 60)
+    return res, int(counter.read_text(encoding = "utf-8"))
+
+
+@pytest.mark.parametrize("loop", _retry_loops(), ids = ["builder", "runtime"])
+def test_two_outages_are_absorbed(loop: str, tmp_path: Path):
+    res, calls = _run_loop(loop, tmp_path, failures = 2)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert calls == 3
+    assert res.stdout.count("retrying") == 2
+
+
+@pytest.mark.parametrize("loop", _retry_loops(), ids = ["builder", "runtime"])
+def test_a_lasting_outage_still_fails_the_build(loop: str, tmp_path: Path):
+    res, calls = _run_loop(loop, tmp_path, failures = 99)
+    assert res.returncode != 0
+    assert calls == 5


### PR DESCRIPTION
## Summary

Two publish runs today failed for the same reason that had nothing to do with the commit being built: `add-apt-repository -y ppa:deadsnakes/ppa` fetches the PPA signing key from Launchpad, and Launchpad answered

```
504 Gateway Time-out
```

Runs 33949273666 (amd64) and 33992510536 (arm64). Every push to `main` builds the image, so each short outage becomes a red publish and a missing `sha-` tag for that commit.

## The change

Both apt stages of `docker/Dockerfile` (builder and runtime) wrap the call:

```sh
for i in 1 2 3 4 5; do add-apt-repository -y ppa:deadsnakes/ppa && break; \
     [ "$i" = 5 ] && exit 1; echo "add-apt-repository failed (attempt $i), retrying in 30s"; sleep 30; done
```

Five attempts, thirty seconds apart, then the build fails as before. Nothing else in the layer changes.

## Verification

- The builder stage's RUN block, cut into a throwaway Dockerfile on the real `nvidia/cuda` base, builds with the loop in place (python3.12 from the PPA installed).
- `docker buildx build --check` reports no warnings.
- `tests/python/test_docker_ppa_retry.py` cuts both loops out of the Dockerfile and runs them under `sh` with a stubbed `add-apt-repository`: two failures are absorbed with two retry lines printed, a lasting outage stops after the fifth call with a non-zero exit, and both stages still carry the loop.
