### PR TITLE
Studio: keep Remote and LAN access on one settings tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ unsloth studio --secure
 ```bash
 unsloth studio -H 0.0.0.0 -p 8888
 ```
-**LAN Access (home network)**: `Settings > API keys > LAN access`
+**LAN Access (home network)**: `Settings > Remote & LAN > LAN access`
 
 #### Password management & headless starts
 Headless starts:

--- a/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
@@ -22,11 +22,10 @@ import { ApiKeyRow } from "../components/api-key-row";
 import { CreateKeyForm } from "../components/create-key-form";
 import { KeyRevealCard } from "../components/key-reveal-card";
 import { KeylessApiAccessSection } from "../components/keyless-api-access-section";
-import { LanAccessSection } from "../components/lan-access-section";
 import { ModelAutoSwitchSection } from "../components/model-auto-switch-section";
 import { MonitorLink } from "../components/monitor-link";
-import { RemoteAccessSection } from "../components/remote-access-section";
 import { UsageExamples } from "../components/usage-examples";
+import { useSettingsDialogStore } from "../stores/settings-dialog-store";
 
 export function ApiKeysTab() {
   const t = useT();
@@ -183,10 +182,19 @@ export function ApiKeysTab() {
 
       <KeylessApiAccessSection onSettingsChange={setKeyless} />
 
-      {/* Also on the Remote & LAN tab. One panel mounts at a time, so only one polls. */}
-      <RemoteAccessSection />
-
-      <LanAccessSection />
+      <p className="text-xs text-muted-foreground">
+        {t("settings.remoteLan.description")}{" "}
+        <button
+          type="button"
+          onClick={() =>
+            useSettingsDialogStore.getState().setActiveTab("remote-lan")
+          }
+          className="font-medium text-foreground underline decoration-border underline-offset-2 transition-colors hover:decoration-foreground"
+        >
+          {t("settings.tabs.remoteLan")}
+        </button>
+        .
+      </p>
 
       <ModelAutoSwitchSection />
 

--- a/tests/studio/test_remote_lan_settings_home.py
+++ b/tests/studio/test_remote_lan_settings_home.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Remote and LAN access cards live on one Settings tab, not two."""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SETTINGS_TABS = REPO / "studio/frontend/src/features/settings/tabs"
+API_KEYS_TAB = SETTINGS_TABS / "api-keys-tab.tsx"
+REMOTE_LAN_TAB = SETTINGS_TABS / "remote-lan-tab.tsx"
+README = REPO / "README.md"
+
+CARDS = ("<RemoteAccessSection", "<LanAccessSection")
+
+
+def test_remote_and_lan_cards_mount_only_on_the_remote_lan_tab():
+    # #9519: both tabs rendered the same two cards. #9389 left the API copy so
+    # the old path still worked. The dedicated tab is the home now.
+    api = API_KEYS_TAB.read_text(encoding = "utf-8")
+    remote = REMOTE_LAN_TAB.read_text(encoding = "utf-8")
+    for tag in CARDS:
+        assert tag not in api, f"{tag} still mounts on the API tab"
+        assert remote.count(tag) == 1, f"{tag} must mount once on Remote & LAN"
+
+
+def test_api_tab_points_at_the_remote_lan_tab():
+    api = API_KEYS_TAB.read_text(encoding = "utf-8")
+    assert 'setActiveTab("remote-lan")' in api
+    assert "settings.tabs.remoteLan" in api
+
+
+def test_readme_sends_lan_access_to_the_remote_lan_tab():
+    text = README.read_text(encoding = "utf-8")
+    assert "Settings > Remote & LAN > LAN access" in text
+    assert "Settings > API keys > LAN access" not in text


### PR DESCRIPTION
## Problem

https://github.com/unslothai/unsloth/issues/9519

Settings > API and Settings > Remote & LAN both mount RemoteAccessSection and LanAccessSection. #9389 added the dedicated tab and left the API copy so the old path still worked. The issue screenshots are that pair twice. README still says `Settings > API keys > LAN access`; the startup banner already says Settings > Remote & LAN.

## Approach

Cards stay on Remote & LAN. The API tab drops the pair and switches with `setActiveTab("remote-lan")`. README path now matches the startup banner. KeylessApiAccessSection is also on both tabs, but that is a different control and not in this issue.

## Testing

macOS, Python 3.12.

`.venv/bin/python -m pytest tests/studio/test_remote_lan_settings_home.py -q` -> 3 passed.

Reverted the tab and README, reran the same file: 3 failed (cards still on API, no setActiveTab, README still on API keys).

`.venv/bin/python -m pytest tests/studio/test_usage_examples_model_source_contract.py::test_auto_switch_section_sits_above_the_usage_examples -q` -> passed.

`.venv/bin/python -m ruff check tests/studio/test_remote_lan_settings_home.py` -> All checks passed.

Did not run Studio desktop or Playwright.
