### PR TITLE
Docker Studio: build the labextension with @jupyter/builder so it never reaches for GitHub

### DIFF
--- a/docker/jupyter/unsloth_labext/package.json
+++ b/docker/jupyter/unsloth_labext/package.json
@@ -24,8 +24,8 @@
     "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
     "build:lib": "tsc --sourceMap",
     "build:lib:prod": "tsc",
-    "build:labextension": "jupyter labextension build .",
-    "build:labextension:dev": "jupyter labextension build --development True .",
+    "build:labextension": "jupyter-builder build .",
+    "build:labextension:dev": "jupyter-builder build --development True .",
     "clean": "rimraf lib tsconfig.tsbuildinfo unsloth-jupyterlab/labextension"
   },
   "dependencies": {
@@ -42,7 +42,7 @@
     "@lumino/widgets": "^2.0.0"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^4.5.0",
+    "@jupyter/builder": "^1.2.3",
     "rimraf": "^5.0.0",
     "typescript": "~5.5.0"
   },


### PR DESCRIPTION
## Summary

The first scheduled Docker publish (run 34151954060, 2026-09-07) lost its arm64 Studio build in the labextension step:

```
RuntimeError: Could not resolve @jupyterlab/core-meta for requested version '4.5.x':
not found on the npm registry (No published @jupyterlab/core-meta versions match range '4.5.x')
or in the jupyterlab/jupyterlab GitHub repository (HTTP Error 403: rate limit exceeded).
```

`docker/jupyter/unsloth_labext/package.json` declared `@jupyterlab/builder ^4.5.0` while the image ships JupyterLab 4.6. The 4.6 builder treats a 4.5.x builder as legacy and needs `@jupyterlab/core-meta 4.5.x`, which was never published to npm, so every fresh build fetched it from the jupyterlab GitHub repository unauthenticated. The amd64 leg of the same run and every earlier arm64 build passed only because that fallback happened not to be rate limited. Now that publishing is once a day, one flake costs the day's `latest`, `studio` and `nightly-<date>` tags (the 2026-09-07 core pins exist, the Studio pins do not).

## Change

- devDependency `@jupyterlab/builder ^4.5.0` -> `@jupyter/builder ^1.2.3`, which depends on `@jupyterlab/core-meta ^4.6.1` from npm. This is the replacement the builder's own warning names.
- `build:labextension` scripts call `jupyter-builder build` directly; `jupyter labextension build` is deprecated and delegates to it.

## Verification

No-cache build of the `labext-builder` stage against `unsloth/unsloth:latest` (JupyterLab 4.6.0, jupyter_builder 1.2.3): no core-meta fallback, no GitHub request, bundle produced. Copied into the image, `jupyter labextension list` reports `unsloth-jupyterlab v0.1.0 enabled OK`.
