### PR TITLE
Studio: stop re-fetching every llama.cpp release from the GitHub API

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -590,7 +590,10 @@ def github_api_headers(url: str | None = None) -> dict[str, str]:
 
 is_github_api_url = _core.is_github_api_url
 is_retryable_url_error = _core.is_retryable_url_error
-_RATE_LIMIT_WAIT_CAP_SECONDS = 60.0
+# Alias, not a copy: _http_error_retry_delay reads prebuilt_core's global, so a
+# literal here would silently do nothing now that the cap decides whether a
+# GitHub 403 is retried at all, not just how long the backoff waits.
+_RATE_LIMIT_WAIT_CAP_SECONDS = _core._RATE_LIMIT_WAIT_CAP_SECONDS
 _http_error_retry_delay = _core._http_error_retry_delay
 sleep_backoff = _core.sleep_backoff
 atomic_write_bytes = _core.atomic_write_bytes

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -1572,14 +1572,9 @@ def parse_approved_release_checksums(
     )
 
 
-def load_approved_release_checksums(repo: str, release_tag: str) -> ApprovedReleaseChecksums:
-    try:
-        release = github_release(repo, release_tag)
-    except Exception as exc:
-        raise PrebuiltFallback(
-            f"approved prebuilt release {repo}@{release_tag} was not available"
-        ) from exc
-    assets = release_asset_map(release)
+def load_approved_release_checksums(
+    repo: str, release_tag: str, assets: dict[str, str]
+) -> ApprovedReleaseChecksums:
     checksum_url = assets.get(DEFAULT_PUBLISHED_SHA256_ASSET)
     if not checksum_url:
         raise PrebuiltFallback(
@@ -1966,7 +1961,7 @@ def _validate_checksums_against_bundle(
 def validated_checksums_for_bundle(
     repo: str, bundle: PublishedReleaseBundle
 ) -> ApprovedReleaseChecksums:
-    checksums = load_approved_release_checksums(repo, bundle.release_tag)
+    checksums = load_approved_release_checksums(repo, bundle.release_tag, bundle.assets)
     return _validate_checksums_against_bundle(repo, bundle, checksums)
 
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -590,9 +590,7 @@ def github_api_headers(url: str | None = None) -> dict[str, str]:
 
 is_github_api_url = _core.is_github_api_url
 is_retryable_url_error = _core.is_retryable_url_error
-# Alias, not a copy: _http_error_retry_delay reads prebuilt_core's global, so a
-# literal here would silently do nothing now that the cap decides whether a
-# GitHub 403 is retried at all, not just how long the backoff waits.
+# Alias, not a copy: _http_error_retry_delay reads prebuilt_core's global, so a literal here does nothing.
 _RATE_LIMIT_WAIT_CAP_SECONDS = _core._RATE_LIMIT_WAIT_CAP_SECONDS
 _http_error_retry_delay = _core._http_error_retry_delay
 sleep_backoff = _core.sleep_backoff

--- a/studio/prebuilt_core.py
+++ b/studio/prebuilt_core.py
@@ -392,14 +392,12 @@ def is_github_api_url(url: str | None) -> bool:
 
 def is_retryable_url_error(exc: Exception) -> bool:
     if isinstance(exc, urllib.error.HTTPError):
-        # GitHub answers an API rate-limit with 403 or 429 (429 is already in
-        # RETRYABLE_HTTP_STATUS); anonymous calls share a 60-req/hour bucket per
-        # runner IP that CI fleets exhaust. Treat 403
-        # against api.github.com as retryable so we get a backoff cycle or two
-        # (honouring Retry-After / X-RateLimit-Reset) before the source-build
-        # fallback fires. 403s on other hosts (private downloads, auth) stay non-retryable.
+        # A GitHub API 403 is a rate limit; only retry when the reset is close enough to wait for.
         if exc.code == 403:
-            return is_github_api_url(getattr(exc, "url", None))
+            return (
+                is_github_api_url(getattr(exc, "url", None))
+                and _http_error_retry_delay(exc) is not None
+            )
         return exc.code in RETRYABLE_HTTP_STATUS
     if isinstance(exc, urllib.error.URLError):
         return True

--- a/tests/studio/install/test_download_host_resolve.py
+++ b/tests/studio/install/test_download_host_resolve.py
@@ -113,10 +113,7 @@ def test_fast_path_none_falls_back_to_api(monkeypatch):
 def test_fast_path_rejected_checksum_falls_back_to_api(monkeypatch):
     monkeypatch.delenv("UNSLOTH_LLAMA_DISABLE_DOWNLOAD_HOST_RESOLVE", raising = False)
 
-    # Two arguments: _download_host_resolved_release is called as (repo, tag). A
-    # one-argument stub raises TypeError, which the caller's broad except also
-    # turns into an API fallback, so the assertion below would pass without the
-    # PrebuiltFallback branch ever running.
+    # Two args: a one-arg stub's TypeError hits the same broad except, so the branch never runs.
     def _reject(_repo, _tag = ""):
         raise PrebuiltFallback("checksum mismatch")
 

--- a/tests/studio/install/test_download_host_resolve.py
+++ b/tests/studio/install/test_download_host_resolve.py
@@ -113,7 +113,11 @@ def test_fast_path_none_falls_back_to_api(monkeypatch):
 def test_fast_path_rejected_checksum_falls_back_to_api(monkeypatch):
     monkeypatch.delenv("UNSLOTH_LLAMA_DISABLE_DOWNLOAD_HOST_RESOLVE", raising = False)
 
-    def _reject(_repo):
+    # Two arguments: _download_host_resolved_release is called as (repo, tag). A
+    # one-argument stub raises TypeError, which the caller's broad except also
+    # turns into an API fallback, so the assertion below would pass without the
+    # PrebuiltFallback branch ever running.
+    def _reject(_repo, _tag = ""):
         raise PrebuiltFallback("checksum mismatch")
 
     monkeypatch.setattr(ILP, "_download_host_resolved_release", _reject)

--- a/tests/studio/install/test_pr4562_bugfixes.py
+++ b/tests/studio/install/test_pr4562_bugfixes.py
@@ -240,7 +240,7 @@ class TestResolveRequestedLlamaTag:
             lambda repo, published_release_tag = "": iter([invalid, valid]),
         )
 
-        def fake_load(repo, release_tag):
+        def fake_load(repo, release_tag, assets):
             if release_tag == "v2.0":
                 raise MOD.PrebuiltFallback("checksum asset missing")
             return ApprovedReleaseChecksums(

--- a/tests/studio/install/test_prebuilt_core.py
+++ b/tests/studio/install/test_prebuilt_core.py
@@ -21,7 +21,6 @@ import io
 import json
 import sys
 import tarfile
-import time
 import urllib.error
 import zipfile
 from pathlib import Path
@@ -934,11 +933,12 @@ def _github_api_403(headers):
     [
         ({}, False),
         ({"Retry-After": "5"}, True),
-        ({"X-RateLimit-Reset": str(int(time.time()) + 30)}, True),
-        ({"X-RateLimit-Reset": str(int(time.time()) + 3600)}, False),
+        ({"X-RateLimit-Reset": "1700000030"}, True),
+        ({"X-RateLimit-Reset": "1700003600"}, False),
     ],
 )
-def test_github_api_403_retries_only_with_a_reachable_reset(headers, retryable):
+def test_github_api_403_retries_only_with_a_reachable_reset(monkeypatch, headers, retryable):
+    monkeypatch.setattr(core.time, "time", lambda: 1_700_000_000.0)
     assert core.is_retryable_url_error(_github_api_403(headers)) is retryable
 
 

--- a/tests/studio/install/test_prebuilt_core.py
+++ b/tests/studio/install/test_prebuilt_core.py
@@ -21,6 +21,8 @@ import io
 import json
 import sys
 import tarfile
+import time
+import urllib.error
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -915,3 +917,46 @@ def test_module_ops_prefers_module_globals_over_core_defaults(component):
     assert callable(ops.fetch_json)
     with pytest.raises(AttributeError):
         _ = ops.does_not_exist_anywhere
+
+
+def _github_api_403(headers):
+    return urllib.error.HTTPError(
+        "https://api.github.com/repos/unslothai/llama.cpp/releases/tags/b1",
+        403,
+        "rate limit exceeded",
+        headers,
+        io.BytesIO(b""),
+    )
+
+
+@pytest.mark.parametrize(
+    ("headers", "retryable"),
+    [
+        ({}, False),
+        ({"Retry-After": "5"}, True),
+        ({"X-RateLimit-Reset": str(int(time.time()) + 30)}, True),
+        ({"X-RateLimit-Reset": str(int(time.time()) + 3600)}, False),
+    ],
+)
+def test_github_api_403_retries_only_with_a_reachable_reset(headers, retryable):
+    assert core.is_retryable_url_error(_github_api_403(headers)) is retryable
+
+
+def test_github_api_403_without_a_reachable_reset_makes_one_request():
+    component = Component(LLAMA_DESCRIPTOR)
+    requests = []
+
+    class Opener:
+        def open(self, request, timeout = None):
+            requests.append(request.full_url)
+            raise _github_api_403({})
+
+    component.namespace["_URL_OPENER"] = Opener()
+
+    with pytest.raises(urllib.error.HTTPError):
+        core.download_bytes(
+            component.ops,
+            "https://api.github.com/repos/unslothai/llama.cpp/releases/tags/b1",
+        )
+
+    assert len(requests) == 1

--- a/tests/studio/install/test_prebuilt_core.py
+++ b/tests/studio/install/test_prebuilt_core.py
@@ -947,7 +947,11 @@ def test_github_api_403_without_a_reachable_reset_makes_one_request():
     requests = []
 
     class Opener:
-        def open(self, request, timeout = None):
+        def open(
+            self,
+            request,
+            timeout = None,
+        ):
             requests.append(request.full_url)
             raise _github_api_403({})
 

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -1077,10 +1077,6 @@ class TestValidatedChecksumsForBundle:
         assert plan.source_ref_kind == "commit"
         assert plan.source_ref == "a" * 40
 
-    # ===========================================================================
-    # K. linux_cuda_choice_from_release -- core selection
-    # ===========================================================================
-
     def test_reads_the_checksum_asset_from_the_listing(self, monkeypatch):
         bundle = make_release([], release_tag = "r1", upstream_tag = "b8508")
         sha_url = "https://github.com/unslothai/llama.cpp/releases/download/r1/sha.json"
@@ -1113,6 +1109,10 @@ class TestValidatedChecksumsForBundle:
         with pytest.raises(PrebuiltFallback, match = "did not expose"):
             validated_checksums_for_bundle("unslothai/llama.cpp", bundle)
 
+
+# ===========================================================================
+# K. linux_cuda_choice_from_release -- core selection
+# ===========================================================================
 
 class TestLinuxCudaChoiceFromRelease:
     def test_no_runtime_lines_detected(self, monkeypatch):

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -793,7 +793,6 @@ class TestPublishedReleaseResolution:
         resolved = resolve_published_release(commit, "unslothai/llama.cpp")
         assert resolved.bundle.release_tag == "release-commit"
 
-
     def test_walk_back_reads_checksums_from_the_listing(self, monkeypatch):
         tags = ["b3", "b2", "b1"]
         cdn = "https://github.com/unslothai/llama.cpp/releases/download"
@@ -835,9 +834,7 @@ class TestPublishedReleaseResolution:
         monkeypatch.setenv("UNSLOTH_LLAMA_DISABLE_DOWNLOAD_HOST_RESOLVE", "1")
 
         resolved = list(
-            INSTALL_LLAMA_PREBUILT.iter_resolved_published_releases(
-                "latest", "unslothai/llama.cpp"
-            )
+            INSTALL_LLAMA_PREBUILT.iter_resolved_published_releases("latest", "unslothai/llama.cpp")
         )
 
         assert [entry.bundle.release_tag for entry in resolved] == tags
@@ -1080,11 +1077,9 @@ class TestValidatedChecksumsForBundle:
         assert plan.source_ref_kind == "commit"
         assert plan.source_ref == "a" * 40
 
-
-# ===========================================================================
-# K. linux_cuda_choice_from_release -- core selection
-# ===========================================================================
-
+    # ===========================================================================
+    # K. linux_cuda_choice_from_release -- core selection
+    # ===========================================================================
 
     def test_reads_the_checksum_asset_from_the_listing(self, monkeypatch):
         bundle = make_release([], release_tag = "r1", upstream_tag = "b8508")

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -840,6 +840,51 @@ class TestPublishedReleaseResolution:
         assert [entry.bundle.release_tag for entry in resolved] == tags
         assert len(api_calls) == 1
 
+    def test_walk_back_skips_a_release_whose_listing_omits_the_checksum_asset(self, monkeypatch):
+        # Reading assets from the listing means a release still being published
+        # (sha256 asset not uploaded yet) is judged on that snapshot instead of a
+        # fresh per-tag lookup. The walk must degrade to the next good release
+        # rather than failing the whole resolution.
+        tags = ["b3", "b2", "b1"]
+        cdn = "https://github.com/unslothai/llama.cpp/releases/download"
+        manifest = INSTALL_LLAMA_PREBUILT.DEFAULT_PUBLISHED_MANIFEST_ASSET
+        sha = INSTALL_LLAMA_PREBUILT.DEFAULT_PUBLISHED_SHA256_ASSET
+        listing = []
+        for tag in tags:
+            assets = [{"name": manifest, "browser_download_url": f"{cdn}/{tag}/{manifest}"}]
+            if tag != "b3":
+                assets.append({"name": sha, "browser_download_url": f"{cdn}/{tag}/{sha}"})
+            listing.append({"tag_name": tag, "draft": False, "prerelease": False, "assets": assets})
+        api_calls = []
+
+        def fake_fetch_json(url):
+            if url.startswith("https://api.github.com/"):
+                api_calls.append(url)
+                assert "/releases/tags/" not in url, f"per-release API call: {url}"
+                return listing
+            return checksum_payload(url.rsplit("/", 2)[-2], "b8508")
+
+        def fake_download_bytes(url, **_):
+            return json.dumps(
+                {
+                    "schema_version": 1,
+                    "component": "llama.cpp",
+                    "upstream_tag": "b8508",
+                    "artifacts": [],
+                }
+            ).encode()
+
+        monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "fetch_json", fake_fetch_json)
+        monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "download_bytes", fake_download_bytes)
+        monkeypatch.setenv("UNSLOTH_LLAMA_DISABLE_DOWNLOAD_HOST_RESOLVE", "1")
+
+        resolved = list(
+            INSTALL_LLAMA_PREBUILT.iter_resolved_published_releases("latest", "unslothai/llama.cpp")
+        )
+
+        assert [entry.bundle.release_tag for entry in resolved] == ["b2", "b1"]
+        assert len(api_calls) == 1
+
 
 class TestSourceBuildPlanResolution:
     def test_matches_request_by_non_tag_provenance(self):

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -1114,6 +1114,7 @@ class TestValidatedChecksumsForBundle:
 # K. linux_cuda_choice_from_release -- core selection
 # ===========================================================================
 
+
 class TestLinuxCudaChoiceFromRelease:
     def test_no_runtime_lines_detected(self, monkeypatch):
         mock_linux_runtime(monkeypatch, [])

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -841,10 +841,7 @@ class TestPublishedReleaseResolution:
         assert len(api_calls) == 1
 
     def test_walk_back_skips_a_release_whose_listing_omits_the_checksum_asset(self, monkeypatch):
-        # Reading assets from the listing means a release still being published
-        # (sha256 asset not uploaded yet) is judged on that snapshot instead of a
-        # fresh per-tag lookup. The walk must degrade to the next good release
-        # rather than failing the whole resolution.
+        # A half-published release is judged on the listing snapshot: degrade, do not fail.
         tags = ["b3", "b2", "b1"]
         cdn = "https://github.com/unslothai/llama.cpp/releases/download"
         manifest = INSTALL_LLAMA_PREBUILT.DEFAULT_PUBLISHED_MANIFEST_ASSET

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -1,6 +1,7 @@
 """Binary selection logic in install_llama_prebuilt.py; all I/O monkeypatched."""
 
 import importlib.util
+import json
 import os
 import socket
 import subprocess
@@ -170,6 +171,22 @@ def make_release(artifacts, **overrides):
     )
     defaults.update(overrides)
     return PublishedReleaseBundle(**defaults)
+
+
+def checksum_payload(release_tag, upstream_tag):
+    return {
+        "schema_version": 1,
+        "component": "llama.cpp",
+        "release_tag": release_tag,
+        "upstream_tag": upstream_tag,
+        "artifacts": {
+            source_archive_logical_name(upstream_tag): {
+                "sha256": "a" * 64,
+                "repo": "ggml-org/llama.cpp",
+                "kind": "upstream-source",
+            }
+        },
+    }
 
 
 def make_checksums(asset_names):
@@ -650,7 +667,7 @@ class TestPublishedReleaseResolution:
             lambda repo, published_release_tag = "": iter([invalid, valid]),
         )
 
-        def fake_load(repo, release_tag):
+        def fake_load(repo, release_tag, assets):
             if release_tag == "v2.0":
                 raise PrebuiltFallback("checksum asset missing")
             return make_checksums_with_source([], release_tag = "v1.0", upstream_tag = "b8999")
@@ -676,7 +693,7 @@ class TestPublishedReleaseResolution:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
-            lambda repo, release_tag: make_checksums_with_source(
+            lambda repo, release_tag, assets: make_checksums_with_source(
                 [],
                 release_tag = release_tag,
                 upstream_tag = "b8508",
@@ -706,7 +723,7 @@ class TestPublishedReleaseResolution:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
-            lambda repo, release_tag: make_checksums_with_source(
+            lambda repo, release_tag, assets: make_checksums_with_source(
                 [],
                 release_tag = release_tag,
                 upstream_tag = "b9000",
@@ -736,7 +753,7 @@ class TestPublishedReleaseResolution:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
-            lambda repo, release_tag: make_checksums_with_source(
+            lambda repo, release_tag, assets: make_checksums_with_source(
                 [],
                 release_tag = release_tag,
                 upstream_tag = "b9000",
@@ -764,7 +781,7 @@ class TestPublishedReleaseResolution:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
-            lambda repo, release_tag: make_checksums_with_source(
+            lambda repo, release_tag, assets: make_checksums_with_source(
                 [],
                 release_tag = release_tag,
                 upstream_tag = "b9000",
@@ -775,6 +792,56 @@ class TestPublishedReleaseResolution:
 
         resolved = resolve_published_release(commit, "unslothai/llama.cpp")
         assert resolved.bundle.release_tag == "release-commit"
+
+
+    def test_walk_back_reads_checksums_from_the_listing(self, monkeypatch):
+        tags = ["b3", "b2", "b1"]
+        cdn = "https://github.com/unslothai/llama.cpp/releases/download"
+        manifest = INSTALL_LLAMA_PREBUILT.DEFAULT_PUBLISHED_MANIFEST_ASSET
+        sha = INSTALL_LLAMA_PREBUILT.DEFAULT_PUBLISHED_SHA256_ASSET
+        listing = [
+            {
+                "tag_name": tag,
+                "draft": False,
+                "prerelease": False,
+                "assets": [
+                    {"name": manifest, "browser_download_url": f"{cdn}/{tag}/{manifest}"},
+                    {"name": sha, "browser_download_url": f"{cdn}/{tag}/{sha}"},
+                ],
+            }
+            for tag in tags
+        ]
+        api_calls = []
+
+        def fake_fetch_json(url):
+            if url.startswith("https://api.github.com/"):
+                api_calls.append(url)
+                assert "/releases/tags/" not in url, f"per-release API call: {url}"
+                return listing
+            return checksum_payload(url.rsplit("/", 2)[-2], "b8508")
+
+        def fake_download_bytes(url, **_):
+            return json.dumps(
+                {
+                    "schema_version": 1,
+                    "component": "llama.cpp",
+                    "upstream_tag": "b8508",
+                    "artifacts": [],
+                }
+            ).encode()
+
+        monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "fetch_json", fake_fetch_json)
+        monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "download_bytes", fake_download_bytes)
+        monkeypatch.setenv("UNSLOTH_LLAMA_DISABLE_DOWNLOAD_HOST_RESOLVE", "1")
+
+        resolved = list(
+            INSTALL_LLAMA_PREBUILT.iter_resolved_published_releases(
+                "latest", "unslothai/llama.cpp"
+            )
+        )
+
+        assert [entry.bundle.release_tag for entry in resolved] == tags
+        assert len(api_calls) == 1
 
 
 class TestSourceBuildPlanResolution:
@@ -964,7 +1031,7 @@ class TestValidatedChecksumsForBundle:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
-            lambda repo, release_tag: checksums,
+            lambda repo, release_tag, assets: checksums,
         )
 
         with pytest.raises(PrebuiltFallback, match = "manifest checksum"):
@@ -980,7 +1047,7 @@ class TestValidatedChecksumsForBundle:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
-            lambda repo, release_tag: checksums,
+            lambda repo, release_tag, assets: checksums,
         )
 
         with pytest.raises(PrebuiltFallback, match = "exact source archive"):
@@ -1002,7 +1069,7 @@ class TestValidatedChecksumsForBundle:
         monkeypatch.setattr(
             INSTALL_LLAMA_PREBUILT,
             "load_approved_release_checksums",
-            lambda repo, release_tag: checksums,
+            lambda repo, release_tag, assets: checksums,
         )
 
         assert validated_checksums_for_bundle("unslothai/llama.cpp", bundle) is checksums
@@ -1017,6 +1084,39 @@ class TestValidatedChecksumsForBundle:
 # ===========================================================================
 # K. linux_cuda_choice_from_release -- core selection
 # ===========================================================================
+
+
+    def test_reads_the_checksum_asset_from_the_listing(self, monkeypatch):
+        bundle = make_release([], release_tag = "r1", upstream_tag = "b8508")
+        sha_url = "https://github.com/unslothai/llama.cpp/releases/download/r1/sha.json"
+        bundle.assets[INSTALL_LLAMA_PREBUILT.DEFAULT_PUBLISHED_SHA256_ASSET] = sha_url
+        fetched = []
+
+        def fake_fetch_json(url):
+            fetched.append(url)
+            return checksum_payload("r1", "b8508")
+
+        def no_release_api(repo, tag):
+            raise AssertionError(f"release API call for {repo}@{tag}")
+
+        monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "fetch_json", fake_fetch_json)
+        monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "github_release", no_release_api)
+
+        checksums = validated_checksums_for_bundle("unslothai/llama.cpp", bundle)
+
+        assert checksums.release_tag == "r1"
+        assert fetched == [sha_url]
+
+    def test_listing_without_checksum_asset_falls_back(self, monkeypatch):
+        bundle = make_release([], release_tag = "r1", upstream_tag = "b8508")
+
+        def no_release_api(repo, tag):
+            raise AssertionError(f"release API call for {repo}@{tag}")
+
+        monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "github_release", no_release_api)
+
+        with pytest.raises(PrebuiltFallback, match = "did not expose"):
+            validated_checksums_for_bundle("unslothai/llama.cpp", bundle)
 
 
 class TestLinuxCudaChoiceFromRelease:


### PR DESCRIPTION
Fixes #10449.

When the installer looks for a prebuilt llama.cpp release, it already gets the full list of releases and their files from GitHub in one request. It then went back to GitHub once more for every single release to ask for the same files again. That extra request per release was enough to use up the free GitHub API limit on its own, and once the limit was hit, each remaining release was still tried four more times with waits in between. For the report in the issue that meant over a hundred requests and a few minutes of waiting, and the final error said no compatible prebuilt was found, which was not true.

This change reads the file list from the release listing it already has, so the walk through releases now makes one request instead of one per release. A GitHub 403 is only retried when GitHub says the limit resets soon enough to wait for, otherwise it fails right away. Because of that, a rate limit now shows up as a rate limit with the GH_TOKEN hint instead of being reported as a missing prebuilt, and the update check no longer caches a false "no prebuilt" answer for a day.

Tested on a Mac against the real GitHub API without a token: three releases resolved with two requests total, both for the listing pages. The install and backend test suites pass with four new tests covering this.
