### PR TITLE
Fix main's red encoding guard, and the ruff drift in the same files

### DIFF
--- a/tests/studio/rag_upload_browser_tests.py
+++ b/tests/studio/rag_upload_browser_tests.py
@@ -173,9 +173,9 @@ def overlapping_uploads(page):
     wait_state(lambda s: s["waiting"] == 2)
     request("/__release-one", {})
     page.evaluate("window.first")
-    assert page.evaluate("window.sim.uploading"), (
-        "The first upload released the second upload's guard"
-    )
+    assert page.evaluate(
+        "window.sim.uploading"
+    ), "The first upload released the second upload's guard"
     request("/__release", {})
     page.evaluate("window.second")
     complete(page)
@@ -189,9 +189,9 @@ def concurrent_same_content(page):
     request("/__release", {})
     page.evaluate("Promise.all([window.first,window.second])")
     complete(page)
-    assert page.evaluate("window.sim.documents.length") == 1, (
-        "Concurrent deduplication left duplicate chips"
-    )
+    assert (
+        page.evaluate("window.sim.documents.length") == 1
+    ), "Concurrent deduplication left duplicate chips"
 
 
 def materialize(page):
@@ -274,7 +274,7 @@ def main():
                 records.append(record)
             browser.close()
     (ROOT / ("browser-results-" + "-".join(engines) + ".json")).write_text(
-        json.dumps(records, indent = 2)
+        json.dumps(records, indent = 2), encoding = "utf-8"
     )
     raise SystemExit(any(r["status"] == "failed" for r in records))
 

--- a/tests/studio/rag_upload_ci.py
+++ b/tests/studio/rag_upload_ci.py
@@ -223,6 +223,7 @@ if run("frontend-install", [npm, "ci"], cwd = frontend):
 (root / "summary.json").write_text(
     json.dumps(
         {"os": platform.platform(), "python": sys.version, "failed_steps": failures}, indent = 2
-    )
+    ),
+    encoding = "utf-8",
 )
 raise SystemExit(bool(failures))

--- a/tests/test_wheel_smoke_publish_guard.py
+++ b/tests/test_wheel_smoke_publish_guard.py
@@ -21,7 +21,7 @@ STEP_NAME = "Publishing path uploads the wheel only"
 
 
 def _workflow():
-    return yaml.safe_load(WORKFLOW.read_text())
+    return yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
 
 
 def _on_block(wf):
@@ -183,7 +183,7 @@ def test_commented_out_upload_is_not_an_artifact(tmp_path):
 
 
 def test_real_build_sh_passes_the_guard(tmp_path):
-    r = _run_guard(tmp_path, (REPO / "build.sh").read_text())
+    r = _run_guard(tmp_path, (REPO / "build.sh").read_text(encoding = "utf-8"))
     assert r.returncode == 0, r.stdout + r.stderr
 
 


### PR DESCRIPTION
`tests/test_source_read_encoding.py` fails on main, so every open PR inherits it.

Four reads and writes of checked-in files in the test trees use the platform default encoding:

- `tests/studio/rag_upload_browser_tests.py:276` and `tests/studio/rag_upload_ci.py:223` (#10496)
- `tests/test_wheel_smoke_publish_guard.py:24` and `:186` (#10419)

The guard is right: on Windows the default is not UTF-8, so these break as soon as one of those files gains a non-ASCII byte. Each call is one keyword short, and that keyword is what this adds.

The same three files were also written under a newer ruff than `.pre-commit-config.yaml` pins, so the hook reformats them and any PR touching them fails `ruff-format-with-kwargs` on a diff it did not create. They are re-formatted here with the pinned ruff 0.6.9, which is the same drift #10512 added a guard against.

Tests: the encoding guard passes, and 59 in `tests/test_wheel_smoke_publish_guard.py`.