### PR TITLE
Stop unsloth start from killing a model download that is still running

### DIFF
--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -84,6 +84,7 @@ class Harness:
         fail_every = 0,
         fail_first = 0,
         unmeasured_every = 0,
+        unmeasured_grows = False,
         ready_at = None,
         tail = KEY_LINE,
     ):
@@ -94,6 +95,7 @@ class Harness:
         self.fail_first = fail_first
         self.failures = 0
         self.unmeasured_every = unmeasured_every
+        self.unmeasured_grows = unmeasured_grows
         self.unmeasured = 0
         self.downloaded_bytes = downloaded_bytes
         self.chunk_bytes = chunk_bytes
@@ -134,10 +136,14 @@ class Harness:
                 self.failures += 1
                 raise TimeoutError("the server took too long to answer")
             if self.unmeasured_every and self.polls % self.unmeasured_every == 0:
-                # A scan the server could not finish: 200, zero bytes, cache_measured false.
+                # A scan the server could not finish: 200, cache_measured false. Zero bytes
+                # is the unreadable-root case; a growing count is the readable-root one,
+                # which `snapshot_progress.py` documents as a real lower bound.
                 self.unmeasured += 1
+                if self.unmeasured_grows:
+                    self.downloaded_bytes += self.chunk_bytes
                 return {
-                    "downloaded_bytes": 0,
+                    "downloaded_bytes": self.downloaded_bytes if self.unmeasured_grows else 0,
                     "expected_bytes": EXPECTED_BYTES,
                     "progress": 0,
                     "cache_measured": False,
@@ -308,4 +314,24 @@ def test_polling_keeps_probing_after_a_long_burst_of_errors(monkeypatch):
     assert harness.shutdowns == []
     assert harness.failures >= 6
     assert harness.downloaded_bytes > 0  # it recovered and saw the transfer again
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_growing_unmeasured_reading_still_counts(monkeypatch):
+    # One cache root unreadable while the download lands in another: the backend answers
+    # `cache_measured: false` with the readable root's real, growing byte count. That is a
+    # lower bound, not an unknown, so rejecting it would kill a live transfer at the cap.
+    harness = Harness(
+        monkeypatch,
+        chunk_bytes = 1024**3,
+        unmeasured_every = 1,
+        unmeasured_grows = True,
+        ready_at = 40,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.unmeasured >= 40  # every reading came back unmeasured
     assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 import typer
 
@@ -13,6 +15,7 @@ import unsloth_cli.commands.start as start_cli
 
 BASE = "http://127.0.0.1:8888"
 MODEL = "unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF"
+BASE_MODEL = "unsloth/Qwen3-Coder-30B-A3B-Instruct"
 KEY_LINE = f"{start_cli._START_API_KEY_PREFIX}sk-unsloth-test\n"
 EXPECTED_BYTES = 500 * 1024**3
 STEP_S = 120.0
@@ -82,6 +85,8 @@ class Harness:
         chunk_bytes = 0,
         chatter = None,
         fail_every = 0,
+        unmeasured_every = 0,
+        base_chunk_bytes = 0,
         ready_at = None,
         tail = KEY_LINE,
     ):
@@ -90,6 +95,10 @@ class Harness:
         self.chatter = chatter
         self.fail_every = fail_every
         self.failures = 0
+        self.unmeasured_every = unmeasured_every
+        self.unmeasured = 0
+        self.base_chunk_bytes = base_chunk_bytes
+        self.base_bytes = 0
         self.downloaded_bytes = downloaded_bytes
         self.chunk_bytes = chunk_bytes
         self.ready_at = ready_at
@@ -121,16 +130,43 @@ class Harness:
                 "default_variant": "Q4_K_M",
                 "variants": [{"quant": "Q4_K_M", "download_size_bytes": EXPECTED_BYTES}],
             }
+        if "active-downloads" in url:
+            # The load's other repos, as `hub/routes/inventory.py` reports them.
+            return {
+                "downloads": [
+                    {"repo_id": BASE_MODEL, "state": "downloading"},
+                ]
+                if self.base_chunk_bytes
+                else []
+            }
         if "download-progress" in url:
+            repo = parse_qs(urlparse(url).query).get("repo_id", [""])[0]
+            if repo == BASE_MODEL:
+                self.base_bytes += self.base_chunk_bytes
+                return {
+                    "downloaded_bytes": self.base_bytes,
+                    "expected_bytes": EXPECTED_BYTES,
+                    "cache_measured": True,
+                }
             self.polls += 1
             if self.fail_every and self.polls % self.fail_every == 0:
                 self.failures += 1
                 raise TimeoutError("the server took too long to answer")
+            if self.unmeasured_every and self.polls % self.unmeasured_every == 0:
+                # A scan the server could not finish: 200, zero bytes, cache_measured false.
+                self.unmeasured += 1
+                return {
+                    "downloaded_bytes": 0,
+                    "expected_bytes": EXPECTED_BYTES,
+                    "progress": 0,
+                    "cache_measured": False,
+                }
             self.downloaded_bytes += self.chunk_bytes
             return {
                 "downloaded_bytes": self.downloaded_bytes,
                 "expected_bytes": EXPECTED_BYTES,
                 "progress": self.downloaded_bytes / EXPECTED_BYTES,
+                "cache_measured": True,
             }
         raise AssertionError(f"unexpected request: {method} {url}")
 
@@ -251,3 +287,43 @@ def test_a_transient_progress_error_does_not_blind_the_loop(monkeypatch):
     assert harness.shutdowns == []
     assert harness.failures >= 10
     assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_base_model_download_counts_as_progress(monkeypatch):
+    # `unsloth start --model <LoRA adapter>` fetches the adapter and then its base, which
+    # `core/inference/worker.py` watches as the real bottleneck. The adapter going quiet
+    # while the base is still arriving is not a stalled transfer.
+    harness = Harness(
+        monkeypatch,
+        downloaded_bytes = 4 * 1024**3,
+        chunk_bytes = 0,
+        base_chunk_bytes = 1024**3,
+        ready_at = 40,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.base_bytes > 0
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_an_unmeasured_reading_is_not_progress(monkeypatch, capsys):
+    # `snapshot_progress_response` answers 200 with zero bytes when it cannot finish the
+    # cache scan. Believing it would drop the count to zero, so the next real reading of
+    # the same cached bytes would read as fresh growth and renew the deadline forever.
+    harness = Harness(
+        monkeypatch,
+        downloaded_bytes = 12 * 1024**3,
+        chunk_bytes = 0,
+        unmeasured_every = 2,
+    )
+
+    with pytest.raises(typer.Exit):
+        harness.start()
+
+    assert harness.unmeasured > 0
+    assert harness.shutdowns == [harness.server]
+    assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
+    assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -86,6 +86,7 @@ class Harness:
         unmeasured_every = 0,
         unmeasured_grows = False,
         reset_at = 0,
+        rebound = False,
         ready_at = None,
         tail = KEY_LINE,
     ):
@@ -100,6 +101,7 @@ class Harness:
         self.unmeasured = 0
         self.reset_at = reset_at
         self.reset_seen = False
+        self.rebound = rebound
         self.downloaded_bytes = downloaded_bytes
         self.chunk_bytes = chunk_bytes
         self.ready_at = ready_at
@@ -138,16 +140,34 @@ class Harness:
             ):
                 self.failures += 1
                 raise TimeoutError("the server took too long to answer")
+            if self.rebound:
+                # Two roots, one intermittently unreadable and nothing downloading: the
+                # partial scan sees less than the complete one, over and over.
+                if self.polls % 2 == 0:
+                    return {
+                        "downloaded_bytes": 12 * 1024**3,
+                        "expected_bytes": EXPECTED_BYTES,
+                        "progress": 0,
+                        "cache_measured": True,
+                    }
+                self.unmeasured += 1
+                return {
+                    "downloaded_bytes": 5 * 1024**3,
+                    "expected_bytes": EXPECTED_BYTES,
+                    "progress": 0,
+                    "cache_measured": False,
+                }
             if self.reset_at and self.polls == self.reset_at:
-                # An XET run falling back to HTTP purges the partial and re-fetches, so
-                # the counter legitimately restarts from a lower figure.
+                # An XET run falling back to HTTP purges the partial and re-fetches. A
+                # complete scan reports the smaller figure, so it is a real reset rather
+                # than a root that could not be read.
                 self.downloaded_bytes = self.chunk_bytes
                 self.reset_seen = True
                 return {
                     "downloaded_bytes": self.downloaded_bytes,
                     "expected_bytes": EXPECTED_BYTES,
                     "progress": 0,
-                    "cache_measured": False,
+                    "cache_measured": True,
                 }
             if self.unmeasured_every and self.polls % self.unmeasured_every == 0:
                 # A scan the server could not finish: 200, cache_measured false. Zero bytes
@@ -352,9 +372,9 @@ def test_a_growing_unmeasured_reading_still_counts(monkeypatch):
 
 
 def test_a_restarted_transfer_is_not_held_to_its_old_high_water_mark(monkeypatch):
-    # An unmeasured reading is not a floor. When an XET transfer falls back to HTTP the
-    # partial is purged and the count restarts lower, and requiring it to beat the old
-    # figure first would shut down a download that is running the whole time.
+    # A complete scan is believed in both directions. When an XET transfer falls back to
+    # HTTP the partial is purged and the count restarts lower, and holding the old figure
+    # as a floor would shut down a download that is running the whole time.
     harness = Harness(
         monkeypatch,
         chunk_bytes = 1024**3,
@@ -371,3 +391,18 @@ def test_a_restarted_transfer_is_not_held_to_its_old_high_water_mark(monkeypatch
     assert server is harness.server
     assert harness.shutdowns == []
     assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_partial_scan_rebound_is_not_progress(monkeypatch, capsys):
+    # Nothing is downloading; one cache root simply comes and goes. Letting the partial
+    # scan lower the baseline would turn the next complete scan of the very same bytes
+    # into growth, and a wedged server would be renewed for as long as the mount flaps.
+    harness = Harness(monkeypatch, rebound = True)
+
+    with pytest.raises(typer.Exit):
+        harness.start()
+
+    assert harness.unmeasured > 0
+    assert harness.shutdowns == [harness.server]
+    assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
+    assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -73,7 +73,15 @@ class Harness:
         monkeypatch.setattr(start_cli.atexit, "register", lambda *a, **k: None)
         monkeypatch.setattr(start_cli.subprocess, "Popen", lambda *a, **k: self.server)
 
-    def http_json(self, method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        self,
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if "gguf-variants" in url:
             return {
                 "default_variant": "Q4_K_M",
@@ -89,12 +97,20 @@ class Harness:
             }
         raise AssertionError(f"unexpected request: {method} {url}")
 
-    def log_tail(self, path, lines = 20):
+    def log_tail(
+        self,
+        path,
+        lines = 20,
+    ):
         # The real file the child writes to, so `_log_size` runs its own stat().
         self.log_path = path
         return self.tail
 
-    def studio_healthy(self, base, timeout = 3.0):
+    def studio_healthy(
+        self,
+        base,
+        timeout = 3.0,
+    ):
         self.iterations += 1
         if self.log_chunk and self.log_path is not None:
             with open(self.log_path, "ab") as handle:

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-from urllib.parse import parse_qs, urlparse
-
 import pytest
 import typer
 
@@ -15,7 +13,6 @@ import unsloth_cli.commands.start as start_cli
 
 BASE = "http://127.0.0.1:8888"
 MODEL = "unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF"
-BASE_MODEL = "unsloth/Qwen3-Coder-30B-A3B-Instruct"
 KEY_LINE = f"{start_cli._START_API_KEY_PREFIX}sk-unsloth-test\n"
 EXPECTED_BYTES = 500 * 1024**3
 STEP_S = 120.0
@@ -85,8 +82,8 @@ class Harness:
         chunk_bytes = 0,
         chatter = None,
         fail_every = 0,
+        fail_first = 0,
         unmeasured_every = 0,
-        base_chunk_bytes = 0,
         ready_at = None,
         tail = KEY_LINE,
     ):
@@ -94,11 +91,10 @@ class Harness:
         self.log_path = None
         self.chatter = chatter
         self.fail_every = fail_every
+        self.fail_first = fail_first
         self.failures = 0
         self.unmeasured_every = unmeasured_every
         self.unmeasured = 0
-        self.base_chunk_bytes = base_chunk_bytes
-        self.base_bytes = 0
         self.downloaded_bytes = downloaded_bytes
         self.chunk_bytes = chunk_bytes
         self.ready_at = ready_at
@@ -130,26 +126,11 @@ class Harness:
                 "default_variant": "Q4_K_M",
                 "variants": [{"quant": "Q4_K_M", "download_size_bytes": EXPECTED_BYTES}],
             }
-        if "active-downloads" in url:
-            # The load's other repos, as `hub/routes/inventory.py` reports them.
-            return {
-                "downloads": [
-                    {"repo_id": BASE_MODEL, "state": "downloading"},
-                ]
-                if self.base_chunk_bytes
-                else []
-            }
         if "download-progress" in url:
-            repo = parse_qs(urlparse(url).query).get("repo_id", [""])[0]
-            if repo == BASE_MODEL:
-                self.base_bytes += self.base_chunk_bytes
-                return {
-                    "downloaded_bytes": self.base_bytes,
-                    "expected_bytes": EXPECTED_BYTES,
-                    "cache_measured": True,
-                }
             self.polls += 1
-            if self.fail_every and self.polls % self.fail_every == 0:
+            if self.polls <= self.fail_first or (
+                self.fail_every and self.polls % self.fail_every == 0
+            ):
                 self.failures += 1
                 raise TimeoutError("the server took too long to answer")
             if self.unmeasured_every and self.polls % self.unmeasured_every == 0:
@@ -289,26 +270,6 @@ def test_a_transient_progress_error_does_not_blind_the_loop(monkeypatch):
     assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
 
 
-def test_a_base_model_download_counts_as_progress(monkeypatch):
-    # `unsloth start --model <LoRA adapter>` fetches the adapter and then its base, which
-    # `core/inference/worker.py` watches as the real bottleneck. The adapter going quiet
-    # while the base is still arriving is not a stalled transfer.
-    harness = Harness(
-        monkeypatch,
-        downloaded_bytes = 4 * 1024**3,
-        chunk_bytes = 0,
-        base_chunk_bytes = 1024**3,
-        ready_at = 40,
-    )
-
-    server = harness.start()
-
-    assert server is harness.server
-    assert harness.shutdowns == []
-    assert harness.base_bytes > 0
-    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
-
-
 def test_an_unmeasured_reading_is_not_progress(monkeypatch, capsys):
     # `snapshot_progress_response` answers 200 with zero bytes when it cannot finish the
     # cache scan. Believing it would drop the count to zero, so the next real reading of
@@ -327,3 +288,24 @@ def test_an_unmeasured_reading_is_not_progress(monkeypatch, capsys):
     assert harness.shutdowns == [harness.server]
     assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
     assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_polling_keeps_probing_after_a_long_burst_of_errors(monkeypatch):
+    # Bytes are the only thing separating a live transfer from a wedged server, so a run
+    # of failures may back the reader off but must never retire it: the download it would
+    # abandon is the one this whole path exists to keep alive. Six in a row is past the
+    # point where the reader used to disable itself for the rest of the startup.
+    harness = Harness(
+        monkeypatch,
+        chunk_bytes = 1024**3,
+        fail_first = 6,
+        ready_at = 40,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.failures >= 6
+    assert harness.downloaded_bytes > 0  # it recovered and saw the transfer again
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -16,6 +16,9 @@ MODEL = "unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF"
 KEY_LINE = f"{start_cli._START_API_KEY_PREFIX}sk-unsloth-test\n"
 EXPECTED_BYTES = 500 * 1024**3
 STEP_S = 120.0
+# A loop that keeps resetting its deadline never returns, so stop it and say so rather
+# than hanging the suite. At STEP_S this is ~7 days of fake wall clock.
+MAX_ITERATIONS = 5000
 
 
 class FakeClock:
@@ -50,12 +53,14 @@ class Harness:
         downloaded_bytes = 0,
         chunk_bytes = 0,
         log_chunk = 0,
+        poll_log = False,
         ready_at = None,
         tail = KEY_LINE,
     ):
         self.clock = FakeClock(STEP_S)
         self.log_path = None
         self.log_chunk = log_chunk
+        self.poll_log = poll_log
         self.downloaded_bytes = downloaded_bytes
         self.chunk_bytes = chunk_bytes
         self.ready_at = ready_at
@@ -102,7 +107,7 @@ class Harness:
         path,
         lines = 20,
     ):
-        # The real file the child writes to, so `_log_size` runs its own stat().
+        # The real file the child writes to, so `_ServerLogProgress` reads it for real.
         self.log_path = path
         return self.tail
 
@@ -112,9 +117,22 @@ class Harness:
         timeout = 3.0,
     ):
         self.iterations += 1
+        assert self.iterations <= MAX_ITERATIONS, (
+            f"readiness loop still running after {self.iterations} passes "
+            f"({self.clock.elapsed:.0f}s of fake clock); its deadline never expires"
+        )
         if self.log_chunk and self.log_path is not None:
             with open(self.log_path, "ab") as handle:
-                handle.write(b"." * self.log_chunk)
+                handle.write(b"." * self.log_chunk + b"\n")
+        if self.poll_log and self.log_path is not None:
+            # Byte-for-byte the line `LoggingMiddleware` writes for the `/api/health`
+            # GET this loop just made, timestamp included so every line is new bytes.
+            with open(self.log_path, "ab") as handle:
+                handle.write(
+                    f"2026-09-08 03:{self.iterations // 60:02d}:{self.iterations % 60:02d}"
+                    " [info     ] request_completed              method=GET"
+                    " path=/api/health process_time_ms=0.4 status_code=200\n".encode()
+                )
         if self.ready_at is not None and self.iterations >= self.ready_at:
             self.tail = f"{KEY_LINE}Model loaded: {MODEL}\n"
             return True
@@ -182,3 +200,21 @@ def test_a_load_that_keeps_logging_survives_past_the_idle_cap(monkeypatch):
     assert server is harness.server
     assert harness.shutdowns == []
     assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_the_cli_s_own_health_poll_does_not_keep_a_wedged_server_alive(monkeypatch, capsys):
+    # The loop calls `_studio_healthy` every pass and the server logs that request, so
+    # the log grows on its own. Counting that as progress would make the cap unreachable.
+    harness = Harness(
+        monkeypatch,
+        downloaded_bytes = EXPECTED_BYTES,
+        chunk_bytes = 0,
+        poll_log = True,
+    )
+
+    with pytest.raises(typer.Exit):
+        harness.start()
+
+    assert harness.shutdowns == [harness.server]
+    assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
+    assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""`unsloth start` must not kill an auto-started server whose model is still downloading."""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+import unsloth_cli.commands.start as start_cli
+
+
+BASE = "http://127.0.0.1:8888"
+MODEL = "unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF"
+KEY_LINE = f"{start_cli._START_API_KEY_PREFIX}sk-unsloth-test\n"
+EXPECTED_BYTES = 500 * 1024**3
+STEP_S = 120.0
+
+
+class FakeClock:
+    """monotonic() only moves when the readiness loop sleeps, so runs are deterministic."""
+
+    def __init__(self, step):
+        self.now = 1000.0
+        self.start = 1000.0
+        self.step = step
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += self.step
+
+    @property
+    def elapsed(self):
+        return self.now - self.start
+
+
+class FakePopen:
+    def poll(self):
+        return None
+
+
+class Harness:
+    def __init__(
+        self,
+        monkeypatch,
+        *,
+        downloaded_bytes = 0,
+        chunk_bytes = 0,
+        log_chunk = 0,
+        ready_at = None,
+        tail = KEY_LINE,
+    ):
+        self.clock = FakeClock(STEP_S)
+        self.log_path = None
+        self.log_chunk = log_chunk
+        self.downloaded_bytes = downloaded_bytes
+        self.chunk_bytes = chunk_bytes
+        self.ready_at = ready_at
+        self.tail = tail
+        self.server = FakePopen()
+        self.iterations = 0
+        self.polls = 0
+        self.shutdowns = []
+        monkeypatch.setattr(start_cli, "time", self.clock)
+        monkeypatch.setattr(start_cli, "_http_json", self.http_json)
+        monkeypatch.setattr(start_cli, "_log_tail", self.log_tail)
+        monkeypatch.setattr(start_cli, "_studio_healthy", self.studio_healthy)
+        monkeypatch.setattr(start_cli, "_shutdown_server", self.shutdowns.append)
+        monkeypatch.setattr(start_cli, "_auto_served_server", None)
+        monkeypatch.setattr(start_cli.atexit, "register", lambda *a, **k: None)
+        monkeypatch.setattr(start_cli.subprocess, "Popen", lambda *a, **k: self.server)
+
+    def http_json(self, method, url, token, payload = None, timeout = 30, error = None):
+        if "gguf-variants" in url:
+            return {
+                "default_variant": "Q4_K_M",
+                "variants": [{"quant": "Q4_K_M", "download_size_bytes": EXPECTED_BYTES}],
+            }
+        if "download-progress" in url:
+            self.polls += 1
+            self.downloaded_bytes += self.chunk_bytes
+            return {
+                "downloaded_bytes": self.downloaded_bytes,
+                "expected_bytes": EXPECTED_BYTES,
+                "progress": self.downloaded_bytes / EXPECTED_BYTES,
+            }
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    def log_tail(self, path, lines = 20):
+        # The real file the child writes to, so `_log_size` runs its own stat().
+        self.log_path = path
+        return self.tail
+
+    def studio_healthy(self, base, timeout = 3.0):
+        self.iterations += 1
+        if self.log_chunk and self.log_path is not None:
+            with open(self.log_path, "ab") as handle:
+                handle.write(b"." * self.log_chunk)
+        if self.ready_at is not None and self.iterations >= self.ready_at:
+            self.tail = f"{KEY_LINE}Model loaded: {MODEL}\n"
+            return True
+        return False
+
+    def start(self):
+        return start_cli._start_studio_server(BASE, MODEL, start_cli.LoadOptions())
+
+
+def test_a_live_download_survives_past_the_idle_cap(monkeypatch):
+    harness = Harness(
+        monkeypatch,
+        chunk_bytes = 1024**3,
+        ready_at = 40,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.polls >= 40
+    # The transfer outlives the cap in wall clock: the case that used to be killed.
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_stalled_download_still_times_out(monkeypatch, capsys):
+    harness = Harness(
+        monkeypatch,
+        downloaded_bytes = 12 * 1024**3,
+        chunk_bytes = 0,
+    )
+
+    with pytest.raises(typer.Exit):
+        harness.start()
+
+    assert harness.shutdowns == [harness.server]
+    message = capsys.readouterr().err
+    assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in message
+    assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_server_that_never_downloads_still_times_out(monkeypatch, capsys):
+    harness = Harness(monkeypatch, tail = "starting\n")
+
+    with pytest.raises(typer.Exit):
+        harness.start()
+
+    assert harness.polls == 0
+    assert harness.shutdowns == [harness.server]
+    assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
+    assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_load_that_keeps_logging_survives_past_the_idle_cap(monkeypatch):
+    harness = Harness(
+        monkeypatch,
+        downloaded_bytes = EXPECTED_BYTES,
+        chunk_bytes = 0,
+        log_chunk = 4096,
+        ready_at = 40,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -85,7 +85,7 @@ class Harness:
         fail_first = 0,
         unmeasured_every = 0,
         unmeasured_grows = False,
-        reset_at = 0,
+        vanish_every = 0,
         rebound = False,
         ready_at = None,
         tail = KEY_LINE,
@@ -99,8 +99,8 @@ class Harness:
         self.unmeasured_every = unmeasured_every
         self.unmeasured_grows = unmeasured_grows
         self.unmeasured = 0
-        self.reset_at = reset_at
-        self.reset_seen = False
+        self.vanish_every = vanish_every
+        self.vanished = 0
         self.rebound = rebound
         self.downloaded_bytes = downloaded_bytes
         self.chunk_bytes = chunk_bytes
@@ -157,14 +157,12 @@ class Harness:
                     "progress": 0,
                     "cache_measured": False,
                 }
-            if self.reset_at and self.polls == self.reset_at:
-                # An XET run falling back to HTTP purges the partial and re-fetches. A
-                # complete scan reports the smaller figure, so it is a real reset rather
-                # than a root that could not be read.
-                self.downloaded_bytes = self.chunk_bytes
-                self.reset_seen = True
+            if self.vanish_every and self.polls % self.vanish_every == 0:
+                # A cache mount that disappears cleanly is a MEASURED absence -- no scan
+                # error -- so the count drops to zero and returns on the next remount.
+                self.vanished += 1
                 return {
-                    "downloaded_bytes": self.downloaded_bytes,
+                    "downloaded_bytes": 0,
                     "expected_bytes": EXPECTED_BYTES,
                     "progress": 0,
                     "cache_measured": True,
@@ -371,28 +369,6 @@ def test_a_growing_unmeasured_reading_still_counts(monkeypatch):
     assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
 
 
-def test_a_restarted_transfer_is_not_held_to_its_old_high_water_mark(monkeypatch):
-    # A complete scan is believed in both directions. When an XET transfer falls back to
-    # HTTP the partial is purged and the count restarts lower, and holding the old figure
-    # as a floor would shut down a download that is running the whole time.
-    harness = Harness(
-        monkeypatch,
-        chunk_bytes = 1024**3,
-        unmeasured_every = 1,
-        unmeasured_grows = True,
-        # Far enough in that re-fetching past the old figure takes longer than the cap.
-        reset_at = 20,
-        ready_at = 45,
-    )
-
-    server = harness.start()
-
-    assert harness.reset_seen
-    assert server is harness.server
-    assert harness.shutdowns == []
-    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
-
-
 def test_a_partial_scan_rebound_is_not_progress(monkeypatch, capsys):
     # Nothing is downloading; one cache root simply comes and goes. Letting the partial
     # scan lower the baseline would turn the next complete scan of the very same bytes
@@ -403,6 +379,26 @@ def test_a_partial_scan_rebound_is_not_progress(monkeypatch, capsys):
         harness.start()
 
     assert harness.unmeasured > 0
+    assert harness.shutdowns == [harness.server]
+    assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
+    assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_vanished_cache_mount_is_not_progress(monkeypatch, capsys):
+    # Nothing is downloading; a cache mount just comes and goes. Its absence is reported
+    # as a MEASURED zero, so a baseline that followed readings down would read every
+    # remount as fresh growth and keep a wedged server waiting for as long as it flaps.
+    harness = Harness(
+        monkeypatch,
+        downloaded_bytes = 12 * 1024**3,
+        chunk_bytes = 0,
+        vanish_every = 2,
+    )
+
+    with pytest.raises(typer.Exit):
+        harness.start()
+
+    assert harness.vanished > 0
     assert harness.shutdowns == [harness.server]
     assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
     assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -85,6 +85,7 @@ class Harness:
         fail_first = 0,
         unmeasured_every = 0,
         unmeasured_grows = False,
+        reset_at = 0,
         ready_at = None,
         tail = KEY_LINE,
     ):
@@ -97,6 +98,8 @@ class Harness:
         self.unmeasured_every = unmeasured_every
         self.unmeasured_grows = unmeasured_grows
         self.unmeasured = 0
+        self.reset_at = reset_at
+        self.reset_seen = False
         self.downloaded_bytes = downloaded_bytes
         self.chunk_bytes = chunk_bytes
         self.ready_at = ready_at
@@ -135,6 +138,17 @@ class Harness:
             ):
                 self.failures += 1
                 raise TimeoutError("the server took too long to answer")
+            if self.reset_at and self.polls == self.reset_at:
+                # An XET run falling back to HTTP purges the partial and re-fetches, so
+                # the counter legitimately restarts from a lower figure.
+                self.downloaded_bytes = self.chunk_bytes
+                self.reset_seen = True
+                return {
+                    "downloaded_bytes": self.downloaded_bytes,
+                    "expected_bytes": EXPECTED_BYTES,
+                    "progress": 0,
+                    "cache_measured": False,
+                }
             if self.unmeasured_every and self.polls % self.unmeasured_every == 0:
                 # A scan the server could not finish: 200, cache_measured false. Zero bytes
                 # is the unreadable-root case; a growing count is the readable-root one,
@@ -334,4 +348,26 @@ def test_a_growing_unmeasured_reading_still_counts(monkeypatch):
     assert server is harness.server
     assert harness.shutdowns == []
     assert harness.unmeasured >= 40  # every reading came back unmeasured
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_restarted_transfer_is_not_held_to_its_old_high_water_mark(monkeypatch):
+    # An unmeasured reading is not a floor. When an XET transfer falls back to HTTP the
+    # partial is purged and the count restarts lower, and requiring it to beat the old
+    # figure first would shut down a download that is running the whole time.
+    harness = Harness(
+        monkeypatch,
+        chunk_bytes = 1024**3,
+        unmeasured_every = 1,
+        unmeasured_grows = True,
+        # Far enough in that re-fetching past the old figure takes longer than the cap.
+        reset_at = 20,
+        ready_at = 45,
+    )
+
+    server = harness.start()
+
+    assert harness.reset_seen
+    assert server is harness.server
+    assert harness.shutdowns == []
     assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -21,6 +21,34 @@ STEP_S = 120.0
 MAX_ITERATIONS = 5000
 
 
+def health_poll_line(n):
+    """What `LoggingMiddleware` logs for the `/api/health` GET this loop just made."""
+    return (
+        f"2026-09-08 03:{n // 60:02d}:{n % 60:02d} [info     ] request_completed"
+        "              method=GET path=/api/health process_time_ms=0.4 status_code=200\n"
+    )
+
+
+def failed_health_poll_record(n):
+    """A health probe that raises: the JSON record, then the traceback `with_readable_traceback`
+    echoes on the lines after it, each carrying `loggers.config._TRACEBACK_ECHO_PREFIX`."""
+    return (
+        f'{{"event": "request_failed", "path": "/api/health", "status_code": 500, "n": {n}}}\n'
+        "| Traceback (most recent call last):\n"
+        '|   File "/opt/unsloth/studio/backend/main.py", line 1796, in health\n'
+        "|     return await _hardware_snapshot()\n"
+        "| RuntimeError: hardware probe timed out\n"
+    )
+
+
+def load_watchdog_heartbeat(n):
+    """`start_watchdog`'s on_heartbeat -> `{"type": "status"}` -> the orchestrator's
+    `Subprocess status` INFO line. Timer driven, so it keeps coming while a load is wedged."""
+    return (
+        f"2026-09-08 03:{n // 60:02d}:{n % 60:02d} [info     ] Subprocess status: still loading\n"
+    )
+
+
 class FakeClock:
     """monotonic() only moves when the readiness loop sleeps, so runs are deterministic."""
 
@@ -52,15 +80,16 @@ class Harness:
         *,
         downloaded_bytes = 0,
         chunk_bytes = 0,
-        log_chunk = 0,
-        poll_log = False,
+        chatter = None,
+        fail_every = 0,
         ready_at = None,
         tail = KEY_LINE,
     ):
         self.clock = FakeClock(STEP_S)
         self.log_path = None
-        self.log_chunk = log_chunk
-        self.poll_log = poll_log
+        self.chatter = chatter
+        self.fail_every = fail_every
+        self.failures = 0
         self.downloaded_bytes = downloaded_bytes
         self.chunk_bytes = chunk_bytes
         self.ready_at = ready_at
@@ -94,6 +123,9 @@ class Harness:
             }
         if "download-progress" in url:
             self.polls += 1
+            if self.fail_every and self.polls % self.fail_every == 0:
+                self.failures += 1
+                raise TimeoutError("the server took too long to answer")
             self.downloaded_bytes += self.chunk_bytes
             return {
                 "downloaded_bytes": self.downloaded_bytes,
@@ -121,18 +153,9 @@ class Harness:
             f"readiness loop still running after {self.iterations} passes "
             f"({self.clock.elapsed:.0f}s of fake clock); its deadline never expires"
         )
-        if self.log_chunk and self.log_path is not None:
+        if self.chatter and self.log_path is not None:
             with open(self.log_path, "ab") as handle:
-                handle.write(b"." * self.log_chunk + b"\n")
-        if self.poll_log and self.log_path is not None:
-            # Byte-for-byte the line `LoggingMiddleware` writes for the `/api/health`
-            # GET this loop just made, timestamp included so every line is new bytes.
-            with open(self.log_path, "ab") as handle:
-                handle.write(
-                    f"2026-09-08 03:{self.iterations // 60:02d}:{self.iterations % 60:02d}"
-                    " [info     ] request_completed              method=GET"
-                    " path=/api/health process_time_ms=0.4 status_code=200\n".encode()
-                )
+                handle.write(self.chatter(self.iterations).encode())
         if self.ready_at is not None and self.iterations >= self.ready_at:
             self.tail = f"{KEY_LINE}Model loaded: {MODEL}\n"
             return True
@@ -186,30 +209,22 @@ def test_a_server_that_never_downloads_still_times_out(monkeypatch, capsys):
     assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S
 
 
-def test_a_load_that_keeps_logging_survives_past_the_idle_cap(monkeypatch):
+@pytest.mark.parametrize(
+    "chatter",
+    [
+        pytest.param(health_poll_line, id = "the loop's own health poll"),
+        pytest.param(failed_health_poll_record, id = "traceback echo lines"),
+        pytest.param(load_watchdog_heartbeat, id = "load watchdog heartbeat"),
+    ],
+)
+def test_a_wedged_server_that_keeps_writing_still_times_out(monkeypatch, capsys, chatter):
+    # Every one of these keeps the log growing on a timer while nothing loads, so log
+    # growth cannot stand in for progress: only fresh download bytes may move the deadline.
     harness = Harness(
         monkeypatch,
         downloaded_bytes = EXPECTED_BYTES,
         chunk_bytes = 0,
-        log_chunk = 4096,
-        ready_at = 40,
-    )
-
-    server = harness.start()
-
-    assert server is harness.server
-    assert harness.shutdowns == []
-    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
-
-
-def test_the_cli_s_own_health_poll_does_not_keep_a_wedged_server_alive(monkeypatch, capsys):
-    # The loop calls `_studio_healthy` every pass and the server logs that request, so
-    # the log grows on its own. Counting that as progress would make the cap unreachable.
-    harness = Harness(
-        monkeypatch,
-        downloaded_bytes = EXPECTED_BYTES,
-        chunk_bytes = 0,
-        poll_log = True,
+        chatter = chatter,
     )
 
     with pytest.raises(typer.Exit):
@@ -218,3 +233,21 @@ def test_the_cli_s_own_health_poll_does_not_keep_a_wedged_server_alive(monkeypat
     assert harness.shutdowns == [harness.server]
     assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
     assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_transient_progress_error_does_not_blind_the_loop(monkeypatch):
+    # One slow reading used to disable the reader for good, which would now leave a live
+    # download with no signal at all and kill it at the cap.
+    harness = Harness(
+        monkeypatch,
+        chunk_bytes = 1024**3,
+        fail_every = 3,
+        ready_at = 40,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.failures >= 10
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1086,15 +1086,18 @@ class _ModelDownloadProgress:
                 self.poll()
                 return
             bytes_read = max(0, int(reading.get("downloaded_bytes") or 0))
-            if reading.get("cache_measured") is False and bytes_read == 0:
-                # An unreadable root reports zero, and that is unknown rather than empty
-                # (`snapshot_progress.py`), so believing it would drop the count and let
-                # the next real reading of the same cached bytes look like fresh growth.
-                # Only zero is ignored: any positive reading is a real change and counts
-                # in either direction, the same rule the download manager reconciles on
-                # (`hub/download-manager/progress-reconcile.ts`). A high-water floor would
-                # hide the restart when an XET run falls back to HTTP and re-fetches from
-                # a lower count -- a live transfer this loop must not shut down.
+            if reading.get("cache_measured") is False and bytes_read <= self._downloaded_bytes:
+                # A scan that could not read every root is only a lower bound
+                # (`snapshot_progress.py`), so it may raise this count but never lower it:
+                # letting it lower the count turns the next complete scan of the very same
+                # cached bytes into apparent growth, and recurring mount errors would renew
+                # the deadline forever for a server that is downloading nothing.
+                # A complete scan is believed in both directions, so a transfer that really
+                # does restart lower -- an XET run falling back to HTTP -- is picked up as
+                # soon as any reading measures the whole cache. The asymmetry is deliberate:
+                # the download manager accepts every non-zero change because it is drawing a
+                # bar, where a wrong move costs a repaint, while here it decides whether to
+                # keep waiting, so a false renewal costs an unbounded hang.
                 raise _UnmeasuredReading
             self._downloaded_bytes = bytes_read
             self._failures = 0

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -994,10 +994,6 @@ def _normalized_variant(value: object) -> str:
     return re.sub(r"[^a-z0-9]", "", str(value or "").lower())
 
 
-class _UnmeasuredReading(Exception):
-    """A progress reading the server answered but could not measure well enough to use."""
-
-
 class _ModelDownloadProgress:
     """Best-effort polling of the model download endpoints."""
 
@@ -1085,21 +1081,18 @@ class _ModelDownloadProgress:
                 self._progress_prefix = "/api/models"
                 self.poll()
                 return
-            bytes_read = max(0, int(reading.get("downloaded_bytes") or 0))
-            if reading.get("cache_measured") is False and bytes_read <= self._downloaded_bytes:
-                # A scan that could not read every root is only a lower bound
-                # (`snapshot_progress.py`), so it may raise this count but never lower it:
-                # letting it lower the count turns the next complete scan of the very same
-                # cached bytes into apparent growth, and recurring mount errors would renew
-                # the deadline forever for a server that is downloading nothing.
-                # A complete scan is believed in both directions, so a transfer that really
-                # does restart lower -- an XET run falling back to HTTP -- is picked up as
-                # soon as any reading measures the whole cache. The asymmetry is deliberate:
-                # the download manager accepts every non-zero change because it is drawing a
-                # bar, where a wrong move costs a repaint, while here it decides whether to
-                # keep waiting, so a false renewal costs an unbounded hang.
-                raise _UnmeasuredReading
-            self._downloaded_bytes = bytes_read
+            # The liveness baseline only ever rises. A reading falls for reasons that are
+            # not "bytes left the disk": an incomplete scan reporting a lower bound, a
+            # cache mount vanishing cleanly (`hf_cache_state._safe_is_dir` calls that a
+            # measured absence, not an error), an XET run purging its partial. Following a
+            # reading down would make the recovery back to the same figure look like fresh
+            # growth and renew the deadline for a server that is downloading nothing, and a
+            # flapping mount could do that forever. The cost is that a transfer which truly
+            # restarts is not counted again until it passes its own high mark; that failure
+            # is bounded and says so, where a false renewal is an unbounded wait.
+            self._downloaded_bytes = max(
+                self._downloaded_bytes, max(0, int(reading.get("downloaded_bytes") or 0))
+            )
             self._failures = 0
             self._retry_at = 0.0
             self._display.update(reading)

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -994,6 +994,10 @@ def _normalized_variant(value: object) -> str:
     return re.sub(r"[^a-z0-9]", "", str(value or "").lower())
 
 
+class _UnmeasuredReading(Exception):
+    """A progress reading the server answered but could not actually measure."""
+
+
 class _ModelDownloadProgress:
     """Best-effort polling of the model download endpoints."""
 
@@ -1005,6 +1009,8 @@ class _ModelDownloadProgress:
         self._expected_bytes = 0
         self._downloaded_bytes = 0
         self._failures = 0
+        self._companions_disabled = False
+        self._companion_total = 0
         self._display = _DownloadProgressDisplay()
         self._configured = False
         self._disabled = not _is_hub_model_id(model)
@@ -1078,7 +1084,14 @@ class _ModelDownloadProgress:
                 self._progress_prefix = "/api/models"
                 self.poll()
                 return
-            self._downloaded_bytes = max(0, int(reading.get("downloaded_bytes") or 0))
+            if reading.get("cache_measured") is False:
+                # A scan the server could not complete answers 200 with zero bytes. Taking
+                # that as the truth would drop the count to zero and make the next real
+                # reading of the same cached bytes look like fresh growth.
+                raise _UnmeasuredReading
+            self._downloaded_bytes = (
+                max(0, int(reading.get("downloaded_bytes") or 0)) + self._companion_bytes()
+            )
             self._failures = 0
             self._display.update(reading)
         except Exception:
@@ -1088,6 +1101,50 @@ class _ModelDownloadProgress:
             self._failures += 1
             if self._failures >= _DOWNLOAD_POLL_MAX_FAILURES:
                 self._disabled = True
+
+    def _companion_bytes(self) -> int:
+        """Bytes of every other repo the server is fetching for this load.
+
+        A LoRA start downloads the adapter and then its base model -- `core/inference/
+        worker.py` watches both, calling the base the bottleneck -- so the adapter
+        finishing is not the transfer finishing. Best effort: a server without the
+        endpoint just leaves this at zero.
+        """
+        if self._companions_disabled:
+            return 0
+        try:
+            listing = _http_json(
+                "GET",
+                f"{self._base}{self._progress_prefix}/active-downloads",
+                self._key,
+                timeout = 10,
+            )
+            repos = {
+                str(item.get("repo_id") or "")
+                for item in listing.get("downloads") or []
+                if str(item.get("repo_id") or "") not in ("", self._model)
+            }
+            total = 0
+            for repo in sorted(repos):
+                reading = _http_json(
+                    "GET",
+                    f"{self._base}{self._progress_prefix}/download-progress?"
+                    f"{urlencode({'repo_id': repo})}",
+                    self._key,
+                    timeout = 10,
+                )
+                if reading.get("cache_measured") is not False:
+                    total += max(0, int(reading.get("downloaded_bytes") or 0))
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:  # endpoint absent, and that will not change
+                self._companions_disabled = True
+            return self._companion_total
+        except Exception:
+            # Never let a companion lookup cost us the reading we already have; the last
+            # known total is a constant, and a constant cannot renew the deadline.
+            return self._companion_total
+        self._companion_total = total
+        return total
 
     @property
     def downloaded_bytes(self) -> int:

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -873,8 +873,8 @@ _auto_served_server: Optional[subprocess.Popen] = None
 # advanced, not total elapsed time (see `_start_studio_server`).
 _SERVER_START_TIMEOUT_S = 900
 _DOWNLOAD_POLL_INTERVAL_S = 1.0
-# Consecutive polling errors before the progress reader gives up for good.
-_DOWNLOAD_POLL_MAX_FAILURES = 5
+# Ceiling on the doubling back-off the progress reader uses after a polling error.
+_DOWNLOAD_POLL_MAX_BACKOFF_S = 60.0
 _START_API_KEY_PREFIX = "UNSLOTH_START_API_KEY: "
 _START_API_KEY_MARKER_ENV = "_UNSLOTH_START_API_KEY_MARKER"
 
@@ -1009,8 +1009,7 @@ class _ModelDownloadProgress:
         self._expected_bytes = 0
         self._downloaded_bytes = 0
         self._failures = 0
-        self._companions_disabled = False
-        self._companion_total = 0
+        self._retry_at = 0.0
         self._display = _DownloadProgressDisplay()
         self._configured = False
         self._disabled = not _is_hub_model_id(model)
@@ -1061,6 +1060,8 @@ class _ModelDownloadProgress:
             self._configure()
         if self._disabled:
             return
+        if time.monotonic() < self._retry_at:
+            return
         try:
             if self._variant or "gguf" in self._model.lower():
                 params = urlencode(
@@ -1089,62 +1090,19 @@ class _ModelDownloadProgress:
                 # that as the truth would drop the count to zero and make the next real
                 # reading of the same cached bytes look like fresh growth.
                 raise _UnmeasuredReading
-            self._downloaded_bytes = (
-                max(0, int(reading.get("downloaded_bytes") or 0)) + self._companion_bytes()
-            )
+            self._downloaded_bytes = max(0, int(reading.get("downloaded_bytes") or 0))
             self._failures = 0
+            self._retry_at = 0.0
             self._display.update(reading)
         except Exception:
             # Progress is best-effort and never fails the load, but `_start_studio_server`
-            # reads `downloaded_bytes` to tell a live transfer from a wedged one, so a
-            # single slow response must not blind it for the rest of the startup.
+            # reads `downloaded_bytes` to tell a live transfer from a wedged one. Backing
+            # off keeps a broken endpoint cheap; giving up for good would kill the very
+            # download this exists to protect, so it never stops probing.
             self._failures += 1
-            if self._failures >= _DOWNLOAD_POLL_MAX_FAILURES:
-                self._disabled = True
-
-    def _companion_bytes(self) -> int:
-        """Bytes of every other repo the server is fetching for this load.
-
-        A LoRA start downloads the adapter and then its base model -- `core/inference/
-        worker.py` watches both, calling the base the bottleneck -- so the adapter
-        finishing is not the transfer finishing. Best effort: a server without the
-        endpoint just leaves this at zero.
-        """
-        if self._companions_disabled:
-            return 0
-        try:
-            listing = _http_json(
-                "GET",
-                f"{self._base}{self._progress_prefix}/active-downloads",
-                self._key,
-                timeout = 10,
+            self._retry_at = time.monotonic() + min(
+                2.0**self._failures, _DOWNLOAD_POLL_MAX_BACKOFF_S
             )
-            repos = {
-                str(item.get("repo_id") or "")
-                for item in listing.get("downloads") or []
-                if str(item.get("repo_id") or "") not in ("", self._model)
-            }
-            total = 0
-            for repo in sorted(repos):
-                reading = _http_json(
-                    "GET",
-                    f"{self._base}{self._progress_prefix}/download-progress?"
-                    f"{urlencode({'repo_id': repo})}",
-                    self._key,
-                    timeout = 10,
-                )
-                if reading.get("cache_measured") is not False:
-                    total += max(0, int(reading.get("downloaded_bytes") or 0))
-        except urllib.error.HTTPError as exc:
-            if exc.code == 404:  # endpoint absent, and that will not change
-                self._companions_disabled = True
-            return self._companion_total
-        except Exception:
-            # Never let a companion lookup cost us the reading we already have; the last
-            # known total is a constant, and a constant cannot renew the deadline.
-            return self._companion_total
-        self._companion_total = total
-        return total
 
     @property
     def downloaded_bytes(self) -> int:

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1086,12 +1086,15 @@ class _ModelDownloadProgress:
                 self.poll()
                 return
             bytes_read = max(0, int(reading.get("downloaded_bytes") or 0))
-            if reading.get("cache_measured") is False and bytes_read <= self._downloaded_bytes:
-                # A reading taken while a cache root could not be listed is only ever a
-                # lower bound (see `snapshot_progress.py`), so it counts when it is
-                # strictly bigger and says nothing when it is not: believing a smaller
-                # one would drop the count and let the next real reading of the same
-                # cached bytes look like fresh growth.
+            if reading.get("cache_measured") is False and bytes_read == 0:
+                # An unreadable root reports zero, and that is unknown rather than empty
+                # (`snapshot_progress.py`), so believing it would drop the count and let
+                # the next real reading of the same cached bytes look like fresh growth.
+                # Only zero is ignored: any positive reading is a real change and counts
+                # in either direction, the same rule the download manager reconciles on
+                # (`hub/download-manager/progress-reconcile.ts`). A high-water floor would
+                # hide the restart when an XET run falls back to HTTP and re-fetches from
+                # a lower count -- a live transfer this loop must not shut down.
                 raise _UnmeasuredReading
             self._downloaded_bytes = bytes_read
             self._failures = 0

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -995,7 +995,7 @@ def _normalized_variant(value: object) -> str:
 
 
 class _UnmeasuredReading(Exception):
-    """A progress reading the server answered but could not actually measure."""
+    """A progress reading the server answered but could not measure well enough to use."""
 
 
 class _ModelDownloadProgress:
@@ -1085,12 +1085,15 @@ class _ModelDownloadProgress:
                 self._progress_prefix = "/api/models"
                 self.poll()
                 return
-            if reading.get("cache_measured") is False:
-                # A scan the server could not complete answers 200 with zero bytes. Taking
-                # that as the truth would drop the count to zero and make the next real
-                # reading of the same cached bytes look like fresh growth.
+            bytes_read = max(0, int(reading.get("downloaded_bytes") or 0))
+            if reading.get("cache_measured") is False and bytes_read <= self._downloaded_bytes:
+                # A reading taken while a cache root could not be listed is only ever a
+                # lower bound (see `snapshot_progress.py`), so it counts when it is
+                # strictly bigger and says nothing when it is not: believing a smaller
+                # one would drop the count and let the next real reading of the same
+                # cached bytes look like fresh growth.
                 raise _UnmeasuredReading
-            self._downloaded_bytes = max(0, int(reading.get("downloaded_bytes") or 0))
+            self._downloaded_bytes = bytes_read
             self._failures = 0
             self._retry_at = 0.0
             self._display.update(reading)

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1156,11 +1156,43 @@ def _log_tail(path: Path, lines: int = 20) -> str:
         return "(no server log)"
 
 
-def _log_size(path: Path) -> int:
-    try:
-        return path.stat().st_size
-    except OSError:
-        return 0
+# structlog events the server writes for a request it served. The readiness loop is the
+# only client during startup, so these lines say the CLI polled, not that the model moved.
+_SERVER_POLL_LOG_EVENTS = ("request_completed", "request_failed")
+
+
+def _is_server_poll_line(line: str) -> bool:
+    return any(event in line for event in _SERVER_POLL_LOG_EVENTS)
+
+
+class _ServerLogProgress:
+    """New log bytes that are not the CLI's own polling heartbeat.
+
+    The wait loop below calls `_studio_healthy` on every pass, and the server logs
+    that request, so raw file growth is not evidence the model is moving: it would
+    keep resetting the deadline for a server that is up but permanently wedged.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._offset = 0
+        self._partial = ""
+
+    def poll(self) -> int:
+        try:
+            with self._path.open("rb") as handle:
+                size = handle.seek(0, os.SEEK_END)
+                if size < self._offset:  # log replaced under us; start over
+                    self._offset, self._partial = 0, ""
+                handle.seek(self._offset)
+                chunk = handle.read()
+                self._offset = handle.tell()
+        except OSError:
+            return 0
+        # Progress bars redraw with \r and never emit \n, so both end a line here.
+        parts = re.split(r"[\r\n]", self._partial + chunk.decode("utf-8", errors = "replace"))
+        self._partial = parts.pop()
+        return sum(len(part) for part in parts if not _is_server_poll_line(part))
 
 
 def _redacted_log_tail(path: Path, lines: int = 20) -> str:
@@ -1333,8 +1365,8 @@ def _start_studio_server(
 
     deadline = time.monotonic() + _SERVER_START_TIMEOUT_S
     progress: Optional[_ModelDownloadProgress] = None
+    log_progress = _ServerLogProgress(log_path)
     downloaded_bytes = 0
-    log_size = 0
     early_key_seen = False
     try:
         while time.monotonic() < deadline:
@@ -1360,13 +1392,12 @@ def _start_studio_server(
                     )
             if progress is not None:
                 progress.poll()
-            # Fresh bytes or a growing log mean the child is alive, so the cap measures
-            # idle time rather than the whole download plus load.
-            log_size_now = _log_size(log_path)
+            # Fresh bytes or new log output of its own mean the child is alive, so the
+            # cap measures idle time rather than the whole download plus load.
             bytes_now = progress.downloaded_bytes if progress is not None else 0
-            if bytes_now > downloaded_bytes or log_size_now > log_size:
+            if bytes_now > downloaded_bytes or log_progress.poll() > 0:
                 deadline = time.monotonic() + _SERVER_START_TIMEOUT_S
-            downloaded_bytes, log_size = bytes_now, log_size_now
+            downloaded_bytes = bytes_now
             # New children emit an early key marker, so wait for the final model banner;
             # older children only print the key after load, so fall back to that.
             ready_signal = "Model loaded:" in tail if early_key_seen else "sk-unsloth-" in tail

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -869,10 +869,12 @@ def _http_json(
 # failure paths and the atexit backstop can tear it down without threading a handle
 # through all six agent commands. Only one agent runs per process, so one slot is enough.
 _auto_served_server: Optional[subprocess.Popen] = None
-# Model download + load can be slow, so this caps idle time, not total elapsed time:
-# observed progress pushes the deadline out (see `_start_studio_server`).
+# Model download + load can be slow, so this caps time since the download last
+# advanced, not total elapsed time (see `_start_studio_server`).
 _SERVER_START_TIMEOUT_S = 900
 _DOWNLOAD_POLL_INTERVAL_S = 1.0
+# Consecutive polling errors before the progress reader gives up for good.
+_DOWNLOAD_POLL_MAX_FAILURES = 5
 _START_API_KEY_PREFIX = "UNSLOTH_START_API_KEY: "
 _START_API_KEY_MARKER_ENV = "_UNSLOTH_START_API_KEY_MARKER"
 
@@ -1002,6 +1004,7 @@ class _ModelDownloadProgress:
         self._variant = variant or ""
         self._expected_bytes = 0
         self._downloaded_bytes = 0
+        self._failures = 0
         self._display = _DownloadProgressDisplay()
         self._configured = False
         self._disabled = not _is_hub_model_id(model)
@@ -1076,10 +1079,15 @@ class _ModelDownloadProgress:
                 self.poll()
                 return
             self._downloaded_bytes = max(0, int(reading.get("downloaded_bytes") or 0))
+            self._failures = 0
             self._display.update(reading)
         except Exception:
-            # Progress is best-effort; never fail the load over a polling error.
-            self._disabled = True
+            # Progress is best-effort and never fails the load, but `_start_studio_server`
+            # reads `downloaded_bytes` to tell a live transfer from a wedged one, so a
+            # single slow response must not blind it for the rest of the startup.
+            self._failures += 1
+            if self._failures >= _DOWNLOAD_POLL_MAX_FAILURES:
+                self._disabled = True
 
     @property
     def downloaded_bytes(self) -> int:
@@ -1154,45 +1162,6 @@ def _log_tail(path: Path, lines: int = 20) -> str:
         return "\n".join(path.read_text(encoding = "utf-8", errors = "replace").splitlines()[-lines:])
     except OSError:
         return "(no server log)"
-
-
-# structlog events the server writes for a request it served. The readiness loop is the
-# only client during startup, so these lines say the CLI polled, not that the model moved.
-_SERVER_POLL_LOG_EVENTS = ("request_completed", "request_failed")
-
-
-def _is_server_poll_line(line: str) -> bool:
-    return any(event in line for event in _SERVER_POLL_LOG_EVENTS)
-
-
-class _ServerLogProgress:
-    """New log bytes that are not the CLI's own polling heartbeat.
-
-    The wait loop below calls `_studio_healthy` on every pass, and the server logs
-    that request, so raw file growth is not evidence the model is moving: it would
-    keep resetting the deadline for a server that is up but permanently wedged.
-    """
-
-    def __init__(self, path: Path) -> None:
-        self._path = path
-        self._offset = 0
-        self._partial = ""
-
-    def poll(self) -> int:
-        try:
-            with self._path.open("rb") as handle:
-                size = handle.seek(0, os.SEEK_END)
-                if size < self._offset:  # log replaced under us; start over
-                    self._offset, self._partial = 0, ""
-                handle.seek(self._offset)
-                chunk = handle.read()
-                self._offset = handle.tell()
-        except OSError:
-            return 0
-        # Progress bars redraw with \r and never emit \n, so both end a line here.
-        parts = re.split(r"[\r\n]", self._partial + chunk.decode("utf-8", errors = "replace"))
-        self._partial = parts.pop()
-        return sum(len(part) for part in parts if not _is_server_poll_line(part))
 
 
 def _redacted_log_tail(path: Path, lines: int = 20) -> str:
@@ -1365,7 +1334,6 @@ def _start_studio_server(
 
     deadline = time.monotonic() + _SERVER_START_TIMEOUT_S
     progress: Optional[_ModelDownloadProgress] = None
-    log_progress = _ServerLogProgress(log_path)
     downloaded_bytes = 0
     early_key_seen = False
     try:
@@ -1392,10 +1360,13 @@ def _start_studio_server(
                     )
             if progress is not None:
                 progress.poll()
-            # Fresh bytes or new log output of its own mean the child is alive, so the
-            # cap measures idle time rather than the whole download plus load.
+            # Fresh bytes are the one unambiguous sign the child is moving, so the cap
+            # measures time since the transfer last advanced rather than total elapsed.
+            # Server log growth deliberately does NOT count: the loop's own health poll,
+            # echoed tracebacks and the loader's watchdog heartbeat all keep the log
+            # growing while nothing loads, which would make this deadline unreachable.
             bytes_now = progress.downloaded_bytes if progress is not None else 0
-            if bytes_now > downloaded_bytes or log_progress.poll() > 0:
+            if bytes_now > downloaded_bytes:
                 deadline = time.monotonic() + _SERVER_START_TIMEOUT_S
             downloaded_bytes = bytes_now
             # New children emit an early key marker, so wait for the final model banner;

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -869,7 +869,8 @@ def _http_json(
 # failure paths and the atexit backstop can tear it down without threading a handle
 # through all six agent commands. Only one agent runs per process, so one slot is enough.
 _auto_served_server: Optional[subprocess.Popen] = None
-# Model download + load can be slow; give the auto-started server room before giving up.
+# Model download + load can be slow, so this caps idle time, not total elapsed time:
+# observed progress pushes the deadline out (see `_start_studio_server`).
 _SERVER_START_TIMEOUT_S = 900
 _DOWNLOAD_POLL_INTERVAL_S = 1.0
 _START_API_KEY_PREFIX = "UNSLOTH_START_API_KEY: "
@@ -1000,6 +1001,7 @@ class _ModelDownloadProgress:
         self._model = model
         self._variant = variant or ""
         self._expected_bytes = 0
+        self._downloaded_bytes = 0
         self._display = _DownloadProgressDisplay()
         self._configured = False
         self._disabled = not _is_hub_model_id(model)
@@ -1073,10 +1075,15 @@ class _ModelDownloadProgress:
                 self._progress_prefix = "/api/models"
                 self.poll()
                 return
+            self._downloaded_bytes = max(0, int(reading.get("downloaded_bytes") or 0))
             self._display.update(reading)
         except Exception:
             # Progress is best-effort; never fail the load over a polling error.
             self._disabled = True
+
+    @property
+    def downloaded_bytes(self) -> int:
+        return self._downloaded_bytes
 
     def close(self) -> None:
         self._display.close()
@@ -1147,6 +1154,13 @@ def _log_tail(path: Path, lines: int = 20) -> str:
         return "\n".join(path.read_text(encoding = "utf-8", errors = "replace").splitlines()[-lines:])
     except OSError:
         return "(no server log)"
+
+
+def _log_size(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
 
 
 def _redacted_log_tail(path: Path, lines: int = 20) -> str:
@@ -1319,6 +1333,8 @@ def _start_studio_server(
 
     deadline = time.monotonic() + _SERVER_START_TIMEOUT_S
     progress: Optional[_ModelDownloadProgress] = None
+    downloaded_bytes = 0
+    log_size = 0
     early_key_seen = False
     try:
         while time.monotonic() < deadline:
@@ -1344,6 +1360,13 @@ def _start_studio_server(
                     )
             if progress is not None:
                 progress.poll()
+            # Fresh bytes or a growing log mean the child is alive, so the cap measures
+            # idle time rather than the whole download plus load.
+            log_size_now = _log_size(log_path)
+            bytes_now = progress.downloaded_bytes if progress is not None else 0
+            if bytes_now > downloaded_bytes or log_size_now > log_size:
+                deadline = time.monotonic() + _SERVER_START_TIMEOUT_S
+            downloaded_bytes, log_size = bytes_now, log_size_now
             # New children emit an early key marker, so wait for the final model banner;
             # older children only print the key after load, so fall back to that.
             ready_signal = "Model loaded:" in tail if early_key_seen else "sk-unsloth-" in tail
@@ -1359,7 +1382,8 @@ def _start_studio_server(
             progress.close()
     _shutdown_auto_served()
     _fail(
-        f"The Unsloth server didn't become ready within {_SERVER_START_TIMEOUT_S}s. See {log_path}."
+        "The Unsloth server didn't become ready and made no progress for "
+        f"{_SERVER_START_TIMEOUT_S}s. See {log_path}."
     )
 
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -3935,6 +3935,8 @@ def test_start_studio_server_polls_progress_from_early_key(monkeypatch):
     created = []
 
     class FakeProgress:
+        downloaded_bytes = 0
+
         def __init__(self, base, key, model, variant):
             created.append((base, key, model, variant, "created"))
 


### PR DESCRIPTION
unsloth start gives the server it launches 15 minutes to become ready. If the model is not on disk yet, the download alone can take longer than that on a large model or a slow connection. The command then prints that the server did not become ready and stops the server it just started, while its own progress bar is still moving.

The cause is that the deadline was set once before the wait loop and never moved, so the 15 minutes had to cover the download and the load together. The loop already checks the download progress on every pass, it just did not use it for anything.

Now that progress counts as a sign of life. When the downloaded bytes go up, or the server log grows, the deadline moves forward. So the 15 minutes measures time since the last sign of progress rather than total time. The attach path already allows an hour for the same load, so this brings the two closer together.

A server that is genuinely stuck still fails at the same limit, and the message now says it made no progress rather than that it ran out of time.

To reproduce, run unsloth start with a model you have not downloaded that is large enough to take more than 15 minutes to fetch.


### Known gaps

Two cases where a live download can still hit the cap. Neither is a regression -- `main` ends both at the same 900s -- and each needs a signal the CLI cannot currently see:

- **A LoRA adapter's base model.** The base transfer happens inside the inference worker, which registers no hub download job, so no endpoint the CLI polls reports its bytes. Covering it means resolving the adapter's base from `adapter_config.json` and polling that repo too.
- **A version-skewed child.** When `unsloth run` re-execs into an environment that does not emit the early key marker, there is no key to authenticate a progress poll with, so no byte signal exists at all. The only alternative signal is server log growth, which this PR removes because it cannot be told apart from the readiness loop's own health poll, echoed tracebacks, or the loader's watchdog heartbeat.
