### PR TITLE
Studio: admit a bearer that carries no token under keyless API access

### DIFF
--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -91,7 +91,11 @@ def admitted_without_credential(credentials: Optional[HTTPAuthorizationCredentia
 
 def _request_would_use_keyless(request: Any) -> bool:
     """Classify a request before the security dependency has recorded its result."""
-    from utils.keyless_api_access import APPROVED_DUMMY_BEARERS, keyless_request_allowed
+    from utils.keyless_api_access import (
+        APPROVED_DUMMY_BEARERS,
+        is_empty_bearer,
+        keyless_request_allowed,
+    )
 
     if not keyless_request_allowed(request):
         return False
@@ -108,6 +112,8 @@ def _request_would_use_keyless(request: Any) -> bool:
         return True
     if len(values) != 1:
         return False
+    if is_empty_bearer(values[0]):
+        return True
     scheme, token = get_authorization_scheme_param(values[0])
     return scheme.lower() == "bearer" and token in APPROVED_DUMMY_BEARERS
 
@@ -145,6 +151,7 @@ class _BearerOrKeyless(HTTPBearer):
     async def __call__(self, request: Request) -> Optional[HTTPAuthorizationCredentials]:
         from utils.keyless_api_access import (
             APPROVED_DUMMY_BEARERS,
+            is_empty_bearer,
             keyless_request_allowed,
             mark_keyless_admission,
             request_was_admitted_keyless,
@@ -171,7 +178,7 @@ class _BearerOrKeyless(HTTPBearer):
             if recorded is None
             else recorded
         )
-        if not authorization and eligible:
+        if (not authorization or is_empty_bearer(header)) and eligible:
             mark_keyless_admission(request, True)
             return _KEYLESS_CREDENTIALS
         dummy = eligible and usable_bearer and token in APPROVED_DUMMY_BEARERS
@@ -365,6 +372,9 @@ async def credentials_for_token(
     """
     from utils.keyless_api_access import APPROVED_DUMMY_BEARERS, keyless_request_allowed
 
+    # /api/health slices the bearer out itself, so a blank one arrives as "", not as None.
+    if token is not None and not token.strip():
+        token = None
     # Settings/listener reads hit SQLite and DNS, so keep them off the event loop.
     if token and token not in APPROVED_DUMMY_BEARERS:
         return HTTPAuthorizationCredentials(scheme = "Bearer", credentials = token)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3368,11 +3368,10 @@ async def _authenticate_header_or_query(request: Request, token: Optional[str]) 
 
     Routed through ``credentials_for_token`` so a scope that covers this path serves it
     without a key, the way the routes behind ``security`` already do."""
-    auth_header = request.headers.get("authorization")
-    if auth_header and auth_header.lower().startswith("bearer "):
-        jwt_token = auth_header[7:]
-    else:
-        jwt_token = token or None
+    auth_header = request.headers.get("authorization") or ""
+    header_token = auth_header[7:] if auth_header.lower().startswith("bearer ") else ""
+    # A blank header is the absent header, so the `?token=` an <img src> sends is still owed.
+    jwt_token = header_token.strip() or token or None
     from auth.authentication import credentials_for_token
 
     creds = await credentials_for_token(request, jwt_token)

--- a/studio/backend/tests/test_keyless_api_access.py
+++ b/studio/backend/tests/test_keyless_api_access.py
@@ -23,6 +23,7 @@ from auth.authentication import (
     admitted_without_credential,
     admitted_without_session,
     create_access_token,
+    credentials_for_token,
     get_current_subject,
     security,
 )
@@ -782,9 +783,13 @@ def test_credentials_never_downgrade_to_keyless():
         subject_of(bearer_request("not-needed", path = "/v1/load"))
     set_keyless_api_access("full")
 
-    for header in ("Bearer arbitrary", "garbage", "Basic abc", "Bearer"):
+    for header in ("Bearer arbitrary", "garbage", "Basic abc"):
         with pytest.raises(HTTPException):
             subject_of(request_for(headers = {"Authorization": header}))
+    for header in ("Bearer", "Bearer ", "bearer   "):
+        blank = request_for(headers = {"Authorization": header})
+        assert resolve(blank).scheme == KEYLESS_SCHEME
+        assert subject_of(blank) == storage.DEFAULT_ADMIN_USERNAME
     duplicate = asgi_scope()
     duplicate["headers"] = [
         (b"authorization", b"Bearer not-needed"),
@@ -833,6 +838,28 @@ def _middleware_policy(scope):
     return observed
 
 
+def test_a_blank_bearer_is_the_missing_header_on_routes_that_read_it_themselves():
+    """A blank header must not suppress the `?token=` credential, turning its 401 into a pass."""
+    from routes.inference import _authenticate_header_or_query
+
+    seed_user()
+    set_keyless_api_access("full")
+    stale = create_access_token(
+        storage.DEFAULT_ADMIN_USERNAME, expires_delta = timedelta(seconds = -60))
+    for headers in (None, {"Authorization": "Bearer "}, {"Authorization": "Bearer"}):
+        sandbox = lambda token: _authenticate_header_or_query(
+            request_for(path = "/v1/sandbox/x", headers = headers), token)
+        with pytest.raises(HTTPException):
+            asyncio.run(sandbox(stale))
+        assert asyncio.run(sandbox(None)) == storage.DEFAULT_ADMIN_USERNAME
+    # /api/health has no query credential to fall back on, so "" must resolve the way None does.
+    for token in (None, "", "   "):
+        credentials = asyncio.run(credentials_for_token(request_for(path = "/api/health"), token))
+        assert credentials is not None and credentials.scheme == KEYLESS_SCHEME, token
+    set_keyless_api_access("off")
+    assert asyncio.run(credentials_for_token(request_for(path = "/api/health"), "")) is None
+
+
 def test_tool_policy_and_api_identity(monkeypatch):
     from core.inference.llama_keepwarm import _carries_bearer_credentials
     from routes import inference
@@ -844,6 +871,8 @@ def test_tool_policy_and_api_identity(monkeypatch):
     assert request.state.keyless_api_admitted is True
     assert admitted_without_credential(resolve(request)) is True
     assert admitted_without_session(request) is True
+    # Same verdict before one is recorded: read as credentialed, it would skip the keyless guards.
+    assert admitted_without_session(request_for(headers = {"Authorization": "Bearer "})) is True
     assert inference._request_has_api_key(request) is True
     assert inference._request_used_api_key(request) is True
     assert inference._request_is_saved_credential_workflow(request) is False

--- a/studio/backend/tests/test_keyless_api_access.py
+++ b/studio/backend/tests/test_keyless_api_access.py
@@ -776,7 +776,7 @@ def test_credentials_never_downgrade_to_keyless():
     seed_user()
     set_keyless_api_access("full")
     assert resolve(request_for()).scheme == KEYLESS_SCHEME
-    for token in ("not-needed", "lm-studio", "ollama"):
+    for token in ("not-needed", "lm-studio", "ollama", "no-key-required"):
         assert resolve(bearer_request(token)).scheme == KEYLESS_FALLBACK_SCHEME
     set_keyless_api_access("inference")
     with pytest.raises(HTTPException):

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -130,8 +130,12 @@ def test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate(
     assert caught.value.status_code in (401, 403)
     # ...and neither the dummy bearers nor an empty one may resurrect it.
     for header in (
-        "Bearer not-needed", "Bearer lm-studio", "Bearer ollama",
-        "Bearer no-key-required", "Bearer", "Bearer ",
+        "Bearer not-needed",
+        "Bearer lm-studio",
+        "Bearer ollama",
+        "Bearer no-key-required",
+        "Bearer",
+        "Bearer ",
     ):
         with pytest.raises(HTTPException):
             asyncio.run(

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -128,13 +128,11 @@ def test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate(
     with pytest.raises(HTTPException) as caught:
         resolve(request_for())
     assert caught.value.status_code in (401, 403)
-    # ...and the dummy bearers must not resurrect it either.
-    for dummy in ("not-needed", "lm-studio", "ollama"):
+    # ...and neither the dummy bearers nor an empty one may resurrect it.
+    for header in ("Bearer not-needed", "Bearer lm-studio", "Bearer ollama", "Bearer", "Bearer "):
         with pytest.raises(HTTPException):
             asyncio.run(
-                get_current_subject(
-                    resolve(request_for(headers = {"Authorization": f"Bearer {dummy}"}))
-                )
+                get_current_subject(resolve(request_for(headers = {"Authorization": header})))
             )
 
 
@@ -401,8 +399,12 @@ def test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes():
         ({"Authorization": "Bearer lm-studio"}, True),
         ({"Authorization": "Bearer ollama"}, True),
         ({"Authorization": "Bearer sk-unsloth-nope"}, False),
-        ({"Authorization": "Bearer"}, False),
+        # What a harness that always sends the header emits with no key: the missing header.
+        ({"Authorization": "Bearer"}, True),
+        ({"Authorization": "Bearer "}, True),
+        ({"Authorization": "bearer   "}, True),
         ({"Authorization": "Basic bm90LW5lZWRlZA=="}, False),
+        ({"Authorization": "Basic"}, False),
         # A doubled space after the scheme. This is the shape the two implementations
         # used to disagree on: the dependency collapsed it and admitted the dummy while
         # the twin did not, so the request was keyless to every route but not-keyless to

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -129,7 +129,10 @@ def test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate(
         resolve(request_for())
     assert caught.value.status_code in (401, 403)
     # ...and neither the dummy bearers nor an empty one may resurrect it.
-    for header in ("Bearer not-needed", "Bearer lm-studio", "Bearer ollama", "Bearer", "Bearer "):
+    for header in (
+        "Bearer not-needed", "Bearer lm-studio", "Bearer ollama",
+        "Bearer no-key-required", "Bearer", "Bearer ",
+    ):
         with pytest.raises(HTTPException):
             asyncio.run(
                 get_current_subject(resolve(request_for(headers = {"Authorization": header})))
@@ -398,6 +401,11 @@ def test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes():
         ({"Authorization": "Bearer not-needed"}, True),
         ({"Authorization": "Bearer lm-studio"}, True),
         ({"Authorization": "Bearer ollama"}, True),
+        # What hermes-agent sends with no key: the SDK refuses an empty one, so it
+        # substitutes this literal rather than the blank header above.
+        ({"Authorization": "Bearer no-key-required"}, True),
+        # Still a credential we do not know, so still refused.
+        ({"Authorization": "Bearer sk-no-key-required"}, False),
         ({"Authorization": "Bearer sk-unsloth-nope"}, False),
         # What a harness that always sends the header emits with no key: the missing header.
         ({"Authorization": "Bearer"}, True),

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -65,6 +65,14 @@ _INFERENCE_ROUTES = frozenset(
 )
 
 
+def is_empty_bearer(header: str) -> bool:
+    """Whether ``header`` is a bearer with no token: what a harness sends with no key set."""
+    from fastapi.security.utils import get_authorization_scheme_param
+
+    scheme, token = get_authorization_scheme_param(header)
+    return scheme.lower() == "bearer" and not token
+
+
 def _coerce_scope(value: Any) -> Optional[str]:
     if isinstance(value, str) and value.strip().lower() in KEYLESS_SCOPES:
         return value.strip().lower()
@@ -698,5 +706,7 @@ def asgi_request_is_keyless(asgi_scope, settings: Optional[tuple[str, bool]] = N
     # making a shape keyless to every route but not-keyless to the middleware that clamps the tool grant.
     from fastapi.security.utils import get_authorization_scheme_param
 
+    if is_empty_bearer(authorization[0]):
+        return True
     scheme, token = get_authorization_scheme_param(authorization[0])
     return bool(scheme.lower() == "bearer" and token in APPROVED_DUMMY_BEARERS)

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -40,7 +40,11 @@ KEYLESS_SCOPE_INFERENCE = "inference"
 KEYLESS_SCOPE_FULL = "full"
 KEYLESS_SCOPES = (KEYLESS_SCOPE_OFF, KEYLESS_SCOPE_INFERENCE, KEYLESS_SCOPE_FULL)
 DEFAULT_KEYLESS_API_ACCESS_SCOPE = KEYLESS_SCOPE_OFF
-APPROVED_DUMMY_BEARERS = frozenset({"not-needed", "lm-studio", "ollama"})
+APPROVED_DUMMY_BEARERS = frozenset(
+    # ``no-key-required`` is what hermes-agent substitutes when no key is configured,
+    # because the OpenAI SDK refuses an empty one (hermes_cli/runtime_provider_backends.py).
+    {"not-needed", "lm-studio", "ollama", "no-key-required"}
+)
 KEYLESS_ADMISSION_STATE_KEY = "keyless_api_admitted"
 
 # Named by method and normalized path: /v1 also aliases model loading, media,


### PR DESCRIPTION
Fixes #10400

## What happens now

With **Keyless API access** on, a client that sends `Authorization: Bearer` with nothing behind it is refused with a 401, on a scope that covers the route. Harnesses that attach the header unconditionally emit exactly that when no key is configured, so pointing one at Studio fails even though the setting says chat works without a key. The reporter hit it with VS Code Copilot and Hermes.

## Root cause

Keyless admission recognised two shapes: no `Authorization` header at all, and `Bearer <token>` for one of the dummy strings the OpenAI SDKs send. A bare `Bearer` is neither. It parses to an empty token, so the usable-bearer test fails while the header list is still non-empty, and the request falls past both keyless branches into stock `HTTPBearer`, which answers 401.

## What changed

A bearer carrying no token names no credential, so it is now admitted wherever a missing header already was. It resolves to the no-header scheme rather than the dummy-token one, whose membership check an empty token would fail.

`is_empty_bearer` is a single predicate rather than a rule spelled out at each site, because the classifiers must not drift: the security dependency, the pre-admission classifier that guards keyless-only side effects, and the ASGI twin the tool-policy middleware reads all ask it. These three already disagreed once over `bearer  not-needed`, which made a request keyless to every route but not-keyless to the middleware that clamps the tool grant.

Routes that read the bearer for themselves get the same rule. `/api/health` slices it out of the header, so a blank one reaches `credentials_for_token` as an empty string rather than as a missing one. The sandbox routes also accept a `?token=` query credential, which an `<img src>` has no other way to send, so a blank header there falls through to the query token instead of suppressing it — otherwise adding `Bearer ` to a request carrying a stale `?token=` would have turned its 401 into an admission, which a missing header never did.

Other placeholder literals (`EMPTY`, `null`, `undefined`, `sk-no-key-required`) still answer 401. Widening the dummy list is a separate question from accepting a header that carries nothing.

## Why this does not widen access

- The transport gate — origin, `Sec-Fetch-Site`, host authority, loopback and private LAN, tunnel, Colab, `--secure` — is evaluated before the header is read, and is untouched. An empty bearer and a missing header pass through exactly the same checks.
- A cross-origin page that sets `Authorization` forces a CORS preflight it could skip by sending nothing, so this is the harder shape for a browser to reach, not the easier one.
- An empty token names no credential, so it cannot collide with the rule that an expired session JWT and a revoked API key keep failing.
- With the scope off, the header still answers 401.

## Reviewer notes

Two behaviours worth knowing about, both measured rather than reasoned:

**Latin-1 high bytes read as empty.** `Bearer \xa0` and `Bearer \x85` decode to characters `str.strip()` treats as whitespace, so FastAPI's parser returns an empty token and they are admitted too. Left as is: they admit no caller who could not be admitted by sending no header at all, over identical transport and scope gates, and the alternative is a second hand-rolled header parser — the exact thing that produced the `bearer  not-needed` drift the shared parser now guards against.

**A pre-existing gap this does not touch.** On unmodified `main`, `/api/health` already resolves `Authorization: Basic abc` and a duplicated `Authorization` keylessly, because its extractor yields `None` for any non-bearer header while the dependency refuses both. Out of scope here; worth a separate fix.

## Validation

```bash
python -m pytest studio/backend/tests/test_keyless_api_access.py \
                 studio/backend/tests/test_keyless_api_access_adversarial.py \
                 studio/backend/tests/test_auth_lookup_off_event_loop.py \
                 studio/backend/tests/test_desktop_auth.py \
                 studio/backend/tests/test_mcp_stdio_api_key_gate.py \
                 studio/backend/tests/test_api_key_expiry.py \
                 studio/backend/tests/test_external_provider_route_wiring.py \
                 studio/backend/tests/test_lan_access_settings.py -q
```

265 passed.

Header shapes through the dependency and the ASGI twin, scope `inference`, loopback:

```text
(no header)                 Keyless         admitted
Bearer not-needed           KeylessBearer   admitted
Bearer                      Keyless         admitted   <- was 401
Bearer                      Keyless         admitted   <- was 401 (trailing space)
Bearer EMPTY                                401
Bearer sk-unsloth-<revoked>                 401
```

Sandbox route, scope `full`, loopback, exercising the query credential:

```text
no header,  ?token=expired   401 Invalid or expired token
Bearer   ,  ?token=expired   401 Invalid or expired token
no header,  no token         admitted
Bearer   ,  no token         admitted
```

Each added or changed test was checked against a mutation of the production line it covers:

| mutation | test that fails |
| --- | --- |
| revert the dependency branch to `if not authorization and eligible` | `test_credentials_never_downgrade_to_keyless`, `test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes` |
| drop the `is_empty_bearer` early return from the ASGI twin | `test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes` |
| drop the scheme check from `is_empty_bearer` | both of the above |
| drop the blank-token normalisation in `credentials_for_token` | `test_a_blank_bearer_is_the_missing_header_on_routes_that_read_it_themselves` |
| revert the sandbox extractor | same |
| drop the empty-bearer branch from `_request_would_use_keyless` | `test_tool_policy_and_api_identity` |
| admit the empty bearer regardless of eligibility | `test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate` |
