### PR TITLE
Studio: ask for a password on a raw `-H 0.0.0.0` bind too

### DIFF
--- a/studio/backend/auth/terminal_prompt.py
+++ b/studio/backend/auth/terminal_prompt.py
@@ -145,11 +145,55 @@ def _getch_posix() -> str:  # pragma: no cover - needs a real tty
 _getch: Callable[[], str] = _getch_windows if os.name == "nt" else _getch_posix
 
 
-def _read_password(prompt: str, *, out: "TextIO | None" = None) -> str:
+class PromptUnattended(Exception):
+    """A terminal is attached but nobody answered the prompt before the deadline.
+
+    A pty is not a person. ``tmux new -d``, ``screen -dmS`` and ``docker run -dt``
+    all allocate a real, foreground pty that no one is reading, so isatty() is
+    True on both streams and the read simply never returns. Callers that must
+    never block a launch pass a deadline and treat this as a refusal.
+    """
+
+
+def _wait_for_first_key(timeout: float) -> bool:
+    """Whether a keystroke arrived within ``timeout`` seconds.
+
+    Must be called with the terminal already in cbreak mode: in canonical mode
+    the driver holds input until a newline, so the fd would not become readable
+    on the first character. True on any doubt, which is the blocking behaviour.
+    """
+    if os.name == "nt":
+        import time
+
+        try:
+            import msvcrt
+        except ImportError:
+            return True
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if msvcrt.kbhit():
+                return True
+            time.sleep(0.05)
+        return False
+    import select
+
+    try:
+        fd = sys.stdin.fileno()
+        ready, _, _ = select.select([fd], [], [], timeout)
+    except (AttributeError, OSError, ValueError):
+        return True
+    return bool(ready)
+
+
+def _read_password(
+    prompt: str, *, out: "TextIO | None" = None, first_key_timeout: "float | None" = None
+) -> str:
     """Read one masked line: echo ``*`` per char, support backspace editing.
 
     Raises KeyboardInterrupt on Ctrl-C and EOFError on Ctrl-D/Ctrl-Z with an
-    empty buffer; the terminal is restored on every exit path.
+    empty buffer; the terminal is restored on every exit path. With
+    ``first_key_timeout`` set, raises PromptUnattended when the FIRST keystroke
+    never arrives; once someone starts typing there is no deadline.
     """
     if out is None:
         out = sys.stderr
@@ -157,6 +201,10 @@ def _read_password(prompt: str, *, out: "TextIO | None" = None) -> str:
     out.flush()
     chars: list[str] = []
     with _prompt_raw_mode():
+        if first_key_timeout is not None and not _wait_for_first_key(first_key_timeout):
+            out.write("\n")
+            out.flush()
+            raise PromptUnattended
         while True:
             key = _getch()
             if key == "":
@@ -225,6 +273,7 @@ def prompt_for_password_change(
     username: str = "unsloth",
     out: "TextIO | None" = None,
     exposure: str = "on the public internet",
+    first_key_timeout: "float | None" = None,
 ) -> bool:
     """Force a new admin password before exposure; True on success.
 
@@ -235,6 +284,12 @@ def prompt_for_password_change(
     the public internet; a raw ``-H 0.0.0.0`` bind is every network interface,
     which is the LAN behind a NAT router and the internet on a cloud box with a
     public address. Claiming the wrong one trains people to ignore the message.
+
+    ``first_key_timeout`` bounds the wait for the FIRST keystroke and returns
+    False if it never comes. Only a caller that must not block a launch passes
+    it: a detached pty (``tmux new -d``, ``docker run -dt``) looks exactly like
+    an attended terminal, so without a deadline such a launch waits forever and
+    never binds its socket. Unset (the tunnel) keeps blocking indefinitely.
     """
     if out is None:
         out = sys.stderr
@@ -244,9 +299,14 @@ def prompt_for_password_change(
         "password now. Ctrl+C to abort.\n\n"
     )
     out.flush()
+    # Only the first read is deadlined; once a key arrives someone is there.
+    pending_timeout = first_key_timeout
     try:
         while True:
-            new_password = _read_password("New password: ", out = out)
+            new_password = _read_password(
+                "New password: ", out = out, first_key_timeout = pending_timeout
+            )
+            pending_timeout = None
             if len(new_password) < min_length:
                 out.write(f"Password must be at least {min_length} characters; try again.\n")
                 out.flush()
@@ -270,6 +330,13 @@ def prompt_for_password_change(
             out.write(f"Password updated for '{username}'.\n")
             out.flush()
             return True
+    except PromptUnattended:
+        out.write(
+            "No response at the terminal; leaving the auto-generated admin "
+            "password in place.\n"
+        )
+        out.flush()
+        return False
     except (KeyboardInterrupt, EOFError):
         out.write("Password change aborted; not exposing Unsloth.\n")
         out.flush()

--- a/studio/backend/auth/terminal_prompt.py
+++ b/studio/backend/auth/terminal_prompt.py
@@ -2,8 +2,8 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 """Interactive terminal prompt that forces a bootstrap password change before
-Unsloth is put where others can reach it: a public Cloudflare URL (``--secure``
-/ ``--cloudflare``) or a raw non-loopback bind such as ``-H 0.0.0.0``.
+Unsloth becomes reachable: a public Cloudflare URL (``--secure`` / ``--cloudflare``)
+or a raw non-loopback bind such as ``-H 0.0.0.0``.
 
 Masked input echoes one ``*`` per keystroke (unlike ``getpass``). Works on
 Windows (``msvcrt``) and Linux/macOS (``termios``). All output goes to stderr so
@@ -146,21 +146,20 @@ _getch: Callable[[], str] = _getch_windows if os.name == "nt" else _getch_posix
 
 
 class PromptUnattended(Exception):
-    """A terminal is attached but nobody answered the prompt before the deadline.
+    """A terminal is attached but nobody answered before the deadline.
 
-    A pty is not a person. ``tmux new -d``, ``screen -dmS`` and ``docker run -dt``
-    all allocate a real, foreground pty that no one is reading, so isatty() is
-    True on both streams and the read simply never returns. Callers that must
-    never block a launch pass a deadline and treat this as a refusal.
+    A pty is not a person: ``tmux new -d`` / ``docker run -dt`` allocate a real
+    foreground pty nobody reads, so isatty() is True on both streams and the read
+    never returns. Callers that must not block a launch treat this as a refusal.
     """
 
 
 def _wait_for_first_key(timeout: float) -> bool:
     """Whether a keystroke arrived within ``timeout`` seconds.
 
-    Must be called with the terminal already in cbreak mode: in canonical mode
-    the driver holds input until a newline, so the fd would not become readable
-    on the first character. True on any doubt, which is the blocking behaviour.
+    Requires cbreak mode already set: canonical mode holds input until a newline,
+    so the fd would not become readable on the first character. True on any doubt
+    (the blocking behaviour).
     """
     if os.name == "nt":
         import time
@@ -195,8 +194,8 @@ def _read_password(
 
     Raises KeyboardInterrupt on Ctrl-C and EOFError on Ctrl-D/Ctrl-Z with an
     empty buffer; the terminal is restored on every exit path. With
-    ``first_key_timeout`` set, raises PromptUnattended when the FIRST keystroke
-    never arrives; once someone starts typing there is no deadline.
+    ``first_key_timeout``, raises PromptUnattended when the FIRST keystroke never
+    arrives; once someone starts typing there is no deadline.
     """
     if out is None:
         out = sys.stderr
@@ -256,12 +255,11 @@ def should_prompt_password_change(
     still has the seeded password, and both stdin and stderr are real terminals
     (headless launches keep the bootstrap-timeout protection instead of hanging).
 
-    Two ways to be reachable, not one. ``tunnel_will_start`` is the public
-    Cloudflare URL. ``bind_is_exposed`` is a raw non-loopback bind such as
-    ``-H 0.0.0.0``, which is reachable by every host on the network, and by the
-    internet when the machine has a public address, yet starts no tunnel. That
-    second case previously got no prompt at all, so the seeded password stayed
-    live and was served in the page to anyone who loaded it.
+    Two ways to be reachable: ``tunnel_will_start`` (public Cloudflare URL) and
+    ``bind_is_exposed`` (a raw non-loopback bind like ``-H 0.0.0.0``, reachable by
+    the whole network yet starting no tunnel). The second used to get no prompt at
+    all, so the seeded password stayed live and was served to anyone who loaded
+    the page.
     """
     if not (tunnel_will_start or bind_is_exposed):
         return False
@@ -282,22 +280,20 @@ def prompt_for_password_change(
     """Force a new admin password before exposure; True on success.
 
     Loops until a valid, confirmed password is committed via ``apply_change``.
-    Ctrl-C / EOF returns False. What that means is the caller's decision, and
-    ``refusal_aborts`` says which one it made so the banner can say the same
-    thing: True for a tunnel, where the caller aborts the launch, False for a raw
-    bind, where the launch proceeds because it worked before this prompt existed.
-    Promising an abort that will not happen is worse than not asking at all.
+    Ctrl-C / EOF returns False; ``refusal_aborts`` tells the banner what the
+    caller does with that, so it never promises an abort that will not happen:
+    True for a tunnel (caller aborts), False for a raw bind (launch proceeds,
+    because it worked before this prompt existed).
 
-    ``exposure`` names where this launch will be reachable. A tunnel really is
-    the public internet; a raw ``-H 0.0.0.0`` bind is every network interface,
-    which is the LAN behind a NAT router and the internet on a cloud box with a
-    public address. Claiming the wrong one trains people to ignore the message.
+    ``exposure`` names where this launch is reachable: a tunnel really is the
+    public internet, a raw bind is every interface (LAN behind NAT, or the
+    internet on a cloud box). Claiming the wrong one trains people to ignore it.
 
-    ``first_key_timeout`` bounds the wait for the FIRST keystroke and returns
+    ``first_key_timeout`` bounds the wait for the FIRST keystroke, returning
     False if it never comes. Only a caller that must not block a launch passes
     it: a detached pty (``tmux new -d``, ``docker run -dt``) looks exactly like
-    an attended terminal, so without a deadline such a launch waits forever and
-    never binds its socket. Unset (the tunnel) keeps blocking indefinitely.
+    an attended terminal, so undeadlined it waits forever and never binds its
+    socket. Unset (the tunnel) blocks indefinitely.
     """
     if out is None:
         out = sys.stderr
@@ -312,7 +308,7 @@ def prompt_for_password_change(
         f"password now. {refusal}\n\n"
     )
     out.flush()
-    # Only the first read is deadlined; once a key arrives someone is there.
+    # Only the first read is deadlined; a key arriving proves someone is there.
     pending_timeout = first_key_timeout
     try:
         while True:

--- a/studio/backend/auth/terminal_prompt.py
+++ b/studio/backend/auth/terminal_prompt.py
@@ -277,11 +277,16 @@ def prompt_for_password_change(
     out: "TextIO | None" = None,
     exposure: str = "on the public internet",
     first_key_timeout: "float | None" = None,
+    refusal_aborts: bool = True,
 ) -> bool:
     """Force a new admin password before exposure; True on success.
 
     Loops until a valid, confirmed password is committed via ``apply_change``.
-    Ctrl-C / EOF returns False; the caller must then abort the launch.
+    Ctrl-C / EOF returns False. What that means is the caller's decision, and
+    ``refusal_aborts`` says which one it made so the banner can say the same
+    thing: True for a tunnel, where the caller aborts the launch, False for a raw
+    bind, where the launch proceeds because it worked before this prompt existed.
+    Promising an abort that will not happen is worse than not asking at all.
 
     ``exposure`` names where this launch will be reachable. A tunnel really is
     the public internet; a raw ``-H 0.0.0.0`` bind is every network interface,
@@ -296,10 +301,15 @@ def prompt_for_password_change(
     """
     if out is None:
         out = sys.stderr
+    refusal = (
+        "Ctrl+C to abort."
+        if refusal_aborts
+        else "Ctrl+C to skip, and Unsloth starts with the auto-generated password."
+    )
     out.write(
         "\n"
         f"Unsloth Studio will be reachable {exposure}, so set a\n"
-        "password now. Ctrl+C to abort.\n\n"
+        f"password now. {refusal}\n\n"
     )
     out.flush()
     # Only the first read is deadlined; once a key arrives someone is there.
@@ -340,7 +350,11 @@ def prompt_for_password_change(
         out.flush()
         return False
     except (KeyboardInterrupt, EOFError):
-        out.write("Password change aborted; not exposing Unsloth.\n")
+        out.write(
+            "Password change aborted; not exposing Unsloth.\n"
+            if refusal_aborts
+            else "Password change skipped; leaving the auto-generated admin password in place.\n"
+        )
         out.flush()
         return False
 

--- a/studio/backend/auth/terminal_prompt.py
+++ b/studio/backend/auth/terminal_prompt.py
@@ -186,7 +186,10 @@ def _wait_for_first_key(timeout: float) -> bool:
 
 
 def _read_password(
-    prompt: str, *, out: "TextIO | None" = None, first_key_timeout: "float | None" = None
+    prompt: str,
+    *,
+    out: "TextIO | None" = None,
+    first_key_timeout: "float | None" = None,
 ) -> str:
     """Read one masked line: echo ``*`` per char, support backspace editing.
 
@@ -332,8 +335,7 @@ def prompt_for_password_change(
             return True
     except PromptUnattended:
         out.write(
-            "No response at the terminal; leaving the auto-generated admin "
-            "password in place.\n"
+            "No response at the terminal; leaving the auto-generated admin password in place.\n"
         )
         out.flush()
         return False

--- a/studio/backend/auth/terminal_prompt.py
+++ b/studio/backend/auth/terminal_prompt.py
@@ -191,8 +191,12 @@ def _read_password(prompt: str, *, out: "TextIO | None" = None) -> str:
 
 
 def should_prompt_password_change(
-    *, tunnel_will_start: bool, requires_change: bool, stdin_isatty: bool,
-    stderr_isatty: bool, bind_is_exposed: bool = False,
+    *,
+    tunnel_will_start: bool,
+    requires_change: bool,
+    stdin_isatty: bool,
+    stderr_isatty: bool,
+    bind_is_exposed: bool = False,
 ) -> bool:
     """Whether to block startup on an interactive terminal password change.
 

--- a/studio/backend/auth/terminal_prompt.py
+++ b/studio/backend/auth/terminal_prompt.py
@@ -191,15 +191,25 @@ def _read_password(prompt: str, *, out: "TextIO | None" = None) -> str:
 
 
 def should_prompt_password_change(
-    *, tunnel_will_start: bool, requires_change: bool, stdin_isatty: bool, stderr_isatty: bool
+    *, tunnel_will_start: bool, requires_change: bool, stdin_isatty: bool,
+    stderr_isatty: bool, bind_is_exposed: bool = False,
 ) -> bool:
     """Whether to block startup on an interactive terminal password change.
 
-    True only when the tunnel is actually about to start, the admin still has
-    the seeded password, and both stdin and stderr are real terminals (headless
-    launches keep the bootstrap-timeout protection instead of hanging).
+    True when the launch puts the web UI where others can reach it, the admin
+    still has the seeded password, and both stdin and stderr are real terminals
+    (headless launches keep the bootstrap-timeout protection instead of hanging).
+
+    Two ways to be reachable, not one. ``tunnel_will_start`` is the public
+    Cloudflare URL. ``bind_is_exposed`` is a raw non-loopback bind such as
+    ``-H 0.0.0.0``, which is reachable by every host on the network, and by the
+    internet when the machine has a public address, yet starts no tunnel. That
+    second case previously got no prompt at all, so the seeded password stayed
+    live and was served in the page to anyone who loaded it.
     """
-    return tunnel_will_start and requires_change and stdin_isatty and stderr_isatty
+    if not (tunnel_will_start or bind_is_exposed):
+        return False
+    return requires_change and stdin_isatty and stderr_isatty
 
 
 def prompt_for_password_change(
@@ -209,17 +219,23 @@ def prompt_for_password_change(
     apply_change: Callable[[str], None],
     username: str = "unsloth",
     out: "TextIO | None" = None,
+    exposure: str = "on the public internet",
 ) -> bool:
-    """Force a new admin password before public exposure; True on success.
+    """Force a new admin password before exposure; True on success.
 
     Loops until a valid, confirmed password is committed via ``apply_change``.
     Ctrl-C / EOF returns False; the caller must then abort the launch.
+
+    ``exposure`` names where this launch will be reachable. A tunnel really is
+    the public internet; a raw ``-H 0.0.0.0`` bind is every network interface,
+    which is the LAN behind a NAT router and the internet on a cloud box with a
+    public address. Claiming the wrong one trains people to ignore the message.
     """
     if out is None:
         out = sys.stderr
     out.write(
         "\n"
-        "Unsloth Studio will be exposed on the public internet, so set a\n"
+        f"Unsloth Studio will be reachable {exposure}, so set a\n"
         "password now. Ctrl+C to abort.\n\n"
     )
     out.flush()

--- a/studio/backend/auth/terminal_prompt.py
+++ b/studio/backend/auth/terminal_prompt.py
@@ -2,7 +2,8 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 """Interactive terminal prompt that forces a bootstrap password change before
-Unsloth is exposed on a public Cloudflare URL (``--secure`` / ``--cloudflare``).
+Unsloth is put where others can reach it: a public Cloudflare URL (``--secure``
+/ ``--cloudflare``) or a raw non-loopback bind such as ``-H 0.0.0.0``.
 
 Masked input echoes one ``*`` per keystroke (unlike ``getpass``). Works on
 Windows (``msvcrt``) and Linux/macOS (``termios``). All output goes to stderr so

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2351,13 +2351,40 @@ def _terminal_password_gate(
     # case (docker/studio_run.sh execs `unsloth studio -H 0.0.0.0` and only
     # supplies a password when the initial-password file is non-empty), so
     # aborting would stop a container that starts today. Warn and proceed at the
-    # protection level this launch already had: the bootstrap deadline.
+    # protection level this launch already had.
+    #
+    # Which is sometimes NO protection: with UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT=0
+    # the deadline never arms, so promising a shutdown would be false, and it is
+    # the one sentence an operator would act on. Say what will actually happen.
+    # Still proceed rather than fail closed: this launch worked before the prompt
+    # existed, the operator disabled the deadline deliberately and cancelled the
+    # prompt deliberately, and refusing to start would break the very case the
+    # paragraph above exists to protect.
+    deadline_arms = should_arm_bootstrap_timeout(
+        host = host,
+        secure = secure,
+        api_only = api_only,
+        frontend_served = frontend_served,
+        is_colab = is_colab,
+        requires_change = True,
+        timeout_seconds = bootstrap_timeout_seconds(),
+    )
+    if deadline_arms:
+        tail = (
+            "Unsloth shuts down after the bootstrap deadline "
+            "(UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT, default 1h) unless the password "
+            "is changed."
+        )
+    else:
+        tail = (
+            "The bootstrap shutdown deadline is DISABLED for this launch "
+            "(UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT=0), so nothing will stop it "
+            "serving that credential."
+        )
     print(
         "  WARNING: continuing with the auto-generated admin password on a bind "
-        "that is reachable from the network. Unsloth shuts down after the "
-        "bootstrap deadline (UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT, default 1h) "
-        "unless the password is changed. Change it by logging in, or with "
-        "`unsloth studio reset-password`.",
+        f"that is reachable from the network. {tail} Change it by logging in, or "
+        "with `unsloth studio reset-password`.",
         file = sys.stderr,
         flush = True,
     )

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2197,9 +2197,7 @@ def _terminal_password_gate(
     # now would move first seeding earlier, open the SQLite file sooner and give a
     # read-only or locked home a new place to fail, none of which a container
     # operator asked for. Tunnel launches are unaffected: they always came here.
-    if not tunnel_will_start and not (
-        _stream_isatty(sys.stdin) and _stream_isatty(sys.stderr)
-    ):
+    if not tunnel_will_start and not (_stream_isatty(sys.stdin) and _stream_isatty(sys.stderr)):
         return True, False
 
     from auth import hashing as _auth_hashing

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2141,18 +2141,13 @@ def _stream_isatty(stream) -> bool:
         return False
 
 
-# How long a raw-bind prompt waits for the FIRST keystroke before giving up and
-# launching anyway. Only the first: once someone is typing there is no deadline.
-#
-# 30s, not longer. The launches that reach this with nobody watching are the ones
-# that allocate a pty and then never read it -- `docker run -dt`, `tmux new -d`,
-# `screen -dmS`, some CI runners -- and they want to bind promptly. A container
-# that takes two minutes to answer a healthcheck can be killed and restarted by
-# the orchestrator, which would turn "delayed" into a restart loop; 30s stays
-# inside a default Docker HEALTHCHECK start period. Someone who is actually
-# looking at the prompt starts typing well inside that, and someone who is not
-# gets the refusal path, which warns and launches with the bootstrap deadline
-# armed. Mirrored in the CLI.
+# How long a raw-bind prompt waits for the FIRST keystroke before launching
+# anyway; once someone is typing there is no deadline. 30s because the launches
+# that reach here unwatched allocate a pty and never read it (`docker run -dt`,
+# `tmux new -d`, CI runners) and need to bind promptly: a longer stall can trip a
+# healthcheck into a restart loop, while 30s stays inside a default Docker
+# HEALTHCHECK start period and is ample for anyone actually watching. Mirrored in
+# the CLI.
 _UNATTENDED_PROMPT_SECONDS = 30.0
 
 
@@ -2160,14 +2155,13 @@ def _prompt_owns_the_terminal() -> bool:
     """Whether this process may DRIVE the terminal, not merely see one.
 
     A backgrounded shell job (`unsloth studio -H 0.0.0.0 &`) inherits the
-    terminal, so isatty() is True, but the masked prompt calls termios.tcsetattr,
-    and POSIX sends SIGTTOU to a background process group that does; the default
-    action stops the process. The launch would freeze before the socket binds
-    instead of starting, which is exactly the "never block a launch that worked"
-    case this gate is careful about everywhere else. Treat it as no terminal.
+    terminal so isatty() is True, but the masked prompt calls termios.tcsetattr
+    and POSIX SIGTTOUs a background process group that does; the default action
+    stops the process, freezing the launch before the socket binds. Treat it as
+    no terminal.
 
-    True on any doubt: no job control (Windows), no controlling terminal, or a
-    stream with no fileno. Nothing can stop us there, so the isatty answer stands.
+    True on any doubt (no job control, no controlling terminal, no fileno):
+    nothing can stop us there, so the isatty answer stands.
     """
     try:
         return os.tcgetpgrp(sys.stdin.fileno()) == os.getpgrp()
@@ -2178,10 +2172,9 @@ def _prompt_owns_the_terminal() -> bool:
 def _exposure_phrase(*, tunnel_will_start: bool, host: str) -> str:
     """Name where this launch will actually be reachable.
 
-    A tunnel really is the public internet. A wildcard bind really is every
-    interface. A CONCRETE bind such as `-H 192.168.1.50` is neither: uvicorn
-    listens on that one address, so claiming every interface is untrue, and the
-    operator is more likely to act on the address they typed than on a category.
+    A tunnel is the public internet; a wildcard bind is every interface. A
+    CONCRETE bind (`-H 192.168.1.50`) is neither, since uvicorn listens on that
+    one address, and the operator acts on the address they typed anyway.
     """
     if tunnel_will_start:
         return "on the public internet"
@@ -2224,16 +2217,12 @@ def _terminal_password_gate(
     from auth.bootstrap_timeout import _is_exposed_bind
 
     # A raw non-loopback bind (-H 0.0.0.0) starts no tunnel, so it used to skip
-    # this gate entirely even though the docstring above describes exactly its
-    # hazard: the served HTML injects the bootstrap credential, and every host on
-    # the network can load it. Scoped like the bootstrap deadline: web UI only,
-    # never api-only (authenticates by API key, not the admin password) and never
-    # Colab (sandboxed, no inbound).
-    # secure = False deliberately. _is_exposed_bind counts --secure as exposed
-    # because for a tunnel launch the tunnel IS the exposure, but --secure forces
-    # a loopback bind, so asking it with secure = True would conflate "the tunnel
-    # publishes this" with "the socket itself is reachable". Here only the second
-    # question matters; the first is already tunnel_will_start.
+    # this gate even though the served HTML injects the bootstrap credential for
+    # every host on the network. Scoped like the bootstrap deadline: web UI only,
+    # never api-only (API key, not the admin password) and never Colab (no inbound).
+    # secure = False deliberately: _is_exposed_bind counts --secure as exposed
+    # (for a tunnel the tunnel IS the exposure) but --secure forces a loopback
+    # bind, and the only question here is whether the socket itself is reachable.
     bind_is_exposed = (
         _is_exposed_bind(host, False) and frontend_served and not api_only and not is_colab
     )
@@ -2241,19 +2230,18 @@ def _terminal_password_gate(
         return True, False
 
     # The parent already held this terminal open and got nothing. Repeating the
-    # wait would double the fallback (and triple it on the `studio run` path,
-    # which re-enters the CLI gate after re-exec), which is exactly the startup
-    # stall the deadline was chosen to stay under. Consumed, not just read, so it
-    # cannot leak into a later launch from the same environment.
+    # wait would double the fallback (triple on the `studio run` path, which
+    # re-enters the CLI gate after re-exec) -- the startup stall the deadline was
+    # chosen to stay under. Consumed, not peeked, so it cannot leak into a later
+    # launch from the same environment.
     if os.environ.pop("UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE", "") and not tunnel_will_start:
         return True, False
 
     # A raw-bind-only launch decides promptability BEFORE opening auth storage.
-    # Before this gate learned about non-tunnel exposure it returned above, so a
-    # headless container never reached ensure_default_admin() from here. Doing so
-    # now would move first seeding earlier, open the SQLite file sooner and give a
-    # read-only or locked home a new place to fail, none of which a container
-    # operator asked for. Tunnel launches are unaffected: they always came here.
+    # Such a launch used to return above, so a headless container never reached
+    # ensure_default_admin() from here; doing so now would seed earlier, open the
+    # SQLite file sooner and give a read-only or locked home a new place to fail.
+    # Tunnel launches are unaffected: they always came here.
     if not tunnel_will_start and not (
         _stream_isatty(sys.stdin) and _stream_isatty(sys.stderr) and _prompt_owns_the_terminal()
     ):
@@ -2284,12 +2272,11 @@ def _terminal_password_gate(
         stdin_isatty = _stream_isatty(sys.stdin),
         stderr_isatty = _stream_isatty(sys.stderr),
     ):
-        # Headless raw bind: leave it EXACTLY as it behaved before this gate
-        # learned about non-tunnel exposure. The refuse-and-strip handling below
-        # is calibrated to publishing a public URL; applying it here would break
-        # long-running headless containers, which are the common use of
-        # -H 0.0.0.0, and would delete the .bootstrap_password file such a
-        # deployment is often read from. The bootstrap deadline still arms.
+        # Headless raw bind: leave it EXACTLY as it behaved before. The
+        # refuse-and-strip handling below is calibrated to publishing a public
+        # URL; here it would break long-running headless containers (the common
+        # use of -H 0.0.0.0) and delete the .bootstrap_password they are read
+        # from. The bootstrap deadline still arms.
         if not tunnel_will_start:
             return True, False
         # No terminal: only proceed if the bootstrap deadline will arm; api-only
@@ -2352,39 +2339,36 @@ def _terminal_password_gate(
         apply_change = _apply_change,
         out = sys.stderr,
         exposure = _exposure_phrase(tunnel_will_start = tunnel_will_start, host = host),
-        # Ctrl+C aborts a tunnel launch and only a tunnel launch. On a raw bind it
+        # Ctrl+C aborts a tunnel launch and only a tunnel launch; on a raw bind it
         # declines the prompt and the launch continues, so the banner must not
         # promise an abort that will not happen.
         refusal_aborts = tunnel_will_start,
         # A raw bind must never block a launch that used to start. A detached pty
-        # (`tmux new -d`, `screen -dmS`, `docker run -dt`) passes every isatty and
-        # process-group test yet nobody will ever type, so an undeadlined read
-        # waits forever and the socket never binds. No answer is handled below as
-        # a refusal: proceed on the bootstrap deadline, exactly as before. The
-        # tunnel keeps waiting indefinitely; it fails closed rather than proceed.
+        # (`tmux new -d`, `docker run -dt`) passes every isatty and process-group
+        # test yet nobody will ever type, so an undeadlined read waits forever and
+        # the socket never binds; no answer is handled below as a refusal and
+        # proceeds on the bootstrap deadline. The tunnel waits forever instead,
+        # failing closed.
         first_key_timeout = None if tunnel_will_start else _UNATTENDED_PROMPT_SECONDS,
     )
     if changed:
         return True, True
     if tunnel_will_start:
-        # Refusing to secure a launch that is about to publish a public URL
-        # aborts it, exactly as before.
+        # Refusing to secure a launch about to publish a public URL aborts it,
+        # exactly as before.
         return False, False
-    # A raw bind is different: this launch worked before the prompt existed, and
-    # aborting it would turn Ctrl+C into "no Studio" for anyone who just wanted
-    # the old behaviour. `docker run -it` on a fresh volume is precisely that
-    # case (docker/studio_run.sh execs `unsloth studio -H 0.0.0.0` and only
-    # supplies a password when the initial-password file is non-empty), so
-    # aborting would stop a container that starts today. Warn and proceed at the
-    # protection level this launch already had.
+    # A raw bind is different: it worked before the prompt existed, and aborting
+    # would turn Ctrl+C into "no Studio". docker/studio_run.sh execs
+    # `unsloth studio -H 0.0.0.0` and only supplies a password when the
+    # initial-password file is non-empty, so `docker run -it` on a fresh volume
+    # meets this prompt and aborting would stop a container that starts today.
+    # Warn and proceed at the protection level this launch already had.
     #
-    # Which is sometimes NO protection: with UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT=0
-    # the deadline never arms, so promising a shutdown would be false, and it is
-    # the one sentence an operator would act on. Say what will actually happen.
-    # Still proceed rather than fail closed: this launch worked before the prompt
-    # existed, the operator disabled the deadline deliberately and cancelled the
-    # prompt deliberately, and refusing to start would break the very case the
-    # paragraph above exists to protect.
+    # Which is sometimes NO protection: UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT=0 never
+    # arms the deadline, so say what will actually happen rather than promise a
+    # shutdown -- that is the one sentence an operator acts on. Still proceed: the
+    # operator disabled the deadline and cancelled the prompt deliberately, and
+    # refusing to start would break the case above.
     deadline_arms = should_arm_bootstrap_timeout(
         host = host,
         secure = secure,

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2172,7 +2172,26 @@ def _terminal_password_gate(
     (api-only, timeout 0) nothing protects it, so refuse. NOT wrapped in a broad
     try/except: an auth storage failure must abort rather than expose the default.
     """
-    if not tunnel_will_start:
+    from auth.bootstrap_timeout import _is_exposed_bind
+
+    # A raw non-loopback bind (-H 0.0.0.0) starts no tunnel, so it used to skip
+    # this gate entirely even though the docstring above describes exactly its
+    # hazard: the served HTML injects the bootstrap credential, and every host on
+    # the network can load it. Scoped like the bootstrap deadline: web UI only,
+    # never api-only (authenticates by API key, not the admin password) and never
+    # Colab (sandboxed, no inbound).
+    # secure = False deliberately. _is_exposed_bind counts --secure as exposed
+    # because for a tunnel launch the tunnel IS the exposure, but --secure forces
+    # a loopback bind, so asking it with secure = True would conflate "the tunnel
+    # publishes this" with "the socket itself is reachable". Here only the second
+    # question matters; the first is already tunnel_will_start.
+    bind_is_exposed = (
+        _is_exposed_bind(host, False)
+        and frontend_served
+        and not api_only
+        and not is_colab
+    )
+    if not tunnel_will_start and not bind_is_exposed:
         return True, False
 
     from auth import hashing as _auth_hashing
@@ -2195,10 +2214,19 @@ def _terminal_password_gate(
 
     if not should_prompt_password_change(
         tunnel_will_start = tunnel_will_start,
+        bind_is_exposed = bind_is_exposed,
         requires_change = requires_change,
         stdin_isatty = _stream_isatty(sys.stdin),
         stderr_isatty = _stream_isatty(sys.stderr),
     ):
+        # Headless raw bind: leave it EXACTLY as it behaved before this gate
+        # learned about non-tunnel exposure. The refuse-and-strip handling below
+        # is calibrated to publishing a public URL; applying it here would break
+        # long-running headless containers, which are the common use of
+        # -H 0.0.0.0, and would delete the .bootstrap_password file such a
+        # deployment is often read from. The bootstrap deadline still arms.
+        if not tunnel_will_start:
+            return True, False
         # No terminal: only proceed if the bootstrap deadline will arm; api-only
         # and TIMEOUT=0 never arm it, leaving the default credential public.
         deadline_arms = should_arm_bootstrap_timeout(
@@ -2258,6 +2286,10 @@ def _terminal_password_gate(
         is_current_password = _is_current_password,
         apply_change = _apply_change,
         out = sys.stderr,
+        exposure = (
+            "on the public internet" if tunnel_will_start
+            else "on every network interface"
+        ),
     )
     return (True, True) if changed else (False, False)
 

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2232,9 +2232,7 @@ def _terminal_password_gate(
     # read-only or locked home a new place to fail, none of which a container
     # operator asked for. Tunnel launches are unaffected: they always came here.
     if not tunnel_will_start and not (
-        _stream_isatty(sys.stdin)
-        and _stream_isatty(sys.stderr)
-        and _prompt_owns_the_terminal()
+        _stream_isatty(sys.stdin) and _stream_isatty(sys.stderr) and _prompt_owns_the_terminal()
     ):
         return True, False
 

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2141,6 +2141,40 @@ def _stream_isatty(stream) -> bool:
         return False
 
 
+# How long a raw-bind prompt waits for the FIRST keystroke before giving up and
+# launching anyway. Only the first: once someone is typing there is no deadline.
+#
+# 30s, not longer. The launches that reach this with nobody watching are the ones
+# that allocate a pty and then never read it -- `docker run -dt`, `tmux new -d`,
+# `screen -dmS`, some CI runners -- and they want to bind promptly. A container
+# that takes two minutes to answer a healthcheck can be killed and restarted by
+# the orchestrator, which would turn "delayed" into a restart loop; 30s stays
+# inside a default Docker HEALTHCHECK start period. Someone who is actually
+# looking at the prompt starts typing well inside that, and someone who is not
+# gets the refusal path, which warns and launches with the bootstrap deadline
+# armed. Mirrored in the CLI.
+_UNATTENDED_PROMPT_SECONDS = 30.0
+
+
+def _prompt_owns_the_terminal() -> bool:
+    """Whether this process may DRIVE the terminal, not merely see one.
+
+    A backgrounded shell job (`unsloth studio -H 0.0.0.0 &`) inherits the
+    terminal, so isatty() is True, but the masked prompt calls termios.tcsetattr,
+    and POSIX sends SIGTTOU to a background process group that does; the default
+    action stops the process. The launch would freeze before the socket binds
+    instead of starting, which is exactly the "never block a launch that worked"
+    case this gate is careful about everywhere else. Treat it as no terminal.
+
+    True on any doubt: no job control (Windows), no controlling terminal, or a
+    stream with no fileno. Nothing can stop us there, so the isatty answer stands.
+    """
+    try:
+        return os.tcgetpgrp(sys.stdin.fileno()) == os.getpgrp()
+    except (AttributeError, OSError, ValueError):
+        return True
+
+
 def _terminal_password_gate(
     *,
     tunnel_will_start: bool,
@@ -2197,7 +2231,11 @@ def _terminal_password_gate(
     # now would move first seeding earlier, open the SQLite file sooner and give a
     # read-only or locked home a new place to fail, none of which a container
     # operator asked for. Tunnel launches are unaffected: they always came here.
-    if not tunnel_will_start and not (_stream_isatty(sys.stdin) and _stream_isatty(sys.stderr)):
+    if not tunnel_will_start and not (
+        _stream_isatty(sys.stdin)
+        and _stream_isatty(sys.stderr)
+        and _prompt_owns_the_terminal()
+    ):
         return True, False
 
     from auth import hashing as _auth_hashing
@@ -2293,6 +2331,13 @@ def _terminal_password_gate(
         apply_change = _apply_change,
         out = sys.stderr,
         exposure = ("on the public internet" if tunnel_will_start else "on every network interface"),
+        # A raw bind must never block a launch that used to start. A detached pty
+        # (`tmux new -d`, `screen -dmS`, `docker run -dt`) passes every isatty and
+        # process-group test yet nobody will ever type, so an undeadlined read
+        # waits forever and the socket never binds. No answer is handled below as
+        # a refusal: proceed on the bootstrap deadline, exactly as before. The
+        # tunnel keeps waiting indefinitely; it fails closed rather than proceed.
+        first_key_timeout = None if tunnel_will_start else _UNATTENDED_PROMPT_SECONDS,
     )
     if changed:
         return True, True

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2191,6 +2191,17 @@ def _terminal_password_gate(
     if not tunnel_will_start and not bind_is_exposed:
         return True, False
 
+    # A raw-bind-only launch decides promptability BEFORE opening auth storage.
+    # Before this gate learned about non-tunnel exposure it returned above, so a
+    # headless container never reached ensure_default_admin() from here. Doing so
+    # now would move first seeding earlier, open the SQLite file sooner and give a
+    # read-only or locked home a new place to fail, none of which a container
+    # operator asked for. Tunnel launches are unaffected: they always came here.
+    if not tunnel_will_start and not (
+        _stream_isatty(sys.stdin) and _stream_isatty(sys.stderr)
+    ):
+        return True, False
+
     from auth import hashing as _auth_hashing
     from auth import storage as _auth_storage
     from auth.bootstrap_timeout import (
@@ -2285,7 +2296,29 @@ def _terminal_password_gate(
         out = sys.stderr,
         exposure = ("on the public internet" if tunnel_will_start else "on every network interface"),
     )
-    return (True, True) if changed else (False, False)
+    if changed:
+        return True, True
+    if tunnel_will_start:
+        # Refusing to secure a launch that is about to publish a public URL
+        # aborts it, exactly as before.
+        return False, False
+    # A raw bind is different: this launch worked before the prompt existed, and
+    # aborting it would turn Ctrl+C into "no Studio" for anyone who just wanted
+    # the old behaviour. `docker run -it` on a fresh volume is precisely that
+    # case (docker/studio_run.sh execs `unsloth studio -H 0.0.0.0` and only
+    # supplies a password when the initial-password file is non-empty), so
+    # aborting would stop a container that starts today. Warn and proceed at the
+    # protection level this launch already had: the bootstrap deadline.
+    print(
+        "  WARNING: continuing with the auto-generated admin password on a bind "
+        "that is reachable from the network. Unsloth shuts down after the "
+        "bootstrap deadline (UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT, default 1h) "
+        "unless the password is changed. Change it by logging in, or with "
+        "`unsloth studio reset-password`.",
+        file = sys.stderr,
+        flush = True,
+    )
+    return True, False
 
 
 def _apply_supplied_password(password_value: "Optional[str]") -> None:

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2186,10 +2186,7 @@ def _terminal_password_gate(
     # publishes this" with "the socket itself is reachable". Here only the second
     # question matters; the first is already tunnel_will_start.
     bind_is_exposed = (
-        _is_exposed_bind(host, False)
-        and frontend_served
-        and not api_only
-        and not is_colab
+        _is_exposed_bind(host, False) and frontend_served and not api_only and not is_colab
     )
     if not tunnel_will_start and not bind_is_exposed:
         return True, False
@@ -2286,10 +2283,7 @@ def _terminal_password_gate(
         is_current_password = _is_current_password,
         apply_change = _apply_change,
         out = sys.stderr,
-        exposure = (
-            "on the public internet" if tunnel_will_start
-            else "on every network interface"
-        ),
+        exposure = ("on the public internet" if tunnel_will_start else "on every network interface"),
     )
     return (True, True) if changed else (False, False)
 

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2175,6 +2175,21 @@ def _prompt_owns_the_terminal() -> bool:
         return True
 
 
+def _exposure_phrase(*, tunnel_will_start: bool, host: str) -> str:
+    """Name where this launch will actually be reachable.
+
+    A tunnel really is the public internet. A wildcard bind really is every
+    interface. A CONCRETE bind such as `-H 192.168.1.50` is neither: uvicorn
+    listens on that one address, so claiming every interface is untrue, and the
+    operator is more likely to act on the address they typed than on a category.
+    """
+    if tunnel_will_start:
+        return "on the public internet"
+    if is_wildcard_host(host):
+        return "on every network interface"
+    return f"at {host}, which other machines on the network can reach"
+
+
 def _terminal_password_gate(
     *,
     tunnel_will_start: bool,
@@ -2336,7 +2351,11 @@ def _terminal_password_gate(
         is_current_password = _is_current_password,
         apply_change = _apply_change,
         out = sys.stderr,
-        exposure = ("on the public internet" if tunnel_will_start else "on every network interface"),
+        exposure = _exposure_phrase(tunnel_will_start = tunnel_will_start, host = host),
+        # Ctrl+C aborts a tunnel launch and only a tunnel launch. On a raw bind it
+        # declines the prompt and the launch continues, so the banner must not
+        # promise an abort that will not happen.
+        refusal_aborts = tunnel_will_start,
         # A raw bind must never block a launch that used to start. A detached pty
         # (`tmux new -d`, `screen -dmS`, `docker run -dt`) passes every isatty and
         # process-group test yet nobody will ever type, so an undeadlined read

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2225,6 +2225,14 @@ def _terminal_password_gate(
     if not tunnel_will_start and not bind_is_exposed:
         return True, False
 
+    # The parent already held this terminal open and got nothing. Repeating the
+    # wait would double the fallback (and triple it on the `studio run` path,
+    # which re-enters the CLI gate after re-exec), which is exactly the startup
+    # stall the deadline was chosen to stay under. Consumed, not just read, so it
+    # cannot leak into a later launch from the same environment.
+    if os.environ.pop("UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE", "") and not tunnel_will_start:
+        return True, False
+
     # A raw-bind-only launch decides promptability BEFORE opening auth storage.
     # Before this gate learned about non-tunnel exposure it returned above, so a
     # headless container never reached ensure_default_admin() from here. Doing so

--- a/studio/backend/tests/test_password_prompt.py
+++ b/studio/backend/tests/test_password_prompt.py
@@ -352,14 +352,16 @@ def test_resolve_supplied_password_off_by_default(monkeypatch):
 
 def test_a_raw_exposed_bind_prompts_when_a_terminal_is_attached():
     from auth.terminal_prompt import should_prompt_password_change
-
-    assert should_prompt_password_change(
-        tunnel_will_start = False,
-        bind_is_exposed = True,
-        requires_change = True,
-        stdin_isatty = True,
-        stderr_isatty = True,
-    ) is True
+    assert (
+        should_prompt_password_change(
+            tunnel_will_start = False,
+            bind_is_exposed = True,
+            requires_change = True,
+            stdin_isatty = True,
+            stderr_isatty = True,
+        )
+        is True
+    )
 
 
 def test_a_raw_exposed_bind_stays_silent_without_a_terminal():
@@ -372,52 +374,60 @@ def test_a_raw_exposed_bind_stays_silent_without_a_terminal():
     keep the bootstrap deadline as their protection instead.
     """
     from auth.terminal_prompt import should_prompt_password_change
-
     for stdin_tty, stderr_tty in ((False, False), (True, False), (False, True)):
-        assert should_prompt_password_change(
-            tunnel_will_start = False,
-            bind_is_exposed = True,
-            requires_change = True,
-            stdin_isatty = stdin_tty,
-            stderr_isatty = stderr_tty,
-        ) is False
+        assert (
+            should_prompt_password_change(
+                tunnel_will_start = False,
+                bind_is_exposed = True,
+                requires_change = True,
+                stdin_isatty = stdin_tty,
+                stderr_isatty = stderr_tty,
+            )
+            is False
+        )
 
 
 def test_a_loopback_launch_is_untouched():
     """Plain `unsloth studio` must be completely unaffected."""
     from auth.terminal_prompt import should_prompt_password_change
-
-    assert should_prompt_password_change(
-        tunnel_will_start = False,
-        bind_is_exposed = False,
-        requires_change = True,
-        stdin_isatty = True,
-        stderr_isatty = True,
-    ) is False
+    assert (
+        should_prompt_password_change(
+            tunnel_will_start = False,
+            bind_is_exposed = False,
+            requires_change = True,
+            stdin_isatty = True,
+            stderr_isatty = True,
+        )
+        is False
+    )
 
 
 def test_an_already_changed_password_never_prompts():
     from auth.terminal_prompt import should_prompt_password_change
-
-    assert should_prompt_password_change(
-        tunnel_will_start = True,
-        bind_is_exposed = True,
-        requires_change = False,
-        stdin_isatty = True,
-        stderr_isatty = True,
-    ) is False
+    assert (
+        should_prompt_password_change(
+            tunnel_will_start = True,
+            bind_is_exposed = True,
+            requires_change = False,
+            stdin_isatty = True,
+            stderr_isatty = True,
+        )
+        is False
+    )
 
 
 def test_the_default_keeps_old_callers_tunnel_only():
     """bind_is_exposed defaults False, so an old caller behaves as before."""
     from auth.terminal_prompt import should_prompt_password_change
-
-    assert should_prompt_password_change(
-        tunnel_will_start = False,
-        requires_change = True,
-        stdin_isatty = True,
-        stderr_isatty = True,
-    ) is False
+    assert (
+        should_prompt_password_change(
+            tunnel_will_start = False,
+            requires_change = True,
+            stdin_isatty = True,
+            stderr_isatty = True,
+        )
+        is False
+    )
 
 
 def test_the_prompt_banner_does_not_claim_the_internet_for_a_lan_bind(monkeypatch):

--- a/studio/backend/tests/test_password_prompt.py
+++ b/studio/backend/tests/test_password_prompt.py
@@ -341,12 +341,9 @@ def test_resolve_supplied_password_off_by_default(monkeypatch):
 
 
 # ──────────────────────────────────────────────────────────────────────
-# A raw non-loopback bind is exposure too.
-#
-# `-H 0.0.0.0` starts no tunnel, so it used to return False here and skip the
-# gate entirely, leaving the seeded admin password live and served in the page
-# to every host on the network. The gate's own docstring in run.py described
-# that hazard while the code returned early on `if not tunnel_will_start`.
+# A raw non-loopback bind is exposure too. `-H 0.0.0.0` starts no tunnel, so it
+# used to return False here and skip the gate, leaving the seeded admin password
+# live and served in the page to every host on the network.
 # ──────────────────────────────────────────────────────────────────────
 
 
@@ -367,11 +364,10 @@ def test_a_raw_exposed_bind_prompts_when_a_terminal_is_attached():
 def test_a_raw_exposed_bind_stays_silent_without_a_terminal():
     """Headless raw binds keep today's behaviour, deliberately.
 
-    Everything downstream of a True here is calibrated to publishing a public
-    URL: it refuses to launch when the deadline is disabled, and it deletes
-    .bootstrap_password. Long-running headless containers are the common use of
-    -H 0.0.0.0 and are often logged into by reading exactly that file, so they
-    keep the bootstrap deadline as their protection instead.
+    Everything downstream of a True here is calibrated to publishing a public URL:
+    it refuses to launch when the deadline is disabled, and it deletes
+    .bootstrap_password, which long-running headless containers (the common use of
+    -H 0.0.0.0) are often logged into by reading. They keep the deadline instead.
     """
     from auth.terminal_prompt import should_prompt_password_change
     for stdin_tty, stderr_tty in ((False, False), (True, False), (False, True)):
@@ -433,8 +429,8 @@ def test_the_default_keeps_old_callers_tunnel_only():
 def test_the_prompt_banner_does_not_claim_the_internet_for_a_lan_bind(monkeypatch):
     """`-H 0.0.0.0` behind a NAT router is the LAN, not the public internet.
 
-    Saying "public internet" there is false often enough to train people to
-    ignore the message, which is the one thing this prompt cannot afford.
+    Saying "public internet" is false often enough to train people to ignore the
+    message, which is the one thing this prompt cannot afford.
     """
     import io
 
@@ -446,8 +442,7 @@ def test_the_prompt_banner_does_not_claim_the_internet_for_a_lan_bind(monkeypatc
     monkeypatch.setattr(terminal_prompt, "_read_password", _no_input)
 
     out = io.StringIO()
-    # The read aborts immediately and returns False, which is fine: the banner
-    # is written before any read.
+    # The read aborts immediately; fine, the banner is written before any read.
     terminal_prompt.prompt_for_password_change(
         min_length = 8,
         is_current_password = lambda _c: False,

--- a/studio/backend/tests/test_password_prompt.py
+++ b/studio/backend/tests/test_password_prompt.py
@@ -338,3 +338,113 @@ def test_resolve_supplied_password_off_by_default(monkeypatch):
     monkeypatch.delenv(tp.SUPPLIED_PASSWORD_ENV, raising = False)
     assert tp.resolve_supplied_password("") is None
     assert tp.resolve_supplied_password(None) is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# A raw non-loopback bind is exposure too.
+#
+# `-H 0.0.0.0` starts no tunnel, so it used to return False here and skip the
+# gate entirely, leaving the seeded admin password live and served in the page
+# to every host on the network. The gate's own docstring in run.py described
+# that hazard while the code returned early on `if not tunnel_will_start`.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_a_raw_exposed_bind_prompts_when_a_terminal_is_attached():
+    from auth.terminal_prompt import should_prompt_password_change
+
+    assert should_prompt_password_change(
+        tunnel_will_start = False,
+        bind_is_exposed = True,
+        requires_change = True,
+        stdin_isatty = True,
+        stderr_isatty = True,
+    ) is True
+
+
+def test_a_raw_exposed_bind_stays_silent_without_a_terminal():
+    """Headless raw binds keep today's behaviour, deliberately.
+
+    Everything downstream of a True here is calibrated to publishing a public
+    URL: it refuses to launch when the deadline is disabled, and it deletes
+    .bootstrap_password. Long-running headless containers are the common use of
+    -H 0.0.0.0 and are often logged into by reading exactly that file, so they
+    keep the bootstrap deadline as their protection instead.
+    """
+    from auth.terminal_prompt import should_prompt_password_change
+
+    for stdin_tty, stderr_tty in ((False, False), (True, False), (False, True)):
+        assert should_prompt_password_change(
+            tunnel_will_start = False,
+            bind_is_exposed = True,
+            requires_change = True,
+            stdin_isatty = stdin_tty,
+            stderr_isatty = stderr_tty,
+        ) is False
+
+
+def test_a_loopback_launch_is_untouched():
+    """Plain `unsloth studio` must be completely unaffected."""
+    from auth.terminal_prompt import should_prompt_password_change
+
+    assert should_prompt_password_change(
+        tunnel_will_start = False,
+        bind_is_exposed = False,
+        requires_change = True,
+        stdin_isatty = True,
+        stderr_isatty = True,
+    ) is False
+
+
+def test_an_already_changed_password_never_prompts():
+    from auth.terminal_prompt import should_prompt_password_change
+
+    assert should_prompt_password_change(
+        tunnel_will_start = True,
+        bind_is_exposed = True,
+        requires_change = False,
+        stdin_isatty = True,
+        stderr_isatty = True,
+    ) is False
+
+
+def test_the_default_keeps_old_callers_tunnel_only():
+    """bind_is_exposed defaults False, so an old caller behaves as before."""
+    from auth.terminal_prompt import should_prompt_password_change
+
+    assert should_prompt_password_change(
+        tunnel_will_start = False,
+        requires_change = True,
+        stdin_isatty = True,
+        stderr_isatty = True,
+    ) is False
+
+
+def test_the_prompt_banner_does_not_claim_the_internet_for_a_lan_bind(monkeypatch):
+    """`-H 0.0.0.0` behind a NAT router is the LAN, not the public internet.
+
+    Saying "public internet" there is false often enough to train people to
+    ignore the message, which is the one thing this prompt cannot afford.
+    """
+    import io
+
+    from auth import terminal_prompt
+
+    def _no_input(*_a, **_k):
+        raise EOFError
+
+    monkeypatch.setattr(terminal_prompt, "_read_password", _no_input)
+
+    out = io.StringIO()
+    # The read aborts immediately and returns False, which is fine: the banner
+    # is written before any read.
+    terminal_prompt.prompt_for_password_change(
+        min_length = 8,
+        is_current_password = lambda _c: False,
+        apply_change = lambda _p: None,
+        out = out,
+        exposure = "on every network interface",
+    )
+    text = out.getvalue()
+    assert "on every network interface" in text
+    assert "public internet" not in text

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -188,7 +188,7 @@ def test_gate_success_applies_route_equivalent_change(monkeypatch):
         lambda u, p, **kw: calls.append(("update", u, p, kw)),
     )
 
-    def _fake_prompt(*, min_length, is_current_password, apply_change, out):
+    def _fake_prompt(*, min_length, is_current_password, apply_change, out, **_kw):
         # The gate wires the policy constant and route-equivalent apply hook.
         assert min_length == auth_storage.MIN_PASSWORD_LENGTH
         # Wired to the real hash comparison: a wrong guess is rejected.
@@ -409,3 +409,90 @@ def test_apply_supplied_password_strips_env_even_when_literal_wins(monkeypatch):
     monkeypatch.setenv(terminal_prompt.SUPPLIED_PASSWORD_ENV, "env-should-be-stripped")
     run._apply_supplied_password("literal-new-password")
     assert terminal_prompt.SUPPLIED_PASSWORD_ENV not in run.os.environ
+
+
+# ──────────────────────────────────────────────────────────────────────
+# The gate now covers a raw exposed bind, not just the tunnel.
+# ──────────────────────────────────────────────────────────────────────
+
+
+_RAW_BIND_KWARGS = dict(
+    host = "0.0.0.0",
+    secure = False,
+    api_only = False,
+    frontend_served = True,
+)
+
+
+def test_a_headless_raw_bind_is_byte_for_byte_unchanged(monkeypatch):
+    """The compatibility promise of this change.
+
+    Headless `-H 0.0.0.0` is the long-running container case. It must still
+    proceed, still keep serving the bootstrap credential, and above all must not
+    reach the strip-and-refuse handling that a public tunnel launch uses; that
+    would delete the .bootstrap_password such deployments are logged into with.
+    """
+    _patch_streams(monkeypatch, tty = False)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, **_RAW_BIND_KWARGS
+    ) == (True, False)
+
+
+def test_a_raw_bind_with_a_terminal_reaches_the_prompt(monkeypatch):
+    """The fix. Before this, `if not tunnel_will_start` returned first."""
+    _patch_streams(monkeypatch, tty = True)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+
+    seen = {}
+
+    def _fake_prompt(*, min_length, is_current_password, apply_change, out, **kw):
+        seen.update(kw)
+        apply_change("a-brand-new-password")
+        return True
+
+    from auth import terminal_prompt
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", _fake_prompt)
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, **_RAW_BIND_KWARGS
+    ) == (True, True)
+    # And it must not tell a LAN operator they are on the public internet.
+    assert seen.get("exposure") == "on every network interface"
+
+
+def test_a_loopback_launch_still_short_circuits(monkeypatch):
+    """Plain `unsloth studio` must not consult storage at all."""
+    def _boom(*_a, **_k):
+        raise AssertionError("storage must not be consulted for a loopback launch")
+
+    monkeypatch.setattr(run, "_stream_isatty", lambda _s: True)
+    from auth import storage as _storage
+    monkeypatch.setattr(_storage, "ensure_default_admin", _boom)
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = False,
+        host = "127.0.0.1",
+        secure = False,
+        api_only = False,
+        frontend_served = True,
+    ) == (True, False)
+
+
+def test_api_only_and_colab_raw_binds_do_not_prompt(monkeypatch):
+    """Scoped like the bootstrap deadline: web UI only, never api-only or Colab."""
+    def _boom(*_a, **_k):
+        raise AssertionError("storage must not be consulted")
+
+    monkeypatch.setattr(run, "_stream_isatty", lambda _s: True)
+    from auth import storage as _storage
+    monkeypatch.setattr(_storage, "ensure_default_admin", _boom)
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, host = "0.0.0.0", secure = False,
+        api_only = True, frontend_served = True,
+    ) == (True, False)
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, host = "0.0.0.0", secure = False,
+        api_only = False, frontend_served = True, is_colab = True,
+    ) == (True, False)

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -8,6 +8,7 @@ so run under the Unsloth venv."""
 from __future__ import annotations
 
 import io
+import os
 import re
 import sys
 from pathlib import Path
@@ -567,3 +568,190 @@ def test_api_only_and_colab_raw_binds_do_not_prompt(monkeypatch):
         frontend_served = True,
         is_colab = True,
     ) == (True, False)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# A backgrounded shell job is not a usable terminal.
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _FdStream(_Stream):
+    def __init__(self):
+        super().__init__(isatty = True)
+
+    def fileno(self):
+        return 0
+
+
+def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
+    """`unsloth studio -H 0.0.0.0 &` must still launch.
+
+    A background job inherits the terminal, so isatty() is True on both streams,
+    but the masked prompt calls termios.tcsetattr; POSIX sends SIGTTOU to a
+    background process group that does, and the default action STOPS the process.
+    The launch would freeze before the socket binds, so it takes the headless
+    path it took before this gate learned about non-tunnel exposure: proceed,
+    protected by the bootstrap deadline, without consulting auth storage.
+    """
+    monkeypatch.setattr(sys, "stdin", _FdStream())
+    monkeypatch.setattr(sys, "stderr", _FdStream())
+    monkeypatch.setattr(run.os, "tcgetpgrp", lambda _fd: 4242)
+    monkeypatch.setattr(run.os, "getpgrp", lambda: 99)
+
+    def _boom(*_a, **_k):
+        raise AssertionError("storage must not be opened for a background job")
+
+    monkeypatch.setattr(auth_storage, "ensure_default_admin", _boom)
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, **_RAW_BIND_KWARGS
+    ) == (True, False)
+
+
+def test_a_backgrounded_tunnel_launch_still_fails_closed(monkeypatch):
+    """A tunnel publishes a public URL: it must not quietly proceed unprompted."""
+    monkeypatch.setattr(sys, "stdin", _FdStream())
+    monkeypatch.setattr(sys, "stderr", _FdStream())
+    monkeypatch.setattr(run.os, "tcgetpgrp", lambda _fd: 4242)
+    monkeypatch.setattr(run.os, "getpgrp", lambda: 99)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+    monkeypatch.setattr(
+        terminal_prompt, "prompt_for_password_change", lambda **_kw: False
+    )
+
+    # The process group check is scoped to the raw-bind branch, so a tunnel
+    # launch still reaches the prompt and still aborts when it is refused.
+    assert run._prompt_owns_the_terminal() is False
+    assert run._terminal_password_gate(
+        tunnel_will_start = True, **_GATE_KWARGS
+    ) == (False, False)
+
+
+def test_a_foreground_raw_bind_still_reaches_the_prompt(monkeypatch):
+    """The ordinary interactive case is untouched."""
+    monkeypatch.setattr(sys, "stdin", _FdStream())
+    monkeypatch.setattr(sys, "stderr", _FdStream())
+    monkeypatch.setattr(run.os, "tcgetpgrp", lambda _fd: 4242)
+    monkeypatch.setattr(run.os, "getpgrp", lambda: 4242)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+    monkeypatch.setattr(
+        terminal_prompt, "prompt_for_password_change", lambda **_kw: True
+    )
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, **_RAW_BIND_KWARGS
+    ) == (True, True)
+
+
+def test_no_job_control_falls_back_to_the_isatty_answer(monkeypatch):
+    """Windows / no controlling terminal: nothing can stop us, so still prompt."""
+    for exc in (OSError("ENOTTY"), AttributeError(), ValueError()):
+        def _boom(_fd, _exc = exc):
+            raise _exc
+
+        monkeypatch.setattr(run.os, "tcgetpgrp", _boom, raising = False)
+        monkeypatch.setattr(sys, "stdin", _FdStream())
+        assert run._prompt_owns_the_terminal() is True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# A pty is not a person: an unattended terminal must not hold the launch.
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _PtyStdin:
+    """sys.stdin standing on a real pty slave, as tmux/screen/docker -t give it."""
+
+    def __init__(self, fd):
+        self._fd = fd
+        self.encoding = "utf-8"
+
+    def fileno(self):
+        return self._fd
+
+    def isatty(self):
+        return True
+
+
+def test_an_unattended_pty_does_not_block_a_raw_bind_forever(monkeypatch):
+    """`tmux new -d 'unsloth studio -H 0.0.0.0'` must still bind its socket.
+
+    A detached pty is a real, foreground terminal that nobody will ever type
+    into: isatty() is True on both streams and the process owns the terminal, so
+    every interactivity test says "prompt". The read then never returns, and
+    because the gate runs BEFORE uvicorn binds, the launch hangs forever instead
+    of starting - a launch that worked before this gate widened to raw binds.
+    """
+    import io
+    import pty
+
+    master, slave = pty.openpty()
+    try:
+        monkeypatch.setattr(sys, "stdin", _PtyStdin(slave))
+        out = io.StringIO()
+        # Nothing is ever written to `master`: the pty exists, the human does not.
+        changed = terminal_prompt.prompt_for_password_change(
+            min_length = 8,
+            is_current_password = lambda _c: False,
+            apply_change = lambda _p: pytest.fail("nothing was typed"),
+            out = out,
+            first_key_timeout = 0.25,
+        )
+    finally:
+        os.close(master)
+        os.close(slave)
+
+    assert changed is False
+    assert "No response at the terminal" in out.getvalue()
+
+
+def test_a_pty_someone_types_into_is_not_treated_as_unattended(monkeypatch):
+    """The deadline is on the FIRST keystroke only, and a real one clears it."""
+    import io
+    import pty
+
+    applied = []
+    master, slave = pty.openpty()
+    try:
+        os.write(master, b"abcdefgh12\rabcdefgh12\r")
+        monkeypatch.setattr(sys, "stdin", _PtyStdin(slave))
+        out = io.StringIO()
+        changed = terminal_prompt.prompt_for_password_change(
+            min_length = 8,
+            is_current_password = lambda _c: False,
+            apply_change = applied.append,
+            out = out,
+            first_key_timeout = 0.25,
+        )
+    finally:
+        os.close(master)
+        os.close(slave)
+
+    assert changed is True
+    assert applied == ["abcdefgh12"]
+
+
+def test_the_gate_deadlines_a_raw_bind_prompt_and_never_the_tunnel(monkeypatch):
+    """Scope: only the launch that must not be blocked gets a deadline.
+
+    A tunnel publishes a public URL, so it keeps waiting indefinitely and fails
+    closed; a raw bind falls back to the protection it already had.
+    """
+    seen = {}
+
+    def _fake_prompt(**kwargs):
+        seen.clear()
+        seen.update(kwargs)
+        return True
+
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", _fake_prompt)
+
+    _patch_streams(monkeypatch, tty = True)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+    run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS)
+    assert seen["first_key_timeout"] == run._UNATTENDED_PROMPT_SECONDS
+
+    _patch_streams(monkeypatch, tty = True)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+    run._terminal_password_gate(tunnel_will_start = True, **_GATE_KWARGS)
+    assert seen["first_key_timeout"] is None

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -800,14 +800,14 @@ def test_the_child_does_not_repeat_a_prompt_the_parent_already_gave_up_on(monkey
         raise AssertionError("the child prompted again after the parent gave up")
 
     from auth import storage as _storage
+
     monkeypatch.setattr(_storage, "ensure_default_admin", _boom)
 
-    assert run._terminal_password_gate(
-        tunnel_will_start = False, **_RAW_BIND_KWARGS
-    ) == (True, False)
+    assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
     # Consumed, so a later launch from the same environment is not silently
     # stripped of its own prompt.
     import os as _os
+
     assert _os.environ.get("UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE") is None
 
 
@@ -818,9 +818,7 @@ def test_the_marker_never_silences_a_tunnel_launch(monkeypatch):
     _patch_seeded_admin(monkeypatch, requires_change = True)
 
     from auth import terminal_prompt
-    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change",
-                        lambda **_kw: False)
 
-    assert run._terminal_password_gate(
-        tunnel_will_start = True, **_GATE_KWARGS
-    ) == (False, False)
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", lambda **_kw: False)
+
+    assert run._terminal_password_gate(tunnel_will_start = True, **_GATE_KWARGS) == (False, False)

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -580,6 +580,12 @@ class _FdStream(_Stream):
         return 0
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
+             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+)
 def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
     """`unsloth studio -H 0.0.0.0 &` must still launch.
 
@@ -602,6 +608,12 @@ def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
     assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
+             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+)
 def test_a_backgrounded_tunnel_launch_still_fails_closed(monkeypatch):
     """A tunnel publishes a public URL: it must not quietly proceed unprompted."""
     monkeypatch.setattr(sys, "stdin", _FdStream())
@@ -617,6 +629,12 @@ def test_a_backgrounded_tunnel_launch_still_fails_closed(monkeypatch):
     assert run._terminal_password_gate(tunnel_will_start = True, **_GATE_KWARGS) == (False, False)
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
+             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+)
 def test_a_foreground_raw_bind_still_reaches_the_prompt(monkeypatch):
     """The ordinary interactive case is untouched."""
     monkeypatch.setattr(sys, "stdin", _FdStream())
@@ -660,6 +678,12 @@ class _PtyStdin:
         return True
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
+             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+)
 def test_an_unattended_pty_does_not_block_a_raw_bind_forever(monkeypatch):
     """`tmux new -d 'unsloth studio -H 0.0.0.0'` must still bind its socket.
 
@@ -691,6 +715,12 @@ def test_an_unattended_pty_does_not_block_a_raw_bind_forever(monkeypatch):
     assert "No response at the terminal" in out.getvalue()
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
+             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+)
 def test_a_pty_someone_types_into_is_not_treated_as_unattended(monkeypatch):
     """The deadline is on the FIRST keystroke only, and a real one clears it."""
     import io
@@ -816,3 +846,17 @@ def test_the_marker_never_silences_a_tunnel_launch(monkeypatch):
     monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", lambda **_kw: False)
 
     assert run._terminal_password_gate(tunnel_will_start = True, **_GATE_KWARGS) == (False, False)
+
+
+def test_windows_has_no_terminal_ownership_to_lose(monkeypatch):
+    """The Windows half of the tests skipped above, and it runs everywhere.
+
+    `_prompt_owns_the_terminal` exists to catch a backgrounded POSIX job, where
+    driving the terminal raises SIGTTOU and stops the process. Windows has no
+    process groups and no `os.tcgetpgrp`, so the call raises AttributeError and
+    the answer must be True: there is nothing there that can stop us, so the
+    isatty verdict stands and an interactive Windows launch still prompts. A
+    False would silently drop the prompt on every Windows terminal.
+    """
+    monkeypatch.delattr(run.os, "tcgetpgrp", raising = False)
+    assert run._prompt_owns_the_terminal() is True

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -755,3 +755,44 @@ def test_the_gate_deadlines_a_raw_bind_prompt_and_never_the_tunnel(monkeypatch):
     _patch_seeded_admin(monkeypatch, requires_change = True)
     run._terminal_password_gate(tunnel_will_start = True, **_GATE_KWARGS)
     assert seen["first_key_timeout"] is None
+
+
+def test_a_refusal_does_not_promise_a_deadline_that_is_disabled(monkeypatch):
+    """With TIMEOUT=0 nothing will shut this instance down; do not say otherwise.
+
+    The refusal path proceeds on purpose, because the launch worked before the
+    prompt existed. What it must not do is tell the operator a deadline will
+    rescue them when `should_arm_bootstrap_timeout` will not arm one: that is the
+    single sentence they would act on.
+    """
+    monkeypatch.setenv("UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT", "0")
+    stderr = _patch_streams(monkeypatch, tty = True)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+
+    from auth import terminal_prompt
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change",
+                        lambda **_kw: False)
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, **_RAW_BIND_KWARGS
+    ) == (True, False)
+    err = stderr.getvalue()
+    assert "DISABLED for this launch" in err, err
+    assert "shuts down after the bootstrap deadline" not in err, err
+
+
+def test_a_refusal_still_names_the_deadline_when_one_will_arm(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT", raising = False)
+    stderr = _patch_streams(monkeypatch, tty = True)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+
+    from auth import terminal_prompt
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change",
+                        lambda **_kw: False)
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, **_RAW_BIND_KWARGS
+    ) == (True, False)
+    err = stderr.getvalue()
+    assert "shuts down after the bootstrap deadline" in err, err
+    assert "DISABLED" not in err, err

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -428,10 +428,10 @@ _RAW_BIND_KWARGS = dict(
 def test_a_headless_raw_bind_is_byte_for_byte_unchanged(monkeypatch):
     """The compatibility promise of this change.
 
-    Headless `-H 0.0.0.0` is the long-running container case. It must still
-    proceed, still keep serving the bootstrap credential, and above all must not
-    reach the strip-and-refuse handling that a public tunnel launch uses; that
-    would delete the .bootstrap_password such deployments are logged into with.
+    Headless `-H 0.0.0.0` is the long-running container case: it must still
+    proceed, keep serving the bootstrap credential, and above all not reach the
+    strip-and-refuse handling a public tunnel launch uses, which would delete the
+    .bootstrap_password such deployments are logged into with.
     """
     _patch_streams(monkeypatch, tty = False)
     _patch_seeded_admin(monkeypatch, requires_change = True)
@@ -441,12 +441,11 @@ def test_a_headless_raw_bind_is_byte_for_byte_unchanged(monkeypatch):
 def test_a_headless_raw_bind_does_not_open_auth_storage(monkeypatch):
     """ "Unchanged" has to mean it does not touch the database either.
 
-    Before this gate learned about non-tunnel exposure, a headless raw bind
-    returned at `if not tunnel_will_start` without importing auth storage. If it
-    now calls ensure_default_admin() first, first seeding moves earlier and the
-    SQLite file is opened sooner, which gives a read-only or locked STUDIO_HOME a
-    brand new place to fail on a launch that used to work. So the promptability
-    decision has to happen before storage is consulted.
+    A headless raw bind used to return at `if not tunnel_will_start` without
+    importing auth storage. Calling ensure_default_admin() first would move
+    seeding earlier and open the SQLite file sooner, giving a read-only or locked
+    STUDIO_HOME a new place to fail on a launch that used to work, so
+    promptability must be decided before storage is consulted.
     """
     _patch_streams(monkeypatch, tty = False)
 
@@ -469,9 +468,8 @@ def test_refusing_the_prompt_on_a_raw_bind_still_launches(monkeypatch):
 
     `docker/studio_run.sh` execs `unsloth studio -H 0.0.0.0` and only supplies a
     password when the initial-password file is non-empty, so a fresh
-    `docker run -it` meets this prompt. Aborting there would stop a container
-    that starts today. The launch proceeds at the protection level it already
-    had, which is the bootstrap deadline.
+    `docker run -it` meets this prompt and aborting would stop a container that
+    starts today. It proceeds on the bootstrap deadline it already had.
     """
     _patch_streams(monkeypatch, tty = True)
     _patch_seeded_admin(monkeypatch, requires_change = True)
@@ -484,8 +482,7 @@ def test_refusing_the_prompt_on_a_raw_bind_still_launches(monkeypatch):
         lambda **_kw: False,  # Ctrl+C / EOF
     )
 
-    # proceed = True, and the bootstrap credential keeps being injected exactly
-    # as it was before this prompt existed.
+    # proceed = True, and the bootstrap credential is still injected as before.
     assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
 
 
@@ -587,11 +584,10 @@ def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
     """`unsloth studio -H 0.0.0.0 &` must still launch.
 
     A background job inherits the terminal, so isatty() is True on both streams,
-    but the masked prompt calls termios.tcsetattr; POSIX sends SIGTTOU to a
-    background process group that does, and the default action STOPS the process.
-    The launch would freeze before the socket binds, so it takes the headless
-    path it took before this gate learned about non-tunnel exposure: proceed,
-    protected by the bootstrap deadline, without consulting auth storage.
+    but the masked prompt calls termios.tcsetattr; POSIX SIGTTOUs a background
+    process group that does, and the default action STOPS the process. The launch
+    would freeze before the socket binds, so it takes the old headless path:
+    proceed on the bootstrap deadline, without consulting auth storage.
     """
     monkeypatch.setattr(sys, "stdin", _FdStream())
     monkeypatch.setattr(sys, "stderr", _FdStream())
@@ -615,8 +611,8 @@ def test_a_backgrounded_tunnel_launch_still_fails_closed(monkeypatch):
     _patch_seeded_admin(monkeypatch, requires_change = True)
     monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", lambda **_kw: False)
 
-    # The process group check is scoped to the raw-bind branch, so a tunnel
-    # launch still reaches the prompt and still aborts when it is refused.
+    # The process group check is scoped to the raw-bind branch, so a tunnel still
+    # reaches the prompt and still aborts when it is refused.
     assert run._prompt_owns_the_terminal() is False
     assert run._terminal_password_gate(tunnel_will_start = True, **_GATE_KWARGS) == (False, False)
 
@@ -667,11 +663,10 @@ class _PtyStdin:
 def test_an_unattended_pty_does_not_block_a_raw_bind_forever(monkeypatch):
     """`tmux new -d 'unsloth studio -H 0.0.0.0'` must still bind its socket.
 
-    A detached pty is a real, foreground terminal that nobody will ever type
-    into: isatty() is True on both streams and the process owns the terminal, so
-    every interactivity test says "prompt". The read then never returns, and
-    because the gate runs BEFORE uvicorn binds, the launch hangs forever instead
-    of starting - a launch that worked before this gate widened to raw binds.
+    A detached pty is a real, foreground terminal nobody will ever type into:
+    isatty() is True on both streams and the process owns the terminal, so every
+    interactivity test says "prompt". The read never returns, and the gate runs
+    BEFORE uvicorn binds, so the launch hangs forever instead of starting.
     """
     import io
     import pty
@@ -680,7 +675,7 @@ def test_an_unattended_pty_does_not_block_a_raw_bind_forever(monkeypatch):
     try:
         monkeypatch.setattr(sys, "stdin", _PtyStdin(slave))
         out = io.StringIO()
-        # Nothing is ever written to `master`: the pty exists, the human does not.
+        # Nothing is written to `master`: the pty exists, the human does not.
         changed = terminal_prompt.prompt_for_password_change(
             min_length = 8,
             is_current_password = lambda _c: False,
@@ -751,10 +746,10 @@ def test_the_gate_deadlines_a_raw_bind_prompt_and_never_the_tunnel(monkeypatch):
 def test_a_refusal_does_not_promise_a_deadline_that_is_disabled(monkeypatch):
     """With TIMEOUT=0 nothing will shut this instance down; do not say otherwise.
 
-    The refusal path proceeds on purpose, because the launch worked before the
-    prompt existed. What it must not do is tell the operator a deadline will
-    rescue them when `should_arm_bootstrap_timeout` will not arm one: that is the
-    single sentence they would act on.
+    The refusal path proceeds on purpose (the launch worked before the prompt
+    existed), but must not tell the operator a deadline will rescue them when
+    `should_arm_bootstrap_timeout` will not arm one: that is the single sentence
+    they would act on.
     """
     monkeypatch.setenv("UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT", "0")
     stderr = _patch_streams(monkeypatch, tty = True)
@@ -789,9 +784,9 @@ def test_the_child_does_not_repeat_a_prompt_the_parent_already_gave_up_on(monkey
     """A 30s fallback must not become 60s across the re-exec.
 
     The CLI parent holds the terminal for its deadline, gets nothing, warns and
-    launches. The child gate then sees the SAME unattended pty. Without a handoff
-    it waits the whole deadline again, and on the `studio run` path a third time,
-    which is exactly the startup stall the 30s value was chosen to stay under.
+    launches. The child gate then sees the SAME unattended pty; without a handoff
+    it waits the whole deadline again, and a third time on the `studio run` path,
+    which is the startup stall the 30s value was chosen to stay under.
     """
     monkeypatch.setenv("UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE", "1")
     _patch_streams(monkeypatch, tty = True)
@@ -804,8 +799,7 @@ def test_the_child_does_not_repeat_a_prompt_the_parent_already_gave_up_on(monkey
     monkeypatch.setattr(_storage, "ensure_default_admin", _boom)
 
     assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
-    # Consumed, so a later launch from the same environment is not silently
-    # stripped of its own prompt.
+    # Consumed, so a later launch from the same environment keeps its own prompt.
     import os as _os
 
     assert _os.environ.get("UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE") is None

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -438,7 +438,7 @@ def test_a_headless_raw_bind_is_byte_for_byte_unchanged(monkeypatch):
 
 
 def test_a_headless_raw_bind_does_not_open_auth_storage(monkeypatch):
-    """"Unchanged" has to mean it does not touch the database either.
+    """ "Unchanged" has to mean it does not touch the database either.
 
     Before this gate learned about non-tunnel exposure, a headless raw bind
     returned at `if not tunnel_will_start` without importing auth storage. If it
@@ -456,12 +456,11 @@ def test_a_headless_raw_bind_does_not_open_auth_storage(monkeypatch):
         )
 
     from auth import storage as _storage
+
     monkeypatch.setattr(_storage, "ensure_default_admin", _boom)
     monkeypatch.setattr(_storage, "requires_password_change", _boom)
 
-    assert run._terminal_password_gate(
-        tunnel_will_start = False, **_RAW_BIND_KWARGS
-    ) == (True, False)
+    assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
 
 
 def test_refusing_the_prompt_on_a_raw_bind_still_launches(monkeypatch):
@@ -477,16 +476,16 @@ def test_refusing_the_prompt_on_a_raw_bind_still_launches(monkeypatch):
     _patch_seeded_admin(monkeypatch, requires_change = True)
 
     from auth import terminal_prompt
+
     monkeypatch.setattr(
-        terminal_prompt, "prompt_for_password_change",
-        lambda **_kw: False,          # Ctrl+C / EOF
+        terminal_prompt,
+        "prompt_for_password_change",
+        lambda **_kw: False,  # Ctrl+C / EOF
     )
 
     # proceed = True, and the bootstrap credential keeps being injected exactly
     # as it was before this prompt existed.
-    assert run._terminal_password_gate(
-        tunnel_will_start = False, **_RAW_BIND_KWARGS
-    ) == (True, False)
+    assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
 
 
 def test_refusing_the_prompt_on_a_tunnel_still_aborts(monkeypatch):
@@ -495,13 +494,10 @@ def test_refusing_the_prompt_on_a_tunnel_still_aborts(monkeypatch):
     _patch_seeded_admin(monkeypatch, requires_change = True)
 
     from auth import terminal_prompt
-    monkeypatch.setattr(
-        terminal_prompt, "prompt_for_password_change", lambda **_kw: False
-    )
 
-    assert run._terminal_password_gate(
-        tunnel_will_start = True, **_GATE_KWARGS
-    ) == (False, False)
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", lambda **_kw: False)
+
+    assert run._terminal_password_gate(tunnel_will_start = True, **_GATE_KWARGS) == (False, False)
 
 
 def test_a_raw_bind_with_a_terminal_reaches_the_prompt(monkeypatch):

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -437,6 +437,73 @@ def test_a_headless_raw_bind_is_byte_for_byte_unchanged(monkeypatch):
     assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
 
 
+def test_a_headless_raw_bind_does_not_open_auth_storage(monkeypatch):
+    """"Unchanged" has to mean it does not touch the database either.
+
+    Before this gate learned about non-tunnel exposure, a headless raw bind
+    returned at `if not tunnel_will_start` without importing auth storage. If it
+    now calls ensure_default_admin() first, first seeding moves earlier and the
+    SQLite file is opened sooner, which gives a read-only or locked STUDIO_HOME a
+    brand new place to fail on a launch that used to work. So the promptability
+    decision has to happen before storage is consulted.
+    """
+    _patch_streams(monkeypatch, tty = False)
+
+    def _boom(*_a, **_k):
+        raise AssertionError(
+            "auth storage was opened on a headless raw bind; the gate must "
+            "decide it cannot prompt before touching the database"
+        )
+
+    from auth import storage as _storage
+    monkeypatch.setattr(_storage, "ensure_default_admin", _boom)
+    monkeypatch.setattr(_storage, "requires_password_change", _boom)
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, **_RAW_BIND_KWARGS
+    ) == (True, False)
+
+
+def test_refusing_the_prompt_on_a_raw_bind_still_launches(monkeypatch):
+    """Ctrl+C must not turn a working launch into no Studio.
+
+    `docker/studio_run.sh` execs `unsloth studio -H 0.0.0.0` and only supplies a
+    password when the initial-password file is non-empty, so a fresh
+    `docker run -it` meets this prompt. Aborting there would stop a container
+    that starts today. The launch proceeds at the protection level it already
+    had, which is the bootstrap deadline.
+    """
+    _patch_streams(monkeypatch, tty = True)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+
+    from auth import terminal_prompt
+    monkeypatch.setattr(
+        terminal_prompt, "prompt_for_password_change",
+        lambda **_kw: False,          # Ctrl+C / EOF
+    )
+
+    # proceed = True, and the bootstrap credential keeps being injected exactly
+    # as it was before this prompt existed.
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, **_RAW_BIND_KWARGS
+    ) == (True, False)
+
+
+def test_refusing_the_prompt_on_a_tunnel_still_aborts(monkeypatch):
+    """The tunnel case is unchanged: refusing to secure a public URL fails closed."""
+    _patch_streams(monkeypatch, tty = True)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+
+    from auth import terminal_prompt
+    monkeypatch.setattr(
+        terminal_prompt, "prompt_for_password_change", lambda **_kw: False
+    )
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = True, **_GATE_KWARGS
+    ) == (False, False)
+
+
 def test_a_raw_bind_with_a_terminal_reaches_the_prompt(monkeypatch):
     """The fix. Before this, `if not tunnel_will_start` returned first."""
     _patch_streams(monkeypatch, tty = True)

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -434,9 +434,7 @@ def test_a_headless_raw_bind_is_byte_for_byte_unchanged(monkeypatch):
     """
     _patch_streams(monkeypatch, tty = False)
     _patch_seeded_admin(monkeypatch, requires_change = True)
-    assert run._terminal_password_gate(
-        tunnel_will_start = False, **_RAW_BIND_KWARGS
-    ) == (True, False)
+    assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
 
 
 def test_a_raw_bind_with_a_terminal_reaches_the_prompt(monkeypatch):
@@ -452,22 +450,23 @@ def test_a_raw_bind_with_a_terminal_reaches_the_prompt(monkeypatch):
         return True
 
     from auth import terminal_prompt
+
     monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", _fake_prompt)
 
-    assert run._terminal_password_gate(
-        tunnel_will_start = False, **_RAW_BIND_KWARGS
-    ) == (True, True)
+    assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, True)
     # And it must not tell a LAN operator they are on the public internet.
     assert seen.get("exposure") == "on every network interface"
 
 
 def test_a_loopback_launch_still_short_circuits(monkeypatch):
     """Plain `unsloth studio` must not consult storage at all."""
+
     def _boom(*_a, **_k):
         raise AssertionError("storage must not be consulted for a loopback launch")
 
     monkeypatch.setattr(run, "_stream_isatty", lambda _s: True)
     from auth import storage as _storage
+
     monkeypatch.setattr(_storage, "ensure_default_admin", _boom)
 
     assert run._terminal_password_gate(
@@ -481,18 +480,27 @@ def test_a_loopback_launch_still_short_circuits(monkeypatch):
 
 def test_api_only_and_colab_raw_binds_do_not_prompt(monkeypatch):
     """Scoped like the bootstrap deadline: web UI only, never api-only or Colab."""
+
     def _boom(*_a, **_k):
         raise AssertionError("storage must not be consulted")
 
     monkeypatch.setattr(run, "_stream_isatty", lambda _s: True)
     from auth import storage as _storage
+
     monkeypatch.setattr(_storage, "ensure_default_admin", _boom)
 
     assert run._terminal_password_gate(
-        tunnel_will_start = False, host = "0.0.0.0", secure = False,
-        api_only = True, frontend_served = True,
+        tunnel_will_start = False,
+        host = "0.0.0.0",
+        secure = False,
+        api_only = True,
+        frontend_served = True,
     ) == (True, False)
     assert run._terminal_password_gate(
-        tunnel_will_start = False, host = "0.0.0.0", secure = False,
-        api_only = False, frontend_served = True, is_colab = True,
+        tunnel_will_start = False,
+        host = "0.0.0.0",
+        secure = False,
+        api_only = False,
+        frontend_served = True,
+        is_colab = True,
     ) == (True, False)

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -783,3 +783,44 @@ def test_a_refusal_still_names_the_deadline_when_one_will_arm(monkeypatch):
     err = stderr.getvalue()
     assert "shuts down after the bootstrap deadline" in err, err
     assert "DISABLED" not in err, err
+
+
+def test_the_child_does_not_repeat_a_prompt_the_parent_already_gave_up_on(monkeypatch):
+    """A 30s fallback must not become 60s across the re-exec.
+
+    The CLI parent holds the terminal for its deadline, gets nothing, warns and
+    launches. The child gate then sees the SAME unattended pty. Without a handoff
+    it waits the whole deadline again, and on the `studio run` path a third time,
+    which is exactly the startup stall the 30s value was chosen to stay under.
+    """
+    monkeypatch.setenv("UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE", "1")
+    _patch_streams(monkeypatch, tty = True)
+
+    def _boom(*_a, **_k):
+        raise AssertionError("the child prompted again after the parent gave up")
+
+    from auth import storage as _storage
+    monkeypatch.setattr(_storage, "ensure_default_admin", _boom)
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = False, **_RAW_BIND_KWARGS
+    ) == (True, False)
+    # Consumed, so a later launch from the same environment is not silently
+    # stripped of its own prompt.
+    import os as _os
+    assert _os.environ.get("UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE") is None
+
+
+def test_the_marker_never_silences_a_tunnel_launch(monkeypatch):
+    """A public URL fails closed regardless of what the parent did."""
+    monkeypatch.setenv("UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE", "1")
+    _patch_streams(monkeypatch, tty = True)
+    _patch_seeded_admin(monkeypatch, requires_change = True)
+
+    from auth import terminal_prompt
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change",
+                        lambda **_kw: False)
+
+    assert run._terminal_password_gate(
+        tunnel_will_start = True, **_GATE_KWARGS
+    ) == (False, False)

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -603,9 +603,7 @@ def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
 
     monkeypatch.setattr(auth_storage, "ensure_default_admin", _boom)
 
-    assert run._terminal_password_gate(
-        tunnel_will_start = False, **_RAW_BIND_KWARGS
-    ) == (True, False)
+    assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
 
 
 def test_a_backgrounded_tunnel_launch_still_fails_closed(monkeypatch):
@@ -615,16 +613,12 @@ def test_a_backgrounded_tunnel_launch_still_fails_closed(monkeypatch):
     monkeypatch.setattr(run.os, "tcgetpgrp", lambda _fd: 4242)
     monkeypatch.setattr(run.os, "getpgrp", lambda: 99)
     _patch_seeded_admin(monkeypatch, requires_change = True)
-    monkeypatch.setattr(
-        terminal_prompt, "prompt_for_password_change", lambda **_kw: False
-    )
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", lambda **_kw: False)
 
     # The process group check is scoped to the raw-bind branch, so a tunnel
     # launch still reaches the prompt and still aborts when it is refused.
     assert run._prompt_owns_the_terminal() is False
-    assert run._terminal_password_gate(
-        tunnel_will_start = True, **_GATE_KWARGS
-    ) == (False, False)
+    assert run._terminal_password_gate(tunnel_will_start = True, **_GATE_KWARGS) == (False, False)
 
 
 def test_a_foreground_raw_bind_still_reaches_the_prompt(monkeypatch):
@@ -634,18 +628,15 @@ def test_a_foreground_raw_bind_still_reaches_the_prompt(monkeypatch):
     monkeypatch.setattr(run.os, "tcgetpgrp", lambda _fd: 4242)
     monkeypatch.setattr(run.os, "getpgrp", lambda: 4242)
     _patch_seeded_admin(monkeypatch, requires_change = True)
-    monkeypatch.setattr(
-        terminal_prompt, "prompt_for_password_change", lambda **_kw: True
-    )
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", lambda **_kw: True)
 
-    assert run._terminal_password_gate(
-        tunnel_will_start = False, **_RAW_BIND_KWARGS
-    ) == (True, True)
+    assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, True)
 
 
 def test_no_job_control_falls_back_to_the_isatty_answer(monkeypatch):
     """Windows / no controlling terminal: nothing can stop us, so still prompt."""
     for exc in (OSError("ENOTTY"), AttributeError(), ValueError()):
+
         def _boom(_fd, _exc = exc):
             raise _exc
 
@@ -770,12 +761,10 @@ def test_a_refusal_does_not_promise_a_deadline_that_is_disabled(monkeypatch):
     _patch_seeded_admin(monkeypatch, requires_change = True)
 
     from auth import terminal_prompt
-    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change",
-                        lambda **_kw: False)
 
-    assert run._terminal_password_gate(
-        tunnel_will_start = False, **_RAW_BIND_KWARGS
-    ) == (True, False)
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", lambda **_kw: False)
+
+    assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
     err = stderr.getvalue()
     assert "DISABLED for this launch" in err, err
     assert "shuts down after the bootstrap deadline" not in err, err
@@ -787,12 +776,10 @@ def test_a_refusal_still_names_the_deadline_when_one_will_arm(monkeypatch):
     _patch_seeded_admin(monkeypatch, requires_change = True)
 
     from auth import terminal_prompt
-    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change",
-                        lambda **_kw: False)
 
-    assert run._terminal_password_gate(
-        tunnel_will_start = False, **_RAW_BIND_KWARGS
-    ) == (True, False)
+    monkeypatch.setattr(terminal_prompt, "prompt_for_password_change", lambda **_kw: False)
+
+    assert run._terminal_password_gate(tunnel_will_start = False, **_RAW_BIND_KWARGS) == (True, False)
     err = stderr.getvalue()
     assert "shuts down after the bootstrap deadline" in err, err
     assert "DISABLED" not in err, err

--- a/studio/backend/tests/test_wildcard_prompt_compatibility.py
+++ b/studio/backend/tests/test_wildcard_prompt_compatibility.py
@@ -54,8 +54,12 @@ def test_the_windows_getch_path_decodes_a_password(monkeypatch):
 
     class _Out:
         encoding = "utf-8"
-        def write(self, s): out.append(s)
-        def flush(self): pass
+
+        def write(self, s):
+            out.append(s)
+
+        def flush(self):
+            pass
 
     assert terminal_prompt._read_password("pw: ", out = _Out()) == "pw1"
     # The arrow key is swallowed, not masked, so exactly one star per character.
@@ -63,8 +67,11 @@ def test_the_windows_getch_path_decodes_a_password(monkeypatch):
 
 
 class _NullCtx:
-    def __enter__(self): return self
-    def __exit__(self, *exc): return False
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
 
 
 def test_a_stream_with_no_fileno_is_not_interactive():
@@ -74,9 +81,13 @@ def test_a_stream_with_no_fileno_is_not_interactive():
     helpers treat a broken stream as non-interactive, so such a launch takes the
     headless path rather than crashing.
     """
+
     class _Broken:
-        def isatty(self): raise ValueError("I/O operation on closed file")
-        def fileno(self): raise OSError("no console")
+        def isatty(self):
+            raise ValueError("I/O operation on closed file")
+
+        def fileno(self):
+            raise OSError("no console")
 
     import run as run_mod
 
@@ -87,10 +98,16 @@ def test_a_stream_with_no_fileno_is_not_interactive():
 @pytest.mark.parametrize("stdin_tty,stderr_tty", [(True, False), (False, True), (False, False)])
 def test_a_split_terminal_never_prompts(stdin_tty, stderr_tty):
     """Masked echo needs stderr; reading needs stdin. Half a terminal is none."""
-    assert terminal_prompt.should_prompt_password_change(
-        tunnel_will_start = False, bind_is_exposed = True, requires_change = True,
-        stdin_isatty = stdin_tty, stderr_isatty = stderr_tty,
-    ) is False
+    assert (
+        terminal_prompt.should_prompt_password_change(
+            tunnel_will_start = False,
+            bind_is_exposed = True,
+            requires_change = True,
+            stdin_isatty = stdin_tty,
+            stderr_isatty = stderr_tty,
+        )
+        is False
+    )
 
 
 # ── old installs ─────────────────────────────────────────────────────
@@ -102,14 +119,24 @@ def test_an_old_caller_that_omits_bind_is_exposed_behaves_as_before():
     A studio venv can hold an older backend than the CLI that launched it, so a
     caller predating this change must keep tunnel-only semantics.
     """
-    assert terminal_prompt.should_prompt_password_change(
-        tunnel_will_start = False, requires_change = True,
-        stdin_isatty = True, stderr_isatty = True,
-    ) is False
-    assert terminal_prompt.should_prompt_password_change(
-        tunnel_will_start = True, requires_change = True,
-        stdin_isatty = True, stderr_isatty = True,
-    ) is True
+    assert (
+        terminal_prompt.should_prompt_password_change(
+            tunnel_will_start = False,
+            requires_change = True,
+            stdin_isatty = True,
+            stderr_isatty = True,
+        )
+        is False
+    )
+    assert (
+        terminal_prompt.should_prompt_password_change(
+            tunnel_will_start = True,
+            requires_change = True,
+            stdin_isatty = True,
+            stderr_isatty = True,
+        )
+        is True
+    )
 
 
 def test_the_prompt_signature_stays_keyword_compatible():
@@ -142,10 +169,13 @@ def test_the_password_gate_imports_no_gpu_or_torch_module():
     )
     out = subprocess.run(
         [sys.executable, "-c", probe],
-        capture_output = True, text = True, timeout = 300,
-        cwd = str(_BACKEND), env = {**os.environ, "PYTHONPATH": str(_BACKEND)},
+        capture_output = True,
+        text = True,
+        timeout = 300,
+        cwd = str(_BACKEND),
+        env = {**os.environ, "PYTHONPATH": str(_BACKEND)},
     )
     assert out.returncode == 0, out.stderr
-    assert out.stdout.strip() == "", (
-        f"the password gate pulled in hardware modules: {out.stdout.strip()}"
-    )
+    assert (
+        out.stdout.strip() == ""
+    ), f"the password gate pulled in hardware modules: {out.stdout.strip()}"

--- a/studio/backend/tests/test_wildcard_prompt_compatibility.py
+++ b/studio/backend/tests/test_wildcard_prompt_compatibility.py
@@ -4,9 +4,8 @@
 """Compatibility surface of the raw-bind password prompt.
 
 The prompt itself is covered by test_password_prompt.py and the gate wiring by
-test_password_prompt_backstop.py. This file covers the things that only break
-somewhere else: other platforms, old installs, and the claim that none of this
-touches hardware.
+test_password_prompt_backstop.py. This file covers what only breaks somewhere
+else: other platforms, old installs, and the no-hardware-coupling claim.
 """
 
 from __future__ import annotations
@@ -31,9 +30,9 @@ from auth import terminal_prompt  # noqa: E402
 def test_the_windows_getch_path_decodes_a_password(monkeypatch):
     """`_getch` is selected by os.name at import; exercise the Windows half.
 
-    This box is Linux, so the msvcrt branch is otherwise never executed. A stub
-    stands in for the module so the two-wchar arrow-key sequence and ordinary
-    characters both go through the real handler.
+    CI is Linux, so the msvcrt branch is otherwise never executed. A stub module
+    puts the two-wchar arrow-key sequence and ordinary characters through the
+    real handler.
     """
     import types
 
@@ -62,7 +61,7 @@ def test_the_windows_getch_path_decodes_a_password(monkeypatch):
             pass
 
     assert terminal_prompt._read_password("pw: ", out = _Out()) == "pw1"
-    # The arrow key is swallowed, not masked, so exactly one star per character.
+    # The arrow key is swallowed, not masked: one star per character.
     assert "".join(out).count("*") == 3
 
 
@@ -77,9 +76,8 @@ class _NullCtx:
 def test_a_stream_with_no_fileno_is_not_interactive():
     """pythonw / a Windows service has no console; isatty must not raise.
 
-    _prompt_raw_mode swallows the resulting error, and the gate's own isatty
-    helpers treat a broken stream as non-interactive, so such a launch takes the
-    headless path rather than crashing.
+    The gate's isatty helpers treat a broken stream as non-interactive, so such a
+    launch takes the headless path rather than crashing.
     """
 
     class _Broken:
@@ -114,7 +112,7 @@ def test_a_split_terminal_never_prompts(stdin_tty, stderr_tty):
 
 
 def test_an_old_caller_that_omits_bind_is_exposed_behaves_as_before():
-    """Forwards compatibility: the new kwarg is optional and defaults off.
+    """The new kwarg is optional and defaults off.
 
     A studio venv can hold an older backend than the CLI that launched it, so a
     caller predating this change must keep tunnel-only semantics.
@@ -153,11 +151,11 @@ def test_the_prompt_signature_stays_keyword_compatible():
 
 
 def test_the_password_gate_imports_no_gpu_or_torch_module():
-    """The claim that this change is hardware-independent, checked not asserted.
+    """The hardware-independence claim, checked not asserted.
 
-    Run in a subprocess: importing torch in THIS interpreter would poison the
-    rest of the session, and a sys.modules probe after the fact proves nothing
-    about what the import graph actually pulls in.
+    In a subprocess: importing torch in THIS interpreter would poison the rest of
+    the session, and a sys.modules probe after the fact proves nothing about what
+    the import graph pulls in.
     """
     probe = (
         "import sys;"

--- a/studio/backend/tests/test_wildcard_prompt_compatibility.py
+++ b/studio/backend/tests/test_wildcard_prompt_compatibility.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Compatibility surface of the raw-bind password prompt.
+
+The prompt itself is covered by test_password_prompt.py and the gate wiring by
+test_password_prompt_backstop.py. This file covers the things that only break
+somewhere else: other platforms, old installs, and the claim that none of this
+touches hardware.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[1]
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from auth import terminal_prompt  # noqa: E402
+
+
+# ── platform seams ───────────────────────────────────────────────────
+
+
+def test_the_windows_getch_path_decodes_a_password(monkeypatch):
+    """`_getch` is selected by os.name at import; exercise the Windows half.
+
+    This box is Linux, so the msvcrt branch is otherwise never executed. A stub
+    stands in for the module so the two-wchar arrow-key sequence and ordinary
+    characters both go through the real handler.
+    """
+    import types
+
+    keys = list("pw1\r")
+    fake = types.ModuleType("msvcrt")
+    # An arrow key arrives as \xe0 then a second wchar that must be swallowed.
+    queue = ["\xe0", "H"] + keys
+
+    def _getwch():
+        return queue.pop(0)
+
+    fake.getwch = _getwch
+    monkeypatch.setitem(sys.modules, "msvcrt", fake)
+
+    out = []
+    monkeypatch.setattr(terminal_prompt, "_getch", terminal_prompt._getch_windows)
+    monkeypatch.setattr(terminal_prompt, "_prompt_raw_mode", lambda: _NullCtx())
+
+    class _Out:
+        encoding = "utf-8"
+        def write(self, s): out.append(s)
+        def flush(self): pass
+
+    assert terminal_prompt._read_password("pw: ", out = _Out()) == "pw1"
+    # The arrow key is swallowed, not masked, so exactly one star per character.
+    assert "".join(out).count("*") == 3
+
+
+class _NullCtx:
+    def __enter__(self): return self
+    def __exit__(self, *exc): return False
+
+
+def test_a_stream_with_no_fileno_is_not_interactive():
+    """pythonw / a Windows service has no console; isatty must not raise.
+
+    _prompt_raw_mode swallows the resulting error, and the gate's own isatty
+    helpers treat a broken stream as non-interactive, so such a launch takes the
+    headless path rather than crashing.
+    """
+    class _Broken:
+        def isatty(self): raise ValueError("I/O operation on closed file")
+        def fileno(self): raise OSError("no console")
+
+    import run as run_mod
+
+    assert run_mod._stream_isatty(_Broken()) is False
+    assert run_mod._stream_isatty(None) is False
+
+
+@pytest.mark.parametrize("stdin_tty,stderr_tty", [(True, False), (False, True), (False, False)])
+def test_a_split_terminal_never_prompts(stdin_tty, stderr_tty):
+    """Masked echo needs stderr; reading needs stdin. Half a terminal is none."""
+    assert terminal_prompt.should_prompt_password_change(
+        tunnel_will_start = False, bind_is_exposed = True, requires_change = True,
+        stdin_isatty = stdin_tty, stderr_isatty = stderr_tty,
+    ) is False
+
+
+# ── old installs ─────────────────────────────────────────────────────
+
+
+def test_an_old_caller_that_omits_bind_is_exposed_behaves_as_before():
+    """Forwards compatibility: the new kwarg is optional and defaults off.
+
+    A studio venv can hold an older backend than the CLI that launched it, so a
+    caller predating this change must keep tunnel-only semantics.
+    """
+    assert terminal_prompt.should_prompt_password_change(
+        tunnel_will_start = False, requires_change = True,
+        stdin_isatty = True, stderr_isatty = True,
+    ) is False
+    assert terminal_prompt.should_prompt_password_change(
+        tunnel_will_start = True, requires_change = True,
+        stdin_isatty = True, stderr_isatty = True,
+    ) is True
+
+
+def test_the_prompt_signature_stays_keyword_compatible():
+    """`exposure` must be optional; an older caller passes neither it nor more."""
+    import inspect
+
+    params = inspect.signature(terminal_prompt.prompt_for_password_change).parameters
+    assert params["exposure"].default == "on the public internet"
+    for name, param in params.items():
+        assert param.kind is not inspect.Parameter.POSITIONAL_ONLY, name
+
+
+# ── no hardware coupling ─────────────────────────────────────────────
+
+
+def test_the_password_gate_imports_no_gpu_or_torch_module():
+    """The claim that this change is hardware-independent, checked not asserted.
+
+    Run in a subprocess: importing torch in THIS interpreter would poison the
+    rest of the session, and a sys.modules probe after the fact proves nothing
+    about what the import graph actually pulls in.
+    """
+    probe = (
+        "import sys;"
+        f"sys.path.insert(0, {str(_BACKEND)!r});"
+        "import auth.terminal_prompt, auth.bootstrap_timeout, utils.host_policy;"
+        "bad = sorted(m for m in sys.modules"
+        " if m.split('.')[0] in ('torch','triton','bitsandbytes','pynvml','amdsmi'));"
+        "print(','.join(bad))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output = True, text = True, timeout = 300,
+        cwd = str(_BACKEND), env = {**os.environ, "PYTHONPATH": str(_BACKEND)},
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "", (
+        f"the password gate pulled in hardware modules: {out.stdout.strip()}"
+    )

--- a/unsloth_cli/commands/_password_prompt.py
+++ b/unsloth_cli/commands/_password_prompt.py
@@ -110,7 +110,11 @@ class _RestoreTtyOnSignals:
                 pass
 
 
-def _read_masked_posix(prompt: str, out: TextIO, first_key_timeout: "float | None" = None) -> str:
+def _read_masked_posix(
+    prompt: str,
+    out: TextIO,
+    first_key_timeout: "float | None" = None,
+) -> str:
     import codecs
     import termios
     import tty
@@ -169,7 +173,11 @@ def _read_masked_posix(prompt: str, out: TextIO, first_key_timeout: "float | Non
     return "".join(chars)
 
 
-def _read_masked_windows(prompt: str, out: TextIO, first_key_timeout: "float | None" = None) -> str:
+def _read_masked_windows(
+    prompt: str,
+    out: TextIO,
+    first_key_timeout: "float | None" = None,
+) -> str:
     import msvcrt
 
     out.write(prompt)
@@ -209,7 +217,10 @@ def _read_masked_windows(prompt: str, out: TextIO, first_key_timeout: "float | N
 
 
 def read_masked(
-    prompt: str, out: TextIO | None = None, *, first_key_timeout: "float | None" = None
+    prompt: str,
+    out: TextIO | None = None,
+    *,
+    first_key_timeout: "float | None" = None,
 ) -> str:
     """Read one line with ``*`` echo. Raises KeyboardInterrupt on Ctrl-C and
     EOFError on Ctrl-D/Ctrl-Z at an empty prompt, and PromptUnattended when

--- a/unsloth_cli/commands/_password_prompt.py
+++ b/unsloth_cli/commands/_password_prompt.py
@@ -31,20 +31,19 @@ _SUBMIT_CHARS = ("\r", "\n")
 class PromptUnattended(Exception):
     """A terminal is attached but nobody answered before the deadline.
 
-    A pty is not a person: ``tmux new -d``, ``screen -dmS`` and ``docker run -dt``
-    allocate a real, foreground pty nobody reads, so isatty() is True on both
-    streams and the read never returns. Callers that must not block a launch pass
-    a deadline and treat this as a refusal. Mirror of
-    studio/backend/auth/terminal_prompt.py -- keep the two in sync.
+    A pty is not a person: ``tmux new -d`` / ``docker run -dt`` allocate a real
+    foreground pty nobody reads, so isatty() is True on both streams and the read
+    never returns. Callers that must not block a launch treat this as a refusal.
+    Mirror of studio/backend/auth/terminal_prompt.py -- keep the two in sync.
     """
 
 
 def _wait_for_first_key(timeout: float) -> bool:
     """Whether a keystroke arrived within ``timeout`` seconds.
 
-    Must be called with the terminal already in cbreak mode: in canonical mode
-    the driver holds input until a newline, so the fd would not become readable
-    on the first character. True on any doubt, which is the blocking behaviour.
+    Requires cbreak mode already set: canonical mode holds input until a newline,
+    so the fd would not become readable on the first character. True on any doubt
+    (the blocking behaviour).
     """
     if os.name == "nt":
         import time
@@ -132,8 +131,8 @@ def _read_masked_posix(
             new_attrs = termios.tcgetattr(fd)
             new_attrs[3] &= ~termios.ISIG
             termios.tcsetattr(fd, termios.TCSADRAIN, new_attrs)
-            # Deadline the FIRST keystroke only: a detached pty is a terminal that
-            # nobody will ever type into, and blocking there never binds the socket.
+            # FIRST keystroke only: a detached pty is a terminal nobody will type
+            # into, and blocking there means the socket never binds.
             if first_key_timeout is not None and not _wait_for_first_key(first_key_timeout):
                 raise PromptUnattended
             # os.read + incremental decoder with errors="replace": text-mode read(1) can raise or yield a lone
@@ -246,7 +245,7 @@ def prompt_new_password(
 
     ``first_key_timeout`` bounds the wait for the FIRST keystroke and raises
     PromptUnattended if it never comes; once someone types there is no deadline.
-    Only a caller that must not block a launch passes it -- a detached pty
+    Only a caller that must not block a launch passes it: a detached pty
     (``tmux new -d``, ``docker run -dt``) is a terminal nobody will answer.
     """
     if out is None:

--- a/unsloth_cli/commands/_password_prompt.py
+++ b/unsloth_cli/commands/_password_prompt.py
@@ -28,6 +28,47 @@ _BACKSPACE_CHARS = ("\x7f", "\x08")
 _SUBMIT_CHARS = ("\r", "\n")
 
 
+class PromptUnattended(Exception):
+    """A terminal is attached but nobody answered before the deadline.
+
+    A pty is not a person: ``tmux new -d``, ``screen -dmS`` and ``docker run -dt``
+    allocate a real, foreground pty nobody reads, so isatty() is True on both
+    streams and the read never returns. Callers that must not block a launch pass
+    a deadline and treat this as a refusal. Mirror of
+    studio/backend/auth/terminal_prompt.py -- keep the two in sync.
+    """
+
+
+def _wait_for_first_key(timeout: float) -> bool:
+    """Whether a keystroke arrived within ``timeout`` seconds.
+
+    Must be called with the terminal already in cbreak mode: in canonical mode
+    the driver holds input until a newline, so the fd would not become readable
+    on the first character. True on any doubt, which is the blocking behaviour.
+    """
+    if os.name == "nt":
+        import time
+
+        try:
+            import msvcrt
+        except ImportError:
+            return True
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if msvcrt.kbhit():
+                return True
+            time.sleep(0.05)
+        return False
+    import select
+
+    try:
+        fd = sys.stdin.fileno()
+        ready, _, _ = select.select([fd], [], [], timeout)
+    except (AttributeError, OSError, ValueError):
+        return True
+    return bool(ready)
+
+
 class _RestoreTtyOnSignals:
     """Restore terminal attrs if SIGTERM/SIGHUP kills the prompt mid-read.
 
@@ -69,7 +110,7 @@ class _RestoreTtyOnSignals:
                 pass
 
 
-def _read_masked_posix(prompt: str, out: TextIO) -> str:
+def _read_masked_posix(prompt: str, out: TextIO, first_key_timeout: "float | None" = None) -> str:
     import codecs
     import termios
     import tty
@@ -87,6 +128,10 @@ def _read_masked_posix(prompt: str, out: TextIO) -> str:
             new_attrs = termios.tcgetattr(fd)
             new_attrs[3] &= ~termios.ISIG
             termios.tcsetattr(fd, termios.TCSADRAIN, new_attrs)
+            # Deadline the FIRST keystroke only: a detached pty is a terminal that
+            # nobody will ever type into, and blocking there never binds the socket.
+            if first_key_timeout is not None and not _wait_for_first_key(first_key_timeout):
+                raise PromptUnattended
             # os.read + incremental decoder with errors="replace": text-mode read(1) can raise or yield a lone
             # surrogate that later crashes pbkdf2.
             # It raises UnicodeDecodeError.
@@ -124,13 +169,15 @@ def _read_masked_posix(prompt: str, out: TextIO) -> str:
     return "".join(chars)
 
 
-def _read_masked_windows(prompt: str, out: TextIO) -> str:
+def _read_masked_windows(prompt: str, out: TextIO, first_key_timeout: "float | None" = None) -> str:
     import msvcrt
 
     out.write(prompt)
     out.flush()
     chars: list[str] = []
     try:
+        if first_key_timeout is not None and not _wait_for_first_key(first_key_timeout):
+            raise PromptUnattended
         while True:
             ch = msvcrt.getwch()
             if ch in _SUBMIT_CHARS:
@@ -161,27 +208,42 @@ def _read_masked_windows(prompt: str, out: TextIO) -> str:
     return "".join(chars)
 
 
-def read_masked(prompt: str, out: TextIO | None = None) -> str:
+def read_masked(
+    prompt: str, out: TextIO | None = None, *, first_key_timeout: "float | None" = None
+) -> str:
     """Read one line with ``*`` echo. Raises KeyboardInterrupt on Ctrl-C and
-    EOFError on Ctrl-D/Ctrl-Z at an empty prompt."""
+    EOFError on Ctrl-D/Ctrl-Z at an empty prompt, and PromptUnattended when
+    ``first_key_timeout`` passes with no keystroke at all."""
     if out is None:
         out = sys.stderr
     if os.name == "nt":
-        return _read_masked_windows(prompt, out)
-    return _read_masked_posix(prompt, out)
+        return _read_masked_windows(prompt, out, first_key_timeout)
+    return _read_masked_posix(prompt, out, first_key_timeout)
 
 
-def prompt_new_password(verify_current: Callable[[str], bool], out: TextIO | None = None) -> str:
+def prompt_new_password(
+    verify_current: Callable[[str], bool],
+    out: TextIO | None = None,
+    *,
+    first_key_timeout: "float | None" = None,
+) -> str:
     """Prompt for a new admin password until a valid, confirmed one is given.
 
     ``verify_current`` returns True when the candidate equals the current stored
     password; such candidates are rejected. KeyboardInterrupt/EOFError propagate
     so the caller can abort the launch.
+
+    ``first_key_timeout`` bounds the wait for the FIRST keystroke and raises
+    PromptUnattended if it never comes; once someone types there is no deadline.
+    Only a caller that must not block a launch passes it -- a detached pty
+    (``tmux new -d``, ``docker run -dt``) is a terminal nobody will answer.
     """
     if out is None:
         out = sys.stderr
+    pending_timeout = first_key_timeout
     while True:
-        password = read_masked("New password: ", out)
+        password = read_masked("New password: ", out, first_key_timeout = pending_timeout)
+        pending_timeout = None
         if len(password) < MIN_PASSWORD_LENGTH:
             out.write(f"Password must be at least {MIN_PASSWORD_LENGTH} characters. Try again.\n")
             out.flush()

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1238,7 +1238,7 @@ def _should_prompt_password_change(
         # A tunnel launch prompts regardless of the terminal; the headless
         # fallback is handled downstream.
         return True
-    return is_external_host(host) and _prompt_streams_interactive()
+    return is_external_host(host) and _prompt_streams_interactive() and _prompt_owns_the_terminal()
 
 
 def _prompt_streams_interactive() -> bool:
@@ -1247,6 +1247,46 @@ def _prompt_streams_interactive() -> bool:
         return sys.stdin.isatty() and sys.stderr.isatty()
     except (AttributeError, ValueError):
         return False
+
+
+# How long a raw-bind prompt waits for the first keystroke before giving up and
+# launching anyway. Long enough for someone watching the terminal to react, short
+# enough that an unattended pty is not held hostage. Mirrors run.py.
+# How long a raw-bind prompt waits for the FIRST keystroke before giving up and
+# launching anyway. Only the first: once someone is typing there is no deadline.
+#
+# 30s, not longer. The launches that reach this with nobody watching are the ones
+# that allocate a pty and then never read it -- `docker run -dt`, `tmux new -d`,
+# `screen -dmS`, some CI runners -- and they want to bind promptly. A container
+# that takes two minutes to answer a healthcheck can be killed and restarted by
+# the orchestrator, which would turn "delayed" into a restart loop; 30s stays
+# inside a default Docker HEALTHCHECK start period. Someone who is actually
+# looking at the prompt starts typing well inside that, and someone who is not
+# gets the refusal path, which warns and launches with the bootstrap deadline
+# armed. Mirrored in the CLI.
+_UNATTENDED_PROMPT_SECONDS = 30.0
+
+
+def _prompt_owns_the_terminal() -> bool:
+    """Whether this process may DRIVE the terminal, not merely see one.
+
+    A backgrounded shell job (`unsloth studio -H 0.0.0.0 &`) inherits the
+    terminal, so isatty() is True, but read_masked calls termios.tcsetattr, and
+    POSIX sends SIGTTOU to a background process group that does; the default
+    action stops the process. The launch would freeze at the prompt instead of
+    starting, which is the one thing widening this gate to raw binds must not do
+    -- such a launch started fine before, protected by the bootstrap deadline.
+    Only the raw-bind branch consults this: a tunnel launch is published on the
+    public internet and keeps failing closed rather than quietly proceeding.
+
+    True on any doubt: no job control (Windows), no controlling terminal, or a
+    stream with no fileno. Nothing can stop us there, so the isatty answer stands.
+    Mirror of run.py's _prompt_owns_the_terminal -- keep the two in sync.
+    """
+    try:
+        return os.tcgetpgrp(sys.stdin.fileno()) == os.getpgrp()
+    except (AttributeError, OSError, ValueError):
+        return True
 
 
 def _bootstrap_deadline_active() -> bool:
@@ -1756,7 +1796,28 @@ def _enforce_password_change_before_exposure(
             err = True,
         )
         try:
-            new_password = _password_prompt.prompt_new_password(_is_current_password)
+            new_password = _password_prompt.prompt_new_password(
+                _is_current_password,
+                # A raw bind must never block a launch that used to start. A
+                # detached pty (`tmux new -d`, `screen -dmS`, `docker run -dt`)
+                # passes every isatty and process-group test yet nobody will ever
+                # type, so an undeadlined read waits forever and no server is ever
+                # started. Fall back to the protection that launch already had,
+                # the bootstrap deadline. A tunnel keeps waiting: it publishes a
+                # public URL, so it fails closed rather than proceeding.
+                first_key_timeout = None if tunnel_will_start else _UNATTENDED_PROMPT_SECONDS,
+            )
+        except _password_prompt.PromptUnattended:
+            typer.echo(
+                "Warning: no response at the terminal, so Unsloth is starting with "
+                "the auto-generated admin password on a bind that is reachable from "
+                "the network. Unsloth shuts down after the bootstrap deadline "
+                "(UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT, default 1h) unless the password "
+                "is changed. Change it by logging in, or with `unsloth studio "
+                "reset-password`.",
+                err = True,
+            )
+            return
         except (KeyboardInterrupt, EOFError):
             typer.echo(
                 "\nError: password change aborted; refusing to expose Unsloth "

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1305,6 +1305,31 @@ def _bootstrap_deadline_active() -> bool:
         return True
 
 
+# Set by the parent when it has already put the prompt in front of this terminal
+# and got nothing, so the re-exec'd child does not repeat the wait.
+_UNATTENDED_PROMPT_DONE_ENV = "UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE"
+
+
+def _deadline_sentence() -> str:
+    """Say what will actually happen, not what usually happens.
+
+    UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT=0 disables the shutdown entirely, and this
+    is the sentence an operator acts on, so promising a deadline that will never
+    arm is worse than saying nothing.
+    """
+    if _bootstrap_deadline_active():
+        return (
+            "Unsloth shuts down after the bootstrap deadline "
+            "(UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT, default 1h) unless the password "
+            "is changed."
+        )
+    return (
+        "The bootstrap shutdown deadline is DISABLED for this launch "
+        "(UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT=0), so nothing will stop it serving "
+        "that credential."
+    )
+
+
 def _generate_reset_password() -> str:
     """Readable 4-word passphrase; the user has to type this one back in."""
     try:
@@ -1818,21 +1843,43 @@ def _enforce_password_change_before_exposure(
             typer.echo(
                 "Warning: no response at the terminal, so Unsloth is starting with "
                 "the auto-generated admin password on a bind that is reachable from "
-                "the network. Unsloth shuts down after the bootstrap deadline "
-                "(UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT, default 1h) unless the password "
-                "is changed. Change it by logging in, or with `unsloth studio "
-                "reset-password`.",
+                f"the network. {_deadline_sentence()} Change it by logging in, or "
+                "with `unsloth studio reset-password`.",
                 err = True,
             )
+            # The child gate sees the SAME unattended terminal and would wait its
+            # own deadline over again, so a 30s fallback becomes 60s, or 90 on the
+            # `studio run` path that re-enters this gate after re-exec. That is
+            # long enough to trip a startup watchdog, which is the restart loop
+            # the deadline exists to avoid. Tell the child the terminal has
+            # already been tried. A direct `python run.py` sets nothing, so it
+            # keeps its own backstop.
+            os.environ[_UNATTENDED_PROMPT_DONE_ENV] = "1"
             return
         except (KeyboardInterrupt, EOFError):
+            if tunnel_will_start:
+                typer.echo(
+                    "\nError: password change aborted; refusing to publish Unsloth "
+                    "on a public URL with the default admin password. Re-run and "
+                    "set a password, or launch without --secure/--cloudflare.",
+                    err = True,
+                )
+                raise typer.Exit(1)
+            # A raw bind is not a publication. This launch worked before the
+            # prompt existed, so Ctrl+C returns it to what it did then rather
+            # than refusing to start; run.py's gate makes the same choice, and
+            # this mirror is the one that actually runs for `unsloth studio
+            # -H 0.0.0.0`, so disagreeing here would make that unreachable.
             typer.echo(
-                "\nError: password change aborted; refusing to expose Unsloth "
-                "with the default admin password. Re-run and set a password, "
-                "or launch without --secure/--cloudflare.",
+                "\nWarning: password change aborted, so Unsloth is starting with "
+                "the auto-generated admin password on a bind that is reachable "
+                f"from the network. {_deadline_sentence()} Change it by logging "
+                "in, with `unsloth studio reset-password`, or by passing "
+                "--password / UNSLOTH_STUDIO_PASSWORD.",
                 err = True,
             )
-            raise typer.Exit(1)
+            os.environ[_UNATTENDED_PROMPT_DONE_ENV] = "1"
+            return
         _cli_update_password(conn, DEFAULT_ADMIN_USERNAME, new_password)
         typer.echo(f"Password updated for '{DEFAULT_ADMIN_USERNAME}'.", err = True)
     finally:

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1170,14 +1170,20 @@ def _create_desktop_secret_in_cli() -> str:
         conn.close()
 
 
-def _should_prompt_password_change(
+def _launch_publishes_tunnel(
     *, cloudflare: Optional[bool], host: str, secure: bool, api_only: bool
 ) -> bool:
-    """Whether this launch will expose Unsloth through the Cloudflare tunnel.
+    """Whether this launch will publish Unsloth through the Cloudflare tunnel.
 
-    CLI mirror of run.py's _cloudflare_tunnel_should_start, minus the Colab
-    case (Colab launches never come through this CLI path). --secure implies
-    the tunnel; --cloudflare only tunnels non-api-only wildcard binds.
+    CLI mirror of run.py's _cloudflare_tunnel_should_start, minus the Colab case
+    (Colab launches never come through this CLI path). --secure implies the
+    tunnel; --cloudflare only tunnels non-api-only wildcard binds.
+
+    Kept separate from _should_prompt_password_change, which is deliberately
+    wider. The guards that key off THIS one exist because a headless tunnel
+    launch strips .bootstrap_password and could lock the admin out; a raw
+    wildcard bind never strips, so widening them would add failure modes that
+    protect nothing.
     """
     if secure:
         return True
@@ -1186,6 +1192,40 @@ def _should_prompt_password_change(
     from unsloth_cli._tool_policy import is_wildcard_host
 
     return is_wildcard_host(host) and not api_only
+
+
+def _should_prompt_password_change(
+    *, cloudflare: Optional[bool], host: str, secure: bool, api_only: bool
+) -> bool:
+    """Whether this launch puts Unsloth where someone else can reach it.
+
+    CLI mirror of run.py's gate, minus the Colab case (Colab launches never come
+    through this CLI path). --secure implies the tunnel; --cloudflare only
+    tunnels non-api-only wildcard binds.
+
+    A raw wildcard bind counts too, and only when a terminal is attached. It is
+    reachable by every host on the network, and by the internet on a machine
+    with a public address, while starting no tunnel, so it previously got no
+    prompt, no warning and no strip: the seeded admin password stayed live and
+    was served in the page to anyone who loaded it.
+
+    The interactivity condition is deliberate and is what keeps this safe to
+    ship. Everything downstream of here is calibrated to publishing a public
+    URL: it refuses to launch when the deadline is disabled and it deletes
+    .bootstrap_password. Applying that to headless -H 0.0.0.0 would break
+    long-running containers, which are the common use of the flag. Headless raw
+    binds therefore keep exactly today's behaviour, protected by the bootstrap
+    deadline; only a launch with a human present is asked to set a password.
+    """
+    if secure:
+        return True
+    from unsloth_cli._tool_policy import is_wildcard_host
+
+    if not is_wildcard_host(host) or api_only:
+        return False
+    if cloudflare is True:
+        return True
+    return _prompt_streams_interactive()
 
 
 def _prompt_streams_interactive() -> bool:
@@ -1394,7 +1434,7 @@ def _require_servable_frontend_or_exit(
     index.html) or the auto-resolved built dist. Returns `frontend` unchanged for
     non-public or --api-only launches (no login page needed).
     """
-    if api_only or not _should_prompt_password_change(
+    if api_only or not _launch_publishes_tunnel(
         cloudflare = cloudflare, host = host, secure = secure, api_only = api_only
     ):
         return frontend
@@ -1436,7 +1476,7 @@ def _validate_inproc_backend_before_strip(
     on that path and exit cleanly if broken, before anything is stripped.
     Headless-only so an interactive prompt is not delayed behind the import.
     """
-    if not _should_prompt_password_change(
+    if not _launch_publishes_tunnel(
         cloudflare = cloudflare, host = host, secure = secure, api_only = api_only
     ):
         return
@@ -1543,6 +1583,15 @@ def _enforce_password_change_before_exposure(
         cloudflare = cloudflare, host = host, secure = secure, api_only = api_only
     ):
         return
+    # Only a tunnel launch is genuinely "a public Cloudflare URL". A raw wildcard
+    # bind is every network interface, which is the LAN behind a NAT router and
+    # the internet on a cloud box. Naming the wrong one in an error trains people
+    # to ignore it, and would be plainly wrong for `unsloth studio -H 0.0.0.0`.
+    tunnel_will_start = secure or cloudflare is True
+    exposure = (
+        "on a public Cloudflare URL" if tunnel_will_start
+        else "on every network interface"
+    )
     # Before public exposure we must PROVE the admin password is no longer the
     # seeded default. If we cannot (auth DB won't open, or a fresh admin cannot be
     # seeded + committed below), an old studio-venv child could regenerate a fresh
@@ -1556,7 +1605,7 @@ def _enforce_password_change_before_exposure(
         # Refuse rather than risk a child serving the default login; a transient
         # lock clears on retry.
         typer.echo(
-            "Error: refusing to publish Unsloth on a public Cloudflare URL: could "
+            f"Error: refusing to expose Unsloth {exposure}: could "
             f"not open the Unsloth auth database ({exc}) to confirm the admin "
             "password was changed. Retry (a transient database lock clears), or "
             "change the password first (run `unsloth studio` locally with a "
@@ -1582,7 +1631,7 @@ def _enforce_password_change_before_exposure(
             except OSError:
                 pass
             typer.echo(
-                "Error: refusing to publish Unsloth on a public Cloudflare URL: could "
+                f"Error: refusing to expose Unsloth {exposure}: could "
                 f"not initialize the admin account ({exc}), so a re-exec'd Unsloth "
                 "child could regenerate and serve a default credential. Retry (a "
                 "transient database lock clears), or change the password first (run "
@@ -1692,7 +1741,7 @@ def _enforce_password_change_before_exposure(
             )
 
         typer.echo(
-            "Unsloth Studio will be exposed on the public internet, so set a "
+            f"Unsloth Studio will be reachable {exposure}, so set a "
             "password now. Ctrl+C to abort.",
             err = True,
         )

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1640,7 +1640,14 @@ def _enforce_password_change_before_exposure(
     # bind is every network interface, which is the LAN behind a NAT router and
     # the internet on a cloud box. Naming the wrong one in an error trains people
     # to ignore it, and would be plainly wrong for `unsloth studio -H 0.0.0.0`.
-    tunnel_will_start = secure or cloudflare is True
+    # The real predicate, not `cloudflare is True`. A non-secure tunnel only
+    # starts for a wildcard host, so `--cloudflare -H 192.168.1.50` starts no
+    # tunnel and is reachable through the raw bind instead. Naming the wrong one
+    # here would tell the operator their credential is about to go on a public
+    # Cloudflare URL when it is not, in the one message they are meant to act on.
+    tunnel_will_start = _launch_publishes_tunnel(
+        cloudflare = cloudflare, host = host, secure = secure, api_only = api_only
+    )
     exposure = "on a public Cloudflare URL" if tunnel_will_start else "on every network interface"
     # Before public exposure we must PROVE the admin password is no longer the
     # seeded default. If we cannot (auth DB won't open, or a fresh admin cannot be

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1179,11 +1179,10 @@ def _launch_publishes_tunnel(
     (Colab launches never come through this CLI path). --secure implies the
     tunnel; --cloudflare only tunnels non-api-only wildcard binds.
 
-    Kept separate from _should_prompt_password_change, which is deliberately
-    wider. The guards that key off THIS one exist because a headless tunnel
-    launch strips .bootstrap_password and could lock the admin out; a raw
-    wildcard bind never strips, so widening them would add failure modes that
-    protect nothing.
+    Kept separate from the deliberately wider _should_prompt_password_change: the
+    guards keyed off THIS one exist because a headless tunnel launch strips
+    .bootstrap_password and could lock the admin out, and a raw wildcard bind
+    never strips, so widening them would add failure modes that protect nothing.
     """
     if secure:
         return True
@@ -1197,9 +1196,9 @@ def _launch_publishes_tunnel(
 def _bind_is_wildcard(host: str) -> bool:
     """Whether this bind really is every interface, rather than one address.
 
-    Only used to word the prompt. `_launch_publishes_tunnel` above has already
-    called `is_wildcard_host` on this same launch, so the getaddrinfo it does for
-    a non-literal host is not a new cost on the path.
+    Only used to word the prompt. `_launch_publishes_tunnel` already called
+    `is_wildcard_host` on this launch, so its getaddrinfo for a non-literal host
+    is not a new cost here.
     """
     from unsloth_cli._tool_policy import is_wildcard_host
 
@@ -1215,30 +1214,26 @@ def _should_prompt_password_change(
     through this CLI path). --secure implies the tunnel; --cloudflare only
     tunnels non-api-only wildcard binds.
 
-    A raw non-loopback bind counts too, and only when a terminal is attached. It
-    is reachable by every host on the network, and by the internet on a machine
-    with a public address, while starting no tunnel, so it previously got no
-    prompt, no warning and no strip: the seeded admin password stayed live and
-    was served in the page to anyone who loaded it.
+    A raw non-loopback bind counts too, but only with a terminal attached. It is
+    reachable by the whole network (and the internet on a machine with a public
+    address) while starting no tunnel, so it previously got no prompt, no warning
+    and no strip: the seeded admin password stayed live and was served in the page.
 
-    is_external_host, NOT is_wildcard_host. The backend gate classifies exposure
-    with auth/bootstrap_timeout._is_exposed_bind, which counts anything that is
-    not one of the three loopback aliases; wildcard is a strict subset of that.
-    Using the narrower test here meant `unsloth studio -H 192.168.1.50`, an
-    ordinary LAN bind, skipped the parent prompt and prompted in the re-exec'd
-    child instead, and against an OLDER studio-venv child, which the mixed-version
-    path explicitly supports and which has no backend gate, it prompted nowhere at
-    all and served the seeded password. It is also cheaper: is_wildcard_host runs
-    socket.getaddrinfo for any non-literal host, while is_external_host is a
-    frozenset membership test.
+    is_external_host, NOT is_wildcard_host. The backend classifies exposure with
+    auth/bootstrap_timeout._is_exposed_bind, which counts anything that is not one
+    of the three loopback aliases; wildcard is a strict subset. The narrower test
+    meant `unsloth studio -H 192.168.1.50`, an ordinary LAN bind, skipped the
+    parent prompt and prompted in the re-exec'd child instead, and against an
+    OLDER studio-venv child (supported by the mixed-version path, and with no
+    backend gate) it prompted nowhere at all and served the seeded password. It is
+    also cheaper: a frozenset lookup rather than getaddrinfo.
 
-    The interactivity condition is deliberate and is what keeps this safe to
-    ship. Everything downstream of here is calibrated to publishing a public
-    URL: it refuses to launch when the deadline is disabled and it deletes
-    .bootstrap_password. Applying that to headless -H 0.0.0.0 would break
-    long-running containers, which are the common use of the flag. Headless raw
-    binds therefore keep exactly today's behaviour, protected by the bootstrap
-    deadline; only a launch with a human present is asked to set a password.
+    The interactivity condition is what keeps this safe to ship. Everything
+    downstream is calibrated to publishing a public URL: it refuses to launch when
+    the deadline is disabled and it deletes .bootstrap_password, which would break
+    the long-running containers that are the common use of -H 0.0.0.0. Headless
+    raw binds therefore keep today's behaviour on the bootstrap deadline; only a
+    launch with a human present is asked to set a password.
     """
     if secure:
         return True
@@ -1247,8 +1242,7 @@ def _should_prompt_password_change(
     from unsloth_cli._tool_policy import is_external_host, is_wildcard_host
 
     if cloudflare is True and is_wildcard_host(host):
-        # A tunnel launch prompts regardless of the terminal; the headless
-        # fallback is handled downstream.
+        # A tunnel prompts regardless of the terminal; headless is handled downstream.
         return True
     return is_external_host(host) and _prompt_streams_interactive() and _prompt_owns_the_terminal()
 
@@ -1261,21 +1255,12 @@ def _prompt_streams_interactive() -> bool:
         return False
 
 
-# How long a raw-bind prompt waits for the first keystroke before giving up and
-# launching anyway. Long enough for someone watching the terminal to react, short
-# enough that an unattended pty is not held hostage. Mirrors run.py.
-# How long a raw-bind prompt waits for the FIRST keystroke before giving up and
-# launching anyway. Only the first: once someone is typing there is no deadline.
-#
-# 30s, not longer. The launches that reach this with nobody watching are the ones
-# that allocate a pty and then never read it -- `docker run -dt`, `tmux new -d`,
-# `screen -dmS`, some CI runners -- and they want to bind promptly. A container
-# that takes two minutes to answer a healthcheck can be killed and restarted by
-# the orchestrator, which would turn "delayed" into a restart loop; 30s stays
-# inside a default Docker HEALTHCHECK start period. Someone who is actually
-# looking at the prompt starts typing well inside that, and someone who is not
-# gets the refusal path, which warns and launches with the bootstrap deadline
-# armed. Mirrored in the CLI.
+# How long a raw-bind prompt waits for the FIRST keystroke before launching
+# anyway; once someone is typing there is no deadline. 30s because the launches
+# that reach here unwatched allocate a pty and never read it (`docker run -dt`,
+# `tmux new -d`, CI runners) and need to bind promptly: a longer stall can trip a
+# healthcheck into a restart loop, while 30s stays inside a default Docker
+# HEALTHCHECK start period and is ample for anyone actually watching. Mirrors run.py.
 _UNATTENDED_PROMPT_SECONDS = 30.0
 
 
@@ -1283,17 +1268,15 @@ def _prompt_owns_the_terminal() -> bool:
     """Whether this process may DRIVE the terminal, not merely see one.
 
     A backgrounded shell job (`unsloth studio -H 0.0.0.0 &`) inherits the
-    terminal, so isatty() is True, but read_masked calls termios.tcsetattr, and
-    POSIX sends SIGTTOU to a background process group that does; the default
-    action stops the process. The launch would freeze at the prompt instead of
-    starting, which is the one thing widening this gate to raw binds must not do
-    -- such a launch started fine before, protected by the bootstrap deadline.
-    Only the raw-bind branch consults this: a tunnel launch is published on the
-    public internet and keeps failing closed rather than quietly proceeding.
+    terminal so isatty() is True, but read_masked calls termios.tcsetattr and
+    POSIX SIGTTOUs a background process group that does; the default action stops
+    the process, freezing the launch instead of starting it -- the one thing
+    widening this gate to raw binds must not do. Only the raw-bind branch
+    consults this; a tunnel keeps failing closed rather than quietly proceeding.
 
-    True on any doubt: no job control (Windows), no controlling terminal, or a
-    stream with no fileno. Nothing can stop us there, so the isatty answer stands.
-    Mirror of run.py's _prompt_owns_the_terminal -- keep the two in sync.
+    True on any doubt (no job control, no controlling terminal, no fileno):
+    nothing can stop us there, so the isatty answer stands. Mirror of run.py's
+    _prompt_owns_the_terminal -- keep the two in sync.
     """
     try:
         return os.tcgetpgrp(sys.stdin.fileno()) == os.getpgrp()
@@ -1317,17 +1300,17 @@ def _bootstrap_deadline_active() -> bool:
         return True
 
 
-# Set by the parent when it has already put the prompt in front of this terminal
-# and got nothing, so the re-exec'd child does not repeat the wait.
+# Set by the parent once it has put the prompt in front of this terminal and got
+# nothing, so the re-exec'd child does not repeat the wait.
 _UNATTENDED_PROMPT_DONE_ENV = "UNSLOTH_STUDIO_UNATTENDED_PROMPT_DONE"
 
 
 def _deadline_sentence() -> str:
     """Say what will actually happen, not what usually happens.
 
-    UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT=0 disables the shutdown entirely, and this
-    is the sentence an operator acts on, so promising a deadline that will never
-    arm is worse than saying nothing.
+    UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT=0 disables the shutdown entirely, and this is
+    the sentence an operator acts on, so promising a deadline that will never arm
+    is worse than saying nothing.
     """
     if _bootstrap_deadline_active():
         return (
@@ -1673,15 +1656,12 @@ def _enforce_password_change_before_exposure(
         cloudflare = cloudflare, host = host, secure = secure, api_only = api_only
     ):
         return
-    # Only a tunnel launch is genuinely "a public Cloudflare URL". A raw wildcard
-    # bind is every network interface, which is the LAN behind a NAT router and
-    # the internet on a cloud box. Naming the wrong one in an error trains people
-    # to ignore it, and would be plainly wrong for `unsloth studio -H 0.0.0.0`.
-    # The real predicate, not `cloudflare is True`. A non-secure tunnel only
-    # starts for a wildcard host, so `--cloudflare -H 192.168.1.50` starts no
-    # tunnel and is reachable through the raw bind instead. Naming the wrong one
-    # here would tell the operator their credential is about to go on a public
-    # Cloudflare URL when it is not, in the one message they are meant to act on.
+    # Only a tunnel launch is genuinely "a public Cloudflare URL"; a raw bind is
+    # the LAN behind a NAT router, or the internet on a cloud box. Use the real
+    # predicate, not `cloudflare is True`: a non-secure tunnel only starts for a
+    # wildcard host, so `--cloudflare -H 192.168.1.50` starts none and is reached
+    # through the raw bind instead. Naming the wrong one in the one message the
+    # operator is meant to act on trains people to ignore it.
     tunnel_will_start = _launch_publishes_tunnel(
         cloudflare = cloudflare, host = host, secure = secure, api_only = api_only
     )
@@ -1690,23 +1670,20 @@ def _enforce_password_change_before_exposure(
         # nobody typed. `unsloth studio run` re-execs into the studio venv and
         # re-enters this gate, so without this the SAME unattended pty is waited
         # on again: 30s becomes 60s before the backend gate even gets its turn,
-        # which is long enough to trip a startup watchdog. The default admin was
-        # committed by the parent before it set this, so there is nothing left to
-        # do here. Peeked, never popped: run.py pops it, and consuming it here
-        # would hand the backend a fresh 30s wait instead.
-        #
-        # Never for a tunnel. That launch fails closed, and a marker set by some
-        # earlier raw-bind attempt must not buy a public URL a free pass.
+        # long enough to trip a startup watchdog. The parent committed the default
+        # admin before setting this, so there is nothing left to do. Peeked, never
+        # popped: run.py consumes it, and popping here would hand the backend a
+        # fresh 30s wait. Never for a tunnel, which fails closed -- a marker from
+        # an earlier raw-bind attempt must not buy a public URL a free pass.
         return
     if tunnel_will_start:
         exposure = "on a public Cloudflare URL"
     elif _bind_is_wildcard(host):
         exposure = "on every network interface"
     else:
-        # A concrete bind such as `-H 192.168.1.50` or `-H myhost.local` listens on
-        # that address ONLY, so "every network interface" is simply untrue. The gate
-        # widened to is_external_host and routes these here too; naming what the
-        # operator actually typed is both accurate and more useful than a category.
+        # A concrete bind (`-H 192.168.1.50`, `-H myhost.local`) listens on that
+        # address ONLY, so "every network interface" is untrue; the gate widened to
+        # is_external_host and routes these here too. Name what the operator typed.
         exposure = f"at {host}, which other machines on the network can reach"
     # Before public exposure we must PROVE the admin password is no longer the
     # seeded default. If we cannot (auth DB won't open, or a fresh admin cannot be
@@ -1856,11 +1833,11 @@ def _enforce_password_change_before_exposure(
                 _pbkdf2_hex(candidate, password_salt.encode("utf-8")), password_hash
             )
 
-        # Ctrl+C aborts a TUNNEL launch and only a tunnel launch. On a raw bind it
+        # Ctrl+C aborts a TUNNEL launch and only a tunnel launch; on a raw bind it
         # declines the prompt and the launch continues, because that launch worked
-        # before this gate existed and must not start failing now. Saying "abort"
-        # there would leave an operator believing they had stopped a server that is
-        # in fact up on the network with the auto-generated password.
+        # before this gate existed. Saying "abort" there would leave an operator
+        # believing they stopped a server that is in fact up on the network with
+        # the auto-generated password.
         refusal = (
             "Ctrl+C to abort."
             if tunnel_will_start
@@ -1874,12 +1851,11 @@ def _enforce_password_change_before_exposure(
             new_password = _password_prompt.prompt_new_password(
                 _is_current_password,
                 # A raw bind must never block a launch that used to start. A
-                # detached pty (`tmux new -d`, `screen -dmS`, `docker run -dt`)
-                # passes every isatty and process-group test yet nobody will ever
-                # type, so an undeadlined read waits forever and no server is ever
-                # started. Fall back to the protection that launch already had,
-                # the bootstrap deadline. A tunnel keeps waiting: it publishes a
-                # public URL, so it fails closed rather than proceeding.
+                # detached pty (`tmux new -d`, `docker run -dt`) passes every
+                # isatty and process-group test yet nobody will ever type, so an
+                # undeadlined read waits forever and no server starts; fall back
+                # to the bootstrap deadline it already had. A tunnel keeps waiting
+                # and fails closed rather than publish a public URL unprompted.
                 first_key_timeout = None if tunnel_will_start else _UNATTENDED_PROMPT_SECONDS,
             )
         except _password_prompt.PromptUnattended:
@@ -1891,12 +1867,11 @@ def _enforce_password_change_before_exposure(
                 err = True,
             )
             # The child gate sees the SAME unattended terminal and would wait its
-            # own deadline over again, so a 30s fallback becomes 60s, or 90 on the
-            # `studio run` path that re-enters this gate after re-exec. That is
-            # long enough to trip a startup watchdog, which is the restart loop
-            # the deadline exists to avoid. Tell the child the terminal has
-            # already been tried. A direct `python run.py` sets nothing, so it
-            # keeps its own backstop.
+            # own deadline again: 30s becomes 60s, or 90 on the `studio run` path
+            # that re-enters this gate after re-exec, long enough to trip a startup
+            # watchdog into the restart loop the deadline exists to avoid. Tell the
+            # child the terminal has been tried. A direct `python run.py` sets
+            # nothing, so it keeps its own backstop.
             os.environ[_UNATTENDED_PROMPT_DONE_ENV] = "1"
             return
         except (KeyboardInterrupt, EOFError):
@@ -1908,11 +1883,11 @@ def _enforce_password_change_before_exposure(
                     err = True,
                 )
                 raise typer.Exit(1)
-            # A raw bind is not a publication. This launch worked before the
-            # prompt existed, so Ctrl+C returns it to what it did then rather
-            # than refusing to start; run.py's gate makes the same choice, and
-            # this mirror is the one that actually runs for `unsloth studio
-            # -H 0.0.0.0`, so disagreeing here would make that unreachable.
+            # A raw bind is not a publication: it worked before the prompt
+            # existed, so Ctrl+C returns it to that rather than refusing to start.
+            # run.py's gate makes the same choice, and this mirror is what actually
+            # runs for `unsloth studio -H 0.0.0.0`, so disagreeing here would make
+            # run.py's warn-and-proceed unreachable.
             typer.echo(
                 "\nWarning: password change aborted, so Unsloth is starting with "
                 "the auto-generated admin password on a bind that is reachable "

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1194,6 +1194,18 @@ def _launch_publishes_tunnel(
     return is_wildcard_host(host) and not api_only
 
 
+def _bind_is_wildcard(host: str) -> bool:
+    """Whether this bind really is every interface, rather than one address.
+
+    Only used to word the prompt. `_launch_publishes_tunnel` above has already
+    called `is_wildcard_host` on this same launch, so the getaddrinfo it does for
+    a non-literal host is not a new cost on the path.
+    """
+    from unsloth_cli._tool_policy import is_wildcard_host
+
+    return is_wildcard_host(host)
+
+
 def _should_prompt_password_change(
     *, cloudflare: Optional[bool], host: str, secure: bool, api_only: bool
 ) -> bool:
@@ -1673,7 +1685,29 @@ def _enforce_password_change_before_exposure(
     tunnel_will_start = _launch_publishes_tunnel(
         cloudflare = cloudflare, host = host, secure = secure, api_only = api_only
     )
-    exposure = "on a public Cloudflare URL" if tunnel_will_start else "on every network interface"
+    if not tunnel_will_start and os.environ.get(_UNATTENDED_PROMPT_DONE_ENV):
+        # An outer CLI already sat at this terminal for the full deadline and
+        # nobody typed. `unsloth studio run` re-execs into the studio venv and
+        # re-enters this gate, so without this the SAME unattended pty is waited
+        # on again: 30s becomes 60s before the backend gate even gets its turn,
+        # which is long enough to trip a startup watchdog. The default admin was
+        # committed by the parent before it set this, so there is nothing left to
+        # do here. Peeked, never popped: run.py pops it, and consuming it here
+        # would hand the backend a fresh 30s wait instead.
+        #
+        # Never for a tunnel. That launch fails closed, and a marker set by some
+        # earlier raw-bind attempt must not buy a public URL a free pass.
+        return
+    if tunnel_will_start:
+        exposure = "on a public Cloudflare URL"
+    elif _bind_is_wildcard(host):
+        exposure = "on every network interface"
+    else:
+        # A concrete bind such as `-H 192.168.1.50` or `-H myhost.local` listens on
+        # that address ONLY, so "every network interface" is simply untrue. The gate
+        # widened to is_external_host and routes these here too; naming what the
+        # operator actually typed is both accurate and more useful than a category.
+        exposure = f"at {host}, which other machines on the network can reach"
     # Before public exposure we must PROVE the admin password is no longer the
     # seeded default. If we cannot (auth DB won't open, or a fresh admin cannot be
     # seeded + committed below), an old studio-venv child could regenerate a fresh
@@ -1822,9 +1856,18 @@ def _enforce_password_change_before_exposure(
                 _pbkdf2_hex(candidate, password_salt.encode("utf-8")), password_hash
             )
 
+        # Ctrl+C aborts a TUNNEL launch and only a tunnel launch. On a raw bind it
+        # declines the prompt and the launch continues, because that launch worked
+        # before this gate existed and must not start failing now. Saying "abort"
+        # there would leave an operator believing they had stopped a server that is
+        # in fact up on the network with the auto-generated password.
+        refusal = (
+            "Ctrl+C to abort."
+            if tunnel_will_start
+            else "Ctrl+C to skip, and Unsloth starts with the auto-generated password."
+        )
         typer.echo(
-            f"Unsloth Studio will be reachable {exposure}, so set a "
-            "password now. Ctrl+C to abort.",
+            f"Unsloth Studio will be reachable {exposure}, so set a password now. {refusal}",
             err = True,
         )
         try:

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1588,10 +1588,7 @@ def _enforce_password_change_before_exposure(
     # the internet on a cloud box. Naming the wrong one in an error trains people
     # to ignore it, and would be plainly wrong for `unsloth studio -H 0.0.0.0`.
     tunnel_will_start = secure or cloudflare is True
-    exposure = (
-        "on a public Cloudflare URL" if tunnel_will_start
-        else "on every network interface"
-    )
+    exposure = "on a public Cloudflare URL" if tunnel_will_start else "on every network interface"
     # Before public exposure we must PROVE the admin password is no longer the
     # seeded default. If we cannot (auth DB won't open, or a fresh admin cannot be
     # seeded + committed below), an old studio-venv child could regenerate a fresh

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1203,11 +1203,22 @@ def _should_prompt_password_change(
     through this CLI path). --secure implies the tunnel; --cloudflare only
     tunnels non-api-only wildcard binds.
 
-    A raw wildcard bind counts too, and only when a terminal is attached. It is
-    reachable by every host on the network, and by the internet on a machine
+    A raw non-loopback bind counts too, and only when a terminal is attached. It
+    is reachable by every host on the network, and by the internet on a machine
     with a public address, while starting no tunnel, so it previously got no
     prompt, no warning and no strip: the seeded admin password stayed live and
     was served in the page to anyone who loaded it.
+
+    is_external_host, NOT is_wildcard_host. The backend gate classifies exposure
+    with auth/bootstrap_timeout._is_exposed_bind, which counts anything that is
+    not one of the three loopback aliases; wildcard is a strict subset of that.
+    Using the narrower test here meant `unsloth studio -H 192.168.1.50`, an
+    ordinary LAN bind, skipped the parent prompt and prompted in the re-exec'd
+    child instead, and against an OLDER studio-venv child, which the mixed-version
+    path explicitly supports and which has no backend gate, it prompted nowhere at
+    all and served the seeded password. It is also cheaper: is_wildcard_host runs
+    socket.getaddrinfo for any non-literal host, while is_external_host is a
+    frozenset membership test.
 
     The interactivity condition is deliberate and is what keeps this safe to
     ship. Everything downstream of here is calibrated to publishing a public
@@ -1219,13 +1230,15 @@ def _should_prompt_password_change(
     """
     if secure:
         return True
-    from unsloth_cli._tool_policy import is_wildcard_host
-
-    if not is_wildcard_host(host) or api_only:
+    if not host or api_only:
         return False
-    if cloudflare is True:
+    from unsloth_cli._tool_policy import is_external_host, is_wildcard_host
+
+    if cloudflare is True and is_wildcard_host(host):
+        # A tunnel launch prompts regardless of the terminal; the headless
+        # fallback is handled downstream.
         return True
-    return _prompt_streams_interactive()
+    return is_external_host(host) and _prompt_streams_interactive()
 
 
 def _prompt_streams_interactive() -> bool:

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -82,25 +82,39 @@ def test_launch_publishes_tunnel_matrix(cloudflare, host, secure, api_only, expe
         # fallback is handled downstream, not here.
         *[(c, h, s, a, False, e) for c, h, s, a, e in _TUNNEL_MATRIX if e],
         *[(c, h, s, a, True, e) for c, h, s, a, e in _TUNNEL_MATRIX if e],
-        # The change: a RAW wildcard bind with a terminal attached. Reachable by
-        # every host on the network with the seeded password live, and it starts
-        # no tunnel, so before this it got no prompt at all.
+        # The change: a RAW non-loopback bind with a terminal attached. Reachable
+        # by every host on the network with the seeded password live, and it
+        # starts no tunnel, so before this it got no prompt at all.
         (None, "0.0.0.0", False, False, True, True),
         (False, "0.0.0.0", False, False, True, True),
         (None, "::", False, False, True, True),
         (None, "0", False, False, True, True),
         (None, "::ffff:0.0.0.0", False, False, True, True),
+        # Concrete LAN addresses and hostnames, NOT just wildcard spellings. The
+        # backend counts these as exposed, so the parent must too; otherwise an
+        # older re-exec'd child, which has no backend gate, prompts nowhere.
+        (None, "192.168.1.50", False, False, True, True),
+        (None, "10.0.0.5", False, False, True, True),
+        (None, "172.16.4.9", False, False, True, True),
+        (None, "example.com", False, False, True, True),
+        (None, "myhost.local", False, False, True, True),
+        (None, "[::]", False, False, True, True),
         # Headless raw binds stay exactly as they were: no prompt, no strip, no
         # refusal. Long-running containers are the common use of this flag and
         # the bootstrap deadline is what covers them.
         (None, "0.0.0.0", False, False, False, False),
         (False, "0.0.0.0", False, False, False, False),
         (None, "::", False, False, False, False),
+        (None, "192.168.1.50", False, False, False, False),
         # --api-only authenticates by API key, not the admin password.
         (None, "0.0.0.0", False, True, True, False),
+        (None, "192.168.1.50", False, True, True, False),
         # Loopback is not exposed, so nothing changes for plain `unsloth studio`.
         (None, "127.0.0.1", False, False, True, False),
         (None, "localhost", False, False, True, False),
+        (None, "::1", False, False, True, False),
+        # An empty host is rejected by the CLI long before this; never prompt on
+        # it, even though is_external_host("") is True.
         (None, "", False, False, True, False),
     ],
 )
@@ -1753,3 +1767,56 @@ def test_studio_default_password_applies_on_headless_wildcard_no_tunnel(monkeypa
     assert after["must_change_password"] == 0
     assert after["password_hash"] != before["password_hash"]
     assert "--password" not in _exec_argv(events)
+
+
+# ── CLI / backend exposure agreement ─────────────────────────────────
+
+
+_EXPOSURE_HOSTS = [
+    # wildcard spellings
+    "0.0.0.0", "::", "::0", "0:0:0:0:0:0:0:0", "0", "::ffff:0.0.0.0",
+    # loopback aliases
+    "127.0.0.1", "localhost", "::1",
+    # concrete external addresses and names
+    "192.168.1.50", "10.0.0.5", "172.16.4.9", "example.com", "myhost.local",
+    # odd spellings
+    "[::]", "0.0.0.0.0",
+]
+
+
+@pytest.mark.parametrize("host", _EXPOSURE_HOSTS)
+def test_cli_and_backend_agree_on_which_hosts_are_exposed(monkeypatch, host):
+    """The parent and the child must classify exposure identically.
+
+    They are separate implementations in separate packages (the CLI cannot import
+    the backend), and they are consulted at different moments: the parent decides
+    before re-exec, the child decides after. When they disagree the prompt lands
+    in the child instead of the parent, and against an OLDER studio-venv child,
+    which the mixed-version path explicitly supports and which has no gate at all,
+    it lands nowhere and the seeded password is served.
+
+    Measured before the fix: wildcard was False but exposed was True for
+    192.168.1.50, 10.0.0.5, example.com, myhost.local, [::] and 0.0.0.0.0.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_bootstrap_timeout_probe",
+        _REPO_ROOT / "studio" / "backend" / "auth" / "bootstrap_timeout.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(_REPO_ROOT / "studio" / "backend"))
+    try:
+        spec.loader.exec_module(module)
+        backend_exposed = module._is_exposed_bind(host, False)
+    finally:
+        sys.path.remove(str(_REPO_ROOT / "studio" / "backend"))
+
+    monkeypatch.setattr(_studio(), "_prompt_streams_interactive", lambda: True)
+    cli_prompts = _studio()._should_prompt_password_change(
+        cloudflare = None, host = host, secure = False, api_only = False
+    )
+    assert cli_prompts is backend_exposed, (
+        f"{host!r}: CLI prompts={cli_prompts} but the backend considers it "
+        f"exposed={backend_exposed}; the parent gate and the child gate disagree"
+    )

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -2053,3 +2053,57 @@ def test_the_exposure_wording_matches_what_will_actually_happen(
         cloudflare = cloudflare, host = host, secure = secure, api_only = False
     )
     assert tunnel is expect_tunnel_wording
+
+
+def test_the_cli_deadline_sentence_tracks_the_configured_timeout(monkeypatch):
+    """The CLI fallback must not promise a shutdown that will never arm."""
+    studio_mod = _studio()
+    monkeypatch.delenv("UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT", raising = False)
+    assert "shuts down after the bootstrap deadline" in studio_mod._deadline_sentence()
+    for disabled in ("0", "-1"):
+        monkeypatch.setenv("UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT", disabled)
+        sentence = studio_mod._deadline_sentence()
+        assert "DISABLED for this launch" in sentence, disabled
+        assert "shuts down after" not in sentence, disabled
+
+
+def test_a_raw_bind_ctrl_c_does_not_abort_the_launch(monkeypatch, tmp_path):
+    """Ctrl+C on `unsloth studio -H 0.0.0.0` must leave it starting.
+
+    The CLI mirror is the gate that actually runs for that command, so if it
+    exits here the warn-and-proceed in run.py is unreachable and the docker
+    run -it case the two of them exist to protect is not protected at all.
+    """
+    studio_mod = _studio()
+    events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
+    _seed_auth(studio_mod)
+
+    def _abort(*_a, **_kw):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(studio_mod._password_prompt, "prompt_new_password", _abort)
+
+    # Returns rather than raising typer.Exit: the launch continues.
+    studio_mod._enforce_password_change_before_exposure(
+        cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
+    )
+    assert _auth_state(studio_mod)["must_change_password"] == 1
+    del events
+
+
+def test_a_tunnel_ctrl_c_still_aborts(monkeypatch, tmp_path):
+    studio_mod = _studio()
+    _install_prompt_env(monkeypatch, tmp_path, interactive = True)
+    _seed_auth(studio_mod)
+
+    def _abort(*_a, **_kw):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(studio_mod._password_prompt, "prompt_new_password", _abort)
+
+    import typer
+
+    with pytest.raises(typer.Exit):
+        studio_mod._enforce_password_change_before_exposure(
+            cloudflare = None, host = "127.0.0.1", secure = True, api_only = False
+        )

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -107,9 +107,7 @@ def test_launch_publishes_tunnel_matrix(cloudflare, host, secure, api_only, expe
 def test_should_prompt_password_change_matrix(
     monkeypatch, cloudflare, host, secure, api_only, interactive, expected
 ):
-    monkeypatch.setattr(
-        _studio(), "_prompt_streams_interactive", lambda: interactive
-    )
+    monkeypatch.setattr(_studio(), "_prompt_streams_interactive", lambda: interactive)
     assert (
         _studio()._should_prompt_password_change(
             cloudflare = cloudflare, host = host, secure = secure, api_only = api_only

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -204,7 +204,11 @@ def _install_prompt_env(
     # dedicated test that overrides this.
     monkeypatch.setattr(studio_mod, "_tunnel_binary_confirmed_unavailable", lambda: False)
 
-    def fake_prompt(verify_current, out = None, **_kw):
+    def fake_prompt(
+        verify_current,
+        out = None,
+        **_kw,
+    ):
         events.append(("prompt", verify_current))
         if isinstance(scripted, BaseException):
             raise scripted
@@ -1854,14 +1858,20 @@ def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
     monkeypatch.setattr(studio.os, "getpgrp", lambda: 99)
     monkeypatch.setattr(studio.sys, "stdin", _FdStream())
 
-    assert studio._should_prompt_password_change(
-        cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
-    ) is False
+    assert (
+        studio._should_prompt_password_change(
+            cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
+        )
+        is False
+    )
     # The tunnel is published on the public internet either way: it must keep
     # failing closed rather than quietly proceeding.
-    assert studio._should_prompt_password_change(
-        cloudflare = None, host = "0.0.0.0", secure = True, api_only = False
-    ) is True
+    assert (
+        studio._should_prompt_password_change(
+            cloudflare = None, host = "0.0.0.0", secure = True, api_only = False
+        )
+        is True
+    )
 
 
 def test_a_foreground_raw_bind_still_prompts(monkeypatch):
@@ -1872,9 +1882,12 @@ def test_a_foreground_raw_bind_still_prompts(monkeypatch):
     monkeypatch.setattr(studio.os, "getpgrp", lambda: 4242)
     monkeypatch.setattr(studio.sys, "stdin", _FdStream())
 
-    assert studio._should_prompt_password_change(
-        cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
-    ) is True
+    assert (
+        studio._should_prompt_password_change(
+            cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
+        )
+        is True
+    )
 
 
 @pytest.mark.parametrize("raised", [OSError("ENOTTY"), AttributeError(), ValueError()])
@@ -1889,14 +1902,20 @@ def test_no_job_control_falls_back_to_the_isatty_answer(monkeypatch, raised):
     monkeypatch.setattr(studio.os, "tcgetpgrp", _boom, raising = False)
     monkeypatch.setattr(studio.sys, "stdin", _FdStream())
 
-    assert studio._should_prompt_password_change(
-        cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
-    ) is True
+    assert (
+        studio._should_prompt_password_change(
+            cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
+        )
+        is True
+    )
 
 
 class _FdStream:
-    def fileno(self): return 0
-    def isatty(self): return True
+    def fileno(self):
+        return 0
+
+    def isatty(self):
+        return True
 
 
 # ── a pty is not a person ────────────────────────────────────────────
@@ -1937,7 +1956,11 @@ def test_an_unattended_pty_still_aborts_a_tunnel_launch(monkeypatch, tmp_path):
     studio_mod = _studio()
     seen = {}
 
-    def _fake_prompt(verify_current, out = None, **kw):
+    def _fake_prompt(
+        verify_current,
+        out = None,
+        **kw,
+    ):
         seen.update(kw)
         return _NEW_PW
 
@@ -1954,7 +1977,11 @@ def test_a_raw_bind_prompt_carries_the_unattended_deadline(monkeypatch, tmp_path
     studio_mod = _studio()
     seen = {}
 
-    def _fake_prompt(verify_current, out = None, **kw):
+    def _fake_prompt(
+        verify_current,
+        out = None,
+        **kw,
+    ):
         seen.update(kw)
         return _NEW_PW
 
@@ -1978,8 +2005,12 @@ def test_read_masked_gives_up_on_a_pty_nobody_types_into(monkeypatch):
 
     class _PtyStdin:
         encoding = "utf-8"
-        def fileno(self): return slave
-        def isatty(self): return True
+
+        def fileno(self):
+            return slave
+
+        def isatty(self):
+            return True
 
     try:
         monkeypatch.setattr(_password_prompt.sys, "stdin", _PtyStdin())

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -1989,3 +1989,36 @@ def test_read_masked_gives_up_on_a_pty_nobody_types_into(monkeypatch):
     finally:
         os.close(master)
         os.close(slave)
+
+
+@pytest.mark.parametrize(
+    "cloudflare,host,secure,expect_tunnel_wording",
+    [
+        # --secure always publishes a tunnel.
+        (None, "127.0.0.1", True, True),
+        # --cloudflare tunnels only WILDCARD hosts...
+        (True, "0.0.0.0", False, True),
+        # ...so a concrete bind is reachable through the raw socket, not a URL.
+        (True, "192.168.1.50", False, False),
+        (True, "example.com", False, False),
+        # No tunnel requested at all.
+        (None, "0.0.0.0", False, False),
+        (None, "192.168.1.50", False, False),
+    ],
+)
+def test_the_exposure_wording_matches_what_will_actually_happen(
+    monkeypatch, tmp_path, cloudflare, host, secure, expect_tunnel_wording
+):
+    """The prompt must not claim a public Cloudflare URL that never starts.
+
+    `--cloudflare -H 192.168.1.50` requests a tunnel that _launch_publishes_tunnel
+    will not start, because a non-secure tunnel needs a wildcard host. Deriving the
+    message from the request rather than the predicate told the operator their
+    credential was about to go on a public URL when it was going on the LAN.
+    """
+    studio_mod = _studio()
+    monkeypatch.setattr(studio_mod, "_prompt_streams_interactive", lambda: True)
+    tunnel = studio_mod._launch_publishes_tunnel(
+        cloudflare = cloudflare, host = host, secure = secure, api_only = False
+    )
+    assert tunnel is expect_tunnel_wording

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -38,10 +38,9 @@ _BASE = ["--model", "unsloth/Qwen3-1.7B-GGUF"]
 def _no_leaked_unattended_marker(monkeypatch):
     """Start every test with the unattended marker unset.
 
-    The gate writes it straight into os.environ, which is exactly right in
-    production (it is inherited across the re-exec and nowhere else) and exactly
-    wrong in a test process, where it then survives into every later test and
-    silently suppresses the very prompt they are asserting on.
+    The gate writes it straight into os.environ, right in production (inherited
+    across the re-exec) but wrong in a test process, where it survives into every
+    later test and silently suppresses the prompt they assert on.
     """
     import unsloth_cli.commands.studio as studio_mod
 
@@ -78,7 +77,7 @@ _TUNNEL_MATRIX = [
 def test_launch_publishes_tunnel_matrix(cloudflare, host, secure, api_only, expected):
     """The narrow predicate. Unchanged, and pinned so it stays that way.
 
-    The strip-and-lockout guards key off this one. A raw wildcard bind never
+    The strip-and-lockout guards key off this one, and a raw wildcard bind never
     strips .bootstrap_password, so it must not be pulled in here even though it
     does now prompt.
     """
@@ -94,12 +93,12 @@ def test_launch_publishes_tunnel_matrix(cloudflare, host, secure, api_only, expe
     "cloudflare,host,secure,api_only,interactive,expected",
     [
         # Every tunnel launch prompts regardless of the terminal; the headless
-        # fallback is handled downstream, not here.
+        # fallback is downstream.
         *[(c, h, s, a, False, e) for c, h, s, a, e in _TUNNEL_MATRIX if e],
         *[(c, h, s, a, True, e) for c, h, s, a, e in _TUNNEL_MATRIX if e],
         # The change: a RAW non-loopback bind with a terminal attached. Reachable
-        # by every host on the network with the seeded password live, and it
-        # starts no tunnel, so before this it got no prompt at all.
+        # by the whole network with the seeded password live, and it starts no
+        # tunnel, so before this it got no prompt at all.
         (None, "0.0.0.0", False, False, True, True),
         (False, "0.0.0.0", False, False, True, True),
         (None, "::", False, False, True, True),
@@ -114,9 +113,8 @@ def test_launch_publishes_tunnel_matrix(cloudflare, host, secure, api_only, expe
         (None, "example.com", False, False, True, True),
         (None, "myhost.local", False, False, True, True),
         (None, "[::]", False, False, True, True),
-        # Headless raw binds stay exactly as they were: no prompt, no strip, no
-        # refusal. Long-running containers are the common use of this flag and
-        # the bootstrap deadline is what covers them.
+        # Headless raw binds stay as they were: no prompt, no strip, no refusal.
+        # Long-running containers are the common use, covered by the deadline.
         (None, "0.0.0.0", False, False, False, False),
         (False, "0.0.0.0", False, False, False, False),
         (None, "::", False, False, False, False),
@@ -268,10 +266,9 @@ def _install_run_reexec(monkeypatch, events):
     real_is_file = Path.is_file
     # The fixture describes a POSIX install ("bin/unsloth", "/fake/..." paths), so
     # pin BOTH platform probes, not just sys.platform: the launcher name comes from
-    # platform.system(), which on a Windows runner looks for unsloth.exe, finds the
-    # fixture's POSIX name instead and exits with "venv missing 'unsloth' entry
-    # point" before any of these tests reaches what it is actually asserting. The
-    # Windows name has its own test below.
+    # platform.system(), so a Windows runner looks for unsloth.exe, misses the
+    # fixture's POSIX name and exits with "venv missing 'unsloth' entry point"
+    # before any of these tests asserts anything. Windows has its own test below.
     monkeypatch.setattr(studio_mod.platform, "system", lambda: "Linux")
     monkeypatch.setattr(
         Path,
@@ -318,9 +315,9 @@ def _invoke_run(monkeypatch, events, args):
 
 def test_run_reexecs_through_the_windows_console_script(monkeypatch):
     # Windows ships the console script as unsloth.exe, so `studio run` looks for
-    # that name instead of the bare one. Runs on every platform: platform.system()
-    # is the only thing that decides, and the branch was previously exercised by
-    # nothing, which is how the POSIX-only fixture above went unnoticed.
+    # that name. Runs on every platform since platform.system() is the only thing
+    # that decides; the branch was previously untested, which is how the
+    # POSIX-only fixture above went unnoticed.
     import typer as _typer
 
     studio_mod = _studio()
@@ -334,8 +331,8 @@ def test_run_reexecs_through_the_windows_console_script(monkeypatch):
         "is_file",
         lambda self: True if str(self) == str(windows_bin) else real_is_file(self),
     )
-    # The bare POSIX name is NOT a file here, so a launch that only got this far
-    # by ignoring platform.system() would exit instead of re-execing.
+    # The bare POSIX name is NOT a file here, so a launch that ignored
+    # platform.system() would exit instead of re-execing.
     monkeypatch.setattr(studio_mod, "_managed_cli_package_present", lambda _python: False)
 
     app = _typer.Typer()
@@ -1858,12 +1855,11 @@ _EXPOSURE_HOSTS = [
 def test_cli_and_backend_agree_on_which_hosts_are_exposed(monkeypatch, host):
     """The parent and the child must classify exposure identically.
 
-    They are separate implementations in separate packages (the CLI cannot import
-    the backend), and they are consulted at different moments: the parent decides
-    before re-exec, the child decides after. When they disagree the prompt lands
-    in the child instead of the parent, and against an OLDER studio-venv child,
-    which the mixed-version path explicitly supports and which has no gate at all,
-    it lands nowhere and the seeded password is served.
+    Separate implementations in separate packages (the CLI cannot import the
+    backend), consulted at different moments: the parent before re-exec, the child
+    after. When they disagree the prompt lands in the child, and against an OLDER
+    studio-venv child (supported by the mixed-version path, and with no gate) it
+    lands nowhere and the seeded password is served.
 
     Measured before the fix: wildcard was False but exposed was True for
     192.168.1.50, 10.0.0.5, example.com, myhost.local, [::] and 0.0.0.0.0.
@@ -1899,11 +1895,10 @@ def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
     """`unsloth studio -H 0.0.0.0 &` must still launch.
 
     A background job inherits the terminal, so isatty() is True on both streams,
-    but the masked prompt calls termios.tcsetattr; POSIX sends SIGTTOU to a
-    background process group that does, and the default action STOPS the process.
-    The launch would freeze at the prompt before the socket binds, i.e. a launch
-    that worked before this gate widened to raw binds stops working. It keeps the
-    protection it already had, the bootstrap deadline.
+    but the masked prompt calls termios.tcsetattr; POSIX SIGTTOUs a background
+    process group that does, and the default action STOPS the process. The launch
+    would freeze before the socket binds, so a launch that worked before this gate
+    widened stops working. It keeps the bootstrap deadline it already had.
     """
     studio = _studio()
     monkeypatch.setattr(studio, "_prompt_streams_interactive", lambda: True)
@@ -1917,8 +1912,7 @@ def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
         )
         is False
     )
-    # The tunnel is published on the public internet either way: it must keep
-    # failing closed rather than quietly proceeding.
+    # A tunnel is public either way, so it keeps failing closed.
     assert (
         studio._should_prompt_password_change(
             cloudflare = None, host = "0.0.0.0", secure = True, api_only = False
@@ -1978,11 +1972,10 @@ def test_an_unattended_pty_still_launches_a_raw_bind(monkeypatch, tmp_path):
     """`tmux new -d 'unsloth studio -H 0.0.0.0'` must still start Unsloth.
 
     A detached pty (tmux/screen/`docker run -dt`) is a real, foreground terminal
-    that nobody will ever type into: both streams are ttys and the process owns
-    the terminal, so every interactivity test says "prompt" and the read then
-    never returns. The gate runs before any server exists, so without a deadline
-    the launch hangs forever instead of starting. It must fall back to the
-    protection it already had, the bootstrap deadline.
+    nobody will ever type into: both streams are ttys and the process owns the
+    terminal, so every interactivity test says "prompt" and the read never
+    returns. The gate runs before any server exists, so undeadlined the launch
+    hangs forever. It must fall back to the bootstrap deadline it already had.
     """
     studio_mod = _studio()
     events = _install_prompt_env(
@@ -2095,10 +2088,10 @@ def test_the_exposure_wording_matches_what_will_actually_happen(
 ):
     """The prompt must not claim a public Cloudflare URL that never starts.
 
-    `--cloudflare -H 192.168.1.50` requests a tunnel that _launch_publishes_tunnel
-    will not start, because a non-secure tunnel needs a wildcard host. Deriving the
-    message from the request rather than the predicate told the operator their
-    credential was about to go on a public URL when it was going on the LAN.
+    `--cloudflare -H 192.168.1.50` requests a tunnel that will not start, since a
+    non-secure tunnel needs a wildcard host. Deriving the message from the request
+    rather than the predicate told the operator their credential was about to go
+    on a public URL when it was going on the LAN.
     """
     studio_mod = _studio()
     monkeypatch.setattr(studio_mod, "_prompt_streams_interactive", lambda: True)
@@ -2123,9 +2116,9 @@ def test_the_cli_deadline_sentence_tracks_the_configured_timeout(monkeypatch):
 def test_a_raw_bind_ctrl_c_does_not_abort_the_launch(monkeypatch, tmp_path):
     """Ctrl+C on `unsloth studio -H 0.0.0.0` must leave it starting.
 
-    The CLI mirror is the gate that actually runs for that command, so if it
-    exits here the warn-and-proceed in run.py is unreachable and the docker
-    run -it case the two of them exist to protect is not protected at all.
+    The CLI mirror is the gate that actually runs for that command, so exiting
+    here makes run.py's warn-and-proceed unreachable and leaves the
+    `docker run -it` case unprotected.
     """
     studio_mod = _studio()
     events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
@@ -2166,10 +2159,9 @@ def test_a_second_cli_gate_does_not_re_wait_the_same_dead_terminal(monkeypatch, 
     """`unsloth studio run` re-execs and re-enters this gate on the SAME pty.
 
     The parent waits its deadline, nobody types, and it marks the terminal as
-    already tried. Without honouring that mark the child waits the whole deadline
-    over again, so 30s becomes 60s before the backend gate has even had its turn,
-    which is long enough to trip a startup watchdog. The mark is peeked, never
-    popped: run.py is what consumes it.
+    already tried. Without honouring that the child waits the whole deadline
+    again, so 30s becomes 60s before the backend gate even has its turn, long
+    enough to trip a startup watchdog. Peeked, never popped: run.py consumes it.
     """
     studio_mod = _studio()
     calls = []
@@ -2218,8 +2210,7 @@ def _banner(monkeypatch, tmp_path, args):
     """Run the gate far enough to capture the banner it prints, then bail out.
 
     Clears the unattended mark first: bailing out with an interrupt SETS it on a
-    raw bind, so a second call in the same test would skip the prompt and capture
-    no banner at all.
+    raw bind, so a second call in the same test would capture no banner.
     """
     import os as _os
 
@@ -2242,10 +2233,10 @@ def test_the_banner_does_not_promise_an_abort_a_raw_bind_will_not_perform(
 ):
     """`Ctrl+C to abort` is true for a tunnel and false for a raw bind.
 
-    On a raw bind the interrupt declines the prompt and the launch continues, by
-    design, because that launch worked before this gate existed. An operator who
-    reads "abort", presses Ctrl+C and walks away would be leaving a server up on
-    the network with the auto-generated password.
+    On a raw bind the interrupt declines the prompt and the launch continues by
+    design, because it worked before this gate existed. An operator who reads
+    "abort", presses Ctrl+C and walks away would be leaving a server up on the
+    network with the auto-generated password.
     """
     raw = _banner(monkeypatch, tmp_path, ["-H", "0.0.0.0"])
     assert "Ctrl+C to abort" not in raw
@@ -2258,8 +2249,8 @@ def test_the_banner_does_not_promise_an_abort_a_raw_bind_will_not_perform(
 def test_a_concrete_bind_is_not_described_as_every_interface(monkeypatch, tmp_path):
     """`-H 192.168.1.50` listens on one address, so say so.
 
-    The gate widened to is_external_host, which routes concrete non-loopback
-    hosts down the same path as the wildcard, and they inherited its wording.
+    The gate widened to is_external_host, routing concrete non-loopback hosts down
+    the wildcard's path, where they inherited its wording.
     """
     concrete = _banner(monkeypatch, tmp_path, ["-H", "192.168.1.50"])
     assert "on every network interface" not in concrete

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -252,6 +252,13 @@ def _install_run_reexec(monkeypatch, events):
     )
     fake_bin = fake_venv / "bin" / "unsloth"
     real_is_file = Path.is_file
+    # The fixture describes a POSIX install ("bin/unsloth", "/fake/..." paths), so
+    # pin BOTH platform probes, not just sys.platform: the launcher name comes from
+    # platform.system(), which on a Windows runner looks for unsloth.exe, finds the
+    # fixture's POSIX name instead and exits with "venv missing 'unsloth' entry
+    # point" before any of these tests reaches what it is actually asserting. The
+    # Windows name has its own test below.
+    monkeypatch.setattr(studio_mod.platform, "system", lambda: "Linux")
     monkeypatch.setattr(
         Path,
         "is_file",
@@ -293,6 +300,38 @@ def _invoke_run(monkeypatch, events, args):
         context_settings = {"allow_extra_args": True, "ignore_unknown_options": True},
     )(studio_mod.run)
     return CliRunner().invoke(app, args, catch_exceptions = True)
+
+
+def test_run_reexecs_through_the_windows_console_script(monkeypatch):
+    # Windows ships the console script as unsloth.exe, so `studio run` looks for
+    # that name instead of the bare one. Runs on every platform: platform.system()
+    # is the only thing that decides, and the branch was previously exercised by
+    # nothing, which is how the POSIX-only fixture above went unnoticed.
+    import typer as _typer
+
+    studio_mod = _studio()
+    events = []
+    _install_run_reexec(monkeypatch, events)
+    monkeypatch.setattr(studio_mod.platform, "system", lambda: "Windows")
+    windows_bin = Path("/fake/studio/venv/unsloth_studio/bin/unsloth.exe")
+    real_is_file = Path.is_file
+    monkeypatch.setattr(
+        Path,
+        "is_file",
+        lambda self: True if str(self) == str(windows_bin) else real_is_file(self),
+    )
+    # The bare POSIX name is NOT a file here, so a launch that only got this far
+    # by ignoring platform.system() would exit instead of re-execing.
+    monkeypatch.setattr(studio_mod, "_managed_cli_package_present", lambda _python: False)
+
+    app = _typer.Typer()
+    app.command(
+        context_settings = {"allow_extra_args": True, "ignore_unknown_options": True},
+    )(studio_mod.run)
+    result = CliRunner().invoke(app, _BASE + ["--api-only"], catch_exceptions = True)
+
+    assert result.exit_code == 0, result.output
+    assert [kind for kind, _ in events] == ["exec"], events
 
 
 @pytest.mark.parametrize("command", ["default", "run"])

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -37,30 +37,79 @@ _NEW_PW = "brand-new-password"
 # ── pure trigger matrix ──────────────────────────────────────────────
 
 
+_TUNNEL_MATRIX = [
+    # --secure always implies the tunnel (host already forced to loopback).
+    (None, "127.0.0.1", True, False, True),
+    (True, "127.0.0.1", True, False, True),
+    (None, "127.0.0.1", True, True, True),
+    # --cloudflare tunnels only non-api-only wildcard binds.
+    (True, "0.0.0.0", False, False, True),
+    (True, "::", False, False, True),
+    (True, "::0", False, False, True),
+    (True, "0:0:0:0:0:0:0:0", False, False, True),
+    (True, "0", False, False, True),
+    (True, "::ffff:0.0.0.0", False, False, True),
+    (True, "", False, False, False),
+    (True, "127.0.0.1", False, False, False),
+    (True, "0.0.0.0", False, True, False),
+    # Off/unset never starts a tunnel without --secure.
+    (None, "0.0.0.0", False, False, False),
+    (False, "0.0.0.0", False, False, False),
+    (None, "127.0.0.1", False, False, False),
+]
+
+
+@pytest.mark.parametrize("cloudflare,host,secure,api_only,expected", _TUNNEL_MATRIX)
+def test_launch_publishes_tunnel_matrix(cloudflare, host, secure, api_only, expected):
+    """The narrow predicate. Unchanged, and pinned so it stays that way.
+
+    The strip-and-lockout guards key off this one. A raw wildcard bind never
+    strips .bootstrap_password, so it must not be pulled in here even though it
+    does now prompt.
+    """
+    assert (
+        _studio()._launch_publishes_tunnel(
+            cloudflare = cloudflare, host = host, secure = secure, api_only = api_only
+        )
+        is expected
+    )
+
+
 @pytest.mark.parametrize(
-    "cloudflare,host,secure,api_only,expected",
+    "cloudflare,host,secure,api_only,interactive,expected",
     [
-        # --secure always implies the tunnel (host already forced to loopback).
-        (None, "127.0.0.1", True, False, True),
-        (True, "127.0.0.1", True, False, True),
-        (None, "127.0.0.1", True, True, True),
-        # --cloudflare tunnels only non-api-only wildcard binds.
-        (True, "0.0.0.0", False, False, True),
-        (True, "::", False, False, True),
-        (True, "::0", False, False, True),
-        (True, "0:0:0:0:0:0:0:0", False, False, True),
-        (True, "0", False, False, True),
-        (True, "::ffff:0.0.0.0", False, False, True),
-        (True, "", False, False, False),
-        (True, "127.0.0.1", False, False, False),
-        (True, "0.0.0.0", False, True, False),
-        # Off/unset never prompts without --secure.
-        (None, "0.0.0.0", False, False, False),
-        (False, "0.0.0.0", False, False, False),
-        (None, "127.0.0.1", False, False, False),
+        # Every tunnel launch prompts regardless of the terminal; the headless
+        # fallback is handled downstream, not here.
+        *[(c, h, s, a, False, e) for c, h, s, a, e in _TUNNEL_MATRIX if e],
+        *[(c, h, s, a, True, e) for c, h, s, a, e in _TUNNEL_MATRIX if e],
+        # The change: a RAW wildcard bind with a terminal attached. Reachable by
+        # every host on the network with the seeded password live, and it starts
+        # no tunnel, so before this it got no prompt at all.
+        (None, "0.0.0.0", False, False, True, True),
+        (False, "0.0.0.0", False, False, True, True),
+        (None, "::", False, False, True, True),
+        (None, "0", False, False, True, True),
+        (None, "::ffff:0.0.0.0", False, False, True, True),
+        # Headless raw binds stay exactly as they were: no prompt, no strip, no
+        # refusal. Long-running containers are the common use of this flag and
+        # the bootstrap deadline is what covers them.
+        (None, "0.0.0.0", False, False, False, False),
+        (False, "0.0.0.0", False, False, False, False),
+        (None, "::", False, False, False, False),
+        # --api-only authenticates by API key, not the admin password.
+        (None, "0.0.0.0", False, True, True, False),
+        # Loopback is not exposed, so nothing changes for plain `unsloth studio`.
+        (None, "127.0.0.1", False, False, True, False),
+        (None, "localhost", False, False, True, False),
+        (None, "", False, False, True, False),
     ],
 )
-def test_should_prompt_password_change_matrix(cloudflare, host, secure, api_only, expected):
+def test_should_prompt_password_change_matrix(
+    monkeypatch, cloudflare, host, secure, api_only, interactive, expected
+):
+    monkeypatch.setattr(
+        _studio(), "_prompt_streams_interactive", lambda: interactive
+    )
     assert (
         _studio()._should_prompt_password_change(
             cloudflare = cloudflare, host = host, secure = secure, api_only = api_only
@@ -694,7 +743,7 @@ def test_studio_default_connect_failure_fails_closed(monkeypatch, tmp_path):
     assert "exec" not in kinds, events
     assert result.exit_code == 1, result.output
     combined = (result.output or "") + (getattr(result, "stderr", "") or "")
-    assert "refusing to publish" in combined.lower()
+    assert "refusing to expose" in combined.lower()
     # Not stripped: a retry can still prompt/strip once the lock clears.
     assert bootstrap_file.exists()
 
@@ -717,7 +766,7 @@ def test_studio_default_seed_commit_failure_fails_closed(monkeypatch, tmp_path):
     assert "exec" not in kinds, events
     assert result.exit_code == 1, result.output
     combined = (result.output or "") + (getattr(result, "stderr", "") or "")
-    assert "refusing to publish" in combined.lower()
+    assert "refusing to expose" in combined.lower()
     # The half-written seed file is stripped, and no admin row was committed.
     assert not (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).exists()
     verify = sqlite3.connect(_auth_db(tmp_path))

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -12,6 +12,7 @@ test_studio_cloudflare_flag.py.
 
 from __future__ import annotations
 
+import io
 import sqlite3
 import sys
 from pathlib import Path
@@ -203,7 +204,7 @@ def _install_prompt_env(
     # dedicated test that overrides this.
     monkeypatch.setattr(studio_mod, "_tunnel_binary_confirmed_unavailable", lambda: False)
 
-    def fake_prompt(verify_current, out = None):
+    def fake_prompt(verify_current, out = None, **_kw):
         events.append(("prompt", verify_current))
         if isinstance(scripted, BaseException):
             raise scripted
@@ -1832,3 +1833,159 @@ def test_cli_and_backend_agree_on_which_hosts_are_exposed(monkeypatch, host):
         f"{host!r}: CLI prompts={cli_prompts} but the backend considers it "
         f"exposed={backend_exposed}; the parent gate and the child gate disagree"
     )
+
+
+# ── a backgrounded shell job is not a usable terminal ─────────────────
+
+
+def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
+    """`unsloth studio -H 0.0.0.0 &` must still launch.
+
+    A background job inherits the terminal, so isatty() is True on both streams,
+    but the masked prompt calls termios.tcsetattr; POSIX sends SIGTTOU to a
+    background process group that does, and the default action STOPS the process.
+    The launch would freeze at the prompt before the socket binds, i.e. a launch
+    that worked before this gate widened to raw binds stops working. It keeps the
+    protection it already had, the bootstrap deadline.
+    """
+    studio = _studio()
+    monkeypatch.setattr(studio, "_prompt_streams_interactive", lambda: True)
+    monkeypatch.setattr(studio.os, "tcgetpgrp", lambda _fd: 4242)
+    monkeypatch.setattr(studio.os, "getpgrp", lambda: 99)
+    monkeypatch.setattr(studio.sys, "stdin", _FdStream())
+
+    assert studio._should_prompt_password_change(
+        cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
+    ) is False
+    # The tunnel is published on the public internet either way: it must keep
+    # failing closed rather than quietly proceeding.
+    assert studio._should_prompt_password_change(
+        cloudflare = None, host = "0.0.0.0", secure = True, api_only = False
+    ) is True
+
+
+def test_a_foreground_raw_bind_still_prompts(monkeypatch):
+    """The ordinary interactive case is untouched."""
+    studio = _studio()
+    monkeypatch.setattr(studio, "_prompt_streams_interactive", lambda: True)
+    monkeypatch.setattr(studio.os, "tcgetpgrp", lambda _fd: 4242)
+    monkeypatch.setattr(studio.os, "getpgrp", lambda: 4242)
+    monkeypatch.setattr(studio.sys, "stdin", _FdStream())
+
+    assert studio._should_prompt_password_change(
+        cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
+    ) is True
+
+
+@pytest.mark.parametrize("raised", [OSError("ENOTTY"), AttributeError(), ValueError()])
+def test_no_job_control_falls_back_to_the_isatty_answer(monkeypatch, raised):
+    """Windows / no controlling terminal: nothing can stop us, so still prompt."""
+    studio = _studio()
+    monkeypatch.setattr(studio, "_prompt_streams_interactive", lambda: True)
+
+    def _boom(_fd):
+        raise raised
+
+    monkeypatch.setattr(studio.os, "tcgetpgrp", _boom, raising = False)
+    monkeypatch.setattr(studio.sys, "stdin", _FdStream())
+
+    assert studio._should_prompt_password_change(
+        cloudflare = None, host = "0.0.0.0", secure = False, api_only = False
+    ) is True
+
+
+class _FdStream:
+    def fileno(self): return 0
+    def isatty(self): return True
+
+
+# ── a pty is not a person ────────────────────────────────────────────
+
+
+def test_an_unattended_pty_still_launches_a_raw_bind(monkeypatch, tmp_path):
+    """`tmux new -d 'unsloth studio -H 0.0.0.0'` must still start Unsloth.
+
+    A detached pty (tmux/screen/`docker run -dt`) is a real, foreground terminal
+    that nobody will ever type into: both streams are ttys and the process owns
+    the terminal, so every interactivity test says "prompt" and the read then
+    never returns. The gate runs before any server exists, so without a deadline
+    the launch hangs forever instead of starting. It must fall back to the
+    protection it already had, the bootstrap deadline.
+    """
+    studio_mod = _studio()
+    events = _install_prompt_env(
+        monkeypatch,
+        tmp_path,
+        interactive = True,
+        scripted = studio_mod._password_prompt.PromptUnattended(),
+    )
+    monkeypatch.setattr(studio_mod, "_prompt_owns_the_terminal", lambda: True)
+    _seed_auth(studio_mod)
+
+    result = _invoke_studio_default(monkeypatch, events, ["-H", "0.0.0.0"])
+
+    kinds = [kind for kind, _ in events]
+    assert kinds == ["prompt", "exec"], events
+    assert result.exit_code == 0, result.output
+    # Unchanged password, and the seeded file is kept: a raw bind never strips.
+    assert _auth_state(studio_mod)["must_change_password"] == 1
+    assert (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).exists()
+
+
+def test_an_unattended_pty_still_aborts_a_tunnel_launch(monkeypatch, tmp_path):
+    """A tunnel publishes a public URL, so it gets no deadline and no fallback."""
+    studio_mod = _studio()
+    seen = {}
+
+    def _fake_prompt(verify_current, out = None, **kw):
+        seen.update(kw)
+        return _NEW_PW
+
+    events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
+    monkeypatch.setattr(studio_mod._password_prompt, "prompt_new_password", _fake_prompt)
+    _seed_auth(studio_mod)
+
+    _invoke_studio_default(monkeypatch, events, ["--secure"])
+    assert seen["first_key_timeout"] is None
+
+
+def test_a_raw_bind_prompt_carries_the_unattended_deadline(monkeypatch, tmp_path):
+    """The other half: only the launch that must not be blocked is deadlined."""
+    studio_mod = _studio()
+    seen = {}
+
+    def _fake_prompt(verify_current, out = None, **kw):
+        seen.update(kw)
+        return _NEW_PW
+
+    events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
+    monkeypatch.setattr(studio_mod._password_prompt, "prompt_new_password", _fake_prompt)
+    monkeypatch.setattr(studio_mod, "_prompt_owns_the_terminal", lambda: True)
+    _seed_auth(studio_mod)
+
+    _invoke_studio_default(monkeypatch, events, ["-H", "0.0.0.0"])
+    assert seen["first_key_timeout"] == studio_mod._UNATTENDED_PROMPT_SECONDS
+
+
+def test_read_masked_gives_up_on_a_pty_nobody_types_into(monkeypatch):
+    """The mechanism itself, against a real pty with no writer."""
+    import os
+    import pty
+
+    from unsloth_cli.commands import _password_prompt
+
+    master, slave = pty.openpty()
+
+    class _PtyStdin:
+        encoding = "utf-8"
+        def fileno(self): return slave
+        def isatty(self): return True
+
+    try:
+        monkeypatch.setattr(_password_prompt.sys, "stdin", _PtyStdin())
+        out = io.StringIO()
+        with pytest.raises(_password_prompt.PromptUnattended):
+            _password_prompt.read_masked("New password: ", out, first_key_timeout = 0.25)
+    finally:
+        os.close(master)
+        os.close(slave)

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import io
 import sqlite3
+import os
 import sys
 from pathlib import Path
 
@@ -1921,6 +1922,12 @@ def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
     )
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
+             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+)
 def test_a_foreground_raw_bind_still_prompts(monkeypatch):
     """The ordinary interactive case is untouched."""
     studio = _studio()
@@ -2040,6 +2047,12 @@ def test_a_raw_bind_prompt_carries_the_unattended_deadline(monkeypatch, tmp_path
     assert seen["first_key_timeout"] == studio_mod._UNATTENDED_PROMPT_SECONDS
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
+             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+)
 def test_read_masked_gives_up_on_a_pty_nobody_types_into(monkeypatch):
     """The mechanism itself, against a real pty with no writer."""
     import os

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -1774,13 +1774,25 @@ def test_studio_default_password_applies_on_headless_wildcard_no_tunnel(monkeypa
 
 _EXPOSURE_HOSTS = [
     # wildcard spellings
-    "0.0.0.0", "::", "::0", "0:0:0:0:0:0:0:0", "0", "::ffff:0.0.0.0",
+    "0.0.0.0",
+    "::",
+    "::0",
+    "0:0:0:0:0:0:0:0",
+    "0",
+    "::ffff:0.0.0.0",
     # loopback aliases
-    "127.0.0.1", "localhost", "::1",
+    "127.0.0.1",
+    "localhost",
+    "::1",
     # concrete external addresses and names
-    "192.168.1.50", "10.0.0.5", "172.16.4.9", "example.com", "myhost.local",
+    "192.168.1.50",
+    "10.0.0.5",
+    "172.16.4.9",
+    "example.com",
+    "myhost.local",
     # odd spellings
-    "[::]", "0.0.0.0.0",
+    "[::]",
+    "0.0.0.0.0",
 ]
 
 

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -32,6 +32,20 @@ def _studio():
 
 
 _BASE = ["--model", "unsloth/Qwen3-1.7B-GGUF"]
+
+
+@pytest.fixture(autouse = True)
+def _no_leaked_unattended_marker(monkeypatch):
+    """Start every test with the unattended marker unset.
+
+    The gate writes it straight into os.environ, which is exactly right in
+    production (it is inherited across the re-exec and nowhere else) and exactly
+    wrong in a test process, where it then survives into every later test and
+    silently suppresses the very prompt they are asserting on.
+    """
+    import unsloth_cli.commands.studio as studio_mod
+
+    monkeypatch.delenv(studio_mod._UNATTENDED_PROMPT_DONE_ENV, raising = False)
 _NEW_PW = "brand-new-password"
 
 
@@ -2146,3 +2160,110 @@ def test_a_tunnel_ctrl_c_still_aborts(monkeypatch, tmp_path):
         studio_mod._enforce_password_change_before_exposure(
             cloudflare = None, host = "127.0.0.1", secure = True, api_only = False
         )
+
+
+def test_a_second_cli_gate_does_not_re_wait_the_same_dead_terminal(monkeypatch, tmp_path):
+    """`unsloth studio run` re-execs and re-enters this gate on the SAME pty.
+
+    The parent waits its deadline, nobody types, and it marks the terminal as
+    already tried. Without honouring that mark the child waits the whole deadline
+    over again, so 30s becomes 60s before the backend gate has even had its turn,
+    which is long enough to trip a startup watchdog. The mark is peeked, never
+    popped: run.py is what consumes it.
+    """
+    studio_mod = _studio()
+    calls = []
+
+    def _fake_prompt(verify_current, out = None, **kw):
+        calls.append(kw)
+        raise studio_mod._password_prompt.PromptUnattended
+
+    events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
+    monkeypatch.setattr(studio_mod._password_prompt, "prompt_new_password", _fake_prompt)
+    monkeypatch.setattr(studio_mod, "_prompt_owns_the_terminal", lambda: True)
+    _seed_auth(studio_mod)
+
+    # Parent: waits, gets nothing, marks the terminal.
+    _invoke_studio_default(monkeypatch, events, ["-H", "0.0.0.0"])
+    assert len(calls) == 1
+    import os as _os
+    assert _os.environ.get(studio_mod._UNATTENDED_PROMPT_DONE_ENV) == "1"
+
+    # Child, after the re-exec: same terminal, must not sit on it again.
+    _invoke_studio_default(monkeypatch, events, ["-H", "0.0.0.0"])
+    assert len(calls) == 1, "the re-executed gate waited on the dead terminal again"
+    assert _os.environ.get(studio_mod._UNATTENDED_PROMPT_DONE_ENV) == "1", "popped, not peeked"
+
+
+def test_the_mark_never_lets_a_tunnel_skip_its_prompt(monkeypatch, tmp_path):
+    """A public URL fails closed, mark or no mark."""
+    studio_mod = _studio()
+    calls = []
+
+    def _fake_prompt(verify_current, out = None, **kw):
+        calls.append(kw)
+        return _NEW_PW
+
+    events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
+    monkeypatch.setattr(studio_mod._password_prompt, "prompt_new_password", _fake_prompt)
+    monkeypatch.setattr(studio_mod, "_prompt_owns_the_terminal", lambda: True)
+    monkeypatch.setenv(studio_mod._UNATTENDED_PROMPT_DONE_ENV, "1")
+    _seed_auth(studio_mod)
+
+    _invoke_studio_default(monkeypatch, events, ["--secure"])
+    assert len(calls) == 1, "a tunnel launch skipped its prompt because of the mark"
+
+
+def _banner(monkeypatch, tmp_path, args):
+    """Run the gate far enough to capture the banner it prints, then bail out.
+
+    Clears the unattended mark first: bailing out with an interrupt SETS it on a
+    raw bind, so a second call in the same test would skip the prompt and capture
+    no banner at all.
+    """
+    import os as _os
+
+    studio_mod = _studio()
+    _os.environ.pop(studio_mod._UNATTENDED_PROMPT_DONE_ENV, None)
+
+    def _fake_prompt(verify_current, out = None, **kw):
+        raise KeyboardInterrupt
+
+    events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
+    monkeypatch.setattr(studio_mod._password_prompt, "prompt_new_password", _fake_prompt)
+    monkeypatch.setattr(studio_mod, "_prompt_owns_the_terminal", lambda: True)
+    _seed_auth(studio_mod)
+    result = _invoke_studio_default(monkeypatch, events, args)
+    return (result.output or "") + (getattr(result, "stderr", "") or "")
+
+
+def test_the_banner_does_not_promise_an_abort_a_raw_bind_will_not_perform(
+    monkeypatch, tmp_path,
+):
+    """`Ctrl+C to abort` is true for a tunnel and false for a raw bind.
+
+    On a raw bind the interrupt declines the prompt and the launch continues, by
+    design, because that launch worked before this gate existed. An operator who
+    reads "abort", presses Ctrl+C and walks away would be leaving a server up on
+    the network with the auto-generated password.
+    """
+    raw = _banner(monkeypatch, tmp_path, ["-H", "0.0.0.0"])
+    assert "Ctrl+C to abort" not in raw
+    assert "Ctrl+C to skip" in raw
+
+    tunnel = _banner(monkeypatch, tmp_path, ["--secure"])
+    assert "Ctrl+C to abort" in tunnel
+
+
+def test_a_concrete_bind_is_not_described_as_every_interface(monkeypatch, tmp_path):
+    """`-H 192.168.1.50` listens on one address, so say so.
+
+    The gate widened to is_external_host, which routes concrete non-loopback
+    hosts down the same path as the wildcard, and they inherited its wording.
+    """
+    concrete = _banner(monkeypatch, tmp_path, ["-H", "192.168.1.50"])
+    assert "on every network interface" not in concrete
+    assert "192.168.1.50" in concrete
+
+    wildcard = _banner(monkeypatch, tmp_path, ["-H", "0.0.0.0"])
+    assert "on every network interface" in wildcard


### PR DESCRIPTION
## Before

The terminal password gate keys off the Cloudflare tunnel:

```python
# studio/backend/run.py
if not tunnel_will_start:
    return True, False

# unsloth_cli/commands/studio.py
if secure:
    return True
if cloudflare is not True:
    return False
```

So `unsloth studio -H 0.0.0.0` never reached it. That launch is reachable by every host on the network, and by the internet on a machine with a public address, while starting no tunnel. It got **no prompt, no warning and no strip**: the seeded admin password stayed live and was served in the page to whoever loaded it. The only thing behind it was the 1h bootstrap deadline, which shuts Studio down after the fact rather than preventing access during it.

The gate's own docstring already described the hazard:

> Must run BEFORE the uvicorn socket binds: on a wildcard bind the served HTML injects the bootstrap credential, so a pre-gate listener would hand the default password to anyone reaching the raw port while the operator types.

and then returned early when no tunnel was starting.

## After

A raw non-loopback bind counts as exposure, so `-H 0.0.0.0` gets the same masked, confirmed prompt that `--cloudflare` already gets, before the socket binds.

Scoped like the bootstrap deadline: web UI only, never `--api-only` (which authenticates by API key rather than the admin password) and never Colab.

## Only when a terminal is attached

This is the part worth reviewing closely. Everything downstream of the gate is calibrated to publishing a public URL: it refuses to launch when the deadline is disabled, and it deletes `.bootstrap_password`. Long-running headless containers are the common use of `-H 0.0.0.0`, and are often logged into by reading exactly that file.

So a headless raw bind keeps today's behaviour byte for byte, protected by the deadline as before, and only a launch with a human present is asked to set a password. There is a test pinning that specifically:

```
test_a_headless_raw_bind_is_byte_for_byte_unchanged
```

If we later decide headless should be covered too, it is a one-line widening on top of this.

## Compatibility

- **Plain `unsloth studio` is untouched.** Loopback is not exposed, and a test asserts the gate does not even consult storage on that path.
- **`--secure` and `--cloudflare` are unchanged.** The old tunnel-only predicate is preserved verbatim as `_launch_publishes_tunnel`, with its matrix pinned.
- **The two strip-and-lockout guards keep the narrow predicate.** They exist because a headless tunnel launch strips `.bootstrap_password` and could lock the admin out. A raw bind never strips, so widening them would add failure modes that protect nothing.
- **Headless containers, k8s, Docker, `UNSLOTH_STUDIO_BOOTSTRAP_TIMEOUT=0`:** all unchanged.
- **`bind_is_exposed` defaults to `False`,** so any caller that has not been updated behaves exactly as before.

One detail worth noting: `_is_exposed_bind` is called with `secure = False` on purpose. It counts `--secure` as exposed because for a tunnel launch the tunnel is the exposure, but `--secure` forces a loopback bind, so passing `secure` through would conflate "the tunnel publishes this" with "the socket itself is reachable". Only the second question matters here; the first is already `tunnel_will_start`.

## Wording

The prompt banner and two error messages hardcoded "the public internet". A wildcard bind behind a NAT router is the LAN, not the internet, and claiming otherwise trains people to ignore the one message that has to be read. `exposure` is now passed in and reads "on every network interface" for a raw bind, "on a public Cloudflare URL" for a tunnel.

## Testing

- 28 of the added tests fail without the source change and pass with it.
- `unsloth_cli/tests/`: 1301 passed, 6 skipped.
- Backend auth, password, bootstrap, login, desktop, prompt, cors, index, host and colab suites: 831 passed. The 6 failures in that run are missing optional dependencies in the sandbox and reproduce identically on a clean `main`.
- New coverage: the interactive raw-bind prompt, the headless raw-bind no-op, loopback short-circuit, `--api-only` and Colab exclusions, the default-argument compatibility case, and the banner wording.

## Scope

Only `unslothai/unsloth`. The Studio CLI and backend both live here, so there is nothing to change in `unsloth-zoo`, `notebooks` or `llama.cpp`.

This is independent of #10387 and does not depend on it. #10387 reduces the value of what sits in the page; this one stops the seeded password being live on that launch in the first place.
