### PR TITLE
Fix send and stop icon centering across display scales

### DIFF
--- a/.github/workflows/studio-composer-icons.yml
+++ b/.github/workflows/studio-composer-icons.yml
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+name: Composer icon alignment
+
+on:
+  pull_request:
+    paths:
+      - 'studio/frontend/src/index.css'
+      - 'studio/frontend/src/components/assistant-ui/**'
+      - 'studio/frontend/src/components/ui/button.tsx'
+      - 'studio/frontend/src/components/ui/tooltip*.tsx'
+      - 'studio/frontend/src/features/chat/shared-composer.tsx'
+      - 'studio/frontend/package*.json'
+      - 'studio/frontend/vite.config.ts'
+      - 'studio/frontend/smoke-composer-icons*'
+      - 'studio/frontend/tests/composer-icon-alignment.test.ts'
+      - 'tests/studio/playwright_composer_icons.py'
+      - 'tests/studio/_playwright_robust.py'
+      - '.github/workflows/studio-composer-icons.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'studio/frontend/**'
+      - 'tests/studio/playwright_composer_icons.py'
+      - 'tests/studio/_playwright_robust.py'
+      - '.github/workflows/studio-composer-icons.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: composer-icons-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  alignment:
+    name: Icons / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            engines: chromium firefox
+          - os: windows-latest
+            engines: chromium firefox
+          - os: macos-15
+            engines: chromium firefox webkit
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - name: Audit dependency lockfiles
+        run: python scripts/lockfile_supply_chain_audit.py
+      - name: Install npm with allowScripts enforcement
+        run: npm install -g npm@11.19.0 --no-fund --no-audit
+      - name: Install frontend dependencies
+        run: npm ci --prefix studio/frontend --strict-allow-scripts --no-fund --no-audit
+      - name: Install Playwright
+        run: python -m pip install playwright==1.61.0
+      - name: Install browser engines
+        run: python -m playwright install ${{ matrix.engines }}
+      - name: Verify rendered icon centers
+        run: python tests/studio/playwright_composer_icons.py ${{ matrix.engines }}
+      - name: Upload measurements and screenshots
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: composer-icons-${{ matrix.os }}
+          path: logs/composer-icons
+          retention-days: 7

--- a/studio/frontend/smoke-composer-icons-main.tsx
+++ b/studio/frontend/smoke-composer-icons-main.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Exercise the shipped button, tooltip, SVGs and stylesheet without a model/backend.
+// Render production buttons and icons without a backend.
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { Button } from "@/components/ui/button";
 import { TooltipProvider } from "@/components/ui/tooltip";

--- a/studio/frontend/smoke-composer-icons-main.tsx
+++ b/studio/frontend/smoke-composer-icons-main.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Exercise the shipped button, tooltip, SVGs and stylesheet without a model/backend.
+import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { Button } from "@/components/ui/button";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ArrowUpIcon, SquareIcon } from "lucide-react";
+import { createRoot } from "react-dom/client";
+import "./src/index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <TooltipProvider>
+    <div className="aui-root" style={{ padding: 32.25 }}>
+      <div className="aui-composer-action-wrapper flex items-center gap-2.5">
+        <TooltipIconButton
+          data-case="chat-send"
+          tooltip="Send message"
+          variant="default"
+          className="aui-composer-send ml-1.5 size-9 rounded-full"
+        >
+          <ArrowUpIcon className="unsloth-send-icon aui-composer-send-icon size-[21px] stroke-2" />
+        </TooltipIconButton>
+        <Button
+          data-case="chat-stop"
+          aria-label="Stop generation"
+          size="icon"
+          className="aui-composer-cancel ml-1.5 size-9 rounded-full"
+        >
+          <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+        </Button>
+        <TooltipIconButton
+          data-case="dictation-stop"
+          tooltip="Stop recording"
+          variant="ghost"
+          className="size-9 rounded-full bg-accent text-foreground"
+        >
+          <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+        </TooltipIconButton>
+      </div>
+    </div>
+    <div
+      className="composer-action-wrapper flex items-center gap-2.5"
+      style={{ padding: 32.5 }}
+    >
+      <TooltipIconButton
+        data-case="comparison-send"
+        tooltip="Send message"
+        variant="default"
+        className="ml-1.5 size-9 rounded-full"
+      >
+        <ArrowUpIcon className="unsloth-send-icon size-[22px] stroke-2" />
+      </TooltipIconButton>
+      <TooltipIconButton
+        data-case="comparison-stop"
+        tooltip="Stop generation"
+        variant="default"
+        className="ml-1.5 size-9 rounded-full"
+      >
+        <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+      </TooltipIconButton>
+      <TooltipIconButton
+        data-case="transcription-stop"
+        tooltip="Cancel transcription"
+        variant="default"
+        className="ml-1.5 size-9 rounded-full"
+      >
+        <SquareIcon className="aui-composer-cancel-icon size-3 animate-pulse fill-current" />
+      </TooltipIconButton>
+    </div>
+  </TooltipProvider>,
+);

--- a/studio/frontend/smoke-composer-icons.html
+++ b/studio/frontend/smoke-composer-icons.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Composer icon alignment</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/smoke-composer-icons-main.tsx"></script>
+  </body>
+</html>

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -3330,9 +3330,7 @@ html[data-chat-font] .aui-root {
 		width: calc(var(--ui-icon-size) * 1.2);
 		height: calc(var(--ui-icon-size) * 1.2);
 	}
-	/* Send and stop glyphs are symmetric in their viewBoxes. Keep the button's
-	   flex centering: Retina-specific nudges shift them off-center at other
-	   display scales and zoom levels. */
+	/* Flex centers both symmetric glyphs; pixel offsets vary by display scale. */
 	& svg.unsloth-send-icon {
 		width: calc(var(--ui-icon-size) * 1.15);
 		height: calc(var(--ui-icon-size) * 1.15);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -3330,16 +3330,12 @@ html[data-chat-font] .aui-root {
 		width: calc(var(--ui-icon-size) * 1.2);
 		height: calc(var(--ui-icon-size) * 1.2);
 	}
+	/* Send and stop glyphs are symmetric in their viewBoxes. Keep the button's
+	   flex centering: Retina-specific nudges shift them off-center at other
+	   display scales and zoom levels. */
 	& svg.unsloth-send-icon {
 		width: calc(var(--ui-icon-size) * 1.15);
 		height: calc(var(--ui-icon-size) * 1.15);
-		/* The stroked arrow rasterizes half a Retina pixel to the right. */
-		transform: translateX(-0.25px);
-	}
-	/* The filled stop glyph lands one Retina pixel right of the circular
-	   action's center even though its SVG box is flex-centered. */
-	& svg.aui-composer-cancel-icon {
-		transform: translateX(-0.5px);
 	}
 	/* Composer plus keeps its pre-#7400 22px base (1.375x the token is the same
 	   curve a 22px glyph would follow), so only its scaling changed. */

--- a/studio/frontend/tests/composer-icon-alignment.test.ts
+++ b/studio/frontend/tests/composer-icon-alignment.test.ts
@@ -11,32 +11,27 @@ const componentSources = [
   "../src/features/chat/shared-composer.tsx",
 ].map((path) => readFileSync(new URL(path, import.meta.url), "utf8"));
 
-const css = readFileSync(new URL("../src/index.css", import.meta.url), "utf8");
-
 function tags(source: string, component: string): string[] {
   return source.match(new RegExp(`<${component}\\b[^>]*\\/>`, "g")) ?? [];
 }
 
-test("every composer send arrow uses the optical centering class", () => {
-  const arrows = componentSources.flatMap((source) => tags(source, "ArrowUpIcon"));
+// Rendered SVG/glyph centers across engines and display scales are checked by
+// tests/studio/playwright_composer_icons.py. These checks keep every call site
+// on the shared styling exercised by that harness.
+test("every composer send arrow uses the shared icon class", () => {
+  const arrows = componentSources.flatMap((source) =>
+    tags(source, "ArrowUpIcon"),
+  );
 
   assert.equal(arrows.length, 5);
   for (const arrow of arrows) assert.match(arrow, /unsloth-send-icon/);
-  assert.match(
-    css,
-    /svg\.unsloth-send-icon[\s\S]*?transform: translateX\(-0\.25px\)/,
-  );
 });
 
-test("every isolated composer stop square uses the optical centering class", () => {
+test("every isolated composer stop square uses the shared icon class", () => {
   const stops = componentSources
     .flatMap((source) => tags(source, "SquareIcon"))
     .filter((tag) => /\bsize-3\b/.test(tag));
 
   assert.equal(stops.length, 6);
   for (const stop of stops) assert.match(stop, /aui-composer-cancel-icon/);
-  assert.match(
-    css,
-    /svg\.aui-composer-cancel-icon[\s\S]*?transform: translateX\(-0\.5px\)/,
-  );
 });

--- a/studio/frontend/tests/composer-icon-alignment.test.ts
+++ b/studio/frontend/tests/composer-icon-alignment.test.ts
@@ -15,9 +15,7 @@ function tags(source: string, component: string): string[] {
   return source.match(new RegExp(`<${component}\\b[^>]*\\/>`, "g")) ?? [];
 }
 
-// Rendered SVG/glyph centers across engines and display scales are checked by
-// tests/studio/playwright_composer_icons.py. These checks keep every call site
-// on the shared styling exercised by that harness.
+// Keep call sites on the styles tested by tests/studio/playwright_composer_icons.py.
 test("every composer send arrow uses the shared icon class", () => {
   const arrows = componentSources.flatMap((source) =>
     tags(source, "ArrowUpIcon"),

--- a/studio/frontend/tsconfig.app.json
+++ b/studio/frontend/tsconfig.app.json
@@ -31,6 +31,7 @@
   "include": [
     "src",
     "smoke-ansi-main.tsx",
+    "smoke-composer-icons-main.tsx",
     "smoke-find-in-page-main.tsx",
     "smoke-autoscroll-main.tsx",
     "smoke-research-main.tsx",

--- a/tests/studio/playwright_composer_icons.py
+++ b/tests/studio/playwright_composer_icons.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Measure composer SVG and glyph centers using the real frontend CSS/components.
+
+Run after npm ci in studio/frontend and python -m playwright install:
+    python tests/studio/playwright_composer_icons.py chromium webkit firefox
+
+Each engine is tested at six device scales, three UI font sizes, three page zooms,
+both themes and both text directions. Fractional layout origins are intentional.
+CSS geometry is the invariant: antialiasing can differ between physical screens.
+Missing engines or dependencies fail the run; they never count as passing coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+from _playwright_robust import start_vite, stop_process, wait_for_smoke_page
+
+
+MEASURE = """() => [...document.querySelectorAll('button[data-case]')].map(button => {
+    const svg = button.querySelector('svg');
+    const buttonBox = button.getBoundingClientRect();
+    const svgBox = svg.getBoundingClientRect();
+    const glyph = svg.getBBox();
+    const glyphCenter = new DOMPoint(glyph.x + glyph.width / 2, glyph.y + glyph.height / 2)
+        .matrixTransform(svg.getScreenCTM());
+    const centerX = buttonBox.x + buttonBox.width / 2;
+    const centerY = buttonBox.y + buttonBox.height / 2;
+    return {
+        name: button.dataset.case,
+        svgDx: svgBox.x + svgBox.width / 2 - centerX,
+        svgDy: svgBox.y + svgBox.height / 2 - centerY,
+        glyphDx: glyphCenter.x - centerX,
+        glyphDy: glyphCenter.y - centerY,
+        width: svgBox.width,
+        height: svgBox.height,
+    };
+})"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description = __doc__)
+    parser.add_argument("engines", nargs = "*", default = ["chromium"])
+    parser.add_argument("--out", type = Path, default = Path("logs/composer-icons"))
+    args = parser.parse_args()
+    args.out.mkdir(parents = True, exist_ok = True)
+    port = int(os.environ.get("PW_PORT", "5417"))
+    server = start_vite(port)
+    results = []
+    failures = []
+    try:
+        wait_for_smoke_page(
+            f"http://127.0.0.1:{port}/smoke-composer-icons.html",
+            "/smoke-composer-icons-main.tsx",
+            proc = server,
+        )
+        with sync_playwright() as pw:
+            for engine in args.engines:
+                browser = getattr(pw, engine).launch()
+                try:
+                    for dpr in (1, 1.25, 1.5, 1.75, 2, 3):
+                        context = browser.new_context(device_scale_factor = dpr)
+                        try:
+                            page = context.new_page()
+                            page.goto(f"http://127.0.0.1:{port}/smoke-composer-icons.html")
+                            page.locator("button[data-case]").last.wait_for()
+                            for font, zoom, dark, direction in itertools.product(
+                                (0.75, 1, 1.25), (0.8, 1, 1.25), (False, True), ("ltr", "rtl")
+                            ):
+                                case = dict(
+                                    engine = engine,
+                                    dpr = dpr,
+                                    font = font,
+                                    zoom = zoom,
+                                    dark = dark,
+                                    direction = direction,
+                                )
+                                page.evaluate(
+                                    """async ({font, zoom, dark, direction}) => {
+                                    const root = document.documentElement;
+                                    root.style.setProperty('--ui-font-scale', String(font));
+                                    root.style.zoom = String(zoom);
+                                    root.classList.toggle('dark', dark);
+                                    root.dir = direction;
+                                    await new Promise(requestAnimationFrame);
+                                }""",
+                                    case,
+                                )
+                                measures = page.evaluate(MEASURE)
+                                assert len(measures) == 6, measures
+                                results.append(dict(case = case, measures = measures))
+                                for measure in measures:
+                                    offsets = [
+                                        measure[key]
+                                        for key in ("svgDx", "svgDy", "glyphDx", "glyphDy")
+                                    ]
+                                    # Flex layout rounds to engine layout units (usually 1/64px).
+                                    # 0.02px permits that rounding but rejects either old offset.
+                                    if (
+                                        max(map(abs, offsets)) > 0.02
+                                        or min(measure["width"], measure["height"]) <= 0
+                                    ):
+                                        failures.append(dict(case = case, measure = measure))
+                                if font == zoom == 1 and direction == "ltr":
+                                    page.screenshot(
+                                        path = str(
+                                            args.out
+                                            / f"{engine}-{dpr}-{'dark' if dark else 'light'}.png"
+                                        )
+                                    )
+                        finally:
+                            context.close()
+                    print(f"{engine}: checked 216 configurations / 1296 icons", flush = True)
+                finally:
+                    browser.close()
+    finally:
+        stop_process(server)
+        (args.out / "report.json").write_text(
+            json.dumps(dict(results = results, failures = failures), indent = 2), encoding = "utf-8"
+        )
+    assert not failures, json.dumps(failures[:8], indent = 2)
+    print(f"PASS: {len(results) * 6} rendered icons centered", flush = True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/studio/playwright_composer_icons.py
+++ b/tests/studio/playwright_composer_icons.py
@@ -1,15 +1,12 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Measure composer SVG and glyph centers using the real frontend CSS/components.
+"""Check composer SVG and glyph centers across browsers and display settings.
 
-Run after npm ci in studio/frontend and python -m playwright install:
+Run after npm ci and Playwright browser installation:
     python tests/studio/playwright_composer_icons.py chromium webkit firefox
 
-Each engine is tested at six device scales, three UI font sizes, three page zooms,
-both themes and both text directions. Fractional layout origins are intentional.
-CSS geometry is the invariant: antialiasing can differ between physical screens.
-Missing engines or dependencies fail the run; they never count as passing coverage.
+Measures CSS geometry; screen antialiasing may differ.
 """
 
 from __future__ import annotations
@@ -102,8 +99,7 @@ def main() -> None:
                                         measure[key]
                                         for key in ("svgDx", "svgDy", "glyphDx", "glyphDy")
                                     ]
-                                    # Flex layout rounds to engine layout units (usually 1/64px).
-                                    # 0.02px permits that rounding but rejects either old offset.
+                                    # Allow layout rounding, but reject the old pixel offsets.
                                     if (
                                         max(map(abs, offsets)) > 0.02
                                         or min(measure["width"], measure["height"]) <= 0


### PR DESCRIPTION
The send arrow and stop square used fixed left offsets of `0.25px` and `0.5px`, intended for Retina displays. These offsets pushed the icons off-center at other display scales. Remove both offsets and use the existing flex centering across chat, dictation, and comparison composers.

Add browser checks that measure the SVG box and drawn glyph against the button center. The checks cover display scaling, page zoom, UI font size, both themes, and both text directions. CI runs on Windows, macOS, and Linux.

Validation:

- Original CSS: reproduced the offset in all 1,296 Chromium measurements.
- Fixed CSS: all 3,888 local measurements passed in Chromium, Firefox, and WebKit. Maximum deviation was below 0.009 CSS pixels.
- Frontend typecheck, production build, targeted tests, lint checks, and workflow checks passed.
- Native OS CI is still queued.
