### PR TITLE
Studio smoke: report a transport failure instead of crashing on one

### DIFF
--- a/tests/studio/playwright_loaded_models_indicator.py
+++ b/tests/studio/playwright_loaded_models_indicator.py
@@ -366,7 +366,18 @@ def run(page, state: Runtime) -> None:
 
     for route in ("/hub", "/train", "/images"):
         page.goto(BASE + route, wait_until = "domcontentloaded")
-        page.wait_for_timeout(3000)
+        # Wait for the card, not for the clock. This is a hard navigation: a
+        # full SPA reload plus a loaded-models poll, and 3000ms was the only
+        # fixed budget in this file that was not derived from SETTLE_MS. On a
+        # loaded runner the first route overran it and all three then failed
+        # together, which is what a fixed budget looks like when it is the
+        # thing that is wrong. The check below is unchanged and still fails if
+        # the card genuinely does not survive the navigation -- this only stops
+        # a slow render from being read as a missing card.
+        try:
+            page.wait_for_selector(CARD, timeout = SETTLE_MS)
+        except Exception:
+            pass
         check(f"card survives {route}", page.locator(CARD).count() > 0)
 
     # ── Hardware shapes a CUDA runner never produces ────────────────────

--- a/tests/studio/studio_api_smoke.py
+++ b/tests/studio/studio_api_smoke.py
@@ -100,6 +100,23 @@ def http(
             return exc.code, json.loads(raw)
         except (json.JSONDecodeError, UnicodeDecodeError):
             return exc.code, raw
+    except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+        # A transport failure is a failed check, not a crashed run. Only
+        # HTTPError was caught here, so a socket timeout propagated out of
+        # http() and killed the script at module level: the traceback named
+        # urlopen and the line number, and nothing about which endpoint had
+        # been slow or what the rest of the suite would have said. Observed on
+        # three unrelated PRs whose /v1/embeddings call hit the 30s ceiling.
+        # Returned as status 0 so every existing `if code == 200 ... else
+        # fail(...)` site reports it with its own diagnosis and the run
+        # continues to the remaining sections.
+        #
+        # Emitted here as well as returned: the call sites report the status
+        # code and not the body, so status 0 on its own would say a request
+        # failed without saying that it timed out or after how long.
+        detail = f"{type(exc).__name__}: {exc}"
+        _emit("  NET   ", f"{method} {path} failed after {timeout}s -- {detail}")
+        return 0, {"error": detail, "timeout": timeout}
 
 
 def login(password: str) -> tuple[int, str | None]:
@@ -449,7 +466,14 @@ code, body = http(
     "/v1/embeddings",
     body = {"model": GGUF_REPO, "input": "hello"},
     headers = AUTH_HEADER,
-    timeout = 30,
+    # This is the first request in the section that forces a model load, so it
+    # pays the load on top of the embedding. Measured at 23.8s on a healthy
+    # macOS runner against a 30s ceiling, i.e. 79% of budget, which is not a
+    # margin: three unrelated PRs timed out here at exactly 30.0s on the same
+    # base while main passed. Raised to leave room for a loaded runner rather
+    # than to hide a slow endpoint -- if this starts taking 90s that is a real
+    # regression and it will still be reported, now as a failed check.
+    timeout = 90,
 )
 if code == 200 and isinstance(body, dict) and body.get("data"):
     ok("/v1/embeddings -> 200 with data")


### PR DESCRIPTION
Two fixed budgets in the Mac UI job that were themselves the problem, not the thing they were measuring. Neither is a product bug, and both failed unrelated PRs.

## 1. A socket timeout killed the whole smoke script

`tests/studio/studio_api_smoke.py`'s `http()` caught only `urllib.error.HTTPError`, so a transport failure propagated out at module level:

```
Traceback (most recent call last):
  File ".../tests/studio/studio_api_smoke.py", line 447, in <module>
    code, body = http(
  File ".../tests/studio/studio_api_smoke.py", line 91, in http
    with urllib.request.urlopen(req, timeout = timeout) as r:
TimeoutError: timed out
```

The traceback names `urlopen` and a line number, and nothing about which endpoint was slow or for how long. Every section after it is abandoned.

Transport failures now return status 0, which the existing `if code == 200 ... else fail(...)` call sites already report as a failure, and `http()` emits the method, path, budget and exception so the reason sits next to the failure instead of only in the returned body:

```
  NET   POST /v1/embeddings failed after 90s -- TimeoutError: timed out
```

## 2. The `/v1/embeddings` ceiling had no margin

That call is the first in its section to force a model load, so it pays the load on top of the embedding. On a healthy macOS runner it takes **23.8s against a 30s ceiling**, 79% of budget:

| run | `/v1/models` OK | outcome | elapsed |
| --- | --- | --- | --- |
| main `dcf12378` | 00:36:46.83 | `OK /v1/embeddings -> 200 with data` 00:37:10.64 | **23.8s** |
| #10404 | 01:27:22.19 | `TimeoutError` 01:27:52.20 | 30.0s (cap) |
| #10406 | 01:44:24.97 | `TimeoutError` 01:44:55.02 | 30.0s (cap) |
| #10403 | 02:40:06.40 | `TimeoutError` 02:40:36.42 | 30.0s (cap) |

Three unrelated PRs (Windows code integrity, chat media turns, MLX install) off the same base `a6e9880c`, none touching the embeddings path, all pinned at exactly the cap. Raised to 90s. This is headroom rather than concealment: a genuinely slow endpoint still fails the check, and now reports rather than crashes.

## 3. A hard 3000ms wait after a hard navigation

`tests/studio/playwright_loaded_models_indicator.py`:

```python
for route in ("/hub", "/train", "/images"):
    page.goto(BASE + route, wait_until = "domcontentloaded")
    page.wait_for_timeout(3000)
    check(f"card survives {route}", page.locator(CARD).count() > 0)
```

A full SPA reload plus a loaded-models poll, then a fixed 3000ms and a single non-retrying `count()`. It was the only fixed budget in the file not derived from `SETTLE_MS` (12000), and the sibling check one line above already uses `wait_for_selector(CARD, timeout = 30_000)`. On #10409, whose diff is 19 lines of `studio/backend/utils/mlx_repair.py` and cannot reach the frontend:

```
[indicator] 35/38 checks passed
[indicator]   FAILED: card survives /hub
[indicator]   FAILED: card survives /train
[indicator]   FAILED: card survives /images
```

All three together, which is what a fixed budget looks like when the runner is loaded. The same job printed `38/38` on #10406, #10404 and #10403 at the identical base. Now waits for the card it is about to assert on, bounded by `SETTLE_MS`. The `check()` is unchanged and still fails if the card genuinely does not survive.

## Verification

Against the pre-change `http()`, a refused connection and a socket timeout both raise `URLError` out of the function. After, both return `0` with the reason emitted and the run continuing:

```
  NET   POST /v1/embeddings failed after 5s -- URLError: <urlopen error [Errno 111] Connection refused>
returned code : 0 (falls to the else -> fail() branch)
```