### PR TITLE
A failed presence check in the indicator driver should say what the page looked like

### DIFF
--- a/tests/studio/playwright_loaded_models_indicator.py
+++ b/tests/studio/playwright_loaded_models_indicator.py
@@ -65,12 +65,19 @@ SETTLE_MS = int(os.environ.get("STUDIO_UI_INDICATOR_SETTLE_MS", "12000"))
 CARD = 'text="Loaded models"'
 EJECT = '[aria-label^="Eject "]'
 HANDLE = '[aria-label="Drag to move"]'
+# The collapsed form of the same card. Named up here because a failed presence check has to say which of the two it
+# found: "no card at all" and "no card but a pill" are different bugs, and a local string cannot be read from the
+# diagnostic below.
+PILL = 'button[aria-label*="Show details"]'
 POSITION_KEY = "unsloth_loaded_models_position"
 COLLAPSED_KEY = "unsloth_loaded_models_collapsed"
 SHOW_KEY = "unsloth_show_loaded_models_indicator"
 
 failures: list[str] = []
 checks = [0]
+# Whatever the page logged, newest last. Module level, as `failures` and `checks` are: the presence checks run after a
+# hard navigation, where a bundle that threw and a card that is merely slow are indistinguishable from the outside.
+console_errors: list[str] = []
 
 
 def info(s: str) -> None:
@@ -234,6 +241,58 @@ def card_text(page) -> str:
         return ""
 
 
+def why_no_card(page, state: Runtime, waited: str = "") -> str:
+    """What the page actually looked like when a presence check went the wrong way.
+
+    "FAILED: card survives /hub" reports only that the assertion failed, which is the one thing already known. These
+    are the states that separate the causes, and each one names a different bug: a redirect or a route that never
+    resolved (pathname), an SPA that never mounted (root_children 0), an auth slip that the /login guard in `boot`
+    cannot catch on a mid-suite navigation (auth_token), a preference that was not seeded (show_pref), a poll that
+    never fired (status_reads flat against the previous line), and a bundle that threw (console).
+    """
+
+    def probe(expression: str):
+        try:
+            return page.evaluate(expression)
+        except Exception:
+            return "<unreadable>"
+
+    def nodes(selector: str) -> int:
+        # Attached, not visible: a card that rendered off screen is a position bug, not a missing card, and the two
+        # have to read differently here.
+        try:
+            return page.locator(selector).count()
+        except Exception:
+            return -1
+
+    pathname = probe("location.pathname")
+    mounted = probe("document.getElementById('root')?.childElementCount ?? -1")
+    token = probe("Boolean(localStorage.getItem('unsloth_auth_token'))")
+    shown = probe(f"localStorage.getItem({json.dumps(SHOW_KEY)})")
+    return (
+        f"wait={waited or 'returned'} pathname={pathname!r} card_nodes={nodes(CARD)} "
+        f"collapsed_pill={nodes(PILL)} root_children={mounted} auth_token={token} "
+        f"show_pref={shown!r} status_reads={state.status_reads} console={console_errors[-4:]}"
+    )
+
+
+def await_selector(page, selector: str, timeout: int) -> str:
+    """Wait, and name what ended the wait rather than swallowing it.
+
+    The exception has to be swallowed -- the caller's own presence assertion is what decides pass or fail, so raising
+    here would turn a product verdict into a traceback. But swallowing it ANONYMOUSLY conflates two different
+    outcomes: a TimeoutError means the card really was not there within the budget, while anything else (a closed
+    target, a navigation error) means the run failed for a reason that has nothing to do with the card. Returning the
+    name lets the detail below say which.
+    """
+    try:
+        page.wait_for_selector(selector, timeout = timeout)
+    except Exception as exc:
+        first_line = str(exc).splitlines()[0] if str(exc) else ""
+        return f"{type(exc).__name__}: {first_line[:120]}"
+    return ""
+
+
 def boot(
     page,
     state: Runtime,
@@ -318,6 +377,15 @@ def main() -> int:
         install_routes(context, state)
         page = context.new_page()
         page.set_default_timeout(60_000)
+        # Recorded rather than printed: a passing run must stay quiet, and only a failed presence check reads them
+        # back. Truncated per message, since one React error carries a whole component stack.
+        page.on(
+            "console",
+            lambda message: console_errors.append(f"{message.type}: {message.text}"[:200])
+            if message.type in ("error", "warning")
+            else None,
+        )
+        page.on("pageerror", lambda error: console_errors.append(f"pageerror: {error}"[:200]))
         try:
             run(page, state)
         finally:
@@ -365,6 +433,8 @@ def run(page, state: Runtime) -> None:
     check("dictation row is distinguished", "Dictation" in text)
 
     for route in ("/hub", "/train", "/images"):
+        # Scoped to this navigation, so a failure names what THIS route logged rather than everything since boot.
+        console_errors.clear()
         page.goto(BASE + route, wait_until = "domcontentloaded")
         # Wait for the card, not for the clock. This is a hard navigation: a
         # full SPA reload plus a loaded-models poll, and 3000ms was the only
@@ -374,11 +444,14 @@ def run(page, state: Runtime) -> None:
         # thing that is wrong. The check below is unchanged and still fails if
         # the card genuinely does not survive the navigation -- this only stops
         # a slow render from being read as a missing card.
-        try:
-            page.wait_for_selector(CARD, timeout = SETTLE_MS)
-        except Exception:
-            pass
-        check(f"card survives {route}", page.locator(CARD).count() > 0)
+        waited = await_selector(page, CARD, SETTLE_MS)
+        present = page.locator(CARD).count() > 0
+        # `count` is attached nodes and the wait above is visible ones, so this pair can disagree. It is not a
+        # failure -- the card is there -- but a card that is present and never became visible is a position or
+        # stacking bug wearing a pass, and it would otherwise leave no trace at all.
+        if waited and present:
+            info(f"NOTE card survives {route}: attached but not visible in {SETTLE_MS}ms ({waited})")
+        check(f"card survives {route}", present, "" if present else why_no_card(page, state, waited))
 
     # ── Hardware shapes a CUDA runner never produces ────────────────────
     matrix = [
@@ -567,11 +640,19 @@ def run(page, state: Runtime) -> None:
     page.wait_for_selector(CARD, timeout = 30_000)
     page.locator('[aria-label="Collapse loaded models"]').first.click()
     page.wait_for_timeout(1500)
-    pill = 'button[aria-label*="Show details"]'
-    check("collapses to a pill", page.locator(pill).count() > 0)
+    check("collapses to a pill", page.locator(PILL).count() > 0)
+    console_errors.clear()
     page.reload(wait_until = "domcontentloaded")
-    page.wait_for_timeout(SETTLE_MS // 2)
-    check("the collapsed state survives a reload", page.locator(pill).count() > 0)
+    # The last hard-navigation-plus-fixed-budget left in this file, and the same shape the /hub loop above was fixed
+    # for: a reload has to re-parse the bundle and re-read the stored preference before the pill can exist, so wait
+    # for the pill rather than for 6000ms of clock. Still fails if the collapse genuinely did not survive.
+    waited = await_selector(page, PILL, SETTLE_MS)
+    restored = page.locator(PILL).count() > 0
+    check(
+        "the collapsed state survives a reload",
+        restored,
+        "" if restored else why_no_card(page, state, waited),
+    )
 
     # ── Closed, then a load nobody announced ────────────────────────────
     # "Back on the next model load" is what the close tooltip promises, and a
@@ -624,9 +705,9 @@ def run(page, state: Runtime) -> None:
     page.wait_for_timeout(SETTLE_MS // 2)
     page.locator('[aria-label="Collapse loaded models"]').first.click()
     page.wait_for_timeout(SETTLE_MS // 2)
-    collapsed_ok = page.locator(CARD).count() == 0 and page.locator(pill).count() > 0
+    collapsed_ok = page.locator(CARD).count() == 0 and page.locator(PILL).count() > 0
     check("the grip drag still collapses to a pill", collapsed_ok)
-    page.locator(pill).first.click()
+    page.locator(PILL).first.click()
     page.wait_for_timeout(SETTLE_MS // 2)
     check(
         "one click reopens the pill after dragging by the grip",

--- a/tests/studio/playwright_loaded_models_indicator.py
+++ b/tests/studio/playwright_loaded_models_indicator.py
@@ -241,7 +241,11 @@ def card_text(page) -> str:
         return ""
 
 
-def why_no_card(page, state: Runtime, waited: str = "") -> str:
+def why_no_card(
+    page,
+    state: Runtime,
+    waited: str = "",
+) -> str:
     """What the page actually looked like when a presence check went the wrong way.
 
     "FAILED: card survives /hub" reports only that the assertion failed, which is the one thing already known. These
@@ -450,8 +454,12 @@ def run(page, state: Runtime) -> None:
         # failure -- the card is there -- but a card that is present and never became visible is a position or
         # stacking bug wearing a pass, and it would otherwise leave no trace at all.
         if waited and present:
-            info(f"NOTE card survives {route}: attached but not visible in {SETTLE_MS}ms ({waited})")
-        check(f"card survives {route}", present, "" if present else why_no_card(page, state, waited))
+            info(
+                f"NOTE card survives {route}: attached but not visible in {SETTLE_MS}ms ({waited})"
+            )
+        check(
+            f"card survives {route}", present, "" if present else why_no_card(page, state, waited)
+        )
 
     # ── Hardware shapes a CUDA runner never produces ────────────────────
     matrix = [


### PR DESCRIPTION
Follow-up to #10420, which fixed the `/hub`, `/train`, `/images` loop. Two things it left behind.

## What the flake actually was

Measured across every `Loaded-models indicator (WebKit)` step execution from 2026-08-25 to 2026-09-07: **1 failure in 1,831 (0.055%)**. The single occurrence is run 34070594239 **attempt 1** (job 101587088024, PR #10409, head `83a5db2cf`), which printed `35/38` with all three routes failing together. Attempt 2 hid it from `gh run list`, which made it look more frequent than it was. `git merge-base --is-ancestor fb9bb4ea0 83a5db2cf` is false, and the step ran 04:08-04:26Z, about 2.4 hours before #10420 landed.

Worth recording since it shaped the method: **job logs in this repo are retained about 24-26 hours** and return `410 Gone` above that, so the full-window figure comes from step exit statuses (valid because `run-studio-indicator-browser.sh` is `set -euo pipefail` ending on the driver, with no `continue-on-error`), and the log-level check covers only the ~28h that survives. That retention is also the argument for the second half of this PR.

## The same shape is still here once

`tests/studio/playwright_loaded_models_indicator.py:572-574` on main:

```python
page.reload(wait_until = "domcontentloaded")
page.wait_for_timeout(SETTLE_MS // 2)
check("the collapsed state survives a reload", page.locator(pill).count() > 0)
```

Hard navigation, fixed budget, positive presence assertion, nothing in between. A reload has to re-parse the bundle and re-read `unsloth_loaded_models_collapsed` before the pill can exist, exactly as `/hub` has to before the card can. It has never failed, but only because 6000ms is double the budget that did. It waits for the pill now, and still fails if the collapse genuinely did not survive.

A detector for that specific shape (nav -> fixed sleep -> positive presence assert, with no intervening `wait_for_selector` / `expect` / `wait_for_load_state`) over all 31 `playwright_*.py` found exactly one other hit, `playwright_chat_ui.py:1854`, which is a conditional branch rather than an assertion and cannot fail a suite. The heaviest users of `wait_for_timeout` -- `playwright_chat_ui.py` (40), `playwright_find_in_page.py` (40), `playwright_nonmodal_menus.py` (38) -- carry no instance. That is a targeted scan, not a full audit.

## A failure should explain itself

The whole output of the one real occurrence was:

```
[indicator] 35/38 checks passed
[indicator]   FAILED: card survives /hub
[indicator]   FAILED: card survives /train
[indicator]   FAILED: card survives /images
```

which is the one thing already known. `check()` already takes a `detail`; the presence checks now pass one:

```
wait=TimeoutError: Timeout 12000ms exceeded. pathname='/hub' card_nodes=0 collapsed_pill=0
root_children=0 auth_token=True show_pref='true' status_reads=7
console=['error: Failed to fetch dynamically imported module hub-abc.js']
```

Each probe separates a different cause: `pathname` a redirect or a route that never resolved, `root_children` an SPA that never mounted, `auth_token` a slip the `/login` guard in `boot` cannot catch on a mid-suite navigation, `show_pref` a preference that was not seeded, `status_reads` a poll that never fired, `console` a bundle that threw. Console messages are recorded rather than printed, cleared per navigation, capped at 200 chars each and the last 4 shown, so a passing run stays exactly as quiet as it is now.

## On swallowing the wait

The exception still must not propagate: the caller's presence assertion is what decides pass or fail, and raising would turn a product verdict into a traceback that loses the remaining checks. But `except Exception: pass` swallowed it *anonymously*, merging two unrelated outcomes. A `TimeoutError` is a real verdict about the card. A closed target or navigation error means the run died for a reason with nothing to do with the card, and was reported identically as `FAILED: card survives /hub`. `await_selector` returns the class and first line so the detail can say which.

It also surfaces a third outcome the old pairing hid entirely: `wait_for_selector` waits for **visible**, `count()` counts **attached**, so a card that attaches and never becomes visible times out *and* passes. Latent today, since `loaded-models-indicator.tsx:246` returns `null` rather than rendering hidden, so this logs a `NOTE` and changes no verdict.

## One budget deliberately left alone

`:591` and `:605` wait 11,000ms for a card to appear or reopen via the 5s poll. Genuinely poll-bound, so a fixed wait is defensible, and `:591` asserts *absence*, which a selector wait cannot express. 11s is only ~2.2 ticks, so it is the next candidate if anything there ever flakes; not changed here because nothing has.

## Validation

Not exercised end to end. This box is Linux, so a `playwright install webkit` gives WebKitGTK rather than the macOS WebKit the job drives, and the driver also needs a built frontend and a running studio. What did run:

- `python -m py_compile` on the driver
- `pytest tests/studio/test_playwright_suites_run_in_ci.py tests/studio/test_indicator_browsers_run_in_parallel.py` -> 23 passed
- `pytest tests/test_enforce_kwargs_spacing.py` -> 62 passed
- no line over the repo's 119 limit
- a stub-page unit test of `why_no_card` / `await_selector` covering the timeout, dead-browser, `/login` redirect and collapsed-pill cases

The Mac job on this PR is the real check.