### PR TITLE
Give `unsloth studio update` the same uv cache the backend already uses

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -21,6 +21,9 @@ function Install-UnslothStudio {
     $script:StudioUvMarkerSaved = $false
     $script:StudioUvMarkerExisted = $false
     $script:StudioUvMarkerPrevious = $null
+    # One flag for both rollbacks: clearing them separately leaves a window either way
+    # round, where an interruption restores one half of a committed install.
+    $script:StudioInstallCommitted = $false
 
     # The user's PowerShell profile has already run by the time this does, and the documented
     # piped web entry point documented in the README has no script file to re-launch
@@ -1260,7 +1263,11 @@ public static class UnslothStudioFinalPathV2
             # Under "Stop", Test-Path inside an ACL-denied directory throws.
             $existing = Test-Path -LiteralPath $markerFile -ErrorAction SilentlyContinue
             if ($existing) {
-                $previous = Get-Content -LiteralPath $markerFile -Raw -ErrorAction SilentlyContinue
+                # UTF8, not the default: Windows PowerShell 5.1 decodes a BOM-less file
+                # with the active ANSI code page, and the update writes this one BOM-less
+                # UTF-8, so a non-ASCII path came back as mojibake and was restored that way.
+                $previous = Get-Content -LiteralPath $markerFile -Raw -Encoding UTF8 `
+                    -ErrorAction SilentlyContinue
                 # One we cannot read is one we cannot put back, so leave it alone.
                 if ($null -eq $previous) { return }
                 $script:StudioUvMarkerPrevious = $previous
@@ -1290,6 +1297,7 @@ public static class UnslothStudioFinalPathV2
         # AllowEmptyString and the blank guard: a throw here would be reported as a
         # failed environment restore.
         param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$StudioRoot)
+        if ($script:StudioInstallCommitted) { return }
         if (-not $script:StudioUvMarkerSaved) { return }
         if ([string]::IsNullOrWhiteSpace($StudioRoot)) { return }
         $markerFile = Join-Path (Join-Path $StudioRoot "cache") "uv-cache-dir"
@@ -1311,6 +1319,15 @@ public static class UnslothStudioFinalPathV2
         $studioCache = Join-Path (Join-Path $StudioRoot "cache") "uv"
         if (-not [string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
             $script:StudioUvCacheMode = "custom"
+            # Absolute before anything uses it, so every phase of one install and the
+            # marker name the same directory (see _absolutize_uv_cache_dir in install.sh).
+            if (-not [System.IO.Path]::IsPathRooted($env:UV_CACHE_DIR)) {
+                try {
+                    $env:UV_CACHE_DIR = [System.IO.Path]::GetFullPath(
+                        (Join-Path $PWD.Path $env:UV_CACHE_DIR)
+                    )
+                } catch { }
+            }
             # Recorded like any other choice; a caller still outranks the marker.
             Write-StudioUvCacheMarker -StudioRoot $StudioRoot -Cache $env:UV_CACHE_DIR
             step "uv cache" "preserving custom UV_CACHE_DIR ($env:UV_CACHE_DIR)"
@@ -4297,6 +4314,9 @@ exit 0
     }
 
     function Restore-StudioVenvRollback {
+        # The same flag the marker restore consults, so an interruption mid-commit cannot
+        # put one half of a committed install back and keep the other.
+        if ($script:StudioInstallCommitted) { return }
         if (-not $script:StudioVenvRollbackActive) { return }
         $backup = $script:StudioVenvRollbackDir
         $target = $script:StudioVenvRollbackTarget
@@ -4348,7 +4368,10 @@ exit 0
     }
 
     function Complete-StudioVenvRollback {
-        # Above the early return: a first install rolls nothing back and still commits.
+        # First and alone: this one assignment is what both restores consult, so an
+        # interruption cannot find them disagreeing. A first install rolls nothing back
+        # and still commits.
+        $script:StudioInstallCommitted = $true
         $script:StudioUvMarkerSaved = $false
         if (-not $script:StudioVenvRollbackActive) { return }
         $backup = $script:StudioVenvRollbackDir

--- a/install.ps1
+++ b/install.ps1
@@ -1237,6 +1237,25 @@ public static class UnslothStudioFinalPathV2
     # Records which cache this install used, so an update reuses it rather than guessing:
     # Set-StudioUvCacheForLaunch repoints the backend at the Studio cache even in shared
     # mode, so one on-demand install makes an empty Studio cache look full. Never fatal.
+    # uv resolves a relative cache-dir against its working directory, which UV_WORKING_DIR
+    # moves and which may itself be relative to where the installer was run. $PWD.Path
+    # explicitly: GetFullPath resolves against the .NET process directory, which
+    # Set-Location does not move. Mirrors _absolutize_uv_cache_dir in install.sh.
+    function Resolve-StudioUvCachePath {
+        param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Cache)
+        if ([string]::IsNullOrEmpty($Cache) -or [System.IO.Path]::IsPathRooted($Cache)) {
+            return $Cache
+        }
+        try {
+            $base = if (-not [string]::IsNullOrWhiteSpace($env:UV_WORKING_DIR)) {
+                if ([System.IO.Path]::IsPathRooted($env:UV_WORKING_DIR)) {
+                    $env:UV_WORKING_DIR
+                } else { Join-Path $PWD.Path $env:UV_WORKING_DIR }
+            } else { $PWD.Path }
+            return [System.IO.Path]::GetFullPath((Join-Path $base $Cache))
+        } catch { return $Cache }
+    }
+
     function Write-StudioUvCacheMarker {
         param(
             [Parameter(Mandatory = $true)][string]$StudioRoot,
@@ -1244,20 +1263,8 @@ public static class UnslothStudioFinalPathV2
         )
         $markerDir = Join-Path $StudioRoot "cache"
         $markerFile = Join-Path $markerDir "uv-cache-dir"
-        # Absolute: the update resolves this against ITS working directory. $PWD is
-        # explicit because GetFullPath uses the unmoved .NET process directory.
-        try {
-            if (-not [System.IO.Path]::IsPathRooted($Cache)) {
-                $base = if (-not [string]::IsNullOrWhiteSpace($env:UV_WORKING_DIR)) {
-                    # May itself be relative, against the installer's own directory.
-                    if ([System.IO.Path]::IsPathRooted($env:UV_WORKING_DIR)) {
-                        $env:UV_WORKING_DIR
-                    } else { Join-Path $PWD.Path $env:UV_WORKING_DIR }
-                } else { $PWD.Path }
-                $Cache = Join-Path $base $Cache
-            }
-            $Cache = [System.IO.Path]::GetFullPath($Cache)
-        } catch { }
+        # Absolute: the update resolves this against ITS working directory.
+        $Cache = Resolve-StudioUvCachePath -Cache $Cache
         # Remembered so a rollback can put it back.
         if (-not $script:StudioUvMarkerSaved) {
             # Under "Stop", Test-Path inside an ACL-denied directory throws.
@@ -1321,13 +1328,7 @@ public static class UnslothStudioFinalPathV2
             $script:StudioUvCacheMode = "custom"
             # Absolute before anything uses it, so every phase of one install and the
             # marker name the same directory (see _absolutize_uv_cache_dir in install.sh).
-            if (-not [System.IO.Path]::IsPathRooted($env:UV_CACHE_DIR)) {
-                try {
-                    $env:UV_CACHE_DIR = [System.IO.Path]::GetFullPath(
-                        (Join-Path $PWD.Path $env:UV_CACHE_DIR)
-                    )
-                } catch { }
-            }
+            $env:UV_CACHE_DIR = Resolve-StudioUvCachePath -Cache $env:UV_CACHE_DIR
             # Recorded like any other choice; a caller still outranks the marker.
             Write-StudioUvCacheMarker -StudioRoot $StudioRoot -Cache $env:UV_CACHE_DIR
             step "uv cache" "preserving custom UV_CACHE_DIR ($env:UV_CACHE_DIR)"

--- a/install.ps1
+++ b/install.ps1
@@ -16,6 +16,12 @@
 function Install-UnslothStudio {
     $ErrorActionPreference = "Stop"
 
+    # First: Exit-InstallFailure restores the marker long before the selection runs, and
+    # under `irm | iex` the script scope is the caller's session.
+    $script:StudioUvMarkerSaved = $false
+    $script:StudioUvMarkerExisted = $false
+    $script:StudioUvMarkerPrevious = $null
+
     # The user's PowerShell profile has already run by the time this does, and the documented
     # piped web entry point documented in the README has no script file to re-launch
     # with -NoProfile, so each way a profile can reach in here is cut individually below.
@@ -317,6 +323,10 @@ function Install-UnslothStudio {
         Remove-Item Env:UNSLOTH_KEPT_TORCH -ErrorAction SilentlyContinue
         if (Get-Command Restore-StudioVenvRollback -CommandType Function -ErrorAction SilentlyContinue) {
             Restore-StudioVenvRollback
+        }
+        # Separate from the venv rollback: an install can fail before one is in flight.
+        if (Get-Command Restore-StudioUvCacheMarker -CommandType Function -ErrorAction SilentlyContinue) {
+            Restore-StudioUvCacheMarker -StudioRoot $StudioHome
         }
         # Most failures return before the lock try/finally, and under `irm | iex`
         # these variables are the caller's own. Defined later, so probed like above.
@@ -1221,6 +1231,77 @@ public static class UnslothStudioFinalPathV2
     }
     $VenvDir = Join-Path $StudioHome "unsloth_studio"
 
+    # Records which cache this install used, so an update reuses it rather than guessing:
+    # Set-StudioUvCacheForLaunch repoints the backend at the Studio cache even in shared
+    # mode, so one on-demand install makes an empty Studio cache look full. Never fatal.
+    function Write-StudioUvCacheMarker {
+        param(
+            [Parameter(Mandatory = $true)][string]$StudioRoot,
+            [Parameter(Mandatory = $true)][string]$Cache
+        )
+        $markerDir = Join-Path $StudioRoot "cache"
+        $markerFile = Join-Path $markerDir "uv-cache-dir"
+        # Absolute: the update resolves this against ITS working directory. $PWD is
+        # explicit because GetFullPath uses the unmoved .NET process directory.
+        try {
+            if (-not [System.IO.Path]::IsPathRooted($Cache)) {
+                $base = if (-not [string]::IsNullOrWhiteSpace($env:UV_WORKING_DIR)) {
+                    # May itself be relative, against the installer's own directory.
+                    if ([System.IO.Path]::IsPathRooted($env:UV_WORKING_DIR)) {
+                        $env:UV_WORKING_DIR
+                    } else { Join-Path $PWD.Path $env:UV_WORKING_DIR }
+                } else { $PWD.Path }
+                $Cache = Join-Path $base $Cache
+            }
+            $Cache = [System.IO.Path]::GetFullPath($Cache)
+        } catch { }
+        # Remembered so a rollback can put it back.
+        if (-not $script:StudioUvMarkerSaved) {
+            # Under "Stop", Test-Path inside an ACL-denied directory throws.
+            $existing = Test-Path -LiteralPath $markerFile -ErrorAction SilentlyContinue
+            if ($existing) {
+                $previous = Get-Content -LiteralPath $markerFile -Raw -ErrorAction SilentlyContinue
+                # One we cannot read is one we cannot put back, so leave it alone.
+                if ($null -eq $previous) { return }
+                $script:StudioUvMarkerPrevious = $previous
+                $script:StudioUvMarkerExisted = $true
+            } else {
+                $script:StudioUvMarkerPrevious = $null
+                $script:StudioUvMarkerExisted = $false
+            }
+            $script:StudioUvMarkerSaved = $true
+        }
+        # CreateDirectory, not New-Item -Path: -Path treats [] in the root as a wildcard.
+        if (-not (Test-Path -LiteralPath $markerDir -PathType Container -ErrorAction SilentlyContinue)) {
+            try { [System.IO.Directory]::CreateDirectory($markerDir) | Out-Null } catch { }
+        }
+        # Removed first: Set-Content follows a symlink and would truncate its target.
+        Remove-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue
+        # And only once gone, since that removal fails non-terminatingly. Get-Item -Force
+        # reports the link itself; Test-Path would follow it.
+        if ($null -ne (Get-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue)) {
+            return
+        }
+        Set-Content -LiteralPath $markerFile -Value $Cache `
+            -Encoding utf8 -ErrorAction SilentlyContinue
+    }
+
+    function Restore-StudioUvCacheMarker {
+        # AllowEmptyString and the blank guard: a throw here would be reported as a
+        # failed environment restore.
+        param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$StudioRoot)
+        if (-not $script:StudioUvMarkerSaved) { return }
+        if ([string]::IsNullOrWhiteSpace($StudioRoot)) { return }
+        $markerFile = Join-Path (Join-Path $StudioRoot "cache") "uv-cache-dir"
+        Remove-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue
+        $stillThere = $null -ne (Get-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue)
+        if (-not $stillThere -and $script:StudioUvMarkerExisted -and $null -ne $script:StudioUvMarkerPrevious) {
+            Set-Content -LiteralPath $markerFile -Value ([string]$script:StudioUvMarkerPrevious).TrimEnd("`r", "`n") `
+                -Encoding utf8 -ErrorAction SilentlyContinue
+        }
+        $script:StudioUvMarkerSaved = $false
+    }
+
     function Set-StudioUvCacheEnvironment {
         param(
             [Parameter(Mandatory = $true)][string]$StudioRoot,
@@ -1230,6 +1311,8 @@ public static class UnslothStudioFinalPathV2
         $studioCache = Join-Path (Join-Path $StudioRoot "cache") "uv"
         if (-not [string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
             $script:StudioUvCacheMode = "custom"
+            # Recorded like any other choice; a caller still outranks the marker.
+            Write-StudioUvCacheMarker -StudioRoot $StudioRoot -Cache $env:UV_CACHE_DIR
             step "uv cache" "preserving custom UV_CACHE_DIR ($env:UV_CACHE_DIR)"
             return
         }
@@ -1299,6 +1382,7 @@ public static class UnslothStudioFinalPathV2
             }
         }
         Set-Item -LiteralPath Env:UV_CACHE_DIR -Value $selectedCache
+        Write-StudioUvCacheMarker -StudioRoot $StudioRoot -Cache $selectedCache
 
         switch ($script:StudioUvCacheMode) {
             "shared" {
@@ -4264,6 +4348,8 @@ exit 0
     }
 
     function Complete-StudioVenvRollback {
+        # Above the early return: a first install rolls nothing back and still commits.
+        $script:StudioUvMarkerSaved = $false
         if (-not $script:StudioVenvRollbackActive) { return }
         $backup = $script:StudioVenvRollbackDir
         # The replacement is committed. Disable restoration before deleting the
@@ -6573,6 +6659,7 @@ sys.exit(2 if conflict else (0 if installed else 1))
     } finally {
         if (-not $studioVenvReplacementCommitted) {
             Restore-StudioVenvRollback
+            Restore-StudioUvCacheMarker -StudioRoot $StudioHome
         }
     }
 

--- a/install.sh
+++ b/install.sh
@@ -787,8 +787,8 @@ _VENV_ROLLBACK_ACTIVE=false
 _UV_MARKER_SAVED=false
 _UV_MARKER_EXISTED=false
 _UV_MARKER_PREVIOUS=""
-# One flag for both rollbacks. Clearing them separately leaves a window either way round:
-# a signal between the two restores one half of a committed install and reverts the other.
+# One flag for both rollbacks: two leave a window either way round, where a signal
+# restores half a committed install.
 _STUDIO_INSTALL_COMMITTED=false
 
 _start_studio_venv_replacement() {
@@ -861,8 +861,7 @@ _discard_venv_for_recreate() {  # venv dir
 }
 
 _restore_studio_venv_replacement() {
-    # The same flag the marker restore consults, so a signal landing mid-commit cannot
-    # put one half of a committed install back and keep the other.
+    # The flag the marker restore consults too, so a signal mid-commit cannot split them.
     [ "${_STUDIO_INSTALL_COMMITTED:-false}" = true ] && return 0
     [ "$_VENV_ROLLBACK_ACTIVE" = true ] || return 0
     # -e/-L, not -d: a rollback holds whatever _dir_has_entries called occupied,
@@ -925,9 +924,8 @@ _prune_stale_studio_venv_rollbacks() {
 }
 
 _commit_studio_venv_replacement() {
-    # First and alone, because a signal can land between any two statements: this one
-    # assignment is what both restores consult, so they cannot disagree about whether
-    # this install committed. A first install rolls nothing back and still commits.
+    # First and alone, because a signal can land between any two statements. A first
+    # install rolls nothing back and still commits.
     _STUDIO_INSTALL_COMMITTED=true
     _UV_MARKER_SAVED=false
     if [ "$_VENV_ROLLBACK_ACTIVE" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -619,12 +619,67 @@ _resolve_studio_destinations() {
     _STUDIO_HOME_REDIRECT=default
 }
 
+# Records which cache this install used, so an update reuses it rather than guessing: the
+# launch below repoints the backend at the Studio cache even in shared mode, so one
+# on-demand install makes an empty Studio cache look full. Never fatal.
+_record_uv_cache_choice() {
+    _uv_marker_dir="$STUDIO_HOME/cache"
+    _uv_marker_file="$_uv_marker_dir/uv-cache-dir"
+    # Absolute: the update resolves this against ITS working directory, and the base is
+    # uv's, which --directory / UV_WORKING_DIR moves.
+    case "$UV_CACHE_DIR" in
+        /*) _uv_marker_value="$UV_CACHE_DIR" ;;
+        *)
+            # Which may itself be relative, against the installer's own directory.
+            _uv_marker_base="${UV_WORKING_DIR:-$PWD}"
+            case "$_uv_marker_base" in
+                /*) ;;
+                *) _uv_marker_base="$PWD/$_uv_marker_base" ;;
+            esac
+            _uv_marker_value="$_uv_marker_base/$UV_CACHE_DIR"
+            ;;
+    esac
+    # Remembered so a failed install can put it back.
+    if [ "$_UV_MARKER_SAVED" != true ]; then
+        if [ -e "$_uv_marker_file" ] || [ -L "$_uv_marker_file" ]; then
+            # One we cannot read is one we cannot put back, so leave it alone.
+            _UV_MARKER_PREVIOUS=$(cat "$_uv_marker_file" 2>/dev/null) || return 0
+            _UV_MARKER_EXISTED=true
+        else
+            _UV_MARKER_PREVIOUS=""
+            _UV_MARKER_EXISTED=false
+        fi
+        _UV_MARKER_SAVED=true
+    fi
+    (
+        mkdir -p "$_uv_marker_dir" 2>/dev/null &&
+            # Unlinked first: a redirection follows a symlink and truncates its target.
+            rm -f "$_uv_marker_file" 2>/dev/null &&
+            # And only once gone: rm can fail on a link in an undeletable directory.
+            ! { [ -e "$_uv_marker_file" ] || [ -L "$_uv_marker_file" ]; } &&
+            printf '%s\n' "$_uv_marker_value" > "$_uv_marker_file" 2>/dev/null
+    ) || true
+}
+
+_restore_uv_cache_marker() {
+    [ "$_UV_MARKER_SAVED" = true ] || return 0
+    _uv_marker_file="$STUDIO_HOME/cache/uv-cache-dir"
+    rm -f "$_uv_marker_file" 2>/dev/null || true
+    if [ "$_UV_MARKER_EXISTED" = true ] \
+       && ! { [ -e "$_uv_marker_file" ] || [ -L "$_uv_marker_file" ]; }; then
+        printf '%s\n' "$_UV_MARKER_PREVIOUS" > "$_uv_marker_file" 2>/dev/null || true
+    fi
+    _UV_MARKER_SAVED=false
+}
+
 _configure_uv_cache() {
     _uv_studio_cache="$STUDIO_HOME/cache/uv"
     case "${UV_CACHE_DIR-}" in
         *[![:space:]]*)
             _UV_CACHE_MODE=custom
             export UV_CACHE_DIR
+            # Recorded like any other choice; a caller still outranks the marker.
+            _record_uv_cache_choice
             step "uv cache" "preserving custom UV_CACHE_DIR ($UV_CACHE_DIR)"
             return 0
             ;;
@@ -634,6 +689,7 @@ _configure_uv_cache() {
         UV_CACHE_DIR="$_uv_studio_cache"
         _UV_CACHE_MODE=isolated
         export UV_CACHE_DIR
+        _record_uv_cache_choice
         step "uv cache" "forced Studio cache isolation ($UV_CACHE_DIR); already-cached packages may download again" "$C_WARN"
         return 0
     fi
@@ -687,6 +743,7 @@ _configure_uv_cache() {
         _UV_CACHE_MODE=studio
     fi
     export UV_CACHE_DIR
+    _record_uv_cache_choice
 
     case "$_UV_CACHE_MODE" in
         shared)
@@ -718,6 +775,10 @@ VENV_DIR="$STUDIO_HOME/unsloth_studio"
 _VENV_ROLLBACK_DIR=""
 _VENV_ROLLBACK_TARGET="$VENV_DIR"
 _VENV_ROLLBACK_ACTIVE=false
+# The marker travels with the environment. See _record_uv_cache_choice.
+_UV_MARKER_SAVED=false
+_UV_MARKER_EXISTED=false
+_UV_MARKER_PREVIOUS=""
 
 _start_studio_venv_replacement() {
     _existing_dir="$1"
@@ -850,6 +911,8 @@ _prune_stale_studio_venv_rollbacks() {
 }
 
 _commit_studio_venv_replacement() {
+    # Outside the branch: a first install rolls nothing back and still commits.
+    _UV_MARKER_SAVED=false
     if [ "$_VENV_ROLLBACK_ACTIVE" = true ]; then
         _rollback_to_remove="$_VENV_ROLLBACK_DIR"
         # The new environment is already committed. Clear the restore state
@@ -886,6 +949,8 @@ _on_install_exit() {
     _status=$?
     if [ "$_status" -ne 0 ]; then
         _restore_studio_venv_replacement
+        # Separate from the venv restore: an install can fail before one is in flight.
+        _restore_uv_cache_marker
     fi
     _cleanup_install_temporaries
     exit "$_status"
@@ -898,6 +963,7 @@ _on_install_signal() {
     trap - EXIT
     trap '' HUP INT TERM
     _restore_studio_venv_replacement
+    _restore_uv_cache_marker
     _cleanup_install_temporaries
     exit "$_signal_status"
 }

--- a/install.sh
+++ b/install.sh
@@ -622,23 +622,30 @@ _resolve_studio_destinations() {
 # Records which cache this install used, so an update reuses it rather than guessing: the
 # launch below repoints the backend at the Studio cache even in shared mode, so one
 # on-demand install makes an empty Studio cache look full. Never fatal.
+# A relative UV_CACHE_DIR names a different directory in each phase of one install: uv
+# resolves it against its working directory, and setup.sh changes into its own before the
+# dependency pass (studio/setup.sh:1788). Absolute once, here, so both phases and the
+# marker agree. The base is uv's working directory, which --directory / UV_WORKING_DIR
+# moves, and which may itself be relative to where the installer was run.
+_absolutize_uv_cache_dir() {
+    case "$UV_CACHE_DIR" in
+        /*) return 0 ;;
+    esac
+    _uv_cache_base="${UV_WORKING_DIR:-$PWD}"
+    case "$_uv_cache_base" in
+        /*) ;;
+        *) _uv_cache_base="$PWD/$_uv_cache_base" ;;
+    esac
+    UV_CACHE_DIR="$_uv_cache_base/$UV_CACHE_DIR"
+}
+
 _record_uv_cache_choice() {
+    # In place, before anything reads it: every branch records, so this is the one point
+    # every phase of the install and the marker are made to agree on one directory.
+    _absolutize_uv_cache_dir
     _uv_marker_dir="$STUDIO_HOME/cache"
     _uv_marker_file="$_uv_marker_dir/uv-cache-dir"
-    # Absolute: the update resolves this against ITS working directory, and the base is
-    # uv's, which --directory / UV_WORKING_DIR moves.
-    case "$UV_CACHE_DIR" in
-        /*) _uv_marker_value="$UV_CACHE_DIR" ;;
-        *)
-            # Which may itself be relative, against the installer's own directory.
-            _uv_marker_base="${UV_WORKING_DIR:-$PWD}"
-            case "$_uv_marker_base" in
-                /*) ;;
-                *) _uv_marker_base="$PWD/$_uv_marker_base" ;;
-            esac
-            _uv_marker_value="$_uv_marker_base/$UV_CACHE_DIR"
-            ;;
-    esac
+    _uv_marker_value="$UV_CACHE_DIR"
     # Remembered so a failed install can put it back.
     if [ "$_UV_MARKER_SAVED" != true ]; then
         if [ -e "$_uv_marker_file" ] || [ -L "$_uv_marker_file" ]; then
@@ -662,6 +669,7 @@ _record_uv_cache_choice() {
 }
 
 _restore_uv_cache_marker() {
+    [ "${_STUDIO_INSTALL_COMMITTED:-false}" = true ] && return 0
     [ "$_UV_MARKER_SAVED" = true ] || return 0
     _uv_marker_file="$STUDIO_HOME/cache/uv-cache-dir"
     rm -f "$_uv_marker_file" 2>/dev/null || true
@@ -779,6 +787,9 @@ _VENV_ROLLBACK_ACTIVE=false
 _UV_MARKER_SAVED=false
 _UV_MARKER_EXISTED=false
 _UV_MARKER_PREVIOUS=""
+# One flag for both rollbacks. Clearing them separately leaves a window either way round:
+# a signal between the two restores one half of a committed install and reverts the other.
+_STUDIO_INSTALL_COMMITTED=false
 
 _start_studio_venv_replacement() {
     _existing_dir="$1"
@@ -850,6 +861,9 @@ _discard_venv_for_recreate() {  # venv dir
 }
 
 _restore_studio_venv_replacement() {
+    # The same flag the marker restore consults, so a signal landing mid-commit cannot
+    # put one half of a committed install back and keep the other.
+    [ "${_STUDIO_INSTALL_COMMITTED:-false}" = true ] && return 0
     [ "$_VENV_ROLLBACK_ACTIVE" = true ] || return 0
     # -e/-L, not -d: a rollback holds whatever _dir_has_entries called occupied,
     # and -d would drop a file or a dangling link and strand the original.
@@ -911,7 +925,10 @@ _prune_stale_studio_venv_rollbacks() {
 }
 
 _commit_studio_venv_replacement() {
-    # Outside the branch: a first install rolls nothing back and still commits.
+    # First and alone, because a signal can land between any two statements: this one
+    # assignment is what both restores consult, so they cannot disagree about whether
+    # this install committed. A first install rolls nothing back and still commits.
+    _STUDIO_INSTALL_COMMITTED=true
     _UV_MARKER_SAVED=false
     if [ "$_VENV_ROLLBACK_ACTIVE" = true ]; then
         _rollback_to_remove="$_VENV_ROLLBACK_DIR"

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1242,6 +1242,16 @@ class TestInstallUvCacheRootParity:
                 "function Set-StudioUvCacheEnvironment"
             )
         ]
+        # The custom branch resolves through the same helper as the marker writer, or the
+        # two disagree the moment UV_WORKING_DIR is set: it anchored to $PWD alone.
+        assert ps1.count("Resolve-StudioUvCachePath -Cache") == 2, ps1.count(
+            "Resolve-StudioUvCachePath -Cache"
+        )
+        assert "$env:UV_CACHE_DIR = Resolve-StudioUvCachePath -Cache $env:UV_CACHE_DIR" in ps1
+        # Both sides read UV_WORKING_DIR to resolve a relative cache, and both anchor a
+        # relative one to the directory the installer was run from.
+        assert "UV_WORKING_DIR" in sh[sh.index("_absolutize_uv_cache_dir() {") :][:600]
+        assert "UV_WORKING_DIR" in ps1[ps1.index("function Resolve-StudioUvCachePath") :][:800]
         for start in _all_indexes(ps1_marker, "Remove-Item -LiteralPath $markerFile"):
             # The call form: the comment above the gate names the cmdlet too.
             window = ps1_marker[

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1181,10 +1181,9 @@ class TestInstallUvCacheRootParity:
         assert 'case "$UV_CACHE_DIR" in' in sh
         assert "IsPathRooted" in ps1
 
-        # The reset must precede both consumers of the snapshot, the selector that writes
-        # the marker and every Exit-InstallFailure that restores it. Under `irm | iex` the
-        # script scope is the caller's session, so a second install failing early would
-        # otherwise revert the first one's marker. Only the entry point is ahead of both.
+        # The reset must precede both consumers, the selector that writes the marker and
+        # every Exit-InstallFailure that restores it. Under `irm | iex` the script scope is
+        # the caller's session, so only the entry point is ahead of both.
         entry = ps1.index("function Install-UnslothStudio {")
         # The call form, not the bare name, which also appears in prose above.
         first_consumer = min(
@@ -1242,14 +1241,12 @@ class TestInstallUvCacheRootParity:
                 "function Set-StudioUvCacheEnvironment"
             )
         ]
-        # The custom branch resolves through the same helper as the marker writer, or the
-        # two disagree the moment UV_WORKING_DIR is set: it anchored to $PWD alone.
+        # One helper for both, or they disagree the moment UV_WORKING_DIR is set.
         assert ps1.count("Resolve-StudioUvCachePath -Cache") == 2, ps1.count(
             "Resolve-StudioUvCachePath -Cache"
         )
         assert "$env:UV_CACHE_DIR = Resolve-StudioUvCachePath -Cache $env:UV_CACHE_DIR" in ps1
-        # Both sides read UV_WORKING_DIR to resolve a relative cache, and both anchor a
-        # relative one to the directory the installer was run from.
+        # And both sides consult UV_WORKING_DIR, itself resolvable against the run dir.
         assert "UV_WORKING_DIR" in sh[sh.index("_absolutize_uv_cache_dir() {") :][:600]
         assert "UV_WORKING_DIR" in ps1[ps1.index("function Resolve-StudioUvCachePath") :][:800]
         for start in _all_indexes(ps1_marker, "Remove-Item -LiteralPath $markerFile"):
@@ -1259,10 +1256,8 @@ class TestInstallUvCacheRootParity:
             ]
             assert "Get-Item -LiteralPath $markerFile -Force" in window, window
 
-        # Read as UTF-8, not the active ANSI code page: the update writes this file
-        # BOM-less UTF-8, and Windows PowerShell 5.1 would decode a non-ASCII path into
-        # mojibake and restore that. Asserted on the source, since pwsh 7 here already
-        # defaults to UTF-8 and would pass the round trip either way.
+        # UTF-8, not the ANSI code page: the update writes this file BOM-less UTF-8 and
+        # 5.1 would restore mojibake. Asserted on source, since pwsh 7 passes either way.
         read_back = ps1_marker.index("Get-Content -LiteralPath $markerFile")
         assert "-Encoding UTF8" in ps1_marker[read_back : read_back + 220], ps1_marker[read_back:]
 

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -36,6 +36,16 @@ def _fallback_range(lines):
     raise AssertionError("install.sh's GPU-detection fallback branch is never closed")
 
 
+def _all_indexes(haystack, needle):
+    """Every occurrence, so an assertion about "each write" cannot pass on the first one."""
+    found, at = [], haystack.find(needle)
+    while at != -1:
+        found.append(at)
+        at = haystack.find(needle, at + 1)
+    assert found, needle
+    return found
+
+
 class TestNoTorchBackendAutoInInstallSh:
     """install.sh primary paths must not use --torch-backend=auto (only the fallback else-branch may)."""
 
@@ -1128,6 +1138,125 @@ class TestInstallUvCacheRootParity:
                 assert bucket in source, bucket
             for metadata_suffix in (".msgpack", ".http", ".rev", ".lock"):
                 assert metadata_suffix in source, metadata_suffix
+
+    def test_both_installers_record_the_cache_they_chose(self):
+        """`unsloth studio update` reads this to reuse the install's cache. Content
+        cannot decide it: install.sh:705 points the backend at the Studio cache even in
+        shared mode, so a runtime install leaves bytes in the losing one."""
+        sh = INSTALL_SH.read_text(encoding = "utf-8")
+        ps1 = INSTALL_PS1.read_text(encoding = "utf-8")
+        cli = (REPO_ROOT / "unsloth_cli" / "commands" / "studio.py").read_text(encoding = "utf-8")
+
+        for source in (sh, ps1, cli):
+            assert "uv-cache-dir" in source
+
+        # Written after the choice is made.
+        assert "_record_uv_cache_choice() {" in sh
+        # Every mode records, custom included, or a previous install's marker survives.
+        call_sites = [
+            match.start()
+            for match in re.finditer(r"^[ \t]+_record_uv_cache_choice[ \t]*$", sh, re.MULTILINE)
+        ]
+        assert len(call_sites) == 3, f"one call site per mode branch, found {len(call_sites)}"
+        assert (
+            sh.index("_UV_CACHE_MODE=custom")
+            < min(call_sites)
+            < sh.index("_UV_CACHE_MODE=isolated")
+        ), "the custom branch records before it returns"
+        assert ps1.count("Write-StudioUvCacheMarker -StudioRoot") == 2
+        # A marker is a preference, not a requirement, so neither installer may fail on it.
+        marker_write = ps1[
+            ps1.index("function Write-StudioUvCacheMarker") : ps1.index(
+                "function Set-StudioUvCacheEnvironment"
+            )
+        ]
+        # Covers both marker functions, which sit together above the selector.
+        assert "-ErrorAction Stop" not in marker_write
+        assert marker_write.count("-ErrorAction SilentlyContinue") >= 2
+        assert "|| true" in sh[sh.index("_record_uv_cache_choice() {") :]
+        # Windows PowerShell 5.1 writes -Encoding utf8 WITH a BOM, so the reader allows one.
+        assert "utf-8-sig" in cli
+
+        # Absolute on both sides: the update resolves it against its own directory.
+        assert 'case "$UV_CACHE_DIR" in' in sh
+        assert "IsPathRooted" in ps1
+
+        # The reset must precede both consumers of the snapshot, the selector that writes
+        # the marker and every Exit-InstallFailure that restores it. Under `irm | iex` the
+        # script scope is the caller's session, so a second install failing early would
+        # otherwise revert the first one's marker. Only the entry point is ahead of both.
+        entry = ps1.index("function Install-UnslothStudio {")
+        # The call form, not the bare name, which also appears in prose above.
+        first_consumer = min(
+            ps1.index("Set-StudioUvCacheEnvironment -StudioRoot $StudioHome"),
+            ps1.index('(Exit-InstallFailure "', entry),
+        )
+        for variable in (
+            "$script:StudioUvMarkerSaved = $false",
+            "$script:StudioUvMarkerExisted = $false",
+            "$script:StudioUvMarkerPrevious = $null",
+        ):
+            assert variable in ps1[entry:first_consumer], variable
+
+        # Committing the environment commits the marker that came with it.
+        assert (
+            "$script:StudioUvMarkerSaved = $false"
+            in ps1[
+                ps1.index("function Complete-StudioVenvRollback") : ps1.index(
+                    "function Complete-StudioVenvRollback"
+                )
+                + 900
+            ]
+        )
+        commit_start = sh.index("_commit_studio_venv_replacement() {")
+        commit_body = sh[commit_start : sh.index("\n}", commit_start)]
+        # Before the venv flag: a signal between the two keeps the environment and
+        # reverts its marker.
+        assert commit_body.index("_UV_MARKER_SAVED=false") < commit_body.index(
+            "_VENV_ROLLBACK_ACTIVE=false"
+        )
+        ps1_commit = ps1[ps1.index("function Complete-StudioVenvRollback") :][:900]
+        assert ps1_commit.index("$script:StudioUvMarkerSaved = $false") < ps1_commit.index(
+            "$script:StudioVenvRollbackActive = $false"
+        )
+        # And outside the rollback branch, which a first install skips entirely.
+        assert commit_body.index("_UV_MARKER_SAVED=false") < commit_body.index(
+            'if [ "$_VENV_ROLLBACK_ACTIVE" = true ]'
+        )
+        assert ps1_commit.index("$script:StudioUvMarkerSaved = $false") < ps1_commit.index(
+            "if (-not $script:StudioVenvRollbackActive) { return }"
+        )
+
+        # Both writes are gated on the old entry being gone: the unlink is what keeps a
+        # symlinked marker from truncating its target, and it can fail silently.
+        for body in (
+            sh[sh.index("_record_uv_cache_choice() {") : sh.index("_restore_uv_cache_marker() {")],
+            sh[sh.index("_restore_uv_cache_marker() {") :][:600],
+        ):
+            unlink = body.index('rm -f "$_uv_marker_file"')
+            write = body.index("printf '%s\\n'", unlink)
+            assert '[ -L "$_uv_marker_file" ]' in body[unlink:write], body[unlink:write]
+        ps1_marker = ps1[
+            ps1.index("function Write-StudioUvCacheMarker") : ps1.index(
+                "function Set-StudioUvCacheEnvironment"
+            )
+        ]
+        for start in _all_indexes(ps1_marker, "Remove-Item -LiteralPath $markerFile"):
+            # The call form: the comment above the gate names the cmdlet too.
+            window = ps1_marker[
+                start : ps1_marker.index("Set-Content -LiteralPath $markerFile", start)
+            ]
+            assert "Get-Item -LiteralPath $markerFile -Force" in window, window
+
+        # Restored whether or not a venv replacement was ever in flight.
+        assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_exit() {") :]
+        assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_signal() {") :]
+        assert ps1.count("Restore-StudioUvCacheMarker -StudioRoot") == 2
+
+        # And the marker travels with the environment: a rolled-back install puts it back.
+        assert "_restore_uv_cache_marker" in sh
+        assert sh.count("_restore_uv_cache_marker") >= 2, "defined but never called"
+        assert "function Restore-StudioUvCacheMarker" in ps1
 
         assert "${XDG_CACHE_HOME}/uv" in sh
         assert "${HOME}/.cache/uv" in sh

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1195,6 +1195,7 @@ class TestInstallUvCacheRootParity:
             "$script:StudioUvMarkerSaved = $false",
             "$script:StudioUvMarkerExisted = $false",
             "$script:StudioUvMarkerPrevious = $null",
+            "$script:StudioInstallCommitted = $false",
         ):
             assert variable in ps1[entry:first_consumer], variable
 
@@ -1247,6 +1248,30 @@ class TestInstallUvCacheRootParity:
                 start : ps1_marker.index("Set-Content -LiteralPath $markerFile", start)
             ]
             assert "Get-Item -LiteralPath $markerFile -Force" in window, window
+
+        # Read as UTF-8, not the active ANSI code page: the update writes this file
+        # BOM-less UTF-8, and Windows PowerShell 5.1 would decode a non-ASCII path into
+        # mojibake and restore that. Asserted on the source, since pwsh 7 here already
+        # defaults to UTF-8 and would pass the round trip either way.
+        read_back = ps1_marker.index("Get-Content -LiteralPath $markerFile")
+        assert "-Encoding UTF8" in ps1_marker[read_back : read_back + 220], ps1_marker[read_back:]
+
+        # One flag decides both rollbacks. Clearing them separately leaves a window either
+        # way round, where a signal restores one half of a committed install.
+        assert commit_body.index("_STUDIO_INSTALL_COMMITTED=true") < commit_body.index(
+            "_UV_MARKER_SAVED=false"
+        )
+        for body in (
+            sh[sh.index("_restore_studio_venv_replacement() {") :][:400],
+            sh[sh.index("_restore_uv_cache_marker() {") :][:400],
+        ):
+            assert "_STUDIO_INSTALL_COMMITTED" in body, body
+        assert ps1_commit.index("$script:StudioInstallCommitted = $true") < ps1_commit.index(
+            "$script:StudioUvMarkerSaved = $false"
+        )
+        for name in ("Restore-StudioVenvRollback", "Restore-StudioUvCacheMarker"):
+            body = ps1[ps1.index(f"function {name} {{") :][:800]
+            assert "if ($script:StudioInstallCommitted) { return }" in body, name
 
         # Restored whether or not a venv replacement was ever in flight.
         assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_exit() {") :]

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -67,6 +67,7 @@ def _uv_cache_functions(source: str) -> str:
     return "".join(
         _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
         for name in (
+            "Resolve-StudioUvCachePath",
             "Write-StudioUvCacheMarker",
             "Set-StudioUvCacheEnvironment",
             "Set-StudioUvCacheForLaunch",
@@ -823,7 +824,11 @@ def test_a_non_ascii_marker_survives_the_rollback(tmp_path: Path, shell: str):
     source = INSTALL_PS1.read_text(encoding = "utf-8")
     functions = "".join(
         _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
-        for name in ("Write-StudioUvCacheMarker", "Restore-StudioUvCacheMarker")
+        for name in (
+            "Resolve-StudioUvCachePath",
+            "Write-StudioUvCacheMarker",
+            "Restore-StudioUvCacheMarker",
+        )
     )
     studio_root = tmp_path / "studio root"
     marker = studio_root / "cache" / "uv-cache-dir"
@@ -866,7 +871,11 @@ def test_a_rolled_back_install_restores_the_previous_uv_cache_marker(
     source = INSTALL_PS1.read_text(encoding = "utf-8")
     functions = "".join(
         _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
-        for name in ("Write-StudioUvCacheMarker", "Restore-StudioUvCacheMarker")
+        for name in (
+            "Resolve-StudioUvCachePath",
+            "Write-StudioUvCacheMarker",
+            "Restore-StudioUvCacheMarker",
+        )
     )
     studio_root = tmp_path / "studio root"
     marker = studio_root / "cache" / "uv-cache-dir"
@@ -909,7 +918,10 @@ def test_a_relative_cache_is_recorded_absolute(tmp_path: Path, shell: str):
     """`uv cache dir` answers a relative cache-dir with the relative spelling, and the
     update resolves the marker against ITS working directory, not the installer's."""
     source = INSTALL_PS1.read_text(encoding = "utf-8")
-    functions = _extract(r"    function Write-StudioUvCacheMarker \{.*?\n    \}\n", source)
+    functions = "".join(
+        _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
+        for name in ("Resolve-StudioUvCachePath", "Write-StudioUvCacheMarker")
+    )
     studio_root = tmp_path / "studio root"
     marker = studio_root / "cache" / "uv-cache-dir"
 
@@ -934,6 +946,40 @@ Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache "relcache"
 
 @pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
 @pytest.mark.parametrize("shell", POWERSHELLS)
+def test_a_relative_working_directory_moves_the_relative_cache(tmp_path: Path, shell: str):
+    """UV_WORKING_DIR is where uv starts, so a relative cache hangs off it and not off the
+    installer's own directory. It may itself be relative, against the installer's."""
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    functions = "".join(
+        _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
+        for name in ("Resolve-StudioUvCachePath", "Write-StudioUvCacheMarker")
+    )
+    studio_root = tmp_path / "studio root"
+    marker = studio_root / "cache" / "uv-cache-dir"
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+{functions}
+$script:StudioUvMarkerSaved = $false
+Set-Location -LiteralPath $env:TEST_CWD
+$env:UV_WORKING_DIR = "subdir"
+Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache "relcache"
+(Get-Content -LiteralPath $env:TEST_MARKER -Raw).Trim()
+"""
+    env = os.environ.copy()
+    env.pop("UV_WORKING_DIR", None)
+    env["TEST_STUDIO_HOME"] = str(studio_root)
+    env["TEST_MARKER"] = str(marker)
+    env["TEST_CWD"] = str(tmp_path)
+    recorded = _run_powershell(shell, script, env).splitlines()[-1]
+
+    assert os.path.normcase(os.path.normpath(recorded)) == os.path.normcase(
+        os.path.normpath(str(tmp_path / "subdir" / "relcache"))
+    ), recorded
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
 def test_an_unreadable_cache_directory_does_not_abort_the_install(tmp_path: Path, shell: str):
     """The marker is optional, so probing for it must not fail the install: under
     $ErrorActionPreference = "Stop", Test-Path inside an ACL-denied directory throws
@@ -941,7 +987,10 @@ def test_an_unreadable_cache_directory_does_not_abort_the_install(tmp_path: Path
     if os.name == "nt" or os.geteuid() == 0:
         pytest.skip("POSIX mode bits do not deny this caller")
     source = INSTALL_PS1.read_text(encoding = "utf-8")
-    functions = _extract(r"    function Write-StudioUvCacheMarker \{.*?\n    \}\n", source)
+    functions = "".join(
+        _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
+        for name in ("Resolve-StudioUvCachePath", "Write-StudioUvCacheMarker")
+    )
     studio_root = tmp_path / "studio root"
     (studio_root / "cache").mkdir(parents = True)
     (studio_root / "cache").chmod(0o000)

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -749,7 +749,13 @@ try {{
     env["LOCALAPPDATA"] = str(tmp_path / "local app data")
     result = json.loads(_run_powershell(shell, script, env).splitlines()[-1])
 
-    expected = initial_value if initial_value.strip() else str(tmp_path / "studio" / "cache" / "uv")
+    # A caller's own value is kept, and resolved: setup runs uv from a directory of its
+    # own choosing, so a relative one would name two caches across the one install. What
+    # gets RESTORED afterwards is still the caller's spelling, asserted below.
+    if initial_value.strip():
+        expected = os.path.abspath(initial_value)
+    else:
+        expected = str(tmp_path / "studio" / "cache" / "uv")
     assert os.path.normcase(os.path.normpath(result["Active"])) == os.path.normcase(
         os.path.normpath(expected)
     )
@@ -806,6 +812,46 @@ foreach ($root in @($env:TEST_STUDIO_HOME_ONE, $env:TEST_STUDIO_HOME_TWO)) {{
     assert result["Modes"] == ["studio", "studio"]
     assert result["PresentAfter"] is False
     assert result["ProviderPresentAfter"] is False
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+def test_a_non_ascii_marker_survives_the_rollback(tmp_path: Path, shell: str):
+    """The update writes this file BOM-less UTF-8, and Windows PowerShell 5.1 reads a
+    BOM-less file with the active ANSI code page, so a non-ASCII path came back as
+    mojibake and the rollback wrote that back over a marker that had been correct."""
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    functions = "".join(
+        _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
+        for name in ("Write-StudioUvCacheMarker", "Restore-StudioUvCacheMarker")
+    )
+    studio_root = tmp_path / "studio root"
+    marker = studio_root / "cache" / "uv-cache-dir"
+    previous = tmp_path / "kaffee cache"
+    # As the Python backfill writes it: UTF-8, no BOM.
+    marker.parent.mkdir(parents = True)
+    marker.write_bytes(f"{previous}\n".replace("kaffee", "k\u00e4ffee").encode("utf-8"))
+    expected = str(previous).replace("kaffee", "k\u00e4ffee")
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+{functions}
+$script:StudioUvMarkerSaved = $false
+$script:StudioUvMarkerExisted = $false
+$script:StudioUvMarkerPrevious = $null
+Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache $env:TEST_CHOSEN
+Restore-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME
+[pscustomobject]@{{
+    After = (Get-Content -LiteralPath $env:TEST_MARKER -Raw -Encoding UTF8).Trim()
+}} | ConvertTo-Json -Compress
+"""
+    env = os.environ.copy()
+    env["TEST_STUDIO_HOME"] = str(studio_root)
+    env["TEST_CHOSEN"] = str(tmp_path / "chosen cache")
+    env["TEST_MARKER"] = str(marker)
+    result = json.loads(_run_powershell(shell, script, env).splitlines()[-1])
+
+    assert result["After"] == expected, result
 
 
 @pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -67,6 +67,7 @@ def _uv_cache_functions(source: str) -> str:
     return "".join(
         _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
         for name in (
+            "Write-StudioUvCacheMarker",
             "Set-StudioUvCacheEnvironment",
             "Set-StudioUvCacheForLaunch",
             "Restore-StudioUvCacheEnvironment",
@@ -238,6 +239,7 @@ def test_restoring_a_split_move_never_deletes_the_half_left_behind(tmp_path: Pat
             "Remove-StudioVenvTreeWithRetry",
             "Merge-StudioVenvRollbackTree",
             "Restore-StudioVenvRollback",
+            "Restore-StudioUvCacheMarker",
         )
     )
     target = tmp_path / "unsloth_studio"
@@ -293,6 +295,7 @@ def test_merging_a_split_move_keeps_every_sibling_at_its_own_path(tmp_path: Path
             "Remove-StudioVenvTreeWithRetry",
             "Merge-StudioVenvRollbackTree",
             "Restore-StudioVenvRollback",
+            "Restore-StudioUvCacheMarker",
         )
     )
     target = tmp_path / "unsloth_studio"
@@ -360,6 +363,7 @@ def test_merging_a_split_move_never_walks_through_a_link(tmp_path: Path, shell: 
             "Remove-StudioVenvTreeWithRetry",
             "Merge-StudioVenvRollbackTree",
             "Restore-StudioVenvRollback",
+            "Restore-StudioUvCacheMarker",
         )
     )
     target = tmp_path / "unsloth_studio"
@@ -685,6 +689,15 @@ try {{
         ) == "keep"
         assert (shared / ".gitignore").read_text(encoding = "utf-8") == "*\n"
 
+    # The marker `unsloth studio update` reads back, so it reuses the cache this install
+    # used instead of re-deriving it from content that a runtime install can change.
+    # utf-8-sig because Windows PowerShell 5.1 writes -Encoding utf8 with a BOM.
+    # Every mode records, custom included: a marker left by a previous install would aim
+    # later updates at a cache this one never filled.
+    marker = studio_root / "cache" / "uv-cache-dir"
+    recorded = marker.read_text(encoding = "utf-8-sig").strip()
+    assert norm(recorded) == norm(str(expected_selected)), case
+
 
 @pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
 @pytest.mark.parametrize("shell", POWERSHELLS)
@@ -793,3 +806,115 @@ foreach ($root in @($env:TEST_STUDIO_HOME_ONE, $env:TEST_STUDIO_HOME_TWO)) {{
     assert result["Modes"] == ["studio", "studio"]
     assert result["PresentAfter"] is False
     assert result["ProviderPresentAfter"] is False
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+@pytest.mark.parametrize("preexisting", [True, False])
+def test_a_rolled_back_install_restores_the_previous_uv_cache_marker(
+    tmp_path: Path, shell: str, preexisting: bool
+):
+    """The marker describes the environment, so it goes back when the environment does:
+    install.ps1 restores the previous venv on failure, and a marker for an install that
+    never happened would outlive it."""
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    functions = "".join(
+        _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
+        for name in ("Write-StudioUvCacheMarker", "Restore-StudioUvCacheMarker")
+    )
+    studio_root = tmp_path / "studio root"
+    marker = studio_root / "cache" / "uv-cache-dir"
+    previous = tmp_path / "previous cache"
+    chosen = tmp_path / "chosen cache"
+    if preexisting:
+        marker.parent.mkdir(parents = True)
+        marker.write_text(f"{previous}\n", encoding = "utf-8")
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+{functions}
+$script:StudioUvMarkerSaved = $false
+$script:StudioUvMarkerExisted = $false
+$script:StudioUvMarkerPrevious = $null
+Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache $env:TEST_CHOSEN
+$during = Get-Content -LiteralPath $env:TEST_MARKER -Raw
+Restore-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME
+$after = if (Test-Path -LiteralPath $env:TEST_MARKER) {{
+    (Get-Content -LiteralPath $env:TEST_MARKER -Raw).Trim()
+}} else {{ "<gone>" }}
+[pscustomobject]@{{ During = $during.Trim(); After = $after }} | ConvertTo-Json -Compress
+"""
+    env = os.environ.copy()
+    env["TEST_STUDIO_HOME"] = str(studio_root)
+    env["TEST_CHOSEN"] = str(chosen)
+    env["TEST_MARKER"] = str(marker)
+    result = json.loads(_run_powershell(shell, script, env).splitlines()[-1])
+
+    norm = lambda value: os.path.normcase(os.path.normpath(value))
+    assert norm(result["During"]) == norm(str(chosen))
+    assert result["After"] == ("<gone>" if not preexisting else result["After"])
+    if preexisting:
+        assert norm(result["After"]) == norm(str(previous))
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+def test_a_relative_cache_is_recorded_absolute(tmp_path: Path, shell: str):
+    """`uv cache dir` answers a relative cache-dir with the relative spelling, and the
+    update resolves the marker against ITS working directory, not the installer's."""
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    functions = _extract(r"    function Write-StudioUvCacheMarker \{.*?\n    \}\n", source)
+    studio_root = tmp_path / "studio root"
+    marker = studio_root / "cache" / "uv-cache-dir"
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+{functions}
+$script:StudioUvMarkerSaved = $false
+Set-Location -LiteralPath $env:TEST_CWD
+Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache "relcache"
+(Get-Content -LiteralPath $env:TEST_MARKER -Raw).Trim()
+"""
+    env = os.environ.copy()
+    env["TEST_STUDIO_HOME"] = str(studio_root)
+    env["TEST_MARKER"] = str(marker)
+    env["TEST_CWD"] = str(tmp_path)
+    recorded = _run_powershell(shell, script, env).splitlines()[-1]
+
+    assert os.path.normcase(os.path.normpath(recorded)) == os.path.normcase(
+        os.path.normpath(str(tmp_path / "relcache"))
+    ), recorded
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+def test_an_unreadable_cache_directory_does_not_abort_the_install(tmp_path: Path, shell: str):
+    """The marker is optional, so probing for it must not fail the install: under
+    $ErrorActionPreference = "Stop", Test-Path inside an ACL-denied directory throws
+    UnauthorizedAccessException rather than returning $false."""
+    if os.name == "nt" or os.geteuid() == 0:
+        pytest.skip("POSIX mode bits do not deny this caller")
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    functions = _extract(r"    function Write-StudioUvCacheMarker \{.*?\n    \}\n", source)
+    studio_root = tmp_path / "studio root"
+    (studio_root / "cache").mkdir(parents = True)
+    (studio_root / "cache").chmod(0o000)
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+{functions}
+$script:StudioUvMarkerSaved = $false
+try {{
+    Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache $env:TEST_CACHE
+    "survived"
+}} catch {{
+    "THREW: " + $_.Exception.GetType().Name
+}}
+"""
+    env = os.environ.copy()
+    env["TEST_STUDIO_HOME"] = str(studio_root)
+    env["TEST_CACHE"] = str(tmp_path / "chosen")
+    try:
+        assert _run_powershell(shell, script, env).splitlines()[-1] == "survived"
+    finally:
+        (studio_root / "cache").chmod(0o755)

--- a/tests/sh/test_install_rollback_lifecycle.sh
+++ b/tests/sh/test_install_rollback_lifecycle.sh
@@ -14,6 +14,21 @@ ok()  { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 bad() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 
 ROLLBACK_BLOCK=$(sed -n '/^_VENV_ROLLBACK_DIR=""/,/^trap '\''_on_install_signal 143'\'' TERM$/p' "$INSTALL_SH")
+# Both are defined above the block, with the rest of the cache selector, and both are
+# called from it. Splicing without them makes the cases exit 127 on a command the real
+# installer has, which satisfies any expectation about a marker that must not change.
+# printf, not $'\n': the workflow runs this file with `sh`, whatever the shebang says.
+MARKER_HELPER=$(awk '
+    /^(_restore_uv_cache_marker|_record_uv_cache_choice)\(\) \{/ { grab = 1 }
+    grab { print }
+    grab && /^}/ { grab = 0 }
+' "$INSTALL_SH")
+if ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_restore_uv_cache_marker() {' \
+   || ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_record_uv_cache_choice() {'; then
+    echo "  FAIL: could not extract the uv cache marker helpers from install.sh"
+    exit 1
+fi
+ROLLBACK_BLOCK=$(printf '%s\n%s\n' "$MARKER_HELPER" "$ROLLBACK_BLOCK")
 if ! printf '%s\n' "$ROLLBACK_BLOCK" | grep -q '^_on_install_signal() {'; then
     echo "  FAIL: could not extract rollback lifecycle block from install.sh"
     exit 1
@@ -392,6 +407,49 @@ if grep -A18 '^    function Remove-StudioVenvTreeWithRetry {' "$INSTALL_PS1" \
 else
     bad "Windows rollback deletion still hides failures"
 fi
+
+# The marker must not outlive the attempt that wrote it, even when no venv replacement
+# was ever in flight: a first install has none, and the ownership guard can refuse early.
+marker_case() {  # label, pre-existing marker value or empty, expect, [commit]
+    _label="$1"; _pre="$2"; _expect="$3"; _commit="${4:-}"
+    _dir="$WORK/marker-$_label"
+    mkdir -p "$_dir/cache"
+    [ -n "$_pre" ] && printf '%s\n' "$_pre" > "$_dir/cache/uv-cache-dir"
+    _h="$_dir/harness.sh"
+    {
+        printf '%s\n' 'set -e'
+        printf '%s\n' 'substep() { :; }'
+        printf '%s\n' 'rollback_substep() { substep "$@"; }'
+        printf '%s\n' 'C_WARN=""'
+        printf "STUDIO_HOME='%s'\n" "$_dir"
+        printf "VENV_DIR='%s/unsloth_studio'\n" "$_dir"
+        printf '%s\n' "$ROLLBACK_BLOCK"
+        printf '%s\n' 'UV_CACHE_DIR="/tmp/this-attempt-cache"'
+        printf '%s\n' '_record_uv_cache_choice'
+        [ -n "$_commit" ] && printf '%s\n' '_commit_studio_venv_replacement'
+        printf '%s\n' 'exit 1'
+    } > "$_h"
+    ( cd "$_dir" && sh "$_h" >/dev/null 2>"$_dir/err" ) || _rc=$?
+    if [ "${_rc:-0}" = 127 ] || [ -s "$_dir/err" ]; then
+        bad "$_label (harness did not run: $(cat "$_dir/err"))"
+        return 0
+    fi
+    if [ -f "$_dir/cache/uv-cache-dir" ]; then _got=$(cat "$_dir/cache/uv-cache-dir"); else _got="<gone>"; fi
+    if [ "$_got" = "$_expect" ]; then
+        ok "$_label"
+    else
+        bad "$_label (expected [$_expect], got [$_got])"
+    fi
+}
+
+echo "=== uv cache marker survives only a successful install ==="
+marker_case "a failed install with no venv replacement restores the previous marker" \
+    "/previous/install/cache" "/previous/install/cache"
+marker_case "a failed first install leaves no marker behind" "" "<gone>"
+# A first install takes no rollback branch and must still commit the marker: what follows
+# can fail, and the environment it installed stays.
+marker_case "a committed first install keeps its marker when a later step fails" \
+    "/previous/install/cache" "/tmp/this-attempt-cache" commit
 
 echo ""
 echo "  PASS: $PASS"

--- a/tests/sh/test_install_rollback_lifecycle.sh
+++ b/tests/sh/test_install_rollback_lifecycle.sh
@@ -19,12 +19,13 @@ ROLLBACK_BLOCK=$(sed -n '/^_VENV_ROLLBACK_DIR=""/,/^trap '\''_on_install_signal 
 # installer has, which satisfies any expectation about a marker that must not change.
 # printf, not $'\n': the workflow runs this file with `sh`, whatever the shebang says.
 MARKER_HELPER=$(awk '
-    /^(_restore_uv_cache_marker|_record_uv_cache_choice)\(\) \{/ { grab = 1 }
+    /^(_restore_uv_cache_marker|_record_uv_cache_choice|_absolutize_uv_cache_dir)\(\) \{/ { grab = 1 }
     grab { print }
     grab && /^}/ { grab = 0 }
 ' "$INSTALL_SH")
 if ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_restore_uv_cache_marker() {' \
-   || ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_record_uv_cache_choice() {'; then
+   || ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_record_uv_cache_choice() {' \
+   || ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_absolutize_uv_cache_dir() {'; then
     echo "  FAIL: could not extract the uv cache marker helpers from install.sh"
     exit 1
 fi
@@ -442,6 +443,50 @@ marker_case() {  # label, pre-existing marker value or empty, expect, [commit]
     fi
 }
 
+# A signal can land between any two statements, so the commit sets one flag that both
+# restores consult. With two flags, a signal mid-commit put the previous environment back
+# and kept the marker of the attempt that replaced it, or the reverse.
+commit_flag_case() {
+    _dir="$WORK/marker-commit-window"
+    mkdir -p "$_dir/cache"
+    printf '%s\n' "/previous/install/cache" > "$_dir/cache/uv-cache-dir"
+    _h="$_dir/harness.sh"
+    {
+        printf '%s\n' 'set -e'
+        printf '%s\n' 'substep() { :; }'
+        printf '%s\n' 'rollback_substep() { substep "$@"; }'
+        printf '%s\n' 'C_WARN=""'
+        printf "STUDIO_HOME='%s'\n" "$_dir"
+        printf "VENV_DIR='%s/unsloth_studio'\n" "$_dir"
+        printf '%s\n' "$ROLLBACK_BLOCK"
+        printf '%s\n' 'UV_CACHE_DIR="/tmp/this-attempt-cache"'
+        printf '%s\n' '_record_uv_cache_choice'
+        # The state a signal would find between the two flag assignments: committed, but
+        # with the venv rollback still armed.
+        printf '%s\n' 'mkdir -p "$VENV_DIR" "$STUDIO_HOME/backup"'
+        printf '%s\n' 'printf "new\n" > "$VENV_DIR/generation"'
+        printf '%s\n' 'printf "old\n" > "$STUDIO_HOME/backup/generation"'
+        printf '%s\n' '_STUDIO_INSTALL_COMMITTED=true'
+        printf '%s\n' '_VENV_ROLLBACK_ACTIVE=true'
+        printf '%s\n' '_VENV_ROLLBACK_DIR="$STUDIO_HOME/backup"'
+        printf '%s\n' '_VENV_ROLLBACK_TARGET="$VENV_DIR"'
+        printf '%s\n' '_restore_studio_venv_replacement'
+        printf '%s\n' '_restore_uv_cache_marker'
+    } > "$_h"
+    ( cd "$_dir" && sh "$_h" >/dev/null 2>"$_dir/err" ) || _rc=$?
+    if [ "${_rc:-0}" = 127 ] || [ -s "$_dir/err" ]; then
+        bad "a committed install is not half rolled back (harness: $(cat "$_dir/err"))"
+        return 0
+    fi
+    _got=$(cat "$_dir/cache/uv-cache-dir" 2>/dev/null)
+    _gen=$(cat "$_dir/unsloth_studio/generation" 2>/dev/null)
+    if [ "$_got" = "/tmp/this-attempt-cache" ] && [ "$_gen" = new ]; then
+        ok "a committed install is not half rolled back by a signal mid-commit"
+    else
+        bad "a signal mid-commit undid half the commit (marker [$_got], venv [$_gen])"
+    fi
+}
+
 echo "=== uv cache marker survives only a successful install ==="
 marker_case "a failed install with no venv replacement restores the previous marker" \
     "/previous/install/cache" "/previous/install/cache"
@@ -450,6 +495,7 @@ marker_case "a failed first install leaves no marker behind" "" "<gone>"
 # can fail, and the environment it installed stays.
 marker_case "a committed first install keeps its marker when a later step fails" \
     "/previous/install/cache" "/tmp/this-attempt-cache" commit
+commit_flag_case
 
 echo ""
 echo "  PASS: $PASS"

--- a/tests/sh/test_install_uv_cache_root.sh
+++ b/tests/sh/test_install_uv_cache_root.sh
@@ -17,12 +17,13 @@ HELPERS=$(awk '
     /^_configure_uv_cache\(\) \{/ { grab = 1 }
     /^_prepare_studio_uv_cache_for_launch\(\) \{/ { grab = 1 }
     /^_record_uv_cache_choice\(\) \{/ { grab = 1 }
+    /^_absolutize_uv_cache_dir\(\) \{/ { grab = 1 }
     /^_restore_uv_cache_marker\(\) \{/ { grab = 1 }
     grab { print }
     grab && /^}/ { grab = 0 }
 ' "$INSTALL_SH")
 for _helper in _configure_uv_cache _prepare_studio_uv_cache_for_launch _record_uv_cache_choice \
-    _restore_uv_cache_marker; do
+    _restore_uv_cache_marker _absolutize_uv_cache_dir; do
     if ! printf '%s\n' "$HELPERS" | grep -q "^${_helper}() {"; then
         echo "  FAIL: could not extract $_helper from install.sh"
         exit 1
@@ -421,6 +422,31 @@ RELATIVE
         ok "$shell: a relative cache is recorded absolute"
     else
         bad "$shell: relative cache recorded as [$_rel], wanted [$CASE/relcache]"
+    fi
+
+    # And the exported variable is absolute too, not only the marker: setup.sh changes
+    # into its own directory before the dependency pass, so a relative value would put
+    # that phase's artifacts somewhere neither the install phase nor the marker names.
+    EXPORT_PROBE="$WORK/$shell custom export.sh"
+    {
+        printf '%s\n' "$HELPERS"
+        cat <<EXPORTED
+step() { :; }
+substep() { :; }
+STUDIO_HOME='$ROOT'
+_UV_MARKER_SAVED=false
+cd '$CASE'
+UV_CACHE_DIR='relcache'
+_configure_uv_cache
+printf '%s\n' "\$UV_CACHE_DIR"
+EXPORTED
+    } > "$EXPORT_PROBE"
+    rm -f "$MARKER"
+    _exp=$($shell "$EXPORT_PROBE")
+    if [ "$_exp" = "$CASE/relcache" ]; then
+        ok "$shell: a relative custom cache is exported absolute"
+    else
+        bad "$shell: custom cache exported as [$_exp], wanted [$CASE/relcache]"
     fi
 
     # An unwritable STUDIO_HOME is a reason to skip the marker, never to fail the install.

--- a/tests/sh/test_install_uv_cache_root.sh
+++ b/tests/sh/test_install_uv_cache_root.sh
@@ -16,10 +16,13 @@ bad() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 HELPERS=$(awk '
     /^_configure_uv_cache\(\) \{/ { grab = 1 }
     /^_prepare_studio_uv_cache_for_launch\(\) \{/ { grab = 1 }
+    /^_record_uv_cache_choice\(\) \{/ { grab = 1 }
+    /^_restore_uv_cache_marker\(\) \{/ { grab = 1 }
     grab { print }
     grab && /^}/ { grab = 0 }
 ' "$INSTALL_SH")
-for _helper in _configure_uv_cache _prepare_studio_uv_cache_for_launch; do
+for _helper in _configure_uv_cache _prepare_studio_uv_cache_for_launch _record_uv_cache_choice \
+    _restore_uv_cache_marker; do
     if ! printf '%s\n' "$HELPERS" | grep -q "^${_helper}() {"; then
         echo "  FAIL: could not extract $_helper from install.sh"
         exit 1
@@ -244,6 +247,190 @@ for shell in sh bash; do
             "reusing existing shared cache ($DEEP_CACHE) to avoid duplicate Torch/CUDA downloads; use --isolated-uv-cache to isolate" \
             "$STUDIO_CACHE"
         chmod 755 "$DEEP_CACHE/archive-v0/aaa hidden" 2>/dev/null || true
+    fi
+
+    # The marker `unsloth studio update` reads: content cannot tell a Studio cache the
+    # installer filled from one a runtime install dropped a single wheel into.
+    MARKER="$ROOT/cache/uv-cache-dir"
+    check_marker() { # label, expected
+        if [ "$(cat "$MARKER" 2>/dev/null)" = "$2" ]; then
+            ok "$shell: $1"
+        else
+            bad "$shell: $1 (expected [$2], got [$(cat "$MARKER" 2>/dev/null)])"
+        fi
+    }
+
+    rm -f "$MARKER"
+    EMPTY_CACHE="$CASE/unrecorded/uv"
+    run_case "$shell" "studio mode still selects the Studio cache" unset "" false \
+        "$HOME_DIR" unset "" "$ROOT" "$EMPTY_CACHE" "$STUDIO_CACHE" studio \
+        "using new Studio-owned cache ($STUDIO_CACHE)" "$STUDIO_CACHE"
+    check_marker "studio mode records the Studio cache" "$STUDIO_CACHE"
+
+    rm -f "$MARKER"
+    run_case "$shell" "shared mode still selects the shared cache" unset "" false \
+        "$HOME_DIR" unset "" "$ROOT" "$BUILDS_CACHE" "$BUILDS_CACHE" shared \
+        "reusing existing shared cache ($BUILDS_CACHE) to avoid duplicate Torch/CUDA downloads; use --isolated-uv-cache to isolate" \
+        "$STUDIO_CACHE"
+    check_marker "shared mode records the shared cache, not the Studio one" "$BUILDS_CACHE"
+
+    rm -f "$MARKER"
+    run_case "$shell" "isolation still forces the Studio cache" unset "" true \
+        "$HOME_DIR" unset "" "$ROOT" "$BUILDS_CACHE" "$STUDIO_CACHE" isolated \
+        "forced Studio cache isolation ($STUDIO_CACHE); already-cached packages may download again" \
+        "$STUDIO_CACHE"
+    check_marker "isolated mode records the Studio cache" "$STUDIO_CACHE"
+
+    # A custom cache holds this install's wheels too, so it is recorded; the caller still
+    # wins on any run that sets the variable.
+    printf '%s\n' "$STUDIO_CACHE" > "$MARKER"
+    run_case "$shell" "custom mode is still preserved" value "$OVERRIDE" false \
+        "$HOME_DIR" unset "" "$ROOT" "$BUILDS_CACHE" "$OVERRIDE" custom \
+        "preserving custom UV_CACHE_DIR ($OVERRIDE)" "$OVERRIDE"
+    check_marker "custom mode replaces an earlier install's marker" "$OVERRIDE"
+
+    # A symlinked marker is replaced, not followed: a redirection truncates its target.
+    rm -rf "$ROOT/cache"; mkdir -p "$ROOT/cache"
+    VICTIM="$CASE/someone elses file"
+    printf 'do not clobber\n' > "$VICTIM"
+    ln -s "$VICTIM" "$ROOT/cache/uv-cache-dir" 2>/dev/null && {
+        run_case "$shell" "a symlinked marker is replaced, not followed" unset "" false \
+            "$HOME_DIR" unset "" "$ROOT" "$EMPTY_CACHE" "$STUDIO_CACHE" studio \
+            "using new Studio-owned cache ($STUDIO_CACHE)" "$STUDIO_CACHE"
+        if [ "$(cat "$VICTIM")" = "do not clobber" ] && [ ! -L "$ROOT/cache/uv-cache-dir" ]; then
+            ok "$shell: the symlink target was left alone"
+        else
+            bad "$shell: writing the marker followed a symlink"
+        fi
+    }
+
+    # One we cannot read is one we cannot put back, so leave it alone.
+    rm -rf "$ROOT/cache"; mkdir -p "$ROOT/cache"
+    printf '%s\n' "/previous/install/cache" > "$MARKER"
+    if [ "$(id -u 2>/dev/null || echo 0)" != 0 ] && chmod 200 "$MARKER" 2>/dev/null; then
+        run_case "$shell" "an unreadable marker does not fail the install" unset "" false \
+            "$HOME_DIR" unset "" "$ROOT" "$EMPTY_CACHE" "$STUDIO_CACHE" studio \
+            "using new Studio-owned cache ($STUDIO_CACHE)" "$STUDIO_CACHE"
+        chmod 600 "$MARKER" 2>/dev/null || true
+        if [ "$(cat "$MARKER")" = "/previous/install/cache" ]; then
+            ok "$shell: an unreadable marker is left as it was"
+        else
+            bad "$shell: an unreadable marker was overwritten ([$(cat "$MARKER")])"
+        fi
+    fi
+
+    # uv resolves a relative cache against its own working directory, which --directory
+    # and UV_WORKING_DIR move.
+    rm -rf "$ROOT/cache"
+    WORKDIR_PROBE="$WORK/$shell workdir.sh"
+    {
+        printf '%s\n' "$HELPERS"
+        cat <<WORKDIR
+step() { :; }
+STUDIO_HOME='$ROOT'
+_UV_MARKER_SAVED=false
+cd '$CASE'
+UV_WORKING_DIR='$CASE/uvdir'; export UV_WORKING_DIR
+UV_CACHE_DIR='relcache'
+_record_uv_cache_choice
+cat '$MARKER'
+WORKDIR
+    } > "$WORKDIR_PROBE"
+    _wd=$($shell "$WORKDIR_PROBE")
+    if [ "$_wd" = "$CASE/uvdir/relcache" ]; then
+        ok "$shell: a relative cache is recorded against uv's working directory"
+    else
+        bad "$shell: recorded [$_wd], wanted [$CASE/uvdir/relcache]"
+    fi
+
+    # Which may itself be relative, against the directory the installer ran from.
+    rm -rf "$ROOT/cache"
+    REL_PROBE="$WORK/$shell relworkdir.sh"
+    {
+        printf '%s\n' "$HELPERS"
+        cat <<RELWD
+step() { :; }
+STUDIO_HOME='$ROOT'
+_UV_MARKER_SAVED=false
+cd '$CASE'
+UV_WORKING_DIR='uvdir'; export UV_WORKING_DIR
+UV_CACHE_DIR='relcache'
+_record_uv_cache_choice
+cat '$MARKER'
+RELWD
+    } > "$REL_PROBE"
+    _rw=$($shell "$REL_PROBE")
+    if [ "$_rw" = "$CASE/uvdir/relcache" ]; then
+        ok "$shell: a relative UV_WORKING_DIR is anchored before the cache is appended"
+    else
+        bad "$shell: recorded [$_rw], wanted [$CASE/uvdir/relcache]"
+    fi
+
+
+    # The marker describes the environment, so a rolled-back install puts it back.
+    ROLLBACK_PROBE="$WORK/$shell rollback.sh"
+    {
+        printf '%s\n' "$HELPERS"
+        cat <<ROLLBACK
+step() { :; }
+STUDIO_HOME='$ROOT'
+_UV_MARKER_SAVED=false
+_UV_MARKER_EXISTED=false
+_UV_MARKER_PREVIOUS=""
+UV_CACHE_DIR='$BUILDS_CACHE'
+_record_uv_cache_choice
+printf 'during=%s\n' "\$(cat '$MARKER')"
+_restore_uv_cache_marker
+if [ -f '$MARKER' ]; then printf 'after=%s\n' "\$(cat '$MARKER')"; else printf 'after=<gone>\n'; fi
+ROLLBACK
+    } > "$ROLLBACK_PROBE"
+
+    printf '%s\n' "$STUDIO_CACHE" > "$MARKER"
+    _rb=$($shell "$ROLLBACK_PROBE")
+    if [ "$_rb" = "$(printf 'during=%s\nafter=%s' "$BUILDS_CACHE" "$STUDIO_CACHE")" ]; then
+        ok "$shell: a rolled-back install restores the previous marker"
+    else
+        bad "$shell: rollback did not restore the marker (got [$_rb])"
+    fi
+
+    rm -f "$MARKER"
+    _rb=$($shell "$ROLLBACK_PROBE")
+    if [ "$_rb" = "$(printf 'during=%s\nafter=<gone>' "$BUILDS_CACHE")" ]; then
+        ok "$shell: a rolled-back first install leaves no marker behind"
+    else
+        bad "$shell: rollback left a marker on a first install (got [$_rb])"
+    fi
+
+    # Absolute, because the update resolves the marker against its own directory.
+    RELATIVE_PROBE="$WORK/$shell relative.sh"
+    {
+        printf '%s\n' "$HELPERS"
+        cat <<RELATIVE
+step() { :; }
+STUDIO_HOME='$ROOT'
+_UV_MARKER_SAVED=false
+cd '$CASE'
+UV_CACHE_DIR='relcache'
+_record_uv_cache_choice
+cat '$MARKER'
+RELATIVE
+    } > "$RELATIVE_PROBE"
+    rm -f "$MARKER"
+    _rel=$($shell "$RELATIVE_PROBE")
+    if [ "$_rel" = "$CASE/relcache" ]; then
+        ok "$shell: a relative cache is recorded absolute"
+    else
+        bad "$shell: relative cache recorded as [$_rel], wanted [$CASE/relcache]"
+    fi
+
+    # An unwritable STUDIO_HOME is a reason to skip the marker, never to fail the install.
+    rm -rf "$ROOT/cache"
+    if [ "$(id -u 2>/dev/null || echo 0)" != 0 ] && mkdir -p "$ROOT" && chmod 500 "$ROOT" 2>/dev/null; then
+        run_case "$shell" "an unwritable Studio root still installs" unset "" false \
+            "$HOME_DIR" unset "" "$ROOT" "$BUILDS_CACHE" "$BUILDS_CACHE" shared \
+            "reusing existing shared cache ($BUILDS_CACHE) to avoid duplicate Torch/CUDA downloads; use --isolated-uv-cache to isolate" \
+            "$STUDIO_CACHE"
+        chmod 755 "$ROOT" 2>/dev/null || true
     fi
 done
 

--- a/tests/studio/test_install_rollback_lifecycle.ps1
+++ b/tests/studio/test_install_rollback_lifecycle.ps1
@@ -23,7 +23,8 @@ $subjectNames = @(
     "Test-StudioVenvRollbackMustBePreserved",
     "Remove-StaleStudioVenvRollbacks",
     "Restore-StudioVenvRollback",
-    "Complete-StudioVenvRollback"
+    "Complete-StudioVenvRollback",
+    "Restore-StudioUvCacheMarker"
 )
 
 $definitions = @{}

--- a/tests/studio/test_install_rollback_lifecycle.ps1
+++ b/tests/studio/test_install_rollback_lifecycle.ps1
@@ -110,6 +110,9 @@ function Reset-RollbackState($target) {
     $script:StudioVenvRollbackDir = $null
     $script:StudioVenvRollbackTarget = $target
     $script:StudioVenvRollbackActive = $false
+    # As Install-UnslothStudio does at entry: the commit flag is per install, and the
+    # restore consults it, so a previous section's commit would suppress this one.
+    $script:StudioInstallCommitted = $false
 }
 
 $StudioHome = Join-Path ([System.IO.Path]::GetTempPath()) "unsloth-rollback-$([guid]::NewGuid().ToString('N'))"

--- a/unsloth_cli/_studio_stage.py
+++ b/unsloth_cli/_studio_stage.py
@@ -14,9 +14,9 @@ from typing import Callable, Optional
 
 STAGE_DIR_NAME = ".update-stage"
 STAGE_ROOT_ENV = "UNSLOTH_STUDIO_STAGE_ROOT"
-# Where a staged update parks the uv cache it used. The live marker is only written once
-# the stage has been accepted, so an update that never activates cannot redirect the
-# environment it did not replace.
+# Where a staged update parks the uv cache it used. The live marker is written only once
+# the stage is accepted, so an update that never activates cannot redirect the environment
+# it did not replace.
 UV_CACHE_MARKER = "uv-cache-dir"
 SHELL_VERSION_ENV = "UNSLOTH_TAURI_SHELL_VERSION"
 READY_MARKER = "READY.json"
@@ -301,8 +301,7 @@ def stage(
         version = installed_version(root / VENV_NAME, env)
         shell_version = (os.environ.get(SHELL_VERSION_ENV) or "").strip() or None
         write_ready_marker(root, version, shell_version)
-        # After verification, not before: until the probes pass there is no accepted
-        # stage whose cache is worth pointing the live install at.
+        # After verification: until the probes pass there is no accepted stage.
         promote_uv_cache_marker(root, studio_home)
     except BaseException:
         discard(root)

--- a/unsloth_cli/_studio_stage.py
+++ b/unsloth_cli/_studio_stage.py
@@ -14,6 +14,10 @@ from typing import Callable, Optional
 
 STAGE_DIR_NAME = ".update-stage"
 STAGE_ROOT_ENV = "UNSLOTH_STUDIO_STAGE_ROOT"
+# Where a staged update parks the uv cache it used. The live marker is only written once
+# the stage has been accepted, so an update that never activates cannot redirect the
+# environment it did not replace.
+UV_CACHE_MARKER = "uv-cache-dir"
 SHELL_VERSION_ENV = "UNSLOTH_TAURI_SHELL_VERSION"
 READY_MARKER = "READY.json"
 VENV_NAME = "unsloth_studio"
@@ -227,6 +231,30 @@ def run_staged_update(root: Path, args: list[str]) -> int:
     return subprocess.call(command, cwd = str(root), env = child_environment(root))
 
 
+def promote_uv_cache_marker(root: Path, studio_home: Path) -> Optional[Path]:
+    """Publish the staged update's cache choice to the live install.
+
+    Best effort in both directions: a stage that parked nothing leaves the live marker
+    alone, and a live root that cannot be written costs the next update a preference.
+    """
+    source = root / UV_CACHE_MARKER
+    try:
+        payload = source.read_bytes()
+    except OSError:
+        return None
+    if not payload.strip():
+        return None
+    marker = studio_home / "cache" / UV_CACHE_MARKER
+    try:
+        marker.parent.mkdir(parents = True, exist_ok = True)
+        # Unlinked first: a write follows a symlink and truncates its target.
+        marker.unlink(missing_ok = True)
+        marker.write_bytes(payload)
+    except OSError:
+        return None
+    return marker
+
+
 def write_ready_marker(root: Path, backend_version: str, shell_version: Optional[str]) -> Path:
     marker = root / READY_MARKER
     payload = {
@@ -273,6 +301,9 @@ def stage(
         version = installed_version(root / VENV_NAME, env)
         shell_version = (os.environ.get(SHELL_VERSION_ENV) or "").strip() or None
         write_ready_marker(root, version, shell_version)
+        # After verification, not before: until the probes pass there is no accepted
+        # stage whose cache is worth pointing the live install at.
+        promote_uv_cache_marker(root, studio_home)
     except BaseException:
         discard(root)
         raise

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3650,6 +3650,106 @@ _PS_PROXY_DEFAULTS_PRELUDE = (
 )
 
 
+_UV_CACHE_BUCKETS = ("archive-", "builds-", "built-wheels-", "wheels-", "sdists-")
+_UV_CACHE_METADATA_SUFFIXES = (".lock", ".msgpack", ".http", ".rev")
+
+
+def _uv_cache_has_packages(cache_dir: Path) -> bool:
+    """Does this uv cache hold package bytes, or only metadata?
+
+    Same rule as install.sh:_configure_uv_cache, deliberately: wheels-* carries only
+    .msgpack/.http on uv 0.10, so counting any file at all reads a cache that has merely
+    been resolved against as if it were warm.
+    """
+    try:
+        buckets = [
+            entry
+            for entry in cache_dir.iterdir()
+            if entry.name.startswith(_UV_CACHE_BUCKETS) and entry.is_dir()
+        ]
+    except OSError:
+        return False
+    for bucket in buckets:
+        for _root, _dirs, files in os.walk(bucket):
+            for name in files:
+                if name in ("CACHEDIR.TAG", ".git", ".gitignore"):
+                    continue
+                if name.endswith(_UV_CACHE_METADATA_SUFFIXES):
+                    continue
+                return True
+    return False
+
+
+def _uv_default_cache_dir() -> Optional[Path]:
+    """Where uv would put its cache if we set nothing.
+
+    Asked of uv rather than reconstructed, so uv.toml, UV_CONFIG_FILE and the platform
+    default all count; UV_CACHE_DIR is dropped so a blank inherited value cannot answer
+    for them, and the last nonblank line is the path in case a notice precedes it.
+    """
+    uv = shutil.which("uv")
+    if not uv:
+        return None
+    child_env = {key: value for key, value in os.environ.items() if key != "UV_CACHE_DIR"}
+    try:
+        result = subprocess.run(
+            [uv, "cache", "dir"],
+            capture_output = True,
+            text = True,
+            # text=True alone decodes with the locale codec and STRICT errors, so a
+            # non-ASCII cache path on an ANSI console raises UnicodeDecodeError -- neither
+            # OSError nor SubprocessError, so it would escape the handler below and take
+            # the update down, exactly as it did for the profile probe above.
+            encoding = "utf-8",
+            errors = "replace",
+            env = child_env,
+            timeout = 30,
+            # Creation flags are not inherited, so a desktop update that is itself hidden
+            # still has to hide each process it starts.
+            **_windows_hidden_subprocess_kwargs(),
+        )
+    except Exception:
+        # Best effort by design. Not knowing where uv would have put its cache costs the
+        # update a preference, never the update itself, so no failure to probe is worth
+        # raising through the caller.
+        return None
+    if result.returncode != 0:
+        return None
+    lines = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+    if not lines:
+        return None
+    # Absolute, because uv answers `cache-dir = "relcache"` with "relcache" and setup.sh
+    # changes directory before it runs uv: a relative path we verified here would name a
+    # different, cold directory there.
+    return Path(os.path.abspath(os.path.expanduser(lines[-1])))
+
+
+def _with_studio_uv_cache(env: Optional[dict]) -> Optional[dict]:
+    """Point the setup script's uv at the cache the install used.
+
+    The installers set UV_CACHE_DIR and storage_roots._setup_cache_env sets it for the
+    server, but an update runs setup.sh/setup.ps1 from here and reached neither, so uv
+    re-downloaded into its own default what the install had just fetched.
+    """
+    if (os.environ.get("UV_CACHE_DIR") or "").strip():
+        return env
+    studio_cache = STUDIO_HOME / "cache" / "uv"
+    if not _uv_cache_has_packages(studio_cache):
+        # A shared-mode install left the wheels in uv's own cache and _setup_cache_env
+        # mkdirs this one empty on every server start, so redirecting here would send the
+        # update to a cache that has nothing in it. Online that is one wasted download;
+        # under --offline / UV_OFFLINE / uv.toml offline = true, where uv may read only
+        # what is already cached, it is an update that cannot resolve at all.
+        default_cache = _uv_default_cache_dir()
+        if default_cache is not None and _uv_cache_has_packages(default_cache):
+            # Named, not left for the child to resolve a second time. A blank inherited
+            # UV_CACHE_DIR reaches uv as `--cache-dir ''`, which exits 2 with "a value is
+            # required" on every uv command, and a cache that came from a uv.toml beside
+            # the caller is not the one uv finds once setup.sh changes directory.
+            return {**(env or os.environ), "UV_CACHE_DIR": str(default_cache)}
+    return {**(env or os.environ), "UV_CACHE_DIR": str(studio_cache)}
+
+
 def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None) -> None:
     """Find and run the studio setup/update script."""
     script = _find_setup_script(repo_root)
@@ -3664,6 +3764,7 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
         raise typer.Exit(1)
 
     env = {**os.environ, "UNSLOTH_VERBOSE": "1"} if verbose else None
+    env = _with_studio_uv_cache(env)
 
     if platform.system() == "Windows":
         # Resolved, not bare: the gate that runs immediately before this in setup() and update()

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3680,6 +3680,22 @@ def _uv_cache_has_packages(cache_dir: Path) -> bool:
     return False
 
 
+def _uv_platform_cache_dir() -> Optional[Path]:
+    """Where uv puts its cache with no configuration, mirroring install.sh:646.
+
+    Only reached when uv cannot be asked. Asking is better, since it accounts for uv.toml
+    and UV_CONFIG_FILE, but "we could not ask" must not read as "there is no cache".
+    """
+    if platform.system() == "Windows":
+        local_app_data = (os.environ.get("LOCALAPPDATA") or "").strip()
+        return Path(local_app_data) / "uv" / "cache" if local_app_data else None
+    xdg = (os.environ.get("XDG_CACHE_HOME") or "").strip()
+    if xdg:
+        return Path(xdg) / "uv"
+    home = (os.environ.get("HOME") or "").strip()
+    return Path(home) / ".cache" / "uv" if home else None
+
+
 def _uv_default_cache_dir() -> Optional[Path]:
     """Where uv would put its cache if we set nothing.
 
@@ -3689,7 +3705,7 @@ def _uv_default_cache_dir() -> Optional[Path]:
     """
     uv = shutil.which("uv")
     if not uv:
-        return None
+        return _uv_platform_cache_dir()
     child_env = {key: value for key, value in os.environ.items() if key != "UV_CACHE_DIR"}
     try:
         result = subprocess.run(
@@ -3712,12 +3728,16 @@ def _uv_default_cache_dir() -> Optional[Path]:
         # Best effort by design. Not knowing where uv would have put its cache costs the
         # update a preference, never the update itself, so no failure to probe is worth
         # raising through the caller.
-        return None
+        return _uv_platform_cache_dir()
     if result.returncode != 0:
-        return None
+        # uv discovers config from the CURRENT directory, so a malformed uv.toml beside
+        # whoever ran `unsloth studio update` makes this exit nonzero even though setup.sh
+        # changes directory before it runs uv at all. install.sh:646 falls back to the
+        # platform default rather than declaring the cache cold, and so does this.
+        return _uv_platform_cache_dir()
     lines = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
     if not lines:
-        return None
+        return _uv_platform_cache_dir()
     # Absolute, because uv answers `cache-dir = "relcache"` with "relcache" and setup.sh
     # changes directory before it runs uv: a relative path we verified here would name a
     # different, cold directory there. Resolved against uv's working directory, which

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3720,8 +3720,12 @@ def _uv_default_cache_dir() -> Optional[Path]:
         return None
     # Absolute, because uv answers `cache-dir = "relcache"` with "relcache" and setup.sh
     # changes directory before it runs uv: a relative path we verified here would name a
-    # different, cold directory there.
-    return Path(os.path.abspath(os.path.expanduser(lines[-1])))
+    # different, cold directory there. Resolved against uv's working directory, which
+    # --directory / UV_WORKING_DIR moves out from under ours, and WITHOUT expanduser,
+    # because uv prints a configured `~/...` verbatim and then treats the tilde as an
+    # ordinary path segment, creating a literal "~" directory rather than one in $HOME.
+    base = os.environ.get("UV_WORKING_DIR") or os.getcwd()
+    return Path(os.path.abspath(os.path.join(base, lines[-1])))
 
 
 def _with_studio_uv_cache(env: Optional[dict]) -> Optional[dict]:

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3723,12 +3723,18 @@ def _uv_default_cache_dir(cwd: Optional[Path] = None) -> Optional[Path]:
     if result.returncode != 0:
         # A malformed uv.toml beside the CALLER fails this, though setup.sh runs uv elsewhere.
         return _uv_platform_cache_dir()
-    lines = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+    # Blank lines are dropped, the path itself is not stripped: a directory name may
+    # legitimately begin or end with a space, and uv reports it verbatim.
+    lines = [line for line in (result.stdout or "").splitlines() if line.strip()]
     if not lines:
         return _uv_platform_cache_dir()
     # uv answers a relative cache-dir with the relative spelling, resolved against its own
-    # working directory. No expanduser: uv makes a literal "~" directory, not one in $HOME.
-    base = os.environ.get("UV_WORKING_DIR") or (str(cwd) if cwd is not None else os.getcwd())
+    # working directory. UV_WORKING_DIR may itself be relative, and uv resolves that after
+    # starting where this probe started, not where the update was launched from.
+    # No expanduser: uv makes a literal "~" directory, not one in $HOME.
+    probe_cwd = str(cwd) if cwd is not None else os.getcwd()
+    working = os.environ.get("UV_WORKING_DIR")
+    base = os.path.join(probe_cwd, working) if working else probe_cwd
     return Path(os.path.abspath(os.path.join(base, lines[-1])))
 
 
@@ -3834,9 +3840,12 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
         raise typer.Exit(1)
 
     env = {**os.environ, "UNSLOTH_VERBOSE": "1"} if verbose else None
-    # The setup script's own directory: that is where it will run uv from, so that is
-    # where the probe has to ask what uv would default to.
-    env = _with_studio_uv_cache(env, cwd = script.parent)
+    # Where setup will run uv from, which is not the same answer on both platforms.
+    # setup.sh changes into its own directory first (studio/setup.sh:1788); setup.ps1
+    # never changes directory, it addresses everything through $PSScriptRoot and hands
+    # install_python_stack.py the cwd it inherited from here (studio/setup.ps1:5191).
+    setup_cwd = None if platform.system() == "Windows" else script.parent
+    env = _with_studio_uv_cache(env, cwd = setup_cwd)
 
     if platform.system() == "Windows":
         # Resolved, not bare: the gate that runs immediately before this in setup() and update()

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3690,6 +3690,21 @@ def _uv_platform_cache_dir() -> Optional[Path]:
     return Path(home) / ".cache" / "uv" if home else None
 
 
+# clap's boolish spelling, which is what uv parses these as. A value outside this set is
+# an error uv refuses to run on, so it is not "no cache" either.
+_UV_TRUE = ("1", "true", "yes", "on")
+
+
+def _uv_no_cache_requested() -> bool:
+    """uv --no-cache puts the cache in a temporary directory and discards it on exit.
+
+    Nothing this module decides applies then: the probe would report that throwaway
+    directory, --no-cache outranks --cache-dir anyway, and recording what setup did not
+    keep would aim later updates at a cache that never existed.
+    """
+    return (os.environ.get("UV_NO_CACHE") or "").strip().lower() in _UV_TRUE
+
+
 def _uv_default_cache_dir(cwd: Optional[Path] = None) -> Optional[Path]:
     """Asked of uv, not reconstructed, so uv.toml and UV_CONFIG_FILE count.
 
@@ -3773,6 +3788,9 @@ def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
     if (os.environ.get("UV_CACHE_DIR") or "").strip():
         # One run's value. Only an installer's own choice becomes a marker.
         return
+    if _uv_no_cache_requested():
+        # Setup cached nothing that outlived it, so there is no choice to record.
+        return
     chosen = (env or {}).get("UV_CACHE_DIR")
     if not chosen:
         return
@@ -3803,6 +3821,10 @@ def _with_studio_uv_cache(env: Optional[dict], cwd: Optional[Path] = None) -> Op
     """An update reached neither installer nor _setup_cache_env, so uv re-downloaded
     what the install had just fetched."""
     if (os.environ.get("UV_CACHE_DIR") or "").strip():
+        return env
+    if _uv_no_cache_requested():
+        # --no-cache outranks --cache-dir, so naming one would change nothing except what
+        # this reads back afterwards.
         return env
     studio_cache = STUDIO_HOME / "cache" / "uv"
     recorded = _recorded_install_uv_cache()

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3722,12 +3722,71 @@ def _uv_default_cache_dir() -> Optional[Path]:
     return Path(os.path.abspath(os.path.join(base, lines[-1])))
 
 
+def _recorded_install_uv_cache() -> Optional[Path]:
+    """The cache the installer used, as it recorded it.
+
+    Content cannot tell a Studio cache the installer filled from one holding a single
+    wheel the running backend dropped there (wheel_utils.py:405), since install.sh:705
+    points it there even in shared mode. Absent, the caller falls back to content.
+    """
+    try:
+        # utf-8-sig: Windows PowerShell 5.1 writes `-Encoding utf8` WITH a BOM.
+        # surrogateescape: a POSIX path may not be UTF-8, and U+FFFD would name nothing.
+        recorded = (STUDIO_HOME / "cache" / "uv-cache-dir").read_text(
+            encoding = "utf-8-sig", errors = "surrogateescape"
+        )
+    except OSError:
+        return None
+    # Not stripped: a recorded path may end or begin with a space. Blank means unset.
+    lines = [line for line in recorded.splitlines() if line.strip()]
+    if not lines:
+        return None
+    # No expanduser, as in the probe: uv treats a tilde as an ordinary path segment.
+    return Path(os.path.abspath(lines[-1]))
+
+
+def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
+    """Record the cache this update used, for installs whose installer never did.
+
+    Those reach the content fallback, which goes stale the moment the backend drops one
+    wheel into the Studio cache and both caches look warm. Writing the choice down once
+    setup has succeeded closes that, and likewise for a marker whose cache was emptied.
+    """
+    if (os.environ.get("UV_CACHE_DIR") or "").strip():
+        # One run's value. Only an installer's own choice becomes a marker.
+        return
+    if (os.environ.get(_studio_stage.STAGE_ROOT_ENV) or "").strip():
+        # STUDIO_HOME names the LIVE install here, and the stage can still be rejected.
+        return
+    chosen = (env or {}).get("UV_CACHE_DIR")
+    if not chosen:
+        return
+    live = _recorded_install_uv_cache()
+    if live is not None and _uv_cache_has_packages(live):
+        return
+    marker = STUDIO_HOME / "cache" / "uv-cache-dir"
+    try:
+        marker.parent.mkdir(parents = True, exist_ok = True)
+        # Unlinked first: a write follows a symlink and truncates its target.
+        marker.unlink(missing_ok = True)
+        # fsencode: an undecodable path arrives as surrogates, and encoding those raises
+        # UnicodeEncodeError, which is not an OSError.
+        marker.write_bytes(os.fsencode(f"{chosen}\n"))
+    except (OSError, ValueError):
+        # ValueError covers UnicodeError, for a path fsencode still cannot render.
+        pass
+
+
 def _with_studio_uv_cache(env: Optional[dict]) -> Optional[dict]:
     """An update reached neither installer nor _setup_cache_env, so uv re-downloaded
     what the install had just fetched."""
     if (os.environ.get("UV_CACHE_DIR") or "").strip():
         return env
     studio_cache = STUDIO_HOME / "cache" / "uv"
+    recorded = _recorded_install_uv_cache()
+    if recorded is not None and _uv_cache_has_packages(recorded):
+        # Only while it holds something: a marker for an emptied cache loses to a warm one.
+        return {**(env or os.environ), "UV_CACHE_DIR": str(recorded)}
     if not _uv_cache_has_packages(studio_cache):
         # _setup_cache_env mkdirs this empty every server start: a shared-mode install
         # would be sent to a cache holding nothing, which --offline cannot recover from.
@@ -3809,6 +3868,8 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
 
     if returncode != 0:
         raise typer.Exit(returncode)
+    # Only now: a cache that did not get through setup is not one to record.
+    _backfill_uv_cache_marker(env)
 
 
 # The refresh re-runs the installer with --shortcuts-only, fetched rather than shipped

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3815,14 +3815,18 @@ def _with_studio_uv_cache(env: Optional[dict], cwd: Optional[Path] = None) -> Op
     if recorded is not None and _uv_cache_has_packages(recorded):
         # Only while it holds something: a marker for an emptied cache loses to a warm one.
         return {**(env or os.environ), "UV_CACHE_DIR": str(recorded)}
-    if not _uv_cache_has_packages(studio_cache):
-        # _setup_cache_env mkdirs this empty every server start: a shared-mode install
-        # would be sent to a cache holding nothing, which --offline cannot recover from.
-        default_cache = _uv_default_cache_dir(cwd)
-        if default_cache is not None and _uv_cache_has_packages(default_cache):
-            # Named, not re-resolved: a blank inherited value reaches uv as
-            # `--cache-dir ''` and exits 2.
-            return {**(env or os.environ), "UV_CACHE_DIR": str(default_cache)}
+    # No marker, so this install predates it and content is all there is. _setup_cache_env
+    # mkdirs the Studio cache empty on every server start, so an empty one says nothing;
+    # and a warm one says less than it looks, because install.sh:705 points the running
+    # backend there even in shared mode, so a single on-demand wheel warms it. Where both
+    # are warm the two are indistinguishable, and uv's default is what such an install has
+    # been updating from all along: preferring the Studio cache there would be a new way
+    # for an offline update to fail, on an install that cannot record its way out.
+    default_cache = _uv_default_cache_dir(cwd)
+    if default_cache is not None and _uv_cache_has_packages(default_cache):
+        # Named, not re-resolved: a blank inherited value reaches uv as
+        # `--cache-dir ''` and exits 2.
+        return {**(env or os.environ), "UV_CACHE_DIR": str(default_cache)}
     return {**(env or os.environ), "UV_CACHE_DIR": str(studio_cache)}
 
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3664,9 +3664,8 @@ def _uv_cache_has_packages(cache_dir: Path) -> bool:
             if entry.name.startswith(_UV_CACHE_BUCKETS) and entry.is_dir()
         ]
     except (OSError, ValueError):
-        # ValueError, not just OSError: a marker someone edited to hold an embedded NUL
-        # builds a Path fine and then raises out of scandir, which would abort an update
-        # over a file this code is meant to treat as advisory.
+        # ValueError too: an embedded NUL builds a Path fine and then raises out of
+        # scandir, aborting an update over a file that is only advisory.
         return False
     for bucket in buckets:
         for _root, _dirs, files in os.walk(bucket):
@@ -3723,15 +3722,13 @@ def _uv_default_cache_dir(cwd: Optional[Path] = None) -> Optional[Path]:
     if result.returncode != 0:
         # A malformed uv.toml beside the CALLER fails this, though setup.sh runs uv elsewhere.
         return _uv_platform_cache_dir()
-    # Blank lines are dropped, the path itself is not stripped: a directory name may
-    # legitimately begin or end with a space, and uv reports it verbatim.
+    # Not stripped: a name may end in a space, and uv reports it verbatim.
     lines = [line for line in (result.stdout or "").splitlines() if line.strip()]
     if not lines:
         return _uv_platform_cache_dir()
-    # uv answers a relative cache-dir with the relative spelling, resolved against its own
-    # working directory. UV_WORKING_DIR may itself be relative, and uv resolves that after
-    # starting where this probe started, not where the update was launched from.
-    # No expanduser: uv makes a literal "~" directory, not one in $HOME.
+    # uv answers a relative cache-dir with the relative spelling, against its own working
+    # directory, and resolves a relative UV_WORKING_DIR after starting where this probe
+    # did. No expanduser: uv makes a literal "~" directory, not one in $HOME.
     probe_cwd = str(cwd) if cwd is not None else os.getcwd()
     working = os.environ.get("UV_WORKING_DIR")
     base = os.path.join(probe_cwd, working) if working else probe_cwd
@@ -3753,10 +3750,9 @@ def _recorded_install_uv_cache() -> Optional[Path]:
         )
     except OSError:
         return None
-    # One record, one trailing delimiter, and everything before it is the path: splitting
-    # on lines would take a POSIX path containing a newline for several records and keep
-    # the last fragment. Not otherwise stripped, since a path may end or begin with a
-    # space; blank still means unset.
+    # One record, one trailing delimiter, everything before it the path: splitting on
+    # lines would take a POSIX path containing a newline for several. Not otherwise
+    # stripped, since a path may end or begin with a space; blank means unset.
     if recorded.endswith("\n"):
         recorded = recorded[:-1]
     if recorded.endswith("\r"):
@@ -3785,11 +3781,9 @@ def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
         return
     stage_root = (os.environ.get(_studio_stage.STAGE_ROOT_ENV) or "").strip()
     if stage_root:
-        # STUDIO_HOME names the LIVE install here and the stage can still be rejected, so
-        # the choice is parked in the stage and _studio_stage.stage promotes it once the
-        # stage is accepted. Writing the live marker now would record an update that may
-        # never activate; not writing at all left desktop-only installs, which never take
-        # the direct path, permanently on the content fallback this exists to replace.
+        # STUDIO_HOME names the LIVE install here and the stage can still be rejected,
+        # so the choice is parked and _studio_stage.stage promotes it on acceptance.
+        # Dropping it instead left desktop-only installs on the content fallback.
         marker = Path(stage_root) / _studio_stage.UV_CACHE_MARKER
     else:
         marker = STUDIO_HOME / "cache" / "uv-cache-dir"
@@ -3797,8 +3791,8 @@ def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
         marker.parent.mkdir(parents = True, exist_ok = True)
         # Unlinked first: a write follows a symlink and truncates its target.
         marker.unlink(missing_ok = True)
-        # fsencode: an undecodable path arrives as surrogates, and encoding those raises
-        # UnicodeEncodeError, which is not an OSError.
+        # fsencode: an undecodable path arrives as surrogates, and encoding those
+        # raises UnicodeEncodeError, which is not an OSError.
         marker.write_bytes(os.fsencode(f"{chosen}\n"))
     except (OSError, ValueError):
         # ValueError covers UnicodeError, for a path fsencode still cannot render.
@@ -3815,13 +3809,10 @@ def _with_studio_uv_cache(env: Optional[dict], cwd: Optional[Path] = None) -> Op
     if recorded is not None and _uv_cache_has_packages(recorded):
         # Only while it holds something: a marker for an emptied cache loses to a warm one.
         return {**(env or os.environ), "UV_CACHE_DIR": str(recorded)}
-    # No marker, so this install predates it and content is all there is. _setup_cache_env
-    # mkdirs the Studio cache empty on every server start, so an empty one says nothing;
-    # and a warm one says less than it looks, because install.sh:705 points the running
-    # backend there even in shared mode, so a single on-demand wheel warms it. Where both
-    # are warm the two are indistinguishable, and uv's default is what such an install has
-    # been updating from all along: preferring the Studio cache there would be a new way
-    # for an offline update to fail, on an install that cannot record its way out.
+    # No marker, so this install predates it and content is all there is, and content
+    # cannot settle it: install.sh:705 points the running backend at the Studio cache even
+    # in shared mode, so one on-demand wheel warms it. uv's default is what such an install
+    # has been updating from all along, and it cannot record its way out of a wrong guess.
     default_cache = _uv_default_cache_dir(cwd)
     if default_cache is not None and _uv_cache_has_packages(default_cache):
         # Named, not re-resolved: a blank inherited value reaches uv as
@@ -3844,10 +3835,9 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
         raise typer.Exit(1)
 
     env = {**os.environ, "UNSLOTH_VERBOSE": "1"} if verbose else None
-    # Where setup will run uv from, which is not the same answer on both platforms.
-    # setup.sh changes into its own directory first (studio/setup.sh:1788); setup.ps1
-    # never changes directory, it addresses everything through $PSScriptRoot and hands
-    # install_python_stack.py the cwd it inherited from here (studio/setup.ps1:5191).
+    # Where setup will run uv from, which differs by platform: setup.sh changes into its
+    # own directory (setup.sh:1788), setup.ps1 never does and hands install_python_stack.py
+    # the cwd it inherited from here (setup.ps1:5191).
     setup_cwd = None if platform.system() == "Windows" else script.parent
     env = _with_studio_uv_cache(env, cwd = setup_cwd)
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3655,12 +3655,8 @@ _UV_CACHE_METADATA_SUFFIXES = (".lock", ".msgpack", ".http", ".rev")
 
 
 def _uv_cache_has_packages(cache_dir: Path) -> bool:
-    """Does this uv cache hold package bytes, or only metadata?
-
-    Same rule as install.sh:_configure_uv_cache, deliberately: wheels-* carries only
-    .msgpack/.http on uv 0.10, so counting any file at all reads a cache that has merely
-    been resolved against as if it were warm.
-    """
+    """wheels-* is metadata only on uv 0.10, so counting any file reads a cache that was
+    merely resolved against as warm. Same rule as install.sh:_configure_uv_cache."""
     try:
         buckets = [
             entry
@@ -3681,11 +3677,7 @@ def _uv_cache_has_packages(cache_dir: Path) -> bool:
 
 
 def _uv_platform_cache_dir() -> Optional[Path]:
-    """Where uv puts its cache with no configuration, mirroring install.sh:646.
-
-    Only reached when uv cannot be asked. Asking is better, since it accounts for uv.toml
-    and UV_CONFIG_FILE, but "we could not ask" must not read as "there is no cache".
-    """
+    """install.sh:646's fallback, for when uv cannot be asked: that is not "no cache"."""
     if platform.system() == "Windows":
         local_app_data = (os.environ.get("LOCALAPPDATA") or "").strip()
         return Path(local_app_data) / "uv" / "cache" if local_app_data else None
@@ -3697,12 +3689,7 @@ def _uv_platform_cache_dir() -> Optional[Path]:
 
 
 def _uv_default_cache_dir() -> Optional[Path]:
-    """Where uv would put its cache if we set nothing.
-
-    Asked of uv rather than reconstructed, so uv.toml, UV_CONFIG_FILE and the platform
-    default all count; UV_CACHE_DIR is dropped so a blank inherited value cannot answer
-    for them, and the last nonblank line is the path in case a notice precedes it.
-    """
+    """Asked of uv, not reconstructed, so uv.toml and UV_CONFIG_FILE count."""
     uv = shutil.which("uv")
     if not uv:
         return _uv_platform_cache_dir()
@@ -3712,64 +3699,42 @@ def _uv_default_cache_dir() -> Optional[Path]:
             [uv, "cache", "dir"],
             capture_output = True,
             text = True,
-            # text=True alone decodes with the locale codec and STRICT errors, so a
-            # non-ASCII cache path on an ANSI console raises UnicodeDecodeError -- neither
-            # OSError nor SubprocessError, so it would escape the handler below and take
-            # the update down, exactly as it did for the profile probe above.
+            # UnicodeDecodeError is a ValueError, so the handler below would not catch it.
             encoding = "utf-8",
             errors = "replace",
             env = child_env,
             timeout = 30,
-            # Creation flags are not inherited, so a desktop update that is itself hidden
-            # still has to hide each process it starts.
+            # Creation flags are not inherited from a hidden desktop update.
             **_windows_hidden_subprocess_kwargs(),
         )
     except Exception:
-        # Best effort by design. Not knowing where uv would have put its cache costs the
-        # update a preference, never the update itself, so no failure to probe is worth
-        # raising through the caller.
+        # Best effort: not knowing costs a preference, never the update.
         return _uv_platform_cache_dir()
     if result.returncode != 0:
-        # uv discovers config from the CURRENT directory, so a malformed uv.toml beside
-        # whoever ran `unsloth studio update` makes this exit nonzero even though setup.sh
-        # changes directory before it runs uv at all. install.sh:646 falls back to the
-        # platform default rather than declaring the cache cold, and so does this.
+        # A malformed uv.toml beside the CALLER fails this, though setup.sh runs uv elsewhere.
         return _uv_platform_cache_dir()
     lines = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
     if not lines:
         return _uv_platform_cache_dir()
-    # Absolute, because uv answers `cache-dir = "relcache"` with "relcache" and setup.sh
-    # changes directory before it runs uv: a relative path we verified here would name a
-    # different, cold directory there. Resolved against uv's working directory, which
-    # --directory / UV_WORKING_DIR moves out from under ours, and WITHOUT expanduser,
-    # because uv prints a configured `~/...` verbatim and then treats the tilde as an
-    # ordinary path segment, creating a literal "~" directory rather than one in $HOME.
+    # uv answers a relative cache-dir with the relative spelling, resolved against its own
+    # working directory. No expanduser: uv makes a literal "~" directory, not one in $HOME.
     base = os.environ.get("UV_WORKING_DIR") or os.getcwd()
     return Path(os.path.abspath(os.path.join(base, lines[-1])))
 
 
 def _with_studio_uv_cache(env: Optional[dict]) -> Optional[dict]:
-    """Point the setup script's uv at the cache the install used.
-
-    The installers set UV_CACHE_DIR and storage_roots._setup_cache_env sets it for the
-    server, but an update runs setup.sh/setup.ps1 from here and reached neither, so uv
-    re-downloaded into its own default what the install had just fetched.
-    """
+    """An update reached neither installer nor _setup_cache_env, so uv re-downloaded
+    what the install had just fetched."""
     if (os.environ.get("UV_CACHE_DIR") or "").strip():
         return env
     studio_cache = STUDIO_HOME / "cache" / "uv"
     if not _uv_cache_has_packages(studio_cache):
-        # A shared-mode install left the wheels in uv's own cache and _setup_cache_env
-        # mkdirs this one empty on every server start, so redirecting here would send the
-        # update to a cache that has nothing in it. Online that is one wasted download;
-        # under --offline / UV_OFFLINE / uv.toml offline = true, where uv may read only
-        # what is already cached, it is an update that cannot resolve at all.
+        # _setup_cache_env mkdirs this empty every server start: a shared-mode install
+        # would be sent to a cache holding nothing, which --offline cannot recover from.
         default_cache = _uv_default_cache_dir()
         if default_cache is not None and _uv_cache_has_packages(default_cache):
-            # Named, not left for the child to resolve a second time. A blank inherited
-            # UV_CACHE_DIR reaches uv as `--cache-dir ''`, which exits 2 with "a value is
-            # required" on every uv command, and a cache that came from a uv.toml beside
-            # the caller is not the one uv finds once setup.sh changes directory.
+            # Named, not re-resolved: a blank inherited value reaches uv as
+            # `--cache-dir ''` and exits 2.
             return {**(env or os.environ), "UV_CACHE_DIR": str(default_cache)}
     return {**(env or os.environ), "UV_CACHE_DIR": str(studio_cache)}
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3690,18 +3690,15 @@ def _uv_platform_cache_dir() -> Optional[Path]:
     return Path(home) / ".cache" / "uv" if home else None
 
 
-# clap's boolish spelling, which is what uv parses these as. A value outside this set is
-# an error uv refuses to run on, so it is not "no cache" either.
+# uv's boolish spelling. Anything outside it is a value uv refuses to run on, which is
+# not "no cache" either.
 _UV_TRUE = ("1", "true", "yes", "on")
 
 
 def _uv_no_cache_requested() -> bool:
-    """uv --no-cache puts the cache in a temporary directory and discards it on exit.
-
-    Nothing this module decides applies then: the probe would report that throwaway
-    directory, --no-cache outranks --cache-dir anyway, and recording what setup did not
-    keep would aim later updates at a cache that never existed.
-    """
+    """uv --no-cache caches in a temporary directory and discards it on exit, so the
+    probe would report that throwaway, --no-cache outranks --cache-dir anyway, and
+    recording it would aim later updates at a cache that never existed."""
     return (os.environ.get("UV_NO_CACHE") or "").strip().lower() in _UV_TRUE
 
 
@@ -3823,8 +3820,7 @@ def _with_studio_uv_cache(env: Optional[dict], cwd: Optional[Path] = None) -> Op
     if (os.environ.get("UV_CACHE_DIR") or "").strip():
         return env
     if _uv_no_cache_requested():
-        # --no-cache outranks --cache-dir, so naming one would change nothing except what
-        # this reads back afterwards.
+        # --no-cache outranks --cache-dir, so naming one changes nothing.
         return env
     studio_cache = STUDIO_HOME / "cache" / "uv"
     recorded = _recorded_install_uv_cache()

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3691,8 +3691,14 @@ def _uv_platform_cache_dir() -> Optional[Path]:
     return Path(home) / ".cache" / "uv" if home else None
 
 
-def _uv_default_cache_dir() -> Optional[Path]:
-    """Asked of uv, not reconstructed, so uv.toml and UV_CONFIG_FILE count."""
+def _uv_default_cache_dir(cwd: Optional[Path] = None) -> Optional[Path]:
+    """Asked of uv, not reconstructed, so uv.toml and UV_CONFIG_FILE count.
+
+    Asked from where setup will ask it, too. Both setup scripts change into their own
+    directory before the dependency pass (studio/setup.sh:1788), and uv discovers
+    uv.toml and pyproject.toml from its working directory, so probing in the caller's
+    would answer for whatever project the user happens to be standing in.
+    """
     uv = shutil.which("uv")
     if not uv:
         return _uv_platform_cache_dir()
@@ -3700,6 +3706,7 @@ def _uv_default_cache_dir() -> Optional[Path]:
     try:
         result = subprocess.run(
             [uv, "cache", "dir"],
+            cwd = str(cwd) if cwd is not None else None,
             capture_output = True,
             text = True,
             # UnicodeDecodeError is a ValueError, so the handler below would not catch it.
@@ -3721,7 +3728,7 @@ def _uv_default_cache_dir() -> Optional[Path]:
         return _uv_platform_cache_dir()
     # uv answers a relative cache-dir with the relative spelling, resolved against its own
     # working directory. No expanduser: uv makes a literal "~" directory, not one in $HOME.
-    base = os.environ.get("UV_WORKING_DIR") or os.getcwd()
+    base = os.environ.get("UV_WORKING_DIR") or (str(cwd) if cwd is not None else os.getcwd())
     return Path(os.path.abspath(os.path.join(base, lines[-1])))
 
 
@@ -3740,12 +3747,18 @@ def _recorded_install_uv_cache() -> Optional[Path]:
         )
     except OSError:
         return None
-    # Not stripped: a recorded path may end or begin with a space. Blank means unset.
-    lines = [line for line in recorded.splitlines() if line.strip()]
-    if not lines:
+    # One record, one trailing delimiter, and everything before it is the path: splitting
+    # on lines would take a POSIX path containing a newline for several records and keep
+    # the last fragment. Not otherwise stripped, since a path may end or begin with a
+    # space; blank still means unset.
+    if recorded.endswith("\n"):
+        recorded = recorded[:-1]
+    if recorded.endswith("\r"):
+        recorded = recorded[:-1]
+    if not recorded.strip():
         return None
     # No expanduser, as in the probe: uv treats a tilde as an ordinary path segment.
-    return Path(os.path.abspath(lines[-1]))
+    return Path(os.path.abspath(recorded))
 
 
 def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
@@ -3786,7 +3799,7 @@ def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
         pass
 
 
-def _with_studio_uv_cache(env: Optional[dict]) -> Optional[dict]:
+def _with_studio_uv_cache(env: Optional[dict], cwd: Optional[Path] = None) -> Optional[dict]:
     """An update reached neither installer nor _setup_cache_env, so uv re-downloaded
     what the install had just fetched."""
     if (os.environ.get("UV_CACHE_DIR") or "").strip():
@@ -3799,7 +3812,7 @@ def _with_studio_uv_cache(env: Optional[dict]) -> Optional[dict]:
     if not _uv_cache_has_packages(studio_cache):
         # _setup_cache_env mkdirs this empty every server start: a shared-mode install
         # would be sent to a cache holding nothing, which --offline cannot recover from.
-        default_cache = _uv_default_cache_dir()
+        default_cache = _uv_default_cache_dir(cwd)
         if default_cache is not None and _uv_cache_has_packages(default_cache):
             # Named, not re-resolved: a blank inherited value reaches uv as
             # `--cache-dir ''` and exits 2.
@@ -3821,7 +3834,9 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
         raise typer.Exit(1)
 
     env = {**os.environ, "UNSLOTH_VERBOSE": "1"} if verbose else None
-    env = _with_studio_uv_cache(env)
+    # The setup script's own directory: that is where it will run uv from, so that is
+    # where the probe has to ask what uv would default to.
+    env = _with_studio_uv_cache(env, cwd = script.parent)
 
     if platform.system() == "Windows":
         # Resolved, not bare: the gate that runs immediately before this in setup() and update()

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3663,7 +3663,10 @@ def _uv_cache_has_packages(cache_dir: Path) -> bool:
             for entry in cache_dir.iterdir()
             if entry.name.startswith(_UV_CACHE_BUCKETS) and entry.is_dir()
         ]
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError, not just OSError: a marker someone edited to hold an embedded NUL
+        # builds a Path fine and then raises out of scandir, which would abort an update
+        # over a file this code is meant to treat as advisory.
         return False
     for bucket in buckets:
         for _root, _dirs, files in os.walk(bucket):
@@ -3755,16 +3758,22 @@ def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
     if (os.environ.get("UV_CACHE_DIR") or "").strip():
         # One run's value. Only an installer's own choice becomes a marker.
         return
-    if (os.environ.get(_studio_stage.STAGE_ROOT_ENV) or "").strip():
-        # STUDIO_HOME names the LIVE install here, and the stage can still be rejected.
-        return
     chosen = (env or {}).get("UV_CACHE_DIR")
     if not chosen:
         return
     live = _recorded_install_uv_cache()
     if live is not None and _uv_cache_has_packages(live):
         return
-    marker = STUDIO_HOME / "cache" / "uv-cache-dir"
+    stage_root = (os.environ.get(_studio_stage.STAGE_ROOT_ENV) or "").strip()
+    if stage_root:
+        # STUDIO_HOME names the LIVE install here and the stage can still be rejected, so
+        # the choice is parked in the stage and _studio_stage.stage promotes it once the
+        # stage is accepted. Writing the live marker now would record an update that may
+        # never activate; not writing at all left desktop-only installs, which never take
+        # the direct path, permanently on the content fallback this exists to replace.
+        marker = Path(stage_root) / _studio_stage.UV_CACHE_MARKER
+    else:
+        marker = STUDIO_HOME / "cache" / "uv-cache-dir"
     try:
         marker.parent.mkdir(parents = True, exist_ok = True)
         # Unlinked first: a write follows a symlink and truncates its target.

--- a/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
+++ b/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
@@ -88,7 +88,12 @@ def test_the_setup_handoff_spawns_the_resolved_interpreter(monkeypatch, tmp_path
 
     studio._run_setup_script(repo_root = repo_root)
 
-    assert spawned and spawned[0][0] == _RESOLVED, spawned
+    # The handoff, not merely the first spawn: _run_setup_script asks uv where its cache
+    # is before it hands over, and subprocess.run is built on Popen, so that probe lands
+    # here too. What this test is about is which interpreter the handoff itself uses.
+    handoffs = [argv for argv in spawned if argv and argv[-1].endswith("*>&1")]
+    assert len(handoffs) == 1, spawned
+    assert handoffs[0][0] == _RESOLVED, spawned
 
 
 def test_the_profile_probe_falls_back_to_the_resolved_interpreter(monkeypatch, tmp_path):

--- a/unsloth_cli/tests/test_studio_update_stage.py
+++ b/unsloth_cli/tests/test_studio_update_stage.py
@@ -155,6 +155,73 @@ def test_stage_builds_a_ready_marker_from_a_successful_update(monkeypatch, tmp_p
     assert echoed == ["[TAURI:STEP] clone", "[TAURI:STEP] update", "[TAURI:STEP] verify"]
 
 
+def test_an_accepted_stage_publishes_the_uv_cache_it_used(monkeypatch, tmp_path):
+    """The staged child cannot write the live marker: STUDIO_HOME names the install it is
+    replacing, and the stage may never activate. It parks the choice, and acceptance is
+    what publishes it, or a desktop-only install never records one at all."""
+    home = tmp_path / "studio"
+    _make_venv(home)
+    monkeypatch.delenv(_studio_stage.SHELL_VERSION_ENV, raising = False)
+
+    def fake_update(root: Path, args: list[str]) -> int:
+        (root / _studio_stage.UV_CACHE_MARKER).write_text("/warm/uv\n", encoding = "utf-8")
+        return 0
+
+    monkeypatch.setattr(_studio_stage, "installed_version", lambda venv, env: "2026.9.1")
+    monkeypatch.setattr(_studio_stage, "probe_cli", lambda venv, env: None)
+    monkeypatch.setattr(_studio_stage, "probe_console_script", lambda venv, env: None)
+
+    _studio_stage.stage(home, update_args = [], echo = lambda _: None, run_update = fake_update)
+
+    live = home / "cache" / _studio_stage.UV_CACHE_MARKER
+    assert live.read_text(encoding = "utf-8").strip() == "/warm/uv"
+
+
+def test_a_rejected_stage_publishes_nothing(monkeypatch, tmp_path):
+    """Verification is the acceptance point, so a stage that parks a choice and then fails
+    its probes must leave the live install pointing where it already pointed."""
+    home = tmp_path / "studio"
+    _make_venv(home)
+    (home / "cache").mkdir(parents = True)
+    (home / "cache" / _studio_stage.UV_CACHE_MARKER).write_text("/live/uv\n", encoding = "utf-8")
+    monkeypatch.delenv(_studio_stage.SHELL_VERSION_ENV, raising = False)
+
+    def fake_update(root: Path, args: list[str]) -> int:
+        (root / _studio_stage.UV_CACHE_MARKER).write_text("/staged/uv\n", encoding = "utf-8")
+        return 0
+
+    def refuse(venv, env):
+        raise _studio_stage.StageError("staged environment failed to start")
+
+    monkeypatch.setattr(_studio_stage, "probe_cli", refuse)
+
+    with pytest.raises(_studio_stage.StageError):
+        _studio_stage.stage(home, update_args = [], echo = lambda _: None, run_update = fake_update)
+
+    live = home / "cache" / _studio_stage.UV_CACHE_MARKER
+    assert live.read_text(encoding = "utf-8").strip() == "/live/uv"
+
+
+def test_a_stage_that_parks_nothing_leaves_the_live_marker_alone(monkeypatch, tmp_path):
+    """Nothing to promote is the normal case for a caller-pinned UV_CACHE_DIR, and it must
+    not blank the marker an installer wrote."""
+    home = tmp_path / "studio"
+    _make_venv(home)
+    (home / "cache").mkdir(parents = True)
+    (home / "cache" / _studio_stage.UV_CACHE_MARKER).write_text("/live/uv\n", encoding = "utf-8")
+    monkeypatch.delenv(_studio_stage.SHELL_VERSION_ENV, raising = False)
+    monkeypatch.setattr(_studio_stage, "installed_version", lambda venv, env: "2026.9.1")
+    monkeypatch.setattr(_studio_stage, "probe_cli", lambda venv, env: None)
+    monkeypatch.setattr(_studio_stage, "probe_console_script", lambda venv, env: None)
+
+    _studio_stage.stage(
+        home, update_args = [], echo = lambda _: None, run_update = lambda root, args: 0
+    )
+
+    live = home / "cache" / _studio_stage.UV_CACHE_MARKER
+    assert live.read_text(encoding = "utf-8").strip() == "/live/uv"
+
+
 def test_stage_discards_the_tree_when_the_update_fails(monkeypatch, tmp_path):
     home = tmp_path / "studio"
     _make_venv(home)

--- a/unsloth_cli/tests/test_studio_update_stage.py
+++ b/unsloth_cli/tests/test_studio_update_stage.py
@@ -214,9 +214,7 @@ def test_a_stage_that_parks_nothing_leaves_the_live_marker_alone(monkeypatch, tm
     monkeypatch.setattr(_studio_stage, "probe_cli", lambda venv, env: None)
     monkeypatch.setattr(_studio_stage, "probe_console_script", lambda venv, env: None)
 
-    _studio_stage.stage(
-        home, update_args = [], echo = lambda _: None, run_update = lambda root, args: 0
-    )
+    _studio_stage.stage(home, update_args = [], echo = lambda _: None, run_update = lambda root, args: 0)
 
     live = home / "cache" / _studio_stage.UV_CACHE_MARKER
     assert live.read_text(encoding = "utf-8").strip() == "/live/uv"

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""`unsloth studio update` must reuse the cache the install filled, not uv's default.
+
+The installers set UV_CACHE_DIR (#10204) and storage_roots._setup_cache_env sets it
+for the server; an update ran setup.sh/setup.ps1 from the CLI process and reached
+neither, so it re-downloaded into uv's own default what the install had just fetched.
+
+It must not overcorrect either: a shared-mode install leaves the wheels in uv's own
+cache, and pointing the update at the empty Studio one costs a download online and
+fails outright when uv may read only what is cached.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _studio():
+    from unsloth_cli.commands import studio as _studio_mod
+    return _studio_mod
+
+
+def _setup_tree(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    (repo_root / "studio").mkdir(parents = True, exist_ok = True)
+    (repo_root / "studio" / "setup.sh").write_text("")
+    (repo_root / "studio" / "setup.ps1").write_text("")
+    return repo_root
+
+
+def _fill(
+    cache_dir: Path,
+    *,
+    bucket: str = "archive-v0",
+    name: str = "payload.so",
+) -> Path:
+    """Give a cache the shape uv gives it: a bucket directory holding package bytes."""
+    leaf = cache_dir / bucket / "pkg"
+    leaf.mkdir(parents = True, exist_ok = True)
+    (leaf / name).write_bytes(b"\0" * 16)
+    return cache_dir
+
+
+@pytest.fixture
+def caches(monkeypatch, tmp_path):
+    """Both caches, cold, and uv's default answered without spawning uv.
+
+    Every test states the state it needs; leaving the real machine's cache in play would
+    make the outcome depend on whoever ran the suite.
+    """
+    studio = _studio()
+    monkeypatch.delenv("UV_CACHE_DIR", raising = False)
+    studio_home = tmp_path / "StudioHome"
+    default_cache = tmp_path / "default-uv"
+    monkeypatch.setattr(studio, "STUDIO_HOME", studio_home)
+    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda: default_cache)
+    return studio_home / "cache" / "uv", default_cache
+
+
+class _Result:
+    returncode = 0
+
+
+def _run_posix(monkeypatch, tmp_path: Path) -> dict:
+    studio = _studio()
+    monkeypatch.setattr(studio.platform, "system", lambda: "Linux")
+    seen: dict = {}
+
+    def _fake_run(
+        argv,
+        env = None,
+        **kwargs,
+    ):
+        seen["argv"] = list(argv)
+        seen["env"] = env
+        return _Result()
+
+    monkeypatch.setattr(studio.subprocess, "run", _fake_run)
+    studio._run_setup_script(repo_root = _setup_tree(tmp_path))
+    return seen
+
+
+def test_the_update_uses_the_studio_cache_when_the_caller_set_none(monkeypatch, tmp_path, caches):
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"] is not None, "env must be materialised, not left as inherit-everything"
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_a_blank_uv_cache_dir_counts_as_unset(monkeypatch, tmp_path, caches, blank):
+    """storage_roots.py:373 treats blank as unset; the update path must agree, or an
+    inherited UV_CACHE_DIR= pins uv's cache to the empty string."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    monkeypatch.setenv("UV_CACHE_DIR", blank)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_an_explicit_uv_cache_dir_still_wins(monkeypatch, tmp_path, caches):
+    """Same precedence the installers use: a nonblank caller value is preserved
+    (install.sh:626, install.ps1:1232), so CI images that pin a cache keep it."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path / "caller cache"))
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"] is None or seen["env"]["UV_CACHE_DIR"] == str(
+        tmp_path / "caller cache"
+    ), seen["env"]
+
+
+def test_verbose_keeps_its_own_flag_alongside_the_cache(monkeypatch, tmp_path, caches):
+    """The verbose branch builds env first; the cache seeding must extend it, not
+    replace it."""
+    studio = _studio()
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    monkeypatch.setattr(studio.platform, "system", lambda: "Linux")
+    seen: dict = {}
+
+    def _fake_run(
+        argv,
+        env = None,
+        **kwargs,
+    ):
+        seen["env"] = env
+        return _Result()
+
+    monkeypatch.setattr(studio.subprocess, "run", _fake_run)
+    studio._run_setup_script(verbose = True, repo_root = _setup_tree(tmp_path))
+
+    assert seen["env"]["UNSLOTH_VERBOSE"] == "1", seen["env"].get("UNSLOTH_VERBOSE")
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache)
+
+
+def test_the_windows_branch_gets_the_same_cache(monkeypatch, tmp_path, caches):
+    """setup.ps1 runs the same uv pip installs, so the PowerShell spawn needs it too."""
+    studio = _studio()
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    monkeypatch.setattr(studio.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        studio._studio_runtime_gate, "resolve_windows_powershell", lambda: "powershell.exe"
+    )
+    monkeypatch.setattr(studio, "_probe_profile_proxy_defaults", lambda hosts: None)
+    monkeypatch.setattr(studio, "_wait_for_windows_setup_process", lambda process: 0)
+    seen: dict = {}
+
+    class _Process:
+        pass
+
+    def _fake_popen(
+        argv,
+        env = None,
+        **kwargs,
+    ):
+        seen["env"] = env
+        return _Process()
+
+    monkeypatch.setattr(studio.subprocess, "Popen", _fake_popen)
+    studio._run_setup_script(repo_root = _setup_tree(tmp_path))
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache)
+
+
+def test_the_seeding_does_not_leak_into_this_process(monkeypatch, tmp_path, caches):
+    """_ensure_studio_env_exported mutates os.environ on purpose; this must not, or a
+    later `unsloth studio` in the same process would look like a caller override to
+    storage_roots._setup_cache_env."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    _run_posix(monkeypatch, tmp_path)
+
+    assert "UV_CACHE_DIR" not in os.environ, os.environ.get("UV_CACHE_DIR")
+
+
+# --- Do not move the update off a warm cache onto a cold one -------------------------
+
+
+def test_a_shared_mode_install_keeps_the_cache_that_actually_has_the_wheels(
+    monkeypatch, tmp_path, caches
+):
+    """install.sh picks uv's own cache when it is already populated, and
+    _setup_cache_env mkdirs an empty Studio cache on every server start. Redirecting
+    here would re-download online and, under UV_OFFLINE / `offline = true`, fail:
+    uv reads only what is cached, and nothing is."""
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(default_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_a_blank_value_is_replaced_even_when_the_default_cache_wins(
+    monkeypatch, tmp_path, caches, blank
+):
+    """Leaving the environment alone here would hand uv the blank value it inherited.
+    uv reads UV_CACHE_DIR as --cache-dir, and `UV_CACHE_DIR= uv cache dir` exits 2 with
+    "a value is required for '--cache-dir'", so every uv call in setup.sh would die."""
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    monkeypatch.setenv("UV_CACHE_DIR", blank)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(default_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_the_chosen_cache_is_named_rather_than_left_to_the_child(monkeypatch, tmp_path, caches):
+    """setup.sh changes directory before running uv, so a cache uv resolved from a
+    uv.toml beside the caller is not one the child would find again. Whichever cache
+    wins, it reaches the child as an explicit path."""
+    studio_cache, default_cache = caches
+    for warm, expected in ((default_cache, default_cache), (studio_cache, studio_cache)):
+        _fill(warm)
+        seen = _run_posix(monkeypatch, tmp_path)
+        assert seen["env"]["UV_CACHE_DIR"] == str(expected), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_studio_mode_install_wins_over_a_populated_default(monkeypatch, tmp_path, caches):
+    """The case the PR exists for: the installer filled the Studio cache, so the update
+    must read it rather than uv's default, whatever else is lying around."""
+    studio_cache, default_cache = caches
+    _fill(studio_cache)
+    _fill(default_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_two_cold_caches_still_go_to_the_studio_one(monkeypatch, tmp_path, caches):
+    """Nothing to preserve, so keep the bytes under the Studio root where uninstall can
+    reclaim them (#10193)."""
+    studio_cache, _default = caches
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+@pytest.mark.parametrize("metadata", ["resolve.msgpack", "wheel.http", "pkg.lock", "x.rev"])
+def test_a_metadata_only_default_cache_is_not_warm(monkeypatch, tmp_path, caches, metadata):
+    """wheels-v6 holds only metadata on uv 0.10, so a single `uv pip install --dry-run`
+    would otherwise pin every later update to uv's default cache (#10204)."""
+    studio_cache, default_cache = caches
+    _fill(default_cache, bucket = "wheels-v6", name = metadata)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_default_cache_uv_cannot_name_does_not_block_the_redirect(monkeypatch, tmp_path, caches):
+    """No uv on PATH, or `uv cache dir` failing, must not strand the update on a cache
+    nobody can identify."""
+    studio = _studio()
+    studio_cache, _default = caches
+    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda: None)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+# --- The warmth test itself ----------------------------------------------------------
+
+
+def test_package_bytes_beside_metadata_count_as_warm(tmp_path):
+    """A real cache has both; the metadata filter must not hide the payload."""
+    studio = _studio()
+    cache = tmp_path / "uv"
+    _fill(cache, bucket = "wheels-v6", name = "resolve.msgpack")
+    _fill(cache, bucket = "wheels-v6", name = "torch.whl")
+
+    assert studio._uv_cache_has_packages(cache) is True
+
+
+@pytest.mark.parametrize("bucket", ["archive-v0", "builds-v0", "built-wheels-v3", "sdists-v9"])
+def test_every_bucket_uv_has_used_counts(tmp_path, bucket):
+    """uv renames these across versions, and an install.sh that scans a bucket this does
+    not would disagree with itself about which cache is warm."""
+    studio = _studio()
+    cache = tmp_path / bucket.split("-")[0]
+    _fill(cache, bucket = bucket)
+
+    assert studio._uv_cache_has_packages(cache) is True
+
+
+def test_an_absent_cache_is_not_warm(tmp_path):
+    studio = _studio()
+
+    assert studio._uv_cache_has_packages(tmp_path / "nope") is False
+
+
+# --- The uv probe ---------------------------------------------------------------------
+
+
+def _probe_kwargs(monkeypatch, stdout: str = "/cache/uv\n") -> dict:
+    studio = _studio()
+    monkeypatch.setattr(studio.shutil, "which", lambda name: "/usr/bin/uv")
+    seen: dict = {}
+
+    class _Completed:
+        returncode = 0
+
+    def _fake_run(argv, **kwargs):
+        seen.update(kwargs)
+        seen["argv"] = list(argv)
+        completed = _Completed()
+        completed.stdout = stdout
+        return completed
+
+    monkeypatch.setattr(studio.subprocess, "run", _fake_run)
+    seen["result"] = studio._uv_default_cache_dir()
+    return seen
+
+
+def test_the_probe_decodes_utf8_whatever_the_console_codec_is(monkeypatch):
+    """text=True alone decodes with the locale codec and strict errors, so a non-ASCII
+    cache path raises UnicodeDecodeError. That is a ValueError, so the OSError /
+    SubprocessError handler does not catch it and the update dies. Same reason the
+    profile probe above already pins the codec."""
+    seen = _probe_kwargs(monkeypatch)
+
+    assert seen["encoding"] == "utf-8", seen.get("encoding")
+    assert seen["errors"] == "replace", seen.get("errors")
+
+
+def test_the_probe_is_hidden_like_every_other_spawn(monkeypatch):
+    """A desktop update runs the CLI with CREATE_NO_WINDOW, and creation flags are not
+    inherited, so each process it starts has to ask for them itself."""
+    studio = _studio()
+    monkeypatch.setattr(studio, "_should_hide_windows_subprocesses", lambda: True)
+    monkeypatch.setattr(studio.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising = False)
+    seen = _probe_kwargs(monkeypatch)
+
+    expected = studio._windows_hidden_subprocess_kwargs()
+    for key, value in expected.items():
+        assert key in seen, f"{key} missing from the probe call"
+    assert seen.get("creationflags") == expected.get("creationflags")
+
+
+def test_the_probe_absolutises_a_relative_answer(monkeypatch, tmp_path):
+    """uv answers `cache-dir = "relcache"` with "relcache" verbatim, and setup.sh runs uv
+    from a different directory, so a relative answer names a different, cold cache there."""
+    monkeypatch.chdir(tmp_path)
+    seen = _probe_kwargs(monkeypatch, stdout = "relcache\n")
+
+    assert seen["result"] == tmp_path / "relcache", seen["result"]
+
+
+def test_a_probe_that_blows_up_costs_a_preference_not_the_update(monkeypatch):
+    """subprocess.run is implemented with Popen, so any caller that fakes Popen reaches
+    this probe too. Losing the answer is fine; raising through an update is not."""
+    studio = _studio()
+    monkeypatch.setattr(studio.shutil, "which", lambda name: "/usr/bin/uv")
+
+    def _boom(argv, **kwargs):
+        raise TypeError("object does not support the context manager protocol")
+
+    monkeypatch.setattr(studio.subprocess, "run", _boom)
+
+    assert studio._uv_default_cache_dir() is None
+
+
+def test_the_probe_reads_the_last_nonblank_line(monkeypatch):
+    """A wrapper or a future uv may print a notice ahead of the path, and a two-line
+    value is not a directory."""
+    seen = _probe_kwargs(monkeypatch, stdout = "warning: something\n/real/cache/uv\n\n")
+
+    assert seen["result"] == Path("/real/cache/uv"), seen["result"]
+
+
+def test_the_probe_hides_uv_cache_dir_from_uv(monkeypatch):
+    """Asking uv for its default while UV_CACHE_DIR is set would just echo that value
+    back, and a blank one makes uv exit 2 instead of answering."""
+    monkeypatch.setenv("UV_CACHE_DIR", "")
+    seen = _probe_kwargs(monkeypatch)
+
+    assert "UV_CACHE_DIR" not in seen["env"], seen["env"].get("UV_CACHE_DIR")
+
+
+def test_files_outside_a_bucket_are_not_warm(tmp_path):
+    """uv writes CACHEDIR.TAG and .gitignore at the cache root; a cache holding only
+    those has never fetched anything."""
+    studio = _studio()
+    cache = tmp_path / "uv"
+    cache.mkdir()
+    (cache / "CACHEDIR.TAG").write_text("Signature: 8a477f597d28d172789f06886806bc55")
+    (cache / ".gitignore").write_text("*")
+    (cache / "simple-v20").mkdir()
+    (cache / "simple-v20" / "index.msgpack").write_bytes(b"\0")
+
+    assert studio._uv_cache_has_packages(cache) is False

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -355,10 +355,35 @@ def test_the_probe_is_hidden_like_every_other_spawn(monkeypatch):
 def test_the_probe_absolutises_a_relative_answer(monkeypatch, tmp_path):
     """uv answers `cache-dir = "relcache"` with "relcache" verbatim, and setup.sh runs uv
     from a different directory, so a relative answer names a different, cold cache there."""
+    monkeypatch.delenv("UV_WORKING_DIR", raising = False)
     monkeypatch.chdir(tmp_path)
     seen = _probe_kwargs(monkeypatch, stdout = "relcache\n")
 
     assert seen["result"] == tmp_path / "relcache", seen["result"]
+
+
+def test_the_probe_resolves_against_uvs_working_directory(monkeypatch, tmp_path):
+    """--directory, whose env alias is UV_WORKING_DIR, moves uv out from under us before
+    it resolves a relative cache-dir. Measured on uv 0.10.7: with UV_WORKING_DIR set, the
+    cache lands under that directory and not under ours."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.setenv("UV_WORKING_DIR", str(elsewhere))
+    monkeypatch.chdir(tmp_path)
+    seen = _probe_kwargs(monkeypatch, stdout = "relcache\n")
+
+    assert seen["result"] == elsewhere / "relcache", seen["result"]
+
+
+def test_the_probe_leaves_uvs_tilde_alone(monkeypatch, tmp_path):
+    """uv prints `cache-dir = "~/.myuv"` verbatim and treats the tilde as an ordinary
+    relative segment: measured on uv 0.10.7 it creates a literal "~" directory in its
+    working directory. Expanding it here would probe a path uv never writes to."""
+    monkeypatch.delenv("UV_WORKING_DIR", raising = False)
+    monkeypatch.chdir(tmp_path)
+    seen = _probe_kwargs(monkeypatch, stdout = "~/.myuv\n")
+
+    assert seen["result"] == tmp_path / "~" / ".myuv", seen["result"]
 
 
 def test_a_probe_that_blows_up_costs_a_preference_not_the_update(monkeypatch):

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -386,18 +386,73 @@ def test_the_probe_leaves_uvs_tilde_alone(monkeypatch, tmp_path):
     assert seen["result"] == tmp_path / "~" / ".myuv", seen["result"]
 
 
-def test_a_probe_that_blows_up_costs_a_preference_not_the_update(monkeypatch):
+def test_a_probe_that_blows_up_costs_a_preference_not_the_update(monkeypatch, tmp_path):
     """subprocess.run is implemented with Popen, so any caller that fakes Popen reaches
-    this probe too. Losing the answer is fine; raising through an update is not."""
+    this probe too. Raising through an update is not acceptable, and neither is reporting
+    no cache at all: it falls back to the platform default install.sh:646 uses."""
     studio = _studio()
     monkeypatch.setattr(studio.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(studio.platform, "system", lambda: "Linux")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
 
     def _boom(argv, **kwargs):
         raise TypeError("object does not support the context manager protocol")
 
     monkeypatch.setattr(studio.subprocess, "run", _boom)
 
-    assert studio._uv_default_cache_dir() is None
+    assert studio._uv_default_cache_dir() == tmp_path / "uv"
+
+
+def test_a_malformed_uv_toml_beside_the_caller_does_not_hide_the_cache(monkeypatch, tmp_path):
+    """uv discovers config from the CURRENT directory, so a broken uv.toml where the user
+    happens to be makes `uv cache dir` exit nonzero even though setup.sh changes directory
+    before it runs uv. install.sh falls back to the platform default rather than calling
+    the cache cold, and so must this."""
+    studio = _studio()
+    monkeypatch.setattr(studio.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(studio.platform, "system", lambda: "Linux")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+    class _Failed:
+        returncode = 2
+        stdout = ""
+
+    monkeypatch.setattr(studio.subprocess, "run", lambda argv, **kw: _Failed())
+
+    assert studio._uv_default_cache_dir() == tmp_path / "uv"
+
+
+@pytest.mark.parametrize(
+    ("system", "env", "expected"),
+    [
+        ("Linux", {"XDG_CACHE_HOME": "/xdg"}, Path("/xdg/uv")),
+        ("Linux", {"HOME": "/home/someone"}, Path("/home/someone/.cache/uv")),
+        ("Darwin", {"HOME": "/Users/someone"}, Path("/Users/someone/.cache/uv")),
+        ("Windows", {"LOCALAPPDATA": "/local"}, Path("/local/uv/cache")),
+    ],
+)
+def test_the_platform_default_matches_the_installers(monkeypatch, system, env, expected):
+    """Same locations install.sh:646 and install.ps1 use. macOS is XDG/HOME, not
+    ~/Library/Caches, which is what uv documents for Unix generally."""
+    studio = _studio()
+    monkeypatch.setattr(studio.platform, "system", lambda: system)
+    for key in ("XDG_CACHE_HOME", "HOME", "LOCALAPPDATA"):
+        monkeypatch.delenv(key, raising = False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    assert studio._uv_platform_cache_dir() == expected
+
+
+def test_no_platform_default_is_better_than_a_guess(monkeypatch):
+    """Nothing to anchor to means nothing to report; the caller then keeps the Studio
+    cache rather than probing a path assembled out of nothing."""
+    studio = _studio()
+    monkeypatch.setattr(studio.platform, "system", lambda: "Linux")
+    for key in ("XDG_CACHE_HOME", "HOME"):
+        monkeypatch.delenv(key, raising = False)
+
+    assert studio._uv_platform_cache_dir() is None
 
 
 def test_the_probe_reads_the_last_nonblank_line(monkeypatch):

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -303,6 +303,38 @@ def test_a_default_cache_uv_cannot_name_does_not_block_the_redirect(monkeypatch,
     assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
 
 
+@pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+def test_no_cache_mode_neither_seeds_nor_records(monkeypatch, tmp_path, caches, value):
+    """uv --no-cache puts the cache in a temporary directory and discards it at exit, so
+    `uv cache dir` names that throwaway, --no-cache outranks --cache-dir, and setup keeps
+    nothing. Seeding a cache would be ignored and recording one would be a lie."""
+    studio = _studio()
+    studio_cache, default_cache = caches
+    _fill(default_cache)
+    monkeypatch.setenv("UV_NO_CACHE", value)
+    monkeypatch.setattr(
+        studio,
+        "_uv_default_cache_dir",
+        lambda cwd = None: pytest.fail("the probe ran under --no-cache"),
+    )
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert "UV_CACHE_DIR" not in (seen["env"] or {}), seen["env"]
+    assert not _marker(tmp_path).exists()
+
+
+@pytest.mark.parametrize("value", ["0", "false", "", "maybe"])
+def test_a_non_true_no_cache_value_changes_nothing(monkeypatch, tmp_path, caches, value):
+    """0 and false mean caching is on. An unparseable value is one uv refuses to run at
+    all, which is not the same as running without a cache."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    monkeypatch.setenv("UV_NO_CACHE", value)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
 # --- The warmth test itself ----------------------------------------------------------
 
 

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -477,16 +477,33 @@ def test_a_caller_supplied_cache_is_never_promoted_to_the_marker(monkeypatch, tm
     assert not _marker(tmp_path).exists()
 
 
-def test_a_staged_update_does_not_write_the_live_marker(monkeypatch, tmp_path, caches):
-    """STUDIO_HOME names the LIVE install even in a staged child, and the stage can
-    still be rejected, so writing now would aim it at an environment never activated."""
+def test_a_staged_update_parks_its_choice_in_the_stage(monkeypatch, tmp_path, caches):
+    """STUDIO_HOME names the LIVE install even in a staged child, and the stage can still
+    be rejected, so the choice waits in the stage for _studio_stage.stage to promote it.
+    Dropping it instead left desktop-only installs on the content fallback forever."""
     studio = _studio()
     _studio_cache, default_cache = caches
     _fill(default_cache)
-    monkeypatch.setenv(studio._studio_stage.STAGE_ROOT_ENV, str(tmp_path / "stage"))
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    monkeypatch.setenv(studio._studio_stage.STAGE_ROOT_ENV, str(stage))
     _run_posix(monkeypatch, tmp_path)
 
     assert not _marker(tmp_path).exists()
+    assert (stage / "uv-cache-dir").read_text(encoding = "utf-8").strip() == str(default_cache)
+
+
+def test_a_marker_holding_a_null_byte_reads_as_a_cold_cache(monkeypatch, tmp_path, caches):
+    """Path takes an embedded NUL and scandir then raises ValueError, not OSError, so a
+    corrupted or hand-edited marker aborted every update before setup ran."""
+    studio = _studio()
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    _record(tmp_path / "StudioHome", "/nul\x00cache")
+
+    env = studio._with_studio_uv_cache({})
+
+    assert env["UV_CACHE_DIR"] == str(studio_cache)
 
 
 def test_the_backfill_replaces_a_symlink_rather_than_its_target(monkeypatch, tmp_path, caches):

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -305,9 +305,8 @@ def test_a_default_cache_uv_cannot_name_does_not_block_the_redirect(monkeypatch,
 
 @pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
 def test_no_cache_mode_neither_seeds_nor_records(monkeypatch, tmp_path, caches, value):
-    """uv --no-cache puts the cache in a temporary directory and discards it at exit, so
-    `uv cache dir` names that throwaway, --no-cache outranks --cache-dir, and setup keeps
-    nothing. Seeding a cache would be ignored and recording one would be a lie."""
+    """uv --no-cache caches in a temporary directory and discards it at exit, so seeding
+    a cache would be ignored and recording one would name something already gone."""
     studio = _studio()
     studio_cache, default_cache = caches
     _fill(default_cache)
@@ -325,8 +324,8 @@ def test_no_cache_mode_neither_seeds_nor_records(monkeypatch, tmp_path, caches, 
 
 @pytest.mark.parametrize("value", ["0", "false", "", "maybe"])
 def test_a_non_true_no_cache_value_changes_nothing(monkeypatch, tmp_path, caches, value):
-    """0 and false mean caching is on. An unparseable value is one uv refuses to run at
-    all, which is not the same as running without a cache."""
+    """0 and false leave caching on, and an unparseable value is one uv refuses to run
+    on at all."""
     studio_cache, _default = caches
     _fill(studio_cache)
     monkeypatch.setenv("UV_NO_CACHE", value)

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -413,7 +413,9 @@ def test_a_relative_marker_is_resolved_before_it_is_handed_over(monkeypatch, tmp
     assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
 
 
-def test_a_recorded_path_containing_a_newline_survives_the_round_trip(monkeypatch, tmp_path, caches):
+def test_a_recorded_path_containing_a_newline_survives_the_round_trip(
+    monkeypatch, tmp_path, caches
+):
     """A newline is legal in a POSIX path and uv reports one verbatim. Read line by line,
     the record looked like several and only the last fragment survived, so the update
     treated a warm cache as absent and redirected uv somewhere else."""
@@ -563,7 +565,11 @@ def test_a_cache_path_that_is_not_utf_8_is_recorded_and_read_back(monkeypatch, t
 # --- The uv probe ---------------------------------------------------------------------
 
 
-def _probe_kwargs(monkeypatch, stdout: str = "/cache/uv\n", cwd = None) -> dict:
+def _probe_kwargs(
+    monkeypatch,
+    stdout: str = "/cache/uv\n",
+    cwd = None,
+) -> dict:
     studio = _studio()
     monkeypatch.setattr(studio.shutil, "which", lambda name: "/usr/bin/uv")
     seen: dict = {}

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -228,20 +228,47 @@ def test_the_chosen_cache_is_named_rather_than_left_to_the_child(monkeypatch, tm
     wins, it reaches the child as an explicit path."""
     studio_cache, default_cache = caches
     for warm, expected in ((default_cache, default_cache), (studio_cache, studio_cache)):
+        # Each iteration states its own starting point: the other cache goes cold, and the
+        # previous run's backfilled marker goes away, or either would decide this one.
+        for cache in (studio_cache, default_cache):
+            shutil.rmtree(cache, ignore_errors = True)
         _fill(warm)
-        # The previous iteration's run backfills a marker, which would then decide this
-        # one. Each iteration states its own starting point.
         (tmp_path / "StudioHome" / "cache" / "uv-cache-dir").unlink(missing_ok = True)
         seen = _run_posix(monkeypatch, tmp_path)
         assert seen["env"]["UV_CACHE_DIR"] == str(expected), seen["env"].get("UV_CACHE_DIR")
 
 
-def test_a_studio_mode_install_wins_over_a_populated_default(monkeypatch, tmp_path, caches):
-    """The case the PR exists for: the installer filled the Studio cache, so the update
-    must read it rather than uv's default, whatever else is lying around."""
+def test_a_studio_mode_install_wins_over_a_cold_default(monkeypatch, tmp_path, caches):
+    """The case the PR exists for: the installer filled the Studio cache and the update
+    was downloading all of it again into a cache holding nothing."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_two_warm_caches_and_no_marker_keep_uv_s_default(monkeypatch, tmp_path, caches):
+    """An install that predates the marker cannot say which cache it used, and content
+    cannot tell either: install.sh:705 points the running backend at the Studio cache even
+    in shared mode, so one on-demand wheel warms it. uv's default is what such an install
+    has been updating from all along, and preferring the Studio cache here would be a new
+    way for an offline update to fail on an install that cannot record its way out."""
     studio_cache, default_cache = caches
     _fill(studio_cache)
     _fill(default_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(default_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_marker_still_settles_two_warm_caches(monkeypatch, tmp_path, caches):
+    """And that ambiguity is exactly what the marker removes: an install that recorded the
+    Studio cache keeps it, warm default or not."""
+    studio_cache, default_cache = caches
+    _fill(studio_cache)
+    _fill(default_cache)
+    _record(tmp_path / "StudioHome", studio_cache)
     seen = _run_posix(monkeypatch, tmp_path)
 
     assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -250,10 +250,8 @@ def test_a_studio_mode_install_wins_over_a_cold_default(monkeypatch, tmp_path, c
 
 def test_two_warm_caches_and_no_marker_keep_uv_s_default(monkeypatch, tmp_path, caches):
     """An install that predates the marker cannot say which cache it used, and content
-    cannot tell either: install.sh:705 points the running backend at the Studio cache even
-    in shared mode, so one on-demand wheel warms it. uv's default is what such an install
-    has been updating from all along, and preferring the Studio cache here would be a new
-    way for an offline update to fail on an install that cannot record its way out."""
+    cannot tell either: one on-demand wheel warms the Studio cache (install.sh:705). uv's
+    default is what it has been updating from, and it cannot record its way out."""
     studio_cache, default_cache = caches
     _fill(studio_cache)
     _fill(default_cache)
@@ -443,9 +441,8 @@ def test_a_relative_marker_is_resolved_before_it_is_handed_over(monkeypatch, tmp
 def test_a_recorded_path_containing_a_newline_survives_the_round_trip(
     monkeypatch, tmp_path, caches
 ):
-    """A newline is legal in a POSIX path and uv reports one verbatim. Read line by line,
-    the record looked like several and only the last fragment survived, so the update
-    treated a warm cache as absent and redirected uv somewhere else."""
+    """A newline is legal in a POSIX path. Read line by line the record looked like
+    several, only the last fragment survived, and a warm cache read as absent."""
     studio = _studio()
     studio_cache, _default = caches
     _fill(studio_cache)
@@ -523,9 +520,9 @@ def test_a_caller_supplied_cache_is_never_promoted_to_the_marker(monkeypatch, tm
 
 
 def test_a_staged_update_parks_its_choice_in_the_stage(monkeypatch, tmp_path, caches):
-    """STUDIO_HOME names the LIVE install even in a staged child, and the stage can still
-    be rejected, so the choice waits in the stage for _studio_stage.stage to promote it.
-    Dropping it instead left desktop-only installs on the content fallback forever."""
+    """STUDIO_HOME names the LIVE install even in a staged child and the stage can still
+    be rejected, so the choice waits there for stage() to promote it. Dropping it left
+    desktop-only installs on the content fallback forever."""
     studio = _studio()
     _studio_cache, default_cache = caches
     _fill(default_cache)
@@ -570,9 +567,9 @@ def test_the_backfill_replaces_a_symlink_rather_than_its_target(monkeypatch, tmp
 
 @pytest.mark.skipif(os.name != "posix", reason = "POSIX filesystem byte semantics")
 def test_a_cache_path_that_is_not_utf_8_is_recorded_and_read_back(monkeypatch, tmp_path):
-    """An undecodable POSIX path reaches Python as surrogates, and encoding those raises
-    UnicodeEncodeError, which is not an OSError and escaped the best-effort handler: an
-    update whose setup had succeeded failed at the end, with its marker already gone."""
+    """An undecodable POSIX path arrives as surrogates, and encoding those raises
+    UnicodeEncodeError, not an OSError, so it escaped the best-effort handler and failed
+    an update whose setup had succeeded, with its marker already gone."""
     studio = _studio()
     weird = (tmp_path / os.fsdecode(b"caf\xe9-cache")).resolve()
     _fill(weird)
@@ -629,10 +626,9 @@ def test_the_probe_asks_from_the_directory_setup_will_ask_from(monkeypatch, tmp_
 
 
 def test_the_windows_handoff_probes_from_the_directory_it_hands_the_child(monkeypatch, tmp_path):
-    """setup.ps1 never changes directory: it addresses everything through $PSScriptRoot and
-    hands install_python_stack.py the cwd it inherited (studio/setup.ps1:5191). Probing in
-    the script's directory there would answer for a configuration the child never sees, and
-    that answer is then forced on it through UV_CACHE_DIR."""
+    """setup.ps1 never changes directory: it hands install_python_stack.py the cwd it
+    inherited (setup.ps1:5191), so probing the script's directory would answer for a
+    configuration the child never sees, and that answer is forced on it."""
     studio = _studio()
     repo_root = tmp_path / "repo"
     (repo_root / "studio").mkdir(parents = True)

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -64,7 +64,7 @@ def caches(monkeypatch, tmp_path):
     studio_home = tmp_path / "StudioHome"
     default_cache = tmp_path / "default-uv"
     monkeypatch.setattr(studio, "STUDIO_HOME", studio_home)
-    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda: default_cache)
+    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda cwd = None: default_cache)
     return studio_home / "cache" / "uv", default_cache
 
 
@@ -272,7 +272,7 @@ def test_a_default_cache_uv_cannot_name_does_not_block_the_redirect(monkeypatch,
     nobody can identify."""
     studio = _studio()
     studio_cache, _default = caches
-    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda: None)
+    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda cwd = None: None)
     seen = _run_posix(monkeypatch, tmp_path)
 
     assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
@@ -413,6 +413,22 @@ def test_a_relative_marker_is_resolved_before_it_is_handed_over(monkeypatch, tmp
     assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
 
 
+def test_a_recorded_path_containing_a_newline_survives_the_round_trip(monkeypatch, tmp_path, caches):
+    """A newline is legal in a POSIX path and uv reports one verbatim. Read line by line,
+    the record looked like several and only the last fragment survived, so the update
+    treated a warm cache as absent and redirected uv somewhere else."""
+    studio = _studio()
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    weird = tmp_path / "two\nline cache"
+    _fill(weird)
+    _record(tmp_path / "StudioHome", weird)
+
+    env = studio._with_studio_uv_cache({})
+
+    assert env["UV_CACHE_DIR"] == str(weird)
+
+
 # --- Backfilling the marker for installs that predate it --------------------------------
 
 
@@ -532,7 +548,7 @@ def test_a_cache_path_that_is_not_utf_8_is_recorded_and_read_back(monkeypatch, t
     weird = (tmp_path / os.fsdecode(b"caf\xe9-cache")).resolve()
     _fill(weird)
     monkeypatch.setattr(studio, "STUDIO_HOME", tmp_path / "StudioHome")
-    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda: weird)
+    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda cwd = None: weird)
     monkeypatch.delenv("UV_CACHE_DIR", raising = False)
 
     studio._backfill_uv_cache_marker({"UV_CACHE_DIR": str(weird)})
@@ -547,7 +563,7 @@ def test_a_cache_path_that_is_not_utf_8_is_recorded_and_read_back(monkeypatch, t
 # --- The uv probe ---------------------------------------------------------------------
 
 
-def _probe_kwargs(monkeypatch, stdout: str = "/cache/uv\n") -> dict:
+def _probe_kwargs(monkeypatch, stdout: str = "/cache/uv\n", cwd = None) -> dict:
     studio = _studio()
     monkeypatch.setattr(studio.shutil, "which", lambda name: "/usr/bin/uv")
     seen: dict = {}
@@ -563,8 +579,51 @@ def _probe_kwargs(monkeypatch, stdout: str = "/cache/uv\n") -> dict:
         return completed
 
     monkeypatch.setattr(studio.subprocess, "run", _fake_run)
-    seen["result"] = studio._uv_default_cache_dir()
+    seen["result"] = studio._uv_default_cache_dir(cwd)
     return seen
+
+
+def test_the_probe_asks_from_the_directory_setup_will_ask_from(monkeypatch, tmp_path):
+    """uv discovers uv.toml and pyproject.toml from its working directory, and both setup
+    scripts change into their own before the dependency pass (studio/setup.sh:1788). Asked
+    in the caller's directory instead, the probe answers for whatever project the user
+    happens to be standing in, and that answer is then forced on the child."""
+    seen = _probe_kwargs(monkeypatch, stdout = "relcache\n", cwd = tmp_path / "studio")
+
+    assert seen["cwd"] == str(tmp_path / "studio")
+    # And the relative answer resolves against that directory, not against the caller's.
+    assert seen["result"] == tmp_path / "studio" / "relcache", seen["result"]
+
+
+def test_the_setup_handoff_probes_from_the_setup_script_directory(monkeypatch, tmp_path):
+    """The wiring, not just the parameter: _run_setup_script is the only caller that knows
+    where the script it is about to run lives. Driven through the Windows branch, whose
+    handoff is a plain Popen rather than the POSIX streaming reader."""
+    studio = _studio()
+    repo_root = tmp_path / "repo"
+    (repo_root / "studio").mkdir(parents = True)
+    (repo_root / "studio" / "setup.ps1").write_text("", encoding = "utf-8")
+    monkeypatch.setattr(studio.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        studio._studio_runtime_gate, "resolve_windows_powershell", lambda: "powershell.exe"
+    )
+    monkeypatch.setattr(studio, "_probe_profile_proxy_defaults", lambda hosts: None)
+    monkeypatch.setattr(studio, "_backfill_uv_cache_marker", lambda env: None)
+    monkeypatch.delenv("UV_CACHE_DIR", raising = False)
+    seen: dict = {}
+    monkeypatch.setattr(
+        studio, "_with_studio_uv_cache", lambda env, cwd = None: seen.update(cwd = cwd) or env
+    )
+
+    class _Process:
+        def wait(self):
+            return 0
+
+    monkeypatch.setattr(studio.subprocess, "Popen", lambda argv, **kw: _Process())
+
+    studio._run_setup_script(repo_root = repo_root)
+
+    assert seen["cwd"] == repo_root / "studio", seen
 
 
 def test_the_probe_decodes_utf8_whatever_the_console_codec_is(monkeypatch):

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -15,6 +15,7 @@ fails outright when uv may read only what is cached.
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -228,6 +229,9 @@ def test_the_chosen_cache_is_named_rather_than_left_to_the_child(monkeypatch, tm
     studio_cache, default_cache = caches
     for warm, expected in ((default_cache, default_cache), (studio_cache, studio_cache)):
         _fill(warm)
+        # The previous iteration's run backfills a marker, which would then decide this
+        # one. Each iteration states its own starting point.
+        (tmp_path / "StudioHome" / "cache" / "uv-cache-dir").unlink(missing_ok = True)
         seen = _run_posix(monkeypatch, tmp_path)
         assert seen["env"]["UV_CACHE_DIR"] == str(expected), seen["env"].get("UV_CACHE_DIR")
 
@@ -302,6 +306,225 @@ def test_an_absent_cache_is_not_warm(tmp_path):
     studio = _studio()
 
     assert studio._uv_cache_has_packages(tmp_path / "nope") is False
+
+
+# --- The cache the installer recorded --------------------------------------------------
+
+
+def _record(studio_home: Path, value) -> None:
+    marker = studio_home / "cache"
+    marker.mkdir(parents = True, exist_ok = True)
+    (marker / "uv-cache-dir").write_text(f"{value}\n", encoding = "utf-8")
+
+
+def test_the_recorded_install_cache_beats_both_guesses(monkeypatch, tmp_path, caches):
+    """The case content cannot decide: a shared install whose backend has since dropped
+    one wheel into the Studio cache (install.sh:705), so both caches hold packages."""
+    studio_cache, default_cache = caches
+    _fill(studio_cache, name = "some_runtime_wheel.whl")
+    _fill(default_cache)
+    _record(tmp_path / "StudioHome", default_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(default_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_recorded_studio_cache_survives_the_user_warming_their_own(monkeypatch, tmp_path, caches):
+    """The mirror: a studio install, and the user has since warmed uv's own cache."""
+    studio_cache, default_cache = caches
+    _fill(studio_cache)
+    _fill(default_cache)
+    _record(tmp_path / "StudioHome", studio_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_an_emptied_recorded_cache_does_not_outrank_a_warm_one(monkeypatch, tmp_path, caches):
+    """A marker pointing at an emptied cache is stale, not authoritative."""
+    studio_cache, default_cache = caches
+    _fill(default_cache)
+    _record(tmp_path / "StudioHome", studio_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(default_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_installs_older_than_the_marker_still_work(monkeypatch, tmp_path, caches):
+    """The normal state for everyone installed before this change."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_reinstall_into_a_custom_cache_is_not_shadowed_by_the_old_marker(
+    monkeypatch, tmp_path, caches
+):
+    """A reinstall with a nonblank UV_CACHE_DIR fills that cache, so it is recorded too:
+    a stale marker would aim later updates at a cache this install never filled, and both
+    hold packages, so nothing downstream could notice."""
+    studio_cache, _default = caches
+    custom = tmp_path / "caller cache"
+    _fill(studio_cache)
+    _fill(custom)
+    _record(tmp_path / "StudioHome", custom)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(custom), seen["env"].get("UV_CACHE_DIR")
+
+
+@pytest.mark.parametrize("spelling", ["trailing ", " leading", "  both  "])
+def test_a_recorded_path_keeps_its_whitespace(monkeypatch, tmp_path, caches, spelling):
+    """A recorded name may start or end with a space, and stripping it would probe a
+    different path and read a warm cache as cold."""
+    _studio_cache, _default = caches
+    odd = tmp_path / spelling
+    _fill(odd)
+    _record(tmp_path / "StudioHome", odd)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(odd), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_marker_written_by_windows_powershell_is_read_back(monkeypatch, tmp_path, caches):
+    """PowerShell 5.1 writes `-Encoding utf8` with a BOM, which utf-8 would decode into
+    the first character of the path."""
+    studio_cache, default_cache = caches
+    _fill(studio_cache)
+    _fill(default_cache)
+    marker = tmp_path / "StudioHome" / "cache"
+    marker.mkdir(parents = True, exist_ok = True)
+    (marker / "uv-cache-dir").write_bytes(b"\xef\xbb\xbf" + f"{studio_cache}\r\n".encode("utf-8"))
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_relative_marker_is_resolved_before_it_is_handed_over(monkeypatch, tmp_path, caches):
+    """setup.sh changes directory, so a relative path would name somewhere else there."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    monkeypatch.chdir(tmp_path)
+    _record(tmp_path / "StudioHome", "StudioHome/cache/uv")
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+# --- Backfilling the marker for installs that predate it --------------------------------
+
+
+def _marker(tmp_path: Path) -> Path:
+    return tmp_path / "StudioHome" / "cache" / "uv-cache-dir"
+
+
+def test_a_legacy_install_records_what_the_update_worked_out(monkeypatch, tmp_path, caches):
+    """Otherwise the fallback is re-derived every time, and goes stale the moment the
+    backend drops one wheel into the Studio cache."""
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    _run_posix(monkeypatch, tmp_path)
+
+    assert _marker(tmp_path).read_text(encoding = "utf-8").strip() == str(default_cache)
+
+
+def test_a_failed_update_records_nothing(monkeypatch, tmp_path, caches):
+    """A cache that did not get through setup is not one to aim later updates at."""
+    studio = _studio()
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    monkeypatch.setattr(studio.platform, "system", lambda: "Linux")
+
+    class _Failed:
+        returncode = 1
+
+    monkeypatch.setattr(studio.subprocess, "run", lambda argv, **kw: _Failed())
+    with pytest.raises(studio.typer.Exit):
+        studio._run_setup_script(repo_root = _setup_tree(tmp_path))
+
+    assert not _marker(tmp_path).exists(), _marker(tmp_path).read_text(encoding = "utf-8")
+
+
+def test_a_live_marker_is_not_overwritten_by_the_update(monkeypatch, tmp_path, caches):
+    """The installer's statement outranks the update's inference while it still holds."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    _record(tmp_path / "StudioHome", studio_cache)
+    _run_posix(monkeypatch, tmp_path)
+
+    assert _marker(tmp_path).read_text(encoding = "utf-8").strip() == str(studio_cache)
+
+
+def test_a_stale_marker_is_replaced_once_the_fallback_works(monkeypatch, tmp_path, caches):
+    """A marker whose cache was emptied is already ignored; stop re-deriving that."""
+    studio_cache, default_cache = caches
+    _fill(default_cache)
+    _record(tmp_path / "StudioHome", studio_cache)
+    _run_posix(monkeypatch, tmp_path)
+
+    assert _marker(tmp_path).read_text(encoding = "utf-8").strip() == str(default_cache)
+
+
+def test_a_caller_supplied_cache_is_never_promoted_to_the_marker(monkeypatch, tmp_path, caches):
+    """One run's environment variable must not become every later update's default."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path / "caller cache"))
+    _run_posix(monkeypatch, tmp_path)
+
+    assert not _marker(tmp_path).exists()
+
+
+def test_a_staged_update_does_not_write_the_live_marker(monkeypatch, tmp_path, caches):
+    """STUDIO_HOME names the LIVE install even in a staged child, and the stage can
+    still be rejected, so writing now would aim it at an environment never activated."""
+    studio = _studio()
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    monkeypatch.setenv(studio._studio_stage.STAGE_ROOT_ENV, str(tmp_path / "stage"))
+    _run_posix(monkeypatch, tmp_path)
+
+    assert not _marker(tmp_path).exists()
+
+
+def test_the_backfill_replaces_a_symlink_rather_than_its_target(monkeypatch, tmp_path, caches):
+    """write_text follows a symlink, so a marker path linked elsewhere would truncate an
+    unrelated file."""
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    victim = tmp_path / "someone elses file"
+    victim.write_text("do not clobber", encoding = "utf-8")
+    marker = _marker(tmp_path)
+    marker.parent.mkdir(parents = True, exist_ok = True)
+    marker.symlink_to(victim)
+    _run_posix(monkeypatch, tmp_path)
+
+    assert victim.read_text(encoding = "utf-8") == "do not clobber"
+    assert not marker.is_symlink()
+    assert marker.read_text(encoding = "utf-8").strip() == str(default_cache)
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX filesystem byte semantics")
+def test_a_cache_path_that_is_not_utf_8_is_recorded_and_read_back(monkeypatch, tmp_path):
+    """An undecodable POSIX path reaches Python as surrogates, and encoding those raises
+    UnicodeEncodeError, which is not an OSError and escaped the best-effort handler: an
+    update whose setup had succeeded failed at the end, with its marker already gone."""
+    studio = _studio()
+    weird = (tmp_path / os.fsdecode(b"caf\xe9-cache")).resolve()
+    _fill(weird)
+    monkeypatch.setattr(studio, "STUDIO_HOME", tmp_path / "StudioHome")
+    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda: weird)
+    monkeypatch.delenv("UV_CACHE_DIR", raising = False)
+
+    studio._backfill_uv_cache_marker({"UV_CACHE_DIR": str(weird)})
+
+    assert _marker(tmp_path).read_bytes().strip() == os.fsencode(str(weird))
+    # And the reader gives back the path the filesystem uses, not one with U+FFFD in it.
+    assert studio._recorded_install_uv_cache() == weird
+    # The tmp_path reaper cannot always delete a name it cannot decode.
+    shutil.rmtree(weird, ignore_errors = True)
 
 
 # --- The uv probe ---------------------------------------------------------------------

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -595,10 +595,11 @@ def test_the_probe_asks_from_the_directory_setup_will_ask_from(monkeypatch, tmp_
     assert seen["result"] == tmp_path / "studio" / "relcache", seen["result"]
 
 
-def test_the_setup_handoff_probes_from_the_setup_script_directory(monkeypatch, tmp_path):
-    """The wiring, not just the parameter: _run_setup_script is the only caller that knows
-    where the script it is about to run lives. Driven through the Windows branch, whose
-    handoff is a plain Popen rather than the POSIX streaming reader."""
+def test_the_windows_handoff_probes_from_the_directory_it_hands_the_child(monkeypatch, tmp_path):
+    """setup.ps1 never changes directory: it addresses everything through $PSScriptRoot and
+    hands install_python_stack.py the cwd it inherited (studio/setup.ps1:5191). Probing in
+    the script's directory there would answer for a configuration the child never sees, and
+    that answer is then forced on it through UV_CACHE_DIR."""
     studio = _studio()
     repo_root = tmp_path / "repo"
     (repo_root / "studio").mkdir(parents = True)
@@ -623,7 +624,48 @@ def test_the_setup_handoff_probes_from_the_setup_script_directory(monkeypatch, t
 
     studio._run_setup_script(repo_root = repo_root)
 
+    assert seen["cwd"] is None, seen
+
+
+def test_the_posix_handoff_probes_from_the_setup_script_directory(monkeypatch, tmp_path):
+    """setup.sh does change into its own directory before the dependency pass
+    (studio/setup.sh:1788), so there is where the probe has to ask."""
+    studio = _studio()
+    repo_root = tmp_path / "repo"
+    (repo_root / "studio").mkdir(parents = True)
+    (repo_root / "studio" / "setup.sh").write_text("", encoding = "utf-8")
+    monkeypatch.setattr(studio.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(studio, "_backfill_uv_cache_marker", lambda env: None)
+    monkeypatch.delenv("UV_CACHE_DIR", raising = False)
+    seen: dict = {}
+    monkeypatch.setattr(
+        studio, "_with_studio_uv_cache", lambda env, cwd = None: seen.update(cwd = cwd) or env
+    )
+    monkeypatch.setattr(
+        studio.subprocess, "Popen", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("stop"))
+    )
+
+    with pytest.raises(RuntimeError, match = "stop"):
+        studio._run_setup_script(repo_root = repo_root)
+
     assert seen["cwd"] == repo_root / "studio", seen
+
+
+def test_the_probe_keeps_whitespace_uv_reported(monkeypatch):
+    """A directory name may begin or end with a space and uv reports it verbatim, so
+    stripping the line probes a path that does not exist and reads a warm cache as cold."""
+    seen = _probe_kwargs(monkeypatch, stdout = "/spaced cache/uv  \n")
+
+    assert seen["result"] == Path("/spaced cache/uv  "), seen["result"]
+
+
+def test_a_relative_uv_working_dir_anchors_to_the_probe_directory(monkeypatch, tmp_path):
+    """uv resolves --directory after starting where it was started, so a relative
+    UV_WORKING_DIR belongs to the probe's cwd, not to wherever the update was launched."""
+    monkeypatch.setenv("UV_WORKING_DIR", "uvdir")
+    seen = _probe_kwargs(monkeypatch, stdout = "relcache\n", cwd = tmp_path / "studio")
+
+    assert seen["result"] == tmp_path / "studio" / "uvdir" / "relcache", seen["result"]
 
 
 def test_the_probe_decodes_utf8_whatever_the_console_codec_is(monkeypatch):


### PR DESCRIPTION
## Summary

Three places pick a uv cache and only two of them agreed.

`install.sh` and `install.ps1` choose one for the install itself (#10204), and `storage_roots._setup_cache_env` seeds `cache_root()/uv` for the backend server, which is also where `install.sh` repoints `UV_CACHE_DIR` just before it autostarts Studio. An update reaches neither. `unsloth studio update` runs `setup.sh` / `setup.ps1` straight from the CLI process, nothing on that path sets the variable, and `_setup_cache_env` is only ever called from `studio/backend/main.py:210` and `ensure_studio_directories`, so uv fell back to its own user-wide default.

On a fresh install that means the installer downloads into `<StudioHome>/cache/uv`, the first update downloads all of it again into `~/.cache/uv` or `%LOCALAPPDATA%\uv\cache`, and the installer's copy is never read again. The second copy also lands where `scripts/uninstall.sh:588` and `scripts/uninstall.ps1:861` cannot reclaim it, since they only remove the Studio root.

## Why the update path was missed

`unsloth studio update` does two things. The dependency work is `_run_setup_script` (`unsloth_cli/commands/studio.py:3653`), which runs `bash setup.sh` or `powershell setup.ps1`. The launcher refresh is `install.sh --shortcuts-only`, and that branch exits at `install.sh:2029` while `_configure_uv_cache` is called at `install.sh:2826`, so the installer's selector is never reached on an update and would not help if it were: the shortcuts branch runs no uv at all.

Repo-wide, the only writers of `UV_CACHE_DIR` are the two installers and `storage_roots.py:362`. Nothing in `unsloth_cli/`, `studio/setup.sh` or `studio/install_python_stack.py` sets it. Worth noting that `install_python_stack.py:6268` drops `--no-cache-dir` when it translates pip args for uv, so `UV_CACHE_DIR` genuinely governs what an update downloads.

## The rule

The installer's own record decides, and content only fills in for installs that predate it.

With a marker naming a cache that still holds packages, that cache wins. Without one, the update prefers uv's default whenever it is warm, and the Studio cache when it is not. A warm Studio cache is deliberately not treated as decisive on its own: `install.sh:705` points the running backend at it even in `shared` mode, so a single on-demand install from the server warms it, and an install that predates the marker cannot record its way out of the mistake, because the backfill only runs after a setup that would already have failed offline. Preferring uv's default there is what such an install has been updating from all along.

That matters because `_setup_cache_env` mkdirs an empty Studio cache on every server start, so a `shared` install would otherwise be sent to a cache holding nothing. Online that is one duplicate download. With `UV_OFFLINE`, `--offline` or `offline = true` in a `uv.toml`, where uv may read only what is already cached, it is an update that cannot resolve at all:

```
shared-mode install, then update
  no UV_CACHE_DIR (before)                  -> UV_OFFLINE=1 update SUCCEEDED
  UV_CACHE_DIR=<StudioHome>/cache/uv        -> UV_OFFLINE=1 update FAILED
      hint: Packages were unavailable because the network was disabled.
```

The fresh-install case the PR exists for is the other direction: the installer filled `<StudioHome>/cache/uv`, uv's own default holds nothing, and the update was downloading all of it again.

Warmth means package bytes, using the same bucket list and metadata-suffix filter as `install.sh:_configure_uv_cache`, since `wheels-v6` carries only `.msgpack`/`.http` on uv 0.10 and would otherwise read as warm after a bare resolve.

Whichever cache wins is passed to the child as an explicit absolute path rather than left for it to resolve again. uv reads `UV_CACHE_DIR` as `--cache-dir`, so a blank inherited value is a missing argument rather than an unset one (`UV_CACHE_DIR= uv cache dir` exits 2 with "a value is required"), and uv answers `cache-dir = "relcache"` with `relcache` verbatim, which `setup.sh` would resolve from a different directory once it changes into `$SCRIPT_DIR`.

## Measured

Real uv 0.10.7 against the merged selector, one package, `--reinstall`, counting files that appear in each cache tree:

| installer mode | before, update reads | after, update reads |
| --- | --- | --- |
| `studio` (no existing uv cache) | uv default, 0 to 23 files, re-downloaded | Studio cache, unchanged, reused |
| `shared` (existing uv cache) | uv default, reused | uv default, reused |

New installs stop paying for a download they already made, and no install pays a new one.

## Behaviour

Precedence is the installers' own. A nonblank `UV_CACHE_DIR` from the caller still wins (`install.sh:626`, `install.ps1:1232`), so a CI image that pins a cache keeps it, and blank counts as unset exactly as `storage_roots.py:373` treats it.

The seeding builds the child environment rather than mutating `os.environ`, so a later `unsloth studio` in the same process does not look like a caller override to `_setup_cache_env`.

The staged update path needs nothing extra: `run_staged_update` spawns `python -m unsloth_cli studio update` with a copy of the environment, and that child re-enters `_run_setup_script` and seeds itself.

`_refresh_desktop_shortcuts` is deliberately left alone. It runs the installers, which treat a preset `UV_CACHE_DIR` as a custom override, so seeding there would change which branch the installer takes.

The probe that asks uv for its default cache is best effort. It pins UTF-8 (`text=True` alone decodes with the locale codec and strict errors, and `UnicodeDecodeError` is a `ValueError`, so it would escape the `OSError` handler), carries the repository's Windows hidden-subprocess kwargs since creation flags are not inherited, and swallows anything else: not knowing where uv would have put its cache costs the update a preference, never the update itself.

## Tests

37 tests in `unsloth_cli/tests/test_studio_update_uv_cache.py`: the default, blank in three spellings, an explicit override, the verbose branch keeping both variables, the PowerShell spawn, no leak into the parent process, and the selection rule itself. The selection cases are a `shared` install keeping the cache that has the wheels, a `studio` install winning over a populated default, both caches cold going to the Studio one, a metadata-only default not counting as warm, `uv cache dir` being unavailable not stranding the update, each bucket name uv has shipped, and the probe's codec, hidden-subprocess kwargs and absolutising.

One existing test changed. `test_studio_runtime_gate_powershell.py::test_the_setup_handoff_spawns_the_resolved_interpreter` asserted on `spawned[0]`, and `subprocess.run` is built on `Popen`, so the new probe lands in a test that fakes `Popen`. It now picks the handoff out of the spawn list, which is what it is about; the resolved-interpreter assertion is unchanged.

Verification run locally:

```
sh / dash / bash tests/sh/test_install_uv_cache_root.sh          81 checks each
sh / dash / bash tests/sh/test_install_rollback_lifecycle.sh     43 checks each
pytest test_studio_update_uv_cache.py + parity + hardening       183 passed, 2 skipped
all 24 tests/studio/*.ps1                                        pass
install.ps1 AST parse                                            clean
ruff 0.15.18 check, scripts/run_ruff_format.py                   clean
```

Run these with `UV_CACHE_DIR` unset. If your shell sets it, `_with_studio_uv_cache` returns at its first line and none of this code is exercised.

One thing to flag for anyone running the CLI suite locally: `unsloth_cli/tests` has 44 failures on `main` already, all in `test_studio_secure_flag.py` and unrelated to this path.

## The installers record their choice too (#10410, merged into this branch)

Content alone cannot always decide. In `shared` mode the installers deliberately point the *running backend* at the Studio cache once the install is done (`_prepare_studio_uv_cache_for_launch` in `install.sh`, `Set-StudioUvCacheForLaunch` in `install.ps1`), even though the install itself used uv's own cache. One on-demand install from the server, such as `studio/backend/utils/wheel_utils.py:405`, then drops package bytes into the Studio cache, both caches read as warm, and the content rule prefers the wrong one. The mirror is just as reachable: a `studio` install loses to uv's default the moment the user runs an unrelated `uv pip install`.

Measured with uv 0.10.7 against the same scratch install:

```
install's cache: 24 files | studio cache (runtime leftovers): 61 files

content rule alone   picks <StudioHome>/cache/uv   -> UV_OFFLINE=1 update FAILED
with the marker      picks the uv default cache    -> UV_OFFLINE=1 update SUCCEEDED
```

So `install.sh` and `install.ps1` write the cache they selected to `<StudioHome>/cache/uv-cache-dir`, and `_with_studio_uv_cache` reads it before falling back to inspecting both caches. Every mode records, a caller's own `UV_CACHE_DIR` included, since that is where the install actually put its wheels; a caller keeps control regardless, because a nonblank `UV_CACHE_DIR` outranks the marker at update time too. A marker is honoured only while the cache it names still holds packages, so `uv cache clean` is not overruled, and installs that predate the marker keep working on the content fallback, which the update then records once setup has returned 0.

The marker travels with the environment: written absolute, restored at every point a failed install puts the previous environment back, cleared the moment the new environment is committed, and reset per run because under `irm | iex` the script scope is the caller's session. It is never fatal: an unwritable Studio root costs the next update a preference, not the install.

## Follow-up

A `shared` install still writes its Torch and CUDA wheels to the user-wide cache, outside the Studio root, where the uninstallers cannot reclaim them, so the storage half of #10193 stays open. Closing that means making the Studio cache the install default and offering the reuse as an opt-in, which reverses the measured trade-off #10204 landed on and is a product call rather than a bug.

