### PR TITLE
Studio: decode a Windows device id before comparing it

### DIFF
--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -722,7 +722,9 @@ def test_reauthorizing_same_path_refreshes_root_identity_and_retains_mappings(
     source_stat = source.stat()
     assert reauthorized.is_set()
     assert refreshed["id"] == folder["id"]
-    assert (refreshed["root_device"], refreshed["root_inode"]) == (
+    # Read back through the loader: an identity above SQLite's signed maximum is stored as
+    # a hex string, which is the ordinary case for a Windows device id.
+    assert folder_sync._load_identity(refreshed["root_device"], refreshed["root_inode"]) == (
         source_stat.st_dev,
         source_stat.st_ino,
     )


### PR DESCRIPTION
Rebased onto main, which resolved the other half of this branch on its own.

`test_reauthorizing_same_path_refreshes_root_identity_and_retains_mappings` compared the raw `root_device` column against `st_dev`. `_store_identity` writes any value above SQLite's signed maximum as a hex string, which is the ordinary case for a Windows device id, so the column held `'xb2f8ffc4f8ff84bf'` where the test expected `12896338754431583423`. It reads back through `_load_identity` now, the same way `_reauthorize_folder` does.

The retirement case this branch also carried is no longer needed: main now passes `retire_scope` an explicit list of owned folder ids instead of a `created_at<=checked_at` bound, so it no longer depends on the clock leaving its tick. That change was dropped in the rebase.

Local: `test_rag_linked_folders.py` = 91 passed. Formatted with the pinned ruff 0.6.9, `ruff check` clean.