### PR TITLE
Unbreak main: catch the install.ps1 handoff harness up with the block it drives

### DIFF
--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -251,10 +251,14 @@ def test_installer_restores_the_private_handoff_after_setup():
     assert f"$previousRocmGfxHandoff = $env:{HANDOFF}" in src
     assert f"$env:{HANDOFF} = $previousRocmGfxHandoff" in src
     assert f"Remove-Item Env:{HANDOFF} -ErrorAction SilentlyContinue" in src
-    # Saved after the last early return, so no path skips the restore.
-    assert src.index("$previousRocmGfxHandoff") > src.index(
-        "--with-llama-cpp-dir path does not exist"
-    )
+    # The invariant is that no path out of the setup call can skip the restore, and
+    # the bail this used to sit after now lives INSIDE the try whose finally does the
+    # restoring, which is a stronger arrangement than the ordering this once asserted.
+    # So the check is the arrangement itself: save, then the bail, then the restore.
+    saved = src.index("$previousRocmGfxHandoff = $env:")
+    bail = src.index("--with-llama-cpp-dir path does not exist")
+    restored = src.index(f"$env:{HANDOFF} = $previousRocmGfxHandoff")
+    assert saved < bail < restored, (saved, bail, restored)
 
 
 def test_setup_consumes_the_handoff_only_after_its_own_inference():
@@ -532,8 +536,14 @@ def _handoff_lifecycle_block() -> str:
 def _run_handoff_lifecycle(
     tmp_path: Path, *, arch: str | None, inherited: str | None, fails: bool
 ) -> dict:
-    body = _handoff_lifecycle_block().replace(
-        "Invoke-ManagedUnslothCli -Python $VenvPython -Arguments $studioArgs",
+    call = "Invoke-ManagedUnslothCli -Python $VenvPython -Arguments $studioArgs"
+    block = _handoff_lifecycle_block()
+    # Loudly, because a silent miss here does not fail this harness: the probe below
+    # would simply never run and every assertion would read "<never ran>" with
+    # nothing saying why. The shipped call is what this block exists to wrap.
+    assert call in block, "install.ps1 no longer makes the setup call this harness replaces"
+    body = block.replace(
+        call,
         "throw 'setup exploded'"
         if fails
         else "$script:SeenByChild = $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF",
@@ -550,13 +560,36 @@ def _run_handoff_lifecycle(
                 "$previousProxyHandoff = $null; $hadPreviousProxyHandoff = $false",
                 "$UnslothProxyHandoffJson = $null",
                 "$UnslothExe = 'stub'; $studioArgs = @(); $setupExit = 0",
+                # The block reads the installer's own inputs and calls its torch-tag
+                # helper. Undefined, they throw under ErrorActionPreference Stop, the
+                # catch below swallows it, and the probe never runs -- which is how
+                # this read as a handoff bug when the block simply grew a dependency.
+                "$PackageName = 'unsloth'; $SkipTorch = $false; $TauriMode = $false",
+                "$StudioLocalInstall = $false; $RepoRoot = $null",
+                "$StudioRedirectMode = 'none'; $StudioHome = $null",
+                "$WithLlamaCppDir = $null; $VenvPython = 'stub-python'; $VenvDir = 'stub-venv'",
+                "$TorchIndexUrl = $null; $ROCmIndexUrl = $null",
+                # Every installer function the block reaches, stubbed. Kept in step
+                # with it by the assertion below, which lists what the block calls.
+                "function Get-ExpectedTorchFlavorTag { param($TorchIndexUrl, $ROCmIndexUrl) 'cu128' }",
+                "function Get-InstalledTorchVersionRaw { param($Python) '' }",
+                "function ConvertTo-TorchNumericRelease { param($Raw) $null }",
+                "function Write-StudioLine { param($Message, $ForegroundColor) }",
+                "function Write-ApplicationControlBlocked { param($Message, $Detail) }",
+                "function Exit-InstallFailure { param($Message) 1 }",
                 "$script:SeenByChild = '<never ran>'",
+                "$script:BlockError = $null",
+                # The line after the setup call reads this, and the block now returns
+                # early when it is null, which took the report with it.
+                "$script:ManagedUnslothCliExit = 0",
+                "$script:PrevTorchPin = $null",
                 "$ROCmGfxArch = " + ("$null" if arch is None else f"'{arch}'"),
                 "try {",
                 body,
-                "} catch { }",
+                "} catch { $script:BlockError = $_.ToString() }",
                 "@{",
                 "  seen_by_child = $script:SeenByChild",
+                "  block_error = $script:BlockError",
                 "  after = $(if (Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) { $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF } else { $null })",
                 "  after_set = [bool](Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF)",
                 "  public = $(if (Test-Path Env:UNSLOTH_ROCM_GFX_ARCH) { $env:UNSLOTH_ROCM_GFX_ARCH } else { $null })",
@@ -576,7 +609,16 @@ def _run_handoff_lifecycle(
         env = env,
     )
     assert proc.returncode == 0, f"handoff block failed:\n{proc.stdout}\n{proc.stderr}"
-    return json.loads(proc.stdout)
+    # The last JSON object on stdout, not the whole stream: a stub above may emit its
+    # own return value into the pipeline, and the report is always written last.
+    reports = [line for line in proc.stdout.splitlines() if line.startswith("{")]
+    assert reports, f"the handoff block printed no report:\n{proc.stdout}\n{proc.stderr}"
+    out = json.loads(reports[-1])
+    # The block is allowed to throw only where the test asked it to. Anything else is
+    # a missing stub or a real error, and reporting it beats "<never ran>".
+    if not fails:
+        assert not out.get("block_error"), f"the handoff block threw: {out['block_error']}"
+    return out
 
 
 @requires_pwsh

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -251,6 +251,9 @@ def test_installer_restores_the_private_handoff_after_setup():
     assert f"$previousRocmGfxHandoff = $env:{HANDOFF}" in src
     assert f"$env:{HANDOFF} = $previousRocmGfxHandoff" in src
     assert f"Remove-Item Env:{HANDOFF} -ErrorAction SilentlyContinue" in src
+    # Read as well as run: test_the_bail_restores_the_caller_environment drives the
+    # bail and watches the environment afterwards, which is the structural claim. This
+    # keeps the cheap textual check beside it so a reader sees the shape at a glance.
     # The invariant is that no path out of the setup call can skip the restore, and
     # the bail this used to sit after now lives INSIDE the try whose finally does the
     # restoring, which is a stronger arrangement than the ordering this once asserted.
@@ -534,7 +537,12 @@ def _handoff_lifecycle_block() -> str:
 
 
 def _run_handoff_lifecycle(
-    tmp_path: Path, *, arch: str | None, inherited: str | None, fails: bool
+    tmp_path: Path,
+    *,
+    arch: str | None,
+    inherited: str | None,
+    fails: bool,
+    bails: bool = False,
 ) -> dict:
     call = "Invoke-ManagedUnslothCli -Python $VenvPython -Arguments $studioArgs"
     block = _handoff_lifecycle_block()
@@ -567,7 +575,12 @@ def _run_handoff_lifecycle(
                 "$PackageName = 'unsloth'; $SkipTorch = $false; $TauriMode = $false",
                 "$StudioLocalInstall = $false; $RepoRoot = $null",
                 "$StudioRedirectMode = 'none'; $StudioHome = $null",
-                "$WithLlamaCppDir = $null; $VenvPython = 'stub-python'; $VenvDir = 'stub-venv'",
+                (
+                    f"$WithLlamaCppDir = '{tmp_path / 'no-such-llama.cpp'}'"
+                    if bails
+                    else "$WithLlamaCppDir = $null"
+                )
+                + "; $VenvPython = 'stub-python'; $VenvDir = 'stub-venv'",
                 "$TorchIndexUrl = $null; $ROCmIndexUrl = $null",
                 # Every installer function the block reaches, stubbed. Kept in step
                 # with it by the assertion below, which lists what the block calls.
@@ -584,15 +597,26 @@ def _run_handoff_lifecycle(
                 "$script:ManagedUnslothCliExit = 0",
                 "$script:PrevTorchPin = $null",
                 "$ROCmGfxArch = " + ("$null" if arch is None else f"'{arch}'"),
+                # In a function, so the block's own `return` leaves the block rather
+                # than the script: that return is the --with-llama-cpp-dir bail, and
+                # watching what the environment looks like AFTER it is the only way to
+                # show the restoring finally really encloses it.
+                "function Invoke-HandoffBlock {",
                 "try {",
                 body,
                 "} catch { $script:BlockError = $_.ToString() }",
+                "}",
+                "Invoke-HandoffBlock | Out-Null",
                 "@{",
                 "  seen_by_child = $script:SeenByChild",
                 "  block_error = $script:BlockError",
                 "  after = $(if (Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) { $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF } else { $null })",
                 "  after_set = [bool](Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF)",
                 "  public = $(if (Test-Path Env:UNSLOTH_ROCM_GFX_ARCH) { $env:UNSLOTH_ROCM_GFX_ARCH } else { $null })",
+                # Two the block sets at the top of its try, before the bail below it.
+                # Whether THOSE are gone afterwards is what says the finally ran.
+                "  package_name = $(if (Test-Path Env:STUDIO_PACKAGE_NAME) { $env:STUDIO_PACKAGE_NAME } else { $null })",
+                "  skip_base = $(if (Test-Path Env:SKIP_STUDIO_BASE) { $env:SKIP_STUDIO_BASE } else { $null })",
                 "} | ConvertTo-Json -Compress",
             ]
         ),
@@ -616,7 +640,14 @@ def _run_handoff_lifecycle(
     out = json.loads(reports[-1])
     # The block is allowed to throw only where the test asked it to. Anything else is
     # a missing stub or a real error, and reporting it beats "<never ran>".
-    if not fails:
+    if fails:
+        # The injected throw, not merely some throw: a helper failing before the
+        # setup call would leave the shipped finally to restore the environment and
+        # every assertion here would pass without the failure path ever running.
+        assert "setup exploded" in (
+            out.get("block_error") or ""
+        ), f"the block failed before the injected throw: {out.get('block_error')}"
+    else:
         assert not out.get("block_error"), f"the handoff block threw: {out['block_error']}"
     return out
 
@@ -635,6 +666,27 @@ def test_the_caller_environment_survives_the_setup_call(tmp_path, arch, inherite
     assert out["after_set"] is (inherited is not None), "the handoff outlived the setup call"
     assert out["after"] == inherited
     assert out["public"] == "gfx90a", "a user's own override must come back untouched"
+
+
+@requires_pwsh
+def test_the_bail_restores_the_caller_environment(tmp_path):
+    """The --with-llama-cpp-dir bail returns from inside the try, so the finally still runs.
+
+    Textual ordering cannot show that: move the try below the bail and `saved < bail <
+    restored` still holds while the return walks out past the restore. So this takes the
+    bail, with a directory that does not exist, and reads the environment afterwards.
+    """
+    out = _run_handoff_lifecycle(
+        tmp_path, arch = "gfx1151", inherited = "gfx1030", fails = False, bails = True
+    )
+    assert out["seen_by_child"] == "<never ran>", "the bail did not happen before the setup call"
+    assert out["after"] == "gfx1030", "the caller's inherited handoff was not restored by the bail"
+    assert out["after_set"] is True
+    # The ones that prove the finally ran rather than that nothing happened: the block
+    # sets both at the top of its try, above the bail, and only the finally takes them
+    # back off. A bail that escaped the try would leave them set in the caller.
+    assert out["package_name"] is None, "STUDIO_PACKAGE_NAME leaked past the bail"
+    assert out["skip_base"] is None, "SKIP_STUDIO_BASE leaked past the bail"
 
 
 @requires_pwsh

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -251,13 +251,9 @@ def test_installer_restores_the_private_handoff_after_setup():
     assert f"$previousRocmGfxHandoff = $env:{HANDOFF}" in src
     assert f"$env:{HANDOFF} = $previousRocmGfxHandoff" in src
     assert f"Remove-Item Env:{HANDOFF} -ErrorAction SilentlyContinue" in src
-    # Read as well as run: test_the_bail_restores_the_caller_environment drives the
-    # bail and watches the environment afterwards, which is the structural claim. This
-    # keeps the cheap textual check beside it so a reader sees the shape at a glance.
-    # The invariant is that no path out of the setup call can skip the restore, and
-    # the bail this used to sit after now lives INSIDE the try whose finally does the
-    # restoring, which is a stronger arrangement than the ordering this once asserted.
-    # So the check is the arrangement itself: save, then the bail, then the restore.
+    # Cheap companion to test_the_bail_restores_the_caller_environment, which drives the
+    # bail: no path out of the setup call may skip the restore, and the bail now lives
+    # inside the restoring try, so assert the arrangement save < bail < restore.
     saved = src.index("$previousRocmGfxHandoff = $env:")
     bail = src.index("--with-llama-cpp-dir path does not exist")
     restored = src.index(f"$env:{HANDOFF} = $previousRocmGfxHandoff")
@@ -546,9 +542,8 @@ def _run_handoff_lifecycle(
 ) -> dict:
     call = "Invoke-ManagedUnslothCli -Python $VenvPython -Arguments $studioArgs"
     block = _handoff_lifecycle_block()
-    # Loudly, because a silent miss here does not fail this harness: the probe below
-    # would simply never run and every assertion would read "<never ran>" with
-    # nothing saying why. The shipped call is what this block exists to wrap.
+    # Loudly: a silent miss leaves the probe unrun and every assertion reading
+    # "<never ran>" with nothing saying why.
     assert call in block, "install.ps1 no longer makes the setup call this harness replaces"
     body = block.replace(
         call,
@@ -568,10 +563,8 @@ def _run_handoff_lifecycle(
                 "$previousProxyHandoff = $null; $hadPreviousProxyHandoff = $false",
                 "$UnslothProxyHandoffJson = $null",
                 "$UnslothExe = 'stub'; $studioArgs = @(); $setupExit = 0",
-                # The block reads the installer's own inputs and calls its torch-tag
-                # helper. Undefined, they throw under ErrorActionPreference Stop, the
-                # catch below swallows it, and the probe never runs -- which is how
-                # this read as a handoff bug when the block simply grew a dependency.
+                # Installer inputs the block reads. Undefined, they throw under
+                # ErrorActionPreference Stop, the catch swallows it, and the probe never runs.
                 "$PackageName = 'unsloth'; $SkipTorch = $false; $TauriMode = $false",
                 "$StudioLocalInstall = $false; $RepoRoot = $null",
                 "$StudioRedirectMode = 'none'; $StudioHome = $null",
@@ -582,8 +575,7 @@ def _run_handoff_lifecycle(
                 )
                 + "; $VenvPython = 'stub-python'; $VenvDir = 'stub-venv'",
                 "$TorchIndexUrl = $null; $ROCmIndexUrl = $null",
-                # Every installer function the block reaches, stubbed. Kept in step
-                # with it by the assertion below, which lists what the block calls.
+                # Every installer function the block reaches, stubbed.
                 "function Get-ExpectedTorchFlavorTag { param($TorchIndexUrl, $ROCmIndexUrl) 'cu128' }",
                 "function Get-InstalledTorchVersionRaw { param($Python) '' }",
                 "function ConvertTo-TorchNumericRelease { param($Raw) $null }",
@@ -592,15 +584,12 @@ def _run_handoff_lifecycle(
                 "function Exit-InstallFailure { param($Message) 1 }",
                 "$script:SeenByChild = '<never ran>'",
                 "$script:BlockError = $null",
-                # The line after the setup call reads this, and the block now returns
-                # early when it is null, which took the report with it.
+                # Read right after the setup call; null makes the block return early.
                 "$script:ManagedUnslothCliExit = 0",
                 "$script:PrevTorchPin = $null",
                 "$ROCmGfxArch = " + ("$null" if arch is None else f"'{arch}'"),
-                # In a function, so the block's own `return` leaves the block rather
-                # than the script: that return is the --with-llama-cpp-dir bail, and
-                # watching what the environment looks like AFTER it is the only way to
-                # show the restoring finally really encloses it.
+                # In a function so the block's own return -- the --with-llama-cpp-dir bail --
+                # leaves the block, not the script, letting us read the environment after it.
                 "function Invoke-HandoffBlock {",
                 "try {",
                 body,
@@ -613,8 +602,8 @@ def _run_handoff_lifecycle(
                 "  after = $(if (Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) { $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF } else { $null })",
                 "  after_set = [bool](Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF)",
                 "  public = $(if (Test-Path Env:UNSLOTH_ROCM_GFX_ARCH) { $env:UNSLOTH_ROCM_GFX_ARCH } else { $null })",
-                # Two the block sets at the top of its try, before the bail below it.
-                # Whether THOSE are gone afterwards is what says the finally ran.
+                # Set at the top of the block's try, above the bail: gone afterwards
+                # is what says the finally ran.
                 "  package_name = $(if (Test-Path Env:STUDIO_PACKAGE_NAME) { $env:STUDIO_PACKAGE_NAME } else { $null })",
                 "  skip_base = $(if (Test-Path Env:SKIP_STUDIO_BASE) { $env:SKIP_STUDIO_BASE } else { $null })",
                 "} | ConvertTo-Json -Compress",
@@ -633,17 +622,14 @@ def _run_handoff_lifecycle(
         env = env,
     )
     assert proc.returncode == 0, f"handoff block failed:\n{proc.stdout}\n{proc.stderr}"
-    # The last JSON object on stdout, not the whole stream: a stub above may emit its
-    # own return value into the pipeline, and the report is always written last.
+    # Last JSON object only: a stub may emit its return value into the pipeline first.
     reports = [line for line in proc.stdout.splitlines() if line.startswith("{")]
     assert reports, f"the handoff block printed no report:\n{proc.stdout}\n{proc.stderr}"
     out = json.loads(reports[-1])
-    # The block is allowed to throw only where the test asked it to. Anything else is
-    # a missing stub or a real error, and reporting it beats "<never ran>".
+    # The block may throw only where the test asked; anything else is a missing stub.
     if fails:
-        # The injected throw, not merely some throw: a helper failing before the
-        # setup call would leave the shipped finally to restore the environment and
-        # every assertion here would pass without the failure path ever running.
+        # The injected throw specifically: an earlier helper failure would still restore
+        # the environment and pass every assertion without the failure path running.
         assert "setup exploded" in (
             out.get("block_error") or ""
         ), f"the block failed before the injected throw: {out.get('block_error')}"
@@ -682,9 +668,8 @@ def test_the_bail_restores_the_caller_environment(tmp_path):
     assert out["seen_by_child"] == "<never ran>", "the bail did not happen before the setup call"
     assert out["after"] == "gfx1030", "the caller's inherited handoff was not restored by the bail"
     assert out["after_set"] is True
-    # The ones that prove the finally ran rather than that nothing happened: the block
-    # sets both at the top of its try, above the bail, and only the finally takes them
-    # back off. A bail that escaped the try would leave them set in the caller.
+    # Set above the bail and removed only by the finally, so still set in the caller
+    # would mean the bail escaped the try.
     assert out["package_name"] is None, "STUDIO_PACKAGE_NAME leaked past the bail"
     assert out["skip_base"] is None, "SKIP_STUDIO_BASE leaked past the bail"
 


### PR DESCRIPTION
`tests/test_windows_amd_gpu_scan_fallback.py` fails four cases on main, so every open PR inherits them.

## What is actually wrong

The harness lifts install.ps1's save / set / try / finally block around the setup call and runs it with that call replaced by a probe. The block has grown dependencies since the harness was written:

- `Get-ExpectedTorchFlavorTag` and the torch pin check (#10524)
- `Write-ApplicationControlBlocked` (#8066)
- `$script:ManagedUnslothCliExit`, read on the line right after the call the harness replaces, with an early return when that exit code is null

None of them were bound in the stub script. Under `$ErrorActionPreference = 'Stop'` the block threw, the harness's own `catch { }` swallowed it, and every assertion read "never ran". That looks like a handoff defect and is not one: the shipped code is fine.

The fourth failure is `test_installer_restores_the_private_handoff_after_setup`, which asserted that the save appears after the `--with-llama-cpp-dir` bail in file order. That bail now sits inside the try whose finally restores, which is a stronger guarantee than the ordering the test used as a proxy for it.

## What this changes

- Bind the installer inputs and stub the functions the block calls.
- Assert the replacement actually matched, so a future rename fails with that sentence rather than an empty probe.
- Report the swallowed exception and fail on it, unless the case under test asked the block to throw.
- Read the report as the last JSON line on stdout, so a stub's own return value cannot be mistaken for it.
- Replace the ordering assertion with the invariant it stood for: save, then the bail, then the restore.

## It is still a real test

Dropping the inherited-handoff clear from install.ps1 fails `stale_only`; restoring it passes. All 82 tests in the file pass.
