### PR TITLE
fix: correct easiet typo, README grammar, and duplicate issue-template frontmatter

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug---issue.md
+++ b/.github/ISSUE_TEMPLATE/bug---issue.md
@@ -7,14 +7,6 @@ assignees: ''
 
 ---
 
----
-name: Unsloth Studio Bug
-about: Report a problem with the Unsloth Studio desktop app or web UI
-title: "[Unsloth Bug] "
-labels: bug
-assignees: ""
----
-
 <!--
 Search existing issues before submitting. Please do not remove the questions.
 Never post API keys, Hugging Face tokens, passwords, cookies, private prompts,

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Unsloth works on **Windows, Linux, WSL** and **macOS**. We support **Multi GPU s
 ### Train & Deploy
 * **Fine-tuning:** Train LLMs, diffusion, TTS, and embedding models 2× faster with 70% less VRAM with [no accuracy loss](https://unsloth.ai/blog#training)
 * **Complete support:** Supports [reinforcement learning](https://unsloth.ai/docs/get-started/reinforcement-learning-rl-guide), LoRA, QLoRA, full fine tuning, pretraining, RL, GRPO, DPO, and FP8.
-* **Export & Deploy:** [Export](https://unsloth.ai/docs/new/studio/export) or Deploy models with including [GGUF](https://unsloth.ai/docs/basics/inference-and-deployment/saving-to-gguf), NVFP4, FP8 and more formats.
+* **Export & Deploy:** [Export](https://unsloth.ai/docs/new/studio/export) or Deploy models including [GGUF](https://unsloth.ai/docs/basics/inference-and-deployment/saving-to-gguf), NVFP4, FP8 and more formats.
 * **Datasets:** Build datasets from PDFs, CSVs, DOCX files, and more with [Data Recipes](https://unsloth.ai/docs/new/studio/data-recipe).
   
 ## 🚀 Unsloth Start

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -897,7 +897,7 @@ def unsloth_save_model(
     if save_method != "lora" and save_method != "merged_16bit" and save_method != "merged_4bit":
         raise RuntimeError(
             "Unsloth: You must select one of 3 options when saving models:\n"
-            '"lora"         ==> This is the fastest and easiet. Just saves LoRA modules.\n'
+            '"lora"         ==> This is the fastest and easiest. Just saves LoRA modules.\n'
             '"merged_16bit" ==> This merges LoRA weights and saves to float16. Needed for llama.cpp / GGUF.\n'
             '"merged_4bit"  ==> This merges LoRA weights and saves to 4bit. Useful for DPO / inference.'
         )


### PR DESCRIPTION
Three small fixes:

1. `unsloth/save.py:900`: "easiet" → "easiest" in the `save_method` error message (printed verbatim to users).
2. `README.md`: "Deploy models **with including** [GGUF]…" → "Deploy models including [GGUF]…".
3. `.github/ISSUE_TEMPLATE/bug---issue.md`: removed the second `---`-delimited frontmatter block ("Unsloth Studio Bug") — GitHub's parser reads only the first block, so the second rendered as raw text at the top of every issue body. If separate Studio triage is wanted, a dedicated `studio-bug.md` template would be the cleaner follow-up.