### PR TITLE
Studio: four load and update messages that told the user the wrong thing

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12654,12 +12654,18 @@ class LlamaCppBackend:
                 return True
             return False
 
-        # Two perturbations per axis: cell counts are padded, so a single step can
-        # land inside the same bucket on a dimension the number does follow. The
-        # second slot candidate is kept distinct from the first at n_parallel 1,
-        # where doubling is also +1 and the pair would probe one point.
+        # Several perturbations per axis: cell counts are padded, so nearby steps can
+        # all land inside the same bucket on a dimension the number does follow. Cells
+        # are padded per stream, so every slot count that divides the padded total
+        # reproduces it exactly -- at 12288 cells, 2, 3 and 4 slots all price the same
+        # and only 5 moves. The last candidate is larger than the padded cell count
+        # itself, which therefore cannot divide it, so it escapes every such plateau.
+        _cells = _pad_kv_cells(max(1, n_ctx)) // 256
         slots_named = _moves(
-            (n_parallel + 1, ubatch), (max(n_parallel + 2, n_parallel * 2), ubatch)
+            (n_parallel + 1, ubatch),
+            (n_parallel + 2, ubatch),
+            (max(n_parallel + 3, n_parallel * 2), ubatch),
+            (max(n_parallel + 3, _cells + 1), ubatch),
         )
         ubatch_named = _moves((n_parallel, ubatch * 2), (n_parallel, max(1, ubatch // 2)))
         scales_with_n_max = bool(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16319,10 +16319,17 @@ class LlamaCppBackend:
                     "different model, or use this model directly through "
                     "Ollama instead."
                 )
+            # Not "cannot be run": the branches above name architectures Studio
+            # knows llama-server will never run, and this one is everything else,
+            # which includes an architecture the INSTALLED build simply predates.
+            # Seen in the field on qwen4exp: four refusals with this wording, then
+            # the identical file at the identical path loaded and ran for six days
+            # after a llama.cpp update. Between the two the user reinstalled four
+            # times, because nothing here pointed at the build.
             return (
-                f"llama.cpp does not support this GGUF's model architecture "
-                f"('{arch}'). The file is valid, but this model type cannot "
-                "be run with llama-server."
+                f"The installed llama.cpp does not recognise this GGUF's model "
+                f"architecture ('{arch}'). The file is valid. If the model is newer "
+                "than this llama.cpp build, updating llama.cpp may add support for it."
             )
 
         # Other Ollama compat failures that don't name an arch. Only when
@@ -21147,9 +21154,14 @@ class LlamaCppBackend:
                         else 0
                     )
                     if _mtp_will_engage:
+                        # Name what the reserve is actually a function of. It was
+                        # printed with n_max, which _mtp_bytes does not take, so the
+                        # line read byte-identical across a 4x change in n_max and
+                        # invited the reader to conclude the reserve had scaled.
                         _mtp_note = (
                             f"MTP reserve: {_mtp_reserve_bytes / (1024**3):.2f} GB "
-                            f"(draft KV @ {effective_ctx} + verify n_max={_mtp_eff_n_max}"
+                            f"(draft KV @ {effective_ctx} x {n_parallel or 1} slots, "
+                            f"ubatch {_effective_ubatch}"
                             + (", flat-frac fallback" if mtp_overhead_fn is None else "")
                             + "), "
                         )
@@ -25726,6 +25738,10 @@ class LlamaCppBackend:
             self._unload_epoch += 1
             self._kill_process()
             self._cleanup_cpu_fallback_runtime()
+            # The one unload line. routes/inference.py used to log its own, from the
+            # request path, so every unload appeared twice 1-3 ms apart under two
+            # different names (a repo id here, a snapshot path there) and "how many
+            # times did this model reload" could not be answered by grep.
             logger.info(f"Unloaded GGUF model: {self._model_identifier}")
             self._model_identifier = None
             self._gguf_path = None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12655,8 +12655,12 @@ class LlamaCppBackend:
             return False
 
         # Two perturbations per axis: cell counts are padded, so a single step can
-        # land inside the same bucket on a dimension the number does follow.
-        slots_named = _moves((n_parallel + 1, ubatch), (max(1, n_parallel * 2), ubatch))
+        # land inside the same bucket on a dimension the number does follow. The
+        # second slot candidate is kept distinct from the first at n_parallel 1,
+        # where doubling is also +1 and the pair would probe one point.
+        slots_named = _moves(
+            (n_parallel + 1, ubatch), (max(n_parallel + 2, n_parallel * 2), ubatch)
+        )
         ubatch_named = _moves((n_parallel, ubatch * 2), (n_parallel, max(1, ubatch // 2)))
         scales_with_n_max = bool(
             target_rollback and n_max and self._rollback_state_bytes(n_parallel) > 0

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12602,6 +12602,42 @@ class LlamaCppBackend:
             return total if total > 0 else None
         return draft_kv + weights + target_ctx_copy + target_recurrent_copies
 
+    def _mtp_reserve_note(
+        self,
+        reserve_bytes: int,
+        *,
+        n_ctx: int,
+        n_parallel: int,
+        n_ubatch: Optional[int],
+        n_max: Optional[int],
+        target_rollback: bool,
+        flat_fallback: bool,
+    ) -> str:
+        """The MTP reserve line, naming what that number is a function of.
+
+        n_max is named only where it moves the number. The line used to carry it
+        unconditionally, and on every model whose recurrent state is nil it then
+        read byte-identical across a 4x change in n_max, inviting the reader to
+        conclude the reserve had scaled. On a Hybrid Mamba target it does scale --
+        verification allocates one rollback copy per drafted token -- so there it
+        is named.
+
+        A None micro-batch is llama.cpp's own default, which is both what the
+        reserve was computed with and what the child runs at, so it is rendered
+        rather than printed as None: "ubatch None" names no parameter.
+        """
+        scales_with_n_max = bool(
+            target_rollback and n_max and self._rollback_state_bytes(n_parallel) > 0
+        )
+        return (
+            f"MTP reserve: {reserve_bytes / (1024**3):.2f} GB "
+            f"(draft KV @ {n_ctx} x {n_parallel} slots, "
+            f"ubatch {self._DEFAULT_N_UBATCH if n_ubatch is None else n_ubatch}"
+            + (f", n_max {n_max}" if scales_with_n_max else "")
+            + (", flat-frac fallback" if flat_fallback else "")
+            + "), "
+        )
+
     _DEFAULT_N_UBATCH = _DEFAULT_LLAMA_N_UBATCH
     _COMPUTE_BUFFER_SAFETY = 1.15  # upper-bound margin on the compute-buffer estimate
     # Soft VRAM the modeled terms omit; charged to the fit budget on tight tiers (#6682).
@@ -21154,16 +21190,14 @@ class LlamaCppBackend:
                         else 0
                     )
                     if _mtp_will_engage:
-                        # Name what the reserve is actually a function of. It was
-                        # printed with n_max, which _mtp_bytes does not take, so the
-                        # line read byte-identical across a 4x change in n_max and
-                        # invited the reader to conclude the reserve had scaled.
-                        _mtp_note = (
-                            f"MTP reserve: {_mtp_reserve_bytes / (1024**3):.2f} GB "
-                            f"(draft KV @ {effective_ctx} x {n_parallel or 1} slots, "
-                            f"ubatch {_effective_ubatch}"
-                            + (", flat-frac fallback" if mtp_overhead_fn is None else "")
-                            + "), "
+                        _mtp_note = self._mtp_reserve_note(
+                            _mtp_reserve_bytes,
+                            n_ctx = effective_ctx,
+                            n_parallel = n_parallel or 1,
+                            n_ubatch = _effective_ubatch,
+                            n_max = _mtp_eff_n_max,
+                            target_rollback = _target_rollback,
+                            flat_fallback = mtp_overhead_fn is None,
                         )
                     else:
                         _mtp_note = ""
@@ -25736,13 +25770,19 @@ class LlamaCppBackend:
         self._cancel_event.set()
         with self._lock:
             self._unload_epoch += 1
+            # Read before the kill clears it. Cleanup paths call unload_model() in a
+            # finally whether or not a server was ever running, and an unload event
+            # for a backend that held nothing is the same problem as the duplicate
+            # below: it makes the count wrong.
+            _was_resident = self._process is not None
             self._kill_process()
             self._cleanup_cpu_fallback_runtime()
             # The one unload line. routes/inference.py used to log its own, from the
             # request path, so every unload appeared twice 1-3 ms apart under two
             # different names (a repo id here, a snapshot path there) and "how many
             # times did this model reload" could not be answered by grep.
-            logger.info(f"Unloaded GGUF model: {self._model_identifier}")
+            if _was_resident:
+                logger.info(f"Unloaded GGUF model: {self._model_identifier}")
             self._model_identifier = None
             self._gguf_path = None
             self._gguf_load_identity = None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12612,27 +12612,60 @@ class LlamaCppBackend:
         n_max: Optional[int],
         target_rollback: bool,
         flat_fallback: bool,
+        reprice: Optional[Callable[[int, int], int]] = None,
     ) -> str:
         """The MTP reserve line, naming what that number is a function of.
 
-        n_max is named only where it moves the number. The line used to carry it
-        unconditionally, and on every model whose recurrent state is nil it then
-        read byte-identical across a 4x change in n_max, inviting the reader to
-        conclude the reserve had scaled. On a Hybrid Mamba target it does scale --
-        verification allocates one rollback copy per drafted token -- so there it
-        is named.
+        Every dimension is named only where it moves the number. The line used to
+        carry all of them unconditionally, and on the models where a given one is
+        nil it then read byte-identical across a 4x change in that parameter,
+        inviting the reader to conclude the reserve had scaled with it. Which
+        dimensions bite is per-model, not per-parameter: a dense embedded head
+        under a unified cache prices its draft KV from the padded context alone,
+        so neither slots nor micro-batch move it, while a separate drafter's own
+        KV follows both and a Hybrid Mamba target allocates one rollback copy per
+        drafted token.
+
+        ``reprice`` is the estimator the reserve came from, so slots and ubatch
+        are decided by asking it rather than by re-deriving which branch it took;
+        without it every dimension is named, which is what the line did before.
+        n_max is not one of its arguments, so that one stays structural.
 
         A None micro-batch is llama.cpp's own default, which is both what the
         reserve was computed with and what the child runs at, so it is rendered
         rather than printed as None: "ubatch None" names no parameter.
         """
+        ubatch = self._DEFAULT_N_UBATCH if n_ubatch is None else n_ubatch
+
+        def _moves(*candidates: tuple[int, int]) -> bool:
+            if reprice is None:
+                return True
+            try:
+                # The estimator's own value at the launched point, not the reported
+                # total: the two can differ (a flat fallback reports 0), and the
+                # question is whether the estimator follows the axis.
+                base = reprice(n_parallel, ubatch)
+                for slots, ub in candidates:
+                    if reprice(slots, ub) != base:
+                        return True
+            except Exception:
+                # An estimator that cannot answer says nothing about the
+                # dependency, so keep the name rather than drop a real one.
+                return True
+            return False
+
+        # Two perturbations per axis: cell counts are padded, so a single step can
+        # land inside the same bucket on a dimension the number does follow.
+        slots_named = _moves((n_parallel + 1, ubatch), (max(1, n_parallel * 2), ubatch))
+        ubatch_named = _moves((n_parallel, ubatch * 2), (n_parallel, max(1, ubatch // 2)))
         scales_with_n_max = bool(
             target_rollback and n_max and self._rollback_state_bytes(n_parallel) > 0
         )
         return (
             f"MTP reserve: {reserve_bytes / (1024**3):.2f} GB "
-            f"(draft KV @ {n_ctx} x {n_parallel} slots, "
-            f"ubatch {self._DEFAULT_N_UBATCH if n_ubatch is None else n_ubatch}"
+            f"(draft KV @ {n_ctx}"
+            + (f" x {n_parallel} slots" if slots_named else "")
+            + (f", ubatch {ubatch}" if ubatch_named else "")
             + (f", n_max {n_max}" if scales_with_n_max else "")
             + (", flat-frac fallback" if flat_fallback else "")
             + "), "
@@ -21198,6 +21231,7 @@ class LlamaCppBackend:
                             n_max = _mtp_eff_n_max,
                             target_rollback = _target_rollback,
                             flat_fallback = mtp_overhead_fn is None,
+                            reprice = lambda slots, ub: _mtp_bytes(effective_ctx, slots, ub),
                         )
                     else:
                         _mtp_note = ""

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12667,7 +12667,14 @@ class LlamaCppBackend:
             (max(n_parallel + 3, n_parallel * 2), ubatch),
             (max(n_parallel + 3, _cells + 1), ubatch),
         )
-        ubatch_named = _moves((n_parallel, ubatch * 2), (n_parallel, max(1, ubatch // 2)))
+        # The micro-batch enters through the same 256-cell padding, as one term of a
+        # compact-SWA window, so a small ubatch and its double can share a bucket. A
+        # step of exactly one bucket always crosses into the next one.
+        ubatch_named = _moves(
+            (n_parallel, ubatch * 2),
+            (n_parallel, max(1, ubatch // 2)),
+            (n_parallel, ubatch + 256),
+        )
         scales_with_n_max = bool(
             target_rollback and n_max and self._rollback_state_bytes(n_parallel) > 0
         )

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12614,26 +12614,13 @@ class LlamaCppBackend:
         flat_fallback: bool,
         reprice: Optional[Callable[[int, int], int]] = None,
     ) -> str:
-        """The MTP reserve line, naming what that number is a function of.
+        """The MTP reserve line, naming only the dimensions that move the number.
 
-        Every dimension is named only where it moves the number. The line used to
-        carry all of them unconditionally, and on the models where a given one is
-        nil it then read byte-identical across a 4x change in that parameter,
-        inviting the reader to conclude the reserve had scaled with it. Which
-        dimensions bite is per-model, not per-parameter: a dense embedded head
-        under a unified cache prices its draft KV from the padded context alone,
-        so neither slots nor micro-batch move it, while a separate drafter's own
-        KV follows both and a Hybrid Mamba target allocates one rollback copy per
-        drafted token.
-
-        ``reprice`` is the estimator the reserve came from, so slots and ubatch
-        are decided by asking it rather than by re-deriving which branch it took;
-        without it every dimension is named, which is what the line did before.
-        n_max is not one of its arguments, so that one stays structural.
-
-        A None micro-batch is llama.cpp's own default, which is both what the
-        reserve was computed with and what the child runs at, so it is rendered
-        rather than printed as None: "ubatch None" names no parameter.
+        Which ones bite is per-model, so ``reprice`` (the estimator the reserve came
+        from) is asked rather than re-deriving its branches; without it every
+        dimension is named, as before. n_max is not one of its arguments, so that one
+        stays structural. A None micro-batch is rendered as llama.cpp's default, since
+        "ubatch None" names no parameter.
         """
         ubatch = self._DEFAULT_N_UBATCH if n_ubatch is None else n_ubatch
 
@@ -12641,25 +12628,18 @@ class LlamaCppBackend:
             if reprice is None:
                 return True
             try:
-                # The estimator's own value at the launched point, not the reported
-                # total: the two can differ (a flat fallback reports 0), and the
-                # question is whether the estimator follows the axis.
+                # The estimator's own value, not the total: a flat fallback reports 0.
                 base = reprice(n_parallel, ubatch)
                 for slots, ub in candidates:
                     if reprice(slots, ub) != base:
                         return True
             except Exception:
-                # An estimator that cannot answer says nothing about the
-                # dependency, so keep the name rather than drop a real one.
+                # Cannot answer says nothing about the dependency: keep the name.
                 return True
             return False
 
-        # Several perturbations per axis: cell counts are padded, so nearby steps can
-        # all land inside the same bucket on a dimension the number does follow. Cells
-        # are padded per stream, so every slot count that divides the padded total
-        # reproduces it exactly -- at 12288 cells, 2, 3 and 4 slots all price the same
-        # and only 5 moves. The last candidate is larger than the padded cell count
-        # itself, which therefore cannot divide it, so it escapes every such plateau.
+        # Every slot count DIVIDING the padded total reproduces it: at 12288 cells 2, 3
+        # and 4 price the same, only 5 moves. The last candidate exceeds it, so cannot.
         _cells = _pad_kv_cells(max(1, n_ctx)) // 256
         slots_named = _moves(
             (n_parallel + 1, ubatch),
@@ -12667,9 +12647,7 @@ class LlamaCppBackend:
             (max(n_parallel + 3, n_parallel * 2), ubatch),
             (max(n_parallel + 3, _cells + 1), ubatch),
         )
-        # The micro-batch enters through the same 256-cell padding, as one term of a
-        # compact-SWA window, so a small ubatch and its double can share a bucket. A
-        # step of exactly one bucket always crosses into the next one.
+        # Same padding, via the compact-SWA window: a step of one bucket always crosses.
         ubatch_named = _moves(
             (n_parallel, ubatch * 2),
             (n_parallel, max(1, ubatch // 2)),
@@ -16405,13 +16383,8 @@ class LlamaCppBackend:
                     "different model, or use this model directly through "
                     "Ollama instead."
                 )
-            # Not "cannot be run": the branches above name architectures Studio
-            # knows llama-server will never run, and this one is everything else,
-            # which includes an architecture the INSTALLED build simply predates.
-            # Seen in the field on qwen4exp: four refusals with this wording, then
-            # the identical file at the identical path loaded and ran for six days
-            # after a llama.cpp update. Between the two the user reinstalled four
-            # times, because nothing here pointed at the build.
+            # Not "cannot be run": unlike the branches above, this includes an arch the
+            # INSTALLED build predates (qwen4exp ran after a llama.cpp update).
             return (
                 f"The installed llama.cpp does not recognise this GGUF's model "
                 f"architecture ('{arch}'). The file is valid. If the model is newer "
@@ -25821,17 +25794,11 @@ class LlamaCppBackend:
         self._cancel_event.set()
         with self._lock:
             self._unload_epoch += 1
-            # Read before the kill clears it. Cleanup paths call unload_model() in a
-            # finally whether or not a server was ever running, and an unload event
-            # for a backend that held nothing is the same problem as the duplicate
-            # below: it makes the count wrong.
+            # Read before the kill clears it: callers unload from a finally either way.
             _was_resident = self._process is not None
             self._kill_process()
             self._cleanup_cpu_fallback_runtime()
-            # The one unload line. routes/inference.py used to log its own, from the
-            # request path, so every unload appeared twice 1-3 ms apart under two
-            # different names (a repo id here, a snapshot path there) and "how many
-            # times did this model reload" could not be answered by grep.
+            # The one unload line: routes/inference.py logged a second, differently named.
             if _was_resident:
                 logger.info(f"Unloaded GGUF model: {self._model_identifier}")
             self._model_identifier = None

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15801,7 +15801,10 @@ async def _unload_model_impl(request: UnloadRequest, current_subject: str):
                     model = _lifecycle_model_label(_unloaded, _unloaded_variant),
                     reason = "manual",
                 )
-                logger.info(f"Unloaded GGUF model: {request.model_path}")
+                # No log line here: unload_model already emits one, for every unload
+                # rather than only the manual route, and two lines 1-3 ms apart under
+                # two different names made the reload count ungreppable. The manual
+                # event itself is on record above, in api_monitor.record_lifecycle.
                 return UnloadResponse(status = "unloaded", model = request.model_path)
 
             # Unload from Unsloth backend off the event loop: unload takes _gen_lock, which

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15801,10 +15801,8 @@ async def _unload_model_impl(request: UnloadRequest, current_subject: str):
                     model = _lifecycle_model_label(_unloaded, _unloaded_variant),
                     reason = "manual",
                 )
-                # No log line here: unload_model already emits one, for every unload
-                # rather than only the manual route, and two lines 1-3 ms apart under
-                # two different names made the reload count ungreppable. The manual
-                # event itself is on record above, in api_monitor.record_lifecycle.
+                # No log line here: unload_model emits one for every unload, and two
+                # under different names made the reload count ungreppable.
                 return UnloadResponse(status = "unloaded", model = request.model_path)
 
             # Unload from Unsloth backend off the event loop: unload takes _gen_lock, which

--- a/studio/backend/tests/test_llama_backend_switch.py
+++ b/studio/backend/tests/test_llama_backend_switch.py
@@ -210,7 +210,7 @@ def test_a_backend_with_no_build_here_is_reported_by_name(monkeypatch, tmp_path)
     job = _await_job()
 
     assert job["state"] == "error"
-    assert "Could not install the rocm llama.cpp build on this machine" in job["error"]
+    assert "Could not install a rocm llama.cpp build on this machine" in job["error"]
 
 
 @pytest.mark.parametrize(
@@ -248,7 +248,40 @@ def test_update_failure_names_the_environment_pinned_backend(
     job = _await_job()
 
     assert job["state"] == "error"
-    assert f"Could not install the {expected} llama.cpp build on this machine" in job["error"]
+    assert f"Could not install a {expected} llama.cpp build on this machine" in job["error"]
+
+
+def test_an_automatic_update_does_not_blame_a_backend_nobody_requested(monkeypatch, tmp_path):
+    """An update carries no backend_request, so failed_backend is None. The message
+    used to read "the requested llama.cpp build", which names a choice the user never
+    made: three consecutive failures in the field were reported that way, against a
+    log line that recorded only backend=null."""
+    install_dir = _install(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        upd,
+        "_plan_llama_phase",
+        lambda backend_request = None: {
+            "spec": {
+                "install_dir": install_dir,
+                "repo": "unslothai/llama.cpp",
+                "asset": None,
+                "script": tmp_path / "install_llama_prebuilt.py",
+                "pin_release_tag": "b9597-mix-new",
+                "from_tag": "b9596-mix-abc",
+                "llama_backend": "auto",
+                "rocm_gfx": None,
+                "backend_request": None,
+            }
+        },
+    )
+    _patch_installer(monkeypatch, returncode = upd._EXIT_BACKEND_UNAVAILABLE)
+
+    assert upd.start_update()["started"] is True
+    job = _await_job()
+
+    assert job["state"] == "error"
+    assert "Could not install a llama.cpp build on this machine" in job["error"]
+    assert "requested" not in job["error"]
 
 
 def test_a_switch_rejects_a_cross_repository_result(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_llama_cpp_start_failure_classification.py
+++ b/studio/backend/tests/test_llama_cpp_start_failure_classification.py
@@ -132,6 +132,18 @@ class TestUnsupportedNonDiffusionArchitecture:
         assert "enough memory" not in msg.lower()
         assert "diffusion" not in msg.lower()
 
+    def test_an_unknown_llm_arch_points_at_the_build_not_at_the_file(self):
+        """The arch branches above name models llama-server will never run. This
+        one is everything else, and "cannot be run with llama-server" was wrong for
+        the case that actually reached users: a build older than the architecture.
+        Seen on qwen4exp, where the identical file loaded after a llama.cpp update
+        and ran for six days, and the user reinstalled four times in between."""
+        out = "error loading model: unknown model architecture: 'qwen4exp'"
+        msg = _classify(out, "/models/x.gguf", "local/x")
+        assert "qwen4exp" in msg
+        assert "updating llama.cpp" in msg.lower()
+        assert "cannot be run" not in msg.lower()
+
     # Exact match: a chat arch merely containing a diffusion token (wan,
     # sd1, flux, ...) must not be routed to the Images page.
     @pytest.mark.parametrize(
@@ -151,7 +163,7 @@ class TestUnsupportedNonDiffusionArchitecture:
         out = f"error loading model: unknown model architecture: '{arch}'"
         msg = _classify(out, f"/models/{arch}.gguf", f"local/{arch}")
         assert arch in msg
-        assert "does not support" in msg.lower()
+        assert "does not recognise" in msg.lower()
         assert "diffusion" not in msg.lower()
         assert "Images page" not in msg
 
@@ -171,7 +183,7 @@ class TestOllamaAndFallback:
         msg = _classify(out, self._OLLAMA_GGUF, "ollama/some-new")
         assert "Ollama" in msg
         assert "directly through Ollama" in msg
-        assert "does not support" not in msg.lower()
+        assert "does not recognise" not in msg.lower()
 
     def test_ollama_diffusion_arch_still_routes_to_images(self):
         # Diffusion routing wins over the Ollama hint.

--- a/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
+++ b/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
@@ -98,6 +98,23 @@ def test_slots_and_ubatch_are_named_only_where_they_move_the_reserve(backend, mo
     assert "ubatch" in _note(backend, reprice = lambda slots, ub: 3 * 1024**3 + ub)
 
 
+def test_a_single_slot_launch_still_probes_a_distinct_slot_count(backend, monkeypatch):
+    # At n_parallel 1 the "double it" perturbation is also "+1", so a pair built from
+    # both probes one point, and a reserve that is flat from 1 to 2 slots only because
+    # of cell padding reads as slot-independent. The real layout is exactly that: a
+    # non-unified 8192-cell context splits into 1 x 8192 and 2 x 4096, then 3 x 2816.
+    monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
+
+    def _cells(slots, _ub):
+        _, streams, per_stream = llama_cpp_module._kv_cache_cell_layout(8192, slots, False)
+        return streams * per_stream
+
+    assert _cells(1, 0) == _cells(2, 0) and _cells(3, 0) != _cells(1, 0), "premise moved"
+
+    note = _note(backend, n_parallel = 1, reprice = _cells)
+    assert "x 1 slots" in note
+
+
 def test_an_estimator_that_cannot_answer_keeps_the_dimension_named(backend, monkeypatch):
     # Dropping a name on a raise would silently under-report a real dependency, which
     # is the failure this whole line is meant to prevent, pointing the other way.

--- a/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
+++ b/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
@@ -71,8 +71,43 @@ def test_the_note_still_names_the_context_slots_and_the_fallback(backend, monkey
     monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
     note = _note(backend, flat_fallback = True)
 
+    # No estimator to ask, so every dimension is named -- what the line always did.
     assert note.startswith("MTP reserve: 3.00 GB (draft KV @ 8192 x 2 slots")
     assert "flat-frac fallback" in note
+
+
+def test_slots_and_ubatch_are_named_only_where_they_move_the_reserve(backend, monkeypatch):
+    # A dense embedded head under a unified cache prices its draft KV from the padded
+    # context alone: _mtp_draft_kv_bytes never reads n_ubatch on that branch, and
+    # _kv_cache_cell_layout gives one stream of padded_ctx cells whatever the slot
+    # count. Naming either is the same misdirection this line exists to remove.
+    monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
+    flat = _note(backend, reprice = lambda slots, ub: 3 * 1024**3)
+    assert flat.startswith("MTP reserve: 3.00 GB (draft KV @ 8192)")
+    assert "slots" not in flat and "ubatch" not in flat
+
+    # A separate drafter carries its own KV through _estimate_kv_cache_bytes, which
+    # follows both, so both come back.
+    both = _note(backend, reprice = lambda slots, ub: 3 * 1024**3 + slots * ub)
+    assert "x 2 slots" in both and f"ubatch {backend._DEFAULT_N_UBATCH}" in both
+
+    # One axis at a time, so a single flag cannot be standing in for the pair.
+    assert "x 2 slots" in _note(backend, reprice = lambda slots, ub: 3 * 1024**3 + slots)
+    assert "ubatch" not in _note(backend, reprice = lambda slots, ub: 3 * 1024**3 + slots)
+    assert "slots" not in _note(backend, reprice = lambda slots, ub: 3 * 1024**3 + ub)
+    assert "ubatch" in _note(backend, reprice = lambda slots, ub: 3 * 1024**3 + ub)
+
+
+def test_an_estimator_that_cannot_answer_keeps_the_dimension_named(backend, monkeypatch):
+    # Dropping a name on a raise would silently under-report a real dependency, which
+    # is the failure this whole line is meant to prevent, pointing the other way.
+    monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
+
+    def _raises(slots, ub):
+        raise RuntimeError("unsized")
+
+    note = _note(backend, reprice = _raises)
+    assert "x 2 slots" in note and "ubatch" in note
 
 
 def test_an_unload_with_nothing_resident_logs_no_unload_event(backend, monkeypatch):
@@ -99,3 +134,45 @@ def test_an_unload_of_a_resident_model_still_logs_one_event(backend, monkeypatch
     backend.unload_model()
 
     assert [line for line in seen if "Unloaded GGUF model: unsloth/B-GGUF:Q4_K_M" in str(line)]
+
+
+def test_the_real_estimator_ignores_both_axes_for_a_dense_embedded_head(backend):
+    """The premise the note now asks about, pinned against the estimator itself.
+
+    Without this the note's tests would only prove it renders whatever a stand-in
+    tells it, and the claim that slots and ubatch really are inert on this branch
+    would rest on reading the code.
+    """
+    backend._nextn_predict_layers = 1
+    backend._n_kv_heads = 8
+    backend._n_heads = 64
+    backend._kv_key_length = 128
+    backend._kv_value_length = 128
+    backend._kv_lora_rank = None  # not MLA: no duplicated target context
+    backend._architecture = "qwen3moe"
+
+    def _reserve(n_parallel, n_ubatch):
+        return backend._estimate_mtp_overhead_bytes(
+            8192,
+            spec_draft_n_max = 4,
+            n_parallel = n_parallel,
+            kv_unified = True,
+            n_ubatch = n_ubatch,
+        )
+
+    base = _reserve(2, 512)
+    assert base and base > 0
+    assert _reserve(3, 512) == base
+    assert _reserve(4, 512) == base
+    assert _reserve(2, 1024) == base
+    assert _reserve(2, 256) == base
+
+    # The control: a non-unified cache gives each slot its own stream and pads each
+    # one, so a slot count the context does not divide evenly does move the number,
+    # and a note driven by this estimator would then name it. Three, not two: at two
+    # the halves pad back to exactly the unified total, which would have made this
+    # control pass for the wrong reason.
+    split = backend._estimate_mtp_overhead_bytes(
+        8192, spec_draft_n_max = 4, n_parallel = 3, kv_unified = False, n_ubatch = 512
+    )
+    assert split != base

--- a/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
+++ b/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
@@ -115,6 +115,29 @@ def test_a_single_slot_launch_still_probes_a_distinct_slot_count(backend, monkey
     assert "x 1 slots" in note
 
 
+def test_the_slot_probe_escapes_a_padding_plateau(backend, monkeypatch):
+    # Cells are padded per stream, so every slot count that divides the padded total
+    # reproduces it: at n_ctx 12288 the launched 2 slots and the neighbours 3 and 4 all
+    # price 12288 cells, and only 5 moves. A ladder of nearby steps therefore cannot
+    # see the dependency; the probe has to reach past the plateau.
+    monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
+
+    def _cells(slots, _ub):
+        _, streams, per_stream = llama_cpp_module._kv_cache_cell_layout(12288, slots, False)
+        return streams * per_stream
+
+    assert [_cells(s, 0) for s in (2, 3, 4)] == [12288] * 3, "premise moved"
+    assert _cells(5, 0) != 12288
+
+    note = _note(backend, n_ctx = 12288, n_parallel = 2, reprice = _cells)
+    assert "x 2 slots" in note
+
+    # The control: a reserve that really is slot-independent stays unnamed however far
+    # the ladder reaches, so this is not a probe that names the axis unconditionally.
+    flat = _note(backend, n_ctx = 12288, n_parallel = 2, reprice = lambda slots, ub: 3 * 1024**3)
+    assert "slots" not in flat
+
+
 def test_an_estimator_that_cannot_answer_keeps_the_dimension_named(backend, monkeypatch):
     # Dropping a name on a raise would silently under-report a real dependency, which
     # is the failure this whole line is meant to prevent, pointing the other way.

--- a/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
+++ b/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Two log lines that named the wrong thing.
+
+The MTP reserve line has to name the parameters the number is a function of, and
+only those: printing a parameter that changes nothing invites the reader to
+conclude the reserve scaled with it, and printing a bare ``None`` for a default
+names no parameter at all. And an unload event for a backend that never held a
+model makes the reload count this file's sibling change exists to fix wrong.
+"""
+
+import os
+import sys
+
+import pytest
+
+_backend = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, _backend)
+
+from core.inference import llama_cpp as llama_cpp_module  # noqa: E402
+from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    monkeypatch.setattr(LlamaCppBackend, "_kill_orphaned_servers", lambda self: 0)
+    monkeypatch.setattr(llama_cpp_module.atexit, "register", lambda *_a, **_k: None)
+    return LlamaCppBackend()
+
+
+def _note(backend, **kwargs):
+    params = {
+        "n_ctx": 8192,
+        "n_parallel": 2,
+        "n_ubatch": None,
+        "n_max": 4,
+        "target_rollback": False,
+        "flat_fallback": False,
+    }
+    params.update(kwargs)
+    return backend._mtp_reserve_note(3 * 1024**3, **params)
+
+
+def test_the_default_micro_batch_is_rendered_not_printed_as_none(backend, monkeypatch):
+    # The estimators read None as llama.cpp's own default and the child runs at it,
+    # so the reserve was computed with a concrete number that the line must name.
+    monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
+
+    assert f"ubatch {backend._DEFAULT_N_UBATCH}" in _note(backend)
+    assert "ubatch None" not in _note(backend)
+    # An explicit micro-batch is still its own value.
+    assert "ubatch 1024" in _note(backend, n_ubatch = 1024)
+
+
+def test_n_max_is_named_exactly_where_it_moves_the_reserve(backend, monkeypatch):
+    # A Hybrid Mamba target allocates one rollback copy per drafted token, so the
+    # reserve scales with n_max there and nowhere else.
+    monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 64 * 1024**2)
+    assert "n_max 4" in _note(backend, target_rollback = True)
+
+    # Same model, no target rollback for this spec type.
+    assert "n_max" not in _note(backend, target_rollback = False)
+
+    # Rollback wanted, but this model keeps no recurrent state to copy.
+    monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
+    assert "n_max" not in _note(backend, target_rollback = True)
+
+
+def test_the_note_still_names_the_context_slots_and_the_fallback(backend, monkeypatch):
+    monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
+    note = _note(backend, flat_fallback = True)
+
+    assert note.startswith("MTP reserve: 3.00 GB (draft KV @ 8192 x 2 slots")
+    assert "flat-frac fallback" in note
+
+
+def test_an_unload_with_nothing_resident_logs_no_unload_event(backend, monkeypatch):
+    # Helper and advisor paths call unload_model() from a finally whether or not a
+    # server was ever started, and a spurious event makes "how many times did this
+    # model reload" unanswerable by grep -- the very thing the single line is for.
+    seen: list = []
+    monkeypatch.setattr(llama_cpp_module.logger, "info", lambda msg, *a, **k: seen.append(msg))
+
+    backend.unload_model()
+
+    assert not [line for line in seen if "Unloaded GGUF model" in str(line)]
+
+
+def test_an_unload_of_a_resident_model_still_logs_one_event(backend, monkeypatch):
+    # The control: without it a fix that silenced the line entirely would pass above.
+    seen: list = []
+    monkeypatch.setattr(llama_cpp_module.logger, "info", lambda msg, *a, **k: seen.append(msg))
+    # Not a Popen: _kill_process treats a non-terminable stand-in as "a server is
+    # loaded" and clears the state without signalling anything.
+    backend._process = object()
+    backend._model_identifier = "unsloth/B-GGUF:Q4_K_M"
+
+    backend.unload_model()
+
+    assert [line for line in seen if "Unloaded GGUF model: unsloth/B-GGUF:Q4_K_M" in str(line)]

--- a/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
+++ b/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
@@ -138,6 +138,28 @@ def test_the_slot_probe_escapes_a_padding_plateau(backend, monkeypatch):
     assert "slots" not in flat
 
 
+def test_the_ubatch_probe_escapes_a_padding_plateau(backend, monkeypatch):
+    # The micro-batch reaches the reserve through the same 256-cell padding, as one term
+    # of a compact-SWA window, so a small value and its double can share a bucket while
+    # a larger one adds another. Halving and doubling alone therefore cannot see it.
+    monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
+
+    def _window(_slots, ub):
+        # The shape of the compact-SWA branch: a padded window whose size the micro-batch
+        # is added into.
+        return llama_cpp_module._pad_kv_cells(1024 + ub)
+
+    assert _window(1, 64) == _window(1, 128) == _window(1, 32), "premise moved"
+    assert _window(1, 64 + 256) != _window(1, 64)
+
+    note = _note(backend, n_ubatch = 64, reprice = _window)
+    assert "ubatch 64" in note
+
+    # The control: a reserve the micro-batch really does not reach stays unnamed.
+    flat = _note(backend, n_ubatch = 64, reprice = lambda slots, ub: 3 * 1024**3)
+    assert "ubatch" not in flat
+
+
 def test_an_estimator_that_cannot_answer_keeps_the_dimension_named(backend, monkeypatch):
     # Dropping a name on a raise would silently under-report a real dependency, which
     # is the failure this whole line is meant to prevent, pointing the other way.

--- a/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
+++ b/studio/backend/tests/test_mtp_reserve_note_and_unload_log.py
@@ -1,14 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Two log lines that named the wrong thing.
-
-The MTP reserve line has to name the parameters the number is a function of, and
-only those: printing a parameter that changes nothing invites the reader to
-conclude the reserve scaled with it, and printing a bare ``None`` for a default
-names no parameter at all. And an unload event for a backend that never held a
-model makes the reload count this file's sibling change exists to fix wrong.
-"""
+"""Two log lines that named the wrong thing: the MTP reserve naming parameters it
+is not a function of, and an unload event for a backend that held no model."""
 
 import os
 import sys
@@ -43,13 +37,12 @@ def _note(backend, **kwargs):
 
 
 def test_the_default_micro_batch_is_rendered_not_printed_as_none(backend, monkeypatch):
-    # The estimators read None as llama.cpp's own default and the child runs at it,
-    # so the reserve was computed with a concrete number that the line must name.
+    # The estimators and the child both read None as llama.cpp's default, so the line
+    # must name that number.
     monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
 
     assert f"ubatch {backend._DEFAULT_N_UBATCH}" in _note(backend)
     assert "ubatch None" not in _note(backend)
-    # An explicit micro-batch is still its own value.
     assert "ubatch 1024" in _note(backend, n_ubatch = 1024)
 
 
@@ -59,10 +52,9 @@ def test_n_max_is_named_exactly_where_it_moves_the_reserve(backend, monkeypatch)
     monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 64 * 1024**2)
     assert "n_max 4" in _note(backend, target_rollback = True)
 
-    # Same model, no target rollback for this spec type.
     assert "n_max" not in _note(backend, target_rollback = False)
 
-    # Rollback wanted, but this model keeps no recurrent state to copy.
+    # Rollback wanted, but no recurrent state to copy.
     monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
     assert "n_max" not in _note(backend, target_rollback = True)
 
@@ -77,17 +69,14 @@ def test_the_note_still_names_the_context_slots_and_the_fallback(backend, monkey
 
 
 def test_slots_and_ubatch_are_named_only_where_they_move_the_reserve(backend, monkeypatch):
-    # A dense embedded head under a unified cache prices its draft KV from the padded
-    # context alone: _mtp_draft_kv_bytes never reads n_ubatch on that branch, and
-    # _kv_cache_cell_layout gives one stream of padded_ctx cells whatever the slot
-    # count. Naming either is the same misdirection this line exists to remove.
+    # A dense embedded head under a unified cache reads neither: one stream is
+    # padded_ctx cells at any slot count, and n_ubatch is not read on that branch.
     monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
     flat = _note(backend, reprice = lambda slots, ub: 3 * 1024**3)
     assert flat.startswith("MTP reserve: 3.00 GB (draft KV @ 8192)")
     assert "slots" not in flat and "ubatch" not in flat
 
-    # A separate drafter carries its own KV through _estimate_kv_cache_bytes, which
-    # follows both, so both come back.
+    # A separate drafter's KV follows both, so both come back.
     both = _note(backend, reprice = lambda slots, ub: 3 * 1024**3 + slots * ub)
     assert "x 2 slots" in both and f"ubatch {backend._DEFAULT_N_UBATCH}" in both
 
@@ -99,10 +88,8 @@ def test_slots_and_ubatch_are_named_only_where_they_move_the_reserve(backend, mo
 
 
 def test_a_single_slot_launch_still_probes_a_distinct_slot_count(backend, monkeypatch):
-    # At n_parallel 1 the "double it" perturbation is also "+1", so a pair built from
-    # both probes one point, and a reserve that is flat from 1 to 2 slots only because
-    # of cell padding reads as slot-independent. The real layout is exactly that: a
-    # non-unified 8192-cell context splits into 1 x 8192 and 2 x 4096, then 3 x 2816.
+    # At n_parallel 1 "double it" is also "+1", so the pair probes one point: a real
+    # 8192-cell context splits 1 x 8192 and 2 x 4096, then 3 x 2816.
     monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
 
     def _cells(slots, _ub):
@@ -116,10 +103,7 @@ def test_a_single_slot_launch_still_probes_a_distinct_slot_count(backend, monkey
 
 
 def test_the_slot_probe_escapes_a_padding_plateau(backend, monkeypatch):
-    # Cells are padded per stream, so every slot count that divides the padded total
-    # reproduces it: at n_ctx 12288 the launched 2 slots and the neighbours 3 and 4 all
-    # price 12288 cells, and only 5 moves. A ladder of nearby steps therefore cannot
-    # see the dependency; the probe has to reach past the plateau.
+    # At n_ctx 12288, 2, 3 and 4 slots all price 12288 cells and only 5 moves.
     monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
 
     def _cells(slots, _ub):
@@ -132,21 +116,17 @@ def test_the_slot_probe_escapes_a_padding_plateau(backend, monkeypatch):
     note = _note(backend, n_ctx = 12288, n_parallel = 2, reprice = _cells)
     assert "x 2 slots" in note
 
-    # The control: a reserve that really is slot-independent stays unnamed however far
-    # the ladder reaches, so this is not a probe that names the axis unconditionally.
+    # The control: a slot-independent reserve stays unnamed however far it reaches.
     flat = _note(backend, n_ctx = 12288, n_parallel = 2, reprice = lambda slots, ub: 3 * 1024**3)
     assert "slots" not in flat
 
 
 def test_the_ubatch_probe_escapes_a_padding_plateau(backend, monkeypatch):
-    # The micro-batch reaches the reserve through the same 256-cell padding, as one term
-    # of a compact-SWA window, so a small value and its double can share a bucket while
-    # a larger one adds another. Halving and doubling alone therefore cannot see it.
+    # Through the same padding, as a compact-SWA term: a value and its double share
+    # a bucket, so halving and doubling cannot see it.
     monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
 
     def _window(_slots, ub):
-        # The shape of the compact-SWA branch: a padded window whose size the micro-batch
-        # is added into.
         return llama_cpp_module._pad_kv_cells(1024 + ub)
 
     assert _window(1, 64) == _window(1, 128) == _window(1, 32), "premise moved"
@@ -155,14 +135,13 @@ def test_the_ubatch_probe_escapes_a_padding_plateau(backend, monkeypatch):
     note = _note(backend, n_ubatch = 64, reprice = _window)
     assert "ubatch 64" in note
 
-    # The control: a reserve the micro-batch really does not reach stays unnamed.
+    # The control: a reserve the micro-batch does not reach stays unnamed.
     flat = _note(backend, n_ubatch = 64, reprice = lambda slots, ub: 3 * 1024**3)
     assert "ubatch" not in flat
 
 
 def test_an_estimator_that_cannot_answer_keeps_the_dimension_named(backend, monkeypatch):
-    # Dropping a name on a raise would silently under-report a real dependency, which
-    # is the failure this whole line is meant to prevent, pointing the other way.
+    # Dropping a name on a raise would under-report a real dependency.
     monkeypatch.setattr(backend, "_rollback_state_bytes", lambda n_parallel = 1: 0)
 
     def _raises(slots, ub):
@@ -173,9 +152,8 @@ def test_an_estimator_that_cannot_answer_keeps_the_dimension_named(backend, monk
 
 
 def test_an_unload_with_nothing_resident_logs_no_unload_event(backend, monkeypatch):
-    # Helper and advisor paths call unload_model() from a finally whether or not a
-    # server was ever started, and a spurious event makes "how many times did this
-    # model reload" unanswerable by grep -- the very thing the single line is for.
+    # Callers unload from a finally either way, and a spurious event makes "how many
+    # times did this model reload" unanswerable by grep.
     seen: list = []
     monkeypatch.setattr(llama_cpp_module.logger, "info", lambda msg, *a, **k: seen.append(msg))
 
@@ -185,11 +163,10 @@ def test_an_unload_with_nothing_resident_logs_no_unload_event(backend, monkeypat
 
 
 def test_an_unload_of_a_resident_model_still_logs_one_event(backend, monkeypatch):
-    # The control: without it a fix that silenced the line entirely would pass above.
+    # The control: a fix that silenced the line entirely would pass above.
     seen: list = []
     monkeypatch.setattr(llama_cpp_module.logger, "info", lambda msg, *a, **k: seen.append(msg))
-    # Not a Popen: _kill_process treats a non-terminable stand-in as "a server is
-    # loaded" and clears the state without signalling anything.
+    # Not a Popen: _kill_process treats a non-terminable stand-in as loaded.
     backend._process = object()
     backend._model_identifier = "unsloth/B-GGUF:Q4_K_M"
 
@@ -229,11 +206,9 @@ def test_the_real_estimator_ignores_both_axes_for_a_dense_embedded_head(backend)
     assert _reserve(2, 1024) == base
     assert _reserve(2, 256) == base
 
-    # The control: a non-unified cache gives each slot its own stream and pads each
-    # one, so a slot count the context does not divide evenly does move the number,
-    # and a note driven by this estimator would then name it. Three, not two: at two
-    # the halves pad back to exactly the unified total, which would have made this
-    # control pass for the wrong reason.
+    # The control: non-unified pads each stream, so a slot count the context does not
+    # divide does move the number. Three, not two: at two the halves pad back to the
+    # unified total and the control would pass for the wrong reason.
     split = backend._estimate_mtp_overhead_bytes(
         8192, spec_draft_n_max = 4, n_parallel = 3, kv_unified = False, n_ubatch = 512
     )

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -832,14 +832,25 @@ def _run_llama_phase(
         if exc.returncode == _EXIT_BACKEND_UNAVAILABLE:
             # This can race hardware or release changes after option resolution.
             failed_backend = backend_request or _env_backend_override()
+            # "requested" reads as the user's choice, and on an automatic update
+            # nobody requested anything: three failures in the field were reported
+            # as "Could not install the requested llama.cpp build" against a
+            # backend_request of None.
             backend_label = (
-                failed_backend
+                f"{failed_backend} "
                 if failed_backend is not None and failed_backend != "auto"
-                else "requested"
+                else ""
             )
-            logger.warning("llama update: backend unavailable", backend = failed_backend)
+            # The reason, like every sibling branch in this except block. Without it
+            # the only record of three consecutive failures was the word "null", and
+            # the installer's own explanation goes to a stdout nothing captures.
+            logger.warning(
+                "llama update: backend unavailable",
+                backend = failed_backend,
+                error = str(exc),
+            )
             raise _LlamaPhaseError(
-                f"Could not install the {backend_label} llama.cpp build on this machine. "
+                f"Could not install a {backend_label}llama.cpp build on this machine. "
                 "The installed backend was kept.",
                 reload_required = model_was_active,
             ) from exc

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -832,18 +832,13 @@ def _run_llama_phase(
         if exc.returncode == _EXIT_BACKEND_UNAVAILABLE:
             # This can race hardware or release changes after option resolution.
             failed_backend = backend_request or _env_backend_override()
-            # "requested" reads as the user's choice, and on an automatic update
-            # nobody requested anything: three failures in the field were reported
-            # as "Could not install the requested llama.cpp build" against a
-            # backend_request of None.
+            # "requested" reads as the user's choice; an automatic update has none.
             backend_label = (
                 f"{failed_backend} "
                 if failed_backend is not None and failed_backend != "auto"
                 else ""
             )
-            # The reason, like every sibling branch in this except block. Without it
-            # the only record of three consecutive failures was the word "null", and
-            # the installer's own explanation goes to a stdout nothing captures.
+            # The reason, as every sibling branch does: otherwise the record is "null".
             logger.warning(
                 "llama update: backend unavailable",
                 backend = failed_backend,


### PR DESCRIPTION
Four messages from one Strix Halo log bundle that sent the user somewhere wrong. Each was checked against mainline before being changed, and each has the log evidence next to it.

## 1. An unknown architecture blamed the model instead of the build

```
llama_model_load: error loading model: unknown model architecture: 'qwen4exp'
```

rendered as:

> llama.cpp does not support this GGUF's model architecture ('qwen4exp'). The file is valid, but this model type cannot be run with llama-server.

The second sentence is refuted by the user's own log. Four loads failed that way over 19 hours on a 103.7 GB model Studio had just downloaded. After `llama update: success to_tag=b10639-mix-f6f92fe`, the identical file at the identical snapshot path loaded 26 seconds later and ran for the next six days. Between the first failure and the fix the user reinstalled llama.cpp four times, because nothing in the message pointed at the build.

The branches above this one in `_classify_llama_start_failure` name architectures llama-server genuinely cannot run: diffusion, text-to-video, the ambiguous image families. This is the fallback for everything else, and "everything else" includes an architecture the installed build predates. It now reads:

> The installed llama.cpp does not recognise this GGUF's model architecture ('qwen4exp'). The file is valid. If the model is newer than this llama.cpp build, updating llama.cpp may add support for it.

## 2. An update failure named a backend nobody requested, and discarded its reason

```
16:47:46 installing b10715 -> 16:47:53 "llama update: backend unavailable", backend=null
16:53:12 installing b10715 -> 16:53:18 same
16:54:31 installing b10715 -> 16:54:37 same (new process, after a full app restart)
16:54:47 desktop updater installs the same release cleanly
```

Two problems in that one branch.

`failed_backend` is `backend_request or _env_backend_override()`, and an ordinary update requests nothing, so the label fell through to the literal `"requested"` and the user was told Studio could not install "the requested llama.cpp build". Nothing was requested.

And the warning logged only `backend`, which is the `null` above. Every sibling branch in the same `except` block logs the reason (`llama update: prebuilt fallback`, `error = message`; `llama update: failed`, `error = str(exc)`). The installer prints its own `prebuilt fallback reason: ...` and a full system report to a stdout nothing captures, so after three failures there was no diagnosis anywhere.

Now: the message says "a llama.cpp build" when no backend was named and "a rocm llama.cpp build" when one was, and the warning carries `error = str(exc)` like its siblings.

## 3. The MTP reserve named a parameter it does not depend on

```
MTP reserve: 10.40 GB (draft KV @ 128000 + verify n_max=4)
MTP reserve: 10.40 GB (draft KV @ 128000 + verify n_max=3)
MTP reserve: 10.27 GB (draft KV @ 64000  + verify n_max=4)
MTP reserve: 10.27 GB (draft KV @ 64000  + verify n_max=16)
```

Byte-identical across a 4x change in `n_max`, because the reserve is `_mtp_bytes(effective_ctx, n_parallel, _effective_ubatch)` and `n_max` is not one of its arguments. The line now names the context, the slot count and the micro-batch, which are what it is computed from.

Whether the reserve *should* scale with `n_max` is a separate question that needs a VRAM measurement, not a log line. This change only stops the message asserting something the code does not do.

## 4. Every unload was logged twice, under two different names

44 `Unloaded GGUF model` events for 44 `POST /api/inference/load`, of which 19 adjacent pairs are duplicates 1 to 3 ms apart. The two emitters print different identifiers, which is why the bundle contains both `Unloaded GGUF model: unsloth/DeepSeek-V4-Flash-0731-GGUF` and `Unloaded GGUF model: C:\Users\Admin\.cache\huggingface\hub\models--unsloth--Qwen3.8-...` for the same event.

The route's line is the one removed. `unload_model` logs every unload, including eviction, reload and shutdown, where the route only sees the manual one, and the manual event is already recorded by `api_monitor.record_lifecycle`. Cosmetic, except that it makes "how many times did this model reload" answerable by grep, which is exactly what this kind of triage needs.

## Testing

Three new tests: the architecture message points at the build and no longer claims the model cannot be run; an automatic update does not blame a backend nobody requested; and two existing wording assertions in the classification suite were updated to the new phrasing.

510 pass across `test_llama_backend_switch`, `test_llama_cpp_update`, `test_combined_update`, `test_update_flow_messages`, `test_llama_route` and `test_llama_cpp_mtp_detection`; 225 pass in `test_llama_cpp_start_failure_classification`.

One note for anyone re-running these together: `test_llama_cpp_start_failure_classification.py` stubs `loggers` and `structlog` at import, and running it in the same process as the update suites makes 13 of them fail. That reproduces identically on a clean checkout of main, so it is pre-existing and not from this change, but it is why the numbers above are quoted as two runs rather than one.
