### PR TITLE
Studio: report a throughput the engine could have produced

### DIFF
--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -46,6 +46,11 @@ class LlamaServerStatsLogger:
         self._stall_since = None
         self._stall_reported = False
         self._unmeasurable_reported = False
+        # Busy seconds since each token counter last advanced. Both counters move
+        # once per generation, at slot release, so the tick they move on is not the
+        # window the tokens were produced in. See _token_rate.
+        self._gen_busy_s = 0.0
+        self._prompt_busy_s = 0.0
 
     def start(self):
         if self._thread is None:
@@ -70,6 +75,25 @@ class LlamaServerStatsLogger:
             except ValueError:
                 continue
         return out
+
+    @staticmethod
+    def _token_rate(delta_tokens, busy_s, tick_s):
+        """Tokens per second over the window they were produced in.
+
+        llama-server updates tokens_predicted_total and prompt_tokens_total once
+        per generation, from callback_on_reset when the slot is released. Dividing
+        the whole count by the poll interval therefore reports the rate of a
+        10-second window that the generation did not run in: a 103.7 GB Q4 MoE whose
+        measured ceiling is 24.6 tok/s was logged at 150.6 and 183.7 tok/s that way.
+
+        busy_s is the time the engine actually held a slot since this counter last
+        moved, so an idle gap between two generations is not charged to the second
+        one. Floored at one tick, which is both a divide-by-zero guard and the
+        smallest window a count can honestly be attributed to.
+        """
+        if delta_tokens <= 0:
+            return 0.0
+        return delta_tokens / max(busy_s, tick_s, 1e-9)
 
     def _stalled_for(self, now, running, decode_calls):
         """Seconds the engine has held a slot without calling llama_decode().
@@ -121,7 +145,7 @@ class LlamaServerStatsLogger:
 
     def _run(self):
         misses = 0
-        prev = None  # (monotonic_t, tokens_predicted_total, prompt_tokens_total)
+        prev = None  # (monotonic_t, tokens_predicted_total, prompt_tokens_total, n_decode_total)
         while not self._stop.wait(self._interval):
             m = self._scrape()
             if not m:
@@ -135,25 +159,42 @@ class LlamaServerStatsLogger:
             now = time.monotonic()
             predicted = m.get("tokens_predicted_total", 0.0)
             prompt = m.get("prompt_tokens_total", 0.0)
-            gen_delta = prompt_delta = 0.0
-            if prev is not None and now > prev[0]:
-                dt = now - prev[0]
-                gen_delta = max(0.0, (predicted - prev[1]) / dt)
-                prompt_delta = max(0.0, (prompt - prev[2]) / dt)
-            prev = (now, predicted, prompt)
-            # Prefer llama.cpp's own throughput gauges; fall back to the counter delta for binaries that expose only the
-            # counters.
-            gen_tps = m.get("predicted_tokens_seconds") or gen_delta
-            prompt_tps = m.get("prompt_tokens_seconds") or prompt_delta
-            running, waiting = (
-                int(m.get("requests_processing", 0)),
-                int(m.get("requests_deferred", 0)),
-            )
             # a build without n_decode_total reads None and never "changes", accumulating the same way
             # A held slot not calling llama_decode() is a wedge, and its only symptom is an endless run of identical
             # info lines. A build without n_decode_total reads None and never "changes", accumulating the same way, so
             # the message is chosen at report time.
             decode_calls = m.get("n_decode_total")
+            running, waiting = (
+                int(m.get("requests_processing", 0)),
+                int(m.get("requests_deferred", 0)),
+            )
+            gen_delta = prompt_delta = 0.0
+            # Calls, not tokens, and never fed into tok/s. This is the one counter
+            # that moves on EVERY llama_decode(), so it is the only thing in the
+            # line that says "the engine is producing" while a generation is still
+            # running. The token counters are 0 for the whole of a healthy one.
+            decode_rate = 0.0
+            if prev is not None and now > prev[0]:
+                dt = now - prev[0]
+                # Only busy time counts toward a rate. A slot held is the engine
+                # working: the token counters stay still through a healthy prefill
+                # and a healthy decode alike, so "not moving" is not "idle".
+                if running or waiting:
+                    self._gen_busy_s += dt
+                    self._prompt_busy_s += dt
+                gen_delta = self._token_rate(predicted - prev[1], self._gen_busy_s, dt)
+                prompt_delta = self._token_rate(prompt - prev[2], self._prompt_busy_s, dt)
+                if predicted > prev[1]:
+                    self._gen_busy_s = 0.0
+                if prompt > prev[2]:
+                    self._prompt_busy_s = 0.0
+                if decode_calls is not None and prev[3] is not None:
+                    decode_rate = max(0.0, (decode_calls - prev[3]) / dt)
+            prev = (now, predicted, prompt, decode_calls)
+            # Prefer llama.cpp's own throughput gauges; fall back to the counter delta for binaries that expose only the
+            # counters.
+            gen_tps = m.get("predicted_tokens_seconds") or gen_delta
+            prompt_tps = m.get("prompt_tokens_seconds") or prompt_delta
             stalled_for = self._stalled_for(now, running, decode_calls)
             if self._stall_timeout and stalled_for >= self._stall_timeout:
                 if decode_calls is None:
@@ -174,6 +215,7 @@ class LlamaServerStatsLogger:
                     "engine_stats",
                     gen_tok_s = round(float(gen_tps), 1),
                     prompt_tok_s = round(float(prompt_tps), 1),
+                    decode_calls_s = round(float(decode_rate), 1),
                     running = running,
                     waiting = waiting,
                 )

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -46,11 +46,14 @@ class LlamaServerStatsLogger:
         self._stall_since = None
         self._stall_reported = False
         self._unmeasurable_reported = False
-        # Busy seconds since tokens_predicted_total last advanced. That counter moves
-        # once per generation, at slot release, so the tick it moves on is not the
-        # window the tokens were produced in. See _token_rate. prompt_tokens_total
-        # needs no such accumulator: llama-server flushes it every decode step.
+        # The busy window: seconds the engine has held a slot, and the generated
+        # tokens released in them. tokens_predicted_total moves once per generation,
+        # at slot release, so the tick it moves on is not the window the tokens were
+        # produced in, and with several slots in flight one release is not the whole
+        # of what the window produced. See _token_rate. prompt_tokens_total needs no
+        # such accumulator: llama-server flushes it every decode step.
         self._gen_busy_s = 0.0
+        self._gen_tokens = 0.0
 
     def start(self):
         if self._thread is None:
@@ -77,7 +80,7 @@ class LlamaServerStatsLogger:
         return out
 
     @staticmethod
-    def _token_rate(delta_tokens, busy_s, tick_s):
+    def _token_rate(window_tokens, busy_s, tick_s):
         """Generated tokens per second over the window they were produced in.
 
         llama-server updates tokens_predicted_total once per generation, from
@@ -87,20 +90,26 @@ class LlamaServerStatsLogger:
         generation did not run in: a 103.7 GB Q4 MoE whose measured ceiling is
         24.6 tok/s was logged at 150.6 and 183.7 tok/s that way.
 
+        Both arguments are the WHOLE window, not this tick's release: with more
+        than one slot in flight a release is only part of what the window produced,
+        and pairing it with the window's full busy time would report the second of
+        two concurrent generations at the interval between the two releases -- the
+        same impossible spike from the other direction.
+
         Generation only. prompt_tokens_total is flushed from metrics_post_decode()
         on EVERY decode step, so its delta already covers the tick it is read in;
         charging it the same busy time would divide one prefill by the decode that
         preceded it (measured: a 2000-token prefill reported at 33 tok/s instead
         of 200).
 
-        busy_s is the time the engine actually held a slot since this counter last
-        moved, so an idle gap between two generations is not charged to the second
-        one. Floored at one tick, which is both a divide-by-zero guard and the
-        smallest window a count can honestly be attributed to.
+        busy_s is the time the engine actually held a slot, so an idle gap between
+        two generations is not charged to the next one. Floored at one tick, which
+        is both a divide-by-zero guard and the smallest window a count can honestly
+        be attributed to.
         """
-        if delta_tokens <= 0:
+        if window_tokens <= 0:
             return 0.0
-        return delta_tokens / max(busy_s, tick_s, 1e-9)
+        return window_tokens / max(busy_s, tick_s, 1e-9)
 
     def _stalled_for(self, now, running, decode_calls):
         """Seconds the engine has held a slot without calling llama_decode().
@@ -183,17 +192,32 @@ class LlamaServerStatsLogger:
             decode_rate = 0.0
             if prev is not None and now > prev[0]:
                 dt = now - prev[0]
+                released = max(0.0, predicted - prev[1])
                 # Only busy time counts toward a rate. A slot held is the engine
                 # working: tokens_predicted_total stays still through a healthy
                 # prefill and a healthy decode alike, so "not moving" is not "idle".
-                if running or waiting:
+                # A release counts too: the generation that produced it ran in this
+                # interval, and a single-slot server that finishes between scrapes
+                # reports 0 slots on the very tick the tokens arrive, so reading the
+                # gauges alone would drop the last interval and overstate the rate.
+                if running or waiting or released:
                     self._gen_busy_s += dt
-                gen_delta = self._token_rate(predicted - prev[1], self._gen_busy_s, dt)
+                self._gen_tokens += released
+                gen_delta = (
+                    self._token_rate(self._gen_tokens, self._gen_busy_s, dt)
+                    if released
+                    else 0.0
+                )
                 # Plain delta: this counter moves on every decode step, so the tick
                 # it is read in IS the window it was produced in.
                 prompt_delta = max(0.0, (prompt - prev[2]) / dt)
-                if predicted > prev[1]:
+                # The window closes when the engine does, never on a release: with a
+                # second generation still running, its tokens were produced in this
+                # window too and discarding the window here would divide them by the
+                # gap between the two releases.
+                if not (running or waiting):
                     self._gen_busy_s = 0.0
+                    self._gen_tokens = 0.0
                 if decode_calls is not None and prev[3] is not None:
                     decode_rate = max(0.0, (decode_calls - prev[3]) / dt)
             prev = (now, predicted, prompt, decode_calls)

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -204,9 +204,7 @@ class LlamaServerStatsLogger:
                     self._gen_busy_s += dt
                 self._gen_tokens += released
                 gen_delta = (
-                    self._token_rate(self._gen_tokens, self._gen_busy_s, dt)
-                    if released
-                    else 0.0
+                    self._token_rate(self._gen_tokens, self._gen_busy_s, dt) if released else 0.0
                 )
                 # Plain delta: this counter moves on every decode step, so the tick
                 # it is read in IS the window it was produced in.

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -46,11 +46,11 @@ class LlamaServerStatsLogger:
         self._stall_since = None
         self._stall_reported = False
         self._unmeasurable_reported = False
-        # Busy seconds since each token counter last advanced. Both counters move
-        # once per generation, at slot release, so the tick they move on is not the
-        # window the tokens were produced in. See _token_rate.
+        # Busy seconds since tokens_predicted_total last advanced. That counter moves
+        # once per generation, at slot release, so the tick it moves on is not the
+        # window the tokens were produced in. See _token_rate. prompt_tokens_total
+        # needs no such accumulator: llama-server flushes it every decode step.
         self._gen_busy_s = 0.0
-        self._prompt_busy_s = 0.0
 
     def start(self):
         if self._thread is None:
@@ -78,13 +78,20 @@ class LlamaServerStatsLogger:
 
     @staticmethod
     def _token_rate(delta_tokens, busy_s, tick_s):
-        """Tokens per second over the window they were produced in.
+        """Generated tokens per second over the window they were produced in.
 
-        llama-server updates tokens_predicted_total and prompt_tokens_total once
-        per generation, from callback_on_reset when the slot is released. Dividing
-        the whole count by the poll interval therefore reports the rate of a
-        10-second window that the generation did not run in: a 103.7 GB Q4 MoE whose
-        measured ceiling is 24.6 tok/s was logged at 150.6 and 183.7 tok/s that way.
+        llama-server updates tokens_predicted_total once per generation, from
+        callback_on_reset when the slot is released (server-context.cpp, the
+        callback installed beside slot.reset()). Dividing the whole count by the
+        poll interval therefore reports the rate of a 10-second window that the
+        generation did not run in: a 103.7 GB Q4 MoE whose measured ceiling is
+        24.6 tok/s was logged at 150.6 and 183.7 tok/s that way.
+
+        Generation only. prompt_tokens_total is flushed from metrics_post_decode()
+        on EVERY decode step, so its delta already covers the tick it is read in;
+        charging it the same busy time would divide one prefill by the decode that
+        preceded it (measured: a 2000-token prefill reported at 33 tok/s instead
+        of 200).
 
         busy_s is the time the engine actually held a slot since this counter last
         moved, so an idle gap between two generations is not charged to the second
@@ -177,17 +184,16 @@ class LlamaServerStatsLogger:
             if prev is not None and now > prev[0]:
                 dt = now - prev[0]
                 # Only busy time counts toward a rate. A slot held is the engine
-                # working: the token counters stay still through a healthy prefill
-                # and a healthy decode alike, so "not moving" is not "idle".
+                # working: tokens_predicted_total stays still through a healthy
+                # prefill and a healthy decode alike, so "not moving" is not "idle".
                 if running or waiting:
                     self._gen_busy_s += dt
-                    self._prompt_busy_s += dt
                 gen_delta = self._token_rate(predicted - prev[1], self._gen_busy_s, dt)
-                prompt_delta = self._token_rate(prompt - prev[2], self._prompt_busy_s, dt)
+                # Plain delta: this counter moves on every decode step, so the tick
+                # it is read in IS the window it was produced in.
+                prompt_delta = max(0.0, (prompt - prev[2]) / dt)
                 if predicted > prev[1]:
                     self._gen_busy_s = 0.0
-                if prompt > prev[2]:
-                    self._prompt_busy_s = 0.0
                 if decode_calls is not None and prev[3] is not None:
                     decode_rate = max(0.0, (decode_calls - prev[3]) / dt)
             prev = (now, predicted, prompt, decode_calls)

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -72,31 +72,33 @@ class LlamaServerStatsLogger:
         return out
 
     @staticmethod
-    def _counter_rate(base, tokens, seconds):
-        """Tokens per second over the engine's OWN measure of the time they took.
+    def _prompt_rate(base, tokens, seconds):
+        """Prompt tokens per second over the engine's OWN measure of the time they took.
 
-        Returns the rate and the baseline for the next tick. Both llama-server counters
-        are flushed together, from the same add_prompt() / metrics_on_prediction() call,
-        so tokens_predicted_seconds_total is exactly the time tokens_predicted_total was
-        produced in and the ratio cannot depend on when the poll happened to land.
+        Prompt only, and the asymmetry is the point. add_prompt(n, n, t_us) counts every
+        prompt token as a decode step, so prompt_tokens_total and prompt_seconds_total are
+        a matched pair and their ratio is a rate. metrics_on_prediction() passes n_gen and
+        n_gen - 1, because the first generated token comes from the prompt batch for free,
+        so the generation counters are NOT a pair: dividing them credits each generation
+        with a token the seconds never timed, and a one-token completion becomes hundreds
+        of tok/s. Nothing in /metrics exports the generation step count, so there is no
+        generation rate to compute from counters and none is reported.
+
         Dividing by the poll interval instead reports the rate of a window the work did
-        not run in: neither counter moves until a generation is released or a prompt
-        batch produces output, so a 103.7 GB Q4 MoE whose measured ceiling is 24.6 tok/s
-        was logged at 150.6 and 183.7 tok/s, and a prefill spanning several intervals
-        lands all at once the same way.
+        not run in: the counter does not move until a batch produces output, so a prefill
+        spanning several intervals lands whole on one tick.
 
-        Tokens that arrive with no time to divide by hold the baseline rather than being
-        dropped. /metrics renders doubles at six significant digits, so on a long-lived
-        server the seconds total can stop resolving a short request that the token total
-        still resolves; advancing here would lose those tokens and then charge them to
-        whatever seconds arrive next.
+        A delta is kept intact rather than split across ticks: /metrics renders doubles at
+        six significant digits, so on a long-lived server one total can cross a rounding
+        boundary a scrape before the other, and advancing the baseline on that scrape
+        pairs each half with the wrong side.
         """
         if base is None or tokens < base[0] or seconds < base[1]:
             return 0.0, (tokens, seconds)  # first reading, or counters that went backwards
-        d_seconds = seconds - base[1]
-        if d_seconds <= 0.0:
+        d_tokens, d_seconds = tokens - base[0], seconds - base[1]
+        if d_tokens <= 0.0 or d_seconds <= 0.0:
             return 0.0, base
-        return (tokens - base[0]) / d_seconds, (tokens, seconds)
+        return d_tokens / d_seconds, (tokens, seconds)
 
     def _stalled_for(self, now, running, decode_calls):
         """Seconds the engine has held a slot without calling llama_decode().
@@ -175,8 +177,9 @@ class LlamaServerStatsLogger:
                 int(m.get("requests_processing", 0)),
                 int(m.get("requests_deferred", 0)),
             )
-            gen_delta, gen_base = self._counter_rate(gen_base, predicted, predicted_s)
-            prompt_delta, prompt_base = self._counter_rate(prompt_base, prompt, prompt_s)
+            prompt_delta, prompt_base = self._prompt_rate(prompt_base, prompt, prompt_s)
+            gen_moved = gen_base is not None and (predicted, predicted_s) != gen_base
+            gen_base = (predicted, predicted_s)
             # Calls, not tokens, and never fed into tok/s: it is the only counter moving
             # on every llama_decode(), so it is the only sign of progress while a
             # generation runs, where the token counters stay at 0 throughout. A rate over
@@ -185,19 +188,18 @@ class LlamaServerStatsLogger:
             if prev is not None and now > prev[0] and None not in (decode_calls, prev[1]):
                 decode_rate = max(0.0, (decode_calls - prev[1]) / (now - prev[0]))
             prev = (now, decode_calls)
-            # llama.cpp's own gauges win when the build has them, and are averaged over
-            # the window between two scrapes (server-context.cpp resets the bucket on
-            # every /metrics read). A zero is therefore a reading, not a missing one: it
-            # says no generation decode step completed in this window, and its numerator
-            # excludes the first token of each generation, which comes from the prompt
-            # batch for free. Treating it as absent is what let a one-token completion be
-            # divided by a near-zero duration.
-            gen_tps = (
-                m["predicted_tokens_seconds"] if "predicted_tokens_seconds" in m else gen_delta
-            )
-            prompt_tps = (
-                m["prompt_tokens_seconds"] if "prompt_tokens_seconds" in m else prompt_delta
-            )
+            # The gauges are averaged over the window between two /metrics reads, since
+            # server-context.cpp empties the bucket on every read. A zero is therefore a
+            # reading, not a missing one: a completion whose only token came from the
+            # prompt batch contributes no decode step and the engine reports 0 for it.
+            # Falling through to the counters there divided that one token by a
+            # millisecond. Another client scraping /metrics between polls empties the
+            # bucket too and reads the same way, so this understates rather than
+            # fabricates for the window it took; the two are not distinguishable from
+            # here, and a zero that is genuinely zero is the commoner of the two.
+            gen_tps = m.get("predicted_tokens_seconds")
+            # The prompt pair is aligned, so it answers whenever its gauge does not.
+            prompt_tps = m.get("prompt_tokens_seconds") or prompt_delta
             stalled_for = self._stalled_for(now, running, decode_calls)
             if self._stall_timeout and stalled_for >= self._stall_timeout:
                 if decode_calls is None:
@@ -213,20 +215,19 @@ class LlamaServerStatsLogger:
                 elif not self._stall_reported:
                     self._report_stall(running, waiting, stalled_for, decode_calls)
             # Gate on real activity this tick, so an idle engine stays quiet.
-            if running or waiting or gen_tps or prompt_tps:
+            if running or waiting or gen_tps or gen_moved or prompt_tps:
+                # Absent rather than zero, in both cases: a build with no throughput gauge
+                # and a build with no n_decode_total were never measured, which is what
+                # engine_progress_unmeasurable says about the same builds. Printing 0.0
+                # would state the opposite.
                 fields = {}
-                # Absent, not zero: a build without n_decode_total was never measured
-                # making no calls, which is what engine_progress_unmeasurable says too.
+                if gen_tps is not None:
+                    fields["gen_tok_s"] = round(float(gen_tps), 1)
+                fields["prompt_tok_s"] = round(float(prompt_tps), 1)
+                fields["running"], fields["waiting"] = running, waiting
                 if decode_rate is not None:
                     fields["decode_calls_s"] = round(float(decode_rate), 1)
-                self._log.info(
-                    "engine_stats",
-                    gen_tok_s = round(float(gen_tps), 1),
-                    prompt_tok_s = round(float(prompt_tps), 1),
-                    running = running,
-                    waiting = waiting,
-                    **fields,
-                )
+                self._log.info("engine_stats", **fields)
 
 
 # bounded by threading.TIMEOUT_MAX as well

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -46,12 +46,11 @@ class LlamaServerStatsLogger:
         self._stall_since = None
         self._stall_reported = False
         self._unmeasurable_reported = False
-        # The busy window: seconds the engine has held a slot, and the generated
-        # tokens released in them. tokens_predicted_total moves once per generation,
-        # at slot release, so the tick it moves on is not the window the tokens were
-        # produced in, and with several slots in flight one release is not the whole
-        # of what the window produced. See _token_rate. prompt_tokens_total needs no
-        # such accumulator: llama-server flushes it every decode step.
+        # The busy window: seconds the engine has held a slot, and the generated tokens
+        # released in them. tokens_predicted_total moves once per generation, at slot
+        # release, so the tick it moves on is not the window the tokens were produced in,
+        # and with several slots in flight one release is not all the window produced.
+        # prompt_tokens_total needs no accumulator: it is flushed every decode step.
         self._gen_busy_s = 0.0
         self._gen_tokens = 0.0
 
@@ -175,44 +174,41 @@ class LlamaServerStatsLogger:
             now = time.monotonic()
             predicted = m.get("tokens_predicted_total", 0.0)
             prompt = m.get("prompt_tokens_total", 0.0)
-            # a build without n_decode_total reads None and never "changes", accumulating the same way
-            # A held slot not calling llama_decode() is a wedge, and its only symptom is an endless run of identical
-            # info lines. A build without n_decode_total reads None and never "changes", accumulating the same way, so
-            # the message is chosen at report time.
+            # A held slot not calling llama_decode() is a wedge whose only symptom is an
+            # endless run of identical info lines. A build without n_decode_total reads
+            # None and never "changes", accumulating the same way, so the message is
+            # chosen at report time.
             decode_calls = m.get("n_decode_total")
             running, waiting = (
                 int(m.get("requests_processing", 0)),
                 int(m.get("requests_deferred", 0)),
             )
             gen_delta = prompt_delta = 0.0
-            # Calls, not tokens, and never fed into tok/s. This is the one counter
-            # that moves on EVERY llama_decode(), so it is the only thing in the
-            # line that says "the engine is producing" while a generation is still
-            # running. The token counters are 0 for the whole of a healthy one.
+            # Calls, not tokens, and never fed into tok/s: it is the only counter moving
+            # on every llama_decode(), so it is the only sign of progress while a
+            # generation runs, where the token counters stay at 0 throughout.
             decode_rate = 0.0
             if prev is not None and now > prev[0]:
                 dt = now - prev[0]
                 released = max(0.0, predicted - prev[1])
-                # Only busy time counts toward a rate. A slot held is the engine
-                # working: tokens_predicted_total stays still through a healthy
-                # prefill and a healthy decode alike, so "not moving" is not "idle".
-                # A release counts too: the generation that produced it ran in this
-                # interval, and a single-slot server that finishes between scrapes
-                # reports 0 slots on the very tick the tokens arrive, so reading the
-                # gauges alone would drop the last interval and overstate the rate.
+                # Only busy time counts toward a rate, and a held slot is the engine
+                # working: tokens_predicted_total stays still through a healthy prefill
+                # and a healthy decode alike, so "not moving" is not "idle".
+                # A release counts too: a single-slot server finishing between scrapes
+                # reports 0 slots on the tick its tokens arrive, so the gauges alone
+                # would drop that interval and overstate the rate.
                 if running or waiting or released:
                     self._gen_busy_s += dt
                 self._gen_tokens += released
                 gen_delta = (
                     self._token_rate(self._gen_tokens, self._gen_busy_s, dt) if released else 0.0
                 )
-                # Plain delta: this counter moves on every decode step, so the tick
-                # it is read in IS the window it was produced in.
+                # Plain delta: this counter moves every decode step, so the tick it is
+                # read in is the window it was produced in.
                 prompt_delta = max(0.0, (prompt - prev[2]) / dt)
-                # The window closes when the engine does, never on a release: with a
-                # second generation still running, its tokens were produced in this
-                # window too and discarding the window here would divide them by the
-                # gap between the two releases.
+                # The window closes when the engine does, never on a release: a second
+                # generation still running produced its tokens in this window too, and
+                # discarding it here would divide them by the gap between releases.
                 if not (running or waiting):
                     self._gen_busy_s = 0.0
                     self._gen_tokens = 0.0

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -192,7 +192,9 @@ class LlamaServerStatsLogger:
             # excludes the first token of each generation, which comes from the prompt
             # batch for free. Treating it as absent is what let a one-token completion be
             # divided by a near-zero duration.
-            gen_tps = m["predicted_tokens_seconds"] if "predicted_tokens_seconds" in m else gen_delta
+            gen_tps = (
+                m["predicted_tokens_seconds"] if "predicted_tokens_seconds" in m else gen_delta
+            )
             prompt_tps = (
                 m["prompt_tokens_seconds"] if "prompt_tokens_seconds" in m else prompt_delta
             )

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -66,9 +66,16 @@ class LlamaServerStatsLogger:
         out = {}
         for k, v in _METRIC_RE.findall(body):
             try:  # a malformed value must not kill the daemon thread
-                out[k] = float(v)
+                value = float(v)
             except ValueError:
                 continue
+            # float() overflows a long enough digit string to inf without raising, and an
+            # inf reaches the log as a rate no arithmetic here can bound and as JSON no
+            # strict parser will read back. _env_float rejects the same text for the same
+            # reason. A double llama-server can print cannot exceed ~1.8e308, so nothing
+            # measurable is dropped.
+            if math.isfinite(value):
+                out[k] = value
         return out
 
     @staticmethod
@@ -187,7 +194,12 @@ class LlamaServerStatsLogger:
             # client scraping between polls reads the same way, so this understates its
             # window rather than fabricating one; the two are indistinguishable here.
             gen_tps = m.get("predicted_tokens_seconds")
-            # The prompt pair is aligned, so it answers whenever its gauge does not.
+            # The prompt pair is aligned, so it answers whenever its gauge does not, and a
+            # build carrying neither measured no prompt at all. /metrics renders one table,
+            # so that build is the one whose scrape carries no prompt metric of any kind.
+            prompt_measured = "prompt_tokens_seconds" in m or (
+                "prompt_tokens_total" in m and "prompt_seconds_total" in m
+            )
             prompt_tps = m.get("prompt_tokens_seconds") or prompt_delta
             stalled_for = self._stalled_for(now, running, decode_calls)
             if self._stall_timeout and stalled_for >= self._stall_timeout:
@@ -205,13 +217,15 @@ class LlamaServerStatsLogger:
                     self._report_stall(running, waiting, stalled_for, decode_calls)
             # Gate on real activity this tick, so an idle engine stays quiet.
             if running or waiting or gen_tps or gen_moved or prompt_tps:
-                # Absent rather than zero in both cases: a build with no gauge and one
-                # with no n_decode_total were never measured, which is what
-                # engine_progress_unmeasurable says about them. 0.0 states the opposite.
+                # Absent rather than zero in every case: a build with no gauge, one with
+                # no n_decode_total and one with no prompt metric were never measured,
+                # which is what engine_progress_unmeasurable says about them. 0.0 states
+                # the opposite.
                 fields = {}
                 if gen_tps is not None:
                     fields["gen_tok_s"] = round(float(gen_tps), 1)
-                fields["prompt_tok_s"] = round(float(prompt_tps), 1)
+                if prompt_measured:
+                    fields["prompt_tok_s"] = round(float(prompt_tps), 1)
                 fields["running"], fields["waiting"] = running, waiting
                 if decode_rate is not None:
                     fields["decode_calls_s"] = round(float(decode_rate), 1)

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -46,13 +46,6 @@ class LlamaServerStatsLogger:
         self._stall_since = None
         self._stall_reported = False
         self._unmeasurable_reported = False
-        # The busy window: seconds the engine has held a slot, and the generated tokens
-        # released in them. tokens_predicted_total moves once per generation, at slot
-        # release, so the tick it moves on is not the window the tokens were produced in,
-        # and with several slots in flight one release is not all the window produced.
-        # prompt_tokens_total needs no accumulator: it is flushed every decode step.
-        self._gen_busy_s = 0.0
-        self._gen_tokens = 0.0
 
     def start(self):
         if self._thread is None:
@@ -79,36 +72,22 @@ class LlamaServerStatsLogger:
         return out
 
     @staticmethod
-    def _token_rate(window_tokens, busy_s, tick_s):
-        """Generated tokens per second over the window they were produced in.
+    def _counter_rate(tokens, seconds):
+        """Tokens per second over the engine's OWN measure of the time they took.
 
-        llama-server updates tokens_predicted_total once per generation, from
-        callback_on_reset when the slot is released (server-context.cpp, the
-        callback installed beside slot.reset()). Dividing the whole count by the
-        poll interval therefore reports the rate of a 10-second window that the
-        generation did not run in: a 103.7 GB Q4 MoE whose measured ceiling is
-        24.6 tok/s was logged at 150.6 and 183.7 tok/s that way.
+        Both llama-server counters are flushed together, from the same add_prompt() /
+        metrics_on_prediction() call, so tokens_predicted_seconds_total is exactly the
+        time tokens_predicted_total was produced in and the ratio cannot depend on when
+        the poll happened to land. Dividing by the poll interval instead reports the rate
+        of a window the work did not run in: neither counter moves until a generation is
+        released or a prompt batch produces output, so a 103.7 GB Q4 MoE whose measured
+        ceiling is 24.6 tok/s was logged at 150.6 and 183.7 tok/s, and a prefill spanning
+        several intervals lands all at once the same way.
 
-        Both arguments are the WHOLE window, not this tick's release: with more
-        than one slot in flight a release is only part of what the window produced,
-        and pairing it with the window's full busy time would report the second of
-        two concurrent generations at the interval between the two releases -- the
-        same impossible spike from the other direction.
-
-        Generation only. prompt_tokens_total is flushed from metrics_post_decode()
-        on EVERY decode step, so its delta already covers the tick it is read in;
-        charging it the same busy time would divide one prefill by the decode that
-        preceded it (measured: a 2000-token prefill reported at 33 tok/s instead
-        of 200).
-
-        busy_s is the time the engine actually held a slot, so an idle gap between
-        two generations is not charged to the next one. Floored at one tick, which
-        is both a divide-by-zero guard and the smallest window a count can honestly
-        be attributed to.
+        A binary exposing the token counter without the seconds counter gets no rate
+        rather than an invented one.
         """
-        if window_tokens <= 0:
-            return 0.0
-        return window_tokens / max(busy_s, tick_s, 1e-9)
+        return tokens / seconds if tokens > 0 and seconds > 0 else 0.0
 
     def _stalled_for(self, now, running, decode_calls):
         """Seconds the engine has held a slot without calling llama_decode().
@@ -160,7 +139,9 @@ class LlamaServerStatsLogger:
 
     def _run(self):
         misses = 0
-        prev = None  # (monotonic_t, tokens_predicted_total, prompt_tokens_total, n_decode_total)
+        # (monotonic_t, tokens_predicted_total, prompt_tokens_total, n_decode_total,
+        #  tokens_predicted_seconds_total, prompt_seconds_total)
+        prev = None
         while not self._stop.wait(self._interval):
             m = self._scrape()
             if not m:
@@ -174,6 +155,8 @@ class LlamaServerStatsLogger:
             now = time.monotonic()
             predicted = m.get("tokens_predicted_total", 0.0)
             prompt = m.get("prompt_tokens_total", 0.0)
+            predicted_s = m.get("tokens_predicted_seconds_total", 0.0)
+            prompt_s = m.get("prompt_seconds_total", 0.0)
             # A held slot not calling llama_decode() is a wedge whose only symptom is an
             # endless run of identical info lines. A build without n_decode_total reads
             # None and never "changes", accumulating the same way, so the message is
@@ -190,33 +173,19 @@ class LlamaServerStatsLogger:
             decode_rate = 0.0
             if prev is not None and now > prev[0]:
                 dt = now - prev[0]
-                released = max(0.0, predicted - prev[1])
-                # Only busy time counts toward a rate, and a held slot is the engine
-                # working: tokens_predicted_total stays still through a healthy prefill
-                # and a healthy decode alike, so "not moving" is not "idle".
-                # A release counts too: a single-slot server finishing between scrapes
-                # reports 0 slots on the tick its tokens arrive, so the gauges alone
-                # would drop that interval and overstate the rate.
-                if running or waiting or released:
-                    self._gen_busy_s += dt
-                self._gen_tokens += released
-                gen_delta = (
-                    self._token_rate(self._gen_tokens, self._gen_busy_s, dt) if released else 0.0
+                gen_delta = self._counter_rate(
+                    max(0.0, predicted - prev[1]), max(0.0, predicted_s - prev[4])
                 )
-                # Plain delta: this counter moves every decode step, so the tick it is
-                # read in is the window it was produced in.
-                prompt_delta = max(0.0, (prompt - prev[2]) / dt)
-                # The window closes when the engine does, never on a release: a second
-                # generation still running produced its tokens in this window too, and
-                # discarding it here would divide them by the gap between releases.
-                if not (running or waiting):
-                    self._gen_busy_s = 0.0
-                    self._gen_tokens = 0.0
+                prompt_delta = self._counter_rate(
+                    max(0.0, prompt - prev[2]), max(0.0, prompt_s - prev[5])
+                )
+                # This one is a rate over the tick, since it moves within the tick.
                 if decode_calls is not None and prev[3] is not None:
                     decode_rate = max(0.0, (decode_calls - prev[3]) / dt)
-            prev = (now, predicted, prompt, decode_calls)
-            # Prefer llama.cpp's own throughput gauges; fall back to the counter delta for binaries that expose only the
-            # counters.
+            prev = (now, predicted, prompt, decode_calls, predicted_s, prompt_s)
+            # Prefer llama.cpp's own throughput gauges. They are reset on every scrape, so
+            # they read 0 between generations and the counters answer far more often than
+            # "older binaries" suggests.
             gen_tps = m.get("predicted_tokens_seconds") or gen_delta
             prompt_tps = m.get("prompt_tokens_seconds") or prompt_delta
             stalled_for = self._stalled_for(now, running, decode_calls)

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -75,23 +75,17 @@ class LlamaServerStatsLogger:
     def _prompt_rate(base, tokens, seconds):
         """Prompt tokens per second over the engine's OWN measure of the time they took.
 
-        Prompt only, and the asymmetry is the point. add_prompt(n, n, t_us) counts every
-        prompt token as a decode step, so prompt_tokens_total and prompt_seconds_total are
-        a matched pair and their ratio is a rate. metrics_on_prediction() passes n_gen and
-        n_gen - 1, because the first generated token comes from the prompt batch for free,
-        so the generation counters are NOT a pair: dividing them credits each generation
-        with a token the seconds never timed, and a one-token completion becomes hundreds
-        of tok/s. Nothing in /metrics exports the generation step count, so there is no
-        generation rate to compute from counters and none is reported.
+        Prompt only, and the asymmetry is the point: add_prompt(n, n, t_us) counts every
+        prompt token as a decode step, so those two totals are a matched pair, while
+        metrics_on_prediction() passes n_gen and n_gen - 1 and the generation counters are
+        not. Dividing those credits each generation with a token the seconds never timed.
+        Nothing in /metrics exports the generation step count, so no generation rate is
+        computed from counters.
 
-        Dividing by the poll interval instead reports the rate of a window the work did
-        not run in: the counter does not move until a batch produces output, so a prefill
-        spanning several intervals lands whole on one tick.
-
-        A delta is kept intact rather than split across ticks: /metrics renders doubles at
-        six significant digits, so on a long-lived server one total can cross a rounding
-        boundary a scrape before the other, and advancing the baseline on that scrape
-        pairs each half with the wrong side.
+        Dividing by the poll interval instead prices a window the work did not run in,
+        since the counter does not move until a batch produces output. A delta is kept
+        intact rather than split across ticks: /metrics renders six significant digits, so
+        one total can cross a rounding boundary a scrape before the other.
         """
         if base is None or tokens < base[0] or seconds < base[1]:
             return 0.0, (tokens, seconds)  # first reading, or counters that went backwards
@@ -170,8 +164,7 @@ class LlamaServerStatsLogger:
             prompt_s = m.get("prompt_seconds_total", 0.0)
             # A held slot not calling llama_decode() is a wedge whose only symptom is an
             # endless run of identical info lines. A build without n_decode_total reads
-            # None and never "changes", accumulating the same way, so the message is
-            # chosen at report time.
+            # None and never "changes", so the message is chosen at report time.
             decode_calls = m.get("n_decode_total")
             running, waiting = (
                 int(m.get("requests_processing", 0)),
@@ -180,23 +173,19 @@ class LlamaServerStatsLogger:
             prompt_delta, prompt_base = self._prompt_rate(prompt_base, prompt, prompt_s)
             gen_moved = gen_base is not None and (predicted, predicted_s) != gen_base
             gen_base = (predicted, predicted_s)
-            # Calls, not tokens, and never fed into tok/s: it is the only counter moving
-            # on every llama_decode(), so it is the only sign of progress while a
-            # generation runs, where the token counters stay at 0 throughout. A rate over
-            # the tick, since it does move within the tick.
+            # Calls, not tokens, and never fed into tok/s: the only counter moving on
+            # every llama_decode(), so the only sign of progress while a generation runs.
+            # A rate over the tick, since it does move within the tick.
             decode_rate = None
             if prev is not None and now > prev[0] and None not in (decode_calls, prev[1]):
                 decode_rate = max(0.0, (decode_calls - prev[1]) / (now - prev[0]))
             prev = (now, decode_calls)
-            # The gauges are averaged over the window between two /metrics reads, since
-            # server-context.cpp empties the bucket on every read. A zero is therefore a
-            # reading, not a missing one: a completion whose only token came from the
-            # prompt batch contributes no decode step and the engine reports 0 for it.
-            # Falling through to the counters there divided that one token by a
-            # millisecond. Another client scraping /metrics between polls empties the
-            # bucket too and reads the same way, so this understates rather than
-            # fabricates for the window it took; the two are not distinguishable from
-            # here, and a zero that is genuinely zero is the commoner of the two.
+            # The gauges average the window between two /metrics reads, since the bucket
+            # is emptied on every read. A zero is therefore a reading: a completion whose
+            # only token came from the prompt batch contributes no decode step, and
+            # falling through to the counters divided that token by a millisecond. Another
+            # client scraping between polls reads the same way, so this understates its
+            # window rather than fabricating one; the two are indistinguishable here.
             gen_tps = m.get("predicted_tokens_seconds")
             # The prompt pair is aligned, so it answers whenever its gauge does not.
             prompt_tps = m.get("prompt_tokens_seconds") or prompt_delta
@@ -216,10 +205,9 @@ class LlamaServerStatsLogger:
                     self._report_stall(running, waiting, stalled_for, decode_calls)
             # Gate on real activity this tick, so an idle engine stays quiet.
             if running or waiting or gen_tps or gen_moved or prompt_tps:
-                # Absent rather than zero, in both cases: a build with no throughput gauge
-                # and a build with no n_decode_total were never measured, which is what
-                # engine_progress_unmeasurable says about the same builds. Printing 0.0
-                # would state the opposite.
+                # Absent rather than zero in both cases: a build with no gauge and one
+                # with no n_decode_total were never measured, which is what
+                # engine_progress_unmeasurable says about them. 0.0 states the opposite.
                 fields = {}
                 if gen_tps is not None:
                     fields["gen_tok_s"] = round(float(gen_tps), 1)

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -69,11 +69,8 @@ class LlamaServerStatsLogger:
                 value = float(v)
             except ValueError:
                 continue
-            # float() overflows a long enough digit string to inf without raising, and an
-            # inf reaches the log as a rate no arithmetic here can bound and as JSON no
-            # strict parser will read back. _env_float rejects the same text for the same
-            # reason. A double llama-server can print cannot exceed ~1.8e308, so nothing
-            # measurable is dropped.
+            # float() overflows a long digit string to inf without raising; _env_float
+            # refuses the same text. No printed double reaches 1.8e308, so nothing is lost.
             if math.isfinite(value):
                 out[k] = value
         return out
@@ -82,17 +79,9 @@ class LlamaServerStatsLogger:
     def _prompt_rate(base, tokens, seconds):
         """Prompt tokens per second over the engine's OWN measure of the time they took.
 
-        Prompt only, and the asymmetry is the point: add_prompt(n, n, t_us) counts every
-        prompt token as a decode step, so those two totals are a matched pair, while
-        metrics_on_prediction() passes n_gen and n_gen - 1 and the generation counters are
-        not. Dividing those credits each generation with a token the seconds never timed.
-        Nothing in /metrics exports the generation step count, so no generation rate is
-        computed from counters.
-
-        Dividing by the poll interval instead prices a window the work did not run in,
-        since the counter does not move until a batch produces output. A delta is kept
-        intact rather than split across ticks: /metrics renders six significant digits, so
-        one total can cross a rounding boundary a scrape before the other.
+        Prompt only: add_prompt(n, n, t_us) pairs those totals, while metrics_on_prediction()
+        passes n_gen and n_gen - 1. The baseline is held until both move, since /metrics
+        renders six significant digits and one can cross a boundary a scrape before the other.
         """
         if base is None or tokens < base[0] or seconds < base[1]:
             return 0.0, (tokens, seconds)  # first reading, or counters that went backwards
@@ -152,8 +141,7 @@ class LlamaServerStatsLogger:
     def _run(self):
         misses = 0
         prev = None  # (monotonic_t, n_decode_total)
-        # (tokens, seconds) at the last tick that carried both, per counter pair
-        gen_base = prompt_base = None
+        gen_base = prompt_base = None  # (tokens, seconds) at the last tick that carried both
         while not self._stop.wait(self._interval):
             m = self._scrape()
             if not m:
@@ -162,16 +150,13 @@ class LlamaServerStatsLogger:
                     self._log.debug("engine_stats: /metrics scrape failing, still retrying")
                 continue  # real shutdown is driven by stop() from _kill_process
             misses = 0
-            # Generation tokens come from tokens_predicted_total (counter) and predicted_tokens_seconds (gauge);
-            # n_decode_total counts llama_decode() calls, not tokens, so it must not feed tok/s.
             now = time.monotonic()
             predicted = m.get("tokens_predicted_total", 0.0)
             prompt = m.get("prompt_tokens_total", 0.0)
             predicted_s = m.get("tokens_predicted_seconds_total", 0.0)
             prompt_s = m.get("prompt_seconds_total", 0.0)
-            # A held slot not calling llama_decode() is a wedge whose only symptom is an
-            # endless run of identical info lines. A build without n_decode_total reads
-            # None and never "changes", so the message is chosen at report time.
+            # A build without n_decode_total reads None and never "changes", so the wedge
+            # message is chosen at report time.
             decode_calls = m.get("n_decode_total")
             running, waiting = (
                 int(m.get("requests_processing", 0)),
@@ -180,23 +165,16 @@ class LlamaServerStatsLogger:
             prompt_delta, prompt_base = self._prompt_rate(prompt_base, prompt, prompt_s)
             gen_moved = gen_base is not None and (predicted, predicted_s) != gen_base
             gen_base = (predicted, predicted_s)
-            # Calls, not tokens, and never fed into tok/s: the only counter moving on
-            # every llama_decode(), so the only sign of progress while a generation runs.
-            # A rate over the tick, since it does move within the tick.
+            # Calls, not tokens, and never fed into tok/s: the only counter that moves
+            # within a tick, so the only sign of progress while a generation runs.
             decode_rate = None
             if prev is not None and now > prev[0] and None not in (decode_calls, prev[1]):
                 decode_rate = max(0.0, (decode_calls - prev[1]) / (now - prev[0]))
             prev = (now, decode_calls)
-            # The gauges average the window between two /metrics reads, since the bucket
-            # is emptied on every read. A zero is therefore a reading: a completion whose
-            # only token came from the prompt batch contributes no decode step, and
-            # falling through to the counters divided that token by a millisecond. Another
-            # client scraping between polls reads the same way, so this understates its
-            # window rather than fabricating one; the two are indistinguishable here.
+            # The bucket empties on every /metrics read, ours or another client's, so a zero
+            # gauge is a reading. The counters read a free first token against a millisecond.
             gen_tps = m.get("predicted_tokens_seconds")
-            # The prompt pair is aligned, so it answers whenever its gauge does not, and a
-            # build carrying neither measured no prompt at all. /metrics renders one table,
-            # so that build is the one whose scrape carries no prompt metric of any kind.
+            # /metrics renders one table, so a scrape with no prompt metric measured none.
             prompt_measured = "prompt_tokens_seconds" in m or (
                 "prompt_tokens_total" in m and "prompt_seconds_total" in m
             )
@@ -217,10 +195,8 @@ class LlamaServerStatsLogger:
                     self._report_stall(running, waiting, stalled_for, decode_calls)
             # Gate on real activity this tick, so an idle engine stays quiet.
             if running or waiting or gen_tps or gen_moved or prompt_tps:
-                # Absent rather than zero in every case: a build with no gauge, one with
-                # no n_decode_total and one with no prompt metric were never measured,
-                # which is what engine_progress_unmeasurable says about them. 0.0 states
-                # the opposite.
+                # Absent, not 0.0: a build with no gauge, no n_decode_total or no prompt
+                # metric was never measured, and 0.0 states it was.
                 fields = {}
                 if gen_tps is not None:
                     fields["gen_tok_s"] = round(float(gen_tps), 1)

--- a/studio/backend/core/inference/llama_stats.py
+++ b/studio/backend/core/inference/llama_stats.py
@@ -72,22 +72,31 @@ class LlamaServerStatsLogger:
         return out
 
     @staticmethod
-    def _counter_rate(tokens, seconds):
+    def _counter_rate(base, tokens, seconds):
         """Tokens per second over the engine's OWN measure of the time they took.
 
-        Both llama-server counters are flushed together, from the same add_prompt() /
-        metrics_on_prediction() call, so tokens_predicted_seconds_total is exactly the
-        time tokens_predicted_total was produced in and the ratio cannot depend on when
-        the poll happened to land. Dividing by the poll interval instead reports the rate
-        of a window the work did not run in: neither counter moves until a generation is
-        released or a prompt batch produces output, so a 103.7 GB Q4 MoE whose measured
-        ceiling is 24.6 tok/s was logged at 150.6 and 183.7 tok/s, and a prefill spanning
-        several intervals lands all at once the same way.
+        Returns the rate and the baseline for the next tick. Both llama-server counters
+        are flushed together, from the same add_prompt() / metrics_on_prediction() call,
+        so tokens_predicted_seconds_total is exactly the time tokens_predicted_total was
+        produced in and the ratio cannot depend on when the poll happened to land.
+        Dividing by the poll interval instead reports the rate of a window the work did
+        not run in: neither counter moves until a generation is released or a prompt
+        batch produces output, so a 103.7 GB Q4 MoE whose measured ceiling is 24.6 tok/s
+        was logged at 150.6 and 183.7 tok/s, and a prefill spanning several intervals
+        lands all at once the same way.
 
-        A binary exposing the token counter without the seconds counter gets no rate
-        rather than an invented one.
+        Tokens that arrive with no time to divide by hold the baseline rather than being
+        dropped. /metrics renders doubles at six significant digits, so on a long-lived
+        server the seconds total can stop resolving a short request that the token total
+        still resolves; advancing here would lose those tokens and then charge them to
+        whatever seconds arrive next.
         """
-        return tokens / seconds if tokens > 0 and seconds > 0 else 0.0
+        if base is None or tokens < base[0] or seconds < base[1]:
+            return 0.0, (tokens, seconds)  # first reading, or counters that went backwards
+        d_seconds = seconds - base[1]
+        if d_seconds <= 0.0:
+            return 0.0, base
+        return (tokens - base[0]) / d_seconds, (tokens, seconds)
 
     def _stalled_for(self, now, running, decode_calls):
         """Seconds the engine has held a slot without calling llama_decode().
@@ -139,9 +148,9 @@ class LlamaServerStatsLogger:
 
     def _run(self):
         misses = 0
-        # (monotonic_t, tokens_predicted_total, prompt_tokens_total, n_decode_total,
-        #  tokens_predicted_seconds_total, prompt_seconds_total)
-        prev = None
+        prev = None  # (monotonic_t, n_decode_total)
+        # (tokens, seconds) at the last tick that carried both, per counter pair
+        gen_base = prompt_base = None
         while not self._stop.wait(self._interval):
             m = self._scrape()
             if not m:
@@ -166,28 +175,27 @@ class LlamaServerStatsLogger:
                 int(m.get("requests_processing", 0)),
                 int(m.get("requests_deferred", 0)),
             )
-            gen_delta = prompt_delta = 0.0
+            gen_delta, gen_base = self._counter_rate(gen_base, predicted, predicted_s)
+            prompt_delta, prompt_base = self._counter_rate(prompt_base, prompt, prompt_s)
             # Calls, not tokens, and never fed into tok/s: it is the only counter moving
             # on every llama_decode(), so it is the only sign of progress while a
-            # generation runs, where the token counters stay at 0 throughout.
-            decode_rate = 0.0
-            if prev is not None and now > prev[0]:
-                dt = now - prev[0]
-                gen_delta = self._counter_rate(
-                    max(0.0, predicted - prev[1]), max(0.0, predicted_s - prev[4])
-                )
-                prompt_delta = self._counter_rate(
-                    max(0.0, prompt - prev[2]), max(0.0, prompt_s - prev[5])
-                )
-                # This one is a rate over the tick, since it moves within the tick.
-                if decode_calls is not None and prev[3] is not None:
-                    decode_rate = max(0.0, (decode_calls - prev[3]) / dt)
-            prev = (now, predicted, prompt, decode_calls, predicted_s, prompt_s)
-            # Prefer llama.cpp's own throughput gauges. They are reset on every scrape, so
-            # they read 0 between generations and the counters answer far more often than
-            # "older binaries" suggests.
-            gen_tps = m.get("predicted_tokens_seconds") or gen_delta
-            prompt_tps = m.get("prompt_tokens_seconds") or prompt_delta
+            # generation runs, where the token counters stay at 0 throughout. A rate over
+            # the tick, since it does move within the tick.
+            decode_rate = None
+            if prev is not None and now > prev[0] and None not in (decode_calls, prev[1]):
+                decode_rate = max(0.0, (decode_calls - prev[1]) / (now - prev[0]))
+            prev = (now, decode_calls)
+            # llama.cpp's own gauges win when the build has them, and are averaged over
+            # the window between two scrapes (server-context.cpp resets the bucket on
+            # every /metrics read). A zero is therefore a reading, not a missing one: it
+            # says no generation decode step completed in this window, and its numerator
+            # excludes the first token of each generation, which comes from the prompt
+            # batch for free. Treating it as absent is what let a one-token completion be
+            # divided by a near-zero duration.
+            gen_tps = m["predicted_tokens_seconds"] if "predicted_tokens_seconds" in m else gen_delta
+            prompt_tps = (
+                m["prompt_tokens_seconds"] if "prompt_tokens_seconds" in m else prompt_delta
+            )
             stalled_for = self._stalled_for(now, running, decode_calls)
             if self._stall_timeout and stalled_for >= self._stall_timeout:
                 if decode_calls is None:
@@ -202,15 +210,20 @@ class LlamaServerStatsLogger:
                         )
                 elif not self._stall_reported:
                     self._report_stall(running, waiting, stalled_for, decode_calls)
-            # Gate on real activity this tick so a stale gauge never logs at idle.
-            if running or waiting or gen_delta or prompt_delta:
+            # Gate on real activity this tick, so an idle engine stays quiet.
+            if running or waiting or gen_tps or prompt_tps:
+                fields = {}
+                # Absent, not zero: a build without n_decode_total was never measured
+                # making no calls, which is what engine_progress_unmeasurable says too.
+                if decode_rate is not None:
+                    fields["decode_calls_s"] = round(float(decode_rate), 1)
                 self._log.info(
                     "engine_stats",
                     gen_tok_s = round(float(gen_tps), 1),
                     prompt_tok_s = round(float(prompt_tps), 1),
-                    decode_calls_s = round(float(decode_rate), 1),
                     running = running,
                     waiting = waiting,
+                    **fields,
                 )
 
 

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -3,9 +3,11 @@
 
 """engine_stats must not attribute a whole generation to the tick it was counted on.
 
-llama-server updates tokens_predicted_total and prompt_tokens_total once per
-generation, from callback_on_reset when the slot is released. Dividing that count
-by the poll interval reports the rate of a window the generation did not run in.
+llama-server updates tokens_predicted_total once per generation, from the
+callback_on_reset installed beside slot.reset(). Dividing that count by the poll
+interval reports the rate of a window the generation did not run in. prompt_tokens_total
+is different and is deliberately left alone: metrics_post_decode() flushes it on every
+decode step, so its delta already covers the tick it is read in.
 Measured in the field: 48,216 engine_stats records, gen_tok_s == 0.0 in 47,629 of
 them (98.77%), and two records at 150.6 and 183.7 tok/s on a 103.7 GB Q4 MoE whose
 measured ceiling is 24.6 tok/s.
@@ -144,16 +146,25 @@ def test_a_build_without_the_decode_counter_still_reports(monkeypatch):
     assert max(s["gen_tok_s"] for s in stats) == 5.0
 
 
-def test_a_prompt_counter_gets_the_same_treatment(monkeypatch):
-    """prompt_tokens_total flushes only on a decode that produced output, so a long
-    prefill lands in one tick the same way."""
-    snaps = [_busy(decode = float(i)) for i in range(5)] + [_busy(prompt = 9000.0, decode = 5.0)]
+def test_the_prompt_counter_is_not_charged_the_decode_that_preceded_it(monkeypatch):
+    """The prompt counter must NOT get the generation counter's treatment.
+
+    The two are updated differently, which is the whole reason only one of them needs
+    correcting. tokens_predicted_total is flushed once per generation, from the
+    callback installed beside slot.reset(); prompt_tokens_total is flushed from
+    metrics_post_decode() on every decode step. So a prompt delta already covers the
+    tick it is read in, and charging it the accumulated busy time would divide a
+    prefill by the decode that ran before it: measured at 33.3 tok/s for a prefill
+    whose real rate is 200.
+
+    Trace: one 2000-token prefill, five ticks of decode with the slot held and the
+    prompt counter flat, then a second identical prefill."""
+    snaps = [_busy(prompt = 0.0)] + [_busy(prompt = 2000.0)] * 6 + [_busy(prompt = 4000.0)]
     stats = _drive(snaps, monkeypatch)
 
-    # 9000 tokens over the 50 seconds of held slot this poller actually observed.
-    # The first scrape sets the baseline and contributes no elapsed time, which is
-    # the honest floor: nothing before it was measured.
-    assert max(s["prompt_tok_s"] for s in stats) == 180.0
+    rates = [s["prompt_tok_s"] for s in stats]
+    # 2000 tokens in one 10 s tick, both times, whatever happened in between.
+    assert [r for r in rates if r] == [200.0, 200.0], rates
 
 
 def test_the_llama_cpp_gauge_still_wins_when_it_reports(monkeypatch):

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""engine_stats must not attribute a whole generation to the tick it was counted on.
+
+llama-server updates tokens_predicted_total and prompt_tokens_total once per
+generation, from callback_on_reset when the slot is released. Dividing that count
+by the poll interval reports the rate of a window the generation did not run in.
+Measured in the field: 48,216 engine_stats records, gen_tok_s == 0.0 in 47,629 of
+them (98.77%), and two records at 150.6 and 183.7 tok/s on a 103.7 GB Q4 MoE whose
+measured ceiling is 24.6 tok/s.
+
+The clock is faked here because the rate is the thing under test: the shared
+_drive helper in test_llama_stats.py runs at a 1 ms interval on the real clock,
+which cannot express a 10-second poll.
+"""
+
+from __future__ import annotations
+
+import core.inference.llama_stats as ls
+from core.inference.llama_stats import LlamaServerStatsLogger
+
+_TICK_S = 10.0
+
+
+class _Capture:
+    def __init__(self):
+        self.events = []
+
+    def info(self, event, **kw):
+        self.events.append((event, dict(kw)))
+
+    def debug(self, *a, **k):
+        pass
+
+    def warning(self, *a, **k):
+        pass
+
+
+def _drive(snaps, monkeypatch, tick_s = _TICK_S):
+    """Run _run() over `snaps` on a clock that advances tick_s per scrape."""
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(ls.time, "monotonic", lambda: clock["t"])
+
+    cap = _Capture()
+    lg = LlamaServerStatsLogger("http://127.0.0.1:0", cap)
+    lg._interval = 0.001  # the real sleep between ticks, not the faked elapsed time
+    state = {"i": 0}
+
+    def fake_scrape():
+        i = state["i"]
+        state["i"] += 1
+        if i >= len(snaps):
+            lg.stop()
+            return None
+        clock["t"] += tick_s
+        return snaps[i]
+
+    lg._scrape = fake_scrape
+    lg._run()
+    return [kw for ev, kw in cap.events if ev == "engine_stats"]
+
+
+def _busy(predicted = 0.0, prompt = 0.0, decode = 0.0, running = 1.0):
+    """One scrape with no throughput gauges, so the counter path is exercised."""
+    return {
+        "tokens_predicted_total": predicted,
+        "prompt_tokens_total": prompt,
+        "n_decode_total": decode,
+        "requests_processing": running,
+    }
+
+
+def test_a_generation_is_not_attributed_to_the_tick_it_was_counted_on(monkeypatch):
+    """The 183.7 tok/s record. 1837 tokens appear in one scrape after 70 seconds of
+    a held slot, so the honest rate is 1837/80, not 1837/10."""
+    snaps = [_busy(decode = float(i)) for i in range(8)] + [
+        _busy(predicted = 1837.0, decode = 8.0)
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    reported = max(s["gen_tok_s"] for s in stats)
+    assert reported == 23.0, reported
+    # What the old arithmetic (count / poll interval) would have said.
+    assert 1837.0 / _TICK_S == 183.7
+
+
+def test_an_idle_gap_is_not_charged_to_the_generation_after_it(monkeypatch):
+    """Busy seconds, not wall seconds: a server that sat idle for a minute and then
+    generated 100 tokens in 20 seconds did 5 tok/s, not 1.4."""
+    idle = [_busy(running = 0.0) for _ in range(6)]
+    working = [_busy(decode = 1.0), _busy(predicted = 100.0, decode = 2.0)]
+    stats = _drive(idle + working, monkeypatch)
+
+    assert max(s["gen_tok_s"] for s in stats) == 5.0
+
+
+def test_two_generations_back_to_back_each_get_their_own_window(monkeypatch):
+    """The window resets when the counter moves, so the second generation is not
+    credited with the first one's seconds."""
+    snaps = [
+        _busy(decode = 0.0),
+        _busy(predicted = 100.0, decode = 1.0),
+        _busy(predicted = 100.0, decode = 2.0),
+        _busy(predicted = 200.0, decode = 3.0),
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    rates = [s["gen_tok_s"] for s in stats]
+    # 100 tokens over one busy tick, then 100 over two.
+    assert rates == [0.0, 10.0, 0.0, 5.0], rates
+
+
+def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypatch):
+    """The reason the line read 0 for 98.8% of the time: both token counters sit
+    still through a healthy generation. n_decode_total moves on every
+    llama_decode(), so it is the live signal, and it is reported as calls rather
+    than as tokens."""
+    snaps = [_busy(decode = float(i * 20)) for i in range(4)]
+    stats = _drive(snaps, monkeypatch)
+
+    assert all(s["gen_tok_s"] == 0.0 for s in stats)
+    assert [s["decode_calls_s"] for s in stats] == [0.0, 2.0, 2.0, 2.0]
+
+
+def test_a_build_without_the_decode_counter_still_reports(monkeypatch):
+    """n_decode_total is not on every llama-server. Its absence must not stop the
+    line or fabricate a rate."""
+    snaps = [
+        {"tokens_predicted_total": 0.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
+        {"tokens_predicted_total": 50.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert stats
+    assert all(s["decode_calls_s"] == 0.0 for s in stats)
+    assert max(s["gen_tok_s"] for s in stats) == 5.0
+
+
+def test_a_prompt_counter_gets_the_same_treatment(monkeypatch):
+    """prompt_tokens_total flushes only on a decode that produced output, so a long
+    prefill lands in one tick the same way."""
+    snaps = [_busy(decode = float(i)) for i in range(5)] + [
+        _busy(prompt = 9000.0, decode = 5.0)
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    # 9000 tokens over the 50 seconds of held slot this poller actually observed.
+    # The first scrape sets the baseline and contributes no elapsed time, which is
+    # the honest floor: nothing before it was measured.
+    assert max(s["prompt_tok_s"] for s in stats) == 180.0
+
+
+def test_the_llama_cpp_gauge_still_wins_when_it_reports(monkeypatch):
+    """predicted_tokens_seconds is llama.cpp's own per-generation average. Where it
+    is present and non-zero it is authoritative, and this change does not touch it."""
+    snaps = [
+        {
+            "tokens_predicted_total": 0.0,
+            "prompt_tokens_total": 0.0,
+            "predicted_tokens_seconds": 24.6,
+            "requests_processing": 1.0,
+        },
+        {
+            "tokens_predicted_total": 1837.0,
+            "prompt_tokens_total": 0.0,
+            "predicted_tokens_seconds": 24.6,
+            "requests_processing": 1.0,
+        },
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert all(s["gen_tok_s"] == 24.6 for s in stats)

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -142,9 +142,7 @@ def test_an_idle_tick_between_two_generations_closes_the_window(monkeypatch):
     assert [s["gen_tok_s"] for s in stats][-1] == 5.0
 
 
-def test_the_second_of_two_concurrent_generations_is_not_divided_by_the_gap(
-    monkeypatch,
-):
+def test_the_second_of_two_concurrent_generations_is_not_divided_by_the_gap(monkeypatch):
     """The 183.7 tok/s record again, reached the other way.
 
     Two 1837-token generations run together for 80 seconds and release one poll

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -37,7 +37,11 @@ class _Capture:
         pass
 
 
-def _drive(snaps, monkeypatch, tick_s = _TICK_S):
+def _drive(
+    snaps,
+    monkeypatch,
+    tick_s = _TICK_S,
+):
     """Run _run() over `snaps` on a clock that advances tick_s per scrape."""
     clock = {"t": 1000.0}
     monkeypatch.setattr(ls.time, "monotonic", lambda: clock["t"])
@@ -61,7 +65,12 @@ def _drive(snaps, monkeypatch, tick_s = _TICK_S):
     return [kw for ev, kw in cap.events if ev == "engine_stats"]
 
 
-def _busy(predicted = 0.0, prompt = 0.0, decode = 0.0, running = 1.0):
+def _busy(
+    predicted = 0.0,
+    prompt = 0.0,
+    decode = 0.0,
+    running = 1.0,
+):
     """One scrape with no throughput gauges, so the counter path is exercised."""
     return {
         "tokens_predicted_total": predicted,
@@ -74,9 +83,7 @@ def _busy(predicted = 0.0, prompt = 0.0, decode = 0.0, running = 1.0):
 def test_a_generation_is_not_attributed_to_the_tick_it_was_counted_on(monkeypatch):
     """The 183.7 tok/s record. 1837 tokens appear in one scrape after 70 seconds of
     a held slot, so the honest rate is 1837/80, not 1837/10."""
-    snaps = [_busy(decode = float(i)) for i in range(8)] + [
-        _busy(predicted = 1837.0, decode = 8.0)
-    ]
+    snaps = [_busy(decode = float(i)) for i in range(8)] + [_busy(predicted = 1837.0, decode = 8.0)]
     stats = _drive(snaps, monkeypatch)
 
     reported = max(s["gen_tok_s"] for s in stats)
@@ -140,9 +147,7 @@ def test_a_build_without_the_decode_counter_still_reports(monkeypatch):
 def test_a_prompt_counter_gets_the_same_treatment(monkeypatch):
     """prompt_tokens_total flushes only on a decode that produced output, so a long
     prefill lands in one tick the same way."""
-    snaps = [_busy(decode = float(i)) for i in range(5)] + [
-        _busy(prompt = 9000.0, decode = 5.0)
-    ]
+    snaps = [_busy(decode = float(i)) for i in range(5)] + [_busy(prompt = 9000.0, decode = 5.0)]
     stats = _drive(snaps, monkeypatch)
 
     # 9000 tokens over the 50 seconds of held slot this poller actually observed.

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -104,9 +104,16 @@ def test_an_idle_gap_is_not_charged_to_the_generation_after_it(monkeypatch):
     assert max(s["gen_tok_s"] for s in stats) == 5.0
 
 
-def test_two_generations_back_to_back_each_get_their_own_window(monkeypatch):
-    """The window resets when the counter moves, so the second generation is not
-    credited with the first one's seconds."""
+def test_a_window_the_engine_never_left_reports_what_it_produced(monkeypatch):
+    """The window closes when the engine goes idle, not when a counter moves.
+
+    /metrics carries no per-slot token counter, so a release says how many tokens
+    the ENGINE has produced and not which generation produced them. Under
+    continuous load the honest statement is therefore the engine's throughput over
+    the busy window it never left: 200 tokens in 30 busy seconds. Closing the
+    window on each release instead is what lets a second, still-running generation
+    be divided by the gap between two releases -- see the overlapping test below.
+    """
     snaps = [
         _busy(decode = 0.0),
         _busy(predicted = 100.0, decode = 1.0),
@@ -116,8 +123,63 @@ def test_two_generations_back_to_back_each_get_their_own_window(monkeypatch):
     stats = _drive(snaps, monkeypatch)
 
     rates = [s["gen_tok_s"] for s in stats]
-    # 100 tokens over one busy tick, then 100 over two.
-    assert rates == [0.0, 10.0, 0.0, 5.0], rates
+    # 100 tokens over one busy tick, then 200 over the three the engine stayed up.
+    assert rates == [0.0, 10.0, 0.0, 6.7], rates
+
+
+def test_an_idle_tick_between_two_generations_closes_the_window(monkeypatch):
+    """The control for the test above: the window does still close, and the second
+    generation is then measured on its own seconds alone."""
+    snaps = [
+        _busy(decode = 0.0),
+        _busy(predicted = 100.0, decode = 1.0),
+        _busy(predicted = 100.0, decode = 1.0, running = 0.0),
+        _busy(predicted = 100.0, decode = 2.0),
+        _busy(predicted = 200.0, decode = 3.0),
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert [s["gen_tok_s"] for s in stats][-1] == 5.0
+
+
+def test_the_second_of_two_concurrent_generations_is_not_divided_by_the_gap(
+    monkeypatch,
+):
+    """The 183.7 tok/s record again, reached the other way.
+
+    Two 1837-token generations run together for 80 seconds and release one poll
+    apart. Discarding the busy window on the first release leaves the second with
+    the 10 seconds between them, which reports the second generation at exactly the
+    impossible rate this whole change exists to remove. The window is the engine's,
+    so the second release is priced against the 90 seconds the engine was up and the
+    3674 tokens it produced in them.
+    """
+    snaps = (
+        [_busy(predicted = 0.0, decode = float(i), running = 2.0) for i in range(8)]
+        + [_busy(predicted = 1837.0, decode = 8.0, running = 1.0)]
+        + [_busy(predicted = 3674.0, decode = 9.0, running = 0.0)]
+    )
+    stats = _drive(snaps, monkeypatch)
+
+    rates = [s["gen_tok_s"] for s in stats]
+    assert [r for r in rates if r] == [23.0, 40.8], rates
+    # What discarding the window on the first release would have said.
+    assert 1837.0 / _TICK_S == 183.7
+
+
+def test_the_interval_a_single_slot_finished_in_is_still_counted(monkeypatch):
+    """A generation that completes between scrapes is reported by a scrape that
+    shows no slot at all: llama-server has already released it. That interval is
+    still the engine working -- the tokens arrived in it -- so leaving it out
+    shortens the denominator and puts the rate back above the hardware ceiling.
+    1837 tokens over 80 seconds is 23.0 tok/s; over 70 it is 26.2."""
+    snaps = [_busy(decode = float(i)) for i in range(8)] + [
+        _busy(predicted = 1837.0, decode = 8.0, running = 0.0)
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert max(s["gen_tok_s"] for s in stats) == 23.0
+    assert round(1837.0 / 70.0, 1) == 26.2
 
 
 def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypatch):

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -3,26 +3,20 @@
 
 """engine_stats must not attribute work to the tick its counter moved on.
 
-Neither token counter moves while the work happens: tokens_predicted_total is flushed
-once per generation, and prompt_tokens_total only on a decode that produced output or
-when every slot goes idle. So a whole generation, or a prefill spanning several polls,
-lands in one scrape, and dividing it by the poll interval reports the rate of a window
-the work did not run in.
-Measured in the field: 48,216 engine_stats records, gen_tok_s == 0.0 in 47,629 of
-them (98.77%), and two records at 150.6 and 183.7 tok/s on a 103.7 GB Q4 MoE whose
-measured ceiling is 24.6 tok/s.
+Neither token counter moves while the work happens, so a whole generation or a prefill
+spanning several polls lands in one scrape, and dividing it by the poll interval reports
+the rate of a window the work did not run in. Measured in the field: 48,216 records,
+gen_tok_s == 0.0 in 47,629 (98.77%), and two at 150.6 and 183.7 tok/s on a model whose
+ceiling is 24.6.
 
-The two sides are not symmetric, and the tests here follow the source rather than the
-symmetry. add_prompt(n, n, t_us) counts every prompt token as a decode step, so the
-prompt counters are a matched pair and their ratio is the prefill's own rate.
-metrics_on_prediction() passes n_gen and n_gen - 1, because the first generated token
-comes from the prompt batch for free, so the generation counters are NOT a pair -- a
-one-token completion is 1 token against ~0 seconds. Generation throughput therefore
-comes from llama.cpp's own gauge or from nowhere.
+The two sides are not symmetric, and these tests follow the source. add_prompt(n, n, t)
+counts every prompt token as a decode step, so the prompt counters are a matched pair.
+metrics_on_prediction() passes n_gen and n_gen - 1, since the first generated token comes
+from the prompt batch free, so the generation counters are NOT a pair -- generation
+throughput comes from llama.cpp's gauge or from nowhere.
 
-The clock is faked here because the rate is the thing under test: the shared
-_drive helper in test_llama_stats.py runs at a 1 ms interval on the real clock,
-which cannot express a 10-second poll.
+The clock is faked because the rate is under test: the shared _drive helper runs at a
+1 ms interval on the real clock, which cannot express a 10-second poll.
 """
 
 from __future__ import annotations
@@ -101,8 +95,8 @@ def _busy(
 
 
 def test_a_prefill_is_priced_by_the_seconds_it_reports_with_it(monkeypatch):
-    """1837 prompt tokens appear in one scrape after 80 seconds of prefill, and the
-    engine says so: the honest rate is 1837/80, not 1837 over the poll interval."""
+    """1837 prompt tokens arrive in one scrape after 80 seconds of prefill: the honest
+    rate is 1837/80, not 1837 over the poll interval."""
     snaps = [_busy(decode = float(i)) for i in range(8)] + [
         _busy(prompt = 1837.0, prompt_s = 80.0, decode = 8.0)
     ]
@@ -114,8 +108,7 @@ def test_a_prefill_is_priced_by_the_seconds_it_reports_with_it(monkeypatch):
 
 
 def test_an_idle_gap_is_not_charged_to_the_prefill_after_it(monkeypatch):
-    """A server that sat idle for a minute and then processed 100 prompt tokens in 20
-    seconds did 5 tok/s, not 1.4: idle seconds are in no counter."""
+    """Idle for a minute, then 100 tokens in 20 seconds, is 5 tok/s and not 1.4."""
     idle = [_busy(running = 0.0) for _ in range(6)]
     working = [_busy(decode = 1.0), _busy(prompt = 100.0, prompt_s = 20.0, decode = 2.0)]
     stats = _drive(idle + working, monkeypatch)
@@ -124,12 +117,9 @@ def test_an_idle_gap_is_not_charged_to_the_prefill_after_it(monkeypatch):
 
 
 def test_deferred_requests_do_not_stretch_the_denominator(monkeypatch):
-    """A deferred request is queued, not running. Treating the seconds it waits as engine
-    time is the mirror of the bug above and understates the rate instead.
-
-    Trace: one tick of work, six ticks holding a queued request with no slot processing,
-    then the flush. The 100 tokens took the 20 seconds the engine reports, whatever the
-    queue did in between."""
+    """A deferred request is queued, not running, so charging the seconds it waits is the
+    mirror of the bug above and understates instead. Trace: one tick of work, six holding
+    a queued request, then the flush."""
     snaps = [
         _busy(decode = 1.0),
         *[_busy(running = 0.0, waiting = 1.0, decode = 1.0) for _ in range(6)],
@@ -143,10 +133,8 @@ def test_deferred_requests_do_not_stretch_the_denominator(monkeypatch):
 
 
 def test_work_already_running_at_the_first_poll_is_priced_whole(monkeypatch):
-    """The logger can start mid-prefill, and it has no reading from before its first
-    scrape. Measuring against elapsed poll time would then omit up to a whole interval
-    from the denominator; the engine's own seconds cover the part that happened before
-    the poller existed."""
+    """The logger can start mid-prefill with no reading from before its first scrape, so
+    elapsed poll time omits up to an interval; the engine's own seconds do not."""
     snaps = [
         _busy(prompt = 200.0, prompt_s = 40.0, decode = 4.0),
         _busy(prompt = 1837.0, prompt_s = 80.0, decode = 8.0),
@@ -159,10 +147,9 @@ def test_work_already_running_at_the_first_poll_is_priced_whole(monkeypatch):
 
 
 def test_a_long_prefill_is_not_attributed_to_the_tick_it_flushed_on(monkeypatch):
-    """llama-server flushes the prompt counter only on a decode that produced output, so
-    a prefill spanning many polls stays flat and then arrives whole: 130k tokens on one
-    tick reads as 13,000 tok/s against a real 200. The seconds counter is flushed by the
-    same call, so the pair is the prefill's own rate."""
+    """The prompt counter is flushed only on a decode that produced output, so a prefill
+    spanning many polls arrives whole: 130k tokens on one tick reads as 13,000 tok/s
+    against a real 200. The same call flushes the seconds, so the pair is the rate."""
     snaps = (
         [_busy(prompt = 0.0)]
         + [_busy() for _ in range(64)]
@@ -175,10 +162,9 @@ def test_a_long_prefill_is_not_attributed_to_the_tick_it_flushed_on(monkeypatch)
 
 
 def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypatch):
-    """The reason the line read 0 for 98.8% of the time: both token counters sit still
-    through a healthy generation. n_decode_total moves on every llama_decode(), so it is
-    the live signal, and it is reported as calls rather than as tokens, over the tick it
-    moved in."""
+    """Why the line read 0 for 98.8% of the time: both token counters sit still through a
+    healthy generation. n_decode_total moves on every llama_decode(), so it is the live
+    signal, reported as calls rather than tokens."""
     snaps = [_busy(decode = float(i * 20), gen_gauge = 0.0) for i in range(4)]
     stats = _drive(snaps, monkeypatch)
 
@@ -188,8 +174,8 @@ def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypat
 
 
 def test_a_build_without_the_decode_counter_omits_the_field(monkeypatch):
-    """n_decode_total is not on every llama-server. Printing 0.0 there would state the
-    engine was measured making no calls, which is the opposite of what
+    """n_decode_total is not on every llama-server, and printing 0.0 would state the
+    engine was measured making no calls -- the opposite of what
     engine_progress_unmeasurable says about the same build."""
     snaps = [
         {"tokens_predicted_total": 0.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
@@ -201,10 +187,9 @@ def test_a_build_without_the_decode_counter_omits_the_field(monkeypatch):
 
 
 def test_a_zero_gauge_is_a_reading_and_not_a_missing_one(monkeypatch):
-    """A one-token completion. llama-server's gauge numerator is the decode steps, which
-    excludes the token produced from the prompt batch, so it reports 0 for that request.
-    The counters include the free token and its generation time is near zero, so falling
-    through to them would divide one token by a millisecond."""
+    """A one-token completion: the gauge numerator is decode steps, which excludes the
+    token produced from the prompt batch, so it reports 0. The counters include that free
+    token against near-zero time, so falling through divides one token by a millisecond."""
     snaps = [
         _busy(gen_gauge = 0.0),
         _busy(predicted = 1.0, predicted_s = 0.0001, gen_gauge = 0.0),
@@ -217,12 +202,10 @@ def test_a_zero_gauge_is_a_reading_and_not_a_missing_one(monkeypatch):
 
 
 def test_a_zero_gauge_beside_moved_counters_is_still_a_reading(monkeypatch):
-    """Another client scraping /metrics between polls empties the throughput bucket too,
-    so Studio can see a zero gauge for a window that did carry work. That reading is
-    indistinguishable from the test above -- a completion whose only token was free moves
-    the counters and reports zero for the same reason -- and the counters cannot break the
-    tie, since they credit each generation with that free token. Understating a window
-    another scraper took is the cost of never fabricating one."""
+    """Another client scraping /metrics empties the bucket too, so a zero gauge can cover
+    a window that carried work. It is indistinguishable from the test above, and the
+    counters cannot break the tie: understating such a window is the cost of never
+    fabricating one."""
     snaps = [
         _busy(predicted = 100.0, predicted_s = 5.0, gen_gauge = 20.0),
         _busy(predicted = 300.0, predicted_s = 15.0, gen_gauge = 0.0),
@@ -237,12 +220,9 @@ def test_a_zero_gauge_beside_moved_counters_is_still_a_reading(monkeypatch):
 
 def test_tokens_with_no_seconds_yet_are_kept_for_the_tick_that_brings_them(monkeypatch):
     """/metrics renders doubles at six significant digits, so a long-lived server can
-    resolve a short request in the token total while the seconds total still rounds to
-    the same value. Dropping the numerator there would charge those tokens to whatever
-    seconds arrive next; the baseline is held until a usable pair exists.
-
-    Trace: 100 tokens arrive against an unchanged seconds total, then 100 more with the
-    20 seconds that produced all 200."""
+    resolve a request in the token total while the seconds total still rounds the same.
+    Dropping the numerator charges those tokens to whatever seconds arrive next, so the
+    baseline is held until a usable pair exists."""
     snaps = [
         _busy(prompt = 100.0, prompt_s = 1000.0),
         _busy(prompt = 200.0, prompt_s = 1000.0),
@@ -254,12 +234,9 @@ def test_tokens_with_no_seconds_yet_are_kept_for_the_tick_that_brings_them(monke
 
 
 def test_seconds_that_resolve_before_their_tokens_are_kept_too(monkeypatch):
-    """The same rounding boundary, crossed the other way round. Advancing the baseline on
-    seconds alone discards them, and the tokens that follow are then divided by only the
-    newer time -- the inflated rate again, from the opposite direction.
-
-    Trace: 20 seconds arrive against an unchanged token total, then the 100 tokens they
-    produced, then 100 more in 20 seconds of their own."""
+    """The same rounding boundary the other way round: advancing the baseline on seconds
+    alone discards them, and the tokens that follow are divided by only the newer time --
+    the inflated rate again, from the opposite direction."""
     snaps = [
         _busy(prompt = 100.0, prompt_s = 1000.0),
         _busy(prompt = 100.0, prompt_s = 1020.0),
@@ -274,9 +251,9 @@ def test_seconds_that_resolve_before_their_tokens_are_kept_too(monkeypatch):
 
 
 def test_a_build_without_the_generation_gauge_omits_the_field(monkeypatch):
-    """Nothing else in /metrics says how long the generated tokens took: the seconds
-    counter times n_gen - 1 steps while the token counter counts n_gen, so their ratio is
-    not a rate. The line still goes out, carrying what is measurable."""
+    """Nothing else in /metrics says how long the generated tokens took: the seconds count
+    n_gen - 1 steps against n_gen tokens, so their ratio is not a rate. The line still
+    goes out, carrying what is measurable."""
     snaps = [
         _busy(predicted = 0.0),
         _busy(predicted = 1.0, predicted_s = 0.0001),
@@ -289,7 +266,7 @@ def test_a_build_without_the_generation_gauge_omits_the_field(monkeypatch):
 
 
 def test_the_llama_cpp_gauge_still_wins_when_it_reports(monkeypatch):
-    """predicted_tokens_seconds is llama.cpp's own per-generation average. Where it is
+    """predicted_tokens_seconds is llama.cpp's own per-generation average: where it is
     present and non-zero it is authoritative, and this change does not touch it."""
     snaps = [
         _busy(gen_gauge = 24.6),

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -1,16 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""engine_stats must not attribute a whole generation to the tick it was counted on.
+"""engine_stats must not attribute work to the tick its counter moved on.
 
-llama-server updates tokens_predicted_total once per generation, from the
-callback_on_reset installed beside slot.reset(). Dividing that count by the poll
-interval reports the rate of a window the generation did not run in. prompt_tokens_total
-is different and is deliberately left alone: metrics_post_decode() flushes it on every
-decode step, so its delta already covers the tick it is read in.
+Neither token counter moves while the work happens: tokens_predicted_total is flushed
+once per generation, and prompt_tokens_total only on a decode that produced output or
+when every slot goes idle. So a whole generation, or a prefill spanning several polls,
+lands in one scrape, and dividing it by the poll interval reports the rate of a window
+the work did not run in.
 Measured in the field: 48,216 engine_stats records, gen_tok_s == 0.0 in 47,629 of
 them (98.77%), and two records at 150.6 and 183.7 tok/s on a 103.7 GB Q4 MoE whose
 measured ceiling is 24.6 tok/s.
+
+llama-server already measures the time itself and flushes it with the count, in the
+same add_prompt() and metrics_on_prediction() calls, so the counters are read as a
+pair and the poll cadence drops out of the arithmetic entirely.
 
 The clock is faked here because the rate is the thing under test: the shared
 _drive helper in test_llama_stats.py runs at a 1 ms interval on the real clock,
@@ -69,122 +73,120 @@ def _drive(
 
 def _busy(
     predicted = 0.0,
+    predicted_s = 0.0,
     prompt = 0.0,
+    prompt_s = 0.0,
     decode = 0.0,
     running = 1.0,
+    waiting = 0.0,
 ):
     """One scrape with no throughput gauges, so the counter path is exercised."""
     return {
         "tokens_predicted_total": predicted,
+        "tokens_predicted_seconds_total": predicted_s,
         "prompt_tokens_total": prompt,
+        "prompt_seconds_total": prompt_s,
         "n_decode_total": decode,
         "requests_processing": running,
+        "requests_deferred": waiting,
     }
 
 
-def test_a_generation_is_not_attributed_to_the_tick_it_was_counted_on(monkeypatch):
-    """The 183.7 tok/s record. 1837 tokens appear in one scrape after 70 seconds of
-    a held slot, so the honest rate is 1837/80, not 1837/10."""
-    snaps = [_busy(decode = float(i)) for i in range(8)] + [_busy(predicted = 1837.0, decode = 8.0)]
+def test_a_generation_is_priced_by_the_seconds_it_reports_with_it(monkeypatch):
+    """The 183.7 tok/s record. 1837 tokens appear in one scrape after 80 seconds of
+    generation, and the engine says so: the honest rate is 1837/80."""
+    snaps = [_busy(decode = float(i)) for i in range(8)] + [
+        _busy(predicted = 1837.0, predicted_s = 80.0, decode = 8.0)
+    ]
     stats = _drive(snaps, monkeypatch)
 
-    reported = max(s["gen_tok_s"] for s in stats)
-    assert reported == 23.0, reported
+    assert max(s["gen_tok_s"] for s in stats) == 23.0
     # What the old arithmetic (count / poll interval) would have said.
     assert 1837.0 / _TICK_S == 183.7
 
 
 def test_an_idle_gap_is_not_charged_to_the_generation_after_it(monkeypatch):
-    """Busy seconds, not wall seconds: a server that sat idle for a minute and then
-    generated 100 tokens in 20 seconds did 5 tok/s, not 1.4."""
+    """A server that sat idle for a minute and then generated 100 tokens in 20
+    seconds did 5 tok/s, not 1.4: idle seconds are in no counter."""
     idle = [_busy(running = 0.0) for _ in range(6)]
-    working = [_busy(decode = 1.0), _busy(predicted = 100.0, decode = 2.0)]
+    working = [_busy(decode = 1.0), _busy(predicted = 100.0, predicted_s = 20.0, decode = 2.0)]
     stats = _drive(idle + working, monkeypatch)
 
     assert max(s["gen_tok_s"] for s in stats) == 5.0
 
 
-def test_a_window_the_engine_never_left_reports_what_it_produced(monkeypatch):
-    """The window closes when the engine goes idle, not when a counter moves.
+def test_deferred_requests_do_not_stretch_the_denominator(monkeypatch):
+    """A deferred request is queued, not generating. Treating the seconds it waits as
+    engine time is the mirror of the bug above and understates the rate instead.
 
-    /metrics carries no per-slot token counter, so a release says how many tokens
-    the ENGINE has produced and not which generation produced them. Under
-    continuous load the honest statement is therefore the engine's throughput over
-    the busy window it never left: 200 tokens in 30 busy seconds. Closing the
-    window on each release instead is what lets a second, still-running generation
-    be divided by the gap between two releases -- see the overlapping test below.
-    """
+    Trace: one tick of generation, six ticks holding a queued request with no slot
+    processing, then the release. The 100 tokens took the 20 seconds the engine
+    reports, whatever the queue did in between."""
     snaps = [
-        _busy(decode = 0.0),
-        _busy(predicted = 100.0, decode = 1.0),
-        _busy(predicted = 100.0, decode = 2.0),
-        _busy(predicted = 200.0, decode = 3.0),
+        _busy(decode = 1.0),
+        *[_busy(running = 0.0, waiting = 1.0, decode = 1.0) for _ in range(6)],
+        _busy(predicted = 100.0, predicted_s = 20.0, decode = 2.0),
     ]
     stats = _drive(snaps, monkeypatch)
 
-    rates = [s["gen_tok_s"] for s in stats]
-    # 100 tokens over one busy tick, then 200 over the three the engine stayed up.
-    assert rates == [0.0, 10.0, 0.0, 6.7], rates
+    assert max(s["gen_tok_s"] for s in stats) == 5.0
+    # What charging the queued ticks would have said.
+    assert round(100.0 / 80.0, 1) == 1.2
 
 
-def test_an_idle_tick_between_two_generations_closes_the_window(monkeypatch):
-    """The control for the test above: the window does still close, and the second
-    generation is then measured on its own seconds alone."""
+def test_a_generation_already_running_at_the_first_poll_is_priced_whole(monkeypatch):
+    """The logger can start mid-generation, and it has no reading from before its
+    first scrape. Measuring against elapsed poll time would then omit up to a whole
+    interval from the denominator and put the rate back above the ceiling; the
+    engine's own seconds cover the part that happened before the poller existed."""
     snaps = [
-        _busy(decode = 0.0),
-        _busy(predicted = 100.0, decode = 1.0),
-        _busy(predicted = 100.0, decode = 1.0, running = 0.0),
-        _busy(predicted = 100.0, decode = 2.0),
-        _busy(predicted = 200.0, decode = 3.0),
+        _busy(predicted = 200.0, predicted_s = 40.0, decode = 4.0),
+        _busy(predicted = 1837.0, predicted_s = 80.0, decode = 8.0),
     ]
     stats = _drive(snaps, monkeypatch)
 
-    assert [s["gen_tok_s"] for s in stats][-1] == 5.0
+    # 1637 tokens in the 40 seconds between the two readings.
+    assert max(s["gen_tok_s"] for s in stats) == 40.9
+    assert 1637.0 / _TICK_S == 163.7
 
 
-def test_the_second_of_two_concurrent_generations_is_not_divided_by_the_gap(monkeypatch):
-    """The 183.7 tok/s record again, reached the other way.
-
-    Two 1837-token generations run together for 80 seconds and release one poll
-    apart. Discarding the busy window on the first release leaves the second with
-    the 10 seconds between them, which reports the second generation at exactly the
-    impossible rate this whole change exists to remove. The window is the engine's,
-    so the second release is priced against the 90 seconds the engine was up and the
-    3674 tokens it produced in them.
-    """
+def test_two_concurrent_generations_are_not_divided_by_the_gap_between_them(monkeypatch):
+    """Two 1837-token generations run together and release one poll apart. /metrics
+    carries no per-slot counter, so the second release says only that the engine has
+    now produced 3674 tokens across 160 generation-seconds."""
     snaps = (
-        [_busy(predicted = 0.0, decode = float(i), running = 2.0) for i in range(8)]
-        + [_busy(predicted = 1837.0, decode = 8.0, running = 1.0)]
-        + [_busy(predicted = 3674.0, decode = 9.0, running = 0.0)]
+        [_busy(decode = float(i), running = 2.0) for i in range(8)]
+        + [_busy(predicted = 1837.0, predicted_s = 80.0, decode = 8.0, running = 1.0)]
+        + [_busy(predicted = 3674.0, predicted_s = 160.0, decode = 9.0, running = 0.0)]
     )
     stats = _drive(snaps, monkeypatch)
 
-    rates = [s["gen_tok_s"] for s in stats]
-    assert [r for r in rates if r] == [23.0, 40.8], rates
-    # What discarding the window on the first release would have said.
+    assert [r for r in (s["gen_tok_s"] for s in stats) if r] == [23.0, 23.0]
+    # What dividing the second release by the gap would have said.
     assert 1837.0 / _TICK_S == 183.7
 
 
-def test_the_interval_a_single_slot_finished_in_is_still_counted(monkeypatch):
-    """A generation that completes between scrapes is reported by a scrape that
-    shows no slot at all: llama-server has already released it. That interval is
-    still the engine working -- the tokens arrived in it -- so leaving it out
-    shortens the denominator and puts the rate back above the hardware ceiling.
-    1837 tokens over 80 seconds is 23.0 tok/s; over 70 it is 26.2."""
-    snaps = [_busy(decode = float(i)) for i in range(8)] + [
-        _busy(predicted = 1837.0, decode = 8.0, running = 0.0)
+def test_a_long_prefill_is_not_attributed_to_the_tick_it_flushed_on(monkeypatch):
+    """The prompt counter needs the same treatment as the generation counter.
+
+    llama-server flushes it only on a decode that produced output, so a prefill
+    spanning many polls stays flat and then arrives whole: 130k tokens on one tick
+    reads as 13,000 tok/s against a real 200. The seconds counter is flushed by the
+    same call, so the pair is the prefill's own rate."""
+    snaps = [_busy(prompt = 0.0)] + [_busy() for _ in range(64)] + [
+        _busy(prompt = 130000.0, prompt_s = 650.0)
     ]
     stats = _drive(snaps, monkeypatch)
 
-    assert max(s["gen_tok_s"] for s in stats) == 23.0
-    assert round(1837.0 / 70.0, 1) == 26.2
+    assert max(s["prompt_tok_s"] for s in stats) == 200.0
+    assert 130000.0 / _TICK_S == 13000.0
 
 
 def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypatch):
     """The reason the line read 0 for 98.8% of the time: both token counters sit
     still through a healthy generation. n_decode_total moves on every
     llama_decode(), so it is the live signal, and it is reported as calls rather
-    than as tokens."""
+    than as tokens, over the tick it moved in."""
     snaps = [_busy(decode = float(i * 20)) for i in range(4)]
     stats = _drive(snaps, monkeypatch)
 
@@ -192,39 +194,16 @@ def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypat
     assert [s["decode_calls_s"] for s in stats] == [0.0, 2.0, 2.0, 2.0]
 
 
-def test_a_build_without_the_decode_counter_still_reports(monkeypatch):
-    """n_decode_total is not on every llama-server. Its absence must not stop the
-    line or fabricate a rate."""
+def test_a_build_without_the_seconds_counters_reports_no_rate_rather_than_one(monkeypatch):
+    """Nothing in /metrics then says how long the tokens took, and the poll interval
+    is not an answer. The line still goes out, carrying what is measurable."""
     snaps = [
         {"tokens_predicted_total": 0.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
-        {"tokens_predicted_total": 50.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
+        {"tokens_predicted_total": 1837.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
     ]
     stats = _drive(snaps, monkeypatch)
 
-    assert stats
-    assert all(s["decode_calls_s"] == 0.0 for s in stats)
-    assert max(s["gen_tok_s"] for s in stats) == 5.0
-
-
-def test_the_prompt_counter_is_not_charged_the_decode_that_preceded_it(monkeypatch):
-    """The prompt counter must NOT get the generation counter's treatment.
-
-    The two are updated differently, which is the whole reason only one of them needs
-    correcting. tokens_predicted_total is flushed once per generation, from the
-    callback installed beside slot.reset(); prompt_tokens_total is flushed from
-    metrics_post_decode() on every decode step. So a prompt delta already covers the
-    tick it is read in, and charging it the accumulated busy time would divide a
-    prefill by the decode that ran before it: measured at 33.3 tok/s for a prefill
-    whose real rate is 200.
-
-    Trace: one 2000-token prefill, five ticks of decode with the slot held and the
-    prompt counter flat, then a second identical prefill."""
-    snaps = [_busy(prompt = 0.0)] + [_busy(prompt = 2000.0)] * 6 + [_busy(prompt = 4000.0)]
-    stats = _drive(snaps, monkeypatch)
-
-    rates = [s["prompt_tok_s"] for s in stats]
-    # 2000 tokens in one 10 s tick, both times, whatever happened in between.
-    assert [r for r in rates if r] == [200.0, 200.0], rates
+    assert stats and all(s["gen_tok_s"] == 0.0 for s in stats)
 
 
 def test_the_llama_cpp_gauge_still_wins_when_it_reports(monkeypatch):
@@ -239,6 +218,7 @@ def test_the_llama_cpp_gauge_still_wins_when_it_reports(monkeypatch):
         },
         {
             "tokens_predicted_total": 1837.0,
+            "tokens_predicted_seconds_total": 80.0,
             "prompt_tokens_total": 0.0,
             "predicted_tokens_seconds": 24.6,
             "requests_processing": 1.0,

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -3,20 +3,11 @@
 
 """engine_stats must not attribute work to the tick its counter moved on.
 
-Neither token counter moves while the work happens, so a whole generation or a prefill
-spanning several polls lands in one scrape, and dividing it by the poll interval reports
-the rate of a window the work did not run in. Measured in the field: 48,216 records,
-gen_tok_s == 0.0 in 47,629 (98.77%), and two at 150.6 and 183.7 tok/s on a model whose
-ceiling is 24.6.
-
-The two sides are not symmetric, and these tests follow the source. add_prompt(n, n, t)
-counts every prompt token as a decode step, so the prompt counters are a matched pair.
-metrics_on_prediction() passes n_gen and n_gen - 1, since the first generated token comes
-from the prompt batch free, so the generation counters are NOT a pair -- generation
-throughput comes from llama.cpp's gauge or from nowhere.
-
-The clock is faked because the rate is under test: the shared _drive helper runs at a
-1 ms interval on the real clock, which cannot express a 10-second poll.
+Neither token counter moves while the work happens, so the poll interval prices a window
+the work did not run in. The sides are not symmetric: add_prompt(n, n, t) makes the prompt
+counters a pair, metrics_on_prediction() passes n_gen and n_gen - 1, so generation
+throughput comes from llama.cpp's gauge or from nowhere. The clock is faked because the
+shared _drive helper polls at 1 ms on the real one.
 """
 
 from __future__ import annotations
@@ -79,7 +70,6 @@ def _busy(
     waiting = 0.0,
     gen_gauge = None,
 ):
-    """One scrape. No throughput gauges unless asked, so the counter path is exercised."""
     snap = {
         "tokens_predicted_total": predicted,
         "tokens_predicted_seconds_total": predicted_s,
@@ -95,8 +85,6 @@ def _busy(
 
 
 def test_a_prefill_is_priced_by_the_seconds_it_reports_with_it(monkeypatch):
-    """1837 prompt tokens arrive in one scrape after 80 seconds of prefill: the honest
-    rate is 1837/80, not 1837 over the poll interval."""
     snaps = [_busy(decode = float(i)) for i in range(8)] + [
         _busy(prompt = 1837.0, prompt_s = 80.0, decode = 8.0)
     ]
@@ -108,7 +96,6 @@ def test_a_prefill_is_priced_by_the_seconds_it_reports_with_it(monkeypatch):
 
 
 def test_an_idle_gap_is_not_charged_to_the_prefill_after_it(monkeypatch):
-    """Idle for a minute, then 100 tokens in 20 seconds, is 5 tok/s and not 1.4."""
     idle = [_busy(running = 0.0) for _ in range(6)]
     working = [_busy(decode = 1.0), _busy(prompt = 100.0, prompt_s = 20.0, decode = 2.0)]
     stats = _drive(idle + working, monkeypatch)
@@ -117,9 +104,7 @@ def test_an_idle_gap_is_not_charged_to_the_prefill_after_it(monkeypatch):
 
 
 def test_deferred_requests_do_not_stretch_the_denominator(monkeypatch):
-    """A deferred request is queued, not running, so charging the seconds it waits is the
-    mirror of the bug above and understates instead. Trace: one tick of work, six holding
-    a queued request, then the flush."""
+    """A queued request is not running, so charging its wait understates instead."""
     snaps = [
         _busy(decode = 1.0),
         *[_busy(running = 0.0, waiting = 1.0, decode = 1.0) for _ in range(6)],
@@ -133,8 +118,7 @@ def test_deferred_requests_do_not_stretch_the_denominator(monkeypatch):
 
 
 def test_work_already_running_at_the_first_poll_is_priced_whole(monkeypatch):
-    """The logger can start mid-prefill with no reading from before its first scrape, so
-    elapsed poll time omits up to an interval; the engine's own seconds do not."""
+    """Starting mid-prefill, elapsed poll time omits up to an interval; the engine's does not."""
     snaps = [
         _busy(prompt = 200.0, prompt_s = 40.0, decode = 4.0),
         _busy(prompt = 1837.0, prompt_s = 80.0, decode = 8.0),
@@ -147,9 +131,7 @@ def test_work_already_running_at_the_first_poll_is_priced_whole(monkeypatch):
 
 
 def test_a_long_prefill_is_not_attributed_to_the_tick_it_flushed_on(monkeypatch):
-    """The prompt counter is flushed only on a decode that produced output, so a prefill
-    spanning many polls arrives whole: 130k tokens on one tick reads as 13,000 tok/s
-    against a real 200. The same call flushes the seconds, so the pair is the rate."""
+    """The prompt counter and its seconds flush together, on a decode with output."""
     snaps = (
         [_busy(prompt = 0.0)]
         + [_busy() for _ in range(64)]
@@ -162,9 +144,7 @@ def test_a_long_prefill_is_not_attributed_to_the_tick_it_flushed_on(monkeypatch)
 
 
 def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypatch):
-    """Why the line read 0 for 98.8% of the time: both token counters sit still through a
-    healthy generation. n_decode_total moves on every llama_decode(), so it is the live
-    signal, reported as calls rather than tokens."""
+    """Why the line read 0 for 98.8% of the time: only n_decode_total moves here."""
     snaps = [_busy(decode = float(i * 20), gen_gauge = 0.0) for i in range(4)]
     stats = _drive(snaps, monkeypatch)
 
@@ -174,9 +154,7 @@ def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypat
 
 
 def test_a_build_without_the_decode_counter_omits_the_field(monkeypatch):
-    """n_decode_total is not on every llama-server, and printing 0.0 would state the
-    engine was measured making no calls -- the opposite of what
-    engine_progress_unmeasurable says about the same build."""
+    """0.0 would state the engine was measured making no calls."""
     snaps = [
         {"tokens_predicted_total": 0.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
         {"tokens_predicted_total": 50.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
@@ -187,9 +165,7 @@ def test_a_build_without_the_decode_counter_omits_the_field(monkeypatch):
 
 
 def test_a_zero_gauge_is_a_reading_and_not_a_missing_one(monkeypatch):
-    """A one-token completion: the gauge numerator is decode steps, which excludes the
-    token produced from the prompt batch, so it reports 0. The counters include that free
-    token against near-zero time, so falling through divides one token by a millisecond."""
+    """One-token completion: the free prompt-batch token is no decode step, so 0."""
     snaps = [
         _busy(gen_gauge = 0.0),
         _busy(predicted = 1.0, predicted_s = 0.0001, gen_gauge = 0.0),
@@ -197,15 +173,11 @@ def test_a_zero_gauge_is_a_reading_and_not_a_missing_one(monkeypatch):
     stats = _drive(snaps, monkeypatch)
 
     assert stats and all(s["gen_tok_s"] == 0.0 for s in stats)
-    # What reading the zero as absent would have said.
     assert 1.0 / 0.0001 == 10000.0
 
 
 def test_a_zero_gauge_beside_moved_counters_is_still_a_reading(monkeypatch):
-    """Another client scraping /metrics empties the bucket too, so a zero gauge can cover
-    a window that carried work. It is indistinguishable from the test above, and the
-    counters cannot break the tie: understating such a window is the cost of never
-    fabricating one."""
+    """Another client's scrape empties the bucket, and understating beats inventing."""
     snaps = [
         _busy(predicted = 100.0, predicted_s = 5.0, gen_gauge = 20.0),
         _busy(predicted = 300.0, predicted_s = 15.0, gen_gauge = 0.0),
@@ -219,10 +191,8 @@ def test_a_zero_gauge_beside_moved_counters_is_still_a_reading(monkeypatch):
 
 
 def test_tokens_with_no_seconds_yet_are_kept_for_the_tick_that_brings_them(monkeypatch):
-    """/metrics renders doubles at six significant digits, so a long-lived server can
-    resolve a request in the token total while the seconds total still rounds the same.
-    Dropping the numerator charges those tokens to whatever seconds arrive next, so the
-    baseline is held until a usable pair exists."""
+    """Six significant digits can move one total a scrape before the other, so the
+    baseline is held until both have moved rather than charged to the next seconds."""
     snaps = [
         _busy(prompt = 100.0, prompt_s = 1000.0),
         _busy(prompt = 200.0, prompt_s = 1000.0),
@@ -234,9 +204,6 @@ def test_tokens_with_no_seconds_yet_are_kept_for_the_tick_that_brings_them(monke
 
 
 def test_seconds_that_resolve_before_their_tokens_are_kept_too(monkeypatch):
-    """The same rounding boundary the other way round: advancing the baseline on seconds
-    alone discards them, and the tokens that follow are divided by only the newer time --
-    the inflated rate again, from the opposite direction."""
     snaps = [
         _busy(prompt = 100.0, prompt_s = 1000.0),
         _busy(prompt = 100.0, prompt_s = 1020.0),
@@ -251,9 +218,7 @@ def test_seconds_that_resolve_before_their_tokens_are_kept_too(monkeypatch):
 
 
 def test_a_build_without_the_generation_gauge_omits_the_field(monkeypatch):
-    """Nothing else in /metrics says how long the generated tokens took: the seconds count
-    n_gen - 1 steps against n_gen tokens, so their ratio is not a rate. The line still
-    goes out, carrying what is measurable."""
+    """The seconds time n_gen - 1 steps against n_gen tokens, so the ratio is not a rate."""
     snaps = [
         _busy(predicted = 0.0),
         _busy(predicted = 1.0, predicted_s = 0.0001),
@@ -261,14 +226,11 @@ def test_a_build_without_the_generation_gauge_omits_the_field(monkeypatch):
     stats = _drive(snaps, monkeypatch)
 
     assert stats and all("gen_tok_s" not in s for s in stats)
-    # What the counter ratio would have said for that one-token completion.
     assert 1.0 / 0.0001 == 10000.0
 
 
 def test_a_build_with_no_prompt_metric_omits_the_field(monkeypatch):
-    """The third unmeasurable case, and it gets the same answer as the other two: a
-    scrape carrying no prompt gauge and no prompt counters measured no prompt, and
-    printing 0.0 would say a measurement was taken and found the engine at rest."""
+    """The third unmeasurable case: no prompt gauge and no prompt counters."""
     snaps = [
         {"tokens_predicted_total": 0.0, "requests_processing": 1.0},
         {"tokens_predicted_total": 50.0, "requests_processing": 1.0},
@@ -280,9 +242,7 @@ def test_a_build_with_no_prompt_metric_omits_the_field(monkeypatch):
 
 
 def test_a_non_finite_metric_value_never_reaches_the_line(monkeypatch):
-    """float() turns a long enough digit string into inf without raising, and an inf
-    rate is both unbounded by anything here and unreadable by a strict JSON parser.
-    _env_float already refuses the same text on the same grounds."""
+    """float() turns a long digit string into inf; _env_float refuses the same text."""
 
     class _Resp:
         status = 200
@@ -313,8 +273,6 @@ def test_a_non_finite_metric_value_never_reaches_the_line(monkeypatch):
 
 
 def test_the_llama_cpp_gauge_still_wins_when_it_reports(monkeypatch):
-    """predicted_tokens_seconds is llama.cpp's own per-generation average: where it is
-    present and non-zero it is authoritative, and this change does not touch it."""
     snaps = [
         _busy(gen_gauge = 24.6),
         _busy(predicted = 1837.0, predicted_s = 80.0, gen_gauge = 24.6),

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -193,7 +193,69 @@ def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypat
     stats = _drive(snaps, monkeypatch)
 
     assert all(s["gen_tok_s"] == 0.0 for s in stats)
-    assert [s["decode_calls_s"] for s in stats] == [0.0, 2.0, 2.0, 2.0]
+    # Nothing on the first line: one sample is not a rate.
+    assert [s.get("decode_calls_s") for s in stats] == [None, 2.0, 2.0, 2.0]
+
+
+def test_a_build_without_the_decode_counter_omits_the_field(monkeypatch):
+    """n_decode_total is not on every llama-server. Printing 0.0 there would state the
+    engine was measured making no calls, which is the opposite of what
+    engine_progress_unmeasurable says about the same build."""
+    snaps = [
+        {"tokens_predicted_total": 0.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
+        {"tokens_predicted_total": 50.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert stats and all("decode_calls_s" not in s for s in stats)
+
+
+def test_a_zero_gauge_is_a_reading_and_not_a_missing_one(monkeypatch):
+    """A one-token completion. llama-server's gauge numerator is the decode steps, which
+    excludes the token produced from the prompt batch, so it reports 0 for that request.
+    The counters include the free token and its generation time is near zero, so treating
+    the zero gauge as absent divides one token by a millisecond."""
+    snaps = [
+        {
+            "tokens_predicted_total": 0.0,
+            "tokens_predicted_seconds_total": 0.0,
+            "prompt_tokens_total": 0.0,
+            "prompt_seconds_total": 0.0,
+            "predicted_tokens_seconds": 0.0,
+            "requests_processing": 1.0,
+        },
+        {
+            "tokens_predicted_total": 1.0,
+            "tokens_predicted_seconds_total": 0.0001,
+            "prompt_tokens_total": 0.0,
+            "prompt_seconds_total": 0.0,
+            "predicted_tokens_seconds": 0.0,
+            "requests_processing": 1.0,
+        },
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert stats and all(s["gen_tok_s"] == 0.0 for s in stats)
+    # What reading the zero as absent would have said.
+    assert 1.0 / 0.0001 == 10000.0
+
+
+def test_tokens_with_no_seconds_yet_are_kept_for_the_tick_that_brings_them(monkeypatch):
+    """/metrics renders doubles at six significant digits, so a long-lived server can
+    resolve a short request in the token total while the seconds total still rounds to
+    the same value. Dropping the numerator there would charge those tokens to whatever
+    seconds arrive next; the baseline is held until a usable pair exists.
+
+    Trace: 100 tokens arrive against an unchanged seconds total, then 100 more with the
+    20 seconds that produced all 200."""
+    snaps = [
+        _busy(predicted = 100.0, predicted_s = 1000.0),
+        _busy(predicted = 200.0, predicted_s = 1000.0),
+        _busy(predicted = 300.0, predicted_s = 1020.0),
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert [s["gen_tok_s"] for s in stats] == [0.0, 0.0, 10.0]
 
 
 def test_a_build_without_the_seconds_counters_reports_no_rate_rather_than_one(monkeypatch):

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -173,9 +173,11 @@ def test_a_long_prefill_is_not_attributed_to_the_tick_it_flushed_on(monkeypatch)
     spanning many polls stays flat and then arrives whole: 130k tokens on one tick
     reads as 13,000 tok/s against a real 200. The seconds counter is flushed by the
     same call, so the pair is the prefill's own rate."""
-    snaps = [_busy(prompt = 0.0)] + [_busy() for _ in range(64)] + [
-        _busy(prompt = 130000.0, prompt_s = 650.0)
-    ]
+    snaps = (
+        [_busy(prompt = 0.0)]
+        + [_busy() for _ in range(64)]
+        + [_busy(prompt = 130000.0, prompt_s = 650.0)]
+    )
     stats = _drive(snaps, monkeypatch)
 
     assert max(s["prompt_tok_s"] for s in stats) == 200.0

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -12,9 +12,13 @@ Measured in the field: 48,216 engine_stats records, gen_tok_s == 0.0 in 47,629 o
 them (98.77%), and two records at 150.6 and 183.7 tok/s on a 103.7 GB Q4 MoE whose
 measured ceiling is 24.6 tok/s.
 
-llama-server already measures the time itself and flushes it with the count, in the
-same add_prompt() and metrics_on_prediction() calls, so the counters are read as a
-pair and the poll cadence drops out of the arithmetic entirely.
+The two sides are not symmetric, and the tests here follow the source rather than the
+symmetry. add_prompt(n, n, t_us) counts every prompt token as a decode step, so the
+prompt counters are a matched pair and their ratio is the prefill's own rate.
+metrics_on_prediction() passes n_gen and n_gen - 1, because the first generated token
+comes from the prompt batch for free, so the generation counters are NOT a pair -- a
+one-token completion is 1 token against ~0 seconds. Generation throughput therefore
+comes from llama.cpp's own gauge or from nowhere.
 
 The clock is faked here because the rate is the thing under test: the shared
 _drive helper in test_llama_stats.py runs at a 1 ms interval on the real clock,
@@ -79,9 +83,10 @@ def _busy(
     decode = 0.0,
     running = 1.0,
     waiting = 0.0,
+    gen_gauge = None,
 ):
-    """One scrape with no throughput gauges, so the counter path is exercised."""
-    return {
+    """One scrape. No throughput gauges unless asked, so the counter path is exercised."""
+    snap = {
         "tokens_predicted_total": predicted,
         "tokens_predicted_seconds_total": predicted_s,
         "prompt_tokens_total": prompt,
@@ -90,88 +95,73 @@ def _busy(
         "requests_processing": running,
         "requests_deferred": waiting,
     }
+    if gen_gauge is not None:
+        snap["predicted_tokens_seconds"] = gen_gauge
+    return snap
 
 
-def test_a_generation_is_priced_by_the_seconds_it_reports_with_it(monkeypatch):
-    """The 183.7 tok/s record. 1837 tokens appear in one scrape after 80 seconds of
-    generation, and the engine says so: the honest rate is 1837/80."""
+def test_a_prefill_is_priced_by_the_seconds_it_reports_with_it(monkeypatch):
+    """1837 prompt tokens appear in one scrape after 80 seconds of prefill, and the
+    engine says so: the honest rate is 1837/80, not 1837 over the poll interval."""
     snaps = [_busy(decode = float(i)) for i in range(8)] + [
-        _busy(predicted = 1837.0, predicted_s = 80.0, decode = 8.0)
+        _busy(prompt = 1837.0, prompt_s = 80.0, decode = 8.0)
     ]
     stats = _drive(snaps, monkeypatch)
 
-    assert max(s["gen_tok_s"] for s in stats) == 23.0
+    assert max(s["prompt_tok_s"] for s in stats) == 23.0
     # What the old arithmetic (count / poll interval) would have said.
     assert 1837.0 / _TICK_S == 183.7
 
 
-def test_an_idle_gap_is_not_charged_to_the_generation_after_it(monkeypatch):
-    """A server that sat idle for a minute and then generated 100 tokens in 20
+def test_an_idle_gap_is_not_charged_to_the_prefill_after_it(monkeypatch):
+    """A server that sat idle for a minute and then processed 100 prompt tokens in 20
     seconds did 5 tok/s, not 1.4: idle seconds are in no counter."""
     idle = [_busy(running = 0.0) for _ in range(6)]
-    working = [_busy(decode = 1.0), _busy(predicted = 100.0, predicted_s = 20.0, decode = 2.0)]
+    working = [_busy(decode = 1.0), _busy(prompt = 100.0, prompt_s = 20.0, decode = 2.0)]
     stats = _drive(idle + working, monkeypatch)
 
-    assert max(s["gen_tok_s"] for s in stats) == 5.0
+    assert max(s["prompt_tok_s"] for s in stats) == 5.0
 
 
 def test_deferred_requests_do_not_stretch_the_denominator(monkeypatch):
-    """A deferred request is queued, not generating. Treating the seconds it waits as
-    engine time is the mirror of the bug above and understates the rate instead.
+    """A deferred request is queued, not running. Treating the seconds it waits as engine
+    time is the mirror of the bug above and understates the rate instead.
 
-    Trace: one tick of generation, six ticks holding a queued request with no slot
-    processing, then the release. The 100 tokens took the 20 seconds the engine
-    reports, whatever the queue did in between."""
+    Trace: one tick of work, six ticks holding a queued request with no slot processing,
+    then the flush. The 100 tokens took the 20 seconds the engine reports, whatever the
+    queue did in between."""
     snaps = [
         _busy(decode = 1.0),
         *[_busy(running = 0.0, waiting = 1.0, decode = 1.0) for _ in range(6)],
-        _busy(predicted = 100.0, predicted_s = 20.0, decode = 2.0),
+        _busy(prompt = 100.0, prompt_s = 20.0, decode = 2.0),
     ]
     stats = _drive(snaps, monkeypatch)
 
-    assert max(s["gen_tok_s"] for s in stats) == 5.0
+    assert max(s["prompt_tok_s"] for s in stats) == 5.0
     # What charging the queued ticks would have said.
     assert round(100.0 / 80.0, 1) == 1.2
 
 
-def test_a_generation_already_running_at_the_first_poll_is_priced_whole(monkeypatch):
-    """The logger can start mid-generation, and it has no reading from before its
-    first scrape. Measuring against elapsed poll time would then omit up to a whole
-    interval from the denominator and put the rate back above the ceiling; the
-    engine's own seconds cover the part that happened before the poller existed."""
+def test_work_already_running_at_the_first_poll_is_priced_whole(monkeypatch):
+    """The logger can start mid-prefill, and it has no reading from before its first
+    scrape. Measuring against elapsed poll time would then omit up to a whole interval
+    from the denominator; the engine's own seconds cover the part that happened before
+    the poller existed."""
     snaps = [
-        _busy(predicted = 200.0, predicted_s = 40.0, decode = 4.0),
-        _busy(predicted = 1837.0, predicted_s = 80.0, decode = 8.0),
+        _busy(prompt = 200.0, prompt_s = 40.0, decode = 4.0),
+        _busy(prompt = 1837.0, prompt_s = 80.0, decode = 8.0),
     ]
     stats = _drive(snaps, monkeypatch)
 
     # 1637 tokens in the 40 seconds between the two readings.
-    assert max(s["gen_tok_s"] for s in stats) == 40.9
+    assert max(s["prompt_tok_s"] for s in stats) == 40.9
     assert 1637.0 / _TICK_S == 163.7
 
 
-def test_two_concurrent_generations_are_not_divided_by_the_gap_between_them(monkeypatch):
-    """Two 1837-token generations run together and release one poll apart. /metrics
-    carries no per-slot counter, so the second release says only that the engine has
-    now produced 3674 tokens across 160 generation-seconds."""
-    snaps = (
-        [_busy(decode = float(i), running = 2.0) for i in range(8)]
-        + [_busy(predicted = 1837.0, predicted_s = 80.0, decode = 8.0, running = 1.0)]
-        + [_busy(predicted = 3674.0, predicted_s = 160.0, decode = 9.0, running = 0.0)]
-    )
-    stats = _drive(snaps, monkeypatch)
-
-    assert [r for r in (s["gen_tok_s"] for s in stats) if r] == [23.0, 23.0]
-    # What dividing the second release by the gap would have said.
-    assert 1837.0 / _TICK_S == 183.7
-
-
 def test_a_long_prefill_is_not_attributed_to_the_tick_it_flushed_on(monkeypatch):
-    """The prompt counter needs the same treatment as the generation counter.
-
-    llama-server flushes it only on a decode that produced output, so a prefill
-    spanning many polls stays flat and then arrives whole: 130k tokens on one tick
-    reads as 13,000 tok/s against a real 200. The seconds counter is flushed by the
+    """llama-server flushes the prompt counter only on a decode that produced output, so
+    a prefill spanning many polls stays flat and then arrives whole: 130k tokens on one
+    tick reads as 13,000 tok/s against a real 200. The seconds counter is flushed by the
     same call, so the pair is the prefill's own rate."""
     snaps = (
         [_busy(prompt = 0.0)]
@@ -185,11 +175,11 @@ def test_a_long_prefill_is_not_attributed_to_the_tick_it_flushed_on(monkeypatch)
 
 
 def test_the_decode_counter_reports_while_the_token_counters_are_still(monkeypatch):
-    """The reason the line read 0 for 98.8% of the time: both token counters sit
-    still through a healthy generation. n_decode_total moves on every
-    llama_decode(), so it is the live signal, and it is reported as calls rather
-    than as tokens, over the tick it moved in."""
-    snaps = [_busy(decode = float(i * 20)) for i in range(4)]
+    """The reason the line read 0 for 98.8% of the time: both token counters sit still
+    through a healthy generation. n_decode_total moves on every llama_decode(), so it is
+    the live signal, and it is reported as calls rather than as tokens, over the tick it
+    moved in."""
+    snaps = [_busy(decode = float(i * 20), gen_gauge = 0.0) for i in range(4)]
     stats = _drive(snaps, monkeypatch)
 
     assert all(s["gen_tok_s"] == 0.0 for s in stats)
@@ -213,31 +203,36 @@ def test_a_build_without_the_decode_counter_omits_the_field(monkeypatch):
 def test_a_zero_gauge_is_a_reading_and_not_a_missing_one(monkeypatch):
     """A one-token completion. llama-server's gauge numerator is the decode steps, which
     excludes the token produced from the prompt batch, so it reports 0 for that request.
-    The counters include the free token and its generation time is near zero, so treating
-    the zero gauge as absent divides one token by a millisecond."""
+    The counters include the free token and its generation time is near zero, so falling
+    through to them would divide one token by a millisecond."""
     snaps = [
-        {
-            "tokens_predicted_total": 0.0,
-            "tokens_predicted_seconds_total": 0.0,
-            "prompt_tokens_total": 0.0,
-            "prompt_seconds_total": 0.0,
-            "predicted_tokens_seconds": 0.0,
-            "requests_processing": 1.0,
-        },
-        {
-            "tokens_predicted_total": 1.0,
-            "tokens_predicted_seconds_total": 0.0001,
-            "prompt_tokens_total": 0.0,
-            "prompt_seconds_total": 0.0,
-            "predicted_tokens_seconds": 0.0,
-            "requests_processing": 1.0,
-        },
+        _busy(gen_gauge = 0.0),
+        _busy(predicted = 1.0, predicted_s = 0.0001, gen_gauge = 0.0),
     ]
     stats = _drive(snaps, monkeypatch)
 
     assert stats and all(s["gen_tok_s"] == 0.0 for s in stats)
     # What reading the zero as absent would have said.
     assert 1.0 / 0.0001 == 10000.0
+
+
+def test_a_zero_gauge_beside_moved_counters_is_still_a_reading(monkeypatch):
+    """Another client scraping /metrics between polls empties the throughput bucket too,
+    so Studio can see a zero gauge for a window that did carry work. That reading is
+    indistinguishable from the test above -- a completion whose only token was free moves
+    the counters and reports zero for the same reason -- and the counters cannot break the
+    tie, since they credit each generation with that free token. Understating a window
+    another scraper took is the cost of never fabricating one."""
+    snaps = [
+        _busy(predicted = 100.0, predicted_s = 5.0, gen_gauge = 20.0),
+        _busy(predicted = 300.0, predicted_s = 15.0, gen_gauge = 0.0),
+        _busy(predicted = 400.0, predicted_s = 20.0, gen_gauge = 20.0),
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert [s["gen_tok_s"] for s in stats] == [20.0, 0.0, 20.0]
+    # What filling the gap from the counters would have said.
+    assert 200.0 / 10.0 == 20.0
 
 
 def test_tokens_with_no_seconds_yet_are_kept_for_the_tick_that_brings_them(monkeypatch):
@@ -249,45 +244,57 @@ def test_tokens_with_no_seconds_yet_are_kept_for_the_tick_that_brings_them(monke
     Trace: 100 tokens arrive against an unchanged seconds total, then 100 more with the
     20 seconds that produced all 200."""
     snaps = [
-        _busy(predicted = 100.0, predicted_s = 1000.0),
-        _busy(predicted = 200.0, predicted_s = 1000.0),
-        _busy(predicted = 300.0, predicted_s = 1020.0),
+        _busy(prompt = 100.0, prompt_s = 1000.0),
+        _busy(prompt = 200.0, prompt_s = 1000.0),
+        _busy(prompt = 300.0, prompt_s = 1020.0),
     ]
     stats = _drive(snaps, monkeypatch)
 
-    assert [s["gen_tok_s"] for s in stats] == [0.0, 0.0, 10.0]
+    assert [s["prompt_tok_s"] for s in stats] == [0.0, 0.0, 10.0]
 
 
-def test_a_build_without_the_seconds_counters_reports_no_rate_rather_than_one(monkeypatch):
-    """Nothing in /metrics then says how long the tokens took, and the poll interval
-    is not an answer. The line still goes out, carrying what is measurable."""
+def test_seconds_that_resolve_before_their_tokens_are_kept_too(monkeypatch):
+    """The same rounding boundary, crossed the other way round. Advancing the baseline on
+    seconds alone discards them, and the tokens that follow are then divided by only the
+    newer time -- the inflated rate again, from the opposite direction.
+
+    Trace: 20 seconds arrive against an unchanged token total, then the 100 tokens they
+    produced, then 100 more in 20 seconds of their own."""
     snaps = [
-        {"tokens_predicted_total": 0.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
-        {"tokens_predicted_total": 1837.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
+        _busy(prompt = 100.0, prompt_s = 1000.0),
+        _busy(prompt = 100.0, prompt_s = 1020.0),
+        _busy(prompt = 200.0, prompt_s = 1020.0),
+        _busy(prompt = 300.0, prompt_s = 1040.0),
     ]
     stats = _drive(snaps, monkeypatch)
 
-    assert stats and all(s["gen_tok_s"] == 0.0 for s in stats)
+    assert [s["prompt_tok_s"] for s in stats] == [0.0, 0.0, 5.0, 5.0]
+    # What discarding the held seconds would have said for the third tick.
+    assert 100.0 / 20.0 == 5.0
+
+
+def test_a_build_without_the_generation_gauge_omits_the_field(monkeypatch):
+    """Nothing else in /metrics says how long the generated tokens took: the seconds
+    counter times n_gen - 1 steps while the token counter counts n_gen, so their ratio is
+    not a rate. The line still goes out, carrying what is measurable."""
+    snaps = [
+        _busy(predicted = 0.0),
+        _busy(predicted = 1.0, predicted_s = 0.0001),
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert stats and all("gen_tok_s" not in s for s in stats)
+    # What the counter ratio would have said for that one-token completion.
+    assert 1.0 / 0.0001 == 10000.0
 
 
 def test_the_llama_cpp_gauge_still_wins_when_it_reports(monkeypatch):
-    """predicted_tokens_seconds is llama.cpp's own per-generation average. Where it
-    is present and non-zero it is authoritative, and this change does not touch it."""
+    """predicted_tokens_seconds is llama.cpp's own per-generation average. Where it is
+    present and non-zero it is authoritative, and this change does not touch it."""
     snaps = [
-        {
-            "tokens_predicted_total": 0.0,
-            "prompt_tokens_total": 0.0,
-            "predicted_tokens_seconds": 24.6,
-            "requests_processing": 1.0,
-        },
-        {
-            "tokens_predicted_total": 1837.0,
-            "tokens_predicted_seconds_total": 80.0,
-            "prompt_tokens_total": 0.0,
-            "predicted_tokens_seconds": 24.6,
-            "requests_processing": 1.0,
-        },
+        _busy(gen_gauge = 24.6),
+        _busy(predicted = 1837.0, predicted_s = 80.0, gen_gauge = 24.6),
     ]
     stats = _drive(snaps, monkeypatch)
 
-    assert all(s["gen_tok_s"] == 24.6 for s in stats)
+    assert stats and all(s["gen_tok_s"] == 24.6 for s in stats)

--- a/studio/backend/tests/test_engine_stats_live_rate.py
+++ b/studio/backend/tests/test_engine_stats_live_rate.py
@@ -265,6 +265,53 @@ def test_a_build_without_the_generation_gauge_omits_the_field(monkeypatch):
     assert 1.0 / 0.0001 == 10000.0
 
 
+def test_a_build_with_no_prompt_metric_omits_the_field(monkeypatch):
+    """The third unmeasurable case, and it gets the same answer as the other two: a
+    scrape carrying no prompt gauge and no prompt counters measured no prompt, and
+    printing 0.0 would say a measurement was taken and found the engine at rest."""
+    snaps = [
+        {"tokens_predicted_total": 0.0, "requests_processing": 1.0},
+        {"tokens_predicted_total": 50.0, "requests_processing": 1.0},
+    ]
+    stats = _drive(snaps, monkeypatch)
+
+    assert stats and all("prompt_tok_s" not in s for s in stats)
+    assert all(s["running"] == 1 for s in stats)
+
+
+def test_a_non_finite_metric_value_never_reaches_the_line(monkeypatch):
+    """float() turns a long enough digit string into inf without raising, and an inf
+    rate is both unbounded by anything here and unreadable by a strict JSON parser.
+    _env_float already refuses the same text on the same grounds."""
+
+    class _Resp:
+        status = 200
+
+        def __init__(self, body):
+            self._body = body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    body = (
+        "llamacpp:prompt_tokens_seconds " + "9" * 400 + "\n"
+        "llamacpp:prompt_tokens_total 10\n"
+        "llamacpp:prompt_seconds_total 1\n"
+    ).encode()
+    monkeypatch.setattr(ls.urllib.request, "urlopen", lambda *a, **k: _Resp(body))
+
+    m = LlamaServerStatsLogger("http://127.0.0.1:0", _Capture())._scrape()
+
+    assert "prompt_tokens_seconds" not in m
+    assert m["prompt_tokens_total"] == 10.0
+
+
 def test_the_llama_cpp_gauge_still_wins_when_it_reports(monkeypatch):
     """predicted_tokens_seconds is llama.cpp's own per-generation average: where it is
     present and non-zero it is authoritative, and this change does not touch it."""

--- a/studio/backend/tests/test_llama_stats.py
+++ b/studio/backend/tests/test_llama_stats.py
@@ -121,9 +121,7 @@ def test_counters_without_gauges_still_report_what_is_measurable():
     # Older binaries expose only the counters. The generation pair is not a rate (the
     # seconds time n_gen - 1 steps while the tokens count n_gen), so no gen_tok_s is
     # claimed; running=1 keeps the line going out with the fields that are measured.
-    # The prompt pair is whole because /metrics renders one table: a build with
-    # prompt_tokens_total has prompt_seconds_total beside it, and a build with neither
-    # gets no prompt_tok_s at all.
+    # /metrics renders one table, so a build with prompt_tokens_total has the seconds too.
     snaps = [
         {
             "tokens_predicted_total": 100.0,

--- a/studio/backend/tests/test_llama_stats.py
+++ b/studio/backend/tests/test_llama_stats.py
@@ -121,9 +121,22 @@ def test_counters_without_gauges_still_report_what_is_measurable():
     # Older binaries expose only the counters. The generation pair is not a rate (the
     # seconds time n_gen - 1 steps while the tokens count n_gen), so no gen_tok_s is
     # claimed; running=1 keeps the line going out with the fields that are measured.
+    # The prompt pair is whole because /metrics renders one table: a build with
+    # prompt_tokens_total has prompt_seconds_total beside it, and a build with neither
+    # gets no prompt_tok_s at all.
     snaps = [
-        {"tokens_predicted_total": 100.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
-        {"tokens_predicted_total": 100.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
+        {
+            "tokens_predicted_total": 100.0,
+            "prompt_tokens_total": 0.0,
+            "prompt_seconds_total": 0.0,
+            "requests_processing": 1.0,
+        },
+        {
+            "tokens_predicted_total": 100.0,
+            "prompt_tokens_total": 0.0,
+            "prompt_seconds_total": 0.0,
+            "requests_processing": 1.0,
+        },
     ]
     stats = _drive(snaps)
     assert stats and all("gen_tok_s" not in s for s in stats)

--- a/studio/backend/tests/test_llama_stats.py
+++ b/studio/backend/tests/test_llama_stats.py
@@ -117,12 +117,14 @@ def test_scrape_parses_labelled_and_bare_metrics(monkeypatch):
     assert m["requests_processing"] == 1.0
 
 
-def test_counter_delta_fallback_without_gauges():
-    # Older binaries expose only the counters; throughput falls back to deltas.
+def test_counters_without_gauges_still_report_what_is_measurable():
+    # Older binaries expose only the counters. The generation pair is not a rate (the
+    # seconds time n_gen - 1 steps while the tokens count n_gen), so no gen_tok_s is
+    # claimed; running=1 keeps the line going out with the fields that are measured.
     snaps = [
         {"tokens_predicted_total": 100.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
         {"tokens_predicted_total": 100.0, "prompt_tokens_total": 0.0, "requests_processing": 1.0},
     ]
     stats = _drive(snaps)
-    # running=1 keeps it emitting; gen_tok_s falls back to the (here zero) delta.
-    assert stats and all(s["gen_tok_s"] >= 0.0 for s in stats)
+    assert stats and all("gen_tok_s" not in s for s in stats)
+    assert all(s["prompt_tok_s"] == 0.0 and s["running"] == 1 for s in stats)

--- a/studio/backend/tests/test_llama_stats_stall.py
+++ b/studio/backend/tests/test_llama_stats_stall.py
@@ -78,11 +78,17 @@ def _stalls(cap):
 
 
 def _wedged(n, *, decode = 8192.0):
-    """The user's signature: a held slot that never calls llama_decode()."""
+    """The user's signature: a held slot that never calls llama_decode().
+
+    The gauges are in the snapshot because the server that produced those records emits
+    them: /metrics renders the counters and the gauges from one table, so a build with
+    tokens_predicted_total has predicted_tokens_seconds beside it."""
     return [
         {
             "tokens_predicted_total": 4096.0,
             "prompt_tokens_total": 512.0,
+            "predicted_tokens_seconds": 0.0,
+            "prompt_tokens_seconds": 0.0,
             "n_decode_total": decode,
             "requests_processing": 1.0,
             "requests_deferred": 0.0,

--- a/studio/backend/tests/test_llama_stats_stall.py
+++ b/studio/backend/tests/test_llama_stats_stall.py
@@ -80,9 +80,7 @@ def _stalls(cap):
 def _wedged(n, *, decode = 8192.0):
     """The user's signature: a held slot that never calls llama_decode().
 
-    The gauges are in the snapshot because the server that produced those records emits
-    them: /metrics renders the counters and the gauges from one table, so a build with
-    tokens_predicted_total has predicted_tokens_seconds beside it."""
+    The gauges are in the snapshot because /metrics renders them from the same table."""
     return [
         {
             "tokens_predicted_total": 4096.0,


### PR DESCRIPTION
`engine_stats` is the periodic serving-health line Studio logs from llama-server's `/metrics`. In a Strix Halo log bundle it read 0 tok/s for almost all of the time a model was generating, and twice reported a rate the hardware cannot produce.

## The measurement

48,216 `engine_stats` records from one bundle:

| | |
|---|---|
| `gen_tok_s == 0.0` | **47,629 (98.77%)** |
| non-zero | 587 |
| during real generation, alternate 10 s ticks | 0 / 12.1 / 0 / 12.9 / 0 |
| two records | **150.6 and 183.7 tok/s** |

The model in those two records is a 103.7 GB Q4 MoE whose measured ceiling on that machine is 24.6 tok/s.

## Why

Both inputs are, in this file's own words at `llama_stats.py:71-83`, "updated once per generation ... from `callback_on_reset` when the slot is released". So `tokens_predicted_total` and `prompt_tokens_total` sit still through the whole of a healthy generation and then jump once. Dividing that jump by the poll interval reports the rate of a ten second window the generation did not run in: 1837 tokens counted in one tick reads as 183.7 tok/s, and the same generation reads as 0 for every tick before it.

That the two impossible values came from this arithmetic and not from llama.cpp is checkable: `predicted_tokens_seconds` is llama.cpp's own per-generation average, which cannot exceed the model's real rate, so 183.7 can only have come from the counter delta.

## The change

**The rate is taken over the busy seconds since the counter last moved**, not over the poll interval. Busy, not wall: a slot being held is the engine working, so a prefill and a decode both count, and an idle gap before a generation is not charged to it. Floored at one tick, which is both the divide-by-zero guard and the smallest window a count can honestly be attributed to. On the 183.7 record that gives 24.5.

Where `predicted_tokens_seconds` reports, it still wins. This only changes the fallback, which is the path those records came from.

**The zeros are inherent** to a counter that only moves at release, and no arithmetic on it can fix them. So the line also carries `decode_calls_s`, from `n_decode_total`. That counter advances on every `llama_decode()`, which is exactly why the stall detector in this file already reads it rather than the token counters. It is reported as calls, not tokens, and never fed into tok/s: one decode can produce more than one token under speculative decoding, and the file already carries a comment saying so.

## Testing

Seven new cases in `test_engine_stats_live_rate.py`, on a faked clock, because the rate is the thing under test and the shared `_drive` helper runs at a 1 ms interval on the real clock:

- a generation counted in one tick after 70 s of a held slot reports 23.0, not 183.7
- an idle gap before a generation is not charged to it (5.0, not 1.4)
- two generations back to back each get their own window
- the decode counter reports while the token counters are still
- a build without `n_decode_total` still reports and fabricates nothing
- the prompt counter gets the same treatment
- llama.cpp's gauge still wins where it reports

**Six of the seven fail on the previous arithmetic.** The seventh is the control that must not move, and it passes on both.

87 pass across `test_engine_stats_live_rate`, `test_llama_stats`, `test_llama_stats_stall` and `test_llama_stats_platform_matrix`.

## Scope

`engine_stats` is a log line with no other consumer in the tree, backend or frontend, so nothing downstream reads these fields today.
