### PR TITLE
Docker Hub README: xformers is amd64 only, GB10 runs through PTX, canonical docs link

### DIFF
--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -75,7 +75,7 @@ docker run -d -e UNSLOTH_ALLOW_CPU=1 -p 8000:8000 -p 8888:8888 unsloth/unsloth
 
 ## Supported GPUs
 
-Compiled for `sm_75 sm_80 sm_86 sm_90 sm_100 sm_120` plus PTX: Turing (T4, RTX 20), Ampere (A100, A10, RTX 30), Ada (L4, L40, RTX 40), Hopper (H100, H200, GH200) and Blackwell (B200, GB200, RTX 50, RTX PRO 6000) run native code; GB10 (DGX Spark, `sm_121`) runs through PTX JIT on first use. The container prints the detected GPU on start and explains what to do when the driver is too old.
+Compiled for `sm_75 sm_80 sm_86 sm_90 sm_100 sm_120`: Turing (T4, RTX 20), Ampere (A100, A10, RTX 30), Ada (L4, L40, RTX 40), Hopper (H100, H200, GH200) and Blackwell (B200, GB200, RTX 50, RTX PRO 6000). GB10 (DGX Spark, `sm_121`) runs the `sm_120` binaries through Blackwell forward compatibility; only kernels compiled at run time, such as Triton, use the CUDA 13 compiler the container switches to on that GPU. The container prints the detected GPU on start and explains what to do when the driver is too old.
 
 Driver requirements:
 

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -1,8 +1,8 @@
 # Unsloth Docker Image
 
-Pre-built images for [Unsloth](https://github.com/unslothai/unsloth): fine-tune and run LLMs, vision, audio and diffusion models with no setup. Every image carries the full training stack (PyTorch 2.11 with CUDA 12.8, Unsloth, unsloth-zoo, bitsandbytes, xformers, TRL, PEFT), JupyterLab with the [Unsloth notebooks](https://github.com/unslothai/notebooks) pre-synced, and prebuilt llama.cpp and whisper.cpp for GGUF work.
+Pre-built images for [Unsloth](https://github.com/unslothai/unsloth): fine-tune and run LLMs, vision, audio and diffusion models with no setup. Every image carries the full training stack (PyTorch 2.11 with CUDA 12.8, Unsloth, unsloth-zoo, bitsandbytes, TRL, PEFT, plus xformers on `linux/amd64`), JupyterLab with the [Unsloth notebooks](https://github.com/unslothai/notebooks) pre-synced, and prebuilt llama.cpp and whisper.cpp for GGUF work.
 
-Source: [`docker/`](https://github.com/unslothai/unsloth/tree/main/docker) in the main repository. Guide: [docs.unsloth.ai](https://docs.unsloth.ai/get-started/install-and-update/docker).
+Source: [`docker/`](https://github.com/unslothai/unsloth/tree/main/docker) in the main repository. Guide: [docs.unsloth.ai](https://docs.unsloth.ai/get-started/install/docker).
 
 ## Tags
 
@@ -75,7 +75,7 @@ docker run -d -e UNSLOTH_ALLOW_CPU=1 -p 8000:8000 -p 8888:8888 unsloth/unsloth
 
 ## Supported GPUs
 
-Compiled for `sm_75 sm_80 sm_86 sm_90 sm_100 sm_120`: Turing (T4, RTX 20), Ampere (A100, A10, RTX 30), Ada (L4, L40, RTX 40), Hopper (H100, H200, GH200), Blackwell (B200, GB200, RTX 50, RTX PRO 6000) and GB10 (DGX Spark). The container prints the detected GPU on start and explains what to do when the driver is too old.
+Compiled for `sm_75 sm_80 sm_86 sm_90 sm_100 sm_120` plus PTX: Turing (T4, RTX 20), Ampere (A100, A10, RTX 30), Ada (L4, L40, RTX 40), Hopper (H100, H200, GH200) and Blackwell (B200, GB200, RTX 50, RTX PRO 6000) run native code; GB10 (DGX Spark, `sm_121`) runs through PTX JIT on first use. The container prints the detected GPU on start and explains what to do when the driver is too old.
 
 Driver requirements:
 


### PR DESCRIPTION
## Summary

Three corrections to `docker/DOCKERHUB.md` (the page the publish workflow syncs to Docker Hub), all surfaced by the DGX Spark report in #10491:

- **xformers**: the page said every image carries xformers. The `linux/arm64` images carry none, because there is no cu128 aarch64 wheel (`docker/Dockerfile` header). It now says xformers ships on `linux/amd64`.
- **GB10 / sm_121**: the page listed GB10 (DGX Spark) among the compiled targets. No wheel carries `sm_121`; GB10 runs the `sm_120` SASS through Blackwell forward compatibility, and only run time compiled kernels such as Triton use the CUDA 13 compiler the container switches to. The wording now says exactly that.
- **Docs link**: the guide link used the old `install-and-update/docker` path; it now points at the canonical `docs.unsloth.ai/get-started/install/docker` page.

The CPU-only llama.cpp in the arm64 Studio layer, the headline of #10491, is a code fix and comes in a separate PR.

## Tests

`tests/python/test_docker_hub_readme.py`, `test_docker_nvidia_toolkit_install.py`, `test_docker_publish_tag_scheme.py`: 80 passed.
