### PR TITLE
Let the torch tag check tell the handoff restore from a conditional report

### DIFF
--- a/tests/studio/test_amd_venv_repair_loop.ps1
+++ b/tests/studio/test_amd_venv_repair_loop.ps1
@@ -652,10 +652,11 @@ Check "it reports the resolved flavor, not the raw index URL" (
 # session must not inherit the first one's answer. Assigning "" clears it on every edition (7.5+
 # keeps a present blank value, 5.1 and 7.0-7.4 remove the variable) and setup reads both as
 # unknown. The -match half is the anti-vacuity half: a bare -notmatch passes against a tree that
-# never grew the assignment at all.
+# never grew the assignment at all. The finally that puts the caller's own value back is a
+# conditional assignment too, and is not the report; only its $previous* form is allowed.
 Check "the report is assigned on every run, not only when known" (
     ($installText -match '(?m)^\s*\$env:UNSLOTH_INSTALLER_TORCH_TAG = ') -and
-    ($installText -notmatch 'if \([^\n]*\) \{\s*\$env:UNSLOTH_INSTALLER_TORCH_TAG'))
+    ($installText -notmatch 'if \([^\n]*\) \{\s*\$env:UNSLOTH_INSTALLER_TORCH_TAG = (?!\$previous)'))
 Check "it is handed over before setup is invoked" (
     $installText.IndexOf('$env:UNSLOTH_INSTALLER_TORCH_TAG') -ge 0 -and
     $installText.IndexOf('$env:UNSLOTH_INSTALLER_TORCH_TAG') -lt

--- a/tests/test_installer_elevation_report.py
+++ b/tests/test_installer_elevation_report.py
@@ -52,8 +52,6 @@ def _repair_block(path: Path) -> str:
     return src[src.index("# A desktop repair runs update.rs") :]
 
 
-
-
 def test_diag_marker_prefix_is_still_parsed_and_reported():
     """Both scripts write [TAURI:DIAG]; if the Rust side stops reading it the
     markers become invisible without either file changing."""
@@ -62,8 +60,6 @@ def test_diag_marker_prefix_is_still_parsed_and_reported():
     assert "installer_diag_markers" in _read(
         REPORT_RS
     ), "the support report no longer prints markers"
-
-
 
 
 def test_install_ps1_reports_elevation():
@@ -226,7 +222,7 @@ def test_every_handoff_variable_is_restored_not_just_skip_studio_base():
     src = _read(INSTALL_PS1)
     restore = src[src.index("} finally {") :]
     # The handoff try specifically; install.ps1 opens several.
-    handoff_try = src.index('\n    try {\n        $env:SKIP_STUDIO_BASE')
+    handoff_try = src.index("\n    try {\n        $env:SKIP_STUDIO_BASE")
     for var, saved in (
         ("SKIP_STUDIO_BASE", "$previousSkipStudioBase"),
         ("STUDIO_PACKAGE_NAME", "$previousStudioPackageName"),
@@ -248,9 +244,9 @@ def test_every_handoff_variable_is_restored_not_just_skip_studio_base():
             "unassigned $hadPrevious* as 'there was nothing here'"
         )
         assert f"$env:{var} = {saved}" in restore, f"{var} is never restored"
-        assert f"Remove-Item Env:{var}" in restore, (
-            f"{var} must be REMOVED when it was originally unset, not left as an empty string"
-        )
+        assert (
+            f"Remove-Item Env:{var}" in restore
+        ), f"{var} must be REMOVED when it was originally unset, not left as an empty string"
 
 
 def test_the_early_bail_restores_the_environment_too():
@@ -342,8 +338,6 @@ def test_setup_ps1_warning_names_the_root_actually_written():
     assert idx < src.index(
         "$StudioHome = Join-Path $env:USERPROFILE"
     ), "this test is only meaningful while the notice precedes the resolver"
-
-
 
 
 def test_degraded_llama_cpp_is_recorded_not_only_flashed():

--- a/tests/test_installer_profile_hardening.py
+++ b/tests/test_installer_profile_hardening.py
@@ -867,7 +867,7 @@ def test_the_handoff_is_published_only_around_the_setup_child():
         "        Invoke-ManagedUnslothCli -Python $VenvPython -Arguments $studioArgs",
         "the child invocation",
     )
-    opened = _locate(source, '\n    try {\n        $env:SKIP_STUDIO_BASE', "the handoff try")
+    opened = _locate(source, "\n    try {\n        $env:SKIP_STUDIO_BASE", "the handoff try")
     assert gate < call and proxy < call, "the handoff must be in place before the child runs"
     # ...and both saves stay above the try, or the finally reads an unassigned
     # $hadPrevious* as "there was nothing here" and clears a value it did not set.
@@ -1535,9 +1535,7 @@ def test_an_installer_launch_with_no_proxy_still_skips_the_probe(monkeypatch):
     ]
     # The publish moved inside the try, so the slice runs to the child invocation. It must
     # still stop before the finally, which legitimately does remove the variable.
-    handoff = handoff[
-        : handoff.index("        Invoke-ManagedUnslothCli -Python $VenvPython")
-    ]
+    handoff = handoff[: handoff.index("        Invoke-ManagedUnslothCli -Python $VenvPython")]
     assert (
         "Remove-Item Env:_UNSLOTH_PS_PROXY_DEFAULTS" not in handoff
     ), "the installer must publish an explicit empty handoff, not remove the variable"


### PR DESCRIPTION
## What

`tests/studio/test_amd_venv_repair_loop.ps1` fails on main since #8066:

```
FAIL  the report is assigned on every run, not only when known
```

The check rejects any `if (...) {` followed by an assignment to `UNSLOTH_INSTALLER_TORCH_TAG`, to make sure the report is unconditional. #8066 added a `finally` that puts the caller's own value back:

```powershell
if ($hadPreviousInstallerTorchTag) {
    $env:UNSLOTH_INSTALLER_TORCH_TAG = $previousInstallerTorchTag
}
```

That is a conditional assignment too, but it is the restore, not the report, so the check now trips on a correct tree.

## Fix

The negative half of the check ignores an assignment from a `$previous*` variable. A conditional report is still rejected:

| tree | result |
| --- | --- |
| main today | passes |
| a synthetic `if ($known) { $env:UNSLOTH_INSTALLER_TORCH_TAG = $tag }` | rejected |
| the restore alone | accepted |

One line in one test; no product code changes.
