### PR TITLE
Studio: keep the llama-server prompt cache on a shared-memory GPU

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -71,6 +71,8 @@ from core.inference.context_window import (
 )
 from core.inference.stream_errors import stream_error_from_chunk
 from core.inference.llama_server_args import (
+    _CACHE_RAM_FLAGS,
+    _CTX_CHECKPOINTS_FLAGS,
     _DEVICE_FLAGS,
     _GPU_LAYER_FLAGS,
     _LAYER_OFFLOAD_FLAGS,
@@ -17261,22 +17263,20 @@ class LlamaCppBackend:
         panel still shows. An explicit field is handled by the caller's own
         None checks, exactly as at launch.
         """
+        # Every spelling llama.cpp accepts, from the sets the arg layer already keeps:
+        # a short -cram or -ctxcp in the extras states the setting exactly as the long
+        # form does, and appending the tuning after one silently zeroes a value the
+        # user typed and the panel still shows.
         stated = {_flag_name(str(token)) for token in cmd}
         flags: list[str] = []
         if (
             cache_ram is None
             and server_caps.get("supports_cache_ram")
-            and "--cache-ram" not in stated
+            and not (_CACHE_RAM_FLAGS & stated)
         ):
             flags.extend(["--cache-ram", "0"])
         checkpoints_flag = server_caps.get("ctx_checkpoints_flag")
-        # Both aliases, since a build that accepts one may still be handed the other
-        # in the extras.
-        if (
-            ctx_checkpoints is None
-            and checkpoints_flag
-            and not ({"--ctx-checkpoints", "--swa-checkpoints"} & stated)
-        ):
+        if ctx_checkpoints is None and checkpoints_flag and not (_CTX_CHECKPOINTS_FLAGS & stated):
             flags.extend([str(checkpoints_flag), "0"])
         return flags
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17221,6 +17221,66 @@ class LlamaCppBackend:
         return discrete if 0 < len(discrete) < len(_selected) else []
 
     @staticmethod
+    def _cache_tuning_target_unknown(
+        extra_args: Optional[Iterable[str]],
+        gpu_ids: Optional[Iterable[int]],
+        env: Mapping[str, str],
+    ) -> bool:
+        """Whether the device this cache tuning would be chosen against is the one
+        the child actually gets.
+
+        A user device selection is not stripped on an automatic load and llama.cpp
+        reads it last (argv) or first (env, before argv either way), so it, not the
+        automatic placement, names the target. Both spellings count: only an explicit
+        ``gpu_ids`` clears LLAMA_ARG_DEVICE, so on an automatic load the env twin
+        survives into the child verbatim. Fail-closed by design -- the failure that
+        matters is emitting --cache-ram 0 against a shared pool, while keeping the
+        prompt cache on a discrete card only forgoes a tuning.
+        """
+        if gpu_ids is not None:
+            return False
+        return bool(
+            _extra_args_set_any_flag(extra_args, _DEVICE_FLAGS)
+            or str(env.get("LLAMA_ARG_DEVICE", "")).strip()
+        )
+
+    @staticmethod
+    def _retry_cache_tuning_flags(
+        cmd: list[str],
+        *,
+        cache_ram: Optional[int],
+        ctx_checkpoints: Optional[int],
+        server_caps: Mapping[str, Any],
+    ) -> list[str]:
+        """The cache tuning to append when an arch-crash retry lands on a discrete GPU.
+
+        The extras were appended to ``cmd`` long before the retry, so anything added
+        here wins the last-wins parse -- the reverse of the initial launch, where a
+        typed --cache-ram overrides the tuning. So a setting the command already
+        states is skipped, keeping that precedence rather than zeroing a value the
+        panel still shows. An explicit field is handled by the caller's own
+        None checks, exactly as at launch.
+        """
+        stated = {_flag_name(str(token)) for token in cmd}
+        flags: list[str] = []
+        if (
+            cache_ram is None
+            and server_caps.get("supports_cache_ram")
+            and "--cache-ram" not in stated
+        ):
+            flags.extend(["--cache-ram", "0"])
+        checkpoints_flag = server_caps.get("ctx_checkpoints_flag")
+        # Both aliases, since a build that accepts one may still be handed the other
+        # in the extras.
+        if (
+            ctx_checkpoints is None
+            and checkpoints_flag
+            and not ({"--ctx-checkpoints", "--swa-checkpoints"} & stated)
+        ):
+            flags.extend([str(checkpoints_flag), "0"])
+        return flags
+
+    @staticmethod
     def _without_flag_pairs(cmd: list[str], pairs: list[str]) -> list[str]:
         """Remove flag/value pairs THIS process appended, by exact token match.
 
@@ -22489,8 +22549,12 @@ class LlamaCppBackend:
                 # extra_args, not the memory policy's list: that one is built later,
                 # and a gpu_ids pin is exactly the case _strip_device_extra_args
                 # removes the flag in, which is the case this does not ask about.
-                _cache_target_unknown = gpu_ids is None and bool(
-                    _extra_args_set_any_flag(extra_args, _DEVICE_FLAGS)
+                # The env twin counts for the same reason the flag does: only an
+                # explicit gpu_ids clears LLAMA_ARG_DEVICE, so on an automatic load
+                # the child inherits it verbatim and llama.cpp reads it BEFORE argv,
+                # leaving a target the generated pin never names.
+                _cache_target_unknown = self._cache_tuning_target_unknown(
+                    extra_args, gpu_ids, os.environ
                 )
                 _shared_memory_offload = (
                     sys.platform == "win32"
@@ -24192,15 +24256,12 @@ class LlamaCppBackend:
                                     "survives."
                                 )
                             elif not _retry_shared and not _cache_flags_emitted:
-                                _retry_flags: list[str] = []
-                                if cache_ram is None and server_caps.get("supports_cache_ram"):
-                                    _retry_flags.extend(["--cache-ram", "0"])
-                                if ctx_checkpoints is None and server_caps.get(
-                                    "ctx_checkpoints_flag"
-                                ):
-                                    _retry_flags.extend(
-                                        [str(server_caps["ctx_checkpoints_flag"]), "0"]
-                                    )
+                                _retry_flags = self._retry_cache_tuning_flags(
+                                    cmd,
+                                    cache_ram = cache_ram,
+                                    ctx_checkpoints = ctx_checkpoints,
+                                    server_caps = server_caps,
+                                )
                                 if _retry_flags:
                                     cmd.extend(_retry_flags)
                                     _cache_flags_emitted = list(_retry_flags)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -22486,8 +22486,11 @@ class LlamaCppBackend:
                 # The exact tokens the tuning appended, so the arch-crash respawn can
                 # take them back off when it lands on a different device class.
                 _cache_flags_emitted: list[str] = []
+                # extra_args, not the memory policy's list: that one is built later,
+                # and a gpu_ids pin is exactly the case _strip_device_extra_args
+                # removes the flag in, which is the case this does not ask about.
                 _cache_target_unknown = gpu_ids is None and bool(
-                    _extra_args_set_any_flag(_mem_extras, _DEVICE_FLAGS)
+                    _extra_args_set_any_flag(extra_args, _DEVICE_FLAGS)
                 )
                 _shared_memory_offload = (
                     sys.platform == "win32"

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8807,6 +8807,42 @@ class LlamaCppBackend:
         return arch_by_id
 
     @staticmethod
+    def _offload_target_shares_system_memory(
+        *,
+        is_vulkan_backend: bool,
+        shared_gpu_ids,
+        detected_gpus,
+        gpu_indices,
+    ) -> bool:
+        """True when EVERY device this launch offloads to reports host RAM as its VRAM.
+
+        An iGPU or a unified-memory APU has no separate pool and no bus between the
+        two: a buffer llama.cpp calls "host RAM" and one it calls "VRAM" are the same
+        physical memory. Tuning that exists to avoid moving bytes across PCI-E
+        therefore buys nothing there, and any recovery path it disables is pure loss.
+
+        Fails closed. A mixed selection, an unreadable inventory or a launch that
+        pins nothing all answer False, so the caller keeps the behaviour it has.
+        The two index spaces are kept apart the way the rest of this file keeps
+        them: Vulkan ordinals against shared_gpu_ids, physical HIP/CUDA ids
+        against the unified-memory sets.
+        """
+        devices = list(gpu_indices) if gpu_indices else [idx for idx, _free in (detected_gpus or ())]
+        if not devices:
+            return False
+        if is_vulkan_backend:
+            shared = set(shared_gpu_ids or ())
+            return bool(shared) and all(idx in shared for idx in devices)
+        try:
+            unified = (
+                LlamaCppBackend._rocm_unified_memory_gpu_ids()
+                | LlamaCppBackend._integrated_cuda_gpu_ids()
+            )
+        except Exception:
+            return False
+        return bool(unified) and all(idx in unified for idx in devices)
+
+    @staticmethod
     def _amd_apu_wants_unified_memory(gpu_indices = None) -> bool:
         """True only for AMD unified-memory APUs, where GGML_CUDA_ENABLE_UNIFIED_MEMORY
         lets llama.cpp use shared system RAM (it hurts discrete GPUs). gpu_indices
@@ -22404,7 +22440,28 @@ class LlamaCppBackend:
                 # Windows + full offload: drop the host-RAM KV checkpoints that cause
                 # WDDM/PCI-E overhead, but keep prompt caching (in-VRAM prefix reuse) so
                 # a repeated prompt is not re-prefilled on every request. #5692.
-                if sys.platform == "win32" and full_offload_tuning_active:
+                # ... unless the offload target IS system RAM. #5692 is a discrete
+                # card: its host-RAM checkpoints cross PCI-E under WDDM, so dropping
+                # them is a saving. An iGPU or APU has one pool and no bus, so the
+                # same flags buy nothing and only remove the prompt cache, and with
+                # it every chance of reusing a prefix. --cache-ram 0 silently takes
+                # --cache-idle-slots down too ("requires --cache-ram, disabling").
+                # Measured cost of getting it wrong on a Strix Halo: one 48.8 h
+                # session spent 44.3 h re-ingesting prompts, 3.38 M prompt tokens
+                # against 72 k generated, on a context it re-read every turn.
+                _shared_memory_offload = self._offload_target_shares_system_memory(
+                    is_vulkan_backend = is_vulkan_backend,
+                    shared_gpu_ids = _shared_gpu_ids,
+                    detected_gpus = _detected_gpus,
+                    gpu_indices = gpu_indices,
+                )
+                if sys.platform == "win32" and full_offload_tuning_active and _shared_memory_offload:
+                    logger.info(
+                        "Keeping the llama-server prompt cache: this load offloads to a GPU "
+                        "that shares system memory, so --cache-ram 0 and --ctx-checkpoints 0 "
+                        "would remove prefix reuse without saving a transfer."
+                    )
+                elif sys.platform == "win32" and full_offload_tuning_active:
                     unsupported_cache_flags: list[str] = []
                     # An explicit control wins over the platform tuning: llama.cpp
                     # is last-wins, so a 0 emitted after it would overrule the panel

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8831,11 +8831,15 @@ class LlamaCppBackend:
         if is_vulkan_backend:
             shared = set(shared_gpu_ids or ())
             return bool(shared) and all(idx in shared for idx in devices)
+        # ROCm only, deliberately. The one caller is the Windows full-offload
+        # branch, and an integrated CUDA part (Jetson, DGX Spark, Tegra) is
+        # Linux-only, so _integrated_cuda_gpu_ids() could only ever answer False
+        # here -- at the price of a torch.cuda.get_device_properties() call, which
+        # creates a CUDA primary context in the backend process that it never gives
+        # back (~700 MiB measured, see _get_gpu_memory). _rocm_unified_memory_gpu_ids
+        # returns an empty set on a CUDA torch without touching the device.
         try:
-            unified = (
-                LlamaCppBackend._rocm_unified_memory_gpu_ids()
-                | LlamaCppBackend._integrated_cuda_gpu_ids()
-            )
+            unified = LlamaCppBackend._rocm_unified_memory_gpu_ids()
         except Exception:
             return False
         return bool(unified) and all(idx in unified for idx in devices)
@@ -22447,17 +22451,21 @@ class LlamaCppBackend:
                 # Measured cost of getting it wrong on a Strix Halo: one 48.8 h
                 # session spent 44.3 h re-ingesting prompts, 3.38 M prompt tokens
                 # against 72 k generated, on a context it re-read every turn.
-                _shared_memory_offload = self._offload_target_shares_system_memory(
-                    is_vulkan_backend = is_vulkan_backend,
-                    shared_gpu_ids = _shared_gpu_ids,
-                    detected_gpus = _detected_gpus,
-                    gpu_indices = gpu_indices,
-                )
-                if (
+                # Short-circuited behind the platform gate on purpose. The helper
+                # reads torch on the non-Vulkan path, and a Linux, macOS or
+                # partial-offload launch never reaches this block, so asking would
+                # spend a device probe to answer a question with no consumer.
+                _shared_memory_offload = (
                     sys.platform == "win32"
                     and full_offload_tuning_active
-                    and _shared_memory_offload
-                ):
+                    and self._offload_target_shares_system_memory(
+                        is_vulkan_backend = is_vulkan_backend,
+                        shared_gpu_ids = _shared_gpu_ids,
+                        detected_gpus = _detected_gpus,
+                        gpu_indices = gpu_indices,
+                    )
+                )
+                if _shared_memory_offload:
                     logger.info(
                         "Keeping the llama-server prompt cache: this load offloads to a GPU "
                         "that shares system memory, so --cache-ram 0 and --ctx-checkpoints 0 "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8808,11 +8808,7 @@ class LlamaCppBackend:
 
     @staticmethod
     def _offload_target_shares_system_memory(
-        *,
-        is_vulkan_backend: bool,
-        shared_gpu_ids,
-        detected_gpus,
-        gpu_indices,
+        *, is_vulkan_backend: bool, shared_gpu_ids, detected_gpus, gpu_indices
     ) -> bool:
         """True when EVERY device this launch offloads to reports host RAM as its VRAM.
 
@@ -8827,7 +8823,9 @@ class LlamaCppBackend:
         them: Vulkan ordinals against shared_gpu_ids, physical HIP/CUDA ids
         against the unified-memory sets.
         """
-        devices = list(gpu_indices) if gpu_indices else [idx for idx, _free in (detected_gpus or ())]
+        devices = (
+            list(gpu_indices) if gpu_indices else [idx for idx, _free in (detected_gpus or ())]
+        )
         if not devices:
             return False
         if is_vulkan_backend:
@@ -22455,7 +22453,11 @@ class LlamaCppBackend:
                     detected_gpus = _detected_gpus,
                     gpu_indices = gpu_indices,
                 )
-                if sys.platform == "win32" and full_offload_tuning_active and _shared_memory_offload:
+                if (
+                    sys.platform == "win32"
+                    and full_offload_tuning_active
+                    and _shared_memory_offload
+                ):
                     logger.info(
                         "Keeping the llama-server prompt cache: this load offloads to a GPU "
                         "that shares system memory, so --cache-ram 0 and --ctx-checkpoints 0 "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17221,6 +17221,25 @@ class LlamaCppBackend:
         return discrete if 0 < len(discrete) < len(_selected) else []
 
     @staticmethod
+    def _without_flag_pairs(cmd: list[str], pairs: list[str]) -> list[str]:
+        """Remove flag/value pairs THIS process appended, by exact token match.
+
+        Only ever called with tokens the cache tuning emitted itself, every one of them
+        a flag followed by its value, so the two-token step cannot swallow a following
+        user extra the way it would for a valueless flag (the reason the mlock path
+        refuses to strip at all). A pair that is no longer present is skipped rather
+        than searched for again, so a repeated call is a no-op.
+        """
+        out = list(cmd)
+        for index in range(0, len(pairs) - 1, 2):
+            flag, value = pairs[index], pairs[index + 1]
+            for at in range(len(out) - 1):
+                if out[at] == flag and out[at + 1] == value:
+                    del out[at : at + 2]
+                    break
+        return out
+
+    @staticmethod
     def _without_tensor_split(cmd: list[str]) -> Optional[list[str]]:
         """Return cmd with ``--tensor-split``/``-ts`` removed (both spellings and the
         ``--tensor-split=1,2`` form), or None when it carries none.
@@ -22455,17 +22474,41 @@ class LlamaCppBackend:
                 # reads torch on the non-Vulkan path, and a Linux, macOS or
                 # partial-offload launch never reaches this block, so asking would
                 # spend a device probe to answer a question with no consumer.
+                #
+                # gpu_indices is the picker's answer, not always the child's. When
+                # gpu_ids is None the picker does not own placement, so a user
+                # --device in the extras is NOT stripped and is appended after the
+                # generated pin, where llama.cpp's last-wins parsing makes it the real
+                # target. Rather than re-derive that target from argv, decline: the
+                # failure that matters is emitting --cache-ram 0 against a shared pool,
+                # and keeping the prompt cache on a discrete card only forgoes a
+                # tuning. Same direction as the helper's own fail-closed contract.
+                # The exact tokens the tuning appended, so the arch-crash respawn can
+                # take them back off when it lands on a different device class.
+                _cache_flags_emitted: list[str] = []
+                _cache_target_unknown = gpu_ids is None and bool(
+                    _extra_args_set_any_flag(_mem_extras, _DEVICE_FLAGS)
+                )
                 _shared_memory_offload = (
                     sys.platform == "win32"
                     and full_offload_tuning_active
-                    and self._offload_target_shares_system_memory(
-                        is_vulkan_backend = is_vulkan_backend,
-                        shared_gpu_ids = _shared_gpu_ids,
-                        detected_gpus = _detected_gpus,
-                        gpu_indices = gpu_indices,
+                    and (
+                        _cache_target_unknown
+                        or self._offload_target_shares_system_memory(
+                            is_vulkan_backend = is_vulkan_backend,
+                            shared_gpu_ids = _shared_gpu_ids,
+                            detected_gpus = _detected_gpus,
+                            gpu_indices = gpu_indices,
+                        )
                     )
                 )
-                if _shared_memory_offload:
+                if _cache_target_unknown and sys.platform == "win32" and full_offload_tuning_active:
+                    logger.info(
+                        "Keeping the llama-server prompt cache: a user --device in the extra "
+                        "arguments overrides the automatic placement, so the offload target "
+                        "this tuning would be chosen against is not the one the child gets."
+                    )
+                elif _shared_memory_offload:
                     logger.info(
                         "Keeping the llama-server prompt cache: this load offloads to a GPU "
                         "that shares system memory, so --cache-ram 0 and --ctx-checkpoints 0 "
@@ -22479,15 +22522,16 @@ class LlamaCppBackend:
                     if cache_ram is not None:
                         pass
                     elif server_caps.get("supports_cache_ram"):
-                        cmd.extend(["--cache-ram", "0"])
+                        _cache_flags_emitted.extend(["--cache-ram", "0"])
                     else:
                         unsupported_cache_flags.append("--cache-ram")
                     if ctx_checkpoints is not None:
                         pass
                     elif server_caps.get("ctx_checkpoints_flag"):
-                        cmd.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])
+                        _cache_flags_emitted.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])
                     else:
                         unsupported_cache_flags.append("--ctx-checkpoints")
+                    cmd.extend(_cache_flags_emitted)
                     if unsupported_cache_flags:
                         logger.info(
                             "Skipping unsupported Windows cache flags for llama-server: %s",
@@ -24118,6 +24162,49 @@ class LlamaCppBackend:
                         self._kill_process()
                         gpu_indices = _remaining
                         _unified_gpu_indices = _remaining
+                        # The Windows full-offload cache tuning was decided against the
+                        # devices that just crashed. This respawn reuses `cmd`, so a
+                        # discrete-to-APU retry would carry --cache-ram 0 onto a shared
+                        # pool -- the prefix-reprocessing regression this tuning exists
+                        # to avoid -- and the reverse retry would reach a discrete card
+                        # without it. Re-decide against the devices actually retried.
+                        if sys.platform == "win32" and full_offload_tuning_active:
+                            _retry_shared = _cache_target_unknown or (
+                                self._offload_target_shares_system_memory(
+                                    is_vulkan_backend = is_vulkan_backend,
+                                    shared_gpu_ids = _shared_gpu_ids,
+                                    detected_gpus = _retry_rows or _detected_gpus,
+                                    gpu_indices = _remaining,
+                                )
+                            )
+                            if _retry_shared and _cache_flags_emitted:
+                                # Exactly the tokens this policy appended, each a flag
+                                # with its value, so the strip cannot eat a user extra
+                                # the way a valueless flag would.
+                                cmd = self._without_flag_pairs(cmd, _cache_flags_emitted)
+                                _cache_flags_emitted = []
+                                logger.info(
+                                    "Retry lands on a GPU that shares system memory: dropped "
+                                    "--cache-ram 0 and --ctx-checkpoints 0 so the prompt cache "
+                                    "survives."
+                                )
+                            elif not _retry_shared and not _cache_flags_emitted:
+                                _retry_flags: list[str] = []
+                                if cache_ram is None and server_caps.get("supports_cache_ram"):
+                                    _retry_flags.extend(["--cache-ram", "0"])
+                                if ctx_checkpoints is None and server_caps.get(
+                                    "ctx_checkpoints_flag"
+                                ):
+                                    _retry_flags.extend(
+                                        [str(server_caps["ctx_checkpoints_flag"]), "0"]
+                                    )
+                                if _retry_flags:
+                                    cmd.extend(_retry_flags)
+                                    _cache_flags_emitted = list(_retry_flags)
+                                    logger.info(
+                                        "Retry lands on a GPU with its own memory: applied the "
+                                        "Windows full-offload cache tuning."
+                                    )
                         # GGML_CUDA_ENABLE_UNIFIED_MEMORY was decided for the CRASHED
                         # set. The canonical #7624 shape crashes on the APU and retries
                         # on the dGPU, where it is harmful, so withdraw it, but only

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8833,13 +8833,11 @@ class LlamaCppBackend:
         if is_vulkan_backend:
             shared = set(shared_gpu_ids or ())
             return bool(shared) and all(idx in shared for idx in devices)
-        # ROCm only, deliberately. The one caller is the Windows full-offload
-        # branch, and an integrated CUDA part (Jetson, DGX Spark, Tegra) is
-        # Linux-only, so _integrated_cuda_gpu_ids() could only ever answer False
-        # here -- at the price of a torch.cuda.get_device_properties() call, which
-        # creates a CUDA primary context in the backend process that it never gives
-        # back (~700 MiB measured, see _get_gpu_memory). _rocm_unified_memory_gpu_ids
-        # returns an empty set on a CUDA torch without touching the device.
+        # ROCm only, deliberately. The one caller is the Windows full-offload branch and
+        # every integrated CUDA part is Linux-only, so _integrated_cuda_gpu_ids() could
+        # only answer False here -- at the price of a get_device_properties() call, which
+        # leaks a ~700 MiB primary context (see _get_gpu_memory). The ROCm helper answers
+        # empty on a CUDA torch without touching the device.
         try:
             unified = LlamaCppBackend._rocm_unified_memory_gpu_ids()
         except Exception:
@@ -17263,10 +17261,9 @@ class LlamaCppBackend:
         panel still shows. An explicit field is handled by the caller's own
         None checks, exactly as at launch.
         """
-        # Every spelling llama.cpp accepts, from the sets the arg layer already keeps:
-        # a short -cram or -ctxcp in the extras states the setting exactly as the long
-        # form does, and appending the tuning after one silently zeroes a value the
-        # user typed and the panel still shows.
+        # Every spelling llama.cpp accepts, from the sets the arg layer already keeps: a
+        # short -cram or -ctxcp states the setting exactly as the long form does, so
+        # appending after one would zero a value the user typed and the panel shows.
         stated = {_flag_name(str(token)) for token in cmd}
         flags: list[str] = []
         if (
@@ -22521,38 +22518,29 @@ class LlamaCppBackend:
                 # Windows + full offload: drop the host-RAM KV checkpoints that cause
                 # WDDM/PCI-E overhead, but keep prompt caching (in-VRAM prefix reuse) so
                 # a repeated prompt is not re-prefilled on every request. #5692.
-                # ... unless the offload target IS system RAM. #5692 is a discrete
-                # card: its host-RAM checkpoints cross PCI-E under WDDM, so dropping
-                # them is a saving. An iGPU or APU has one pool and no bus, so the
-                # same flags buy nothing and only remove the prompt cache, and with
-                # it every chance of reusing a prefix. --cache-ram 0 silently takes
-                # --cache-idle-slots down too ("requires --cache-ram, disabling").
-                # Measured cost of getting it wrong on a Strix Halo: one 48.8 h
-                # session spent 44.3 h re-ingesting prompts, 3.38 M prompt tokens
-                # against 72 k generated, on a context it re-read every turn.
-                # Short-circuited behind the platform gate on purpose. The helper
-                # reads torch on the non-Vulkan path, and a Linux, macOS or
-                # partial-offload launch never reaches this block, so asking would
-                # spend a device probe to answer a question with no consumer.
+                # ... unless the offload target IS system RAM. #5692 is a discrete card,
+                # whose host-RAM checkpoints cross PCI-E under WDDM, so dropping them is
+                # a saving. An iGPU has one pool and no bus, so the flags only remove the
+                # prompt cache and every chance of reusing a prefix; --cache-ram 0 takes
+                # --cache-idle-slots down with it. Measured on a Strix Halo: a 48.8 h
+                # session spent 44.3 h re-ingesting, 3.38 M prompt against 72 k generated.
+                # Behind the platform gate on purpose: the helper reads torch, and a
+                # launch that never reaches this block would spend a device probe on a
+                # question with no consumer.
                 #
-                # gpu_indices is the picker's answer, not always the child's. When
-                # gpu_ids is None the picker does not own placement, so a user
-                # --device in the extras is NOT stripped and is appended after the
-                # generated pin, where llama.cpp's last-wins parsing makes it the real
-                # target. Rather than re-derive that target from argv, decline: the
-                # failure that matters is emitting --cache-ram 0 against a shared pool,
-                # and keeping the prompt cache on a discrete card only forgoes a
-                # tuning. Same direction as the helper's own fail-closed contract.
+                # gpu_indices is the picker's answer, not always the child's: with no
+                # gpu_ids a user --device survives in the extras and wins last-wins over
+                # the generated pin. Decline rather than re-derive the target from argv --
+                # the failure that matters is --cache-ram 0 against a shared pool, and
+                # keeping the prompt cache on a discrete card only forgoes a tuning.
                 # The exact tokens the tuning appended, so the arch-crash respawn can
                 # take them back off when it lands on a different device class.
                 _cache_flags_emitted: list[str] = []
-                # extra_args, not the memory policy's list: that one is built later,
-                # and a gpu_ids pin is exactly the case _strip_device_extra_args
-                # removes the flag in, which is the case this does not ask about.
-                # The env twin counts for the same reason the flag does: only an
-                # explicit gpu_ids clears LLAMA_ARG_DEVICE, so on an automatic load
-                # the child inherits it verbatim and llama.cpp reads it BEFORE argv,
-                # leaving a target the generated pin never names.
+                # extra_args, not the memory policy's list: that one is built later, and
+                # a gpu_ids pin is the case _strip_device_extra_args removes the flag in.
+                # The env twin counts too: only an explicit gpu_ids clears
+                # LLAMA_ARG_DEVICE, and llama.cpp reads it before argv, so an automatic
+                # load can place against a target the generated pin never names.
                 _cache_target_unknown = self._cache_tuning_target_unknown(
                     extra_args, gpu_ids, os.environ
                 )
@@ -24229,12 +24217,10 @@ class LlamaCppBackend:
                         self._kill_process()
                         gpu_indices = _remaining
                         _unified_gpu_indices = _remaining
-                        # The Windows full-offload cache tuning was decided against the
-                        # devices that just crashed. This respawn reuses `cmd`, so a
-                        # discrete-to-APU retry would carry --cache-ram 0 onto a shared
-                        # pool -- the prefix-reprocessing regression this tuning exists
-                        # to avoid -- and the reverse retry would reach a discrete card
-                        # without it. Re-decide against the devices actually retried.
+                        # The tuning was decided against the devices that just crashed,
+                        # and this respawn reuses `cmd`, so a discrete-to-APU retry would
+                        # carry --cache-ram 0 onto a shared pool and the reverse would
+                        # reach a discrete card without it. Re-decide against the retry.
                         if sys.platform == "win32" and full_offload_tuning_active:
                             _retry_shared = _cache_target_unknown or (
                                 self._offload_target_shares_system_memory(
@@ -24246,8 +24232,7 @@ class LlamaCppBackend:
                             )
                             if _retry_shared and _cache_flags_emitted:
                                 # Exactly the tokens this policy appended, each a flag
-                                # with its value, so the strip cannot eat a user extra
-                                # the way a valueless flag would.
+                                # with its value, so the strip cannot eat a user extra.
                                 cmd = self._without_flag_pairs(cmd, _cache_flags_emitted)
                                 _cache_flags_emitted = []
                                 logger.info(

--- a/studio/backend/tests/test_server_tuning_flags.py
+++ b/studio/backend/tests/test_server_tuning_flags.py
@@ -300,7 +300,13 @@ def test_the_checkpoint_flag_falls_back_to_the_legacy_spelling():
     # and the emission uses the recorded name, not a hard-coded one
     load = inspect.getsource(llama_cpp.LlamaCppBackend.load_model)
     assert "cmd.extend([str(_ctxcp_flag), str(int(ctx_checkpoints))])" in load
-    assert 'cmd.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])' in load
+    # The Windows tuning's 0 goes through the list the arch-crash respawn takes its
+    # own flags back off, so the sink is that list rather than cmd directly. What
+    # this pins is unchanged: the recorded name, never a hard-coded one.
+    assert (
+        '_cache_flags_emitted.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])' in load
+    )
+    assert "cmd.extend(_cache_flags_emitted)" in load
 
 
 def test_an_unsupported_draft_cache_dtype_is_dropped_not_launched():

--- a/studio/backend/tests/test_server_tuning_flags.py
+++ b/studio/backend/tests/test_server_tuning_flags.py
@@ -303,9 +303,7 @@ def test_the_checkpoint_flag_falls_back_to_the_legacy_spelling():
     # The Windows tuning's 0 goes through the list the arch-crash respawn takes its
     # own flags back off, so the sink is that list rather than cmd directly. What
     # this pins is unchanged: the recorded name, never a hard-coded one.
-    assert (
-        '_cache_flags_emitted.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])' in load
-    )
+    assert '_cache_flags_emitted.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])' in load
     assert "cmd.extend(_cache_flags_emitted)" in load
 
 

--- a/studio/backend/tests/test_server_tuning_flags.py
+++ b/studio/backend/tests/test_server_tuning_flags.py
@@ -300,9 +300,8 @@ def test_the_checkpoint_flag_falls_back_to_the_legacy_spelling():
     # and the emission uses the recorded name, not a hard-coded one
     load = inspect.getsource(llama_cpp.LlamaCppBackend.load_model)
     assert "cmd.extend([str(_ctxcp_flag), str(int(ctx_checkpoints))])" in load
-    # The Windows tuning's 0 goes through the list the arch-crash respawn takes its
-    # own flags back off, so the sink is that list rather than cmd directly. What
-    # this pins is unchanged: the recorded name, never a hard-coded one.
+    # The Windows tuning's 0 goes through the list the arch-crash respawn takes its own
+    # flags back off, so the sink is that list rather than cmd. What it pins is unchanged.
     assert '_cache_flags_emitted.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])' in load
     assert "cmd.extend(_cache_flags_emitted)" in load
 

--- a/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
+++ b/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
@@ -297,6 +297,32 @@ def test_the_retry_does_not_overrule_a_cache_flag_the_command_already_states():
     )
 
 
+def test_the_retry_reads_the_short_spellings_as_the_same_settings():
+    # -cram and -ctxcp are aliases llama.cpp accepts and the extras panel offers, so a
+    # command that states one has stated the setting; appending the long form after it
+    # would silently zero the user's value.
+    assert LlamaCppBackend._retry_cache_tuning_flags(
+        ["llama-server", "-cram", "8192", "-ctxcp", "4"],
+        cache_ram = None,
+        ctx_checkpoints = None,
+        server_caps = _CAPS,
+    ) == []
+
+    # One at a time, so a single alias cannot stand in for the pair.
+    assert LlamaCppBackend._retry_cache_tuning_flags(
+        ["llama-server", "-cram", "8192"],
+        cache_ram = None,
+        ctx_checkpoints = None,
+        server_caps = _CAPS,
+    ) == ["--ctx-checkpoints", "0"]
+    assert LlamaCppBackend._retry_cache_tuning_flags(
+        ["llama-server", "-ctxcp=4"],
+        cache_ram = None,
+        ctx_checkpoints = None,
+        server_caps = _CAPS,
+    ) == ["--cache-ram", "0"]
+
+
 def test_the_retry_reads_the_other_checkpoint_alias_as_the_same_setting():
     # A build advertising --ctx-checkpoints can still be handed --swa-checkpoints.
     assert LlamaCppBackend._retry_cache_tuning_flags(

--- a/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
+++ b/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
@@ -239,9 +239,7 @@ def test_a_trailing_flag_without_its_value_is_left_alone():
 
 
 def test_a_user_device_flag_makes_the_target_unknown():
-    assert LlamaCppBackend._cache_tuning_target_unknown(
-        ["--device", "ROCm1"], None, {}
-    )
+    assert LlamaCppBackend._cache_tuning_target_unknown(["--device", "ROCm1"], None, {})
 
 
 def test_an_inherited_device_env_makes_the_target_unknown():
@@ -249,13 +247,9 @@ def test_an_inherited_device_env_makes_the_target_unknown():
     # clears it -- and llama.cpp reads it before argv, so the generated pin is not
     # what the child places against. Reading argv alone emitted --cache-ram 0 at an
     # APU the picker had paired with a discrete card.
-    assert LlamaCppBackend._cache_tuning_target_unknown(
-        None, None, {"LLAMA_ARG_DEVICE": "ROCm0"}
-    )
+    assert LlamaCppBackend._cache_tuning_target_unknown(None, None, {"LLAMA_ARG_DEVICE": "ROCm0"})
     # Set but empty is not a selection.
-    assert not LlamaCppBackend._cache_tuning_target_unknown(
-        None, None, {"LLAMA_ARG_DEVICE": "  "}
-    )
+    assert not LlamaCppBackend._cache_tuning_target_unknown(None, None, {"LLAMA_ARG_DEVICE": "  "})
 
 
 def test_an_explicit_pin_owns_the_placement_so_the_target_is_known():
@@ -292,12 +286,15 @@ def test_the_retry_does_not_overrule_a_cache_flag_the_command_already_states():
     assert flags == ["--ctx-checkpoints", "0"]
 
     # The attached spelling is the same setting.
-    assert LlamaCppBackend._retry_cache_tuning_flags(
-        ["llama-server", "--cache-ram=8192", "--ctx-checkpoints=4"],
-        cache_ram = None,
-        ctx_checkpoints = None,
-        server_caps = _CAPS,
-    ) == []
+    assert (
+        LlamaCppBackend._retry_cache_tuning_flags(
+            ["llama-server", "--cache-ram=8192", "--ctx-checkpoints=4"],
+            cache_ram = None,
+            ctx_checkpoints = None,
+            server_caps = _CAPS,
+        )
+        == []
+    )
 
 
 def test_the_retry_reads_the_other_checkpoint_alias_as_the_same_setting():
@@ -312,12 +309,18 @@ def test_the_retry_reads_the_other_checkpoint_alias_as_the_same_setting():
 
 def test_the_retry_skips_what_the_build_and_the_fields_already_own():
     # An explicit field, as at launch, and a build without the capability.
-    assert LlamaCppBackend._retry_cache_tuning_flags(
-        ["llama-server"], cache_ram = 4096, ctx_checkpoints = 8, server_caps = _CAPS
-    ) == []
-    assert LlamaCppBackend._retry_cache_tuning_flags(
-        ["llama-server"],
-        cache_ram = None,
-        ctx_checkpoints = None,
-        server_caps = {"supports_cache_ram": False, "ctx_checkpoints_flag": None},
-    ) == []
+    assert (
+        LlamaCppBackend._retry_cache_tuning_flags(
+            ["llama-server"], cache_ram = 4096, ctx_checkpoints = 8, server_caps = _CAPS
+        )
+        == []
+    )
+    assert (
+        LlamaCppBackend._retry_cache_tuning_flags(
+            ["llama-server"],
+            cache_ram = None,
+            ctx_checkpoints = None,
+            server_caps = {"supports_cache_ram": False, "ctx_checkpoints_flag": None},
+        )
+        == []
+    )

--- a/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
+++ b/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Windows full-offload tuning (#5692) drops the llama-server prompt cache to avoid
+WDDM/PCI-E traffic. An iGPU or APU has one memory pool and no bus, so the same flags
+save nothing and remove prefix reuse instead.
+
+Measured on a Strix Halo running the Vulkan build with -ngl -1: one 48.8 h session
+spent 44.3 h re-ingesting prompts, 3.38 M prompt tokens against 72 k generated, with
+`--cache-ram 0 --ctx-checkpoints 0` in its own argv and
+`--cache-idle-slots requires --cache-ram, disabling` in llama-server's first lines.
+
+The predicate fails closed everywhere it cannot prove the whole target is shared, so
+a discrete card keeps the tuning it was written for.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from core.inference.llama_cpp import LlamaCppBackend
+
+_VISIBLE_DEVICE_MASKS = ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
+
+
+@pytest.fixture(autouse = True)
+def _no_inherited_gpu_mask(monkeypatch):
+    """The ROCm arm asks about physical ids on a faked torch host. A mask inherited
+    from the shell remaps them onto ids the fake host does not have."""
+    for _mask in _VISIBLE_DEVICE_MASKS:
+        monkeypatch.delenv(_mask, raising = False)
+
+
+def _shares(**kwargs) -> bool:
+    return LlamaCppBackend._offload_target_shares_system_memory(**kwargs)
+
+
+def _vulkan(shared_gpu_ids, detected, gpu_indices = None) -> bool:
+    return _shares(
+        is_vulkan_backend = True,
+        shared_gpu_ids = shared_gpu_ids,
+        detected_gpus = detected,
+        gpu_indices = gpu_indices,
+    )
+
+
+def _fake_torch(archs, *, hip = "6.4.0"):
+    torch = types.ModuleType("torch")
+    torch.version = types.SimpleNamespace(hip = hip)
+    torch.cuda = types.SimpleNamespace(
+        is_available = lambda: True,
+        device_count = lambda: len(archs),
+        get_device_properties = lambda i: types.SimpleNamespace(gcnArchName = archs[i]),
+    )
+    return torch
+
+
+# ── Vulkan, where the shared set is ggml's compact ordinals ──
+
+
+def test_an_igpu_only_target_shares_system_memory():
+    assert _vulkan({0}, [(0, 170079)], gpu_indices = [0]) is True
+
+
+def test_an_unpinned_load_reads_the_detected_list():
+    """The auto-Vulkan arm pins nothing at this point, which is the shape the
+    Strix Halo session ran in."""
+    assert _vulkan({0}, [(0, 170079)]) is True
+
+
+def test_a_discrete_card_beside_the_igpu_keeps_the_tuning():
+    assert _vulkan({0}, [(0, 170079), (1, 24000)], gpu_indices = [0, 1]) is False
+    assert _vulkan({0}, [(0, 170079), (1, 24000)]) is False
+
+
+def test_pinning_only_the_igpu_of_a_mixed_host_still_shares():
+    assert _vulkan({0}, [(0, 170079), (1, 24000)], gpu_indices = [0]) is True
+
+
+def test_a_discrete_only_host_keeps_the_tuning():
+    assert _vulkan(set(), [(0, 24000)], gpu_indices = [0]) is False
+
+
+def test_a_load_with_no_device_at_all_fails_closed():
+    assert _vulkan({0}, []) is False
+    assert _vulkan(set(), []) is False
+
+
+# ── ROCm and CUDA, where the ids are physical ──
+
+
+def test_an_amd_apu_shares_system_memory(monkeypatch):
+    monkeypatch.setitem(__import__("sys").modules, "torch", _fake_torch(["gfx1151"]))
+    assert (
+        _shares(
+            is_vulkan_backend = False,
+            shared_gpu_ids = set(),
+            detected_gpus = [(0, 60000)],
+            gpu_indices = [0],
+        )
+        is True
+    )
+
+
+def test_a_discrete_amd_card_keeps_the_tuning(monkeypatch):
+    monkeypatch.setitem(__import__("sys").modules, "torch", _fake_torch(["gfx1100"]))
+    assert (
+        _shares(
+            is_vulkan_backend = False,
+            shared_gpu_ids = set(),
+            detected_gpus = [(0, 24000)],
+            gpu_indices = [0],
+        )
+        is False
+    )
+
+
+def test_an_apu_next_to_a_discrete_card_keeps_the_tuning(monkeypatch):
+    monkeypatch.setitem(
+        __import__("sys").modules, "torch", _fake_torch(["gfx1151", "gfx1100"])
+    )
+    assert (
+        _shares(
+            is_vulkan_backend = False,
+            shared_gpu_ids = set(),
+            detected_gpus = [(0, 60000), (1, 24000)],
+            gpu_indices = [0, 1],
+        )
+        is False
+    )
+
+
+def test_an_unreadable_inventory_fails_closed(monkeypatch):
+    """No torch, so neither unified-memory set can be built. The tuning stays as it
+    is rather than being dropped on a guess."""
+    monkeypatch.setitem(__import__("sys").modules, "torch", None)
+    assert (
+        _shares(
+            is_vulkan_backend = False,
+            shared_gpu_ids = set(),
+            detected_gpus = [(0, 60000)],
+            gpu_indices = [0],
+        )
+        is False
+    )
+
+
+def test_the_vulkan_shared_set_is_not_read_as_physical_ids(monkeypatch):
+    """Vulkan ordinals and HIP ids are different spaces. A ROCm launch must not
+    inherit a shared set that was built from Vulkan's numbering."""
+    monkeypatch.setitem(__import__("sys").modules, "torch", _fake_torch(["gfx1100"]))
+    assert (
+        _shares(
+            is_vulkan_backend = False,
+            shared_gpu_ids = {0},
+            detected_gpus = [(0, 24000)],
+            gpu_indices = [0],
+        )
+        is False
+    )

--- a/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
+++ b/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
@@ -37,7 +37,11 @@ def _shares(**kwargs) -> bool:
     return LlamaCppBackend._offload_target_shares_system_memory(**kwargs)
 
 
-def _vulkan(shared_gpu_ids, detected, gpu_indices = None) -> bool:
+def _vulkan(
+    shared_gpu_ids,
+    detected,
+    gpu_indices = None,
+) -> bool:
     return _shares(
         is_vulkan_backend = True,
         shared_gpu_ids = shared_gpu_ids,
@@ -118,9 +122,7 @@ def test_a_discrete_amd_card_keeps_the_tuning(monkeypatch):
 
 
 def test_an_apu_next_to_a_discrete_card_keeps_the_tuning(monkeypatch):
-    monkeypatch.setitem(
-        __import__("sys").modules, "torch", _fake_torch(["gfx1151", "gfx1100"])
-    )
+    monkeypatch.setitem(__import__("sys").modules, "torch", _fake_torch(["gfx1151", "gfx1100"]))
     assert (
         _shares(
             is_vulkan_backend = False,

--- a/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
+++ b/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
@@ -199,3 +199,37 @@ def test_a_cuda_host_is_answered_without_touching_the_device(monkeypatch):
         )
         is False
     )
+
+
+# ── _without_flag_pairs: the strip the arch-crash respawn uses ──
+
+
+def test_only_the_pairs_this_policy_emitted_are_stripped():
+    """The respawn reuses the argv it already built, so taking the tuning back off has
+    to be an exact-token removal. Every pair is a flag with its value, which is what
+    makes the two-token step safe: a valueless flag would swallow the user extra that
+    follows it, which is why the mlock path refuses to strip at all."""
+    cmd = [
+        "llama-server",
+        "--cache-ram",
+        "0",
+        "--ctx-checkpoints",
+        "0",
+        "--cache-ram",
+        "4096",
+        "--verbose",
+    ]
+    out = LlamaCppBackend._without_flag_pairs(cmd, ["--cache-ram", "0", "--ctx-checkpoints", "0"])
+    # The user's own --cache-ram 4096 survives; only the emitted zeros go.
+    assert out == ["llama-server", "--cache-ram", "4096", "--verbose"]
+
+
+def test_stripping_a_pair_that_is_gone_is_a_no_op():
+    cmd = ["llama-server", "--verbose"]
+    assert LlamaCppBackend._without_flag_pairs(cmd, ["--cache-ram", "0"]) == cmd
+
+
+def test_a_trailing_flag_without_its_value_is_left_alone():
+    # Defensive: an odd-length pair list would otherwise index past the end.
+    cmd = ["llama-server", "--cache-ram"]
+    assert LlamaCppBackend._without_flag_pairs(cmd, ["--cache-ram"]) == cmd

--- a/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
+++ b/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
@@ -162,3 +162,40 @@ def test_the_vulkan_shared_set_is_not_read_as_physical_ids(monkeypatch):
         )
         is False
     )
+
+
+def test_a_cuda_host_is_answered_without_touching_the_device(monkeypatch):
+    """The predicate must not create a CUDA primary context to answer.
+
+    ``torch.cuda.get_device_properties`` initialises CUDA in the backend process
+    and never gives the memory back (~700 MiB), which is VRAM the child
+    llama-server then cannot use. On a CUDA host the answer is False either way,
+    so it has to come from ``torch.version.hip`` alone. The fake raises on any
+    device probe, so a reintroduced ``_integrated_cuda_gpu_ids()`` call fails
+    this test rather than merely costing memory in production."""
+
+    class _DeviceProbed(BaseException):
+        """BaseException on purpose: every helper in this family swallows
+        ``Exception`` per device, so an ordinary error would be caught and the
+        test would pass against the very code it exists to catch."""
+
+    def _explode(_ordinal):
+        raise _DeviceProbed("probed the CUDA device to answer a Windows-only question")
+
+    torch = types.ModuleType("torch")
+    torch.version = types.SimpleNamespace(hip = None)
+    torch.cuda = types.SimpleNamespace(
+        is_available = lambda: True,
+        device_count = lambda: 1,
+        get_device_properties = _explode,
+    )
+    monkeypatch.setitem(__import__("sys").modules, "torch", torch)
+    assert (
+        _shares(
+            is_vulkan_backend = False,
+            shared_gpu_ids = set(),
+            detected_gpus = [(0, 24000)],
+            gpu_indices = [0],
+        )
+        is False
+    )

--- a/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
+++ b/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
@@ -233,3 +233,91 @@ def test_a_trailing_flag_without_its_value_is_left_alone():
     # Defensive: an odd-length pair list would otherwise index past the end.
     cmd = ["llama-server", "--cache-ram"]
     assert LlamaCppBackend._without_flag_pairs(cmd, ["--cache-ram"]) == cmd
+
+
+# ── the target the tuning is chosen against ──
+
+
+def test_a_user_device_flag_makes_the_target_unknown():
+    assert LlamaCppBackend._cache_tuning_target_unknown(
+        ["--device", "ROCm1"], None, {}
+    )
+
+
+def test_an_inherited_device_env_makes_the_target_unknown():
+    # The env twin survives an automatic load verbatim -- only an explicit gpu_ids
+    # clears it -- and llama.cpp reads it before argv, so the generated pin is not
+    # what the child places against. Reading argv alone emitted --cache-ram 0 at an
+    # APU the picker had paired with a discrete card.
+    assert LlamaCppBackend._cache_tuning_target_unknown(
+        None, None, {"LLAMA_ARG_DEVICE": "ROCm0"}
+    )
+    # Set but empty is not a selection.
+    assert not LlamaCppBackend._cache_tuning_target_unknown(
+        None, None, {"LLAMA_ARG_DEVICE": "  "}
+    )
+
+
+def test_an_explicit_pin_owns_the_placement_so_the_target_is_known():
+    # The control: gpu_ids clears both spellings, so neither can name another device.
+    assert not LlamaCppBackend._cache_tuning_target_unknown(
+        ["--device", "ROCm1"], [0], {"LLAMA_ARG_DEVICE": "ROCm0"}
+    )
+    assert not LlamaCppBackend._cache_tuning_target_unknown(None, None, {})
+
+
+# ── the arch-crash retry keeps the launch's precedence ──
+
+_CAPS = {"supports_cache_ram": True, "ctx_checkpoints_flag": "--ctx-checkpoints"}
+
+
+def test_the_retry_applies_the_tuning_when_nothing_states_it():
+    assert LlamaCppBackend._retry_cache_tuning_flags(
+        ["llama-server", "-m", "x.gguf"],
+        cache_ram = None,
+        ctx_checkpoints = None,
+        server_caps = _CAPS,
+    ) == ["--cache-ram", "0", "--ctx-checkpoints", "0"]
+
+
+def test_the_retry_does_not_overrule_a_cache_flag_the_command_already_states():
+    # The extras sit in cmd already, so appending here wins last-wins and would zero a
+    # value the panel still shows -- the reverse of the launch, where extras win.
+    flags = LlamaCppBackend._retry_cache_tuning_flags(
+        ["llama-server", "-m", "x.gguf", "--cache-ram", "8192"],
+        cache_ram = None,
+        ctx_checkpoints = None,
+        server_caps = _CAPS,
+    )
+    assert flags == ["--ctx-checkpoints", "0"]
+
+    # The attached spelling is the same setting.
+    assert LlamaCppBackend._retry_cache_tuning_flags(
+        ["llama-server", "--cache-ram=8192", "--ctx-checkpoints=4"],
+        cache_ram = None,
+        ctx_checkpoints = None,
+        server_caps = _CAPS,
+    ) == []
+
+
+def test_the_retry_reads_the_other_checkpoint_alias_as_the_same_setting():
+    # A build advertising --ctx-checkpoints can still be handed --swa-checkpoints.
+    assert LlamaCppBackend._retry_cache_tuning_flags(
+        ["llama-server", "--swa-checkpoints", "4"],
+        cache_ram = None,
+        ctx_checkpoints = None,
+        server_caps = _CAPS,
+    ) == ["--cache-ram", "0"]
+
+
+def test_the_retry_skips_what_the_build_and_the_fields_already_own():
+    # An explicit field, as at launch, and a build without the capability.
+    assert LlamaCppBackend._retry_cache_tuning_flags(
+        ["llama-server"], cache_ram = 4096, ctx_checkpoints = 8, server_caps = _CAPS
+    ) == []
+    assert LlamaCppBackend._retry_cache_tuning_flags(
+        ["llama-server"],
+        cache_ram = None,
+        ctx_checkpoints = None,
+        server_caps = {"supports_cache_ram": False, "ctx_checkpoints_flag": None},
+    ) == []

--- a/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
+++ b/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
@@ -301,12 +301,15 @@ def test_the_retry_reads_the_short_spellings_as_the_same_settings():
     # -cram and -ctxcp are aliases llama.cpp accepts and the extras panel offers, so a
     # command that states one has stated the setting; appending the long form after it
     # would silently zero the user's value.
-    assert LlamaCppBackend._retry_cache_tuning_flags(
-        ["llama-server", "-cram", "8192", "-ctxcp", "4"],
-        cache_ram = None,
-        ctx_checkpoints = None,
-        server_caps = _CAPS,
-    ) == []
+    assert (
+        LlamaCppBackend._retry_cache_tuning_flags(
+            ["llama-server", "-cram", "8192", "-ctxcp", "4"],
+            cache_ram = None,
+            ctx_checkpoints = None,
+            server_caps = _CAPS,
+        )
+        == []
+    )
 
     # One at a time, so a single alias cannot stand in for the pair.
     assert LlamaCppBackend._retry_cache_tuning_flags(

--- a/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
+++ b/studio/backend/tests/test_shared_memory_offload_keeps_the_prompt_cache.py
@@ -243,12 +243,10 @@ def test_a_user_device_flag_makes_the_target_unknown():
 
 
 def test_an_inherited_device_env_makes_the_target_unknown():
-    # The env twin survives an automatic load verbatim -- only an explicit gpu_ids
-    # clears it -- and llama.cpp reads it before argv, so the generated pin is not
-    # what the child places against. Reading argv alone emitted --cache-ram 0 at an
-    # APU the picker had paired with a discrete card.
+    # Only an explicit gpu_ids clears the env twin, and llama.cpp reads it before argv, so
+    # the generated pin is not what the child places against. Reading argv alone emitted
+    # --cache-ram 0 at an APU the picker had paired with a discrete card.
     assert LlamaCppBackend._cache_tuning_target_unknown(None, None, {"LLAMA_ARG_DEVICE": "ROCm0"})
-    # Set but empty is not a selection.
     assert not LlamaCppBackend._cache_tuning_target_unknown(None, None, {"LLAMA_ARG_DEVICE": "  "})
 
 
@@ -275,8 +273,8 @@ def test_the_retry_applies_the_tuning_when_nothing_states_it():
 
 
 def test_the_retry_does_not_overrule_a_cache_flag_the_command_already_states():
-    # The extras sit in cmd already, so appending here wins last-wins and would zero a
-    # value the panel still shows -- the reverse of the launch, where extras win.
+    # The extras sit in cmd already, so appending here wins last-wins and zeroes a value
+    # the panel still shows -- the reverse of the launch, where the extras win.
     flags = LlamaCppBackend._retry_cache_tuning_flags(
         ["llama-server", "-m", "x.gguf", "--cache-ram", "8192"],
         cache_ram = None,
@@ -285,7 +283,6 @@ def test_the_retry_does_not_overrule_a_cache_flag_the_command_already_states():
     )
     assert flags == ["--ctx-checkpoints", "0"]
 
-    # The attached spelling is the same setting.
     assert (
         LlamaCppBackend._retry_cache_tuning_flags(
             ["llama-server", "--cache-ram=8192", "--ctx-checkpoints=4"],
@@ -298,9 +295,8 @@ def test_the_retry_does_not_overrule_a_cache_flag_the_command_already_states():
 
 
 def test_the_retry_reads_the_short_spellings_as_the_same_settings():
-    # -cram and -ctxcp are aliases llama.cpp accepts and the extras panel offers, so a
-    # command that states one has stated the setting; appending the long form after it
-    # would silently zero the user's value.
+    # -cram and -ctxcp are aliases llama.cpp accepts and the panel offers, so appending
+    # the long form after one would silently zero the user's value.
     assert (
         LlamaCppBackend._retry_cache_tuning_flags(
             ["llama-server", "-cram", "8192", "-ctxcp", "4"],


### PR DESCRIPTION
Studio's Windows full-offload tuning turns off the llama-server prompt cache. On a discrete card that is the trade #5692 intended. On an integrated GPU it is a pure loss, and it cost one user 44 hours.

## What happened

From a Strix Halo log bundle, one 48.8 hour session:

| | |
|---|---|
| prompt tokens processed | **3,376,080 in 159,393 s (44.3 h)** |
| generated tokens | 72,041 in 14,784 s |
| share of measured compute spent on prompt processing | **91.5%** |
| reprocessed context, turn by turn | 18k, 20k, 41k, 81k, 90k, 98k, 110k, 125k, 144k, 156k, 167k, 175k, 183k tokens |
| worst single turn | **4.3 hours for one user message** (183,295 tokens at 11.83 t/s) |

Consecutive lines from the same slot, one turn apart:

```
release: id  2 | task 17496 | stop processing: n_tokens = 89586
get_availabl: id  2 | task -1 | selected slot by LCP similarity, f_sim_best = 0.996, f_keep = 1.000
task 17616 | prompt eval time = 3183539.68 ms / 89920 tokens (35.40 ms per token, 28.25 t/s)
```

53 minutes to re-ingest a context the server had just reported keeping. This is not a wedge and not a hang: it is real, repeated, avoidable work.

The argv Studio composed for that run:

```
llama-server.exe -m ...UD-Q4_K_XL-00001-of-00004.gguf --parallel 4 --flash-attn on
  --no-context-shift -c 262144 -ngl -1 --fit off --metrics
  --slot-save-path ... --kv-unified --threads 2 --jinja --spec-default
  --cache-ram 0 --ctx-checkpoints 0 --device Vulkan0
```

`--cache-ram 0 --ctx-checkpoints 0` is ours, from the `sys.platform == "win32" and full_offload_tuning_active` block. `-ngl -1` makes `fully_gpu_offloaded` true, so the tuning fires. llama-server's own first lines then record the third feature it takes down:

```
W srv init: --cache-idle-slots requires --cache-ram, disabling
```

## Why the tuning does not apply here

#5692 is about WDDM: host-RAM KV checkpoints on a discrete card cross PCI-E, so dropping them is a saving. The device in that argv is `Vulkan0` on a Radeon 8060S, an integrated GPU whose VRAM is system RAM. There is one pool and no bus. The flags save nothing and remove every chance of reusing a prefix.

The same reasoning is already in this file for the Apple case: "Unified memory: the 'VRAM' is host RAM, so the weights stay pageable however fully they are offloaded."

## The change

`_offload_target_shares_system_memory` answers whether **every** device this launch offloads to reports host RAM as its VRAM, and the Windows tuning is skipped when it does.

It keeps the two index spaces apart the way the rest of the file does, because they are not interchangeable: Vulkan ordinals are matched against `shared_gpu_ids` (which the probe fills only for integrated devices, on the Vulkan path only), and physical HIP and CUDA ids against the unified-memory sets.

It fails closed. A mixed selection, an unreadable inventory, or a launch that pins nothing all answer False and keep today's behaviour, so a discrete card is untouched. When it does answer True the load logs one line saying why the tuning was skipped.

The OMP half of the same block (`OMP_WAIT_POLICY=PASSIVE`, `OMP_NUM_THREADS=2`) is deliberately left alone: it is about spin-wait CPU burn, not bus traffic, and nothing here measures it.

## Testing

11 new cases in `test_shared_memory_offload_keeps_the_prompt_cache.py`, covering both index spaces and every way the predicate should decline: an iGPU-only target pinned and unpinned, a discrete card beside the iGPU, pinning only the iGPU of a mixed host, a discrete-only host, no device at all, an AMD APU, a discrete AMD card, an APU next to a discrete card, an unreadable inventory, and a Vulkan shared set offered to a ROCm launch (which must not be read as physical ids).

2341 pass and 32 skip across the nine suites around the change (`test_shared_memory_offload_keeps_the_prompt_cache`, `test_idle_slot_clearing_is_known`, `test_server_tuning_flags`, `test_amd_apu_unified_memory`, `test_llama_server_args`, `test_load_mode_fit_matrix`, `test_slot_refit_ctx_checkpoints`, `test_offload_planner_seam`, `test_llama_cpp_placement`). One failure, `test_oversubscribed_decode_threads_decline_spill_planning`, is host-only and pre-existing: it fails the same way on a clean checkout of main in a second worktree.

What the tests do not cover, stated plainly: the predicate is unit tested, but the argv it gates is not, because there is no launch-level harness to assert `--cache-ram` in the composed command. The composition is a single boolean at the call site.

## Not fixed here

The same bundle shows two other contributors to that 44 hours, both left for their own change:

- A slot state larger than llama.cpp's default 8192 MiB `--cache-ram` is silently skipped (`prompt state size 9206.065 MiB exceeds cache size limit 8192.000 MiB, skipping`). Studio passes `--slot-save-path` on every launch and never raises the limit to match the context it requests.
- `--parallel 4 --kv-unified -c 262144` advertises the whole pool to each of four slots, which then evict each other (`purging slot 2 with 183269 tokens`).
