### PR TITLE
Studio: keep Switch Back visible for a snapshot-path chat

### DIFF
--- a/studio/frontend/src/features/chat/components/chat-model-notice-switch.ts
+++ b/studio/frontend/src/features/chat/components/chat-model-notice-switch.ts
@@ -7,8 +7,9 @@ import type {
 } from "@/features/model-picker/components/model-selector/types";
 import {
   ggufQuantLabel,
+  ggufVariantsMatch,
   normalizeGgufVariantIdentity,
-  publicModelId,
+  residentModelIdMatches,
 } from "../../model-picker/model-config/model-identity";
 import { resolveOnlyRememberedGgufVariant } from "../../model-picker/model-config/per-model-config";
 
@@ -17,7 +18,25 @@ export type ChatModelSwitchTarget = {
   ggufVariant?: string | null;
 };
 
-/** Exact picker id, or the namespaced HF-cache alias resolveResidentInitialConfig uses. */
+/** Snapshot path and repo id of the same HF cache row, either direction. */
+export function chatModelIsResident(
+  createdModel: ChatModelSwitchTarget,
+  checkpoint: string,
+  activeGgufVariant: string | null,
+): boolean {
+  const sameId =
+    residentModelIdMatches(checkpoint, createdModel.modelId) ||
+    residentModelIdMatches(createdModel.modelId, checkpoint);
+  if (!sameId) {
+    return false;
+  }
+  return (
+    createdModel.ggufVariant == null ||
+    ggufVariantsMatch(createdModel.ggufVariant, activeGgufVariant)
+  );
+}
+
+/** Exact picker id, or the same namespaced identity residentModelIdMatches uses. */
 export function chatModelIsSelectable(
   modelId: string,
   selectableModelIds: ReadonlySet<string>,
@@ -25,11 +44,15 @@ export function chatModelIsSelectable(
   if (selectableModelIds.has(modelId)) {
     return true;
   }
-  const alias = publicModelId(modelId);
-  if (alias === modelId || !alias.includes("/")) {
-    return false;
+  for (const id of selectableModelIds) {
+    if (
+      residentModelIdMatches(id, modelId) ||
+      residentModelIdMatches(modelId, id)
+    ) {
+      return true;
+    }
   }
-  return selectableModelIds.has(alias);
+  return false;
 }
 
 type ChatModelThreadSnapshot = {

--- a/studio/frontend/src/features/chat/components/chat-model-notice-switch.ts
+++ b/studio/frontend/src/features/chat/components/chat-model-notice-switch.ts
@@ -8,6 +8,7 @@ import type {
 import {
   ggufQuantLabel,
   normalizeGgufVariantIdentity,
+  publicModelId,
 } from "../../model-picker/model-config/model-identity";
 import { resolveOnlyRememberedGgufVariant } from "../../model-picker/model-config/per-model-config";
 
@@ -15,6 +16,21 @@ export type ChatModelSwitchTarget = {
   modelId: string;
   ggufVariant?: string | null;
 };
+
+/** Exact picker id, or the namespaced HF-cache alias resolveResidentInitialConfig uses. */
+export function chatModelIsSelectable(
+  modelId: string,
+  selectableModelIds: ReadonlySet<string>,
+): boolean {
+  if (selectableModelIds.has(modelId)) {
+    return true;
+  }
+  const alias = publicModelId(modelId);
+  if (alias === modelId || !alias.includes("/")) {
+    return false;
+  }
+  return selectableModelIds.has(alias);
+}
 
 type ChatModelThreadSnapshot = {
   id: string;

--- a/studio/frontend/src/features/chat/components/chat-model-notice-switch.ts
+++ b/studio/frontend/src/features/chat/components/chat-model-notice-switch.ts
@@ -3,6 +3,7 @@
 
 import {
   isHfCacheSnapshotPath,
+  isOllamaLinkPath,
   modelIdsMatch,
   publicModelId,
 } from "@/features/hub/lib/model-identity";
@@ -24,13 +25,18 @@ export type ChatModelSwitchTarget = {
   ggufVariant?: string | null;
 };
 
+function isExactOnlyIdentity(id: string): boolean {
+  return isExternalModelId(id) || isOllamaLinkPath(id);
+}
+
 function sameHfCacheIdentity(left: string, right: string): boolean {
   if (left === right) {
     return true;
   }
-  // Opaque `external::<provider>::<id>` values stay case-sensitive. Folding them
-  // through residentModelIdMatches would hide Switch Back across distinct models.
-  if (isExternalModelId(left) || isExternalModelId(right)) {
+  // Opaque `external::<provider>::<id>` and `ollama-manifest:` values stay
+  // case-sensitive. Folding them through residentModelIdMatches would hide
+  // Switch Back across distinct models.
+  if (isExactOnlyIdentity(left) || isExactOnlyIdentity(right)) {
     return false;
   }
   if (
@@ -64,7 +70,7 @@ export function chatModelIsResident(
 }
 
 /** The picker id Switch Back should load. Exact match first, then the live HF
- *  cache row that shares the same repo. External ids never alias. */
+ *  cache row that shares the same repo. External and Ollama ids never alias. */
 export function chatModelSelectableId(
   modelId: string,
   selectableModelIds: ReadonlySet<string>,
@@ -72,11 +78,11 @@ export function chatModelSelectableId(
   if (selectableModelIds.has(modelId)) {
     return modelId;
   }
-  if (isExternalModelId(modelId)) {
+  if (isExactOnlyIdentity(modelId)) {
     return null;
   }
   for (const id of selectableModelIds) {
-    if (isExternalModelId(id)) {
+    if (isExactOnlyIdentity(id)) {
       continue;
     }
     if (sameHfCacheIdentity(id, modelId)) {

--- a/studio/frontend/src/features/chat/components/chat-model-notice-switch.ts
+++ b/studio/frontend/src/features/chat/components/chat-model-notice-switch.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import {
+  isHfCacheSnapshotPath,
+  modelIdsMatch,
+  publicModelId,
+} from "@/features/hub/lib/model-identity";
 import type {
   LoraModelOption,
   ModelSelectorChangeMeta,
@@ -12,11 +17,36 @@ import {
   residentModelIdMatches,
 } from "../../model-picker/model-config/model-identity";
 import { resolveOnlyRememberedGgufVariant } from "../../model-picker/model-config/per-model-config";
+import { isExternalModelId } from "../external-providers";
 
 export type ChatModelSwitchTarget = {
   modelId: string;
   ggufVariant?: string | null;
 };
+
+function sameHfCacheIdentity(left: string, right: string): boolean {
+  if (left === right) {
+    return true;
+  }
+  // Opaque `external::<provider>::<id>` values stay case-sensitive. Folding them
+  // through residentModelIdMatches would hide Switch Back across distinct models.
+  if (isExternalModelId(left) || isExternalModelId(right)) {
+    return false;
+  }
+  if (
+    residentModelIdMatches(left, right) ||
+    residentModelIdMatches(right, left)
+  ) {
+    return true;
+  }
+  if (!(isHfCacheSnapshotPath(left) && isHfCacheSnapshotPath(right))) {
+    return false;
+  }
+  const leftRepo = publicModelId(left);
+  return (
+    leftRepo.includes("/") && modelIdsMatch(leftRepo, publicModelId(right))
+  );
+}
 
 /** Snapshot path and repo id of the same HF cache row, either direction. */
 export function chatModelIsResident(
@@ -24,10 +54,7 @@ export function chatModelIsResident(
   checkpoint: string,
   activeGgufVariant: string | null,
 ): boolean {
-  const sameId =
-    residentModelIdMatches(checkpoint, createdModel.modelId) ||
-    residentModelIdMatches(createdModel.modelId, checkpoint);
-  if (!sameId) {
+  if (!sameHfCacheIdentity(checkpoint, createdModel.modelId)) {
     return false;
   }
   return (
@@ -36,23 +63,34 @@ export function chatModelIsResident(
   );
 }
 
-/** Exact picker id, or the same namespaced identity residentModelIdMatches uses. */
+/** The picker id Switch Back should load. Exact match first, then the live HF
+ *  cache row that shares the same repo. External ids never alias. */
+export function chatModelSelectableId(
+  modelId: string,
+  selectableModelIds: ReadonlySet<string>,
+): string | null {
+  if (selectableModelIds.has(modelId)) {
+    return modelId;
+  }
+  if (isExternalModelId(modelId)) {
+    return null;
+  }
+  for (const id of selectableModelIds) {
+    if (isExternalModelId(id)) {
+      continue;
+    }
+    if (sameHfCacheIdentity(id, modelId)) {
+      return id;
+    }
+  }
+  return null;
+}
+
 export function chatModelIsSelectable(
   modelId: string,
   selectableModelIds: ReadonlySet<string>,
 ): boolean {
-  if (selectableModelIds.has(modelId)) {
-    return true;
-  }
-  for (const id of selectableModelIds) {
-    if (
-      residentModelIdMatches(id, modelId) ||
-      residentModelIdMatches(modelId, id)
-    ) {
-      return true;
-    }
-  }
-  return false;
+  return chatModelSelectableId(modelId, selectableModelIds) != null;
 }
 
 type ChatModelThreadSnapshot = {

--- a/studio/frontend/src/features/chat/components/chat-model-notice.tsx
+++ b/studio/frontend/src/features/chat/components/chat-model-notice.tsx
@@ -13,6 +13,7 @@ import { compareModelDisplayName } from "../lib/external-model-label";
 import { getStoredChatThread } from "../utils/chat-history-storage";
 import {
   type ChatModelSwitchTarget,
+  chatModelIsSelectable,
   createChatModelHistoryReader,
 } from "./chat-model-notice-switch";
 
@@ -82,7 +83,9 @@ export function ChatModelNotice({
   }
   // A model that has since been deleted, or a connection that is gone: the switch could not be
   // honoured, and saying so on every open is just noise.
-  if (!selectableModelIds.has(createdModel.modelId)) return null;
+  if (!chatModelIsSelectable(createdModel.modelId, selectableModelIds)) {
+    return null;
+  }
   const label = compareModelDisplayName(createdModel.modelId);
   return (
     // Positioned, not in flow. The chat header is `absolute ... z-40` with an opaque `bg-background`,

--- a/studio/frontend/src/features/chat/components/chat-model-notice.tsx
+++ b/studio/frontend/src/features/chat/components/chat-model-notice.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { publicModelId } from "@/features/hub/lib/model-identity";
 import {
   CHAT_HISTORY_UPDATED_EVENT,
   type ChatHistoryUpdatedDetail,
@@ -82,7 +83,7 @@ export function ChatModelNotice({
   if (!chatModelIsSelectable(createdModel.modelId, selectableModelIds)) {
     return null;
   }
-  const label = compareModelDisplayName(createdModel.modelId);
+  const label = compareModelDisplayName(publicModelId(createdModel.modelId));
   return (
     // Positioned, not in flow. The chat header is `absolute ... z-40` with an opaque `bg-background`,
     // so an in-flow sibling starts at y=0 UNDER it and the bar is invisible bar the 10px the

--- a/studio/frontend/src/features/chat/components/chat-model-notice.tsx
+++ b/studio/frontend/src/features/chat/components/chat-model-notice.tsx
@@ -4,17 +4,17 @@
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { publicModelId } from "@/features/hub/lib/model-identity";
+import { modelDisplayName } from "@/features/hub/lib/model-identity";
 import {
   CHAT_HISTORY_UPDATED_EVENT,
   type ChatHistoryUpdatedDetail,
 } from "../api/chat-api";
-import { compareModelDisplayName } from "../lib/external-model-label";
+import { externalModelLabel } from "../lib/external-model-label";
 import { getStoredChatThread } from "../utils/chat-history-storage";
 import {
   type ChatModelSwitchTarget,
   chatModelIsResident,
-  chatModelIsSelectable,
+  chatModelSelectableId,
   createChatModelHistoryReader,
 } from "./chat-model-notice-switch";
 
@@ -79,11 +79,22 @@ export function ChatModelNotice({
     return null;
   }
   // A model that has since been deleted, or a connection that is gone: the switch could not be
-  // honoured, and saying so on every open is just noise.
-  if (!chatModelIsSelectable(createdModel.modelId, selectableModelIds)) {
+  // honoured, and saying so on every open is just noise. When the saved snapshot is gone but
+  // the same repo is still in the picker, load that live row instead of the stale path.
+  const selectableId = chatModelSelectableId(
+    createdModel.modelId,
+    selectableModelIds,
+  );
+  if (!selectableId) {
     return null;
   }
-  const label = compareModelDisplayName(publicModelId(createdModel.modelId));
+  const switchTarget =
+    selectableId === createdModel.modelId
+      ? createdModel
+      : { ...createdModel, modelId: selectableId };
+  const label =
+    externalModelLabel(createdModel.modelId) ??
+    modelDisplayName(createdModel.modelId);
   return (
     // Positioned, not in flow. The chat header is `absolute ... z-40` with an opaque `bg-background`,
     // so an in-flow sibling starts at y=0 UNDER it and the bar is invisible bar the 10px the
@@ -100,7 +111,7 @@ export function ChatModelNotice({
         variant="ghost"
         size="sm"
         className="ml-auto h-6 shrink-0 px-2 text-ui-12"
-        onClick={() => onSwitch(createdModel)}
+        onClick={() => onSwitch(switchTarget)}
       >
         Switch back
       </Button>

--- a/studio/frontend/src/features/chat/components/chat-model-notice.tsx
+++ b/studio/frontend/src/features/chat/components/chat-model-notice.tsx
@@ -4,7 +4,6 @@
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { ggufVariantsMatch } from "@/features/hub";
 import {
   CHAT_HISTORY_UPDATED_EVENT,
   type ChatHistoryUpdatedDetail,
@@ -13,6 +12,7 @@ import { compareModelDisplayName } from "../lib/external-model-label";
 import { getStoredChatThread } from "../utils/chat-history-storage";
 import {
   type ChatModelSwitchTarget,
+  chatModelIsResident,
   chatModelIsSelectable,
   createChatModelHistoryReader,
 } from "./chat-model-notice-switch";
@@ -74,11 +74,7 @@ export function ChatModelNotice({
 }: ChatModelNoticeProps) {
   const createdModel = useChatCreatedModel(threadId);
   if (!createdModel) return null;
-  if (
-    createdModel.modelId === checkpoint &&
-    (createdModel.ggufVariant == null ||
-      ggufVariantsMatch(createdModel.ggufVariant, activeGgufVariant))
-  ) {
+  if (chatModelIsResident(createdModel, checkpoint, activeGgufVariant)) {
     return null;
   }
   // A model that has since been deleted, or a connection that is gone: the switch could not be

--- a/studio/frontend/tests/chat-remembers-its-model.test.ts
+++ b/studio/frontend/tests/chat-remembers-its-model.test.ts
@@ -21,6 +21,7 @@ const { store } = installLocalStorageFake();
 const {
   chatModelIsResident,
   chatModelIsSelectable,
+  chatModelSelectableId,
   chatModelSwitchMeta,
   createChatModelHistoryReader,
   resolveChatModelSwitchTarget,
@@ -28,7 +29,7 @@ const {
 const { compareModelDisplayName } = await import(
   "../src/features/chat/lib/external-model-label.ts"
 );
-const { publicModelId } = await import(
+const { modelDisplayName, publicModelId } = await import(
   "../src/features/hub/lib/model-identity.ts"
 );
 const { chatLocalModelOptions } = await import(
@@ -97,7 +98,7 @@ test("the notice never switches a model on its own", () => {
   // Opening a chat must not evict what is resident: a local load is multi-gigabyte.
   assert.doesNotMatch(notice, /loadModel|setCheckpoint/);
   // The only way out of it is the button.
-  assert.match(notice, /onClick=\{\(\) => onSwitch\(createdModel\)\}/);
+  assert.match(notice, /onClick=\{\(\) => onSwitch\(switchTarget\)\}/);
 });
 
 test("the notice stays quiet when it has nothing to offer", () => {
@@ -110,7 +111,7 @@ test("the notice stays quiet when it has nothing to offer", () => {
   );
   assert.match(
     body,
-    /chatModelIsSelectable\(\s*createdModel\.modelId,\s*selectableModelIds\s*\)/,
+    /chatModelSelectableId\(\s*createdModel\.modelId,\s*selectableModelIds,?\s*\)/,
   );
 });
 
@@ -200,6 +201,7 @@ test("a snapshot-path chat is selectable through its repo row", () => {
   const snapshotPath =
     "/home/u/.cache/huggingface/hub/models--unsloth--Repo-GGUF/snapshots/2f1c9ab";
   const repoId = "unsloth/Repo-GGUF";
+  assert.equal(chatModelSelectableId(snapshotPath, new Set([repoId])), repoId);
   assert.equal(
     chatModelIsSelectable(snapshotPath, new Set([repoId])),
     true,
@@ -213,6 +215,39 @@ test("a snapshot-path chat is selectable through its repo row", () => {
     chatModelIsSelectable("/srv/models/a/Repo-Q4_K_M.gguf", new Set(["Repo-Q4_K_M"])),
     false,
   );
+});
+
+test("Switch Back loads the live picker row when the saved snapshot is gone", () => {
+  const snapshotA =
+    "/home/u/.cache/huggingface/hub/models--unsloth--Repo-GGUF/snapshots/aaa1111";
+  const snapshotB =
+    "/home/u/.cache/huggingface/hub/models--unsloth--Repo-GGUF/snapshots/bbb2222";
+  const repoId = "unsloth/Repo-GGUF";
+  assert.equal(chatModelSelectableId(snapshotA, new Set([snapshotA])), snapshotA);
+  assert.equal(chatModelSelectableId(snapshotA, new Set([snapshotB])), snapshotB);
+  assert.equal(chatModelSelectableId(snapshotA, new Set([repoId])), repoId);
+  assert.equal(
+    chatModelIsResident({ modelId: snapshotA, ggufVariant: "Q4_K_M" }, snapshotB, "Q4_K_M"),
+    true,
+  );
+  assert.equal(
+    chatModelSelectableId(
+      snapshotA,
+      new Set([
+        "/home/u/.cache/huggingface/hub/models--unsloth--Other-GGUF/snapshots/ccc3333",
+      ]),
+    ),
+    null,
+  );
+});
+
+test("a case-distinct external id is not already resident", () => {
+  const upper = `external::vendor::${encodeURIComponent("Vendor/Qwen3.8-27B")}`;
+  const lower = `external::vendor::${encodeURIComponent("vendor/qwen3.8-27b")}`;
+  assert.equal(chatModelIsResident({ modelId: upper }, upper, null), true);
+  assert.equal(chatModelIsResident({ modelId: upper }, lower, null), false);
+  assert.equal(chatModelIsSelectable(upper, new Set([lower])), false);
+  assert.equal(chatModelIsSelectable(upper, new Set([upper])), true);
 });
 
 test("a snapshot-path chat is already on its repo-id checkpoint", () => {
@@ -241,15 +276,12 @@ test("a snapshot-path chat is labelled by its repo name, not the revision sha", 
   const snapshotPath =
     "/home/u/.cache/huggingface/hub/models--unsloth--Repo-GGUF/snapshots/2f1c9ab";
   assert.equal(compareModelDisplayName(snapshotPath), "2f1c9ab");
-  assert.equal(
-    compareModelDisplayName(publicModelId(snapshotPath)),
-    "Repo-GGUF",
-  );
+  assert.equal(publicModelId("org/model.gguf"), "model");
+  assert.equal(modelDisplayName(snapshotPath), "Repo-GGUF");
+  assert.equal(modelDisplayName("org/model.gguf"), "model.gguf");
   const body = notice.slice(notice.indexOf("export function ChatModelNotice"));
-  assert.match(
-    body,
-    /compareModelDisplayName\(\s*publicModelId\(\s*createdModel\.modelId\s*\)\s*\)/,
-  );
+  assert.match(body, /externalModelLabel\(createdModel\.modelId\)/);
+  assert.match(body, /modelDisplayName\(createdModel\.modelId\)/);
 });
 
 test("the notice clears the chat header instead of rendering underneath it", () => {

--- a/studio/frontend/tests/chat-remembers-its-model.test.ts
+++ b/studio/frontend/tests/chat-remembers-its-model.test.ts
@@ -25,6 +25,12 @@ const {
   createChatModelHistoryReader,
   resolveChatModelSwitchTarget,
 } = await import("../src/features/chat/components/chat-model-notice-switch.ts");
+const { compareModelDisplayName } = await import(
+  "../src/features/chat/lib/external-model-label.ts"
+);
+const { publicModelId } = await import(
+  "../src/features/hub/lib/model-identity.ts"
+);
 const { chatLocalModelOptions } = await import(
   "../src/features/chat/local-model-options.ts"
 );
@@ -228,6 +234,21 @@ test("a snapshot-path chat is already on its repo-id checkpoint", () => {
   assert.equal(
     chatModelIsResident(created, "unsloth/Other-GGUF", "Q4_K_M"),
     false,
+  );
+});
+
+test("a snapshot-path chat is labelled by its repo name, not the revision sha", () => {
+  const snapshotPath =
+    "/home/u/.cache/huggingface/hub/models--unsloth--Repo-GGUF/snapshots/2f1c9ab";
+  assert.equal(compareModelDisplayName(snapshotPath), "2f1c9ab");
+  assert.equal(
+    compareModelDisplayName(publicModelId(snapshotPath)),
+    "Repo-GGUF",
+  );
+  const body = notice.slice(notice.indexOf("export function ChatModelNotice"));
+  assert.match(
+    body,
+    /compareModelDisplayName\(\s*publicModelId\(\s*createdModel\.modelId\s*\)\s*\)/,
   );
 });
 

--- a/studio/frontend/tests/chat-remembers-its-model.test.ts
+++ b/studio/frontend/tests/chat-remembers-its-model.test.ts
@@ -19,6 +19,7 @@ import {
 registerBundlerResolver();
 const { store } = installLocalStorageFake();
 const {
+  chatModelIsResident,
   chatModelIsSelectable,
   chatModelSwitchMeta,
   createChatModelHistoryReader,
@@ -95,20 +96,15 @@ test("the notice never switches a model on its own", () => {
 
 test("the notice stays quiet when it has nothing to offer", () => {
   const body = notice.slice(notice.indexOf("export function ChatModelNotice"));
-  // no stamp, already on the exact pick, or a model that has since gone away
+  // no stamp, already on the pick (including snapshot vs repo id), or a model that has since gone away
   assert.match(body, /if \(!createdModel\) return null;/);
-  assert.match(body, /createdModel\.modelId === checkpoint/);
   assert.match(
     body,
-    /ggufVariantsMatch\(createdModel\.ggufVariant, activeGgufVariant\)/,
+    /chatModelIsResident\(createdModel, checkpoint, activeGgufVariant\)/,
   );
   assert.match(
     body,
     /chatModelIsSelectable\(\s*createdModel\.modelId,\s*selectableModelIds\s*\)/,
-  );
-  assert.doesNotMatch(
-    body,
-    /selectableModelIds\.has\(createdModel\.modelId\)/,
   );
 });
 
@@ -209,6 +205,28 @@ test("a snapshot-path chat is selectable through its repo row", () => {
   assert.equal(chatModelIsSelectable(repoId, new Set([repoId])), true);
   assert.equal(
     chatModelIsSelectable("/srv/models/a/Repo-Q4_K_M.gguf", new Set(["Repo-Q4_K_M"])),
+    false,
+  );
+});
+
+test("a snapshot-path chat is already on its repo-id checkpoint", () => {
+  const snapshotPath =
+    "/home/u/.cache/huggingface/hub/models--unsloth--Repo-GGUF/snapshots/2f1c9ab";
+  const repoId = "unsloth/Repo-GGUF";
+  const created = { modelId: snapshotPath, ggufVariant: "Q4_K_M" };
+  assert.equal(chatModelIsResident(created, repoId, "Q4_K_M"), true);
+  assert.equal(chatModelIsResident(created, snapshotPath, "Q4_K_M"), true);
+  assert.equal(
+    chatModelIsResident(
+      { modelId: repoId, ggufVariant: "Q4_K_M" },
+      snapshotPath,
+      "Q4_K_M",
+    ),
+    true,
+  );
+  assert.equal(chatModelIsResident(created, repoId, "Q8_0"), false);
+  assert.equal(
+    chatModelIsResident(created, "unsloth/Other-GGUF", "Q4_K_M"),
     false,
   );
 });

--- a/studio/frontend/tests/chat-remembers-its-model.test.ts
+++ b/studio/frontend/tests/chat-remembers-its-model.test.ts
@@ -250,6 +250,19 @@ test("a case-distinct external id is not already resident", () => {
   assert.equal(chatModelIsSelectable(upper, new Set([upper])), true);
 });
 
+test("a case-distinct ollama-manifest id is not already resident", () => {
+  const upper = `ollama-manifest:${encodeURIComponent(
+    "/home/u/.ollama/manifests/Llama",
+  )}`;
+  const lower = `ollama-manifest:${encodeURIComponent(
+    "/home/u/.ollama/manifests/llama",
+  )}`;
+  assert.equal(chatModelIsResident({ modelId: upper }, upper, null), true);
+  assert.equal(chatModelIsResident({ modelId: upper }, lower, null), false);
+  assert.equal(chatModelIsSelectable(upper, new Set([lower])), false);
+  assert.equal(chatModelIsSelectable(upper, new Set([upper])), true);
+});
+
 test("a snapshot-path chat is already on its repo-id checkpoint", () => {
   const snapshotPath =
     "/home/u/.cache/huggingface/hub/models--unsloth--Repo-GGUF/snapshots/2f1c9ab";

--- a/studio/frontend/tests/chat-remembers-its-model.test.ts
+++ b/studio/frontend/tests/chat-remembers-its-model.test.ts
@@ -19,6 +19,7 @@ import {
 registerBundlerResolver();
 const { store } = installLocalStorageFake();
 const {
+  chatModelIsSelectable,
   chatModelSwitchMeta,
   createChatModelHistoryReader,
   resolveChatModelSwitchTarget,
@@ -103,7 +104,11 @@ test("the notice stays quiet when it has nothing to offer", () => {
   );
   assert.match(
     body,
-    /if \(!selectableModelIds\.has\(createdModel\.modelId\)\) return null;/,
+    /chatModelIsSelectable\(\s*createdModel\.modelId,\s*selectableModelIds\s*\)/,
+  );
+  assert.doesNotMatch(
+    body,
+    /selectableModelIds\.has\(createdModel\.modelId\)/,
   );
 });
 
@@ -187,6 +192,25 @@ test("only models that can actually be selected are offered", () => {
       `${source} is missing from the selectable set`,
     );
   }
+});
+
+test("a snapshot-path chat is selectable through its repo row", () => {
+  const snapshotPath =
+    "/home/u/.cache/huggingface/hub/models--unsloth--Repo-GGUF/snapshots/2f1c9ab";
+  const repoId = "unsloth/Repo-GGUF";
+  assert.equal(
+    chatModelIsSelectable(snapshotPath, new Set([repoId])),
+    true,
+  );
+  assert.equal(
+    chatModelIsSelectable(snapshotPath, new Set(["unsloth/Other-GGUF"])),
+    false,
+  );
+  assert.equal(chatModelIsSelectable(repoId, new Set([repoId])), true);
+  assert.equal(
+    chatModelIsSelectable("/srv/models/a/Repo-Q4_K_M.gguf", new Set(["Repo-Q4_K_M"])),
+    false,
+  );
 });
 
 test("the notice clears the chat header instead of rendering underneath it", () => {


### PR DESCRIPTION
After #10447 (#10338), ChatModelNotice still gated Switch Back on selectableModelIds.has(createdModel.modelId), so a thread stamped with an HF cache snapshot path never matched its repo row.

The selectable gate and the already-on-this-model check now share the HF cache identity rule (snapshot path, repo id, or a later snapshot of the same repo). Exact picker ids are checked first. Switch Back loads the live picker id, not a deleted snapshot path. Opaque external::<provider>::<id> and ollama-manifest: values stay case-sensitive and do not alias. The bar now labels the model the way the picker does (modelDisplayName), so an OpenRouter id shows its org prefix and a local GGUF path drops .gguf.

`cd studio/frontend && node --experimental-strip-types --test tests/chat-remembers-its-model.test.ts`: 32 pass. Reverting chat-model-notice-switch.ts to eddf86013: 1 fail. Not run: a live Studio Switch Back session.

Refs #10338
