### PR TITLE
Studio: harden the codec-audio eval config added in #10259

### DIFF
--- a/studio/backend/core/training/eval_dataset.py
+++ b/studio/backend/core/training/eval_dataset.py
@@ -18,7 +18,9 @@ def evaluation_enabled(value: Any) -> bool:
         return False
     try:
         interval = float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError, not ValueError: json hands back an arbitrary-precision int for a JSON
+        # integer literal, and float() refuses one too large to represent.
         return False
     return math.isfinite(interval) and interval > 0
 

--- a/studio/backend/core/training/eval_dataset.py
+++ b/studio/backend/core/training/eval_dataset.py
@@ -19,8 +19,7 @@ def evaluation_enabled(value: Any) -> bool:
     try:
         interval = float(value)
     except (TypeError, ValueError, OverflowError):
-        # OverflowError, not ValueError: json hands back an arbitrary-precision int for a JSON
-        # integer literal, and float() refuses one too large to represent.
+        # OverflowError, not ValueError: float() refuses a JSON int too large to represent.
         return False
     return math.isfinite(interval) and interval > 0
 

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -2369,6 +2369,12 @@ class UnslothTrainer:
         try:
             return preprocess(eval_dataset, custom_format_mapping)
         except Exception as e:
+            if self.should_stop:
+                # A stop empties the codec preprocessors' output, which they report as "no valid
+                # examples". That is the cancel, not the user's file: warning about their eval data
+                # here would be a false accusation on every cancelled run.
+                logger.info("Stopped during eval preprocessing\n")
+                return None
             self._record_warning(
                 "The eval dataset could not be prepared for this audio model, so this run has "
                 f"no evaluation: {e}"
@@ -2397,20 +2403,34 @@ class UnslothTrainer:
 
     def _audio_eval_config(self, training_args):
         """Build audio evaluation arguments and return the eval dataset."""
+        from core.training.eval_dataset import evaluation_enabled
+
         eval_dataset = training_args.get("eval_dataset", None)
         eval_steps = training_args.get("eval_steps", 0.00)
         if eval_dataset is None:
             return {}, None
-        if not eval_steps or eval_steps <= 0:
+        # evaluation_enabled rejects bools and non-finite values too: `eval_steps <= 0` alone lets
+        # True through as "every step", inf through to an OverflowError inside TrainingArguments,
+        # and NaN through to a cadence that never fires. It is what the MLX worker already uses.
+        if not evaluation_enabled(eval_steps):
             logger.info(f"⚠️  Eval dataset provided but eval_steps={eval_steps} (disabled)\n")
             return {}, None
         rows = len(eval_dataset) if hasattr(eval_dataset, "__len__") else "?"
+        if rows == 0:
+            # eval_strategy="steps" over an empty dataloader yields no eval_loss at all, so the run
+            # would claim evaluation and report none.
+            self._record_warning(
+                "The eval dataset is empty after preprocessing, so this run has no evaluation."
+            )
+            return {}, None
         logger.info(f"✅ Evaluation enabled: eval_steps={eval_steps}, eval rows={rows}\n")
         return {
             "eval_strategy": "steps",
-            "eval_steps": eval_steps,
+            # float(): a numeric string passes evaluation_enabled but TrainingArguments compares
+            # eval_steps against an int, which raises TypeError on a str.
+            "eval_steps": float(eval_steps),
             # Avoid HF's default of 8, which can OOM audio runs.
-            "per_device_eval_batch_size": training_args.get("batch_size", 2),
+            "per_device_eval_batch_size": training_args.get("batch_size") or 2,
         }, eval_dataset
 
     def _preprocess_whisper_dataset(

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3136,7 +3136,10 @@ class UnslothTrainer:
             elif self._audio_type == "whisper":
                 train_data, eval_data = self._preprocess_whisper_dataset(
                     dataset,
-                    eval_split = eval_split,
+                    # Whisper carves 6% off train whenever eval_split is set. Without the gate
+                    # it would do that, and feature-extract the rows, for a cadence the trainer
+                    # branch then refuses.
+                    eval_split = eval_split if eval_enabled else None,
                     custom_format_mapping = custom_format_mapping,
                     eval_dataset = eval_dataset,
                 )
@@ -3888,10 +3891,18 @@ class UnslothTrainer:
                 from utils.datasets import DataCollatorSpeechSeq2SeqWithPadding
 
                 eval_dataset = training_args.get("eval_dataset", None)
+                eval_steps_val = training_args.get("eval_steps", 5)
                 extra = {"remove_unused_columns": False, "label_names": ["labels"]}
-                if eval_dataset:
+                if eval_dataset and not evaluation_enabled(eval_steps_val):
+                    # The named-split carve-out below runs off eval_split, not off the cadence, so
+                    # this branch is the only thing standing between an inf and an OverflowError
+                    # inside Seq2SeqTrainingArguments.
+                    logger.info(
+                        f"⚠️  Eval dataset provided but eval_steps={eval_steps_val} (disabled)\n"
+                    )
+                elif eval_dataset:
                     extra["eval_strategy"] = "steps"
-                    extra["eval_steps"] = training_args.get("eval_steps", 5)
+                    extra["eval_steps"] = float(eval_steps_val)
                     # HF's default of 8 can OOM audio runs, as the codec branches already note.
                     extra["per_device_eval_batch_size"] = training_args.get("batch_size") or 2
 

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -2368,18 +2368,14 @@ class UnslothTrainer:
         if eval_dataset is None:
             return None
         if self.should_stop:
-            # A stop during the train pass still returns its partial rows, so without this the
-            # eval pass starts anyway and reloads a codec model (DAC pulls Whisper Turbo) just
-            # to abort on its first row.
+            # A stopped train pass still returns partial rows, so eval would reload a codec model.
             logger.info("Stopped before eval preprocessing\n")
             return None
         try:
             return preprocess(eval_dataset, custom_format_mapping)
         except Exception as e:
             if self.should_stop:
-                # A stop empties the codec preprocessors' output, which they report as "no valid
-                # examples". That is the cancel, not the user's file: warning about their eval data
-                # here would be a false accusation on every cancelled run.
+                # A stop reads as "no valid examples": the cancel, not a bad eval file.
                 logger.info("Stopped during eval preprocessing\n")
                 return None
             self._record_warning(
@@ -2414,16 +2410,14 @@ class UnslothTrainer:
         eval_steps = training_args.get("eval_steps", 0.00)
         if eval_dataset is None:
             return {}, None
-        # evaluation_enabled rejects bools and non-finite values too: `eval_steps <= 0` alone lets
-        # True through as "every step", inf through to an OverflowError inside TrainingArguments,
-        # and NaN through to a cadence that never fires. It is what the MLX worker already uses.
+        # evaluation_enabled rejects bools and non-finite values, which `eval_steps <= 0` does not:
+        # True means "every step", inf raises inside TrainingArguments, NaN never fires.
         if not evaluation_enabled(eval_steps):
             logger.info(f"⚠️  Eval dataset provided but eval_steps={eval_steps} (disabled)\n")
             return {}, None
         rows = len(eval_dataset) if hasattr(eval_dataset, "__len__") else "?"
         if rows == 0:
-            # eval_strategy="steps" over an empty dataloader yields no eval_loss at all, so the run
-            # would claim evaluation and report none.
+            # An empty dataloader yields no eval_loss, so the run would report none.
             self._record_warning(
                 "The eval dataset is empty after preprocessing, so this run has no evaluation."
             )
@@ -2431,8 +2425,7 @@ class UnslothTrainer:
         logger.info(f"✅ Evaluation enabled: eval_steps={eval_steps}, eval rows={rows}\n")
         return {
             "eval_strategy": "steps",
-            # float(): a numeric string passes evaluation_enabled but TrainingArguments compares
-            # eval_steps against an int, which raises TypeError on a str.
+            # float(): a numeric string passes the gate but TrainingArguments needs a number.
             "eval_steps": float(eval_steps),
             # Avoid HF's default of 8, which can OOM audio runs.
             "per_device_eval_batch_size": training_args.get("batch_size") or 2,
@@ -2657,8 +2650,7 @@ class UnslothTrainer:
             eval_dataset = None
             dataset_attestation_source = None
             has_separate_eval_source = False
-            # Not `eval_steps > 0`: inf and NaN pass that and would have the whole eval
-            # split loaded and codec-encoded before _audio_eval_config discards it.
+            # Not `eval_steps > 0`: inf and NaN pass that and codec-encode a split later discarded.
             eval_enabled = evaluation_enabled(eval_steps)
             raw_text_mode = is_cpt or format_type == "raw"
             dataset_loaded_from_cache = False
@@ -3136,9 +3128,7 @@ class UnslothTrainer:
             elif self._audio_type == "whisper":
                 train_data, eval_data = self._preprocess_whisper_dataset(
                     dataset,
-                    # Whisper carves 6% off train whenever eval_split is set. Without the gate
-                    # it would do that, and feature-extract the rows, for a cadence the trainer
-                    # branch then refuses.
+                    # Whisper's 6% carve-out keys off eval_split, not the cadence, so gate it here.
                     eval_split = eval_split if eval_enabled else None,
                     custom_format_mapping = custom_format_mapping,
                     eval_dataset = eval_dataset,
@@ -3894,9 +3884,7 @@ class UnslothTrainer:
                 eval_steps_val = training_args.get("eval_steps", 5)
                 extra = {"remove_unused_columns": False, "label_names": ["labels"]}
                 if eval_dataset and not evaluation_enabled(eval_steps_val):
-                    # The named-split carve-out below runs off eval_split, not off the cadence, so
-                    # this branch is the only thing standing between an inf and an OverflowError
-                    # inside Seq2SeqTrainingArguments.
+                    # The carve-out keys off eval_split, not the cadence: only this gate stops inf.
                     logger.info(
                         f"⚠️  Eval dataset provided but eval_steps={eval_steps_val} (disabled)\n"
                     )
@@ -4133,8 +4121,7 @@ class UnslothTrainer:
             eval_steps_val = training_args.get("eval_steps", 0.00)
             if eval_dataset is not None:
                 eval_rows = len(eval_dataset) if hasattr(eval_dataset, "__len__") else None
-                # Same gate as _audio_eval_config. BiCodec and DAC land here rather than in an
-                # audio branch, so without this they would still hand inf to TrainingArguments.
+                # Same gate as _audio_eval_config: BiCodec and DAC land here, not an audio branch.
                 if not evaluation_enabled(eval_steps_val):
                     logger.info(
                         f"⚠️  Eval dataset provided but eval_steps={eval_steps_val} (disabled)\n"

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -56,6 +56,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Callable
 from datasets import Dataset
+from core.training.eval_dataset import evaluation_enabled
 from utils.datasets.audio_decode import ensure_audio_decoding
 from utils.datasets.cache_safe import load_dataset_cache_safe as load_dataset
 from utils.hf_dataset_options import hf_dataset_split_instruction_names
@@ -2366,6 +2367,12 @@ class UnslothTrainer:
         """Preprocess eval data, warning and dropping it on failure."""
         if eval_dataset is None:
             return None
+        if self.should_stop:
+            # A stop during the train pass still returns its partial rows, so without this the
+            # eval pass starts anyway and reloads a codec model (DAC pulls Whisper Turbo) just
+            # to abort on its first row.
+            logger.info("Stopped before eval preprocessing\n")
+            return None
         try:
             return preprocess(eval_dataset, custom_format_mapping)
         except Exception as e:
@@ -2403,8 +2410,6 @@ class UnslothTrainer:
 
     def _audio_eval_config(self, training_args):
         """Build audio evaluation arguments and return the eval dataset."""
-        from core.training.eval_dataset import evaluation_enabled
-
         eval_dataset = training_args.get("eval_dataset", None)
         eval_steps = training_args.get("eval_steps", 0.00)
         if eval_dataset is None:
@@ -2652,7 +2657,9 @@ class UnslothTrainer:
             eval_dataset = None
             dataset_attestation_source = None
             has_separate_eval_source = False
-            eval_enabled = eval_steps is not None and eval_steps > 0
+            # Not `eval_steps > 0`: inf and NaN pass that and would have the whole eval
+            # split loaded and codec-encoded before _audio_eval_config discards it.
+            eval_enabled = evaluation_enabled(eval_steps)
             raw_text_mode = is_cpt or format_type == "raw"
             dataset_loaded_from_cache = False
 
@@ -4114,24 +4121,32 @@ class UnslothTrainer:
             eval_dataset = training_args.get("eval_dataset", None)
             eval_steps_val = training_args.get("eval_steps", 0.00)
             if eval_dataset is not None:
-                if eval_steps_val > 0:
+                eval_rows = len(eval_dataset) if hasattr(eval_dataset, "__len__") else None
+                # Same gate as _audio_eval_config. BiCodec and DAC land here rather than in an
+                # audio branch, so without this they would still hand inf to TrainingArguments.
+                if not evaluation_enabled(eval_steps_val):
+                    logger.info(
+                        f"⚠️  Eval dataset provided but eval_steps={eval_steps_val} (disabled)\n"
+                    )
+                    logger.info("To enable evaluation, set eval_steps > 0.0\n")
+                elif eval_rows == 0:
+                    self._record_warning(
+                        "The eval dataset is empty after preprocessing, so this run has no "
+                        "evaluation."
+                    )
+                else:
                     config_args["eval_strategy"] = "steps"
-                    config_args["eval_steps"] = eval_steps_val
+                    config_args["eval_steps"] = float(eval_steps_val)
                     config_args["per_device_eval_batch_size"] = config_args[
                         "per_device_train_batch_size"
                     ]
                     logger.info(
                         f"✅ Evaluation enabled: eval_steps={eval_steps_val} (fraction of total steps)\n"
                     )
-                    if hasattr(eval_dataset, "__len__"):
-                        logger.info(f"Eval dataset: {len(eval_dataset)} rows\n")
-                    else:
+                    if eval_rows is None:
                         logger.info("Eval dataset is streaming / length unknown\n")
-                else:
-                    logger.info(
-                        f"⚠️  Eval dataset provided but eval_steps={eval_steps_val} (disabled)\n"
-                    )
-                    logger.info("To enable evaluation, set eval_steps > 0.0\n")
+                    else:
+                        logger.info(f"Eval dataset: {eval_rows} rows\n")
             else:
                 logger.info("No eval dataset — evaluation disabled\n")
 

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -36,6 +36,7 @@ from utils.native_path_leases import (
     run_without_native_path_secret,
 )
 from utils.paths import is_local_path, outputs_root
+from utils.training_runs import drop_non_finite
 from utils.utils import canonical_model_repo_id
 
 logger = get_logger(__name__)
@@ -304,7 +305,7 @@ def _sanitize_db_config(config: dict[str, Any]) -> dict[str, Any]:
             "prefix": s3_config.get("prefix"),
             "use_iam_role": bool(s3_config.get("use_iam_role")),
         }
-    return db_config
+    return drop_non_finite(db_config)
 
 
 _MODEL_SNAPSHOT_METADATA = ("config.json", "adapter_config.json")

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -210,21 +210,16 @@ class TrainingStartRequest(BaseModel):
     @field_validator("eval_steps", mode = "before")
     @classmethod
     def _normalize_eval_steps(cls, value: Any) -> Any:
-        # float is not strict, so `"eval_steps": true` would arrive as 1.0 and read as a cadence
-        # of every step. A bool is not a cadence; say so instead of guessing which one was meant.
+        # float is not strict, so `"eval_steps": true` would arrive as 1.0, a cadence of every step.
         if isinstance(value, bool):
             raise ValueError("eval_steps must be a number, not a boolean")
         # `1e309` is a plain JSON number that coerces to inf, which every gate reads as disabled.
-        # Store it as the disabled value it already means, so it never reaches config_json: json
-        # writes it as `Infinity` and Starlette renders responses with allow_nan = False, so the
-        # run's own detail view would then 500.
+        # Store it as that, so config_json never gets an `Infinity` literal Starlette then 500s on.
         try:
             if not math.isfinite(float(value)):
                 return 0.0
         except OverflowError:
-            # A JSON integer literal arrives as an arbitrary-precision int, and float() refuses one
-            # too large to represent. That is the same "not a usable cadence" case as inf, so it
-            # must not escape the validator as a 500.
+            # float() refuses a JSON int too large to represent: same unusable cadence as inf.
             return 0.0
         except (TypeError, ValueError):
             pass

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -5,6 +5,8 @@
 Pydantic schemas for Training API
 """
 
+import contextlib
+import math
 import re
 from pathlib import Path, PureWindowsPath
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -208,11 +210,18 @@ class TrainingStartRequest(BaseModel):
 
     @field_validator("eval_steps", mode = "before")
     @classmethod
-    def _reject_boolean_eval_steps(cls, value: Any) -> Any:
+    def _normalize_eval_steps(cls, value: Any) -> Any:
         # float is not strict, so `"eval_steps": true` would arrive as 1.0 and read as a cadence
         # of every step. A bool is not a cadence; say so instead of guessing which one was meant.
         if isinstance(value, bool):
             raise ValueError("eval_steps must be a number, not a boolean")
+        # `1e309` is a plain JSON number that coerces to inf, which every gate reads as disabled.
+        # Store it as the disabled value it already means, so it never reaches config_json: json
+        # writes it as `Infinity` and Starlette renders responses with allow_nan = False, so the
+        # run's own detail view would then 500.
+        with contextlib.suppress(TypeError, ValueError):
+            if not math.isfinite(float(value)):
+                return 0.0
         return value
 
     # pydantic runs all mode="after" validators in definition order and _check_steps_or_epochs is lower

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -5,7 +5,6 @@
 Pydantic schemas for Training API
 """
 
-import contextlib
 import math
 import re
 from pathlib import Path, PureWindowsPath
@@ -219,9 +218,16 @@ class TrainingStartRequest(BaseModel):
         # Store it as the disabled value it already means, so it never reaches config_json: json
         # writes it as `Infinity` and Starlette renders responses with allow_nan = False, so the
         # run's own detail view would then 500.
-        with contextlib.suppress(TypeError, ValueError):
+        try:
             if not math.isfinite(float(value)):
                 return 0.0
+        except OverflowError:
+            # A JSON integer literal arrives as an arbitrary-precision int, and float() refuses one
+            # too large to represent. That is the same "not a usable cadence" case as inf, so it
+            # must not escape the validator as a 500.
+            return 0.0
+        except (TypeError, ValueError):
+            pass
         return value
 
     # pydantic runs all mode="after" validators in definition order and _check_steps_or_epochs is lower

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -206,6 +206,15 @@ class TrainingStartRequest(BaseModel):
     def _normalize_project_name(cls, value: Optional[str]) -> Optional[str]:
         return normalize_project_name(value)
 
+    @field_validator("eval_steps", mode = "before")
+    @classmethod
+    def _reject_boolean_eval_steps(cls, value: Any) -> Any:
+        # float is not strict, so `"eval_steps": true` would arrive as 1.0 and read as a cadence
+        # of every step. A bool is not a cadence; say so instead of guessing which one was meant.
+        if isinstance(value, bool):
+            raise ValueError("eval_steps must be a number, not a boolean")
+        return value
+
     # pydantic runs all mode="after" validators in definition order and _check_steps_or_epochs is lower
     # in this class, so keep these checks order-independent.
     @model_validator(mode = "after")

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -1334,9 +1334,7 @@ async def start_training(
             request.local_datasets = _validate_local_dataset_paths(
                 request.local_datasets, "Local dataset"
             )
-        # Not `eval_steps > 0`: `1e309` is a valid JSON number that pydantic coerces to inf, which
-        # passes that but reads as disabled everywhere in the trainer. The route has to agree, or
-        # it validates eval paths for a run that will not evaluate.
+        # Not `eval_steps > 0`: inf passes that but reads as disabled everywhere in the trainer.
         if request.local_eval_datasets and evaluation_enabled(request.eval_steps):
             request.local_eval_datasets = _validate_local_dataset_paths(
                 request.local_eval_datasets, "Local eval dataset"

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -38,6 +38,7 @@ if str(backend_path) not in sys.path:
 try:
     from core.training import get_training_backend
     from core.training.diffusion_clip_formats import CLIP_EXTS as _CLIP_EXTS
+    from core.training.eval_dataset import evaluation_enabled
     from core.training.training import (
         TrainingStartCancellationCapacityError,
         TrainingStatusIdentitySnapshot,
@@ -59,6 +60,7 @@ except ImportError:
         sys.path.insert(0, str(parent_backend))
     from core.training import get_training_backend
     from core.training.diffusion_clip_formats import CLIP_EXTS as _CLIP_EXTS
+    from core.training.eval_dataset import evaluation_enabled
     from core.training.training import (
         TrainingStartCancellationCapacityError,
         TrainingStatusIdentitySnapshot,
@@ -1332,7 +1334,10 @@ async def start_training(
             request.local_datasets = _validate_local_dataset_paths(
                 request.local_datasets, "Local dataset"
             )
-        if request.local_eval_datasets and request.eval_steps > 0:
+        # Not `eval_steps > 0`: `1e309` is a valid JSON number that pydantic coerces to inf, which
+        # passes that but reads as disabled everywhere in the trainer. The route has to agree, or
+        # it validates eval paths for a run that will not evaluate.
+        if request.local_eval_datasets and evaluation_enabled(request.eval_steps):
             request.local_eval_datasets = _validate_local_dataset_paths(
                 request.local_eval_datasets, "Local eval dataset"
             )
@@ -1374,7 +1379,7 @@ async def start_training(
                     status_code = 422,
                     detail = "dataset_streaming is not supported with train_on_completions yet.",
                 )
-            if request.eval_steps > 0:
+            if evaluation_enabled(request.eval_steps):
                 train_split = request.train_split or "train"
                 if not request.eval_split or request.eval_split == train_split:
                     raise HTTPException(

--- a/studio/backend/routes/training_history.py
+++ b/studio/backend/routes/training_history.py
@@ -17,6 +17,7 @@ from loggers import get_logger
 
 from auth.authentication import authenticated_without_credential, get_current_subject
 from core.training.resume import artifacts_present, can_resume_run
+from utils.training_runs import drop_non_finite
 from models import (
     TrainingRunDeleteResponse,
     TrainingRunDetailResponse,
@@ -310,7 +311,9 @@ async def get_training_run_detail(
         raise HTTPException(status_code = 404, detail = f"Run {run_id} not found")
 
     try:
-        config = json.loads(run.get("config_json", "{}"))
+        # An older install could have written `Infinity` or `NaN` here, which json accepts on the
+        # way in but Starlette refuses on the way out, so drop them rather than 500 the view.
+        config = drop_non_finite(json.loads(run.get("config_json", "{}")))
     except (json.JSONDecodeError, TypeError):
         logger.debug("Failed to parse config_json for run %s", run_id)
         config = {}

--- a/studio/backend/routes/training_history.py
+++ b/studio/backend/routes/training_history.py
@@ -311,8 +311,7 @@ async def get_training_run_detail(
         raise HTTPException(status_code = 404, detail = f"Run {run_id} not found")
 
     try:
-        # An older install could have written `Infinity` or `NaN` here, which json accepts on the
-        # way in but Starlette refuses on the way out, so drop them rather than 500 the view.
+        # An older install may have stored `Infinity` / `NaN`, which Starlette refuses to render.
         config = drop_non_finite(json.loads(run.get("config_json", "{}")))
     except (json.JSONDecodeError, TypeError):
         logger.debug("Failed to parse config_json for run %s", run_id)

--- a/studio/backend/tests/test_audio_eval_dataset.py
+++ b/studio/backend/tests/test_audio_eval_dataset.py
@@ -152,8 +152,7 @@ def test_no_eval_dataset_disables_evaluation(audio_trainer):
 
 @pytest.mark.parametrize("eval_steps", [True, float("inf"), float("nan"), "abc"])
 def test_hostile_eval_steps_disable_evaluation(audio_trainer, eval_steps):
-    """`eval_steps <= 0` alone lets these through: True evaluates every step, inf raises
-    OverflowError inside TrainingArguments, NaN never fires, a non-numeric str raises."""
+    """`eval_steps <= 0` lets these through: True is every step, inf raises, NaN never fires."""
     args, eval_dataset = audio_trainer._audio_eval_config(
         {"eval_dataset": ["a", "b"], "eval_steps": eval_steps, "batch_size": 2}
     )
@@ -185,8 +184,7 @@ def test_missing_batch_size_falls_back_instead_of_passing_none(audio_trainer):
 
 
 def test_a_stop_during_eval_preprocessing_is_not_reported_as_a_bad_eval_file(audio_trainer):
-    """The codec preprocessors report a stop as "no valid examples"; that is the cancel, not
-    the user's upload, so it must not raise a warning about their eval dataset."""
+    """A stop is reported as "no valid examples"; that is the cancel, not the user's upload."""
     audio_trainer.should_stop = True
 
     def stopped(dataset, custom_format_mapping = None):
@@ -214,8 +212,7 @@ def test_numeric_string_eval_steps_is_normalised(audio_trainer):
 
 
 def test_a_length_less_eval_split_still_enables_evaluation(audio_trainer):
-    """The empty-split guard reads a row count; a streaming split has none and must not be
-    mistaken for an empty one."""
+    """A streaming split has no row count and must not be mistaken for an empty one."""
 
     class _NoLen:
         pass
@@ -260,8 +257,7 @@ def test_transformers_accepts_the_produced_config(audio_trainer, tmp_path, eval_
 
 
 def test_a_stop_skips_the_eval_preprocessor_entirely(audio_trainer):
-    """A stop during the train pass still returns partial rows, so the eval pass would start
-    anyway and reload a codec model (DAC pulls Whisper Turbo) just to abort on its first row."""
+    """A stopped train pass returns partial rows, so eval would reload a codec model to abort."""
     audio_trainer.should_stop = True
     calls = []
 
@@ -279,8 +275,7 @@ def test_a_stop_skips_the_eval_preprocessor_entirely(audio_trainer):
 def test_an_invalid_cadence_never_preprocesses_the_eval_split(
     audio_trainer, tmp_path, monkeypatch, audio_type, eval_steps
 ):
-    """load_and_format_dataset used to gate on `eval_steps > 0`, so inf and NaN had the whole
-    eval split loaded and codec-encoded before _audio_eval_config discarded it."""
+    """Gating on `eval_steps > 0` let inf and NaN codec-encode a split _audio_eval_config drops."""
     audio_trainer._audio_type = audio_type
     monkeypatch.setattr(tmod, "ensure_audio_decoding", lambda: True)
     seen = []
@@ -309,8 +304,7 @@ def test_an_invalid_cadence_never_preprocesses_the_eval_split(
 def test_the_generic_sft_path_uses_the_same_cadence_gate(
     audio_trainer, tmp_path, monkeypatch, eval_steps, expect_enabled
 ):
-    """BiCodec and DAC deliberately fall through to the generic SFT path, so the gate there has
-    to match the one in _audio_eval_config or inf still reaches TrainingArguments for them."""
+    """BiCodec and DAC fall through here, so this gate must match the one in _audio_eval_config."""
     captured = {}
 
     class _FakeSFTConfig:
@@ -357,8 +351,8 @@ def test_the_generic_sft_path_uses_the_same_cadence_gate(
             output_dir = str(tmp_path),
         )
     except Exception:
-        # The generic path needs far more of a real model than this test provides; the eval
-        # decision is made before any of that, so the captured config is what matters.
+        # The generic path needs a real model; the eval decision happens before that, so only
+        # the captured config matters.
         pass
 
     if expect_enabled:

--- a/studio/backend/tests/test_audio_eval_dataset.py
+++ b/studio/backend/tests/test_audio_eval_dataset.py
@@ -211,3 +211,49 @@ def test_numeric_string_eval_steps_is_normalised(audio_trainer):
     )
     assert eval_dataset is not None
     assert isinstance(args["eval_steps"], float) and args["eval_steps"] == 0.1
+
+
+def test_a_length_less_eval_split_still_enables_evaluation(audio_trainer):
+    """The empty-split guard reads a row count; a streaming split has none and must not be
+    mistaken for an empty one."""
+
+    class _NoLen:
+        pass
+
+    args, eval_dataset = audio_trainer._audio_eval_config(
+        {"eval_dataset": _NoLen(), "eval_steps": 0.1, "batch_size": 2}
+    )
+    assert eval_dataset is not None
+    assert args["eval_strategy"] == "steps"
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 8])
+def test_explicit_batch_sizes_are_preserved(audio_trainer, batch_size):
+    args, _ = audio_trainer._audio_eval_config(
+        {"eval_dataset": ["a"], "eval_steps": 0.1, "batch_size": batch_size}
+    )
+    assert args["per_device_eval_batch_size"] == batch_size
+
+
+@pytest.mark.parametrize("eval_steps,expected", [(0.1, 0.1), (0.25, 0.25), (1, 1), (2, 2)])
+def test_transformers_accepts_the_produced_config(audio_trainer, tmp_path, eval_steps, expected):
+    """Normalising eval_steps to float must not change the cadence transformers ends up with."""
+    transformers = pytest.importorskip("transformers")
+
+    training_args = {
+        "eval_dataset": ["a", "b"],
+        "eval_steps": eval_steps,
+        "batch_size": 2,
+        "max_steps": 8,
+        "optim": "adamw_torch",
+    }
+    eval_args, eval_dataset = audio_trainer._audio_eval_config(training_args)
+    assert eval_dataset is not None
+    config = audio_trainer._build_audio_training_args(
+        training_args, str(tmp_path), extra_args = {"remove_unused_columns": False, **eval_args}
+    )
+    config.update(bf16 = False, fp16 = False, use_cpu = True, report_to = [])
+    args = transformers.TrainingArguments(**config)
+    assert args.eval_strategy == "steps"
+    assert args.eval_steps == expected
+    assert args.per_device_eval_batch_size == 2

--- a/studio/backend/tests/test_audio_eval_dataset.py
+++ b/studio/backend/tests/test_audio_eval_dataset.py
@@ -365,6 +365,6 @@ def test_the_generic_sft_path_uses_the_same_cadence_gate(
         assert captured.get("eval_strategy") == "steps", f"eval_steps={eval_steps} was not enabled"
     else:
         assert captured, "the config was never built, so this asserts nothing"
-        assert "eval_strategy" not in captured, (
-            f"eval_steps={eval_steps} reached TrainingArguments as a cadence"
-        )
+        assert (
+            "eval_strategy" not in captured
+        ), f"eval_steps={eval_steps} reached TrainingArguments as a cadence"

--- a/studio/backend/tests/test_audio_eval_dataset.py
+++ b/studio/backend/tests/test_audio_eval_dataset.py
@@ -148,3 +148,66 @@ def test_eval_steps_zero_disables_evaluation(audio_trainer):
 def test_no_eval_dataset_disables_evaluation(audio_trainer):
     args, eval_dataset = audio_trainer._audio_eval_config({"eval_dataset": None, "eval_steps": 0.1})
     assert (args, eval_dataset) == ({}, None)
+
+
+@pytest.mark.parametrize("eval_steps", [True, float("inf"), float("nan"), "abc"])
+def test_hostile_eval_steps_disable_evaluation(audio_trainer, eval_steps):
+    """`eval_steps <= 0` alone lets these through: True evaluates every step, inf raises
+    OverflowError inside TrainingArguments, NaN never fires, a non-numeric str raises."""
+    args, eval_dataset = audio_trainer._audio_eval_config(
+        {"eval_dataset": ["a", "b"], "eval_steps": eval_steps, "batch_size": 2}
+    )
+    assert (args, eval_dataset) == ({}, None)
+
+
+def test_audio_eval_config_agrees_with_the_shared_validator(audio_trainer):
+    from core.training.eval_dataset import evaluation_enabled
+    for value in (0.1, 0.25, 1, 2, 0, 0.0, -1, None, True, False, float("inf"), float("nan")):
+        _args, eval_dataset = audio_trainer._audio_eval_config(
+            {"eval_dataset": ["a"], "eval_steps": value, "batch_size": 2}
+        )
+        assert (eval_dataset is not None) == evaluation_enabled(value), value
+
+
+def test_empty_eval_split_disables_evaluation_with_a_warning(audio_trainer):
+    args, eval_dataset = audio_trainer._audio_eval_config(
+        {"eval_dataset": [], "eval_steps": 0.1, "batch_size": 2}
+    )
+    assert (args, eval_dataset) == ({}, None)
+    assert any("empty" in w for w in audio_trainer.training_progress.warnings)
+
+
+def test_missing_batch_size_falls_back_instead_of_passing_none(audio_trainer):
+    args, _ = audio_trainer._audio_eval_config(
+        {"eval_dataset": ["a"], "eval_steps": 0.1, "batch_size": None}
+    )
+    assert args["per_device_eval_batch_size"] == 2
+
+
+def test_a_stop_during_eval_preprocessing_is_not_reported_as_a_bad_eval_file(audio_trainer):
+    """The codec preprocessors report a stop as "no valid examples"; that is the cancel, not
+    the user's upload, so it must not raise a warning about their eval dataset."""
+    audio_trainer.should_stop = True
+
+    def stopped(dataset, custom_format_mapping = None):
+        raise ValueError("No valid examples after CSM preprocessing (skipped 4)")
+
+    assert audio_trainer._preprocess_audio_eval_split(object(), stopped, None) is None
+    assert not audio_trainer.training_progress.warnings
+
+
+def test_a_real_failure_still_warns_when_not_stopping(audio_trainer):
+    def explode(dataset, custom_format_mapping = None):
+        raise ValueError("no audio column found in dataset")
+
+    assert audio_trainer._preprocess_audio_eval_split(object(), explode, None) is None
+    assert any("no evaluation" in w for w in audio_trainer.training_progress.warnings)
+
+
+def test_numeric_string_eval_steps_is_normalised(audio_trainer):
+    """A numeric string is a valid cadence, but TrainingArguments compares it against an int."""
+    args, eval_dataset = audio_trainer._audio_eval_config(
+        {"eval_dataset": ["a"], "eval_steps": "0.1", "batch_size": 2}
+    )
+    assert eval_dataset is not None
+    assert isinstance(args["eval_steps"], float) and args["eval_steps"] == 0.1

--- a/studio/backend/tests/test_audio_eval_dataset.py
+++ b/studio/backend/tests/test_audio_eval_dataset.py
@@ -257,3 +257,114 @@ def test_transformers_accepts_the_produced_config(audio_trainer, tmp_path, eval_
     assert args.eval_strategy == "steps"
     assert args.eval_steps == expected
     assert args.per_device_eval_batch_size == 2
+
+
+def test_a_stop_skips_the_eval_preprocessor_entirely(audio_trainer):
+    """A stop during the train pass still returns partial rows, so the eval pass would start
+    anyway and reload a codec model (DAC pulls Whisper Turbo) just to abort on its first row."""
+    audio_trainer.should_stop = True
+    calls = []
+
+    def preprocess(dataset, custom_format_mapping = None):
+        calls.append(dataset)
+        return dataset
+
+    assert audio_trainer._preprocess_audio_eval_split(object(), preprocess, None) is None
+    assert calls == [], "the codec preprocessor ran after the run was stopped"
+    assert not audio_trainer.training_progress.warnings
+
+
+@pytest.mark.parametrize("eval_steps", [float("inf"), float("nan"), 0, -1])
+@pytest.mark.parametrize("audio_type", CODEC_TYPES)
+def test_an_invalid_cadence_never_preprocesses_the_eval_split(
+    audio_trainer, tmp_path, monkeypatch, audio_type, eval_steps
+):
+    """load_and_format_dataset used to gate on `eval_steps > 0`, so inf and NaN had the whole
+    eval split loaded and codec-encoded before _audio_eval_config discarded it."""
+    audio_trainer._audio_type = audio_type
+    monkeypatch.setattr(tmod, "ensure_audio_decoding", lambda: True)
+    seen = []
+    monkeypatch.setattr(
+        audio_trainer,
+        f"_preprocess_{audio_type}_dataset",
+        lambda ds, m = None: (seen.append(len(ds)), ds)[1],
+        raising = True,
+    )
+
+    _train, evaluation = audio_trainer.load_and_format_dataset(
+        None,
+        local_datasets = [_rows(tmp_path / "train.jsonl", "train")],
+        local_eval_datasets = [_rows(tmp_path / "eval.jsonl", "eval")],
+        eval_steps = eval_steps,
+    )
+
+    assert evaluation is None
+    assert len(seen) == 1, f"eval_steps={eval_steps} still preprocessed the eval split"
+
+
+@pytest.mark.parametrize(
+    "eval_steps,expect_enabled",
+    [(0.25, True), (2, True), (float("inf"), False), (float("nan"), False), (0, False)],
+)
+def test_the_generic_sft_path_uses_the_same_cadence_gate(
+    audio_trainer, tmp_path, monkeypatch, eval_steps, expect_enabled
+):
+    """BiCodec and DAC deliberately fall through to the generic SFT path, so the gate there has
+    to match the one in _audio_eval_config or inf still reaches TrainingArguments for them."""
+    captured = {}
+
+    class _FakeSFTConfig:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    class _FakeSFTTrainer:
+        def __init__(self, **kwargs):
+            captured["trainer_kwargs"] = kwargs
+
+        def add_callback(self, cb):
+            pass
+
+        def train(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(tmod, "SFTConfig", _FakeSFTConfig, raising = False)
+    monkeypatch.setattr(tmod, "SFTTrainer", _FakeSFTTrainer, raising = False)
+    monkeypatch.setattr(tmod, "resolve_output_dir", lambda p: tmp_path, raising = True)
+    monkeypatch.setattr(tmod, "ensure_dir", lambda p: p, raising = True)
+    monkeypatch.setattr(tmod, "_drop_hf_stdout_callbacks", lambda trainer: None, raising = True)
+    monkeypatch.setattr(
+        tmod.UnslothTrainer, "_finalize_training", lambda self, *a, **k: None, raising = True
+    )
+    monkeypatch.setattr(
+        tmod.UnslothTrainer, "_preflight_first_batch", lambda self: None, raising = True
+    )
+
+    audio_trainer._audio_type = "bicodec"
+    audio_trainer.model = object()
+    audio_trainer.tokenizer = object()
+    audio_trainer.model_name = "unsloth/spark-tts"
+
+    rows = [{"text": "a"}, {"text": "b"}]
+    try:
+        audio_trainer._train_worker(
+            {"dataset": rows, "final_format": "audio_bicodec"},
+            eval_dataset = rows,
+            eval_steps = eval_steps,
+            batch_size = 2,
+            gradient_accumulation_steps = 1,
+            max_steps = 8,
+            warmup_steps = 0,
+            output_dir = str(tmp_path),
+        )
+    except Exception:
+        # The generic path needs far more of a real model than this test provides; the eval
+        # decision is made before any of that, so the captured config is what matters.
+        pass
+
+    if expect_enabled:
+        assert captured.get("eval_strategy") == "steps", f"eval_steps={eval_steps} was not enabled"
+    else:
+        assert captured, "the config was never built, so this asserts nothing"
+        assert "eval_strategy" not in captured, (
+            f"eval_steps={eval_steps} reached TrainingArguments as a cadence"
+        )

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -3305,9 +3305,7 @@ def test_cache_local_paths_blank_normalizes_to_none():
 
 @pytest.mark.parametrize("value", [True, False])
 def test_boolean_eval_steps_is_rejected_by_the_request_model(value):
-    """`float` is not strict, so `"eval_steps": true` used to arrive as 1.0 and read as a
-    cadence of every step. Checking for a bool inside the trainer cannot see that, because the
-    coercion happens first."""
+    """`float` is not strict, so `"eval_steps": true` arrived as 1.0 before any trainer check."""
     with pytest.raises(ValidationError):
         _request(eval_steps = value)
 
@@ -3318,9 +3316,8 @@ def test_numeric_eval_steps_still_accepted(value):
 
 
 def test_a_json_number_too_large_for_a_float_arrives_as_infinity():
-    """Pins the library behaviour the gates exist for, so the premise cannot drift: `1e309` is a
-    plain JSON number, not one of the non-standard `Infinity` / `NaN` literals, so a
-    spec-conformant client can send it and pydantic's non-strict `float` coerces it to inf."""
+    """Pins the premise: `1e309` is a plain JSON number, not a non-standard `Infinity` literal,
+    and pydantic's non-strict `float` coerces it to inf."""
     from pydantic import BaseModel
 
     class _Bare(BaseModel):
@@ -3332,8 +3329,7 @@ def test_a_json_number_too_large_for_a_float_arrives_as_infinity():
 
 @pytest.mark.parametrize("cadence", [float("inf"), float("nan")])
 def test_a_disabled_cadence_does_not_validate_the_local_eval_paths(cadence):
-    """The trainer reads a non-finite cadence as evaluation off, so the route must not 400 a
-    run over eval paths it is never going to read."""
+    """A non-finite cadence is evaluation off, so the route must not 400 over unused paths."""
     route = _load_route_module("training_route_disabled_cadence_skips_eval_paths")
     request = _request(eval_steps = cadence, local_eval_datasets = [""])
 
@@ -3351,8 +3347,7 @@ def test_a_disabled_cadence_does_not_validate_the_local_eval_paths(cadence):
 
 
 def test_a_disabled_cadence_does_not_demand_a_separate_streaming_eval_split():
-    """`eval_steps > 0` let inf through, so a streaming run was rejected outright for lacking an
-    eval split it did not need."""
+    """`eval_steps > 0` let inf through, rejecting a streaming run over a split it did not need."""
     route = _load_route_module("training_route_disabled_cadence_streaming_eval_split")
     request = _request(
         dataset_streaming = True, max_steps = 10, eval_steps = float("inf"), eval_split = None
@@ -3381,9 +3376,8 @@ def test_a_usable_cadence_still_demands_a_separate_streaming_eval_split():
 
 @pytest.mark.parametrize("literal", ["1e309", "-1e309", "Infinity", "NaN"])
 def test_a_non_finite_cadence_is_stored_as_disabled(literal):
-    """inf and NaN survive `json.dumps` as the non-standard `Infinity` / `NaN` literals and parse
-    back fine, but Starlette renders with `allow_nan = False`, so a run that persisted one to
-    config_json would 500 its own detail view. Normalise at the boundary instead."""
+    """json writes inf/NaN as the non-standard `Infinity` / `NaN` literals but Starlette renders
+    with `allow_nan = False`, so a config_json carrying one 500s the run's detail view."""
     request = TrainingStartRequest.model_validate_json(
         '{"model_name": "unsloth/test", "training_type": "LoRA/QLoRA", '
         '"format_type": "alpaca", "hf_dataset": "org/dataset", '
@@ -3414,8 +3408,7 @@ def test_the_persisted_config_never_carries_a_non_finite_value():
 
 
 def test_a_run_stored_by_an_older_install_still_renders():
-    """An install from before this change can already have `Infinity` in config_json, and no
-    change to the request model repairs that row."""
+    """An older install can already hold `Infinity` in config_json; the request model cannot."""
     from utils.training_runs import drop_non_finite
 
     stored = json.dumps({"eval_steps": float("inf"), "model_name": "unsloth/test"})
@@ -3426,9 +3419,8 @@ def test_a_run_stored_by_an_older_install_still_renders():
 
 
 def test_a_json_integer_too_large_for_a_float_is_disabled_not_a_500():
-    """A JSON integer literal arrives as an arbitrary-precision int, and `float()` raises
-    OverflowError on one too large to represent. OverflowError is not a ValueError, so it would
-    escape the validator and the start endpoint would 500 instead of returning a request error."""
+    """`float()` on a huge JSON int raises OverflowError, which is not a ValueError, so it
+    escaped the validator and 500d the start endpoint."""
     huge = "1" + "0" * 310
     assert isinstance(json.loads(huge), int)
     with pytest.raises(OverflowError):
@@ -3443,7 +3435,6 @@ def test_a_json_integer_too_large_for_a_float_is_disabled_not_a_500():
 
 
 def test_the_shared_cadence_gate_survives_an_unrepresentable_integer():
-    """`evaluation_enabled` caught only TypeError and ValueError, so the same value took down
-    every caller of it, including the route gate and the MLX worker."""
+    """`evaluation_enabled` caught only TypeError and ValueError, so this took down every caller."""
     from core.training.eval_dataset import evaluation_enabled
     assert evaluation_enabled(int("1" + "0" * 310)) is False

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -3423,3 +3423,27 @@ def test_a_run_stored_by_an_older_install_still_renders():
 
     assert config == {"eval_steps": None, "model_name": "unsloth/test"}
     JSONResponse(content = config).render(config)
+
+
+def test_a_json_integer_too_large_for_a_float_is_disabled_not_a_500():
+    """A JSON integer literal arrives as an arbitrary-precision int, and `float()` raises
+    OverflowError on one too large to represent. OverflowError is not a ValueError, so it would
+    escape the validator and the start endpoint would 500 instead of returning a request error."""
+    huge = "1" + "0" * 310
+    assert isinstance(json.loads(huge), int)
+    with pytest.raises(OverflowError):
+        float(json.loads(huge))
+
+    request = TrainingStartRequest.model_validate_json(
+        '{"model_name": "unsloth/test", "training_type": "LoRA/QLoRA", '
+        '"format_type": "alpaca", "hf_dataset": "org/dataset", '
+        f'"eval_steps": {huge}}}'
+    )
+    assert request.eval_steps == 0.0
+
+
+def test_the_shared_cadence_gate_survives_an_unrepresentable_integer():
+    """`evaluation_enabled` caught only TypeError and ValueError, so the same value took down
+    every caller of it, including the route gate and the MLX worker."""
+    from core.training.eval_dataset import evaluation_enabled
+    assert evaluation_enabled(int("1" + "0" * 310)) is False

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -1446,7 +1446,7 @@ def test_reset_route_without_body_stays_supported():
     route = _load_route_module("training_route_unscoped_reset")
     calls: list[str | None] = []
     backend = SimpleNamespace(
-        reset_training_state = lambda expected_job_id = None: (calls.append(expected_job_id) or "ok")
+        reset_training_state = lambda expected_job_id = None: calls.append(expected_job_id) or "ok"
     )
 
     with (
@@ -2336,8 +2336,9 @@ def test_worker_security_scans_exact_model_load_target(offline):
         ),
         patch(
             "utils.security.evaluate_file_security",
-            side_effect = lambda target, **kwargs: scanned.append((target, kwargs["local_only_load"]))
-            or decision,
+            side_effect = lambda target, **kwargs: (
+                scanned.append((target, kwargs["local_only_load"])) or decision
+            ),
         ),
         patch("utils.utils.hf_env_offline", return_value = offline),
     ):
@@ -2370,8 +2371,9 @@ def test_worker_remote_retry_security_scan_is_not_local_only():
         patch("utils.security.security_load_subdirs", return_value = ()),
         patch(
             "utils.security.evaluate_file_security",
-            side_effect = lambda target, **kwargs: scanned.append((target, kwargs["local_only_load"]))
-            or decision,
+            side_effect = lambda target, **kwargs: (
+                scanned.append((target, kwargs["local_only_load"])) or decision
+            ),
         ),
         patch("utils.utils.hf_env_offline", return_value = False),
     ):
@@ -2403,12 +2405,13 @@ def test_worker_security_scopes_pinned_target_before_registry_fallback():
         ),
         patch(
             "utils.security.security_load_subdirs",
-            side_effect = lambda target, _token: (("LLM",) if target == snapshot else ("registry",)),
+            side_effect = lambda target, _token: ("LLM",) if target == snapshot else ("registry",),
         ),
         patch(
             "utils.security.evaluate_file_security",
-            side_effect = lambda target, **kwargs: scanned.append((target, kwargs["load_subdirs"]))
-            or decision,
+            side_effect = lambda target, **kwargs: (
+                scanned.append((target, kwargs["load_subdirs"])) or decision
+            ),
         ),
         patch("utils.utils.hf_env_offline", return_value = False),
     ):
@@ -3296,3 +3299,17 @@ def test_cache_local_paths_blank_normalizes_to_none():
     request = _request(model_local_path = "   ", dataset_local_path = "")
     assert request.model_local_path is None
     assert request.dataset_local_path is None
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_boolean_eval_steps_is_rejected_by_the_request_model(value):
+    """`float` is not strict, so `"eval_steps": true` used to arrive as 1.0 and read as a
+    cadence of every step. Checking for a bool inside the trainer cannot see that, because the
+    coercion happens first."""
+    with pytest.raises(ValidationError):
+        _request(eval_steps = value)
+
+
+@pytest.mark.parametrize("value", [0, 0.0, 0.25, 1, 2, "0.1"])
+def test_numeric_eval_steps_still_accepted(value):
+    assert _request(eval_steps = value).eval_steps == float(value)

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import importlib.util
+import contextlib
 import json
 import os
 import sys
@@ -3313,3 +3314,69 @@ def test_boolean_eval_steps_is_rejected_by_the_request_model(value):
 @pytest.mark.parametrize("value", [0, 0.0, 0.25, 1, 2, "0.1"])
 def test_numeric_eval_steps_still_accepted(value):
     assert _request(eval_steps = value).eval_steps == float(value)
+
+
+def test_a_json_number_too_large_for_a_float_arrives_as_infinity():
+    """Pins the behaviour the route gate exists for. `1e309` is a plain JSON number, not one of
+    the non-standard `Infinity` / `NaN` literals, so a spec-conformant client can send it and
+    pydantic's non-strict `float` coerces it to inf."""
+    request = TrainingStartRequest.model_validate_json(
+        json.dumps(
+            {
+                "model_name": "unsloth/test",
+                "training_type": "LoRA/QLoRA",
+                "format_type": "alpaca",
+                "hf_dataset": "org/dataset",
+            }
+        ).replace("}", ', "eval_steps": 1e309}')
+    )
+    assert request.eval_steps == float("inf")
+
+
+@pytest.mark.parametrize("cadence", [float("inf"), float("nan")])
+def test_a_disabled_cadence_does_not_validate_the_local_eval_paths(cadence):
+    """The trainer reads a non-finite cadence as evaluation off, so the route must not 400 a
+    run over eval paths it is never going to read."""
+    route = _load_route_module("training_route_disabled_cadence_skips_eval_paths")
+    request = _request(eval_steps = cadence, local_eval_datasets = [""])
+
+    labels: list[str] = []
+
+    with patch.object(
+        route,
+        "_validate_local_dataset_paths",
+        side_effect = lambda paths, label: labels.append(label) or paths,
+    ):
+        with contextlib.suppress(Exception):
+            _start(route, request)
+
+    assert labels == [], f"eval paths were validated for eval_steps={cadence}"
+
+
+def test_a_disabled_cadence_does_not_demand_a_separate_streaming_eval_split():
+    """`eval_steps > 0` let inf through, so a streaming run was rejected outright for lacking an
+    eval split it did not need."""
+    route = _load_route_module("training_route_disabled_cadence_streaming_eval_split")
+    request = _request(
+        dataset_streaming = True, max_steps = 10, eval_steps = float("inf"), eval_split = None
+    )
+
+    detail = None
+    try:
+        _start(route, request)
+    except HTTPException as exc:
+        detail = exc.detail
+
+    assert detail != "dataset_streaming with evaluation requires a separate eval_split."
+
+
+def test_a_usable_cadence_still_demands_a_separate_streaming_eval_split():
+    route = _load_route_module("training_route_usable_cadence_streaming_eval_split")
+    request = _request(dataset_streaming = True, max_steps = 10, eval_steps = 0.25, eval_split = None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _start(route, request)
+
+    assert (
+        exc_info.value.detail == "dataset_streaming with evaluation requires a separate eval_split."
+    )

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 from fastapi import HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
 from hub.utils import hf_cache_state
@@ -3317,20 +3318,16 @@ def test_numeric_eval_steps_still_accepted(value):
 
 
 def test_a_json_number_too_large_for_a_float_arrives_as_infinity():
-    """Pins the behaviour the route gate exists for. `1e309` is a plain JSON number, not one of
-    the non-standard `Infinity` / `NaN` literals, so a spec-conformant client can send it and
-    pydantic's non-strict `float` coerces it to inf."""
-    request = TrainingStartRequest.model_validate_json(
-        json.dumps(
-            {
-                "model_name": "unsloth/test",
-                "training_type": "LoRA/QLoRA",
-                "format_type": "alpaca",
-                "hf_dataset": "org/dataset",
-            }
-        ).replace("}", ', "eval_steps": 1e309}')
-    )
-    assert request.eval_steps == float("inf")
+    """Pins the library behaviour the gates exist for, so the premise cannot drift: `1e309` is a
+    plain JSON number, not one of the non-standard `Infinity` / `NaN` literals, so a
+    spec-conformant client can send it and pydantic's non-strict `float` coerces it to inf."""
+    from pydantic import BaseModel
+
+    class _Bare(BaseModel):
+        eval_steps: float = 0.0
+
+    assert json.loads("1e309") == float("inf")
+    assert _Bare.model_validate_json('{"eval_steps": 1e309}').eval_steps == float("inf")
 
 
 @pytest.mark.parametrize("cadence", [float("inf"), float("nan")])
@@ -3380,3 +3377,49 @@ def test_a_usable_cadence_still_demands_a_separate_streaming_eval_split():
     assert (
         exc_info.value.detail == "dataset_streaming with evaluation requires a separate eval_split."
     )
+
+
+@pytest.mark.parametrize("literal", ["1e309", "-1e309", "Infinity", "NaN"])
+def test_a_non_finite_cadence_is_stored_as_disabled(literal):
+    """inf and NaN survive `json.dumps` as the non-standard `Infinity` / `NaN` literals and parse
+    back fine, but Starlette renders with `allow_nan = False`, so a run that persisted one to
+    config_json would 500 its own detail view. Normalise at the boundary instead."""
+    request = TrainingStartRequest.model_validate_json(
+        '{"model_name": "unsloth/test", "training_type": "LoRA/QLoRA", '
+        '"format_type": "alpaca", "hf_dataset": "org/dataset", '
+        f'"eval_steps": {literal}}}'
+    )
+    assert request.eval_steps == 0.0
+
+
+def test_the_persisted_config_never_carries_a_non_finite_value():
+    from core.training.training import _sanitize_db_config
+
+    sanitized = _sanitize_db_config(
+        {
+            "eval_steps": float("inf"),
+            "learning_rate": float("nan"),
+            "nested": {"a": [float("-inf"), 1.0]},
+            "keep": 0.25,
+            "flag": True,
+        }
+    )
+
+    assert sanitized["eval_steps"] is None
+    assert sanitized["learning_rate"] is None
+    assert sanitized["nested"] == {"a": [None, 1.0]}
+    assert sanitized["keep"] == 0.25
+    assert sanitized["flag"] is True
+    JSONResponse(content = sanitized).render(sanitized)
+
+
+def test_a_run_stored_by_an_older_install_still_renders():
+    """An install from before this change can already have `Infinity` in config_json, and no
+    change to the request model repairs that row."""
+    from utils.training_runs import drop_non_finite
+
+    stored = json.dumps({"eval_steps": float("inf"), "model_name": "unsloth/test"})
+    config = drop_non_finite(json.loads(stored))
+
+    assert config == {"eval_steps": None, "model_name": "unsloth/test"}
+    JSONResponse(content = config).render(config)

--- a/studio/backend/tests/test_whisper_audio_vlm_eval_dataset.py
+++ b/studio/backend/tests/test_whisper_audio_vlm_eval_dataset.py
@@ -421,7 +421,14 @@ def test_audio_vlm_matching_eval_split_leaves_the_column_alone(
     assert audio_trainer._audio_vlm_audio_col == "audio"
 
 
-def _drive_whisper_branch(audio_trainer, tmp_path, monkeypatch, *, eval_rows):
+def _drive_whisper_branch(
+    audio_trainer,
+    tmp_path,
+    monkeypatch,
+    *,
+    eval_rows,
+    eval_steps = 0.25,
+):
     """Drive the real Whisper _train_worker branch; only train() is stubbed, so the asserted
     args and eval dataset are genuine transformers objects."""
     transformers = pytest.importorskip("transformers")
@@ -463,7 +470,7 @@ def _drive_whisper_branch(audio_trainer, tmp_path, monkeypatch, *, eval_rows):
     audio_trainer._train_worker(
         [{"input_features": [0.0], "labels": [1]}] * 4,
         eval_dataset = eval_rows,
-        eval_steps = 0.25,
+        eval_steps = eval_steps,
         batch_size = 2,
         gradient_accumulation_steps = 1,
         max_steps = 8,
@@ -505,6 +512,76 @@ def test_whisper_trainer_branch_omits_eval_for_an_empty_split(audio_trainer, tmp
     assert trainer is not None
     assert not trainer.eval_dataset
     assert trainer.args.eval_strategy == "no"
+
+
+@pytest.mark.parametrize("bad", [float("inf"), float("nan"), True, 0, -1])
+def test_whisper_trainer_branch_refuses_an_unusable_cadence(
+    audio_trainer, tmp_path, monkeypatch, bad
+):
+    """inf raised an OverflowError inside Seq2SeqTrainingArguments, NaN and 0 configured an
+    evaluation that never ran, and True evaluated every step."""
+    trainer = _drive_whisper_branch(
+        audio_trainer,
+        tmp_path,
+        monkeypatch,
+        eval_rows = [{"input_features": [0.0], "labels": [2]}] * 2,
+        eval_steps = bad,
+    )
+
+    assert trainer is not None, f"eval_steps={bad!r} took the Whisper branch down"
+    assert trainer.args.eval_strategy == "no"
+
+
+def test_whisper_trainer_branch_normalises_a_numeric_string_cadence(
+    audio_trainer, tmp_path, monkeypatch
+):
+    """A numeric string is a usable cadence, but TrainingArguments compares eval_steps against
+    an int and raises TypeError on a str."""
+    trainer = _drive_whisper_branch(
+        audio_trainer,
+        tmp_path,
+        monkeypatch,
+        eval_rows = [{"input_features": [0.0], "labels": [2]}] * 2,
+        eval_steps = "0.1",
+    )
+
+    assert trainer is not None
+    assert trainer.args.eval_strategy == "steps"
+    assert trainer.args.eval_steps == 0.1
+
+
+def test_whisper_carve_out_is_skipped_when_the_cadence_is_unusable(audio_trainer, monkeypatch):
+    """The 6% carve-out runs off eval_split, not off the cadence, so it used to feature-extract
+    rows for an evaluation the trainer branch then refuses."""
+    seen = {}
+
+    def fake(
+        dataset,
+        eval_split = None,
+        custom_format_mapping = None,
+        eval_dataset = None,
+    ):
+        seen["eval_split"] = eval_split
+        return ([{"input_features": [0.0], "labels": [1]}], None)
+
+    datasets = pytest.importorskip("datasets")
+    audio_trainer._audio_type = "whisper"
+    monkeypatch.setattr(audio_trainer, "_preprocess_whisper_dataset", fake, raising = True)
+    monkeypatch.setattr(tmod, "ensure_audio_decoding", lambda: True, raising = False)
+    monkeypatch.setattr(
+        tmod,
+        "load_dataset",
+        lambda *a, **k: datasets.Dataset.from_dict({"audio": ["a"] * 4, "text": ["x"] * 4}),
+        raising = False,
+    )
+
+    audio_trainer.load_and_format_dataset(
+        "some/dataset", eval_split = "validation", eval_steps = float("inf")
+    )
+    assert seen["eval_split"] is None
+
+    audio_trainer.load_and_format_dataset("some/dataset", eval_split = "validation", eval_steps = 0.25)
+    assert seen["eval_split"] == "validation"
 
 
 def test_whisper_eval_split_whose_rows_are_all_skipped_warns(audio_trainer):

--- a/studio/backend/tests/test_whisper_audio_vlm_eval_dataset.py
+++ b/studio/backend/tests/test_whisper_audio_vlm_eval_dataset.py
@@ -518,8 +518,7 @@ def test_whisper_trainer_branch_omits_eval_for_an_empty_split(audio_trainer, tmp
 def test_whisper_trainer_branch_refuses_an_unusable_cadence(
     audio_trainer, tmp_path, monkeypatch, bad
 ):
-    """inf raised an OverflowError inside Seq2SeqTrainingArguments, NaN and 0 configured an
-    evaluation that never ran, and True evaluated every step."""
+    """inf raised inside Seq2SeqTrainingArguments, NaN and 0 never ran, True ran every step."""
     trainer = _drive_whisper_branch(
         audio_trainer,
         tmp_path,
@@ -535,8 +534,7 @@ def test_whisper_trainer_branch_refuses_an_unusable_cadence(
 def test_whisper_trainer_branch_normalises_a_numeric_string_cadence(
     audio_trainer, tmp_path, monkeypatch
 ):
-    """A numeric string is a usable cadence, but TrainingArguments compares eval_steps against
-    an int and raises TypeError on a str."""
+    """A numeric string is usable, but TrainingArguments compares eval_steps against an int."""
     trainer = _drive_whisper_branch(
         audio_trainer,
         tmp_path,
@@ -551,8 +549,8 @@ def test_whisper_trainer_branch_normalises_a_numeric_string_cadence(
 
 
 def test_whisper_carve_out_is_skipped_when_the_cadence_is_unusable(audio_trainer, monkeypatch):
-    """The 6% carve-out runs off eval_split, not off the cadence, so it used to feature-extract
-    rows for an evaluation the trainer branch then refuses."""
+    """The 6% carve-out keys off eval_split, not the cadence, so it used to feature-extract rows
+    for an evaluation the trainer branch then refuses."""
     seen = {}
 
     def fake(

--- a/studio/backend/utils/training_runs.py
+++ b/studio/backend/utils/training_runs.py
@@ -157,9 +157,8 @@ def extract_project_name(config: Any) -> Optional[str]:
 def drop_non_finite(value: Any) -> Any:
     """Replace inf and NaN with None, recursively.
 
-    ``json.dumps`` writes them as the non-standard ``Infinity`` / ``NaN`` literals and reads them
-    back happily, but Starlette renders responses with ``allow_nan = False``, so anything that
-    reaches a stored config this way makes the view that returns it 500.
+    json writes them as the non-standard ``Infinity`` / ``NaN`` literals, but Starlette renders
+    with ``allow_nan = False``, so a stored config carrying one 500s the view that returns it.
     """
     if isinstance(value, bool):
         return value

--- a/studio/backend/utils/training_runs.py
+++ b/studio/backend/utils/training_runs.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 import time
 from typing import Any, Optional
@@ -151,3 +152,21 @@ def extract_project_name(config: Any) -> Optional[str]:
     if not isinstance(config, dict):
         return None
     return normalize_project_name(config.get("project_name"))
+
+
+def drop_non_finite(value: Any) -> Any:
+    """Replace inf and NaN with None, recursively.
+
+    ``json.dumps`` writes them as the non-standard ``Infinity`` / ``NaN`` literals and reads them
+    back happily, but Starlette renders responses with ``allow_nan = False``, so anything that
+    reaches a stored config this way makes the view that returns it 500.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {k: drop_non_finite(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [drop_non_finite(v) for v in value]
+    return value


### PR DESCRIPTION
Follow-up to #10259, which is already merged (41d2ff40a6). That PR is correct and I confirmed it end to end on a B200: a CSM LoRA run over a 12 train / 4 eval local upload goes from zero eval loss on the merge base to four eval losses at steps 2/4/6/8, with train losses, grad norms and peak memory unchanged.

While testing it I found four edge cases in the two new helpers.

### Cancelling a run was reported as a bad eval file

The codec preprocessors break out of their loop on `should_stop` and then raise `No valid examples after preprocessing`, and `_preprocess_audio_eval_split` turned that into `The eval dataset could not be prepared for this audio model, so this run has no evaluation`. So every cancelled CSM / SNAC / BiCodec / DAC run with an eval upload finished with a warning blaming the user's file. Check `should_stop` before recording the warning.

### eval_steps accepted three values it should not

`not eval_steps or eval_steps <= 0` lets through:

| value | what transformers does |
|---|---|
| `True` | a bool is an int, `global_step % True == 0` always, so it evaluates on **every step** |
| `inf` | `OverflowError: cannot convert float infinity to integer` inside `TrainingArguments` |
| `nan` | `x % nan` is never 0, so evaluation is enabled and **silently never runs** |

`core/training/eval_dataset.py` already has `evaluation_enabled()` for exactly this, and the MLX worker at `core/training/worker.py:3073` already uses it, so the CUDA path now uses it too. `eval_steps` is also normalised to `float`, since a numeric string passes that check but `TrainingArguments` compares `eval_steps` against an int.

### A zero-row eval split claimed evaluation and produced none

`_audio_eval_config` checked `is None`, not row count. Transformers' eval loop over an empty dataloader does not raise and does not emit NaN, it just omits the `eval_loss` key entirely, so the run reports `eval_strategy="steps"` and no eval loss ever appears. Warn and disable instead.

### per_device_eval_batch_size could be None

`.get("batch_size", 2)` only defaults on a missing key, so a present-but-`None` batch size reached `TrainingArguments` as `None`.

### Tests

Six new cases in `studio/backend/tests/test_audio_eval_dataset.py`, covering the hostile `eval_steps` domain, agreement with `evaluation_enabled()`, the empty split, the batch-size fallback, the numeric-string normalisation, and the cancel-versus-real-failure split. `studio/backend/tests` is 197 passed on Linux, and the same suite is green on `windows-latest` and `macos-15`.

No behaviour change on the normal path: the same CSM run before and after this branch produces byte-identical train losses, grad norms, eval losses (5.2901, 5.1648, 5.0371, 4.9410) and peak memory (4.324 GB).

### The Whisper branch needed the same gate

Rebased on main now that #10482 has landed. The Whisper branch turned out to need the gate too, and it is the one place the gate in `load_and_format_dataset` does not already cover: the 6% carve-out inside `_preprocess_whisper_dataset` runs off `eval_split`, not off `eval_steps`, so a named validation split still produced eval rows when evaluation was meant to be off. Those rows then reached `Seq2SeqTrainingArguments` with the raw cadence.

Confirmed by driving the real branch against a real `Seq2SeqTrainer`, on main before this commit:

| eval_steps | before |
|---|---|
| `inf` | `OverflowError: cannot convert float infinity to integer`, the run dies |
| `nan` | `eval_strategy="steps"`, evaluation never fires |
| `True` | evaluates every step |
| `0` | evaluation configured even though the user turned it off |
| `-1` | `eval_strategy="steps"` with a negative cadence |
| `"0.1"` | `TypeError: '>' not supported between instances of 'str' and 'int'` |

After: the first five disable evaluation with a log line, and `"0.1"` is normalised to `0.1`. The carve-out is also skipped when the cadence is unusable, so no rows are feature-extracted for an evaluation the branch then refuses.

Seven new cases in `studio/backend/tests/test_whisper_audio_vlm_eval_dataset.py`. All seven fail on current main and pass here.
