### PR TITLE
studio: unbreak the composer icon checks (crypto polyfill, and a Firefox zoom measurement bug)

### DIFF
--- a/studio/frontend/smoke-composer-icons.html
+++ b/studio/frontend/smoke-composer-icons.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <html lang="en">
-  <head><meta charset="UTF-8" /><title>Composer icon alignment</title></head>
+  <head>
+    <meta charset="UTF-8" />
+    <script src="/crypto-boot.js"></script>
+    <title>Composer icon alignment</title>
+  </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/smoke-composer-icons-main.tsx"></script>

--- a/tests/studio/playwright_composer_icons.py
+++ b/tests/studio/playwright_composer_icons.py
@@ -27,8 +27,21 @@ MEASURE = """() => [...document.querySelectorAll('button[data-case]')].map(butto
     const buttonBox = button.getBoundingClientRect();
     const svgBox = svg.getBoundingClientRect();
     const glyph = svg.getBBox();
-    const glyphCenter = new DOMPoint(glyph.x + glyph.width / 2, glyph.y + glyph.height / 2)
-        .matrixTransform(svg.getScreenCTM());
+    // Map the glyph bbox through the viewBox rather than through getScreenCTM.
+    // Firefox's getScreenCTM leaves CSS `zoom` out of the matrix while its
+    // getBoundingClientRect includes it, so at zoom != 1 the two disagree and a
+    // perfectly centred glyph measures off by (1 / zoom - 1) times its offset
+    // from the SVG origin. Chromium folds zoom in and agrees either way, so the
+    // old form reported a Firefox-only failure for geometry that is correct in
+    // both. getBBox already accounts for transforms on the glyph itself, so this
+    // still measures where the glyph actually sits inside the SVG.
+    const viewBox = (svg.getAttribute('viewBox') || '').trim().split(/[ ,]+/).map(Number);
+    const [viewX, viewY, viewW, viewH] = viewBox.length === 4 ? viewBox
+        : [0, 0, svgBox.width, svgBox.height];
+    const glyphCenter = {
+        x: svgBox.x + (glyph.x + glyph.width / 2 - viewX) / viewW * svgBox.width,
+        y: svgBox.y + (glyph.y + glyph.height / 2 - viewY) / viewH * svgBox.height,
+    };
     const centerX = buttonBox.x + buttonBox.width / 2;
     const centerY = buttonBox.y + buttonBox.height / 2;
     return {


### PR DESCRIPTION
## Summary

Two fixes to the composer icon work from #10407, which merged with both frontend checks already red.

## 1. The smoke page never loaded the crypto polyfill

`studio/frontend/smoke-composer-icons.html` arrived without the `/crypto-boot.js` tag every other HTML entry in that directory carries. `studio/frontend/tests/crypto-uuid-boot.test.ts` globs the directory and requires each page to load the polyfill ahead of its module entry, so it has failed from that commit onward.

```
a6e9880c4  success
a9aa13517  failure   <- adds studio/frontend/smoke-composer-icons.html
2a95eb78b  failure
```

```
not ok 1309 - every page loads the polyfill before its module entry
  error: 'smoke-composer-icons.html must load /crypto-boot.js'
```

**Frontend unit tests (Windows)** and **Frontend build + bundle sanity** are red on `main`, and on every open PR whose merge commit picks the page up, which is how I ran into this.

Fixed by adding the tag where the other smoke pages put it, in `head` ahead of the module entry. This is not only about the test: `crypto-boot.js` backfills `crypto.randomUUID` on origins where it is absent, which is exactly what a smoke page opened over plain http hits.

## 2. The icon check itself had never run, and fails on Firefox when it does

The `npm test` step ahead of it was failing, so the job stopped before reaching `playwright_composer_icons.py`. With the polyfill fixed it runs, and fails on Firefox at `font 0.75, zoom 0.8, dpr 1`, 8 measurements, tolerance 0.02.

The icons are fine. `svgDx`/`svgDy` are within `7.6e-05` of the button centre, so the SVG box is centred; only the glyph centre, which the check derived by transforming `getBBox` through `svg.getScreenCTM()`, disagreed. Firefox leaves CSS `zoom` out of that matrix while its `getBoundingClientRect` includes it, so at `zoom != 1` the two disagree.

Measured on the failing case, `chat-send`:

```
firefox    ctm.a = 0.574653        svgBox centre 45.0000    ctm centre 46.3792   delta +1.3792
chromium   ctm.a = 0.459635        svgBox centre 44.9844    ctm centre 44.9844   delta +0.0000
```

`0.574653 x 0.8 = 0.459635`, and the scale the element box actually has is `11.0333 / 24 = 0.45972`, so Chromium's matrix is right and Firefox's is short by exactly the zoom factor. Mapping the same bbox through the `viewBox` instead is `0.0000` out on both engines.

Fixed by mapping through the `viewBox`. `getBBox` already accounts for transforms on the glyph, so this still measures where the glyph sits inside the SVG, and `svgDx`/`svgDy` are untouched.

## Verification

`node --experimental-strip-types --test studio/frontend/tests/crypto-uuid-boot.test.ts`, which is what `npm test` runs:

- before: `fail 1`, on `every page loads the polyfill before its module entry`
- after: `pass 4`, `fail 0`

`python tests/studio/playwright_composer_icons.py firefox chromium webkit`:

- before: `AssertionError`, 8 failing measurements, all Firefox, all at `zoom 0.8`
- after: `firefox/chromium/webkit: checked 216 configurations / 1296 icons` each, `PASS: 3888 rendered icons centered`
