### PR TITLE
Studio: retry as one sequence when llama.cpp refuses a unified KV cache

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17556,8 +17556,10 @@ class LlamaCppBackend:
                 saw_kv_unified = True
                 # llama.cpp's own form is bare, but an inline "=1" and a separate
                 # "1" both reach us through user extras.
-                if "=" not in tok and cmd[i + 1 : i + 2] and cmd[i + 1] in (
-                    _LLAMA_ARG_TRUE_FALSE_AUTO_VALUES
+                if (
+                    "=" not in tok
+                    and cmd[i + 1 : i + 2]
+                    and cmd[i + 1] in (_LLAMA_ARG_TRUE_FALSE_AUTO_VALUES)
                 ):
                     skip_value = True
                 continue

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17513,6 +17513,87 @@ class LlamaCppBackend:
         """
         return env.pop("LLAMA_ARG_FLASH_ATTN", None) is not None
 
+    # llama.cpp refusing a unified KV cache because this architecture needs one
+    # sequence per stream. Matched on llama.cpp's own wording rather than on an
+    # architecture name, so a second model with the same constraint is covered
+    # without a list to keep current.
+    _KV_UNIFIED_REFUSED_MARKERS = (
+        "a unified kv cache is only supported with a single sequence",
+        "needs one sequence per stream",
+    )
+
+    @staticmethod
+    def _is_kv_unified_refused(output: str) -> bool:
+        """Did the child refuse to build a context because of --kv-unified?"""
+        low = (output or "").lower()
+        return any(marker in low for marker in LlamaCppBackend._KV_UNIFIED_REFUSED_MARKERS)
+
+    @staticmethod
+    def _with_single_sequence(cmd: list[str]) -> Optional[list[str]]:
+        """Return cmd re-run as one sequence, or None when it already is one.
+
+        Studio appends --kv-unified whenever it asks for more than one slot, to
+        stop llama.cpp splitting -c into per-slot windows. Some architectures
+        reject that pairing outright and the model then cannot load at all, so
+        the retry reverses Studio's own choice rather than the user's context:
+        drop --kv-unified and pin --parallel to 1, which is the configuration
+        that would never have added the flag in the first place.
+
+        Every occurrence is rewritten, not just the emitted one. Extras are
+        appended after Unsloth's flags and llama.cpp is last-wins, so a --parallel
+        surviving in the tail would put the rejected geometry straight back.
+        """
+        out: list[str] = []
+        saw_kv_unified = False
+        multi_slot = False
+        skip_value = False
+        for i, tok in enumerate(cmd):
+            if skip_value:
+                skip_value = False
+                continue
+            name = _flag_name(tok)
+            if name in ("--kv-unified", "-kvu"):
+                saw_kv_unified = True
+                # llama.cpp's own form is bare, but an inline "=1" and a separate
+                # "1" both reach us through user extras.
+                if "=" not in tok and cmd[i + 1 : i + 2] and cmd[i + 1] in (
+                    _LLAMA_ARG_TRUE_FALSE_AUTO_VALUES
+                ):
+                    skip_value = True
+                continue
+            if name in ("--parallel", "-np"):
+                if "=" in tok:
+                    value = tok.partition("=")[2]
+                elif tok != name:
+                    # The attached short, -np8, which _flag_name peels to -np.
+                    value = tok[len(name) :]
+                else:
+                    value = cmd[i + 1] if i + 1 < len(cmd) else ""
+                    skip_value = True
+                try:
+                    multi_slot = multi_slot or int(value.strip()) > 1
+                except (AttributeError, TypeError, ValueError):
+                    pass
+                out.extend([name, "1"])
+                continue
+            out.append(tok)
+        if not saw_kv_unified and not multi_slot:
+            return None
+        if not any(_flag_name(tok) in ("--parallel", "-np") for tok in out):
+            out.extend(["--parallel", "1"])
+        return out
+
+    @staticmethod
+    def _drop_env_single_sequence(env: MutableMapping[str, str]) -> bool:
+        """Drop inherited unified-cache and slot-count env before that retry.
+
+        llama.cpp applies the environment before parsing argv, so the argv wins
+        on --parallel. LLAMA_ARG_KV_UNIFIED has no negated twin to emit, so
+        dropping it is the only way the retry can be sure the flag is off.
+        """
+        dropped = env.pop("LLAMA_ARG_KV_UNIFIED", None) is not None
+        return env.pop("LLAMA_ARG_N_PARALLEL", None) is not None or dropped
+
     @staticmethod
     def _strip_mmproj_args(cmd: list[str]) -> list[str]:
         """Return cmd without the '--mmproj <path>' pair (text-only retry).
@@ -24243,6 +24324,36 @@ class LlamaCppBackend:
                             # the respawn runs, and the record has to match it.
                             self._memory_state = resolve_effective_memory_state(cmd, env)
                         healthy = _spawn_and_wait(cmd, label = "-archfallback")
+
+                # Some architectures need one sequence per stream and refuse to
+                # build a context under --kv-unified, which Studio appends on its
+                # own whenever it asks for more than one slot. The model is then
+                # unloadable no matter what the user changes, so reverse Studio's
+                # choice rather than theirs: one slot, no unified cache, the
+                # requested context intact. A clean refusal, not a crash, so this
+                # sits ahead of the flash-attn rung, which only fires on a signal.
+                if not healthy and not _load_cancelled():
+                    _kvu_cmd = (
+                        self._with_single_sequence(_last_spawn_cmd)
+                        if self._is_kv_unified_refused("\n".join(self._stdout_lines))
+                        else None
+                    )
+                    if _kvu_cmd is not None:
+                        logger.warning(
+                            "llama-server refused a unified KV cache with more than "
+                            "one sequence; retrying with one slot and --kv-unified "
+                            "dropped. Concurrent requests will queue."
+                        )
+                        self._kill_process()
+                        # llama.cpp reads the environment before argv, and
+                        # LLAMA_ARG_KV_UNIFIED has no negated flag to emit against it.
+                        if self._drop_env_single_sequence(env):
+                            logger.info(
+                                "Dropped inherited LLAMA_ARG_KV_UNIFIED / "
+                                "LLAMA_ARG_N_PARALLEL for the single-sequence retry."
+                            )
+                        cmd = _kvu_cmd
+                        healthy = _spawn_and_wait(_kvu_cmd, label = "-single-seq")
 
                 # Flash-attention kernels hard-crash at startup on some ROCm/GPU
                 # builds (frequently inside the vision tower). Disabling FA keeps

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -24355,6 +24355,13 @@ class LlamaCppBackend:
                                 "LLAMA_ARG_N_PARALLEL for the single-sequence retry."
                             )
                         cmd = _kvu_cmd
+                        # The geometry that launches is what gets committed below
+                        # (_commit_effective_parallel_slots, _kv_cache_unified), and
+                        # the admission controller and the slot save read it from
+                        # there. Left at the rejected values, Studio would admit
+                        # several requests at once against a server with one slot.
+                        n_parallel = 1
+                        kv_cache_unified = False
                         healthy = _spawn_and_wait(_kvu_cmd, label = "-single-seq")
 
                 # Flash-attention kernels hard-crash at startup on some ROCm/GPU

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -24355,12 +24355,10 @@ class LlamaCppBackend:
                                 "LLAMA_ARG_N_PARALLEL for the single-sequence retry."
                             )
                         cmd = _kvu_cmd
-                        # The geometry that launches is what gets committed below
-                        # (_commit_effective_parallel_slots, _kv_cache_unified), and
-                        # the admission controller and the slot save read it from
-                        # there. Left at the rejected values, Studio would admit
-                        # several requests at once against a server with one slot.
-                        n_parallel = 1
+                        # Committed below (_commit_effective_parallel_slots,
+                        # _kv_cache_unified) and read by admission control; left at the
+                        # rejected values Studio would admit several requests at once.
+                        n_parallel = 1  # allow-slot-clamp: llama-server refused more
                         kv_cache_unified = False
                         healthy = _spawn_and_wait(_kvu_cmd, label = "-single-seq")
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -75,6 +75,7 @@ from core.inference.llama_server_args import (
     _GPU_LAYER_FLAGS,
     _LAYER_OFFLOAD_FLAGS,
     _MOE_OFFLOAD_FLAGS,
+    _PARALLEL_FLAGS,
     _SPLIT_MODE_FLAGS,
     _TENSOR_SPLIT_FLAGS,
     _effective_tensor_parallel,
@@ -17516,7 +17517,10 @@ class LlamaCppBackend:
     # llama.cpp refusing a unified KV cache because this architecture needs one
     # sequence per stream. Matched on llama.cpp's own wording rather than on an
     # architecture name, so a second model with the same constraint is covered
-    # without a list to keep current.
+    # without a list to keep current. What glm5next actually emits is the
+    # GGML_ASSERT in ggml-org/llama.cpp#27754, whose stringified expression
+    # carries the second marker; the first is the same refusal worded as a
+    # context-init error, which is how the field report quoted it.
     _KV_UNIFIED_REFUSED_MARKERS = (
         "a unified kv cache is only supported with a single sequence",
         "needs one sequence per stream",
@@ -17539,9 +17543,11 @@ class LlamaCppBackend:
         drop --kv-unified and pin --parallel to 1, which is the configuration
         that would never have added the flag in the first place.
 
-        Every occurrence is rewritten, not just the emitted one. Extras are
-        appended after Unsloth's flags and llama.cpp is last-wins, so a --parallel
-        surviving in the tail would put the rejected geometry straight back.
+        Every occurrence and every alias is rewritten, not just the emitted one.
+        Extras are appended after Unsloth's flags and llama.cpp is last-wins, so
+        one slot count surviving in the tail would put the rejected geometry
+        straight back. _PARALLEL_FLAGS is the set the denylist uses, so the two
+        cannot drift apart.
         """
         out: list[str] = []
         saw_kv_unified = False
@@ -17559,19 +17565,23 @@ class LlamaCppBackend:
                 if (
                     "=" not in tok
                     and cmd[i + 1 : i + 2]
-                    and cmd[i + 1] in (_LLAMA_ARG_TRUE_FALSE_AUTO_VALUES)
+                    # Case-sensitive, like llama.cpp's own bool parse and the
+                    # flash-attn helpers: "ON" is not a value it would accept.
+                    and cmd[i + 1] in _LLAMA_ARG_TRUE_FALSE_AUTO_VALUES
                 ):
                     skip_value = True
                 continue
-            if name in ("--parallel", "-np"):
+            if name in _PARALLEL_FLAGS:
                 if "=" in tok:
                     value = tok.partition("=")[2]
                 elif tok != name:
                     # The attached short, -np8, which _flag_name peels to -np.
                     value = tok[len(name) :]
                 else:
+                    # Only a real value is consumed: a valueless --parallel is
+                    # malformed, and swallowing the next token would delete a flag.
                     value = cmd[i + 1] if i + 1 < len(cmd) else ""
-                    skip_value = True
+                    skip_value = _flag_name(value) is None
                 try:
                     multi_slot = multi_slot or int(value.strip()) > 1
                 except (AttributeError, TypeError, ValueError):
@@ -17581,7 +17591,7 @@ class LlamaCppBackend:
             out.append(tok)
         if not saw_kv_unified and not multi_slot:
             return None
-        if not any(_flag_name(tok) in ("--parallel", "-np") for tok in out):
+        if not any(_flag_name(tok) in _PARALLEL_FLAGS for tok in out):
             out.extend(["--parallel", "1"])
         return out
 
@@ -17590,8 +17600,9 @@ class LlamaCppBackend:
         """Drop inherited unified-cache and slot-count env before that retry.
 
         llama.cpp applies the environment before parsing argv, so the argv wins
-        on --parallel. LLAMA_ARG_KV_UNIFIED has no negated twin to emit, so
-        dropping it is the only way the retry can be sure the flag is off.
+        on --parallel. Dropped rather than negated with --no-kv-unified: the drop
+        needs nothing of the binary, while emitting a flag needs every build that
+        reaches here to know it, and one that does not never starts at all.
         """
         dropped = env.pop("LLAMA_ARG_KV_UNIFIED", None) is not None
         return env.pop("LLAMA_ARG_N_PARALLEL", None) is not None or dropped
@@ -23539,6 +23550,14 @@ class LlamaCppBackend:
                             _startup_output
                         ) or self._is_tensor_quant_kv_unsupported(_startup_output)
                         _hip_rocr_mismatch = self._is_bundled_hip_rocr_mismatch(_startup_output)
+                        # The unified-cache refusal is the same shape: an architecture
+                        # constraint no fit retry can reach, and the caller's
+                        # single-sequence rung reads the argv and the output of the
+                        # launch that refused, which a fit retry would have replaced.
+                        # Whole buffer, not the tail: this one arrives with a backtrace.
+                        _capability_crash = _tensor_capability_crash or self._is_kv_unified_refused(
+                            "\n".join(self._stdout_lines)
+                        )
                         if (
                             not _did_rocm_retry
                             and _startup_crashed
@@ -23569,7 +23588,7 @@ class LlamaCppBackend:
                         if (
                             not _did_fit_retry
                             and _startup_crashed
-                            and not _tensor_capability_crash
+                            and not _capability_crash
                             and not _hip_rocr_mismatch
                         ):
                             # A spill-planned launch that crashed on startup. The
@@ -23601,7 +23620,7 @@ class LlamaCppBackend:
                             not _did_fit_retry
                             and fully_gpu_offloaded
                             and _startup_crashed
-                            and not _tensor_capability_crash
+                            and not _capability_crash
                             and not _hip_rocr_mismatch
                         ):
                             # We forced --fit off because Unsloth's (conservative) VRAM
@@ -23669,7 +23688,7 @@ class LlamaCppBackend:
                             not _did_fit_retry
                             and _fit_retry_allowed
                             and _startup_crashed
-                            and not _tensor_capability_crash
+                            and not _capability_crash
                             and not _hip_rocr_mismatch
                         ):
                             logger.warning(
@@ -24332,8 +24351,11 @@ class LlamaCppBackend:
                 # own whenever it asks for more than one slot. The model is then
                 # unloadable no matter what the user changes, so reverse Studio's
                 # choice rather than theirs: one slot, no unified cache, the
-                # requested context intact. A clean refusal, not a crash, so this
-                # sits ahead of the flash-attn rung, which only fires on a signal.
+                # requested context intact. glm5next spells the refusal as a
+                # GGML_ASSERT, so the child aborts: this MUST stay ahead of the
+                # flash-attn rung, which takes any signal crash and would spend
+                # the retry disabling a flag that was never the cause. Matched on
+                # the message, not the exit, so the Windows abort lands here too.
                 if not healthy and not _load_cancelled():
                     _kvu_cmd = (
                         self._with_single_sequence(_last_spawn_cmd)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17514,13 +17514,8 @@ class LlamaCppBackend:
         """
         return env.pop("LLAMA_ARG_FLASH_ATTN", None) is not None
 
-    # llama.cpp refusing a unified KV cache because this architecture needs one
-    # sequence per stream. Matched on llama.cpp's own wording rather than on an
-    # architecture name, so a second model with the same constraint is covered
-    # without a list to keep current. What glm5next actually emits is the
-    # GGML_ASSERT in ggml-org/llama.cpp#27754, whose stringified expression
-    # carries the second marker; the first is the same refusal worded as a
-    # context-init error, which is how the field report quoted it.
+    # On the wording, not an architecture name, so the next model needs no list.
+    # glm5next spells it as the GGML_ASSERT of ggml-org/llama.cpp#27754.
     _KV_UNIFIED_REFUSED_MARKERS = (
         "a unified kv cache is only supported with a single sequence",
         "needs one sequence per stream",
@@ -17528,7 +17523,6 @@ class LlamaCppBackend:
 
     @staticmethod
     def _is_kv_unified_refused(output: str) -> bool:
-        """Did the child refuse to build a context because of --kv-unified?"""
         low = (output or "").lower()
         return any(marker in low for marker in LlamaCppBackend._KV_UNIFIED_REFUSED_MARKERS)
 
@@ -17536,18 +17530,9 @@ class LlamaCppBackend:
     def _with_single_sequence(cmd: list[str]) -> Optional[list[str]]:
         """Return cmd re-run as one sequence, or None when it already is one.
 
-        Studio appends --kv-unified whenever it asks for more than one slot, to
-        stop llama.cpp splitting -c into per-slot windows. Some architectures
-        reject that pairing outright and the model then cannot load at all, so
-        the retry reverses Studio's own choice rather than the user's context:
-        drop --kv-unified and pin --parallel to 1, which is the configuration
-        that would never have added the flag in the first place.
-
-        Every occurrence and every alias is rewritten, not just the emitted one.
-        Extras are appended after Unsloth's flags and llama.cpp is last-wins, so
-        one slot count surviving in the tail would put the rejected geometry
-        straight back. _PARALLEL_FLAGS is the set the denylist uses, so the two
-        cannot drift apart.
+        Studio adds --kv-unified itself above one slot, so this reverses Studio's
+        choice, not the user's. Every alias goes, from _PARALLEL_FLAGS so it cannot
+        drift from the denylist; llama.cpp is last-wins.
         """
         out: list[str] = []
         saw_kv_unified = False
@@ -17560,13 +17545,11 @@ class LlamaCppBackend:
             name = _flag_name(tok)
             if name in ("--kv-unified", "-kvu"):
                 saw_kv_unified = True
-                # llama.cpp's own form is bare, but an inline "=1" and a separate
-                # "1" both reach us through user extras.
+                # The flag is bare, but an inline "=1" or a separate "1" reach us.
                 if (
                     "=" not in tok
                     and cmd[i + 1 : i + 2]
-                    # Case-sensitive, like llama.cpp's own bool parse and the
-                    # flash-attn helpers: "ON" is not a value it would accept.
+                    # Case-sensitive, like llama.cpp's own bool parse.
                     and cmd[i + 1] in _LLAMA_ARG_TRUE_FALSE_AUTO_VALUES
                 ):
                     skip_value = True
@@ -17578,8 +17561,7 @@ class LlamaCppBackend:
                     # The attached short, -np8, which _flag_name peels to -np.
                     value = tok[len(name) :]
                 else:
-                    # Only a real value is consumed: a valueless --parallel is
-                    # malformed, and swallowing the next token would delete a flag.
+                    # Valueless --parallel: eating the next token would delete a flag.
                     value = cmd[i + 1] if i + 1 < len(cmd) else ""
                     skip_value = _flag_name(value) is None
                 try:
@@ -17599,10 +17581,8 @@ class LlamaCppBackend:
     def _drop_env_single_sequence(env: MutableMapping[str, str]) -> bool:
         """Drop inherited unified-cache and slot-count env before that retry.
 
-        llama.cpp applies the environment before parsing argv, so the argv wins
-        on --parallel. Dropped rather than negated with --no-kv-unified: the drop
-        needs nothing of the binary, while emitting a flag needs every build that
-        reaches here to know it, and one that does not never starts at all.
+        llama.cpp reads its environment before argv. Dropped, not negated with
+        --no-kv-unified, which needs every build reaching here to know it.
         """
         dropped = env.pop("LLAMA_ARG_KV_UNIFIED", None) is not None
         return env.pop("LLAMA_ARG_N_PARALLEL", None) is not None or dropped
@@ -23550,11 +23530,8 @@ class LlamaCppBackend:
                             _startup_output
                         ) or self._is_tensor_quant_kv_unsupported(_startup_output)
                         _hip_rocr_mismatch = self._is_bundled_hip_rocr_mismatch(_startup_output)
-                        # The unified-cache refusal is the same shape: an architecture
-                        # constraint no fit retry can reach, and the caller's
-                        # single-sequence rung reads the argv and the output of the
-                        # launch that refused, which a fit retry would have replaced.
-                        # Whole buffer, not the tail: this one arrives with a backtrace.
+                        # No fit retry reaches it, and the rung below needs this
+                        # launch's argv. Whole buffer: it arrives with a backtrace.
                         _capability_crash = _tensor_capability_crash or self._is_kv_unified_refused(
                             "\n".join(self._stdout_lines)
                         )
@@ -24346,16 +24323,10 @@ class LlamaCppBackend:
                             self._memory_state = resolve_effective_memory_state(cmd, env)
                         healthy = _spawn_and_wait(cmd, label = "-archfallback")
 
-                # Some architectures need one sequence per stream and refuse to
-                # build a context under --kv-unified, which Studio appends on its
-                # own whenever it asks for more than one slot. The model is then
-                # unloadable no matter what the user changes, so reverse Studio's
-                # choice rather than theirs: one slot, no unified cache, the
-                # requested context intact. glm5next spells the refusal as a
-                # GGML_ASSERT, so the child aborts: this MUST stay ahead of the
-                # flash-attn rung, which takes any signal crash and would spend
-                # the retry disabling a flag that was never the cause. Matched on
-                # the message, not the exit, so the Windows abort lands here too.
+                # Studio adds --kv-unified itself above one slot, so nothing the user
+                # changes reaches it: retry at one slot, context intact. It aborts, so
+                # this MUST stay ahead of the flash-attn rung, which takes any signal
+                # crash; on the message, not the exit, so Windows lands here too.
                 if not healthy and not _load_cancelled():
                     _kvu_cmd = (
                         self._with_single_sequence(_last_spawn_cmd)
@@ -24369,17 +24340,13 @@ class LlamaCppBackend:
                             "dropped. Concurrent requests will queue."
                         )
                         self._kill_process()
-                        # llama.cpp reads the environment before argv, and
-                        # LLAMA_ARG_KV_UNIFIED has no negated flag to emit against it.
                         if self._drop_env_single_sequence(env):
                             logger.info(
                                 "Dropped inherited LLAMA_ARG_KV_UNIFIED / "
                                 "LLAMA_ARG_N_PARALLEL for the single-sequence retry."
                             )
                         cmd = _kvu_cmd
-                        # Committed below (_commit_effective_parallel_slots,
-                        # _kv_cache_unified) and read by admission control; left at the
-                        # rejected values Studio would admit several requests at once.
+                        # Read by admission control; left as-is Studio over-admits.
                         n_parallel = 1  # allow-slot-clamp: llama-server refused more
                         kv_cache_unified = False
                         healthy = _spawn_and_wait(_kvu_cmd, label = "-single-seq")

--- a/studio/backend/core/inference/llama_server_args.py
+++ b/studio/backend/core/inference/llama_server_args.py
@@ -35,8 +35,8 @@ BATCH_MAX = 65536
 CTX_CHECKPOINTS_MAX = 256
 CACHE_RAM_MAX_MIB = 1024 * 1024
 
-# Slot-count aliases, in one place: the denial below, its #9510 hint, and the single-sequence retry in llama_cpp.py all
-# have to cover the same set, or a spelling one of them misses reaches llama-server unnoticed.
+# Slot-count aliases in one place: the denial below, its #9510 hint and the single-sequence retry must cover the same
+# set, or a spelling one of them misses reaches llama-server unnoticed.
 _PARALLEL_FLAGS: frozenset[str] = frozenset({"-np", "--parallel", "--n-parallel"})
 
 # Each group = every alias (short + long) of one hard-denied flag. Extend the matching group when llama.cpp adds a new

--- a/studio/backend/core/inference/llama_server_args.py
+++ b/studio/backend/core/inference/llama_server_args.py
@@ -35,12 +35,16 @@ BATCH_MAX = 65536
 CTX_CHECKPOINTS_MAX = 256
 CACHE_RAM_MAX_MIB = 1024 * 1024
 
+# Slot-count aliases, in one place: the denial below, its #9510 hint, and the single-sequence retry in llama_cpp.py all
+# have to cover the same set, or a spelling one of them misses reaches llama-server unnoticed.
+_PARALLEL_FLAGS: frozenset[str] = frozenset({"-np", "--parallel", "--n-parallel"})
+
 # Each group = every alias (short + long) of one hard-denied flag. Extend the matching group when llama.cpp adds a new
 # alias.
 _DENYLIST_GROUPS: tuple[frozenset[str], ...] = (
     # Parallel slots: owned by typer --parallel and LoadRequest.n_parallel; a pass-through would desync the slot
     # bookkeeping from llama-server.
-    frozenset({"-np", "--parallel", "--n-parallel"}),
+    _PARALLEL_FLAGS,
     # Model identity: a second -m would load a different model than Unsloth thinks it loaded
     # Model identity: Unsloth resolves it from LoadRequest; a second -m would load a different model than Unsloth thinks
     # it loaded.
@@ -275,7 +279,7 @@ def validate_extra_args(args: Optional[Iterable[str]]) -> list[str]:
             # #9510: users reaching for `--parallel 1` hit this refusal with no pointer to the supported knob
             # Why (#9510): users reaching for `--parallel 1` to cap concurrent predictions on a local model hit this
             # refusal with no pointer to the supported knob; name it.
-            if flag in {"-np", "--parallel", "--n-parallel"}:
+            if flag in _PARALLEL_FLAGS:
                 message += "; set n_parallel on the load request (parallel decode slots) instead"
             raise ValueError(message)
         if flag is None:

--- a/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
+++ b/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
@@ -121,3 +121,16 @@ def test_a_clean_environment_reports_nothing_dropped():
 
     assert LlamaCppBackend._drop_env_single_sequence(env) is False
     assert env == {"PATH": "/usr/bin"}
+
+
+def test_the_retry_commits_the_one_slot_geometry_it_launched():
+    # The launch commits n_parallel and kv_cache_unified after the ladder, so the
+    # retry has to overwrite the locals it reverses, or Studio would advertise and
+    # admit the multi-slot geometry that llama-server just refused.
+    import inspect
+
+    src = inspect.getsource(LlamaCppBackend.load_model)
+    start = src.index('label = "-single-seq"')
+    block = src[src.rindex("cmd = _kvu_cmd", 0, start):start]
+    assert "n_parallel = 1" in block
+    assert "kv_cache_unified = False" in block

--- a/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
+++ b/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
@@ -131,6 +131,6 @@ def test_the_retry_commits_the_one_slot_geometry_it_launched():
 
     src = inspect.getsource(LlamaCppBackend.load_model)
     start = src.index('label = "-single-seq"')
-    block = src[src.rindex("cmd = _kvu_cmd", 0, start):start]
+    block = src[src.rindex("cmd = _kvu_cmd", 0, start) : start]
     assert "n_parallel = 1" in block
     assert "kv_cache_unified = False" in block

--- a/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
+++ b/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
@@ -42,10 +42,22 @@ def test_an_unrelated_failure_is_not():
 def test_the_reported_launch_becomes_one_slot_with_no_unified_cache():
     """The argv is the one in the report, trimmed to the flags that matter."""
     cmd = [
-        "llama-server", "-m", "GLM-5.3-Flash-UD-IQ4_XS-00001-of-00004.gguf",
-        "--parallel", "4", "--flash-attn", "on", "--no-context-shift",
-        "-c", "128000", "--gpu-layers", "47", "--fit", "off",
-        "--kv-unified", "--jinja",
+        "llama-server",
+        "-m",
+        "GLM-5.3-Flash-UD-IQ4_XS-00001-of-00004.gguf",
+        "--parallel",
+        "4",
+        "--flash-attn",
+        "on",
+        "--no-context-shift",
+        "-c",
+        "128000",
+        "--gpu-layers",
+        "47",
+        "--fit",
+        "off",
+        "--kv-unified",
+        "--jinja",
     ]
 
     out = LlamaCppBackend._with_single_sequence(cmd)
@@ -71,7 +83,11 @@ def test_a_parallel_surviving_in_the_extras_tail_is_rewritten_too():
 def test_every_spelling_of_the_two_flags_is_handled():
     cmd = ["llama-server", "--parallel=4", "-kvu", "--alias", "m"]
     assert LlamaCppBackend._with_single_sequence(cmd) == [
-        "llama-server", "--parallel", "1", "--alias", "m",
+        "llama-server",
+        "--parallel",
+        "1",
+        "--alias",
+        "m",
     ]
 
     # -np8 is llama.cpp's attached short form, which _flag_name peels to -np.
@@ -81,9 +97,7 @@ def test_every_spelling_of_the_two_flags_is_handled():
 
 def test_a_command_already_running_one_sequence_has_nothing_to_retry():
     assert LlamaCppBackend._with_single_sequence(["llama-server", "-c", "8192"]) is None
-    assert (
-        LlamaCppBackend._with_single_sequence(["llama-server", "--parallel", "1"]) is None
-    )
+    assert LlamaCppBackend._with_single_sequence(["llama-server", "--parallel", "1"]) is None
 
 
 def test_a_slot_count_is_added_when_the_command_carried_none():

--- a/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
+++ b/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The single-sequence retry for architectures that refuse a unified KV cache.
+
+Studio appends ``--kv-unified`` on its own whenever it asks for more than one
+slot, to stop llama.cpp splitting ``-c`` into per-slot windows. Some
+architectures need one sequence per stream and refuse to build a context that
+way, so the model cannot load at all and nothing the user changes in the UI
+reaches the flag that caused it. The retry reverses Studio's choice, not the
+user's context.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.inference.llama_cpp import LlamaCppBackend
+
+# Verbatim from a Strix Halo report: llama-server refusing GLM-5.3-Flash.
+_REFUSAL = (
+    "0.56.012.623 E llama_init_from_model: failed to initialize the context: "
+    "glm5next: the pooled indexer needs one sequence per stream, so a unified "
+    "KV cache is only supported with a single sequence"
+)
+
+
+def test_the_reported_refusal_is_recognised():
+    assert LlamaCppBackend._is_kv_unified_refused(_REFUSAL)
+
+
+def test_an_unrelated_failure_is_not():
+    assert not LlamaCppBackend._is_kv_unified_refused(
+        "error loading model: unknown model architecture: 'qwen4exp'"
+    )
+    assert not LlamaCppBackend._is_kv_unified_refused("")
+
+
+def test_the_reported_launch_becomes_one_slot_with_no_unified_cache():
+    """The argv is the one in the report, trimmed to the flags that matter."""
+    cmd = [
+        "llama-server", "-m", "GLM-5.3-Flash-UD-IQ4_XS-00001-of-00004.gguf",
+        "--parallel", "4", "--flash-attn", "on", "--no-context-shift",
+        "-c", "128000", "--gpu-layers", "47", "--fit", "off",
+        "--kv-unified", "--jinja",
+    ]
+
+    out = LlamaCppBackend._with_single_sequence(cmd)
+
+    assert out is not None
+    assert "--kv-unified" not in out
+    assert out[out.index("--parallel") + 1] == "1"
+    # The user's context is theirs; only Studio's own choice is reversed.
+    assert out[out.index("-c") + 1] == "128000"
+    assert out[out.index("--gpu-layers") + 1] == "47"
+    assert "--jinja" in out and "--no-context-shift" in out
+
+
+def test_a_parallel_surviving_in_the_extras_tail_is_rewritten_too():
+    """llama.cpp is last-wins and extras are appended after Unsloth's flags."""
+    cmd = ["llama-server", "--parallel", "4", "--kv-unified", "-np", "8"]
+
+    out = LlamaCppBackend._with_single_sequence(cmd)
+
+    assert out == ["llama-server", "--parallel", "1", "-np", "1"]
+
+
+def test_every_spelling_of_the_two_flags_is_handled():
+    cmd = ["llama-server", "--parallel=4", "-kvu", "--alias", "m"]
+    assert LlamaCppBackend._with_single_sequence(cmd) == [
+        "llama-server", "--parallel", "1", "--alias", "m",
+    ]
+
+    # -np8 is llama.cpp's attached short form, which _flag_name peels to -np.
+    cmd = ["llama-server", "-np8", "--kv-unified", "1"]
+    assert LlamaCppBackend._with_single_sequence(cmd) == ["llama-server", "-np", "1"]
+
+
+def test_a_command_already_running_one_sequence_has_nothing_to_retry():
+    assert LlamaCppBackend._with_single_sequence(["llama-server", "-c", "8192"]) is None
+    assert (
+        LlamaCppBackend._with_single_sequence(["llama-server", "--parallel", "1"]) is None
+    )
+
+
+def test_a_slot_count_is_added_when_the_command_carried_none():
+    out = LlamaCppBackend._with_single_sequence(["llama-server", "--kv-unified"])
+
+    assert out == ["llama-server", "--parallel", "1"]
+
+
+def test_the_inherited_environment_is_dropped_so_it_cannot_undo_the_retry():
+    """llama.cpp applies its environment before parsing argv."""
+    env = {"LLAMA_ARG_KV_UNIFIED": "1", "LLAMA_ARG_N_PARALLEL": "4", "PATH": "/usr/bin"}
+
+    assert LlamaCppBackend._drop_env_single_sequence(env) is True
+    assert "LLAMA_ARG_KV_UNIFIED" not in env
+    assert "LLAMA_ARG_N_PARALLEL" not in env
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_a_clean_environment_reports_nothing_dropped():
+    env = {"PATH": "/usr/bin"}
+
+    assert LlamaCppBackend._drop_env_single_sequence(env) is False
+    assert env == {"PATH": "/usr/bin"}

--- a/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
+++ b/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
@@ -3,12 +3,8 @@
 
 """The single-sequence retry for architectures that refuse a unified KV cache.
 
-Studio appends ``--kv-unified`` on its own whenever it asks for more than one
-slot, to stop llama.cpp splitting ``-c`` into per-slot windows. Some
-architectures need one sequence per stream and refuse to build a context that
-way, so the model cannot load at all and nothing the user changes in the UI
-reaches the flag that caused it. The retry reverses Studio's choice, not the
-user's context.
+Studio appends ``--kv-unified`` itself above one slot, so nothing the user changes
+in the UI reaches the flag that stops the model loading.
 """
 
 from __future__ import annotations
@@ -28,9 +24,7 @@ _REFUSAL = (
 )
 
 
-# What the binary actually prints: the GGML_ASSERT of ggml-org/llama.cpp#27754,
-# stringified expression and all, then a backtrace and abort(). The full buffer
-# is scanned, not its tail, so the backtrace cannot push the marker out of view.
+# What the binary prints: the full buffer is scanned, so the backtrace cannot bury it.
 _ASSERT = (
     "/build/llama.cpp/src/models/glm5next.cpp:1018: GGML_ASSERT(n_ps == 1 && "
     '"the per-cell pool view needs one sequence per stream") failed\n'
@@ -51,8 +45,7 @@ def test_an_unrelated_failure_is_not():
         "error loading model: unknown model architecture: 'qwen4exp'"
     )
     assert not LlamaCppBackend._is_kv_unified_refused("")
-    # Upstream's minimax-m3 warning degrades to dense attention and still loads;
-    # retrying it as one slot would cost three slots for nothing.
+    # minimax-m3 still loads: retrying it would cost three slots for nothing.
     assert not LlamaCppBackend._is_kv_unified_refused(
         "minimax_m3: unified KV cache with n_seq_max > 1; MSA needs per-sequence "
         "streams -> running DENSE attention. Drop --kv-unified to enable MSA."
@@ -60,7 +53,6 @@ def test_an_unrelated_failure_is_not():
 
 
 def test_the_reported_launch_becomes_one_slot_with_no_unified_cache():
-    """The argv is the one in the report, trimmed to the flags that matter."""
     cmd = [
         "llama-server",
         "-m",
@@ -85,7 +77,6 @@ def test_the_reported_launch_becomes_one_slot_with_no_unified_cache():
     assert out is not None
     assert "--kv-unified" not in out
     assert out[out.index("--parallel") + 1] == "1"
-    # The user's context is theirs; only Studio's own choice is reversed.
     assert out[out.index("-c") + 1] == "128000"
     assert out[out.index("--gpu-layers") + 1] == "47"
     assert "--jinja" in out and "--no-context-shift" in out
@@ -110,13 +101,12 @@ def test_every_spelling_of_the_two_flags_is_handled():
         "m",
     ]
 
-    # -np8 is llama.cpp's attached short form, which _flag_name peels to -np.
     cmd = ["llama-server", "-np8", "--kv-unified", "1"]
     assert LlamaCppBackend._with_single_sequence(cmd) == ["llama-server", "-np", "1"]
 
 
 def test_every_alias_of_the_slot_count_is_rewritten():
-    """--n-parallel is in the denylist group too, and llama.cpp is last-wins."""
+    """--n-parallel is in the denylist group too."""
     out = LlamaCppBackend._with_single_sequence(
         ["llama-server", "--parallel", "4", "--kv-unified", "--n-parallel", "8"]
     )
@@ -160,23 +150,18 @@ def test_a_clean_environment_reports_nothing_dropped():
 
 
 def test_the_fit_recovery_rungs_stand_down_for_this_refusal():
-    """The abort is a startup crash, so _spawn_and_wait's --fit rungs would take
-    it first: a second full model load on a theory unrelated to the failure, and
-    the argv this retry then reads would be the fit-rewritten one, not the one
-    that refused. They are excluded the same way the tensor-capability crash is."""
+    """A startup crash, so the --fit rungs would take it first and waste a load."""
     import inspect
 
     src = inspect.getsource(LlamaCppBackend.load_model)
     assert "_capability_crash = _tensor_capability_crash or self._is_kv_unified_refused" in src
-    # Every --fit rung, and only those: the HIP rung keeps its own narrower gate.
+    # Every --fit rung, and only those: the HIP rung keeps its narrower gate.
     assert src.count("and not _capability_crash") == 3
     assert src.count("and not _tensor_capability_crash") == 1
 
 
 def test_the_retry_commits_the_one_slot_geometry_it_launched():
-    # The launch commits n_parallel and kv_cache_unified after the ladder, so the
-    # retry has to overwrite the locals it reverses, or Studio would advertise and
-    # admit the multi-slot geometry that llama-server just refused.
+    # Committed after the ladder, so the retry must overwrite what it reverses.
     import inspect
 
     src = inspect.getsource(LlamaCppBackend.load_model)

--- a/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
+++ b/studio/backend/tests/test_llama_cpp_single_sequence_retry.py
@@ -28,8 +28,22 @@ _REFUSAL = (
 )
 
 
+# What the binary actually prints: the GGML_ASSERT of ggml-org/llama.cpp#27754,
+# stringified expression and all, then a backtrace and abort(). The full buffer
+# is scanned, not its tail, so the backtrace cannot push the marker out of view.
+_ASSERT = (
+    "/build/llama.cpp/src/models/glm5next.cpp:1018: GGML_ASSERT(n_ps == 1 && "
+    '"the per-cell pool view needs one sequence per stream") failed\n'
+    "[New LWP 4242]\n#0  0x00007f0000000000 in abort ()"
+)
+
+
 def test_the_reported_refusal_is_recognised():
     assert LlamaCppBackend._is_kv_unified_refused(_REFUSAL)
+
+
+def test_the_assert_the_binary_actually_prints_is_recognised():
+    assert LlamaCppBackend._is_kv_unified_refused(_ASSERT)
 
 
 def test_an_unrelated_failure_is_not():
@@ -37,6 +51,12 @@ def test_an_unrelated_failure_is_not():
         "error loading model: unknown model architecture: 'qwen4exp'"
     )
     assert not LlamaCppBackend._is_kv_unified_refused("")
+    # Upstream's minimax-m3 warning degrades to dense attention and still loads;
+    # retrying it as one slot would cost three slots for nothing.
+    assert not LlamaCppBackend._is_kv_unified_refused(
+        "minimax_m3: unified KV cache with n_seq_max > 1; MSA needs per-sequence "
+        "streams -> running DENSE attention. Drop --kv-unified to enable MSA."
+    )
 
 
 def test_the_reported_launch_becomes_one_slot_with_no_unified_cache():
@@ -95,6 +115,22 @@ def test_every_spelling_of_the_two_flags_is_handled():
     assert LlamaCppBackend._with_single_sequence(cmd) == ["llama-server", "-np", "1"]
 
 
+def test_every_alias_of_the_slot_count_is_rewritten():
+    """--n-parallel is in the denylist group too, and llama.cpp is last-wins."""
+    out = LlamaCppBackend._with_single_sequence(
+        ["llama-server", "--parallel", "4", "--kv-unified", "--n-parallel", "8"]
+    )
+
+    assert out == ["llama-server", "--parallel", "1", "--n-parallel", "1"]
+
+
+def test_a_valueless_slot_flag_does_not_swallow_the_next_flag():
+    """Malformed, but eating the token behind it would delete --kv-unified."""
+    out = LlamaCppBackend._with_single_sequence(["llama-server", "--parallel", "--kv-unified"])
+
+    assert out == ["llama-server", "--parallel", "1"]
+
+
 def test_a_command_already_running_one_sequence_has_nothing_to_retry():
     assert LlamaCppBackend._with_single_sequence(["llama-server", "-c", "8192"]) is None
     assert LlamaCppBackend._with_single_sequence(["llama-server", "--parallel", "1"]) is None
@@ -121,6 +157,20 @@ def test_a_clean_environment_reports_nothing_dropped():
 
     assert LlamaCppBackend._drop_env_single_sequence(env) is False
     assert env == {"PATH": "/usr/bin"}
+
+
+def test_the_fit_recovery_rungs_stand_down_for_this_refusal():
+    """The abort is a startup crash, so _spawn_and_wait's --fit rungs would take
+    it first: a second full model load on a theory unrelated to the failure, and
+    the argv this retry then reads would be the fit-rewritten one, not the one
+    that refused. They are excluded the same way the tensor-capability crash is."""
+    import inspect
+
+    src = inspect.getsource(LlamaCppBackend.load_model)
+    assert "_capability_crash = _tensor_capability_crash or self._is_kv_unified_refused" in src
+    # Every --fit rung, and only those: the HIP rung keeps its own narrower gate.
+    assert src.count("and not _capability_crash") == 3
+    assert src.count("and not _tensor_capability_crash") == 1
 
 
 def test_the_retry_commits_the_one_slot_geometry_it_launched():

--- a/studio/backend/tests/test_tp_vision_regression.py
+++ b/studio/backend/tests/test_tp_vision_regression.py
@@ -617,13 +617,10 @@ def test_fit_off_retry_skipped_on_a_tensor_capability_crash():
     """The fit-independent --fit off retry is skipped on the split-axis marker, else
     the model crashes a second time before the latch records it (reviewer.py, #6659).
 
-    The same skip now also covers the pre-b9455 refusal of a quantized KV cache in
-    tensor mode (ggml-org/llama.cpp#23792) and the unified-cache refusal an
-    architecture needing one sequence per stream raises: none of the three is
-    something a second spawn to let it offload can help, and each costs a full
-    model load. Hence _capability_crash, wider than the split-axis guard it
-    started as, with _tensor_capability_crash left as the tensor-only half the
-    ROCm rung still gates on.
+    It now also covers the pre-b9455 quantized-KV refusal in tensor mode
+    (ggml-org/llama.cpp#23792) and the unified-cache refusal: no second spawn helps
+    any of the three, and each costs a full model load. Hence _capability_crash,
+    with _tensor_capability_crash left as the half the ROCm rung gates on.
     """
     src = inspect.getsource(LlamaCppBackend.load_model)
     retry = src.find('run_cmd = [*run_cmd, "--fit", "off"]')

--- a/studio/backend/tests/test_tp_vision_regression.py
+++ b/studio/backend/tests/test_tp_vision_regression.py
@@ -618,10 +618,12 @@ def test_fit_off_retry_skipped_on_a_tensor_capability_crash():
     the model crashes a second time before the latch records it (reviewer.py, #6659).
 
     The same skip now also covers the pre-b9455 refusal of a quantized KV cache in
-    tensor mode (ggml-org/llama.cpp#23792): both are capabilities the binary lacks,
-    so a second spawn to let it offload cannot help and costs a full model load.
-    Hence the guard's name is _tensor_capability_crash rather than the split-axis
-    one it started as.
+    tensor mode (ggml-org/llama.cpp#23792) and the unified-cache refusal an
+    architecture needing one sequence per stream raises: none of the three is
+    something a second spawn to let it offload can help, and each costs a full
+    model load. Hence _capability_crash, wider than the split-axis guard it
+    started as, with _tensor_capability_crash left as the tensor-only half the
+    ROCm rung still gates on.
     """
     src = inspect.getsource(LlamaCppBackend.load_model)
     retry = src.find('run_cmd = [*run_cmd, "--fit", "off"]')
@@ -629,11 +631,12 @@ def test_fit_off_retry_skipped_on_a_tensor_capability_crash():
     guard = src[max(0, retry - 1000) : retry]
     assert "_fit_retry_allowed" in guard and "_startup_crashed" in guard
     assert (
-        "not _tensor_capability_crash" in guard
-    ), "the fit-off retry must be skipped when the crash is a tensor capability limit"
-    # Both markers feed it, so neither can be dropped without this failing.
+        "not _capability_crash" in guard
+    ), "the fit-off retry must be skipped when the crash is a capability limit"
+    # All three markers feed it, so none can be dropped without this failing.
     assert "_is_tensor_split_assert" in src
     assert "_is_tensor_quant_kv_unsupported" in src
+    assert "_is_kv_unified_refused" in src
 
 
 def test_is_abort_exit_recognizes_windows_crt_abort():


### PR DESCRIPTION
## The bug

Studio appends `--kv-unified` on its own whenever it asks for more than one slot, so llama.cpp does not split `-c` into per-slot windows (`_ctx_integrity_flags`: `if n_parallel > 1 and caps.get("supports_kv_unified")`). Some architectures need one sequence per stream and cannot build a context that way. In the GLM-5-Next port (ggml-org/llama.cpp#27754) the pooled indexer resolves its geometry like this:

```c
const int64_t n_stream = cparams.kv_unified ? 1 : ubatch.n_seqs_unq;
const int64_t n_ps     = (int64_t) ubatch.n_seqs_unq/n_stream;
...
// one row per stream, so a shared cell has nowhere to put its second pool
GGML_ASSERT(n_ps == 1 && "the per-cell pool view needs one sequence per stream");
```

Under `--kv-unified` with more than one sequence, `n_stream` collapses to 1, `n_ps` becomes the slot count, and the assert aborts the child. Drop the flag and `n_stream` equals the sequence count, `n_ps` is 1, and the same slots load. So the flag is the cause, not the slot count and not the context.

Neither flag was asked for by the user, and neither is reachable from the UI, so the model simply cannot load and nothing they change helps. From a Strix Halo report: GLM-5.3-Flash UD-IQ4_XS was tried four times over two days after a ~146 GB download and never ran once. Each attempt spent ~56 s loading the model before the context check. The second attempt cut the context from 128000 to 8192, which could not have worked, because the context was never the problem.

## The fix

Retry once with the geometry that would never have added the flag in the first place: one slot, no unified cache, the requested context untouched. This reverses Studio's own choice rather than the user's.

The match is on llama.cpp's own wording, not on an architecture name, so a second model with the same constraint is covered without a list to keep current. `GGML_ASSERT` stringifies the whole expression, so the message the binary prints carries the marker verbatim.

Because the refusal is an assert, the child aborts, and two things follow:

- The rung sits ahead of the flash-attention retry. That one fires on any signal crash, so it would otherwise take this one first and spend the retry disabling a flag that was never the cause.
- The three `--fit` recovery rungs inside `_spawn_and_wait` stand down for it, the same way they already do for the split-axis abort and the pre-b9455 quantized-KV refusal. They are gated on a bare startup crash, so the reported launch (`--gpu-layers 47` with `--fit off`) would have taken the `fully_gpu_offloaded` arm first: a second full model load on a theory unrelated to the failure, after which the retry would have read a fit-rewritten argv and committed a `--fit on` the user never asked for.

Matching is on the message rather than the exit code, so the POSIX `SIGABRT` and the MSVC CRT exit 3 both land here.

Two details that follow the existing rungs:

- **Every** occurrence and every alias of the slot count is rewritten, not just the one Studio emitted. Extras are appended after Unsloth's flags and llama.cpp is last-wins, so one surviving in the tail would put the rejected geometry straight back. The aliases come from `_PARALLEL_FLAGS`, the same frozenset the extra-args denylist and its #9510 hint use, so the three cannot drift apart. `--parallel=4`, `-np 4`, the attached short `-np8` and `--n-parallel 4` are all handled.
- `LLAMA_ARG_KV_UNIFIED` is dropped from the child environment, for the same reason `_drop_env_flash_attn` exists: llama.cpp applies its environment before parsing argv. It is dropped rather than negated with `--no-kv-unified`, because the drop needs nothing of the binary while emitting a flag needs every build that reaches here to know it.

## Verification

`studio/backend/tests/test_llama_cpp_single_sequence_retry.py`, 13 cases, including the report's own argv, the `GGML_ASSERT` the binary actually prints, and the upstream minimax-m3 warning that must **not** trip it (that one degrades to dense attention and still loads, so retrying it would cost three slots for nothing).

608 tests pass across that file plus `test_tp_vision_regression`, `test_llama_server_args`, `test_llama_cpp_effective_parallel_slots`, `test_llama_cpp_no_context_shift`, `test_llama_cpp_context_fit` and `test_llama_cpp_mmproj_fallback`.

Beyond the unit tests, the rewrite was simulated against a llama-server stand-in that implements the three lines above and llama.cpp's own resolution order (environment first, then last-wins argv):

- 22,051 generated command lines, exhaustive over slot spelling x count x unified-cache spelling x position plus 20,000 randomised ones, checking that no unrelated token is dropped, duplicated or reordered, that the result reads back as one slot and not unified through Studio's own parsers, that it is idempotent, and that `-c` and `--gpu-layers` survive.
- 18 before/after loads, each run with the rung and without it. Before: the reported 4-slot launch never loads, at 128000 or at 8192. After: it loads on the second attempt at one slot with the context intact. Launches that already worked are never retried and keep their slots.
- 720 combinations of [Windows, Linux, WSL, macOS] x [NVIDIA, AMD, CPU] x slots x context x fit x vision, checking that every platform and device flag comes back byte for byte and that each one loads.
- The whole set re-run under Python 3.9, 3.10, 3.11, 3.12 and 3.13 in isolated venvs, identical results, for older installs.

## Note on what this does not do

Dropping to one slot means concurrent requests queue, and the warning says so. Keeping `--parallel` and dropping only `--kv-unified` would satisfy the assert too and preserve concurrency, but it silently divides the requested context by the slot count, which is the behaviour `--kv-unified` was added to prevent. Loading at the requested context is the better trade for a model that otherwise does not load at all.
