### PR TITLE
Tests: let the xFormers pin guards hold on both main and pip

### DIFF
--- a/tests/python/test_windows_xformers_wheel_match.py
+++ b/tests/python/test_windows_xformers_wheel_match.py
@@ -14,6 +14,13 @@ These tests pin the two halves of the fix that live in pyproject.toml:
     to a win_amd64 wheel from the MATCHING CUDA index, and
   * the CUDA-agnostic ``windows`` extra can no longer float onto an arbitrary
     xFormers release.
+
+The first half has two legal spellings. main pins the wheel by URL, which names the
+index outright. The ``pip`` branch is what gets uploaded to PyPI, and PyPI rejects a
+direct reference in ``Requires-Dist``, so there it is a ``==`` pin on the same version
+with the index supplied by ``--index-url`` at install time. The version and the Windows
+marker are what both forms have to agree on, and that is what is asserted; only the URL
+form can additionally be checked for the index it came from.
 """
 
 from __future__ import annotations
@@ -68,8 +75,8 @@ def _extras() -> dict[str, list[str]]:
     return tomllib.loads(PYPROJECT.read_text(encoding = "utf-8"))["project"]["optional-dependencies"]
 
 
-def _windows_xformers_urls(deps: list[str]) -> list[str]:
-    """Every xformers direct-URL dep in ``deps`` whose marker holds on Windows x64."""
+def _windows_xformers(deps: list[str]) -> list[str]:
+    """Every xformers dep in ``deps``, URL or version pin, whose marker holds on Win x64."""
     markers = pytest.importorskip("packaging.markers")
     env = {
         "sys_platform": "win32",
@@ -81,15 +88,16 @@ def _windows_xformers_urls(deps: list[str]) -> list[str]:
         "implementation_name": "cpython",
         "platform_python_implementation": "CPython",
     }
-    urls: list[str] = []
+    found: list[str] = []
     for dep in deps:
         spec, _, marker_text = dep.partition(";")
-        if "xformers @ " not in spec:
+        spec = spec.strip()
+        if not spec.startswith("xformers"):
             continue
         if marker_text.strip() and not markers.Marker(marker_text.strip()).evaluate(env):
             continue
-        urls.append(spec.split("@", 1)[1].strip())
-    return urls
+        found.append(spec)
+    return found
 
 
 @pytest.mark.parametrize(("family", "torch_tag"), sorted(XFORMERS_WHEEL_MATRIX))
@@ -97,14 +105,23 @@ def test_windows_resolves_a_cuda_matched_wheel(family: str, torch_tag: str):
     """`unsloth[cu128-torch2100]` / `unsloth[cu130-torch2100]` and friends must land on
     a win_amd64 wheel served by their OWN CUDA index -- never PyPI, never a neighbour's."""
     version = XFORMERS_WHEEL_MATRIX[(family, torch_tag)]
-    deps = _extras()[f"{family}onlytorch{torch_tag}"]
-    urls = _windows_xformers_urls(deps)
+    extra = f"{family}onlytorch{torch_tag}"
+    specs = _windows_xformers(_extras()[extra])
 
-    assert len(urls) == 1, (
-        f"{family}onlytorch{torch_tag} must resolve exactly one xformers wheel on "
-        f"Windows, got {urls}"
+    assert len(specs) == 1, (
+        f"{extra} must resolve exactly one xformers wheel on Windows, got {specs}"
     )
-    assert urls[0] == (f"{WHEEL_INDEX_BASE}/{family}/xformers-{version}-cp39-abi3-win_amd64.whl")
+    spec = specs[0]
+    if "@" in spec:
+        url = spec.split("@", 1)[1].strip()
+        assert url == f"{WHEEL_INDEX_BASE}/{family}/xformers-{version}-cp39-abi3-win_amd64.whl"
+    else:
+        # Version-pin form: the index is the install-time --index-url, so the version is
+        # the only half of the pairing this branch can carry. It still has to be the
+        # version that index publishes for this torch, which is what the matrix holds.
+        assert spec == f"xformers=={version}", (
+            f"{extra} must pin the {family} wheel version for torch {torch_tag}, got {spec!r}"
+        )
 
 
 @pytest.mark.parametrize(("family", "torch_tag"), sorted(XFORMERS_WHEEL_MATRIX))

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2292,6 +2292,17 @@ def _audited_requirements(root):
 # added at all, fails rather than silently widening the exemption.
 FIRST_PARTY_DIGEST_PINNED = {"unsloth-zoo"}
 
+# The `pip` branch is the one uploaded to PyPI, and its `[project].dependencies` carries
+# the whole training runtime rather than just the CLI entry path main declares there.
+# torch comes with it, and it has to stay a range: an exact pin in published wheel
+# metadata would put every `pip install unsloth` on one torch build, which is what the
+# cuXXX-torchYYY extras exist to choose instead. Digest pinning still does its job -- the
+# audit reopens on any byte change -- it just cannot name the version ahead of time, so
+# the bound is what gets asserted. Named, not skipped, and only for the pyproject half:
+# the studio requirement files pin exactly and are held to that. On main, where torch is
+# not declared in pyproject at all, this allowance never fires.
+PYPROJECT_BOUNDED_RANGE_ALLOWED = {"torch"}
+
 
 def test_digest_pinned_packages_are_pinned_on_every_supported_python():
     """A digest-pinned third-party package must be `==` pinned on every Python we support.
@@ -2358,6 +2369,17 @@ def test_digest_pinned_packages_are_pinned_on_every_supported_python():
             continue
         present.add(pkg)
         specifiers = list(requirement.specifier)
+        if source == "pyproject.toml" and pkg in PYPROJECT_BOUNDED_RANGE_ALLOWED:
+            operators = {s.operator for s in specifiers}
+            assert operators & {">=", ">"} and operators & {"<=", "<"}, (
+                f"{pkg} is allowed a range in pyproject.toml, but only a bounded one: an "
+                f"open-ended spec resolves to whatever ships next; got {spec!r}"
+            )
+            marker = requirement.marker
+            for python in pythons:
+                if marker is None or marker.evaluate({"python_version": python}):
+                    covered.setdefault(pkg, set()).add(python)
+            continue
         exact = (
             len(specifiers) == 1
             and specifiers[0].operator == "=="

--- a/tests/test_torch2110_cuda_extras.py
+++ b/tests/test_torch2110_cuda_extras.py
@@ -17,6 +17,12 @@
 """Regression guard: the CUDA torch2110 / torch212x extras must pin the torch trio to the
 matching +cuXXX local build (xformers 0.0.35 does not pin torch), else resolution walks
 torch up to a release the xformers wheel was not built for. Parses files only, no network.
+
+The ``pip`` branch is what gets uploaded to PyPI, and PyPI rejects PEP 508 direct
+references in ``Requires-Dist``, so the xformers wheels main pins by URL are carried
+there as a plain ``==`` pin gated on the platforms those wheels exist for. The xformers
+checks therefore accept either shape, so this file reads the same on both branches. The
+torch trio is asserted identically either way, since that is what this guard is about.
 """
 
 from __future__ import annotations
@@ -61,6 +67,39 @@ def _reqs(specs: list[str]) -> dict[str, list[Requirement]]:
     return out
 
 
+def _assert_xformers_035(xformers: list[Requirement], cuda: str, extra: str) -> None:
+    """0.0.35 on the {cuda} index, reachable on Linux and Windows x86-64 and nowhere else.
+
+    Two spellings are legal. main pins the two wheels by URL, one per platform. This
+    branch pins the version and merges the two markers into one, because a direct
+    reference cannot go to PyPI. Either way the version has to be 0.0.35, the marker has
+    to admit Linux x86-64 and Windows AMD64, and it has to skip Linux aarch64 and Windows
+    ARM64, which have no wheel.
+    """
+    urls = [r for r in xformers if r.url]
+    if urls:
+        linux = [r for r in urls if r.url.endswith("manylinux_2_28_x86_64.whl")]
+        windows = [r for r in urls if r.url.endswith("win_amd64.whl")]
+        assert len(linux) == 1 and len(windows) == 1, f"{extra}: unexpected wheels {xformers}"
+        for r in linux + windows:
+            assert f"/whl/{cuda}/xformers-0.0.35-" in r.url, (
+                f"{extra}: xformers not on the {cuda} index: {r.url}"
+            )
+    else:
+        (req,) = xformers
+        assert str(req.specifier) == "==0.0.35", (
+            f"{extra}: xformers pinned as '{req.specifier}', expected ==0.0.35"
+        )
+        linux = windows = xformers
+
+    for r in xformers:
+        assert r.marker is not None, f"{extra}: xformers needs a platform marker"
+        assert not r.marker.evaluate({"sys_platform": "linux", "platform_machine": "aarch64"})
+        assert not r.marker.evaluate({"sys_platform": "win32", "platform_machine": "ARM64"})
+    assert linux[0].marker.evaluate({"sys_platform": "linux", "platform_machine": "x86_64"})
+    assert windows[0].marker.evaluate({"sys_platform": "win32", "platform_machine": "AMD64"})
+
+
 @pytest.mark.parametrize("cuda", ["cu126", "cu128", "cu130"])
 def test_cuda12_torch2110_pins_matching_local_build(cuda: str):
     reqs = _reqs(_extra(f"{cuda}onlytorch2110"))
@@ -70,20 +109,7 @@ def test_cuda12_torch2110_pins_matching_local_build(cuda: str):
         assert (
             spec == f"=={('2.11.0' if pkg != 'torchvision' else '0.26.0')}+{cuda}"
         ), f"{cuda}onlytorch2110: {pkg} pinned as '{spec}', expected the +{cuda} local build"
-    xformers = reqs["xformers"]
-    assert len(xformers) == 2, f"expected Linux + Windows xformers wheels, got {xformers}"
-    linux = [r for r in xformers if r.url and r.url.endswith("manylinux_2_28_x86_64.whl")]
-    windows = [r for r in xformers if r.url and r.url.endswith("win_amd64.whl")]
-    assert len(linux) == 1 and len(windows) == 1, f"unexpected xformers wheels: {xformers}"
-    for r in linux + windows:
-        assert (
-            f"/whl/{cuda}/xformers-0.0.35-" in r.url
-        ), f"xformers not on the {cuda} index: {r.url}"
-        assert r.marker is not None
-        assert not r.marker.evaluate({"sys_platform": "linux", "platform_machine": "aarch64"})
-        assert not r.marker.evaluate({"sys_platform": "win32", "platform_machine": "ARM64"})
-    assert linux[0].marker.evaluate({"sys_platform": "linux", "platform_machine": "x86_64"})
-    assert windows[0].marker.evaluate({"sys_platform": "win32", "platform_machine": "AMD64"})
+    _assert_xformers_035(reqs["xformers"], cuda, f"{cuda}onlytorch2110")
 
 
 @pytest.mark.parametrize("cuda", ["cu126", "cu128", "cu130"])
@@ -109,19 +135,7 @@ def test_cuda12_torch212_pins_matching_local_build(cuda: str, series: str):
             f"expected the =={want}+{cuda} local build"
         )
         assert req.marker is None, f"the {pkg} pin must apply on every machine"
-    xformers = reqs["xformers"]
-    linux = [r for r in xformers if r.url and r.url.endswith("manylinux_2_28_x86_64.whl")]
-    windows = [r for r in xformers if r.url and r.url.endswith("win_amd64.whl")]
-    assert len(linux) == 1 and len(windows) == 1, f"unexpected xformers wheels: {xformers}"
-    for r in linux + windows:
-        assert (
-            f"/whl/{cuda}/xformers-0.0.35-" in r.url
-        ), f"xformers not on the {cuda} index: {r.url}"
-        assert r.marker is not None
-        assert not r.marker.evaluate({"sys_platform": "linux", "platform_machine": "aarch64"})
-        assert not r.marker.evaluate({"sys_platform": "win32", "platform_machine": "ARM64"})
-    assert linux[0].marker.evaluate({"sys_platform": "linux", "platform_machine": "x86_64"})
-    assert windows[0].marker.evaluate({"sys_platform": "win32", "platform_machine": "AMD64"})
+    _assert_xformers_035(reqs["xformers"], cuda, f"{cuda}only{series}")
 
 
 @pytest.mark.parametrize("cuda", _TORCH212_CUDA)


### PR DESCRIPTION
`pip` is the branch uploaded to PyPI, and PyPI rejects any PEP 508 direct reference in `Requires-Dist` (`Invalid value for requires_dist. Error: Can't have direct dependency`, pypi/warehouse#7136). So every xFormers wheel main pins by URL is carried there as a plain `==` pin on the same version, with the index supplied by `--index-url` at install time rather than by the requirement itself.

Three guards assert main's spelling rather than the property being guarded, so they can only ever be green on one branch, and every merge from main has to pick which one. This makes them accept either form.

- `test_torch2110_cuda_extras.py` and `test_windows_xformers_wheel_match.py` check the version and the Linux/Windows markers on both forms, and the index only on the URL form, which is the only form that carries one. The torch trio, which is what the first of those two exists to guard, is asserted identically either way.
- `test_scan_packages.py`: `torch` is digest-pinned in the scan baseline, and on `pip` it is a range, because that branch declares the whole training runtime in `[project].dependencies` and a published wheel cannot exact-pin torch without putting every `pip install unsloth` on one build. Allowed by name, only for the pyproject half so the studio requirement files are still held to exact pins, and with the bound itself asserted so the allowance cannot quietly become open ended. On main, where torch is not declared in pyproject at all, it never fires.

No verdict changes on main: 184 passed, 1 skipped, same as before.

Companion to #10513, which merges `main` into `pip` and carries the same three files.
