### PR TITLE
Stop unsloth train from ignoring config keys it does not know

### DIFF
--- a/unsloth_cli/commands/train.py
+++ b/unsloth_cli/commands/train.py
@@ -9,7 +9,7 @@ import typer
 
 from unsloth_cli._inference import ensure_studio_backend_path
 from unsloth_cli._studio_deps import studio_backend_imports
-from unsloth_cli.config import Config, load_config
+from unsloth_cli.config import Config, ConfigError, load_config
 from unsloth_cli.options import add_options_from_config
 
 
@@ -71,7 +71,7 @@ def train(
     """Launch training using the existing Unsloth training backend."""
     try:
         cfg = load_config(config)
-    except FileNotFoundError as e:
+    except (FileNotFoundError, ConfigError) as e:
         typer.echo(f"Error: {e}", err = True)
         raise typer.Exit(code = 2)
 

--- a/unsloth_cli/config.py
+++ b/unsloth_cli/config.py
@@ -176,6 +176,9 @@ def _config_error_message(path: Path, error: ValidationError) -> str:
         loc = tuple(err.get("loc") or ())
         if err.get("type") == "extra_forbidden" and loc:
             lines.append(f"  - {_describe_unknown_key(loc)}")
+        elif not loc:
+            got = type(err.get("input")).__name__
+            lines.append(f"  - the top level must be a mapping of keys and sections, not a {got}")
         else:
             field = ".".join(str(part) for part in loc) or "config"
             lines.append(f"  - {field}: {err.get('msg', 'invalid value')}")
@@ -193,12 +196,21 @@ def load_config(path: Optional[Path]) -> Config:
 
     text = path.read_text(encoding = "utf-8")
     if path.suffix.lower() in {".yaml", ".yml"}:
-        data = yaml.safe_load(text) or {}
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as error:
+            raise ConfigError(f"Could not parse config file: {path}\n  - {error}") from None
     else:
         import json
-        data = json.loads(text or "{}")
+        try:
+            data = json.loads(text or "{}")
+        except json.JSONDecodeError as error:
+            raise ConfigError(f"Could not parse config file: {path}\n  - {error}") from None
+
+    if data is None:
+        data = {}
 
     try:
-        return Config(**data)
+        return Config.model_validate(data)
     except ValidationError as error:
         raise ConfigError(_config_error_message(path, error)) from None

--- a/unsloth_cli/config.py
+++ b/unsloth_cli/config.py
@@ -197,8 +197,7 @@ def load_config(path: Optional[Path]) -> Config:
     if not path.exists():
         raise FileNotFoundError(f"Config file not found: {path}")
 
-    # utf-8-sig so a config saved by Notepad (which prepends a BOM) still loads; it is
-    # identical to utf-8 when no BOM is present.
+    # utf-8-sig: drops a Notepad BOM, identical to utf-8 when there is none.
     try:
         text = path.read_text(encoding = "utf-8-sig")
     except UnicodeDecodeError as error:

--- a/unsloth_cli/config.py
+++ b/unsloth_cli/config.py
@@ -5,16 +5,20 @@ from pathlib import Path
 from typing import Literal, Optional, List
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
 class DataConfig(BaseModel):
+    model_config = ConfigDict(extra = "forbid")
+
     dataset: Optional[str] = None
     local_dataset: Optional[List[str]] = None
     format_type: Literal["auto", "alpaca", "chatml", "sharegpt"] = "auto"
 
 
 class TrainingConfig(BaseModel):
+    model_config = ConfigDict(extra = "forbid")
+
     training_type: Literal["lora", "full"] = "lora"
     max_seq_length: int = 2048
     load_in_4bit: bool = True
@@ -34,6 +38,8 @@ class TrainingConfig(BaseModel):
 
 
 class LoraConfig(BaseModel):
+    model_config = ConfigDict(extra = "forbid")
+
     lora_r: int = 64
     lora_alpha: int = 16
     lora_dropout: float = 0.0
@@ -49,6 +55,8 @@ class LoraConfig(BaseModel):
 
 
 class LoggingConfig(BaseModel):
+    model_config = ConfigDict(extra = "forbid")
+
     enable_wandb: bool = False
     wandb_project: str = "unsloth-training"
     wandb_token: Optional[str] = None
@@ -58,6 +66,8 @@ class LoggingConfig(BaseModel):
 
 
 class Config(BaseModel):
+    model_config = ConfigDict(extra = "forbid")
+
     model: Optional[str] = None
     data: DataConfig = Field(default_factory = DataConfig)
     training: TrainingConfig = Field(default_factory = TrainingConfig)
@@ -128,6 +138,50 @@ class Config(BaseModel):
         }
 
 
+class ConfigError(ValueError):
+    pass
+
+
+def _section_for_field(name: str) -> Optional[str]:
+    for section, field_info in Config.model_fields.items():
+        annotation = field_info.annotation
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            if name in annotation.model_fields:
+                return section
+    return None
+
+
+def _describe_unknown_key(loc: tuple) -> str:
+    key = str(loc[-1])
+    parent = str(loc[-2]) if len(loc) > 1 else None
+    where = f"in section '{parent}'" if parent else "at the top level"
+    canonical = key.replace("-", "_")
+    section = _section_for_field(canonical)
+    subject = "it" if canonical == key else f"'{canonical}'"
+
+    if section is not None and section == parent:
+        return f"unknown key '{key}' {where}: did you mean '{canonical}'?"
+    if section is not None:
+        return f"unknown key '{key}' {where}: {subject} belongs under '{section}:'"
+    if canonical in Config.model_fields:
+        if parent is None:
+            return f"unknown key '{key}' {where}: did you mean '{canonical}'?"
+        return f"unknown key '{key}' {where}: {subject} belongs at the top level"
+    return f"unknown key '{key}' {where}"
+
+
+def _config_error_message(path: Path, error: ValidationError) -> str:
+    lines = [f"Invalid config file: {path}"]
+    for err in error.errors():
+        loc = tuple(err.get("loc") or ())
+        if err.get("type") == "extra_forbidden" and loc:
+            lines.append(f"  - {_describe_unknown_key(loc)}")
+        else:
+            field = ".".join(str(part) for part in loc) or "config"
+            lines.append(f"  - {field}: {err.get('msg', 'invalid value')}")
+    return "\n".join(lines)
+
+
 def load_config(path: Optional[Path]) -> Config:
     """Load config from YAML/JSON file, or return defaults if no path given."""
     if not path:
@@ -144,4 +198,7 @@ def load_config(path: Optional[Path]) -> Config:
         import json
         data = json.loads(text or "{}")
 
-    return Config(**data)
+    try:
+        return Config(**data)
+    except ValidationError as error:
+        raise ConfigError(_config_error_message(path, error)) from None

--- a/unsloth_cli/config.py
+++ b/unsloth_cli/config.py
@@ -178,7 +178,10 @@ def _config_error_message(path: Path, error: ValidationError) -> str:
             lines.append(f"  - {_describe_unknown_key(loc)}")
         elif not loc:
             got = type(err.get("input")).__name__
-            lines.append(f"  - the top level must be a mapping of keys and sections, not a {got}")
+            article = "an" if got[:1].lower() in "aeiou" else "a"
+            lines.append(
+                f"  - the top level must be a mapping of keys and sections, not {article} {got}"
+            )
         else:
             field = ".".join(str(part) for part in loc) or "config"
             lines.append(f"  - {field}: {err.get('msg', 'invalid value')}")
@@ -194,7 +197,19 @@ def load_config(path: Optional[Path]) -> Config:
     if not path.exists():
         raise FileNotFoundError(f"Config file not found: {path}")
 
-    text = path.read_text(encoding = "utf-8")
+    # utf-8-sig so a config saved by Notepad (which prepends a BOM) still loads; it is
+    # identical to utf-8 when no BOM is present.
+    try:
+        text = path.read_text(encoding = "utf-8-sig")
+    except UnicodeDecodeError as error:
+        raise ConfigError(
+            f"Could not read config file: {path}\n"
+            f"  - {error}\n"
+            f"  - config files must be UTF-8; re-save it as UTF-8 and try again"
+        ) from None
+    except OSError as error:
+        raise ConfigError(f"Could not read config file: {path}\n  - {error}") from None
+
     if path.suffix.lower() in {".yaml", ".yml"}:
         try:
             data = yaml.safe_load(text)
@@ -203,9 +218,17 @@ def load_config(path: Optional[Path]) -> Config:
     else:
         import json
         try:
-            data = json.loads(text or "{}")
+            data = json.loads(text.strip() or "{}")
         except json.JSONDecodeError as error:
-            raise ConfigError(f"Could not parse config file: {path}\n  - {error}") from None
+            hint = (
+                ""
+                if path.suffix.lower() == ".json"
+                else (
+                    f"\n  - parsed as JSON because of the '{path.suffix}' extension; "
+                    f"name it .yaml or .yml for YAML"
+                )
+            )
+            raise ConfigError(f"Could not parse config file: {path}\n  - {error}{hint}") from None
 
     if data is None:
         data = {}

--- a/unsloth_cli/tests/test_train_config_unknown_keys.py
+++ b/unsloth_cli/tests/test_train_config_unknown_keys.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""`unsloth train --config` used to drop every key it did not recognise, so a
+config that put `learning_rate` at the top level (where the CLI flag lives) or
+spelled a key CLI-style inside a section trained on defaults and said nothing."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from unsloth_cli.config import ConfigError, load_config  # noqa: E402
+
+_SHIPPED_CONFIGS = _REPO_ROOT / "studio" / "backend" / "assets" / "configs"
+
+
+def _write(tmp_path, body: str) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(body, encoding = "utf-8")
+    return path
+
+
+def _train_app():
+    from unsloth_cli.commands.train import train
+
+    app = typer.Typer()
+    app.command()(train)
+    return app
+
+
+def test_top_level_flat_key_is_rejected_and_names_its_section(tmp_path):
+    path = _write(tmp_path, "model: unsloth/Qwen2.5-0.5B\nlearning_rate: 5e-5\n")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(path)
+
+    message = str(excinfo.value)
+    assert "learning_rate" in message
+    assert "training:" in message
+
+
+def test_hyphenated_top_level_key_is_rejected_and_names_its_section(tmp_path):
+    path = _write(tmp_path, "learning-rate: 5e-5\n")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(path)
+
+    message = str(excinfo.value)
+    assert "learning-rate" in message
+    assert "training:" in message
+
+
+def test_key_in_the_wrong_section_is_rejected_and_names_the_right_one(tmp_path):
+    path = _write(tmp_path, "training:\n  lora_r: 8\n")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(path)
+
+    message = str(excinfo.value)
+    assert "lora_r" in message
+    assert "'training'" in message
+    assert "'lora:'" in message
+
+
+def test_cli_spelling_inside_a_section_is_rejected_with_the_yaml_spelling(tmp_path):
+    path = _write(tmp_path, "training:\n  num-epochs: 9\n")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(path)
+
+    message = str(excinfo.value)
+    assert "num-epochs" in message
+    assert "num_epochs" in message
+
+
+def test_valid_config_still_loads(tmp_path):
+    path = _write(
+        tmp_path,
+        "model: unsloth/Qwen2.5-0.5B\n"
+        "data:\n"
+        "  dataset: tatsu-lab/alpaca\n"
+        "training:\n"
+        "  num_epochs: 9\n"
+        "  learning_rate: 5e-5\n"
+        "lora:\n"
+        "  lora_r: 8\n",
+    )
+
+    cfg = load_config(path)
+
+    assert cfg.model == "unsloth/Qwen2.5-0.5B"
+    assert cfg.data.dataset == "tatsu-lab/alpaca"
+    assert cfg.training.num_epochs == 9
+    assert cfg.training.learning_rate == 5e-5
+    assert cfg.lora.lora_r == 8
+
+
+@pytest.mark.parametrize(
+    "name", ["full_finetune.yaml", "lora_text.yaml", "vision_lora.yaml"]
+)
+def test_shipped_example_configs_still_load(name):
+    assert load_config(_SHIPPED_CONFIGS / name).model
+
+
+def test_train_exits_2_instead_of_tracebacking_on_an_unknown_key(tmp_path):
+    path = _write(tmp_path, "model: unsloth/Qwen2.5-0.5B\nlearning_rate: 5e-5\n")
+
+    result = CliRunner().invoke(_train_app(), ["--config", str(path)])
+
+    assert result.exit_code == 2
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "learning_rate" in result.output
+    assert "training:" in result.output

--- a/unsloth_cli/tests/test_train_config_unknown_keys.py
+++ b/unsloth_cli/tests/test_train_config_unknown_keys.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""`unsloth train --config` used to drop every key it did not recognise, so a
-config that put `learning_rate` at the top level (where the CLI flag lives) or
-spelled a key CLI-style inside a section trained on defaults and said nothing."""
+"""`unsloth train --config` used to drop unrecognised keys, so `learning_rate` at the
+top level, or a CLI-style spelling inside a section, trained on defaults in silence."""
 
 from __future__ import annotations
 
@@ -155,9 +154,7 @@ def test_an_empty_config_still_loads_defaults(tmp_path):
 
 
 def test_a_directory_reports_cleanly_instead_of_tracebacking(tmp_path):
-    """`path.read_text` sits outside the parse handlers, so a directory, an
-    unreadable file and a non-UTF-8 file used to escape as raw tracebacks even
-    after the parse step was wrapped."""
+    """read_text sits outside the parse handlers, so this escaped as a raw traceback."""
     directory = tmp_path / "config.yaml"
     directory.mkdir()
 

--- a/unsloth_cli/tests/test_train_config_unknown_keys.py
+++ b/unsloth_cli/tests/test_train_config_unknown_keys.py
@@ -154,6 +154,78 @@ def test_an_empty_config_still_loads_defaults(tmp_path):
     assert load_config(_write(tmp_path, "")).training.num_epochs == 3
 
 
+def test_a_directory_reports_cleanly_instead_of_tracebacking(tmp_path):
+    """`path.read_text` sits outside the parse handlers, so a directory, an
+    unreadable file and a non-UTF-8 file used to escape as raw tracebacks even
+    after the parse step was wrapped."""
+    directory = tmp_path / "config.yaml"
+    directory.mkdir()
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(directory)
+
+    assert "Could not read config file" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("name", "raw"),
+    [
+        ("latin1", "model: café\n".encode("latin-1")),
+        ("utf16", "model: unsloth/Qwen2.5-0.5B\n".encode("utf-16")),
+    ],
+)
+def test_a_non_utf8_config_reports_cleanly_instead_of_tracebacking(tmp_path, name, raw):
+    path = tmp_path / f"{name}.yaml"
+    path.write_bytes(raw)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(path)
+
+    message = str(excinfo.value)
+    assert "Could not read config file" in message
+    assert "UTF-8" in message
+
+
+@pytest.mark.parametrize("suffix", [".yaml", ".json"])
+def test_a_byte_order_mark_written_by_notepad_still_loads(tmp_path, suffix):
+    """Windows editors prepend a UTF-8 BOM; utf-8-sig drops it, plain utf-8 does not."""
+    body = (
+        "model: unsloth/Qwen2.5-0.5B\n"
+        if suffix == ".yaml"
+        else '{"model": "unsloth/Qwen2.5-0.5B"}'
+    )
+    path = tmp_path / f"config{suffix}"
+    path.write_bytes(b"\xef\xbb\xbf" + body.encode("utf-8"))
+
+    assert load_config(path).model == "unsloth/Qwen2.5-0.5B"
+
+
+def test_a_whitespace_only_json_config_loads_defaults_like_yaml_does(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text("   \n\t\n", encoding = "utf-8")
+
+    assert load_config(path).training.num_epochs == 3
+
+
+def test_an_unrecognised_extension_says_it_was_parsed_as_json(tmp_path):
+    path = tmp_path / "config.txt"
+    path.write_text("model: unsloth/Qwen2.5-0.5B\n", encoding = "utf-8")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(path)
+
+    message = str(excinfo.value)
+    assert "parsed as JSON" in message
+    assert ".yaml" in message
+
+
+def test_a_top_level_scalar_reads_grammatically(tmp_path):
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(_write(tmp_path, "42\n"))
+
+    assert "not an int" in str(excinfo.value)
+
+
 @pytest.mark.parametrize(
     "body",
     [

--- a/unsloth_cli/tests/test_train_config_unknown_keys.py
+++ b/unsloth_cli/tests/test_train_config_unknown_keys.py
@@ -118,3 +118,52 @@ def test_train_exits_2_instead_of_tracebacking_on_an_unknown_key(tmp_path):
     assert result.exception is None or isinstance(result.exception, SystemExit)
     assert "learning_rate" in result.output
     assert "training:" in result.output
+
+
+def test_unparseable_yaml_reports_cleanly_instead_of_tracebacking(tmp_path):
+    path = _write(tmp_path, "training:\n  num_epochs: 3\n   learning_rate: 1\n")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(path)
+
+    assert "Could not parse config file" in str(excinfo.value)
+
+
+def test_unparseable_json_reports_cleanly_instead_of_tracebacking(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text("{oops}", encoding = "utf-8")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(path)
+
+    assert "Could not parse config file" in str(excinfo.value)
+
+
+def test_a_top_level_list_reports_cleanly_instead_of_tracebacking(tmp_path):
+    path = _write(tmp_path, "- model: unsloth/Qwen2.5-0.5B\n- model: unsloth/Qwen2.5-1.5B\n")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(path)
+
+    message = str(excinfo.value)
+    assert "must be a mapping" in message
+    assert "list" in message
+
+
+def test_an_empty_config_still_loads_defaults(tmp_path):
+    assert load_config(_write(tmp_path, "")).training.num_epochs == 3
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "training:\n  num_epochs: 3\n   learning_rate: 1\n",
+        "- model: unsloth/Qwen2.5-0.5B\n",
+    ],
+)
+def test_train_exits_2_on_an_unloadable_config(tmp_path, body):
+    result = CliRunner().invoke(_train_app(), ["--config", str(_write(tmp_path, body))])
+
+    assert result.exit_code == 2
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert result.output.startswith("Error: ")

--- a/unsloth_cli/tests/test_train_config_unknown_keys.py
+++ b/unsloth_cli/tests/test_train_config_unknown_keys.py
@@ -104,9 +104,7 @@ def test_valid_config_still_loads(tmp_path):
     assert cfg.lora.lora_r == 8
 
 
-@pytest.mark.parametrize(
-    "name", ["full_finetune.yaml", "lora_text.yaml", "vision_lora.yaml"]
-)
+@pytest.mark.parametrize("name", ["full_finetune.yaml", "lora_text.yaml", "vision_lora.yaml"])
 def test_shipped_example_configs_still_load(name):
     assert load_config(_SHIPPED_CONFIGS / name).model
 


### PR DESCRIPTION
unsloth train --config quietly dropped any key it did not recognise. The run started, trained with default settings, and printed nothing, so the first sign of trouble was the loss curve hours later.

This is easy to hit because the CLI flags are flat while the config file is nested. The flags are spelled --learning-rate, --num-epochs and --lora-r, so the natural guess is to put learning_rate at the top level of the YAML, or to write num-epochs with a hyphen inside a section, or to put lora_r under training instead of lora. All of those parse cleanly today and are thrown away.

The cause is that none of the config models set an extra fields rule, so the default of ignoring unknown keys applied at every level.

All five models now reject unknown keys, and the error names the key and the section it belongs in. A top level learning_rate reports that it belongs under training, and num-epochs inside training suggests num_epochs. The command exits with code 2. A wrong value type now reports the same way instead of showing a raw traceback.

The same path now covers the two other ways a config file can be unloadable, which used to end in a raw traceback and exit code 1. A YAML file with a bad indent, or a JSON file that does not parse, reports "Could not parse config file" with the parser's own line and column. A file whose top level is a list rather than a mapping says so. Both exit with code 2 like every other config error.

This is a breaking change worth calling out. A config carrying a key the models do not define, such as version, will now fail instead of being ignored, and there is no option to turn the check off. The three configs shipped in the repo still load, and a valid config produces the same output as before.

