### PR TITLE
Studio: toast eject immediately and bound active-generations

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -251,8 +251,12 @@ export interface ActiveGenerationsResponse {
 
 /** Chats generating on the backend right now. Authoritative where `runningByThreadId` is not: that
  *  map is per-tab, empty after a reload and blind to a second tab, and /load 409s on these. */
-export async function getActiveGenerations(): Promise<ActiveGenerationsResponse> {
-  const response = await authFetch("/api/inference/active-generations");
+export async function getActiveGenerations(
+  signal?: AbortSignal,
+): Promise<ActiveGenerationsResponse> {
+  const response = await authFetch("/api/inference/active-generations", {
+    signal,
+  });
   return parseJsonOrThrow<ActiveGenerationsResponse>(response);
 }
 

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -675,6 +675,9 @@ function pickOf(info: {
   };
 }
 
+// Shared across the three live useChatModelRuntime instances (chat, hub, hub gear).
+let chatEjectInFlight = false;
+
 export function useChatModelRuntime() {
   const params = useChatRuntimeStore((state) => state.params);
   const models = useChatRuntimeStore((state) => state.models);
@@ -2567,6 +2570,10 @@ export function useChatModelRuntime() {
     if (!params.checkpoint) {
       return false;
     }
+    if (chatEjectInFlight) {
+      toast.info("Wait for the model to finish unloading.");
+      return false;
+    }
     const bailIfLoading = (): boolean => {
       const runtime = useChatRuntimeStore.getState();
       if (!runtime.modelLoading && !runtime.loadingModelPick) return false;
@@ -2583,11 +2590,13 @@ export function useChatModelRuntime() {
       return true;
     }
     let lifecycleLease: ModelLifecycleLease | null = null;
+    chatEjectInFlight = true;
     try {
       // Block queue materialization before taking the confirmation snapshot, or a queue can appear
       // while the dialog is open and be stopped without the user confirming it.
       lifecycleLease = useChatRuntimeStore.getState().beginModelLoading();
       if (lifecycleLease === null) {
+        toast.info("Wait for the current model to finish loading.");
         return false;
       }
       // Ejecting tears down llama-server, so every chat stops. Same prompt, but it leaves no model
@@ -2626,6 +2635,7 @@ export function useChatModelRuntime() {
       setModelsError(message);
       return false;
     } finally {
+      chatEjectInFlight = false;
       if (lifecycleLease !== null) {
         useChatRuntimeStore.getState().endModelLoading(lifecycleLease);
       }

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -2596,16 +2596,21 @@ export function useChatModelRuntime() {
       // while the dialog is open and be stopped without the user confirming it.
       lifecycleLease = useChatRuntimeStore.getState().beginModelLoading();
       if (lifecycleLease === null) {
-        toast.info("Wait for the current model to finish loading.");
         return false;
       }
-      // Ejecting tears down llama-server, so every chat stops. Same prompt, but it leaves no model
-      // loaded, so it must not be worded as a reload.
+      // Visible before the backend snapshot: that read had no timeout, so a wedged
+      // /active-generations left the first click with no toast and the lease held.
+      const toastId = toast.loading("Unloading model", {
+        description: "Releases VRAM and resets inference state.",
+      });
       const stopDecision = await confirmStopRunningChatsIfNeeded(
         "Unloading the model",
         "unload",
       );
-      if (!stopDecision.proceed) return false;
+      if (!stopDecision.proceed) {
+        toast.dismiss(toastId);
+        return false;
+      }
 
       async function performUnload(): Promise<void> {
         cancelPreStreamRunReservations(stopDecision.preStreamRunTokens);
@@ -2621,6 +2626,7 @@ export function useChatModelRuntime() {
 
       const unloadPromise = performUnload();
       toast.promise(unloadPromise, {
+        id: toastId,
         loading: "Unloading model",
         success: { message: "Model unloaded", duration: 1200 },
         error: (err) =>

--- a/studio/frontend/src/features/chat/utils/confirm-stop-running-chats.ts
+++ b/studio/frontend/src/features/chat/utils/confirm-stop-running-chats.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { getActiveGenerations } from "../api/chat-api";
+import { disposableTimeoutSignal } from "@/features/hub/lib/abort-signals";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import { usePromptQueueUI } from "../stores/prompt-queue-ui-store";
 import {
@@ -10,6 +11,10 @@ import {
 } from "../stores/stop-running-chats-dialog-store";
 import { listStoredChatThreads } from "./chat-history-storage";
 import { listLocalPreStreamRunReservations } from "./pre-stream-run-reservation";
+
+// Pre-dialog snapshot of other tabs' runs. Unbounded, a wedged backend leaves the
+// eject click with no toast and the load lease held until refresh.
+const ACTIVE_GENERATIONS_TIMEOUT_MS = 8_000;
 
 export interface StopRunningChatsDecision {
   /** False when the user chose to keep generating; the caller must not load. */
@@ -93,7 +98,13 @@ export async function confirmStopRunningChatsIfNeeded(
   // reload and blind to a second tab, while force_cancel_active cancels every backend run. The
   // union stays local-only, since external-provider runs are never in it.
   try {
-    const active = await getActiveGenerations();
+    const timeout = disposableTimeoutSignal(ACTIVE_GENERATIONS_TIMEOUT_MS);
+    let active;
+    try {
+      active = await getActiveGenerations(timeout.signal);
+    } finally {
+      timeout.dispose();
+    }
     const entries = active.active ?? [];
     const merged = new Set(running);
     for (const threadId of active.thread_ids ?? []) {

--- a/tests/studio/test_chat_eject_in_flight.py
+++ b/tests/studio/test_chat_eject_in_flight.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A second chat eject while confirm is open must not toast as a load (#10339).
+
+The red-circle path lives in ``useChatModelRuntime`` three times (chat, hub, hub
+gear), so the in-flight flag is module-scoped. This replays the callback body
+verbatim with confirm hanging, then fires a second eject.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from _node_harness import (
+    WORKDIR,
+    read,
+    require_node,
+    run_harness,
+    slice_between,
+    source_path,
+)
+
+HOOK = source_path("studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts")
+TEMP = WORKDIR / "temp" / "chat_eject_in_flight"
+
+HARNESS = """
+// @ts-nocheck
+export const world: any = {
+  toasts: [] as { title: string; description?: string }[],
+  unloads: 0,
+  beginCalls: 0,
+  lease: { id: "lease-1" } as any,
+};
+
+let chatEjectInFlight = false;
+const params = { checkpoint: "org/model" };
+function setModelsError(_message: string | null): void {}
+function clearCheckpoint(): void {}
+async function refresh(): Promise<void> {}
+function isExternalModelId(_id: string): boolean { return false; }
+function cancelPreStreamRunReservations(_tokens: unknown): void {}
+function requestLocalPromptQueueStop(_ids?: unknown): void {}
+async function unloadModel(_payload: unknown): Promise<void> {
+  world.unloads += 1;
+}
+
+let confirmGate: Promise<void> | null = null;
+let releaseConfirm: (() => void) | null = null;
+export function hangNextConfirm(): void {
+  confirmGate = new Promise((resolve) => {
+    releaseConfirm = resolve;
+  });
+}
+export function releaseHungConfirm(): void {
+  releaseConfirm?.();
+  releaseConfirm = null;
+  confirmGate = null;
+}
+
+async function confirmStopRunningChatsIfNeeded(
+  _action: string,
+  _effect: string,
+): Promise<any> {
+  if (confirmGate) await confirmGate;
+  return {
+    proceed: true,
+    forceCancelActive: false,
+    promptQueueThreadIds: [],
+    preStreamRunTokens: [],
+  };
+}
+
+const toast = {
+  info(title: string, options?: { description?: string }) {
+    world.toasts.push({ title, description: options?.description });
+  },
+  promise(pending: Promise<unknown>) {
+    return pending;
+  },
+};
+
+const useChatRuntimeStore = {
+  getState() {
+    return {
+      modelLoading: false,
+      loadingModelPick: null,
+      beginModelLoading() {
+        world.beginCalls += 1;
+        return world.lease;
+      },
+      endModelLoading(_lease: unknown) {},
+    };
+  },
+};
+
+async function ejectModel(): Promise<boolean> {
+__EJECT_BODY__
+}
+
+export { ejectModel };
+"""
+
+
+def _eject_body() -> str:
+    return slice_between(
+        read(HOOK),
+        "    if (!params.checkpoint) {\n      return false;\n    }",
+        "  }, [clearCheckpoint, params.checkpoint, refresh, setModelsError]);",
+    )
+
+
+def _run(script: str) -> dict:
+    require_node((HOOK,))
+    return run_harness(
+        TEMP,
+        HARNESS.replace("__EJECT_BODY__", _eject_body()),
+        script,
+        sources = (),
+    )
+
+
+def test_a_second_eject_while_confirm_is_open_does_not_unload_twice():
+    out = _run(
+        textwrap.dedent(
+            """
+            // @ts-nocheck
+            import { ejectModel, hangNextConfirm, releaseHungConfirm, world } from "./harness.ts";
+            hangNextConfirm();
+            const first = ejectModel();
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            const second = await ejectModel();
+            releaseHungConfirm();
+            const firstResult = await first;
+            console.log(JSON.stringify({
+              second,
+              firstResult,
+              unloads: world.unloads,
+              toasts: world.toasts.map((t) => t.title),
+              beginCalls: world.beginCalls,
+            }));
+            """
+        )
+    )
+    assert out["second"] is False
+    assert out["firstResult"] is True
+    assert out["unloads"] == 1
+    assert out["beginCalls"] == 1
+    assert out["toasts"] == ["Wait for the model to finish unloading."]
+
+
+def test_a_null_lifecycle_lease_toasts_instead_of_returning_silently():
+    out = _run(
+        textwrap.dedent(
+            """
+            // @ts-nocheck
+            import { ejectModel, world } from "./harness.ts";
+            world.lease = null;
+            const result = await ejectModel();
+            console.log(JSON.stringify({
+              result,
+              unloads: world.unloads,
+              toasts: world.toasts.map((t) => t.title),
+            }));
+            """
+        )
+    )
+    assert out["result"] is False
+    assert out["unloads"] == 0
+    assert out["toasts"] == ["Wait for the current model to finish loading."]

--- a/tests/studio/test_chat_eject_in_flight.py
+++ b/tests/studio/test_chat_eject_in_flight.py
@@ -219,9 +219,9 @@ def test_the_first_eject_click_shows_a_loading_toast_before_confirm():
             """
         )
     )
-    assert out["loading"] == ["Unloading model"], (
-        "the first click must toast before confirmStopRunningChatsIfNeeded returns"
-    )
+    assert out["loading"] == [
+        "Unloading model"
+    ], "the first click must toast before confirmStopRunningChatsIfNeeded returns"
     assert out["second"] is False
     assert out["firstResult"] is True
     assert out["unloads"] == 1

--- a/tests/studio/test_chat_eject_in_flight.py
+++ b/tests/studio/test_chat_eject_in_flight.py
@@ -1,18 +1,16 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""A second chat eject while confirm is open must not toast as a load (#10339).
+"""Chat eject must show a toast on the first click and refuse a second (#10339).
 
-The red-circle path lives in ``useChatModelRuntime`` three times (chat, hub, hub
-gear), so the in-flight flag is module-scoped. This replays the callback body
-verbatim with confirm hanging, then fires a second eject.
+The in-flight flag is module-scoped because three ``useChatModelRuntime``
+instances share one llama-server. The fixture store mirrors the real gate:
+``modelLoading`` is true while a lease is held.
 """
 
 from __future__ import annotations
 
 import textwrap
-
-import pytest
 
 from _node_harness import (
     WORKDIR,
@@ -24,18 +22,19 @@ from _node_harness import (
 )
 
 HOOK = source_path("studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts")
+CONFIRM = source_path("studio/frontend/src/features/chat/utils/confirm-stop-running-chats.ts")
 TEMP = WORKDIR / "temp" / "chat_eject_in_flight"
 
-HARNESS = """
+EJECT_HARNESS = """
 // @ts-nocheck
 export const world: any = {
-  toasts: [] as { title: string; description?: string }[],
+  toasts: [] as { kind: string; title: string }[],
   unloads: 0,
   beginCalls: 0,
-  lease: { id: "lease-1" } as any,
 };
 
 let chatEjectInFlight = false;
+let leaseHeld = false;
 const params = { checkpoint: "org/model" };
 function setModelsError(_message: string | null): void {}
 function clearCheckpoint(): void {}
@@ -74,8 +73,15 @@ async function confirmStopRunningChatsIfNeeded(
 }
 
 const toast = {
-  info(title: string, options?: { description?: string }) {
-    world.toasts.push({ title, description: options?.description });
+  info(title: string) {
+    world.toasts.push({ kind: "info", title });
+  },
+  loading(title: string) {
+    world.toasts.push({ kind: "loading", title });
+    return "toast-1";
+  },
+  dismiss(_id: unknown) {
+    world.toasts.push({ kind: "dismiss", title: "" });
   },
   promise(pending: Promise<unknown>) {
     return pending;
@@ -85,13 +91,17 @@ const toast = {
 const useChatRuntimeStore = {
   getState() {
     return {
-      modelLoading: false,
+      get modelLoading() { return leaseHeld; },
       loadingModelPick: null,
       beginModelLoading() {
         world.beginCalls += 1;
-        return world.lease;
+        if (leaseHeld) return null;
+        leaseHeld = true;
+        return { id: "lease-1" };
       },
-      endModelLoading(_lease: unknown) {},
+      endModelLoading(_lease: unknown) {
+        leaseHeld = false;
+      },
     };
   },
 };
@@ -103,6 +113,52 @@ __EJECT_BODY__
 export { ejectModel };
 """
 
+CONFIRM_HARNESS = """
+// @ts-nocheck
+export const world: any = {
+  hadSignal: false,
+  disposed: 0,
+  timeoutMs: 0,
+};
+
+const ACTIVE_GENERATIONS_TIMEOUT_MS = 8_000;
+
+function disposableTimeoutSignal(ms: number) {
+  world.timeoutMs = ms;
+  const controller = new AbortController();
+  return {
+    signal: controller.signal,
+    dispose() {
+      world.disposed += 1;
+    },
+  };
+}
+
+async function getActiveGenerations(signal?: AbortSignal) {
+  world.hadSignal = signal instanceof AbortSignal;
+  return { count: 0, thread_ids: [], active: [] };
+}
+
+const useChatRuntimeStore = {
+  getState() {
+    return { runningByThreadId: {}, localRunByThreadId: {} };
+  },
+};
+const usePromptQueueUI = {
+  getState() {
+    return { byThreadId: {} };
+  },
+};
+function listLocalPreStreamRunReservations() { return []; }
+function getLocalPromptQueueThreadIds() { return []; }
+const useStopRunningChatsDialogStore = {
+  getState() { return { requestConfirm: async () => true }; },
+};
+async function listStoredChatThreads() { return []; }
+
+__CONFIRM__
+"""
+
 
 def _eject_body() -> str:
     return slice_between(
@@ -112,18 +168,35 @@ def _eject_body() -> str:
     )
 
 
-def _run(script: str) -> dict:
+def _confirm_source() -> str:
+    text = read(CONFIRM)
+    start = "export async function confirmStopRunningChatsIfNeeded("
+    return text[text.index(start) :]
+
+
+def _run_eject(script: str) -> dict:
     require_node((HOOK,))
     return run_harness(
         TEMP,
-        HARNESS.replace("__EJECT_BODY__", _eject_body()),
+        EJECT_HARNESS.replace("__EJECT_BODY__", _eject_body()),
         script,
         sources = (),
     )
 
 
-def test_a_second_eject_while_confirm_is_open_does_not_unload_twice():
-    out = _run(
+def _run_confirm(script: str) -> dict:
+    require_node((CONFIRM,))
+    return run_harness(
+        TEMP / "confirm",
+        CONFIRM_HARNESS.replace("__CONFIRM__", _confirm_source()),
+        script,
+        sources = (),
+    )
+
+
+def test_the_first_eject_click_shows_a_loading_toast_before_confirm():
+    """#10339: the first red-circle click had no UI until /active-generations answered."""
+    out = _run_eject(
         textwrap.dedent(
             """
             // @ts-nocheck
@@ -131,42 +204,51 @@ def test_a_second_eject_while_confirm_is_open_does_not_unload_twice():
             hangNextConfirm();
             const first = ejectModel();
             await new Promise((resolve) => setTimeout(resolve, 20));
+            const loading = world.toasts.filter((t) => t.kind === "loading").map((t) => t.title);
             const second = await ejectModel();
             releaseHungConfirm();
             const firstResult = await first;
             console.log(JSON.stringify({
+              loading,
               second,
               firstResult,
               unloads: world.unloads,
-              toasts: world.toasts.map((t) => t.title),
+              info: world.toasts.filter((t) => t.kind === "info").map((t) => t.title),
               beginCalls: world.beginCalls,
             }));
             """
         )
     )
+    assert out["loading"] == ["Unloading model"], (
+        "the first click must toast before confirmStopRunningChatsIfNeeded returns"
+    )
     assert out["second"] is False
     assert out["firstResult"] is True
     assert out["unloads"] == 1
     assert out["beginCalls"] == 1
-    assert out["toasts"] == ["Wait for the model to finish unloading."]
+    assert out["info"] == ["Wait for the model to finish unloading."]
 
 
-def test_a_null_lifecycle_lease_toasts_instead_of_returning_silently():
-    out = _run(
+def test_the_active_generations_snapshot_passes_a_timeout_signal():
+    """A wedged /active-generations used to hold the eject lease with no toast."""
+    assert "ACTIVE_GENERATIONS_TIMEOUT_MS = 8_000" in read(CONFIRM)
+    assert "getActiveGenerations(timeout.signal)" in read(CONFIRM)
+    out = _run_confirm(
         textwrap.dedent(
             """
             // @ts-nocheck
-            import { ejectModel, world } from "./harness.ts";
-            world.lease = null;
-            const result = await ejectModel();
+            import { confirmStopRunningChatsIfNeeded, world } from "./harness.ts";
+            const decision = await confirmStopRunningChatsIfNeeded("Unloading the model", "unload");
             console.log(JSON.stringify({
-              result,
-              unloads: world.unloads,
-              toasts: world.toasts.map((t) => t.title),
+              proceed: decision.proceed,
+              hadSignal: world.hadSignal,
+              disposed: world.disposed,
+              timeoutMs: world.timeoutMs,
             }));
             """
         )
     )
-    assert out["result"] is False
-    assert out["unloads"] == 0
-    assert out["toasts"] == ["Wait for the current model to finish loading."]
+    assert out["proceed"] is True
+    assert out["hadSignal"] is True
+    assert out["disposed"] == 1
+    assert out["timeoutMs"] == 8000


### PR DESCRIPTION
The chat model's red-circle eject takes a load lease, then waits on `getActiveGenerations()` with no timeout and no toast (https://github.com/unslothai/unsloth/issues/10339). A wedged backend leaves the first click looking like a no-op. A second click toasts "A model is loading" and the lease stays held until refresh.

The first click now shows "Unloading model" before that snapshot. `/active-generations` is bounded to 8s through `disposableTimeoutSignal` and then falls back to the local running map. That bound is on the shared confirm helper, so load and audio ejects get it too. A second click while the first is in flight toasts "Wait for the model to finish unloading."

`.venv/bin/python -m pytest -q tests/studio/test_chat_eject_in_flight.py` passed. Replacing the three production files with `upstream/main` failed both tests: first click had no loading toast, and `ACTIVE_GENERATIONS_TIMEOUT_MS` was missing.
