### PR TITLE
Drop late inference responses after their request is released

### DIFF
--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -905,7 +905,8 @@ class InferenceOrchestrator:
                         else:
                             self._mark_worker_started(owner)
                     other.put(resp)
-                    return None
+                # Late frames from a released request must not satisfy this reader.
+                return None
             return resp
 
         def drain(timeout: float = 5.0) -> bool:

--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -905,7 +905,6 @@ class InferenceOrchestrator:
                         else:
                             self._mark_worker_started(owner)
                     other.put(resp)
-                # Late frames from a released request must not satisfy this reader.
                 return None
             return resp
 

--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -905,10 +905,7 @@ class InferenceOrchestrator:
                         else:
                             self._mark_worker_started(owner)
                     other.put(resp)
-                # Outside the mailbox check on purpose: a response for a request whose
-                # mailbox is already gone -- cancel releases it before the worker stops
-                # emitting -- belongs to nobody, so it must not be handed to this reader.
-                # Unaddressed frames still fall through: the guard above needs a rid.
+                # Outside the mailbox check on purpose: a released request's late frames go to nobody.
                 return None
             return resp
 
@@ -2003,9 +2000,7 @@ class InferenceOrchestrator:
                     if not self._ensure_subprocess_alive():
                         raise RuntimeError(self._subprocess_crash_message("count"))
                     continue
-                # _direct_reader now drops a reply whose own mailbox is gone -- an earlier
-                # count that timed out while the worker still held its command -- so this
-                # check is the backstop for the window before that release lands.
+                # _direct_reader already drops a reply whose mailbox is gone; this is the backstop.
                 if (
                     candidate.get("type") == "count_tokens_response"
                     and candidate.get("request_id") == request_id

--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -905,6 +905,10 @@ class InferenceOrchestrator:
                         else:
                             self._mark_worker_started(owner)
                     other.put(resp)
+                # Outside the mailbox check on purpose: a response for a request whose
+                # mailbox is already gone -- cancel releases it before the worker stops
+                # emitting -- belongs to nobody, so it must not be handed to this reader.
+                # Unaddressed frames still fall through: the guard above needs a rid.
                 return None
             return resp
 
@@ -1999,9 +2003,9 @@ class InferenceOrchestrator:
                     if not self._ensure_subprocess_alive():
                         raise RuntimeError(self._subprocess_crash_message("count"))
                     continue
-                # A reply whose own mailbox is gone -- an earlier count that timed out
-                # while the worker still held its command -- is handed back to whoever is
-                # reading, and the type alone cannot tell it from this one's.
+                # _direct_reader now drops a reply whose own mailbox is gone -- an earlier
+                # count that timed out while the worker still held its command -- so this
+                # check is the backstop for the window before that release lands.
                 if (
                     candidate.get("type") == "count_tokens_response"
                     and candidate.get("request_id") == request_id

--- a/studio/backend/tests/test_inference_dispatcher_resilience.py
+++ b/studio/backend/tests/test_inference_dispatcher_resilience.py
@@ -17,6 +17,8 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
+
 _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
@@ -184,3 +186,37 @@ def _direct_reader_calls(o, request_id):
     """_direct_reader wired to a scripted _read_resp (o._scripted, popped in order)."""
     o._read_resp = lambda timeout = 1.0: o._scripted.pop(0) if o._scripted else None
     return o._direct_reader(request_id)
+
+
+@pytest.mark.parametrize("response_type", ["token", "gen_done", "gen_error", "audio_done"])
+def test_direct_reader_discards_responses_from_released_requests(response_type):
+    o = _direct_reader_host()
+    current = {"request_id": "current", "type": "token", "text": "current answer"}
+    o._scripted = [
+        {"request_id": "cancelled", "type": response_type, "text": "old answer"},
+        current,
+    ]
+    read_one, _drain, release = _direct_reader_calls(o, "current")
+    try:
+        # Cancellation may release the old mailbox before the worker finishes.
+        # Its late tokens/errors/terminal frame must not satisfy a new request.
+        assert read_one(timeout = 0.1) is None
+        assert read_one(timeout = 0.1) == current
+    finally:
+        release()
+
+
+def test_direct_reader_drain_waits_for_its_own_terminal_response():
+    o = _direct_reader_host()
+    o._scripted = [
+        {"request_id": "cancelled", "type": "gen_done"},
+        {"request_id": "current", "type": "token", "text": "still running"},
+        {"request_id": "current", "type": "gen_done"},
+    ]
+    o._ensure_subprocess_alive = lambda: True
+    _read_one, drain, release = _direct_reader_calls(o, "current")
+    try:
+        assert drain(timeout = 1.0)
+        assert not o._scripted, "an orphan gen_done must not end the current drain early"
+    finally:
+        release()

--- a/studio/backend/tests/test_inference_dispatcher_resilience.py
+++ b/studio/backend/tests/test_inference_dispatcher_resilience.py
@@ -192,10 +192,7 @@ def _direct_reader_calls(o, request_id):
     "response_type", ["token", "gen_done", "gen_error", "audio_done", "audio_error"]
 )
 def test_direct_reader_discards_responses_from_released_requests(response_type):
-    # Cancellation may release the old mailbox before the worker finishes. Its late
-    # tokens/errors/terminal frame must not satisfy a new request: _consume_token_stream
-    # and the blocking TTS loop dispatch on type alone, so a stale token becomes this
-    # chat's text and a stale audio_done becomes this request's wav.
+    # Consumers dispatch on type alone: a released request's late frame becomes this one's answer.
     o = _direct_reader_host()
     current = {"request_id": "current", "type": "token", "text": "current answer"}
     o._scripted = [
@@ -211,10 +208,7 @@ def test_direct_reader_discards_responses_from_released_requests(response_type):
 
 
 def test_direct_reader_discards_only_what_is_addressed_to_someone_else():
-    # The truthiness half of `if rid and rid != request_id` is load-bearing: the worker
-    # stamps no request_id on a subprocess-level failure (the command loop's catch-all),
-    # and _consume_token_stream turns that bare error into the user's crash message.
-    # Dropping it too would hang the chat until the read timeout instead of reporting.
+    # Dropping the `rid and` half would swallow the worker's unaddressed crash error and hang the chat.
     o = _direct_reader_host()
     worker_error = {"type": "error", "error": "Command 'generate' failed: out of memory"}
     o._scripted = [worker_error, {"request_id": "", "type": "gen_done"}]
@@ -227,10 +221,7 @@ def test_direct_reader_discards_only_what_is_addressed_to_someone_else():
 
 
 def test_discarding_a_released_response_leaves_worker_ownership_alone():
-    # A released request can outlive its mailbox in _request_cancel_events. Promoting or
-    # retiring it from here would make the dead request the executor, so the live chat's
-    # Stop would go to the wrong generation -- the hazard the two tests above guard for
-    # the forwarding path, which the discard path must not reintroduce.
+    # Ownership must not move on a discarded frame, or the live chat's Stop hits the wrong generation.
     o = _direct_reader_host()
     mine, theirs = threading.Event(), threading.Event()
     o._request_cancel_events = {"current": mine, "cancelled": theirs}
@@ -248,9 +239,7 @@ def test_discarding_a_released_response_leaves_worker_ownership_alone():
 
 
 def test_direct_reader_drain_waits_for_its_own_terminal_response():
-    # Cancel drains until the worker's terminal frame so stale events don't leak into the
-    # next request. A released request's terminal frame would end it while this one is
-    # still generating, handing the next request a worker that never stopped.
+    # Ending the drain on an orphan terminal hands the next request a worker that never stopped.
     o = _direct_reader_host()
     o._scripted = [
         {"request_id": "cancelled", "type": "gen_done"},

--- a/studio/backend/tests/test_inference_dispatcher_resilience.py
+++ b/studio/backend/tests/test_inference_dispatcher_resilience.py
@@ -188,8 +188,14 @@ def _direct_reader_calls(o, request_id):
     return o._direct_reader(request_id)
 
 
-@pytest.mark.parametrize("response_type", ["token", "gen_done", "gen_error", "audio_done"])
+@pytest.mark.parametrize(
+    "response_type", ["token", "gen_done", "gen_error", "audio_done", "audio_error"]
+)
 def test_direct_reader_discards_responses_from_released_requests(response_type):
+    # Cancellation may release the old mailbox before the worker finishes. Its late
+    # tokens/errors/terminal frame must not satisfy a new request: _consume_token_stream
+    # and the blocking TTS loop dispatch on type alone, so a stale token becomes this
+    # chat's text and a stale audio_done becomes this request's wav.
     o = _direct_reader_host()
     current = {"request_id": "current", "type": "token", "text": "current answer"}
     o._scripted = [
@@ -198,15 +204,53 @@ def test_direct_reader_discards_responses_from_released_requests(response_type):
     ]
     read_one, _drain, release = _direct_reader_calls(o, "current")
     try:
-        # Cancellation may release the old mailbox before the worker finishes.
-        # Its late tokens/errors/terminal frame must not satisfy a new request.
         assert read_one(timeout = 0.1) is None
         assert read_one(timeout = 0.1) == current
     finally:
         release()
 
 
+def test_direct_reader_discards_only_what_is_addressed_to_someone_else():
+    # The truthiness half of `if rid and rid != request_id` is load-bearing: the worker
+    # stamps no request_id on a subprocess-level failure (the command loop's catch-all),
+    # and _consume_token_stream turns that bare error into the user's crash message.
+    # Dropping it too would hang the chat until the read timeout instead of reporting.
+    o = _direct_reader_host()
+    worker_error = {"type": "error", "error": "Command 'generate' failed: out of memory"}
+    o._scripted = [worker_error, {"request_id": "", "type": "gen_done"}]
+    read_one, _drain, release = _direct_reader_calls(o, "current")
+    try:
+        assert read_one(timeout = 0.1) == worker_error
+        assert read_one(timeout = 0.1) == {"request_id": "", "type": "gen_done"}
+    finally:
+        release()
+
+
+def test_discarding_a_released_response_leaves_worker_ownership_alone():
+    # A released request can outlive its mailbox in _request_cancel_events. Promoting or
+    # retiring it from here would make the dead request the executor, so the live chat's
+    # Stop would go to the wrong generation -- the hazard the two tests above guard for
+    # the forwarding path, which the discard path must not reintroduce.
+    o = _direct_reader_host()
+    mine, theirs = threading.Event(), threading.Event()
+    o._request_cancel_events = {"current": mine, "cancelled": theirs}
+    o._claim_worker(mine)
+    o._mark_worker_started(mine)
+    o._scripted = [{"request_id": "cancelled", "type": "token", "text": "late"}]
+
+    read_one, _drain, release = _direct_reader_calls(o, "current")
+    try:
+        assert read_one(timeout = 0.1) is None
+        assert o._owns_worker(mine), "a discarded frame must not move the executor"
+        assert not o._owns_worker(theirs)
+    finally:
+        release()
+
+
 def test_direct_reader_drain_waits_for_its_own_terminal_response():
+    # Cancel drains until the worker's terminal frame so stale events don't leak into the
+    # next request. A released request's terminal frame would end it while this one is
+    # still generating, handing the next request a worker that never stopped.
     o = _direct_reader_host()
     o._scripted = [
         {"request_id": "cancelled", "type": "gen_done"},


### PR DESCRIPTION
Cancelling a generation can release its mailbox before the worker finishes sending responses. In `_direct_reader`, a response for another request is forwarded when that request still has a mailbox. When the mailbox is gone, it falls through and is returned to the current request. This can deliver the previous answer or let an old `gen_done` end the current drain early.

Return `None` for these unmatched responses, while keeping forwarding to live mailboxes unchanged.

Five new regression cases fail before the fix and pass afterward. They cover late tokens, errors, terminal responses, and draining until the current request finishes. The dispatcher resilience, unload cancellation, and audio cancellation suites pass together: 107 tests. Ruff passes for both changed files.
