### PR TITLE
Studio: make the Min P and Repetition Penalty sliders work

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -52,6 +52,10 @@ _CONTINUATION_FLAG_PROVIDERS = frozenset({"vllm", "llama_cpp"})
 # which reports usage on its own.
 _USAGE_STREAM_OPTION_PROVIDERS = frozenset({"vllm", "openrouter", "kimi"})
 
+# llama-server names the knob "repeat_penalty" and ignores "repetition_penalty", so the
+# slider would read as off. Same rename as routes/inference._COMPLETIONS_SAMPLING_BODY_KEY.
+_REPETITION_PENALTY_BODY_KEY = {"llama_cpp": "repeat_penalty"}
+
 # structlog so INFO diagnostics reach the backend's JSON log stream (the
 # stdlib root logger defaults to WARNING with no handlers). It accepts the
 # existing printf-style positional args.
@@ -1111,6 +1115,8 @@ class ExternalProviderClient:
         max_tokens: Optional[int] = None,
         presence_penalty: float = 0.0,
         top_k: Optional[int] = None,
+        min_p: Optional[float] = None,
+        repetition_penalty: Optional[float] = None,
         enable_thinking: Optional[bool] = None,
         reasoning_effort: Optional[str] = None,
         enabled_tools: Optional[list[str]] = None,
@@ -1132,10 +1138,10 @@ class ExternalProviderClient:
         OpenAI-compatible providers forward lines verbatim. For Anthropic, the
         native Messages API SSE is translated to OpenAI format.
 
-        ``top_k`` and ``presence_penalty`` are forwarded only when the caller
-        supplies a value the provider accepts; the frontend's
-        provider-capability map already filters these per provider, so they're
-        opt-in here.
+        ``top_k``, ``min_p``, ``repetition_penalty`` and ``presence_penalty``
+        are forwarded only when the caller supplies a value the provider
+        accepts; the frontend's provider-capability map already filters these
+        per provider, so they're opt-in here.
 
         ``fast_mode`` only applies to Anthropic Opus 5 / Opus 4.8 (silently
         dropped elsewhere); adds the beta header and ``speed: "fast"``.
@@ -1287,6 +1293,14 @@ class ExternalProviderClient:
                 body["max_completion_tokens"] = max_tokens
             else:
                 body["max_tokens"] = max_tokens
+        if top_k is not None:
+            body["top_k"] = top_k
+        if min_p is not None:
+            body["min_p"] = min_p
+        if repetition_penalty is not None:
+            body[_REPETITION_PENALTY_BODY_KEY.get(self.provider_type, "repetition_penalty")] = (
+                repetition_penalty
+            )
 
         # Drop fields the registry flags as unusable so reasoning-class models
         # with fixed defaults (Kimi k2.6 etc) don't 400 on pydantic defaults

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -52,8 +52,7 @@ _CONTINUATION_FLAG_PROVIDERS = frozenset({"vllm", "llama_cpp"})
 # which reports usage on its own.
 _USAGE_STREAM_OPTION_PROVIDERS = frozenset({"vllm", "openrouter", "kimi"})
 
-# llama-server names the knob "repeat_penalty" and ignores "repetition_penalty", so the
-# slider would read as off. Same rename as routes/inference._COMPLETIONS_SAMPLING_BODY_KEY.
+# llama-server reads repeat_penalty, not repetition_penalty (as routes/inference does).
 _REPETITION_PENALTY_BODY_KEY = {"llama_cpp": "repeat_penalty"}
 
 # structlog so INFO diagnostics reach the backend's JSON log stream (the
@@ -1139,9 +1138,8 @@ class ExternalProviderClient:
         native Messages API SSE is translated to OpenAI format.
 
         ``top_k``, ``min_p``, ``repetition_penalty`` and ``presence_penalty``
-        are forwarded only when the caller supplies a value the provider
-        accepts; the frontend's provider-capability map already filters these
-        per provider, so they're opt-in here.
+        are opt-in: forwarded only when supplied, since the frontend's
+        capability map already filters them per provider.
 
         ``fast_mode`` only applies to Anthropic Opus 5 / Opus 4.8 (silently
         dropped elsewhere); adds the beta header and ``speed: "fast"``.

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -380,9 +380,7 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
             "/v1/chat/completions; API key optional (required by Ollama "
             "cloud). Surfaced via CUSTOM_PROVIDER_PRESETS in the frontend."
         ),
-        # Ollama's /v1 layer reads only the OpenAI-documented fields and drops these three
-        # without an error; they live in the native /api/chat options. The panel hides them,
-        # but /v1/chat/completions is a public surface, so strip them here too.
+        # Ollama's /v1 silently drops these (native /api/chat options); this route is public.
         "body_omit": ("top_k", "min_p", "repetition_penalty"),
         "hidden": True,
     },

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -362,9 +362,7 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
             "User-supplied OpenAI-compatible server. Routed to "
             "/v1/chat/completions; /models is optional."
         ),
-        # A strict gateway 400s the whole turn on an unknown key, and a browser tab left open
-        # across an upgrade still runs the bundle that spread top_k on every custom request.
-        # Servers that want these are reachable through the vllm / llama_cpp presets.
+        # A strict gateway 400s on an unknown key, and a pre-upgrade tab still spreads top_k.
         "body_omit": ("top_k", "min_p", "repetition_penalty"),
         # Surfaced by the frontend's generic Custom option, not the dropdown.
         "hidden": True,

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -362,6 +362,10 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
             "User-supplied OpenAI-compatible server. Routed to "
             "/v1/chat/completions; /models is optional."
         ),
+        # A strict gateway 400s the whole turn on an unknown key, and a browser tab left open
+        # across an upgrade still runs the bundle that spread top_k on every custom request.
+        # Servers that want these are reachable through the vllm / llama_cpp presets.
+        "body_omit": ("top_k", "min_p", "repetition_penalty"),
         # Surfaced by the frontend's generic Custom option, not the dropdown.
         "hidden": True,
     },

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -380,6 +380,10 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
             "/v1/chat/completions; API key optional (required by Ollama "
             "cloud). Surfaced via CUSTOM_PROVIDER_PRESETS in the frontend."
         ),
+        # Ollama's /v1 layer reads only the OpenAI-documented fields and drops these three
+        # without an error; they live in the native /api/chat options. The panel hides them,
+        # but /v1/chat/completions is a public surface, so strip them here too.
+        "body_omit": ("top_k", "min_p", "repetition_penalty"),
         "hidden": True,
     },
     "llama_cpp": {

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -20283,12 +20283,19 @@ async def _proxy_to_external_provider(
         api_key = api_key,
     )
 
-    # `top_k` defaults to 20 in ChatCompletionRequest because the local path
-    # expects an int, but the external-provider path treats "field omitted from
-    # JSON" as "use provider default" so callers sending only model/messages
-    # don't silently get different sampling than before this PR. Pydantic's
-    # `model_fields_set` tracks explicit-vs-default per request.
+    # `top_k` / `min_p` / `repetition_penalty` carry non-None schema defaults (20, 0.01,
+    # 1.0) because the local path expects numbers, but the external-provider path treats
+    # "field omitted from JSON" as "use provider default" so callers sending only
+    # model/messages don't silently get different sampling than before this PR. Pydantic's
+    # `model_fields_set` tracks explicit-vs-default per request. Read before
+    # `_fill_recommended_sampling_openai`, whose setattr would mark every field explicit.
     _top_k_explicit = payload.top_k if "top_k" in payload.model_fields_set else None
+    _min_p_explicit = payload.min_p if "min_p" in payload.model_fields_set else None
+    _repetition_penalty_explicit = (
+        payload.repetition_penalty
+        if "repetition_penalty" in payload.model_fields_set
+        else None
+    )
 
     # Unsloth-owned tool loop for every non-Codex provider that declares the
     # capability. The catalog comes from the same selector the local and Codex
@@ -20341,6 +20348,8 @@ async def _proxy_to_external_provider(
             max_tokens = _effective_max_tokens(payload),
             presence_penalty = payload.presence_penalty,
             top_k = _top_k_explicit,
+            min_p = _min_p_explicit,
+            repetition_penalty = _repetition_penalty_explicit,
             enable_thinking = payload.enable_thinking,
             reasoning_effort = payload.reasoning_effort,
             enable_prompt_caching = payload.enable_prompt_caching,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -20283,17 +20283,9 @@ async def _proxy_to_external_provider(
         api_key = api_key,
     )
 
-    # `top_k` / `min_p` / `repetition_penalty` carry non-None schema defaults (20, 0.01,
-    # 1.0) because the local path expects numbers, but the external-provider path treats
-    # "field omitted from JSON" as "use provider default" so callers sending only
-    # model/messages don't silently get different sampling than before this PR. Pydantic's
-    # `model_fields_set` tracks explicit-vs-default per request, so these three reads have
-    # to happen before ANY write to `payload`: a `setattr` adds the name to
-    # `model_fields_set`, turning an omission into an explicit request for the default.
-    # `_fill_recommended_sampling_openai` is the one helper that does that, and today it
-    # cannot reach this: the external branch returns long before its call site on the local
-    # path. Nothing enforces that ordering except this comment and the runtime coverage in
-    # tests/test_external_provider_sampling_over_the_wire.py.
+    # Schema defaults are non-None (20, 0.01, 1.0) for the local path, so only
+    # `model_fields_set` separates "asked for 20" from "said nothing", and the provider keeps
+    # its own default for the latter. Read before ANY write: a setattr marks a field explicit.
     _top_k_explicit = payload.top_k if "top_k" in payload.model_fields_set else None
     _min_p_explicit = payload.min_p if "min_p" in payload.model_fields_set else None
     _repetition_penalty_explicit = (

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -20292,9 +20292,7 @@ async def _proxy_to_external_provider(
     _top_k_explicit = payload.top_k if "top_k" in payload.model_fields_set else None
     _min_p_explicit = payload.min_p if "min_p" in payload.model_fields_set else None
     _repetition_penalty_explicit = (
-        payload.repetition_penalty
-        if "repetition_penalty" in payload.model_fields_set
-        else None
+        payload.repetition_penalty if "repetition_penalty" in payload.model_fields_set else None
     )
 
     # Unsloth-owned tool loop for every non-Codex provider that declares the

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -20287,8 +20287,13 @@ async def _proxy_to_external_provider(
     # 1.0) because the local path expects numbers, but the external-provider path treats
     # "field omitted from JSON" as "use provider default" so callers sending only
     # model/messages don't silently get different sampling than before this PR. Pydantic's
-    # `model_fields_set` tracks explicit-vs-default per request. Read before
-    # `_fill_recommended_sampling_openai`, whose setattr would mark every field explicit.
+    # `model_fields_set` tracks explicit-vs-default per request, so these three reads have
+    # to happen before ANY write to `payload`: a `setattr` adds the name to
+    # `model_fields_set`, turning an omission into an explicit request for the default.
+    # `_fill_recommended_sampling_openai` is the one helper that does that, and today it
+    # cannot reach this: the external branch returns long before its call site on the local
+    # path. Nothing enforces that ordering except this comment and the runtime coverage in
+    # tests/test_external_provider_sampling_over_the_wire.py.
     _top_k_explicit = payload.top_k if "top_k" in payload.model_fields_set else None
     _min_p_explicit = payload.min_p if "min_p" in payload.model_fields_set else None
     _repetition_penalty_explicit = (

--- a/studio/backend/tests/test_external_provider_sampling_forwarding.py
+++ b/studio/backend/tests/test_external_provider_sampling_forwarding.py
@@ -150,10 +150,7 @@ def test_the_proxy_hands_the_client_explicit_values_not_schema_defaults():
 
 @pytest.mark.parametrize("provider_type", ["ollama", "custom"])
 def test_the_registry_strips_the_three_for_providers_that_cannot_take_them(provider_type):
-    # Ollama's /v1 accepts and ignores them; an unknown gateway behind a Custom base URL
-    # 400s the whole turn instead. Both are registry-guarded, so neither can leave the box
-    # even when a caller names them: a browser tab left open across an upgrade still runs
-    # the bundle that spread top_k on every custom request.
+    # Ollama ignores them; a gateway behind a Custom base URL rejects the whole turn.
     body = _capture_body(
         provider_type,
         temperature = 0.31,

--- a/studio/backend/tests/test_external_provider_sampling_forwarding.py
+++ b/studio/backend/tests/test_external_provider_sampling_forwarding.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Min P / Repetition Penalty / Top K must reach a self-hosted OpenAI-compatible server.
+
+The Chat Settings panel offers all three on vLLM, llama.cpp, OpenRouter and custom
+connections and persists them per model and per thread, but the outbound body carried
+none of them: ``stream_chat_completion`` built ``temperature`` / ``top_p`` /
+``presence_penalty`` / ``max_tokens`` and dropped the rest, so moving either slider
+changed nothing.
+
+They stay opt-in. ``ChatCompletionRequest`` gives top_k / min_p / repetition_penalty
+non-None schema defaults (20 / 0.01 / 1.0) for the local path, so forwarding them
+unconditionally would start sending sampling params to providers that never received
+any; the route reads ``model_fields_set`` and passes None for a field nobody set.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import pathlib
+
+import httpx
+import pytest
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import ExternalProviderClient
+from models.inference import ChatCompletionRequest
+
+
+_ROUTE_SOURCE = pathlib.Path(__file__).resolve().parents[1] / "routes" / "inference.py"
+
+
+def _capture_body(provider_type: str, **kwargs) -> dict:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode())
+        sse = 'data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}\n\n' "data: [DONE]\n\n"
+        return httpx.Response(200, content = sse, headers = {"content-type": "text/event-stream"})
+
+    mock_client = httpx.AsyncClient(transport = httpx.MockTransport(handler))
+    client = ExternalProviderClient(
+        provider_type = provider_type,
+        base_url = "http://127.0.0.1:8000/v1",
+        api_key = "",
+    )
+
+    async def run() -> None:
+        try:
+            async for _ in client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "a-model",
+                **kwargs,
+            ):
+                pass
+        finally:
+            await mock_client.aclose()
+
+    event_loop = asyncio.new_event_loop()
+    previous_client = ep_mod._http_client
+    ep_mod._http_client = mock_client
+    try:
+        event_loop.run_until_complete(run())
+    finally:
+        ep_mod._http_client = previous_client
+        event_loop.close()
+    return captured["body"]
+
+
+@pytest.mark.parametrize("provider_type", ["vllm", "openrouter", "custom"])
+def test_the_sliders_reach_the_server(provider_type):
+    body = _capture_body(
+        provider_type,
+        top_k = 40,
+        min_p = 0.07,
+        repetition_penalty = 1.15,
+    )
+    assert body["top_k"] == 40
+    assert body["min_p"] == 0.07
+    assert body["repetition_penalty"] == 1.15
+
+
+@pytest.mark.parametrize("provider_type", ["vllm", "openrouter", "custom", "llama_cpp"])
+def test_a_request_that_set_none_of_them_sends_none(provider_type):
+    body = _capture_body(provider_type)
+    for field in ("top_k", "min_p", "repetition_penalty", "repeat_penalty"):
+        assert field not in body, field
+    # the fields that always travelled are untouched
+    assert body["temperature"] == 0.7
+    assert body["top_p"] == 0.95
+    assert body["presence_penalty"] == 0.0
+
+
+def test_llama_server_gets_repeat_penalty_not_repetition_penalty():
+    # llama-server reads "repeat_penalty" and ignores "repetition_penalty", so the
+    # documented name would leave the slider inert. Same rename the in-process
+    # llama.cpp client and the /v1/completions proxy already apply.
+    body = _capture_body("llama_cpp", min_p = 0.07, repetition_penalty = 1.15, top_k = 40)
+    assert body["repeat_penalty"] == 1.15
+    assert "repetition_penalty" not in body
+    assert body["min_p"] == 0.07
+    assert body["top_k"] == 40
+
+
+def test_a_zero_value_is_forwarded_rather_than_read_as_unset():
+    # min_p 0 and top_k 0 both mean "disabled" to vLLM and llama-server; a truthiness
+    # gate would drop them and leave the provider's own default sampling in place.
+    body = _capture_body("vllm", top_k = 0, min_p = 0.0)
+    assert body["top_k"] == 0
+    assert body["min_p"] == 0.0
+
+
+def test_the_schema_defaults_are_not_none_so_the_route_cannot_test_for_none():
+    # The reason the route has to consult model_fields_set at all: reading payload.min_p
+    # on a request that never mentioned it yields 0.01, not None.
+    bare = ChatCompletionRequest(messages = [{"role": "user", "content": "hi"}])
+    assert bare.top_k == 20
+    assert bare.min_p == 0.01
+    assert bare.repetition_penalty == 1.0
+    assert "min_p" not in bare.model_fields_set
+    assert "repetition_penalty" not in bare.model_fields_set
+
+    asked = ChatCompletionRequest(
+        messages = [{"role": "user", "content": "hi"}],
+        min_p = 0.0,
+        repetition_penalty = 1.0,
+    )
+    # Both equal a default, so only model_fields_set can tell them from an omission.
+    assert {"min_p", "repetition_penalty"} <= asked.model_fields_set
+
+
+def test_the_proxy_hands_the_client_explicit_values_not_schema_defaults():
+    tree = ast.parse(_ROUTE_SOURCE.read_text(encoding = "utf-8"))
+    proxy = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "_proxy_to_external_provider"
+    )
+    kwargs = next(
+        node
+        for node in ast.walk(proxy)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "dict"
+        and any(keyword.arg == "top_k" for keyword in node.keywords)
+    )
+    passed = {
+        keyword.arg: ast.unparse(keyword.value)
+        for keyword in kwargs.keywords
+        if keyword.arg in ("top_k", "min_p", "repetition_penalty")
+    }
+    assert passed == {
+        "top_k": "_top_k_explicit",
+        "min_p": "_min_p_explicit",
+        "repetition_penalty": "_repetition_penalty_explicit",
+    }
+
+
+def test_ollama_strips_the_three_its_v1_layer_drops_even_from_a_raw_api_caller():
+    body = _capture_body(
+        "ollama",
+        temperature = 0.31,
+        top_k = 42,
+        min_p = 0.07,
+        repetition_penalty = 1.23,
+        presence_penalty = 0.11,
+    )
+    assert "top_k" not in body
+    assert "min_p" not in body
+    assert "repetition_penalty" not in body
+    assert body["temperature"] == 0.31
+    assert body["presence_penalty"] == 0.11

--- a/studio/backend/tests/test_external_provider_sampling_forwarding.py
+++ b/studio/backend/tests/test_external_provider_sampling_forwarding.py
@@ -3,9 +3,10 @@
 
 """Min P / Repetition Penalty / Top K must reach a self-hosted OpenAI-compatible server.
 
-The Chat Settings panel offers all three on vLLM, llama.cpp, OpenRouter and custom
-connections and persists them per model and per thread, but the outbound body carried
-none of them: ``stream_chat_completion`` built ``temperature`` / ``top_p`` /
+The Chat Settings panel offers all three on vLLM, llama.cpp and OpenRouter connections
+(and, before this PR narrowed them to the OpenAI-compatible baseline, on Ollama and custom
+ones too) and persists them per model and per thread, but the outbound body carried none
+of them: ``stream_chat_completion`` built ``temperature`` / ``top_p`` /
 ``presence_penalty`` / ``max_tokens`` and dropped the rest, so moving either slider
 changed nothing.
 

--- a/studio/backend/tests/test_external_provider_sampling_forwarding.py
+++ b/studio/backend/tests/test_external_provider_sampling_forwarding.py
@@ -3,17 +3,12 @@
 
 """Min P / Repetition Penalty / Top K must reach a self-hosted OpenAI-compatible server.
 
-The Chat Settings panel offers all three on vLLM, llama.cpp and OpenRouter connections
-(and, before this PR narrowed them to the OpenAI-compatible baseline, on Ollama and custom
-ones too) and persists them per model and per thread, but the outbound body carried none
-of them: ``stream_chat_completion`` built ``temperature`` / ``top_p`` /
-``presence_penalty`` / ``max_tokens`` and dropped the rest, so moving either slider
-changed nothing.
+The panel offered all three and persisted them, but ``stream_chat_completion`` built only
+``temperature`` / ``top_p`` / ``presence_penalty`` / ``max_tokens``, so the sliders moved
+and nothing changed.
 
-They stay opt-in. ``ChatCompletionRequest`` gives top_k / min_p / repetition_penalty
-non-None schema defaults (20 / 0.01 / 1.0) for the local path, so forwarding them
-unconditionally would start sending sampling params to providers that never received
-any; the route reads ``model_fields_set`` and passes None for a field nobody set.
+They stay opt-in: the schema defaults (20 / 0.01 / 1.0) are non-None for the local path, so
+forwarding unconditionally would start sending sampling to providers that never got any.
 """
 
 from __future__ import annotations
@@ -39,7 +34,7 @@ def _capture_body(provider_type: str, **kwargs) -> dict:
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["body"] = json.loads(request.content.decode())
-        sse = 'data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}\n\n' "data: [DONE]\n\n"
+        sse = 'data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n'
         return httpx.Response(200, content = sse, headers = {"content-type": "text/event-stream"})
 
     mock_client = httpx.AsyncClient(transport = httpx.MockTransport(handler))
@@ -89,16 +84,12 @@ def test_a_request_that_set_none_of_them_sends_none(provider_type):
     body = _capture_body(provider_type)
     for field in ("top_k", "min_p", "repetition_penalty", "repeat_penalty"):
         assert field not in body, field
-    # the fields that always travelled are untouched
     assert body["temperature"] == 0.7
     assert body["top_p"] == 0.95
     assert body["presence_penalty"] == 0.0
 
 
 def test_llama_server_gets_repeat_penalty_not_repetition_penalty():
-    # llama-server reads "repeat_penalty" and ignores "repetition_penalty", so the
-    # documented name would leave the slider inert. Same rename the in-process
-    # llama.cpp client and the /v1/completions proxy already apply.
     body = _capture_body("llama_cpp", min_p = 0.07, repetition_penalty = 1.15, top_k = 40)
     assert body["repeat_penalty"] == 1.15
     assert "repetition_penalty" not in body
@@ -107,16 +98,13 @@ def test_llama_server_gets_repeat_penalty_not_repetition_penalty():
 
 
 def test_a_zero_value_is_forwarded_rather_than_read_as_unset():
-    # min_p 0 and top_k 0 both mean "disabled" to vLLM and llama-server; a truthiness
-    # gate would drop them and leave the provider's own default sampling in place.
+    # 0 means "disabled" here, so a truthiness gate would restore the server's default.
     body = _capture_body("vllm", top_k = 0, min_p = 0.0)
     assert body["top_k"] == 0
     assert body["min_p"] == 0.0
 
 
 def test_the_schema_defaults_are_not_none_so_the_route_cannot_test_for_none():
-    # The reason the route has to consult model_fields_set at all: reading payload.min_p
-    # on a request that never mentioned it yields 0.01, not None.
     bare = ChatCompletionRequest(messages = [{"role": "user", "content": "hi"}])
     assert bare.top_k == 20
     assert bare.min_p == 0.01

--- a/studio/backend/tests/test_external_provider_sampling_forwarding.py
+++ b/studio/backend/tests/test_external_provider_sampling_forwarding.py
@@ -137,8 +137,7 @@ def test_the_proxy_hands_the_client_explicit_values_not_schema_defaults():
     proxy = next(
         node
         for node in ast.walk(tree)
-        if isinstance(node, ast.AsyncFunctionDef)
-        and node.name == "_proxy_to_external_provider"
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_proxy_to_external_provider"
     )
     kwargs = next(
         node

--- a/studio/backend/tests/test_external_provider_sampling_forwarding.py
+++ b/studio/backend/tests/test_external_provider_sampling_forwarding.py
@@ -66,7 +66,7 @@ def _capture_body(provider_type: str, **kwargs) -> dict:
     return captured["body"]
 
 
-@pytest.mark.parametrize("provider_type", ["vllm", "openrouter", "custom"])
+@pytest.mark.parametrize("provider_type", ["vllm", "openrouter"])
 def test_the_sliders_reach_the_server(provider_type):
     body = _capture_body(
         provider_type,
@@ -148,9 +148,14 @@ def test_the_proxy_hands_the_client_explicit_values_not_schema_defaults():
     }
 
 
-def test_ollama_strips_the_three_its_v1_layer_drops_even_from_a_raw_api_caller():
+@pytest.mark.parametrize("provider_type", ["ollama", "custom"])
+def test_the_registry_strips_the_three_for_providers_that_cannot_take_them(provider_type):
+    # Ollama's /v1 accepts and ignores them; an unknown gateway behind a Custom base URL
+    # 400s the whole turn instead. Both are registry-guarded, so neither can leave the box
+    # even when a caller names them: a browser tab left open across an upgrade still runs
+    # the bundle that spread top_k on every custom request.
     body = _capture_body(
-        "ollama",
+        provider_type,
         temperature = 0.31,
         top_k = 42,
         min_p = 0.07,

--- a/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
+++ b/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The same forwarding claims, but over a socket and through the real route.
+
+``test_external_provider_sampling_forwarding.py`` covers the body builder with an
+``httpx.MockTransport`` and covers the route by AST-parsing ``routes/inference.py`` and
+comparing the names handed to ``dict(...)`` against the strings ``"_top_k_explicit"`` and
+friends. That proves the source says the right words; it cannot fail on the runtime hazard
+those words exist to prevent, which is that pydantic v2 records every ``setattr`` in
+``model_fields_set``, so anything writing to the payload before those three reads turns
+"the caller omitted this" into "the caller asked for the schema default".
+
+So this drives ``_proxy_to_external_provider`` itself, and a real ``http.server`` on
+loopback records the bytes. Stdlib only, no fixtures, no external network: the same file
+has to pass on Linux, macOS and Windows runners.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import pytest
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import ExternalProviderClient
+from models.inference import ChatCompletionRequest
+
+
+SAMPLING_EXTENSIONS = ("top_k", "min_p", "repetition_penalty", "repeat_penalty")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args, **kwargs) -> None:
+        return
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        self.server.recorded.append(json.loads(raw.decode()))  # type: ignore[attr-defined]
+
+        sse = (
+            'data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}\n\n'
+            'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+            "data: [DONE]\n\n"
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(sse)))
+        self.end_headers()
+        self.wfile.write(sse)
+
+
+class _Server:
+    """A live OpenAI-compatible endpoint that keeps every body it was posted."""
+
+    def __enter__(self) -> "_Server":
+        # Port 0 lets the OS assign, which closes the bind-then-lose race a scanning
+        # helper cannot, and needs no free-port range on a busy CI runner.
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._httpd.recorded = []  # type: ignore[attr-defined]
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=10)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self._httpd.server_address[1]}/v1"
+
+    @property
+    def bodies(self) -> list[dict]:
+        return self._httpd.recorded  # type: ignore[attr-defined]
+
+    def sampling(self, index: int = -1) -> dict:
+        body = self.bodies[index]
+        return {k: body[k] for k in SAMPLING_EXTENSIONS if k in body}
+
+
+def _run(coro) -> None:
+    """One loop per call, with a matching client, mirroring the sibling test file.
+
+    ``ep_mod._http_client`` is built at import time and its pool binds to whichever loop
+    first uses it, so the real client has to be replaced per loop rather than reused.
+    """
+    loop = asyncio.new_event_loop()
+    previous = ep_mod._http_client
+    client = httpx.AsyncClient()
+
+    async def wrapper() -> None:
+        try:
+            await coro()
+        finally:
+            await client.aclose()
+
+    ep_mod._http_client = client
+    try:
+        loop.run_until_complete(wrapper())
+    finally:
+        ep_mod._http_client = previous
+        loop.close()
+
+
+def _client_capture(provider_type: str, **kwargs) -> dict:
+    with _Server() as server:
+        client = ExternalProviderClient(
+            provider_type = provider_type, base_url = server.base_url, api_key = "",
+        )
+
+        async def go() -> None:
+            async for _ in client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "a-model",
+                **kwargs,
+            ):
+                pass
+
+        _run(go)
+        assert server.bodies, "nothing reached the provider"
+        return server.sampling()
+
+
+def _route_capture(**payload_fields) -> dict:
+    """POST through `_proxy_to_external_provider`, not around it."""
+    import routes.inference as ri
+    from starlette.requests import Request
+
+    async def receive() -> dict:
+        return {"type": "http.disconnect"}
+
+    with _Server() as server:
+        payload = ChatCompletionRequest(
+            provider_type = "vllm",
+            provider_base_url = server.base_url,
+            messages = [{"role": "user", "content": "hi"}],
+            model = "a-model",
+            stream = True,
+            **payload_fields,
+        )
+        request = Request({
+            "type": "http", "http_version": "1.1", "method": "POST",
+            "path": "/v1/chat/completions", "raw_path": b"/v1/chat/completions",
+            "root_path": "", "scheme": "http", "query_string": b"",
+            "headers": [(b"content-type", b"application/json")],
+            "client": ("127.0.0.1", 12345), "server": ("127.0.0.1", 8000),
+        }, receive)
+
+        async def go() -> None:
+            response = await ri._proxy_to_external_provider(payload, request)
+            async for _ in response.body_iterator:
+                pass
+
+        _run(go)
+        assert server.bodies, "the route never reached the provider"
+        return server.sampling()
+
+
+# ── the route's explicit-vs-default gate, executed rather than parsed ──────────────────
+
+def test_a_request_that_never_mentioned_them_forwards_nothing():
+    # Reading payload.min_p on such a request yields 0.01, not None; only
+    # model_fields_set can tell it from a caller who asked for 0.01.
+    assert _route_capture() == {}
+
+
+def test_the_route_forwards_explicit_values():
+    assert _route_capture(top_k = 40, min_p = 0.07, repetition_penalty = 1.15) == {
+        "top_k": 40, "min_p": 0.07, "repetition_penalty": 1.15,
+    }
+
+
+def test_explicit_values_equal_to_the_schema_defaults_are_still_forwarded():
+    # 20 / 0.01 / 1.0 ARE the defaults, so a `!= default` shortcut would drop them and a
+    # user who deliberately set the panel's own numbers would get provider sampling.
+    assert _route_capture(top_k = 20, min_p = 0.01, repetition_penalty = 1.0) == {
+        "top_k": 20, "min_p": 0.01, "repetition_penalty": 1.0,
+    }
+
+
+def test_zero_survives_the_route():
+    assert _route_capture(top_k = 0, min_p = 0.0) == {"top_k": 0, "min_p": 0.0}
+
+
+@pytest.mark.parametrize("field,value", [
+    ("top_k", 40), ("min_p", 0.07), ("repetition_penalty", 1.15),
+])
+def test_one_field_set_forwards_only_that_field(field, value):
+    assert _route_capture(**{field: value}) == {field: value}
+
+
+def test_writing_to_the_payload_would_make_an_omission_look_explicit():
+    # The hazard the route's comment names, demonstrated. Any helper that setattr'd the
+    # payload before those reads would silently start forwarding schema defaults.
+    payload = ChatCompletionRequest(messages = [{"role": "user", "content": "hi"}])
+    assert "min_p" not in payload.model_fields_set
+    payload.min_p = payload.min_p          # a no-op write, same value
+    assert "min_p" in payload.model_fields_set
+
+
+# ── the body on the wire, for the providers the panel offers these on ──────────────────
+
+@pytest.mark.parametrize("provider_type", ["vllm", "openrouter"])
+def test_all_three_reach_a_live_endpoint(provider_type):
+    assert _client_capture(
+        provider_type, top_k = 40, min_p = 0.07, repetition_penalty = 1.15,
+    ) == {"top_k": 40, "min_p": 0.07, "repetition_penalty": 1.15}
+
+
+def test_llama_server_receives_repeat_penalty_on_the_wire():
+    assert _client_capture(
+        "llama_cpp", top_k = 40, min_p = 0.07, repetition_penalty = 1.15,
+    ) == {"top_k": 40, "min_p": 0.07, "repeat_penalty": 1.15}
+
+
+def test_ollama_receives_none_of_them_even_from_a_raw_api_caller():
+    assert _client_capture(
+        "ollama", top_k = 42, min_p = 0.07, repetition_penalty = 1.23,
+    ) == {}
+
+
+def test_the_tool_loop_continuation_keeps_the_same_sampling():
+    # OAICompatTransport captures **request_kwargs once and replays them every turn, so a
+    # conversation that calls a tool must not start sampling differently afterwards.
+    from core.inference.external_tool_transport import OAICompatTransport
+
+    with _Server() as server:
+        client = ExternalProviderClient(
+            provider_type = "vllm", base_url = server.base_url, api_key = "",
+        )
+        transport = OAICompatTransport(
+            client, model = "a-model", stream = True,
+            top_k = 40, min_p = 0.07, repetition_penalty = 1.15,
+        )
+        cancel_event = threading.Event()
+        turns = [
+            [{"role": "user", "content": "hi"}],
+            [{"role": "user", "content": "hi"},
+             {"role": "assistant", "content": "", "tool_calls": [
+                 {"id": "call_1", "type": "function",
+                  "function": {"name": "web_search", "arguments": "{}"}}]},
+             {"role": "tool", "tool_call_id": "call_1", "content": "result"}],
+        ]
+
+        async def go() -> None:
+            for messages in turns:
+                async for _ in transport.stream(
+                    messages = messages, tools = None, tool_choice = None,
+                    cancel_event = cancel_event,
+                ):
+                    pass
+
+        _run(go)
+        assert len(server.bodies) == 2
+        assert server.sampling(0) == {"top_k": 40, "min_p": 0.07, "repetition_penalty": 1.15}
+        assert server.sampling(1) == server.sampling(0)

--- a/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
+++ b/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
@@ -65,14 +65,14 @@ class _Server:
         # helper cannot, and needs no free-port range on a busy CI runner.
         self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
         self._httpd.recorded = []  # type: ignore[attr-defined]
-        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread = threading.Thread(target = self._httpd.serve_forever, daemon = True)
         self._thread.start()
         return self
 
     def __exit__(self, *exc) -> None:
         self._httpd.shutdown()
         self._httpd.server_close()
-        self._thread.join(timeout=10)
+        self._thread.join(timeout = 10)
 
     @property
     def base_url(self) -> str:
@@ -114,7 +114,9 @@ def _run(coro) -> None:
 def _client_capture(provider_type: str, **kwargs) -> dict:
     with _Server() as server:
         client = ExternalProviderClient(
-            provider_type = provider_type, base_url = server.base_url, api_key = "",
+            provider_type = provider_type,
+            base_url = server.base_url,
+            api_key = "",
         )
 
         async def go() -> None:
@@ -147,13 +149,22 @@ def _route_capture(**payload_fields) -> dict:
             stream = True,
             **payload_fields,
         )
-        request = Request({
-            "type": "http", "http_version": "1.1", "method": "POST",
-            "path": "/v1/chat/completions", "raw_path": b"/v1/chat/completions",
-            "root_path": "", "scheme": "http", "query_string": b"",
-            "headers": [(b"content-type", b"application/json")],
-            "client": ("127.0.0.1", 12345), "server": ("127.0.0.1", 8000),
-        }, receive)
+        request = Request(
+            {
+                "type": "http",
+                "http_version": "1.1",
+                "method": "POST",
+                "path": "/v1/chat/completions",
+                "raw_path": b"/v1/chat/completions",
+                "root_path": "",
+                "scheme": "http",
+                "query_string": b"",
+                "headers": [(b"content-type", b"application/json")],
+                "client": ("127.0.0.1", 12345),
+                "server": ("127.0.0.1", 8000),
+            },
+            receive,
+        )
 
         async def go() -> None:
             response = await ri._proxy_to_external_provider(payload, request)
@@ -167,6 +178,7 @@ def _route_capture(**payload_fields) -> dict:
 
 # ── the route's explicit-vs-default gate, executed rather than parsed ──────────────────
 
+
 def test_a_request_that_never_mentioned_them_forwards_nothing():
     # Reading payload.min_p on such a request yields 0.01, not None; only
     # model_fields_set can tell it from a caller who asked for 0.01.
@@ -175,7 +187,9 @@ def test_a_request_that_never_mentioned_them_forwards_nothing():
 
 def test_the_route_forwards_explicit_values():
     assert _route_capture(top_k = 40, min_p = 0.07, repetition_penalty = 1.15) == {
-        "top_k": 40, "min_p": 0.07, "repetition_penalty": 1.15,
+        "top_k": 40,
+        "min_p": 0.07,
+        "repetition_penalty": 1.15,
     }
 
 
@@ -183,7 +197,9 @@ def test_explicit_values_equal_to_the_schema_defaults_are_still_forwarded():
     # 20 / 0.01 / 1.0 ARE the defaults, so a `!= default` shortcut would drop them and a
     # user who deliberately set the panel's own numbers would get provider sampling.
     assert _route_capture(top_k = 20, min_p = 0.01, repetition_penalty = 1.0) == {
-        "top_k": 20, "min_p": 0.01, "repetition_penalty": 1.0,
+        "top_k": 20,
+        "min_p": 0.01,
+        "repetition_penalty": 1.0,
     }
 
 
@@ -191,9 +207,14 @@ def test_zero_survives_the_route():
     assert _route_capture(top_k = 0, min_p = 0.0) == {"top_k": 0, "min_p": 0.0}
 
 
-@pytest.mark.parametrize("field,value", [
-    ("top_k", 40), ("min_p", 0.07), ("repetition_penalty", 1.15),
-])
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("top_k", 40),
+        ("min_p", 0.07),
+        ("repetition_penalty", 1.15),
+    ],
+)
 def test_one_field_set_forwards_only_that_field(field, value):
     assert _route_capture(**{field: value}) == {field: value}
 
@@ -203,58 +224,80 @@ def test_writing_to_the_payload_would_make_an_omission_look_explicit():
     # payload before those reads would silently start forwarding schema defaults.
     payload = ChatCompletionRequest(messages = [{"role": "user", "content": "hi"}])
     assert "min_p" not in payload.model_fields_set
-    payload.min_p = payload.min_p          # a no-op write, same value
+    payload.min_p = payload.min_p  # a no-op write, same value
     assert "min_p" in payload.model_fields_set
 
 
 # ── the body on the wire, for the providers the panel offers these on ──────────────────
 
+
 @pytest.mark.parametrize("provider_type", ["vllm", "openrouter"])
 def test_all_three_reach_a_live_endpoint(provider_type):
     assert _client_capture(
-        provider_type, top_k = 40, min_p = 0.07, repetition_penalty = 1.15,
+        provider_type,
+        top_k = 40,
+        min_p = 0.07,
+        repetition_penalty = 1.15,
     ) == {"top_k": 40, "min_p": 0.07, "repetition_penalty": 1.15}
 
 
 def test_llama_server_receives_repeat_penalty_on_the_wire():
     assert _client_capture(
-        "llama_cpp", top_k = 40, min_p = 0.07, repetition_penalty = 1.15,
+        "llama_cpp",
+        top_k = 40,
+        min_p = 0.07,
+        repetition_penalty = 1.15,
     ) == {"top_k": 40, "min_p": 0.07, "repeat_penalty": 1.15}
 
 
 def test_ollama_receives_none_of_them_even_from_a_raw_api_caller():
-    assert _client_capture(
-        "ollama", top_k = 42, min_p = 0.07, repetition_penalty = 1.23,
-    ) == {}
+    assert _client_capture("ollama", top_k = 42, min_p = 0.07, repetition_penalty = 1.23) == {}
 
 
 def test_the_tool_loop_continuation_keeps_the_same_sampling():
     # OAICompatTransport captures **request_kwargs once and replays them every turn, so a
     # conversation that calls a tool must not start sampling differently afterwards.
     from core.inference.external_tool_transport import OAICompatTransport
-
     with _Server() as server:
         client = ExternalProviderClient(
-            provider_type = "vllm", base_url = server.base_url, api_key = "",
+            provider_type = "vllm",
+            base_url = server.base_url,
+            api_key = "",
         )
         transport = OAICompatTransport(
-            client, model = "a-model", stream = True,
-            top_k = 40, min_p = 0.07, repetition_penalty = 1.15,
+            client,
+            model = "a-model",
+            stream = True,
+            top_k = 40,
+            min_p = 0.07,
+            repetition_penalty = 1.15,
         )
         cancel_event = threading.Event()
         turns = [
             [{"role": "user", "content": "hi"}],
-            [{"role": "user", "content": "hi"},
-             {"role": "assistant", "content": "", "tool_calls": [
-                 {"id": "call_1", "type": "function",
-                  "function": {"name": "web_search", "arguments": "{}"}}]},
-             {"role": "tool", "tool_call_id": "call_1", "content": "result"}],
+            [
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "web_search", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ],
         ]
 
         async def go() -> None:
             for messages in turns:
                 async for _ in transport.stream(
-                    messages = messages, tools = None, tool_choice = None,
+                    messages = messages,
+                    tools = None,
+                    tool_choice = None,
                     cancel_event = cancel_event,
                 ):
                     pass

--- a/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
+++ b/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
@@ -3,17 +3,13 @@
 
 """The same forwarding claims, but over a socket and through the real route.
 
-``test_external_provider_sampling_forwarding.py`` covers the body builder with an
-``httpx.MockTransport`` and covers the route by AST-parsing ``routes/inference.py`` and
-comparing the names handed to ``dict(...)`` against the strings ``"_top_k_explicit"`` and
-friends. That proves the source says the right words; it cannot fail on the runtime hazard
-those words exist to prevent, which is that pydantic v2 records every ``setattr`` in
-``model_fields_set``, so anything writing to the payload before those three reads turns
-"the caller omitted this" into "the caller asked for the schema default".
+``test_external_provider_sampling_forwarding.py`` mocks the transport and AST-parses the
+route, which proves the source says the right words but cannot fail on the runtime hazard
+those words prevent: pydantic v2 records every ``setattr`` in ``model_fields_set``, so a
+write before those reads turns an omission into a request for the schema default.
 
-So this drives ``_proxy_to_external_provider`` itself, and a real ``http.server`` on
-loopback records the bytes. Stdlib only, no fixtures, no external network: the same file
-has to pass on Linux, macOS and Windows runners.
+So this drives ``_proxy_to_external_provider`` itself against a loopback ``http.server``.
+Stdlib only, so it passes identically on the Linux, macOS and Windows runners.
 """
 
 from __future__ import annotations
@@ -61,8 +57,7 @@ class _Server:
     """A live OpenAI-compatible endpoint that keeps every body it was posted."""
 
     def __enter__(self) -> "_Server":
-        # Port 0 lets the OS assign, which closes the bind-then-lose race a scanning
-        # helper cannot, and needs no free-port range on a busy CI runner.
+        # Port 0: the OS assigns, so no free-port scan can lose the race on a busy runner.
         self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
         self._httpd.recorded = []  # type: ignore[attr-defined]
         self._thread = threading.Thread(target = self._httpd.serve_forever, daemon = True)
@@ -176,12 +171,8 @@ def _route_capture(**payload_fields) -> dict:
         return server.sampling()
 
 
-# ── the route's explicit-vs-default gate, executed rather than parsed ──────────────────
-
-
 def test_a_request_that_never_mentioned_them_forwards_nothing():
-    # Reading payload.min_p on such a request yields 0.01, not None; only
-    # model_fields_set can tell it from a caller who asked for 0.01.
+    # payload.min_p yields 0.01 here, not None; only model_fields_set separates the two.
     assert _route_capture() == {}
 
 
@@ -194,8 +185,7 @@ def test_the_route_forwards_explicit_values():
 
 
 def test_explicit_values_equal_to_the_schema_defaults_are_still_forwarded():
-    # 20 / 0.01 / 1.0 ARE the defaults, so a `!= default` shortcut would drop them and a
-    # user who deliberately set the panel's own numbers would get provider sampling.
+    # 20 / 0.01 / 1.0 ARE the defaults, so a `!= default` shortcut would drop them.
     assert _route_capture(top_k = 20, min_p = 0.01, repetition_penalty = 1.0) == {
         "top_k": 20,
         "min_p": 0.01,
@@ -220,15 +210,10 @@ def test_one_field_set_forwards_only_that_field(field, value):
 
 
 def test_writing_to_the_payload_would_make_an_omission_look_explicit():
-    # The hazard the route's comment names, demonstrated. Any helper that setattr'd the
-    # payload before those reads would silently start forwarding schema defaults.
     payload = ChatCompletionRequest(messages = [{"role": "user", "content": "hi"}])
     assert "min_p" not in payload.model_fields_set
     payload.min_p = payload.min_p  # a no-op write, same value
     assert "min_p" in payload.model_fields_set
-
-
-# ── the body on the wire, for the providers the panel offers these on ──────────────────
 
 
 @pytest.mark.parametrize("provider_type", ["vllm", "openrouter"])
@@ -255,8 +240,7 @@ def test_ollama_receives_none_of_them_even_from_a_raw_api_caller():
 
 
 def test_the_tool_loop_continuation_keeps_the_same_sampling():
-    # OAICompatTransport captures **request_kwargs once and replays them every turn, so a
-    # conversation that calls a tool must not start sampling differently afterwards.
+    # OAICompatTransport replays **request_kwargs every turn; a tool call must not change it.
     from core.inference.external_tool_transport import OAICompatTransport
     with _Server() as server:
         client = ExternalProviderClient(

--- a/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
+++ b/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
@@ -53,12 +53,37 @@ class _Handler(BaseHTTPRequestHandler):
         self.wfile.write(sse)
 
 
+# What a gateway that validates its input accepts; the sampling extensions are absent.
+_OPENAI_DOCUMENTED = frozenset(
+    {
+        "model",
+        "messages",
+        "stream",
+        "stream_options",
+        "temperature",
+        "top_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "max_tokens",
+        "max_completion_tokens",
+        "stop",
+        "seed",
+        "response_format",
+        "tools",
+        "tool_choice",
+    }
+)
+
+
 class _Server:
     """A live OpenAI-compatible endpoint that keeps every body it was posted."""
 
+    def __init__(self, handler = None) -> None:
+        self._handler = handler or _Handler
+
     def __enter__(self) -> "_Server":
         # Port 0: the OS assigns, so no free-port scan can lose the race on a busy runner.
-        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), self._handler)
         self._httpd.recorded = []  # type: ignore[attr-defined]
         self._thread = threading.Thread(target = self._httpd.serve_forever, daemon = True)
         self._thread.start()
@@ -290,3 +315,56 @@ def test_the_tool_loop_continuation_keeps_the_same_sampling():
         assert len(server.bodies) == 2
         assert server.sampling(0) == {"top_k": 40, "min_p": 0.07, "repetition_penalty": 1.15}
         assert server.sampling(1) == server.sampling(0)
+
+
+def test_a_stale_frontend_bundle_does_not_start_400ing_a_custom_gateway():
+    # The pre-PR bundle classified custom as ALL_SUPPORTED and spread top_k on EVERY
+    # request, so a tab left open across an upgrade sends `top_k` to a backend that now
+    # forwards it. Measured on a gateway that validates its input: without custom's
+    # registry guard the same body went 200 -> 400 and the turn failed outright.
+    class _Strict(_Handler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length") or 0)
+            body = json.loads(self.rfile.read(length).decode() or "{}")
+            self.server.recorded.append(body)  # type: ignore[attr-defined]
+            unknown = sorted(set(body) - _OPENAI_DOCUMENTED)
+            if unknown:
+                payload = json.dumps(
+                    {
+                        "error": {
+                            "message": f"Unrecognized request argument supplied: {', '.join(unknown)}",
+                            "type": "invalid_request_error",
+                        }
+                    }
+                ).encode()
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+            else:
+                payload = (
+                    'data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n'
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    with _Server(handler = _Strict) as server:
+        client = ExternalProviderClient(
+            provider_type = "custom",
+            base_url = server.base_url,
+            api_key = "",
+        )
+        lines: list[str] = []
+
+        async def go() -> None:
+            async for line in client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "a-model",
+                top_k = 20,
+            ):
+                lines.append(line)
+
+        _run(go)
+        assert server.sampling() == {}, "custom leaked an extension the gateway rejects"
+        assert "Unrecognized request argument" not in "".join(lines)

--- a/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
+++ b/studio/backend/tests/test_external_provider_sampling_over_the_wire.py
@@ -318,10 +318,8 @@ def test_the_tool_loop_continuation_keeps_the_same_sampling():
 
 
 def test_a_stale_frontend_bundle_does_not_start_400ing_a_custom_gateway():
-    # The pre-PR bundle classified custom as ALL_SUPPORTED and spread top_k on EVERY
-    # request, so a tab left open across an upgrade sends `top_k` to a backend that now
-    # forwards it. Measured on a gateway that validates its input: without custom's
-    # registry guard the same body went 200 -> 400 and the turn failed outright.
+    # The pre-PR bundle spread top_k on every custom request and a tab left open across an
+    # upgrade still runs it. Without custom's registry guard this same body went 200 -> 400.
     class _Strict(_Handler):
         def do_POST(self) -> None:  # noqa: N802
             length = int(self.headers.get("Content-Length") or 0)

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5838,6 +5838,10 @@ export function createOpenAIStreamAdapter(
                 ? { thread_id: resolvedThreadId }
                 : {}),
               ...(externalCapabilities?.topK ? { top_k: params.topK } : {}),
+              ...(externalCapabilities?.minP ? { min_p: params.minP } : {}),
+              ...(externalCapabilities?.repetitionPenalty
+                ? { repetition_penalty: params.repetitionPenalty }
+                : {}),
               ...(externalCapabilities?.presencePenalty
                 ? { presence_penalty: params.presencePenalty }
                 : {}),

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -541,16 +541,12 @@ const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
   // OpenRouter silently drops unsupported params, so surface every knob and let the gateway
   // fan out per model.
   openrouter: ALL_SUPPORTED,
-  // An unknown OpenAI-compat endpoint may reject top_k / min_p / repetition_penalty outright
-  // (OpenAI-shaped gateways 400 on unrecognized fields), so custom stays on the baseline; the
-  // vllm / llama_cpp presets accept any base URL and surface the extra knobs.
+  // An OpenAI-shaped gateway 400s on unrecognized fields; vllm / llama_cpp take any base URL.
   custom: OPENAI_COMPAT_BASE,
   vllm: ALL_SUPPORTED,
-  // Ollama's /v1 layer reads only the OpenAI-documented fields and drops top_k / min_p /
-  // repeat_penalty without an error; they live in the native /api/chat options instead.
+  // Ollama's /v1 silently drops top_k / min_p / repeat_penalty (native /api/chat options).
   // https://docs.ollama.com/api/openai-compatibility
   ollama: OPENAI_COMPAT_BASE,
-  // The backend renames repetition_penalty to repeat_penalty for llama-server.
   llama_cpp: ALL_SUPPORTED,
 };
 

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -541,11 +541,16 @@ const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
   // OpenRouter silently drops unsupported params, so surface every knob and let the gateway
   // fan out per model.
   openrouter: ALL_SUPPORTED,
-  // Local OpenAI-compat connections use the OpenAI path, but vLLM/Ollama/llama.cpp users
-  // want top_k/min_p/repetition, so be permissive.
-  custom: ALL_SUPPORTED,
+  // An unknown OpenAI-compat endpoint may reject top_k / min_p / repetition_penalty outright
+  // (OpenAI-shaped gateways 400 on unrecognized fields), so custom stays on the baseline; the
+  // vllm / llama_cpp presets accept any base URL and surface the extra knobs.
+  custom: OPENAI_COMPAT_BASE,
   vllm: ALL_SUPPORTED,
-  ollama: ALL_SUPPORTED,
+  // Ollama's /v1 layer reads only the OpenAI-documented fields and drops top_k / min_p /
+  // repeat_penalty without an error; they live in the native /api/chat options instead.
+  // https://docs.ollama.com/api/openai-compatibility
+  ollama: OPENAI_COMPAT_BASE,
+  // The backend renames repetition_penalty to repeat_penalty for llama-server.
   llama_cpp: ALL_SUPPORTED,
 };
 

--- a/studio/frontend/tests/external-sampling-payload.test.ts
+++ b/studio/frontend/tests/external-sampling-payload.test.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The Chat Settings panel renders Min P and Repetition Penalty off the provider's
+// capability flags, and both persist per model and per thread -- but the external
+// request body only ever spread temperature, top_p, max_tokens, top_k and
+// presence_penalty, so on OpenRouter / vLLM / llama.cpp the two sliders moved
+// and nothing changed. The local body has sent both unconditionally all along.
+//
+// The body is built inside a several-thousand-line function that cannot be called from
+// here, so read the capability-gated spreads out of it and evaluate those: a row that
+// stops existing, or that gates on the wrong flag, fails.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import ts from "typescript";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { getProviderCapabilities } = await import(
+  "../src/features/chat/provider-capabilities.ts"
+);
+
+const PARAMS = {
+  temperature: 0.6,
+  topP: 0.95,
+  topK: 40,
+  minP: 0.07,
+  repetitionPenalty: 1.15,
+  presencePenalty: 0.3,
+};
+
+const source = readFileSync(
+  new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
+  "utf8",
+);
+const tree = ts.createSourceFile(
+  "chat-adapter.ts",
+  source,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+);
+
+function externalBodyLiteral(): ts.ObjectLiteralExpression {
+  let found: ts.ObjectLiteralExpression | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found &&
+      ts.isObjectLiteralExpression(node) &&
+      node.properties.some(
+        (property) =>
+          ts.isPropertyAssignment(property) &&
+          property.name.getText() === "model" &&
+          property.initializer.getText() === "externalSelection.modelId",
+      )
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(tree);
+  assert.ok(found, "external request body literal not found");
+  return found;
+}
+
+const gatedSpreads = externalBodyLiteral()
+  .properties.filter(ts.isSpreadAssignment)
+  .map((property) => property.expression.getText())
+  .filter((text) => text.includes("externalCapabilities"));
+
+// A guard against the extraction silently matching nothing and every assertion below
+// passing vacuously.
+assert.ok(gatedSpreads.length >= 4, `only ${gatedSpreads.length} gated spreads`);
+
+const buildSamplingFields = new Function(
+  "externalCapabilities",
+  "params",
+  `return Object.assign({}, ${gatedSpreads.join(", ")});`,
+) as (
+  capabilities: unknown,
+  params: typeof PARAMS,
+) => Record<string, number>;
+
+function bodyFor(providerType: string): Record<string, number> {
+  return buildSamplingFields(getProviderCapabilities(providerType), PARAMS);
+}
+
+for (const providerType of ["vllm", "openrouter", "llama_cpp"]) {
+  test(`${providerType} carries the min_p and repetition_penalty the panel offers`, () => {
+    const body = bodyFor(providerType);
+    assert.equal(body.min_p, PARAMS.minP);
+    assert.equal(body.repetition_penalty, PARAMS.repetitionPenalty);
+    // The rows that already worked must keep working.
+    assert.equal(body.top_k, PARAMS.topK);
+    assert.equal(body.presence_penalty, PARAMS.presencePenalty);
+    assert.equal(body.temperature, PARAMS.temperature);
+    assert.equal(body.top_p, PARAMS.topP);
+  });
+}
+
+test("custom stays on the OpenAI-compatible baseline", () => {
+  const body = bodyFor("custom");
+  assert.ok(!("min_p" in body));
+  assert.ok(!("repetition_penalty" in body));
+  assert.ok(!("top_k" in body));
+  assert.equal(body.presence_penalty, PARAMS.presencePenalty);
+  assert.equal(body.temperature, PARAMS.temperature);
+});
+
+test("ollama is sent none of the three its /v1 layer drops", () => {
+  // Ollama's OpenAI-compatibility layer reads only the OpenAI-documented fields; top_k,
+  // min_p and repeat_penalty are native /api/chat "options", so a body carrying them is
+  // answered with default sampling and no error. The panel hides all three instead.
+  const body = bodyFor("ollama");
+  assert.ok(!("min_p" in body));
+  assert.ok(!("repetition_penalty" in body));
+  assert.ok(!("top_k" in body));
+  assert.equal(body.presence_penalty, PARAMS.presencePenalty);
+  assert.equal(body.temperature, PARAMS.temperature);
+});
+
+test("a hosted provider's body is unchanged by the new rows", () => {
+  // Anthropic, OpenAI, Gemini, Kimi and DeepSeek all declare minP and repetitionPenalty
+  // false, so nothing new can appear in their bodies.
+  for (const providerType of [
+    "anthropic",
+    "openai",
+    "openai_codex",
+    "gemini",
+    "kimi",
+    "deepseek",
+    "mistral",
+    "qwen",
+    "huggingface",
+  ]) {
+    const body = bodyFor(providerType);
+    assert.ok(!("min_p" in body), providerType);
+    assert.ok(!("repetition_penalty" in body), providerType);
+  }
+});
+
+test("an unknown provider stays on the OpenAI-compatible shape", () => {
+  // A connection saved by a newer build lands on the default capability set, which must
+  // not start sending extensions a strict endpoint would 400 on.
+  const body = bodyFor("some-provider-this-build-never-heard-of");
+  assert.ok(!("min_p" in body));
+  assert.ok(!("repetition_penalty" in body));
+  assert.ok(!("top_k" in body));
+});
+
+test("the panel and the request read the same capability flags", () => {
+  const sheet = readFileSync(
+    new URL("../src/features/chat/chat-settings-sheet.tsx", import.meta.url),
+    "utf8",
+  );
+  // The sliders are rendered off providerCapabilities.minP / .repetitionPenalty; a body
+  // gating on anything else is how the two drifted apart in the first place.
+  assert.match(sheet, /Boolean\(providerCapabilities\?\.minP\)/);
+  assert.match(sheet, /Boolean\(providerCapabilities\?\.repetitionPenalty\)/);
+  assert.ok(
+    gatedSpreads.some((text) => text.includes("externalCapabilities?.minP")),
+  );
+  assert.ok(
+    gatedSpreads.some((text) =>
+      text.includes("externalCapabilities?.repetitionPenalty"),
+    ),
+  );
+});

--- a/studio/frontend/tests/external-sampling-payload.test.ts
+++ b/studio/frontend/tests/external-sampling-payload.test.ts
@@ -1,15 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// The Chat Settings panel renders Min P and Repetition Penalty off the provider's
-// capability flags, and both persist per model and per thread -- but the external
-// request body only ever spread temperature, top_p, max_tokens, top_k and
-// presence_penalty, so on OpenRouter / vLLM / llama.cpp the two sliders moved
-// and nothing changed. The local body has sent both unconditionally all along.
-//
-// The body is built inside a several-thousand-line function that cannot be called from
-// here, so read the capability-gated spreads out of it and evaluate those: a row that
-// stops existing, or that gates on the wrong flag, fails.
+// The external body never spread min_p / repetition_penalty, so the sliders did nothing.
+// Its function is too large to call here, so the gated spreads are extracted and evaluated.
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -74,8 +67,7 @@ const gatedSpreads = externalBodyLiteral()
   .map((property) => property.expression.getText())
   .filter((text) => text.includes("externalCapabilities"));
 
-// A guard against the extraction silently matching nothing and every assertion below
-// passing vacuously.
+// Without this, an extraction that matched nothing would pass every assertion vacuously.
 assert.ok(gatedSpreads.length >= 4, `only ${gatedSpreads.length} gated spreads`);
 
 const buildSamplingFields = new Function(
@@ -96,7 +88,6 @@ for (const providerType of ["vllm", "openrouter", "llama_cpp"]) {
     const body = bodyFor(providerType);
     assert.equal(body.min_p, PARAMS.minP);
     assert.equal(body.repetition_penalty, PARAMS.repetitionPenalty);
-    // The rows that already worked must keep working.
     assert.equal(body.top_k, PARAMS.topK);
     assert.equal(body.presence_penalty, PARAMS.presencePenalty);
     assert.equal(body.temperature, PARAMS.temperature);
@@ -114,9 +105,6 @@ test("custom stays on the OpenAI-compatible baseline", () => {
 });
 
 test("ollama is sent none of the three its /v1 layer drops", () => {
-  // Ollama's OpenAI-compatibility layer reads only the OpenAI-documented fields; top_k,
-  // min_p and repeat_penalty are native /api/chat "options", so a body carrying them is
-  // answered with default sampling and no error. The panel hides all three instead.
   const body = bodyFor("ollama");
   assert.ok(!("min_p" in body));
   assert.ok(!("repetition_penalty" in body));
@@ -126,8 +114,6 @@ test("ollama is sent none of the three its /v1 layer drops", () => {
 });
 
 test("a hosted provider's body is unchanged by the new rows", () => {
-  // Anthropic, OpenAI, Gemini, Kimi and DeepSeek all declare minP and repetitionPenalty
-  // false, so nothing new can appear in their bodies.
   for (const providerType of [
     "anthropic",
     "openai",
@@ -146,8 +132,7 @@ test("a hosted provider's body is unchanged by the new rows", () => {
 });
 
 test("an unknown provider stays on the OpenAI-compatible shape", () => {
-  // A connection saved by a newer build lands on the default capability set, which must
-  // not start sending extensions a strict endpoint would 400 on.
+  // A connection saved by a newer build lands here, and a strict endpoint 400s on extensions.
   const body = bodyFor("some-provider-this-build-never-heard-of");
   assert.ok(!("min_p" in body));
   assert.ok(!("repetition_penalty" in body));
@@ -159,8 +144,7 @@ test("the panel and the request read the same capability flags", () => {
     new URL("../src/features/chat/chat-settings-sheet.tsx", import.meta.url),
     "utf8",
   );
-  // The sliders are rendered off providerCapabilities.minP / .repetitionPenalty; a body
-  // gating on anything else is how the two drifted apart in the first place.
+  // Gating the body on anything but these flags is how panel and request drifted apart.
   assert.match(sheet, /Boolean\(providerCapabilities\?\.minP\)/);
   assert.match(sheet, /Boolean\(providerCapabilities\?\.repetitionPenalty\)/);
   assert.ok(


### PR DESCRIPTION
On OpenRouter, vLLM and llama.cpp connections the chat settings panel shows Min P and Repetition Penalty sliders and remembers their values per model and per thread. The request never carried either one, so moving the sliders had no effect on the output.

Top K had a second problem in the same area. The value was passed all the way through to the client and then never written into the request body, even though the code comment said it was forwarded.

All three are now sent, and only when a value was actually set, so a request that does not mention them still sends nothing. For llama.cpp the field is renamed to repeat_penalty, which is the name that server reads. Sending repetition_penalty to it is accepted and then ignored, so the slider looked broken. The in process llama.cpp client in this repo already uses the correct name.

Ollama does not accept any of the three on its OpenAI compatible endpoint. They belong to its own API instead, and unknown fields there are dropped without an error. Those sliders are now hidden for Ollama, and the fields are also stripped on the server side, since that endpoint can be called directly and not only from the app.

Custom connections stay on the standard OpenAI fields. An unknown server behind a custom base URL may reject fields it does not know, and the vLLM and llama.cpp presets accept any base URL if you want the extra sliders.

Hosted providers are unchanged. They already report these sliders as unsupported, so nothing new appears in their requests.
