### PR TITLE
Studio: record what was on screen when an upload simulation fails

### DIFF
--- a/tests/studio/rag_upload_browser_tests.py
+++ b/tests/studio/rag_upload_browser_tests.py
@@ -37,6 +37,28 @@ def wait_state(predicate):
     raise AssertionError(f"Server condition was not reached: {state}")
 
 
+def _snapshot(page):
+    """What the page and the fixture server held when a case failed.
+
+    A wait that expires reports only its own timeout, which says nothing about which side
+    stopped: the upload never posted, the stream never ended, or the rows were dropped.
+    """
+    snapshot = {}
+    try:
+        snapshot["page"] = page.evaluate(
+            "({documents: window.sim.documents, uploading: window.sim.uploading, "
+            "hasIndexing: window.sim.hasIndexing, errors: window.errors, "
+            "pageErrors: window.pageErrors, url: location.href})"
+        )
+    except Exception as exc:  # noqa: BLE001 - a snapshot must not replace the real failure
+        snapshot["page"] = f"unreadable: {exc}"
+    try:
+        snapshot["server"] = request("/__state")
+    except Exception as exc:  # noqa: BLE001 - same
+        snapshot["server"] = f"unreadable: {exc}"
+    return snapshot
+
+
 def run_case(browser, mode, action):
     request("/__scenario", {"mode": mode})
     context = browser.new_context()
@@ -49,6 +71,9 @@ def run_case(browser, mode, action):
         action(page)
         assert not errors, errors
         assert not page.evaluate("window.pageErrors"), "Unexpected browser error"
+    except Exception as exc:
+        exc.rag_snapshot = _snapshot(page)
+        raise
     finally:
         request("/__release", {})
         context.close()
@@ -270,6 +295,9 @@ def main():
                         "status": "failed",
                         "error": str(exc),
                     }
+                    snapshot = getattr(exc, "rag_snapshot", None)
+                    if snapshot is not None:
+                        record["snapshot"] = snapshot
                 record["seconds"] = round(time.monotonic() - start, 3)
                 print(json.dumps(record), flush = True)
                 records.append(record)


### PR DESCRIPTION
`Uploads (ubuntu-latest)` has now failed three consecutive runs on the same case, `lazy-thread-materialization` under webkit, always at the full 30s deadline. The record says only `Page.wait_for_function: Timeout 30000ms exceeded`, which does not distinguish the three ways it can happen: the upload never posted, the stream never reached a terminal state, or the rows were dropped before the wait could see them. macOS passes the same case, and a full local run on Linux passes it too, so the answer has to come from the runner.

A failing case now attaches a snapshot to its record: the page's `documents`, `uploading`, `hasIndexing`, its collected toast and page errors and its URL, plus the fixture server's `/__state` (uploads received, job states, open streams, poll count). Both reads are guarded so a snapshot can never replace the real failure.

Verified by forcing a wait to expire against a healthy fixture: the record came back with the page holding one `completed` document while the server showed the upload received, the job completed and zero open streams, which is exactly the shape needed to tell those three cases apart.