### PR TITLE
Make the formatter refuse a ruff it is not pinned to, and re-format the four files that drifted

### DIFF
--- a/scripts/run_ruff_format.py
+++ b/scripts/run_ruff_format.py
@@ -5,17 +5,83 @@ string-merge post-pass."""
 
 from __future__ import annotations
 
+import os
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
+CONFIG = HERE.parent / ".pre-commit-config.yaml"
+# Set to run against whatever ruff is installed. For a one-off experiment; a commit
+# made under it will be reformatted by the hook and fail pre-commit.
+ANY_VERSION_ENV = "UNSLOTH_RUFF_FORMAT_ANY_VERSION"
+
+# `- ruff==0.6.9` under the hook's additional_dependencies. Read out of the config
+# rather than copied here, because a second copy of the pin is a second thing to
+# forget; a regex rather than yaml.safe_load because this hook installs ruff and
+# nothing else, and adding PyYAML to run a version check would be the tail wagging
+# the dog.
+_PIN_RE = re.compile(r"^\s*-\s*ruff\s*==\s*([0-9][^\s#]*)\s*(?:#.*)?$", re.MULTILINE)
+_VERSION_RE = re.compile(r"^ruff\s+([0-9][^\s]*)")
+
+
+def pinned_ruff_version(config_text: str) -> str | None:
+    """The ruff this repo's formatting was produced with, or None if unpinned."""
+    found = {match.group(1) for match in _PIN_RE.finditer(config_text)}
+    # Two different pins is not a question this script can answer, and guessing
+    # would enforce the wrong one.
+    return found.pop() if len(found) == 1 else None
+
+
+def installed_ruff_version(python: str = sys.executable) -> str | None:
+    """The ruff the format below would actually run, or None when it cannot say."""
+    try:
+        out = subprocess.run(
+            [python, "-m", "ruff", "--version"], capture_output = True, text = True, timeout = 60
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    match = _VERSION_RE.match(out.stdout.strip())
+    return match.group(1) if match else None
+
+
+def version_mismatch(pinned: str | None, installed: str | None) -> bool:
+    """Whether running this ruff would produce formatting the hook then undoes.
+
+    An unreadable pin or an unreadable ruff is not a mismatch: the format below
+    fails loudly enough on its own, and refusing on a question we could not ask
+    would break the hook wherever the config moves.
+    """
+    return bool(pinned and installed and pinned != installed)
 
 
 def main(argv: list[str]) -> int:
     files = [arg for arg in argv if Path(arg).exists()]
     if not files:
         return 0
+
+    # Checked before anything is rewritten. ruff's own formatting is not stable
+    # across releases -- 0.9 changed which half of an `assert cond, "msg"` gets
+    # wrapped -- so running this with a newer ruff silently produces a style the
+    # pinned hook reformats back, and the commit fails pre-commit on files that
+    # are otherwise correct. It reached main twice before this check existed.
+    pinned = pinned_ruff_version(CONFIG.read_text(encoding = "utf-8")) if CONFIG.exists() else None
+    installed = installed_ruff_version()
+    if version_mismatch(pinned, installed) and not os.environ.get(ANY_VERSION_ENV):
+        print(
+            f"run_ruff_format: this would run ruff {installed}, but the repo is formatted "
+            f"with ruff {pinned} ({CONFIG.name}).\n"
+            f"  Their output differs, so the hook would undo this run and pre-commit would "
+            f"fail on files you did not break.\n"
+            f"  Fix: pip install ruff=={pinned}, or run the hook itself "
+            f"(pre-commit run ruff-format-with-kwargs --files ...).\n"
+            f"  Override with {ANY_VERSION_ENV}=1 if you really mean it.",
+            file = sys.stderr,
+        )
+        return 1
 
     spacing_script = HERE / "enforce_kwargs_spacing.py"
 

--- a/studio/backend/tests/test_password_prompt_backstop.py
+++ b/studio/backend/tests/test_password_prompt_backstop.py
@@ -583,8 +583,8 @@ class _FdStream(_Stream):
 @pytest.mark.skipif(
     os.name == "nt",
     reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
-             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
-             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+    "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+    "which test_windows_has_no_terminal_ownership_to_lose pins.",
 )
 def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
     """`unsloth studio -H 0.0.0.0 &` must still launch.
@@ -611,8 +611,8 @@ def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
 @pytest.mark.skipif(
     os.name == "nt",
     reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
-             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
-             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+    "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+    "which test_windows_has_no_terminal_ownership_to_lose pins.",
 )
 def test_a_backgrounded_tunnel_launch_still_fails_closed(monkeypatch):
     """A tunnel publishes a public URL: it must not quietly proceed unprompted."""
@@ -632,8 +632,8 @@ def test_a_backgrounded_tunnel_launch_still_fails_closed(monkeypatch):
 @pytest.mark.skipif(
     os.name == "nt",
     reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
-             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
-             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+    "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+    "which test_windows_has_no_terminal_ownership_to_lose pins.",
 )
 def test_a_foreground_raw_bind_still_reaches_the_prompt(monkeypatch):
     """The ordinary interactive case is untouched."""
@@ -681,8 +681,8 @@ class _PtyStdin:
 @pytest.mark.skipif(
     os.name == "nt",
     reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
-             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
-             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+    "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+    "which test_windows_has_no_terminal_ownership_to_lose pins.",
 )
 def test_an_unattended_pty_does_not_block_a_raw_bind_forever(monkeypatch):
     """`tmux new -d 'unsloth studio -H 0.0.0.0'` must still bind its socket.
@@ -718,8 +718,8 @@ def test_an_unattended_pty_does_not_block_a_raw_bind_forever(monkeypatch):
 @pytest.mark.skipif(
     os.name == "nt",
     reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
-             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
-             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+    "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+    "which test_windows_has_no_terminal_ownership_to_lose pins.",
 )
 def test_a_pty_someone_types_into_is_not_treated_as_unattended(monkeypatch):
     """The deadline is on the FIRST keystroke only, and a real one clears it."""

--- a/tests/studio/install/test_docker_studio_keep_cuda_prebuilt.py
+++ b/tests/studio/install/test_docker_studio_keep_cuda_prebuilt.py
@@ -459,9 +459,9 @@ def test_setup_sh_keeps_the_bundle_instead_of_installing_a_prebuilt():
     )
     assert "_LLAMA_KEEP_PREBUILT_ACTIVE=true" in text
     call = text[keep : text.index("\n", keep)]
-    assert "${UNSLOTH_LLAMA_RELEASE_TAG:-}" in call, (
-        "an explicit published release pin must reach the keep decision"
-    )
+    assert (
+        "${UNSLOTH_LLAMA_RELEASE_TAG:-}" in call
+    ), "an explicit published release pin must reach the keep decision"
 
 
 def test_the_arm64_cpu_last_resort_cannot_undo_a_kept_bundle():

--- a/tests/test_run_ruff_format_pin.py
+++ b/tests/test_run_ruff_format_pin.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""The formatter must run the ruff the repo is formatted with, or refuse.
+
+ruff's output is not stable across releases: 0.9 changed which half of an
+`assert cond, "msg"` gets wrapped. So a contributor whose environment has a newer
+ruff than `.pre-commit-config.yaml` pins produces files the hook reformats back,
+and pre-commit.ci fails the PR on files nobody broke -- which is how four files
+reached main in that state, and how two PRs went red without a code defect
+between them.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = str(_ROOT / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+from run_ruff_format import (  # noqa: E402
+    ANY_VERSION_ENV,
+    CONFIG,
+    installed_ruff_version,
+    main,
+    pinned_ruff_version,
+    version_mismatch,
+)
+
+
+class TestReadingThePin:
+    def test_the_repo_pins_a_ruff_and_it_is_readable(self):
+        # The pin is the contract this whole check rests on. If the hook stops
+        # naming a version, or names it another way, this is where that shows up.
+        assert CONFIG.exists()
+        assert pinned_ruff_version(CONFIG.read_text(encoding = "utf-8"))
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("        additional_dependencies:\n          - ruff==0.6.9\n", "0.6.9"),
+            ("  - ruff == 0.6.9\n", "0.6.9"),
+            ("  - ruff==0.6.9  # keep in step with the formatter\n", "0.6.9"),
+            ("  - ruff==0.12.0rc1\n", "0.12.0rc1"),
+        ],
+    )
+    def test_the_spellings_a_config_may_use(self, text, expected):
+        assert pinned_ruff_version(text) == expected
+
+    def test_no_pin_is_not_a_mismatch(self):
+        # An unpinned hook is a different problem, and refusing to format would be
+        # the wrong answer to it.
+        assert pinned_ruff_version("repos:\n  - repo: local\n") is None
+        assert version_mismatch(None, "0.16.6") is False
+
+    def test_two_different_pins_answer_nothing(self):
+        # Which one would we enforce? Neither: say nothing rather than guess.
+        assert pinned_ruff_version("  - ruff==0.6.9\n  - ruff==0.9.0\n") is None
+
+    def test_the_same_pin_twice_is_still_one_answer(self):
+        assert pinned_ruff_version("  - ruff==0.6.9\n  - ruff==0.6.9\n") == "0.6.9"
+
+
+class TestTheMismatchRule:
+    def test_a_newer_ruff_is_a_mismatch(self):
+        assert version_mismatch("0.6.9", "0.16.6") is True
+
+    def test_the_pinned_ruff_is_not(self):
+        assert version_mismatch("0.6.9", "0.6.9") is False
+
+    def test_an_unreadable_ruff_is_not(self):
+        # `python -m ruff --version` failing means the format below fails too, and
+        # loudly. Refusing here would only replace one error with a worse one.
+        assert version_mismatch("0.6.9", None) is False
+
+
+class TestRefusing:
+    @staticmethod
+    def _fake_ruff(tmp_path: Path, version: str) -> str:
+        """A python whose `-m ruff --version` answers `version` and formats nothing."""
+        pkg = tmp_path / "ruff"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "__main__.py").write_text(
+            f"import sys\nprint('ruff {version}')\nsys.exit(0)\n",
+            encoding = "utf-8",
+        )
+        shim = tmp_path / "python_shim.py"
+        shim.write_text(
+            "import runpy, sys\n"
+            f"sys.path.insert(0, {str(tmp_path)!r})\n"
+            "runpy.run_module('ruff', run_name='__main__')\n",
+            encoding = "utf-8",
+        )
+        return str(shim)
+
+    def test_a_mismatched_ruff_is_reported_by_version(self, tmp_path):
+        # The message has to name both versions: "reformatted by the hook" on its
+        # own sends people looking for a defect in their diff.
+        shim = self._fake_ruff(tmp_path, "9.9.9")
+        assert installed_ruff_version(sys.executable) != "9.9.9"
+        out = subprocess.run([sys.executable, shim], capture_output = True, text = True, timeout = 60)
+        assert "ruff 9.9.9" in out.stdout
+
+    def test_it_refuses_before_touching_a_file(self, tmp_path, monkeypatch):
+        # The refusal must come first. A run that rewrites half the argument list
+        # and then declines is worse than either outcome.
+        target = tmp_path / "sample.py"
+        original = "x = f(a = 1)\n"
+        target.write_text(original, encoding = "utf-8")
+        monkeypatch.setattr("run_ruff_format.installed_ruff_version", lambda *a, **k: "9.9.9")
+        monkeypatch.delenv(ANY_VERSION_ENV, raising = False)
+        assert main([str(target)]) == 1
+        assert target.read_text(encoding = "utf-8") == original
+
+    def test_the_override_lets_it_through(self, tmp_path, monkeypatch):
+        # An escape hatch, because a pin bump has to be runnable before it is merged.
+        target = tmp_path / "sample.py"
+        target.write_text("x = f(a=1)\n", encoding = "utf-8")
+        monkeypatch.setattr("run_ruff_format.installed_ruff_version", lambda *a, **k: "9.9.9")
+        monkeypatch.setenv(ANY_VERSION_ENV, "1")
+        assert main([str(target)]) == 0
+        # And it really ran: the post-pass is what puts the spaces in.
+        assert target.read_text(encoding = "utf-8") == "x = f(a = 1)\n"
+
+    def test_no_files_is_still_a_no_op(self, monkeypatch):
+        # pre-commit calls with the changed files; an unrelated commit passes none,
+        # and must not be failed for a version it never used.
+        monkeypatch.setattr("run_ruff_format.installed_ruff_version", lambda *a, **k: "9.9.9")
+        assert main([]) == 0

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1201,7 +1201,6 @@ def _bind_is_wildcard(host: str) -> bool:
     is not a new cost here.
     """
     from unsloth_cli._tool_policy import is_wildcard_host
-
     return is_wildcard_host(host)
 
 

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -44,8 +44,9 @@ def _no_leaked_unattended_marker(monkeypatch):
     later test and silently suppresses the prompt they assert on.
     """
     import unsloth_cli.commands.studio as studio_mod
-
     monkeypatch.delenv(studio_mod._UNATTENDED_PROMPT_DONE_ENV, raising = False)
+
+
 _NEW_PW = "brand-new-password"
 
 
@@ -1925,8 +1926,8 @@ def test_a_backgrounded_raw_bind_does_not_prompt(monkeypatch):
 @pytest.mark.skipif(
     os.name == "nt",
     reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
-             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
-             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+    "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+    "which test_windows_has_no_terminal_ownership_to_lose pins.",
 )
 def test_a_foreground_raw_bind_still_prompts(monkeypatch):
     """The ordinary interactive case is untouched."""
@@ -2050,8 +2051,8 @@ def test_a_raw_bind_prompt_carries_the_unattended_deadline(monkeypatch, tmp_path
 @pytest.mark.skipif(
     os.name == "nt",
     reason = "POSIX terminal semantics: Windows has no process groups, no SIGTTOU and no pty, "
-             "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
-             "which test_windows_has_no_terminal_ownership_to_lose pins.",
+    "so there is nothing here to assert. _prompt_owns_the_terminal fails open there, "
+    "which test_windows_has_no_terminal_ownership_to_lose pins.",
 )
 def test_read_masked_gives_up_on_a_pty_nobody_types_into(monkeypatch):
     """The mechanism itself, against a real pty with no writer."""
@@ -2179,7 +2180,11 @@ def test_a_second_cli_gate_does_not_re_wait_the_same_dead_terminal(monkeypatch, 
     studio_mod = _studio()
     calls = []
 
-    def _fake_prompt(verify_current, out = None, **kw):
+    def _fake_prompt(
+        verify_current,
+        out = None,
+        **kw,
+    ):
         calls.append(kw)
         raise studio_mod._password_prompt.PromptUnattended
 
@@ -2192,6 +2197,7 @@ def test_a_second_cli_gate_does_not_re_wait_the_same_dead_terminal(monkeypatch, 
     _invoke_studio_default(monkeypatch, events, ["-H", "0.0.0.0"])
     assert len(calls) == 1
     import os as _os
+
     assert _os.environ.get(studio_mod._UNATTENDED_PROMPT_DONE_ENV) == "1"
 
     # Child, after the re-exec: same terminal, must not sit on it again.
@@ -2205,7 +2211,11 @@ def test_the_mark_never_lets_a_tunnel_skip_its_prompt(monkeypatch, tmp_path):
     studio_mod = _studio()
     calls = []
 
-    def _fake_prompt(verify_current, out = None, **kw):
+    def _fake_prompt(
+        verify_current,
+        out = None,
+        **kw,
+    ):
         calls.append(kw)
         return _NEW_PW
 
@@ -2230,7 +2240,11 @@ def _banner(monkeypatch, tmp_path, args):
     studio_mod = _studio()
     _os.environ.pop(studio_mod._UNATTENDED_PROMPT_DONE_ENV, None)
 
-    def _fake_prompt(verify_current, out = None, **kw):
+    def _fake_prompt(
+        verify_current,
+        out = None,
+        **kw,
+    ):
         raise KeyboardInterrupt
 
     events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
@@ -2241,9 +2255,7 @@ def _banner(monkeypatch, tmp_path, args):
     return (result.output or "") + (getattr(result, "stderr", "") or "")
 
 
-def test_the_banner_does_not_promise_an_abort_a_raw_bind_will_not_perform(
-    monkeypatch, tmp_path,
-):
+def test_the_banner_does_not_promise_an_abort_a_raw_bind_will_not_perform(monkeypatch, tmp_path):
     """`Ctrl+C to abort` is true for a tunnel and false for a raw bind.
 
     On a raw bind the interrupt declines the prompt and the launch continues by


### PR DESCRIPTION
main is currently red under its own formatting hook. `pre-commit run --all-files`
reformats four files nobody is touching, so every open PR fails
`ruff-format-with-kwargs` with "files were modified by this hook" and a diff that
has nothing to do with it. #10494 is one; there will be more.

## Why the drift happens

`scripts/run_ruff_format.py` runs `sys.executable -m ruff`, which under
pre-commit is the pinned `ruff==0.6.9` and on a contributor's machine is whatever
they have. ruff's formatting is not stable across releases -- 0.9 moved the
wrapping in `assert cond, "msg"` from the condition to the message -- so a file
written under a newer ruff is committed in a style the hook reformats back, and
the hook then fails on it forever. The linter hook beside it is on v0.15.18 and
autoupdates, which makes a modern ruff the natural thing to have installed.

Nothing catches it locally: the file looks formatted, `ruff format --check`
agrees (with the newer ruff), and the failure only appears on pre-commit.ci.

## The change

`run_ruff_format.py` reads the pin out of `.pre-commit-config.yaml` and refuses,
before rewriting anything, when the ruff it would run is a different version. The
message names both versions and how to fix it, since "files were modified by this
hook" sends people looking for a defect in their own diff.
`UNSLOTH_RUFF_FORMAT_ANY_VERSION=1` overrides it, which a pin bump needs.

The pin is read rather than copied, so there is no second thing to forget; an
unreadable pin or an unreadable ruff is not a mismatch, because the format step
below already fails loudly on its own.

## The four files

Re-formatted with the pinned 0.6.9, no other change: the assert wrapping in
`test_docker_studio_keep_cuda_prebuilt.py`, `test_password_prompt_backstop.py`
and `test_studio_password_prompt.py`, and the blank line after a short local
import in `unsloth_cli/commands/studio.py`, which is the repo's own rule from
#6079.

Not a pin bump: moving to 0.16 reformats 1062 files and would conflict with every
open PR. That is worth doing deliberately, on a quiet branch, not as a side
effect of unblocking CI.

15 new tests, and the existing kwarg-spacing suite still passes (77 total).