### PR TITLE
Publish Docker on the daily schedule, and move layer cache off the Actions quota

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,12 @@ name: Publish Blackwell Docker image
 
 on:
   push:
-    branches: [main]
+    # Deliberately NOT branches: [main]. Publishing on every merge meant 23 runs on
+    # 2026-09-06 and 14 on 2026-09-05 against one scheduled run each day, and since
+    # each is a two-arch build of both images it was the bulk of the repo's Actions
+    # cache and a large share of its runner minutes. The daily cron below is the
+    # release cadence for main now. Tags still publish immediately: a release that
+    # produced no image until the next morning would be worse than the spend.
     tags: ['v*']
   schedule:
     # Daily. Actions cron is UTC with no DST handling, so this is 11:17 in San
@@ -50,14 +55,17 @@ env:
   # Not a secret, and named once so the four login steps cannot drift apart.
   REGISTRY_USERNAME: unsloth
 
-# Serialise per-ref runs, EXCEPT on main where each commit gets its own group: a
-# shared group does not queue a main burst, it DISCARDS it (GitHub cancels any PENDING
-# run the moment a newer one is queued), so the earlier commit would publish no image
-# at all. The accepted cost is that two main commits can race to retag :core/:latest,
-# which is self-correcting on the next push, where a cancelled run leaves that commit
-# with no image at all. Each published image is still internally coherent: the digest
-# handoff and the smoke test resolve this run's own tag, not tags[0], and verify it.
-# tests/studio/test_main_runs_survive_merge_bursts.py enforces this shape.
+# Serialise per-ref runs, EXCEPT on main where each run gets its own group: a shared
+# group does not queue a burst, it DISCARDS it (GitHub cancels any PENDING run the
+# moment a newer one is queued), so the earlier one would publish no image at all.
+# Merges no longer trigger this workflow, so the burst it now guards against is a
+# scheduled run overlapping a workflow_dispatch, rather than a merge burst. Keeping
+# the per-sha key costs nothing and still prevents a dispatch being discarded.
+# Each published image is internally coherent either way: the digest handoff and the
+# smoke test resolve this run's own tag, not tags[0], and verify it.
+# Dropping the main push trigger also drops this workflow out of the scan in
+# tests/studio/test_main_runs_survive_merge_bursts.py, which selects on
+# `push.branches` containing main, so no exemption is needed there.
 concurrency:
   group: docker-publish-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: false
@@ -254,8 +262,14 @@ jobs:
           file: ./docker/Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=build-${{ matrix.platform }}
-          cache-to:   type=gha,scope=build-${{ matrix.platform }},mode=max
+          # Registry cache, not type=gha. mode=max exports every intermediate layer,
+          # which on the GHA backend put 127 blob entries and 32GB into a 50GB repo
+          # cache in a single morning and starved the GGUF and pip caches sharing it.
+          # A cache tag on the image's own repo has no such budget, so mode=max keeps
+          # its rebuild speed without the eviction pressure. The Docker Hub login
+          # above covers both reading and writing this ref.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-core-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          cache-to:   type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-core-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }},mode=max
           outputs:    type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           # Keep prose OUT of build-args: build-push-action forwards every non-empty
           # line verbatim, so a #-line becomes a bogus --build-arg.
@@ -439,9 +453,12 @@ jobs:
           file: ./docker/Dockerfile.studio
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          # mode=max here would blow the 10GB GHA quota and evict the base build's cache
-          cache-from: type=gha,scope=studio-${{ matrix.platform }}
-          cache-to:   type=gha,scope=studio-${{ matrix.platform }},mode=min
+          # Kept at mode=min. The original reason was the GHA cache quota, which no
+          # longer applies now that this is a registry ref on the image's own repo,
+          # but the remaining cost is Docker Hub storage rather than a hard budget,
+          # so raising it is a separate decision from moving the transport.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-studio-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          cache-to:   type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-studio-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }},mode=min
           outputs:    type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           # the same values the base build baked, so Studio matches it even if upstream
           # moved mid-run (build-args must be KEY=VALUE only)


### PR DESCRIPTION
The repo is over its Actions cache budget: `active_caches_size_in_bytes` reports **55.5GB across 146 caches** against a 50GB limit. Two changes to one workflow, both aimed at that.

## 1. Publish on the schedule, not on every merge

`on.push.branches` was `[main]` with no `paths:` filter, so every merge built both images for two architectures and pushed them:

| day | total runs | breakdown |
| --- | ---: | --- |
| 2026-09-06 | 24 | **push=23**, schedule=1 |
| 2026-09-05 | 15 | **push=14**, schedule=1 |
| 2026-09-07 | 10 | push=10 |

The scheduled run was 1 in 24. The cron already fires at `17 18 * * *`, which the existing comment notes is 11:17 in San Francisco under PDT, so that becomes the cadence for main.

**Tag pushes still publish immediately.** A release sitting without an image until the next morning would be worse than the spend, so `tags: ['v*']` is untouched. Say the word if you want tags on the schedule too.

Dropping the main push trigger takes this workflow out of the scan in `tests/studio/test_main_runs_survive_merge_bursts.py`, which selects on `push.branches` containing main (`_runs_on_main_push`, line 134), so it needs no entry in `QUOTA_BOUND`. The per-sha concurrency key is kept, since a scheduled run can still overlap a `workflow_dispatch`, and its comment now describes that rather than merge bursts.

## 2. Move the layer cache off the Actions quota

`cache-to` on the base build was `type=gha,scope=build-...,mode=max`. `mode=max` exports every intermediate layer, and with several runs in flight at once it produced:

- **127 `buildkit-blob-1-sha256:*` entries, 32.07GB, 61% of the entire repo cache**
- all created on **one morning**, 09:21 to 10:39, all on `refs/heads/main`
- largest single blobs 6.74GB, 6.29GB, 5.50GB

That budget is shared with caches that are far more expensive to rebuild: 4.94GB for a gemma-4-E4B GGUF, 3.51GB for gemma-4-E2B on macOS, 12.98GB of model weights across 6 entries. Self-renewing buildkit churn permanently occupying 61% of a 50GB budget means LRU eventually evicts the multi-GB HF downloads to make room for layers that a rebuild would regenerate anyway.

Switching to `type=registry` puts the cache on a tag in the image's own Docker Hub repo, which has no such budget, so **`mode=max` is kept** and rebuild speed is unchanged. Both jobs already run `docker/login-action` before building, which covers reading and writing the cache ref.

There is a note worth preserving here: the Studio build at line 444 already used `mode=min`, with the comment `mode=max here would blow the 10GB GHA quota and evict the base build's cache`. That diagnosis was correct, it was just applied to the smaller of the two images while the base build kept `mode=max`. This PR resolves that asymmetry by removing the constraint rather than by degrading the base build.

The Studio build stays at `mode=min`. Its stated reason no longer applies, but the remaining cost is Hub storage rather than a hard budget, so raising it is a separate decision from moving the transport.

## Safety

The `buildcache-core-*` and `buildcache-studio-*` tags are not touched by the `cleanup` job. It drops this run's `core-build-<run_id>` and `build-<run_id>` handles, and on schedule prunes nightly pins matched by an explicit `nightly-YYYY.MM.DD` / `core-nightly-YYYY.MM.DD` glob. Neither matches.

## Checks

- `scripts/lint_workflow_triggers.py`: `OK: scanned 45 workflow file(s)`
- `tests/python/test_docker_publish_tag_scheme.py`, `test_docker_hub_readme.py`, `test_docker_publish_ref_freeze.py`: 49 passed
- `tests/studio/test_main_runs_survive_merge_bursts.py`: 8 passed

## Not included

This does not delete the 32GB already in the cache. That is an Actions write and needs a credential with `actions: write`; happy to follow up, though GitHub will also evict it by LRU once the inflow stops.
