### PR TITLE
Studio: keep the overlay rail honest about what it reserves

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -421,6 +421,11 @@ function TauriUpdateLayer({
       // cards still land on 16px, since the box sits on the floor and the
       // bottom gutter carries them back up.
       className="pointer-events-none fixed bottom-0 right-4 -mx-3 flex max-h-[calc(100dvh_-_8px)] flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3"
+      // The rail is measured from the outside, per card, by
+      // tests/studio/playwright_update_banner_layout.py. Reaching it through
+      // whichever banner happens to be up finds nothing when none is, which is
+      // exactly the state the download panel has to be judged in.
+      data-testid="overlay-rail"
       // Block gutter in px, never a spacing utility: those are rem, and at any
       // root but 16px the cards would drift off the corner. Across stays a
       // utility, since px-3 and -mx-3 cancel whatever a rem is worth.
@@ -737,6 +742,11 @@ function TauriWrapper({ children }: { children: ReactNode }) {
           // padding. The cards still land on 16px, since the box sits on the
           // floor and the bottom gutter carries them back up.
           className="pointer-events-none fixed bottom-0 right-4 -mx-3 flex max-h-[calc(100dvh_-_8px)] flex-col items-end gap-2 overflow-y-auto overflow-x-hidden overscroll-contain px-3"
+          // The rail is measured from the outside, per card, by
+          // tests/studio/playwright_update_banner_layout.py. Reaching it through
+          // whichever banner happens to be up finds nothing when none is, which is
+          // exactly the state the download panel has to be judged in.
+          data-testid="overlay-rail"
           // Block gutter in px, never a spacing utility: those are rem, and at
           // any root but 16px the cards would drift off the corner.
           style={{

--- a/studio/frontend/tests/download-panel-not-permanent.test.ts
+++ b/studio/frontend/tests/download-panel-not-permanent.test.ts
@@ -81,11 +81,11 @@ job list at all, it can no longer know when to unmount.`,
 }
 
 /**
- * Does `condition` test for an empty `jobKeys`? Operand order matters: an
+ * Is this leaf the test "the list is empty"? Operand order matters: an
  * unordered match also accepts `0 < jobKeys.length`, the exact inverse, and the
  * always-true `0 <= jobKeys.length`. Hence the explicit shapes.
  */
-function testsForAnEmptyList(condition: ts.Node, jobKeys: string): boolean {
+function isEmptyTest(node: ts.Node, jobKeys: string): boolean {
   const length = `${jobKeys}.length`;
   const K = ts.SyntaxKind;
   // [left, operator, right], each meaning "the list is empty".
@@ -97,27 +97,60 @@ function testsForAnEmptyList(condition: ts.Node, jobKeys: string): boolean {
     ["0", K.GreaterThanEqualsToken, length],
     ["1", K.GreaterThanToken, length],
   ];
-  let ok = false;
-  const visit = (node: ts.Node): void => {
-    if (ts.isBinaryExpression(node)) {
-      const left = node.left.getText();
-      const right = node.right.getText();
-      const op = node.operatorToken.kind;
-      if (shapes.some(([l, o, r]) => left === l && op === o && right === r)) {
-        ok = true;
-      }
+  if (ts.isBinaryExpression(node)) {
+    const left = node.left.getText();
+    const right = node.right.getText();
+    const op = node.operatorToken.kind;
+    return shapes.some(([l, o, r]) => left === l && op === o && right === r);
+  }
+  // !jobKeys.length
+  return (
+    ts.isPrefixUnaryExpression(node) &&
+    node.operator === K.ExclamationToken &&
+    node.operand.getText() === length
+  );
+}
+
+/**
+ * Does an empty list force `condition` true?
+ *
+ * Finding the comparison somewhere inside the condition is not the same
+ * question, and answers it wrongly in both directions: `jobKeys.length === 0 &&
+ * activeCount > 0` only unmounts for one of the empty states, and
+ * `!(jobKeys.length === 0)` unmounts for none of them. So the condition is
+ * evaluated with the empty test pinned true and every other term unknown; only
+ * a definite true counts.
+ */
+type Truth = true | false | null;
+
+function underAnEmptyList(node: ts.Node, jobKeys: string): Truth {
+  if (isEmptyTest(node, jobKeys)) return true;
+  if (ts.isParenthesizedExpression(node)) {
+    return underAnEmptyList(node.expression, jobKeys);
+  }
+  if (
+    ts.isPrefixUnaryExpression(node) &&
+    node.operator === ts.SyntaxKind.ExclamationToken
+  ) {
+    const inner = underAnEmptyList(node.operand, jobKeys);
+    return inner === null ? null : !inner;
+  }
+  if (ts.isBinaryExpression(node)) {
+    const op = node.operatorToken.kind;
+    const left = underAnEmptyList(node.left, jobKeys);
+    const right = underAnEmptyList(node.right, jobKeys);
+    if (op === ts.SyntaxKind.BarBarToken) {
+      if (left === true || right === true) return true;
+      if (left === false && right === false) return false;
+      return null;
     }
-    if (
-      ts.isPrefixUnaryExpression(node) &&
-      node.operator === K.ExclamationToken &&
-      node.operand.getText() === length
-    ) {
-      ok = true;
+    if (op === ts.SyntaxKind.AmpersandAmpersandToken) {
+      if (left === false || right === false) return false;
+      if (left === true && right === true) return true;
+      return null;
     }
-    ts.forEachChild(node, visit);
-  };
-  visit(condition);
-  return ok;
+  }
+  return null; // Any other term: unknown, so it cannot carry the guard.
 }
 
 function returnsNull(statement: ts.Statement): boolean {
@@ -139,7 +172,7 @@ test("the Downloads overlay unmounts when there are no jobs", () => {
     (statement) =>
       ts.isIfStatement(statement) &&
       returnsNull(statement.thenStatement) &&
-      testsForAnEmptyList(statement.expression, jobKeys),
+      underAnEmptyList(statement.expression, jobKeys) === true,
   );
 
   assert.ok(

--- a/studio/frontend/tests/download-panel-not-permanent.test.ts
+++ b/studio/frontend/tests/download-panel-not-permanent.test.ts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * The Downloads overlay is a transient card, not furniture.
+ *
+ * #9849 dropped `jobKeys.length === 0` from the early return so the panel would
+ * "always be there to open", and defaulted it to its collapsed FAB. The result
+ * was a download button pinned to the bottom-right corner of every hub route on
+ * a fresh install, with nothing to show. It had to be reverted wholesale by
+ * #10298, and nothing in either suite failed while it was on main.
+ *
+ * Two things go wrong when the guard is weakened, and only the first is
+ * obvious. The panel itself becomes permanent; and because the rail in
+ * provider.tsx is a `flex flex-col gap-2` column, a panel that returns a
+ * wrapper instead of `null` also takes a slot and its gap, pushing the loaded
+ * models card - the one overlay that IS meant to sit on the corner - up off it.
+ *
+ * Read from the source: the node suite has no DOM to render into. The guard is
+ * matched through the AST rather than as a string so that reformatting, a
+ * rename of `jobKeys`, or an extra clause in the condition do not silently
+ * turn this into a test of nothing.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import ts from "typescript";
+
+import { openingTag } from "./helpers/tsx-ast.ts";
+
+const parse = (relative: string, name: string): ts.SourceFile =>
+  ts.createSourceFile(
+    name,
+    readFileSync(new URL(`../src/${relative}`, import.meta.url), "utf8"),
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+const PANEL_PATH = "features/hub/download-manager/download-manager-panel.tsx";
+const panel = parse(PANEL_PATH, "download-manager-panel.tsx");
+const provider = parse("app/provider.tsx", "provider.tsx");
+
+/** The `DownloadManagerPanel` function declaration. */
+function panelComponent(): ts.FunctionDeclaration {
+  let found: ts.FunctionDeclaration | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name?.getText() === "DownloadManagerPanel"
+    ) {
+      found = node;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(panel, visit);
+  assert.ok(found, `${PANEL_PATH} no longer exports a DownloadManagerPanel`);
+  return found;
+}
+
+/**
+ * The local that holds the ordered job keys, found by its initializer rather
+ * than by name: a rename must not be able to slip the guard past this file.
+ */
+function jobKeysBinding(component: ts.FunctionDeclaration): string {
+  let name: string | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isCallExpression(node.initializer) &&
+      node.initializer.expression.getText() === "useDownloadManagerStore" &&
+      node.initializer.arguments.some((arg) =>
+        /orderedJobKeys/i.test(arg.getText()),
+      )
+    ) {
+      name = node.name.getText();
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(component, visit);
+  assert.ok(
+    name,
+    `${PANEL_PATH}: no local is bound from useDownloadManagerStore with the
+ordered-job-keys selector, so the guard below cannot be located. If the
+selector was renamed, update this test; if the panel stopped reading the
+job list at all, it can no longer know when to unmount.`,
+  );
+  return name;
+}
+
+/** Does `condition` contain a test for an empty `jobKeys`? */
+function testsForAnEmptyList(condition: ts.Node, jobKeys: string): boolean {
+  let ok = false;
+  const visit = (node: ts.Node): void => {
+    // jobKeys.length === 0, jobKeys.length < 1, 0 === jobKeys.length
+    if (ts.isBinaryExpression(node)) {
+      const operands = [node.left.getText(), node.right.getText()];
+      const comparesLength = operands.includes(`${jobKeys}.length`);
+      const comparesZero =
+        operands.includes("0") ||
+        (node.operatorToken.kind === ts.SyntaxKind.LessThanToken &&
+          operands.includes("1"));
+      const equality =
+        node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+        node.operatorToken.kind === ts.SyntaxKind.LessThanToken ||
+        node.operatorToken.kind === ts.SyntaxKind.LessThanEqualsToken;
+      if (comparesLength && comparesZero && equality) ok = true;
+    }
+    // !jobKeys.length
+    if (
+      ts.isPrefixUnaryExpression(node) &&
+      node.operator === ts.SyntaxKind.ExclamationToken &&
+      node.operand.getText() === `${jobKeys}.length`
+    ) {
+      ok = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(condition);
+  return ok;
+}
+
+/** `return null` directly, or as the only statement of a block. */
+function returnsNull(statement: ts.Statement): boolean {
+  const body = ts.isBlock(statement) ? statement.statements : [statement];
+  return body.some(
+    (node) =>
+      ts.isReturnStatement(node) &&
+      node.expression?.kind === ts.SyntaxKind.NullKeyword,
+  );
+}
+
+test("the Downloads overlay unmounts when there are no jobs", () => {
+  const component = panelComponent();
+  const jobKeys = jobKeysBinding(component);
+  const statements = component.body?.statements ?? ts.factory.createNodeArray();
+
+  // Top level of the component only. A guard nested inside another branch is
+  // not the same promise: it would leave states in which the panel is mounted
+  // with an empty list, which is the whole of what #9849 shipped.
+  const guarded = statements.some(
+    (statement) =>
+      ts.isIfStatement(statement) &&
+      returnsNull(statement.thenStatement) &&
+      testsForAnEmptyList(statement.expression, jobKeys),
+  );
+
+  assert.ok(
+    guarded,
+    `${PANEL_PATH}: DownloadManagerPanel must return null while ${jobKeys} is
+empty, at the top level of the component.
+
+Without it the Downloads overlay is permanent: a bottom-right FAB on
+every hub route of a fresh install, and a flex slot in the rail that
+pushes the loaded models card off the corner even when it paints
+nothing. That is PR #9849, which had to be reverted by PR #10298.
+
+Expected something of the shape:  if (... || ${jobKeys}.length === 0) return null;`,
+  );
+});
+
+test("the rail-facing wrapper can still be squeezed by the rail's cap", () => {
+  // min-h-0 on the non-positioned branch: a flex item's min-height defaults to
+  // auto, so without it a capped rail takes the height out of the update card
+  // above instead of out of this list, and the card clips its own buttons.
+  const source = readFileSync(
+    new URL(`../src/${PANEL_PATH}`, import.meta.url),
+    "utf8",
+  );
+  const ternary = source.match(/positioned\s*\?\s*"([^"]*)"\s*:\s*"([^"]*)"/);
+  assert.ok(
+    ternary,
+    `${PANEL_PATH}: the positioned/stacked className ternary is gone, so the
+rail-facing branch can no longer be checked`,
+  );
+  assert.match(
+    ternary[1],
+    /\bfixed\b.*\bbottom-4\b.*\bright-4\b/,
+    `${PANEL_PATH}: the standalone panel has left the bottom-right corner`,
+  );
+  assert.match(
+    ternary[2],
+    /\bmin-h-0\b/,
+    `${PANEL_PATH}: the stacked branch dropped min-h-0, so a capped rail will
+squeeze the update card above this list instead of the list`,
+  );
+});
+
+test("the Downloads panel sits above the loaded models card in both rails", () => {
+  // The loaded models card is the one overlay meant to hold the corner; the
+  // download panel is deliberately ordered above it because it comes and goes.
+  const tags: { name: string; at: number }[] = [];
+  const visit = (node: ts.Node): void => {
+    const opening = openingTag(node);
+    const name = opening?.tagName.getText();
+    if (name === "DownloadManagerPanel" || name === "LoadedModelsIndicator") {
+      tags.push({ name, at: node.getStart() });
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(provider, visit);
+  tags.sort((a, b) => a.at - b.at);
+
+  const panels = tags.filter((t) => t.name === "DownloadManagerPanel");
+  const indicators = tags.filter((t) => t.name === "LoadedModelsIndicator");
+  assert.ok(
+    panels.length > 0 && panels.length === indicators.length,
+    `provider.tsx: expected the download panel and the loaded models card to be
+paired in every rail, found ${panels.length} and ${indicators.length}`,
+  );
+  for (let i = 0; i < panels.length; i += 1) {
+    assert.ok(
+      panels[i].at < indicators[i].at,
+      "provider.tsx: DownloadManagerPanel is rendered below LoadedModelsIndicator.\n" +
+        "The rail is a bottom-anchored column, so the last child is the one on\n" +
+        "the corner, and that is meant to be the loaded models card.",
+    );
+  }
+});

--- a/studio/frontend/tests/download-panel-not-permanent.test.ts
+++ b/studio/frontend/tests/download-panel-not-permanent.test.ts
@@ -2,24 +2,16 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 /**
- * The Downloads overlay is a transient card, not furniture.
+ * The Downloads overlay must unmount when the job list is empty (#9849, which
+ * shipped a permanent corner FAB and was reverted by #10298).
  *
- * #9849 dropped `jobKeys.length === 0` from the early return so the panel would
- * "always be there to open", and defaulted it to its collapsed FAB. The result
- * was a download button pinned to the bottom-right corner of every hub route on
- * a fresh install, with nothing to show. It had to be reverted wholesale by
- * #10298, and nothing in either suite failed while it was on main.
+ * The second consequence is the one that reads as harmless: the rail is a
+ * `flex flex-col gap-2` column, so a panel returning a wrapper instead of
+ * `null` takes a slot and its gap, pushing the loaded models card off the
+ * corner it is meant to hold.
  *
- * Two things go wrong when the guard is weakened, and only the first is
- * obvious. The panel itself becomes permanent; and because the rail in
- * provider.tsx is a `flex flex-col gap-2` column, a panel that returns a
- * wrapper instead of `null` also takes a slot and its gap, pushing the loaded
- * models card - the one overlay that IS meant to sit on the corner - up off it.
- *
- * Read from the source: the node suite has no DOM to render into. The guard is
- * matched through the AST rather than as a string so that reformatting, a
- * rename of `jobKeys`, or an extra clause in the condition do not silently
- * turn this into a test of nothing.
+ * Read from the source: the node suite has no DOM. Matched through the AST, so
+ * reformatting or a rename of `jobKeys` cannot quietly retire it.
  */
 
 import assert from "node:assert/strict";
@@ -43,7 +35,6 @@ const PANEL_PATH = "features/hub/download-manager/download-manager-panel.tsx";
 const panel = parse(PANEL_PATH, "download-manager-panel.tsx");
 const provider = parse("app/provider.tsx", "provider.tsx");
 
-/** The `DownloadManagerPanel` function declaration. */
 function panelComponent(): ts.FunctionDeclaration {
   let found: ts.FunctionDeclaration | null = null;
   const visit = (node: ts.Node): void => {
@@ -60,10 +51,7 @@ function panelComponent(): ts.FunctionDeclaration {
   return found;
 }
 
-/**
- * The local that holds the ordered job keys, found by its initializer rather
- * than by name: a rename must not be able to slip the guard past this file.
- */
+/** The ordered-job-keys local, found by its initializer so a rename cannot slip past. */
 function jobKeysBinding(component: ts.FunctionDeclaration): string {
   let name: string | null = null;
   const visit = (node: ts.Node): void => {
@@ -93,13 +81,9 @@ job list at all, it can no longer know when to unmount.`,
 }
 
 /**
- * Does `condition` contain a test for an empty `jobKeys`?
- *
- * Side matters. An unordered "contains the length and contains zero" match also
- * accepts `0 < jobKeys.length`, which unmounts the panel exactly when there ARE
- * jobs, and `0 <= jobKeys.length`, which is always true. Both would satisfy a
- * test whose whole job is to prove the panel unmounts when the list is empty,
- * so the accepted shapes are spelled out rather than inferred.
+ * Does `condition` test for an empty `jobKeys`? Operand order matters: an
+ * unordered match also accepts `0 < jobKeys.length`, the exact inverse, and the
+ * always-true `0 <= jobKeys.length`. Hence the explicit shapes.
  */
 function testsForAnEmptyList(condition: ts.Node, jobKeys: string): boolean {
   const length = `${jobKeys}.length`;
@@ -123,7 +107,6 @@ function testsForAnEmptyList(condition: ts.Node, jobKeys: string): boolean {
         ok = true;
       }
     }
-    // !jobKeys.length
     if (
       ts.isPrefixUnaryExpression(node) &&
       node.operator === K.ExclamationToken &&
@@ -137,7 +120,6 @@ function testsForAnEmptyList(condition: ts.Node, jobKeys: string): boolean {
   return ok;
 }
 
-/** `return null` directly, or as the only statement of a block. */
 function returnsNull(statement: ts.Statement): boolean {
   const body = ts.isBlock(statement) ? statement.statements : [statement];
   return body.some(
@@ -152,9 +134,7 @@ test("the Downloads overlay unmounts when there are no jobs", () => {
   const jobKeys = jobKeysBinding(component);
   const statements = component.body?.statements ?? ts.factory.createNodeArray();
 
-  // Top level of the component only. A guard nested inside another branch is
-  // not the same promise: it would leave states in which the panel is mounted
-  // with an empty list, which is the whole of what #9849 shipped.
+  // Top level only: a nested guard still leaves mounted-and-empty states.
   const guarded = statements.some(
     (statement) =>
       ts.isIfStatement(statement) &&
@@ -177,9 +157,8 @@ Expected something of the shape:  if (... || ${jobKeys}.length === 0) return nul
 });
 
 test("the rail-facing wrapper can still be squeezed by the rail's cap", () => {
-  // min-h-0 on the non-positioned branch: a flex item's min-height defaults to
-  // auto, so without it a capped rail takes the height out of the update card
-  // above instead of out of this list, and the card clips its own buttons.
+  // min-h-0: without it a flex item floors at auto and the capped rail squeezes
+  // the update card above instead of this list.
   const source = readFileSync(
     new URL(`../src/${PANEL_PATH}`, import.meta.url),
     "utf8",
@@ -204,8 +183,7 @@ squeeze the update card above this list instead of the list`,
 });
 
 test("the Downloads panel sits above the loaded models card in both rails", () => {
-  // The loaded models card is the one overlay meant to hold the corner; the
-  // download panel is deliberately ordered above it because it comes and goes.
+  // The loaded models card holds the corner; this one comes and goes above it.
   const tags: { name: string; at: number }[] = [];
   const visit = (node: ts.Node): void => {
     const opening = openingTag(node);

--- a/studio/frontend/tests/download-panel-not-permanent.test.ts
+++ b/studio/frontend/tests/download-panel-not-permanent.test.ts
@@ -92,29 +92,42 @@ job list at all, it can no longer know when to unmount.`,
   return name;
 }
 
-/** Does `condition` contain a test for an empty `jobKeys`? */
+/**
+ * Does `condition` contain a test for an empty `jobKeys`?
+ *
+ * Side matters. An unordered "contains the length and contains zero" match also
+ * accepts `0 < jobKeys.length`, which unmounts the panel exactly when there ARE
+ * jobs, and `0 <= jobKeys.length`, which is always true. Both would satisfy a
+ * test whose whole job is to prove the panel unmounts when the list is empty,
+ * so the accepted shapes are spelled out rather than inferred.
+ */
 function testsForAnEmptyList(condition: ts.Node, jobKeys: string): boolean {
+  const length = `${jobKeys}.length`;
+  const K = ts.SyntaxKind;
+  // [left, operator, right], each meaning "the list is empty".
+  const shapes: [string, ts.SyntaxKind, string][] = [
+    [length, K.EqualsEqualsEqualsToken, "0"],
+    ["0", K.EqualsEqualsEqualsToken, length],
+    [length, K.LessThanToken, "1"],
+    [length, K.LessThanEqualsToken, "0"],
+    ["0", K.GreaterThanEqualsToken, length],
+    ["1", K.GreaterThanToken, length],
+  ];
   let ok = false;
   const visit = (node: ts.Node): void => {
-    // jobKeys.length === 0, jobKeys.length < 1, 0 === jobKeys.length
     if (ts.isBinaryExpression(node)) {
-      const operands = [node.left.getText(), node.right.getText()];
-      const comparesLength = operands.includes(`${jobKeys}.length`);
-      const comparesZero =
-        operands.includes("0") ||
-        (node.operatorToken.kind === ts.SyntaxKind.LessThanToken &&
-          operands.includes("1"));
-      const equality =
-        node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken ||
-        node.operatorToken.kind === ts.SyntaxKind.LessThanToken ||
-        node.operatorToken.kind === ts.SyntaxKind.LessThanEqualsToken;
-      if (comparesLength && comparesZero && equality) ok = true;
+      const left = node.left.getText();
+      const right = node.right.getText();
+      const op = node.operatorToken.kind;
+      if (shapes.some(([l, o, r]) => left === l && op === o && right === r)) {
+        ok = true;
+      }
     }
     // !jobKeys.length
     if (
       ts.isPrefixUnaryExpression(node) &&
-      node.operator === ts.SyntaxKind.ExclamationToken &&
-      node.operand.getText() === `${jobKeys}.length`
+      node.operator === K.ExclamationToken &&
+      node.operand.getText() === length
     ) {
       ok = true;
     }

--- a/studio/frontend/tests/download-panel-not-permanent.test.ts
+++ b/studio/frontend/tests/download-panel-not-permanent.test.ts
@@ -80,15 +80,11 @@ job list at all, it can no longer know when to unmount.`,
   return name;
 }
 
-/**
- * Is this leaf the test "the list is empty"? Operand order matters: an
- * unordered match also accepts `0 < jobKeys.length`, the exact inverse, and the
- * always-true `0 <= jobKeys.length`. Hence the explicit shapes.
- */
+/** Operand order matters: unordered also accepts `0 < jobKeys.length`, the inverse. */
 function isEmptyTest(node: ts.Node, jobKeys: string): boolean {
   const length = `${jobKeys}.length`;
   const K = ts.SyntaxKind;
-  // [left, operator, right], each meaning "the list is empty".
+  // [left, operator, right], each meaning the list is empty.
   const shapes: [string, ts.SyntaxKind, string][] = [
     [length, K.EqualsEqualsEqualsToken, "0"],
     ["0", K.EqualsEqualsEqualsToken, length],
@@ -103,7 +99,6 @@ function isEmptyTest(node: ts.Node, jobKeys: string): boolean {
     const op = node.operatorToken.kind;
     return shapes.some(([l, o, r]) => left === l && op === o && right === r);
   }
-  // !jobKeys.length
   return (
     ts.isPrefixUnaryExpression(node) &&
     node.operator === K.ExclamationToken &&
@@ -112,14 +107,10 @@ function isEmptyTest(node: ts.Node, jobKeys: string): boolean {
 }
 
 /**
- * Does an empty list force `condition` true?
- *
- * Finding the comparison somewhere inside the condition is not the same
- * question, and answers it wrongly in both directions: `jobKeys.length === 0 &&
- * activeCount > 0` only unmounts for one of the empty states, and
- * `!(jobKeys.length === 0)` unmounts for none of them. So the condition is
- * evaluated with the empty test pinned true and every other term unknown; only
- * a definite true counts.
+ * Does an empty list force `condition` true? Finding the comparison somewhere
+ * inside it is a different question, wrong in both directions: `... === 0 &&
+ * activeCount > 0` covers some empty states, `!(... === 0)` none. Evaluated with
+ * the empty test pinned true and every other term unknown.
  */
 type Truth = true | false | null;
 
@@ -150,7 +141,7 @@ function underAnEmptyList(node: ts.Node, jobKeys: string): Truth {
       return null;
     }
   }
-  return null; // Any other term: unknown, so it cannot carry the guard.
+  return null; // Unknown, so it cannot carry the guard.
 }
 
 function returnsNull(statement: ts.Statement): boolean {

--- a/studio/frontend/tests/overlay-rail-floor-gating.test.ts
+++ b/studio/frontend/tests/overlay-rail-floor-gating.test.ts
@@ -60,25 +60,44 @@ const provider = parse(src("app/provider.tsx"), "provider.tsx");
 /** The rails, matched on the corner they are anchored to. */
 const RAIL_ANCHOR = "pointer-events-none fixed bottom-0 right-4";
 
-/** Every component rendered directly into a rail, by tag name. */
+/**
+ * Every component that ends up in a rail, by tag name.
+ *
+ * Two sources, because neither is complete on its own. Literal children of an
+ * anchored rail miss anything the Tauri layer receives through `{children}`,
+ * which is how its llama, downloads and loaded-models cards arrive; today those
+ * three are also listed literally in the browser rail, but a desktop-only card
+ * would be invisible here. `positioned={false}` is the prop that puts a card in
+ * a rail rather than on the corner by itself, so it catches those, and the
+ * literal scan still catches a card that takes no such prop.
+ */
 function railChildren(): string[] {
   const names = new Set<string>();
   const visit = (node: ts.Node): void => {
     if (ts.isJsxElement(node)) {
-      const opening = node.openingElement;
-      const className = opening.attributes.properties.find(
+      const className = node.openingElement.attributes.properties.find(
         (p): p is ts.JsxAttribute =>
           ts.isJsxAttribute(p) && p.name.getText() === "className",
       );
       if (className?.getText().includes(RAIL_ANCHOR)) {
         for (const child of node.children) {
-          const tag = openingTag(child);
-          const name = tag?.tagName.getText();
-          // {children} in the Tauri layer is followed to its own rail by the
-          // second match; a lower-case tag is a plain element, not a card.
+          const name = openingTag(child)?.tagName.getText();
+          // A lower-case tag is a plain element, not a card.
           if (name && /^[A-Z]/.test(name)) names.add(name);
         }
       }
+    }
+    const tag = openingTag(node);
+    if (tag && /^[A-Z]/.test(tag.tagName.getText())) {
+      const stacked = tag.attributes.properties.some(
+        (p) =>
+          ts.isJsxAttribute(p) &&
+          p.name.getText() === "positioned" &&
+          p.initializer &&
+          ts.isJsxExpression(p.initializer) &&
+          p.initializer.expression?.kind === ts.SyntaxKind.FalseKeyword,
+      );
+      if (stacked) names.add(tag.tagName.getText());
     }
     ts.forEachChild(node, visit);
   };
@@ -127,7 +146,24 @@ function sourceOf(name: string): { path: URL; label: string } | null {
   return followed ? { path: followed, label: `${base}/${hop[1]}` } : null;
 }
 
-/** Class tokens carrying a `min-h-[calc(...)]` floor, per string literal. */
+/**
+ * Class tokens that reserve a minimum height, in any spelling.
+ *
+ * Not just `min-h-[calc(`: `min-h-52`, `min-h-[204px]` and a named utility
+ * reserve height exactly as well, and a rule that only knows one spelling can
+ * be retired by rewriting it. `min-h-0` is the opposite of a floor - it removes
+ * the flex default of `auto` - so it is not one.
+ */
+const FLOOR_TOKEN = /(^|:)min-h-(?!0$)\S+/;
+
+/** Class tokens of a literal. getText() keeps the quotes; they are not classes. */
+const classTokens = (literal: ts.Node): string[] =>
+  literal.getText().replace(/["'`]/g, " ").split(/\s+/).filter(Boolean);
+
+/** Does this class token reserve a minimum height? */
+const isFloor = (token: string): boolean => FLOOR_TOKEN.test(token);
+
+/** String literals carrying a floor. */
 function floorLiterals(file: ts.SourceFile): ts.Node[] {
   const found: ts.Node[] = [];
   const visit = (node: ts.Node): void => {
@@ -135,7 +171,7 @@ function floorLiterals(file: ts.SourceFile): ts.Node[] {
       (ts.isStringLiteral(node) ||
         ts.isNoSubstitutionTemplateLiteral(node) ||
         ts.isTemplateExpression(node)) &&
-      node.getText().includes("min-h-[calc(")
+      classTokens(node).some(isFloor)
     ) {
       found.push(node);
     }
@@ -147,15 +183,10 @@ function floorLiterals(file: ts.SourceFile): ts.Node[] {
 
 /** Is every floor in `literal` gated by the CSS `:has()` on a rendered slot? */
 function gatedByHas(literal: ts.Node): boolean {
-  const tokens = literal
-    .getText()
-    .split(/\s+/)
-    .filter((token) => token.includes("min-h-[calc("));
+  const tokens = classTokens(literal).filter(isFloor);
   return (
     tokens.length > 0 &&
-    tokens.every((token) =>
-      /has-\[\[data-slot=[^\]]+\]\]:min-h-\[calc\(/.test(token),
-    )
+    tokens.every((token) => /has-\[\[data-slot=[^\]]+\]\]:min-h-/.test(token))
   );
 }
 
@@ -182,20 +213,27 @@ function branchConditions(literal: ts.Node): string[] {
 }
 
 /**
- * Does `condition` also decide whether an element renders?
+ * Does `condition` decide whether the PANEL THE FLOOR PROTECTS renders?
  *
- * The point of the gate is that the floor and the panel it protects turn on
- * together. A condition that only picks between two class strings - `positioned`
- * being the one that mattered - reserves height for a panel it has no opinion
- * about.
+ * Rendering something is not enough. `changelogAvailable` renders the changelog
+ * toggle and is true while the panel is still closed, so a floor gated on it
+ * reserves the panel's height on every collapsed card - #10117 exactly. The
+ * predicate has to turn on with the notes, so the element it renders has to be
+ * the notes.
  */
-function gatesAnElement(source: string, condition: string): boolean {
+const PROTECTED_PANEL = /(Notes|Changelog)/i;
+
+function gatesTheNotes(source: string, condition: string): boolean {
   const name = condition.trim();
   if (!/^[A-Za-z_$][\w$]*$/.test(name)) return false;
   const rendered = new RegExp(
-    `\\b${name}\\b[^;{}]{0,160}?(\\?|&&)\\s*\\(?\\s*<[A-Za-z]`,
+    `\\b${name}\\b[^;{}]{0,160}?(\\?|&&)\\s*\\(?\\s*<([A-Za-z][\\w.]*)`,
+    "g",
   );
-  return rendered.test(source);
+  for (const hit of source.matchAll(rendered)) {
+    if (PROTECTED_PANEL.test(hit[2])) return true;
+  }
+  return false;
 }
 
 const CHILDREN = railChildren();
@@ -222,6 +260,17 @@ for (const name of CHILDREN) {
     assert.ok(resolved, `<${name} /> did not resolve`);
     const file = parse(resolved.path, `${name}.tsx`);
     const source = readFileSync(resolved.path, "utf8");
+    // An inline minHeight cannot be gated by a class and is invisible to the
+    // analysis below, so the rail's geometry stays in CSS, as provider.tsx's
+    // own tests already require of the rail itself.
+    assert.doesNotMatch(
+      source,
+      /\bminHeight\s*:/,
+      `${resolved.label}: a floor is set from JS. The rail's cards floor in CSS
+so the gate can be read here and by the browser suite; an inline minHeight is
+reserved unconditionally and nothing checks it.`,
+    );
+
     const literals = floorLiterals(file);
     if (literals.length === 0) return; // No floor, nothing to gate.
 
@@ -229,19 +278,23 @@ for (const name of CHILDREN) {
       const gated =
         gatedByHas(literal) ||
         branchConditions(literal).some((condition) =>
-          gatesAnElement(source, condition),
+          gatesTheNotes(source, condition),
         );
       assert.ok(
         gated,
-        `${resolved.label}: a min-h-[calc(...)] floor is applied without being
-gated on the panel it exists to protect, so the card reserves height it may
-paint none of. In a bottom-anchored rail that dead space lifts every visible
-card off the corner. This is PR #10117, fixed by PR #10229.
+        `${resolved.label}: a min-h floor is applied without being gated on the
+panel it exists to protect, so the card reserves height it may paint none of.
+In a bottom-anchored rail that dead space lifts every visible card off the
+corner. This is PR #10117, fixed by PR #10229.
 
 Gate it one of the two ways already in use:
-  has-[[data-slot=update-release-notes]]:min-h-[calc(...)]   (CSS)
-  changelogPanelOpen ? "min-h-[calc(...)]" : "shrink-0"      (React, using the
-    same predicate that renders the panel)
+  has-[[data-slot=update-release-notes]]:min-h-[...]   (CSS)
+  changelogPanelOpen ? "min-h-[...]" : "shrink-0"      (React, using the same
+    predicate that renders the notes or changelog panel)
+
+A predicate that renders something else does not count: changelogAvailable
+renders the changelog toggle and is true while the panel is still closed, which
+is the state that reserved 64.9px in #10117.
 
 Floor found in: ${literal.getText().slice(0, 200)}
 Ternary conditions around it: ${branchConditions(literal).join(", ") || "(none)"}`,

--- a/studio/frontend/tests/overlay-rail-floor-gating.test.ts
+++ b/studio/frontend/tests/overlay-rail-floor-gating.test.ts
@@ -20,7 +20,8 @@
  */
 
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -149,12 +150,43 @@ function floorLiterals(file: ts.SourceFile): ts.Node[] {
   return found;
 }
 
-/** Is every floor in `literal` gated by the CSS `:has()` on a rendered slot? */
+/**
+ * The components that ARE the protected panel, and the `data-slot` names they
+ * declare, both read out of the tree rather than matched by name. A substring
+ * rule would accept a `<ChangelogToggle>`, and an unresolved `data-slot` would
+ * accept `has-[[data-slot=card-footer]]:`, which an always-present footer makes
+ * permanent. A panel is one that renders the shared notes layout root.
+ */
+function notesPanels(): { components: Set<string>; slots: Set<string> } {
+  const components = new Set<string>();
+  const slots = new Set<string>();
+  const dir = fileURLToPath(src("components"));
+  for (const entry of readdirSync(dir, {
+    recursive: true,
+    withFileTypes: true,
+  })) {
+    if (!entry.isFile() || !entry.name.endsWith(".tsx")) continue;
+    const text = readFileSync(join(entry.parentPath, entry.name), "utf8");
+    if (!text.includes("UPDATE_NOTES_ROOT_CLASS")) continue;
+    for (const hit of text.matchAll(/export function ([A-Z]\w*)/g)) {
+      components.add(hit[1]);
+    }
+    for (const hit of text.matchAll(/data-slot="([^"]+)"/g)) slots.add(hit[1]);
+  }
+  return { components, slots };
+}
+
+const NOTES = notesPanels();
+
+/** Is every floor in `literal` gated by `:has()` on a slot the panel declares? */
 function gatedByHas(literal: ts.Node): boolean {
   const tokens = classTokens(literal).filter(isFloor);
   return (
     tokens.length > 0 &&
-    tokens.every((token) => /has-\[\[data-slot=[^\]]+\]\]:min-h-/.test(token))
+    tokens.every((token) => {
+      const slot = token.match(/has-\[\[data-slot=([^\]]+)\]\]:min-h-/);
+      return slot !== null && NOTES.slots.has(slot[1]);
+    })
   );
 }
 
@@ -182,7 +214,29 @@ function branchConditions(literal: ts.Node): string[] {
  * is true while the panel is closed, which is #10117 exactly. It must render the
  * notes themselves.
  */
-const PROTECTED_PANEL = /(Notes|Changelog)/i;
+/**
+ * The className of the element painted inside the slot this floor is on: the
+ * floor's own JSX element, then its first child element.
+ */
+function paintedSurface(literal: ts.Node): string | null {
+  let node: ts.Node | undefined = literal;
+  while (node && !ts.isJsxAttribute(node)) node = node.parent;
+  // attribute -> attributes -> opening tag -> the element that owns the children
+  const opening = node?.parent?.parent;
+  if (!opening || !ts.isJsxOpeningElement(opening)) return null;
+  const owner = opening.parent;
+  if (!ts.isJsxElement(owner)) return null;
+  for (const child of owner.children) {
+    const tag = openingTag(child);
+    if (!tag) continue;
+    const className = tag.attributes.properties.find(
+      (p): p is ts.JsxAttribute =>
+        ts.isJsxAttribute(p) && p.name.getText() === "className",
+    );
+    return className?.initializer?.getText() ?? "";
+  }
+  return null;
+}
 
 function gatesTheNotes(source: string, condition: string): boolean {
   const name = condition.trim();
@@ -192,7 +246,7 @@ function gatesTheNotes(source: string, condition: string): boolean {
     "g",
   );
   for (const hit of source.matchAll(rendered)) {
-    if (PROTECTED_PANEL.test(hit[2])) return true;
+    if (NOTES.components.has(hit[2])) return true;
   }
   return false;
 }
@@ -258,15 +312,26 @@ is the state that reserved 64.9px in #10117.
 Floor found in: ${literal.getText().slice(0, 200)}
 Ternary conditions around it: ${branchConditions(literal).join(", ") || "(none)"}`,
       );
-    }
 
-    // A gated floor still has to be filled, or the gap returns the other way.
-    assert.match(
-      source,
-      /className="relative flex [^"]*\bgrow\b/,
-      `${resolved.label}: the card carries a floor but its painted surface has
-no \`grow\`, so short content leaves an unpainted gap inside the slot the
-floor reserved.`,
-    );
+      // A gated floor still has to be filled, or the gap returns the other way.
+      // The surface is this floor's own painted child, not any `grow` in the
+      // file: an alternate branch carrying one would answer for a surface that
+      // does not, and the desktop card's rail is never rendered by the browser
+      // suite that would otherwise catch it.
+      const surface = paintedSurface(literal);
+      assert.ok(
+        surface,
+        `${resolved.label}: cannot find the element painted inside the floored
+slot, so nothing checks that the floor is filled.`,
+      );
+      assert.match(
+        surface,
+        /\bgrow\b/,
+        `${resolved.label}: the floored slot's painted child has no \`grow\`, so
+short content leaves an unpainted gap inside the height the floor reserved.
+
+Painted child: ${surface.slice(0, 160)}`,
+      );
+    }
   });
 }

--- a/studio/frontend/tests/overlay-rail-floor-gating.test.ts
+++ b/studio/frontend/tests/overlay-rail-floor-gating.test.ts
@@ -4,34 +4,19 @@
 /**
  * A card in the bottom-right rail may not reserve height it does not paint.
  *
- * The rail is a bottom-anchored column, so reserved-but-unpainted height inside
- * a card does not disappear: it lifts everything the reader can see off the
- * corner. #10117 copied the desktop updater's
- * `min-h-[calc(117px+93px*var(--ui-font-scale,1))]` onto the llama.cpp banner
- * while making its changelog render only once opened, so the default state
- * reserved 204.2px and painted 147.3px and the whole stack sat 64.9px high.
- * #10229 fixed it.
+ * The rail is bottom-anchored, so dead space inside a card lifts everything
+ * visible off the corner. #10117 put an ungated floor on the llama.cpp banner
+ * whose changelog only renders once opened: 204.2px reserved, 147.3px painted.
+ * Fixed by #10229.
  *
- * Both suites ran on #10117 and both went green, and the reason is worth
- * keeping in mind while reading this file. The source suite of the day asserted
- * that the llama card CARRIED the floor and, in the same commit, that it did
- * not carry `shrink-0` - the bug was pinned as a contract. Any test that only
- * compares one card's class string against another's will agree that two cards
- * are consistent while both are wrong.
+ * The rule pinned here, rather than a spelling: a floor may only be reserved
+ * when the thing it protects is on screen. Two gates satisfy it, the CSS
+ * `has-[[data-slot=...]]:` and a React predicate that also renders the panel.
+ * The suite that missed #10117 asserted the floor was PRESENT, so a spelling
+ * check can be edited into agreement with the bug it should catch.
  *
- * So this file does not check for a spelling. It enumerates the rail's children
- * out of provider.tsx, follows each to its source, and applies one rule:
- *
- *   a floor may only be reserved when the thing it protects is on screen.
- *
- * Two gates satisfy it, and both are in use. `has-[[data-slot=...]]:` makes CSS
- * ask whether the panel rendered; a React predicate works if it is the same
- * predicate that renders the panel. A floor sitting in the `positioned` ternary
- * with no other gate - exactly what #10117 shipped - satisfies neither.
- *
- * Read from the source: the node suite has no DOM to compute styles in. The
- * geometry itself is checked in tests/studio/playwright_update_banner_layout.py,
- * which measures each slot against the surface painted inside it.
+ * Read from the source: the node suite has no DOM. The geometry itself is in
+ * tests/studio/playwright_update_banner_layout.py.
  */
 
 import assert from "node:assert/strict";
@@ -61,15 +46,9 @@ const provider = parse(src("app/provider.tsx"), "provider.tsx");
 const RAIL_ANCHOR = "pointer-events-none fixed bottom-0 right-4";
 
 /**
- * Every component that ends up in a rail, by tag name.
- *
- * Two sources, because neither is complete on its own. Literal children of an
- * anchored rail miss anything the Tauri layer receives through `{children}`,
- * which is how its llama, downloads and loaded-models cards arrive; today those
- * three are also listed literally in the browser rail, but a desktop-only card
- * would be invisible here. `positioned={false}` is the prop that puts a card in
- * a rail rather than on the corner by itself, so it catches those, and the
- * literal scan still catches a card that takes no such prop.
+ * Every component that ends up in a rail. Two sources: literal children of an
+ * anchored rail miss whatever the Tauri layer takes through `{children}`, and
+ * `positioned={false}` misses a card that takes no such prop.
  */
 function railChildren(): string[] {
   const names = new Set<string>();
@@ -82,7 +61,6 @@ function railChildren(): string[] {
       if (className?.getText().includes(RAIL_ANCHOR)) {
         for (const child of node.children) {
           const name = openingTag(child)?.tagName.getText();
-          // A lower-case tag is a plain element, not a card.
           if (name && /^[A-Z]/.test(name)) names.add(name);
         }
       }
@@ -105,10 +83,7 @@ function railChildren(): string[] {
   return [...names].sort();
 }
 
-/**
- * Where `name` is imported from in provider.tsx, resolved to a file on disk.
- * Barrels are followed one hop, which is as far as the rail's children go.
- */
+/** Where `name` is imported from, resolved on disk. Barrels followed one hop. */
 function sourceOf(name: string): { path: URL; label: string } | null {
   let specifier: string | null = null;
   for (const statement of provider.statements) {
@@ -133,7 +108,6 @@ function sourceOf(name: string): { path: URL; label: string } | null {
   const direct = resolve(base);
   if (direct) return { path: direct, label: base };
 
-  // A barrel: find `export { name } from "./x"` and follow it.
   const index = resolve(`${base}/index`);
   if (!index) return null;
   const barrel = readFileSync(index, "utf8");
@@ -147,23 +121,17 @@ function sourceOf(name: string): { path: URL; label: string } | null {
 }
 
 /**
- * Class tokens that reserve a minimum height, in any spelling.
- *
- * Not just `min-h-[calc(`: `min-h-52`, `min-h-[204px]` and a named utility
- * reserve height exactly as well, and a rule that only knows one spelling can
- * be retired by rewriting it. `min-h-0` is the opposite of a floor - it removes
- * the flex default of `auto` - so it is not one.
+ * Any spelling, since a rule that knows only `min-h-[calc(` is retired by
+ * rewriting it. `min-h-0` removes the flex `auto` default, so it is not a floor.
  */
 const FLOOR_TOKEN = /(^|:)min-h-(?!0$)\S+/;
 
-/** Class tokens of a literal. getText() keeps the quotes; they are not classes. */
+/** getText() keeps the quotes, which are not class tokens. */
 const classTokens = (literal: ts.Node): string[] =>
   literal.getText().replace(/["'`]/g, " ").split(/\s+/).filter(Boolean);
 
-/** Does this class token reserve a minimum height? */
 const isFloor = (token: string): boolean => FLOOR_TOKEN.test(token);
 
-/** String literals carrying a floor. */
 function floorLiterals(file: ts.SourceFile): ts.Node[] {
   const found: ts.Node[] = [];
   const visit = (node: ts.Node): void => {
@@ -191,12 +159,9 @@ function gatedByHas(literal: ts.Node): boolean {
 }
 
 /**
- * The conditions this literal is the `whenTrue` branch of, innermost first.
- *
- * Only `whenTrue`. A floor on the other side of a ternary applies when its
- * predicate is FALSE, which is the opposite of a gate: `showFailure ?
- * "shrink-0" : "<floor>"` - the shape #8367 shipped - floors every state
- * except the one state named, including the states with no notes to protect.
+ * `whenTrue` only. A floor in the other branch applies when its predicate is
+ * false, which is no gate at all: `showFailure ? "shrink-0" : "<floor>"`, the
+ * shape #8367 shipped, floors every state except the one named.
  */
 function branchConditions(literal: ts.Node): string[] {
   const conditions: string[] = [];
@@ -213,13 +178,9 @@ function branchConditions(literal: ts.Node): string[] {
 }
 
 /**
- * Does `condition` decide whether the PANEL THE FLOOR PROTECTS renders?
- *
- * Rendering something is not enough. `changelogAvailable` renders the changelog
- * toggle and is true while the panel is still closed, so a floor gated on it
- * reserves the panel's height on every collapsed card - #10117 exactly. The
- * predicate has to turn on with the notes, so the element it renders has to be
- * the notes.
+ * Rendering something is not enough: `changelogAvailable` renders the toggle and
+ * is true while the panel is closed, which is #10117 exactly. It must render the
+ * notes themselves.
  */
 const PROTECTED_PANEL = /(Notes|Changelog)/i;
 
@@ -260,9 +221,7 @@ for (const name of CHILDREN) {
     assert.ok(resolved, `<${name} /> did not resolve`);
     const file = parse(resolved.path, `${name}.tsx`);
     const source = readFileSync(resolved.path, "utf8");
-    // An inline minHeight cannot be gated by a class and is invisible to the
-    // analysis below, so the rail's geometry stays in CSS, as provider.tsx's
-    // own tests already require of the rail itself.
+    // Invisible to the analysis below, and the rail already keeps its geometry in CSS.
     assert.doesNotMatch(
       source,
       /\bminHeight\s*:/,
@@ -301,8 +260,7 @@ Ternary conditions around it: ${branchConditions(literal).join(", ") || "(none)"
       );
     }
 
-    // A gated floor still has to be filled, or the card paints short inside a
-    // slot it legitimately asked for and the gap comes back the other way.
+    // A gated floor still has to be filled, or the gap returns the other way.
     assert.match(
       source,
       /className="relative flex [^"]*\bgrow\b/,

--- a/studio/frontend/tests/overlay-rail-floor-gating.test.ts
+++ b/studio/frontend/tests/overlay-rail-floor-gating.test.ts
@@ -151,11 +151,10 @@ function floorLiterals(file: ts.SourceFile): ts.Node[] {
 }
 
 /**
- * The components that ARE the protected panel, and the `data-slot` names they
- * declare, both read out of the tree rather than matched by name. A substring
- * rule would accept a `<ChangelogToggle>`, and an unresolved `data-slot` would
- * accept `has-[[data-slot=card-footer]]:`, which an always-present footer makes
- * permanent. A panel is one that renders the shared notes layout root.
+ * The protected panels and the slots they declare, read out of the tree, not
+ * matched by name: a substring rule accepts a `<ChangelogToggle>` and a free
+ * `data-slot` accepts `card-footer`, which an always-present footer makes
+ * permanent. A panel is one rendering the shared notes layout root.
  */
 function notesPanels(): { components: Set<string>; slots: Set<string> } {
   const components = new Set<string>();
@@ -214,14 +213,11 @@ function branchConditions(literal: ts.Node): string[] {
  * is true while the panel is closed, which is #10117 exactly. It must render the
  * notes themselves.
  */
-/**
- * The className of the element painted inside the slot this floor is on: the
- * floor's own JSX element, then its first child element.
- */
+/** The className painted inside this floor's own slot: its element's first child. */
 function paintedSurface(literal: ts.Node): string | null {
   let node: ts.Node | undefined = literal;
   while (node && !ts.isJsxAttribute(node)) node = node.parent;
-  // attribute -> attributes -> opening tag -> the element that owns the children
+  // attribute -> attributes -> opening tag
   const opening = node?.parent?.parent;
   if (!opening || !ts.isJsxOpeningElement(opening)) return null;
   const owner = opening.parent;
@@ -275,7 +271,7 @@ for (const name of CHILDREN) {
     assert.ok(resolved, `<${name} /> did not resolve`);
     const file = parse(resolved.path, `${name}.tsx`);
     const source = readFileSync(resolved.path, "utf8");
-    // Invisible to the analysis below, and the rail already keeps its geometry in CSS.
+    // Invisible to the analysis below; the rail keeps its geometry in CSS.
     assert.doesNotMatch(
       source,
       /\bminHeight\s*:/,
@@ -313,11 +309,8 @@ Floor found in: ${literal.getText().slice(0, 200)}
 Ternary conditions around it: ${branchConditions(literal).join(", ") || "(none)"}`,
       );
 
-      // A gated floor still has to be filled, or the gap returns the other way.
-      // The surface is this floor's own painted child, not any `grow` in the
-      // file: an alternate branch carrying one would answer for a surface that
-      // does not, and the desktop card's rail is never rendered by the browser
-      // suite that would otherwise catch it.
+      // This floor's own painted child, not any `grow` in the file: an alternate
+      // branch carrying one would answer for a surface that does not.
       const surface = paintedSurface(literal);
       assert.ok(
         surface,

--- a/studio/frontend/tests/overlay-rail-floor-gating.test.ts
+++ b/studio/frontend/tests/overlay-rail-floor-gating.test.ts
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * A card in the bottom-right rail may not reserve height it does not paint.
+ *
+ * The rail is a bottom-anchored column, so reserved-but-unpainted height inside
+ * a card does not disappear: it lifts everything the reader can see off the
+ * corner. #10117 copied the desktop updater's
+ * `min-h-[calc(117px+93px*var(--ui-font-scale,1))]` onto the llama.cpp banner
+ * while making its changelog render only once opened, so the default state
+ * reserved 204.2px and painted 147.3px and the whole stack sat 64.9px high.
+ * #10229 fixed it.
+ *
+ * Both suites ran on #10117 and both went green, and the reason is worth
+ * keeping in mind while reading this file. The source suite of the day asserted
+ * that the llama card CARRIED the floor and, in the same commit, that it did
+ * not carry `shrink-0` - the bug was pinned as a contract. Any test that only
+ * compares one card's class string against another's will agree that two cards
+ * are consistent while both are wrong.
+ *
+ * So this file does not check for a spelling. It enumerates the rail's children
+ * out of provider.tsx, follows each to its source, and applies one rule:
+ *
+ *   a floor may only be reserved when the thing it protects is on screen.
+ *
+ * Two gates satisfy it, and both are in use. `has-[[data-slot=...]]:` makes CSS
+ * ask whether the panel rendered; a React predicate works if it is the same
+ * predicate that renders the panel. A floor sitting in the `positioned` ternary
+ * with no other gate - exactly what #10117 shipped - satisfies neither.
+ *
+ * Read from the source: the node suite has no DOM to compute styles in. The
+ * geometry itself is checked in tests/studio/playwright_update_banner_layout.py,
+ * which measures each slot against the surface painted inside it.
+ */
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+import { openingTag } from "./helpers/tsx-ast.ts";
+
+const src = (relative: string): URL =>
+  new URL(`../src/${relative}`, import.meta.url);
+
+const parse = (path: URL, name: string): ts.SourceFile =>
+  ts.createSourceFile(
+    name,
+    readFileSync(path, "utf8"),
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+const provider = parse(src("app/provider.tsx"), "provider.tsx");
+
+/** The rails, matched on the corner they are anchored to. */
+const RAIL_ANCHOR = "pointer-events-none fixed bottom-0 right-4";
+
+/** Every component rendered directly into a rail, by tag name. */
+function railChildren(): string[] {
+  const names = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxElement(node)) {
+      const opening = node.openingElement;
+      const className = opening.attributes.properties.find(
+        (p): p is ts.JsxAttribute =>
+          ts.isJsxAttribute(p) && p.name.getText() === "className",
+      );
+      if (className?.getText().includes(RAIL_ANCHOR)) {
+        for (const child of node.children) {
+          const tag = openingTag(child);
+          const name = tag?.tagName.getText();
+          // {children} in the Tauri layer is followed to its own rail by the
+          // second match; a lower-case tag is a plain element, not a card.
+          if (name && /^[A-Z]/.test(name)) names.add(name);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(provider, visit);
+  return [...names].sort();
+}
+
+/**
+ * Where `name` is imported from in provider.tsx, resolved to a file on disk.
+ * Barrels are followed one hop, which is as far as the rail's children go.
+ */
+function sourceOf(name: string): { path: URL; label: string } | null {
+  let specifier: string | null = null;
+  for (const statement of provider.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    if (bindings.elements.some((el) => el.name.getText() === name)) {
+      specifier = (statement.moduleSpecifier as ts.StringLiteral).text;
+    }
+  }
+  if (!specifier?.startsWith("@/")) return null;
+
+  const resolve = (relative: string): URL | null => {
+    for (const candidate of [`${relative}.tsx`, `${relative}.ts`]) {
+      const url = src(candidate);
+      if (existsSync(fileURLToPath(url))) return url;
+    }
+    return null;
+  };
+
+  const base = specifier.slice(2);
+  const direct = resolve(base);
+  if (direct) return { path: direct, label: base };
+
+  // A barrel: find `export { name } from "./x"` and follow it.
+  const index = resolve(`${base}/index`);
+  if (!index) return null;
+  const barrel = readFileSync(index, "utf8");
+  const re = new RegExp(
+    `export\\s*\\{[^}]*\\b${name}\\b[^}]*\\}\\s*from\\s*"\\./([^"]+)"`,
+  );
+  const hop = barrel.match(re);
+  if (!hop) return null;
+  const followed = resolve(`${base}/${hop[1]}`);
+  return followed ? { path: followed, label: `${base}/${hop[1]}` } : null;
+}
+
+/** Class tokens carrying a `min-h-[calc(...)]` floor, per string literal. */
+function floorLiterals(file: ts.SourceFile): ts.Node[] {
+  const found: ts.Node[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isStringLiteral(node) ||
+        ts.isNoSubstitutionTemplateLiteral(node) ||
+        ts.isTemplateExpression(node)) &&
+      node.getText().includes("min-h-[calc(")
+    ) {
+      found.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(file, visit);
+  return found;
+}
+
+/** Is every floor in `literal` gated by the CSS `:has()` on a rendered slot? */
+function gatedByHas(literal: ts.Node): boolean {
+  const tokens = literal
+    .getText()
+    .split(/\s+/)
+    .filter((token) => token.includes("min-h-[calc("));
+  return (
+    tokens.length > 0 &&
+    tokens.every((token) =>
+      /has-\[\[data-slot=[^\]]+\]\]:min-h-\[calc\(/.test(token),
+    )
+  );
+}
+
+/**
+ * The conditions this literal is the `whenTrue` branch of, innermost first.
+ *
+ * Only `whenTrue`. A floor on the other side of a ternary applies when its
+ * predicate is FALSE, which is the opposite of a gate: `showFailure ?
+ * "shrink-0" : "<floor>"` - the shape #8367 shipped - floors every state
+ * except the one state named, including the states with no notes to protect.
+ */
+function branchConditions(literal: ts.Node): string[] {
+  const conditions: string[] = [];
+  let node: ts.Node = literal;
+  let parent = node.parent;
+  while (parent && !ts.isJsxAttribute(parent)) {
+    if (ts.isConditionalExpression(parent) && parent.whenTrue === node) {
+      conditions.push(parent.condition.getText());
+    }
+    node = parent;
+    parent = parent.parent;
+  }
+  return conditions;
+}
+
+/**
+ * Does `condition` also decide whether an element renders?
+ *
+ * The point of the gate is that the floor and the panel it protects turn on
+ * together. A condition that only picks between two class strings - `positioned`
+ * being the one that mattered - reserves height for a panel it has no opinion
+ * about.
+ */
+function gatesAnElement(source: string, condition: string): boolean {
+  const name = condition.trim();
+  if (!/^[A-Za-z_$][\w$]*$/.test(name)) return false;
+  const rendered = new RegExp(
+    `\\b${name}\\b[^;{}]{0,160}?(\\?|&&)\\s*\\(?\\s*<[A-Za-z]`,
+  );
+  return rendered.test(source);
+}
+
+const CHILDREN = railChildren();
+
+test("the rail's children are all resolvable, or this file proves nothing", () => {
+  assert.ok(
+    CHILDREN.length >= 3,
+    `provider.tsx: found ${CHILDREN.length} cards in a rail anchored on
+"${RAIL_ANCHOR}". Either the rail moved or its children are no longer
+rendered inline, and every check below just skipped silently.`,
+  );
+  for (const name of CHILDREN) {
+    assert.ok(
+      sourceOf(name),
+      `provider.tsx: cannot follow <${name} /> to a source file, so its floor
+cannot be checked. Add the import path it resolves through.`,
+    );
+  }
+});
+
+for (const name of CHILDREN) {
+  test(`${name} reserves no height it may not paint`, () => {
+    const resolved = sourceOf(name);
+    assert.ok(resolved, `<${name} /> did not resolve`);
+    const file = parse(resolved.path, `${name}.tsx`);
+    const source = readFileSync(resolved.path, "utf8");
+    const literals = floorLiterals(file);
+    if (literals.length === 0) return; // No floor, nothing to gate.
+
+    for (const literal of literals) {
+      const gated =
+        gatedByHas(literal) ||
+        branchConditions(literal).some((condition) =>
+          gatesAnElement(source, condition),
+        );
+      assert.ok(
+        gated,
+        `${resolved.label}: a min-h-[calc(...)] floor is applied without being
+gated on the panel it exists to protect, so the card reserves height it may
+paint none of. In a bottom-anchored rail that dead space lifts every visible
+card off the corner. This is PR #10117, fixed by PR #10229.
+
+Gate it one of the two ways already in use:
+  has-[[data-slot=update-release-notes]]:min-h-[calc(...)]   (CSS)
+  changelogPanelOpen ? "min-h-[calc(...)]" : "shrink-0"      (React, using the
+    same predicate that renders the panel)
+
+Floor found in: ${literal.getText().slice(0, 200)}
+Ternary conditions around it: ${branchConditions(literal).join(", ") || "(none)"}`,
+      );
+    }
+
+    // A gated floor still has to be filled, or the card paints short inside a
+    // slot it legitimately asked for and the gap comes back the other way.
+    assert.match(
+      source,
+      /className="relative flex [^"]*\bgrow\b/,
+      `${resolved.label}: the card carries a floor but its painted surface has
+no \`grow\`, so short content leaves an unpainted gap inside the slot the
+floor reserved.`,
+    );
+  });
+}

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -713,10 +713,7 @@ def measure(page, label: str) -> dict:
             facts["gutterIsRail"] is False,
             f"scrolls={scrolls} gutterIsRail={facts['gutterIsRail']}",
         )
-    # A floor must not leave unpainted space around a compact card. Every card in
-    # the rail, not a named two: the regression this catches arrived on a card
-    # that had no floor at all the day before, and the rail is a bottom-anchored
-    # column, so one card's dead space lifts every card below it off the corner.
+    # The rail is bottom-anchored, so one card's dead space lifts the rest off the corner.
     cards = facts["railCards"]
     check(
         f"{label}: the rail has cards to judge",
@@ -733,10 +730,8 @@ def measure(page, label: str) -> dict:
             hole["above"] <= 1.0 and hole["below"] <= 1.0,
             f"dead={hole} painted-child={kid['painted']}",
         )
-    # And the stack as a whole still sits on the corner, measured off the card
-    # the reader can see rather than off the rail's own box. Only while the rail
-    # is not scrolling: under the cap the bottom card is where the scroll
-    # position puts it, and the fold is what RAIL_CORNER and REACH cover.
+    # Measured off the card the reader sees. Not while scrolling: under the cap the
+    # bottom card is wherever the scroll position puts it, which REACH covers.
     if cards and not facts["railScrolls"]:
         check(
             f"{label}: the bottom card is on the corner, not floating above it",
@@ -756,9 +751,7 @@ def measure(page, label: str) -> dict:
     return facts
 
 
-# The Downloads overlay is a transient card. #9849 made it always mount, so a
-# fresh install carried a download button on the corner with nothing behind it,
-# and it had to be reverted by #10298. Nothing failed while it was on main.
+# #9849 made the Downloads overlay always mount, and was reverted by #10298.
 DOWNLOADS = """
 () => {
   const rail = document.querySelector('[data-testid="overlay-rail"]');
@@ -792,9 +785,7 @@ def check_downloads_absent(page, label: str, expected_cards: int) -> None:
         f"{seen['panels']} download panel(s) mounted with an empty job list, "
         "which is the permanent corner FAB from #9849",
     )
-    # An exact count, not an absence: an absence also holds when the selector
-    # has rotted or nothing rendered at all, and that is the failure mode this
-    # whole file exists to avoid.
+    # An exact count: a bare absence also holds when the selector has rotted.
     check(
         f"{label}: the rail holds exactly the cards that are up",
         seen["cards"] == expected_cards,
@@ -1055,9 +1046,7 @@ def main() -> int:
                     )
                 measure(page, f"{size} {name} collapsed")
                 if path == "/":
-                    # Both update cards are up here and the models indicator is
-                    # off by default (#8346), so the rail is exactly two cards
-                    # unless something mounted that had nothing to show.
+                    # Both update cards up, indicator off by default (#8346).
                     check_downloads_absent(page, f"{size} {name}", 2)
                 page.screenshot(path = str(ART / f"{size}-{path.strip('/') or 'new-chat'}.png"))
 

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -274,6 +274,10 @@ INDICATOR_VIEWPORTS = [(921, 534), (768, 500)]
 # One roomy viewport and one capped viewport.
 NO_PREVIEW_VIEWPORTS = [(1440, 900), (921, 534)]
 
+# Where the cards sit, off both edges. The rail carries a shadow gutter, so this
+# is the cards' inset and not the rail's own box; see RAIL_CORNER below.
+CORNER_INSET_PX = 16
+
 # Where the rail actually is, against the corner it is anchored to. It was placed from JS for a while, lifting clear
 # of the boxes in the frame store, and drifted to the middle and the top of the window as those boxes and its own
 # cards changed. Nothing on the page may move it now.
@@ -464,7 +468,16 @@ MEASURE = """
   const snooze = q('[data-testid="web-update-snooze-button"]');
   const copy = q('[data-testid="web-update-copy-button"]');
   const footer = snooze ? snooze.closest('div').parentElement : null;
-  const rail = card ? card.parentElement : (llama ? llama.parentElement : null);
+  // By its own handle, not through whichever banner happens to be up: reaching
+  // the rail via a card finds nothing when no card is up, and "no cards" is a
+  // state the download panel and the loaded models card have to be judged in.
+  const rail = document.querySelector('[data-testid="overlay-rail"]')
+            || (card ? card.parentElement : (llama ? llama.parentElement : null));
+  // Cards in the rail's own flow. A dragged loaded models card is `fixed`
+  // somewhere else and says nothing about the rail.
+  const flowed = rail
+    ? [...rail.children].filter((kid) => getComputedStyle(kid).position === 'static')
+    : [];
   // The clipper is the card's inner surface, the one with overflow-hidden; the
   // rail-facing root above it is overflow-visible and clips nothing.
   const surface = card ? card.firstElementChild : null;
@@ -474,6 +487,30 @@ MEASURE = """
     // fold the reader can scroll to; what the card hides is gone for good.
     card: rect(card), llama: rect(llama),
     cardDead: dead(card), llamaDead: dead(llama),
+    // Every card in the rail, not only the two update banners. #10117 put an
+    // ungated floor on a card that had none the day before, so naming the cards
+    // to check is naming the ones that have already gone wrong.
+    railCards: flowed.map((kid) => ({
+      // Enough to name the offender in the failure without opening a browser.
+      tag: kid.tagName.toLowerCase(),
+      testid: kid.getAttribute('data-testid'),
+      cls: (kid.getAttribute('class') || '').slice(0, 120),
+      painted: kid.firstElementChild
+        ? (kid.firstElementChild.getAttribute('class') || '').slice(0, 80)
+        : null,
+      dead: dead(kid),
+    })),
+    // Where the bottom-most card ACTUALLY paints, against the corner it is
+    // anchored to. `fromBottom` in RAIL_CORNER comes off the rail's padding
+    // box, which is `fixed bottom-0` and so reports the intended offset however
+    // much dead air sits inside the last card. That is why the rail passed its
+    // own corner check all through #10117. This reads the painted surface.
+    lastPaintedFromBottom: (() => {
+      const last = flowed[flowed.length - 1];
+      const paint = last && (last.firstElementChild || last);
+      if (!paint) return null;
+      return Math.round((innerHeight - paint.getBoundingClientRect().bottom) * 10) / 10;
+    })(),
     // The same two, as much of them as the rail is SHOWING. Containment is
     // asked of these: a card the rail has folded away is not on screen at all,
     // and judging its unclipped rect against the viewport fails it for being
@@ -673,15 +710,36 @@ def measure(page, label: str) -> dict:
             facts["gutterIsRail"] is False,
             f"scrolls={scrolls} gutterIsRail={facts['gutterIsRail']}",
         )
-    # A floor must not leave unpainted space around a compact card.
-    for name in ("card", "llama"):
-        hole = facts[f"{name}Dead"]
+    # A floor must not leave unpainted space around a compact card. Every card in
+    # the rail, not a named two: the regression this catches arrived on a card
+    # that had no floor at all the day before, and the rail is a bottom-anchored
+    # column, so one card's dead space lifts every card below it off the corner.
+    cards = facts["railCards"]
+    check(
+        f"{label}: the rail has cards to judge",
+        len(cards) > 0,
+        f"railCards={cards}, so every dead-space check below passed vacuously",
+    )
+    for index, kid in enumerate(cards):
+        hole = kid["dead"]
         if hole is None:
             continue
+        who = kid["testid"] or kid["cls"] or f"{kid['tag']}#{index}"
         check(
-            f"{label}: the {name}'s slot reserves no height it does not paint",
+            f"{label}: {who} reserves no height it does not paint",
             hole["above"] <= 1.0 and hole["below"] <= 1.0,
-            f"{name}Dead={hole}",
+            f"dead={hole} painted-child={kid['painted']}",
+        )
+    # And the stack as a whole still sits on the corner, measured off the card
+    # the reader can see rather than off the rail's own box. Only while the rail
+    # is not scrolling: under the cap the bottom card is where the scroll
+    # position puts it, and the fold is what RAIL_CORNER and REACH cover.
+    if cards and not facts["railScrolls"]:
+        check(
+            f"{label}: the bottom card is on the corner, not floating above it",
+            facts["lastPaintedFromBottom"] == CORNER_INSET_PX,
+            f"lastPaintedFromBottom={facts['lastPaintedFromBottom']} "
+            f"(want {CORNER_INSET_PX}) last={cards[-1]}",
         )
     # The notes are allowed to yield all of their height, and do; the controls are not, and a card clipped to nothing is
     # the failure being tested for.
@@ -693,6 +751,53 @@ def measure(page, label: str) -> dict:
             f"{name}={box}",
         )
     return facts
+
+
+# The Downloads overlay is a transient card. #9849 made it always mount, so a
+# fresh install carried a download button on the corner with nothing behind it,
+# and it had to be reverted by #10298. Nothing failed while it was on main.
+DOWNLOADS = """
+() => {
+  const rail = document.querySelector('[data-testid="overlay-rail"]');
+  if (!rail) return null;
+  return {
+    // The panel and its collapsed FAB. Neither may exist with no jobs.
+    panels: document.querySelectorAll('.hub-download-panel, .hub-download-fab').length,
+    // Slots, not pixels: a panel that renders a wrapper around nothing is
+    // invisible but still takes a flex slot and its gap-2, which pushes the
+    // card that is meant to hold the corner up off it.
+    cards: [...rail.children].filter(
+      (kid) => getComputedStyle(kid).position === 'static').length,
+  };
+}
+"""
+
+
+def check_downloads_absent(page, label: str, expected_cards: int) -> None:
+    """With no transfers, the Downloads overlay must not be in the rail at all."""
+    seen = page.evaluate(DOWNLOADS)
+    check(
+        f"{label}: the rail is reachable by its own handle",
+        seen is not None,
+        "no [data-testid=overlay-rail] on the page, so the two checks below prove nothing",
+    )
+    if seen is None:
+        return
+    check(
+        f"{label}: no Downloads overlay while there is nothing downloading",
+        seen["panels"] == 0,
+        f"{seen['panels']} download panel(s) mounted with an empty job list, "
+        "which is the permanent corner FAB from #9849",
+    )
+    # An exact count, not an absence: an absence also holds when the selector
+    # has rotted or nothing rendered at all, and that is the failure mode this
+    # whole file exists to avoid.
+    check(
+        f"{label}: the rail holds exactly the cards that are up",
+        seen["cards"] == expected_cards,
+        f"cards={seen['cards']} want={expected_cards}; an extra slot is an "
+        "overlay mounting when it has nothing to show",
+    )
 
 
 def stub(payload: dict):
@@ -946,6 +1051,11 @@ def main() -> int:
                         "nothing to measure, so every other check is vacuous",
                     )
                 measure(page, f"{size} {name} collapsed")
+                if path == "/":
+                    # Both update cards are up here and the models indicator is
+                    # off by default (#8346), so the rail is exactly two cards
+                    # unless something mounted that had nothing to show.
+                    check_downloads_absent(page, f"{size} {name}", 2)
                 page.screenshot(path = str(ART / f"{size}-{path.strip('/') or 'new-chat'}.png"))
 
                 toggle = page.locator('[data-testid="web-update-release-notes-toggle"]')
@@ -1044,7 +1154,9 @@ def main() -> int:
             )
             check(
                 f"{width}x{height}: the rail is still in its bottom-right corner",
-                seen is not None and seen["fromBottom"] == 16 and seen["fromRight"] == 16,
+                seen is not None
+                and seen["fromBottom"] == CORNER_INSET_PX
+                and seen["fromRight"] == CORNER_INSET_PX,
                 f"{seen}, so the rail has left the corner it is anchored to",
             )
             check(

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -288,9 +288,10 @@ RAIL_CORNER = """
   const rail = card.parentElement;
   const a = rail.getBoundingClientRect();
   // Cards in the rail's own flow. A dragged loaded models card is `fixed`
-  // somewhere else and says nothing about the rail.
+  // somewhere else and says nothing about the rail; `relative` and `sticky`
+  // still take part in layout, so only the out-of-flow pair is excluded.
   const flowed = Array.from(rail.children).filter(
-    (kid) => getComputedStyle(kid).position === 'static',
+    (kid) => !['absolute', 'fixed'].includes(getComputedStyle(kid).position),
   );
   return {
     rail: {top: Math.round(a.top), bottom: Math.round(a.bottom),
@@ -474,9 +475,11 @@ MEASURE = """
   const rail = document.querySelector('[data-testid="overlay-rail"]')
             || (card ? card.parentElement : (llama ? llama.parentElement : null));
   // Cards in the rail's own flow. A dragged loaded models card is `fixed`
-  // somewhere else and says nothing about the rail.
+  // somewhere else and says nothing about the rail; `relative` and `sticky`
+  // still take part in layout, so only the out-of-flow pair is excluded.
   const flowed = rail
-    ? [...rail.children].filter((kid) => getComputedStyle(kid).position === 'static')
+    ? [...rail.children].filter(
+        (kid) => !['absolute', 'fixed'].includes(getComputedStyle(kid).position))
     : [];
   // The clipper is the card's inner surface, the one with overflow-hidden; the
   // rail-facing root above it is overflow-visible and clips nothing.
@@ -767,7 +770,7 @@ DOWNLOADS = """
     // invisible but still takes a flex slot and its gap-2, which pushes the
     // card that is meant to hold the corner up off it.
     cards: [...rail.children].filter(
-      (kid) => getComputedStyle(kid).position === 'static').length,
+      (kid) => !['absolute', 'fixed'].includes(getComputedStyle(kid).position)).length,
   };
 }
 """


### PR DESCRIPTION
## Summary

Two regressions in the bottom-right overlay rail shipped to `main` and had to be undone by hand. Neither failed a test on the way in. This adds the coverage that would have caught both, at a cost of about a second inside the existing `npm test` step.

- #9849 dropped `jobKeys.length === 0` from the Downloads panel's early return, so a fresh install carried a download FAB on the corner with nothing behind it. Reverted by #10298.
- #10117 copied the desktop updater's `min-h` floor onto the llama.cpp banner while making its changelog render only once opened, so the card reserved 204.2px and painted 147.3px and the stack sat 64.9px off the corner. Fixed by #10229.

## Why CI did not catch the second one

Both suites ran on #10117 and both passed. Three separate reasons, none of them a missing workflow:

1. No fixture ever produced the empty-notes state. `playwright_update_banner_layout.py` only routed `/api/studio/release-notes` with a previewable body, and only measured the llama changelog opened. The `return null` branch in `release-notes-panel.tsx`, live since #7432, was never rendered in a browser.
2. Every geometric check read the outer slot. `MEASURE` selects `[data-testid="llama-update-banner"]`, which is the element carrying the `min-h`. A card reserving 204px and painting 147px at the top of it satisfies "inside the viewport", "does not overlap" and "height > 1". `RAIL_CORNER.fromBottom` is read off the rail's padding box, which is `fixed bottom-0` and so reports the intended 16 however much dead air sits inside the last card.
3. The source suite was edited in the same commit as the regression. #10117 added `assert.doesNotMatch(llamaRoot, /\bshrink-0\b/)`, which turned the bug into a pinned contract. A test that compares one card's class string against another's will agree that two cards are consistent while both are wrong.

#10229 closed the first two for the two update banners specifically. It did not generalise either.

## Changes

`studio/frontend/tests/download-panel-not-permanent.test.ts`, new. Matches the guard through the AST and finds the `jobKeys` binding by its initializer rather than by name, so reformatting, a rename, or an extra clause in the condition cannot quietly retire it. Also pins `min-h-0` on the rail-facing branch and the panel's position above the loaded models card, which is the one overlay meant to hold the corner.

`studio/frontend/tests/overlay-rail-floor-gating.test.ts`, new. Enumerates the rail's children out of `provider.tsx`, follows each to its source through the barrels, and applies one rule rather than a spelling:

> a floor may only be reserved when the thing it protects is on screen.

Both gates in use satisfy it: `has-[[data-slot=update-release-notes]]:` for the web and desktop cards, and a React predicate for the llama card provided that predicate also renders the panel. Only the `whenTrue` branch counts, since a floor on the other side of a ternary applies when its predicate is false, which is the opposite of a gate and is the shape #8367 shipped. A floor sitting in the `positioned` ternary with no other gate, which is what #10117 shipped, satisfies neither. The file refuses to run vacuously: if the rail anchor changes it fails saying so rather than finding zero cards.

`tests/studio/playwright_update_banner_layout.py`. The dead-space probe now runs over every flowed card in the rail instead of the two named banners, reporting the offending card's testid and class so a failure names it. The corner is measured off the bottom-most painted surface rather than the rail's padding box. A new pass asserts the Downloads overlay is absent while nothing is downloading, by exact card count rather than by absence, since a bare absence also holds when the selector has rotted.

`studio/frontend/src/app/provider.tsx`. `data-testid="overlay-rail"` on both rails. The probe reached the rail through whichever banner happened to be up, which finds nothing when none is, and that is exactly the state the download panel has to be judged in.

## Verification

Both new tests were checked against the commits that shipped the bugs, since a regression test that does not fail there is not one:

- Applying #9849's one-line change makes `download-panel-not-permanent.test.ts` fail with its intended message. Reverting makes it pass.
- Restored to `5e774c260` (#10117), `overlay-rail-floor-gating.test.ts` fails on all three banners and names `positioned` as the ternary condition it found, which is the diagnosis. At `a860357c5` (#8367) it fails on the anti-vacuity guard instead, because the rail carried a different anchor then.

Other checks:

- Full frontend suite: 6889 passed, 0 failed, 28.4s. The two new files add 9 tests and about a second between them.
- `npm run typecheck`: passed.
- Biome and ruff clean on the changed files. `provider.tsx` carries 3 pre-existing `useExhaustiveDependencies` errors on `main`, unchanged here.
- `tests/studio/test_overlay_layering.py`, `test_update_release_notes.py`, `test_banner_update_delay_override.py`, `test_windows_ui_lanes_are_isolated.py`: 207 passed.

The Playwright changes themselves have not been run: that lane needs a booted Studio behind `BASE_URL`. They get their first real run in the `banner` shard here.

## CI

No workflow changes. Both new files live under `studio/frontend/**`, which is a `pull_request` path filter of `studio-frontend-ci.yml`, and `npm test` globs `tests/**/*.test.ts` in both the Ubuntu build job and the Windows unit job, so they gate every frontend PR twice. The Playwright edits and `provider.tsx` are under `studio/**` and `tests/studio/**`, which trigger the `banner` shard of `studio-ui-smoke.yml`.