### PR TITLE
Make the venv-hardening decode strict, and say which codepoints differed

### DIFF
--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -95,14 +95,18 @@ def _assert_same_text(actual: str, expected: str, note: str) -> None:
         f"    actual   {describe(actual[head:])}",
         f"    expected {describe(expected[head:])}",
     ]
-    # Only claim a cause when the bytes show one. A wrong explanation on a real restore bug
-    # costs more than none: mojibake is the actual reading as expected's UTF-8 bytes back
-    # through a single-byte code page, so test that directly rather than pattern-matching.
+    # Only claim a cause when the bytes show one, and only the cause that is still possible.
+    # _run_powershell decodes stdout as strict UTF-8, so a transport mis-decode raises there
+    # rather than arriving here: mojibake that reaches this point was produced inside the
+    # script, which is the product defect these cases exist to catch. Saying "the script did
+    # not lose the path" would be exactly backwards, and a wrong explanation on a real
+    # restore bug costs more than none.
     if _looks_like_a_mis_decode(actual[head:], expected[head:]):
         lines.append(
-            "  actual is expected's UTF-8 bytes decoded as a single-byte code page, i.e. this "
-            "shell's stdout was read with the Windows ANSI code page. The script did not lose "
-            "the path."
+            "  actual is expected's UTF-8 bytes read back through a single-byte code page. "
+            "Stdout is decoded strictly as UTF-8 here, so the shell handed us these "
+            "characters: the mis-decode happened inside the script, not in transport. Check "
+            "the marker read/write path for a missing -Encoding utf8."
         )
     raise AssertionError("\n".join(lines))
 

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -63,10 +63,59 @@ def _run_powershell(shell: str, script: str, env: dict[str, str]) -> str:
         capture_output = True,
         text = True,
         encoding = "utf-8",
+        # strict, so the next mismatch raises here rather than turning into U+FFFD and
+        # failing an assertion somewhere downstream about a value that was written fine.
+        errors = "strict",
         env = env,
         timeout = 30,
     )
     return result.stdout.strip()
+
+
+def _assert_same_text(actual: str, expected: str, note: str) -> None:
+    """`actual == expected`, but a mismatch names the codepoints that differ.
+
+    A bare `==` between two paths that differ in one accented character is unreadable in
+    CI: pytest renders its diff through the same stdout that mangled the string, so on a
+    non-UTF-8 console one side comes back as U+FFFD and the report accuses the half that
+    was right. Codepoints survive any code page, so they are what gets printed.
+    """
+    if actual == expected:
+        return
+    head = len(os.path.commonprefix([actual, expected]))
+
+    def describe(text: str) -> str:
+        shown = text[:24]
+        codepoints = " ".join(f"U+{ord(ch):04X}" for ch in shown)
+        return f"{shown!r}  [{codepoints}{' ...' if len(text) > len(shown) else ''}]"
+
+    lines = [
+        note,
+        f"  first {head} characters match, then:",
+        f"    actual   {describe(actual[head:])}",
+        f"    expected {describe(expected[head:])}",
+    ]
+    # Only claim a cause when the bytes show one. A wrong explanation on a real restore bug
+    # costs more than none: mojibake is the actual reading as expected's UTF-8 bytes back
+    # through a single-byte code page, so test that directly rather than pattern-matching.
+    if _looks_like_a_mis_decode(actual[head:], expected[head:]):
+        lines.append(
+            "  actual is expected's UTF-8 bytes decoded as a single-byte code page, i.e. this "
+            "shell's stdout was read with the Windows ANSI code page. The script did not lose "
+            "the path."
+        )
+    raise AssertionError("\n".join(lines))
+
+
+def _looks_like_a_mis_decode(actual: str, expected: str) -> bool:
+    """True when `actual` is `expected` encoded UTF-8 and decoded through a legacy code page."""
+    for codec in ("cp1252", "latin-1", "cp437", "cp850"):
+        try:
+            if expected.encode("utf-8").decode(codec) == actual:
+                return True
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            continue
+    return False
 
 
 def _uv_cache_functions(source: str) -> str:
@@ -862,7 +911,7 @@ Restore-StudioUvCacheMarker -StudioRoot $env:TEST_STUDIO_HOME
     env["TEST_MARKER"] = str(marker)
     result = json.loads(_run_powershell(shell, script, env).splitlines()[-1])
 
-    assert result["After"] == expected, result
+    _assert_same_text(result["After"], expected, "the rollback did not restore the marker it saved")
 
 
 @pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")


### PR DESCRIPTION
Rebased and narrowed. #10476 landed the decode fix and its `parity (windows-latest)` is green, so the transport bug is closed and this PR no longer carries it. What remains is the part that failure exposed and that fix did not cover.

## `errors = "strict"`

`encoding = "utf-8"` on its own already defaults to `errors="strict"` in subprocess text mode today, so this changes no behaviour. But the default is not the contract, and the cost of being wrong here is precisely the failure #10476 just fixed: an undecodable byte becomes U+FFFD and fails an assertion about a value that was written correctly. Worth stating at the one helper in this file that reads non-ASCII output.

## The assertion

This is the substantive half. The old line was:

```python
assert result["After"] == expected, result
```

which renders its diff through the same stdout under suspicion. On a cp1252 console the **expected** side came back as U+FFFD while the actual side round-tripped, so the report read as though the correct half were the broken one. Establishing which operand was mangled took byte-level reading of the raw log plus a caret count: one caret under expected, two under actual.

It now prints codepoints, which survive any code page, sliced from the common prefix so the message stays short:

```
the rollback did not restore the marker it saved
  first 56 characters match, then:
    actual   'A~A€ffee cache'  [U+00C3 U+00A4 U+0066 U+0066 U+0065 U+0065 ...]
    expected 'affee cache'   [U+00E4 U+0066 U+0066 U+0065 U+0065 ...]
  actual is expected's UTF-8 bytes decoded as a single-byte code page, i.e. this shell's
  stdout was read with the Windows ANSI code page. The script did not lose the path.
```

It names a cause **only when the bytes show one**. Mojibake is the actual reading as expected's UTF-8 bytes back through a single-byte code page, so that is tested by re-encoding through cp1252/latin-1/cp437/cp850 rather than pattern-matched. A genuine restore bug prints the codepoints and no explanation:

```
the rollback did not restore the marker it saved
  first 55 characters match, then:
    actual   'WRONG cache'   [U+0057 U+0052 U+004F U+004E U+0047 ...]
    expected 'kaffee cache'  [U+006B U+00E4 U+0066 U+0066 U+0065 U+0065 ...]
```

Explaining a real restore bug away as an encoding artefact would be worse than saying nothing, which is why the claim is earned rather than asserted.

## Deliberately dropped

The earlier revision of this branch also prepended `install.ps1`'s UTF-8 preamble to `_run_powershell`, pinning the *emit* side so the result would not depend on the runner's console code page. #10476's green run shows the runners already emit UTF-8, so that was defence against a condition that does not hold. Dropped rather than carried.

## Verification

- `pytest tests/python/test_windows_python_venv_hardening.py` -> 45 passed
- `pytest tests/test_enforce_kwargs_spacing.py` -> 62 passed
- no line over the repo's 119 limit
- both branches of the new assertion exercised directly: the cp1252 mojibake case names the code page, a substituted path does not

Net delta against main is 50 insertions, 1 deletion, one file.