### PR TITLE
Studio: unbreak the frontend suite and the icon alignment check

### DIFF
--- a/studio/frontend/smoke-composer-icons.html
+++ b/studio/frontend/smoke-composer-icons.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <html lang="en">
-  <head><meta charset="UTF-8" /><title>Composer icon alignment</title></head>
+  <head>
+    <meta charset="UTF-8" />
+    <script src="/crypto-boot.js"></script>
+    <title>Composer icon alignment</title>
+  </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/smoke-composer-icons-main.tsx"></script>

--- a/tests/studio/playwright_composer_icons.py
+++ b/tests/studio/playwright_composer_icons.py
@@ -27,8 +27,16 @@ MEASURE = """() => [...document.querySelectorAll('button[data-case]')].map(butto
     const buttonBox = button.getBoundingClientRect();
     const svgBox = svg.getBoundingClientRect();
     const glyph = svg.getBBox();
-    const glyphCenter = new DOMPoint(glyph.x + glyph.width / 2, glyph.y + glyph.height / 2)
-        .matrixTransform(svg.getScreenCTM());
+    // Scale from the rendered box, not from getScreenCTM(). Firefox leaves CSS `zoom` out of
+    // the CTM while getBoundingClientRect() applies it, so a CTM-mapped centre lands 1/zoom
+    // out and reads as a misaligned glyph on a correctly aligned icon.
+    const view = svg.viewBox.baseVal;
+    const scaleX = view.width ? svgBox.width / view.width : 1;
+    const scaleY = view.height ? svgBox.height / view.height : 1;
+    const glyphCenter = {
+        x: svgBox.x + (glyph.x + glyph.width / 2 - view.x) * scaleX,
+        y: svgBox.y + (glyph.y + glyph.height / 2 - view.y) * scaleY,
+    };
     const centerX = buttonBox.x + buttonBox.width / 2;
     const centerY = buttonBox.y + buttonBox.height / 2;
     return {


### PR DESCRIPTION
Frontend CI has been red on `main` since #10407 landed (runs 34071451180 and 34074738138, both jobs failing). Two independent breaks from that PR, the first of which was masking the second.

**1. The smoke page has no crypto polyfill.** `smoke-composer-icons.html` is the one HTML entry without the `/crypto-boot.js` tag, and `tests/crypto-uuid-boot.test.ts` enumerates `*.html` rather than a fixed list:

```
every page loads the polyfill before its module entry
  AssertionError: smoke-composer-icons.html must load /crypto-boot.js
```

Reproduced on a clean checkout of `main`. One tag, where the other entries put it. `npm test` goes 6933 pass / 1 fail to 6934 pass / 0 fail.

**2. The alignment check measures the glyph centre wrongly on firefox.** Only visible once the first fix lets the job reach that step. It reports `chat-send` 1.38px out on an icon whose svg box it measures as perfectly centred, at every zoom except 1, on Linux as well as Windows:

```
"svgDx": 0, "svgDy": -7.6e-06, "glyphDx": 1.379167, "glyphDy": 1.379163
```

The icons are fine; the measurement is not. Firefox leaves CSS `zoom` out of `getScreenCTM()` while `getBoundingClientRect()` applies it, so at `zoom: 0.8` the CTM scale comes back as **0.5747** where the rendered box gives **0.4597** (chromium reports 0.4596 for the same icon), and the mapped centre lands `1/zoom` out. Mapping with the correct scale puts the glyph centre at 44.9997 against a button centre of 45.0.

Scaling from the rendered box and the viewBox needs no CTM and is engine independent. 216 configurations on each of chromium, firefox **and** webkit now pass, 3888 icons.

The check still bites, which I verified rather than assumed: injecting a 2px glyph shift inside an unmoved svg box is caught on both engines at 0.91px against the 0.02px tolerance.

Opened while reviewing #10262, whose only red check is this one.
