### PR TITLE
Make the install.ps1 handoff scrape run again, and fail loudly when it cannot

### DIFF
--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -251,12 +251,9 @@ def test_installer_restores_the_private_handoff_after_setup():
     assert f"$previousRocmGfxHandoff = $env:{HANDOFF}" in src
     assert f"$env:{HANDOFF} = $previousRocmGfxHandoff" in src
     assert f"Remove-Item Env:{HANDOFF} -ErrorAction SilentlyContinue" in src
-    # No path may skip the restore. This used to be spelled "the save sits after the last
-    # early return", which was a proxy for that and only for the shape the script had then:
-    # #8066 moved the --with-llama-cpp-dir bail INSIDE the try, which satisfies the same
-    # guarantee by a stronger route and inverted the index comparison. Assert the structure
-    # the guarantee actually needs -- save, then try, with every early return between the
-    # try and the finally that restores.
+    # No path may skip the restore. Spelled structurally, not as "the save sits after the
+    # last early return": that proxy held only for the old shape and #8066 inverted it by
+    # moving the bail inside the try.
     save = src.index("$previousRocmGfxHandoff = $env:")
     opened = src.index("\n    try {", save)
     restore = src.index(f"$env:{HANDOFF} = $previousRocmGfxHandoff", opened)
@@ -553,14 +550,11 @@ def _run_handoff_lifecycle(
         "\n".join(
             [
                 "$ErrorActionPreference = 'Stop'",
-                # The block calls helpers defined elsewhere in install.ps1. Stubbed rather than
-                # sourced, because sourcing runs the whole installer; none of them decides
-                # anything this test asserts, they just have to exist. A helper added later
-                # surfaces as block_error below rather than as a silent '<never ran>'.
+                # Helpers defined elsewhere in install.ps1: stubbed rather than sourced,
+                # since sourcing runs the whole installer. None decides anything asserted here.
                 "function Get-ExpectedTorchFlavorTag { param($TorchIndexUrl, $ROCmIndexUrl) 'cpu' }",
                 "function Get-InstalledTorchVersionRaw { param($Python) '' }",
-                # ValueFromRemainingArguments so a stub does not have to track the real
-                # signature: these are called with -ForegroundColor and friends.
+                # ValueFromRemainingArguments: called with -ForegroundColor and friends.
                 "function Write-StudioLine { param([Parameter(ValueFromRemainingArguments=$true)]$Rest) }",
                 "function Write-ApplicationControlBlocked { param([Parameter(ValueFromRemainingArguments=$true)]$Rest) }",
                 "function Exit-InstallFailure { param([Parameter(ValueFromRemainingArguments=$true)]$Rest) throw 'install failed' }",
@@ -571,9 +565,8 @@ def _run_handoff_lifecycle(
                 "$previousProxyHandoff = $null; $hadPreviousProxyHandoff = $false",
                 "$UnslothProxyHandoffJson = $null",
                 "$UnslothExe = 'stub'; $studioArgs = @(); $setupExit = 0",
-                # The substituted call stands in for Invoke-ManagedUnslothCli, so the exit code
-                # it publishes has to stand in too: the block reads it straight after, and $null
-                # there means "Application Control refused the process" and aborts.
+                # The block reads this straight after the call, and $null there means
+                # "Application Control refused the process" and aborts.
                 "$script:ManagedUnslothCliExit = 0",
                 # Inputs the shipped block reads on its way to the setup call.
                 "$PackageName = 'unsloth'; $SkipTorch = $false; $InstallerTorchTag = $null",
@@ -584,11 +577,9 @@ def _run_handoff_lifecycle(
                 "$ROCmGfxArch = " + ("$null" if arch is None else f"'{arch}'"),
                 "try {",
                 body,
-                # Recorded, not swallowed. A swallowed error left every assertion reading
-                # '<never ran>', which says nothing about WHY: when #8066 grew this block from
-                # 61 lines to 197 and added a Get-ExpectedTorchFlavorTag call, four tests
-                # failed with `assert '<never ran>' == 'gfx1151'` and no hint that a helper
-                # was missing rather than the handoff being broken.
+                # Recorded, not swallowed: swallowing it left every assertion reading
+                # '<never ran>', which names neither the missing helper nor the fact that the
+                # block never ran.
                 "} catch { $script:BlockError = $_.Exception.Message }",
                 "@{",
                 "  block_error = $script:BlockError",

--- a/tests/test_windows_amd_gpu_scan_fallback.py
+++ b/tests/test_windows_amd_gpu_scan_fallback.py
@@ -251,9 +251,19 @@ def test_installer_restores_the_private_handoff_after_setup():
     assert f"$previousRocmGfxHandoff = $env:{HANDOFF}" in src
     assert f"$env:{HANDOFF} = $previousRocmGfxHandoff" in src
     assert f"Remove-Item Env:{HANDOFF} -ErrorAction SilentlyContinue" in src
-    # Saved after the last early return, so no path skips the restore.
-    assert src.index("$previousRocmGfxHandoff") > src.index(
-        "--with-llama-cpp-dir path does not exist"
+    # No path may skip the restore. This used to be spelled "the save sits after the last
+    # early return", which was a proxy for that and only for the shape the script had then:
+    # #8066 moved the --with-llama-cpp-dir bail INSIDE the try, which satisfies the same
+    # guarantee by a stronger route and inverted the index comparison. Assert the structure
+    # the guarantee actually needs -- save, then try, with every early return between the
+    # try and the finally that restores.
+    save = src.index("$previousRocmGfxHandoff = $env:")
+    opened = src.index("\n    try {", save)
+    restore = src.index(f"$env:{HANDOFF} = $previousRocmGfxHandoff", opened)
+    bail = src.index("--with-llama-cpp-dir path does not exist", save)
+    assert save < opened < bail < restore, (
+        "an early return that can set the handoff must sit inside the try whose finally "
+        f"restores it (save={save}, try={opened}, bail={bail}, restore={restore})"
     )
 
 
@@ -543,6 +553,17 @@ def _run_handoff_lifecycle(
         "\n".join(
             [
                 "$ErrorActionPreference = 'Stop'",
+                # The block calls helpers defined elsewhere in install.ps1. Stubbed rather than
+                # sourced, because sourcing runs the whole installer; none of them decides
+                # anything this test asserts, they just have to exist. A helper added later
+                # surfaces as block_error below rather than as a silent '<never ran>'.
+                "function Get-ExpectedTorchFlavorTag { param($TorchIndexUrl, $ROCmIndexUrl) 'cpu' }",
+                "function Get-InstalledTorchVersionRaw { param($Python) '' }",
+                # ValueFromRemainingArguments so a stub does not have to track the real
+                # signature: these are called with -ForegroundColor and friends.
+                "function Write-StudioLine { param([Parameter(ValueFromRemainingArguments=$true)]$Rest) }",
+                "function Write-ApplicationControlBlocked { param([Parameter(ValueFromRemainingArguments=$true)]$Rest) }",
+                "function Exit-InstallFailure { param([Parameter(ValueFromRemainingArguments=$true)]$Rest) throw 'install failed' }",
                 # Not under test, but the shipped finally restores these too and needs them bound.
                 "$previousUnslothStudioHome = $null; $hadPreviousUnslothStudioHome = $false",
                 "$previousTauriMode = $null; $hadPreviousTauriMode = $false",
@@ -550,12 +571,27 @@ def _run_handoff_lifecycle(
                 "$previousProxyHandoff = $null; $hadPreviousProxyHandoff = $false",
                 "$UnslothProxyHandoffJson = $null",
                 "$UnslothExe = 'stub'; $studioArgs = @(); $setupExit = 0",
+                # The substituted call stands in for Invoke-ManagedUnslothCli, so the exit code
+                # it publishes has to stand in too: the block reads it straight after, and $null
+                # there means "Application Control refused the process" and aborts.
+                "$script:ManagedUnslothCliExit = 0",
+                # Inputs the shipped block reads on its way to the setup call.
+                "$PackageName = 'unsloth'; $SkipTorch = $false; $InstallerTorchTag = $null",
+                "$VenvPython = 'python'; $TorchIndexUrl = $null; $ROCmIndexUrl = $null",
+                "$VenvDir = $PSScriptRoot; $WithLlamaCppDir = $null; $StudioLocalRepo = $null",
                 "$script:SeenByChild = '<never ran>'",
+                "$script:BlockError = $null",
                 "$ROCmGfxArch = " + ("$null" if arch is None else f"'{arch}'"),
                 "try {",
                 body,
-                "} catch { }",
+                # Recorded, not swallowed. A swallowed error left every assertion reading
+                # '<never ran>', which says nothing about WHY: when #8066 grew this block from
+                # 61 lines to 197 and added a Get-ExpectedTorchFlavorTag call, four tests
+                # failed with `assert '<never ran>' == 'gfx1151'` and no hint that a helper
+                # was missing rather than the handoff being broken.
+                "} catch { $script:BlockError = $_.Exception.Message }",
                 "@{",
+                "  block_error = $script:BlockError",
                 "  seen_by_child = $script:SeenByChild",
                 "  after = $(if (Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF) { $env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF } else { $null })",
                 "  after_set = [bool](Test-Path Env:_UNSLOTH_ROCM_GFX_ARCH_HANDOFF)",
@@ -576,7 +612,16 @@ def _run_handoff_lifecycle(
         env = env,
     )
     assert proc.returncode == 0, f"handoff block failed:\n{proc.stdout}\n{proc.stderr}"
-    return json.loads(proc.stdout)
+    out = json.loads(proc.stdout)
+    # The fails=True variant throws on purpose, to drive the finally path. Anything else
+    # means the block died before reaching the setup call, and every assertion below would
+    # then be about an environment it never touched.
+    expected = "setup exploded" if fails else None
+    assert out["block_error"] == expected, (
+        "the shipped block threw before reaching the setup call, so nothing below is about "
+        f"the handoff at all: {out['block_error']}"
+    )
+    return out
 
 
 @requires_pwsh


### PR DESCRIPTION
Four tests in `tests/test_windows_amd_gpu_scan_fallback.py` fail on main:

```
FAILED test_only_this_runs_arch_is_handed_to_the_child[resolved]
E   AssertionError: assert '<never ran>' == 'gfx1151'
```

## Cause

The test lifts install.ps1's save / set / try / finally block out of the shipped script by string markers and runs it under `pwsh`. #8066 grew that block from **61 lines to 197** and, on the way to the setup call, added calls to `Get-ExpectedTorchFlavorTag`, `Get-InstalledTorchVersionRaw`, `Write-StudioLine`, `Write-ApplicationControlBlocked` and `Exit-InstallFailure`, plus reads of `$VenvDir` and `$script:ManagedUnslothCliExit`. None of those exist in the synthesized script, so the block threw on its first helper call and never reached the substituted line that records what the child saw.

**The production change is correct and this PR does not touch it.** The handoff is still set, cleared and restored (install.ps1:6637-6643, 6668-6670), and the `--with-llama-cpp-dir` bail moved *inside* the try, so the `finally` now covers a path that previously sat outside it. Only the test was wrong.

## The part worth reading

There were two failure modes, and the visible one was the milder.

`assert '<never ran>' == 'gfx1151'` names neither the missing helper nor the fact that the block never ran, because the harness wrapped the block in `catch { }` and discarded the error. The error is now recorded as `block_error` and asserted directly, so the next helper added to install.ps1 fails with `The term 'X' is not recognized` instead. Verified by deleting a stub: the failure names it.

More importantly, **eight further tests were passing while the block threw** -- `test_the_caller_environment_survives_the_setup_call` asserts that the handoff did not outlive the setup call, which is trivially true when the block never touched the environment. Surfacing `block_error` turned those into honest failures. That is why this change fixes 4 visible failures by first exposing 12.

`test_installer_restores_the_private_handoff_after_setup` had the same shape of problem in miniature: it asserted "the save sits after the last early return", a *proxy* for "no path skips the restore" that held only for the old layout, and #8066 inverted the index comparison by moving the bail inside the try. It now asserts the structure the guarantee actually needs -- save, then `try`, with the early return between the `try` and the `finally` that restores.

## Verification

- `tests/test_windows_amd_gpu_scan_fallback.py`: 4 failed / 78 passed -> **82 passed**.
- Mutation: remove any one helper stub and the suite fails naming the missing command, not `'<never ran>'`.
- `ruff check tests`: clean.

Found while confirming CI after #10490 merged; unrelated to that PR.
