### PR TITLE
Pin the accelerator index for torchao too, and let a starved index pin fall back

### DIFF
--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -174,22 +174,43 @@ def test_the_index_pin_starves_only_where_the_retry_covers_it(monkeypatch):
     }, sorted(starved)
 
 
+def _torchao_installer_source():
+    source = _INSTALL_SCRIPT.read_text(encoding = "utf-8")
+    body = source.split("def _install_torchao_for_torch(", 1)[1]
+    return body.split("\ndef ", 1)[0]
+
+
 def test_the_torchao_step_pins_the_index_and_retries_without_it():
     """cu129 serves torch to 2.13 but stops at torchao 0.17.0, and a leaf added upstream
     after this ships can lag a release, so the pin must not be able to fail an install.
     Unlike torchcodec the retry stays FATAL if it also fails: torchao is not optional."""
-    source = _INSTALL_SCRIPT.read_text(encoding = "utf-8")
-    step = source.split("# 4. Install the torch-matched torchao override", 1)[1]
-    step = step.split("# 5. Triton kernels", 1)[0]
-    assert "_torchao_index = _torch_accelerator_index_url(_torch_ver)" in step
-    assert '"--index-url",\n            _torchao_index,' in step
-    assert "retrying from the default index" in step
+    body = _torchao_installer_source()
+    assert "index = _torch_accelerator_index_url(torch_version)" in body
+    assert '"--index-url", index, spec' in body
+    assert "retrying from the default index" in body
     # The unpinned attempt is pip_install, not pip_install_try: still fatal on failure.
-    retry = step.split("retrying from the default index", 1)[1]
-    assert 'pip_install("Installing dependency overrides", *_torchao_args, _torchao_spec)' in retry
+    retry = body.split("retrying from the default index", 1)[1]
+    assert 'pip_install("Installing dependency overrides", *args, spec)' in retry
     assert "--index-url" not in retry
     # And the printed line redacts, since a mirror URL can carry credentials.
-    assert "_strip_index_url_credentials(_torchao_index)" in step
+    assert "_strip_index_url_credentials(index)" in body
+
+
+def test_the_fallback_is_blocked_where_a_cuda_12_build_cannot_load(monkeypatch):
+    """PyPI only builds torchao for CUDA 12. torchao's cpp loads whenever the torch RELEASE
+    matches, so on a CUDA-13, ROCm or XPU torch the fallback would trade "kernels skipped"
+    for libcudart.so.12 at import. A private mirror makes this reachable without any public
+    index lagging: it can serve torch and not the selected torchao."""
+    mod = _load_module(monkeypatch)
+    for version in ("2.13.0+cu130", "2.13.0+cu132", "2.11.0+rocm7.2", "2.10.0+xpu"):
+        assert not mod._default_index_torchao_can_load(version), version
+    for version in ("2.13.0+cu128", "2.9.0+cu118", "2.13.0+cpu", "2.13.0", None, ""):
+        assert mod._default_index_torchao_can_load(version), version
+    # And the installer takes that branch rather than falling back.
+    body = _torchao_installer_source()
+    assert "if not _default_index_torchao_can_load(torch_version):" in body
+    blocked = body.split("if not _default_index_torchao_can_load(torch_version):", 1)[1]
+    assert "Leaving torchao alone" in blocked.split("_note(", 1)[0]
 
 
 @pytest.mark.parametrize(
@@ -249,13 +270,30 @@ def test_the_wanted_tag_follows_the_index_that_will_be_pinned(monkeypatch):
     assert mod._torch_index_tag("2.13.0+cu128") == "cu128"
 
 
-def test_both_torchao_call_sites_ask_for_the_pinned_tag():
-    """Two places install torchao, step 4 and the post-repair resync. Passing the torch
-    version to either would reintroduce the drift the helper exists to remove."""
+def test_every_torchao_call_site_asks_for_the_pinned_tag():
+    """Passing the torch version rather than the pinned tag would reintroduce the drift the
+    helper exists to remove, so no call site may spell it any other way."""
     source = _INSTALL_SCRIPT.read_text(encoding = "utf-8")
     assert source.count("_pin_needs_reinstall(") == 3  # the def plus both call sites
-    assert "_torch_index_tag(_torch_ver) if _torchao_index else _NO_INDEX_PINNED" in source
+    assert "_torch_index_tag(torch_version) if index else _NO_INDEX_PINNED" in source
     assert "_torch_index_tag(_label_after) if _ao_index else _NO_INDEX_PINNED" in source
+
+
+def test_torchao_is_re_selected_after_the_linux_torch_repair():
+    """Step 4 chooses torchao from the torch present BEFORE step 13's repairs, which move
+    torch across families and releases. The explicit XPU pin is the sharp case: its spec is
+    torch>=2.6,<2.11.0, so it necessarily lands below the 2.11 floor torchao 0.18.0 needs,
+    leaving 0.18.0 beside torch 2.10. Only the Windows flavor repair reaches
+    _resync_torch_coupled_packages, so on Linux nothing re-selected it."""
+    source = _INSTALL_SCRIPT.read_text(encoding = "utf-8")
+    step = source.split('_progress(_torch_step_label("final"))', 1)[1]
+    step = step.split("# 13w.", 1)[0]
+    assert "_torch_before_repair = str(_probe_installed_torch_version() or \"\")" in step
+    assert "_install_torchao_for_torch(_torch_after_repair)" in step
+    # Guarded on an actual move, so an install where nothing shifted pays no second resolve.
+    assert "if _torch_after_repair and _torch_after_repair != _torch_before_repair:" in step
+    # The XPU repair really does land below the 0.18.0 floor.
+    assert '"torch>=2.6,<2.11.0",' in source
 
 
 def test_windows_first_hop_uses_einx_wheel_without_shared_test_tree():

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -198,21 +198,27 @@ def test_the_torchao_step_pins_the_index_and_retries_without_it():
     assert "_strip_index_url_credentials(index)" in body
 
 
-def test_the_fallback_is_blocked_where_a_cuda_12_build_cannot_load(monkeypatch):
-    """PyPI only builds torchao for CUDA 12. torchao's cpp loads whenever the torch RELEASE
-    matches, so on a CUDA-13, ROCm or XPU torch the fallback would trade "kernels skipped"
-    for libcudart.so.12 at import. A private mirror makes this reachable without any public
-    index lagging: it can serve torch and not the selected torchao."""
-    mod = _load_module(monkeypatch)
-    for version in ("2.13.0+cu130", "2.13.0+cu132", "2.11.0+rocm7.2", "2.10.0+xpu"):
-        assert not mod._default_index_torchao_can_load(version), version
-    for version in ("2.13.0+cu128", "2.9.0+cu118", "2.13.0+cpu", "2.13.0", None, ""):
-        assert mod._default_index_torchao_can_load(version), version
-    # And the installer takes that branch rather than falling back.
+def test_the_fallback_is_never_conditioned_on_the_accelerator(monkeypatch):
+    """A wrong-accelerator torchao COSTS ITS KERNELS; it does not fail to import, so the
+    fallback must stay unconditional. Guarding it on the CUDA major would regress a CUDA-13,
+    ROCm or XPU host from a working-but-slower torchao to none at all.
+
+    The premise is checked here rather than trusted, because a comment claiming otherwise is
+    what motivated a guard that had to be reverted. torchao/__init__.py has wrapped the whole
+    cpp load in try/except since 0.12.0 (and per-file since 0.16.0), logging "Failed to load
+    {file}: {e}" -- the exact message unsloth/import_fixes.py already filters as expected on
+    an ABI mismatch. Forcing torch.ops.load_library to raise the libcudart.so.12 OSError
+    leaves `import torchao` and torchao.quantization both working."""
     body = _torchao_installer_source()
-    assert "if not _default_index_torchao_can_load(torch_version):" in body
-    blocked = body.split("if not _default_index_torchao_can_load(torch_version):", 1)[1]
-    assert "Leaving torchao alone" in blocked.split("_note(", 1)[0]
+    fallback = body.split("retrying from the default index", 1)[1]
+    assert 'pip_install("Installing dependency overrides", *args, spec)' in fallback
+    # No branch may stand between the failed pin and the retry. Comments carry the word,
+    # so compare code only.
+    between = body.split("if pip_install_try(", 1)[1].split("retrying from the default index", 1)[0]
+    code = [l for l in between.split("\n") if not l.strip().startswith("#")]
+    assert not any(l.strip().startswith(("if ", "elif ")) for l in code), between
+    mod = _load_module(monkeypatch)
+    assert not hasattr(mod, "_default_index_torchao_can_load")
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -193,28 +193,69 @@ def test_the_torchao_step_pins_the_index_and_retries_without_it():
 
 
 @pytest.mark.parametrize(
-    "installed, spec, torch_version, expected",
+    "installed, spec, want_tag, expected",
     [
         # No index pinned: only the release matters, and a local tag on what is installed
         # must not force a reinstall on every single run.
-        ("0.18.0", "torchao==0.18.0", None, False),
-        ("0.18.0+cu130", "torchao==0.18.0", None, False),
-        ("0.17.0", "torchao==0.18.0", None, True),
-        (None, "torchao==0.18.0", None, True),
+        ("0.18.0", "torchao==0.18.0", "<none>", False),
+        ("0.18.0+cu130", "torchao==0.18.0", "<none>", False),
+        ("0.17.0", "torchao==0.18.0", "<none>", True),
+        (None, "torchao==0.18.0", "<none>", True),
         # Index pinned: the release can be right while the BUILD is wrong. pip counts an
         # 0.18.0+cu126 wheel as satisfying ==0.18.0, fetches nothing, and leaves exactly the
         # wrong-accelerator build the pin exists to replace.
-        ("0.18.0+cu130", "torchao==0.18.0", "2.14.0+cu130", False),
-        ("0.18.0+cu126", "torchao==0.18.0", "2.14.0+cu130", True),
-        ("0.18.0", "torchao==0.18.0", "2.14.0+cu130", True),
-        ("0.18.0+rocm7.2", "torchao==0.18.0", "2.11.0+rocm7.2", False),
-        ("0.17.0+cu130", "torchao==0.18.0", "2.14.0+cu130", True),
+        ("0.18.0+cu130", "torchao==0.18.0", "cu130", False),
+        ("0.18.0+cu126", "torchao==0.18.0", "cu130", True),
+        ("0.18.0", "torchao==0.18.0", "cu130", True),
+        ("0.18.0+rocm7.2", "torchao==0.18.0", "rocm7.2", False),
+        ("0.17.0+cu130", "torchao==0.18.0", "cu130", True),
+        # An opaque mirror proves nothing about the installed wheel, so it is replaced.
+        # Accepting it would leave an untagged wheel satisfying the pin and the mirror
+        # would never be contacted.
+        ("0.18.0", "torchao==0.18.0", None, True),
+        ("0.18.0+cu130", "torchao==0.18.0", None, True),
     ],
 )
-def test_pin_needs_reinstall(monkeypatch, installed, spec, torch_version, expected):
+def test_pin_needs_reinstall(monkeypatch, installed, spec, want_tag, expected):
     mod = _load_module(monkeypatch)
     monkeypatch.setattr(mod, "_installed_distribution_version", lambda _name: installed)
-    assert mod._pin_needs_reinstall(spec, torch_version) is expected
+    tag = mod._NO_INDEX_PINNED if want_tag == "<none>" else want_tag
+    assert mod._pin_needs_reinstall(spec, tag) is expected
+
+
+def test_the_wanted_tag_follows_the_index_that_will_be_pinned(monkeypatch):
+    """The provenance tag has to come from the leaf the pin resolves to, not from the
+    resident torch. With UNSLOTH_TORCH_INDEX_FAMILY=cu130 over a +cu128 venv the pin goes to
+    cu130 while the old comparison asked for cu128, so an 0.18.0+cu128 wheel looked correct,
+    pip found the requirement satisfied and the cu130 build was never fetched."""
+    mod = _load_module(monkeypatch)
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_URL", raising = False)
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "cu130")
+    assert mod._torch_accelerator_index_url("2.13.0+cu128").endswith("/cu130")
+    assert mod._torch_index_tag("2.13.0+cu128") == "cu130"
+
+    monkeypatch.setattr(mod, "_installed_distribution_version", lambda _name: "0.18.0+cu128")
+    assert mod._pin_needs_reinstall("torchao==0.18.0", mod._torch_index_tag("2.13.0+cu128"))
+    monkeypatch.setattr(mod, "_installed_distribution_version", lambda _name: "0.18.0+cu130")
+    assert not mod._pin_needs_reinstall("torchao==0.18.0", mod._torch_index_tag("2.13.0+cu128"))
+
+    # An explicit URL is opaque, so nothing can prove where a wheel came from.
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.corp.example/whl/cu130")
+    assert mod._torch_index_tag("2.13.0+cu128") is None
+
+    # And with no override at all the resident tag is still what is asked for.
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_URL")
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY")
+    assert mod._torch_index_tag("2.13.0+cu128") == "cu128"
+
+
+def test_both_torchao_call_sites_ask_for_the_pinned_tag():
+    """Two places install torchao, step 4 and the post-repair resync. Passing the torch
+    version to either would reintroduce the drift the helper exists to remove."""
+    source = _INSTALL_SCRIPT.read_text(encoding = "utf-8")
+    assert source.count("_pin_needs_reinstall(") == 3  # the def plus both call sites
+    assert "_torch_index_tag(_torch_ver) if _torchao_index else _NO_INDEX_PINNED" in source
+    assert "_torch_index_tag(_label_after) if _ao_index else _NO_INDEX_PINNED" in source
 
 
 def test_windows_first_hop_uses_einx_wheel_without_shared_test_tree():

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -51,10 +51,22 @@ def _load_module(monkeypatch):
         ("2.10.0.dev20250804+cu130", "torchao==0.17.0"),
         ("2.10.0.dev20250804+cu128", "torchao==0.16.0"),
         ("2.10rc1", "torchao==0.16.0"),
-        # torch 2.11 (reachable via ROCm rocm7.2) and forward -> 0.17.0.
+        # torch 2.11 (reachable via ROCm rocm7.2) -> 0.17.0, whose cpp is built for it.
         ("2.11.0+cu130", "torchao==0.17.0"),
         ("2.11.0", "torchao==0.17.0"),
-        ("2.12.0", "torchao==0.17.0"),
+        ("2.11.1+cu126", "torchao==0.17.0"),
+        # torch 2.12 and forward -> 0.18.0. 0.18.0 dropped torch <2.11 and pinned its
+        # release CI to 2.13, and 0.17.0's own upstream table stops supporting the Python
+        # API at 2.11, so leaving this range on 0.17.0 ran it outside its declared window.
+        ("2.12.0", "torchao==0.18.0"),
+        ("2.12.1+cu130", "torchao==0.18.0"),
+        ("2.13.0+cu132", "torchao==0.18.0"),
+        ("2.14.0+cu130", "torchao==0.18.0"),
+        ("2.14.0+xpu", "torchao==0.18.0"),
+        ("2.99.0", "torchao==0.18.0"),
+        # The CUDA-13 branch belongs to 2.10 alone; it must not leak upward.
+        ("2.12.0+cu126", "torchao==0.18.0"),
+        ("2.12.0.dev20260801+cu132", "torchao==0.18.0"),
         # torch <=2.9 keeps today's pin (already a correct match for 2.9.0).
         ("2.9.0+cu128", "torchao==0.14.0"),
         ("2.9.1", "torchao==0.14.0"),
@@ -85,6 +97,124 @@ def test_matching_torchao_pin_does_not_need_force_reinstall(monkeypatch):
     monkeypatch.setattr(mod, "_installed_distribution_version", lambda _name: "0.17.0")
     assert mod._exact_distribution_spec_is_installed("torchao==0.17.0")
     assert not mod._exact_distribution_spec_is_installed("torchao==0.16.0")
+
+
+@pytest.mark.parametrize(
+    "torch_version, leaf",
+    [
+        ("2.12.0+cu126", "cu126"),
+        ("2.13.0+cu132", "cu132"),
+        ("2.14.0+cu130", "cu130"),
+        ("2.11.0+rocm7.2", "rocm7.2"),  # rocm DOES publish torchao, unlike torchcodec
+        ("2.9.0+rocm6.4", "rocm6.4"),
+        ("2.14.0+xpu", "xpu"),
+        ("2.12.0+cpu", "cpu"),
+        # Untagged torch is PyPI's own build and its counterpart is PyPI's own torchao.
+        ("2.14.0", None),
+        ("2.11.0", None),
+        (None, None),
+        ("", None),
+        ("garbage", None),
+    ],
+)
+def test_the_torchao_index_follows_the_resident_torch_build(monkeypatch, torch_version, leaf):
+    """torchao publishes a wheel per accelerator and PyPI's default is the CUDA-12 one, so
+    an unpinned install puts a CUDA-12 cpp beside a CUDA-13 or ROCm torch. That is the
+    `libcudart.so.12: cannot open shared object file` the 2.10 CUDA-13 row already dodges by
+    picking a build whose cpp gets skipped instead."""
+    mod = _load_module(monkeypatch)
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_URL", raising = False)
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY", raising = False)
+    got = mod._torch_accelerator_index_url(torch_version)
+    assert got == (f"https://download.pytorch.org/whl/{leaf}" if leaf else None)
+
+
+# What each accelerator leaf publishes for torchao, read off the live listings. Only the
+# leaves whose inventory does NOT cover every release this selector can ask for are listed:
+# everything absent from here serves its whole range.
+_TORCHAO_INDEX_GAPS = {
+    "cu118": ({m: f"0.{m}.0" for m in range(3, 12)}, range(5, 8)),
+    "cu129": ({12: "0.12.0", 13: "0.13.0", 14: "0.14.1", 15: "0.15.0", 16: "0.16.0",
+               17: "0.17.0"}, range(8, 14)),
+    "rocm7.0": ({16: "0.16.0"}, range(9, 11)),
+}
+
+
+def test_the_index_pin_starves_only_where_the_retry_covers_it(monkeypatch):
+    """A pin that could not be served would fail an install, because this step is fatal.
+
+    Four cells cannot be served, and none of them is predictable from a rule: cu118 stops at
+    torchao 0.11.0, rocm7.0 carries 0.16.0 alone, and cu129 has 0.14.1 where the 2.9 row asks
+    for 0.14.0 exactly -- a hole in the MIDDLE of its range, which no floor could describe.
+    All four resolve from the default index, which is where they came from before this step
+    pinned anything, so the retry makes them identical to today rather than broken. Recording
+    them here means a fifth cannot appear unnoticed.
+    """
+    mod = _load_module(monkeypatch)
+    starved = set()
+    for leaf, (published, torch_minors) in _TORCHAO_INDEX_GAPS.items():
+        for minor in torch_minors:
+            version = f"2.{minor}.0+{leaf}"
+            assert mod._torch_accelerator_index_url(version).endswith("/" + leaf)
+            wanted = mod._select_torchao_spec(version).split("==", 1)[1]
+            if wanted not in published.values():
+                starved.add((leaf, minor, wanted))
+    assert starved == {
+        # cu118 tops out at torchao 0.11.0, so every torch it serves wants more than it has.
+        ("cu118", 5, "0.14.0"),
+        ("cu118", 6, "0.14.0"),
+        ("cu118", 7, "0.14.0"),
+        # cu129 publishes 0.14.1, not 0.14.0, and stops at 0.17.0.
+        ("cu129", 8, "0.14.0"),
+        ("cu129", 9, "0.14.0"),
+        ("cu129", 12, "0.18.0"),
+        ("cu129", 13, "0.18.0"),
+        # rocm7.0 publishes 0.16.0 alone, which is what its torch 2.10 row already wants.
+        ("rocm7.0", 9, "0.14.0"),
+    }, sorted(starved)
+
+
+def test_the_torchao_step_pins_the_index_and_retries_without_it():
+    """cu129 serves torch to 2.13 but stops at torchao 0.17.0, and a leaf added upstream
+    after this ships can lag a release, so the pin must not be able to fail an install.
+    Unlike torchcodec the retry stays FATAL if it also fails: torchao is not optional."""
+    source = _INSTALL_SCRIPT.read_text(encoding = "utf-8")
+    step = source.split("# 4. Install the torch-matched torchao override", 1)[1]
+    step = step.split("# 5. Triton kernels", 1)[0]
+    assert "_torchao_index = _torch_accelerator_index_url(_torch_ver)" in step
+    assert '"--index-url",\n            _torchao_index,' in step
+    assert "retrying from the default index" in step
+    # The unpinned attempt is pip_install, not pip_install_try: still fatal on failure.
+    retry = step.split("retrying from the default index", 1)[1]
+    assert 'pip_install("Installing dependency overrides", *_torchao_args, _torchao_spec)' in retry
+    assert "--index-url" not in retry
+    # And the printed line redacts, since a mirror URL can carry credentials.
+    assert "_strip_index_url_credentials(_torchao_index)" in step
+
+
+@pytest.mark.parametrize(
+    "installed, spec, torch_version, expected",
+    [
+        # No index pinned: only the release matters, and a local tag on what is installed
+        # must not force a reinstall on every single run.
+        ("0.18.0", "torchao==0.18.0", None, False),
+        ("0.18.0+cu130", "torchao==0.18.0", None, False),
+        ("0.17.0", "torchao==0.18.0", None, True),
+        (None, "torchao==0.18.0", None, True),
+        # Index pinned: the release can be right while the BUILD is wrong. pip counts an
+        # 0.18.0+cu126 wheel as satisfying ==0.18.0, fetches nothing, and leaves exactly the
+        # wrong-accelerator build the pin exists to replace.
+        ("0.18.0+cu130", "torchao==0.18.0", "2.14.0+cu130", False),
+        ("0.18.0+cu126", "torchao==0.18.0", "2.14.0+cu130", True),
+        ("0.18.0", "torchao==0.18.0", "2.14.0+cu130", True),
+        ("0.18.0+rocm7.2", "torchao==0.18.0", "2.11.0+rocm7.2", False),
+        ("0.17.0+cu130", "torchao==0.18.0", "2.14.0+cu130", True),
+    ],
+)
+def test_pin_needs_reinstall(monkeypatch, installed, spec, torch_version, expected):
+    mod = _load_module(monkeypatch)
+    monkeypatch.setattr(mod, "_installed_distribution_version", lambda _name: installed)
+    assert mod._pin_needs_reinstall(spec, torch_version) is expected
 
 
 def test_windows_first_hop_uses_einx_wheel_without_shared_test_tree():

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -51,13 +51,12 @@ def _load_module(monkeypatch):
         ("2.10.0.dev20250804+cu130", "torchao==0.17.0"),
         ("2.10.0.dev20250804+cu128", "torchao==0.16.0"),
         ("2.10rc1", "torchao==0.16.0"),
-        # torch 2.11 (reachable via ROCm rocm7.2) -> 0.17.0, whose cpp is built for it.
+        # 2.11 -> 0.17.0, whose cpp is built for it.
         ("2.11.0+cu130", "torchao==0.17.0"),
         ("2.11.0", "torchao==0.17.0"),
         ("2.11.1+cu126", "torchao==0.17.0"),
-        # torch 2.12 and forward -> 0.18.0. 0.18.0 dropped torch <2.11 and pinned its
-        # release CI to 2.13, and 0.17.0's own upstream table stops supporting the Python
-        # API at 2.11, so leaving this range on 0.17.0 ran it outside its declared window.
+        # 2.12+ -> 0.18.0, whose release CI is pinned to 2.13. 0.17.0's upstream table stops
+        # at 2.11, so leaving this range there ran it outside its declared window.
         ("2.12.0", "torchao==0.18.0"),
         ("2.12.1+cu130", "torchao==0.18.0"),
         ("2.13.0+cu132", "torchao==0.18.0"),
@@ -129,9 +128,8 @@ def test_the_torchao_index_follows_the_resident_torch_build(monkeypatch, torch_v
     assert got == (f"https://download.pytorch.org/whl/{leaf}" if leaf else None)
 
 
-# What each accelerator leaf publishes for torchao, read off the live listings. Only the
-# leaves whose inventory does NOT cover every release this selector can ask for are listed:
-# everything absent from here serves its whole range.
+# torchao per leaf, from the live listings. Only leaves that do NOT cover every release this
+# selector can ask for; everything absent serves its whole range.
 _TORCHAO_INDEX_GAPS = {
     "cu118": ({m: f"0.{m}.0" for m in range(3, 12)}, range(5, 8)),
     "cu129": (
@@ -199,21 +197,13 @@ def test_the_torchao_step_pins_the_index_and_retries_without_it():
 
 
 def test_the_fallback_is_never_conditioned_on_the_accelerator(monkeypatch):
-    """A wrong-accelerator torchao COSTS ITS KERNELS; it does not fail to import, so the
-    fallback must stay unconditional. Guarding it on the CUDA major would regress a CUDA-13,
-    ROCm or XPU host from a working-but-slower torchao to none at all.
-
-    The premise is checked here rather than trusted, because a comment claiming otherwise is
-    what motivated a guard that had to be reverted. torchao/__init__.py has wrapped the whole
-    cpp load in try/except since 0.12.0 (and per-file since 0.16.0), logging "Failed to load
-    {file}: {e}" -- the exact message unsloth/import_fixes.py already filters as expected on
-    an ABI mismatch. Forcing torch.ops.load_library to raise the libcudart.so.12 OSError
-    leaves `import torchao` and torchao.quantization both working."""
+    """A wrong-accelerator torchao costs its kernels, not its import, so the fallback stays
+    unconditional -- guarding it on the CUDA major regressed CUDA-13/ROCm/XPU hosts from a
+    slow torchao to none. torchao/__init__.py has wrapped the cpp load since 0.12.0."""
     body = _torchao_installer_source()
     fallback = body.split("retrying from the default index", 1)[1]
     assert 'pip_install("Installing dependency overrides", *args, spec)' in fallback
-    # No branch may stand between the failed pin and the retry. Comments carry the word,
-    # so compare code only.
+    # No branch between the failed pin and the retry. Comments carry the word; compare code.
     between = body.split("if pip_install_try(", 1)[1].split("retrying from the default index", 1)[0]
     code = [l for l in between.split("\n") if not l.strip().startswith("#")]
     assert not any(l.strip().startswith(("if ", "elif ")) for l in code), between
@@ -226,23 +216,20 @@ def test_the_fallback_is_never_conditioned_on_the_accelerator(monkeypatch):
     [
         # No index pinned: the wheel comes from the default index, which stamps no tag.
         ("0.18.0", "torchao==0.18.0", "<none>", False),
-        # No index pinned means the DEFAULT index, whose wheels carry no local tag, so a
-        # tagged wheel sitting there came from somewhere else and is replaced. It settles
-        # after one pass: what lands is bare and matches on the next run.
+        # A tagged wheel on the unpinned path came from elsewhere, so it is replaced once,
+        # then settles: what lands is bare.
         ("0.18.0+cu130", "torchao==0.18.0", "<none>", True),
         ("0.17.0", "torchao==0.18.0", "<none>", True),
         (None, "torchao==0.18.0", "<none>", True),
-        # Index pinned: the release can be right while the BUILD is wrong. pip counts an
-        # 0.18.0+cu126 wheel as satisfying ==0.18.0, fetches nothing, and leaves exactly the
-        # wrong-accelerator build the pin exists to replace.
+        # Pinned: the release can be right while the BUILD is wrong. 0.18.0+cu126 satisfies
+        # ==0.18.0, so pip fetches nothing and the wrong build stays.
         ("0.18.0+cu130", "torchao==0.18.0", "cu130", False),
         ("0.18.0+cu126", "torchao==0.18.0", "cu130", True),
         ("0.18.0", "torchao==0.18.0", "cu130", True),
         ("0.18.0+rocm7.2", "torchao==0.18.0", "rocm7.2", False),
         ("0.17.0+cu130", "torchao==0.18.0", "cu130", True),
-        # An opaque mirror proves nothing about the installed wheel, so it is replaced.
-        # Accepting it would leave an untagged wheel satisfying the pin and the mirror
-        # would never be contacted.
+        # An opaque mirror proves nothing, so it is replaced: otherwise an untagged wheel
+        # satisfies the pin and the mirror is never contacted.
         ("0.18.0", "torchao==0.18.0", None, True),
         ("0.18.0+cu130", "torchao==0.18.0", None, True),
     ],
@@ -290,13 +277,9 @@ def test_every_torchao_call_site_asks_for_the_pinned_tag():
 
 
 def test_no_torchao_install_can_resolve_a_dependency():
-    """Both call sites pass --no-deps. The post-repair one is why: it runs directly after
-    step 13 has fixed the torch build, so any dependency resolution there could undo it.
-
-    No torchao release actually declares a runtime torch dependency -- PyPI and the
-    cpu/cu126/cu130/cu132/xpu/rocm7.2 leaves all carry Requires-Dist entries only under the
-    dev extra -- so this is hardening rather than a live fix, and the test exists so that
-    stays true if a future torchao adds a pin."""
+    """Both call sites pass --no-deps, for the post-repair one: it runs right after step 13
+    fixed the torch build. No torchao release declares a runtime torch dependency today, so
+    this is hardening that must stay if one ever gains a pin."""
     body = _torchao_installer_source()
     assert 'args = ["--no-deps", "--no-cache-dir"]' in body
     # --force-reinstall must not be able to widen the install back out.

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -224,10 +224,12 @@ def test_the_fallback_is_never_conditioned_on_the_accelerator(monkeypatch):
 @pytest.mark.parametrize(
     "installed, spec, want_tag, expected",
     [
-        # No index pinned: only the release matters, and a local tag on what is installed
-        # must not force a reinstall on every single run.
+        # No index pinned: the wheel comes from the default index, which stamps no tag.
         ("0.18.0", "torchao==0.18.0", "<none>", False),
-        ("0.18.0+cu130", "torchao==0.18.0", "<none>", False),
+        # No index pinned means the DEFAULT index, whose wheels carry no local tag, so a
+        # tagged wheel sitting there came from somewhere else and is replaced. It settles
+        # after one pass: what lands is bare and matches on the next run.
+        ("0.18.0+cu130", "torchao==0.18.0", "<none>", True),
         ("0.17.0", "torchao==0.18.0", "<none>", True),
         (None, "torchao==0.18.0", "<none>", True),
         # Index pinned: the release can be right while the BUILD is wrong. pip counts an
@@ -248,7 +250,7 @@ def test_the_fallback_is_never_conditioned_on_the_accelerator(monkeypatch):
 def test_pin_needs_reinstall(monkeypatch, installed, spec, want_tag, expected):
     mod = _load_module(monkeypatch)
     monkeypatch.setattr(mod, "_installed_distribution_version", lambda _name: installed)
-    tag = mod._NO_INDEX_PINNED if want_tag == "<none>" else want_tag
+    tag = "" if want_tag == "<none>" else want_tag
     assert mod._pin_needs_reinstall(spec, tag) is expected
 
 
@@ -283,8 +285,8 @@ def test_every_torchao_call_site_asks_for_the_pinned_tag():
     helper exists to remove, so no call site may spell it any other way."""
     source = _INSTALL_SCRIPT.read_text(encoding = "utf-8")
     assert source.count("_pin_needs_reinstall(") == 3  # the def plus both call sites
-    assert "_torch_index_tag(torch_version) if index else _NO_INDEX_PINNED" in source
-    assert "_torch_index_tag(_label_after) if _ao_index else _NO_INDEX_PINNED" in source
+    assert '_torch_index_tag(torch_version) if index else ""' in source
+    assert '_torch_index_tag(_label_after) if _ao_index else ""' in source
 
 
 def test_no_torchao_install_can_resolve_a_dependency():

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -287,6 +287,26 @@ def test_every_torchao_call_site_asks_for_the_pinned_tag():
     assert "_torch_index_tag(_label_after) if _ao_index else _NO_INDEX_PINNED" in source
 
 
+def test_no_torchao_install_can_resolve_a_dependency():
+    """Both call sites pass --no-deps. The post-repair one is why: it runs directly after
+    step 13 has fixed the torch build, so any dependency resolution there could undo it.
+
+    No torchao release actually declares a runtime torch dependency -- PyPI and the
+    cpu/cu126/cu130/cu132/xpu/rocm7.2 leaves all carry Requires-Dist entries only under the
+    dev extra -- so this is hardening rather than a live fix, and the test exists so that
+    stays true if a future torchao adds a pin."""
+    body = _torchao_installer_source()
+    assert 'args = ["--no-deps", "--no-cache-dir"]' in body
+    # --force-reinstall must not be able to widen the install back out.
+    for call in ("pip_install(", "pip_install_try("):
+        for fragment in body.split(call)[1:]:
+            assert "*args" in fragment.split(")")[0], fragment[:120]
+    source = _INSTALL_SCRIPT.read_text(encoding = "utf-8")
+    resync = source.split("def _resync_torch_coupled_packages", 1)[1]
+    ao = resync.split("_ao_index", 1)[1][:1200]
+    assert "--no-deps" in ao
+
+
 def test_torchao_is_re_selected_after_the_linux_torch_repair():
     """Step 4 chooses torchao from the torch present BEFORE step 13's repairs, which move
     torch across families and releases. The explicit XPU pin is the sharp case: its spec is

--- a/studio/backend/tests/test_torchao_select.py
+++ b/studio/backend/tests/test_torchao_select.py
@@ -134,8 +134,10 @@ def test_the_torchao_index_follows_the_resident_torch_build(monkeypatch, torch_v
 # everything absent from here serves its whole range.
 _TORCHAO_INDEX_GAPS = {
     "cu118": ({m: f"0.{m}.0" for m in range(3, 12)}, range(5, 8)),
-    "cu129": ({12: "0.12.0", 13: "0.13.0", 14: "0.14.1", 15: "0.15.0", 16: "0.16.0",
-               17: "0.17.0"}, range(8, 14)),
+    "cu129": (
+        {12: "0.12.0", 13: "0.13.0", 14: "0.14.1", 15: "0.15.0", 16: "0.16.0", 17: "0.17.0"},
+        range(8, 14),
+    ),
     "rocm7.0": ({16: "0.16.0"}, range(9, 11)),
 }
 
@@ -288,7 +290,7 @@ def test_torchao_is_re_selected_after_the_linux_torch_repair():
     source = _INSTALL_SCRIPT.read_text(encoding = "utf-8")
     step = source.split('_progress(_torch_step_label("final"))', 1)[1]
     step = step.split("# 13w.", 1)[0]
-    assert "_torch_before_repair = str(_probe_installed_torch_version() or \"\")" in step
+    assert '_torch_before_repair = str(_probe_installed_torch_version() or "")' in step
     assert "_install_torchao_for_torch(_torch_after_repair)" in step
     # Guarded on an actual move, so an install where nothing shifted pays no second resolve.
     assert "if _torch_after_repair and _torch_after_repair != _torch_before_repair:" in step

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4326,7 +4326,12 @@ def _install_torchao_for_torch(torch_version: "str | None") -> None:
     # indexes carry a build per tag. rocm is included here, unlike torchcodec -- the rocm
     # leaves really do publish torchao.
     index = _torch_accelerator_index_url(torch_version)
-    args = ["--no-cache-dir"]
+    # --no-deps matches the resync call site. No torchao release declares a runtime torch
+    # dependency (checked on PyPI and on the cpu/cu126/cu130/cu132/xpu/rocm7.2 leaves, every
+    # one of which is Requires-Dist free outside its dev extra), so today this skips nothing.
+    # It is here because the second caller runs immediately after the torch repair, where a
+    # torchao that ever gained a torch pin would resolve it and undo that repair.
+    args = ["--no-deps", "--no-cache-dir"]
     if _pin_needs_reinstall(spec, _torch_index_tag(torch_version) if index else _NO_INDEX_PINNED):
         args.insert(0, "--force-reinstall")
     _note(

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -514,7 +514,10 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
 _TORCH_ACCELERATOR_TAG_RE = re.compile(r"cpu|cu\d+|xpu|rocm\d+(\.\d+)?")
 
 
-def _torch_accelerator_index_url(torch_version: "str | None", tag: str = "") -> "str | None":
+def _torch_accelerator_index_url(
+    torch_version: "str | None",
+    substitutions: "dict[str, str] | None" = None,
+) -> "str | None":
     """The download.pytorch.org leaf serving the resident torch's build, or None.
 
     Companion wheels (torchcodec, torchao) are published per accelerator exactly the way
@@ -529,16 +532,27 @@ def _torch_accelerator_index_url(torch_version: "str | None", tag: str = "") -> 
     """
     if not torch_version:
         return None
-    local = tag or str(torch_version).partition("+")[2].strip().lower()
+    substitutions = substitutions or {}
+    local = str(torch_version).partition("+")[2].strip().lower()
     if not _TORCH_ACCELERATOR_TAG_RE.fullmatch(local):
         return None
-    # An explicit pin wins, as it does for the torch repair helpers: synthesising the public
+    # An explicit URL wins, as it does for the torch repair helpers: synthesising the public
     # URL from the local tag sent authenticated, corporate and air-gapped mirrors to
     # download.pytorch.org, and the --index-url also makes _install_env_for_cmd drop the
-    # inherited index config, so the install fails outright there. _PYTORCH_WHL_BASE rather
-    # than a literal, since UNSLOTH_PYTORCH_MIRROR redirects every other index this module
-    # builds.
-    return _explicit_torch_index_url() or f"{_PYTORCH_WHL_BASE}/{local}"
+    # inherited index config, so the install fails outright there. It is taken verbatim: its
+    # path belongs to whoever configured it and rewriting a leaf inside it would be a guess.
+    url = os.environ.get("UNSLOTH_TORCH_INDEX_URL", "").strip()
+    if url:
+        return _trim_index_path_slashes(url)
+    # A FAMILY override names a leaf under our own base, so a per-package substitution still
+    # applies to it -- otherwise UNSLOTH_TORCH_INDEX_FAMILY=xpu would send torchcodec to the
+    # xpu leaf, which publishes no codec below 0.13.
+    family = os.environ.get("UNSLOTH_TORCH_INDEX_FAMILY", "").strip().strip("/")
+    if family:
+        return f"{_PYTORCH_WHL_BASE}/{substitutions.get(family.lower(), family)}"
+    # _PYTORCH_WHL_BASE rather than a literal, since UNSLOTH_PYTORCH_MIRROR redirects every
+    # other index this module builds.
+    return f"{_PYTORCH_WHL_BASE}/{substitutions.get(local, local)}"
 
 
 def _torchcodec_index_url(torch_version: "str | None", spec: str = "") -> "str | None":
@@ -562,14 +576,18 @@ def _torchcodec_index_url(torch_version: "str | None", spec: str = "") -> "str |
         _, ceiling = _torchcodec_spec_bounds(spec)
         if ceiling is not None and ceiling <= _TORCHCODEC_MIN_ON_TORCH_INDEX:
             return None  # window sits entirely below what any torch index publishes
-    return _torch_accelerator_index_url(torch_version, _torchcodec_index_tag(torch_version))
+    return _torch_accelerator_index_url(torch_version, _TORCHCODEC_INDEX_TAGS)
 
 
 def _torchcodec_index_tag(torch_version: "str | None") -> str:
     """The local tag of the codec build the index pin will fetch, which is NOT always the
-    resident torch's own tag: an xpu torch is served the cpu wheel. The provenance check
-    below compares against this, so it must come from the same place the URL does."""
-    local = str(torch_version or "").partition("+")[2].strip().lower()
+    resident torch's own tag: an xpu torch is served the cpu wheel, and a FAMILY override
+    names a leaf of its own. The provenance check below compares against this, so it has to
+    be derived the same way the URL is. An explicit URL is opaque, so it claims no tag."""
+    if os.environ.get("UNSLOTH_TORCH_INDEX_URL", "").strip():
+        return ""
+    family = os.environ.get("UNSLOTH_TORCH_INDEX_FAMILY", "").strip().strip("/").lower()
+    local = family or str(torch_version or "").partition("+")[2].strip().lower()
     return _TORCHCODEC_INDEX_TAGS.get(local, local)
 
 
@@ -4293,16 +4311,27 @@ def _resync_torch_coupled_packages(label_before: str) -> bool:
     if _release_moved or _cuda_moved:
         try:
             _spec = _select_torchao_spec(_label_after)
-            if not _exact_distribution_spec_is_installed(_spec):
+            # The same index pin step 4 uses. Without it this call reinstalls PyPI's CUDA-12
+            # wheel straight over the correctly pinned one, and _pin_needs_reinstall rather
+            # than an exact compare because the pinned wheel carries a local tag that
+            # ==0.18.0 never equals, which would make this fire on every repair.
+            _ao_index = _torch_accelerator_index_url(_label_after)
+            _ao_args = ["--force-reinstall", "--no-deps", "--no-cache-dir"]
+            if _pin_needs_reinstall(_spec, _label_after if _ao_index else None):
                 _note(f"torch {_label_after} after repair -- reinstalling {_spec}")
                 _touched_torch = True
-                if not pip_install_try(
+                _ao_ok = pip_install_try(
                     "Re-matching torchao to the repaired torch",
-                    "--force-reinstall",
-                    "--no-deps",
-                    "--no-cache-dir",
+                    *_ao_args,
+                    *(("--index-url", _ao_index) if _ao_index else ()),
                     _spec,
-                ):
+                )
+                if not _ao_ok and _ao_index:
+                    # Same starved-leaf fallback as step 4; see the note there.
+                    _ao_ok = pip_install_try(
+                        "Re-matching torchao to the repaired torch", *_ao_args, _spec
+                    )
+                if not _ao_ok:
                     # Across a CUDA-major move the resident build is not merely slower:
                     # _select_torchao_spec exists because a torchao compiled for CUDA 12
                     # cannot load its cpp under cu130. Remove it, the way the xFormers arm
@@ -7959,10 +7988,18 @@ def install_python_stack() -> int:
                 f"{_strip_index_url_credentials(_codec_index)} did not serve {_codec_spec} "
                 "-- retrying from the default index"
             )
+            # Drop only the pin. --force-reinstall has to survive: it is set when the
+            # installed codec is inside the version window but built by another index, and
+            # without it pip calls the requirement satisfied, fetches nothing, and leaves
+            # that same incompatible wheel in place.
+            _codec_retry_args = [
+                a for i, a in enumerate(_codec_args)
+                if a != "--index-url" and _codec_args[i - 1] != "--index-url"
+            ]
             # _codec_index stays set on purpose: the wheel PyPI serves for a cuNNN host is
             # still a CUDA build, so it still dlopens NPP and the step below still applies.
             _codec_ok = pip_install_try(
-                "Installing torchcodec", "--no-deps", "--no-cache-dir", _codec_spec
+                "Installing torchcodec", *_codec_retry_args, _codec_spec
             )
         if not _codec_ok:
             _note(

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -579,16 +579,33 @@ def _torchcodec_index_url(torch_version: "str | None", spec: str = "") -> "str |
     return _torch_accelerator_index_url(torch_version, _TORCHCODEC_INDEX_TAGS)
 
 
-def _torchcodec_index_tag(torch_version: "str | None") -> str:
-    """The local tag of the codec build the index pin will fetch, which is NOT always the
-    resident torch's own tag: an xpu torch is served the cpu wheel, and a FAMILY override
-    names a leaf of its own. The provenance check below compares against this, so it has to
-    be derived the same way the URL is. An explicit URL is opaque, so it claims no tag."""
+def _torch_index_tag(
+    torch_version: "str | None",
+    substitutions: "dict[str, str] | None" = None,
+) -> "str | None":
+    """The local tag of the build the index pin will fetch, or None when unknowable.
+
+    NOT always the resident torch's own tag: a FAMILY override names a leaf of its own, and
+    a per-package substitution can redirect one (xpu takes the cpu codec). Provenance checks
+    compare against this, so it has to be derived the same way the URL is, or a pin to one
+    leaf gets validated against another leaf's tag and never fires.
+
+    None means an explicit UNSLOTH_TORCH_INDEX_URL is in play. That URL is opaque -- it can
+    be an accelerator-specific private mirror -- so nothing here can say which build it
+    serves. Callers must treat that as "cannot prove the installed wheel came from there"
+    and replace, not as "no tag required": an untagged wheel already satisfies the version,
+    so pip would fetch nothing and the mirror would never be reached.
+    """
     if os.environ.get("UNSLOTH_TORCH_INDEX_URL", "").strip():
-        return ""
+        return None
+    substitutions = substitutions or {}
     family = os.environ.get("UNSLOTH_TORCH_INDEX_FAMILY", "").strip().strip("/").lower()
     local = family or str(torch_version or "").partition("+")[2].strip().lower()
-    return _TORCHCODEC_INDEX_TAGS.get(local, local)
+    return substitutions.get(local, local)
+
+
+def _torchcodec_index_tag(torch_version: "str | None") -> "str | None":
+    return _torch_index_tag(torch_version, _TORCHCODEC_INDEX_TAGS)
 
 
 def _torchcodec_spec_bounds(spec: str) -> "tuple[tuple[int, ...], tuple[int, ...] | None]":
@@ -782,7 +799,11 @@ def _exact_distribution_spec_is_installed(spec: str) -> bool:
     return installed is not None and installed == match.group(2)
 
 
-def _pin_needs_reinstall(spec: str, torch_version: "str | None" = None) -> bool:
+# "no index is being pinned", which is not the same as "the index is opaque" (None).
+_NO_INDEX_PINNED = object()
+
+
+def _pin_needs_reinstall(spec: str, want_tag: object = _NO_INDEX_PINNED) -> bool:
     """Whether a ``name==version`` pin has to be forced over what is already installed.
 
     Two reasons, and the second only exists once an index is pinned. The version can be
@@ -790,9 +811,13 @@ def _pin_needs_reinstall(spec: str, torch_version: "str | None" = None) -> bool:
     be RIGHT while the build is wrong: an accelerator index stamps its tag into the local
     version (``0.18.0+cu130``) and PyPI forbids one, so a wheel already inside the pin
     satisfies pip, nothing is fetched, and the wrong-accelerator build this pin exists to
-    replace stays put. Comparing local tags is what catches that. Pass torch_version only
-    when an index is actually being pinned; without one the tag carries no requirement and
-    a matching release must not be reinstalled every run.
+    replace stays put.
+
+    want_tag is the tag the pin will FETCH, from _torch_index_tag -- not the resident
+    torch's own tag, which a FAMILY override or a substitution can differ from. Leave it
+    unset when no index is pinned: the tag then carries no requirement and a matching
+    release must not be reinstalled on every run. None means the index is an opaque mirror,
+    where nothing can prove the installed wheel came from it, so it is replaced.
     """
     match = re.fullmatch(r"([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s]+)", spec)
     if match is None:
@@ -802,10 +827,9 @@ def _pin_needs_reinstall(spec: str, torch_version: "str | None" = None) -> bool:
         return True  # absent; kept True so the flag matches what this step passed before
     if installed.partition("+")[0] != match.group(2).partition("+")[0]:
         return True
-    if not torch_version:
+    if want_tag is _NO_INDEX_PINNED:
         return False
-    want = str(torch_version).partition("+")[2].strip().lower()
-    return installed.partition("+")[2].strip().lower() != want
+    return installed.partition("+")[2].strip().lower() != want_tag
 
 
 def _installed_torch_is_windows_rocm() -> bool:
@@ -4317,7 +4341,9 @@ def _resync_torch_coupled_packages(label_before: str) -> bool:
             # ==0.18.0 never equals, which would make this fire on every repair.
             _ao_index = _torch_accelerator_index_url(_label_after)
             _ao_args = ["--force-reinstall", "--no-deps", "--no-cache-dir"]
-            if _pin_needs_reinstall(_spec, _label_after if _ao_index else None):
+            if _pin_needs_reinstall(
+                _spec, _torch_index_tag(_label_after) if _ao_index else _NO_INDEX_PINNED
+            ):
                 _note(f"torch {_label_after} after repair -- reinstalling {_spec}")
                 _touched_torch = True
                 _ao_ok = pip_install_try(
@@ -7744,7 +7770,10 @@ def install_python_stack() -> int:
         # rocm leaves really do publish torchao.
         _torchao_index = _torch_accelerator_index_url(_torch_ver)
         _torchao_args = ["--no-cache-dir"]
-        if _pin_needs_reinstall(_torchao_spec, _torch_ver if _torchao_index else None):
+        if _pin_needs_reinstall(
+            _torchao_spec,
+            _torch_index_tag(_torch_ver) if _torchao_index else _NO_INDEX_PINNED,
+        ):
             _torchao_args.insert(0, "--force-reinstall")
         _note(
             f"torch {_torch_ver or 'unknown'} detected -- installing {_torchao_spec}"
@@ -7955,9 +7984,15 @@ def install_python_stack() -> int:
             _codec_have = _installed_distribution_version("torchcodec") or ""
             # The tag the PIN will fetch, not the resident torch's own: an xpu torch is
             # served the cpu wheel, and comparing against "xpu" would never match, so every
-            # run would force-reinstall a codec that was already correct.
+            # run would force-reinstall a codec that was already correct. None means an
+            # opaque mirror, which cannot prove anything, so the wheel is replaced -- an
+            # untagged one already satisfies the range, so pip would otherwise fetch nothing
+            # and the mirror would never be reached.
             _codec_want = _torchcodec_index_tag(_codec_torch_ver)
-            if _codec_have and _codec_have.partition("+")[2].strip().lower() != _codec_want:
+            if _codec_have and (
+                _codec_want is None
+                or _codec_have.partition("+")[2].strip().lower() != _codec_want
+            ):
                 _codec_args += ("--force-reinstall",)
                 _codec_rebuild = True
         _safe_print(

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -479,11 +479,13 @@ def _torchcodec_python_is_supported(
 # oldest venvs. They keep today's unpinned behavior.
 _TORCHCODEC_MIN_ON_TORCH_INDEX = (0, 3, 0)
 
-# Leaves that joined later than that. A floor, not an inventory: it only ever says "this
-# index published nothing below X", which upstream does not walk back, so it cannot rot the
-# way a list of held versions does. Holes ABOVE the floor are real (cu129 carries no 0.8 or
-# 0.9) and are left to the caller's unpinned retry rather than tabulated here.
-_TORCHCODEC_INDEX_FLOORS = {"xpu": (0, 13, 0)}
+# torchcodec has no XPU build. The xpu leaf carries the CPU wheels verbatim
+# (torchcodec-0.16.0+cpu-...), and only for Linux x86_64, while the cpu leaf carries that
+# same wheel for aarch64 and Windows as well and goes back to 0.3 instead of starting at
+# 0.13. So an Intel-GPU torch is sent to cpu. Not cosmetic: PyPI's default torchcodec is
+# the CUDA build (9.5 MB, byte-for-byte the size of the cu130 wheel, against 5.1 MB for
+# cpu), so an xpu host left unpinned gets a codec that tries to dlopen CUDA.
+_TORCHCODEC_INDEX_TAGS = {"xpu": "cpu"}
 
 
 def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
@@ -512,7 +514,7 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
 _TORCH_ACCELERATOR_TAG_RE = re.compile(r"cpu|cu\d+|xpu|rocm\d+(\.\d+)?")
 
 
-def _torch_accelerator_index_url(torch_version: "str | None") -> "str | None":
+def _torch_accelerator_index_url(torch_version: "str | None", tag: str = "") -> "str | None":
     """The download.pytorch.org leaf serving the resident torch's build, or None.
 
     Companion wheels (torchcodec, torchao) are published per accelerator exactly the way
@@ -527,7 +529,7 @@ def _torch_accelerator_index_url(torch_version: "str | None") -> "str | None":
     """
     if not torch_version:
         return None
-    local = str(torch_version).partition("+")[2].strip().lower()
+    local = tag or str(torch_version).partition("+")[2].strip().lower()
     if not _TORCH_ACCELERATOR_TAG_RE.fullmatch(local):
         return None
     # An explicit pin wins, as it does for the torch repair helpers: synthesising the public
@@ -548,21 +550,27 @@ def _torchcodec_index_url(torch_version: "str | None", spec: str = "") -> "str |
     docker/Dockerfile already pins cu128 by hand for this reason.
 
     rocm is the one accelerator excluded: every rocm leaf answers 404/403 for torchcodec,
-    so a pin there is a guaranteed wasted resolve. xpu IS pinnable -- it began publishing
-    torchcodec at 0.13 -- and an xpu host that stays unpinned takes PyPI's CUDA build.
-    Where a pinned index turns out not to serve the selected window (cu129 has no 0.8 or
-    0.9), the caller's unpinned retry recovers; that is deliberate, because no local table
-    of index contents stays true.
+    so a pin there is a guaranteed wasted resolve. xpu is redirected to cpu, for the reason
+    beside _TORCHCODEC_INDEX_TAGS. Where a pinned index turns out not to serve the selected
+    window (cu129 has no 0.8 or 0.9), the caller's unpinned retry recovers; that is
+    deliberate, because no local table of index CONTENTS stays true.
     """
     local = str(torch_version or "").partition("+")[2].strip().lower()
     if local.startswith("rocm"):
         return None
     if spec:
         _, ceiling = _torchcodec_spec_bounds(spec)
-        floor = max(_TORCHCODEC_MIN_ON_TORCH_INDEX, _TORCHCODEC_INDEX_FLOORS.get(local, (0,)))
-        if ceiling is not None and ceiling <= floor:
-            return None  # window sits entirely below what this index ever published
-    return _torch_accelerator_index_url(torch_version)
+        if ceiling is not None and ceiling <= _TORCHCODEC_MIN_ON_TORCH_INDEX:
+            return None  # window sits entirely below what any torch index publishes
+    return _torch_accelerator_index_url(torch_version, _torchcodec_index_tag(torch_version))
+
+
+def _torchcodec_index_tag(torch_version: "str | None") -> str:
+    """The local tag of the codec build the index pin will fetch, which is NOT always the
+    resident torch's own tag: an xpu torch is served the cpu wheel. The provenance check
+    below compares against this, so it must come from the same place the URL does."""
+    local = str(torch_version or "").partition("+")[2].strip().lower()
+    return _TORCHCODEC_INDEX_TAGS.get(local, local)
 
 
 def _torchcodec_spec_bounds(spec: str) -> "tuple[tuple[int, ...], tuple[int, ...] | None]":
@@ -7916,7 +7924,10 @@ def install_python_stack() -> int:
             # from the version: the torch indexes carry a +cuNNN / +cpu local tag and PyPI
             # forbids one, so a local tag that is missing or different means another build.
             _codec_have = _installed_distribution_version("torchcodec") or ""
-            _codec_want = str(_codec_torch_ver).partition("+")[2].strip().lower()
+            # The tag the PIN will fetch, not the resident torch's own: an xpu torch is
+            # served the cpu wheel, and comparing against "xpu" would never match, so every
+            # run would force-reinstall a codec that was already correct.
+            _codec_want = _torchcodec_index_tag(_codec_torch_ver)
             if _codec_have and _codec_have.partition("+")[2].strip().lower() != _codec_want:
                 _codec_args += ("--force-reinstall",)
                 _codec_rebuild = True

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4311,6 +4311,67 @@ def _resident_xformers_build_torch() -> "str | None":
     return recorded.strip() if isinstance(recorded, str) and recorded.strip() else None
 
 
+# PyPI's torchao is the CUDA-12 build, so falling back to it is only safe where a CUDA-12
+# extension could load at all. On CUDA 13, ROCm or XPU it cannot, and torchao's cpp loads
+# whenever the torch release matches, so the fallback would trade "no kernels" for
+# "libcudart.so.12: cannot open shared object file" at import. Absence is the supported
+# state there -- _resync_torch_coupled_packages already removes torchao across a CUDA-major
+# move, and Windows ROCm skips this step entirely and stubs torchao at runtime.
+def _default_index_torchao_can_load(torch_version: "str | None") -> bool:
+    local = str(torch_version or "").partition("+")[2].strip().lower()
+    if not local or local == "cpu":
+        return True  # untagged is PyPI's own torch; cpu needs no CUDA runtime at all
+    major = _cuda_major_from_torch_version(str(torch_version or ""))
+    return major is not None and major <= 12
+
+
+def _install_torchao_for_torch(torch_version: "str | None") -> None:
+    """Select the torchao matching torch_version and install it from its own index.
+
+    Called twice: once as step 4, and again after the Linux torch repair, which can move
+    torch across families and releases underneath the first call (the explicit XPU pin
+    lands torch <2.11, where 0.18.0 is not supported at all).
+    """
+    spec = _select_torchao_spec(torch_version)
+    # Pin the index to the resident torch's build, for the reason spelled out beside
+    # _TORCHAO_DEFAULT_SPEC: PyPI's torchao is the CUDA-12 wheel, and the accelerator
+    # indexes carry a build per tag. rocm is included here, unlike torchcodec -- the rocm
+    # leaves really do publish torchao.
+    index = _torch_accelerator_index_url(torch_version)
+    args = ["--no-cache-dir"]
+    if _pin_needs_reinstall(spec, _torch_index_tag(torch_version) if index else _NO_INDEX_PINNED):
+        args.insert(0, "--force-reinstall")
+    _note(
+        f"torch {torch_version or 'unknown'} detected -- installing {spec}"
+        # Redacted for display only; the installer below still gets the exact URL.
+        + (f" from {_strip_index_url_credentials(index)}" if index else "")
+    )
+    if not index:
+        pip_install("Installing dependency overrides", *args, spec)
+        return
+    if pip_install_try("Installing dependency overrides", *args, "--index-url", index, spec):
+        return
+    # The pinned index may simply not carry this release: cu129 stops at 0.17.0 while
+    # serving torch up to 2.13, cu118 stops at 0.11.0, rocm7.0 publishes 0.16.0 alone, and
+    # a private mirror or a leaf added upstream after this shipped can lag by a release.
+    if not _default_index_torchao_can_load(torch_version):
+        _safe_print(
+            f"   [WARN] {_strip_index_url_credentials(index)} did not serve {spec}, and the "
+            f"default index only builds torchao for CUDA 12, which cannot load beside this "
+            f"torch. Leaving torchao alone; install {spec} from a matching index by hand to "
+            f"restore its kernels."
+        )
+        return
+    # Otherwise the default index is where this step went before it pinned anything, so
+    # falling back is a working install rather than a failed one. Still fatal if that fails
+    # too: torchao is not optional the way audio is, and this step was fatal before.
+    _note(
+        f"{_strip_index_url_credentials(index)} did not serve {spec} "
+        "-- retrying from the default index"
+    )
+    pip_install("Installing dependency overrides", *args, spec)
+
+
 def _resync_torch_coupled_packages(label_before: str) -> bool:
     """Re-settle the packages whose compiled extensions are tied to the torch build.
 
@@ -7762,45 +7823,7 @@ def install_python_stack() -> int:
         _note("Windows ROCm -- skipping torchao (no working build; stubbed at runtime)")
     else:
         _progress("dependency overrides")
-        _torch_ver = _probe_installed_torch_version()
-        _torchao_spec = _select_torchao_spec(_torch_ver)
-        # Pin the index to the resident torch's build, for the reason spelled out beside
-        # _TORCHAO_DEFAULT_SPEC: PyPI's torchao is the CUDA-12 wheel, and the accelerator
-        # indexes carry a build per tag. rocm is included here, unlike torchcodec -- the
-        # rocm leaves really do publish torchao.
-        _torchao_index = _torch_accelerator_index_url(_torch_ver)
-        _torchao_args = ["--no-cache-dir"]
-        if _pin_needs_reinstall(
-            _torchao_spec,
-            _torch_index_tag(_torch_ver) if _torchao_index else _NO_INDEX_PINNED,
-        ):
-            _torchao_args.insert(0, "--force-reinstall")
-        _note(
-            f"torch {_torch_ver or 'unknown'} detected -- installing {_torchao_spec}"
-            # Redacted for display only; the installer below still gets the exact URL.
-            + (f" from {_strip_index_url_credentials(_torchao_index)}" if _torchao_index else "")
-        )
-        if not _torchao_index:
-            pip_install("Installing dependency overrides", *_torchao_args, _torchao_spec)
-        elif not pip_install_try(
-            "Installing dependency overrides",
-            *_torchao_args,
-            "--index-url",
-            _torchao_index,
-            _torchao_spec,
-        ):
-            # The pinned index may simply not carry this release: cu129 stops at 0.17.0
-            # while serving torch up to 2.13, cu118 stops at 0.11.0, rocm7.0 publishes
-            # 0.16.0 alone, and a leaf added upstream after this shipped can lag. Falling
-            # back to the default index restores exactly what this step did before it
-            # pinned anything, which is a working install rather than a failed one. Still
-            # fatal if that fails too: torchao is not optional the way audio is, and this
-            # step was fatal before.
-            _note(
-                f"{_strip_index_url_credentials(_torchao_index)} did not serve "
-                f"{_torchao_spec} -- retrying from the default index"
-            )
-            pip_install("Installing dependency overrides", *_torchao_args, _torchao_spec)
+        _install_torchao_for_torch(_probe_installed_torch_version())
 
     # 5. Triton kernels (no-deps, from source). Skipped on Windows/macOS (no support)
     #    and without git (the requirement is a git+https URL); a training speedup
@@ -7915,6 +7938,7 @@ def install_python_stack() -> int:
     torch_flavor_tag = ""
     if not IS_WINDOWS and not IS_MACOS and not NO_TORCH:
         _progress(_torch_step_label("final"))
+        _torch_before_repair = str(_probe_installed_torch_version() or "")
         _ensure_cuda_torch()
         _ensure_rocm_torch()
         _ensure_xpu_torch()
@@ -7922,6 +7946,19 @@ def install_python_stack() -> int:
         # Last, after every torch migration: the swap keys off the installed +xpu label, so a
         # CPU pin over an XPU venv would leave XPU triton under a CPU torch.
         _ensure_xpu_triton()
+        # These repairs move torch across families AND releases, and step 4 chose torchao
+        # from the version torch had BEFORE them. An explicit XPU pin is the sharp case:
+        # _XPU_TORCH_PKG_SPEC is torch>=2.6,<2.11.0, so it necessarily lands below the 2.11
+        # floor that torchao 0.18.0 requires. Only the Windows flavor repair reaches
+        # _resync_torch_coupled_packages, so on Linux nothing re-selected it (#10493).
+        # Re-running the same decision is a no-op when torch did not move.
+        _torch_after_repair = str(_probe_installed_torch_version() or "")
+        if _torch_after_repair and _torch_after_repair != _torch_before_repair:
+            _note(
+                f"torch moved from {_torch_before_repair or 'unknown'} to "
+                f"{_torch_after_repair} during the repair -- re-selecting torchao"
+            )
+            _install_torchao_for_torch(_torch_after_repair)
 
     # 13w. Windows torch flavor invariant, separate from step 13's Linux-shaped repair set
     # but in the same position: last, after the with-deps steps re-resolved torch.

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -301,30 +301,20 @@ _TORCH_FLAVOR_REPAIR_PKG_SPEC: tuple[str, str, str] = (
     "torchaudio>=2.4,<2.12.0",
 )
 
-# torchao's cpp extensions are pinned to ONE torch release AND CUDA major, and either
-# mismatch costs the kernels rather than the import. A torch mismatch is refused up front
-# ("Skipping import of cpp extensions due to incompatible torch version"); a CUDA mismatch
-# gets as far as the dlopen and fails there on libcudart, which torchao/__init__.py has
-# caught and logged since 0.12 -- unsloth/import_fixes.py filters that exact warning. So
-# the wrong build is the slow path, never a crash. Verified by forcing torch.ops.load_library
-# to raise that error: `import torchao` and torchao.quantization both still work.
-# The torch pin is a range, so match torchao to the installed torch (table: pytorch/ao#2919):
+# torchao's cpp is built for ONE torch release AND CUDA major. Either mismatch costs the
+# kernels, never the import: torchao/__init__.py has caught the dlopen failure since 0.12 and
+# import_fixes.py filters that warning. Match torchao to the installed torch (pytorch/ao#2919):
 #   2.9.x            -> 0.14.0
 #   2.10.x, CUDA<=12 -> 0.16.0 (cpp built for 2.10, loads via the CUDA-12 wheel)
 #   2.10.x, CUDA>=13 -> 0.17.0 (cu130: 0.16.0's CUDA-12 cpp crashes on load; 0.17.0
 #                       targets torch 2.11 so its cpp is cleanly skipped, not crashed)
-#   2.11.x           -> 0.17.0 (reachable via CUDA or ROCm rocm7.2; cpp built for 2.11)
-#   2.12.x and up    -> 0.18.0 (0.18.0 dropped torch <2.11 and pinned its release CI to
-#                       2.13, so it is the build for this range; 0.17.0's own table stops
-#                       supporting the Python API at 2.11)
+#   2.11.x           -> 0.17.0 (cpp built for 2.11)
+#   2.12.x and up    -> 0.18.0 (dropped torch <2.11; release CI pinned to 2.13)
 # Unknown/older torch keeps the conservative default.
 #
-# The pin alone is not enough: torchao publishes a wheel per accelerator under
-# download.pytorch.org/whl/<tag>, while PyPI carries ONE default whose CUDA major is whatever
-# PyTorch currently ships by default -- 13 as of 0.18.0, which links libcudart.so.13, not 12.
-# So the default index is not a fixed fallback major and cannot be reasoned about as one; the
-# caller pins the index to the resident torch's build instead. Taking the default beside a
-# torch of another major costs the cpp kernels (see above), not the install.
+# The version alone is not enough: torchao ships per accelerator under /whl/<tag>, and PyPI's
+# single default tracks whatever major PyTorch currently ships (13 as of 0.18.0), so it cannot
+# be treated as a fixed fallback major. The caller pins the index to the resident torch.
 _TORCHAO_DEFAULT_SPEC = "torchao==0.14.0"
 _TORCHAO_TORCH_210_SPEC = "torchao==0.16.0"
 _TORCHAO_TORCH_210_CUDA13_SPEC = "torchao==0.17.0"
@@ -483,12 +473,8 @@ def _torchcodec_python_is_supported(
 # oldest venvs. They keep today's unpinned behavior.
 _TORCHCODEC_MIN_ON_TORCH_INDEX = (0, 3, 0)
 
-# torchcodec has no XPU build. The xpu leaf carries the CPU wheels verbatim
-# (torchcodec-0.16.0+cpu-...), and only for Linux x86_64, while the cpu leaf carries that
-# same wheel for aarch64 and Windows as well and goes back to 0.3 instead of starting at
-# 0.13. So an Intel-GPU torch is sent to cpu. Not cosmetic: PyPI's default torchcodec is
-# the CUDA build (9.5 MB, byte-for-byte the size of the cu130 wheel, against 5.1 MB for
-# cpu), so an xpu host left unpinned gets a codec that tries to dlopen CUDA.
+# torchcodec has no xpu build: the xpu leaf republishes cpu wheels, Linux x86_64 only, from
+# 0.13 up, so xpu takes cpu. Unpinned is not an option -- PyPI's default is the CUDA build.
 _TORCHCODEC_INDEX_TAGS = {"xpu": "cpu"}
 
 
@@ -511,9 +497,8 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
     return match.group(1)[:2] if match else ""
 
 
-# Any sign of the CUDA runtime, versioned or not. nvcudart_hybrid64.dll is the Windows
-# cu130 spelling, which carries no major; nvcuda.dll and torch_cuda are the driver and
-# torch's own CUDA library, present in a CUDA build and absent from a cpu one.
+# Any sign of the CUDA runtime, versioned or not: nvcudart_hybrid64.dll is the Windows cu130
+# spelling and carries no major. Absent entirely from a cpu build, which is what makes "" safe.
 _CUDA_RUNTIME_MARKER_RE = re.compile(
     rb"nvcuda\.dll|torch_cuda|nvcudart|libcudart|cudart64|libcuda\.so"
 )
@@ -522,17 +507,10 @@ _CUDA_RUNTIME_MARKER_RE = re.compile(
 def _pytorch_whl_leaf_url(leaf: str) -> "str | None":
     """_PYTORCH_WHL_BASE plus an accelerator leaf, or None when it cannot be expressed.
 
-    A mirror may authenticate through a query token, and NO url shape pins such an index:
-    pip joins the project name as text (posixpath.join), so both "base?token=x/cu130" and
-    "base/cu130/?token=x" ask the wrong thing -- _warn_query_index_unusable spells this out
-    and says the join cannot repair it.
-
-    So there is nothing to construct here, and constructing something anyway is worse than
-    declining. Passing --index-url makes _install_env_for_cmd strip the user's own index
-    configuration (UV_NO_CONFIG=1, PIP_CONFIG_FILE=os.devnull), which for a query-auth
-    mirror is the ONLY channel that can work: the credential has to come from pip.conf or
-    ~/.netrc. A broken pin therefore destroys the working path to install a wheel from an
-    index that never resolves. Returning None leaves the configuration in place.
+    No URL shape pins a query-auth mirror -- pip joins the project name as text, so the token
+    swallows either the leaf or the name (see _warn_query_index_unusable). Constructing one
+    anyway is worse than declining: --index-url makes _install_env_for_cmd strip pip.conf and
+    ~/.netrc, the only channel that can carry that credential.
     """
     if "?" in _PYTORCH_WHL_BASE or "#" in _PYTORCH_WHL_BASE:
         _warn_query_index_unusable(_PYTORCH_WHL_BASE)
@@ -550,22 +528,14 @@ def _torchcodec_distribution_for_probe():
 
 
 def _installed_torchcodec_cuda_major() -> "str | None":
-    """The CUDA major the INSTALLED torchcodec links, or "" when it links none.
+    """The CUDA major the INSTALLED torchcodec links, "" when it links none, None when unknown.
 
-    None means "cannot tell -- keep whatever the caller already decided". Only the unpinned
-    fallback needs this: a pinned index guarantees the major, but the default index carries
-    whichever major PyTorch currently defaults to, which is not necessarily the resident
-    torch's. Read from the wheel's own native files rather than inferred, since that default
-    moves (torchcodec 0.16.0 on PyPI links libcudart.so.13 while a +cu129 host's tag says 12).
+    Only the unpinned fallback needs this: the default index carries whichever major PyTorch
+    currently ships, not the resident torch's (PyPI's 0.16.0 links libcudart.so.13 while a
+    +cu129 tag says 12), so it is read off the wheel rather than inferred.
 
-    The three answers are deliberately distinct, because "" SKIPS the NPP install and getting
-    that wrong leaves audio broken on a host with no system toolkit. Windows is why: its
-    natives are .dll/.pyd, and the majors are spelled cudart64_12.dll rather than
-    libcudart.so.12. Worse, the win_amd64 cu130 wheel names no major at all -- it references
-    nvcudart_hybrid64.dll -- so a CUDA build there is recognisable without being readable.
-    That case has to be None, not "". Verified across the 0.16.0 wheels: cpu on both
-    platforms carries no CUDA reference whatsoever, cu126 spells its major on both, and only
-    win_amd64 cu130 is CUDA-with-no-major.
+    The three answers must stay distinct because "" SKIPS the NPP install. win_amd64 cu130
+    names no major anywhere -- only nvcudart_hybrid64.dll -- so it is None, not "".
     """
     dist = _torchcodec_distribution_for_probe()
     if dist is None:
@@ -592,10 +562,8 @@ def _installed_torchcodec_cuda_major() -> "str | None":
     return None if saw_cuda else ""
 
 
-# The local tags download.pytorch.org serves a companion wheel under. cpu and cuNNN have
-# always been here; xpu and rocmX.Y are listed because the indexes really do carry per-
-# accelerator builds of the companions (torchao on rocm6.4/7.0/7.1/7.2 and xpu, torchcodec
-# on xpu). Which of them a given package may use is that package's own call, below.
+# Local tags a companion wheel is served under. xpu and rocmX.Y are here because those leaves
+# really do carry companion builds; which a given package may use is that package's call.
 _TORCH_ACCELERATOR_TAG_RE = re.compile(r"cpu|cu\d+|xpu|rocm\d+(\.\d+)?")
 
 
@@ -617,36 +585,21 @@ def _torch_accelerator_index_url(
     if not torch_version:
         return None
     substitutions = substitutions or {}
-    # An explicit URL wins, as it does for the torch repair helpers: synthesising the public
-    # URL from the local tag sent authenticated, corporate and air-gapped mirrors to
-    # download.pytorch.org, and the --index-url also makes _install_env_for_cmd drop the
-    # inherited index config, so the install fails outright there. It is taken verbatim: its
-    # path belongs to whoever configured it and rewriting a leaf inside it would be a guess.
-    #
-    # Read BEFORE the tag check, because a private index is exactly where an UNTAGGED GPU
-    # build comes from: only download.pytorch.org stamps +cuNNN, so a corporate mirror that
-    # rebuilds torch ships it bare. _ensure_expected_torch_flavor already supports that host
-    # through its runtime markers. Requiring a tag first sent it to PyPI for both companions,
-    # which on an air-gapped box fails the fatal torchao step outright.
+    # Verbatim, and BEFORE the tag check: only download.pytorch.org stamps +cuNNN, so a
+    # private mirror rebuilding torch ships it bare, and requiring a tag first sent exactly
+    # that host to PyPI. Rewriting a leaf inside the URL would be a guess.
     url = os.environ.get("UNSLOTH_TORCH_INDEX_URL", "").strip()
     if url:
         return _trim_index_path_slashes(url)
-    # A FAMILY override names a leaf under our own base, so a per-package substitution still
-    # applies to it -- otherwise UNSLOTH_TORCH_INDEX_FAMILY=xpu would send torchcodec to the
-    # xpu leaf, which publishes no codec below 0.13.
-    #
-    # Read BEFORE the tag check for the same reason as the URL above: it is an explicit
-    # instruction, and the host that needs it is exactly the one whose torch has no tag.
-    # _explicit_unknown_family_torch_index_url already treats a custom leaf such as /current
-    # as authoritative and leaves that torch alone, so nothing later corrects a None here.
+    # Substitution still applies (FAMILY=xpu must not send torchcodec to a leaf with no codec
+    # below 0.13). Before the tag check for the same reason as the URL, and because
+    # _explicit_unknown_family_torch_index_url leaves such a torch alone: a None is final.
     family = os.environ.get("UNSLOTH_TORCH_INDEX_FAMILY", "").strip().strip("/")
     if family:
         return _pytorch_whl_leaf_url(substitutions.get(family.lower(), family))
     local = str(torch_version).partition("+")[2].strip().lower()
     if not _TORCH_ACCELERATOR_TAG_RE.fullmatch(local):
         return None
-    # _PYTORCH_WHL_BASE rather than a literal, since UNSLOTH_PYTORCH_MIRROR redirects every
-    # other index this module builds.
     return _pytorch_whl_leaf_url(substitutions.get(local, local))
 
 
@@ -903,13 +856,10 @@ def _pin_needs_reinstall(spec: str, want_tag: "str | None" = "") -> bool:
     satisfies pip, nothing is fetched, and the wrong-accelerator build this pin exists to
     replace stays put.
 
-    want_tag is the tag the pin will FETCH, from _torch_index_tag -- not the resident
-    torch's own tag, which a FAMILY override or a substitution can differ from. The default
-    "" is the no-index-pinned case rather than an absent argument: the wheel then comes from
-    the default index, which stamps no local tag, so a TAGGED wheel sitting there is still a
-    build from somewhere else and is still replaced. That settles after one reinstall, since
-    what lands is bare and matches "". None means the index is an opaque mirror, where
-    nothing can prove the installed wheel came from it, so it is replaced every time.
+    want_tag is the tag the pin will FETCH (_torch_index_tag), not the resident torch's,
+    which a FAMILY override can differ from. "" is the unpinned case: the default index stamps
+    no tag, so a tagged wheel there came from elsewhere and is replaced once, then settles.
+    None is an opaque mirror, where provenance is unprovable, so it is replaced every time.
     """
     match = re.fullmatch(r"([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s]+)", spec)
     if match is None:
@@ -4404,21 +4354,15 @@ def _resident_xformers_build_torch() -> "str | None":
 def _install_torchao_for_torch(torch_version: "str | None") -> None:
     """Select the torchao matching torch_version and install it from its own index.
 
-    Called twice: once as step 4, and again after the Linux torch repair, which can move
-    torch across families and releases underneath the first call (the explicit XPU pin
-    lands torch <2.11, where 0.18.0 is not supported at all).
+    Called twice: as step 4, and again after the Linux torch repair, which can move torch
+    across families and releases underneath the first call.
     """
     spec = _select_torchao_spec(torch_version)
-    # Pin the index to the resident torch's build, for the reason spelled out beside
-    # _TORCHAO_DEFAULT_SPEC: PyPI carries one torchao built for whichever CUDA major
-    # PyTorch defaults to (13 today), and the accelerator indexes carry a build per tag.
-    # rocm is included here, unlike torchcodec -- the rocm leaves really do publish torchao.
+    # See _TORCHAO_DEFAULT_SPEC. rocm is included here, unlike torchcodec: the rocm leaves
+    # really do publish torchao.
     index = _torch_accelerator_index_url(torch_version)
-    # --no-deps matches the resync call site. No torchao release declares a runtime torch
-    # dependency (checked on PyPI and on the cpu/cu126/cu130/cu132/xpu/rocm7.2 leaves, every
-    # one of which is Requires-Dist free outside its dev extra), so today this skips nothing.
-    # It is here because the second caller runs immediately after the torch repair, where a
-    # torchao that ever gained a torch pin would resolve it and undo that repair.
+    # --no-deps skips nothing today (no torchao release declares a runtime torch dependency)
+    # and guards the second caller, which runs right after the torch repair.
     args = ["--no-deps", "--no-cache-dir"]
     if _pin_needs_reinstall(spec, _torch_index_tag(torch_version) if index else ""):
         args.insert(0, "--force-reinstall")
@@ -4432,14 +4376,8 @@ def _install_torchao_for_torch(torch_version: "str | None") -> None:
         return
     if pip_install_try("Installing dependency overrides", *args, "--index-url", index, spec):
         return
-    # The pinned index may simply not carry this release: cu129 stops at 0.17.0 while
-    # serving torch up to 2.13, cu118 stops at 0.11.0, rocm7.0 publishes 0.16.0 alone, and
-    # a private mirror or a leaf added upstream after this shipped can lag by a release. The
-    # default index is where this step went before it pinned anything, so falling back is a
-    # working install rather than a failed one, and the default build beside another
-    # accelerator costs the cpp kernels and nothing else (see _TORCHAO_DEFAULT_SPEC). Still
-    # fatal if that fails too: torchao is not optional the way audio is, and this step was
-    # fatal before.
+    # A leaf can lack this release outright (cu129 stops at 0.17.0 while serving torch 2.13),
+    # and the wrong build only costs the kernels, so retry unpinned -- still fatally.
     _note(
         f"{_strip_index_url_credentials(index)} did not serve {spec} "
         "-- retrying from the default index; its kernels may be skipped"
@@ -4463,9 +4401,8 @@ def _resync_torch_coupled_packages(label_before: str) -> bool:
     if not _label_after or _label_after == label_before:
         return True
     _touched_torch = False
-    # Release OR accelerator family: cu124 to cu130 at one release still changes the build,
-    # and so does cpu to xpu, which moves no CUDA major at all (both read None) and so was
-    # invisible to a cuda-major-only test. Compare the whole local tag.
+    # The whole local tag, not just the CUDA major: cpu to xpu moves no major at all (both
+    # read None) yet still changes the build.
     _release_moved = _label_after.split("+", 1)[0] != str(label_before).split("+", 1)[0]
     _family_moved = _label_after.partition("+")[2].strip().lower() != (
         str(label_before).partition("+")[2].strip().lower()
@@ -4476,10 +4413,8 @@ def _resync_torch_coupled_packages(label_before: str) -> bool:
     if _release_moved or _family_moved or _cuda_moved:
         try:
             _spec = _select_torchao_spec(_label_after)
-            # The same index pin step 4 uses. Without it this call reinstalls PyPI's CUDA-12
-            # wheel straight over the correctly pinned one, and _pin_needs_reinstall rather
-            # than an exact compare because the pinned wheel carries a local tag that
-            # ==0.18.0 never equals, which would make this fire on every repair.
+            # The same pin step 4 uses, or this reinstalls PyPI's build over it.
+            # _pin_needs_reinstall, not an exact compare: ==0.18.0 never equals 0.18.0+cu130.
             _ao_index = _torch_accelerator_index_url(_label_after)
             _ao_args = ["--force-reinstall", "--no-deps", "--no-cache-dir"]
             if _pin_needs_reinstall(
@@ -8026,12 +7961,10 @@ def install_python_stack() -> int:
         # Last, after every torch migration: the swap keys off the installed +xpu label, so a
         # CPU pin over an XPU venv would leave XPU triton under a CPU torch.
         _ensure_xpu_triton()
-        # These repairs move torch across families AND releases, and step 4 chose torchao
-        # from the version torch had BEFORE them. An explicit XPU pin is the sharp case:
-        # _XPU_TORCH_PKG_SPEC is torch>=2.6,<2.11.0, so it necessarily lands below the 2.11
-        # floor that torchao 0.18.0 requires. Only the Windows flavor repair reaches
-        # _resync_torch_coupled_packages, so on Linux nothing re-selected it (#10493).
-        # Re-running the same decision is a no-op when torch did not move.
+        # Step 4 chose torchao from the torch these repairs then moved. The XPU pin is the
+        # sharp case: torch>=2.6,<2.11.0 lands below torchao 0.18.0's 2.11 floor. Only the
+        # Windows repair reaches _resync_torch_coupled_packages, so on Linux nothing
+        # re-selected it (#10493).
         _torch_after_repair = str(_probe_installed_torch_version() or "")
         if _torch_after_repair and _torch_after_repair != _torch_before_repair:
             _note(
@@ -8099,12 +8032,8 @@ def install_python_stack() -> int:
             # from the version: the torch indexes carry a +cuNNN / +cpu local tag and PyPI
             # forbids one, so a local tag that is missing or different means another build.
             _codec_have = _installed_distribution_version("torchcodec") or ""
-            # The tag the PIN will fetch, not the resident torch's own: an xpu torch is
-            # served the cpu wheel, and comparing against "xpu" would never match, so every
-            # run would force-reinstall a codec that was already correct. None means an
-            # opaque mirror, which cannot prove anything, so the wheel is replaced -- an
-            # untagged one already satisfies the range, so pip would otherwise fetch nothing
-            # and the mirror would never be reached.
+            # The tag the PIN will fetch, not the resident torch's: an xpu torch is served
+            # the cpu wheel, so comparing against "xpu" would force-reinstall every run.
             _codec_want = _torchcodec_index_tag(_codec_torch_ver)
             if _codec_have and (
                 _codec_want is None or _codec_have.partition("+")[2].strip().lower() != _codec_want
@@ -8128,29 +8057,23 @@ def install_python_stack() -> int:
         _codec_ok = pip_install_try("Installing torchcodec", *_codec_args, _codec_spec)
         _codec_fellback = False
         if not _codec_ok and _codec_index:
-            # The pinned index may not carry this window at all: cu129 publishes 0.6, 0.7
-            # and 0.10 upward but neither 0.8 nor 0.9, while serving torch 2.8 to 2.13, so
-            # torch 2.9 there selects a range that index has nothing in. A local table of
-            # what each index holds is what goes stale -- cu132 did not exist when this was
-            # written and xpu gained torchcodec after it -- so retry unpinned instead, which
-            # is exactly what such a host got before this step pinned anything. If that
-            # lands a build from another accelerator, _torchcodec_provenance_hint says so at
-            # import rather than leaving it unexplained.
+            # The leaf may not carry this window at all: cu129 serves torch 2.8-2.13 but
+            # publishes no 0.8 or 0.9. Retry unpinned rather than table what each index
+            # holds, which is what goes stale. _torchcodec_provenance_hint explains at
+            # import if that lands another accelerator's build.
             _note(
                 f"{_strip_index_url_credentials(_codec_index)} did not serve {_codec_spec} "
                 "-- retrying from the default index"
             )
-            # Drop only the pin. --force-reinstall has to survive: it is set when the
-            # installed codec is inside the version window but built by another index, and
-            # without it pip calls the requirement satisfied, fetches nothing, and leaves
-            # that same incompatible wheel in place.
+            # Drop only the pin: --force-reinstall must survive, or pip calls the requirement
+            # satisfied and leaves the wrong-accelerator wheel in place.
             _codec_retry_args = [
                 a
                 for i, a in enumerate(_codec_args)
                 if a != "--index-url" and _codec_args[i - 1] != "--index-url"
             ]
-            # _codec_index stays set on purpose: the wheel PyPI serves for a cuNNN host is
-            # still a CUDA build, so it still dlopens NPP and the step below still applies.
+            # _codec_index stays set: PyPI's wheel is still a CUDA build on Linux, so the
+            # NPP step below still applies.
             _codec_ok = pip_install_try("Installing torchcodec", *_codec_retry_args, _codec_spec)
             _codec_fellback = _codec_ok
         if not _codec_ok:
@@ -8166,14 +8089,9 @@ def install_python_stack() -> int:
             # same wheel for exactly this. cu13x wheels want nvidia-npp-cu13.
             _npp_major = _cuda_major_for_npp(_codec_torch_ver, _codec_index)
             if _codec_fellback:
-                # The retry dropped the pin, so the resident torch's tag no longer describes
-                # where this wheel came from, and the probe has to run for EVERY fallback
-                # rather than only where the tag already implied CUDA. PyPI's torchcodec is
-                # a CUDA build, so a host whose tag implies none -- xpu, which takes the cpu
-                # leaf, or an untagged private build -- lands one anyway and needs the NPP
-                # its tag said nothing about. Gating the probe on the tag skipped exactly
-                # the hosts it was meant to rescue. In the other direction a cu129 host
-                # lands a libcudart.so.13 codec while its tag asks for nvidia-npp-cu12.
+                # The pin is gone, so the tag no longer describes this wheel. Probe EVERY
+                # fallback, including tags implying no CUDA: an xpu host takes the cpu leaf
+                # and still lands PyPI's CUDA build, needing NPP its tag never mentioned.
                 _npp_probed = _installed_torchcodec_cuda_major()
                 if _npp_probed is not None and _npp_probed != _npp_major:
                     _note(
@@ -8182,8 +8100,6 @@ def install_python_stack() -> int:
                         "which its torch tag implies -- matching NPP to the wheel"
                     )
                     _npp_major = _npp_probed
-            # _npp_major is "" when the probe found a build linking no CUDA runtime at
-            # all, which needs no NPP.
             if _npp_major and not pip_install_try(
                 "Installing torchcodec CUDA runtime (NPP)",
                 "--no-cache-dir",

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -511,6 +511,14 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
     return match.group(1)[:2] if match else ""
 
 
+# Any sign of the CUDA runtime, versioned or not. nvcudart_hybrid64.dll is the Windows
+# cu130 spelling, which carries no major; nvcuda.dll and torch_cuda are the driver and
+# torch's own CUDA library, present in a CUDA build and absent from a cpu one.
+_CUDA_RUNTIME_MARKER_RE = re.compile(
+    rb"nvcuda\.dll|torch_cuda|nvcudart|libcudart|cudart64|libcuda\.so"
+)
+
+
 def _torchcodec_distribution_for_probe():
     """The installed torchcodec distribution, or None when it cannot be read."""
     try:
@@ -523,32 +531,44 @@ def _torchcodec_distribution_for_probe():
 def _installed_torchcodec_cuda_major() -> "str | None":
     """The CUDA major the INSTALLED torchcodec links, or "" when it links none.
 
-    None when it cannot be read, which means "keep whatever the caller already decided".
-    Only the unpinned fallback needs this: a pinned index guarantees the major, but the
-    default index carries whichever major PyTorch currently defaults to, which is not
-    necessarily the resident torch's. Read from the wheel's own shared objects rather than
-    inferred, since that default moves (torchcodec 0.16.0 on PyPI links libcudart.so.13
-    while a +cu129 host's tag says 12).
+    None means "cannot tell -- keep whatever the caller already decided". Only the unpinned
+    fallback needs this: a pinned index guarantees the major, but the default index carries
+    whichever major PyTorch currently defaults to, which is not necessarily the resident
+    torch's. Read from the wheel's own native files rather than inferred, since that default
+    moves (torchcodec 0.16.0 on PyPI links libcudart.so.13 while a +cu129 host's tag says 12).
+
+    The three answers are deliberately distinct, because "" SKIPS the NPP install and getting
+    that wrong leaves audio broken on a host with no system toolkit. Windows is why: its
+    natives are .dll/.pyd, and the majors are spelled cudart64_12.dll rather than
+    libcudart.so.12. Worse, the win_amd64 cu130 wheel names no major at all -- it references
+    nvcudart_hybrid64.dll -- so a CUDA build there is recognisable without being readable.
+    That case has to be None, not "". Verified across the 0.16.0 wheels: cpu on both
+    platforms carries no CUDA reference whatsoever, cu126 spells its major on both, and only
+    win_amd64 cu130 is CUDA-with-no-major.
     """
     dist = _torchcodec_distribution_for_probe()
-    files = list(getattr(dist, "files", None) or []) if dist is not None else []
     if dist is None:
         return None
-    majors = set()
+    files = list(getattr(dist, "files", None) or [])
+    majors, saw_cuda, inspected = set(), False, False
     for entry in files:
-        name = str(entry)
-        if not (name.endswith(".so") or ".so." in name):
+        name = str(entry).lower()
+        if not (name.endswith((".so", ".dll", ".pyd")) or ".so." in name):
             continue
         try:
             blob = Path(entry.locate()).read_bytes()
         except OSError:
             continue
+        inspected = True
         majors |= {m.decode()[-2:] for m in re.findall(rb"libcudart\.so\.\d+", blob)}
-    if not majors:
-        # Distinguish "a cpu build, needs no NPP" from "could not look": a torchcodec whose
-        # files we did read and which links no CUDA runtime is genuinely NPP-free.
-        return "" if files else None
-    return sorted(majors)[-1]
+        majors |= {m.decode()[9:11] for m in re.findall(rb"cudart64_\d+\.dll", blob)}
+        saw_cuda = saw_cuda or bool(_CUDA_RUNTIME_MARKER_RE.search(blob))
+    if not inspected:
+        return None  # nothing readable: say so rather than claim there is no CUDA
+    if majors:
+        return sorted(majors)[-1]
+    # CUDA is clearly there but unversioned in the names, so the tag-derived answer stands.
+    return None if saw_cuda else ""
 
 
 # The local tags download.pytorch.org serves a companion wheel under. cpu and cuNNN have

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -519,21 +519,24 @@ _CUDA_RUNTIME_MARKER_RE = re.compile(
 )
 
 
-def _pytorch_whl_leaf_url(leaf: str) -> str:
-    """_PYTORCH_WHL_BASE plus an accelerator leaf, keeping a mirror's query out of the way.
+def _pytorch_whl_leaf_url(leaf: str) -> "str | None":
+    """_PYTORCH_WHL_BASE plus an accelerator leaf, or None when it cannot be expressed.
 
-    UNSLOTH_PYTORCH_MIRROR may authenticate through a query token, and plain concatenation
-    buries the leaf inside it -- "https://m/whl?token=abc" + "/cu130" asks for /whl with
-    "abc/cu130" as the token, which resolves nothing. torchcodec would silently lose audio;
-    torchao's step is fatal AND its unpinned retry drops the mirror too, so a mirror-only
-    host could not install it at all.
+    A mirror may authenticate through a query token, and NO url shape pins such an index:
+    pip joins the project name as text (posixpath.join), so both "base?token=x/cu130" and
+    "base/cu130/?token=x" ask the wrong thing -- _warn_query_index_unusable spells this out
+    and says the join cannot repair it.
 
-    _index_url_join is the existing fix for exactly this, written for the ROCm mirrors, but
-    it also appends a trailing slash. That is harmless to pip and wrong to spread: without a
-    query there is nothing to work around, so the plain form is kept byte for byte.
+    So there is nothing to construct here, and constructing something anyway is worse than
+    declining. Passing --index-url makes _install_env_for_cmd strip the user's own index
+    configuration (UV_NO_CONFIG=1, PIP_CONFIG_FILE=os.devnull), which for a query-auth
+    mirror is the ONLY channel that can work: the credential has to come from pip.conf or
+    ~/.netrc. A broken pin therefore destroys the working path to install a wheel from an
+    index that never resolves. Returning None leaves the configuration in place.
     """
     if "?" in _PYTORCH_WHL_BASE or "#" in _PYTORCH_WHL_BASE:
-        return _index_url_join(_PYTORCH_WHL_BASE, leaf)
+        _warn_query_index_unusable(_PYTORCH_WHL_BASE)
+        return None
     return f"{_PYTORCH_WHL_BASE}/{leaf}"
 
 
@@ -628,15 +631,20 @@ def _torch_accelerator_index_url(
     url = os.environ.get("UNSLOTH_TORCH_INDEX_URL", "").strip()
     if url:
         return _trim_index_path_slashes(url)
-    local = str(torch_version).partition("+")[2].strip().lower()
-    if not _TORCH_ACCELERATOR_TAG_RE.fullmatch(local):
-        return None
     # A FAMILY override names a leaf under our own base, so a per-package substitution still
     # applies to it -- otherwise UNSLOTH_TORCH_INDEX_FAMILY=xpu would send torchcodec to the
     # xpu leaf, which publishes no codec below 0.13.
+    #
+    # Read BEFORE the tag check for the same reason as the URL above: it is an explicit
+    # instruction, and the host that needs it is exactly the one whose torch has no tag.
+    # _explicit_unknown_family_torch_index_url already treats a custom leaf such as /current
+    # as authoritative and leaves that torch alone, so nothing later corrects a None here.
     family = os.environ.get("UNSLOTH_TORCH_INDEX_FAMILY", "").strip().strip("/")
     if family:
         return _pytorch_whl_leaf_url(substitutions.get(family.lower(), family))
+    local = str(torch_version).partition("+")[2].strip().lower()
+    if not _TORCH_ACCELERATOR_TAG_RE.fullmatch(local):
+        return None
     # _PYTORCH_WHL_BASE rather than a literal, since UNSLOTH_PYTORCH_MIRROR redirects every
     # other index this module builds.
     return _pytorch_whl_leaf_url(substitutions.get(local, local))
@@ -8150,7 +8158,7 @@ def install_python_stack() -> int:
                 f"could not install {_codec_spec} -- audio decoding stays disabled, "
                 "the rest of the install is unaffected"
             )
-        elif _codec_index and _cuda_major_for_npp(_codec_torch_ver, _codec_index):
+        elif _codec_index:
             # torchcodec's CUDA build dlopens libnppicc and libnppc, and NPP is NOT in
             # torch's own dependency set, so a --no-deps install from a cuNNN index reports
             # success and then fails to import, disabling audio for a reason nothing here
@@ -8159,17 +8167,19 @@ def install_python_stack() -> int:
             _npp_major = _cuda_major_for_npp(_codec_torch_ver, _codec_index)
             if _codec_fellback:
                 # The retry dropped the pin, so the resident torch's tag no longer describes
-                # where this wheel came from. The default index carries one build per
-                # release, at whatever CUDA major PyTorch currently defaults to, so a cu129
-                # host lands a libcudart.so.13 codec and the tag would have asked for
-                # nvidia-npp-cu12 -- the wrong runtime, and audio stays broken on a host
-                # with no system toolkit, which is the case this whole step exists for.
+                # where this wheel came from, and the probe has to run for EVERY fallback
+                # rather than only where the tag already implied CUDA. PyPI's torchcodec is
+                # a CUDA build, so a host whose tag implies none -- xpu, which takes the cpu
+                # leaf, or an untagged private build -- lands one anyway and needs the NPP
+                # its tag said nothing about. Gating the probe on the tag skipped exactly
+                # the hosts it was meant to rescue. In the other direction a cu129 host
+                # lands a libcudart.so.13 codec while its tag asks for nvidia-npp-cu12.
                 _npp_probed = _installed_torchcodec_cuda_major()
                 if _npp_probed is not None and _npp_probed != _npp_major:
                     _note(
                         f"the unpinned torchcodec links CUDA {_npp_probed or 'nothing'} "
-                        f"rather than the CUDA {_npp_major} its torch tag implies "
-                        "-- matching NPP to the wheel"
+                        f"rather than {'CUDA ' + _npp_major if _npp_major else 'nothing'}, "
+                        "which its torch tag implies -- matching NPP to the wheel"
                     )
                     _npp_major = _npp_probed
             # _npp_major is "" when the probe found a build linking no CUDA runtime at

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -320,11 +320,11 @@ _TORCH_FLAVOR_REPAIR_PKG_SPEC: tuple[str, str, str] = (
 # Unknown/older torch keeps the conservative default.
 #
 # The pin alone is not enough: torchao publishes a wheel per accelerator under
-# download.pytorch.org/whl/<tag> and PyPI's default is the CUDA-12 one, so the caller pins
-# the index to the resident torch's build. Without that, taking 0.18.0 on a torch 2.13 host
-# would LOAD its cpp (built for 2.13) and then fail on libcudart.so.12 wherever torch is
-# CUDA 13 -- the same crash the 2.10 CUDA-13 row above exists to dodge by picking a build
-# whose cpp is skipped instead.
+# download.pytorch.org/whl/<tag>, while PyPI carries ONE default whose CUDA major is whatever
+# PyTorch currently ships by default -- 13 as of 0.18.0, which links libcudart.so.13, not 12.
+# So the default index is not a fixed fallback major and cannot be reasoned about as one; the
+# caller pins the index to the resident torch's build instead. Taking the default beside a
+# torch of another major costs the cpp kernels (see above), not the install.
 _TORCHAO_DEFAULT_SPEC = "torchao==0.14.0"
 _TORCHAO_TORCH_210_SPEC = "torchao==0.16.0"
 _TORCHAO_TORCH_210_CUDA13_SPEC = "torchao==0.17.0"
@@ -511,6 +511,46 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
     return match.group(1)[:2] if match else ""
 
 
+def _torchcodec_distribution_for_probe():
+    """The installed torchcodec distribution, or None when it cannot be read."""
+    try:
+        from importlib.metadata import PackageNotFoundError, distribution
+        return distribution("torchcodec")
+    except (PackageNotFoundError, ValueError, OSError):
+        return None
+
+
+def _installed_torchcodec_cuda_major() -> "str | None":
+    """The CUDA major the INSTALLED torchcodec links, or "" when it links none.
+
+    None when it cannot be read, which means "keep whatever the caller already decided".
+    Only the unpinned fallback needs this: a pinned index guarantees the major, but the
+    default index carries whichever major PyTorch currently defaults to, which is not
+    necessarily the resident torch's. Read from the wheel's own shared objects rather than
+    inferred, since that default moves (torchcodec 0.16.0 on PyPI links libcudart.so.13
+    while a +cu129 host's tag says 12).
+    """
+    dist = _torchcodec_distribution_for_probe()
+    files = list(getattr(dist, "files", None) or []) if dist is not None else []
+    if dist is None:
+        return None
+    majors = set()
+    for entry in files:
+        name = str(entry)
+        if not (name.endswith(".so") or ".so." in name):
+            continue
+        try:
+            blob = Path(entry.locate()).read_bytes()
+        except OSError:
+            continue
+        majors |= {m.decode()[-2:] for m in re.findall(rb"libcudart\.so\.\d+", blob)}
+    if not majors:
+        # Distinguish "a cpu build, needs no NPP" from "could not look": a torchcodec whose
+        # files we did read and which links no CUDA runtime is genuinely NPP-free.
+        return "" if files else None
+    return sorted(majors)[-1]
+
+
 # The local tags download.pytorch.org serves a companion wheel under. cpu and cuNNN have
 # always been here; xpu and rocmX.Y are listed because the indexes really do carry per-
 # accelerator builds of the companions (torchao on rocm6.4/7.0/7.1/7.2 and xpu, torchcodec
@@ -536,17 +576,23 @@ def _torch_accelerator_index_url(
     if not torch_version:
         return None
     substitutions = substitutions or {}
-    local = str(torch_version).partition("+")[2].strip().lower()
-    if not _TORCH_ACCELERATOR_TAG_RE.fullmatch(local):
-        return None
     # An explicit URL wins, as it does for the torch repair helpers: synthesising the public
     # URL from the local tag sent authenticated, corporate and air-gapped mirrors to
     # download.pytorch.org, and the --index-url also makes _install_env_for_cmd drop the
     # inherited index config, so the install fails outright there. It is taken verbatim: its
     # path belongs to whoever configured it and rewriting a leaf inside it would be a guess.
+    #
+    # Read BEFORE the tag check, because a private index is exactly where an UNTAGGED GPU
+    # build comes from: only download.pytorch.org stamps +cuNNN, so a corporate mirror that
+    # rebuilds torch ships it bare. _ensure_expected_torch_flavor already supports that host
+    # through its runtime markers. Requiring a tag first sent it to PyPI for both companions,
+    # which on an air-gapped box fails the fatal torchao step outright.
     url = os.environ.get("UNSLOTH_TORCH_INDEX_URL", "").strip()
     if url:
         return _trim_index_path_slashes(url)
+    local = str(torch_version).partition("+")[2].strip().lower()
+    if not _TORCH_ACCELERATOR_TAG_RE.fullmatch(local):
+        return None
     # A FAMILY override names a leaf under our own base, so a per-package substitution still
     # applies to it -- otherwise UNSLOTH_TORCH_INDEX_FAMILY=xpu would send torchcodec to the
     # xpu leaf, which publishes no codec below 0.13.
@@ -801,11 +847,7 @@ def _exact_distribution_spec_is_installed(spec: str) -> bool:
     return installed is not None and installed == match.group(2)
 
 
-# "no index is being pinned", which is not the same as "the index is opaque" (None).
-_NO_INDEX_PINNED = object()
-
-
-def _pin_needs_reinstall(spec: str, want_tag: object = _NO_INDEX_PINNED) -> bool:
+def _pin_needs_reinstall(spec: str, want_tag: "str | None" = "") -> bool:
     """Whether a ``name==version`` pin has to be forced over what is already installed.
 
     Two reasons, and the second only exists once an index is pinned. The version can be
@@ -816,10 +858,12 @@ def _pin_needs_reinstall(spec: str, want_tag: object = _NO_INDEX_PINNED) -> bool
     replace stays put.
 
     want_tag is the tag the pin will FETCH, from _torch_index_tag -- not the resident
-    torch's own tag, which a FAMILY override or a substitution can differ from. Leave it
-    unset when no index is pinned: the tag then carries no requirement and a matching
-    release must not be reinstalled on every run. None means the index is an opaque mirror,
-    where nothing can prove the installed wheel came from it, so it is replaced.
+    torch's own tag, which a FAMILY override or a substitution can differ from. The default
+    "" is the no-index-pinned case rather than an absent argument: the wheel then comes from
+    the default index, which stamps no local tag, so a TAGGED wheel sitting there is still a
+    build from somewhere else and is still replaced. That settles after one reinstall, since
+    what lands is bare and matches "". None means the index is an opaque mirror, where
+    nothing can prove the installed wheel came from it, so it is replaced every time.
     """
     match = re.fullmatch(r"([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s]+)", spec)
     if match is None:
@@ -829,8 +873,6 @@ def _pin_needs_reinstall(spec: str, want_tag: object = _NO_INDEX_PINNED) -> bool
         return True  # absent; kept True so the flag matches what this step passed before
     if installed.partition("+")[0] != match.group(2).partition("+")[0]:
         return True
-    if want_tag is _NO_INDEX_PINNED:
-        return False
     return installed.partition("+")[2].strip().lower() != want_tag
 
 
@@ -4322,9 +4364,9 @@ def _install_torchao_for_torch(torch_version: "str | None") -> None:
     """
     spec = _select_torchao_spec(torch_version)
     # Pin the index to the resident torch's build, for the reason spelled out beside
-    # _TORCHAO_DEFAULT_SPEC: PyPI's torchao is the CUDA-12 wheel, and the accelerator
-    # indexes carry a build per tag. rocm is included here, unlike torchcodec -- the rocm
-    # leaves really do publish torchao.
+    # _TORCHAO_DEFAULT_SPEC: PyPI carries one torchao built for whichever CUDA major
+    # PyTorch defaults to (13 today), and the accelerator indexes carry a build per tag.
+    # rocm is included here, unlike torchcodec -- the rocm leaves really do publish torchao.
     index = _torch_accelerator_index_url(torch_version)
     # --no-deps matches the resync call site. No torchao release declares a runtime torch
     # dependency (checked on PyPI and on the cpu/cu126/cu130/cu132/xpu/rocm7.2 leaves, every
@@ -4332,7 +4374,7 @@ def _install_torchao_for_torch(torch_version: "str | None") -> None:
     # It is here because the second caller runs immediately after the torch repair, where a
     # torchao that ever gained a torch pin would resolve it and undo that repair.
     args = ["--no-deps", "--no-cache-dir"]
-    if _pin_needs_reinstall(spec, _torch_index_tag(torch_version) if index else _NO_INDEX_PINNED):
+    if _pin_needs_reinstall(spec, _torch_index_tag(torch_version) if index else ""):
         args.insert(0, "--force-reinstall")
     _note(
         f"torch {torch_version or 'unknown'} detected -- installing {spec}"
@@ -4348,7 +4390,7 @@ def _install_torchao_for_torch(torch_version: "str | None") -> None:
     # serving torch up to 2.13, cu118 stops at 0.11.0, rocm7.0 publishes 0.16.0 alone, and
     # a private mirror or a leaf added upstream after this shipped can lag by a release. The
     # default index is where this step went before it pinned anything, so falling back is a
-    # working install rather than a failed one, and PyPI's CUDA-12 build beside another
+    # working install rather than a failed one, and the default build beside another
     # accelerator costs the cpp kernels and nothing else (see _TORCHAO_DEFAULT_SPEC). Still
     # fatal if that fails too: torchao is not optional the way audio is, and this step was
     # fatal before.
@@ -4395,7 +4437,7 @@ def _resync_torch_coupled_packages(label_before: str) -> bool:
             _ao_index = _torch_accelerator_index_url(_label_after)
             _ao_args = ["--force-reinstall", "--no-deps", "--no-cache-dir"]
             if _pin_needs_reinstall(
-                _spec, _torch_index_tag(_label_after) if _ao_index else _NO_INDEX_PINNED
+                _spec, _torch_index_tag(_label_after) if _ao_index else ""
             ):
                 _note(f"torch {_label_after} after repair -- reinstalling {_spec}")
                 _touched_torch = True
@@ -8038,6 +8080,7 @@ def install_python_stack() -> int:
         # the index can refuse for reasons no local table predicts -- a yanked release, an
         # offline mirror, a platform tag added or dropped upstream after this shipped.
         _codec_ok = pip_install_try("Installing torchcodec", *_codec_args, _codec_spec)
+        _codec_fellback = False
         if not _codec_ok and _codec_index:
             # The pinned index may not carry this window at all: cu129 publishes 0.6, 0.7
             # and 0.10 upward but neither 0.8 nor 0.9, while serving torch 2.8 to 2.13, so
@@ -8063,6 +8106,7 @@ def install_python_stack() -> int:
             # _codec_index stays set on purpose: the wheel PyPI serves for a cuNNN host is
             # still a CUDA build, so it still dlopens NPP and the step below still applies.
             _codec_ok = pip_install_try("Installing torchcodec", *_codec_retry_args, _codec_spec)
+            _codec_fellback = _codec_ok
         if not _codec_ok:
             _note(
                 f"could not install {_codec_spec} -- audio decoding stays disabled, "
@@ -8075,7 +8119,24 @@ def install_python_stack() -> int:
             # would otherwise name. docker/Dockerfile installs nvidia-npp-cu12 beside the
             # same wheel for exactly this. cu13x wheels want nvidia-npp-cu13.
             _npp_major = _cuda_major_for_npp(_codec_torch_ver, _codec_index)
-            if not pip_install_try(
+            if _codec_fellback:
+                # The retry dropped the pin, so the resident torch's tag no longer describes
+                # where this wheel came from. The default index carries one build per
+                # release, at whatever CUDA major PyTorch currently defaults to, so a cu129
+                # host lands a libcudart.so.13 codec and the tag would have asked for
+                # nvidia-npp-cu12 -- the wrong runtime, and audio stays broken on a host
+                # with no system toolkit, which is the case this whole step exists for.
+                _npp_probed = _installed_torchcodec_cuda_major()
+                if _npp_probed is not None and _npp_probed != _npp_major:
+                    _note(
+                        f"the unpinned torchcodec links CUDA {_npp_probed or 'nothing'} "
+                        f"rather than the CUDA {_npp_major} its torch tag implies "
+                        "-- matching NPP to the wheel"
+                    )
+                    _npp_major = _npp_probed
+            # _npp_major is "" when the probe found a build linking no CUDA runtime at
+            # all, which needs no NPP.
+            if _npp_major and not pip_install_try(
                 "Installing torchcodec CUDA runtime (NPP)",
                 "--no-cache-dir",
                 f"nvidia-npp-cu{_npp_major}",

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -519,6 +519,24 @@ _CUDA_RUNTIME_MARKER_RE = re.compile(
 )
 
 
+def _pytorch_whl_leaf_url(leaf: str) -> str:
+    """_PYTORCH_WHL_BASE plus an accelerator leaf, keeping a mirror's query out of the way.
+
+    UNSLOTH_PYTORCH_MIRROR may authenticate through a query token, and plain concatenation
+    buries the leaf inside it -- "https://m/whl?token=abc" + "/cu130" asks for /whl with
+    "abc/cu130" as the token, which resolves nothing. torchcodec would silently lose audio;
+    torchao's step is fatal AND its unpinned retry drops the mirror too, so a mirror-only
+    host could not install it at all.
+
+    _index_url_join is the existing fix for exactly this, written for the ROCm mirrors, but
+    it also appends a trailing slash. That is harmless to pip and wrong to spread: without a
+    query there is nothing to work around, so the plain form is kept byte for byte.
+    """
+    if "?" in _PYTORCH_WHL_BASE or "#" in _PYTORCH_WHL_BASE:
+        return _index_url_join(_PYTORCH_WHL_BASE, leaf)
+    return f"{_PYTORCH_WHL_BASE}/{leaf}"
+
+
 def _torchcodec_distribution_for_probe():
     """The installed torchcodec distribution, or None when it cannot be read."""
     try:
@@ -618,10 +636,10 @@ def _torch_accelerator_index_url(
     # xpu leaf, which publishes no codec below 0.13.
     family = os.environ.get("UNSLOTH_TORCH_INDEX_FAMILY", "").strip().strip("/")
     if family:
-        return f"{_PYTORCH_WHL_BASE}/{substitutions.get(family.lower(), family)}"
+        return _pytorch_whl_leaf_url(substitutions.get(family.lower(), family))
     # _PYTORCH_WHL_BASE rather than a literal, since UNSLOTH_PYTORCH_MIRROR redirects every
     # other index this module builds.
-    return f"{_PYTORCH_WHL_BASE}/{substitutions.get(local, local)}"
+    return _pytorch_whl_leaf_url(substitutions.get(local, local))
 
 
 def _torchcodec_index_url(torch_version: "str | None", spec: str = "") -> "str | None":

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -309,12 +309,23 @@ _TORCH_FLAVOR_REPAIR_PKG_SPEC: tuple[str, str, str] = (
 #   2.10.x, CUDA<=12 -> 0.16.0 (cpp built for 2.10, loads via the CUDA-12 wheel)
 #   2.10.x, CUDA>=13 -> 0.17.0 (cu130: 0.16.0's CUDA-12 cpp crashes on load; 0.17.0
 #                       targets torch 2.11 so its cpp is cleanly skipped, not crashed)
-#   2.11.x           -> 0.17.0 (reachable via CUDA or ROCm rocm7.2)
+#   2.11.x           -> 0.17.0 (reachable via CUDA or ROCm rocm7.2; cpp built for 2.11)
+#   2.12.x and up    -> 0.18.0 (0.18.0 dropped torch <2.11 and pinned its release CI to
+#                       2.13, so it is the build for this range; 0.17.0's own table stops
+#                       supporting the Python API at 2.11)
 # Unknown/older torch keeps the conservative default.
+#
+# The pin alone is not enough: torchao publishes a wheel per accelerator under
+# download.pytorch.org/whl/<tag> and PyPI's default is the CUDA-12 one, so the caller pins
+# the index to the resident torch's build. Without that, taking 0.18.0 on a torch 2.13 host
+# would LOAD its cpp (built for 2.13) and then fail on libcudart.so.12 wherever torch is
+# CUDA 13 -- the same crash the 2.10 CUDA-13 row above exists to dodge by picking a build
+# whose cpp is skipped instead.
 _TORCHAO_DEFAULT_SPEC = "torchao==0.14.0"
 _TORCHAO_TORCH_210_SPEC = "torchao==0.16.0"
 _TORCHAO_TORCH_210_CUDA13_SPEC = "torchao==0.17.0"
-_TORCHAO_TORCH_211_PLUS_SPEC = "torchao==0.17.0"
+_TORCHAO_TORCH_211_SPEC = "torchao==0.17.0"
+_TORCHAO_TORCH_212_PLUS_SPEC = "torchao==0.18.0"
 # torch 2.10 built against CUDA >= this major can't load 0.16.0's CUDA-12 cpp.
 _TORCHAO_CUDA13_MIN_MAJOR = 13
 
@@ -348,8 +359,10 @@ def _select_torchao_spec(torch_version: str | None) -> str:
         return _TORCHAO_DEFAULT_SPEC
     if major != 2:
         return _TORCHAO_DEFAULT_SPEC
-    if minor >= 11:
-        return _TORCHAO_TORCH_211_PLUS_SPEC  # newest known build; covers 2.11+
+    if minor >= 12:
+        return _TORCHAO_TORCH_212_PLUS_SPEC  # newest known build; covers 2.12+
+    if minor == 11:
+        return _TORCHAO_TORCH_211_SPEC  # 0.17.0's cpp is built for exactly this minor
     if minor == 10:
         # cu130+ can't load 0.16.0's CUDA-12 cpp; use 0.17.0 (cpp skipped, not crashed).
         cuda_major = _cuda_major_from_torch_version(str(torch_version))
@@ -466,6 +479,12 @@ def _torchcodec_python_is_supported(
 # oldest venvs. They keep today's unpinned behavior.
 _TORCHCODEC_MIN_ON_TORCH_INDEX = (0, 3, 0)
 
+# Leaves that joined later than that. A floor, not an inventory: it only ever says "this
+# index published nothing below X", which upstream does not walk back, so it cannot rot the
+# way a list of held versions does. Holes ABOVE the floor are real (cu129 carries no 0.8 or
+# 0.9) and are left to the caller's unpinned retry rather than tabulated here.
+_TORCHCODEC_INDEX_FLOORS = {"xpu": (0, 13, 0)}
+
 
 def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
     """`"12"`, `"13"`, or `""` when this codec install needs no NPP runtime.
@@ -486,39 +505,64 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
     return match.group(1)[:2] if match else ""
 
 
-def _torchcodec_index_url(torch_version: "str | None", spec: str = "") -> "str | None":
-    """The torchcodec index serving the resident torch's build, or None to stay unpinned.
+# The local tags download.pytorch.org serves a companion wheel under. cpu and cuNNN have
+# always been here; xpu and rocmX.Y are listed because the indexes really do carry per-
+# accelerator builds of the companions (torchao on rocm6.4/7.0/7.1/7.2 and xpu, torchcodec
+# on xpu). Which of them a given package may use is that package's own call, below.
+_TORCH_ACCELERATOR_TAG_RE = re.compile(r"cpu|cu\d+|xpu|rocm\d+(\.\d+)?")
 
-    torchcodec is published per accelerator exactly the way torch is: PyPI carries one
-    default flavor and the rest live at download.pytorch.org/whl/<tag>. Upstream's install
-    docs say to pass --index-url and "make sure to install the corresponding PyTorch version
-    as well", so a cu126 or cu128 venv that takes PyPI's default gets a codec built against a
-    different CUDA and libtorchcodec cannot dlopen. docker/Dockerfile already pins cu128 by
-    hand for this reason.
+
+def _torch_accelerator_index_url(torch_version: "str | None") -> "str | None":
+    """The download.pytorch.org leaf serving the resident torch's build, or None.
+
+    Companion wheels (torchcodec, torchao) are published per accelerator exactly the way
+    torch is: PyPI carries one default flavor and the rest live under /whl/<tag>. The right
+    version from the wrong index is a wheel whose cpp cannot dlopen against the resident
+    CUDA or HIP runtime.
 
     Only an EXPLICIT local tag pins. An untagged torch is PyPI's own build, whose counterpart
-    is PyPI's default torchcodec -- already the right pairing. That is the opposite reading
-    from _torch_flavor_tag, which maps untagged to "cpu" for the Windows repair path; here an
+    is PyPI's default wheel -- already the right pairing. That is the opposite reading from
+    _torch_flavor_tag, which maps untagged to "cpu" for the Windows repair path; here an
     untagged Linux torch is a CUDA build, so pinning cpu would install the wrong one.
-    rocm and xpu publish no torchcodec under that name, so they stay unpinned rather than
-    being sent to an index that cannot serve them.
     """
     if not torch_version:
         return None
+    local = str(torch_version).partition("+")[2].strip().lower()
+    if not _TORCH_ACCELERATOR_TAG_RE.fullmatch(local):
+        return None
+    # An explicit pin wins, as it does for the torch repair helpers: synthesising the public
+    # URL from the local tag sent authenticated, corporate and air-gapped mirrors to
+    # download.pytorch.org, and the --index-url also makes _install_env_for_cmd drop the
+    # inherited index config, so the install fails outright there. _PYTORCH_WHL_BASE rather
+    # than a literal, since UNSLOTH_PYTORCH_MIRROR redirects every other index this module
+    # builds.
+    return _explicit_torch_index_url() or f"{_PYTORCH_WHL_BASE}/{local}"
+
+
+def _torchcodec_index_url(torch_version: "str | None", spec: str = "") -> "str | None":
+    """The torchcodec index serving the resident torch's build, or None to stay unpinned.
+
+    Upstream's install docs say to pass --index-url and "make sure to install the
+    corresponding PyTorch version as well", so a cu126 or cu128 venv that takes PyPI's
+    default gets a codec built against a different CUDA and libtorchcodec cannot dlopen.
+    docker/Dockerfile already pins cu128 by hand for this reason.
+
+    rocm is the one accelerator excluded: every rocm leaf answers 404/403 for torchcodec,
+    so a pin there is a guaranteed wasted resolve. xpu IS pinnable -- it began publishing
+    torchcodec at 0.13 -- and an xpu host that stays unpinned takes PyPI's CUDA build.
+    Where a pinned index turns out not to serve the selected window (cu129 has no 0.8 or
+    0.9), the caller's unpinned retry recovers; that is deliberate, because no local table
+    of index contents stays true.
+    """
+    local = str(torch_version or "").partition("+")[2].strip().lower()
+    if local.startswith("rocm"):
+        return None
     if spec:
         _, ceiling = _torchcodec_spec_bounds(spec)
-        if ceiling is not None and ceiling <= _TORCHCODEC_MIN_ON_TORCH_INDEX:
-            return None  # window sits entirely below what any torch index publishes
-    local = str(torch_version).partition("+")[2].strip().lower()
-    if local == "cpu" or re.fullmatch(r"cu\d+", local):
-        # An explicit pin wins, as it does for the torch repair helpers: synthesising the
-        # public URL from the local tag sent authenticated, corporate and air-gapped mirrors
-        # to download.pytorch.org, and the --index-url also makes _install_env_for_cmd drop
-        # the inherited index config, so the install fails outright there. _PYTORCH_WHL_BASE
-        # rather than a literal, since UNSLOTH_PYTORCH_MIRROR redirects every other index
-        # this module builds.
-        return _explicit_torch_index_url() or f"{_PYTORCH_WHL_BASE}/{local}"
-    return None
+        floor = max(_TORCHCODEC_MIN_ON_TORCH_INDEX, _TORCHCODEC_INDEX_FLOORS.get(local, (0,)))
+        if ceiling is not None and ceiling <= floor:
+            return None  # window sits entirely below what this index ever published
+    return _torch_accelerator_index_url(torch_version)
 
 
 def _torchcodec_spec_bounds(spec: str) -> "tuple[tuple[int, ...], tuple[int, ...] | None]":
@@ -710,6 +754,32 @@ def _exact_distribution_spec_is_installed(spec: str) -> bool:
         return False
     installed = _installed_distribution_version(match.group(1))
     return installed is not None and installed == match.group(2)
+
+
+def _pin_needs_reinstall(spec: str, torch_version: "str | None" = None) -> bool:
+    """Whether a ``name==version`` pin has to be forced over what is already installed.
+
+    Two reasons, and the second only exists once an index is pinned. The version can be
+    wrong, which _exact_distribution_spec_is_installed already answers. Or the version can
+    be RIGHT while the build is wrong: an accelerator index stamps its tag into the local
+    version (``0.18.0+cu130``) and PyPI forbids one, so a wheel already inside the pin
+    satisfies pip, nothing is fetched, and the wrong-accelerator build this pin exists to
+    replace stays put. Comparing local tags is what catches that. Pass torch_version only
+    when an index is actually being pinned; without one the tag carries no requirement and
+    a matching release must not be reinstalled every run.
+    """
+    match = re.fullmatch(r"([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s]+)", spec)
+    if match is None:
+        return False
+    installed = _installed_distribution_version(match.group(1))
+    if installed is None:
+        return True  # absent; kept True so the flag matches what this step passed before
+    if installed.partition("+")[0] != match.group(2).partition("+")[0]:
+        return True
+    if not torch_version:
+        return False
+    want = str(torch_version).partition("+")[2].strip().lower()
+    return installed.partition("+")[2].strip().lower() != want
 
 
 def _installed_torch_is_windows_rocm() -> bool:
@@ -7631,15 +7701,40 @@ def install_python_stack() -> int:
         _progress("dependency overrides")
         _torch_ver = _probe_installed_torch_version()
         _torchao_spec = _select_torchao_spec(_torch_ver)
-        _note(f"torch {_torch_ver or 'unknown'} detected -- installing {_torchao_spec}")
+        # Pin the index to the resident torch's build, for the reason spelled out beside
+        # _TORCHAO_DEFAULT_SPEC: PyPI's torchao is the CUDA-12 wheel, and the accelerator
+        # indexes carry a build per tag. rocm is included here, unlike torchcodec -- the
+        # rocm leaves really do publish torchao.
+        _torchao_index = _torch_accelerator_index_url(_torch_ver)
         _torchao_args = ["--no-cache-dir"]
-        if not _exact_distribution_spec_is_installed(_torchao_spec):
+        if _pin_needs_reinstall(_torchao_spec, _torch_ver if _torchao_index else None):
             _torchao_args.insert(0, "--force-reinstall")
-        pip_install(
+        _note(
+            f"torch {_torch_ver or 'unknown'} detected -- installing {_torchao_spec}"
+            # Redacted for display only; the installer below still gets the exact URL.
+            + (f" from {_strip_index_url_credentials(_torchao_index)}" if _torchao_index else "")
+        )
+        if not _torchao_index:
+            pip_install("Installing dependency overrides", *_torchao_args, _torchao_spec)
+        elif not pip_install_try(
             "Installing dependency overrides",
             *_torchao_args,
+            "--index-url",
+            _torchao_index,
             _torchao_spec,
-        )
+        ):
+            # The pinned index may simply not carry this release: cu129 stops at 0.17.0
+            # while serving torch up to 2.13, cu118 stops at 0.11.0, rocm7.0 publishes
+            # 0.16.0 alone, and a leaf added upstream after this shipped can lag. Falling
+            # back to the default index restores exactly what this step did before it
+            # pinned anything, which is a working install rather than a failed one. Still
+            # fatal if that fails too: torchao is not optional the way audio is, and this
+            # step was fatal before.
+            _note(
+                f"{_strip_index_url_credentials(_torchao_index)} did not serve "
+                f"{_torchao_spec} -- retrying from the default index"
+            )
+            pip_install("Installing dependency overrides", *_torchao_args, _torchao_spec)
 
     # 5. Triton kernels (no-deps, from source). Skipped on Windows/macOS (no support)
     #    and without git (the requirement is a git+https URL); a training speedup
@@ -7839,11 +7934,26 @@ def install_python_stack() -> int:
         # install inverts the rule the extras-no-deps filter above exists to enforce, and
         # the index can refuse for reasons no local table predicts -- a yanked release, an
         # offline mirror, a platform tag added or dropped upstream after this shipped.
-        if not pip_install_try(
-            "Installing torchcodec",
-            *_codec_args,
-            _codec_spec,
-        ):
+        _codec_ok = pip_install_try("Installing torchcodec", *_codec_args, _codec_spec)
+        if not _codec_ok and _codec_index:
+            # The pinned index may not carry this window at all: cu129 publishes 0.6, 0.7
+            # and 0.10 upward but neither 0.8 nor 0.9, while serving torch 2.8 to 2.13, so
+            # torch 2.9 there selects a range that index has nothing in. A local table of
+            # what each index holds is what goes stale -- cu132 did not exist when this was
+            # written and xpu gained torchcodec after it -- so retry unpinned instead, which
+            # is exactly what such a host got before this step pinned anything. If that
+            # lands a build from another accelerator, _torchcodec_provenance_hint says so at
+            # import rather than leaving it unexplained.
+            _note(
+                f"{_strip_index_url_credentials(_codec_index)} did not serve {_codec_spec} "
+                "-- retrying from the default index"
+            )
+            # _codec_index stays set on purpose: the wheel PyPI serves for a cuNNN host is
+            # still a CUDA build, so it still dlopens NPP and the step below still applies.
+            _codec_ok = pip_install_try(
+                "Installing torchcodec", "--no-deps", "--no-cache-dir", _codec_spec
+            )
+        if not _codec_ok:
             _note(
                 f"could not install {_codec_spec} -- audio decoding stays disabled, "
                 "the rest of the install is unaffected"

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -301,10 +301,14 @@ _TORCH_FLAVOR_REPAIR_PKG_SPEC: tuple[str, str, str] = (
     "torchaudio>=2.4,<2.12.0",
 )
 
-# torchao's cpp extensions are pinned to ONE torch release AND CUDA major. A torch
-# mismatch just skips the cpp kernels (slow Python fallback); a CUDA mismatch fails
-# to import ("libcudart.so.12: cannot open shared object file"). The torch pin is a
-# range, so match torchao to the installed torch (table: pytorch/ao#2919):
+# torchao's cpp extensions are pinned to ONE torch release AND CUDA major, and either
+# mismatch costs the kernels rather than the import. A torch mismatch is refused up front
+# ("Skipping import of cpp extensions due to incompatible torch version"); a CUDA mismatch
+# gets as far as the dlopen and fails there on libcudart, which torchao/__init__.py has
+# caught and logged since 0.12 -- unsloth/import_fixes.py filters that exact warning. So
+# the wrong build is the slow path, never a crash. Verified by forcing torch.ops.load_library
+# to raise that error: `import torchao` and torchao.quantization both still work.
+# The torch pin is a range, so match torchao to the installed torch (table: pytorch/ao#2919):
 #   2.9.x            -> 0.14.0
 #   2.10.x, CUDA<=12 -> 0.16.0 (cpp built for 2.10, loads via the CUDA-12 wheel)
 #   2.10.x, CUDA>=13 -> 0.17.0 (cu130: 0.16.0's CUDA-12 cpp crashes on load; 0.17.0
@@ -4309,20 +4313,6 @@ def _resident_xformers_build_torch() -> "str | None":
     return recorded.strip() if isinstance(recorded, str) and recorded.strip() else None
 
 
-# PyPI's torchao is the CUDA-12 build, so falling back to it is only safe where a CUDA-12
-# extension could load at all. On CUDA 13, ROCm or XPU it cannot, and torchao's cpp loads
-# whenever the torch release matches, so the fallback would trade "no kernels" for
-# "libcudart.so.12: cannot open shared object file" at import. Absence is the supported
-# state there -- _resync_torch_coupled_packages already removes torchao across a CUDA-major
-# move, and Windows ROCm skips this step entirely and stubs torchao at runtime.
-def _default_index_torchao_can_load(torch_version: "str | None") -> bool:
-    local = str(torch_version or "").partition("+")[2].strip().lower()
-    if not local or local == "cpu":
-        return True  # untagged is PyPI's own torch; cpu needs no CUDA runtime at all
-    major = _cuda_major_from_torch_version(str(torch_version or ""))
-    return major is not None and major <= 12
-
-
 def _install_torchao_for_torch(torch_version: "str | None") -> None:
     """Select the torchao matching torch_version and install it from its own index.
 
@@ -4351,21 +4341,15 @@ def _install_torchao_for_torch(torch_version: "str | None") -> None:
         return
     # The pinned index may simply not carry this release: cu129 stops at 0.17.0 while
     # serving torch up to 2.13, cu118 stops at 0.11.0, rocm7.0 publishes 0.16.0 alone, and
-    # a private mirror or a leaf added upstream after this shipped can lag by a release.
-    if not _default_index_torchao_can_load(torch_version):
-        _safe_print(
-            f"   [WARN] {_strip_index_url_credentials(index)} did not serve {spec}, and the "
-            f"default index only builds torchao for CUDA 12, which cannot load beside this "
-            f"torch. Leaving torchao alone; install {spec} from a matching index by hand to "
-            f"restore its kernels."
-        )
-        return
-    # Otherwise the default index is where this step went before it pinned anything, so
-    # falling back is a working install rather than a failed one. Still fatal if that fails
-    # too: torchao is not optional the way audio is, and this step was fatal before.
+    # a private mirror or a leaf added upstream after this shipped can lag by a release. The
+    # default index is where this step went before it pinned anything, so falling back is a
+    # working install rather than a failed one, and PyPI's CUDA-12 build beside another
+    # accelerator costs the cpp kernels and nothing else (see _TORCHAO_DEFAULT_SPEC). Still
+    # fatal if that fails too: torchao is not optional the way audio is, and this step was
+    # fatal before.
     _note(
         f"{_strip_index_url_credentials(index)} did not serve {spec} "
-        "-- retrying from the default index"
+        "-- retrying from the default index; its kernels may be skipped"
     )
     pip_install("Installing dependency overrides", *args, spec)
 
@@ -4386,12 +4370,17 @@ def _resync_torch_coupled_packages(label_before: str) -> bool:
     if not _label_after or _label_after == label_before:
         return True
     _touched_torch = False
-    # Release OR CUDA major: cu124 to cu130 at one release still changes the build.
+    # Release OR accelerator family: cu124 to cu130 at one release still changes the build,
+    # and so does cpu to xpu, which moves no CUDA major at all (both read None) and so was
+    # invisible to a cuda-major-only test. Compare the whole local tag.
     _release_moved = _label_after.split("+", 1)[0] != str(label_before).split("+", 1)[0]
+    _family_moved = _label_after.partition("+")[2].strip().lower() != (
+        str(label_before).partition("+")[2].strip().lower()
+    )
     _cuda_moved = _cuda_major_from_torch_version(_label_after) != (
         _cuda_major_from_torch_version(str(label_before))
     )
-    if _release_moved or _cuda_moved:
+    if _release_moved or _family_moved or _cuda_moved:
         try:
             _spec = _select_torchao_spec(_label_after)
             # The same index pin step 4 uses. Without it this call reinstalls PyPI's CUDA-12

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -515,8 +515,7 @@ _TORCH_ACCELERATOR_TAG_RE = re.compile(r"cpu|cu\d+|xpu|rocm\d+(\.\d+)?")
 
 
 def _torch_accelerator_index_url(
-    torch_version: "str | None",
-    substitutions: "dict[str, str] | None" = None,
+    torch_version: "str | None", substitutions: "dict[str, str] | None" = None
 ) -> "str | None":
     """The download.pytorch.org leaf serving the resident torch's build, or None.
 
@@ -580,8 +579,7 @@ def _torchcodec_index_url(torch_version: "str | None", spec: str = "") -> "str |
 
 
 def _torch_index_tag(
-    torch_version: "str | None",
-    substitutions: "dict[str, str] | None" = None,
+    torch_version: "str | None", substitutions: "dict[str, str] | None" = None
 ) -> "str | None":
     """The local tag of the build the index pin will fetch, or None when unknowable.
 
@@ -8027,8 +8025,7 @@ def install_python_stack() -> int:
             # and the mirror would never be reached.
             _codec_want = _torchcodec_index_tag(_codec_torch_ver)
             if _codec_have and (
-                _codec_want is None
-                or _codec_have.partition("+")[2].strip().lower() != _codec_want
+                _codec_want is None or _codec_have.partition("+")[2].strip().lower() != _codec_want
             ):
                 _codec_args += ("--force-reinstall",)
                 _codec_rebuild = True
@@ -8065,14 +8062,13 @@ def install_python_stack() -> int:
             # without it pip calls the requirement satisfied, fetches nothing, and leaves
             # that same incompatible wheel in place.
             _codec_retry_args = [
-                a for i, a in enumerate(_codec_args)
+                a
+                for i, a in enumerate(_codec_args)
                 if a != "--index-url" and _codec_args[i - 1] != "--index-url"
             ]
             # _codec_index stays set on purpose: the wheel PyPI serves for a cuNNN host is
             # still a CUDA build, so it still dlopens NPP and the step below still applies.
-            _codec_ok = pip_install_try(
-                "Installing torchcodec", *_codec_retry_args, _codec_spec
-            )
+            _codec_ok = pip_install_try("Installing torchcodec", *_codec_retry_args, _codec_spec)
         if not _codec_ok:
             _note(
                 f"could not install {_codec_spec} -- audio decoding stays disabled, "

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -31,8 +31,7 @@ def _tomllib():
 
 @pytest.fixture(autouse = True)
 def _no_inherited_index_config(monkeypatch):
-    """Nearly every test here reads the index configuration, so a developer's own
-    UNSLOTH_TORCH_INDEX_URL must not be what decides which URL the suite asserts."""
+    """A developer's own UNSLOTH_TORCH_INDEX_URL must not decide what the suite asserts."""
     for name in (
         "UNSLOTH_TORCH_INDEX_URL",
         "UNSLOTH_TORCH_INDEX_FAMILY",
@@ -180,11 +179,8 @@ def _load_install_python_stack():
 
 
 def _reload_install_python_stack():
-    """A PRIVATE module instance, for the constants read once at import.
-
-    _PYTORCH_WHL_BASE is computed from UNSLOTH_PYTORCH_MIRROR at import time, so the cached
-    module in sys.modules answers with whatever the environment was on first import. Loading
-    a fresh instance is the only way to exercise a mirror."""
+    """A private instance: _PYTORCH_WHL_BASE is read from the environment at import, so the
+    cached module answers with whatever was set on first import."""
     import importlib.util
 
     spec = importlib.util.spec_from_file_location(
@@ -314,9 +310,8 @@ _UPSTREAM_TORCH_TO_TORCHCODEC_MINORS = {
 
 
 # What each download.pytorch.org index actually publishes, read off the live listings:
-# the torch 2.x minors it serves, and the torchcodec minors it carries. Explicit minors
-# rather than a range, because the inventory is not contiguous: cu129 skips 0.8, 0.9 and
-# 0.12-0.14 entirely. No index carries 0.1 or 0.2 -- those are PyPI-only.
+# the torch 2.x minors it serves and the torchcodec minors it carries. Explicit minors, not
+# ranges: the inventory is not contiguous (cu129 skips 0.8, 0.9 and 0.12-0.14).
 _INDEX_INVENTORY = {
     "cpu": {"torch": range(5, 15), "codec": {3, 4, *range(6, 17)}},
     "cu118": {"torch": range(5, 8), "codec": {3, 4}},
@@ -340,9 +335,7 @@ def test_torchcodec_index_follows_the_resident_torch_build():
     assert ips._torchcodec_index_url("2.14.0+cu130") == base + "cu130"
     assert ips._torchcodec_index_url("2.11.0+cpu") == base + "cpu"
 
-    # An Intel-GPU torch is sent to cpu: torchcodec publishes no xpu build, the xpu leaf
-    # only mirrors the CPU wheels for Linux x86_64, and PyPI's default is the CUDA build,
-    # so leaving xpu unpinned hands it a codec that tries to dlopen CUDA.
+    # xpu is sent to cpu: no xpu codec build exists, and PyPI's default is the CUDA one.
     assert ips._torchcodec_index_url("2.14.0+xpu") == base + "cpu"
     assert ips._torchcodec_index_url("2.9.0+xpu") == base + "cpu"
 
@@ -392,8 +385,7 @@ def test_pinning_the_index_starves_only_where_the_retry_covers_it():
     really there.
     """
     starved = {(tag, minor) for tag, minor, _ in _starved_index_cells()}
-    # One cell, and it is the one no floor could have predicted: cu129 publishes 0.6, 0.7,
-    # 0.10, 0.11, 0.15 and 0.16, so its gap is in the MIDDLE of its range.
+    # The one cell no floor could predict: cu129's gap is in the MIDDLE of its range.
     assert starved == {("cu129", 9)}, sorted(starved)
 
 
@@ -402,11 +394,8 @@ def test_the_installer_retries_without_the_index_when_the_pin_finds_nothing():
     source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
     step = source.split("# 13b. torchcodec", 1)[1].split("# 14.", 1)[0]
     assert "retrying from the default index" in step
-    # The retry must drop the pin and NOTHING else. --no-deps still matters, since a
-    # torchcodec that re-resolves torch would undo the repair two steps above, and
-    # --force-reinstall still matters: it is set when the installed codec is inside the
-    # window but built by another index, and without it pip calls the requirement satisfied
-    # and leaves that same incompatible wheel in place.
+    # The retry drops the pin and NOTHING else: --no-deps stops a re-resolve undoing the
+    # repair two steps above, and --force-reinstall stops pip calling the pin satisfied.
     retry = step.split("retrying from the default index", 1)[1]
     assert "_codec_retry_args = [" in retry
     assert 'a != "--index-url" and _codec_args[i - 1] != "--index-url"' in retry
@@ -457,9 +446,8 @@ def test_an_explicit_family_override_still_gets_the_substituted_leaf(monkeypatch
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "cu126")
     assert ips._torchcodec_index_url("2.11.0+cu128", "torchcodec>=0.11.0,<0.12.0") == base + "cu126"
 
-    # An explicit URL is opaque: taken as-is, and its provenance is UNKNOWN rather than
-    # absent. Reporting it as absent made an untagged wheel compare equal, which satisfies
-    # the range, so pip fetched nothing and the mirror was never contacted.
+    # An explicit URL is opaque, so provenance is UNKNOWN, not absent: reporting absent let
+    # an untagged wheel compare equal and the mirror was never contacted.
     monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY")
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.corp.example/whl/xpu/")
     assert ips._torchcodec_index_url("2.14.0+xpu", "torchcodec>=0.12.0") == (
@@ -991,10 +979,8 @@ def test_the_codec_index_honours_an_explicitly_pinned_torch_mirror(monkeypatch):
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "cu126")
     assert ips._torchcodec_index_url("2.11.0+cu128") == "https://download.pytorch.org/whl/cu126"
 
-    # An explicit family DOES make an untagged torch pin, and deliberately so: a private
-    # mirror that rebuilds torch ships it bare, and naming the family is how such a host
-    # says which leaf to use. rocm still never pins a codec, because no rocm index
-    # publishes one under any name.
+    # An explicit family DOES make an untagged torch pin: a private mirror ships torch bare,
+    # and naming the family is how it says which leaf. rocm still never pins a codec.
     assert ips._torchcodec_index_url("2.11.0") == "https://download.pytorch.org/whl/cu126"
     assert ips._torchcodec_index_url("2.11.0+rocm7.0") is None
 
@@ -1295,11 +1281,8 @@ def test_the_provenance_hint_reads_a_codec_it_cannot_import(monkeypatch):
 
 
 def test_an_explicit_index_wins_even_when_torch_carries_no_tag(monkeypatch):
-    """Only download.pytorch.org stamps +cuNNN, so a corporate or air-gapped mirror that
-    rebuilds torch ships it BARE. Requiring a recognised local tag before reading
-    UNSLOTH_TORCH_INDEX_URL sent exactly that host to PyPI for both companions, which on an
-    air-gapped box fails the fatal torchao step outright. _ensure_expected_torch_flavor
-    already supports the untagged private GPU build through its runtime markers."""
+    """Only download.pytorch.org stamps +cuNNN, so a private mirror ships torch bare, and
+    requiring a tag first sent that host to PyPI for both companions."""
     mod = _load_install_python_stack()
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.corp/simple?token=abc")
     for version in ("2.14.0", "2.13.0+cu130", "2.11.0+rocm7.2", "2.10.0+weird"):
@@ -1316,8 +1299,7 @@ def test_an_explicit_index_wins_even_when_torch_carries_no_tag(monkeypatch):
 
 
 def test_an_untagged_torch_without_an_explicit_index_stays_unpinned(monkeypatch):
-    """The other half of the rule above: with no override, an untagged torch is PyPI's own
-    build and PyPI's default companion is already the right pairing."""
+    """With no override an untagged torch is PyPI's own build, already the right pairing."""
     mod = _load_install_python_stack()
     assert mod._torch_accelerator_index_url("2.14.0") is None
     assert mod._torchcodec_index_url("2.14.0") is None
@@ -1325,10 +1307,8 @@ def test_an_untagged_torch_without_an_explicit_index_stays_unpinned(monkeypatch)
 
 
 def test_the_installed_codec_reports_the_cuda_major_it_actually_links(monkeypatch, tmp_path):
-    """The unpinned fallback takes whatever CUDA major PyTorch currently defaults to, which
-    need not be the resident torch's tag: torchcodec 0.16.0 links libcudart.so.13 on PyPI and
-    libcudart.so.12 on the cu126 leaf, both verified by installing them into a venv. So the
-    NPP choice reads the wheel rather than the tag, and this pins the reading."""
+    """torchcodec 0.16.0 links libcudart.so.13 on PyPI and .12 on the cu126 leaf, so the NPP
+    choice reads the wheel rather than the torch tag."""
     mod = _load_install_python_stack()
 
     class _Dist:
@@ -1373,10 +1353,8 @@ def test_the_installed_codec_reports_the_cuda_major_it_actually_links(monkeypatc
 
 
 def test_the_remedy_spells_the_variable_for_the_shell_it_will_be_pasted_into(monkeypatch):
-    """PowerShell is Studio's supported Windows shell and does not expand $NAME, so the
-    POSIX spelling silently produced an empty --index-url there. The tests above compare
-    against _shell_env_ref for that reason; this one pins the rule itself, so asking the
-    helper cannot degrade into asserting whatever the helper happens to return."""
+    """PowerShell does not expand $NAME, so the POSIX spelling produced an empty --index-url.
+    The tests above ask _shell_env_ref; this pins the rule so that cannot become circular."""
     fixes = _load_import_fixes_module()
     monkeypatch.setattr(fixes.sys, "platform", "win32")
     assert fixes._shell_env_ref("UNSLOTH_TORCH_INDEX_URL") == "$env:UNSLOTH_TORCH_INDEX_URL"
@@ -1386,15 +1364,9 @@ def test_the_remedy_spells_the_variable_for_the_shell_it_will_be_pasted_into(mon
 
 
 def test_a_query_authenticated_mirror_is_not_pinned_at_all(monkeypatch):
-    """No URL shape pins a query-auth index: pip joins the project name as text, so both
-    "base?token=x/cu130" and "base/cu130/?token=x" ask the wrong thing.
-    _warn_query_index_unusable says so directly, and says the join cannot repair it.
-
-    Constructing one anyway is worse than declining, which is the whole point. Passing
-    --index-url makes _install_env_for_cmd strip the user's own index configuration
-    (UV_NO_CONFIG=1, PIP_CONFIG_FILE=os.devnull), and for this mirror that configuration is
-    the only channel that can work, since the credential has to come from pip.conf or
-    ~/.netrc. So a broken pin trades a working install for a guaranteed failure."""
+    """No URL shape pins a query-auth index, and building a broken one is worse than
+    declining: --index-url makes _install_env_for_cmd strip pip.conf and ~/.netrc, the only
+    channel that can carry that credential."""
     for base in ("https://mirror.example/whl?token=abc", "https://mirror.example/whl#tok"):
         monkeypatch.setenv("UNSLOTH_PYTORCH_MIRROR", base)
         mod = _reload_install_python_stack()
@@ -1415,12 +1387,9 @@ def test_a_query_authenticated_mirror_is_not_pinned_at_all(monkeypatch):
 
 
 def test_an_explicit_family_is_honoured_when_torch_carries_no_tag(monkeypatch):
-    """UNSLOTH_TORCH_INDEX_FAMILY is as explicit an instruction as the full URL, and the
-    host that needs it is exactly the one whose torch has no local tag -- a private mirror
-    rebuilding torch bare. _explicit_unknown_family_torch_index_url already treats a custom
-    leaf such as /current as authoritative and leaves that torch alone, so returning None
-    here is never corrected later; step 4 just installs torchao from the default index,
-    which on an air-gapped host is no index at all."""
+    """As explicit as the full URL, and needed by the same host: a mirror that rebuilds torch
+    bare. _explicit_unknown_family_torch_index_url treats a custom leaf as authoritative, so a
+    None here is never corrected later."""
     monkeypatch.setenv("UNSLOTH_PYTORCH_MIRROR", "https://mirror.example/whl")
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "current")
     mod = _reload_install_python_stack()

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -309,7 +309,7 @@ _INDEX_INVENTORY = {
     "cu129": {"torch": range(8, 14), "codec": {6, 7, 10, 11, 15, 16}},
     "cu130": {"torch": range(9, 15), "codec": set(range(8, 17))},
     "cu132": {"torch": range(12, 15), "codec": set(range(12, 17))},
-    "xpu": {"torch": range(6, 15), "codec": {13, 14, 15, 16}},
+    # xpu is not listed: an xpu torch is pinned to the cpu leaf, which is covered above.
 }
 
 
@@ -324,9 +324,11 @@ def test_torchcodec_index_follows_the_resident_torch_build():
     assert ips._torchcodec_index_url("2.14.0+cu130") == base + "cu130"
     assert ips._torchcodec_index_url("2.11.0+cpu") == base + "cpu"
 
-    # xpu began publishing torchcodec at 0.13, so it pins like any other accelerator. An
-    # xpu host left unpinned takes PyPI's CUDA build, which is the failure this prevents.
-    assert ips._torchcodec_index_url("2.14.0+xpu") == base + "xpu"
+    # An Intel-GPU torch is sent to cpu: torchcodec publishes no xpu build, the xpu leaf
+    # only mirrors the CPU wheels for Linux x86_64, and PyPI's default is the CUDA build,
+    # so leaving xpu unpinned hands it a codec that tries to dlopen CUDA.
+    assert ips._torchcodec_index_url("2.14.0+xpu") == base + "cpu"
+    assert ips._torchcodec_index_url("2.9.0+xpu") == base + "cpu"
 
     # Untagged is PyPI's own torch, whose counterpart is PyPI's default torchcodec. Pinning
     # cpu here would be wrong: on Linux an untagged torch is a CUDA build.
@@ -375,8 +377,7 @@ def test_pinning_the_index_starves_only_where_the_retry_covers_it():
     """
     starved = {(tag, minor) for tag, minor, _ in _starved_index_cells()}
     # One cell, and it is the one no floor could have predicted: cu129 publishes 0.6, 0.7,
-    # 0.10, 0.11, 0.15 and 0.16, so its gap is in the MIDDLE. The xpu rows below 0.13, which
-    # would otherwise be five more, are declined up front by _TORCHCODEC_INDEX_FLOORS.
+    # 0.10, 0.11, 0.15 and 0.16, so its gap is in the MIDDLE of its range.
     assert starved == {("cu129", 9)}, sorted(starved)
 
 
@@ -392,26 +393,42 @@ def test_the_installer_retries_without_the_index_when_the_pin_finds_nothing():
     assert "--index-url" not in retry
 
 
-def test_an_index_that_joined_late_is_not_pinned_below_its_first_release():
-    """xpu serves torch from 2.6 but published no torchcodec before 0.13, so pinning it for
-    the older lines is a resolve that cannot succeed. A floor, unlike a list of what an index
-    holds, only says "nothing below X was ever published here", which upstream does not walk
-    back, so it stays true as releases are added."""
+def test_an_accelerator_with_no_codec_build_of_its_own_takes_the_cpu_one():
+    """torchcodec has no XPU build at all. The xpu leaf republishes the CPU wheels verbatim
+    (`torchcodec-0.16.0+cpu-...`) and only for Linux x86_64, whereas the cpu leaf carries the
+    same wheel for aarch64 and Windows too and goes back to 0.3 rather than starting at 0.13.
+    So every Intel-GPU torch is served, not just the newest."""
     ips = _load_install_python_stack()
-    assert ips._TORCHCODEC_INDEX_FLOORS["xpu"] == (0, 13, 0)
-    for minor in (7, 8, 9, 10, 11):
+    assert ips._TORCHCODEC_INDEX_TAGS == {"xpu": "cpu"}
+    for minor in (7, 8, 9, 10, 11, 12, 13, 14):
         version = f"2.{minor}.0+xpu"
         spec = ips._select_torchcodec_spec(version)
-        assert ips._torchcodec_index_url(version, spec) is None, spec
-    # 2.12+ takes the open ABI-stable window, which reaches 0.13, so it pins.
-    for minor in (12, 13, 14):
-        version = f"2.{minor}.0+xpu"
-        spec = ips._select_torchcodec_spec(version)
-        assert ips._torchcodec_index_url(version, spec) == "https://download.pytorch.org/whl/xpu"
-    # The floor is per leaf, not global: cu126 still pins the same old lines it always did.
+        assert ips._torchcodec_index_url(version, spec) == (
+            "https://download.pytorch.org/whl/cpu"
+        ), spec
+    # The substitution is per tag, not a blanket fallback: cu126 still pins its own leaf.
     assert ips._torchcodec_index_url("2.9.0+cu126", ips._select_torchcodec_spec("2.9.0")) == (
         "https://download.pytorch.org/whl/cu126"
     )
+    # torchao is unaffected: its xpu leaf really does carry +xpu builds.
+    assert ips._torch_accelerator_index_url("2.14.0+xpu") == "https://download.pytorch.org/whl/xpu"
+
+
+def test_the_provenance_check_compares_against_the_tag_the_pin_will_fetch():
+    """The step force-reinstalls when the installed codec's local tag says another index
+    built it. That tag has to be the one the PIN fetches, not the resident torch's own: an
+    xpu torch is served a `+cpu` wheel, so comparing against `xpu` never matches and every
+    run would force-reinstall a codec that was already right."""
+    ips = _load_install_python_stack()
+    assert ips._torchcodec_index_tag("2.14.0+xpu") == "cpu"
+    assert ips._torchcodec_index_tag("2.14.0+cu130") == "cu130"
+    assert ips._torchcodec_index_tag("2.14.0") == ""
+
+    source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
+    step = source.split("# 13b. torchcodec", 1)[1].split("# 14.", 1)[0]
+    assert "_codec_want = _torchcodec_index_tag(_codec_torch_ver)" in step
+    # The old spelling read the torch tag straight off the version string.
+    assert '_codec_want = str(_codec_torch_ver).partition("+")' not in step
 
 
 def test_the_two_pypi_only_rows_stay_unpinned():

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -386,11 +386,15 @@ def test_the_installer_retries_without_the_index_when_the_pin_finds_nothing():
     source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
     step = source.split("# 13b. torchcodec", 1)[1].split("# 14.", 1)[0]
     assert "retrying from the default index" in step
-    # The retry must drop the pin and nothing else: --no-deps still matters, since a
-    # torchcodec that re-resolves torch would undo the repair two steps above.
+    # The retry must drop the pin and NOTHING else. --no-deps still matters, since a
+    # torchcodec that re-resolves torch would undo the repair two steps above, and
+    # --force-reinstall still matters: it is set when the installed codec is inside the
+    # window but built by another index, and without it pip calls the requirement satisfied
+    # and leaves that same incompatible wheel in place.
     retry = step.split("retrying from the default index", 1)[1]
-    assert '"--no-deps", "--no-cache-dir", _codec_spec' in retry
-    assert "--index-url" not in retry
+    assert "_codec_retry_args = [" in retry
+    assert 'a != "--index-url" and _codec_args[i - 1] != "--index-url"' in retry
+    assert "*_codec_retry_args, _codec_spec" in retry
 
 
 def test_an_accelerator_with_no_codec_build_of_its_own_takes_the_cpu_one():
@@ -412,6 +416,61 @@ def test_an_accelerator_with_no_codec_build_of_its_own_takes_the_cpu_one():
     )
     # torchao is unaffected: its xpu leaf really does carry +xpu builds.
     assert ips._torch_accelerator_index_url("2.14.0+xpu") == "https://download.pytorch.org/whl/xpu"
+
+
+def test_an_explicit_family_override_still_gets_the_substituted_leaf(monkeypatch):
+    """UNSLOTH_TORCH_INDEX_FAMILY names a leaf under our own base, so the xpu-to-cpu
+    substitution has to apply to it as well. Without that, setting the family to xpu sent
+    the codec to the xpu leaf, which publishes nothing below 0.13, and the retry then
+    installed PyPI's CUDA build -- exactly the case the substitution exists to avoid.
+
+    A full UNSLOTH_TORCH_INDEX_URL is different and is taken verbatim: its path belongs to
+    whoever configured the mirror, and rewriting a leaf inside it would be a guess."""
+    ips = _load_install_python_stack()
+    base = "https://download.pytorch.org/whl/"
+
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "xpu")
+    for version in ("2.9.0+xpu", "2.14.0+xpu"):
+        spec = ips._select_torchcodec_spec(version)
+        assert ips._torchcodec_index_url(version, spec) == base + "cpu", version
+        assert ips._torchcodec_index_tag(version) == "cpu"
+    # torchao has no substitution, so its own leaf is unchanged by the same override.
+    assert ips._torch_accelerator_index_url("2.14.0+xpu") == base + "xpu"
+
+    # A family with no substitution passes straight through.
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "cu126")
+    assert ips._torchcodec_index_url("2.11.0+cu128", "torchcodec>=0.11.0,<0.12.0") == base + "cu126"
+
+    # An explicit URL is opaque: taken as-is, and it claims no provenance tag.
+    monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY")
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.corp.example/whl/xpu/")
+    assert ips._torchcodec_index_url("2.14.0+xpu", "torchcodec>=0.12.0") == (
+        "https://mirror.corp.example/whl/xpu"
+    )
+    assert ips._torchcodec_index_tag("2.14.0+xpu") == ""
+
+
+def test_no_cuda_13_index_relies_on_the_unpinned_torchao_fallback():
+    """The fallback installs PyPI's torchao, which is the CUDA-12 build. That is harmless
+    wherever its cpp is skipped or the host is CUDA 12, and every starved cell today is one
+    of those. It would NOT be harmless on a CUDA-13 leaf whose torch matches the selected
+    release, so this fails if such a cell ever appears."""
+    ips = _load_install_python_stack()
+    # torchao releases each CUDA-13 leaf carries, and the torch minors it serves, read off
+    # the live listings. A leaf is only reachable for the torch it actually publishes.
+    published = {
+        "cu130": ({"0.14.0", "0.14.1", "0.15.0", "0.16.0", "0.17.0", "0.18.0"}, range(9, 15)),
+        "cu132": ({"0.18.0"}, range(12, 15)),
+    }
+    for leaf, (releases, torch_minors) in published.items():
+        for minor in torch_minors:
+            version = f"2.{minor}.0+{leaf}"
+            assert ips._cuda_major_from_torch_version(version) >= 13, version
+            wanted = ips._select_torchao_spec(version).split("==", 1)[1]
+            assert wanted in releases, (
+                f"{version} selects torchao {wanted}, which {leaf} does not publish, so the "
+                f"fallback would put PyPI's CUDA-12 wheel on a CUDA-13 host"
+            )
 
 
 def test_the_provenance_check_compares_against_the_tag_the_pin_will_fetch():

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1000,7 +1000,7 @@ def test_the_runtime_remedy_honours_a_configured_torch_index(monkeypatch):
         "UNSLOTH_TORCH_INDEX_URL", "https://user:secret@mirror.corp.example/pytorch/cu128/"
     )
     hint = fixes._torchcodec_version_mismatch_hint()
-    assert '--index-url "$UNSLOTH_TORCH_INDEX_URL" ' in hint
+    assert f'--index-url {fixes._shell_env_ref("UNSLOTH_TORCH_INDEX_URL")} ' in hint
     assert "secret" not in hint
     assert "mirror.corp.example" not in hint
     assert "download.pytorch.org" not in hint
@@ -1099,13 +1099,13 @@ def test_the_runtime_remedy_follows_a_configured_pytorch_mirror(monkeypatch):
 
     monkeypatch.setenv("UNSLOTH_PYTORCH_MIRROR", "https://user:secret@mirror.corp.example/whl")
     hint = fixes._torchcodec_version_mismatch_hint()
-    assert '--index-url "$UNSLOTH_PYTORCH_MIRROR"/cu128' in hint
+    assert f'--index-url {fixes._shell_env_ref("UNSLOTH_PYTORCH_MIRROR")}/cu128' in hint
     assert "secret" not in hint
     assert "download.pytorch.org" not in hint
 
     # The family names the leaf under the same mirror.
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "cu126")
-    assert '--index-url "$UNSLOTH_PYTORCH_MIRROR"/cu126' in (
+    assert f'--index-url {fixes._shell_env_ref("UNSLOTH_PYTORCH_MIRROR")}/cu126' in (
         fixes._torchcodec_version_mismatch_hint() or ""
     )
 
@@ -1148,7 +1148,7 @@ def test_the_remedy_uses_the_shell_of_the_host_it_prints_on(monkeypatch):
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://user:secret@mirror.corp.example/cu128")
 
     monkeypatch.setattr(fixes.sys, "platform", "linux")
-    assert '--index-url "$UNSLOTH_TORCH_INDEX_URL"' in (
+    assert f'--index-url {fixes._shell_env_ref("UNSLOTH_TORCH_INDEX_URL")}' in (
         fixes._torchcodec_version_mismatch_hint() or ""
     )
 
@@ -1273,3 +1273,82 @@ def test_the_provenance_hint_reads_a_codec_it_cannot_import(monkeypatch):
 
     monkeypatch.setattr(importlib.metadata, "version", _absent)
     assert fixes._torchcodec_provenance_hint() is None
+
+
+def test_an_explicit_index_wins_even_when_torch_carries_no_tag(monkeypatch):
+    """Only download.pytorch.org stamps +cuNNN, so a corporate or air-gapped mirror that
+    rebuilds torch ships it BARE. Requiring a recognised local tag before reading
+    UNSLOTH_TORCH_INDEX_URL sent exactly that host to PyPI for both companions, which on an
+    air-gapped box fails the fatal torchao step outright. _ensure_expected_torch_flavor
+    already supports the untagged private GPU build through its runtime markers."""
+    mod = _load_install_python_stack()
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.corp/simple?token=abc")
+    for version in ("2.14.0", "2.13.0+cu130", "2.11.0+rocm7.2", "2.10.0+weird"):
+        assert mod._torch_accelerator_index_url(version) == "https://mirror.corp/simple?token=abc"
+    # torchcodec keeps its own two refusals, which are about the WHEEL not existing rather
+    # than about where to look: rocm publishes no torchcodec under any index.
+    assert mod._torchcodec_index_url("2.11.0+rocm7.2") is None
+    assert mod._torchcodec_index_url("2.14.0") == "https://mirror.corp/simple?token=abc"
+    # No torch at all still means no companion pin.
+    assert mod._torch_accelerator_index_url(None) is None
+    assert mod._torch_accelerator_index_url("") is None
+    # And provenance stays unknowable through an opaque mirror, so the wheel is replaced.
+    assert mod._torch_index_tag("2.14.0") is None
+
+
+def test_an_untagged_torch_without_an_explicit_index_stays_unpinned(monkeypatch):
+    """The other half of the rule above: with no override, an untagged torch is PyPI's own
+    build and PyPI's default companion is already the right pairing."""
+    mod = _load_install_python_stack()
+    assert mod._torch_accelerator_index_url("2.14.0") is None
+    assert mod._torchcodec_index_url("2.14.0") is None
+    assert mod._torch_index_tag("2.14.0") == ""
+
+
+def test_the_installed_codec_reports_the_cuda_major_it_actually_links(monkeypatch, tmp_path):
+    """The unpinned fallback takes whatever CUDA major PyTorch currently defaults to, which
+    need not be the resident torch's tag: torchcodec 0.16.0 links libcudart.so.13 on PyPI and
+    libcudart.so.12 on the cu126 leaf, both verified by installing them into a venv. So the
+    NPP choice reads the wheel rather than the tag, and this pins the reading."""
+    mod = _load_install_python_stack()
+
+    class _Dist:
+        def __init__(self, files):
+            self.files = files
+
+    def _probe(blobs):
+        files = []
+        for name, payload in blobs.items():
+            target = tmp_path / name
+            target.write_bytes(payload)
+
+            class _Entry(str):
+                def locate(self, _t = target):
+                    return str(_t)
+
+            files.append(_Entry(f"torchcodec/{name}"))
+        monkeypatch.setattr(mod, "_torchcodec_distribution_for_probe", lambda: _Dist(files))
+        return mod._installed_torchcodec_cuda_major()
+
+    assert _probe({"libtorchcodec_cuda.so": b"\x00pad\x00libcudart.so.13\x00more"}) == "13"
+    assert _probe({"libtorchcodec_cuda.so": b"\x00libcudart.so.12\x00"}) == "12"
+    # A cpu build links no CUDA runtime at all: "" means "needs no NPP", not "unknown".
+    assert _probe({"libtorchcodec_core.so": b"nothing interesting here"}) == ""
+    # Non-.so payloads are never read, so a stray text file cannot fake a major.
+    assert _probe({"version.txt": b"libcudart.so.12"}) == ""
+    # Absent entirely: None, which the caller reads as "keep the tag-derived answer".
+    monkeypatch.setattr(mod, "_torchcodec_distribution_for_probe", lambda: None)
+    assert mod._installed_torchcodec_cuda_major() is None
+
+
+def test_the_remedy_spells_the_variable_for_the_shell_it_will_be_pasted_into(monkeypatch):
+    """PowerShell is Studio's supported Windows shell and does not expand $NAME, so the
+    POSIX spelling silently produced an empty --index-url there. The tests above compare
+    against _shell_env_ref for that reason; this one pins the rule itself, so asking the
+    helper cannot degrade into asserting whatever the helper happens to return."""
+    fixes = _load_import_fixes_module()
+    monkeypatch.setattr(fixes.sys, "platform", "win32")
+    assert fixes._shell_env_ref("UNSLOTH_TORCH_INDEX_URL") == "$env:UNSLOTH_TORCH_INDEX_URL"
+    for platform in ("linux", "darwin"):
+        monkeypatch.setattr(fixes.sys, "platform", platform)
+        assert fixes._shell_env_ref("UNSLOTH_TORCH_INDEX_URL") == '"$UNSLOTH_TORCH_INDEX_URL"'

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -441,13 +441,15 @@ def test_an_explicit_family_override_still_gets_the_substituted_leaf(monkeypatch
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "cu126")
     assert ips._torchcodec_index_url("2.11.0+cu128", "torchcodec>=0.11.0,<0.12.0") == base + "cu126"
 
-    # An explicit URL is opaque: taken as-is, and it claims no provenance tag.
+    # An explicit URL is opaque: taken as-is, and its provenance is UNKNOWN rather than
+    # absent. Reporting it as absent made an untagged wheel compare equal, which satisfies
+    # the range, so pip fetched nothing and the mirror was never contacted.
     monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY")
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.corp.example/whl/xpu/")
     assert ips._torchcodec_index_url("2.14.0+xpu", "torchcodec>=0.12.0") == (
         "https://mirror.corp.example/whl/xpu"
     )
-    assert ips._torchcodec_index_tag("2.14.0+xpu") == ""
+    assert ips._torchcodec_index_tag("2.14.0+xpu") is None
 
 
 def test_no_cuda_13_index_relies_on_the_unpinned_torchao_fallback():
@@ -488,6 +490,24 @@ def test_the_provenance_check_compares_against_the_tag_the_pin_will_fetch():
     assert "_codec_want = _torchcodec_index_tag(_codec_torch_ver)" in step
     # The old spelling read the torch tag straight off the version string.
     assert '_codec_want = str(_codec_torch_ver).partition("+")' not in step
+    # An unknown tag has to force, not compare equal to an untagged wheel.
+    assert "_codec_want is None" in step
+
+
+def test_an_opaque_mirror_replaces_a_codec_it_cannot_vouch_for(monkeypatch):
+    """UNSLOTH_TORCH_INDEX_URL can be an accelerator-specific private mirror, and nothing
+    here can tell which build it serves. Reporting that as "no tag required" let an
+    installed untagged wheel -- PyPI's CUDA build -- compare equal and satisfy the version
+    range, so pip fetched nothing and the mirror was never reached."""
+    ips = _load_install_python_stack()
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.corp.example/whl/cu130")
+    want = ips._torchcodec_index_tag("2.14.0+cu130")
+    assert want is None
+    for have in ("0.16.0", "0.16.0+cu126", "0.16.0+cu130"):
+        forced = bool(have) and (
+            want is None or have.partition("+")[2].strip().lower() != want
+        )
+        assert forced, have
 
 
 def test_the_two_pypi_only_rows_stay_unpinned():

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1332,10 +1332,22 @@ def test_the_installed_codec_reports_the_cuda_major_it_actually_links(monkeypatc
 
     assert _probe({"libtorchcodec_cuda.so": b"\x00pad\x00libcudart.so.13\x00more"}) == "13"
     assert _probe({"libtorchcodec_cuda.so": b"\x00libcudart.so.12\x00"}) == "12"
+    # Windows spells both the file and the major differently. Its natives are .dll/.pyd, so
+    # an .so-only filter inspected nothing, found no major, and returned "" -- which SKIPS
+    # the NPP install and leaves audio broken on a host with no system toolkit.
+    assert _probe({"libtorchcodec_core7.dll": b"\x00cudart64_12.dll\x00"}) == "12"
+    assert _probe({"libtorchcodec_pybind_ops.pyd": b"cudart64_13.dll"}) == "13"
+    # The win_amd64 cu130 wheel names no major at all: it references nvcudart_hybrid64.dll.
+    # CUDA is plainly there, so "" would be a lie; None keeps the tag-derived answer.
+    assert _probe({"libtorchcodec_core7.dll": b"\x00nvcudart_hybrid64.dll\x00nvcuda.dll"}) is None
     # A cpu build links no CUDA runtime at all: "" means "needs no NPP", not "unknown".
+    # Checked against the real 0.16.0 cpu wheels, x86_64 and win_amd64: neither carries any
+    # CUDA reference.
     assert _probe({"libtorchcodec_core.so": b"nothing interesting here"}) == ""
-    # Non-.so payloads are never read, so a stray text file cannot fake a major.
-    assert _probe({"version.txt": b"libcudart.so.12"}) == ""
+    assert _probe({"libtorchcodec_core7.dll": b"nothing interesting here"}) == ""
+    # Nothing native to read is "cannot tell", not "no CUDA": a stray text file mentioning a
+    # major must neither be believed nor counted as an inspection.
+    assert _probe({"version.txt": b"libcudart.so.12"}) is None
     # Absent entirely: None, which the caller reads as "keep the tag-derived answer".
     monkeypatch.setattr(mod, "_torchcodec_distribution_for_probe", lambda: None)
     assert mod._installed_torchcodec_cuda_major() is None

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -991,8 +991,11 @@ def test_the_codec_index_honours_an_explicitly_pinned_torch_mirror(monkeypatch):
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "cu126")
     assert ips._torchcodec_index_url("2.11.0+cu128") == "https://download.pytorch.org/whl/cu126"
 
-    # The override does not make an untagged or rocm torch start pinning.
-    assert ips._torchcodec_index_url("2.11.0") is None
+    # An explicit family DOES make an untagged torch pin, and deliberately so: a private
+    # mirror that rebuilds torch ships it bare, and naming the family is how such a host
+    # says which leaf to use. rocm still never pins a codec, because no rocm index
+    # publishes one under any name.
+    assert ips._torchcodec_index_url("2.11.0") == "https://download.pytorch.org/whl/cu126"
     assert ips._torchcodec_index_url("2.11.0+rocm7.0") is None
 
 
@@ -1382,27 +1385,54 @@ def test_the_remedy_spells_the_variable_for_the_shell_it_will_be_pasted_into(mon
         assert fixes._shell_env_ref("UNSLOTH_TORCH_INDEX_URL") == '"$UNSLOTH_TORCH_INDEX_URL"'
 
 
-def test_a_mirror_carrying_a_token_gets_the_leaf_in_its_path(monkeypatch):
-    """UNSLOTH_PYTORCH_MIRROR may authenticate through a query token. Concatenating the leaf
-    put it INSIDE the token -- "https://m/whl?token=abc/cu130" -- so the index resolved
-    nothing. For torchcodec that silently costs audio; for torchao, whose step is fatal, the
-    unpinned retry also drops the mirror, so a mirror-only host cannot install it at all.
+def test_a_query_authenticated_mirror_is_not_pinned_at_all(monkeypatch):
+    """No URL shape pins a query-auth index: pip joins the project name as text, so both
+    "base?token=x/cu130" and "base/cu130/?token=x" ask the wrong thing.
+    _warn_query_index_unusable says so directly, and says the join cannot repair it.
 
-    _index_url_join already existed for the ROCm mirrors and its docstring names this exact
-    failure, so this is about using it rather than about new logic."""
-    monkeypatch.setenv("UNSLOTH_PYTORCH_MIRROR", "https://mirror.example/whl?token=abc")
+    Constructing one anyway is worse than declining, which is the whole point. Passing
+    --index-url makes _install_env_for_cmd strip the user's own index configuration
+    (UV_NO_CONFIG=1, PIP_CONFIG_FILE=os.devnull), and for this mirror that configuration is
+    the only channel that can work, since the credential has to come from pip.conf or
+    ~/.netrc. So a broken pin trades a working install for a guaranteed failure."""
+    for base in ("https://mirror.example/whl?token=abc", "https://mirror.example/whl#tok"):
+        monkeypatch.setenv("UNSLOTH_PYTORCH_MIRROR", base)
+        mod = _reload_install_python_stack()
+        assert mod._torch_accelerator_index_url("2.13.0+cu130") is None, base
+        assert mod._torchcodec_index_url("2.13.0+cu130") is None, base
+        # The FAMILY override reaches the same base, so it declines the same way.
+        monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "cu126")
+        assert mod._torch_accelerator_index_url("2.13.0") is None, base
+        monkeypatch.delenv("UNSLOTH_TORCH_INDEX_FAMILY")
+    # An explicit full UNSLOTH_TORCH_INDEX_URL is still taken verbatim: that is the user
+    # naming one exact index rather than a base this code appends a leaf to.
+    monkeypatch.delenv("UNSLOTH_PYTORCH_MIRROR")
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_URL", "https://mirror.example/simple?token=abc")
     mod = _reload_install_python_stack()
     assert mod._torch_accelerator_index_url("2.13.0+cu130") == (
-        "https://mirror.example/whl/cu130/?token=abc"
+        "https://mirror.example/simple?token=abc"
     )
-    assert mod._torchcodec_index_url("2.13.0+cu130") == (
-        "https://mirror.example/whl/cu130/?token=abc"
+
+
+def test_an_explicit_family_is_honoured_when_torch_carries_no_tag(monkeypatch):
+    """UNSLOTH_TORCH_INDEX_FAMILY is as explicit an instruction as the full URL, and the
+    host that needs it is exactly the one whose torch has no local tag -- a private mirror
+    rebuilding torch bare. _explicit_unknown_family_torch_index_url already treats a custom
+    leaf such as /current as authoritative and leaves that torch alone, so returning None
+    here is never corrected later; step 4 just installs torchao from the default index,
+    which on an air-gapped host is no index at all."""
+    monkeypatch.setenv("UNSLOTH_PYTORCH_MIRROR", "https://mirror.example/whl")
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "current")
+    mod = _reload_install_python_stack()
+    assert mod._torch_accelerator_index_url("2.14.0") == "https://mirror.example/whl/current"
+    assert mod._torchcodec_index_url("2.14.0") == "https://mirror.example/whl/current"
+    # A tagged torch is unaffected: the family still wins, as it did before.
+    assert mod._torch_accelerator_index_url("2.14.0+cu130") == (
+        "https://mirror.example/whl/current"
     )
-    # The FAMILY override takes the same path, substitution included.
+    # And the per-package substitution still applies to the override.
     monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "xpu")
-    assert mod._torchcodec_index_url("2.13.0+xpu") == (
-        "https://mirror.example/whl/cpu/?token=abc"
-    )
+    assert mod._torchcodec_index_url("2.14.0") == "https://mirror.example/whl/cpu"
 
 
 def test_a_plain_mirror_is_still_joined_the_obvious_way(monkeypatch):

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -179,6 +179,22 @@ def _load_install_python_stack():
     return install_python_stack
 
 
+def _reload_install_python_stack():
+    """A PRIVATE module instance, for the constants read once at import.
+
+    _PYTORCH_WHL_BASE is computed from UNSLOTH_PYTORCH_MIRROR at import time, so the cached
+    module in sys.modules answers with whatever the environment was on first import. Loading
+    a fresh instance is the only way to exercise a mirror."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_install_python_stack_probe", REPO_ROOT / "studio" / "install_python_stack.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_pyproject_declares_torch211_audio_extra_with_python_gate():
     text = PYPROJECT.read_text(encoding = "utf-8")
     match = re.search(r"^audio-torch211 = \[(.*?)^\]", text, re.MULTILINE | re.DOTALL)
@@ -1364,3 +1380,38 @@ def test_the_remedy_spells_the_variable_for_the_shell_it_will_be_pasted_into(mon
     for platform in ("linux", "darwin"):
         monkeypatch.setattr(fixes.sys, "platform", platform)
         assert fixes._shell_env_ref("UNSLOTH_TORCH_INDEX_URL") == '"$UNSLOTH_TORCH_INDEX_URL"'
+
+
+def test_a_mirror_carrying_a_token_gets_the_leaf_in_its_path(monkeypatch):
+    """UNSLOTH_PYTORCH_MIRROR may authenticate through a query token. Concatenating the leaf
+    put it INSIDE the token -- "https://m/whl?token=abc/cu130" -- so the index resolved
+    nothing. For torchcodec that silently costs audio; for torchao, whose step is fatal, the
+    unpinned retry also drops the mirror, so a mirror-only host cannot install it at all.
+
+    _index_url_join already existed for the ROCm mirrors and its docstring names this exact
+    failure, so this is about using it rather than about new logic."""
+    monkeypatch.setenv("UNSLOTH_PYTORCH_MIRROR", "https://mirror.example/whl?token=abc")
+    mod = _reload_install_python_stack()
+    assert mod._torch_accelerator_index_url("2.13.0+cu130") == (
+        "https://mirror.example/whl/cu130/?token=abc"
+    )
+    assert mod._torchcodec_index_url("2.13.0+cu130") == (
+        "https://mirror.example/whl/cu130/?token=abc"
+    )
+    # The FAMILY override takes the same path, substitution included.
+    monkeypatch.setenv("UNSLOTH_TORCH_INDEX_FAMILY", "xpu")
+    assert mod._torchcodec_index_url("2.13.0+xpu") == (
+        "https://mirror.example/whl/cpu/?token=abc"
+    )
+
+
+def test_a_plain_mirror_is_still_joined_the_obvious_way(monkeypatch):
+    """The join must not disturb the ordinary case, which is every host without a token."""
+    monkeypatch.setenv("UNSLOTH_PYTORCH_MIRROR", "https://mirror.example/whl")
+    mod = _reload_install_python_stack()
+    assert mod._torch_accelerator_index_url("2.13.0+cu130") == "https://mirror.example/whl/cu130"
+    monkeypatch.delenv("UNSLOTH_PYTORCH_MIRROR")
+    mod = _reload_install_python_stack()
+    assert mod._torch_accelerator_index_url("2.13.0+cu130") == (
+        "https://download.pytorch.org/whl/cu130"
+    )

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -298,14 +298,18 @@ _UPSTREAM_TORCH_TO_TORCHCODEC_MINORS = {
 
 
 # What each download.pytorch.org index actually publishes, read off the live listings:
-# the torch 2.x minors it serves, and the inclusive range of torchcodec minors.
-# Note cu130 starts at codec 0.8, and no index carries 0.1 or 0.2 -- those are PyPI-only.
+# the torch 2.x minors it serves, and the torchcodec minors it carries. Explicit minors
+# rather than a range, because the inventory is not contiguous: cu129 skips 0.8, 0.9 and
+# 0.12-0.14 entirely. No index carries 0.1 or 0.2 -- those are PyPI-only.
 _INDEX_INVENTORY = {
-    "cpu": {"torch": range(5, 15), "codec": (3, 16)},
-    "cu118": {"torch": range(5, 8), "codec": (3, 5)},
-    "cu126": {"torch": range(6, 15), "codec": (3, 16)},
-    "cu128": {"torch": range(7, 12), "codec": (3, 11)},
-    "cu130": {"torch": range(9, 15), "codec": (8, 16)},
+    "cpu": {"torch": range(5, 15), "codec": {3, 4, *range(6, 17)}},
+    "cu118": {"torch": range(5, 8), "codec": {3, 4}},
+    "cu126": {"torch": range(6, 15), "codec": {3, 4, *range(6, 17)}},
+    "cu128": {"torch": range(7, 12), "codec": {3, 4, *range(6, 12)}},
+    "cu129": {"torch": range(8, 14), "codec": {6, 7, 10, 11, 15, 16}},
+    "cu130": {"torch": range(9, 15), "codec": set(range(8, 17))},
+    "cu132": {"torch": range(12, 15), "codec": set(range(12, 17))},
+    "xpu": {"torch": range(6, 15), "codec": {13, 14, 15, 16}},
 }
 
 
@@ -320,47 +324,94 @@ def test_torchcodec_index_follows_the_resident_torch_build():
     assert ips._torchcodec_index_url("2.14.0+cu130") == base + "cu130"
     assert ips._torchcodec_index_url("2.11.0+cpu") == base + "cpu"
 
+    # xpu began publishing torchcodec at 0.13, so it pins like any other accelerator. An
+    # xpu host left unpinned takes PyPI's CUDA build, which is the failure this prevents.
+    assert ips._torchcodec_index_url("2.14.0+xpu") == base + "xpu"
+
     # Untagged is PyPI's own torch, whose counterpart is PyPI's default torchcodec. Pinning
     # cpu here would be wrong: on Linux an untagged torch is a CUDA build.
     assert ips._torchcodec_index_url("2.11.0") is None
-    # No torchcodec is published under these, so unpinned beats an index that cannot serve.
+    # Every rocm leaf answers 404/403 for torchcodec, so a pin there cannot ever serve.
     assert ips._torchcodec_index_url("2.9.0+rocm6.4") is None
-    assert ips._torchcodec_index_url("2.10.0+xpu") is None
+    assert ips._torchcodec_index_url("2.11.0+rocm7.2") is None
     assert ips._torchcodec_index_url(None) is None
     assert ips._torchcodec_index_url("") is None
 
 
-def test_pinning_the_index_never_starves_a_reachable_torch():
-    """A pin that removed audio from a supported host would trade one bug for another.
-
-    Every torch build that pins must find its selected codec on that same index. This holds
-    because torch and torchcodec are cut together: cu128 stops at torch 2.11 and its
-    torchcodec stops at 0.11, the exact pair the matrix maps 2.11 to; cu130 starts at torch
-    2.9 and its torchcodec starts at 0.8, the pair for 2.9.
-
-    The one gap is deliberate and handled in the helper rather than here: no index carries
-    torchcodec 0.1 or 0.2, so torch 2.5 and 2.6 must not pin at all.
-    """
+def _starved_index_cells():
+    """Every (tag, torch minor) whose pinned index publishes nothing in the window."""
     from packaging.specifiers import SpecifierSet
 
     ips = _load_install_python_stack()
+    starved = []
     for tag, inv in _INDEX_INVENTORY.items():
-        low, high = inv["codec"]
         for minor in inv["torch"]:
             version = f"2.{minor}.0+{tag}"
             spec = ips._select_torchcodec_spec(version)
-            specifier = SpecifierSet(spec.split("torchcodec", 1)[1])
-            served = [f"0.{m}.0" for m in range(low, high + 1) if specifier.contains(f"0.{m}.0")]
             index = ips._torchcodec_index_url(version, spec)
             if index is None:
-                # Only the PyPI-only rows may decline to pin.
-                assert minor in (5, 6), f"torch 2.{minor}+{tag} unexpectedly refused to pin"
                 continue
-            assert index.endswith("/" + tag)
-            assert served, (
-                f"torch 2.{minor} pins the {tag} index and selects {spec}, but that index "
-                f"publishes only torchcodec 0.{low}-0.{high}"
-            )
+            assert index.endswith("/" + tag), index
+            specifier = SpecifierSet(spec.split("torchcodec", 1)[1])
+            if not any(specifier.contains(f"0.{m}.0") for m in inv["codec"]):
+                starved.append((tag, minor, spec))
+    return starved
+
+
+def test_pinning_the_index_starves_only_where_the_retry_covers_it():
+    """A pin that removed audio from a supported host would trade one bug for another.
+
+    Mostly the pin cannot starve, because torch and torchcodec are cut together: cu128 stops
+    at torch 2.11 and its torchcodec stops at 0.11, the exact pair the matrix maps 2.11 to.
+    But cu129 serves torch 2.8 to 2.13 while publishing no torchcodec 0.8 or 0.9, so torch
+    2.9 there selects a window that index has nothing in, and cu132 and xpu start above the
+    lines the older torch minors select.
+
+    The answer is not a table of index contents -- that is what goes stale, and cu132 did not
+    exist when this file was written -- so the installer retries unpinned, which is what such
+    a host got before any of this pinned anything. This test pins down which cells rely on
+    that retry, so a new one cannot appear unnoticed, and the test below proves the retry is
+    really there.
+    """
+    starved = {(tag, minor) for tag, minor, _ in _starved_index_cells()}
+    # One cell, and it is the one no floor could have predicted: cu129 publishes 0.6, 0.7,
+    # 0.10, 0.11, 0.15 and 0.16, so its gap is in the MIDDLE. The xpu rows below 0.13, which
+    # would otherwise be five more, are declined up front by _TORCHCODEC_INDEX_FLOORS.
+    assert starved == {("cu129", 9)}, sorted(starved)
+
+
+def test_the_installer_retries_without_the_index_when_the_pin_finds_nothing():
+    """The starved cells above are only survivable because the step falls back."""
+    source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
+    step = source.split("# 13b. torchcodec", 1)[1].split("# 14.", 1)[0]
+    assert "retrying from the default index" in step
+    # The retry must drop the pin and nothing else: --no-deps still matters, since a
+    # torchcodec that re-resolves torch would undo the repair two steps above.
+    retry = step.split("retrying from the default index", 1)[1]
+    assert '"--no-deps", "--no-cache-dir", _codec_spec' in retry
+    assert "--index-url" not in retry
+
+
+def test_an_index_that_joined_late_is_not_pinned_below_its_first_release():
+    """xpu serves torch from 2.6 but published no torchcodec before 0.13, so pinning it for
+    the older lines is a resolve that cannot succeed. A floor, unlike a list of what an index
+    holds, only says "nothing below X was ever published here", which upstream does not walk
+    back, so it stays true as releases are added."""
+    ips = _load_install_python_stack()
+    assert ips._TORCHCODEC_INDEX_FLOORS["xpu"] == (0, 13, 0)
+    for minor in (7, 8, 9, 10, 11):
+        version = f"2.{minor}.0+xpu"
+        spec = ips._select_torchcodec_spec(version)
+        assert ips._torchcodec_index_url(version, spec) is None, spec
+    # 2.12+ takes the open ABI-stable window, which reaches 0.13, so it pins.
+    for minor in (12, 13, 14):
+        version = f"2.{minor}.0+xpu"
+        spec = ips._select_torchcodec_spec(version)
+        assert ips._torchcodec_index_url(version, spec) == "https://download.pytorch.org/whl/xpu"
+    # The floor is per leaf, not global: cu126 still pins the same old lines it always did.
+    assert ips._torchcodec_index_url("2.9.0+cu126", ips._select_torchcodec_spec("2.9.0")) == (
+        "https://download.pytorch.org/whl/cu126"
+    )
 
 
 def test_the_two_pypi_only_rows_stay_unpinned():

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -504,9 +504,7 @@ def test_an_opaque_mirror_replaces_a_codec_it_cannot_vouch_for(monkeypatch):
     want = ips._torchcodec_index_tag("2.14.0+cu130")
     assert want is None
     for have in ("0.16.0", "0.16.0+cu126", "0.16.0+cu130"):
-        forced = bool(have) and (
-            want is None or have.partition("+")[2].strip().lower() != want
-        )
+        forced = bool(have) and (want is None or have.partition("+")[2].strip().lower() != want)
         assert forced, have
 
 

--- a/tests/studio/install/test_cuda_repair.py
+++ b/tests/studio/install/test_cuda_repair.py
@@ -1644,16 +1644,14 @@ class TestThePackagesTiedToTheTorchReleaseAreResettled:
         assert any("torchao==0.17.0" in " ".join(c) for c in calls["torchao"])
 
     def test_a_flavor_change_within_one_cuda_major_re_pins_torchao(self):
-        """This left torchao alone while every host took PyPI's one build, where cu124 and
-        cu128 really did resolve to the same file. Now that the install is pinned to the leaf
-        matching torch, they are different wheels and the move has to be followed."""
+        """A no-op while every host took PyPI's one build; different wheels now that the
+        install is pinned to the leaf matching torch."""
         calls = self._resync("2.10.0+cu124", "2.10.0+cu128")
         assert calls["torchao"], "the leaf moved, so the pinned build has to be re-selected"
         assert any("cu128" in " ".join(c) for c in calls["torchao"]), calls["torchao"]
 
     def test_a_cpu_to_xpu_move_re_pins_torchao(self):
-        """Neither side names a CUDA major, so a cuda-major-only test read None == None and
-        skipped the resync entirely, leaving a +cpu torchao beside an xpu torch."""
+        """Neither side names a CUDA major, so None == None skipped the resync entirely."""
         calls = self._resync("2.10.0+cpu", "2.10.0+xpu")
         assert calls["torchao"], "cpu to xpu changes the build even at one release"
         assert any("/xpu" in " ".join(c) for c in calls["torchao"]), calls["torchao"]
@@ -1670,9 +1668,8 @@ class TestThePackagesTiedToTheTorchReleaseAreResettled:
         assert calls["ok"] is False, "re-pinning torchao asks for a re-verify, as anywhere else"
 
     def test_the_torchao_reinstall_cannot_drag_torch_back(self):
-        # Belt and braces: torchao declares no runtime torch dependency in any release, so
-        # this skips nothing today, but a reinstall right after a repair is the one place
-        # where a torchao that gained one would undo the repair.
+        # No torchao release declares a runtime torch dependency, but a reinstall right after
+        # a repair is where one would undo it.
         calls = self._resync("2.11.0+cu124", "2.10.0+cu124")
         assert calls["torchao"], "the release moved, so torchao is re-pinned"
         assert all("--no-deps" in c for c in calls["torchao"])

--- a/tests/studio/install/test_cuda_repair.py
+++ b/tests/studio/install/test_cuda_repair.py
@@ -1643,16 +1643,31 @@ class TestThePackagesTiedToTheTorchReleaseAreResettled:
         assert calls["torchao"], "the CUDA major moved, so the pin has to be re-selected"
         assert any("torchao==0.17.0" in " ".join(c) for c in calls["torchao"])
 
-    def test_a_flavor_change_within_one_cuda_major_leaves_torchao_alone(self):
+    def test_a_flavor_change_within_one_cuda_major_re_pins_torchao(self):
+        """This left torchao alone while every host took PyPI's one build, where cu124 and
+        cu128 really did resolve to the same file. Now that the install is pinned to the leaf
+        matching torch, they are different wheels and the move has to be followed."""
         calls = self._resync("2.10.0+cu124", "2.10.0+cu128")
-        assert calls["torchao"] == []
+        assert calls["torchao"], "the leaf moved, so the pinned build has to be re-selected"
+        assert any("cu128" in " ".join(c) for c in calls["torchao"]), calls["torchao"]
+
+    def test_a_cpu_to_xpu_move_re_pins_torchao(self):
+        """Neither side names a CUDA major, so a cuda-major-only test read None == None and
+        skipped the resync entirely, leaving a +cpu torchao beside an xpu torch."""
+        calls = self._resync("2.10.0+cpu", "2.10.0+xpu")
+        assert calls["torchao"], "cpu to xpu changes the build even at one release"
+        assert any("/xpu" in " ".join(c) for c in calls["torchao"]), calls["torchao"]
+
+    def test_a_build_that_kept_its_leaf_is_still_left_alone(self):
+        """The widened test must not have become "always re-pin"."""
+        assert self._resync("2.10.0+cu128", "2.10.0+cu128")["torchao"] == []
+        assert self._resync("2.10.0", "2.10.0")["torchao"] == []
 
     def test_a_flavor_change_alone_still_rechecks_xformers(self):
         # xFormers links against the exact (torch, CUDA) pair.
         calls = self._resync("2.10.0+cu124", "2.10.0+cu128", resident_xformers = "2.10.0+cu124")
-        assert calls["torchao"] == [], "the release did not move; torchao is fine"
         assert calls["removed"] == ["xformers"]
-        assert calls["ok"] is True, "nothing here touched torch"
+        assert calls["ok"] is False, "re-pinning torchao asks for a re-verify, as anywhere else"
 
     def test_the_torchao_reinstall_cannot_drag_torch_back(self):
         # torchao depends on torch: resolving deps re-pulls the wheel just removed.

--- a/tests/studio/install/test_cuda_repair.py
+++ b/tests/studio/install/test_cuda_repair.py
@@ -1670,7 +1670,9 @@ class TestThePackagesTiedToTheTorchReleaseAreResettled:
         assert calls["ok"] is False, "re-pinning torchao asks for a re-verify, as anywhere else"
 
     def test_the_torchao_reinstall_cannot_drag_torch_back(self):
-        # torchao depends on torch: resolving deps re-pulls the wheel just removed.
+        # Belt and braces: torchao declares no runtime torch dependency in any release, so
+        # this skips nothing today, but a reinstall right after a repair is the one place
+        # where a torchao that gained one would undo the repair.
         calls = self._resync("2.11.0+cu124", "2.10.0+cu124")
         assert calls["torchao"], "the release moved, so torchao is re-pinned"
         assert all("--no-deps" in c for c in calls["torchao"])

--- a/tests/studio/install/test_cuda_repair.py
+++ b/tests/studio/install/test_cuda_repair.py
@@ -1593,10 +1593,19 @@ class TestThePackagesTiedToTheTorchReleaseAreResettled:
 
         with (
             patch.object(stack_mod, "_probe_installed_torch_version", return_value = after),
+            # The resync asks _pin_needs_reinstall, which reads the installed version and
+            # compares its local tag against the index it is about to pin. So "already
+            # matching" means the exact wheel that pin would fetch, tag included -- an
+            # untagged 0.16.0 beside a cu130 pin is precisely the case it must NOT skip.
             patch.object(
                 stack_mod,
-                "_exact_distribution_spec_is_installed",
-                return_value = installed_spec,
+                "_installed_distribution_version",
+                side_effect = lambda name: (
+                    stack_mod._select_torchao_spec(after).split("==", 1)[1]
+                    + ("+" + after.partition("+")[2] if after.partition("+")[2] else "")
+                    if (installed_spec and name == "torchao")
+                    else None
+                ),
             ),
             patch.object(
                 stack_mod,

--- a/tests/studio/install/test_windows_torch_flavor_invariant.py
+++ b/tests/studio/install/test_windows_torch_flavor_invariant.py
@@ -290,9 +290,8 @@ class TestStepThirteenWiring:
             assert calls[:2] == ["_progress", "_torch_step_label"]
         # str() is the label coercion around the probe, not a step.
         step13 = [c for c in _calls_in(guards[1]) if c != "str"]
-        # Step 13 additionally re-selects torchao when a repair moved the torch label: the
-        # spec and the index leaf are both read off it, so the earlier choice can be stale.
-        # Nothing else may join the set, and step 2b must not have grown the same call.
+        # Step 13 also re-selects torchao when a repair moved the torch label, which both the
+        # spec and the leaf are read from. Nothing else may join the set.
         assert step13 == (
             ["_progress", "_torch_step_label", "_probe_installed_torch_version"]
             + repairs + ["_probe_installed_torch_version", "_note", "_install_torchao_for_torch"]

--- a/tests/studio/install/test_windows_torch_flavor_invariant.py
+++ b/tests/studio/install/test_windows_torch_flavor_invariant.py
@@ -277,16 +277,27 @@ class TestStepThirteenWiring:
             "not IS_MACOS and (not NO_TORCH)",
             "not IS_WINDOWS and (not IS_MACOS) and (not NO_TORCH)",
         ]
+        repairs = [
+            "_ensure_cuda_torch",
+            "_ensure_rocm_torch",
+            "_ensure_xpu_torch",
+            "_ensure_cpu_torch",
+            "_ensure_xpu_triton",
+        ]
         for guard in guards:
-            assert _calls_in(guard) == [
-                "_progress",
-                "_torch_step_label",
-                "_ensure_cuda_torch",
-                "_ensure_rocm_torch",
-                "_ensure_xpu_torch",
-                "_ensure_cpu_torch",
-                "_ensure_xpu_triton",
-            ]
+            calls = _calls_in(guard)
+            assert [c for c in calls if c in repairs] == repairs
+            assert calls[:2] == ["_progress", "_torch_step_label"]
+        # str() is the label coercion around the probe, not a step.
+        step13 = [c for c in _calls_in(guards[1]) if c != "str"]
+        # Step 13 additionally re-selects torchao when a repair moved the torch label: the
+        # spec and the index leaf are both read off it, so the earlier choice can be stale.
+        # Nothing else may join the set, and step 2b must not have grown the same call.
+        assert step13 == (
+            ["_progress", "_torch_step_label", "_probe_installed_torch_version"]
+            + repairs + ["_probe_installed_torch_version", "_note", "_install_torchao_for_torch"]
+        ), step13
+        assert "_install_torchao_for_torch" not in _calls_in(guards[0])
 
     def test_the_invariant_is_wired_in_exactly_once(self):
         body = ast.unparse(_install_stack_ast())


### PR DESCRIPTION
Follow-up to #7474. That PR established that a torch-coupled wheel needs two things, not one: the right version for the resident torch, and the right accelerator index to fetch it from. Re-enumerating `download.pytorch.org` found three places where only half of that is applied, two of them in the code #7474 just landed.

Every claim below was checked against the live indexes and upstream on 2026-09-08, not inferred.

## What breaks today

**1. A cu129 host with torch 2.9 silently loses audio.** cu129 publishes torchcodec 0.6, 0.7, 0.10, 0.11, 0.11.1, 0.15 and 0.16, with no 0.8 and no 0.9, while serving torch 2.8 through 2.13. torch 2.9 there selects `torchcodec>=0.8.0,<0.10.0` and pins `--index-url .../cu129`, which has nothing in that window. The install is non-fatal, so audio just goes away.

**2. An Intel-GPU host gets a CUDA codec.** `_torchcodec_index_url` returned `None` for `xpu`, so an xpu venv takes PyPI's default torchcodec, and PyPI's default is the CUDA build: 9.5 MB, exactly the size of the cu130 wheel, against 5.1 MB for cpu. It then tries to `dlopen` CUDA on a machine that has none.

**3. torchao is stale and never index-pinned.** `_select_torchao_spec` returned `torchao==0.17.0` for every torch `>=2.11`, but 0.18.0 shipped on 2026-08-03, dropped torch <2.11 and pinned its release CI to torch 2.13. Separately, torchao is published per accelerator under `/whl/<tag>` (including on every rocm leaf), yet the override step installs it with no index at all, so every host takes whichever single build PyPI carries.

The two torchao halves are **coupled and have to land together**. 0.17.0's cpp targets torch 2.11, so on 2.12+ it is skipped and you quietly get the slow Python path. 0.18.0's cpp targets 2.13, so on a torch 2.13 host it would actually attempt the load, and PyPI carries exactly one build, at whichever CUDA major PyTorch currently defaults to. Bumping the version without pinning the index would just move which hosts get their kernels skipped.

A correction to an earlier revision of this description, which claimed the mismatch crashes on `libcudart.so.12`: it does not, and neither does any other torchao this installer can select. `torchao/__init__.py` has wrapped the cpp load in `try/except` since 0.12.0, so a mismatch costs the kernels and logs a warning that `unsloth/import_fixes.py` already filters. Forcing `torch.ops.load_library` to raise that exact `OSError` leaves `import torchao` and `torchao.quantization` working. Nothing here depends on a crash.

## What this does

- One `_torch_accelerator_index_url` helper maps a torch local tag to its leaf, and both packages use it. `_explicit_torch_index_url()` still wins and `_PYTORCH_WHL_BASE` is still the base, so `UNSLOTH_TORCH_INDEX_URL`, `UNSLOTH_TORCH_INDEX_FAMILY` and `UNSLOTH_PYTORCH_MIRROR` behave exactly as before.
- torchao takes `0.18.0` from torch 2.12 up and is installed from the leaf matching the resident torch. torch 2.11 stays on 0.17.0, whose cpp is built for it. Nothing at or below 2.10 changes.
- An xpu torch is pinned to the **cpu** leaf. torchcodec publishes no xpu build at all: the xpu leaf republishes the CPU wheels verbatim (`torchcodec-0.16.0+cpu-...`) and only for Linux x86_64, while the cpu leaf carries that same wheel for aarch64 and Windows too and goes back to 0.3 instead of starting at 0.13.
- Both steps **retry once without the pin** when the pinned index does not serve the spec. This is deliberately not a table of index contents: a table is exactly what went stale here, cu132 did not exist when this code was written, and cu129's gap is in the middle of its range where no floor could describe it. The retry restores precisely the pre-pin behaviour on a starved cell. torchcodec's failure stays non-fatal; torchao's stays fatal, but only after both attempts.
- `_pin_needs_reinstall` replaces an exact string compare that the index pin would otherwise have broken. An index wheel carries a local tag (`0.18.0+cu130`) and PyPI forbids one, so `==0.18.0` would never have equalled the installed string and every run would have force-reinstalled. It compares the release and the tag separately, which additionally catches the case the pin exists for: a right version built for the wrong accelerator.

## Before and after

| host | before | after |
|---|---|---|
| torch 2.9 + cu129 | codec pinned to an index with nothing in its window, audio silently off | pinned attempt misses, retries unpinned, audio works |
| torch 2.14 + xpu | PyPI's CUDA codec, cannot dlopen | `0.16.0+cpu` from the cpu leaf |
| torch 2.13 + cu132 | `torchao==0.17.0` from PyPI, wrong-major cpp, kernels skipped | `torchao==0.18.0+cu132` |
| torch 2.11 + rocm7.2 | `torchao==0.17.0` from PyPI, the CUDA build | `torchao==0.17.0+rocm7.2` |
| torch 2.10 + cu128 | unchanged | unchanged |
| untagged torch (macOS, plain PyPI) | unpinned | unpinned, same single fatal call |

## torchaudio: audited, no change

Recording the result so the question is closed rather than left open. torchaudio is in the same class as torchcodec, declaring no `torch` dependency for pip to check, but it is already handled: `pyproject.toml` pairs `torch==2.12.0+cu126` with `torchaudio==2.11.0+cu126` under the comment "torchaudio has no 2.12 release", `install.sh` bounds it to torch's window noting "torchaudio 2.11 dropped its torch pin, so it can drift", and `disable_torchaudio_if_cuda_mismatched` neutralises a CUDA-mismatched wheel at runtime. Upstream has published nothing since 2.11.0 on 2026-03-23, so there is no newer wheel any change could select.

torchvision, xformers and bitsandbytes need nothing here: they declare a `torch` dependency in their metadata (`torch==2.14.0`, `torch>=2.10`, `torch<3,>=2.4`), so pip catches a mismatch by itself. triton declares none, but torch pins `triton~=3.8.0` from its own side.

## Verification

Simulated rather than argued. Details in the review comment below, but in summary:

- **7,018 decision rows** across [Linux, WSL, macOS x86_64/arm64, Windows AMD64/ARM64] x [untagged, cpu, cu118/124/126/128/129/130/132, rocm6.3/6.4/7.0/7.1/7.2, xpu] x torch 2.4 to 2.99 including rc/dev/malformed x Python 3.9 to 3.14, dumped from this branch and from `main` and diffed. Exactly three kinds of difference appear, all intended; nothing else moved.
- **36 replay checks** driving the real step 4 and step 13b bodies against a recording pip, asserting the exact argv including the retry, the `--no-deps` on the codec retry, the NPP step surviving a fallback, and both skip paths.
- **73 live resolves** against the real indexes, plus **18 `--report` resolves** confirming the pinned build is the one that lands (`torchao==0.18.0 --index-url .../cu130` -> `0.18.0+cu130`, and unpinned -> `0.18.0`).
- **One real venv install**: `torchao==0.14.0` from the cpu leaf lands `0.14.0+cpu`, the metadata carries the tag, and `import torchao` works.
- Six mutations of the new behaviour, each confirmed to fail the tests.

No UI, HTTP route or browser code is touched, so this has no browser dimension.

## Follow-ups found during review

Three more, all verified against the live indexes rather than reasoned about, and all fixed here:

- **An explicit index was discarded when torch carried no local tag.** Only download.pytorch.org stamps `+cuNNN`, so a corporate or air-gapped mirror that rebuilds torch ships it bare. `UNSLOTH_TORCH_INDEX_URL` is now read before a tag is required, which is what `_ensure_expected_torch_flavor` already does for the same host.
- **NPP is chosen from the wheel, not the tag, after an unpinned retry.** PyPI's default carries whichever CUDA major PyTorch currently defaults to, which need not be the resident torch's: `torchcodec-0.16.0` from PyPI links `libcudart.so.13` while the `+cu126` leaf links `.12`. So a starved `+cu129` host that falls back was asking for `nvidia-npp-cu12` beside a CUDA-13 codec. The installed shared objects are read instead. Confirmed by installing all three wheels: `+cu126` reads 12, PyPI reads 13, `+cpu` reads none and skips NPP.
- **A tagged wheel is replaced when no index is pinned.** The unpinned case fetches from the default index, which stamps no local tag, so a tagged wheel sitting there came from somewhere else. It settles after one reinstall.
