### PR TITLE
Studio: keep queued prompts when generation is stopped

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -3072,9 +3072,13 @@ export function AppSidebar() {
       item.type === "compare"
         ? (item.threadIds ?? []).some((id) => Boolean(runningByThreadId[id]))
         : Boolean(runningByThreadId[item.id]);
-    const hasQueuedActivity = threadIds.some((threadId) =>
-      Boolean(queueByThreadId[threadId]),
-    );
+    // A paused queue is not activity. The entry survives a Stop now that the composer
+    // pauses instead of deleting the run, so without this the row keeps spinning for
+    // work the user explicitly stopped, with nothing left to ever clear it.
+    const hasQueuedActivity = threadIds.some((threadId) => {
+      const entry = queueByThreadId[threadId];
+      return Boolean(entry) && !entry.paused;
+    });
     // Active generation and queued work share the in-row spinner slot so they cannot drift.
     const showQueuedActivity = hasQueuedActivity && !isGenerating;
     const showWorkSpinner = isGenerating || showQueuedActivity;

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -3072,9 +3072,7 @@ export function AppSidebar() {
       item.type === "compare"
         ? (item.threadIds ?? []).some((id) => Boolean(runningByThreadId[id]))
         : Boolean(runningByThreadId[item.id]);
-    // A paused queue is not activity. The entry survives a Stop now that the composer
-    // pauses instead of deleting the run, so without this the row keeps spinning for
-    // work the user explicitly stopped, with nothing left to ever clear it.
+    // A paused queue is not activity: its entry outlives Stop, so the row would spin on.
     const hasQueuedActivity = threadIds.some((threadId) => {
       const entry = queueByThreadId[threadId];
       return Boolean(entry) && !entry.paused;

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1354,8 +1354,7 @@ function resumePromptQueueRun(threadIds?: string[]) {
       continue;
     }
     run.paused = false;
-    // prevStoreRunning is recorded before the paused early-return, so a stale rising
-    // edge would let the next idle edge skip a prompt. The other two are defensive.
+    // prevStoreRunning outlives the paused early-return; a stale edge skips a prompt.
     run.waitingForTargetIdle = false;
     run.prevStoreRunning = false;
     clearPromptQueueRetryTimer(run);

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -703,10 +703,23 @@ function pumpPromptQueues() {
       deletePromptQueueRun(run);
       continue;
     }
+    const dispatchGeneration = run.generation;
     promptQueueDispatchingRunIds.add(run.id);
     dispatchQueuedPrompt(run, item, run.generation)
       .catch(() => undefined)
       .finally(() => {
+        // The dispatching flag is keyed on the run, not on the attempt, so a
+        // dispatch that a pause superseded would release the flag a LIVE dispatch
+        // is holding. Pausing bumps the generation and clears the flag, so after
+        // Stop then Resume the old attempt's probe can settle while the new one is
+        // still in flight: it frees the flag, re-pumps, and the same prompt is
+        // appended twice. Only the attempt that still owns the generation releases.
+        if (
+          promptQueueRuns.get(run.id) === run &&
+          dispatchGeneration !== run.generation
+        ) {
+          return;
+        }
         promptQueueDispatchingRunIds.delete(run.id);
         syncPromptQueueUI();
         if (!promptQueueActiveRunIds.has(run.id)) {
@@ -1302,7 +1315,16 @@ function pausePromptQueueRun(threadIds?: string[]) {
       deletePromptQueueRun(run);
     } else {
       run.items = plan.retainedItemIndexes.map((index) => run.items[index]);
-      const nextIndex = run.items.findIndex((item) => !item.dispatched);
+      // Scan from where the run actually was, not from the head of the list. A
+      // findIndex from 0 rewinds onto any undispatched item the run has already
+      // moved past, so Resume would send it AFTER prompts that already went out.
+      const resumeFrom = plan.retainedItemIndexes.findIndex(
+        (index) => index >= Math.max(run.index, 0),
+      );
+      const searchFrom = resumeFrom < 0 ? 0 : resumeFrom;
+      const nextIndex = run.items.findIndex(
+        (item, index) => index >= searchFrom && !item.dispatched,
+      );
       if (nextIndex < 0) {
         deletePromptQueueRun(run);
       } else {
@@ -1339,6 +1361,18 @@ function resumePromptQueueRun(threadIds?: string[]) {
       continue;
     }
     run.paused = false;
+    // prevStoreRunning is the one that matters. handlePromptQueueRunState writes it
+    // BEFORE its `if (run.paused) return`, so a rising edge seen while paused (the
+    // user stops the queue and then sends an ordinary message in the same chat, or a
+    // shared alias picks up another run) is left behind. Clearing paused without
+    // clearing this lets the following idle edge take the advancePromptQueue branch,
+    // which completes and SKIPS the first retained prompt without ever sending it --
+    // the same silent prompt loss this PR set out to fix, through the new path.
+    // The other two are defensive: pausePromptQueueRun already clears the idle wait,
+    // and an edit-armed retry timer self-clears.
+    run.waitingForTargetIdle = false;
+    run.prevStoreRunning = false;
+    clearPromptQueueRetryTimer(run);
     syncPromptQueueUI();
   }
   requestPromptQueuePumpIfReady();

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -708,12 +708,7 @@ function pumpPromptQueues() {
     dispatchQueuedPrompt(run, item, run.generation)
       .catch(() => undefined)
       .finally(() => {
-        // The dispatching flag is keyed on the run, not on the attempt, so a
-        // dispatch that a pause superseded would release the flag a LIVE dispatch
-        // is holding. Pausing bumps the generation and clears the flag, so after
-        // Stop then Resume the old attempt's probe can settle while the new one is
-        // still in flight: it frees the flag, re-pumps, and the same prompt is
-        // appended twice. Only the attempt that still owns the generation releases.
+        // Releasing a live attempt's flag makes Stop then Resume append twice.
         if (
           promptQueueRuns.get(run.id) === run &&
           dispatchGeneration !== run.generation
@@ -1315,9 +1310,7 @@ function pausePromptQueueRun(threadIds?: string[]) {
       deletePromptQueueRun(run);
     } else {
       run.items = plan.retainedItemIndexes.map((index) => run.items[index]);
-      // Scan from where the run actually was, not from the head of the list. A
-      // findIndex from 0 rewinds onto any undispatched item the run has already
-      // moved past, so Resume would send it AFTER prompts that already went out.
+      // From 0 this rewinds onto an item already passed, replaying it out of order.
       const resumeFrom = plan.retainedItemIndexes.findIndex(
         (index) => index >= Math.max(run.index, 0),
       );
@@ -1361,15 +1354,8 @@ function resumePromptQueueRun(threadIds?: string[]) {
       continue;
     }
     run.paused = false;
-    // prevStoreRunning is the one that matters. handlePromptQueueRunState writes it
-    // BEFORE its `if (run.paused) return`, so a rising edge seen while paused (the
-    // user stops the queue and then sends an ordinary message in the same chat, or a
-    // shared alias picks up another run) is left behind. Clearing paused without
-    // clearing this lets the following idle edge take the advancePromptQueue branch,
-    // which completes and SKIPS the first retained prompt without ever sending it --
-    // the same silent prompt loss this PR set out to fix, through the new path.
-    // The other two are defensive: pausePromptQueueRun already clears the idle wait,
-    // and an edit-armed retry timer self-clears.
+    // prevStoreRunning is recorded before the paused early-return, so a stale rising
+    // edge would let the next idle edge skip a prompt. The other two are defensive.
     run.waitingForTargetIdle = false;
     run.prevStoreRunning = false;
     clearPromptQueueRetryTimer(run);

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1237,7 +1237,6 @@ function startPromptQueue(
     if (existingRun.deepResearchConsumed) {
       target.consumeDeepResearch();
     }
-    existingRun.paused = false;
     existingRun.items.push(
       ...filtered.map((prompt) => createQueuedPrompt(prompt, target)),
     );
@@ -1562,17 +1561,13 @@ interface PromptQueueCallbacks {
     onAborted?: () => void,
   ) => boolean;
   stopQueue: () => void;
-  resumeQueue: () => void;
 }
 const noopStartPromptQueue: PromptQueueCallbacks["startQueue"] = () =>
   false;
 const noopStopPromptQueue: PromptQueueCallbacks["stopQueue"] = () => undefined;
-const noopResumePromptQueue: PromptQueueCallbacks["resumeQueue"] = () =>
-  undefined;
 const PromptQueueContext = createContext<PromptQueueCallbacks>({
   startQueue: noopStartPromptQueue,
   stopQueue: noopStopPromptQueue,
-  resumeQueue: noopResumePromptQueue,
 });
 
 // Gap (px) between last message and floating composer; bottom spacer tracks
@@ -4781,11 +4776,7 @@ const Composer: FC<{
     [aui, startHydratedPromptQueue, threadIsRunning, disableQueue],
   );
 
-  const queueContextValue: PromptQueueCallbacks = {
-    startQueue,
-    stopQueue,
-    resumeQueue,
-  };
+  const queueContextValue: PromptQueueCallbacks = { startQueue, stopQueue };
 
   const composerContent = (
     <>
@@ -6760,7 +6751,7 @@ const ComposerRightControls: FC<{
       </AuiIf>
       {isQueueRunning && !isResearchActive ? (
         <AuiIf condition={({ thread }) => !thread.isRunning}>
-          {queueEntry?.paused ? (
+          {queueEntry?.paused && queueDisabled ? (
             <TooltipIconButton
               tooltip="Resume queue"
               side="bottom"
@@ -6773,7 +6764,7 @@ const ComposerRightControls: FC<{
             >
               <FastForwardIcon className="size-[18px] stroke-2" />
             </TooltipIconButton>
-          ) : queueEntry?.dispatched ? (
+          ) : queueEntry?.dispatched && !queueEntry.paused ? (
             <Button
               type="button"
               variant="default"

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -186,6 +186,7 @@ import {
   notifyPromptQueueRunFailed,
   planLocalPromptQueueStop,
   planUserPromptQueueStop,
+  userStopTargetCancelMode,
   registerQueuedChatRunSettings,
   releasePreStreamRunReservation,
   reservePreStreamRun,
@@ -358,6 +359,7 @@ type PromptQueueTarget = {
   append: (prompt: string) => void | Promise<void>;
   complete: () => void;
   cancel: () => void;
+  cancelActiveRun: () => void;
   isIndexing: () => boolean;
   usesThreadDocuments: boolean;
   usesLocalModel: boolean;
@@ -873,6 +875,9 @@ function getPromptQueueItemStatus(
   index: number,
   activeItemIndex: number,
 ): PromptQueueUIItemStatus {
+  if (run.paused && run.index >= 0 && index === activeItemIndex) {
+    return "paused";
+  }
   if (run.index >= 0 && index === activeItemIndex) {
     return run.waitingForTargetIdle ? "waiting" : "next";
   }
@@ -936,6 +941,7 @@ function syncPromptQueueUI() {
       local: promptQueueRunUsesLocalModel(run),
       temporary: promptQueueRunIsTemporary(run),
       dispatched: Boolean(getActivePromptQueueItem(run)?.dispatched),
+      paused: run.paused,
     };
     for (const id of ids) {
       byThreadId[id] = entry;
@@ -1222,16 +1228,11 @@ function startPromptQueue(
   waitForCurrentRun = false,
 ) {
   const filtered = items.map((item) => item.trim()).filter(Boolean);
-  const existingRun = findPromptQueueRunByTarget(target);
   if (filtered.length === 0) {
-    if (existingRun?.paused) {
-      existingRun.paused = false;
-      syncPromptQueueUI();
-      requestPromptQueuePump();
-    }
     return;
   }
 
+  const existingRun = findPromptQueueRunByTarget(target);
   if (existingRun) {
     if (existingRun.deepResearchConsumed) {
       target.consumeDeepResearch();
@@ -1290,13 +1291,14 @@ function getPromptQueueRunsForThreadIds(threadIds?: string[]) {
   return Array.from(runs);
 }
 
-function stopPromptQueueRun(threadIds?: string[]) {
+function pausePromptQueueRun(threadIds?: string[]) {
   for (const run of getPromptQueueRunsForThreadIds(threadIds)) {
     const activeItem = getActivePromptQueueItem(run);
     const plan = planUserPromptQueueStop(
       run.items.map((item) => ({ dispatched: item.dispatched })),
       run.index,
     );
+    const cancelMode = userStopTargetCancelMode(plan);
     if (plan.retainedItemIndexes.length === 0) {
       deletePromptQueueRun(run);
     } else {
@@ -1316,11 +1318,44 @@ function stopPromptQueueRun(threadIds?: string[]) {
         syncPromptQueueUI();
       }
     }
-    if (!plan.cancelActiveItem) {
+    if (cancelMode === "none") {
       continue;
     }
     try {
-      activeItem?.target.cancel();
+      if (cancelMode === "permanent") {
+        activeItem?.target.cancel();
+      } else {
+        activeItem?.target.cancelActiveRun();
+      }
+    } catch {
+      // The active run may have already ended.
+    }
+  }
+  requestPromptQueuePumpIfReady();
+}
+
+function resumePromptQueueRun(threadIds?: string[]) {
+  for (const run of getPromptQueueRunsForThreadIds(threadIds)) {
+    if (!run.paused) {
+      continue;
+    }
+    run.paused = false;
+    syncPromptQueueUI();
+  }
+  requestPromptQueuePumpIfReady();
+}
+
+function stopPromptQueueRun(threadIds?: string[]) {
+  for (const run of getPromptQueueRunsForThreadIds(threadIds)) {
+    const activeItem = getActivePromptQueueItem(run);
+    const activeTarget = activeItem?.target;
+    const shouldCancelActiveRun = Boolean(activeItem?.dispatched);
+    deletePromptQueueRun(run);
+    if (!shouldCancelActiveRun) {
+      continue;
+    }
+    try {
+      activeTarget?.cancel();
     } catch {
       // The active run may have already ended.
     }
@@ -1527,13 +1562,17 @@ interface PromptQueueCallbacks {
     onAborted?: () => void,
   ) => boolean;
   stopQueue: () => void;
+  resumeQueue: () => void;
 }
 const noopStartPromptQueue: PromptQueueCallbacks["startQueue"] = () =>
   false;
 const noopStopPromptQueue: PromptQueueCallbacks["stopQueue"] = () => undefined;
+const noopResumePromptQueue: PromptQueueCallbacks["resumeQueue"] = () =>
+  undefined;
 const PromptQueueContext = createContext<PromptQueueCallbacks>({
   startQueue: noopStartPromptQueue,
   stopQueue: noopStopPromptQueue,
+  resumeQueue: noopResumePromptQueue,
 });
 
 // Gap (px) between last message and floating composer; bottom spacer tracks
@@ -3551,6 +3590,7 @@ const Composer: FC<{
     };
     const pendingSettingsIds = new Set<number>();
     let cancelled = false;
+    let appendEpoch = 0;
     let shouldCorrectPersistedModel: boolean | null = null;
     let initializedFreshThreadId: string | null = null;
     let freshThreadAppendAccepted = false;
@@ -3599,6 +3639,7 @@ const Composer: FC<{
         hasPreStreamRunReservation(getQueueThreadIds()) ||
         Boolean(getThreadRuntime()?.getState().isRunning),
       append: async (prompt) => {
+        const epoch = appendEpoch;
         const thread = getThreadRuntime();
         if (!thread) {
           throw new Error("Prompt queue thread runtime is unavailable");
@@ -3652,6 +3693,7 @@ const Composer: FC<{
           if (
             removeFreshThreadPersistedAfterAbort() ||
             cancelled ||
+            epoch !== appendEpoch ||
             !pendingSettingsIds.has(settingsId)
           ) {
             return;
@@ -3672,6 +3714,7 @@ const Composer: FC<{
             if (
               removeFreshThreadPersistedAfterAbort() ||
               cancelled ||
+              epoch !== appendEpoch ||
               !pendingSettingsIds.has(settingsId)
             ) {
               return;
@@ -3711,6 +3754,11 @@ const Composer: FC<{
           discardQueuedChatRunSettings(settingsId);
         }
         pendingSettingsIds.clear();
+        getThreadRuntime()?.cancelRun();
+      },
+      cancelActiveRun: () => {
+        appendEpoch += 1;
+        discardOldestPendingSettings();
         getThreadRuntime()?.cancelRun();
       },
       isIndexing: () =>
@@ -4706,7 +4754,11 @@ const Composer: FC<{
   );
 
   const stopQueue = useCallback(() => {
-    stopPromptQueueRunForThreadIds(promptQueueThreadIds);
+    pausePromptQueueRun(promptQueueThreadIds);
+  }, [promptQueueThreadIds]);
+
+  const resumeQueue = useCallback(() => {
+    resumePromptQueueRun(promptQueueThreadIds);
   }, [promptQueueThreadIds]);
 
   const startQueue = useCallback(
@@ -4729,7 +4781,11 @@ const Composer: FC<{
     [aui, startHydratedPromptQueue, threadIsRunning, disableQueue],
   );
 
-  const queueContextValue: PromptQueueCallbacks = { startQueue, stopQueue };
+  const queueContextValue: PromptQueueCallbacks = {
+    startQueue,
+    stopQueue,
+    resumeQueue,
+  };
 
   const composerContent = (
     <>
@@ -4867,6 +4923,7 @@ const Composer: FC<{
               // submitting the form, so run the complete queue/capacity path.
               onSendClick={handleSubmit}
               onStopClick={stopQueue}
+              onResumeClick={resumeQueue}
               onDictateClick={startDictation}
               pendingSend={pendingSend}
               menuSide={effectiveMenuSide}
@@ -6327,6 +6384,8 @@ function promptQueueStatusLabel(status: PromptQueueUIItemStatus) {
       return "Waiting";
     case "next":
       return "Next";
+    case "paused":
+      return "Paused";
     case "queued":
       return "Queued";
     default: {
@@ -6574,6 +6633,7 @@ const ComposerRightControls: FC<{
   onQueueClick?: () => void;
   onSendClick?: (event: { preventDefault: () => void }) => void;
   onStopClick?: () => void;
+  onResumeClick?: () => void;
   onDictateClick?: () => void;
   pendingSend?: boolean;
   menuSide?: "top" | "bottom";
@@ -6584,6 +6644,7 @@ const ComposerRightControls: FC<{
   onQueueClick,
   onSendClick,
   onStopClick,
+  onResumeClick,
   onDictateClick,
   pendingSend,
   menuSide,
@@ -6699,7 +6760,20 @@ const ComposerRightControls: FC<{
       </AuiIf>
       {isQueueRunning && !isResearchActive ? (
         <AuiIf condition={({ thread }) => !thread.isRunning}>
-          {queueEntry?.dispatched ? (
+          {queueEntry?.paused ? (
+            <TooltipIconButton
+              tooltip="Resume queue"
+              side="bottom"
+              type="button"
+              variant="default"
+              size="icon"
+              onClick={onResumeClick}
+              className="aui-composer-send ml-1.5 size-9 rounded-full"
+              aria-label="Resume queue"
+            >
+              <FastForwardIcon className="size-[18px] stroke-2" />
+            </TooltipIconButton>
+          ) : queueEntry?.dispatched ? (
             <Button
               type="button"
               variant="default"

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -185,6 +185,7 @@ import {
   localPromptQueueModelBoundary,
   notifyPromptQueueRunFailed,
   planLocalPromptQueueStop,
+  planUserPromptQueueStop,
   registerQueuedChatRunSettings,
   releasePreStreamRunReservation,
   reservePreStreamRun,
@@ -382,6 +383,7 @@ type PromptQueueRun = {
   generation: number;
   prevStoreRunning: boolean;
   waitingForTargetIdle: boolean;
+  paused: boolean;
   retryTimer: ReturnType<typeof setTimeout> | null;
   deepResearchConsumed: boolean;
 };
@@ -649,6 +651,7 @@ function isPromptQueueRunReadyToDispatch(run: PromptQueueRun) {
       run.index >= 0 &&
       !item.dispatched &&
       !run.waitingForTargetIdle &&
+      !run.paused &&
       !run.retryTimer &&
       !promptQueueActiveRunIds.has(run.id) &&
       !promptQueueDispatchingRunIds.has(run.id),
@@ -1170,6 +1173,9 @@ function handlePromptQueueRunState(
   if (!wasRunning || isRunning) {
     return;
   }
+  if (run.paused) {
+    return;
+  }
   if (run.waitingForTargetIdle) {
     clearPromptQueueRetryTimer(run);
     run.waitingForTargetIdle = false;
@@ -1216,15 +1222,21 @@ function startPromptQueue(
   waitForCurrentRun = false,
 ) {
   const filtered = items.map((item) => item.trim()).filter(Boolean);
+  const existingRun = findPromptQueueRunByTarget(target);
   if (filtered.length === 0) {
+    if (existingRun?.paused) {
+      existingRun.paused = false;
+      syncPromptQueueUI();
+      requestPromptQueuePump();
+    }
     return;
   }
 
-  const existingRun = findPromptQueueRunByTarget(target);
   if (existingRun) {
     if (existingRun.deepResearchConsumed) {
       target.consumeDeepResearch();
     }
+    existingRun.paused = false;
     existingRun.items.push(
       ...filtered.map((prompt) => createQueuedPrompt(prompt, target)),
     );
@@ -1244,6 +1256,7 @@ function startPromptQueue(
     generation: 0,
     prevStoreRunning: shouldWaitForCurrentRun,
     waitingForTargetIdle: false,
+    paused: false,
     retryTimer: null,
     deepResearchConsumed: false,
   };
@@ -1280,14 +1293,34 @@ function getPromptQueueRunsForThreadIds(threadIds?: string[]) {
 function stopPromptQueueRun(threadIds?: string[]) {
   for (const run of getPromptQueueRunsForThreadIds(threadIds)) {
     const activeItem = getActivePromptQueueItem(run);
-    const activeTarget = activeItem?.target;
-    const shouldCancelActiveRun = Boolean(activeItem?.dispatched);
-    deletePromptQueueRun(run);
-    if (!shouldCancelActiveRun) {
+    const plan = planUserPromptQueueStop(
+      run.items.map((item) => ({ dispatched: item.dispatched })),
+      run.index,
+    );
+    if (plan.retainedItemIndexes.length === 0) {
+      deletePromptQueueRun(run);
+    } else {
+      run.items = plan.retainedItemIndexes.map((index) => run.items[index]);
+      const nextIndex = run.items.findIndex((item) => !item.dispatched);
+      if (nextIndex < 0) {
+        deletePromptQueueRun(run);
+      } else {
+        run.generation += 1;
+        run.index = nextIndex;
+        run.paused = plan.pause;
+        run.waitingForTargetIdle = false;
+        run.prevStoreRunning = false;
+        clearPromptQueueRetryTimer(run);
+        promptQueueActiveRunIds.delete(run.id);
+        promptQueueDispatchingRunIds.delete(run.id);
+        syncPromptQueueUI();
+      }
+    }
+    if (!plan.cancelActiveItem) {
       continue;
     }
     try {
-      activeTarget?.cancel();
+      activeItem?.target.cancel();
     } catch {
       // The active run may have already ended.
     }
@@ -1376,6 +1409,9 @@ function stopLocalPromptQueueRunsForThreadIds(threadIds: string[]) {
 }
 
 function retainPendingPromptQueueItemsAfterFailure(run: PromptQueueRun) {
+  if (run.paused) {
+    return true;
+  }
   const activeIndex = Math.max(run.index, 0);
   const activeItem = run.items[activeIndex];
   if (run.index < 0 || !activeItem?.dispatched) {

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -165,7 +165,10 @@ export {
   shouldAbortPendingQueueForModelBoundary,
   shouldAbortPendingQueueForSettingsChange,
 } from "./utils/prompt-queue-model-boundary";
-export { planUserPromptQueueStop } from "./utils/prompt-queue-user-stop";
+export {
+  planUserPromptQueueStop,
+  userStopTargetCancelMode,
+} from "./utils/prompt-queue-user-stop";
 export { chatHistoryClearBoundary } from "./utils/chat-history-clear-boundary";
 export { rangeBetween, toggleSelected } from "./utils/row-selection";
 export {

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -165,6 +165,7 @@ export {
   shouldAbortPendingQueueForModelBoundary,
   shouldAbortPendingQueueForSettingsChange,
 } from "./utils/prompt-queue-model-boundary";
+export { planUserPromptQueueStop } from "./utils/prompt-queue-user-stop";
 export { chatHistoryClearBoundary } from "./utils/chat-history-clear-boundary";
 export { rangeBetween, toggleSelected } from "./utils/row-selection";
 export {

--- a/studio/frontend/src/features/chat/stores/prompt-queue-ui-store.ts
+++ b/studio/frontend/src/features/chat/stores/prompt-queue-ui-store.ts
@@ -10,13 +10,15 @@ export type PromptQueueUIEntry = {
   local: boolean;
   temporary: boolean;
   dispatched: boolean;
+  paused: boolean;
 };
 
 export type PromptQueueUIItemStatus =
   | "queued"
   | "next"
   | "waiting"
-  | "running";
+  | "running"
+  | "paused";
 
 export type PromptQueueUIItem = {
   id: string;

--- a/studio/frontend/src/features/chat/utils/confirm-stop-running-chats.ts
+++ b/studio/frontend/src/features/chat/utils/confirm-stop-running-chats.ts
@@ -70,7 +70,10 @@ export async function confirmStopRunningChatsIfNeeded(
   const aliasesByQueuedRun = new Map<string, string[]>();
   for (const threadId of promptQueueThreadIds) {
     const entry = promptQueuesByThreadId[threadId];
-    if (!entry) {
+    // A paused queue is not a running chat. Its entry outlives the composer Stop
+    // now that Stop pauses rather than deletes the run, so counting it here would
+    // put a chat the user has already stopped into the "still running" list.
+    if (!entry || entry.paused) {
       continue;
     }
     const aliases = aliasesByQueuedRun.get(entry.runId) ?? [];

--- a/studio/frontend/src/features/chat/utils/confirm-stop-running-chats.ts
+++ b/studio/frontend/src/features/chat/utils/confirm-stop-running-chats.ts
@@ -70,9 +70,7 @@ export async function confirmStopRunningChatsIfNeeded(
   const aliasesByQueuedRun = new Map<string, string[]>();
   for (const threadId of promptQueueThreadIds) {
     const entry = promptQueuesByThreadId[threadId];
-    // A paused queue is not a running chat. Its entry outlives the composer Stop
-    // now that Stop pauses rather than deletes the run, so counting it here would
-    // put a chat the user has already stopped into the "still running" list.
+    // A paused queue is not a running chat: its entry outlives Stop.
     if (!entry || entry.paused) {
       continue;
     }

--- a/studio/frontend/src/features/chat/utils/prompt-queue-user-stop.ts
+++ b/studio/frontend/src/features/chat/utils/prompt-queue-user-stop.ts
@@ -11,7 +11,17 @@ export type UserPromptQueueStopPlan = {
   pause: boolean;
 };
 
-/** Stop generation without discarding prompts that have not been sent yet. */
+export type PromptQueueTargetCancelMode = "none" | "activeRun" | "permanent";
+
+export function userStopTargetCancelMode(
+  plan: UserPromptQueueStopPlan,
+): PromptQueueTargetCancelMode {
+  if (!plan.cancelActiveItem) {
+    return "none";
+  }
+  return plan.pause ? "activeRun" : "permanent";
+}
+
 export function planUserPromptQueueStop(
   items: readonly PromptQueueUserStopItem[],
   runIndex: number,

--- a/studio/frontend/src/features/chat/utils/prompt-queue-user-stop.ts
+++ b/studio/frontend/src/features/chat/utils/prompt-queue-user-stop.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export type PromptQueueUserStopItem = {
+  dispatched: boolean;
+};
+
+export type UserPromptQueueStopPlan = {
+  cancelActiveItem: boolean;
+  retainedItemIndexes: number[];
+  pause: boolean;
+};
+
+/** Stop generation without discarding prompts that have not been sent yet. */
+export function planUserPromptQueueStop(
+  items: readonly PromptQueueUserStopItem[],
+  runIndex: number,
+): UserPromptQueueStopPlan {
+  if (runIndex < 0) {
+    return {
+      cancelActiveItem: false,
+      retainedItemIndexes: items.map((_, index) => index),
+      pause: items.length > 0,
+    };
+  }
+  const activeIndex = runIndex;
+  const activeItem = items[activeIndex];
+  const dropActive = Boolean(activeItem?.dispatched);
+  const retainedItemIndexes = items.flatMap((_, index) =>
+    dropActive && index === activeIndex ? [] : [index],
+  );
+  return {
+    cancelActiveItem: dropActive,
+    retainedItemIndexes,
+    pause: retainedItemIndexes.some((index) => !items[index]?.dispatched),
+  };
+}

--- a/studio/frontend/tests/prompt-queue-user-stop.test.ts
+++ b/studio/frontend/tests/prompt-queue-user-stop.test.ts
@@ -49,16 +49,16 @@ const plans: Array<{
     want: { cancelActiveItem: true, retainedItemIndexes: [], pause: false },
   },
   {
-    name: "an undispatched stop keeps the whole queue and pauses",
-    items: [{ dispatched: false }, { dispatched: false }],
-    index: 0,
-    want: { cancelActiveItem: false, retainedItemIndexes: [0, 1], pause: true },
-  },
-  {
     name: "a queue still waiting to start is paused without cancelling",
     items: [{ dispatched: false }, { dispatched: false }],
     index: -1,
     want: { cancelActiveItem: false, retainedItemIndexes: [0, 1], pause: true },
+  },
+  {
+    name: "completed history without follow-ups is retained and not paused",
+    items: [{ dispatched: true }, { dispatched: true }, { dispatched: true }],
+    index: 2,
+    want: { cancelActiveItem: true, retainedItemIndexes: [0, 1], pause: false },
   },
 ];
 

--- a/studio/frontend/tests/prompt-queue-user-stop.test.ts
+++ b/studio/frontend/tests/prompt-queue-user-stop.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { planUserPromptQueueStop } from "../src/features/chat/utils/prompt-queue-user-stop.ts";
+
+test("a dispatched stop keeps pending follow-ups and pauses", () => {
+  assert.deepEqual(
+    planUserPromptQueueStop(
+      [
+        { dispatched: true },
+        { dispatched: false },
+        { dispatched: false },
+      ],
+      0,
+    ),
+    {
+      cancelActiveItem: true,
+      retainedItemIndexes: [1, 2],
+      pause: true,
+    },
+  );
+});
+
+test("a dispatched stop with no follow-ups leaves nothing to resume", () => {
+  assert.deepEqual(
+    planUserPromptQueueStop([{ dispatched: true }], 0),
+    {
+      cancelActiveItem: true,
+      retainedItemIndexes: [],
+      pause: false,
+    },
+  );
+});
+
+test("an undispatched stop keeps the whole queue and pauses", () => {
+  assert.deepEqual(
+    planUserPromptQueueStop(
+      [{ dispatched: false }, { dispatched: false }],
+      0,
+    ),
+    {
+      cancelActiveItem: false,
+      retainedItemIndexes: [0, 1],
+      pause: true,
+    },
+  );
+});
+
+test("completed history is kept when a later dispatched item is stopped", () => {
+  assert.deepEqual(
+    planUserPromptQueueStop(
+      [
+        { dispatched: true },
+        { dispatched: true },
+        { dispatched: false },
+      ],
+      1,
+    ),
+    {
+      cancelActiveItem: true,
+      retainedItemIndexes: [0, 2],
+      pause: true,
+    },
+  );
+});
+
+test("a queue still waiting to start is paused without cancelling", () => {
+  assert.deepEqual(
+    planUserPromptQueueStop(
+      [{ dispatched: false }, { dispatched: false }],
+      -1,
+    ),
+    {
+      cancelActiveItem: false,
+      retainedItemIndexes: [0, 1],
+      pause: true,
+    },
+  );
+});

--- a/studio/frontend/tests/prompt-queue-user-stop.test.ts
+++ b/studio/frontend/tests/prompt-queue-user-stop.test.ts
@@ -1,79 +1,88 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { planUserPromptQueueStop } from "../src/features/chat/utils/prompt-queue-user-stop.ts";
+import {
+  planUserPromptQueueStop,
+  userStopTargetCancelMode,
+} from "../src/features/chat/utils/prompt-queue-user-stop.ts";
 
-test("a dispatched stop keeps pending follow-ups and pauses", () => {
-  assert.deepEqual(
-    planUserPromptQueueStop(
-      [
-        { dispatched: true },
-        { dispatched: false },
-        { dispatched: false },
-      ],
-      0,
-    ),
-    {
-      cancelActiveItem: true,
-      retainedItemIndexes: [1, 2],
-      pause: true,
-    },
+class SharedQueueTarget {
+  permanentlyCancelled = false;
+  activeRunCancels = 0;
+  cancel() {
+    this.permanentlyCancelled = true;
+  }
+  cancelActiveRun() {
+    this.activeRunCancels += 1;
+  }
+  append() {
+    return this.permanentlyCancelled ? "skipped" : "sent";
+  }
+}
+
+function applyStopCancel(
+  target: SharedQueueTarget,
+  plan: ReturnType<typeof planUserPromptQueueStop>,
+) {
+  const mode = userStopTargetCancelMode(plan);
+  if (mode === "permanent") target.cancel();
+  else if (mode === "activeRun") target.cancelActiveRun();
+  return mode;
+}
+
+const plans: Array<{
+  name: string;
+  items: Array<{ dispatched: boolean }>;
+  index: number;
+  want: ReturnType<typeof planUserPromptQueueStop>;
+}> = [
+  {
+    name: "a dispatched stop keeps pending follow-ups and pauses",
+    items: [{ dispatched: true }, { dispatched: false }, { dispatched: false }],
+    index: 0,
+    want: { cancelActiveItem: true, retainedItemIndexes: [1, 2], pause: true },
+  },
+  {
+    name: "a dispatched stop with no follow-ups leaves nothing to resume",
+    items: [{ dispatched: true }],
+    index: 0,
+    want: { cancelActiveItem: true, retainedItemIndexes: [], pause: false },
+  },
+  {
+    name: "an undispatched stop keeps the whole queue and pauses",
+    items: [{ dispatched: false }, { dispatched: false }],
+    index: 0,
+    want: { cancelActiveItem: false, retainedItemIndexes: [0, 1], pause: true },
+  },
+  {
+    name: "a queue still waiting to start is paused without cancelling",
+    items: [{ dispatched: false }, { dispatched: false }],
+    index: -1,
+    want: { cancelActiveItem: false, retainedItemIndexes: [0, 1], pause: true },
+  },
+];
+
+for (const entry of plans) {
+  test(entry.name, () => {
+    assert.deepEqual(planUserPromptQueueStop(entry.items, entry.index), entry.want);
+  });
+}
+
+test("pausing a shared-target batch still lets the next prompt append", () => {
+  const target = new SharedQueueTarget();
+  const plan = planUserPromptQueueStop(
+    [{ dispatched: true }, { dispatched: false }],
+    0,
   );
+  assert.equal(applyStopCancel(target, plan), "activeRun");
+  assert.equal(target.append(), "sent");
+  assert.equal(target.activeRunCancels, 1);
+  assert.equal(target.permanentlyCancelled, false);
 });
 
-test("a dispatched stop with no follow-ups leaves nothing to resume", () => {
-  assert.deepEqual(
-    planUserPromptQueueStop([{ dispatched: true }], 0),
-    {
-      cancelActiveItem: true,
-      retainedItemIndexes: [],
-      pause: false,
-    },
-  );
-});
-
-test("an undispatched stop keeps the whole queue and pauses", () => {
-  assert.deepEqual(
-    planUserPromptQueueStop(
-      [{ dispatched: false }, { dispatched: false }],
-      0,
-    ),
-    {
-      cancelActiveItem: false,
-      retainedItemIndexes: [0, 1],
-      pause: true,
-    },
-  );
-});
-
-test("completed history is kept when a later dispatched item is stopped", () => {
-  assert.deepEqual(
-    planUserPromptQueueStop(
-      [
-        { dispatched: true },
-        { dispatched: true },
-        { dispatched: false },
-      ],
-      1,
-    ),
-    {
-      cancelActiveItem: true,
-      retainedItemIndexes: [0, 2],
-      pause: true,
-    },
-  );
-});
-
-test("a queue still waiting to start is paused without cancelling", () => {
-  assert.deepEqual(
-    planUserPromptQueueStop(
-      [{ dispatched: false }, { dispatched: false }],
-      -1,
-    ),
-    {
-      cancelActiveItem: false,
-      retainedItemIndexes: [0, 1],
-      pause: true,
-    },
-  );
+test("a stop with nothing left permanently cancels the shared target", () => {
+  const target = new SharedQueueTarget();
+  const plan = planUserPromptQueueStop([{ dispatched: true }], 0);
+  assert.equal(applyStopCancel(target, plan), "permanent");
+  assert.equal(target.append(), "skipped");
 });

--- a/tests/studio/test_prompt_queue_pause_side_effects.py
+++ b/tests/studio/test_prompt_queue_pause_side_effects.py
@@ -1,13 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Contracts for the paths a paused prompt queue reaches without being edited by it.
-
-Pausing instead of deleting keeps the run, and therefore its PromptQueueUIEntry,
-alive after the user presses Stop. Everything that treated "an entry exists" as
-"work is happening" silently starts reporting a chat the user has already stopped.
-These pin the three places that had to learn about `paused`.
-"""
+"""A paused run keeps its PromptQueueUIEntry, so every reader of "an entry exists"
+had to learn about `paused`. These pin those places and the two dispatch races."""
 
 from pathlib import Path
 
@@ -22,8 +17,6 @@ CONFIRM = (
 
 
 def test_the_sidebar_work_spinner_ignores_a_paused_queue():
-    # Measured before the guard: BEFORE 0 sidebar spinners after Stop settled,
-    # AFTER 1, on the same probe against two builds of the same commit pair.
     block = SIDEBAR.split("const hasQueuedActivity", 1)[1]
     block = block.split("const showQueuedActivity", 1)[0]
     assert "entry.paused" in block
@@ -36,9 +29,6 @@ def test_a_paused_queue_is_not_a_running_chat_in_the_stop_dialog():
 
 
 def test_resume_clears_the_stale_running_edge_so_it_cannot_skip_a_prompt():
-    # handlePromptQueueRunState records prevStoreRunning before it returns for a paused
-    # run, so a rising edge seen while paused survives. Resuming without clearing it
-    # lets the next idle edge advance past the first retained prompt without sending it.
     resume = THREAD.split("function resumePromptQueueRun(threadIds?: string[])", 1)[1]
     resume = resume.split("function stopPromptQueueRun", 1)[0]
     assert "run.prevStoreRunning = false" in resume
@@ -47,8 +37,6 @@ def test_resume_clears_the_stale_running_edge_so_it_cannot_skip_a_prompt():
 
 
 def test_a_superseded_dispatch_does_not_release_the_live_dispatch_flag():
-    # Without this the same prompt is appended twice when Stop then Resume happen
-    # while a document-indexing probe is still outstanding.
     pump = THREAD.split("function pumpPromptQueues()", 1)[1]
     pump = pump.split("async function dispatchQueuedPrompt(", 1)[0]
     assert "const dispatchGeneration = run.generation" in pump

--- a/tests/studio/test_prompt_queue_pause_side_effects.py
+++ b/tests/studio/test_prompt_queue_pause_side_effects.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Contracts for the paths a paused prompt queue reaches without being edited by it.
+
+Pausing instead of deleting keeps the run, and therefore its PromptQueueUIEntry,
+alive after the user presses Stop. Everything that treated "an entry exists" as
+"work is happening" silently starts reporting a chat the user has already stopped.
+These pin the three places that had to learn about `paused`.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+THREAD = (ROOT / "studio/frontend/src/components/assistant-ui/thread.tsx").read_text(
+    encoding = "utf-8"
+)
+SIDEBAR = (ROOT / "studio/frontend/src/components/app-sidebar.tsx").read_text(
+    encoding = "utf-8"
+)
+CONFIRM = (
+    ROOT / "studio/frontend/src/features/chat/utils/confirm-stop-running-chats.ts"
+).read_text(encoding = "utf-8")
+
+
+def test_the_sidebar_work_spinner_ignores_a_paused_queue():
+    # Measured before the guard: BEFORE 0 sidebar spinners after Stop settled,
+    # AFTER 1, on the same probe against two builds of the same commit pair.
+    block = SIDEBAR.split("const hasQueuedActivity", 1)[1]
+    block = block.split("const showQueuedActivity", 1)[0]
+    assert "entry.paused" in block
+
+
+def test_a_paused_queue_is_not_a_running_chat_in_the_stop_dialog():
+    loop = CONFIRM.split("for (const threadId of promptQueueThreadIds)", 1)[1]
+    loop = loop.split("for (const aliases of aliasesByQueuedRun.values())", 1)[0]
+    assert "entry.paused" in loop
+
+
+def test_resume_clears_the_stale_running_edge_so_it_cannot_skip_a_prompt():
+    # handlePromptQueueRunState records prevStoreRunning before it returns for a paused
+    # run, so a rising edge seen while paused survives. Resuming without clearing it
+    # lets the next idle edge advance past the first retained prompt without sending it.
+    resume = THREAD.split("function resumePromptQueueRun(threadIds?: string[])", 1)[1]
+    resume = resume.split("function stopPromptQueueRun", 1)[0]
+    assert "run.prevStoreRunning = false" in resume
+    assert "run.waitingForTargetIdle = false" in resume
+    assert "clearPromptQueueRetryTimer(run)" in resume
+
+
+def test_a_superseded_dispatch_does_not_release_the_live_dispatch_flag():
+    # Without this the same prompt is appended twice when Stop then Resume happen
+    # while a document-indexing probe is still outstanding.
+    pump = THREAD.split("function pumpPromptQueues()", 1)[1]
+    pump = pump.split("async function dispatchQueuedPrompt(", 1)[0]
+    assert "const dispatchGeneration = run.generation" in pump
+    assert "dispatchGeneration !== run.generation" in pump
+
+
+def test_pause_does_not_rewind_past_a_prompt_the_run_already_moved_beyond():
+    pause = THREAD.split("function pausePromptQueueRun(threadIds?: string[])", 1)[1]
+    pause = pause.split("function resumePromptQueueRun", 1)[0]
+    assert "resumeFrom" in pause
+    assert "index >= searchFrom" in pause

--- a/tests/studio/test_prompt_queue_pause_side_effects.py
+++ b/tests/studio/test_prompt_queue_pause_side_effects.py
@@ -15,9 +15,7 @@ ROOT = Path(__file__).resolve().parents[2]
 THREAD = (ROOT / "studio/frontend/src/components/assistant-ui/thread.tsx").read_text(
     encoding = "utf-8"
 )
-SIDEBAR = (ROOT / "studio/frontend/src/components/app-sidebar.tsx").read_text(
-    encoding = "utf-8"
-)
+SIDEBAR = (ROOT / "studio/frontend/src/components/app-sidebar.tsx").read_text(encoding = "utf-8")
 CONFIRM = (
     ROOT / "studio/frontend/src/features/chat/utils/confirm-stop-running-chats.ts"
 ).read_text(encoding = "utf-8")

--- a/tests/studio/test_prompt_queue_user_stop.py
+++ b/tests/studio/test_prompt_queue_user_stop.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Stop generation must keep prompts that have not been sent yet.
+
+https://github.com/unslothai/unsloth/issues/10428
+"""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+FRONTEND = REPO / "studio/frontend/src"
+THREAD = (FRONTEND / "components/assistant-ui/thread.tsx").read_text(encoding = "utf-8")
+PLANNER_PATH = FRONTEND / "features/chat/utils/prompt-queue-user-stop.ts"
+BARREL = (FRONTEND / "features/chat/index.ts").read_text(encoding = "utf-8")
+
+
+def _between(source: str, start: str, end: str) -> str:
+    assert start in source, f"missing start marker: {start}"
+    tail = source.split(start, 1)[1]
+    assert end in tail, f"missing end marker after {start}: {end}"
+    return tail.split(end, 1)[0]
+
+
+def test_user_stop_plans_with_pending_items_kept():
+    assert PLANNER_PATH.is_file()
+    planner = PLANNER_PATH.read_text(encoding = "utf-8")
+    assert "export function planUserPromptQueueStop(" in planner
+    assert 'from "./utils/prompt-queue-user-stop"' in BARREL
+    stop = _between(
+        THREAD,
+        "function stopPromptQueueRun(threadIds?: string[])",
+        "function stopPromptQueueRunForThreadIds(threadIds: string[])",
+    )
+    assert "planUserPromptQueueStop(" in stop
+    assert stop.index("planUserPromptQueueStop(") < stop.index(
+        "deletePromptQueueRun(run);"
+    )
+    assert "run.paused = plan.pause" in stop
+    assert "run.generation += 1" in stop
+
+
+def test_paused_queue_does_not_dispatch_or_advance():
+    ready = _between(
+        THREAD,
+        "function isPromptQueueRunReadyToDispatch(run: PromptQueueRun)",
+        "function getNextReadyPromptQueueRun()",
+    )
+    assert "!run.paused" in ready
+    run_state = _between(
+        THREAD,
+        "function handlePromptQueueRunState(",
+        "function ensurePromptQueueSubscription()",
+    )
+    assert run_state.index("if (run.paused)") < run_state.index(
+        "advancePromptQueue(run);"
+    )
+    retained = _between(
+        THREAD,
+        "function retainPendingPromptQueueItemsAfterFailure(run: PromptQueueRun)",
+        "function cancelPendingPromptQueueFactoriesForStop<",
+    )
+    assert retained.index("if (run.paused)") < retained.index(
+        "run.items.splice(activeIndex, 1);"
+    )
+
+
+def test_start_unpauses_an_existing_run():
+    start = _between(
+        THREAD,
+        "function startPromptQueue(",
+        "function getPromptQueueRunsForThreadIds(threadIds?: string[])",
+    )
+    assert "existingRun.paused = false" in start
+    assert "existingRun?.paused" in start
+    assert "paused: false" in start

--- a/tests/studio/test_prompt_queue_user_stop.py
+++ b/tests/studio/test_prompt_queue_user_stop.py
@@ -4,8 +4,7 @@
 from pathlib import Path
 
 THREAD = (
-    Path(__file__).resolve().parents[2]
-    / "studio/frontend/src/components/assistant-ui/thread.tsx"
+    Path(__file__).resolve().parents[2] / "studio/frontend/src/components/assistant-ui/thread.tsx"
 ).read_text(encoding = "utf-8")
 
 

--- a/tests/studio/test_prompt_queue_user_stop.py
+++ b/tests/studio/test_prompt_queue_user_stop.py
@@ -1,19 +1,14 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Stop generation must keep prompts that have not been sent yet.
-
-https://github.com/unslothai/unsloth/issues/10428
-"""
+"""Composer stop pauses the queue; delete/archive still delete it."""
 
 from pathlib import Path
 
-
-REPO = Path(__file__).resolve().parents[2]
-FRONTEND = REPO / "studio/frontend/src"
-THREAD = (FRONTEND / "components/assistant-ui/thread.tsx").read_text(encoding = "utf-8")
-PLANNER_PATH = FRONTEND / "features/chat/utils/prompt-queue-user-stop.ts"
-BARREL = (FRONTEND / "features/chat/index.ts").read_text(encoding = "utf-8")
+THREAD = (
+    Path(__file__).resolve().parents[2]
+    / "studio/frontend/src/components/assistant-ui/thread.tsx"
+).read_text(encoding = "utf-8")
 
 
 def _between(source: str, start: str, end: str) -> str:
@@ -23,55 +18,27 @@ def _between(source: str, start: str, end: str) -> str:
     return tail.split(end, 1)[0]
 
 
-def test_user_stop_plans_with_pending_items_kept():
-    assert PLANNER_PATH.is_file()
-    planner = PLANNER_PATH.read_text(encoding = "utf-8")
-    assert "export function planUserPromptQueueStop(" in planner
-    assert 'from "./utils/prompt-queue-user-stop"' in BARREL
+def test_composer_stop_pauses_without_permanently_cancelling_the_target():
+    pause = _between(
+        THREAD,
+        "function pausePromptQueueRun(threadIds?: string[])",
+        "function resumePromptQueueRun(threadIds?: string[])",
+    )
+    assert "userStopTargetCancelMode(plan)" in pause
+    assert "cancelActiveRun()" in pause
+    assert "pausePromptQueueRun(promptQueueThreadIds)" in THREAD
+    assert 'aria-label="Resume queue"' in THREAD
     stop = _between(
         THREAD,
         "function stopPromptQueueRun(threadIds?: string[])",
         "function stopPromptQueueRunForThreadIds(threadIds: string[])",
     )
-    assert "planUserPromptQueueStop(" in stop
-    assert stop.index("planUserPromptQueueStop(") < stop.index(
-        "deletePromptQueueRun(run);"
-    )
-    assert "run.paused = plan.pause" in stop
-    assert "run.generation += 1" in stop
-
-
-def test_paused_queue_does_not_dispatch_or_advance():
-    ready = _between(
+    assert "planUserPromptQueueStop(" not in stop
+    assert "deletePromptQueueRun(run);" in stop
+    listener = _between(
         THREAD,
-        "function isPromptQueueRunReadyToDispatch(run: PromptQueueRun)",
-        "function getNextReadyPromptQueueRun()",
+        "window.addEventListener(PROMPT_QUEUE_STOP_EVENT",
+        "window.addEventListener(PROMPT_QUEUE_RUN_FAILED_EVENT",
     )
-    assert "!run.paused" in ready
-    run_state = _between(
-        THREAD,
-        "function handlePromptQueueRunState(",
-        "function ensurePromptQueueSubscription()",
-    )
-    assert run_state.index("if (run.paused)") < run_state.index(
-        "advancePromptQueue(run);"
-    )
-    retained = _between(
-        THREAD,
-        "function retainPendingPromptQueueItemsAfterFailure(run: PromptQueueRun)",
-        "function cancelPendingPromptQueueFactoriesForStop<",
-    )
-    assert retained.index("if (run.paused)") < retained.index(
-        "run.items.splice(activeIndex, 1);"
-    )
-
-
-def test_start_unpauses_an_existing_run():
-    start = _between(
-        THREAD,
-        "function startPromptQueue(",
-        "function getPromptQueueRunsForThreadIds(threadIds?: string[])",
-    )
-    assert "existingRun.paused = false" in start
-    assert "existingRun?.paused" in start
-    assert "paused: false" in start
+    assert "stopPromptQueueRunForThreadIds(threadIds)" in listener
+    assert "pausePromptQueueRun(" not in listener

--- a/tests/studio/test_prompt_queue_user_stop.py
+++ b/tests/studio/test_prompt_queue_user_stop.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Composer stop pauses the queue; delete/archive still delete it."""
-
 from pathlib import Path
 
 THREAD = (
@@ -11,34 +9,14 @@ THREAD = (
 ).read_text(encoding = "utf-8")
 
 
-def _between(source: str, start: str, end: str) -> str:
-    assert start in source, f"missing start marker: {start}"
-    tail = source.split(start, 1)[1]
-    assert end in tail, f"missing end marker after {start}: {end}"
-    return tail.split(end, 1)[0]
-
-
-def test_composer_stop_pauses_without_permanently_cancelling_the_target():
-    pause = _between(
-        THREAD,
-        "function pausePromptQueueRun(threadIds?: string[])",
-        "function resumePromptQueueRun(threadIds?: string[])",
-    )
-    assert "userStopTargetCancelMode(plan)" in pause
-    assert "cancelActiveRun()" in pause
+def test_composer_stop_pauses_and_delete_still_deletes():
     assert "pausePromptQueueRun(promptQueueThreadIds)" in THREAD
+    assert "cancelActiveRun()" in THREAD
     assert 'aria-label="Resume queue"' in THREAD
-    stop = _between(
-        THREAD,
-        "function stopPromptQueueRun(threadIds?: string[])",
-        "function stopPromptQueueRunForThreadIds(threadIds: string[])",
-    )
+    stop = THREAD.split("function stopPromptQueueRun(threadIds?: string[])", 1)[1]
+    stop = stop.split("function stopPromptQueueRunForThreadIds", 1)[0]
     assert "planUserPromptQueueStop(" not in stop
-    assert "deletePromptQueueRun(run);" in stop
-    listener = _between(
-        THREAD,
-        "window.addEventListener(PROMPT_QUEUE_STOP_EVENT",
-        "window.addEventListener(PROMPT_QUEUE_RUN_FAILED_EVENT",
-    )
+    listener = THREAD.split("window.addEventListener(PROMPT_QUEUE_STOP_EVENT", 1)[1]
+    listener = listener.split("window.addEventListener(PROMPT_QUEUE_RUN_FAILED_EVENT", 1)[0]
     assert "stopPromptQueueRunForThreadIds(threadIds)" in listener
     assert "pausePromptQueueRun(" not in listener


### PR DESCRIPTION
Stopping generation called `deletePromptQueueRun`, so every prompt still waiting in that chat disappeared (https://github.com/unslothai/unsloth/issues/10428). Delete, archive, and clear-all still delete the run.

Composer Stop pauses: it drops the in-flight item, keeps the rest, and calls `cancelActiveRun` so the shared target can append again. Resume shows when the composer is empty. Typing a follow-up shows Queue and does not unpause, so Enter cannot fire the leftover prompts ahead of the new text.

`node --experimental-strip-types --test tests/prompt-queue-user-stop.test.ts` in studio/frontend -> 6 passed, including a shared-target stop then append. `.venv/bin/python -m pytest -q tests/studio/test_prompt_queue_user_stop.py tests/studio/test_multi_chat_prompt_queue_contract.py` -> 17 passed.
