### PR TITLE
Studio: add GPT-6 Astra to the fallback catalog and reasoning controls

### DIFF
--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -28,6 +28,7 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
             "gpt-5.6-luna",
             "gpt-5.6-sol",
             "gpt-5.6-terra",
+            "gpt-6-astra",
         ],
         "model_capabilities": {
             "gpt-5.4": {"vision": True, "studio_tools": True},
@@ -36,6 +37,7 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
             "gpt-5.6-luna": {"vision": True, "studio_tools": True},
             "gpt-5.6-sol": {"vision": True, "studio_tools": True},
             "gpt-5.6-terra": {"vision": True, "studio_tools": True},
+            "gpt-6-astra": {"vision": True, "studio_tools": True},
         },
         "supports_streaming": True,
         "supports_vision": True,

--- a/studio/backend/tests/test_openai_codex_subscription.py
+++ b/studio/backend/tests/test_openai_codex_subscription.py
@@ -70,6 +70,7 @@ def test_protocol_constants_and_curated_provider_contract():
         "gpt-5.6-luna",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
+        "gpt-6-astra",
     ]
     assert OPENAI_CODEX_DEVICE_REDIRECT_URI == ("https://auth.openai.com/deviceauth/callback")
     row = next(

--- a/studio/backend/tests/test_openai_codex_subscription.py
+++ b/studio/backend/tests/test_openai_codex_subscription.py
@@ -263,7 +263,14 @@ def test_successful_callback_does_not_wait_for_its_own_connection(monkeypatch):
     assert len(persisted) == 1
 
 
-def test_fixed_host_transport_sends_subscription_headers_and_normalizes_sse():
+@pytest.mark.parametrize(
+    ("model", "reasoning_effort"),
+    [("gpt-5.4", "none")]
+    + [("gpt-6-astra", effort) for effort in ("low", "medium", "high", "xhigh", "max")],
+)
+def test_fixed_host_transport_sends_subscription_headers_and_normalizes_sse(
+    model, reasoning_effort
+):
     captured = {}
 
     class FakeResponse:
@@ -299,9 +306,9 @@ def test_fixed_host_transport_sends_subscription_headers_and_normalizes_sse():
                 provider_id = "provider-1",
                 thread_id = "thread-1",
                 messages = [{"role": "user", "content": "hello"}],
-                model = "gpt-5.4",
+                model = model,
                 max_tokens = 100,
-                reasoning_effort = "none",
+                reasoning_effort = reasoning_effort,
                 tools = None,
                 tool_choice = None,
             )
@@ -318,7 +325,8 @@ def test_fixed_host_transport_sends_subscription_headers_and_normalizes_sse():
     assert captured["json"]["store"] is False
     assert "max_output_tokens" not in captured["json"]
 
-    assert captured["json"]["reasoning"] == {"effort": "none", "summary": "auto"}
+    assert captured["json"]["model"] == model
+    assert captured["json"]["reasoning"] == {"effort": reasoning_effort, "summary": "auto"}
     assert captured["json"]["include"] == ["reasoning.encrypted_content"]
     assert any("hello" in line for line in lines)
     assert not any("secret-token" in line for line in lines)

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -647,6 +647,11 @@ function resolveAnthropicReasoningEffortCapabilities(modelId: string): Reasoning
 
 const OPENAI_REASONING_MODELS = [
   {
+    prefixes: ["gpt-6-astra"],
+    supportsOff: false,
+    levels: ["low", "medium", "high", "xhigh", "max"],
+  },
+  {
     prefixes: ["gpt-5.5-pro", "gpt-5.4-pro"],
     supportsOff: false,
     levels: ["medium", "high", "xhigh"],

--- a/studio/frontend/tests/provider-capabilities-current-models.test.ts
+++ b/studio/frontend/tests/provider-capabilities-current-models.test.ts
@@ -9,6 +9,7 @@ import { registerBundlerResolver } from "./helpers/kit.ts";
 registerBundlerResolver();
 
 const {
+  clampReasoningEffortToLevels,
   getExternalMaxOutputTokens,
   getExternalReasoningCapabilities,
   providerSupportsBuiltinCodeExecution,
@@ -73,6 +74,27 @@ test("the gpt-5.6 family gets the gpt-5.5 reasoning ladder", () => {
       model,
     );
     assert.equal(getExternalMaxOutputTokens("openai", model), 128000, model);
+  }
+});
+
+test("Astra exposes mandatory reasoning with its full effort ladder", () => {
+  const caps = getExternalReasoningCapabilities("openai_codex", "gpt-6-astra");
+  assert.equal(caps.supportsReasoning, true);
+  assert.equal(caps.reasoningStyle, "reasoning_effort");
+  assert.equal(caps.supportsReasoningOff, false);
+  assert.deepEqual(
+    [...caps.reasoningEffortLevels],
+    ["low", "medium", "high", "xhigh", "max"],
+  );
+  for (const effort of ["none", "minimal"] as const) {
+    assert.equal(clampReasoningEffortToLevels(effort, caps.reasoningEffortLevels), "low");
+  }
+  assert.equal(clampReasoningEffortToLevels("max", caps.reasoningEffortLevels), "max");
+});
+
+test("Astra reasoning does not enable unrelated model families", () => {
+  for (const model of ["gpt-6-other", "gpt-60-astra"]) {
+    assert.equal(getExternalReasoningCapabilities("openai_codex", model).supportsReasoning, false);
   }
 });
 
@@ -149,8 +171,9 @@ test("ChatGPT subscription models expose Unsloth-owned search and code tools", (
     "gpt-5.3-codex-spark": { vision: false, studio_tools: true },
     "gpt-5.4": { vision: true, studio_tools: true },
     "gpt-5.6-sol": { vision: true, studio_tools: true },
+    "gpt-6-astra": { vision: true, studio_tools: true },
   });
-  for (const model of ["gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.6-sol"]) {
+  for (const model of ["gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.6-sol", "gpt-6-astra"]) {
     const caps = getExternalReasoningCapabilities("openai_codex", model);
     assert.equal(caps.supportsReasoning, true, model);
     assert.equal(caps.reasoningStyle, "reasoning_effort", model);


### PR DESCRIPTION
GPT-6 Astra is missing from Studio's built-in subscription model catalog. Its reasoning controls are also hidden because the frontend does not recognize the model, even when live discovery makes it selectable.

Add `gpt-6-astra` to the fallback catalog with vision and Studio tool support. Register its mandatory reasoning ladder: `low`, `medium`, `high`, `xhigh`, and `max`. Stale `none` or `minimal` selections fall back to `low`. These levels follow the [model documentation](https://developers.openai.com/api/docs/models/gpt-6-astra).

The subscription output limit already resolves to 128,000 tokens; regression coverage now includes Astra. Live account model discovery and saved model selections keep their existing behavior.

Validation:

- 98 backend subscription, model allowlist, and registry filter tests pass, including outgoing requests at all five Astra effort levels.
- 37 frontend capability, output-limit, and tool tests pass. The Astra reasoning assertions fail before the fix and pass afterward.
- Full frontend type checking, ESLint on the changed TypeScript files, Ruff on the changed Python files, and `git diff --check` pass.
