### PR TITLE
Studio: voice conversation mode on the current audio stack (reconstruction of #6527, part A)

### DIFF
--- a/studio/backend/core/inference/audio_codecs.py
+++ b/studio/backend/core/inference/audio_codecs.py
@@ -171,10 +171,7 @@ class AudioCodecManager:
         device = self._codec_devices.get("snac", device)
         try:
             import torch as _torch
-
-            return self._snac_ids_to_waveform(
-                _torch.tensor([token_ids], dtype = _torch.long), device
-            )
+            return self._snac_ids_to_waveform(_torch.tensor([token_ids], dtype = _torch.long), device)
         except ValueError:
             return None
 

--- a/studio/backend/core/inference/audio_codecs.py
+++ b/studio/backend/core/inference/audio_codecs.py
@@ -78,6 +78,18 @@ class AudioCodecManager:
         else:
             raise ValueError(f"Unknown audio_type: {audio_type}")
 
+    def has_codec(self, audio_type: str) -> bool:
+        """Whether the codec weights for ``audio_type`` are currently loaded."""
+        if audio_type == "snac":
+            return self._snac_model is not None
+        if audio_type == "bicodec":
+            return self._bicodec_tokenizer is not None
+        if audio_type == "dac":
+            return self._dac_audio_codec is not None
+        if audio_type == "csm":
+            return True  # decoding is built into the model
+        return False
+
     # ── Lazy loaders ─────────────────────────────────────────────
 
     def _load_snac(self, device: str) -> None:
@@ -144,12 +156,34 @@ class AudioCodecManager:
     # ── Decoders ─────────────────────────────────────────────────
 
     def decode_snac(self, generated_ids: torch.Tensor, device: str) -> Tuple[bytes, int]:
-        """Decode SNAC tokens (Orpheus) into WAV bytes.
+        """Decode SNAC tokens (Orpheus) into WAV bytes. Returns (wav_bytes, 24000)."""
+        waveform = self._snac_ids_to_waveform(generated_ids, device)
+        return _numpy_to_wav_bytes(waveform, 24000), 24000
 
-        Finds the START_OF_SPEECH (128257) marker, extracts codes after it,
-        strips EOS (128258), redistributes 7-per-frame codes into 3 SNAC layers.
-        Returns (wav_bytes, 24000).
-        """
+    def decode_snac_pcm(self, token_ids: list, device: str):
+        """Decode a list of Orpheus token ids into a float32 waveform (numpy), 24kHz.
+
+        Same math as decode_snac but returns the raw samples, so the streaming path
+        can decode the growing token list and slice off the newly-finished samples.
+        Returns None if there aren't enough valid codes yet (fewer than one frame)."""
+        # Same rule as decode(): where the codec is actually resident wins, or a
+        # tensor built on the other device fails the decode outright.
+        device = self._codec_devices.get("snac", device)
+        try:
+            import torch as _torch
+
+            return self._snac_ids_to_waveform(
+                _torch.tensor([token_ids], dtype = _torch.long), device
+            )
+        except ValueError:
+            return None
+
+    def _snac_ids_to_waveform(self, generated_ids: torch.Tensor, device: str):
+        """Token ids -> float32 waveform (numpy). Shared by one-shot + streaming decode.
+
+        Finds the START_OF_SPEECH (128257) marker, extracts codes after it, strips
+        EOS (128258), redistributes 7-per-frame codes into 3 SNAC layers, decodes."""
+        # Find START_OF_SPEECH token (128257)
         token_indices = (generated_ids == 128257).nonzero(as_tuple = True)
         if len(token_indices[1]) > 0:
             cropped = generated_ids[:, token_indices[1][-1] + 1 :]
@@ -185,8 +219,7 @@ class AudioCodecManager:
         with torch.no_grad():
             audio = self._snac_model.decode(snac_codes)
 
-        waveform = audio.squeeze().cpu().numpy()
-        return _numpy_to_wav_bytes(waveform, 24000), 24000
+        return audio.squeeze().cpu().numpy()
 
     def decode_csm(self, audio_values: torch.Tensor) -> Tuple[bytes, int]:
         """Decode CSM output (already a waveform). Returns (wav_bytes, 24000)."""

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25862,7 +25862,11 @@ class LlamaCppBackend:
         self._clear_server_pid(self._pid_slot)
 
     @classmethod
-    def _record_server_pid(cls, pid: int, slot: str = "") -> None:
+    def _record_server_pid(
+        cls,
+        pid: int,
+        slot: str = "",
+    ) -> None:
         """Best-effort record of the spawned llama-server PID for orphan reaping.
 
         Stores ``pid:starttime`` so a later startup can reject a PID that has
@@ -26006,9 +26010,7 @@ class LlamaCppBackend:
             return 0
         paths = [base]
         try:
-            paths += sorted(
-                q for q in base.parent.glob(f"{base.stem}-*{base.suffix}") if q != base
-            )
+            paths += sorted(q for q in base.parent.glob(f"{base.stem}-*{base.suffix}") if q != base)
         except Exception:
             pass
         return sum(cls._reap_pidfile(q) for q in paths)
@@ -32693,6 +32695,7 @@ class LlamaCppBackend:
     # parallelizes token generation, but the codec (SNAC/BiCodec) is one shared
     # torch model on the GPU, so decodes must not overlap.
     import threading as _threading
+
     _codec_decode_lock = _threading.Lock()
     # The chat slot and the voice slot can both hold a GGUF TTS model, and they share
     # this one manager. A per-instance "I loaded it" flag is not enough to decide who
@@ -32799,7 +32802,7 @@ class LlamaCppBackend:
             cut = max(0, onset - preroll)
             if cut <= 0:
                 return wav_bytes  # already starts promptly; nothing to trim
-            trimmed = mono[cut * frame:]
+            trimmed = mono[cut * frame :]
             if trimmed.size < frame:
                 return wav_bytes
             buf = io.BytesIO()
@@ -32846,7 +32849,9 @@ class LlamaCppBackend:
 
     @staticmethod
     def _trim_leading_word(
-        wav_bytes: bytes, sample_rate: int, expected_ms: Optional[float] = None
+        wav_bytes: bytes,
+        sample_rate: int,
+        expected_ms: Optional[float] = None,
     ) -> bytes:
         """Slice the leading spoken speaker name off Orpheus audio on low quants.
 
@@ -32912,7 +32917,7 @@ class LlamaCppBackend:
             if gap_end > onset + span_cap or gap_end >= n:
                 return wav_bytes
             cut = max(name_end + 1, gap_end - f(40))
-            trimmed = mono[cut * frame:]
+            trimmed = mono[cut * frame :]
             if trimmed.size < frame:
                 return wav_bytes
             buf = io.BytesIO()
@@ -32988,9 +32993,8 @@ class LlamaCppBackend:
         # audio model (e.g. a speech-LLM chat model) can tear it down while this
         # voice slot stays loaded -- then decode() would hit None. Re-ensure our
         # codec here so the voice slot survives chat-model swaps.
-        if (
-            LlamaCppBackend._codec_mgr is None
-            or not LlamaCppBackend._codec_mgr.has_codec(audio_type)
+        if LlamaCppBackend._codec_mgr is None or not LlamaCppBackend._codec_mgr.has_codec(
+            audio_type
         ):
             self.init_audio_codec(audio_type)
 
@@ -33139,9 +33143,8 @@ class LlamaCppBackend:
         clip). Use the one-shot generate_audio_response where the name-trim matters."""
         if audio_type != "snac":
             raise RuntimeError("Streaming TTS is currently SNAC (Orpheus) only.")
-        if (
-            LlamaCppBackend._codec_mgr is None
-            or not LlamaCppBackend._codec_mgr.has_codec(audio_type)
+        if LlamaCppBackend._codec_mgr is None or not LlamaCppBackend._codec_mgr.has_codec(
+            audio_type
         ):
             self.init_audio_codec(audio_type)
 
@@ -33177,7 +33180,7 @@ class LlamaCppBackend:
         # Preference only: decode_snac_pcm pins it to where the codec actually lives.
         device = "cuda" if _torch.cuda.is_available() and not self.holds_no_vram else "cpu"
         HOLDBACK = int(0.08 * 24000)  # 80 ms right-context held back for clean seams
-        DECODE_EVERY = 56             # ~8 SNAC frames (7 tokens each) between decodes
+        DECODE_EVERY = 56  # ~8 SNAC frames (7 tokens each) between decodes
 
         ids: list = []
         state = {"emitted": 0}
@@ -33189,7 +33192,7 @@ class LlamaCppBackend:
             end = len(wave) if final else max(0, len(wave) - HOLDBACK)
             if end <= state["emitted"]:
                 return b""
-            chunk = wave[state["emitted"]:end]
+            chunk = wave[state["emitted"] : end]
             state["emitted"] = end
             pcm = _np.clip(chunk, -1.0, 1.0)
             return (pcm * 32767.0).astype("<i2").tobytes()
@@ -33198,16 +33201,14 @@ class LlamaCppBackend:
         with httpx.Client(
             timeout = httpx.Timeout(300, connect = 10), headers = self._auth_headers
         ) as client:
-            with client.stream(
-                "POST", f"{self.base_url}/completion", json = payload
-            ) as resp:
+            with client.stream("POST", f"{self.base_url}/completion", json = payload) as resp:
                 if resp.status_code != 200:
                     raise RuntimeError(f"llama-server returned {resp.status_code}")
                 for line in resp.iter_lines():
                     if not line or not line.startswith("data:"):
                         continue
                     try:
-                        obj = _json.loads(line[len("data:"):].strip())
+                        obj = _json.loads(line[len("data:") :].strip())
                     except _json.JSONDecodeError:
                         continue
                     for p in obj.get("completion_probabilities", []) or []:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6184,6 +6184,13 @@ class LlamaCppBackend:
         3. unload_model(): terminate the subprocess
     """
 
+    # Which llama-server slot an instance is. "" is the chat slot; the voice slot
+    # sets its own so the two pidfile records cannot overwrite each other. Declared
+    # on the class as well as in __init__ because teardown reads it, and teardown
+    # also runs on a backend built through __new__ (a partially constructed one, and
+    # the stubs the tests stand in for it).
+    _pid_slot: str = ""
+
     def __init__(self, *, manages_processes: bool = True):
         """``manages_processes = False`` builds an INERT probe.
 
@@ -6484,6 +6491,11 @@ class LlamaCppBackend:
         self._is_audio: bool = False
         self._audio_type: Optional[str] = None
         self._audio_probed: bool = False
+        # Set when THIS instance called init_audio_codec(); guards codec teardown
+        # so the voice slot's codec survives main-slot unloads.
+        self._owns_codec: bool = False
+        self._pid_slot = ""
+        self._n_parallel: int = 1  # --parallel slots the current server launched with
         # Audio INPUT capability (distinct from _is_audio, which is TTS output).
         self._has_audio_input: bool = False
         # Video INPUT capability, from llama-server's /props modalities. True
@@ -17967,7 +17979,7 @@ class LlamaCppBackend:
         )
         # Cross-session backstop: record the PID so a later startup can reap this
         # server if parent-death cleanup did not run (macOS / best-effort failure).
-        self._record_server_pid(self._process.pid)
+        self._record_own_server_pid(self._process.pid)
 
         # Start background thread to drain stdout and prevent pipe deadlock
         self._stdout_thread = threading.Thread(
@@ -18589,6 +18601,9 @@ class LlamaCppBackend:
 
             # Set identifier early so _read_gguf_metadata can use it (DeepSeek).
             self._model_identifier = model_identifier
+            # Remember the launched --parallel so callers can detect a change and
+            # force a reload (the voice slot exposes this to hot-swap slot count).
+            self._n_parallel = n_parallel
 
             # Auto resolves to DSpark whenever a sidecar is available and this
             # binary can run it: 1.84x decode on 4x B200 and 1.91x on one, against
@@ -23256,7 +23271,7 @@ class LlamaCppBackend:
                             **_windows_hidden_subprocess_kwargs(),
                             **_child_popen_kwargs(),
                         )
-                        self._record_server_pid(self._process.pid)
+                        self._record_own_server_pid(self._process.pid)
                         # is_active covers it from here, so drop the pre-spawn flag.
                         self._memory_launch_pending = False
 
@@ -25778,7 +25793,7 @@ class LlamaCppBackend:
                 except Exception:
                     pass
             self._process = None
-            self._clear_server_pid()
+            self._clear_own_server_pid()
             # Clear healthy so a /load during the replacement's warm-up can't
             # short-circuit against the previous server's health (#5401).
             self._healthy = False
@@ -25813,12 +25828,47 @@ class LlamaCppBackend:
             return None
 
     @classmethod
-    def _record_server_pid(cls, pid: int) -> None:
+    def _slot_pidfile_path(cls, slot: str = "") -> Optional[Path]:
+        """Pidfile for one llama-server slot, derived from the chat slot's path.
+
+        Two slots can run at once -- the chat model and the voice (TTS) model each own
+        a llama-server. With one shared record whichever spawned second overwrote the
+        first, so after an unclean exit the orphan reaper knew about only one of the
+        two and the other kept its memory. The chat slot keeps the historical filename
+        so an orphan recorded by an older build is still found.
+        """
+        base = cls._server_pidfile_path()
+        if base is None or not slot:
+            return base
+        return base.with_name(f"{base.stem}-{slot}{base.suffix}")
+
+    def _record_own_server_pid(self, pid: int) -> None:
+        """Record this backend's llama-server PID under its own slot key.
+
+        The chat slot calls ``_record_server_pid`` with the single argument it has
+        always taken, so the seam stays exactly as it was for everything that stubs
+        it. Only a named slot -- today just the voice slot -- passes a key.
+        """
+        if not self._pid_slot:
+            self._record_server_pid(pid)
+            return
+        self._record_server_pid(pid, self._pid_slot)
+
+    def _clear_own_server_pid(self) -> None:
+        """Remove this backend's own slot pidfile. Mirrors _record_own_server_pid."""
+        if not self._pid_slot:
+            self._clear_server_pid()
+            return
+        self._clear_server_pid(self._pid_slot)
+
+    @classmethod
+    def _record_server_pid(cls, pid: int, slot: str = "") -> None:
         """Best-effort record of the spawned llama-server PID for orphan reaping.
 
         Stores ``pid:starttime`` so a later startup can reject a PID that has
         since been recycled to a different process (see ``_pid_start_identity``).
         A bare ``pid`` (no identity) is still accepted on read for compatibility.
+        ``slot`` keys the record so a second slot cannot overwrite the first's.
         """
         # Track it generically too: the pidfile holds one server, while the
         # process-lifetime record covers every child and is what the startup
@@ -25828,7 +25878,7 @@ class LlamaCppBackend:
             adopt_pid(pid)
         except Exception as e:
             logger.debug(f"Could not track llama-server for lifetime sweep: {e}")
-        path = cls._server_pidfile_path()
+        path = cls._slot_pidfile_path(slot)
         if path is None:
             return
         try:
@@ -25838,9 +25888,9 @@ class LlamaCppBackend:
             logger.debug(f"Could not write llama-server pidfile: {e}")
 
     @classmethod
-    def _clear_server_pid(cls) -> None:
-        """Best-effort removal of the llama-server pidfile."""
-        path = cls._server_pidfile_path()
+    def _clear_server_pid(cls, slot: str = "") -> None:
+        """Best-effort removal of one slot's llama-server pidfile."""
+        path = cls._slot_pidfile_path(slot)
         if path is None:
             return
         try:
@@ -25946,6 +25996,25 @@ class LlamaCppBackend:
 
     @classmethod
     def _reap_recorded_pid(cls) -> int:
+        """Reap every recorded llama-server orphan, one per slot.
+
+        Each slot writes its own pidfile (see _slot_pidfile_path), so this sweeps the
+        chat slot's record and every sibling slot record beside it rather than only one
+        path. Returns the total killed."""
+        base = cls._server_pidfile_path()
+        if base is None:
+            return 0
+        paths = [base]
+        try:
+            paths += sorted(
+                q for q in base.parent.glob(f"{base.stem}-*{base.suffix}") if q != base
+            )
+        except Exception:
+            pass
+        return sum(cls._reap_pidfile(q) for q in paths)
+
+    @classmethod
+    def _reap_pidfile(cls, path: Path) -> int:
         """Kill the exact llama-server PID recorded at spawn, but only when it is a
         genuine orphan -- its parent (the Unsloth that spawned it) is gone. This is
         the cross-session backstop the parent-death reaper (Job Object /
@@ -25960,8 +26029,7 @@ class LlamaCppBackend:
         and the llama-server name check, so unrelated user processes are never
         touched. SIGKILL falls back to SIGTERM on Windows, where os.kill maps it to
         TerminateProcess and SIGKILL is undefined."""
-        path = cls._server_pidfile_path()
-        if path is None or not path.exists():
+        if not path.exists():
             return 0
 
         pid = -1
@@ -27692,6 +27760,16 @@ class LlamaCppBackend:
                 elif now - last_chunk_at >= stall_timeout_s:
                     raise httpx.ReadTimeout("The model stopped producing tokens mid-response.")
                 continue
+            except httpx.RequestError:
+                # A barge-in cancel closes the upstream response mid-read, which
+                # surfaces here as a RequestError (e.g. ReadError / WinError 10038).
+                # That is an expected cancellation, not a failure -- stop cleanly,
+                # same as the top-of-loop cancel check above, so a GeneratorExit
+                # never has to propagate up the async streaming wrapper (which was
+                # logging "coroutine ignored GeneratorExit" on every interruption).
+                if cancel_event is not None and cancel_event.is_set():
+                    return
+                raise
 
     @staticmethod
     def _set_stream_read_timeout(response: "httpx.Response", read_timeout_s: float) -> None:
@@ -32605,14 +32683,53 @@ class LlamaCppBackend:
         ),
     }
 
-    _codec_mgr = None  # Shared AudioCodecManager instance
+    # orpheus-3b-0.1-ft speaker names. Orpheus is a named-voice model: the prompt
+    # "voice: text" pins the speaker. Without the prefix it free-runs a random
+    # voice every utterance, which is why the voice kept changing. Fallback: tara.
+    _ORPHEUS_VOICES = ("tara", "leah", "jess", "leo", "dan", "mia", "zac", "zoe")
 
-    @staticmethod
-    def _unload_audio_codec() -> None:
-        if LlamaCppBackend._codec_mgr is None:
+    _codec_mgr = None  # Shared AudioCodecManager instance
+    # Serializes codec decode across concurrent --parallel synths: llama-server
+    # parallelizes token generation, but the codec (SNAC/BiCodec) is one shared
+    # torch model on the GPU, so decodes must not overlap.
+    import threading as _threading
+    _codec_decode_lock = _threading.Lock()
+    # The chat slot and the voice slot can both hold a GGUF TTS model, and they share
+    # this one manager. A per-instance "I loaded it" flag is not enough to decide who
+    # may free it: whichever slot unloaded first would drop the codec the other is
+    # still decoding through, and that slot's next generate_audio_response() would
+    # then dereference a None _codec_mgr. Count the slots holding it and free on the
+    # last release. Guarded because loads and unloads run on different threads.
+    _codec_owners: int = 0
+    _codec_owner_lock = _threading.Lock()
+
+    def _claim_audio_codec(self) -> None:
+        """Register this slot as a holder of the shared codec. Idempotent per slot."""
+        with LlamaCppBackend._codec_owner_lock:
+            if self._owns_codec:
+                return
+            self._owns_codec = True
+            LlamaCppBackend._codec_owners += 1
+
+    def _unload_audio_codec(self) -> None:
+        """Release this slot's claim; free the shared codec once nobody holds it."""
+        with LlamaCppBackend._codec_owner_lock:
+            if self._owns_codec:
+                self._owns_codec = False
+                LlamaCppBackend._codec_owners = max(0, LlamaCppBackend._codec_owners - 1)
+            if LlamaCppBackend._codec_owners > 0:
+                # Somebody else is still decoding through it. Never free it here:
+                # that is the whole point of counting.
+                return
+            # Zero owners and a manager still installed means it was never claimed --
+            # a load cancelled between constructing the manager and claiming it, which
+            # is exactly when the cancel path calls this. An unowned manager has to be
+            # freed or it is leaked for the life of the process.
+            mgr = LlamaCppBackend._codec_mgr
+            LlamaCppBackend._codec_mgr = None
+        if mgr is None:
             return
-        LlamaCppBackend._codec_mgr.unload()
-        LlamaCppBackend._codec_mgr = None
+        mgr.unload()
         import torch
 
         if torch.cuda.is_available():
@@ -32641,12 +32758,204 @@ class LlamaCppBackend:
             model_repo_path = os.path.abspath(repo_path)
 
         LlamaCppBackend._codec_mgr.load_codec(audio_type, device, model_repo_path = model_repo_path)
+        self._claim_audio_codec()
         logger.info(f"Loaded audio codec for GGUF TTS: {audio_type}")
+
+    def _orpheus_voice_prefix_ok(self) -> bool:
+        """Whether the loaded Orpheus GGUF quant is high enough to treat a
+        "voice: " prefix as a speaker cue. Ultra-low quants (IQ1/IQ2/Q2) read the
+        prefix aloud instead, stapling the speaker name into the audio, so skip it
+        for those. The quant tag lives in both the variant and the file name."""
+        tag = f"{self._hf_variant or ''} {self._gguf_path or ''}".lower()
+        return not any(bad in tag for bad in ("iq1", "iq2", "q2_k"))
+
+    @staticmethod
+    def _trim_leading_silence(wav_bytes: bytes, sample_rate: int) -> bytes:
+        """Cut the dead air Orpheus emits before speech starts, keeping a ~40 ms
+        pre-roll so the first consonant's attack isn't clipped. This is straight
+        first-audio latency: the user waits through it before hearing anything.
+        Returns the audio unchanged on any failure or if there's no clear onset."""
+        try:
+            import io
+
+            import numpy as np
+            import soundfile as sf
+
+            data, sr = sf.read(io.BytesIO(wav_bytes), dtype = "float32")
+            mono = data.mean(axis = 1) if data.ndim > 1 else data
+            frame = max(1, int(sr * 0.02))
+            n = mono.size // frame
+            if n < 3:
+                return wav_bytes
+            energy = np.abs(mono[: n * frame]).reshape(n, frame).mean(axis = 1)
+            peak = float(energy.max())
+            if peak <= 0:
+                return wav_bytes
+            voiced = energy > peak * 0.05
+            if not voiced.any():
+                return wav_bytes
+            onset = int(np.argmax(voiced))
+            preroll = max(1, int(0.04 / 0.02))  # keep ~40 ms before the onset
+            cut = max(0, onset - preroll)
+            if cut <= 0:
+                return wav_bytes  # already starts promptly; nothing to trim
+            trimmed = mono[cut * frame:]
+            if trimmed.size < frame:
+                return wav_bytes
+            buf = io.BytesIO()
+            sf.write(buf, trimmed, sr, format = "WAV")
+            return buf.getvalue()
+        except Exception:
+            return wav_bytes
+
+    @staticmethod
+    def _leading_voiced_ms(wav_bytes: bytes, sample_rate: int) -> Optional[float]:
+        """Length in ms of the first voiced run at the very start of a clip (onset
+        to the first silence gap). Used to CALIBRATE how long the spoken speaker
+        name is on a low quant: synthesize the name once and measure it here so the
+        trim can key off the real name length instead of guessing. Returns None if
+        no clear leading word is present."""
+        try:
+            import io
+
+            import numpy as np
+            import soundfile as sf
+
+            data, sr = sf.read(io.BytesIO(wav_bytes), dtype = "float32")
+            mono = data.mean(axis = 1) if data.ndim > 1 else data
+            frame = max(1, int(sr * 0.02))
+            n = mono.size // frame
+            if n < 4:
+                return None
+            energy = np.abs(mono[: n * frame]).reshape(n, frame).mean(axis = 1)
+            peak = float(energy.max())
+            if peak <= 0:
+                return None
+            voiced = energy > peak * 0.06
+            if not voiced.any():
+                return None
+            onset = int(np.argmax(voiced))
+            if onset > int(0.5 / 0.02):  # first sound must be near the start
+                return None
+            end = onset
+            while end < n and voiced[end]:
+                end += 1
+            return (end - onset) * 20.0
+        except Exception:
+            return None
+
+    @staticmethod
+    def _trim_leading_word(
+        wav_bytes: bytes, sample_rate: int, expected_ms: Optional[float] = None
+    ) -> bytes:
+        """Slice the leading spoken speaker name off Orpheus audio on low quants.
+
+        The name is ONE short word at the very start, set off by the colon's pause.
+        When ``expected_ms`` is given (this voice's name length, measured by
+        calibrating on the loaded model -- see ``_orpheus_name_length_ms``), we ONLY
+        cut a leading voiced run whose length MATCHES it. So a genuine short first
+        word like "Yes," -- which the model synthesizes on the sentences where it
+        does NOT read the name -- is left alone instead of being clipped, because
+        its length won't match the measured name. Without a calibration we fall back
+        to a broad plausible-name window. Either way, no clear "short word + real
+        pause at the very start" -> return the audio unchanged (a stray name beats a
+        clipped reply)."""
+        try:
+            import io
+
+            import numpy as np
+            import soundfile as sf
+
+            data, sr = sf.read(io.BytesIO(wav_bytes), dtype = "float32")
+            mono = data.mean(axis = 1) if data.ndim > 1 else data
+            frame = max(1, int(sr * 0.02))  # 20 ms frames
+            n = mono.size // frame
+            if n < 6:
+                return wav_bytes
+            energy = np.abs(mono[: n * frame]).reshape(n, frame).mean(axis = 1)
+            peak = float(energy.max())
+            if peak <= 0:
+                return wav_bytes
+            voiced = energy > peak * 0.06
+
+            def f(ms: float) -> int:  # ms -> number of 20 ms frames
+                return max(1, int((ms / 1000.0) / 0.02))
+
+            onset = int(np.argmax(voiced))
+            # The name must start near the very beginning.
+            if onset > f(500):
+                return wav_bytes
+            # End + length of the leading (name) voiced run.
+            name_end = onset
+            while name_end < n and voiced[name_end]:
+                name_end += 1
+            name_ms = (name_end - onset) * 20.0
+            # Length gate. With a calibrated name length, require the leading run to
+            # match it (tight window) so a real first word of a different length is
+            # never cut. Otherwise use a broad plausible-name window.
+            if expected_ms and expected_ms > 0:
+                if not (0.6 * expected_ms <= name_ms <= 1.5 * expected_ms):
+                    return wav_bytes
+                span_cap = f(expected_ms) + f(600)
+            else:
+                if not (100.0 <= name_ms <= 600.0):
+                    return wav_bytes
+                span_cap = f(900)
+            # Require a real pause right after the name.
+            gap_end = name_end
+            while gap_end < n and not voiced[gap_end]:
+                gap_end += 1
+            if gap_end - name_end < f(80):
+                return wav_bytes  # no clear pause -> not a name we can safely cut
+            # The name + pause must sit near the start, with real speech after it.
+            # Back off ~40 ms so the reply's first consonant isn't clipped.
+            if gap_end > onset + span_cap or gap_end >= n:
+                return wav_bytes
+            cut = max(name_end + 1, gap_end - f(40))
+            trimmed = mono[cut * frame:]
+            if trimmed.size < frame:
+                return wav_bytes
+            buf = io.BytesIO()
+            sf.write(buf, trimmed, sr, format = "WAV")
+            return buf.getvalue()
+        except Exception:
+            return wav_bytes
+
+    def _orpheus_name_length_ms(self, voice: str, audio_type: str) -> Optional[float]:
+        """Measured spoken length (ms) of this voice's name on the loaded low quant,
+        so the trim knows EXACTLY how much to cut instead of guessing. Calibrated
+        once per (model, voice) by synthesizing a short throwaway line with the
+        "{voice}:" prefix and measuring the leading voiced run (the spoken name).
+        Cached and keyed by the loaded quant, so a model/quant swap re-calibrates; a
+        failed measurement is stored as 0.0 so the trim falls back to its broad
+        heuristic instead of re-calibrating every sentence."""
+        cache = getattr(self, "_orpheus_name_ms", None)
+        if cache is None:
+            cache = {}
+            self._orpheus_name_ms = cache
+        key = f"{self._hf_variant or ''}|{self._gguf_path or ''}|{voice}"
+        if key in cache:
+            return cache[key] or None
+        ms: Optional[float] = None
+        try:
+            wav, sr = self.generate_audio_response(
+                "Okay, sounds good.", audio_type, voice = voice, _calibration = True
+            )
+            measured = self._leading_voiced_ms(wav, sr)
+            if measured is not None and 120.0 <= measured <= 700.0:
+                ms = measured
+        except Exception as e:
+            logger.debug("Orpheus name calibration failed for %s: %s", voice, e)
+        cache[key] = ms or 0.0
+        if ms:
+            logger.info("Orpheus name length calibrated: voice=%s ~%.0fms", voice, ms)
+        return ms
 
     def generate_audio_response(
         self,
         text: str,
         audio_type: str,
+        voice: str = "tara",
         temperature: float = 0.6,
         top_p: float = 0.95,
         top_k: int = 50,
@@ -32654,6 +32963,8 @@ class LlamaCppBackend:
         max_new_tokens: int = 2048,
         repetition_penalty: float = 1.1,
         cancel_event: Optional[threading.Event] = None,
+        seed: int = 42,
+        _calibration: bool = False,
     ) -> tuple:
         """
         Generate TTS audio via llama-server /completion + codec decode.
@@ -32662,16 +32973,52 @@ class LlamaCppBackend:
         ``cancel_event`` lets a Stop or a forced model swap end the request: the
         decode is one blocking POST, so a watcher closes the client out from under
         it rather than polling. Raises RuntimeError once cancelled.
+        seed: fixed by default so the same text yields the SAME audio every time --
+        deterministic output (reproducible benchmarks, a stable voice) and no
+        occasional slow/rambling take. Temperature is unchanged, so voice quality is
+        the same; only the RNG is pinned.
+        _calibration: internal. Skips the low-quant name-trim so this call can be
+        used to MEASURE the spoken name length (see _orpheus_name_length_ms) without
+        recursing back into calibration.
         """
         if audio_type not in self._TTS_PROMPTS:
             raise RuntimeError(f"GGUF TTS does not support '{audio_type}' codec.")
+
+        # The codec manager is shared class-level, so swapping/unloading another
+        # audio model (e.g. a speech-LLM chat model) can tear it down while this
+        # voice slot stays loaded -- then decode() would hit None. Re-ensure our
+        # codec here so the voice slot survives chat-model swaps.
+        if (
+            LlamaCppBackend._codec_mgr is None
+            or not LlamaCppBackend._codec_mgr.has_codec(audio_type)
+        ):
+            self.init_audio_codec(audio_type)
 
         tpl, stop, need_ids = self._TTS_PROMPTS[audio_type]
         # Raw prompt, not messages: codec delimiters are the only structure to break (#7066).
         from core.inference.chat_template_helpers import neutralize_tts_prompt_text
 
+        # Orpheus (snac) selects a speaker with a "voice: text" prefix. High quants
+        # use it as a SILENT cue; ultra-low quants (IQ1/IQ2/Q2) read the name aloud.
+        # Keep the prefix either way so the speaker stays pinned, and on the low
+        # quants trim the spoken name off the front of the audio (see below).
+        # Neutralize first, then add the speaker prefix, so the prefix is built on
+        # text that can no longer carry codec delimiters and is not itself mangled.
+        prompt_text = neutralize_tts_prompt_text(text, audio_type)
+        trim_name = False
+        if audio_type == "snac":
+            v = voice if voice in self._ORPHEUS_VOICES else "tara"
+            # A colon inside the CONTENT reads to Orpheus like a "name: text"
+            # speaker tag (that's the format it was trained on for voice select),
+            # so a colon mid-reply can flip or garble the voice. Drop content colons
+            # (replace with a space) so the ONLY colon Orpheus sees is our intended
+            # "{voice}:" speaker prefix -- the voice stays stable across the reply.
+            clean = prompt_text.replace(":", " ")
+            prompt_text = f"{v}: {clean}"
+            trim_name = not self._orpheus_voice_prefix_ok()
+
         payload: dict = {
-            "prompt": tpl.format(text = neutralize_tts_prompt_text(text, audio_type)),
+            "prompt": tpl.format(text = prompt_text),
             "stream": False,
             "n_predict": max_new_tokens,
             "temperature": temperature,
@@ -32680,6 +33027,7 @@ class LlamaCppBackend:
             "min_p": min_p,
             "repeat_penalty": repetition_penalty,
         }
+        _apply_seeded_llama_request(payload, seed)
         if stop:
             payload["stop"] = stop
         if need_ids:
@@ -32746,6 +33094,135 @@ class LlamaCppBackend:
         import torch
 
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        return LlamaCppBackend._codec_mgr.decode(
-            audio_type, device, token_ids = token_ids, text = data.get("content", "")
-        )
+        with LlamaCppBackend._codec_decode_lock:
+            wav_bytes, sample_rate = LlamaCppBackend._codec_mgr.decode(
+                audio_type, device, token_ids = token_ids, text = data.get("content", "")
+            )
+        if audio_type == "snac" and not _calibration:
+            if trim_name:
+                # Low quant: calibrate this voice's spoken-name length (once, cached),
+                # then trim only a leading run that matches it -- real short first
+                # words aren't clipped. This also removes the leading silence.
+                expected = self._orpheus_name_length_ms(v, audio_type)
+                wav_bytes = self._trim_leading_word(wav_bytes, sample_rate, expected)
+            else:
+                # High quant (no spoken name): Orpheus still emits ~0.3-0.6s of dead
+                # air before speech, which is pure first-audio latency. Trim it (keep
+                # a small pre-roll so the first consonant isn't clipped).
+                wav_bytes = self._trim_leading_silence(wav_bytes, sample_rate)
+        return wav_bytes, sample_rate
+
+    def generate_audio_response_stream(
+        self,
+        text: str,
+        audio_type: str,
+        voice: str = "tara",
+        temperature: float = 0.6,
+        top_p: float = 0.95,
+        top_k: int = 50,
+        min_p: float = 0.0,
+        max_new_tokens: int = 2048,
+        repetition_penalty: float = 1.1,
+        seed: int = 42,
+    ):
+        """Stream TTS audio for `text` as it generates: yields raw 16-bit PCM (mono,
+        24 kHz) so playback can start on the first fraction of a second instead of
+        waiting for the whole clip to synthesize. SNAC (Orpheus) only.
+
+        The llama-server completion is consumed token-by-token; every ~8 SNAC frames
+        we re-decode the growing code list and emit the newly-finished samples, with
+        an 80 ms right-context holdback so chunk seams stay click-free. Decoding from
+        frame 0 each step keeps full left context (no boundary artifacts); SNAC decode
+        is cheap next to token generation, so the re-decode overhead is negligible.
+
+        Note: this does NOT apply the low-quant spoken-name trim (that needs the whole
+        clip). Use the one-shot generate_audio_response where the name-trim matters."""
+        if audio_type != "snac":
+            raise RuntimeError("Streaming TTS is currently SNAC (Orpheus) only.")
+        if (
+            LlamaCppBackend._codec_mgr is None
+            or not LlamaCppBackend._codec_mgr.has_codec(audio_type)
+        ):
+            self.init_audio_codec(audio_type)
+
+        tpl, stop, _need_ids = self._TTS_PROMPTS[audio_type]
+        # Raw prompt, not messages: codec delimiters are the only structure to break (#7066).
+        # The blocking path neutralizes them; the stream builds the same prompt, so it
+        # has to do the same or streaming would be the way around that guard.
+        from core.inference.chat_template_helpers import neutralize_tts_prompt_text
+
+        v = voice if voice in self._ORPHEUS_VOICES else "tara"
+        clean = neutralize_tts_prompt_text(text, audio_type).replace(":", " ")
+        prompt_text = f"{v}: {clean}"
+        payload: dict = {
+            "prompt": tpl.format(text = prompt_text),
+            "stream": True,
+            "n_predict": max_new_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "top_k": top_k if top_k >= 0 else 0,
+            "min_p": min_p,
+            "repeat_penalty": repetition_penalty,
+            "n_probs": 1,
+        }
+        _apply_seeded_llama_request(payload, seed)
+        if stop:
+            payload["stop"] = stop
+
+        import json as _json
+
+        import numpy as _np
+        import torch as _torch
+
+        # Preference only: decode_snac_pcm pins it to where the codec actually lives.
+        device = "cuda" if _torch.cuda.is_available() and not self.holds_no_vram else "cpu"
+        HOLDBACK = int(0.08 * 24000)  # 80 ms right-context held back for clean seams
+        DECODE_EVERY = 56             # ~8 SNAC frames (7 tokens each) between decodes
+
+        ids: list = []
+        state = {"emitted": 0}
+
+        def _decode_emit(final: bool) -> bytes:
+            wave = LlamaCppBackend._codec_mgr.decode_snac_pcm(ids, device)
+            if wave is None:
+                return b""
+            end = len(wave) if final else max(0, len(wave) - HOLDBACK)
+            if end <= state["emitted"]:
+                return b""
+            chunk = wave[state["emitted"]:end]
+            state["emitted"] = end
+            pcm = _np.clip(chunk, -1.0, 1.0)
+            return (pcm * 32767.0).astype("<i2").tobytes()
+
+        since_decode = 0
+        with httpx.Client(
+            timeout = httpx.Timeout(300, connect = 10), headers = self._auth_headers
+        ) as client:
+            with client.stream(
+                "POST", f"{self.base_url}/completion", json = payload
+            ) as resp:
+                if resp.status_code != 200:
+                    raise RuntimeError(f"llama-server returned {resp.status_code}")
+                for line in resp.iter_lines():
+                    if not line or not line.startswith("data:"):
+                        continue
+                    try:
+                        obj = _json.loads(line[len("data:"):].strip())
+                    except _json.JSONDecodeError:
+                        continue
+                    for p in obj.get("completion_probabilities", []) or []:
+                        if "id" in p:
+                            ids.append(p["id"])
+                            since_decode += 1
+                    if since_decode >= DECODE_EVERY:
+                        since_decode = 0
+                        with LlamaCppBackend._codec_decode_lock:
+                            pcm = _decode_emit(final = False)
+                        if pcm:
+                            yield pcm
+                    if obj.get("stop"):
+                        break
+        with LlamaCppBackend._codec_decode_lock:
+            pcm = _decode_emit(final = True)
+        if pcm:
+            yield pcm

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -33198,8 +33198,15 @@ class LlamaCppBackend:
             return (pcm * 32767.0).astype("<i2").tobytes()
 
         since_decode = 0
+        # Flat, unlike the blocking path's _audio_generation_timeout(): httpx applies
+        # the read timeout per socket read, and this response is consumed token by
+        # token, so it bounds the gap between two tokens (a stalled server), not the
+        # whole clip. The blocking path scales because its single post waits for
+        # the entire generation. Scaling this one with the token budget would only
+        # delay noticing a wedged server.
         with httpx.Client(
-            timeout = httpx.Timeout(300, connect = 10), headers = self._auth_headers
+            timeout = httpx.Timeout(_GGUF_AUDIO_READ_TIMEOUT, connect = 10),
+            headers = self._auth_headers,
         ) as client:
             with client.stream("POST", f"{self.base_url}/completion", json = payload) as resp:
                 if resp.status_code != 200:

--- a/studio/backend/core/inference/llama_keepwarm.py
+++ b/studio/backend/core/inference/llama_keepwarm.py
@@ -91,6 +91,10 @@ _INFERENCE_SUFFIXES = (
     "/generate/stream",
     "/audio/generate",  # direct GGUF TTS; can outlive the idle TTL
     "/audio/speech",
+    # The streaming counterpart holds the voice slot (or an Orpheus chat slot) for the whole PCM response; it
+    # ends in /stream, so the entry above does not cover it. Untracked, an API-key training start saw a count
+    # of 0, unloaded the voice backend and cut the live clip off instead of returning 409.
+    "/audio/speech/stream",
     # Image generation holds a multi-GB pipeline for the whole request; tracking it lets other_inference_request_count()
     # see an in-flight generation so an API-key training start is refused (409). endswith avoids matching *-progress /
     # */cancel.

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -4360,14 +4360,19 @@ class ImageGenerationResponse(BaseModel):
 class AudioSpeechRequest(BaseModel):
     """OpenAI ``CreateSpeechRequest`` for ``POST /v1/audio/speech``.
 
-    ``voice`` and ``speed`` are accepted for client compatibility but unused: no loaded
-    TTS backend has voice or rate plumbing (CSM is fixed to speaker 0)."""
+    ``voice`` names a speaker for the codecs that have them (Orpheus/SNAC) and is
+    ignored by codecs with a single fixed speaker (CSM is fixed to speaker 0).
+    ``speed`` is accepted for client compatibility but unused: no loaded TTS backend
+    has rate plumbing."""
 
     input: str = Field(..., min_length = 1, description = "The text to synthesize.")
     model: Optional[str] = Field(
         None, description = "Model id (informational; the loaded audio model is used)."
     )
-    voice: Optional[str] = Field(None, description = "Voice name (accepted, unused).")
+    voice: Optional[str] = Field(
+        None,
+        description = "Speaker name, for codecs that have named speakers (Orpheus/SNAC).",
+    )
     response_format: Optional[str] = Field(
         "wav", description = "Output container. Only 'wav' is supported."
     )

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15863,7 +15863,9 @@ class _VoiceLoadRequest(BaseModel):
     hf_token: Optional[str] = Field(None, description = "HuggingFace token for gated models")
     n_ctx: int = Field(4096, ge = 0, description = "Context length (0 = model default)")
     parallel: int = Field(
-        1, ge = 1, le = 4,
+        1,
+        ge = 1,
+        le = 4,
         description = "llama-server --parallel slots for the voice slot, i.e. how many "
         "sentences may synthesize concurrently.",
     )
@@ -16001,9 +16003,7 @@ async def voice_load_model(
     # warm-up phase absorbs it instead of freezing the user's first spoken reply.
     # Best-effort: a priming failure must never fail an otherwise-good load.
     try:
-        await asyncio.to_thread(
-            voice_backend.generate_audio_response, "Hi there.", audio_type
-        )
+        await asyncio.to_thread(voice_backend.generate_audio_response, "Hi there.", audio_type)
     except Exception as e:
         logger.warning("Voice slot warmup synth failed (first /speech may be slower): %s", e)
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15882,19 +15882,27 @@ async def voice_load_model(
     accepted.  Any other model (text LLM, csm, whisper, audio_vlm) is rejected
     with HTTP 400 after detection and the slot is left empty.
     """
+    from core.inference.llama_cpp import _hf_offline_if_unreachable_for
     from utils.models import ModelConfig
 
     model_identifier = request.model_path.strip()
     voice_backend = get_voice_llama_backend()
 
     # Resolve model config — auto-selects GGUF variant when gguf_variant is None,
-    # exactly mirroring the ModelConfig.from_identifier() call in /load.
+    # mirroring the ModelConfig.from_identifier() call in /load, including how it
+    # runs: from_identifier scans the HF cache and can resolve Hub metadata, so it
+    # goes to a worker thread under the same offline guard rather than stalling every
+    # other request on the event loop while it does.
+    def _resolve_config():
+        with _hf_offline_if_unreachable_for(model_identifier):
+            return ModelConfig.from_identifier(
+                model_id = model_identifier,
+                hf_token = request.hf_token,
+                gguf_variant = request.gguf_variant,
+            )
+
     try:
-        config = ModelConfig.from_identifier(
-            model_id = model_identifier,
-            hf_token = request.hf_token,
-            gguf_variant = request.gguf_variant,
-        )
+        config = await asyncio.to_thread(_resolve_config)
     except Exception as e:
         raise HTTPException(status_code = 400, detail = f"Could not resolve model: {e}")
 
@@ -15971,9 +15979,10 @@ async def voice_load_model(
     if not ok:
         # load_model returned False (e.g. the server became healthy but audio
         # codec init failed). Tear the half-started slot down before raising so
-        # the llama-server process doesn't linger and occupy memory.
+        # the llama-server process doesn't linger and occupy memory. Off-loop,
+        # like every other unload here: teardown waits on the subprocess.
         try:
-            voice_backend.unload_model()
+            await asyncio.to_thread(voice_backend.unload_model)
         except Exception:
             pass
         raise HTTPException(status_code = 500, detail = "Voice model failed to start.")
@@ -15984,7 +15993,7 @@ async def voice_load_model(
     if not is_audio or audio_type not in _VOICE_SLOT_AUDIO_TYPES:
         # Not a supported TTS type — reject and leave slot empty.
         try:
-            voice_backend.unload_model()
+            await asyncio.to_thread(voice_backend.unload_model)
         except Exception:
             pass
         raise HTTPException(
@@ -16022,8 +16031,11 @@ async def voice_unload_model(current_subject: str = Depends(get_current_subject)
     if not voice_backend.is_active:
         return {"status": "not_loaded"}
     model_id = voice_backend.model_identifier
+    # Off the event loop, as /unload runs the chat slot's teardown: unload_model
+    # waits on the llama-server subprocess, and a sync call would block every
+    # other request for the whole of that wait.
     try:
-        voice_backend.unload_model()
+        await asyncio.to_thread(voice_backend.unload_model)
     except Exception as e:
         logger.error("Voice slot unload error: %s", e, exc_info = True)
         raise HTTPException(status_code = 500, detail = f"Failed to unload voice model: {e}")
@@ -17272,6 +17284,19 @@ async def openai_audio_speech_stream(
         raise HTTPException(
             status_code = 400,
             detail = "Streaming speech requires a loaded SNAC (Orpheus) voice.",
+        )
+    # IQ1/IQ2/Q2 Orpheus quants read the "voice:" speaker prefix aloud. The blocking
+    # route trims that spoken name off the clip, which needs the whole clip and so has
+    # no streaming equivalent (see generate_audio_response_stream). Refuse up front,
+    # before the monitor row opens, so the client falls back to /audio/speech instead
+    # of hearing the speaker's name before every sentence.
+    if not backend._orpheus_voice_prefix_ok():
+        raise HTTPException(
+            status_code = 400,
+            detail = (
+                "Streaming speech is unavailable for IQ1/IQ2/Q2 Orpheus quants, which "
+                "speak the voice prefix aloud. Use /audio/speech, which trims it."
+            ),
         )
 
     voice_name = (body.voice or "").strip().lower() or "tara"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -27,6 +27,7 @@ from fastapi import (
 )
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse, JSONResponse, PlainTextResponse, Response
+from pydantic import BaseModel, Field
 from starlette.requests import ClientDisconnect
 from typing import (
     Any,
@@ -6795,12 +6796,25 @@ def _resolve_model_identifier_for_request(
     return str(grant.canonical_path), display_label, True
 
 
-# GGUF inference backend (llama-server)
+# GGUF inference backend (llama-server) — chat / LLM slot
 _llama_cpp_backend = LlamaCppBackend()
+
+# Voice slot — independent llama-server subprocess for GGUF TTS models only
+_voice_llama_backend = LlamaCppBackend()
+# Its own pidfile record, so the two live llama-servers cannot overwrite each other's
+# and leave one unreachable to the orphan reaper after an unclean exit.
+_voice_llama_backend._pid_slot = "voice"
+
+# Audio types accepted by the voice slot (GGUF TTS via llama-server token generation)
+_VOICE_SLOT_AUDIO_TYPES: frozenset[str] = frozenset({"snac", "bicodec", "dac"})
 
 
 def get_llama_cpp_backend() -> LlamaCppBackend:
     return _llama_cpp_backend
+
+
+def get_voice_llama_backend() -> LlamaCppBackend:
+    return _voice_llama_backend
 
 
 # Serializes opt-in auto-switch loads so two requests can't race a swap. One
@@ -15836,6 +15850,200 @@ async def _unload_model_impl(request: UnloadRequest, current_subject: str):
         raise HTTPException(status_code = 500, detail = "Failed to unload model")
 
 
+# =====================================================================
+# Voice Slot  (/voice/load  /voice/unload  /voice/status)
+# =====================================================================
+
+
+class _VoiceLoadRequest(BaseModel):
+    model_path: str = Field(..., description = "GGUF model identifier or local .gguf path")
+    gguf_variant: Optional[str] = Field(
+        None, description = "GGUF quantization variant (e.g. 'Q4_K_M')"
+    )
+    hf_token: Optional[str] = Field(None, description = "HuggingFace token for gated models")
+    n_ctx: int = Field(4096, ge = 0, description = "Context length (0 = model default)")
+    parallel: int = Field(
+        1, ge = 1, le = 4,
+        description = "llama-server --parallel slots for the voice slot, i.e. how many "
+        "sentences may synthesize concurrently.",
+    )
+
+
+@router.post("/voice/load")
+async def voice_load_model(
+    request: _VoiceLoadRequest, current_subject: str = Depends(get_current_subject)
+):
+    """
+    Load a TTS model into the voice slot (independent of the main chat slot).
+
+    Only GGUF models whose detected audio_type is snac, bicodec, or dac are
+    accepted.  Any other model (text LLM, csm, whisper, audio_vlm) is rejected
+    with HTTP 400 after detection and the slot is left empty.
+    """
+    from utils.models import ModelConfig
+
+    model_identifier = request.model_path.strip()
+    voice_backend = get_voice_llama_backend()
+
+    # Resolve model config — auto-selects GGUF variant when gguf_variant is None,
+    # exactly mirroring the ModelConfig.from_identifier() call in /load.
+    try:
+        config = ModelConfig.from_identifier(
+            model_id = model_identifier,
+            hf_token = request.hf_token,
+            gguf_variant = request.gguf_variant,
+        )
+    except Exception as e:
+        raise HTTPException(status_code = 400, detail = f"Could not resolve model: {e}")
+
+    if not config or not config.is_gguf:
+        raise HTTPException(
+            status_code = 400,
+            detail = "Voice slot only accepts GGUF models. The provided identifier did not resolve to a GGUF.",
+        )
+
+    # The voice slot starts a second llama-server, so it takes memory exactly like a
+    # chat load does. /load refuses one that would not fit beside a running trainer;
+    # without the same guard here, enabling a voice while training is active would
+    # download and place another model and could OOM or disrupt the run. Modelled as
+    # the equivalent chat load, since that is what the guard is written against.
+    guard_request = LoadRequest(
+        model_path = model_identifier,
+        hf_token = request.hf_token,
+        gguf_variant = config.gguf_variant,
+        max_seq_length = request.n_ctx,
+        load_in_4bit = False,
+    )
+    placement = await _prepare_load_placement(config, guard_request, None)
+    # Off-loop and offline-guarded, exactly as /load runs it: the guard does sync
+    # nvidia-smi and HF work, and an unwrapped call would burn the retry backoff the
+    # forced-offline window exists to skip.
+    await asyncio.to_thread(
+        _offline_guarded,
+        (model_identifier, config.identifier, getattr(config, "base_model", None)),
+        _guard_chat_load_against_training,
+        config,
+        guard_request,
+        load_in_4bit = False,
+        placement = placement,
+        n_parallel = request.parallel,
+    )
+
+    # Already loaded with the same resolved config — skip reload. Include the
+    # --parallel slot count so changing it in the UI forces a relaunch.
+    if (
+        voice_backend.is_loaded
+        and voice_backend.model_identifier
+        and voice_backend.model_identifier.lower() == config.identifier.lower()
+        and (not config.gguf_variant or voice_backend.hf_variant == config.gguf_variant)
+        and getattr(voice_backend, "_n_parallel", 1) == request.parallel
+        and getattr(voice_backend, "_is_audio", False)
+    ):
+        return {
+            "status": "already_loaded",
+            "model": voice_backend.model_identifier,
+            "audio_type": getattr(voice_backend, "_audio_type", None),
+        }
+
+    # One immutable intent, the same shape /load hands the backend. Everything the
+    # chat slot negotiates -- draft models, vision projectors, tensor split, inherited
+    # extra args -- is deliberately left at its default: a TTS slot loads one small
+    # codec model and none of that applies to it.
+    intent = GgufLoadIntent(
+        model_identifier = config.identifier,
+        # -hf when the repo is known, -m for a local file; never both, or the
+        # loader would have two sources for one slot.
+        hf_repo = config.gguf_hf_repo or None,
+        gguf_path = None if config.gguf_hf_repo else config.gguf_file,
+        hf_variant = config.gguf_variant,
+        hf_token = request.hf_token,
+        n_ctx = request.n_ctx,
+        n_parallel = request.parallel,
+    )
+    try:
+        ok = await asyncio.to_thread(voice_backend.load_model, intent)
+    except Exception as e:
+        logger.error("Voice slot load error: %s", e, exc_info = True)
+        raise HTTPException(status_code = 500, detail = f"Failed to load voice model: {e}")
+
+    if not ok:
+        # load_model returned False (e.g. the server became healthy but audio
+        # codec init failed). Tear the half-started slot down before raising so
+        # the llama-server process doesn't linger and occupy memory.
+        try:
+            voice_backend.unload_model()
+        except Exception:
+            pass
+        raise HTTPException(status_code = 500, detail = "Voice model failed to start.")
+
+    audio_type = getattr(voice_backend, "_audio_type", None)
+    is_audio = getattr(voice_backend, "_is_audio", False)
+
+    if not is_audio or audio_type not in _VOICE_SLOT_AUDIO_TYPES:
+        # Not a supported TTS type — reject and leave slot empty.
+        try:
+            voice_backend.unload_model()
+        except Exception:
+            pass
+        raise HTTPException(
+            status_code = 400,
+            detail = (
+                f"Model is not a supported TTS type for the voice slot "
+                f"(detected: {audio_type!r}). "
+                f"Only snac, bicodec, and dac GGUF models are accepted."
+            ),
+        )
+
+    # Prime the pipeline so the FIRST real /speech is fast. The llama-server
+    # completion graph and the codec's first decode each pay a one-time cold cost
+    # (kernel compile / cache alloc -- seconds on ROCm). Run one tiny throwaway
+    # synth now, while the slot still reads as "loading" (voiceSlotLoading), so the
+    # warm-up phase absorbs it instead of freezing the user's first spoken reply.
+    # Best-effort: a priming failure must never fail an otherwise-good load.
+    try:
+        await asyncio.to_thread(
+            voice_backend.generate_audio_response, "Hi there.", audio_type
+        )
+    except Exception as e:
+        logger.warning("Voice slot warmup synth failed (first /speech may be slower): %s", e)
+
+    logger.info("Voice slot loaded: %s (audio_type=%s)", voice_backend.model_identifier, audio_type)
+    return {
+        "status": "loaded",
+        "model": voice_backend.model_identifier,
+        "audio_type": audio_type,
+    }
+
+
+@router.post("/voice/unload")
+async def voice_unload_model(current_subject: str = Depends(get_current_subject)):
+    """Unload whatever model is in the voice slot."""
+    voice_backend = get_voice_llama_backend()
+    if not voice_backend.is_active:
+        return {"status": "not_loaded"}
+    model_id = voice_backend.model_identifier
+    try:
+        voice_backend.unload_model()
+    except Exception as e:
+        logger.error("Voice slot unload error: %s", e, exc_info = True)
+        raise HTTPException(status_code = 500, detail = f"Failed to unload voice model: {e}")
+    logger.info("Voice slot unloaded: %s", model_id)
+    return {"status": "unloaded", "model": model_id}
+
+
+@router.get("/voice/status")
+async def voice_slot_status(current_subject: str = Depends(get_current_subject)):
+    """Return the current state of the voice slot."""
+    voice_backend = get_voice_llama_backend()
+    loaded = voice_backend.is_loaded
+    return {
+        "loaded": loaded,
+        "loading": voice_backend.is_active and not loaded,
+        "model": voice_backend.model_identifier if loaded else None,
+        "audio_type": getattr(voice_backend, "_audio_type", None) if loaded else None,
+    }
+
+
 @studio_router.post("/cancel")
 async def cancel_inference(request: Request, current_subject: str = Depends(get_current_subject)):
     """Cancel in-flight inference requests.
@@ -16546,9 +16754,13 @@ async def _generate_tts_wav(
     current_subject: str,
     *,
     speech_api_default_max_tokens: bool = False,
+    voice: Optional[str] = None,
 ) -> tuple[bytes, int, str, Optional[str]]:
     """Shared core of /audio/generate and /audio/speech. Returns
-    (wav_bytes, sample_rate, model_name, audio_type)."""
+    (wav_bytes, sample_rate, model_name, audio_type).
+
+    ``voice`` names a speaker for models that have them (Orpheus/SNAC); it is
+    ignored by codecs with a single fixed speaker."""
     _raise_if_prompt_leaves_no_speech_budget(text)
     # Restore an idle-evicted GGUF before selecting a backend: this path is
     # keep-warm-tracked but had no reload hook, so a standalone idle TTL could
@@ -16561,9 +16773,19 @@ async def _generate_tts_wav(
     # the client model through the resolver could load a text- or vision-only target
     # and evict the working audio model before the audio backend check fails. Only
     # the idle-stash restore runs here; switching TTS models is an explicit /load.
-    await _maybe_auto_switch_model(
-        _RELOAD_ONLY_MODEL, request, current_subject, claim_resident = False
+    #
+    # Skipped entirely when the voice slot holds the TTS model: the restore targets the
+    # chat slot, which in voice mode is the user's LLM. Reloading it here would be at
+    # best wasted work between spoken sentences and at worst an unasked-for chat-model
+    # load, and the speech is not coming from that slot anyway.
+    _voice_backend = get_voice_llama_backend()
+    _voice_slot_serves = bool(
+        _voice_backend.is_loaded and getattr(_voice_backend, "_is_audio", False)
     )
+    if not _voice_slot_serves:
+        await _maybe_auto_switch_model(
+            _RELOAD_ONLY_MODEL, request, current_subject, claim_resident = False
+        )
     # Again, now that a context exists to measure against. The check above runs before the
     # restore so an invalid request never triggers a reload, but with nothing loaded it has
     # no context length and passes everything, so the first request after an idle eviction
@@ -16576,7 +16798,11 @@ async def _generate_tts_wav(
     prompt_for_budget = text
 
     # Pick backend - both return (wav_bytes, sample_rate)
-    llama_backend = get_llama_cpp_backend()
+    # The voice slot is a second llama-server holding a TTS model so the chat slot can
+    # hold an LLM at the same time. When it is loaded it owns speech: without this the
+    # request would go to the chat slot, which in voice mode is a text model, and fail
+    # the is_audio check below with a voice sitting loaded next to it.
+    llama_backend = _voice_backend if _voice_slot_serves else get_llama_cpp_backend()
     # GGUF TTS goes straight to llama-server /completion, holding a slot with no
     # admission lease, so only the direct counter can show it in the slot readout.
     _direct_llama_tts = bool(llama_backend.is_loaded and getattr(llama_backend, "_is_audio", False))
@@ -16590,6 +16816,7 @@ async def _generate_tts_wav(
         gen = lambda: llama_backend.generate_audio_response(
             text = text,
             audio_type = llama_backend._audio_type,
+            voice = (voice or "").strip().lower() or "tara",
             temperature = payload.temperature,
             top_p = payload.top_p,
             top_k = payload.top_k,
@@ -16925,9 +17152,11 @@ async def openai_audio_speech(
     """OpenAI-compatible text-to-speech (POST /v1/audio/speech).
 
     With ``provider_id`` the request is proxied to that connection, forwarding
-    model/voice/speed/instructions. Otherwise the loaded model is used: ``model`` is informational,
-    ``voice``/``speed`` ignored, and only WAV exists, so another ``response_format`` is
-    a 400 rather than a silent container mismatch."""
+    model/voice/speed/instructions. Otherwise the loaded model is used (the voice slot
+    when one is loaded, else the chat slot): ``model`` is informational, ``voice`` picks
+    the speaker on models that have named ones and is ignored elsewhere, ``speed`` is
+    ignored, and only WAV exists, so another ``response_format`` is a 400 rather than a
+    silent container mismatch."""
     if body.provider_id:
         fmt = (body.response_format or "wav").strip().lower()
         if fmt != "wav":
@@ -16991,12 +17220,118 @@ async def openai_audio_speech(
             request,
             current_subject,
             speech_api_default_max_tokens = body.max_new_tokens is None,
+            voice = body.voice,
         )
         api_monitor.relabel(monitor_id, model_name)
         await asyncio.to_thread(
             _persist_tts_clip, wav_bytes, sample_rate, body.input, model_name, audio_type
         )
     return Response(content = wav_bytes, media_type = "audio/wav")
+
+
+# Streaming counterpart to /audio/speech. Dual-mounted like it, so /v1/audio/speech/stream
+# answers too; the [x-unsloth] extension is namespaced by the /stream suffix rather than a
+# body flag so an OpenAI client that knows only /audio/speech is unaffected.
+@router.post("/audio/speech/stream")
+async def openai_audio_speech_stream(
+    body: AudioSpeechRequest,
+    request: Request,
+    current_subject: str = Depends(get_current_subject),
+) -> Response:
+    """[x-unsloth] Streaming text-to-speech (POST /v1/audio/speech/stream).
+
+    Yields raw little-endian 16-bit PCM (mono, 24 kHz -- see the X-Sample-Rate and
+    X-Audio-Format headers) as it synthesizes, so playback starts on the first
+    fraction of a second instead of after the whole clip. SNAC (Orpheus) only: it is
+    the one codec that decodes incrementally from a growing code list. Everything
+    else, and every external connection, uses the blocking /audio/speech.
+
+    Not persisted to the audio gallery: the gallery stores finished clips and this
+    route never holds one. Use /audio/speech for a clip you want kept.
+    """
+    if body.provider_id:
+        raise HTTPException(
+            status_code = 400,
+            detail = (
+                "Streaming speech is local-only. Use /audio/speech for an external "
+                "TTS connection."
+            ),
+        )
+    text = body.input.strip()
+    if not text:
+        raise HTTPException(status_code = 400, detail = "input must not be empty.")
+
+    # The voice slot first, for the same reason as _generate_tts_wav: in voice mode the
+    # chat slot holds the LLM.
+    backend = None
+    for candidate in (get_voice_llama_backend(), get_llama_cpp_backend()):
+        if candidate.is_loaded and getattr(candidate, "_audio_type", None) == "snac":
+            backend = candidate
+            break
+    if backend is None:
+        raise HTTPException(
+            status_code = 400,
+            detail = "Streaming speech requires a loaded SNAC (Orpheus) voice.",
+        )
+
+    voice_name = (body.voice or "").strip().lower() or "tara"
+    max_new_tokens = body.max_new_tokens or AUDIO_GENERATION_MAX_TOKENS
+
+    # The monitor row is driven by hand rather than through _monitored_media_request:
+    # that closes the row when its block exits, and this route's block exits the moment
+    # the StreamingResponse is handed back -- before a single sample is generated. The
+    # row would then read "succeeded" for a synthesis that had not started, and stay
+    # that way even if it later failed. Opened here and closed by the generator, so it
+    # covers the work it claims to.
+    monitor_id = None
+    if not getattr(request.state, "skip_api_monitor", False):
+        monitor_id = api_monitor.start(
+            endpoint = request.url.path,
+            method = request.method,
+            via_api_key = _request_used_api_key(request),
+            model = public_model_id(body.model) or body.model or "",
+            prompt = body.input,
+            subject = current_subject,
+        )
+        api_monitor.relabel(monitor_id, _llama_public_model_id(backend))
+
+    # The row is closed exactly once, on whichever arm the stream actually takes.
+    # else runs only when no exception escaped, so "closed already" is structural
+    # rather than a flag to keep in sync.
+    def gen():
+        try:
+            yield from backend.generate_audio_response_stream(
+                text = text,
+                audio_type = "snac",
+                voice = voice_name,
+                max_new_tokens = max_new_tokens,
+                seed = body.seed if body.seed is not None else 42,
+            )
+        except GeneratorExit:
+            # The client went away mid-clip (a barge-in, a closed tab). Not a failure,
+            # and re-raising is mandatory: swallowing it makes the runtime complain
+            # that the generator ignored GeneratorExit.
+            api_monitor.finish(monitor_id, "cancelled")
+            raise
+        except Exception as e:
+            # The status line is long gone by the time synthesis can fail, so the only
+            # signal left on the wire is a short stream. Log it and mark the row failed
+            # rather than raising into the response body, which the client decodes as
+            # audio.
+            logger.error("Streaming speech error: %s", e, exc_info = True)
+            api_monitor.fail(monitor_id, _friendly_error(e))
+        else:
+            api_monitor.finish(monitor_id)
+
+    return StreamingResponse(
+        gen(),
+        media_type = "application/octet-stream",
+        headers = {
+            "X-Sample-Rate": "24000",
+            "X-Audio-Format": "pcm_s16le_mono",
+            "Cache-Control": "no-store",
+        },
+    )
 
 
 async def _external_stt_transcription(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -108,6 +108,7 @@ from core.inference.llama_admission import (
     peek_llama_admission_snapshot,
 )
 from core.inference.tool_stream_exec import TOOL_APPROVAL_FLUSH_DELAY_S
+from core.inference.runtime_context import MAX_REQUESTABLE_CONTEXT
 
 
 def _positive_int_or_none(value: Any) -> Optional[int]:
@@ -15861,7 +15862,15 @@ class _VoiceLoadRequest(BaseModel):
         None, description = "GGUF quantization variant (e.g. 'Q4_K_M')"
     )
     hf_token: Optional[str] = Field(None, description = "HuggingFace token for gated models")
-    n_ctx: int = Field(4096, ge = 0, description = "Context length (0 = model default)")
+    # Same ceiling as LoadRequest.max_seq_length: the handler models the load as a chat
+    # LoadRequest for the training-coexistence guard, so an oversized value used to fail
+    # there as a 500 (after the HF resolve) instead of a 422 at validation.
+    n_ctx: int = Field(
+        4096,
+        ge = 0,
+        le = MAX_REQUESTABLE_CONTEXT,
+        description = "Context length (0 = model default)",
+    )
     parallel: int = Field(
         1,
         ge = 1,
@@ -17345,6 +17354,12 @@ async def openai_audio_speech_stream(
             # audio.
             logger.error("Streaming speech error: %s", e, exc_info = True)
             api_monitor.fail(monitor_id, _friendly_error(e))
+            # The route is a tracked inference path and this arm ends the stream cleanly
+            # at 200, so without the flag the keep-warm middleware would read the failed
+            # clip as a successful completion and claim a preview-owned chat slot.
+            from core.inference.llama_keepwarm import mark_current_response_failed
+
+            mark_current_response_failed()
         else:
             api_monitor.finish(monitor_id)
 

--- a/studio/backend/routes/training_vram.py
+++ b/studio/backend/routes/training_vram.py
@@ -36,9 +36,14 @@ def _free_vram_by_index(devices: List[Dict[str, Any]]) -> Dict[int, float]:
 
 
 def summarize_resident_chat() -> Dict[str, Any]:
-    """Report which chat models hold GPU memory (resident even while loading). Never raises."""
+    """Report which chat models hold GPU memory (resident even while loading). Never raises.
+
+    The voice slot counts too: it is a second llama-server, holding VRAM exactly like
+    the chat slot's, so training coordination that saw only the chat slot could unload
+    that one and launch the trainer beside a voice server it never knew about."""
     hf_name: Optional[str] = None
     gguf_name: Optional[str] = None
+    voice_name: Optional[str] = None
     loading: bool = False
 
     try:
@@ -67,11 +72,24 @@ def summarize_resident_chat() -> Dict[str, Any]:
     except Exception as e:
         logger.warning("Could not inspect GGUF backend: %s", e)
 
+    try:
+        from routes.inference import get_voice_llama_backend
+        voice = get_voice_llama_backend()
+        # Same rule as the chat slot: active (not merely loaded) holds VRAM, and a
+        # confirmed CPU-only server holds none.
+        if voice.is_active and getattr(voice, "_gpu_offload_active", None) is not False:
+            voice_name = voice.model_identifier or "voice"
+            if not getattr(voice, "is_loaded", False):
+                loading = True
+    except Exception as e:
+        logger.warning("Could not inspect voice slot backend: %s", e)
+
     return {
         "hf": hf_name,
         "gguf": gguf_name,
+        "voice": voice_name,
         "loading": loading,
-        "any": bool(hf_name or gguf_name),
+        "any": bool(hf_name or gguf_name or voice_name),
     }
 
 
@@ -452,6 +470,22 @@ def free_chat_models_for_training(reason: str) -> List[str]:
             freed.append(f"gguf:{name}")
     except Exception as e:
         logger.warning("Could not unload GGUF chat model: %s", e)
+
+    try:
+        from routes.inference import get_voice_llama_backend
+        voice = get_voice_llama_backend()
+        # The voice slot is its own llama-server; same CPU-only exemption as above.
+        if voice.is_active and getattr(voice, "_gpu_offload_active", None) is not False:
+            name = voice.model_identifier or "voice"
+            logger.info(
+                "Unloading GGUF voice model '%s' to free GPU memory for training (%s)",
+                name,
+                reason,
+            )
+            voice.unload_model()
+            freed.append(f"voice:{name}")
+    except Exception as e:
+        logger.warning("Could not unload GGUF voice model: %s", e)
 
     return freed
 

--- a/studio/backend/tests/test_mcp_training_start_guard.py
+++ b/studio/backend/tests/test_mcp_training_start_guard.py
@@ -142,6 +142,20 @@ def test_stream_finishing_then_retrying_starts(monkeypatch):
 # --------------------------------------------------------------------------------------
 
 
+def test_streaming_speech_is_tracked_like_the_blocking_route():
+    """/audio/speech/stream holds the voice slot for the whole PCM response. The suffix
+    tuple is an endswith test and the route ends in /stream, so the /audio/speech entry
+    never covered it: with it as the only inference in flight, an API-key training start
+    counted 0, unloaded the voice backend and cut the clip off instead of returning 409."""
+    for path in (
+        "/v1/audio/speech",
+        "/api/inference/audio/speech",
+        "/v1/audio/speech/stream",
+        "/api/inference/audio/speech/stream",
+    ):
+        assert keepwarm._is_inference_path(path) is True, path
+
+
 def test_the_mcp_call_does_not_count_itself():
     """/mcp is not an inference path, so the MCP request is never tracked."""
     assert keepwarm._is_inference_path("/mcp") is False

--- a/studio/backend/tests/test_openai_audio_speech_route.py
+++ b/studio/backend/tests/test_openai_audio_speech_route.py
@@ -1011,3 +1011,22 @@ def test_an_ordinary_model_id_is_still_recorded_verbatim(monkeypatch):
             == 400
         )
         assert api_monitor.snapshot(include_details = False)[0]["model"] == requested
+
+
+def test_voice_load_rejects_a_context_above_the_requestable_ceiling():
+    """/voice/load models its load as a chat LoadRequest for the training-coexistence
+    guard, and that model caps max_seq_length at MAX_REQUESTABLE_CONTEXT. Without the
+    same bound on n_ctx, an oversized value passed validation and then blew up inside
+    the handler as a 500, after the HF resolve, instead of a 422 up front."""
+    from pydantic import ValidationError
+
+    from core.inference.runtime_context import MAX_REQUESTABLE_CONTEXT
+
+    with pytest.raises(ValidationError):
+        routes_module._VoiceLoadRequest(model_path = "unsloth/orpheus-3b-0.1-ft-GGUF", n_ctx = MAX_REQUESTABLE_CONTEXT + 1)
+    assert (
+        routes_module._VoiceLoadRequest(model_path = "unsloth/orpheus-3b-0.1-ft-GGUF", n_ctx = MAX_REQUESTABLE_CONTEXT).n_ctx
+        == MAX_REQUESTABLE_CONTEXT
+    )
+    # 0 keeps meaning "model default".
+    assert routes_module._VoiceLoadRequest(model_path = "x.gguf", n_ctx = 0).n_ctx == 0

--- a/studio/backend/tests/test_openai_audio_speech_route.py
+++ b/studio/backend/tests/test_openai_audio_speech_route.py
@@ -1023,9 +1023,13 @@ def test_voice_load_rejects_a_context_above_the_requestable_ceiling():
     from core.inference.runtime_context import MAX_REQUESTABLE_CONTEXT
 
     with pytest.raises(ValidationError):
-        routes_module._VoiceLoadRequest(model_path = "unsloth/orpheus-3b-0.1-ft-GGUF", n_ctx = MAX_REQUESTABLE_CONTEXT + 1)
+        routes_module._VoiceLoadRequest(
+            model_path = "unsloth/orpheus-3b-0.1-ft-GGUF", n_ctx = MAX_REQUESTABLE_CONTEXT + 1
+        )
     assert (
-        routes_module._VoiceLoadRequest(model_path = "unsloth/orpheus-3b-0.1-ft-GGUF", n_ctx = MAX_REQUESTABLE_CONTEXT).n_ctx
+        routes_module._VoiceLoadRequest(
+            model_path = "unsloth/orpheus-3b-0.1-ft-GGUF", n_ctx = MAX_REQUESTABLE_CONTEXT
+        ).n_ctx
         == MAX_REQUESTABLE_CONTEXT
     )
     # 0 keeps meaning "model default".

--- a/studio/backend/tests/test_training_vram_coexistence.py
+++ b/studio/backend/tests/test_training_vram_coexistence.py
@@ -72,13 +72,16 @@ def _fake_llama_backend(
     return llama
 
 
-def _patch_backends(inf, llama):
+def _patch_backends(inf, llama, voice = None):
     """Stub core.inference + routes.inference modules so the lazy imports inside
-    training_vram resolve to fakes (avoids importing torch-heavy backends)."""
+    training_vram resolve to fakes (avoids importing torch-heavy backends).
+    ``voice`` is the voice-slot llama-server; empty unless a test loads one."""
     core_inf = types.ModuleType("core.inference")
     core_inf.get_inference_backend = lambda: inf
     routes_inf = types.ModuleType("routes.inference")
     routes_inf.get_llama_cpp_backend = lambda: llama
+    voice = voice if voice is not None else _fake_llama_backend(active = False)
+    routes_inf.get_voice_llama_backend = lambda: voice
     return patch.dict(sys.modules, {"core.inference": core_inf, "routes.inference": routes_inf})
 
 
@@ -147,7 +150,7 @@ class TestSummarizeResidentChat(_GpuCacheResetMixin, unittest.TestCase):
         with _patch_backends(_fake_inference_backend(), _fake_llama_backend(active = False)):
             self.assertEqual(
                 tv.summarize_resident_chat(),
-                {"hf": None, "gguf": None, "loading": False, "any": False},
+                {"hf": None, "gguf": None, "voice": None, "loading": False, "any": False},
             )
 
     def test_hf_resident_via_active_model(self):
@@ -224,6 +227,40 @@ class TestSummarizeResidentChat(_GpuCacheResetMixin, unittest.TestCase):
             out = tv.summarize_resident_chat()
         self.assertIsNone(out["hf"])
         self.assertTrue(out["any"])  # GGUF still detected
+
+    def test_voice_slot_is_a_vram_resident(self):
+        # A loaded voice slot with an EMPTY chat slot: the second llama-server holds
+        # VRAM on its own, so training must see it (the case that used to be invisible).
+        with _patch_backends(
+            _fake_inference_backend(),
+            _fake_llama_backend(active = False),
+            voice = _fake_llama_backend(active = True, identifier = "orpheus.gguf"),
+        ):
+            out = tv.summarize_resident_chat()
+        self.assertEqual(out["voice"], "orpheus.gguf")
+        self.assertIsNone(out["gguf"])
+        self.assertFalse(out["loading"])
+        self.assertTrue(out["any"])
+
+    def test_mid_start_voice_slot_is_in_flight(self):
+        with _patch_backends(
+            _fake_inference_backend(),
+            _fake_llama_backend(active = False),
+            voice = _fake_llama_backend(active = True, loaded = False, identifier = "orpheus.gguf"),
+        ):
+            out = tv.summarize_resident_chat()
+        self.assertEqual(out["voice"], "orpheus.gguf")
+        self.assertTrue(out["loading"])
+
+    def test_cpu_only_voice_slot_is_not_a_vram_resident(self):
+        with _patch_backends(
+            _fake_inference_backend(),
+            _fake_llama_backend(active = False),
+            voice = _fake_llama_backend(active = True, identifier = "cpu.gguf", gpu_offload = False),
+        ):
+            out = tv.summarize_resident_chat()
+        self.assertIsNone(out["voice"])
+        self.assertFalse(out["any"])
 
 
 class TestSummarizeResidentStt(_GpuCacheResetMixin, unittest.TestCase):
@@ -536,6 +573,37 @@ class TestFreeChatModels(_GpuCacheResetMixin, unittest.TestCase):
         llama = _fake_llama_backend(active = False)
         with _patch_backends(inf, llama):
             freed = tv.free_chat_models_for_training(reason = "test")
+        self.assertEqual(freed, [])
+
+    def test_unloads_voice_slot_beside_chat_slot(self):
+        # Both llama-servers resident: freeing only the chat slot would leave the
+        # voice server holding VRAM under the trainer.
+        inf = _fake_inference_backend()
+        llama = _fake_llama_backend(active = True, identifier = "gemma.gguf")
+        voice = _fake_llama_backend(active = True, identifier = "orpheus.gguf")
+        with _patch_backends(inf, llama, voice = voice):
+            freed = tv.free_chat_models_for_training(reason = "test")
+        llama.unload_model.assert_called_once()
+        voice.unload_model.assert_called_once()
+        self.assertEqual(freed, ["gguf:gemma.gguf", "voice:orpheus.gguf"])
+
+    def test_unloads_voice_slot_alone(self):
+        inf = _fake_inference_backend()
+        llama = _fake_llama_backend(active = False)
+        voice = _fake_llama_backend(active = True, identifier = "orpheus.gguf")
+        with _patch_backends(inf, llama, voice = voice):
+            freed = tv.free_chat_models_for_training(reason = "test")
+        llama.unload_model.assert_not_called()
+        voice.unload_model.assert_called_once()
+        self.assertEqual(freed, ["voice:orpheus.gguf"])
+
+    def test_leaves_cpu_only_voice_slot_alone(self):
+        inf = _fake_inference_backend()
+        llama = _fake_llama_backend(active = False)
+        voice = _fake_llama_backend(active = True, identifier = "cpu.gguf", gpu_offload = False)
+        with _patch_backends(inf, llama, voice = voice):
+            freed = tv.free_chat_models_for_training(reason = "test")
+        voice.unload_model.assert_not_called()
         self.assertEqual(freed, [])
 
     def test_hf_failure_still_unloads_gguf(self):

--- a/studio/backend/tests/test_training_vram_coexistence.py
+++ b/studio/backend/tests/test_training_vram_coexistence.py
@@ -72,7 +72,11 @@ def _fake_llama_backend(
     return llama
 
 
-def _patch_backends(inf, llama, voice = None):
+def _patch_backends(
+    inf,
+    llama,
+    voice = None,
+):
     """Stub core.inference + routes.inference modules so the lazy imports inside
     training_vram resolve to fakes (avoids importing torch-heavy backends).
     ``voice`` is the voice-slot llama-server; empty unless a test loads one."""

--- a/studio/frontend/scripts/check-bundle-budget.ts
+++ b/studio/frontend/scripts/check-bundle-budget.ts
@@ -41,7 +41,14 @@ export const BUDGET = {
   // Raised for the audio placement control: same build both sides, merge base
   // 1,560.9 KB transfer against branch 1,562.6 KB, so it crossed the old 1,562.5 KB
   // ceiling by a tenth of a kilobyte.
-  transferBytes: 1_620_000,
+  // Raised again for voice conversation mode: same build both sides, merge base
+  // 1,571.5 KB transfer / 79 chunks against branch 1,582.2 KB / 79 chunks, so the
+  // 10.7 KB is the feature itself and not a chunk that stopped being lazy. It
+  // crossed the old 1,582.0 KB ceiling by two tenths of a kilobyte. Lazy-loading
+  // the orb and the pickers behind React.lazy was measured first and made both
+  // numbers worse -- more eagerly preloaded chunks, and more transfer -- so it was
+  // reverted rather than shipped to buy the headroom.
+  transferBytes: 1_632_000,
   rawBytes: 5_500_000,
 };
 

--- a/studio/frontend/src/components/assistant-ui/stt-model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/stt-model-selector.tsx
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { ArrowDown01Icon, CloudIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { MicIcon, MicVocalIcon } from "lucide-react";
+import { useEffect, useState, type FC } from "react";
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { useVoiceSettingsStore } from "@/features/settings/stores/voice-settings-store";
+import { DotTag } from "@/features/hub/catalog/dot-tag";
+import { formatBytes } from "@/features/hub/lib/format";
+import { splitRepoLabel } from "@/features/model-picker/components/model-selector/row-meta";
+import type { LoraModelOption } from "@/features/model-picker/components/model-selector/types";
+
+interface SttModelSelectorProps {
+  /** On-device Whisper models available to pick, in addition to Browser. */
+  models: LoraModelOption[];
+  /** Selected Whisper model id, or null for the browser's built-in engine. */
+  value: string | null;
+  onValueChange: (id: string | null) => void;
+  /** When true (no main chat model loaded), grey out and block the selector:
+   *  listening is pointless with no brain to generate replies. */
+  disabled?: boolean;
+  /** True when the STT engine is loaded and ready (browser always; Whisper after
+   *  warmup), so the listen icon goes green instead of grey. */
+  ready?: boolean;
+  /** True while Whisper is warming up, so the listen icon shows amber (loading)
+   *  rather than grey (idle). Takes precedence over `ready`. */
+  loading?: boolean;
+  className?: string;
+}
+
+const BROWSER_ENGINE_ID = null;
+const BROWSER_ENGINE_LABEL = "Browser";
+
+// Input-device picker: pins the voice-loop mic to a specific device so it
+// captures the user's headset mic and not a loopback / "Stereo Mix" / default-
+// communications device that mixes in system/app audio (e.g. a Discord call).
+// Applies to both the Whisper and browser capture paths. Rendered as themed
+// button rows (not a native <select>, whose option list renders unstyled
+// white-on-white). Device labels are only populated once mic permission has been
+// granted; before that they read as generic names.
+const MicDevicePicker: FC = () => {
+  const selectedMicDeviceId = useChatRuntimeStore((s) => s.selectedMicDeviceId);
+  const setSelectedMicDeviceId = useChatRuntimeStore((s) => s.setSelectedMicDeviceId);
+  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const enumerate = () => {
+      navigator.mediaDevices
+        ?.enumerateDevices()
+        .then((all) => {
+          if (cancelled) return;
+          setDevices(all.filter((d) => d.kind === "audioinput"));
+        })
+        .catch(() => {});
+    };
+    enumerate();
+    navigator.mediaDevices?.addEventListener?.("devicechange", enumerate);
+    return () => {
+      cancelled = true;
+      navigator.mediaDevices?.removeEventListener?.("devicechange", enumerate);
+    };
+  }, []);
+
+  if (devices.length === 0) return null;
+
+  const rows: { id: string | null; label: string }[] = [
+    { id: null, label: "Default input" },
+    ...devices.map((d, i) => ({
+      id: d.deviceId,
+      label: d.label || `Microphone ${i + 1}`,
+    })),
+  ];
+  const current =
+    rows.find((r) => r.id === (selectedMicDeviceId ?? null)) ?? rows[0];
+
+  return (
+    <>
+      <div className="my-1.5 h-px bg-black/[0.08] dark:bg-white/[0.08]" />
+      <div className="px-2 pb-1 pt-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        Microphone
+      </div>
+      {/* Collapsed selector: shows the current mic; expands the device list on
+          click so many inputs don't blow out the popover height. */}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2 rounded-full px-2 py-1.5 text-left text-sm transition-colors hover:bg-[#ececec] dark:hover:bg-[var(--sidebar-accent)]"
+      >
+        <MicIcon className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate">{current.label}</span>
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
+          strokeWidth={2}
+          className={cn(
+            "size-3.5 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open && (
+        <div className="max-h-[8.5rem] overflow-y-auto">
+          {rows.map((row, i) => {
+            const active = (selectedMicDeviceId ?? null) === row.id;
+            return (
+              <button
+                key={row.id ?? `default-${i}`}
+                type="button"
+                onClick={() => {
+                  setSelectedMicDeviceId(row.id);
+                  setOpen(false);
+                }}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-full px-2 py-1.5 pl-7 text-left text-sm transition-colors hover:bg-[#ececec] dark:hover:bg-[var(--sidebar-accent)]",
+                  active && "bg-[#ececec] dark:bg-[var(--sidebar-accent)]",
+                )}
+              >
+                <span className="min-w-0 flex-1 truncate">{row.label}</span>
+                {active && (
+                  <DotTag
+                    tone="success"
+                    label="Active"
+                    className="ml-auto h-[18px] shrink-0 gap-1 rounded-md px-1.5"
+                    dotClassName="size-[5px]"
+                  />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+};
+
+// Speech-to-text picker, split out from the TTS ("Speak with") picker so each
+// can grey out independently -- listening stays available even when the
+// loaded chat model is a speech-LLM that owns its own output voice. Lists
+// on-device Whisper models the same way the TTS picker lists voices;
+// downloading new ones happens in the main model dropdown's Hub search, not here.
+export const SttModelSelector: FC<SttModelSelectorProps> = ({
+  models,
+  value,
+  onValueChange,
+  disabled = false,
+  ready = false,
+  loading = false,
+  className,
+}) => {
+  const [open, setOpen] = useState(false);
+  // The PR carried its own sttEngine field; upstream since shipped the same
+  // choice as dictationEngine in the Voice settings tab. Drive that one, so the
+  // picker and Settings cannot disagree about which engine is listening.
+  const setDictationEngine = useVoiceSettingsStore((s) => s.setDictationEngine);
+
+  const selectedModel = value ? models.find((m) => m.id === value) : null;
+  const displayName = selectedModel?.name ?? BROWSER_ENGINE_LABEL;
+
+  const handleSelect = (id: string | null) => {
+    setOpen(false);
+    setDictationEngine(id === BROWSER_ENGINE_ID ? "browser" : "model");
+    onValueChange(id);
+  };
+
+  return (
+    <Popover
+      open={disabled ? false : open}
+      onOpenChange={(next) => !disabled && setOpen(next)}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "flex min-w-0 items-center gap-2 rounded-[10px] transition-colors",
+            disabled
+              ? "cursor-not-allowed opacity-50"
+              : "hover:bg-[#ececec] dark:hover:bg-[#2d2e32]",
+            "h-9 px-3.5 text-sm",
+            className,
+          )}
+          aria-label={disabled ? "Select a chat model first" : "Select listening engine"}
+        >
+          <MicVocalIcon
+            className={cn(
+              "size-3.5 shrink-0",
+              loading
+                ? "text-amber-500"
+                : ready && !disabled
+                  ? "text-emerald-500"
+                  : "text-muted-foreground",
+            )}
+          />
+          <span className="min-w-0 truncate font-heading text-[16px] font-medium leading-tight text-black dark:text-white">
+            {disabled ? "Select model first" : displayName}
+          </span>
+          <span className="flex size-4 shrink-0 items-center justify-center">
+            <HugeiconsIcon
+              icon={ArrowDown01Icon}
+              className="size-3.5 text-muted-foreground"
+              strokeWidth={2}
+            />
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="unsloth-model-selector-menu menu-soft-surface w-[340px] gap-0 rounded-lg border-0 p-1.5 ring-0"
+      >
+        <div className="px-2 pb-1 pt-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Listen with
+        </div>
+
+        {/* Browser's built-in speech recognition -- not a downloadable file,
+            so it's badged like a cloud/API entry rather than an on-device one. */}
+        <button
+          type="button"
+          onClick={() => handleSelect(BROWSER_ENGINE_ID)}
+          className={cn(
+            "flex w-full items-center gap-2 rounded-full px-2 py-1.5 text-left text-sm transition-colors hover:bg-[#ececec] dark:hover:bg-[var(--sidebar-accent)]",
+            value === null && "bg-[#ececec] dark:bg-[var(--sidebar-accent)]",
+          )}
+        >
+          <MicVocalIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate">{BROWSER_ENGINE_LABEL}</span>
+          <span className="ml-auto flex shrink-0 items-center gap-1.5">
+            <HugeiconsIcon
+              icon={CloudIcon}
+              strokeWidth={1.75}
+              className="size-3.5 text-muted-foreground"
+            />
+            {value === null && (
+              <DotTag
+                tone="success"
+                label="Active"
+                className="h-[18px] gap-1 rounded-md px-1.5"
+                dotClassName="size-[5px]"
+              />
+            )}
+          </span>
+        </button>
+
+        {models.length > 0 && (
+          <div className="my-1.5 h-px bg-black/[0.08] dark:bg-white/[0.08]" />
+        )}
+
+        {models.map((model) => {
+          const { name } = splitRepoLabel(model.id);
+          return (
+            <button
+              key={model.id}
+              type="button"
+              onClick={() => handleSelect(model.id)}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-full px-2 py-1.5 text-left text-sm transition-colors hover:bg-[#ececec] dark:hover:bg-[var(--sidebar-accent)]",
+                value === model.id && "bg-[#ececec] dark:bg-[var(--sidebar-accent)]",
+              )}
+            >
+              <span className="min-w-0 flex-1 truncate">{name}</span>
+              <span className="ml-auto flex shrink-0 items-center gap-1.5">
+                {model.deviceSizeBytes != null && (
+                  <span className="shrink-0 text-[11px] text-muted-foreground">
+                    {formatBytes(model.deviceSizeBytes)}
+                  </span>
+                )}
+                {!model.source && (
+                  <DotTag
+                    tone={model.isGguf ? "gguf" : "checkpoint"}
+                    label={model.isGguf ? "GGUF" : "Safetensors"}
+                    className="h-[18px] gap-1 rounded-md px-1.5"
+                    dotClassName="size-[5px]"
+                  />
+                )}
+                {value === model.id && (
+                  <DotTag
+                    tone="success"
+                    label="Active"
+                    className="h-[18px] gap-1 rounded-md px-1.5"
+                    dotClassName="size-[5px]"
+                  />
+                )}
+              </span>
+            </button>
+          );
+        })}
+
+        {models.length === 0 && (
+          <p className="px-3 py-2 text-[12px] text-muted-foreground">
+            No Whisper models on device. Download one from the model dropdown.
+          </p>
+        )}
+
+        <MicDevicePicker />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -97,6 +97,13 @@ import {
   resolveProjectId,
   sentAudioNames,
 } from "@/features/chat/api/chat-adapter";
+import { requestVoiceToggle } from "@/features/chat/voice/voice-loop-bridge";
+import {
+  useVoiceAvailable,
+  VoiceControlButton,
+  VoiceEngine,
+} from "@/features/chat/voice/voice-engine";
+import { VoiceOrb } from "@/components/assistant-ui/voice-orb";
 import {
   PromptStorageDialog,
   exportConversationShareGPT,
@@ -458,7 +465,7 @@ function deletePromptQueueRun(run: PromptQueueRun) {
   syncPromptQueueUI();
 }
 
-function resetPromptQueues() {
+export function resetPromptQueues() {
   for (const run of promptQueueRuns.values()) {
     run.generation += 1;
     clearPromptQueueRetryTimer(run);
@@ -1545,6 +1552,15 @@ export const Thread: FC<{
   const { ref: viewportRef, context: autoScrollContext } =
     useIntentAwareAutoScroll();
 
+  // Force the docked composer (and suppress the centered welcome) only once the
+  // full orb is ACTIVE -- including its warmup -- so the empty-thread orb view
+  // always has a bottom input bar above it (z-40) instead of the orb-covered
+  // welcome composer. Deliberately NOT keyed on merely "configuring": pressing the
+  // Voice toggle should leave you in the normal chat/welcome with a grey mini orb;
+  // opening the full orb is exclusively the mini-orb button's job.
+  const voiceActive = useChatRuntimeStore((s) => s.voiceMode === "active");
+  const effectiveHideWelcome = hideWelcome || voiceActive;
+
   const isComposerAttachPending = useAuiState(({ threads }) =>
     targetThreadId ? threads.mainThreadId !== targetThreadId : false,
   );
@@ -1790,7 +1806,7 @@ export const Thread: FC<{
                   "pt-[calc(var(--studio-content-top-inset,0px)+48px+var(--studio-chat-notice-height,0px))]",
             )}
           >
-            {!hideWelcome && (
+            {!effectiveHideWelcome && (
               <AuiIf
                 condition={({ thread }) => thread.isEmpty && !thread.isLoading}
               >
@@ -1813,7 +1829,7 @@ export const Thread: FC<{
             {/* Bottom slack so the last message has room above the sticky
             scroll-to-bottom button (and floating composer in single mode),
             instead of butting against the footer. */}
-            <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
+            <AuiIf condition={({ thread }) => effectiveHideWelcome || !thread.isEmpty}>
               <div
                 ref={spacerRef}
                 className={cn(
@@ -1828,7 +1844,7 @@ export const Thread: FC<{
               />
             </AuiIf>
 
-            <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
+            <AuiIf condition={({ thread }) => effectiveHideWelcome || !thread.isEmpty}>
               <ThreadPrimitive.ViewportFooter
                 className={cn(
                   "aui-thread-viewport-footer pointer-events-none sticky z-20 flex w-full justify-center bg-transparent",
@@ -1854,9 +1870,10 @@ export const Thread: FC<{
             hideComposer={hideComposer}
             bottomOffsetPx={footerBottomPx}
           />
+          <VoiceOrb />
 
           {!hideComposer && (
-            <AuiIf condition={({ thread }) => hideWelcome || !thread.isEmpty}>
+            <AuiIf condition={({ thread }) => effectiveHideWelcome || !thread.isEmpty}>
               <ThreadComposerDock
                 disabled={isComposerAttachPending}
                 threadId={threadId}
@@ -1984,6 +2001,7 @@ const ThreadComposerDock: FC<{
   onHeightChange?: (height: number | null) => void;
 }> = ({ disabled, threadId, onHeightChange }) => {
   const { overlay } = useGeneratedImageOverlay();
+  const voiceOrbActive = useChatRuntimeStore((s) => s.voiceOrbState !== null);
   const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
   const threadListItemId = useAuiState(
     ({ threadListItem }) => threadListItem.id,
@@ -2030,7 +2048,7 @@ const ThreadComposerDock: FC<{
       ref={dockRef}
       className={cn(
         "aui-thread-composer-dock pointer-events-none absolute bottom-0 left-0 right-0 md:right-[10px]",
-        overlay ? "z-40" : "z-20",
+        overlay || voiceOrbActive ? "z-40" : "z-20",
       )}
     >
       {/* Fade the top edge so scrolling text is not cut off by a hard line. */}
@@ -5761,6 +5779,8 @@ const ComposerToolsMenu: FC<{
   researchAvailable: boolean;
 }> = ({ side = "bottom", researchAvailable }) => {
   const navigate = useNavigate();
+  const voiceMode = useChatRuntimeStore((s) => s.voiceMode);
+  const voiceAvailable = useVoiceAvailable();
   const toolsEnabled = useChatRuntimeStore((s) => s.toolsEnabled);
   const setToolsEnabled = useChatRuntimeStore((s) => s.setToolsEnabled);
   const codeToolsEnabled = useChatRuntimeStore((s) => s.codeToolsEnabled);
@@ -6256,6 +6276,27 @@ const ComposerToolsMenu: FC<{
             ) : null}
           </DropdownMenuItem>
         )}
+        {voiceAvailable && (
+          <DropdownMenuItem
+            className={voiceMode !== "off" ? "text-primary font-medium" : undefined}
+            onSelect={() => requestVoiceToggle()}
+          >
+            <MicIcon className="size-[18px]" />
+            Voice
+            {voiceMode === "active" ? (
+              <HugeiconsIcon
+                icon={Tick02Icon}
+                strokeWidth={2}
+                className="ml-auto"
+              />
+            ) : voiceMode === "configuring" ? (
+              <span
+                className="ml-auto size-2 rounded-full bg-amber-500"
+                aria-hidden
+              />
+            ) : null}
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
         {pinnedPlusItems.map((id) => (
           <Fragment key={id}>{plusMenuNodes[id]}</Fragment>
@@ -6616,24 +6657,36 @@ const ComposerRightControls: FC<{
     }
     if (isQueueRunning) onStopClick?.();
   };
+  // While voice mode is engaged, the mini orb is the mic control; hide the raw
+  // Dictate / Stop-dictation buttons (the loop drives dictation internally via
+  // the composer runtime's startDictation()/stopDictation(), not by clicking
+  // these). Kept mounted (display:none) only so composer state stays consistent.
+  const voiceEngaged = useChatRuntimeStore((s) => s.voiceMode !== "off");
   return (
     <div className="aui-composer-action-wrapper flex shrink-0 items-center gap-1.5">
       <ReasoningToggle side={menuSide} />
+      <VoiceEngine />
+      <VoiceControlButton />
       {/* Starts dictation; the recording bar then covers the input row and owns
-          the stop and send actions. */}
-      <ComposerPrimitive.If dictation={false}>
-        <TooltipIconButton
-          tooltip="Dictate"
-          aria-label="Dictate"
-          type="button"
-          variant="ghost"
-          className="size-8 rounded-full text-foreground"
-          onClick={onDictateClick}
-        >
-          {/* size-[22px] is the fallback; unsloth-dictate-icon sets the size. */}
-          <MicIcon className="unsloth-dictate-icon size-[22px]" />
-        </TooltipIconButton>
-      </ComposerPrimitive.If>
+          the stop and send actions. Hidden while voice mode is engaged: the mini
+          orb is the mic control there, and the loop drives dictation through the
+          composer runtime rather than by clicking this. Kept mounted so composer
+          state stays consistent across entering and leaving voice mode. */}
+      <div className={cn(voiceEngaged ? "hidden" : "contents")}>
+        <ComposerPrimitive.If dictation={false}>
+          <TooltipIconButton
+            tooltip="Dictate"
+            aria-label="Dictate"
+            type="button"
+            variant="ghost"
+            className="size-8 rounded-full text-foreground"
+            onClick={onDictateClick}
+          >
+            {/* size-[22px] is the fallback; unsloth-dictate-icon sets the size. */}
+            <MicIcon className="unsloth-dictate-icon size-[22px]" />
+          </TooltipIconButton>
+        </ComposerPrimitive.If>
+      </div>
       <AuiIf
         condition={({ thread }) =>
           !thread.isRunning && !isQueueRunning && !isResearchActive

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -465,7 +465,7 @@ function deletePromptQueueRun(run: PromptQueueRun) {
   syncPromptQueueUI();
 }
 
-export function resetPromptQueues() {
+function resetPromptQueues() {
   for (const run of promptQueueRuns.values()) {
     run.generation += 1;
     clearPromptQueueRetryTimer(run);
@@ -478,6 +478,17 @@ export function resetPromptQueues() {
   clearPromptQueuePumpTimer();
   stopPromptQueueSubscription();
   syncPromptQueueUI();
+}
+
+// Drop the queued prompts of ONE thread and nothing else. The voice loop calls
+// this when a spoken utterance supersedes that thread's queue; a global reset
+// there would silently discard prompts queued in background chats too. Delete
+// only, no target cancel, matching resetPromptQueues -- the caller has already
+// cancelled the run it means to cancel.
+export function resetPromptQueuesForThread(threadId: string) {
+  for (const run of getPromptQueueRunsForThreadIds([threadId])) {
+    deletePromptQueueRun(run);
+  }
 }
 
 function requestPromptQueuePumpIfReady(delay = 0) {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2290,6 +2290,13 @@ const Composer: FC<{
 }> = ({ disabled, threadId, menuSide, disableQueue }) => {
   const aui = useAui();
   const isDictating = useAuiState((s) => s.composer.dictation != null);
+  // In voice mode the orb is the entire mic interface. The loop keeps a dictation
+  // session open continuously, so the composer's recording bar would sit there
+  // counting from the moment voice starts -- reading as "recording you" during
+  // every pause and every reply. The session is real and must stay open; only its
+  // UI is wrong here, so hide the presentation and leave the state alone.
+  const voiceEngaged = useChatRuntimeStore((s) => s.voiceMode !== "off");
+  const showDictationUi = isDictating && !voiceEngaged;
   const pageDragging = useContext(PageDragContext);
   const { overlay, closeOverlay } = useGeneratedImageOverlay();
   const setImageToolsEnabled = useChatRuntimeStore(
@@ -4725,7 +4732,7 @@ const Composer: FC<{
 
   const composerContent = (
     <>
-      {!isDictating ? (
+      {!showDictationUi ? (
         <>
           <ComposerAttachments />
           <PendingAudioChip />
@@ -4733,19 +4740,19 @@ const Composer: FC<{
       ) : null}
       {/* Keep indexing state subscribed while dictating, but hide its chips so
           the waveform stays the composer's only status indicator. */}
-      <div className={isDictating ? "hidden" : "contents"}>
+      <div className={showDictationUi ? "hidden" : "contents"}>
         <ThreadDocumentsBar
           threadId={referenceThreadId}
           onIndexingChange={handleIndexingChange}
         />
       </div>
-      {!isDictating ? <ToolStatusDisplay /> : null}
+      {!showDictationUi ? <ToolStatusDisplay /> : null}
       <div
         className="unsloth-composer-line"
         // The permission pill is always visible, so keep the two-row layout
         // expanded whenever not dictating; dictation collapses to the bar.
-        data-expanded={!isDictating ? "true" : "false"}
-        data-dictating={isDictating ? "true" : undefined}
+        data-expanded={!showDictationUi ? "true" : "false"}
+        data-dictating={showDictationUi ? "true" : undefined}
       >
         <div
           ref={pillRowRef}
@@ -4778,7 +4785,7 @@ const Composer: FC<{
             </>
           ) : null}
         </div>
-        {isDictating ? (
+        {showDictationUi ? (
           // The recording UI replaces the input and send controls; only the
           // left plus stays visible alongside it.
           <ChatDictationBar

--- a/studio/frontend/src/components/assistant-ui/voice-model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/voice-model-selector.tsx
@@ -296,9 +296,14 @@ export const VoiceModelSelector: FC<VoiceModelSelectorProps> = ({
               </button>
               {model.isGguf && isExpanded && (
                 <div className="max-h-[240px] overflow-y-auto pl-2">
+                  {/* A browse listing, not an On Device one: onDevice honors the
+                      global "Show all quantizations" setting (off by default) and
+                      lists only quants already on disk, so the uncached default
+                      voice expanded to "No GGUF variants found" on a fresh install
+                      and its first-use download could never start. Every row here
+                      downloads a missing quant on pick, so every quant is offered. */}
                   <GgufVariantExpander
                     repoId={model.id}
-                    onDevice
                     onSelect={(id, meta) =>
                       handleSelect(id, meta.ggufVariant ?? null)
                     }

--- a/studio/frontend/src/components/assistant-ui/voice-model-selector.tsx
+++ b/studio/frontend/src/components/assistant-ui/voice-model-selector.tsx
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import { ArrowDown01Icon, CloudIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Speech } from "lucide-react";
+import { useState, type FC } from "react";
+import { useChatRuntimeStore } from "@/features/chat";
+import { DotTag } from "@/features/hub/catalog/dot-tag";
+import { GgufVariantExpander } from "@/features/model-picker/components/model-selector/pickers";
+import { splitRepoLabel } from "@/features/model-picker/components/model-selector/row-meta";
+import type { LoraModelOption } from "@/features/model-picker/components/model-selector/types";
+
+interface VoiceModelSelectorProps {
+  models: LoraModelOption[];
+  value: string | null;
+  onValueChange: (id: string | null) => void;
+  loading?: boolean;
+  /** When true (no main chat model loaded), grey out and block the selector:
+   *  picking a voice would load a TTS model with no brain to generate replies. */
+  disabled?: boolean;
+  /** When true, the loaded chat model is a speech-LLM (Orpheus etc.) that speaks
+   *  with its own voice, so a separate voice does not apply and the picker is
+   *  disabled. ChatPage also clears and unloads the slot when this becomes true. */
+  voiceOwnedByModel?: boolean;
+  /** True only when the backend voice slot is actually loaded with this voice
+   *  (from /voice/status), so the speak icon goes green. A mere selection is not
+   *  enough -- it persists but doesn't load the slot until voice mode starts. */
+  loaded?: boolean;
+  className?: string;
+}
+
+const BROWSER_VOICE_ID = null;
+const BROWSER_VOICE_LABEL = "Browser voice";
+
+// How many sentence chunks a GGUF voice slot synthesizes at once (llama-server
+// --parallel N). If a voice is loaded, changing it hot-reloads that slot so
+// backend and UI stay in sync.
+const ParallelVoicesPicker: FC<{
+  reloadVoiceId: string | null;
+  onReload: (id: string) => void;
+}> = ({ reloadVoiceId, onReload }) => {
+  const value = useChatRuntimeStore((s) => s.voiceParallelN);
+  const setValue = useChatRuntimeStore((s) => s.setVoiceParallelN);
+  return (
+    <>
+      <div className="my-1.5 h-px bg-black/[0.08] dark:bg-white/[0.08]" />
+      <div className="flex items-center justify-between gap-2 px-2 py-1">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Parallel synthesis
+        </span>
+        <div className="flex items-center gap-1">
+          {[1, 2, 3, 4].map((n) => (
+            <button
+              key={n}
+              type="button"
+              onClick={() => {
+                if (n === value) return;
+                setValue(n);
+                // Hot-reload the active GGUF voice so its --parallel matches now.
+                if (reloadVoiceId) onReload(reloadVoiceId);
+              }}
+              className={cn(
+                "flex size-6 items-center justify-center rounded-md text-[13px] transition-colors",
+                value === n
+                  ? "bg-[#ececec] text-foreground dark:bg-[var(--sidebar-accent)]"
+                  : "text-muted-foreground hover:bg-[#ececec] dark:hover:bg-[var(--sidebar-accent)]",
+              )}
+              aria-label={`${n} parallel voice${n > 1 ? "s" : ""}`}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </div>
+      <p className="px-2 pb-1 text-[10px] leading-tight text-muted-foreground/70">
+        GGUF voices only.
+      </p>
+    </>
+  );
+};
+
+export const VoiceModelSelector: FC<VoiceModelSelectorProps> = ({
+  models,
+  value,
+  onValueChange,
+  loading = false,
+  disabled = false,
+  voiceOwnedByModel = false,
+  loaded = false,
+  className,
+}) => {
+  const [open, setOpen] = useState(false);
+  // Which GGUF voice row is expanded to show its quant list.
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const setSelectedVoiceVariant = useChatRuntimeStore(
+    (s) => s.setSelectedVoiceVariant,
+  );
+
+  const selectedVoiceVariant = useChatRuntimeStore((s) => s.selectedVoiceVariant);
+  const selectedModel = value ? models.find((m) => m.id === value) : null;
+
+  // The picker is non-interactive when there's no chat model to answer (disabled)
+  // OR the chat model is a speech-LLM that speaks with its own voice
+  // (voiceOwnedByModel) -- in both cases it greys out and can't be opened.
+  const inactive = disabled || voiceOwnedByModel;
+  // Green only when a voice is truly loaded: the backend slot is up with this
+  // voice, or the chat model speaks with its own voice. A persisted selection
+  // alone (slot not yet loaded, e.g. right after a reload) stays grey.
+  const ready = voiceOwnedByModel || loaded;
+  // Match the chat-model trigger: bold name + a muted "GGUF · <quant>" suffix,
+  // rather than appending the quant in the same weight as the name.
+  const nameText = disabled
+    ? "Select model first"
+    : voiceOwnedByModel
+      ? "Model's own voice"
+      : selectedModel
+        ? selectedModel.name
+        : BROWSER_VOICE_LABEL;
+  const metaText =
+    !inactive && selectedModel?.isGguf && selectedVoiceVariant
+      ? `GGUF · ${selectedVoiceVariant}`
+      : null;
+
+  const handleSelect = (id: string | null, variant: string | null = null) => {
+    setOpen(false);
+    setSelectedVoiceVariant(variant);
+    onValueChange(id);
+  };
+
+  return (
+    <Popover
+      open={inactive ? false : open}
+      onOpenChange={(next) => !inactive && setOpen(next)}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={inactive}
+          title={
+            voiceOwnedByModel
+              ? "The loaded model is a speech-LLM and speaks with its own voice."
+              : undefined
+          }
+          className={cn(
+            "flex min-w-0 items-center gap-2 rounded-[10px] transition-colors",
+            inactive
+              ? "cursor-not-allowed opacity-50"
+              : "hover:bg-[#ececec] dark:hover:bg-[#2d2e32]",
+            "h-9 px-3.5 text-sm",
+            className,
+          )}
+          aria-label={
+            disabled
+              ? "Select a chat model first"
+              : voiceOwnedByModel
+                ? "The chat model provides its own voice"
+                : "Select voice model"
+          }
+        >
+          {loading && !voiceOwnedByModel ? (
+            <Spinner className="size-3.5 shrink-0 text-amber-500" />
+          ) : (
+            <Speech
+              className={cn(
+                "size-3.5 shrink-0",
+                ready ? "text-emerald-500" : "text-muted-foreground",
+              )}
+            />
+          )}
+          <span className="flex min-w-0 items-baseline">
+            <span className="min-w-0 truncate font-heading text-[16px] font-medium leading-tight text-black dark:text-white">
+              {nameText}
+            </span>
+            {metaText && (
+              <span className="ml-2 shrink-0 text-xs leading-none text-muted-foreground">
+                {metaText}
+              </span>
+            )}
+          </span>
+          {/* Chevron only when the picker can actually open. */}
+          {!inactive && (
+            <span className="flex size-4 shrink-0 items-center justify-center">
+              <HugeiconsIcon
+                icon={ArrowDown01Icon}
+                className="size-3.5 text-muted-foreground"
+                strokeWidth={2}
+              />
+            </span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="unsloth-model-selector-menu menu-soft-surface w-[340px] gap-0 rounded-lg border-0 p-1.5 ring-0"
+      >
+        <div className="px-2 pb-1 pt-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Speak with
+        </div>
+
+        {/* Browser's built-in speech synthesis -- not a downloadable file, so
+            it's badged like a cloud/API entry rather than an on-device one. The
+            picker only opens for a regular chat model; a speech-LLM greys the
+            trigger out (voiceOwnedByModel), so no "own voice" message is needed
+            here. Entering the ball is a separate phone button in the composer. */}
+        <button
+          type="button"
+          onClick={() => handleSelect(BROWSER_VOICE_ID)}
+          className={cn(
+            "flex w-full items-center gap-2 rounded-full px-2 py-1.5 text-left text-sm transition-colors hover:bg-[#ececec] dark:hover:bg-[var(--sidebar-accent)]",
+            value === null && "bg-[#ececec] dark:bg-[var(--sidebar-accent)]",
+          )}
+        >
+          <Speech className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate">{BROWSER_VOICE_LABEL}</span>
+          <span className="ml-auto flex shrink-0 items-center gap-1.5">
+            <HugeiconsIcon
+              icon={CloudIcon}
+              strokeWidth={1.75}
+              className="size-3.5 text-muted-foreground"
+            />
+            {value === null && (
+              <DotTag
+                tone="success"
+                label="Active"
+                className="h-[18px] gap-1 rounded-md px-1.5"
+                dotClassName="size-[5px]"
+              />
+            )}
+          </span>
+        </button>
+
+        {models.length > 0 && (
+          <div className="my-1.5 h-px bg-black/[0.08] dark:bg-white/[0.08]" />
+        )}
+
+        {models.map((model) => {
+          const { name } = splitRepoLabel(model.id);
+          const isExpanded = expandedId === model.id;
+          // A repo expands to the same quant list as the model picker, so clicking
+          // the row toggles the quants instead of loading the repo default. A row that
+          // is already one loadable artifact loads directly on click.
+          return (
+            <div key={model.id}>
+              <button
+                type="button"
+                onClick={() =>
+                  model.isGguf
+                    ? setExpandedId(isExpanded ? null : model.id)
+                    : handleSelect(model.id)
+                }
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-full px-2 py-1.5 text-left text-sm transition-colors hover:bg-[#ececec] dark:hover:bg-[var(--sidebar-accent)]",
+                  value === model.id && "bg-[#ececec] dark:bg-[var(--sidebar-accent)]",
+                )}
+              >
+                <span className="min-w-0 flex-1 truncate">{name}</span>
+                <span className="ml-auto flex shrink-0 items-center gap-1.5">
+                  {/* No size tag here: every voice this picker lists is a GGUF, and
+                      GGUF sizes belong to the per-quant expander below. */}
+                  {!model.source && (
+                    <DotTag
+                      tone={model.isGguf ? "gguf" : "checkpoint"}
+                      label={model.isGguf ? "GGUF" : "Safetensors"}
+                      className="h-[18px] gap-1 rounded-md px-1.5"
+                      dotClassName="size-[5px]"
+                    />
+                  )}
+                  {value === model.id && (
+                    <DotTag
+                      tone="success"
+                      label="Active"
+                      className="h-[18px] gap-1 rounded-md px-1.5"
+                      dotClassName="size-[5px]"
+                    />
+                  )}
+                  {model.isGguf && (
+                    <HugeiconsIcon
+                      icon={ArrowDown01Icon}
+                      strokeWidth={2}
+                      className={cn(
+                        "size-3.5 text-muted-foreground transition-transform",
+                        isExpanded && "rotate-180",
+                      )}
+                    />
+                  )}
+                </span>
+              </button>
+              {model.isGguf && isExpanded && (
+                <div className="max-h-[240px] overflow-y-auto pl-2">
+                  <GgufVariantExpander
+                    repoId={model.id}
+                    onDevice
+                    onSelect={(id, meta) =>
+                      handleSelect(id, meta.ggufVariant ?? null)
+                    }
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {models.length === 0 && (
+          <p className="px-3 py-2 text-[12px] text-muted-foreground">
+            No TTS models found. Train or export a voice model first.
+          </p>
+        )}
+
+        <ParallelVoicesPicker
+          reloadVoiceId={value && selectedModel?.isGguf ? value : null}
+          onReload={(id) => onValueChange(id)}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/studio/frontend/src/components/assistant-ui/voice-name-picker.tsx
+++ b/studio/frontend/src/components/assistant-ui/voice-name-picker.tsx
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { cn } from "@/lib/utils";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+
+// orpheus-3b-0.1-ft speakers. Orpheus randomizes the voice unless one is pinned,
+// so this picker lets the user choose which built-in speaker the TTS uses.
+const ORPHEUS_VOICES = ["tara", "leah", "jess", "leo", "dan", "mia", "zac", "zoe"];
+const cap = (v: string) => v.charAt(0).toUpperCase() + v.slice(1);
+
+/** Speaker picker for the Orpheus voice slot. Renders only when an Orpheus voice
+ *  is selected -- other TTS codecs (Spark's bicodec, Oute's dac) pick their voice
+ *  differently (a speaker id or a reference clip), so a named-speaker list does not
+ *  apply to them.
+ *  Uses the themed dropdown so it tracks light/dark like the other top-bar menus. */
+export function VoiceNamePicker({ className }: { className?: string }) {
+  const voiceModelId = useChatRuntimeStore((s) => s.selectedVoiceModelId);
+  const voiceName = useChatRuntimeStore((s) => s.selectedVoiceName);
+  const setVoiceName = useChatRuntimeStore((s) => s.setSelectedVoiceName);
+
+  if (!voiceModelId || !voiceModelId.toLowerCase().includes("orpheus")) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild={true}>
+        <button
+          type="button"
+          aria-label="Voice speaker"
+          className={cn(
+            "flex h-[34px] shrink-0 items-center gap-1 rounded-lg pl-2.5 pr-1.5",
+            "text-[13.5px] text-foreground transition-colors hover:bg-accent/60",
+            "focus-visible:outline-none",
+            className,
+          )}
+        >
+          <span>{cap(voiceName)}</span>
+          <ChevronDownIcon className="size-3.5 text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[150px]">
+        <DropdownMenuLabel className="text-[11px] font-normal text-muted-foreground">
+          Orpheus voice
+        </DropdownMenuLabel>
+        {ORPHEUS_VOICES.map((v) => (
+          <DropdownMenuItem
+            key={v}
+            onSelect={() => setVoiceName(v)}
+            className="flex items-center justify-between gap-4"
+          >
+            <span>{cap(v)}</span>
+            {v === voiceName && <CheckIcon className="size-4 text-primary" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/studio/frontend/src/components/assistant-ui/voice-orb.tsx
+++ b/studio/frontend/src/components/assistant-ui/voice-orb.tsx
@@ -29,7 +29,8 @@ export const orbConfig = {
     duration: "1.4s",
     shadow: "0 0 32px 8px rgba(251,113,133,0.4)",
   },
-  // Grey-blue slow pulse: a model is loading / warming (voice slot or Whisper),
+  // Grey-blue slow pulse: a model is loading / warming (the voice slot, or the
+  // transcription model),
   // so it clearly reads as "not ready yet" -- distinct from the idle grey and the
   // ready green. Separate from lilac, which now means only TTS generating speech.
   loading: {
@@ -38,7 +39,8 @@ export const orbConfig = {
     duration: "2s",
     shadow: "0 0 26px 6px rgba(148,163,184,0.3)",
   },
-  // Fuchsia quick pulse: Whisper is turning your captured speech into text. A
+  // Fuchsia quick pulse: the transcription engine is turning your captured
+  // speech into text. A
   // magenta hue -- the farthest from the idle/listening green on the palette -- so
   // "transcribing" never reads as "ready", and its pencil icon plus this colour
   // keep it distinct from the amber "generating LLM response" below.

--- a/studio/frontend/src/components/assistant-ui/voice-orb.tsx
+++ b/studio/frontend/src/components/assistant-ui/voice-orb.tsx
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { voiceOutputLevel } from "@/features/chat/hooks/use-tts-player";
+import { cn } from "@/lib/utils";
+import {
+  AudioLinesIcon,
+  AudioWaveformIcon,
+  LoaderCircleIcon,
+  MicIcon,
+  PencilLineIcon,
+} from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { useEffect, useRef, type FC } from "react";
+
+export const orbConfig = {
+  listening: {
+    gradient: "radial-gradient(circle at 40% 35%, #34d399, #059669)",
+    animation: "voice-orb-breathe",
+    duration: "3s",
+    shadow: "0 0 32px 8px rgba(52,211,153,0.35)",
+  },
+  // Salmon pink: the mic is actively hearing your voice (distinct from the idle
+  // green "listening"). A quicker breathe so it reads as responsive/live.
+  hearing: {
+    gradient: "radial-gradient(circle at 40% 35%, #ffb0a0, #fb7185)",
+    animation: "voice-orb-breathe",
+    duration: "1.4s",
+    shadow: "0 0 32px 8px rgba(251,113,133,0.4)",
+  },
+  // Grey-blue slow pulse: a model is loading / warming (voice slot or Whisper),
+  // so it clearly reads as "not ready yet" -- distinct from the idle grey and the
+  // ready green. Separate from lilac, which now means only TTS generating speech.
+  loading: {
+    gradient: "radial-gradient(circle at 40% 35%, #94a3b8, #475569)",
+    animation: "voice-orb-pulse",
+    duration: "2s",
+    shadow: "0 0 26px 6px rgba(148,163,184,0.3)",
+  },
+  // Fuchsia quick pulse: Whisper is turning your captured speech into text. A
+  // magenta hue -- the farthest from the idle/listening green on the palette -- so
+  // "transcribing" never reads as "ready", and its pencil icon plus this colour
+  // keep it distinct from the amber "generating LLM response" below.
+  transcribing: {
+    gradient: "radial-gradient(circle at 40% 35%, #e879f9, #c026d3)",
+    animation: "voice-orb-pulse",
+    duration: "1.1s",
+    shadow: "0 0 30px 7px rgba(217,70,239,0.4)",
+  },
+  // Amber pulse: the LLM is writing its reply, nothing playing yet. The typing
+  // dots are the classic "assistant is generating a response" indicator.
+  generating: {
+    gradient: "radial-gradient(circle at 40% 35%, #fbbf24, #d97706)",
+    animation: "voice-orb-pulse",
+    duration: "1s",
+    shadow: "0 0 32px 8px rgba(251,191,36,0.35)",
+  },
+  synthesizing: {
+    gradient: "radial-gradient(circle at 40% 35%, #c4b5fd, #8b5cf6)",
+    animation: "voice-orb-pulse",
+    duration: "1.4s",
+    shadow: "0 0 32px 8px rgba(167,139,250,0.35)",
+  },
+  speaking: {
+    gradient: "radial-gradient(circle at 40% 35%, #38bdf8, #0284c7)",
+    animation: "voice-orb-speak",
+    duration: "0.8s",
+    shadow: "0 0 32px 8px rgba(56,189,248,0.35)",
+  },
+} as const;
+
+type OrbStateName = keyof typeof orbConfig;
+
+// Grey gradient for the mini orb when the voice loop isn't running yet.
+export const ORB_IDLE_GRADIENT =
+  "radial-gradient(circle at 40% 35%, #9ca3af, #4b5563)";
+
+// The full-overlay orb is a dark 3D glass sphere. Each state carves an icon into
+// it as a recessed "black hole" (near-black fill + a light bottom rim so the
+// shape reads as pressed into the surface) and shows a one-word caption below.
+const orbMeta: Record<OrbStateName, { label: string; icon: IconKind }> = {
+  listening: { label: "Listening", icon: "mic" },
+  hearing: { label: "Hearing you", icon: "wave" },
+  loading: { label: "Warming up", icon: "spinner" },
+  transcribing: { label: "Transcribing", icon: "pencil" },
+  generating: { label: "Generating LLM response", icon: "dots" },
+  synthesizing: { label: "Generating voice", icon: "waveform" },
+  speaking: { label: "Speaking", icon: "bars-live" },
+};
+
+type IconKind = "mic" | "wave" | "bars-live" | "dots" | "spinner" | "pencil" | "waveform";
+
+// Deboss: near-black fill with a faint highlight below and a dark cut above, so
+// the glyph looks carved into the sphere rather than sitting on top of it.
+const HOLE = "#08080b";
+const DEBOSS =
+  "drop-shadow(0 1px 0.5px rgba(255,255,255,0.22)) drop-shadow(0 -1px 1.5px rgba(0,0,0,0.6))";
+
+// Three dots that jump left-to-right in sequence (thinking). This is a vertical
+// translate, not a scale, so the dots never grow or shrink independently -- their
+// size stays locked to the ball's breathe.
+const Dots: FC = () => (
+  <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+    {[0, 1, 2].map((i) => (
+      <motion.span
+        key={i}
+        style={{ width: 11, height: 11, borderRadius: "50%", background: HOLE, filter: DEBOSS }}
+        animate={{ y: [0, -9, 0] }}
+        transition={{ duration: 0.7, repeat: Infinity, ease: "easeInOut", delay: i * 0.15 }}
+      />
+    ))}
+  </div>
+);
+
+// Speaking: black equalizer bars driven by the ACTUAL TTS output loudness
+// (voiceOutputLevel), set imperatively per animation frame so there are no React
+// re-renders. The group still rides the ball's breathe; the bar HEIGHTS move with
+// the audio. SPEAK_GAIN scales the RMS toward full height on loud speech (tunable).
+const SPEAK_GAIN = 5.5;
+const SpeakingBars: FC = () => {
+  const refs = useRef<Array<HTMLSpanElement | null>>([]);
+  useEffect(() => {
+    const weights = [0.55, 0.85, 1, 0.82, 0.5];
+    const smooth = [0, 0, 0, 0, 0];
+    let raf = 0;
+    const tick = () => {
+      const lvl = Math.min(1, voiceOutputLevel.current * SPEAK_GAIN);
+      const t = performance.now() / 1000;
+      for (let i = 0; i < refs.current.length; i++) {
+        // Per-bar shimmer so the band isn't a flat block, scaled by loudness.
+        const shimmer = 0.78 + 0.22 * Math.sin(t * 9 + i * 1.7);
+        const target = Math.min(1, 0.16 + lvl * weights[i] * shimmer);
+        smooth[i] += (target - smooth[i]) * 0.4;
+        const el = refs.current[i];
+        if (el) el.style.transform = `scaleY(${Math.max(0.14, smooth[i])})`;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 5, height: 40 }}>
+      {[0, 1, 2, 3, 4].map((i) => (
+        <span
+          key={i}
+          ref={(el) => {
+            refs.current[i] = el;
+          }}
+          style={{
+            width: 6,
+            height: 40,
+            borderRadius: 3,
+            background: HOLE,
+            transformOrigin: "center",
+            filter: DEBOSS,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+const OrbIcon: FC<{ icon: IconKind }> = ({ icon }) => {
+  // Speaking: live equalizer bars that move with the audio output.
+  if (icon === "bars-live") return <SpeakingBars />;
+  // Soundwave (hearing): a static glyph -- the ball's pulse supplies the motion
+  // and the icon rides it, growing/shrinking with the sphere, not on its own.
+  if (icon === "wave")
+    return (
+      <AudioLinesIcon size={46} strokeWidth={2.4} color={HOLE} style={{ filter: DEBOSS }} />
+    );
+  if (icon === "dots") return <Dots />;
+  if (icon === "spinner")
+    return (
+      <motion.div
+        animate={{ rotate: 360 }}
+        transition={{ duration: 1.1, repeat: Infinity, ease: "linear" }}
+        style={{ display: "grid", placeItems: "center" }}
+      >
+        <LoaderCircleIcon size={46} strokeWidth={2.4} color={HOLE} style={{ filter: DEBOSS }} />
+      </motion.div>
+    );
+  if (icon === "pencil")
+    // Transcribing: a pencil writing down what you said. Static, rides the breathe.
+    return (
+      <PencilLineIcon size={44} strokeWidth={2.4} color={HOLE} style={{ filter: DEBOSS }} />
+    );
+  if (icon === "waveform")
+    // Generating voice: a single audio waveform being built. Static like the rest,
+    // so it grows/shrinks with the sphere instead of animating on its own.
+    return (
+      <AudioWaveformIcon size={46} strokeWidth={2.4} color={HOLE} style={{ filter: DEBOSS }} />
+    );
+  // mic (listening): a resting state, so the icon gets NO independent animation.
+  // It rides the ball's breathe scale only, so it grows and shrinks in perfect
+  // sync with the sphere -- reading as carved into the surface, not floating.
+  return <MicIcon size={46} strokeWidth={2.4} color={HOLE} style={{ filter: DEBOSS }} />;
+};
+
+export const VoiceOrb: FC = () => {
+  const orbState = useChatRuntimeStore((s) => s.voiceOrbState);
+  // Minimized: the loop keeps running (orbState stays set) but the full-screen
+  // overlay is hidden so the chat is visible underneath.
+  const collapsed = useChatRuntimeStore((s) => s.voiceOrbCollapsed);
+  const setVoiceOrbCollapsed = useChatRuntimeStore((s) => s.setVoiceOrbCollapsed);
+  const showOverlay = Boolean(orbState) && !collapsed;
+
+  const cfg = orbState ? orbConfig[orbState] : null;
+  const meta = orbState ? orbMeta[orbState] : null;
+
+  // Esc only minimizes the orb back to chat -- it does NOT stop voice mode. The
+  // single place to turn voice off is the + menu's Voice toggle, so exiting the
+  // orb view is never confused with ending the session. Listener attached only
+  // while the overlay is showing.
+  useEffect(() => {
+    if (!showOverlay) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setVoiceOrbCollapsed(true);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [showOverlay, setVoiceOrbCollapsed]);
+
+  return (
+    <>
+      <style>{`
+        @keyframes voice-orb-breathe {
+          0%, 100% { transform: scale(1);    }
+          50%       { transform: scale(1.05); }
+        }
+        @keyframes voice-orb-pulse {
+          0%, 100% { transform: scale(1);    }
+          50%       { transform: scale(1.06); }
+        }
+        @keyframes voice-orb-speak {
+          0%, 100% { transform: scale(1);    }
+          50%       { transform: scale(1.1);  }
+        }
+      `}</style>
+
+      <div
+        className={cn(
+          // When active, the backdrop must intercept pointer events so hovers
+          // don't fall through to hidden chat history underneath (tooltips,
+          // hover menus, side panels). The composer dock sits at z-40 above this
+          // and keeps its own pointer-events-auto, so it stays interactive. When
+          // inactive the backdrop is still mounted (opacity-0), so it must let
+          // clicks pass through.
+          "absolute inset-0 z-30 flex flex-col items-center justify-center gap-8 bg-background",
+          "transition-opacity duration-500",
+          showOverlay
+            ? "pointer-events-auto opacity-100"
+            : "pointer-events-none opacity-0",
+        )}
+      >
+        {/* Original sphere: a single radial-gradient ball with a soft glow that
+            breathes/pulses via the CSS keyframes. The state icon is a near-black
+            deboss ("door hole") carved into the surface. It lives INSIDE the ball,
+            so it grows and shrinks with the sphere -- reading as part of the
+            surface rather than floating on top. */}
+        <div
+          className="grid place-items-center transition-all duration-500"
+          aria-hidden
+          style={{
+            width: 140,
+            height: 140,
+            borderRadius: "50%",
+            background: cfg?.gradient ?? orbConfig.listening.gradient,
+            boxShadow: cfg?.shadow ?? "none",
+            animation: cfg
+              ? `${cfg.animation} ${cfg.duration} ease-in-out infinite`
+              : undefined,
+          }}
+        >
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={meta?.icon ?? "none"}
+              initial={{ opacity: 0, scale: 0.85 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.85 }}
+              transition={{ duration: 0.18 }}
+              style={{ display: "grid", placeItems: "center" }}
+            >
+              {meta && <OrbIcon icon={meta.icon} />}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* Live caption: names the current state so the color never needs a
+            legend. Studio heading font (Hellix / Space Grotesk) to match chrome. */}
+        <div className="h-5">
+          <AnimatePresence mode="wait">
+            {meta && (
+              <motion.span
+                key={meta.label}
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                transition={{ duration: 0.22 }}
+                className="text-[13px] font-medium uppercase tracking-[0.28em] text-foreground/55"
+                style={{ fontFamily: "var(--font-heading)" }}
+              >
+                {meta.label}
+              </motion.span>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/studio/frontend/src/features/chat/adapters/studio-dictation-adapter.tsx
+++ b/studio/frontend/src/features/chat/adapters/studio-dictation-adapter.tsx
@@ -18,6 +18,8 @@ import {
   type StudioDictationSession,
   StudioWebSpeechDictationAdapter,
 } from "./studio-web-speech-dictation-adapter";
+import { StudioWhisperDictationAdapter } from "./studio-whisper-dictation-adapter";
+import { getVoiceMode } from "../voice/voice-loop-bridge";
 
 // The one live dictation session, so Escape can discard it without going
 // through assistant-ui (which only exposes stop, i.e. transcribe). Cancelling
@@ -94,6 +96,16 @@ export class StudioDictationAdapter implements DictationAdapter {
 
   private createSession(): StudioDictationSession {
     const { dictationEngine } = useVoiceSettingsStore.getState();
+    // The conversation loop needs an adapter that owns its own turn: capture,
+    // end-of-utterance, transcribe, submit, re-arm. The dictation adapters here
+    // deliberately do none of that -- they record until told to stop, which is
+    // right for a Dictate button and leaves a continuous loop with nothing to
+    // end a turn on.
+    if (getVoiceMode() === "active" && usesRecordedAudio(dictationEngine)) {
+      if (StudioWhisperDictationAdapter.isSupported()) {
+        return new StudioWhisperDictationAdapter().listen();
+      }
+    }
     if (usesRecordedAudio(dictationEngine)) {
       if (dictationEngine === "custom" && !customSttConfigured()) {
         throw new Error(

--- a/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
@@ -8,6 +8,7 @@ import {
   resolveDictationLanguage,
   useVoiceSettingsStore,
 } from "@/features/settings/stores/voice-settings-store";
+import { requestVoiceResume } from "@/features/chat/voice/voice-loop-bridge";
 import { isTauri } from "@/lib/api-base";
 import type { DictationAdapter } from "@assistant-ui/react";
 import { toast } from "sonner";
@@ -364,10 +365,17 @@ export class StudioWebSpeechDictationAdapter implements DictationAdapter {
         }
         return;
       }
-      const description = describeSpeechError(
-        errorEvent.error,
-        errorEvent.message,
-      );
+      if (errorEvent.error === "no-speech") {
+        // The engine heard nothing for a few seconds and gave up. Don't fail the
+        // loop or toast — end this session quietly and re-arm dictation so the
+        // orb stays active and listening continues. requestVoiceResume is a
+        // no-op unless voice mode is still "active". Deferred so assistant-ui
+        // clears the just-ended session before resumeListen re-checks it.
+        finish("stopped");
+        setTimeout(() => requestVoiceResume(), 0);
+        return;
+      }
+      const description = describeSpeechError(errorEvent.error, errorEvent.message);
       console.error("Dictation error:", errorEvent.error, errorEvent.message);
       if (errorEvent.error === "network") {
         // Online speech service unreachable; point the user to the offline

--- a/studio/frontend/src/features/chat/adapters/studio-whisper-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-whisper-dictation-adapter.ts
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  requestVoiceBargeIn,
+  requestVoiceResume,
+  requestVoiceSubmit,
+} from "@/features/chat/voice/voice-loop-bridge";
+// The store directly, not the feature barrel: the barrel pulls in the runtime
+// provider, which reaches back here through the dictation dispatcher.
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { useVoiceSettingsStore } from "@/features/settings/stores/voice-settings-store";
+import { requestSttDownload } from "@/features/settings/stores/stt-download-prompt-store";
+import { SttModelNotDownloadedError } from "./stt-errors";
+import {
+  loadSttModel,
+  transcribeAudioBlob,
+} from "./studio-model-dictation-adapter";
+import type { DictationAdapter } from "@assistant-ui/react";
+import { toast } from "@/lib/toast";
+
+// Backend Whisper STT dictation: capture the mic, detect end-of-utterance with a
+// simple energy VAD, then POST the recorded audio to /api/audio/transcribe and
+// emit the transcript. Unlike the Web Speech adapter this needs no browser cloud
+// speech service, so it works in Edge/Brave and the Tauri desktop webview.
+//
+// Whisper is batch, not streaming, so there are no interim results: one final
+// transcript per utterance, mirroring how the Web Speech adapter ends a session
+// on silence and lets the voice loop re-arm.
+
+const SILENCE_RMS = 0.012;       // RMS below this counts as silence (ends the utterance)
+// A frame only counts as real SPEECH toward the transcribe gate (voicedMs /
+// heardSpeech) at or above this, comfortably over the ambient-noise floor. Frames
+// between SILENCE_RMS and SPEECH_RMS keep the utterance alive but don't count, so
+// room noise or a mic click can't quietly accumulate the 350ms of "speech" that
+// would get fed to Whisper (which then hallucinates "Thank you." etc. from noise).
+// Lower it if genuinely soft speech is being dropped.
+const SPEECH_RMS = 0.02;
+const SILENCE_HANG_MS = 1000;    // silence after speech ends the utterance
+const MAX_UTTERANCE_MS = 30000;  // hard cap so a stuck mic can't record forever
+const NO_SPEECH_TIMEOUT_MS = 8000;  // give up quietly if no speech is heard
+// Minimum total voiced audio required to treat a window as real speech and
+// transcribe it. Coughs, clicks, a blip of the model's own voice, or ambient
+// noise fall under this and are dropped -- this is what stops Whisper being fed
+// junk (and hallucinating repeated tokens) during barge-in / idle listening.
+const MIN_SPEECH_MS = 350;
+// Real-time barge-in (cut the TTS while the model speaks). We cut at two points,
+// whichever comes first:
+//   1. Commit: the moment this utterance has accumulated MIN_SPEECH_MS of real
+//      voiced speech -- i.e. the instant we KNOW it will be transcribed and sent.
+//      Tying the cut to the transcribe gate means you never end up talking over a
+//      reply that's already committed to being replaced, and a sub-threshold blip
+//      that WON'T be transcribed never cuts the model.
+//   2. Fast: a clearly LOUD burst (>= BARGE_IN_RMS) sustained continuously for
+//      BARGE_IN_FAST_MS cuts even sooner, so an emphatic "stop" interrupts snappily.
+// The higher BARGE_IN_RMS gate on the fast path keeps quiet speaker-bleed from
+// self-interrupting before the commit point; the commit path leans on the same
+// SPEECH_RMS floor that already guards transcription itself against bleed.
+const BARGE_IN_FAST_MS = 220;
+const BARGE_IN_RMS = 0.045;
+// Silence trimmed around the voiced span before sending to Whisper (Whisper
+// hallucinates on long leading/trailing silence). Keep a little context.
+const SILENCE_PAD_MS = 200;
+// Faked streaming reveal: Whisper is batch (one transcript per utterance), but
+// once it lands we replay it as growing interim results so the composer types it
+// out char-by-char like the streaming Web Speech engine, instead of the whole
+// line appearing at once. REVEAL_MAX_MS caps the total so long transcripts don't
+// lag the send much.
+const REVEAL_CHAR_MS = 12;
+const REVEAL_MAX_MS = 1000;
+
+type AudioContextCtor = typeof AudioContext;
+
+const getAudioContextCtor = (): AudioContextCtor | undefined => {
+  if (typeof window === "undefined") return undefined;
+  return (
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: AudioContextCtor }).webkitAudioContext
+  );
+};
+
+// Encode mono float samples as a 16-bit PCM WAV blob (soundfile reads this; no
+// ffmpeg needed server-side).
+function encodeWav(samples: Float32Array, sampleRate: number): Blob {
+  const buffer = new ArrayBuffer(44 + samples.length * 2);
+  const view = new DataView(buffer);
+  const writeStr = (offset: number, s: string) => {
+    for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i));
+  };
+  writeStr(0, "RIFF");
+  view.setUint32(4, 36 + samples.length * 2, true);
+  writeStr(8, "WAVE");
+  writeStr(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true); // PCM
+  view.setUint16(22, 1, true); // mono
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeStr(36, "data");
+  view.setUint32(40, samples.length * 2, true);
+  let offset = 44;
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i] ?? 0));
+    view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+    offset += 2;
+  }
+  return new Blob([view], { type: "audio/wav" });
+}
+
+// Whisper hallucinates a repeated word/phrase on non-speech audio (noise,
+// breath, silence) -- e.g. "Ha, ha, ha..." or "Thank you. Thank you...". Reject
+// a transcript dominated by one repeated token (very low unique-word ratio) so
+// it isn't sent as a prompt. Short utterances (< 6 words) are always allowed.
+function isHallucinatedTranscript(text: string): boolean {
+  const words = text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length < 6) return false;
+  return new Set(words).size / words.length < 0.3;
+}
+
+export class StudioWhisperDictationAdapter implements DictationAdapter {
+  static isSupported(): boolean {
+    return (
+      typeof window !== "undefined" &&
+      navigator.mediaDevices?.getUserMedia !== undefined &&
+      getAudioContextCtor() !== undefined
+    );
+  }
+
+  listen(): DictationAdapter.Session {
+    const AudioCtx = getAudioContextCtor();
+    if (!AudioCtx || !navigator.mediaDevices?.getUserMedia) {
+      throw new Error("Whisper dictation is not supported in this browser.");
+    }
+
+    const speechStartCallbacks = new Set<() => void>();
+    const speechEndCallbacks = new Set<(result: DictationAdapter.Result) => void>();
+    const speechCallbacks = new Set<(result: DictationAdapter.Result) => void>();
+
+    let stream: MediaStream | null = null;
+    let audioCtx: AudioContext | null = null;
+    let processor: ScriptProcessorNode | null = null;
+    let source: MediaStreamAudioSourceNode | null = null;
+    const chunks: Float32Array[] = [];
+    // Parallel to chunks: whether each frame was above the silence floor, used to
+    // measure voiced duration and to trim silence before transcription.
+    const chunkVoiced: boolean[] = [];
+    let voicedMs = 0;
+    // Run of continuous LOUD frames (>= BARGE_IN_RMS) for the fast barge path;
+    // resets on any quiet frame.
+    let bargeLoudMs = 0;
+    let bargedIn = false;
+    let sampleRate = 16000;
+    let heardSpeech = false;
+    let lastVoiceAt = 0;
+    let startedAt = 0;
+    let ended = false;
+    let resolveEnded: (() => void) | null = null;
+    const endedPromise = new Promise<void>((resolve) => {
+      resolveEnded = resolve;
+    });
+
+    const session: DictationAdapter.Session = {
+      status: { type: "starting" },
+      stop: async () => {
+        await finalize();
+        await endedPromise;
+      },
+      cancel: () => {
+        teardown();
+        finish("cancelled");
+      },
+      onSpeechStart: (cb) => {
+        speechStartCallbacks.add(cb);
+        return () => speechStartCallbacks.delete(cb);
+      },
+      onSpeechEnd: (cb) => {
+        speechEndCallbacks.add(cb);
+        return () => speechEndCallbacks.delete(cb);
+      },
+      onSpeech: (cb) => {
+        speechCallbacks.add(cb);
+        return () => speechCallbacks.delete(cb);
+      },
+    };
+
+    const teardown = () => {
+      // Mic is closing: no longer hearing the user, so drop the orb's salmon
+      // "hearing you" state (the utterance ended or was cancelled).
+      useChatRuntimeStore.getState().setVoiceHearing(false);
+      if (processor) {
+        processor.onaudioprocess = null;
+        processor.disconnect();
+        processor = null;
+      }
+      source?.disconnect();
+      source = null;
+      stream?.getTracks().forEach((t) => t.stop());
+      stream = null;
+      void audioCtx?.close().catch(() => {});
+      audioCtx = null;
+    };
+
+    const finish = (reason: "stopped" | "cancelled" | "error", transcript?: string) => {
+      if (ended) return;
+      ended = true;
+      session.status = { type: "ended", reason };
+      if (transcript) {
+        for (const cb of speechEndCallbacks) cb({ transcript });
+      }
+      resolveEnded?.();
+    };
+
+    // End the utterance: tear down capture, transcribe the buffer, emit result.
+    let finalizing = false;
+    const finalize = async () => {
+      if (finalizing || ended) return;
+      finalizing = true;
+      teardown();
+
+      if (!heardSpeech || chunks.length === 0 || voicedMs < MIN_SPEECH_MS) {
+        // Nothing said this window (or only a sub-threshold blip: cough, click,
+        // a bit of the model's own voice, ambient noise). End quietly and re-arm,
+        // mirroring the Web Speech "no-speech" path so the loop keeps listening
+        // without feeding Whisper junk to hallucinate on.
+        finish("stopped");
+        setTimeout(() => requestVoiceResume(), 0);
+        return;
+      }
+
+      // Trim to the voiced span (+ a little padding) so Whisper isn't handed long
+      // leading/trailing silence, which it tends to hallucinate words from.
+      const frameMs = chunks[0] ? (chunks[0].length / sampleRate) * 1000 : 0;
+      const padFrames = frameMs > 0 ? Math.ceil(SILENCE_PAD_MS / frameMs) : 0;
+      const firstVoiced = chunkVoiced.indexOf(true);
+      const lastVoiced = chunkVoiced.lastIndexOf(true);
+      const start = Math.max(0, firstVoiced - padFrames);
+      const end = Math.min(chunks.length - 1, lastVoiced + padFrames);
+      const span = chunks.slice(start, end + 1);
+
+      const total = span.reduce((n, c) => n + c.length, 0);
+      const merged = new Float32Array(total);
+      let offset = 0;
+      for (const c of span) {
+        merged.set(c, offset);
+        offset += c.length;
+      }
+      const wav = encodeWav(merged, sampleRate);
+
+      try {
+        // The PR posted its own multipart to /api/audio/transcribe and let the
+        // backend pick a model. Upstream since grew a real STT stack: a curated
+        // model list, per-model engines, downloads, and language handling. Go
+        // through its helper so the loop transcribes with the model the Voice
+        // settings tab actually downloaded, instead of whatever the route
+        // defaults to (which is how this asked for an absent "small").
+        const modelId =
+          useChatRuntimeStore.getState().selectedSttModelId ?? undefined;
+        // Flag transcribing so the orb shows a processing state (not idle green)
+        // while Whisper runs -- the first call can take many seconds on ROCm.
+        const store = useChatRuntimeStore.getState();
+        store.setVoiceTranscribing(true);
+        let transcript = "";
+        try {
+          transcript = (
+            await transcribeAudioBlob(wav, { model: modelId })
+          ).trim();
+          if (ended) return;
+        } catch (error) {
+          // A model the user has selected but never downloaded is the common
+          // first-run case, not a failure: raise the same download prompt the
+          // Dictate button raises and keep the loop alive.
+          if (error instanceof SttModelNotDownloadedError) {
+            requestSttDownload(
+              modelId ?? useVoiceSettingsStore.getState().sttModel,
+            );
+          }
+          throw error;
+        } finally {
+          store.setVoiceTranscribing(false);
+        }
+        if (transcript && isHallucinatedTranscript(transcript)) {
+          // Whisper invents a repeated token ("Ha, ha, ha...", "Thank you.
+          // Thank you...") from noise/breath/silence. Drop it and keep listening
+          // rather than sending garbage as a prompt.
+          transcript = "";
+        }
+        if (transcript) {
+          // Fake a streaming reveal: replay the transcript as growing interim
+          // results so the composer types it out char-by-char (like Web Speech),
+          // then commit + send. Bails immediately if the session is superseded.
+          const total = transcript.length;
+          const stepChars = Math.max(
+            1,
+            Math.ceil(total / Math.max(1, REVEAL_MAX_MS / REVEAL_CHAR_MS)),
+          );
+          for (let i = stepChars; i < total; i += stepChars) {
+            if (ended) return;
+            const partial = transcript.slice(0, i);
+            for (const cb of speechCallbacks) cb({ transcript: partial, isFinal: false });
+            await new Promise<void>((r) => setTimeout(r, REVEAL_CHAR_MS));
+          }
+          if (ended) return;
+          // onSpeech(isFinal) commits the full transcript into the composer text;
+          // onSpeechEnd (via finish) ends the session. Then, deferred so those
+          // state updates land first, submit the turn. requestVoiceSubmit is a
+          // no-op outside voice mode, so plain Dictate-button use just fills the
+          // composer as before.
+          for (const cb of speechCallbacks) cb({ transcript, isFinal: true });
+          finish("stopped", transcript);
+          setTimeout(() => requestVoiceSubmit(), 0);
+        } else {
+          finish("stopped");
+          setTimeout(() => requestVoiceResume(), 0);
+        }
+      } catch (error) {
+        if (ended) return;
+        console.error("Whisper dictation error:", error);
+        toast.error("Whisper transcription failed.");
+        finish("error");
+        // Keep the voice loop alive: a transcribe failure (transient backend
+        // hiccup, etc.) shouldn't leave the mic dead so it never hears you again.
+        // Re-arm so the next utterance still gets a shot.
+        setTimeout(() => requestVoiceResume(), 0);
+      }
+    };
+
+    void (async () => {
+      try {
+        // Pin capture to the user-chosen input device when set, so the loop
+        // listens to their headset mic and not a loopback / "Stereo Mix" /
+        // default-communications device that mixes in system/app audio (e.g.
+        // Discord). null -> browser default.
+        const micDeviceId = useChatRuntimeStore.getState().selectedMicDeviceId;
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            ...(micDeviceId ? { deviceId: { exact: micDeviceId } } : {}),
+          },
+        });
+        if (ended) {
+          teardown();
+          return;
+        }
+        audioCtx = new AudioCtx();
+        sampleRate = audioCtx.sampleRate;
+        source = audioCtx.createMediaStreamSource(stream);
+        processor = audioCtx.createScriptProcessor(4096, 1, 1);
+        startedAt = performance.now();
+        lastVoiceAt = startedAt;
+        session.status = { type: "running" };
+
+        // Warm the STT model while the user is still drawing breath. Whisper's
+        // first load is slow enough (tens of seconds on ROCm) that paying it
+        // after the first utterance reads as the loop having missed what was
+        // said. Fire-and-forget: transcription awaits the same load, so a
+        // failure here surfaces there rather than killing the session.
+        void loadSttModel(
+          useChatRuntimeStore.getState().selectedSttModelId ??
+            useVoiceSettingsStore.getState().sttModel,
+        ).catch(() => {});
+
+        processor.onaudioprocess = (event) => {
+          if (ended || finalizing) return;
+          const input = event.inputBuffer.getChannelData(0);
+          chunks.push(new Float32Array(input));
+
+          let sumSquares = 0;
+          for (let i = 0; i < input.length; i++) sumSquares += input[i] * input[i];
+          const rms = Math.sqrt(sumSquares / input.length);
+          const now = performance.now();
+
+          const frameMs = (input.length / sampleRate) * 1000;
+          // notSilent keeps the utterance alive (resets the silence-hang timer);
+          // speech is the stricter bar that actually counts toward transcription,
+          // so noise/clicks between the two thresholds never reach Whisper.
+          const notSilent = rms >= SILENCE_RMS;
+          const speech = rms >= SPEECH_RMS;
+          chunkVoiced.push(speech);
+          if (notSilent) lastVoiceAt = now;
+          if (speech) {
+            voicedMs += frameMs;
+            if (!heardSpeech) {
+              heardSpeech = true;
+              // Light the orb's salmon "hearing you" state the instant the mic
+              // picks up real voice -- immediate proof the mic is capturing you.
+              useChatRuntimeStore.getState().setVoiceHearing(true);
+              for (const cb of speechStartCallbacks) cb();
+            }
+          }
+          // Real-time barge-in: cut the currently-playing TTS the instant this
+          // utterance commits to being transcribed (voicedMs past the transcribe
+          // gate), so you never talk over a reply that's already going to be
+          // replaced. A clearly LOUD continuous burst cuts even sooner. Firing only
+          // at/after the commit point means blips that WON'T be transcribed never
+          // self-interrupt. The VoiceEngine handler no-ops unless the model is
+          // actually speaking, so stray calls are harmless.
+          if (rms >= BARGE_IN_RMS) bargeLoudMs += frameMs;
+          else bargeLoudMs = 0;
+          if (
+            !bargedIn &&
+            (voicedMs >= MIN_SPEECH_MS || bargeLoudMs >= BARGE_IN_FAST_MS)
+          ) {
+            bargedIn = true;
+            requestVoiceBargeIn();
+          }
+
+          const sinceVoice = now - lastVoiceAt;
+          const elapsed = now - startedAt;
+          if (
+            (heardSpeech && sinceVoice >= SILENCE_HANG_MS) ||
+            elapsed >= MAX_UTTERANCE_MS ||
+            (!heardSpeech && elapsed >= NO_SPEECH_TIMEOUT_MS)
+          ) {
+            void finalize();
+          }
+        };
+
+        source.connect(processor);
+        processor.connect(audioCtx.destination); // required for onaudioprocess to fire
+      } catch (error) {
+        teardown();
+        console.error("Whisper dictation mic error:", error);
+        toast.error("Could not access the microphone for dictation.");
+        finish("error");
+      }
+    })();
+
+    return session;
+  }
+}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -19,6 +19,14 @@ import {
   useActiveModelConfig,
 } from "@/features/model-picker";
 import { ProjectComposer, Thread } from "@/components/assistant-ui/thread";
+import {
+  getVoiceMode,
+  requestVoiceToggle,
+} from "@/features/chat/voice/voice-loop-bridge";
+import { VoiceModelSelector } from "@/components/assistant-ui/voice-model-selector";
+import { VoiceNamePicker } from "@/components/assistant-ui/voice-name-picker";
+import { authFetch } from "@/features/auth";
+import { VOICE_SLOT_AUDIO_TYPES } from "@/features/chat/hooks/use-tts-player";
 import { usePlatformStore } from "@/config/env";
 import { CopyableErrorChip } from "@/components/ui/copyable-error-chip";
 import {
@@ -65,6 +73,7 @@ import {
   downloadManager,
   jobKeyOf,
   useRepoDownload,
+  subscribeJobListeners,
 } from "@/features/hub/download-manager";
 import {
   INVENTORY_FRESHNESS_WINDOW_MS,
@@ -323,6 +332,16 @@ const ARTIFACT_PANEL_DEFAULT_SIZE = "38%";
 const ARTIFACT_PANEL_TRANSITION_MS = 260;
 const ARTIFACT_SURFACE_POP_DELAY_MS = 150;
 
+// A speech-LLM chat model (Orpheus, CSM, Spark...) produces its own voice, so a
+// separate TTS voice slot doesn't apply and must not be auto-loaded. Module-level
+// so both the render-time greying and the voice-slot ensure-load effect can share
+// one definition.
+const SPEECH_LLM_CHECKPOINT_RE =
+  /(?:orpheus|csm|spark|bark|parler|musicgen|text-to-speech|[-_]tts)/i;
+function isSpeechLLMCheckpoint(checkpoint: string | null | undefined): boolean {
+  return SPEECH_LLM_CHECKPOINT_RE.test(checkpoint ?? "");
+}
+
 const SingleContent = memo(function SingleContent({
   threadId,
   artifact,
@@ -431,6 +450,35 @@ const SingleContent = memo(function SingleContent({
     onCloseArtifact();
     useChatRuntimeStore.getState().setSettingsPanelOpen(false);
   }, [researchMatchesThread, onCloseArtifact]);
+
+  // Thread-switch voice reset. Lives here (not in VoiceEngine) because SingleContent
+  // is stable across the ThreadWelcome → ThreadComposerDock remount that fires on
+  // first-send; VoiceEngine remounts there and never observes null → __LOCALID_xxx,
+  // leaving its prev-thread ref stale so the later New Chat (→ null) reset is missed.
+  // We drive the module-level toggle bridge, gated on getVoiceMode() so a plain
+  // thread switch while voice is OFF can't accidentally toggle voice ON.
+  const prevVoiceThreadIdRef = useRef(activeThreadId);
+  useEffect(() => {
+    const current = activeThreadId;
+    const prev = prevVoiceThreadIdRef.current;
+    if (prev === current) {
+      prevVoiceThreadIdRef.current = current;
+      return;
+    }
+    // Thread birth (null → __LOCALID_xxx on first send) is the initial thread being
+    // created, not a real switch, so it must NOT kill voice mid-conversation. Skip
+    // the reset but still advance the ref, so the later New Chat (__LOCALID_xxx → null)
+    // is still detected as a genuine switch. Real switches — non-null → null (New Chat)
+    // and non-null → different non-null (sidebar) — fall through below.
+    if (prev === null && current !== null) {
+      prevVoiceThreadIdRef.current = current;
+      return;
+    }
+    if (getVoiceMode() !== "off") {
+      requestVoiceToggle();
+    }
+    prevVoiceThreadIdRef.current = current;
+  }, [activeThreadId]);
 
   const threadPane = (
     <div className="flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden">
@@ -2419,6 +2467,368 @@ export function ChatPage({
     loadProgress,
     loadToastDismissed,
   } = useChatModelRuntime();
+  const voiceMode = useChatRuntimeStore((s) => s.voiceMode);
+  const selectedVoiceModelId = useChatRuntimeStore(
+    (s) => s.selectedVoiceModelId,
+  );
+  const setSelectedVoiceModelId = useChatRuntimeStore(
+    (s) => s.setSelectedVoiceModelId,
+  );
+  const voiceSlotLoading = useChatRuntimeStore((s) => s.voiceSlotLoading);
+  const setVoiceSlotLoading = useChatRuntimeStore((s) => s.setVoiceSlotLoading);
+  const voiceSlotLoaded = useChatRuntimeStore((s) => s.voiceSlotLoaded);
+  const [cachedGgufs, setCachedGgufs] = useState<LoraModelOption[]>([]);
+  const cachedGgufsFetchedRef = useRef(false);
+
+  const handleVoiceModelChange = useCallback(
+    async (id: string | null) => {
+      // Captured before we optimistically switch the selection so a cancelled
+      // download can roll back to whatever voice was active.
+      const previousId = useChatRuntimeStore.getState().selectedVoiceModelId;
+      setSelectedVoiceModelId(id);
+      if (!id) {
+        // Browser voice — just unload any loaded TTS voice slot. Selecting a
+        // voice only configures it; entering the ball is a separate, explicit
+        // action ("Start voice mode" in the popover) so picking a voice never
+        // yanks you out of the text chat you might still be reading.
+        void authFetch("/api/inference/voice/unload", { method: "POST" });
+        return;
+      }
+
+      // The specific quant the user picked from the expander (not the repo
+      // default), so an undownloaded non-default quant is handled correctly.
+      const variant = useChatRuntimeStore.getState().selectedVoiceVariant;
+
+      // Is that exact quant already on disk? A repo can be partially cached
+      // (some quants present, others not), so ask gguf-variants for the picked
+      // one rather than doing a repo-level "is it cached" check.
+      let needsDownload = false;
+      let expectedBytes = 0;
+      try {
+        const vr = await authFetch(
+          `/api/models/gguf-variants?repo_id=${encodeURIComponent(id)}`,
+        );
+        if (vr.ok) {
+          const vdata = (await vr.json()) as {
+            default_variant?: string;
+            variants?: {
+              quant: string;
+              size_bytes: number;
+              download_size_bytes?: number;
+              downloaded: boolean;
+            }[];
+          };
+          const picked =
+            vdata.variants?.find((v) => v.quant === variant) ??
+            vdata.variants?.find((v) => v.quant === vdata.default_variant) ??
+            vdata.variants?.[0];
+          if (picked && !picked.downloaded) {
+            needsDownload = true;
+            // download_size_bytes first, as every other download path does: a
+            // sharded GGUF reports one shard in size_bytes and the whole set here.
+            expectedBytes = picked.download_size_bytes || picked.size_bytes;
+          }
+        }
+      } catch {
+        // gguf-variants unavailable (e.g. a local path or non-GGUF voice) —
+        // treat it as on-disk and let the load path deal with it.
+      }
+
+      // Not on disk: pull it through the same download manager the main model
+      // dropdown uses, so it shows the global progress card and only loads the
+      // voice slot once the file is complete. Letting /voice/load fetch it via
+      // llama-server -hf instead would run a multi-GB transfer inside the
+      // server's startup health-check window and time out with no progress.
+      if (needsDownload) {
+        const ok = await new Promise<boolean>((resolve) => {
+          const unsub = subscribeJobListeners(DOWNLOAD_KIND.MODEL, id, {
+            onComplete: (completedVariant) => {
+              // Listeners are repo-scoped; ignore a sibling quant finishing.
+              if (variant && completedVariant && completedVariant !== variant)
+                return;
+              unsub();
+              resolve(true);
+            },
+            onCancelled: () => {
+              unsub();
+              resolve(false);
+            },
+            onError: () => {
+              unsub();
+              resolve(false);
+            },
+          });
+          void downloadManager
+            .requestStart({
+              kind: DOWNLOAD_KIND.MODEL,
+              repoId: id,
+              variant: variant ?? null,
+              expectedBytes,
+            })
+            .then((outcome) => {
+              // "started" -> a listener above settles when the transfer ends.
+              // Any other outcome never fires a listener, so settle here.
+              if (outcome === "started") return;
+              unsub();
+              resolve(false);
+              if (outcome === "conflict") {
+                toast.info("Resume this download from the Hub", {
+                  description:
+                    "An earlier partial download used a different transport. Open the Hub tab to resume it.",
+                });
+              } else if (outcome !== "busy") {
+                toast.error("Couldn't start the voice download");
+              }
+            });
+        });
+        if (!ok) {
+          // Roll back to the prior voice; any loaded slot stays intact and the
+          // selector keeps matching what /api/inference/audio/speech will use.
+          setSelectedVoiceModelId(previousId);
+          return;
+        }
+      }
+
+      setVoiceSlotLoading(true);
+      try {
+        const res = await authFetch("/api/inference/voice/load", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model_path: id,
+            parallel: useChatRuntimeStore.getState().voiceParallelN,
+            gguf_variant: useChatRuntimeStore.getState().selectedVoiceVariant,
+          }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          toast.error("Voice model failed to load", {
+            description: (body as { detail?: string }).detail ?? undefined,
+          });
+          setSelectedVoiceModelId(null);
+        }
+        // On success we just leave the model loaded and selected; entering the
+        // ball is the separate "Start voice mode" action in the popover.
+      } catch {
+        toast.error("Voice model failed to load");
+        setSelectedVoiceModelId(null);
+      } finally {
+        setVoiceSlotLoading(false);
+      }
+    },
+    [setSelectedVoiceModelId, setVoiceSlotLoading],
+  );
+
+  // Reload the backend voice slot if a voice is selected but the slot is gone
+  // (unloaded by a remount, auth bounce, or studio relaunch). Registered in the
+  // store so the TTS player can call it to self-heal a /api/inference/audio/speech 400
+  // instead of going silent. De-duped via a ref so a burst of parallel synth
+  // 400s triggers a single reload, not a stampede.
+  const voiceReloadInflightRef = useRef<Promise<boolean> | null>(null);
+  const ensureVoiceSlotLoaded = useCallback(async (): Promise<boolean> => {
+    const store = useChatRuntimeStore.getState();
+    const id = store.selectedVoiceModelId;
+    // Browser voice / nothing selected: there's no separate slot to load.
+    if (!id) return false;
+    // Speech-LLM chat models speak with their own voice; no separate slot.
+    if (isSpeechLLMCheckpoint(store.params.checkpoint)) return false;
+    if (voiceReloadInflightRef.current) return voiceReloadInflightRef.current;
+    const run = (async () => {
+      try {
+        // Already loaded with the selected voice? Nothing to do.
+        const st = await authFetch("/api/inference/voice/status");
+        const data = st.ok
+          ? ((await st.json()) as { loaded?: boolean; model?: string | null })
+          : null;
+        const loaded = data?.loaded ? (data.model ?? null) : null;
+        if (loaded && loaded.toLowerCase() === id.toLowerCase()) return true;
+        setVoiceSlotLoading(true);
+        const res = await authFetch("/api/inference/voice/load", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model_path: id,
+            parallel: useChatRuntimeStore.getState().voiceParallelN,
+            gguf_variant: useChatRuntimeStore.getState().selectedVoiceVariant,
+          }),
+        });
+        return res.ok;
+      } catch {
+        return false;
+      } finally {
+        setVoiceSlotLoading(false);
+        voiceReloadInflightRef.current = null;
+      }
+    })();
+    voiceReloadInflightRef.current = run;
+    return run;
+  }, [setVoiceSlotLoading]);
+
+  // Expose the reloader to the store so the TTS player (a different component
+  // tree) can call it to self-heal. Cleared on unmount.
+  useEffect(() => {
+    const register = useChatRuntimeStore.getState().setEnsureVoiceSlotLoaded;
+    register(ensureVoiceSlotLoaded);
+    return () => register(null);
+  }, [ensureVoiceSlotLoaded]);
+
+  // Unload the voice slot whenever voice mode turns off.
+  useEffect(() => {
+    if (voiceMode === "off" && selectedVoiceModelId) {
+      void authFetch("/api/inference/voice/unload", { method: "POST" });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [voiceMode]);
+
+  // Ensure the backend voice slot matches the selected voice once voice mode is
+  // actually STARTED (active), not merely being configured -- otherwise just
+  // opening the voice picker would kick off the (slow) TTS load. selectedVoiceModelId
+  // is persisted and shows "Active", but the backend slot is empty after a restart
+  // (and the unload effect above clears it on mount), so without this /api/inference/audio/speech
+  // has no TTS slot loaded and 400s. Keyed on voiceMode (not the selection) so it
+  // fires on entering the ball, not on every pick (handleVoiceModelChange already
+  // loads on pick); the /voice/status check makes a redundant load a no-op.
+  useEffect(() => {
+    if (voiceMode !== "active") return;
+    // Speech-LLM chat models (Orpheus etc.) speak with their own voice, so the
+    // separate TTS slot is greyed out and must not be auto-loaded -- doing so
+    // wastes VRAM/time loading a voice that never gets used.
+    if (isSpeechLLMCheckpoint(useChatRuntimeStore.getState().params.checkpoint)) {
+      return;
+    }
+    const id = useChatRuntimeStore.getState().selectedVoiceModelId;
+    if (!id) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const st = await authFetch("/api/inference/voice/status");
+        const data = st.ok
+          ? ((await st.json()) as { loaded?: boolean; model?: string | null })
+          : null;
+        const loadedModel = data?.loaded ? (data.model ?? null) : null;
+        if (loadedModel && loadedModel.toLowerCase() === id.toLowerCase()) return;
+        if (cancelled) return;
+        setVoiceSlotLoading(true);
+        const res = await authFetch("/api/inference/voice/load", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model_path: id,
+            parallel: useChatRuntimeStore.getState().voiceParallelN,
+            gguf_variant: useChatRuntimeStore.getState().selectedVoiceVariant,
+          }),
+        });
+        if (!res.ok && !cancelled) {
+          const body = await res.json().catch(() => ({}));
+          toast.error("Voice model failed to load", {
+            description: (body as { detail?: string }).detail ?? undefined,
+          });
+        }
+      } catch {
+        // status/load unavailable -- leave the slot as-is.
+      } finally {
+        if (!cancelled) setVoiceSlotLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [voiceMode]);
+
+
+  // Keep the top-bar speak icon honest: green only when the backend voice slot
+  // is actually loaded with the selected voice. A selection persists across
+  // reloads but the slot doesn't, so sync from /voice/status whenever the
+  // selection, voice mode, or load state changes instead of trusting the
+  // selection alone (which would show green for an unloaded slot after a reload).
+  useEffect(() => {
+    const setLoaded = useChatRuntimeStore.getState().setVoiceSlotLoaded;
+    if (voiceMode === "off" || !selectedVoiceModelId) {
+      setLoaded(false);
+      return;
+    }
+    let cancelled = false;
+    void authFetch("/api/inference/voice/status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { loaded?: boolean; model?: string | null } | null) => {
+        if (cancelled) return;
+        const id = selectedVoiceModelId;
+        setLoaded(
+          !!data?.loaded &&
+            !!id &&
+            (data.model ?? "").toLowerCase() === id.toLowerCase(),
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [voiceMode, selectedVoiceModelId, voiceSlotLoading]);
+
+  // Navigating away from Chat while voice mode is still active unmounts this
+  // component without flipping voiceMode to "off", so the effect above never
+  // runs. Unload on teardown so the independent voice model can't keep holding
+  // VRAM until the backend restarts. Reads the store at cleanup time to avoid a
+  // stale closure over selectedVoiceModelId.
+  useEffect(() => {
+    return () => {
+      if (useChatRuntimeStore.getState().selectedVoiceModelId) {
+        void authFetch("/api/inference/voice/unload", { method: "POST" });
+      }
+    };
+  }, []);
+
+  // Switching the chat checkpoint to a speech-LLM means the model produces its own
+  // voice, and the picker greys out. Greying out is not enough on its own: the speech
+  // route prefers the voice slot whenever one is loaded, so a previously picked voice
+  // would keep speaking every reply while the UI said the model owned its voice. Drop
+  // the selection and unload the slot so what you hear matches what the UI claims.
+  // Derived here rather than read from the chatModelIsSpeechLLM const the picker
+  // uses: that one is declared further down this component, so reading it here
+  // would be a temporal-dead-zone throw on first render.
+  const checkpointOwnsItsVoice = isSpeechLLMCheckpoint(inferenceParams.checkpoint);
+  useEffect(() => {
+    if (!checkpointOwnsItsVoice) return;
+    if (!useChatRuntimeStore.getState().selectedVoiceModelId) return;
+    setSelectedVoiceModelId(null);
+    useChatRuntimeStore.getState().setVoiceSlotLoaded(false);
+    void authFetch("/api/inference/voice/unload", { method: "POST" });
+  }, [checkpointOwnsItsVoice, setSelectedVoiceModelId]);
+
+  // Fetch cached GGUFs + cached safetensors once when voice mode is first
+  // activated. TTS only lists GGUFs -- /api/inference/voice/load hard-requires
+  // one (separate llama-server voice slot), so a safetensors-only TTS repo
+  // can't load there yet even if it's downloaded. Downloading itself stays in
+  // the main model dropdown's Hub search.
+  useEffect(() => {
+    if (voiceMode === "off" || cachedGgufsFetchedRef.current) return;
+    cachedGgufsFetchedRef.current = true;
+    // TTS-capable GGUFs for the voice slot: standalone TTS (bicodec/dac) plus the
+    // speech-LLMs (orpheus/snac, csm) -- those can double as a plain voice for a
+    // *different* chat model when picked here, in which case they only synthesize
+    // its replies rather than acting as the LLM. GGUF-only: the voice slot is a
+    // llama-server, so safetensors-only checkpoints (e.g. Spark's LLM) can't load.
+    const TTS_REPO_KEYWORDS = ["bicodec", "dac", "tts", "orpheus", "csm"];
+    const lower = (s: string) => s.toLowerCase();
+    const toOption = (repoId: string, isGguf: boolean): LoraModelOption => ({
+      id: repoId,
+      name: repoId.includes("/") ? (repoId.split("/")[1] ?? repoId) : repoId,
+      isGguf,
+    });
+
+    void authFetch("/api/models/cached-gguf")
+      .then((r) => (r.ok ? r.json() : { cached: [] }))
+      .then((data: { cached: { repo_id: string; size_bytes?: number }[] }) => {
+        setCachedGgufs(
+          (data.cached ?? [])
+            .filter((c) => TTS_REPO_KEYWORDS.some((kw) => lower(c.repo_id).includes(kw)))
+            .map((c) => toOption(c.repo_id, true)),
+        );
+      })
+      .catch(() => {});
+  }, [voiceMode]);
+
   const prevConnectionsEnabledRef = useRef(connectionsEnabled);
   useEffect(() => {
     const turnedOff = prevConnectionsEnabledRef.current && !connectionsEnabled;
@@ -3809,6 +4219,41 @@ export function ChatPage({
     void localModelInventory.refreshIfOlderThan(INVENTORY_FRESHNESS_WINDOW_MS);
   }, [refresh, localModelInventory.refreshIfOlderThan]);
 
+  // TTS voices offerable to the voice slot: trained TTS checkpoints from the
+  // fine-tune scan, cached TTS GGUFs, and the canonical defaults (downloaded on
+  // first load if not cached).
+  //
+  // Both halves of the filter matter. The codec must be one the slot's llama-server
+  // can decode, and the checkpoint must be a GGUF export: the slot loads a GGUF, so
+  // a merged or adapter-only row would be offered here and then rejected by
+  // /voice/load. Speech-LLM codecs (Orpheus/snac) belong in this list -- picking one
+  // here uses it purely as the voice for a separate chat model, which is exactly the
+  // "hear the voice you fine-tuned" case, and it is what the Orpheus default below
+  // already offers.
+  const ttsModels = useMemo<LoraModelOption[]>(() => {
+    const fromLoras = loraModels.filter(
+      (m) =>
+        VOICE_SLOT_AUDIO_TYPES.has(m.audioType ?? "") && m.exportType === "gguf",
+    );
+    const VOICE_MODEL_DEFAULTS: LoraModelOption[] = [
+      {
+        id: "unsloth/orpheus-3b-0.1-ft-GGUF",
+        name: "orpheus-3b-0.1-ft (voice)",
+        isGguf: true,
+      },
+    ];
+    const knownIds = new Set([
+      ...cachedGgufs.map((m) => m.id),
+      ...fromLoras.map((m) => m.id),
+    ]);
+    const voiceDefaults = VOICE_MODEL_DEFAULTS.filter((d) => !knownIds.has(d.id));
+    return [...fromLoras, ...cachedGgufs, ...voiceDefaults];
+  }, [loraModels, cachedGgufs]);
+
+  // A speech-LLM chat model (Orpheus, CSM, Spark...) produces its own voice, so a
+  // separate TTS voice doesn't apply.
+  const chatModelIsSpeechLLM = isSpeechLLMCheckpoint(inferenceParams.checkpoint);
+
   useEffect(() => {
     if (getTrainingCompareHandoff()) return;
     const controller = new AbortController();
@@ -4090,6 +4535,19 @@ export function ChatPage({
                 className="max-w-[62vw] !pr-3 sm:max-w-none !h-[var(--studio-chat-control-height,34px)]"
               />
             )}
+            {view.mode !== "compare" && voiceMode !== "off" && (
+              <VoiceModelSelector
+                models={ttsModels}
+                value={selectedVoiceModelId}
+                onValueChange={(id) => void handleVoiceModelChange(id)}
+                loading={voiceSlotLoading}
+                disabled={!hasActiveModel}
+                voiceOwnedByModel={chatModelIsSpeechLLM}
+                loaded={voiceSlotLoaded}
+                className="!h-[34px]"
+              />
+            )}
+            {view.mode !== "compare" && voiceMode !== "off" && <VoiceNamePicker />}
             {view.mode !== "compare" && currentProjectId && (
               <nav
                 aria-label="Project location"

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -27,6 +27,7 @@ import { VoiceModelSelector } from "@/components/assistant-ui/voice-model-select
 import { VoiceNamePicker } from "@/components/assistant-ui/voice-name-picker";
 import { authFetch } from "@/features/auth";
 import { VOICE_SLOT_AUDIO_TYPES } from "@/features/chat/hooks/use-tts-player";
+import { chatModelOwnsItsVoice } from "./voice/speech-llm.ts";
 import { usePlatformStore } from "@/config/env";
 import { CopyableErrorChip } from "@/components/ui/copyable-error-chip";
 import {
@@ -331,16 +332,6 @@ function messageHasImage(message: MessageRecord): boolean {
 const ARTIFACT_PANEL_DEFAULT_SIZE = "38%";
 const ARTIFACT_PANEL_TRANSITION_MS = 260;
 const ARTIFACT_SURFACE_POP_DELAY_MS = 150;
-
-// A speech-LLM chat model (Orpheus, CSM, Spark...) produces its own voice, so a
-// separate TTS voice slot doesn't apply and must not be auto-loaded. Module-level
-// so both the render-time greying and the voice-slot ensure-load effect can share
-// one definition.
-const SPEECH_LLM_CHECKPOINT_RE =
-  /(?:orpheus|csm|spark|bark|parler|musicgen|text-to-speech|[-_]tts)/i;
-function isSpeechLLMCheckpoint(checkpoint: string | null | undefined): boolean {
-  return SPEECH_LLM_CHECKPOINT_RE.test(checkpoint ?? "");
-}
 
 const SingleContent = memo(function SingleContent({
   threadId,
@@ -2631,7 +2622,7 @@ export function ChatPage({
     // Browser voice / nothing selected: there's no separate slot to load.
     if (!id) return false;
     // Speech-LLM chat models speak with their own voice; no separate slot.
-    if (isSpeechLLMCheckpoint(store.params.checkpoint)) return false;
+    if (chatModelOwnsItsVoice(store)) return false;
     if (voiceReloadInflightRef.current) return voiceReloadInflightRef.current;
     const run = (async () => {
       try {
@@ -2693,7 +2684,7 @@ export function ChatPage({
     // Speech-LLM chat models (Orpheus etc.) speak with their own voice, so the
     // separate TTS slot is greyed out and must not be auto-loaded -- doing so
     // wastes VRAM/time loading a voice that never gets used.
-    if (isSpeechLLMCheckpoint(useChatRuntimeStore.getState().params.checkpoint)) {
+    if (chatModelOwnsItsVoice(useChatRuntimeStore.getState())) {
       return;
     }
     const id = useChatRuntimeStore.getState().selectedVoiceModelId;
@@ -2784,10 +2775,10 @@ export function ChatPage({
   // route prefers the voice slot whenever one is loaded, so a previously picked voice
   // would keep speaking every reply while the UI said the model owned its voice. Drop
   // the selection and unload the slot so what you hear matches what the UI claims.
-  // Derived here rather than read from the chatModelIsSpeechLLM const the picker
-  // uses: that one is declared further down this component, so reading it here
-  // would be a temporal-dead-zone throw on first render.
-  const checkpointOwnsItsVoice = isSpeechLLMCheckpoint(inferenceParams.checkpoint);
+  // Read from the store (the inventory record's detected codec, with the name
+  // pattern as fallback) so a renamed fine-tune is caught too. The picker's
+  // chatModelIsSpeechLLM further down reuses this value rather than recomputing it.
+  const checkpointOwnsItsVoice = useChatRuntimeStore(chatModelOwnsItsVoice);
   useEffect(() => {
     if (!checkpointOwnsItsVoice) return;
     if (!useChatRuntimeStore.getState().selectedVoiceModelId) return;
@@ -4252,7 +4243,7 @@ export function ChatPage({
 
   // A speech-LLM chat model (Orpheus, CSM, Spark...) produces its own voice, so a
   // separate TTS voice doesn't apply.
-  const chatModelIsSpeechLLM = isSpeechLLMCheckpoint(inferenceParams.checkpoint);
+  const chatModelIsSpeechLLM = checkpointOwnsItsVoice;
 
   useEffect(() => {
     if (getTrainingCompareHandoff()) return;

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -25,6 +25,11 @@ import {
 } from "@/features/chat/voice/voice-loop-bridge";
 import { VoiceModelSelector } from "@/components/assistant-ui/voice-model-selector";
 import { VoiceNamePicker } from "@/components/assistant-ui/voice-name-picker";
+import { SttModelSelector } from "@/components/assistant-ui/stt-model-selector";
+import {
+  STT_MODELS,
+  sttModelName,
+} from "@/features/settings/stores/stt-model-catalog";
 import { authFetch } from "@/features/auth";
 import { VOICE_SLOT_AUDIO_TYPES } from "@/features/chat/hooks/use-tts-player";
 import { chatModelOwnsItsVoice } from "./voice/speech-llm.ts";
@@ -2468,6 +2473,10 @@ export function ChatPage({
   const voiceSlotLoading = useChatRuntimeStore((s) => s.voiceSlotLoading);
   const setVoiceSlotLoading = useChatRuntimeStore((s) => s.setVoiceSlotLoading);
   const voiceSlotLoaded = useChatRuntimeStore((s) => s.voiceSlotLoaded);
+  const selectedSttModelId = useChatRuntimeStore((s) => s.selectedSttModelId);
+  const setSelectedSttModelId = useChatRuntimeStore(
+    (s) => s.setSelectedSttModelId,
+  );
   const [cachedGgufs, setCachedGgufs] = useState<LoraModelOption[]>([]);
   const cachedGgufsFetchedRef = useRef(false);
 
@@ -4221,6 +4230,19 @@ export function ChatPage({
   // here uses it purely as the voice for a separate chat model, which is exactly the
   // "hear the voice you fine-tuned" case, and it is what the Orpheus default below
   // already offers.
+  // Listening side of the pair. The PR shipped its own Whisper list; upstream now
+  // curates one (Qwen3-ASR alongside the Whisper sizes), so read that rather than
+  // keep a second list that would drift from Settings > Voice.
+  const sttModels = useMemo<LoraModelOption[]>(
+    () =>
+      STT_MODELS.map((id) => ({
+        id,
+        name: sttModelName(id),
+        isGguf: true,
+      })),
+    [],
+  );
+
   const ttsModels = useMemo<LoraModelOption[]>(() => {
     const fromLoras = loraModels.filter(
       (m) =>
@@ -4539,6 +4561,16 @@ export function ChatPage({
               />
             )}
             {view.mode !== "compare" && voiceMode !== "off" && <VoiceNamePicker />}
+            {view.mode !== "compare" && voiceMode !== "off" && (
+              <SttModelSelector
+                models={sttModels}
+                value={selectedSttModelId}
+                onValueChange={setSelectedSttModelId}
+                disabled={!hasActiveModel}
+                ready={true}
+                className="!h-[34px]"
+              />
+            )}
             {view.mode !== "compare" && currentProjectId && (
               <nav
                 aria-label="Project location"

--- a/studio/frontend/src/features/chat/hooks/use-tts-player.ts
+++ b/studio/frontend/src/features/chat/hooks/use-tts-player.ts
@@ -4,15 +4,11 @@
 import { authFetch } from "@/features/auth";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { TTS_AUDIO_TYPES, VOICE_SLOT_AUDIO_TYPES } from "../voice/tts-audio-types.ts";
 
-export const TTS_AUDIO_TYPES = new Set(["snac", "csm", "bicodec", "dac"]);
-
-// Codecs the backend voice slot accepts. Mirrors _VOICE_SLOT_AUDIO_TYPES in
-// routes/inference.py: the slot is a second llama-server, and llama.cpp decodes
-// snac, bicodec and dac. `csm` is in TTS_AUDIO_TYPES but not here -- a CSM GGUF
-// loads and then has no decoder, so offering one as a voice is offering a load
-// that always fails.
-export const VOICE_SLOT_AUDIO_TYPES = new Set(["snac", "bicodec", "dac"]);
+// Defined in ../voice/tts-audio-types (dependency-free, so the pure voice helpers
+// and their tests can read them); re-exported here for this hook's importers.
+export { TTS_AUDIO_TYPES, VOICE_SLOT_AUDIO_TYPES };
 
 // Split assistant text into sentence-sized chunks so the first one can start
 // speaking while the rest are still synthesizing, instead of waiting for the
@@ -503,7 +499,14 @@ export function useTtsPlayer(
             // aborted (stop / barge-in) or a network error
           } finally {
             streamEnded = true;
-            if (pending <= 0) finish(true);
+            // Nothing scheduled means nothing was spoken: the request failed at the
+            // network layer, or a 200 closed before its first PCM chunk. Report that
+            // as unplayed so the caller falls back to the blob path (and, failing
+            // that, the browser voice) instead of advancing the loop in silence. A
+            // superseded request (stop / barge-in) still reads as played: the caller
+            // drops it on the request-id check either way, and a reply the user just
+            // cut off must not trigger a fallback.
+            if (pending <= 0) finish(started || requestIdRef.current !== reqId);
           }
         })();
       });
@@ -574,12 +577,20 @@ export function useTtsPlayer(
       const utterances = sentences.map((sentence) => {
         const utterance = new SpeechSynthesisUtterance(sentence);
         utterance.onstart = () => setIsPlaying(true);
+        // Both handlers can fire for a cancelled utterance long after stop():
+        // speechSynthesis.cancel() reports the old utterance's end/error
+        // asynchronously, by which time the replacement reply may already be
+        // queued. Only the current request may touch playback state or the global
+        // queue, or that stale event kills the new reply too; finish() re-checks
+        // the same id for the same reason.
         utterance.onend = () => {
+          if (requestIdRef.current !== reqId) return;
           setIsPlaying(false);
           remaining -= 1;
           if (remaining <= 0) finish();
         };
         utterance.onerror = () => {
+          if (requestIdRef.current !== reqId) return;
           window.speechSynthesis.cancel();
           finish();
         };
@@ -599,7 +610,13 @@ export function useTtsPlayer(
     async (text: string) => {
       stop();
       text = stripForSpeech(text);
-      if (!text) return;
+      if (!text) {
+        // Emoji-only or pure markup: nothing to say, but the turn still has to end
+        // like any other, or the loop never resumes listening (beginStream has
+        // already stopped dictation by the time endStream reaches here).
+        onPlaybackEndRef.current?.();
+        return;
+      }
       // stop() above bumped the counter; this is now our request's id.
       const reqId = requestIdRef.current;
       const sentences = splitIntoSentences(text);

--- a/studio/frontend/src/features/chat/hooks/use-tts-player.ts
+++ b/studio/frontend/src/features/chat/hooks/use-tts-player.ts
@@ -1,0 +1,865 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const TTS_AUDIO_TYPES = new Set(["snac", "csm", "bicodec", "dac"]);
+
+// Codecs the backend voice slot accepts. Mirrors _VOICE_SLOT_AUDIO_TYPES in
+// routes/inference.py: the slot is a second llama-server, and llama.cpp decodes
+// snac, bicodec and dac. `csm` is in TTS_AUDIO_TYPES but not here -- a CSM GGUF
+// loads and then has no decoder, so offering one as a voice is offering a load
+// that always fails.
+export const VOICE_SLOT_AUDIO_TYPES = new Set(["snac", "bicodec", "dac"]);
+
+// Split assistant text into sentence-sized chunks so the first one can start
+// speaking while the rest are still synthesizing, instead of waiting for the
+// whole response. Collapses whitespace, breaks on sentence punctuation and
+// newlines, and falls back to the whole text when there's no boundary.
+function splitIntoSentences(text: string): string[] {
+  const chunks = text
+    .replace(/\s+/g, " ")
+    .trim()
+    .match(/[^.!?\n]*[.!?]+|\S[^.!?\n]*$/g);
+  const out = (chunks ?? [text]).map((s) => s.trim()).filter(Boolean);
+  return out;
+}
+
+// For streaming: while the LLM is still writing, only fully-terminated sentences
+// are safe to synthesize; the trailing chunk is the sentence in progress.
+// Emoji / pictographs / symbol chars a TTS model can't pronounce -- it otherwise
+// voices their raw codepoints as gibberish. Stripped for speech only; the on-
+// screen chat text keeps them. Covers emoji, regional-indicator flags, keycaps,
+// variation selectors and the zero-width joiner.
+const SPEECH_STRIP_RE =
+  /[\p{Extended_Pictographic}\u{1F1E6}-\u{1F1FF}\u{20E3}\u{FE00}-\u{FE0F}\u{200D}]/gu;
+
+// Normalize text for TTS: some characters derail Orpheus (like the colon it reads
+// as a speaker tag) or get voiced literally by any TTS model. Em/en dashes and the
+// single-char ellipsis are the main offenders (an em dash breaks the voice), and
+// markdown/markup symbols get read out ("asterisk asterisk"). All of these are just
+// dropped (replaced with a space, not a comma, so no phantom pauses are inserted);
+// smart quotes are normalized. Speech ONLY -- the on-screen chat text keeps everything.
+function stripForSpeech(text: string): string {
+  return text
+    .replace(SPEECH_STRIP_RE, "")
+    .replace(/\s*[—–―‒−]\s*/g, " ") // — – ― ‒ −  -> drop
+    .replace(/\s*…\s*/g, " ") //                           …  -> drop
+    .replace(/\.{2,}/g, " ") //                                 ... -> drop
+    .replace(/[‐‑]/g, "-") //                          unicode hyphens -> ASCII
+    .replace(/[*_`~^|#<>\\{}[\]]/g, " ") //                      markdown / markup -> space
+    .replace(/[‘’‚‛]/g, "'") //             smart single quotes
+    .replace(/[“”„‟]/g, '"') //             smart double quotes
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function splitStreaming(text: string): {
+  complete: string[];
+  partial: string;
+} {
+  const parts = splitIntoSentences(text);
+  if (parts.length === 0) return { complete: [], partial: "" };
+  // If the text already ends with terminal punctuation, everything is complete.
+  if (/[.!?]["')\]]?\s*$/.test(text)) return { complete: parts, partial: "" };
+  return { complete: parts.slice(0, -1), partial: parts[parts.length - 1] ?? "" };
+}
+
+// Live output loudness (RMS-ish, ~0..0.3) of the TTS clip currently playing,
+// refreshed each animation frame from a decoded copy of the audio -- the live
+// <audio> element is NEVER routed through Web Audio, so playback can't be
+// silenced. The speaking orb reads this to move its bars with the voice. Plain
+// mutable ref so it never triggers React re-renders; reset to 0 when playback
+// ends or is cut off.
+export const voiceOutputLevel = { current: 0 };
+
+const ENVELOPE_BUCKET_S = 1 / 60;
+let _analysisCtx: AudioContext | null = null;
+
+// Decode a clip and return its RMS envelope (one value per ~1/60s bucket) so the
+// speaking bars can be indexed by playback time. Analysis-only: the context is
+// never connected to an output, so decoding here cannot affect what the user hears.
+async function envelopeFromBlob(blob: Blob): Promise<Float32Array | null> {
+  try {
+    const Ctor =
+      window.AudioContext ??
+      (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!Ctor) return null;
+    if (!_analysisCtx) _analysisCtx = new Ctor();
+    const audioBuffer = await _analysisCtx.decodeAudioData(await blob.arrayBuffer());
+    const ch = audioBuffer.getChannelData(0);
+    const per = Math.max(1, Math.floor(audioBuffer.sampleRate * ENVELOPE_BUCKET_S));
+    const n = Math.max(1, Math.ceil(ch.length / per));
+    const env = new Float32Array(n);
+    for (let b = 0; b < n; b++) {
+      const start = b * per;
+      const end = Math.min(ch.length, start + per);
+      let sum = 0;
+      for (let i = start; i < end; i++) sum += ch[i] * ch[i];
+      env[b] = Math.sqrt(sum / Math.max(1, end - start));
+    }
+    return env;
+  } catch {
+    return null;
+  }
+}
+
+// Shared AudioContext for STREAMING PCM playback. Unlike the analysis-only context
+// above, this one IS connected to the speakers: incoming 24 kHz int16 PCM chunks are
+// scheduled back-to-back on it so audio starts on the first chunk (~1s) instead of
+// waiting for the whole clip. Created lazily; resumed on a user gesture (primeAudio).
+let _playCtx: AudioContext | null = null;
+function getPlayCtx(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  const Ctor =
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) return null;
+  if (!_playCtx) _playCtx = new Ctor();
+  return _playCtx;
+}
+
+function streamPlaybackSupported(): boolean {
+  return getPlayCtx() !== null && typeof ReadableStream !== "undefined";
+}
+
+// Jitter buffer: Orpheus generates at ~real time (RTF ~1), so streamed chunks
+// barely keep pace with playback. Starting the first buffer this far in the future
+// keeps the scheduler ~this many seconds ahead of generation, so a late chunk
+// (GPU jitter) doesn't starve playback into a gap/click. Costs ~this much extra
+// first-audio latency, still far below waiting for the whole clip.
+const STREAM_PREROLL_S = 0.35;
+
+// Sample rate assumed when /audio/speech/stream does not advertise one. The route
+// sends X-Sample-Rate and that is what is used; this is only the floor for a proxy
+// that strips the header.
+const STREAM_FALLBACK_SAMPLE_RATE = 24000;
+
+// One frame of silent 8 kHz mono PCM WAV. Short enough to be inaudible and to
+// finish inside the gesture, real enough that play() resolves instead of
+// rejecting -- which is the whole point of priming (see primeAudio).
+const SILENT_WAV_DATA_URI =
+  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=";
+
+export function useTtsPlayer(
+  audioType: string | null | undefined,
+  onPlaybackEnd?: () => void,
+  voiceSlotLoaded = false,
+): {
+  isSpeaking: boolean;
+  /** True only while an audio clip is actually playing (not during synthesis). */
+  isPlaying: boolean;
+  speak(text: string): void;
+  /** Streaming: start a session, feed growing text, then end. Synthesizes each
+   *  complete sentence as it arrives so the first one plays fast. */
+  beginStream(): void;
+  feedText(text: string): void;
+  endStream(finalText: string): void;
+  stop(): void;
+  primeAudio(): void;
+} {
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  // Distinct from isSpeaking: true only while a clip is audibly playing, so the
+  // orb can show a separate "synthesizing" state during the (slow) synth gaps.
+  const [isPlaying, setIsPlaying] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+  // Bumped on every stop()/new speak()/unmount so an in-flight /api/inference/audio/speech
+  // response (or a queued sentence) can detect it was superseded and skip late
+  // playback + state updates.
+  const requestIdRef = useRef(0);
+  // Aborts in-flight /api/inference/audio/speech synth fetches on stop()/barge-in, so the
+  // backend voice slot stops grinding through stale sentences and is free to
+  // synthesize the new turn immediately (llama-server cancels a slot when its
+  // request connection closes).
+  const synthAbortRef = useRef<AbortController | null>(null);
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  // Resolver for the sentence currently awaiting playback, so stop() can unwind
+  // the speak loop immediately (pause() doesn't fire "ended").
+  const playResolveRef = useRef<(() => void) | null>(null);
+  // Streaming-PCM playback state: the Web Audio sources currently scheduled (so
+  // stop()/barge-in can cut them), the orb-level rAF handle, and a resolver so
+  // stop() can immediately unwind a sentence that's mid-stream.
+  const streamSourcesRef = useRef<Set<AudioBufferSourceNode>>(new Set());
+  const streamLevelRafRef = useRef(0);
+  const streamResolveRef = useRef<(() => void) | null>(null);
+  const onPlaybackEndRef = useRef(onPlaybackEnd);
+  onPlaybackEndRef.current = onPlaybackEnd;
+
+  // Streaming session state. `sentences` holds every known sentence text (grows
+  // as the reply streams); `jobs`/`launched` track synth jobs actually fired --
+  // only a small lookahead window ahead of `playIndex` is launched, so the backend
+  // never backs up with stale sentences and barge-in leaves almost nothing queued.
+  const streamRef = useRef<{
+    reqId: number;
+    sentences: string[];
+    jobs: Array<Promise<Blob | null>>;
+    launched: number;
+    playIndex: number;
+    final: boolean;
+  } | null>(null);
+
+  const isTtsModel = TTS_AUDIO_TYPES.has(audioType ?? "") || voiceSlotLoaded;
+  // Stream PCM straight from /api/inference/audio/speech/stream (SNAC/Orpheus voice slot) and
+  // play it as it arrives, so first audio lands ~1s in instead of after the whole
+  // clip. Only for the loaded voice slot (the streaming endpoint is SNAC-only); if
+  // the stream 400s (non-SNAC), playSentenceStream falls back to the blocking blob.
+  const streamMode = voiceSlotLoaded && streamPlaybackSupported();
+
+  // Unlock Safari's audio autoplay policy by calling play()+pause() during
+  // a synchronous user gesture. The element is reused for all subsequent plays
+  // so the unlock survives async fetch callbacks. Also resume the streaming
+  // AudioContext in the same gesture so scheduled PCM isn't blocked by autoplay.
+  const primeAudio = useCallback(() => {
+    if (typeof window === "undefined") return;
+    if (!audioRef.current) {
+      audioRef.current = new Audio();
+    }
+    // play() on a sourceless element rejects immediately, so the old call primed
+    // nothing and the catch hid it: the first real clip, arriving later from an
+    // async fetch, was then refused by autoplay policy and treated as finished --
+    // silent TTS. Give it something to actually play inside the gesture. The same
+    // element is reused by playBlob, so this unlocks the path that matters.
+    if (!audioRef.current.src) audioRef.current.src = SILENT_WAV_DATA_URI;
+    audioRef.current
+      .play()
+      .then(() => audioRef.current?.pause())
+      .catch(() => {});
+    void getPlayCtx()?.resume().catch(() => {});
+  }, []);
+
+  const revokeUrl = useCallback(() => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+  }, []);
+
+  const stopTts = useCallback(() => {
+    const audio = audioRef.current;
+    if (audio) {
+      audio.onended = null;
+      audio.onerror = null;
+      audio.pause();
+      audio.src = "";  // release current source but keep element alive for reuse
+    }
+    revokeUrl();
+    // Release a sentence mid-playback so the speak loop's await resolves and the
+    // chunk pipeline unwinds instead of hanging.
+    playResolveRef.current?.();
+    playResolveRef.current = null;
+  }, [revokeUrl]);
+
+  const stopSynth = useCallback(() => {
+    if (utteranceRef.current) {
+      window.speechSynthesis.cancel();
+      utteranceRef.current = null;
+    }
+  }, []);
+
+  // Cut streaming-PCM playback: stop every scheduled buffer source, drop the orb
+  // level loop, and resolve the sentence that's mid-stream so its awaiter unwinds.
+  const stopStream = useCallback(() => {
+    for (const src of streamSourcesRef.current) {
+      try {
+        src.onended = null;
+        src.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    streamSourcesRef.current.clear();
+    if (streamLevelRafRef.current) cancelAnimationFrame(streamLevelRafRef.current);
+    streamLevelRafRef.current = 0;
+    voiceOutputLevel.current = 0;
+    const resolve = streamResolveRef.current;
+    streamResolveRef.current = null;
+    resolve?.();
+  }, []);
+
+  const stop = useCallback(() => {
+    requestIdRef.current += 1;
+    // Cancel any in-flight synth so the voice slot stops on stale sentences and
+    // is free for the next turn; then arm a fresh controller for that turn.
+    synthAbortRef.current?.abort();
+    synthAbortRef.current = new AbortController();
+    stopTts();
+    stopStream();
+    stopSynth();
+    setIsSpeaking(false);
+    setIsPlaying(false);
+  }, [stopTts, stopStream, stopSynth]);
+
+  // Play a single audio blob; resolves when it ends, errors, or is superseded by
+  // a stop()/new speak().
+  const playBlob = useCallback((blob: Blob, reqId: number) => {
+    return new Promise<void>((resolve) => {
+      if (requestIdRef.current !== reqId) {
+        resolve();
+        return;
+      }
+      const url = URL.createObjectURL(blob);
+      objectUrlRef.current = url;
+      const audio = audioRef.current ?? new Audio();
+      audioRef.current = audio;
+
+      // Drive the speaking-orb bars from this clip's loudness. Decode a copy for
+      // its envelope (async; the live element is untouched) and, while it plays,
+      // publish the level at the current playback time each animation frame.
+      let env: Float32Array | null = null;
+      void envelopeFromBlob(blob).then((e) => {
+        env = e;
+      });
+      let levelRaf = 0;
+      const runLevel = () => {
+        if (env) {
+          voiceOutputLevel.current =
+            env[Math.floor(audio.currentTime / ENVELOPE_BUCKET_S)] ?? 0;
+        }
+        levelRaf = requestAnimationFrame(runLevel);
+      };
+      const stopLevel = () => {
+        if (levelRaf) cancelAnimationFrame(levelRaf);
+        levelRaf = 0;
+        voiceOutputLevel.current = 0;
+      };
+
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        stopLevel();
+        if (playResolveRef.current === done) playResolveRef.current = null;
+        if (objectUrlRef.current === url) {
+          URL.revokeObjectURL(url);
+          objectUrlRef.current = null;
+        }
+        audio.onended = null;
+        audio.onerror = null;
+        audio.onplaying = null;
+        // Between chunks we're synthesizing again, not playing.
+        if (requestIdRef.current === reqId) setIsPlaying(false);
+        resolve();
+      };
+      playResolveRef.current = done;
+      audio.onended = done;
+      audio.onerror = done;
+      // Flip to "playing" only once audio actually starts, so the gap before it
+      // (synthesis) stays in the synthesizing state.
+      audio.onplaying = () => {
+        if (requestIdRef.current === reqId) setIsPlaying(true);
+        if (!levelRaf) levelRaf = requestAnimationFrame(runLevel);
+      };
+      audio.src = url;
+      // play() returns a promise that can reject (autoplay policy, decode error)
+      // without ever firing onerror; settle so the loop can't stall.
+      void audio.play().catch(done);
+    });
+  }, []);
+
+  // Stream ONE sentence from /api/inference/audio/speech/stream and play its 24 kHz int16 PCM
+  // as it arrives (Web Audio, buffer sources scheduled back-to-back), so audio
+  // starts on the first chunk (~1s) instead of after the whole clip. Resolves true
+  // once playback finished or was cut; resolves FALSE without playing if the stream
+  // isn't usable (non-SNAC voice / error) so the caller can fall back to the blob.
+  const playSentenceStream = useCallback(
+    (sentence: string, reqId: number): Promise<boolean> => {
+      return new Promise<boolean>((resolve) => {
+        if (requestIdRef.current !== reqId) {
+          resolve(true);
+          return;
+        }
+        const ctx = getPlayCtx();
+        if (!ctx) {
+          resolve(false);
+          return;
+        }
+        void ctx.resume().catch(() => {});
+        const voice = useChatRuntimeStore.getState().selectedVoiceName || "tara";
+
+        const analyser = ctx.createAnalyser();
+        analyser.fftSize = 256;
+        analyser.connect(ctx.destination);
+        const levelBuf = new Float32Array(analyser.fftSize);
+        const runLevel = () => {
+          analyser.getFloatTimeDomainData(levelBuf);
+          let s = 0;
+          for (let i = 0; i < levelBuf.length; i++) s += levelBuf[i] * levelBuf[i];
+          voiceOutputLevel.current = Math.sqrt(s / levelBuf.length);
+          streamLevelRafRef.current = requestAnimationFrame(runLevel);
+        };
+
+        let playHead = 0;
+        let started = false;
+        let streamEnded = false;
+        let pending = 0;
+        let settled = false;
+        let leftover: Uint8Array | null = null;
+        let sampleRate = STREAM_FALLBACK_SAMPLE_RATE;
+
+        const finish = (played: boolean) => {
+          if (settled) return;
+          settled = true;
+          streamResolveRef.current = null;
+          try {
+            analyser.disconnect();
+          } catch {
+            /* already gone */
+          }
+          if (streamLevelRafRef.current && streamSourcesRef.current.size === 0) {
+            cancelAnimationFrame(streamLevelRafRef.current);
+            streamLevelRafRef.current = 0;
+            voiceOutputLevel.current = 0;
+          }
+          if (requestIdRef.current === reqId) setIsPlaying(false);
+          resolve(played);
+        };
+        // stop()/barge-in calls this (via stopStream) to unwind immediately.
+        streamResolveRef.current = () => finish(true);
+
+        const schedule = (bytes: Uint8Array) => {
+          let data = bytes;
+          if (leftover && leftover.length) {
+            const merged = new Uint8Array(leftover.length + bytes.length);
+            merged.set(leftover);
+            merged.set(bytes, leftover.length);
+            data = merged;
+            leftover = null;
+          }
+          const nSamples = data.length >> 1;
+          if (nSamples === 0) {
+            leftover = data;
+            return;
+          }
+          const usable = nSamples * 2;
+          if (usable < data.length) leftover = data.slice(usable);
+          const view = new DataView(data.buffer, data.byteOffset, usable);
+          const f32 = new Float32Array(nSamples);
+          for (let i = 0; i < nSamples; i++) f32[i] = view.getInt16(i * 2, true) / 32768;
+          const audioBuf = ctx.createBuffer(1, nSamples, sampleRate);
+          audioBuf.copyToChannel(f32, 0);
+          const src = ctx.createBufferSource();
+          src.buffer = audioBuf;
+          src.connect(analyser);
+          // First buffer starts a jitter-buffer ahead (STREAM_PREROLL_S) so the
+          // scheduler stays ahead of the ~real-time generation; the rest chain
+          // gaplessly off the running playhead. The max() guard means a chunk that
+          // arrived late still schedules just ahead of now instead of in the past.
+          const startAt = !started
+            ? ctx.currentTime + STREAM_PREROLL_S
+            : Math.max(ctx.currentTime + 0.005, playHead);
+          src.start(startAt);
+          playHead = startAt + audioBuf.duration;
+          streamSourcesRef.current.add(src);
+          pending++;
+          if (!started) {
+            started = true;
+            if (requestIdRef.current === reqId) setIsPlaying(true);
+            if (!streamLevelRafRef.current)
+              streamLevelRafRef.current = requestAnimationFrame(runLevel);
+          }
+          src.onended = () => {
+            streamSourcesRef.current.delete(src);
+            pending--;
+            if (streamEnded && pending <= 0) finish(true);
+          };
+        };
+
+        void (async () => {
+          try {
+            const resp = await authFetch("/api/inference/audio/speech/stream", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ input: sentence, voice }),
+              signal: synthAbortRef.current?.signal,
+            });
+            if (!resp.ok || !resp.body) {
+              finish(false); // let the caller fall back to the blocking blob path
+              return;
+            }
+            // Read the rate the route actually decoded at rather than assuming the
+            // codec's. Every chunk of this response is decoded at one rate, and the
+            // first schedule() call happens below, so setting it here is in time.
+            const advertised = Number(resp.headers.get("X-Sample-Rate"));
+            if (Number.isFinite(advertised) && advertised > 0) sampleRate = advertised;
+            const reader = resp.body.getReader();
+            for (;;) {
+              const { done: rdone, value } = await reader.read();
+              if (rdone) break;
+              if (requestIdRef.current !== reqId) {
+                try {
+                  await reader.cancel();
+                } catch {
+                  /* ignore */
+                }
+                break;
+              }
+              if (value && value.length) schedule(value);
+            }
+          } catch {
+            // aborted (stop / barge-in) or a network error
+          } finally {
+            streamEnded = true;
+            if (pending <= 0) finish(true);
+          }
+        })();
+      });
+    },
+    [],
+  );
+
+  // POST one sentence to /api/inference/audio/speech and return the audio blob. If the
+  // backend voice slot is gone (400 -- unloaded by a ChatPage remount, an auth
+  // bounce, or a studio relaunch), reload it once via the store hook and retry,
+  // so TTS heals itself instead of silently 400ing for the rest of the session.
+  const requestSpeechBlob = useCallback(
+    async (input: string): Promise<Blob | null> => {
+      const voice =
+        useChatRuntimeStore.getState().selectedVoiceName || "tara";
+      const doFetch = () =>
+        authFetch("/api/inference/audio/speech", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ input, voice }),
+          signal: synthAbortRef.current?.signal,
+        });
+      try {
+        let r = await doFetch();
+        if (r.ok) return await r.blob();
+        if (r.status === 400) {
+          const reload = useChatRuntimeStore.getState().ensureVoiceSlotLoaded;
+          if (reload && (await reload())) {
+            r = await doFetch();
+            if (r.ok) return await r.blob();
+          }
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    },
+    [],
+  );
+
+  // Speak with the browser's own voice. Reached either because no backend TTS is
+  // available, or because backend synthesis produced nothing for this reply --
+  // in that second case it is the difference between a spoken answer and silence.
+  const speakWithBrowser = useCallback(
+    (sentences: string[], reqId: number) => {
+      if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+        onPlaybackEndRef.current?.();
+        return;
+      }
+      // Queue one utterance per sentence: gives the same chunked cadence and
+      // sidesteps Chrome's long-utterance cutoff bug. Completion fires on the
+      // last sentence; any error ends the loop.
+      setIsSpeaking(true);
+      let remaining = sentences.length;
+      const finish = () => {
+        // Tied to this speak() call, not merely to "some utterance is recorded".
+        // A cancelled utterance still fires onend/onerror, and after a quick
+        // stop-then-restart that stale event arrives with the NEW utterance
+        // recorded -- clearing its state and resuming the voice loop while the
+        // new speech was still queued.
+        if (requestIdRef.current !== reqId) return;
+        if (utteranceRef.current === null) return;
+        utteranceRef.current = null;
+        setIsSpeaking(false);
+        setIsPlaying(false);
+        onPlaybackEndRef.current?.();
+      };
+      const utterances = sentences.map((sentence) => {
+        const utterance = new SpeechSynthesisUtterance(sentence);
+        utterance.onstart = () => setIsPlaying(true);
+        utterance.onend = () => {
+          setIsPlaying(false);
+          remaining -= 1;
+          if (remaining <= 0) finish();
+        };
+        utterance.onerror = () => {
+          window.speechSynthesis.cancel();
+          finish();
+        };
+        return utterance;
+      });
+      // Sentinel so stop()/stopSynth() knows synth playback is active.
+      utteranceRef.current = utterances[utterances.length - 1] ?? null;
+      for (const utterance of utterances) window.speechSynthesis.speak(utterance);
+    },
+    // Empty on purpose: everything closed over is a ref or a setState, all stable
+    // for the life of the hook. A dependency here would give speak() a new identity
+    // every render and restart the loop's effects mid-conversation.
+    [],
+  );
+
+  const speak = useCallback(
+    async (text: string) => {
+      stop();
+      text = stripForSpeech(text);
+      if (!text) return;
+      // stop() above bumped the counter; this is now our request's id.
+      const reqId = requestIdRef.current;
+      const sentences = splitIntoSentences(text);
+      if (sentences.length === 0) {
+        onPlaybackEndRef.current?.();
+        return;
+      }
+
+      if (isTtsModel) {
+        setIsSpeaking(true);
+        // Whether the backend produced any audio at all for this reply.
+        let playedAnything = false;
+
+        if (streamMode) {
+          // Stream each sentence's PCM and play it as it generates (first audio in
+          // ~1s). Sequential per sentence: the single voice slot generates one at a
+          // time, so there's nothing to pre-synthesize ahead.
+          for (let i = 0; i < sentences.length; i++) {
+            if (requestIdRef.current !== reqId) return;
+            const played = await playSentenceStream(sentences[i], reqId);
+            if (requestIdRef.current !== reqId) return;
+            if (played) {
+              playedAnything = true;
+            } else {
+              // Stream not usable (non-SNAC voice) -> blocking blob fallback.
+              const blob = await requestSpeechBlob(sentences[i]);
+              if (requestIdRef.current !== reqId) return;
+              if (blob) {
+                playedAnything = true;
+                await playBlob(blob, reqId);
+              }
+            }
+          }
+        } else {
+          const synth = (sentence: string): Promise<Blob | null> =>
+            requestSpeechBlob(sentence);
+
+          // Bounded-concurrency pipeline: keep up to N sentences synthesizing at
+          // once (voiceParallelN), play them back strictly in order. N=1 is the old
+          // one-ahead behavior. The GGUF voice slot must be loaded with matching
+          // --parallel N; the backend serializes only the shared codec decode.
+          const N = Math.min(
+            sentences.length,
+            Math.max(1, useChatRuntimeStore.getState().voiceParallelN),
+          );
+          const jobs: Array<Promise<Blob | null>> = [];
+          let launched = 0;
+          const launchUpTo = (limit: number) => {
+            while (launched < sentences.length && launched < limit) {
+              jobs[launched] = synth(sentences[launched]);
+              launched++;
+            }
+          };
+          launchUpTo(N); // prime N in flight
+          for (let i = 0; i < sentences.length; i++) {
+            if (requestIdRef.current !== reqId) return;  // superseded
+            const blob = await jobs[i];
+            if (requestIdRef.current !== reqId) return;
+            // Refill the window so N stay in flight ahead of playback.
+            launchUpTo(i + 1 + N);
+            if (!blob) continue;  // skip a sentence that failed to synthesize
+            playedAnything = true;
+            await playBlob(blob, reqId);
+          }
+        }
+
+        if (requestIdRef.current !== reqId) return;
+        if (!playedAnything) {
+          // Every sentence failed to synthesize. That is what a codec the speech
+          // route cannot serve looks like from here -- a GGUF CSM model reports
+          // audio_type "csm" but the llama.cpp decoder only does snac, bicodec and
+          // dac -- and it also covers a slot that went away mid-reply. Either way
+          // the reply must still be spoken, so fall through to browser speech
+          // rather than ending in silence.
+          speakWithBrowser(sentences, reqId);
+          return;
+        }
+        setIsSpeaking(false);
+        onPlaybackEndRef.current?.();
+      } else {
+        speakWithBrowser(sentences, reqId);
+      }
+    },
+    [isTtsModel, streamMode, stop, playBlob, playSentenceStream, requestSpeechBlob, speakWithBrowser],
+  );
+
+
+  // ── Streaming TTS ───────────────────────────────────────────────
+  // POST one sentence to /api/inference/audio/speech; null on failure.
+  const synthOne = useCallback(
+    (sentence: string): Promise<Blob | null> => {
+      // Strip emoji here -- the single synth chokepoint for streaming, hit by both
+      // feedText and the endStream flush -- so no path can send unpronounceable
+      // glyphs. An emoji-only chunk has nothing to say, so skip it.
+      const clean = stripForSpeech(sentence);
+      if (!clean) return Promise.resolve(null);
+      return requestSpeechBlob(clean);
+    },
+    [requestSpeechBlob],
+  );
+
+  // Launch synth jobs only up to a small lookahead window ahead of the sentence
+  // currently playing -- "always one (or voiceParallelN) ahead", never the whole
+  // reply. This keeps audio close to real time and means a barge-in leaves at most
+  // a couple of stale sentences on the backend instead of a long tail.
+  const pumpSynth = useCallback(() => {
+    const st = streamRef.current;
+    // In stream mode the loop pulls each sentence straight off st.sentences and
+    // streams it, so there are no blob jobs to pre-launch.
+    if (!st || requestIdRef.current !== st.reqId || !isTtsModel || streamMode) return;
+    // Keep at most ONE sentence synthesizing ahead of the one playing. The voice
+    // slot is compute-bound on a single GPU even at --parallel N, so firing
+    // further ahead just backs up the queue and makes a barge-in throw away more
+    // in-flight audio; one ahead is enough to hide the gap between sentences.
+    const lookahead = 1;
+    const limit = Math.min(st.sentences.length, st.playIndex + 1 + lookahead);
+    while (st.launched < limit) {
+      st.jobs[st.launched] = synthOne(st.sentences[st.launched] ?? "");
+      st.launched++;
+    }
+  }, [isTtsModel, synthOne, streamMode]);
+
+  // Start a streaming session. Sentences fed via feedText are synthesized within a
+  // bounded lookahead window and played strictly in order, so the first sentence
+  // plays without waiting for the whole reply. Browser voice has no server synth,
+  // so it just waits for endStream and speaks the whole thing.
+  const beginStream = useCallback(() => {
+    stop();
+    const reqId = requestIdRef.current;
+    streamRef.current = {
+      reqId,
+      sentences: [],
+      jobs: [],
+      launched: 0,
+      playIndex: 0,
+      final: false,
+    };
+    if (!isTtsModel) return;
+    setIsSpeaking(true);
+    // Whether the backend produced any audio at all across the whole reply.
+    let playedAnything = false;
+    void (async () => {
+      while (true) {
+        if (requestIdRef.current !== reqId) return;
+        const st = streamRef.current;
+        if (!st || st.reqId !== reqId) return;
+        if (st.playIndex < st.sentences.length) {
+          if (streamMode) {
+            // Stream this sentence's PCM and play as it generates (fast first audio),
+            // keeping the per-sentence order. Fall back to a blob if the stream 400s.
+            const sentence = stripForSpeech(st.sentences[st.playIndex] ?? "");
+            st.playIndex++;
+            if (sentence) {
+              const played = await playSentenceStream(sentence, reqId);
+              if (requestIdRef.current !== reqId) return;
+              if (played) {
+                playedAnything = true;
+              } else {
+                const blob = await synthOne(sentence);
+                if (requestIdRef.current !== reqId) return;
+                if (blob) {
+                  playedAnything = true;
+                  await playBlob(blob, reqId);
+                }
+              }
+            }
+          } else {
+            pumpSynth(); // ensure the current sentence (and window) is launched
+            const blob = await st.jobs[st.playIndex];
+            if (requestIdRef.current !== reqId) return;
+            st.playIndex++;
+            pumpSynth(); // playback advanced -> refill the lookahead window
+            if (blob) {
+              playedAnything = true;
+              await playBlob(blob, reqId);
+            }
+          }
+        } else if (st.final) {
+          break;
+        } else {
+          await new Promise<void>((r) => setTimeout(r, 40));
+        }
+      }
+      if (requestIdRef.current !== reqId) return;
+      const spoken = streamRef.current?.sentences ?? [];
+      streamRef.current = null;
+      if (!playedAnything && spoken.length > 0) {
+        // The backend produced nothing for the entire reply. That is what a codec
+        // the speech route cannot serve looks like from here -- a GGUF CSM model
+        // reports audio_type "csm", but the llama.cpp decoder only does snac,
+        // bicodec and dac -- and it also covers a voice slot that went away
+        // mid-reply. In voice mode silence is indistinguishable from a hung loop,
+        // so say it with the browser voice rather than say nothing.
+        speakWithBrowser(spoken, reqId);
+        return;
+      }
+      setIsSpeaking(false);
+      onPlaybackEndRef.current?.();
+    })();
+  }, [
+    stop,
+    isTtsModel,
+    streamMode,
+    playBlob,
+    pumpSynth,
+    playSentenceStream,
+    synthOne,
+    speakWithBrowser,
+  ]);
+
+  // Feed the growing assistant text; records newly-complete sentences and lets the
+  // pump launch synth for them within the lookahead window (not all at once).
+  const feedText = useCallback(
+    (text: string) => {
+      const s = streamRef.current;
+      if (!s || requestIdRef.current !== s.reqId || !isTtsModel) return;
+      const { complete } = splitStreaming(text);
+      while (s.sentences.length < complete.length) {
+        s.sentences.push(complete[s.sentences.length] ?? "");
+      }
+      pumpSynth();
+    },
+    [isTtsModel, pumpSynth],
+  );
+
+  // Finish the session: record the final (incl. trailing) sentences, mark done.
+  const endStream = useCallback(
+    (finalText: string) => {
+      const s = streamRef.current;
+      if (!s || requestIdRef.current !== s.reqId) return;
+      if (!isTtsModel) {
+        // Browser voice: nothing streamed; speak the whole reply now.
+        streamRef.current = null;
+        speak(finalText);
+        return;
+      }
+      const all = splitIntoSentences(finalText);
+      while (s.sentences.length < all.length) {
+        s.sentences.push(all[s.sentences.length] ?? "");
+      }
+      s.final = true;
+      pumpSynth();
+      if (s.sentences.length === 0) {
+        streamRef.current = null;
+        setIsSpeaking(false);
+        onPlaybackEndRef.current?.();
+      }
+    },
+    [isTtsModel, pumpSynth, speak],
+  );
+
+  useEffect(() => {
+    return () => {
+      requestIdRef.current += 1;
+      synthAbortRef.current?.abort();
+      stopTts();
+      stopStream();
+      stopSynth();
+    };
+  }, [stopTts, stopStream, stopSynth]);
+
+  return { isSpeaking, isPlaying, speak, beginStream, feedText, endStream, stop, primeAudio };
+}

--- a/studio/frontend/src/features/chat/hooks/use-tts-player.ts
+++ b/studio/frontend/src/features/chat/hooks/use-tts-player.ts
@@ -4,55 +4,28 @@
 import { authFetch } from "@/features/auth";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { TTS_AUDIO_TYPES, VOICE_SLOT_AUDIO_TYPES } from "../voice/tts-audio-types.ts";
+import { TTS_AUDIO_TYPES, VOICE_SLOT_AUDIO_TYPES } from "../voice/tts-audio-types";
+import {
+  splitIntoSentences,
+  stripForSpeech,
+} from "../voice/speech-text";
 
-// Defined in ../voice/tts-audio-types (dependency-free, so the pure voice helpers
-// and their tests can read them); re-exported here for this hook's importers.
+// Re-exported for importers that predate the split into a dependency-free module.
+export { splitIntoSentences, stripForSpeech };
+
+// The codec vocabulary lives in its own dependency-free module so the pure voice
+// helpers and their node:test suites can read it without pulling in React and
+// auth. Re-exported here for the importers that predate that split.
 export { TTS_AUDIO_TYPES, VOICE_SLOT_AUDIO_TYPES };
 
-// Split assistant text into sentence-sized chunks so the first one can start
-// speaking while the rest are still synthesizing, instead of waiting for the
-// whole response. Collapses whitespace, breaks on sentence punctuation and
-// newlines, and falls back to the whole text when there's no boundary.
-function splitIntoSentences(text: string): string[] {
-  const chunks = text
-    .replace(/\s+/g, " ")
-    .trim()
-    .match(/[^.!?\n]*[.!?]+|\S[^.!?\n]*$/g);
-  const out = (chunks ?? [text]).map((s) => s.trim()).filter(Boolean);
-  return out;
-}
+// Subset of TTS_AUDIO_TYPES that are standalone TTS voices (Spark/bicodec,
+// Dia/dac) rather than speech-LLMs (Orpheus/snac, Sesame CSM/csm) that speak
+// with their own voice and don't need a separate TTS picker.
+export const STANDALONE_TTS_AUDIO_TYPES = new Set(["bicodec", "dac"]);
 
 // For streaming: while the LLM is still writing, only fully-terminated sentences
 // are safe to synthesize; the trailing chunk is the sentence in progress.
-// Emoji / pictographs / symbol chars a TTS model can't pronounce -- it otherwise
-// voices their raw codepoints as gibberish. Stripped for speech only; the on-
-// screen chat text keeps them. Covers emoji, regional-indicator flags, keycaps,
-// variation selectors and the zero-width joiner.
-const SPEECH_STRIP_RE =
-  /[\p{Extended_Pictographic}\u{1F1E6}-\u{1F1FF}\u{20E3}\u{FE00}-\u{FE0F}\u{200D}]/gu;
-
-// Normalize text for TTS: some characters derail Orpheus (like the colon it reads
-// as a speaker tag) or get voiced literally by any TTS model. Em/en dashes and the
-// single-char ellipsis are the main offenders (an em dash breaks the voice), and
-// markdown/markup symbols get read out ("asterisk asterisk"). All of these are just
-// dropped (replaced with a space, not a comma, so no phantom pauses are inserted);
-// smart quotes are normalized. Speech ONLY -- the on-screen chat text keeps everything.
-function stripForSpeech(text: string): string {
-  return text
-    .replace(SPEECH_STRIP_RE, "")
-    .replace(/\s*[—–―‒−]\s*/g, " ") // — – ― ‒ −  -> drop
-    .replace(/\s*…\s*/g, " ") //                           …  -> drop
-    .replace(/\.{2,}/g, " ") //                                 ... -> drop
-    .replace(/[‐‑]/g, "-") //                          unicode hyphens -> ASCII
-    .replace(/[*_`~^|#<>\\{}[\]]/g, " ") //                      markdown / markup -> space
-    .replace(/[‘’‚‛]/g, "'") //             smart single quotes
-    .replace(/[“”„‟]/g, '"') //             smart double quotes
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function splitStreaming(text: string): {
+export function splitStreaming(text: string): {
   complete: string[];
   partial: string;
 } {
@@ -127,18 +100,12 @@ function streamPlaybackSupported(): boolean {
 // keeps the scheduler ~this many seconds ahead of generation, so a late chunk
 // (GPU jitter) doesn't starve playback into a gap/click. Costs ~this much extra
 // first-audio latency, still far below waiting for the whole clip.
-const STREAM_PREROLL_S = 0.35;
-
-// Sample rate assumed when /audio/speech/stream does not advertise one. The route
-// sends X-Sample-Rate and that is what is used; this is only the floor for a proxy
-// that strips the header.
-const STREAM_FALLBACK_SAMPLE_RATE = 24000;
-
-// One frame of silent 8 kHz mono PCM WAV. Short enough to be inaudible and to
-// finish inside the gesture, real enough that play() resolves instead of
-// rejecting -- which is the whole point of priming (see primeAudio).
-const SILENT_WAV_DATA_URI =
-  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=";
+// 0.35 was tuned on a box where the voice slot had the GPU to itself. Voice mode
+// now shares it with the chat model and the STT sidecar, and that contention shows
+// up as generation jitter rather than a slower average, so the old cushion drains
+// mid-sentence and playback skips. Buying ~0.65s of first-audio latency here is
+// worth it: a late first word is far less noticeable than a stuttering one.
+const STREAM_PREROLL_S = 1.0;
 
 export function useTtsPlayer(
   audioType: string | null | undefined,
@@ -163,11 +130,11 @@ export function useTtsPlayer(
   const [isPlaying, setIsPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const objectUrlRef = useRef<string | null>(null);
-  // Bumped on every stop()/new speak()/unmount so an in-flight /api/inference/audio/speech
+  // Bumped on every stop()/new speak()/unmount so an in-flight /api/audio/speech
   // response (or a queued sentence) can detect it was superseded and skip late
   // playback + state updates.
   const requestIdRef = useRef(0);
-  // Aborts in-flight /api/inference/audio/speech synth fetches on stop()/barge-in, so the
+  // Aborts in-flight /api/audio/speech synth fetches on stop()/barge-in, so the
   // backend voice slot stops grinding through stale sentences and is free to
   // synthesize the new turn immediately (llama-server cancels a slot when its
   // request connection closes).
@@ -181,7 +148,16 @@ export function useTtsPlayer(
   // stop() can immediately unwind a sentence that's mid-stream.
   const streamSourcesRef = useRef<Set<AudioBufferSourceNode>>(new Set());
   const streamLevelRafRef = useRef(0);
-  const streamResolveRef = useRef<(() => void) | null>(null);
+  // One unwind callback per sentence currently streaming. A set rather than a
+  // single slot because the lookahead keeps more than one in flight at a time.
+  const streamUnwindRef = useRef<Set<() => void>>(new Set());
+  // Absolute AudioContext time where the next PCM buffer should start. Shared
+  // across sentences so they chain onto ONE continuous timeline: the jitter
+  // buffer is paid once at the start of a reply, not again at every boundary.
+  const streamPlayHeadRef = useRef(0);
+  // Shared analyser for the orb level -- per-sentence ones would fight over
+  // voiceOutputLevel as soon as two sentences overlap.
+  const streamAnalyserRef = useRef<AnalyserNode | null>(null);
   const onPlaybackEndRef = useRef(onPlaybackEnd);
   onPlaybackEndRef.current = onPlaybackEnd;
 
@@ -199,7 +175,7 @@ export function useTtsPlayer(
   } | null>(null);
 
   const isTtsModel = TTS_AUDIO_TYPES.has(audioType ?? "") || voiceSlotLoaded;
-  // Stream PCM straight from /api/inference/audio/speech/stream (SNAC/Orpheus voice slot) and
+  // Stream PCM straight from /api/audio/speech/stream (SNAC/Orpheus voice slot) and
   // play it as it arrives, so first audio lands ~1s in instead of after the whole
   // clip. Only for the loaded voice slot (the streaming endpoint is SNAC-only); if
   // the stream 400s (non-SNAC), playSentenceStream falls back to the blocking blob.
@@ -214,16 +190,7 @@ export function useTtsPlayer(
     if (!audioRef.current) {
       audioRef.current = new Audio();
     }
-    // play() on a sourceless element rejects immediately, so the old call primed
-    // nothing and the catch hid it: the first real clip, arriving later from an
-    // async fetch, was then refused by autoplay policy and treated as finished --
-    // silent TTS. Give it something to actually play inside the gesture. The same
-    // element is reused by playBlob, so this unlocks the path that matters.
-    if (!audioRef.current.src) audioRef.current.src = SILENT_WAV_DATA_URI;
-    audioRef.current
-      .play()
-      .then(() => audioRef.current?.pause())
-      .catch(() => {});
+    audioRef.current.play().then(() => audioRef.current?.pause()).catch(() => {});
     void getPlayCtx()?.resume().catch(() => {});
   }, []);
 
@@ -271,9 +238,10 @@ export function useTtsPlayer(
     if (streamLevelRafRef.current) cancelAnimationFrame(streamLevelRafRef.current);
     streamLevelRafRef.current = 0;
     voiceOutputLevel.current = 0;
-    const resolve = streamResolveRef.current;
-    streamResolveRef.current = null;
-    resolve?.();
+    streamPlayHeadRef.current = 0;
+    const unwinds = [...streamUnwindRef.current];
+    streamUnwindRef.current.clear();
+    for (const unwind of unwinds) unwind();
   }, []);
 
   const stop = useCallback(() => {
@@ -356,13 +324,22 @@ export function useTtsPlayer(
     });
   }, []);
 
-  // Stream ONE sentence from /api/inference/audio/speech/stream and play its 24 kHz int16 PCM
-  // as it arrives (Web Audio, buffer sources scheduled back-to-back), so audio
-  // starts on the first chunk (~1s) instead of after the whole clip. Resolves true
-  // once playback finished or was cut; resolves FALSE without playing if the stream
-  // isn't usable (non-SNAC voice / error) so the caller can fall back to the blob.
+  // Stream ONE sentence from /api/audio/speech/stream as 24 kHz int16 PCM, played
+  // through Web Audio as it arrives.
+  //
+  // The fetch starts immediately, but nothing is scheduled until `gate` resolves
+  // (the previous sentence finished scheduling), so the voice slot can be
+  // generating sentence N+1 while N is still playing and the audio still comes out
+  // in order. That overlap is the whole point: synthesize strictly one at a time
+  // and every sentence boundary costs a full time-to-first-audio plus another
+  // STREAM_PREROLL_S of jitter buffer, which is audible as a break.
+  //
+  // Resolves true once this sentence is fully SCHEDULED -- not when it finishes
+  // playing; the shared playhead is what keeps the order. Resolves false without
+  // scheduling anything if the stream isn't usable (non-SNAC voice / error), so the
+  // caller can fall back to the blocking blob.
   const playSentenceStream = useCallback(
-    (sentence: string, reqId: number): Promise<boolean> => {
+    (sentence: string, reqId: number, gate: Promise<unknown>): Promise<boolean> => {
       return new Promise<boolean>((resolve) => {
         if (requestIdRef.current !== reqId) {
           resolve(true);
@@ -376,9 +353,13 @@ export function useTtsPlayer(
         void ctx.resume().catch(() => {});
         const voice = useChatRuntimeStore.getState().selectedVoiceName || "tara";
 
-        const analyser = ctx.createAnalyser();
-        analyser.fftSize = 256;
-        analyser.connect(ctx.destination);
+        if (!streamAnalyserRef.current) {
+          const node = ctx.createAnalyser();
+          node.fftSize = 256;
+          node.connect(ctx.destination);
+          streamAnalyserRef.current = node;
+        }
+        const analyser = streamAnalyserRef.current;
         const levelBuf = new Float32Array(analyser.fftSize);
         const runLevel = () => {
           analyser.getFloatTimeDomainData(levelBuf);
@@ -388,33 +369,23 @@ export function useTtsPlayer(
           streamLevelRafRef.current = requestAnimationFrame(runLevel);
         };
 
-        let playHead = 0;
-        let started = false;
-        let streamEnded = false;
-        let pending = 0;
         let settled = false;
+        let scheduledAny = false;
         let leftover: Uint8Array | null = null;
-        let sampleRate = STREAM_FALLBACK_SAMPLE_RATE;
+        // Before the gate opens, chunks pile up here instead of being scheduled --
+        // this sentence is generating ahead of its turn.
+        let open = false;
+        const queued: Uint8Array[] = [];
 
         const finish = (played: boolean) => {
           if (settled) return;
           settled = true;
-          streamResolveRef.current = null;
-          try {
-            analyser.disconnect();
-          } catch {
-            /* already gone */
-          }
-          if (streamLevelRafRef.current && streamSourcesRef.current.size === 0) {
-            cancelAnimationFrame(streamLevelRafRef.current);
-            streamLevelRafRef.current = 0;
-            voiceOutputLevel.current = 0;
-          }
-          if (requestIdRef.current === reqId) setIsPlaying(false);
+          streamUnwindRef.current.delete(unwind);
           resolve(played);
         };
-        // stop()/barge-in calls this (via stopStream) to unwind immediately.
-        streamResolveRef.current = () => finish(true);
+        // stop()/barge-in runs this (via stopStream) to unwind immediately.
+        const unwind = () => finish(true);
+        streamUnwindRef.current.add(unwind);
 
         const schedule = (bytes: Uint8Array) => {
           let data = bytes;
@@ -435,52 +406,79 @@ export function useTtsPlayer(
           const view = new DataView(data.buffer, data.byteOffset, usable);
           const f32 = new Float32Array(nSamples);
           for (let i = 0; i < nSamples; i++) f32[i] = view.getInt16(i * 2, true) / 32768;
-          const audioBuf = ctx.createBuffer(1, nSamples, sampleRate);
+          const audioBuf = ctx.createBuffer(1, nSamples, 24000);
           audioBuf.copyToChannel(f32, 0);
           const src = ctx.createBufferSource();
           src.buffer = audioBuf;
           src.connect(analyser);
-          // First buffer starts a jitter-buffer ahead (STREAM_PREROLL_S) so the
-          // scheduler stays ahead of the ~real-time generation; the rest chain
-          // gaplessly off the running playhead. The max() guard means a chunk that
-          // arrived late still schedules just ahead of now instead of in the past.
-          const startAt = !started
-            ? ctx.currentTime + STREAM_PREROLL_S
-            : Math.max(ctx.currentTime + 0.005, playHead);
+          // Chain off the SHARED playhead, so sentence N+1 lands flush against the
+          // tail of N. When the playhead is in the past -- the start of a reply, or
+          // after generation underran -- buy the jitter buffer back instead.
+          const head = streamPlayHeadRef.current;
+          const startAt =
+            head > ctx.currentTime
+              ? head
+              : ctx.currentTime + (scheduledAny ? 0.005 : STREAM_PREROLL_S);
           src.start(startAt);
-          playHead = startAt + audioBuf.duration;
+          streamPlayHeadRef.current = startAt + audioBuf.duration;
+          scheduledAny = true;
+          const wasIdle = streamSourcesRef.current.size === 0;
           streamSourcesRef.current.add(src);
-          pending++;
-          if (!started) {
-            started = true;
-            if (requestIdRef.current === reqId) setIsPlaying(true);
-            if (!streamLevelRafRef.current)
-              streamLevelRafRef.current = requestAnimationFrame(runLevel);
-          }
+          if (wasIdle && requestIdRef.current === reqId) setIsPlaying(true);
+          if (!streamLevelRafRef.current)
+            streamLevelRafRef.current = requestAnimationFrame(runLevel);
           src.onended = () => {
             streamSourcesRef.current.delete(src);
-            pending--;
-            if (streamEnded && pending <= 0) finish(true);
+            // The timeline is only actually idle when no sentence has anything
+            // left scheduled -- not merely when this one runs out.
+            if (streamSourcesRef.current.size === 0) {
+              if (streamLevelRafRef.current) {
+                cancelAnimationFrame(streamLevelRafRef.current);
+                streamLevelRafRef.current = 0;
+              }
+              voiceOutputLevel.current = 0;
+              if (requestIdRef.current === reqId) setIsPlaying(false);
+            }
           };
         };
 
+        const openGate = () => {
+          if (open || settled) return;
+          if (requestIdRef.current !== reqId) return;
+          open = true;
+          for (const chunk of queued) schedule(chunk);
+          queued.length = 0;
+        };
+        void gate.then(openGate, openGate);
+
         void (async () => {
+          let resp: Response;
           try {
-            const resp = await authFetch("/api/inference/audio/speech/stream", {
+            resp = await authFetch("/api/inference/audio/speech/stream", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ input: sentence, voice }),
               signal: synthAbortRef.current?.signal,
             });
-            if (!resp.ok || !resp.body) {
-              finish(false); // let the caller fall back to the blocking blob path
-              return;
-            }
-            // Read the rate the route actually decoded at rather than assuming the
-            // codec's. Every chunk of this response is decoded at one rate, and the
-            // first schedule() call happens below, so setting it here is in time.
-            const advertised = Number(resp.headers.get("X-Sample-Rate"));
-            if (Number.isFinite(advertised) && advertised > 0) sampleRate = advertised;
+          } catch {
+            // Aborted (stop / barge-in) or a network error. Still wait our turn
+            // before resolving, for the same reason as the 400 below.
+            await gate.catch(() => {});
+            finish(scheduledAny);
+            return;
+          }
+          if (!resp.ok || !resp.body) {
+            // Wait our turn even though we have nothing to schedule. The caller
+            // answers a false here by synthesizing and playing a blob on the
+            // shared <audio> element, and a 400 comes back almost instantly -- so
+            // resolving early would let every sentence in the window start its
+            // fallback at once and stamp over each other's playback. This is the
+            // path a Q2 Orpheus quant takes for EVERY sentence.
+            await gate.catch(() => {});
+            finish(false);
+            return;
+          }
+          try {
             const reader = resp.body.getReader();
             for (;;) {
               const { done: rdone, value } = await reader.read();
@@ -493,28 +491,42 @@ export function useTtsPlayer(
                 }
                 break;
               }
-              if (value && value.length) schedule(value);
+              if (!value || !value.length) continue;
+              if (open) schedule(value);
+              else queued.push(value);
             }
           } catch {
-            // aborted (stop / barge-in) or a network error
-          } finally {
-            streamEnded = true;
-            // Nothing scheduled means nothing was spoken: the request failed at the
-            // network layer, or a 200 closed before its first PCM chunk. Report that
-            // as unplayed so the caller falls back to the blob path (and, failing
-            // that, the browser voice) instead of advancing the loop in silence. A
-            // superseded request (stop / barge-in) still reads as played: the caller
-            // drops it on the request-id check either way, and a reply the user just
-            // cut off must not trigger a fallback.
-            if (pending <= 0) finish(started || requestIdRef.current !== reqId);
+            // aborted (stop / barge-in) or a network error mid-stream
           }
+          // Generation finished ahead of our turn: wait for it, flush, and only
+          // then resolve -- the next sentence gates on this, so it starts
+          // scheduling the moment we are done.
+          await gate.catch(() => {});
+          openGate();
+          finish(true);
         })();
       });
     },
     [],
   );
 
-  // POST one sentence to /api/inference/audio/speech and return the audio blob. If the
+  // Wait for the scheduled PCM timeline to actually run out. The sentence
+  // promises resolve once everything is SCHEDULED, so the end of a reply is a
+  // second or more ahead of them; without this the loop would re-arm the mic over
+  // the tail of its own last sentence.
+  const drainStream = useCallback(async (reqId: number): Promise<void> => {
+    const ctx = getPlayCtx();
+    for (;;) {
+      if (requestIdRef.current !== reqId) return;
+      if (streamSourcesRef.current.size === 0) return;
+      // Bound the wait by the timeline itself: a suspended context or a source
+      // that never fires onended must not strand the loop with the mic shut.
+      if (ctx && ctx.currentTime > streamPlayHeadRef.current + 0.5) return;
+      await new Promise<void>((r) => setTimeout(r, 50));
+    }
+  }, []);
+
+  // POST one sentence to /api/audio/speech and return the audio blob. If the
   // backend voice slot is gone (400 -- unloaded by a ChatPage remount, an auth
   // bounce, or a studio relaunch), reload it once via the store hook and retry,
   // so TTS heals itself instead of silently 400ing for the rest of the session.
@@ -547,76 +559,11 @@ export function useTtsPlayer(
     [],
   );
 
-  // Speak with the browser's own voice. Reached either because no backend TTS is
-  // available, or because backend synthesis produced nothing for this reply --
-  // in that second case it is the difference between a spoken answer and silence.
-  const speakWithBrowser = useCallback(
-    (sentences: string[], reqId: number) => {
-      if (typeof window === "undefined" || !("speechSynthesis" in window)) {
-        onPlaybackEndRef.current?.();
-        return;
-      }
-      // Queue one utterance per sentence: gives the same chunked cadence and
-      // sidesteps Chrome's long-utterance cutoff bug. Completion fires on the
-      // last sentence; any error ends the loop.
-      setIsSpeaking(true);
-      let remaining = sentences.length;
-      const finish = () => {
-        // Tied to this speak() call, not merely to "some utterance is recorded".
-        // A cancelled utterance still fires onend/onerror, and after a quick
-        // stop-then-restart that stale event arrives with the NEW utterance
-        // recorded -- clearing its state and resuming the voice loop while the
-        // new speech was still queued.
-        if (requestIdRef.current !== reqId) return;
-        if (utteranceRef.current === null) return;
-        utteranceRef.current = null;
-        setIsSpeaking(false);
-        setIsPlaying(false);
-        onPlaybackEndRef.current?.();
-      };
-      const utterances = sentences.map((sentence) => {
-        const utterance = new SpeechSynthesisUtterance(sentence);
-        utterance.onstart = () => setIsPlaying(true);
-        // Both handlers can fire for a cancelled utterance long after stop():
-        // speechSynthesis.cancel() reports the old utterance's end/error
-        // asynchronously, by which time the replacement reply may already be
-        // queued. Only the current request may touch playback state or the global
-        // queue, or that stale event kills the new reply too; finish() re-checks
-        // the same id for the same reason.
-        utterance.onend = () => {
-          if (requestIdRef.current !== reqId) return;
-          setIsPlaying(false);
-          remaining -= 1;
-          if (remaining <= 0) finish();
-        };
-        utterance.onerror = () => {
-          if (requestIdRef.current !== reqId) return;
-          window.speechSynthesis.cancel();
-          finish();
-        };
-        return utterance;
-      });
-      // Sentinel so stop()/stopSynth() knows synth playback is active.
-      utteranceRef.current = utterances[utterances.length - 1] ?? null;
-      for (const utterance of utterances) window.speechSynthesis.speak(utterance);
-    },
-    // Empty on purpose: everything closed over is a ref or a setState, all stable
-    // for the life of the hook. A dependency here would give speak() a new identity
-    // every render and restart the loop's effects mid-conversation.
-    [],
-  );
-
   const speak = useCallback(
     async (text: string) => {
       stop();
       text = stripForSpeech(text);
-      if (!text) {
-        // Emoji-only or pure markup: nothing to say, but the turn still has to end
-        // like any other, or the loop never resumes listening (beginStream has
-        // already stopped dictation by the time endStream reaches here).
-        onPlaybackEndRef.current?.();
-        return;
-      }
+      if (!text) return;
       // stop() above bumped the counter; this is now our request's id.
       const reqId = requestIdRef.current;
       const sentences = splitIntoSentences(text);
@@ -627,29 +574,40 @@ export function useTtsPlayer(
 
       if (isTtsModel) {
         setIsSpeaking(true);
-        // Whether the backend produced any audio at all for this reply.
-        let playedAnything = false;
 
         if (streamMode) {
           // Stream each sentence's PCM and play it as it generates (first audio in
-          // ~1s). Sequential per sentence: the single voice slot generates one at a
-          // time, so there's nothing to pre-synthesize ahead.
+          // ~1s). Up to voiceParallelN generate at once, gated so they still
+          // schedule in order -- the next sentence is already buffered when the
+          // current one runs out, so the boundary has no synth gap in it.
+          const N = Math.min(
+            sentences.length,
+            Math.max(1, useChatRuntimeStore.getState().voiceParallelN),
+          );
+          let gate: Promise<unknown> = Promise.resolve();
+          const inflight: Array<Promise<void>> = [];
           for (let i = 0; i < sentences.length; i++) {
             if (requestIdRef.current !== reqId) return;
-            const played = await playSentenceStream(sentences[i], reqId);
-            if (requestIdRef.current !== reqId) return;
-            if (played) {
-              playedAnything = true;
-            } else {
-              // Stream not usable (non-SNAC voice) -> blocking blob fallback.
-              const blob = await requestSpeechBlob(sentences[i]);
-              if (requestIdRef.current !== reqId) return;
-              if (blob) {
-                playedAnything = true;
-                await playBlob(blob, reqId);
-              }
+            const sentence = sentences[i] ?? "";
+            const job = playSentenceStream(sentence, reqId, gate).then(
+              async (played) => {
+                if (played || requestIdRef.current !== reqId) return;
+                // Stream not usable (non-SNAC voice) -> blocking blob fallback.
+                const blob = await requestSpeechBlob(sentence);
+                if (requestIdRef.current !== reqId) return;
+                if (blob) await playBlob(blob, reqId);
+              },
+            );
+            gate = job;
+            inflight.push(job);
+            while (inflight.length >= N) {
+              const head = inflight.shift();
+              if (head) await head;
             }
           }
+          for (const job of inflight) await job;
+          if (requestIdRef.current !== reqId) return;
+          await drainStream(reqId);
         } else {
           const synth = (sentence: string): Promise<Blob | null> =>
             requestSpeechBlob(sentence);
@@ -678,34 +636,62 @@ export function useTtsPlayer(
             // Refill the window so N stay in flight ahead of playback.
             launchUpTo(i + 1 + N);
             if (!blob) continue;  // skip a sentence that failed to synthesize
-            playedAnything = true;
             await playBlob(blob, reqId);
           }
         }
 
         if (requestIdRef.current !== reqId) return;
-        if (!playedAnything) {
-          // Every sentence failed to synthesize. That is what a codec the speech
-          // route cannot serve looks like from here -- a GGUF CSM model reports
-          // audio_type "csm" but the llama.cpp decoder only does snac, bicodec and
-          // dac -- and it also covers a slot that went away mid-reply. Either way
-          // the reply must still be spoken, so fall through to browser speech
-          // rather than ending in silence.
-          speakWithBrowser(sentences, reqId);
-          return;
-        }
         setIsSpeaking(false);
         onPlaybackEndRef.current?.();
       } else {
-        speakWithBrowser(sentences, reqId);
+        if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+          onPlaybackEndRef.current?.();
+          return;
+        }
+        // Queue one utterance per sentence: gives the same chunked cadence and
+        // sidesteps Chrome's long-utterance cutoff bug. Completion fires on the
+        // last sentence; any error ends the loop.
+        setIsSpeaking(true);
+        let remaining = sentences.length;
+        const finish = () => {
+          if (utteranceRef.current === null) return;
+          utteranceRef.current = null;
+          setIsSpeaking(false);
+          setIsPlaying(false);
+          onPlaybackEndRef.current?.();
+        };
+        const utterances = sentences.map((sentence) => {
+          const utterance = new SpeechSynthesisUtterance(sentence);
+          utterance.onstart = () => setIsPlaying(true);
+          utterance.onend = () => {
+            setIsPlaying(false);
+            remaining -= 1;
+            if (remaining <= 0) finish();
+          };
+          utterance.onerror = () => {
+            window.speechSynthesis.cancel();
+            finish();
+          };
+          return utterance;
+        });
+        // Sentinel so stop()/stopSynth() knows synth playback is active.
+        utteranceRef.current = utterances[utterances.length - 1] ?? null;
+        for (const utterance of utterances) window.speechSynthesis.speak(utterance);
       }
     },
-    [isTtsModel, streamMode, stop, playBlob, playSentenceStream, requestSpeechBlob, speakWithBrowser],
+    [
+      isTtsModel,
+      streamMode,
+      stop,
+      playBlob,
+      playSentenceStream,
+      requestSpeechBlob,
+      drainStream,
+    ],
   );
 
-
   // ── Streaming TTS ───────────────────────────────────────────────
-  // POST one sentence to /api/inference/audio/speech; null on failure.
+  // POST one sentence to /api/audio/speech; null on failure.
   const synthOne = useCallback(
     (sentence: string): Promise<Blob | null> => {
       // Strip emoji here -- the single synth chokepoint for streaming, hit by both
@@ -756,9 +742,15 @@ export function useTtsPlayer(
     };
     if (!isTtsModel) return;
     setIsSpeaking(true);
-    // Whether the backend produced any audio at all across the whole reply.
-    let playedAnything = false;
     void (async () => {
+      // Stream mode keeps up to voiceParallelN sentences generating at once. They
+      // are chained on `gate` so they schedule in order however they finish, and
+      // `inflight` bounds how far ahead the voice slot may run -- too far and a
+      // barge-in throws away more audio than it saves.
+      let gate: Promise<unknown> = Promise.resolve();
+      const inflight: Array<Promise<void>> = [];
+      const parallelN = () =>
+        Math.max(1, useChatRuntimeStore.getState().voiceParallelN);
       while (true) {
         if (requestIdRef.current !== reqId) return;
         const st = streamRef.current;
@@ -770,17 +762,20 @@ export function useTtsPlayer(
             const sentence = stripForSpeech(st.sentences[st.playIndex] ?? "");
             st.playIndex++;
             if (sentence) {
-              const played = await playSentenceStream(sentence, reqId);
-              if (requestIdRef.current !== reqId) return;
-              if (played) {
-                playedAnything = true;
-              } else {
-                const blob = await synthOne(sentence);
-                if (requestIdRef.current !== reqId) return;
-                if (blob) {
-                  playedAnything = true;
-                  await playBlob(blob, reqId);
-                }
+              const job = playSentenceStream(sentence, reqId, gate).then(
+                async (played) => {
+                  if (played || requestIdRef.current !== reqId) return;
+                  const blob = await synthOne(sentence);
+                  if (requestIdRef.current !== reqId) return;
+                  if (blob) await playBlob(blob, reqId);
+                },
+              );
+              gate = job;
+              inflight.push(job);
+              const limit = parallelN();
+              while (inflight.length >= limit) {
+                const head = inflight.shift();
+                if (head) await head;
               }
             }
           } else {
@@ -789,10 +784,7 @@ export function useTtsPlayer(
             if (requestIdRef.current !== reqId) return;
             st.playIndex++;
             pumpSynth(); // playback advanced -> refill the lookahead window
-            if (blob) {
-              playedAnything = true;
-              await playBlob(blob, reqId);
-            }
+            if (blob) await playBlob(blob, reqId);
           }
         } else if (st.final) {
           break;
@@ -800,20 +792,13 @@ export function useTtsPlayer(
           await new Promise<void>((r) => setTimeout(r, 40));
         }
       }
+      for (const job of inflight) await job;
       if (requestIdRef.current !== reqId) return;
-      const spoken = streamRef.current?.sentences ?? [];
-      streamRef.current = null;
-      if (!playedAnything && spoken.length > 0) {
-        // The backend produced nothing for the entire reply. That is what a codec
-        // the speech route cannot serve looks like from here -- a GGUF CSM model
-        // reports audio_type "csm", but the llama.cpp decoder only does snac,
-        // bicodec and dac -- and it also covers a voice slot that went away
-        // mid-reply. In voice mode silence is indistinguishable from a hung loop,
-        // so say it with the browser voice rather than say nothing.
-        speakWithBrowser(spoken, reqId);
-        return;
-      }
+      // Everything is scheduled, but the tail is still seconds from playing out.
+      if (streamMode) await drainStream(reqId);
+      if (requestIdRef.current !== reqId) return;
       setIsSpeaking(false);
+      streamRef.current = null;
       onPlaybackEndRef.current?.();
     })();
   }, [
@@ -824,7 +809,7 @@ export function useTtsPlayer(
     pumpSynth,
     playSentenceStream,
     synthOne,
-    speakWithBrowser,
+    drainStream,
   ]);
 
   // Feed the growing assistant text; records newly-complete sentences and lets the

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -156,6 +156,10 @@ export const CHAT_PERMISSION_MODE_KEY = "unsloth_chat_permission_mode";
 export type PermissionMode = "ask" | "auto" | "off" | "full";
 export const CHAT_WEB_FETCH_TOOLS_ENABLED_KEY =
   "unsloth_chat_web_fetch_tools_enabled";
+const CHAT_VOICE_MODEL_ID_KEY = "unsloth_chat_voice_model_id";
+const CHAT_VOICE_PARALLEL_KEY = "unsloth_chat_voice_parallel";
+const CHAT_VOICE_VARIANT_KEY = "unsloth_chat_voice_variant";
+const CHAT_VOICE_NAME_KEY = "unsloth_chat_voice_name";
 export const CHAT_RAG_SOURCE_KEY = "unsloth_chat_rag_source";
 export const CHAT_RAG_MODE_KEY = "unsloth_chat_rag_mode";
 export const CHAT_RAG_TOP_K_KEY = "unsloth_chat_rag_top_k";
@@ -2878,11 +2882,89 @@ type ChatRuntimeStore = {
   // prunes file leases after a TTL, so a reload checks this to prompt
   // re-selection instead of reusing a dead token.
   activeNativePathExpiresAtMs: number | null;
+  /**
+   * Voice conversation mode state (set by the composer voice control).
+   * - "off"         — inactive
+   * - "configuring" — armed, voice picker visible, loop NOT started
+   * - "active"      — loop running (mic auto-start enabled)
+   * Not persisted — resets to "off" on page load.
+   */
+  voiceMode: "off" | "configuring" | "active";
+  /** The LoRA/GGUF model ID chosen for the voice slot. Persisted. */
+  selectedVoiceModelId: string | null;
+  /** Named speaker for Orpheus (snac) TTS -- tara/leo/jess/etc. Orpheus randomizes
+   *  the voice unless a speaker is pinned, so this is sent with every synth call.
+   *  Persisted so the choice sticks across reloads. */
+  selectedVoiceName: string;
+  /** llama-server --parallel slots for a GGUF voice slot: how many sentence
+   *  chunks synthesize concurrently. 1-4. Persisted. */
+  voiceParallelN: number;
+  /** GGUF quant variant for the selected GGUF voice (null = repo default).
+   *  Applied on next voice-slot load. Persisted. */
+  selectedVoiceVariant: string | null;
+  /** True while the voice slot (TTS) is loading, so the orb can show a loading
+   *  state instead of appearing ready to listen. Not persisted. */
+  voiceSlotLoading: boolean;
+  /** True only when the backend voice slot is actually loaded with the selected
+   *  voice (synced from /voice/status), so the top-bar speak icon goes green.
+   *  Distinct from a mere selection, which persists but doesn't load the slot.
+   *  Not persisted. */
+  voiceSlotLoaded: boolean;
+  /** True while a batch STT engine is turning an utterance into text, so the orb
+   *  shows a processing state instead of appearing idle. The streaming engine the
+   *  loop runs on today never sets it; it is the hook a batch engine needs. Not
+   *  persisted. */
+  voiceTranscribing: boolean;
+  /** True while the mic is actively hearing your voice (VAD above the floor), so
+   *  the orb shows a distinct "hearing you" colour -- immediate feedback that your
+   *  speech is being captured. Not persisted. */
+  voiceHearing: boolean;
+  /** Derived orb state written by the voice control; consumed by VoiceOrb. */
+  voiceOrbState:
+    | "listening"
+    | "transcribing"
+    | "generating"
+    | "synthesizing"
+    | "speaking"
+    | "hearing"
+    | "loading"
+    | null;
+  /** When voice mode is active, whether the full-screen orb is minimized so the
+   *  chat is visible while speech-to-speech keeps running. Not persisted. */
+  voiceOrbCollapsed: boolean;
+  /** Reloads the backend voice slot if a voice is selected but the slot is
+   *  unloaded (after a remount, auth bounce, or backend relaunch). Set by
+   *  ChatPage; called by the TTS player to self-heal a 400 (slot gone). Resolves
+   *  true once a matching slot is loaded. Null until ChatPage mounts. Not
+   *  persisted. */
+  ensureVoiceSlotLoaded: (() => Promise<boolean>) | null;
+  setEnsureVoiceSlotLoaded: (fn: (() => Promise<boolean>) | null) => void;
   hydratePersistedSettings: () => Promise<void>;
   beginModelLoading: () => ModelLifecycleLease | null;
   endModelLoading: (lease: ModelLifecycleLease) => void;
   setLoadingModelPick: (pick: LoadingModelPick | null) => void;
   clearLoadingModelPick: (expected: LoadingModelPick) => void;
+  setVoiceMode: (mode: "off" | "configuring" | "active") => void;
+  setSelectedVoiceModelId: (id: string | null) => void;
+  setSelectedVoiceName: (name: string) => void;
+  setVoiceParallelN: (n: number) => void;
+  setSelectedVoiceVariant: (variant: string | null) => void;
+  setVoiceSlotLoading: (loading: boolean) => void;
+  setVoiceSlotLoaded: (loaded: boolean) => void;
+  setVoiceTranscribing: (transcribing: boolean) => void;
+  setVoiceHearing: (hearing: boolean) => void;
+  setVoiceOrbState: (
+    state:
+      | "listening"
+      | "transcribing"
+      | "generating"
+      | "synthesizing"
+      | "speaking"
+      | "hearing"
+      | "loading"
+      | null,
+  ) => void;
+  setVoiceOrbCollapsed: (collapsed: boolean) => void;
   setModelRequiresTrustRemoteCode: (required: boolean) => void;
   setParams: (
     params: InferenceParams,
@@ -4566,6 +4648,18 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   activeLoadId: null,
   activeNativePathToken: null,
   activeNativePathExpiresAtMs: null,
+  voiceMode: "off" as const,
+  selectedVoiceModelId: loadString(CHAT_VOICE_MODEL_ID_KEY, "") || null,
+  selectedVoiceName: loadString(CHAT_VOICE_NAME_KEY, "tara") || "tara",
+  voiceParallelN: Math.min(4, Math.max(1, Number(loadString(CHAT_VOICE_PARALLEL_KEY, "1")) || 1)),
+  selectedVoiceVariant: loadString(CHAT_VOICE_VARIANT_KEY, "") || null,
+  voiceSlotLoading: false,
+  voiceSlotLoaded: false,
+  voiceTranscribing: false,
+  voiceHearing: false,
+  voiceOrbState: null,
+  voiceOrbCollapsed: false,
+  ensureVoiceSlotLoaded: null,
   hydratePersistedSettings: async () => {
     if (get().settingsHydrated) {
       return;
@@ -4786,6 +4880,42 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       }
       return { loadingModelPick: null };
     }),
+  setVoiceMode: (voiceMode) =>
+    // Leaving voice mode always resets the minimized/collapsed orb view so the
+    // next session starts expanded, and clears any lingering "hearing" state.
+    set(
+      voiceMode === "off"
+        ? { voiceMode, voiceOrbCollapsed: false, voiceHearing: false }
+        : { voiceMode },
+    ),
+  setVoiceHearing: (voiceHearing) => set({ voiceHearing }),
+  setVoiceOrbState: (voiceOrbState) => set({ voiceOrbState }),
+  setVoiceOrbCollapsed: (voiceOrbCollapsed) => set({ voiceOrbCollapsed }),
+  setEnsureVoiceSlotLoaded: (ensureVoiceSlotLoaded) => set({ ensureVoiceSlotLoaded }),
+  setSelectedVoiceName: (selectedVoiceName) =>
+    set(() => {
+      saveString(CHAT_VOICE_NAME_KEY, selectedVoiceName);
+      return { selectedVoiceName };
+    }),
+  setSelectedVoiceModelId: (selectedVoiceModelId) =>
+    set(() => {
+      saveString(CHAT_VOICE_MODEL_ID_KEY, selectedVoiceModelId ?? "");
+      return { selectedVoiceModelId };
+    }),
+  setVoiceParallelN: (n) =>
+    set(() => {
+      const voiceParallelN = Math.min(4, Math.max(1, Math.round(n) || 1));
+      saveString(CHAT_VOICE_PARALLEL_KEY, String(voiceParallelN));
+      return { voiceParallelN };
+    }),
+  setSelectedVoiceVariant: (selectedVoiceVariant) =>
+    set(() => {
+      saveString(CHAT_VOICE_VARIANT_KEY, selectedVoiceVariant ?? "");
+      return { selectedVoiceVariant };
+    }),
+  setVoiceSlotLoading: (voiceSlotLoading) => set({ voiceSlotLoading }),
+  setVoiceSlotLoaded: (voiceSlotLoaded) => set({ voiceSlotLoaded }),
+  setVoiceTranscribing: (voiceTranscribing) => set({ voiceTranscribing }),
   setModelRequiresTrustRemoteCode: (modelRequiresTrustRemoteCode) =>
     set({ modelRequiresTrustRemoteCode }),
   setParams: (params, options) => {

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -157,6 +157,8 @@ export type PermissionMode = "ask" | "auto" | "off" | "full";
 export const CHAT_WEB_FETCH_TOOLS_ENABLED_KEY =
   "unsloth_chat_web_fetch_tools_enabled";
 const CHAT_VOICE_MODEL_ID_KEY = "unsloth_chat_voice_model_id";
+const CHAT_STT_MODEL_ID_KEY = "unsloth_chat_stt_model_id";
+const CHAT_MIC_DEVICE_ID_KEY = "unsloth_chat_mic_device_id";
 const CHAT_VOICE_PARALLEL_KEY = "unsloth_chat_voice_parallel";
 const CHAT_VOICE_VARIANT_KEY = "unsloth_chat_voice_variant";
 const CHAT_VOICE_NAME_KEY = "unsloth_chat_voice_name";
@@ -2892,6 +2894,13 @@ type ChatRuntimeStore = {
   voiceMode: "off" | "configuring" | "active";
   /** The LoRA/GGUF model ID chosen for the voice slot. Persisted. */
   selectedVoiceModelId: string | null;
+  /** Whisper checkpoint the loop transcribes with (null = backend default).
+   *  Persisted. */
+  selectedSttModelId: string | null;
+  /** Input device the loop captures from (null = browser default). Pinning it
+   *  matters: a default-communications device or a "Stereo Mix" loopback mixes in
+   *  system audio, so the loop hears the model's own voice. Persisted. */
+  selectedMicDeviceId: string | null;
   /** Named speaker for Orpheus (snac) TTS -- tara/leo/jess/etc. Orpheus randomizes
    *  the voice unless a speaker is pinned, so this is sent with every synth call.
    *  Persisted so the choice sticks across reloads. */
@@ -2948,6 +2957,8 @@ type ChatRuntimeStore = {
   setSelectedVoiceModelId: (id: string | null) => void;
   setSelectedVoiceName: (name: string) => void;
   setVoiceParallelN: (n: number) => void;
+  setSelectedSttModelId: (id: string | null) => void;
+  setSelectedMicDeviceId: (id: string | null) => void;
   setSelectedVoiceVariant: (variant: string | null) => void;
   setVoiceSlotLoading: (loading: boolean) => void;
   setVoiceSlotLoaded: (loaded: boolean) => void;
@@ -4650,6 +4661,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   activeNativePathExpiresAtMs: null,
   voiceMode: "off" as const,
   selectedVoiceModelId: loadString(CHAT_VOICE_MODEL_ID_KEY, "") || null,
+  selectedSttModelId: loadString(CHAT_STT_MODEL_ID_KEY, "") || null,
+  selectedMicDeviceId: loadString(CHAT_MIC_DEVICE_ID_KEY, "") || null,
   selectedVoiceName: loadString(CHAT_VOICE_NAME_KEY, "tara") || "tara",
   voiceParallelN: Math.min(4, Math.max(1, Number(loadString(CHAT_VOICE_PARALLEL_KEY, "1")) || 1)),
   selectedVoiceVariant: loadString(CHAT_VOICE_VARIANT_KEY, "") || null,
@@ -4901,6 +4914,16 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     set(() => {
       saveString(CHAT_VOICE_MODEL_ID_KEY, selectedVoiceModelId ?? "");
       return { selectedVoiceModelId };
+    }),
+  setSelectedSttModelId: (selectedSttModelId) =>
+    set(() => {
+      saveString(CHAT_STT_MODEL_ID_KEY, selectedSttModelId ?? "");
+      return { selectedSttModelId };
+    }),
+  setSelectedMicDeviceId: (selectedMicDeviceId) =>
+    set(() => {
+      saveString(CHAT_MIC_DEVICE_ID_KEY, selectedMicDeviceId ?? "");
+      return { selectedMicDeviceId };
     }),
   setVoiceParallelN: (n) =>
     set(() => {

--- a/studio/frontend/src/features/chat/voice/orb-state.ts
+++ b/studio/frontend/src/features/chat/voice/orb-state.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * What the voice orb shows, decided in one place.
+ *
+ * Seven inputs arrive from three different sources -- the loop's own mode, the
+ * chat runtime store, and the TTS player -- and several are true at once for most
+ * of a turn: the model is still writing while the first sentence is already
+ * playing, and the mic is live over the top of both. So the orb needs a stated
+ * priority order rather than whichever effect happened to run last.
+ *
+ * Pure and React-free so the order is unit-testable, which matters here: the loop
+ * itself cannot be exercised without a microphone, a GPU and a browser.
+ */
+
+export type VoiceOrbState =
+  | "listening"
+  | "transcribing"
+  | "generating"
+  | "synthesizing"
+  | "speaking"
+  | "hearing"
+  | "loading";
+
+export type VoiceOrbInputs = {
+  /** The loop's own mode, not the store mirror. */
+  voiceMode: "off" | "configuring" | "active";
+  /** The voice slot or the transcription model is still warming up. */
+  voiceSlotLoading: boolean;
+  /** The microphone is picking up speech right now. */
+  voiceHearing: boolean;
+  /** A clip is audibly playing. */
+  isPlaying: boolean;
+  /** A captured utterance is being turned into text. */
+  voiceTranscribing: boolean;
+  /** The model is generating a reply. */
+  isThreadRunning: boolean;
+  /** A TTS session is open, whether or not a clip is playing this instant. */
+  isSpeaking: boolean;
+};
+
+/**
+ * "hold" means the caller must not change the orb yet: a TTS session is open but
+ * nothing is playing, which is usually just the gap between two already
+ * synthesized sentences swapping the audio element. Switching straight to
+ * "synthesizing" would flicker at every sentence boundary, so the caller holds the
+ * current state and only shows it if the gap persists.
+ */
+export type VoiceOrbDecision =
+  | { kind: "set"; state: VoiceOrbState | null }
+  | { kind: "hold" };
+
+const set = (state: VoiceOrbState | null): VoiceOrbDecision => ({
+  kind: "set",
+  state,
+});
+
+export function deriveOrbState(inputs: VoiceOrbInputs): VoiceOrbDecision {
+  // Voice is not running: the orb has nothing to say.
+  if (inputs.voiceMode !== "active") return set(null);
+  // A model is warming up (~35s on ROCm). Grey-blue rather than the lilac
+  // "generating speech", so it does not read as a ready green, and so loading
+  // does not collide with TTS synthesis on the same colour.
+  if (inputs.voiceSlotLoading) return set("loading");
+  // Above the speaking checks, so talking over the model (a barge-in) reads as
+  // hearing; and above generating, so it shows the instant you start.
+  if (inputs.voiceHearing) return set("hearing");
+  // Playback wins over any background work. The model writing the rest of the
+  // reply and the next sentence synthesizing both run in parallel with playback,
+  // but playback is what the user is actually perceiving.
+  if (inputs.isPlaying) return set("speaking");
+  // Nothing playing yet, so name the real phase rather than a vague "thinking".
+  // Transcribing precedes generation within a turn, so it is checked first.
+  if (inputs.voiceTranscribing) return set("transcribing");
+  if (inputs.isThreadRunning) return set("generating");
+  if (inputs.isSpeaking) return { kind: "hold" };
+  return set("listening");
+}

--- a/studio/frontend/src/features/chat/voice/speech-llm.ts
+++ b/studio/frontend/src/features/chat/voice/speech-llm.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { TTS_AUDIO_TYPES } from "./tts-audio-types.ts";
+
+// A speech-LLM chat model (Orpheus, CSM, Spark...) produces its own voice, so a
+// separate TTS voice slot doesn't apply and must not be auto-loaded. Shared by the
+// render-time greying, the voice-slot ensure-load effect, and the self-heal
+// reloader in chat-page.tsx so they cannot disagree.
+//
+// Name pattern, kept as the FALLBACK only: a checkpoint not yet in the inventory
+// has no record to read, and its id is all there is to go on.
+const SPEECH_LLM_CHECKPOINT_RE =
+  /(?:orpheus|csm|spark|bark|parler|musicgen|text-to-speech|[-_]tts)/i;
+
+/**
+ * Whether the chat checkpoint speaks for itself. The model record's detected
+ * codec (`audioType`) is the authority: a renamed fine-tune whose id carries none
+ * of the keywords still reports "snac" or "csm", and treating it as a text model
+ * would leave a previously picked voice slot loaded and preferred by
+ * /audio/speech over the model's own voice.
+ */
+export function isSpeechLLMCheckpoint(
+  checkpoint: string | null | undefined,
+  audioType?: string | null,
+): boolean {
+  return (
+    TTS_AUDIO_TYPES.has(audioType ?? "") ||
+    SPEECH_LLM_CHECKPOINT_RE.test(checkpoint ?? "")
+  );
+}
+
+/** The store-state form: the active checkpoint plus its inventory record. */
+export function chatModelOwnsItsVoice(s: {
+  params: { checkpoint: string | null | undefined };
+  models: ReadonlyArray<{ id: string; audioType?: string | null }>;
+}): boolean {
+  const checkpoint = s.params.checkpoint;
+  const audioType =
+    s.models.find((m) => m.id === checkpoint)?.audioType ?? null;
+  return isSpeechLLMCheckpoint(checkpoint, audioType);
+}

--- a/studio/frontend/src/features/chat/voice/speech-text.ts
+++ b/studio/frontend/src/features/chat/voice/speech-text.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Turning assistant text into what the codec actually speaks, and into the chunks
+// it speaks one at a time. Dependency-free for the same reason tts-audio-types is:
+// these are the only part of the voice path testable without a mic or a GPU, and
+// the player hook they used to live in drags in React, auth and asset imports.
+
+const SPEECH_STRIP_RE =
+  /[\p{Extended_Pictographic}\u{1F1E6}-\u{1F1FF}\u{20E3}\u{FE00}-\u{FE0F}\u{200D}]/gu;
+
+// Normalize text for TTS: some characters derail Orpheus (like the colon it reads
+// as a speaker tag) or get voiced literally by any TTS model. Em/en dashes and the
+// single-char ellipsis are the main offenders (an em dash breaks the voice), and
+// markdown/markup symbols get read out ("asterisk asterisk"). All of these are just
+// dropped (replaced with a space, not a comma, so no phantom pauses are inserted);
+// smart quotes are normalized. Speech ONLY -- the on-screen chat text keeps everything.
+export function stripForSpeech(text: string): string {
+  return text
+    .replace(SPEECH_STRIP_RE, "")
+    .replace(/[^\S\n]*[—–―‒−][^\S\n]*/g, " ") // — – ― ‒ −  -> drop
+    .replace(/[^\S\n]*…[^\S\n]*/g, " ") //                 …  -> drop
+    .replace(/\.{2,}/g, " ") //                                 ... -> drop
+    .replace(/[‐‑]/g, "-") //                          unicode hyphens -> ASCII
+    .replace(/[*_`~^|#<>\\{}[\]]/g, " ") //                      markdown / markup -> space
+    .replace(/[‘’‚‛]/g, "'") //             smart single quotes
+    .replace(/[“”„‟]/g, '"') //             smart double quotes
+    // Collapse horizontal whitespace only. Newlines are sentence boundaries to
+    // splitIntoSentences, and flattening them here (as this used to) made a
+    // multi-paragraph reply one enormous sentence: the loop then waited on a
+    // single long synth instead of speaking the first line straight away.
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/\n{2,}/g, "\n")
+    .trim();
+}
+
+// Words whose trailing period ends an abbreviation, not a sentence. Splitting
+// there hands the codec a fragment ("Dr.") and starts the next clip mid-thought.
+const SPEECH_ABBREVIATIONS = new Set([
+  "mr", "mrs", "ms", "dr", "prof", "sr", "jr", "st", "mt", "vs", "etc", "eg",
+  "ie", "approx", "dept", "est", "fig", "no", "vol", "inc", "ltd", "co",
+  "jan", "feb", "mar", "apr", "jun", "jul", "aug", "sep", "sept", "oct",
+  "nov", "dec",
+]);
+
+export function splitIntoSentences(text: string): string[] {
+  // Horizontal whitespace only: a newline is a boundary the regex below relies on.
+  const norm = text
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/\n{2,}/g, "\n")
+    .trim();
+  const raw = norm.match(/[^.!?\n]*[.!?]+|\S[^.!?\n]*$|\S[^.!?\n]*(?=\n)/g);
+  if (!raw) return [text];
+  const out: string[] = [];
+  for (const chunk of raw) {
+    const part = chunk.trim();
+    if (!part) continue;
+    const prev = out[out.length - 1];
+    if (prev !== undefined) {
+      // Quotes and brackets only CLOSE when whitespace or the end follows one.
+      // Followed by a letter it opens a quotation, which is a real boundary.
+      const closer = /^["')\]]+(\s|$)/.test(part);
+      const tail = prev.replace(/["')\]]+$/, "");
+      const lastWord = /([A-Za-z]+)\.$/.exec(tail)?.[1];
+      const decimal = /\d\.$/.test(tail) && /^\d/.test(part);
+      const initial = /(^|\s)[A-Za-z]\.$/.test(tail) && /^[A-Za-z]\./.test(part);
+      const abbrev =
+        lastWord !== undefined && SPEECH_ABBREVIATIONS.has(lastWord.toLowerCase());
+      if (decimal || initial || abbrev || closer) {
+        // "3.50" and "D.C." close up; "Dr. Smith" keeps the space it was written with.
+        out[out.length - 1] = prev + (decimal || initial || closer ? "" : " ") + part;
+        continue;
+      }
+    }
+    out.push(part);
+  }
+  return out.filter(Boolean);
+}

--- a/studio/frontend/src/features/chat/voice/tts-audio-types.ts
+++ b/studio/frontend/src/features/chat/voice/tts-audio-types.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The TTS codec vocabulary, kept dependency-free so the pure voice helpers (and
+// their node:test suites) can read it without pulling in the player hook's React
+// and auth imports. use-tts-player re-exports both for its existing importers.
+
+export const TTS_AUDIO_TYPES = new Set(["snac", "csm", "bicodec", "dac"]);
+
+// Codecs the backend voice slot accepts. Mirrors _VOICE_SLOT_AUDIO_TYPES in
+// routes/inference.py: the slot is a second llama-server, and llama.cpp decodes
+// snac, bicodec and dac. `csm` is in TTS_AUDIO_TYPES but not here -- a CSM GGUF
+// loads and then has no decoder, so offering one as a voice is offering a load
+// that always fails.
+export const VOICE_SLOT_AUDIO_TYPES = new Set(["snac", "bicodec", "dac"]);

--- a/studio/frontend/src/features/chat/voice/voice-engine.tsx
+++ b/studio/frontend/src/features/chat/voice/voice-engine.tsx
@@ -18,6 +18,8 @@
 import { resetPromptQueues } from "@/components/assistant-ui/thread";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { ORB_IDLE_GRADIENT, orbConfig } from "@/components/assistant-ui/voice-orb";
+import { subscribeDictationLevel } from "@/features/chat/adapters/dictation-level";
+import { StudioModelDictationAdapter } from "@/features/chat/adapters/studio-model-dictation-adapter";
 import { StudioWebSpeechDictationAdapter } from "@/features/chat/adapters/studio-web-speech-dictation-adapter";
 import {
   TTS_AUDIO_TYPES,
@@ -64,13 +66,33 @@ const VOICE_COALESCE_MS = 650;
 // past this (synthesis genuinely behind playback) shows lilac.
 const SYNTH_GAP_MS = 350;
 
+// --- Batch transcription -------------------------------------------------
+// The local ("model") and custom engines return one transcript when the session
+// ends, so the loop cannot watch it grow the way it does on Web Speech. It takes
+// end-of-utterance itself instead, from the microphone meter both adapters
+// already publish (subscribeDictationLevel).
+//
+// How long the mic must stay quiet, after the user has actually said something,
+// before the turn is finished. Comfortably above the model adapter's own 280ms
+// segment-cut pause so an ordinary mid-sentence breath cuts a segment at most,
+// and below the streaming engine's 1.5s so the batch path does not feel slower
+// than it already is.
+const VOICE_BATCH_SILENCE_MS = 900;
+// Published level (0..1) above which a frame counts as speech. The meter
+// publishes min(1, rms * 3.2) and the model adapter counts a frame as voiced
+// above raw RMS 0.015, so this is the same line, rounded.
+const VOICE_LEVEL_SPEECH = 0.05;
+// Ceiling on the wait for a batch transcript once the mic is closed. A local
+// Whisper on CPU is slow but not unbounded; past this the turn is sent with what
+// arrived (usually nothing, which just re-arms the mic) rather than stranding the
+// orb on "Transcribing" forever.
+const VOICE_TRANSCRIBE_TIMEOUT_MS = 60_000;
+
 /**
- * Whether the plus menu may offer Voice at all. It needs BOTH halves, and the
- * listening half is the narrower one. Speaking: the browser's speechSynthesis, or a
- * loaded TTS codec. Listening: the streaming Web Speech engine specifically,
- * because the loop's turn-taking watches the transcript grow. A batch engine
- * (local or custom transcription) holds its transcript until end-of-utterance, so
- * the orb would sit on "listening" and nothing would ever send.
+ * Whether the plus menu may offer Voice at all. It needs BOTH halves. Speaking:
+ * the browser's speechSynthesis, or a loaded TTS codec. Listening: whichever
+ * engine is configured, provided it can run here -- Web Speech needs
+ * SpeechRecognition, the batch engines need a secure context and MediaRecorder.
  *
  * Gating on TTS alone offered Voice in browsers with speechSynthesis but no
  * SpeechRecognition, where it could be switched on and never produce a word.
@@ -84,8 +106,9 @@ export function useVoiceAvailable(): boolean {
   return (
     ((typeof window !== "undefined" && "speechSynthesis" in window) ||
       TTS_AUDIO_TYPES.has(activeAudioType ?? "")) &&
-    dictationEngine === "browser" &&
-    StudioWebSpeechDictationAdapter.isSupported()
+    (dictationEngine === "browser"
+      ? StudioWebSpeechDictationAdapter.isSupported()
+      : StudioModelDictationAdapter.isSupported())
   );
 }
 
@@ -131,6 +154,11 @@ export const VoiceEngine: FC = () => {
     const m = s.models.find((m) => m.id === s.params.checkpoint);
     return m?.audioType ?? null;
   });
+  // Which listening engine is configured. "browser" streams a transcript that
+  // grows during the utterance; "model" and "custom" return one transcript when
+  // the session ends. Two different turn-taking paths, below.
+  const dictationEngine = useVoiceSettingsStore((s) => s.dictationEngine);
+  const batchDictation = dictationEngine !== "browser";
   // The store field, synced from /voice/status -- not "a voice is selected", which
   // is true from the moment the picker changes and stays true while the slot is
   // still loading. The player keys both isTtsModel and streamMode off this, so the
@@ -218,7 +246,7 @@ export const VoiceEngine: FC = () => {
     return "";
   }, []);
 
-  // Submit a batch-STT (Whisper) transcript. The adapter has already committed
+  // Submit a batch-transcription transcript. The adapter has already committed
   // the final transcript into the composer via its onSpeech(isFinal) callback,
   // so here we just end dictation and send it — the run-lifecycle effect then
   // speaks the reply and re-arms the mic, same as the streaming path. Mirrors
@@ -424,11 +452,10 @@ export const VoiceEngine: FC = () => {
         streamPollRef.current = setInterval(() => {
           feedTextRef.current(latestAssistantText());
         }, 150);
-        // The mic is not re-armed during generation here: on the streaming engine
-        // the silence timer would send a second, concurrent run mid-generation.
-        // armDuringTts below arms it for the playback window instead. A batch STT
-        // engine wants the opposite (arm here, let its own VAD supersede the run),
-        // which is part of wiring that engine into the loop.
+        // The mic is not re-armed during generation, on either engine: the
+        // streaming engine's silence timer would send a second, concurrent run
+        // mid-generation, and a batch engine would be recording a turn the run
+        // has already consumed.
       }
       return;
     }
@@ -452,12 +479,22 @@ export const VoiceEngine: FC = () => {
     // Flush the remaining sentences (incl. the trailing one) and finish; the
     // stream's consumer calls resumeListen when playback drains.
     endStreamRef.current(text);
-    // Arm the mic DURING TTS so barge-in works: the streaming engine needs a live
-    // session for its transcript to grow. The just-ended turn's dictation can read
-    // as "set" for a few frames, and a single check would skip arming (leaving no
-    // mic to barge with), so retry until it clears, then click Dictate.
+    // Arm the mic DURING TTS so barge-in works -- the streaming engine needs a
+    // live session for its transcript to grow. The just-ended turn's dictation can
+    // read as "set" for a few frames, and a single check would skip arming
+    // (leaving no mic to barge with), so retry until it clears, then click
+    // Dictate.
+    //
+    // Not for a batch engine, deliberately. Its session records everything it
+    // hears and transcribes the whole recording on stop, so a mic open during
+    // playback would post the model's own words back as the user's next message,
+    // and there is no post-hoc echo check possible on a transcript that only
+    // arrives at the end. Barge-in for those engines needs acoustic echo
+    // cancellation on the capture stream and is deliberately absent here; the
+    // batch loop is listen, transcribe, generate, speak, then listen again.
     const armDuringTts = (n: number) => {
       if (voiceModeRef.current !== "active") return;
+      if (batchDictation) return;
       if (auiRef.current.composer().getState().dictation) {
         if (n < 6) setTimeout(() => armDuringTts(n + 1), 60);
         return;
@@ -465,7 +502,7 @@ export const VoiceEngine: FC = () => {
       auiRef.current.composer().startDictation();
     };
     armDuringTts(0);
-  }, [isThreadRunning, resumeListen, latestAssistantText]);
+  }, [batchDictation, isThreadRunning, resumeListen, latestAssistantText]);
 
   // Silence timer: only fires in "active" state. This watches the transcript
   // grow, so it needs the streaming (Web Speech) engine; VoiceControlButton
@@ -475,6 +512,9 @@ export const VoiceEngine: FC = () => {
   useEffect(() => {
     if (dictationStatusType !== "running") return;
     if (voiceModeRef.current !== "active") return;
+    // A batch engine has no growing transcript to debounce against; the effect
+    // below owns its turn-taking, off the microphone meter.
+    if (batchDictation) return;
 
     // Barge-in (debounced): speech while TTS is playing only interrupts if it's
     // sustained. On the first fragment, open a window and snapshot the transcript
@@ -551,7 +591,100 @@ export const VoiceEngine: FC = () => {
         silenceTimerRef.current = null;
       }
     };
-  }, [dictationTranscript, dictationStatusType, stop, resumeListen]);
+  }, [batchDictation, dictationTranscript, dictationStatusType, stop, resumeListen]);
+
+  // Microphone meter. Both adapters publish it through startDictationLevelMeter,
+  // so this drives the orb's "hearing" state for either engine -- that state
+  // claims the mic is picking you up, and here it actually is the mic.
+  //
+  // It also carries turn-taking for the batch engines, which the effect above
+  // cannot serve: their transcript arrives once, at the end, so nothing grows for
+  // a debounce to watch and the 1.5s timer would close the mic and find an empty
+  // composer every time. Here the loop ends the turn itself, once the user has
+  // stopped talking, and sends the transcript down the same path.
+  //
+  // This is the only writer of voiceHearing and voiceTranscribing; the orb
+  // already renders both.
+  useEffect(() => {
+    if (voiceMode !== "active") return;
+    if (dictationStatusType !== "running") return;
+    const store = useChatRuntimeStore.getState();
+
+    let lastAt = 0;
+    let silenceMs = 0;
+    let voiced = false;
+    let hearing = false;
+    let finishing = false;
+
+    const setHearing = (next: boolean) => {
+      if (hearing === next) return;
+      hearing = next;
+      store.setVoiceHearing(next);
+    };
+
+    // Close the mic, wait for the adapter to hand its transcript to the composer,
+    // then send it the same way the streaming engine's silence timer does.
+    const endUtterance = () => {
+      finishing = true;
+      setHearing(false);
+      store.setVoiceTranscribing(true);
+      auiRef.current.composer().stopDictation();
+      const deadline = performance.now() + VOICE_TRANSCRIBE_TIMEOUT_MS;
+      const settle = () => {
+        if (voiceModeRef.current !== "active") {
+          store.setVoiceTranscribing(false);
+          return;
+        }
+        // The adapter commits the transcript through its onSpeech(isFinal)
+        // callback and only then ends the session, so a cleared dictation field
+        // means the composer already holds the text -- or the user said nothing,
+        // and submitTranscript just re-arms.
+        if (
+          auiRef.current.composer().getState().dictation &&
+          performance.now() < deadline
+        ) {
+          setTimeout(settle, 100);
+          return;
+        }
+        store.setVoiceTranscribing(false);
+        submitTranscript();
+      };
+      setTimeout(settle, 0);
+    };
+
+    const unsubscribe = subscribeDictationLevel((level) => {
+      const now = performance.now();
+      const dt = lastAt ? now - lastAt : 0;
+      lastAt = now;
+      if (finishing) return;
+      const speech = level > VOICE_LEVEL_SPEECH;
+      setHearing(speech);
+      if (!batchDictation) return;
+      // A batch mic is never open during playback (see armDuringTts), so anything
+      // heard here is the user. Belt and braces: if one ever is, do not let the
+      // model's own voice through the speakers end the turn.
+      if (isSpeakingRef.current || isPlayingRef.current) {
+        voiced = false;
+        silenceMs = 0;
+        return;
+      }
+      if (speech) {
+        voiced = true;
+        silenceMs = 0;
+        return;
+      }
+      // Silence before the user has said anything is just the room, so an idle
+      // mic listens indefinitely. Only a pause that follows speech ends the turn.
+      if (!voiced) return;
+      silenceMs += dt;
+      if (silenceMs >= VOICE_BATCH_SILENCE_MS) endUtterance();
+    });
+
+    return () => {
+      unsubscribe();
+      store.setVoiceHearing(false);
+    };
+  }, [batchDictation, voiceMode, dictationStatusType, submitTranscript]);
 
   const toggle = useCallback(() => {
     // OFF → CONFIGURING (show dropdown, don't start mic)

--- a/studio/frontend/src/features/chat/voice/voice-engine.tsx
+++ b/studio/frontend/src/features/chat/voice/voice-engine.tsx
@@ -1,0 +1,708 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * The voice conversation loop: continuous speech to speech.
+ *
+ * VoiceEngine is headless. It owns the turn-taking -- listen, send, generate,
+ * speak, listen again -- plus barge-in, and publishes the orb's state to the chat
+ * runtime store. VoiceControlButton is the small composer control that mirrors that
+ * state. The full-screen orb itself is voice-orb.tsx, and the module-level registry
+ * both of these talk through is voice-loop-bridge.ts.
+ *
+ * It sits beside the composer in thread.tsx rather than inside it because the loop
+ * has to keep running while the composer remounts (see _prevRunning below and the
+ * bridge's own header).
+ */
+
+import { resetPromptQueues } from "@/components/assistant-ui/thread";
+import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { ORB_IDLE_GRADIENT, orbConfig } from "@/components/assistant-ui/voice-orb";
+import { StudioWebSpeechDictationAdapter } from "@/features/chat/adapters/studio-web-speech-dictation-adapter";
+import {
+  TTS_AUDIO_TYPES,
+  useTtsPlayer,
+} from "@/features/chat/hooks/use-tts-player";
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { deriveOrbState } from "@/features/chat/voice/orb-state";
+import {
+  getVoiceMode,
+  registerVoiceResume,
+  registerVoiceToggle,
+  setVoiceMode as setLoopVoiceMode,
+} from "@/features/chat/voice/voice-loop-bridge";
+import { useVoiceSettingsStore } from "@/features/settings/stores/voice-settings-store";
+import { cn } from "@/lib/utils";
+import { useAui, useAuiState } from "@assistant-ui/react";
+import { MessageSquareIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type FC } from "react";
+
+// Tracks the previous thread-running state across the first-send remount, so the
+// run-lifecycle effect doesn't lose the first turn's true->false transition. The
+// loop's mode itself lives in the bridge, which is what the rest of the app reads.
+let _prevRunning = false;
+
+// Silence debounce: how long the transcript must stop growing before we treat
+// the user as done and send. Reset on every transcript update so a mid-sentence
+// pause never clips speech; only a real pause this long auto-sends.
+const VOICE_SILENCE_DEBOUNCE_MS = 1500;
+// Barge-in debounce: when speech is heard while TTS is playing, wait this long
+// and only interrupt if the transcript kept growing across the window. A cough
+// or stray blip produces one fragment that doesn't sustain, so it's ignored;
+// real "wait, stop" speech keeps adding words and cuts the model off.
+const VOICE_BARGE_IN_DEBOUNCE_MS = 300;
+// Voice coalescing window: after a finished utterance is appended as a user
+// bubble, wait this long for another utterance before generating. Utterances that
+// arrive within the window fold into the SAME prompt (several bubbles, one reply)
+// instead of stacking as separate turns. Tunable: lower = snappier single turns,
+// higher = groups slower/longer multi-part barge-ins.
+const VOICE_COALESCE_MS = 650;
+// How long playback may pause between sentences before the orb admits a real
+// synth stall and turns lilac ("Generating voice"). The swap between two already
+// synthesized clips is well under this, so ordinary sentence boundaries hold the
+// blue "Speaking" state instead of flickering to lilac; only a gap that persists
+// past this (synthesis genuinely behind playback) shows lilac.
+const SYNTH_GAP_MS = 350;
+
+/**
+ * Whether the plus menu may offer Voice at all. It needs BOTH halves, and the
+ * listening half is the narrower one. Speaking: the browser's speechSynthesis, or a
+ * loaded TTS codec. Listening: the streaming Web Speech engine specifically,
+ * because the loop's turn-taking watches the transcript grow. A batch engine
+ * (local or custom transcription) holds its transcript until end-of-utterance, so
+ * the orb would sit on "listening" and nothing would ever send.
+ *
+ * Gating on TTS alone offered Voice in browsers with speechSynthesis but no
+ * SpeechRecognition, where it could be switched on and never produce a word.
+ */
+export function useVoiceAvailable(): boolean {
+  const activeAudioType = useChatRuntimeStore((s) => {
+    const m = s.models.find((mm) => mm.id === s.params.checkpoint);
+    return m?.audioType ?? null;
+  });
+  const dictationEngine = useVoiceSettingsStore((s) => s.dictationEngine);
+  return (
+    ((typeof window !== "undefined" && "speechSynthesis" in window) ||
+      TTS_AUDIO_TYPES.has(activeAudioType ?? "")) &&
+    dictationEngine === "browser" &&
+    StudioWebSpeechDictationAdapter.isSupported()
+  );
+}
+
+export const VoiceEngine: FC = () => {
+  const aui = useAui();
+  const [voiceMode, setVoiceModeState] = useState(getVoiceMode());
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Barge-in debounce: timer that confirms sustained speech, and the latest
+  // transcript so the timer can check whether it grew across the window.
+  const bargeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Coalesce debounce: after appending a spoken utterance as a user bubble, this
+  // fires the single run once the user pauses; reset each time another utterance
+  // folds into the same prompt.
+  const voiceCoalesceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestTranscriptRef = useRef("");
+  // voiceModeRef is only written in toggle/activate — never in the render body.
+  const voiceModeRef = useRef(getVoiceMode());
+  const isSpeakingRef = useRef(false);
+  // Mirrors isPlaying (a clip is audibly playing) separately from isSpeaking (the
+  // TTS session is streaming). Barge-in must cut in BOTH cases -- including the
+  // tail where the last clip is still playing after the session already ended.
+  const isPlayingRef = useRef(false);
+  // Debounce timer for the speaking -> synthesizing (lilac) transition, so a brief
+  // inter-sentence playback gap doesn't flicker the orb to lilac.
+  const synthGapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const auiRef = useRef(aui);
+  auiRef.current = aui;
+
+  // Read from the store keyed by activeThreadId, not useAuiState(thread.isRunning):
+  // the store value survives the composer remount on first send, so the first
+  // turn's running transition isn't missed (same reason the prompt queue uses
+  // runningByThreadId instead of aui.thread()).
+  const isThreadRunning = useChatRuntimeStore((s) =>
+    s.activeThreadId ? Boolean(s.runningByThreadId[s.activeThreadId]) : false,
+  );
+  const dictationStatusType = useAuiState(
+    ({ composer }) => composer.dictation?.status.type,
+  );
+  const dictationTranscript = useAuiState(
+    ({ composer }) => composer.dictation?.transcript ?? "",
+  );
+  const activeAudioType = useChatRuntimeStore((s) => {
+    const m = s.models.find((m) => m.id === s.params.checkpoint);
+    return m?.audioType ?? null;
+  });
+  // The store field, synced from /voice/status -- not "a voice is selected", which
+  // is true from the moment the picker changes and stays true while the slot is
+  // still loading. The player keys both isTtsModel and streamMode off this, so the
+  // selection alone would POST the first synth into an empty slot.
+  const voiceSlotLoaded = useChatRuntimeStore((s) => s.voiceSlotLoaded);
+
+  // Called after speaking ends (or immediately if there's nothing to speak).
+  const resumeListen = useCallback(() => {
+    // After a session ends (no-speech finish, silence timer), the composer's
+    // dictation field can lag a few frames before clearing. Clicking Dictate
+    // while it is still set would toggle dictation OFF and kill the loop, so
+    // poll briefly for it to clear before re-arming; as a last resort, re-arm
+    // anyway rather than leave the loop dead.
+    const MAX_ATTEMPTS = 5;
+    const RETRY_MS = 50;
+
+    const clickDictate = () => {
+      const fresh = auiRef.current.composer();
+      // Already listening (e.g. the mic was armed during TTS for barge-in): do
+      // NOT restart it. Calling startDictation() on a live session tears the
+      // current mic down -- that's what broke the continuous loop (turn 1 heard
+      // you, turn 2 went deaf). The old button-click was a no-op here because the
+      // Dictate button isn't rendered while dictating; mirror that no-op.
+      if (fresh.getState().dictation) return;
+      // Proactively clear any stale text on a FRESH handle before re-arming, in
+      // case the deferred post-send clear hadn't landed before this re-arm got
+      // here. Without it, turn 2's dictation appends onto turn 1's leftover text.
+      if (fresh.getState().text) {
+        fresh.setText("");
+      }
+      // Start dictation via the composer runtime, NOT by clicking the Dictate
+      // button: in voice mode that button is hidden/replaced by the orb, so a
+      // DOM query returns null and the mic never opens (silent green orb).
+      fresh.startDictation();
+    };
+
+    const attempt = (n: number) => {
+      // Voice turned off while we were waiting — abort the re-arm.
+      if (voiceModeRef.current !== "active") return;
+      const hasDictation = Boolean(
+        auiRef.current.composer().getState().dictation,
+      );
+      if (!hasDictation) {
+        clickDictate();
+        return;
+      }
+      if (n < MAX_ATTEMPTS) {
+        setTimeout(() => attempt(n + 1), RETRY_MS);
+        return;
+      }
+      // Exhausted ~250ms of retries; assume the state is stale and re-arm.
+      clickDictate();
+    };
+
+    attempt(1);
+  }, []);
+
+  const { isSpeaking, isPlaying, beginStream, feedText, endStream, stop, primeAudio } =
+    useTtsPlayer(activeAudioType, resumeListen, voiceSlotLoaded);
+  isSpeakingRef.current = isSpeaking;
+  isPlayingRef.current = isPlaying;
+  // Streaming TTS handles (refs so the run-lifecycle effect never goes stale).
+  const beginStreamRef = useRef(beginStream);
+  beginStreamRef.current = beginStream;
+  const feedTextRef = useRef(feedText);
+  feedTextRef.current = feedText;
+  const endStreamRef = useRef(endStream);
+  endStreamRef.current = endStream;
+  // Interval that feeds the growing assistant reply into the TTS stream.
+  const streamPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Latest assistant reply text (concatenated text parts of the newest assistant
+  // message). Used both to stream during generation and to flush on completion.
+  const latestAssistantText = useCallback((): string => {
+    const messages = auiRef.current.thread().getState().messages;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.role !== "assistant") continue;
+      let text = "";
+      for (const part of msg.content as Array<{ type: string; text?: string }>) {
+        if (part.type === "text" && part.text) text += part.text;
+      }
+      return text;
+    }
+    return "";
+  }, []);
+
+  // Submit a batch-STT (Whisper) transcript. The adapter has already committed
+  // the final transcript into the composer via its onSpeech(isFinal) callback,
+  // so here we just end dictation and send it — the run-lifecycle effect then
+  // speaks the reply and re-arms the mic, same as the streaming path. Mirrors
+  // the silence-timer send block (clear-on-turn-1 race guard included).
+  const submitTranscript = useCallback(() => {
+    if (voiceModeRef.current !== "active") return;
+    const composer = auiRef.current.composer();
+    if (composer.getState().dictation) composer.stopDictation();
+    const text = composer.getState().text.trim();
+    // Barge-in: the instant the user speaks, cut the audio and the in-flight run.
+    // This utterance supersedes whatever the model was saying. Cover the tail
+    // clip (isPlaying) too, not just an active streaming session (isSpeaking).
+    if (isSpeakingRef.current || isPlayingRef.current) stop();
+    if (!text) {
+      resumeListen();
+      return;
+    }
+    const thread = auiRef.current.thread();
+    if (thread.getState().isRunning) {
+      try {
+        thread.cancelRun();
+      } catch {
+        // Run may have ended between the check and here.
+      }
+    }
+    // Voice coalescing: several barge-ins in a row should read as ONE prompt --
+    // a user bubble each, then a single reply -- NOT a stack of separate turns
+    // like the text-chat prompt queue. Append this utterance WITHOUT running,
+    // clear that queue, keep the mic live, and (re)arm the coalesce debounce; the
+    // single run fires only once the user has actually paused. Another utterance
+    // arriving first appends another bubble and resets the debounce, folding into
+    // the same prompt.
+    resetPromptQueues();
+    const DEFERRED_CLEAR_MS = 50;
+    const deferredClear = (n: number) => {
+      if (voiceModeRef.current !== "active") return;
+      const fresh = auiRef.current.composer();
+      if (!fresh.getState().text) return;
+      fresh.setText("");
+      if (n < 5) setTimeout(() => deferredClear(n + 1), DEFERRED_CLEAR_MS);
+    };
+
+    // First message of a thread: the append + delayed-startRun coalescing path
+    // can't reliably drive a brand-new thread -- its runtime remounts on the first
+    // send, so the captured handle goes stale and the run never fires (the bubble
+    // shows but gets no reply). Use the normal composer.send() for the very first
+    // utterance; it creates the thread and runs. Coalescing kicks in from turn 2 on.
+    if (thread.getState().messages.length === 0) {
+      composer.send();
+      composer.setText("");
+      setTimeout(() => deferredClear(1), DEFERRED_CLEAR_MS);
+      return;
+    }
+
+    let appended = false;
+    try {
+      auiRef.current.thread().append({
+        role: "user",
+        content: [{ type: "text", text }],
+        createdAt: new Date(),
+        startRun: false,
+      } as never);
+      appended = true;
+    } catch {
+      // Runtime without append({startRun:false}) support -- fall back below.
+    }
+
+    if (!appended) {
+      // Fallback: old immediate-send behavior (text is still in the composer).
+      composer.send();
+      composer.setText("");
+      setTimeout(() => deferredClear(1), DEFERRED_CLEAR_MS);
+      return;
+    }
+
+    composer.setText("");
+    setTimeout(() => deferredClear(1), DEFERRED_CLEAR_MS);
+    // Keep listening so the user can chain more utterances into this same prompt.
+    resumeListen();
+    if (voiceCoalesceTimerRef.current) clearTimeout(voiceCoalesceTimerRef.current);
+    voiceCoalesceTimerRef.current = setTimeout(() => {
+      voiceCoalesceTimerRef.current = null;
+      if (voiceModeRef.current !== "active") return;
+      const t = auiRef.current.thread();
+      if (t.getState().isRunning) return;
+      const msgs = t.getState().messages;
+      const lastId = msgs.length > 0 ? msgs[msgs.length - 1].id : null;
+      try {
+        t.startRun({ parentId: lastId });
+      } catch {
+        // startRun unsupported -- the bubbles are already shown; nothing to do.
+      }
+    }, VOICE_COALESCE_MS);
+  }, [resumeListen, stop]);
+
+  // Sync derived orb state to the store so VoiceOrb can read it without prop-drilling.
+  // The priority order itself lives in deriveOrbState, which is pure and tested.
+  const setVoiceOrbState = useChatRuntimeStore((s) => s.setVoiceOrbState);
+  const voiceSlotLoading = useChatRuntimeStore((s) => s.voiceSlotLoading);
+  const voiceTranscribing = useChatRuntimeStore((s) => s.voiceTranscribing);
+  const voiceHearing = useChatRuntimeStore((s) => s.voiceHearing);
+  useEffect(() => {
+    const clearSynthGap = () => {
+      if (synthGapTimerRef.current) {
+        clearTimeout(synthGapTimerRef.current);
+        synthGapTimerRef.current = null;
+      }
+    };
+    const decision = deriveOrbState({
+      voiceMode,
+      voiceSlotLoading,
+      voiceHearing,
+      isPlaying,
+      voiceTranscribing,
+      isThreadRunning,
+      isSpeaking,
+    });
+    if (decision.kind === "set") {
+      clearSynthGap();
+      setVoiceOrbState(decision.state);
+      return;
+    }
+    // A TTS session with nothing playing. Only show "Generating voice" if the gap
+    // outlasts SYNTH_GAP_MS -- playback genuinely behind synthesis -- rather than
+    // flickering at every sentence boundary. If a clip starts inside the window,
+    // isPlaying flips true, this effect re-runs into the "set" arm above, and
+    // clearSynthGap cancels the pending switch.
+    if (synthGapTimerRef.current) return;
+    synthGapTimerRef.current = setTimeout(() => {
+      synthGapTimerRef.current = null;
+      // Re-check live via refs at fire time: only go lilac if still stalled.
+      if (
+        voiceModeRef.current === "active" &&
+        isSpeakingRef.current &&
+        !isPlayingRef.current
+      ) {
+        setVoiceOrbState("synthesizing");
+      }
+    }, SYNTH_GAP_MS);
+  }, [voiceMode, voiceSlotLoading, voiceHearing, voiceTranscribing, isThreadRunning, isSpeaking, isPlaying, setVoiceOrbState]);
+
+  // Clear any pending synth-gap timer on unmount so it can't fire after teardown.
+  useEffect(() => () => {
+    if (synthGapTimerRef.current) clearTimeout(synthGapTimerRef.current);
+  }, []);
+
+  // Helper: transition to "active" and start the mic.
+  const activateLoop = useCallback(() => {
+    setLoopVoiceMode("active");
+    voiceModeRef.current = "active";
+    setVoiceModeState("active");
+    if (!auiRef.current.thread().getState().isRunning && !isSpeakingRef.current) {
+      auiRef.current.composer().startDictation();
+    }
+  }, []);
+
+  // On remount: restore "active" only — "configuring" stays as-is (no mic).
+  // Deferred one tick: on a New Chat the Thread remounts here with getVoiceMode() still
+  // "active", but the parent's thread-switch reset (which flips voice OFF) runs in
+  // the SAME commit, after this child effect. Starting the mic synchronously would
+  // arm dictation on the fresh chat that voice is being turned off for (voice reads
+  // off, yet the red "stop dictation" square is showing). By deferring and
+  // re-checking getVoiceMode(), the reset settles first and we skip the restore. The
+  // first-send remount keeps getVoiceMode() "active", so dictation still resumes there.
+  useEffect(() => {
+    if (getVoiceMode() !== "active" || isThreadRunning) return;
+    const id = setTimeout(() => {
+      if (getVoiceMode() !== "active") return;
+      if (auiRef.current.thread().getState().isRunning || isSpeakingRef.current) return;
+      auiRef.current.composer().startDictation();
+    }, 0);
+    return () => clearTimeout(id);
+  }, []); // mount only
+
+  // Watch the store: when it transitions from "configuring" → "active"
+  // (triggered externally by the voice-model dropdown pick), activate the loop.
+  const storeVoiceMode = useChatRuntimeStore((s) => s.voiceMode);
+  useEffect(() => {
+    if (
+      storeVoiceMode === "active" &&
+      voiceModeRef.current === "configuring"
+    ) {
+      activateLoop();
+    }
+  }, [storeVoiceMode, activateLoop]);
+
+  // Run lifecycle: while the model streams, synthesize each finished sentence so
+  // the first plays fast; on completion flush the rest and re-arm the mic.
+  useEffect(() => {
+    if (isThreadRunning) {
+      _prevRunning = true;
+      if (voiceModeRef.current === "active") {
+        if (silenceTimerRef.current) {
+          clearTimeout(silenceTimerRef.current);
+          silenceTimerRef.current = null;
+        }
+        const composer = auiRef.current.composer();
+        if (composer.getState().dictation) composer.stopDictation();
+        // Begin streaming TTS and feed the reply as it generates so audio starts
+        // on the first complete sentence, not after the whole reply.
+        beginStreamRef.current();
+        if (streamPollRef.current) clearInterval(streamPollRef.current);
+        streamPollRef.current = setInterval(() => {
+          feedTextRef.current(latestAssistantText());
+        }, 150);
+        // The mic is not re-armed during generation here: on the streaming engine
+        // the silence timer would send a second, concurrent run mid-generation.
+        // armDuringTts below arms it for the playback window instead. A batch STT
+        // engine wants the opposite (arm here, let its own VAD supersede the run),
+        // which is part of wiring that engine into the loop.
+      }
+      return;
+    }
+    if (!_prevRunning) return;
+    _prevRunning = false;
+
+    if (streamPollRef.current) {
+      clearInterval(streamPollRef.current);
+      streamPollRef.current = null;
+    }
+    if (voiceModeRef.current !== "active") return;
+    // Note: no isSpeaking guard here. If a stale utterance is still speaking when
+    // a newer reply lands, the newest wins — beginStream above supersedes via
+    // stop(). Skipping would silently drop the reply and dead-end the loop.
+
+    const text = latestAssistantText();
+    if (!text) {
+      resumeListen();
+      return;
+    }
+    // Flush the remaining sentences (incl. the trailing one) and finish; the
+    // stream's consumer calls resumeListen when playback drains.
+    endStreamRef.current(text);
+    // Arm the mic DURING TTS so barge-in works: the streaming engine needs a live
+    // session for its transcript to grow. The just-ended turn's dictation can read
+    // as "set" for a few frames, and a single check would skip arming (leaving no
+    // mic to barge with), so retry until it clears, then click Dictate.
+    const armDuringTts = (n: number) => {
+      if (voiceModeRef.current !== "active") return;
+      if (auiRef.current.composer().getState().dictation) {
+        if (n < 6) setTimeout(() => armDuringTts(n + 1), 60);
+        return;
+      }
+      auiRef.current.composer().startDictation();
+    };
+    armDuringTts(0);
+  }, [isThreadRunning, resumeListen, latestAssistantText]);
+
+  // Silence timer: only fires in "active" state. This watches the transcript
+  // grow, so it needs the streaming (Web Speech) engine; VoiceControlButton
+  // refuses to enter voice mode on any other, because a batch engine holds its
+  // transcript until end-of-utterance and this would stop the mic after 1.5s and
+  // find an empty composer every time.
+  useEffect(() => {
+    if (dictationStatusType !== "running") return;
+    if (voiceModeRef.current !== "active") return;
+
+    // Barge-in (debounced): speech while TTS is playing only interrupts if it's
+    // sustained. On the first fragment, open a window and snapshot the transcript
+    // length; when it elapses, barge only if the transcript grew (the user kept
+    // talking). A cough/blip doesn't grow, so it's ignored.
+    latestTranscriptRef.current = dictationTranscript;
+    if (isSpeakingRef.current && dictationTranscript.trim()) {
+      if (bargeTimerRef.current === null) {
+        const baseline = dictationTranscript.trim().length;
+        bargeTimerRef.current = setTimeout(() => {
+          bargeTimerRef.current = null;
+          if (!isSpeakingRef.current) return;
+          if (latestTranscriptRef.current.trim().length > baseline) stop();
+        }, VOICE_BARGE_IN_DEBOUNCE_MS);
+      }
+    } else if (bargeTimerRef.current !== null) {
+      clearTimeout(bargeTimerRef.current);
+      bargeTimerRef.current = null;
+    }
+
+    if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+    silenceTimerRef.current = setTimeout(() => {
+      silenceTimerRef.current = null;
+      if (voiceModeRef.current !== "active") return;
+      const composer = auiRef.current.composer();
+      composer.stopDictation();
+      // Still audible? Then whatever the mic picked up is the model's own voice
+      // coming back through the speakers. Real speech over the top gets through a
+      // different door: it grows the transcript, which cuts the TTS above, and by
+      // the time this window expires nothing is playing. Sending here instead
+      // would post a fragment of the model's own sentence as the user's next
+      // message. Drop it and keep listening.
+      if (isSpeakingRef.current || isPlayingRef.current) {
+        composer.setText("");
+        setTimeout(() => resumeListen(), 0);
+        return;
+      }
+      if (composer.getState().isEditing && composer.getState().text.trim()) {
+        composer.send();
+        // On the first turn the send-reset can race with the new-thread bind /
+        // composer remount, leaving the utterance as a prefix on the next
+        // message. Clear explicitly to guard against that.
+        composer.setText("");
+        // The synchronous clear above lands on the pre-remount composer instance,
+        // which the FIRST send unmounts a few ms later (ComposerActionWrapper
+        // remount) — so on turn 1 it has no effect. Re-clear against a FRESH
+        // composer handle (auiRef.current.composer(), never the captured `composer`)
+        // across a few frames until it takes, or voice turns off.
+        const DEFERRED_CLEAR_MAX = 5;
+        const DEFERRED_CLEAR_MS = 50;
+        const deferredClear = (n: number) => {
+          if (voiceModeRef.current !== "active") return;
+          const fresh = auiRef.current.composer();
+          if (!fresh.getState().text) {
+            return;
+          }
+          fresh.setText("");
+          if (n < DEFERRED_CLEAR_MAX) setTimeout(() => deferredClear(n + 1), DEFERRED_CLEAR_MS);
+        };
+        setTimeout(() => deferredClear(1), DEFERRED_CLEAR_MS);
+      } else {
+        // No speech this window: stopDictation ends the session but nothing
+        // re-arms it, so the loop would die while voiceMode stays "active"
+        // (orb stuck, mic dead). Re-arm so we keep listening indefinitely.
+        // Deferred so assistant-ui clears the ended session before resumeListen
+        // re-checks it.
+        setTimeout(() => resumeListen(), 0);
+      }
+    }, VOICE_SILENCE_DEBOUNCE_MS);
+
+    return () => {
+      if (silenceTimerRef.current) {
+        clearTimeout(silenceTimerRef.current);
+        silenceTimerRef.current = null;
+      }
+    };
+  }, [dictationTranscript, dictationStatusType, stop, resumeListen]);
+
+  const toggle = useCallback(() => {
+    // OFF → CONFIGURING (show dropdown, don't start mic)
+    // CONFIGURING → OFF (user cancelled before picking)
+    // ACTIVE → OFF (turn off the loop)
+    const next: "off" | "configuring" =
+      voiceModeRef.current === "off" ? "configuring" : "off";
+    setLoopVoiceMode(next);
+    voiceModeRef.current = next;
+    setVoiceModeState(next);
+    useChatRuntimeStore.getState().setVoiceMode(next);
+
+    if (next === "configuring") {
+      // Open each voice session with no TTS pre-selected (Browser voice) so a
+      // previously-remembered pick doesn't silently auto-load; the user chooses
+      // a voice explicitly from the "Speak with" dropdown.
+      useChatRuntimeStore.getState().setSelectedVoiceModelId(null);
+      primeAudio();
+    }
+
+    if (next === "off") {
+      if (silenceTimerRef.current) {
+        clearTimeout(silenceTimerRef.current);
+        silenceTimerRef.current = null;
+      }
+      if (bargeTimerRef.current) {
+        clearTimeout(bargeTimerRef.current);
+        bargeTimerRef.current = null;
+      }
+      if (voiceCoalesceTimerRef.current) {
+        clearTimeout(voiceCoalesceTimerRef.current);
+        voiceCoalesceTimerRef.current = null;
+      }
+      stop();
+      const composer = auiRef.current.composer();
+      if (composer.getState().dictation) composer.stopDictation();
+    }
+    // "configuring": dropdown appears via store; mic stays off.
+  }, [stop, primeAudio]);
+
+  // When voice mode turns off, make sure no loop-owned dictation session lingers.
+  // Otherwise the manual Dictate button (un-hidden the instant voice is off) shows
+  // its red pulsing "stop dictation" square because the composer still thinks it's
+  // recording. stopDictation can lag a frame or a late re-arm can slip in, so retry
+  // until the session actually clears.
+  useEffect(() => {
+    if (voiceMode !== "off") return;
+    let n = 0;
+    const clear = () => {
+      if (voiceModeRef.current !== "off") return;
+      const c = auiRef.current.composer();
+      if (!c.getState().dictation) return;
+      c.stopDictation();
+      if (n++ < 8) setTimeout(clear, 60);
+    };
+    clear();
+  }, [voiceMode]);
+
+  useEffect(() => {
+    return () => {
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+      if (bargeTimerRef.current) clearTimeout(bargeTimerRef.current);
+      if (voiceCoalesceTimerRef.current) clearTimeout(voiceCoalesceTimerRef.current);
+      if (streamPollRef.current) clearInterval(streamPollRef.current);
+    };
+  }, []);
+
+  // Expose the toggle so the plus-menu Voice item can drive it (and run
+  // primeAudio inside that click gesture) from a different component.
+  useEffect(() => {
+    registerVoiceToggle(toggle);
+    return () => {
+      registerVoiceToggle(null);
+    };
+  }, [toggle]);
+
+  // Expose resumeListen so the dictation adapter can re-arm the mic after a
+  // recoverable no-speech timeout. It self-guards: no-op unless voice is active.
+  useEffect(() => {
+    registerVoiceResume(resumeListen);
+    return () => {
+      registerVoiceResume(null);
+    };
+  }, [resumeListen]);
+
+  // Thread-switch voice reset moved OUT of VoiceEngine: this component remounts
+  // across the ThreadWelcome → ThreadComposerDock (first-send) boundary and loses
+  // its prev-thread subscription, so it never sees null → __LOCALID_xxx. The reset
+  // now lives in SingleContent (chat-page.tsx), which is stable across that remount,
+  // and drives requestVoiceToggle() via the module-level bridge.
+
+  // Headless: the visible control now lives in the plus menu (ComposerToolsMenu).
+  // This component stays mounted only to keep the voice loop's hooks/effects alive.
+  return null;
+};
+
+// Composer voice control, shown once voice is opened from the + menu. It is a
+// mini version of the orb whose color mirrors the full orb's state:
+//   - configuring (loop not started): grey mini orb; click starts the loop.
+//   - active + minimized (chat visible): colored mini orb (listening/thinking/
+//     speaking); click re-opens the full orb.
+//   - active + full orb showing: a "back to chat" icon; click minimizes the orb
+//     so you can read/use the chat while speech-to-speech keeps running.
+export const VoiceControlButton: FC = () => {
+  const voiceMode = useChatRuntimeStore((s) => s.voiceMode);
+  const orbState = useChatRuntimeStore((s) => s.voiceOrbState);
+  const collapsed = useChatRuntimeStore((s) => s.voiceOrbCollapsed);
+  const setVoiceMode = useChatRuntimeStore((s) => s.setVoiceMode);
+  const setVoiceOrbCollapsed = useChatRuntimeStore((s) => s.setVoiceOrbCollapsed);
+
+  if (voiceMode === "off") return null;
+
+  // Full orb is showing: offer to minimize it back to the chat view.
+  if (voiceMode === "active" && !collapsed) {
+    return (
+      <TooltipIconButton
+        tooltip="Back to chat"
+        aria-label="Back to chat"
+        variant="ghost"
+        className="size-8 rounded-full text-foreground"
+        onClick={() => setVoiceOrbCollapsed(true)}
+      >
+        <MessageSquareIcon className="size-5" />
+      </TooltipIconButton>
+    );
+  }
+
+  const active = voiceMode === "active";
+  const gradient =
+    active && orbState ? orbConfig[orbState].gradient : ORB_IDLE_GRADIENT;
+  const tooltip = active ? "Open voice orb" : "Start voice mode";
+
+  return (
+    <TooltipIconButton
+      tooltip={tooltip}
+      aria-label={tooltip}
+      variant="ghost"
+      className="size-8 rounded-full"
+      onClick={() => {
+        setVoiceOrbCollapsed(false);
+        if (!active) setVoiceMode("active");
+      }}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "size-4 rounded-full transition-colors",
+          active && orbState === "speaking" && "animate-pulse",
+        )}
+        style={{ background: gradient }}
+      />
+    </TooltipIconButton>
+  );
+};

--- a/studio/frontend/src/features/chat/voice/voice-engine.tsx
+++ b/studio/frontend/src/features/chat/voice/voice-engine.tsx
@@ -15,16 +15,13 @@
  * bridge's own header).
  */
 
-import { resetPromptQueues } from "@/components/assistant-ui/thread";
+import { resetPromptQueuesForThread } from "@/components/assistant-ui/thread";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { ORB_IDLE_GRADIENT, orbConfig } from "@/components/assistant-ui/voice-orb";
 import { subscribeDictationLevel } from "@/features/chat/adapters/dictation-level";
 import { StudioModelDictationAdapter } from "@/features/chat/adapters/studio-model-dictation-adapter";
 import { StudioWebSpeechDictationAdapter } from "@/features/chat/adapters/studio-web-speech-dictation-adapter";
-import {
-  TTS_AUDIO_TYPES,
-  useTtsPlayer,
-} from "@/features/chat/hooks/use-tts-player";
+import { useTtsPlayer } from "@/features/chat/hooks/use-tts-player";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
 import { deriveOrbState } from "@/features/chat/voice/orb-state";
 import {
@@ -59,6 +56,11 @@ const VOICE_BARGE_IN_DEBOUNCE_MS = 300;
 // instead of stacking as separate turns. Tunable: lower = snappier single turns,
 // higher = groups slower/longer multi-part barge-ins.
 const VOICE_COALESCE_MS = 650;
+// thread.cancelRun() is asynchronous, so the old run can still read as running
+// when the coalesce window closes. Rather than give up and leave the appended
+// bubbles unanswered, re-check every VOICE_COALESCE_MS up to this many times
+// (~10s) before concluding the run will never settle.
+const VOICE_COALESCE_MAX_RETRIES = 15;
 // How long playback may pause between sentences before the orb admits a real
 // synth stall and turns lilac ("Generating voice"). The swap between two already
 // synthesized clips is well under this, so ordinary sentence boundaries hold the
@@ -89,27 +91,24 @@ const VOICE_LEVEL_SPEECH = 0.05;
 const VOICE_TRANSCRIBE_TIMEOUT_MS = 60_000;
 
 /**
- * Whether the plus menu may offer Voice at all. It needs BOTH halves. Speaking:
- * the browser's speechSynthesis, or a loaded TTS codec. Listening: whichever
- * engine is configured, provided it can run here -- Web Speech needs
+ * Whether the plus menu may offer Voice at all. Listening is the gate: whichever
+ * engine is configured has to be able to run here -- Web Speech needs
  * SpeechRecognition, the batch engines need a secure context and MediaRecorder.
+ * Without it, Voice could be switched on and never produce a word.
  *
- * Gating on TTS alone offered Voice in browsers with speechSynthesis but no
- * SpeechRecognition, where it could be switched on and never produce a word.
+ * Speaking is deliberately not gated. It is always satisfiable: the voice picker
+ * always offers a local GGUF voice for the slot (VOICE_MODEL_DEFAULTS in
+ * chat-page.tsx), and the browser voice ends the turn cleanly when
+ * speechSynthesis is missing rather than hanging the loop. Requiring
+ * speechSynthesis or a loaded TTS chat model here hid the menu in exactly the
+ * browser where that local voice is the only way to speak -- and since the voice
+ * inventory is fetched only after voice mode opens, nothing could satisfy it first.
  */
 export function useVoiceAvailable(): boolean {
-  const activeAudioType = useChatRuntimeStore((s) => {
-    const m = s.models.find((mm) => mm.id === s.params.checkpoint);
-    return m?.audioType ?? null;
-  });
   const dictationEngine = useVoiceSettingsStore((s) => s.dictationEngine);
-  return (
-    ((typeof window !== "undefined" && "speechSynthesis" in window) ||
-      TTS_AUDIO_TYPES.has(activeAudioType ?? "")) &&
-    (dictationEngine === "browser"
-      ? StudioWebSpeechDictationAdapter.isSupported()
-      : StudioModelDictationAdapter.isSupported())
-  );
+  return dictationEngine === "browser"
+    ? StudioWebSpeechDictationAdapter.isSupported()
+    : StudioModelDictationAdapter.isSupported();
 }
 
 export const VoiceEngine: FC = () => {
@@ -275,11 +274,13 @@ export const VoiceEngine: FC = () => {
     // Voice coalescing: several barge-ins in a row should read as ONE prompt --
     // a user bubble each, then a single reply -- NOT a stack of separate turns
     // like the text-chat prompt queue. Append this utterance WITHOUT running,
-    // clear that queue, keep the mic live, and (re)arm the coalesce debounce; the
-    // single run fires only once the user has actually paused. Another utterance
-    // arriving first appends another bubble and resets the debounce, folding into
-    // the same prompt.
-    resetPromptQueues();
+    // clear THIS thread's queue (prompts queued in other chats are not ours to
+    // drop), keep the mic live, and (re)arm the coalesce debounce; the single run
+    // fires only once the user has actually paused. Another utterance arriving
+    // first appends another bubble and resets the debounce, folding into the same
+    // prompt.
+    const activeThreadId = useChatRuntimeStore.getState().activeThreadId;
+    if (activeThreadId) resetPromptQueuesForThread(activeThreadId);
     const DEFERRED_CLEAR_MS = 50;
     const deferredClear = (n: number) => {
       if (voiceModeRef.current !== "active") return;
@@ -326,20 +327,39 @@ export const VoiceEngine: FC = () => {
     setTimeout(() => deferredClear(1), DEFERRED_CLEAR_MS);
     // Keep listening so the user can chain more utterances into this same prompt.
     resumeListen();
-    if (voiceCoalesceTimerRef.current) clearTimeout(voiceCoalesceTimerRef.current);
-    voiceCoalesceTimerRef.current = setTimeout(() => {
+    const fireCoalescedRun = (attempt: number) => {
       voiceCoalesceTimerRef.current = null;
       if (voiceModeRef.current !== "active") return;
       const t = auiRef.current.thread();
-      if (t.getState().isRunning) return;
+      if (t.getState().isRunning) {
+        // The barge-in's cancelRun() has not settled yet. Wait for the running
+        // transition instead of returning for good; the timer ref stays pointed at
+        // the retry so a fresh utterance still clears and restarts the window.
+        if (attempt < VOICE_COALESCE_MAX_RETRIES) {
+          voiceCoalesceTimerRef.current = setTimeout(
+            () => fireCoalescedRun(attempt + 1),
+            VOICE_COALESCE_MS,
+          );
+        }
+        return;
+      }
       const msgs = t.getState().messages;
-      const lastId = msgs.length > 0 ? msgs[msgs.length - 1].id : null;
+      const last = msgs.length > 0 ? msgs[msgs.length - 1] : null;
+      // Only a trailing user bubble is unanswered. If a reply has landed since
+      // (something else answered while we waited), starting another run here
+      // would regenerate on top of it.
+      if (!last || last.role !== "user") return;
       try {
-        t.startRun({ parentId: lastId });
+        t.startRun({ parentId: last.id });
       } catch {
         // startRun unsupported -- the bubbles are already shown; nothing to do.
       }
-    }, VOICE_COALESCE_MS);
+    };
+    if (voiceCoalesceTimerRef.current) clearTimeout(voiceCoalesceTimerRef.current);
+    voiceCoalesceTimerRef.current = setTimeout(
+      () => fireCoalescedRun(0),
+      VOICE_COALESCE_MS,
+    );
   }, [resumeListen, stop]);
 
   // Sync derived orb state to the store so VoiceOrb can read it without prop-drilling.

--- a/studio/frontend/src/features/chat/voice/voice-engine.tsx
+++ b/studio/frontend/src/features/chat/voice/voice-engine.tsx
@@ -215,7 +215,7 @@ export const VoiceEngine: FC = () => {
     attempt(1);
   }, []);
 
-  const { isSpeaking, isPlaying, beginStream, feedText, endStream, stop, primeAudio } =
+  const { isSpeaking, isPlaying, speak, beginStream, feedText, endStream, stop, primeAudio } =
     useTtsPlayer(activeAudioType, resumeListen, voiceSlotLoaded);
   isSpeakingRef.current = isSpeaking;
   isPlayingRef.current = isPlaying;
@@ -226,6 +226,12 @@ export const VoiceEngine: FC = () => {
   feedTextRef.current = feedText;
   const endStreamRef = useRef(endStream);
   endStreamRef.current = endStream;
+  const speakRef = useRef(speak);
+  speakRef.current = speak;
+  // Whether the run-start branch opened a TTS session for the run in flight. It
+  // only does so while voice mode is already active, so a run that started before
+  // the user switched voice mode on has no session for endStream to flush.
+  const streamBegunRef = useRef(false);
   // Interval that feeds the growing assistant reply into the TTS stream.
   const streamPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -468,6 +474,7 @@ export const VoiceEngine: FC = () => {
         // Begin streaming TTS and feed the reply as it generates so audio starts
         // on the first complete sentence, not after the whole reply.
         beginStreamRef.current();
+        streamBegunRef.current = true;
         if (streamPollRef.current) clearInterval(streamPollRef.current);
         streamPollRef.current = setInterval(() => {
           feedTextRef.current(latestAssistantText());
@@ -481,6 +488,8 @@ export const VoiceEngine: FC = () => {
     }
     if (!_prevRunning) return;
     _prevRunning = false;
+    const streamBegun = streamBegunRef.current;
+    streamBegunRef.current = false;
 
     if (streamPollRef.current) {
       clearInterval(streamPollRef.current);
@@ -496,9 +505,19 @@ export const VoiceEngine: FC = () => {
       resumeListen();
       return;
     }
-    // Flush the remaining sentences (incl. the trailing one) and finish; the
-    // stream's consumer calls resumeListen when playback drains.
-    endStreamRef.current(text);
+    if (streamBegun) {
+      // Flush the remaining sentences (incl. the trailing one) and finish; the
+      // stream's consumer calls resumeListen when playback drains.
+      endStreamRef.current(text);
+    } else {
+      // Voice mode was switched on while this run was already generating, so the
+      // run-start branch never opened a session: endStream would be a no-op, and
+      // on a batch engine armDuringTts below is skipped too, which left voice mode
+      // active with no dictation session until it was toggled off and on. Speak the
+      // finished reply whole, as endStream's browser branch does; every speak()
+      // path ends the turn through onPlaybackEnd -> resumeListen on either engine.
+      speakRef.current(text);
+    }
     // Arm the mic DURING TTS so barge-in works -- the streaming engine needs a
     // live session for its transcript to grow. The just-ended turn's dictation can
     // read as "set" for a few frames, and a single check would skip arming

--- a/studio/frontend/src/features/chat/voice/voice-engine.tsx
+++ b/studio/frontend/src/features/chat/voice/voice-engine.tsx
@@ -26,7 +26,9 @@ import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
 import { deriveOrbState } from "@/features/chat/voice/orb-state";
 import {
   getVoiceMode,
+  registerVoiceBargeIn,
   registerVoiceResume,
+  registerVoiceSubmit,
   registerVoiceToggle,
   setVoiceMode as setLoopVoiceMode,
 } from "@/features/chat/voice/voice-loop-bridge";
@@ -80,10 +82,27 @@ const SYNTH_GAP_MS = 350;
 // and below the streaming engine's 1.5s so the batch path does not feel slower
 // than it already is.
 const VOICE_BATCH_SILENCE_MS = 900;
-// Published level (0..1) above which a frame counts as speech. The meter
-// publishes min(1, rms * 3.2) and the model adapter counts a frame as voiced
-// above raw RMS 0.015, so this is the same line, rounded.
-const VOICE_LEVEL_SPEECH = 0.05;
+// Turn-taking gates, as multiples of the measured room floor rather than fixed
+// levels. Mic gain varies by an order of magnitude across machines, so any single
+// number is right on the box it was tuned on and wrong elsewhere: too low and room
+// noise reads as speech and resets the silence timer forever, too high and the
+// user is never heard at all. Two lines, not one -- a frame between them holds the
+// turn open without counting as either.
+const VOICE_SPEECH_OVER_FLOOR = 3.0;
+const VOICE_SILENCE_OVER_FLOOR = 1.8;
+// Absolute minimums so a mic reporting a near-zero floor (or digital silence)
+// still needs real signal rather than gating on nothing.
+const VOICE_LEVEL_SPEECH_MIN = 0.03;
+const VOICE_LEVEL_SILENCE_MIN = 0.018;
+// A run of speech shorter than this is a click or a cough, not a turn.
+const VOICE_MIN_SPEECH_MS = 350;
+// Backstop: end the turn regardless once the mic has been open this long, so a
+// noisy room or a stuck level meter cannot record forever.
+const VOICE_MAX_UTTERANCE_MS = 30_000;
+// Same, for a mic that never crossed the speech gate at all. Cut and let Whisper
+// decide: a misjudging gate must degrade to "sends a bit late", never to "never
+// sends". An empty transcript just re-arms.
+const VOICE_NO_SPEECH_CUT_MS = 12_000;
 // Ceiling on the wait for a batch transcript once the mic is closed. A local
 // Whisper on CPU is slow but not unbounded; past this the turn is sent with what
 // arrived (usually nothing, which just re-arms the mic) rather than stranding the
@@ -158,6 +177,11 @@ export const VoiceEngine: FC = () => {
   // the session ends. Two different turn-taking paths, below.
   const dictationEngine = useVoiceSettingsStore((s) => s.dictationEngine);
   const batchDictation = dictationEngine !== "browser";
+  const batchDictationRef = useRef(batchDictation);
+  batchDictationRef.current = batchDictation;
+  // Supersedes an in-flight re-arm poll, so a later resumeListen can't leave two
+  // of them racing to open the mic.
+  const rearmSeqRef = useRef(0);
   // The store field, synced from /voice/status -- not "a voice is selected", which
   // is true from the moment the picker changes and stays true while the slot is
   // still loading. The player keys both isTtsModel and streamMode off this, so the
@@ -194,9 +218,28 @@ export const VoiceEngine: FC = () => {
       fresh.startDictation();
     };
 
+    const seq = ++rearmSeqRef.current;
+
     const attempt = (n: number) => {
       // Voice turned off while we were waiting — abort the re-arm.
       if (voiceModeRef.current !== "active") return;
+      if (rearmSeqRef.current !== seq) return; // superseded by a newer re-arm
+      // Half-duplex, and the reason this guard lives here rather than at the call
+      // sites: a batch engine transcribes the whole session at the end, so a mic
+      // open while the model is talking records the model. Its own voice then
+      // trips the adapter's barge-in (220ms of level over threshold) and cuts the
+      // reply a word in, and the empty transcript it hands back lands in the
+      // composer. Wait it out rather than dropping the re-arm, so the loop can
+      // still not dead-end; voiceMode going inactive is what ends the wait.
+      if (
+        batchDictationRef.current &&
+        (isSpeakingRef.current ||
+          isPlayingRef.current ||
+          auiRef.current.thread().getState().isRunning)
+      ) {
+        setTimeout(() => attempt(n), RETRY_MS);
+        return;
+      }
       const hasDictation = Boolean(
         auiRef.current.composer().getState().dictation,
       );
@@ -261,14 +304,18 @@ export const VoiceEngine: FC = () => {
     const composer = auiRef.current.composer();
     if (composer.getState().dictation) composer.stopDictation();
     const text = composer.getState().text.trim();
+    if (!text) {
+      // Nothing was said: a no-speech finish, or the half-duplex close the
+      // run-start effect does. Neither is a barge-in, so leave a playing reply
+      // alone -- cutting here is what truncated it after the first word. Just
+      // re-arm; resumeListen defers that until the reply has finished speaking.
+      resumeListen();
+      return;
+    }
     // Barge-in: the instant the user speaks, cut the audio and the in-flight run.
     // This utterance supersedes whatever the model was saying. Cover the tail
     // clip (isPlaying) too, not just an active streaming session (isSpeaking).
     if (isSpeakingRef.current || isPlayingRef.current) stop();
-    if (!text) {
-      resumeListen();
-      return;
-    }
     const thread = auiRef.current.thread();
     if (thread.getState().isRunning) {
       try {
@@ -647,13 +694,26 @@ export const VoiceEngine: FC = () => {
   useEffect(() => {
     if (voiceMode !== "active") return;
     if (dictationStatusType !== "running") return;
+    // The Whisper adapter runs its own energy VAD on the raw PCM it captures, and
+    // ends the turn itself. Driving a second one from the published meter fights
+    // it: two gates, two silence timers, and the meter's perceptual scaling is a
+    // worse signal than the RMS the adapter already has. Batch turn-taking lives
+    // in the adapter; this effect stays only for the streaming engine's orb state.
+    if (batchDictation) return;
     const store = useChatRuntimeStore.getState();
 
     let lastAt = 0;
     let silenceMs = 0;
+    let voicedMs = 0;
+    let openMs = 0;
+    let armedMs = 0;
     let voiced = false;
     let hearing = false;
     let finishing = false;
+    // Running estimate of the room, in published meter units. Drops fast toward a
+    // new quiet level and climbs very slowly, so a long utterance cannot drag the
+    // floor up to meet its own voice and gate the speaker out mid-sentence.
+    let noiseFloor = -1;
 
     const setHearing = (next: boolean) => {
       if (hearing === next) return;
@@ -696,7 +756,17 @@ export const VoiceEngine: FC = () => {
       const dt = lastAt ? now - lastAt : 0;
       lastAt = now;
       if (finishing) return;
-      const speech = level > VOICE_LEVEL_SPEECH;
+      if (noiseFloor < 0) noiseFloor = level;
+      else noiseFloor += (level - noiseFloor) * (level < noiseFloor ? 0.25 : 0.0005);
+      const speechGate = Math.max(
+        VOICE_LEVEL_SPEECH_MIN,
+        noiseFloor * VOICE_SPEECH_OVER_FLOOR,
+      );
+      const silenceGate = Math.max(
+        VOICE_LEVEL_SILENCE_MIN,
+        noiseFloor * VOICE_SILENCE_OVER_FLOOR,
+      );
+      const speech = level >= speechGate;
       setHearing(speech);
       if (!batchDictation) return;
       // A batch mic is never open during playback (see armDuringTts), so anything
@@ -704,17 +774,42 @@ export const VoiceEngine: FC = () => {
       // model's own voice through the speakers end the turn.
       if (isSpeakingRef.current || isPlayingRef.current) {
         voiced = false;
+        voicedMs = 0;
         silenceMs = 0;
+        openMs = 0;
+        armedMs = 0;
         return;
       }
+      openMs += dt;
+      armedMs += dt;
       if (speech) {
-        voiced = true;
+        voicedMs += dt;
+        if (voicedMs >= VOICE_MIN_SPEECH_MS) voiced = true;
         silenceMs = 0;
         return;
       }
       // Silence before the user has said anything is just the room, so an idle
       // mic listens indefinitely. Only a pause that follows speech ends the turn.
-      if (!voiced) return;
+      if (!voiced) {
+        // The cap is on the utterance, not on the mic: an idle mic waiting for
+        // someone to speak must not bank toward it and cut the first sentence off.
+        openMs = 0;
+        // Not speech and not yet a turn: a lone blip decays rather than banking
+        // toward VOICE_MIN_SPEECH_MS across unrelated noise minutes apart.
+        if (level < silenceGate) voicedMs = 0;
+        // The gate can still be wrong for this mic. Rather than listen forever,
+        // hand what was captured to Whisper and let it decide there was nothing.
+        if (armedMs >= VOICE_NO_SPEECH_CUT_MS) endUtterance();
+        return;
+      }
+      if (openMs >= VOICE_MAX_UTTERANCE_MS) {
+        endUtterance();
+        return;
+      }
+      // Between the two lines is neither speech nor silence: hold the turn open
+      // without banking silence, so room noise cannot end it early OR, by
+      // resetting the timer every frame, stop it ending at all.
+      if (level >= silenceGate) return;
       silenceMs += dt;
       if (silenceMs >= VOICE_BATCH_SILENCE_MS) endUtterance();
     });
@@ -724,6 +819,13 @@ export const VoiceEngine: FC = () => {
       store.setVoiceHearing(false);
     };
   }, [batchDictation, voiceMode, dictationStatusType, submitTranscript]);
+
+  // No session-end watcher here on purpose. The Whisper adapter raises
+  // requestVoiceSubmit itself once it has a transcript, on its own end-of-turn
+  // AND on a manual stop, so submission is already covered. Driving it from the
+  // session ending instead would also fire on the half-duplex close: the loop
+  // shuts the mic when the model starts speaking, which would read as a finished
+  // turn and let submitTranscript's barge-in branch cut the reply a word in.
 
   const toggle = useCallback(() => {
     // OFF → CONFIGURING (show dropdown, don't start mic)
@@ -808,6 +910,34 @@ export const VoiceEngine: FC = () => {
       registerVoiceResume(null);
     };
   }, [resumeListen]);
+
+  // The Whisper adapter owns end-of-utterance, so it also raises the two events
+  // that turn one into a conversation turn: cut the reply we are talking over,
+  // and send what it just committed to the composer.
+  useEffect(() => {
+    registerVoiceBargeIn(() => {
+      if (voiceModeRef.current !== "active") return;
+      // The adapter raises this off raw mic energy, which on a batch engine
+      // cannot tell the user apart from the model coming back through the
+      // speakers -- and that is the only thing a mic can hear here, since the
+      // loop keeps it shut while the reply plays. Interrupting a batch turn goes
+      // through submitTranscript with actual words instead.
+      if (batchDictationRef.current) return;
+      // No-op unless something is actually audible, so an utterance that starts
+      // in silence does not cancel a run that was never speaking.
+      if (isSpeakingRef.current || isPlayingRef.current) stop();
+    });
+    return () => {
+      registerVoiceBargeIn(null);
+    };
+  }, [stop]);
+
+  useEffect(() => {
+    registerVoiceSubmit(submitTranscript);
+    return () => {
+      registerVoiceSubmit(null);
+    };
+  }, [submitTranscript]);
 
   // Thread-switch voice reset moved OUT of VoiceEngine: this component remounts
   // across the ThreadWelcome → ThreadComposerDock (first-send) boundary and loses

--- a/studio/frontend/src/features/chat/voice/voice-loop-bridge.ts
+++ b/studio/frontend/src/features/chat/voice/voice-loop-bridge.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Module-level registry for the voice conversation loop: its mode, and the two
+ * calls other parts of the app make back into it.
+ *
+ * Everything here exists because the loop's own component remounts. Sending the
+ * first message swaps ThreadWelcome for ThreadComposerDock, so a subscription or a
+ * React ref would be torn down at exactly the moment the loop must not forget it is
+ * running. These module bindings survive it.
+ *
+ * It is also the only thing a dictation adapter or the chat page has to import to
+ * reach the loop. Importing the loop itself would be a cycle
+ * (runtime-provider -> adapter -> voice-engine -> ...), and bundlers resolve those
+ * by handing one side a partially initialised module.
+ */
+
+/** Whether the conversation loop is off, being configured, or running. */
+export type VoiceMode = "off" | "configuring" | "active";
+
+// The loop's own mode, distinct from the store field of the same name: this one
+// survives the ThreadWelcome -> ThreadComposerDock remount that the first send
+// triggers, which is exactly when the loop must not forget it is running.
+let voiceMode: VoiceMode = "off";
+
+let voiceToggle: (() => void) | null = null;
+let voiceResume: (() => void) | null = null;
+
+/** The loop's current mode. Safe to call from anywhere, including render. */
+export function getVoiceMode(): VoiceMode {
+  return voiceMode;
+}
+
+/** Written only by the loop itself as it transitions. */
+export function setVoiceMode(next: VoiceMode): void {
+  voiceMode = next;
+}
+
+/** Registered by the mounted loop. Pass null on teardown. */
+export function registerVoiceToggle(fn: (() => void) | null): void {
+  voiceToggle = fn;
+}
+
+/**
+ * Drive the same off/configuring/active toggle the plus menu uses -- from the orb
+ * overlay's close button, its Esc handler, or the chat page's thread-switch reset.
+ * A no-op while the loop is unmounted.
+ */
+export function requestVoiceToggle(): void {
+  voiceToggle?.();
+}
+
+/** Called by the mounted voice loop. Pass null on teardown. */
+export function registerVoiceResume(fn: (() => void) | null): void {
+  voiceResume = fn;
+}
+
+/**
+ * Re-arm the mic after a recoverable end of session -- a Web Speech "no-speech"
+ * timeout, say, where the engine heard nothing and gave up but the conversation is
+ * still going. A no-op unless the loop is mounted and voice mode is still active, so
+ * an adapter used outside voice mode can call it freely.
+ */
+export function requestVoiceResume(): void {
+  voiceResume?.();
+}

--- a/studio/frontend/src/features/chat/voice/voice-loop-bridge.ts
+++ b/studio/frontend/src/features/chat/voice/voice-loop-bridge.ts
@@ -26,6 +26,8 @@ let voiceMode: VoiceMode = "off";
 
 let voiceToggle: (() => void) | null = null;
 let voiceResume: (() => void) | null = null;
+let voiceBargeIn: (() => void) | null = null;
+let voiceSubmit: (() => void) | null = null;
 
 /** The loop's current mode. Safe to call from anywhere, including render. */
 export function getVoiceMode(): VoiceMode {
@@ -64,4 +66,34 @@ export function registerVoiceResume(fn: (() => void) | null): void {
  */
 export function requestVoiceResume(): void {
   voiceResume?.();
+}
+
+/** Called by the mounted voice loop. Pass null on teardown. */
+export function registerVoiceBargeIn(fn: (() => void) | null): void {
+  voiceBargeIn = fn;
+}
+
+/**
+ * Cut the currently-playing reply because the user has started talking over it.
+ * The adapter raises this the instant an utterance commits to being transcribed,
+ * so the model is not still speaking into a turn it is about to lose. The handler
+ * no-ops unless something is actually audible, so stray calls are harmless.
+ */
+export function requestVoiceBargeIn(): void {
+  voiceBargeIn?.();
+}
+
+/** Called by the mounted voice loop. Pass null on teardown. */
+export function registerVoiceSubmit(fn: (() => void) | null): void {
+  voiceSubmit = fn;
+}
+
+/**
+ * Send the utterance the adapter has just committed into the composer. The
+ * adapter owns end-of-turn, so it is also what says the turn is ready to go: a
+ * no-op outside voice mode, which is what leaves the plain Dictate button filling
+ * the composer without sending.
+ */
+export function requestVoiceSubmit(): void {
+  voiceSubmit?.();
 }

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -1566,7 +1566,9 @@ function useSoleDownloadedQuants(
   return { quants, pending };
 }
 
-function GgufVariantExpander({
+// Exported for the voice model selector, which offers the same quant list for a
+// GGUF voice as the chat picker does for a chat model.
+export function GgufVariantExpander({
   repoId,
   pipelineTag,
   loadId,

--- a/studio/frontend/src/speech-recognition.d.ts
+++ b/studio/frontend/src/speech-recognition.d.ts
@@ -37,6 +37,7 @@ interface SpeechRecognition extends EventTarget {
   continuous: boolean;
   interimResults: boolean;
   lang: string;
+  onstart: (() => void) | null;
   onresult: ((event: SpeechRecognitionEvent) => void) | null;
   onerror: ((event: Event) => void) | null;
   onend: (() => void) | null;

--- a/studio/frontend/tests/voice-orb-state.test.ts
+++ b/studio/frontend/tests/voice-orb-state.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deriveOrbState,
+  type VoiceOrbInputs,
+} from "../src/features/chat/voice/orb-state.ts";
+
+/** Every input false, voice running: the resting state of a live loop. */
+function idle(overrides: Partial<VoiceOrbInputs> = {}): VoiceOrbInputs {
+  return {
+    voiceMode: "active",
+    voiceSlotLoading: false,
+    voiceHearing: false,
+    isPlaying: false,
+    voiceTranscribing: false,
+    isThreadRunning: false,
+    isSpeaking: false,
+    ...overrides,
+  };
+}
+
+test("the orb is blank unless the loop is actually running", () => {
+  for (const voiceMode of ["off", "configuring"] as const) {
+    // Even with everything else lit: configuring opens the picker, it does not
+    // start the mic, so an orb state here would claim a loop that is not running.
+    const decision = deriveOrbState(
+      idle({ voiceMode, voiceSlotLoading: true, isPlaying: true }),
+    );
+    assert.deepEqual(decision, { kind: "set", state: null });
+  }
+});
+
+test("a warming model reads as loading, not as a ready orb", () => {
+  assert.deepEqual(deriveOrbState(idle({ voiceSlotLoading: true })), {
+    kind: "set",
+    state: "loading",
+  });
+});
+
+test("hearing you outranks the model speaking, so barge-in is visible", () => {
+  // This is the ordering that makes talking over the model legible: the mic is
+  // live during playback on the streaming engine, and the moment it picks you up
+  // the orb must stop claiming the model has the floor.
+  assert.deepEqual(
+    deriveOrbState(idle({ voiceHearing: true, isPlaying: true, isSpeaking: true })),
+    { kind: "set", state: "hearing" },
+  );
+});
+
+test("playback outranks the work still running behind it", () => {
+  // The model keeps writing and the next sentence keeps synthesizing while the
+  // first one plays. Playback is what the user perceives, so it wins.
+  assert.deepEqual(
+    deriveOrbState(
+      idle({ isPlaying: true, isThreadRunning: true, isSpeaking: true }),
+    ),
+    { kind: "set", state: "speaking" },
+  );
+});
+
+test("transcribing is reported ahead of generating, the order they happen in", () => {
+  assert.deepEqual(
+    deriveOrbState(idle({ voiceTranscribing: true, isThreadRunning: true })),
+    { kind: "set", state: "transcribing" },
+  );
+  assert.deepEqual(deriveOrbState(idle({ isThreadRunning: true })), {
+    kind: "set",
+    state: "generating",
+  });
+});
+
+test("a synthesis gap holds the current state instead of switching", () => {
+  // A TTS session with nothing playing is usually two already-synthesized
+  // sentences swapping the audio element. Deciding "synthesizing" here would
+  // flicker the orb at every sentence boundary; the caller waits it out instead.
+  assert.deepEqual(deriveOrbState(idle({ isSpeaking: true })), { kind: "hold" });
+});
+
+test("an armed mic with nothing else happening is listening", () => {
+  assert.deepEqual(deriveOrbState(idle()), { kind: "set", state: "listening" });
+});

--- a/studio/frontend/tests/voice-sentence-chunker.test.ts
+++ b/studio/frontend/tests/voice-sentence-chunker.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Sentence chunking for the voice loop. Each chunk becomes one synth request, so
+ * a bad boundary is audible: the codec is handed a fragment, and the next clip
+ * starts mid-thought after a gap.
+ *
+ * Worth real tests because this is the one part of the voice path that needs no
+ * microphone, no GPU and no loaded model.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  splitIntoSentences,
+  stripForSpeech,
+} from "../src/features/chat/voice/speech-text.ts";
+
+test("splits on sentence punctuation", () => {
+  assert.deepEqual(splitIntoSentences("Hello! How can I assist you today?"), [
+    "Hello!",
+    "How can I assist you today?",
+  ]);
+});
+
+test("apostrophes are not boundaries", () => {
+  assert.deepEqual(
+    splitIntoSentences("I'm sorry, but I can't ask questions."),
+    ["I'm sorry, but I can't ask questions."],
+  );
+  assert.deepEqual(splitIntoSentences("Don't worry. It's fine!"), [
+    "Don't worry.",
+    "It's fine!",
+  ]);
+});
+
+test("a decimal point is not a sentence end", () => {
+  assert.deepEqual(splitIntoSentences("It cost $3.50 today."), [
+    "It cost $3.50 today.",
+  ]);
+});
+
+test("abbreviations keep their sentence", () => {
+  assert.deepEqual(splitIntoSentences("Dr. Smith went home."), [
+    "Dr. Smith went home.",
+  ]);
+});
+
+test("a closing quote stays with the sentence it closes", () => {
+  assert.deepEqual(splitIntoSentences('He said "stop." Then he left.'), [
+    'He said "stop." Then he left.',
+  ]);
+});
+
+test("an opening quote still starts a new chunk", () => {
+  assert.deepEqual(splitIntoSentences('Ready?\n"Lice, lice, lice."'), [
+    "Ready?",
+    '"Lice, lice, lice."',
+  ]);
+});
+
+test("newlines are boundaries, so a list speaks a line at a time", () => {
+  assert.deepEqual(splitIntoSentences("Here is a list:\nitem one\nitem two"), [
+    "Here is a list:",
+    "item one",
+    "item two",
+  ]);
+});
+
+test("stripForSpeech keeps the newlines the splitter needs", () => {
+  // Regression: this used to collapse every \s+ to a space, which erased the
+  // paragraph breaks and made a whole multi-paragraph reply one synth request.
+  const reply = 'Sure! Here it is:\n\n**"Lice, lice, lice."**\n\nLet me know!';
+  const spoken = stripForSpeech(reply);
+  assert.ok(spoken.includes("\n"), "paragraph breaks must survive stripping");
+  assert.deepEqual(splitIntoSentences(spoken), [
+    "Sure!",
+    "Here it is:",
+    '"Lice, lice, lice."',
+    "Let me know!",
+  ]);
+});
+
+test("stripForSpeech still drops markup and emoji", () => {
+  assert.equal(stripForSpeech("**bold** and `code` 😀"), "bold and code");
+});

--- a/studio/frontend/tests/voice-speech-llm-detection.test.ts
+++ b/studio/frontend/tests/voice-speech-llm-detection.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  chatModelOwnsItsVoice,
+  isSpeechLLMCheckpoint,
+} from "../src/features/chat/voice/speech-llm.ts";
+
+test("a renamed fine-tune is a speech model by its detected codec, not its name", () => {
+  // No keyword in the id: the name pattern alone said "text model".
+  assert.equal(isSpeechLLMCheckpoint("me/my-finetune-v3"), false);
+  assert.equal(isSpeechLLMCheckpoint("me/my-finetune-v3", "snac"), true);
+  assert.equal(isSpeechLLMCheckpoint("me/my-finetune-v3", "csm"), true);
+});
+
+test("the name pattern still catches a checkpoint with no inventory record", () => {
+  assert.equal(isSpeechLLMCheckpoint("unsloth/orpheus-3b-0.1-ft", null), true);
+  assert.equal(isSpeechLLMCheckpoint("unsloth/csm-1b", undefined), true);
+  assert.equal(isSpeechLLMCheckpoint("unsloth/Qwen3-4B", null), false);
+});
+
+test("a non-speech audio type does not make a text model own its voice", () => {
+  // Speech INPUT (whisper) and audio VLMs are not TTS codecs.
+  assert.equal(isSpeechLLMCheckpoint("unsloth/Qwen3-4B", "whisper"), false);
+  assert.equal(isSpeechLLMCheckpoint("unsloth/Qwen3-4B", "audio_vlm"), false);
+});
+
+test("chatModelOwnsItsVoice reads the active checkpoint's record from the store", () => {
+  const models = [
+    { id: "me/my-finetune-v3", audioType: "snac" },
+    { id: "unsloth/Qwen3-4B", audioType: null },
+  ];
+  assert.equal(
+    chatModelOwnsItsVoice({
+      params: { checkpoint: "me/my-finetune-v3" },
+      models,
+    }),
+    true,
+  );
+  assert.equal(
+    chatModelOwnsItsVoice({
+      params: { checkpoint: "unsloth/Qwen3-4B" },
+      models,
+    }),
+    false,
+  );
+  // Not in the inventory yet: falls back to the name.
+  assert.equal(
+    chatModelOwnsItsVoice({
+      params: { checkpoint: "unsloth/orpheus-3b-0.1-ft" },
+      models,
+    }),
+    true,
+  );
+  assert.equal(
+    chatModelOwnsItsVoice({ params: { checkpoint: "" }, models }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

This is the conversation-loop half of #6527 by @BardiaKoopah and @LeoBorcherding, reconstructed on top of current `main` as offered in [this comment](https://github.com/unslothai/unsloth/pull/6527#issuecomment-5557458072). The feature and the credit are theirs; this PR exists so it can be cherry-picked or merged without the 2,230-commit rebase.

What `main` already had (`/audio/speech`, `/audio/transcriptions`, the STT sidecar family, the Audio page, both dictation adapters) is not duplicated here. What this adds is what `main` still lacks:

- the speech-to-speech conversation loop itself (`voiceMode`, the orb, barge-in on the streaming engine)
- a second llama-server slot so a chat LLM and a TTS model can be resident at once; `_generate_tts_wav` currently only ever calls `get_llama_cpp_backend()`
- `/voice/load` rewritten onto `GgufLoadIntent` (the original 7-kwarg call would 500 on first use)
- streaming PCM TTS on `/audio/speech/stream`, honouring `AudioSpeechRequest.voice`
- the conversation loop running on the batch transcription engines too (meter-driven end-of-utterance; barge-in deliberately not wired for batch engines, since a transcript that arrives only at the end cannot be echo-checked)
- carried from the Codex review threads on #6527: the training guard on `/voice/load`, refcounting the shared audio codec, per-slot pidfiles, and refusing auto-send while TTS is audible

## Test plan

- [x] Lint tier: compileall, ruff 0.15.12, all four custom CI linters
- [x] Frontend: typecheck, i18n strict, 6851 unit tests, build, bundle:check
- [x] Backend: CI's own studio-backend invocation, 135 failed / 36,850 passed / 309 skipped; every one of the 135 also fails identically on the merge-base, so none is attributable to this branch (details in the linked comment)
- [x] CI's serial 11-file step: 0 failed
- [ ] Not exercised here: a microphone and a browser. This typechecks, builds, and passes the unit suite; nothing in this PR claims the loop speaks until someone with hardware runs it

Co-authored with the original authors' work preserved in the commit trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)