### PR TITLE
Studio: name the llama.cpp backend in the install log, and stop labelling Windows ROCm torch as CPU

### DIFF
--- a/studio/backend/tests/test_torch_step_label.py
+++ b/studio/backend/tests/test_torch_step_label.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for _torch_step_label in install_python_stack.py.
+
+The label is the only place a standalone `unsloth studio update` states which
+torch backend it is working on. On Windows the ROCm probe reads rocminfo and
+amd-smi, which ship with the HIP SDK and not with AMD's bundled-runtime wheels,
+so a working ROCm host printed "torch check (cpu)" on the same line-block where
+the next step correctly reported Windows ROCm.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_INSTALL_SCRIPT = Path(__file__).resolve().parents[2] / "install_python_stack.py"
+
+
+def _load_module(monkeypatch):
+    sys.modules.pop("install_python_stack", None)
+    monkeypatch.syspath_prepend(str(_INSTALL_SCRIPT.parent))
+    import install_python_stack
+
+    return install_python_stack
+
+
+def _label(monkeypatch, *, nvidia, rocm_probe, windows_rocm_torch, known_backend = ""):
+    mod = _load_module(monkeypatch)
+    monkeypatch.setattr(mod, "_TORCH_BACKEND", known_backend)
+    monkeypatch.setattr(mod, "_has_usable_nvidia_gpu", lambda: nvidia)
+    monkeypatch.setattr(mod, "_has_rocm_gpu", lambda: rocm_probe)
+    monkeypatch.setattr(mod, "_installed_torch_is_windows_rocm", lambda: windows_rocm_torch)
+    return mod._torch_step_label("check")
+
+
+def test_an_explicit_backend_wins_over_every_probe(monkeypatch):
+    label = _label(
+        monkeypatch,
+        nvidia = True,
+        rocm_probe = True,
+        windows_rocm_torch = True,
+        known_backend = "xpu",
+    )
+    assert label == "torch check (xpu)"
+
+
+def test_nvidia_still_takes_priority(monkeypatch):
+    label = _label(monkeypatch, nvidia = True, rocm_probe = False, windows_rocm_torch = True)
+    assert label == "torch check (cuda)"
+
+
+def test_the_rocm_probe_still_answers(monkeypatch):
+    label = _label(monkeypatch, nvidia = False, rocm_probe = True, windows_rocm_torch = False)
+    assert label == "torch check (rocm)"
+
+
+def test_a_windows_rocm_torch_is_rocm_even_with_no_rocm_tooling(monkeypatch):
+    """The regression: rocminfo and amd-smi are absent, torch.version.hip is not."""
+    label = _label(monkeypatch, nvidia = False, rocm_probe = False, windows_rocm_torch = True)
+    assert label == "torch check (rocm)"
+
+
+def test_a_host_with_neither_is_still_cpu(monkeypatch):
+    label = _label(monkeypatch, nvidia = False, rocm_probe = False, windows_rocm_torch = False)
+    assert label == "torch check (cpu)"

--- a/studio/backend/tests/test_torch_step_label.py
+++ b/studio/backend/tests/test_torch_step_label.py
@@ -26,7 +26,14 @@ def _load_module(monkeypatch):
     return install_python_stack
 
 
-def _label(monkeypatch, *, nvidia, rocm_probe, windows_rocm_torch, known_backend = ""):
+def _label(
+    monkeypatch,
+    *,
+    nvidia,
+    rocm_probe,
+    windows_rocm_torch,
+    known_backend = "",
+):
     mod = _load_module(monkeypatch)
     monkeypatch.setattr(mod, "_TORCH_BACKEND", known_backend)
     monkeypatch.setattr(mod, "_has_usable_nvidia_gpu", lambda: nvidia)

--- a/studio/backend/tests/test_torch_step_label.py
+++ b/studio/backend/tests/test_torch_step_label.py
@@ -361,7 +361,13 @@ def _requires_hip_reader(mod):
         pytest.skip("_torch_hip_version_on_disk does not exist on this tree")
 
 
-def _fake_torch_on_path(monkeypatch, tmp_path, version_py, *, as_directory = False):
+def _fake_torch_on_path(
+    monkeypatch,
+    tmp_path,
+    version_py,
+    *,
+    as_directory = False,
+):
     """Put a stand-in torch package first on sys.path and make find_spec see it.
 
     importlib.util.find_spec returns sys.modules[name].__spec__ when the module is

--- a/studio/backend/tests/test_torch_step_label.py
+++ b/studio/backend/tests/test_torch_step_label.py
@@ -145,8 +145,6 @@ def test_every_suffix_keeps_the_same_backend(monkeypatch, platform_name, hardwar
     assert mod._torch_step_label(suffix) == f"torch {suffix} ({expected})"
 
 
-
-
 @pytest.mark.parametrize("known_backend", ["cuda", "rocm", "cpu", "xpu", "gfx1151-custom"])
 @pytest.mark.parametrize("platform_name", sorted(_PLATFORMS))
 def test_an_explicit_backend_wins_over_every_probe(monkeypatch, known_backend, platform_name):
@@ -180,8 +178,6 @@ def test_an_explicit_backend_consults_no_detector(monkeypatch):
     assert mod._torch_step_label("check") == "torch check (cuda)"
 
 
-
-
 def test_nvidia_still_takes_priority(monkeypatch):
     mod, _calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "nvidia")
     monkeypatch.setattr(mod, "_torch_hip_version_on_disk", lambda: "6.4.43483")
@@ -209,8 +205,6 @@ def test_a_windows_rocm_torch_is_recognised_by_version_string_alone(monkeypatch)
 def test_a_host_with_neither_is_still_cpu(monkeypatch):
     mod, _calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "cpu")
     assert mod._torch_step_label("check") == "torch check (cpu)"
-
-
 
 
 @pytest.mark.parametrize("platform_name", sorted(_PLATFORMS))
@@ -411,8 +405,6 @@ def test_the_hip_reader_starts_no_subprocess(monkeypatch, tmp_path):
     )
     _fake_torch_on_path(monkeypatch, tmp_path, _VERSION_PY_ROCM)
     assert mod._torch_hip_version_on_disk() == "6.4.43483-a1b2c3d"
-
-
 
 
 def test_the_label_on_this_real_host(monkeypatch):

--- a/studio/backend/tests/test_torch_step_label.py
+++ b/studio/backend/tests/test_torch_step_label.py
@@ -8,12 +8,22 @@ torch backend it is working on. On Windows the ROCm probe reads rocminfo and
 amd-smi, which ship with the HIP SDK and not with AMD's bundled-runtime wheels,
 so a working ROCm host printed "torch check (cpu)" on the same line-block where
 the next step correctly reported Windows ROCm.
+
+The second thing this file pins is the COST of answering that. _torch_step_label
+runs before the first pip step of its block, where the memoized _TORCH_RUNTIME_PROBE
+is cold, and on the affected host none of the four _ensure_* calls that follow reach
+the probe either. Answering with `import torch` there spent up to the probe's 90s
+timeout before _progress() emitted anything -- on exactly the wedged-driver hosts
+that timeout exists to rescue -- so the verdict is read off disk instead.
 """
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 _INSTALL_SCRIPT = Path(__file__).resolve().parents[2] / "install_python_stack.py"
 
@@ -26,49 +36,450 @@ def _load_module(monkeypatch):
     return install_python_stack
 
 
-def _label(
+# -- the hardware half of the matrix -------------------------------------------------
+# Each fixture is what the four detectors report on that machine. "amd_bundled" is the
+# reported Strix Halo case: AMD's bundled-runtime wheels carry no rocminfo and no
+# amd-smi, so only torch's own version.py knows the build is ROCm.
+_HARDWARE = {
+    "nvidia":      dict(nvidia = True,  rocm_probe = False, hip = "",             label = "2.9.1+cu128"),
+    "amd_tooling": dict(nvidia = False, rocm_probe = True,  hip = "6.4.43483",    label = "2.8.0+rocm6.4"),
+    "amd_bundled": dict(nvidia = False, rocm_probe = False, hip = "6.4.43483-a1", label = "2.8.0a0+rocmsdk20250901"),
+    "xpu":         dict(nvidia = False, rocm_probe = False, hip = "",             label = "2.9.1+xpu"),
+    "cpu":         dict(nvidia = False, rocm_probe = False, hip = "",             label = "2.9.1+cpu"),
+    "no_torch":    dict(nvidia = False, rocm_probe = False, hip = "",             label = ""),
+}
+
+# -- the platform half ---------------------------------------------------------------
+_PLATFORMS = {
+    "windows": dict(is_windows = True,  is_macos = False, is_wsl = False),
+    "linux":   dict(is_windows = False, is_macos = False, is_wsl = False),
+    "wsl":     dict(is_windows = False, is_macos = False, is_wsl = True),
+    "macos":   dict(is_windows = False, is_macos = True,  is_wsl = False),
+}
+
+
+def _prepare(
     monkeypatch,
     *,
-    nvidia,
-    rocm_probe,
-    windows_rocm_torch,
+    platform_name,
+    hardware_name,
     known_backend = "",
+    warm_probe = None,
 ):
+    """Load the module with one (platform, hardware) cell of the matrix in place.
+
+    Everything is stubbed at a boundary that exists on BOTH sides of this change --
+    the four detectors, the two file reads, and _probe_torch_runtime -- so the same
+    file discriminates rather than erroring out on a symbol one tree lacks.
+
+    Returns the module and the list _probe_torch_runtime calls are recorded into.
+    Reaching that function is the expensive event: it is what spawns `import torch`
+    under a 90s timeout, so an empty list is the assertion that a label cost nothing.
+    """
     mod = _load_module(monkeypatch)
+    plat = _PLATFORMS[platform_name]
+    hw = _HARDWARE[hardware_name]
+
     monkeypatch.setattr(mod, "_TORCH_BACKEND", known_backend)
-    monkeypatch.setattr(mod, "_has_usable_nvidia_gpu", lambda: nvidia)
-    monkeypatch.setattr(mod, "_has_rocm_gpu", lambda: rocm_probe)
-    monkeypatch.setattr(mod, "_installed_torch_is_windows_rocm", lambda: windows_rocm_torch)
-    return mod._torch_step_label("check")
+    monkeypatch.setattr(mod, "IS_WINDOWS", plat["is_windows"])
+    monkeypatch.setattr(mod, "IS_MACOS", plat["is_macos"])
+    monkeypatch.setattr(mod, "IS_LINUX", not plat["is_windows"] and not plat["is_macos"])
+    monkeypatch.setattr(mod, "_is_wsl", lambda: plat["is_wsl"])
+    monkeypatch.setattr(mod, "_has_usable_nvidia_gpu", lambda: hw["nvidia"])
+    monkeypatch.setattr(mod, "_has_rocm_gpu", lambda: hw["rocm_probe"])
+    # The OFF-DISK reads. raising = False because _torch_hip_version_on_disk does not
+    # exist on the pre-fix tree; there the same facts arrive via _probe_torch_runtime.
+    monkeypatch.setattr(mod, "_torch_hip_version_on_disk", lambda: hw["hip"], raising = False)
+    monkeypatch.setattr(mod, "_installed_torch_version_label", lambda: hw["label"])
+    monkeypatch.setattr(mod, "_TORCH_RUNTIME_PROBE", warm_probe)
 
-
-def test_an_explicit_backend_wins_over_every_probe(monkeypatch):
-    label = _label(
-        monkeypatch,
-        nvidia = True,
-        rocm_probe = True,
-        windows_rocm_torch = True,
-        known_backend = "xpu",
+    probe_calls = []
+    probe_result = warm_probe if warm_probe is not None else (
+        True, bool(hw["label"]), hw["label"] or None, hw["hip"], ""
     )
-    assert label == "torch check (xpu)"
+
+    def _recording_probe():
+        # Mirror the real function's memo exactly: a warm memo returns instantly and costs
+        # nothing, so only a COLD entry is an interpreter start worth recording.
+        if mod._TORCH_RUNTIME_PROBE is not None:
+            return mod._TORCH_RUNTIME_PROBE
+        probe_calls.append(probe_result)
+        mod._TORCH_RUNTIME_PROBE = probe_result
+        return probe_result
+
+    monkeypatch.setattr(mod, "_probe_torch_runtime", _recording_probe)
+    # Belt and braces: nothing in this path may shell out either.
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *a, **k: pytest.fail(f"a progress label must not start a subprocess: {a!r}"),
+    )
+    return mod, probe_calls
+
+
+# ==== the platform x hardware matrix ================================================
+# Expected label per cell with UNSLOTH_TORCH_BACKEND unset, i.e. every standalone
+# `unsloth studio update`. Only Windows consults torch's own ROCm build, because
+# _installed_torch_is_windows_rocm_cheap returns False on `not IS_WINDOWS` before doing
+# any work -- that is what keeps Linux, WSL and macOS on their pre-existing answers.
+_MATRIX = {
+    ("windows", "nvidia"): "cuda",
+    ("windows", "amd_tooling"): "rocm",
+    ("windows", "amd_bundled"): "rocm",   # the regression this PR fixes
+    ("windows", "xpu"): "cpu",
+    ("windows", "cpu"): "cpu",
+    ("windows", "no_torch"): "cpu",
+    ("linux", "nvidia"): "cuda",
+    ("linux", "amd_tooling"): "rocm",
+    ("linux", "amd_bundled"): "cpu",      # no rocminfo on Linux means no ROCm claim
+    ("linux", "xpu"): "cpu",
+    ("linux", "cpu"): "cpu",
+    ("linux", "no_torch"): "cpu",
+    ("wsl", "nvidia"): "cuda",
+    ("wsl", "amd_tooling"): "rocm",
+    ("wsl", "amd_bundled"): "cpu",
+    ("wsl", "xpu"): "cpu",
+    ("wsl", "cpu"): "cpu",
+    ("wsl", "no_torch"): "cpu",
+    # macOS has no NVIDIA or AMD ROCm story; these rows pin the function's actual
+    # behaviour rather than claiming the configurations are supported.
+    ("macos", "nvidia"): "cuda",
+    ("macos", "amd_tooling"): "rocm",
+    ("macos", "amd_bundled"): "cpu",
+    ("macos", "xpu"): "cpu",
+    ("macos", "cpu"): "cpu",
+    ("macos", "no_torch"): "cpu",
+}
+
+
+@pytest.mark.parametrize(("platform_name", "hardware_name"), sorted(_MATRIX))
+def test_label_over_the_platform_and_hardware_matrix(monkeypatch, platform_name, hardware_name):
+    mod, _calls = _prepare(
+        monkeypatch, platform_name = platform_name, hardware_name = hardware_name
+    )
+    expected = _MATRIX[(platform_name, hardware_name)]
+    assert mod._torch_step_label("check") == f"torch check ({expected})"
+
+
+@pytest.mark.parametrize(("platform_name", "hardware_name"), sorted(_MATRIX))
+@pytest.mark.parametrize("suffix", ["check", "final", "flavor"])
+def test_every_suffix_keeps_the_same_backend(monkeypatch, platform_name, hardware_name, suffix):
+    """All three call sites (:7166, :7371, :7383) share one backend verdict."""
+    mod, _calls = _prepare(
+        monkeypatch, platform_name = platform_name, hardware_name = hardware_name
+    )
+    expected = _MATRIX[(platform_name, hardware_name)]
+    assert mod._torch_step_label(suffix) == f"torch {suffix} ({expected})"
+
+
+# ==== an explicit backend wins over every probe =====================================
+
+
+@pytest.mark.parametrize("known_backend", ["cuda", "rocm", "cpu", "xpu", "gfx1151-custom"])
+@pytest.mark.parametrize("platform_name", sorted(_PLATFORMS))
+def test_an_explicit_backend_wins_over_every_probe(monkeypatch, known_backend, platform_name):
+    """install.sh's resolved backend is authoritative, verbatim, on every platform."""
+    mod, _calls = _prepare(
+        monkeypatch,
+        platform_name = platform_name,
+        # deliberately contradictory hardware: nothing below may override the pin
+        hardware_name = "amd_bundled",
+        known_backend = known_backend,
+    )
+    assert mod._torch_step_label("check") == f"torch check ({known_backend})"
+
+
+def test_an_explicit_backend_consults_no_detector(monkeypatch):
+    mod = _load_module(monkeypatch)
+    monkeypatch.setattr(mod, "_TORCH_BACKEND", "cuda")
+    for name in (
+        "_has_usable_nvidia_gpu",
+        "_has_rocm_gpu",
+        "_installed_torch_is_windows_rocm",
+        "_installed_torch_is_windows_rocm_cheap",
+        "_torch_hip_version_on_disk",
+        "_installed_torch_version_label",
+    ):
+        monkeypatch.setattr(
+            mod,
+            name,
+            lambda *_a, **_k: pytest.fail(f"{name} must not run for a pinned backend"),
+            raising = False,
+        )
+    assert mod._torch_step_label("check") == "torch check (cuda)"
+
+
+# ==== precedence ====================================================================
 
 
 def test_nvidia_still_takes_priority(monkeypatch):
-    label = _label(monkeypatch, nvidia = True, rocm_probe = False, windows_rocm_torch = True)
-    assert label == "torch check (cuda)"
+    """A mixed NVIDIA+AMD Windows host stays CUDA even with a ROCm torch installed."""
+    mod, _calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "nvidia")
+    monkeypatch.setattr(mod, "_torch_hip_version_on_disk", lambda: "6.4.43483")
+    assert mod._torch_step_label("check") == "torch check (cuda)"
 
 
 def test_the_rocm_probe_still_answers(monkeypatch):
-    label = _label(monkeypatch, nvidia = False, rocm_probe = True, windows_rocm_torch = False)
-    assert label == "torch check (rocm)"
+    """rocminfo/amd-smi remain the primary signal; nothing about them changed."""
+    mod, _calls = _prepare(monkeypatch, platform_name = "linux", hardware_name = "amd_tooling")
+    monkeypatch.setattr(mod, "_torch_hip_version_on_disk", lambda: "")
+    monkeypatch.setattr(mod, "_installed_torch_version_label", lambda: "")
+    assert mod._torch_step_label("check") == "torch check (rocm)"
 
 
 def test_a_windows_rocm_torch_is_rocm_even_with_no_rocm_tooling(monkeypatch):
-    """The regression: rocminfo and amd-smi are absent, torch.version.hip is not."""
-    label = _label(monkeypatch, nvidia = False, rocm_probe = False, windows_rocm_torch = True)
-    assert label == "torch check (rocm)"
+    """The regression: rocminfo and amd-smi are absent, torch's own version.py is not."""
+    mod, _calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "amd_bundled")
+    assert mod._torch_step_label("check") == "torch check (rocm)"
+
+
+def test_a_windows_rocm_torch_is_recognised_by_version_string_alone(monkeypatch):
+    """A build whose version.py carries no hip= line but whose __version__ says rocm."""
+    mod, _calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "amd_bundled")
+    monkeypatch.setattr(mod, "_torch_hip_version_on_disk", lambda: "")
+    assert mod._torch_step_label("check") == "torch check (rocm)"
 
 
 def test_a_host_with_neither_is_still_cpu(monkeypatch):
-    label = _label(monkeypatch, nvidia = False, rocm_probe = False, windows_rocm_torch = False)
-    assert label == "torch check (cpu)"
+    mod, _calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "cpu")
+    assert mod._torch_step_label("check") == "torch check (cpu)"
+
+
+# ==== the cost of the answer ========================================================
+
+
+@pytest.mark.parametrize("platform_name", sorted(_PLATFORMS))
+@pytest.mark.parametrize("hardware_name", sorted(_HARDWARE))
+def test_the_label_never_runs_the_torch_probe(monkeypatch, platform_name, hardware_name):
+    """Every cell of the matrix, with a COLD memo: zero `import torch` subprocesses.
+
+    _probe_torch_runtime is the 90s-bounded interpreter start. Formatting a progress
+    line must never be what pays for it.
+    """
+    mod, probe_calls = _prepare(
+        monkeypatch, platform_name = platform_name, hardware_name = hardware_name
+    )
+    mod._torch_step_label("check")
+    assert probe_calls == []
+
+
+def test_the_label_leaves_the_probe_memo_cold(monkeypatch):
+    """A cold _TORCH_RUNTIME_PROBE stays cold, so the label pays for nothing.
+
+    The discriminating assertion for the affected host: pre-fix, the label reached
+    _probe_torch_runtime, populating the memo and spending up to its 90s timeout before
+    _progress() had printed anything -- and pip_install invalidates that memo three
+    statements later, so the cost was not even amortised.
+    """
+    mod, probe_calls = _prepare(
+        monkeypatch, platform_name = "windows", hardware_name = "amd_bundled"
+    )
+    assert mod._TORCH_RUNTIME_PROBE is None
+    assert mod._torch_step_label("check") == "torch check (rocm)"
+    assert probe_calls == []
+    assert mod._TORCH_RUNTIME_PROBE is None
+
+
+def test_the_label_reuses_a_warm_probe_instead_of_the_disk(monkeypatch):
+    """When something else already paid for the probe, prefer its richer answer."""
+    warm = (True, True, "2.8.0a0+rocmsdk20250901", "6.4.43483", "")
+    mod, probe_calls = _prepare(
+        monkeypatch,
+        platform_name = "windows",
+        hardware_name = "cpu",  # disk says CPU
+        warm_probe = warm,
+    )
+    disk_reads = []
+    monkeypatch.setattr(
+        mod,
+        "_torch_hip_version_on_disk",
+        lambda: disk_reads.append("hip") or "",
+        raising = False,
+    )
+    assert mod._torch_step_label("check") == "torch check (rocm)"
+    assert probe_calls == []    # a warm memo is reused, never re-probed
+    assert disk_reads == []     # and the disk is not consulted behind it
+
+
+def test_a_warm_negative_probe_is_believed(monkeypatch):
+    """A warm probe saying "not ROCm" is authoritative over the disk heuristics."""
+    warm = (True, True, "2.9.1+cpu", "", "")
+    mod, probe_calls = _prepare(
+        monkeypatch,
+        platform_name = "windows",
+        hardware_name = "amd_bundled",
+        warm_probe = warm,
+    )
+    assert mod._torch_step_label("check") == "torch check (cpu)"
+    assert probe_calls == []
+
+
+def test_an_inconclusive_warm_probe_is_not_read_as_rocm(monkeypatch):
+    """The wedged-driver tuple (ran=False) must not manufacture a ROCm claim."""
+    mod, probe_calls = _prepare(
+        monkeypatch,
+        platform_name = "windows",
+        hardware_name = "cpu",
+        warm_probe = (False, False, None, "", ""),
+    )
+    assert mod._torch_step_label("check") == "torch check (cpu)"
+    assert probe_calls == []
+
+
+@pytest.mark.parametrize("platform_name", ["linux", "wsl", "macos"])
+def test_non_windows_never_touches_the_torch_build(monkeypatch, platform_name):
+    """Linux, WSL and macOS short-circuit before any disk or probe read.
+
+    This is what makes the change incapable of altering the answer on those platforms.
+    """
+    mod, probe_calls = _prepare(
+        monkeypatch, platform_name = platform_name, hardware_name = "amd_bundled"
+    )
+    touched = []
+    monkeypatch.setattr(
+        mod,
+        "_torch_hip_version_on_disk",
+        lambda: touched.append("hip") or "",
+        raising = False,
+    )
+    monkeypatch.setattr(
+        mod, "_installed_torch_version_label", lambda: touched.append("label") or ""
+    )
+    # Not asserted here: whether the Windows helper is CALLED off Windows. Both trees
+    # return False on `not IS_WINDOWS` before doing any work, so the call is free; what
+    # matters is that no probe and no disk read happen behind it.
+    assert mod._torch_step_label("check") == "torch check (cpu)"
+    assert touched == []
+    assert probe_calls == []
+
+
+# ==== the off-disk reader itself ====================================================
+# Unit tests for the helper this change introduces. They are skipped, not failed, on a
+# tree that predates it: their job is to hold the new reader, not to discriminate.
+
+
+def _requires_hip_reader(mod):
+    if not hasattr(mod, "_torch_hip_version_on_disk"):
+        pytest.skip("_torch_hip_version_on_disk does not exist on this tree")
+
+
+_VERSION_PY_ROCM = """\
+from typing import Optional
+
+__all__ = ['__version__', 'debug', 'cuda', 'git_version', 'hip', 'xpu']
+__version__ = '2.8.0a0+rocmsdk20250901'
+debug = False
+cuda: Optional[str] = None
+git_version = 'deadbeef'
+hip: Optional[str] = '6.4.43483-a1b2c3d'
+xpu: Optional[str] = None
+"""
+
+_VERSION_PY_CUDA = """\
+from typing import Optional
+
+__all__ = ['__version__', 'debug', 'cuda', 'git_version', 'hip', 'xpu']
+__version__ = '2.9.1+cu128'
+debug = False
+cuda: Optional[str] = '12.8'
+git_version = 'deadbeef'
+hip: Optional[str] = None
+xpu: Optional[str] = None
+"""
+
+# The un-annotated form older torch builds wrote.
+_VERSION_PY_ROCM_UNANNOTATED = """\
+__version__ = '2.7.0+rocm6.3'
+hip = '6.3.42131'
+cuda = None
+"""
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (_VERSION_PY_ROCM, "6.4.43483-a1b2c3d"),
+        (_VERSION_PY_ROCM_UNANNOTATED, "6.3.42131"),
+        (_VERSION_PY_CUDA, ""),          # hip = None must not read as a HIP string
+        ("", ""),
+        ("hip = \"6.9.0\"\n", "6.9.0"),   # double-quoted
+        ("__version__ = '2.9.1'\n", ""),
+        ("# hip = '1.0'\n", ""),          # not at the start of a line after ^ anchoring
+    ],
+)
+def test_the_hip_reader_matches_only_a_quoted_value(monkeypatch, tmp_path, text, expected):
+    mod = _load_module(monkeypatch)
+    _requires_hip_reader(mod)
+    torch_dir = tmp_path / "torch"
+    torch_dir.mkdir()
+    (torch_dir / "__init__.py").write_text("", encoding = "utf-8")
+    (torch_dir / "version.py").write_text(text, encoding = "utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    assert mod._torch_hip_version_on_disk() == expected
+
+
+def test_the_hip_reader_survives_a_missing_torch(monkeypatch, tmp_path):
+    """An absent torch is "no answer", never an exception into a progress label."""
+    mod = _load_module(monkeypatch)
+    _requires_hip_reader(mod)
+    monkeypatch.setattr(
+        mod.importlib.util, "find_spec", lambda _name: (_ for _ in ()).throw(ImportError("x"))
+    )
+    assert mod._torch_hip_version_on_disk() == ""
+
+
+def test_the_hip_reader_survives_an_unreadable_version_py(monkeypatch, tmp_path):
+    mod = _load_module(monkeypatch)
+    _requires_hip_reader(mod)
+    torch_dir = tmp_path / "torch"
+    torch_dir.mkdir()
+    (torch_dir / "__init__.py").write_text("", encoding = "utf-8")
+    # version.py is a directory: the read raises OSError, which must be swallowed.
+    (torch_dir / "version.py").mkdir()
+    monkeypatch.syspath_prepend(str(tmp_path))
+    assert mod._torch_hip_version_on_disk() == ""
+
+
+def test_the_hip_reader_starts_no_subprocess(monkeypatch, tmp_path):
+    mod = _load_module(monkeypatch)
+    _requires_hip_reader(mod)
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *a, **k: pytest.fail("reading version.py must not start a subprocess"),
+    )
+    torch_dir = tmp_path / "torch"
+    torch_dir.mkdir()
+    (torch_dir / "__init__.py").write_text("", encoding = "utf-8")
+    (torch_dir / "version.py").write_text(_VERSION_PY_ROCM, encoding = "utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    assert mod._torch_hip_version_on_disk() == "6.4.43483-a1b2c3d"
+
+
+# ==== this machine, unsimulated =====================================================
+
+
+def test_the_label_on_this_real_host(monkeypatch):
+    """One unsimulated observation: whatever this box is, the label costs no subprocess.
+
+    Deliberately asserts the shape rather than a fixed backend, so it holds on the CPU
+    CI runner and on a GPU box alike.
+    """
+    mod = _load_module(monkeypatch)
+    monkeypatch.setattr(mod, "_TORCH_BACKEND", "")
+    monkeypatch.setattr(mod, "_TORCH_RUNTIME_PROBE", None)
+    real_run = subprocess.run
+    calls = []
+
+    def _record(*args, **kwargs):
+        calls.append(args)
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(mod.subprocess, "run", _record)
+    label = mod._torch_step_label("check")
+    assert label.startswith("torch check (") and label.endswith(")")
+    assert label[len("torch check (") : -1] in {"cuda", "rocm", "cpu"}
+    # _has_usable_nvidia_gpu/_has_rocm_gpu may shell out to nvidia-smi or rocminfo; the
+    # `import torch` probe (which is the expensive one) must not be among the calls.
+    assert not any("import torch" in str(a) for a in calls), calls
+    assert mod._TORCH_RUNTIME_PROBE is None

--- a/studio/backend/tests/test_torch_step_label.py
+++ b/studio/backend/tests/test_torch_step_label.py
@@ -361,6 +361,28 @@ def _requires_hip_reader(mod):
         pytest.skip("_torch_hip_version_on_disk does not exist on this tree")
 
 
+def _fake_torch_on_path(monkeypatch, tmp_path, version_py, *, as_directory = False):
+    """Put a stand-in torch package first on sys.path and make find_spec see it.
+
+    importlib.util.find_spec returns sys.modules[name].__spec__ when the module is
+    already imported, so on a runner that HAS torch (every CI job that installs it)
+    prepending sys.path is not enough -- the real package answers and the fixture is
+    silently ignored. Dropping the entry makes find_spec do a real path search; the
+    monkeypatch is undone at teardown, so the real torch comes back.
+    """
+    torch_dir = tmp_path / "torch"
+    torch_dir.mkdir(exist_ok = True)
+    (torch_dir / "__init__.py").write_text("", encoding = "utf-8")
+    if as_directory:
+        (torch_dir / "version.py").mkdir()
+    else:
+        (torch_dir / "version.py").write_text(version_py, encoding = "utf-8")
+    monkeypatch.delitem(sys.modules, "torch", raising = False)
+    monkeypatch.delitem(sys.modules, "torch.version", raising = False)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return torch_dir
+
+
 _VERSION_PY_ROCM = """\
 from typing import Optional
 
@@ -408,11 +430,7 @@ cuda = None
 def test_the_hip_reader_matches_only_a_quoted_value(monkeypatch, tmp_path, text, expected):
     mod = _load_module(monkeypatch)
     _requires_hip_reader(mod)
-    torch_dir = tmp_path / "torch"
-    torch_dir.mkdir()
-    (torch_dir / "__init__.py").write_text("", encoding = "utf-8")
-    (torch_dir / "version.py").write_text(text, encoding = "utf-8")
-    monkeypatch.syspath_prepend(str(tmp_path))
+    _fake_torch_on_path(monkeypatch, tmp_path, text)
     assert mod._torch_hip_version_on_disk() == expected
 
 
@@ -429,12 +447,8 @@ def test_the_hip_reader_survives_a_missing_torch(monkeypatch, tmp_path):
 def test_the_hip_reader_survives_an_unreadable_version_py(monkeypatch, tmp_path):
     mod = _load_module(monkeypatch)
     _requires_hip_reader(mod)
-    torch_dir = tmp_path / "torch"
-    torch_dir.mkdir()
-    (torch_dir / "__init__.py").write_text("", encoding = "utf-8")
     # version.py is a directory: the read raises OSError, which must be swallowed.
-    (torch_dir / "version.py").mkdir()
-    monkeypatch.syspath_prepend(str(tmp_path))
+    _fake_torch_on_path(monkeypatch, tmp_path, "", as_directory = True)
     assert mod._torch_hip_version_on_disk() == ""
 
 
@@ -446,11 +460,7 @@ def test_the_hip_reader_starts_no_subprocess(monkeypatch, tmp_path):
         "run",
         lambda *a, **k: pytest.fail("reading version.py must not start a subprocess"),
     )
-    torch_dir = tmp_path / "torch"
-    torch_dir.mkdir()
-    (torch_dir / "__init__.py").write_text("", encoding = "utf-8")
-    (torch_dir / "version.py").write_text(_VERSION_PY_ROCM, encoding = "utf-8")
-    monkeypatch.syspath_prepend(str(tmp_path))
+    _fake_torch_on_path(monkeypatch, tmp_path, _VERSION_PY_ROCM)
     assert mod._torch_hip_version_on_disk() == "6.4.43483-a1b2c3d"
 
 

--- a/studio/backend/tests/test_torch_step_label.py
+++ b/studio/backend/tests/test_torch_step_label.py
@@ -1,20 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Tests for _torch_step_label in install_python_stack.py.
+"""Tests for _torch_step_label: which backend it names, and what answering costs.
 
-The label is the only place a standalone `unsloth studio update` states which
-torch backend it is working on. On Windows the ROCm probe reads rocminfo and
-amd-smi, which ship with the HIP SDK and not with AMD's bundled-runtime wheels,
-so a working ROCm host printed "torch check (cpu)" on the same line-block where
-the next step correctly reported Windows ROCm.
-
-The second thing this file pins is the COST of answering that. _torch_step_label
-runs before the first pip step of its block, where the memoized _TORCH_RUNTIME_PROBE
-is cold, and on the affected host none of the four _ensure_* calls that follow reach
-the probe either. Answering with `import torch` there spent up to the probe's 90s
-timeout before _progress() emitted anything -- on exactly the wedged-driver hosts
-that timeout exists to rescue -- so the verdict is read off disk instead.
+rocminfo and amd-smi ship with the HIP SDK, not with AMD's bundled-runtime wheels, so a
+working Windows ROCm host printed "torch check (cpu)". Answering with `import torch`
+instead cost up to the probe's 90s timeout before _progress() emitted anything.
 """
 
 from __future__ import annotations
@@ -36,10 +27,7 @@ def _load_module(monkeypatch):
     return install_python_stack
 
 
-# -- the hardware half of the matrix -------------------------------------------------
-# Each fixture is what the four detectors report on that machine. "amd_bundled" is the
-# reported Strix Halo case: AMD's bundled-runtime wheels carry no rocminfo and no
-# amd-smi, so only torch's own version.py knows the build is ROCm.
+# "amd_bundled" is the Strix Halo case: no rocminfo, no amd-smi, only version.py knows.
 _HARDWARE = {
     "nvidia": dict(nvidia = True, rocm_probe = False, hip = "", label = "2.9.1+cu128"),
     "amd_tooling": dict(nvidia = False, rocm_probe = True, hip = "6.4.43483", label = "2.8.0+rocm6.4"),
@@ -51,7 +39,6 @@ _HARDWARE = {
     "no_torch": dict(nvidia = False, rocm_probe = False, hip = "", label = ""),
 }
 
-# -- the platform half ---------------------------------------------------------------
 _PLATFORMS = {
     "windows": dict(is_windows = True, is_macos = False, is_wsl = False),
     "linux": dict(is_windows = False, is_macos = False, is_wsl = False),
@@ -68,15 +55,9 @@ def _prepare(
     known_backend = "",
     warm_probe = None,
 ):
-    """Load the module with one (platform, hardware) cell of the matrix in place.
+    """One matrix cell, stubbed only at names both trees have, so this file discriminates.
 
-    Everything is stubbed at a boundary that exists on BOTH sides of this change --
-    the four detectors, the two file reads, and _probe_torch_runtime -- so the same
-    file discriminates rather than erroring out on a symbol one tree lacks.
-
-    Returns the module and the list _probe_torch_runtime calls are recorded into.
-    Reaching that function is the expensive event: it is what spawns `import torch`
-    under a 90s timeout, so an empty list is the assertion that a label cost nothing.
+    Returns the recorded _probe_torch_runtime calls; empty means the label cost nothing.
     """
     mod = _load_module(monkeypatch)
     plat = _PLATFORMS[platform_name]
@@ -89,8 +70,7 @@ def _prepare(
     monkeypatch.setattr(mod, "_is_wsl", lambda: plat["is_wsl"])
     monkeypatch.setattr(mod, "_has_usable_nvidia_gpu", lambda: hw["nvidia"])
     monkeypatch.setattr(mod, "_has_rocm_gpu", lambda: hw["rocm_probe"])
-    # The OFF-DISK reads. raising = False because _torch_hip_version_on_disk does not
-    # exist on the pre-fix tree; there the same facts arrive via _probe_torch_runtime.
+    # raising = False: _torch_hip_version_on_disk does not exist on the pre-fix tree.
     monkeypatch.setattr(mod, "_torch_hip_version_on_disk", lambda: hw["hip"], raising = False)
     monkeypatch.setattr(mod, "_installed_torch_version_label", lambda: hw["label"])
     monkeypatch.setattr(mod, "_TORCH_RUNTIME_PROBE", warm_probe)
@@ -103,8 +83,7 @@ def _prepare(
     )
 
     def _recording_probe():
-        # Mirror the real function's memo exactly: a warm memo returns instantly and costs
-        # nothing, so only a COLD entry is an interpreter start worth recording.
+        # Mirror the real memo: only a COLD entry is an interpreter start.
         if mod._TORCH_RUNTIME_PROBE is not None:
             return mod._TORCH_RUNTIME_PROBE
         probe_calls.append(probe_result)
@@ -112,7 +91,6 @@ def _prepare(
         return probe_result
 
     monkeypatch.setattr(mod, "_probe_torch_runtime", _recording_probe)
-    # Belt and braces: nothing in this path may shell out either.
     monkeypatch.setattr(
         mod.subprocess,
         "run",
@@ -121,11 +99,8 @@ def _prepare(
     return mod, probe_calls
 
 
-# ==== the platform x hardware matrix ================================================
-# Expected label per cell with UNSLOTH_TORCH_BACKEND unset, i.e. every standalone
-# `unsloth studio update`. Only Windows consults torch's own ROCm build, because
-# _installed_torch_is_windows_rocm_cheap returns False on `not IS_WINDOWS` before doing
-# any work -- that is what keeps Linux, WSL and macOS on their pre-existing answers.
+# UNSLOTH_TORCH_BACKEND unset. Only Windows consults torch's own build, which is what
+# keeps Linux, WSL and macOS on their pre-existing answers.
 _MATRIX = {
     ("windows", "nvidia"): "cuda",
     ("windows", "amd_tooling"): "rocm",
@@ -145,8 +120,7 @@ _MATRIX = {
     ("wsl", "xpu"): "cpu",
     ("wsl", "cpu"): "cpu",
     ("wsl", "no_torch"): "cpu",
-    # macOS has no NVIDIA or AMD ROCm story; these rows pin the function's actual
-    # behaviour rather than claiming the configurations are supported.
+    # macOS rows pin actual behaviour, not supported configurations.
     ("macos", "nvidia"): "cuda",
     ("macos", "amd_tooling"): "rocm",
     ("macos", "amd_bundled"): "cpu",
@@ -166,19 +140,16 @@ def test_label_over_the_platform_and_hardware_matrix(monkeypatch, platform_name,
 @pytest.mark.parametrize(("platform_name", "hardware_name"), sorted(_MATRIX))
 @pytest.mark.parametrize("suffix", ["check", "final", "flavor"])
 def test_every_suffix_keeps_the_same_backend(monkeypatch, platform_name, hardware_name, suffix):
-    """All three call sites (:7166, :7371, :7383) share one backend verdict."""
     mod, _calls = _prepare(monkeypatch, platform_name = platform_name, hardware_name = hardware_name)
     expected = _MATRIX[(platform_name, hardware_name)]
     assert mod._torch_step_label(suffix) == f"torch {suffix} ({expected})"
 
 
-# ==== an explicit backend wins over every probe =====================================
 
 
 @pytest.mark.parametrize("known_backend", ["cuda", "rocm", "cpu", "xpu", "gfx1151-custom"])
 @pytest.mark.parametrize("platform_name", sorted(_PLATFORMS))
 def test_an_explicit_backend_wins_over_every_probe(monkeypatch, known_backend, platform_name):
-    """install.sh's resolved backend is authoritative, verbatim, on every platform."""
     mod, _calls = _prepare(
         monkeypatch,
         platform_name = platform_name,
@@ -209,18 +180,15 @@ def test_an_explicit_backend_consults_no_detector(monkeypatch):
     assert mod._torch_step_label("check") == "torch check (cuda)"
 
 
-# ==== precedence ====================================================================
 
 
 def test_nvidia_still_takes_priority(monkeypatch):
-    """A mixed NVIDIA+AMD Windows host stays CUDA even with a ROCm torch installed."""
     mod, _calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "nvidia")
     monkeypatch.setattr(mod, "_torch_hip_version_on_disk", lambda: "6.4.43483")
     assert mod._torch_step_label("check") == "torch check (cuda)"
 
 
 def test_the_rocm_probe_still_answers(monkeypatch):
-    """rocminfo/amd-smi remain the primary signal; nothing about them changed."""
     mod, _calls = _prepare(monkeypatch, platform_name = "linux", hardware_name = "amd_tooling")
     monkeypatch.setattr(mod, "_torch_hip_version_on_disk", lambda: "")
     monkeypatch.setattr(mod, "_installed_torch_version_label", lambda: "")
@@ -228,13 +196,11 @@ def test_the_rocm_probe_still_answers(monkeypatch):
 
 
 def test_a_windows_rocm_torch_is_rocm_even_with_no_rocm_tooling(monkeypatch):
-    """The regression: rocminfo and amd-smi are absent, torch's own version.py is not."""
     mod, _calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "amd_bundled")
     assert mod._torch_step_label("check") == "torch check (rocm)"
 
 
 def test_a_windows_rocm_torch_is_recognised_by_version_string_alone(monkeypatch):
-    """A build whose version.py carries no hip= line but whose __version__ says rocm."""
     mod, _calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "amd_bundled")
     monkeypatch.setattr(mod, "_torch_hip_version_on_disk", lambda: "")
     assert mod._torch_step_label("check") == "torch check (rocm)"
@@ -245,17 +211,11 @@ def test_a_host_with_neither_is_still_cpu(monkeypatch):
     assert mod._torch_step_label("check") == "torch check (cpu)"
 
 
-# ==== the cost of the answer ========================================================
 
 
 @pytest.mark.parametrize("platform_name", sorted(_PLATFORMS))
 @pytest.mark.parametrize("hardware_name", sorted(_HARDWARE))
 def test_the_label_never_runs_the_torch_probe(monkeypatch, platform_name, hardware_name):
-    """Every cell of the matrix, with a COLD memo: zero `import torch` subprocesses.
-
-    _probe_torch_runtime is the 90s-bounded interpreter start. Formatting a progress
-    line must never be what pays for it.
-    """
     mod, probe_calls = _prepare(
         monkeypatch, platform_name = platform_name, hardware_name = hardware_name
     )
@@ -264,12 +224,8 @@ def test_the_label_never_runs_the_torch_probe(monkeypatch, platform_name, hardwa
 
 
 def test_the_label_leaves_the_probe_memo_cold(monkeypatch):
-    """A cold _TORCH_RUNTIME_PROBE stays cold, so the label pays for nothing.
-
-    The discriminating assertion for the affected host: pre-fix, the label reached
-    _probe_torch_runtime, populating the memo and spending up to its 90s timeout before
-    _progress() had printed anything -- and pip_install invalidates that memo three
-    statements later, so the cost was not even amortised.
+    """The discriminating case: pre-fix the label probed here, and pip_install then
+    invalidated the memo three statements later, so the 90s was not even amortised.
     """
     mod, probe_calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "amd_bundled")
     assert mod._TORCH_RUNTIME_PROBE is None
@@ -279,7 +235,6 @@ def test_the_label_leaves_the_probe_memo_cold(monkeypatch):
 
 
 def test_the_label_reuses_a_warm_probe_instead_of_the_disk(monkeypatch):
-    """When something else already paid for the probe, prefer its richer answer."""
     warm = (True, True, "2.8.0a0+rocmsdk20250901", "6.4.43483", "")
     mod, probe_calls = _prepare(
         monkeypatch,
@@ -300,7 +255,6 @@ def test_the_label_reuses_a_warm_probe_instead_of_the_disk(monkeypatch):
 
 
 def test_a_warm_negative_probe_is_believed(monkeypatch):
-    """A warm probe saying "not ROCm" is authoritative over the disk heuristics."""
     warm = (True, True, "2.9.1+cpu", "", "")
     mod, probe_calls = _prepare(
         monkeypatch,
@@ -313,7 +267,6 @@ def test_a_warm_negative_probe_is_believed(monkeypatch):
 
 
 def test_an_inconclusive_warm_probe_is_not_read_as_rocm(monkeypatch):
-    """The wedged-driver tuple (ran=False) must not manufacture a ROCm claim."""
     mod, probe_calls = _prepare(
         monkeypatch,
         platform_name = "windows",
@@ -326,10 +279,7 @@ def test_an_inconclusive_warm_probe_is_not_read_as_rocm(monkeypatch):
 
 @pytest.mark.parametrize("platform_name", ["linux", "wsl", "macos"])
 def test_non_windows_never_touches_the_torch_build(monkeypatch, platform_name):
-    """Linux, WSL and macOS short-circuit before any disk or probe read.
-
-    This is what makes the change incapable of altering the answer on those platforms.
-    """
+    """Linux, WSL and macOS short-circuit, so the change cannot alter their answer."""
     mod, probe_calls = _prepare(
         monkeypatch, platform_name = platform_name, hardware_name = "amd_bundled"
     )
@@ -343,17 +293,14 @@ def test_non_windows_never_touches_the_torch_build(monkeypatch, platform_name):
     monkeypatch.setattr(
         mod, "_installed_torch_version_label", lambda: touched.append("label") or ""
     )
-    # Not asserted here: whether the Windows helper is CALLED off Windows. Both trees
-    # return False on `not IS_WINDOWS` before doing any work, so the call is free; what
-    # matters is that no probe and no disk read happen behind it.
+    # Not whether the helper is called off Windows (free either way), but that nothing
+    # happens behind it.
     assert mod._torch_step_label("check") == "torch check (cpu)"
     assert touched == []
     assert probe_calls == []
 
 
-# ==== the off-disk reader itself ====================================================
-# Unit tests for the helper this change introduces. They are skipped, not failed, on a
-# tree that predates it: their job is to hold the new reader, not to discriminate.
+# Skipped, not failed, on a tree without the helper: these hold it, not discriminate.
 
 
 def _requires_hip_reader(mod):
@@ -368,13 +315,10 @@ def _fake_torch_on_path(
     *,
     as_directory = False,
 ):
-    """Put a stand-in torch package first on sys.path and make find_spec see it.
+    """Put a stand-in torch package where find_spec will see it.
 
-    importlib.util.find_spec returns sys.modules[name].__spec__ when the module is
-    already imported, so on a runner that HAS torch (every CI job that installs it)
-    prepending sys.path is not enough -- the real package answers and the fixture is
-    silently ignored. Dropping the entry makes find_spec do a real path search; the
-    monkeypatch is undone at teardown, so the real torch comes back.
+    find_spec returns sys.modules[name].__spec__ for an already-imported module, so on a
+    runner that has torch, prepending sys.path alone leaves the fixture ignored.
     """
     torch_dir = tmp_path / "torch"
     torch_dir.mkdir(exist_ok = True)
@@ -441,7 +385,6 @@ def test_the_hip_reader_matches_only_a_quoted_value(monkeypatch, tmp_path, text,
 
 
 def test_the_hip_reader_survives_a_missing_torch(monkeypatch, tmp_path):
-    """An absent torch is "no answer", never an exception into a progress label."""
     mod = _load_module(monkeypatch)
     _requires_hip_reader(mod)
     monkeypatch.setattr(
@@ -470,15 +413,10 @@ def test_the_hip_reader_starts_no_subprocess(monkeypatch, tmp_path):
     assert mod._torch_hip_version_on_disk() == "6.4.43483-a1b2c3d"
 
 
-# ==== this machine, unsimulated =====================================================
 
 
 def test_the_label_on_this_real_host(monkeypatch):
-    """One unsimulated observation: whatever this box is, the label costs no subprocess.
-
-    Deliberately asserts the shape rather than a fixed backend, so it holds on the CPU
-    CI runner and on a GPU box alike.
-    """
+    """One unsimulated observation. Asserts the shape, so it holds on CPU and GPU alike."""
     mod = _load_module(monkeypatch)
     monkeypatch.setattr(mod, "_TORCH_BACKEND", "")
     monkeypatch.setattr(mod, "_TORCH_RUNTIME_PROBE", None)
@@ -493,7 +431,6 @@ def test_the_label_on_this_real_host(monkeypatch):
     label = mod._torch_step_label("check")
     assert label.startswith("torch check (") and label.endswith(")")
     assert label[len("torch check (") : -1] in {"cuda", "rocm", "cpu"}
-    # _has_usable_nvidia_gpu/_has_rocm_gpu may shell out to nvidia-smi or rocminfo; the
-    # `import torch` probe (which is the expensive one) must not be among the calls.
+    # nvidia-smi/rocminfo may run; the expensive `import torch` must not.
     assert not any("import torch" in str(a) for a in calls), calls
     assert mod._TORCH_RUNTIME_PROBE is None

--- a/studio/backend/tests/test_torch_step_label.py
+++ b/studio/backend/tests/test_torch_step_label.py
@@ -41,20 +41,22 @@ def _load_module(monkeypatch):
 # reported Strix Halo case: AMD's bundled-runtime wheels carry no rocminfo and no
 # amd-smi, so only torch's own version.py knows the build is ROCm.
 _HARDWARE = {
-    "nvidia":      dict(nvidia = True,  rocm_probe = False, hip = "",             label = "2.9.1+cu128"),
-    "amd_tooling": dict(nvidia = False, rocm_probe = True,  hip = "6.4.43483",    label = "2.8.0+rocm6.4"),
-    "amd_bundled": dict(nvidia = False, rocm_probe = False, hip = "6.4.43483-a1", label = "2.8.0a0+rocmsdk20250901"),
-    "xpu":         dict(nvidia = False, rocm_probe = False, hip = "",             label = "2.9.1+xpu"),
-    "cpu":         dict(nvidia = False, rocm_probe = False, hip = "",             label = "2.9.1+cpu"),
-    "no_torch":    dict(nvidia = False, rocm_probe = False, hip = "",             label = ""),
+    "nvidia": dict(nvidia = True, rocm_probe = False, hip = "", label = "2.9.1+cu128"),
+    "amd_tooling": dict(nvidia = False, rocm_probe = True, hip = "6.4.43483", label = "2.8.0+rocm6.4"),
+    "amd_bundled": dict(
+        nvidia = False, rocm_probe = False, hip = "6.4.43483-a1", label = "2.8.0a0+rocmsdk20250901"
+    ),
+    "xpu": dict(nvidia = False, rocm_probe = False, hip = "", label = "2.9.1+xpu"),
+    "cpu": dict(nvidia = False, rocm_probe = False, hip = "", label = "2.9.1+cpu"),
+    "no_torch": dict(nvidia = False, rocm_probe = False, hip = "", label = ""),
 }
 
 # -- the platform half ---------------------------------------------------------------
 _PLATFORMS = {
-    "windows": dict(is_windows = True,  is_macos = False, is_wsl = False),
-    "linux":   dict(is_windows = False, is_macos = False, is_wsl = False),
-    "wsl":     dict(is_windows = False, is_macos = False, is_wsl = True),
-    "macos":   dict(is_windows = False, is_macos = True,  is_wsl = False),
+    "windows": dict(is_windows = True, is_macos = False, is_wsl = False),
+    "linux": dict(is_windows = False, is_macos = False, is_wsl = False),
+    "wsl": dict(is_windows = False, is_macos = False, is_wsl = True),
+    "macos": dict(is_windows = False, is_macos = True, is_wsl = False),
 }
 
 
@@ -94,8 +96,10 @@ def _prepare(
     monkeypatch.setattr(mod, "_TORCH_RUNTIME_PROBE", warm_probe)
 
     probe_calls = []
-    probe_result = warm_probe if warm_probe is not None else (
-        True, bool(hw["label"]), hw["label"] or None, hw["hip"], ""
+    probe_result = (
+        warm_probe
+        if warm_probe is not None
+        else (True, bool(hw["label"]), hw["label"] or None, hw["hip"], "")
     )
 
     def _recording_probe():
@@ -125,13 +129,13 @@ def _prepare(
 _MATRIX = {
     ("windows", "nvidia"): "cuda",
     ("windows", "amd_tooling"): "rocm",
-    ("windows", "amd_bundled"): "rocm",   # the regression this PR fixes
+    ("windows", "amd_bundled"): "rocm",  # the regression this PR fixes
     ("windows", "xpu"): "cpu",
     ("windows", "cpu"): "cpu",
     ("windows", "no_torch"): "cpu",
     ("linux", "nvidia"): "cuda",
     ("linux", "amd_tooling"): "rocm",
-    ("linux", "amd_bundled"): "cpu",      # no rocminfo on Linux means no ROCm claim
+    ("linux", "amd_bundled"): "cpu",  # no rocminfo on Linux means no ROCm claim
     ("linux", "xpu"): "cpu",
     ("linux", "cpu"): "cpu",
     ("linux", "no_torch"): "cpu",
@@ -154,9 +158,7 @@ _MATRIX = {
 
 @pytest.mark.parametrize(("platform_name", "hardware_name"), sorted(_MATRIX))
 def test_label_over_the_platform_and_hardware_matrix(monkeypatch, platform_name, hardware_name):
-    mod, _calls = _prepare(
-        monkeypatch, platform_name = platform_name, hardware_name = hardware_name
-    )
+    mod, _calls = _prepare(monkeypatch, platform_name = platform_name, hardware_name = hardware_name)
     expected = _MATRIX[(platform_name, hardware_name)]
     assert mod._torch_step_label("check") == f"torch check ({expected})"
 
@@ -165,9 +167,7 @@ def test_label_over_the_platform_and_hardware_matrix(monkeypatch, platform_name,
 @pytest.mark.parametrize("suffix", ["check", "final", "flavor"])
 def test_every_suffix_keeps_the_same_backend(monkeypatch, platform_name, hardware_name, suffix):
     """All three call sites (:7166, :7371, :7383) share one backend verdict."""
-    mod, _calls = _prepare(
-        monkeypatch, platform_name = platform_name, hardware_name = hardware_name
-    )
+    mod, _calls = _prepare(monkeypatch, platform_name = platform_name, hardware_name = hardware_name)
     expected = _MATRIX[(platform_name, hardware_name)]
     assert mod._torch_step_label(suffix) == f"torch {suffix} ({expected})"
 
@@ -271,9 +271,7 @@ def test_the_label_leaves_the_probe_memo_cold(monkeypatch):
     _progress() had printed anything -- and pip_install invalidates that memo three
     statements later, so the cost was not even amortised.
     """
-    mod, probe_calls = _prepare(
-        monkeypatch, platform_name = "windows", hardware_name = "amd_bundled"
-    )
+    mod, probe_calls = _prepare(monkeypatch, platform_name = "windows", hardware_name = "amd_bundled")
     assert mod._TORCH_RUNTIME_PROBE is None
     assert mod._torch_step_label("check") == "torch check (rocm)"
     assert probe_calls == []
@@ -297,8 +295,8 @@ def test_the_label_reuses_a_warm_probe_instead_of_the_disk(monkeypatch):
         raising = False,
     )
     assert mod._torch_step_label("check") == "torch check (rocm)"
-    assert probe_calls == []    # a warm memo is reused, never re-probed
-    assert disk_reads == []     # and the disk is not consulted behind it
+    assert probe_calls == []  # a warm memo is reused, never re-probed
+    assert disk_reads == []  # and the disk is not consulted behind it
 
 
 def test_a_warm_negative_probe_is_believed(monkeypatch):
@@ -400,11 +398,11 @@ cuda = None
     [
         (_VERSION_PY_ROCM, "6.4.43483-a1b2c3d"),
         (_VERSION_PY_ROCM_UNANNOTATED, "6.3.42131"),
-        (_VERSION_PY_CUDA, ""),          # hip = None must not read as a HIP string
+        (_VERSION_PY_CUDA, ""),  # hip = None must not read as a HIP string
         ("", ""),
-        ("hip = \"6.9.0\"\n", "6.9.0"),   # double-quoted
+        ('hip = "6.9.0"\n', "6.9.0"),  # double-quoted
         ("__version__ = '2.9.1'\n", ""),
-        ("# hip = '1.0'\n", ""),          # not at the start of a line after ^ anchoring
+        ("# hip = '1.0'\n", ""),  # not at the start of a line after ^ anchoring
     ],
 )
 def test_the_hip_reader_matches_only_a_quoted_value(monkeypatch, tmp_path, text, expected):

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5027,7 +5027,11 @@ def _torch_step_label(suffix: str) -> str:
     if not backend:
         if _has_usable_nvidia_gpu():
             backend = "cuda"
-        elif _has_rocm_gpu():
+        # _has_rocm_gpu() probes rocminfo and amd-smi, which ship with the HIP SDK
+        # and not with AMD's bundled-runtime wheels, so a Windows ROCm host without
+        # the SDK reads as CPU here while the very next step correctly detects it.
+        # torch.version.hip is the installed build's own answer.
+        elif _has_rocm_gpu() or _installed_torch_is_windows_rocm():
             backend = "rocm"
         else:
             backend = "cpu"

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5037,8 +5037,8 @@ def _torch_hip_version_on_disk() -> str:
     if spec is None or not spec.origin:
         return ""
     try:
-        text = Path(spec.origin).with_name("version.py").read_text(
-            encoding = "utf-8", errors = "replace"
+        text = (
+            Path(spec.origin).with_name("version.py").read_text(encoding = "utf-8", errors = "replace")
         )
     except OSError:
         return ""

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5017,6 +5017,55 @@ if not _TORCH_BACKEND:
         _TORCH_BACKEND = "cuda"
 
 
+# torch/version.py writes `hip = '6.4...'` on a ROCm build and `hip: Optional[str] = None`
+# elsewhere. Only a QUOTED value matches, so the None form is correctly negative, and the
+# optional annotation between the name and the `=` is skipped.
+_TORCH_VERSION_PY_HIP_RE = re.compile(r"""^hip\s*(?::[^=]*)?=\s*['"]([^'"]*)['"]""", re.MULTILINE)
+
+
+def _torch_hip_version_on_disk() -> str:
+    """torch.version.hip read from torch/version.py, launching no interpreter.
+
+    The read half of _installed_torch_version_label, against the same file: find_spec
+    locates the package without executing it, so a wedged GPU driver cannot stall this.
+    """
+    try:
+        importlib.invalidate_caches()
+        spec = importlib.util.find_spec("torch")
+    except (ImportError, ValueError):
+        return ""
+    if spec is None or not spec.origin:
+        return ""
+    try:
+        text = Path(spec.origin).with_name("version.py").read_text(
+            encoding = "utf-8", errors = "replace"
+        )
+    except OSError:
+        return ""
+    match = _TORCH_VERSION_PY_HIP_RE.search(text)
+    return match.group(1) if match else ""
+
+
+def _installed_torch_is_windows_rocm_cheap() -> bool:
+    """_installed_torch_is_windows_rocm's verdict without ever running `import torch`.
+
+    _torch_step_label runs BEFORE the first pip step of its block, where the memoized
+    _TORCH_RUNTIME_PROBE is cold and none of the _ensure_* calls that follow reach the probe
+    on the very host this label exists for (Windows, no NVIDIA, no rocminfo/amd-smi). Calling
+    the probing form there spent up to its 90s timeout, before _progress() had emitted
+    anything, purely to format a string -- and on a wedged driver that is exactly the host the
+    timeout exists to rescue. Read the same facts off disk instead, and reuse the probe only
+    when something else has already paid for it.
+    """
+    if not IS_WINDOWS:
+        return False
+    if _TORCH_RUNTIME_PROBE is not None:
+        return _installed_torch_is_windows_rocm()
+    if _torch_hip_version_on_disk():
+        return True
+    return "rocm" in _installed_torch_version_label().lower()
+
+
 def _torch_step_label(suffix: str) -> str:
     """Return a progress label like 'torch check (cuda)' using the known backend.
 
@@ -5030,8 +5079,9 @@ def _torch_step_label(suffix: str) -> str:
         # _has_rocm_gpu() probes rocminfo and amd-smi, which ship with the HIP SDK
         # and not with AMD's bundled-runtime wheels, so a Windows ROCm host without
         # the SDK reads as CPU here while the very next step correctly detects it.
-        # torch.version.hip is the installed build's own answer.
-        elif _has_rocm_gpu() or _installed_torch_is_windows_rocm():
+        # torch.version.hip is the installed build's own answer, read off disk so a
+        # label never costs an interpreter start.
+        elif _has_rocm_gpu() or _installed_torch_is_windows_rocm_cheap():
             backend = "rocm"
         else:
             backend = "cpu"

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5017,18 +5017,12 @@ if not _TORCH_BACKEND:
         _TORCH_BACKEND = "cuda"
 
 
-# torch/version.py writes `hip = '6.4...'` on a ROCm build and `hip: Optional[str] = None`
-# elsewhere. Only a QUOTED value matches, so the None form is correctly negative, and the
-# optional annotation between the name and the `=` is skipped.
+# Quoted values only, so the `hip: Optional[str] = None` a non-ROCm build writes is negative.
 _TORCH_VERSION_PY_HIP_RE = re.compile(r"""^hip\s*(?::[^=]*)?=\s*['"]([^'"]*)['"]""", re.MULTILINE)
 
 
 def _torch_hip_version_on_disk() -> str:
-    """torch.version.hip read from torch/version.py, launching no interpreter.
-
-    The read half of _installed_torch_version_label, against the same file: find_spec
-    locates the package without executing it, so a wedged GPU driver cannot stall this.
-    """
+    """torch.version.hip read from torch/version.py, launching no interpreter."""
     try:
         importlib.invalidate_caches()
         spec = importlib.util.find_spec("torch")
@@ -5049,13 +5043,8 @@ def _torch_hip_version_on_disk() -> str:
 def _installed_torch_is_windows_rocm_cheap() -> bool:
     """_installed_torch_is_windows_rocm's verdict without ever running `import torch`.
 
-    _torch_step_label runs BEFORE the first pip step of its block, where the memoized
-    _TORCH_RUNTIME_PROBE is cold and none of the _ensure_* calls that follow reach the probe
-    on the very host this label exists for (Windows, no NVIDIA, no rocminfo/amd-smi). Calling
-    the probing form there spent up to its 90s timeout, before _progress() had emitted
-    anything, purely to format a string -- and on a wedged driver that is exactly the host the
-    timeout exists to rescue. Read the same facts off disk instead, and reuse the probe only
-    when something else has already paid for it.
+    _torch_step_label runs with the probe memo cold, so the probing form spent up to its
+    90s timeout before _progress() emitted anything, to format a string.
     """
     if not IS_WINDOWS:
         return False
@@ -5076,11 +5065,8 @@ def _torch_step_label(suffix: str) -> str:
     if not backend:
         if _has_usable_nvidia_gpu():
             backend = "cuda"
-        # _has_rocm_gpu() probes rocminfo and amd-smi, which ship with the HIP SDK
-        # and not with AMD's bundled-runtime wheels, so a Windows ROCm host without
-        # the SDK reads as CPU here while the very next step correctly detects it.
-        # torch.version.hip is the installed build's own answer, read off disk so a
-        # label never costs an interpreter start.
+        # rocminfo and amd-smi ship with the HIP SDK, not with AMD's bundled-runtime
+        # wheels, so a Windows ROCm host reads as CPU without the second operand.
         elif _has_rocm_gpu() or _installed_torch_is_windows_rocm_cheap():
             backend = "rocm"
         else:

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -584,6 +584,12 @@ function Get-InstalledLlamaPrebuiltRelease {
     if ($payload.tag -and $payload.tag -ne $payload.release_tag) {
         $message += " (tag $($payload.tag))"
     }
+    # Name the backend. Without it a host running a Vulkan bundle and a host running
+    # a ROCm one print the same line, so a bundle that has drifted away from the
+    # hardware is invisible in the install log.
+    if ($payload.backend) {
+        $message += " -- $($payload.backend) backend"
+    }
     return $message
 }
 

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -576,11 +576,8 @@ function Get-InstalledLlamaPrebuiltRelease {
         return $null
     }
 
-    # An empty, truncated or non-object marker deserializes to $null or to a scalar, and
-    # the guard below reads properties off it OUTSIDE the try above. Under a caller's
-    # Set-StrictMode that read is a terminating error, and without one the function fell
-    # through and printed "installed release: @". An interrupted marker write leaves
-    # exactly this file behind, so it is reachable on any old install.
+    # An interrupted write leaves an empty marker, which deserializes to $null: reading a
+    # property off that is fatal under a caller's Set-StrictMode, and printed "@" without one.
     if ($null -eq $payload -or $payload -isnot [System.Management.Automation.PSCustomObject]) {
         return $null
     }
@@ -593,8 +590,7 @@ function Get-InstalledLlamaPrebuiltRelease {
     }
 
     $message = "installed release: $($payload.published_repo)@$($payload.release_tag)"
-    # tag is optional in the same way backend is: guard it rather than leaving one strict
-    # mode hazard beside a fixed one.
+    # tag is optional too, so it carries the same strict-mode hazard as backend.
     $llamaTag = ""
     if ($payload.PSObject.Properties.Name -ccontains 'tag') {
         $llamaTag = [string]$payload.tag
@@ -602,23 +598,11 @@ function Get-InstalledLlamaPrebuiltRelease {
     if ($llamaTag -and $llamaTag -ne $payload.release_tag) {
         $message += " (tag $llamaTag)"
     }
-    # Name the backend. Without it a host running a Vulkan bundle and a host running
-    # a ROCm one print the same line, so a bundle that has drifted away from the
-    # hardware is invisible in the install log.
-    #
-    # The key only exists in markers written since #8520; every install from #4562 (Mar 2026)
-    # to then has none, and reading a missing property under a CALLER's Set-StrictMode
-    # -Version 2.0+ is a terminating error, which would abort setup on exactly those hosts.
-    # Probe PSObject.Properties first, as the other optional reads in this file do.
-    #
-    # The type and shape checks keep this printer byte-identical to its setup.sh twin: a
-    # non-string value renders differently in each language (PowerShell prints @(1,2) as
-    # "1 2", Python as "[1, 2]"), and a newline would split the log line. Backend names come
-    # from one closed vocabulary (cuda/rocm/vulkan/cpu/metal), so nothing real is rejected.
+    # Name the backend: a Vulkan and a ROCm bundle print an identical line without it.
+    # Absent in every marker written before #8520, and a missing property is fatal under a
+    # caller's Set-StrictMode. -ccontains and the type/shape checks keep this byte-identical
+    # to the setup.sh twin, which is case-sensitive and renders non-strings differently.
     $backendName = ""
-    # -ccontains, not -contains: PowerShell property access is case-insensitive and Python's
-    # dict lookup in the setup.sh twin is not, so a case-folded guard here would print a
-    # suffix for a "BACKEND" key that setup.sh silently ignores.
     if (($payload.PSObject.Properties.Name -ccontains 'backend') -and ($payload.backend -is [string])) {
         $backendName = $payload.backend.Trim()
     }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -576,19 +576,54 @@ function Get-InstalledLlamaPrebuiltRelease {
         return $null
     }
 
+    # An empty, truncated or non-object marker deserializes to $null or to a scalar, and
+    # the guard below reads properties off it OUTSIDE the try above. Under a caller's
+    # Set-StrictMode that read is a terminating error, and without one the function fell
+    # through and printed "installed release: @". An interrupted marker write leaves
+    # exactly this file behind, so it is reachable on any old install.
+    if ($null -eq $payload -or $payload -isnot [System.Management.Automation.PSCustomObject]) {
+        return $null
+    }
+    if (-not ($payload.PSObject.Properties.Name -ccontains 'published_repo') -or
+        -not ($payload.PSObject.Properties.Name -ccontains 'release_tag')) {
+        return $null
+    }
     if (-not $payload.published_repo -or -not $payload.release_tag) {
         return $null
     }
 
     $message = "installed release: $($payload.published_repo)@$($payload.release_tag)"
-    if ($payload.tag -and $payload.tag -ne $payload.release_tag) {
-        $message += " (tag $($payload.tag))"
+    # tag is optional in the same way backend is: guard it rather than leaving one strict
+    # mode hazard beside a fixed one.
+    $llamaTag = ""
+    if ($payload.PSObject.Properties.Name -ccontains 'tag') {
+        $llamaTag = [string]$payload.tag
+    }
+    if ($llamaTag -and $llamaTag -ne $payload.release_tag) {
+        $message += " (tag $llamaTag)"
     }
     # Name the backend. Without it a host running a Vulkan bundle and a host running
     # a ROCm one print the same line, so a bundle that has drifted away from the
     # hardware is invisible in the install log.
-    if ($payload.backend) {
-        $message += " -- $($payload.backend) backend"
+    #
+    # The key only exists in markers written since #8520; every install from #4562 (Mar 2026)
+    # to then has none, and reading a missing property under a CALLER's Set-StrictMode
+    # -Version 2.0+ is a terminating error, which would abort setup on exactly those hosts.
+    # Probe PSObject.Properties first, as the other optional reads in this file do.
+    #
+    # The type and shape checks keep this printer byte-identical to its setup.sh twin: a
+    # non-string value renders differently in each language (PowerShell prints @(1,2) as
+    # "1 2", Python as "[1, 2]"), and a newline would split the log line. Backend names come
+    # from one closed vocabulary (cuda/rocm/vulkan/cpu/metal), so nothing real is rejected.
+    $backendName = ""
+    # -ccontains, not -contains: PowerShell property access is case-insensitive and Python's
+    # dict lookup in the setup.sh twin is not, so a case-folded guard here would print a
+    # suffix for a "BACKEND" key that setup.sh silently ignores.
+    if (($payload.PSObject.Properties.Name -ccontains 'backend') -and ($payload.backend -is [string])) {
+        $backendName = $payload.backend.Trim()
+    }
+    if ($backendName -match '^[A-Za-z0-9._+-]{1,32}$') {
+        $message += " -- $backendName backend"
     }
     return $message
 }

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -792,6 +792,7 @@ llama_tag = str(payload.get("tag") or "").strip()
 source = str(payload.get("source") or "").strip()
 binary_repo = str(payload.get("binary_repo") or "").strip()
 binary_tag = str(payload.get("binary_release_tag") or "").strip()
+backend = str(payload.get("backend") or "").strip()
 if not repo or not release_tag:
     raise SystemExit(0)
 
@@ -804,6 +805,11 @@ else:
     message = f"installed release: {repo}@{release_tag}"
     if llama_tag and llama_tag != release_tag:
         message += f" (tag {llama_tag})"
+# Name the backend. Without it a host running a Vulkan bundle and a host running a
+# ROCm one print the same line, so a bundle that has drifted away from the hardware
+# is invisible in the install log.
+if backend:
+    message += f" -- {backend} backend"
 print(message)
 PY
 }

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -794,9 +794,8 @@ source = str(payload.get("source") or "").strip()
 binary_repo = str(payload.get("binary_repo") or "").strip()
 binary_tag = str(payload.get("binary_release_tag") or "").strip()
 _backend_raw = payload.get("backend")
-# str() only for an actual string. The key is absent in every marker written before #8520
-# and can be JSON null when backend_for_install_kind() had no answer, and a non-string would
-# render differently here than in the setup.ps1 twin (Python str([1, 2]) vs PowerShell "1 2").
+# Absent before #8520, and null when backend_for_install_kind() had no answer. str() on a
+# non-string would diverge from the setup.ps1 twin (Python "[1, 2]" vs PowerShell "1 2").
 backend = _backend_raw.strip() if isinstance(_backend_raw, str) else ""
 if not repo or not release_tag:
     raise SystemExit(0)
@@ -810,11 +809,8 @@ else:
     message = f"installed release: {repo}@{release_tag}"
     if llama_tag and llama_tag != release_tag:
         message += f" (tag {llama_tag})"
-# Name the backend. Without it a host running a Vulkan bundle and a host running a
-# ROCm one print the same line, so a bundle that has drifted away from the hardware
-# is invisible in the install log. The shape check keeps this line single-line and keeps
-# the setup.ps1 twin's output byte-identical; backend names are one closed vocabulary
-# (cuda/rocm/vulkan/cpu/metal), so nothing real is rejected.
+# Name the backend: a Vulkan and a ROCm bundle print an identical line without it. The
+# shape check keeps the line single-line and matches the setup.ps1 twin byte for byte.
 if re.fullmatch(r"[A-Za-z0-9._+-]{1,32}", backend):
     message += f" -- {backend} backend"
 print(message)

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -775,6 +775,7 @@ installed_llama_prebuilt_release() {
     [ -f "$metadata_path" ] || return 0
     python - "$metadata_path" <<'PY' 2>/dev/null || true
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -792,7 +793,11 @@ llama_tag = str(payload.get("tag") or "").strip()
 source = str(payload.get("source") or "").strip()
 binary_repo = str(payload.get("binary_repo") or "").strip()
 binary_tag = str(payload.get("binary_release_tag") or "").strip()
-backend = str(payload.get("backend") or "").strip()
+_backend_raw = payload.get("backend")
+# str() only for an actual string. The key is absent in every marker written before #8520
+# and can be JSON null when backend_for_install_kind() had no answer, and a non-string would
+# render differently here than in the setup.ps1 twin (Python str([1, 2]) vs PowerShell "1 2").
+backend = _backend_raw.strip() if isinstance(_backend_raw, str) else ""
 if not repo or not release_tag:
     raise SystemExit(0)
 
@@ -807,8 +812,10 @@ else:
         message += f" (tag {llama_tag})"
 # Name the backend. Without it a host running a Vulkan bundle and a host running a
 # ROCm one print the same line, so a bundle that has drifted away from the hardware
-# is invisible in the install log.
-if backend:
+# is invisible in the install log. The shape check keeps this line single-line and keeps
+# the setup.ps1 twin's output byte-identical; backend names are one closed vocabulary
+# (cuda/rocm/vulkan/cpu/metal), so nothing real is rejected.
+if re.fullmatch(r"[A-Za-z0-9._+-]{1,32}", backend):
     message += f" -- {backend} backend"
 print(message)
 PY

--- a/tests/studio/install/test_installed_release_backend_line.py
+++ b/tests/studio/install/test_installed_release_backend_line.py
@@ -3,26 +3,13 @@
 
 """The "installed release: ..." line, in both setup twins, against real markers.
 
-setup.ps1's Get-InstalledLlamaPrebuiltRelease and setup.sh's
-installed_llama_prebuilt_release print the same line from the same
-UNSLOTH_PREBUILT_INFO.json, so they are tested together and every case asserts they
-agree. They have drifted apart before precisely because nothing compared them.
+Two things this holds. `backend` is absent from every marker written before #8520
+(2026-08-13), and reading a missing property is a terminating error under a caller's
+Set-StrictMode 2.0+, so an unguarded read aborts setup on those installs. And the twins
+must render identical bytes: PowerShell prints @(1, 2) as "1 2", Python as "[1, 2]".
 
-Two things this file exists to hold:
-
-1. ``backend`` has only been written since #8520 (2026-08-13); markers go back to #4562
-   (2026-03-25). Reading a property that a legacy marker does not have is a TERMINATING
-   error under a caller's ``Set-StrictMode -Version 2.0`` or higher, so an unguarded read
-   would abort setup on every install older than that. The whole historical key-set
-   sequence is replayed here under every strict mode.
-
-2. The two printers must render the same bytes for the same marker. A non-string value
-   does not survive that on its own: PowerShell renders @(1, 2) as "1 2" and Python
-   renders [1, 2] as "[1, 2]".
-
-Both functions are sliced out of their scripts rather than sourced whole, because both
-scripts run install steps at load. That is the same technique as
-tests/studio_setup_ps1/Get-FunctionSource.ps1 and tests/sh/test_node_decision.sh.
+Both functions are sliced out rather than sourced whole, because both scripts run install
+steps at load (as tests/studio_setup_ps1/Get-FunctionSource.ps1 and tests/sh/ do).
 """
 
 from __future__ import annotations
@@ -47,8 +34,7 @@ requires_bash = pytest.mark.skipif(
     shutil.which("bash") is None, reason = "bash is required to run the setup.sh printer"
 )
 
-# Every strict mode a caller can impose. 2.0 is where non-existent property reads become
-# terminating errors; 3.0 and Latest keep that rule and add array-index rules on top.
+# 2.0 is where missing-property reads turn fatal; 3.0 and Latest keep that rule.
 STRICT_MODES = ["off", "1.0", "2.0", "3.0", "Latest"]
 
 _BASE_MARKER = {
@@ -75,18 +61,16 @@ def _drop_backend_key():
     return json.dumps(dict(_BASE_MARKER))
 
 
-# -- the corpus ----------------------------------------------------------------------
-# (id, raw file text or None for "no file at all", expected printed line)
+# (id, raw file text or None for "no file", expected printed line)
 _CASES = [
-    # --- the legacy shape, which is the whole point of the guard --------------------
+    # the legacy shape, which is the whole point of the guard
     ("legacy_no_backend_key", _drop_backend_key(), _BASE_LINE),
-    # --- every backend the vocabulary can produce ----------------------------------
     ("cuda", _with_backend("cuda"), _BASE_LINE + " -- cuda backend"),
     ("rocm", _with_backend("rocm"), _BASE_LINE + " -- rocm backend"),
     ("vulkan", _with_backend("vulkan"), _BASE_LINE + " -- vulkan backend"),
     ("cpu", _with_backend("cpu"), _BASE_LINE + " -- cpu backend"),
     ("metal", _with_backend("metal"), _BASE_LINE + " -- metal backend"),
-    # a name this build has never heard of still prints: no allowlist
+    # an unknown name still prints: no allowlist
     ("unknown_future_backend", _with_backend("sycl2"), _BASE_LINE + " -- sycl2 backend"),
     (
         "backend_with_punctuation",
@@ -95,7 +79,6 @@ _CASES = [
     ),
     ("backend_padded", _with_backend("  vulkan  "), _BASE_LINE + " -- vulkan backend"),
     ("backend_max_length", _with_backend("a" * 32), _BASE_LINE + " -- " + "a" * 32 + " backend"),
-    # --- values that must be ignored, identically, by both printers -----------------
     ("backend_null", _with_backend(None), _BASE_LINE),
     ("backend_empty", _with_backend(""), _BASE_LINE),
     ("backend_whitespace", _with_backend("   "), _BASE_LINE),
@@ -116,7 +99,6 @@ _CASES = [
     ("backend_64kib", _with_backend("v" * 65536), _BASE_LINE),
     ("backend_with_space", _with_backend("vulkan gpu"), _BASE_LINE),
     ("backend_underscore", _with_backend("windows_rocm"), _BASE_LINE + " -- windows_rocm backend"),
-    # --- text that must be treated as data, never as code --------------------------
     ("backend_double_quote", _with_backend('vul"kan'), _BASE_LINE),
     ("backend_single_quote", _with_backend("vul'kan"), _BASE_LINE),
     ("backend_backtick", _with_backend("vul`kan"), _BASE_LINE),
@@ -130,12 +112,9 @@ _CASES = [
     ("backend_tab", _with_backend("vul\tkan"), _BASE_LINE),
     ("backend_ansi", _with_backend("\x1b[31mrocm\x1b[0m"), _BASE_LINE),
     ("backend_nul", _with_backend("rocm\x00x"), _BASE_LINE),
-    # --- key-name handling ----------------------------------------------------------
-    # PowerShell property access is case-insensitive and Python's is not; the guard is
-    # -ccontains so both printers ignore a case-folded key rather than disagreeing.
+    # -ccontains, so a case-folded key is ignored by both rather than only by Python.
     ("backend_key_uppercase", _marker(BACKEND = "vulkan"), _BASE_LINE),
     ("backend_key_mixed_case", _marker(Backend = "vulkan"), _BASE_LINE),
-    # --- the rest of the line, unchanged by this PR ---------------------------------
     (
         "no_tag_key",
         json.dumps({"published_repo": "unslothai/llama.cpp", "release_tag": "b10715-mix"}),
@@ -168,7 +147,6 @@ _CASES = [
         _marker(backend = "rocm", future_key = {"a": [1, 2]}),
         _BASE_LINE + " -- rocm backend",
     ),
-    # --- unreadable inputs: both printers stay silent -------------------------------
     ("malformed_json", "{not json at all", ""),
     ("truncated_json", '{"published_repo": "r/l", "release_ta', ""),
     ("empty_file", "", ""),
@@ -178,12 +156,7 @@ _CASES = [
 
 _IDS = [case[0] for case in _CASES]
 
-# setup.sh has a "+ <source>@<binary_tag>" branch for non-fork binary sources that
-# setup.ps1 has never had (there is no `source` / `binary_repo` read anywhere in
-# Get-InstalledLlamaPrebuiltRelease). That divergence predates this change and is left
-# alone rather than silently dropped: these are the ids where the twins legitimately
-# differ, and the difference itself is asserted by
-# test_the_upstream_source_branch_is_a_known_pre_existing_divergence below.
+# setup.sh has a "+ <source>@<binary_tag>" branch setup.ps1 never has. Pre-existing.
 _PS1_EXPECTED_OVERRIDES = {
     "upstream_binary_source": "installed release: unslothai/unsloth@b10715-mix (tag b10715) -- cpu backend",
 }
@@ -205,15 +178,13 @@ def marker_dir(tmp_path):
     return _write
 
 
-# -- the PowerShell twin -------------------------------------------------------------
 
 _PS_HARNESS = """
 param([string]$InstallDir, [string]$StrictMode)
 
 if ($StrictMode -ne 'off') {{ Set-StrictMode -Version $StrictMode }}
 
-# The real function's only dependency, stubbed the way tests/studio/install's PowerShell
-# harnesses do: Get-PathState pulls in half the installer and answers nothing this needs.
+# Stubbed: the real Get-PathState pulls in half the installer.
 function Test-PathQuiet {{
     param([string]$Path, [string]$PathType = "Any")
     return (Test-Path -LiteralPath $Path)
@@ -234,9 +205,8 @@ def _run_ps1_printer(install_dir, strict_mode):
         get_function_source = f"'{GET_FUNCTION_SOURCE}'",
         setup_ps1 = f"'{SETUP_PS1}'",
     )
-    # -File, not -Command: a param() block only binds named arguments when the script is
-    # run as a file, and the strict mode has to be set in the CALLER's scope to reproduce
-    # what an embedding script does to setup.ps1.
+    # -File, not -Command: param() only binds named args from a file, and strict mode has
+    # to sit in the CALLER's scope.
     script_path = Path(install_dir).parent / f"drive_{strict_mode.replace('.', '_')}.ps1"
     script_path.write_text(script, encoding = "utf-8")
     proc = subprocess.run(
@@ -262,7 +232,6 @@ def _run_ps1_printer(install_dir, strict_mode):
     return proc
 
 
-# -- the bash twin -------------------------------------------------------------------
 
 _SH_HARNESS = """
 set -u
@@ -275,7 +244,6 @@ installed_llama_prebuilt_release "$_INSTALL_DIR"
 
 
 def _sliced_sh_function(tmp_path):
-    """The real installed_llama_prebuilt_release, sliced out of setup.sh."""
     text = SETUP_SH.read_text(encoding = "utf-8")
     start = text.index("installed_llama_prebuilt_release() {")
     end = text.index("\n}\n", start) + len("\n}\n")
@@ -291,8 +259,7 @@ def _run_sh_printer(install_dir, tmp_path):
     func_file = _sliced_sh_function(tmp_path)
     script = tmp_path / "drive.sh"
     script.write_text(_SH_HARNESS, encoding = "utf-8")
-    # The sliced function shells out to `python`; point it at the interpreter running
-    # the tests so this does not depend on what happens to be on PATH.
+    # The sliced function shells out to `python`; pin it to the test interpreter.
     shim_dir = tmp_path / "shim"
     shim_dir.mkdir(exist_ok = True)
     shim = shim_dir / "python"
@@ -315,7 +282,6 @@ def _run_sh_printer(install_dir, tmp_path):
     return proc
 
 
-# ==== setup.ps1, under every strict mode ============================================
 
 
 @requires_pwsh
@@ -335,12 +301,8 @@ def test_ps1_printer(marker_dir, strict_mode, case_id, raw, expected):
 @requires_pwsh
 @pytest.mark.parametrize("strict_mode", ["2.0", "3.0", "Latest"])
 def test_a_legacy_marker_does_not_abort_under_strict_mode(marker_dir, strict_mode):
-    """The discriminating case for the guard.
-
-    Markers written between #4562 (2026-03-25) and #8520 (2026-08-13) have
-    published_repo and release_tag but no backend at all. Reading that missing property
-    raises PropertyNotFoundException from StrictMode 2.0 up, and the function's only
-    try/catch wraps ConvertFrom-Json, so it escapes and takes setup down.
+    """The discriminating case: markers between #4562 and #8520 have no backend key, and
+    the function's only try/catch wraps ConvertFrom-Json, so the read escapes it.
     """
     install_dir = marker_dir(_drop_backend_key())
     proc = _run_ps1_printer(install_dir, strict_mode)
@@ -361,7 +323,6 @@ def test_a_legacy_marker_does_not_abort_under_strict_mode(marker_dir, strict_mod
     ],
 )
 def test_ps1_printer_never_evaluates_the_marker(marker_dir, payload):
-    """A marker is data. Nothing in it may reach the PowerShell parser."""
     install_dir = marker_dir(_with_backend(payload))
     proc = _run_ps1_printer(install_dir, "Latest")
     assert proc.returncode == 0, proc.stderr
@@ -369,7 +330,6 @@ def test_ps1_printer_never_evaluates_the_marker(marker_dir, payload):
     assert proc.stdout == _BASE_LINE
 
 
-# ==== setup.sh ======================================================================
 
 
 @requires_bash
@@ -393,7 +353,6 @@ def test_sh_printer_never_evaluates_the_marker(marker_dir, tmp_path, payload):
     assert proc.stdout.rstrip("\n") == _BASE_LINE
 
 
-# ==== the twins must agree ==========================================================
 
 
 @requires_pwsh
@@ -413,14 +372,11 @@ def test_the_two_printers_agree(marker_dir, tmp_path, case_id, raw, expected):
     ), f"{case_id}: setup.ps1 printed {ps1.stdout!r}, setup.sh printed {sh.stdout!r}"
 
 
-# ==== every historical marker shape =================================================
-# Reconstructed from git history of studio/install_llama_prebuilt.py's
-# write_prebuilt_metadata. The point of each row is its KEY SET: markers from the
-# 2026-04-01 to 2026-08-13 era are on disk today and carry no backend key at all.
+# Every key set write_prebuilt_metadata has emitted; the 2026-04-01 to 2026-08-13 era is
+# on disk today with no backend key.
 
 _HISTORICAL_MARKERS = {
-    # f4d8a246b, 2026-03-25 (#4562): no published_repo / release_tag yet, so both
-    # printers correctly print nothing.
+    # no published_repo / release_tag yet, so both printers print nothing.
     "2026_03_25_f4d8a246b": (
         {
             "requested_tag": "b4000",
@@ -435,7 +391,6 @@ _HISTORICAL_MARKERS = {
         },
         "",
     ),
-    # 428efc7d9, 2026-04-01: published_repo + release_tag arrive. No backend.
     "2026_04_01_428efc7d9": (
         {
             "requested_tag": "b4100",
@@ -456,7 +411,6 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b4100-mix (tag b4100)",
     ),
-    # 1ce8a8e7c, 2026-04-02: the source_* block.
     "2026_04_02_1ce8a8e7c": (
         {
             "requested_tag": "b4200",
@@ -475,7 +429,6 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b4200-mix (tag b4200)",
     ),
-    # 61df3aaef, 2026-05-30: binary_repo / binary_release_tag.
     "2026_05_30_61df3aaef": (
         {
             "tag": "b5300",
@@ -488,7 +441,6 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b5300-mix + ggml-org@b5300",
     ),
-    # cf912cbd8, 2026-07-20: force_cpu.
     "2026_07_20_cf912cbd8": (
         {
             "tag": "b6900",
@@ -500,8 +452,7 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b6900-mix (tag b6900)",
     ),
-    # 7917c7828, 2026-07-27: llama_backend, the pre-#8520 backend field. It is NOT the
-    # key the printer reads, so this marker still prints no suffix.
+    # llama_backend is the pre-#8520 field, not the key the printer reads.
     "2026_07_27_7917c7828": (
         {
             "tag": "b7100",
@@ -512,7 +463,6 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b7100-mix (tag b7100)",
     ),
-    # 9b452cb3b, 2026-08-04: ggml_tree.
     "2026_08_04_9b452cb3b": (
         {
             "tag": "b7400",
@@ -523,7 +473,6 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b7400-mix (tag b7400)",
     ),
-    # 738413ab0, 2026-08-08: rocm_gfx, conditional. Last shape before backend existed.
     "2026_08_08_738413ab0": (
         {
             "tag": "b7600",
@@ -535,7 +484,6 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b7600-mix (tag b7600)",
     ),
-    # 5426a78c3, 2026-08-13 (#8520): backend + backend_request arrive.
     "2026_08_13_5426a78c3": (
         {
             "tag": "b7900",
@@ -547,8 +495,7 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b7900-mix (tag b7900) -- vulkan backend",
     ),
-    # backend_for_install_kind() returns None for an install kind it does not know, and
-    # that lands in the marker as a JSON null.
+    # backend_for_install_kind() returns None for an unknown kind, landing as JSON null.
     "backend_written_as_null": (
         {
             "tag": "b7900",
@@ -560,7 +507,6 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b7900-mix (tag b7900)",
     ),
-    # 5a3e9fc7a, 2026-08-13: gfx_target / mapped_targets.
     "2026_08_13_5a3e9fc7a": (
         {
             "tag": "b8000",
@@ -573,7 +519,6 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b8000-mix (tag b8000) -- rocm backend",
     ),
-    # 9d1dcfe58, 2026-08-18: supported_sms.
     "2026_08_18_9d1dcfe58": (
         {
             "tag": "b8300",
@@ -585,7 +530,7 @@ _HISTORICAL_MARKERS = {
         },
         "installed release: unslothai/llama.cpp@b8300-mix (tag b8300) -- cuda backend",
     ),
-    # 1400031e2, 2026-08-31: runtime_asset. The current 34-key shape.
+    # the current shape.
     "2026_08_31_1400031e2_current": (
         {
             "requested_tag": "b10715",
@@ -663,7 +608,6 @@ def test_every_historical_marker_shape_agrees(marker_dir, tmp_path, shape_id):
     assert ps1.stdout == sh.stdout.rstrip("\n"), shape_id
 
 
-# ==== the source text, so a future edit cannot quietly unguard it ====================
 
 
 def test_the_ps1_guard_checks_property_existence():
@@ -677,7 +621,6 @@ def test_the_ps1_guard_checks_property_existence():
 
 
 def test_both_printers_share_one_backend_shape_rule():
-    """The one rule that keeps the twins in lockstep, asserted in both sources."""
     shape = "[A-Za-z0-9._+-]{1,32}"
     assert shape in SETUP_PS1.read_text(encoding = "utf-8")
     assert shape in SETUP_SH.read_text(encoding = "utf-8")
@@ -693,12 +636,8 @@ def test_the_sh_printer_only_accepts_a_string():
 @requires_pwsh
 @requires_bash
 def test_the_upstream_source_branch_is_a_known_pre_existing_divergence(marker_dir, tmp_path):
-    """setup.sh names a non-fork binary source; setup.ps1 never has.
-
-    Recorded rather than fixed: teaching setup.ps1 the branch changes what Windows
-    installs print for upstream ggml-org bundles, which is a separate change from
-    naming the backend. Asserted here so it stays a known quantity instead of turning
-    up as a surprise the next time somebody compares the two logs.
+    """Recorded, not fixed: teaching setup.ps1 this branch changes what Windows prints
+    for upstream bundles, which is a separate change from naming the backend.
     """
     raw = json.dumps(
         {
@@ -720,6 +659,5 @@ def test_the_upstream_source_branch_is_a_known_pre_existing_divergence(marker_di
     assert sh.stdout.rstrip("\n") == (
         "installed release: unslothai/unsloth@b10715-mix + ggml-org@b10715 -- cpu backend"
     )
-    # The part this change owns -- the backend suffix -- is identical on both sides.
     assert ps1.stdout.endswith(" -- cpu backend")
     assert sh.stdout.rstrip("\n").endswith(" -- cpu backend")

--- a/tests/studio/install/test_installed_release_backend_line.py
+++ b/tests/studio/install/test_installed_release_backend_line.py
@@ -178,7 +178,6 @@ def marker_dir(tmp_path):
     return _write
 
 
-
 _PS_HARNESS = """
 param([string]$InstallDir, [string]$StrictMode)
 
@@ -232,7 +231,6 @@ def _run_ps1_printer(install_dir, strict_mode):
     return proc
 
 
-
 _SH_HARNESS = """
 set -u
 _FUNC_FILE="$1"
@@ -282,8 +280,6 @@ def _run_sh_printer(install_dir, tmp_path):
     return proc
 
 
-
-
 @requires_pwsh
 @pytest.mark.parametrize("strict_mode", STRICT_MODES)
 @pytest.mark.parametrize(("case_id", "raw", "expected"), _CASES, ids = _IDS)
@@ -330,8 +326,6 @@ def test_ps1_printer_never_evaluates_the_marker(marker_dir, payload):
     assert proc.stdout == _BASE_LINE
 
 
-
-
 @requires_bash
 @pytest.mark.parametrize(("case_id", "raw", "expected"), _CASES, ids = _IDS)
 def test_sh_printer(marker_dir, tmp_path, case_id, raw, expected):
@@ -351,8 +345,6 @@ def test_sh_printer_never_evaluates_the_marker(marker_dir, tmp_path, payload):
     assert proc.returncode == 0, proc.stderr
     assert "pwned" not in proc.stdout
     assert proc.stdout.rstrip("\n") == _BASE_LINE
-
-
 
 
 @requires_pwsh
@@ -606,8 +598,6 @@ def test_every_historical_marker_shape_agrees(marker_dir, tmp_path, shape_id):
     ps1 = _run_ps1_printer(install_dir, "Latest")
     sh = _run_sh_printer(install_dir, tmp_path)
     assert ps1.stdout == sh.stdout.rstrip("\n"), shape_id
-
-
 
 
 def test_the_ps1_guard_checks_property_existence():

--- a/tests/studio/install/test_installed_release_backend_line.py
+++ b/tests/studio/install/test_installed_release_backend_line.py
@@ -88,7 +88,11 @@ _CASES = [
     ("metal", _with_backend("metal"), _BASE_LINE + " -- metal backend"),
     # a name this build has never heard of still prints: no allowlist
     ("unknown_future_backend", _with_backend("sycl2"), _BASE_LINE + " -- sycl2 backend"),
-    ("backend_with_punctuation", _with_backend("cuda13.0+x-1"), _BASE_LINE + " -- cuda13.0+x-1 backend"),
+    (
+        "backend_with_punctuation",
+        _with_backend("cuda13.0+x-1"),
+        _BASE_LINE + " -- cuda13.0+x-1 backend",
+    ),
     ("backend_padded", _with_backend("  vulkan  "), _BASE_LINE + " -- vulkan backend"),
     ("backend_max_length", _with_backend("a" * 32), _BASE_LINE + " -- " + "a" * 32 + " backend"),
     # --- values that must be ignored, identically, by both printers -----------------
@@ -139,9 +143,7 @@ _CASES = [
     ),
     (
         "tag_equals_release_tag",
-        json.dumps(
-            {"published_repo": "r/l", "release_tag": "b1", "tag": "b1", "backend": "rocm"}
-        ),
+        json.dumps({"published_repo": "r/l", "release_tag": "b1", "tag": "b1", "backend": "rocm"}),
         "installed release: r/l@b1 -- rocm backend",
     ),
     (
@@ -161,7 +163,11 @@ _CASES = [
     ),
     ("missing_published_repo", json.dumps({"release_tag": "b1", "backend": "rocm"}), ""),
     ("missing_release_tag", json.dumps({"published_repo": "r/l", "backend": "rocm"}), ""),
-    ("extra_unknown_keys", _marker(backend = "rocm", future_key = {"a": [1, 2]}), _BASE_LINE + " -- rocm backend"),
+    (
+        "extra_unknown_keys",
+        _marker(backend = "rocm", future_key = {"a": [1, 2]}),
+        _BASE_LINE + " -- rocm backend",
+    ),
     # --- unreadable inputs: both printers stay silent -------------------------------
     ("malformed_json", "{not json at all", ""),
     ("truncated_json", '{"published_repo": "r/l", "release_ta', ""),
@@ -179,16 +185,12 @@ _IDS = [case[0] for case in _CASES]
 # differ, and the difference itself is asserted by
 # test_the_upstream_source_branch_is_a_known_pre_existing_divergence below.
 _PS1_EXPECTED_OVERRIDES = {
-    "upstream_binary_source":
-        "installed release: unslothai/unsloth@b10715-mix (tag b10715) -- cpu backend",
+    "upstream_binary_source": "installed release: unslothai/unsloth@b10715-mix (tag b10715) -- cpu backend",
 }
 _HISTORICAL_PS1_OVERRIDES = {
-    "2026_05_30_61df3aaef":
-        "installed release: unslothai/llama.cpp@b5300-mix (tag b5300)",
+    "2026_05_30_61df3aaef": "installed release: unslothai/llama.cpp@b5300-mix (tag b5300)",
 }
-_KNOWN_TWIN_DIVERGENCES = frozenset(_PS1_EXPECTED_OVERRIDES) | frozenset(
-    _HISTORICAL_PS1_OVERRIDES
-)
+_KNOWN_TWIN_DIVERGENCES = frozenset(_PS1_EXPECTED_OVERRIDES) | frozenset(_HISTORICAL_PS1_OVERRIDES)
 
 
 @pytest.fixture
@@ -239,10 +241,16 @@ def _run_ps1_printer(install_dir, strict_mode):
     script_path.write_text(script, encoding = "utf-8")
     proc = subprocess.run(
         [
-            "pwsh", "-NoLogo", "-NoProfile", "-NonInteractive",
-            "-File", str(script_path),
-            "-InstallDir", str(install_dir),
-            "-StrictMode", strict_mode,
+            "pwsh",
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            str(script_path),
+            "-InstallDir",
+            str(install_dir),
+            "-StrictMode",
+            strict_mode,
         ],
         stdout = subprocess.PIPE,
         stderr = subprocess.PIPE,
@@ -318,9 +326,9 @@ def test_ps1_printer(marker_dir, strict_mode, case_id, raw, expected):
     install_dir = marker_dir(raw)
     proc = _run_ps1_printer(install_dir, strict_mode)
     assert proc.returncode == 0, proc.stderr
-    assert proc.stdout == expected, (
-        f"{case_id} under StrictMode {strict_mode}: {proc.stdout!r} != {expected!r}"
-    )
+    assert (
+        proc.stdout == expected
+    ), f"{case_id} under StrictMode {strict_mode}: {proc.stdout!r} != {expected!r}"
     assert proc.stderr == "", f"{case_id} wrote to the error stream: {proc.stderr!r}"
 
 
@@ -370,9 +378,7 @@ def test_sh_printer(marker_dir, tmp_path, case_id, raw, expected):
     install_dir = marker_dir(raw)
     proc = _run_sh_printer(install_dir, tmp_path)
     assert proc.returncode == 0, proc.stderr
-    assert proc.stdout.rstrip("\n") == expected, (
-        f"{case_id}: {proc.stdout!r} != {expected!r}"
-    )
+    assert proc.stdout.rstrip("\n") == expected, f"{case_id}: {proc.stdout!r} != {expected!r}"
 
 
 @requires_bash
@@ -402,9 +408,9 @@ def test_the_two_printers_agree(marker_dir, tmp_path, case_id, raw, expected):
     sh = _run_sh_printer(install_dir, tmp_path)
     assert ps1.returncode == 0, ps1.stderr
     assert sh.returncode == 0, sh.stderr
-    assert ps1.stdout == sh.stdout.rstrip("\n"), (
-        f"{case_id}: setup.ps1 printed {ps1.stdout!r}, setup.sh printed {sh.stdout!r}"
-    )
+    assert ps1.stdout == sh.stdout.rstrip(
+        "\n"
+    ), f"{case_id}: setup.ps1 printed {ps1.stdout!r}, setup.sh printed {sh.stdout!r}"
 
 
 # ==== every historical marker shape =================================================
@@ -417,9 +423,14 @@ _HISTORICAL_MARKERS = {
     # printers correctly print nothing.
     "2026_03_25_f4d8a246b": (
         {
-            "requested_tag": "b4000", "tag": "b4000", "asset": "linux-cuda",
-            "source": "unsloth", "bundle_profile": "full", "runtime_line": "cuda",
-            "coverage_class": "broad", "prebuilt_fallback_used": False,
+            "requested_tag": "b4000",
+            "tag": "b4000",
+            "asset": "linux-cuda",
+            "source": "unsloth",
+            "bundle_profile": "full",
+            "runtime_line": "cuda",
+            "coverage_class": "broad",
+            "prebuilt_fallback_used": False,
             "installed_at_utc": "2026-03-25T00:00:00Z",
         },
         "",
@@ -427,33 +438,52 @@ _HISTORICAL_MARKERS = {
     # 428efc7d9, 2026-04-01: published_repo + release_tag arrive. No backend.
     "2026_04_01_428efc7d9": (
         {
-            "requested_tag": "b4100", "tag": "b4100", "release_tag": "b4100-mix",
-            "published_repo": "unslothai/llama.cpp", "asset": "linux-cuda",
-            "asset_sha256": "0" * 64, "source": "unsloth", "source_sha256": "1" * 64,
-            "source_commit": "a" * 40, "install_fingerprint": "fp",
-            "bundle_profile": "full", "runtime_line": "cuda", "coverage_class": "broad",
-            "prebuilt_fallback_used": False, "installed_at_utc": "2026-04-01T00:00:00Z",
+            "requested_tag": "b4100",
+            "tag": "b4100",
+            "release_tag": "b4100-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "asset": "linux-cuda",
+            "asset_sha256": "0" * 64,
+            "source": "unsloth",
+            "source_sha256": "1" * 64,
+            "source_commit": "a" * 40,
+            "install_fingerprint": "fp",
+            "bundle_profile": "full",
+            "runtime_line": "cuda",
+            "coverage_class": "broad",
+            "prebuilt_fallback_used": False,
+            "installed_at_utc": "2026-04-01T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b4100-mix (tag b4100)",
     ),
     # 1ce8a8e7c, 2026-04-02: the source_* block.
     "2026_04_02_1ce8a8e7c": (
         {
-            "requested_tag": "b4200", "tag": "b4200", "release_tag": "b4200-mix",
-            "published_repo": "unslothai/llama.cpp", "asset": "linux-vulkan",
-            "source_asset": "src.tar.gz", "source_commit_short": "aaaaaaa",
-            "source_repo": "ggml-org/llama.cpp", "source_repo_url": "https://x",
-            "source_ref_kind": "tag", "requested_source_ref": "b4200",
-            "resolved_source_ref": "b4200", "installed_at_utc": "2026-04-02T00:00:00Z",
+            "requested_tag": "b4200",
+            "tag": "b4200",
+            "release_tag": "b4200-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "asset": "linux-vulkan",
+            "source_asset": "src.tar.gz",
+            "source_commit_short": "aaaaaaa",
+            "source_repo": "ggml-org/llama.cpp",
+            "source_repo_url": "https://x",
+            "source_ref_kind": "tag",
+            "requested_source_ref": "b4200",
+            "resolved_source_ref": "b4200",
+            "installed_at_utc": "2026-04-02T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b4200-mix (tag b4200)",
     ),
     # 61df3aaef, 2026-05-30: binary_repo / binary_release_tag.
     "2026_05_30_61df3aaef": (
         {
-            "tag": "b5300", "release_tag": "b5300-mix",
-            "published_repo": "unslothai/llama.cpp", "source": "ggml-org",
-            "binary_repo": "ggml-org/llama.cpp", "binary_release_tag": "b5300",
+            "tag": "b5300",
+            "release_tag": "b5300-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "source": "ggml-org",
+            "binary_repo": "ggml-org/llama.cpp",
+            "binary_release_tag": "b5300",
             "installed_at_utc": "2026-05-30T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b5300-mix + ggml-org@b5300",
@@ -461,9 +491,12 @@ _HISTORICAL_MARKERS = {
     # cf912cbd8, 2026-07-20: force_cpu.
     "2026_07_20_cf912cbd8": (
         {
-            "tag": "b6900", "release_tag": "b6900-mix",
-            "published_repo": "unslothai/llama.cpp", "force_cpu": True,
-            "asset": "linux-cpu", "installed_at_utc": "2026-07-20T00:00:00Z",
+            "tag": "b6900",
+            "release_tag": "b6900-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "force_cpu": True,
+            "asset": "linux-cpu",
+            "installed_at_utc": "2026-07-20T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b6900-mix (tag b6900)",
     ),
@@ -471,8 +504,10 @@ _HISTORICAL_MARKERS = {
     # key the printer reads, so this marker still prints no suffix.
     "2026_07_27_7917c7828": (
         {
-            "tag": "b7100", "release_tag": "b7100-mix",
-            "published_repo": "unslothai/llama.cpp", "llama_backend": "vulkan",
+            "tag": "b7100",
+            "release_tag": "b7100-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "llama_backend": "vulkan",
             "installed_at_utc": "2026-07-27T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b7100-mix (tag b7100)",
@@ -480,8 +515,10 @@ _HISTORICAL_MARKERS = {
     # 9b452cb3b, 2026-08-04: ggml_tree.
     "2026_08_04_9b452cb3b": (
         {
-            "tag": "b7400", "release_tag": "b7400-mix",
-            "published_repo": "unslothai/llama.cpp", "ggml_tree": "abc123",
+            "tag": "b7400",
+            "release_tag": "b7400-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "ggml_tree": "abc123",
             "installed_at_utc": "2026-08-04T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b7400-mix (tag b7400)",
@@ -489,18 +526,24 @@ _HISTORICAL_MARKERS = {
     # 738413ab0, 2026-08-08: rocm_gfx, conditional. Last shape before backend existed.
     "2026_08_08_738413ab0": (
         {
-            "tag": "b7600", "release_tag": "b7600-mix",
-            "published_repo": "unslothai/llama.cpp", "llama_backend": "auto",
-            "rocm_gfx": "gfx1151", "installed_at_utc": "2026-08-08T00:00:00Z",
+            "tag": "b7600",
+            "release_tag": "b7600-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "llama_backend": "auto",
+            "rocm_gfx": "gfx1151",
+            "installed_at_utc": "2026-08-08T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b7600-mix (tag b7600)",
     ),
     # 5426a78c3, 2026-08-13 (#8520): backend + backend_request arrive.
     "2026_08_13_5426a78c3": (
         {
-            "tag": "b7900", "release_tag": "b7900-mix",
-            "published_repo": "unslothai/llama.cpp", "backend": "vulkan",
-            "backend_request": "auto", "installed_at_utc": "2026-08-13T00:00:00Z",
+            "tag": "b7900",
+            "release_tag": "b7900-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "backend": "vulkan",
+            "backend_request": "auto",
+            "installed_at_utc": "2026-08-13T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b7900-mix (tag b7900) -- vulkan backend",
     ),
@@ -508,18 +551,24 @@ _HISTORICAL_MARKERS = {
     # that lands in the marker as a JSON null.
     "backend_written_as_null": (
         {
-            "tag": "b7900", "release_tag": "b7900-mix",
-            "published_repo": "unslothai/llama.cpp", "backend": None,
-            "backend_request": "auto", "installed_at_utc": "2026-08-13T00:00:00Z",
+            "tag": "b7900",
+            "release_tag": "b7900-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "backend": None,
+            "backend_request": "auto",
+            "installed_at_utc": "2026-08-13T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b7900-mix (tag b7900)",
     ),
     # 5a3e9fc7a, 2026-08-13: gfx_target / mapped_targets.
     "2026_08_13_5a3e9fc7a": (
         {
-            "tag": "b8000", "release_tag": "b8000-mix",
-            "published_repo": "unslothai/llama.cpp", "backend": "rocm",
-            "gfx_target": "gfx1151", "mapped_targets": ["gfx1151", "gfx1200"],
+            "tag": "b8000",
+            "release_tag": "b8000-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "backend": "rocm",
+            "gfx_target": "gfx1151",
+            "mapped_targets": ["gfx1151", "gfx1200"],
             "installed_at_utc": "2026-08-13T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b8000-mix (tag b8000) -- rocm backend",
@@ -527,30 +576,51 @@ _HISTORICAL_MARKERS = {
     # 9d1dcfe58, 2026-08-18: supported_sms.
     "2026_08_18_9d1dcfe58": (
         {
-            "tag": "b8300", "release_tag": "b8300-mix",
-            "published_repo": "unslothai/llama.cpp", "backend": "cuda",
-            "supported_sms": ["90", "100"], "installed_at_utc": "2026-08-18T00:00:00Z",
+            "tag": "b8300",
+            "release_tag": "b8300-mix",
+            "published_repo": "unslothai/llama.cpp",
+            "backend": "cuda",
+            "supported_sms": ["90", "100"],
+            "installed_at_utc": "2026-08-18T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b8300-mix (tag b8300) -- cuda backend",
     ),
     # 1400031e2, 2026-08-31: runtime_asset. The current 34-key shape.
     "2026_08_31_1400031e2_current": (
         {
-            "requested_tag": "b10715", "tag": "b10715",
-            "release_tag": "b10715-mix-86bd2d3", "published_repo": "unslothai/llama.cpp",
-            "asset": "windows-vulkan", "force_cpu": False, "llama_backend": "vulkan",
-            "backend": "vulkan", "backend_request": "auto", "asset_sha256": "0" * 64,
-            "runtime_asset": "runtime.zip", "source": "unsloth",
-            "binary_repo": "unslothai/llama.cpp", "binary_release_tag": "b10715-mix",
-            "source_asset": "src.tar.gz", "source_sha256": "1" * 64,
-            "source_commit": "a" * 40, "source_commit_short": "aaaaaaa",
-            "source_repo": "ggml-org/llama.cpp", "source_repo_url": "https://x",
-            "source_ref_kind": "tag", "requested_source_ref": "b10715",
-            "resolved_source_ref": "b10715", "ggml_tree": "abc123",
-            "bundle_profile": "full", "runtime_line": "vulkan",
-            "coverage_class": "broad", "gfx_target": "", "mapped_targets": [],
-            "supported_sms": [], "install_fingerprint": "fp",
-            "prebuilt_fallback_used": False, "installed_at_utc": "2026-08-31T00:00:00Z",
+            "requested_tag": "b10715",
+            "tag": "b10715",
+            "release_tag": "b10715-mix-86bd2d3",
+            "published_repo": "unslothai/llama.cpp",
+            "asset": "windows-vulkan",
+            "force_cpu": False,
+            "llama_backend": "vulkan",
+            "backend": "vulkan",
+            "backend_request": "auto",
+            "asset_sha256": "0" * 64,
+            "runtime_asset": "runtime.zip",
+            "source": "unsloth",
+            "binary_repo": "unslothai/llama.cpp",
+            "binary_release_tag": "b10715-mix",
+            "source_asset": "src.tar.gz",
+            "source_sha256": "1" * 64,
+            "source_commit": "a" * 40,
+            "source_commit_short": "aaaaaaa",
+            "source_repo": "ggml-org/llama.cpp",
+            "source_repo_url": "https://x",
+            "source_ref_kind": "tag",
+            "requested_source_ref": "b10715",
+            "resolved_source_ref": "b10715",
+            "ggml_tree": "abc123",
+            "bundle_profile": "full",
+            "runtime_line": "vulkan",
+            "coverage_class": "broad",
+            "gfx_target": "",
+            "mapped_targets": [],
+            "supported_sms": [],
+            "install_fingerprint": "fp",
+            "prebuilt_fallback_used": False,
+            "installed_at_utc": "2026-08-31T00:00:00Z",
         },
         "installed release: unslothai/llama.cpp@b10715-mix-86bd2d3 (tag b10715) -- vulkan backend",
     ),
@@ -615,9 +685,9 @@ def test_both_printers_share_one_backend_shape_rule():
 
 def test_the_sh_printer_only_accepts_a_string():
     text = SETUP_SH.read_text(encoding = "utf-8")
-    assert "isinstance(_backend_raw, str)" in text, (
-        "str() on a non-string diverges from the PowerShell twin"
-    )
+    assert (
+        "isinstance(_backend_raw, str)" in text
+    ), "str() on a non-string diverges from the PowerShell twin"
 
 
 @requires_pwsh

--- a/tests/studio/install/test_installed_release_backend_line.py
+++ b/tests/studio/install/test_installed_release_backend_line.py
@@ -1,0 +1,655 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The "installed release: ..." line, in both setup twins, against real markers.
+
+setup.ps1's Get-InstalledLlamaPrebuiltRelease and setup.sh's
+installed_llama_prebuilt_release print the same line from the same
+UNSLOTH_PREBUILT_INFO.json, so they are tested together and every case asserts they
+agree. They have drifted apart before precisely because nothing compared them.
+
+Two things this file exists to hold:
+
+1. ``backend`` has only been written since #8520 (2026-08-13); markers go back to #4562
+   (2026-03-25). Reading a property that a legacy marker does not have is a TERMINATING
+   error under a caller's ``Set-StrictMode -Version 2.0`` or higher, so an unguarded read
+   would abort setup on every install older than that. The whole historical key-set
+   sequence is replayed here under every strict mode.
+
+2. The two printers must render the same bytes for the same marker. A non-string value
+   does not survive that on its own: PowerShell renders @(1, 2) as "1 2" and Python
+   renders [1, 2] as "[1, 2]".
+
+Both functions are sliced out of their scripts rather than sourced whole, because both
+scripts run install steps at load. That is the same technique as
+tests/studio_setup_ps1/Get-FunctionSource.ps1 and tests/sh/test_node_decision.sh.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[3]
+SETUP_PS1 = PACKAGE_ROOT / "studio" / "setup.ps1"
+SETUP_SH = PACKAGE_ROOT / "studio" / "setup.sh"
+GET_FUNCTION_SOURCE = PACKAGE_ROOT / "tests" / "studio_setup_ps1" / "Get-FunctionSource.ps1"
+
+requires_pwsh = pytest.mark.skipif(
+    shutil.which("pwsh") is None, reason = "pwsh is required to run the setup.ps1 printer"
+)
+requires_bash = pytest.mark.skipif(
+    shutil.which("bash") is None, reason = "bash is required to run the setup.sh printer"
+)
+
+# Every strict mode a caller can impose. 2.0 is where non-existent property reads become
+# terminating errors; 3.0 and Latest keep that rule and add array-index rules on top.
+STRICT_MODES = ["off", "1.0", "2.0", "3.0", "Latest"]
+
+_BASE_MARKER = {
+    "published_repo": "unslothai/llama.cpp",
+    "release_tag": "b10715-mix-86bd2d3",
+    "tag": "b10715",
+}
+_BASE_LINE = "installed release: unslothai/llama.cpp@b10715-mix-86bd2d3 (tag b10715)"
+
+
+def _marker(**overrides):
+    payload = dict(_BASE_MARKER)
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def _with_backend(value):
+    payload = dict(_BASE_MARKER)
+    payload["backend"] = value
+    return json.dumps(payload)
+
+
+def _drop_backend_key():
+    return json.dumps(dict(_BASE_MARKER))
+
+
+# -- the corpus ----------------------------------------------------------------------
+# (id, raw file text or None for "no file at all", expected printed line)
+_CASES = [
+    # --- the legacy shape, which is the whole point of the guard --------------------
+    ("legacy_no_backend_key", _drop_backend_key(), _BASE_LINE),
+    # --- every backend the vocabulary can produce ----------------------------------
+    ("cuda", _with_backend("cuda"), _BASE_LINE + " -- cuda backend"),
+    ("rocm", _with_backend("rocm"), _BASE_LINE + " -- rocm backend"),
+    ("vulkan", _with_backend("vulkan"), _BASE_LINE + " -- vulkan backend"),
+    ("cpu", _with_backend("cpu"), _BASE_LINE + " -- cpu backend"),
+    ("metal", _with_backend("metal"), _BASE_LINE + " -- metal backend"),
+    # a name this build has never heard of still prints: no allowlist
+    ("unknown_future_backend", _with_backend("sycl2"), _BASE_LINE + " -- sycl2 backend"),
+    ("backend_with_punctuation", _with_backend("cuda13.0+x-1"), _BASE_LINE + " -- cuda13.0+x-1 backend"),
+    ("backend_padded", _with_backend("  vulkan  "), _BASE_LINE + " -- vulkan backend"),
+    ("backend_max_length", _with_backend("a" * 32), _BASE_LINE + " -- " + "a" * 32 + " backend"),
+    # --- values that must be ignored, identically, by both printers -----------------
+    ("backend_null", _with_backend(None), _BASE_LINE),
+    ("backend_empty", _with_backend(""), _BASE_LINE),
+    ("backend_whitespace", _with_backend("   "), _BASE_LINE),
+    ("backend_zero", _with_backend(0), _BASE_LINE),
+    ("backend_false", _with_backend(False), _BASE_LINE),
+    ("backend_true", _with_backend(True), _BASE_LINE),
+    ("backend_int", _with_backend(7), _BASE_LINE),
+    ("backend_float", _with_backend(1.5), _BASE_LINE),
+    ("backend_empty_list", _with_backend([]), _BASE_LINE),
+    ("backend_list", _with_backend(["rocm", "vulkan"]), _BASE_LINE),
+    ("backend_empty_object", _with_backend({}), _BASE_LINE),
+    ("backend_object", _with_backend({"name": "rocm"}), _BASE_LINE),
+    ("backend_too_long", _with_backend("a" * 33), _BASE_LINE),
+    ("backend_unicode", _with_backend("vulkän"), _BASE_LINE),
+    ("backend_emoji", _with_backend("rocm\U0001f680"), _BASE_LINE),
+    ("backend_cjk", _with_backend("显卡"), _BASE_LINE),
+    ("backend_1kib", _with_backend("v" * 1024), _BASE_LINE),
+    ("backend_64kib", _with_backend("v" * 65536), _BASE_LINE),
+    ("backend_with_space", _with_backend("vulkan gpu"), _BASE_LINE),
+    ("backend_underscore", _with_backend("windows_rocm"), _BASE_LINE + " -- windows_rocm backend"),
+    # --- text that must be treated as data, never as code --------------------------
+    ("backend_double_quote", _with_backend('vul"kan'), _BASE_LINE),
+    ("backend_single_quote", _with_backend("vul'kan"), _BASE_LINE),
+    ("backend_backtick", _with_backend("vul`kan"), _BASE_LINE),
+    ("backend_ps_subexpression", _with_backend("$(Write-Output pwned)"), _BASE_LINE),
+    ("backend_ps_variable", _with_backend("$env:PATH"), _BASE_LINE),
+    ("backend_shell_semicolon", _with_backend("vulkan; echo pwned"), _BASE_LINE),
+    ("backend_shell_substitution", _with_backend("$(echo pwned)"), _BASE_LINE),
+    ("backend_backslash", _with_backend("vul\\kan"), _BASE_LINE),
+    ("backend_newline", _with_backend("vulkan\nrocm"), _BASE_LINE),
+    ("backend_crlf", _with_backend("vulkan\r\nrocm"), _BASE_LINE),
+    ("backend_tab", _with_backend("vul\tkan"), _BASE_LINE),
+    ("backend_ansi", _with_backend("\x1b[31mrocm\x1b[0m"), _BASE_LINE),
+    ("backend_nul", _with_backend("rocm\x00x"), _BASE_LINE),
+    # --- key-name handling ----------------------------------------------------------
+    # PowerShell property access is case-insensitive and Python's is not; the guard is
+    # -ccontains so both printers ignore a case-folded key rather than disagreeing.
+    ("backend_key_uppercase", _marker(BACKEND = "vulkan"), _BASE_LINE),
+    ("backend_key_mixed_case", _marker(Backend = "vulkan"), _BASE_LINE),
+    # --- the rest of the line, unchanged by this PR ---------------------------------
+    (
+        "no_tag_key",
+        json.dumps({"published_repo": "unslothai/llama.cpp", "release_tag": "b10715-mix"}),
+        "installed release: unslothai/llama.cpp@b10715-mix",
+    ),
+    (
+        "tag_equals_release_tag",
+        json.dumps(
+            {"published_repo": "r/l", "release_tag": "b1", "tag": "b1", "backend": "rocm"}
+        ),
+        "installed release: r/l@b1 -- rocm backend",
+    ),
+    (
+        "upstream_binary_source",
+        json.dumps(
+            {
+                "published_repo": "unslothai/unsloth",
+                "release_tag": "b10715-mix",
+                "tag": "b10715",
+                "source": "ggml-org",
+                "binary_repo": "ggml-org/llama.cpp",
+                "binary_release_tag": "b10715",
+                "backend": "cpu",
+            }
+        ),
+        "installed release: unslothai/unsloth@b10715-mix + ggml-org@b10715 -- cpu backend",
+    ),
+    ("missing_published_repo", json.dumps({"release_tag": "b1", "backend": "rocm"}), ""),
+    ("missing_release_tag", json.dumps({"published_repo": "r/l", "backend": "rocm"}), ""),
+    ("extra_unknown_keys", _marker(backend = "rocm", future_key = {"a": [1, 2]}), _BASE_LINE + " -- rocm backend"),
+    # --- unreadable inputs: both printers stay silent -------------------------------
+    ("malformed_json", "{not json at all", ""),
+    ("truncated_json", '{"published_repo": "r/l", "release_ta', ""),
+    ("empty_file", "", ""),
+    ("whitespace_file", "   \n  ", ""),
+    ("absent_file", None, ""),
+]
+
+_IDS = [case[0] for case in _CASES]
+
+# setup.sh has a "+ <source>@<binary_tag>" branch for non-fork binary sources that
+# setup.ps1 has never had (there is no `source` / `binary_repo` read anywhere in
+# Get-InstalledLlamaPrebuiltRelease). That divergence predates this change and is left
+# alone rather than silently dropped: these are the ids where the twins legitimately
+# differ, and the difference itself is asserted by
+# test_the_upstream_source_branch_is_a_known_pre_existing_divergence below.
+_PS1_EXPECTED_OVERRIDES = {
+    "upstream_binary_source":
+        "installed release: unslothai/unsloth@b10715-mix (tag b10715) -- cpu backend",
+}
+_HISTORICAL_PS1_OVERRIDES = {
+    "2026_05_30_61df3aaef":
+        "installed release: unslothai/llama.cpp@b5300-mix (tag b5300)",
+}
+_KNOWN_TWIN_DIVERGENCES = frozenset(_PS1_EXPECTED_OVERRIDES) | frozenset(
+    _HISTORICAL_PS1_OVERRIDES
+)
+
+
+@pytest.fixture
+def marker_dir(tmp_path):
+    def _write(raw):
+        install_dir = tmp_path / "llama.cpp"
+        install_dir.mkdir(exist_ok = True)
+        if raw is not None:
+            (install_dir / "UNSLOTH_PREBUILT_INFO.json").write_text(raw, encoding = "utf-8")
+        return install_dir
+
+    return _write
+
+
+# -- the PowerShell twin -------------------------------------------------------------
+
+_PS_HARNESS = """
+param([string]$InstallDir, [string]$StrictMode)
+
+if ($StrictMode -ne 'off') {{ Set-StrictMode -Version $StrictMode }}
+
+# The real function's only dependency, stubbed the way tests/studio/install's PowerShell
+# harnesses do: Get-PathState pulls in half the installer and answers nothing this needs.
+function Test-PathQuiet {{
+    param([string]$Path, [string]$PathType = "Any")
+    return (Test-Path -LiteralPath $Path)
+}}
+
+. {get_function_source}
+$src = Get-FunctionSource -Path {setup_ps1} -Name Get-InstalledLlamaPrebuiltRelease
+if (-not $src) {{ Write-Error "could not slice Get-InstalledLlamaPrebuiltRelease"; exit 2 }}
+. ([scriptblock]::Create($src))
+
+$result = Get-InstalledLlamaPrebuiltRelease -InstallDir $InstallDir
+if ($null -ne $result) {{ [Console]::Out.Write($result) }}
+"""
+
+
+def _run_ps1_printer(install_dir, strict_mode):
+    script = _PS_HARNESS.format(
+        get_function_source = f"'{GET_FUNCTION_SOURCE}'",
+        setup_ps1 = f"'{SETUP_PS1}'",
+    )
+    # -File, not -Command: a param() block only binds named arguments when the script is
+    # run as a file, and the strict mode has to be set in the CALLER's scope to reproduce
+    # what an embedding script does to setup.ps1.
+    script_path = Path(install_dir).parent / f"drive_{strict_mode.replace('.', '_')}.ps1"
+    script_path.write_text(script, encoding = "utf-8")
+    proc = subprocess.run(
+        [
+            "pwsh", "-NoLogo", "-NoProfile", "-NonInteractive",
+            "-File", str(script_path),
+            "-InstallDir", str(install_dir),
+            "-StrictMode", strict_mode,
+        ],
+        stdout = subprocess.PIPE,
+        stderr = subprocess.PIPE,
+        text = True,
+        encoding = "utf-8",
+        errors = "replace",
+        timeout = 120,
+    )
+    return proc
+
+
+# -- the bash twin -------------------------------------------------------------------
+
+_SH_HARNESS = """
+set -u
+_FUNC_FILE="$1"
+_INSTALL_DIR="$2"
+# shellcheck disable=SC1090
+. "$_FUNC_FILE"
+installed_llama_prebuilt_release "$_INSTALL_DIR"
+"""
+
+
+def _sliced_sh_function(tmp_path):
+    """The real installed_llama_prebuilt_release, sliced out of setup.sh."""
+    text = SETUP_SH.read_text(encoding = "utf-8")
+    start = text.index("installed_llama_prebuilt_release() {")
+    end = text.index("\n}\n", start) + len("\n}\n")
+    body = text[start:end]
+    assert "UNSLOTH_PREBUILT_INFO.json" in body, "sliced the wrong block out of setup.sh"
+    assert body.count("<<'PY'") == 1, "expected exactly one heredoc in the sliced block"
+    path = tmp_path / "installed_release_fn.sh"
+    path.write_text(body, encoding = "utf-8")
+    return path
+
+
+def _run_sh_printer(install_dir, tmp_path):
+    func_file = _sliced_sh_function(tmp_path)
+    script = tmp_path / "drive.sh"
+    script.write_text(_SH_HARNESS, encoding = "utf-8")
+    # The sliced function shells out to `python`; point it at the interpreter running
+    # the tests so this does not depend on what happens to be on PATH.
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir(exist_ok = True)
+    shim = shim_dir / "python"
+    shim.write_text(f'#!/bin/sh\nexec "{sys.executable}" "$@"\n', encoding = "utf-8")
+    shim.chmod(0o755)
+    import os
+
+    env = dict(os.environ)
+    env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', '')}"
+    proc = subprocess.run(
+        ["bash", str(script), str(func_file), str(install_dir)],
+        stdout = subprocess.PIPE,
+        stderr = subprocess.PIPE,
+        text = True,
+        encoding = "utf-8",
+        errors = "replace",
+        env = env,
+        timeout = 120,
+    )
+    return proc
+
+
+# ==== setup.ps1, under every strict mode ============================================
+
+
+@requires_pwsh
+@pytest.mark.parametrize("strict_mode", STRICT_MODES)
+@pytest.mark.parametrize(("case_id", "raw", "expected"), _CASES, ids = _IDS)
+def test_ps1_printer(marker_dir, strict_mode, case_id, raw, expected):
+    expected = _PS1_EXPECTED_OVERRIDES.get(case_id, expected)
+    install_dir = marker_dir(raw)
+    proc = _run_ps1_printer(install_dir, strict_mode)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == expected, (
+        f"{case_id} under StrictMode {strict_mode}: {proc.stdout!r} != {expected!r}"
+    )
+    assert proc.stderr == "", f"{case_id} wrote to the error stream: {proc.stderr!r}"
+
+
+@requires_pwsh
+@pytest.mark.parametrize("strict_mode", ["2.0", "3.0", "Latest"])
+def test_a_legacy_marker_does_not_abort_under_strict_mode(marker_dir, strict_mode):
+    """The discriminating case for the guard.
+
+    Markers written between #4562 (2026-03-25) and #8520 (2026-08-13) have
+    published_repo and release_tag but no backend at all. Reading that missing property
+    raises PropertyNotFoundException from StrictMode 2.0 up, and the function's only
+    try/catch wraps ConvertFrom-Json, so it escapes and takes setup down.
+    """
+    install_dir = marker_dir(_drop_backend_key())
+    proc = _run_ps1_printer(install_dir, strict_mode)
+    assert "PropertyNotFound" not in proc.stderr, proc.stderr
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == _BASE_LINE
+    assert proc.stderr == ""
+
+
+@requires_pwsh
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "$(Write-Output pwned)",
+        "`$(Write-Output pwned)",
+        "vulkan; Write-Output pwned",
+        "$(1+1)",
+    ],
+)
+def test_ps1_printer_never_evaluates_the_marker(marker_dir, payload):
+    """A marker is data. Nothing in it may reach the PowerShell parser."""
+    install_dir = marker_dir(_with_backend(payload))
+    proc = _run_ps1_printer(install_dir, "Latest")
+    assert proc.returncode == 0, proc.stderr
+    assert "pwned" not in proc.stdout
+    assert proc.stdout == _BASE_LINE
+
+
+# ==== setup.sh ======================================================================
+
+
+@requires_bash
+@pytest.mark.parametrize(("case_id", "raw", "expected"), _CASES, ids = _IDS)
+def test_sh_printer(marker_dir, tmp_path, case_id, raw, expected):
+    install_dir = marker_dir(raw)
+    proc = _run_sh_printer(install_dir, tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.rstrip("\n") == expected, (
+        f"{case_id}: {proc.stdout!r} != {expected!r}"
+    )
+
+
+@requires_bash
+@pytest.mark.parametrize(
+    "payload", ["vulkan; echo pwned", "$(echo pwned)", "`echo pwned`", "$(id)"]
+)
+def test_sh_printer_never_evaluates_the_marker(marker_dir, tmp_path, payload):
+    install_dir = marker_dir(_with_backend(payload))
+    proc = _run_sh_printer(install_dir, tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert "pwned" not in proc.stdout
+    assert proc.stdout.rstrip("\n") == _BASE_LINE
+
+
+# ==== the twins must agree ==========================================================
+
+
+@requires_pwsh
+@requires_bash
+@pytest.mark.parametrize(("case_id", "raw", "expected"), _CASES, ids = _IDS)
+def test_the_two_printers_agree(marker_dir, tmp_path, case_id, raw, expected):
+    """Byte-for-byte parity. Without it the twins drift and nobody notices."""
+    if case_id in _KNOWN_TWIN_DIVERGENCES:
+        pytest.skip("documented pre-existing divergence; see the dedicated test")
+    install_dir = marker_dir(raw)
+    ps1 = _run_ps1_printer(install_dir, "Latest")
+    sh = _run_sh_printer(install_dir, tmp_path)
+    assert ps1.returncode == 0, ps1.stderr
+    assert sh.returncode == 0, sh.stderr
+    assert ps1.stdout == sh.stdout.rstrip("\n"), (
+        f"{case_id}: setup.ps1 printed {ps1.stdout!r}, setup.sh printed {sh.stdout!r}"
+    )
+
+
+# ==== every historical marker shape =================================================
+# Reconstructed from git history of studio/install_llama_prebuilt.py's
+# write_prebuilt_metadata. The point of each row is its KEY SET: markers from the
+# 2026-04-01 to 2026-08-13 era are on disk today and carry no backend key at all.
+
+_HISTORICAL_MARKERS = {
+    # f4d8a246b, 2026-03-25 (#4562): no published_repo / release_tag yet, so both
+    # printers correctly print nothing.
+    "2026_03_25_f4d8a246b": (
+        {
+            "requested_tag": "b4000", "tag": "b4000", "asset": "linux-cuda",
+            "source": "unsloth", "bundle_profile": "full", "runtime_line": "cuda",
+            "coverage_class": "broad", "prebuilt_fallback_used": False,
+            "installed_at_utc": "2026-03-25T00:00:00Z",
+        },
+        "",
+    ),
+    # 428efc7d9, 2026-04-01: published_repo + release_tag arrive. No backend.
+    "2026_04_01_428efc7d9": (
+        {
+            "requested_tag": "b4100", "tag": "b4100", "release_tag": "b4100-mix",
+            "published_repo": "unslothai/llama.cpp", "asset": "linux-cuda",
+            "asset_sha256": "0" * 64, "source": "unsloth", "source_sha256": "1" * 64,
+            "source_commit": "a" * 40, "install_fingerprint": "fp",
+            "bundle_profile": "full", "runtime_line": "cuda", "coverage_class": "broad",
+            "prebuilt_fallback_used": False, "installed_at_utc": "2026-04-01T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b4100-mix (tag b4100)",
+    ),
+    # 1ce8a8e7c, 2026-04-02: the source_* block.
+    "2026_04_02_1ce8a8e7c": (
+        {
+            "requested_tag": "b4200", "tag": "b4200", "release_tag": "b4200-mix",
+            "published_repo": "unslothai/llama.cpp", "asset": "linux-vulkan",
+            "source_asset": "src.tar.gz", "source_commit_short": "aaaaaaa",
+            "source_repo": "ggml-org/llama.cpp", "source_repo_url": "https://x",
+            "source_ref_kind": "tag", "requested_source_ref": "b4200",
+            "resolved_source_ref": "b4200", "installed_at_utc": "2026-04-02T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b4200-mix (tag b4200)",
+    ),
+    # 61df3aaef, 2026-05-30: binary_repo / binary_release_tag.
+    "2026_05_30_61df3aaef": (
+        {
+            "tag": "b5300", "release_tag": "b5300-mix",
+            "published_repo": "unslothai/llama.cpp", "source": "ggml-org",
+            "binary_repo": "ggml-org/llama.cpp", "binary_release_tag": "b5300",
+            "installed_at_utc": "2026-05-30T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b5300-mix + ggml-org@b5300",
+    ),
+    # cf912cbd8, 2026-07-20: force_cpu.
+    "2026_07_20_cf912cbd8": (
+        {
+            "tag": "b6900", "release_tag": "b6900-mix",
+            "published_repo": "unslothai/llama.cpp", "force_cpu": True,
+            "asset": "linux-cpu", "installed_at_utc": "2026-07-20T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b6900-mix (tag b6900)",
+    ),
+    # 7917c7828, 2026-07-27: llama_backend, the pre-#8520 backend field. It is NOT the
+    # key the printer reads, so this marker still prints no suffix.
+    "2026_07_27_7917c7828": (
+        {
+            "tag": "b7100", "release_tag": "b7100-mix",
+            "published_repo": "unslothai/llama.cpp", "llama_backend": "vulkan",
+            "installed_at_utc": "2026-07-27T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b7100-mix (tag b7100)",
+    ),
+    # 9b452cb3b, 2026-08-04: ggml_tree.
+    "2026_08_04_9b452cb3b": (
+        {
+            "tag": "b7400", "release_tag": "b7400-mix",
+            "published_repo": "unslothai/llama.cpp", "ggml_tree": "abc123",
+            "installed_at_utc": "2026-08-04T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b7400-mix (tag b7400)",
+    ),
+    # 738413ab0, 2026-08-08: rocm_gfx, conditional. Last shape before backend existed.
+    "2026_08_08_738413ab0": (
+        {
+            "tag": "b7600", "release_tag": "b7600-mix",
+            "published_repo": "unslothai/llama.cpp", "llama_backend": "auto",
+            "rocm_gfx": "gfx1151", "installed_at_utc": "2026-08-08T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b7600-mix (tag b7600)",
+    ),
+    # 5426a78c3, 2026-08-13 (#8520): backend + backend_request arrive.
+    "2026_08_13_5426a78c3": (
+        {
+            "tag": "b7900", "release_tag": "b7900-mix",
+            "published_repo": "unslothai/llama.cpp", "backend": "vulkan",
+            "backend_request": "auto", "installed_at_utc": "2026-08-13T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b7900-mix (tag b7900) -- vulkan backend",
+    ),
+    # backend_for_install_kind() returns None for an install kind it does not know, and
+    # that lands in the marker as a JSON null.
+    "backend_written_as_null": (
+        {
+            "tag": "b7900", "release_tag": "b7900-mix",
+            "published_repo": "unslothai/llama.cpp", "backend": None,
+            "backend_request": "auto", "installed_at_utc": "2026-08-13T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b7900-mix (tag b7900)",
+    ),
+    # 5a3e9fc7a, 2026-08-13: gfx_target / mapped_targets.
+    "2026_08_13_5a3e9fc7a": (
+        {
+            "tag": "b8000", "release_tag": "b8000-mix",
+            "published_repo": "unslothai/llama.cpp", "backend": "rocm",
+            "gfx_target": "gfx1151", "mapped_targets": ["gfx1151", "gfx1200"],
+            "installed_at_utc": "2026-08-13T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b8000-mix (tag b8000) -- rocm backend",
+    ),
+    # 9d1dcfe58, 2026-08-18: supported_sms.
+    "2026_08_18_9d1dcfe58": (
+        {
+            "tag": "b8300", "release_tag": "b8300-mix",
+            "published_repo": "unslothai/llama.cpp", "backend": "cuda",
+            "supported_sms": ["90", "100"], "installed_at_utc": "2026-08-18T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b8300-mix (tag b8300) -- cuda backend",
+    ),
+    # 1400031e2, 2026-08-31: runtime_asset. The current 34-key shape.
+    "2026_08_31_1400031e2_current": (
+        {
+            "requested_tag": "b10715", "tag": "b10715",
+            "release_tag": "b10715-mix-86bd2d3", "published_repo": "unslothai/llama.cpp",
+            "asset": "windows-vulkan", "force_cpu": False, "llama_backend": "vulkan",
+            "backend": "vulkan", "backend_request": "auto", "asset_sha256": "0" * 64,
+            "runtime_asset": "runtime.zip", "source": "unsloth",
+            "binary_repo": "unslothai/llama.cpp", "binary_release_tag": "b10715-mix",
+            "source_asset": "src.tar.gz", "source_sha256": "1" * 64,
+            "source_commit": "a" * 40, "source_commit_short": "aaaaaaa",
+            "source_repo": "ggml-org/llama.cpp", "source_repo_url": "https://x",
+            "source_ref_kind": "tag", "requested_source_ref": "b10715",
+            "resolved_source_ref": "b10715", "ggml_tree": "abc123",
+            "bundle_profile": "full", "runtime_line": "vulkan",
+            "coverage_class": "broad", "gfx_target": "", "mapped_targets": [],
+            "supported_sms": [], "install_fingerprint": "fp",
+            "prebuilt_fallback_used": False, "installed_at_utc": "2026-08-31T00:00:00Z",
+        },
+        "installed release: unslothai/llama.cpp@b10715-mix-86bd2d3 (tag b10715) -- vulkan backend",
+    ),
+}
+
+
+@requires_pwsh
+@pytest.mark.parametrize("strict_mode", STRICT_MODES)
+@pytest.mark.parametrize("shape_id", sorted(_HISTORICAL_MARKERS))
+def test_every_historical_marker_shape_on_ps1(marker_dir, strict_mode, shape_id):
+    payload, expected = _HISTORICAL_MARKERS[shape_id]
+    expected = _HISTORICAL_PS1_OVERRIDES.get(shape_id, expected)
+    install_dir = marker_dir(json.dumps(payload, indent = 2) + "\n")
+    proc = _run_ps1_printer(install_dir, strict_mode)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stderr == "", f"{shape_id} under {strict_mode}: {proc.stderr!r}"
+    assert proc.stdout == expected, f"{shape_id} under {strict_mode}"
+
+
+@requires_bash
+@pytest.mark.parametrize("shape_id", sorted(_HISTORICAL_MARKERS))
+def test_every_historical_marker_shape_on_sh(marker_dir, tmp_path, shape_id):
+    payload, expected = _HISTORICAL_MARKERS[shape_id]
+    install_dir = marker_dir(json.dumps(payload, indent = 2) + "\n")
+    proc = _run_sh_printer(install_dir, tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.rstrip("\n") == expected, shape_id
+
+
+@requires_pwsh
+@requires_bash
+@pytest.mark.parametrize("shape_id", sorted(_HISTORICAL_MARKERS))
+def test_every_historical_marker_shape_agrees(marker_dir, tmp_path, shape_id):
+    if shape_id in _KNOWN_TWIN_DIVERGENCES:
+        pytest.skip("documented pre-existing divergence; see the dedicated test")
+    payload, _expected = _HISTORICAL_MARKERS[shape_id]
+    install_dir = marker_dir(json.dumps(payload, indent = 2) + "\n")
+    ps1 = _run_ps1_printer(install_dir, "Latest")
+    sh = _run_sh_printer(install_dir, tmp_path)
+    assert ps1.stdout == sh.stdout.rstrip("\n"), shape_id
+
+
+# ==== the source text, so a future edit cannot quietly unguard it ====================
+
+
+def test_the_ps1_guard_checks_property_existence():
+    text = SETUP_PS1.read_text(encoding = "utf-8")
+    start = text.index("function Get-InstalledLlamaPrebuiltRelease")
+    body = text[start : text.index("\nfunction ", start + 1)]
+    assert "PSObject.Properties.Name -ccontains 'backend'" in body, (
+        "the backend read must stay guarded: a bare $payload.backend is a terminating "
+        "error under a caller's Set-StrictMode for every marker written before #8520"
+    )
+
+
+def test_both_printers_share_one_backend_shape_rule():
+    """The one rule that keeps the twins in lockstep, asserted in both sources."""
+    shape = "[A-Za-z0-9._+-]{1,32}"
+    assert shape in SETUP_PS1.read_text(encoding = "utf-8")
+    assert shape in SETUP_SH.read_text(encoding = "utf-8")
+
+
+def test_the_sh_printer_only_accepts_a_string():
+    text = SETUP_SH.read_text(encoding = "utf-8")
+    assert "isinstance(_backend_raw, str)" in text, (
+        "str() on a non-string diverges from the PowerShell twin"
+    )
+
+
+@requires_pwsh
+@requires_bash
+def test_the_upstream_source_branch_is_a_known_pre_existing_divergence(marker_dir, tmp_path):
+    """setup.sh names a non-fork binary source; setup.ps1 never has.
+
+    Recorded rather than fixed: teaching setup.ps1 the branch changes what Windows
+    installs print for upstream ggml-org bundles, which is a separate change from
+    naming the backend. Asserted here so it stays a known quantity instead of turning
+    up as a surprise the next time somebody compares the two logs.
+    """
+    raw = json.dumps(
+        {
+            "published_repo": "unslothai/unsloth",
+            "release_tag": "b10715-mix",
+            "tag": "b10715",
+            "source": "ggml-org",
+            "binary_repo": "ggml-org/llama.cpp",
+            "binary_release_tag": "b10715",
+            "backend": "cpu",
+        }
+    )
+    install_dir = marker_dir(raw)
+    ps1 = _run_ps1_printer(install_dir, "Latest")
+    sh = _run_sh_printer(install_dir, tmp_path)
+    assert ps1.stdout == (
+        "installed release: unslothai/unsloth@b10715-mix (tag b10715) -- cpu backend"
+    )
+    assert sh.stdout.rstrip("\n") == (
+        "installed release: unslothai/unsloth@b10715-mix + ggml-org@b10715 -- cpu backend"
+    )
+    # The part this change owns -- the backend suffix -- is identical on both sides.
+    assert ps1.stdout.endswith(" -- cpu backend")
+    assert sh.stdout.rstrip("\n").endswith(" -- cpu backend")

--- a/tests/studio/install/test_installed_release_backend_line.py
+++ b/tests/studio/install/test_installed_release_backend_line.py
@@ -15,6 +15,7 @@ steps at load (as tests/studio_setup_ps1/Get-FunctionSource.ps1 and tests/sh/ do
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -30,8 +31,37 @@ GET_FUNCTION_SOURCE = PACKAGE_ROOT / "tests" / "studio_setup_ps1" / "Get-Functio
 requires_pwsh = pytest.mark.skipif(
     shutil.which("pwsh") is None, reason = "pwsh is required to run the setup.ps1 printer"
 )
+
+
+def _usable_bash():
+    """A bash that actually runs a command, or None.
+
+    shutil.which("bash") alone is wrong on Windows: C:\\Windows\\System32\\bash.exe is the
+    WSL launcher, so it is the first PATH hit even with no distro installed, and running it
+    writes "Windows Subsystem for Linux has no installed distributions." to stdout as UTF-16
+    -- which this file then compared against a printer line. setup.sh is never executed on
+    Windows anyway (_find_setup_script picks setup.ps1 there), so probe before trusting.
+    """
+    exe = shutil.which("bash")
+    if exe is None:
+        return None
+    try:
+        probe = subprocess.run(
+            [exe, "-c", "printf ok"],
+            stdout = subprocess.PIPE,
+            stderr = subprocess.DEVNULL,
+            text = True,
+            errors = "replace",
+            timeout = 60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return exe if probe.stdout.strip() == "ok" else None
+
+
+BASH = _usable_bash()
 requires_bash = pytest.mark.skipif(
-    shutil.which("bash") is None, reason = "bash is required to run the setup.sh printer"
+    BASH is None, reason = "a working bash is required to run the setup.sh printer"
 )
 
 # 2.0 is where missing-property reads turn fatal; 3.0 and Latest keep that rule.
@@ -263,12 +293,10 @@ def _run_sh_printer(install_dir, tmp_path):
     shim = shim_dir / "python"
     shim.write_text(f'#!/bin/sh\nexec "{sys.executable}" "$@"\n', encoding = "utf-8")
     shim.chmod(0o755)
-    import os
-
     env = dict(os.environ)
     env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', '')}"
     proc = subprocess.run(
-        ["bash", str(script), str(func_file), str(install_dir)],
+        [BASH, str(script), str(func_file), str(install_dir)],
         stdout = subprocess.PIPE,
         stderr = subprocess.PIPE,
         text = True,


### PR DESCRIPTION
## What this fixes

A Strix Halo report arrived with four Unsloth Studio install and update logs spanning nine days. The machine was running the Vulkan llama.cpp bundle throughout, deliberately and correctly, and none of the four logs can say so, because the installer never names the backend:

```
installed release: unslothai/llama.cpp@b10715-mix-86bd2d3 (tag b10715)
```

That line is identical whether the installed bundle is ROCm, Vulkan, CUDA or CPU. Establishing which one was in use needed the server logs, which record `"backend": "vulkan"` on each update.

On this hardware the answer matters: AMD put the ROCm/Vulkan gap on Strix Halo at about 20%, so which bundle you are on is a first-order performance fact, not a detail. The prebuilt marker already carries the resolved backend (`backend_for_install_kind`), so both setup scripts now print it:

```
installed release: unslothai/llama.cpp@b10715-mix-86bd2d3 (tag b10715) -- vulkan backend
```

A marker without the field prints exactly what it prints today, so older installs are unaffected.

## And a second misleading line in the same logs

Every update run printed:

```
 3/13  torch check (cpu)
...
 6/13  dependency overrides (skipped, Windows ROCm)
```

Two detectors disagreeing three lines apart, on a host that really is Windows ROCm. `_torch_step_label` falls back to GPU detection when `UNSLOTH_TORCH_BACKEND` is unset, which is every standalone `unsloth studio update`, and on Windows that detection probes `rocminfo` and `amd-smi`. Those ship with the HIP SDK, not with AMD's bundled-runtime wheels, so a working ROCm host reads as CPU. `_installed_torch_is_windows_rocm()` reads `torch.version.hip` and is already consulted a few steps later for the torchao override, so the label now uses it too.

This is a label only. `_ensure_cpu_torch()` returns immediately unless an explicit CPU index URL is set, so no CPU torch was ever pushed over the ROCm build. It is the single most misleading string in these logs for anyone asking "is my GPU being used".

## Verification

- `studio/backend/tests/test_torch_step_label.py`, five cases. The regression case fails on the pre-change code with the other four passing, so the test discriminates rather than ritually passing.
- Both setup twins exercised on real markers rather than eyeballed. The PowerShell function dot-sourced against three markers (vulkan, rocm, no backend field) and the `setup.sh` Python snippet run against the same three, producing the same three lines.
- `setup.ps1` parses clean through the PowerShell AST parser; `setup.sh` through `bash -n`.
- `test_torchao_select.py` and `test_pytorch_mirror.py` still pass, 39 tests with the new file.

## Not changed here

While reading this path I found that `setup.ps1`'s mismatched-install guard reads `$existingMeta.install_kind`, and `write_prebuilt_metadata` never writes that key, so the guard can never fire. The marker does carry the equivalent `backend`. Making it live changes deletion behaviour and there is no PowerShell test coverage to hold it, so it is left alone and reported rather than patched.