### PR TITLE
Throwaway: Strix Halo memory repro kit for a 96 GiB graphics carve-out

### DIFF
--- a/strix_halo_repro/README.md
+++ b/strix_halo_repro/README.md
@@ -1,0 +1,133 @@
+# Strix Halo memory reporting: a repro kit
+
+AMD reported that llama.cpp reads the Variable Graphics Memory carve-out as
+shared iGPU memory on Ryzen AI Max (Strix Halo), so large models will not load,
+and that Unsloth Studio then uses very little of the GPU. They said the effect
+is visible with the carve-out set to 96 GiB.
+
+We ran the same measurements on a devlab Strix Halo box and **could not
+reproduce the over-report there**, because that machine carves out 64 GiB of its
+128 GB. At 64 GiB the numbers stay inside the machine and nothing looks wrong:
+
+| reading | devlab box, 64 GiB carve-out |
+|---|---|
+| carve-out, from the registry | 64.00 GiB |
+| RAM Windows can see | 63.65 GiB |
+| so the machine holds | 127.65 GiB |
+| Vulkan heaps, raw | 37.22 GiB + 74.43 GiB (device-local) |
+| **what ggml reports as GPU memory** | **111.65 GiB** = the two heaps added together |
+| what HIP reports | 99.74 GiB |
+
+The summation is confirmed: 37.22 + 74.43 is ggml's 111.65 to the byte, because
+`ggml_backend_vk_get_device_memory` adds every heap on an integrated device. But
+111.65 is still under the 127.65 GiB the machine has, so nothing is claimed that
+cannot exist, and a 77 GiB model loaded and served on that box.
+
+Whether the sum goes past the machine depends on the carve-out, which is the one
+thing a CI runner cannot change: setting it needs the firmware or the Adrenalin
+panel plus a reboot, and the runner has no administrator. Hence this kit, for
+someone with a box they can configure.
+
+## What you need
+
+- A Windows Ryzen AI Max / Max+ machine (gfx1150 or gfx1151).
+- Python 3.9 or newer from python.org. The Microsoft Store stub does not work;
+  the script says so rather than failing obscurely.
+- About 1 GB of free disk for two llama.cpp release zips, plus whatever a model
+  needs if you use the optional model step.
+- No administrator rights, no pip install, no Docker.
+
+## Setting the carve-out
+
+The interesting configuration is a large one. On most of these machines it is
+set in one of two places, and both need a reboot:
+
+- **Firmware**: look for UMA Frame Buffer Size, or Dedicated Graphics Memory,
+  under an Advanced or NBIO menu.
+- **AMD Software: Adrenalin Edition**: Performance, then Tuning, then Variable
+  Graphics Memory.
+
+Set it as high as the machine allows (96 GiB is what AMD reported against),
+reboot, and run the kit. Running it at your current setting first is also
+useful: two carve-outs on one machine is a stronger result than one.
+
+## Running it
+
+```powershell
+cd strix_halo_repro
+powershell -ExecutionPolicy Bypass -File .\run.ps1
+```
+
+Takes a few minutes and about 200 MB of downloads. To also ask what llama.cpp
+would place for a model you already have:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\run.ps1 -ModelPath D:\gguf\model-00001-of-00004.gguf
+```
+
+To measure AMD's patched HIP runtime beside the shipped one:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\run.ps1 `
+  -PatchedDllUrl "https://.../hiprtc-builtins0716.zip" `
+  -PatchedDllSha256 "72cb13857ef4da1bbcaa0a5a415c2db1e138898b430e36758f040e038f416131"
+```
+
+The script prints an output directory at the end. **Send that whole directory
+back.** It holds `REPORT.md` and the raw JSON behind every number, so a reading
+can be re-checked rather than taken on trust.
+
+## What it measures, and what a bad answer looks like
+
+1. **The host.** Carve-out from the registry, RAM Windows can see, GPU name and
+   driver version. WMI's `AdapterRAM` is recorded too, and it will say 4 GB on
+   any large card because the field is a 32-bit integer; it is there as the trap
+   it is, not as a reading.
+
+2. **llama.cpp.** Two release builds, ROCm gfx1151 and Vulkan, at a pinned tag.
+   Both are hashed so the report names exactly which binaries answered.
+
+3. **What every layer reports.** Per-heap Vulkan sizes and flags, the number
+   `ggml_backend_vk_get_device_memory` returns, the number `hipMemGetInfo`
+   returns, and what `llama-server --list-devices` prints. The three statements
+   at the end of `REPORT.md` are the result:
+   - `over_report`: the number llama.cpp places against is larger than the
+     machine's physical memory. **If this holds, the claim reproduces.**
+   - `sums_heaps`: that number equals the heaps added together rather than the
+     largest one, which is the mechanism.
+   - `hip_is_vgm_only`: HIP reports the carve-out alone, so the two backends
+     disagree because they answer different questions.
+
+4. **The largest single allocation** the HIP runtime allows, found by bisection,
+   writing and reading back every candidate so a pointer that is not backed by
+   memory does not count. The search stops at 92% of the machine on purpose:
+   AMD's own note warns that committing near all of RAM can hang the host or
+   bugcheck it, and the question is whether an allocation the shipped runtime
+   refuses now succeeds, not what the new ceiling is.
+
+5. **Unsloth Studio's own Vulkan probe**, fetched verbatim at a pinned commit
+   and run against the same build. A re-implementation would answer a different
+   question: the claim is about what Studio sees.
+
+6. **What `--fit` would place** for a model you name, via `llama-fit-params`.
+   This is where an over-report turns into a model that will not load: fit plans
+   against the number from step 3, so if that number is larger than the machine,
+   it will offload more than can exist.
+
+## What we already know from the 64 GiB box
+
+Worth having beside your numbers, so a difference is attributable:
+
+- The largest single `hipMalloc` was **110.2 GiB**, not the 64 GiB AMD described.
+  The vendor's own note says the stock rule is
+  `max(dedicated_VRAM_heap, 0.75 x shared_GART_heap)`, so on a box with a small
+  carve-out and a large aperture the GART branch wins and there is no 64 GiB
+  constant to hit. On a 96 GiB carve-out the dedicated branch may dominate
+  instead, in which case their patch changes nothing there and the interesting
+  arm is the memory report rather than the cap.
+- The Vulkan build was faster than the ROCm build on the same model:
+  **+22.9% prefill, +8.3% decode**, each gap wider than the spread within an arm.
+- Prefill time grows about 6.35 ms per token, so a 20 minute first-token
+  deadline is crossed near 197k tokens and a 250k prompt projects to about 26
+  minutes. Studio renews that deadline on prompt progress as of 2026-09-03, and
+  the server does emit the progress it renews on.

--- a/strix_halo_repro/fetch.py
+++ b/strix_halo_repro/fetch.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""Download one file, record what arrived.
+
+For inputs that are not release archives and not Hub files: a single library
+supplied by hand, for instance. Records size and sha256 so the report can name
+exactly which artifact was measured, and so a swapped file is visible without
+trusting the URL.
+
+--zip-member takes one file out of a downloaded archive. The hash that is
+checked is then the MEMBER's, not the archive's: a vendor who re-zips the same
+library changes the archive hash and nothing else, and it is the library that
+gets loaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import urllib.request
+import zipfile
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required = True)
+    ap.add_argument("--dest", required = True, help = "file path to write")
+    ap.add_argument("--expect-sha256", default = "")
+    ap.add_argument("--zip-member", default = "",
+                    help = "extract this member from the download and write IT to --dest")
+    ap.add_argument("--out", default = "")
+    a = ap.parse_args()
+
+    dest = Path(a.dest)
+    dest.parent.mkdir(parents = True, exist_ok = True)
+    landing = dest.with_suffix(dest.suffix + ".download") if a.zip_member else dest
+    with urllib.request.urlopen(a.url, timeout = 600) as r, open(landing, "wb") as fh:
+        while True:
+            chunk = r.read(1 << 20)
+            if not chunk:
+                break
+            fh.write(chunk)
+    info = {"url": a.url, "path": str(dest)}
+    if a.zip_member:
+        info["archive_bytes"] = landing.stat().st_size
+        info["archive_sha256"] = hashlib.sha256(landing.read_bytes()).hexdigest()
+        try:
+            with zipfile.ZipFile(landing) as zf:
+                names = zf.namelist()
+                info["archive_members"] = names
+                # Match on the base name: an archive is free to carry its own
+                # directory layout, and the caller asked for a library, not a path.
+                hit = [n for n in names if n.rsplit("/", 1)[-1].lower() == a.zip_member.lower()]
+                if len(hit) != 1:
+                    print(f"FATAL: expected exactly one member named {a.zip_member}, found {hit}")
+                    return 1
+                dest.write_bytes(zf.read(hit[0]))
+                info["archive_member"] = hit[0]
+        except zipfile.BadZipFile:
+            print("FATAL: --zip-member was given but the download is not a zip archive")
+            return 1
+        finally:
+            landing.unlink(missing_ok = True)
+    digest = hashlib.sha256(dest.read_bytes()).hexdigest()
+    info.update({"bytes": dest.stat().st_size, "sha256": digest})
+    print(json.dumps(info, indent = 2))
+    if a.out:
+        Path(a.out).write_text(json.dumps(info, indent = 2), encoding = "utf-8")
+    if a.expect_sha256 and a.expect_sha256.lower() != digest:
+        # A file that is not the one asked for is not a file that will do.
+        print(f"FATAL: expected sha256 {a.expect_sha256}, got {digest}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/strix_halo_repro/fetch.py
+++ b/strix_halo_repro/fetch.py
@@ -29,8 +29,11 @@ def main() -> int:
     ap.add_argument("--url", required = True)
     ap.add_argument("--dest", required = True, help = "file path to write")
     ap.add_argument("--expect-sha256", default = "")
-    ap.add_argument("--zip-member", default = "",
-                    help = "extract this member from the download and write IT to --dest")
+    ap.add_argument(
+        "--zip-member",
+        default = "",
+        help = "extract this member from the download and write IT to --dest",
+    )
     ap.add_argument("--out", default = "")
     a = ap.parse_args()
 

--- a/strix_halo_repro/fetch_llamacpp.py
+++ b/strix_halo_repro/fetch_llamacpp.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""Fetch one llama.cpp release archive and locate its llama-server.
+
+Downloads, extracts, finds the directory holding `llama-server` (tarballs and
+zips nest differently between tags), restores the executable bit, records
+`--version`, and writes a JSON report for `emit_bin_env.py`.
+
+  python amd_ci/lib/fetch_llamacpp.py \\
+      --url https://github.com/unslothai/llama.cpp/releases/download/TAG/app-TAG-linux-x64-vulkan.tar.gz \\
+      --dest "$AMD_CI_WORK/lcpp/vulkan_head" --out "$AMD_CI_WORK/out/bin_vulkan_head.json"
+
+A missing binary exits 1: a setup failure, not a finding.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tarfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+MARKER = "llama-server"
+MARKERS = ("llama-server", "llama-server.exe")
+
+
+def download(url: str, dest: Path) -> Path:
+    dest.parent.mkdir(parents = True, exist_ok = True)
+    with urllib.request.urlopen(url, timeout = 600) as r, open(dest, "wb") as fh:
+        shutil.copyfileobj(r, fh)
+    return dest
+
+
+def extract(archive: Path, into: Path) -> None:
+    into.mkdir(parents = True, exist_ok = True)
+    if archive.name.endswith((".tar.gz", ".tgz")):
+        with tarfile.open(archive, encoding = "utf-8") as tf:
+            # `filter` became required-in-practice in 3.12 and defaults to
+            # rejecting in 3.14; passing it explicitly keeps one code path.
+            if sys.version_info >= (3, 12):
+                tf.extractall(into, filter = "data")
+            else:
+                tf.extractall(into)  # noqa: S202 - trusted release artifacts
+    elif archive.name.endswith(".zip"):
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(into)  # noqa: S202
+    else:
+        raise SystemExit(f"unknown archive type: {archive.name}")
+
+
+def find_bin_dir(root: Path) -> Path | None:
+    """The directory holding llama-server, shallowest first."""
+    hits = sorted((h for m in MARKERS for h in root.rglob(m)), key = lambda p: len(p.parts))
+    for h in hits:
+        if h.is_file():
+            return h.parent
+    return None
+
+def server_path(bin_dir: Path) -> Path:
+    for m in MARKERS:
+        if (bin_dir / m).is_file():
+            return bin_dir / m
+    return bin_dir / MARKER
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required = True)
+    ap.add_argument("--dest", required = True, type = Path,
+                    help = "directory to extract into")
+    ap.add_argument("--out", type = Path, default = None)
+    args = ap.parse_args()
+
+    info: dict = {"url": args.url, "dest": str(args.dest)}
+    archive = args.dest.parent / args.url.rsplit("/", 1)[-1]
+    try:
+        download(args.url, archive)
+        info["archive_bytes"] = archive.stat().st_size
+        extract(archive, args.dest)
+        archive.unlink(missing_ok = True)
+    except Exception as e:  # noqa: BLE001
+        info["error"] = f"{type(e).__name__}: {e}"
+
+    bin_dir = find_bin_dir(args.dest) if args.dest.is_dir() else None
+    info["bin_dir"] = str(bin_dir) if bin_dir else None
+    if bin_dir:
+        # The release archives do not always carry the executable bit through,
+        # and a non-executable llama-server reads downstream as "no binary".
+        for f in bin_dir.iterdir():
+            if f.is_file() and (f.name.startswith("llama-") or f.name.startswith("test-")):
+                f.chmod(f.stat().st_mode | 0o111)
+        info["binaries"] = sorted(p.name for p in bin_dir.iterdir()
+                                  if p.is_file() and p.name.startswith(("llama-", "test-")))
+        info["has_test_backend_ops"] = (bin_dir / "test-backend-ops").is_file()
+        env = {"LD_LIBRARY_PATH": str(bin_dir)}
+        try:
+            p = subprocess.run([str(server_path(bin_dir)), "--version"], capture_output = True,
+                               text = True, timeout = 300, env = env)
+            info["version"] = ((p.stdout or "") + (p.stderr or "")).strip()[:400]
+        except Exception as e:  # noqa: BLE001
+            info["version_error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(info, indent = 2))
+    if args.out:
+        args.out.parent.mkdir(parents = True, exist_ok = True)
+        args.out.write_text(json.dumps(info, indent = 2), encoding = "utf-8")
+    # A missing binary is a setup failure, not a finding: fail loudly here rather
+    # than letting every downstream probe report "no llama-server".
+    return 0 if bin_dir else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/strix_halo_repro/fetch_llamacpp.py
+++ b/strix_halo_repro/fetch_llamacpp.py
@@ -62,6 +62,7 @@ def find_bin_dir(root: Path) -> Path | None:
             return h.parent
     return None
 
+
 def server_path(bin_dir: Path) -> Path:
     for m in MARKERS:
         if (bin_dir / m).is_file():
@@ -72,8 +73,7 @@ def server_path(bin_dir: Path) -> Path:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--url", required = True)
-    ap.add_argument("--dest", required = True, type = Path,
-                    help = "directory to extract into")
+    ap.add_argument("--dest", required = True, type = Path, help = "directory to extract into")
     ap.add_argument("--out", type = Path, default = None)
     args = ap.parse_args()
 
@@ -95,13 +95,21 @@ def main() -> int:
         for f in bin_dir.iterdir():
             if f.is_file() and (f.name.startswith("llama-") or f.name.startswith("test-")):
                 f.chmod(f.stat().st_mode | 0o111)
-        info["binaries"] = sorted(p.name for p in bin_dir.iterdir()
-                                  if p.is_file() and p.name.startswith(("llama-", "test-")))
+        info["binaries"] = sorted(
+            p.name
+            for p in bin_dir.iterdir()
+            if p.is_file() and p.name.startswith(("llama-", "test-"))
+        )
         info["has_test_backend_ops"] = (bin_dir / "test-backend-ops").is_file()
         env = {"LD_LIBRARY_PATH": str(bin_dir)}
         try:
-            p = subprocess.run([str(server_path(bin_dir)), "--version"], capture_output = True,
-                               text = True, timeout = 300, env = env)
+            p = subprocess.run(
+                [str(server_path(bin_dir)), "--version"],
+                capture_output = True,
+                text = True,
+                timeout = 300,
+                env = env,
+            )
             info["version"] = ((p.stdout or "") + (p.stderr or "")).strip()[:400]
         except Exception as e:  # noqa: BLE001
             info["version_error"] = f"{type(e).__name__}: {e}"

--- a/strix_halo_repro/probe.py
+++ b/strix_halo_repro/probe.py
@@ -1,0 +1,829 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""Probe: what does every layer report as this GPU's memory, and how big a single
+allocation does the HIP runtime actually allow?
+
+Five independent readings of the same machine, so a number can be attributed to
+the layer that produced it rather than to "the GPU":
+
+  host         the OS: physical RAM, the per-adapter VRAM the registry records
+               (Windows `HardwareInformation.qwMemorySize`, which is 64-bit;
+               WMI `AdapterRAM` is uint32 and saturates at 4 GiB, so it is
+               collected only as the trap it is), page file.
+  hip          amdhip64_7.dll: hipMemGetInfo, hipDeviceTotalMem, runtime and
+               driver versions, and the module path Windows actually loaded.
+  vulkan_raw   vulkan-1.dll: every memory heap of every physical device, its
+               flags, and its VK_EXT_memory_budget budget/usage when supported.
+  ggml_vulkan  ggml_backend_vk_get_device_memory, i.e. the number llama.cpp and
+               Unsloth Studio see. Run in a child process: a Vulkan instance in
+               the reporting process would outlive the reading.
+  fit          llama-server --list-devices and llama-fit-params, i.e. what the
+               loader believes it may place.
+
+  alloc_cap    the largest single hipMalloc that also memsets and reads back,
+               found by bisection with one fresh process per candidate. This is
+               the only reading that measures the allocator rather than asking
+               it, which matters because hipMemGetInfo cannot express a cap that
+               is a constant rather than a measurement (ROCm/rocm-systems#10974
+               clamps maxAllocSize_ at 64 GiB on stock PAL).
+
+Standard library only: the Windows runners have the system Python and no venv.
+Every section is independent, and a section that fails records why instead of
+reporting a plausible zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+GIB = 1024 ** 3
+IS_WIN = os.name == "nt"
+
+# hipMemcpyKind; stable across every HIP release.
+HIP_MEMCPY_DEVICE_TO_HOST = 2
+
+
+# --------------------------------------------------------------------------- utils
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def file_version(path: Path) -> str:
+    """PE FileVersion, so a swapped DLL is identified by more than its size."""
+    if not IS_WIN:
+        return ""
+    try:
+        size = ctypes.windll.version.GetFileVersionInfoSizeW(str(path), None)
+        if not size:
+            return ""
+        buf = ctypes.create_string_buffer(size)
+        ctypes.windll.version.GetFileVersionInfoW(str(path), 0, size, buf)
+        block = ctypes.c_void_p()
+        length = ctypes.c_uint()
+        if not ctypes.windll.version.VerQueryValueW(
+                buf, "\\", ctypes.byref(block), ctypes.byref(length)):
+            return ""
+        ffi = ctypes.cast(block, ctypes.POINTER(ctypes.c_uint32 * 13)).contents
+        ms, ls = ffi[2], ffi[3]
+        return f"{ms >> 16}.{ms & 0xFFFF}.{ls >> 16}.{ls & 0xFFFF}"
+    except Exception as e:  # noqa: BLE001
+        return f"<{type(e).__name__}>"
+
+
+def describe_file(path: Path) -> dict:
+    try:
+        st = path.stat()
+        return {"path": str(path), "bytes": st.st_size, "sha256": sha256(path),
+                "file_version": file_version(path)}
+    except Exception as e:  # noqa: BLE001
+        return {"path": str(path), "error": f"{type(e).__name__}: {e}"}
+
+
+def loaded_module_path(handle: int) -> str:
+    """Where Windows actually found the DLL. Putting a file next to the exe is a
+    request, not a guarantee: the loader may already hold another copy."""
+    if not IS_WIN:
+        return ""
+    try:
+        buf = ctypes.create_unicode_buffer(32768)
+        n = ctypes.windll.kernel32.GetModuleFileNameW(ctypes.c_void_p(handle), buf, 32768)
+        return buf.value if n else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def find_lib(directory: Path, stem: str) -> Path | None:
+    exact = directory / stem
+    if exact.is_file():
+        return exact
+    try:
+        for entry in sorted(os.listdir(directory)):
+            if entry.startswith(stem + "."):
+                return directory / entry
+    except OSError:
+        pass
+    return None
+
+
+def run(cmd: list[str], timeout: int = 300, env: dict | None = None) -> dict:
+    try:
+        r = subprocess.run(cmd, capture_output = True, text = True, timeout = timeout,
+                           encoding = "utf-8", errors = "replace", env = env)
+        return {"cmd": cmd, "rc": r.returncode,
+                "stdout": r.stdout[-20000:], "stderr": r.stderr[-8000:]}
+    except Exception as e:  # noqa: BLE001
+        return {"cmd": cmd, "error": f"{type(e).__name__}: {e}"}
+
+
+# --------------------------------------------------------------------------- host
+
+class MEMORYSTATUSEX(ctypes.Structure):
+    _fields_ = [("dwLength", ctypes.c_uint32), ("dwMemoryLoad", ctypes.c_uint32),
+                ("ullTotalPhys", ctypes.c_uint64), ("ullAvailPhys", ctypes.c_uint64),
+                ("ullTotalPageFile", ctypes.c_uint64), ("ullAvailPageFile", ctypes.c_uint64),
+                ("ullTotalVirtual", ctypes.c_uint64), ("ullAvailVirtual", ctypes.c_uint64),
+                ("ullAvailExtendedVirtual", ctypes.c_uint64)]
+
+
+def read_host() -> dict:
+    out: dict = {"platform": platform.platform(), "python": sys.version.split()[0]}
+    if IS_WIN:
+        st = MEMORYSTATUSEX()
+        st.dwLength = ctypes.sizeof(st)
+        ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(st))
+        out["total_phys_bytes"] = int(st.ullTotalPhys)
+        out["avail_phys_bytes"] = int(st.ullAvailPhys)
+        out["total_pagefile_bytes"] = int(st.ullTotalPageFile)
+        out["adapters"] = read_windows_adapters()
+        # AdapterRAM is uint32 and cannot express more than 4 GiB. Recorded to
+        # show the trap, never used as a capacity.
+        out["wmi_adapter_ram_trap"] = run(
+            ["powershell", "-NoProfile", "-Command",
+             "Get-CimInstance Win32_VideoController | "
+             "Select-Object Name,AdapterRAM,DriverVersion | ConvertTo-Json -Compress"], 120)
+    else:
+        try:
+            meminfo = Path("/proc/meminfo").read_text(encoding = "utf-8")
+            for line in meminfo.splitlines():
+                if line.startswith(("MemTotal", "MemAvailable")):
+                    k, v = line.split(":", 1)
+                    out[k.lower() + "_bytes"] = int(v.split()[0]) * 1024
+        except OSError as e:
+            out["meminfo_error"] = str(e)
+        out["rocminfo"] = run(["rocminfo"], 120)
+    return out
+
+
+def read_windows_adapters() -> list:
+    """Per-adapter VRAM from the driver's registry key. 64-bit, and readable
+    without administrator rights, which is what makes it usable here."""
+    import winreg  # noqa: PLC0415  (Windows-only)
+
+    base = r"SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}"
+    found = []
+    try:
+        key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, base)
+    except OSError as e:
+        return [{"error": f"{type(e).__name__}: {e}"}]
+    i = 0
+    while True:
+        try:
+            sub = winreg.EnumKey(key, i)
+        except OSError:
+            break
+        i += 1
+        if not sub.isdigit():
+            continue
+        row: dict = {"index": sub}
+        try:
+            with winreg.OpenKey(key, sub) as k:
+                for name, out_name in (("DriverDesc", "name"),
+                                       ("HardwareInformation.qwMemorySize", "qw_memory_size"),
+                                       ("HardwareInformation.MemorySize", "memory_size"),
+                                       ("DriverVersion", "driver_version")):
+                    try:
+                        value, kind = winreg.QueryValueEx(k, name)
+                    except OSError:
+                        continue
+                    if isinstance(value, bytes):
+                        value = int.from_bytes(value, "little")
+                    row[out_name] = value
+                    row[out_name + "_kind"] = kind
+        except OSError as e:
+            row["error"] = f"{type(e).__name__}: {e}"
+        if len(row) > 1:
+            found.append(row)
+    return found
+
+
+# --------------------------------------------------------------------------- HIP
+
+class Hip:
+    """The HIP runtime from one specific directory, with the loaded path proved."""
+
+    def __init__(self, hip_dir: Path | None):
+        self.dir = Path(hip_dir) if hip_dir else None
+        self._dll_dir = None
+        name = "amdhip64_7.dll" if IS_WIN else "libamdhip64.so"
+        path = None
+        if self.dir:
+            path = find_lib(self.dir, name)
+            if IS_WIN:
+                try:
+                    self._dll_dir = os.add_dll_directory(str(self.dir))
+                except Exception:  # noqa: BLE001
+                    pass
+        self.requested = str(path) if path else name
+        self.lib = ctypes.CDLL(self.requested)
+        self.loaded = loaded_module_path(self.lib._handle) or self.requested
+        for fn, argtypes in (
+                ("hipInit", [ctypes.c_uint]),
+                ("hipGetDeviceCount", [ctypes.POINTER(ctypes.c_int)]),
+                ("hipSetDevice", [ctypes.c_int]),
+                ("hipDeviceGetName", [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]),
+                ("hipDeviceTotalMem", [ctypes.POINTER(ctypes.c_size_t), ctypes.c_int]),
+                ("hipMemGetInfo", [ctypes.POINTER(ctypes.c_size_t),
+                                   ctypes.POINTER(ctypes.c_size_t)]),
+                ("hipRuntimeGetVersion", [ctypes.POINTER(ctypes.c_int)]),
+                ("hipDriverGetVersion", [ctypes.POINTER(ctypes.c_int)]),
+                ("hipMalloc", [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]),
+                ("hipFree", [ctypes.c_void_p]),
+                ("hipMemset", [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]),
+                ("hipMemcpy", [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]),
+                ("hipDeviceSynchronize", []),
+                ("hipGetLastError", []),
+        ):
+            f = getattr(self.lib, fn)
+            f.argtypes = argtypes
+            f.restype = ctypes.c_int
+        self.lib.hipGetErrorString.argtypes = [ctypes.c_int]
+        self.lib.hipGetErrorString.restype = ctypes.c_char_p
+
+    def err(self, code: int) -> str:
+        try:
+            return (self.lib.hipGetErrorString(code) or b"").decode("utf-8", "replace")
+        except Exception:  # noqa: BLE001
+            return f"hip error {code}"
+
+    def inventory(self) -> dict:
+        out: dict = {"requested_dll": self.requested, "loaded_dll": self.loaded,
+                     "dll": describe_file(Path(self.loaded)) if self.loaded else {}}
+        rc = self.lib.hipInit(0)
+        out["hipInit_rc"] = rc
+        if rc != 0:
+            out["error"] = self.err(rc)
+            return out
+        for fn, key in (("hipRuntimeGetVersion", "runtime_version"),
+                        ("hipDriverGetVersion", "driver_version")):
+            v = ctypes.c_int(0)
+            if getattr(self.lib, fn)(ctypes.byref(v)) == 0:
+                out[key] = v.value
+        n = ctypes.c_int(0)
+        self.lib.hipGetDeviceCount(ctypes.byref(n))
+        out["device_count"] = n.value
+        devices = []
+        for i in range(n.value):
+            d: dict = {"index": i}
+            self.lib.hipSetDevice(i)
+            buf = ctypes.create_string_buffer(256)
+            if self.lib.hipDeviceGetName(buf, 256, i) == 0:
+                d["name"] = buf.value.decode("utf-8", "replace")
+            total = ctypes.c_size_t(0)
+            if self.lib.hipDeviceTotalMem(ctypes.byref(total), i) == 0:
+                d["device_total_bytes"] = total.value
+            free_b, total_b = ctypes.c_size_t(0), ctypes.c_size_t(0)
+            rc = self.lib.hipMemGetInfo(ctypes.byref(free_b), ctypes.byref(total_b))
+            d["hipMemGetInfo_rc"] = rc
+            if rc == 0:
+                # On Windows this "free" counts only this process's allocations,
+                # so it is an optimistic ceiling, not machine-wide occupancy.
+                d["free_bytes"], d["total_bytes"] = free_b.value, total_b.value
+            devices.append(d)
+        out["devices"] = devices
+        return out
+
+    def try_alloc(self, nbytes: int, device: int = 0) -> dict:
+        """One allocation, written and read back. A hipMalloc that returns a
+        pointer nothing was ever stored in is not evidence the memory exists."""
+        res: dict = {"bytes": nbytes}
+        rc = self.lib.hipInit(0)
+        if rc != 0:
+            return {**res, "ok": False, "stage": "hipInit", "error": self.err(rc)}
+        rc = self.lib.hipSetDevice(device)
+        if rc != 0:
+            return {**res, "ok": False, "stage": "hipSetDevice", "error": self.err(rc)}
+        ptr = ctypes.c_void_p()
+        t0 = time.monotonic()
+        rc = self.lib.hipMalloc(ctypes.byref(ptr), ctypes.c_size_t(nbytes))
+        res["malloc_seconds"] = round(time.monotonic() - t0, 3)
+        if rc != 0 or not ptr:
+            return {**res, "ok": False, "stage": "hipMalloc", "rc": rc, "error": self.err(rc)}
+        try:
+            rc = self.lib.hipMemset(ptr, 0xA5, ctypes.c_size_t(nbytes))
+            if rc != 0:
+                return {**res, "ok": False, "stage": "hipMemset", "rc": rc, "error": self.err(rc)}
+            rc = self.lib.hipDeviceSynchronize()
+            if rc != 0:
+                return {**res, "ok": False, "stage": "hipDeviceSynchronize", "rc": rc,
+                        "error": self.err(rc)}
+            probe = ctypes.create_string_buffer(64)
+            for offset in (0, nbytes // 2, nbytes - 64):
+                src = ctypes.c_void_p(ptr.value + max(0, offset))
+                rc = self.lib.hipMemcpy(probe, src, 64, HIP_MEMCPY_DEVICE_TO_HOST)
+                if rc != 0:
+                    return {**res, "ok": False, "stage": f"hipMemcpy@{offset}", "rc": rc,
+                            "error": self.err(rc)}
+                if probe.raw[:64] != b"\xa5" * 64:
+                    return {**res, "ok": False, "stage": f"readback@{offset}",
+                            "error": "buffer did not read back as written"}
+            res["ok"] = True
+            free_b, total_b = ctypes.c_size_t(0), ctypes.c_size_t(0)
+            if self.lib.hipMemGetInfo(ctypes.byref(free_b), ctypes.byref(total_b)) == 0:
+                res["free_after_bytes"], res["total_after_bytes"] = free_b.value, total_b.value
+            return res
+        finally:
+            self.lib.hipFree(ptr)
+
+
+def read_hip(hip_dir: Path | None) -> dict:
+    return Hip(hip_dir).inventory()
+
+
+# --------------------------------------------------------------------------- Vulkan
+
+VK_MAX_MEMORY_TYPES = 32
+VK_MAX_MEMORY_HEAPS = 16
+VK_MAX_EXTENSION_NAME_SIZE = 256
+VK_STRUCTURE_TYPE_APPLICATION_INFO = 0
+VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1
+VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2 = 1000059006
+VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT = 1000237000
+VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = 0x1
+VK_MEMORY_HEAP_MULTI_INSTANCE_BIT = 0x2
+VK_DEVICE_TYPES = {0: "other", 1: "integrated", 2: "discrete", 3: "virtual", 4: "cpu"}
+MEMORY_PROPERTY_BITS = [(0x1, "DEVICE_LOCAL"), (0x2, "HOST_VISIBLE"), (0x4, "HOST_COHERENT"),
+                        (0x8, "HOST_CACHED"), (0x10, "LAZILY_ALLOCATED"), (0x20, "PROTECTED")]
+
+
+class VkMemoryType(ctypes.Structure):
+    _fields_ = [("propertyFlags", ctypes.c_uint32), ("heapIndex", ctypes.c_uint32)]
+
+
+class VkMemoryHeap(ctypes.Structure):
+    _fields_ = [("size", ctypes.c_uint64), ("flags", ctypes.c_uint32)]
+
+
+class VkPhysicalDeviceMemoryProperties(ctypes.Structure):
+    _fields_ = [("memoryTypeCount", ctypes.c_uint32),
+                ("memoryTypes", VkMemoryType * VK_MAX_MEMORY_TYPES),
+                ("memoryHeapCount", ctypes.c_uint32),
+                ("memoryHeaps", VkMemoryHeap * VK_MAX_MEMORY_HEAPS)]
+
+
+class VkPhysicalDeviceMemoryProperties2(ctypes.Structure):
+    _fields_ = [("sType", ctypes.c_uint32), ("pNext", ctypes.c_void_p),
+                ("memoryProperties", VkPhysicalDeviceMemoryProperties)]
+
+
+class VkPhysicalDeviceMemoryBudgetPropertiesEXT(ctypes.Structure):
+    _fields_ = [("sType", ctypes.c_uint32), ("pNext", ctypes.c_void_p),
+                ("heapBudget", ctypes.c_uint64 * VK_MAX_MEMORY_HEAPS),
+                ("heapUsage", ctypes.c_uint64 * VK_MAX_MEMORY_HEAPS)]
+
+
+class VkPhysicalDeviceProperties(ctypes.Structure):
+    # Only the head is parsed; the tail is spare room for limits and sparse
+    # properties, which the driver writes and this probe does not read.
+    _fields_ = [("apiVersion", ctypes.c_uint32), ("driverVersion", ctypes.c_uint32),
+                ("vendorID", ctypes.c_uint32), ("deviceID", ctypes.c_uint32),
+                ("deviceType", ctypes.c_uint32), ("deviceName", ctypes.c_char * 256),
+                ("pipelineCacheUUID", ctypes.c_uint8 * 16), ("tail", ctypes.c_uint8 * 4096)]
+
+
+class VkExtensionProperties(ctypes.Structure):
+    _fields_ = [("extensionName", ctypes.c_char * VK_MAX_EXTENSION_NAME_SIZE),
+                ("specVersion", ctypes.c_uint32)]
+
+
+class VkApplicationInfo(ctypes.Structure):
+    _fields_ = [("sType", ctypes.c_uint32), ("pNext", ctypes.c_void_p),
+                ("pApplicationName", ctypes.c_char_p), ("applicationVersion", ctypes.c_uint32),
+                ("pEngineName", ctypes.c_char_p), ("engineVersion", ctypes.c_uint32),
+                ("apiVersion", ctypes.c_uint32)]
+
+
+class VkInstanceCreateInfo(ctypes.Structure):
+    _fields_ = [("sType", ctypes.c_uint32), ("pNext", ctypes.c_void_p),
+                ("flags", ctypes.c_uint32), ("pApplicationInfo", ctypes.c_void_p),
+                ("enabledLayerCount", ctypes.c_uint32), ("ppEnabledLayerNames", ctypes.c_void_p),
+                ("enabledExtensionCount", ctypes.c_uint32),
+                ("ppEnabledExtensionNames", ctypes.c_void_p)]
+
+
+def _flag_names(flags: int) -> list[str]:
+    return [name for bit, name in MEMORY_PROPERTY_BITS if flags & bit]
+
+
+def read_vulkan_raw() -> dict:
+    """Every heap of every physical device, from the loader directly.
+
+    This is the ground truth the ggml reading is compared against: on an
+    integrated part the same physical RAM is exposed through several
+    device-local heaps, so summing them counts it twice."""
+    lib_name = "vulkan-1.dll" if IS_WIN else "libvulkan.so.1"
+    vk = ctypes.CDLL(lib_name)
+    out: dict = {"library": loaded_module_path(vk._handle) or lib_name}
+
+    api_version = (1 << 22) | (1 << 12)  # 1.1: memory properties 2 is core there
+    try:
+        vk.vkEnumerateInstanceVersion.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
+        vk.vkEnumerateInstanceVersion.restype = ctypes.c_int
+        v = ctypes.c_uint32(0)
+        if vk.vkEnumerateInstanceVersion(ctypes.byref(v)) == 0:
+            out["loader_api_version"] = f"{v.value >> 22}.{(v.value >> 12) & 0x3FF}.{v.value & 0xFFF}"
+            api_version = min(api_version, v.value)
+    except AttributeError:
+        out["loader_api_version"] = "1.0"
+
+    app = VkApplicationInfo(sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+                            pApplicationName = b"amd_ci_memory_report",
+                            pEngineName = b"amd_ci", apiVersion = api_version)
+    ci = VkInstanceCreateInfo(sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+                              pApplicationInfo = ctypes.cast(ctypes.byref(app), ctypes.c_void_p))
+    vk.vkCreateInstance.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                    ctypes.POINTER(ctypes.c_void_p)]
+    vk.vkCreateInstance.restype = ctypes.c_int
+    inst = ctypes.c_void_p()
+    rc = vk.vkCreateInstance(ctypes.byref(ci), None, ctypes.byref(inst))
+    if rc != 0:
+        out["error"] = f"vkCreateInstance rc={rc}"
+        return out
+
+    try:
+        vk.vkEnumeratePhysicalDevices.argtypes = [ctypes.c_void_p,
+                                                  ctypes.POINTER(ctypes.c_uint32),
+                                                  ctypes.POINTER(ctypes.c_void_p)]
+        vk.vkEnumeratePhysicalDevices.restype = ctypes.c_int
+        count = ctypes.c_uint32(0)
+        vk.vkEnumeratePhysicalDevices(inst, ctypes.byref(count), None)
+        devices = (ctypes.c_void_p * max(1, count.value))()
+        vk.vkEnumeratePhysicalDevices(inst, ctypes.byref(count), devices)
+
+        vk.vkGetPhysicalDeviceProperties.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        vk.vkGetPhysicalDeviceProperties.restype = None
+        vk.vkGetPhysicalDeviceMemoryProperties.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        vk.vkGetPhysicalDeviceMemoryProperties.restype = None
+        vk.vkEnumerateDeviceExtensionProperties.argtypes = [
+            ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_uint32), ctypes.c_void_p]
+        vk.vkEnumerateDeviceExtensionProperties.restype = ctypes.c_int
+        mem2 = _memory_properties2(vk, inst)
+
+        rows = []
+        for i in range(count.value):
+            pd = devices[i]
+            props = VkPhysicalDeviceProperties()
+            vk.vkGetPhysicalDeviceProperties(pd, ctypes.byref(props))
+            ext_count = ctypes.c_uint32(0)
+            vk.vkEnumerateDeviceExtensionProperties(pd, None, ctypes.byref(ext_count), None)
+            exts = (VkExtensionProperties * max(1, ext_count.value))()
+            vk.vkEnumerateDeviceExtensionProperties(pd, None, ctypes.byref(ext_count), exts)
+            names = {e.extensionName.decode("utf-8", "replace") for e in exts[:ext_count.value]}
+            has_budget = "VK_EXT_memory_budget" in names
+
+            budget = VkPhysicalDeviceMemoryBudgetPropertiesEXT(
+                sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT)
+            mp2 = VkPhysicalDeviceMemoryProperties2(
+                sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2,
+                pNext = ctypes.cast(ctypes.byref(budget), ctypes.c_void_p) if (
+                    has_budget and mem2) else None)
+            if mem2:
+                mem2(pd, ctypes.byref(mp2))
+                mp = mp2.memoryProperties
+            else:
+                mp = VkPhysicalDeviceMemoryProperties()
+                vk.vkGetPhysicalDeviceMemoryProperties(pd, ctypes.byref(mp))
+
+            heaps = []
+            for h in range(mp.memoryHeapCount):
+                row = {"index": h, "size_bytes": int(mp.memoryHeaps[h].size),
+                       "flags": int(mp.memoryHeaps[h].flags),
+                       "device_local": bool(mp.memoryHeaps[h].flags
+                                            & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT),
+                       "multi_instance": bool(mp.memoryHeaps[h].flags
+                                              & VK_MEMORY_HEAP_MULTI_INSTANCE_BIT)}
+                if has_budget and mem2:
+                    row["budget_bytes"] = int(budget.heapBudget[h])
+                    row["usage_bytes"] = int(budget.heapUsage[h])
+                heaps.append(row)
+            types = [{"index": t, "heap": int(mp.memoryTypes[t].heapIndex),
+                      "flags": int(mp.memoryTypes[t].propertyFlags),
+                      "names": _flag_names(int(mp.memoryTypes[t].propertyFlags))}
+                     for t in range(mp.memoryTypeCount)]
+            local = [h["size_bytes"] for h in heaps if h["device_local"]]
+            rows.append({
+                "index": i,
+                "name": props.deviceName.decode("utf-8", "replace"),
+                "type": VK_DEVICE_TYPES.get(int(props.deviceType), int(props.deviceType)),
+                "vendor_id": hex(int(props.vendorID)), "device_id": hex(int(props.deviceID)),
+                "api_version": f"{props.apiVersion >> 22}.{(props.apiVersion >> 12) & 0x3FF}"
+                               f".{props.apiVersion & 0xFFF}",
+                "driver_version": int(props.driverVersion),
+                "memory_budget_ext": has_budget,
+                "heaps": heaps, "memory_types": types,
+                # The two candidate readings, side by side, so the over-report is
+                # visible without recomputing anything downstream.
+                "device_local_sum_bytes": sum(local),
+                "device_local_max_bytes": max(local) if local else 0,
+                "all_heaps_sum_bytes": sum(h["size_bytes"] for h in heaps),
+            })
+        out["devices"] = rows
+    finally:
+        try:
+            vk.vkDestroyInstance.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+            vk.vkDestroyInstance(inst, None)
+        except Exception:  # noqa: BLE001
+            pass
+    return out
+
+
+def _memory_properties2(vk, inst):
+    """vkGetPhysicalDeviceMemoryProperties2, statically or through the loader."""
+    for name in ("vkGetPhysicalDeviceMemoryProperties2",
+                 "vkGetPhysicalDeviceMemoryProperties2KHR"):
+        try:
+            fn = getattr(vk, name)
+            fn.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+            fn.restype = None
+            return fn
+        except AttributeError:
+            pass
+    try:
+        vk.vkGetInstanceProcAddr.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        vk.vkGetInstanceProcAddr.restype = ctypes.c_void_p
+        for name in (b"vkGetPhysicalDeviceMemoryProperties2",
+                     b"vkGetPhysicalDeviceMemoryProperties2KHR"):
+            addr = vk.vkGetInstanceProcAddr(inst, name)
+            if addr:
+                proto = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p)
+                return proto(addr)
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+# ------------------------------------------------------------------- ggml Vulkan
+
+def read_ggml_vulkan(bin_dir: Path) -> dict:
+    """What ggml reports, which is what llama.cpp and Studio place against.
+
+    Same load path as Studio's own `_vulkan_probe.py`, in a child process, so a
+    driver that dies taking its instance with it does not take the rest of the
+    report."""
+    r = run([sys.executable, str(Path(__file__).resolve()), "--ggml-vulkan-only", str(bin_dir)],
+            300)
+    out: dict = {"bin_dir": str(bin_dir), "rc": r.get("rc"), "stderr": r.get("stderr", "")}
+    if r.get("rc") != 0:
+        # A directory without the Vulkan backend is a wrong argument, not a
+        # machine with no Vulkan memory; say so instead of returning no devices.
+        raise RuntimeError(f"ggml Vulkan child rc={r.get('rc')}: "
+                           f"{(r.get('stderr') or '').strip()[:300]}")
+    try:
+        out["devices"] = json.loads(r.get("stdout") or "[]")
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"unparsable ggml Vulkan child output: {e}") from e
+    return out
+
+
+def ggml_vulkan_child(bin_dir: str) -> int:
+    base_name = "ggml-base.dll" if IS_WIN else "libggml-base.so"
+    vk_name = "ggml-vulkan.dll" if IS_WIN else "libggml-vulkan.so"
+    directory = Path(bin_dir)
+    if IS_WIN:
+        try:
+            os.add_dll_directory(bin_dir)
+        except Exception:  # noqa: BLE001
+            pass
+    base_path, vk_path = find_lib(directory, base_name), find_lib(directory, vk_name)
+    if not base_path or not vk_path:
+        print(f"ggml vulkan libraries not found in {bin_dir}", file = sys.stderr)
+        return 1
+    mode = getattr(ctypes, "RTLD_GLOBAL", 0)
+    base = ctypes.CDLL(str(base_path), mode = mode)
+    lib = ctypes.CDLL(str(vk_path), mode = mode)
+    lib.ggml_backend_vk_get_device_count.restype = ctypes.c_int
+    lib.ggml_backend_vk_get_device_memory.argtypes = [
+        ctypes.c_int, ctypes.POINTER(ctypes.c_size_t), ctypes.POINTER(ctypes.c_size_t)]
+    lib.ggml_backend_vk_get_device_memory.restype = None
+    count = lib.ggml_backend_vk_get_device_count()
+
+    types: dict[int, int] = {}
+    names: dict[int, str] = {}
+    try:
+        lib.ggml_backend_vk_reg.restype = ctypes.c_void_p
+        base.ggml_backend_reg_dev_count.argtypes = [ctypes.c_void_p]
+        base.ggml_backend_reg_dev_count.restype = ctypes.c_size_t
+        base.ggml_backend_reg_dev_get.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+        base.ggml_backend_reg_dev_get.restype = ctypes.c_void_p
+        base.ggml_backend_dev_type.argtypes = [ctypes.c_void_p]
+        base.ggml_backend_dev_type.restype = ctypes.c_int
+        base.ggml_backend_dev_description.argtypes = [ctypes.c_void_p]
+        base.ggml_backend_dev_description.restype = ctypes.c_char_p
+        reg = lib.ggml_backend_vk_reg()
+        for i in range(min(count, base.ggml_backend_reg_dev_count(reg))):
+            dev = base.ggml_backend_reg_dev_get(reg, i)
+            types[i] = base.ggml_backend_dev_type(dev)
+            names[i] = (base.ggml_backend_dev_description(dev) or b"").decode("utf-8", "replace")
+    except Exception:  # noqa: BLE001
+        pass
+
+    rows = []
+    for i in range(count):
+        free_b, total_b = ctypes.c_size_t(0), ctypes.c_size_t(0)
+        lib.ggml_backend_vk_get_device_memory(i, ctypes.byref(free_b), ctypes.byref(total_b))
+        rows.append({"index": i, "free_bytes": free_b.value, "total_bytes": total_b.value,
+                     "ggml_dev_type": types.get(i), "is_igpu": types.get(i) == 2,
+                     "name": names.get(i, "")})
+    print(json.dumps(rows))
+    return 0
+
+
+# --------------------------------------------------------------------------- fit
+
+def read_fit(bin_dir: Path, model: str | None, env_extra: dict | None = None) -> dict:
+    exe = ".exe" if IS_WIN else ""
+    env = dict(os.environ)
+    if not IS_WIN:
+        env["LD_LIBRARY_PATH"] = f"{bin_dir}{os.pathsep}" + env.get("LD_LIBRARY_PATH", "")
+    env.update(env_extra or {})
+    out: dict = {"bin_dir": str(bin_dir)}
+    server = bin_dir / f"llama-server{exe}"
+    out["version"] = run([str(server), "--version"], 120, env)
+    out["list_devices"] = run([str(server), "--list-devices"], 300, env)
+    fit = bin_dir / f"llama-fit-params{exe}"
+    if model and fit.is_file():
+        out["fit_params"] = run([str(fit), "-m", model, "-ngl", "999", "-c", "8192"], 900, env)
+    return out
+
+
+# ----------------------------------------------------------------- allocation cap
+
+def alloc_once_subprocess(hip_dir: Path | None, nbytes: int, device: int,
+                          timeout: int = 900, settle: float = 2.0) -> dict:
+    """One candidate, one process. HIP's Windows free-memory accounting is
+    process-scoped, so a stale allocator state would otherwise leak between
+    candidates and turn a cap into a fragmentation measurement."""
+    cmd = [sys.executable, str(Path(__file__).resolve()), "--try-alloc", str(nbytes),
+           "--alloc-device", str(device)]
+    if hip_dir:
+        cmd += ["--hip-dir", str(hip_dir)]
+    r = run(cmd, timeout)
+    # Let the driver hand the pages back before the next candidate asks for them,
+    # so a refusal is the cap rather than the previous attempt still unwinding.
+    time.sleep(settle)
+    try:
+        return json.loads((r.get("stdout") or "").strip().splitlines()[-1])
+    except Exception:  # noqa: BLE001
+        return {"bytes": nbytes, "ok": False, "stage": "child",
+                "error": f"rc={r.get('rc')} {(r.get('stderr') or '')[-400:]}"}
+
+
+def read_alloc_cap(hip_dir: Path | None, lo_gib: float, hi_gib: float,
+                   reps: int, device: int, resolution_gib: float,
+                   attempt_timeout: int = 900) -> dict:
+    """Bisect for the largest allocation that succeeds and reads back.
+
+    Ascending and descending confirmation around the boundary, because an
+    allocator with hysteresis or fragmentation gives different answers depending
+    on the order candidates are tried, and one pass cannot tell the two apart."""
+    attempts: list[dict] = []
+
+    def attempt(gib: float) -> bool:
+        res = alloc_once_subprocess(hip_dir, int(gib * GIB), device, attempt_timeout)
+        res["gib"] = round(gib, 3)
+        attempts.append(res)
+        return bool(res.get("ok"))
+
+    out: dict = {"hip_dir": str(hip_dir) if hip_dir else None, "device": device,
+                 "search_lo_gib": lo_gib, "search_hi_gib": hi_gib,
+                 "resolution_gib": resolution_gib, "attempt_timeout_s": attempt_timeout}
+    if not attempt(lo_gib):
+        out["error"] = (f"the {lo_gib} GiB floor already fails, so there is no interval to "
+                        f"bisect; this is a broken runtime, not a cap")
+        out["attempts"] = attempts
+        return out
+    if attempt(hi_gib):
+        out["max_ok_gib"] = hi_gib
+        out["capped"] = False
+        out["note"] = "the ceiling itself succeeded: the cap is above the search range"
+        out["attempts"] = attempts
+        return out
+
+    lo, hi = lo_gib, hi_gib  # lo known good, hi known bad
+    while hi - lo > resolution_gib:
+        mid = (lo + hi) / 2
+        if attempt(mid):
+            lo = mid
+        else:
+            hi = mid
+    out["max_ok_gib"] = round(lo, 3)
+    out["min_fail_gib"] = round(hi, 3)
+    out["capped"] = True
+
+    # Confirmation: the boundary must reproduce from both directions.
+    conf = {"below_ok": [], "above_fail": []}
+    for _ in range(max(0, reps)):
+        conf["below_ok"].append(attempt(lo))
+        conf["above_fail"].append(not attempt(hi))
+    out["confirmation"] = conf
+    out["boundary_stable"] = all(conf["below_ok"]) and all(conf["above_fail"])
+    out["attempts"] = attempts
+    return out
+
+
+# --------------------------------------------------------------------------- main
+
+SECTIONS = ("host", "hip", "vulkan_raw", "ggml_vulkan", "fit", "alloc_cap")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--state", default = "solo")
+    ap.add_argument("--checkout", default = "", help = "directory holding the llama.cpp binaries")
+    ap.add_argument("--out", default = "")
+    ap.add_argument("--hip-dir", default = "",
+                    help = "directory whose amdhip64_7.dll is loaded; defaults to --checkout")
+    ap.add_argument("--vulkan-dir", default = "",
+                    help = "directory holding ggml-vulkan (the vulkan release)")
+    ap.add_argument("--fit-model", default = "")
+    ap.add_argument("--sections", default = "host,hip,vulkan_raw,ggml_vulkan,fit")
+    ap.add_argument("--alloc-lo-gib", type = float, default = 1.0)
+    ap.add_argument("--alloc-hi-gib", type = float, default = 200.0)
+    ap.add_argument("--alloc-resolution-gib", type = float, default = 0.5)
+    ap.add_argument("--alloc-reps", type = int, default = 2)
+    ap.add_argument("--alloc-device", type = int, default = 0)
+    ap.add_argument("--alloc-attempt-timeout", type = int, default = 900,
+                    help = "seconds one candidate allocation may take before it is a failure")
+    ap.add_argument("--try-alloc", type = int, default = 0,
+                    help = "internal: attempt one allocation and print the JSON result")
+    ap.add_argument("--ggml-vulkan-only", default = "",
+                    help = "internal: print the ggml Vulkan inventory of this directory")
+    a = ap.parse_args()
+
+    if a.ggml_vulkan_only:
+        return ggml_vulkan_child(a.ggml_vulkan_only)
+    if a.try_alloc:
+        hip_dir = Path(a.hip_dir) if a.hip_dir else None
+        try:
+            res = Hip(hip_dir).try_alloc(a.try_alloc, a.alloc_device)
+        except Exception as e:  # noqa: BLE001
+            res = {"bytes": a.try_alloc, "ok": False, "stage": "load",
+                   "error": f"{type(e).__name__}: {e}"}
+        print(json.dumps(res))
+        return 0 if res.get("ok") else 3
+
+    checkout = Path(a.checkout) if a.checkout else None
+    hip_dir = Path(a.hip_dir) if a.hip_dir else checkout
+    vulkan_dir = Path(a.vulkan_dir) if a.vulkan_dir else None
+    wanted = [s.strip() for s in a.sections.split(",") if s.strip()]
+    unknown = [s for s in wanted if s not in SECTIONS]
+    if unknown:
+        raise SystemExit(f"unknown section(s) {unknown}; choose from {list(SECTIONS)}")
+
+    res: dict = {"state": a.state, "checkout": a.checkout, "hip_dir": str(hip_dir or ""),
+                 "vulkan_dir": a.vulkan_dir, "sections_requested": wanted,
+                 "platform": platform.platform(), "sections": {}, "errors": {}}
+    if hip_dir:
+        name = "amdhip64_7.dll" if IS_WIN else "libamdhip64.so"
+        found = find_lib(hip_dir, name)
+        res["hip_dll_file"] = describe_file(found) if found else {"error": f"{name} not in {hip_dir}"}
+
+    todo = {
+        "host": lambda: read_host(),
+        "hip": lambda: read_hip(hip_dir),
+        "vulkan_raw": lambda: read_vulkan_raw(),
+        "ggml_vulkan": lambda: read_ggml_vulkan(vulkan_dir or checkout),
+        "fit": lambda: read_fit(checkout, a.fit_model or None),
+        "alloc_cap": lambda: read_alloc_cap(hip_dir, a.alloc_lo_gib, a.alloc_hi_gib,
+                                            a.alloc_reps, a.alloc_device, a.alloc_resolution_gib,
+                                            a.alloc_attempt_timeout),
+    }
+    for name in wanted:
+        if name in ("ggml_vulkan", "fit") and not (vulkan_dir or checkout):
+            res["errors"][name] = "no --checkout or --vulkan-dir given"
+            continue
+        t0 = time.monotonic()
+        try:
+            res["sections"][name] = todo[name]()
+        except Exception as e:  # noqa: BLE001
+            res["errors"][name] = f"{type(e).__name__}: {e}"
+        print(f"== {name}: {round(time.monotonic() - t0, 1)}s"
+              f"{' ERROR ' + res['errors'][name] if name in res['errors'] else ''}", flush = True)
+
+    res["ok"] = not res["errors"]
+    text = json.dumps(res, indent = 2)
+    if a.out:
+        Path(a.out).parent.mkdir(parents = True, exist_ok = True)
+        Path(a.out).write_text(text, encoding = "utf-8")
+        print(json.dumps({k: v for k, v in res.items() if k != "sections"}, indent = 2))
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/strix_halo_repro/probe.py
+++ b/strix_halo_repro/probe.py
@@ -46,7 +46,7 @@ import sys
 import time
 from pathlib import Path
 
-GIB = 1024 ** 3
+GIB = 1024**3
 IS_WIN = os.name == "nt"
 
 # hipMemcpyKind; stable across every HIP release.
@@ -54,6 +54,7 @@ HIP_MEMCPY_DEVICE_TO_HOST = 2
 
 
 # --------------------------------------------------------------------------- utils
+
 
 def sha256(path: Path) -> str:
     h = hashlib.sha256()
@@ -76,7 +77,8 @@ def file_version(path: Path) -> str:
         block = ctypes.c_void_p()
         length = ctypes.c_uint()
         if not ctypes.windll.version.VerQueryValueW(
-                buf, "\\", ctypes.byref(block), ctypes.byref(length)):
+            buf, "\\", ctypes.byref(block), ctypes.byref(length)
+        ):
             return ""
         ffi = ctypes.cast(block, ctypes.POINTER(ctypes.c_uint32 * 13)).contents
         ms, ls = ffi[2], ffi[3]
@@ -88,8 +90,12 @@ def file_version(path: Path) -> str:
 def describe_file(path: Path) -> dict:
     try:
         st = path.stat()
-        return {"path": str(path), "bytes": st.st_size, "sha256": sha256(path),
-                "file_version": file_version(path)}
+        return {
+            "path": str(path),
+            "bytes": st.st_size,
+            "sha256": sha256(path),
+            "file_version": file_version(path),
+        }
     except Exception as e:  # noqa: BLE001
         return {"path": str(path), "error": f"{type(e).__name__}: {e}"}
 
@@ -120,24 +126,46 @@ def find_lib(directory: Path, stem: str) -> Path | None:
     return None
 
 
-def run(cmd: list[str], timeout: int = 300, env: dict | None = None) -> dict:
+def run(
+    cmd: list[str],
+    timeout: int = 300,
+    env: dict | None = None,
+) -> dict:
     try:
-        r = subprocess.run(cmd, capture_output = True, text = True, timeout = timeout,
-                           encoding = "utf-8", errors = "replace", env = env)
-        return {"cmd": cmd, "rc": r.returncode,
-                "stdout": r.stdout[-20000:], "stderr": r.stderr[-8000:]}
+        r = subprocess.run(
+            cmd,
+            capture_output = True,
+            text = True,
+            timeout = timeout,
+            encoding = "utf-8",
+            errors = "replace",
+            env = env,
+        )
+        return {
+            "cmd": cmd,
+            "rc": r.returncode,
+            "stdout": r.stdout[-20000:],
+            "stderr": r.stderr[-8000:],
+        }
     except Exception as e:  # noqa: BLE001
         return {"cmd": cmd, "error": f"{type(e).__name__}: {e}"}
 
 
 # --------------------------------------------------------------------------- host
 
+
 class MEMORYSTATUSEX(ctypes.Structure):
-    _fields_ = [("dwLength", ctypes.c_uint32), ("dwMemoryLoad", ctypes.c_uint32),
-                ("ullTotalPhys", ctypes.c_uint64), ("ullAvailPhys", ctypes.c_uint64),
-                ("ullTotalPageFile", ctypes.c_uint64), ("ullAvailPageFile", ctypes.c_uint64),
-                ("ullTotalVirtual", ctypes.c_uint64), ("ullAvailVirtual", ctypes.c_uint64),
-                ("ullAvailExtendedVirtual", ctypes.c_uint64)]
+    _fields_ = [
+        ("dwLength", ctypes.c_uint32),
+        ("dwMemoryLoad", ctypes.c_uint32),
+        ("ullTotalPhys", ctypes.c_uint64),
+        ("ullAvailPhys", ctypes.c_uint64),
+        ("ullTotalPageFile", ctypes.c_uint64),
+        ("ullAvailPageFile", ctypes.c_uint64),
+        ("ullTotalVirtual", ctypes.c_uint64),
+        ("ullAvailVirtual", ctypes.c_uint64),
+        ("ullAvailExtendedVirtual", ctypes.c_uint64),
+    ]
 
 
 def read_host() -> dict:
@@ -153,9 +181,15 @@ def read_host() -> dict:
         # AdapterRAM is uint32 and cannot express more than 4 GiB. Recorded to
         # show the trap, never used as a capacity.
         out["wmi_adapter_ram_trap"] = run(
-            ["powershell", "-NoProfile", "-Command",
-             "Get-CimInstance Win32_VideoController | "
-             "Select-Object Name,AdapterRAM,DriverVersion | ConvertTo-Json -Compress"], 120)
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                "Get-CimInstance Win32_VideoController | "
+                "Select-Object Name,AdapterRAM,DriverVersion | ConvertTo-Json -Compress",
+            ],
+            120,
+        )
     else:
         try:
             meminfo = Path("/proc/meminfo").read_text(encoding = "utf-8")
@@ -192,10 +226,12 @@ def read_windows_adapters() -> list:
         row: dict = {"index": sub}
         try:
             with winreg.OpenKey(key, sub) as k:
-                for name, out_name in (("DriverDesc", "name"),
-                                       ("HardwareInformation.qwMemorySize", "qw_memory_size"),
-                                       ("HardwareInformation.MemorySize", "memory_size"),
-                                       ("DriverVersion", "driver_version")):
+                for name, out_name in (
+                    ("DriverDesc", "name"),
+                    ("HardwareInformation.qwMemorySize", "qw_memory_size"),
+                    ("HardwareInformation.MemorySize", "memory_size"),
+                    ("DriverVersion", "driver_version"),
+                ):
                     try:
                         value, kind = winreg.QueryValueEx(k, name)
                     except OSError:
@@ -212,6 +248,7 @@ def read_windows_adapters() -> list:
 
 
 # --------------------------------------------------------------------------- HIP
+
 
 class Hip:
     """The HIP runtime from one specific directory, with the loaded path proved."""
@@ -232,21 +269,20 @@ class Hip:
         self.lib = ctypes.CDLL(self.requested)
         self.loaded = loaded_module_path(self.lib._handle) or self.requested
         for fn, argtypes in (
-                ("hipInit", [ctypes.c_uint]),
-                ("hipGetDeviceCount", [ctypes.POINTER(ctypes.c_int)]),
-                ("hipSetDevice", [ctypes.c_int]),
-                ("hipDeviceGetName", [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]),
-                ("hipDeviceTotalMem", [ctypes.POINTER(ctypes.c_size_t), ctypes.c_int]),
-                ("hipMemGetInfo", [ctypes.POINTER(ctypes.c_size_t),
-                                   ctypes.POINTER(ctypes.c_size_t)]),
-                ("hipRuntimeGetVersion", [ctypes.POINTER(ctypes.c_int)]),
-                ("hipDriverGetVersion", [ctypes.POINTER(ctypes.c_int)]),
-                ("hipMalloc", [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]),
-                ("hipFree", [ctypes.c_void_p]),
-                ("hipMemset", [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]),
-                ("hipMemcpy", [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]),
-                ("hipDeviceSynchronize", []),
-                ("hipGetLastError", []),
+            ("hipInit", [ctypes.c_uint]),
+            ("hipGetDeviceCount", [ctypes.POINTER(ctypes.c_int)]),
+            ("hipSetDevice", [ctypes.c_int]),
+            ("hipDeviceGetName", [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]),
+            ("hipDeviceTotalMem", [ctypes.POINTER(ctypes.c_size_t), ctypes.c_int]),
+            ("hipMemGetInfo", [ctypes.POINTER(ctypes.c_size_t), ctypes.POINTER(ctypes.c_size_t)]),
+            ("hipRuntimeGetVersion", [ctypes.POINTER(ctypes.c_int)]),
+            ("hipDriverGetVersion", [ctypes.POINTER(ctypes.c_int)]),
+            ("hipMalloc", [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]),
+            ("hipFree", [ctypes.c_void_p]),
+            ("hipMemset", [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]),
+            ("hipMemcpy", [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]),
+            ("hipDeviceSynchronize", []),
+            ("hipGetLastError", []),
         ):
             f = getattr(self.lib, fn)
             f.argtypes = argtypes
@@ -261,15 +297,20 @@ class Hip:
             return f"hip error {code}"
 
     def inventory(self) -> dict:
-        out: dict = {"requested_dll": self.requested, "loaded_dll": self.loaded,
-                     "dll": describe_file(Path(self.loaded)) if self.loaded else {}}
+        out: dict = {
+            "requested_dll": self.requested,
+            "loaded_dll": self.loaded,
+            "dll": describe_file(Path(self.loaded)) if self.loaded else {},
+        }
         rc = self.lib.hipInit(0)
         out["hipInit_rc"] = rc
         if rc != 0:
             out["error"] = self.err(rc)
             return out
-        for fn, key in (("hipRuntimeGetVersion", "runtime_version"),
-                        ("hipDriverGetVersion", "driver_version")):
+        for fn, key in (
+            ("hipRuntimeGetVersion", "runtime_version"),
+            ("hipDriverGetVersion", "driver_version"),
+        ):
             v = ctypes.c_int(0)
             if getattr(self.lib, fn)(ctypes.byref(v)) == 0:
                 out[key] = v.value
@@ -297,7 +338,11 @@ class Hip:
         out["devices"] = devices
         return out
 
-    def try_alloc(self, nbytes: int, device: int = 0) -> dict:
+    def try_alloc(
+        self,
+        nbytes: int,
+        device: int = 0,
+    ) -> dict:
         """One allocation, written and read back. A hipMalloc that returns a
         pointer nothing was ever stored in is not evidence the memory exists."""
         res: dict = {"bytes": nbytes}
@@ -319,18 +364,32 @@ class Hip:
                 return {**res, "ok": False, "stage": "hipMemset", "rc": rc, "error": self.err(rc)}
             rc = self.lib.hipDeviceSynchronize()
             if rc != 0:
-                return {**res, "ok": False, "stage": "hipDeviceSynchronize", "rc": rc,
-                        "error": self.err(rc)}
+                return {
+                    **res,
+                    "ok": False,
+                    "stage": "hipDeviceSynchronize",
+                    "rc": rc,
+                    "error": self.err(rc),
+                }
             probe = ctypes.create_string_buffer(64)
             for offset in (0, nbytes // 2, nbytes - 64):
                 src = ctypes.c_void_p(ptr.value + max(0, offset))
                 rc = self.lib.hipMemcpy(probe, src, 64, HIP_MEMCPY_DEVICE_TO_HOST)
                 if rc != 0:
-                    return {**res, "ok": False, "stage": f"hipMemcpy@{offset}", "rc": rc,
-                            "error": self.err(rc)}
+                    return {
+                        **res,
+                        "ok": False,
+                        "stage": f"hipMemcpy@{offset}",
+                        "rc": rc,
+                        "error": self.err(rc),
+                    }
                 if probe.raw[:64] != b"\xa5" * 64:
-                    return {**res, "ok": False, "stage": f"readback@{offset}",
-                            "error": "buffer did not read back as written"}
+                    return {
+                        **res,
+                        "ok": False,
+                        "stage": f"readback@{offset}",
+                        "error": "buffer did not read back as written",
+                    }
             res["ok"] = True
             free_b, total_b = ctypes.c_size_t(0), ctypes.c_size_t(0)
             if self.lib.hipMemGetInfo(ctypes.byref(free_b), ctypes.byref(total_b)) == 0:
@@ -356,8 +415,14 @@ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT = 1000237000
 VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = 0x1
 VK_MEMORY_HEAP_MULTI_INSTANCE_BIT = 0x2
 VK_DEVICE_TYPES = {0: "other", 1: "integrated", 2: "discrete", 3: "virtual", 4: "cpu"}
-MEMORY_PROPERTY_BITS = [(0x1, "DEVICE_LOCAL"), (0x2, "HOST_VISIBLE"), (0x4, "HOST_COHERENT"),
-                        (0x8, "HOST_CACHED"), (0x10, "LAZILY_ALLOCATED"), (0x20, "PROTECTED")]
+MEMORY_PROPERTY_BITS = [
+    (0x1, "DEVICE_LOCAL"),
+    (0x2, "HOST_VISIBLE"),
+    (0x4, "HOST_COHERENT"),
+    (0x8, "HOST_CACHED"),
+    (0x10, "LAZILY_ALLOCATED"),
+    (0x20, "PROTECTED"),
+]
 
 
 class VkMemoryType(ctypes.Structure):
@@ -369,50 +434,76 @@ class VkMemoryHeap(ctypes.Structure):
 
 
 class VkPhysicalDeviceMemoryProperties(ctypes.Structure):
-    _fields_ = [("memoryTypeCount", ctypes.c_uint32),
-                ("memoryTypes", VkMemoryType * VK_MAX_MEMORY_TYPES),
-                ("memoryHeapCount", ctypes.c_uint32),
-                ("memoryHeaps", VkMemoryHeap * VK_MAX_MEMORY_HEAPS)]
+    _fields_ = [
+        ("memoryTypeCount", ctypes.c_uint32),
+        ("memoryTypes", VkMemoryType * VK_MAX_MEMORY_TYPES),
+        ("memoryHeapCount", ctypes.c_uint32),
+        ("memoryHeaps", VkMemoryHeap * VK_MAX_MEMORY_HEAPS),
+    ]
 
 
 class VkPhysicalDeviceMemoryProperties2(ctypes.Structure):
-    _fields_ = [("sType", ctypes.c_uint32), ("pNext", ctypes.c_void_p),
-                ("memoryProperties", VkPhysicalDeviceMemoryProperties)]
+    _fields_ = [
+        ("sType", ctypes.c_uint32),
+        ("pNext", ctypes.c_void_p),
+        ("memoryProperties", VkPhysicalDeviceMemoryProperties),
+    ]
 
 
 class VkPhysicalDeviceMemoryBudgetPropertiesEXT(ctypes.Structure):
-    _fields_ = [("sType", ctypes.c_uint32), ("pNext", ctypes.c_void_p),
-                ("heapBudget", ctypes.c_uint64 * VK_MAX_MEMORY_HEAPS),
-                ("heapUsage", ctypes.c_uint64 * VK_MAX_MEMORY_HEAPS)]
+    _fields_ = [
+        ("sType", ctypes.c_uint32),
+        ("pNext", ctypes.c_void_p),
+        ("heapBudget", ctypes.c_uint64 * VK_MAX_MEMORY_HEAPS),
+        ("heapUsage", ctypes.c_uint64 * VK_MAX_MEMORY_HEAPS),
+    ]
 
 
 class VkPhysicalDeviceProperties(ctypes.Structure):
     # Only the head is parsed; the tail is spare room for limits and sparse
     # properties, which the driver writes and this probe does not read.
-    _fields_ = [("apiVersion", ctypes.c_uint32), ("driverVersion", ctypes.c_uint32),
-                ("vendorID", ctypes.c_uint32), ("deviceID", ctypes.c_uint32),
-                ("deviceType", ctypes.c_uint32), ("deviceName", ctypes.c_char * 256),
-                ("pipelineCacheUUID", ctypes.c_uint8 * 16), ("tail", ctypes.c_uint8 * 4096)]
+    _fields_ = [
+        ("apiVersion", ctypes.c_uint32),
+        ("driverVersion", ctypes.c_uint32),
+        ("vendorID", ctypes.c_uint32),
+        ("deviceID", ctypes.c_uint32),
+        ("deviceType", ctypes.c_uint32),
+        ("deviceName", ctypes.c_char * 256),
+        ("pipelineCacheUUID", ctypes.c_uint8 * 16),
+        ("tail", ctypes.c_uint8 * 4096),
+    ]
 
 
 class VkExtensionProperties(ctypes.Structure):
-    _fields_ = [("extensionName", ctypes.c_char * VK_MAX_EXTENSION_NAME_SIZE),
-                ("specVersion", ctypes.c_uint32)]
+    _fields_ = [
+        ("extensionName", ctypes.c_char * VK_MAX_EXTENSION_NAME_SIZE),
+        ("specVersion", ctypes.c_uint32),
+    ]
 
 
 class VkApplicationInfo(ctypes.Structure):
-    _fields_ = [("sType", ctypes.c_uint32), ("pNext", ctypes.c_void_p),
-                ("pApplicationName", ctypes.c_char_p), ("applicationVersion", ctypes.c_uint32),
-                ("pEngineName", ctypes.c_char_p), ("engineVersion", ctypes.c_uint32),
-                ("apiVersion", ctypes.c_uint32)]
+    _fields_ = [
+        ("sType", ctypes.c_uint32),
+        ("pNext", ctypes.c_void_p),
+        ("pApplicationName", ctypes.c_char_p),
+        ("applicationVersion", ctypes.c_uint32),
+        ("pEngineName", ctypes.c_char_p),
+        ("engineVersion", ctypes.c_uint32),
+        ("apiVersion", ctypes.c_uint32),
+    ]
 
 
 class VkInstanceCreateInfo(ctypes.Structure):
-    _fields_ = [("sType", ctypes.c_uint32), ("pNext", ctypes.c_void_p),
-                ("flags", ctypes.c_uint32), ("pApplicationInfo", ctypes.c_void_p),
-                ("enabledLayerCount", ctypes.c_uint32), ("ppEnabledLayerNames", ctypes.c_void_p),
-                ("enabledExtensionCount", ctypes.c_uint32),
-                ("ppEnabledExtensionNames", ctypes.c_void_p)]
+    _fields_ = [
+        ("sType", ctypes.c_uint32),
+        ("pNext", ctypes.c_void_p),
+        ("flags", ctypes.c_uint32),
+        ("pApplicationInfo", ctypes.c_void_p),
+        ("enabledLayerCount", ctypes.c_uint32),
+        ("ppEnabledLayerNames", ctypes.c_void_p),
+        ("enabledExtensionCount", ctypes.c_uint32),
+        ("ppEnabledExtensionNames", ctypes.c_void_p),
+    ]
 
 
 def _flag_names(flags: int) -> list[str]:
@@ -435,18 +526,28 @@ def read_vulkan_raw() -> dict:
         vk.vkEnumerateInstanceVersion.restype = ctypes.c_int
         v = ctypes.c_uint32(0)
         if vk.vkEnumerateInstanceVersion(ctypes.byref(v)) == 0:
-            out["loader_api_version"] = f"{v.value >> 22}.{(v.value >> 12) & 0x3FF}.{v.value & 0xFFF}"
+            out["loader_api_version"] = (
+                f"{v.value >> 22}.{(v.value >> 12) & 0x3FF}.{v.value & 0xFFF}"
+            )
             api_version = min(api_version, v.value)
     except AttributeError:
         out["loader_api_version"] = "1.0"
 
-    app = VkApplicationInfo(sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
-                            pApplicationName = b"amd_ci_memory_report",
-                            pEngineName = b"amd_ci", apiVersion = api_version)
-    ci = VkInstanceCreateInfo(sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-                              pApplicationInfo = ctypes.cast(ctypes.byref(app), ctypes.c_void_p))
-    vk.vkCreateInstance.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
-                                    ctypes.POINTER(ctypes.c_void_p)]
+    app = VkApplicationInfo(
+        sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        pApplicationName = b"amd_ci_memory_report",
+        pEngineName = b"amd_ci",
+        apiVersion = api_version,
+    )
+    ci = VkInstanceCreateInfo(
+        sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        pApplicationInfo = ctypes.cast(ctypes.byref(app), ctypes.c_void_p),
+    )
+    vk.vkCreateInstance.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
     vk.vkCreateInstance.restype = ctypes.c_int
     inst = ctypes.c_void_p()
     rc = vk.vkCreateInstance(ctypes.byref(ci), None, ctypes.byref(inst))
@@ -455,9 +556,11 @@ def read_vulkan_raw() -> dict:
         return out
 
     try:
-        vk.vkEnumeratePhysicalDevices.argtypes = [ctypes.c_void_p,
-                                                  ctypes.POINTER(ctypes.c_uint32),
-                                                  ctypes.POINTER(ctypes.c_void_p)]
+        vk.vkEnumeratePhysicalDevices.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_uint32),
+            ctypes.POINTER(ctypes.c_void_p),
+        ]
         vk.vkEnumeratePhysicalDevices.restype = ctypes.c_int
         count = ctypes.c_uint32(0)
         vk.vkEnumeratePhysicalDevices(inst, ctypes.byref(count), None)
@@ -469,7 +572,11 @@ def read_vulkan_raw() -> dict:
         vk.vkGetPhysicalDeviceMemoryProperties.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
         vk.vkGetPhysicalDeviceMemoryProperties.restype = None
         vk.vkEnumerateDeviceExtensionProperties.argtypes = [
-            ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_uint32), ctypes.c_void_p]
+            ctypes.c_void_p,
+            ctypes.c_char_p,
+            ctypes.POINTER(ctypes.c_uint32),
+            ctypes.c_void_p,
+        ]
         vk.vkEnumerateDeviceExtensionProperties.restype = ctypes.c_int
         mem2 = _memory_properties2(vk, inst)
 
@@ -482,15 +589,18 @@ def read_vulkan_raw() -> dict:
             vk.vkEnumerateDeviceExtensionProperties(pd, None, ctypes.byref(ext_count), None)
             exts = (VkExtensionProperties * max(1, ext_count.value))()
             vk.vkEnumerateDeviceExtensionProperties(pd, None, ctypes.byref(ext_count), exts)
-            names = {e.extensionName.decode("utf-8", "replace") for e in exts[:ext_count.value]}
+            names = {e.extensionName.decode("utf-8", "replace") for e in exts[: ext_count.value]}
             has_budget = "VK_EXT_memory_budget" in names
 
             budget = VkPhysicalDeviceMemoryBudgetPropertiesEXT(
-                sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT)
+                sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT
+            )
             mp2 = VkPhysicalDeviceMemoryProperties2(
                 sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2,
-                pNext = ctypes.cast(ctypes.byref(budget), ctypes.c_void_p) if (
-                    has_budget and mem2) else None)
+                pNext = ctypes.cast(ctypes.byref(budget), ctypes.c_void_p)
+                if (has_budget and mem2)
+                else None,
+            )
             if mem2:
                 mem2(pd, ctypes.byref(mp2))
                 mp = mp2.memoryProperties
@@ -500,37 +610,49 @@ def read_vulkan_raw() -> dict:
 
             heaps = []
             for h in range(mp.memoryHeapCount):
-                row = {"index": h, "size_bytes": int(mp.memoryHeaps[h].size),
-                       "flags": int(mp.memoryHeaps[h].flags),
-                       "device_local": bool(mp.memoryHeaps[h].flags
-                                            & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT),
-                       "multi_instance": bool(mp.memoryHeaps[h].flags
-                                              & VK_MEMORY_HEAP_MULTI_INSTANCE_BIT)}
+                row = {
+                    "index": h,
+                    "size_bytes": int(mp.memoryHeaps[h].size),
+                    "flags": int(mp.memoryHeaps[h].flags),
+                    "device_local": bool(mp.memoryHeaps[h].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT),
+                    "multi_instance": bool(
+                        mp.memoryHeaps[h].flags & VK_MEMORY_HEAP_MULTI_INSTANCE_BIT
+                    ),
+                }
                 if has_budget and mem2:
                     row["budget_bytes"] = int(budget.heapBudget[h])
                     row["usage_bytes"] = int(budget.heapUsage[h])
                 heaps.append(row)
-            types = [{"index": t, "heap": int(mp.memoryTypes[t].heapIndex),
-                      "flags": int(mp.memoryTypes[t].propertyFlags),
-                      "names": _flag_names(int(mp.memoryTypes[t].propertyFlags))}
-                     for t in range(mp.memoryTypeCount)]
+            types = [
+                {
+                    "index": t,
+                    "heap": int(mp.memoryTypes[t].heapIndex),
+                    "flags": int(mp.memoryTypes[t].propertyFlags),
+                    "names": _flag_names(int(mp.memoryTypes[t].propertyFlags)),
+                }
+                for t in range(mp.memoryTypeCount)
+            ]
             local = [h["size_bytes"] for h in heaps if h["device_local"]]
-            rows.append({
-                "index": i,
-                "name": props.deviceName.decode("utf-8", "replace"),
-                "type": VK_DEVICE_TYPES.get(int(props.deviceType), int(props.deviceType)),
-                "vendor_id": hex(int(props.vendorID)), "device_id": hex(int(props.deviceID)),
-                "api_version": f"{props.apiVersion >> 22}.{(props.apiVersion >> 12) & 0x3FF}"
-                               f".{props.apiVersion & 0xFFF}",
-                "driver_version": int(props.driverVersion),
-                "memory_budget_ext": has_budget,
-                "heaps": heaps, "memory_types": types,
-                # The two candidate readings, side by side, so the over-report is
-                # visible without recomputing anything downstream.
-                "device_local_sum_bytes": sum(local),
-                "device_local_max_bytes": max(local) if local else 0,
-                "all_heaps_sum_bytes": sum(h["size_bytes"] for h in heaps),
-            })
+            rows.append(
+                {
+                    "index": i,
+                    "name": props.deviceName.decode("utf-8", "replace"),
+                    "type": VK_DEVICE_TYPES.get(int(props.deviceType), int(props.deviceType)),
+                    "vendor_id": hex(int(props.vendorID)),
+                    "device_id": hex(int(props.deviceID)),
+                    "api_version": f"{props.apiVersion >> 22}.{(props.apiVersion >> 12) & 0x3FF}"
+                    f".{props.apiVersion & 0xFFF}",
+                    "driver_version": int(props.driverVersion),
+                    "memory_budget_ext": has_budget,
+                    "heaps": heaps,
+                    "memory_types": types,
+                    # The two candidate readings, side by side, so the over-report is
+                    # visible without recomputing anything downstream.
+                    "device_local_sum_bytes": sum(local),
+                    "device_local_max_bytes": max(local) if local else 0,
+                    "all_heaps_sum_bytes": sum(h["size_bytes"] for h in heaps),
+                }
+            )
         out["devices"] = rows
     finally:
         try:
@@ -543,8 +665,7 @@ def read_vulkan_raw() -> dict:
 
 def _memory_properties2(vk, inst):
     """vkGetPhysicalDeviceMemoryProperties2, statically or through the loader."""
-    for name in ("vkGetPhysicalDeviceMemoryProperties2",
-                 "vkGetPhysicalDeviceMemoryProperties2KHR"):
+    for name in ("vkGetPhysicalDeviceMemoryProperties2", "vkGetPhysicalDeviceMemoryProperties2KHR"):
         try:
             fn = getattr(vk, name)
             fn.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
@@ -555,8 +676,10 @@ def _memory_properties2(vk, inst):
     try:
         vk.vkGetInstanceProcAddr.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
         vk.vkGetInstanceProcAddr.restype = ctypes.c_void_p
-        for name in (b"vkGetPhysicalDeviceMemoryProperties2",
-                     b"vkGetPhysicalDeviceMemoryProperties2KHR"):
+        for name in (
+            b"vkGetPhysicalDeviceMemoryProperties2",
+            b"vkGetPhysicalDeviceMemoryProperties2KHR",
+        ):
             addr = vk.vkGetInstanceProcAddr(inst, name)
             if addr:
                 proto = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p)
@@ -568,20 +691,23 @@ def _memory_properties2(vk, inst):
 
 # ------------------------------------------------------------------- ggml Vulkan
 
+
 def read_ggml_vulkan(bin_dir: Path) -> dict:
     """What ggml reports, which is what llama.cpp and Studio place against.
 
     Same load path as Studio's own `_vulkan_probe.py`, in a child process, so a
     driver that dies taking its instance with it does not take the rest of the
     report."""
-    r = run([sys.executable, str(Path(__file__).resolve()), "--ggml-vulkan-only", str(bin_dir)],
-            300)
+    r = run(
+        [sys.executable, str(Path(__file__).resolve()), "--ggml-vulkan-only", str(bin_dir)], 300
+    )
     out: dict = {"bin_dir": str(bin_dir), "rc": r.get("rc"), "stderr": r.get("stderr", "")}
     if r.get("rc") != 0:
         # A directory without the Vulkan backend is a wrong argument, not a
         # machine with no Vulkan memory; say so instead of returning no devices.
-        raise RuntimeError(f"ggml Vulkan child rc={r.get('rc')}: "
-                           f"{(r.get('stderr') or '').strip()[:300]}")
+        raise RuntimeError(
+            f"ggml Vulkan child rc={r.get('rc')}: " f"{(r.get('stderr') or '').strip()[:300]}"
+        )
     try:
         out["devices"] = json.loads(r.get("stdout") or "[]")
     except json.JSONDecodeError as e:
@@ -607,7 +733,10 @@ def ggml_vulkan_child(bin_dir: str) -> int:
     lib = ctypes.CDLL(str(vk_path), mode = mode)
     lib.ggml_backend_vk_get_device_count.restype = ctypes.c_int
     lib.ggml_backend_vk_get_device_memory.argtypes = [
-        ctypes.c_int, ctypes.POINTER(ctypes.c_size_t), ctypes.POINTER(ctypes.c_size_t)]
+        ctypes.c_int,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.POINTER(ctypes.c_size_t),
+    ]
     lib.ggml_backend_vk_get_device_memory.restype = None
     count = lib.ggml_backend_vk_get_device_count()
 
@@ -635,16 +764,28 @@ def ggml_vulkan_child(bin_dir: str) -> int:
     for i in range(count):
         free_b, total_b = ctypes.c_size_t(0), ctypes.c_size_t(0)
         lib.ggml_backend_vk_get_device_memory(i, ctypes.byref(free_b), ctypes.byref(total_b))
-        rows.append({"index": i, "free_bytes": free_b.value, "total_bytes": total_b.value,
-                     "ggml_dev_type": types.get(i), "is_igpu": types.get(i) == 2,
-                     "name": names.get(i, "")})
+        rows.append(
+            {
+                "index": i,
+                "free_bytes": free_b.value,
+                "total_bytes": total_b.value,
+                "ggml_dev_type": types.get(i),
+                "is_igpu": types.get(i) == 2,
+                "name": names.get(i, ""),
+            }
+        )
     print(json.dumps(rows))
     return 0
 
 
 # --------------------------------------------------------------------------- fit
 
-def read_fit(bin_dir: Path, model: str | None, env_extra: dict | None = None) -> dict:
+
+def read_fit(
+    bin_dir: Path,
+    model: str | None,
+    env_extra: dict | None = None,
+) -> dict:
     exe = ".exe" if IS_WIN else ""
     env = dict(os.environ)
     if not IS_WIN:
@@ -662,13 +803,25 @@ def read_fit(bin_dir: Path, model: str | None, env_extra: dict | None = None) ->
 
 # ----------------------------------------------------------------- allocation cap
 
-def alloc_once_subprocess(hip_dir: Path | None, nbytes: int, device: int,
-                          timeout: int = 900, settle: float = 2.0) -> dict:
+
+def alloc_once_subprocess(
+    hip_dir: Path | None,
+    nbytes: int,
+    device: int,
+    timeout: int = 900,
+    settle: float = 2.0,
+) -> dict:
     """One candidate, one process. HIP's Windows free-memory accounting is
     process-scoped, so a stale allocator state would otherwise leak between
     candidates and turn a cap into a fragmentation measurement."""
-    cmd = [sys.executable, str(Path(__file__).resolve()), "--try-alloc", str(nbytes),
-           "--alloc-device", str(device)]
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--try-alloc",
+        str(nbytes),
+        "--alloc-device",
+        str(device),
+    ]
     if hip_dir:
         cmd += ["--hip-dir", str(hip_dir)]
     r = run(cmd, timeout)
@@ -678,13 +831,23 @@ def alloc_once_subprocess(hip_dir: Path | None, nbytes: int, device: int,
     try:
         return json.loads((r.get("stdout") or "").strip().splitlines()[-1])
     except Exception:  # noqa: BLE001
-        return {"bytes": nbytes, "ok": False, "stage": "child",
-                "error": f"rc={r.get('rc')} {(r.get('stderr') or '')[-400:]}"}
+        return {
+            "bytes": nbytes,
+            "ok": False,
+            "stage": "child",
+            "error": f"rc={r.get('rc')} {(r.get('stderr') or '')[-400:]}",
+        }
 
 
-def read_alloc_cap(hip_dir: Path | None, lo_gib: float, hi_gib: float,
-                   reps: int, device: int, resolution_gib: float,
-                   attempt_timeout: int = 900) -> dict:
+def read_alloc_cap(
+    hip_dir: Path | None,
+    lo_gib: float,
+    hi_gib: float,
+    reps: int,
+    device: int,
+    resolution_gib: float,
+    attempt_timeout: int = 900,
+) -> dict:
     """Bisect for the largest allocation that succeeds and reads back.
 
     Ascending and descending confirmation around the boundary, because an
@@ -698,12 +861,19 @@ def read_alloc_cap(hip_dir: Path | None, lo_gib: float, hi_gib: float,
         attempts.append(res)
         return bool(res.get("ok"))
 
-    out: dict = {"hip_dir": str(hip_dir) if hip_dir else None, "device": device,
-                 "search_lo_gib": lo_gib, "search_hi_gib": hi_gib,
-                 "resolution_gib": resolution_gib, "attempt_timeout_s": attempt_timeout}
+    out: dict = {
+        "hip_dir": str(hip_dir) if hip_dir else None,
+        "device": device,
+        "search_lo_gib": lo_gib,
+        "search_hi_gib": hi_gib,
+        "resolution_gib": resolution_gib,
+        "attempt_timeout_s": attempt_timeout,
+    }
     if not attempt(lo_gib):
-        out["error"] = (f"the {lo_gib} GiB floor already fails, so there is no interval to "
-                        f"bisect; this is a broken runtime, not a cap")
+        out["error"] = (
+            f"the {lo_gib} GiB floor already fails, so there is no interval to "
+            f"bisect; this is a broken runtime, not a cap"
+        )
         out["attempts"] = attempts
         return out
     if attempt(hi_gib):
@@ -745,10 +915,14 @@ def main() -> int:
     ap.add_argument("--state", default = "solo")
     ap.add_argument("--checkout", default = "", help = "directory holding the llama.cpp binaries")
     ap.add_argument("--out", default = "")
-    ap.add_argument("--hip-dir", default = "",
-                    help = "directory whose amdhip64_7.dll is loaded; defaults to --checkout")
-    ap.add_argument("--vulkan-dir", default = "",
-                    help = "directory holding ggml-vulkan (the vulkan release)")
+    ap.add_argument(
+        "--hip-dir",
+        default = "",
+        help = "directory whose amdhip64_7.dll is loaded; defaults to --checkout",
+    )
+    ap.add_argument(
+        "--vulkan-dir", default = "", help = "directory holding ggml-vulkan (the vulkan release)"
+    )
     ap.add_argument("--fit-model", default = "")
     ap.add_argument("--sections", default = "host,hip,vulkan_raw,ggml_vulkan,fit")
     ap.add_argument("--alloc-lo-gib", type = float, default = 1.0)
@@ -756,12 +930,23 @@ def main() -> int:
     ap.add_argument("--alloc-resolution-gib", type = float, default = 0.5)
     ap.add_argument("--alloc-reps", type = int, default = 2)
     ap.add_argument("--alloc-device", type = int, default = 0)
-    ap.add_argument("--alloc-attempt-timeout", type = int, default = 900,
-                    help = "seconds one candidate allocation may take before it is a failure")
-    ap.add_argument("--try-alloc", type = int, default = 0,
-                    help = "internal: attempt one allocation and print the JSON result")
-    ap.add_argument("--ggml-vulkan-only", default = "",
-                    help = "internal: print the ggml Vulkan inventory of this directory")
+    ap.add_argument(
+        "--alloc-attempt-timeout",
+        type = int,
+        default = 900,
+        help = "seconds one candidate allocation may take before it is a failure",
+    )
+    ap.add_argument(
+        "--try-alloc",
+        type = int,
+        default = 0,
+        help = "internal: attempt one allocation and print the JSON result",
+    )
+    ap.add_argument(
+        "--ggml-vulkan-only",
+        default = "",
+        help = "internal: print the ggml Vulkan inventory of this directory",
+    )
     a = ap.parse_args()
 
     if a.ggml_vulkan_only:
@@ -771,8 +956,12 @@ def main() -> int:
         try:
             res = Hip(hip_dir).try_alloc(a.try_alloc, a.alloc_device)
         except Exception as e:  # noqa: BLE001
-            res = {"bytes": a.try_alloc, "ok": False, "stage": "load",
-                   "error": f"{type(e).__name__}: {e}"}
+            res = {
+                "bytes": a.try_alloc,
+                "ok": False,
+                "stage": "load",
+                "error": f"{type(e).__name__}: {e}",
+            }
         print(json.dumps(res))
         return 0 if res.get("ok") else 3
 
@@ -784,13 +973,22 @@ def main() -> int:
     if unknown:
         raise SystemExit(f"unknown section(s) {unknown}; choose from {list(SECTIONS)}")
 
-    res: dict = {"state": a.state, "checkout": a.checkout, "hip_dir": str(hip_dir or ""),
-                 "vulkan_dir": a.vulkan_dir, "sections_requested": wanted,
-                 "platform": platform.platform(), "sections": {}, "errors": {}}
+    res: dict = {
+        "state": a.state,
+        "checkout": a.checkout,
+        "hip_dir": str(hip_dir or ""),
+        "vulkan_dir": a.vulkan_dir,
+        "sections_requested": wanted,
+        "platform": platform.platform(),
+        "sections": {},
+        "errors": {},
+    }
     if hip_dir:
         name = "amdhip64_7.dll" if IS_WIN else "libamdhip64.so"
         found = find_lib(hip_dir, name)
-        res["hip_dll_file"] = describe_file(found) if found else {"error": f"{name} not in {hip_dir}"}
+        res["hip_dll_file"] = (
+            describe_file(found) if found else {"error": f"{name} not in {hip_dir}"}
+        )
 
     todo = {
         "host": lambda: read_host(),
@@ -798,9 +996,15 @@ def main() -> int:
         "vulkan_raw": lambda: read_vulkan_raw(),
         "ggml_vulkan": lambda: read_ggml_vulkan(vulkan_dir or checkout),
         "fit": lambda: read_fit(checkout, a.fit_model or None),
-        "alloc_cap": lambda: read_alloc_cap(hip_dir, a.alloc_lo_gib, a.alloc_hi_gib,
-                                            a.alloc_reps, a.alloc_device, a.alloc_resolution_gib,
-                                            a.alloc_attempt_timeout),
+        "alloc_cap": lambda: read_alloc_cap(
+            hip_dir,
+            a.alloc_lo_gib,
+            a.alloc_hi_gib,
+            a.alloc_reps,
+            a.alloc_device,
+            a.alloc_resolution_gib,
+            a.alloc_attempt_timeout,
+        ),
     }
     for name in wanted:
         if name in ("ggml_vulkan", "fit") and not (vulkan_dir or checkout):
@@ -811,8 +1015,11 @@ def main() -> int:
             res["sections"][name] = todo[name]()
         except Exception as e:  # noqa: BLE001
             res["errors"][name] = f"{type(e).__name__}: {e}"
-        print(f"== {name}: {round(time.monotonic() - t0, 1)}s"
-              f"{' ERROR ' + res['errors'][name] if name in res['errors'] else ''}", flush = True)
+        print(
+            f"== {name}: {round(time.monotonic() - t0, 1)}s"
+            f"{' ERROR ' + res['errors'][name] if name in res['errors'] else ''}",
+            flush = True,
+        )
 
     res["ok"] = not res["errors"]
     text = json.dumps(res, indent = 2)

--- a/strix_halo_repro/report.py
+++ b/strix_halo_repro/report.py
@@ -27,7 +27,7 @@ import argparse
 import json
 from pathlib import Path
 
-GIB = 1024 ** 3
+GIB = 1024**3
 # Two readings of the same pool never match to the byte: drivers round, reserve
 # and report at different moments. 2% is wide enough for that and far narrower
 # than the gaps being distinguished (a heap sum is 2x-3x a single heap).
@@ -53,35 +53,51 @@ def host_numbers(doc: dict) -> dict:
         size = adapter.get("qw_memory_size")
         if isinstance(size, int):
             vram = max(vram, size)
-    return {"ram_gib": gib(host.get("total_phys_bytes") or host.get("memtotal_bytes")),
-            "registry_vram_gib": gib(vram),
-            "pagefile_gib": gib(host.get("total_pagefile_bytes"))}
+    return {
+        "ram_gib": gib(host.get("total_phys_bytes") or host.get("memtotal_bytes")),
+        "registry_vram_gib": gib(vram),
+        "pagefile_gib": gib(host.get("total_pagefile_bytes")),
+    }
 
 
 def rows_for(name: str, doc: dict) -> list[str]:
     out = []
     h = host_numbers(doc)
     out.append(f"| {name} | host: physical RAM | {h['ram_gib']} GiB | GlobalMemoryStatusEx |")
-    out.append(f"| {name} | host: registry VRAM (carve-out) | {h['registry_vram_gib']} GiB | "
-               f"HardwareInformation.qwMemorySize |")
+    out.append(
+        f"| {name} | host: registry VRAM (carve-out) | {h['registry_vram_gib']} GiB | "
+        f"HardwareInformation.qwMemorySize |"
+    )
     for d in sec(doc, "hip").get("devices") or []:
-        out.append(f"| {name} | HIP device {d.get('index')} total | "
-                   f"{gib(d.get('total_bytes') or d.get('device_total_bytes'))} GiB | "
-                   f"hipMemGetInfo / hipDeviceTotalMem ({d.get('name', '')}) |")
-        out.append(f"| {name} | HIP device {d.get('index')} free | {gib(d.get('free_bytes'))} GiB "
-                   f"| process-scoped on Windows, an optimistic ceiling |")
+        out.append(
+            f"| {name} | HIP device {d.get('index')} total | "
+            f"{gib(d.get('total_bytes') or d.get('device_total_bytes'))} GiB | "
+            f"hipMemGetInfo / hipDeviceTotalMem ({d.get('name', '')}) |"
+        )
+        out.append(
+            f"| {name} | HIP device {d.get('index')} free | {gib(d.get('free_bytes'))} GiB "
+            f"| process-scoped on Windows, an optimistic ceiling |"
+        )
     for d in sec(doc, "vulkan_raw").get("devices") or []:
-        heaps = ", ".join(f"{gib(x['size_bytes'])}{'L' if x['device_local'] else ''}"
-                          for x in d.get("heaps") or [])
-        out.append(f"| {name} | Vulkan raw heaps ({d.get('type')}) | {heaps} GiB | "
-                   f"vkGetPhysicalDeviceMemoryProperties2, L = DEVICE_LOCAL |")
-        out.append(f"| {name} | Vulkan device-local sum / max | "
-                   f"{gib(d.get('device_local_sum_bytes'))} / "
-                   f"{gib(d.get('device_local_max_bytes'))} GiB | the two candidate readings |")
+        heaps = ", ".join(
+            f"{gib(x['size_bytes'])}{'L' if x['device_local'] else ''}"
+            for x in d.get("heaps") or []
+        )
+        out.append(
+            f"| {name} | Vulkan raw heaps ({d.get('type')}) | {heaps} GiB | "
+            f"vkGetPhysicalDeviceMemoryProperties2, L = DEVICE_LOCAL |"
+        )
+        out.append(
+            f"| {name} | Vulkan device-local sum / max | "
+            f"{gib(d.get('device_local_sum_bytes'))} / "
+            f"{gib(d.get('device_local_max_bytes'))} GiB | the two candidate readings |"
+        )
     for d in sec(doc, "ggml_vulkan").get("devices") or []:
-        out.append(f"| {name} | ggml Vulkan total (what llama.cpp places against) | "
-                   f"{gib(d.get('total_bytes'))} GiB | ggml_backend_vk_get_device_memory, "
-                   f"igpu={d.get('is_igpu')} |")
+        out.append(
+            f"| {name} | ggml Vulkan total (what llama.cpp places against) | "
+            f"{gib(d.get('total_bytes'))} GiB | ggml_backend_vk_get_device_memory, "
+            f"igpu={d.get('is_igpu')} |"
+        )
         out.append(f"| {name} | ggml Vulkan free | {gib(d.get('free_bytes'))} GiB | same call |")
     for line in (sec(doc, "fit").get("list_devices") or {}).get("stdout", "").splitlines():
         if "MiB" in line:
@@ -107,9 +123,14 @@ def statements(name: str, doc: dict) -> list[tuple[str, bool | None, str]]:
     if ggml_total is None or physical is None:
         out.append((f"{name}: over_report", None, "no ggml Vulkan total or no host RAM reading"))
     else:
-        out.append((f"{name}: over_report", ggml_total > physical,
-                    f"ggml reports {ggml_total} GiB where the machine holds {physical} GiB "
-                    f"({h['ram_gib']} GiB visible plus a {h['registry_vram_gib']} GiB carve-out)"))
+        out.append(
+            (
+                f"{name}: over_report",
+                ggml_total > physical,
+                f"ggml reports {ggml_total} GiB where the machine holds {physical} GiB "
+                f"({h['ram_gib']} GiB visible plus a {h['registry_vram_gib']} GiB carve-out)",
+            )
+        )
 
     local_sum = gib((vk_raw or {}).get("device_local_sum_bytes"))
     local_max = gib((vk_raw or {}).get("device_local_max_bytes"))
@@ -121,28 +142,43 @@ def statements(name: str, doc: dict) -> list[tuple[str, bool | None, str]]:
         # ones, and on Strix Halo the host-visible aperture is its own heap. An
         # earlier version compared against the device-local sum alone and so
         # answered NO on a machine where the summation was the whole mechanism.
-        which = ("all heaps" if close(ggml_total, all_sum)
-                 else "the device-local heaps" if close(ggml_total, local_sum) else None)
-        out.append((f"{name}: sums_heaps",
-                    bool(which) and not close(ggml_total, local_max),
-                    f"ggml {ggml_total} GiB against {all_sum} GiB over all heaps, "
-                    f"{local_sum} GiB device-local and {local_max} GiB largest"
-                    + (f": it is {which}" if which else ": it matches none of them")))
+        which = (
+            "all heaps"
+            if close(ggml_total, all_sum)
+            else "the device-local heaps"
+            if close(ggml_total, local_sum)
+            else None
+        )
+        out.append(
+            (
+                f"{name}: sums_heaps",
+                bool(which) and not close(ggml_total, local_max),
+                f"ggml {ggml_total} GiB against {all_sum} GiB over all heaps, "
+                f"{local_sum} GiB device-local and {local_max} GiB largest"
+                + (f": it is {which}" if which else ": it matches none of them"),
+            )
+        )
 
     hip_total = gib((hip or {}).get("total_bytes") or (hip or {}).get("device_total_bytes"))
     if hip_total is None or h["registry_vram_gib"] is None:
         out.append((f"{name}: hip_is_vgm_only", None, "no HIP total or no registry VRAM"))
     else:
-        out.append((f"{name}: hip_is_vgm_only", close(hip_total, h["registry_vram_gib"]),
-                    f"HIP {hip_total} GiB against a {h['registry_vram_gib']} GiB carve-out"))
+        out.append(
+            (
+                f"{name}: hip_is_vgm_only",
+                close(hip_total, h["registry_vram_gib"]),
+                f"HIP {hip_total} GiB against a {h['registry_vram_gib']} GiB carve-out",
+            )
+        )
     return out
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("reports", nargs = "+", help = "probe JSON files, name=path or path")
-    ap.add_argument("--require", default = "",
-                    help = "comma-separated statements that must be decidable (not None)")
+    ap.add_argument(
+        "--require", default = "", help = "comma-separated statements that must be decidable (not None)"
+    )
     a = ap.parse_args()
 
     docs: dict[str, dict] = {}
@@ -175,15 +211,19 @@ def main() -> int:
         if doc.get("_error"):
             continue
         for label, ok, why in statements(name, doc):
-            print(f"| {label} | {'yes' if ok else ('NO' if ok is False else 'undecided')} | {why} |")
+            print(
+                f"| {label} | {'yes' if ok else ('NO' if ok is False else 'undecided')} | {why} |"
+            )
             if ok is None:
                 undecided.append(label)
 
     required = [s.strip() for s in a.require.split(",") if s.strip()]
     blocking = [u for u in undecided if any(u.endswith(": " + r) for r in required)]
     if blocking:
-        print(f"\n**A required statement could not be decided: {blocking}.** An undecidable "
-              f"statement is a missing reading, not a negative result.")
+        print(
+            f"\n**A required statement could not be decided: {blocking}.** An undecidable "
+            f"statement is a missing reading, not a negative result."
+        )
         return 1
     return 0
 

--- a/strix_halo_repro/report.py
+++ b/strix_halo_repro/report.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""One table over what every layer says this GPU's memory is, and the three
+statements that table is being collected to settle.
+
+Reads the JSON written by probes/gpu_memory_report_probe.py (one file per arm)
+and prints markdown. The statements are checked, not narrated:
+
+  over_report      the number llama.cpp places against exceeds the machine's
+                   physical RAM, which no single device can hold.
+  sums_heaps       that number equals the heaps added together rather than the
+                   largest one, which is how the over-report arises on an
+                   integrated part where several heaps alias the same RAM. ggml
+                   adds EVERY heap, not only the device-local ones.
+  hip_is_vgm_only  the HIP total equals the carve-out the registry records, so
+                   the two backends disagree because they are answering
+                   different questions, not because one is broken.
+
+Exits non-zero when a reading needed for a statement is missing, so a missing
+section can never read as "the statement did not hold".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+GIB = 1024 ** 3
+# Two readings of the same pool never match to the byte: drivers round, reserve
+# and report at different moments. 2% is wide enough for that and far narrower
+# than the gaps being distinguished (a heap sum is 2x-3x a single heap).
+TOL = 0.02
+
+
+def gib(value) -> float | None:
+    return round(value / GIB, 2) if isinstance(value, (int, float)) and value else None
+
+
+def close(a, b) -> bool:
+    return bool(a and b and abs(a - b) <= TOL * max(a, b))
+
+
+def sec(doc: dict, name: str) -> dict:
+    return (doc.get("sections") or {}).get(name) or {}
+
+
+def host_numbers(doc: dict) -> dict:
+    host = sec(doc, "host")
+    vram = 0
+    for adapter in host.get("adapters") or []:
+        size = adapter.get("qw_memory_size")
+        if isinstance(size, int):
+            vram = max(vram, size)
+    return {"ram_gib": gib(host.get("total_phys_bytes") or host.get("memtotal_bytes")),
+            "registry_vram_gib": gib(vram),
+            "pagefile_gib": gib(host.get("total_pagefile_bytes"))}
+
+
+def rows_for(name: str, doc: dict) -> list[str]:
+    out = []
+    h = host_numbers(doc)
+    out.append(f"| {name} | host: physical RAM | {h['ram_gib']} GiB | GlobalMemoryStatusEx |")
+    out.append(f"| {name} | host: registry VRAM (carve-out) | {h['registry_vram_gib']} GiB | "
+               f"HardwareInformation.qwMemorySize |")
+    for d in sec(doc, "hip").get("devices") or []:
+        out.append(f"| {name} | HIP device {d.get('index')} total | "
+                   f"{gib(d.get('total_bytes') or d.get('device_total_bytes'))} GiB | "
+                   f"hipMemGetInfo / hipDeviceTotalMem ({d.get('name', '')}) |")
+        out.append(f"| {name} | HIP device {d.get('index')} free | {gib(d.get('free_bytes'))} GiB "
+                   f"| process-scoped on Windows, an optimistic ceiling |")
+    for d in sec(doc, "vulkan_raw").get("devices") or []:
+        heaps = ", ".join(f"{gib(x['size_bytes'])}{'L' if x['device_local'] else ''}"
+                          for x in d.get("heaps") or [])
+        out.append(f"| {name} | Vulkan raw heaps ({d.get('type')}) | {heaps} GiB | "
+                   f"vkGetPhysicalDeviceMemoryProperties2, L = DEVICE_LOCAL |")
+        out.append(f"| {name} | Vulkan device-local sum / max | "
+                   f"{gib(d.get('device_local_sum_bytes'))} / "
+                   f"{gib(d.get('device_local_max_bytes'))} GiB | the two candidate readings |")
+    for d in sec(doc, "ggml_vulkan").get("devices") or []:
+        out.append(f"| {name} | ggml Vulkan total (what llama.cpp places against) | "
+                   f"{gib(d.get('total_bytes'))} GiB | ggml_backend_vk_get_device_memory, "
+                   f"igpu={d.get('is_igpu')} |")
+        out.append(f"| {name} | ggml Vulkan free | {gib(d.get('free_bytes'))} GiB | same call |")
+    for line in (sec(doc, "fit").get("list_devices") or {}).get("stdout", "").splitlines():
+        if "MiB" in line:
+            out.append(f"| {name} | llama-server --list-devices | `{line.strip()}` | the loader |")
+    return out
+
+
+def statements(name: str, doc: dict) -> list[tuple[str, bool | None, str]]:
+    h = host_numbers(doc)
+    vk_raw = (sec(doc, "vulkan_raw").get("devices") or [None])[0]
+    ggml = (sec(doc, "ggml_vulkan").get("devices") or [None])[0]
+    hip = (sec(doc, "hip").get("devices") or [None])[0]
+    out: list[tuple[str, bool | None, str]] = []
+
+    ggml_total = gib((ggml or {}).get("total_bytes"))
+    # The bound is visible RAM PLUS the carve-out, not visible RAM: Windows
+    # subtracts the carve-out from what it reports, so a 128 GB machine with a
+    # 64 GiB VGM shows about 63 GiB and comparing against that alone would call
+    # every honest reading an over-report.
+    physical = None
+    if h["ram_gib"] is not None:
+        physical = round(h["ram_gib"] + (h["registry_vram_gib"] or 0), 2)
+    if ggml_total is None or physical is None:
+        out.append((f"{name}: over_report", None, "no ggml Vulkan total or no host RAM reading"))
+    else:
+        out.append((f"{name}: over_report", ggml_total > physical,
+                    f"ggml reports {ggml_total} GiB where the machine holds {physical} GiB "
+                    f"({h['ram_gib']} GiB visible plus a {h['registry_vram_gib']} GiB carve-out)"))
+
+    local_sum = gib((vk_raw or {}).get("device_local_sum_bytes"))
+    local_max = gib((vk_raw or {}).get("device_local_max_bytes"))
+    all_sum = gib((vk_raw or {}).get("all_heaps_sum_bytes"))
+    if ggml_total is None or local_sum is None:
+        out.append((f"{name}: sums_heaps", None, "no raw Vulkan heaps or no ggml total"))
+    else:
+        # ggml adds EVERY heap on an integrated device, not only the device-local
+        # ones, and on Strix Halo the host-visible aperture is its own heap. An
+        # earlier version compared against the device-local sum alone and so
+        # answered NO on a machine where the summation was the whole mechanism.
+        which = ("all heaps" if close(ggml_total, all_sum)
+                 else "the device-local heaps" if close(ggml_total, local_sum) else None)
+        out.append((f"{name}: sums_heaps",
+                    bool(which) and not close(ggml_total, local_max),
+                    f"ggml {ggml_total} GiB against {all_sum} GiB over all heaps, "
+                    f"{local_sum} GiB device-local and {local_max} GiB largest"
+                    + (f": it is {which}" if which else ": it matches none of them")))
+
+    hip_total = gib((hip or {}).get("total_bytes") or (hip or {}).get("device_total_bytes"))
+    if hip_total is None or h["registry_vram_gib"] is None:
+        out.append((f"{name}: hip_is_vgm_only", None, "no HIP total or no registry VRAM"))
+    else:
+        out.append((f"{name}: hip_is_vgm_only", close(hip_total, h["registry_vram_gib"]),
+                    f"HIP {hip_total} GiB against a {h['registry_vram_gib']} GiB carve-out"))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("reports", nargs = "+", help = "probe JSON files, name=path or path")
+    ap.add_argument("--require", default = "",
+                    help = "comma-separated statements that must be decidable (not None)")
+    a = ap.parse_args()
+
+    docs: dict[str, dict] = {}
+    for item in a.reports:
+        name, _, path = item.partition("=")
+        if not path:
+            name, path = Path(item).stem.replace("memreport_", ""), item
+        try:
+            docs[name] = json.loads(Path(path).read_text(encoding = "utf-8"))
+        except Exception as e:  # noqa: BLE001
+            docs[name] = {"_error": f"{type(e).__name__}: {e}"}
+
+    print("### What each layer reports\n")
+    print("| arm | layer | value | source |")
+    print("|---|---|---|---|")
+    for name, doc in docs.items():
+        if doc.get("_error"):
+            print(f"| {name} | UNREADABLE | - | {doc['_error']} |")
+            continue
+        for line in rows_for(name, doc):
+            print(line)
+        for k, v in (doc.get("errors") or {}).items():
+            print(f"| {name} | section {k} FAILED | - | {v} |")
+
+    print("\n### Statements\n")
+    print("| statement | holds | evidence |")
+    print("|---|---|---|")
+    undecided: list[str] = []
+    for name, doc in docs.items():
+        if doc.get("_error"):
+            continue
+        for label, ok, why in statements(name, doc):
+            print(f"| {label} | {'yes' if ok else ('NO' if ok is False else 'undecided')} | {why} |")
+            if ok is None:
+                undecided.append(label)
+
+    required = [s.strip() for s in a.require.split(",") if s.strip()]
+    blocking = [u for u in undecided if any(u.endswith(": " + r) for r in required)]
+    if blocking:
+        print(f"\n**A required statement could not be decided: {blocking}.** An undecidable "
+              f"statement is a missing reading, not a negative result.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/strix_halo_repro/run.ps1
+++ b/strix_halo_repro/run.ps1
@@ -1,0 +1,200 @@
+<#
+    Strix Halo memory reporting: what every layer says this GPU has.
+
+    Run this on a Windows Ryzen AI Max (gfx1150/gfx1151) box, ideally with
+    Variable Graphics Memory set high (96 GiB is the configuration AMD reported
+    against). Everything runs from the current user: no admin, no pip install,
+    no Docker. The GPU is touched only by the allocation probe and, if you pass
+    -ModelPath, by one model load.
+
+    Default run downloads two llama.cpp release zips (~200 MB) and takes a few
+    minutes. -ModelPath additionally loads a model you already have.
+
+        powershell -ExecutionPolicy Bypass -File .\run.ps1
+        powershell -ExecutionPolicy Bypass -File .\run.ps1 -ModelPath D:\gguf\model-00001-of-00004.gguf
+
+    Send back the whole output directory: it is printed at the end.
+#>
+[CmdletBinding()]
+param(
+    [string] $Tag              = "b10798-mix-659e406",
+    [string] $Work             = "$env:USERPROFILE\strix_halo_repro",
+    [string] $ModelPath        = "",
+    [string] $PatchedDllUrl    = "",
+    [string] $PatchedDllSha256 = "",
+    [string] $Python           = ""
+)
+
+$ErrorActionPreference = "Continue"
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$rel  = "https://github.com/unslothai/llama.cpp/releases/download"
+$out  = Join-Path $Work "out"
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+function Fail($msg) {
+    Write-Host ""
+    Write-Host "FAILED: $msg" -ForegroundColor Red
+    Write-Host "Nothing further ran. Send $out anyway; a failure this early is itself the finding."
+    exit 1
+}
+
+# --- Python -----------------------------------------------------------------
+# The probes are stdlib only, so any 3.9+ interpreter does. Named explicitly
+# rather than trusting PATH: a Microsoft Store stub on PATH answers `python`
+# and then refuses to run, which reads as a broken probe rather than a missing
+# interpreter.
+if ($Python -and (Test-Path $Python)) {
+    $py = $Python
+} else {
+    $py = $null
+    foreach ($c in @("C:\Program Files\Python313\python.exe",
+                     "C:\Program Files\Python312\python.exe",
+                     "C:\Program Files\Python311\python.exe",
+                     "C:\Program Files\Python310\python.exe")) {
+        if (Test-Path $c) { $py = $c; break }
+    }
+    if (-not $py) {
+        $cmd = Get-Command python -ErrorAction SilentlyContinue
+        if ($cmd -and $cmd.Source -notlike "*WindowsApps*") { $py = $cmd.Source }
+    }
+}
+if (-not $py) { Fail "no Python 3 found. Install from python.org, or pass -Python C:\path\to\python.exe" }
+& $py -c "import sys; assert sys.version_info >= (3, 9)" 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) { Fail "the Python at $py is older than 3.9" }
+Write-Host "python: $py"
+
+# --- 1. what the machine is -------------------------------------------------
+Write-Host ""
+Write-Host "== 1. the host =============================================================="
+& $py "$here\probe.py" --state host --sections host --out "$out\host.json"
+if ($LASTEXITCODE -ne 0) { Fail "the host probe did not run" }
+$h = Get-Content "$out\host.json" -Encoding UTF8 | ConvertFrom-Json
+$ramB = [double]$h.sections.host.total_phys_bytes
+$vgmB = 0
+foreach ($ad in $h.sections.host.adapters) {
+    if ($ad.qw_memory_size -and ([double]$ad.qw_memory_size) -gt $vgmB) {
+        $vgmB = [double]$ad.qw_memory_size
+        Write-Host ("GPU: {0}  driver {1}" -f $ad.name, $ad.driver_version)
+    }
+}
+if ($vgmB -le 0) {
+    # Not fatal: every later cell reads its own numbers, and a machine whose
+    # carve-out cannot be read is itself worth reporting rather than refusing.
+    Write-Host "WARNING: no graphics carve-out found in the registry." -ForegroundColor Yellow
+    Write-Host "The over-report statement needs it, so that statement will be undecided." -ForegroundColor Yellow
+}
+$ram = [math]::Round($ramB / 1GB, 2)
+$vgm = [math]::Round($vgmB / 1GB, 2)
+$machine = [math]::Round(($ramB + $vgmB) / 1GB, 2)
+Write-Host "carve-out (registry)  : $vgm GiB"
+Write-Host "RAM Windows can see   : $ram GiB"
+Write-Host "so the machine holds  : $machine GiB"
+if ($vgm -lt 80) {
+    Write-Host ""
+    Write-Host "NOTE: the carve-out is $vgm GiB. The over-report AMD described needs a LARGE" -ForegroundColor Yellow
+    Write-Host "carve-out (96 GiB was theirs). This run is still useful, but if the numbers" -ForegroundColor Yellow
+    Write-Host "come back consistent that may only mean the carve-out is too small to show it." -ForegroundColor Yellow
+}
+
+# --- 2. the llama.cpp builds ------------------------------------------------
+Write-Host ""
+Write-Host "== 2. llama.cpp $Tag ========================================================"
+& $py "$here\fetch_llamacpp.py" --url "$rel/$Tag/app-$Tag-windows-x64-rocm-gfx1151.zip" --dest "$Work\lcpp\rocm"   --out "$out\bin_rocm.json"
+if ($LASTEXITCODE -ne 0) { Fail "the ROCm build did not download" }
+& $py "$here\fetch_llamacpp.py" --url "$rel/$Tag/app-$Tag-windows-x64-vulkan.zip"        --dest "$Work\lcpp\vulkan" --out "$out\bin_vulkan.json"
+if ($LASTEXITCODE -ne 0) { Fail "the Vulkan build did not download" }
+$rocmBin   = (Get-Content "$out\bin_rocm.json"   -Encoding UTF8 | ConvertFrom-Json).bin_dir
+$vulkanBin = (Get-Content "$out\bin_vulkan.json" -Encoding UTF8 | ConvertFrom-Json).bin_dir
+Write-Host "rocm  : $rocmBin"
+Write-Host "vulkan: $vulkanBin"
+
+# The runtime under test, when one is supplied: a copy of the release with only
+# amdhip64_7.dll replaced, so the two arms differ by one file and nothing else.
+$patchedBin = ""
+if ($PatchedDllUrl) {
+    $patchedBin = "$Work\lcpp\rocm_patched"
+    Copy-Item -Recurse -Force -LiteralPath $rocmBin -Destination $patchedBin
+    $member = ""
+    if ($PatchedDllUrl -match "\.zip($|\?)") { $member = "amdhip64_7.dll" }
+    & $py "$here\fetch.py" --url $PatchedDllUrl --dest "$patchedBin\amdhip64_7.dll" `
+        --zip-member "$member" --expect-sha256 $PatchedDllSha256 --out "$out\patched_dll.json"
+    if ($LASTEXITCODE -ne 0) { Fail "the runtime under test did not download, or did not match its hash" }
+    Write-Host "patched HIP runtime staged at $patchedBin"
+}
+
+# --- 3. what every layer reports --------------------------------------------
+Write-Host ""
+Write-Host "== 3. what every layer reports =============================================="
+& $py "$here\probe.py" --state stock --checkout $rocmBin --vulkan-dir $vulkanBin `
+    --sections host,hip,vulkan_raw,ggml_vulkan --out "$out\memreport_stock.json"
+if ($LASTEXITCODE -ne 0) { Write-Host "the memory report exited non-zero; the JSON still holds whatever it reached" }
+
+# --- 4. the largest single allocation ---------------------------------------
+# Bounded at 92% of the machine on purpose. The patched runtime's own note warns
+# that committing near all of RAM can hang the host or bugcheck it (0x19C), and
+# the question is whether an allocation the shipped runtime refuses now succeeds,
+# not what the new ceiling is.
+$ceil = [math]::Round($machine * 0.92, 1)
+Write-Host ""
+Write-Host "== 4. largest single hipMalloc that writes and reads back (search stops at $ceil GiB) =="
+& $py "$here\probe.py" --state stock --checkout $rocmBin --sections host,hip,alloc_cap `
+    --alloc-lo-gib 1 --alloc-hi-gib $ceil --alloc-resolution-gib 0.5 --alloc-reps 2 `
+    --out "$out\alloccap_stock.json"
+if ($patchedBin) {
+    & $py "$here\probe.py" --state patched --checkout $patchedBin --sections host,hip,alloc_cap `
+        --alloc-lo-gib 1 --alloc-hi-gib $ceil --alloc-resolution-gib 0.5 --alloc-reps 2 `
+        --out "$out\alloccap_patched.json"
+}
+
+# --- 5. what Unsloth Studio would see ---------------------------------------
+# Studio's own probe verbatim at a pinned commit. A re-implementation here would
+# answer a different question: the claim is about what Studio sees.
+Write-Host ""
+Write-Host "== 5. Unsloth Studio's own Vulkan probe ====================================="
+& $py "$here\fetch.py" `
+    --url "https://raw.githubusercontent.com/unslothai/unsloth/ca42c015f/studio/backend/core/inference/_vulkan_probe.py" `
+    --dest "$out\_vulkan_probe.py" --out "$out\studio_probe_source.json"
+if ($LASTEXITCODE -eq 0) {
+    & $py "$out\_vulkan_probe.py" $vulkanBin 2>&1 | Tee-Object -FilePath "$out\studio_vulkan_probe.txt"
+    Write-Host "(index, free bytes, is_igpu, total bytes, name)"
+} else {
+    Write-Host "Studio's probe could not be fetched; this cell has no reading."
+}
+
+# --- 6. what llama.cpp would place, for a model you already have -------------
+# llama-fit-params answers the placement question without serving, so this needs
+# no port, no lifecycle and no generation: it reports what --fit decides against
+# the numbers cell 3 measured, which is where an over-report turns into a model
+# that will not load.
+if ($ModelPath) {
+    Write-Host ""
+    Write-Host "== 6. what --fit would place ================================================"
+    if (-not (Test-Path $ModelPath)) { Fail "-ModelPath does not exist: $ModelPath" }
+    & $py "$here\probe.py" --state fit_rocm   --checkout $rocmBin   --sections fit --fit-model $ModelPath --out "$out\fit_rocm.json"
+    & $py "$here\probe.py" --state fit_vulkan --checkout $vulkanBin --sections fit --fit-model $ModelPath --out "$out\fit_vulkan.json"
+    foreach ($f in @("fit_rocm", "fit_vulkan")) {
+        $j = Get-Content "$out\$f.json" -Encoding UTF8 | ConvertFrom-Json
+        Write-Host "-- $f"
+        Write-Host ($j.sections.fit.list_devices.stdout)
+        if ($j.sections.fit.fit_params) {
+            Write-Host ($j.sections.fit.fit_params.stdout)
+            Write-Host ($j.sections.fit.fit_params.stderr)
+        } else {
+            Write-Host "   llama-fit-params is not in this build, so only --list-devices was read."
+        }
+    }
+} else {
+    Write-Host ""
+    Write-Host "== 6. skipped: pass -ModelPath <first shard> to also ask what --fit would place"
+}
+
+# --- 7. the report ----------------------------------------------------------
+Write-Host ""
+Write-Host "== the three statements ====================================================="
+$reports = @("stock=$out\memreport_stock.json")
+& $py "$here\report.py" @reports 2>&1 | Tee-Object -FilePath "$out\REPORT.md"
+
+Write-Host ""
+Write-Host "Done. Send back this whole directory:" -ForegroundColor Green
+Write-Host "  $out"
+Write-Host "It holds REPORT.md plus the raw JSON every number came from."


### PR DESCRIPTION
Throwaway PR. Do not merge. It exists so someone with a Strix Halo box set to a large
graphics carve-out can run one script and send back a directory of JSON.

## Why

AMD report two things about Strix Halo, both of which they see at a 96 GiB Variable
Graphics Memory setting:

1. llama.cpp reads the VGM carve-out as shared iGPU memory, so large models will not load.
2. ROCm will not load more than 64 GB because of an old HIP DLL in the llama.cpp artifact.

Our Strix Halo CI runner is a 128 GB machine with a **64 GiB** carve-out, and at that size
neither claim reproduces:

| layer | what it reports on the runner |
|---|---|
| registry `HardwareInformation.qwMemorySize` (the carve-out) | 64.00 GiB |
| `GlobalMemoryStatusEx` visible RAM | 63.65 GiB |
| the machine (visible + carve-out) | 127.65 GiB |
| Vulkan raw heaps | 37.22 GiB and 74.43 GiB (DEVICE_LOCAL) |
| **ggml Vulkan total** | **111.65 GiB** (the sum of both heaps, exactly) |
| HIP `hipMemGetInfo` total | 99.74 GiB |
| largest single `hipMalloc` that allocated and read back | **110.2 GiB** |
| UD-Q4_K_XL (about 77 GiB on device) | loads and serves on ROCm and on Vulkan |

The summation mechanism is real and confirmed to the byte: ggml adds every heap on an
integrated device, not just the device-local ones. But at a 64 GiB carve-out the sum stays
under the machine, so nothing impossible is claimed and the model loads. Windows subtracts
the carve-out from visible RAM, so as the carve-out grows the heap sum grows while the
physical bound does not: at 96 GiB the same call is expected to report more memory than the
machine physically has, which is what AMD saw. That is why this needs their configuration
and not ours.

Same for the allocation cap. The stock rule is not a flat 64 GiB clamp, it is
`max(dedicated_VRAM_heap, 0.75 * shared_GART_heap)`. On the runner the GART branch wins,
which is where 110.2 GiB comes from. On a larger carve-out the dedicated branch may dominate
instead, and then the interesting arm is the memory report rather than the cap.

## What to do

On a Windows Strix Halo box, set the carve-out to 96 GiB (firmware UMA Frame Buffer Size, or
Adrenalin -> Performance -> Tuning -> Variable Graphics Memory), reboot, then:

```
cd strix_halo_repro
powershell -ExecutionPolicy Bypass -File run.ps1 -OutDir C:\strix_out
python report.py C:\strix_out\*.json
```

It downloads two stock llama.cpp release builds (ROCm gfx1151 and Vulkan) at a pinned tag,
runs six cells, and writes JSON per cell. Nothing is compiled and nothing is installed.
Budget about 30 minutes plus the model download if you include the model cells.

`report.py` prints one table of what every layer reports next to the machine's real memory,
and three statements as yes or no:

- `over_report`: does ggml claim more memory than the machine physically has
- `sums_heaps`: is that number the heaps added together rather than the largest one
- `hip_is_vgm_only`: does HIP report only the carve-out

On the 64 GiB runner those come out NO / yes / NO. On a 96 GiB box the first is expected to
flip, and that flip is the bug AMD are describing.

## The allocation search is deliberately bounded

Cell 4 stops at 92 percent of physical RAM. AMD's own note with the patched runtime warns
that an allocation near 100 percent of usable RAM can hang the host or trigger a
`WIN32K_POWER_WATCHDOG_TIMEOUT` bugcheck. The question worth answering is whether an
allocation the stock runtime refused now succeeds, not what the new ceiling is, and a
bounded search answers it without going near that condition. Every success is verified by
writing the buffer and reading it back, not by `hipMalloc` returning.

## What to send back

The whole output directory. It contains the host facts, the raw per-heap Vulkan numbers,
the HIP numbers, the allocation boundary, what Studio's own Vulkan probe returns, and
`llama-fit-params` on both backends. `README.md` in the folder says what each cell measures
and what a wrong-looking answer looks like, so a cell that fails is still informative.
