### PR TITLE
Decode the PowerShell venv-hardening pipe as UTF-8

### DIFF
--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -52,12 +52,10 @@ def _run_powershell(shell: str, script: str, env: dict[str, str]) -> str:
     # case in this file reads its stdout, so an interpreter that died at startup would surface as install.ps1 losing
     # half a moved environment.
     # See tests/_shared/unsloth_pwsh_runner.py.
-    #
     # Both ends of the pipe are pinned to UTF-8. `text = True` alone decodes with the LOCALE codec, cp1252 on the
-    # GitHub Windows runners, so a non-ASCII path came back doubly encoded -- `ä` written as UTF-8 and read as
-    # cp1252 is `Ã¤` -- and test_a_non_ascii_marker_survives_the_rollback failed on both shells against an
-    # install.ps1 that had done nothing wrong. `[Console]::OutputEncoding` is the child's half: Windows PowerShell
-    # 5.1 otherwise encodes a redirected stream with the console's OEM code page, which is not UTF-8 either.
+    # Windows runners, so a non-ASCII path came back doubly encoded and the rollback case failed against an
+    # install.ps1 that had done nothing wrong. `[Console]::OutputEncoding` is the child's half: 5.1 otherwise
+    # writes a redirected stream in the console's OEM code page.
     result = run_pwsh(
         [
             shell,
@@ -1029,10 +1027,8 @@ try {{
 
 
 def test_the_powershell_pipe_is_utf8_at_both_ends(monkeypatch):
-    """`text = True` alone decodes with the LOCALE codec, cp1252 on the Windows runners, so a
-    non-ASCII path came back doubly encoded and the rollback case failed against an install.ps1
-    that had done nothing wrong. Pinned here because the decode is invisible on a UTF-8 host:
-    both the child's output encoding and this side's decode have to name UTF-8."""
+    """The decode is invisible on a UTF-8 host, so both ends are pinned here: the child's output
+    encoding and this side's decode have to name UTF-8."""
     import tests.python.test_windows_python_venv_hardening as module
 
     seen = {}

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -52,11 +52,24 @@ def _run_powershell(shell: str, script: str, env: dict[str, str]) -> str:
     # case in this file reads its stdout, so an interpreter that died at startup would surface as install.ps1 losing
     # half a moved environment.
     # See tests/_shared/unsloth_pwsh_runner.py.
+    #
+    # Both ends of the pipe are pinned to UTF-8. `text = True` alone decodes with the LOCALE codec, cp1252 on the
+    # GitHub Windows runners, so a non-ASCII path came back doubly encoded -- `ä` written as UTF-8 and read as
+    # cp1252 is `Ã¤` -- and test_a_non_ascii_marker_survives_the_rollback failed on both shells against an
+    # install.ps1 that had done nothing wrong. `[Console]::OutputEncoding` is the child's half: Windows PowerShell
+    # 5.1 otherwise encodes a redirected stream with the console's OEM code page, which is not UTF-8 either.
     result = run_pwsh(
-        [shell, "-NoProfile", "-NonInteractive", "-Command", script],
+        [
+            shell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)\n" + script,
+        ],
         check = True,
         capture_output = True,
         text = True,
+        encoding = "utf-8",
         env = env,
         timeout = 30,
     )
@@ -1013,3 +1026,24 @@ try {{
         assert _run_powershell(shell, script, env).splitlines()[-1] == "survived"
     finally:
         (studio_root / "cache").chmod(0o755)
+
+
+def test_the_powershell_pipe_is_utf8_at_both_ends(monkeypatch):
+    """`text = True` alone decodes with the LOCALE codec, cp1252 on the Windows runners, so a
+    non-ASCII path came back doubly encoded and the rollback case failed against an install.ps1
+    that had done nothing wrong. Pinned here because the decode is invisible on a UTF-8 host:
+    both the child's output encoding and this side's decode have to name UTF-8."""
+    import tests.python.test_windows_python_venv_hardening as module
+
+    seen = {}
+
+    def _fake_run_pwsh(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return subprocess.CompletedProcess(argv, 0, stdout = "ok\n", stderr = "")
+
+    monkeypatch.setattr(module, "run_pwsh", _fake_run_pwsh)
+    assert module._run_powershell("pwsh", "Write-Output 'ok'", {}) == "ok"
+    assert seen["kwargs"]["encoding"] == "utf-8"
+    assert "[Console]::OutputEncoding" in seen["argv"][-1]
+    assert seen["argv"][-1].endswith("Write-Output 'ok'")


### PR DESCRIPTION
`parity (windows-latest)` has been red since #10386 landed: `test_a_non_ascii_marker_survives_the_rollback` fails on both `[powershell]` and `[pwsh]`, so every later PR that trips the workflow's path filter inherits it. #10386 itself merged with the job red ([job 101647844866](https://github.com/unslothai/unsloth/actions/runs/34092189956/job/101647844866)), and it reproduces unchanged on unrelated branches ([job 101862979068](https://github.com/unslothai/unsloth/actions/runs/34161104514/job/101862979068)). Filed as #10460.

It is not install.ps1. `_run_powershell` ran the shell with `text = True` and no `encoding`, so Python decoded the child's stdout with the locale codec, which is cp1252 on the GitHub Windows runners. UTF-8 `ä` read as cp1252 is `Ã¤`, which is exactly what the failure shows:

```
E  assert 'C:\\Users\\r...käffee cache' == 'C:\\Users\\r...\käffee cache'
E    - _surviv0\k<one char> ffee cache      <- expected
E    + _surviv0\k<two chars> ffee cache     <- actual, doubly encoded
```

Both ends are pinned here. This side decodes UTF-8; `[Console]::OutputEncoding` is the child's half, because Windows PowerShell 5.1 otherwise encodes a redirected stream with the console's OEM code page, which is not UTF-8 either. The byte-exact tests in `tests/python/test_windows_setup_output_encoding.py` already capture bytes and decode UTF-8 explicitly for the same reason; this file is the one that did not.

## Verification

The runners' cp1252 has no equivalent here, but the mechanism is the locale codec, so `LC_ALL=C` reproduces it on Linux:

```
LC_ALL=C python3 -m pytest tests/python/test_windows_python_venv_hardening.py -k non_ascii
  before: 1 failed  -- decoding with 'ANSI_X3.4-1968' codec failed
  after:  1 passed
```

Full file: 46 passed (pwsh 7 present, so the PowerShell cases really run). `test_the_powershell_pipe_is_utf8_at_both_ends` pins the contract on any host, since the decode is invisible on a UTF-8 one; it fails against the parent.

What this cannot answer from here: whether Windows PowerShell 5.1's own half behaves as expected on the runner. The CI evidence says the child was already emitting UTF-8, so the decode alone accounts for the failure; the `[Console]::OutputEncoding` line is there so it stays true if a runner image changes its console code page.