### PR TITLE
Format two files that drifted from the pinned ruff on main

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4433,9 +4433,7 @@ def _resync_torch_coupled_packages(label_before: str) -> bool:
             # _pin_needs_reinstall, not an exact compare: ==0.18.0 never equals 0.18.0+cu130.
             _ao_index = _torch_accelerator_index_url(_label_after)
             _ao_args = ["--force-reinstall", "--no-deps", "--no-cache-dir"]
-            if _pin_needs_reinstall(
-                _spec, _torch_index_tag(_label_after) if _ao_index else ""
-            ):
+            if _pin_needs_reinstall(_spec, _torch_index_tag(_label_after) if _ao_index else ""):
                 _note(f"torch {_label_after} after repair -- reinstalling {_spec}")
                 _touched_torch = True
                 _ao_ok = pip_install_try(

--- a/tests/studio/install/test_windows_torch_flavor_invariant.py
+++ b/tests/studio/install/test_windows_torch_flavor_invariant.py
@@ -294,7 +294,8 @@ class TestStepThirteenWiring:
         # spec and the leaf are read from. Nothing else may join the set.
         assert step13 == (
             ["_progress", "_torch_step_label", "_probe_installed_torch_version"]
-            + repairs + ["_probe_installed_torch_version", "_note", "_install_torchao_for_torch"]
+            + repairs
+            + ["_probe_installed_torch_version", "_note", "_install_torchao_for_torch"]
         ), step13
         assert "_install_torchao_for_torch" not in _calls_in(guards[0])
 


### PR DESCRIPTION
## Summary

The `ruff-format-with-kwargs` hook rewraps two files on main under the pinned ruff 0.6.9, so `pre-commit.ci - push` is red on main and every open PR's merge commit inherits the failure with an autofix that cannot be applied to the PR ("a conflict occurred when applying fixes"). This commit is the hook's own output on `999dd850`, nothing else.

## Files

- `studio/install_python_stack.py`: one signature rewrapped.
- `tests/studio/install/test_windows_torch_flavor_invariant.py`: one assert rewrapped.

## Verification

`pre-commit run ruff-format-with-kwargs --all-files` with the pinned ruff on a clean checkout of main changes exactly these two files; after this commit it changes nothing.
