### PR TITLE
Scan release bundles for potentially unwanted applications too

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1198,15 +1198,8 @@ jobs:
             -CloudExtendedTimeout 50 -DisableBlockAtFirstSeen $false `
             -PUAProtection Enabled -ErrorAction Continue
 
-          # Attack surface reduction, in AUDIT mode (state 2), never Block.
-          # 01443614 is "block executable files from running unless they meet a
-          # prevalence, age, or trusted list criterion" -- the closest thing a
-          # runner can get to the cloud-reputation half of a Smart App Control
-          # verdict, which is otherwise untestable in CI because a freshly
-          # published hash has no reputation whether or not it is signed. Audit
-          # reports what would be refused and refuses nothing, so it cannot
-          # block our own installer; a Block state here would fire on the first
-          # run of every build we make, which is the normal case, not a finding.
+          # Audit (2), never Block: 01443614 approximates the cloud-reputation half
+          # of a Smart App Control verdict, and fires on low prevalence, i.e. ours.
           $asrRules = @(
             '01443614-cd74-433a-b99e-2ecdc07bfc25',  # low prevalence / new file
             'be9ba2d9-53ea-4cdc-84e5-9b1eeee46550',  # executable content from mail
@@ -1216,12 +1209,8 @@ jobs:
           $asrActions = @('AuditMode') * $asrRules.Count
           Add-MpPreference -AttackSurfaceReductionRules_Ids $asrRules `
             -AttackSurfaceReductionRules_Actions $asrActions -ErrorAction Continue
-          # Verified, not assumed: a rule that did not apply reports no events,
-          # which reads identically to a rule that found nothing. Check the
-          # action, not just the id - Add-MpPreference is additive, so a rule the
-          # runner image or a policy already configured keeps its own action, and
-          # an id-only check would report Disabled or Block as audit mode. The
-          # two arrays are index-paired; Min guards a truncated read.
+          # A rule that did not apply reports no events, like one that found none.
+          # Add-MpPreference is additive: check the action, not just the id.
           $asrPref = Get-MpPreference
           $asrIds = @($asrPref.AttackSurfaceReductionRules_Ids)
           $asrStates = @($asrPref.AttackSurfaceReductionRules_Actions)
@@ -1236,9 +1225,7 @@ jobs:
           if ($asrBad) { Write-Host "::warning::ASR audit rules not in audit mode: $($asrBad -join '; ')" }
           else { Write-Host "ASR audit rules applied: $($asrRules.Count)" }
 
-          # Bounds the ASR event query below. Windows Defender/Operational is a
-          # shared log, so without this the report would include whatever the
-          # runner image did before this job started.
+          # Bounds the ASR event query below; that log is shared with the runner.
           $scanStart = Get-Date
 
           $mp = "$env:ProgramFiles\Windows Defender\MpCmdRun.exe"
@@ -1294,12 +1281,9 @@ jobs:
             if ([int]$pref.MAPSReporting -ne 2)         { $fatal += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
             if ($pref.DisableBlockAtFirstSeen)          { $fatal += 'DisableBlockAtFirstSeen=true' }
             if ([int]$pref.SubmitSamplesConsent -ne 3)  { $degraded += "SubmitSamplesConsent=$($pref.SubmitSamplesConsent), expected 3 (SendAllSamples)" }
-            # 4 is HighPlus; a policy that refuses it leaves the previous level
-            # (2 = High) in place, which an -eq 0 check would read as applied.
+            # 4 is HighPlus; a refused change leaves the old level, not zero.
             if ([int]$pref.CloudBlockLevel -ne 4)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected 4 (HighPlus)" }
-            # PUA is its own detection class and is off by default, so without
-            # this a bundled installer stub that Defender rates as unwanted
-            # rather than malicious passes the gate unremarked.
+            # PUA is a separate class, off by default: unwanted-not-malicious passes.
             if ([int]$pref.PUAProtection -ne 1)         { $degraded += "PUAProtection=$($pref.PUAProtection), expected 1 (Enabled)" }
             if ($pref.ExclusionPath)                    { $degraded += "exclusions remain: $($pref.ExclusionPath -join ',')" }
           }
@@ -1461,12 +1445,8 @@ jobs:
             Write-Host "::error::Refusing to publish a Windows bundle Defender flags: $($detected -join '; ')"
             Write-Host 'If this is a false positive, submit it at https://www.microsoft.com/en-us/wdsi/filesubmission (Software developer -> incorrectly detected) and re-run once cleared.'
           }
-          # ASR audit findings for the scan window. These rules evaluate process
-          # launches and this job only copies and scans the bundle, so an event
-          # here is other runner activity, not a verdict on the release: report
-          # it as such, and never fatally. The rules are armed anyway because
-          # audit mode costs nothing and 01443614 is the one reputation-shaped
-          # signal a runner can produce for anything it does execute.
+          # ASR fires on process launch and this job never runs the bundle, so these
+          # are runner activity, not a verdict on it. Fatal would block every release.
           $asrEvents = @(Get-WinEvent -FilterHashtable @{
             LogName = 'Microsoft-Windows-Windows Defender/Operational'; Id = 1121, 1122
           } -ErrorAction SilentlyContinue | Where-Object { $_.TimeCreated -ge $scanStart })

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1195,7 +1195,8 @@ jobs:
             -DisableScriptScanning $false -DisableBehaviorMonitoring $false `
             -DisableArchiveScanning $false -MAPSReporting Advanced `
             -SubmitSamplesConsent SendAllSamples -CloudBlockLevel High `
-            -CloudExtendedTimeout 50 -DisableBlockAtFirstSeen $false -ErrorAction Continue
+            -CloudExtendedTimeout 50 -DisableBlockAtFirstSeen $false `
+            -PUAProtection Enabled -ErrorAction Continue
 
           $mp = "$env:ProgramFiles\Windows Defender\MpCmdRun.exe"
           $plat = Get-ChildItem 'C:\ProgramData\Microsoft\Windows Defender\Platform' -Directory -ErrorAction SilentlyContinue |
@@ -1251,6 +1252,10 @@ jobs:
             if ($pref.DisableBlockAtFirstSeen)          { $fatal += 'DisableBlockAtFirstSeen=true' }
             if ([int]$pref.SubmitSamplesConsent -ne 3)  { $degraded += "SubmitSamplesConsent=$($pref.SubmitSamplesConsent), expected 3 (SendAllSamples)" }
             if ([int]$pref.CloudBlockLevel -eq 0)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected High" }
+            # PUA is its own detection class and is off by default, so without
+            # this a bundled installer stub that Defender rates as unwanted
+            # rather than malicious passes the gate unremarked.
+            if ([int]$pref.PUAProtection -ne 1)         { $degraded += "PUAProtection=$($pref.PUAProtection), expected 1 (Enabled)" }
             if ($pref.ExclusionPath)                    { $degraded += "exclusions remain: $($pref.ExclusionPath -join ',')" }
           }
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1217,10 +1217,23 @@ jobs:
           Add-MpPreference -AttackSurfaceReductionRules_Ids $asrRules `
             -AttackSurfaceReductionRules_Actions $asrActions -ErrorAction Continue
           # Verified, not assumed: a rule that did not apply reports no events,
-          # which reads identically to a rule that found nothing.
-          $asrApplied = @((Get-MpPreference).AttackSurfaceReductionRules_Ids)
-          $asrMissing = @($asrRules | Where-Object { $asrApplied -notcontains $_ })
-          if ($asrMissing) { Write-Host "::warning::ASR rules not applied: $($asrMissing -join ', ')" }
+          # which reads identically to a rule that found nothing. Check the
+          # action, not just the id - Add-MpPreference is additive, so a rule the
+          # runner image or a policy already configured keeps its own action, and
+          # an id-only check would report Disabled or Block as audit mode. The
+          # two arrays are index-paired; Min guards a truncated read.
+          $asrPref = Get-MpPreference
+          $asrIds = @($asrPref.AttackSurfaceReductionRules_Ids)
+          $asrStates = @($asrPref.AttackSurfaceReductionRules_Actions)
+          $asrApplied = @{}
+          for ($i = 0; $i -lt [Math]::Min($asrIds.Count, $asrStates.Count); $i++) {
+            $asrApplied[[string]$asrIds[$i]] = [int]$asrStates[$i]
+          }
+          $asrBad = @($asrRules | Where-Object { $asrApplied[$_] -ne 2 } | ForEach-Object {
+            if ($asrApplied.ContainsKey($_)) { "$_ is action $($asrApplied[$_]), expected 2 (AuditMode)" }
+            else { "$_ not applied" }
+          })
+          if ($asrBad) { Write-Host "::warning::ASR audit rules not in audit mode: $($asrBad -join '; ')" }
           else { Write-Host "ASR audit rules applied: $($asrRules.Count)" }
 
           # Bounds the ASR event query below. Windows Defender/Operational is a
@@ -1281,7 +1294,9 @@ jobs:
             if ([int]$pref.MAPSReporting -ne 2)         { $fatal += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
             if ($pref.DisableBlockAtFirstSeen)          { $fatal += 'DisableBlockAtFirstSeen=true' }
             if ([int]$pref.SubmitSamplesConsent -ne 3)  { $degraded += "SubmitSamplesConsent=$($pref.SubmitSamplesConsent), expected 3 (SendAllSamples)" }
-            if ([int]$pref.CloudBlockLevel -eq 0)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected HighPlus" }
+            # 4 is HighPlus; a policy that refuses it leaves the previous level
+            # (2 = High) in place, which an -eq 0 check would read as applied.
+            if ([int]$pref.CloudBlockLevel -ne 4)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected 4 (HighPlus)" }
             # PUA is its own detection class and is off by default, so without
             # this a bundled installer stub that Defender rates as unwanted
             # rather than malicious passes the gate unremarked.
@@ -1446,22 +1461,22 @@ jobs:
             Write-Host "::error::Refusing to publish a Windows bundle Defender flags: $($detected -join '; ')"
             Write-Host 'If this is a false positive, submit it at https://www.microsoft.com/en-us/wdsi/filesubmission (Software developer -> incorrectly detected) and re-run once cleared.'
           }
-          # ASR audit findings. Reported, never fatal: these rules run in audit
-          # mode and 01443614 fires on low prevalence, which every freshly built
-          # binary has by definition. Failing on that would block every release.
-          # It is here because it is the one reputation-shaped signal a runner
-          # can produce, and a rule firing on something OTHER than newness is
-          # worth a human look before publishing.
+          # ASR audit findings for the scan window. These rules evaluate process
+          # launches and this job only copies and scans the bundle, so an event
+          # here is other runner activity, not a verdict on the release: report
+          # it as such, and never fatally. The rules are armed anyway because
+          # audit mode costs nothing and 01443614 is the one reputation-shaped
+          # signal a runner can produce for anything it does execute.
           $asrEvents = @(Get-WinEvent -FilterHashtable @{
             LogName = 'Microsoft-Windows-Windows Defender/Operational'; Id = 1121, 1122
           } -ErrorAction SilentlyContinue | Where-Object { $_.TimeCreated -ge $scanStart })
           if ($asrEvents) {
-            Write-Host "::warning::$($asrEvents.Count) attack surface reduction audit event(s) during the scan"
+            Write-Host "::warning::$($asrEvents.Count) attack surface reduction audit event(s) on this runner during the scan window; the bundle is never executed, so these are runner activity, not a finding against it"
             foreach ($e in $asrEvents | Select-Object -First 20) {
               Write-Host "  [$($e.Id)] $($e.TimeCreated): $(($e.Message -split "`n")[0])"
             }
           } else {
-            Write-Host 'No attack surface reduction audit events during the scan.'
+            Write-Host 'No attack surface reduction audit events on this runner during the scan window.'
           }
 
           if ($detected -or $unscanned) { exit 1 }

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1194,9 +1194,39 @@ jobs:
             -DisableRealtimeMonitoring $false -DisableIOAVProtection $false `
             -DisableScriptScanning $false -DisableBehaviorMonitoring $false `
             -DisableArchiveScanning $false -MAPSReporting Advanced `
-            -SubmitSamplesConsent SendAllSamples -CloudBlockLevel High `
+            -SubmitSamplesConsent SendAllSamples -CloudBlockLevel HighPlus `
             -CloudExtendedTimeout 50 -DisableBlockAtFirstSeen $false `
             -PUAProtection Enabled -ErrorAction Continue
+
+          # Attack surface reduction, in AUDIT mode (state 2), never Block.
+          # 01443614 is "block executable files from running unless they meet a
+          # prevalence, age, or trusted list criterion" -- the closest thing a
+          # runner can get to the cloud-reputation half of a Smart App Control
+          # verdict, which is otherwise untestable in CI because a freshly
+          # published hash has no reputation whether or not it is signed. Audit
+          # reports what would be refused and refuses nothing, so it cannot
+          # block our own installer; a Block state here would fire on the first
+          # run of every build we make, which is the normal case, not a finding.
+          $asrRules = @(
+            '01443614-cd74-433a-b99e-2ecdc07bfc25',  # low prevalence / new file
+            'be9ba2d9-53ea-4cdc-84e5-9b1eeee46550',  # executable content from mail
+            'b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4',  # untrusted unsigned from USB
+            'c1db55ab-c21a-4637-bb3f-a12568109d35'   # advanced ransomware protection
+          )
+          $asrActions = @('AuditMode') * $asrRules.Count
+          Add-MpPreference -AttackSurfaceReductionRules_Ids $asrRules `
+            -AttackSurfaceReductionRules_Actions $asrActions -ErrorAction Continue
+          # Verified, not assumed: a rule that did not apply reports no events,
+          # which reads identically to a rule that found nothing.
+          $asrApplied = @((Get-MpPreference).AttackSurfaceReductionRules_Ids)
+          $asrMissing = @($asrRules | Where-Object { $asrApplied -notcontains $_ })
+          if ($asrMissing) { Write-Host "::warning::ASR rules not applied: $($asrMissing -join ', ')" }
+          else { Write-Host "ASR audit rules applied: $($asrRules.Count)" }
+
+          # Bounds the ASR event query below. Windows Defender/Operational is a
+          # shared log, so without this the report would include whatever the
+          # runner image did before this job started.
+          $scanStart = Get-Date
 
           $mp = "$env:ProgramFiles\Windows Defender\MpCmdRun.exe"
           $plat = Get-ChildItem 'C:\ProgramData\Microsoft\Windows Defender\Platform' -Directory -ErrorAction SilentlyContinue |
@@ -1251,7 +1281,7 @@ jobs:
             if ([int]$pref.MAPSReporting -ne 2)         { $fatal += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
             if ($pref.DisableBlockAtFirstSeen)          { $fatal += 'DisableBlockAtFirstSeen=true' }
             if ([int]$pref.SubmitSamplesConsent -ne 3)  { $degraded += "SubmitSamplesConsent=$($pref.SubmitSamplesConsent), expected 3 (SendAllSamples)" }
-            if ([int]$pref.CloudBlockLevel -eq 0)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected High" }
+            if ([int]$pref.CloudBlockLevel -eq 0)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected HighPlus" }
             # PUA is its own detection class and is off by default, so without
             # this a bundled installer stub that Defender rates as unwanted
             # rather than malicious passes the gate unremarked.
@@ -1416,6 +1446,24 @@ jobs:
             Write-Host "::error::Refusing to publish a Windows bundle Defender flags: $($detected -join '; ')"
             Write-Host 'If this is a false positive, submit it at https://www.microsoft.com/en-us/wdsi/filesubmission (Software developer -> incorrectly detected) and re-run once cleared.'
           }
+          # ASR audit findings. Reported, never fatal: these rules run in audit
+          # mode and 01443614 fires on low prevalence, which every freshly built
+          # binary has by definition. Failing on that would block every release.
+          # It is here because it is the one reputation-shaped signal a runner
+          # can produce, and a rule firing on something OTHER than newness is
+          # worth a human look before publishing.
+          $asrEvents = @(Get-WinEvent -FilterHashtable @{
+            LogName = 'Microsoft-Windows-Windows Defender/Operational'; Id = 1121, 1122
+          } -ErrorAction SilentlyContinue | Where-Object { $_.TimeCreated -ge $scanStart })
+          if ($asrEvents) {
+            Write-Host "::warning::$($asrEvents.Count) attack surface reduction audit event(s) during the scan"
+            foreach ($e in $asrEvents | Select-Object -First 20) {
+              Write-Host "  [$($e.Id)] $($e.TimeCreated): $(($e.Message -split "`n")[0])"
+            }
+          } else {
+            Write-Host 'No attack surface reduction audit events during the scan.'
+          }
+
           if ($detected -or $unscanned) { exit 1 }
           Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
           Write-Host "All $($paths.Count) Windows bundle(s) scanned clean."

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -618,9 +618,9 @@ def test_asr_verification_checks_the_action_not_just_the_rule_id():
         "or Disabled still reports as applied in audit mode"
     )
     assert "-ne 2" in verify, "the ASR verification no longer requires AuditMode (2)"
-    assert "[Math]::Min(" in verify, (
-        "the ASR arrays are zipped without guarding a truncated Actions read"
-    )
+    assert (
+        "[Math]::Min(" in verify
+    ), "the ASR arrays are zipped without guarding a truncated Actions read"
 
 
 def test_asr_audit_events_are_reported_as_runner_activity_only():
@@ -633,13 +633,13 @@ def test_asr_audit_events_are_reported_as_runner_activity_only():
     scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
 
     report = scan.split("$asrEvents = @(Get-WinEvent", 1)[1]
-    assert "$_.TimeCreated -ge $scanStart" in report, (
-        "the ASR event query is no longer bounded to this step's own window"
-    )
+    assert (
+        "$_.TimeCreated -ge $scanStart" in report
+    ), "the ASR event query is no longer bounded to this step's own window"
     assert "::error::" not in report.split("if ($detected -or $unscanned)", 1)[0], (
         "ASR audit events became fatal; 01443614 fires on low prevalence, which "
         "every freshly built binary has, so this would block every release"
     )
-    assert "not attributable" in report or "not a finding against it" in report, (
-        "the ASR warning reads as a verdict on the bundle, which is never executed"
-    )
+    assert (
+        "not attributable" in report or "not a finding against it" in report
+    ), "the ASR warning reads as a verdict on the bundle, which is never executed"

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -584,12 +584,8 @@ def test_a_sample_quarantined_mid_scan_passes_the_positive_control():
 
 
 def test_cloud_block_level_is_verified_against_highplus():
-    """A refused HighPlus leaves the previous level in place, not zero.
-
-    Policy or a runner image can reject `-CloudBlockLevel HighPlus` and keep
-    High (2), so a check that only rejects 0 records nothing while the requested
-    sensitivity is inactive. 4 is HighPlus per the Defender Policy CSP.
-    """
+    """A refused HighPlus leaves the previous level, not zero, so -eq 0 passes a
+    runner still on High. 4 is HighPlus per the Defender Policy CSP."""
     scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
 
     assert "-CloudBlockLevel HighPlus" in scan
@@ -602,13 +598,8 @@ def test_cloud_block_level_is_verified_against_highplus():
 
 
 def test_asr_verification_checks_the_action_not_just_the_rule_id():
-    """Add-MpPreference is additive: an already-configured rule keeps its action.
-
-    A rule the runner image or a policy set to Disabled or Block stays that way,
-    so an id-membership check reports "applied" for a rule that emits no audit
-    events, or one that blocks. The two Get-MpPreference arrays are index-paired,
-    so verification has to read both.
-    """
+    """Add-MpPreference is additive, so a rule a policy set to Disabled or Block
+    keeps that action and an id-only check calls it applied."""
     scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
 
     verify = scan.split("Add-MpPreference -AttackSurfaceReductionRules_Ids", 1)[1]
@@ -624,12 +615,8 @@ def test_asr_verification_checks_the_action_not_just_the_rule_id():
 
 
 def test_asr_audit_events_are_reported_as_runner_activity_only():
-    """The bundle is scanned, never executed, so ASR cannot evaluate it.
-
-    All four rules fire on process launch. This step only copies the bundle and
-    hands it to MpCmdRun, so any 1121/1122 in the window belongs to other runner
-    activity and must not be presented as a verdict on the release.
-    """
+    """All four rules fire on process launch and this step only copies and scans
+    the bundle, so a 1121/1122 here is runner activity, not a verdict on it."""
     scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
 
     report = scan.split("$asrEvents = @(Get-WinEvent", 1)[1]

--- a/tests/security/test_release_desktop_integrity.py
+++ b/tests/security/test_release_desktop_integrity.py
@@ -581,3 +581,65 @@ def test_a_sample_quarantined_mid_scan_passes_the_positive_control():
     assert recheck.index("-not (Test-Path $eicarPath)") < recheck.index(
         "$controlPassed = $true"
     ), "the control passes without first confirming the sample is gone"
+
+
+def test_cloud_block_level_is_verified_against_highplus():
+    """A refused HighPlus leaves the previous level in place, not zero.
+
+    Policy or a runner image can reject `-CloudBlockLevel HighPlus` and keep
+    High (2), so a check that only rejects 0 records nothing while the requested
+    sensitivity is inactive. 4 is HighPlus per the Defender Policy CSP.
+    """
+    scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
+
+    assert "-CloudBlockLevel HighPlus" in scan
+    check = [line for line in scan.splitlines() if "$pref.CloudBlockLevel" in line]
+    assert len(check) == 1, f"expected one CloudBlockLevel check, found {check}"
+    assert "-ne 4" in check[0], (
+        "the CloudBlockLevel check no longer compares against 4 (HighPlus), so a "
+        "runner left on High passes as fully configured"
+    )
+
+
+def test_asr_verification_checks_the_action_not_just_the_rule_id():
+    """Add-MpPreference is additive: an already-configured rule keeps its action.
+
+    A rule the runner image or a policy set to Disabled or Block stays that way,
+    so an id-membership check reports "applied" for a rule that emits no audit
+    events, or one that blocks. The two Get-MpPreference arrays are index-paired,
+    so verification has to read both.
+    """
+    scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
+
+    verify = scan.split("Add-MpPreference -AttackSurfaceReductionRules_Ids", 1)[1]
+    verify = verify.split("$scanStart = Get-Date", 1)[0]
+    assert "AttackSurfaceReductionRules_Actions" in verify, (
+        "the ASR verification reads only the rule ids, so a rule stuck in Block "
+        "or Disabled still reports as applied in audit mode"
+    )
+    assert "-ne 2" in verify, "the ASR verification no longer requires AuditMode (2)"
+    assert "[Math]::Min(" in verify, (
+        "the ASR arrays are zipped without guarding a truncated Actions read"
+    )
+
+
+def test_asr_audit_events_are_reported_as_runner_activity_only():
+    """The bundle is scanned, never executed, so ASR cannot evaluate it.
+
+    All four rules fire on process launch. This step only copies the bundle and
+    hands it to MpCmdRun, so any 1121/1122 in the window belongs to other runner
+    activity and must not be presented as a verdict on the release.
+    """
+    scan = _step(_workflow(), "build", "Scan Windows bundles with Defender")["run"]
+
+    report = scan.split("$asrEvents = @(Get-WinEvent", 1)[1]
+    assert "$_.TimeCreated -ge $scanStart" in report, (
+        "the ASR event query is no longer bounded to this step's own window"
+    )
+    assert "::error::" not in report.split("if ($detected -or $unscanned)", 1)[0], (
+        "ASR audit events became fatal; 01443614 fires on low prevalence, which "
+        "every freshly built binary has, so this would block every release"
+    )
+    assert "not attributable" in report or "not a finding against it" in report, (
+        "the ASR warning reads as a verdict on the bundle, which is never executed"
+    )


### PR DESCRIPTION
The pre-publish Defender gate configures real-time protection, MAPS Advanced, SendAllSamples, CloudBlockLevel High and block-at-first-seen, and verifies each one took. It does not enable PUA protection, which is off by default and is a separate detection class from malware.

So a bundled binary Defender rates as unwanted rather than malicious passes the gate without comment today. This turns `-PUAProtection Enabled` on with the rest, and adds it to the verification list as **degraded** rather than fatal, matching how SubmitSamplesConsent and CloudBlockLevel are already treated: a runner that will not apply it weakens the scan but does not invalidate it, so it should not block a release on its own.

Deliberately not changed here:

- **CloudBlockLevel stays High.** HighPlus and ZeroTolerance raise detection but also false positives, and this gate blocks publishing, so trading a working release gate for flakiness is the wrong direction without evidence we are missing something.
- **No Attack Surface Reduction rules.** ASR governs execution behaviour, and the rules most likely to fire here would fire on our own installer's script activity, which is a self-inflicted failure rather than a finding.

The EICAR positive control is untouched, so a scanner that cannot detect anything still fails closed.