### PR TITLE
Studio: keep Ollama Modelfile SYSTEM when dating the prompt

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3246,8 +3246,10 @@ import io
 import base64
 
 from utils.current_date_prompt_settings import (
+    attach_date_line_to_first_user_message,
     contains_current_date_prompt_line,
     current_date_prompt_line,
+    date_prompt_preserves_server_system,
     replace_current_date_prompt_lines,
 )
 
@@ -5089,11 +5091,14 @@ def _prepend_current_date_to_messages(
     request: Any = None,
     *,
     include_api_key: bool = False,
+    preserve_server_system: bool = False,
 ) -> list[dict]:
     """Apply the date to an already-built message list for a provider Studio proxies to.
 
     The local path prefixes ``system_prompt`` before the messages exist; an external payload is
-    assembled first, so the date goes onto its leading system turn instead.
+    assembled first, so the date goes onto its leading system turn instead. Ollama treats a
+    request system turn as a replacement for the model SYSTEM, so ``preserve_server_system``
+    puts the date on the first user turn when Studio did not send one.
     """
     if request is not None and not _wants_current_date(request):
         if not include_api_key or _request_is_internal_workflow(request):
@@ -5133,6 +5138,8 @@ def _prepend_current_date_to_messages(
                 return copied
             msg["content"] = [{"type": "text", "text": date_line}, *copied_parts]
             return copied
+    if preserve_server_system:
+        return attach_date_line_to_first_user_message(copied, date_line)
     return [{"role": "system", "content": date_line}, *copied]
 
 
@@ -20306,6 +20313,7 @@ async def _proxy_to_external_provider(
         chat_messages,
         request,
         include_api_key = run_studio_tool_loop,
+        preserve_server_system = date_prompt_preserves_server_system(provider_type),
     )
     if run_studio_tool_loop and payload.bypass_permissions:
         # Full access disables the sandbox at execution time, so the schemas must

--- a/studio/backend/utils/current_date_prompt_settings.py
+++ b/studio/backend/utils/current_date_prompt_settings.py
@@ -106,3 +106,41 @@ def current_date_prompt_line(today: date | None = None, request: Any = None) -> 
         return ""
     resolved_date = today or _request_local_date(request)
     return f"{CURRENT_DATE_PROMPT_PREFIX}{resolved_date.isoformat()}."
+
+
+def date_prompt_preserves_server_system(provider_type: str | None) -> bool:
+    """Ollama replaces a model's SYSTEM with any request-level system turn (#10436)."""
+    return provider_type == "ollama"
+
+
+def attach_date_line_to_first_user_message(
+    messages: list[dict],
+    date_line: str,
+) -> list[dict]:
+    """Put ``date_line`` on the first user turn instead of inventing a system turn."""
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            msg["content"] = (
+                date_line + "\n\n" + content.lstrip() if content.strip() else date_line
+            )
+            return messages
+        if isinstance(content, list):
+            copied_parts = [
+                dict(part) if isinstance(part, dict) else part for part in content
+            ]
+            for part in copied_parts:
+                if not isinstance(part, dict) or not isinstance(part.get("text"), str):
+                    continue
+                part["text"] = (
+                    date_line + "\n\n" + part["text"].lstrip()
+                    if part["text"].strip()
+                    else date_line
+                )
+                msg["content"] = copied_parts
+                return messages
+            msg["content"] = [{"type": "text", "text": date_line}, *copied_parts]
+            return messages
+    return messages

--- a/studio/backend/utils/current_date_prompt_settings.py
+++ b/studio/backend/utils/current_date_prompt_settings.py
@@ -113,24 +113,17 @@ def date_prompt_preserves_server_system(provider_type: str | None) -> bool:
     return provider_type == "ollama"
 
 
-def attach_date_line_to_first_user_message(
-    messages: list[dict],
-    date_line: str,
-) -> list[dict]:
+def attach_date_line_to_first_user_message(messages: list[dict], date_line: str) -> list[dict]:
     """Put ``date_line`` on the first user turn instead of inventing a system turn."""
     for msg in messages:
         if msg.get("role") != "user":
             continue
         content = msg.get("content", "")
         if isinstance(content, str):
-            msg["content"] = (
-                date_line + "\n\n" + content.lstrip() if content.strip() else date_line
-            )
+            msg["content"] = date_line + "\n\n" + content.lstrip() if content.strip() else date_line
             return messages
         if isinstance(content, list):
-            copied_parts = [
-                dict(part) if isinstance(part, dict) else part for part in content
-            ]
+            copied_parts = [dict(part) if isinstance(part, dict) else part for part in content]
             for part in copied_parts:
                 if not isinstance(part, dict) or not isinstance(part.get("text"), str):
                     continue

--- a/tests/studio/test_ollama_date_prompt_keeps_modelfile.py
+++ b/tests/studio/test_ollama_date_prompt_keeps_modelfile.py
@@ -1,84 +1,118 @@
-# SPDX-License-Identifier: AGPL-3.0-only
-# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
-
 """A date-only system turn replaces Ollama's Modelfile SYSTEM (#10436).
 
 ``_prepend_current_date_to_messages`` used to invent ``{role: system, content: date}``
 when the payload had no system turn. The chat adapter only unshifts a system turn when
-``combinedSystemPrompt`` is non-empty, so Settings -> Chat -> Tell the model today's date
-was enough to wipe the model SYSTEM on Ollama's /v1 path. The date goes on the first user
-turn instead for ``provider_type == "ollama"``.
+``combinedSystemPrompt`` is non-empty, so the date setting was enough to put one on the
+wire. For ``preserve_server_system=True`` the date goes on the first user turn instead.
+
+inference.py cannot be imported here (no fastapi in this venv), so the two functions are
+ast-extracted and exec'd against ``utils.current_date_prompt_settings``.
 """
 
 from __future__ import annotations
 
+import ast
+import inspect
 import sys
 from pathlib import Path
+from typing import Any
 
 
 REPO = Path(__file__).resolve().parents[2]
 BACKEND = REPO / "studio" / "backend"
-INFERENCE = REPO / "studio" / "backend" / "routes" / "inference.py"
+INFERENCE = BACKEND / "routes" / "inference.py"
+SETTINGS = BACKEND / "utils" / "current_date_prompt_settings.py"
 DATE_LINE = "The current date is 2026-08-15."
 
 if str(BACKEND) not in sys.path:
     sys.path.insert(0, str(BACKEND))
 
 
-def _inference_src() -> str:
-    return INFERENCE.read_text(encoding = "utf-8")
+def _extract_func(source: str, tree: ast.AST, name: str) -> str:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            segment = ast.get_source_segment(source, node)
+            assert segment is not None
+            return segment
+    raise AssertionError(f"{name} not found")
 
 
-def _date_settings():
+def _load_prepend(date_line: str = DATE_LINE):
     from utils import current_date_prompt_settings as settings
 
-    return settings
+    inference_src = INFERENCE.read_text(encoding = "utf-8")
+    inference_tree = ast.parse(inference_src)
+    settings_src = SETTINGS.read_text(encoding = "utf-8")
+    settings_tree = ast.parse(settings_src)
+    namespace = {
+        "Any": Any,
+        "current_date_prompt_line": lambda **_kwargs: date_line,
+        "contains_current_date_prompt_line": settings.contains_current_date_prompt_line,
+        "replace_current_date_prompt_lines": settings.replace_current_date_prompt_lines,
+        "attach_date_line_to_first_user_message": lambda messages, _date_line: messages,
+    }
+    try:
+        exec(
+            compile(
+                _extract_func(
+                    settings_src, settings_tree, "attach_date_line_to_first_user_message"
+                ),
+                "attach_date_line_to_first_user_message",
+                "exec",
+            ),
+            namespace,
+        )
+    except AssertionError:
+        pass
+    for name in ("_refresh_stated_date", "_prepend_current_date_to_messages"):
+        exec(
+            compile(_extract_func(inference_src, inference_tree, name), name, "exec"),
+            namespace,
+        )
+    return namespace["_prepend_current_date_to_messages"]
 
 
-def test_only_ollama_preserves_the_server_system():
-    date_prompt_preserves_server_system = getattr(
-        _date_settings(), "date_prompt_preserves_server_system", None
+def _prepend_preserving(messages):
+    prepend = _load_prepend()
+    assert "preserve_server_system" in inspect.signature(prepend).parameters
+    return prepend(messages, preserve_server_system = True)
+
+
+def test_ollama_without_a_system_turn_puts_the_date_on_the_user():
+    messages = [{"role": "user", "content": "hi"}]
+    out = _prepend_preserving(messages)
+    assert [msg["role"] for msg in out] == ["user"]
+    assert out[0]["content"] == f"{DATE_LINE}\n\nhi"
+    assert messages == [{"role": "user", "content": "hi"}]
+
+
+def test_ollama_still_prefixes_a_user_supplied_system_turn():
+    out = _prepend_preserving(
+        [{"role": "system", "content": "Be terse."}, {"role": "user", "content": "hi"}],
     )
-    assert date_prompt_preserves_server_system is not None
-    assert date_prompt_preserves_server_system("ollama") is True
-    for provider in (
-        "openai",
-        "anthropic",
-        "vllm",
-        "llama_cpp",
-        "custom",
-        "openai_codex",
-        None,
-        "",
-    ):
-        assert date_prompt_preserves_server_system(provider) is False
+    assert out[0]["content"] == f"{DATE_LINE}\n\nBe terse."
+    assert out[1] == {"role": "user", "content": "hi"}
 
 
-def _attach():
-    fn = getattr(_date_settings(), "attach_date_line_to_first_user_message", None)
-    assert fn is not None
-    return fn
+def test_other_providers_still_invent_a_system_turn():
+    prepend = _load_prepend()
+    out = prepend([{"role": "user", "content": "hi"}])
+    assert out[0] == {"role": "system", "content": DATE_LINE}
+    assert out[1] == {"role": "user", "content": "hi"}
 
 
-def test_date_lands_on_the_user_turn_without_a_system_role():
-    payload = [{"role": "assistant", "content": "ready"}, {"role": "user", "content": "hi"}]
-    out = _attach()(payload, DATE_LINE)
-    assert [msg["role"] for msg in out] == ["assistant", "user"]
-    assert out[0]["content"] == "ready"
-    assert out[1]["content"] == f"{DATE_LINE}\n\nhi"
-
-
-def test_structured_user_text_is_prefixed_the_same_way():
-    payload = [
-        {
-            "role": "user",
-            "content": [
-                {"type": "image_url", "image_url": {"url": "data:image/png,x"}},
-                {"type": "text", "text": "what is this"},
-            ],
-        }
-    ]
-    out = _attach()(payload, DATE_LINE)
+def test_ollama_prefixes_structured_user_text():
+    out = _prepend_preserving(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png,x"}},
+                    {"type": "text", "text": "what is this"},
+                ],
+            }
+        ],
+    )
     assert out[0]["role"] == "user"
     assert out[0]["content"][0] == {
         "type": "image_url",
@@ -87,38 +121,6 @@ def test_structured_user_text_is_prefixed_the_same_way():
     assert out[0]["content"][1]["text"] == f"{DATE_LINE}\n\nwhat is this"
 
 
-def test_a_user_turn_with_no_text_part_gets_one():
-    payload = [
-        {
-            "role": "user",
-            "content": [{"type": "image_url", "image_url": {"url": "data:image/png,x"}}],
-        }
-    ]
-    out = _attach()(payload, DATE_LINE)
-    assert out[0]["content"][0] == {"type": "text", "text": DATE_LINE}
-    assert out[0]["content"][1]["type"] == "image_url"
-
-
-def test_no_user_turn_does_not_invent_a_system_turn():
-    payload = [{"role": "assistant", "content": "ready"}]
-    out = _attach()(payload, DATE_LINE)
+def test_ollama_without_a_user_turn_does_not_invent_a_system_turn():
+    out = _prepend_preserving([{"role": "assistant", "content": "ready"}])
     assert out == [{"role": "assistant", "content": "ready"}]
-
-
-def test_external_proxy_passes_the_ollama_preserve_flag():
-    src = _inference_src()
-    marker = "run_studio_tool_loop = bool(external_studio_tools)"
-    window = src[src.index(marker) : src.index(marker) + 600]
-    assert (
-        "preserve_server_system = date_prompt_preserves_server_system(provider_type)"
-        in window
-    )
-
-
-def test_prepend_fallback_attaches_to_the_user_when_preserving():
-    src = _inference_src()
-    fallback = src[src.index("def _prepend_current_date_to_messages(") :]
-    fallback = fallback[: fallback.index("\n\n# Strip leaked tool-call markup")]
-    assert "if preserve_server_system:" in fallback
-    assert "attach_date_line_to_first_user_message(copied, date_line)" in fallback
-    assert 'return [{"role": "system", "content": date_line}, *copied]' in fallback

--- a/tests/studio/test_ollama_date_prompt_keeps_modelfile.py
+++ b/tests/studio/test_ollama_date_prompt_keeps_modelfile.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A date-only system turn replaces Ollama's Modelfile SYSTEM (#10436).
+
+``_prepend_current_date_to_messages`` used to invent ``{role: system, content: date}``
+when the payload had no system turn. The chat adapter only unshifts a system turn when
+``combinedSystemPrompt`` is non-empty, so Settings -> Chat -> Tell the model today's date
+was enough to wipe the model SYSTEM on Ollama's /v1 path. The date goes on the first user
+turn instead for ``provider_type == "ollama"``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+BACKEND = REPO / "studio" / "backend"
+INFERENCE = REPO / "studio" / "backend" / "routes" / "inference.py"
+DATE_LINE = "The current date is 2026-08-15."
+
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+
+def _inference_src() -> str:
+    return INFERENCE.read_text(encoding = "utf-8")
+
+
+def _date_settings():
+    from utils import current_date_prompt_settings as settings
+
+    return settings
+
+
+def test_only_ollama_preserves_the_server_system():
+    date_prompt_preserves_server_system = getattr(
+        _date_settings(), "date_prompt_preserves_server_system", None
+    )
+    assert date_prompt_preserves_server_system is not None
+    assert date_prompt_preserves_server_system("ollama") is True
+    for provider in (
+        "openai",
+        "anthropic",
+        "vllm",
+        "llama_cpp",
+        "custom",
+        "openai_codex",
+        None,
+        "",
+    ):
+        assert date_prompt_preserves_server_system(provider) is False
+
+
+def _attach():
+    fn = getattr(_date_settings(), "attach_date_line_to_first_user_message", None)
+    assert fn is not None
+    return fn
+
+
+def test_date_lands_on_the_user_turn_without_a_system_role():
+    payload = [{"role": "assistant", "content": "ready"}, {"role": "user", "content": "hi"}]
+    out = _attach()(payload, DATE_LINE)
+    assert [msg["role"] for msg in out] == ["assistant", "user"]
+    assert out[0]["content"] == "ready"
+    assert out[1]["content"] == f"{DATE_LINE}\n\nhi"
+
+
+def test_structured_user_text_is_prefixed_the_same_way():
+    payload = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png,x"}},
+                {"type": "text", "text": "what is this"},
+            ],
+        }
+    ]
+    out = _attach()(payload, DATE_LINE)
+    assert out[0]["role"] == "user"
+    assert out[0]["content"][0] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png,x"},
+    }
+    assert out[0]["content"][1]["text"] == f"{DATE_LINE}\n\nwhat is this"
+
+
+def test_a_user_turn_with_no_text_part_gets_one():
+    payload = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": "data:image/png,x"}}],
+        }
+    ]
+    out = _attach()(payload, DATE_LINE)
+    assert out[0]["content"][0] == {"type": "text", "text": DATE_LINE}
+    assert out[0]["content"][1]["type"] == "image_url"
+
+
+def test_no_user_turn_does_not_invent_a_system_turn():
+    payload = [{"role": "assistant", "content": "ready"}]
+    out = _attach()(payload, DATE_LINE)
+    assert out == [{"role": "assistant", "content": "ready"}]
+
+
+def test_external_proxy_passes_the_ollama_preserve_flag():
+    src = _inference_src()
+    marker = "run_studio_tool_loop = bool(external_studio_tools)"
+    window = src[src.index(marker) : src.index(marker) + 600]
+    assert (
+        "preserve_server_system = date_prompt_preserves_server_system(provider_type)"
+        in window
+    )
+
+
+def test_prepend_fallback_attaches_to_the_user_when_preserving():
+    src = _inference_src()
+    fallback = src[src.index("def _prepend_current_date_to_messages(") :]
+    fallback = fallback[: fallback.index("\n\n# Strip leaked tool-call markup")]
+    assert "if preserve_server_system:" in fallback
+    assert "attach_date_line_to_first_user_message(copied, date_line)" in fallback
+    assert 'return [{"role": "system", "content": date_line}, *copied]' in fallback


### PR DESCRIPTION
Empty Unsloth system prompt plus Settings -> Chat -> Tell the model today's date made `_prepend_current_date_to_messages` invent a date-only system turn, which is what made Ollama /v1 drop the Modelfile SYSTEM (https://github.com/unslothai/unsloth/issues/10436). chat-adapter.ts only unshifts a system turn when `combinedSystemPrompt` is non-empty, so the date setting was the only thing putting one on the wire.

For `provider_type == "ollama"` the date now goes on the first user message when there is no system turn to prefix. Other providers still get the created system turn, and a user-supplied system prompt is still prefixed. A `custom` OpenAI-compatible URL pointed at Ollama is out of scope.

`.venv/bin/python -m pytest -q tests/studio/test_ollama_date_prompt_keeps_modelfile.py` -> 5 passed. The tests ast-extract `_prepend_current_date_to_messages` and call it with `preserve_server_system=True`. Reverting `studio/backend/routes/inference.py` and `studio/backend/utils/current_date_prompt_settings.py` to 2e6db0c12 -> 4 failed. ruff check on those two files plus the test passed.