### PR TITLE
CI: assert the installed unsloth CLI runs on the virgin Windows lane

### DIFF
--- a/.github/scripts/virgin-windows-install.ps1
+++ b/.github/scripts/virgin-windows-install.ps1
@@ -80,7 +80,16 @@ if ($rc -ne 0) {
         & $venvPy -V
     }
     foreach ($cli in (Join-Path $venv 'Scripts\unsloth.exe'), (Join-Path $env:UNSLOTH_STUDIO_HOME 'bin\unsloth.exe')) {
-        if (Test-Path -LiteralPath $cli) { Write-Host "unsloth CLI: $cli" }
+        if (Test-Path -LiteralPath $cli) {
+            Write-Host "unsloth CLI: $cli"
+            # Present is not runnable: the console script imports the whole command
+            # tree, so a dependency missing under --no-deps surfaces here and nowhere
+            # else. This is the assertion the hosted Windows leg already makes.
+            & $cli --version
+            if ($LASTEXITCODE -ne 0) {
+                $failures += "unsloth CLI at $cli is on disk but does not run (exit $LASTEXITCODE)"
+            }
+        }
         else { $failures += "installer exited 0 but left no unsloth CLI at $cli" }
     }
     # issue #8490: the generated .exe launchers above are unsigned, so Application


### PR DESCRIPTION
A Windows 11 user on 0.1.807-beta reported an install that could not repair itself. The managed CLI failed to start:

```
File "<studio_home>\unsloth_studio\Lib\site-packages\unsloth_cli\__init__.py", line 29, in <module>
    import typer
File "<studio_home>\unsloth_studio\Lib\site-packages\typer\main.py", line 18, in <module>
    from annotated_doc import Doc
ModuleNotFoundError: No module named 'annotated_doc'
```

`annotated-doc` is a hard dependency of every typer we install (0.23.2, 0.27.1 and 0.27.2 all declare `annotated-doc>=0.0.2`), so a resolving install always has it. `no-torch-runtime.txt` names it explicitly for the `--no-deps` path, under the comment about typer's remaining runtime dep tree. That combination is why current installs are fine, and this report is a venv that predates the pin rather than a regression.

What is missing is the check that would stop the next one reaching users.

`virgin-windows-install.ps1` says in its header that it makes "the same assertions the hosted Windows leg makes". For the CLI it does not. It checks the file exists:

```powershell
if (Test-Path -LiteralPath $cli) { Write-Host "unsloth CLI: $cli" }
else { $failures += "installer exited 0 but left no unsloth CLI at $cli" }
```

The hosted leg in `clean-machine-install-ci.yml` goes further, and says why:

```powershell
# Present is not runnable: the console script imports the whole command tree, so a
# missing dependency or unimportable extension surfaces here and nowhere else.
& $cli --version
```

So the virgin container lane passes with a CLI that is on disk and cannot start, which is the exact shape of this report. That lane is the one running on a bare Windows box with no toolchain, so it is the one most likely to expose a dependency that the hosted image happens to have cached.

This runs `--version` on each CLI it finds and records a failure when it does not exit 0, matching the hosted leg. Existing presence checks and the `unsloth.cmd` shim check are unchanged.

Verified the script still parses.

Related: #10533 fixes the other half of that user's report, the unreadable llama.cpp cache that stopped the installer from repairing the broken venv in the first place.
