### PR TITLE
Studio: give the document upload simulations one deadline

### DIFF
--- a/tests/studio/rag_upload_browser_tests.py
+++ b/tests/studio/rag_upload_browser_tests.py
@@ -27,7 +27,8 @@ def request(path, body = None):
 
 
 def wait_state(predicate):
-    deadline = time.monotonic() + 8
+    # Same contention as the browser waits below: three engines on a two-core runner.
+    deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         state = request("/__state")
         if predicate(state):
@@ -156,7 +157,7 @@ def large_batch(page):
     page.evaluate(
         "window.pending=window.sim.uploadNames(Array.from({length:12},(_,i)=>'report-'+i+'.txt'));void 0"
     )
-    deadline = time.monotonic() + 4
+    deadline = time.monotonic() + 30
     while time.monotonic() < deadline and len(request("/__state")["uploads"]) < 12:
         time.sleep(0.05)
     data = request("/__state")

--- a/tests/studio/rag_upload_ci.py
+++ b/tests/studio/rag_upload_ci.py
@@ -93,8 +93,10 @@ else:
         check = True,
     ).stdout
     interpreter = next(
-        entry["path"] for entry in json.loads(listed) if entry["version"].startswith("3.12.")
+        (entry["path"] for entry in json.loads(listed) if entry["version"].startswith("3.12.")),
+        "",
     )
+    assert interpreter, f"uv installed no 3.12 to build the venv from: {listed}"
 assert run(
     "venv", [bootstrap, "-m", "uv", "venv", "--clear", "--python", interpreter, root / "venv"]
 )


### PR DESCRIPTION
Follow-up to #10496. The browser completion waits there went to 30 seconds because three engines share a two-core runner, but two server-side waits kept deadlines that the same contention had already been seen to blow.

- `wait_state` waited 8 seconds for a fixture condition. Eight seconds is the budget that timed out on WebKit in #10496 before it was raised.
- `large_batch` waited 4 seconds for twelve POSTs to arrive, the tightest deadline in the file and the one most exposed to a loaded runner.

Neither measures latency: the first polls the fixture for a state transition, the second asserts that all twelve uploads get through while an SSE stream is open. A longer budget asserts exactly the same thing, and a broken connection budget still fails at 30 seconds because the POSTs never arrive at all.

Also names the failure when `uv python list` reports no 3.12 to build the venv from. That path currently ends the run on a bare `StopIteration` from a generator expression, which is an opaque way to fail a CI step; the neighbouring `sqlite-extensions` check already fails by name.

## Validation

- Backend: 703 passed, 22 skipped across `studio/backend/tests/test_rag_*.py`.
- Frontend: 7074 passed, 0 failed; application and test typechecks passed.
- Scoped Ruff passed on both changed files.

The `Document upload compatibility` workflow #10496 added never completed a run on that PR: every attempt was either superseded by `concurrency.cancel-in-progress` or still queued when it merged. This PR touches `tests/studio/rag_upload*`, so its own CI gives that workflow its first full run on ubuntu-latest, macos-latest and windows-latest.