### PR TITLE
Studio: clear dumpability before every crash the RAG probe child takes

### DIFF
--- a/studio/backend/tests/test_rag_embeddings.py
+++ b/studio/backend/tests/test_rag_embeddings.py
@@ -24,6 +24,13 @@ from core.rag import config, embeddings
 _CRASHING_UNLESS_CPU_SCRIPT = (
     "import ctypes, os, sys\n"
     "if sys.argv[1] != 'cpu':\n"
+    # First, and above the Windows branch below: every crash this child can take has to
+    # be preceded by the clear, and the abort() arm was not. A no-op off Linux, which is
+    # why it can sit ahead of the platform test rather than inside each arm.
+    "    try:\n"
+    "        ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)  # PR_SET_DUMPABLE = 0\n"
+    "    except Exception:\n"
+    "        pass\n"
     # ctypes installs a structured exception handler on Windows, so the null read below
     # comes back as an ordinary OSError and the child exits like any reporting child,
     # which the probe reads as a working device. abort() is the real shape there: it is
@@ -31,10 +38,6 @@ _CRASHING_UNLESS_CPU_SCRIPT = (
     # probe already recognises.
     "    if sys.platform == 'win32':\n"
     "        os.abort()\n"
-    "    try:\n"
-    "        ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)  # PR_SET_DUMPABLE = 0\n"
-    "    except Exception:\n"
-    "        pass\n"
     "    ctypes.string_at(0)\n"
 )
 


### PR DESCRIPTION
`tests/test_deliberate_crashes_suppress_cores.py::test_every_deliberate_crash_suppresses_its_core` fails on plain `origin/main` (reproduced at 56b8a6e4a, 1 failed / 72 passed):

```
assert not {PosixPath('studio/backend/tests/test_rag_embeddings.py'): ('a child script that crashes on purpose',)}
```

### What happened

#10530 gave the RAG probe's crashing child a Windows arm, because ctypes turns the null read into an ordinary OSError there and `abort()` is the shape a dying ROCm library actually has. That arm is correct, but it was placed above the `PR_SET_DUMPABLE` clear, so the child now has two crash paths and only the second one is suppressed. The guard parses the snippet and reports exactly that.

### The fix

Move the clear above the platform test rather than repeating it inside each arm. The call is already wrapped in `try/except` and is a no-op off Linux, so it is safe ahead of the branch, and every crash the child can take is now preceded by it. Linux behaviour is unchanged.

### Checks

- `studio/backend/tests/test_rag_embeddings.py`: 52 passed
- `tests/test_deliberate_crashes_suppress_cores.py`: 73 passed
- Mutation: restoring the old ordering makes the guard fail again, so the test is actually load-bearing here.
