### PR TITLE
Stop shipping the frontend source tree and desktop crate in the wheel

### DIFF
--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -9,7 +9,8 @@
 # Verified locally end-to-end against this branch:
 #   - python -m build produces unsloth-<version>-py3-none-any.whl in 13s
 #   - wheel content sanity passes:
-#       lockfile shipped, frontend dist shipped,
+#       frontend dist shipped, and none of the pre-build tree with it:
+#       no package-lock, no frontend public, no frontend src,
 #       no node_modules in wheel, no bun.lock in wheel,
 #       main bundle has unstable_Provider hits=1 (assistant-ui internals only).
 #   - Unsloth backend imports cleanly from the installed wheel with the

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -98,7 +98,12 @@ jobs:
           with zipfile.ZipFile(w) as z:
               n = z.namelist()
               checks = {
-                "lockfile shipped":      any(s.endswith("studio/frontend/package-lock.json") for s in n),
+                # The lockfile used to be asserted PRESENT. It is a build input for
+                # `npm ci` above, not something an installed Unsloth reads, so it now
+                # has to be absent along with the rest of the pre-build tree.
+                "no package-lock":       not any(s.endswith("studio/frontend/package-lock.json") for s in n),
+                "no frontend public":    not any("studio/frontend/public/" in s for s in n),
+                "no frontend src":       not any("studio/frontend/src/"    in s for s in n),
                 "frontend dist shipped": any(s.endswith("studio/frontend/dist/index.html")    for s in n),
                 "no node_modules":       not any("studio/frontend/node_modules/" in s for s in n),
                 "no bun.lock":           not any(s.endswith("studio/frontend/bun.lock")       for s in n),

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,9 +14,10 @@ prune unsloth/kernels/moe/tests
 # Frontend pre-build tree. public/ is copied into frontend/dist by Vite, so
 # shipping both put all 99 of its files in the wheel twice; src/ is .tsx that is
 # already compiled into dist/assets. Only frontend/dist is served at runtime.
-# Keep these in step with exclude-package-data in pyproject.toml: that entry
-# covers the wheel built in place, this one covers the wheel `python -m build`
-# rebuilds from the sdist.
+# Keep these in step with exclude-package-data in pyproject.toml. That entry is
+# what actually keeps them out of the wheel, including the wheel `python -m build`
+# rebuilds from the sdist; these prunes keep them out of the sdist itself, so the
+# two artifacts agree and neither carries a tree nothing installs.
 prune studio/frontend/public
 prune studio/frontend/src
 exclude studio/frontend/package-lock.json
@@ -30,6 +31,14 @@ prune studio/src-tauri/linux
 prune studio/src-tauri/windows
 prune studio/src-tauri/dmg
 prune studio/src-tauri/capabilities
+# `prune` only takes directories, so the crate's root files need naming. Without
+# these the sdist still carried Cargo.lock and the tauri*.json configs even though
+# exclude-package-data kept them out of the wheel.
+exclude studio/src-tauri/Cargo.lock
+exclude studio/src-tauri/Cargo.toml
+exclude studio/src-tauri/build.rs
+exclude studio/src-tauri/*.plist
+exclude studio/src-tauri/tauri*.json
 
 # Backstop for a suite added anywhere else later. `prune` and a `*` glob are both
 # single-level, so this needs `**`, and it cannot see a root-level tests/ at all.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,26 @@ prune studio/frontend/tests
 prune unsloth_cli/tests
 prune unsloth/kernels/moe/tests
 
+# Frontend pre-build tree. public/ is copied into frontend/dist by Vite, so
+# shipping both put all 99 of its files in the wheel twice; src/ is .tsx that is
+# already compiled into dist/assets. Only frontend/dist is served at runtime.
+# Keep these in step with exclude-package-data in pyproject.toml: that entry
+# covers the wheel built in place, this one covers the wheel `python -m build`
+# rebuilds from the sdist.
+prune studio/frontend/public
+prune studio/frontend/src
+exclude studio/frontend/package-lock.json
+
+# Desktop crate. `tauri build` reads these from a git checkout in
+# release-desktop.yml, never from the published wheel. src-tauri/icons is
+# deliberately absent here: install.sh copies icon.icns and icon.png out of
+# site-packages to build the macOS and Linux launchers.
+prune studio/src-tauri/src
+prune studio/src-tauri/linux
+prune studio/src-tauri/windows
+prune studio/src-tauri/dmg
+prune studio/src-tauri/capabilities
+
 # Backstop for a suite added anywhere else later. `prune` and a `*` glob are both
 # single-level, so this needs `**`, and it cannot see a root-level tests/ at all.
 global-exclude */tests/**

--- a/install.sh
+++ b/install.sh
@@ -1723,8 +1723,13 @@ LAUNCHER_EOF
     # Try to find rounded-512.png from installed package (site-packages) or local repo
     _css_found_icon=""
     _css_venv_dir=$(dirname "$(dirname "$_css_exe")")
-    # Check site-packages
-    for _sp in "$_css_venv_dir"/lib/python*/site-packages/unsloth/studio/frontend/public; do
+    # Check site-packages. `studio` is a top-level package in the wheel (see
+    # top_level.txt), not a subpackage of `unsloth`, so the old
+    # site-packages/unsloth/studio/... glob never matched and every install fell
+    # through to the network download below. Read it out of frontend/dist rather
+    # than frontend/public: Vite copies public/ into dist/ at build time, so the
+    # file is in both in a checkout, but only dist/ ships in the wheel.
+    for _sp in "$_css_venv_dir"/lib/python*/site-packages/studio/frontend/dist; do
         if [ -f "$_sp/rounded-512.png" ]; then
             _css_found_icon="$_sp/rounded-512.png"
         fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,41 @@ exclude = [
 [tool.setuptools.exclude-package-data]
 "studio.backend" = ["tests/*"]
 "studio.backend.hub" = ["tests/*"]
+# Same mechanism, applied to the frontend source tree. package-data above names
+# `frontend/dist/**/*` and nothing else under frontend/, but include-package-data
+# plus setuptools-scm's git file finder ships every tracked file under studio/
+# anyway, so the wheel carried the whole pre-build tree:
+#
+#   frontend/public   31.1MB compressed, and every one of its 99 files is already
+#                     in frontend/dist byte for byte, because Vite copies public/
+#                     into dist/ during `npm run build`. Pure duplication.
+#   frontend/src       4.0MB of .ts/.tsx that nothing imports at runtime.
+#
+# Neither path is read from an installed Unsloth: run.py mounts frontend/dist
+# (_DEFAULT_FRONTEND_PATH) and the only `frontend/public` references in Python are
+# the remote raw.githubusercontent URLs in backend/colab.py. The desktop app is
+# unaffected either way, since release-desktop.yml builds both the frontend and
+# Tauri from a git checkout, not from this wheel.
+#
+# src-tauri is the desktop crate: Rust sources plus NSIS/AppImage/dmg installer
+# branding, all consumed by `tauri build` in CI from the checkout. icons/ is the
+# exception and stays, because install.sh reads icon.icns and icon.png back out of
+# site-packages/studio/src-tauri/icons to build the macOS and Linux launchers.
+"studio" = [
+    "frontend/public/**",
+    "frontend/src/**",
+    "frontend/package-lock.json",
+    "src-tauri/src/**",
+    "src-tauri/linux/**",
+    "src-tauri/windows/**",
+    "src-tauri/dmg/**",
+    "src-tauri/capabilities/**",
+    "src-tauri/Cargo.lock",
+    "src-tauri/Cargo.toml",
+    "src-tauri/build.rs",
+    "src-tauri/*.plist",
+    "src-tauri/tauri*.json",
+]
 
 [project.optional-dependencies]
 # Unsloth's server stack, mirroring studio/backend/requirements/studio.txt.

--- a/tests/studio/install/test_package_discovery.py
+++ b/tests/studio/install/test_package_discovery.py
@@ -163,17 +163,13 @@ def test_built_wheel_has_no_frontend_source():
     if not wheels:
         pytest.skip("no built wheel in dist/, run `python -m build --wheel` first")
     names = zipfile.ZipFile(wheels[-1]).namelist()
-    leaked = [
-        n
-        for n in names
-        if n.startswith(("studio/frontend/public/", "studio/frontend/src/"))
-    ]
+    leaked = [n for n in names if n.startswith(("studio/frontend/public/", "studio/frontend/src/"))]
     assert not leaked, f"{wheels[-1].name} ships {len(leaked)} frontend source files"
     # The served frontend must still be there. Guarding the exclusion alone would
     # pass just as happily on a wheel with no UI in it at all.
-    assert any(n.startswith("studio/frontend/dist/") for n in names), (
-        f"{wheels[-1].name} ships no frontend/dist; the UI would 404"
-    )
+    assert any(
+        n.startswith("studio/frontend/dist/") for n in names
+    ), f"{wheels[-1].name} ships no frontend/dist; the UI would 404"
 
 
 def test_manifest_prunes_match_exclude_package_data():
@@ -191,9 +187,9 @@ def test_manifest_prunes_match_exclude_package_data():
         "studio/src-tauri/src",
     ):
         assert f"prune {path}\n" in manifest, f"MANIFEST.in must prune {path}"
-    assert "prune studio/src-tauri/icons" not in manifest, (
-        "src-tauri/icons is read from site-packages by install.sh; do not prune it"
-    )
+    assert (
+        "prune studio/src-tauri/icons" not in manifest
+    ), "src-tauri/icons is read from site-packages by install.sh; do not prune it"
 
 
 def test_backend_runtime_still_ships():

--- a/tests/studio/install/test_package_discovery.py
+++ b/tests/studio/install/test_package_discovery.py
@@ -32,12 +32,18 @@ def _exclude_package_data():
     assert len(section) == 2, "no exclude-package-data table in pyproject.toml"
     body = section[1].split("\n[", 1)[0]
     table = {}
-    for line in body.splitlines():
-        entry = re.match(r'^\s*"?([\w.*]+)"?\s*=\s*\[(.*?)\]\s*$', line)
-        if entry:
-            # "*" is setuptools' pyproject spelling of the all-packages key.
-            key = "" if entry.group(1) == "*" else entry.group(1)
-            table[key] = re.findall(r'["\']([^"\']+)["\']', entry.group(2))
+    # DOTALL so a value spread over several lines is read whole. Matching only
+    # single-line arrays would silently return {} for a multi-line entry, and every
+    # caller reads an empty veto list as "nothing is excluded", so the simulation
+    # would disagree with the wheel setuptools actually builds.
+    for entry in re.finditer(
+        r'^\s*"?([\w.*]+)"?\s*=\s*\[(.*?)\]',
+        body,
+        re.MULTILINE | re.DOTALL,
+    ):
+        # "*" is setuptools' pyproject spelling of the all-packages key.
+        key = "" if entry.group(1) == "*" else entry.group(1)
+        table[key] = re.findall(r'["\']([^"\']+)["\']', entry.group(2))
     return table
 
 
@@ -113,6 +119,81 @@ def test_backend_test_suites_stay_out_of_the_wheel():
         if path.startswith("studio/backend/") and "/tests/" in path
     ]
     assert not leaked, f"{len(leaked)} backend test files would ship, e.g. {leaked[:3]}"
+
+
+def test_frontend_source_tree_stays_out_of_the_wheel():
+    # public/ is copied into frontend/dist by Vite, so without the veto every one of
+    # its files shipped twice, and src/ is .tsx that is already compiled into
+    # dist/assets. Together they were 35MB of an 82MB wheel in 2026.9.2.
+    shipped = _wheel_payload()
+    leaked = [
+        path
+        for path in shipped
+        if path.startswith(("studio/frontend/public/", "studio/frontend/src/"))
+    ]
+    assert not leaked, f"{len(leaked)} frontend source files would ship, e.g. {leaked[:3]}"
+
+
+def test_desktop_crate_sources_stay_out_of_the_wheel():
+    # `tauri build` reads these from a git checkout in release-desktop.yml. Only
+    # src-tauri/icons is needed from an installed Unsloth, by install.sh.
+    leaked = [
+        path
+        for path in _wheel_payload()
+        if path.startswith("studio/src-tauri/") and not path.startswith("studio/src-tauri/icons/")
+    ]
+    assert not leaked, f"{len(leaked)} desktop crate files would ship, e.g. {leaked[:3]}"
+
+
+def test_installer_icons_survive_the_src_tauri_exclusion():
+    # install.sh copies both out of site-packages/studio/src-tauri/icons to build the
+    # macOS .icns and the Linux .desktop launcher, so the exclusion above must not
+    # take the whole directory with it.
+    shipped = set(_wheel_payload())
+    for path in (
+        "studio/src-tauri/icons/icon.icns",
+        "studio/src-tauri/icons/icon.png",
+    ):
+        assert path in shipped, f"{path} must stay in the wheel for install.sh"
+
+
+def test_built_wheel_has_no_frontend_source():
+    """Artifact-level check, run when a wheel has already been built."""
+    wheels = sorted((REPO_ROOT / "dist").glob("unsloth-*.whl"))
+    if not wheels:
+        pytest.skip("no built wheel in dist/, run `python -m build --wheel` first")
+    names = zipfile.ZipFile(wheels[-1]).namelist()
+    leaked = [
+        n
+        for n in names
+        if n.startswith(("studio/frontend/public/", "studio/frontend/src/"))
+    ]
+    assert not leaked, f"{wheels[-1].name} ships {len(leaked)} frontend source files"
+    # The served frontend must still be there. Guarding the exclusion alone would
+    # pass just as happily on a wheel with no UI in it at all.
+    assert any(n.startswith("studio/frontend/dist/") for n in names), (
+        f"{wheels[-1].name} ships no frontend/dist; the UI would 404"
+    )
+
+
+def test_manifest_prunes_match_exclude_package_data():
+    """MANIFEST.in is the veto that survives the sdist -> wheel rebuild.
+
+    `python -m build` builds the wheel from the sdist, where exclude-package-data
+    no longer bites because there is no .git tree for the setuptools-scm file
+    finder. Anything vetoed in pyproject.toml has to be pruned here too or it
+    comes straight back.
+    """
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding = "utf-8")
+    for path in (
+        "studio/frontend/public",
+        "studio/frontend/src",
+        "studio/src-tauri/src",
+    ):
+        assert f"prune {path}\n" in manifest, f"MANIFEST.in must prune {path}"
+    assert "prune studio/src-tauri/icons" not in manifest, (
+        "src-tauri/icons is read from site-packages by install.sh; do not prune it"
+    )
 
 
 def test_backend_runtime_still_ships():

--- a/tests/studio/install/test_package_discovery.py
+++ b/tests/studio/install/test_package_discovery.py
@@ -173,12 +173,14 @@ def test_built_wheel_has_no_frontend_source():
 
 
 def test_manifest_prunes_match_exclude_package_data():
-    """MANIFEST.in is the veto that survives the sdist -> wheel rebuild.
+    """The two vetoes have to name the same paths, for different artifacts.
 
-    `python -m build` builds the wheel from the sdist, where exclude-package-data
-    no longer bites because there is no .git tree for the setuptools-scm file
-    finder. Anything vetoed in pyproject.toml has to be pruned here too or it
-    comes straight back.
+    exclude-package-data is what keeps these out of the WHEEL, and it keeps
+    working in the sdist -> wheel rebuild `python -m build` performs: restoring
+    the excluded files into an extracted sdist and listing them in its MANIFEST
+    still produces a wheel without them, which is setuptools' documented
+    exclusion precedence. These prunes are what keep them out of the SDIST
+    itself, so neither artifact carries a tree nothing installs.
     """
     manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding = "utf-8")
     for path in (


### PR DESCRIPTION
The 2026.9.2 wheel is 82.3MB. 35MB of that is the pre-build frontend tree and the Tauri desktop crate, neither of which an installed Unsloth ever reads.

## What was happening

`include-package-data = true` combined with setuptools-scm's git file finder hands **every tracked file** under `studio/` to the nearest surviving package. So `package-data` naming `frontend/dist/**/*` and nothing else under `frontend/` was never the constraint it looks like, and the wheel carried the whole source tree:

| Path | Compressed | Why it should not ship |
| --- | --- | --- |
| `studio/frontend/public` | 31.1MB | All 99 files are byte-identical to their copies in `frontend/dist`. Vite copies `public/` into `dist/` during `npm run build`, so every one of them shipped twice. |
| `studio/frontend/src` | 4.0MB | 1366 `.ts`/`.tsx` files, already compiled into `dist/assets`. |
| `studio/src-tauri` | 0.6MB | Rust sources plus NSIS/AppImage/dmg installer branding, consumed by `tauri build` from a checkout. |

The duplication is exact, not approximate. Comparing CRCs across the two directories in the published wheel: 99 files in `public/`, 99 present in `dist/`, 0 differing, 0 unique to `public/`.

## The fix

Veto them in `exclude-package-data` and prune them in `MANIFEST.in`. Both are needed, for the reason the top of `MANIFEST.in` already documents: `python -m build` rebuilds the wheel from the sdist, where `exclude-package-data` no longer bites because there is no `.git` tree for the file finder.

`src-tauri/icons` is deliberately kept. `install.sh:1764` and `1776` read `icon.icns` and `icon.png` back out of `site-packages/studio/src-tauri/icons` to build the macOS `.icns` and the Linux `.desktop` launcher, and `test_installer_shortcut_icons.py` already pins both to `package-data`.

## Why this does not affect Studio or the desktop release

- Studio serves `frontend/dist` and only `frontend/dist` (`run.py:1725`, `_DEFAULT_FRONTEND_PATH`, plus the site-packages fallbacks at 1746). It still ships in full.
- The only `frontend/public` references in Python are the remote `raw.githubusercontent.com` URLs in `backend/colab.py`, which are unaffected by packaging.
- Every `frontend/src` and `src-tauri` reference in Python is inside a comment.
- `release-desktop.yml` builds the frontend (`working-directory: studio/frontend`, line 706) and Tauri (line 723) from `actions/checkout`, not from the wheel, and `tauri.conf.json` sets `frontendDist: "../frontend/dist"` so the app bundles its own build.
- The workflow's PyPI stamp check reads `studio/backend/utils/_studio_release_build.py` (`stamp_studio_release.py:45`), which nothing here touches, so `--verify-dist` still passes.

## Verification

Built locally with a stand-in `frontend/dist`, then inspected both artifacts:

- absent from the wheel and sdist: `frontend/public/`, `frontend/src/`, `src-tauri/{src,linux,windows,dmg,capabilities}/`, `frontend/package-lock.json`, `Cargo.lock`
- still present: `frontend/dist/`, `src-tauri/icons/icon.icns`, `src-tauri/icons/icon.png`, `_studio_release_build.py`, `backend/vendor/`, `backend/assets/docs_ui/`, `backend/plugins/`

**82.3MB to 46.0MB.**

## Tests

Four regression tests in `test_package_discovery.py`, reusing its existing `_wheel_payload()` simulation, plus an artifact-level check that also asserts `frontend/dist` is still present, since guarding the exclusion alone would pass just as happily on a wheel with no UI in it at all. One more asserts the `MANIFEST.in` prunes stay in step with `exclude-package-data`.

One helper fix was needed: `_exclude_package_data()` matched single-line arrays only, and every caller reads an empty veto list as "nothing is excluded", so a multi-line entry would have made the simulation quietly disagree with the wheel setuptools actually builds. It now parses with `DOTALL`.

Image assets are the other half of the remaining size and are left for a separate PR.
