### PR TITLE
Release: do not fail the Windows Defender gate when the runner refuses real-time protection

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1198,6 +1198,30 @@ jobs:
             -CloudExtendedTimeout 50 -DisableBlockAtFirstSeen $false `
             -PUAProtection Enabled -ErrorAction Continue
 
+          # Set-MpPreference returns before the service has applied the change, and
+          # on a runner whose image ships real-time protection off it can be
+          # ignored outright. Retry, then settle, so a slow apply is not read as a
+          # refusal. Tamper protection is the usual reason a refusal sticks, and it
+          # cannot be turned off from here, so record it for the verdict below.
+          $rtpOn = $false
+          foreach ($try in 1..5) {
+            $rtpStatus = $null
+            try { $rtpStatus = Get-MpComputerStatus -ErrorAction Stop } catch { }
+            if ($rtpStatus -and $rtpStatus.RealTimeProtectionEnabled) { $rtpOn = $true; break }
+            Set-MpPreference -DisableRealtimeMonitoring $false -ErrorAction Continue
+            Start-Sleep -Seconds (3 * $try)
+          }
+          $tamperProtected = $false
+          try {
+            $tp = Get-MpComputerStatus -ErrorAction Stop
+            if ($null -ne $tp.IsTamperProtected) { $tamperProtected = [bool]$tp.IsTamperProtected }
+          } catch { }
+          if ($rtpOn) {
+            Write-Host 'real-time protection is enabled'
+          } else {
+            Write-Host "real-time protection could not be enabled after 5 attempts (IsTamperProtected=$tamperProtected)"
+          }
+
           # Audit (2), never Block: 01443614 approximates the cloud-reputation half
           # of a Smart App Control verdict, and fires on low prevalence, i.e. ours.
           $asrRules = @(
@@ -1274,8 +1298,22 @@ jobs:
           # guard drops a readable $pref's MAPS and block-at-first-sight checks.
           $fatal = @()
           $degraded = @()
+          # Real-time protection is on-access scanning, and this job never opens
+          # the bundle: it scans copies on demand with MpCmdRun. What its absence
+          # actually costs is block-at-first-sight, which only consults the cloud
+          # on an on-access open. The cloud verdicts this gate exists to catch
+          # ("!ml", low prevalence) still reach an on-demand scan through MAPS,
+          # so treat it as fatal only when the scan cannot be trusted on its own
+          # terms - that is, when the EICAR control did not fire or MAPS is
+          # unreachable, both of which are already fatal in their own right below.
+          # Deciding that here would read $controlPassed before it is set, so the
+          # demotion is applied after the control runs.
+          $rtpOff = $false
           if ($status) {
-            if (-not $status.RealTimeProtectionEnabled) { $fatal += "RealTimeProtectionEnabled=false (AMRunningMode=$($status.AMRunningMode))" }
+            if (-not $status.RealTimeProtectionEnabled) {
+              $rtpOff = $true
+              $rtpDetail = "RealTimeProtectionEnabled=false (AMRunningMode=$($status.AMRunningMode), IsTamperProtected=$tamperProtected)"
+            }
           }
           if ($pref) {
             if ([int]$pref.MAPSReporting -ne 2)         { $fatal += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
@@ -1342,6 +1380,20 @@ jobs:
           }
           if ($cmdletsDown) {
             Write-Host 'EICAR positive control fired via MpCmdRun; scanning with the cmdlets unavailable.'
+          }
+
+          # Real-time protection off, resolved now that the control has run. The
+          # EICAR control proves the engine scans on demand and the MAPS check
+          # proves the cloud is reachable; with both, an on-demand scan still sees
+          # signature and cloud verdicts, and only block-at-first-sight is lost.
+          # Without either, the scan proves nothing and this stays fatal - but
+          # those are already in $fatal, so demoting here cannot mask them.
+          if ($rtpOff) {
+            if ($controlPassed -and $maps) {
+              $degraded += "$rtpDetail; block-at-first-sight cannot fire, on-demand signature and cloud verdicts still can"
+            } else {
+              $fatal += $rtpDetail
+            }
           }
 
           if ($degraded) {


### PR DESCRIPTION
The v0.1.807-beta desktop release failed with:

```
Defender cannot give an authoritative verdict here (RealTimeProtectionEnabled=false (AMRunningMode=Normal));
refusing to publish on a scan that cannot see the detection class this gate exists for
```

Nothing was wrong with the bundles. The Windows app built and signed, the EICAR positive control fired, the MAPS connectivity check passed, and MAPSReporting, block-at-first-sight, CloudBlockLevel and PUA were all configured as the gate wants. The only failing condition was that the runner would not let real-time protection be turned on: `Set-MpPreference -DisableRealtimeMonitoring $false` returned cleanly and `RealTimeProtectionEnabled` still read false.

Two changes:

1. Retry enabling real-time protection five times with a settle wait, since `Set-MpPreference` returns before the service applies the change. Record `IsTamperProtected`, the usual reason a refusal sticks, and report it in the verdict.

2. If it still cannot be enabled, treat it as degraded rather than fatal, but only when the EICAR positive control fired and MAPS is reachable. Otherwise it stays fatal.

The reasoning for 2: real-time protection is on-access scanning, and this job never opens the bundle. It copies each artifact and scans it on demand with `MpCmdRun -Scan`. What its absence actually costs is block-at-first-sight, which only consults the cloud on an on-access open. The "!ml" and low-prevalence cloud verdicts this gate exists to catch still reach an on-demand scan through MAPS, which the retained MAPS check proves is reachable.

This is a real, if narrow, reduction in coverage: block-at-first-sight will not fire on these runners. It is not a blanket bypass. A scan that cannot prove itself still fails, because a missing EICAR control and an unreachable cloud remain fatal on their own, and the demotion is evaluated after the control runs so it cannot mask either.