### PR TITLE
Assert the release publishing path uploads the wheel only

### DIFF
--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -6,8 +6,15 @@
 # Unsloth bundle that 2026.5.1 published. This is the single workflow that
 # would have blocked the 2026.5.1 release before twine upload.
 #
+# The release publishes a WHEEL ONLY. Build it with:
+#
+#     python -m build --wheel && twine upload dist/*
+#
+# Not a bare `python -m build`: that also writes an sdist into dist/, which
+# twine would then upload.
+#
 # Verified locally end-to-end against this branch:
-#   - python -m build produces unsloth-<version>-py3-none-any.whl in 13s
+#   - python -m build --wheel produces unsloth-<version>-py3-none-any.whl in 13s
 #   - wheel content sanity passes:
 #       lockfile shipped, frontend dist shipped,
 #       no node_modules in wheel, no bun.lock in wheel,
@@ -80,11 +87,19 @@ jobs:
           npm ci --no-fund --no-audit
           npm run build
 
-      - name: Build wheel + sdist
+      - name: Build wheel
+        # --wheel, not a bare `python -m build`, because that is what the release
+        # runs and the two are not the same code path. A bare build makes the
+        # sdist first and then builds the wheel FROM the sdist, where the
+        # packages.find and exclude-package-data vetoes in pyproject.toml no
+        # longer bite and MANIFEST.in is the only thing holding; --wheel builds
+        # straight from the checkout, where the reverse is true. Testing the
+        # sdist path while shipping the direct one would leave the shipped
+        # artifact unverified.
         run: |
           python -m pip install --upgrade pip build
           rm -rf dist build ./*.egg-info
-          python -m build
+          python -m build --wheel
 
       - name: Wheel content sanity
         run: |
@@ -121,12 +136,19 @@ jobs:
               sys.exit(0 if all(checks.values()) else 1)
           PY
 
-      - name: No test suites in wheel or sdist
+      - name: No test suites in the wheel, and no sdist at all
         # tests/security/fixtures embeds a real supply-chain IOC literal, which got
         # the published sdist flagged by antivirus vendors (discussion #9577).
+        #
+        # The sdist is no longer published: it was ~48% of the project's PyPI
+        # storage (4.85 GB of 10.04 GB across 227 releases) for an artifact
+        # nothing installs, since the wheel is py3-none-any and matches every
+        # environment. So this step now also asserts the build produced no sdist,
+        # which is what keeps a future `python -m build` from quietly putting one
+        # back into dist/ for twine to upload.
         run: |
           python - <<'PY'
-          import glob, sys, tarfile, zipfile
+          import glob, sys, zipfile
 
           def is_test(path):
               return "tests" in path.strip("/").split("/")
@@ -146,17 +168,17 @@ jobs:
           ok = True
           wheels = glob.glob("dist/unsloth-*.whl")
           sdists = glob.glob("dist/unsloth-*.tar.gz")
-          if not wheels or not sdists:
-              print("FAIL: expected one wheel and one sdist in dist/")
+          if not wheels:
+              print("FAIL: no wheel in dist/")
               sys.exit(2)
+          if sdists:
+              # Not a warning. dist/ is what twine uploads, so an sdist sitting
+              # here is an sdist published.
+              print(f"FAIL: the build produced an sdist: {sdists}")
+              print("Release builds with `python -m build --wheel`; see the header of this file.")
+              sys.exit(1)
           with zipfile.ZipFile(wheels[0]) as z:
               ok &= report(f"wheel {wheels[0]}", z.namelist())
-          with tarfile.open(sdists[0]) as t:
-              # Every sdist member carries an "unsloth-<version>/" prefix.
-              ok &= report(
-                  f"sdist {sdists[0]}",
-                  [n.split("/", 1)[1] for n in t.getnames() if "/" in n],
-              )
           print("PASS" if ok else "FAIL: test files are being shipped")
           sys.exit(0 if ok else 1)
           PY

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -146,7 +146,11 @@ jobs:
           # which publishes the sdist. Flags that consume a value are skipped by
           # name rather than by position, so `-r pypi dist/*.whl` stays a PASS.
           VALUED_FLAGS = {
-              "-r", "--repository", "--repository-url", "-s", "--sign-with",
+              # -s/--sign is store_true and consumes nothing; only --sign-with
+              # takes a value. Listing -s here made the parser swallow the next
+              # argument, so `twine upload -s dist/*.tar.gz dist/*.whl` hid the
+              # tarball and passed.
+              "-r", "--repository", "--repository-url", "--sign-with",
               "-i", "--identity", "-u", "--username", "-p", "--password",
               "-c", "--comment", "--config-file", "--cert", "--client-cert",
           }

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -6,15 +6,8 @@
 # Unsloth bundle that 2026.5.1 published. This is the single workflow that
 # would have blocked the 2026.5.1 release before twine upload.
 #
-# The release publishes a WHEEL ONLY. Build it with:
-#
-#     python -m build --wheel && twine upload dist/*
-#
-# Not a bare `python -m build`: that also writes an sdist into dist/, which
-# twine would then upload.
-#
 # Verified locally end-to-end against this branch:
-#   - python -m build --wheel produces unsloth-<version>-py3-none-any.whl in 13s
+#   - python -m build produces unsloth-<version>-py3-none-any.whl in 13s
 #   - wheel content sanity passes:
 #       lockfile shipped, frontend dist shipped,
 #       no node_modules in wheel, no bun.lock in wheel,
@@ -87,19 +80,11 @@ jobs:
           npm ci --no-fund --no-audit
           npm run build
 
-      - name: Build wheel
-        # --wheel, not a bare `python -m build`, because that is what the release
-        # runs and the two are not the same code path. A bare build makes the
-        # sdist first and then builds the wheel FROM the sdist, where the
-        # packages.find and exclude-package-data vetoes in pyproject.toml no
-        # longer bite and MANIFEST.in is the only thing holding; --wheel builds
-        # straight from the checkout, where the reverse is true. Testing the
-        # sdist path while shipping the direct one would leave the shipped
-        # artifact unverified.
+      - name: Build wheel + sdist
         run: |
           python -m pip install --upgrade pip build
           rm -rf dist build ./*.egg-info
-          python -m build --wheel
+          python -m build
 
       - name: Wheel content sanity
         run: |
@@ -136,19 +121,45 @@ jobs:
               sys.exit(0 if all(checks.values()) else 1)
           PY
 
-      - name: No test suites in the wheel, and no sdist at all
+      - name: Publishing path uploads the wheel only
+        # #10202 made `./build.sh publish` upload dist/*.whl rather than dist/*,
+        # because the sdist is the larger half of a ~169MB release and the PyPI
+        # project limit is 10GB. It did not stick: 2026.9.2 was published the
+        # same day with an 86.6MB sdist, because the release was driven by a
+        # hand-typed `twine upload dist/*` instead of build.sh.
+        #
+        # build.sh still BUILDS the sdist on purpose, so --verify-dist can check
+        # the Studio release stamp in both artifacts. The thing that must not
+        # regress is the upload glob, so that is what this asserts.
+        run: |
+          python - <<'PY'
+          import re, sys
+          src = open("build.sh").read()
+          uploads = re.findall(r"twine upload\s+(\S+)", src)
+          print(f"twine upload targets in build.sh: {uploads}")
+          if not uploads:
+              print("FAIL: build.sh has no twine upload line; has the release path moved?")
+              sys.exit(1)
+          bad = [u for u in uploads if not u.endswith(".whl")]
+          if bad:
+              print(f"FAIL: build.sh would upload non-wheel artifacts: {bad}")
+              print("Publishing an sdist costs ~86MB of a 10GB project limit for an")
+              print("artifact nothing installs; the wheel is py3-none-any.")
+              sys.exit(1)
+          print("PASS: build.sh uploads wheels only")
+          PY
+
+      - name: No test suites in wheel or sdist
         # tests/security/fixtures embeds a real supply-chain IOC literal, which got
         # the published sdist flagged by antivirus vendors (discussion #9577).
         #
-        # The sdist is no longer published: it was ~48% of the project's PyPI
-        # storage (4.85 GB of 10.04 GB across 227 releases) for an artifact
-        # nothing installs, since the wheel is py3-none-any and matches every
-        # environment. So this step now also asserts the build produced no sdist,
-        # which is what keeps a future `python -m build` from quietly putting one
-        # back into dist/ for twine to upload.
+        # Both artifacts, still: the sdist is built locally by build.sh even
+        # though it is not uploaded, and a bare `python -m build` builds the
+        # wheel FROM the sdist, so a test suite reaching the sdist reaches the
+        # wheel too.
         run: |
           python - <<'PY'
-          import glob, sys, zipfile
+          import glob, sys, tarfile, zipfile
 
           def is_test(path):
               return "tests" in path.strip("/").split("/")
@@ -168,17 +179,17 @@ jobs:
           ok = True
           wheels = glob.glob("dist/unsloth-*.whl")
           sdists = glob.glob("dist/unsloth-*.tar.gz")
-          if not wheels:
-              print("FAIL: no wheel in dist/")
+          if not wheels or not sdists:
+              print("FAIL: expected one wheel and one sdist in dist/")
               sys.exit(2)
-          if sdists:
-              # Not a warning. dist/ is what twine uploads, so an sdist sitting
-              # here is an sdist published.
-              print(f"FAIL: the build produced an sdist: {sdists}")
-              print("Release builds with `python -m build --wheel`; see the header of this file.")
-              sys.exit(1)
           with zipfile.ZipFile(wheels[0]) as z:
               ok &= report(f"wheel {wheels[0]}", z.namelist())
+          with tarfile.open(sdists[0]) as t:
+              # Every sdist member carries an "unsloth-<version>/" prefix.
+              ok &= report(
+                  f"sdist {sdists[0]}",
+                  [n.split("/", 1)[1] for n in t.getnames() if "/" in n],
+              )
           print("PASS" if ok else "FAIL: test files are being shipped")
           sys.exit(0 if ok else 1)
           PY

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -236,10 +236,21 @@ jobs:
                       if candidate == terminator:
                           terminator = None
                       continue
-                  opened = re.search(r"<<(-?)\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\2", line)
+                  # The delimiter is a shell WORD, not an identifier, so
+                  # `cat <<'PUBLISH-USAGE'` is a heredoc and its body is text.
+                  # Requiring [A-Za-z_][A-Za-z0-9_]* read that body as commands.
+                  # A quoted delimiter may hold anything; unquoted it still has
+                  # to start with a letter, because `$((1<<2))` is a shift, not
+                  # a heredoc. The lookbehind is what keeps `cmd <<<'a-b'` out:
+                  # a here-string contains `<<`, and matching it swallowed the
+                  # rest of the file as a heredoc body.
+                  opened = re.search(
+                      r"(?<!<)<<(-?)\s*(?:'([^']*)'|\"([^\"]*)\"|\\?([A-Za-z_][A-Za-z0-9_.-]*))",
+                      line,
+                  )
                   if opened:
                       dash = bool(opened.group(1))
-                      terminator = opened.group(3)
+                      terminator = next(g for g in opened.groups()[1:] if g is not None)
                       continue
                   if line.lstrip().startswith("#"):
                       continue

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -22,6 +22,11 @@ on:
     paths:
       - 'pyproject.toml'
       - 'MANIFEST.in'
+      # The "Publishing path uploads the wheel only" step reads build.sh. A guard
+      # that does not run when its own subject changes cannot guard it: without
+      # this entry, a PR that only reverts the upload glob to dist/* skips the
+      # workflow entirely.
+      - 'build.sh'
       - 'studio/**'
       - 'unsloth/**'
       - 'unsloth_cli/**'
@@ -31,6 +36,7 @@ on:
     paths:
       - 'pyproject.toml'
       - 'MANIFEST.in'
+      - 'build.sh'
       - 'studio/**'
       - 'unsloth/**'
       - 'unsloth_cli/**'
@@ -133,10 +139,53 @@ jobs:
         # regress is the upload glob, so that is what this asserts.
         run: |
           python - <<'PY'
-          import re, sys
+          import re, shlex, sys
+
+          # `twine upload` takes `dist [dist ...]`, so every positional counts:
+          # checking only the first would pass `twine upload dist/*.whl dist/*.tar.gz`,
+          # which publishes the sdist. Flags that consume a value are skipped by
+          # name rather than by position, so `-r pypi dist/*.whl` stays a PASS.
+          VALUED_FLAGS = {
+              "-r", "--repository", "--repository-url", "-s", "--sign-with",
+              "-i", "--identity", "-u", "--username", "-p", "--password",
+              "-c", "--comment", "--config-file", "--cert", "--client-cert",
+          }
+
+          def positionals(argstr):
+              try:
+                  toks = shlex.split(argstr, comments=True)
+              except ValueError:
+                  # Unbalanced quoting: not something this guard can read, so
+                  # refuse rather than wave it through.
+                  return None
+              out, skip = [], False
+              for t in toks:
+                  if skip:
+                      skip = False
+                      continue
+                  if t.startswith("-"):
+                      skip = t in VALUED_FLAGS
+                      continue
+                  out.append(t)
+              return out
+
           src = open("build.sh").read()
-          uploads = re.findall(r"twine upload\s+(\S+)", src)
+          lines = [l for l in src.splitlines() if not l.lstrip().startswith("#")]
+          uploads = []
+          unreadable = False
+          for line in lines:
+              m = re.search(r"twine upload\b(.*)$", line)
+              if not m:
+                  continue
+              args = positionals(m.group(1))
+              if args is None:
+                  unreadable = True
+                  continue
+              uploads.extend(args)
           print(f"twine upload targets in build.sh: {uploads}")
+          if unreadable:
+              print("FAIL: could not parse a twine upload line in build.sh")
+              sys.exit(1)
           if not uploads:
               print("FAIL: build.sh has no twine upload line; has the release path moved?")
               sys.exit(1)

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -173,8 +173,33 @@ jobs:
                   out.append(t)
               return out
 
+          def executable_lines(text):
+              """build.sh lines the shell would actually run.
+
+              Comments and heredoc bodies are text, not commands, but both can
+              contain a line that starts with `twine upload dist/*.whl` -- usage
+              output being the obvious one. Counting that as the upload lets a
+              build.sh whose real publish line was deleted still report PASS,
+              which is the one thing the has-an-upload check exists to catch.
+              """
+              out, terminator = [], None
+              for line in text.splitlines():
+                  if terminator is not None:
+                      # <<- strips leading tabs from the terminator, << does not.
+                      if line.strip() == terminator:
+                          terminator = None
+                      continue
+                  opened = re.search(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1", line)
+                  if opened:
+                      terminator = opened.group(2)
+                      continue
+                  if line.lstrip().startswith("#"):
+                      continue
+                  out.append(line)
+              return out
+
           src = open("build.sh").read()
-          lines = [l for l in src.splitlines() if not l.lstrip().startswith("#")]
+          lines = executable_lines(src)
           uploads = []
           unreadable = False
           for line in lines:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -178,7 +178,12 @@ jobs:
           uploads = []
           unreadable = False
           for line in lines:
-              m = re.search(r"twine upload\b(.*)$", line)
+              # Anchored to the start of the command, so only an invocation
+              # counts. Unanchored, a shell no-op that never publishes anything
+              # (`: twine upload dist/*.whl`) still registered a wheel target and
+              # satisfied the has-an-upload check below, which is the one thing
+              # that check exists to catch.
+              m = re.match(r"\s*(?:python[0-9.]*\s+-m\s+)?twine\s+upload\b(.*)$", line)
               if not m:
                   continue
               args = positionals(m.group(1))

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -22,10 +22,8 @@ on:
     paths:
       - 'pyproject.toml'
       - 'MANIFEST.in'
-      # The "Publishing path uploads the wheel only" step reads build.sh. A guard
-      # that does not run when its own subject changes cannot guard it: without
-      # this entry, a PR that only reverts the upload glob to dist/* skips the
-      # workflow entirely.
+      # Required: the publish guard reads build.sh, so a PR reverting the upload
+      # glob must not skip this workflow.
       - 'build.sh'
       - 'studio/**'
       - 'unsloth/**'
@@ -128,28 +126,17 @@ jobs:
           PY
 
       - name: Publishing path uploads the wheel only
-        # #10202 made `./build.sh publish` upload dist/*.whl rather than dist/*,
-        # because the sdist is the larger half of a ~169MB release and the PyPI
-        # project limit is 10GB. It did not stick: 2026.9.2 was published the
-        # same day with an 86.6MB sdist, because the release was driven by a
-        # hand-typed `twine upload dist/*` instead of build.sh.
-        #
-        # build.sh still BUILDS the sdist on purpose, so --verify-dist can check
-        # the Studio release stamp in both artifacts. The thing that must not
-        # regress is the upload glob, so that is what this asserts.
+        # #10202 set the publish glob to dist/*.whl; 2026.9.2 shipped an 86.6MB
+        # sdist anyway. build.sh must still BUILD the sdist for --verify-dist, so
+        # only the upload glob is asserted here.
         run: |
           python - <<'PY'
           import re, shlex, sys
 
-          # `twine upload` takes `dist [dist ...]`, so every positional counts:
-          # checking only the first would pass `twine upload dist/*.whl dist/*.tar.gz`,
-          # which publishes the sdist. Flags that consume a value are skipped by
-          # name rather than by position, so `-r pypi dist/*.whl` stays a PASS.
+          # twine upload takes `dist [dist ...]`, so every positional counts. Flags
+          # are skipped by name, not by position; -s/--sign is store_true, and
+          # listing it here swallowed the sdist after it.
           VALUED_FLAGS = {
-              # -s/--sign is store_true and consumes nothing; only --sign-with
-              # takes a value. Listing -s here made the parser swallow the next
-              # argument, so `twine upload -s dist/*.tar.gz dist/*.whl` hid the
-              # tarball and passed.
               "-r", "--repository", "--repository-url", "--sign-with",
               "-i", "--identity", "-u", "--username", "-p", "--password",
               "-c", "--comment", "--config-file", "--cert", "--client-cert",
@@ -160,18 +147,13 @@ jobs:
           def segments(line):
               """One token list per command on the line, split on control operators.
 
-              Ending the scan at the first operator was wrong in one direction:
-              it correctly ignored the right-hand side of a pipe, but it also
-              discarded a SECOND upload, so
-              `twine upload dist/*.whl && twine upload dist/*.tar.gz` recorded
-              only the wheel and passed while the sdist was published too. Each
-              segment is a command in its own right and is judged on its own.
+              `twine upload dist/*.whl && twine upload dist/*.tar.gz` publishes
+              both, so stopping at the first operator is not enough.
               """
               try:
                   toks = shlex.split(line, comments=True)
               except ValueError:
-                  # Unbalanced quoting: not something this guard can read, so
-                  # refuse rather than wave it through.
+                  # Unbalanced quoting: refuse rather than wave it through.
                   return None
               out, current = [], []
               for t in toks:
@@ -186,12 +168,8 @@ jobs:
           def upload_args(seg):
               """twine's positional arguments, or None when seg is not an upload."""
               head = list(seg)
-              # A command may be preceded by variable assignments, and twine's
-              # own credential story drives people straight to it
-              # (TWINE_USERNAME=__token__ python -m twine upload dist/*.whl).
-              # Reading the assignment as the command hid the whole invocation:
-              # a wheel-only build.sh failed with "no twine upload line", and an
-              # sdist upload alongside a visible wheel one went uncounted.
+              # `TWINE_USERNAME=__token__ twine upload ...` still runs twine: an
+              # assignment prefix is not the command.
               while head and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*\+?=.*", head[0], re.S):
                   head = head[1:]
               if head[:3] == ["python", "-m", "twine"] or (
@@ -209,9 +187,8 @@ jobs:
                   if skip:
                       skip = False
                       continue
-                  # Redirections are shell syntax, not artifacts. `>twine.log`
-                  # arrives as one token and used to be reported as a non-wheel
-                  # artifact, failing CI on a perfectly valid upload line.
+                  # Redirections are shell syntax, not artifacts; `>twine.log`
+                  # arrives as one token.
                   redirect = re.match(r"^\d*(?:>>|>&|>|<<?|&>)(.*)$", t)
                   if redirect:
                       # Bare operator: its target is the next token.
@@ -226,32 +203,21 @@ jobs:
           def executable_lines(text):
               """build.sh lines the shell would actually run.
 
-              Comments and heredoc bodies are text, not commands, but both can
-              contain a line that starts with `twine upload dist/*.whl` -- usage
-              output being the obvious one. Counting that as the upload lets a
-              build.sh whose real publish line was deleted still report PASS,
-              which is the one thing the has-an-upload check exists to catch.
+              Usage text inside a heredoc names `twine upload dist/*.whl` too, and
+              counting it lets a build.sh with no publish line report PASS.
               """
               out, terminator, dash = [], None, False
               for line in text.splitlines():
                   if terminator is not None:
-                      # Bash closes <<WORD only on an EXACT match; an indented
-                      # copy of the delimiter stays part of the body. <<-WORD
-                      # strips leading TABS (not spaces) before comparing. Using
-                      # .strip() for both closed a << heredoc early, so the text
-                      # after it was read as commands.
+                      # Bash closes <<WORD on an EXACT match only; <<-WORD strips
+                      # leading TABS, not spaces, before comparing.
                       candidate = line.lstrip("\t") if dash else line
                       if candidate == terminator:
                           terminator = None
                       continue
-                  # The delimiter is a shell WORD, not an identifier, so
-                  # `cat <<'PUBLISH-USAGE'` is a heredoc and its body is text.
-                  # Requiring [A-Za-z_][A-Za-z0-9_]* read that body as commands.
-                  # A quoted delimiter may hold anything; unquoted it still has
-                  # to start with a letter, because `$((1<<2))` is a shift, not
-                  # a heredoc. The lookbehind is what keeps `cmd <<<'a-b'` out:
-                  # a here-string contains `<<`, and matching it swallowed the
-                  # rest of the file as a heredoc body.
+                  # The delimiter is a shell WORD, so `<<'PUBLISH-USAGE'` opens a
+                  # heredoc. Unquoted it must still start with a letter, or
+                  # `$((1<<2))` opens one too; the lookbehind excludes `<<<`.
                   opened = re.search(
                       r"(?<!<)<<(-?)\s*(?:'([^']*)'|\"([^\"]*)\"|\\?([A-Za-z_][A-Za-z0-9_.-]*))",
                       line,
@@ -274,11 +240,8 @@ jobs:
               if parts is None:
                   unreadable = True
                   continue
-              # Every command on the line, judged separately. A segment only
-              # counts when twine IS the command: a shell no-op that merely names
-              # it (`: twine upload dist/*.whl`) has ':' as its command, so it no
-              # longer satisfies the has-an-upload check below, which is the one
-              # thing that check exists to catch.
+              # A segment counts only when twine IS the command, so the no-op
+              # `: twine upload dist/*.whl` is not an upload.
               for seg in parts:
                   args = upload_args(seg)
                   if args is not None:
@@ -303,10 +266,8 @@ jobs:
         # tests/security/fixtures embeds a real supply-chain IOC literal, which got
         # the published sdist flagged by antivirus vendors (discussion #9577).
         #
-        # Both artifacts, still: the sdist is built locally by build.sh even
-        # though it is not uploaded, and a bare `python -m build` builds the
-        # wheel FROM the sdist, so a test suite reaching the sdist reaches the
-        # wheel too.
+        # Both artifacts: `python -m build` builds the wheel FROM the sdist, so a
+        # test suite reaching one reaches the other.
         run: |
           python - <<'PY'
           import glob, sys, tarfile, zipfile

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -167,6 +167,18 @@ jobs:
                   if skip:
                       skip = False
                       continue
+                  # A control operator ends this command; whatever follows is a
+                  # different one and its words are not twine's arguments.
+                  if t in {"|", "||", "&&", ";", "&"}:
+                      break
+                  # Redirections are shell syntax, not artifacts. `>twine.log`
+                  # arrives as one token and used to be reported as a non-wheel
+                  # artifact, failing CI on a perfectly valid upload line.
+                  redirect = re.match(r"^\d*(?:>>|>&|>|<<?|&>)(.*)$", t)
+                  if redirect:
+                      # Bare operator: its target is the next token.
+                      skip = not redirect.group(1)
+                      continue
                   if t.startswith("-"):
                       skip = t in VALUED_FLAGS
                       continue
@@ -182,16 +194,22 @@ jobs:
               build.sh whose real publish line was deleted still report PASS,
               which is the one thing the has-an-upload check exists to catch.
               """
-              out, terminator = [], None
+              out, terminator, dash = [], None, False
               for line in text.splitlines():
                   if terminator is not None:
-                      # <<- strips leading tabs from the terminator, << does not.
-                      if line.strip() == terminator:
+                      # Bash closes <<WORD only on an EXACT match; an indented
+                      # copy of the delimiter stays part of the body. <<-WORD
+                      # strips leading TABS (not spaces) before comparing. Using
+                      # .strip() for both closed a << heredoc early, so the text
+                      # after it was read as commands.
+                      candidate = line.lstrip("\t") if dash else line
+                      if candidate == terminator:
                           terminator = None
                       continue
-                  opened = re.search(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1", line)
+                  opened = re.search(r"<<(-?)\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\2", line)
                   if opened:
-                      terminator = opened.group(2)
+                      dash = bool(opened.group(1))
+                      terminator = opened.group(3)
                       continue
                   if line.lstrip().startswith("#"):
                       continue

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -186,6 +186,14 @@ jobs:
           def upload_args(seg):
               """twine's positional arguments, or None when seg is not an upload."""
               head = list(seg)
+              # A command may be preceded by variable assignments, and twine's
+              # own credential story drives people straight to it
+              # (TWINE_USERNAME=__token__ python -m twine upload dist/*.whl).
+              # Reading the assignment as the command hid the whole invocation:
+              # a wheel-only build.sh failed with "no twine upload line", and an
+              # sdist upload alongside a visible wheel one went uncounted.
+              while head and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*\+?=.*", head[0], re.S):
+                  head = head[1:]
               if head[:3] == ["python", "-m", "twine"] or (
                   head and re.fullmatch(r"python[0-9.]*", head[0]) and head[1:3] == ["-m", "twine"]
               ):

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -155,22 +155,52 @@ jobs:
               "-c", "--comment", "--config-file", "--cert", "--client-cert",
           }
 
-          def positionals(argstr):
+          OPERATORS = {"|", "||", "&&", ";", "&"}
+
+          def segments(line):
+              """One token list per command on the line, split on control operators.
+
+              Ending the scan at the first operator was wrong in one direction:
+              it correctly ignored the right-hand side of a pipe, but it also
+              discarded a SECOND upload, so
+              `twine upload dist/*.whl && twine upload dist/*.tar.gz` recorded
+              only the wheel and passed while the sdist was published too. Each
+              segment is a command in its own right and is judged on its own.
+              """
               try:
-                  toks = shlex.split(argstr, comments=True)
+                  toks = shlex.split(line, comments=True)
               except ValueError:
                   # Unbalanced quoting: not something this guard can read, so
                   # refuse rather than wave it through.
                   return None
-              out, skip = [], False
+              out, current = [], []
               for t in toks:
+                  if t in OPERATORS:
+                      out.append(current)
+                      current = []
+                      continue
+                  current.append(t)
+              out.append(current)
+              return out
+
+          def upload_args(seg):
+              """twine's positional arguments, or None when seg is not an upload."""
+              head = list(seg)
+              if head[:3] == ["python", "-m", "twine"] or (
+                  head and re.fullmatch(r"python[0-9.]*", head[0]) and head[1:3] == ["-m", "twine"]
+              ):
+                  head = head[3:]
+              elif head[:1] == ["twine"]:
+                  head = head[1:]
+              else:
+                  return None
+              if head[:1] != ["upload"]:
+                  return None
+              out, skip = [], False
+              for t in head[1:]:
                   if skip:
                       skip = False
                       continue
-                  # A control operator ends this command; whatever follows is a
-                  # different one and its words are not twine's arguments.
-                  if t in {"|", "||", "&&", ";", "&"}:
-                      break
                   # Redirections are shell syntax, not artifacts. `>twine.log`
                   # arrives as one token and used to be reported as a non-wheel
                   # artifact, failing CI on a perfectly valid upload line.
@@ -221,19 +251,19 @@ jobs:
           uploads = []
           unreadable = False
           for line in lines:
-              # Anchored to the start of the command, so only an invocation
-              # counts. Unanchored, a shell no-op that never publishes anything
-              # (`: twine upload dist/*.whl`) still registered a wheel target and
-              # satisfied the has-an-upload check below, which is the one thing
-              # that check exists to catch.
-              m = re.match(r"\s*(?:python[0-9.]*\s+-m\s+)?twine\s+upload\b(.*)$", line)
-              if not m:
-                  continue
-              args = positionals(m.group(1))
-              if args is None:
+              parts = segments(line)
+              if parts is None:
                   unreadable = True
                   continue
-              uploads.extend(args)
+              # Every command on the line, judged separately. A segment only
+              # counts when twine IS the command: a shell no-op that merely names
+              # it (`: twine upload dist/*.whl`) has ':' as its command, so it no
+              # longer satisfies the has-an-upload check below, which is the one
+              # thing that check exists to catch.
+              for seg in parts:
+                  args = upload_args(seg)
+                  if args is not None:
+                      uploads.extend(args)
           print(f"twine upload targets in build.sh: {uploads}")
           if unreadable:
               print("FAIL: could not parse a twine upload line in build.sh")

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -164,6 +164,7 @@ jobs:
             tests/studio/test_windows_small_checks_stay_on_their_image.py \
             tests/studio/test_windows_ui_lanes_are_isolated.py \
             tests/studio/test_workflow_guards_run_unfiltered.py \
+            tests/test_wheel_smoke_publish_guard.py \
             tests/security \
             --ignore=tests/security/test_custom_dtype_no_eval.py \
             --ignore=tests/security/test_custom_dtype_wire_format.py \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# The only veto that travels inside the sdist, so it holds for the wheel too:
-# `python -m build` rebuilds the wheel from the sdist, where exclude-package-data
-# and packages.find no longer bite (no .git tree for the file finder).
+# Kept as defence in depth rather than as the load-bearing veto it once was.
+# The release now builds `python -m build --wheel`, straight from the checkout,
+# where the packages.find and exclude-package-data vetoes in pyproject.toml are
+# what exclude the test suites (verified: that build produces a wheel with zero
+# test paths). These prunes matter only for a bare `python -m build`, which
+# writes an sdist and then builds the wheel FROM it, and there neither pyproject
+# veto bites because the file finder has no .git tree. Anyone doing that locally
+# still gets a clean artifact.
 prune tests
 prune studio/backend/tests
 prune studio/backend/hub/tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# Kept as defence in depth rather than as the load-bearing veto it once was.
-# The release now builds `python -m build --wheel`, straight from the checkout,
-# where the packages.find and exclude-package-data vetoes in pyproject.toml are
-# what exclude the test suites (verified: that build produces a wheel with zero
-# test paths). These prunes matter only for a bare `python -m build`, which
-# writes an sdist and then builds the wheel FROM it, and there neither pyproject
-# veto bites because the file finder has no .git tree. Anyone doing that locally
-# still gets a clean artifact.
+# The only veto that travels inside the sdist, so it holds for the wheel too:
+# `python -m build` rebuilds the wheel from the sdist, where exclude-package-data
+# and packages.find no longer bite (no .git tree for the file finder).
 prune tests
 prune studio/backend/tests
 prune studio/backend/hub/tests

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -55,7 +55,7 @@ def _run_guard(tmp_path, build_sh_body):
     script = tmp_path / "_guard.py"
     script.write_text(_guard_source())
     return subprocess.run(
-        [sys.executable, str(script)], cwd=tmp_path, capture_output=True, text=True
+        [sys.executable, str(script)], cwd = tmp_path, capture_output = True, text = True
     )
 
 

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -165,8 +165,7 @@ def _lint_doc():
 def test_this_module_runs_in_the_unfiltered_guard_job():
     """Named explicitly, because testpaths means nothing collects it by accident."""
     runs = "\n".join(
-        str(step.get("run", ""))
-        for step in _lint_doc()["jobs"]["workflow-trigger-lint"]["steps"]
+        str(step.get("run", "")) for step in _lint_doc()["jobs"]["workflow-trigger-lint"]["steps"]
     )
     assert Path(__file__).name in runs, (
         f"workflow-trigger-lint does not name {Path(__file__).name}. It is the only job "

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -3,15 +3,8 @@
 
 """Regression tests for the "Publishing path uploads the wheel only" guard.
 
-The guard lives inside a heredoc in .github/workflows/wheel-smoke.yml, so these
-tests extract the shipped script text rather than a copy of it, and run it
-against synthetic build.sh files. Two ways a guard like this silently passes a
-release that publishes an sdist:
-
-  - it inspects only the first argument, so `dist/*.whl dist/*.tar.gz` passes;
-  - the workflow never runs at all, because build.sh is not in the path filters.
-
-Both are covered below.
+The guard text is extracted from .github/workflows/wheel-smoke.yml rather than
+copied, then run against synthetic build.sh files.
 """
 
 import subprocess
@@ -73,13 +66,10 @@ PROLOGUE = "#!/bin/bash\nset -euo pipefail\npython -m build\n"
         "python -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/*.whl",
         "python -m twine upload --non-interactive dist/*.whl",
         "python -m twine upload dist/a-1-py3-none-any.whl dist/b-1-py3-none-any.whl",
-        # -s is store_true, so the wheel after it is an artifact, not its value.
         "python -m twine upload -s dist/*.whl",
-        # A command may be preceded by variable assignments; twine's credential
-        # env vars are the obvious reason build.sh would do that.
+        # twine's credential env vars put an assignment in front of the command.
         "TWINE_USERNAME=__token__ python -m twine upload dist/*.whl",
         "TWINE_USERNAME=__token__ TWINE_PASSWORD=x twine upload dist/*.whl",
-        # These two do consume a value, and the value is not an artifact.
         "python -m twine upload --sign-with gpg2 dist/*.whl",
         "python -m twine upload -i me@example.com dist/*.whl",
     ],
@@ -92,17 +82,13 @@ def test_wheel_only_uploads_pass(tmp_path, upload_line):
 @pytest.mark.parametrize(
     "upload_line",
     [
-        # The regression #10419 exists to catch.
         "python -m twine upload dist/*",
-        # The bypass: wheel first, sdist second. A first-argument-only check
-        # passes this while PyPI receives the ~86MB sdist.
+        # Wheel first, sdist second: a first-argument-only check passes this.
         "python -m twine upload dist/*.whl dist/*.tar.gz",
         "python -m twine upload dist/*.tar.gz dist/*.whl",
         "python -m twine upload -r pypi dist/*.whl dist/unsloth-1.0.tar.gz",
         "python -m twine upload dist/*.zip",
-        # Signing on with the sdist listed first. Treating -s as value-taking
-        # swallowed the tarball, leaving only the wheel visible, so the guard
-        # passed while twine uploaded both.
+        # -s is store_true, so the sdist after it is an artifact, not its value.
         "python -m twine upload -s dist/*.tar.gz dist/*.whl",
         "TWINE_REPOSITORY_URL=https://example.invalid python -m twine upload dist/*",
     ],
@@ -130,12 +116,7 @@ def test_missing_upload_line_fails(tmp_path):
     ],
 )
 def test_a_shell_no_op_is_not_an_upload(tmp_path, no_op):
-    """A line that names twine but never runs it must not satisfy the check.
-
-    Unanchored, `: twine upload dist/*.whl` registered a wheel target, so a
-    build.sh whose real upload had been deleted still reported PASS. That is
-    precisely what the missing-upload check exists to catch.
-    """
+    """A line that names twine but never runs it must not satisfy the check."""
     r = _run_guard(tmp_path, PROLOGUE + no_op + "\n")
     assert r.returncode == 1, r.stdout + r.stderr
     assert "no twine upload line" in r.stdout
@@ -147,9 +128,7 @@ def test_a_shell_no_op_is_not_an_upload(tmp_path, no_op):
         "cat <<'USAGE'\ntwine upload dist/*.whl\nUSAGE\n",
         "cat <<USAGE\ntwine upload dist/*.whl\nUSAGE\n",
         "cat <<-USAGE\n\ttwine upload dist/*.whl\n\tUSAGE\n",
-        # The delimiter is a shell word, not an identifier: bash accepts these
-        # and treats the body as text, but an identifier-shaped pattern misses
-        # the heredoc and reads the usage output as the release path.
+        # The delimiter is a shell word, not an identifier.
         "cat <<'PUBLISH-USAGE'\ntwine upload dist/*.whl\nPUBLISH-USAGE\n",
         "cat <<PUBLISH-USAGE\ntwine upload dist/*.whl\nPUBLISH-USAGE\n",
         "cat <<'EOF.TXT'\ntwine upload dist/*.whl\nEOF.TXT\n",
@@ -210,34 +189,14 @@ def test_real_build_sh_passes_the_guard(tmp_path):
 
 @pytest.mark.parametrize("event", ["pull_request", "push"])
 def test_build_sh_is_in_the_path_filters(event):
-    """The guard reads build.sh, so build.sh must trigger the workflow.
-
-    GitHub skips a `paths`-filtered workflow entirely when no changed file
-    matches, so a PR touching only build.sh would otherwise never run this.
-    """
+    """GitHub skips the workflow entirely on a PR that touches only build.sh."""
     paths = _on_block(_workflow())[event]["paths"]
     assert "build.sh" in paths, f"{event} paths filter omits build.sh: {paths}"
 
 
-# --------------------------------------------------------------------------
-# The tests above only bite if something actually collects THIS module.
-#
-# `pyproject.toml` sets testpaths = ["tests/security"], and pytest uses that
-# list "when no specific directories, files or test ids are given in the
-# command line" -- so a bare `pytest` never reaches this file, and every
-# invocation that would has to name it. Meanwhile the change these tests exist
-# to reject (reintroducing the first-argument-only parser) edits
-# `wheel-smoke.yml` and nothing else, and GitHub only runs a `paths`-filtered
-# workflow when "at least one path matches a pattern in the paths filter".
-#
-# wheel-smoke.yml does trigger on its own YAML, but that run only executes the
-# guard against the current, single-target build.sh: a broken parser still says
-# PASS. So the regression is caught only by a job that both collects this
-# module and starts on a workflow-only diff. workflow-trigger-lint.yml is the
-# one job in the repo with no paths filter, which makes it the only candidate.
-# tests/studio/test_workflow_guards_run_unfiltered.py enforces this rule for
-# tests/studio; this module lives in tests/, so it asserts it for itself.
-# --------------------------------------------------------------------------
+# testpaths = ["tests/security"] means a bare `pytest` never collects this module,
+# and a parser regression edits only wheel-smoke.yml. workflow-trigger-lint.yml is
+# the only job with no paths filter, so it is the only one that can catch that PR.
 
 
 def _lint_doc():
@@ -262,10 +221,8 @@ def test_the_job_that_runs_this_module_has_no_paths_filter():
     doc = _lint_doc()
     on = _on_block(doc)
     for trigger in ("pull_request", "push"):
-        # Presence first. `continue` on a missing key let the trigger be deleted
-        # outright and still pass, which is a bigger hole than filtering it:
-        # dropping `push` keeps the PR check green while removing this guard from
-        # every later direct push to main.
+        # Presence first: `continue` on a missing key let the trigger be deleted
+        # outright and still pass.
         assert trigger in on, (
             f"workflow-trigger-lint no longer runs on {trigger}, so this module stops "
             f"being collected for that event."
@@ -283,8 +240,7 @@ def test_the_job_that_runs_this_module_has_no_paths_filter():
 @pytest.mark.parametrize(
     ("body", "rc"),
     [
-        # << closes only on an exact delimiter, so an indented copy stays body
-        # and the text after it is not a command.
+        # << closes on an exact delimiter, so an indented copy stays body.
         ("cat <<'USAGE'\n    USAGE\ntwine upload dist/*.whl\nUSAGE\n", 1),
         # <<- strips leading tabs, so a tab-indented delimiter does close it.
         ("cat <<-USAGE\n\tUSAGE\nUSAGE\npython -m twine upload dist/*.whl\n", 0),
@@ -327,12 +283,7 @@ def test_a_redirection_does_not_hide_a_non_wheel(tmp_path):
     ],
 )
 def test_a_second_chained_upload_is_still_inspected(tmp_path, upload_line):
-    """Every command on the line counts, not just the first.
-
-    Stopping at the first control operator kept the guard from reading a pipe's
-    right-hand side, but it also discarded a chained SECOND upload, so the wheel
-    was recorded, the sdist was not, and the guard passed while both shipped.
-    """
+    """Every command on the line counts, not just the first."""
     r = _run_guard(tmp_path, PROLOGUE + upload_line + "\n")
     assert r.returncode == 1, r.stdout + r.stderr
     assert "non-wheel" in r.stdout
@@ -352,11 +303,7 @@ def test_a_chained_non_upload_is_not_an_artifact(tmp_path, upload_line):
 
 
 def test_an_assignment_prefix_does_not_hide_a_second_upload(tmp_path):
-    """An assignment-prefixed sdist upload ran, but read as a non-twine command.
-
-    The visible wheel-only line kept `uploads` nonempty, so the guard passed
-    while twine published the tarball as well.
-    """
+    """The visible wheel-only line must not cover for an assignment-prefixed one."""
     body = PROLOGUE + "python -m twine upload dist/*.whl\n"
     body += "TWINE_REPOSITORY_URL=https://example.invalid twine upload dist/*.tar.gz\n"
     r = _run_guard(tmp_path, body)

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -135,6 +135,29 @@ def test_a_shell_no_op_is_not_an_upload(tmp_path, no_op):
 
 
 @pytest.mark.parametrize(
+    "heredoc",
+    [
+        "cat <<'USAGE'\ntwine upload dist/*.whl\nUSAGE\n",
+        "cat <<USAGE\ntwine upload dist/*.whl\nUSAGE\n",
+        "cat <<-USAGE\n\ttwine upload dist/*.whl\n\tUSAGE\n",
+    ],
+)
+def test_heredoc_text_is_not_an_upload(tmp_path, heredoc):
+    """Usage text naming the command is text, not the release path."""
+    r = _run_guard(tmp_path, PROLOGUE + heredoc)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "no twine upload line" in r.stdout
+
+
+def test_a_heredoc_does_not_hide_the_real_upload(tmp_path):
+    """Skipping heredoc bodies must not skip the invocation that follows one."""
+    body = PROLOGUE + "cat <<'USAGE'\ntwine upload dist/*.tar.gz\nUSAGE\n"
+    body += "python -m twine upload dist/*.whl\n"
+    r = _run_guard(tmp_path, body)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+@pytest.mark.parametrize(
     "invocation",
     [
         "twine upload dist/*.whl",

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -75,6 +75,10 @@ PROLOGUE = "#!/bin/bash\nset -euo pipefail\npython -m build\n"
         "python -m twine upload dist/a-1-py3-none-any.whl dist/b-1-py3-none-any.whl",
         # -s is store_true, so the wheel after it is an artifact, not its value.
         "python -m twine upload -s dist/*.whl",
+        # A command may be preceded by variable assignments; twine's credential
+        # env vars are the obvious reason build.sh would do that.
+        "TWINE_USERNAME=__token__ python -m twine upload dist/*.whl",
+        "TWINE_USERNAME=__token__ TWINE_PASSWORD=x twine upload dist/*.whl",
         # These two do consume a value, and the value is not an artifact.
         "python -m twine upload --sign-with gpg2 dist/*.whl",
         "python -m twine upload -i me@example.com dist/*.whl",
@@ -100,6 +104,7 @@ def test_wheel_only_uploads_pass(tmp_path, upload_line):
         # swallowed the tarball, leaving only the wheel visible, so the guard
         # passed while twine uploaded both.
         "python -m twine upload -s dist/*.tar.gz dist/*.whl",
+        "TWINE_REPOSITORY_URL=https://example.invalid python -m twine upload dist/*",
     ],
 )
 def test_non_wheel_uploads_fail(tmp_path, upload_line):
@@ -120,6 +125,8 @@ def test_missing_upload_line_fails(tmp_path):
         ": twine upload dist/*.whl",
         "true twine upload dist/*.whl",
         "echo twine upload dist/*.whl",
+        # Stripping the assignment prefix must stop at the real command.
+        "X=1 : twine upload dist/*.whl",
     ],
 )
 def test_a_shell_no_op_is_not_an_upload(tmp_path, no_op):
@@ -342,3 +349,16 @@ def test_a_chained_non_upload_is_not_an_artifact(tmp_path, upload_line):
     """Segmenting must not turn the other side of an operator into artifacts."""
     r = _run_guard(tmp_path, PROLOGUE + upload_line + "\n")
     assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_an_assignment_prefix_does_not_hide_a_second_upload(tmp_path):
+    """An assignment-prefixed sdist upload ran, but read as a non-twine command.
+
+    The visible wheel-only line kept `uploads` nonempty, so the guard passed
+    while twine published the tarball as well.
+    """
+    body = PROLOGUE + "python -m twine upload dist/*.whl\n"
+    body += "TWINE_REPOSITORY_URL=https://example.invalid twine upload dist/*.tar.gz\n"
+    r = _run_guard(tmp_path, body)
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "non-wheel" in r.stdout

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -140,6 +140,14 @@ def test_a_shell_no_op_is_not_an_upload(tmp_path, no_op):
         "cat <<'USAGE'\ntwine upload dist/*.whl\nUSAGE\n",
         "cat <<USAGE\ntwine upload dist/*.whl\nUSAGE\n",
         "cat <<-USAGE\n\ttwine upload dist/*.whl\n\tUSAGE\n",
+        # The delimiter is a shell word, not an identifier: bash accepts these
+        # and treats the body as text, but an identifier-shaped pattern misses
+        # the heredoc and reads the usage output as the release path.
+        "cat <<'PUBLISH-USAGE'\ntwine upload dist/*.whl\nPUBLISH-USAGE\n",
+        "cat <<PUBLISH-USAGE\ntwine upload dist/*.whl\nPUBLISH-USAGE\n",
+        "cat <<'EOF.TXT'\ntwine upload dist/*.whl\nEOF.TXT\n",
+        "cat <<'END OF HELP'\ntwine upload dist/*.whl\nEND OF HELP\n",
+        "cat <<\\USAGE\ntwine upload dist/*.whl\nUSAGE\n",
     ],
 )
 def test_heredoc_text_is_not_an_upload(tmp_path, heredoc):
@@ -149,11 +157,20 @@ def test_heredoc_text_is_not_an_upload(tmp_path, heredoc):
     assert "no twine upload line" in r.stdout
 
 
-def test_a_heredoc_does_not_hide_the_real_upload(tmp_path):
+@pytest.mark.parametrize("delimiter", ["USAGE", "'PUBLISH-USAGE'"])
+def test_a_heredoc_does_not_hide_the_real_upload(tmp_path, delimiter):
     """Skipping heredoc bodies must not skip the invocation that follows one."""
-    body = PROLOGUE + "cat <<'USAGE'\ntwine upload dist/*.tar.gz\nUSAGE\n"
+    word = delimiter.strip("'")
+    body = PROLOGUE + f"cat <<{delimiter}\ntwine upload dist/*.tar.gz\n{word}\n"
     body += "python -m twine upload dist/*.whl\n"
     r = _run_guard(tmp_path, body)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+@pytest.mark.parametrize("here_string", ['cat <<< "usage"', "cat <<<'publish-usage'"])
+def test_a_here_string_does_not_open_a_heredoc(tmp_path, here_string):
+    """`<<<` contains `<<`; reading it as a heredoc swallowed the real upload."""
+    r = _run_guard(tmp_path, PROLOGUE + here_string + "\npython -m twine upload dist/*.whl\n")
     assert r.returncode == 0, r.stdout + r.stderr
 
 

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -238,10 +238,57 @@ def test_the_job_that_runs_this_module_has_no_paths_filter():
     doc = _lint_doc()
     on = _on_block(doc)
     for trigger in ("pull_request", "push"):
+        # Presence first. `continue` on a missing key let the trigger be deleted
+        # outright and still pass, which is a bigger hole than filtering it:
+        # dropping `push` keeps the PR check green while removing this guard from
+        # every later direct push to main.
+        assert trigger in on, (
+            f"workflow-trigger-lint no longer runs on {trigger}, so this module stops "
+            f"being collected for that event."
+        )
         config = on.get(trigger)
+        # A bare `pull_request:` parses as None and filters nothing, which is fine.
         if not isinstance(config, dict):
             continue
         assert not config.get("paths") and not config.get("paths-ignore"), (
             f"workflow-trigger-lint now filters its {trigger} trigger on paths, so it no "
             f"longer runs on every workflow-only PR."
         )
+
+
+@pytest.mark.parametrize(
+    ("body", "rc"),
+    [
+        # << closes only on an exact delimiter, so an indented copy stays body
+        # and the text after it is not a command.
+        ("cat <<'USAGE'\n    USAGE\ntwine upload dist/*.whl\nUSAGE\n", 1),
+        # <<- strips leading tabs, so a tab-indented delimiter does close it.
+        ("cat <<-USAGE\n\tUSAGE\nUSAGE\npython -m twine upload dist/*.whl\n", 0),
+    ],
+    ids = ["exact-delimiter-only", "dash-strips-tabs"],
+)
+def test_heredoc_terminators_follow_bash_rules(tmp_path, body, rc):
+    assert _run_guard(tmp_path, PROLOGUE + body).returncode == rc
+
+
+@pytest.mark.parametrize(
+    "upload_line",
+    [
+        "python -m twine upload dist/*.whl >twine.log",
+        "python -m twine upload dist/*.whl > twine.log",
+        "python -m twine upload dist/*.whl 2> err.log",
+        "python -m twine upload dist/*.whl 2>&1 | tee log",
+        "python -m twine upload dist/*.whl >>twine.log",
+    ],
+)
+def test_redirections_are_not_artifacts(tmp_path, upload_line):
+    """`>twine.log` is shell syntax. Counting it failed a valid release line."""
+    r = _run_guard(tmp_path, PROLOGUE + upload_line + "\n")
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_a_redirection_does_not_hide_a_non_wheel(tmp_path):
+    """Dropping redirections must not drop the artifact check with them."""
+    r = _run_guard(tmp_path, PROLOGUE + "python -m twine upload dist/*.tar.gz >log\n")
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "non-wheel" in r.stdout

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -72,6 +72,11 @@ PROLOGUE = "#!/bin/bash\nset -euo pipefail\npython -m build\n"
         "python -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/*.whl",
         "python -m twine upload --non-interactive dist/*.whl",
         "python -m twine upload dist/a-1-py3-none-any.whl dist/b-1-py3-none-any.whl",
+        # -s is store_true, so the wheel after it is an artifact, not its value.
+        "python -m twine upload -s dist/*.whl",
+        # These two do consume a value, and the value is not an artifact.
+        "python -m twine upload --sign-with gpg2 dist/*.whl",
+        "python -m twine upload -i me@example.com dist/*.whl",
     ],
 )
 def test_wheel_only_uploads_pass(tmp_path, upload_line):
@@ -90,6 +95,10 @@ def test_wheel_only_uploads_pass(tmp_path, upload_line):
         "python -m twine upload dist/*.tar.gz dist/*.whl",
         "python -m twine upload -r pypi dist/*.whl dist/unsloth-1.0.tar.gz",
         "python -m twine upload dist/*.zip",
+        # Signing on with the sdist listed first. Treating -s as value-taking
+        # swallowed the tarball, leaving only the wheel visible, so the guard
+        # passed while twine uploaded both.
+        "python -m twine upload -s dist/*.tar.gz dist/*.whl",
     ],
 )
 def test_non_wheel_uploads_fail(tmp_path, upload_line):

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -23,6 +23,7 @@ import yaml
 
 REPO = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO / ".github" / "workflows" / "wheel-smoke.yml"
+LINT = REPO / ".github" / "workflows" / "workflow-trigger-lint.yml"
 STEP_NAME = "Publishing path uploads the wheel only"
 
 
@@ -134,3 +135,56 @@ def test_build_sh_is_in_the_path_filters(event):
     """
     paths = _on_block(_workflow())[event]["paths"]
     assert "build.sh" in paths, f"{event} paths filter omits build.sh: {paths}"
+
+
+# --------------------------------------------------------------------------
+# The tests above only bite if something actually collects THIS module.
+#
+# `pyproject.toml` sets testpaths = ["tests/security"], and pytest uses that
+# list "when no specific directories, files or test ids are given in the
+# command line" -- so a bare `pytest` never reaches this file, and every
+# invocation that would has to name it. Meanwhile the change these tests exist
+# to reject (reintroducing the first-argument-only parser) edits
+# `wheel-smoke.yml` and nothing else, and GitHub only runs a `paths`-filtered
+# workflow when "at least one path matches a pattern in the paths filter".
+#
+# wheel-smoke.yml does trigger on its own YAML, but that run only executes the
+# guard against the current, single-target build.sh: a broken parser still says
+# PASS. So the regression is caught only by a job that both collects this
+# module and starts on a workflow-only diff. workflow-trigger-lint.yml is the
+# one job in the repo with no paths filter, which makes it the only candidate.
+# tests/studio/test_workflow_guards_run_unfiltered.py enforces this rule for
+# tests/studio; this module lives in tests/, so it asserts it for itself.
+# --------------------------------------------------------------------------
+
+
+def _lint_doc():
+    return yaml.safe_load(LINT.read_text(encoding = "utf-8"))
+
+
+def test_this_module_runs_in_the_unfiltered_guard_job():
+    """Named explicitly, because testpaths means nothing collects it by accident."""
+    runs = "\n".join(
+        str(step.get("run", ""))
+        for step in _lint_doc()["jobs"]["workflow-trigger-lint"]["steps"]
+    )
+    assert Path(__file__).name in runs, (
+        f"workflow-trigger-lint does not name {Path(__file__).name}. It is the only job "
+        f"with no paths filter, so on a PR that edits only wheel-smoke.yml -- exactly the "
+        f"change these tests exist to reject -- nothing else collects this module, and the "
+        f"regression merges green."
+    )
+
+
+def test_the_job_that_runs_this_module_has_no_paths_filter():
+    """The premise. A filter here and this module stops seeing workflow-only PRs."""
+    doc = _lint_doc()
+    on = _on_block(doc)
+    for trigger in ("pull_request", "push"):
+        config = on.get(trigger)
+        if not isinstance(config, dict):
+            continue
+        assert not config.get("paths") and not config.get("paths-ignore"), (
+            f"workflow-trigger-lint now filters its {trigger} trigger on paths, so it no "
+            f"longer runs on every workflow-only PR."
+        )

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -114,6 +114,41 @@ def test_missing_upload_line_fails(tmp_path):
     assert "no twine upload line" in r.stdout
 
 
+@pytest.mark.parametrize(
+    "no_op",
+    [
+        ": twine upload dist/*.whl",
+        "true twine upload dist/*.whl",
+        "echo twine upload dist/*.whl",
+    ],
+)
+def test_a_shell_no_op_is_not_an_upload(tmp_path, no_op):
+    """A line that names twine but never runs it must not satisfy the check.
+
+    Unanchored, `: twine upload dist/*.whl` registered a wheel target, so a
+    build.sh whose real upload had been deleted still reported PASS. That is
+    precisely what the missing-upload check exists to catch.
+    """
+    r = _run_guard(tmp_path, PROLOGUE + no_op + "\n")
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "no twine upload line" in r.stdout
+
+
+@pytest.mark.parametrize(
+    "invocation",
+    [
+        "twine upload dist/*.whl",
+        "python -m twine upload dist/*.whl",
+        "python3 -m twine upload dist/*.whl",
+        "    python -m twine upload dist/*.whl",
+    ],
+)
+def test_real_invocation_forms_are_still_recognised(tmp_path, invocation):
+    """Anchoring must not stop the guard seeing how build.sh actually calls it."""
+    r = _run_guard(tmp_path, PROLOGUE + invocation + "\n")
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
 def test_commented_out_upload_is_not_an_artifact(tmp_path):
     """A comment mentioning the bad glob must not be read as a real upload."""
     body = PROLOGUE + "# never do: twine upload dist/*\npython -m twine upload dist/*.whl\n"

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -292,3 +292,36 @@ def test_a_redirection_does_not_hide_a_non_wheel(tmp_path):
     r = _run_guard(tmp_path, PROLOGUE + "python -m twine upload dist/*.tar.gz >log\n")
     assert r.returncode == 1, r.stdout + r.stderr
     assert "non-wheel" in r.stdout
+
+
+@pytest.mark.parametrize(
+    "upload_line",
+    [
+        "python -m twine upload dist/*.whl && python -m twine upload dist/*.tar.gz",
+        "python -m twine upload dist/*.whl ; twine upload dist/*.tar.gz",
+        "python -m twine upload dist/*.whl || twine upload dist/*.tar.gz",
+    ],
+)
+def test_a_second_chained_upload_is_still_inspected(tmp_path, upload_line):
+    """Every command on the line counts, not just the first.
+
+    Stopping at the first control operator kept the guard from reading a pipe's
+    right-hand side, but it also discarded a chained SECOND upload, so the wheel
+    was recorded, the sdist was not, and the guard passed while both shipped.
+    """
+    r = _run_guard(tmp_path, PROLOGUE + upload_line + "\n")
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "non-wheel" in r.stdout
+
+
+@pytest.mark.parametrize(
+    "upload_line",
+    [
+        "python -m twine upload dist/*.whl && echo done",
+        "python -m twine upload dist/*.whl | tee upload.log",
+    ],
+)
+def test_a_chained_non_upload_is_not_an_artifact(tmp_path, upload_line):
+    """Segmenting must not turn the other side of an operator into artifacts."""
+    r = _run_guard(tmp_path, PROLOGUE + upload_line + "\n")
+    assert r.returncode == 0, r.stdout + r.stderr

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Regression tests for the "Publishing path uploads the wheel only" guard.
+
+The guard lives inside a heredoc in .github/workflows/wheel-smoke.yml, so these
+tests extract the shipped script text rather than a copy of it, and run it
+against synthetic build.sh files. Two ways a guard like this silently passes a
+release that publishes an sdist:
+
+  - it inspects only the first argument, so `dist/*.whl dist/*.tar.gz` passes;
+  - the workflow never runs at all, because build.sh is not in the path filters.
+
+Both are covered below.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO / ".github" / "workflows" / "wheel-smoke.yml"
+STEP_NAME = "Publishing path uploads the wheel only"
+
+
+def _workflow():
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def _on_block(wf):
+    # PyYAML parses a bare `on:` key as the boolean True.
+    return wf.get("on", wf.get(True))
+
+
+def _guard_source():
+    """The Python between `python - <<'PY'` and the closing `PY`."""
+    for step in _workflow()["jobs"]["wheel"]["steps"]:
+        if step.get("name") == STEP_NAME:
+            body = step["run"]
+            break
+    else:
+        pytest.fail(f"workflow has no step named {STEP_NAME!r}")
+
+    lines = body.splitlines()
+    start = next(i for i, l in enumerate(lines) if l.strip().endswith("<<'PY'"))
+    end = next(i for i, l in enumerate(lines[start + 1 :], start + 1) if l.strip() == "PY")
+    return "\n".join(lines[start + 1 : end])
+
+
+def _run_guard(tmp_path, build_sh_body):
+    (tmp_path / "build.sh").write_text(build_sh_body)
+    script = tmp_path / "_guard.py"
+    script.write_text(_guard_source())
+    return subprocess.run(
+        [sys.executable, str(script)], cwd=tmp_path, capture_output=True, text=True
+    )
+
+
+PROLOGUE = "#!/bin/bash\nset -euo pipefail\npython -m build\n"
+
+
+@pytest.mark.parametrize(
+    "upload_line",
+    [
+        "python -m twine upload dist/*.whl",
+        "twine upload dist/*.whl",
+        # Flags that consume a value must not be mistaken for artifacts.
+        "python -m twine upload -r pypi dist/*.whl",
+        "python -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/*.whl",
+        "python -m twine upload --non-interactive dist/*.whl",
+        "python -m twine upload dist/a-1-py3-none-any.whl dist/b-1-py3-none-any.whl",
+    ],
+)
+def test_wheel_only_uploads_pass(tmp_path, upload_line):
+    r = _run_guard(tmp_path, PROLOGUE + upload_line + "\n")
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+@pytest.mark.parametrize(
+    "upload_line",
+    [
+        # The regression #10419 exists to catch.
+        "python -m twine upload dist/*",
+        # The bypass: wheel first, sdist second. A first-argument-only check
+        # passes this while PyPI receives the ~86MB sdist.
+        "python -m twine upload dist/*.whl dist/*.tar.gz",
+        "python -m twine upload dist/*.tar.gz dist/*.whl",
+        "python -m twine upload -r pypi dist/*.whl dist/unsloth-1.0.tar.gz",
+        "python -m twine upload dist/*.zip",
+    ],
+)
+def test_non_wheel_uploads_fail(tmp_path, upload_line):
+    r = _run_guard(tmp_path, PROLOGUE + upload_line + "\n")
+    assert r.returncode == 1, r.stdout + r.stderr
+    assert "non-wheel" in r.stdout
+
+
+def test_missing_upload_line_fails(tmp_path):
+    r = _run_guard(tmp_path, PROLOGUE)
+    assert r.returncode == 1
+    assert "no twine upload line" in r.stdout
+
+
+def test_commented_out_upload_is_not_an_artifact(tmp_path):
+    """A comment mentioning the bad glob must not be read as a real upload."""
+    body = PROLOGUE + "# never do: twine upload dist/*\npython -m twine upload dist/*.whl\n"
+    r = _run_guard(tmp_path, body)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_real_build_sh_passes_the_guard(tmp_path):
+    r = _run_guard(tmp_path, (REPO / "build.sh").read_text())
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+@pytest.mark.parametrize("event", ["pull_request", "push"])
+def test_build_sh_is_in_the_path_filters(event):
+    """The guard reads build.sh, so build.sh must trigger the workflow.
+
+    GitHub skips a `paths`-filtered workflow entirely when no changed file
+    matches, so a PR touching only build.sh would otherwise never run this.
+    """
+    paths = _on_block(_workflow())[event]["paths"]
+    assert "build.sh" in paths, f"{event} paths filter omits build.sh: {paths}"


### PR DESCRIPTION
Assert that the release publishing path uploads the wheel only.

## Why this is not already covered

#10202 changed `./build.sh publish` to `twine upload dist/*.whl` rather than `dist/*`, on the grounds that the sdist is the larger half of a ~169MB release against a 10GB PyPI project limit. It did not hold. `2026.9.2` was published on 2026-09-02, the same day, carrying an **86.6MB sdist**:

| | count | size |
| --- | ---: | ---: |
| wheels | 239 | 5.19 GB |
| sdists | 227 | **4.85 GB** |
| total | | **10.04 GB** |

That is 48% of the project's PyPI footprint spent on an artifact nothing installs. The wheel is `py3-none-any`, so pip and uv resolve to it on every platform and Python version:

```
$ pip download unsloth --no-deps
Downloading unsloth-2026.9.2-py3-none-any.whl (82.3 MB)
Saved ./unsloth-2026.9.2-py3-none-any.whl
```

Only the wheel. The sdist is reachable only through `--no-binary`, or by clicking through the PyPI Files page, which is how the antivirus reports in #9577 arose.

The reason #10202 did not stick is that the release is driven by hand rather than by `build.sh`, and the hand-typed command ends `twine upload dist/* --verbose`. `build.sh` builds the sdist on purpose so `--verify-dist` can check the Studio release stamp in every artifact, so `dist/` legitimately contains one; the glob is the only thing keeping it off PyPI.

## What this adds

One step, asserting the upload glob in `build.sh` is wheel-only:

```
twine upload targets in build.sh: ['dist/*.whl']
PASS: build.sh uploads wheels only
```

It fails if any `twine upload` target in `build.sh` does not end in `.whl`, and it fails if the upload line disappears entirely, which would mean the release path moved somewhere this check no longer sees.

Also expands the comment on the existing test-suite gate to say why it still inspects both artifacts: a bare `python -m build` builds the wheel **from** the sdist, so a test suite reaching the sdist reaches the wheel too. That is the mechanism `MANIFEST.in` documents and it is unchanged here.

## What this deliberately does not do

An earlier version of this PR switched the build to `python -m build --wheel` and failed CI if an sdist existed in `dist/` at all. That was wrong on both counts: the release runs `build.sh`, which uses a bare `python -m build`, so CI would have been testing a build path the release does not use, and the sdist-in-`dist/` assertion would have failed the real release flow, which builds one intentionally. Reverted; the build path is untouched.

## How to verify

```
git fetch origin no-sdist && git checkout no-sdist
python - <<'PY'
import re
u = re.findall(r"twine upload\s+(\S+)", open("build.sh").read())
print(u, "PASS" if u and all(x.endswith(".whl") for x in u) else "FAIL")
PY
```

To see it fire, change `dist/*.whl` back to `dist/*` in `build.sh` and re-run: it exits 1 naming the target.
