### PR TITLE
Fix the red Cross-platform parity run: decode PowerShell stdout as UTF-8

### DIFF
--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -52,11 +52,17 @@ def _run_powershell(shell: str, script: str, env: dict[str, str]) -> str:
     # case in this file reads its stdout, so an interpreter that died at startup would surface as install.ps1 losing
     # half a moved environment.
     # See tests/_shared/unsloth_pwsh_runner.py.
+    # encoding, not the default: `text = True` alone decodes with the locale codec, which is
+    # cp1252 on a Windows runner, while both shells write their stdout as UTF-8. A non-ASCII
+    # path therefore came back as mojibake ("kaffee" with the a-umlaut arriving as A-tilde
+    # plus currency sign) and failed an assertion about a file that was in fact written
+    # correctly, so this decoded the transport wrongly rather than catching a real defect.
     result = run_pwsh(
         [shell, "-NoProfile", "-NonInteractive", "-Command", script],
         check = True,
         capture_output = True,
         text = True,
+        encoding = "utf-8",
         env = env,
         timeout = 30,
     )


### PR DESCRIPTION
`Cross-platform parity` has been red on `main` since #10386 merged, and the failure is in the test harness rather than in `install.ps1`.

### What fails

`test_a_non_ascii_marker_survives_the_rollback` fails on both shells:

```
AssertionError: {'After': '...\käffee cache'}
assert '...käffee cache' == '...käffee cache'
```

`käffee` is the UTF-8 encoding of `käffee` read back as cp1252.

### Why

`_run_powershell` calls `run_pwsh(..., text = True)` without an `encoding`, and `run_pwsh` forwards its kwargs to `subprocess.run` untouched. `text = True` on its own decodes with the locale codec, which is cp1252 on a Windows runner. Both `pwsh` and Windows PowerShell 5.1 write stdout as UTF-8, so the JSON the script emits is decoded with the wrong codec and every non-ASCII path in it turns to mojibake.

The assertion is about a value that made a round trip through the marker file, so the mojibake looked like `Write-StudioUvCacheMarker` or `Restore-StudioUvCacheMarker` corrupting it. They do not.

### Evidence that the product is fine

Driving the three real functions extracted from `install.ps1` over the same round trip and reading the marker back as bytes:

```
BEFORE bytes: b'.../k\xc3\xa4ffee cache\n'
AFTER  bytes: b'.../k\xc3\xa4ffee cache\n'
```

Byte-identical, still UTF-8. Separately, the mojibake reproduces exactly from the transport alone:

```
raw bytes : b'{"After":"C:\\\\tmp\\\\k\xc3\xa4ffee cache"}'
as utf-8  : C:\tmp\käffee cache
as cp1252 : C:\tmp\käffee cache
```

The second line is what the test expects and the third is what CI reported.

### The fix

Pass `encoding = "utf-8"` on that one call, so stdout is decoded as what the shells actually write.

Scoped to this file rather than to `run_pwsh` itself. Defaulting the shared runner to UTF-8 would change decoding for every caller across the suite, and that is a wider blast radius than this failure justifies.

### Verification

Under a non-UTF-8 locale, before and after:

```
WITHOUT fix, LC_ALL=C:  1 failed   (UnicodeDecodeError in subprocess.py)
WITH    fix, LC_ALL=C:  1 passed
```

`LC_ALL=C` raises where cp1252 silently substitutes, but it is the same root cause: the locale codec is not what the shell wrote. Full file passes locally, 45 tests.

The Windows leg of `Cross-platform parity` on this PR is the real check, since neither locale here is cp1252.
