### PR TITLE
Docker: one command sets up the NVIDIA Container Toolkit on the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ unsloth studio --secure
 ```
 
 #### Docker
-Use our [Docker image](https://hub.docker.com/r/unsloth/unsloth) ```unsloth/unsloth```. On Linux, set up GPU access once with `curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo -E bash` (Windows: Docker Desktop with WSL 2). Run:
+Use our [Docker image](https://hub.docker.com/r/unsloth/unsloth) ```unsloth/unsloth```. On Linux, set up GPU access once with `curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh -o install_nvidia_toolkit.sh && sudo -E bash install_nvidia_toolkit.sh` (Windows: Docker Desktop with WSL 2). Run:
 ```bash
 docker run -d --gpus all --ipc=host \
   -p 8000:8000 -p 8888:8888 \

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ unsloth studio --secure
 ```
 
 #### Docker
-Use our [Docker image](https://hub.docker.com/r/unsloth/unsloth) ```unsloth/unsloth``` (needs the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)). Run:
+Use our [Docker image](https://hub.docker.com/r/unsloth/unsloth) ```unsloth/unsloth```. On Linux, set up GPU access once with `curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo bash` (Windows: Docker Desktop with WSL 2). Run:
 ```bash
 docker run -d --gpus all --ipc=host \
   -p 8000:8000 -p 8888:8888 \

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ unsloth studio --secure
 ```
 
 #### Docker
-Use our [Docker image](https://hub.docker.com/r/unsloth/unsloth) ```unsloth/unsloth```. On Linux, set up GPU access once with `curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo bash` (Windows: Docker Desktop with WSL 2). Run:
+Use our [Docker image](https://hub.docker.com/r/unsloth/unsloth) ```unsloth/unsloth```. On Linux, set up GPU access once with `curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo -E bash` (Windows: Docker Desktop with WSL 2). Run:
 ```bash
 docker run -d --gpus all --ipc=host \
   -p 8000:8000 -p 8888:8888 \

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -20,7 +20,7 @@ Source: [`docker/`](https://github.com/unslothai/unsloth/tree/main/docker) in th
 Needs an NVIDIA driver of 570.26 or newer and, on Linux, the NVIDIA Container Toolkit. One command installs the toolkit (Ubuntu, Debian, RHEL, Fedora, Rocky, Amazon Linux, SUSE) and checks a container can see the GPU:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo -E bash
 ```
 
 On Windows use Docker Desktop with the WSL 2 backend and a current NVIDIA Windows driver; nothing else to install. Then:

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -20,7 +20,7 @@ Source: [`docker/`](https://github.com/unslothai/unsloth/tree/main/docker) in th
 Needs an NVIDIA driver of 570.26 or newer and, on Linux, the NVIDIA Container Toolkit. One command installs the toolkit (Ubuntu, Debian, RHEL, Fedora, Rocky, Amazon Linux, SUSE) and checks a container can see the GPU:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo -E bash
+curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh -o install_nvidia_toolkit.sh && sudo -E bash install_nvidia_toolkit.sh
 ```
 
 On Windows use Docker Desktop with the WSL 2 backend and a current NVIDIA Windows driver; nothing else to install. Then:

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -17,7 +17,13 @@ Source: [`docker/`](https://github.com/unslothai/unsloth/tree/main/docker) in th
 
 ## Quick start
 
-Requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) and an NVIDIA driver of 570.26 or newer. On Windows use Docker Desktop with the WSL 2 backend.
+Needs an NVIDIA driver of 570.26 or newer and, on Linux, the NVIDIA Container Toolkit. One command installs the toolkit (Ubuntu, Debian, RHEL, Fedora, Rocky, Amazon Linux, SUSE) and checks a container can see the GPU:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo bash
+```
+
+On Windows use Docker Desktop with the WSL 2 backend and a current NVIDIA Windows driver; nothing else to install. Then:
 
 ```bash
 docker run -d --gpus all --ipc=host \

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -17,12 +17,14 @@
 #   UNSLOTH_OS_RELEASE         alternative os-release file (tests only)
 #   UNSLOTH_PROC_VERSION       alternative /proc/version file (tests only)
 #   UNSLOTH_RUN_USER_DIR       alternative /run/user (tests only)
+#   UNSLOTH_WSL_LIB_DIR        alternative /usr/lib/wsl/lib (tests only)
 set -euo pipefail
 
 DESTDIR="${UNSLOTH_DESTDIR:-}"
 OS_RELEASE="${UNSLOTH_OS_RELEASE:-/etc/os-release}"
 PROC_VERSION="${UNSLOTH_PROC_VERSION:-/proc/version}"
 RUN_USER_DIR="${UNSLOTH_RUN_USER_DIR:-/run/user}"
+WSL_LIB_DIR="${UNSLOTH_WSL_LIB_DIR:-/usr/lib/wsl/lib}"
 BASE="https://nvidia.github.io/libnvidia-container"
 
 say()  { printf '%s\n' "$*"; }
@@ -46,7 +48,12 @@ if docker info 2>/dev/null | grep -qi 'Operating System: Docker Desktop'; then
 fi
 
 # 3. a CLI pointed at another machine: everything below edits THIS machine
-endpoint="${DOCKER_HOST:-$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)}"
+# DOCKER_CONTEXT overrides DOCKER_HOST, which overrides the selected context
+if [[ -n "${DOCKER_CONTEXT:-}" || -z "${DOCKER_HOST:-}" ]]; then
+    endpoint="$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)"
+else
+    endpoint="$DOCKER_HOST"
+fi
 case "$endpoint" in
     ""|unix://*|npipe://*) ;;
     *) fail "the Docker CLI talks to a remote daemon (${endpoint}); run this script on that host, it configures the local Docker only." 2 ;;
@@ -77,14 +84,18 @@ if [[ "$(id -u)" != 0 ]]; then
     fail "run this as root: pipe it into 'sudo -E bash', or 'sudo -E bash docker/install_nvidia_toolkit.sh'." 2
 fi
 
-if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi -L 2>/dev/null | grep -q '^GPU'; then
+# On WSL 2 the Windows driver provides nvidia-smi under /usr/lib/wsl/lib, which
+# sudo's secure_path drops, so look there as well as on PATH.
+NVSMI="$(command -v nvidia-smi 2>/dev/null || true)"
+[[ -z "$NVSMI" && -x "${WSL_LIB_DIR}/nvidia-smi" ]] && NVSMI="${WSL_LIB_DIR}/nvidia-smi"
+if [[ -z "$NVSMI" ]] || ! "$NVSMI" -L 2>/dev/null | grep -q '^GPU'; then
     fail "no NVIDIA driver found (nvidia-smi lists no GPU). Install the driver first, with your
        distribution's packages (Ubuntu: 'sudo ubuntu-drivers install'; RHEL/Fedora: the
        nvidia-driver module from the CUDA repository), reboot, then run this again.
        Unsloth images need driver 570.26 or newer." 2
 fi
 MIN_DRIVER=570.26
-DRIVER="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1 | tr -d '[:space:]')"
+DRIVER="$("$NVSMI" --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1 | tr -d '[:space:]')"
 driver_ok() {
     [[ -n "$DRIVER" ]] && [[ "$(printf '%s\n' "$MIN_DRIVER" "$DRIVER" | sort -V | head -1)" == "$MIN_DRIVER" ]]
 }
@@ -109,19 +120,25 @@ else
             apt-get update -qq
             apt-get install -y -qq --no-install-recommends ca-certificates curl gnupg2 >/dev/null
             mkdir -p "${DESTDIR}/usr/share/keyrings" "${DESTDIR}/etc/apt/sources.list.d"
-            curl -fsSL "${BASE}/gpgkey" \
-                | gpg --dearmor --yes -o "${DESTDIR}/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+            # staged, then renamed: a failed download must not leave a truncated
+            # keyring or source list behind on a rerun
+            keyring="${DESTDIR}/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+            list="${DESTDIR}/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+            curl -fsSL "${BASE}/gpgkey" | gpg --dearmor --yes -o "${keyring}.tmp"
+            mv -f "${keyring}.tmp" "$keyring"
             curl -fsSL "${BASE}/stable/deb/nvidia-container-toolkit.list" \
                 | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
-                > "${DESTDIR}/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+                > "${list}.tmp"
+            mv -f "${list}.tmp" "$list"
             apt-get update -qq
             apt-get install -y -qq nvidia-container-toolkit
             ;;
         *" rhel "*|*" fedora "*|*" centos "*|*" amzn "*|*" rocky "*|*" almalinux "*)
             command -v curl >/dev/null 2>&1 || { command -v dnf >/dev/null 2>&1 && dnf install -y curl || yum install -y curl; }
             mkdir -p "${DESTDIR}/etc/yum.repos.d"
-            curl -fsSL "${BASE}/stable/rpm/nvidia-container-toolkit.repo" \
-                > "${DESTDIR}/etc/yum.repos.d/nvidia-container-toolkit.repo"
+            repo="${DESTDIR}/etc/yum.repos.d/nvidia-container-toolkit.repo"
+            curl -fsSL "${BASE}/stable/rpm/nvidia-container-toolkit.repo" > "${repo}.tmp"
+            mv -f "${repo}.tmp" "$repo"
             if command -v dnf >/dev/null 2>&1; then
                 say "Installing nvidia-container-toolkit with dnf."
                 dnf install -y nvidia-container-toolkit

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -3,7 +3,7 @@
 # `docker run --gpus all unsloth/unsloth` works. This is the host side that no image
 # can do for itself: Docker resolves --gpus in the daemon, before a container exists.
 #
-#   curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo -E bash
+#   curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh -o install_nvidia_toolkit.sh && sudo -E bash install_nvidia_toolkit.sh
 #
 # Follows NVIDIA's install guide (apt, dnf/yum, zypper), then
 # `nvidia-ctk runtime configure --runtime=docker`, restarts Docker and verifies with a
@@ -81,7 +81,7 @@ if [[ "$(id -u)" != 0 ]]; then
         say "Re-running with sudo."
         exec sudo -E bash "$0" "$@"
     fi
-    fail "run this as root: pipe it into 'sudo -E bash', or 'sudo -E bash docker/install_nvidia_toolkit.sh'." 2
+    fail "run this as root: sudo -E bash install_nvidia_toolkit.sh" 2
 fi
 
 # On WSL 2 the Windows driver provides nvidia-smi under /usr/lib/wsl/lib, which
@@ -102,7 +102,11 @@ driver_ok() {
 
 # explicit platform for the checks below: a cached ubuntu image of the other arch
 # would otherwise be picked and fail on "exec nvidia-smi: no such file"
-case "$(uname -m)" in aarch64|arm64) PLATFORM=linux/arm64 ;; *) PLATFORM=linux/amd64 ;; esac
+case "$(uname -m)" in
+    aarch64|arm64) PLATFORM=linux/arm64 ;;
+    x86_64|amd64)  PLATFORM=linux/amd64 ;;
+    *) fail "unsupported architecture $(uname -m): the Unsloth images are built for linux/amd64 and linux/arm64 only." 2 ;;
+esac
 
 configured() {
     command -v nvidia-ctk >/dev/null 2>&1 && docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'
@@ -110,6 +114,9 @@ configured() {
 
 if configured; then
     say "NVIDIA Container Toolkit is already installed and Docker lists the nvidia runtime."
+elif command -v nvidia-ctk >/dev/null 2>&1; then
+    # packages present, runtime entry missing: no network work, just register
+    say "nvidia-container-toolkit is installed but Docker does not list the nvidia runtime."
 else
     [[ -r "$OS_RELEASE" ]] || fail "cannot read $OS_RELEASE to pick a package manager." 2
     # shellcheck disable=SC1090
@@ -125,6 +132,7 @@ else
             keyring="${DESTDIR}/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
             list="${DESTDIR}/etc/apt/sources.list.d/nvidia-container-toolkit.list"
             curl -fsSL "${BASE}/gpgkey" | gpg --dearmor --yes -o "${keyring}.tmp"
+            chmod 0644 "${keyring}.tmp"  # apt reads Signed-By keys as _apt, so not umask 077
             mv -f "${keyring}.tmp" "$keyring"
             curl -fsSL "${BASE}/stable/deb/nvidia-container-toolkit.list" \
                 | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
@@ -157,7 +165,9 @@ else
        https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html" 2
             ;;
     esac
+fi
 
+if ! configured; then
     say "Registering the nvidia runtime with Docker."
     nvidia-ctk runtime configure --runtime=docker
     # WSL 2 distros and containers often run without systemd; `service` covers them.

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Installs the NVIDIA Container Toolkit on a Linux host and wires it into Docker, so
+# `docker run --gpus all unsloth/unsloth` works. This is the host side that no image
+# can do for itself: Docker resolves --gpus in the daemon, before a container exists.
+#
+#   curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo bash
+#
+# Follows NVIDIA's install guide (apt, dnf/yum, zypper), then
+# `nvidia-ctk runtime configure --runtime=docker`, restarts Docker and verifies with a
+# real `docker run --gpus all`. Idempotent: a host that is already set up only runs
+# the verification. The NVIDIA driver itself is a kernel module and is not installed
+# here; without one this stops and says how to get it.
+#
+# Environment:
+#   UNSLOTH_TOOLKIT_VERIFY=0   skip the final `docker run --gpus all` check
+#   UNSLOTH_DESTDIR            prefix for /etc and /usr/share paths (tests only)
+#   UNSLOTH_OS_RELEASE         alternative os-release file (tests only)
+#   UNSLOTH_PROC_VERSION       alternative /proc/version file (tests only)
+set -euo pipefail
+
+DESTDIR="${UNSLOTH_DESTDIR:-}"
+OS_RELEASE="${UNSLOTH_OS_RELEASE:-/etc/os-release}"
+PROC_VERSION="${UNSLOTH_PROC_VERSION:-/proc/version}"
+BASE="https://nvidia.github.io/libnvidia-container"
+
+say()  { printf '%s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit "${2:-1}"; }
+
+if [[ "$(id -u)" != 0 ]]; then
+    # piped through `curl | bash` there is no file to re-run: $0 is just "bash"
+    if [[ -r "$0" ]] && command -v sudo >/dev/null 2>&1; then
+        say "Re-running with sudo."
+        exec sudo -E bash "$0" "$@"
+    fi
+    fail "run this as root: pipe it into 'sudo bash', or 'sudo bash docker/install_nvidia_toolkit.sh'." 2
+fi
+
+# Docker Desktop (macOS, or Windows with the WSL 2 backend) ships its own GPU
+# integration: nothing to install on that side, and apt inside the WSL distro would
+# configure a daemon Docker Desktop does not use.
+if docker info 2>/dev/null | grep -qi 'Operating System: Docker Desktop'; then
+    say "Docker Desktop detected: GPU support comes with it, nothing to install."
+    say "On Windows keep the WSL 2 backend on and the NVIDIA Windows driver current (wsl --update)."
+    exit 0
+fi
+
+if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi -L 2>/dev/null | grep -q '^GPU'; then
+    fail "no NVIDIA driver found (nvidia-smi lists no GPU). Install the driver first, with your
+       distribution's packages (Ubuntu: 'sudo ubuntu-drivers install'; RHEL/Fedora: the
+       nvidia-driver module from the CUDA repository), reboot, then run this again.
+       Unsloth images need driver 570.26 or newer." 2
+fi
+
+configured() {
+    command -v nvidia-ctk >/dev/null 2>&1 && docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'
+}
+
+if configured; then
+    say "NVIDIA Container Toolkit is already installed and Docker lists the nvidia runtime."
+else
+    [[ -r "$OS_RELEASE" ]] || fail "cannot read $OS_RELEASE to pick a package manager." 2
+    # shellcheck disable=SC1090
+    ID_LIKE="$( . "$OS_RELEASE"; printf '%s %s' "${ID:-}" "${ID_LIKE:-}" )"
+    case " $ID_LIKE " in
+        *" ubuntu "*|*" debian "*)
+            say "Adding NVIDIA's apt repository and installing nvidia-container-toolkit."
+            apt-get update -qq
+            apt-get install -y -qq --no-install-recommends ca-certificates curl gnupg2 >/dev/null
+            mkdir -p "${DESTDIR}/usr/share/keyrings" "${DESTDIR}/etc/apt/sources.list.d"
+            curl -fsSL "${BASE}/gpgkey" \
+                | gpg --dearmor --yes -o "${DESTDIR}/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+            curl -fsSL "${BASE}/stable/deb/nvidia-container-toolkit.list" \
+                | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+                > "${DESTDIR}/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+            apt-get update -qq
+            apt-get install -y -qq nvidia-container-toolkit
+            ;;
+        *" rhel "*|*" fedora "*|*" centos "*|*" amzn "*|*" rocky "*|*" almalinux "*)
+            mkdir -p "${DESTDIR}/etc/yum.repos.d"
+            curl -fsSL "${BASE}/stable/rpm/nvidia-container-toolkit.repo" \
+                > "${DESTDIR}/etc/yum.repos.d/nvidia-container-toolkit.repo"
+            if command -v dnf >/dev/null 2>&1; then
+                say "Installing nvidia-container-toolkit with dnf."
+                dnf install -y nvidia-container-toolkit
+            else
+                say "Installing nvidia-container-toolkit with yum."
+                yum install -y nvidia-container-toolkit
+            fi
+            ;;
+        *" suse "*|*" opensuse "*|*" sles "*|*" opensuse-leap "*|*" opensuse-tumbleweed "*)
+            say "Installing nvidia-container-toolkit with zypper."
+            zypper --non-interactive ar "${BASE}/stable/rpm/nvidia-container-toolkit.repo" || true
+            zypper --non-interactive --gpg-auto-import-keys install nvidia-container-toolkit
+            ;;
+        *)
+            fail "unrecognised distribution ($ID_LIKE). Install the toolkit by hand:
+       https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html" 2
+            ;;
+    esac
+
+    say "Registering the nvidia runtime with Docker."
+    nvidia-ctk runtime configure --runtime=docker
+    # WSL 2 distros and containers often run without systemd; `service` covers them.
+    if command -v systemctl >/dev/null 2>&1 && systemctl restart docker 2>/dev/null; then
+        say "Docker restarted (systemctl)."
+    elif command -v service >/dev/null 2>&1 && service docker restart 2>/dev/null; then
+        say "Docker restarted (service)."
+    else
+        fail "could not restart Docker; restart it yourself, then run: docker run --rm --gpus all ubuntu:24.04 nvidia-smi -L"
+    fi
+    configured || fail "Docker still does not list the nvidia runtime after the install; see 'docker info'."
+fi
+
+if [[ "${UNSLOTH_TOOLKIT_VERIFY:-1}" != 0 ]]; then
+    # explicit platform: a cached ubuntu image of the other arch would otherwise be
+    # picked and fail on "exec nvidia-smi: no such file" for the wrong reason
+    case "$(uname -m)" in aarch64|arm64) PLATFORM=linux/arm64 ;; *) PLATFORM=linux/amd64 ;; esac
+    say "Verifying: docker run --rm --gpus all --platform ${PLATFORM} ubuntu:24.04 nvidia-smi -L"
+    if ! docker run --rm --gpus all --platform "${PLATFORM}" ubuntu:24.04 nvidia-smi -L; then
+        fail "a container could not see the GPU. If this host is WSL 2 without Docker Desktop, make
+       sure the Windows NVIDIA driver is current (wsl --update); otherwise see
+       https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/troubleshooting.html"
+    fi
+fi
+if grep -qi microsoft "$PROC_VERSION" 2>/dev/null; then
+    say "WSL 2 host: the GPU is the Windows driver's; keep it current with the NVIDIA installer."
+fi
+say "Done. Run: docker run -d --gpus all -p 8000:8000 -p 8888:8888 unsloth/unsloth"

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -54,7 +54,8 @@ fi
 # 3. a CLI pointed at another machine: everything below edits THIS machine
 # DOCKER_CONTEXT overrides DOCKER_HOST, which overrides the selected context
 if [[ -n "${DOCKER_CONTEXT:-}" || -z "${DOCKER_HOST:-}" ]]; then
-    endpoint="$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)"
+    endpoint="$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null)" \
+        || fail "cannot inspect the Docker context '${DOCKER_CONTEXT:-current}' (it may exist only in the invoking user's Docker config); refusing to guess which daemon to configure." 2
 else
     endpoint="$DOCKER_HOST"
 fi
@@ -94,6 +95,11 @@ fi
 NVSMI="$(command -v nvidia-smi 2>/dev/null || true)"
 [[ -z "$NVSMI" && -x "${WSL_LIB_DIR}/nvidia-smi" ]] && NVSMI="${WSL_LIB_DIR}/nvidia-smi"
 if [[ -z "$NVSMI" ]] || ! "$NVSMI" -L 2>/dev/null | grep -q '^GPU'; then
+    if grep -qi microsoft "$PROC_VERSION" 2>/dev/null; then
+        fail "no NVIDIA GPU is visible in this WSL 2 distro. Install a current NVIDIA Windows driver
+       from nvidia.com (never a Linux driver inside WSL), restart WSL (wsl --shutdown), then run
+       this again. Unsloth images need driver 570.26 or newer." 2
+    fi
     fail "no NVIDIA driver found (nvidia-smi lists no GPU). Install the driver first, with your
        distribution's packages (Ubuntu: 'sudo ubuntu-drivers install'; RHEL/Fedora: the
        nvidia-driver module from the CUDA repository), reboot, then run this again.
@@ -120,8 +126,9 @@ configured() {
 
 if configured; then
     say "Docker already lists the nvidia runtime; nothing to install."
-elif command -v nvidia-ctk >/dev/null 2>&1; then
-    # packages present, runtime entry missing: no network work, just register
+elif command -v nvidia-ctk >/dev/null 2>&1 && command -v nvidia-container-runtime >/dev/null 2>&1; then
+    # full toolkit present (nvidia-container-toolkit-base alone ships only the CLI),
+    # runtime entry missing: no network work, just register
     say "nvidia-container-toolkit is installed but Docker does not list the nvidia runtime."
 else
     [[ -r "$OS_RELEASE" ]] || fail "cannot read $OS_RELEASE to pick a package manager." 2

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -26,6 +26,14 @@ BASE="https://nvidia.github.io/libnvidia-container"
 say()  { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit "${2:-1}"; }
 
+# Rootless Docker keeps its daemon and config under the user; the system-wide steps
+# below would configure a daemon that user never talks to. NVIDIA documents the
+# rootless procedure separately. Checked before elevating: root sees another daemon.
+if docker info --format '{{join .SecurityOptions ","}}' 2>/dev/null | grep -q rootless; then
+    fail "rootless Docker detected. Follow NVIDIA's rootless procedure instead:
+       https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#rootless-mode" 2
+fi
+
 if [[ "$(id -u)" != 0 ]]; then
     # piped through `curl | bash` there is no file to re-run: $0 is just "bash"
     if [[ -r "$0" ]] && command -v sudo >/dev/null 2>&1; then
@@ -50,6 +58,11 @@ if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi -L 2>/dev/null | grep
        nvidia-driver module from the CUDA repository), reboot, then run this again.
        Unsloth images need driver 570.26 or newer." 2
 fi
+MIN_DRIVER=570.26
+DRIVER="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1 | tr -d '[:space:]')"
+driver_ok() {
+    [[ -n "$DRIVER" ]] && [[ "$(printf '%s\n' "$MIN_DRIVER" "$DRIVER" | sort -V | head -1)" == "$MIN_DRIVER" ]]
+}
 
 configured() {
     command -v nvidia-ctk >/dev/null 2>&1 && docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'
@@ -125,4 +138,11 @@ fi
 if grep -qi microsoft "$PROC_VERSION" 2>/dev/null; then
     say "WSL 2 host: the GPU is the Windows driver's; keep it current with the NVIDIA installer."
 fi
+if ! driver_ok; then
+    # the toolkit is in place, but the image's CUDA 12.8 stack will not start on this
+    # driver, so do not call it done
+    fail "the toolkit works, but NVIDIA driver ${DRIVER:-unknown} is below ${MIN_DRIVER}, the minimum for
+       the Unsloth images. Update the driver, reboot, then run: docker run --rm --gpus all --platform ${PLATFORM:-linux/amd64} ubuntu:24.04 nvidia-smi -L" 3
+fi
+say "Driver ${DRIVER} meets the ${MIN_DRIVER} minimum."
 say "Done. Run: docker run -d --gpus all -p 8000:8000 -p 8888:8888 unsloth/unsloth"

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -1,23 +1,8 @@
 #!/usr/bin/env bash
-# Installs the NVIDIA Container Toolkit on a Linux host and wires it into Docker, so
-# `docker run --gpus all unsloth/unsloth` works. This is the host side that no image
-# can do for itself: Docker resolves --gpus in the daemon, before a container exists.
-#
+# Installs the NVIDIA Container Toolkit into Docker. Host side only: Docker resolves --gpus in the daemon, before a container exists, so no image can do this itself.
 #   curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh -o install_nvidia_toolkit.sh && sudo -E bash install_nvidia_toolkit.sh
-#
-# Follows NVIDIA's install guide (apt, dnf/yum, zypper), then
-# `nvidia-ctk runtime configure --runtime=docker`, restarts Docker and verifies with a
-# real `docker run --gpus all`. Idempotent: a host that is already set up only runs
-# the verification. The NVIDIA driver itself is a kernel module and is not installed
-# here; without one this stops and says how to get it.
-#
-# Environment:
-#   UNSLOTH_TOOLKIT_VERIFY=0   skip the final `docker run --gpus all` check
-#   UNSLOTH_DESTDIR            prefix for /etc and /usr/share paths (tests only)
-#   UNSLOTH_OS_RELEASE         alternative os-release file (tests only)
-#   UNSLOTH_PROC_VERSION       alternative /proc/version file (tests only)
-#   UNSLOTH_RUN_USER_DIR       alternative /run/user (tests only)
-#   UNSLOTH_WSL_LIB_DIR        alternative /usr/lib/wsl/lib (tests only)
+# UNSLOTH_TOOLKIT_VERIFY=0 skips the final `docker run --gpus all` check. UNSLOTH_DESTDIR, UNSLOTH_OS_RELEASE,
+# UNSLOTH_PROC_VERSION, UNSLOTH_RUN_USER_DIR and UNSLOTH_WSL_LIB_DIR redirect the host paths they name (tests only).
 set -euo pipefail
 
 DESTDIR="${UNSLOTH_DESTDIR:-}"
@@ -33,9 +18,7 @@ fail() { printf 'ERROR: %s\n' "$1" >&2; exit "${2:-1}"; }
 command -v docker >/dev/null 2>&1 \
     || fail "docker is not installed. Install Docker Engine first (https://docs.docker.com/engine/install/), then run this again." 2
 
-# Docker Desktop (macOS, or Windows with the WSL 2 backend) ships its own GPU
-# integration: nothing to install on that side, and apt inside the WSL distro would
-# configure a daemon Docker Desktop does not use. Checked before asking for sudo.
+# Docker Desktop ships its own GPU integration; installing here would configure a daemon it does not use. Checked before elevating.
 if docker info 2>/dev/null | grep -qi 'Operating System: Docker Desktop'; then
     if [[ "$(uname -s)" == Darwin ]]; then
         say "Docker Desktop on macOS: no NVIDIA GPU can be attached on a Mac, so there is nothing to install."
@@ -46,13 +29,11 @@ if docker info 2>/dev/null | grep -qi 'Operating System: Docker Desktop'; then
         say "Keep a current NVIDIA Windows driver installed (from nvidia.com; wsl --update updates WSL itself, not the driver)."
         exit 0
     fi
-    # Docker Desktop for Linux runs its daemon in a VM with no GPU passthrough
     fail "Docker Desktop for Linux has no NVIDIA GPU support. Install Docker Engine instead
        (https://docs.docker.com/engine/install/) and run this again." 2
 fi
 
-# 3. a CLI pointed at another machine: everything below edits THIS machine
-# DOCKER_CONTEXT overrides DOCKER_HOST, which overrides the selected context
+# Everything below edits THIS machine; DOCKER_CONTEXT overrides DOCKER_HOST, which overrides the selected context.
 if [[ -n "${DOCKER_CONTEXT:-}" || -z "${DOCKER_HOST:-}" ]]; then
     endpoint="$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null)" \
         || fail "cannot inspect the Docker context '${DOCKER_CONTEXT:-current}' (it may exist only in the invoking user's Docker config); refusing to guess which daemon to configure." 2
@@ -65,11 +46,7 @@ case "$endpoint" in
     *) fail "the Docker CLI talks to a remote daemon (${endpoint}); run this script on that host, it configures the local Docker only." 2 ;;
 esac
 
-# Rootless Docker keeps its daemon and config under the user; the system-wide steps
-# below would configure a daemon that user never talks to. NVIDIA documents the
-# rootless procedure separately. Checked before elevating, because root sees another
-# daemon; `curl | sudo bash` arrives already root with DOCKER_HOST stripped, so the
-# invoking user's socket is looked up through SUDO_UID as well.
+# Rootless Docker keeps its own daemon, which the steps below would miss; root sees a different one, and `curl | sudo bash` arrives root with DOCKER_HOST stripped, so probe SUDO_UID's socket too.
 rootless_daemon() {
     docker info --format '{{join .SecurityOptions ","}}' 2>/dev/null | grep -q rootless && return 0
     [[ -n "${SUDO_UID:-}" && -S "${RUN_USER_DIR}/${SUDO_UID}/docker.sock" ]] \
@@ -90,8 +67,7 @@ if [[ "$(id -u)" != 0 ]]; then
     fail "run this as root: sudo -E bash install_nvidia_toolkit.sh" 2
 fi
 
-# On WSL 2 the Windows driver provides nvidia-smi under /usr/lib/wsl/lib, which
-# sudo's secure_path drops, so look there as well as on PATH.
+# On WSL 2 the Windows driver puts nvidia-smi under /usr/lib/wsl/lib, which sudo's secure_path drops from PATH.
 NVSMI="$(command -v nvidia-smi 2>/dev/null || true)"
 [[ -z "$NVSMI" && -x "${WSL_LIB_DIR}/nvidia-smi" ]] && NVSMI="${WSL_LIB_DIR}/nvidia-smi"
 if [[ -z "$NVSMI" ]] || ! "$NVSMI" -L 2>/dev/null | grep -q '^GPU'; then
@@ -111,8 +87,7 @@ driver_ok() {
     [[ -n "$DRIVER" ]] && [[ "$(printf '%s\n' "$MIN_DRIVER" "$DRIVER" | sort -V | head -1)" == "$MIN_DRIVER" ]]
 }
 
-# explicit platform for the checks below: a cached ubuntu image of the other arch
-# would otherwise be picked and fail on "exec nvidia-smi: no such file"
+# Explicit platform: a cached ubuntu image of the other arch would be picked and fail on "exec nvidia-smi: no such file".
 case "$(uname -m)" in
     aarch64|arm64) PLATFORM=linux/arm64 ;;
     x86_64|amd64)  PLATFORM=linux/amd64 ;;
@@ -120,15 +95,13 @@ case "$(uname -m)" in
 esac
 
 configured() {
-    # a legacy or hand-made registration counts too; nvidia-ctk is only needed to make one
     docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'
 }
 
 if configured; then
     say "Docker already lists the nvidia runtime; nothing to install."
 elif command -v nvidia-ctk >/dev/null 2>&1 && command -v nvidia-container-runtime >/dev/null 2>&1; then
-    # full toolkit present (nvidia-container-toolkit-base alone ships only the CLI),
-    # runtime entry missing: no network work, just register
+    # nvidia-container-toolkit-base ships nvidia-ctk without the runtime, so check both before skipping the install.
     say "nvidia-container-toolkit is installed but Docker does not list the nvidia runtime."
 else
     [[ -r "$OS_RELEASE" ]] || fail "cannot read $OS_RELEASE to pick a package manager." 2
@@ -140,8 +113,7 @@ else
             apt-get update -qq
             apt-get install -y -qq --no-install-recommends ca-certificates curl gnupg2 >/dev/null
             mkdir -p "${DESTDIR}/usr/share/keyrings" "${DESTDIR}/etc/apt/sources.list.d"
-            # staged, then renamed: a failed download must not leave a truncated
-            # keyring or source list behind on a rerun
+            # Staged then renamed: a failed download must not leave a truncated keyring or list behind.
             keyring="${DESTDIR}/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
             list="${DESTDIR}/etc/apt/sources.list.d/nvidia-container-toolkit.list"
             curl -fsSL "${BASE}/gpgkey" | gpg --dearmor --yes -o "${keyring}.tmp"
@@ -183,7 +155,6 @@ fi
 if ! configured; then
     say "Registering the nvidia runtime with Docker."
     nvidia-ctk runtime configure --runtime=docker
-    # WSL 2 distros and containers often run without systemd; `service` covers them.
     if command -v systemctl >/dev/null 2>&1 && systemctl restart docker 2>/dev/null; then
         say "Docker restarted (systemctl)."
     elif command -v service >/dev/null 2>&1 && service docker restart 2>/dev/null; then
@@ -206,8 +177,6 @@ if grep -qi microsoft "$PROC_VERSION" 2>/dev/null; then
     say "WSL 2 host: the GPU comes from the Windows NVIDIA driver; update it with NVIDIA's Windows installer."
 fi
 if ! driver_ok; then
-    # the toolkit is in place, but the image's CUDA 12.8 stack will not start on this
-    # driver, so do not call it done
     fail "the toolkit works, but NVIDIA driver ${DRIVER:-unknown} is below ${MIN_DRIVER}, the minimum for
        the Unsloth images. Update the driver, reboot, then run: docker run --rm --gpus all --platform ${PLATFORM} ubuntu:24.04 nvidia-smi -L" 3
 fi

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -3,7 +3,7 @@
 # `docker run --gpus all unsloth/unsloth` works. This is the host side that no image
 # can do for itself: Docker resolves --gpus in the daemon, before a container exists.
 #
-#   curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo bash
+#   curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo -E bash
 #
 # Follows NVIDIA's install guide (apt, dnf/yum, zypper), then
 # `nvidia-ctk runtime configure --runtime=docker`, restarts Docker and verifies with a
@@ -35,10 +35,22 @@ command -v docker >/dev/null 2>&1 \
 # integration: nothing to install on that side, and apt inside the WSL distro would
 # configure a daemon Docker Desktop does not use. Checked before asking for sudo.
 if docker info 2>/dev/null | grep -qi 'Operating System: Docker Desktop'; then
-    say "Docker Desktop detected: GPU support comes with it, nothing to install."
-    say "On Windows keep the WSL 2 backend on and the NVIDIA Windows driver current (wsl --update)."
+    if [[ "$(uname -s)" == Darwin ]]; then
+        say "Docker Desktop on macOS: no NVIDIA GPU can be attached on a Mac, so there is nothing to install."
+        say "The image runs CPU-only there: drop --gpus and set UNSLOTH_ALLOW_CPU=1."
+    else
+        say "Docker Desktop detected: GPU support comes with it, nothing to install."
+        say "On Windows keep the WSL 2 backend on and the NVIDIA Windows driver current (wsl --update)."
+    fi
     exit 0
 fi
+
+# 3. a CLI pointed at another machine: everything below edits THIS machine
+endpoint="${DOCKER_HOST:-$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)}"
+case "$endpoint" in
+    ""|unix://*|npipe://*) ;;
+    *) fail "the Docker CLI talks to a remote daemon (${endpoint}); run this script on that host, it configures the local Docker only." 2 ;;
+esac
 
 # Rootless Docker keeps its daemon and config under the user; the system-wide steps
 # below would configure a daemon that user never talks to. NVIDIA documents the
@@ -62,7 +74,7 @@ if [[ "$(id -u)" != 0 ]]; then
         say "Re-running with sudo."
         exec sudo -E bash "$0" "$@"
     fi
-    fail "run this as root: pipe it into 'sudo bash', or 'sudo bash docker/install_nvidia_toolkit.sh'." 2
+    fail "run this as root: pipe it into 'sudo -E bash', or 'sudo -E bash docker/install_nvidia_toolkit.sh'." 2
 fi
 
 if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi -L 2>/dev/null | grep -q '^GPU'; then
@@ -76,6 +88,10 @@ DRIVER="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/nul
 driver_ok() {
     [[ -n "$DRIVER" ]] && [[ "$(printf '%s\n' "$MIN_DRIVER" "$DRIVER" | sort -V | head -1)" == "$MIN_DRIVER" ]]
 }
+
+# explicit platform for the checks below: a cached ubuntu image of the other arch
+# would otherwise be picked and fail on "exec nvidia-smi: no such file"
+case "$(uname -m)" in aarch64|arm64) PLATFORM=linux/arm64 ;; *) PLATFORM=linux/amd64 ;; esac
 
 configured() {
     command -v nvidia-ctk >/dev/null 2>&1 && docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'
@@ -133,15 +149,12 @@ else
     elif command -v service >/dev/null 2>&1 && service docker restart 2>/dev/null; then
         say "Docker restarted (service)."
     else
-        fail "could not restart Docker; restart it yourself, then run: docker run --rm --gpus all ubuntu:24.04 nvidia-smi -L"
+        fail "could not restart Docker; restart it yourself, then run: docker run --rm --gpus all --platform ${PLATFORM} ubuntu:24.04 nvidia-smi -L"
     fi
     configured || fail "Docker still does not list the nvidia runtime after the install; see 'docker info'."
 fi
 
 if [[ "${UNSLOTH_TOOLKIT_VERIFY:-1}" != 0 ]]; then
-    # explicit platform: a cached ubuntu image of the other arch would otherwise be
-    # picked and fail on "exec nvidia-smi: no such file" for the wrong reason
-    case "$(uname -m)" in aarch64|arm64) PLATFORM=linux/arm64 ;; *) PLATFORM=linux/amd64 ;; esac
     say "Verifying: docker run --rm --gpus all --platform ${PLATFORM} ubuntu:24.04 nvidia-smi -L"
     if ! docker run --rm --gpus all --platform "${PLATFORM}" ubuntu:24.04 nvidia-smi -L; then
         fail "a container could not see the GPU. If this host is WSL 2 without Docker Desktop, make
@@ -156,7 +169,7 @@ if ! driver_ok; then
     # the toolkit is in place, but the image's CUDA 12.8 stack will not start on this
     # driver, so do not call it done
     fail "the toolkit works, but NVIDIA driver ${DRIVER:-unknown} is below ${MIN_DRIVER}, the minimum for
-       the Unsloth images. Update the driver, reboot, then run: docker run --rm --gpus all --platform ${PLATFORM:-linux/amd64} ubuntu:24.04 nvidia-smi -L" 3
+       the Unsloth images. Update the driver, reboot, then run: docker run --rm --gpus all --platform ${PLATFORM} ubuntu:24.04 nvidia-smi -L" 3
 fi
 say "Driver ${DRIVER} meets the ${MIN_DRIVER} minimum."
 say "Done. Run: docker run -d --gpus all -p 8000:8000 -p 8888:8888 unsloth/unsloth"

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -40,11 +40,15 @@ if docker info 2>/dev/null | grep -qi 'Operating System: Docker Desktop'; then
     if [[ "$(uname -s)" == Darwin ]]; then
         say "Docker Desktop on macOS: no NVIDIA GPU can be attached on a Mac, so there is nothing to install."
         say "The image runs CPU-only there: drop --gpus and set UNSLOTH_ALLOW_CPU=1."
-    else
-        say "Docker Desktop detected: GPU support comes with it, nothing to install."
-        say "On Windows keep the WSL 2 backend on and the NVIDIA Windows driver current (wsl --update)."
+        exit 0
+    elif grep -qi microsoft "$PROC_VERSION" 2>/dev/null; then
+        say "Docker Desktop with the WSL 2 backend: GPU support comes with it, nothing to install here."
+        say "Keep a current NVIDIA Windows driver installed (from nvidia.com; wsl --update updates WSL itself, not the driver)."
+        exit 0
     fi
-    exit 0
+    # Docker Desktop for Linux runs its daemon in a VM with no GPU passthrough
+    fail "Docker Desktop for Linux has no NVIDIA GPU support. Install Docker Engine instead
+       (https://docs.docker.com/engine/install/) and run this again." 2
 fi
 
 # 3. a CLI pointed at another machine: everything below edits THIS machine
@@ -55,7 +59,8 @@ else
     endpoint="$DOCKER_HOST"
 fi
 case "$endpoint" in
-    ""|unix://*|npipe://*) ;;
+    ""|unix:///var/run/docker.sock|unix:///run/docker.sock|npipe://*) ;;
+    unix://*) fail "the Docker CLI talks to a daemon on ${endpoint}, not the system daemon this script configures (/etc/docker/daemon.json, service docker). Point it at the default socket or configure that daemon by hand." 2 ;;
     *) fail "the Docker CLI talks to a remote daemon (${endpoint}); run this script on that host, it configures the local Docker only." 2 ;;
 esac
 
@@ -109,11 +114,12 @@ case "$(uname -m)" in
 esac
 
 configured() {
-    command -v nvidia-ctk >/dev/null 2>&1 && docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'
+    # a legacy or hand-made registration counts too; nvidia-ctk is only needed to make one
+    docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'
 }
 
 if configured; then
-    say "NVIDIA Container Toolkit is already installed and Docker lists the nvidia runtime."
+    say "Docker already lists the nvidia runtime; nothing to install."
 elif command -v nvidia-ctk >/dev/null 2>&1; then
     # packages present, runtime entry missing: no network work, just register
     say "nvidia-container-toolkit is installed but Docker does not list the nvidia runtime."
@@ -184,13 +190,13 @@ fi
 if [[ "${UNSLOTH_TOOLKIT_VERIFY:-1}" != 0 ]]; then
     say "Verifying: docker run --rm --gpus all --platform ${PLATFORM} ubuntu:24.04 nvidia-smi -L"
     if ! docker run --rm --gpus all --platform "${PLATFORM}" ubuntu:24.04 nvidia-smi -L; then
-        fail "a container could not see the GPU. If this host is WSL 2 without Docker Desktop, make
-       sure the Windows NVIDIA driver is current (wsl --update); otherwise see
+        fail "a container could not see the GPU. On WSL 2 install a current NVIDIA Windows driver
+       from nvidia.com (wsl --update updates WSL itself, not the driver); otherwise see
        https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/troubleshooting.html"
     fi
 fi
 if grep -qi microsoft "$PROC_VERSION" 2>/dev/null; then
-    say "WSL 2 host: the GPU is the Windows driver's; keep it current with the NVIDIA installer."
+    say "WSL 2 host: the GPU comes from the Windows NVIDIA driver; update it with NVIDIA's Windows installer."
 fi
 if ! driver_ok; then
     # the toolkit is in place, but the image's CUDA 12.8 stack will not start on this

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -16,20 +16,42 @@
 #   UNSLOTH_DESTDIR            prefix for /etc and /usr/share paths (tests only)
 #   UNSLOTH_OS_RELEASE         alternative os-release file (tests only)
 #   UNSLOTH_PROC_VERSION       alternative /proc/version file (tests only)
+#   UNSLOTH_RUN_USER_DIR       alternative /run/user (tests only)
 set -euo pipefail
 
 DESTDIR="${UNSLOTH_DESTDIR:-}"
 OS_RELEASE="${UNSLOTH_OS_RELEASE:-/etc/os-release}"
 PROC_VERSION="${UNSLOTH_PROC_VERSION:-/proc/version}"
+RUN_USER_DIR="${UNSLOTH_RUN_USER_DIR:-/run/user}"
 BASE="https://nvidia.github.io/libnvidia-container"
 
 say()  { printf '%s\n' "$*"; }
-fail() { printf 'ERROR: %s\n' "$*" >&2; exit "${2:-1}"; }
+fail() { printf 'ERROR: %s\n' "$1" >&2; exit "${2:-1}"; }
+
+command -v docker >/dev/null 2>&1 \
+    || fail "docker is not installed. Install Docker Engine first (https://docs.docker.com/engine/install/), then run this again." 2
+
+# Docker Desktop (macOS, or Windows with the WSL 2 backend) ships its own GPU
+# integration: nothing to install on that side, and apt inside the WSL distro would
+# configure a daemon Docker Desktop does not use. Checked before asking for sudo.
+if docker info 2>/dev/null | grep -qi 'Operating System: Docker Desktop'; then
+    say "Docker Desktop detected: GPU support comes with it, nothing to install."
+    say "On Windows keep the WSL 2 backend on and the NVIDIA Windows driver current (wsl --update)."
+    exit 0
+fi
 
 # Rootless Docker keeps its daemon and config under the user; the system-wide steps
 # below would configure a daemon that user never talks to. NVIDIA documents the
-# rootless procedure separately. Checked before elevating: root sees another daemon.
-if docker info --format '{{join .SecurityOptions ","}}' 2>/dev/null | grep -q rootless; then
+# rootless procedure separately. Checked before elevating, because root sees another
+# daemon; `curl | sudo bash` arrives already root with DOCKER_HOST stripped, so the
+# invoking user's socket is looked up through SUDO_UID as well.
+rootless_daemon() {
+    docker info --format '{{join .SecurityOptions ","}}' 2>/dev/null | grep -q rootless && return 0
+    [[ -n "${SUDO_UID:-}" && -S "${RUN_USER_DIR}/${SUDO_UID}/docker.sock" ]] \
+        && DOCKER_HOST="unix://${RUN_USER_DIR}/${SUDO_UID}/docker.sock" \
+           docker info --format '{{join .SecurityOptions ","}}' 2>/dev/null | grep -q rootless
+}
+if rootless_daemon; then
     fail "rootless Docker detected. Follow NVIDIA's rootless procedure instead:
        https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#rootless-mode" 2
 fi
@@ -41,15 +63,6 @@ if [[ "$(id -u)" != 0 ]]; then
         exec sudo -E bash "$0" "$@"
     fi
     fail "run this as root: pipe it into 'sudo bash', or 'sudo bash docker/install_nvidia_toolkit.sh'." 2
-fi
-
-# Docker Desktop (macOS, or Windows with the WSL 2 backend) ships its own GPU
-# integration: nothing to install on that side, and apt inside the WSL distro would
-# configure a daemon Docker Desktop does not use.
-if docker info 2>/dev/null | grep -qi 'Operating System: Docker Desktop'; then
-    say "Docker Desktop detected: GPU support comes with it, nothing to install."
-    say "On Windows keep the WSL 2 backend on and the NVIDIA Windows driver current (wsl --update)."
-    exit 0
 fi
 
 if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi -L 2>/dev/null | grep -q '^GPU'; then
@@ -89,6 +102,7 @@ else
             apt-get install -y -qq nvidia-container-toolkit
             ;;
         *" rhel "*|*" fedora "*|*" centos "*|*" amzn "*|*" rocky "*|*" almalinux "*)
+            command -v curl >/dev/null 2>&1 || { command -v dnf >/dev/null 2>&1 && dnf install -y curl || yum install -y curl; }
             mkdir -p "${DESTDIR}/etc/yum.repos.d"
             curl -fsSL "${BASE}/stable/rpm/nvidia-container-toolkit.repo" \
                 > "${DESTDIR}/etc/yum.repos.d/nvidia-container-toolkit.repo"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -129,7 +129,7 @@ elif [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia \
             ;;
         *)
             printf "      Install it with one command (Linux, needs sudo):\n" >&2
-            printf "      curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo -E bash\n\n" >&2
+            printf "      curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh -o install_nvidia_toolkit.sh && sudo -E bash install_nvidia_toolkit.sh\n\n" >&2
             ;;
     esac
 fi

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -94,11 +94,8 @@ if [[ ${#GPU_FLAG[@]} -gt 0 ]] && ! host_has_nvidia; then
     printf "\n" >&2
 fi
 
-# A GPU host whose Docker has no nvidia runtime is missing the NVIDIA Container
-# Toolkit, which is the one thing the image cannot bring along. Offer to install it
-# (install_nvidia_toolkit.sh, NVIDIA's own recipe) rather than let --gpus fail at
-# the daemon with exit 125. UNSLOTH_INSTALL_TOOLKIT=1 says yes without a prompt,
-# =0 never asks; with neither and no terminal, print the one-liner and continue.
+# A GPU host with no nvidia runtime would fail --gpus at the daemon with exit 125, so offer the installer.
+# UNSLOTH_INSTALL_TOOLKIT=1 says yes without a prompt, =0 never asks; with neither and no terminal, print the one-liner and continue.
 DOCKER_INFO=""
 DOCKER_ERR=""
 if [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia; then
@@ -106,8 +103,6 @@ if [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia; then
     DOCKER_INFO="$(docker info 2>&1)" || { DOCKER_ERR="$DOCKER_INFO"; DOCKER_INFO=""; }
 fi
 if [[ -n "$DOCKER_ERR" ]]; then
-    # no daemon, or no permission on its socket: an install offer would be the wrong
-    # answer, and the docker run below fails with the same message
     printf "\033[1;33mWARN:\033[0m 'docker info' failed, so the GPU runtime could not be checked:\n      %s\n" "${DOCKER_ERR##*$'\n'}" >&2
     printf "      Start the Docker daemon, or add yourself to the docker group (newgrp docker).\n\n" >&2
 elif [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia \
@@ -122,9 +117,7 @@ elif [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia \
     fi
     case "$answer" in
         1|[Yy]*)
-            # -E keeps UNSLOTH_TOOLKIT_VERIFY and proxy settings through sudo's env_reset.
-            # An offer, not a precondition: a failed, cancelled or driver-too-old install
-            # (exit 3, toolkit working) must not take run.sh down before docker run.
+            # -E keeps UNSLOTH_TOOLKIT_VERIFY and the proxy settings through env_reset; a failed, cancelled or driver-too-old install (exit 3) must not stop the docker run below.
             if [[ "$(id -u)" = 0 ]]; then bash "$INSTALLER" || true; else sudo -E bash "$INSTALLER" || true; fi
             ;;
         *)

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -99,8 +99,21 @@ fi
 # (install_nvidia_toolkit.sh, NVIDIA's own recipe) rather than let --gpus fail at
 # the daemon with exit 125. UNSLOTH_INSTALL_TOOLKIT=1 says yes without a prompt,
 # =0 never asks; with neither and no terminal, print the one-liner and continue.
-if [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia \
-        && ! docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'; then
+DOCKER_INFO=""
+DOCKER_ERR=""
+if [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia; then
+    if ! DOCKER_INFO="$(docker info 2>"${TMPDIR:-/tmp}/unsloth-docker-info.$$")"; then
+        DOCKER_ERR="$(cat "${TMPDIR:-/tmp}/unsloth-docker-info.$$" 2>/dev/null)"
+    fi
+    rm -f "${TMPDIR:-/tmp}/unsloth-docker-info.$$"
+fi
+if [[ -n "$DOCKER_ERR" ]]; then
+    # no daemon, or no permission on its socket: an install offer would be the wrong
+    # answer, and the docker run below fails with the same message
+    printf "\033[1;33mWARN:\033[0m 'docker info' failed, so the GPU runtime could not be checked:\n      %s\n" "${DOCKER_ERR##*$'\n'}" >&2
+    printf "      Start the Docker daemon, or add yourself to the docker group (newgrp docker).\n\n" >&2
+elif [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia \
+        && ! grep -qi 'Runtimes:.*nvidia' <<<"$DOCKER_INFO"; then
     INSTALLER="$(dirname "${BASH_SOURCE[0]}")/install_nvidia_toolkit.sh"
     printf "\033[1;33mWARN:\033[0m 'docker info' does not list 'nvidia' as a runtime: the NVIDIA\n" >&2
     printf "      Container Toolkit is not set up, so --gpus %s would fail at the daemon.\n" "$GPUS" >&2
@@ -118,7 +131,7 @@ if [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia \
             ;;
         *)
             printf "      Install it with one command (Linux, needs sudo):\n" >&2
-            printf "      curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo bash\n\n" >&2
+            printf "      curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo -E bash\n\n" >&2
             ;;
     esac
 fi

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -111,8 +111,10 @@ if [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia \
     fi
     case "$answer" in
         1|[Yy]*)
-            # -E: keep UNSLOTH_TOOLKIT_VERIFY and proxy settings through sudo's env_reset
-            if [[ "$(id -u)" = 0 ]]; then bash "$INSTALLER"; else sudo -E bash "$INSTALLER"; fi
+            # -E keeps UNSLOTH_TOOLKIT_VERIFY and proxy settings through sudo's env_reset.
+            # An offer, not a precondition: a failed, cancelled or driver-too-old install
+            # (exit 3, toolkit working) must not take run.sh down before docker run.
+            if [[ "$(id -u)" = 0 ]]; then bash "$INSTALLER" || true; else sudo -E bash "$INSTALLER" || true; fi
             ;;
         *)
             printf "      Install it with one command (Linux, needs sudo):\n" >&2

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -111,7 +111,8 @@ if [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia \
     fi
     case "$answer" in
         1|[Yy]*)
-            if [[ "$(id -u)" = 0 ]]; then bash "$INSTALLER"; else sudo bash "$INSTALLER"; fi
+            # -E: keep UNSLOTH_TOOLKIT_VERIFY and proxy settings through sudo's env_reset
+            if [[ "$(id -u)" = 0 ]]; then bash "$INSTALLER"; else sudo -E bash "$INSTALLER"; fi
             ;;
         *)
             printf "      Install it with one command (Linux, needs sudo):\n" >&2

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -102,10 +102,8 @@ fi
 DOCKER_INFO=""
 DOCKER_ERR=""
 if [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia; then
-    if ! DOCKER_INFO="$(docker info 2>"${TMPDIR:-/tmp}/unsloth-docker-info.$$")"; then
-        DOCKER_ERR="$(cat "${TMPDIR:-/tmp}/unsloth-docker-info.$$" 2>/dev/null)"
-    fi
-    rm -f "${TMPDIR:-/tmp}/unsloth-docker-info.$$"
+    # stderr folded in: on failure the captured text IS the daemon's error
+    DOCKER_INFO="$(docker info 2>&1)" || { DOCKER_ERR="$DOCKER_INFO"; DOCKER_INFO=""; }
 fi
 if [[ -n "$DOCKER_ERR" ]]; then
     # no daemon, or no permission on its socket: an install offer would be the wrong

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -94,11 +94,30 @@ if [[ ${#GPU_FLAG[@]} -gt 0 ]] && ! host_has_nvidia; then
     printf "\n" >&2
 fi
 
-# warn, do not abort: some setups report runtimes differently
-if [[ ${#GPU_FLAG[@]} -gt 0 ]] && ! docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'; then
-    printf "\033[1;33mWARN:\033[0m 'docker info' does not list 'nvidia' as a runtime.\n" >&2
-    printf "      If --gpus all fails below, install nvidia-container-toolkit:\n" >&2
-    printf "      https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html\n\n" >&2
+# A GPU host whose Docker has no nvidia runtime is missing the NVIDIA Container
+# Toolkit, which is the one thing the image cannot bring along. Offer to install it
+# (install_nvidia_toolkit.sh, NVIDIA's own recipe) rather than let --gpus fail at
+# the daemon with exit 125. UNSLOTH_INSTALL_TOOLKIT=1 says yes without a prompt,
+# =0 never asks; with neither and no terminal, print the one-liner and continue.
+if [[ ${#GPU_FLAG[@]} -gt 0 ]] && host_has_nvidia \
+        && ! docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'; then
+    INSTALLER="$(dirname "${BASH_SOURCE[0]}")/install_nvidia_toolkit.sh"
+    printf "\033[1;33mWARN:\033[0m 'docker info' does not list 'nvidia' as a runtime: the NVIDIA\n" >&2
+    printf "      Container Toolkit is not set up, so --gpus %s would fail at the daemon.\n" "$GPUS" >&2
+    answer="${UNSLOTH_INSTALL_TOOLKIT:-}"
+    if [[ -z "$answer" && -t 0 && -t 1 ]]; then
+        read -r -p "      Install it now with sudo (bash $INSTALLER)? [Y/n] " answer </dev/tty || answer=n
+        answer="${answer:-y}"
+    fi
+    case "$answer" in
+        1|[Yy]*)
+            if [[ "$(id -u)" = 0 ]]; then bash "$INSTALLER"; else sudo bash "$INSTALLER"; fi
+            ;;
+        *)
+            printf "      Install it with one command (Linux, needs sudo):\n" >&2
+            printf "      curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo bash\n\n" >&2
+            ;;
+    esac
 fi
 
 # Only if set, else an empty string shadows the image's. The dash-only `-e VAR` form

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-Present the Unsloth team. See /studio/LICENSE.AGPL-3.0
+
+"""docker/install_nvidia_toolkit.sh sets up the one host-side piece the image cannot
+carry: the NVIDIA Container Toolkit. Every package manager, restart and verification
+path runs here against stubs, and docker/run.sh's offer to run it is checked too."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "docker" / "install_nvidia_toolkit.sh"
+RUN_SH = REPO_ROOT / "docker" / "run.sh"
+
+OS_RELEASE = {
+    "ubuntu": 'ID=ubuntu\nID_LIKE=debian\nVERSION_ID="24.04"\n',
+    "debian": "ID=debian\nVERSION_ID=12\n",
+    "rhel": 'ID="rhel"\nID_LIKE="fedora"\nVERSION_ID="9.4"\n',
+    "fedora": "ID=fedora\nVERSION_ID=41\n",
+    "amzn": 'ID="amzn"\nID_LIKE="fedora"\nVERSION_ID="2023"\n',
+    "rocky": 'ID="rocky"\nID_LIKE="rhel centos fedora"\n',
+    "suse": 'ID="opensuse-leap"\nID_LIKE="suse opensuse"\n',
+    "alpine": "ID=alpine\n",
+}
+
+
+def _stub(path: Path, body: str) -> None:
+    path.write_text("#!/usr/bin/env bash\n" + body, encoding = "utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _setup(
+    tmp_path: Path,
+    *,
+    distro: str = "ubuntu",
+    driver: bool = True,
+    configured: bool = False,
+    desktop: bool = False,
+    systemctl: str = "ok",
+    verify_ok: bool = True,
+    uid: int = 0,
+    wsl: bool = False,
+) -> tuple[Path, Path, dict]:
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    root = tmp_path / "root"
+    root.mkdir()
+    log = tmp_path / "calls.log"
+    marker = tmp_path / "configured"
+    if configured:
+        marker.write_text("", encoding = "utf-8")
+    rec = f'echo "$(basename "$0") $*" >> {log}\n'
+    _stub(bindir / "id", f'echo {uid}\n')
+    _stub(bindir / "sudo", rec + "exit 0\n")
+    _stub(
+        bindir / "nvidia-smi",
+        'echo "GPU 0: NVIDIA H100 (UUID: GPU-abc)"\n' if driver else "exit 9\n",
+    )
+    _stub(bindir / "nvidia-ctk", rec + f"touch {marker}\n")
+    _stub(
+        bindir / "docker",
+        rec
+        + 'if [ "$1" = info ]; then\n'
+        + ('  echo " Operating System: Docker Desktop"\n' if desktop else "")
+        + f'  if [ -e {marker} ]; then echo " Runtimes: io.containerd.runc.v2 nvidia runc"; else echo " Runtimes: io.containerd.runc.v2 runc"; fi\n'
+        + "  exit 0\nfi\n"
+        + ("exit 0\n" if verify_ok else 'echo "docker: could not select device driver" >&2; exit 125\n'),
+    )
+    for pm in ("apt-get", "dnf", "yum", "zypper", "service"):
+        _stub(bindir / pm, rec + "exit 0\n")
+    if systemctl == "ok":
+        _stub(bindir / "systemctl", rec + "exit 0\n")
+    elif systemctl == "fails":
+        _stub(bindir / "systemctl", rec + "exit 1\n")
+    _stub(
+        bindir / "curl",
+        rec
+        + 'case "$*" in\n'
+        '  *gpgkey) printf "FAKE-ARMORED-KEY\\n" ;;\n'
+        '  *.list) printf "deb https://nvidia.github.io/libnvidia-container/stable/deb/\\$(ARCH) /\\n" ;;\n'
+        '  *.repo) printf "[nvidia-container-toolkit]\\nbaseurl=https://nvidia.github.io/libnvidia-container/stable/rpm/\\$basearch\\n" ;;\n'
+        "esac\n",
+    )
+    _stub(
+        bindir / "gpg",
+        rec + 'while [ $# -gt 0 ]; do if [ "$1" = -o ]; then out="$2"; shift; fi; shift; done\n'
+        'printf "DEARMORED:"; cat > "$out"\n',
+    )
+    osr = tmp_path / "os-release"
+    osr.write_text(OS_RELEASE[distro], encoding = "utf-8")
+    procv = tmp_path / "proc-version"
+    procv.write_text(
+        "Linux version 5.15.167.4-microsoft-standard-WSL2\n" if wsl else "Linux version 6.8.0-45-generic\n",
+        encoding = "utf-8",
+    )
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}{os.pathsep}" + env["PATH"]
+    env["UNSLOTH_DESTDIR"] = str(root)
+    env["UNSLOTH_OS_RELEASE"] = str(osr)
+    env["UNSLOTH_PROC_VERSION"] = str(procv)
+    env.pop("UNSLOTH_TOOLKIT_VERIFY", None)
+    return root, log, env
+
+
+def _run(env: dict, script: Path = INSTALLER, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    e = dict(env)
+    e.update(extra_env or {})
+    return subprocess.run(["bash", str(script)], capture_output = True, text = True, env = e, timeout = 60)
+
+
+def _calls(log: Path) -> list[str]:
+    return log.read_text(encoding = "utf-8").splitlines() if log.exists() else []
+
+
+def test_ubuntu_gets_the_apt_recipe_then_docker_is_configured_restarted_and_verified(tmp_path: Path):
+    root, log, env = _setup(tmp_path, distro = "ubuntu")
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    calls = _calls(log)
+    assert "apt-get update -qq" in calls
+    assert any(c.startswith("apt-get install") and c.endswith("nvidia-container-toolkit") for c in calls)
+    key = root / "usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+    assert key.read_text(encoding = "utf-8") == "FAKE-ARMORED-KEY\n"
+    lst = (root / "etc/apt/sources.list.d/nvidia-container-toolkit.list").read_text(encoding = "utf-8")
+    assert lst.startswith("deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://")
+    assert "nvidia-ctk runtime configure --runtime=docker" in calls
+    assert "systemctl restart docker" in calls
+    assert calls[-1] == "docker run --rm --gpus all --platform linux/amd64 ubuntu:24.04 nvidia-smi -L"
+    assert not any(c.startswith(("dnf", "yum", "zypper")) for c in calls)
+
+
+@pytest.mark.parametrize("distro", ["rhel", "fedora", "amzn", "rocky"])
+def test_rpm_distributions_use_dnf_and_the_repo_file(tmp_path: Path, distro: str):
+    root, log, env = _setup(tmp_path, distro = distro)
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    calls = _calls(log)
+    assert "dnf install -y nvidia-container-toolkit" in calls
+    repo = (root / "etc/yum.repos.d/nvidia-container-toolkit.repo").read_text(encoding = "utf-8")
+    assert repo.startswith("[nvidia-container-toolkit]")
+    assert not any(c.startswith(("apt-get", "yum", "zypper")) for c in calls)
+    assert "nvidia-ctk runtime configure --runtime=docker" in calls
+
+
+def test_yum_when_dnf_is_absent(tmp_path: Path):
+    root, log, env = _setup(tmp_path, distro = "rhel")
+    (tmp_path / "bin" / "dnf").unlink()
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "yum install -y nvidia-container-toolkit" in _calls(log)
+
+
+def test_suse_uses_zypper(tmp_path: Path):
+    _, log, env = _setup(tmp_path, distro = "suse")
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    calls = _calls(log)
+    assert any(c.startswith("zypper --non-interactive ar https://nvidia.github.io/") for c in calls)
+    assert "zypper --non-interactive --gpg-auto-import-keys install nvidia-container-toolkit" in calls
+    assert not any(c.startswith(("apt-get", "dnf", "yum")) for c in calls)
+
+
+def test_an_unknown_distribution_stops_before_touching_anything(tmp_path: Path):
+    _, log, env = _setup(tmp_path, distro = "alpine")
+    res = _run(env)
+    assert res.returncode == 2
+    assert "unrecognised distribution" in res.stderr
+    assert "install-guide" in res.stderr
+    assert not any(c.startswith(("apt-get", "dnf", "yum", "zypper", "nvidia-ctk")) for c in _calls(log))
+
+
+def test_no_driver_means_stop_and_say_how_to_get_one(tmp_path: Path):
+    _, log, env = _setup(tmp_path, driver = False)
+    res = _run(env)
+    assert res.returncode == 2
+    assert "no NVIDIA driver found" in res.stderr
+    assert "570.26" in res.stderr
+    assert not any(c.startswith(("apt-get", "nvidia-ctk", "docker run")) for c in _calls(log))
+
+
+def test_a_configured_host_only_verifies(tmp_path: Path):
+    _, log, env = _setup(tmp_path, configured = True)
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "already installed" in res.stdout
+    calls = _calls(log)
+    assert not any(c.startswith(("apt-get", "nvidia-ctk", "systemctl", "service")) for c in calls)
+    assert "docker run --rm --gpus all --platform linux/amd64 ubuntu:24.04 nvidia-smi -L" in calls
+
+
+def test_docker_desktop_needs_nothing(tmp_path: Path):
+    _, log, env = _setup(tmp_path, desktop = True, driver = False)
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "Docker Desktop detected" in res.stdout
+    assert _calls(log) == ["docker info"]
+
+
+@pytest.mark.parametrize("systemctl", ["missing", "fails"])
+def test_without_a_working_systemctl_the_service_command_restarts_docker(tmp_path: Path, systemctl: str):
+    _, log, env = _setup(tmp_path, systemctl = systemctl, wsl = True)
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "service docker restart" in _calls(log)
+    assert "WSL 2 host" in res.stdout
+
+
+def test_a_failed_verification_is_an_error_with_a_pointer(tmp_path: Path):
+    _, _, env = _setup(tmp_path, verify_ok = False)
+    res = _run(env)
+    assert res.returncode == 1
+    assert "could not see the GPU" in res.stderr
+    assert "troubleshooting" in res.stderr
+
+
+def test_verification_can_be_skipped(tmp_path: Path):
+    _, log, env = _setup(tmp_path, verify_ok = False)
+    res = _run(env, extra_env = {"UNSLOTH_TOOLKIT_VERIFY": "0"})
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert not any(c.startswith("docker run") for c in _calls(log))
+
+
+def test_a_non_root_run_of_the_file_re_executes_itself_under_sudo(tmp_path: Path):
+    _, log, env = _setup(tmp_path, uid = 1000)
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert _calls(log) == [f"sudo -E bash {INSTALLER}"]
+
+
+def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):
+    _, log, env = _setup(tmp_path, uid = 1000)
+    res = subprocess.run(
+        ["bash", "-s"], input = INSTALLER.read_text(encoding = "utf-8"),
+        capture_output = True, text = True, env = env, timeout = 60,
+    )
+    assert res.returncode == 2
+    assert "sudo bash" in res.stderr
+    assert _calls(log) == []
+
+
+def _run_sh_env(tmp_path: Path, *, nvidia_runtime: bool) -> tuple[Path, Path, dict]:
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "calls.log"
+    argv = tmp_path / "argv"
+    rec = f'echo "$(basename "$0") $*" >> {log}\n'
+    runtimes = "io.containerd.runc.v2 nvidia runc" if nvidia_runtime else "io.containerd.runc.v2 runc"
+    _stub(
+        bindir / "docker",
+        rec + f'if [ "$1" = info ]; then echo " Runtimes: {runtimes}"; exit 0; fi\n'
+        f'printf "%s\\n" "$@" > {argv}\nexit 0\n',
+    )
+    _stub(bindir / "nvidia-smi", 'echo "GPU 0: NVIDIA H100 (UUID: GPU-abc)"\n')
+    _stub(bindir / "sudo", rec + "exit 0\n")
+    _stub(bindir / "getent", "exit 2\n")
+    dev_root = tmp_path / "root"
+    (dev_root / "dev").mkdir(parents = True)
+    (dev_root / "dev" / "nvidiactl").write_text("", encoding = "utf-8")
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}{os.pathsep}" + env["PATH"]
+    env["UNSLOTH_DEV_ROOT"] = str(dev_root)
+    env["HF_HOME"] = str(tmp_path / "hf")
+    env["TRITON_CACHE_DIR"] = str(tmp_path / "triton")
+    env.pop("UNSLOTH_INSTALL_TOOLKIT", None)
+    return log, argv, env
+
+
+def _run_run_sh(env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(RUN_SH), "true"], capture_output = True, text = True, env = env,
+        stdin = subprocess.DEVNULL, timeout = 60,
+    )
+
+
+def test_run_sh_installs_the_toolkit_when_told_to_then_runs(tmp_path: Path):
+    log, argv, env = _run_sh_env(tmp_path, nvidia_runtime = False)
+    env["UNSLOTH_INSTALL_TOOLKIT"] = "1"
+    res = _run_run_sh(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert f"sudo bash {INSTALLER}" in _calls(log)
+    assert "--gpus\nall\n" in argv.read_text(encoding = "utf-8")
+
+
+def test_run_sh_without_a_terminal_prints_the_one_liner_and_still_runs(tmp_path: Path):
+    log, argv, env = _run_sh_env(tmp_path, nvidia_runtime = False)
+    res = _run_run_sh(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "install_nvidia_toolkit.sh | sudo bash" in res.stderr
+    assert not any(c.startswith("sudo") for c in _calls(log))
+    assert argv.exists()
+
+
+def test_run_sh_is_quiet_when_the_runtime_is_present(tmp_path: Path):
+    _, _, env = _run_sh_env(tmp_path, nvidia_runtime = True)
+    res = _run_run_sh(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "Container Toolkit" not in res.stderr
+
+
+def test_the_docs_point_at_the_installer():
+    for doc in (REPO_ROOT / "docker" / "DOCKERHUB.md", REPO_ROOT / "README.md"):
+        text = doc.read_text(encoding = "utf-8")
+        assert "docker/install_nvidia_toolkit.sh | sudo bash" in text, doc
+    assert "Docker Desktop" in (REPO_ROOT / "docker" / "DOCKERHUB.md").read_text(encoding = "utf-8")

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -35,8 +35,20 @@ OS_RELEASE = {
 # that reaches for an absent command (dnf gone, systemctl gone) must find nothing,
 # never the runner's own package manager or init.
 _REAL_TOOLS = (
-    "bash", "grep", "sed", "head", "tr", "sort", "mkdir", "cat", "basename", "dirname",
-    "touch", "cut", "rm", "true",
+    "bash",
+    "grep",
+    "sed",
+    "head",
+    "tr",
+    "sort",
+    "mkdir",
+    "cat",
+    "basename",
+    "dirname",
+    "touch",
+    "cut",
+    "rm",
+    "true",
 )
 
 
@@ -104,7 +116,11 @@ def _setup(
             '    case "${DOCKER_HOST:-}" in *docker.sock) echo "name=rootless,name=seccomp" ;; *) echo "name=seccomp" ;; esac; exit 0\n'
             "  fi\n"
             if rootless == "via_sudo_uid"
-            else ('  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n' if rootless else "")
+            else (
+                '  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n'
+                if rootless
+                else ""
+            )
         )
         + f'  if [ -e {marker} ]; then echo " Runtimes: io.containerd.runc.v2 nvidia runc"; else echo " Runtimes: io.containerd.runc.v2 runc"; fi\n'
         + "  exit 0\nfi\n"
@@ -399,7 +415,10 @@ def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):
 
 
 def _run_sh_env(
-    tmp_path: Path, *, nvidia_runtime: bool, docker_down: bool = False
+    tmp_path: Path,
+    *,
+    nvidia_runtime: bool,
+    docker_down: bool = False,
 ) -> tuple[Path, Path, dict]:
     bindir = tmp_path / "bin"
     bindir.mkdir()
@@ -416,8 +435,7 @@ def _run_sh_env(
     )
     _stub(
         bindir / "docker",
-        rec + f'if [ "$1" = info ]; then {info}; fi\n'
-        f'printf "%s\\n" "$@" > {argv}\nexit 0\n',
+        rec + f'if [ "$1" = info ]; then {info}; fi\n' f'printf "%s\\n" "$@" > {argv}\nexit 0\n',
     )
     _stub(bindir / "nvidia-smi", 'echo "GPU 0: NVIDIA H100 (UUID: GPU-abc)"\n')
     _stub(bindir / "sudo", rec + "exit 0\n")

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -110,14 +110,16 @@ def _setup(
     # suite means the same thing on an arm64 runner
     _stub(bindir / "uname", 'if [ "$1" = -s ]; then echo Linux; else echo x86_64; fi\n')
     ctk = bindir / "nvidia-ctk"
+    runtime = bindir / "nvidia-container-runtime"
     ctk_body = rec + f"touch {marker}\n"
     if configured or toolkit_installed:
         _stub(ctk, ctk_body)
+        _stub(runtime, "exit 0\n")
     (tmp_path / "ctk-stub-body").write_text("#!/usr/bin/env bash\n" + ctk_body, encoding = "utf-8")
     _stub(
         bindir / "docker",
         rec
-        + 'if [ "$1" = context ]; then case "${DOCKER_CONTEXT:-}" in remote*) echo "tcp://gpu-box:2376" ;; *) echo "unix:///var/run/docker.sock" ;; esac; exit 0; fi\n'
+        + 'if [ "$1" = context ]; then case "${DOCKER_CONTEXT:-}" in remote*) echo "tcp://gpu-box:2376" ;; missing*) echo "context not found" >&2; exit 1 ;; *) echo "unix:///var/run/docker.sock" ;; esac; exit 0; fi\n'
         + 'if [ "$1" = info ]; then\n'
         + ('  echo " Operating System: Docker Desktop"\n' if desktop else "")
         + (
@@ -140,7 +142,10 @@ def _setup(
         ),
     )
     # installing the package makes nvidia-ctk appear, as it does for real
-    installs = f'case "$*" in *install*nvidia-container-toolkit*) cp {tmp_path / "ctk-stub-body"} {ctk}; chmod 755 {ctk} ;; esac\n'
+    installs = (
+        f'case "$*" in *install*nvidia-container-toolkit*) cp {tmp_path / "ctk-stub-body"} {ctk}; chmod 755 {ctk};'
+        f' printf "#!/usr/bin/env bash\\nexit 0\\n" > {runtime}; chmod 755 {runtime} ;; esac\n'
+    )
     for pm in ("apt-get", "dnf", "yum", "zypper"):
         _stub(bindir / pm, rec + installs + "exit 0\n")
     _stub(bindir / "service", rec + "exit 0\n")
@@ -406,6 +411,36 @@ def test_the_keyring_is_world_readable_under_a_strict_umask(tmp_path: Path):
     assert res.returncode == 0, res.stdout + res.stderr
     key = root / "usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
     assert oct(key.stat().st_mode & 0o777) == "0o644"
+
+
+def test_an_uninspectable_context_is_an_error_not_the_local_daemon(tmp_path: Path):
+    _, log, env = _setup(tmp_path)
+    env["DOCKER_CONTEXT"] = "missing-in-root-config"
+    res = _run(env)
+    assert res.returncode == 2
+    assert "cannot inspect the Docker context 'missing-in-root-config'" in res.stderr
+    assert not any(c.startswith(("apt-get", "nvidia-ctk", "systemctl")) for c in _calls(log))
+
+
+def test_no_gpu_on_wsl_points_at_the_windows_driver(tmp_path: Path):
+    _, log, env = _setup(tmp_path, driver = False, wsl = True)
+    res = _run(env)
+    assert res.returncode == 2
+    assert "NVIDIA Windows driver" in res.stderr and "never a Linux driver" in res.stderr
+    assert "ubuntu-drivers" not in res.stderr
+    assert not any(c.startswith("apt-get") for c in _calls(log))
+
+
+def test_only_the_toolkit_cli_present_still_installs_the_full_package(tmp_path: Path):
+    """nvidia-container-toolkit-base ships nvidia-ctk without the runtime binary; a
+    registration on its own would be unusable."""
+    _, log, env = _setup(tmp_path, toolkit_installed = True)
+    (tmp_path / "bin" / "nvidia-container-runtime").unlink()
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    calls = _calls(log)
+    assert any(c.startswith("apt-get install") and c.endswith("nvidia-container-toolkit") for c in calls)
+    assert "nvidia-ctk runtime configure --runtime=docker" in calls
 
 
 def test_a_remote_docker_endpoint_is_refused(tmp_path: Path):

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -46,6 +46,7 @@ _REAL_TOOLS = (
     "basename",
     "dirname",
     "touch",
+    "mv",
     "cut",
     "rm",
     "true",
@@ -108,7 +109,7 @@ def _setup(
     _stub(
         bindir / "docker",
         rec
-        + 'if [ "$1" = context ]; then echo "unix:///var/run/docker.sock"; exit 0; fi\n'
+        + 'if [ "$1" = context ]; then case "${DOCKER_CONTEXT:-}" in remote*) echo "tcp://gpu-box:2376" ;; *) echo "unix:///var/run/docker.sock" ;; esac; exit 0; fi\n'
         + 'if [ "$1" = info ]; then\n'
         + ('  echo " Operating System: Docker Desktop"\n' if desktop else "")
         + (
@@ -140,7 +141,7 @@ def _setup(
         bindir / "curl",
         rec + 'case "$*" in\n'
         '  *gpgkey) printf "FAKE-ARMORED-KEY\\n" ;;\n'
-        '  *.list) printf "deb https://nvidia.github.io/libnvidia-container/stable/deb/\\$(ARCH) /\\n" ;;\n'
+        '  *.list) if [ -e "$LIST_DOWNLOAD_FAILS" ]; then echo "curl: (22) 503" >&2; exit 22; fi; printf "deb https://nvidia.github.io/libnvidia-container/stable/deb/\\$(ARCH) /\\n" ;;\n'
         '  *.repo) printf "[nvidia-container-toolkit]\\nbaseurl=https://nvidia.github.io/libnvidia-container/stable/rpm/\\$basearch\\n" ;;\n'
         "esac\n",
     )
@@ -161,12 +162,15 @@ def _setup(
     env = dict(os.environ)
     env["PATH"] = _isolated_path(tmp_path, bindir)
     env["UNSLOTH_DESTDIR"] = str(root)
+    env["LIST_DOWNLOAD_FAILS"] = str(tmp_path / "list-download-fails")
     env["UNSLOTH_OS_RELEASE"] = str(osr)
     env["UNSLOTH_PROC_VERSION"] = str(procv)
     env["UNSLOTH_RUN_USER_DIR"] = str(tmp_path / "run-user")
+    env["UNSLOTH_WSL_LIB_DIR"] = str(tmp_path / "wsl-lib")
     env.pop("UNSLOTH_TOOLKIT_VERIFY", None)
     env.pop("SUDO_UID", None)
     env.pop("DOCKER_HOST", None)
+    env.pop("DOCKER_CONTEXT", None)
     return root, log, env
 
 
@@ -320,6 +324,42 @@ def test_without_docker_the_script_says_so(tmp_path: Path):
     assert res.returncode == 2
     assert "docker is not installed" in res.stderr
     assert _calls(log) == []
+
+
+def test_docker_context_wins_over_a_local_docker_host(tmp_path: Path):
+    _, log, env = _setup(tmp_path, uid = 1000)
+    env["DOCKER_HOST"] = "unix:///var/run/docker.sock"
+    env["DOCKER_CONTEXT"] = "remote-gpu"
+    res = _run(env)
+    assert res.returncode == 2
+    assert "remote daemon (tcp://gpu-box:2376)" in res.stderr
+    assert not any(c.startswith(("sudo", "apt-get")) for c in _calls(log))
+
+
+def test_nvidia_smi_is_found_in_the_wsl_library_dir_after_sudo(tmp_path: Path):
+    """secure_path drops /usr/lib/wsl/lib even with sudo -E, where the Windows
+    driver keeps nvidia-smi on a WSL 2 distro running its own Docker Engine."""
+    _, log, env = _setup(tmp_path, wsl = True)
+    smi = tmp_path / "bin" / "nvidia-smi"
+    wsl_lib = tmp_path / "wsl-lib"
+    wsl_lib.mkdir()
+    smi.rename(wsl_lib / "nvidia-smi")
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "nvidia-ctk runtime configure --runtime=docker" in _calls(log)
+    assert "meets the 570.26 minimum" in res.stdout
+
+
+def test_a_failed_source_list_download_keeps_the_existing_file(tmp_path: Path):
+    root, log, env = _setup(tmp_path, distro = "ubuntu")
+    lst = root / "etc/apt/sources.list.d/nvidia-container-toolkit.list"
+    lst.parent.mkdir(parents = True)
+    lst.write_text("deb [signed-by=/usr/share/keyrings/x.gpg] https://old /\n", encoding = "utf-8")
+    (tmp_path / "list-download-fails").write_text("", encoding = "utf-8")
+    res = _run(env)
+    assert res.returncode != 0
+    assert lst.read_text(encoding = "utf-8").startswith("deb [signed-by=/usr/share/keyrings/x.gpg] https://old")
+    assert not any(c.startswith("nvidia-ctk") for c in _calls(log))
 
 
 def test_a_remote_docker_endpoint_is_refused(tmp_path: Path):
@@ -504,6 +544,12 @@ def test_run_sh_does_not_offer_an_install_when_docker_itself_is_unreachable(tmp_
     assert "Container Toolkit is not set up" not in res.stderr
     assert not any(c.startswith("sudo") for c in _calls(log))
     assert argv.exists()
+
+
+def test_run_sh_uses_no_scratch_file_for_the_daemon_probe():
+    text = RUN_SH.read_text(encoding = "utf-8")
+    assert "unsloth-docker-info" not in text and "mktemp" not in text
+    assert 'DOCKER_INFO="$(docker info 2>&1)"' in text
 
 
 def test_run_sh_is_quiet_when_the_runtime_is_present(tmp_path: Path):

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-Present the Unsloth team. See /studio/LICENSE.AGPL-3.0
 
-"""docker/install_nvidia_toolkit.sh sets up the one host-side piece the image cannot
-carry: the NVIDIA Container Toolkit. Every package manager, restart and verification
-path runs here against stubs, and docker/run.sh's offer to run it is checked too."""
+"""docker/install_nvidia_toolkit.sh against stubbed package managers, drivers and
+Docker daemons, plus docker/run.sh's offer to run it."""
 
 from __future__ import annotations
 
@@ -31,9 +30,8 @@ OS_RELEASE = {
 }
 
 
-# The scripts under test are given ONLY these real tools, next to the stubs. A branch
-# that reaches for an absent command (dnf gone, systemctl gone) must find nothing,
-# never the runner's own package manager or init.
+# Only these real tools, so a branch reaching for an absent command (dnf, systemctl)
+# finds nothing rather than the runner's own package manager or init.
 _REAL_TOOLS = (
     "bash",
     "grep",
@@ -106,8 +104,7 @@ def _setup(
         if driver
         else "exit 9\n",
     )
-    # the installer picks the verification platform from uname -m; pin it so the
-    # suite means the same thing on an arm64 runner
+    # pinned: the installer picks the verification platform from uname -m
     _stub(bindir / "uname", 'if [ "$1" = -s ]; then echo Linux; else echo x86_64; fi\n')
     ctk = bindir / "nvidia-ctk"
     runtime = bindir / "nvidia-container-runtime"
@@ -314,8 +311,7 @@ def test_rootless_docker_is_refused_before_anything_runs(tmp_path: Path):
 
 
 def test_rootless_docker_is_still_caught_when_piped_into_sudo_bash(tmp_path: Path):
-    """`curl | sudo bash` arrives as root with the user's DOCKER_HOST stripped by
-    env_reset; SUDO_UID survives, so the user's socket is probed through it."""
+    """env_reset strips DOCKER_HOST but keeps SUDO_UID, so the user's socket is probed through it."""
     import socket
 
     _, log, env = _setup(tmp_path, rootless = "via_sudo_uid", uid = 0)
@@ -357,8 +353,7 @@ def test_docker_context_wins_over_a_local_docker_host(tmp_path: Path):
 
 
 def test_nvidia_smi_is_found_in_the_wsl_library_dir_after_sudo(tmp_path: Path):
-    """secure_path drops /usr/lib/wsl/lib even with sudo -E, where the Windows
-    driver keeps nvidia-smi on a WSL 2 distro running its own Docker Engine."""
+    """secure_path drops /usr/lib/wsl/lib, where the Windows driver keeps nvidia-smi."""
     _, log, env = _setup(tmp_path, wsl = True)
     smi = tmp_path / "bin" / "nvidia-smi"
     wsl_lib = tmp_path / "wsl-lib"
@@ -394,8 +389,7 @@ def test_an_unsupported_architecture_is_refused_before_any_install(tmp_path: Pat
 
 
 def test_an_installed_toolkit_is_only_registered(tmp_path: Path):
-    """nvidia-ctk present, runtime entry gone: no repository or package work, which
-    is what an offline host needs."""
+    """nvidia-ctk present, runtime entry gone: no repository or package work, as an offline host needs."""
     _, log, env = _setup(tmp_path, toolkit_installed = True)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
@@ -432,8 +426,7 @@ def test_no_gpu_on_wsl_points_at_the_windows_driver(tmp_path: Path):
 
 
 def test_only_the_toolkit_cli_present_still_installs_the_full_package(tmp_path: Path):
-    """nvidia-container-toolkit-base ships nvidia-ctk without the runtime binary; a
-    registration on its own would be unusable."""
+    """nvidia-container-toolkit-base ships nvidia-ctk without the runtime binary."""
     _, log, env = _setup(tmp_path, toolkit_installed = True)
     (tmp_path / "bin" / "nvidia-container-runtime").unlink()
     res = _run(env)
@@ -601,7 +594,7 @@ def _run_sh_env(
     )
     _stub(bindir / "nvidia-smi", 'echo "GPU 0: NVIDIA H100 (UUID: GPU-abc)"\n')
     _stub(bindir / "sudo", rec + "exit 0\n")
-    # never root here: as uid 0 run.sh would execute the REAL installer against the host
+    # never root: as uid 0 run.sh would run the REAL installer against this host
     _stub(bindir / "id", "echo 1000\n")
     _stub(bindir / "getent", "exit 2\n")
     dev_root = tmp_path / "root"
@@ -637,8 +630,7 @@ def test_run_sh_installs_the_toolkit_when_told_to_then_runs(tmp_path: Path):
 
 
 def test_run_sh_still_runs_the_container_when_the_installer_fails(tmp_path: Path):
-    """Exit 3 means the toolkit works and only the driver is old; a cancelled sudo is
-    exit 1. Neither may stop the docker run the user asked for."""
+    """Exit 3 (only the driver is old) and exit 1 (cancelled sudo) must not stop the docker run."""
     log, argv, env = _run_sh_env(tmp_path, nvidia_runtime = False)
     _stub(tmp_path / "bin" / "sudo", f'echo "$(basename "$0") $*" >> {log}\nexit 3\n')
     env["UNSLOTH_INSTALL_TOOLKIT"] = "1"

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -78,7 +78,11 @@ def _setup(
         rec
         + 'if [ "$1" = info ]; then\n'
         + ('  echo " Operating System: Docker Desktop"\n' if desktop else "")
-        + ('  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n' if rootless else "")
+        + (
+            '  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n'
+            if rootless
+            else ""
+        )
         + f'  if [ -e {marker} ]; then echo " Runtimes: io.containerd.runc.v2 nvidia runc"; else echo " Runtimes: io.containerd.runc.v2 runc"; fi\n'
         + "  exit 0\nfi\n"
         + (
@@ -291,7 +295,9 @@ def test_a_non_root_run_of_the_file_re_executes_itself_under_sudo(tmp_path: Path
     _, log, env = _setup(tmp_path, uid = 1000)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert [c for c in _calls(log) if not c.startswith("docker info")] == [f"sudo -E bash {INSTALLER}"]
+    assert [c for c in _calls(log) if not c.startswith("docker info")] == [
+        f"sudo -E bash {INSTALLER}"
+    ]
 
 
 def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -47,6 +47,9 @@ _REAL_TOOLS = (
     "dirname",
     "touch",
     "mv",
+    "cp",
+    "chmod",
+    "stat",
     "cut",
     "rm",
     "true",
@@ -74,6 +77,7 @@ def _setup(
     distro: str = "ubuntu",
     driver: bool = True,
     configured: bool = False,
+    toolkit_installed: bool | None = None,
     desktop: bool = False,
     systemctl: str = "ok",
     verify_ok: bool = True,
@@ -105,7 +109,11 @@ def _setup(
     # the installer picks the verification platform from uname -m; pin it so the
     # suite means the same thing on an arm64 runner
     _stub(bindir / "uname", 'if [ "$1" = -s ]; then echo Linux; else echo x86_64; fi\n')
-    _stub(bindir / "nvidia-ctk", rec + f"touch {marker}\n")
+    ctk = bindir / "nvidia-ctk"
+    ctk_body = rec + f"touch {marker}\n"
+    if configured or toolkit_installed:
+        _stub(ctk, ctk_body)
+    (tmp_path / "ctk-stub-body").write_text("#!/usr/bin/env bash\n" + ctk_body, encoding = "utf-8")
     _stub(
         bindir / "docker",
         rec
@@ -131,8 +139,13 @@ def _setup(
             else 'echo "docker: could not select device driver" >&2; exit 125\n'
         ),
     )
-    for pm in ("apt-get", "dnf", "yum", "zypper", "service"):
-        _stub(bindir / pm, rec + "exit 0\n")
+    # installing the package makes nvidia-ctk appear, as it does for real
+    installs = (
+        f'case "$*" in *install*nvidia-container-toolkit*) cp {tmp_path / "ctk-stub-body"} {ctk}; chmod 755 {ctk} ;; esac\n'
+    )
+    for pm in ("apt-get", "dnf", "yum", "zypper"):
+        _stub(bindir / pm, rec + installs + "exit 0\n")
+    _stub(bindir / "service", rec + "exit 0\n")
     if systemctl == "ok":
         _stub(bindir / "systemctl", rec + "exit 0\n")
     elif systemctl == "fails":
@@ -175,13 +188,14 @@ def _setup(
 
 
 def _run(
-    env: dict,
-    script: Path = INSTALLER,
-    extra_env: dict | None = None,
+    env: dict, script: Path = INSTALLER, extra_env: dict | None = None, umask: str | None = None
 ) -> subprocess.CompletedProcess:
     e = dict(env)
     e.update(extra_env or {})
-    return subprocess.run(["bash", str(script)], capture_output = True, text = True, env = e, timeout = 60)
+    cmd = ["bash", str(script)]
+    if umask:
+        cmd = ["bash", "-c", f'umask {umask}; exec bash "$0"', str(script)]
+    return subprocess.run(cmd, capture_output = True, text = True, env = e, timeout = 60)
 
 
 def _calls(log: Path) -> list[str]:
@@ -364,6 +378,35 @@ def test_a_failed_source_list_download_keeps_the_existing_file(tmp_path: Path):
     assert not any(c.startswith("nvidia-ctk") for c in _calls(log))
 
 
+def test_an_unsupported_architecture_is_refused_before_any_install(tmp_path: Path):
+    _, log, env = _setup(tmp_path)
+    _stub(tmp_path / "bin" / "uname", 'if [ "$1" = -s ]; then echo Linux; else echo ppc64le; fi\n')
+    res = _run(env)
+    assert res.returncode == 2
+    assert "unsupported architecture ppc64le" in res.stderr
+    assert not any(c.startswith(("apt-get", "nvidia-ctk", "docker run")) for c in _calls(log))
+
+
+def test_an_installed_toolkit_is_only_registered(tmp_path: Path):
+    """nvidia-ctk present, runtime entry gone: no repository or package work, which
+    is what an offline host needs."""
+    _, log, env = _setup(tmp_path, toolkit_installed = True)
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    calls = _calls(log)
+    assert not any(c.startswith(("apt-get", "dnf", "yum", "zypper", "curl")) for c in calls)
+    assert "nvidia-ctk runtime configure --runtime=docker" in calls
+    assert "systemctl restart docker" in calls
+
+
+def test_the_keyring_is_world_readable_under_a_strict_umask(tmp_path: Path):
+    root, _, env = _setup(tmp_path, distro = "ubuntu")
+    res = _run(env, umask = "077")
+    assert res.returncode == 0, res.stdout + res.stderr
+    key = root / "usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+    assert oct(key.stat().st_mode & 0o777) == "0o644"
+
+
 def test_a_remote_docker_endpoint_is_refused(tmp_path: Path):
     _, log, env = _setup(tmp_path, uid = 1000)
     env["DOCKER_HOST"] = "tcp://gpu-box:2376"
@@ -532,7 +575,7 @@ def test_run_sh_without_a_terminal_prints_the_one_liner_and_still_runs(tmp_path:
     log, argv, env = _run_sh_env(tmp_path, nvidia_runtime = False)
     res = _run_run_sh(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert "install_nvidia_toolkit.sh | sudo -E bash" in res.stderr
+    assert "-o install_nvidia_toolkit.sh && sudo -E bash install_nvidia_toolkit.sh" in res.stderr
     assert not any(c.startswith("sudo") for c in _calls(log))
     assert argv.exists()
 
@@ -564,5 +607,7 @@ def test_run_sh_is_quiet_when_the_runtime_is_present(tmp_path: Path):
 def test_the_docs_point_at_the_installer():
     for doc in (REPO_ROOT / "docker" / "DOCKERHUB.md", REPO_ROOT / "README.md"):
         text = doc.read_text(encoding = "utf-8")
-        assert "docker/install_nvidia_toolkit.sh | sudo -E bash" in text, doc
+        assert "install_nvidia_toolkit.sh -o install_nvidia_toolkit.sh && sudo -E bash install_nvidia_toolkit.sh" in text, doc
+        assert "| sudo" not in text, "a pipe into bash masks a failed download"
+
     assert "Docker Desktop" in (REPO_ROOT / "docker" / "DOCKERHUB.md").read_text(encoding = "utf-8")

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -140,9 +140,7 @@ def _setup(
         ),
     )
     # installing the package makes nvidia-ctk appear, as it does for real
-    installs = (
-        f'case "$*" in *install*nvidia-container-toolkit*) cp {tmp_path / "ctk-stub-body"} {ctk}; chmod 755 {ctk} ;; esac\n'
-    )
+    installs = f'case "$*" in *install*nvidia-container-toolkit*) cp {tmp_path / "ctk-stub-body"} {ctk}; chmod 755 {ctk} ;; esac\n'
     for pm in ("apt-get", "dnf", "yum", "zypper"):
         _stub(bindir / pm, rec + installs + "exit 0\n")
     _stub(bindir / "service", rec + "exit 0\n")
@@ -188,7 +186,10 @@ def _setup(
 
 
 def _run(
-    env: dict, script: Path = INSTALLER, extra_env: dict | None = None, umask: str | None = None
+    env: dict,
+    script: Path = INSTALLER,
+    extra_env: dict | None = None,
+    umask: str | None = None,
 ) -> subprocess.CompletedProcess:
     e = dict(env)
     e.update(extra_env or {})
@@ -607,7 +608,10 @@ def test_run_sh_is_quiet_when_the_runtime_is_present(tmp_path: Path):
 def test_the_docs_point_at_the_installer():
     for doc in (REPO_ROOT / "docker" / "DOCKERHUB.md", REPO_ROOT / "README.md"):
         text = doc.read_text(encoding = "utf-8")
-        assert "install_nvidia_toolkit.sh -o install_nvidia_toolkit.sh && sudo -E bash install_nvidia_toolkit.sh" in text, doc
+        assert (
+            "install_nvidia_toolkit.sh -o install_nvidia_toolkit.sh && sudo -E bash install_nvidia_toolkit.sh"
+            in text
+        ), doc
         assert "| sudo" not in text, "a pipe into bash masks a failed download"
 
     assert "Docker Desktop" in (REPO_ROOT / "docker" / "DOCKERHUB.md").read_text(encoding = "utf-8")

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -31,6 +31,25 @@ OS_RELEASE = {
 }
 
 
+# The scripts under test are given ONLY these real tools, next to the stubs. A branch
+# that reaches for an absent command (dnf gone, systemctl gone) must find nothing,
+# never the runner's own package manager or init.
+_REAL_TOOLS = (
+    "bash", "grep", "sed", "head", "tr", "sort", "mkdir", "cat", "basename", "dirname",
+    "touch", "cut", "rm", "true",
+)
+
+
+def _isolated_path(tmp_path: Path, bindir: Path) -> str:
+    sysbin = tmp_path / "sysbin"
+    sysbin.mkdir(exist_ok = True)
+    for name in _REAL_TOOLS:
+        real = shutil.which(name)
+        assert real, f"{name} not found on this host"
+        (sysbin / name).symlink_to(real)
+    return f"{bindir}{os.pathsep}{sysbin}"
+
+
 def _stub(path: Path, body: str) -> None:
     path.write_text("#!/usr/bin/env bash\n" + body, encoding = "utf-8")
     path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
@@ -72,11 +91,12 @@ def _setup(
     )
     # the installer picks the verification platform from uname -m; pin it so the
     # suite means the same thing on an arm64 runner
-    _stub(bindir / "uname", "echo x86_64\n")
+    _stub(bindir / "uname", 'if [ "$1" = -s ]; then echo Linux; else echo x86_64; fi\n')
     _stub(bindir / "nvidia-ctk", rec + f"touch {marker}\n")
     _stub(
         bindir / "docker",
         rec
+        + 'if [ "$1" = context ]; then echo "unix:///var/run/docker.sock"; exit 0; fi\n'
         + 'if [ "$1" = info ]; then\n'
         + ('  echo " Operating System: Docker Desktop"\n' if desktop else "")
         + (
@@ -84,11 +104,7 @@ def _setup(
             '    case "${DOCKER_HOST:-}" in *docker.sock) echo "name=rootless,name=seccomp" ;; *) echo "name=seccomp" ;; esac; exit 0\n'
             "  fi\n"
             if rootless == "via_sudo_uid"
-            else (
-                '  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n'
-                if rootless
-                else ""
-            )
+            else ('  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n' if rootless else "")
         )
         + f'  if [ -e {marker} ]; then echo " Runtimes: io.containerd.runc.v2 nvidia runc"; else echo " Runtimes: io.containerd.runc.v2 runc"; fi\n'
         + "  exit 0\nfi\n"
@@ -127,13 +143,14 @@ def _setup(
         encoding = "utf-8",
     )
     env = dict(os.environ)
-    env["PATH"] = f"{bindir}{os.pathsep}" + env["PATH"]
+    env["PATH"] = _isolated_path(tmp_path, bindir)
     env["UNSLOTH_DESTDIR"] = str(root)
     env["UNSLOTH_OS_RELEASE"] = str(osr)
     env["UNSLOTH_PROC_VERSION"] = str(procv)
     env["UNSLOTH_RUN_USER_DIR"] = str(tmp_path / "run-user")
     env.pop("UNSLOTH_TOOLKIT_VERIFY", None)
     env.pop("SUDO_UID", None)
+    env.pop("DOCKER_HOST", None)
     return root, log, env
 
 
@@ -282,15 +299,37 @@ def test_rootless_docker_is_still_caught_when_piped_into_sudo_bash(tmp_path: Pat
 
 def test_without_docker_the_script_says_so(tmp_path: Path):
     _, log, env = _setup(tmp_path)
-    (tmp_path / "bin" / "docker").unlink()
-    sysbin = tmp_path / "sysbin"  # bash only, so the host's real docker is out of reach
-    sysbin.mkdir()
-    (sysbin / "bash").symlink_to(shutil.which("bash"))
-    env["PATH"] = f"{tmp_path / 'bin'}{os.pathsep}{sysbin}"
+    (tmp_path / "bin" / "docker").unlink()  # the PATH holds no real docker either
     res = _run(env)
     assert res.returncode == 2
     assert "docker is not installed" in res.stderr
     assert _calls(log) == []
+
+
+def test_a_remote_docker_endpoint_is_refused(tmp_path: Path):
+    _, log, env = _setup(tmp_path, uid = 1000)
+    env["DOCKER_HOST"] = "tcp://gpu-box:2376"
+    res = _run(env)
+    assert res.returncode == 2
+    assert "remote daemon (tcp://gpu-box:2376)" in res.stderr
+    assert not any(c.startswith(("sudo", "apt-get", "nvidia-ctk")) for c in _calls(log))
+
+
+def test_docker_desktop_on_macos_says_cpu_only(tmp_path: Path):
+    _, log, env = _setup(tmp_path, desktop = True, driver = False, uid = 1000)
+    _stub(tmp_path / "bin" / "uname", 'if [ "$1" = -s ]; then echo Darwin; else echo arm64; fi\n')
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "no NVIDIA GPU" in res.stdout and "UNSLOTH_ALLOW_CPU=1" in res.stdout
+    assert "GPU support comes with it" not in res.stdout
+
+
+def test_the_old_driver_message_names_the_host_platform_even_without_verification(tmp_path: Path):
+    _, _, env = _setup(tmp_path, driver_version = "550.54.15")
+    _stub(tmp_path / "bin" / "uname", 'if [ "$1" = -s ]; then echo Linux; else echo aarch64; fi\n')
+    res = _run(env, extra_env = {"UNSLOTH_TOOLKIT_VERIFY": "0"})
+    assert res.returncode == 3
+    assert "--platform linux/arm64" in res.stderr
 
 
 def test_a_configured_host_only_verifies(tmp_path: Path):
@@ -308,7 +347,7 @@ def test_docker_desktop_needs_nothing(tmp_path: Path):
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
     assert "Docker Desktop detected" in res.stdout
-    assert [c for c in _calls(log) if not c.startswith("docker info")] == []
+    assert [c for c in _calls(log) if not c.startswith("docker ")] == []
 
 
 @pytest.mark.parametrize("systemctl", ["missing", "fails"])
@@ -341,9 +380,7 @@ def test_a_non_root_run_of_the_file_re_executes_itself_under_sudo(tmp_path: Path
     _, log, env = _setup(tmp_path, uid = 1000)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert [c for c in _calls(log) if not c.startswith("docker info")] == [
-        f"sudo -E bash {INSTALLER}"
-    ]
+    assert [c for c in _calls(log) if not c.startswith("docker ")] == [f"sudo -E bash {INSTALLER}"]
 
 
 def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):
@@ -357,11 +394,13 @@ def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):
         timeout = 60,
     )
     assert res.returncode == 2
-    assert "sudo bash" in res.stderr
-    assert [c for c in _calls(log) if not c.startswith("docker info")] == []
+    assert "sudo -E bash" in res.stderr
+    assert [c for c in _calls(log) if not c.startswith("docker ")] == []
 
 
-def _run_sh_env(tmp_path: Path, *, nvidia_runtime: bool) -> tuple[Path, Path, dict]:
+def _run_sh_env(
+    tmp_path: Path, *, nvidia_runtime: bool, docker_down: bool = False
+) -> tuple[Path, Path, dict]:
     bindir = tmp_path / "bin"
     bindir.mkdir()
     log = tmp_path / "calls.log"
@@ -370,9 +409,14 @@ def _run_sh_env(tmp_path: Path, *, nvidia_runtime: bool) -> tuple[Path, Path, di
     runtimes = (
         "io.containerd.runc.v2 nvidia runc" if nvidia_runtime else "io.containerd.runc.v2 runc"
     )
+    info = (
+        'echo "permission denied while trying to connect to the Docker daemon socket" >&2; exit 1'
+        if docker_down
+        else f'echo " Runtimes: {runtimes}"; exit 0'
+    )
     _stub(
         bindir / "docker",
-        rec + f'if [ "$1" = info ]; then echo " Runtimes: {runtimes}"; exit 0; fi\n'
+        rec + f'if [ "$1" = info ]; then {info}; fi\n'
         f'printf "%s\\n" "$@" > {argv}\nexit 0\n',
     )
     _stub(bindir / "nvidia-smi", 'echo "GPU 0: NVIDIA H100 (UUID: GPU-abc)"\n')
@@ -384,7 +428,7 @@ def _run_sh_env(tmp_path: Path, *, nvidia_runtime: bool) -> tuple[Path, Path, di
     (dev_root / "dev").mkdir(parents = True)
     (dev_root / "dev" / "nvidiactl").write_text("", encoding = "utf-8")
     env = dict(os.environ)
-    env["PATH"] = f"{bindir}{os.pathsep}" + env["PATH"]
+    env["PATH"] = _isolated_path(tmp_path, bindir)
     env["UNSLOTH_DEV_ROOT"] = str(dev_root)
     env["HF_HOME"] = str(tmp_path / "hf")
     env["TRITON_CACHE_DIR"] = str(tmp_path / "triton")
@@ -428,7 +472,18 @@ def test_run_sh_without_a_terminal_prints_the_one_liner_and_still_runs(tmp_path:
     log, argv, env = _run_sh_env(tmp_path, nvidia_runtime = False)
     res = _run_run_sh(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert "install_nvidia_toolkit.sh | sudo bash" in res.stderr
+    assert "install_nvidia_toolkit.sh | sudo -E bash" in res.stderr
+    assert not any(c.startswith("sudo") for c in _calls(log))
+    assert argv.exists()
+
+
+def test_run_sh_does_not_offer_an_install_when_docker_itself_is_unreachable(tmp_path: Path):
+    log, argv, env = _run_sh_env(tmp_path, nvidia_runtime = False, docker_down = True)
+    env["UNSLOTH_INSTALL_TOOLKIT"] = "1"
+    res = _run_run_sh(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "permission denied" in res.stderr and "docker group" in res.stderr
+    assert "Container Toolkit is not set up" not in res.stderr
     assert not any(c.startswith("sudo") for c in _calls(log))
     assert argv.exists()
 
@@ -443,5 +498,5 @@ def test_run_sh_is_quiet_when_the_runtime_is_present(tmp_path: Path):
 def test_the_docs_point_at_the_installer():
     for doc in (REPO_ROOT / "docker" / "DOCKERHUB.md", REPO_ROOT / "README.md"):
         text = doc.read_text(encoding = "utf-8")
-        assert "docker/install_nvidia_toolkit.sh | sudo bash" in text, doc
+        assert "docker/install_nvidia_toolkit.sh | sudo -E bash" in text, doc
     assert "Docker Desktop" in (REPO_ROOT / "docker" / "DOCKERHUB.md").read_text(encoding = "utf-8")

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -8,6 +8,7 @@ path runs here against stubs, and docker/run.sh's offer to run it is checked too
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -47,7 +48,7 @@ def _setup(
     uid: int = 0,
     wsl: bool = False,
     driver_version: str = "580.65.06",
-    rootless: bool = False,
+    rootless: bool | str = False,
 ) -> tuple[Path, Path, dict]:
     bindir = tmp_path / "bin"
     bindir.mkdir()
@@ -79,9 +80,11 @@ def _setup(
         + 'if [ "$1" = info ]; then\n'
         + ('  echo " Operating System: Docker Desktop"\n' if desktop else "")
         + (
-            '  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n'
-            if rootless
-            else ""
+            '  if [ "$2" = "--format" ]; then\n'
+            '    case "${DOCKER_HOST:-}" in *docker.sock) echo "name=rootless,name=seccomp" ;; *) echo "name=seccomp" ;; esac; exit 0\n'
+            "  fi\n"
+            if rootless == "via_sudo_uid"
+            else ('  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n' if rootless else "")
         )
         + f'  if [ -e {marker} ]; then echo " Runtimes: io.containerd.runc.v2 nvidia runc"; else echo " Runtimes: io.containerd.runc.v2 runc"; fi\n'
         + "  exit 0\nfi\n"
@@ -124,7 +127,9 @@ def _setup(
     env["UNSLOTH_DESTDIR"] = str(root)
     env["UNSLOTH_OS_RELEASE"] = str(osr)
     env["UNSLOTH_PROC_VERSION"] = str(procv)
+    env["UNSLOTH_RUN_USER_DIR"] = str(tmp_path / "run-user")
     env.pop("UNSLOTH_TOOLKIT_VERIFY", None)
+    env.pop("SUDO_UID", None)
     return root, log, env
 
 
@@ -247,6 +252,43 @@ def test_rootless_docker_is_refused_before_anything_runs(tmp_path: Path):
     assert not any(c.startswith(("sudo", "apt-get", "nvidia-ctk")) for c in _calls(log))
 
 
+def test_rootless_docker_is_still_caught_when_piped_into_sudo_bash(tmp_path: Path):
+    """`curl | sudo bash` arrives as root with the user's DOCKER_HOST stripped by
+    env_reset; SUDO_UID survives, so the user's socket is probed through it."""
+    import socket
+
+    _, log, env = _setup(tmp_path, rootless = "via_sudo_uid", uid = 0)
+    sock_dir = tmp_path / "run-user" / "1000"
+    sock_dir.mkdir(parents = True)
+    s = socket.socket(socket.AF_UNIX)
+    cwd = os.getcwd()
+    os.chdir(sock_dir)  # AF_UNIX paths are capped at 108 bytes; bind relative
+    try:
+        s.bind("docker.sock")
+    finally:
+        os.chdir(cwd)
+    env["SUDO_UID"] = "1000"
+    res = _run(env)
+    s.close()
+    assert res.returncode == 2
+    assert "rootless" in res.stderr
+    assert not res.stderr.rstrip().endswith(" 2"), "the exit code leaked into the message"
+    assert not any(c.startswith(("apt-get", "nvidia-ctk")) for c in _calls(log))
+
+
+def test_without_docker_the_script_says_so(tmp_path: Path):
+    _, log, env = _setup(tmp_path)
+    (tmp_path / "bin" / "docker").unlink()
+    sysbin = tmp_path / "sysbin"  # bash only, so the host's real docker is out of reach
+    sysbin.mkdir()
+    (sysbin / "bash").symlink_to(shutil.which("bash"))
+    env["PATH"] = f"{tmp_path / 'bin'}{os.pathsep}{sysbin}"
+    res = _run(env)
+    assert res.returncode == 2
+    assert "docker is not installed" in res.stderr
+    assert _calls(log) == []
+
+
 def test_a_configured_host_only_verifies(tmp_path: Path):
     _, log, env = _setup(tmp_path, configured = True)
     res = _run(env)
@@ -258,7 +300,7 @@ def test_a_configured_host_only_verifies(tmp_path: Path):
 
 
 def test_docker_desktop_needs_nothing(tmp_path: Path):
-    _, log, env = _setup(tmp_path, desktop = True, driver = False)
+    _, log, env = _setup(tmp_path, desktop = True, driver = False, uid = 1000)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
     assert "Docker Desktop detected" in res.stdout
@@ -295,9 +337,7 @@ def test_a_non_root_run_of_the_file_re_executes_itself_under_sudo(tmp_path: Path
     _, log, env = _setup(tmp_path, uid = 1000)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert [c for c in _calls(log) if not c.startswith("docker info")] == [
-        f"sudo -E bash {INSTALLER}"
-    ]
+    assert [c for c in _calls(log) if not c.startswith("docker info")] == [f"sudo -E bash {INSTALLER}"]
 
 
 def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):
@@ -364,6 +404,18 @@ def test_run_sh_installs_the_toolkit_when_told_to_then_runs(tmp_path: Path):
     assert res.returncode == 0, res.stdout + res.stderr
     assert f"sudo -E bash {INSTALLER}" in _calls(log)
     assert "--gpus\nall\n" in argv.read_text(encoding = "utf-8")
+
+
+def test_run_sh_still_runs_the_container_when_the_installer_fails(tmp_path: Path):
+    """Exit 3 means the toolkit works and only the driver is old; a cancelled sudo is
+    exit 1. Neither may stop the docker run the user asked for."""
+    log, argv, env = _run_sh_env(tmp_path, nvidia_runtime = False)
+    _stub(tmp_path / "bin" / "sudo", f'echo "$(basename "$0") $*" >> {log}\nexit 3\n')
+    env["UNSLOTH_INSTALL_TOOLKIT"] = "1"
+    res = _run_run_sh(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert f"sudo -E bash {INSTALLER}" in _calls(log)
+    assert argv.exists(), "docker run never happened"
 
 
 def test_run_sh_without_a_terminal_prints_the_one_liner_and_still_runs(tmp_path: Path):

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -46,6 +46,8 @@ def _setup(
     verify_ok: bool = True,
     uid: int = 0,
     wsl: bool = False,
+    driver_version: str = "580.65.06",
+    rootless: bool = False,
 ) -> tuple[Path, Path, dict]:
     bindir = tmp_path / "bin"
     bindir.mkdir()
@@ -60,14 +62,23 @@ def _setup(
     _stub(bindir / "sudo", rec + "exit 0\n")
     _stub(
         bindir / "nvidia-smi",
-        'echo "GPU 0: NVIDIA H100 (UUID: GPU-abc)"\n' if driver else "exit 9\n",
+        (
+            f'if [ "$1" = --query-gpu=driver_version ]; then echo " {driver_version}"; exit 0; fi\n'
+            'echo "GPU 0: NVIDIA H100 (UUID: GPU-abc)"\n'
+        )
+        if driver
+        else "exit 9\n",
     )
+    # the installer picks the verification platform from uname -m; pin it so the
+    # suite means the same thing on an arm64 runner
+    _stub(bindir / "uname", "echo x86_64\n")
     _stub(bindir / "nvidia-ctk", rec + f"touch {marker}\n")
     _stub(
         bindir / "docker",
         rec
         + 'if [ "$1" = info ]; then\n'
         + ('  echo " Operating System: Docker Desktop"\n' if desktop else "")
+        + ('  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n' if rootless else "")
         + f'  if [ -e {marker} ]; then echo " Runtimes: io.containerd.runc.v2 nvidia runc"; else echo " Runtimes: io.containerd.runc.v2 runc"; fi\n'
         + "  exit 0\nfi\n"
         + (
@@ -207,6 +218,31 @@ def test_no_driver_means_stop_and_say_how_to_get_one(tmp_path: Path):
     assert not any(c.startswith(("apt-get", "nvidia-ctk", "docker run")) for c in _calls(log))
 
 
+def test_an_old_driver_is_reported_after_the_toolkit_is_in_place(tmp_path: Path):
+    _, log, env = _setup(tmp_path, driver_version = "550.54.15")
+    res = _run(env)
+    assert res.returncode == 3
+    assert "550.54.15 is below 570.26" in res.stderr
+    calls = _calls(log)
+    assert "nvidia-ctk runtime configure --runtime=docker" in calls
+    assert any(c.startswith("docker run") for c in calls)
+
+
+def test_a_current_driver_is_confirmed(tmp_path: Path):
+    _, _, env = _setup(tmp_path, driver_version = "570.26")
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "570.26 meets the 570.26 minimum" in res.stdout
+
+
+def test_rootless_docker_is_refused_before_anything_runs(tmp_path: Path):
+    _, log, env = _setup(tmp_path, rootless = True, uid = 1000)
+    res = _run(env)
+    assert res.returncode == 2
+    assert "rootless" in res.stderr and "#rootless-mode" in res.stderr
+    assert not any(c.startswith(("sudo", "apt-get", "nvidia-ctk")) for c in _calls(log))
+
+
 def test_a_configured_host_only_verifies(tmp_path: Path):
     _, log, env = _setup(tmp_path, configured = True)
     res = _run(env)
@@ -222,7 +258,7 @@ def test_docker_desktop_needs_nothing(tmp_path: Path):
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
     assert "Docker Desktop detected" in res.stdout
-    assert _calls(log) == ["docker info"]
+    assert [c for c in _calls(log) if not c.startswith("docker info")] == []
 
 
 @pytest.mark.parametrize("systemctl", ["missing", "fails"])
@@ -255,7 +291,7 @@ def test_a_non_root_run_of_the_file_re_executes_itself_under_sudo(tmp_path: Path
     _, log, env = _setup(tmp_path, uid = 1000)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert _calls(log) == [f"sudo -E bash {INSTALLER}"]
+    assert [c for c in _calls(log) if not c.startswith("docker info")] == [f"sudo -E bash {INSTALLER}"]
 
 
 def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):
@@ -270,7 +306,7 @@ def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):
     )
     assert res.returncode == 2
     assert "sudo bash" in res.stderr
-    assert _calls(log) == []
+    assert [c for c in _calls(log) if not c.startswith("docker info")] == []
 
 
 def _run_sh_env(tmp_path: Path, *, nvidia_runtime: bool) -> tuple[Path, Path, dict]:
@@ -289,6 +325,8 @@ def _run_sh_env(tmp_path: Path, *, nvidia_runtime: bool) -> tuple[Path, Path, di
     )
     _stub(bindir / "nvidia-smi", 'echo "GPU 0: NVIDIA H100 (UUID: GPU-abc)"\n')
     _stub(bindir / "sudo", rec + "exit 0\n")
+    # never root here: as uid 0 run.sh would execute the REAL installer against the host
+    _stub(bindir / "id", "echo 1000\n")
     _stub(bindir / "getent", "exit 2\n")
     dev_root = tmp_path / "root"
     (dev_root / "dev").mkdir(parents = True)
@@ -318,7 +356,7 @@ def test_run_sh_installs_the_toolkit_when_told_to_then_runs(tmp_path: Path):
     env["UNSLOTH_INSTALL_TOOLKIT"] = "1"
     res = _run_run_sh(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert f"sudo bash {INSTALLER}" in _calls(log)
+    assert f"sudo -E bash {INSTALLER}" in _calls(log)
     assert "--gpus\nall\n" in argv.read_text(encoding = "utf-8")
 
 

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -56,7 +56,7 @@ def _setup(
     if configured:
         marker.write_text("", encoding = "utf-8")
     rec = f'echo "$(basename "$0") $*" >> {log}\n'
-    _stub(bindir / "id", f'echo {uid}\n')
+    _stub(bindir / "id", f"echo {uid}\n")
     _stub(bindir / "sudo", rec + "exit 0\n")
     _stub(
         bindir / "nvidia-smi",
@@ -70,7 +70,11 @@ def _setup(
         + ('  echo " Operating System: Docker Desktop"\n' if desktop else "")
         + f'  if [ -e {marker} ]; then echo " Runtimes: io.containerd.runc.v2 nvidia runc"; else echo " Runtimes: io.containerd.runc.v2 runc"; fi\n'
         + "  exit 0\nfi\n"
-        + ("exit 0\n" if verify_ok else 'echo "docker: could not select device driver" >&2; exit 125\n'),
+        + (
+            "exit 0\n"
+            if verify_ok
+            else 'echo "docker: could not select device driver" >&2; exit 125\n'
+        ),
     )
     for pm in ("apt-get", "dnf", "yum", "zypper", "service"):
         _stub(bindir / pm, rec + "exit 0\n")
@@ -80,8 +84,7 @@ def _setup(
         _stub(bindir / "systemctl", rec + "exit 1\n")
     _stub(
         bindir / "curl",
-        rec
-        + 'case "$*" in\n'
+        rec + 'case "$*" in\n'
         '  *gpgkey) printf "FAKE-ARMORED-KEY\\n" ;;\n'
         '  *.list) printf "deb https://nvidia.github.io/libnvidia-container/stable/deb/\\$(ARCH) /\\n" ;;\n'
         '  *.repo) printf "[nvidia-container-toolkit]\\nbaseurl=https://nvidia.github.io/libnvidia-container/stable/rpm/\\$basearch\\n" ;;\n'
@@ -96,7 +99,9 @@ def _setup(
     osr.write_text(OS_RELEASE[distro], encoding = "utf-8")
     procv = tmp_path / "proc-version"
     procv.write_text(
-        "Linux version 5.15.167.4-microsoft-standard-WSL2\n" if wsl else "Linux version 6.8.0-45-generic\n",
+        "Linux version 5.15.167.4-microsoft-standard-WSL2\n"
+        if wsl
+        else "Linux version 6.8.0-45-generic\n",
         encoding = "utf-8",
     )
     env = dict(os.environ)
@@ -108,7 +113,11 @@ def _setup(
     return root, log, env
 
 
-def _run(env: dict, script: Path = INSTALLER, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+def _run(
+    env: dict,
+    script: Path = INSTALLER,
+    extra_env: dict | None = None,
+) -> subprocess.CompletedProcess:
     e = dict(env)
     e.update(extra_env or {})
     return subprocess.run(["bash", str(script)], capture_output = True, text = True, env = e, timeout = 60)
@@ -118,20 +127,30 @@ def _calls(log: Path) -> list[str]:
     return log.read_text(encoding = "utf-8").splitlines() if log.exists() else []
 
 
-def test_ubuntu_gets_the_apt_recipe_then_docker_is_configured_restarted_and_verified(tmp_path: Path):
+def test_ubuntu_gets_the_apt_recipe_then_docker_is_configured_restarted_and_verified(
+    tmp_path: Path,
+):
     root, log, env = _setup(tmp_path, distro = "ubuntu")
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
     calls = _calls(log)
     assert "apt-get update -qq" in calls
-    assert any(c.startswith("apt-get install") and c.endswith("nvidia-container-toolkit") for c in calls)
+    assert any(
+        c.startswith("apt-get install") and c.endswith("nvidia-container-toolkit") for c in calls
+    )
     key = root / "usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
     assert key.read_text(encoding = "utf-8") == "FAKE-ARMORED-KEY\n"
-    lst = (root / "etc/apt/sources.list.d/nvidia-container-toolkit.list").read_text(encoding = "utf-8")
-    assert lst.startswith("deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://")
+    lst = (root / "etc/apt/sources.list.d/nvidia-container-toolkit.list").read_text(
+        encoding = "utf-8"
+    )
+    assert lst.startswith(
+        "deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://"
+    )
     assert "nvidia-ctk runtime configure --runtime=docker" in calls
     assert "systemctl restart docker" in calls
-    assert calls[-1] == "docker run --rm --gpus all --platform linux/amd64 ubuntu:24.04 nvidia-smi -L"
+    assert (
+        calls[-1] == "docker run --rm --gpus all --platform linux/amd64 ubuntu:24.04 nvidia-smi -L"
+    )
     assert not any(c.startswith(("dnf", "yum", "zypper")) for c in calls)
 
 
@@ -162,7 +181,9 @@ def test_suse_uses_zypper(tmp_path: Path):
     assert res.returncode == 0, res.stdout + res.stderr
     calls = _calls(log)
     assert any(c.startswith("zypper --non-interactive ar https://nvidia.github.io/") for c in calls)
-    assert "zypper --non-interactive --gpg-auto-import-keys install nvidia-container-toolkit" in calls
+    assert (
+        "zypper --non-interactive --gpg-auto-import-keys install nvidia-container-toolkit" in calls
+    )
     assert not any(c.startswith(("apt-get", "dnf", "yum")) for c in calls)
 
 
@@ -172,7 +193,9 @@ def test_an_unknown_distribution_stops_before_touching_anything(tmp_path: Path):
     assert res.returncode == 2
     assert "unrecognised distribution" in res.stderr
     assert "install-guide" in res.stderr
-    assert not any(c.startswith(("apt-get", "dnf", "yum", "zypper", "nvidia-ctk")) for c in _calls(log))
+    assert not any(
+        c.startswith(("apt-get", "dnf", "yum", "zypper", "nvidia-ctk")) for c in _calls(log)
+    )
 
 
 def test_no_driver_means_stop_and_say_how_to_get_one(tmp_path: Path):
@@ -203,7 +226,9 @@ def test_docker_desktop_needs_nothing(tmp_path: Path):
 
 
 @pytest.mark.parametrize("systemctl", ["missing", "fails"])
-def test_without_a_working_systemctl_the_service_command_restarts_docker(tmp_path: Path, systemctl: str):
+def test_without_a_working_systemctl_the_service_command_restarts_docker(
+    tmp_path: Path, systemctl: str
+):
     _, log, env = _setup(tmp_path, systemctl = systemctl, wsl = True)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
@@ -236,8 +261,12 @@ def test_a_non_root_run_of_the_file_re_executes_itself_under_sudo(tmp_path: Path
 def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):
     _, log, env = _setup(tmp_path, uid = 1000)
     res = subprocess.run(
-        ["bash", "-s"], input = INSTALLER.read_text(encoding = "utf-8"),
-        capture_output = True, text = True, env = env, timeout = 60,
+        ["bash", "-s"],
+        input = INSTALLER.read_text(encoding = "utf-8"),
+        capture_output = True,
+        text = True,
+        env = env,
+        timeout = 60,
     )
     assert res.returncode == 2
     assert "sudo bash" in res.stderr
@@ -250,7 +279,9 @@ def _run_sh_env(tmp_path: Path, *, nvidia_runtime: bool) -> tuple[Path, Path, di
     log = tmp_path / "calls.log"
     argv = tmp_path / "argv"
     rec = f'echo "$(basename "$0") $*" >> {log}\n'
-    runtimes = "io.containerd.runc.v2 nvidia runc" if nvidia_runtime else "io.containerd.runc.v2 runc"
+    runtimes = (
+        "io.containerd.runc.v2 nvidia runc" if nvidia_runtime else "io.containerd.runc.v2 runc"
+    )
     _stub(
         bindir / "docker",
         rec + f'if [ "$1" = info ]; then echo " Runtimes: {runtimes}"; exit 0; fi\n'
@@ -273,8 +304,12 @@ def _run_sh_env(tmp_path: Path, *, nvidia_runtime: bool) -> tuple[Path, Path, di
 
 def _run_run_sh(env: dict) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ["bash", str(RUN_SH), "true"], capture_output = True, text = True, env = env,
-        stdin = subprocess.DEVNULL, timeout = 60,
+        ["bash", str(RUN_SH), "true"],
+        capture_output = True,
+        text = True,
+        env = env,
+        stdin = subprocess.DEVNULL,
+        timeout = 60,
     )
 
 

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -358,7 +358,9 @@ def test_a_failed_source_list_download_keeps_the_existing_file(tmp_path: Path):
     (tmp_path / "list-download-fails").write_text("", encoding = "utf-8")
     res = _run(env)
     assert res.returncode != 0
-    assert lst.read_text(encoding = "utf-8").startswith("deb [signed-by=/usr/share/keyrings/x.gpg] https://old")
+    assert lst.read_text(encoding = "utf-8").startswith(
+        "deb [signed-by=/usr/share/keyrings/x.gpg] https://old"
+    )
     assert not any(c.startswith("nvidia-ctk") for c in _calls(log))
 
 

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -417,6 +417,43 @@ def test_a_remote_docker_endpoint_is_refused(tmp_path: Path):
     assert not any(c.startswith(("sudo", "apt-get", "nvidia-ctk")) for c in _calls(log))
 
 
+def test_docker_desktop_on_native_linux_is_refused(tmp_path: Path):
+    _, log, env = _setup(tmp_path, desktop = True, driver = False, uid = 1000)
+    res = _run(env)
+    assert res.returncode == 2
+    assert "Docker Desktop for Linux has no NVIDIA GPU support" in res.stderr
+    assert not any(c.startswith(("sudo", "apt-get")) for c in _calls(log))
+
+
+def test_a_runtime_registered_without_nvidia_ctk_is_left_alone(tmp_path: Path):
+    _, log, env = _setup(tmp_path, configured = True)
+    (tmp_path / "bin" / "nvidia-ctk").unlink()
+    res = _run(env)
+    assert res.returncode == 0, res.stdout + res.stderr
+    calls = _calls(log)
+    assert not any(c.startswith(("apt-get", "dnf", "curl", "systemctl")) for c in calls)
+    assert "docker run --rm --gpus all --platform linux/amd64 ubuntu:24.04 nvidia-smi -L" in calls
+
+
+def test_a_second_daemon_on_its_own_socket_is_refused(tmp_path: Path):
+    _, log, env = _setup(tmp_path, uid = 1000)
+    env["DOCKER_HOST"] = "unix:///run/dockerd-b/docker.sock"
+    res = _run(env)
+    assert res.returncode == 2
+    assert "not the system daemon" in res.stderr
+    assert not any(c.startswith(("sudo", "apt-get")) for c in _calls(log))
+
+
+def test_the_default_sockets_are_accepted(tmp_path: Path):
+    for i, sock in enumerate(("unix:///var/run/docker.sock", "unix:///run/docker.sock")):
+        sub = tmp_path / f"case{i}"
+        sub.mkdir()
+        _, log, env = _setup(sub, uid = 1000)
+        env["DOCKER_HOST"] = sock
+        res = _run(env)
+        assert "not the system daemon" not in res.stderr, sock
+
+
 def test_docker_desktop_on_macos_says_cpu_only(tmp_path: Path):
     _, log, env = _setup(tmp_path, desktop = True, driver = False, uid = 1000)
     _stub(tmp_path / "bin" / "uname", 'if [ "$1" = -s ]; then echo Darwin; else echo arm64; fi\n')
@@ -438,17 +475,18 @@ def test_a_configured_host_only_verifies(tmp_path: Path):
     _, log, env = _setup(tmp_path, configured = True)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert "already installed" in res.stdout
+    assert "already lists the nvidia runtime" in res.stdout
     calls = _calls(log)
     assert not any(c.startswith(("apt-get", "nvidia-ctk", "systemctl", "service")) for c in calls)
     assert "docker run --rm --gpus all --platform linux/amd64 ubuntu:24.04 nvidia-smi -L" in calls
 
 
-def test_docker_desktop_needs_nothing(tmp_path: Path):
-    _, log, env = _setup(tmp_path, desktop = True, driver = False, uid = 1000)
+def test_docker_desktop_on_wsl_needs_nothing(tmp_path: Path):
+    _, log, env = _setup(tmp_path, desktop = True, driver = False, uid = 1000, wsl = True)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert "Docker Desktop detected" in res.stdout
+    assert "WSL 2 backend" in res.stdout and "nvidia.com" in res.stdout
+    assert "wsl --update updates WSL itself" in res.stdout
     assert [c for c in _calls(log) if not c.startswith("docker ")] == []
 
 
@@ -469,6 +507,7 @@ def test_a_failed_verification_is_an_error_with_a_pointer(tmp_path: Path):
     assert res.returncode == 1
     assert "could not see the GPU" in res.stderr
     assert "troubleshooting" in res.stderr
+    assert "wsl --update updates WSL itself" in res.stderr
 
 
 def test_verification_can_be_skipped(tmp_path: Path):

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -439,7 +439,9 @@ def test_only_the_toolkit_cli_present_still_installs_the_full_package(tmp_path: 
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
     calls = _calls(log)
-    assert any(c.startswith("apt-get install") and c.endswith("nvidia-container-toolkit") for c in calls)
+    assert any(
+        c.startswith("apt-get install") and c.endswith("nvidia-container-toolkit") for c in calls
+    )
     assert "nvidia-ctk runtime configure --runtime=docker" in calls
 
 

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -84,7 +84,11 @@ def _setup(
             '    case "${DOCKER_HOST:-}" in *docker.sock) echo "name=rootless,name=seccomp" ;; *) echo "name=seccomp" ;; esac; exit 0\n'
             "  fi\n"
             if rootless == "via_sudo_uid"
-            else ('  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n' if rootless else "")
+            else (
+                '  if [ "$2" = "--format" ]; then echo "name=rootless,name=seccomp"; exit 0; fi\n'
+                if rootless
+                else ""
+            )
         )
         + f'  if [ -e {marker} ]; then echo " Runtimes: io.containerd.runc.v2 nvidia runc"; else echo " Runtimes: io.containerd.runc.v2 runc"; fi\n'
         + "  exit 0\nfi\n"
@@ -337,7 +341,9 @@ def test_a_non_root_run_of_the_file_re_executes_itself_under_sudo(tmp_path: Path
     _, log, env = _setup(tmp_path, uid = 1000)
     res = _run(env)
     assert res.returncode == 0, res.stdout + res.stderr
-    assert [c for c in _calls(log) if not c.startswith("docker info")] == [f"sudo -E bash {INSTALLER}"]
+    assert [c for c in _calls(log) if not c.startswith("docker info")] == [
+        f"sudo -E bash {INSTALLER}"
+    ]
 
 
 def test_a_non_root_pipe_cannot_re_execute_and_says_so(tmp_path: Path):


### PR DESCRIPTION
## Why

The Hub quick start said "Requires the NVIDIA Container Toolkit" and linked NVIDIA's guide. That is the one host-side piece no image can bring along: Docker resolves `--gpus` in the daemon before a container exists, which is why vLLM and SGLang ship nothing for it either. The setup itself is mechanical, so this PR makes it one command.

## What

- `docker/install_nvidia_toolkit.sh`, a host-side script: follows NVIDIA's install guide for apt (Ubuntu, Debian), dnf or yum (RHEL, Fedora, Rocky, Amazon Linux) and zypper (SUSE), runs `nvidia-ctk runtime configure --runtime=docker`, restarts Docker via `systemctl` or `service` (WSL 2 distros without systemd), and proves it with `docker run --rm --gpus all --platform <host> ubuntu:24.04 nvidia-smi -L`. Idempotent: an already configured host only runs the check. Stops with directions when there is no NVIDIA driver or an unrecognised distribution. Detects Docker Desktop (macOS, Windows WSL 2 backend) and says nothing needs installing there. Re-executes itself under sudo when run as a file by a normal user.
- `docker/run.sh`: when a GPU host has Docker without the nvidia runtime, offers to run the installer (prompt on a terminal, `UNSLOTH_INSTALL_TOOLKIT=1` for scripts, otherwise prints the one-liner) instead of letting `--gpus` fail with exit 125.
- `docker/DOCKERHUB.md` and `README.md`: the one-liner replaces the "go install it" sentence; Windows stays "Docker Desktop with the WSL 2 backend".

```bash
curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/docker/install_nvidia_toolkit.sh | sudo bash
```

## Tests

`tests/python/test_docker_nvidia_toolkit_install.py` runs the script against stubbed package managers, curl, gpg, nvidia-ctk, systemctl, service and docker, with `UNSLOTH_DESTDIR` redirecting `/etc` and `/usr/share`: the apt recipe writes the dearmored keyring and the `signed-by` sources entry; dnf, yum and zypper paths; unknown distribution and missing driver stop before touching anything; a configured host only verifies; Docker Desktop is a no-op; `service docker restart` when systemctl is missing or fails; a failed verification is an error; `UNSLOTH_TOOLKIT_VERIFY=0`; sudo re-exec as a file and the pipe case; and `run.sh` running the installer on `UNSLOTH_INSTALL_TOOLKIT=1`, printing the one-liner without a terminal, and staying quiet when the runtime exists. The verification command was also run for real on a B200 host.

Not included: CUDA forward-compatibility libraries for older drivers, which only apply to datacenter GPUs.
