### PR TITLE
Record which uv cache the install used, instead of inferring it later

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1221,6 +1221,66 @@ public static class UnslothStudioFinalPathV2
     }
     $VenvDir = Join-Path $StudioHome "unsloth_studio"
 
+    # Write down which cache this install used, so a later `unsloth studio update` reuses
+    # it instead of guessing from content. Guessing cannot work: in shared mode
+    # Set-StudioUvCacheForLaunch repoints the running backend at the Studio cache, so any
+    # on-demand install the server does leaves package bytes there and makes an empty
+    # Studio cache look like a full one.
+    # SilentlyContinue rather than Stop: an unwritable Studio root costs the next update a
+    # preference, never the install.
+    function Write-StudioUvCacheMarker {
+        param(
+            [Parameter(Mandatory = $true)][string]$StudioRoot,
+            [Parameter(Mandatory = $true)][string]$Cache
+        )
+        $markerDir = Join-Path $StudioRoot "cache"
+        $markerFile = Join-Path $markerDir "uv-cache-dir"
+        # Absolute, because the update resolves this against ITS working directory, not the
+        # installer's, and both UV_CACHE_DIR and a uv.toml cache-dir may be relative.
+        # $PWD explicitly: GetFullPath alone resolves against the .NET process directory,
+        # which Set-Location does not move, so it would anchor to wherever the process
+        # started rather than to where the installer is running.
+        try {
+            if (-not [System.IO.Path]::IsPathRooted($Cache)) {
+                $Cache = Join-Path $PWD.Path $Cache
+            }
+            $Cache = [System.IO.Path]::GetFullPath($Cache)
+        } catch { }
+        # Remembered so a failed install can put it back: the rollback below restores the
+        # previous environment, and a marker naming the cache of an install that never
+        # happened would outlive it.
+        if (-not $script:StudioUvMarkerSaved) {
+            $script:StudioUvMarkerExisted = Test-Path -LiteralPath $markerFile -PathType Leaf
+            $script:StudioUvMarkerPrevious = if ($script:StudioUvMarkerExisted) {
+                Get-Content -LiteralPath $markerFile -Raw -ErrorAction SilentlyContinue
+            } else { $null }
+            $script:StudioUvMarkerSaved = $true
+        }
+        if (-not (Test-Path -LiteralPath $markerDir -PathType Container)) {
+            New-Item -ItemType Directory -Path $markerDir -Force `
+                -ErrorAction SilentlyContinue | Out-Null
+        }
+        Set-Content -LiteralPath $markerFile -Value $Cache `
+            -Encoding utf8 -ErrorAction SilentlyContinue
+    }
+
+    function Restore-StudioUvCacheMarker {
+        # AllowEmptyString and the guard below: this runs from the rollback, where the
+        # partial branch is outside any try and the other branch's catch reports "could
+        # not restore" for a move that already succeeded. A marker is never worth either.
+        param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$StudioRoot)
+        if (-not $script:StudioUvMarkerSaved) { return }
+        if ([string]::IsNullOrWhiteSpace($StudioRoot)) { return }
+        $markerFile = Join-Path (Join-Path $StudioRoot "cache") "uv-cache-dir"
+        if ($script:StudioUvMarkerExisted) {
+            Set-Content -LiteralPath $markerFile -Value ($script:StudioUvMarkerPrevious).TrimEnd("`r", "`n") `
+                -Encoding utf8 -ErrorAction SilentlyContinue
+        } else {
+            Remove-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue
+        }
+        $script:StudioUvMarkerSaved = $false
+    }
+
     function Set-StudioUvCacheEnvironment {
         param(
             [Parameter(Mandatory = $true)][string]$StudioRoot,
@@ -1230,6 +1290,10 @@ public static class UnslothStudioFinalPathV2
         $studioCache = Join-Path (Join-Path $StudioRoot "cache") "uv"
         if (-not [string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
             $script:StudioUvCacheMode = "custom"
+            # Recorded like any other choice, so the previous install's marker cannot send
+            # later updates to a cache this install never filled. A caller keeps control
+            # regardless: a nonblank UV_CACHE_DIR outranks the marker at update time too.
+            Write-StudioUvCacheMarker -StudioRoot $StudioRoot -Cache $env:UV_CACHE_DIR
             step "uv cache" "preserving custom UV_CACHE_DIR ($env:UV_CACHE_DIR)"
             return
         }
@@ -1299,6 +1363,13 @@ public static class UnslothStudioFinalPathV2
             }
         }
         Set-Item -LiteralPath Env:UV_CACHE_DIR -Value $selectedCache
+        # Write down which cache this install used, so a later `unsloth studio update`
+        # reuses it instead of guessing from content. Guessing cannot work: in shared mode
+        # Set-StudioUvCacheForLaunch repoints the running backend at the Studio cache, so
+        # any on-demand install the server does leaves package bytes there and makes an
+        # empty Studio cache look like a full one. Best effort: an unwritable StudioRoot
+        # must not fail the install.
+        Write-StudioUvCacheMarker -StudioRoot $StudioRoot -Cache $selectedCache
 
         switch ($script:StudioUvCacheMode) {
             "shared" {
@@ -3961,6 +4032,13 @@ exit 0
     $script:StudioVenvRollbackTarget = $VenvDir
     $script:StudioVenvRollbackActive = $false
     $script:StudioVenvRollbackPartial = $false
+    # The uv cache marker snapshot travels with the environment, so it resets with the
+    # rollback state. Same reason as the line below: under `irm | iex` the script scope is
+    # the caller's session, so a second install in one session would otherwise roll back
+    # to the marker it snapshotted before the first.
+    $script:StudioUvMarkerSaved = $false
+    $script:StudioUvMarkerExisted = $false
+    $script:StudioUvMarkerPrevious = $null
     # Reset per run: under `irm | iex` the script scope IS the caller's session.
     $script:PrevTorchVer = ""
     $script:PrevTorchPin = $null
@@ -4236,6 +4314,8 @@ exit 0
             }
             if ($merged) {
                 substep "restored previous environment"
+                # The marker describes the environment, so it goes back with it.
+                Restore-StudioUvCacheMarker -StudioRoot $StudioHome
                 $script:StudioVenvRollbackActive = $false
                 $script:StudioVenvRollbackDir = $null
                 $script:StudioVenvRollbackPartial = $false
@@ -4255,6 +4335,8 @@ exit 0
             }
             Move-Item -LiteralPath $backup -Destination $target -Force -ErrorAction Stop
             substep "restored previous environment"
+            # The marker describes the environment, so it goes back with it.
+            Restore-StudioUvCacheMarker -StudioRoot $StudioHome
             $script:StudioVenvRollbackActive = $false
             $script:StudioVenvRollbackDir = $null
         } catch {

--- a/install.ps1
+++ b/install.ps1
@@ -318,6 +318,12 @@ function Install-UnslothStudio {
         if (Get-Command Restore-StudioVenvRollback -CommandType Function -ErrorAction SilentlyContinue) {
             Restore-StudioVenvRollback
         }
+        # Not inside that rollback: an install can fail before a replacement is even in
+        # flight, and the failed attempt must not leave a marker naming a cache no
+        # environment here was built from. Defined later, so probed like the line above.
+        if (Get-Command Restore-StudioUvCacheMarker -CommandType Function -ErrorAction SilentlyContinue) {
+            Restore-StudioUvCacheMarker -StudioRoot $StudioHome
+        }
         # Most failures return before the lock try/finally, and under `irm | iex`
         # these variables are the caller's own. Defined later, so probed like above.
         if (Get-Command Restore-StudioTempEnvironment -CommandType Function -ErrorAction SilentlyContinue) {
@@ -1250,13 +1256,18 @@ public static class UnslothStudioFinalPathV2
         # previous environment, and a marker naming the cache of an install that never
         # happened would outlive it.
         if (-not $script:StudioUvMarkerSaved) {
-            $script:StudioUvMarkerExisted = Test-Path -LiteralPath $markerFile -PathType Leaf
+            # SilentlyContinue on the probe too, not just the write: the script runs under
+            # $ErrorActionPreference = "Stop", and Test-Path on a path inside a directory
+            # the ACL denies throws UnauthorizedAccessException rather than returning
+            # $false, which would abort the install over an optional marker.
+            $script:StudioUvMarkerExisted = Test-Path -LiteralPath $markerFile -PathType Leaf `
+                -ErrorAction SilentlyContinue
             $script:StudioUvMarkerPrevious = if ($script:StudioUvMarkerExisted) {
                 Get-Content -LiteralPath $markerFile -Raw -ErrorAction SilentlyContinue
             } else { $null }
             $script:StudioUvMarkerSaved = $true
         }
-        if (-not (Test-Path -LiteralPath $markerDir -PathType Container)) {
+        if (-not (Test-Path -LiteralPath $markerDir -PathType Container -ErrorAction SilentlyContinue)) {
             New-Item -ItemType Directory -Path $markerDir -Force `
                 -ErrorAction SilentlyContinue | Out-Null
         }
@@ -4005,6 +4016,14 @@ exit 0
         return (Exit-InstallFailure "uv could not be installed")
     }
 
+    # Before the selector, which is what writes the marker: resetting afterwards would
+    # discard the snapshot it had just taken and make every Restore-StudioUvCacheMarker a
+    # no-op. Reset per run because under `irm | iex` the script scope is the caller's
+    # session, so a second install would otherwise restore the first one's marker.
+    $script:StudioUvMarkerSaved = $false
+    $script:StudioUvMarkerExisted = $false
+    $script:StudioUvMarkerPrevious = $null
+
     Set-StudioUvCacheEnvironment -StudioRoot $StudioHome -Isolated $IsolateUvCache -UvExecutable $script:UvExe
 
     # Bytecode compilation can exceed uv's 60s default on slow machines ("0" disables).
@@ -4032,13 +4051,6 @@ exit 0
     $script:StudioVenvRollbackTarget = $VenvDir
     $script:StudioVenvRollbackActive = $false
     $script:StudioVenvRollbackPartial = $false
-    # The uv cache marker snapshot travels with the environment, so it resets with the
-    # rollback state. Same reason as the line below: under `irm | iex` the script scope is
-    # the caller's session, so a second install in one session would otherwise roll back
-    # to the marker it snapshotted before the first.
-    $script:StudioUvMarkerSaved = $false
-    $script:StudioUvMarkerExisted = $false
-    $script:StudioUvMarkerPrevious = $null
     # Reset per run: under `irm | iex` the script scope IS the caller's session.
     $script:PrevTorchVer = ""
     $script:PrevTorchPin = $null
@@ -4314,8 +4326,6 @@ exit 0
             }
             if ($merged) {
                 substep "restored previous environment"
-                # The marker describes the environment, so it goes back with it.
-                Restore-StudioUvCacheMarker -StudioRoot $StudioHome
                 $script:StudioVenvRollbackActive = $false
                 $script:StudioVenvRollbackDir = $null
                 $script:StudioVenvRollbackPartial = $false
@@ -4335,8 +4345,6 @@ exit 0
             }
             Move-Item -LiteralPath $backup -Destination $target -Force -ErrorAction Stop
             substep "restored previous environment"
-            # The marker describes the environment, so it goes back with it.
-            Restore-StudioUvCacheMarker -StudioRoot $StudioHome
             $script:StudioVenvRollbackActive = $false
             $script:StudioVenvRollbackDir = $null
         } catch {
@@ -6655,6 +6663,7 @@ sys.exit(2 if conflict else (0 if installed else 1))
     } finally {
         if (-not $studioVenvReplacementCommitted) {
             Restore-StudioVenvRollback
+            Restore-StudioUvCacheMarker -StudioRoot $StudioHome
         }
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -1257,7 +1257,12 @@ public static class UnslothStudioFinalPathV2
         try {
             if (-not [System.IO.Path]::IsPathRooted($Cache)) {
                 $base = if (-not [string]::IsNullOrWhiteSpace($env:UV_WORKING_DIR)) {
-                    $env:UV_WORKING_DIR
+                    # May itself be relative, and uv resolves it against the directory the
+                    # installer was run from. GetFullPath below would use the .NET process
+                    # directory instead, which Set-Location does not move.
+                    if ([System.IO.Path]::IsPathRooted($env:UV_WORKING_DIR)) {
+                        $env:UV_WORKING_DIR
+                    } else { Join-Path $PWD.Path $env:UV_WORKING_DIR }
                 } else { $PWD.Path }
                 $Cache = Join-Path $base $Cache
             }

--- a/install.ps1
+++ b/install.ps1
@@ -16,6 +16,14 @@
 function Install-UnslothStudio {
     $ErrorActionPreference = "Stop"
 
+    # First thing in the function, because Exit-InstallFailure restores the marker and the
+    # lock checks can reach it long before the cache selection runs. Under `irm | iex` the
+    # script scope is the caller's session and nothing clears this on success, so a second
+    # install failing early would otherwise revert the marker of the one that succeeded.
+    $script:StudioUvMarkerSaved = $false
+    $script:StudioUvMarkerExisted = $false
+    $script:StudioUvMarkerPrevious = $null
+
     # The user's PowerShell profile has already run by the time this does, and the documented
     # piped web entry point documented in the README has no script file to re-launch
     # with -NoProfile, so each way a profile can reach in here is cut individually below.
@@ -1242,17 +1250,20 @@ public static class UnslothStudioFinalPathV2
         $markerDir = Join-Path $StudioRoot "cache"
         $markerFile = Join-Path $markerDir "uv-cache-dir"
         # Absolute, because the update resolves this against ITS working directory, not the
-        # installer's, and both UV_CACHE_DIR and a uv.toml cache-dir may be relative.
-        # $PWD explicitly: GetFullPath alone resolves against the .NET process directory,
-        # which Set-Location does not move, so it would anchor to wherever the process
-        # started rather than to where the installer is running.
+        # installer's, and both UV_CACHE_DIR and a uv.toml cache-dir may be relative. The
+        # base is uv's working directory, which --directory / UV_WORKING_DIR moves; $PWD
+        # explicitly because GetFullPath resolves against the .NET process directory, which
+        # Set-Location does not move.
         try {
             if (-not [System.IO.Path]::IsPathRooted($Cache)) {
-                $Cache = Join-Path $PWD.Path $Cache
+                $base = if (-not [string]::IsNullOrWhiteSpace($env:UV_WORKING_DIR)) {
+                    $env:UV_WORKING_DIR
+                } else { $PWD.Path }
+                $Cache = Join-Path $base $Cache
             }
             $Cache = [System.IO.Path]::GetFullPath($Cache)
         } catch { }
-        # Remembered so a failed install can put it back: the rollback below restores the
+        # Remembered so a failed install can put it back: the rollback restores the
         # previous environment, and a marker naming the cache of an install that never
         # happened would outlive it.
         if (-not $script:StudioUvMarkerSaved) {
@@ -1260,17 +1271,30 @@ public static class UnslothStudioFinalPathV2
             # $ErrorActionPreference = "Stop", and Test-Path on a path inside a directory
             # the ACL denies throws UnauthorizedAccessException rather than returning
             # $false, which would abort the install over an optional marker.
-            $script:StudioUvMarkerExisted = Test-Path -LiteralPath $markerFile -PathType Leaf `
-                -ErrorAction SilentlyContinue
-            $script:StudioUvMarkerPrevious = if ($script:StudioUvMarkerExisted) {
-                Get-Content -LiteralPath $markerFile -Raw -ErrorAction SilentlyContinue
-            } else { $null }
+            $existing = Test-Path -LiteralPath $markerFile -ErrorAction SilentlyContinue
+            if ($existing) {
+                $previous = Get-Content -LiteralPath $markerFile -Raw -ErrorAction SilentlyContinue
+                # An existing marker we cannot read is one we cannot put back. Leaving it
+                # alone loses this run's preference; overwriting it loses the previous
+                # install's, and a rollback would then restore nothing at all.
+                if ($null -eq $previous) { return }
+                $script:StudioUvMarkerPrevious = $previous
+                $script:StudioUvMarkerExisted = $true
+            } else {
+                $script:StudioUvMarkerPrevious = $null
+                $script:StudioUvMarkerExisted = $false
+            }
             $script:StudioUvMarkerSaved = $true
         }
+        # CreateDirectory, not New-Item -Path: -Path treats [] as a wildcard, and a custom
+        # Studio root may contain them (same reason as the calls at 1199 and 4044).
         if (-not (Test-Path -LiteralPath $markerDir -PathType Container -ErrorAction SilentlyContinue)) {
-            New-Item -ItemType Directory -Path $markerDir -Force `
-                -ErrorAction SilentlyContinue | Out-Null
+            try { [System.IO.Directory]::CreateDirectory($markerDir) | Out-Null } catch { }
         }
+        # Removed first: Set-Content follows a symlink and would truncate whatever it
+        # points at, so a marker path someone has linked elsewhere would quietly destroy
+        # an unrelated file.
+        Remove-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue
         Set-Content -LiteralPath $markerFile -Value $Cache `
             -Encoding utf8 -ErrorAction SilentlyContinue
     }
@@ -1283,11 +1307,10 @@ public static class UnslothStudioFinalPathV2
         if (-not $script:StudioUvMarkerSaved) { return }
         if ([string]::IsNullOrWhiteSpace($StudioRoot)) { return }
         $markerFile = Join-Path (Join-Path $StudioRoot "cache") "uv-cache-dir"
-        if ($script:StudioUvMarkerExisted) {
-            Set-Content -LiteralPath $markerFile -Value ($script:StudioUvMarkerPrevious).TrimEnd("`r", "`n") `
+        Remove-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue
+        if ($script:StudioUvMarkerExisted -and $null -ne $script:StudioUvMarkerPrevious) {
+            Set-Content -LiteralPath $markerFile -Value ([string]$script:StudioUvMarkerPrevious).TrimEnd("`r", "`n") `
                 -Encoding utf8 -ErrorAction SilentlyContinue
-        } else {
-            Remove-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue
         }
         $script:StudioUvMarkerSaved = $false
     }
@@ -4016,14 +4039,6 @@ exit 0
         return (Exit-InstallFailure "uv could not be installed")
     }
 
-    # Before the selector, which is what writes the marker: resetting afterwards would
-    # discard the snapshot it had just taken and make every Restore-StudioUvCacheMarker a
-    # no-op. Reset per run because under `irm | iex` the script scope is the caller's
-    # session, so a second install would otherwise restore the first one's marker.
-    $script:StudioUvMarkerSaved = $false
-    $script:StudioUvMarkerExisted = $false
-    $script:StudioUvMarkerPrevious = $null
-
     Set-StudioUvCacheEnvironment -StudioRoot $StudioHome -Isolated $IsolateUvCache -UvExecutable $script:UvExe
 
     # Bytecode compilation can exceed uv's 60s default on slow machines ("0" disables).
@@ -4358,6 +4373,10 @@ exit 0
         $backup = $script:StudioVenvRollbackDir
         # The replacement is committed. Disable restoration before deleting the
         # backup so interruption cannot restore a partially deleted environment.
+        # The marker came with this environment, so it is committed too: a later failure
+        # rolls nothing back, and reverting the marker would leave the installed
+        # environment pointing at the cache of the one before it.
+        $script:StudioUvMarkerSaved = $false
         $script:StudioVenvRollbackActive = $false
         $script:StudioVenvRollbackDir = $null
         $script:StudioVenvRollbackPartial = $false

--- a/install.ps1
+++ b/install.ps1
@@ -16,10 +16,8 @@
 function Install-UnslothStudio {
     $ErrorActionPreference = "Stop"
 
-    # First thing in the function, because Exit-InstallFailure restores the marker and the
-    # lock checks can reach it long before the cache selection runs. Under `irm | iex` the
-    # script scope is the caller's session and nothing clears this on success, so a second
-    # install failing early would otherwise revert the marker of the one that succeeded.
+    # First: Exit-InstallFailure restores the marker long before the selection runs, and
+    # under `irm | iex` the script scope is the caller's session.
     $script:StudioUvMarkerSaved = $false
     $script:StudioUvMarkerExisted = $false
     $script:StudioUvMarkerPrevious = $null
@@ -326,9 +324,7 @@ function Install-UnslothStudio {
         if (Get-Command Restore-StudioVenvRollback -CommandType Function -ErrorAction SilentlyContinue) {
             Restore-StudioVenvRollback
         }
-        # Not inside that rollback: an install can fail before a replacement is even in
-        # flight, and the failed attempt must not leave a marker naming a cache no
-        # environment here was built from. Defined later, so probed like the line above.
+        # Separate from the venv rollback: an install can fail before one is in flight.
         if (Get-Command Restore-StudioUvCacheMarker -CommandType Function -ErrorAction SilentlyContinue) {
             Restore-StudioUvCacheMarker -StudioRoot $StudioHome
         }
@@ -1235,13 +1231,9 @@ public static class UnslothStudioFinalPathV2
     }
     $VenvDir = Join-Path $StudioHome "unsloth_studio"
 
-    # Write down which cache this install used, so a later `unsloth studio update` reuses
-    # it instead of guessing from content. Guessing cannot work: in shared mode
-    # Set-StudioUvCacheForLaunch repoints the running backend at the Studio cache, so any
-    # on-demand install the server does leaves package bytes there and makes an empty
-    # Studio cache look like a full one.
-    # SilentlyContinue rather than Stop: an unwritable Studio root costs the next update a
-    # preference, never the install.
+    # Records which cache this install used, so an update reuses it rather than guessing:
+    # Set-StudioUvCacheForLaunch repoints the backend at the Studio cache even in shared
+    # mode, so one on-demand install makes an empty Studio cache look full. Never fatal.
     function Write-StudioUvCacheMarker {
         param(
             [Parameter(Mandatory = $true)][string]$StudioRoot,
@@ -1249,17 +1241,12 @@ public static class UnslothStudioFinalPathV2
         )
         $markerDir = Join-Path $StudioRoot "cache"
         $markerFile = Join-Path $markerDir "uv-cache-dir"
-        # Absolute, because the update resolves this against ITS working directory, not the
-        # installer's, and both UV_CACHE_DIR and a uv.toml cache-dir may be relative. The
-        # base is uv's working directory, which --directory / UV_WORKING_DIR moves; $PWD
-        # explicitly because GetFullPath resolves against the .NET process directory, which
-        # Set-Location does not move.
+        # Absolute: the update resolves this against ITS working directory. $PWD is
+        # explicit because GetFullPath uses the unmoved .NET process directory.
         try {
             if (-not [System.IO.Path]::IsPathRooted($Cache)) {
                 $base = if (-not [string]::IsNullOrWhiteSpace($env:UV_WORKING_DIR)) {
-                    # May itself be relative, and uv resolves it against the directory the
-                    # installer was run from. GetFullPath below would use the .NET process
-                    # directory instead, which Set-Location does not move.
+                    # May itself be relative, against the installer's own directory.
                     if ([System.IO.Path]::IsPathRooted($env:UV_WORKING_DIR)) {
                         $env:UV_WORKING_DIR
                     } else { Join-Path $PWD.Path $env:UV_WORKING_DIR }
@@ -1268,20 +1255,13 @@ public static class UnslothStudioFinalPathV2
             }
             $Cache = [System.IO.Path]::GetFullPath($Cache)
         } catch { }
-        # Remembered so a failed install can put it back: the rollback restores the
-        # previous environment, and a marker naming the cache of an install that never
-        # happened would outlive it.
+        # Remembered so a rollback can put it back.
         if (-not $script:StudioUvMarkerSaved) {
-            # SilentlyContinue on the probe too, not just the write: the script runs under
-            # $ErrorActionPreference = "Stop", and Test-Path on a path inside a directory
-            # the ACL denies throws UnauthorizedAccessException rather than returning
-            # $false, which would abort the install over an optional marker.
+            # Under "Stop", Test-Path inside an ACL-denied directory throws.
             $existing = Test-Path -LiteralPath $markerFile -ErrorAction SilentlyContinue
             if ($existing) {
                 $previous = Get-Content -LiteralPath $markerFile -Raw -ErrorAction SilentlyContinue
-                # An existing marker we cannot read is one we cannot put back. Leaving it
-                # alone loses this run's preference; overwriting it loses the previous
-                # install's, and a rollback would then restore nothing at all.
+                # One we cannot read is one we cannot put back, so leave it alone.
                 if ($null -eq $previous) { return }
                 $script:StudioUvMarkerPrevious = $previous
                 $script:StudioUvMarkerExisted = $true
@@ -1291,19 +1271,14 @@ public static class UnslothStudioFinalPathV2
             }
             $script:StudioUvMarkerSaved = $true
         }
-        # CreateDirectory, not New-Item -Path: -Path treats [] as a wildcard, and a custom
-        # Studio root may contain them (same reason as the calls at 1199 and 4044).
+        # CreateDirectory, not New-Item -Path: -Path treats [] in the root as a wildcard.
         if (-not (Test-Path -LiteralPath $markerDir -PathType Container -ErrorAction SilentlyContinue)) {
             try { [System.IO.Directory]::CreateDirectory($markerDir) | Out-Null } catch { }
         }
-        # Removed first: Set-Content follows a symlink and would truncate whatever it
-        # points at, so a marker path someone has linked elsewhere would quietly destroy
-        # an unrelated file.
+        # Removed first: Set-Content follows a symlink and would truncate its target.
         Remove-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue
-        # And only write once it is gone. Remove-Item fails non-terminatingly here, and a
-        # link whose directory denies deletion while its target is writable is exactly the
-        # case Set-Content would follow and truncate. Get-Item -Force, not Test-Path: it
-        # reports the reparse point itself rather than following it to a missing target.
+        # And only once gone, since that removal fails non-terminatingly. Get-Item -Force
+        # reports the link itself; Test-Path would follow it.
         if ($null -ne (Get-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue)) {
             return
         }
@@ -1312,9 +1287,8 @@ public static class UnslothStudioFinalPathV2
     }
 
     function Restore-StudioUvCacheMarker {
-        # AllowEmptyString and the guard below: this runs from the rollback, where the
-        # partial branch is outside any try and the other branch's catch reports "could
-        # not restore" for a move that already succeeded. A marker is never worth either.
+        # AllowEmptyString and the blank guard: a throw here would be reported as a
+        # failed environment restore.
         param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$StudioRoot)
         if (-not $script:StudioUvMarkerSaved) { return }
         if ([string]::IsNullOrWhiteSpace($StudioRoot)) { return }
@@ -1337,9 +1311,7 @@ public static class UnslothStudioFinalPathV2
         $studioCache = Join-Path (Join-Path $StudioRoot "cache") "uv"
         if (-not [string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
             $script:StudioUvCacheMode = "custom"
-            # Recorded like any other choice, so the previous install's marker cannot send
-            # later updates to a cache this install never filled. A caller keeps control
-            # regardless: a nonblank UV_CACHE_DIR outranks the marker at update time too.
+            # Recorded like any other choice; a caller still outranks the marker.
             Write-StudioUvCacheMarker -StudioRoot $StudioRoot -Cache $env:UV_CACHE_DIR
             step "uv cache" "preserving custom UV_CACHE_DIR ($env:UV_CACHE_DIR)"
             return
@@ -1410,12 +1382,6 @@ public static class UnslothStudioFinalPathV2
             }
         }
         Set-Item -LiteralPath Env:UV_CACHE_DIR -Value $selectedCache
-        # Write down which cache this install used, so a later `unsloth studio update`
-        # reuses it instead of guessing from content. Guessing cannot work: in shared mode
-        # Set-StudioUvCacheForLaunch repoints the running backend at the Studio cache, so
-        # any on-demand install the server does leaves package bytes there and makes an
-        # empty Studio cache look like a full one. Best effort: an unwritable StudioRoot
-        # must not fail the install.
         Write-StudioUvCacheMarker -StudioRoot $StudioRoot -Cache $selectedCache
 
         switch ($script:StudioUvCacheMode) {
@@ -4382,10 +4348,7 @@ exit 0
     }
 
     function Complete-StudioVenvRollback {
-        # Above the early return, because a first install has no previous environment to
-        # roll back and still commits one. The marker came with that environment, so it is
-        # committed too: reverting it later would leave the installed environment pointing
-        # at the cache of the one before it.
+        # Above the early return: a first install rolls nothing back and still commits.
         $script:StudioUvMarkerSaved = $false
         if (-not $script:StudioVenvRollbackActive) { return }
         $backup = $script:StudioVenvRollbackDir

--- a/install.ps1
+++ b/install.ps1
@@ -1300,6 +1300,13 @@ public static class UnslothStudioFinalPathV2
         # points at, so a marker path someone has linked elsewhere would quietly destroy
         # an unrelated file.
         Remove-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue
+        # And only write once it is gone. Remove-Item fails non-terminatingly here, and a
+        # link whose directory denies deletion while its target is writable is exactly the
+        # case Set-Content would follow and truncate. Get-Item -Force, not Test-Path: it
+        # reports the reparse point itself rather than following it to a missing target.
+        if ($null -ne (Get-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue)) {
+            return
+        }
         Set-Content -LiteralPath $markerFile -Value $Cache `
             -Encoding utf8 -ErrorAction SilentlyContinue
     }
@@ -1313,7 +1320,8 @@ public static class UnslothStudioFinalPathV2
         if ([string]::IsNullOrWhiteSpace($StudioRoot)) { return }
         $markerFile = Join-Path (Join-Path $StudioRoot "cache") "uv-cache-dir"
         Remove-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue
-        if ($script:StudioUvMarkerExisted -and $null -ne $script:StudioUvMarkerPrevious) {
+        $stillThere = $null -ne (Get-Item -LiteralPath $markerFile -Force -ErrorAction SilentlyContinue)
+        if (-not $stillThere -and $script:StudioUvMarkerExisted -and $null -ne $script:StudioUvMarkerPrevious) {
             Set-Content -LiteralPath $markerFile -Value ([string]$script:StudioUvMarkerPrevious).TrimEnd("`r", "`n") `
                 -Encoding utf8 -ErrorAction SilentlyContinue
         }
@@ -4374,14 +4382,15 @@ exit 0
     }
 
     function Complete-StudioVenvRollback {
+        # Above the early return, because a first install has no previous environment to
+        # roll back and still commits one. The marker came with that environment, so it is
+        # committed too: reverting it later would leave the installed environment pointing
+        # at the cache of the one before it.
+        $script:StudioUvMarkerSaved = $false
         if (-not $script:StudioVenvRollbackActive) { return }
         $backup = $script:StudioVenvRollbackDir
         # The replacement is committed. Disable restoration before deleting the
         # backup so interruption cannot restore a partially deleted environment.
-        # The marker came with this environment, so it is committed too: a later failure
-        # rolls nothing back, and reverting the marker would leave the installed
-        # environment pointing at the cache of the one before it.
-        $script:StudioUvMarkerSaved = $false
         $script:StudioVenvRollbackActive = $false
         $script:StudioVenvRollbackDir = $null
         $script:StudioVenvRollbackPartial = $false

--- a/install.sh
+++ b/install.sh
@@ -853,8 +853,6 @@ _restore_studio_venv_replacement() {
     rm -rf "$_VENV_ROLLBACK_TARGET"
     if mv "$_VENV_ROLLBACK_DIR" "$_VENV_ROLLBACK_TARGET"; then
         rollback_substep "restored previous environment"
-        # The marker describes the environment, so it goes back with it.
-        _restore_uv_cache_marker
         _VENV_ROLLBACK_ACTIVE=false
         _VENV_ROLLBACK_DIR=""
     else
@@ -940,6 +938,11 @@ _on_install_exit() {
     _status=$?
     if [ "$_status" -ne 0 ]; then
         _restore_studio_venv_replacement
+        # Not inside the venv restore: an install can fail before a replacement is even
+        # in flight (a first install has no previous venv, the ownership guard can refuse
+        # the directory, the backup mv can fail), and that failed attempt must not leave
+        # a marker naming a cache no environment here was built from.
+        _restore_uv_cache_marker
     fi
     _cleanup_install_temporaries
     exit "$_status"
@@ -952,6 +955,7 @@ _on_install_signal() {
     trap - EXIT
     trap '' HUP INT TERM
     _restore_studio_venv_replacement
+    _restore_uv_cache_marker
     _cleanup_install_temporaries
     exit "$_signal_status"
 }

--- a/install.sh
+++ b/install.sh
@@ -619,12 +619,57 @@ _resolve_studio_destinations() {
     _STUDIO_HOME_REDIRECT=default
 }
 
+# Write down which cache this install used, so a later `unsloth studio update` reuses it
+# instead of guessing from content. Guessing cannot work: in shared mode the launch below
+# repoints the running backend at the Studio cache, so any on-demand install the server
+# does leaves package bytes there and makes an empty Studio cache look like a full one.
+# Best effort, since a read-only or unwritable STUDIO_HOME must not fail the install.
+_record_uv_cache_choice() {
+    _uv_marker_dir="$STUDIO_HOME/cache"
+    _uv_marker_file="$_uv_marker_dir/uv-cache-dir"
+    # Absolute, because the update resolves this against ITS working directory, not the
+    # installer's: `uv cache dir` answers a relative cache-dir with the relative spelling,
+    # and UV_CACHE_DIR itself may be relative.
+    case "$UV_CACHE_DIR" in
+        /*) _uv_marker_value="$UV_CACHE_DIR" ;;
+        *) _uv_marker_value="$PWD/$UV_CACHE_DIR" ;;
+    esac
+    # Remembered so a failed install can put it back: the trap below restores the previous
+    # environment, and a marker naming the cache of an install that never happened would
+    # outlive it and send the next update somewhere that environment never used.
+    if [ "$_UV_MARKER_SAVED" != true ]; then
+        _UV_MARKER_PREVIOUS=$(cat "$_uv_marker_file" 2>/dev/null) || _UV_MARKER_PREVIOUS=""
+        [ -f "$_uv_marker_file" ] && _UV_MARKER_EXISTED=true || _UV_MARKER_EXISTED=false
+        _UV_MARKER_SAVED=true
+    fi
+    (
+        mkdir -p "$_uv_marker_dir" 2>/dev/null &&
+            printf '%s\n' "$_uv_marker_value" > "$_uv_marker_file" 2>/dev/null
+    ) || true
+}
+
+_restore_uv_cache_marker() {
+    [ "$_UV_MARKER_SAVED" = true ] || return 0
+    _uv_marker_file="$STUDIO_HOME/cache/uv-cache-dir"
+    if [ "$_UV_MARKER_EXISTED" = true ]; then
+        printf '%s\n' "$_UV_MARKER_PREVIOUS" > "$_uv_marker_file" 2>/dev/null || true
+    else
+        rm -f "$_uv_marker_file" 2>/dev/null || true
+    fi
+    _UV_MARKER_SAVED=false
+}
+
 _configure_uv_cache() {
     _uv_studio_cache="$STUDIO_HOME/cache/uv"
     case "${UV_CACHE_DIR-}" in
         *[![:space:]]*)
             _UV_CACHE_MODE=custom
             export UV_CACHE_DIR
+            # Recorded like any other choice. Leaving the previous install's marker in
+            # place would point later updates at a cache this install never filled, and
+            # a caller who wants the variable to stay one-shot still wins on every run:
+            # a nonblank UV_CACHE_DIR outranks the marker in _with_studio_uv_cache too.
+            _record_uv_cache_choice
             step "uv cache" "preserving custom UV_CACHE_DIR ($UV_CACHE_DIR)"
             return 0
             ;;
@@ -634,6 +679,7 @@ _configure_uv_cache() {
         UV_CACHE_DIR="$_uv_studio_cache"
         _UV_CACHE_MODE=isolated
         export UV_CACHE_DIR
+        _record_uv_cache_choice
         step "uv cache" "forced Studio cache isolation ($UV_CACHE_DIR); already-cached packages may download again" "$C_WARN"
         return 0
     fi
@@ -687,6 +733,7 @@ _configure_uv_cache() {
         _UV_CACHE_MODE=studio
     fi
     export UV_CACHE_DIR
+    _record_uv_cache_choice
 
     case "$_UV_CACHE_MODE" in
         shared)
@@ -718,6 +765,11 @@ VENV_DIR="$STUDIO_HOME/unsloth_studio"
 _VENV_ROLLBACK_DIR=""
 _VENV_ROLLBACK_TARGET="$VENV_DIR"
 _VENV_ROLLBACK_ACTIVE=false
+# The uv cache marker travels with the environment: saved before the first write, put
+# back if the environment is rolled back. See _record_uv_cache_choice.
+_UV_MARKER_SAVED=false
+_UV_MARKER_EXISTED=false
+_UV_MARKER_PREVIOUS=""
 
 _start_studio_venv_replacement() {
     _existing_dir="$1"
@@ -801,6 +853,8 @@ _restore_studio_venv_replacement() {
     rm -rf "$_VENV_ROLLBACK_TARGET"
     if mv "$_VENV_ROLLBACK_DIR" "$_VENV_ROLLBACK_TARGET"; then
         rollback_substep "restored previous environment"
+        # The marker describes the environment, so it goes back with it.
+        _restore_uv_cache_marker
         _VENV_ROLLBACK_ACTIVE=false
         _VENV_ROLLBACK_DIR=""
     else

--- a/install.sh
+++ b/install.sh
@@ -633,7 +633,16 @@ _record_uv_cache_choice() {
     # $PWD would name a directory uv never used.
     case "$UV_CACHE_DIR" in
         /*) _uv_marker_value="$UV_CACHE_DIR" ;;
-        *) _uv_marker_value="${UV_WORKING_DIR:-$PWD}/$UV_CACHE_DIR" ;;
+        *)
+            # UV_WORKING_DIR may itself be relative, and uv resolves it against the
+            # directory the installer was run from before it resolves the cache.
+            _uv_marker_base="${UV_WORKING_DIR:-$PWD}"
+            case "$_uv_marker_base" in
+                /*) ;;
+                *) _uv_marker_base="$PWD/$_uv_marker_base" ;;
+            esac
+            _uv_marker_value="$_uv_marker_base/$UV_CACHE_DIR"
+            ;;
     esac
     # Remembered so a failed install can put it back: the traps restore the previous
     # environment, and a marker naming the cache of an install that never happened would
@@ -918,6 +927,9 @@ _commit_studio_venv_replacement() {
         _rollback_to_remove="$_VENV_ROLLBACK_DIR"
         # The new environment is already committed. Clear the restore state
         # before deletion so an interrupt cannot replace it with a half-deleted backup.
+        # The marker goes with it, and in the same breath: a signal landing between the
+        # two would keep the committed environment and revert the marker it came with.
+        _UV_MARKER_SAVED=false
         _VENV_ROLLBACK_ACTIVE=false
         _VENV_ROLLBACK_DIR=""
         # Same shapes as the restore, or such a backup is never cleaned up.
@@ -931,10 +943,6 @@ _commit_studio_venv_replacement() {
     # Only prune older orphaned copies after the replacement has succeeded, so
     # an interrupted install never discards the last known-good environment.
     _prune_stale_studio_venv_rollbacks
-    # The marker came with this environment, so it is committed too: a later failure
-    # rolls nothing back, and reverting the marker would leave the installed environment
-    # pointing at the cache of the one before it.
-    _UV_MARKER_SAVED=false
 }
 
 _cleanup_install_temporaries() {

--- a/install.sh
+++ b/install.sh
@@ -666,6 +666,10 @@ _record_uv_cache_choice() {
             # it points at, so a marker path someone has linked elsewhere would quietly
             # destroy an unrelated file.
             rm -f "$_uv_marker_file" 2>/dev/null &&
+            # And only write once it is gone: rm can fail on a link whose directory
+            # denies deletion while its target is writable, which is exactly the case
+            # the redirection would truncate.
+            ! { [ -e "$_uv_marker_file" ] || [ -L "$_uv_marker_file" ]; } &&
             printf '%s\n' "$_uv_marker_value" > "$_uv_marker_file" 2>/dev/null
     ) || true
 }
@@ -674,7 +678,8 @@ _restore_uv_cache_marker() {
     [ "$_UV_MARKER_SAVED" = true ] || return 0
     _uv_marker_file="$STUDIO_HOME/cache/uv-cache-dir"
     rm -f "$_uv_marker_file" 2>/dev/null || true
-    if [ "$_UV_MARKER_EXISTED" = true ]; then
+    if [ "$_UV_MARKER_EXISTED" = true ] \
+       && ! { [ -e "$_uv_marker_file" ] || [ -L "$_uv_marker_file" ]; }; then
         printf '%s\n' "$_UV_MARKER_PREVIOUS" > "$_uv_marker_file" 2>/dev/null || true
     fi
     _UV_MARKER_SAVED=false
@@ -923,13 +928,15 @@ _prune_stale_studio_venv_rollbacks() {
 }
 
 _commit_studio_venv_replacement() {
+    # Outside the rollback branch, because a first install has no previous environment to
+    # roll back and still commits one. Anything failing after this point (the shim-path
+    # guard, a signal) would otherwise revert the marker while leaving that environment
+    # installed, and send its next offline update to a cache it never filled.
+    _UV_MARKER_SAVED=false
     if [ "$_VENV_ROLLBACK_ACTIVE" = true ]; then
         _rollback_to_remove="$_VENV_ROLLBACK_DIR"
         # The new environment is already committed. Clear the restore state
         # before deletion so an interrupt cannot replace it with a half-deleted backup.
-        # The marker goes with it, and in the same breath: a signal landing between the
-        # two would keep the committed environment and revert the marker it came with.
-        _UV_MARKER_SAVED=false
         _VENV_ROLLBACK_ACTIVE=false
         _VENV_ROLLBACK_DIR=""
         # Same shapes as the restore, or such a backup is never cleaned up.

--- a/install.sh
+++ b/install.sh
@@ -619,23 +619,18 @@ _resolve_studio_destinations() {
     _STUDIO_HOME_REDIRECT=default
 }
 
-# Write down which cache this install used, so a later `unsloth studio update` reuses it
-# instead of guessing from content. Guessing cannot work: in shared mode the launch below
-# repoints the running backend at the Studio cache, so any on-demand install the server
-# does leaves package bytes there and makes an empty Studio cache look like a full one.
-# Best effort, since a read-only or unwritable STUDIO_HOME must not fail the install.
+# Records which cache this install used, so an update reuses it rather than guessing: the
+# launch below repoints the backend at the Studio cache even in shared mode, so one
+# on-demand install makes an empty Studio cache look full. Never fatal.
 _record_uv_cache_choice() {
     _uv_marker_dir="$STUDIO_HOME/cache"
     _uv_marker_file="$_uv_marker_dir/uv-cache-dir"
-    # Absolute, because the update resolves this against ITS working directory, not the
-    # installer's. The base is uv's working directory, which --directory / UV_WORKING_DIR
-    # moves: uv changes into it before resolving a relative cache-dir, so anchoring to
-    # $PWD would name a directory uv never used.
+    # Absolute: the update resolves this against ITS working directory, and the base is
+    # uv's, which --directory / UV_WORKING_DIR moves.
     case "$UV_CACHE_DIR" in
         /*) _uv_marker_value="$UV_CACHE_DIR" ;;
         *)
-            # UV_WORKING_DIR may itself be relative, and uv resolves it against the
-            # directory the installer was run from before it resolves the cache.
+            # Which may itself be relative, against the installer's own directory.
             _uv_marker_base="${UV_WORKING_DIR:-$PWD}"
             case "$_uv_marker_base" in
                 /*) ;;
@@ -644,14 +639,10 @@ _record_uv_cache_choice() {
             _uv_marker_value="$_uv_marker_base/$UV_CACHE_DIR"
             ;;
     esac
-    # Remembered so a failed install can put it back: the traps restore the previous
-    # environment, and a marker naming the cache of an install that never happened would
-    # outlive it and send the next update somewhere that environment never used.
+    # Remembered so a failed install can put it back.
     if [ "$_UV_MARKER_SAVED" != true ]; then
         if [ -e "$_uv_marker_file" ] || [ -L "$_uv_marker_file" ]; then
-            # An existing marker we cannot read is one we cannot put back. Leaving it
-            # alone loses this run's preference; overwriting it loses the previous
-            # install's, and a rollback would then restore a blank file.
+            # One we cannot read is one we cannot put back, so leave it alone.
             _UV_MARKER_PREVIOUS=$(cat "$_uv_marker_file" 2>/dev/null) || return 0
             _UV_MARKER_EXISTED=true
         else
@@ -662,13 +653,9 @@ _record_uv_cache_choice() {
     fi
     (
         mkdir -p "$_uv_marker_dir" 2>/dev/null &&
-            # Unlinked first: a redirection follows a symlink and would truncate whatever
-            # it points at, so a marker path someone has linked elsewhere would quietly
-            # destroy an unrelated file.
+            # Unlinked first: a redirection follows a symlink and truncates its target.
             rm -f "$_uv_marker_file" 2>/dev/null &&
-            # And only write once it is gone: rm can fail on a link whose directory
-            # denies deletion while its target is writable, which is exactly the case
-            # the redirection would truncate.
+            # And only once gone: rm can fail on a link in an undeletable directory.
             ! { [ -e "$_uv_marker_file" ] || [ -L "$_uv_marker_file" ]; } &&
             printf '%s\n' "$_uv_marker_value" > "$_uv_marker_file" 2>/dev/null
     ) || true
@@ -691,10 +678,7 @@ _configure_uv_cache() {
         *[![:space:]]*)
             _UV_CACHE_MODE=custom
             export UV_CACHE_DIR
-            # Recorded like any other choice. Leaving the previous install's marker in
-            # place would point later updates at a cache this install never filled, and
-            # a caller who wants the variable to stay one-shot still wins on every run:
-            # a nonblank UV_CACHE_DIR outranks the marker in _with_studio_uv_cache too.
+            # Recorded like any other choice; a caller still outranks the marker.
             _record_uv_cache_choice
             step "uv cache" "preserving custom UV_CACHE_DIR ($UV_CACHE_DIR)"
             return 0
@@ -791,8 +775,7 @@ VENV_DIR="$STUDIO_HOME/unsloth_studio"
 _VENV_ROLLBACK_DIR=""
 _VENV_ROLLBACK_TARGET="$VENV_DIR"
 _VENV_ROLLBACK_ACTIVE=false
-# The uv cache marker travels with the environment: saved before the first write, put
-# back if the environment is rolled back. See _record_uv_cache_choice.
+# The marker travels with the environment. See _record_uv_cache_choice.
 _UV_MARKER_SAVED=false
 _UV_MARKER_EXISTED=false
 _UV_MARKER_PREVIOUS=""
@@ -928,10 +911,7 @@ _prune_stale_studio_venv_rollbacks() {
 }
 
 _commit_studio_venv_replacement() {
-    # Outside the rollback branch, because a first install has no previous environment to
-    # roll back and still commits one. Anything failing after this point (the shim-path
-    # guard, a signal) would otherwise revert the marker while leaving that environment
-    # installed, and send its next offline update to a cache it never filled.
+    # Outside the branch: a first install rolls nothing back and still commits.
     _UV_MARKER_SAVED=false
     if [ "$_VENV_ROLLBACK_ACTIVE" = true ]; then
         _rollback_to_remove="$_VENV_ROLLBACK_DIR"
@@ -969,10 +949,7 @@ _on_install_exit() {
     _status=$?
     if [ "$_status" -ne 0 ]; then
         _restore_studio_venv_replacement
-        # Not inside the venv restore: an install can fail before a replacement is even
-        # in flight (a first install has no previous venv, the ownership guard can refuse
-        # the directory, the backup mv can fail), and that failed attempt must not leave
-        # a marker naming a cache no environment here was built from.
+        # Separate from the venv restore: an install can fail before one is in flight.
         _restore_uv_cache_marker
     fi
     _cleanup_install_temporaries

--- a/install.sh
+++ b/install.sh
@@ -628,22 +628,35 @@ _record_uv_cache_choice() {
     _uv_marker_dir="$STUDIO_HOME/cache"
     _uv_marker_file="$_uv_marker_dir/uv-cache-dir"
     # Absolute, because the update resolves this against ITS working directory, not the
-    # installer's: `uv cache dir` answers a relative cache-dir with the relative spelling,
-    # and UV_CACHE_DIR itself may be relative.
+    # installer's. The base is uv's working directory, which --directory / UV_WORKING_DIR
+    # moves: uv changes into it before resolving a relative cache-dir, so anchoring to
+    # $PWD would name a directory uv never used.
     case "$UV_CACHE_DIR" in
         /*) _uv_marker_value="$UV_CACHE_DIR" ;;
-        *) _uv_marker_value="$PWD/$UV_CACHE_DIR" ;;
+        *) _uv_marker_value="${UV_WORKING_DIR:-$PWD}/$UV_CACHE_DIR" ;;
     esac
-    # Remembered so a failed install can put it back: the trap below restores the previous
+    # Remembered so a failed install can put it back: the traps restore the previous
     # environment, and a marker naming the cache of an install that never happened would
     # outlive it and send the next update somewhere that environment never used.
     if [ "$_UV_MARKER_SAVED" != true ]; then
-        _UV_MARKER_PREVIOUS=$(cat "$_uv_marker_file" 2>/dev/null) || _UV_MARKER_PREVIOUS=""
-        [ -f "$_uv_marker_file" ] && _UV_MARKER_EXISTED=true || _UV_MARKER_EXISTED=false
+        if [ -e "$_uv_marker_file" ] || [ -L "$_uv_marker_file" ]; then
+            # An existing marker we cannot read is one we cannot put back. Leaving it
+            # alone loses this run's preference; overwriting it loses the previous
+            # install's, and a rollback would then restore a blank file.
+            _UV_MARKER_PREVIOUS=$(cat "$_uv_marker_file" 2>/dev/null) || return 0
+            _UV_MARKER_EXISTED=true
+        else
+            _UV_MARKER_PREVIOUS=""
+            _UV_MARKER_EXISTED=false
+        fi
         _UV_MARKER_SAVED=true
     fi
     (
         mkdir -p "$_uv_marker_dir" 2>/dev/null &&
+            # Unlinked first: a redirection follows a symlink and would truncate whatever
+            # it points at, so a marker path someone has linked elsewhere would quietly
+            # destroy an unrelated file.
+            rm -f "$_uv_marker_file" 2>/dev/null &&
             printf '%s\n' "$_uv_marker_value" > "$_uv_marker_file" 2>/dev/null
     ) || true
 }
@@ -651,10 +664,9 @@ _record_uv_cache_choice() {
 _restore_uv_cache_marker() {
     [ "$_UV_MARKER_SAVED" = true ] || return 0
     _uv_marker_file="$STUDIO_HOME/cache/uv-cache-dir"
+    rm -f "$_uv_marker_file" 2>/dev/null || true
     if [ "$_UV_MARKER_EXISTED" = true ]; then
         printf '%s\n' "$_UV_MARKER_PREVIOUS" > "$_uv_marker_file" 2>/dev/null || true
-    else
-        rm -f "$_uv_marker_file" 2>/dev/null || true
     fi
     _UV_MARKER_SAVED=false
 }
@@ -919,6 +931,10 @@ _commit_studio_venv_replacement() {
     # Only prune older orphaned copies after the replacement has succeeded, so
     # an interrupted install never discards the last known-good environment.
     _prune_stale_studio_venv_rollbacks
+    # The marker came with this environment, so it is committed too: a later failure
+    # rolls nothing back, and reverting the marker would leave the installed environment
+    # pointing at the cache of the one before it.
+    _UV_MARKER_SAVED=false
 }
 
 _cleanup_install_temporaries() {

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1174,28 +1174,34 @@ class TestInstallUvCacheRootParity:
         assert 'case "$UV_CACHE_DIR" in' in sh
         assert "IsPathRooted" in ps1
 
-        # Under `irm | iex` the script scope is the caller's session, so the snapshot has
-        # to be reset per run beside the rollback state it belongs to. A second install in
-        # one session would otherwise roll back to the marker it saw before the first.
-        reset_block = ps1[
-            ps1.index("$script:StudioVenvRollbackPartial = $false") : ps1.index(
-                "# Reset per run: under `irm | iex`"
-            )
-        ]
+        # The reset must precede the call that writes the marker. Resetting after it
+        # discards the snapshot Write-StudioUvCacheMarker had just taken, which makes
+        # every Restore-StudioUvCacheMarker a no-op and leaves a failed reinstall's
+        # marker in place. Per run because under `irm | iex` the script scope is the
+        # caller's session.
+        selector_call = ps1.index("Set-StudioUvCacheEnvironment -StudioRoot $StudioHome")
+        # The whole triple, in the run of lines directly above the call. Searching the
+        # file instead would match the copy inside Restore-StudioUvCacheMarker and pass
+        # even with the reset moved back below the call.
+        preamble = ps1[:selector_call]
         for variable in (
             "$script:StudioUvMarkerSaved = $false",
             "$script:StudioUvMarkerExisted = $false",
             "$script:StudioUvMarkerPrevious = $null",
         ):
-            assert variable in reset_block, variable
+            assert variable in preamble[-600:], variable
+
+        # A failed install restores the marker whether or not a venv replacement was ever
+        # in flight: a first install has no previous venv, and the ownership guard can
+        # refuse the directory before one starts.
+        assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_exit() {"):]
+        assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_signal() {"):]
+        assert ps1.count("Restore-StudioUvCacheMarker -StudioRoot") == 2
 
         # And the marker travels with the environment: a rolled-back install puts it back.
         assert "_restore_uv_cache_marker" in sh
         assert sh.count("_restore_uv_cache_marker") >= 2, "defined but never called"
         assert "function Restore-StudioUvCacheMarker" in ps1
-        assert (
-            ps1.count("Restore-StudioUvCacheMarker -StudioRoot") == 2
-        ), "install.ps1 restores the previous environment at two points; both carry the marker"
 
         assert "${XDG_CACHE_HOME}/uv" in sh
         assert "${HOME}/.cache/uv" in sh

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1194,8 +1194,8 @@ class TestInstallUvCacheRootParity:
         # A failed install restores the marker whether or not a venv replacement was ever
         # in flight: a first install has no previous venv, and the ownership guard can
         # refuse the directory before one starts.
-        assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_exit() {"):]
-        assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_signal() {"):]
+        assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_exit() {") :]
+        assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_signal() {") :]
         assert ps1.count("Restore-StudioUvCacheMarker -StudioRoot") == 2
 
         # And the marker travels with the environment: a rolled-back install puts it back.

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1129,6 +1129,74 @@ class TestInstallUvCacheRootParity:
             for metadata_suffix in (".msgpack", ".http", ".rev", ".lock"):
                 assert metadata_suffix in source, metadata_suffix
 
+    def test_both_installers_record_the_cache_they_chose(self):
+        """`unsloth studio update` reads this to reuse the install's cache. Content alone
+        cannot decide it: install.sh:705 points the running backend at the Studio cache
+        even in shared mode, so a runtime install leaves bytes in the losing cache."""
+        sh = INSTALL_SH.read_text(encoding = "utf-8")
+        ps1 = INSTALL_PS1.read_text(encoding = "utf-8")
+        cli = (REPO_ROOT / "unsloth_cli" / "commands" / "studio.py").read_text(encoding = "utf-8")
+
+        for source in (sh, ps1, cli):
+            assert "uv-cache-dir" in source
+
+        # Written after the choice is made, and never for a caller's own UV_CACHE_DIR:
+        # that is one run's business, not a property of the install.
+        assert "_record_uv_cache_choice() {" in sh
+        # Every mode records, custom included: a marker left over from a previous install
+        # would aim later updates at a cache this one never filled.
+        call_sites = [
+            match.start()
+            for match in re.finditer(r"^[ \t]+_record_uv_cache_choice[ \t]*$", sh, re.MULTILINE)
+        ]
+        assert len(call_sites) == 3, f"one call site per mode branch, found {len(call_sites)}"
+        assert (
+            sh.index("_UV_CACHE_MODE=custom")
+            < min(call_sites)
+            < sh.index("_UV_CACHE_MODE=isolated")
+        ), "the custom branch records before it returns"
+        assert ps1.count("Write-StudioUvCacheMarker -StudioRoot") == 2
+        # A marker is a preference, not a requirement, so neither installer may fail on it.
+        marker_write = ps1[
+            ps1.index("function Write-StudioUvCacheMarker") : ps1.index(
+                "function Set-StudioUvCacheEnvironment"
+            )
+        ]
+        # Covers both marker functions, which sit together above the selector.
+        assert "-ErrorAction Stop" not in marker_write
+        assert marker_write.count("-ErrorAction SilentlyContinue") >= 2
+        assert "|| true" in sh[sh.index("_record_uv_cache_choice() {") :]
+        # Windows PowerShell 5.1 writes -Encoding utf8 WITH a BOM, so the reader allows one.
+        assert "utf-8-sig" in cli
+
+        # Absolute on both sides: the update resolves the marker against its own working
+        # directory, and uv answers a relative cache-dir with the relative spelling.
+        assert 'case "$UV_CACHE_DIR" in' in sh
+        assert "IsPathRooted" in ps1
+
+        # Under `irm | iex` the script scope is the caller's session, so the snapshot has
+        # to be reset per run beside the rollback state it belongs to. A second install in
+        # one session would otherwise roll back to the marker it saw before the first.
+        reset_block = ps1[
+            ps1.index("$script:StudioVenvRollbackPartial = $false") : ps1.index(
+                "# Reset per run: under `irm | iex`"
+            )
+        ]
+        for variable in (
+            "$script:StudioUvMarkerSaved = $false",
+            "$script:StudioUvMarkerExisted = $false",
+            "$script:StudioUvMarkerPrevious = $null",
+        ):
+            assert variable in reset_block, variable
+
+        # And the marker travels with the environment: a rolled-back install puts it back.
+        assert "_restore_uv_cache_marker" in sh
+        assert sh.count("_restore_uv_cache_marker") >= 2, "defined but never called"
+        assert "function Restore-StudioUvCacheMarker" in ps1
+        assert (
+            ps1.count("Restore-StudioUvCacheMarker -StudioRoot") == 2
+        ), "install.ps1 restores the previous environment at two points; both carry the marker"
+
         assert "${XDG_CACHE_HOME}/uv" in sh
         assert "${HOME}/.cache/uv" in sh
         assert 'Join-Path (Join-Path $env:LOCALAPPDATA "uv") "cache"' in ps1

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1201,7 +1201,15 @@ class TestInstallUvCacheRootParity:
         ]
         commit_start = sh.index("_commit_studio_venv_replacement() {")
         commit_body = sh[commit_start : sh.index("\n}", commit_start)]
-        assert "_UV_MARKER_SAVED=false" in commit_body
+        # Before the venv flag, not merely inside the function: a signal landing between
+        # the two would keep the committed environment and revert the marker it came with.
+        assert commit_body.index("_UV_MARKER_SAVED=false") < commit_body.index(
+            "_VENV_ROLLBACK_ACTIVE=false"
+        )
+        ps1_commit = ps1[ps1.index("function Complete-StudioVenvRollback") :][:900]
+        assert ps1_commit.index("$script:StudioUvMarkerSaved = $false") < ps1_commit.index(
+            "$script:StudioVenvRollbackActive = $false"
+        )
 
         # A failed install restores the marker whether or not a venv replacement was ever
         # in flight: a first install has no previous venv, and the ownership guard can

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -36,6 +36,16 @@ def _fallback_range(lines):
     raise AssertionError("install.sh's GPU-detection fallback branch is never closed")
 
 
+def _all_indexes(haystack, needle):
+    """Every occurrence, so an assertion about "each write" cannot pass on the first one."""
+    found, at = [], haystack.find(needle)
+    while at != -1:
+        found.append(at)
+        at = haystack.find(needle, at + 1)
+    assert found, needle
+    return found
+
+
 class TestNoTorchBackendAutoInInstallSh:
     """install.sh primary paths must not use --torch-backend=auto (only the fallback else-branch may)."""
 
@@ -1215,6 +1225,38 @@ class TestInstallUvCacheRootParity:
         assert ps1_commit.index("$script:StudioUvMarkerSaved = $false") < ps1_commit.index(
             "$script:StudioVenvRollbackActive = $false"
         )
+        # And outside the rollback branch on both sides. A first install has no previous
+        # environment, so the branch is skipped and the marker would stay revertible under
+        # an environment that stays installed.
+        assert commit_body.index("_UV_MARKER_SAVED=false") < commit_body.index(
+            'if [ "$_VENV_ROLLBACK_ACTIVE" = true ]'
+        )
+        assert ps1_commit.index("$script:StudioUvMarkerSaved = $false") < ps1_commit.index(
+            "if (-not $script:StudioVenvRollbackActive) { return }"
+        )
+
+        # Both marker writes are gated on the old entry actually being gone. The unlink is
+        # what keeps a symlinked marker from truncating what it points at, and it can fail
+        # silently: the directory may deny deletion while the target stays writable.
+        for body in (
+            sh[sh.index("_record_uv_cache_choice() {") : sh.index("_restore_uv_cache_marker() {")],
+            sh[sh.index("_restore_uv_cache_marker() {") :][:600],
+        ):
+            unlink = body.index('rm -f "$_uv_marker_file"')
+            write = body.index("printf '%s\\n'", unlink)
+            assert '[ -L "$_uv_marker_file" ]' in body[unlink:write], body[unlink:write]
+        ps1_marker = ps1[
+            ps1.index("function Write-StudioUvCacheMarker") : ps1.index(
+                "function Set-StudioUvCacheEnvironment"
+            )
+        ]
+        for start in _all_indexes(ps1_marker, "Remove-Item -LiteralPath $markerFile"):
+            # The call form, not the bare name: the comment above the gate names the
+            # cmdlet, and a window ending there would exclude the gate it is about.
+            window = ps1_marker[
+                start : ps1_marker.index("Set-Content -LiteralPath $markerFile", start)
+            ]
+            assert "Get-Item -LiteralPath $markerFile -Force" in window, window
 
         # A failed install restores the marker whether or not a venv replacement was ever
         # in flight: a first install has no previous venv, and the ownership guard can

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1140,9 +1140,9 @@ class TestInstallUvCacheRootParity:
                 assert metadata_suffix in source, metadata_suffix
 
     def test_both_installers_record_the_cache_they_chose(self):
-        """`unsloth studio update` reads this to reuse the install's cache. Content alone
-        cannot decide it: install.sh:705 points the running backend at the Studio cache
-        even in shared mode, so a runtime install leaves bytes in the losing cache."""
+        """`unsloth studio update` reads this to reuse the install's cache. Content
+        cannot decide it: install.sh:705 points the backend at the Studio cache even in
+        shared mode, so a runtime install leaves bytes in the losing one."""
         sh = INSTALL_SH.read_text(encoding = "utf-8")
         ps1 = INSTALL_PS1.read_text(encoding = "utf-8")
         cli = (REPO_ROOT / "unsloth_cli" / "commands" / "studio.py").read_text(encoding = "utf-8")
@@ -1150,11 +1150,9 @@ class TestInstallUvCacheRootParity:
         for source in (sh, ps1, cli):
             assert "uv-cache-dir" in source
 
-        # Written after the choice is made, and never for a caller's own UV_CACHE_DIR:
-        # that is one run's business, not a property of the install.
+        # Written after the choice is made.
         assert "_record_uv_cache_choice() {" in sh
-        # Every mode records, custom included: a marker left over from a previous install
-        # would aim later updates at a cache this one never filled.
+        # Every mode records, custom included, or a previous install's marker survives.
         call_sites = [
             match.start()
             for match in re.finditer(r"^[ \t]+_record_uv_cache_choice[ \t]*$", sh, re.MULTILINE)
@@ -1179,17 +1177,14 @@ class TestInstallUvCacheRootParity:
         # Windows PowerShell 5.1 writes -Encoding utf8 WITH a BOM, so the reader allows one.
         assert "utf-8-sig" in cli
 
-        # Absolute on both sides: the update resolves the marker against its own working
-        # directory, and uv answers a relative cache-dir with the relative spelling.
+        # Absolute on both sides: the update resolves it against its own directory.
         assert 'case "$UV_CACHE_DIR" in' in sh
         assert "IsPathRooted" in ps1
 
-        # The reset must precede everything that can consume the snapshot: the selector
-        # that writes the marker, and every Exit-InstallFailure that restores it. Under
-        # `irm | iex` the script scope is the caller's session and nothing clears the flag
-        # on success, so a second install failing early would otherwise revert the marker
-        # belonging to the first, which succeeded. Entry of Install-UnslothStudio is the
-        # only place that is ahead of both.
+        # The reset must precede both consumers of the snapshot, the selector that writes
+        # the marker and every Exit-InstallFailure that restores it. Under `irm | iex` the
+        # script scope is the caller's session, so a second install failing early would
+        # otherwise revert the first one's marker. Only the entry point is ahead of both.
         entry = ps1.index("function Install-UnslothStudio {")
         # The call form, not the bare name, which also appears in prose above.
         first_consumer = min(
@@ -1203,8 +1198,7 @@ class TestInstallUvCacheRootParity:
         ):
             assert variable in ps1[entry:first_consumer], variable
 
-        # Committing the environment commits the marker that came with it, so a failure
-        # after the commit does not revert it.
+        # Committing the environment commits the marker that came with it.
         assert (
             "$script:StudioUvMarkerSaved = $false"
             in ps1[
@@ -1216,8 +1210,8 @@ class TestInstallUvCacheRootParity:
         )
         commit_start = sh.index("_commit_studio_venv_replacement() {")
         commit_body = sh[commit_start : sh.index("\n}", commit_start)]
-        # Before the venv flag, not merely inside the function: a signal landing between
-        # the two would keep the committed environment and revert the marker it came with.
+        # Before the venv flag: a signal between the two keeps the environment and
+        # reverts its marker.
         assert commit_body.index("_UV_MARKER_SAVED=false") < commit_body.index(
             "_VENV_ROLLBACK_ACTIVE=false"
         )
@@ -1225,9 +1219,7 @@ class TestInstallUvCacheRootParity:
         assert ps1_commit.index("$script:StudioUvMarkerSaved = $false") < ps1_commit.index(
             "$script:StudioVenvRollbackActive = $false"
         )
-        # And outside the rollback branch on both sides. A first install has no previous
-        # environment, so the branch is skipped and the marker would stay revertible under
-        # an environment that stays installed.
+        # And outside the rollback branch, which a first install skips entirely.
         assert commit_body.index("_UV_MARKER_SAVED=false") < commit_body.index(
             'if [ "$_VENV_ROLLBACK_ACTIVE" = true ]'
         )
@@ -1235,9 +1227,8 @@ class TestInstallUvCacheRootParity:
             "if (-not $script:StudioVenvRollbackActive) { return }"
         )
 
-        # Both marker writes are gated on the old entry actually being gone. The unlink is
-        # what keeps a symlinked marker from truncating what it points at, and it can fail
-        # silently: the directory may deny deletion while the target stays writable.
+        # Both writes are gated on the old entry being gone: the unlink is what keeps a
+        # symlinked marker from truncating its target, and it can fail silently.
         for body in (
             sh[sh.index("_record_uv_cache_choice() {") : sh.index("_restore_uv_cache_marker() {")],
             sh[sh.index("_restore_uv_cache_marker() {") :][:600],
@@ -1251,16 +1242,13 @@ class TestInstallUvCacheRootParity:
             )
         ]
         for start in _all_indexes(ps1_marker, "Remove-Item -LiteralPath $markerFile"):
-            # The call form, not the bare name: the comment above the gate names the
-            # cmdlet, and a window ending there would exclude the gate it is about.
+            # The call form: the comment above the gate names the cmdlet too.
             window = ps1_marker[
                 start : ps1_marker.index("Set-Content -LiteralPath $markerFile", start)
             ]
             assert "Get-Item -LiteralPath $markerFile -Force" in window, window
 
-        # A failed install restores the marker whether or not a venv replacement was ever
-        # in flight: a first install has no previous venv, and the ownership guard can
-        # refuse the directory before one starts.
+        # Restored whether or not a venv replacement was ever in flight.
         assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_exit() {") :]
         assert "_restore_uv_cache_marker" in sh[sh.index("_on_install_signal() {") :]
         assert ps1.count("Restore-StudioUvCacheMarker -StudioRoot") == 2

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1174,22 +1174,34 @@ class TestInstallUvCacheRootParity:
         assert 'case "$UV_CACHE_DIR" in' in sh
         assert "IsPathRooted" in ps1
 
-        # The reset must precede the call that writes the marker. Resetting after it
-        # discards the snapshot Write-StudioUvCacheMarker had just taken, which makes
-        # every Restore-StudioUvCacheMarker a no-op and leaves a failed reinstall's
-        # marker in place. Per run because under `irm | iex` the script scope is the
-        # caller's session.
-        selector_call = ps1.index("Set-StudioUvCacheEnvironment -StudioRoot $StudioHome")
-        # The whole triple, in the run of lines directly above the call. Searching the
-        # file instead would match the copy inside Restore-StudioUvCacheMarker and pass
-        # even with the reset moved back below the call.
-        preamble = ps1[:selector_call]
+        # The reset must precede everything that can consume the snapshot: the selector
+        # that writes the marker, and every Exit-InstallFailure that restores it. Under
+        # `irm | iex` the script scope is the caller's session and nothing clears the flag
+        # on success, so a second install failing early would otherwise revert the marker
+        # belonging to the first, which succeeded. Entry of Install-UnslothStudio is the
+        # only place that is ahead of both.
+        entry = ps1.index("function Install-UnslothStudio {")
+        # The call form, not the bare name, which also appears in prose above.
+        first_consumer = min(
+            ps1.index("Set-StudioUvCacheEnvironment -StudioRoot $StudioHome"),
+            ps1.index('(Exit-InstallFailure "', entry),
+        )
         for variable in (
             "$script:StudioUvMarkerSaved = $false",
             "$script:StudioUvMarkerExisted = $false",
             "$script:StudioUvMarkerPrevious = $null",
         ):
-            assert variable in preamble[-600:], variable
+            assert variable in ps1[entry:first_consumer], variable
+
+        # Committing the environment commits the marker that came with it, so a failure
+        # after the commit does not revert it.
+        assert "$script:StudioUvMarkerSaved = $false" in ps1[
+            ps1.index("function Complete-StudioVenvRollback") :
+            ps1.index("function Complete-StudioVenvRollback") + 900
+        ]
+        commit_start = sh.index("_commit_studio_venv_replacement() {")
+        commit_body = sh[commit_start : sh.index("\n}", commit_start)]
+        assert "_UV_MARKER_SAVED=false" in commit_body
 
         # A failed install restores the marker whether or not a venv replacement was ever
         # in flight: a first install has no previous venv, and the ownership guard can

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -1195,10 +1195,15 @@ class TestInstallUvCacheRootParity:
 
         # Committing the environment commits the marker that came with it, so a failure
         # after the commit does not revert it.
-        assert "$script:StudioUvMarkerSaved = $false" in ps1[
-            ps1.index("function Complete-StudioVenvRollback") :
-            ps1.index("function Complete-StudioVenvRollback") + 900
-        ]
+        assert (
+            "$script:StudioUvMarkerSaved = $false"
+            in ps1[
+                ps1.index("function Complete-StudioVenvRollback") : ps1.index(
+                    "function Complete-StudioVenvRollback"
+                )
+                + 900
+            ]
+        )
         commit_start = sh.index("_commit_studio_venv_replacement() {")
         commit_body = sh[commit_start : sh.index("\n}", commit_start)]
         assert "_UV_MARKER_SAVED=false" in commit_body

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -886,3 +886,40 @@ Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache "relcache"
     assert os.path.normcase(os.path.normpath(recorded)) == os.path.normcase(
         os.path.normpath(str(tmp_path / "relcache"))
     ), recorded
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+def test_an_unreadable_cache_directory_does_not_abort_the_install(tmp_path: Path, shell: str):
+    """The marker is optional; probing for it must not be able to fail the install.
+
+    install.ps1 runs under $ErrorActionPreference = "Stop", and Test-Path on a path inside
+    a directory the ACL denies throws UnauthorizedAccessException rather than returning
+    $false, so an unsuppressed probe took the whole install down.
+    """
+    if os.name == "nt" or os.geteuid() == 0:
+        pytest.skip("POSIX mode bits do not deny this caller")
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    functions = _extract(r"    function Write-StudioUvCacheMarker \{.*?\n    \}\n", source)
+    studio_root = tmp_path / "studio root"
+    (studio_root / "cache").mkdir(parents = True)
+    (studio_root / "cache").chmod(0o000)
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+{functions}
+$script:StudioUvMarkerSaved = $false
+try {{
+    Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache $env:TEST_CACHE
+    "survived"
+}} catch {{
+    "THREW: " + $_.Exception.GetType().Name
+}}
+"""
+    env = os.environ.copy()
+    env["TEST_STUDIO_HOME"] = str(studio_root)
+    env["TEST_CACHE"] = str(tmp_path / "chosen")
+    try:
+        assert _run_powershell(shell, script, env).splitlines()[-1] == "survived"
+    finally:
+        (studio_root / "cache").chmod(0o755)

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -67,6 +67,7 @@ def _uv_cache_functions(source: str) -> str:
     return "".join(
         _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
         for name in (
+            "Write-StudioUvCacheMarker",
             "Set-StudioUvCacheEnvironment",
             "Set-StudioUvCacheForLaunch",
             "Restore-StudioUvCacheEnvironment",
@@ -238,6 +239,7 @@ def test_restoring_a_split_move_never_deletes_the_half_left_behind(tmp_path: Pat
             "Remove-StudioVenvTreeWithRetry",
             "Merge-StudioVenvRollbackTree",
             "Restore-StudioVenvRollback",
+            "Restore-StudioUvCacheMarker",
         )
     )
     target = tmp_path / "unsloth_studio"
@@ -293,6 +295,7 @@ def test_merging_a_split_move_keeps_every_sibling_at_its_own_path(tmp_path: Path
             "Remove-StudioVenvTreeWithRetry",
             "Merge-StudioVenvRollbackTree",
             "Restore-StudioVenvRollback",
+            "Restore-StudioUvCacheMarker",
         )
     )
     target = tmp_path / "unsloth_studio"
@@ -360,6 +363,7 @@ def test_merging_a_split_move_never_walks_through_a_link(tmp_path: Path, shell: 
             "Remove-StudioVenvTreeWithRetry",
             "Merge-StudioVenvRollbackTree",
             "Restore-StudioVenvRollback",
+            "Restore-StudioUvCacheMarker",
         )
     )
     target = tmp_path / "unsloth_studio"
@@ -685,6 +689,15 @@ try {{
         ) == "keep"
         assert (shared / ".gitignore").read_text(encoding = "utf-8") == "*\n"
 
+    # The marker `unsloth studio update` reads back, so it reuses the cache this install
+    # used instead of re-deriving it from content that a runtime install can change.
+    # utf-8-sig because Windows PowerShell 5.1 writes -Encoding utf8 with a BOM.
+    # Every mode records, custom included: a marker left by a previous install would aim
+    # later updates at a cache this one never filled.
+    marker = studio_root / "cache" / "uv-cache-dir"
+    recorded = marker.read_text(encoding = "utf-8-sig").strip()
+    assert norm(recorded) == norm(str(expected_selected)), case
+
 
 @pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
 @pytest.mark.parametrize("shell", POWERSHELLS)
@@ -793,3 +806,83 @@ foreach ($root in @($env:TEST_STUDIO_HOME_ONE, $env:TEST_STUDIO_HOME_TWO)) {{
     assert result["Modes"] == ["studio", "studio"]
     assert result["PresentAfter"] is False
     assert result["ProviderPresentAfter"] is False
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+@pytest.mark.parametrize("preexisting", [True, False])
+def test_a_rolled_back_install_restores_the_previous_uv_cache_marker(
+    tmp_path: Path, shell: str, preexisting: bool
+):
+    """The marker describes the environment, so it goes back when the environment does.
+
+    install.ps1 restores the previous venv on failure; a marker naming the cache of an
+    install that never happened would outlive the environment it was chosen for.
+    """
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    functions = "".join(
+        _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
+        for name in ("Write-StudioUvCacheMarker", "Restore-StudioUvCacheMarker")
+    )
+    studio_root = tmp_path / "studio root"
+    marker = studio_root / "cache" / "uv-cache-dir"
+    previous = tmp_path / "previous cache"
+    chosen = tmp_path / "chosen cache"
+    if preexisting:
+        marker.parent.mkdir(parents = True)
+        marker.write_text(f"{previous}\n", encoding = "utf-8")
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+{functions}
+$script:StudioUvMarkerSaved = $false
+$script:StudioUvMarkerExisted = $false
+$script:StudioUvMarkerPrevious = $null
+Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache $env:TEST_CHOSEN
+$during = Get-Content -LiteralPath $env:TEST_MARKER -Raw
+Restore-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME
+$after = if (Test-Path -LiteralPath $env:TEST_MARKER) {{
+    (Get-Content -LiteralPath $env:TEST_MARKER -Raw).Trim()
+}} else {{ "<gone>" }}
+[pscustomobject]@{{ During = $during.Trim(); After = $after }} | ConvertTo-Json -Compress
+"""
+    env = os.environ.copy()
+    env["TEST_STUDIO_HOME"] = str(studio_root)
+    env["TEST_CHOSEN"] = str(chosen)
+    env["TEST_MARKER"] = str(marker)
+    result = json.loads(_run_powershell(shell, script, env).splitlines()[-1])
+
+    norm = lambda value: os.path.normcase(os.path.normpath(value))
+    assert norm(result["During"]) == norm(str(chosen))
+    assert result["After"] == ("<gone>" if not preexisting else result["After"])
+    if preexisting:
+        assert norm(result["After"]) == norm(str(previous))
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+def test_a_relative_cache_is_recorded_absolute(tmp_path: Path, shell: str):
+    """`uv cache dir` answers a relative cache-dir with the relative spelling, and the
+    update resolves the marker against ITS working directory, not the installer's."""
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    functions = _extract(r"    function Write-StudioUvCacheMarker \{.*?\n    \}\n", source)
+    studio_root = tmp_path / "studio root"
+    marker = studio_root / "cache" / "uv-cache-dir"
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+{functions}
+$script:StudioUvMarkerSaved = $false
+Set-Location -LiteralPath $env:TEST_CWD
+Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache "relcache"
+(Get-Content -LiteralPath $env:TEST_MARKER -Raw).Trim()
+"""
+    env = os.environ.copy()
+    env["TEST_STUDIO_HOME"] = str(studio_root)
+    env["TEST_MARKER"] = str(marker)
+    env["TEST_CWD"] = str(tmp_path)
+    recorded = _run_powershell(shell, script, env).splitlines()[-1]
+
+    assert os.path.normcase(os.path.normpath(recorded)) == os.path.normcase(
+        os.path.normpath(str(tmp_path / "relcache"))
+    ), recorded

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -814,11 +814,9 @@ foreach ($root in @($env:TEST_STUDIO_HOME_ONE, $env:TEST_STUDIO_HOME_TWO)) {{
 def test_a_rolled_back_install_restores_the_previous_uv_cache_marker(
     tmp_path: Path, shell: str, preexisting: bool
 ):
-    """The marker describes the environment, so it goes back when the environment does.
-
-    install.ps1 restores the previous venv on failure; a marker naming the cache of an
-    install that never happened would outlive the environment it was chosen for.
-    """
+    """The marker describes the environment, so it goes back when the environment does:
+    install.ps1 restores the previous venv on failure, and a marker for an install that
+    never happened would outlive it."""
     source = INSTALL_PS1.read_text(encoding = "utf-8")
     functions = "".join(
         _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
@@ -891,12 +889,9 @@ Write-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME -Cache "relcache"
 @pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
 @pytest.mark.parametrize("shell", POWERSHELLS)
 def test_an_unreadable_cache_directory_does_not_abort_the_install(tmp_path: Path, shell: str):
-    """The marker is optional; probing for it must not be able to fail the install.
-
-    install.ps1 runs under $ErrorActionPreference = "Stop", and Test-Path on a path inside
-    a directory the ACL denies throws UnauthorizedAccessException rather than returning
-    $false, so an unsuppressed probe took the whole install down.
-    """
+    """The marker is optional, so probing for it must not fail the install: under
+    $ErrorActionPreference = "Stop", Test-Path inside an ACL-denied directory throws
+    UnauthorizedAccessException rather than returning $false."""
     if os.name == "nt" or os.geteuid() == 0:
         pytest.skip("POSIX mode bits do not deny this caller")
     source = INSTALL_PS1.read_text(encoding = "utf-8")

--- a/tests/sh/test_install_rollback_lifecycle.sh
+++ b/tests/sh/test_install_rollback_lifecycle.sh
@@ -14,6 +14,20 @@ ok()  { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 bad() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 
 ROLLBACK_BLOCK=$(sed -n '/^_VENV_ROLLBACK_DIR=""/,/^trap '\''_on_install_signal 143'\'' TERM$/p' "$INSTALL_SH")
+# _restore_studio_venv_replacement calls this, and it is defined above the block, with the
+# rest of the uv cache selector. Splicing the block without it makes every signal case exit
+# 127 on a command that is present in the real installer.
+# printf, not $'\n': the workflow runs this file with `sh`, whatever the shebang says.
+MARKER_HELPER=$(awk '
+    /^_restore_uv_cache_marker\(\) \{/ { grab = 1 }
+    grab { print }
+    grab && /^}/ { grab = 0 }
+' "$INSTALL_SH")
+if ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_restore_uv_cache_marker() {'; then
+    echo "  FAIL: could not extract _restore_uv_cache_marker from install.sh"
+    exit 1
+fi
+ROLLBACK_BLOCK=$(printf '%s\n%s\n' "$MARKER_HELPER" "$ROLLBACK_BLOCK")
 if ! printf '%s\n' "$ROLLBACK_BLOCK" | grep -q '^_on_install_signal() {'; then
     echo "  FAIL: could not extract rollback lifecycle block from install.sh"
     exit 1

--- a/tests/sh/test_install_rollback_lifecycle.sh
+++ b/tests/sh/test_install_rollback_lifecycle.sh
@@ -407,6 +407,41 @@ else
     bad "Windows rollback deletion still hides failures"
 fi
 
+# A failed install restores the marker even when no venv replacement was ever in flight:
+# a first install has no previous venv, and the ownership guard can refuse the directory
+# before one starts. The marker must not outlive the attempt that wrote it.
+marker_case() {  # label, pre-existing marker value or empty, expect
+    _label="$1"; _pre="$2"; _expect="$3"
+    _dir="$WORK/marker-$_label"
+    mkdir -p "$_dir/cache"
+    [ -n "$_pre" ] && printf '%s\n' "$_pre" > "$_dir/cache/uv-cache-dir"
+    _h="$_dir/harness.sh"
+    {
+        printf '%s\n' 'set -e'
+        printf '%s\n' 'substep() { :; }'
+        printf '%s\n' 'rollback_substep() { substep "$@"; }'
+        printf '%s\n' 'C_WARN=""'
+        printf "STUDIO_HOME='%s'\n" "$_dir"
+        printf "VENV_DIR='%s/unsloth_studio'\n" "$_dir"
+        printf '%s\n' "$ROLLBACK_BLOCK"
+        printf '%s\n' 'UV_CACHE_DIR="/tmp/this-attempt-cache"'
+        printf '%s\n' '_record_uv_cache_choice'
+        printf '%s\n' 'exit 1'
+    } > "$_h"
+    ( cd "$_dir" && sh "$_h" >/dev/null 2>&1 ) || true
+    if [ -f "$_dir/cache/uv-cache-dir" ]; then _got=$(cat "$_dir/cache/uv-cache-dir"); else _got="<gone>"; fi
+    if [ "$_got" = "$_expect" ]; then
+        ok "$_label"
+    else
+        bad "$_label (expected [$_expect], got [$_got])"
+    fi
+}
+
+echo "=== uv cache marker survives only a successful install ==="
+marker_case "a failed install with no venv replacement restores the previous marker" \
+    "/previous/install/cache" "/previous/install/cache"
+marker_case "a failed first install leaves no marker behind" "" "<gone>"
+
 echo ""
 echo "  PASS: $PASS"
 echo "  FAIL: $FAIL"

--- a/tests/sh/test_install_rollback_lifecycle.sh
+++ b/tests/sh/test_install_rollback_lifecycle.sh
@@ -14,13 +14,10 @@ ok()  { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 bad() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 
 ROLLBACK_BLOCK=$(sed -n '/^_VENV_ROLLBACK_DIR=""/,/^trap '\''_on_install_signal 143'\'' TERM$/p' "$INSTALL_SH")
-# _restore_studio_venv_replacement calls this, and it is defined above the block, with the
-# rest of the uv cache selector. Splicing the block without it makes every signal case exit
-# 127 on a command that is present in the real installer.
+# Both are defined above the block, with the rest of the cache selector, and both are
+# called from it. Splicing without them makes the cases exit 127 on a command the real
+# installer has, which satisfies any expectation about a marker that must not change.
 # printf, not $'\n': the workflow runs this file with `sh`, whatever the shebang says.
-# _record_uv_cache_choice comes along for the same reason: the marker cases below call it,
-# and without it they exit 127 before writing anything, which every expectation about a
-# marker that must not change would then satisfy vacuously.
 MARKER_HELPER=$(awk '
     /^(_restore_uv_cache_marker|_record_uv_cache_choice)\(\) \{/ { grab = 1 }
     grab { print }
@@ -411,9 +408,8 @@ else
     bad "Windows rollback deletion still hides failures"
 fi
 
-# A failed install restores the marker even when no venv replacement was ever in flight:
-# a first install has no previous venv, and the ownership guard can refuse the directory
-# before one starts. The marker must not outlive the attempt that wrote it.
+# The marker must not outlive the attempt that wrote it, even when no venv replacement
+# was ever in flight: a first install has none, and the ownership guard can refuse early.
 marker_case() {  # label, pre-existing marker value or empty, expect, [commit]
     _label="$1"; _pre="$2"; _expect="$3"; _commit="${4:-}"
     _dir="$WORK/marker-$_label"
@@ -450,10 +446,8 @@ echo "=== uv cache marker survives only a successful install ==="
 marker_case "a failed install with no venv replacement restores the previous marker" \
     "/previous/install/cache" "/previous/install/cache"
 marker_case "a failed first install leaves no marker behind" "" "<gone>"
-# A first install has no previous environment, so the commit takes no rollback branch. It
-# must still commit the marker: what follows the commit can fail, and the environment it
-# installed stays, so reverting the marker aims that environment's next offline update at
-# a cache it never filled.
+# A first install takes no rollback branch and must still commit the marker: what follows
+# can fail, and the environment it installed stays.
 marker_case "a committed first install keeps its marker when a later step fails" \
     "/previous/install/cache" "/tmp/this-attempt-cache" commit
 

--- a/tests/sh/test_install_rollback_lifecycle.sh
+++ b/tests/sh/test_install_rollback_lifecycle.sh
@@ -18,13 +18,17 @@ ROLLBACK_BLOCK=$(sed -n '/^_VENV_ROLLBACK_DIR=""/,/^trap '\''_on_install_signal 
 # rest of the uv cache selector. Splicing the block without it makes every signal case exit
 # 127 on a command that is present in the real installer.
 # printf, not $'\n': the workflow runs this file with `sh`, whatever the shebang says.
+# _record_uv_cache_choice comes along for the same reason: the marker cases below call it,
+# and without it they exit 127 before writing anything, which every expectation about a
+# marker that must not change would then satisfy vacuously.
 MARKER_HELPER=$(awk '
-    /^_restore_uv_cache_marker\(\) \{/ { grab = 1 }
+    /^(_restore_uv_cache_marker|_record_uv_cache_choice)\(\) \{/ { grab = 1 }
     grab { print }
     grab && /^}/ { grab = 0 }
 ' "$INSTALL_SH")
-if ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_restore_uv_cache_marker() {'; then
-    echo "  FAIL: could not extract _restore_uv_cache_marker from install.sh"
+if ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_restore_uv_cache_marker() {' \
+   || ! printf '%s\n' "$MARKER_HELPER" | grep -q '^_record_uv_cache_choice() {'; then
+    echo "  FAIL: could not extract the uv cache marker helpers from install.sh"
     exit 1
 fi
 ROLLBACK_BLOCK=$(printf '%s\n%s\n' "$MARKER_HELPER" "$ROLLBACK_BLOCK")
@@ -410,8 +414,8 @@ fi
 # A failed install restores the marker even when no venv replacement was ever in flight:
 # a first install has no previous venv, and the ownership guard can refuse the directory
 # before one starts. The marker must not outlive the attempt that wrote it.
-marker_case() {  # label, pre-existing marker value or empty, expect
-    _label="$1"; _pre="$2"; _expect="$3"
+marker_case() {  # label, pre-existing marker value or empty, expect, [commit]
+    _label="$1"; _pre="$2"; _expect="$3"; _commit="${4:-}"
     _dir="$WORK/marker-$_label"
     mkdir -p "$_dir/cache"
     [ -n "$_pre" ] && printf '%s\n' "$_pre" > "$_dir/cache/uv-cache-dir"
@@ -426,9 +430,14 @@ marker_case() {  # label, pre-existing marker value or empty, expect
         printf '%s\n' "$ROLLBACK_BLOCK"
         printf '%s\n' 'UV_CACHE_DIR="/tmp/this-attempt-cache"'
         printf '%s\n' '_record_uv_cache_choice'
+        [ -n "$_commit" ] && printf '%s\n' '_commit_studio_venv_replacement'
         printf '%s\n' 'exit 1'
     } > "$_h"
-    ( cd "$_dir" && sh "$_h" >/dev/null 2>&1 ) || true
+    ( cd "$_dir" && sh "$_h" >/dev/null 2>"$_dir/err" ) || _rc=$?
+    if [ "${_rc:-0}" = 127 ] || [ -s "$_dir/err" ]; then
+        bad "$_label (harness did not run: $(cat "$_dir/err"))"
+        return 0
+    fi
     if [ -f "$_dir/cache/uv-cache-dir" ]; then _got=$(cat "$_dir/cache/uv-cache-dir"); else _got="<gone>"; fi
     if [ "$_got" = "$_expect" ]; then
         ok "$_label"
@@ -441,6 +450,12 @@ echo "=== uv cache marker survives only a successful install ==="
 marker_case "a failed install with no venv replacement restores the previous marker" \
     "/previous/install/cache" "/previous/install/cache"
 marker_case "a failed first install leaves no marker behind" "" "<gone>"
+# A first install has no previous environment, so the commit takes no rollback branch. It
+# must still commit the marker: what follows the commit can fail, and the environment it
+# installed stays, so reverting the marker aims that environment's next offline update at
+# a cache it never filled.
+marker_case "a committed first install keeps its marker when a later step fails" \
+    "/previous/install/cache" "/tmp/this-attempt-cache" commit
 
 echo ""
 echo "  PASS: $PASS"

--- a/tests/sh/test_install_uv_cache_root.sh
+++ b/tests/sh/test_install_uv_cache_root.sh
@@ -16,10 +16,13 @@ bad() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 HELPERS=$(awk '
     /^_configure_uv_cache\(\) \{/ { grab = 1 }
     /^_prepare_studio_uv_cache_for_launch\(\) \{/ { grab = 1 }
+    /^_record_uv_cache_choice\(\) \{/ { grab = 1 }
+    /^_restore_uv_cache_marker\(\) \{/ { grab = 1 }
     grab { print }
     grab && /^}/ { grab = 0 }
 ' "$INSTALL_SH")
-for _helper in _configure_uv_cache _prepare_studio_uv_cache_for_launch; do
+for _helper in _configure_uv_cache _prepare_studio_uv_cache_for_launch _record_uv_cache_choice \
+    _restore_uv_cache_marker; do
     if ! printf '%s\n' "$HELPERS" | grep -q "^${_helper}() {"; then
         echo "  FAIL: could not extract $_helper from install.sh"
         exit 1
@@ -244,6 +247,116 @@ for shell in sh bash; do
             "reusing existing shared cache ($DEEP_CACHE) to avoid duplicate Torch/CUDA downloads; use --isolated-uv-cache to isolate" \
             "$STUDIO_CACHE"
         chmod 755 "$DEEP_CACHE/archive-v0/aaa hidden" 2>/dev/null || true
+    fi
+
+    # The marker `unsloth studio update` reads. Content alone cannot tell a Studio cache
+    # the installer filled from one a runtime install dropped a single wheel into, so the
+    # choice is recorded rather than re-derived later.
+    MARKER="$ROOT/cache/uv-cache-dir"
+    check_marker() { # label, expected
+        if [ "$(cat "$MARKER" 2>/dev/null)" = "$2" ]; then
+            ok "$shell: $1"
+        else
+            bad "$shell: $1 (expected [$2], got [$(cat "$MARKER" 2>/dev/null)])"
+        fi
+    }
+
+    rm -f "$MARKER"
+    EMPTY_CACHE="$CASE/unrecorded/uv"
+    run_case "$shell" "studio mode still selects the Studio cache" unset "" false \
+        "$HOME_DIR" unset "" "$ROOT" "$EMPTY_CACHE" "$STUDIO_CACHE" studio \
+        "using new Studio-owned cache ($STUDIO_CACHE)" "$STUDIO_CACHE"
+    check_marker "studio mode records the Studio cache" "$STUDIO_CACHE"
+
+    rm -f "$MARKER"
+    run_case "$shell" "shared mode still selects the shared cache" unset "" false \
+        "$HOME_DIR" unset "" "$ROOT" "$BUILDS_CACHE" "$BUILDS_CACHE" shared \
+        "reusing existing shared cache ($BUILDS_CACHE) to avoid duplicate Torch/CUDA downloads; use --isolated-uv-cache to isolate" \
+        "$STUDIO_CACHE"
+    check_marker "shared mode records the shared cache, not the Studio one" "$BUILDS_CACHE"
+
+    rm -f "$MARKER"
+    run_case "$shell" "isolation still forces the Studio cache" unset "" true \
+        "$HOME_DIR" unset "" "$ROOT" "$BUILDS_CACHE" "$STUDIO_CACHE" isolated \
+        "forced Studio cache isolation ($STUDIO_CACHE); already-cached packages may download again" \
+        "$STUDIO_CACHE"
+    check_marker "isolated mode records the Studio cache" "$STUDIO_CACHE"
+
+    # A custom cache is where this install actually put its wheels, so it is recorded too.
+    # Leaving the previous install's marker in place would aim later updates at a cache
+    # this install never filled; the caller still wins on any run that sets the variable.
+    printf '%s\n' "$STUDIO_CACHE" > "$MARKER"
+    run_case "$shell" "custom mode is still preserved" value "$OVERRIDE" false \
+        "$HOME_DIR" unset "" "$ROOT" "$BUILDS_CACHE" "$OVERRIDE" custom \
+        "preserving custom UV_CACHE_DIR ($OVERRIDE)" "$OVERRIDE"
+    check_marker "custom mode replaces an earlier install's marker" "$OVERRIDE"
+
+    # The marker describes the environment, so a rolled-back install puts it back. The
+    # installer restores the previous venv on failure; a marker naming the cache of an
+    # install that never happened would outlive the environment it was chosen for.
+    ROLLBACK_PROBE="$WORK/$shell rollback.sh"
+    {
+        printf '%s\n' "$HELPERS"
+        cat <<ROLLBACK
+step() { :; }
+STUDIO_HOME='$ROOT'
+_UV_MARKER_SAVED=false
+_UV_MARKER_EXISTED=false
+_UV_MARKER_PREVIOUS=""
+UV_CACHE_DIR='$BUILDS_CACHE'
+_record_uv_cache_choice
+printf 'during=%s\n' "\$(cat '$MARKER')"
+_restore_uv_cache_marker
+if [ -f '$MARKER' ]; then printf 'after=%s\n' "\$(cat '$MARKER')"; else printf 'after=<gone>\n'; fi
+ROLLBACK
+    } > "$ROLLBACK_PROBE"
+
+    printf '%s\n' "$STUDIO_CACHE" > "$MARKER"
+    _rb=$($shell "$ROLLBACK_PROBE")
+    if [ "$_rb" = "$(printf 'during=%s\nafter=%s' "$BUILDS_CACHE" "$STUDIO_CACHE")" ]; then
+        ok "$shell: a rolled-back install restores the previous marker"
+    else
+        bad "$shell: rollback did not restore the marker (got [$_rb])"
+    fi
+
+    rm -f "$MARKER"
+    _rb=$($shell "$ROLLBACK_PROBE")
+    if [ "$_rb" = "$(printf 'during=%s\nafter=<gone>' "$BUILDS_CACHE")" ]; then
+        ok "$shell: a rolled-back first install leaves no marker behind"
+    else
+        bad "$shell: rollback left a marker on a first install (got [$_rb])"
+    fi
+
+    # Absolute, because the update resolves the marker against its own directory.
+    RELATIVE_PROBE="$WORK/$shell relative.sh"
+    {
+        printf '%s\n' "$HELPERS"
+        cat <<RELATIVE
+step() { :; }
+STUDIO_HOME='$ROOT'
+_UV_MARKER_SAVED=false
+cd '$CASE'
+UV_CACHE_DIR='relcache'
+_record_uv_cache_choice
+cat '$MARKER'
+RELATIVE
+    } > "$RELATIVE_PROBE"
+    rm -f "$MARKER"
+    _rel=$($shell "$RELATIVE_PROBE")
+    if [ "$_rel" = "$CASE/relcache" ]; then
+        ok "$shell: a relative cache is recorded absolute"
+    else
+        bad "$shell: relative cache recorded as [$_rel], wanted [$CASE/relcache]"
+    fi
+
+    # An unwritable STUDIO_HOME is a reason to skip the marker, never to fail the install.
+    rm -rf "$ROOT/cache"
+    if [ "$(id -u 2>/dev/null || echo 0)" != 0 ] && mkdir -p "$ROOT" && chmod 500 "$ROOT" 2>/dev/null; then
+        run_case "$shell" "an unwritable Studio root still installs" unset "" false \
+            "$HOME_DIR" unset "" "$ROOT" "$BUILDS_CACHE" "$BUILDS_CACHE" shared \
+            "reusing existing shared cache ($BUILDS_CACHE) to avoid duplicate Torch/CUDA downloads; use --isolated-uv-cache to isolate" \
+            "$STUDIO_CACHE"
+        chmod 755 "$ROOT" 2>/dev/null || true
     fi
 done
 

--- a/tests/sh/test_install_uv_cache_root.sh
+++ b/tests/sh/test_install_uv_cache_root.sh
@@ -291,6 +291,63 @@ for shell in sh bash; do
         "preserving custom UV_CACHE_DIR ($OVERRIDE)" "$OVERRIDE"
     check_marker "custom mode replaces an earlier install's marker" "$OVERRIDE"
 
+    # A marker path that is a symlink must be replaced, not followed: a redirection would
+    # truncate whatever it points at.
+    rm -rf "$ROOT/cache"; mkdir -p "$ROOT/cache"
+    VICTIM="$CASE/someone elses file"
+    printf 'do not clobber\n' > "$VICTIM"
+    ln -s "$VICTIM" "$ROOT/cache/uv-cache-dir" 2>/dev/null && {
+        run_case "$shell" "a symlinked marker is replaced, not followed" unset "" false \
+            "$HOME_DIR" unset "" "$ROOT" "$EMPTY_CACHE" "$STUDIO_CACHE" studio \
+            "using new Studio-owned cache ($STUDIO_CACHE)" "$STUDIO_CACHE"
+        if [ "$(cat "$VICTIM")" = "do not clobber" ] && [ ! -L "$ROOT/cache/uv-cache-dir" ]; then
+            ok "$shell: the symlink target was left alone"
+        else
+            bad "$shell: writing the marker followed a symlink"
+        fi
+    }
+
+    # An existing marker we cannot read is one we cannot put back, so leave it alone
+    # rather than overwrite it and restore a blank file on rollback.
+    rm -rf "$ROOT/cache"; mkdir -p "$ROOT/cache"
+    printf '%s\n' "/previous/install/cache" > "$MARKER"
+    if [ "$(id -u 2>/dev/null || echo 0)" != 0 ] && chmod 200 "$MARKER" 2>/dev/null; then
+        run_case "$shell" "an unreadable marker does not fail the install" unset "" false \
+            "$HOME_DIR" unset "" "$ROOT" "$EMPTY_CACHE" "$STUDIO_CACHE" studio \
+            "using new Studio-owned cache ($STUDIO_CACHE)" "$STUDIO_CACHE"
+        chmod 600 "$MARKER" 2>/dev/null || true
+        if [ "$(cat "$MARKER")" = "/previous/install/cache" ]; then
+            ok "$shell: an unreadable marker is left as it was"
+        else
+            bad "$shell: an unreadable marker was overwritten ([$(cat "$MARKER")])"
+        fi
+    fi
+
+    # uv resolves a relative cache against its own working directory, which --directory
+    # and UV_WORKING_DIR move; anchoring to $PWD would record a directory uv never used.
+    rm -rf "$ROOT/cache"
+    WORKDIR_PROBE="$WORK/$shell workdir.sh"
+    {
+        printf '%s\n' "$HELPERS"
+        cat <<WORKDIR
+step() { :; }
+STUDIO_HOME='$ROOT'
+_UV_MARKER_SAVED=false
+cd '$CASE'
+UV_WORKING_DIR='$CASE/uvdir'; export UV_WORKING_DIR
+UV_CACHE_DIR='relcache'
+_record_uv_cache_choice
+cat '$MARKER'
+WORKDIR
+    } > "$WORKDIR_PROBE"
+    _wd=$($shell "$WORKDIR_PROBE")
+    if [ "$_wd" = "$CASE/uvdir/relcache" ]; then
+        ok "$shell: a relative cache is recorded against uv's working directory"
+    else
+        bad "$shell: recorded [$_wd], wanted [$CASE/uvdir/relcache]"
+    fi
+
+
     # The marker describes the environment, so a rolled-back install puts it back. The
     # installer restores the previous venv on failure; a marker naming the cache of an
     # install that never happened would outlive the environment it was chosen for.

--- a/tests/sh/test_install_uv_cache_root.sh
+++ b/tests/sh/test_install_uv_cache_root.sh
@@ -249,9 +249,8 @@ for shell in sh bash; do
         chmod 755 "$DEEP_CACHE/archive-v0/aaa hidden" 2>/dev/null || true
     fi
 
-    # The marker `unsloth studio update` reads. Content alone cannot tell a Studio cache
-    # the installer filled from one a runtime install dropped a single wheel into, so the
-    # choice is recorded rather than re-derived later.
+    # The marker `unsloth studio update` reads: content cannot tell a Studio cache the
+    # installer filled from one a runtime install dropped a single wheel into.
     MARKER="$ROOT/cache/uv-cache-dir"
     check_marker() { # label, expected
         if [ "$(cat "$MARKER" 2>/dev/null)" = "$2" ]; then
@@ -282,17 +281,15 @@ for shell in sh bash; do
         "$STUDIO_CACHE"
     check_marker "isolated mode records the Studio cache" "$STUDIO_CACHE"
 
-    # A custom cache is where this install actually put its wheels, so it is recorded too.
-    # Leaving the previous install's marker in place would aim later updates at a cache
-    # this install never filled; the caller still wins on any run that sets the variable.
+    # A custom cache holds this install's wheels too, so it is recorded; the caller still
+    # wins on any run that sets the variable.
     printf '%s\n' "$STUDIO_CACHE" > "$MARKER"
     run_case "$shell" "custom mode is still preserved" value "$OVERRIDE" false \
         "$HOME_DIR" unset "" "$ROOT" "$BUILDS_CACHE" "$OVERRIDE" custom \
         "preserving custom UV_CACHE_DIR ($OVERRIDE)" "$OVERRIDE"
     check_marker "custom mode replaces an earlier install's marker" "$OVERRIDE"
 
-    # A marker path that is a symlink must be replaced, not followed: a redirection would
-    # truncate whatever it points at.
+    # A symlinked marker is replaced, not followed: a redirection truncates its target.
     rm -rf "$ROOT/cache"; mkdir -p "$ROOT/cache"
     VICTIM="$CASE/someone elses file"
     printf 'do not clobber\n' > "$VICTIM"
@@ -307,8 +304,7 @@ for shell in sh bash; do
         fi
     }
 
-    # An existing marker we cannot read is one we cannot put back, so leave it alone
-    # rather than overwrite it and restore a blank file on rollback.
+    # One we cannot read is one we cannot put back, so leave it alone.
     rm -rf "$ROOT/cache"; mkdir -p "$ROOT/cache"
     printf '%s\n' "/previous/install/cache" > "$MARKER"
     if [ "$(id -u 2>/dev/null || echo 0)" != 0 ] && chmod 200 "$MARKER" 2>/dev/null; then
@@ -324,7 +320,7 @@ for shell in sh bash; do
     fi
 
     # uv resolves a relative cache against its own working directory, which --directory
-    # and UV_WORKING_DIR move; anchoring to $PWD would record a directory uv never used.
+    # and UV_WORKING_DIR move.
     rm -rf "$ROOT/cache"
     WORKDIR_PROBE="$WORK/$shell workdir.sh"
     {
@@ -347,8 +343,7 @@ WORKDIR
         bad "$shell: recorded [$_wd], wanted [$CASE/uvdir/relcache]"
     fi
 
-    # A relative UV_WORKING_DIR is itself resolved against the directory the installer ran
-    # from, so recording "work/cache" would name somewhere else at update time.
+    # Which may itself be relative, against the directory the installer ran from.
     rm -rf "$ROOT/cache"
     REL_PROBE="$WORK/$shell relworkdir.sh"
     {
@@ -372,9 +367,7 @@ RELWD
     fi
 
 
-    # The marker describes the environment, so a rolled-back install puts it back. The
-    # installer restores the previous venv on failure; a marker naming the cache of an
-    # install that never happened would outlive the environment it was chosen for.
+    # The marker describes the environment, so a rolled-back install puts it back.
     ROLLBACK_PROBE="$WORK/$shell rollback.sh"
     {
         printf '%s\n' "$HELPERS"

--- a/tests/sh/test_install_uv_cache_root.sh
+++ b/tests/sh/test_install_uv_cache_root.sh
@@ -347,6 +347,30 @@ WORKDIR
         bad "$shell: recorded [$_wd], wanted [$CASE/uvdir/relcache]"
     fi
 
+    # A relative UV_WORKING_DIR is itself resolved against the directory the installer ran
+    # from, so recording "work/cache" would name somewhere else at update time.
+    rm -rf "$ROOT/cache"
+    REL_PROBE="$WORK/$shell relworkdir.sh"
+    {
+        printf '%s\n' "$HELPERS"
+        cat <<RELWD
+step() { :; }
+STUDIO_HOME='$ROOT'
+_UV_MARKER_SAVED=false
+cd '$CASE'
+UV_WORKING_DIR='uvdir'; export UV_WORKING_DIR
+UV_CACHE_DIR='relcache'
+_record_uv_cache_choice
+cat '$MARKER'
+RELWD
+    } > "$REL_PROBE"
+    _rw=$($shell "$REL_PROBE")
+    if [ "$_rw" = "$CASE/uvdir/relcache" ]; then
+        ok "$shell: a relative UV_WORKING_DIR is anchored before the cache is appended"
+    else
+        bad "$shell: recorded [$_rw], wanted [$CASE/uvdir/relcache]"
+    fi
+
 
     # The marker describes the environment, so a rolled-back install puts it back. The
     # installer restores the previous venv on failure; a marker naming the cache of an

--- a/tests/studio/test_install_rollback_lifecycle.ps1
+++ b/tests/studio/test_install_rollback_lifecycle.ps1
@@ -23,7 +23,8 @@ $subjectNames = @(
     "Test-StudioVenvRollbackMustBePreserved",
     "Remove-StaleStudioVenvRollbacks",
     "Restore-StudioVenvRollback",
-    "Complete-StudioVenvRollback"
+    "Complete-StudioVenvRollback",
+    "Restore-StudioUvCacheMarker"
 )
 
 $definitions = @{}

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3724,6 +3724,56 @@ def _uv_default_cache_dir() -> Optional[Path]:
     return Path(os.path.abspath(os.path.expanduser(lines[-1])))
 
 
+def _recorded_install_uv_cache() -> Optional[Path]:
+    """The cache the installer actually used, as it recorded it.
+
+    Guessing from content cannot tell a Studio cache the installer filled from one that
+    holds a single wheel some runtime install dropped there (wheel_utils.py:405), because
+    install.sh:705 points the running backend at it even in shared mode. The installers
+    know which they chose, so they write it down; absent, for installs that predate the
+    marker, the caller falls back to inspecting both caches.
+    """
+    try:
+        # utf-8-sig, not utf-8: Windows PowerShell 5.1 writes `-Encoding utf8` WITH a BOM,
+        # which utf-8 would decode into the first character of the path.
+        recorded = (STUDIO_HOME / "cache" / "uv-cache-dir").read_text(
+            encoding = "utf-8-sig", errors = "replace"
+        )
+    except OSError:
+        return None
+    lines = [line.strip() for line in recorded.splitlines() if line.strip()]
+    if not lines:
+        return None
+    return Path(os.path.abspath(os.path.expanduser(lines[-1])))
+
+
+def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
+    """Record the cache this update used, for installs whose installer never did.
+
+    Everyone installed before the marker existed reaches the content fallback, and that
+    fallback goes stale the moment the backend drops one wheel into the Studio cache:
+    both caches then look warm and the next update stops preferring the one the install
+    filled. Writing the choice down once the setup it drove has succeeded closes that,
+    and does the same for a marker whose cache has since been emptied.
+    """
+    if (os.environ.get("UV_CACHE_DIR") or "").strip():
+        # The caller's, for this run. The installers record their own choice; an update
+        # must not promote a one-shot value into one.
+        return
+    chosen = (env or {}).get("UV_CACHE_DIR")
+    if not chosen:
+        return
+    live = _recorded_install_uv_cache()
+    if live is not None and _uv_cache_has_packages(live):
+        return
+    marker = STUDIO_HOME / "cache" / "uv-cache-dir"
+    try:
+        marker.parent.mkdir(parents = True, exist_ok = True)
+        marker.write_text(f"{chosen}\n", encoding = "utf-8")
+    except OSError:
+        pass
+
+
 def _with_studio_uv_cache(env: Optional[dict]) -> Optional[dict]:
     """Point the setup script's uv at the cache the install used.
 
@@ -3734,6 +3784,11 @@ def _with_studio_uv_cache(env: Optional[dict]) -> Optional[dict]:
     if (os.environ.get("UV_CACHE_DIR") or "").strip():
         return env
     studio_cache = STUDIO_HOME / "cache" / "uv"
+    recorded = _recorded_install_uv_cache()
+    if recorded is not None and _uv_cache_has_packages(recorded):
+        # Only while it still holds something: `uv cache clean` is the user's to run, and
+        # a marker pointing at an emptied cache should not outrank a warm one.
+        return {**(env or os.environ), "UV_CACHE_DIR": str(recorded)}
     if not _uv_cache_has_packages(studio_cache):
         # A shared-mode install left the wheels in uv's own cache and _setup_cache_env
         # mkdirs this one empty on every server start, so redirecting here would send the
@@ -3820,6 +3875,8 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
 
     if returncode != 0:
         raise typer.Exit(returncode)
+    # Only now: a cache that did not get through setup is not one to point later updates at.
+    _backfill_uv_cache_marker(env)
 
 
 # The refresh re-runs the installer with --shortcuts-only, fetched rather than shipped

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3741,7 +3741,10 @@ def _recorded_install_uv_cache() -> Optional[Path]:
         )
     except OSError:
         return None
-    lines = [line.strip() for line in recorded.splitlines() if line.strip()]
+    # splitlines already drops the terminator; the line itself is NOT stripped, because
+    # the installers write UV_CACHE_DIR through verbatim and a path may legitimately end
+    # or begin with a space. Blank lines are still skipped, since blank means unset.
+    lines = [line for line in recorded.splitlines() if line.strip()]
     if not lines:
         return None
     return Path(os.path.abspath(os.path.expanduser(lines[-1])))

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3751,7 +3751,10 @@ def _recorded_install_uv_cache() -> Optional[Path]:
     lines = [line for line in recorded.splitlines() if line.strip()]
     if not lines:
         return None
-    return Path(os.path.abspath(os.path.expanduser(lines[-1])))
+    # No expanduser, for the same reason the probe drops it: the installers write this
+    # path through the way uv would read it, and uv treats a tilde as an ordinary path
+    # segment rather than $HOME.
+    return Path(os.path.abspath(lines[-1]))
 
 
 def _backfill_uv_cache_marker(env: Optional[dict]) -> None:

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3729,54 +3729,40 @@ def _uv_default_cache_dir() -> Optional[Path]:
 
 
 def _recorded_install_uv_cache() -> Optional[Path]:
-    """The cache the installer actually used, as it recorded it.
+    """The cache the installer used, as it recorded it.
 
-    Guessing from content cannot tell a Studio cache the installer filled from one that
-    holds a single wheel some runtime install dropped there (wheel_utils.py:405), because
-    install.sh:705 points the running backend at it even in shared mode. The installers
-    know which they chose, so they write it down; absent, for installs that predate the
-    marker, the caller falls back to inspecting both caches.
+    Content cannot tell a Studio cache the installer filled from one holding a single
+    wheel the running backend dropped there (wheel_utils.py:405), since install.sh:705
+    points it there even in shared mode. Absent, the caller falls back to content.
     """
     try:
-        # utf-8-sig, not utf-8: Windows PowerShell 5.1 writes `-Encoding utf8` WITH a BOM,
-        # which utf-8 would decode into the first character of the path.
-        # surrogateescape, not replace: a POSIX path may hold bytes that are not UTF-8 at
-        # all, and U+FFFD would name a directory that does not exist. This is the exact
-        # spelling os.fsdecode gives such a path, which is what the write below records.
+        # utf-8-sig: Windows PowerShell 5.1 writes `-Encoding utf8` WITH a BOM.
+        # surrogateescape: a POSIX path may not be UTF-8, and U+FFFD would name nothing.
         recorded = (STUDIO_HOME / "cache" / "uv-cache-dir").read_text(
             encoding = "utf-8-sig", errors = "surrogateescape"
         )
     except OSError:
         return None
-    # splitlines already drops the terminator; the line itself is NOT stripped, because
-    # the installers write UV_CACHE_DIR through verbatim and a path may legitimately end
-    # or begin with a space. Blank lines are still skipped, since blank means unset.
+    # Not stripped: a recorded path may end or begin with a space. Blank means unset.
     lines = [line for line in recorded.splitlines() if line.strip()]
     if not lines:
         return None
-    # No expanduser, for the same reason the probe drops it: the installers write this
-    # path through the way uv would read it, and uv treats a tilde as an ordinary path
-    # segment rather than $HOME.
+    # No expanduser, as in the probe: uv treats a tilde as an ordinary path segment.
     return Path(os.path.abspath(lines[-1]))
 
 
 def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
     """Record the cache this update used, for installs whose installer never did.
 
-    Everyone installed before the marker existed reaches the content fallback, and that
-    fallback goes stale the moment the backend drops one wheel into the Studio cache:
-    both caches then look warm and the next update stops preferring the one the install
-    filled. Writing the choice down once the setup it drove has succeeded closes that,
-    and does the same for a marker whose cache has since been emptied.
+    Those reach the content fallback, which goes stale the moment the backend drops one
+    wheel into the Studio cache and both caches look warm. Writing the choice down once
+    setup has succeeded closes that, and likewise for a marker whose cache was emptied.
     """
     if (os.environ.get("UV_CACHE_DIR") or "").strip():
-        # The caller's, for this run. The installers record their own choice; an update
-        # must not promote a one-shot value into one.
+        # One run's value. Only an installer's own choice becomes a marker.
         return
     if (os.environ.get(_studio_stage.STAGE_ROOT_ENV) or "").strip():
-        # A staged update still has verification and the outer stage probes to pass, and
-        # STUDIO_HOME here names the LIVE install, not the stage. Writing now would point
-        # the live marker at a cache built for an environment that may never be activated.
+        # STUDIO_HOME names the LIVE install here, and the stage can still be rejected.
         return
     chosen = (env or {}).get("UV_CACHE_DIR")
     if not chosen:
@@ -3787,14 +3773,10 @@ def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
     marker = STUDIO_HOME / "cache" / "uv-cache-dir"
     try:
         marker.parent.mkdir(parents = True, exist_ok = True)
-        # Unlinked first: write_text follows a symlink and would truncate whatever it
-        # points at, so a marker path someone has linked elsewhere would quietly destroy
-        # an unrelated file.
+        # Unlinked first: a write follows a symlink and truncates its target.
         marker.unlink(missing_ok = True)
-        # fsencode, not write_text: an undecodable POSIX path reaches here as surrogates,
-        # and encoding those raises UnicodeEncodeError, which is not an OSError and so
-        # escaped this handler entirely, failing an update whose setup had already
-        # succeeded. Encoding it the way the filesystem gave it to us writes it instead.
+        # fsencode: an undecodable path arrives as surrogates, and encoding those raises
+        # UnicodeEncodeError, which is not an OSError.
         marker.write_bytes(os.fsencode(f"{chosen}\n"))
     except (OSError, ValueError):
         # ValueError covers UnicodeError, for a path fsencode still cannot render.
@@ -3813,8 +3795,7 @@ def _with_studio_uv_cache(env: Optional[dict]) -> Optional[dict]:
     studio_cache = STUDIO_HOME / "cache" / "uv"
     recorded = _recorded_install_uv_cache()
     if recorded is not None and _uv_cache_has_packages(recorded):
-        # Only while it still holds something: `uv cache clean` is the user's to run, and
-        # a marker pointing at an emptied cache should not outrank a warm one.
+        # Only while it holds something: a marker for an emptied cache loses to a warm one.
         return {**(env or os.environ), "UV_CACHE_DIR": str(recorded)}
     if not _uv_cache_has_packages(studio_cache):
         # A shared-mode install left the wheels in uv's own cache and _setup_cache_env
@@ -3902,7 +3883,7 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
 
     if returncode != 0:
         raise typer.Exit(returncode)
-    # Only now: a cache that did not get through setup is not one to point later updates at.
+    # Only now: a cache that did not get through setup is not one to record.
     _backfill_uv_cache_marker(env)
 
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3740,8 +3740,11 @@ def _recorded_install_uv_cache() -> Optional[Path]:
     try:
         # utf-8-sig, not utf-8: Windows PowerShell 5.1 writes `-Encoding utf8` WITH a BOM,
         # which utf-8 would decode into the first character of the path.
+        # surrogateescape, not replace: a POSIX path may hold bytes that are not UTF-8 at
+        # all, and U+FFFD would name a directory that does not exist. This is the exact
+        # spelling os.fsdecode gives such a path, which is what the write below records.
         recorded = (STUDIO_HOME / "cache" / "uv-cache-dir").read_text(
-            encoding = "utf-8-sig", errors = "replace"
+            encoding = "utf-8-sig", errors = "surrogateescape"
         )
     except OSError:
         return None
@@ -3788,8 +3791,13 @@ def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
         # points at, so a marker path someone has linked elsewhere would quietly destroy
         # an unrelated file.
         marker.unlink(missing_ok = True)
-        marker.write_text(f"{chosen}\n", encoding = "utf-8")
-    except OSError:
+        # fsencode, not write_text: an undecodable POSIX path reaches here as surrogates,
+        # and encoding those raises UnicodeEncodeError, which is not an OSError and so
+        # escaped this handler entirely, failing an update whose setup had already
+        # succeeded. Encoding it the way the filesystem gave it to us writes it instead.
+        marker.write_bytes(os.fsencode(f"{chosen}\n"))
+    except (OSError, ValueError):
+        # ValueError covers UnicodeError, for a path fsencode still cannot render.
         pass
 
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3770,6 +3770,11 @@ def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
         # The caller's, for this run. The installers record their own choice; an update
         # must not promote a one-shot value into one.
         return
+    if (os.environ.get(_studio_stage.STAGE_ROOT_ENV) or "").strip():
+        # A staged update still has verification and the outer stage probes to pass, and
+        # STUDIO_HOME here names the LIVE install, not the stage. Writing now would point
+        # the live marker at a cache built for an environment that may never be activated.
+        return
     chosen = (env or {}).get("UV_CACHE_DIR")
     if not chosen:
         return
@@ -3779,6 +3784,10 @@ def _backfill_uv_cache_marker(env: Optional[dict]) -> None:
     marker = STUDIO_HOME / "cache" / "uv-cache-dir"
     try:
         marker.parent.mkdir(parents = True, exist_ok = True)
+        # Unlinked first: write_text follows a symlink and would truncate whatever it
+        # points at, so a marker path someone has linked elsewhere would quietly destroy
+        # an unrelated file.
+        marker.unlink(missing_ok = True)
         marker.write_text(f"{chosen}\n", encoding = "utf-8")
     except OSError:
         pass

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -379,6 +379,20 @@ def test_a_reinstall_into_a_custom_cache_is_not_shadowed_by_the_old_marker(
     assert seen["env"]["UV_CACHE_DIR"] == str(custom), seen["env"].get("UV_CACHE_DIR")
 
 
+@pytest.mark.parametrize("spelling", ["trailing ", " leading", "  both  "])
+def test_a_recorded_path_keeps_its_whitespace(monkeypatch, tmp_path, caches, spelling):
+    """The installers write UV_CACHE_DIR through verbatim and a directory name may
+    legitimately start or end with a space, so stripping the line would probe a different
+    path and read a warm cache as cold."""
+    _studio_cache, _default = caches
+    odd = tmp_path / spelling
+    _fill(odd)
+    _record(tmp_path / "StudioHome", odd)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(odd), seen["env"].get("UV_CACHE_DIR")
+
+
 def test_a_marker_written_by_windows_powershell_is_read_back(monkeypatch, tmp_path, caches):
     """Windows PowerShell 5.1 writes `-Encoding utf8` with a BOM, and utf-8 would decode
     it into the first character of the path."""

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -228,6 +228,9 @@ def test_the_chosen_cache_is_named_rather_than_left_to_the_child(monkeypatch, tm
     studio_cache, default_cache = caches
     for warm, expected in ((default_cache, default_cache), (studio_cache, studio_cache)):
         _fill(warm)
+        # The previous iteration's run backfills a marker, which would then decide this
+        # one. Each iteration states its own starting point.
+        (tmp_path / "StudioHome" / "cache" / "uv-cache-dir").unlink(missing_ok = True)
         seen = _run_posix(monkeypatch, tmp_path)
         assert seen["env"]["UV_CACHE_DIR"] == str(expected), seen["env"].get("UV_CACHE_DIR")
 
@@ -302,6 +305,169 @@ def test_an_absent_cache_is_not_warm(tmp_path):
     studio = _studio()
 
     assert studio._uv_cache_has_packages(tmp_path / "nope") is False
+
+
+# --- The cache the installer recorded --------------------------------------------------
+
+
+def _record(studio_home: Path, value) -> None:
+    marker = studio_home / "cache"
+    marker.mkdir(parents = True, exist_ok = True)
+    (marker / "uv-cache-dir").write_text(f"{value}\n", encoding = "utf-8")
+
+
+def test_the_recorded_install_cache_beats_both_guesses(monkeypatch, tmp_path, caches):
+    """The case content cannot decide: a shared-mode install, and the running backend has
+    since dropped one wheel into the Studio cache (install.sh:705 points it there even in
+    shared mode), so both caches hold package bytes."""
+    studio_cache, default_cache = caches
+    _fill(studio_cache, name = "some_runtime_wheel.whl")
+    _fill(default_cache)
+    _record(tmp_path / "StudioHome", default_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(default_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_recorded_studio_cache_survives_the_user_warming_their_own(monkeypatch, tmp_path, caches):
+    """The mirror image: a studio-mode install, and the user has since used uv for
+    something else. Content alone would hand the update a cache the install never used."""
+    studio_cache, default_cache = caches
+    _fill(studio_cache)
+    _fill(default_cache)
+    _record(tmp_path / "StudioHome", studio_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_an_emptied_recorded_cache_does_not_outrank_a_warm_one(monkeypatch, tmp_path, caches):
+    """`uv cache clean` is the user's to run. A marker pointing at nothing is stale, not
+    authoritative."""
+    studio_cache, default_cache = caches
+    _fill(default_cache)
+    _record(tmp_path / "StudioHome", studio_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(default_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_installs_older_than_the_marker_still_work(monkeypatch, tmp_path, caches):
+    """No marker is the normal state for everyone installed before this change, so the
+    content fallback has to stay."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_reinstall_into_a_custom_cache_is_not_shadowed_by_the_old_marker(
+    monkeypatch, tmp_path, caches
+):
+    """A reinstall with a nonblank UV_CACHE_DIR fills that cache, so the installers record
+    it too. Were the previous install's marker left behind, a later update without the
+    variable would read a cache this install never filled, and both still hold packages,
+    so nothing downstream could notice."""
+    studio_cache, _default = caches
+    custom = tmp_path / "caller cache"
+    _fill(studio_cache)
+    _fill(custom)
+    _record(tmp_path / "StudioHome", custom)
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(custom), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_marker_written_by_windows_powershell_is_read_back(monkeypatch, tmp_path, caches):
+    """Windows PowerShell 5.1 writes `-Encoding utf8` with a BOM, and utf-8 would decode
+    it into the first character of the path."""
+    studio_cache, default_cache = caches
+    _fill(studio_cache)
+    _fill(default_cache)
+    marker = tmp_path / "StudioHome" / "cache"
+    marker.mkdir(parents = True, exist_ok = True)
+    (marker / "uv-cache-dir").write_bytes(b"\xef\xbb\xbf" + f"{studio_cache}\r\n".encode("utf-8"))
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+def test_a_relative_marker_is_resolved_before_it_is_handed_over(monkeypatch, tmp_path, caches):
+    """setup.sh changes directory, so a relative path would name somewhere else there."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    monkeypatch.chdir(tmp_path)
+    _record(tmp_path / "StudioHome", "StudioHome/cache/uv")
+    seen = _run_posix(monkeypatch, tmp_path)
+
+    assert seen["env"]["UV_CACHE_DIR"] == str(studio_cache), seen["env"].get("UV_CACHE_DIR")
+
+
+# --- Backfilling the marker for installs that predate it --------------------------------
+
+
+def _marker(tmp_path: Path) -> Path:
+    return tmp_path / "StudioHome" / "cache" / "uv-cache-dir"
+
+
+def test_a_legacy_install_records_what_the_update_worked_out(monkeypatch, tmp_path, caches):
+    """Otherwise the fallback has to be re-derived every time, and it goes stale the
+    moment the backend drops one wheel into the Studio cache."""
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    _run_posix(monkeypatch, tmp_path)
+
+    assert _marker(tmp_path).read_text(encoding = "utf-8").strip() == str(default_cache)
+
+
+def test_a_failed_update_records_nothing(monkeypatch, tmp_path, caches):
+    """A cache that did not get through setup is not one to aim later updates at."""
+    studio = _studio()
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    monkeypatch.setattr(studio.platform, "system", lambda: "Linux")
+
+    class _Failed:
+        returncode = 1
+
+    monkeypatch.setattr(studio.subprocess, "run", lambda argv, **kw: _Failed())
+    with pytest.raises(studio.typer.Exit):
+        studio._run_setup_script(repo_root = _setup_tree(tmp_path))
+
+    assert not _marker(tmp_path).exists(), _marker(tmp_path).read_text(encoding = "utf-8")
+
+
+def test_a_live_marker_is_not_overwritten_by_the_update(monkeypatch, tmp_path, caches):
+    """The installer's statement outranks the update's inference while it still holds."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    _record(tmp_path / "StudioHome", studio_cache)
+    _run_posix(monkeypatch, tmp_path)
+
+    assert _marker(tmp_path).read_text(encoding = "utf-8").strip() == str(studio_cache)
+
+
+def test_a_stale_marker_is_replaced_once_the_fallback_works(monkeypatch, tmp_path, caches):
+    """`uv cache clean` on the recorded cache leaves a pointer to nothing; the update
+    already ignores it, and should stop re-deriving that every time."""
+    studio_cache, default_cache = caches
+    _fill(default_cache)
+    _record(tmp_path / "StudioHome", studio_cache)
+    _run_posix(monkeypatch, tmp_path)
+
+    assert _marker(tmp_path).read_text(encoding = "utf-8").strip() == str(default_cache)
+
+
+def test_a_caller_supplied_cache_is_never_promoted_to_the_marker(monkeypatch, tmp_path, caches):
+    """The installers record their own choice. An update must not turn one run's
+    environment variable into every later update's default."""
+    studio_cache, _default = caches
+    _fill(studio_cache)
+    monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path / "caller cache"))
+    _run_posix(monkeypatch, tmp_path)
+
+    assert not _marker(tmp_path).exists()
 
 
 # --- The uv probe ---------------------------------------------------------------------

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -318,9 +318,8 @@ def _record(studio_home: Path, value) -> None:
 
 
 def test_the_recorded_install_cache_beats_both_guesses(monkeypatch, tmp_path, caches):
-    """The case content cannot decide: a shared-mode install, and the running backend has
-    since dropped one wheel into the Studio cache (install.sh:705 points it there even in
-    shared mode), so both caches hold package bytes."""
+    """The case content cannot decide: a shared install whose backend has since dropped
+    one wheel into the Studio cache (install.sh:705), so both caches hold packages."""
     studio_cache, default_cache = caches
     _fill(studio_cache, name = "some_runtime_wheel.whl")
     _fill(default_cache)
@@ -331,8 +330,7 @@ def test_the_recorded_install_cache_beats_both_guesses(monkeypatch, tmp_path, ca
 
 
 def test_a_recorded_studio_cache_survives_the_user_warming_their_own(monkeypatch, tmp_path, caches):
-    """The mirror image: a studio-mode install, and the user has since used uv for
-    something else. Content alone would hand the update a cache the install never used."""
+    """The mirror: a studio install, and the user has since warmed uv's own cache."""
     studio_cache, default_cache = caches
     _fill(studio_cache)
     _fill(default_cache)
@@ -343,8 +341,7 @@ def test_a_recorded_studio_cache_survives_the_user_warming_their_own(monkeypatch
 
 
 def test_an_emptied_recorded_cache_does_not_outrank_a_warm_one(monkeypatch, tmp_path, caches):
-    """`uv cache clean` is the user's to run. A marker pointing at nothing is stale, not
-    authoritative."""
+    """A marker pointing at an emptied cache is stale, not authoritative."""
     studio_cache, default_cache = caches
     _fill(default_cache)
     _record(tmp_path / "StudioHome", studio_cache)
@@ -354,8 +351,7 @@ def test_an_emptied_recorded_cache_does_not_outrank_a_warm_one(monkeypatch, tmp_
 
 
 def test_installs_older_than_the_marker_still_work(monkeypatch, tmp_path, caches):
-    """No marker is the normal state for everyone installed before this change, so the
-    content fallback has to stay."""
+    """The normal state for everyone installed before this change."""
     studio_cache, _default = caches
     _fill(studio_cache)
     seen = _run_posix(monkeypatch, tmp_path)
@@ -366,10 +362,9 @@ def test_installs_older_than_the_marker_still_work(monkeypatch, tmp_path, caches
 def test_a_reinstall_into_a_custom_cache_is_not_shadowed_by_the_old_marker(
     monkeypatch, tmp_path, caches
 ):
-    """A reinstall with a nonblank UV_CACHE_DIR fills that cache, so the installers record
-    it too. Were the previous install's marker left behind, a later update without the
-    variable would read a cache this install never filled, and both still hold packages,
-    so nothing downstream could notice."""
+    """A reinstall with a nonblank UV_CACHE_DIR fills that cache, so it is recorded too:
+    a stale marker would aim later updates at a cache this install never filled, and both
+    hold packages, so nothing downstream could notice."""
     studio_cache, _default = caches
     custom = tmp_path / "caller cache"
     _fill(studio_cache)
@@ -382,9 +377,8 @@ def test_a_reinstall_into_a_custom_cache_is_not_shadowed_by_the_old_marker(
 
 @pytest.mark.parametrize("spelling", ["trailing ", " leading", "  both  "])
 def test_a_recorded_path_keeps_its_whitespace(monkeypatch, tmp_path, caches, spelling):
-    """The installers write UV_CACHE_DIR through verbatim and a directory name may
-    legitimately start or end with a space, so stripping the line would probe a different
-    path and read a warm cache as cold."""
+    """A recorded name may start or end with a space, and stripping it would probe a
+    different path and read a warm cache as cold."""
     _studio_cache, _default = caches
     odd = tmp_path / spelling
     _fill(odd)
@@ -395,8 +389,8 @@ def test_a_recorded_path_keeps_its_whitespace(monkeypatch, tmp_path, caches, spe
 
 
 def test_a_marker_written_by_windows_powershell_is_read_back(monkeypatch, tmp_path, caches):
-    """Windows PowerShell 5.1 writes `-Encoding utf8` with a BOM, and utf-8 would decode
-    it into the first character of the path."""
+    """PowerShell 5.1 writes `-Encoding utf8` with a BOM, which utf-8 would decode into
+    the first character of the path."""
     studio_cache, default_cache = caches
     _fill(studio_cache)
     _fill(default_cache)
@@ -427,8 +421,8 @@ def _marker(tmp_path: Path) -> Path:
 
 
 def test_a_legacy_install_records_what_the_update_worked_out(monkeypatch, tmp_path, caches):
-    """Otherwise the fallback has to be re-derived every time, and it goes stale the
-    moment the backend drops one wheel into the Studio cache."""
+    """Otherwise the fallback is re-derived every time, and goes stale the moment the
+    backend drops one wheel into the Studio cache."""
     _studio_cache, default_cache = caches
     _fill(default_cache)
     _run_posix(monkeypatch, tmp_path)
@@ -464,8 +458,7 @@ def test_a_live_marker_is_not_overwritten_by_the_update(monkeypatch, tmp_path, c
 
 
 def test_a_stale_marker_is_replaced_once_the_fallback_works(monkeypatch, tmp_path, caches):
-    """`uv cache clean` on the recorded cache leaves a pointer to nothing; the update
-    already ignores it, and should stop re-deriving that every time."""
+    """A marker whose cache was emptied is already ignored; stop re-deriving that."""
     studio_cache, default_cache = caches
     _fill(default_cache)
     _record(tmp_path / "StudioHome", studio_cache)
@@ -475,8 +468,7 @@ def test_a_stale_marker_is_replaced_once_the_fallback_works(monkeypatch, tmp_pat
 
 
 def test_a_caller_supplied_cache_is_never_promoted_to_the_marker(monkeypatch, tmp_path, caches):
-    """The installers record their own choice. An update must not turn one run's
-    environment variable into every later update's default."""
+    """One run's environment variable must not become every later update's default."""
     studio_cache, _default = caches
     _fill(studio_cache)
     monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path / "caller cache"))
@@ -486,9 +478,8 @@ def test_a_caller_supplied_cache_is_never_promoted_to_the_marker(monkeypatch, tm
 
 
 def test_a_staged_update_does_not_write_the_live_marker(monkeypatch, tmp_path, caches):
-    """STUDIO_HOME names the LIVE install even in a staged child, and the stage can still
-    be rejected by verification or the outer probes. Writing now would point the live
-    marker at a cache built for an environment that was never activated."""
+    """STUDIO_HOME names the LIVE install even in a staged child, and the stage can
+    still be rejected, so writing now would aim it at an environment never activated."""
     studio = _studio()
     _studio_cache, default_cache = caches
     _fill(default_cache)
@@ -517,10 +508,9 @@ def test_the_backfill_replaces_a_symlink_rather_than_its_target(monkeypatch, tmp
 
 @pytest.mark.skipif(os.name != "posix", reason = "POSIX filesystem byte semantics")
 def test_a_cache_path_that_is_not_utf_8_is_recorded_and_read_back(monkeypatch, tmp_path):
-    """A POSIX path is bytes, and an undecodable one reaches Python as surrogates.
-    Encoding those raises UnicodeEncodeError, which is not an OSError and so escaped the
-    best-effort handler entirely: an update whose setup had already succeeded then failed
-    at the very end, after unlinking the marker it was replacing."""
+    """An undecodable POSIX path reaches Python as surrogates, and encoding those raises
+    UnicodeEncodeError, which is not an OSError and escaped the best-effort handler: an
+    update whose setup had succeeded failed at the end, with its marker already gone."""
     studio = _studio()
     weird = (tmp_path / os.fsdecode(b"caf\xe9-cache")).resolve()
     _fill(weird)
@@ -533,8 +523,7 @@ def test_a_cache_path_that_is_not_utf_8_is_recorded_and_read_back(monkeypatch, t
     assert _marker(tmp_path).read_bytes().strip() == os.fsencode(str(weird))
     # And the reader gives back the path the filesystem uses, not one with U+FFFD in it.
     assert studio._recorded_install_uv_cache() == weird
-    # Removed here rather than left to the tmp_path reaper, which cannot always delete a
-    # name it cannot decode and would report it as leaked garbage on every later run.
+    # The tmp_path reaper cannot always delete a name it cannot decode.
     shutil.rmtree(weird, ignore_errors = True)
 
 

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -484,6 +484,36 @@ def test_a_caller_supplied_cache_is_never_promoted_to_the_marker(monkeypatch, tm
     assert not _marker(tmp_path).exists()
 
 
+def test_a_staged_update_does_not_write_the_live_marker(monkeypatch, tmp_path, caches):
+    """STUDIO_HOME names the LIVE install even in a staged child, and the stage can still
+    be rejected by verification or the outer probes. Writing now would point the live
+    marker at a cache built for an environment that was never activated."""
+    studio = _studio()
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    monkeypatch.setenv(studio._studio_stage.STAGE_ROOT_ENV, str(tmp_path / "stage"))
+    _run_posix(monkeypatch, tmp_path)
+
+    assert not _marker(tmp_path).exists()
+
+
+def test_the_backfill_replaces_a_symlink_rather_than_its_target(monkeypatch, tmp_path, caches):
+    """write_text follows a symlink, so a marker path linked elsewhere would truncate an
+    unrelated file."""
+    _studio_cache, default_cache = caches
+    _fill(default_cache)
+    victim = tmp_path / "someone elses file"
+    victim.write_text("do not clobber", encoding = "utf-8")
+    marker = _marker(tmp_path)
+    marker.parent.mkdir(parents = True, exist_ok = True)
+    marker.symlink_to(victim)
+    _run_posix(monkeypatch, tmp_path)
+
+    assert victim.read_text(encoding = "utf-8") == "do not clobber"
+    assert not marker.is_symlink()
+    assert marker.read_text(encoding = "utf-8").strip() == str(default_cache)
+
+
 # --- The uv probe ---------------------------------------------------------------------
 
 

--- a/unsloth_cli/tests/test_studio_update_uv_cache.py
+++ b/unsloth_cli/tests/test_studio_update_uv_cache.py
@@ -15,6 +15,7 @@ fails outright when uv may read only what is cached.
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -512,6 +513,29 @@ def test_the_backfill_replaces_a_symlink_rather_than_its_target(monkeypatch, tmp
     assert victim.read_text(encoding = "utf-8") == "do not clobber"
     assert not marker.is_symlink()
     assert marker.read_text(encoding = "utf-8").strip() == str(default_cache)
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX filesystem byte semantics")
+def test_a_cache_path_that_is_not_utf_8_is_recorded_and_read_back(monkeypatch, tmp_path):
+    """A POSIX path is bytes, and an undecodable one reaches Python as surrogates.
+    Encoding those raises UnicodeEncodeError, which is not an OSError and so escaped the
+    best-effort handler entirely: an update whose setup had already succeeded then failed
+    at the very end, after unlinking the marker it was replacing."""
+    studio = _studio()
+    weird = (tmp_path / os.fsdecode(b"caf\xe9-cache")).resolve()
+    _fill(weird)
+    monkeypatch.setattr(studio, "STUDIO_HOME", tmp_path / "StudioHome")
+    monkeypatch.setattr(studio, "_uv_default_cache_dir", lambda: weird)
+    monkeypatch.delenv("UV_CACHE_DIR", raising = False)
+
+    studio._backfill_uv_cache_marker({"UV_CACHE_DIR": str(weird)})
+
+    assert _marker(tmp_path).read_bytes().strip() == os.fsencode(str(weird))
+    # And the reader gives back the path the filesystem uses, not one with U+FFFD in it.
+    assert studio._recorded_install_uv_cache() == weird
+    # Removed here rather than left to the tmp_path reaper, which cannot always delete a
+    # name it cannot decode and would report it as leaked garbage on every later run.
+    shutil.rmtree(weird, ignore_errors = True)
 
 
 # --- The uv probe ---------------------------------------------------------------------


### PR DESCRIPTION
Stacked on #10386, which this targets. That PR makes `unsloth studio update` pick a uv cache by inspecting what the two candidate caches contain. This one makes the installers say which they used, because content cannot always tell.

## The case content cannot decide

In `shared` mode the installers deliberately point the *running backend* at the Studio cache once the install is done (`_prepare_studio_uv_cache_for_launch` in `install.sh`, `Set-StudioUvCacheForLaunch` in `install.ps1`), even though the install itself used uv's own cache. So one on-demand install from the server, such as `studio/backend/utils/wheel_utils.py:405`, drops package bytes into the Studio cache.

Both caches now hold packages. The update's content rule prefers the Studio one and abandons the cache that actually has the Torch and CUDA wheels.

Reproduced end to end with uv 0.10.7, running the real `_with_studio_uv_cache` from each branch against the same scratch install:

```
install's cache: 24 files | studio cache (runtime leftovers): 61 files

#10386 alone   picks <StudioHome>/cache/uv   -> UV_OFFLINE=1 update FAILED
with this PR   picks the uv default cache    -> UV_OFFLINE=1 update SUCCEEDED
```

The mirror case is just as wrong and just as reachable: a `studio` install loses to uv's default the moment the user runs an unrelated `uv pip install` and warms it. No content rule separates these, because by then both caches genuinely hold package bytes. Only the installer knows which one it used.

## What this adds

`install.sh` and `install.ps1` write the cache they selected to `<StudioHome>/cache/uv-cache-dir`, and `_with_studio_uv_cache` reads it before falling back to inspecting both caches.

**Every mode records, a caller's own `UV_CACHE_DIR` included.** That is where the install actually put its wheels, and leaving an earlier install's marker in place would aim later updates at a cache this one never filled. A caller keeps control regardless: a nonblank `UV_CACHE_DIR` outranks the marker at update time too, so a CI image that pins a cache is unaffected either way. The marker only decides anything when the caller sets nothing.

**A marker is honoured only while the cache it names still holds packages.** `uv cache clean` is the user's to run, and a pointer to an emptied cache should not outrank a warm one.

**Installs that predate the marker keep working.** They have none, so the content fallback stays. The update also records what that fallback worked out, once setup has returned 0, and replaces a marker whose cache has since been emptied. A caller's `UV_CACHE_DIR` is never promoted into a marker: that belongs to one run, and the installers are what record an install.

Note the ordering is deliberately opposite on the two sides. The installer writes before the work, because the marker configures that work, and restores it if the work fails. The update writes after, because it is recording a conclusion rather than a configuration.

## The marker travels with the environment

Written absolute. `uv cache dir` answers `cache-dir = "relcache"` with `relcache` verbatim and `UV_CACHE_DIR` may itself be relative, while the update resolves the marker against its own working directory. On the PowerShell side that needs `$PWD` explicitly: `[System.IO.Path]::GetFullPath` resolves against the .NET process directory, which `Set-Location` does not move, so it would anchor to wherever the process started.

Restored on rollback. Both installers put the previous environment back when an install fails (`_restore_studio_venv_replacement`, `Restore-StudioVenvRollback`), and a marker naming the cache of an install that never happened would outlive the environment it was chosen for. The previous contents are captured before the first write and restored at every point the environment comes back, which on PowerShell is two branches, the merged split-move and the plain move. A first install that fails removes the marker rather than restoring one that was never there.

Reset per run. Under `irm | iex` the script scope is the caller's session, the same hazard the rollback state next to it already documents.

Never fatal. An unwritable Studio root skips the marker rather than failing the install, which on PowerShell means `-ErrorAction SilentlyContinue` rather than `Stop`, since a parity test already forbids anything after the bucket scan from failing closed. `Restore-StudioUvCacheMarker` takes `[AllowEmptyString()]` and returns early on a blank root deliberately: it runs from the rollback, where the partial branch sits outside any try and the other branch's catch would report "could not restore previous environment" for a move that had already succeeded.

Read as `utf-8-sig`. Windows PowerShell 5.1 writes `-Encoding utf8` with a BOM, which plain utf-8 would decode into the first character of the path.

## Tests

`tests/sh/test_install_uv_cache_root.sh` goes from 45 to 81 checks under `sh`, `bash` and `dash`: what each mode records, custom mode replacing an earlier install's marker, a rolled-back install restoring the previous marker, a rolled-back first install leaving none behind, a relative cache recorded absolute, a relative `UV_WORKING_DIR` anchored to the run directory, and an unwritable Studio root still installing.

The pwsh selector test asserts the same marker for every parametrised mode, and there are new parametrised tests for the rollback round trip and the relative-path case. A parity test pins the marker in both installers, including that every call site sits after the custom branch and that neither write can fail closed.

`unsloth_cli/tests/test_studio_update_uv_cache.py` gains 14 tests: the marker beating both guesses in either direction, a stale marker not outranking a warm cache, a reinstall into a custom cache not being shadowed, a BOM-prefixed marker being read back, a relative marker resolved, the legacy backfill, a failed update recording nothing, a live marker not being overwritten, a caller value never promoted, and a cache path holding bytes that are not UTF-8 recorded and read back unchanged.

Three existing rollback tests and `tests/studio/test_install_rollback_lifecycle.ps1` splice `Restore-StudioVenvRollback` into a fresh shell, so they now extract the new helper alongside it. `tests/sh/test_install_rollback_lifecycle.sh` does the same for the sh side; note the parity workflow runs that file with `sh`, whatever the shebang says, so the join is `printf` rather than `$'\n'`.

`tests/sh/test_install_rollback_lifecycle.sh` goes from 40 to 43, including a first install that commits and then fails afterwards. Two of its existing marker cases were passing vacuously until this round: `_record_uv_cache_choice` is defined outside the block they splice, so the harness exited 127 before writing anything, which satisfies any expectation about a marker that must not change. The helper is spliced alongside the others now and the cases fail if the harness writes to stderr or dies on a missing command.

```
sh / dash / bash tests/sh/test_install_uv_cache_root.sh          81 checks each
sh / dash / bash tests/sh/test_install_rollback_lifecycle.sh     43 checks each
pytest test_studio_update_uv_cache.py + parity + hardening       183 passed
all 24 tests/studio/*.ps1                                        pass
install.ps1 AST parse                                            clean
ruff 0.15.18 check, scripts/run_ruff_format.py                   clean
```

Run the Python tests with `UV_CACHE_DIR` unset. If your shell sets it, `_with_studio_uv_cache` returns at its first line and none of this is exercised.

## Not in this PR

A `shared` install still writes its Torch and CUDA wheels to the user-wide cache, outside the Studio root, where the uninstallers cannot reclaim them, so the storage half of #10193 stays open. Closing that means making the Studio cache the install default and offering the reuse as an opt-in, which reverses the measured trade-off #10204 landed on and is a product call rather than a bug.

