### PR TITLE
Studio: show mlx-community models as MLX in the model picker

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -11,10 +11,7 @@ const GGUF_SUFFIX_RE = /-GGUF(?:$|-)/i;
 // Mirrors the backend's _looks_like_mlx_repo: owner prefix, or a bounded mlx token in the leaf.
 const MLX_RE = /(?:^|[-_.])mlx(?:$|[-_.])/i;
 const MLX_OWNER_PREFIX = "mlx-community/";
-// localModelIsMlx feeds LocalModelInfo.id, which is a filesystem PATH for models_dir/lmstudio/custom
-// rows, so the leaf is taken on either separator. A repo id can never contain a backslash, so repo
-// ids are unaffected; this only stops a Windows path from being judged by its parent directories,
-// the way a POSIX one already is.
+// Callers pass LocalModelInfo.id, a filesystem path, so a Windows one must split too.
 const PATH_SEP_RE = /[\\/]/;
 
 export function isGgufId(id: string, hintedIsGguf?: boolean): boolean {

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -11,6 +11,11 @@ const GGUF_SUFFIX_RE = /-GGUF(?:$|-)/i;
 // Mirrors the backend's _looks_like_mlx_repo: owner prefix, or a bounded mlx token in the leaf.
 const MLX_RE = /(?:^|[-_.])mlx(?:$|[-_.])/i;
 const MLX_OWNER_PREFIX = "mlx-community/";
+// localModelIsMlx feeds LocalModelInfo.id, which is a filesystem PATH for models_dir/lmstudio/custom
+// rows, so the leaf is taken on either separator. A repo id can never contain a backslash, so repo
+// ids are unaffected; this only stops a Windows path from being judged by its parent directories,
+// the way a POSIX one already is.
+const PATH_SEP_RE = /[\\/]/;
 
 export function isGgufId(id: string, hintedIsGguf?: boolean): boolean {
   return Boolean(hintedIsGguf) || GGUF_SUFFIX_RE.test(id);
@@ -19,7 +24,7 @@ export function isGgufId(id: string, hintedIsGguf?: boolean): boolean {
 export function isMlxId(id: string): boolean {
   const trimmed = id.trim();
   if (trimmed.toLowerCase().startsWith(MLX_OWNER_PREFIX)) return true;
-  const leaf = trimmed.split("/").filter(Boolean).at(-1) ?? trimmed;
+  const leaf = trimmed.split(PATH_SEP_RE).filter(Boolean).at(-1) ?? trimmed;
   return MLX_RE.test(leaf);
 }
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/recommended-fit.ts
@@ -8,14 +8,19 @@ import { classifyGgufFit } from "../../../../lib/gguf-fit.ts";
 import { classifyMediaGgufFit } from "./model-catalog.ts";
 
 const GGUF_SUFFIX_RE = /-GGUF(?:$|-)/i;
-const MLX_RE = /-MLX(?:$|-)/i;
+// Mirrors the backend's _looks_like_mlx_repo: owner prefix, or a bounded mlx token in the leaf.
+const MLX_RE = /(?:^|[-_.])mlx(?:$|[-_.])/i;
+const MLX_OWNER_PREFIX = "mlx-community/";
 
 export function isGgufId(id: string, hintedIsGguf?: boolean): boolean {
   return Boolean(hintedIsGguf) || GGUF_SUFFIX_RE.test(id);
 }
 
 export function isMlxId(id: string): boolean {
-  return MLX_RE.test(id);
+  const trimmed = id.trim();
+  if (trimmed.toLowerCase().startsWith(MLX_OWNER_PREFIX)) return true;
+  const leaf = trimmed.split("/").filter(Boolean).at(-1) ?? trimmed;
+  return MLX_RE.test(leaf);
 }
 
 // "mobile" build token (e.g. "gemma-4-E4B-it-qat-mobile-GGUF"); bounded so it never matches inside a longer word.

--- a/studio/frontend/tests/mlx-community-repo-detection.test.ts
+++ b/studio/frontend/tests/mlx-community-repo-detection.test.ts
@@ -38,18 +38,14 @@ test("the format filter routes an mlx-community repo to MLX, not Safetensors", (
   assert.equal(matchesFormatFilter(COMMUNITY, false, "all"), true);
 });
 
-// localModelIsMlx passes LocalModelInfo.id, which is a filesystem path for models_dir, lmstudio and
-// custom-folder rows, so a local model is judged by its own folder name on every platform rather
-// than by whatever the parent directories happen to be called.
+// localModelIsMlx passes LocalModelInfo.id, a filesystem path: parent directories must not decide.
 test("a local path is judged by its leaf on both separators", () => {
   assert.equal(isMlxId("/Users/me/models/Qwen3-8B-MLX"), true);
   assert.equal(isMlxId("C:\\Users\\me\\models\\Qwen3-8B-MLX"), true);
   assert.equal(isMlxId("/Users/me/Qwen-MLX-builds/Qwen3-8B"), false);
   assert.equal(isMlxId("C:\\Users\\me\\Qwen-MLX-builds\\Qwen3-8B"), false);
-  // A .gguf file under an MLX-named folder is GGUF, not MLX, on either platform.
   assert.equal(isMlxId("/Users/me/Qwen3-MLX-4bit/model.gguf"), false);
   assert.equal(isMlxId("C:\\Users\\me\\Qwen3-MLX-4bit\\model.gguf"), false);
-  // LM Studio's publisher layout reaches the same verdict through model_id.
   assert.equal(isMlxId("mlx-community/Qwen3-8B-4bit"), true);
 });
 

--- a/studio/frontend/tests/mlx-community-repo-detection.test.ts
+++ b/studio/frontend/tests/mlx-community-repo-detection.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isMlxId,
+  matchesFormatFilter,
+} from "../src/features/model-picker/components/model-selector/recommended-fit.ts";
+
+const COMMUNITY = "mlx-community/Qwen3-8B-4bit";
+
+test("an mlx-community repo is MLX even without an -MLX suffix", () => {
+  assert.equal(isMlxId(COMMUNITY), true);
+  assert.equal(isMlxId("MLX-Community/gemma-3-27b-it-8bit"), true);
+  assert.equal(isMlxId("mlx-community/Llama-3.2-3B-Instruct-4bit"), true);
+});
+
+test("an mlx token in the repo leaf is MLX wherever it sits", () => {
+  assert.equal(isMlxId("unsloth/Qwen3-8B-MLX"), true);
+  assert.equal(isMlxId("unsloth/Qwen3-MLX-8B"), true);
+  assert.equal(isMlxId("unsloth/mlx_Qwen3-8B"), true);
+  assert.equal(isMlxId("Qwen3-8B-4bit-mlx"), true);
+});
+
+test("the mlx token stays bounded, so a longer word is not MLX", () => {
+  assert.equal(isMlxId("org/mlxray-7B"), false);
+  assert.equal(isMlxId("org/Qwen-mlxtra"), false);
+  assert.equal(isMlxId("mlxcommunity/Qwen3-8B-4bit"), false);
+  assert.equal(isMlxId("unsloth/Qwen3-8B-GGUF"), false);
+});
+
+test("the format filter routes an mlx-community repo to MLX, not Safetensors", () => {
+  assert.equal(matchesFormatFilter(COMMUNITY, false, "mlx"), true);
+  assert.equal(matchesFormatFilter(COMMUNITY, false, "safetensors"), false);
+  assert.equal(matchesFormatFilter(COMMUNITY, false, "gguf"), false);
+  assert.equal(matchesFormatFilter(COMMUNITY, false, "all"), true);
+});
+
+test("a plain safetensors repo still answers the safetensors filter", () => {
+  const plain = "unsloth/Qwen3-8B";
+  assert.equal(matchesFormatFilter(plain, false, "safetensors"), true);
+  assert.equal(matchesFormatFilter(plain, false, "mlx"), false);
+  assert.equal(matchesFormatFilter("org/mlxray-7B", false, "safetensors"), true);
+});

--- a/studio/frontend/tests/mlx-community-repo-detection.test.ts
+++ b/studio/frontend/tests/mlx-community-repo-detection.test.ts
@@ -38,6 +38,21 @@ test("the format filter routes an mlx-community repo to MLX, not Safetensors", (
   assert.equal(matchesFormatFilter(COMMUNITY, false, "all"), true);
 });
 
+// localModelIsMlx passes LocalModelInfo.id, which is a filesystem path for models_dir, lmstudio and
+// custom-folder rows, so a local model is judged by its own folder name on every platform rather
+// than by whatever the parent directories happen to be called.
+test("a local path is judged by its leaf on both separators", () => {
+  assert.equal(isMlxId("/Users/me/models/Qwen3-8B-MLX"), true);
+  assert.equal(isMlxId("C:\\Users\\me\\models\\Qwen3-8B-MLX"), true);
+  assert.equal(isMlxId("/Users/me/Qwen-MLX-builds/Qwen3-8B"), false);
+  assert.equal(isMlxId("C:\\Users\\me\\Qwen-MLX-builds\\Qwen3-8B"), false);
+  // A .gguf file under an MLX-named folder is GGUF, not MLX, on either platform.
+  assert.equal(isMlxId("/Users/me/Qwen3-MLX-4bit/model.gguf"), false);
+  assert.equal(isMlxId("C:\\Users\\me\\Qwen3-MLX-4bit\\model.gguf"), false);
+  // LM Studio's publisher layout reaches the same verdict through model_id.
+  assert.equal(isMlxId("mlx-community/Qwen3-8B-4bit"), true);
+});
+
 test("a plain safetensors repo still answers the safetensors filter", () => {
   const plain = "unsloth/Qwen3-8B";
   assert.equal(matchesFormatFilter(plain, false, "safetensors"), true);

--- a/studio/frontend/tests/mlx-community-repo-detection.test.ts
+++ b/studio/frontend/tests/mlx-community-repo-detection.test.ts
@@ -42,5 +42,8 @@ test("a plain safetensors repo still answers the safetensors filter", () => {
   const plain = "unsloth/Qwen3-8B";
   assert.equal(matchesFormatFilter(plain, false, "safetensors"), true);
   assert.equal(matchesFormatFilter(plain, false, "mlx"), false);
-  assert.equal(matchesFormatFilter("org/mlxray-7B", false, "safetensors"), true);
+  assert.equal(
+    matchesFormatFilter("org/mlxray-7B", false, "safetensors"),
+    true,
+  );
 });


### PR DESCRIPTION
The model picker decided a repo was MLX only if its name ended in -MLX. Nearly every MLX model is published under the mlx-community account, and those names do not end that way, so the picker got them wrong in three places.

They were labelled Safetensors instead of MLX. Choosing MLX in the format dropdown gave an empty list even when MLX models were downloaded. And on a Mac set up for chat only, an MLX folder sitting in the models directory was not listed at all, because that view only shows GGUF and MLX.

The backend already handles this correctly. It treats a repo as MLX if it comes from mlx-community or if mlx appears as a whole word in the repo name. The Hub page in the app uses the same idea. The picker now uses that rule too, so the three places agree.

The match still needs mlx to be a separate word, so a name like mlxray is not treated as MLX. Only files in the picker changed here, GGUF results are unchanged, and models that already ended in -MLX still work.
