### PR TITLE
Studio: fix sending an image with no caption on Anthropic

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2084,7 +2084,7 @@ class ExternalProviderClient:
                 #   https://platform.claude.com/docs/en/build-with-claude/vision)
                 anthropic_parts: list[dict[str, Any]] = []
                 for part in content:
-                    if part.get("type") == "text":
+                    if part.get("type") == "text" and part.get("text"):
                         anthropic_parts.append({"type": "text", "text": part["text"]})
                     elif part.get("type") == "compaction":
                         # Round-trip a prior turn's compaction block back onto this

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -183,17 +183,7 @@ _GEMINI3_PRO = re.compile(r"^gemini-3(?:\.\d+)?-pro")
 
 
 def _anthropic_text_is_sendable(value: Any) -> bool:
-    """Whether a text block's ``text`` is something Anthropic will accept.
-
-    ``TextBlockParam.text`` is ``minLength: 1``, and the API additionally rejects a
-    block holding nothing but whitespace ("text content blocks must contain
-    non-whitespace text"). Truthiness alone is not enough: the composer joins its
-    text parts with "\\n", so a turn carrying two empty caption parts arrives here
-    as "\\n", which is truthy and still 400s.
-
-    Non-string values are left to the API to judge rather than silently dropped,
-    so this only ever removes a block that could not have been sent anyway.
-    """
+    """Anthropic rejects empty and whitespace-only text; the composer joins with "\\n"."""
     if isinstance(value, str):
         return bool(value.strip())
     return bool(value)
@@ -2281,13 +2271,7 @@ class ExternalProviderClient:
                     if _blocks:
                         filtered.append({"role": "assistant", "content": _blocks})
                     continue
-                # Same rule as the list form above, for the string shape. A stored
-                # turn whose content was empty reaches us as content:"" (see the
-                # runtime's placeholder), and Anthropic reads a plain string as one
-                # text block -- so forwarding it 400s exactly like the empty block
-                # did. With prompt caching on it is worse: the tail breakpoint wraps
-                # the empty string into a text block carrying cache_control, which
-                # the API rejects a second time.
+                # A plain string is one text block, so an empty one 400s too.
                 if isinstance(content, str) and not content.strip():
                     continue
                 filtered.append(msg)

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2245,7 +2245,9 @@ class ExternalProviderClient:
                 ):
                     _text_content = msg.get("content")
                     _blocks: list[dict[str, Any]] = []
-                    if isinstance(_text_content, str) and _text_content:
+                    if isinstance(_text_content, str) and _anthropic_text_is_sendable(
+                        _text_content
+                    ):
                         _blocks.append({"type": "text", "text": _text_content})
                     for _tc in msg["tool_calls"]:
                         if not isinstance(_tc, dict):

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -182,6 +182,23 @@ _GEMINI3_FAMILY = re.compile(r"^gemini-3(?:\.\d+)?-")
 _GEMINI3_PRO = re.compile(r"^gemini-3(?:\.\d+)?-pro")
 
 
+def _anthropic_text_is_sendable(value: Any) -> bool:
+    """Whether a text block's ``text`` is something Anthropic will accept.
+
+    ``TextBlockParam.text`` is ``minLength: 1``, and the API additionally rejects a
+    block holding nothing but whitespace ("text content blocks must contain
+    non-whitespace text"). Truthiness alone is not enough: the composer joins its
+    text parts with "\\n", so a turn carrying two empty caption parts arrives here
+    as "\\n", which is truthy and still 400s.
+
+    Non-string values are left to the API to judge rather than silently dropped,
+    so this only ever removes a block that could not have been sent anyway.
+    """
+    if isinstance(value, str):
+        return bool(value.strip())
+    return bool(value)
+
+
 def _anthropic_sampling_params_removed(model: str) -> bool:
     """Whether Anthropic rejects non-default sampling params for ``model``."""
     normalized = model.strip().lower()
@@ -2084,7 +2101,7 @@ class ExternalProviderClient:
                 #   https://platform.claude.com/docs/en/build-with-claude/vision)
                 anthropic_parts: list[dict[str, Any]] = []
                 for part in content:
-                    if part.get("type") == "text" and part.get("text"):
+                    if part.get("type") == "text" and _anthropic_text_is_sendable(part.get("text")):
                         anthropic_parts.append({"type": "text", "text": part["text"]})
                     elif part.get("type") == "compaction":
                         # Round-trip a prior turn's compaction block back onto this
@@ -2263,6 +2280,15 @@ class ExternalProviderClient:
                         )
                     if _blocks:
                         filtered.append({"role": "assistant", "content": _blocks})
+                    continue
+                # Same rule as the list form above, for the string shape. A stored
+                # turn whose content was empty reaches us as content:"" (see the
+                # runtime's placeholder), and Anthropic reads a plain string as one
+                # text block -- so forwarding it 400s exactly like the empty block
+                # did. With prompt caching on it is worse: the tail breakpoint wraps
+                # the empty string into a text block carrying cache_control, which
+                # the API rejects a second time.
+                if isinstance(content, str) and not content.strip():
                     continue
                 filtered.append(msg)
 

--- a/studio/backend/tests/test_anthropic_empty_text_block.py
+++ b/studio/backend/tests/test_anthropic_empty_text_block.py
@@ -21,14 +21,18 @@ def _drive(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
-def _capture(monkeypatch, messages) -> dict:
+def _capture(
+    monkeypatch,
+    messages,
+    caching = False,
+) -> dict:
     captured: dict = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["body"] = json.loads(request.content.decode("utf-8"))
         return httpx.Response(
             200,
-            content = b"event: message_stop\n" b'data: {"type": "message_stop"}\n\n',
+            content = b'event: message_stop\ndata: {"type": "message_stop"}\n\n',
             headers = {"content-type": "text/event-stream"},
         )
 
@@ -50,7 +54,7 @@ def _capture(monkeypatch, messages) -> dict:
             temperature = 0.7,
             top_p = 0.95,
             max_tokens = 32,
-            enable_prompt_caching = False,
+            enable_prompt_caching = caching,
         ):
             pass
         await client.close()
@@ -117,3 +121,118 @@ def test_text_only_empty_block_drops_the_whole_message(monkeypatch):
         ],
     )
     assert captured["body"]["messages"] == [{"role": "user", "content": "but THIS one is fine"}]
+
+
+# Anthropic rejects a whitespace-only text block as well as an empty one, with
+# "text content blocks must contain non-whitespace text". Studio reaches that shape
+# on its own: collectTextParts joins with "\n", so a turn carrying two empty caption
+# parts serialises to "\n" rather than "".
+
+
+def test_whitespace_only_caption_dropped_from_image_turn(monkeypatch):
+    captured = _capture(
+        monkeypatch,
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "\n"},
+                    {"type": "image_url", "image_url": {"url": _IMAGE_DATA_URI}},
+                ],
+            }
+        ],
+    )
+    parts = captured["body"]["messages"][0]["content"]
+    assert [p["type"] for p in parts] == ["image"], parts
+
+
+def test_caption_keeps_its_own_surrounding_whitespace(monkeypatch):
+    # Only the DECISION uses strip(); a real caption goes out verbatim.
+    captured = _capture(
+        monkeypatch,
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "  what is this?  "},
+                    {"type": "image_url", "image_url": {"url": _IMAGE_DATA_URI}},
+                ],
+            }
+        ],
+    )
+    parts = captured["body"]["messages"][0]["content"]
+    assert parts[0] == {"type": "text", "text": "  what is this?  "}
+
+
+def test_empty_string_content_message_dropped(monkeypatch):
+    # The string shape of the same defect. The runtime substitutes an empty text
+    # part for a stored message with no content, which serialises to "" -- and
+    # Anthropic reads a plain string as one text block.
+    captured = _capture(
+        monkeypatch,
+        [
+            {"role": "user", "content": ""},
+            {"role": "user", "content": "   "},
+            {"role": "user", "content": "but THIS one is fine"},
+        ],
+    )
+    assert captured["body"]["messages"] == [{"role": "user", "content": "but THIS one is fine"}]
+
+
+def test_dropping_the_last_message_moves_the_cache_breakpoint(monkeypatch):
+    # With caching on, the tail breakpoint lands on the LAST surviving message. If
+    # the empty turn survived, cache_control would sit on an empty text block, which
+    # Anthropic rejects separately ("cache_control cannot be set for empty text
+    # blocks").
+    captured = _capture(
+        monkeypatch,
+        [
+            {"role": "user", "content": "keep me"},
+            {"role": "user", "content": [{"type": "text", "text": ""}]},
+        ],
+        caching = True,
+    )
+    messages = captured["body"]["messages"]
+    assert len(messages) == 1
+    last_block = messages[-1]["content"][-1]
+    assert last_block["type"] == "text"
+    assert last_block["text"] == "keep me"
+    assert last_block.get("cache_control") is not None
+
+
+def test_cached_image_only_turn_marks_the_image(monkeypatch):
+    captured = _capture(
+        monkeypatch,
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "image_url", "image_url": {"url": _IMAGE_DATA_URI}},
+                ],
+            }
+        ],
+        caching = True,
+    )
+    parts = captured["body"]["messages"][0]["content"]
+    assert [p["type"] for p in parts] == ["image"], parts
+    assert parts[-1].get("cache_control") is not None
+
+
+def test_missing_text_key_does_not_raise(monkeypatch):
+    # `part["text"]` used to KeyError here, taking the whole request down rather
+    # than dropping one unusable block.
+    captured = _capture(
+        monkeypatch,
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text"},
+                    {"type": "image_url", "image_url": {"url": _IMAGE_DATA_URI}},
+                ],
+            }
+        ],
+    )
+    parts = captured["body"]["messages"][0]["content"]
+    assert [p["type"] for p in parts] == ["image"], parts

--- a/studio/backend/tests/test_anthropic_empty_text_block.py
+++ b/studio/backend/tests/test_anthropic_empty_text_block.py
@@ -108,8 +108,7 @@ def test_captioned_image_keeps_its_text_block(monkeypatch):
 
 
 def test_text_only_empty_block_drops_the_whole_message(monkeypatch):
-    # Nothing usable survives, and an empty content array 400s with
-    # "at least one block is required".
+    # Nothing usable survives, and an empty content array 400s too.
     captured = _capture(
         monkeypatch,
         [

--- a/studio/backend/tests/test_anthropic_empty_text_block.py
+++ b/studio/backend/tests/test_anthropic_empty_text_block.py
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""An image-only user turn must not carry an empty text block to Anthropic.
-
-The Messages API 400s with "messages: text content blocks must be
-non-empty", so `{"type":"text","text":""}` has to be dropped before the
-wire the way the Gemini translator already drops it.
-"""
+"""An image-only user turn must not carry an empty text block to Anthropic."""
 
 import asyncio
 import json
@@ -123,10 +118,7 @@ def test_text_only_empty_block_drops_the_whole_message(monkeypatch):
     assert captured["body"]["messages"] == [{"role": "user", "content": "but THIS one is fine"}]
 
 
-# Anthropic rejects a whitespace-only text block as well as an empty one, with
-# "text content blocks must contain non-whitespace text". Studio reaches that shape
-# on its own: collectTextParts joins with "\n", so a turn carrying two empty caption
-# parts serialises to "\n" rather than "".
+# collectTextParts joins with "\n", so two empty caption parts serialise to "\n".
 
 
 def test_whitespace_only_caption_dropped_from_image_turn(monkeypatch):
@@ -165,9 +157,7 @@ def test_caption_keeps_its_own_surrounding_whitespace(monkeypatch):
 
 
 def test_empty_string_content_message_dropped(monkeypatch):
-    # The string shape of the same defect. The runtime substitutes an empty text
-    # part for a stored message with no content, which serialises to "" -- and
-    # Anthropic reads a plain string as one text block.
+    # Anthropic reads a plain string as one text block, so "" 400s the same way.
     captured = _capture(
         monkeypatch,
         [
@@ -180,10 +170,7 @@ def test_empty_string_content_message_dropped(monkeypatch):
 
 
 def test_dropping_the_last_message_moves_the_cache_breakpoint(monkeypatch):
-    # With caching on, the tail breakpoint lands on the LAST surviving message. If
-    # the empty turn survived, cache_control would sit on an empty text block, which
-    # Anthropic rejects separately ("cache_control cannot be set for empty text
-    # blocks").
+    # cache_control on an empty text block is rejected separately.
     captured = _capture(
         monkeypatch,
         [
@@ -220,8 +207,7 @@ def test_cached_image_only_turn_marks_the_image(monkeypatch):
 
 
 def test_missing_text_key_does_not_raise(monkeypatch):
-    # `part["text"]` used to KeyError here, taking the whole request down rather
-    # than dropping one unusable block.
+    # `part["text"]` used to KeyError, taking down the whole request.
     captured = _capture(
         monkeypatch,
         [

--- a/studio/backend/tests/test_anthropic_empty_text_block.py
+++ b/studio/backend/tests/test_anthropic_empty_text_block.py
@@ -206,6 +206,55 @@ def test_cached_image_only_turn_marks_the_image(monkeypatch):
     assert parts[-1].get("cache_control") is not None
 
 
+def test_whitespace_only_assistant_text_beside_a_tool_call(monkeypatch):
+    # A model that emits a newline before calling a tool: the whitespace block 400s
+    # and takes the tool_use with it.
+    captured = _capture(
+        monkeypatch,
+        [
+            {"role": "user", "content": "q"},
+            {
+                "role": "assistant",
+                "content": "  \n ",
+                "tool_calls": [
+                    {
+                        "id": "toolu_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "42"},
+        ],
+    )
+    blocks = captured["body"]["messages"][1]["content"]
+    assert [b["type"] for b in blocks] == ["tool_use"], blocks
+
+
+def test_real_assistant_text_beside_a_tool_call_survives(monkeypatch):
+    captured = _capture(
+        monkeypatch,
+        [
+            {"role": "user", "content": "q"},
+            {
+                "role": "assistant",
+                "content": "calling f",
+                "tool_calls": [
+                    {
+                        "id": "toolu_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "42"},
+        ],
+    )
+    blocks = captured["body"]["messages"][1]["content"]
+    assert blocks[0] == {"type": "text", "text": "calling f"}
+    assert blocks[1]["type"] == "tool_use"
+
+
 def test_missing_text_key_does_not_raise(monkeypatch):
     # `part["text"]` used to KeyError, taking down the whole request.
     captured = _capture(

--- a/studio/backend/tests/test_anthropic_empty_text_block.py
+++ b/studio/backend/tests/test_anthropic_empty_text_block.py
@@ -117,6 +117,4 @@ def test_text_only_empty_block_drops_the_whole_message(monkeypatch):
             {"role": "user", "content": "but THIS one is fine"},
         ],
     )
-    assert captured["body"]["messages"] == [
-        {"role": "user", "content": "but THIS one is fine"}
-    ]
+    assert captured["body"]["messages"] == [{"role": "user", "content": "but THIS one is fine"}]

--- a/studio/backend/tests/test_anthropic_empty_text_block.py
+++ b/studio/backend/tests/test_anthropic_empty_text_block.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""An image-only user turn must not carry an empty text block to Anthropic."""
-
 import asyncio
 import json
 
@@ -118,9 +116,6 @@ def test_text_only_empty_block_drops_the_whole_message(monkeypatch):
     assert captured["body"]["messages"] == [{"role": "user", "content": "but THIS one is fine"}]
 
 
-# collectTextParts joins with "\n", so two empty caption parts serialise to "\n".
-
-
 def test_whitespace_only_caption_dropped_from_image_turn(monkeypatch):
     captured = _capture(
         monkeypatch,
@@ -157,7 +152,6 @@ def test_caption_keeps_its_own_surrounding_whitespace(monkeypatch):
 
 
 def test_empty_string_content_message_dropped(monkeypatch):
-    # Anthropic reads a plain string as one text block, so "" 400s the same way.
     captured = _capture(
         monkeypatch,
         [
@@ -207,8 +201,7 @@ def test_cached_image_only_turn_marks_the_image(monkeypatch):
 
 
 def test_whitespace_only_assistant_text_beside_a_tool_call(monkeypatch):
-    # A model that emits a newline before calling a tool: the whitespace block 400s
-    # and takes the tool_use with it.
+    # The whitespace block 400s and takes the tool_use down with it.
     captured = _capture(
         monkeypatch,
         [

--- a/studio/backend/tests/test_anthropic_empty_text_block.py
+++ b/studio/backend/tests/test_anthropic_empty_text_block.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""An image-only user turn must not carry an empty text block to Anthropic.
+
+The Messages API 400s with "messages: text content blocks must be
+non-empty", so `{"type":"text","text":""}` has to be dropped before the
+wire the way the Gemini translator already drops it.
+"""
+
+import asyncio
+import json
+
+import httpx
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import ExternalProviderClient
+
+
+def _drive(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _capture(monkeypatch, messages) -> dict:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content = b"event: message_stop\n" b'data: {"type": "message_stop"}\n\n',
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    monkeypatch.setattr(
+        ep_mod,
+        "_http_client",
+        httpx.AsyncClient(transport = httpx.MockTransport(handler)),
+    )
+
+    async def run():
+        client = ExternalProviderClient(
+            provider_type = "anthropic",
+            base_url = "https://api.anthropic.com/v1",
+            api_key = "sk-ant-test",
+        )
+        async for _ in client._stream_anthropic(
+            messages = messages,
+            model = "claude-opus-4-7",
+            temperature = 0.7,
+            top_p = 0.95,
+            max_tokens = 32,
+            enable_prompt_caching = False,
+        ):
+            pass
+        await client.close()
+
+    _drive(run())
+    return captured
+
+
+_IMAGE_DATA_URI = "data:image/png;base64,aGVsbG8="
+
+
+def test_empty_text_block_dropped_from_image_only_turn(monkeypatch):
+    captured = _capture(
+        monkeypatch,
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "image_url", "image_url": {"url": _IMAGE_DATA_URI}},
+                ],
+            }
+        ],
+    )
+    parts = captured["body"]["messages"][0]["content"]
+    assert not [p for p in parts if p.get("type") == "text"], parts
+    assert parts == [
+        {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "aGVsbG8=",
+            },
+        }
+    ]
+
+
+def test_captioned_image_keeps_its_text_block(monkeypatch):
+    captured = _capture(
+        monkeypatch,
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image_url", "image_url": {"url": _IMAGE_DATA_URI}},
+                ],
+            }
+        ],
+    )
+    parts = captured["body"]["messages"][0]["content"]
+    assert parts[0] == {"type": "text", "text": "what is this?"}
+    assert parts[1]["type"] == "image"
+
+
+def test_text_only_empty_block_drops_the_whole_message(monkeypatch):
+    # Nothing usable survives, and an empty content array 400s with
+    # "at least one block is required".
+    captured = _capture(
+        monkeypatch,
+        [
+            {"role": "user", "content": [{"type": "text", "text": ""}]},
+            {"role": "user", "content": "but THIS one is fine"},
+        ],
+    )
+    assert captured["body"]["messages"] == [
+        {"role": "user", "content": "but THIS one is fine"}
+    ]

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1191,9 +1191,10 @@ function buildReplayContent(
   textContent: string,
   imageParts: Array<{ type: "image_url"; image_url: { url: string } }>,
 ): OpenAIMessageContent {
-  return imageParts.length > 0
+  if (imageParts.length === 0) return textContent;
+  return textContent
     ? [{ type: "text", text: textContent }, ...imageParts]
-    : textContent;
+    : imageParts;
 }
 
 function collectAssistantTextThoughtSignature(

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1192,9 +1192,15 @@ function buildReplayContent(
   imageParts: Array<{ type: "image_url"; image_url: { url: string } }>,
 ): OpenAIMessageContent {
   if (imageParts.length === 0) return textContent;
-  return textContent
+  // trim() only decides whether the block is worth sending; the block itself keeps
+  // the text verbatim. Anthropic rejects a whitespace-only text block as well as an
+  // empty one, and collectTextParts joins with "\n", so a turn with two empty text
+  // parts and an image arrives here as "\n" -- truthy, and still rejected.
+  // Spread rather than return imageParts itself: the caller's array must not become
+  // the message content it passed in.
+  return textContent.trim()
     ? [{ type: "text", text: textContent }, ...imageParts]
-    : imageParts;
+    : [...imageParts];
 }
 
 function collectAssistantTextThoughtSignature(

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1192,12 +1192,8 @@ function buildReplayContent(
   imageParts: Array<{ type: "image_url"; image_url: { url: string } }>,
 ): OpenAIMessageContent {
   if (imageParts.length === 0) return textContent;
-  // trim() only decides whether the block is worth sending; the block itself keeps
-  // the text verbatim. Anthropic rejects a whitespace-only text block as well as an
-  // empty one, and collectTextParts joins with "\n", so a turn with two empty text
-  // parts and an image arrives here as "\n" -- truthy, and still rejected.
-  // Spread rather than return imageParts itself: the caller's array must not become
-  // the message content it passed in.
+  // Anthropic rejects whitespace-only text, and collectTextParts joins with "\n".
+  // Spread: the caller's array must not become the message content.
   return textContent.trim()
     ? [{ type: "text", text: textContent }, ...imageParts]
     : [...imageParts];

--- a/studio/frontend/tests/uncaptioned-image-empty-text-block.test.ts
+++ b/studio/frontend/tests/uncaptioned-image-empty-text-block.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+// chat-adapter.ts drags in the stores and the toast layer, so lift the shipped
+// source the way tests/search-images.test.ts does. Only the user branch of
+// toOpenAIMessages is exercised, so the assistant serialiser stays a stub.
+const adapterSource = readFileSync(
+  fileURLToPath(
+    new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
+  ),
+  "utf8",
+);
+
+function liftAdapterFunction(opener: string): string {
+  const start = adapterSource.indexOf(opener);
+  assert.ok(start >= 0, `${opener} is no longer defined in chat-adapter.ts`);
+  const end = adapterSource.indexOf("\n}", start);
+  assert.ok(end > start, `could not find the end of ${opener}`);
+  return adapterSource.slice(start, end + 2);
+}
+
+const serializeJs = ts.transpileModule(
+  [
+    "function serializeAssistantReplayMessages() { throw new Error('not under test'); }",
+    liftAdapterFunction("function collectTextParts("),
+    liftAdapterFunction("function collectImageParts("),
+    liftAdapterFunction("function buildReplayContent("),
+    liftAdapterFunction("function toOpenAIMessages("),
+    "return toOpenAIMessages;",
+  ].join("\n\n"),
+  { compilerOptions: { target: ts.ScriptTarget.ES2022 } },
+).outputText;
+
+const toOpenAIMessages = new Function(serializeJs)() as (
+  message: unknown,
+) => Array<{ role: string; content: unknown }>;
+
+const IMAGE_DATA_URL = "data:image/png;base64,aGVsbG8=";
+
+test("an uncaptioned image sends no empty text block", () => {
+  const [serialized] = toOpenAIMessages({
+    role: "user",
+    content: [{ type: "image", image: IMAGE_DATA_URL }],
+  });
+
+  assert.equal(serialized.role, "user");
+  assert.deepEqual(serialized.content, [
+    { type: "image_url", image_url: { url: IMAGE_DATA_URL } },
+  ]);
+});
+
+test("a captioned image still leads with its text block", () => {
+  const [serialized] = toOpenAIMessages({
+    role: "user",
+    content: [
+      { type: "text", text: "what is this?" },
+      { type: "image", image: IMAGE_DATA_URL },
+    ],
+  });
+
+  assert.deepEqual(serialized.content, [
+    { type: "text", text: "what is this?" },
+    { type: "image_url", image_url: { url: IMAGE_DATA_URL } },
+  ]);
+});
+
+test("a text-only turn still serialises to a plain string", () => {
+  const [serialized] = toOpenAIMessages({
+    role: "user",
+    content: [{ type: "text", text: "no attachments here" }],
+  });
+
+  assert.equal(serialized.content, "no attachments here");
+});

--- a/studio/frontend/tests/uncaptioned-image-empty-text-block.test.ts
+++ b/studio/frontend/tests/uncaptioned-image-empty-text-block.test.ts
@@ -8,9 +8,8 @@ import { fileURLToPath } from "node:url";
 
 import ts from "typescript";
 
-// chat-adapter.ts drags in the stores and the toast layer, so lift the shipped
-// source the way tests/search-images.test.ts does. Only the user branch of
-// toOpenAIMessages is exercised, so the assistant serialiser stays a stub.
+// chat-adapter.ts drags in the stores, so lift the source like
+// tests/search-images.test.ts. Only the user branch runs; assistant is a stub.
 const adapterSource = readFileSync(
   fileURLToPath(
     new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),

--- a/studio/frontend/tests/uncaptioned-image-empty-text-block.test.ts
+++ b/studio/frontend/tests/uncaptioned-image-empty-text-block.test.ts
@@ -32,14 +32,19 @@ const serializeJs = ts.transpileModule(
     liftAdapterFunction("function collectImageParts("),
     liftAdapterFunction("function buildReplayContent("),
     liftAdapterFunction("function toOpenAIMessages("),
-    "return toOpenAIMessages;",
+    "return { toOpenAIMessages, buildReplayContent };",
   ].join("\n\n"),
   { compilerOptions: { target: ts.ScriptTarget.ES2022 } },
 ).outputText;
 
-const toOpenAIMessages = new Function(serializeJs)() as (
-  message: unknown,
-) => Array<{ role: string; content: unknown }>;
+const { toOpenAIMessages, buildReplayContent } = new Function(
+  serializeJs,
+)() as {
+  toOpenAIMessages: (
+    message: unknown,
+  ) => Array<{ role: string; content: unknown }>;
+  buildReplayContent: (text: string, images: unknown[]) => unknown;
+};
 
 const IMAGE_DATA_URL = "data:image/png;base64,aGVsbG8=";
 
@@ -68,6 +73,48 @@ test("a captioned image still leads with its text block", () => {
     { type: "text", text: "what is this?" },
     { type: "image_url", image_url: { url: IMAGE_DATA_URL } },
   ]);
+});
+
+test("a whitespace-only caption sends no text block either", () => {
+  // Two empty text parts join to "\n", which is truthy. Anthropic rejects that
+  // block as well, with "text content blocks must contain non-whitespace text".
+  const [serialized] = toOpenAIMessages({
+    role: "user",
+    content: [
+      { type: "text", text: "" },
+      { type: "text", text: "" },
+      { type: "image", image: IMAGE_DATA_URL },
+    ],
+  });
+
+  assert.deepEqual(serialized.content, [
+    { type: "image_url", image_url: { url: IMAGE_DATA_URL } },
+  ]);
+});
+
+test("a real caption keeps its own surrounding whitespace", () => {
+  const [serialized] = toOpenAIMessages({
+    role: "user",
+    content: [
+      { type: "text", text: "  what is this?  " },
+      { type: "image", image: IMAGE_DATA_URL },
+    ],
+  });
+
+  assert.deepEqual(serialized.content, [
+    { type: "text", text: "  what is this?  " },
+    { type: "image_url", image_url: { url: IMAGE_DATA_URL } },
+  ]);
+});
+
+test("the serialised content is not the collected image array itself", () => {
+  // buildReplayContent returns a fresh array, so a consumer that mutates the
+  // message content cannot reach back into what was passed in.
+  const images = [
+    { type: "image_url" as const, image_url: { url: IMAGE_DATA_URL } },
+  ];
+  assert.notEqual(buildReplayContent("", images), images);
+  assert.deepEqual(buildReplayContent("", images), images);
 });
 
 test("a text-only turn still serialises to a plain string", () => {

--- a/studio/frontend/tests/uncaptioned-image-empty-text-block.test.ts
+++ b/studio/frontend/tests/uncaptioned-image-empty-text-block.test.ts
@@ -8,8 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import ts from "typescript";
 
-// chat-adapter.ts drags in the stores, so lift the source like
-// tests/search-images.test.ts. Only the user branch runs; assistant is a stub.
+// chat-adapter.ts drags in the stores, so lift the source; assistant is a stub.
 const adapterSource = readFileSync(
   fileURLToPath(
     new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
@@ -76,8 +75,7 @@ test("a captioned image still leads with its text block", () => {
 });
 
 test("a whitespace-only caption sends no text block either", () => {
-  // Two empty text parts join to "\n", which is truthy. Anthropic rejects that
-  // block as well, with "text content blocks must contain non-whitespace text".
+  // Two empty text parts join to "\n", which is truthy but still rejected.
   const [serialized] = toOpenAIMessages({
     role: "user",
     content: [
@@ -108,8 +106,6 @@ test("a real caption keeps its own surrounding whitespace", () => {
 });
 
 test("the serialised content is not the collected image array itself", () => {
-  // buildReplayContent returns a fresh array, so a consumer that mutates the
-  // message content cannot reach back into what was passed in.
   const images = [
     { type: "image_url" as const, image_url: { url: IMAGE_DATA_URL } },
   ];


### PR DESCRIPTION
On an Anthropic connection, attaching an image and pressing send without typing anything fails with "Generation failed" and a provider message saying text content blocks must not be empty. The composer allows sending an image on its own, so this is easy to hit.

When a message has an image, Studio always put a text block in front of it, even when there was no text. So an image with no caption went out as an empty text block followed by the image, and Anthropic rejects empty text blocks.

Studio now leaves the text block out when there is nothing to put in it. The backend also drops empty text blocks when it builds the Anthropic request, so a message from any client with the same shape no longer fails. Gemini already did this, and the Anthropic path already did it for plain string content but not for the list form.

An image with a caption still sends the caption first, and a text only message is unchanged.
