### PR TITLE
Fix composer send and stop icon centering across display scales

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -19,6 +19,7 @@ on:
       - 'tests/studio/test_frontend_dep_removal.py'
 
       - 'tests/studio/playwright_strip_ansi_smoke.py'
+      - 'tests/studio/playwright_composer_icons.py'
       - 'tests/studio/playwright_chat_autoscroll.py'
       - 'tests/studio/playwright_research_freeze.py'
       - 'tests/studio/playwright_heavy_thread.py'
@@ -392,6 +393,11 @@ jobs:
           PW_BROWSER: chromium
         run: python3 tests/studio/playwright_strip_ansi_smoke.py
 
+      - name: Composer icon alignment
+        working-directory: ${{ github.workspace }}
+        timeout-minutes: 3
+        run: python3 tests/studio/playwright_composer_icons.py chromium
+
       # Each harness owns its vite server: starting one here backgrounds npm, so $! is the
       # wrapper and killing it orphans the node child.
       - name: Browser smoke for chat autoscroll
@@ -535,14 +541,8 @@ jobs:
   # across three files: two shapes of path/URL confusion, one of them added by a
   # PR whose whole purpose was to fix a Windows bug.
   #
-  # Deliberately NOT a matrix over the job above. Measured on a staging replica
-  # of this workflow, `windows-latest` runs `npm test` in 49s against ubuntu's
-  # 47s, so the tests themselves are not the expensive part; typecheck (48s),
-  # build (33s), the Chromium install and the three browser smokes are, and none
-  # of them can fail on Windows for a reason they would not also fail on ubuntu.
-  # Repeating them would roughly triple the cost of this workflow to re-answer a
-  # question ubuntu already answered. Checkout, node, `npm ci` and `npm test` on
-  # Windows measured ~132s.
+  # Reuse this runner for composer geometry, which needs native Windows coverage.
+  # Typecheck, build and the remaining browser smokes stay on Linux.
   #
   # Line endings need no special handling here: .gitattributes pins
   # `studio/frontend/** text=auto eol=lf`, so the tree checks out LF whatever the
@@ -588,3 +588,24 @@ jobs:
 
       - name: Unit tests
         run: npm test
+
+      - name: Install alignment test browsers
+        working-directory: ${{ github.workspace }}
+        timeout-minutes: 5
+        run: |
+          python -m pip install 'playwright>=1.45,<2'
+          python -m playwright install chromium firefox
+
+      - name: Composer icon alignment
+        working-directory: ${{ github.workspace }}
+        timeout-minutes: 3
+        run: python tests/studio/playwright_composer_icons.py chromium firefox
+
+      - name: Upload alignment failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-composer-icons
+          path: logs/playwright-composer-icons
+          retention-days: 1
+          if-no-files-found: ignore

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -36,6 +36,7 @@ on:
       - '.github/scripts/run-studio-permission-browser.sh'
       - '.github/scripts/run-studio-indicator-browser.sh'
       - '.github/workflows/studio-mac-ui-smoke.yml'
+      - 'scripts/lockfile_supply_chain_audit.py'
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
@@ -81,6 +82,7 @@ on:
       - '.github/scripts/run-studio-permission-browser.sh'
       - '.github/scripts/run-studio-indicator-browser.sh'
       - '.github/workflows/studio-mac-ui-smoke.yml'
+      - 'scripts/lockfile_supply_chain_audit.py'
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
@@ -290,6 +292,15 @@ jobs:
               open(path, "w").write(patched)
               print(f"pipeTransport.js: patched JSON.parse calls in {path}")
           PY
+
+      - name: Composer icon alignment
+        timeout-minutes: 5
+        run: |
+          if [ ! -x studio/frontend/node_modules/.bin/vite ]; then
+            python scripts/lockfile_supply_chain_audit.py
+            npm ci --prefix studio/frontend --ignore-scripts --no-fund --no-audit
+          fi
+          python tests/studio/playwright_composer_icons.py chromium webkit
 
       - name: Reset auth + boot Unsloth
         run: |
@@ -1754,6 +1765,7 @@ jobs:
             logs/uninstall.log
             logs/install.log
             logs/playwright
+            logs/playwright-composer-icons
             logs/playwright-permissions-*
             logs/playwright_extra
             logs/playwright_update_banner

--- a/studio/frontend/smoke-composer-icons-main.tsx
+++ b/studio/frontend/smoke-composer-icons-main.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Render production buttons and icons without a backend.
+import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { Button } from "@/components/ui/button";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ArrowUpIcon, SquareIcon } from "lucide-react";
+import { createRoot } from "react-dom/client";
+import "./src/index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <TooltipProvider>
+    <div className="aui-root" style={{ padding: 32.25 }}>
+      <div className="aui-composer-action-wrapper flex items-center gap-2.5">
+        <TooltipIconButton
+          data-case="chat-send"
+          tooltip="Send message"
+          variant="default"
+          className="aui-composer-send ml-1.5 size-9 rounded-full"
+        >
+          <ArrowUpIcon className="unsloth-send-icon aui-composer-send-icon size-[21px] stroke-2" />
+        </TooltipIconButton>
+        <Button
+          data-case="chat-stop"
+          aria-label="Stop generation"
+          size="icon"
+          className="aui-composer-cancel ml-1.5 size-9 rounded-full"
+        >
+          <SquareIcon className="size-3 fill-current" />
+        </Button>
+        <TooltipIconButton
+          data-case="dictation-stop"
+          tooltip="Stop recording"
+          variant="ghost"
+          className="size-9 rounded-full bg-accent text-foreground"
+        >
+          <SquareIcon className="size-3 fill-current" />
+        </TooltipIconButton>
+      </div>
+    </div>
+    <div
+      className="composer-action-wrapper flex items-center gap-2.5"
+      style={{ padding: 32.5 }}
+    >
+      <TooltipIconButton
+        data-case="comparison-send"
+        tooltip="Send message"
+        variant="default"
+        className="ml-1.5 size-9 rounded-full"
+      >
+        <ArrowUpIcon className="unsloth-send-icon size-[22px] stroke-2" />
+      </TooltipIconButton>
+      <Button
+        data-case="comparison-stop"
+        aria-label="Stop generation"
+        variant="default"
+        size="icon"
+        className="ml-1.5 size-9 rounded-full"
+      >
+        <SquareIcon className="size-3 fill-current" />
+      </Button>
+      <TooltipIconButton
+        data-case="transcription-stop"
+        tooltip="Cancel transcription"
+        variant="default"
+        className="ml-1.5 size-9 rounded-full"
+      >
+        <SquareIcon className="size-3 animate-pulse fill-current" />
+      </TooltipIconButton>
+    </div>
+  </TooltipProvider>,
+);

--- a/studio/frontend/smoke-composer-icons.html
+++ b/studio/frontend/smoke-composer-icons.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Composer icon alignment</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/smoke-composer-icons-main.tsx"></script>
+  </body>
+</html>

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -261,7 +261,7 @@ export const ChatDictationBar: FC<{
           {transcribing === "stop" ? (
             <Spinner className="size-3.5" />
           ) : (
-            <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+            <SquareIcon className="size-3 fill-current" />
           )}
         </TooltipIconButton>
         <TooltipIconButton

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -6672,7 +6672,7 @@ const ComposerRightControls: FC<{
               aria-label="Stop queued message"
               onClick={stop}
             >
-              <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+              <SquareIcon className="size-3 fill-current" />
             </Button>
           ) : (
             <TooltipIconButton
@@ -6704,7 +6704,7 @@ const ComposerRightControls: FC<{
           {researchStopping ? (
             <Spinner className="size-3.5" />
           ) : (
-            <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+            <SquareIcon className="size-3 fill-current" />
           )}
         </Button>
       ) : (
@@ -6720,7 +6720,7 @@ const ComposerRightControls: FC<{
                 aria-label="Stop generating"
                 onClick={stop}
               >
-                <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+                <SquareIcon className="size-3 fill-current" />
               </Button>
             </ComposerPrimitive.Cancel>
             ) : (

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -2788,7 +2788,7 @@ export function SharedComposer({
                       : "Stop dictation"
                   }
                 >
-                  <SquareIcon className="aui-composer-cancel-icon size-3 animate-pulse fill-current" />
+                  <SquareIcon className="size-3 animate-pulse fill-current" />
                 </TooltipIconButton>
               )}
             </>
@@ -2816,7 +2816,7 @@ export function SharedComposer({
               className="ml-1.5 size-9 rounded-full"
               onClick={stop}
             >
-              <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
+              <SquareIcon className="size-3 fill-current" />
             </Button>
           ) : (
             <TooltipIconButton

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -3330,12 +3330,7 @@ html[data-chat-font] .aui-root {
 		width: calc(var(--ui-icon-size) * 1.2);
 		height: calc(var(--ui-icon-size) * 1.2);
 	}
-	/* No sub-pixel nudge on the composer action glyphs. A translate is a CSS
-	   length, so its device-pixel value follows the DPR and only lands on a
-	   raster symmetry point at some ratios: the arrow's old -0.25px was clean
-	   at DPR 2 but put ~2.9x the ink on the arrowhead's left tip at DPR 1, and
-	   the stop square's -0.5px broke at 1.25/1.5. Centering the glyph in the
-	   action instead is symmetric at every ratio. */
+	/* Flex centers both symmetric glyphs; pixel offsets vary by display scale. */
 	& svg.unsloth-send-icon {
 		width: calc(var(--ui-icon-size) * 1.15);
 		height: calc(var(--ui-icon-size) * 1.15);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -3330,16 +3330,15 @@ html[data-chat-font] .aui-root {
 		width: calc(var(--ui-icon-size) * 1.2);
 		height: calc(var(--ui-icon-size) * 1.2);
 	}
+	/* No sub-pixel nudge on the composer action glyphs. A translate is a CSS
+	   length, so its device-pixel value follows the DPR and only lands on a
+	   raster symmetry point at some ratios: the arrow's old -0.25px was clean
+	   at DPR 2 but put ~2.9x the ink on the arrowhead's left tip at DPR 1, and
+	   the stop square's -0.5px broke at 1.25/1.5. Centering the glyph in the
+	   action instead is symmetric at every ratio. */
 	& svg.unsloth-send-icon {
 		width: calc(var(--ui-icon-size) * 1.15);
 		height: calc(var(--ui-icon-size) * 1.15);
-		/* The stroked arrow rasterizes half a Retina pixel to the right. */
-		transform: translateX(-0.25px);
-	}
-	/* The filled stop glyph lands one Retina pixel right of the circular
-	   action's center even though its SVG box is flex-centered. */
-	& svg.aui-composer-cancel-icon {
-		transform: translateX(-0.5px);
 	}
 	/* Composer plus keeps its pre-#7400 22px base (1.375x the token is the same
 	   curve a 22px glyph would follow), so only its scaling changed. */

--- a/studio/frontend/tests/composer-icon-alignment.test.ts
+++ b/studio/frontend/tests/composer-icon-alignment.test.ts
@@ -17,26 +17,38 @@ function tags(source: string, component: string): string[] {
   return source.match(new RegExp(`<${component}\\b[^>]*\\/>`, "g")) ?? [];
 }
 
-test("every composer send arrow uses the optical centering class", () => {
+const COMPOSER_GLYPH_RULES = [
+  /& svg\.unsloth-send-icon \{([\s\S]*?)\n\t\}/,
+  /& svg\.aui-composer-cancel-icon \{([\s\S]*?)\n\t\}/,
+];
+const TRANSLATE = /transform:\s*translate/;
+const RETIRED_CANCEL_CLASS = /aui-composer-cancel-icon/;
+
+test("every composer send arrow uses the shared sizing class", () => {
   const arrows = componentSources.flatMap((source) => tags(source, "ArrowUpIcon"));
 
   assert.equal(arrows.length, 5);
   for (const arrow of arrows) assert.match(arrow, /unsloth-send-icon/);
-  assert.match(
-    css,
-    /svg\.unsloth-send-icon[\s\S]*?transform: translateX\(-0\.25px\)/,
-  );
 });
 
-test("every isolated composer stop square uses the optical centering class", () => {
+test("every isolated composer stop square keeps its size-3 glyph", () => {
   const stops = componentSources
     .flatMap((source) => tags(source, "SquareIcon"))
     .filter((tag) => /\bsize-3\b/.test(tag));
 
   assert.equal(stops.length, 6);
-  for (const stop of stops) assert.match(stop, /aui-composer-cancel-icon/);
-  assert.match(
-    css,
-    /svg\.aui-composer-cancel-icon[\s\S]*?transform: translateX\(-0\.5px\)/,
-  );
+});
+
+// A sub-pixel translate is calibrated for one DPR and skews the glyph on the
+// others, so centering has to come from the geometry.
+test("neither composer action glyph carries a device-pixel nudge", () => {
+  for (const rule of COMPOSER_GLYPH_RULES) {
+    const body = css.match(rule)?.[1];
+    if (body !== undefined) assert.doesNotMatch(body, TRANSLATE);
+  }
+  // The stop square is styled by size-3 alone now, so the class it used to
+  // carry the nudge on must be gone from the components too.
+  for (const source of componentSources) {
+    assert.doesNotMatch(source, RETIRED_CANCEL_CLASS);
+  }
 });

--- a/studio/frontend/tests/composer-icon-alignment.test.ts
+++ b/studio/frontend/tests/composer-icon-alignment.test.ts
@@ -39,15 +39,13 @@ test("every isolated composer stop square keeps its size-3 glyph", () => {
   assert.equal(stops.length, 6);
 });
 
-// A sub-pixel translate is calibrated for one DPR and skews the glyph on the
-// others, so centering has to come from the geometry.
+// Browser geometry is checked by tests/studio/playwright_composer_icons.py.
 test("neither composer action glyph carries a device-pixel nudge", () => {
   for (const rule of COMPOSER_GLYPH_RULES) {
     const body = css.match(rule)?.[1];
     if (body !== undefined) assert.doesNotMatch(body, TRANSLATE);
   }
-  // The stop square is styled by size-3 alone now, so the class it used to
-  // carry the nudge on must be gone from the components too.
+  // The retired class must not return at a call site.
   for (const source of componentSources) {
     assert.doesNotMatch(source, RETIRED_CANCEL_CLASS);
   }

--- a/studio/frontend/tsconfig.app.json
+++ b/studio/frontend/tsconfig.app.json
@@ -31,6 +31,7 @@
   "include": [
     "src",
     "smoke-ansi-main.tsx",
+    "smoke-composer-icons-main.tsx",
     "smoke-find-in-page-main.tsx",
     "smoke-autoscroll-main.tsx",
     "smoke-research-main.tsx",

--- a/tests/studio/playwright_composer_icons.py
+++ b/tests/studio/playwright_composer_icons.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Check composer SVG and glyph centers across browsers and display settings.
+
+Run after npm ci and Playwright browser installation:
+    python tests/studio/playwright_composer_icons.py chromium webkit firefox
+
+Measures CSS geometry; screen antialiasing may differ.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+from _playwright_robust import start_vite, stop_process, wait_for_smoke_page
+
+
+MEASURE = """() => [...document.querySelectorAll('button[data-case]')].map(button => {
+    const svg = button.querySelector('svg');
+    const buttonBox = button.getBoundingClientRect();
+    const svgBox = svg.getBoundingClientRect();
+    const glyph = svg.getBBox();
+    const glyphCenter = new DOMPoint(glyph.x + glyph.width / 2, glyph.y + glyph.height / 2)
+        .matrixTransform(svg.getScreenCTM());
+    const centerX = buttonBox.x + buttonBox.width / 2;
+    const centerY = buttonBox.y + buttonBox.height / 2;
+    return {
+        name: button.dataset.case,
+        svgDx: svgBox.x + svgBox.width / 2 - centerX,
+        svgDy: svgBox.y + svgBox.height / 2 - centerY,
+        glyphDx: glyphCenter.x - centerX,
+        glyphDy: glyphCenter.y - centerY,
+        width: svgBox.width,
+        height: svgBox.height,
+    };
+})"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description = __doc__)
+    parser.add_argument("engines", nargs = "*", default = ["chromium"])
+    parser.add_argument("--out", type = Path, default = Path("logs/playwright-composer-icons"))
+    args = parser.parse_args()
+    args.out.mkdir(parents = True, exist_ok = True)
+    port = int(os.environ.get("PW_PORT", "5417"))
+    server = start_vite(port)
+    results = []
+    failures = []
+    try:
+        wait_for_smoke_page(
+            f"http://127.0.0.1:{port}/smoke-composer-icons.html",
+            "/smoke-composer-icons-main.tsx",
+            proc = server,
+        )
+        with sync_playwright() as pw:
+            for engine in args.engines:
+                browser = getattr(pw, engine).launch()
+                try:
+                    for dpr in (1, 1.25, 1.5, 1.75, 2, 3):
+                        context = browser.new_context(device_scale_factor = dpr)
+                        try:
+                            page = context.new_page()
+                            page.goto(f"http://127.0.0.1:{port}/smoke-composer-icons.html")
+                            page.locator("button[data-case]").last.wait_for()
+                            for font, zoom, dark, direction in itertools.product(
+                                (0.75, 1, 1.25), (0.8, 1, 1.25), (False, True), ("ltr", "rtl")
+                            ):
+                                case = dict(
+                                    engine = engine,
+                                    dpr = dpr,
+                                    font = font,
+                                    zoom = zoom,
+                                    dark = dark,
+                                    direction = direction,
+                                )
+                                page.evaluate(
+                                    """async ({font, zoom, dark, direction}) => {
+                                    const root = document.documentElement;
+                                    root.style.setProperty('--ui-font-scale', String(font));
+                                    root.style.zoom = String(zoom);
+                                    root.classList.toggle('dark', dark);
+                                    root.dir = direction;
+                                    await new Promise(requestAnimationFrame);
+                                }""",
+                                    case,
+                                )
+                                measures = page.evaluate(MEASURE)
+                                assert len(measures) == 6, measures
+                                results.append(dict(case = case, measures = measures))
+                                for measure in measures:
+                                    offsets = [
+                                        measure[key]
+                                        for key in ("svgDx", "svgDy", "glyphDx", "glyphDy")
+                                    ]
+                                    # Allow layout rounding, but reject the old pixel offsets.
+                                    if (
+                                        max(map(abs, offsets)) > 0.02
+                                        or min(measure["width"], measure["height"]) <= 0
+                                    ):
+                                        failures.append(dict(case = case, measure = measure))
+                                if font == zoom == 1 and direction == "ltr":
+                                    page.screenshot(
+                                        path = str(
+                                            args.out
+                                            / f"{engine}-{dpr}-{'dark' if dark else 'light'}.png"
+                                        )
+                                    )
+                        finally:
+                            context.close()
+                    print(f"{engine}: checked 216 configurations / 1296 icons", flush = True)
+                finally:
+                    browser.close()
+    finally:
+        stop_process(server)
+        (args.out / "report.json").write_text(
+            json.dumps(dict(results = results, failures = failures), indent = 2), encoding = "utf-8"
+        )
+    assert not failures, json.dumps(failures[:8], indent = 2)
+    print(f"PASS: {len(results) * 6} rendered icons centered", flush = True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The composer send arrow and stop square used fixed left offsets intended for Retina displays. Those offsets pushed the icons off-center at other display scales. Remove both offsets, retain flex centering, and remove the unused stop-icon class from all six call sites.

Add browser measurements of the SVG box and drawn glyph against the button center. Each engine covers 216 configurations across display scaling, page zoom, UI font size, themes, and text directions. The checks reuse existing CI jobs: Chromium on Linux, Chromium and Firefox on Windows, and Chromium and WebKit on macOS.

Validation:

- All 3,888 local icon measurements passed across Chromium, Firefox, and WebKit, with maximum deviation below 0.009 CSS pixels.
- Frontend typecheck, production build, and all three alignment unit tests passed.
- All 193 selected workflow tests passed. ESLint and Ruff passed. Workflow validation found no new actionlint issues.
- Native OS CI results are pending.
