### PR TITLE
Studio: do not crash a model load when shutdown tears the server down under it

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -27476,8 +27476,14 @@ class LlamaCppBackend:
             # Cleared before probing so output during the request stays latched for
             # the fallback wait below.
             health_probe_event.clear()
+            # Read once: app shutdown kills the child and clears the reference
+            # from another thread, and this wait outlives that (#10353).
+            process = self._process
+            if process is None:
+                logger.info("llama-server was torn down while waiting for it to become healthy")
+                return False
             # Process crashed?
-            if self._process.poll() is not None:
+            if process.poll() is not None:
                 # Let the drain thread collect final output.
                 if self._stdout_thread is not None:
                     self._stdout_thread.join(timeout = 2)
@@ -27491,7 +27497,7 @@ class LlamaCppBackend:
                     else ""
                 )
                 logger.error(
-                    f"llama-server exited with code {self._process.returncode}. "
+                    f"llama-server exited with code {process.returncode}. "
                     f"Output (tail): {output[-2000:]}{_log_hint}"
                 )
                 return False

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -23442,8 +23442,13 @@ class LlamaCppBackend:
                             return True
                         if getattr(self, "_health_wait_cancelled", False):
                             return False
+                        # `is not None` like every other post-wait read below: a
+                        # teardown clears the reference from the shutdown thread,
+                        # and no process is not a startup crash.
                         _startup_crashed = (
-                            self._process.poll() is not None and self._process.returncode != 0
+                            self._process is not None
+                            and self._process.poll() is not None
+                            and self._process.returncode != 0
                         )
                         # A split-axis abort (#6415) is fit-independent: skip the
                         # --fit off retry and let the caller latch it. So is a
@@ -27481,6 +27486,11 @@ class LlamaCppBackend:
             process = self._process
             if process is None:
                 logger.info("llama-server was torn down while waiting for it to become healthy")
+                # Terminal, like a cancel: the caller must not read the cleared
+                # reference for an exit code, and must not respawn. Shutdown has
+                # already killed this child, so a retry ladder here would leave a
+                # llama-server running after the app it belonged to is gone.
+                self._health_wait_cancelled = True
                 return False
             # Process crashed?
             if process.poll() is not None:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -23442,12 +23442,14 @@ class LlamaCppBackend:
                             return True
                         if getattr(self, "_health_wait_cancelled", False):
                             return False
-                        # is not None like the other post-wait reads: a cleared
-                        # reference is a teardown, not a startup crash.
+                        # Read once, like the wait itself: a cleared reference is a
+                        # teardown, not a startup crash, and re-reading the
+                        # attribute per term would race the shutdown thread again.
+                        _crashed_proc = self._process
                         _startup_crashed = (
-                            self._process is not None
-                            and self._process.poll() is not None
-                            and self._process.returncode != 0
+                            _crashed_proc is not None
+                            and _crashed_proc.poll() is not None
+                            and _crashed_proc.returncode != 0
                         )
                         # A split-axis abort (#6415) is fit-independent: skip the
                         # --fit off retry and let the caller latch it. So is a
@@ -23481,7 +23483,7 @@ class LlamaCppBackend:
                                     "because a bundled ROCm library could not resolve a "
                                     "symbol against the system ROCm; retrying once "
                                     "with the bundled runtime only. Crash log: %s",
-                                    self._process.returncode,
+                                    _crashed_proc.returncode,
                                     self._llama_log_path,
                                 )
                                 env["LD_LIBRARY_PATH"] = _retry_ld
@@ -23511,7 +23513,7 @@ class LlamaCppBackend:
                                     "with a tensor-spill plan; the plan was optimistic, "
                                     "retrying once with --fit on so llama.cpp can place "
                                     "the model itself. Crash log: %s",
-                                    self._process.returncode,
+                                    _crashed_proc.returncode,
                                     self._llama_log_path,
                                 )
                                 run_cmd = _reverted
@@ -23536,7 +23538,7 @@ class LlamaCppBackend:
                                 "with forced --fit off; the fit estimate was optimistic, "
                                 "retrying once with --fit on so it can offload. "
                                 "Crash log: %s",
-                                self._process.returncode,
+                                _crashed_proc.returncode,
                                 self._llama_log_path,
                             )
                             # Flip Unsloth's own --fit off (added first, before any
@@ -23598,7 +23600,7 @@ class LlamaCppBackend:
                                 "with the default memory-fit step enabled; Unsloth "
                                 "already verified the model fits, retrying once "
                                 "with --fit off. Crash log: %s",
-                                self._process.returncode,
+                                _crashed_proc.returncode,
                                 self._llama_log_path,
                             )
                             run_cmd = [*run_cmd, "--fit", "off"]

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -23442,9 +23442,8 @@ class LlamaCppBackend:
                             return True
                         if getattr(self, "_health_wait_cancelled", False):
                             return False
-                        # `is not None` like every other post-wait read below: a
-                        # teardown clears the reference from the shutdown thread,
-                        # and no process is not a startup crash.
+                        # is not None like the other post-wait reads: a cleared
+                        # reference is a teardown, not a startup crash.
                         _startup_crashed = (
                             self._process is not None
                             and self._process.poll() is not None
@@ -27481,15 +27480,12 @@ class LlamaCppBackend:
             # Cleared before probing so output during the request stays latched for
             # the fallback wait below.
             health_probe_event.clear()
-            # Read once: app shutdown kills the child and clears the reference
-            # from another thread, and this wait outlives that (#10353).
+            # Read once: shutdown clears the reference from another thread (#10353).
             process = self._process
             if process is None:
                 logger.info("llama-server was torn down while waiting for it to become healthy")
-                # Terminal, like a cancel: the caller must not read the cleared
-                # reference for an exit code, and must not respawn. Shutdown has
-                # already killed this child, so a retry ladder here would leave a
-                # llama-server running after the app it belonged to is gone.
+                # Terminal like a cancel: the caller must not read the cleared
+                # reference, nor respawn a server shutdown just killed.
                 self._health_wait_cancelled = True
                 return False
             # Process crashed?

--- a/studio/backend/tests/test_chat_generation_supervisor.py
+++ b/studio/backend/tests/test_chat_generation_supervisor.py
@@ -213,10 +213,15 @@ async def test_a_prefill_reporting_only_progress_renews_the_lease(durable_run, m
     def _progress(processed):
         # The shape llama-server sends on /v1/chat/completions with
         # return_progress: a delta with no content, alongside the progress.
-        return {"choices": [{"delta": {"role": "assistant", "content": None},
-                             "finish_reason": None}],
-                "prompt_progress": {"total": 250000, "cache": 0, "processed": processed,
-                                    "time_ms": processed}}
+        return {
+            "choices": [{"delta": {"role": "assistant", "content": None}, "finish_reason": None}],
+            "prompt_progress": {
+                "total": 250000,
+                "cache": 0,
+                "processed": processed,
+                "time_ms": processed,
+            },
+        }
 
     async def body():
         for processed in (1024, 8192, 65536):
@@ -225,8 +230,9 @@ async def test_a_prefill_reporting_only_progress_renews_the_lease(durable_run, m
         # while the model still has not emitted a token.
         await asyncio.sleep(0.35)
         sampled["progress"] = runs_db.get_progress("run-1")
-        sampled["events"] = [e["payload"] for e in runs_db.list_events("run-1")
-                             if e["type"] == "chunk"]
+        sampled["events"] = [
+            e["payload"] for e in runs_db.list_events("run-1") if e["type"] == "chunk"
+        ]
         released.set()
         yield f"data: {json.dumps({'choices': [{'delta': {'content': 'Hi'}, 'finish_reason': 'stop'}]})}\n\n"
         yield "data: [DONE]\n\n"

--- a/studio/backend/tests/test_chat_generation_supervisor.py
+++ b/studio/backend/tests/test_chat_generation_supervisor.py
@@ -197,6 +197,55 @@ async def test_background_producer_persists_chunks_and_completes(durable_run, mo
     ] == chunks
 
 
+@pytest.mark.asyncio
+async def test_a_prefill_reporting_only_progress_renews_the_lease(durable_run, monkeypatch):
+    """A 250K-token prefill can run for 40 minutes before the first token, which
+    is longer than the 1200 second lease. llama-server reports progress while it
+    works, and those events carry a null-content delta, so they must reach the
+    database like any other chunk: it is the write that renews the lease, and a
+    filter that dropped content-less chunks would reap a healthy prefill.
+
+    Sampled mid-run, before any token exists, because after the run every chunk
+    has landed and the distinction disappears."""
+    released = asyncio.Event()
+    sampled: dict = {}
+
+    def _progress(processed):
+        # The shape llama-server sends on /v1/chat/completions with
+        # return_progress: a delta with no content, alongside the progress.
+        return {"choices": [{"delta": {"role": "assistant", "content": None},
+                             "finish_reason": None}],
+                "prompt_progress": {"total": 250000, "cache": 0, "processed": processed,
+                                    "time_ms": processed}}
+
+    async def body():
+        for processed in (1024, 8192, 65536):
+            yield f"data: {json.dumps(_progress(processed))}\n\n"
+        # Give the producer time to flush what it has, then look at the lease
+        # while the model still has not emitted a token.
+        await asyncio.sleep(0.35)
+        sampled["progress"] = runs_db.get_progress("run-1")
+        sampled["events"] = [e["payload"] for e in runs_db.list_events("run-1")
+                             if e["type"] == "chunk"]
+        released.set()
+        yield f"data: {json.dumps({'choices': [{'delta': {'content': 'Hi'}, 'finish_reason': 'stop'}]})}\n\n"
+        yield "data: [DONE]\n\n"
+
+    async def fake(_payload, _request, _subject, *, cancel_on_disconnect):
+        return SimpleNamespace(status_code = 200, body_iterator = body())
+
+    monkeypatch.setattr(inference, "produce_openai_chat_completions", fake)
+    supervisor = ChatGenerationSupervisor(SimpleNamespace(state = SimpleNamespace()))
+    await supervisor._produce("run-1")
+    assert released.is_set()
+    assert len(sampled["events"]) == 3, sampled["events"]
+    assert all("prompt_progress" in e for e in sampled["events"])
+    # Three chunk writes: the lease counts them, so it has been renewed three
+    # times before the first token.
+    assert sampled["progress"][1] == 3, sampled["progress"]
+    assert runs_db.get_run("run-1", "alice")["status"] == "completed"
+
+
 async def _subscriber_sequences(after = 0):
     response = await run_routes.chat_generation_events(
         "run-1",

--- a/studio/backend/tests/test_chat_generation_supervisor.py
+++ b/studio/backend/tests/test_chat_generation_supervisor.py
@@ -226,13 +226,20 @@ async def test_a_prefill_reporting_only_progress_renews_the_lease(durable_run, m
     async def body():
         for processed in (1024, 8192, 65536):
             yield f"data: {json.dumps(_progress(processed))}\n\n"
-        # Give the producer time to flush what it has, then look at the lease
-        # while the model still has not emitted a token.
-        await asyncio.sleep(0.35)
+        # Wait for the producer's idle flush, then look at the lease while the
+        # model still has not emitted a token. Polled rather than slept: the flush
+        # is on a 0.1s timer (_EVENT_BATCH_SECONDS) and a fixed sleep sized against
+        # it is a coin flip on a loaded CI runner. The deadline only bounds a
+        # failure, so a slow host waits instead of flaking.
+        _deadline = time.monotonic() + 10.0
+        while time.monotonic() < _deadline:
+            sampled["events"] = [
+                e["payload"] for e in runs_db.list_events("run-1") if e["type"] == "chunk"
+            ]
+            if len(sampled["events"]) >= 3:
+                break
+            await asyncio.sleep(0.01)
         sampled["progress"] = runs_db.get_progress("run-1")
-        sampled["events"] = [
-            e["payload"] for e in runs_db.list_events("run-1") if e["type"] == "chunk"
-        ]
         released.set()
         yield f"data: {json.dumps({'choices': [{'delta': {'content': 'Hi'}, 'finish_reason': 'stop'}]})}\n\n"
         yield "data: [DONE]\n\n"

--- a/studio/backend/tests/test_chat_generation_supervisor.py
+++ b/studio/backend/tests/test_chat_generation_supervisor.py
@@ -199,20 +199,14 @@ async def test_background_producer_persists_chunks_and_completes(durable_run, mo
 
 @pytest.mark.asyncio
 async def test_a_prefill_reporting_only_progress_renews_the_lease(durable_run, monkeypatch):
-    """A 250K-token prefill can run for 40 minutes before the first token, which
-    is longer than the 1200 second lease. llama-server reports progress while it
-    works, and those events carry a null-content delta, so they must reach the
-    database like any other chunk: it is the write that renews the lease, and a
-    filter that dropped content-less chunks would reap a healthy prefill.
-
-    Sampled mid-run, before any token exists, because after the run every chunk
-    has landed and the distinction disappears."""
+    """A 250K prefill outruns the 1200s lease before its first token, and the
+    write is what renews it, so dropping content-less progress chunks would reap a
+    healthy prefill. Sampled mid-run: afterwards every chunk has landed."""
     released = asyncio.Event()
     sampled: dict = {}
 
     def _progress(processed):
-        # The shape llama-server sends on /v1/chat/completions with
-        # return_progress: a delta with no content, alongside the progress.
+        # What llama-server sends under return_progress: a content-less delta.
         return {
             "choices": [{"delta": {"role": "assistant", "content": None}, "finish_reason": None}],
             "prompt_progress": {
@@ -226,11 +220,8 @@ async def test_a_prefill_reporting_only_progress_renews_the_lease(durable_run, m
     async def body():
         for processed in (1024, 8192, 65536):
             yield f"data: {json.dumps(_progress(processed))}\n\n"
-        # Wait for the producer's idle flush, then look at the lease while the
-        # model still has not emitted a token. Polled rather than slept: the flush
-        # is on a 0.1s timer (_EVENT_BATCH_SECONDS) and a fixed sleep sized against
-        # it is a coin flip on a loaded CI runner. The deadline only bounds a
-        # failure, so a slow host waits instead of flaking.
+        # Polled, not slept: the idle flush is on a 0.1s timer
+        # (_EVENT_BATCH_SECONDS) and a sleep sized against it flakes under load.
         _deadline = time.monotonic() + 10.0
         while time.monotonic() < _deadline:
             sampled["events"] = [
@@ -253,8 +244,7 @@ async def test_a_prefill_reporting_only_progress_renews_the_lease(durable_run, m
     assert released.is_set()
     assert len(sampled["events"]) == 3, sampled["events"]
     assert all("prompt_progress" in e for e in sampled["events"])
-    # Three chunk writes: the lease counts them, so it has been renewed three
-    # times before the first token.
+    # The lease counts writes, so it renewed three times before the first token.
     assert sampled["progress"][1] == 3, sampled["progress"]
     assert runs_db.get_run("run-1", "alice")["status"] == "completed"
 

--- a/studio/backend/tests/test_llama_cpp_wait_for_health.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_health.py
@@ -76,6 +76,45 @@ class TestWaitForHealthResilience:
         assert b._wait_for_health(timeout = 0.02, interval = 0.01) is False
         assert any("health check timed out" in ln for ln in b._stdout_lines)
 
+    def test_a_teardown_during_the_wait_is_a_failed_load_not_a_crash(self, monkeypatch):
+        """App shutdown kills llama-server and clears the reference from another
+        thread while this wait is still running, so the wait has to read the
+        process once and treat its absence as "the server is gone" (#10353).
+        Before this it raised AttributeError, which surfaced to the user as
+        "Error loading model: 'NoneType' object has no attribute 'poll'"."""
+        b = _make_backend()
+        b._process.poll.return_value = None
+        probes = []
+
+        def probe(*a, **kw):
+            probes.append(1)
+            if len(probes) == 2:
+                b._process = None  # what _kill_process does on shutdown
+            return mock.Mock(status_code = 503)
+
+        monkeypatch.setattr(httpx, "get", probe)
+        assert b._wait_for_health(timeout = 30.0, interval = 0.01) is False
+        assert len(probes) == 2
+        assert not any("health check timed out" in ln for ln in b._stdout_lines)
+
+    def test_a_teardown_before_the_first_probe_is_still_not_a_crash(self, monkeypatch):
+        b = _make_backend()
+        b._process = None
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock.Mock(status_code = 200))
+        assert b._wait_for_health(timeout = 30.0, interval = 0.01) is False
+
+    def test_a_crash_still_reports_the_exit_code(self, monkeypatch):
+        """The teardown guard must not swallow the crash branch: an exited
+        process still has to name its exit code and its output."""
+        b = _make_backend()
+        b._process.poll.return_value = 1
+        b._process.returncode = 1
+        b._stdout_lines = ["ROCm error: out of memory"]
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock.Mock(status_code = 503))
+        with mock.patch("core.inference.llama_cpp.logger") as log:
+            assert b._wait_for_health(timeout = 1.0, interval = 0.01) is False
+        assert any("exited with code 1" in str(c) for c in log.error.call_args_list)
+
     def test_cancel_stops_the_wait_without_a_timeout_marker(self, monkeypatch):
         b = _make_backend()
         b._process.poll.return_value = None

--- a/studio/backend/tests/test_llama_cpp_wait_for_health.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_health.py
@@ -77,11 +77,9 @@ class TestWaitForHealthResilience:
         assert any("health check timed out" in ln for ln in b._stdout_lines)
 
     def test_a_teardown_during_the_wait_is_a_failed_load_not_a_crash(self, monkeypatch):
-        """App shutdown kills llama-server and clears the reference from another
-        thread while this wait is still running, so the wait has to read the
-        process once and treat its absence as "the server is gone" (#10353).
-        Before this it raised AttributeError, which surfaced to the user as
-        "Error loading model: 'NoneType' object has no attribute 'poll'"."""
+        """Shutdown clears the reference mid-wait; reading it once and treating
+        its absence as "gone" is what stops the AttributeError the user saw as
+        "Error loading model: 'NoneType' object has no attribute 'poll'" (#10353)."""
         b = _make_backend()
         b._process.poll.return_value = None
         probes = []
@@ -96,7 +94,6 @@ class TestWaitForHealthResilience:
         assert b._wait_for_health(timeout = 30.0, interval = 0.01) is False
         assert len(probes) == 2
         assert not any("health check timed out" in ln for ln in b._stdout_lines)
-        # The contract _spawn_and_wait relies on: see the test below.
         assert b._health_wait_cancelled is True
 
     def test_a_teardown_before_the_first_probe_is_still_not_a_crash(self, monkeypatch):
@@ -107,12 +104,8 @@ class TestWaitForHealthResilience:
         assert b._health_wait_cancelled is True
 
     def test_a_teardown_is_terminal_so_the_caller_reads_no_exit_code(self, monkeypatch):
-        """Returning False is not enough on its own. _spawn_and_wait only stops on
-        _health_wait_cancelled; without it, it falls through to
-        `self._process.poll()` for a startup exit code and raises the very
-        AttributeError this guard exists to prevent, one frame further up. Marking
-        the wait terminal also keeps the --fit / ROCm / CPU-fallback retry ladder
-        from spawning a replacement llama-server after shutdown killed the first."""
+        """False alone is not enough: _spawn_and_wait stops only on this flag, else
+        it reads the cleared reference and raises one frame up, and respawns."""
         b = _make_backend()
         b._process = None
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock.Mock(status_code = 503))
@@ -124,9 +117,8 @@ class TestWaitForHealthResilience:
         ) is False
 
     def test_a_crash_leaves_the_wait_unmarked_so_the_retries_still_run(self, monkeypatch):
-        """The other side of the guard above: a real startup crash must NOT look
-        terminal, or the --fit off and CPU fallbacks stop recovering loads that
-        used to recover."""
+        """The other side: a real crash must NOT look terminal, or the --fit off
+        and CPU fallbacks stop recovering loads that used to recover."""
         b = _make_backend()
         b._process.poll.return_value = 1
         b._process.returncode = 1
@@ -135,8 +127,6 @@ class TestWaitForHealthResilience:
         assert b._health_wait_cancelled is False
 
     def test_a_teardown_marker_does_not_leak_into_the_next_load(self, monkeypatch):
-        """The flag is per-wait. A load following a torn-down one must not inherit
-        its abort, or the first load after a cancelled quit silently fails."""
         b = _make_backend()
         b._process = None
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock.Mock(status_code = 200))
@@ -148,10 +138,8 @@ class TestWaitForHealthResilience:
         assert b._health_wait_cancelled is False
 
     def test_a_teardown_from_a_real_thread_is_not_a_crash(self, monkeypatch):
-        """The production race is two threads, not a callback: the shutdown thread
-        clears _process while the load thread is inside the probe. Reading the
-        attribute once per iteration is what makes that safe, so drive it that way
-        rather than only through a monkeypatched probe."""
+        """Two real threads, not a probe callback: the once-per-iteration read is
+        what makes it safe, so drive it that way."""
         b = _make_backend()
         b._process.poll.return_value = None
         in_probe = threading.Event()
@@ -538,15 +526,8 @@ class TestCancelledWaitEndsTheLoad:
         )
 
     def test_a_teardown_mid_load_ends_the_load_instead_of_raising(self, tmp_path, monkeypatch):
-        """The whole race, through the real caller (#10353).
-
-        The three waiter tests above call _wait_for_health directly, so none of
-        them reach _spawn_and_wait, which is where the reported traceback actually
-        resurfaced: it stops early only on _health_wait_cancelled, and otherwise
-        reads self._process.poll() for a startup exit code. With the reference
-        cleared that is the same "'NoneType' object has no attribute 'poll'" the
-        user saw, one frame up. This drives load_model with a live child and lets
-        the shutdown kill land inside the health probe."""
+        """The whole race through the real caller (#10353): the waiter tests above
+        never reach _spawn_and_wait, which is where the traceback resurfaced."""
         import subprocess
 
         from core.inference.llama_cpp import GgufLoadIntent
@@ -571,10 +552,7 @@ class TestCancelledWaitEndsTheLoad:
 
         def _popen(*a, **kw):
             argv = [str(x) for x in (a[0] if a else kw.get("args") or [])]
-            # A load also shells out to probe_server_capabilities (`<binary>
-            # --help`) and to nvidia-smi for the VRAM read. Neither is a server
-            # launch, and subprocess.run needs the real Popen for its context
-            # manager, so only argv naming the model counts here.
+            # `--help` and nvidia-smi are not launches; run() needs a real Popen.
             if str(gguf) not in argv:
                 return _real_popen(*a, **kw)
             spawns.append(argv)
@@ -601,8 +579,7 @@ class TestCancelledWaitEndsTheLoad:
             )
             is False
         )
-        # A teardown is terminal, so no fallback may start a second llama-server:
-        # it would outlive the app whose shutdown just killed the first.
+        # A second server would outlive the app whose shutdown killed the first.
         assert len(spawns) == 1, f"respawned after shutdown (spawns={len(spawns)})"
 
 

--- a/studio/backend/tests/test_llama_cpp_wait_for_health.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_health.py
@@ -96,12 +96,88 @@ class TestWaitForHealthResilience:
         assert b._wait_for_health(timeout = 30.0, interval = 0.01) is False
         assert len(probes) == 2
         assert not any("health check timed out" in ln for ln in b._stdout_lines)
+        # The contract _spawn_and_wait relies on: see the test below.
+        assert b._health_wait_cancelled is True
 
     def test_a_teardown_before_the_first_probe_is_still_not_a_crash(self, monkeypatch):
         b = _make_backend()
         b._process = None
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock.Mock(status_code = 200))
         assert b._wait_for_health(timeout = 30.0, interval = 0.01) is False
+        assert b._health_wait_cancelled is True
+
+    def test_a_teardown_is_terminal_so_the_caller_reads_no_exit_code(self, monkeypatch):
+        """Returning False is not enough on its own. _spawn_and_wait only stops on
+        _health_wait_cancelled; without it, it falls through to
+        `self._process.poll()` for a startup exit code and raises the very
+        AttributeError this guard exists to prevent, one frame further up. Marking
+        the wait terminal also keeps the --fit / ROCm / CPU-fallback retry ladder
+        from spawning a replacement llama-server after shutdown killed the first."""
+        b = _make_backend()
+        b._process = None
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock.Mock(status_code = 503))
+        assert b._wait_for_health(timeout = 30.0, interval = 0.01) is False
+        assert b._health_wait_cancelled is True
+        # Exactly what the caller does at the `if not healthy` branch.
+        assert (
+            b._process is not None
+            and b._process.poll() is not None
+            and b._process.returncode != 0
+        ) is False
+
+    def test_a_crash_leaves_the_wait_unmarked_so_the_retries_still_run(self, monkeypatch):
+        """The other side of the guard above: a real startup crash must NOT look
+        terminal, or the --fit off and CPU fallbacks stop recovering loads that
+        used to recover."""
+        b = _make_backend()
+        b._process.poll.return_value = 1
+        b._process.returncode = 1
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock.Mock(status_code = 503))
+        assert b._wait_for_health(timeout = 1.0, interval = 0.01) is False
+        assert b._health_wait_cancelled is False
+
+    def test_a_teardown_marker_does_not_leak_into_the_next_load(self, monkeypatch):
+        """The flag is per-wait. A load following a torn-down one must not inherit
+        its abort, or the first load after a cancelled quit silently fails."""
+        b = _make_backend()
+        b._process = None
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock.Mock(status_code = 200))
+        assert b._wait_for_health(timeout = 30.0, interval = 0.01) is False
+        assert b._health_wait_cancelled is True
+        b._process = mock.Mock()
+        b._process.poll.return_value = None
+        assert b._wait_for_health(timeout = 30.0, interval = 0.01) is True
+        assert b._health_wait_cancelled is False
+
+    def test_a_teardown_from_a_real_thread_is_not_a_crash(self, monkeypatch):
+        """The production race is two threads, not a callback: the shutdown thread
+        clears _process while the load thread is inside the probe. Reading the
+        attribute once per iteration is what makes that safe, so drive it that way
+        rather than only through a monkeypatched probe."""
+        b = _make_backend()
+        b._process.poll.return_value = None
+        in_probe = threading.Event()
+        cleared = threading.Event()
+
+        def probe(*a, **kw):
+            in_probe.set()
+            cleared.wait(2.0)
+            return mock.Mock(status_code = 503)
+
+        monkeypatch.setattr(httpx, "get", probe)
+
+        def shutdown():
+            in_probe.wait(2.0)
+            b._process = None  # _kill_process, from run.py's shutdown path
+            cleared.set()
+
+        t = threading.Thread(target = shutdown)
+        t.start()
+        try:
+            assert b._wait_for_health(timeout = 30.0, interval = 0.01) is False
+        finally:
+            t.join(5.0)
+        assert b._health_wait_cancelled is True
 
     def test_a_crash_still_reports_the_exit_code(self, monkeypatch):
         """The teardown guard must not swallow the crash branch: an exited
@@ -462,6 +538,74 @@ class TestCancelledWaitEndsTheLoad:
             )
             is False
         )
+
+    def test_a_teardown_mid_load_ends_the_load_instead_of_raising(self, tmp_path, monkeypatch):
+        """The whole race, through the real caller (#10353).
+
+        The three waiter tests above call _wait_for_health directly, so none of
+        them reach _spawn_and_wait, which is where the reported traceback actually
+        resurfaced: it stops early only on _health_wait_cancelled, and otherwise
+        reads self._process.poll() for a startup exit code. With the reference
+        cleared that is the same "'NoneType' object has no attribute 'poll'" the
+        user saw, one frame up. This drives load_model with a live child and lets
+        the shutdown kill land inside the health probe."""
+        import subprocess
+
+        from core.inference.llama_cpp import GgufLoadIntent
+
+        gguf = tmp_path / "model.gguf"
+        gguf.write_bytes(b"GGUF" + b"\0" * 4096)
+
+        b = LlamaCppBackend()
+        b._find_llama_server_binary = lambda *a, **kw: "/usr/bin/true"
+        b._non_chat_gguf_refusal_for_path = lambda *a, **kw: None
+        b._non_chat_gguf_refusal = lambda *a, **kw: None
+        # The drain thread would iterate a Mock's stdout forever.
+        b._drain_stdout = lambda *a, **kw: None
+
+        def _kill():
+            b._process = None  # the one line of _kill_process this race turns on
+
+        b._kill_process = _kill
+
+        spawns = []
+        _real_popen = subprocess.Popen
+
+        def _popen(*a, **kw):
+            argv = [str(x) for x in (a[0] if a else kw.get("args") or [])]
+            # A load also shells out to probe_server_capabilities (`<binary>
+            # --help`) and to nvidia-smi for the VRAM read. Neither is a server
+            # launch, and subprocess.run needs the real Popen for its context
+            # manager, so only argv naming the model counts here.
+            if str(gguf) not in argv:
+                return _real_popen(*a, **kw)
+            spawns.append(argv)
+            proc = mock.Mock()
+            proc.poll.return_value = None  # alive: shutdown kills it, it does not crash
+            proc.pid = 424242
+            return proc
+
+        monkeypatch.setattr(subprocess, "Popen", _popen)
+
+        def probe(*a, **kw):
+            _kill()  # run.py's shutdown, arriving while the load waits
+            return mock.Mock(status_code = 503)
+
+        monkeypatch.setattr(httpx, "get", probe)
+
+        assert (
+            b.load_model(
+                GgufLoadIntent(
+                    model_identifier = "owner/model",
+                    gguf_path = str(gguf),
+                    n_ctx = 4096,
+                ),
+            )
+            is False
+        )
+        # A teardown is terminal, so no fallback may start a second llama-server:
+        # it would outlive the app whose shutdown just killed the first.
+        assert len(spawns) == 1, f"respawned after shutdown (spawns={len(spawns)})"
 
 
 def test_a_cancelled_diffusion_start_reaps_the_runner():

--- a/studio/backend/tests/test_llama_cpp_wait_for_health.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_health.py
@@ -120,9 +120,7 @@ class TestWaitForHealthResilience:
         assert b._health_wait_cancelled is True
         # Exactly what the caller does at the `if not healthy` branch.
         assert (
-            b._process is not None
-            and b._process.poll() is not None
-            and b._process.returncode != 0
+            b._process is not None and b._process.poll() is not None and b._process.returncode != 0
         ) is False
 
     def test_a_crash_leaves_the_wait_unmarked_so_the_retries_still_run(self, monkeypatch):


### PR DESCRIPTION
A Strix Halo user's log ends a model load with

```
Error loading model: 'NoneType' object has no attribute 'poll'
  File "studio/backend/core/inference/llama_cpp.py", line 25723, in _wait_for_health
    if self._process.poll() is not None:
```

The app had started a graceful shutdown while the model was still loading. The cleanup killed llama-server and `_kill_process` cleared `self._process`; the load thread then dereferenced it on its next pass through the wait loop, so a normal quit during a slow load surfaced to the user as a load error with a Python traceback.

`_wait_for_health` now reads the process once per iteration and treats its absence as the server being gone, which is what it is. A process that has actually exited still reports its exit code and its output tail, unchanged; only the torn-down case is new.

Three tests on the wait: a teardown mid-wait and a teardown before the first probe both return False instead of raising, and a crashed server still names its exit code, so the new guard cannot swallow the crash branch. Both teardown tests fail on `main` with the exact `AttributeError` above.

### The second test

The same session is the one that reported long prefills being cut short. That first-token deadline was fixed in #10172, but nothing covered the other clock: the durable generation lease, which is also 1200 seconds. A 250K-token prefill runs longer than that before it produces a token, and what keeps its lease alive is that llama-server's progress events reach the database like any other chunk. Those events carry a null-content delta, so a filter that dropped content-less chunks would reap a healthy prefill and nothing would say why. The test samples the lease mid-run, before any token exists, and asserts the three progress events landed.

### Verification

- `test_llama_cpp_wait_for_health.py` 42 passed
- `test_chat_generation_supervisor.py` 25 passed
- `test_chat_generation_run_lease.py` 30 passed
- `test_chat_generation_runs.py` 56 passed
- `test_chat_generation_lease_compat.py` 47 passed