### PR TITLE
Docker publish: keep the tag list to core, latest, studio, releases and dated nightly pins

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,11 +76,17 @@ jobs:
     permissions:
       contents: read
     outputs:
+      # the nightly pin's date; computed once so a rerun of failed jobs keeps it
+      pin_date: ${{ steps.pin.outputs.date }}
       llama_tag: ${{ steps.llama.outputs.tag }}
       unsloth_ref: ${{ steps.unsloth_ref.outputs.ref }}
       zoo_ref: ${{ steps.zoo_ref.outputs.ref }}
       notebooks_commit: ${{ steps.notebooks.outputs.commit }}
     steps:
+      - name: Date of this run, for the nightly pins
+        id: pin
+        run: echo "date=$(date -u +%Y.%m.%d)" >> "$GITHUB_OUTPUT"
+
       - name: Resolve llama.cpp prebuilt tag
         id: llama
         env:
@@ -269,7 +275,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [prepare, build]
     timeout-minutes: 15
     permissions:
       contents: read
@@ -304,15 +310,28 @@ jobs:
             type=raw,value=core,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '' }}
             type=ref,event=tag,prefix=core-
             # one immutable pin per daily rebuild; pruned after 60 days by cleanup
-            type=schedule,pattern=core-nightly-{{date 'YYYY.MM.DD'}}
+            type=schedule,pattern=core-nightly-${{ needs.prepare.outputs.pin_date }}
             # this run's handle for the digest handoff below; cleanup removes it
             type=raw,value=core-build-${{ github.run_id }}
 
       - name: Create multi-arch manifest
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create \
-              $(jq -cr '.tags | map("-t " + .) | join(" ")' <<<"$DOCKER_METADATA_OUTPUT_JSON") \
+          # A dated pin is immutable: a rerun on the same day, or a late rerun of an
+          # older scheduled run, must not replace one that already exists.
+          TAGS=""
+          for t in $(jq -r '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON"); do
+            name="${t##*:}"
+            case "$name" in
+              nightly-[0-9]*|core-nightly-[0-9]*)
+                if [ "$(curl -sS -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/${name}")" = "200" ]; then
+                  echo "::notice::${t} already exists and stays as it is"
+                  continue
+                fi ;;
+            esac
+            TAGS="${TAGS} -t ${t}"
+          done
+          docker buildx imagetools create ${TAGS} \
               $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect the result
@@ -438,7 +457,7 @@ jobs:
 
   merge-studio:
     runs-on: ubuntu-latest
-    needs: build-studio
+    needs: [prepare, build-studio]
     timeout-minutes: 15
     permissions:
       contents: read
@@ -472,14 +491,27 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '' }}
             type=raw,value=studio,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '' }}
             type=ref,event=tag
-            type=schedule,pattern=nightly-{{date 'YYYY.MM.DD'}}
+            type=schedule,pattern=nightly-${{ needs.prepare.outputs.pin_date }}
             type=raw,value=build-${{ github.run_id }}
 
       - name: Create multi-arch manifest
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create \
-              $(jq -cr '.tags | map("-t " + .) | join(" ")' <<<"$DOCKER_METADATA_OUTPUT_JSON") \
+          # A dated pin is immutable: a rerun on the same day, or a late rerun of an
+          # older scheduled run, must not replace one that already exists.
+          TAGS=""
+          for t in $(jq -r '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON"); do
+            name="${t##*:}"
+            case "$name" in
+              nightly-[0-9]*|core-nightly-[0-9]*)
+                if [ "$(curl -sS -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/${name}")" = "200" ]; then
+                  echo "::notice::${t} already exists and stays as it is"
+                  continue
+                fi ;;
+            esac
+            TAGS="${TAGS} -t ${t}"
+          done
+          docker buildx imagetools create ${TAGS} \
               $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect the result
@@ -619,11 +651,13 @@ jobs:
   # the release tags and one dated nightly pin per image. This removes the handles
   # (namespace-scoped route: the legacy /v2/repositories path rejects the
   # organization token) and, on the daily rebuild, prunes nightly pins older than
-  # 60 days. A dispatch with overridden inputs publishes nothing durable by design,
-  # so it keeps its handles for whoever dispatched it to pull and delete.
+  # 60 days. A dispatch with an overridden input publishes nothing durable by
+  # design (the stable-tag gates above are off), so that one keeps its handles for
+  # whoever dispatched it to pull and delete; a dispatch with the defaults on the
+  # default branch published :core/:latest/:studio and is cleaned like a push.
   cleanup:
     needs: [merge, merge-studio, hub-readme, smoke-test]
-    if: ${{ always() && github.event_name != 'workflow_dispatch' }}
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -656,10 +690,21 @@ jobs:
           drop "build-${{ github.run_id }}"
           if [ "${{ github.event_name }}" = "schedule" ]; then
             cutoff="$(date -u -d "-${NIGHTLY_KEEP_DAYS} days" +%Y.%m.%d)"
-            for name in $(curl -sS "${HUB}/tags?page_size=100" -H "Authorization: Bearer ${TOKEN}" \
-                          | python3 -c 'import json,sys,re; print("\n".join(t["name"] for t in json.load(sys.stdin).get("results", []) if re.fullmatch(r"(core-)?nightly-\d{4}\.\d{2}\.\d{2}", t["name"])))'); do
-              stamp="${name##*nightly-}"
-              if [ "$stamp" \< "$cutoff" ]; then drop "$name"; fi
+            # every page: the listing is newest first, so the expired pins are exactly
+            # the ones a first-page-only read would never see
+            url="${HUB}/tags?page_size=100"
+            names=""
+            while [ -n "$url" ]; do
+              page="$(curl -sS "$url" -H "Authorization: Bearer ${TOKEN}")"
+              names="${names} $(jq -r '.results[]?.name' <<<"$page")"
+              url="$(jq -r '.next // empty' <<<"$page")"
+            done
+            for name in $names; do
+              case "$name" in
+                nightly-[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]|core-nightly-[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9])
+                  stamp="${name##*nightly-}"
+                  if [ "$stamp" \< "$cutoff" ]; then drop "$name"; fi ;;
+              esac
             done
           fi
           test "$failed" = 0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,12 +56,9 @@ env:
 # at all. The accepted cost is that two main commits can race to retag :core/:latest,
 # which is self-correcting on the next push, where a cancelled run leaves that commit
 # with no image at all. Each published image is still internally coherent: the digest
-# handoff and the smoke test resolve a :core-sha-/:sha- tag rather than tags[0], and
-# then verify that the manifest behind it holds the arches THIS run pushed. That last
-# step is the load-bearing one, because the sha tag is only immutable across COMMITS:
-# a branch push and a lightweight v* tag push at one commit produce the same short
-# sha, and the concurrency group is keyed on the ref, so those two runs never wait for
-# each other and both write that name.
+# handoff and the smoke test resolve this run's own :core-build-<run_id>/:build-<run_id>
+# tag rather than tags[0], and then verify that the manifest behind it holds the arches
+# THIS run pushed. Those tags are unique per run and removed by the cleanup job.
 # tests/studio/test_main_runs_survive_merge_bursts.py enforces this shape.
 concurrency:
   group: docker-publish-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
@@ -306,8 +303,10 @@ jobs:
             # dispatch, else a feature ref overwrites :core with non-main bits
             type=raw,value=core,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '' }}
             type=ref,event=tag,prefix=core-
-            type=schedule,pattern=core-nightly
-            type=sha,prefix=core-sha-,format=short
+            # one immutable pin per daily rebuild; pruned after 60 days by cleanup
+            type=schedule,pattern=core-nightly-{{date 'YYYY.MM.DD'}}
+            # this run's handle for the digest handoff below; cleanup removes it
+            type=raw,value=core-build-${{ github.run_id }}
 
       - name: Create multi-arch manifest
         working-directory: /tmp/digests
@@ -327,19 +326,14 @@ jobs:
         id: manifest_digest
         working-directory: /tmp/digests
         run: |
-          # NOT tags[0]: metadata-action sorts by priority (raw=200 above sha=100), so
-          # on a main push that is the mutable :core, which an unserialised second run
-          # can retag between the manifest creation and this inspection.
-          TAG="$(jq -r '([.tags[] | select(contains(":core-sha-"))] | first) // .tags[0]' <<<"$DOCKER_METADATA_OUTPUT_JSON")"
+          # NOT tags[0]: on a main push that is the mutable :core, which an
+          # unserialised second run can retag between the manifest creation and this
+          # inspection. :core-build-<run_id> is this run's own name.
+          TAG="$(jq -r '([.tags[] | select(contains(":core-build-"))] | first) // .tags[0]' <<<"$DOCKER_METADATA_OUTPUT_JSON")"
           DIGEST="$(docker buildx imagetools inspect "$TAG" --format '{{json .Manifest.Digest}}' | tr -d '"')"
           test -n "$DIGEST"
-          # :core-sha- is immutable across COMMITS, which is the only case the tag
-          # choice above defends against. It is NOT unique across REFS: a branch push
-          # and a lightweight v* tag push at the same commit produce the same short
-          # sha, and the concurrency group is keyed on the ref, so the two runs are
-          # never serialised against each other and both write this name. Confirm the
-          # manifest we are about to hand to build-studio really is the one this run
-          # pushed, because baking another run's base image is silent otherwise.
+          # Still confirm the manifest we hand to build-studio holds what this run
+          # pushed: baking another run's base image would be silent otherwise.
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
           CHILDREN="$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]?.digest')"
           # A build leg does not push a bare image manifest: with provenance and SBOM
@@ -478,8 +472,8 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '' }}
             type=raw,value=studio,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '' }}
             type=ref,event=tag
-            type=schedule,pattern=nightly
-            type=sha,prefix=sha-,format=short
+            type=schedule,pattern=nightly-{{date 'YYYY.MM.DD'}}
+            type=raw,value=build-${{ github.run_id }}
 
       - name: Create multi-arch manifest
         working-directory: /tmp/digests
@@ -499,10 +493,10 @@ jobs:
         id: studio_manifest_digest
         working-directory: /tmp/digests
         run: |
-          # Same reasoning as the base merge: :sha- is shared by every ref sitting on
-          # this commit, so resolve it once here and hand the smoke test an immutable
-          # digest rather than a name another run can retag under it.
-          TAG="$(jq -r '([.tags[] | select(contains(":sha-"))] | first) // .tags[0]' <<<"$DOCKER_METADATA_OUTPUT_JSON")"
+          # Same reasoning as the base merge: resolve this run's own :build-<run_id>
+          # once and hand the smoke test an immutable digest rather than a name
+          # another run can retag under it.
+          TAG="$(jq -r '([.tags[] | select(contains(":build-"))] | first) // .tags[0]' <<<"$DOCKER_METADATA_OUTPUT_JSON")"
           DIGEST="$(docker buildx imagetools inspect "$TAG" --format '{{json .Manifest.Digest}}' | tr -d '"')"
           test -n "$DIGEST"
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
@@ -592,11 +586,9 @@ jobs:
       # with the merge jobs' gates.
       - name: Pull and smoke-test the base image
         run: |
-          # By digest, not by name. Every ref sitting on this commit publishes the
-          # same :core-sha- tag, and those runs are in different concurrency groups,
-          # so a name resolved here can be another run's image. merge already had to
-          # resolve this digest to hand build-studio a base, and it verified that the
-          # manifest is the one it pushed.
+          # By digest, not by name: the :core-build-<run_id> tag is gone once cleanup
+          # ran, and merge already verified that the manifest behind this digest is
+          # the one it pushed.
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.merge.outputs.digest }}"
           echo "smoke-testing $REF"
           docker pull "$REF"
@@ -621,3 +613,53 @@ jobs:
           [ "$ok_studio"  = 1 ] || { echo "Studio /api/health never went healthy"; exit 1; }
           [ "$ok_jupyter" = 1 ] || { echo "Jupyter /login never responded"; exit 1; }
           echo "Studio + Jupyter healthy"
+
+  # The :build-<run_id> / :core-build-<run_id> handles exist only for the digest
+  # handoff and verification above; the published names are :core, :latest, :studio,
+  # the release tags and one dated nightly pin per image. This removes the handles
+  # (namespace-scoped route: the legacy /v2/repositories path rejects the
+  # organization token) and, on the daily rebuild, prunes nightly pins older than
+  # 60 days. A dispatch with overridden inputs publishes nothing durable by design,
+  # so it keeps its handles for whoever dispatched it to pull and delete.
+  cleanup:
+    needs: [merge, merge-studio, hub-readme, smoke-test]
+    if: ${{ always() && github.event_name != 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Remove this run's handle tags, prune old nightly pins
+        env:
+          NIGHTLY_KEEP_DAYS: "60"
+        run: |
+          HUB="https://hub.docker.com/v2/namespaces/${IMAGE_NAME%%/*}/repositories/${IMAGE_NAME#*/}"
+          TOKEN="$(curl -sS -X POST https://hub.docker.com/v2/auth/token \
+            -H 'Content-Type: application/json' \
+            -d "{\"identifier\": \"${{ env.REGISTRY_USERNAME }}\", \"secret\": \"${{ secrets.DOCKER_API_KEY }}\"}" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))')"
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Could not exchange DOCKER_API_KEY for a Hub API token; handle tags of run ${{ github.run_id }} were not removed."
+            exit 1
+          fi
+          failed=0
+          drop() {
+            # 204 removed, 404 never existed (a failed merge); anything else is a
+            # leftover that would show on the tag list
+            code="$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE "${HUB}/tags/$1" -H "Authorization: Bearer ${TOKEN}")"
+            case "$code" in
+              204|404) echo "removed ${IMAGE_NAME}:$1 (HTTP ${code})" ;;
+              *) echo "::error::${IMAGE_NAME}:$1 not removed (HTTP ${code})"; failed=1 ;;
+            esac
+          }
+          drop "core-build-${{ github.run_id }}"
+          drop "build-${{ github.run_id }}"
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            cutoff="$(date -u -d "-${NIGHTLY_KEEP_DAYS} days" +%Y.%m.%d)"
+            for name in $(curl -sS "${HUB}/tags?page_size=100" -H "Authorization: Bearer ${TOKEN}" \
+                          | python3 -c 'import json,sys,re; print("\n".join(t["name"] for t in json.load(sys.stdin).get("results", []) if re.fullmatch(r"(core-)?nightly-\d{4}\.\d{2}\.\d{2}", t["name"])))'); do
+              stamp="${name##*nightly-}"
+              if [ "$stamp" \< "$cutoff" ]; then drop "$name"; fi
+            done
+          fi
+          test "$failed" = 0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,6 +75,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      actions: read
     outputs:
       # the nightly pin's date; computed once so a rerun of failed jobs keeps it
       pin_date: ${{ steps.pin.outputs.date }}
@@ -85,7 +86,20 @@ jobs:
     steps:
       - name: Date of this run, for the nightly pins
         id: pin
-        run: echo "date=$(date -u +%Y.%m.%d)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The run's creation time, not the clock: created_at is fixed at the first
+          # attempt (run_started_at resets), so a rerun of an older scheduled run on
+          # a later day keeps its own date instead of claiming that day's pin with
+          # an older commit and racing the real daily run for it.
+          created="$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .created_at || true)"
+          case "$created" in
+            [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T*) ;;
+            *) echo "::error::Could not read this run's creation time (got '${created}')"; exit 1 ;;
+          esac
+          day="${created%%T*}"
+          echo "date=${day//-/.}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve llama.cpp prebuilt tag
         id: llama
@@ -324,10 +338,18 @@ jobs:
             name="${t##*:}"
             case "$name" in
               nightly-[0-9]*|core-nightly-[0-9]*)
-                if [ "$(curl -sS -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/${name}")" = "200" ]; then
-                  echo "::notice::${t} already exists and stays as it is"
-                  continue
-                fi ;;
+                # Only a 404 frees the name. A transport error (000), 429 or 5xx is
+                # retried, then stops the merge: it must not become an overwrite.
+                for i in 1 2 3 4 5; do
+                  code="$(curl -sS -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/${name}" || true)"
+                  case "$code" in 200|404) break ;; esac
+                  echo "probe of ${t} returned HTTP ${code} (attempt $i)"; sleep 15
+                done
+                case "$code" in
+                  200) echo "::notice::${t} already exists and stays as it is"; continue ;;
+                  404) ;;
+                  *) echo "::error::Cannot tell whether ${t} exists (HTTP ${code}); not risking an overwrite"; exit 1 ;;
+                esac ;;
             esac
             TAGS="${TAGS} -t ${t}"
           done
@@ -504,10 +526,18 @@ jobs:
             name="${t##*:}"
             case "$name" in
               nightly-[0-9]*|core-nightly-[0-9]*)
-                if [ "$(curl -sS -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/${name}")" = "200" ]; then
-                  echo "::notice::${t} already exists and stays as it is"
-                  continue
-                fi ;;
+                # Only a 404 frees the name. A transport error (000), 429 or 5xx is
+                # retried, then stops the merge: it must not become an overwrite.
+                for i in 1 2 3 4 5; do
+                  code="$(curl -sS -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/${name}" || true)"
+                  case "$code" in 200|404) break ;; esac
+                  echo "probe of ${t} returned HTTP ${code} (attempt $i)"; sleep 15
+                done
+                case "$code" in
+                  200) echo "::notice::${t} already exists and stays as it is"; continue ;;
+                  404) ;;
+                  *) echo "::error::Cannot tell whether ${t} exists (HTTP ${code}); not risking an overwrite"; exit 1 ;;
+                esac ;;
             esac
             TAGS="${TAGS} -t ${t}"
           done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,9 +56,7 @@ env:
 # at all. The accepted cost is that two main commits can race to retag :core/:latest,
 # which is self-correcting on the next push, where a cancelled run leaves that commit
 # with no image at all. Each published image is still internally coherent: the digest
-# handoff and the smoke test resolve this run's own :core-build-<run_id>/:build-<run_id>
-# tag rather than tags[0], and then verify that the manifest behind it holds the arches
-# THIS run pushed. Those tags are unique per run and removed by the cleanup job.
+# handoff and the smoke test resolve this run's own tag, not tags[0], and verify it.
 # tests/studio/test_main_runs_survive_merge_bursts.py enforces this shape.
 concurrency:
   group: docker-publish-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
@@ -77,7 +75,7 @@ jobs:
       contents: read
       actions: read
     outputs:
-      # the nightly pin's date; computed once so a rerun of failed jobs keeps it
+      # computed once, so a rerun of failed jobs keeps the same date
       pin_date: ${{ steps.pin.outputs.date }}
       llama_tag: ${{ steps.llama.outputs.tag }}
       unsloth_ref: ${{ steps.unsloth_ref.outputs.ref }}
@@ -89,10 +87,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # The run's creation time, not the clock: created_at is fixed at the first
-          # attempt (run_started_at resets), so a rerun of an older scheduled run on
-          # a later day keeps its own date instead of claiming that day's pin with
-          # an older commit and racing the real daily run for it.
+          # created_at is fixed at the first attempt: a late rerun cannot claim today's pin.
           created="$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" --jq .created_at || true)"
           case "$created" in
             [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T*) ;;
@@ -323,23 +318,19 @@ jobs:
             # dispatch, else a feature ref overwrites :core with non-main bits
             type=raw,value=core,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '' }}
             type=ref,event=tag,prefix=core-
-            # one immutable pin per daily rebuild; pruned after 60 days by cleanup
             type=schedule,pattern=core-nightly-${{ needs.prepare.outputs.pin_date }}
-            # this run's handle for the digest handoff below; cleanup removes it
             type=raw,value=core-build-${{ github.run_id }}
 
       - name: Create multi-arch manifest
         working-directory: /tmp/digests
         run: |
-          # A dated pin is immutable: a rerun on the same day, or a late rerun of an
-          # older scheduled run, must not replace one that already exists.
+          # A dated pin is immutable: a rerun must not replace an existing one.
           TAGS=""
           for t in $(jq -r '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON"); do
             name="${t##*:}"
             case "$name" in
               nightly-[0-9]*|core-nightly-[0-9]*)
-                # Only a 404 frees the name. A transport error (000), 429 or 5xx is
-                # retried, then stops the merge: it must not become an overwrite.
+                # Only 404 frees the name; 000/429/5xx must not become an overwrite.
                 for i in 1 2 3 4 5; do
                   code="$(curl -sS -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/${name}" || true)"
                   case "$code" in 200|404) break ;; esac
@@ -367,14 +358,11 @@ jobs:
         id: manifest_digest
         working-directory: /tmp/digests
         run: |
-          # NOT tags[0]: on a main push that is the mutable :core, which an
-          # unserialised second run can retag between the manifest creation and this
-          # inspection. :core-build-<run_id> is this run's own name.
+          # NOT tags[0]: on a main push that is the mutable :core, retagged by racing runs.
           TAG="$(jq -r '([.tags[] | select(contains(":core-build-"))] | first) // .tags[0]' <<<"$DOCKER_METADATA_OUTPUT_JSON")"
           DIGEST="$(docker buildx imagetools inspect "$TAG" --format '{{json .Manifest.Digest}}' | tr -d '"')"
           test -n "$DIGEST"
-          # Still confirm the manifest we hand to build-studio holds what this run
-          # pushed: baking another run's base image would be silent otherwise.
+          # Confirm it holds what this run pushed: baking another run's base is silent.
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
           CHILDREN="$(docker buildx imagetools inspect --raw "$REF" | jq -r '.manifests[]?.digest')"
           # A build leg does not push a bare image manifest: with provenance and SBOM
@@ -519,15 +507,13 @@ jobs:
       - name: Create multi-arch manifest
         working-directory: /tmp/digests
         run: |
-          # A dated pin is immutable: a rerun on the same day, or a late rerun of an
-          # older scheduled run, must not replace one that already exists.
+          # A dated pin is immutable: a rerun must not replace an existing one.
           TAGS=""
           for t in $(jq -r '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON"); do
             name="${t##*:}"
             case "$name" in
               nightly-[0-9]*|core-nightly-[0-9]*)
-                # Only a 404 frees the name. A transport error (000), 429 or 5xx is
-                # retried, then stops the merge: it must not become an overwrite.
+                # Only 404 frees the name; 000/429/5xx must not become an overwrite.
                 for i in 1 2 3 4 5; do
                   code="$(curl -sS -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/${name}" || true)"
                   case "$code" in 200|404) break ;; esac
@@ -555,9 +541,6 @@ jobs:
         id: studio_manifest_digest
         working-directory: /tmp/digests
         run: |
-          # Same reasoning as the base merge: resolve this run's own :build-<run_id>
-          # once and hand the smoke test an immutable digest rather than a name
-          # another run can retag under it.
           TAG="$(jq -r '([.tags[] | select(contains(":build-"))] | first) // .tags[0]' <<<"$DOCKER_METADATA_OUTPUT_JSON")"
           DIGEST="$(docker buildx imagetools inspect "$TAG" --format '{{json .Manifest.Digest}}' | tr -d '"')"
           test -n "$DIGEST"
@@ -648,9 +631,7 @@ jobs:
       # with the merge jobs' gates.
       - name: Pull and smoke-test the base image
         run: |
-          # By digest, not by name: the :core-build-<run_id> tag is gone once cleanup
-          # ran, and merge already verified that the manifest behind this digest is
-          # the one it pushed.
+          # By digest: the handle tag is gone once cleanup ran.
           REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.merge.outputs.digest }}"
           echo "smoke-testing $REF"
           docker pull "$REF"
@@ -676,15 +657,8 @@ jobs:
           [ "$ok_jupyter" = 1 ] || { echo "Jupyter /login never responded"; exit 1; }
           echo "Studio + Jupyter healthy"
 
-  # The :build-<run_id> / :core-build-<run_id> handles exist only for the digest
-  # handoff and verification above; the published names are :core, :latest, :studio,
-  # the release tags and one dated nightly pin per image. This removes the handles
-  # (namespace-scoped route: the legacy /v2/repositories path rejects the
-  # organization token) and, on the daily rebuild, prunes nightly pins older than
-  # 60 days. A dispatch with an overridden input publishes nothing durable by
-  # design (the stable-tag gates above are off), so that one keeps its handles for
-  # whoever dispatched it to pull and delete; a dispatch with the defaults on the
-  # default branch published :core/:latest/:studio and is cleaned like a push.
+  # Namespace-scoped route: the legacy /v2/repositories path rejects the organization
+  # token. A dispatch with an overridden input keeps its handles, its only names.
   cleanup:
     needs: [merge, merge-studio, hub-readme, smoke-test]
     if: ${{ always() && (github.event_name != 'workflow_dispatch' || (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.inputs.unsloth_ref == '' && (github.event.inputs.unsloth_zoo_ref == '' || github.event.inputs.unsloth_zoo_ref == 'main') && (github.event.inputs.notebooks_ref == '' || github.event.inputs.notebooks_ref == 'main') && github.event.inputs.llama_prebuilt_tag == '')) }}
@@ -708,8 +682,6 @@ jobs:
           fi
           failed=0
           drop() {
-            # 204 removed, 404 never existed (a failed merge); anything else is a
-            # leftover that would show on the tag list
             code="$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE "${HUB}/tags/$1" -H "Authorization: Bearer ${TOKEN}")"
             case "$code" in
               204|404) echo "removed ${IMAGE_NAME}:$1 (HTTP ${code})" ;;
@@ -720,8 +692,6 @@ jobs:
           drop "build-${{ github.run_id }}"
           if [ "${{ github.event_name }}" = "schedule" ]; then
             cutoff="$(date -u -d "-${NIGHTLY_KEEP_DAYS} days" +%Y.%m.%d)"
-            # every page: the listing is newest first, so the expired pins are exactly
-            # the ones a first-page-only read would never see
             url="${HUB}/tags?page_size=100"
             names=""
             while [ -n "$url" ]; do

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -10,7 +10,7 @@ Source: [`docker/`](https://github.com/unslothai/unsloth/tree/main/docker) in th
 |---|---|---|
 | `latest`, `studio` | Unsloth Studio web UI + JupyterLab + notebooks + key-only SSH | Most users. Train and chat in the browser. |
 | `core` | Training stack + JupyterLab + notebooks, no Studio | Notebooks, scripts, CI, slimmer pulls. |
-| `sha-<commit>`, `core-sha-<commit>` | The same two images, pinned to one commit of `main` | Reproducible runs. |
+| `nightly-<YYYY.MM.DD>`, `core-nightly-<YYYY.MM.DD>` | The same two images, one immutable pin per daily rebuild, kept 60 days | Reproducible runs. |
 | `<version>`, `core-<version>` | Release builds | Pin a release. |
 
 `latest` and `core` move with every push to `main` and on a daily rebuild. Both images are multi-arch: `linux/amd64` and `linux/arm64` (GH200, DGX Spark).

--- a/tests/python/test_docker_publish_ref_freeze.py
+++ b/tests/python/test_docker_publish_ref_freeze.py
@@ -382,7 +382,9 @@ def test_the_exported_digest_comes_from_this_runs_tag(manifest_digest_step: str,
 
 
 @pytest.mark.skipif(shutil.which("jq") is None, reason = "needs jq")
-def test_the_digest_export_still_works_without_a_handle_tag(manifest_digest_step: str, tmp_path: Path):
+def test_the_digest_export_still_works_without_a_handle_tag(
+    manifest_digest_step: str, tmp_path: Path
+):
     bin_dir = tmp_path / "bin"
     _docker_stub(
         bin_dir,

--- a/tests/python/test_docker_publish_ref_freeze.py
+++ b/tests/python/test_docker_publish_ref_freeze.py
@@ -415,9 +415,7 @@ def test_the_digest_export_still_works_without_a_handle_tag(
 
 @pytest.mark.skipif(shutil.which("jq") is None, reason = "needs jq")
 def test_the_digest_export_refuses_another_runs_manifest(manifest_digest_step: str, tmp_path: Path):
-    """:core-build-<run_id> is this run's own name, but the step still checks the
-    manifest it resolves to: if it does not contain the per-arch digests this run
-    pushed, the step has to fail rather than hand build-studio another run's base."""
+    """Even under this run's own name, a manifest without the per-arch digests this run pushed must fail rather than hand build-studio another run's base."""
     bin_dir = tmp_path / "bin"
     # the tag now resolves to a manifest built from somebody else's arches, while
     # this run's own per-arch indexes still answer with their real children

--- a/tests/python/test_docker_publish_ref_freeze.py
+++ b/tests/python/test_docker_publish_ref_freeze.py
@@ -352,7 +352,7 @@ def test_the_exported_digest_comes_from_this_runs_tag(manifest_digest_step: str,
         bin_dir,
         'case "$4" in\n'
         f'  --raw) printf "{_raw_index()}" ;;\n'
-        f"  *core-sha-*) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
+        f"  *core-build-*) printf '\"{THIS_RUN_DIGEST}\"' ;;\n"
         f"  *) printf '\"{OTHER_RUN_DIGEST}\"' ;;\n"
         "esac\n",
     )
@@ -362,7 +362,7 @@ def test_the_exported_digest_comes_from_this_runs_tag(manifest_digest_step: str,
     env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
     env["GITHUB_OUTPUT"] = str(out)
     env["DOCKER_METADATA_OUTPUT_JSON"] = (
-        '{"tags":["' + IMAGE + ':core","' + IMAGE + ':core-sha-abc1234"]}'
+        '{"tags":["' + IMAGE + ':core","' + IMAGE + ':core-build-123"]}'
     )
     path = tmp_path / "digest_step.sh"
     path.write_text(_expand(manifest_digest_step), encoding = "utf-8")
@@ -382,7 +382,7 @@ def test_the_exported_digest_comes_from_this_runs_tag(manifest_digest_step: str,
 
 
 @pytest.mark.skipif(shutil.which("jq") is None, reason = "needs jq")
-def test_the_digest_export_still_works_without_a_sha_tag(manifest_digest_step: str, tmp_path: Path):
+def test_the_digest_export_still_works_without_a_handle_tag(manifest_digest_step: str, tmp_path: Path):
     bin_dir = tmp_path / "bin"
     _docker_stub(
         bin_dir,
@@ -413,10 +413,8 @@ def test_the_digest_export_still_works_without_a_sha_tag(manifest_digest_step: s
 
 @pytest.mark.skipif(shutil.which("jq") is None, reason = "needs jq")
 def test_the_digest_export_refuses_another_runs_manifest(manifest_digest_step: str, tmp_path: Path):
-    """:core-sha- is immutable across COMMITS but not across REFS: a branch push and a
-    lightweight v* tag push at one commit produce the same short sha and land in
-    different concurrency groups, so both write this name and neither waits. If the
-    tag resolves to a manifest that does not contain the per-arch digests this run
+    """:core-build-<run_id> is this run's own name, but the step still checks the
+    manifest it resolves to: if it does not contain the per-arch digests this run
     pushed, the step has to fail rather than hand build-studio another run's base."""
     bin_dir = tmp_path / "bin"
     # the tag now resolves to a manifest built from somebody else's arches, while
@@ -434,7 +432,7 @@ def test_the_digest_export_refuses_another_runs_manifest(manifest_digest_step: s
     env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
     env["GITHUB_OUTPUT"] = str(out)
     env["DOCKER_METADATA_OUTPUT_JSON"] = (
-        '{"tags":["' + IMAGE + ':core","' + IMAGE + ':core-sha-abc1234"]}'
+        '{"tags":["' + IMAGE + ':core","' + IMAGE + ':core-build-123"]}'
     )
     path = tmp_path / "digest_step.sh"
     path.write_text(_expand(manifest_digest_step), encoding = "utf-8")
@@ -477,7 +475,7 @@ def test_the_digest_export_accepts_the_flattened_per_arch_indexes(
     env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
     env["GITHUB_OUTPUT"] = str(out)
     env["DOCKER_METADATA_OUTPUT_JSON"] = (
-        '{"tags":["' + IMAGE + ':core","' + IMAGE + ':core-sha-abc1234"]}'
+        '{"tags":["' + IMAGE + ':core","' + IMAGE + ':core-build-123"]}'
     )
     path = tmp_path / "digest_step.sh"
     path.write_text(_expand(manifest_digest_step), encoding = "utf-8")

--- a/tests/python/test_docker_publish_tag_scheme.py
+++ b/tests/python/test_docker_publish_tag_scheme.py
@@ -42,7 +42,7 @@ def test_no_per_commit_tags_are_published(doc: dict):
     assert "type=sha" not in text, "sha-<commit> tags are back on every push"
     for job in ("merge", "merge-studio"):
         assert not any(
-            "nightly" in r and "{{date" not in r for r in _tag_rules(doc, job)
+            "nightly" in r and "pin_date" not in r for r in _tag_rules(doc, job)
         ), f"{job} still writes a mutable nightly tag"
 
 
@@ -52,12 +52,12 @@ def test_no_per_commit_tags_are_published(doc: dict):
         (
             "merge",
             "type=raw,value=core-build-${{ github.run_id }}",
-            "type=schedule,pattern=core-nightly-{{date 'YYYY.MM.DD'}}",
+            "type=schedule,pattern=core-nightly-${{ needs.prepare.outputs.pin_date }}",
         ),
         (
             "merge-studio",
             "type=raw,value=build-${{ github.run_id }}",
-            "type=schedule,pattern=nightly-{{date 'YYYY.MM.DD'}}",
+            "type=schedule,pattern=nightly-${{ needs.prepare.outputs.pin_date }}",
         ),
     ],
 )
@@ -67,6 +67,9 @@ def test_each_image_has_a_per_run_handle_and_a_dated_pin(
     rules = _tag_rules(doc, job)
     assert handle in rules, f"{job} lost the per-run handle the digest handoff resolves"
     assert pin in rules, f"{job} lost its dated nightly pin"
+    # the date comes from prepare, computed once, so a rerun of failed jobs keeps it
+    assert "prepare" in doc["jobs"][job]["needs"]
+    assert doc["jobs"]["prepare"]["outputs"]["pin_date"] == "${{ steps.pin.outputs.date }}"
 
 
 def test_the_digest_export_resolves_the_handle(doc: dict):
@@ -90,10 +93,76 @@ def cleanup_job(doc: dict) -> dict:
     return doc["jobs"]["cleanup"]
 
 
-def test_cleanup_runs_after_everything_except_on_dispatch(cleanup_job: dict):
+def test_cleanup_runs_after_everything_except_an_overridden_dispatch(cleanup_job: dict, doc: dict):
+    """A dispatch with the default inputs on the default branch publishes the stable
+    tags, so its handles are not its only names and must go like a push's."""
     assert set(cleanup_job["needs"]) == {"merge", "merge-studio", "hub-readme", "smoke-test"}
     cond = cleanup_job["if"]
-    assert "always()" in cond and "github.event_name != 'workflow_dispatch'" in cond
+    assert cond.startswith("${{ always() && (github.event_name != 'workflow_dispatch' || (")
+    gate = doc["jobs"]["hub-readme"]["if"].strip().removeprefix("${{").removesuffix("}}").strip()
+    assert gate in cond, "the dispatch exception must be the stable-tag gate itself"
+
+
+def _manifest_step(doc: dict, job: str) -> str:
+    return [s for s in doc["jobs"][job]["steps"] if s.get("name") == "Create multi-arch manifest"][0]["run"]
+
+
+def _run_manifest(step: str, tmp_path: Path, *, existing: list[str], tags: list[str]) -> tuple[subprocess.CompletedProcess, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "docker.log"
+    (bin_dir / "docker").write_text(
+        "#!/usr/bin/env bash\n" + f"printf '%s\\n' \"$*\" >> {log}\n", encoding = "utf-8"
+    )
+    (bin_dir / "docker").chmod(0o755)
+    (bin_dir / "curl").write_text(
+        "#!/usr/bin/env bash\n"
+        'case "$*" in\n'
+        + "".join(f"  */tags/{e}) printf '200' ;;\n" for e in existing)
+        + "  *) printf '404' ;;\n"
+        "esac\n",
+        encoding = "utf-8",
+    )
+    (bin_dir / "curl").chmod(0o755)
+    digests = tmp_path / "digests"
+    digests.mkdir()
+    (digests / ("a" * 64)).write_text("", encoding = "utf-8")
+    script = step.replace("${{ env.REGISTRY }}", "docker.io").replace("${{ env.IMAGE_NAME }}", "unsloth/unsloth")
+    assert "${{" not in script
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
+    env["DOCKER_METADATA_OUTPUT_JSON"] = '{"tags": [' + ", ".join(f'"docker.io/unsloth/unsloth:{t}"' for t in tags) + "]}"
+    res = subprocess.run(
+        ["bash", "-e", "-c", script], capture_output = True, text = True, env = env, cwd = str(digests), timeout = 60
+    )
+    return res, log.read_text(encoding = "utf-8") if log.exists() else ""
+
+
+@pytest.mark.parametrize("job", ["merge", "merge-studio"])
+def test_an_existing_dated_pin_is_never_replaced(doc: dict, job: str, tmp_path: Path):
+    """A same-day rerun, or a late rerun of an older scheduled run, would otherwise
+    rewrite an allegedly immutable pin with different contents."""
+    step = _manifest_step(doc, job)
+    res, log = _run_manifest(
+        step, tmp_path, existing = ["core-nightly-2026.09.06"],
+        tags = ["core", "core-nightly-2026.09.06", "core-build-777"],
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "-t docker.io/unsloth/unsloth:core " in log
+    assert "-t docker.io/unsloth/unsloth:core-build-777 " in log
+    assert "core-nightly-2026.09.06" not in log
+    assert "already exists" in res.stdout
+
+
+@pytest.mark.parametrize("job", ["merge", "merge-studio"])
+def test_a_new_dated_pin_is_created(doc: dict, job: str, tmp_path: Path):
+    step = _manifest_step(doc, job)
+    res, log = _run_manifest(
+        step, tmp_path, existing = [], tags = ["latest", "nightly-2026.09.06", "build-777"],
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+    for t in ("latest", "nightly-2026.09.06", "build-777"):
+        assert f"-t docker.io/unsloth/unsloth:{t} " in log
 
 
 def _run_cleanup(
@@ -103,14 +172,21 @@ def _run_cleanup(
     event: str,
     delete_code: str = "204",
     tags: list[str] | None = None,
+    second_page: list[str] | None = None,
     today: str = "2026.09.06",
 ) -> tuple[subprocess.CompletedProcess, str]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "curl.log"
     listing = tmp_path / "tags.json"
+    page2 = tmp_path / "tags2.json"
+    nxt = ', "next": "https://hub.docker.com/v2/namespaces/unsloth/repositories/unsloth/tags?page=2&page_size=100"' if second_page else ', "next": null'
     listing.write_text(
-        '{"results": [' + ", ".join(f'{{"name": "{t}"}}' for t in (tags or [])) + "]}",
+        '{"results": [' + ", ".join(f'{{"name": "{t}"}}' for t in (tags or [])) + "]" + nxt + "}",
+        encoding = "utf-8",
+    )
+    page2.write_text(
+        '{"results": [' + ", ".join(f'{{"name": "{t}"}}' for t in (second_page or [])) + '], "next": null}',
         encoding = "utf-8",
     )
     (bin_dir / "curl").write_text(
@@ -119,6 +195,7 @@ def _run_cleanup(
         'case "$*" in\n'
         '  *auth/token*) printf \'{"access_token": "tok"}\' ;;\n'
         f"  *-X\\ DELETE*) printf '{delete_code}' ;;\n"
+        f"  *page=2*) cat {page2} ;;\n"
         f"  *) cat {listing} ;;\n"
         "esac\n",
         encoding = "utf-8",
@@ -204,3 +281,19 @@ def test_the_daily_run_prunes_only_old_dated_pins(cleanup_job: dict, tmp_path: P
         "nightly-2026.07.01",
         "core-nightly-2026.07.01",
     ], deleted
+
+
+def test_the_prune_follows_every_page(cleanup_job: dict, tmp_path: Path):
+    """Two pins a day pass 100 tags well inside the retention window, and the listing
+    is newest first, so the expired pins live on the pages a single request never
+    returns."""
+    step = cleanup_job["steps"][-1]["run"]
+    res, log = _run_cleanup(
+        step, tmp_path, event = "schedule",
+        tags = ["latest", "nightly-2026.09.05"],
+        second_page = ["nightly-2026.06.01", "core-nightly-2026.06.01", "stable"],
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+    deleted = [l.split("/tags/")[1].split(" ")[0] for l in log.splitlines() if "-X DELETE" in l]
+    assert deleted == ["core-build-777", "build-777", "nightly-2026.06.01", "core-nightly-2026.06.01"], deleted
+    assert log.count("page_size=100") == 2, "the second page was not fetched"

--- a/tests/python/test_docker_publish_tag_scheme.py
+++ b/tests/python/test_docker_publish_tag_scheme.py
@@ -104,10 +104,14 @@ def test_cleanup_runs_after_everything_except_an_overridden_dispatch(cleanup_job
 
 
 def _manifest_step(doc: dict, job: str) -> str:
-    return [s for s in doc["jobs"][job]["steps"] if s.get("name") == "Create multi-arch manifest"][0]["run"]
+    return [s for s in doc["jobs"][job]["steps"] if s.get("name") == "Create multi-arch manifest"][
+        0
+    ]["run"]
 
 
-def _run_manifest(step: str, tmp_path: Path, *, existing: list[str], tags: list[str]) -> tuple[subprocess.CompletedProcess, str]:
+def _run_manifest(
+    step: str, tmp_path: Path, *, existing: list[str], tags: list[str]
+) -> tuple[subprocess.CompletedProcess, str]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "docker.log"
@@ -127,13 +131,22 @@ def _run_manifest(step: str, tmp_path: Path, *, existing: list[str], tags: list[
     digests = tmp_path / "digests"
     digests.mkdir()
     (digests / ("a" * 64)).write_text("", encoding = "utf-8")
-    script = step.replace("${{ env.REGISTRY }}", "docker.io").replace("${{ env.IMAGE_NAME }}", "unsloth/unsloth")
+    script = step.replace("${{ env.REGISTRY }}", "docker.io").replace(
+        "${{ env.IMAGE_NAME }}", "unsloth/unsloth"
+    )
     assert "${{" not in script
     env = dict(os.environ)
     env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
-    env["DOCKER_METADATA_OUTPUT_JSON"] = '{"tags": [' + ", ".join(f'"docker.io/unsloth/unsloth:{t}"' for t in tags) + "]}"
+    env["DOCKER_METADATA_OUTPUT_JSON"] = (
+        '{"tags": [' + ", ".join(f'"docker.io/unsloth/unsloth:{t}"' for t in tags) + "]}"
+    )
     res = subprocess.run(
-        ["bash", "-e", "-c", script], capture_output = True, text = True, env = env, cwd = str(digests), timeout = 60
+        ["bash", "-e", "-c", script],
+        capture_output = True,
+        text = True,
+        env = env,
+        cwd = str(digests),
+        timeout = 60,
     )
     return res, log.read_text(encoding = "utf-8") if log.exists() else ""
 
@@ -144,7 +157,9 @@ def test_an_existing_dated_pin_is_never_replaced(doc: dict, job: str, tmp_path: 
     rewrite an allegedly immutable pin with different contents."""
     step = _manifest_step(doc, job)
     res, log = _run_manifest(
-        step, tmp_path, existing = ["core-nightly-2026.09.06"],
+        step,
+        tmp_path,
+        existing = ["core-nightly-2026.09.06"],
         tags = ["core", "core-nightly-2026.09.06", "core-build-777"],
     )
     assert res.returncode == 0, res.stdout + res.stderr
@@ -158,7 +173,10 @@ def test_an_existing_dated_pin_is_never_replaced(doc: dict, job: str, tmp_path: 
 def test_a_new_dated_pin_is_created(doc: dict, job: str, tmp_path: Path):
     step = _manifest_step(doc, job)
     res, log = _run_manifest(
-        step, tmp_path, existing = [], tags = ["latest", "nightly-2026.09.06", "build-777"],
+        step,
+        tmp_path,
+        existing = [],
+        tags = ["latest", "nightly-2026.09.06", "build-777"],
     )
     assert res.returncode == 0, res.stdout + res.stderr
     for t in ("latest", "nightly-2026.09.06", "build-777"):
@@ -180,13 +198,19 @@ def _run_cleanup(
     log = tmp_path / "curl.log"
     listing = tmp_path / "tags.json"
     page2 = tmp_path / "tags2.json"
-    nxt = ', "next": "https://hub.docker.com/v2/namespaces/unsloth/repositories/unsloth/tags?page=2&page_size=100"' if second_page else ', "next": null'
+    nxt = (
+        ', "next": "https://hub.docker.com/v2/namespaces/unsloth/repositories/unsloth/tags?page=2&page_size=100"'
+        if second_page
+        else ', "next": null'
+    )
     listing.write_text(
         '{"results": [' + ", ".join(f'{{"name": "{t}"}}' for t in (tags or [])) + "]" + nxt + "}",
         encoding = "utf-8",
     )
     page2.write_text(
-        '{"results": [' + ", ".join(f'{{"name": "{t}"}}' for t in (second_page or [])) + '], "next": null}',
+        '{"results": ['
+        + ", ".join(f'{{"name": "{t}"}}' for t in (second_page or []))
+        + '], "next": null}',
         encoding = "utf-8",
     )
     (bin_dir / "curl").write_text(
@@ -289,11 +313,18 @@ def test_the_prune_follows_every_page(cleanup_job: dict, tmp_path: Path):
     returns."""
     step = cleanup_job["steps"][-1]["run"]
     res, log = _run_cleanup(
-        step, tmp_path, event = "schedule",
+        step,
+        tmp_path,
+        event = "schedule",
         tags = ["latest", "nightly-2026.09.05"],
         second_page = ["nightly-2026.06.01", "core-nightly-2026.06.01", "stable"],
     )
     assert res.returncode == 0, res.stdout + res.stderr
     deleted = [l.split("/tags/")[1].split(" ")[0] for l in log.splitlines() if "-X DELETE" in l]
-    assert deleted == ["core-build-777", "build-777", "nightly-2026.06.01", "core-nightly-2026.06.01"], deleted
+    assert deleted == [
+        "core-build-777",
+        "build-777",
+        "nightly-2026.06.01",
+        "core-nightly-2026.06.01",
+    ], deleted
     assert log.count("page_size=100") == 2, "the second page was not fetched"

--- a/tests/python/test_docker_publish_tag_scheme.py
+++ b/tests/python/test_docker_publish_tag_scheme.py
@@ -1,12 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-Present the Unsloth team. See /studio/LICENSE.AGPL-3.0
 
-"""The published tag list is meant to be short: :core, :latest, :studio, the release
-tags, and one dated nightly pin per image. Per-commit sha tags used to land on every
-push, and the mutable :nightly said nothing :latest did not. The digest handoff
-between jobs now uses a per-run handle that a cleanup job removes, so these pin the
-scheme and run the cleanup step with curl stubbed.
-"""
+"""The published tag list must stay short: :core, :latest, :studio, the release tags,
+and one dated nightly pin per image. Per-run handles are removed by cleanup."""
 
 from __future__ import annotations
 
@@ -67,7 +63,6 @@ def test_each_image_has_a_per_run_handle_and_a_dated_pin(
     rules = _tag_rules(doc, job)
     assert handle in rules, f"{job} lost the per-run handle the digest handoff resolves"
     assert pin in rules, f"{job} lost its dated nightly pin"
-    # the date comes from prepare, computed once, so a rerun of failed jobs keeps it
     assert "prepare" in doc["jobs"][job]["needs"]
     assert doc["jobs"]["prepare"]["outputs"]["pin_date"] == "${{ steps.pin.outputs.date }}"
 
@@ -99,9 +94,7 @@ def _run_pin(step: dict, tmp_path: Path, *, gh: str) -> tuple[subprocess.Complet
 
 
 def test_the_pin_date_is_the_run_creation_date(doc: dict, tmp_path: Path):
-    """created_at is fixed at the first attempt while run_started_at and the clock
-    move, so a rerun of an older scheduled run on a later day keeps its own date
-    instead of claiming that day's pin with an older commit."""
+    """created_at is fixed at the first attempt, unlike run_started_at and the clock, so a late rerun cannot claim today's pin with an older commit."""
     step = _pin_step(doc)
     assert doc["jobs"]["prepare"]["permissions"].get("actions") == "read"
     assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
@@ -147,8 +140,7 @@ def cleanup_job(doc: dict) -> dict:
 
 
 def test_cleanup_runs_after_everything_except_an_overridden_dispatch(cleanup_job: dict, doc: dict):
-    """A dispatch with the default inputs on the default branch publishes the stable
-    tags, so its handles are not its only names and must go like a push's."""
+    """A default-input dispatch on the default branch publishes the stable tags, so its handles are not its only names and must go like a push's."""
     assert set(cleanup_job["needs"]) == {"merge", "merge-studio", "hub-readme", "smoke-test"}
     cond = cleanup_job["if"]
     assert cond.startswith("${{ always() && (github.event_name != 'workflow_dispatch' || (")
@@ -225,8 +217,6 @@ def _probes(tmp_path: Path) -> list[str]:
 
 @pytest.mark.parametrize("job", ["merge", "merge-studio"])
 def test_an_existing_dated_pin_is_never_replaced(doc: dict, job: str, tmp_path: Path):
-    """A same-day rerun, or a late rerun of an older scheduled run, would otherwise
-    rewrite an allegedly immutable pin with different contents."""
     step = _manifest_step(doc, job)
     res, log = _run_manifest(
         step,
@@ -259,8 +249,7 @@ def test_a_new_dated_pin_is_created(doc: dict, job: str, tmp_path: Path):
 @pytest.mark.parametrize("job", ["merge", "merge-studio"])
 @pytest.mark.parametrize("code", ["000", "429", "503"])
 def test_an_unanswered_probe_stops_the_merge(doc: dict, job: str, code: str, tmp_path: Path):
-    """Anything but a 404 used to count as absent, and the probe sits in a condition
-    where bash -e is off, so a transport failure or a 429 became an overwrite."""
+    """Anything but 404 used to count as absent, and bash -e is off inside the probe's condition, so a transport failure or a 429 became an overwrite."""
     step = _manifest_step(doc, job)
     res, log = _run_manifest(
         step,
@@ -318,7 +307,6 @@ def _run_cleanup(
         encoding = "utf-8",
     )
     (bin_dir / "curl").chmod(0o755)
-    # the cutoff comes from `date -u -d "-N days"`; pin today so the test is stable
     (bin_dir / "date").write_text(
         "#!/usr/bin/env bash\n"
         f'/bin/date -u -d "{today.replace(".", "-")} -${{NIGHTLY_KEEP_DAYS}} days" +%Y.%m.%d\n',
@@ -360,7 +348,7 @@ def test_a_push_removes_both_handles_on_the_namespace_route(cleanup_job: dict, t
 
 
 def test_a_missing_handle_is_not_a_failure(cleanup_job: dict, tmp_path: Path):
-    """A failed merge never created the handle; 404 on delete is the expected shape."""
+    """A failed merge never created the handle, so 404 on delete is expected."""
     step = cleanup_job["steps"][-1]["run"]
     res, _ = _run_cleanup(step, tmp_path, event = "push", delete_code = "404")
     assert res.returncode == 0, res.stdout + res.stderr
@@ -382,11 +370,11 @@ def test_the_daily_run_prunes_only_old_dated_pins(cleanup_job: dict, tmp_path: P
         "core-v2026.9.1",
         "stable",
         "nightly-2026.09.05",
-        "core-nightly-2026.09.05",  # fresh, kept
+        "core-nightly-2026.09.05",
         "nightly-2026.07.01",
-        "core-nightly-2026.07.01",  # older than 60 days, pruned
+        "core-nightly-2026.07.01",
         "nightly",
-        "core-nightly",  # not dated pins, never touched
+        "core-nightly",
         "2026.5.9-pt2.10.0-vllm-0.16.0-cu12.8-studio-release-v0.1.43-beta-2026-MAY-31",
     ]
     res, log = _run_cleanup(step, tmp_path, event = "schedule", tags = tags)
@@ -401,9 +389,7 @@ def test_the_daily_run_prunes_only_old_dated_pins(cleanup_job: dict, tmp_path: P
 
 
 def test_the_prune_follows_every_page(cleanup_job: dict, tmp_path: Path):
-    """Two pins a day pass 100 tags well inside the retention window, and the listing
-    is newest first, so the expired pins live on the pages a single request never
-    returns."""
+    """The listing is newest first and two pins a day pass 100 tags inside the retention window, so expired pins live on pages a single request never returns."""
     step = cleanup_job["steps"][-1]["run"]
     res, log = _run_cleanup(
         step,

--- a/tests/python/test_docker_publish_tag_scheme.py
+++ b/tests/python/test_docker_publish_tag_scheme.py
@@ -72,6 +72,57 @@ def test_each_image_has_a_per_run_handle_and_a_dated_pin(
     assert doc["jobs"]["prepare"]["outputs"]["pin_date"] == "${{ steps.pin.outputs.date }}"
 
 
+def _pin_step(doc: dict) -> dict:
+    return [s for s in doc["jobs"]["prepare"]["steps"] if s.get("id") == "pin"][0]
+
+
+def _run_pin(step: dict, tmp_path: Path, *, gh: str) -> tuple[subprocess.CompletedProcess, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "gh").write_text("#!/usr/bin/env bash\n" + gh + "\n", encoding = "utf-8")
+    (bin_dir / "gh").chmod(0o755)
+    out = tmp_path / "output"
+    out.write_text("", encoding = "utf-8")
+    script = step["run"].replace("${{ github.repository }}", "unslothai/unsloth").replace(
+        "${{ github.run_id }}", "424242"
+    )
+    assert "${{" not in script
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
+    env["GITHUB_OUTPUT"] = str(out)
+    res = subprocess.run(
+        ["bash", "-e", "-c", script], capture_output = True, text = True, env = env, timeout = 60
+    )
+    return res, out.read_text(encoding = "utf-8")
+
+
+def test_the_pin_date_is_the_run_creation_date(doc: dict, tmp_path: Path):
+    """created_at is fixed at the first attempt while run_started_at and the clock
+    move, so a rerun of an older scheduled run on a later day keeps its own date
+    instead of claiming that day's pin with an older commit."""
+    step = _pin_step(doc)
+    assert doc["jobs"]["prepare"]["permissions"].get("actions") == "read"
+    assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert "actions/runs/${{ github.run_id }}" in step["run"]
+    assert "date -u" not in step["run"]
+    res, out = _run_pin(
+        step,
+        tmp_path,
+        gh = 'echo "$*" >&2; printf \'2026-09-05T18:17:03Z\\n\'',
+    )
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert out == "date=2026.09.05\n"
+    assert "repos/unslothai/unsloth/actions/runs/424242 --jq .created_at" in res.stderr
+
+
+@pytest.mark.parametrize("gh", ["exit 1", "printf ''", "printf 'null'"])
+def test_an_unreadable_creation_time_fails_prepare(doc: dict, tmp_path: Path, gh: str):
+    res, out = _run_pin(_pin_step(doc), tmp_path, gh = gh)
+    assert res.returncode != 0
+    assert "::error::" in res.stdout
+    assert out == ""
+
+
 def test_the_digest_export_resolves_the_handle(doc: dict):
     for job, needle in (("merge", ":core-build-"), ("merge-studio", ":build-")):
         step = [s for s in doc["jobs"][job]["steps"] if s.get("name") == "Export manifest digest"][
@@ -110,21 +161,26 @@ def _manifest_step(doc: dict, job: str) -> str:
 
 
 def _run_manifest(
-    step: str, tmp_path: Path, *, existing: list[str], tags: list[str]
+    step: str, tmp_path: Path, *, existing: list[str], tags: list[str], probe_code: str = "404"
 ) -> tuple[subprocess.CompletedProcess, str]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "docker.log"
+    (bin_dir / "sleep").write_text("#!/usr/bin/env bash\n", encoding = "utf-8")
+    (bin_dir / "sleep").chmod(0o755)
     (bin_dir / "docker").write_text(
         "#!/usr/bin/env bash\n" + f"printf '%s\\n' \"$*\" >> {log}\n", encoding = "utf-8"
     )
     (bin_dir / "docker").chmod(0o755)
+    probes = tmp_path / "curl.log"
     (bin_dir / "curl").write_text(
         "#!/usr/bin/env bash\n"
+        f'echo "$*" >> {probes}\n'
         'case "$*" in\n'
         + "".join(f"  */tags/{e}) printf '200' ;;\n" for e in existing)
-        + "  *) printf '404' ;;\n"
-        "esac\n",
+        # curl prints 000 and exits 7 when the connection fails
+        + ("  *) printf '000'; exit 7 ;;\n" if probe_code == "000" else f"  *) printf '{probe_code}' ;;\n")
+        + "esac\n",
         encoding = "utf-8",
     )
     (bin_dir / "curl").chmod(0o755)
@@ -149,6 +205,11 @@ def _run_manifest(
         timeout = 60,
     )
     return res, log.read_text(encoding = "utf-8") if log.exists() else ""
+
+
+def _probes(tmp_path: Path) -> list[str]:
+    path = tmp_path / "curl.log"
+    return path.read_text(encoding = "utf-8").splitlines() if path.exists() else []
 
 
 @pytest.mark.parametrize("job", ["merge", "merge-studio"])
@@ -181,6 +242,27 @@ def test_a_new_dated_pin_is_created(doc: dict, job: str, tmp_path: Path):
     assert res.returncode == 0, res.stdout + res.stderr
     for t in ("latest", "nightly-2026.09.06", "build-777"):
         assert f"-t docker.io/unsloth/unsloth:{t} " in log
+    assert len(_probes(tmp_path)) == 1, "only the dated pin is probed, once"
+
+
+@pytest.mark.parametrize("job", ["merge", "merge-studio"])
+@pytest.mark.parametrize("code", ["000", "429", "503"])
+def test_an_unanswered_probe_stops_the_merge(doc: dict, job: str, code: str, tmp_path: Path):
+    """Anything but a 404 used to count as absent, and the probe sits in a condition
+    where bash -e is off, so a transport failure or a 429 became an overwrite."""
+    step = _manifest_step(doc, job)
+    res, log = _run_manifest(
+        step,
+        tmp_path,
+        existing = [],
+        tags = ["latest", "nightly-2026.09.06", "build-777"],
+        probe_code = code,
+    )
+    assert res.returncode != 0
+    assert f"(HTTP {code})" in res.stdout
+    assert "::error::" in res.stdout
+    assert log == "", "no manifest may be written while the pin's state is unknown"
+    assert len(_probes(tmp_path)) == 5, "the probe is retried before giving up"
 
 
 def _run_cleanup(

--- a/tests/python/test_docker_publish_tag_scheme.py
+++ b/tests/python/test_docker_publish_tag_scheme.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-Present the Unsloth team. See /studio/LICENSE.AGPL-3.0
+
+"""The published tag list is meant to be short: :core, :latest, :studio, the release
+tags, and one dated nightly pin per image. Per-commit sha tags used to land on every
+push, and the mutable :nightly said nothing :latest did not. The digest handoff
+between jobs now uses a per-run handle that a cleanup job removes, so these pin the
+scheme and run the cleanup step with curl stubbed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker-publish.yml"
+HUB_README = REPO_ROOT / "docker" / "DOCKERHUB.md"
+
+
+@pytest.fixture(scope = "module")
+def doc() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
+
+
+def _tag_rules(doc: dict, job: str) -> list[str]:
+    steps = [s for s in doc["jobs"][job]["steps"] if s.get("id") == "meta"]
+    assert len(steps) == 1
+    return [l.strip() for l in steps[0]["with"]["tags"].splitlines() if l.strip() and not l.strip().startswith("#")]
+
+
+def test_no_per_commit_tags_are_published(doc: dict):
+    text = WORKFLOW.read_text(encoding = "utf-8")
+    assert "type=sha" not in text, "sha-<commit> tags are back on every push"
+    for job in ("merge", "merge-studio"):
+        assert not any("nightly" in r and "{{date" not in r for r in _tag_rules(doc, job)), (
+            f"{job} still writes a mutable nightly tag"
+        )
+
+
+@pytest.mark.parametrize(
+    ("job", "handle", "pin"),
+    [
+        ("merge", "type=raw,value=core-build-${{ github.run_id }}", "type=schedule,pattern=core-nightly-{{date 'YYYY.MM.DD'}}"),
+        ("merge-studio", "type=raw,value=build-${{ github.run_id }}", "type=schedule,pattern=nightly-{{date 'YYYY.MM.DD'}}"),
+    ],
+)
+def test_each_image_has_a_per_run_handle_and_a_dated_pin(doc: dict, job: str, handle: str, pin: str):
+    rules = _tag_rules(doc, job)
+    assert handle in rules, f"{job} lost the per-run handle the digest handoff resolves"
+    assert pin in rules, f"{job} lost its dated nightly pin"
+
+
+def test_the_digest_export_resolves_the_handle(doc: dict):
+    for job, needle in (("merge", ':core-build-'), ("merge-studio", ':build-')):
+        step = [s for s in doc["jobs"][job]["steps"] if s.get("name") == "Export manifest digest"][0]["run"]
+        assert f'select(contains("{needle}"))' in step
+
+
+def test_the_hub_readme_lists_the_pins_not_the_handles():
+    text = HUB_README.read_text(encoding = "utf-8")
+    assert "core-nightly-<YYYY.MM.DD>" in text
+    for stale in ("sha-<commit>", "core-sha-", "build-<run_id>"):
+        assert stale not in text
+
+
+@pytest.fixture(scope = "module")
+def cleanup_job(doc: dict) -> dict:
+    assert "cleanup" in doc["jobs"], "the handle cleanup job is missing"
+    return doc["jobs"]["cleanup"]
+
+
+def test_cleanup_runs_after_everything_except_on_dispatch(cleanup_job: dict):
+    assert set(cleanup_job["needs"]) == {"merge", "merge-studio", "hub-readme", "smoke-test"}
+    cond = cleanup_job["if"]
+    assert "always()" in cond and "github.event_name != 'workflow_dispatch'" in cond
+
+
+def _run_cleanup(
+    step: str,
+    tmp_path: Path,
+    *,
+    event: str,
+    delete_code: str = "204",
+    tags: list[str] | None = None,
+    today: str = "2026.09.06",
+) -> tuple[subprocess.CompletedProcess, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "curl.log"
+    listing = tmp_path / "tags.json"
+    listing.write_text(
+        '{"results": [' + ", ".join(f'{{"name": "{t}"}}' for t in (tags or [])) + "]}", encoding = "utf-8"
+    )
+    (bin_dir / "curl").write_text(
+        "#!/usr/bin/env bash\n"
+        f"printf '%s\\n' \"$*\" >> {log}\n"
+        'case "$*" in\n'
+        '  *auth/token*) printf \'{"access_token": "tok"}\' ;;\n'
+        f"  *-X\\ DELETE*) printf '{delete_code}' ;;\n"
+        f"  *) cat {listing} ;;\n"
+        "esac\n",
+        encoding = "utf-8",
+    )
+    (bin_dir / "curl").chmod(0o755)
+    # the cutoff comes from `date -u -d "-N days"`; pin today so the test is stable
+    (bin_dir / "date").write_text(
+        "#!/usr/bin/env bash\n"
+        f'/bin/date -u -d "{today.replace(".", "-")} -${{NIGHTLY_KEEP_DAYS}} days" +%Y.%m.%d\n',
+        encoding = "utf-8",
+    )
+    (bin_dir / "date").chmod(0o755)
+    script = (
+        step.replace("${{ secrets.DOCKER_API_KEY }}", "not-a-secret")
+        .replace("${{ env.REGISTRY_USERNAME }}", "unsloth")
+        .replace("${{ github.run_id }}", "777")
+        .replace("${{ github.event_name }}", event)
+    )
+    assert "${{" not in script, "unexpanded expression in the cleanup step"
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
+    env.update(IMAGE_NAME = "unsloth/unsloth", NIGHTLY_KEEP_DAYS = "60")
+    res = subprocess.run(
+        ["bash", "-e", "-c", script], capture_output = True, text = True, env = env, cwd = str(tmp_path), timeout = 60
+    )
+    return res, log.read_text(encoding = "utf-8") if log.exists() else ""
+
+
+def test_a_push_removes_both_handles_on_the_namespace_route(cleanup_job: dict, tmp_path: Path):
+    step = cleanup_job["steps"][-1]["run"]
+    res, log = _run_cleanup(step, tmp_path, event = "push")
+    assert res.returncode == 0, res.stdout + res.stderr
+    deletes = [l for l in log.splitlines() if "-X DELETE" in l]
+    assert [l.split("/tags/")[1].split(" ")[0] for l in deletes] == ["core-build-777", "build-777"]
+    assert all("/v2/namespaces/unsloth/repositories/unsloth/tags/" in l for l in deletes)
+    assert "/v2/repositories/" not in log, "the legacy route answers every organization token with 403"
+    assert "?page_size" not in log, "a push must not prune pins"
+
+
+def test_a_missing_handle_is_not_a_failure(cleanup_job: dict, tmp_path: Path):
+    """A failed merge never created the handle; 404 on delete is the expected shape."""
+    step = cleanup_job["steps"][-1]["run"]
+    res, _ = _run_cleanup(step, tmp_path, event = "push", delete_code = "404")
+    assert res.returncode == 0, res.stdout + res.stderr
+
+
+def test_a_handle_that_survives_fails_the_job(cleanup_job: dict, tmp_path: Path):
+    step = cleanup_job["steps"][-1]["run"]
+    res, _ = _run_cleanup(step, tmp_path, event = "push", delete_code = "403")
+    assert res.returncode != 0
+    assert "not removed" in res.stdout + res.stderr
+
+
+def test_the_daily_run_prunes_only_old_dated_pins(cleanup_job: dict, tmp_path: Path):
+    step = cleanup_job["steps"][-1]["run"]
+    tags = [
+        "latest", "core", "studio", "core-v2026.9.1", "stable",
+        "nightly-2026.09.05", "core-nightly-2026.09.05",      # fresh, kept
+        "nightly-2026.07.01", "core-nightly-2026.07.01",      # older than 60 days, pruned
+        "nightly", "core-nightly",                            # not dated pins, never touched
+        "2026.5.9-pt2.10.0-vllm-0.16.0-cu12.8-studio-release-v0.1.43-beta-2026-MAY-31",
+    ]
+    res, log = _run_cleanup(step, tmp_path, event = "schedule", tags = tags)
+    assert res.returncode == 0, res.stdout + res.stderr
+    deleted = [l.split("/tags/")[1].split(" ")[0] for l in log.splitlines() if "-X DELETE" in l]
+    assert deleted == ["core-build-777", "build-777", "nightly-2026.07.01", "core-nightly-2026.07.01"], deleted

--- a/tests/python/test_docker_publish_tag_scheme.py
+++ b/tests/python/test_docker_publish_tag_scheme.py
@@ -30,34 +30,50 @@ def doc() -> dict:
 def _tag_rules(doc: dict, job: str) -> list[str]:
     steps = [s for s in doc["jobs"][job]["steps"] if s.get("id") == "meta"]
     assert len(steps) == 1
-    return [l.strip() for l in steps[0]["with"]["tags"].splitlines() if l.strip() and not l.strip().startswith("#")]
+    return [
+        l.strip()
+        for l in steps[0]["with"]["tags"].splitlines()
+        if l.strip() and not l.strip().startswith("#")
+    ]
 
 
 def test_no_per_commit_tags_are_published(doc: dict):
     text = WORKFLOW.read_text(encoding = "utf-8")
     assert "type=sha" not in text, "sha-<commit> tags are back on every push"
     for job in ("merge", "merge-studio"):
-        assert not any("nightly" in r and "{{date" not in r for r in _tag_rules(doc, job)), (
-            f"{job} still writes a mutable nightly tag"
-        )
+        assert not any(
+            "nightly" in r and "{{date" not in r for r in _tag_rules(doc, job)
+        ), f"{job} still writes a mutable nightly tag"
 
 
 @pytest.mark.parametrize(
     ("job", "handle", "pin"),
     [
-        ("merge", "type=raw,value=core-build-${{ github.run_id }}", "type=schedule,pattern=core-nightly-{{date 'YYYY.MM.DD'}}"),
-        ("merge-studio", "type=raw,value=build-${{ github.run_id }}", "type=schedule,pattern=nightly-{{date 'YYYY.MM.DD'}}"),
+        (
+            "merge",
+            "type=raw,value=core-build-${{ github.run_id }}",
+            "type=schedule,pattern=core-nightly-{{date 'YYYY.MM.DD'}}",
+        ),
+        (
+            "merge-studio",
+            "type=raw,value=build-${{ github.run_id }}",
+            "type=schedule,pattern=nightly-{{date 'YYYY.MM.DD'}}",
+        ),
     ],
 )
-def test_each_image_has_a_per_run_handle_and_a_dated_pin(doc: dict, job: str, handle: str, pin: str):
+def test_each_image_has_a_per_run_handle_and_a_dated_pin(
+    doc: dict, job: str, handle: str, pin: str
+):
     rules = _tag_rules(doc, job)
     assert handle in rules, f"{job} lost the per-run handle the digest handoff resolves"
     assert pin in rules, f"{job} lost its dated nightly pin"
 
 
 def test_the_digest_export_resolves_the_handle(doc: dict):
-    for job, needle in (("merge", ':core-build-'), ("merge-studio", ':build-')):
-        step = [s for s in doc["jobs"][job]["steps"] if s.get("name") == "Export manifest digest"][0]["run"]
+    for job, needle in (("merge", ":core-build-"), ("merge-studio", ":build-")):
+        step = [s for s in doc["jobs"][job]["steps"] if s.get("name") == "Export manifest digest"][
+            0
+        ]["run"]
         assert f'select(contains("{needle}"))' in step
 
 
@@ -94,7 +110,8 @@ def _run_cleanup(
     log = tmp_path / "curl.log"
     listing = tmp_path / "tags.json"
     listing.write_text(
-        '{"results": [' + ", ".join(f'{{"name": "{t}"}}' for t in (tags or [])) + "]}", encoding = "utf-8"
+        '{"results": [' + ", ".join(f'{{"name": "{t}"}}' for t in (tags or [])) + "]}",
+        encoding = "utf-8",
     )
     (bin_dir / "curl").write_text(
         "#!/usr/bin/env bash\n"
@@ -125,7 +142,12 @@ def _run_cleanup(
     env["PATH"] = f"{bin_dir}{os.pathsep}" + env["PATH"]
     env.update(IMAGE_NAME = "unsloth/unsloth", NIGHTLY_KEEP_DAYS = "60")
     res = subprocess.run(
-        ["bash", "-e", "-c", script], capture_output = True, text = True, env = env, cwd = str(tmp_path), timeout = 60
+        ["bash", "-e", "-c", script],
+        capture_output = True,
+        text = True,
+        env = env,
+        cwd = str(tmp_path),
+        timeout = 60,
     )
     return res, log.read_text(encoding = "utf-8") if log.exists() else ""
 
@@ -137,7 +159,9 @@ def test_a_push_removes_both_handles_on_the_namespace_route(cleanup_job: dict, t
     deletes = [l for l in log.splitlines() if "-X DELETE" in l]
     assert [l.split("/tags/")[1].split(" ")[0] for l in deletes] == ["core-build-777", "build-777"]
     assert all("/v2/namespaces/unsloth/repositories/unsloth/tags/" in l for l in deletes)
-    assert "/v2/repositories/" not in log, "the legacy route answers every organization token with 403"
+    assert (
+        "/v2/repositories/" not in log
+    ), "the legacy route answers every organization token with 403"
     assert "?page_size" not in log, "a push must not prune pins"
 
 
@@ -158,13 +182,25 @@ def test_a_handle_that_survives_fails_the_job(cleanup_job: dict, tmp_path: Path)
 def test_the_daily_run_prunes_only_old_dated_pins(cleanup_job: dict, tmp_path: Path):
     step = cleanup_job["steps"][-1]["run"]
     tags = [
-        "latest", "core", "studio", "core-v2026.9.1", "stable",
-        "nightly-2026.09.05", "core-nightly-2026.09.05",      # fresh, kept
-        "nightly-2026.07.01", "core-nightly-2026.07.01",      # older than 60 days, pruned
-        "nightly", "core-nightly",                            # not dated pins, never touched
+        "latest",
+        "core",
+        "studio",
+        "core-v2026.9.1",
+        "stable",
+        "nightly-2026.09.05",
+        "core-nightly-2026.09.05",  # fresh, kept
+        "nightly-2026.07.01",
+        "core-nightly-2026.07.01",  # older than 60 days, pruned
+        "nightly",
+        "core-nightly",  # not dated pins, never touched
         "2026.5.9-pt2.10.0-vllm-0.16.0-cu12.8-studio-release-v0.1.43-beta-2026-MAY-31",
     ]
     res, log = _run_cleanup(step, tmp_path, event = "schedule", tags = tags)
     assert res.returncode == 0, res.stdout + res.stderr
     deleted = [l.split("/tags/")[1].split(" ")[0] for l in log.splitlines() if "-X DELETE" in l]
-    assert deleted == ["core-build-777", "build-777", "nightly-2026.07.01", "core-nightly-2026.07.01"], deleted
+    assert deleted == [
+        "core-build-777",
+        "build-777",
+        "nightly-2026.07.01",
+        "core-nightly-2026.07.01",
+    ], deleted

--- a/tests/python/test_docker_publish_tag_scheme.py
+++ b/tests/python/test_docker_publish_tag_scheme.py
@@ -83,8 +83,10 @@ def _run_pin(step: dict, tmp_path: Path, *, gh: str) -> tuple[subprocess.Complet
     (bin_dir / "gh").chmod(0o755)
     out = tmp_path / "output"
     out.write_text("", encoding = "utf-8")
-    script = step["run"].replace("${{ github.repository }}", "unslothai/unsloth").replace(
-        "${{ github.run_id }}", "424242"
+    script = (
+        step["run"]
+        .replace("${{ github.repository }}", "unslothai/unsloth")
+        .replace("${{ github.run_id }}", "424242")
     )
     assert "${{" not in script
     env = dict(os.environ)
@@ -108,7 +110,7 @@ def test_the_pin_date_is_the_run_creation_date(doc: dict, tmp_path: Path):
     res, out = _run_pin(
         step,
         tmp_path,
-        gh = 'echo "$*" >&2; printf \'2026-09-05T18:17:03Z\\n\'',
+        gh = "echo \"$*\" >&2; printf '2026-09-05T18:17:03Z\\n'",
     )
     assert res.returncode == 0, res.stdout + res.stderr
     assert out == "date=2026.09.05\n"
@@ -161,7 +163,12 @@ def _manifest_step(doc: dict, job: str) -> str:
 
 
 def _run_manifest(
-    step: str, tmp_path: Path, *, existing: list[str], tags: list[str], probe_code: str = "404"
+    step: str,
+    tmp_path: Path,
+    *,
+    existing: list[str],
+    tags: list[str],
+    probe_code: str = "404",
 ) -> tuple[subprocess.CompletedProcess, str]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -179,7 +186,11 @@ def _run_manifest(
         'case "$*" in\n'
         + "".join(f"  */tags/{e}) printf '200' ;;\n" for e in existing)
         # curl prints 000 and exits 7 when the connection fails
-        + ("  *) printf '000'; exit 7 ;;\n" if probe_code == "000" else f"  *) printf '{probe_code}' ;;\n")
+        + (
+            "  *) printf '000'; exit 7 ;;\n"
+            if probe_code == "000"
+            else f"  *) printf '{probe_code}' ;;\n"
+        )
         + "esac\n",
         encoding = "utf-8",
     )


### PR DESCRIPTION
## Summary

The tag list on hub.docker.com/r/unsloth/unsloth grew by two names per push to `main` (`sha-<commit>`, `core-sha-<commit>`), plus a mutable `nightly` that never differed from `latest` for long. None of those were what anyone pulled. After this the published names are:

| Tag | Moves |
|---|---|
| `latest`, `studio` | every push to `main` and the daily rebuild |
| `core` | same |
| `<version>`, `core-<version>` | on a `v*` tag |
| `nightly-YYYY.MM.DD`, `core-nightly-YYYY.MM.DD` | never: one immutable pin per daily rebuild, pruned after 60 days |

## Why the sha tags existed, and what replaces them

The merge job hands build-studio the digest of the base image it just pushed, and it resolves that through a tag no other run can retag in between. The commit sha did that job imperfectly: a branch push and a `v*` tag push at the same commit share the short sha and run in different concurrency groups. The handle is now `core-build-<run_id>` / `build-<run_id>`, unique per run, and a final `cleanup` job removes both on the namespace-scoped Hub route, the one the organization token is allowed on. The verification that the resolved manifest holds this run's per-arch digests is unchanged.

`cleanup` runs after everything with `always()`, tolerates 404 (a failed merge never created the handle), fails on anything else so a leftover is visible, and on the scheduled run prunes dated pins older than `NIGHTLY_KEEP_DAYS` (60). It is skipped for `workflow_dispatch`, where a run with overridden inputs publishes nothing else and the handles are its only output.

The existing `sha-*` / `core-sha-*` tags have already been deleted from the Hub. `nightly` and `core-nightly` go once this is merged, so the old workflow does not recreate them at the next 18:17 UTC run.

## Tests

`tests/python/test_docker_publish_ref_freeze.py` uses the new handle in its stubs. New `tests/python/test_docker_publish_tag_scheme.py`: no `type=sha`, dated schedule patterns, handles in both merge jobs, the export steps resolve them, the Hub page lists pins not handles, and the cleanup step run with curl stubbed: both handles deleted on the namespace route and nothing on the legacy path, 404 tolerated, 403 fails, the daily prune deletes only dated pins older than the cutoff and leaves `latest`, `core`, `stable`, release and legacy tags alone. 42 pass with the neighbouring workflow suites.
