### PR TITLE
feat(api-monitor): add Load button to API page toolbar

### DIFF
--- a/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
+++ b/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
@@ -754,7 +754,9 @@ export function ApiMonitorPage(): ReactElement {
               size="sm"
               placeholder="Load"
               disabled={loadingModel !== null}
-              className="h-9 gap-1.5 rounded-full"
+              hideChevron
+              triggerLabelClassName="font-sans text-sm text-foreground dark:text-foreground"
+              className="h-9 gap-1.5 rounded-full px-3 disabled:opacity-50 bg-background dark:border-transparent dark:bg-white/[0.06] hover:bg-accent/50 dark:hover:bg-white/10"
             />
           </span>
           <Button

--- a/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
+++ b/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
@@ -13,13 +13,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchDeviceType, usePlatformStore } from "@/config/env";
 import { getInferenceStatus, unloadModel } from "@/features/chat/api/chat-api";
 import { resolveInferenceCheckpointId } from "@/features/chat/lib/apply-inference-status-to-store";
+import { useChatModelRuntime } from "@/features/chat/hooks/use-chat-model-runtime";
 import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
 import type { ApiMonitorEntry } from "@/features/chat";
 import { isExternalModelId } from "@/features/chat/external-providers";
+import { ModelSelector } from "@/features/model-picker/components/model-selector";
 import { modelIdsMatch } from "@/features/hub/lib/model-identity";
 import { useSettingsDialogStore } from "@/features/settings";
 import { remoteApiOrigin } from "@/features/settings/api/remote-access-state";
@@ -29,6 +36,7 @@ import { Tick02Icon } from "@/lib/tick-icon";
 import { cn } from "@/lib/utils";
 import {
   Copy01Icon,
+  Download01Icon,
   Delete02Icon,
   Globe02Icon,
   PauseIcon,
@@ -550,6 +558,9 @@ export function ApiMonitorPage(): ReactElement {
   const cloudflareUrl = usePlatformStore((s) => s.cloudflareUrl);
   const [unloading, setUnloading] = useState(false);
   const [unloadError, setUnloadError] = useState<string | null>(null);
+  const { selectModel, loadingModel } = useChatModelRuntime();
+  const models = useChatRuntimeStore((state) => state.models);
+  const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
 
   useEffect(() => {
     const refreshRemoteBase = () => {
@@ -703,6 +714,50 @@ export function ApiMonitorPage(): ReactElement {
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          <Popover open={modelSelectorOpen} onOpenChange={setModelSelectorOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={loadingModel !== null}
+                title={loadingModel ? "Model is loading" : "Load a model"}
+                className="h-9 gap-1.5 rounded-full"
+              >
+                <HugeiconsIcon
+                  icon={Download01Icon}
+                  strokeWidth={1.75}
+                  className="size-4"
+                />
+                Load
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[400px]">
+              <ModelSelector.Content
+                open={modelSelectorOpen}
+                models={models}
+                loraModels={[]}
+                externalModels={[]}
+                value=""
+                onSelect={(id, meta) => {
+                  selectModel({
+                    id,
+                    ggufVariant: meta.ggufVariant,
+                    source: meta.source,
+                    isLora: meta.isLora,
+                    isDownloaded: meta.isDownloaded,
+                    expectedBytes: meta.expectedBytes,
+                    isGguf: meta.isGguf,
+                    isDiffusion: meta.isDiffusion,
+                    config: meta.config,
+                    nativePathToken: meta.nativePathToken,
+                    nativePathExpiresAtMs: meta.nativePathExpiresAtMs,
+                  });
+                  setModelSelectorOpen(false);
+                }}
+              />
+            </PopoverContent>
+          </Popover>
           <Button
             type="button"
             variant="outline"

--- a/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
+++ b/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
@@ -13,11 +13,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchDeviceType, usePlatformStore } from "@/config/env";
 import { getInferenceStatus, unloadModel } from "@/features/chat/api/chat-api";
@@ -27,6 +22,11 @@ import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
 import type { ApiMonitorEntry } from "@/features/chat";
 import { isExternalModelId } from "@/features/chat/external-providers";
 import { ModelSelector } from "@/features/model-picker/components/model-selector";
+import {
+  currentRuntimePerModelConfig,
+  resolveInitialConfig,
+  type ModelSelectorChangeMeta,
+} from "@/features/model-picker";
 import { modelIdsMatch } from "@/features/hub/lib/model-identity";
 import { useSettingsDialogStore } from "@/features/settings";
 import { remoteApiOrigin } from "@/features/settings/api/remote-access-state";
@@ -36,7 +36,6 @@ import { Tick02Icon } from "@/lib/tick-icon";
 import { cn } from "@/lib/utils";
 import {
   Copy01Icon,
-  Download01Icon,
   Delete02Icon,
   Globe02Icon,
   PauseIcon,
@@ -46,7 +45,7 @@ import {
   Settings02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SavedModelSettingsPanel } from "./components/saved-model-settings";
 import { isLifecycleEntry, lifecycleLabel } from "./lifecycle";
 import { unloadResident } from "./unload-resident";
@@ -560,7 +559,34 @@ export function ApiMonitorPage(): ReactElement {
   const [unloadError, setUnloadError] = useState<string | null>(null);
   const { selectModel, loadingModel } = useChatModelRuntime();
   const models = useChatRuntimeStore((state) => state.models);
-  const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
+  const handleModelSelect = useCallback(
+    (id: string, meta: ModelSelectorChangeMeta) => {
+      const previousConfig = currentRuntimePerModelConfig({
+        includeMaxSeqLength: true,
+      });
+      const remembered = resolveInitialConfig(id, meta.ggufVariant);
+      const loadConfig =
+        meta.config ??
+        (remembered.remembered ? remembered.config : null);
+      void selectModel({
+        id,
+        ggufVariant: meta.ggufVariant,
+        source: meta.source,
+        isLora: meta.isLora,
+        isDownloaded: meta.isDownloaded,
+        expectedBytes: meta.expectedBytes,
+        isGguf: meta.isGguf,
+        isDiffusion: meta.isDiffusion,
+        nativePathToken: meta.nativePathToken,
+        nativePathExpiresAtMs: meta.nativePathExpiresAtMs,
+        ...(loadConfig
+          ? { keepSpeculative: true, config: loadConfig }
+          : {}),
+        previousConfig,
+      });
+    },
+    [selectModel],
+  );
 
   useEffect(() => {
     const refreshRemoteBase = () => {
@@ -714,50 +740,23 @@ export function ApiMonitorPage(): ReactElement {
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <Popover open={modelSelectorOpen} onOpenChange={setModelSelectorOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={loadingModel !== null}
-                title={loadingModel ? "Model is loading" : "Load a model"}
-                className="h-9 gap-1.5 rounded-full"
-              >
-                <HugeiconsIcon
-                  icon={Download01Icon}
-                  strokeWidth={1.75}
-                  className="size-4"
-                />
-                Load
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-[400px]">
-              <ModelSelector.Content
-                open={modelSelectorOpen}
-                models={models}
-                loraModels={[]}
-                externalModels={[]}
-                value=""
-                onSelect={(id, meta) => {
-                  selectModel({
-                    id,
-                    ggufVariant: meta.ggufVariant,
-                    source: meta.source,
-                    isLora: meta.isLora,
-                    isDownloaded: meta.isDownloaded,
-                    expectedBytes: meta.expectedBytes,
-                    isGguf: meta.isGguf,
-                    isDiffusion: meta.isDiffusion,
-                    config: meta.config,
-                    nativePathToken: meta.nativePathToken,
-                    nativePathExpiresAtMs: meta.nativePathExpiresAtMs,
-                  });
-                  setModelSelectorOpen(false);
-                }}
-              />
-            </PopoverContent>
-          </Popover>
+          <span
+            title={loadingModel ? "Model is loading" : "Load a model"}
+            className="inline-flex"
+          >
+            <ModelSelector
+              models={models}
+              loraModels={[]}
+              externalModels={[]}
+              value=""
+              onValueChange={handleModelSelect}
+              variant="outline"
+              size="sm"
+              placeholder="Load"
+              disabled={loadingModel !== null}
+              className="h-9 gap-1.5 rounded-full"
+            />
+          </span>
           <Button
             type="button"
             variant="outline"

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -162,6 +162,8 @@ interface ModelSelectorProps {
   deleteDisabled?: boolean;
   /** Disable the trigger button entirely (e.g. while a load is in flight). */
   disabled?: boolean;
+  /** Hide the trailing chevron so the trigger reads as a plain toolbar action. */
+  hideChevron?: boolean;
   variant?: "outline" | "ghost" | "muted";
   size?: "sm" | "default" | "lg";
   className?: string;
@@ -197,6 +199,7 @@ function ModelSelectorTrigger({
   dataTour,
   onEject,
   disabled,
+  hideChevron = false,
   // Task pages name what they pick ("Select image model"), so the choice reads as separate from the chat model.
   placeholder = "Select model",
 }: {
@@ -211,6 +214,7 @@ function ModelSelectorTrigger({
   onEject?: () => void;
   placeholder?: string;
   disabled?: boolean;
+  hideChevron?: boolean;
 }) {
   return (
     <PopoverTrigger asChild={true}>
@@ -299,13 +303,15 @@ function ModelSelectorTrigger({
             </span>
           )}
         </span>
-        <span className="-ml-1 flex size-4 shrink-0 items-center justify-center">
-          <HugeiconsIcon
-            icon={ChevronDownStandardIcon}
-            strokeWidth={1.75}
-            className="size-3.5 text-muted-foreground"
-          />
-        </span>
+        {!hideChevron && (
+          <span className="-ml-1 flex size-4 shrink-0 items-center justify-center">
+            <HugeiconsIcon
+              icon={ChevronDownStandardIcon}
+              strokeWidth={1.75}
+              className="size-3.5 text-muted-foreground"
+            />
+          </span>
+        )}
       </button>
     </PopoverTrigger>
   );
@@ -674,6 +680,7 @@ export function ModelSelector({
   onModelsChange,
   deleteDisabled,
   disabled,
+  hideChevron,
   variant = "outline",
   size = "default",
   className,
@@ -826,6 +833,7 @@ export function ModelSelector({
         onEject={onEject ? handleEject : undefined}
         placeholder={placeholder}
         disabled={disabled}
+        hideChevron={hideChevron}
       />
       <ModelSelectorContent
         open={open}

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -160,6 +160,8 @@ interface ModelSelectorProps {
   onFoldersChange?: () => void;
   onModelsChange?: (deletedModel?: DeletedModelRef) => void;
   deleteDisabled?: boolean;
+  /** Disable the trigger button entirely (e.g. while a load is in flight). */
+  disabled?: boolean;
   variant?: "outline" | "ghost" | "muted";
   size?: "sm" | "default" | "lg";
   className?: string;
@@ -194,6 +196,7 @@ function ModelSelectorTrigger({
   triggerLabelClassName,
   dataTour,
   onEject,
+  disabled,
   // Task pages name what they pick ("Select image model"), so the choice reads as separate from the chat model.
   placeholder = "Select model",
 }: {
@@ -207,12 +210,14 @@ function ModelSelectorTrigger({
   dataTour?: string;
   onEject?: () => void;
   placeholder?: string;
+  disabled?: boolean;
 }) {
   return (
     <PopoverTrigger asChild={true}>
       <button
         type="button"
         data-tour={dataTour}
+        disabled={disabled}
         className={cn(
           "unsloth-model-selector-trigger group/trigger flex min-w-0 items-center gap-2 transition-colors",
           // Suppress the pill's hover background while the eject hit area is hovered.
@@ -668,6 +673,7 @@ export function ModelSelector({
   onFoldersChange,
   onModelsChange,
   deleteDisabled,
+  disabled,
   variant = "outline",
   size = "default",
   className,
@@ -819,6 +825,7 @@ export function ModelSelector({
         dataTour={triggerDataTour}
         onEject={onEject ? handleEject : undefined}
         placeholder={placeholder}
+        disabled={disabled}
       />
       <ModelSelectorContent
         open={open}


### PR DESCRIPTION
## Summary

Adds a `Load` action to the API monitor toolbar.

The new action:
- reuses the existing shared `ModelSelector`
- reuses the existing model loading flow
- respects model-specific saved configuration
- disables duplicate load attempts while a model is loading
- visually matches the existing API toolbar controls

## Motivation

The API page already exposes `Unload`, but loading a model currently requires navigating to another part of Studio.

This makes model lifecycle management asymmetric for API-focused workflows.

## Implementation

- Adds `Load` to the left of `Pause`
- Uses the existing `ModelSelector`
- Uses the existing `useChatModelRuntime().selectModel()` path
- Preserves config precedence used by Chat
- Adds generic `disabled` and `hideChevron` support to `ModelSelector`
- Keeps all backend/API behavior unchanged

## Testing

- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed
- Manual runtime test:
  - Load opens the model selector
  - selecting a model triggers inference load
  - Load is disabled while loading
  - loaded-model state updates
  - existing Pause / Unload / Refresh actions remain functional

## Scope

- frontend only
- no new inference endpoint
- no duplicate model picker
- no unrelated refactoring

## Screenshot

<img width="1422" height="361" alt="image" src="https://github.com/user-attachments/assets/c9c1e2c4-d4f9-4b0b-b866-6d0fe2402f0f" />
