### PR TITLE
fix(save): collapse identical if/else arms in the GGUF llama.cpp install path

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -2107,16 +2107,9 @@ def save_to_gguf(
         print("Unsloth: llama.cpp found in the system. Skipping installation.")
     except:
         print("Unsloth: Installing llama.cpp. This might take 3 minutes...")
-        if IS_KAGGLE_ENVIRONMENT:
-            quantizer_location, converter_location = install_llama_cpp(
-                gpu_support = False, print_output = print_output
-            )
-        else:
-            # Kaggle: no CUDA support due to environment limitations.
-            quantizer_location, converter_location = install_llama_cpp(
-                gpu_support = False,
-                print_output = print_output,
-            )
+        quantizer_location, converter_location = install_llama_cpp(
+            gpu_support = False, print_output = print_output
+        )
 
     print("Unsloth: Preparing converter script...")
     with use_local_gguf():


### PR DESCRIPTION
In the GGUF export path (`unsloth/save.py`, GGUF install block), both arms of the `IS_KAGGLE_ENVIRONMENT` if/else called `install_llama_cpp(gpu_support=False, print_output=...)` identically — and the "Kaggle: no CUDA support" comment sat on the **non-Kaggle** else branch after 115339ba0 trimmed comments. Collapsed to a single call; behavior unchanged.