### PR TITLE
Studio: make three RAG tests hold on Windows

### DIFF
--- a/studio/backend/tests/test_rag_embed_llama_server.py
+++ b/studio/backend/tests/test_rag_embed_llama_server.py
@@ -869,7 +869,7 @@ def test_cached_gguf_is_found_in_a_subdirectory(monkeypatch, tmp_path):
     _seed_cache(tmp_path / "hub", repo, ["F16/bge-small.gguf"])
     _use_cache_root(monkeypatch, tmp_path / "hub")
     resolved = LlamaServerBackend._resolve_cached_gguf(repo)
-    assert resolved is not None and resolved.endswith("F16/bge-small.gguf")
+    assert resolved is not None and Path(resolved).parts[-2:] == ("F16", "bge-small.gguf")
 
 
 def test_an_incomplete_cached_shard_set_is_not_a_hit(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_rag_embeddings.py
+++ b/studio/backend/tests/test_rag_embeddings.py
@@ -22,8 +22,15 @@ from core.rag import config, embeddings
 # RLIMIT_CORE = 0 does NOT work here, because a piped core_pattern ignores it.
 # prctl is Linux-only, so the call is guarded and does nothing elsewhere.
 _CRASHING_UNLESS_CPU_SCRIPT = (
-    "import ctypes, sys\n"
+    "import ctypes, os, sys\n"
     "if sys.argv[1] != 'cpu':\n"
+    # ctypes installs a structured exception handler on Windows, so the null read below
+    # comes back as an ordinary OSError and the child exits like any reporting child,
+    # which the probe reads as a working device. abort() is the real shape there: it is
+    # what a ROCm library calls when it dies, and it leaves the CRT exit status 3 the
+    # probe already recognises.
+    "    if sys.platform == 'win32':\n"
+    "        os.abort()\n"
     "    try:\n"
     "        ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)  # PR_SET_DUMPABLE = 0\n"
     "    except Exception:\n"

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -738,6 +738,10 @@ def test_reauthorizing_same_path_refreshes_root_identity_and_retains_mappings(
 
 @pytest.mark.parametrize("source_name", ["source", "source "])
 def test_directory_lease_contract_preserves_path_and_purpose(rag_home, source_name):
+    if source_name.endswith(" ") and os.name == "nt":
+        # Win32 strips a trailing space from a path component, so the two names are one
+        # directory there and the pair this case contrasts cannot be created at all.
+        pytest.skip("Windows cannot hold a directory whose name ends in a space")
     source = rag_home / source_name
     source.mkdir()
     if source_name.endswith(" "):

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4433,9 +4433,7 @@ def _resync_torch_coupled_packages(label_before: str) -> bool:
             # _pin_needs_reinstall, not an exact compare: ==0.18.0 never equals 0.18.0+cu130.
             _ao_index = _torch_accelerator_index_url(_label_after)
             _ao_args = ["--force-reinstall", "--no-deps", "--no-cache-dir"]
-            if _pin_needs_reinstall(
-                _spec, _torch_index_tag(_label_after) if _ao_index else ""
-            ):
+            if _pin_needs_reinstall(_spec, _torch_index_tag(_label_after) if _ao_index else ""):
                 _note(f"torch {_label_after} after repair -- reinstalling {_spec}")
                 _touched_torch = True
                 _ao_ok = pip_install_try(

--- a/tests/studio/install/test_windows_torch_flavor_invariant.py
+++ b/tests/studio/install/test_windows_torch_flavor_invariant.py
@@ -294,7 +294,8 @@ class TestStepThirteenWiring:
         # spec and the leaf are read from. Nothing else may join the set.
         assert step13 == (
             ["_progress", "_torch_step_label", "_probe_installed_torch_version"]
-            + repairs + ["_probe_installed_torch_version", "_note", "_install_torchao_for_torch"]
+            + repairs
+            + ["_probe_installed_torch_version", "_note", "_install_torchao_for_torch"]
         ), step13
         assert "_install_torchao_for_torch" not in _calls_in(guards[0])
 


### PR DESCRIPTION
The `Document upload compatibility` workflow now runs the RAG suite on a Windows runner, and its first complete run reported three failures. All three are the tests' own assumptions about the platform, not defects in the code under test.

- `test_cached_gguf_is_found_in_a_subdirectory` asserted `resolved.endswith("F16/bge-small.gguf")`. `_resolve_cached_gguf` returns a filesystem path, so on Windows it comes back with backslashes and the assertion could never match. Compares path components now.
- `test_directory_lease_contract_preserves_path_and_purpose[source ]` creates a directory whose name ends in a space and a sibling without it, to prove the resolver keeps the name it was given. Win32 strips a trailing space from a path component, so both names are the same directory there and the second `mkdir` raises `FileExistsError`. The pair the case contrasts cannot exist on Windows, so that parametrization skips there.
- `test_a_real_crashing_child_moves_the_load_to_cpu` had its probe child dereference null through ctypes. ctypes installs a structured exception handler on Windows, so that surfaces as an ordinary `OSError`, the child exits like any child that ran and reported, and `device_can_allocate` correctly reads that as a usable device. The test then saw `cuda` instead of `cpu`. On Windows it now calls `os.abort()`, which leaves the CRT exit status 3 that `_died_by_signal` already recognises, and which is the shape a ROCm library death actually takes there.

Evidence: staging run of the compatibility workflow on windows-latest, `3 failed, 840 passed, 22 skipped`, the three above.

Local: `test_rag_linked_folders.py`, `test_rag_embed_llama_server.py`, `test_rag_embeddings.py` = 227 passed. Full runner on Linux (`tests/studio/rag_upload_ci.py`) = backend 844 passed / 21 skipped, frontend unit and typecheck clean, 63/63 browser cases across chromium, firefox and webkit.