### PR TITLE
Apply the load settings unsloth start dsh is given

### DIFF
--- a/tests/studio/test_cli_attach_load_knobs.py
+++ b/tests/studio/test_cli_attach_load_knobs.py
@@ -411,10 +411,12 @@ def _registered_command_name(command) -> str:
 
     `@start_app.command()` with no name leaves `command.name` None, and dropping those
     would silently shrink the roster -- the failure mode this whole derivation exists to
-    avoid. Typer's rule is `main.get_command_name`; inline the same lowercase/underscore
-    swap so the fallback holds on the older typers `pyproject.toml` still allows.
+    avoid. Ask Typer itself rather than copying the rule, so a roster name can never
+    drift from the name the CLI actually dispatches on.
     """
-    return command.name or command.callback.__name__.lower().replace("_", "-")
+    from typer.main import get_command_name
+
+    return command.name or get_command_name(command.callback.__name__)
 
 
 def _scan_start_commands() -> tuple:
@@ -479,13 +481,11 @@ class TestExplicitFlagsThroughTheRealCli:
     )
     def test_flags_equal_to_their_default_are_recorded(self, flag, expected):
         load = self._load_for(["codex", "--no-launch", *flag])
-        assert load is not None, "the command never reached _connect"
         assert expected in load.supplied
         assert expected in load.overrides()
 
     def test_a_bare_invocation_records_nothing(self):
         load = self._load_for(["codex", "--no-launch"])
-        assert load is not None
         assert load.supplied == frozenset()
         assert load.overrides() == frozenset()
 
@@ -504,7 +504,6 @@ class TestExplicitFlagsThroughTheRealCli:
     @pytest.mark.parametrize("command", AGENT_COMMANDS)
     def test_every_agent_command_tracks_flags_identically(self, command):
         load = self._load_for([command, "--no-launch", "--context-length", "0"])
-        assert load is not None, f"{command} never reached _connect"
         assert "max_seq_length" in load.supplied
         # overrides() is what _resolve_model reads; supplied alone never reaches the load.
         assert "max_seq_length" in load.overrides()

--- a/tests/studio/test_cli_attach_load_knobs.py
+++ b/tests/studio/test_cli_attach_load_knobs.py
@@ -407,25 +407,14 @@ def test_omitted_default_flags_are_not_forwarded(monkeypatch):
 
 
 def _registered_command_name(command) -> str:
-    """The name the CLI answers to, including one Typer inferred from the function.
-
-    `@start_app.command()` with no name leaves `command.name` None, and dropping those
-    would silently shrink the roster -- the failure mode this whole derivation exists to
-    avoid. Ask Typer itself rather than copying the rule, so a roster name can never
-    drift from the name the CLI actually dispatches on.
-    """
+    """Name the CLI dispatches on. Ask Typer, so an unnamed command cannot drop out."""
     from typer.main import get_command_name
     return command.name or get_command_name(command.callback.__name__)
 
 
 def _scan_start_commands() -> tuple:
-    """(commands taking every load knob, commands taking only some), off the app itself.
-
-    Hardcoding the list is how `dsh` shipped without flag tracking: the roster below is
-    whatever is registered today, so a new agent command is covered the day it lands.
-    A command holding only SOME of the knobs is reported rather than skipped -- excluding
-    it would hide exactly the per-command inconsistency this roster is here to catch.
-    """
+    """(all-knob commands, partial-knob commands) read off the app itself.
+    Hardcoding the roster is how `dsh` shipped without flag tracking."""
     knobs = set(start_cli._LOAD_OPTION_PARAMS)
     full, partial = [], []
     for command in start_cli.start_app.registered_commands:
@@ -461,8 +450,7 @@ class TestExplicitFlagsThroughTheRealCli:
         finally:
             start_cli._connect = real_connect
         if "load" not in captured:
-            # Without the runner's own verdict a parser incompatibility and a dropped
-            # flag both surface as a bare None, and only one of them is this file's bug.
+            # Without the exit code, a parser incompatibility reads as a dropped flag.
             pytest.fail(
                 f"{argv} never reached _connect (exit {result.exit_code}): "
                 f"{result.exception!r}\n{result.output}"
@@ -493,7 +481,6 @@ class TestExplicitFlagsThroughTheRealCli:
         assert AGENT_COMMANDS
 
     def test_no_start_command_takes_only_part_of_the_load_knobs(self):
-        """A partial set would drop out of the roster below and go untested in silence."""
         assert PARTIAL_KNOB_COMMANDS == [], (
             f"{PARTIAL_KNOB_COMMANDS} take some load knobs but not all of "
             f"{sorted(start_cli._LOAD_OPTION_PARAMS)}; give them the full set (and "

--- a/tests/studio/test_cli_attach_load_knobs.py
+++ b/tests/studio/test_cli_attach_load_knobs.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 import typer
 
@@ -404,6 +406,23 @@ def test_omitted_default_flags_are_not_forwarded(monkeypatch):
     assert sent(server) == {"model_path": "unsloth/Qwen3-14B"}
 
 
+def _agent_commands() -> list:
+    """Every `unsloth start` command that takes the load knobs, read off the app itself.
+
+    Hardcoding the list is how `dsh` shipped without flag tracking: the roster below is
+    whatever is registered today, so a new agent command is covered the day it lands.
+    """
+    knobs = set(start_cli._LOAD_OPTION_PARAMS)
+    return sorted(
+        command.name
+        for command in start_cli.start_app.registered_commands
+        if command.name and knobs <= set(inspect.signature(command.callback).parameters)
+    )
+
+
+AGENT_COMMANDS = _agent_commands()
+
+
 class TestExplicitFlagsThroughTheRealCli:
     """`supplied` tracking through the real Typer and Click stack."""
 
@@ -446,13 +465,17 @@ class TestExplicitFlagsThroughTheRealCli:
         assert load.supplied == frozenset()
         assert load.overrides() == frozenset()
 
-    @pytest.mark.parametrize(
-        "command", ["codex", "claude", "opencode", "hermes", "pi", "openclaw", "dsh"]
-    )
+    def test_the_agent_command_roster_is_not_empty(self):
+        """An empty parametrization collects no tests, so the check below would vanish."""
+        assert AGENT_COMMANDS
+
+    @pytest.mark.parametrize("command", AGENT_COMMANDS)
     def test_every_agent_command_tracks_flags_identically(self, command):
         load = self._load_for([command, "--no-launch", "--context-length", "0"])
         assert load is not None, f"{command} never reached _connect"
         assert "max_seq_length" in load.supplied
+        # overrides() is what _resolve_model reads; supplied alone never reaches the load.
+        assert "max_seq_length" in load.overrides()
 
 
 def test_inferred_reload_carries_the_resident_runtime_settings(monkeypatch):

--- a/tests/studio/test_cli_attach_load_knobs.py
+++ b/tests/studio/test_cli_attach_load_knobs.py
@@ -415,7 +415,6 @@ def _registered_command_name(command) -> str:
     drift from the name the CLI actually dispatches on.
     """
     from typer.main import get_command_name
-
     return command.name or get_command_name(command.callback.__name__)
 
 

--- a/tests/studio/test_cli_attach_load_knobs.py
+++ b/tests/studio/test_cli_attach_load_knobs.py
@@ -413,8 +413,7 @@ def _registered_command_name(command) -> str:
 
 
 def _scan_start_commands() -> tuple:
-    """(all-knob commands, partial-knob commands) read off the app itself.
-    Hardcoding the roster is how `dsh` shipped without flag tracking."""
+    """(all-knob, partial-knob) commands, read off the app: a hardcoded roster missed dsh."""
     knobs = set(start_cli._LOAD_OPTION_PARAMS)
     full, partial = [], []
     for command in start_cli.start_app.registered_commands:

--- a/tests/studio/test_cli_attach_load_knobs.py
+++ b/tests/studio/test_cli_attach_load_knobs.py
@@ -446,7 +446,9 @@ class TestExplicitFlagsThroughTheRealCli:
         assert load.supplied == frozenset()
         assert load.overrides() == frozenset()
 
-    @pytest.mark.parametrize("command", ["codex", "claude", "opencode", "hermes", "pi", "openclaw"])
+    @pytest.mark.parametrize(
+        "command", ["codex", "claude", "opencode", "hermes", "pi", "openclaw", "dsh"]
+    )
     def test_every_agent_command_tracks_flags_identically(self, command):
         load = self._load_for([command, "--no-launch", "--context-length", "0"])
         assert load is not None, f"{command} never reached _connect"

--- a/tests/studio/test_cli_attach_load_knobs.py
+++ b/tests/studio/test_cli_attach_load_knobs.py
@@ -406,21 +406,38 @@ def test_omitted_default_flags_are_not_forwarded(monkeypatch):
     assert sent(server) == {"model_path": "unsloth/Qwen3-14B"}
 
 
-def _agent_commands() -> list:
-    """Every `unsloth start` command that takes the load knobs, read off the app itself.
+def _registered_command_name(command) -> str:
+    """The name the CLI answers to, including one Typer inferred from the function.
+
+    `@start_app.command()` with no name leaves `command.name` None, and dropping those
+    would silently shrink the roster -- the failure mode this whole derivation exists to
+    avoid. Typer's rule is `main.get_command_name`; inline the same lowercase/underscore
+    swap so the fallback holds on the older typers `pyproject.toml` still allows.
+    """
+    return command.name or command.callback.__name__.lower().replace("_", "-")
+
+
+def _scan_start_commands() -> tuple:
+    """(commands taking every load knob, commands taking only some), off the app itself.
 
     Hardcoding the list is how `dsh` shipped without flag tracking: the roster below is
     whatever is registered today, so a new agent command is covered the day it lands.
+    A command holding only SOME of the knobs is reported rather than skipped -- excluding
+    it would hide exactly the per-command inconsistency this roster is here to catch.
     """
     knobs = set(start_cli._LOAD_OPTION_PARAMS)
-    return sorted(
-        command.name
-        for command in start_cli.start_app.registered_commands
-        if command.name and knobs <= set(inspect.signature(command.callback).parameters)
-    )
+    full, partial = [], []
+    for command in start_cli.start_app.registered_commands:
+        if command.callback is None:
+            continue
+        params = set(inspect.signature(command.callback).parameters)
+        if not knobs & params:
+            continue
+        (full if knobs <= params else partial).append(_registered_command_name(command))
+    return sorted(full), sorted(partial)
 
 
-AGENT_COMMANDS = _agent_commands()
+AGENT_COMMANDS, PARTIAL_KNOB_COMMANDS = _scan_start_commands()
 
 
 class TestExplicitFlagsThroughTheRealCli:
@@ -439,10 +456,17 @@ class TestExplicitFlagsThroughTheRealCli:
 
         start_cli._connect = fake_connect
         try:
-            CliRunner().invoke(start_cli.start_app, argv)
+            result = CliRunner().invoke(start_cli.start_app, argv)
         finally:
             start_cli._connect = real_connect
-        return captured.get("load")
+        if "load" not in captured:
+            # Without the runner's own verdict a parser incompatibility and a dropped
+            # flag both surface as a bare None, and only one of them is this file's bug.
+            pytest.fail(
+                f"{argv} never reached _connect (exit {result.exit_code}): "
+                f"{result.exception!r}\n{result.output}"
+            )
+        return captured["load"]
 
     @pytest.mark.parametrize(
         "flag, expected",
@@ -468,6 +492,14 @@ class TestExplicitFlagsThroughTheRealCli:
     def test_the_agent_command_roster_is_not_empty(self):
         """An empty parametrization collects no tests, so the check below would vanish."""
         assert AGENT_COMMANDS
+
+    def test_no_start_command_takes_only_part_of_the_load_knobs(self):
+        """A partial set would drop out of the roster below and go untested in silence."""
+        assert PARTIAL_KNOB_COMMANDS == [], (
+            f"{PARTIAL_KNOB_COMMANDS} take some load knobs but not all of "
+            f"{sorted(start_cli._LOAD_OPTION_PARAMS)}; give them the full set (and "
+            "_load_options) or they will never be checked for flag tracking."
+        )
 
     @pytest.mark.parametrize("command", AGENT_COMMANDS)
     def test_every_agent_command_tracks_flags_identically(self, command):

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -5843,7 +5843,9 @@ def dsh(
     base, key, entry = _connect(
         api_key,
         model,
-        LoadOptions(gguf_variant, max_seq_length, load_in_4bit, tensor_parallel, gpu_memory_mode),
+        _load_options(
+            ctx, gguf_variant, max_seq_length, load_in_4bit, tensor_parallel, gpu_memory_mode
+        ),
         serve = serve,
         launch = launch,
         server_options = ServerOptions(


### PR DESCRIPTION
unsloth start dsh ignored the load flags you typed when a server was already running. Running unsloth start dsh --context-length 0 left the model on its old context length and printed nothing about it, so you got a session with settings you did not ask for. The same flags work on codex, claude, opencode, openclaw, hermes and pi.

The cause is that dsh built its load options positionally and never recorded which flags came from the command line. Without that list the code falls back to comparing each value against its default, so a flag whose value happens to equal the default looks like it was never passed. --context-length 0 is exactly that case, and so are --load-in-4bit and --no-tensor-parallel.

The fix is to call the same helper the other six commands use, which records the flags Click saw.

To reproduce, start a server with a model pinned to a smaller context, then run unsloth start dsh --context-length 0 against it. Before this change no load request is sent and the model stays where it was. After it, the reset is applied like it is for codex.

Note the bug only shows up for values that match the default. unsloth start dsh --context-length 8192 already worked.
