### PR TITLE
Keep the loggers stub a package so tests/studio can be collected in one process

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4433,9 +4433,7 @@ def _resync_torch_coupled_packages(label_before: str) -> bool:
             # _pin_needs_reinstall, not an exact compare: ==0.18.0 never equals 0.18.0+cu130.
             _ao_index = _torch_accelerator_index_url(_label_after)
             _ao_args = ["--force-reinstall", "--no-deps", "--no-cache-dir"]
-            if _pin_needs_reinstall(
-                _spec, _torch_index_tag(_label_after) if _ao_index else ""
-            ):
+            if _pin_needs_reinstall(_spec, _torch_index_tag(_label_after) if _ao_index else ""):
                 _note(f"torch {_label_after} after repair -- reinstalling {_spec}")
                 _touched_torch = True
                 _ao_ok = pip_install_try(

--- a/tests/studio/install/test_windows_torch_flavor_invariant.py
+++ b/tests/studio/install/test_windows_torch_flavor_invariant.py
@@ -294,7 +294,8 @@ class TestStepThirteenWiring:
         # spec and the leaf are read from. Nothing else may join the set.
         assert step13 == (
             ["_progress", "_torch_step_label", "_probe_installed_torch_version"]
-            + repairs + ["_probe_installed_torch_version", "_note", "_install_torchao_for_torch"]
+            + repairs
+            + ["_probe_installed_torch_version", "_note", "_install_torchao_for_torch"]
         ), step13
         assert "_install_torchao_for_torch" not in _calls_in(guards[0])
 

--- a/tests/studio/load_freeze/test_load_orchestrator.py
+++ b/tests/studio/load_freeze/test_load_orchestrator.py
@@ -46,7 +46,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import logging as _logging  # noqa: E402
 
+# Stub get_logger so this file need not import the real package's structlog chain, but keep
+# __path__ pointing at the real package: this entry outlives the module in sys.modules, and a
+# stub with no __path__ makes every later-collected test that reaches loggers.media_progress
+# die with "'loggers' is not a package". Same care the structlog block below already takes.
 _loggers_stub = types.ModuleType("loggers")
+_loggers_stub.__path__ = [str(_STUDIO_BACKEND / "loggers")]
 _loggers_stub.get_logger = lambda name: _logging.getLogger(name)
 sys.modules.setdefault("loggers", _loggers_stub)
 # structlog is a hard studio.txt requirement imported only lazily, so a bare setdefault would shadow the real package.

--- a/tests/studio/test_loggers_package_not_shadowed.py
+++ b/tests/studio/test_loggers_package_not_shadowed.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""`loggers` must still be a PACKAGE after every test module has been imported.
+
+Test modules that exercise a single backend file routinely stub `loggers` so they need
+not pull structlog and the rest of the chain in. The stub is fine; leaving a stub with no
+`__path__` in `sys.modules` is not, because that entry outlives the module that installed
+it and pytest imports every test module during collection. Any later test that reaches a
+real submodule then dies at COLLECTION with
+
+    ModuleNotFoundError: No module named 'loggers.media_progress'; 'loggers' is not a package
+
+which reads like a missing dependency rather than one test file shadowing a package for
+the whole session. tests/studio/load_freeze/test_load_orchestrator.py did exactly this
+(from #5669) and took tests/studio/test_mlx_context_platform_matrix.py down with it, so
+the whole directory could not be collected in one pytest process.
+
+Asserting this at RUN time is what makes it a guard: collection has finished by then, so
+every module-level stub in the session is already installed.
+"""
+
+import importlib
+import sys
+
+
+def test_the_loggers_entry_left_in_sys_modules_is_still_a_package():
+    loggers = sys.modules.get("loggers")
+    if loggers is None:
+        return  # nothing in this session touched it, so nothing can have shadowed it
+    assert hasattr(loggers, "__path__"), (
+        "a test module replaced `loggers` with a non-package stub and left it in "
+        "sys.modules; give the stub __path__ = [<studio/backend/loggers>] so submodule "
+        "imports still resolve"
+    )
+
+
+def test_a_real_submodule_still_imports_through_whatever_stub_is_installed():
+    """__path__ is only worth asserting if it actually reaches the real files."""
+    if sys.modules.get("loggers") is None:
+        return
+    assert importlib.import_module("loggers.media_progress") is not None


### PR DESCRIPTION
`tests/studio` cannot be collected in a single pytest process on main:

```
$ python3 -m pytest tests/studio --collect-only -q
ERROR tests/studio/test_mlx_context_platform_matrix.py
E   ModuleNotFoundError: No module named 'loggers.media_progress'; 'loggers' is not a package
8331 tests collected, 1 error
```

That file passes its own 60 tests when run alone, so the failure is entirely about what else is in the session.

## Cause

`tests/studio/load_freeze/test_load_orchestrator.py` installs a stub at import time:

```python
_loggers_stub = types.ModuleType("loggers")
_loggers_stub.get_logger = lambda name: _logging.getLogger(name)
sys.modules.setdefault("loggers", _loggers_stub)
```

pytest imports every test module during collection, and that `sys.modules` entry outlives the module that installed it. A stub built by `ModuleType` has no `__path__`, so from that point on every `loggers.<submodule>` import in the session fails, and it fails as `'loggers' is not a package` -- which reads like a missing dependency rather than one test file shadowing a package.

Not a recent regression: this arrived with #5669. Worth noting that the **structlog block immediately below it already guards against this exact hazard**, in a comment that says so:

```python
# structlog is a hard studio.txt requirement imported only lazily, so a bare setdefault would shadow the real package.
```

The care was applied to structlog and not to `loggers`.

## Fix

The stub itself is reasonable -- it exists so this file need not import structlog and the rest of the logging chain for the one `get_logger` it uses. It just has to remain a *package*:

```python
_loggers_stub.__path__ = [str(_STUDIO_BACKEND / "loggers")]
```

`_STUDIO_BACKEND` is already on `sys.path` two lines above, so submodule imports resolve to the real files while `get_logger` stays the cheap stub.

## Guard

`tests/studio/test_loggers_package_not_shadowed.py` asserts the invariant at **run** time, which is the point: collection has finished by then, so every module-level stub in the session is already installed. It checks both that the entry is a package and that a real submodule imports through it.

Verified by mutation: drop the `__path__` line and both tests fail; restore it and they pass.

## Scope

79 other test files use the same stub pattern without `__path__`. Left alone deliberately -- they sit in sessions where nothing imports a real `loggers` submodule, `studio/backend/tests` and `tests/python` both collect clean, and rewriting them would be churn against no defect. If one of those sessions later grows a test that needs the real package, this guard is what will say so.

## Verification

- `tests/studio` collection: 8331 + 1 error -> **8407 collected, no errors**.
- `tests/studio tests/python studio/backend/tests/test_torchao_select.py` as one process: **10595 passed, 333 skipped, 0 failed**.
- `tests/studio/load_freeze` on its own: 23 passed, unchanged.
- `ruff check tests`: clean.