### PR TITLE
notebook_validator: read shell prefixes, backticks and case arms the way bash does

### DIFF
--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -260,7 +260,7 @@ jobs:
         if: always()
         run: |
           python unsloth/scripts/notebook_validator.py refresh-colab \
-              --out unsloth/scripts/data/colab_pip_freeze.gpu.txt
+              --all --snapshot-dir unsloth/scripts/data
       - name: Lint with live PyPI metadata
         if: always()
         # Same backlog, same disposition as the PR-time `Lint` step above:

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -237,7 +237,11 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with: { python-version: '3.12' }
       - name: Install
-        run: pip install -U pip
+        # packaging is not in a bare setup-python environment, and _requirement_applies
+        # falls back to "applies" when it cannot import Marker. Without it this job
+        # replays every environment-marked requirement, including the ones Colab's pip
+        # skips, which is exactly what the Python-version oracle exists to decide.
+        run: pip install -U pip packaging
       - name: Diff Colab oracle vs committed snapshots (--strict on cron)
         # Cron-only escalation of the advisory PR-time check. Fails if
         # pip-freeze.gpu.txt has drifted from scripts/data/colab_*.txt --

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -144,10 +144,16 @@ jobs:
           python unsloth/scripts/notebook_validator.py colab-diff \
               --snapshot-dir unsloth/scripts/data
 
-      - name: Refresh Colab pip-freeze (best-effort; falls back to snapshot)
+      - name: Refresh Colab oracles (best-effort; falls back to snapshot)
+        # --all, not just pip-freeze: marker evaluation reads the Python version out of
+        # colab_os_info.gpu.txt, so refreshing the package set on its own would judge the
+        # live packages against the previous image's Python after a Colab version rotation,
+        # skipping requirements that apply or replaying ones that do not. --all writes
+        # nothing unless it fetched every oracle, so the fallback is the committed pair,
+        # which is at least self-consistent.
         run: |
           python unsloth/scripts/notebook_validator.py refresh-colab \
-              --out unsloth/scripts/data/colab_pip_freeze.gpu.txt \
+              --all --snapshot-dir unsloth/scripts/data \
             || echo "::warning::refresh-colab failed; using committed snapshot"
 
       - name: Drift check (re-run update_all_notebooks.py + git diff)

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -26,6 +26,9 @@ on:
       - 'scripts/notebook_validator.py'
       - 'scripts/notebook_to_python.py'
       - 'scripts/data/colab_pip_freeze.gpu.txt'
+      # Rule-bearing since _marker_environment started reading the image's Python out of it:
+      # an OS-only rotation changes which requirements the validator replays.
+      - 'scripts/data/colab_os_info.gpu.txt'
       - 'scripts/data/colab_to_cpu_pin.json'
       - 'tests/notebooks/**'
       - 'tests/_zoo_aggressive_cuda_spoof.py'

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -428,8 +428,10 @@ _INTERPRETER_RE = r"""(?:
       | '(?:[^']*[/\\])python[0-9.]*(?:\.exe)?'
       | \S*[/\\]python[0-9.]*(?:\.exe)?
     )"""
+# `-m uv pip` as well as `-m pip`: unsloth_nb_pip_magic rewrites `(pip|uv)` after the
+# module flag, and uv's pip-compatible interface really is spelled `uv pip <action>`.
 PIP_LINE_RE = re.compile(
-    r"^\s*!\s*(?P<tool>(?:uv\s+)?pip|" + _INTERPRETER_RE + r"\s+-m\s+pip)\s+"
+    r"^\s*!\s*(?P<tool>(?:uv\s+)?pip|" + _INTERPRETER_RE + r"\s+-m\s+(?:uv\s+)?pip)\s+"
     r"(?P<action>install|uninstall)\b(?P<rest>.*)$",
     re.IGNORECASE | re.VERBOSE,
 )
@@ -453,9 +455,9 @@ def parse_pip_line(line: str, line_no: int = 0) -> PipInvocation | None:
     m = PIP_LINE_RE.match(line)
     if not m:
         return None
-    # startswith, not `in`: `python3 -m pip` must not be read as uv because of a stray
-    # substring, and only the uv form can begin with it.
-    tool = "uv-pip" if m.group("tool").lower().startswith("uv") else "pip"
+    # `uv pip` and `python -m uv pip` are both uv; a plain `python3 -m pip` is not, and
+    # must not be read as uv because "uv" appears somewhere in the interpreter path.
+    tool = "uv-pip" if re.search(r"(?:^|\s)uv\s+pip\b", m.group("tool"), re.IGNORECASE) else "pip"
     rest = m.group("rest")
     # Strip trailing comment.
     rest = re.split(r"(?<!\S)#", rest, maxsplit = 1)[0]

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -479,8 +479,24 @@ _ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_]\w*=")
 _PREFIX_OPERAND_FLAGS: dict[str, frozenset[str]] = {
     "env": frozenset({"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}),
     "sudo": frozenset(
-        {"-u", "--user", "-g", "--group", "-p", "--prompt", "-C", "--close-from",
-         "-r", "--role", "-t", "--type", "-U", "--other-user", "-h", "--host"}
+        {
+            "-u",
+            "--user",
+            "-g",
+            "--group",
+            "-p",
+            "--prompt",
+            "-C",
+            "--close-from",
+            "-r",
+            "--role",
+            "-t",
+            "--type",
+            "-U",
+            "--other-user",
+            "-h",
+            "--host",
+        }
     ),
     "exec": frozenset({"-a"}),
     "time": frozenset({"-f", "--format", "-o", "--output"}),
@@ -531,6 +547,8 @@ def _strip_exec_prefixes(text: str) -> tuple[str, bool]:
                 rest = tail
         text = rest
     return text, prefixed
+
+
 _PIP_WORD_RE = re.compile(r"(?:^|\s)((?:uv\s+)?pip|python[0-9.]*\s+-m\s+pip)\s+", re.IGNORECASE)
 
 _SHELL_TEST_KEYWORDS = frozenset({"if", "while", "until", "for", "case"})

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -198,13 +198,21 @@ COLAB_ORACLE_FILES: dict[str, str] = {
 # what R-INST-002/003/004/005 resolve against. apt-list drift is reported but never fails,
 # otherwise an Ubuntu security bump nothing can consult turns the daily cron red.
 #
-# os-info is no longer purely human context, though it still does not fail --strict:
-# _marker_environment reads its Python version to decide which requirements pip would skip.
-# It therefore has to be refreshed WITH the pip snapshot, never on its own -- markers
-# evaluated at an old Python against a freshly pulled package set can skip a requirement
-# that applies to the live image, or replay one that does not. notebooks-ci.yml refreshes
-# both together via `refresh-colab --all` for that reason.
+# os-info is no longer purely human context: _marker_environment reads its Python version to
+# decide which requirements pip would skip. It therefore has to be refreshed WITH the pip
+# snapshot, never on its own -- markers evaluated at an old Python against a freshly pulled
+# package set can skip a requirement that applies to the live image, or replay one that does
+# not. notebooks-ci.yml refreshes both together via `refresh-colab --all` for that reason,
+# and COLAB_STRICT_ORACLE_KEYS makes the Python line alone fail --strict, so a Colab
+# interpreter bump cannot sit uncommitted behind an unchanged pip freeze. The rest of
+# os-info, and all of apt-list, stay advisory: an Ubuntu bump nothing can consult must not
+# turn the daily cron red.
 COLAB_STRICT_ORACLE = "pip-freeze.gpu.txt"
+# Keys within a non-strict oracle that are rule-bearing anyway. `python` is the one
+# _parse_os_lines emits for the "Python 3.13.15" line.
+COLAB_STRICT_ORACLE_KEYS: dict[str, frozenset[str]] = {
+    "os-info-gpu.txt": frozenset({"python"}),
+}
 COLAB_ORACLE_BASE_URL = "https://raw.githubusercontent.com/googlecolab/backend-info/main/"
 
 # ----- Compat tables. PRs add rows as new releases land. ----- #
@@ -399,8 +407,12 @@ class PipInvocation:
     conditional: bool = False  # the fallback side of an `||`: runs only if the left failed
 
 
+# `python -m pip` is pip's own recommended invocation, so it has to parse to the same
+# thing as bare `pip`. Without it a cell still matched _PIP_CELL_RE, yielded no
+# invocation, and R-INST-001 missed a prohibited `git+` install outright.
 PIP_LINE_RE = re.compile(
-    r"^\s*!\s*(?P<tool>(?:uv\s+)?pip)\s+(?P<action>install|uninstall)\b(?P<rest>.*)$",
+    r"^\s*!\s*(?P<tool>(?:uv\s+)?pip|python[0-9.]*\s+-m\s+pip)\s+"
+    r"(?P<action>install|uninstall)\b(?P<rest>.*)$",
     re.IGNORECASE,
 )
 NON_PKG_FLAG_TAKES_VAL = {
@@ -423,7 +435,9 @@ def parse_pip_line(line: str, line_no: int = 0) -> PipInvocation | None:
     m = PIP_LINE_RE.match(line)
     if not m:
         return None
-    tool = "uv-pip" if "uv" in m.group("tool") else "pip"
+    # startswith, not `in`: `python3 -m pip` must not be read as uv because of a stray
+    # substring, and only the uv form can begin with it.
+    tool = "uv-pip" if m.group("tool").lower().startswith("uv") else "pip"
     rest = m.group("rest")
     # Strip trailing comment.
     rest = re.split(r"(?<!\S)#", rest, maxsplit = 1)[0]
@@ -568,8 +582,6 @@ def _strip_exec_prefixes(text: str) -> tuple[str, bool]:
         text = rest
     return text, prefixed
 
-
-_PIP_WORD_RE = re.compile(r"(?:^|\s)((?:uv\s+)?pip|python[0-9.]*\s+-m\s+pip)\s+", re.IGNORECASE)
 
 _SHELL_TEST_KEYWORDS = frozenset({"if", "while", "until", "for", "case"})
 _SHELL_BODY_KEYWORDS = frozenset({"then", "elif", "else", "do"})
@@ -1961,12 +1973,15 @@ def cmd_lint(args: argparse.Namespace) -> int:
         # Whole-notebook rules: install steps may span multiple cells, so merge
         # before resolving compat against Colab.
         merged = "\n".join(c for _, c in cells)
-        # A cell can look like an install and contain none -- `!echo "pip install foo"` matches
-        # _PIP_CELL_RE but runs no pip. The compat rules then resolve nothing and compare the
-        # bare oracle against itself, so any finding describes the base image rather than the
-        # notebook (R-INST-003 fires on Colab's own peft/torchao pair). A notebook with no
-        # install cell at all is already skipped; this makes the lookalike behave the same.
-        if not any(True for _ in iter_pip_invocations(merged)):
+        # A cell can look like an install and resolve nothing -- `!echo "pip install foo"`
+        # matches _PIP_CELL_RE but runs no pip, and `!command -v uv || pip install foo` runs
+        # pip only on the fallback side. The compat rules replay UNCONDITIONAL invocations
+        # only, so in both cases they compare the bare oracle against itself and any finding
+        # describes the base image rather than the notebook (R-INST-003 fires on Colab's own
+        # peft/torchao pair). A notebook with no install cell at all is already skipped; this
+        # makes both lookalikes behave the same. R-INST-001 still sees the conditional path:
+        # it runs per cell above, before this gate.
+        if not any(True for _ in unconditional_pip_invocations(merged)):
             merged = ""
         if env == "colab" and merged:
             first_cell = cells[0][0] if cells else None
@@ -2198,7 +2213,19 @@ def cmd_colab_diff(args: argparse.Namespace) -> int:
             print("  no drift")
             continue
         any_diff = True
-        strict_diff = strict_diff or upstream_name == COLAB_STRICT_ORACLE
+        strict_keys = COLAB_STRICT_ORACLE_KEYS.get(upstream_name, frozenset())
+        drifted_strict_keys = sorted(
+            strict_keys.intersection(
+                [k for k, _ in new] + [k for k, _ in removed] + [k for k, _, _ in changed]
+            )
+        )
+        if upstream_name == COLAB_STRICT_ORACLE:
+            strict_diff = True
+        elif drifted_strict_keys:
+            strict_diff = True
+            print(
+                f"  (rule-bearing key drifted: {', '.join(drifted_strict_keys)})"
+            )
         for k, v in new[:50]:
             print(f"  NEW      {k}=={v}")
         if len(new) > 50:
@@ -2213,8 +2240,8 @@ def cmd_colab_diff(args: argparse.Namespace) -> int:
             print(f"  ...and {len(changed) - 80} more changed entries")
     if strict_diff and args.strict:
         print(
-            f"\n::error::Colab oracle {COLAB_STRICT_ORACLE} drifted from its "
-            "committed snapshot; run `notebook_validator.py refresh-colab --all "
+            "\n::error::A rule-bearing Colab oracle drifted from its committed "
+            "snapshot; run `notebook_validator.py refresh-colab --all "
             "--snapshot-dir scripts/data` to acknowledge.",
             file = sys.stderr,
         )

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -85,17 +85,14 @@ COLAB_FALLBACK_FILE = DATA_DIR / "colab_pip_freeze.gpu.txt"
 # subcommand surfaces NEW/REMOVED/CHANGED entries so upstream Colab base
 # image rotations land in CI within ~24h, giving R-INST-002/003/004/005
 # earlier signal.
-# The image's Python, read from the os-info oracle beside the pip freeze ("Python 3.13.15").
-# Only used to evaluate PEP 508 markers, so an unreadable or absent snapshot just means no
-# marker is evaluated and every requirement is replayed, which is the older behaviour.
+# The image's Python, from the os-info oracle ("Python 3.13.15"). Only used for PEP 508
+# markers, so an unreadable snapshot just replays every requirement, as before.
 _COLAB_OS_INFO_FILE = DATA_DIR / "colab_os_info.gpu.txt"
 _COLAB_PYTHON_RE = re.compile(r"^Python\s+(\d+\.\d+(?:\.\d+)?)", re.MULTILINE)
 
 
-# Directory the OS oracle is read from. Follows `lint --colab-pin` so the Python version
-# and the package snapshot always come from the SAME capture: a pin outside scripts/data
-# paired with this repo's committed os-info would evaluate markers against a different
-# image's interpreter than the packages being judged.
+# Follows `lint --colab-pin` so the Python version and the package snapshot come from the
+# SAME capture; otherwise markers are judged against a different image's interpreter.
 _COLAB_ORACLE_DIR: pathlib.Path = DATA_DIR
 
 
@@ -134,18 +131,15 @@ def _marker_environment(colab: dict[str, str]) -> dict[str, str] | None:
         "platform_system": "Linux",
         "platform_machine": "x86_64",
         "os_name": "posix",
-        # A requirement handed straight to pip is not being evaluated for a selected extra,
-        # so `extra` has the known empty value and any `extra == "..."` marker is false.
-        # Omitting it made _requirement_applies replay requirements pip discards, e.g.
-        # `pip install "torch==2.12.0; extra == 'foo'"`, which pip reports as
-        # `Ignoring torch: markers 'extra == "foo"' don't match your environment`.
+        # A top-level requirement is not evaluated for a selected extra, so `extra` is
+        # empty and any `extra == "..."` marker is false. Omitting it replayed requirements
+        # pip reports as `Ignoring torch: markers ... don't match your environment`.
         "extra": "",
     }
 
 
-# PEP 508 names a fixed set of marker variables. `Marker.evaluate` fills any field the given
-# environment omits from the running process, so a marker naming one of these would be judged
-# against this machine rather than the image and the answer would move between runners.
+# `Marker.evaluate` fills any omitted field from the RUNNING process, so a marker naming one
+# of these would be judged against this machine and the answer would move between runners.
 _MARKER_VARIABLES = frozenset(
     {
         "os_name",
@@ -194,19 +188,11 @@ COLAB_ORACLE_FILES: dict[str, str] = {
     "apt-list-gpu.txt": "colab_apt_list.gpu.txt",
     "os-info-gpu.txt": "colab_os_info.gpu.txt",
 }
-# The pip oracle is the one that fails --strict: `lint --colab-pin` reads it, and that is
-# what R-INST-002/003/004/005 resolve against. apt-list drift is reported but never fails,
-# otherwise an Ubuntu security bump nothing can consult turns the daily cron red.
-#
-# os-info is no longer purely human context: _marker_environment reads its Python version to
-# decide which requirements pip would skip. It therefore has to be refreshed WITH the pip
-# snapshot, never on its own -- markers evaluated at an old Python against a freshly pulled
-# package set can skip a requirement that applies to the live image, or replay one that does
-# not. notebooks-ci.yml refreshes both together via `refresh-colab --all` for that reason,
-# and COLAB_STRICT_ORACLE_KEYS makes the Python line alone fail --strict, so a Colab
-# interpreter bump cannot sit uncommitted behind an unchanged pip freeze. The rest of
-# os-info, and all of apt-list, stay advisory: an Ubuntu bump nothing can consult must not
-# turn the daily cron red.
+# The pip oracle fails --strict: `lint --colab-pin` reads it and R-INST-002/003/004/005
+# resolve against it. os-info is rule-bearing too now, since _marker_environment reads its
+# Python line, so the two must be refreshed TOGETHER (`refresh-colab --all`) and
+# COLAB_STRICT_ORACLE_KEYS makes that one line fail --strict. Everything else stays
+# advisory: an Ubuntu bump nothing can consult must not turn the daily cron red.
 COLAB_STRICT_ORACLE = "pip-freeze.gpu.txt"
 # Keys within a non-strict oracle that are rule-bearing anyway. `python` is the one
 # _parse_os_lines emits for the "Python 3.13.15" line.
@@ -311,9 +297,8 @@ def code_cells(nb: dict[str, Any]) -> list[tuple[int, str]]:
     return out
 
 
-# A shell line that runs pip somewhere in it. Anchored on the `!` so a `pip install` inside a
-# Python string is not a cell, and open after it so a chained or compound command is:
-# `!echo start; pip install x` and `!if ...; then pip install x; fi` both install.
+# A shell line that runs pip somewhere in it. Anchored on `!` so a `pip install` inside a
+# Python string is not a cell, open after it so chained and compound commands are.
 _PIP_CELL_RE = re.compile(r"^[ \t]*!.*\b(?:uv\s+)?pip\s+(?:install|uninstall)\b", re.MULTILINE)
 
 
@@ -413,14 +398,11 @@ class PipInvocation:
     conditional: bool = False  # the fallback side of an `||`: runs only if the left failed
 
 
-# `python -m pip` is pip's own recommended invocation, so it has to parse to the same
-# thing as bare `pip`. Without it a cell still matched _PIP_CELL_RE, yielded no
-# invocation, and R-INST-001 missed a prohibited `git+` install outright.
-# The interpreter spellings `python -m pip` really appears under. Kept in step with
-# docker/unsloth_nb_pip_magic.py::_PY_M_PIP, which rewrites the same forms at runtime: a
-# notebook the shim handles must not be one the validator reads as running no pip at all.
-# Transformers see the RAW cell text (IPython expands `{sys.executable}` later), so the
-# braced form and quoted or bare interpreter paths have to be matched here too.
+# `python -m pip` is pip's own recommended invocation and must parse the same as bare `pip`;
+# without it a cell matched _PIP_CELL_RE, yielded nothing, and R-INST-001 missed a `git+`
+# install. Interpreter spellings kept in step with unsloth_nb_pip_magic.py::_PY_M_PIP, which
+# rewrites the same forms at runtime. Transformers see the RAW text (IPython expands
+# `{sys.executable}` later), so the braced and path forms are matched here too.
 _INTERPRETER_RE = r"""(?:
         (?:python[0-9.]*|py)
       | ["']?\{\s*sys\.executable\s*\}["']?
@@ -525,11 +507,9 @@ def _glue_line_continuations(text: str) -> list[tuple[int, str]]:
 # `env FOO=1 pip install ...` install exactly as a bare `pip install ...` does.
 _SHELL_EXEC_PREFIXES = frozenset({"command", "env", "exec", "nohup", "time", "sudo", "builtin"})
 _ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_]\w*=")
-# Per prefix, the options that take a SEPARATE operand. Everything else starting with `-` is
-# a flag on its own and `--` ends the options. This table is what tells a prefix's operand
-# apart from the command it runs: in `env -u pip pip install ...` the first `pip` is the
-# variable being unset and the second is the executable, so searching for the first
-# pip-looking word picks the operand and the line stops parsing as pip at all.
+# Per prefix, the options taking a SEPARATE operand; everything else starting with `-` is a
+# lone flag and `--` ends them. This is what tells a prefix's operand from the command it
+# runs: in `env -u pip pip install ...` the first `pip` is the variable being unset.
 _PREFIX_OPERAND_FLAGS: dict[str, frozenset[str]] = {
     "env": frozenset({"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}),
     "sudo": frozenset(
@@ -693,14 +673,12 @@ def _unwrap_shell_group(command: str) -> tuple[str, bool]:
     bang = stripped.startswith("!")
     if bang:
         stripped = stripped[1:].lstrip()
-    # A grouping bracket is noise and has to go, but the `)` that closes a `$( )` belongs to
-    # the command: a bare rstrip(")}") ate it, so `x) echo $(pip install ...)` came back as
-    # `echo $(pip install ...` and _substitution_bodies could no longer read the body out.
+    # A grouping bracket is noise, but the `)` closing a `$( )` belongs to the command: a
+    # bare rstrip(")}") left `echo $(pip install ...` unreadable to _substitution_bodies.
     # A piece can also be a lone `}` when a group spans a separator, which still strips.
-    # `{` opens a shell group only as its OWN token (POSIX reserved word), so `{ pip
-    # install x; }` is a group while IPython's `{sys.executable}` is a single word that
-    # expands to an interpreter path. Stripping it unconditionally left `sys.executable}`
-    # as the executable and hid the pip command behind it. `(` needs no such space.
+    # `{` opens a shell group only as its OWN token, so `{ pip install x; }` is a group while
+    # IPython's `{sys.executable}` is one word. Stripping it always left `sys.executable}` as
+    # the executable and hid the pip command. `(` needs no such space.
     while stripped:
         if stripped[0] == "(":
             stripped = stripped[1:].lstrip()
@@ -720,10 +698,8 @@ def _unwrap_shell_group(command: str) -> tuple[str, bool]:
             break
         conditional = conditional or parts[0].lower() in _SHELL_BODY_KEYWORDS
         stripped = parts[1].strip() if len(parts) > 1 else ""
-    # A `case` arm label: `x in x) pip install ...`, a quoted `"x") ...`, and the bare
-    # `b) pip install ...` of a later arm. Only the matching arm runs, so the command is
-    # conditional. The label ends at the first unquoted `)` with nothing open before it; a `)`
-    # inside quotes or inside a `$( )` belongs to the command.
+    # A `case` arm label, quoted or bare. Only the matching arm runs, so the command is
+    # conditional. The label ends at the first unquoted `)` with nothing open before it.
     close = _unquoted_arm_close(stripped)
     if close is not None:
         stripped = stripped[close + 1 :].strip()
@@ -826,10 +802,8 @@ def _split_chained(line: str) -> list[tuple[str, bool]]:
     # inside a word, so a `#` after it is a literal, not a comment.
     groupings: list[bool] = []
     grouping_closed = False
-    # An open legacy `` `...` `` substitution. Backticks run their contents the way `$( )`
-    # does, so the operators inside one are the inner command's, not this line's. Without
-    # this the `;` in ``echo `pip install git+...; echo ok` `` split the line and left
-    # `_substitution_bodies` an unmatched fragment it could not read at all.
+    # An open legacy `` `...` `` substitution: its operators belong to the inner command, so
+    # without this the `;` inside one split the line into an unreadable fragment.
     in_backtick = False
     i = 0
 
@@ -909,11 +883,9 @@ def _split_chained(line: str) -> list[tuple[str, bool]]:
             i += 1
         else:
             if ch in "({":
-                # `$(`, `<(` and `>(` open a substitution, which lives inside a word and runs
-                # its own commands; a bare `(` groups this line's. `${ }` is a parameter
-                # expansion, which runs nothing at all: the `||` in `${X:-a||pip install ...}`
-                # is part of the fallback WORD, so splitting there manufactures a pip command
-                # bash never runs and R-INST-001 rejects a clean notebook over it.
+                # `$(`, `<(`, `>(` open a substitution running its own commands; a bare `(`
+                # groups this line's. `${ }` expands a WORD and runs nothing, so splitting on
+                # the `||` in `${X:-a||pip install ...}` invents a command bash never runs.
                 groupings.append(
                     not (
                         (ch == "(" and buf and buf[-1] in "$<>")
@@ -936,17 +908,16 @@ def _split_chained(line: str) -> list[tuple[str, bool]]:
     flush()
     (head, head_conditional), *rest = out
     head_text, head_keyword = _unwrap_shell_group(head)
-    # One entry per piece in `out`, empties included. Dropping them here and then zipping
-    # against `out` slid every later pair by one and cut the tail off at the shorter list,
-    # so a `case` -- which emits an empty piece per `;;`, and whose `esac` unwraps to ""
-    # -- left its last arms unscanned entirely. The empties are filtered after the pairing.
+    # One entry per piece in `out`, empties included: dropping them before the zip slid every
+    # later pair by one and cut the tail, leaving a `case`'s last arms unscanned. Filtered
+    # after the pairing instead.
     commands = [(head_text, head_conditional or head_keyword)]
     for piece, flag in rest:
         text, keyword = _unwrap_shell_group(piece.strip())
         commands.append((f"!{text}" if text else "", flag or keyword))
-    # `echo $(pip install x)` runs the install as surely as the echo, and the outer command is
-    # not pip, so the inner one has to be a command of its own. Read off the raw pieces: an
-    # assignment prefix like ``X=`pip install y` `` is stripped by the unwrap above.
+    # `echo $(pip install x)` runs the install, and the outer command is not pip, so the
+    # inner one is a command of its own. Read off the raw pieces, since the unwrap above
+    # strips an assignment prefix like ``X=`pip install y` ``.
     ordered: list[tuple[str, bool]] = []
     for (piece, flag), (text, command_flag) in zip(out, commands):
         for inner in _substitution_bodies(piece):
@@ -1145,8 +1116,8 @@ def _git_source_repository(source: str) -> str:
     path = path.split("@", 1)[0].rstrip("/")  # drop a trailing @ref
     if path.endswith(".git"):
         path = path[: -len(".git")]
-    # Resolve `.` and `..` the way a URL client does, or
-    # `github.com/unslothai/unsloth/../../attacker/repo` reads as an allowlisted prefix.
+    # Resolve `.` and `..` as a URL client does, or `unslothai/unsloth/../../attacker/repo`
+    # reads as an allowlisted prefix.
     segments: list[str] = []
     for segment in path.split("/"):
         if segment in ("", "."):
@@ -1291,9 +1262,9 @@ def _compatible_release_ceiling(version: str) -> str | None:
     return ".".join(head)
 
 
-# pip takes `<archive url/path>` as an install target and parse_spec skips anything with a
-# `://`, so a wheel that replaces the package reads as no install at all. The version sits in
-# the filename: PEP 427 puts it in the second `-` field.
+# pip takes an archive URL or path as an install target and parse_spec skips anything with a
+# `://`, so a wheel reads as no install at all. PEP 427 puts the version in the second
+# `-` field of the filename.
 _ARCHIVE_RE = re.compile(
     r"(?P<name>[A-Za-z0-9._-]+?)-(?P<version>\d[^-]*?)(?:-.*)?\.(?:whl|tar\.gz|zip)$",
     re.IGNORECASE,
@@ -1522,9 +1493,8 @@ def _effective_version(
             current = None  # removed; a later install can put it back
             continue
         if not pins and not replaced_unnamed and _forces_resolution(inv.flags):
-            # A bare name with any of these takes whatever the index offers: none of them let
-            # the installed version satisfy the requirement, so it is not what the cell ends
-            # on, and nothing here names what does.
+            # A bare name with any of these takes whatever the index offers, and nothing
+            # here names which release that is.
             current, exact_known = None, True
             continue
         if replaced_unnamed:
@@ -1534,22 +1504,18 @@ def _effective_version(
         # Where an install lands when it has to move, or None when nothing names it.
         landing = floor if _window_names_one_minor(floor, ceiling, cap) else None
         if landing is None and ceiling is not None:
-            # A wider window still names the MINOR pip moves to, which is the granularity the
-            # callers compare on. Without this a bare `<0.10.5`, or `>=0.8,<0.11`, came back
-            # unknown and R-INST-004 skipped a mismatch it can see.
+            # A wider window still names the MINOR pip moves to, which is what the callers
+            # compare; without it `<0.10.5` and `>=0.8,<0.11` came back unknown.
             below = _highest_minor_below(ceiling)
             if below and (floor is None or cmp_versions(below, floor) >= 0):
                 landing = below
         if exact is not None:
             current, exact_known = exact, True
         elif current is None:
-            # Absent, so the install puts it there, and the question is only where. A `<=V`
-            # names it exactly: pip takes the highest release the requirement allows, which
-            # is V. Treating a cap-only requirement as "still absent" was a miss, since
-            # `pip uninstall torchcodec` then `pip install "torchcodec<=0.10"` really does
-            # leave 0.10 installed. A floor alone says at least how low it can be. An
-            # exclusive ceiling names nothing, because which release sits just below it
-            # depends on the index.
+            # Absent, so the install puts it there and the only question is where. `<=V`
+            # names it exactly (pip takes the highest release allowed), a floor says at
+            # least how low, and an exclusive ceiling names nothing: which release sits
+            # just below it is only in the index.
             if cap is not None:
                 current, exact_known = cap, True
             elif floor is not None and not exclusive_floor:
@@ -1571,12 +1537,10 @@ def _effective_version(
             current, exact_known = cap, True  # `<=V` allows V, so V is what pip picks
         elif ceiling is not None and cmp_versions(current, ceiling) >= 0:
             current, exact_known = landing, True
-        # Whatever the requirement leaves in place still has to satisfy its own exclusions,
-        # which covers the version that was already installed and the one just landed on.
+        # Whatever is left still has to satisfy the requirement's own exclusions.
         if current is not None and any(_version_is_excluded(current, ver) for ver in exclusions):
-            # A window that pins one minor still pins it: `>=0.11,<0.12,!=0.11.0` moves off
-            # 0.11.0 and stays in the 0.11 line, and the minor is what the callers compare.
-            # Only an exclusion covering the whole minor takes that away.
+            # `>=0.11,<0.12,!=0.11.0` moves off 0.11.0 and stays in the 0.11 line, so only
+            # an exclusion covering the whole minor takes the landing away.
             if landing is not None and not any(
                 _exclusion_covers_minor(landing, ver) for ver in exclusions
             ):
@@ -1633,8 +1597,8 @@ def rule_inst_004_torchcodec_torch(
     # to 2.11), so that half of the matrix is open-ended and cannot be a finite set of minors.
     # Without this, adding the 2.11 row below would flag torch 2.11 with torchcodec 0.12
     # through 0.15, all of which upstream supports, and R-INST-004 is an error.
-    # An inexact version is a floor: everything at or above it is possible. That is enough for
-    # the ABI check, which only asks whether both sides clear a floor of their own.
+    # An inexact version is a floor, which is enough for a check that only asks whether both
+    # sides clear a floor of their own.
     if (
         cmp_versions(torch_v, TORCHCODEC_ABI_STABLE_TORCH) >= 0
         and cmp_versions(codec_v, TORCHCODEC_ABI_STABLE_CODEC) >= 0
@@ -1839,11 +1803,9 @@ def rule_l12_exceptions_coverage(notebooks_dir: pathlib.Path) -> list[Finding]:
             continue
         nb = load_notebook(path)
         for idx, cell in install_cells(nb):
-            # install_cells is a text heuristic, so a documentation-only line such as
-            # `!echo "pip install peft"` reaches here running no pip at all. `applies` then
-            # sees the package name in the prose and demands a policy clause the notebook
-            # has no install to carry, which is a blocking R-EXC-001. cmd_lint gates on a
-            # parsed invocation for the same reason; this path had no such gate.
+            # install_cells is a text heuristic, so `!echo "pip install peft"` reaches here
+            # running no pip; `applies` then sees the name in the prose and demands a clause
+            # the notebook has no install to carry. cmd_lint has the same gate.
             if not any(True for _ in iter_pip_invocations(cell)):
                 continue
             for cid, pat, applies in clauses:
@@ -2037,14 +1999,12 @@ def cmd_lint(args: argparse.Namespace) -> int:
         # Whole-notebook rules: install steps may span multiple cells, so merge
         # before resolving compat against Colab.
         merged = "\n".join(c for _, c in cells)
-        # A cell can look like an install and resolve nothing -- `!echo "pip install foo"`
-        # matches _PIP_CELL_RE but runs no pip, and `!command -v uv || pip install foo` runs
-        # pip only on the fallback side. The compat rules replay UNCONDITIONAL invocations
-        # only, so in both cases they compare the bare oracle against itself and any finding
-        # describes the base image rather than the notebook (R-INST-003 fires on Colab's own
-        # peft/torchao pair). A notebook with no install cell at all is already skipped; this
-        # makes both lookalikes behave the same. R-INST-001 still sees the conditional path:
-        # it runs per cell above, before this gate.
+        # A cell can look like an install and resolve nothing: `!echo "pip install foo"`
+        # runs no pip, and `!command -v uv || pip install foo` runs it only on the fallback
+        # side. The compat rules replay UNCONDITIONAL invocations, so both would compare the
+        # oracle against itself and report the base image (R-INST-003 fires on Colab's own
+        # peft/torchao pair). R-INST-001 still sees the conditional path: it runs per cell,
+        # before this gate.
         if not any(True for _ in unconditional_pip_invocations(merged)):
             merged = ""
         if env == "colab" and merged:

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import argparse
 import ast
 import dataclasses
+import functools
 import json
 import os
 import pathlib
@@ -45,6 +46,7 @@ import tempfile
 import textwrap
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, Iterable, Iterator
 
@@ -79,22 +81,108 @@ COLAB_PIP_FREEZE_URL = (
 )
 COLAB_FALLBACK_FILE = DATA_DIR / "colab_pip_freeze.gpu.txt"
 
-# Oracle files snapshotted from googlecolab/backend-info.
-# The colab-diff subcommand surfaces NEW/REMOVED/CHANGED entries so upstream Colab base image rotations land in CI
-# within ~24h, giving R-INST-002/003/004/005 earlier signal.
+# Oracle files snapshotted from googlecolab/backend-info. The colab-diff
+# subcommand surfaces NEW/REMOVED/CHANGED entries so upstream Colab base
+# image rotations land in CI within ~24h, giving R-INST-002/003/004/005
+# earlier signal.
+# The image's Python, read from the os-info oracle beside the pip freeze ("Python 3.13.15").
+# Only used to evaluate PEP 508 markers, so an unreadable or absent snapshot just means no
+# marker is evaluated and every requirement is replayed, which is the older behaviour.
+_COLAB_OS_INFO_FILE = DATA_DIR / "colab_os_info.gpu.txt"
+_COLAB_PYTHON_RE = re.compile(r"^Python\s+(\d+\.\d+(?:\.\d+)?)", re.MULTILINE)
+
+
+@functools.lru_cache(maxsize = 1)
+def _colab_python_version() -> str | None:
+    try:
+        text = _COLAB_OS_INFO_FILE.read_text(encoding = "utf-8")
+    except OSError:
+        return None
+    match = _COLAB_PYTHON_RE.search(text)
+    return match.group(1) if match else None
+
+
+def _marker_environment(colab: dict[str, str]) -> dict[str, str] | None:
+    """The environment PEP 508 markers are evaluated against, or None to skip them.
+
+    Only for notebooks resolved against the Colab image, since that is the one environment
+    this can name. Everything else replays every requirement, as before.
+    """
+    if not colab:
+        return None
+    full = _colab_python_version()
+    if not full:
+        return None
+    parts = full.split(".")
+    return {
+        "python_version": ".".join(parts[:2]),
+        "python_full_version": full if len(parts) > 2 else f"{full}.0",
+        "sys_platform": "linux",
+        "platform_system": "Linux",
+        "platform_machine": "x86_64",
+        "os_name": "posix",
+    }
+
+
+# PEP 508 names a fixed set of marker variables. `Marker.evaluate` fills any field the given
+# environment omits from the running process, so a marker naming one of these would be judged
+# against this machine rather than the image and the answer would move between runners.
+_MARKER_VARIABLES = frozenset(
+    {
+        "os_name",
+        "sys_platform",
+        "platform_machine",
+        "platform_python_implementation",
+        "platform_release",
+        "platform_system",
+        "platform_version",
+        "python_version",
+        "python_full_version",
+        "implementation_name",
+        "implementation_version",
+        "extra",
+    }
+)
+
+
+def _requirement_applies(raw: str, environment: dict[str, str] | None) -> bool:
+    """False only when the requirement carries a marker that is false for `environment`.
+
+    pip skips such a requirement outright, so replaying its bounds moves a version the cell
+    never touches. An unparseable marker, a missing `packaging`, or no environment to judge
+    against all mean the requirement is replayed.
+    """
+    if environment is None or ";" not in raw:
+        return True
+    marker_text = raw.split(";", 1)[1].strip()
+    if not marker_text:
+        return True
+    # Outside the string literals: `sys_platform == 'platform_release'` references one
+    # variable, not two.
+    bare = re.sub(r"\"[^\"]*\"|'[^']*'", " ", marker_text)
+    named = set(re.findall(r"[A-Za-z_]\w*", bare)) & _MARKER_VARIABLES
+    if not named or named - environment.keys():
+        return True  # nothing to judge on, or a field the oracle cannot answer for
+    try:
+        from packaging.markers import Marker
+        return bool(Marker(marker_text).evaluate(environment))
+    except Exception:
+        return True
+
+
 COLAB_ORACLE_FILES: dict[str, str] = {
     "pip-freeze.gpu.txt": "colab_pip_freeze.gpu.txt",
     "apt-list-gpu.txt": "colab_apt_list.gpu.txt",
     "os-info-gpu.txt": "colab_os_info.gpu.txt",
 }
-# Only the pip oracle feeds a rule: `lint --colab-pin` reads it, and that is what R-INST-002/003/004/005 resolve
-# against. apt-list / os-info are human context (what else the image ships), so their drift is reported but never
-# fails --strict -- otherwise an Ubuntu security bump nothing can consult turns the daily cron red.
+# Only the pip oracle feeds a rule: `lint --colab-pin` reads it, and that is
+# what R-INST-002/003/004/005 resolve against. apt-list / os-info are human
+# context (what else the image ships), so their drift is reported but never
+# fails --strict -- otherwise an Ubuntu security bump nothing can consult
+# turns the daily cron red.
 COLAB_STRICT_ORACLE = "pip-freeze.gpu.txt"
 COLAB_ORACLE_BASE_URL = "https://raw.githubusercontent.com/googlecolab/backend-info/main/"
 
-
-# torch.minor -> compatible torchcodec.minor strings. Source: pytorch/torchcodec README compatibility matrix.
 # ----- Compat tables. PRs add rows as new releases land. ----- #
 
 # Lockstep rows only: torchcodec 0.12+ is ABI-stable against torch >=2.11 and is handled by
@@ -102,6 +190,9 @@ COLAB_ORACLE_BASE_URL = "https://raw.githubusercontent.com/googlecolab/backend-i
 TORCHCODEC_ABI_STABLE_TORCH = "2.11"
 TORCHCODEC_ABI_STABLE_CODEC = "0.12"
 
+# torch.minor -> set of compatible torchcodec.minor strings.
+# Source: pytorch/torchcodec compatibility matrix on its README.
+# Mirrors import_fixes._TORCH_TORCHCODEC_MINORS (test_torchcodec_torch_compat asserts equality).
 TORCH_TORCHCODEC: dict[str, set[str]] = {
     "2.11": {"0.11"},
     "2.10": {"0.10"},
@@ -112,13 +203,17 @@ TORCH_TORCHCODEC: dict[str, set[str]] = {
     "2.5": {"0.1"},
 }
 
+# torchcodec 0.12+ is ABI-stable against torch >=2.11, so that half is open-ended.
+TORCHCODEC_ABI_STABLE_TORCH = "2.11"
+TORCHCODEC_ABI_STABLE_CODEC = "0.12"
+
 # When peft >= trigger is on the resolved set, torchao >= floor must also be.
 PEFT_TORCHAO_FLOOR: list[dict[str, str]] = [
     {"trigger_peft": "0.19", "torchao_floor": "0.16.0"},
 ]
 
-# git+ allowlist: install lines that legitimately fetch from GitHub.
-# Anything else flags R-INST-001.
+# git+ allowlist: install lines that legitimately fetch from GitHub. Anything
+# else flags R-INST-001.
 GIT_PLUS_ALLOWLIST = (
     "github.com/SparkAudio/Spark-TTS",
     "github.com/state-spaces/mamba",
@@ -126,6 +221,8 @@ GIT_PLUS_ALLOWLIST = (
     "github.com/unslothai/unsloth-zoo",
     "github.com/unslothai/unsloth",
 )
+
+# ----- Findings ----- #
 
 
 @dataclasses.dataclass
@@ -186,6 +283,12 @@ def code_cells(nb: dict[str, Any]) -> list[tuple[int, str]]:
     return out
 
 
+# A shell line that runs pip somewhere in it. Anchored on the `!` so a `pip install` inside a
+# Python string is not a cell, and open after it so a chained or compound command is:
+# `!echo start; pip install x` and `!if ...; then pip install x; fi` both install.
+_PIP_CELL_RE = re.compile(r"^[ \t]*!.*\b(?:uv\s+)?pip\s+(?:install|uninstall)\b", re.MULTILINE)
+
+
 def install_cells(nb: dict[str, Any]) -> list[tuple[int, str]]:
     """Heuristic: any code cell that contains a `pip install`, `pip uninstall`
     or `uv pip install` shell command, or a top-line `%%capture` magic."""
@@ -195,7 +298,9 @@ def install_cells(nb: dict[str, Any]) -> list[tuple[int, str]]:
         if first and first[0].strip().startswith("%%capture"):
             out.append((i, src))
             continue
-        if re.search(r"^[ \t]*!\s*(uv\s+)?pip\s+(install|uninstall)\b", src, re.MULTILINE):
+        # Glued, since a `\\` continuation can put the `!` and the pip call on different
+        # physical lines.
+        if any(_PIP_CELL_RE.search(line) for _, line in _glue_line_continuations(src)):
             out.append((i, src))
     return out
 
@@ -260,6 +365,9 @@ def cmp_versions(a: str, b: str) -> int:
     return 0
 
 
+# ----- Install-cell parsing ----- #
+
+
 @dataclasses.dataclass
 class PipInvocation:
     tool: str  # "pip" | "uv-pip"
@@ -267,10 +375,12 @@ class PipInvocation:
     packages: list[str]  # raw package specifiers (e.g. 'transformers==5.5.0')
     raw: str
     line_no: int = 0
+    action: str = "install"  # "install" | "uninstall"
+    conditional: bool = False  # the fallback side of an `||`: runs only if the left failed
 
 
 PIP_LINE_RE = re.compile(
-    r"^\s*!\s*(?P<tool>(?:uv\s+)?pip)\s+(?:install|uninstall)\b(?P<rest>.*)$",
+    r"^\s*!\s*(?P<tool>(?:uv\s+)?pip)\s+(?P<action>install|uninstall)\b(?P<rest>.*)$",
     re.IGNORECASE,
 )
 NON_PKG_FLAG_TAKES_VAL = {
@@ -295,10 +405,12 @@ def parse_pip_line(line: str, line_no: int = 0) -> PipInvocation | None:
         return None
     tool = "uv-pip" if "uv" in m.group("tool") else "pip"
     rest = m.group("rest")
+    # Strip trailing comment.
     rest = re.split(r"(?<!\S)#", rest, maxsplit = 1)[0]
     try:
         tokens = shlex.split(rest, posix = True)
     except ValueError:
+        # f-string interpolation like {xformers}: replace braces with placeholders.
         rest_safe = re.sub(r"\{[^}]+\}", "PLACEHOLDER", rest)
         try:
             tokens = shlex.split(rest_safe, posix = True)
@@ -321,7 +433,14 @@ def parse_pip_line(line: str, line_no: int = 0) -> PipInvocation | None:
         if t in ("install", "uninstall"):
             continue
         packages.append(t)
-    return PipInvocation(tool = tool, flags = flags, packages = packages, raw = line, line_no = line_no)
+    return PipInvocation(
+        tool = tool,
+        flags = flags,
+        packages = packages,
+        raw = line,
+        line_no = line_no,
+        action = m.group("action").lower(),
+    )
 
 
 def _glue_line_continuations(text: str) -> list[tuple[int, str]]:
@@ -345,13 +464,434 @@ def _glue_line_continuations(text: str) -> list[tuple[int, str]]:
     return out
 
 
-def iter_pip_invocations(install_cell: str) -> Iterator[PipInvocation]:
-    for line_no, line in _glue_line_continuations(install_cell):
-        inv = parse_pip_line(line, line_no)
-        if inv is not None:
+# Words that introduce a compound command. A pip call behind one still runs, so it has to
+# parse. Whether it is certain depends on which word: `if pip install ...` is the test and is
+# reached whenever the line is, while a `then` or `do` body runs only if that test said so.
+# Words that run the command after them rather than being it. `command pip install ...` and
+# `env FOO=1 pip install ...` install exactly as a bare `pip install ...` does.
+_SHELL_EXEC_PREFIXES = frozenset({"command", "env", "exec", "nohup", "time", "sudo", "builtin"})
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_]\w*=")
+# Per prefix, the options that take a SEPARATE operand. Everything else starting with `-` is
+# a flag on its own and `--` ends the options. This table is what tells a prefix's operand
+# apart from the command it runs: in `env -u pip pip install ...` the first `pip` is the
+# variable being unset and the second is the executable, so searching for the first
+# pip-looking word picks the operand and the line stops parsing as pip at all.
+_PREFIX_OPERAND_FLAGS: dict[str, frozenset[str]] = {
+    "env": frozenset({"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}),
+    "sudo": frozenset(
+        {"-u", "--user", "-g", "--group", "-p", "--prompt", "-C", "--close-from",
+         "-r", "--role", "-t", "--type", "-U", "--other-user", "-h", "--host"}
+    ),
+    "exec": frozenset({"-a"}),
+    "time": frozenset({"-f", "--format", "-o", "--output"}),
+    "command": frozenset(),
+    "nohup": frozenset(),
+    "builtin": frozenset(),
+}
+
+
+def _strip_exec_prefixes(text: str) -> tuple[str, bool]:
+    """Drop `env -u VAR`, `sudo -u root`, `nohup`, `A=1` ... and return the command they run.
+
+    Positional, not pattern-matched: each prefix's own options and operands are consumed in
+    order, so the executable is whatever word is left, even when an operand is spelled `pip`.
+    """
+    prefixed = False
+    while True:
+        parts = text.split(maxsplit = 1)
+        if not parts:
+            break
+        word = parts[0]
+        rest = parts[1].strip() if len(parts) > 1 else ""
+        if _ENV_ASSIGNMENT_RE.match(word):
+            prefixed = True
+            text = rest
+            continue
+        name = word.lower()
+        if name not in _SHELL_EXEC_PREFIXES:
+            break
+        prefixed = True
+        operand_flags = _PREFIX_OPERAND_FLAGS.get(name, frozenset())
+        while rest:
+            token_parts = rest.split(maxsplit = 1)
+            token = token_parts[0]
+            tail = token_parts[1].strip() if len(token_parts) > 1 else ""
+            if token == "--":
+                rest = tail  # end of options; what follows is the command
+                break
+            if token == "-" or not token.startswith("-"):
+                break
+            if "=" in token and token.startswith("--"):
+                rest = tail  # `--unset=NAME` carries its operand inline
+                continue
+            if token in operand_flags:
+                operand = tail.split(maxsplit = 1)
+                rest = operand[1].strip() if len(operand) > 1 else ""
+            else:
+                rest = tail
+        text = rest
+    return text, prefixed
+_PIP_WORD_RE = re.compile(r"(?:^|\s)((?:uv\s+)?pip|python[0-9.]*\s+-m\s+pip)\s+", re.IGNORECASE)
+
+_SHELL_TEST_KEYWORDS = frozenset({"if", "while", "until", "for", "case"})
+_SHELL_BODY_KEYWORDS = frozenset({"then", "elif", "else", "do"})
+_SHELL_KEYWORDS = _SHELL_TEST_KEYWORDS | _SHELL_BODY_KEYWORDS | {"fi", "done", "esac"}
+
+
+def _unquoted_arm_close(text: str) -> int | None:
+    """Index of the `)` that closes a case-arm pattern, or None when there is none.
+
+    Shell quoting decides: `"x")` is a pattern, while the `)` in `pip install "a)b"` and in a
+    `$( )` substitution belongs to the command.
+    """
+    quote = ""
+    depth = 0
+    index = -1
+    escaped = False
+    for index, ch in enumerate(text):
+        if escaped:
+            escaped = False
+            continue
+        if ch == "\\" and quote != "'":
+            escaped = True  # `x\\)y)` matches a literal `)`, so only the second one closes
+            continue
+        if quote:
+            if ch == quote:
+                quote = ""
+        elif ch in "\"'":
+            quote = ch
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            if depth:
+                depth -= 1
+            elif index:
+                return index
+            else:
+                return None
+    return None
+
+
+def _final_bracket_closes_substitution(text: str) -> bool:
+    """True when the last character closes a `$( )`, `<( )` or `>( )` opened in `text`.
+
+    That `)` is part of the command and must survive the grouping-bracket strip; a `)` or `}`
+    that closes a plain group, or one left over from a group that spanned a separator, is not.
+    """
+    if not text.endswith(")"):
+        return False
+    quote = ""
+    depth = 0
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and quote != "'":
+            i += 2
+            continue
+        if quote:
+            if ch == quote:
+                quote = ""
+            i += 1
+            continue
+        if ch in "\"'":
+            quote = ch
+            i += 1
+            continue
+        if text.startswith("$(", i) or (ch in "<>" and text[i + 1 : i + 2] == "("):
+            depth += 1
+            i += 2
+            continue
+        if ch == "(" and depth:
+            depth += 1  # a nested plain group inside a substitution
+        elif ch == ")" and depth:
+            depth -= 1
+            if depth == 0 and i == len(text) - 1:
+                return True
+        i += 1
+    return False
+
+
+def _unwrap_shell_group(command: str) -> tuple[str, bool]:
+    """`( pip install x )` -> `("pip install x", False)`, `then pip install x` -> `(..., True)`.
+
+    A grouped or compound command still runs, so leaving the bracket or the keyword on hides
+    it from PIP_LINE_RE and with it from every rule, R-INST-001's git+ ban included. The flag
+    says the keyword made it conditional, which only a body word does: `if pip install ...` is
+    the test and is reached whenever the line is.
+    """
+    stripped = command.strip()
+    bang = stripped.startswith("!")
+    if bang:
+        stripped = stripped[1:].lstrip()
+    # A grouping bracket is noise and has to go, but the `)` that closes a `$( )` belongs to
+    # the command: a bare rstrip(")}") ate it, so `x) echo $(pip install ...)` came back as
+    # `echo $(pip install ...` and _substitution_bodies could no longer read the body out.
+    # A piece can also be a lone `}` when a group spans a separator, which still strips.
+    stripped = stripped.lstrip("({").strip()
+    while stripped[-1:] in (")", "}") and not _final_bracket_closes_substitution(stripped):
+        stripped = stripped[:-1].rstrip()
+    conditional = False
+    while True:
+        # Any whitespace, not a literal space: `then\tpip install ...` is the same command to
+        # the shell, and leaving `then\tpip` as one word hides it from every rule.
+        parts = stripped.split(maxsplit = 1)
+        if not parts or parts[0].lower() not in _SHELL_KEYWORDS:
+            break
+        conditional = conditional or parts[0].lower() in _SHELL_BODY_KEYWORDS
+        stripped = parts[1].strip() if len(parts) > 1 else ""
+    # A `case` arm label: `x in x) pip install ...`, a quoted `"x") ...`, and the bare
+    # `b) pip install ...` of a later arm. Only the matching arm runs, so the command is
+    # conditional. The label ends at the first unquoted `)` with nothing open before it; a `)`
+    # inside quotes or inside a `$( )` belongs to the command.
+    close = _unquoted_arm_close(stripped)
+    if close is not None:
+        stripped = stripped[close + 1 :].strip()
+        conditional = True
+    # `env -u VAR pip install ...`, `sudo -u root pip ...`, `nohup pip ...`, `A=1 pip ...`.
+    # Each prefix's own options and operands are consumed positionally, so the executable is
+    # whatever word survives rather than the first one that looks like pip.
+    stripped, _prefixed = _strip_exec_prefixes(stripped)
+    return (f"!{stripped}" if bang and stripped else stripped), conditional
+
+
+def _substitution_bodies(command: str) -> list[str]:
+    """The insides of every substitution in `command`, in the order the shell runs them.
+
+    `$( )`, backticks and the `<( )` / `>( )` process forms all run when the command runs, so
+    a pip call in one is an install like any other and the outer command is usually not pip.
+    Single quotes and an escaped `$` make the text literal, and then nothing runs.
+    """
+    bodies: list[str] = []
+    quote = ""
+    i = 0
+    while i < len(command):
+        ch = command[i]
+        if ch == "\\" and quote != "'":
+            i += 2  # escaped: `\\$(` is a literal dollar
+            continue
+        if quote == "'":
+            if ch == "'":
+                quote = ""  # single quotes make the text literal, so nothing runs in there
+            i += 1
+            continue
+        if ch in "\"'":
+            quote = "" if ch == quote else (quote or ch)
+            i += 1
+            continue
+        # `$( )` and backticks expand inside double quotes; `<( )` and `>( )` do not.
+        opens = command.startswith("$(", i) or (
+            not quote and ch in "<>" and command[i + 1 : i + 2] == "("
+        )
+        if opens:
+            depth, j = 1, i + 2
+            inner_quote = ""
+            while j < len(command) and depth:
+                inner = command[j]
+                if inner == "\\" and inner_quote != "'":
+                    j += 2
+                    continue
+                if inner_quote:
+                    if inner == inner_quote:
+                        inner_quote = ""
+                elif inner in "\"'":
+                    inner_quote = inner
+                elif inner == "(":
+                    depth += 1
+                elif inner == ")":
+                    depth -= 1
+                j += 1
+            bodies.append(command[i + 2 : j - 1 if depth == 0 else j])
+            i = j
+        elif ch == "`":
+            j = command.find("`", i + 1)
+            if j == -1:
+                break
+            bodies.append(command[i + 1 : j])
+            i = j + 1
+        else:
+            i += 1
+    return [body.strip() for body in bodies if body.strip()]
+
+
+def _split_chained(line: str) -> list[tuple[str, bool]]:
+    """One shell line -> `(command, conditional)` per command. Only the first keeps the `!`.
+
+    `pip uninstall -y x && pip install x==1` is two commands with two actions; read as one,
+    the regex hands the whole line to the first and the reinstall lands in the uninstall's
+    package list. Scanned rather than split on a pattern because a PEP 508 marker puts a
+    quoted `;` inside a single argument (`"torch==2.12.0; python_version >= '3.10'"`), and a
+    backslash escapes the next character outside single quotes, as the shlex pass in
+    parse_pip_line does.
+
+    A `||` fallback runs only when the command before it failed, so it is flagged conditional
+    rather than dropped: it can still run, and the rules that must see every install path
+    (R-INST-001 and the git+ ban above all) have to keep seeing it. Only the effective-version
+    replay skips them. The tail ends at an `&&` or a `;`, since the lists are left-associative
+    and `(A || B) && C` runs C when A succeeded. Each group keeps its own tail, and a command
+    is conditional when any level above it is in one: the `&&` in `A || (B && C)` ends the
+    group's tail and leaves the outer one, the one in `(A || B && C)` ends the only tail there
+    is. A single `&` or `|` separates as well, and both sides run either way, so neither opens
+    a tail; `>&` and `&>` are redirections and are left alone. An unquoted `#` that starts a
+    word comments out the rest of the line, so scanning stops.
+    """
+    out: list[tuple[str, bool]] = []
+    buf: list[str] = []
+    quote = ""
+    # One flag per open group, plus the base list. A command is conditional when any level
+    # above it is in a fallback tail, so an inner list cannot clear an outer one.
+    tails = [False]
+    buf_conditional = False
+    # One entry per open `(`/`{`: True when it opened a grouping. A `)` closing a `$( )` is
+    # inside a word, so a `#` after it is a literal, not a comment.
+    groupings: list[bool] = []
+    grouping_closed = False
+    # An open legacy `` `...` `` substitution. Backticks run their contents the way `$( )`
+    # does, so the operators inside one are the inner command's, not this line's. Without
+    # this the `;` in ``echo `pip install git+...; echo ok` `` split the line and left
+    # `_substitution_bodies` an unmatched fragment it could not read at all.
+    in_backtick = False
+    i = 0
+
+    def in_sub() -> bool:
+        return in_backtick or not all(groupings)
+
+    def flush() -> None:
+        nonlocal buf
+        out.append(("".join(buf), buf_conditional))
+        buf = []
+
+    while i < len(line):
+        ch = line[i]
+        in_substitution = in_sub()
+        if ch == "\\" and quote != "'" and i + 1 < len(line):
+            buf.append(ch)
+            buf.append(line[i + 1])
+            i += 2
+        elif ch == "`" and quote != "'":
+            # Backticks expand inside double quotes as well, so this is checked before the
+            # quote branch; only single quotes make them literal.
+            in_backtick = not in_backtick
+            buf.append(ch)
+            i += 1
+        elif quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = ""
+            i += 1
+        elif ch in "\"'":
+            quote = ch
+            buf.append(ch)
+            i += 1
+        elif ch in ")}" and in_substitution:
+            # Close it here, before the guard below would swallow the bracket.
+            grouping_closed = groupings.pop() if groupings else True
+            if len(tails) > 1:
+                tails.pop()
+            buf.append(ch)
+            i += 1
+        elif ch == "#" and (
+            i == 0
+            or line[i - 1].isspace()
+            or line[i - 1] in ";&|"
+            or (line[i - 1] in ")}" and grouping_closed)
+        ):
+            break  # an operator, or a bracket that closed a grouping, ends a word
+        elif in_substitution:
+            buf.append(ch)  # its separators are its own; the body is split on its own later
+            i += 1
+        elif line.startswith("||", i):
+            flush()
+            tails[-1] = True
+            buf_conditional = any(tails)
+            i += 2
+        elif line.startswith("&&", i):
+            flush()
+            # Left-associative: (A || B) && C runs C when A succeeded. Only this list's tail
+            # ends here, so an enclosing fallback still covers what follows.
+            tails[-1] = False
+            buf_conditional = any(tails)
+            i += 2
+        elif (
+            ch == ";"
+            or (
+                # `A & B` backgrounds A and runs B, `A | B` runs both: unconditional either way.
+                # `>&` and `&>` are redirections, not separators.
+                ch in "&|"
+                # `>&`, `&>` and `>|` are redirections rather than separators.
+                and not (ch == "&" and (line[i - 1 : i] == ">" or line[i + 1 : i + 2] == ">"))
+                and not (ch == "|" and line[i - 1 : i] == ">")
+            )
+        ):
+            flush()
+            tails[-1] = False
+            buf_conditional = any(tails)
+            i += 1
+        else:
+            if ch in "({":
+                # `$(`, `<(` and `>(` open a substitution, which lives inside a word and runs
+                # its own commands; a bare `(` groups this line's.
+                groupings.append(not (ch == "(" and buf and buf[-1] in "$<>"))
+                tails.append(False)
+                if not "".join(buf).strip():
+                    buf_conditional = any(tails)  # the group opens before the command
+            elif ch in ")}":
+                grouping_closed = groupings.pop() if groupings else True
+                if len(tails) > 1:
+                    # The command in hand belongs to the level being closed, so its flag stays
+                    # what it was; the pop only affects what comes after.
+                    tails.pop()
+            if ch not in ")}":
+                grouping_closed = False
+            buf.append(ch)
+            i += 1
+    flush()
+    (head, head_conditional), *rest = out
+    head_text, head_keyword = _unwrap_shell_group(head)
+    # One entry per piece in `out`, empties included. Dropping them here and then zipping
+    # against `out` slid every later pair by one and cut the tail off at the shorter list,
+    # so a `case` -- which emits an empty piece per `;;`, and whose `esac` unwraps to ""
+    # -- left its last arms unscanned entirely. The empties are filtered after the pairing.
+    commands = [(head_text, head_conditional or head_keyword)]
+    for piece, flag in rest:
+        text, keyword = _unwrap_shell_group(piece.strip())
+        commands.append((f"!{text}" if text else "", flag or keyword))
+    # `echo $(pip install x)` runs the install as surely as the echo, and the outer command is
+    # not pip, so the inner one has to be a command of its own. Read off the raw pieces: an
+    # assignment prefix like ``X=`pip install y` `` is stripped by the unwrap above.
+    ordered: list[tuple[str, bool]] = []
+    for (piece, flag), (text, command_flag) in zip(out, commands):
+        for inner in _substitution_bodies(piece):
+            ordered.extend(
+                (inner_text, flag or inner_flag)
+                for inner_text, inner_flag in _split_chained(f"!{inner}")
+            )
+        if text:
+            ordered.append((text, command_flag))
+    return ordered
+
+
+def unconditional_pip_invocations(install_cell: str) -> Iterator[PipInvocation]:
+    """The commands that certainly run.
+
+    Anything asking what the cell leaves installed wants this one. `iter_pip_invocations`
+    yields the `||` fallbacks too, and only a rule that must see every path a notebook could
+    take, R-INST-001's git+ ban above all, should be reading those.
+    """
+    for inv in iter_pip_invocations(install_cell):
+        if not inv.conditional:
             yield inv
 
 
+def iter_pip_invocations(install_cell: str) -> Iterator[PipInvocation]:
+    for line_no, line in _glue_line_continuations(install_cell):
+        for command, conditional in _split_chained(line):
+            inv = parse_pip_line(command, line_no)
+            if inv is not None:
+                inv.conditional = conditional
+                yield inv
+
+
+# Spec parsing: only what we need (no full PEP 440).
 SPEC_RE = re.compile(r"^(?P<name>[A-Za-z0-9._-]+)(?:\[[^\]]*\])?(?P<rest>.*)$")
 OP_VERSION_RE = re.compile(r"(==|>=|<=|!=|~=|>|<)\s*([0-9][^,;\s]*)")
 
@@ -416,8 +956,8 @@ def transitive_constraint(name: str, version: str, target: str) -> tuple[str | N
     requires = info.get("requires_dist") or []
     target_l = target.lower()
     for req in requires:
-        # Examples: 'tokenizers (<=0.23.0,>=0.22.0)', 'tokenizers <=0.23.0,>=0.22.0', 'tokenizers (>=0.22.0,<=0.23.0);
-        # python_version >= "3.9"'
+        # Examples: 'tokenizers (<=0.23.0,>=0.22.0)', 'tokenizers <=0.23.0,>=0.22.0',
+        # 'tokenizers (>=0.22.0,<=0.23.0); python_version >= "3.9"'
         head = req.split(";", 1)[0].strip()
         m = re.match(r"^([A-Za-z0-9._-]+)\s*\(?([^)]*)?\)?\s*$", head)
         if not m:
@@ -469,10 +1009,11 @@ def resolved_set(install_cell: str, colab: dict[str, str]) -> dict[str, str]:
     out = dict(colab)
     pinned: set[str] = set()
     upper_bounds: dict[str, str] = {}
-    for inv in iter_pip_invocations(install_cell):
+    environment = _marker_environment(colab)
+    for inv in unconditional_pip_invocations(install_cell):
         for raw in inv.packages:
             sp = parse_spec(raw)
-            if sp is None:
+            if sp is None or not _requirement_applies(raw, environment):
                 continue
             for op, ver in sp.pins:
                 if op == "==":
@@ -494,23 +1035,85 @@ def resolved_set(install_cell: str, colab: dict[str, str]) -> dict[str, str]:
 # ----- Rules ----- #
 
 
+# A `git+` target runs to the next shell or quoting boundary. Case-insensitive: pip
+# normalises `Git+https://` to the same link.
+_GIT_SOURCE_RE = re.compile(r"""git\+[^\s'"]+""", re.IGNORECASE)
+
+
+def _git_source_repository(source: str) -> str:
+    """`git+https://user@github.com/Org/Repo.git@ref` -> `github.com/org/repo`.
+
+    Matched against the allowlist as a path rather than a substring: an arbitrary repository
+    can carry `github.com/unslothai/unsloth` inside its own path, and a substring test reads
+    that as permission.
+    """
+    remainder = source.split("+", 1)[1] if "+" in source else source
+    # pip normalises the scheme, so the comparison is on the lowered host and path below.
+    remainder = remainder.split("://", 1)[-1]
+    host, _, path = remainder.partition("/")
+    host = host.rsplit("@", 1)[-1]  # drop any credentials
+    path = path.split("#", 1)[0].split("?", 1)[0]
+    path = path.split("@", 1)[0].rstrip("/")  # drop a trailing @ref
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+    # Resolve `.` and `..` the way a URL client does, or
+    # `github.com/unslothai/unsloth/../../attacker/repo` reads as an allowlisted prefix.
+    segments: list[str] = []
+    for segment in path.split("/"):
+        if segment in ("", "."):
+            continue
+        if segment == "..":
+            if segments:
+                segments.pop()
+            continue
+        segments.append(segment)
+    return "/".join([host.lower(), *(segment.lower() for segment in segments)])
+
+
+def _git_source_is_allowed(source: str) -> bool:
+    """Exact repository match. Every allowlist entry is one `host/org/repo`, and pip puts a
+    subdirectory in the URL fragment rather than on the path, so nothing needs a prefix."""
+    repository = _git_source_repository(source)
+    return any(repository == allowed.lower() for allowed in GIT_PLUS_ALLOWLIST)
+
+
 def rule_inst_001_git_plus(install_cell: str, file: str, cell_idx: int) -> list[Finding]:
+    """Every pip command on the line, conditional ones included.
+
+    The question is whether the cell can reach a `git+` source at all, so the answer must not
+    depend on how the line splits: a fallback, a `(...)` group and an `if ...; then` body are
+    all reachable, and `unconditional_pip_invocations` would drop them. It does depend on the
+    command being pip: a `git+` in an `echo` beside an install installs nothing, and a `git+`
+    in a comment is documentation, which `_split_chained` has already dropped.
+
+    Each source is read twice over, from the command text and from the arguments shlex made
+    of it: `"git+"https://...` is one argument to pip and two words to a text scan, and a
+    source inside a construct only one of them can read still has to be seen.
+    """
     findings: list[Finding] = []
-    for inv in iter_pip_invocations(install_cell):
-        if any("git+" in p for p in inv.packages) or "git+" in inv.raw:
-            if any(allowed in inv.raw for allowed in GIT_PLUS_ALLOWLIST):
+    for line_no, line in _glue_line_continuations(install_cell):
+        sources: list[str] = []
+        for command, _ in _split_chained(line):
+            inv = parse_pip_line(command, line_no)
+            if inv is None:
                 continue
-            findings.append(
-                Finding(
-                    rule = "R-INST-001",
-                    file = file,
-                    cell = cell_idx,
-                    line = inv.line_no,
-                    severity = "error",
-                    message = "install line uses `git+` (volatile, not pinned to a release)",
-                    hint = f"replace with a `pip install foo==X.Y.Z` from PyPI; allow-list is {GIT_PLUS_ALLOWLIST}",
-                )
+            sources += _GIT_SOURCE_RE.findall(command)
+            sources += [arg for arg in inv.packages if arg.lower().startswith("git+")]
+        # Per source, not per line: one allowlisted repository beside a prohibited one must
+        # not clear the whole line.
+        if not sources or all(_git_source_is_allowed(source) for source in sources):
+            continue
+        findings.append(
+            Finding(
+                rule = "R-INST-001",
+                file = file,
+                cell = cell_idx,
+                line = line_no,
+                severity = "error",
+                message = "install line uses `git+` (volatile, not pinned to a release)",
+                hint = f"replace with a `pip install foo==X.Y.Z` from PyPI; allow-list is {GIT_PLUS_ALLOWLIST}",
             )
+        )
     return findings
 
 
@@ -519,12 +1122,13 @@ def rule_inst_002_no_deps_transitive(
 ) -> list[Finding]:
     findings: list[Finding] = []
     res = resolved_set(install_cell, colab)
-    for inv in iter_pip_invocations(install_cell):
+    environment = _marker_environment(colab)
+    for inv in unconditional_pip_invocations(install_cell):
         if "--no-deps" not in inv.flags:
             continue
         for raw in inv.packages:
             sp = parse_spec(raw)
-            if sp is None:
+            if sp is None or not _requirement_applies(raw, environment):
                 continue
             v = explicit_pin(sp)
             if v is None:
@@ -559,21 +1163,305 @@ def rule_inst_002_no_deps_transitive(
     return findings
 
 
-def _install_cell_lower_bound(install_cell: str, target: str) -> str | None:
+def _install_cell_lower_bound(
+    install_cell: str,
+    target: str,
+    environment: dict[str, str] | None = None,
+) -> str | None:
     """Return the highest lower bound any install line places on `target`
     (treating `==V` as both bounds), or None. Used by R-INST-003 so a
     `torchao>=0.16.0` line satisfies the floor without a `==` pin."""
     best: str | None = None
-    for inv in iter_pip_invocations(install_cell):
+    for inv in unconditional_pip_invocations(install_cell):
         for raw in inv.packages:
             sp = parse_spec(raw)
             if sp is None or sp.name != target:
                 continue
+            if not _requirement_applies(raw, environment):
+                continue  # pip skips it, so it satisfies no floor
             for op, ver in sp.pins:
                 if op in ("==", ">="):
                     if best is None or cmp_versions(ver, best) > 0:
                         best = ver
     return best
+
+
+def _compatible_release_ceiling(version: str) -> str | None:
+    """The exclusive ceiling `~=version` implies: `~=2.10.0` allows `<2.11`, `~=2.10` `<3`.
+
+    PEP 440 drops the last component and increments what is then last.
+    """
+    parts = normalise_version(version).split(".")
+    if len(parts) < 2:
+        return None
+    head = parts[:-1]
+    try:
+        head[-1] = str(int(head[-1]) + 1)
+    except ValueError:
+        return None
+    return ".".join(head)
+
+
+# pip takes `<archive url/path>` as an install target and parse_spec skips anything with a
+# `://`, so a wheel that replaces the package reads as no install at all. The version sits in
+# the filename: PEP 427 puts it in the second `-` field.
+_ARCHIVE_RE = re.compile(
+    r"(?P<name>[A-Za-z0-9._-]+?)-(?P<version>\d[^-]*?)(?:-.*)?\.(?:whl|tar\.gz|zip)$",
+    re.IGNORECASE,
+)
+
+
+def _archive_requirement(argument: str) -> tuple[str, str | None] | None:
+    """`(project, version)` for a direct archive install, or None when it is not one.
+
+    The version is None when the target is named but its archive does not encode one, as in
+    `torchcodec @ https://.../v0.13.0.zip`: the package is replaced, by something this cannot
+    name.
+    """
+    named, sep, reference = argument.partition("@")
+    if sep and "://" in reference:
+        argument = reference.strip()
+        named = named.strip().split("[", 1)[0].replace("_", "-").lower()
+    else:
+        named = ""
+    lowered = argument.lower().split("#", 1)[0].split("?", 1)[0]
+    if "://" not in argument and not lowered.endswith((".whl", ".tar.gz", ".zip")):
+        return None
+    leaf = argument.split("#", 1)[0].split("?", 1)[0].rstrip("/").rsplit("/", 1)[-1]
+    leaf = urllib.parse.unquote(leaf)  # a URL spells the local tag `%2Bcu130`
+    match = _ARCHIVE_RE.match(leaf)
+    if match is None:
+        return (named, None) if named else None
+    project = match.group("name").replace("_", "-").lower()
+    return (named or project), match.group("version")
+
+
+def cmp_releases(a: str, b: str) -> int:
+    """`cmp_versions` with the release segments padded, as PEP 440 compares them.
+
+    `cmp_versions` stops at the shorter tuple, so it reads `0.11.0` as above `0.11`. That is
+    harmless for ordering across different releases and wrong wherever the question is whether
+    two spellings name the same one, which is what an exclusion and a minor bound both ask.
+    """
+    left = [int(part) for part in re.findall(r"\d+", normalise_version(a))]
+    right = [int(part) for part in re.findall(r"\d+", normalise_version(b))]
+    width = max(len(left), len(right))
+    left += [0] * (width - len(left))
+    right += [0] * (width - len(right))
+    return (left > right) - (left < right)
+
+
+def _exclusion_covers_minor(version: str, exclusion: str) -> bool:
+    """True when `!=exclusion` rules out every release in `version`'s minor.
+
+    Only a wildcard can: `!=0.11.*` takes the whole 0.11 line, while `!=0.11` and `!=0.11.1.*`
+    each remove one release or one patch line and leave the minor reachable.
+    """
+    wanted = normalise_version(exclusion).split(".")
+    if not wanted or wanted[-1] != "*":
+        return False
+    wanted = wanted[:-1]
+    return len(wanted) <= 2 and normalise_version(version).split(".")[: len(wanted)] == wanted
+
+
+def _version_is_excluded(version: str, exclusion: str) -> bool:
+    """True when `!=exclusion` rules `version` out. A trailing `.*` is a prefix match."""
+    wanted = normalise_version(exclusion).split(".")
+    if wanted and wanted[-1] == "*":
+        wanted = wanted[:-1]
+        return normalise_version(version).split(".")[: len(wanted)] == wanted
+    return cmp_releases(version, exclusion) == 0
+
+
+def _window_names_one_minor(
+    floor: str | None,
+    ceiling: str | None,
+    cap: str | None = None,
+) -> bool:
+    """True when the window above `floor` cannot leave the minor `floor` is in.
+
+    A window lands on the newest release it admits, which only the window itself names when
+    there is one minor to land in. `>=0.10,<0.11` and `>=0.10,<=0.10.5` qualify;
+    `>=0.10,<0.12` and `>=0.10,<=0.11` do not, and pip would pick 0.11 there.
+    """
+    if floor is None:
+        return False
+    if cap is not None and version_minor(cap) == version_minor(floor):
+        return True
+    if ceiling is None:
+        return False
+    next_minor = _compatible_release_ceiling(f"{version_minor(floor)}.0")
+    # Padded: `<0.11.0` and `<0.11` name the same boundary.
+    return next_minor is not None and cmp_releases(ceiling, next_minor) <= 0
+
+
+def _spec_window(
+    pins: list[tuple[str, str]],
+) -> tuple[str | None, str | None, str | None, str | None, list[str], bool]:
+    """`(exact, floor, cap, ceiling, exclusions, floor_excludes_itself)` for one requirement.
+
+    `cap` is an inclusive `<=`, which names the version pip lands on; `ceiling` is an
+    exclusive `<` or the one `~=` implies, which does not. A `>` floor comes back with the
+    flag set, since the endpoint it names is the one version pip will not install.
+    """
+    exact = floor = cap = ceiling = None
+    floor_excludes_itself = False
+    exclusions: list[str] = []
+    for op, ver in pins:
+        if op == "==":
+            exact = ver
+        elif op == "!=":
+            exclusions.append(ver)
+        elif op in (">=", ">", "~="):
+            if floor is None or cmp_releases(ver, floor) > 0:
+                floor = ver
+                floor_excludes_itself = op == ">"
+            elif cmp_releases(ver, floor) == 0 and op == ">":
+                # Same version, stricter operator: intersecting them keeps the exclusion.
+                floor_excludes_itself = True
+        elif op == "<=":
+            if cap is None or cmp_versions(ver, cap) < 0:
+                cap = ver
+        elif op == "<":
+            if ceiling is None or cmp_versions(ver, ceiling) < 0:
+                ceiling = ver
+        if op == "~=":
+            implied = _compatible_release_ceiling(ver)
+            if implied is not None and (ceiling is None or cmp_versions(implied, ceiling) < 0):
+                ceiling = implied
+    return exact, floor, cap, ceiling, exclusions, floor_excludes_itself
+
+
+# Flags that stop pip treating what is installed as satisfying an unbounded requirement, so
+# it resolves from the index instead of leaving the version alone.
+_RESOLVE_ANYWAY_LONG = frozenset({"--upgrade", "--force-reinstall", "--ignore-installed"})
+_RESOLVE_ANYWAY_SHORT = frozenset({"U", "I"})
+
+
+def _forces_resolution(flags: set[str]) -> bool:
+    """True when any flag makes pip re-resolve rather than keep what is installed.
+
+    Short options bundle: pip takes `-Uq` and parse_pip_line keeps it as one token, so the
+    letters are compared rather than the token.
+    """
+    if flags & _RESOLVE_ANYWAY_LONG:
+        return True
+    return any(
+        not flag.startswith("--") and flag.startswith("-") and set(flag[1:]) & _RESOLVE_ANYWAY_SHORT
+        for flag in flags
+    )
+
+
+def _effective_version(
+    install_cell: str,
+    target: str,
+    resolved: str | None,
+    environment: dict[str, str] | None = None,
+) -> tuple[str | None, bool]:
+    """`resolved` walked forward through the cell's own requirements, in invocation order.
+
+    resolved_set() drops every bound but `==` and `<=`, and applies those all at once at the
+    end. Order is what decides between them: a later requirement overrides an earlier one
+    either way. Without this R-INST-004's own `torchcodec>=0.12.0` remedy could not clear the
+    error it offers, and `torchcodec>=0.10,<0.11` could not raise one.
+
+    Each requirement is a window. An install moves the version into that window when it falls
+    outside and leaves it alone when it does not, which is what pip does. Where it moves to is
+    the window's floor, or an inclusive `<=` when the move is downwards. Moving down only
+    names a version when the window holds one minor, which is the granularity the callers
+    compare on: `>=0.10,<0.11` and `~=0.10.0` do, `>=0.10,<0.12` and `>=0.9,!=0.11.*` do not.
+    A `>` floor names the one version pip will not install, so it too only moves the version
+    when a ceiling pins the minor. Anything that cannot say where the install lands clears the
+    version rather than keeping a stale one, and a bound on an absent package leaves it
+    absent, unless the requirement carries a floor, which at least says it is installed and
+    how low it can be.
+
+    Returns `(version, exact)`. An open floor moves the version up but does not name it: pip
+    takes the newest release above it, so `>=0.8` can land anywhere from 0.8 upwards. That
+    comes back inexact, and the caller may only use it where every version at or above it
+    gives the same answer.
+    """
+    current = resolved
+    exact_known = True
+    for inv in unconditional_pip_invocations(install_cell):
+        # One command names a project once as far as pip is concerned: it intersects repeated
+        # arguments into a single requirement, so they have to be one window here too.
+        pins: list[tuple[str, str]] = []
+        named = False
+        replaced_unnamed = False
+        for raw in inv.packages:
+            if not _requirement_applies(raw, environment):
+                continue  # pip skips it, so its bounds never move anything
+            # Before parse_spec, which reads `./torchcodec-0.13.0-...whl` as a project called
+            # `.` and hides the archive behind a name that never matches.
+            archive = _archive_requirement(raw)
+            if archive is not None:
+                if archive[0] == target:
+                    named = True
+                    if archive[1] is None:
+                        replaced_unnamed = True  # installed, by something with no version here
+                    else:
+                        pins.append(("==", archive[1]))
+                continue
+            sp = parse_spec(raw)
+            if sp is None or sp.name != target:
+                continue
+            named = True
+            pins.extend(sp.pins)
+        if not named:
+            continue
+        if inv.action == "uninstall":
+            current = None  # removed; a later install can put it back
+            continue
+        if not pins and not replaced_unnamed and _forces_resolution(inv.flags):
+            # A bare name with any of these takes whatever the index offers: none of them let
+            # the installed version satisfy the requirement, so it is not what the cell ends
+            # on, and nothing here names what does.
+            current, exact_known = None, True
+            continue
+        if replaced_unnamed:
+            current, exact_known = None, True
+            continue
+        exact, floor, cap, ceiling, exclusions, exclusive_floor = _spec_window(pins)
+        # Where an install lands when it has to move, or None when nothing names it.
+        landing = floor if _window_names_one_minor(floor, ceiling, cap) else None
+        if exact is not None:
+            current, exact_known = exact, True
+        elif current is None:
+            # Absent, so the install puts it there. A floor is all that can be said about
+            # where; without one there is nothing to say at all.
+            if floor is not None and not exclusive_floor:
+                current, exact_known = floor, landing is not None
+        elif floor is not None and (
+            cmp_versions(floor, current) > 0
+            # `>V` is not satisfied by V itself, so equality still forces a move.
+            or (exclusive_floor and cmp_versions(floor, current) == 0)
+        ):
+            if cap is not None:
+                current, exact_known = cap, True  # `<=V` allows V, so V is what pip picks
+            elif landing is not None:
+                current, exact_known = landing, True  # the window pins the minor
+            elif exclusive_floor:
+                current, exact_known = None, True  # nothing names where it went
+            else:
+                current, exact_known = floor, False  # at least the floor, possibly newer
+        elif cap is not None and cmp_versions(current, cap) > 0:
+            current, exact_known = cap, True  # `<=V` allows V, so V is what pip picks
+        elif ceiling is not None and cmp_versions(current, ceiling) >= 0:
+            current, exact_known = landing, True
+        # Whatever the requirement leaves in place still has to satisfy its own exclusions,
+        # which covers the version that was already installed and the one just landed on.
+        if current is not None and any(_version_is_excluded(current, ver) for ver in exclusions):
+            # A window that pins one minor still pins it: `>=0.11,<0.12,!=0.11.0` moves off
+            # 0.11.0 and stays in the 0.11 line, and the minor is what the callers compare.
+            # Only an exclusion covering the whole minor takes that away.
+            if landing is not None and not any(
+                _exclusion_covers_minor(landing, ver) for ver in exclusions
+            ):
+                current, exact_known = landing, True
+            else:
+                current, exact_known = None, True
+    return current, exact_known if current is not None else True
 
 
 def rule_inst_003_peft_torchao(
@@ -584,7 +1472,9 @@ def rule_inst_003_peft_torchao(
     peft_v = res.get("peft")
     if not peft_v:
         return findings
-    torchao_explicit = _install_cell_lower_bound(install_cell, "torchao")
+    torchao_explicit = _install_cell_lower_bound(
+        install_cell, "torchao", _marker_environment(colab)
+    )
     torchao_resolved = torchao_explicit or res.get("torchao")
     for floor in PEFT_TORCHAO_FLOOR:
         if cmp_versions(peft_v, floor["trigger_peft"]) >= 0:
@@ -643,8 +1533,11 @@ def rule_inst_004_torchcodec_torch(
 ) -> list[Finding]:
     findings: list[Finding] = []
     res = resolved_set(install_cell, colab)
-    torch_v = res.get("torch")
-    codec_v = res.get("torchcodec")
+    environment = _marker_environment(colab)
+    torch_v, torch_exact = _effective_version(install_cell, "torch", res.get("torch"), environment)
+    codec_v, codec_exact = _effective_version(
+        install_cell, "torchcodec", res.get("torchcodec"), environment
+    )
     if not torch_v or not codec_v:
         return findings
     # resolved_set keeps the oracle's preinstalled version for anything the cell does not pin
@@ -655,21 +1548,22 @@ def rule_inst_004_torchcodec_torch(
     # to 2.11), so that half of the matrix is open-ended and cannot be a finite set of minors.
     # Without this, adding the 2.11 row below would flag torch 2.11 with torchcodec 0.12
     # through 0.15, all of which upstream supports, and R-INST-004 is an error.
+    # An inexact version is a floor: everything at or above it is possible. That is enough for
+    # the ABI check, which only asks whether both sides clear a floor of their own.
     if (
         cmp_versions(torch_v, TORCHCODEC_ABI_STABLE_TORCH) >= 0
         and cmp_versions(codec_v, TORCHCODEC_ABI_STABLE_CODEC) >= 0
     ):
-        return findings
+        return findings  # ABI-stable pairing, not locked to one torch minor
     t_minor = version_minor(torch_v)
     c_minor = version_minor(codec_v)
     allowed = TORCH_TORCHCODEC.get(t_minor)
     if allowed is None:
         if cmp_versions(torch_v, TORCHCODEC_ABI_STABLE_TORCH) < 0:
-            return findings  # older than the table, and no row to judge it by
-        # Past the ABI floor with no lockstep row, and the exemption above already returned
-        # for every 0.12+, so this codec is pre-0.12: built against a single older torch
-        # minor, and this torch is newer than any of them. Silence here would mean the
-        # table's last row decides how far the rule can see.
+            return findings  # torch older than the table — don't flag
+        if not codec_exact and cmp_versions(c_minor, TORCHCODEC_ABI_STABLE_CODEC) < 0:
+            return findings  # a newer codec above this floor would be ABI-stable and fine
+        # Past the ABI floor with a pre-0.12 codec: locked to an older torch minor.
         findings.append(
             Finding(
                 rule = "R-INST-004",
@@ -680,6 +1574,12 @@ def rule_inst_004_torchcodec_torch(
                 hint = f"pin `torchcodec>={TORCHCODEC_ABI_STABLE_CODEC}.0` (the ABI-stable line, which targets torch >={TORCHCODEC_ABI_STABLE_TORCH})",
             )
         )
+        return findings
+    if not torch_exact:
+        # The row that applies depends on which torch this floor resolves to.
+        return findings
+    if not codec_exact and cmp_versions(c_minor, sorted(allowed)[-1]) <= 0:
+        # Some release at or above the floor is in the row, so nothing is proven.
         return findings
     if c_minor not in allowed:
         findings.append(
@@ -709,13 +1609,14 @@ def rule_inst_005_transformers_tokenizers(
     if not tf or tok is None:
         return findings
     # Find the transformers pin and check for --no-deps.
+    environment = _marker_environment(colab)
     transformers_line_no_deps = False
-    for inv in iter_pip_invocations(install_cell):
+    for inv in unconditional_pip_invocations(install_cell):
         for raw in inv.packages:
             sp = parse_spec(raw)
             if sp is None or sp.name != "transformers":
                 continue
-            if explicit_pin(sp) is None:
+            if explicit_pin(sp) is None or not _requirement_applies(raw, environment):
                 continue
             if "--no-deps" in inv.flags:
                 transformers_line_no_deps = True
@@ -778,9 +1679,9 @@ class _APIScanner(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> None:
         # SFTConfig with suboptimal optim (R-API-003).
-        # NOTE: PR #221 also stripped gradient_checkpointing kwargs from some vision notebooks, but they're still
-        # accepted by live TRL (trl==0.25.1) so that was cosmetic.
-        # R-API-004 catches real drift.
+        # NOTE: PR #221 also stripped gradient_checkpointing kwargs from some
+        # vision notebooks, but they're still accepted by live TRL (trl==0.25.1)
+        # so that was cosmetic. We don't flag them; R-API-004 catches real drift.
         if isinstance(node.func, ast.Name) and node.func.id == "SFTConfig":
             for kw in node.keywords:
                 if (
@@ -821,6 +1722,7 @@ def scan_user_cells(nb: dict[str, Any], file: str) -> list[Finding]:
 # ----- DONT_UPDATE_EXCEPTIONS coverage ----- #
 
 POLICY_CLAUSES_DEFAULT = [
+    # (id, regex, applies_to_predicate_on_install_cell_text)
     (
         "torchao-floor",
         re.compile(r"torchao>=0\.16\.0"),
@@ -900,7 +1802,9 @@ def cmd_drift(args: argparse.Namespace) -> int:
         check = False,
         capture_output = True,
     )
-    # The restore MUST run even on SystemExit/KeyboardInterrupt, else the working tree stays rolled back into the stash.
+    # The restore MUST run even on SystemExit/KeyboardInterrupt, else the
+    # working tree stays rolled back into the stash. A bare try/finally keeps
+    # the original exception while still running the cleanup (stash pop).
     findings: list[Finding] = []
     rc: int
     try:
@@ -1028,14 +1932,16 @@ def cmd_lint(args: argparse.Namespace) -> int:
             continue
         rel = str(path.relative_to(nbdir))
         env = target_environment(rel)
-        # Colab oracle applies only to Colab notebooks; other targets get the environment-agnostic rules only (their
-        # preinstalls aren't tracked).
+        # Colab oracle applies only to Colab notebooks; other targets get the
+        # environment-agnostic rules only (their preinstalls aren't tracked).
         oracle = colab if env == "colab" else {}
         cells = install_cells(nb)
+        # Per-cell forbid-pattern checks.
         for idx, cell in cells:
             findings += rule_inst_001_git_plus(cell, rel, idx)
             findings += rule_inst_006_double_bang(cell, rel, idx)
-        # Whole-notebook rules: install steps may span multiple cells, so merge before resolving compat against Colab.
+        # Whole-notebook rules: install steps may span multiple cells, so merge
+        # before resolving compat against Colab.
         merged = "\n".join(c for _, c in cells)
         if env == "colab" and merged:
             first_cell = cells[0][0] if cells else None
@@ -1140,8 +2046,9 @@ def cmd_refresh_colab(args: argparse.Namespace) -> int:
     colab-diff drift report is acknowledged in one command."""
     if args.all:
         snapshot_dir = pathlib.Path(args.snapshot_dir).resolve()
-        # Fetch everything before writing anything. Writing as we go would let a transient apt/os-info failure leave
-        # a mixed-generation directory -- and since pip is fetched first and is the only oracle --strict reads, the
+        # Fetch everything before writing anything. Writing as we go would let a
+        # transient apt/os-info failure leave a mixed-generation directory -- and
+        # since pip is fetched first and is the only oracle --strict reads, the
         # tripwire would go quiet on a refresh that actually failed.
         payloads: dict[str, bytes] = {}
         for upstream_name, snapshot_name in COLAB_ORACLE_FILES.items():

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -175,11 +175,16 @@ COLAB_ORACLE_FILES: dict[str, str] = {
     "apt-list-gpu.txt": "colab_apt_list.gpu.txt",
     "os-info-gpu.txt": "colab_os_info.gpu.txt",
 }
-# Only the pip oracle feeds a rule: `lint --colab-pin` reads it, and that is
-# what R-INST-002/003/004/005 resolve against. apt-list / os-info are human
-# context (what else the image ships), so their drift is reported but never
-# fails --strict -- otherwise an Ubuntu security bump nothing can consult
-# turns the daily cron red.
+# The pip oracle is the one that fails --strict: `lint --colab-pin` reads it, and that is
+# what R-INST-002/003/004/005 resolve against. apt-list drift is reported but never fails,
+# otherwise an Ubuntu security bump nothing can consult turns the daily cron red.
+#
+# os-info is no longer purely human context, though it still does not fail --strict:
+# _marker_environment reads its Python version to decide which requirements pip would skip.
+# It therefore has to be refreshed WITH the pip snapshot, never on its own -- markers
+# evaluated at an old Python against a freshly pulled package set can skip a requirement
+# that applies to the live image, or replay one that does not. notebooks-ci.yml refreshes
+# both together via `refresh-colab --all` for that reason.
 COLAB_STRICT_ORACLE = "pip-freeze.gpu.txt"
 COLAB_ORACLE_BASE_URL = "https://raw.githubusercontent.com/googlecolab/backend-info/main/"
 
@@ -847,8 +852,16 @@ def _split_chained(line: str) -> list[tuple[str, bool]]:
         else:
             if ch in "({":
                 # `$(`, `<(` and `>(` open a substitution, which lives inside a word and runs
-                # its own commands; a bare `(` groups this line's.
-                groupings.append(not (ch == "(" and buf and buf[-1] in "$<>"))
+                # its own commands; a bare `(` groups this line's. `${ }` is a parameter
+                # expansion, which runs nothing at all: the `||` in `${X:-a||pip install ...}`
+                # is part of the fallback WORD, so splitting there manufactures a pip command
+                # bash never runs and R-INST-001 rejects a clean notebook over it.
+                groupings.append(
+                    not (
+                        (ch == "(" and buf and buf[-1] in "$<>")
+                        or (ch == "{" and buf and buf[-1] == "$")
+                    )
+                )
                 tails.append(False)
                 if not "".join(buf).strip():
                     buf_conditional = any(tails)  # the group opens before the command
@@ -1446,9 +1459,16 @@ def _effective_version(
         if exact is not None:
             current, exact_known = exact, True
         elif current is None:
-            # Absent, so the install puts it there. A floor is all that can be said about
-            # where; without one there is nothing to say at all.
-            if floor is not None and not exclusive_floor:
+            # Absent, so the install puts it there, and the question is only where. A `<=V`
+            # names it exactly: pip takes the highest release the requirement allows, which
+            # is V. Treating a cap-only requirement as "still absent" was a miss, since
+            # `pip uninstall torchcodec` then `pip install "torchcodec<=0.10"` really does
+            # leave 0.10 installed. A floor alone says at least how low it can be. An
+            # exclusive ceiling names nothing, because which release sits just below it
+            # depends on the index.
+            if cap is not None:
+                current, exact_known = cap, True
+            elif floor is not None and not exclusive_floor:
                 current, exact_known = floor, landing is not None
         elif floor is not None and (
             cmp_versions(floor, current) > 0

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -121,6 +121,12 @@ def _marker_environment(colab: dict[str, str]) -> dict[str, str] | None:
         "platform_system": "Linux",
         "platform_machine": "x86_64",
         "os_name": "posix",
+        # A requirement handed straight to pip is not being evaluated for a selected extra,
+        # so `extra` has the known empty value and any `extra == "..."` marker is false.
+        # Omitting it made _requirement_applies replay requirements pip discards, e.g.
+        # `pip install "torch==2.12.0; extra == 'foo'"`, which pip reports as
+        # `Ignoring torch: markers 'extra == "foo"' don't match your environment`.
+        "extra": "",
     }
 
 
@@ -1977,6 +1983,13 @@ def cmd_lint(args: argparse.Namespace) -> int:
         # Whole-notebook rules: install steps may span multiple cells, so merge
         # before resolving compat against Colab.
         merged = "\n".join(c for _, c in cells)
+        # A cell can look like an install and contain none -- `!echo "pip install foo"` matches
+        # _PIP_CELL_RE but runs no pip. The compat rules then resolve nothing and compare the
+        # bare oracle against itself, so any finding describes the base image rather than the
+        # notebook (R-INST-003 fires on Colab's own peft/torchao pair). A notebook with no
+        # install cell at all is already skipped; this makes the lookalike behave the same.
+        if not any(True for _ in iter_pip_invocations(merged)):
+            merged = ""
         if env == "colab" and merged:
             first_cell = cells[0][0] if cells else None
             findings += rule_inst_003_peft_torchao(merged, oracle, rel, first_cell)

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -386,6 +386,12 @@ def cmp_versions(a: str, b: str) -> int:
         return tuple(int(x) for x in re.findall(r"\d+", normalise_version(v)))
 
     ta, tb = to_tuple(a), to_tuple(b)
+    # PEP 440 pads the shorter release segment with zeros, so `0.11` and `0.11.0` are the
+    # same version. Comparing the raw tuples made `0.11` sort BELOW `0.11.0`, which discarded
+    # a ceiling-derived minor whenever the floor spelled out its patch.
+    width = max(len(ta), len(tb))
+    ta = ta + (0,) * (width - len(ta))
+    tb = tb + (0,) * (width - len(tb))
     if ta < tb:
         return -1
     if ta > tb:
@@ -410,10 +416,22 @@ class PipInvocation:
 # `python -m pip` is pip's own recommended invocation, so it has to parse to the same
 # thing as bare `pip`. Without it a cell still matched _PIP_CELL_RE, yielded no
 # invocation, and R-INST-001 missed a prohibited `git+` install outright.
+# The interpreter spellings `python -m pip` really appears under. Kept in step with
+# docker/unsloth_nb_pip_magic.py::_PY_M_PIP, which rewrites the same forms at runtime: a
+# notebook the shim handles must not be one the validator reads as running no pip at all.
+# Transformers see the RAW cell text (IPython expands `{sys.executable}` later), so the
+# braced form and quoted or bare interpreter paths have to be matched here too.
+_INTERPRETER_RE = r"""(?:
+        (?:python[0-9.]*|py)
+      | ["']?\{\s*sys\.executable\s*\}["']?
+      | "(?:[^"]*[/\\])python[0-9.]*(?:\.exe)?"
+      | '(?:[^']*[/\\])python[0-9.]*(?:\.exe)?'
+      | \S*[/\\]python[0-9.]*(?:\.exe)?
+    )"""
 PIP_LINE_RE = re.compile(
-    r"^\s*!\s*(?P<tool>(?:uv\s+)?pip|python[0-9.]*\s+-m\s+pip)\s+"
+    r"^\s*!\s*(?P<tool>(?:uv\s+)?pip|" + _INTERPRETER_RE + r"\s+-m\s+pip)\s+"
     r"(?P<action>install|uninstall)\b(?P<rest>.*)$",
-    re.IGNORECASE,
+    re.IGNORECASE | re.VERBOSE,
 )
 NON_PKG_FLAG_TAKES_VAL = {
     "-r",
@@ -677,7 +695,18 @@ def _unwrap_shell_group(command: str) -> tuple[str, bool]:
     # the command: a bare rstrip(")}") ate it, so `x) echo $(pip install ...)` came back as
     # `echo $(pip install ...` and _substitution_bodies could no longer read the body out.
     # A piece can also be a lone `}` when a group spans a separator, which still strips.
-    stripped = stripped.lstrip("({").strip()
+    # `{` opens a shell group only as its OWN token (POSIX reserved word), so `{ pip
+    # install x; }` is a group while IPython's `{sys.executable}` is a single word that
+    # expands to an interpreter path. Stripping it unconditionally left `sys.executable}`
+    # as the executable and hid the pip command behind it. `(` needs no such space.
+    while stripped:
+        if stripped[0] == "(":
+            stripped = stripped[1:].lstrip()
+        elif stripped[0] == "{" and (len(stripped) == 1 or stripped[1].isspace()):
+            stripped = stripped[1:].lstrip()
+        else:
+            break
+    stripped = stripped.strip()
     while stripped[-1:] in (")", "}") and not _final_bracket_closes_substitution(stripped):
         stripped = stripped[:-1].rstrip()
     conditional = False
@@ -1808,6 +1837,13 @@ def rule_l12_exceptions_coverage(notebooks_dir: pathlib.Path) -> list[Finding]:
             continue
         nb = load_notebook(path)
         for idx, cell in install_cells(nb):
+            # install_cells is a text heuristic, so a documentation-only line such as
+            # `!echo "pip install peft"` reaches here running no pip at all. `applies` then
+            # sees the package name in the prose and demands a policy clause the notebook
+            # has no install to carry, which is a blocking R-EXC-001. cmd_lint gates on a
+            # parsed invocation for the same reason; this path had no such gate.
+            if not any(True for _ in iter_pip_invocations(cell)):
+                continue
             for cid, pat, applies in clauses:
                 if not applies(cell):
                     continue

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -208,10 +208,6 @@ TORCH_TORCHCODEC: dict[str, set[str]] = {
     "2.5": {"0.1"},
 }
 
-# torchcodec 0.12+ is ABI-stable against torch >=2.11, so that half is open-ended.
-TORCHCODEC_ABI_STABLE_TORCH = "2.11"
-TORCHCODEC_ABI_STABLE_CODEC = "0.12"
-
 # When peft >= trigger is on the resolved set, torchao >= floor must also be.
 PEFT_TORCHAO_FLOOR: list[dict[str, str]] = [
     {"trigger_peft": "0.19", "torchao_floor": "0.16.0"},

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -92,10 +92,23 @@ _COLAB_OS_INFO_FILE = DATA_DIR / "colab_os_info.gpu.txt"
 _COLAB_PYTHON_RE = re.compile(r"^Python\s+(\d+\.\d+(?:\.\d+)?)", re.MULTILINE)
 
 
+# Directory the OS oracle is read from. Follows `lint --colab-pin` so the Python version
+# and the package snapshot always come from the SAME capture: a pin outside scripts/data
+# paired with this repo's committed os-info would evaluate markers against a different
+# image's interpreter than the packages being judged.
+_COLAB_ORACLE_DIR: pathlib.Path = DATA_DIR
+
+
+def _set_colab_oracle_dir(directory: pathlib.Path) -> None:
+    global _COLAB_ORACLE_DIR
+    _COLAB_ORACLE_DIR = directory
+    _colab_python_version.cache_clear()
+
+
 @functools.lru_cache(maxsize = 1)
 def _colab_python_version() -> str | None:
     try:
-        text = _COLAB_OS_INFO_FILE.read_text(encoding = "utf-8")
+        text = (_COLAB_ORACLE_DIR / _COLAB_OS_INFO_FILE.name).read_text(encoding = "utf-8")
     except OSError:
         return None
     match = _COLAB_PYTHON_RE.search(text)
@@ -1911,6 +1924,8 @@ def cmd_convert(args: argparse.Namespace) -> int:
 def cmd_lint(args: argparse.Namespace) -> int:
     nbdir = pathlib.Path(args.notebooks_dir).resolve()
     colab_path = pathlib.Path(args.colab_pin).resolve() if args.colab_pin else COLAB_FALLBACK_FILE
+    # Pair the marker oracle with the package snapshot actually being used.
+    _set_colab_oracle_dir(colab_path.parent)
     colab = parse_pip_freeze(colab_path)
     if not colab:
         print(

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -2249,9 +2249,7 @@ def cmd_colab_diff(args: argparse.Namespace) -> int:
             strict_diff = True
         elif drifted_strict_keys:
             strict_diff = True
-            print(
-                f"  (rule-bearing key drifted: {', '.join(drifted_strict_keys)})"
-            )
+            print(f"  (rule-bearing key drifted: {', '.join(drifted_strict_keys)})")
         for k, v in new[:50]:
             print(f"  NEW      {k}=={v}")
         if len(new) > 50:

--- a/scripts/notebook_validator.py
+++ b/scripts/notebook_validator.py
@@ -1535,39 +1535,6 @@ def rule_inst_003_peft_torchao(
     return findings
 
 
-def _requested_bounds(install_cell: str, package: str) -> tuple[str, str]:
-    """The cell's `>=` floor and `<` ceiling for `package`, each "" when absent."""
-    floor = ceiling = ""
-    for invocation in iter_pip_invocations(install_cell):
-        for requirement in invocation.packages:
-            if not re.match(rf"\s*{re.escape(package)}\s*[><=!~]", requirement):
-                continue
-            for operator, version in re.findall(r"([><=!~]=?)\s*([0-9][0-9.]*)", requirement):
-                if operator == ">=" and (not floor or cmp_versions(version, floor) > 0):
-                    floor = version
-                elif operator == "<" and (not ceiling or cmp_versions(version, ceiling) < 0):
-                    ceiling = version
-    return floor, ceiling
-
-
-def _effective_requested_version(install_cell: str, package: str, oracle: str) -> str:
-    """What pip actually leaves installed, when the cell's range rules the oracle out.
-
-    resolved_set only overrides the oracle on an exact `==` pin, so a range such as
-    `torchcodec>=0.10.0,<0.11.0` still reads as whatever the image preinstalled. When the
-    oracle satisfies the range it does survive; otherwise pip must move, and the floor is
-    the version it moves to for the one-minor-wide ranges these rules care about.
-    """
-    floor, ceiling = _requested_bounds(install_cell, package)
-    if not floor and not ceiling:
-        return oracle
-    if floor and cmp_versions(oracle, floor) < 0:
-        return floor
-    if ceiling and cmp_versions(oracle, ceiling) >= 0:
-        return floor or oracle
-    return oracle
-
-
 def rule_inst_004_torchcodec_torch(
     install_cell: str, colab: dict[str, str], file: str, cell_idx: int
 ) -> list[Finding]:
@@ -1580,10 +1547,6 @@ def rule_inst_004_torchcodec_torch(
     )
     if not torch_v or not codec_v:
         return findings
-    # resolved_set keeps the oracle's preinstalled version for anything the cell does not pin
-    # exactly, so a cell asking for `torchcodec>=0.12.0` still reads as Colab's 0.11 and the
-    # branches below report a mismatch pip would never produce. Judge what pip installs.
-    codec_v = _effective_requested_version(install_cell, "torchcodec", codec_v)
     # torchcodec 0.12+ is ABI-stable against torch >=2.11 (its build sets TORCH_TARGET_VERSION
     # to 2.11), so that half of the matrix is open-ended and cannot be a finite set of minors.
     # Without this, adding the 2.11 row below would flag torch 2.11 with torchcodec 0.12

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1810,7 +1810,9 @@ def test_the_os_oracle_is_documented_as_feeding_marker_evaluation():
     The workflow has to refresh it with the pip snapshot; asserted here so the two cannot
     drift apart silently again.
     """
-    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
+    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text(
+        encoding = "utf-8"
+    )
     assert "refresh-colab \\\n              --all --snapshot-dir" in workflow
     assert "--out unsloth/scripts/data/colab_pip_freeze.gpu.txt \\\n            ||" not in workflow
 
@@ -1872,7 +1874,9 @@ def test_notebooks_ci_watches_the_oracle_that_feeds_marker_evaluation():
     """_marker_environment reads the image's Python out of colab_os_info.gpu.txt, so an
     OS-only rotation changes which requirements the validator replays. Without the path
     filter entry that PR would not run the lint and smoke jobs the change affects."""
-    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
+    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text(
+        encoding = "utf-8"
+    )
     paths = workflow.split("paths:", 1)[1].split("jobs:", 1)[0]
     assert "'scripts/data/colab_os_info.gpu.txt'" in paths
     assert "'scripts/data/colab_pip_freeze.gpu.txt'" in paths
@@ -1906,7 +1910,9 @@ def test_the_cron_refreshes_both_oracles_not_just_the_packages():
     """The scheduled job linted with a freshly refreshed pip snapshot against a stale
     os-info, so after a Colab Python rotation it judged the new packages with the old
     interpreter. The PR-time step already uses --all; this one has to match."""
-    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
+    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text(
+        encoding = "utf-8"
+    )
     assert "--out unsloth/scripts/data/colab_pip_freeze.gpu.txt" not in workflow
     assert workflow.count("--all --snapshot-dir unsloth/scripts/data") >= 2
 
@@ -2102,7 +2108,9 @@ def test_the_cron_lint_job_installs_packaging():
     without packaging silently replays every environment-marked requirement -- including the
     ones Colab's pip skips, which is the question the Python-version oracle exists to answer.
     A bare setup-python environment does not provide it."""
-    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
+    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text(
+        encoding = "utf-8"
+    )
 
     install_steps = [
         line.strip()

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -272,7 +272,7 @@ def test_notebook_validator_respects_escaped_separators():
     parse_pip_line. Split on it and the fragment ends in a backslash and parses as nothing."""
     nv = _load_notebook_validator_module()
 
-    escaped = "!pip install torch==2.12.0\;\\ python_version\\ \\>\\=\\ \\'3.10\\'"
+    escaped = "!pip install torch==2.12.0\\;\\ python_version\\ \\>\\=\\ \\'3.10\\'"
     assert nv._split_chained(escaped) == [(escaped, False)]
     assert [inv.packages for inv in nv.iter_pip_invocations(escaped)] == [
         ["torch==2.12.0; python_version >= '3.10'"]

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -590,6 +590,39 @@ def test_notebook_validator_moves_off_an_exclusive_endpoint():
             len(nv.rule_inst_004_torchcodec_torch(cell, on_the_endpoint, "nb.ipynb", 0)) == 1
         ), cell
 
+def test_every_rule_reads_the_filtered_invocations():
+    """Every reader asks what the cell leaves installed and takes the filtered iterator.
+    R-INST-001 asks what could run at all, and answers it from whole lines instead."""
+    nv = _load_notebook_validator_module()
+
+    cell = "!pip install foo || pip install --no-deps git+https://example.com/evil.git"
+    assert [inv.packages for inv in nv.unconditional_pip_invocations(cell)] == [["foo"]]
+    assert len(list(nv.iter_pip_invocations(cell))) == 2
+
+    # The ban reads whole lines, so no shell construct can put a git+ source out of reach.
+    for evil in (
+        cell,
+        "!pip install foo || (pip install git+https://example.com/evil.git)",
+        "!pip install foo || if command -v uv; then pip install git+https://example.com/evil.git; fi",
+    ):
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(evil, "nb.ipynb", 0)
+        ), evil
+
+    # Still line-scoped: the allowlist holds, and a line with no pip command is not an install.
+    assert (
+        nv.rule_inst_001_git_plus(
+            "!pip install git+https://github.com/unslothai/unsloth-zoo.git", "nb.ipynb", 0
+        )
+        == []
+    )
+    assert nv.rule_inst_001_git_plus('x = "git+https://example.com/evil.git"', "nb.ipynb", 0) == []
+
+    source = (REPO_ROOT / "scripts" / "notebook_validator.py").read_text(encoding = "utf-8")
+    assert (
+        source.count("in iter_pip_invocations(install_cell)") == 1
+    ), "only unconditional_pip_invocations may read the raw iterator; rules take the filtered one"
+
 def test_notebook_validator_keeps_a_group_conditional_throughout():
     """An `&&` or `;` inside a `(` or `{` group belongs to the group, so it does not end the
     fallback: if the left side succeeded, nothing in the group runs."""
@@ -669,6 +702,28 @@ def test_notebook_validator_reads_an_archive_given_as_a_path():
         == 1
     )
 
+def test_git_allowlist_is_scoped_to_each_source():
+    """One allowlisted repository on a line must not clear a prohibited one beside it. The
+    line-level scan finds every `git+` target; the allowlist then applies to each."""
+    nv = _load_notebook_validator_module()
+
+    allowed = "git+https://github.com/unslothai/unsloth-zoo.git"
+    evil = "git+https://example.com/evil.git"
+
+    assert nv.rule_inst_001_git_plus(f"!pip install {allowed}", "nb.ipynb", 0) == []
+    for cell in (
+        f"!pip install {evil}",
+        f"!pip install {allowed} ; pip install {evil}",
+        f"!pip install {allowed} || pip install {evil}",
+        f"!pip install {allowed} {evil}",
+    ):
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0)
+        ), cell
+
+    two_allowed = "!pip install {} git+https://github.com/state-spaces/mamba.git".format(allowed)
+    assert nv.rule_inst_001_git_plus(two_allowed, "nb.ipynb", 0) == []
+
 def test_notebook_validator_keeps_the_stricter_of_two_equal_floors():
     """`>=0.8.0,>0.8.0` intersect to the exclusive one, so the installed 0.8.0 still moves."""
     nv = _load_notebook_validator_module()
@@ -709,6 +764,50 @@ def test_notebook_validator_reads_a_named_direct_reference():
             )
         )
         == 1
+    )
+
+def test_git_allowlist_matches_the_repository_not_a_substring():
+    """An arbitrary repository can carry an allowlisted path inside its own, so the allowlist
+    is compared against the normalised host and path."""
+    nv = _load_notebook_validator_module()
+
+    assert (
+        nv._git_source_repository("git+https://user:pw@github.com/state-spaces/mamba.git@v2.0")
+        == "github.com/state-spaces/mamba"
+    )
+    assert nv._git_source_is_allowed("git+https://github.com/unslothai/unsloth-zoo.git")
+    assert not nv._git_source_is_allowed(
+        "git+https://evil.example/repo/github.com/unslothai/unsloth.git"
+    )
+
+    smuggled = "!pip install git+https://evil.example/repo/github.com/unslothai/unsloth.git"
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(smuggled, "nb.ipynb", 0))
+
+    # Credentials and a trailing ref do not stop an allowlisted repository from matching.
+    assert (
+        nv.rule_inst_001_git_plus(
+            "!pip install git+https://user:pw@github.com/state-spaces/mamba.git@v2.0", "nb.ipynb", 0
+        )
+        == []
+    )
+
+def test_git_ban_reads_commands_not_the_comment():
+    """`_split_chained` drops a shell comment, so a comment naming a prohibited source is
+    documentation and must not fail the notebook."""
+    nv = _load_notebook_validator_module()
+
+    assert (
+        nv.rule_inst_001_git_plus(
+            "!pip install foo # avoid git+https://example.com/evil.git", "nb.ipynb", 0
+        )
+        == []
+    )
+    # The executable half of the same line still counts.
+    assert any(
+        f.rule == "R-INST-001"
+        for f in nv.rule_inst_001_git_plus(
+            "!pip install git+https://example.com/evil.git # needed", "nb.ipynb", 0
+        )
     )
 
 def test_notebook_validator_ends_a_grouped_and_or_list_at_its_own_operator():
@@ -878,6 +977,24 @@ def test_notebook_validator_reads_a_compound_only_line():
         == 1
     )
 
+def test_git_ban_reads_the_arguments_shlex_produced():
+    """`"git+"https://...` is one argument to pip and two words to a text scan, so the
+    source has to be looked for in the parsed packages as well as in the command text."""
+    nv = _load_notebook_validator_module()
+
+    concatenated = '!pip install "git+"https://example.com/evil.git'
+    assert any(
+        f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(concatenated, "nb.ipynb", 0)
+    )
+
+    # The allowlist still applies to the joined argument.
+    assert (
+        nv.rule_inst_001_git_plus(
+            '!pip install "git+"https://github.com/unslothai/unsloth-zoo.git', "nb.ipynb", 0
+        )
+        == []
+    )
+
 def test_notebook_validator_keeps_a_pip_call_used_as_a_test():
     """`if pip install ...` is the condition, reached whenever the line is. Only a `then`,
     `elif`, `else` or `do` body depends on how that condition went."""
@@ -896,6 +1013,27 @@ def test_notebook_validator_keeps_a_pip_call_used_as_a_test():
         '!while true; do pip install "torch==2.12.0"; done',
     ):
         assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], cell
+
+def test_git_ban_only_reads_pip_commands():
+    """A `git+` in an `echo` beside an install installs nothing. The scan is per command, and
+    only the ones that parse as pip count."""
+    nv = _load_notebook_validator_module()
+
+    assert (
+        nv.rule_inst_001_git_plus(
+            "!echo git+https://example.com/evil.git; pip install numpy", "nb.ipynb", 0
+        )
+        == []
+    )
+    assert nv.rule_inst_001_git_plus("!echo git+https://example.com/evil.git", "nb.ipynb", 0) == []
+
+    # The install beside it still counts when it is the one carrying the source.
+    assert any(
+        f.rule == "R-INST-001"
+        for f in nv.rule_inst_001_git_plus(
+            "!echo installing; pip install git+https://example.com/evil.git", "nb.ipynb", 0
+        )
+    )
 
 def test_notebook_validator_evaluates_environment_markers():
     """pip skips a requirement whose marker is false, so replaying its bounds moves a version
@@ -971,6 +1109,29 @@ def test_notebook_validator_expands_bundled_short_flags():
         == 1
     )
 
+def _one_cell_notebook(source: str) -> dict:
+    return {"cells": [{"cell_type": "code", "source": source.splitlines(keepends = True)}]}
+
+def test_install_cell_discovery_finds_compound_commands():
+    """The rules only see cells `install_cells` hands them, and it wanted `pip` right after
+    the `!`, so every compound form was invisible to the real lint flow no matter what the
+    splitter did with it."""
+    nv = _load_notebook_validator_module()
+
+    for source in (
+        "!pip install torch==2.12.0",
+        "!uv pip install torch",
+        "!pip uninstall -y torchcodec",
+        "!if command -v uv; then pip install git+https://example.com/x.git; fi",
+        "!echo start; pip install torch==2.12.0",
+        "!pip install foo || (pip install git+https://example.com/x.git)",
+    ):
+        assert nv.install_cells(_one_cell_notebook(source)), source
+
+    # Still anchored on the `!`, so a pip mention in Python is not an install cell.
+    for source in ('cmd = "pip install torch"', "import torch", "# pip install torch"):
+        assert nv.install_cells(_one_cell_notebook(source)) == [], source
+
 def test_notebook_validator_splits_on_single_control_operators():
     """`A & B` backgrounds A and runs B, `A | B` runs both. Neither opened a command boundary,
     so a line starting with something other than pip hid the install entirely."""
@@ -998,6 +1159,87 @@ def test_notebook_validator_splits_on_single_control_operators():
         "!pip install foo > log 2>&1"
     ]
     assert nv._split_chained('!pip install "a&b"')[0][0] == '!pip install "a&b"'
+
+def test_torchao_floor_ignores_a_requirement_pip_skips():
+    """R-INST-003 reads the floor from the same cell, so a requirement whose marker is false
+    must not satisfy it either."""
+    nv = _load_notebook_validator_module()
+
+    colab = {"peft": "0.20.0", "torchao": "0.10.0"}
+    assert [
+        f.rule
+        for f in nv.rule_inst_003_peft_torchao(
+            "!pip install \"torchao>=0.16.0; python_version < '3.10'\"", colab, "nb.ipynb", 0
+        )
+    ] == ["R-INST-003"]
+
+    # A marker that holds, and no marker at all, both still clear the floor.
+    for cell in (
+        "!pip install \"torchao>=0.16.0; python_version >= '3.10'\"",
+        '!pip install "torchao>=0.16.0"',
+    ):
+        assert nv.rule_inst_003_peft_torchao(cell, colab, "nb.ipynb", 0) == [], cell
+
+def test_git_allowlist_resolves_dot_segments_and_matches_exactly():
+    """`unslothai/unsloth/../../attacker/repo` reads as an allowlisted prefix and resolves to
+    somebody else's repository. Every entry is one `host/org/repo`, and pip puts a
+    subdirectory in the fragment, so the match is exact."""
+    nv = _load_notebook_validator_module()
+
+    assert (
+        nv._git_source_repository(
+            "git+https://github.com/unslothai/unsloth/../../attacker/repo.git"
+        )
+        == "github.com/attacker/repo"
+    )
+    assert not nv._git_source_is_allowed(
+        "git+https://github.com/unslothai/unsloth/../../attacker/repo.git"
+    )
+    assert not nv._git_source_is_allowed("git+https://github.com/unslothai/unsloth/extra.git")
+
+    # The real forms still match: a ref, credentials, a fragment.
+    for allowed in (
+        "git+https://github.com/unslothai/unsloth.git",
+        "git+https://user:pw@github.com/state-spaces/mamba.git@v2.0",
+        "git+https://github.com/unslothai/unsloth-zoo.git#subdirectory=x",
+    ):
+        assert nv._git_source_is_allowed(allowed), allowed
+
+    smuggled = "!pip install git+https://github.com/unslothai/unsloth/../../attacker/repo.git"
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(smuggled, "nb.ipynb", 0))
+
+def test_install_cell_discovery_glues_continuations():
+    """A `\\` continuation can put the `!` and the pip call on different physical lines, and
+    discovery reads lines."""
+    nv = _load_notebook_validator_module()
+
+    source = "!echo ready && \\\n  pip install git+https://example.com/pkg.git"
+    assert nv.install_cells(_one_cell_notebook(source))
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(source, "nb.ipynb", 0))
+
+def test_no_deps_rules_skip_a_requirement_pip_skips(monkeypatch):
+    """R-INST-002 and R-INST-005 read the raw pins themselves, so a marker-false `--no-deps`
+    requirement must not be treated as installed by either."""
+    nv = _load_notebook_validator_module()
+    monkeypatch.setattr(
+        nv,
+        "pypi_metadata",
+        lambda name, version: {"info": {"requires_dist": ["tokenizers (>=0.30.0)"]}}
+        if name.lower() == "transformers"
+        else None,
+    )
+    colab = {"transformers": "5.0.0", "tokenizers": "0.22.2"}
+
+    skipped = "!pip install --no-deps \"transformers==5.5.0; python_version < '3.10'\""
+    assert nv.rule_inst_002_no_deps_transitive(skipped, colab, "nb.ipynb", 0) == []
+    assert nv.rule_inst_005_transformers_tokenizers(skipped, colab, "nb.ipynb", 0) == []
+
+    for applied in (
+        "!pip install --no-deps \"transformers==5.5.0; python_version >= '3.10'\"",
+        '!pip install --no-deps "transformers==5.5.0"',
+    ):
+        assert nv.rule_inst_002_no_deps_transitive(applied, colab, "nb.ipynb", 0), applied
+        assert nv.rule_inst_005_transformers_tokenizers(applied, colab, "nb.ipynb", 0), applied
 
 def test_notebook_validator_splits_keywords_on_any_whitespace():
     """A tab after `then` is the same command to the shell. Splitting on a literal space left
@@ -1227,6 +1469,26 @@ def test_notebook_validator_keeps_substitution_commands_in_order():
     findings = nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0)
     assert len(findings) == 1
     assert "torchcodec==0.11.0" in findings[0].message
+
+def test_git_sources_are_matched_case_insensitively():
+    """pip normalises `Git+https://` to the same link, so the ban has to see it."""
+    nv = _load_notebook_validator_module()
+
+    for cell in (
+        "!pip install Git+https://example.com/pkg.git",
+        "!pip install GIT+HTTPS://example.com/pkg.git",
+    ):
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0)
+        ), cell
+
+    # The allowlist still clears an allowlisted repository whatever the case.
+    assert (
+        nv.rule_inst_001_git_plus(
+            "!pip install Git+https://github.com/unslothai/unsloth-zoo.git", "nb.ipynb", 0
+        )
+        == []
+    )
 
 def test_notebook_validator_skips_a_prefixs_own_options():
     """`env -u VAR pip install ...` runs pip, and stripping only the word left the options in

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1864,3 +1864,13 @@ def test_a_cell_that_only_mentions_pip_is_not_an_install_cell():
     assert nv.install_cells(nb) == [(0, mention)]
     # But it parses to no invocation, which is what the compat rules key off now.
     assert list(nv.iter_pip_invocations(mention)) == []
+
+
+def test_notebooks_ci_watches_the_oracle_that_feeds_marker_evaluation():
+    """_marker_environment reads the image's Python out of colab_os_info.gpu.txt, so an
+    OS-only rotation changes which requirements the validator replays. Without the path
+    filter entry that PR would not run the lint and smoke jobs the change affects."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
+    paths = workflow.split("paths:", 1)[1].split("jobs:", 1)[0]
+    assert "'scripts/data/colab_os_info.gpu.txt'" in paths
+    assert "'scripts/data/colab_pip_freeze.gpu.txt'" in paths

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -3,7 +3,9 @@
 """torch / torchcodec ABI guardrails (unslothai/unsloth#7225)."""
 
 from __future__ import annotations
+import argparse
 import importlib.util
+import json
 import re
 import sys
 import types
@@ -1907,3 +1909,87 @@ def test_the_cron_refreshes_both_oracles_not_just_the_packages():
     workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
     assert "--out unsloth/scripts/data/colab_pip_freeze.gpu.txt" not in workflow
     assert workflow.count("--all --snapshot-dir unsloth/scripts/data") >= 2
+
+
+def test_python_dash_m_pip_is_a_pip_invocation():
+    """`python -m pip` is pip's own recommended invocation, and the cell regex already
+    selected it, so a notebook using it reached the rules with zero invocations and
+    R-INST-001 missed a prohibited `git+` install outright."""
+    nv = _load_notebook_validator_module()
+
+    for line in (
+        "!python -m pip install git+https://example.com/pkg.git",
+        "!python3 -m pip install git+https://example.com/pkg.git",
+        "!python3.11 -m pip install -q git+https://example.com/pkg.git",
+    ):
+        invocations = list(nv.iter_pip_invocations(line))
+        assert len(invocations) == 1, line
+        assert invocations[0].tool == "pip", line
+        assert invocations[0].packages == ["git+https://example.com/pkg.git"], line
+        assert nv.rule_inst_001_git_plus(line, "nb/T.ipynb", 0), line
+
+    # The bare forms keep their own tool, and a lookalike is still not pip.
+    assert next(nv.iter_pip_invocations("!uv pip install foo")).tool == "uv-pip"
+    assert next(nv.iter_pip_invocations("!pip install foo")).tool == "pip"
+    assert not list(nv.iter_pip_invocations("!python -m pipx install foo"))
+
+
+def test_a_conditional_only_cell_does_not_replay_the_bare_oracle(tmp_path):
+    """`!command -v uv || pip install foo` runs pip only on the fallback side, so the
+    compat rules -- which replay UNCONDITIONAL invocations only -- resolved nothing and
+    compared the Colab oracle against itself, blaming an unrelated notebook for the base
+    image's own peft/torchao pair."""
+    nv = _load_notebook_validator_module()
+
+    conditional = "!command -v uv || pip install foo"
+    assert list(nv.iter_pip_invocations(conditional))
+    assert not list(nv.unconditional_pip_invocations(conditional))
+
+    colab = {"peft": "0.20.0", "torchao": "0.10.0"}
+    # The rule itself still reports on the bare oracle; the gate in cmd_lint is what keeps
+    # such a cell away from it, so assert the property the gate reads.
+    assert nv.rule_inst_003_peft_torchao(conditional, colab, "nb/T.ipynb", 0)
+
+    notebook = {
+        "cells": [{
+            "cell_type": "code",
+            "metadata": {},
+            "source": [conditional + "\n"],
+            "outputs": [],
+            "execution_count": None,
+        }],
+        "metadata": {"kernelspec": {"name": "python3", "display_name": "Python 3"},
+                     "language_info": {"name": "python"}},
+        "nbformat": 4,
+        "nbformat_minor": 0,
+    }
+    nb_dir = tmp_path / "nb"
+    nb_dir.mkdir()
+    (nb_dir / "Conditional_Only.ipynb").write_text(json.dumps(notebook), encoding = "utf-8")
+
+    args = argparse.Namespace(
+        notebooks_dir = str(tmp_path), colab_pin = None, no_pypi = True, json = False,
+    )
+    findings: list = []
+    original_emit = nv._emit
+    nv._emit = lambda f: findings.extend(f)
+    try:
+        nv.cmd_lint(args)
+    finally:
+        nv._emit = original_emit
+    assert [f for f in findings if f.rule.startswith("R-INST-00")] == []
+
+
+def test_python_version_drift_in_the_os_oracle_fails_strict():
+    """_marker_environment reads the Python line out of os-info, so that key is
+    rule-bearing even though the rest of the file is human context. With only the pip
+    freeze named strict, a Colab interpreter bump behind an unchanged package set left the
+    cron green and the committed Python stale."""
+    nv = _load_notebook_validator_module()
+
+    assert nv.COLAB_STRICT_ORACLE == "pip-freeze.gpu.txt"
+    assert "python" in nv.COLAB_STRICT_ORACLE_KEYS["os-info-gpu.txt"]
+    # apt-list stays fully advisory: an Ubuntu bump nothing consults must not go red.
+    assert "apt-list-gpu.txt" not in nv.COLAB_STRICT_ORACLE_KEYS
+    # The key is the one _parse_os_lines actually emits for that line.
+    assert nv._parse_os_lines("Python 3.13.15\nUbuntu 22.04\n")["python"] == "3.13.15"

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -561,10 +561,8 @@ def test_notebook_validator_applies_exclusions_to_where_it_landed():
     nv = _load_notebook_validator_module()
 
     newer = {"torch": "2.10.0+cu128", "torchcodec": "0.15.0"}
-    # An earlier pin puts the codec above the cap, so the cap applies inside the replay
-    # rather than in resolved_set. It says 0.11, the exclusion rules the whole 0.11 line out,
-    # and pip lands below it: recording the cap reported a 0.11 codec against torch 2.10 when
-    # what actually installs there is a 0.10 release the row allows.
+    # The cap says 0.11, the exclusion rules that whole line out, and pip lands below it, so
+    # recording the cap reported a 0.11 codec where a 0.10 the row allows is what installs.
     capped = '!pip install "torchcodec==0.15"\n!pip install "torchcodec<=0.11,!=0.11.*"'
     assert nv.rule_inst_004_torchcodec_torch(capped, newer, "nb.ipynb", 0) == []
 

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1748,3 +1748,64 @@ def test_an_arm_close_paren_is_not_stripped_off_a_substitution():
     assert nv._substitution_bodies(text) == ["pip install git+https://e.com/p.git"]
     # A real group still loses its brackets.
     assert nv._unwrap_shell_group("( pip install x )")[0] == "pip install x"
+
+
+# ----------------------------------------------------------------------------------
+# Codex review round 11 (2026-09-06), on the split-out branch.
+# ----------------------------------------------------------------------------------
+
+
+def test_operators_inside_a_parameter_expansion_stay_literal():
+    """`${X:-a||b}` is one word to bash; the `||` is part of the fallback, not a list.
+
+    Splitting there manufactured a pip command bash never runs, so R-INST-001 rejected a
+    notebook whose only install was an `echo`. A false positive, unlike the other three.
+    """
+    nv = _load_notebook_validator_module()
+
+    line = "!echo ${X:-plain||pip install git+https://example.com/pkg.git}"
+    assert len(nv._split_chained(line)) == 1
+    assert nv.rule_inst_001_git_plus(line, "nb.ipynb", 0) == []
+
+    # A `$( )` inside an expansion does run, and is still read.
+    ran = "!echo ${X:-$(pip install git+https://example.com/pkg.git)}"
+    assert [f.rule for f in nv.rule_inst_001_git_plus(ran, "nb.ipynb", 0)] == ["R-INST-001"]
+
+    # A real brace group still splits on its own separators.
+    grouped = "!{ echo a; pip install git+https://example.com/pkg.git; }"
+    assert [f.rule for f in nv.rule_inst_001_git_plus(grouped, "nb.ipynb", 0)] == ["R-INST-001"]
+
+
+def test_a_cap_only_install_after_an_uninstall_lands_on_the_cap():
+    """`pip install "x<=V"` on an absent package installs V, so it is not still absent.
+
+    Treating a cap-only requirement as "nothing was installed" made R-INST-004 silent on an
+    uninstall-then-downgrade, which is exactly the mismatch it exists to catch.
+    """
+    nv = _load_notebook_validator_module()
+
+    cell = '!pip uninstall -y torchcodec\n!pip install "torchcodec<=0.10"'
+    colab = {"torch": "2.11.0+cu128", "torchcodec": "0.11.0+cu128"}
+    assert nv._effective_version(
+        cell, "torchcodec", colab["torchcodec"], nv._marker_environment(colab)
+    ) == ("0.10", True)
+    assert [
+        f.rule for f in nv.rule_inst_004_torchcodec_torch(cell, colab, "nb.ipynb", 0)
+    ] == ["R-INST-004"]
+
+    # An exclusive ceiling names no landing version, so it stays unknown rather than guessing.
+    open_ceiling = '!pip uninstall -y torchcodec\n!pip install "torchcodec<0.11"'
+    assert nv._effective_version(
+        open_ceiling, "torchcodec", colab["torchcodec"], nv._marker_environment(colab)
+    ) == (None, True)
+
+
+def test_the_os_oracle_is_documented_as_feeding_marker_evaluation():
+    """os-info stopped being human-only when markers began reading its Python version.
+
+    The workflow has to refresh it with the pip snapshot; asserted here so the two cannot
+    drift apart silently again.
+    """
+    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
+    assert "refresh-colab \\\n              --all --snapshot-dir" in workflow
+    assert "--out unsloth/scripts/data/colab_pip_freeze.gpu.txt \\\n            ||" not in workflow

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
 """torch / torchcodec ABI guardrails (unslothai/unsloth#7225)."""
 
 from __future__ import annotations

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1789,9 +1789,9 @@ def test_a_cap_only_install_after_an_uninstall_lands_on_the_cap():
     assert nv._effective_version(
         cell, "torchcodec", colab["torchcodec"], nv._marker_environment(colab)
     ) == ("0.10", True)
-    assert [
-        f.rule for f in nv.rule_inst_004_torchcodec_torch(cell, colab, "nb.ipynb", 0)
-    ] == ["R-INST-004"]
+    assert [f.rule for f in nv.rule_inst_004_torchcodec_torch(cell, colab, "nb.ipynb", 0)] == [
+        "R-INST-004"
+    ]
 
     # An exclusive ceiling names no landing version, so it stays unknown rather than guessing.
     open_ceiling = '!pip uninstall -y torchcodec\n!pip install "torchcodec<0.11"'

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1874,3 +1874,36 @@ def test_notebooks_ci_watches_the_oracle_that_feeds_marker_evaluation():
     paths = workflow.split("paths:", 1)[1].split("jobs:", 1)[0]
     assert "'scripts/data/colab_os_info.gpu.txt'" in paths
     assert "'scripts/data/colab_pip_freeze.gpu.txt'" in paths
+
+
+def test_the_marker_oracle_follows_the_selected_pip_snapshot(tmp_path, monkeypatch):
+    """The Python version and the package snapshot must come from the SAME capture.
+
+    _colab_python_version read scripts/data unconditionally, so `lint --colab-pin` pointing
+    at a snapshot captured elsewhere evaluated markers against this repo's committed
+    os-info: a different image's interpreter than the packages being judged.
+    """
+    nv = _load_notebook_validator_module()
+
+    paired = tmp_path / "snap"
+    paired.mkdir()
+    (paired / "colab_os_info.gpu.txt").write_text("Python 3.11.9\n", encoding="utf-8")
+    nv._set_colab_oracle_dir(paired)
+    assert nv._colab_python_version() == "3.11.9"
+
+    # A directory with no os-info answers nothing rather than falling back to the repo's.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    nv._set_colab_oracle_dir(empty)
+    assert nv._colab_python_version() is None
+
+    nv._set_colab_oracle_dir(nv.DATA_DIR)
+
+
+def test_the_cron_refreshes_both_oracles_not_just_the_packages():
+    """The scheduled job linted with a freshly refreshed pip snapshot against a stale
+    os-info, so after a Colab Python rotation it judged the new packages with the old
+    interpreter. The PR-time step already uses --all; this one has to match."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
+    assert "--out unsloth/scripts/data/colab_pip_freeze.gpu.txt" not in workflow
+    assert workflow.count("--all --snapshot-dir unsloth/scripts/data") >= 2

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1951,15 +1951,19 @@ def test_a_conditional_only_cell_does_not_replay_the_bare_oracle(tmp_path):
     assert nv.rule_inst_003_peft_torchao(conditional, colab, "nb/T.ipynb", 0)
 
     notebook = {
-        "cells": [{
-            "cell_type": "code",
-            "metadata": {},
-            "source": [conditional + "\n"],
-            "outputs": [],
-            "execution_count": None,
-        }],
-        "metadata": {"kernelspec": {"name": "python3", "display_name": "Python 3"},
-                     "language_info": {"name": "python"}},
+        "cells": [
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "source": [conditional + "\n"],
+                "outputs": [],
+                "execution_count": None,
+            }
+        ],
+        "metadata": {
+            "kernelspec": {"name": "python3", "display_name": "Python 3"},
+            "language_info": {"name": "python"},
+        },
         "nbformat": 4,
         "nbformat_minor": 0,
     }
@@ -1968,7 +1972,10 @@ def test_a_conditional_only_cell_does_not_replay_the_bare_oracle(tmp_path):
     (nb_dir / "Conditional_Only.ipynb").write_text(json.dumps(notebook), encoding = "utf-8")
 
     args = argparse.Namespace(
-        notebooks_dir = str(tmp_path), colab_pin = None, no_pypi = True, json = False,
+        notebooks_dir = str(tmp_path),
+        colab_pin = None,
+        no_pypi = True,
+        json = False,
     )
     findings: list = []
     original_emit = nv._emit

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -2000,3 +2000,69 @@ def test_python_version_drift_in_the_os_oracle_fails_strict():
     assert "apt-list-gpu.txt" not in nv.COLAB_STRICT_ORACLE_KEYS
     # The key is the one _parse_os_lines actually emits for that line.
     assert nv._parse_os_lines("Python 3.13.15\nUbuntu 22.04\n")["python"] == "3.13.15"
+
+
+def test_expanded_interpreter_forms_run_pip():
+    """`!{sys.executable} -m pip` and an absolute interpreter path are the notebook-standard
+    spellings, and docker/unsloth_nb_pip_magic.py rewrites both at runtime. Accepting only a
+    literal `python*` left them matching _PIP_CELL_RE while yielding no invocation, so
+    R-INST-001 and every compatibility replay skipped the cell."""
+    nv = _load_notebook_validator_module()
+
+    for line in (
+        "!{sys.executable} -m pip install git+https://example.com/pkg.git",
+        '!"{sys.executable}" -m pip install git+https://example.com/pkg.git',
+        "!/usr/bin/python3 -m pip install git+https://example.com/pkg.git",
+        "!python3.11 -m pip install git+https://example.com/pkg.git",
+    ):
+        invocations = list(nv.iter_pip_invocations(line))
+        assert len(invocations) == 1, line
+        assert invocations[0].tool == "pip", line
+        assert invocations[0].packages == ["git+https://example.com/pkg.git"], line
+        assert nv.rule_inst_001_git_plus(line, "nb/T.ipynb", 0), line
+
+    # A real shell brace group still unwraps, and a lookalike is still not pip.
+    assert [i.packages for i in nv.iter_pip_invocations("!{ pip install foo; }")] == [["foo"]]
+    assert [
+        i.packages for i in nv.iter_pip_invocations("!pip install foo && { pip install bar; }")
+    ] == [["foo"], ["bar"]]
+    assert not list(nv.iter_pip_invocations("!{sys.executable} -m pipx install foo"))
+
+
+def test_exception_coverage_skips_cells_that_run_no_pip(tmp_path):
+    """install_cells is a text heuristic, so `!echo "pip install peft"` reaches
+    rule_l12_exceptions_coverage running no pip. Its `applies` predicate saw the package name
+    in the prose and emitted a blocking R-EXC-001 for a clause the notebook has no install to
+    carry. cmd_lint gates on a parsed invocation; this path did not."""
+    nv = _load_notebook_validator_module()
+
+    (tmp_path / "nb").mkdir()
+    (tmp_path / "update_all_notebooks.py").write_text(
+        'DONT_UPDATE_EXCEPTIONS = ["Doc_Only.ipynb"]\n', encoding = "utf-8"
+    )
+
+    def write(source: str) -> None:
+        notebook = {
+            "cells": [{
+                "cell_type": "code",
+                "metadata": {},
+                "source": [source],
+                "outputs": [],
+                "execution_count": None,
+            }],
+            "metadata": {"kernelspec": {"name": "python3", "display_name": "Python 3"},
+                         "language_info": {"name": "python"}},
+            "nbformat": 4,
+            "nbformat_minor": 0,
+        }
+        (tmp_path / "nb" / "Doc_Only.ipynb").write_text(json.dumps(notebook), encoding = "utf-8")
+
+    write('!echo "pip install peft"\n')
+    assert nv.rule_l12_exceptions_coverage(tmp_path) == []
+
+    # A real install missing the clause is still a finding, so the gate did not mute the rule.
+    write("!pip install peft\n")
+    assert [f.rule for f in nv.rule_l12_exceptions_coverage(tmp_path)] == ["R-EXC-001"]
+
+    write('!pip install peft "torchao>=0.16.0"\n')
+    assert nv.rule_l12_exceptions_coverage(tmp_path) == []

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -2070,3 +2070,45 @@ def test_exception_coverage_skips_cells_that_run_no_pip(tmp_path):
 
     write('!pip install peft "torchao>=0.16.0"\n')
     assert nv.rule_l12_exceptions_coverage(tmp_path) == []
+
+
+def test_python_dash_m_uv_pip_is_a_uv_invocation():
+    """unsloth_nb_pip_magic rewrites `(pip|uv)` after the module flag, and uv's
+    pip-compatible interface is spelled `uv pip <action>`. Accepting only `-m pip` left
+    `!python -m uv pip install ...` matching _PIP_CELL_RE while yielding no invocation, so
+    R-INST-001 missed a prohibited git+ source the notebook really runs."""
+    nv = _load_notebook_validator_module()
+
+    for line in (
+        "!python -m uv pip install git+https://example.com/pkg.git",
+        "!{sys.executable} -m uv pip install git+https://example.com/pkg.git",
+        "!/usr/bin/python3 -m uv pip install git+https://example.com/pkg.git",
+    ):
+        invocations = list(nv.iter_pip_invocations(line))
+        assert len(invocations) == 1, line
+        assert invocations[0].tool == "uv-pip", line
+        assert invocations[0].packages == ["git+https://example.com/pkg.git"], line
+        assert nv.rule_inst_001_git_plus(line, "nb/T.ipynb", 0), line
+
+    # A plain `-m pip` stays pip, even under an interpreter path containing "uv".
+    assert next(nv.iter_pip_invocations("!python -m pip install foo")).tool == "pip"
+    assert next(nv.iter_pip_invocations("!/opt/uv-tools/python3 -m pip install foo")).tool == "pip"
+    # And another module is still not pip.
+    assert not list(nv.iter_pip_invocations("!python -m uvloop install foo"))
+
+
+def test_the_cron_lint_job_installs_packaging():
+    """_requirement_applies falls back to "applies" when it cannot import Marker, so a job
+    without packaging silently replays every environment-marked requirement -- including the
+    ones Colab's pip skips, which is the question the Python-version oracle exists to answer.
+    A bare setup-python environment does not provide it."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
+
+    install_steps = [
+        line.strip()
+        for line in workflow.splitlines()
+        if line.strip().startswith("run: pip install -U pip")
+    ]
+    assert install_steps, "the cron lint job's install step moved; update this test"
+    for step in install_steps:
+        assert "packaging" in step, step

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1887,7 +1887,7 @@ def test_the_marker_oracle_follows_the_selected_pip_snapshot(tmp_path, monkeypat
 
     paired = tmp_path / "snap"
     paired.mkdir()
-    (paired / "colab_os_info.gpu.txt").write_text("Python 3.11.9\n", encoding="utf-8")
+    (paired / "colab_os_info.gpu.txt").write_text("Python 3.11.9\n", encoding = "utf-8")
     nv._set_colab_oracle_dir(paired)
     assert nv._colab_python_version() == "3.11.9"
 

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1809,3 +1809,56 @@ def test_the_os_oracle_is_documented_as_feeding_marker_evaluation():
     workflow = (REPO_ROOT / ".github" / "workflows" / "notebooks-ci.yml").read_text()
     assert "refresh-colab \\\n              --all --snapshot-dir" in workflow
     assert "--out unsloth/scripts/data/colab_pip_freeze.gpu.txt \\\n            ||" not in workflow
+
+
+def test_a_top_level_extra_marker_is_false_not_unknown():
+    """`extra` is only bound while resolving a selected extra's dependency metadata. For a
+    requirement handed straight to pip it has the known empty value, so `extra == "foo"` is
+    definitively false and pip drops the requirement:
+
+        $ pip install --dry-run --no-deps "certifi; extra == 'foo'"
+        Ignoring certifi: markers 'extra == "foo"' don't match your environment
+
+    Leaving it out of the environment made _requirement_applies replay the pin anyway and
+    R-INST-004 (error severity) fired on a notebook pip would have left alone.
+    """
+    nv = _load_notebook_validator_module()
+
+    ignored = "!pip install \"torch==2.12.0; extra == 'foo'\""
+    assert nv.rule_inst_004_torchcodec_torch(ignored, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # The same pin without the marker is still judged, so the gate did not go silent.
+    applied = '!pip install "torch==2.12.0"'
+    assert [
+        f.rule for f in nv.rule_inst_004_torchcodec_torch(applied, COLAB_TORCH211, "nb.ipynb", 0)
+    ] == ["R-INST-004"]
+
+
+def test_a_cell_that_only_mentions_pip_is_not_an_install_cell():
+    """`!echo "pip install foo"` matches the install-cell regex but runs no pip. The compat
+    rules then resolved nothing and compared the Colab oracle against itself, so R-INST-003
+    reported the base image's own peft/torchao pair as an error in the notebook.
+
+    A notebook with no install cell at all was always skipped; the lookalike now matches it.
+    """
+    nv = _load_notebook_validator_module()
+
+    mention = '!echo "pip install foo"'
+    nb = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "source": [mention],
+                "outputs": [],
+                "metadata": {},
+                "execution_count": None,
+            }
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    # Still discovered as a candidate -- the forbid-pattern rules must keep seeing it.
+    assert nv.install_cells(nb) == [(0, mention)]
+    # But it parses to no invocation, which is what the compat rules key off now.
+    assert list(nv.iter_pip_invocations(mention)) == []

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -2043,15 +2043,19 @@ def test_exception_coverage_skips_cells_that_run_no_pip(tmp_path):
 
     def write(source: str) -> None:
         notebook = {
-            "cells": [{
-                "cell_type": "code",
-                "metadata": {},
-                "source": [source],
-                "outputs": [],
-                "execution_count": None,
-            }],
-            "metadata": {"kernelspec": {"name": "python3", "display_name": "Python 3"},
-                         "language_info": {"name": "python"}},
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "metadata": {},
+                    "source": [source],
+                    "outputs": [],
+                    "execution_count": None,
+                }
+            ],
+            "metadata": {
+                "kernelspec": {"name": "python3", "display_name": "Python 3"},
+                "language_info": {"name": "python"},
+            },
             "nbformat": 4,
             "nbformat_minor": 0,
         }

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1,4 +1,5 @@
 """torch / torchcodec ABI guardrails (unslothai/unsloth#7225)."""
+
 from __future__ import annotations
 import importlib.util
 import re
@@ -6,6 +7,7 @@ import sys
 import types
 from pathlib import Path
 import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 IMPORT_FIXES_PATH = REPO_ROOT / "unsloth" / "import_fixes.py"
@@ -35,6 +37,7 @@ def _load_notebook_validator_module():
         raise
     return mod
 
+
 def test_notebook_validator_rejects_legacy_codec_past_last_lockstep_row():
     """The mirrored notebook rule must flag the same pairing as import_fixes."""
     nv = _load_notebook_validator_module()
@@ -49,6 +52,7 @@ def test_notebook_validator_rejects_legacy_codec_past_last_lockstep_row():
     old = '!pip install --no-deps "torch==2.4.0" "torchcodec==0.0.3"'
     assert nv.rule_inst_004_torchcodec_torch(old, {}, "nb.ipynb", 0) == []
 
+
 def test_notebook_validator_allows_abi_stable_pairing():
     """R-INST-004 is an error-severity rule: it must not fire on torch 2.11 + 0.12+."""
     nv = _load_notebook_validator_module()
@@ -61,6 +65,7 @@ def test_notebook_validator_allows_abi_stable_pairing():
     assert len(findings) == 1
     assert findings[0].rule == "R-INST-004"
 
+
 def test_notebook_validator_accepts_its_own_torchcodec_remedy():
     """The hint is a `>=` pin and resolved_set() drops `>=`, so following it changed nothing."""
     nv = _load_notebook_validator_module()
@@ -71,6 +76,7 @@ def test_notebook_validator_accepts_its_own_torchcodec_remedy():
     fixed = '!pip install "torch==2.12.0" "torchcodec>=0.12.0"'
     assert nv.rule_inst_004_torchcodec_torch(fixed, COLAB_TORCH211, "nb.ipynb", 0) == []
 
+
 def test_notebook_validator_reads_torch_range_pins():
     """A `torch>=` floor above Colab's torch moves pip while torchcodec stays put."""
     nv = _load_notebook_validator_module()
@@ -80,12 +86,14 @@ def test_notebook_validator_reads_torch_range_pins():
     assert len(findings) == 1
     assert "torchcodec>=0.12.0" in findings[0].hint
 
+
 def test_notebook_validator_ignores_lower_bounds_under_the_resolved_version():
     """A floor below the installed version changes nothing, so it must not be flagged."""
     nv = _load_notebook_validator_module()
 
     for cell in ('!pip install "torchcodec>=0.10"', '!pip install "torch>=2.9"'):
         assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], cell
+
 
 def test_notebook_validator_reads_the_bounds_in_invocation_order():
     """Whichever bound runs last is the one pip leaves behind, in both directions."""
@@ -119,6 +127,7 @@ def test_notebook_validator_reads_the_bounds_in_invocation_order():
     ranged = '!pip install "torch==2.12.0" "torchcodec>=0.12,<=0.13"'
     assert nv.rule_inst_004_torchcodec_torch(ranged, COLAB_TORCH211, "nb.ipynb", 0) == []
 
+
 def test_notebook_validator_honours_a_torchcodec_uninstall():
     """Removing the codec is a valid answer to the mismatch, so the new post-2.11 branch
     must not report one. parse_pip_line drops the `install`/`uninstall` word before the
@@ -141,6 +150,7 @@ def test_notebook_validator_honours_a_torchcodec_uninstall():
     dropped = '!pip install "torch==2.12.0" "torchcodec==0.13.0"\n!pip uninstall -y torchcodec'
     assert nv.rule_inst_004_torchcodec_torch(dropped, COLAB_TORCH211, "nb.ipynb", 0) == []
 
+
 def test_notebook_validator_keeps_an_absent_package_unknown():
     """Only `==` names a version. A floor on a package that is not there resolves to the
     newest release satisfying it, which the bound does not name, so the pairing stays
@@ -157,6 +167,7 @@ def test_notebook_validator_keeps_an_absent_package_unknown():
     # An exact pin still names one, with or without a baseline.
     exact = '!pip install --no-deps "torch==2.12.1" "torchcodec==0.11.1"'
     assert len(nv.rule_inst_004_torchcodec_torch(exact, {}, "nb.ipynb", 0)) == 1
+
 
 def test_notebook_validator_splits_chained_shell_commands():
     """`pip uninstall x && pip install x==V` is two actions on one line. Read as one, the
@@ -187,6 +198,7 @@ def test_notebook_validator_splits_chained_shell_commands():
     assert nv._split_chained(marked) == [(marked, False)]
     assert len(nv.rule_inst_004_torchcodec_torch(marked, COLAB_TORCH211, "nb.ipynb", 0)) == 1
 
+
 def test_notebook_validator_skips_the_fallback_side_of_an_or_chain():
     """`A || B` runs B only when A failed, so replaying both reports a codec the notebook
     does not have. The left side still counts."""
@@ -204,6 +216,7 @@ def test_notebook_validator_skips_the_fallback_side_of_an_or_chain():
     )
     assert len(nv.rule_inst_004_torchcodec_torch(primary, COLAB_TORCH211, "nb.ipynb", 0)) == 1
 
+
 def test_notebook_validator_reads_compatible_release_pins():
     """`~=2.12.0` implies `>=2.12.0`, so its floor moves the baseline up."""
     nv = _load_notebook_validator_module()
@@ -215,6 +228,7 @@ def test_notebook_validator_reads_compatible_release_pins():
 
     remedied = '!pip install "torch==2.12.0" "torchcodec~=0.13.0"'
     assert nv.rule_inst_004_torchcodec_torch(remedied, COLAB_TORCH211, "nb.ipynb", 0) == []
+
 
 def test_notebook_validator_stops_at_a_shell_comment():
     """An unquoted `#` comments out the rest of the line, so a `;` inside it is not a
@@ -234,6 +248,7 @@ def test_notebook_validator_stops_at_a_shell_comment():
     fragment = '!pip install "torchcodec==0.13.0#egg=x"'
     assert nv._split_chained(fragment) == [(fragment, False)]
 
+
 def test_notebook_validator_resumes_after_an_or_list():
     """`A || B; C` runs C whatever A did. Only the conditional tail is dropped, and a `;`
     ends it."""
@@ -251,6 +266,7 @@ def test_notebook_validator_resumes_after_an_or_list():
     cell = '!pip install "torchcodec==0.11.1" || echo failed; pip install "torch==2.12.0"'
     assert len(nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0)) == 1
 
+
 def test_notebook_validator_respects_escaped_separators():
     """A backslash-escaped `;` is part of the argument, the way shlex reads it in
     parse_pip_line. Split on it and the fragment ends in a backslash and parses as nothing."""
@@ -262,6 +278,7 @@ def test_notebook_validator_respects_escaped_separators():
         ["torch==2.12.0; python_version >= '3.10'"]
     ]
     assert len(nv.rule_inst_004_torchcodec_torch(escaped, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
 
 def test_notebook_validator_merges_repeated_requirements_in_one_command():
     """pip intersects a project named twice in one command, so the bounds are one window.
@@ -281,6 +298,7 @@ def test_notebook_validator_merges_repeated_requirements_in_one_command():
     wide = '!pip install "torchcodec>=0.10" "torchcodec<0.12"'
     assert nv.rule_inst_004_torchcodec_torch(wide, COLAB_TORCH211, "nb.ipynb", 0) == []
 
+
 def test_notebook_validator_resumes_after_an_and_following_an_or():
     """And-or lists are left-associative: in `A || B && C`, C runs when A succeeded, so the
     conditional tail ends at the `&&`."""
@@ -294,6 +312,7 @@ def test_notebook_validator_resumes_after_an_and_following_an_or():
 
     cell = '!pip install "torchcodec==0.11.1" || echo failed && pip install "torch==2.12.0"'
     assert len(nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
 
 def test_notebook_validator_will_not_name_a_multi_minor_window():
     """Moving down lands on the newest release the window admits, which the floor only names
@@ -310,6 +329,7 @@ def test_notebook_validator_will_not_name_a_multi_minor_window():
     # One minor still names its floor.
     single = '!pip install "torchcodec>=0.10,<0.11"'
     assert len(nv.rule_inst_004_torchcodec_torch(single, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
 
 def test_notebook_validator_reads_a_direct_wheel_install():
     """pip takes an archive URL as an install target and parse_spec skips it, so a wheel that
@@ -329,6 +349,7 @@ def test_notebook_validator_reads_a_direct_wheel_install():
 
     stale = compatible.replace("0.13.0", "0.10.0").replace("torch==2.12.0", "torch==2.11.0")
     assert len(nv.rule_inst_004_torchcodec_torch(stale, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
 
 def test_notebook_validator_replays_exclusions():
     """`!=` rules out what is installed, so keeping it reports a version pip cannot leave in
@@ -355,6 +376,7 @@ def test_notebook_validator_replays_exclusions():
     narrow = '!pip install "torch==2.11.0" "torchcodec>=0.10,<0.11,!=0.11.*"'
     assert len(nv.rule_inst_004_torchcodec_torch(narrow, COLAB_TORCH211, "nb.ipynb", 0)) == 1
 
+
 def test_notebook_validator_keeps_or_fallbacks_visible_to_other_rules():
     """The fallback still runs when the left side fails, so dropping it from
     iter_pip_invocations hid it from R-INST-001's git+ ban. Only the version replay skips it."""
@@ -370,6 +392,7 @@ def test_notebook_validator_keeps_or_fallbacks_visible_to_other_rules():
         '!pip install "torch==2.12.0"'
     )
     assert nv.rule_inst_004_torchcodec_torch(fallback, COLAB_TORCH211, "nb.ipynb", 0) == []
+
 
 def test_notebook_validator_will_not_name_an_exclusive_floor():
     """`>V` names the one version pip will not install, so on its own it says the install
@@ -393,6 +416,7 @@ def test_notebook_validator_will_not_name_an_exclusive_floor():
         )
         == 1
     )
+
 
 def test_notebook_validator_treats_an_open_floor_as_a_floor():
     """pip takes the newest release above an open `>=`, so the floor is a lower bound and not
@@ -432,6 +456,7 @@ def test_notebook_validator_treats_an_open_floor_as_a_floor():
         == 1
     )
 
+
 def test_notebook_validator_ignores_a_conditional_pin_when_seeding():
     """resolved_set seeds the replay, so it has to skip the `||` fallback as well or the
     conditional pin comes back in through the seed."""
@@ -440,6 +465,7 @@ def test_notebook_validator_ignores_a_conditional_pin_when_seeding():
     cell = '!pip install foo || pip install "torch==2.12.0"'
     assert nv.resolved_set(cell, COLAB_TORCH211)["torch"] == "2.11.0+cu128"
     assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == []
+
 
 def test_notebook_validator_pads_release_segments_when_excluding():
     """PEP 440 pads the release segment, so `!=0.11` rules out an installed `0.11.0`."""
@@ -451,6 +477,7 @@ def test_notebook_validator_pads_release_segments_when_excluding():
 
     cell = '!pip install "torch==2.12" "torchcodec!=0.11"'
     assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == []
+
 
 def test_notebook_validator_unwraps_shell_groups():
     """A grouped command still runs, so leaving the bracket on it hides it from PIP_LINE_RE
@@ -472,6 +499,7 @@ def test_notebook_validator_unwraps_shell_groups():
     assert nv._unwrap_shell_group("then pip install x") == ("pip install x", True)
     # `if pip install ...` is the test, which runs whenever the line is reached.
     assert nv._unwrap_shell_group("if pip install x") == ("pip install x", False)
+
 
 def test_notebook_validator_skips_conditional_invocations_in_rule_002(monkeypatch):
     """resolved_set drops a fallback's pins, so a rule reading both has to drop the
@@ -498,6 +526,7 @@ def test_notebook_validator_skips_conditional_invocations_in_rule_002(monkeypatc
     assert [inv.conditional for inv in nv.iter_pip_invocations(fallback)] == [False, True]
     assert nv.rule_inst_002_no_deps_transitive(fallback, colab, "nb.ipynb", 0) == []
 
+
 def test_notebook_validator_bounds_the_minor_with_an_inclusive_cap():
     """`>=0.10,<=0.10.5` admits only the 0.10 line, so the window names it just as
     `>=0.10,<0.11` does."""
@@ -520,6 +549,7 @@ def test_notebook_validator_bounds_the_minor_with_an_inclusive_cap():
         )
         == []
     )
+
 
 def test_notebook_validator_applies_exclusions_to_where_it_landed():
     """An exclusion has to hold for the version the requirement leaves in place, not only for
@@ -544,6 +574,7 @@ def test_notebook_validator_applies_exclusions_to_where_it_landed():
     assert len(findings) == 1
     assert "torchcodec==0.10" in findings[0].message
 
+
 def test_notebook_validator_skips_conditional_invocations_in_rule_003():
     """The torchao floor helper reads the same cell, so a fallback that never runs must not
     satisfy the floor R-INST-003 is checking."""
@@ -565,6 +596,7 @@ def test_notebook_validator_skips_conditional_invocations_in_rule_003():
     assert (
         nv.rule_inst_003_peft_torchao('!pip install "torchao>=0.16.0"', colab, "nb.ipynb", 0) == []
     )
+
 
 def test_notebook_validator_moves_off_an_exclusive_endpoint():
     """`>V` is not satisfied by V, so an installed version sitting exactly on the endpoint
@@ -589,6 +621,7 @@ def test_notebook_validator_moves_off_an_exclusive_endpoint():
         assert (
             len(nv.rule_inst_004_torchcodec_torch(cell, on_the_endpoint, "nb.ipynb", 0)) == 1
         ), cell
+
 
 def test_every_rule_reads_the_filtered_invocations():
     """Every reader asks what the cell leaves installed and takes the filtered iterator.
@@ -623,6 +656,7 @@ def test_every_rule_reads_the_filtered_invocations():
         source.count("in iter_pip_invocations(install_cell)") == 1
     ), "only unconditional_pip_invocations may read the raw iterator; rules take the filtered one"
 
+
 def test_notebook_validator_keeps_a_group_conditional_throughout():
     """An `&&` or `;` inside a `(` or `{` group belongs to the group, so it does not end the
     fallback: if the left side succeeded, nothing in the group runs."""
@@ -651,6 +685,7 @@ def test_notebook_validator_keeps_a_group_conditional_throughout():
     evil = "!pip install foo || (pip install bar && pip install git+https://example.com/evil.git)"
     assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(evil, "nb.ipynb", 0))
 
+
 def test_notebook_validator_pads_the_minor_boundary():
     """`<0.11.0` and `<0.11` name the same boundary, so both windows hold one minor."""
     nv = _load_notebook_validator_module()
@@ -673,6 +708,7 @@ def test_notebook_validator_pads_the_minor_boundary():
         )
         == []
     )
+
 
 def test_notebook_validator_reads_an_archive_given_as_a_path():
     """`./torchcodec-0.13.0-...whl` parses as a project called `.`, so checking parse_spec
@@ -702,6 +738,7 @@ def test_notebook_validator_reads_an_archive_given_as_a_path():
         == 1
     )
 
+
 def test_git_allowlist_is_scoped_to_each_source():
     """One allowlisted repository on a line must not clear a prohibited one beside it. The
     line-level scan finds every `git+` target; the allowlist then applies to each."""
@@ -724,6 +761,7 @@ def test_git_allowlist_is_scoped_to_each_source():
     two_allowed = "!pip install {} git+https://github.com/state-spaces/mamba.git".format(allowed)
     assert nv.rule_inst_001_git_plus(two_allowed, "nb.ipynb", 0) == []
 
+
 def test_notebook_validator_keeps_the_stricter_of_two_equal_floors():
     """`>=0.8.0,>0.8.0` intersect to the exclusive one, so the installed 0.8.0 still moves."""
     nv = _load_notebook_validator_module()
@@ -739,6 +777,7 @@ def test_notebook_validator_keeps_the_stricter_of_two_equal_floors():
     assert nv._effective_version(
         '!pip install "torchcodec>=0.8.0,>=0.8.0"', "torchcodec", "0.8.0"
     ) == ("0.8.0", True)
+
 
 def test_notebook_validator_reads_a_named_direct_reference():
     """`name @ url` replaces the package even when the archive filename does not name it, so
@@ -766,6 +805,7 @@ def test_notebook_validator_reads_a_named_direct_reference():
         == 1
     )
 
+
 def test_git_allowlist_matches_the_repository_not_a_substring():
     """An arbitrary repository can carry an allowlisted path inside its own, so the allowlist
     is compared against the normalised host and path."""
@@ -791,6 +831,7 @@ def test_git_allowlist_matches_the_repository_not_a_substring():
         == []
     )
 
+
 def test_git_ban_reads_commands_not_the_comment():
     """`_split_chained` drops a shell comment, so a comment naming a prohibited source is
     documentation and must not fail the notebook."""
@@ -810,6 +851,7 @@ def test_git_ban_reads_commands_not_the_comment():
         )
     )
 
+
 def test_notebook_validator_ends_a_grouped_and_or_list_at_its_own_operator():
     """Which list an operator belongs to is its group depth. `(A || B && C)` is one list, so
     the `&&` ends the tail; `A || (B && C)` is not, so it does not."""
@@ -822,6 +864,7 @@ def test_notebook_validator_ends_a_grouped_and_or_list_at_its_own_operator():
     inner = '!pip install foo || (pip install bar && pip install "torch==2.12.0")'
     assert [flag for _, flag in nv._split_chained(inner)] == [False, True, True]
     assert nv.rule_inst_004_torchcodec_torch(inner, COLAB_TORCH211, "nb.ipynb", 0) == []
+
 
 def test_notebook_validator_keeps_a_minor_a_narrow_exclusion_cannot_remove():
     """`>=0.11,<0.12,!=0.11.0` still lands in the 0.11 line, and the minor is what the rule
@@ -848,6 +891,7 @@ def test_notebook_validator_keeps_a_minor_a_narrow_exclusion_cannot_remove():
         == []
     )
 
+
 def test_notebook_validator_keeps_an_outer_fallback_across_a_nested_or():
     """Each group keeps its own tail, so an inner `||` cannot hand the outer one back. A
     command is conditional when any level above it is in a fallback."""
@@ -863,6 +907,7 @@ def test_notebook_validator_keeps_an_outer_fallback_across_a_nested_or():
     same_list = '!(pip install foo || pip install bar && pip install "torch==2.12.0")'
     assert [flag for _, flag in nv._split_chained(same_list)] == [False, True, False]
     assert len(nv.rule_inst_004_torchcodec_torch(same_list, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
 
 def test_notebook_validator_lands_an_upward_move_on_an_inclusive_cap():
     """`<=V` allows V, so V is what pip picks, whichever side the version moves from."""
@@ -881,6 +926,7 @@ def test_notebook_validator_lands_an_upward_move_on_an_inclusive_cap():
         )
         == []
     )
+
 
 def test_notebook_validator_will_not_keep_a_version_through_an_upgrade():
     """A bare name with `--upgrade` takes the newest release, so the installed version is not
@@ -934,6 +980,7 @@ def test_notebook_validator_will_not_keep_a_version_through_an_upgrade():
         == 1
     )
 
+
 def test_notebook_validator_keeps_the_flag_of_the_command_in_hand():
     """A group's closing bracket ends the level, not the command being read: the install
     before the `)` still belongs to the fallback the `||` opened."""
@@ -947,6 +994,7 @@ def test_notebook_validator_keeps_the_flag_of_the_command_in_hand():
     ended = '!(pip install foo || pip install bar && pip install "torch==2.12.0")'
     assert [flag for _, flag in nv._split_chained(ended)] == [False, True, False]
     assert len(nv.rule_inst_004_torchcodec_torch(ended, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
 
 def test_notebook_validator_reads_a_compound_only_line():
     """With no standalone pip command on the line, every piece kept a keyword and none
@@ -977,6 +1025,7 @@ def test_notebook_validator_reads_a_compound_only_line():
         == 1
     )
 
+
 def test_git_ban_reads_the_arguments_shlex_produced():
     """`"git+"https://...` is one argument to pip and two words to a text scan, so the
     source has to be looked for in the parsed packages as well as in the command text."""
@@ -994,6 +1043,7 @@ def test_git_ban_reads_the_arguments_shlex_produced():
         )
         == []
     )
+
 
 def test_notebook_validator_keeps_a_pip_call_used_as_a_test():
     """`if pip install ...` is the condition, reached whenever the line is. Only a `then`,
@@ -1013,6 +1063,7 @@ def test_notebook_validator_keeps_a_pip_call_used_as_a_test():
         '!while true; do pip install "torch==2.12.0"; done',
     ):
         assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], cell
+
 
 def test_git_ban_only_reads_pip_commands():
     """A `git+` in an `echo` beside an install installs nothing. The scan is per command, and
@@ -1034,6 +1085,7 @@ def test_git_ban_only_reads_pip_commands():
             "!echo installing; pip install git+https://example.com/evil.git", "nb.ipynb", 0
         )
     )
+
 
 def test_notebook_validator_evaluates_environment_markers():
     """pip skips a requirement whose marker is false, so replaying its bounds moves a version
@@ -1084,6 +1136,7 @@ def test_notebook_validator_evaluates_environment_markers():
         == 1
     )
 
+
 def test_notebook_validator_expands_bundled_short_flags():
     """pip takes `-Uq`, and parse_pip_line keeps it as one token, so the letters are what
     gets compared."""
@@ -1109,8 +1162,10 @@ def test_notebook_validator_expands_bundled_short_flags():
         == 1
     )
 
+
 def _one_cell_notebook(source: str) -> dict:
     return {"cells": [{"cell_type": "code", "source": source.splitlines(keepends = True)}]}
+
 
 def test_install_cell_discovery_finds_compound_commands():
     """The rules only see cells `install_cells` hands them, and it wanted `pip` right after
@@ -1131,6 +1186,7 @@ def test_install_cell_discovery_finds_compound_commands():
     # Still anchored on the `!`, so a pip mention in Python is not an install cell.
     for source in ('cmd = "pip install torch"', "import torch", "# pip install torch"):
         assert nv.install_cells(_one_cell_notebook(source)) == [], source
+
 
 def test_notebook_validator_splits_on_single_control_operators():
     """`A & B` backgrounds A and runs B, `A | B` runs both. Neither opened a command boundary,
@@ -1160,6 +1216,7 @@ def test_notebook_validator_splits_on_single_control_operators():
     ]
     assert nv._split_chained('!pip install "a&b"')[0][0] == '!pip install "a&b"'
 
+
 def test_torchao_floor_ignores_a_requirement_pip_skips():
     """R-INST-003 reads the floor from the same cell, so a requirement whose marker is false
     must not satisfy it either."""
@@ -1179,6 +1236,7 @@ def test_torchao_floor_ignores_a_requirement_pip_skips():
         '!pip install "torchao>=0.16.0"',
     ):
         assert nv.rule_inst_003_peft_torchao(cell, colab, "nb.ipynb", 0) == [], cell
+
 
 def test_git_allowlist_resolves_dot_segments_and_matches_exactly():
     """`unslothai/unsloth/../../attacker/repo` reads as an allowlisted prefix and resolves to
@@ -1208,6 +1266,7 @@ def test_git_allowlist_resolves_dot_segments_and_matches_exactly():
     smuggled = "!pip install git+https://github.com/unslothai/unsloth/../../attacker/repo.git"
     assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(smuggled, "nb.ipynb", 0))
 
+
 def test_install_cell_discovery_glues_continuations():
     """A `\\` continuation can put the `!` and the pip call on different physical lines, and
     discovery reads lines."""
@@ -1216,6 +1275,7 @@ def test_install_cell_discovery_glues_continuations():
     source = "!echo ready && \\\n  pip install git+https://example.com/pkg.git"
     assert nv.install_cells(_one_cell_notebook(source))
     assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(source, "nb.ipynb", 0))
+
 
 def test_no_deps_rules_skip_a_requirement_pip_skips(monkeypatch):
     """R-INST-002 and R-INST-005 read the raw pins themselves, so a marker-false `--no-deps`
@@ -1241,6 +1301,7 @@ def test_no_deps_rules_skip_a_requirement_pip_skips(monkeypatch):
         assert nv.rule_inst_002_no_deps_transitive(applied, colab, "nb.ipynb", 0), applied
         assert nv.rule_inst_005_transformers_tokenizers(applied, colab, "nb.ipynb", 0), applied
 
+
 def test_notebook_validator_splits_keywords_on_any_whitespace():
     """A tab after `then` is the same command to the shell. Splitting on a literal space left
     `then\\tpip` as one word, which parses as nothing and hides the install."""
@@ -1255,6 +1316,7 @@ def test_notebook_validator_splits_keywords_on_any_whitespace():
     spaced = "!if true; then pip install git+https://example.com/pkg.git; fi"
     assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(spaced, "nb.ipynb", 0))
 
+
 def test_notebook_validator_comments_after_a_closing_bracket():
     """A `)` ends a word, so `)#` opens a comment and what follows is documentation."""
     nv = _load_notebook_validator_module()
@@ -1262,6 +1324,7 @@ def test_notebook_validator_comments_after_a_closing_bracket():
     cell = "!(pip install unsloth)# alternative: pip install git+https://example.com/pkg.git"
     assert [c for c, _ in nv._split_chained(cell)] == ["!pip install unsloth"]
     assert nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0) == []
+
 
 def test_notebook_validator_declines_markers_it_cannot_judge():
     """`Marker.evaluate` fills any field the environment omits from the running process, so a
@@ -1279,6 +1342,7 @@ def test_notebook_validator_declines_markers_it_cannot_judge():
     # The fields the oracle can answer for are still evaluated.
     assert not nv._requirement_applies("torch>=2.12; python_version < '3.10'", environment)
     assert nv._requirement_applies("torch>=2.12; sys_platform == 'linux'", environment)
+
 
 def test_notebook_validator_reads_case_arms():
     """Stripping `case` left `x in x) pip install ...`, which parses as nothing. Only the
@@ -1323,6 +1387,7 @@ def test_notebook_validator_reads_case_arms():
     quoted = '!pip install "a)b" git+https://example.com/evil.git'
     assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(quoted, "nb.ipynb", 0))
 
+
 def test_notebook_validator_reads_pip_in_a_substitution():
     """`echo $(pip install x)` runs the install as surely as the echo, and the outer command
     is not pip, so the inner one has to be a command of its own."""
@@ -1346,6 +1411,7 @@ def test_notebook_validator_reads_pip_in_a_substitution():
     ]
     assert nv._substitution_bodies("pip install x") == []
 
+
 def test_notebook_validator_honours_escaped_case_patterns():
     """A `\\)` in a pattern matches a literal parenthesis, so it is not what closes the arm."""
     nv = _load_notebook_validator_module()
@@ -1353,6 +1419,7 @@ def test_notebook_validator_honours_escaped_case_patterns():
     escaped = "!case 'x)y' in x\\)y) pip install git+https://example.com/pkg.git ;; esac"
     assert nv._split_chained(escaped) == [("!pip install git+https://example.com/pkg.git", True)]
     assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(escaped, "nb.ipynb", 0))
+
 
 def test_notebook_validator_ignores_marker_names_in_literals():
     """`sys_platform == 'platform_release'` references one variable, not two, so the marker
@@ -1366,6 +1433,7 @@ def test_notebook_validator_ignores_marker_names_in_literals():
     assert nv._requirement_applies("torch==2.12.0; sys_platform == 'linux'", environment)
     # A real reference to an unknown field is still declined.
     assert nv._requirement_applies("torch>=2.12; platform_release < '5.0'", environment)
+
 
 def test_notebook_validator_strips_execution_prefixes():
     """`command pip install ...` and `env FOO=1 pip install ...` install exactly as a bare
@@ -1391,6 +1459,7 @@ def test_notebook_validator_strips_execution_prefixes():
         == 1
     )
 
+
 def test_notebook_validator_quotes_inside_a_substitution():
     """A `)` inside a quoted argument closes no substitution, so the body runs past it."""
     nv = _load_notebook_validator_module()
@@ -1407,6 +1476,7 @@ def test_notebook_validator_quotes_inside_a_substitution():
         )
     )
 
+
 def test_notebook_validator_tells_a_grouping_close_from_a_substitution_close():
     """`)` ends a word when it closes a grouping and not when it closes a `$( )` inside one,
     so only the first makes a following `#` a comment."""
@@ -1419,6 +1489,7 @@ def test_notebook_validator_tells_a_grouping_close_from_a_substitution_close():
     # A grouping close still opens a comment.
     grouped = "!(pip install unsloth)# git+https://example.com/pkg.git"
     assert nv.rule_inst_001_git_plus(grouped, "nb.ipynb", 0) == []
+
 
 def test_notebook_validator_ignores_quoted_substitution_text():
     """Single quotes and an escaped `$` make the text literal, so nothing in it runs and the
@@ -1439,6 +1510,7 @@ def test_notebook_validator_ignores_quoted_substitution_text():
     expanded = "!echo \"$(printf 'X)'; pip install git+https://example.com/pkg.git)\""
     assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(expanded, "nb.ipynb", 0))
 
+
 def test_notebook_validator_reads_process_substitutions():
     """`<( )` and `>( )` run their commands too."""
     nv = _load_notebook_validator_module()
@@ -1450,6 +1522,7 @@ def test_notebook_validator_reads_process_substitutions():
         assert any(
             f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0)
         ), cell
+
 
 def test_notebook_validator_keeps_substitution_commands_in_order():
     """A substitution runs before its host and its own separators are its own, so its commands
@@ -1470,6 +1543,7 @@ def test_notebook_validator_keeps_substitution_commands_in_order():
     assert len(findings) == 1
     assert "torchcodec==0.11.0" in findings[0].message
 
+
 def test_git_sources_are_matched_case_insensitively():
     """pip normalises `Git+https://` to the same link, so the ban has to see it."""
     nv = _load_notebook_validator_module()
@@ -1489,6 +1563,7 @@ def test_git_sources_are_matched_case_insensitively():
         )
         == []
     )
+
 
 def test_notebook_validator_skips_a_prefixs_own_options():
     """`env -u VAR pip install ...` runs pip, and stripping only the word left the options in
@@ -1520,6 +1595,7 @@ def test_notebook_validator_skips_a_prefixs_own_options():
         == 1
     )
 
+
 def test_notebook_validator_keeps_redirections_and_quoted_process_forms():
     """`>|` overrides noclobber rather than piping, and `<( )` inside double quotes is text."""
     nv = _load_notebook_validator_module()
@@ -1546,6 +1622,7 @@ def test_notebook_validator_keeps_redirections_and_quoted_process_forms():
         )
     )
 
+
 def test_notebook_validator_reads_a_range_as_one_window():
     """A `>=X,<Y` pair is the same constraint as `~=X`, and the guard's own remedy is
     spelled that way (`pip install 'torchcodec>=0.11,<0.12.0'`), so the rule has to read it
@@ -1571,6 +1648,7 @@ def test_notebook_validator_reads_a_range_as_one_window():
     # An inclusive cap does name one, so it still clamps rather than clearing.
     capped = '!pip install "torch==2.12.0" "torchcodec>=0.12"\n!pip install "torchcodec<=0.11"'
     assert len(nv.rule_inst_004_torchcodec_torch(capped, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
 
 def test_notebook_validator_reads_the_compatible_release_ceiling():
     """`~=` pins a window, so it moves the baseline down as well as up. PEP 440 drops the

--- a/tests/notebooks/test_notebook_validator_shell_parsing.py
+++ b/tests/notebooks/test_notebook_validator_shell_parsing.py
@@ -1,0 +1,1410 @@
+"""torch / torchcodec ABI guardrails (unslothai/unsloth#7225)."""
+from __future__ import annotations
+import importlib.util
+import re
+import sys
+import types
+from pathlib import Path
+import pytest
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+IMPORT_FIXES_PATH = REPO_ROOT / "unsloth" / "import_fixes.py"
+EXTRAS_NO_DEPS_TXT = REPO_ROOT / "studio" / "backend" / "requirements" / "extras-no-deps.txt"
+SECURITY_AUDIT_YML = REPO_ROOT / ".github" / "workflows" / "security-audit.yml"
+COLAB_TORCH211 = {"torch": "2.11.0+cu128", "torchcodec": "0.11.0+cu128"}
+TORCHCODEC_WHEEL = (
+    "https://download.pytorch.org/whl/torchcodec-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl"
+)
+
+
+def _load_notebook_validator_module():
+    """Load by path: `from scripts import ...` picks up whatever `scripts`
+    package happens to be on sys.path first, which is not always this repo's."""
+    spec = importlib.util.spec_from_file_location(
+        "unsloth_notebook_validator_under_test",
+        REPO_ROOT / "scripts" / "notebook_validator.py",
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # dataclasses resolves annotations through sys.modules: register before executing.
+    sys.modules[spec.name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop(spec.name, None)
+        raise
+    return mod
+
+def test_notebook_validator_rejects_legacy_codec_past_last_lockstep_row():
+    """The mirrored notebook rule must flag the same pairing as import_fixes."""
+    nv = _load_notebook_validator_module()
+
+    cell = '!pip install --no-deps "torch==2.12.1" "torchcodec==0.11.1"'
+    findings = nv.rule_inst_004_torchcodec_torch(cell, {}, "nb.ipynb", 0)
+    assert len(findings) == 1
+    assert findings[0].rule == "R-INST-004"
+    assert findings[0].severity == "error"
+    assert "torchcodec>=0.12.0" in findings[0].hint
+
+    old = '!pip install --no-deps "torch==2.4.0" "torchcodec==0.0.3"'
+    assert nv.rule_inst_004_torchcodec_torch(old, {}, "nb.ipynb", 0) == []
+
+def test_notebook_validator_allows_abi_stable_pairing():
+    """R-INST-004 is an error-severity rule: it must not fire on torch 2.11 + 0.12+."""
+    nv = _load_notebook_validator_module()
+
+    cell = '!pip install --no-deps "torch==2.11.0" "torchcodec==0.15.0"'
+    assert nv.rule_inst_004_torchcodec_torch(cell, {}, "nb.ipynb", 0) == []
+
+    stale = '!pip install --no-deps "torch==2.11.0" "torchcodec==0.10.0"'
+    findings = nv.rule_inst_004_torchcodec_torch(stale, {}, "nb.ipynb", 0)
+    assert len(findings) == 1
+    assert findings[0].rule == "R-INST-004"
+
+def test_notebook_validator_accepts_its_own_torchcodec_remedy():
+    """The hint is a `>=` pin and resolved_set() drops `>=`, so following it changed nothing."""
+    nv = _load_notebook_validator_module()
+
+    broken = '!pip install "torch==2.12.0"'
+    assert nv.rule_inst_004_torchcodec_torch(broken, COLAB_TORCH211, "nb.ipynb", 0)
+
+    fixed = '!pip install "torch==2.12.0" "torchcodec>=0.12.0"'
+    assert nv.rule_inst_004_torchcodec_torch(fixed, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+def test_notebook_validator_reads_torch_range_pins():
+    """A `torch>=` floor above Colab's torch moves pip while torchcodec stays put."""
+    nv = _load_notebook_validator_module()
+
+    ranged = '!pip install "torch>=2.12"'
+    findings = nv.rule_inst_004_torchcodec_torch(ranged, COLAB_TORCH211, "nb.ipynb", 0)
+    assert len(findings) == 1
+    assert "torchcodec>=0.12.0" in findings[0].hint
+
+def test_notebook_validator_ignores_lower_bounds_under_the_resolved_version():
+    """A floor below the installed version changes nothing, so it must not be flagged."""
+    nv = _load_notebook_validator_module()
+
+    for cell in ('!pip install "torchcodec>=0.10"', '!pip install "torch>=2.9"'):
+        assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], cell
+
+def test_notebook_validator_reads_the_bounds_in_invocation_order():
+    """Whichever bound runs last is the one pip leaves behind, in both directions."""
+    nv = _load_notebook_validator_module()
+
+    downgraded = (
+        '!pip install "torch==2.12.0" "torchcodec>=0.12"\n'
+        '!pip install --no-deps "torchcodec==0.11.1"'
+    )
+    findings = nv.rule_inst_004_torchcodec_torch(downgraded, COLAB_TORCH211, "nb.ipynb", 0)
+    assert len(findings) == 1, "a later exact pin must win over an earlier floor"
+    assert "torchcodec==0.11.1" in findings[0].message
+
+    upgraded = '!pip install "torch==2.12.0" "torchcodec==0.11.1"\n!pip install "torchcodec>=0.12"'
+    assert nv.rule_inst_004_torchcodec_torch(upgraded, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # The reported torch must be the one the notebook ends on, not the discarded floor.
+    retreated = '!pip install "torch>=2.12"\n!pip install "torch==2.10.0"'
+    findings = nv.rule_inst_004_torchcodec_torch(retreated, COLAB_TORCH211, "nb.ipynb", 0)
+    assert len(findings) == 1
+    assert "torch==2.10.0" in findings[0].message
+
+    # `<=` closes the same gap as `==`, and only downwards.
+    capped = '!pip install "torch==2.12.0" "torchcodec>=0.12"\n!pip install "torchcodec<=0.11"'
+    assert len(nv.rule_inst_004_torchcodec_torch(capped, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+    lifted = '!pip install "torch==2.12.0" "torchcodec<=0.11"\n!pip install "torchcodec>=0.12"'
+    assert nv.rule_inst_004_torchcodec_torch(lifted, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # A one-line range is not a downgrade: the floor still decides.
+    ranged = '!pip install "torch==2.12.0" "torchcodec>=0.12,<=0.13"'
+    assert nv.rule_inst_004_torchcodec_torch(ranged, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+def test_notebook_validator_honours_a_torchcodec_uninstall():
+    """Removing the codec is a valid answer to the mismatch, so the new post-2.11 branch
+    must not report one. parse_pip_line drops the `install`/`uninstall` word before the
+    package list, so without the action an uninstall reads exactly like an install."""
+    nv = _load_notebook_validator_module()
+
+    removed = '!pip uninstall -y torchcodec\n!pip install "torch==2.12.0"'
+    assert nv.rule_inst_004_torchcodec_torch(removed, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # Put back incompatibly and it is a finding again; put back compatibly and it is not.
+    back_stale = (
+        "!pip uninstall -y torchcodec\n" '!pip install "torch==2.12.0" "torchcodec==0.11.1"'
+    )
+    assert len(nv.rule_inst_004_torchcodec_torch(back_stale, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+    back_ok = "!pip uninstall -y torchcodec\n" '!pip install "torch==2.12.0" "torchcodec==0.13.0"'
+    assert nv.rule_inst_004_torchcodec_torch(back_ok, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # Uninstalling after a good install still leaves nothing to flag.
+    dropped = '!pip install "torch==2.12.0" "torchcodec==0.13.0"\n!pip uninstall -y torchcodec'
+    assert nv.rule_inst_004_torchcodec_torch(dropped, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+def test_notebook_validator_keeps_an_absent_package_unknown():
+    """Only `==` names a version. A floor on a package that is not there resolves to the
+    newest release satisfying it, which the bound does not name, so the pairing stays
+    unknown rather than being pinned to the floor and reported."""
+    nv = _load_notebook_validator_module()
+
+    reinstalled = '!pip uninstall -y torchcodec\n!pip install "torchcodec>=0.10"'
+    assert nv.rule_inst_004_torchcodec_torch(reinstalled, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # Same when nothing supplies a baseline at all (a non-Colab notebook).
+    floor_only = '!pip install "torch==2.11.0" "torchcodec>=0.10"'
+    assert nv.rule_inst_004_torchcodec_torch(floor_only, {}, "nb.ipynb", 0) == []
+
+    # An exact pin still names one, with or without a baseline.
+    exact = '!pip install --no-deps "torch==2.12.1" "torchcodec==0.11.1"'
+    assert len(nv.rule_inst_004_torchcodec_torch(exact, {}, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_splits_chained_shell_commands():
+    """`pip uninstall x && pip install x==V` is two actions on one line. Read as one, the
+    reinstall lands in the uninstall's package list and the pairing disappears."""
+    nv = _load_notebook_validator_module()
+
+    invocations = list(
+        nv.iter_pip_invocations('!pip uninstall -y torchcodec && pip install "torchcodec==0.11.1"')
+    )
+    assert [inv.action for inv in invocations] == ["uninstall", "install"]
+    assert [inv.packages for inv in invocations] == [["torchcodec"], ["torchcodec==0.11.1"]]
+
+    for sep in ("&&", ";"):
+        cell = (
+            f'!pip uninstall -y torchcodec {sep} pip install "torchcodec==0.11.1"\n'
+            '!pip install "torch==2.12.0"'
+        )
+        assert len(nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0)) == 1, sep
+
+    healed = (
+        '!pip uninstall -y torchcodec && pip install "torchcodec==0.13.0"\n'
+        '!pip install "torch==2.12.0"'
+    )
+    assert nv.rule_inst_004_torchcodec_torch(healed, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # A `;` inside a PEP 508 marker is one argument, not a separator.
+    marked = "!pip install \"torch==2.12.0; python_version >= '3.10'\""
+    assert nv._split_chained(marked) == [(marked, False)]
+    assert len(nv.rule_inst_004_torchcodec_torch(marked, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_skips_the_fallback_side_of_an_or_chain():
+    """`A || B` runs B only when A failed, so replaying both reports a codec the notebook
+    does not have. The left side still counts."""
+    nv = _load_notebook_validator_module()
+
+    fallback = (
+        '!pip install "torchcodec==0.13.0" || pip install "torchcodec==0.11.1"\n'
+        '!pip install "torch==2.12.0"'
+    )
+    assert nv.rule_inst_004_torchcodec_torch(fallback, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    primary = (
+        '!pip install "torchcodec==0.11.1" || pip install "torchcodec==0.13.0"\n'
+        '!pip install "torch==2.12.0"'
+    )
+    assert len(nv.rule_inst_004_torchcodec_torch(primary, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_reads_compatible_release_pins():
+    """`~=2.12.0` implies `>=2.12.0`, so its floor moves the baseline up."""
+    nv = _load_notebook_validator_module()
+
+    upgraded = '!pip install "torch~=2.12.0"'
+    findings = nv.rule_inst_004_torchcodec_torch(upgraded, COLAB_TORCH211, "nb.ipynb", 0)
+    assert len(findings) == 1
+    assert "torchcodec>=0.12.0" in findings[0].hint
+
+    remedied = '!pip install "torch==2.12.0" "torchcodec~=0.13.0"'
+    assert nv.rule_inst_004_torchcodec_torch(remedied, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+def test_notebook_validator_stops_at_a_shell_comment():
+    """An unquoted `#` comments out the rest of the line, so a `;` inside it is not a
+    separator and the commented-out install must not be replayed."""
+    nv = _load_notebook_validator_module()
+
+    cell = '!pip install "torch==2.12.0" # keep codec; pip install "torchcodec==0.13.0"'
+    assert nv._split_chained(cell) == [('!pip install "torch==2.12.0"', False)]
+    assert len(nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+    # A control operator ends a word, so `;#` opens a comment with no space in front of it.
+    tight = '!pip install "torch==2.12.0";# keep codec; pip install "torchcodec==0.13.0"'
+    assert nv._split_chained(tight) == [('!pip install "torch==2.12.0"', False)]
+    assert len(nv.rule_inst_004_torchcodec_torch(tight, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+    # A `#` inside a word is not a comment: it is part of the argument.
+    fragment = '!pip install "torchcodec==0.13.0#egg=x"'
+    assert nv._split_chained(fragment) == [(fragment, False)]
+
+def test_notebook_validator_resumes_after_an_or_list():
+    """`A || B; C` runs C whatever A did. Only the conditional tail is dropped, and a `;`
+    ends it."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._split_chained(
+        "!pip install a && pip install b || pip install c ; pip install d"
+    ) == [
+        ("!pip install a", False),
+        ("!pip install b", False),
+        ("!pip install c", True),
+        ("!pip install d", False),
+    ]
+
+    cell = '!pip install "torchcodec==0.11.1" || echo failed; pip install "torch==2.12.0"'
+    assert len(nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_respects_escaped_separators():
+    """A backslash-escaped `;` is part of the argument, the way shlex reads it in
+    parse_pip_line. Split on it and the fragment ends in a backslash and parses as nothing."""
+    nv = _load_notebook_validator_module()
+
+    escaped = "!pip install torch==2.12.0\;\\ python_version\\ \\>\\=\\ \\'3.10\\'"
+    assert nv._split_chained(escaped) == [(escaped, False)]
+    assert [inv.packages for inv in nv.iter_pip_invocations(escaped)] == [
+        ["torch==2.12.0; python_version >= '3.10'"]
+    ]
+    assert len(nv.rule_inst_004_torchcodec_torch(escaped, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_merges_repeated_requirements_in_one_command():
+    """pip intersects a project named twice in one command, so the bounds are one window.
+    Applied one argument at a time the floor lands first and the ceiling then clears it."""
+    nv = _load_notebook_validator_module()
+
+    split_window = '!pip install "torchcodec>=0.10" "torchcodec<0.11"'
+    findings = nv.rule_inst_004_torchcodec_torch(split_window, COLAB_TORCH211, "nb.ipynb", 0)
+    assert len(findings) == 1
+    assert "torchcodec==0.10" in findings[0].message
+
+    # Same answer as the comma spelling, which is the point.
+    comma = '!pip install "torchcodec>=0.10,<0.11"'
+    assert nv.rule_inst_004_torchcodec_torch(comma, COLAB_TORCH211, "nb.ipynb", 0) == findings
+
+    # A window the baseline already sits in is still a no-op.
+    wide = '!pip install "torchcodec>=0.10" "torchcodec<0.12"'
+    assert nv.rule_inst_004_torchcodec_torch(wide, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+def test_notebook_validator_resumes_after_an_and_following_an_or():
+    """And-or lists are left-associative: in `A || B && C`, C runs when A succeeded, so the
+    conditional tail ends at the `&&`."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._split_chained("!pip install a || pip install b && pip install c") == [
+        ("!pip install a", False),
+        ("!pip install b", True),
+        ("!pip install c", False),
+    ]
+
+    cell = '!pip install "torchcodec==0.11.1" || echo failed && pip install "torch==2.12.0"'
+    assert len(nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_will_not_name_a_multi_minor_window():
+    """Moving down lands on the newest release the window admits, which the floor only names
+    when there is one minor to land in."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._window_names_one_minor("0.10", "0.11")
+    assert not nv._window_names_one_minor("0.10", "0.12")
+
+    # pip picks 0.11 here, which torch 2.11 is fine with, so nothing is reported.
+    spanning = '!pip install "torchcodec==0.15"\n!pip install "torchcodec>=0.10,<0.12"'
+    assert nv.rule_inst_004_torchcodec_torch(spanning, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # One minor still names its floor.
+    single = '!pip install "torchcodec>=0.10,<0.11"'
+    assert len(nv.rule_inst_004_torchcodec_torch(single, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_reads_a_direct_wheel_install():
+    """pip takes an archive URL as an install target and parse_spec skips it, so a wheel that
+    replaces the codec used to read as no install at all."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._archive_requirement(TORCHCODEC_WHEEL) == ("torchcodec", "0.13.0")
+    assert nv._archive_requirement("torchcodec==0.13.0") is None
+    assert nv._archive_requirement("git+https://github.com/meta-pytorch/torchcodec.git") is None
+    # A URL spells the local tag percent-encoded.
+    assert nv._archive_requirement(
+        "https://x/torch-2.12.0%2Bcu130-cp312-cp312-linux_x86_64.whl"
+    ) == ("torch", "2.12.0+cu130")
+
+    compatible = f'!pip install "torch==2.12.0" {TORCHCODEC_WHEEL}'
+    assert nv.rule_inst_004_torchcodec_torch(compatible, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    stale = compatible.replace("0.13.0", "0.10.0").replace("torch==2.12.0", "torch==2.11.0")
+    assert len(nv.rule_inst_004_torchcodec_torch(stale, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_replays_exclusions():
+    """`!=` rules out what is installed, so keeping it reports a version pip cannot leave in
+    place. Without a floor to fall back on the pairing is unknown, not stale."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._version_is_excluded("0.11.0+cu128", "0.11.*")
+    assert nv._version_is_excluded("0.11.0", "0.11.0")
+    assert not nv._version_is_excluded("0.11.0", "0.9.*")
+
+    for pin in ("torchcodec!=0.11.*", "torchcodec!=0.11.0"):
+        cell = f'!pip install "torch==2.12.0" "{pin}"'
+        assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], pin
+
+    # An exclusion that does not match leaves the baseline, and the pairing, alone.
+    untouched = '!pip install "torch==2.12.0" "torchcodec!=0.9.*"'
+    assert len(nv.rule_inst_004_torchcodec_torch(untouched, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+    # What is left after the exclusion spans minors, so the floor does not name it either.
+    broad = '!pip install "torch==2.12.0" "torchcodec>=0.9,!=0.11.*"'
+    assert nv.rule_inst_004_torchcodec_torch(broad, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # One minor left over still names its floor.
+    narrow = '!pip install "torch==2.11.0" "torchcodec>=0.10,<0.11,!=0.11.*"'
+    assert len(nv.rule_inst_004_torchcodec_torch(narrow, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_keeps_or_fallbacks_visible_to_other_rules():
+    """The fallback still runs when the left side fails, so dropping it from
+    iter_pip_invocations hid it from R-INST-001's git+ ban. Only the version replay skips it."""
+    nv = _load_notebook_validator_module()
+
+    cell = "!pip install foo || pip install git+https://example.com/evil.git"
+    assert [inv.conditional for inv in nv.iter_pip_invocations(cell)] == [False, True]
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0))
+
+    # The replay still ignores it, so the fallback codec is not reported as installed.
+    fallback = (
+        '!pip install "torchcodec==0.13.0" || pip install "torchcodec==0.11.1"\n'
+        '!pip install "torch==2.12.0"'
+    )
+    assert nv.rule_inst_004_torchcodec_torch(fallback, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+def test_notebook_validator_will_not_name_an_exclusive_floor():
+    """`>V` names the one version pip will not install, so on its own it says the install
+    moved but not where. Only a ceiling that pins the minor can answer that."""
+    nv = _load_notebook_validator_module()
+
+    for cell in ('!pip install "torch>2.12"', '!pip install "torch>2.11.999"'):
+        assert nv._effective_version(cell, "torch", "2.11.0+cu128") == (None, True), cell
+        assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], cell
+
+    # `>=` still names its endpoint, which is what the earlier rounds rest on.
+    assert nv._effective_version('!pip install "torch>=2.12"', "torch", "2.11.0+cu128") == (
+        "2.12",
+        False,
+    )
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                '!pip install "torch>=2.12"', COLAB_TORCH211, "nb.ipynb", 0
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_treats_an_open_floor_as_a_floor():
+    """pip takes the newest release above an open `>=`, so the floor is a lower bound and not
+    the answer. It is enough for the ABI check, where everything above it gives the same
+    answer, and not enough for the table, where it does not."""
+    nv = _load_notebook_validator_module()
+
+    old_pair = {"torch": "2.9.0+cu128", "torchcodec": "0.7.0+cu128"}
+
+    # 0.8 is in the torch 2.9 row, but `>=0.8` can just as easily land on 0.16, so nothing is
+    # proven either way and the rule stays quiet.
+    assert (
+        nv.rule_inst_004_torchcodec_torch('!pip install "torchcodec>=0.8"', old_pair, "nb.ipynb", 0)
+        == []
+    )
+
+    # Every release above this floor is outside the torch 2.10 row, so it is provable.
+    absent = {"torch": "2.10.0+cu128"}
+    findings = nv.rule_inst_004_torchcodec_torch(
+        '!pip install "torch==2.10.0" "torchcodec>=0.12.0"', absent, "nb.ipynb", 0
+    )
+    assert len(findings) == 1
+
+    # An exact pin in the row is still accepted, and one outside it still reported.
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!pip install "torchcodec==0.8.0"', old_pair, "nb.ipynb", 0
+        )
+        == []
+    )
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                '!pip install "torchcodec==0.11.0"', old_pair, "nb.ipynb", 0
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_ignores_a_conditional_pin_when_seeding():
+    """resolved_set seeds the replay, so it has to skip the `||` fallback as well or the
+    conditional pin comes back in through the seed."""
+    nv = _load_notebook_validator_module()
+
+    cell = '!pip install foo || pip install "torch==2.12.0"'
+    assert nv.resolved_set(cell, COLAB_TORCH211)["torch"] == "2.11.0+cu128"
+    assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+def test_notebook_validator_pads_release_segments_when_excluding():
+    """PEP 440 pads the release segment, so `!=0.11` rules out an installed `0.11.0`."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._version_is_excluded("0.11.0+cu128", "0.11")
+    assert nv._version_is_excluded("0.11", "0.11.0")
+    assert not nv._version_is_excluded("0.11.1", "0.11")
+
+    cell = '!pip install "torch==2.12" "torchcodec!=0.11"'
+    assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+def test_notebook_validator_unwraps_shell_groups():
+    """A grouped command still runs, so leaving the bracket on it hides it from PIP_LINE_RE
+    and with it from R-INST-001's git+ ban."""
+    nv = _load_notebook_validator_module()
+
+    for evil in (
+        "!pip install foo || (pip install git+https://example.com/evil.git)",
+        "!pip install foo || { pip install git+https://example.com/evil.git; }",
+        "!(pip install git+https://example.com/evil.git)",
+    ):
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(evil, "nb.ipynb", 0)
+        ), evil
+
+    assert nv._unwrap_shell_group("!( pip install x )") == ("!pip install x", False)
+    assert nv._unwrap_shell_group("{ pip install x") == ("pip install x", False)
+    assert nv._unwrap_shell_group("}") == ("", False)
+    assert nv._unwrap_shell_group("then pip install x") == ("pip install x", True)
+    # `if pip install ...` is the test, which runs whenever the line is reached.
+    assert nv._unwrap_shell_group("if pip install x") == ("pip install x", False)
+
+def test_notebook_validator_skips_conditional_invocations_in_rule_002(monkeypatch):
+    """resolved_set drops a fallback's pins, so a rule reading both has to drop the
+    invocation as well or it checks that install against an environment it never made."""
+    nv = _load_notebook_validator_module()
+    monkeypatch.setattr(
+        nv,
+        "pypi_metadata",
+        lambda name, version: {"info": {"requires_dist": ["tokenizers (>=0.30.0)"]}}
+        if name.lower() == "transformers"
+        else None,
+    )
+    colab = {"transformers": "5.0.0", "tokenizers": "0.22.2"}
+
+    # Unconditional, so the mismatch against Colab's tokenizers is real and reported.
+    plain = '!pip install --no-deps "transformers==5.5.0"'
+    assert [f.rule for f in nv.rule_inst_002_no_deps_transitive(plain, colab, "nb.ipynb", 0)] == [
+        "R-INST-002"
+    ]
+
+    # Behind an `||`, its pins never reach resolved_set, so checking it compares against an
+    # environment this branch did not build.
+    fallback = '!pip install foo || pip install --no-deps "transformers==5.5.0"'
+    assert [inv.conditional for inv in nv.iter_pip_invocations(fallback)] == [False, True]
+    assert nv.rule_inst_002_no_deps_transitive(fallback, colab, "nb.ipynb", 0) == []
+
+def test_notebook_validator_bounds_the_minor_with_an_inclusive_cap():
+    """`>=0.10,<=0.10.5` admits only the 0.10 line, so the window names it just as
+    `>=0.10,<0.11` does."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._window_names_one_minor("0.10", None, "0.10.5")
+    assert not nv._window_names_one_minor("0.10", None, "0.11")
+
+    older = {"torch": "2.11.0+cu128", "torchcodec": "0.9.0+cu128"}
+    findings = nv.rule_inst_004_torchcodec_torch(
+        '!pip install "torchcodec>=0.10,<=0.10.5"', older, "nb.ipynb", 0
+    )
+    assert len(findings) == 1
+    assert "torchcodec==0.10" in findings[0].message
+
+    # A cap that reaches into the next minor still cannot name where it lands.
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!pip install "torchcodec>=0.10,<=0.11"', older, "nb.ipynb", 0
+        )
+        == []
+    )
+
+def test_notebook_validator_applies_exclusions_to_where_it_landed():
+    """An exclusion has to hold for the version the requirement leaves in place, not only for
+    the one that was there before it ran."""
+    nv = _load_notebook_validator_module()
+
+    newer = {"torch": "2.10.0+cu128", "torchcodec": "0.15.0"}
+    # An earlier pin puts the codec above the cap, so the cap applies inside the replay
+    # rather than in resolved_set. It says 0.11, the exclusion rules the whole 0.11 line out,
+    # and pip lands below it: recording the cap reported a 0.11 codec against torch 2.10 when
+    # what actually installs there is a 0.10 release the row allows.
+    capped = '!pip install "torchcodec==0.15"\n!pip install "torchcodec<=0.11,!=0.11.*"'
+    assert nv.rule_inst_004_torchcodec_torch(capped, newer, "nb.ipynb", 0) == []
+
+    # A window that still names a minor after the exclusion keeps naming it.
+    findings = nv.rule_inst_004_torchcodec_torch(
+        '!pip install "torchcodec>=0.10,<0.11,!=0.11.*"',
+        {"torch": "2.11.0+cu128", "torchcodec": "0.15.0"},
+        "nb.ipynb",
+        0,
+    )
+    assert len(findings) == 1
+    assert "torchcodec==0.10" in findings[0].message
+
+def test_notebook_validator_skips_conditional_invocations_in_rule_003():
+    """The torchao floor helper reads the same cell, so a fallback that never runs must not
+    satisfy the floor R-INST-003 is checking."""
+    nv = _load_notebook_validator_module()
+
+    colab = {"peft": "0.19.1", "torchao": "0.15.0"}
+    assert (
+        nv._install_cell_lower_bound('!pip install foo || pip install "torchao>=0.16.0"', "torchao")
+        is None
+    )
+    assert [
+        f.rule
+        for f in nv.rule_inst_003_peft_torchao(
+            '!pip install foo || pip install "torchao>=0.16.0"', colab, "nb.ipynb", 0
+        )
+    ] == ["R-INST-003"]
+
+    # Run unconditionally and it does satisfy the floor.
+    assert (
+        nv.rule_inst_003_peft_torchao('!pip install "torchao>=0.16.0"', colab, "nb.ipynb", 0) == []
+    )
+
+def test_notebook_validator_moves_off_an_exclusive_endpoint():
+    """`>V` is not satisfied by V, so an installed version sitting exactly on the endpoint
+    still has to be replaced."""
+    nv = _load_notebook_validator_module()
+
+    on_the_endpoint = {"torch": "2.11.0+cu128", "torchcodec": "0.8.0"}
+    assert nv._effective_version('!pip install "torchcodec>0.8.0"', "torchcodec", "0.8.0") == (
+        None,
+        True,
+    )
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!pip install "torchcodec>0.8.0"', on_the_endpoint, "nb.ipynb", 0
+        )
+        == []
+    )
+
+    # `>=` is satisfied by it, and a lower `>` leaves it alone, so both still report the
+    # 0.8 codec against the torch 2.11 row.
+    for cell in ('!pip install "torchcodec>=0.8.0"', '!pip install "torchcodec>0.7.0"'):
+        assert (
+            len(nv.rule_inst_004_torchcodec_torch(cell, on_the_endpoint, "nb.ipynb", 0)) == 1
+        ), cell
+
+def test_notebook_validator_keeps_a_group_conditional_throughout():
+    """An `&&` or `;` inside a `(` or `{` group belongs to the group, so it does not end the
+    fallback: if the left side succeeded, nothing in the group runs."""
+    nv = _load_notebook_validator_module()
+
+    for grouped in (
+        '!pip install foo || (pip install bar && pip install "torch==2.12.0")',
+        '!pip install foo || (pip install bar ; pip install "torch==2.12.0")',
+    ):
+        assert [flag for _, flag in nv._split_chained(grouped)] == [False, True, True], grouped
+        assert (
+            nv.rule_inst_004_torchcodec_torch(grouped, COLAB_TORCH211, "nb.ipynb", 0) == []
+        ), grouped
+
+    # Outside a group, and after one closes, the operator still ends the tail.
+    for ungrouped in (
+        '!pip install foo || pip install bar && pip install "torch==2.12.0"',
+        '!pip install foo || (pip install bar) && pip install "torch==2.12.0"',
+    ):
+        assert [flag for _, flag in nv._split_chained(ungrouped)] == [False, True, False], ungrouped
+        assert (
+            len(nv.rule_inst_004_torchcodec_torch(ungrouped, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+        ), ungrouped
+
+    # The git+ ban still sees inside the group, conditional or not.
+    evil = "!pip install foo || (pip install bar && pip install git+https://example.com/evil.git)"
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(evil, "nb.ipynb", 0))
+
+def test_notebook_validator_pads_the_minor_boundary():
+    """`<0.11.0` and `<0.11` name the same boundary, so both windows hold one minor."""
+    nv = _load_notebook_validator_module()
+
+    assert nv.cmp_releases("0.11.0", "0.11") == 0
+    assert nv.cmp_releases("0.11.1", "0.11") == 1
+    assert nv._window_names_one_minor("0.10", "0.11.0")
+
+    for cell in (
+        '!pip install "torchcodec>=0.10,<0.11.0"',
+        '!pip install "torchcodec>=0.10,<0.11"',
+    ):
+        assert (
+            len(nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+        ), cell
+
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!pip install "torchcodec>=0.10,<0.12"', COLAB_TORCH211, "nb.ipynb", 0
+        )
+        == []
+    )
+
+def test_notebook_validator_reads_an_archive_given_as_a_path():
+    """`./torchcodec-0.13.0-...whl` parses as a project called `.`, so checking parse_spec
+    first hid the wheel behind a name that never matches."""
+    nv = _load_notebook_validator_module()
+
+    for path in (
+        "./torchcodec-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl",
+        "torchcodec-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl",
+        "/tmp/torchcodec-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl",
+    ):
+        assert nv._archive_requirement(path) == ("torchcodec", "0.13.0"), path
+        assert (
+            nv.rule_inst_004_torchcodec_torch(
+                f'!pip install "torch==2.12.0" {path}', COLAB_TORCH211, "nb.ipynb", 0
+            )
+            == []
+        ), path
+
+    stale = "./torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl"
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                f'!pip install "torch==2.12.0" {stale}', COLAB_TORCH211, "nb.ipynb", 0
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_keeps_the_stricter_of_two_equal_floors():
+    """`>=0.8.0,>0.8.0` intersect to the exclusive one, so the installed 0.8.0 still moves."""
+    nv = _load_notebook_validator_module()
+
+    for spelling in ("torchcodec>=0.8.0,>0.8.0", "torchcodec>0.8.0,>=0.8.0"):
+        assert nv._spec_window(nv.parse_spec(spelling).pins)[5] is True, spelling
+        assert nv._effective_version(f'!pip install "{spelling}"', "torchcodec", "0.8.0") == (
+            None,
+            True,
+        ), spelling
+
+    # Two inclusive floors still name the endpoint.
+    assert nv._effective_version(
+        '!pip install "torchcodec>=0.8.0,>=0.8.0"', "torchcodec", "0.8.0"
+    ) == ("0.8.0", True)
+
+def test_notebook_validator_reads_a_named_direct_reference():
+    """`name @ url` replaces the package even when the archive filename does not name it, so
+    the old version cannot be reported as if it were still installed."""
+    nv = _load_notebook_validator_module()
+
+    tag = "torchcodec @ https://github.com/meta-pytorch/torchcodec/archive/refs/tags/v0.13.0.zip"
+    assert nv._archive_requirement(tag) == ("torchcodec", None)
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            f'!pip install "torch==2.12.0" "{tag}"', COLAB_TORCH211, "nb.ipynb", 0
+        )
+        == []
+    )
+
+    # A named reference whose archive does name a version still yields it, either way.
+    wheel = "torchcodec @ https://x/torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl"
+    assert nv._archive_requirement(wheel) == ("torchcodec", "0.10.0")
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                f'!pip install "torch==2.11.0" "{wheel}"', COLAB_TORCH211, "nb.ipynb", 0
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_ends_a_grouped_and_or_list_at_its_own_operator():
+    """Which list an operator belongs to is its group depth. `(A || B && C)` is one list, so
+    the `&&` ends the tail; `A || (B && C)` is not, so it does not."""
+    nv = _load_notebook_validator_module()
+
+    same_list = '!(pip install foo || pip install bar && pip install "torch==2.12.0")'
+    assert [flag for _, flag in nv._split_chained(same_list)] == [False, True, False]
+    assert len(nv.rule_inst_004_torchcodec_torch(same_list, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+    inner = '!pip install foo || (pip install bar && pip install "torch==2.12.0")'
+    assert [flag for _, flag in nv._split_chained(inner)] == [False, True, True]
+    assert nv.rule_inst_004_torchcodec_torch(inner, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+def test_notebook_validator_keeps_a_minor_a_narrow_exclusion_cannot_remove():
+    """`>=0.11,<0.12,!=0.11.0` still lands in the 0.11 line, and the minor is what the rule
+    compares. Only a wildcard over the whole minor takes it away."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._exclusion_covers_minor("0.11", "0.11.*")
+    assert not nv._exclusion_covers_minor("0.11", "0.11.0")
+    assert not nv._exclusion_covers_minor("0.11", "0.11.1.*")
+
+    older = {"torch": "2.10.0+cu128", "torchcodec": "0.10.0"}
+    for cell in (
+        '!pip install "torchcodec>=0.11,<0.12,!=0.11.0"',
+        '!pip install "torchcodec>=0.11,<=0.11.1,!=0.11"',
+    ):
+        assert len(nv.rule_inst_004_torchcodec_torch(cell, older, "nb.ipynb", 0)) == 1, cell
+
+    # A wildcard over the minor still clears it.
+    newer = {"torch": "2.10.0+cu128", "torchcodec": "0.15.0"}
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!pip install "torchcodec>=0.10,<0.12,!=0.11.*"', newer, "nb.ipynb", 0
+        )
+        == []
+    )
+
+def test_notebook_validator_keeps_an_outer_fallback_across_a_nested_or():
+    """Each group keeps its own tail, so an inner `||` cannot hand the outer one back. A
+    command is conditional when any level above it is in a fallback."""
+    nv = _load_notebook_validator_module()
+
+    nested = (
+        "!pip install foo || (pip install bar || pip install baz && " 'pip install "torch==2.12.0")'
+    )
+    assert [flag for _, flag in nv._split_chained(nested)] == [False, True, True, True]
+    assert nv.rule_inst_004_torchcodec_torch(nested, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # The grouped head list still ends its own tail at the `&&`.
+    same_list = '!(pip install foo || pip install bar && pip install "torch==2.12.0")'
+    assert [flag for _, flag in nv._split_chained(same_list)] == [False, True, False]
+    assert len(nv.rule_inst_004_torchcodec_torch(same_list, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_lands_an_upward_move_on_an_inclusive_cap():
+    """`<=V` allows V, so V is what pip picks, whichever side the version moves from."""
+    nv = _load_notebook_validator_module()
+
+    # 0.7 upward into a window that spans minors: the cap names where it stops.
+    spanning = '!pip install "torchcodec==0.7.0"\n!pip install "torchcodec>=0.8,<=0.10.0"'
+    findings = nv.rule_inst_004_torchcodec_torch(spanning, COLAB_TORCH211, "nb.ipynb", 0)
+    assert len(findings) == 1
+    assert "torchcodec==0.10.0" in findings[0].message
+
+    # An open floor has no cap to land on and stays a floor, which the ABI remedy needs.
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!pip install "torch==2.12.0" "torchcodec>=0.12.0"', COLAB_TORCH211, "nb.ipynb", 0
+        )
+        == []
+    )
+
+def test_notebook_validator_will_not_keep_a_version_through_an_upgrade():
+    """A bare name with `--upgrade` takes the newest release, so the installed version is not
+    what the cell ends on. Without the flag pip leaves a satisfied requirement alone."""
+    nv = _load_notebook_validator_module()
+
+    # None of these let the installed version satisfy the requirement, so pip resolves from
+    # the index and the old version is not what the cell ends on.
+    for flag in ("--upgrade", "-U", "--force-reinstall", "--ignore-installed", "-I"):
+        cell = f'!pip install {flag} "torch==2.12.0" torchcodec'
+        assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], flag
+
+    # No flag: the requirement is already satisfied, so 0.11 stays and is reported.
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                '!pip install "torch==2.12.0" torchcodec', COLAB_TORCH211, "nb.ipynb", 0
+            )
+        )
+        == 1
+    )
+
+    # A bound still bounds it, forced or not.
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!pip install --force-reinstall "torch==2.12.0" "torchcodec>=0.12.0"',
+            COLAB_TORCH211,
+            "nb.ipynb",
+            0,
+        )
+        == []
+    )
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!pip install --upgrade "torch==2.12.0" "torchcodec>=0.12.0"',
+            COLAB_TORCH211,
+            "nb.ipynb",
+            0,
+        )
+        == []
+    )
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                '!pip install --upgrade "torch==2.11.0" "torchcodec==0.10.0"',
+                COLAB_TORCH211,
+                "nb.ipynb",
+                0,
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_keeps_the_flag_of_the_command_in_hand():
+    """A group's closing bracket ends the level, not the command being read: the install
+    before the `)` still belongs to the fallback the `||` opened."""
+    nv = _load_notebook_validator_module()
+
+    closing = '!(pip install foo || pip install "torch==2.12.0")'
+    assert [flag for _, flag in nv._split_chained(closing)] == [False, True]
+    assert nv.rule_inst_004_torchcodec_torch(closing, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # The same list ending its tail at an `&&` is unchanged.
+    ended = '!(pip install foo || pip install bar && pip install "torch==2.12.0")'
+    assert [flag for _, flag in nv._split_chained(ended)] == [False, True, False]
+    assert len(nv.rule_inst_004_torchcodec_torch(ended, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_reads_a_compound_only_line():
+    """With no standalone pip command on the line, every piece kept a keyword and none
+    parsed, so the git+ ban never looked. The body runs, but only if its test did."""
+    nv = _load_notebook_validator_module()
+
+    for evil in (
+        "!if command -v uv; then pip install git+https://example.com/evil.git; fi",
+        "!while true; do pip install git+https://example.com/evil.git; done",
+    ):
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(evil, "nb.ipynb", 0)
+        ), evil
+
+    # The `if` test runs; only the `then` body is conditional, and that is the pip call here,
+    # so the version replay leaves it alone.
+    guarded = '!if command -v uv; then pip install "torch==2.12.0"; fi'
+    assert [flag for _, flag in nv._split_chained(guarded)] == [False, True]
+    assert nv.rule_inst_004_torchcodec_torch(guarded, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # An unguarded install on its own line still counts.
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                '!pip install "torch==2.12.0"', COLAB_TORCH211, "nb.ipynb", 0
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_keeps_a_pip_call_used_as_a_test():
+    """`if pip install ...` is the condition, reached whenever the line is. Only a `then`,
+    `elif`, `else` or `do` body depends on how that condition went."""
+    nv = _load_notebook_validator_module()
+
+    older = {"torch": "2.10.0+cu128", "torchcodec": "0.10.0+cu128"}
+    for cell in (
+        '!pip install foo; if pip install "torch==2.9.0"; then true; fi',
+        '!while pip install "torch==2.9.0"; do true; done',
+    ):
+        assert len(nv.rule_inst_004_torchcodec_torch(cell, older, "nb.ipynb", 0)) == 1, cell
+
+    # The bodies stay conditional.
+    for cell in (
+        '!if command -v uv; then pip install "torch==2.12.0"; fi',
+        '!while true; do pip install "torch==2.12.0"; done',
+    ):
+        assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], cell
+
+def test_notebook_validator_evaluates_environment_markers():
+    """pip skips a requirement whose marker is false, so replaying its bounds moves a version
+    the cell never touches. The environment comes from the os-info oracle beside the pip
+    freeze, and without one nothing is evaluated."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._colab_python_version() is not None
+    environment = nv._marker_environment(COLAB_TORCH211)
+    assert environment is not None
+    assert not nv._requirement_applies("torch>=2.12; python_version < '3.10'", environment)
+    assert nv._requirement_applies("torch==2.12.0; python_version >= '3.10'", environment)
+    assert nv._requirement_applies("torch==2.12.0", environment)
+    # An unreadable marker is replayed rather than guessed at.
+    assert nv._requirement_applies("torch==2.12.0; nonsense !!", environment)
+
+    for skipped in (
+        "!pip install \"torch>=2.12; python_version < '3.10'\"",
+        "!pip install \"torch==2.12.0; python_version < '3.10'\"",
+        "!pip install 'torch==2.12.0; sys_platform == \"win32\"'",
+    ):
+        assert (
+            nv.rule_inst_004_torchcodec_torch(skipped, COLAB_TORCH211, "nb.ipynb", 0) == []
+        ), skipped
+
+    # A marker that holds is replayed, and so is one with no environment to judge it against.
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                "!pip install \"torch==2.12.0; python_version >= '3.10'\"",
+                COLAB_TORCH211,
+                "nb.ipynb",
+                0,
+            )
+        )
+        == 1
+    )
+    assert nv._marker_environment({}) is None
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                '!pip install --no-deps "torch==2.12.1; python_version < \'3.10\'" "torchcodec==0.11.1"',
+                {},
+                "nb.ipynb",
+                0,
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_expands_bundled_short_flags():
+    """pip takes `-Uq`, and parse_pip_line keeps it as one token, so the letters are what
+    gets compared."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._forces_resolution({"-Uq"})
+    assert nv._forces_resolution({"-qU"})
+    assert nv._forces_resolution({"--upgrade"})
+    assert not nv._forces_resolution({"-q"})
+    assert not nv._forces_resolution({"--quiet"})
+
+    for flag in ("-Uq", "-qU", "-qI"):
+        cell = f'!pip install "torch==2.12.0" {flag} torchcodec'
+        assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], flag
+
+    # A quiet flag on its own does not re-resolve anything.
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                '!pip install "torch==2.12.0" -q torchcodec', COLAB_TORCH211, "nb.ipynb", 0
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_splits_on_single_control_operators():
+    """`A & B` backgrounds A and runs B, `A | B` runs both. Neither opened a command boundary,
+    so a line starting with something other than pip hid the install entirely."""
+    nv = _load_notebook_validator_module()
+
+    assert [c for c, _ in nv._split_chained("!sleep 1 & pip install x")] == [
+        "!sleep 1",
+        "!pip install x",
+    ]
+    assert [c for c, _ in nv._split_chained("!echo x | pip install y")] == [
+        "!echo x",
+        "!pip install y",
+    ]
+
+    for evil in (
+        "!sleep 1 & pip install git+https://example.com/evil.git",
+        "!echo x | pip install git+https://example.com/evil.git",
+    ):
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(evil, "nb.ipynb", 0)
+        ), evil
+
+    # A redirection is not a separator, and neither is a quoted ampersand.
+    assert [c for c, _ in nv._split_chained("!pip install foo > log 2>&1")] == [
+        "!pip install foo > log 2>&1"
+    ]
+    assert nv._split_chained('!pip install "a&b"')[0][0] == '!pip install "a&b"'
+
+def test_notebook_validator_splits_keywords_on_any_whitespace():
+    """A tab after `then` is the same command to the shell. Splitting on a literal space left
+    `then\\tpip` as one word, which parses as nothing and hides the install."""
+    nv = _load_notebook_validator_module()
+
+    tabbed = "!if true; then\tpip install git+https://example.com/pkg.git; fi"
+    assert [c for c, _ in nv._split_chained(tabbed)][-1] == (
+        "!pip install git+https://example.com/pkg.git"
+    )
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(tabbed, "nb.ipynb", 0))
+
+    spaced = "!if true; then pip install git+https://example.com/pkg.git; fi"
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(spaced, "nb.ipynb", 0))
+
+def test_notebook_validator_comments_after_a_closing_bracket():
+    """A `)` ends a word, so `)#` opens a comment and what follows is documentation."""
+    nv = _load_notebook_validator_module()
+
+    cell = "!(pip install unsloth)# alternative: pip install git+https://example.com/pkg.git"
+    assert [c for c, _ in nv._split_chained(cell)] == ["!pip install unsloth"]
+    assert nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0) == []
+
+def test_notebook_validator_declines_markers_it_cannot_judge():
+    """`Marker.evaluate` fills any field the environment omits from the running process, so a
+    marker naming one would answer for this machine and move between runners."""
+    nv = _load_notebook_validator_module()
+
+    environment = nv._marker_environment(COLAB_TORCH211)
+    for unknown in (
+        "torch>=2.12; platform_release < '5.0'",
+        "torch>=2.12; platform_version == 'x'",
+        "torch>=2.12; implementation_version > '3'",
+    ):
+        assert nv._requirement_applies(unknown, environment), unknown
+
+    # The fields the oracle can answer for are still evaluated.
+    assert not nv._requirement_applies("torch>=2.12; python_version < '3.10'", environment)
+    assert nv._requirement_applies("torch>=2.12; sys_platform == 'linux'", environment)
+
+def test_notebook_validator_reads_case_arms():
+    """Stripping `case` left `x in x) pip install ...`, which parses as nothing. Only the
+    matching arm runs, so the command is conditional, and the git+ ban still sees it."""
+    nv = _load_notebook_validator_module()
+
+    single = "!case x in x) pip install git+https://example.com/pkg.git ;; esac"
+    assert nv._split_chained(single) == [("!pip install git+https://example.com/pkg.git", True)]
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(single, "nb.ipynb", 0))
+
+    # A later arm carries no keyword at all, just its own label.
+    multi = (
+        "!case x in a) pip install git+https://a.example/a.git ;; "
+        "b) pip install git+https://b.example/b.git ;; esac"
+    )
+    assert [c for c, _ in nv._split_chained(multi)] == [
+        "!pip install git+https://a.example/a.git",
+        "!pip install git+https://b.example/b.git",
+    ]
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(multi, "nb.ipynb", 0))
+
+    # Conditional, so the version replay leaves an arm alone.
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!case x in x) pip install "torch==2.12.0" ;; esac', COLAB_TORCH211, "nb.ipynb", 0
+        )
+        == []
+    )
+
+    # Bash accepts a quoted pattern, and the label still ends at its `)`.
+    quoted_pattern = '!case x in "x") pip install git+https://example.com/pkg.git ;; esac'
+    assert nv._split_chained(quoted_pattern) == [
+        ("!pip install git+https://example.com/pkg.git", True)
+    ]
+    assert any(
+        f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(quoted_pattern, "nb.ipynb", 0)
+    )
+
+    # A `)` inside a quoted argument, or inside a substitution, belongs to the command.
+    assert nv._unquoted_arm_close('pip install "a)b"') is None
+    assert nv._unquoted_arm_close("echo $(date) ; pip install a") is None
+    quoted = '!pip install "a)b" git+https://example.com/evil.git'
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(quoted, "nb.ipynb", 0))
+
+def test_notebook_validator_reads_pip_in_a_substitution():
+    """`echo $(pip install x)` runs the install as surely as the echo, and the outer command
+    is not pip, so the inner one has to be a command of its own."""
+    nv = _load_notebook_validator_module()
+
+    for cell in (
+        "!echo $(pip install git+https://example.com/pkg.git)",
+        "!X=`pip install git+https://example.com/pkg.git`",
+        "!echo $(echo $(pip install git+https://example.com/pkg.git))",
+    ):
+        assert "!pip install git+https://example.com/pkg.git" in [
+            command for command, _ in nv._split_chained(cell)
+        ], cell
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0)
+        ), cell
+
+    assert nv._substitution_bodies("echo $(pip install x) and `pip install y`") == [
+        "pip install x",
+        "pip install y",
+    ]
+    assert nv._substitution_bodies("pip install x") == []
+
+def test_notebook_validator_honours_escaped_case_patterns():
+    """A `\\)` in a pattern matches a literal parenthesis, so it is not what closes the arm."""
+    nv = _load_notebook_validator_module()
+
+    escaped = "!case 'x)y' in x\\)y) pip install git+https://example.com/pkg.git ;; esac"
+    assert nv._split_chained(escaped) == [("!pip install git+https://example.com/pkg.git", True)]
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(escaped, "nb.ipynb", 0))
+
+def test_notebook_validator_ignores_marker_names_in_literals():
+    """`sys_platform == 'platform_release'` references one variable, not two, so the marker
+    is judged rather than declined."""
+    nv = _load_notebook_validator_module()
+
+    environment = nv._marker_environment(COLAB_TORCH211)
+    assert not nv._requirement_applies(
+        "torch==2.12.0; sys_platform == 'platform_release'", environment
+    )
+    assert nv._requirement_applies("torch==2.12.0; sys_platform == 'linux'", environment)
+    # A real reference to an unknown field is still declined.
+    assert nv._requirement_applies("torch>=2.12; platform_release < '5.0'", environment)
+
+def test_notebook_validator_strips_execution_prefixes():
+    """`command pip install ...` and `env FOO=1 pip install ...` install exactly as a bare
+    `pip install ...` does, so the prefix must not hide them."""
+    nv = _load_notebook_validator_module()
+
+    for cell in (
+        "!command pip install git+https://example.com/pkg.git",
+        "!env FOO=1 pip install git+https://example.com/pkg.git",
+        "!FOO=1 pip install git+https://example.com/pkg.git",
+    ):
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0)
+        ), cell
+
+    # The replay reads them too, so a prefixed install still moves the version.
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                '!env FOO=1 pip install "torch==2.12.0"', COLAB_TORCH211, "nb.ipynb", 0
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_quotes_inside_a_substitution():
+    """A `)` inside a quoted argument closes no substitution, so the body runs past it."""
+    nv = _load_notebook_validator_module()
+
+    cell = "!echo \"$(printf 'X)'; pip install git+https://example.com/pkg.git)\""
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0))
+
+    # A backtick body survives the assignment-prefix strip, since the bodies are read off the
+    # raw pieces.
+    assert any(
+        f.rule == "R-INST-001"
+        for f in nv.rule_inst_001_git_plus(
+            "!X=`pip install git+https://example.com/pkg.git`", "nb.ipynb", 0
+        )
+    )
+
+def test_notebook_validator_tells_a_grouping_close_from_a_substitution_close():
+    """`)` ends a word when it closes a grouping and not when it closes a `$( )` inside one,
+    so only the first makes a following `#` a comment."""
+    nv = _load_notebook_validator_module()
+
+    # Bash prints `ok#suffix` here and runs the install.
+    embedded = "!echo $(printf ok)#suffix; pip install git+https://example.com/pkg.git"
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(embedded, "nb.ipynb", 0))
+
+    # A grouping close still opens a comment.
+    grouped = "!(pip install unsloth)# git+https://example.com/pkg.git"
+    assert nv.rule_inst_001_git_plus(grouped, "nb.ipynb", 0) == []
+
+def test_notebook_validator_ignores_quoted_substitution_text():
+    """Single quotes and an escaped `$` make the text literal, so nothing in it runs and the
+    notebook must not be failed for it. Double quotes still expand."""
+    nv = _load_notebook_validator_module()
+
+    literal = "!echo '$(pip install git+https://example.com/pkg.git)'; pip install unsloth"
+    assert nv._substitution_bodies(literal) == []
+    assert nv.rule_inst_001_git_plus(literal, "nb.ipynb", 0) == []
+
+    escaped = (
+        '!echo "' + chr(92) + '$(pip install git+https://example.com/pkg.git)"; '
+        "pip install unsloth"
+    )
+    assert nv.rule_inst_001_git_plus(escaped, "nb.ipynb", 0) == []
+
+    # A substitution inside double quotes is expanded, so it still counts.
+    expanded = "!echo \"$(printf 'X)'; pip install git+https://example.com/pkg.git)\""
+    assert any(f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(expanded, "nb.ipynb", 0))
+
+def test_notebook_validator_reads_process_substitutions():
+    """`<( )` and `>( )` run their commands too."""
+    nv = _load_notebook_validator_module()
+
+    for cell in (
+        "!cat <(pip install git+https://example.com/pkg.git); pip install unsloth",
+        "!tee >(pip install git+https://example.com/pkg.git); pip install unsloth",
+    ):
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0)
+        ), cell
+
+def test_notebook_validator_keeps_substitution_commands_in_order():
+    """A substitution runs before its host and its own separators are its own, so its commands
+    stay in sequence rather than being split across the line and appended at the end."""
+    nv = _load_notebook_validator_module()
+
+    cell = (
+        "!echo $(pip install torchcodec==0.12.0; pip install torchcodec==0.11.0); "
+        "pip install torch==2.12.0"
+    )
+    commands = [command for command, _ in nv._split_chained(cell)]
+    assert commands[0] == "!pip install torchcodec==0.12.0"
+    assert commands[1] == "!pip install torchcodec==0.11.0"
+    assert commands[-1] == "!pip install torch==2.12.0"
+
+    # 0.11 is what is left installed, and torch 2.12 does not take it.
+    findings = nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0)
+    assert len(findings) == 1
+    assert "torchcodec==0.11.0" in findings[0].message
+
+def test_notebook_validator_skips_a_prefixs_own_options():
+    """`env -u VAR pip install ...` runs pip, and stripping only the word left the options in
+    front of it. Rather than an option table per prefix, skip to where pip starts."""
+    nv = _load_notebook_validator_module()
+
+    for cell in (
+        "!env -u UNUSED pip install git+https://example.com/pkg.git",
+        "!sudo -u root pip install git+https://example.com/pkg.git",
+    ):
+        assert any(
+            f.rule == "R-INST-001" for f in nv.rule_inst_001_git_plus(cell, "nb.ipynb", 0)
+        ), cell
+
+    # Only after a prefix: an ordinary command that merely mentions pip is untouched.
+    assert (
+        nv.rule_inst_001_git_plus(
+            "!echo git+https://example.com/evil.git; pip install numpy", "nb.ipynb", 0
+        )
+        == []
+    )
+
+    assert (
+        len(
+            nv.rule_inst_004_torchcodec_torch(
+                '!env -u X pip install "torch==2.12.0"', COLAB_TORCH211, "nb.ipynb", 0
+            )
+        )
+        == 1
+    )
+
+def test_notebook_validator_keeps_redirections_and_quoted_process_forms():
+    """`>|` overrides noclobber rather than piping, and `<( )` inside double quotes is text."""
+    nv = _load_notebook_validator_module()
+
+    redirected = (
+        "!echo harmless >| pip install git+https://example.com/pkg.git; pip install unsloth"
+    )
+    assert nv.rule_inst_001_git_plus(redirected, "nb.ipynb", 0) == []
+
+    quoted = '!echo "<(pip install git+https://example.com/pkg.git)"; pip install unsloth'
+    assert nv.rule_inst_001_git_plus(quoted, "nb.ipynb", 0) == []
+
+    # Unquoted it runs, and a real pipeline still separates.
+    assert any(
+        f.rule == "R-INST-001"
+        for f in nv.rule_inst_001_git_plus(
+            "!cat <(pip install git+https://example.com/pkg.git)", "nb.ipynb", 0
+        )
+    )
+    assert any(
+        f.rule == "R-INST-001"
+        for f in nv.rule_inst_001_git_plus(
+            "!echo x | pip install git+https://example.com/evil.git", "nb.ipynb", 0
+        )
+    )
+
+def test_notebook_validator_reads_a_range_as_one_window():
+    """A `>=X,<Y` pair is the same constraint as `~=X`, and the guard's own remedy is
+    spelled that way (`pip install 'torchcodec>=0.11,<0.12.0'`), so the rule has to read it
+    back. A `<` with nothing under it names no version and leaves the pairing unknown."""
+    nv = _load_notebook_validator_module()
+
+    # Colab is on 0.11, which this window excludes, so pip drops into the 0.10 line.
+    narrowed = '!pip install "torchcodec>=0.10,<0.11"'
+    assert len(nv.rule_inst_004_torchcodec_torch(narrowed, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+    # The window torch 2.11 actually wants is a no-op on the same baseline.
+    matching = '!pip install "torchcodec>=0.11,<0.12.0"'
+    assert nv.rule_inst_004_torchcodec_torch(matching, COLAB_TORCH211, "nb.ipynb", 0) == []
+
+    # Open below: the release pip picks is unnamed, so no stale baseline is kept either.
+    assert (
+        nv.rule_inst_004_torchcodec_torch(
+            '!pip install "torch<2.11"', COLAB_TORCH211, "nb.ipynb", 0
+        )
+        == []
+    )
+
+    # An inclusive cap does name one, so it still clamps rather than clearing.
+    capped = '!pip install "torch==2.12.0" "torchcodec>=0.12"\n!pip install "torchcodec<=0.11"'
+    assert len(nv.rule_inst_004_torchcodec_torch(capped, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+def test_notebook_validator_reads_the_compatible_release_ceiling():
+    """`~=` pins a window, so it moves the baseline down as well as up. PEP 440 drops the
+    last component: `~=2.10.0` allows `<2.11`, `~=2.10` allows `<3`."""
+    nv = _load_notebook_validator_module()
+
+    assert nv._compatible_release_ceiling("2.10.0") == "2.11"
+    assert nv._compatible_release_ceiling("2.10") == "3"
+    assert nv._compatible_release_ceiling("2") is None
+
+    # Colab is on torch 2.11, which `~=2.10.0` excludes, so pip drops into the 2.10 line.
+    downgraded = '!pip install "torch~=2.10.0"'
+    assert len(nv.rule_inst_004_torchcodec_torch(downgraded, COLAB_TORCH211, "nb.ipynb", 0)) == 1
+
+    # `~=2.10` admits 2.11, and `~=2.11.0` is already satisfied. Neither moves anything.
+    for cell in ('!pip install "torch~=2.10"', '!pip install "torch~=2.11.0"'):
+        assert nv.rule_inst_004_torchcodec_torch(cell, COLAB_TORCH211, "nb.ipynb", 0) == [], cell
+
+
+# ----------------------------------------------------------------------------------
+# Codex review round 10 (2026-09-02): three P1 defects, each of which let
+# R-INST-001 miss a `git+` install that Bash really would run. One test per item,
+# each paired with the control that already passed, since what makes these bugs
+# rather than gaps is that the neighbouring form was caught all along.
+# ----------------------------------------------------------------------------------
+
+
+def _git_plus_rules(line: str) -> list[str]:
+    nv = _load_notebook_validator_module()
+    return [f.rule for f in nv.rule_inst_001_git_plus(line, "t.ipynb", 0)]
+
+
+def test_a_prefix_operand_named_pip_is_not_the_executable():
+    """`env -u pip` unsets the variable `pip`; the command is the word after it.
+
+    Selecting the first pip-looking word produced `pip pip install ...`, which PIP_LINE_RE
+    rejects outright, so the install was never collected and the git+ source never seen.
+    """
+    assert _git_plus_rules("!env -u pip pip install git+https://example.com/pkg.git") == [
+        "R-INST-001"
+    ]
+    # The control that always worked: the operand is spelled something else.
+    assert _git_plus_rules("!env -u VAR pip install git+https://example.com/pkg.git") == [
+        "R-INST-001"
+    ]
+
+
+def test_prefix_operands_are_consumed_for_every_supported_prefix():
+    for line in (
+        "!sudo -u pip pip install git+https://example.com/pkg.git",
+        "!env --unset=pip pip install git+https://example.com/pkg.git",
+        "!env -u pip -u also A=1 pip install git+https://example.com/pkg.git",
+        "!nohup pip install git+https://example.com/pkg.git",
+        "!env -- pip install git+https://example.com/pkg.git",
+    ):
+        assert _git_plus_rules(line) == ["R-INST-001"], line
+
+
+def test_a_command_list_inside_backticks_is_not_split_at_its_own_separator():
+    """Backticks run their contents like `$( )`, so the `;` inside one is not this line's.
+
+    Splitting there handed `_substitution_bodies` an unmatched fragment, which it cannot
+    read, so neither the nested pip command nor its git+ source was ever seen.
+    """
+    assert _git_plus_rules(
+        "!echo `pip install git+https://example.com/pkg.git; echo ok`; pip install unsloth"
+    ) == ["R-INST-001"]
+    # The control: the same shape written as `$( )` was caught before this fix.
+    assert _git_plus_rules(
+        "!echo $(pip install git+https://example.com/pkg.git); pip install unsloth"
+    ) == ["R-INST-001"]
+    # Single quotes make a backtick literal, so nothing runs and nothing is flagged.
+    assert _git_plus_rules("!echo 'a `pip install git+https://example.com/p.git` b'") == []
+
+
+def test_every_case_arm_is_scanned_not_just_the_ones_before_an_empty_piece():
+    """`;;` emits an empty piece and `esac` unwraps to "", so `out` outran `commands`.
+
+    `zip` stopped at the shorter list, and the arm holding the substitution fell off the
+    end without ever being handed to `_substitution_bodies`.
+    """
+    assert _git_plus_rules(
+        "!case x in y) echo no;; x) echo $(pip install git+https://example.com/pkg.git);; esac"
+    ) == ["R-INST-001"]
+    # The control: in the first arm, before any empty piece has been dropped.
+    assert _git_plus_rules(
+        "!case x in x) echo $(pip install git+https://example.com/pkg.git);; y) echo no;; esac"
+    ) == ["R-INST-001"]
+
+
+def test_an_arm_close_paren_is_not_stripped_off_a_substitution():
+    """`rstrip(")}")` ate the `)` that closes a `$( )` when no `(` had been stripped."""
+    nv = _load_notebook_validator_module()
+    text, conditional = nv._unwrap_shell_group(" x) echo $(pip install git+https://e.com/p.git)")
+    assert conditional is True
+    assert text.endswith(")"), text
+    assert nv._substitution_bodies(text) == ["pip install git+https://e.com/p.git"]
+    # A real group still loses its brackets.
+    assert nv._unwrap_shell_group("( pip install x )")[0] == "pip install x"

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1209,9 +1209,9 @@ def test_an_exclusion_rules_out_the_installed_version():
     # mismatch is still reported.
     untouched = '!pip install "torch==2.9.0" "torchcodec!=0.12.0"'
     assert nv._effective_version(untouched, "torchcodec", "0.11.0") == ("0.11.0", True)
-    assert [
-        f.rule for f in nv.rule_inst_004_torchcodec_torch(untouched, colab, "nb.ipynb", 0)
-    ] == ["R-INST-004"]
+    assert [f.rule for f in nv.rule_inst_004_torchcodec_torch(untouched, colab, "nb.ipynb", 0)] == [
+        "R-INST-004"
+    ]
 
 
 def test_versions_are_compared_with_pep440_zero_padding():

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1284,9 +1284,9 @@ def test_an_equal_strict_bound_upgrades_the_floor():
 
     colab = {"torch": "2.10.0+cu128", "torchcodec": "0.10.0+cu128"}
     assert nv._effective_version(combined, "torchcodec", "0.10.0") == ("0.11", True)
-    assert [
-        f.rule for f in nv.rule_inst_004_torchcodec_torch(combined, colab, "nb.ipynb", 0)
-    ] == ["R-INST-004"]
+    assert [f.rule for f in nv.rule_inst_004_torchcodec_torch(combined, colab, "nb.ipynb", 0)] == [
+        "R-INST-004"
+    ]
 
     # Order does not matter, and a plain `>=` is still inclusive.
     assert nv._spec_window([(">", "0.10"), (">=", "0.10"), ("<", "0.12")])[5] is True
@@ -1378,9 +1378,7 @@ def test_the_printed_codec_index_is_redacted(monkeypatch):
     assert "secret" not in shown
 
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.corp.example/simple?token=abc")
-    assert "abc" not in ips._strip_index_url_credentials(
-        ips._torchcodec_index_url("2.11.0+cu128")
-    )
+    assert "abc" not in ips._strip_index_url_credentials(ips._torchcodec_index_url("2.11.0+cu128"))
 
     # The status line itself uses the redacting call, not the raw variable.
     source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -424,9 +424,7 @@ def test_pinning_the_index_never_starves_a_reachable_torch():
             version = f"2.{minor}.0+{tag}"
             spec = ips._select_torchcodec_spec(version)
             specifier = SpecifierSet(spec.split("torchcodec", 1)[1])
-            served = [
-                f"0.{m}.0" for m in range(low, high + 1) if specifier.contains(f"0.{m}.0")
-            ]
+            served = [f"0.{m}.0" for m in range(low, high + 1) if specifier.contains(f"0.{m}.0")]
             index = ips._torchcodec_index_url(version, spec)
             if index is None:
                 # Only the PyPI-only rows may decline to pin.
@@ -447,7 +445,9 @@ def test_the_two_pypi_only_rows_stay_unpinned():
         version = f"2.{minor}.0+cu126"
         assert ips._torchcodec_index_url(version, ips._select_torchcodec_spec(version)) is None
     # 2.7 selects >=0.3.0,<0.6.0, which the indexes do carry, so it pins.
-    assert ips._torchcodec_index_url("2.7.0+cu118", ips._select_torchcodec_spec("2.7.0")) is not None
+    assert (
+        ips._torchcodec_index_url("2.7.0+cu118", ips._select_torchcodec_spec("2.7.0")) is not None
+    )
 
 
 def test_compat_matrix_matches_the_published_upstream_table():
@@ -596,9 +596,9 @@ def test_a_requested_codec_range_beats_the_preinstalled_oracle():
         '!pip install torch==2.10.0 "torchcodec>=0.12.0"',
     ]
     for cell in flagged:
-        assert [
-            f.rule for f in nv.rule_inst_004_torchcodec_torch(cell, colab, "nb.ipynb", 0)
-        ] == ["R-INST-004"], cell
+        assert [f.rule for f in nv.rule_inst_004_torchcodec_torch(cell, colab, "nb.ipynb", 0)] == [
+            "R-INST-004"
+        ], cell
 
 
 def test_validator_and_runtime_guard_agree_on_the_whole_matrix(monkeypatch):

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1458,3 +1458,74 @@ def test_the_runtime_remedy_follows_a_configured_pytorch_mirror(monkeypatch):
     assert "--index-url https://download.pytorch.org/whl/cu126" in (
         fixes._torchcodec_version_mismatch_hint() or ""
     )
+
+
+def test_the_provenance_hint_does_not_assert_a_cause_it_has_not_established(monkeypatch):
+    """Differing local tags show the two wheels came from different indexes, nothing more.
+    torchcodec is published per accelerator on every line, 0.12+ included, so the mismatch
+    stays possible there, but the load can equally have failed on a missing libavutil that no
+    reinstall repairs. The hint has to name both."""
+    import sys
+    import types
+
+    fixes = _load_import_fixes_module()
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_URL", raising = False)
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY", raising = False)
+    monkeypatch.delenv("UNSLOTH_PYTORCH_MIRROR", raising = False)
+    _stub_torch(monkeypatch, "2.12.0+cu128")
+
+    codec = types.ModuleType("torchcodec")
+    codec.__version__ = "0.12.0"
+    monkeypatch.setitem(sys.modules, "torchcodec", codec)
+    hint = fixes._torchcodec_provenance_hint()
+    assert hint is not None  # 0.12+ is ABI-stable against torch, not accelerator-agnostic
+    assert "may be built for a different accelerator" in hint
+    assert "cannot load" not in hint
+    assert "FFmpeg" in hint
+
+def test_the_remedy_uses_the_shell_of_the_host_it_prints_on(monkeypatch):
+    """PowerShell is Studio's supported Windows shell and does not expand `$NAME`, so the
+    POSIX spelling pasted there produced an empty `--index-url`."""
+    import importlib.metadata
+
+    fixes = _load_import_fixes_module()
+    monkeypatch.setattr(importlib.metadata, "version", lambda _name: "0.11.0")
+    _stub_torch(monkeypatch, "2.10.0+cu128")
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://user:secret@mirror.corp.example/cu128")
+
+    monkeypatch.setattr(fixes.sys, "platform", "linux")
+    assert '--index-url "$UNSLOTH_TORCH_INDEX_URL"' in (
+        fixes._torchcodec_version_mismatch_hint() or ""
+    )
+
+    monkeypatch.setattr(fixes.sys, "platform", "win32")
+    windows = fixes._torchcodec_version_mismatch_hint() or ""
+    assert "--index-url $env:UNSLOTH_TORCH_INDEX_URL" in windows
+    assert "secret" not in windows
+
+    # The mirror branch follows the same rule.
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_URL")
+    monkeypatch.setenv("UNSLOTH_PYTORCH_MIRROR", "https://mirror.corp.example/whl")
+    assert "--index-url $env:UNSLOTH_PYTORCH_MIRROR/cu128" in (
+        fixes._torchcodec_version_mismatch_hint() or ""
+    )
+
+
+
+def test_a_torch_range_is_replayed_before_the_pair_is_judged():
+    """`pip install "torch>=2.12.0"` does not satisfy the image's 2.11, so pip upgrades torch
+    while the codec stays on 0.11. Both sides have to be replayed, not just the codec."""
+    from scripts import notebook_validator as nv
+
+    colab = {"torch": "2.11.0+cu128", "torchcodec": "0.11.0+cu128"}
+    assert [
+        f.rule
+        for f in nv.rule_inst_004_torchcodec_torch(
+            '!pip install "torch>=2.12.0"', colab, "nb.ipynb", 0
+        )
+    ] == ["R-INST-004"]
+    # A floor the image already satisfies moves nothing, and a removal leaves nothing to judge.
+    assert nv.rule_inst_004_torchcodec_torch(
+        '!pip install "torch>=2.11.0"', colab, "nb.ipynb", 0
+    ) == []
+    assert nv.rule_inst_004_torchcodec_torch("!pip uninstall -y torch", colab, "nb.ipynb", 0) == []

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1212,3 +1212,44 @@ def test_an_exclusion_rules_out_the_installed_version():
     assert [
         f.rule for f in nv.rule_inst_004_torchcodec_torch(untouched, colab, "nb.ipynb", 0)
     ] == ["R-INST-004"]
+
+
+def test_versions_are_compared_with_pep440_zero_padding():
+    """PEP 440 pads the shorter release segment, so `0.11` and `0.11.0` are one version.
+    Comparing the raw tuples sorted `0.11` below `0.11.0`, which silently changed which
+    branch answered for a window whose floor spells out its patch."""
+    from scripts import notebook_validator as nv
+
+    assert nv.cmp_versions("0.11", "0.11.0") == 0
+    assert nv.cmp_versions("2.12", "2.12.0.0") == 0
+    assert nv.cmp_versions("0.11", "0.11.1") == -1
+    assert nv.cmp_versions("0.12", "0.11.9") == 1
+
+    colab = {"torch": "2.11.0+cu128", "torchcodec": "0.11.0+cu128"}
+    strict_window = '!pip install "torch==2.12.0" "torchcodec>0.11.0,<0.12.0"'
+    assert [
+        f.rule for f in nv.rule_inst_004_torchcodec_torch(strict_window, colab, "nb.ipynb", 0)
+    ] == ["R-INST-004"]
+
+
+def test_the_codec_index_honours_an_explicitly_pinned_torch_mirror(monkeypatch):
+    """UNSLOTH_TORCH_INDEX_URL names the index torch itself came from. Rebuilding a public
+    download.pytorch.org URL from the local tag sent an authenticated or air-gapped mirror to
+    the internet, and the `--index-url` that follows also drops the inherited index
+    configuration, so the codec install fails outright where public PyTorch is unreachable."""
+    from studio import install_python_stack as ips
+
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_URL", raising = False)
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY", raising = False)
+    assert ips._torchcodec_index_url("2.11.0+cu128") == "https://download.pytorch.org/whl/cu128"
+
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.corp.example/pytorch/cu128/")
+    assert ips._torchcodec_index_url("2.11.0+cu128") == "https://mirror.corp.example/pytorch/cu128"
+
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_URL")
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "cu126")
+    assert ips._torchcodec_index_url("2.11.0+cu128") == "https://download.pytorch.org/whl/cu126"
+
+    # The override does not make an untagged or rocm torch start pinning.
+    assert ips._torchcodec_index_url("2.11.0") is None
+    assert ips._torchcodec_index_url("2.11.0+rocm7.0") is None

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1140,7 +1140,9 @@ def test_an_exclusive_ceiling_names_the_minor_pip_moves_to():
     assert [f.rule for f in nv.rule_inst_004_torchcodec_torch(cell, colab, "nb.ipynb", 0)] == [
         "R-INST-004"
     ]
-    assert nv._effective_version('!pip install "torchcodec>=0.8,<0.11"', "torchcodec", "0.11.0") == (
+    assert nv._effective_version(
+        '!pip install "torchcodec>=0.8,<0.11"', "torchcodec", "0.11.0"
+    ) == (
         "0.10",
         True,
     )

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1395,9 +1395,9 @@ def test_a_chained_uninstall_does_not_swallow_the_reinstall():
     colab = {"torch": "2.11.0+cu128", "torchcodec": "0.11.0+cu128"}
     chained = "!pip uninstall -y torchcodec && pip install torchcodec==0.10.0"
     assert nv._effective_version(chained, "torchcodec", "0.11.0") == ("0.10.0", True)
-    assert [
-        f.rule for f in nv.rule_inst_004_torchcodec_torch(chained, colab, "nb.ipynb", 0)
-    ] == ["R-INST-004"]
+    assert [f.rule for f in nv.rule_inst_004_torchcodec_torch(chained, colab, "nb.ipynb", 0)] == [
+        "R-INST-004"
+    ]
 
     # A line that really does end on a removal still clears it, in either spelling.
     for removed in (
@@ -1419,6 +1419,7 @@ def test_the_codec_index_follows_a_configured_pytorch_mirror(monkeypatch):
     monkeypatch.delenv("UNSLOTH_TORCH_INDEX_URL", raising = False)
     monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY", raising = False)
     from studio import install_python_stack as ips
+
     ips = importlib.reload(ips)  # _PYTORCH_WHL_BASE is read at import time
     try:
         assert ips._torchcodec_index_url("2.11.0+cu128") == "https://mirror.corp.example/whl/cu128"
@@ -1483,6 +1484,7 @@ def test_the_provenance_hint_does_not_assert_a_cause_it_has_not_established(monk
     assert "cannot load" not in hint
     assert "FFmpeg" in hint
 
+
 def test_the_remedy_uses_the_shell_of_the_host_it_prints_on(monkeypatch):
     """PowerShell is Studio's supported Windows shell and does not expand `$NAME`, so the
     POSIX spelling pasted there produced an empty `--index-url`."""
@@ -1511,7 +1513,6 @@ def test_the_remedy_uses_the_shell_of_the_host_it_prints_on(monkeypatch):
     )
 
 
-
 def test_a_torch_range_is_replayed_before_the_pair_is_judged():
     """`pip install "torch>=2.12.0"` does not satisfy the image's 2.11, so pip upgrades torch
     while the codec stays on 0.11. Both sides have to be replayed, not just the codec."""
@@ -1525,9 +1526,10 @@ def test_a_torch_range_is_replayed_before_the_pair_is_judged():
         )
     ] == ["R-INST-004"]
     # A floor the image already satisfies moves nothing, and a removal leaves nothing to judge.
-    assert nv.rule_inst_004_torchcodec_torch(
-        '!pip install "torch>=2.11.0"', colab, "nb.ipynb", 0
-    ) == []
+    assert (
+        nv.rule_inst_004_torchcodec_torch('!pip install "torch>=2.11.0"', colab, "nb.ipynb", 0)
+        == []
+    )
     assert nv.rule_inst_004_torchcodec_torch("!pip uninstall -y torch", colab, "nb.ipynb", 0) == []
 
 
@@ -1539,9 +1541,7 @@ def test_each_pip_command_owns_the_packages_it_names():
 
     colab = {"torch": "2.11.0+cu128", "torchcodec": "0.11.0+cu128"}
 
-    other_package = (
-        "!pip install torch==2.10.0 torchcodec==0.12.0 && pip uninstall -y torchaudio"
-    )
+    other_package = "!pip install torch==2.10.0 torchcodec==0.12.0 && pip uninstall -y torchaudio"
     assert nv._effective_version(other_package, "torchcodec", "0.11.0") == ("0.12.0", True)
     assert nv._effective_version(other_package, "torch", "2.11.0") == ("2.10.0", True)
     assert [


### PR DESCRIPTION
Split out of #7474, which is a torchcodec/torch 2.11 pin. The parser rewrite in `scripts/notebook_validator.py` rode along with that PR and has since driven every one of its nine review rounds, while sharing no code with the pin itself. Separating them makes each reviewable and revertable on its own, and stops a compatibility fix waiting on a shell-parsing arms race.

This carries the rewrite as it stood at `75a808c5c`, plus fixes for the three P1 items from the 2026-09-02 round, which were still open when I split.

## The three defects

Each let `R-INST-001` return no finding for a line bash really would run the prohibited `git+` install on. In each case the neighbouring form was already caught, which is what makes them defects rather than gaps in coverage.

**A prefix operand can be spelled like the command.** `env -u pip` unsets the variable named `pip` and then runs the second `pip`. The executable was located with `_PIP_WORD_RE.search()`, which takes the first match, so it selected the operand and produced `pip pip install ...` -- rejected by `PIP_LINE_RE` on its `install|uninstall` group, so the invocation was never collected at all.

```
raw:    !env -u pip pip install git+https://example.com/pkg.git
unwrap: ('! pip pip install git+https://example.com/pkg.git', False)
invocations: []
```

Prefixes now consume their own options and operands positionally, driven by a small per-prefix table of which flags take a separate argument, with `--` ending the options and `--unset=NAME` handled inline. The executable is whatever word survives.

**Backticks were not tracked as substitutions.** `_split_chained` knew about quotes and `(`/`{` but never a backtick, and `in_sub()` was defined purely off the groupings stack. So the `;` inside `` `pip install git+...; echo ok` `` reached the top-level separator branch, split the line, and left `_substitution_bodies` an unmatched fragment it bails on. The `$( )` spelling of the same shape was caught throughout, which isolates it:

```
_substitution_bodies(whole line)  -> ['pip install git+https://example.com/pkg.git; echo ok']
_substitution_bodies(first piece) -> []
```

There is now a backtick state folded into `in_sub()`, checked before the quote branch since backticks expand inside double quotes and only single quotes make them literal.

**`zip(out, commands)` was not one-to-one.** `commands` dropped any piece that unwrapped to empty while `out` kept them, so every later pair slid by one and `zip` stopped at the shorter list. A `case` emits an empty piece per `;;` and its `esac` also unwraps to `""`, so a two-arm `case` gave `out` 5 entries against `commands` 2, and the arm carrying the substitution was never handed to `_substitution_bodies` at all -- not merely mispaired, but off the end. Empty pieces are carried through the pairing now and filtered after it.

One adjacent defect the same trace exposed: `_unwrap_shell_group` ended with `stripped.rstrip(")}")`, which also ate the `)` closing a `$( )` when no `(` had been stripped, leaving `echo $(pip install git+...` unbalanced even once the piece was reached. Only a grouping bracket is stripped now. A lone `}` from a group that spanned a separator still strips, which is why this needs `_final_bracket_closes_substitution` rather than simple bracket counting -- I tried the counting version first and it broke exactly that case.

## Verification

Five tests, one per item plus one for the bracket strip, each paired with the control that already passed. All five are red against the parser at `75a808c5c` and green here:

```
FAILED test_a_prefix_operand_named_pip_is_not_the_executable
FAILED test_prefix_operands_are_consumed_for_every_supported_prefix
FAILED test_a_command_list_inside_backticks_is_not_split_at_its_own_separator
FAILED test_every_case_arm_is_scanned_not_just_the_ones_before_an_empty_piece
FAILED test_an_arm_close_paren_is_not_stripped_off_a_substitution
5 failed, 63 deselected
```

`tests/notebooks` is 119 passed / 2 skipped at head, which includes the 64 validator tests moved over from #7474's test file. ruff clean on both changed files.

## One overlap with #7474

The `"2.11": {"0.11"}` torchcodec row is in this file too, because `rule_inst_004_torchcodec_torch` lives here and its update depends on `_effective_version` and `_marker_environment` from this rewrite -- so the rule change could not be separated from the parser change. #7474 adds the same one line on its side to keep `test_torchcodec_matrix_matches_notebook_validator` green. Whichever merges second will conflict on that single line, with identical content on both sides.
