### PR TITLE
Suppress the core dump on every crashing path in the RAG probe child

### DIFF
--- a/studio/backend/tests/test_rag_embeddings.py
+++ b/studio/backend/tests/test_rag_embeddings.py
@@ -29,12 +29,15 @@ _CRASHING_UNLESS_CPU_SCRIPT = (
     # which the probe reads as a working device. abort() is the real shape there: it is
     # what a ROCm library calls when it dies, and it leaves the CRT exit status 3 the
     # probe already recognises.
-    "    if sys.platform == 'win32':\n"
-    "        os.abort()\n"
+    # Hoisted above the win32 branch so it dominates EVERY crashing path, which is what
+    # tests/test_deliberate_crashes_suppress_cores.py checks. It costs nothing on Windows:
+    # prctl is Linux-only, the call is already guarded, and Windows has no core_pattern.
     "    try:\n"
     "        ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)  # PR_SET_DUMPABLE = 0\n"
     "    except Exception:\n"
     "        pass\n"
+    "    if sys.platform == 'win32':\n"
+    "        os.abort()\n"
     "    ctypes.string_at(0)\n"
 )
 


### PR DESCRIPTION
`tests/test_deliberate_crashes_suppress_cores.py` fails on main:

```
E   AssertionError: These crash a process on purpose without suppressing the core dump:
E       studio/backend/tests/test_rag_embeddings.py
E           a child script that crashes on purpose
```

## Cause

The suppression is there, but it stopped dominating every crashing path. #10530 ("make three RAG tests hold on Windows") added a Windows branch **above** it:

```python
"if sys.argv[1] != 'cpu':\n"
"    if sys.platform == 'win32':\n"
"        os.abort()\n"              # <- no suppression in front of this path
"    try:\n"
"        ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)  # PR_SET_DUMPABLE = 0\n"
```

The guard walks every branch with an AST path analysis and requires suppression to dominate each crash, so it flags the `abort()` path correctly.

## Both readings hold, so this is a move, not a behaviour change

- **#10530 is right.** `ctypes` installs a structured exception handler on Windows, so the null read comes back as an ordinary `OSError` and the child exits like a healthy one, which the probe misreads as a working device. `abort()` is the real shape there.
- **The guard is right.** A fatal signal piped to the host `core_pattern` handler costs about 4x the wall time and a multi-MB write per fault, every run.

Hoisting the `prctl` call above the platform split satisfies both. It already sits in a `try/except`, `prctl` is Linux-only so the call is a no-op on Windows, and Windows has no `core_pattern` to suppress. Nothing about what the child does, or which signal it dies of, changes.

## Verification

- `tests/test_deliberate_crashes_suppress_cores.py`: **73 passed** (was 1 failed).
- `studio/backend/tests/test_rag_embeddings.py`: **52 passed**, unchanged.
- Mutation: put the `abort()` back above the suppression and the guard fails again, so this is not being blessed by accident.

Found on a staging replica while confirming CI after #10490 merged; unrelated to that PR.
