### PR TITLE
Default the launch-time reasoning effort to medium, not high

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7027,14 +7027,22 @@ class LlamaCppBackend:
             # the template's default effort (max) in place.
             return {"enable_thinking": enable_thinking}
         if self._reasoning_style == "reasoning_effort":
+            # medium, not high, when thinking is on. This is the value a request that omits
+            # reasoning_effort falls back to, and gpt-oss already defaults to medium on its own:
+            # the Harmony template sets it when the key is undefined, and the harmony library
+            # does the same. Sending high here made a raw /v1/chat/completions call reason
+            # harder than the same model does anywhere else.
+            #
+            # Only when the template actually branches on medium. The level scan publishes whatever
+            # literals it found as long as low and high are among them, so a template that ladders
+            # low|high|max has no medium to land on, and handing it one would fall through every
+            # branch. Those keep high, which is what they got before. An empty list means the scan
+            # found nothing to trust and the default low|medium|high applies, so medium is safe.
+            levels = self._reasoning_effort_levels or []
+            thinking_effort = "medium" if (not levels or "medium" in levels) else "high"
             return _coerce_reasoning_effort(
                 getattr(self, "_architecture", None),
-                # medium, not high, when thinking is on. This is the value a request that omits
-                # reasoning_effort falls back to, and gpt-oss already defaults to medium on its own:
-                # the Harmony template sets it when the key is undefined, and the harmony library
-                # does the same. Sending high here made a raw /v1/chat/completions call reason
-                # harder than the same model does anywhere else.
-                {"reasoning_effort": "medium" if enable_thinking else "low"},
+                {"reasoning_effort": thinking_effort if enable_thinking else "low"},
             )
         return {"enable_thinking": enable_thinking}
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7029,7 +7029,12 @@ class LlamaCppBackend:
         if self._reasoning_style == "reasoning_effort":
             return _coerce_reasoning_effort(
                 getattr(self, "_architecture", None),
-                {"reasoning_effort": "high" if enable_thinking else "low"},
+                # medium, not high, when thinking is on. This is the value a request that omits
+                # reasoning_effort falls back to, and gpt-oss already defaults to medium on its own:
+                # the Harmony template sets it when the key is undefined, and the harmony library
+                # does the same. Sending high here made a raw /v1/chat/completions call reason
+                # harder than the same model does anywhere else.
+                {"reasoning_effort": "medium" if enable_thinking else "low"},
             )
         return {"enable_thinking": enable_thinking}
 

--- a/studio/backend/tests/test_reasoning_effort_wide_ladder.py
+++ b/studio/backend/tests/test_reasoning_effort_wide_ladder.py
@@ -164,3 +164,55 @@ def test_other_reasoning_styles_are_untouched():
     backend._reasoning_style = "reasoning_effort"
     backend._reasoning_always_on = True
     assert backend._request_reasoning_kwargs(True, "max", None) is None
+
+
+def test_the_launch_default_lands_on_a_level_the_template_actually_branches_on():
+    """The load-time ``--chat-template-kwargs`` default has to be on the ladder.
+
+    ``_reasoning_kwargs`` builds the value llama-server falls back to for every
+    request that omits ``reasoning_effort``. Detection publishes whatever effort
+    literals it found as long as ``low`` and ``high`` are among them, so a
+    template laddering ``low|high|max`` has no ``medium`` branch, and handing it
+    one would fall through every arm of its ``if``/``elif`` chain. Those models
+    keep ``high``; the ones whose ladder has ``medium``, and the ones that
+    publish no ladder at all and so run on the default ``low|medium|high``, get
+    ``medium`` to match what the template would have chosen unprompted.
+    """
+    # No published ladder: the default low/medium/high applies, so medium is on it.
+    assert _shim([], architecture = None)._reasoning_kwargs(True) == {
+        "reasoning_effort": "medium",
+    }
+    # Published and contains medium.
+    assert _shim(["low", "medium", "high"], architecture = None)._reasoning_kwargs(True) == {
+        "reasoning_effort": "medium",
+    }
+    assert _shim(
+        ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        architecture = None,
+    )._reasoning_kwargs(True) == {"reasoning_effort": "medium"}
+    # Published without medium: stays on high, which is what it got before.
+    assert _shim(["low", "high"], architecture = None)._reasoning_kwargs(True) == {
+        "reasoning_effort": "high",
+    }
+    assert _shim(["low", "high", "max"], architecture = None)._reasoning_kwargs(True) == {
+        "reasoning_effort": "high",
+    }
+    # Thinking off is unchanged everywhere, and low is on every published ladder
+    # because detection only trusts a scan that holds both low and high.
+    for levels in ([], ["low", "medium", "high"], ["low", "high"], ["low", "high", "max"]):
+        assert _shim(levels, architecture = None)._reasoning_kwargs(False) == {
+            "reasoning_effort": "low",
+        }
+    # The inkling dial maps the chosen name, so it moves with the ladder too.
+    assert _shim([], architecture = "inkling")._reasoning_kwargs(True) == {
+        "reasoning_effort": 0.7,
+    }
+    assert _shim(["low", "high"], architecture = "inkling")._reasoning_kwargs(True) == {
+        "reasoning_effort": 0.9,
+    }
+    # The other styles never read the effort literal at all.
+    _et = _shim([], architecture = None)
+    _et._reasoning_style = "enable_thinking_effort"
+    assert _et._reasoning_kwargs(True) == {"enable_thinking": True}
+    _et._reasoning_style = "enable_thinking"
+    assert _et._reasoning_kwargs(False) == {"enable_thinking": False}

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -3953,7 +3953,10 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   reasoningAlwaysOn: false,
   reasoningEnabled: loadBool(CHAT_REASONING_ENABLED_KEY, true),
   reasoningStyle: "enable_thinking",
-  reasoningEffort: "medium",
+  // Matches the load-time --chat-template-kwargs default the backend passes to
+  // llama-server, so a chat here and a raw /v1/chat/completions call that omits
+  // reasoning_effort both get the same effort out of the same model.
+  reasoningEffort: "high",
   supportsReasoningOff: false,
   reasoningEffortLevels: ["low", "medium", "high"],
   lastOpenRouterChosenModel: null,

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -3953,10 +3953,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   reasoningAlwaysOn: false,
   reasoningEnabled: loadBool(CHAT_REASONING_ENABLED_KEY, true),
   reasoningStyle: "enable_thinking",
-  // Matches the load-time --chat-template-kwargs default the backend passes to
-  // llama-server, so a chat here and a raw /v1/chat/completions call that omits
-  // reasoning_effort both get the same effort out of the same model.
-  reasoningEffort: "high",
+  reasoningEffort: "medium",
   supportsReasoningOff: false,
   reasoningEffortLevels: ["low", "medium", "high"],
   lastOpenRouterChosenModel: null,


### PR DESCRIPTION
### The problem

When a `reasoning_effort` style model loads, `_reasoning_kwargs` builds `--chat-template-kwargs` and we pass it to llama-server. For thinking on that was `{"reasoning_effort": "high"}`. llama-server merges those kwargs per key a request omits, so a raw `/v1/chat/completions` call that sets no reasoning fields ran the model at high.

Nothing upstream defaults to high:

- the Harmony chat template hard codes the fallback: `{%- if reasoning_effort is not defined %}{%- set reasoning_effort = "medium" %}`, so omitting the key and sending medium are the same thing
- the `openai/harmony` library defaults to `ReasoningEffort::Medium`
- OpenAI's own reference CLI defaults to `low`
- our own gpt-oss guide documents medium as the default

So the high here was ours alone, and it made the same model reason harder through a raw API call than it does anywhere else.

### The fix

Pass medium instead. One literal.

### What this does and does not change

No effect on Studio chat. The frontend always sends an explicit `reasoning_effort` for `reasoning_effort` style models, since `reasoningEnabled` is forced true when the model advertises the style, so the load time kwarg is never what chat falls back on.

The only population this moves is raw `/v1/chat/completions` callers that omit the key, which is exactly the case the value exists for. They go from high to medium, which is what the model would have done on its own.

The thinking off path is untouched and still sends low. `enable_thinking` and `enable_thinking_effort` style models are untouched, since neither reads this key.

### On the earlier version of this PR

This started as the opposite change, defaulting the frontend store to high so chat matched the backend. I dropped that, for two reasons.

It aligned to the wrong value. And the store default is global rather than per family, so it reached further than gpt-oss: `mistral-small-latest` and `mistral-vibe-cli-latest` advertise `["none","high"]` and fall through to the store default rather than the per provider policy, so they would have gone from sending `reasoning_effort: "none"` to sending `"high"`, turning reasoning on by default on a paid provider. A local ladder of `["low","high","max"]` would have jumped two rungs as well.

The revert is kept in the history rather than force pushed, since Codex had already reviewed the first commit.

### Checks

Isolated `uv venv`, backend suites:

- `test_kimi_k3_reasoning_defaults`, `test_deepseek_v4_thinking_effort`, `test_qwen_thinking_size_gate`, `test_reasoning_effort_wide_ladder`, `test_provider_reasoning_normalization`, `test_ollama_reasoning_effort`, `test_chat_only_reason`: 91 passed, 5 skipped
- `test_llama_server_args`: 328 passed. Its `--chat-template-kwargs {"reasoning_effort":"high"}` case is a pass through allowlist input, not an assertion about this default
- `test_length_truncated_reasoning_continuation` and `test_openai_tool_passthrough`: 375 passed, 25 failed. The 25 are image normalization tests failing identically on the unmodified tree in this minimal venv, and no reasoning test fails either way

Frontend is untouched by the final diff.
