### PR TITLE
Studio: keep unsloth start alive while a LoRA adapter's base model downloads

### DIFF
--- a/studio/backend/core/inference/audio_codecs.py
+++ b/studio/backend/core/inference/audio_codecs.py
@@ -22,6 +22,8 @@ import numpy as np
 import torch
 
 from utils.third_party_source import (
+    SNAC_REPOSITORY,
+    SPARK_TTS_REPOSITORY,
     deactivate_pinned_package,
     ensure_dac_speech_weights,
     ensure_outetts_source,
@@ -31,7 +33,7 @@ from utils.third_party_source import (
 )
 
 logger = get_logger(__name__)
-_SPARK_TTS_REPO = "unsloth/Spark-TTS-0.5B"
+_SPARK_TTS_REPO = SPARK_TTS_REPOSITORY
 _MAX_SPARK_EXPORT_METADATA_BYTES = 1_000_000
 
 
@@ -178,7 +180,7 @@ class AudioCodecManager:
         # Route weights to the selected cache; this can run in the main process.
         self._snac_model = (
             SNAC.from_pretrained(
-                model_repo_path or "hubertsiuzdak/snac_24khz",
+                model_repo_path or SNAC_REPOSITORY,
                 cache_dir = active_hf_hub_cache(),
             )
             .to(device)

--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -302,6 +302,7 @@ class InferenceOrchestrator:
         self.active_model_name: Optional[str] = None
         self.models: dict = {}
         self.loading_models: set = set()
+        self._load_download_keys: list[str] = []
         from core.inference.defaults import get_default_models
 
         # The list depends on detection (chat-only hosts get the GGUF set) and the MLX self-heal re-detects, so
@@ -840,6 +841,11 @@ class InferenceOrchestrator:
 
             if rtype == "status":
                 logger.info("Subprocess status: %s", resp.get("message", ""))
+                deadline = time.monotonic() + timeout
+                continue
+
+            if rtype == "downloads":
+                self._claim_load_downloads(resp)
                 deadline = time.monotonic() + timeout
                 continue
 
@@ -1757,6 +1763,7 @@ class InferenceOrchestrator:
                     if isinstance(_tpl_info, dict):
                         self.models[self.active_model_name]["chat_template_info"] = _tpl_info
                     self.loading_models.discard(model_name)
+                    self._release_load_downloads("complete")
                     logger.info("Model '%s' loaded successfully in subprocess", model_name)
                     return True
                 else:
@@ -1768,6 +1775,7 @@ class InferenceOrchestrator:
 
         except Exception as exc:
             self.loading_models.discard(model_name)
+            self._release_load_downloads("error")
             from utils.transformers_version import SidecarSwapInProgress
 
             if isinstance(exc, SidecarSwapInProgress) and self._ensure_subprocess_alive():
@@ -1783,6 +1791,32 @@ class InferenceOrchestrator:
             except Exception as teardown_exc:
                 logger.warning("Could not shut the failed load's worker down: %s", teardown_exc)
             raise
+        finally:
+            self._release_load_downloads("cancelled")
+
+    def _claim_load_downloads(self, resp: dict) -> None:
+        from hub.services.load_downloads import claim_load_downloads
+
+        self._release_load_downloads("cancelled")
+        try:
+            self._load_download_keys = claim_load_downloads(
+                resp.get("repo_ids") or [],
+                xet_disabled = bool(resp.get("xet_disabled")),
+                hub_cache = resp.get("hub_cache"),
+            )
+        except Exception as exc:
+            logger.warning("Could not register the load's downloads: %s", exc)
+
+    def _release_load_downloads(self, state: str) -> None:
+        keys, self._load_download_keys = self._load_download_keys, []
+        if not keys:
+            return
+        from hub.services.load_downloads import release_load_downloads
+
+        try:
+            release_load_downloads(keys, state)
+        except Exception as exc:
+            logger.warning("Could not release the load's downloads: %s", exc)
 
     def cancel_load(self, model_name: str) -> bool:
         """Abort an in-flight load by terminating its subprocess.

--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -1796,7 +1796,6 @@ class InferenceOrchestrator:
 
     def _claim_load_downloads(self, resp: dict) -> None:
         from hub.services.load_downloads import claim_load_downloads
-
         self._release_load_downloads("cancelled")
         try:
             self._load_download_keys = claim_load_downloads(

--- a/studio/backend/core/inference/orchestrator.py
+++ b/studio/backend/core/inference/orchestrator.py
@@ -1763,7 +1763,7 @@ class InferenceOrchestrator:
                     if isinstance(_tpl_info, dict):
                         self.models[self.active_model_name]["chat_template_info"] = _tpl_info
                     self.loading_models.discard(model_name)
-                    self._release_load_downloads("complete")
+                    self._release_load_downloads()
                     logger.info("Model '%s' loaded successfully in subprocess", model_name)
                     return True
                 else:
@@ -1775,7 +1775,7 @@ class InferenceOrchestrator:
 
         except Exception as exc:
             self.loading_models.discard(model_name)
-            self._release_load_downloads("error")
+            self._release_load_downloads()
             from utils.transformers_version import SidecarSwapInProgress
 
             if isinstance(exc, SidecarSwapInProgress) and self._ensure_subprocess_alive():
@@ -1792,11 +1792,11 @@ class InferenceOrchestrator:
                 logger.warning("Could not shut the failed load's worker down: %s", teardown_exc)
             raise
         finally:
-            self._release_load_downloads("cancelled")
+            self._release_load_downloads()
 
     def _claim_load_downloads(self, resp: dict) -> None:
         from hub.services.load_downloads import claim_load_downloads
-        self._release_load_downloads("cancelled")
+        self._release_load_downloads()
         try:
             self._load_download_keys = claim_load_downloads(
                 resp.get("repo_ids") or [],
@@ -1806,14 +1806,14 @@ class InferenceOrchestrator:
         except Exception as exc:
             logger.warning("Could not register the load's downloads: %s", exc)
 
-    def _release_load_downloads(self, state: str) -> None:
+    def _release_load_downloads(self) -> None:
         keys, self._load_download_keys = self._load_download_keys, []
         if not keys:
             return
         from hub.services.load_downloads import release_load_downloads
 
         try:
-            release_load_downloads(keys, state)
+            release_load_downloads(keys)
         except Exception as exc:
             logger.warning("Could not release the load's downloads: %s", exc)
 

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -413,7 +413,12 @@ def _load_download_repos(
                 from unsloth.models import loader
                 from unsloth.models.loader_utils import get_model_name
 
-                mapped = get_model_name(str(base), load_in_4bit = load_in_4bit and audio_type is None)
+                quantized = (
+                    load_in_4bit
+                    and audio_type is None
+                    and getattr(loader, "ALLOW_BITSANDBYTES", True)
+                )
+                mapped = get_model_name(str(base), load_in_4bit = quantized)
                 if mapped and not getattr(loader, "ALLOW_PREQUANTIZED_MODELS", True):
                     mapped = loader._strip_unsloth_bnb_4bit_suffix(mapped)
             except Exception:

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -392,12 +392,8 @@ def _worker_reclaimable_gpu_gb(config: dict) -> dict[str, float] | None:
         return None
 
 
-def _load_download_repos(
-    mc,
-    load_in_4bit: bool,
-    backend,
-    companions = (),
-) -> list[str]:
+def _load_download_repos(mc, load_in_4bit: bool, backend, companions = ()) -> list[str]:
+    from hub.utils.paths import is_valid_repo_id
     from utils.paths import is_local_path
     from utils.security.file_security import load_scan_target
     from utils.third_party_source import SPEECH_CODEC_REPOSITORIES
@@ -423,7 +419,7 @@ def _load_download_repos(
     hub_ids: list[str] = []
     for repo in repos:
         repo, _subdirs = load_scan_target(repo, ())
-        if repo.count("/") == 1 and not is_local_path(repo) and repo not in hub_ids:
+        if is_valid_repo_id(repo) and not is_local_path(repo) and repo not in hub_ids:
             hub_ids.append(repo)
     return hub_ids
 

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -392,7 +392,12 @@ def _worker_reclaimable_gpu_gb(config: dict) -> dict[str, float] | None:
         return None
 
 
-def _load_download_repos(mc, load_in_4bit: bool, backend, companions = ()) -> list[str]:
+def _load_download_repos(
+    mc,
+    load_in_4bit: bool,
+    backend,
+    companions = (),
+) -> list[str]:
     from utils.paths import is_local_path
     from utils.security.file_security import load_scan_target
     from utils.third_party_source import SPEECH_CODEC_REPOSITORIES

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -412,7 +412,6 @@ def _load_download_repos(
         if getattr(backend, "device", None) == "mlx":
             try:
                 from unsloth_zoo.mlx.loader import _remap_unsloth_bnb_hub_id_for_mlx
-
                 mapped = _remap_unsloth_bnb_hub_id_for_mlx(str(base), None)[0]
             except Exception:
                 mapped = None

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -401,8 +401,11 @@ def _load_download_repos(mc, load_in_4bit: bool, backend) -> list[str]:
         repos.append(str(base))
         if getattr(backend, "device", None) != "mlx":
             try:
+                from unsloth.models import loader
                 from unsloth.models.loader_utils import get_model_name
                 mapped = get_model_name(str(base), load_in_4bit = load_in_4bit)
+                if mapped and not getattr(loader, "ALLOW_PREQUANTIZED_MODELS", True):
+                    mapped = loader._strip_unsloth_bnb_4bit_suffix(mapped)
             except Exception:
                 mapped = None
             if mapped:

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -392,7 +392,12 @@ def _worker_reclaimable_gpu_gb(config: dict) -> dict[str, float] | None:
         return None
 
 
-def _load_download_repos(mc, load_in_4bit: bool, backend, companions = ()) -> list[str]:
+def _load_download_repos(
+    mc,
+    load_in_4bit: bool,
+    backend,
+    companions = (),
+) -> list[str]:
     from hub.utils.paths import is_valid_repo_id
     from utils.paths import is_local_path
     from utils.security.file_security import load_scan_target

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -23,7 +23,7 @@ import time
 import traceback
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 logger = get_logger(__name__)
 from core.inference.audio_errors import AUDIO_UNSUPPORTED_CODE
@@ -392,6 +392,34 @@ def _worker_reclaimable_gpu_gb(config: dict) -> dict[str, float] | None:
         return None
 
 
+def _load_download_repos(mc, load_in_4bit: bool, backend) -> list[str]:
+    from utils.paths import is_local_path
+
+    repos = [str(mc.identifier)]
+    base = getattr(mc, "base_model", None)
+    if base:
+        repos.append(str(base))
+        if getattr(backend, "device", None) != "mlx":
+            try:
+                from unsloth.models.loader_utils import get_model_name
+
+                mapped = get_model_name(str(base), load_in_4bit = load_in_4bit)
+            except Exception:
+                mapped = None
+            if mapped:
+                repos.append(str(mapped))
+    return [repo for repo in dict.fromkeys(repos) if repo.count("/") == 1 and not is_local_path(repo)]
+
+
+def _hub_cache_dir() -> Optional[str]:
+    try:
+        from utils.hf_cache_settings import get_hf_cache_paths
+
+        return str(get_hf_cache_paths().hub_cache)
+    except Exception:
+        return None
+
+
 def _handle_load(backend, config: dict, resp_queue: Any) -> None:
     """Handle a load command: load a model into the backend."""
     try:
@@ -462,6 +490,15 @@ def _handle_load(backend, config: dict, resp_queue: Any) -> None:
         if base and str(base) != mc.identifier:
             watch_repos.append(str(base))
 
+        _send_response(
+            resp_queue,
+            {
+                "type": "downloads",
+                "repo_ids": _load_download_repos(mc, load_in_4bit, backend),
+                "xet_disabled": os.environ.get("HF_HUB_DISABLE_XET") == "1",
+                "hub_cache": _hub_cache_dir(),
+            },
+        )
         heartbeat_stop = start_watchdog(
             repo_ids = watch_repos,
             on_stall = lambda msg: _send_response(resp_queue, {"type": "stall", "message": msg}),

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -402,19 +402,19 @@ def _load_download_repos(mc, load_in_4bit: bool, backend) -> list[str]:
         if getattr(backend, "device", None) != "mlx":
             try:
                 from unsloth.models.loader_utils import get_model_name
-
                 mapped = get_model_name(str(base), load_in_4bit = load_in_4bit)
             except Exception:
                 mapped = None
             if mapped:
                 repos.append(str(mapped))
-    return [repo for repo in dict.fromkeys(repos) if repo.count("/") == 1 and not is_local_path(repo)]
+    return [
+        repo for repo in dict.fromkeys(repos) if repo.count("/") == 1 and not is_local_path(repo)
+    ]
 
 
 def _hub_cache_dir() -> Optional[str]:
     try:
         from utils.hf_cache_settings import get_hf_cache_paths
-
         return str(get_hf_cache_paths().hub_cache)
     except Exception:
         return None

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -392,10 +392,13 @@ def _worker_reclaimable_gpu_gb(config: dict) -> dict[str, float] | None:
         return None
 
 
-def _load_download_repos(mc, load_in_4bit: bool, backend) -> list[str]:
+def _load_download_repos(mc, load_in_4bit: bool, backend, companions = ()) -> list[str]:
     from utils.paths import is_local_path
+    from utils.security.file_security import load_scan_target
+    from utils.third_party_source import SPEECH_CODEC_REPOSITORIES
 
-    repos = [str(mc.identifier)]
+    audio_type = getattr(mc, "audio_type", None)
+    repos = [str(mc.identifier), *(str(repo) for repo in companions)]
     base = getattr(mc, "base_model", None)
     if base:
         repos.append(str(base))
@@ -404,16 +407,20 @@ def _load_download_repos(mc, load_in_4bit: bool, backend) -> list[str]:
                 from unsloth.models import loader
                 from unsloth.models.loader_utils import get_model_name
 
-                mapped = get_model_name(str(base), load_in_4bit = load_in_4bit)
+                mapped = get_model_name(str(base), load_in_4bit = load_in_4bit and audio_type is None)
                 if mapped and not getattr(loader, "ALLOW_PREQUANTIZED_MODELS", True):
                     mapped = loader._strip_unsloth_bnb_4bit_suffix(mapped)
             except Exception:
                 mapped = None
             if mapped:
                 repos.append(str(mapped))
-    return [
-        repo for repo in dict.fromkeys(repos) if repo.count("/") == 1 and not is_local_path(repo)
-    ]
+    repos.extend(SPEECH_CODEC_REPOSITORIES.get(audio_type, ()))
+    hub_ids: list[str] = []
+    for repo in repos:
+        repo, _subdirs = load_scan_target(repo, ())
+        if repo.count("/") == 1 and not is_local_path(repo) and repo not in hub_ids:
+            hub_ids.append(repo)
+    return hub_ids
 
 
 def _hub_cache_dir() -> Optional[str]:
@@ -498,7 +505,7 @@ def _handle_load(backend, config: dict, resp_queue: Any) -> None:
             resp_queue,
             {
                 "type": "downloads",
-                "repo_ids": _load_download_repos(mc, load_in_4bit, backend),
+                "repo_ids": _load_download_repos(mc, load_in_4bit, backend, targets),
                 "xet_disabled": os.environ.get("HF_HUB_DISABLE_XET") == "1",
                 "hub_cache": _hub_cache_dir(),
             },

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -408,7 +408,15 @@ def _load_download_repos(
     base = getattr(mc, "base_model", None)
     if base:
         repos.append(str(base))
-        if getattr(backend, "device", None) != "mlx":
+        mapped = None
+        if getattr(backend, "device", None) == "mlx":
+            try:
+                from unsloth_zoo.mlx.loader import _remap_unsloth_bnb_hub_id_for_mlx
+
+                mapped = _remap_unsloth_bnb_hub_id_for_mlx(str(base), None)[0]
+            except Exception:
+                mapped = None
+        else:
             try:
                 from unsloth.models import loader
                 from unsloth.models.loader_utils import get_model_name
@@ -423,8 +431,8 @@ def _load_download_repos(
                     mapped = loader._strip_unsloth_bnb_4bit_suffix(mapped)
             except Exception:
                 mapped = None
-            if mapped:
-                repos.append(str(mapped))
+        if mapped:
+            repos.append(str(mapped))
     repos.extend(SPEECH_CODEC_REPOSITORIES.get(audio_type, ()))
     hub_ids: list[str] = []
     for repo in repos:

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -403,6 +403,7 @@ def _load_download_repos(mc, load_in_4bit: bool, backend) -> list[str]:
             try:
                 from unsloth.models import loader
                 from unsloth.models.loader_utils import get_model_name
+
                 mapped = get_model_name(str(base), load_in_4bit = load_in_4bit)
                 if mapped and not getattr(loader, "ALLOW_PREQUANTIZED_MODELS", True):
                     mapped = loader._strip_unsloth_bnb_4bit_suffix(mapped)

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -423,7 +423,7 @@ def _load_download_repos(
 
                 quantized = (
                     load_in_4bit
-                    and audio_type is None
+                    and not getattr(mc, "is_audio", False)
                     and getattr(loader, "ALLOW_BITSANDBYTES", True)
                 )
                 mapped = get_model_name(str(base), load_in_4bit = quantized)

--- a/studio/backend/hub/schemas/downloads.py
+++ b/studio/backend/hub/schemas/downloads.py
@@ -102,6 +102,7 @@ class ActiveDownload(BaseModel):
     transport: Optional[str] = None
     cancel_transport: Optional[str] = None
     owner: Optional[str] = None
+    load_attached: Optional[bool] = None
     state: str
     files: Optional[List[str]] = Field(
         None,

--- a/studio/backend/hub/schemas/downloads.py
+++ b/studio/backend/hub/schemas/downloads.py
@@ -101,6 +101,7 @@ class ActiveDownload(BaseModel):
     variant: Optional[str] = None
     transport: Optional[str] = None
     cancel_transport: Optional[str] = None
+    owner: Optional[str] = None
     state: str
     files: Optional[List[str]] = Field(
         None,

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -1356,6 +1356,7 @@ def active_download_refs(
                     metadata.cancel_marker_transport if metadata is not None else None
                 ),
                 owner = metadata.owner if metadata is not None else None,
+                load_attached = metadata.load_attached if metadata is not None else None,
                 state = ref.state,
                 generation = ref.generation,
                 files = scoped_files or None,

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -1355,6 +1355,7 @@ def active_download_refs(
                 cancel_transport = (
                     metadata.cancel_marker_transport if metadata is not None else None
                 ),
+                owner = metadata.owner if metadata is not None else None,
                 state = ref.state,
                 generation = ref.generation,
                 files = scoped_files or None,

--- a/studio/backend/hub/services/load_downloads.py
+++ b/studio/backend/hub/services/load_downloads.py
@@ -52,8 +52,5 @@ def claim_load_downloads(
 def release_load_downloads(keys: Sequence[str]) -> None:
     registry = download_registry.get_models_registry()
     for key in keys:
-        if is_load_owned(registry, key):
-            registry.set_job(key, "idle")
-            registry.release_active_slot(key)
-        else:
+        if not registry.release_owned(key, LOAD_OWNER):
             registry.mark_load_attached(key, False)

--- a/studio/backend/hub/services/load_downloads.py
+++ b/studio/backend/hub/services/load_downloads.py
@@ -39,11 +39,13 @@ def claim_load_downloads(
             hub_cache = hub_cache,
             owner = LOAD_OWNER,
         )
-        if not accepted and registry.get_job(key).state in _ACTIVE:
-            registry.mark_load_attached(key, True)
-            accepted = True
         if accepted:
             keys.append(key)
+            continue
+        for ref in registry.active_job_refs(repo_id):
+            registry.mark_load_attached(ref.key, True)
+            if ref.key not in keys:
+                keys.append(ref.key)
     return keys
 
 

--- a/studio/backend/hub/services/load_downloads.py
+++ b/studio/backend/hub/services/load_downloads.py
@@ -4,6 +4,7 @@ from hub.utils import download_registry
 from hub.utils.hf_cache_state import TRANSPORT_HTTP, TRANSPORT_XET
 
 LOAD_OWNER = "load"
+_ACTIVE = ("running", "cancelling")
 
 
 def _job_key(repo_id: str) -> str:
@@ -14,7 +15,7 @@ def is_load_owned(registry: download_registry.DownloadRegistry, key: str) -> boo
     metadata = registry.get_job_metadata(key)
     if metadata is None or metadata.owner != LOAD_OWNER:
         return False
-    return registry.get_job(key).state in ("running", "cancelling")
+    return registry.get_job(key).state in _ACTIVE
 
 
 def claim_load_downloads(
@@ -25,25 +26,32 @@ def claim_load_downloads(
 ) -> list[str]:
     registry = download_registry.get_models_registry()
     transport = TRANSPORT_HTTP if xet_disabled else TRANSPORT_XET
-    claimed: list[str] = []
+    keys: list[str] = []
     for repo_id in dict.fromkeys(str(repo).strip() for repo in repo_ids if repo):
         if not repo_id:
             continue
+        key = _job_key(repo_id)
         accepted, _state = registry.claim(
-            _job_key(repo_id),
+            key,
             transport,
             repo_type = "model",
             repo_id = repo_id,
             hub_cache = hub_cache,
             owner = LOAD_OWNER,
         )
+        if not accepted and registry.get_job(key).state in _ACTIVE:
+            registry.mark_load_attached(key, True)
+            accepted = True
         if accepted:
-            claimed.append(_job_key(repo_id))
-    return claimed
+            keys.append(key)
+    return keys
 
 
-def release_load_downloads(keys: Sequence[str], state: download_registry.JobState) -> None:
+def release_load_downloads(keys: Sequence[str]) -> None:
     registry = download_registry.get_models_registry()
     for key in keys:
         if is_load_owned(registry, key):
-            registry.set_job(key, state)
+            registry.set_job(key, "idle")
+            registry.release_active_slot(key)
+        else:
+            registry.mark_load_attached(key, False)

--- a/studio/backend/hub/services/load_downloads.py
+++ b/studio/backend/hub/services/load_downloads.py
@@ -1,0 +1,49 @@
+from typing import Optional, Sequence
+
+from hub.utils import download_registry
+from hub.utils.hf_cache_state import TRANSPORT_HTTP, TRANSPORT_XET
+
+LOAD_OWNER = "load"
+
+
+def _job_key(repo_id: str) -> str:
+    return download_registry.normalize_job_key(f"{download_registry.normalize_repo_key(repo_id)}::")
+
+
+def is_load_owned(registry: download_registry.DownloadRegistry, key: str) -> bool:
+    metadata = registry.get_job_metadata(key)
+    if metadata is None or metadata.owner != LOAD_OWNER:
+        return False
+    return registry.get_job(key).state in ("running", "cancelling")
+
+
+def claim_load_downloads(
+    repo_ids: Sequence[str],
+    *,
+    xet_disabled: bool = False,
+    hub_cache: Optional[str] = None,
+) -> list[str]:
+    registry = download_registry.get_models_registry()
+    transport = TRANSPORT_HTTP if xet_disabled else TRANSPORT_XET
+    claimed: list[str] = []
+    for repo_id in dict.fromkeys(str(repo).strip() for repo in repo_ids if repo):
+        if not repo_id:
+            continue
+        accepted, _state = registry.claim(
+            _job_key(repo_id),
+            transport,
+            repo_type = "model",
+            repo_id = repo_id,
+            hub_cache = hub_cache,
+            owner = LOAD_OWNER,
+        )
+        if accepted:
+            claimed.append(_job_key(repo_id))
+    return claimed
+
+
+def release_load_downloads(keys: Sequence[str], state: download_registry.JobState) -> None:
+    registry = download_registry.get_models_registry()
+    for key in keys:
+        if is_load_owned(registry, key):
+            registry.set_job(key, state)

--- a/studio/backend/hub/services/models/downloads.py
+++ b/studio/backend/hub/services/models/downloads.py
@@ -148,6 +148,17 @@ def _reject_if_load_in_flight(repo_id: str) -> None:
         raise _load_in_flight_error(repo_id)
 
 
+def _reject_if_load_owned(key: str) -> None:
+    if load_downloads.is_load_owned(_registry, key):
+        raise HTTPException(
+            status_code = 409,
+            detail = (
+                "A model load is fetching this repo. Wait for the load to finish "
+                "(or cancel it), then start the download."
+            ),
+        )
+
+
 def _spawn_download_worker(
     repo_id: str,
     variant: Optional[str],
@@ -218,6 +229,7 @@ async def download_model_response(
             raise HTTPException(status_code = 400, detail = f"Invalid scope_id: {body.scope_id!r}")
         variant = scope_variant
     key = _download_job_key(repo_id, variant)
+    _reject_if_load_owned(key)
     # Off the event loop: resolving "auto" can run the Xet reachability probe, and a blackholed DNS
     # makes that outlast its 3s budget while every other request waits behind it.
     use_xet, transport_reason = await asyncio.to_thread(

--- a/studio/backend/hub/services/models/downloads.py
+++ b/studio/backend/hub/services/models/downloads.py
@@ -320,6 +320,7 @@ async def download_model_response(
         # claim_state is the blocking job's state. Attaching and accepting are one verdict: only this
         # key's own in-flight job can be joined, and a cross-variant conflict or in-progress delete joined
         # nothing.
+        _reject_if_load_owned(key)
         adoptable = _registry.adoptable(key)
         return {
             "job_key": key,

--- a/studio/backend/hub/services/models/downloads.py
+++ b/studio/backend/hub/services/models/downloads.py
@@ -31,6 +31,7 @@ from hub.utils.paths import (
 )
 from hub.services import snapshot_progress
 from hub.services import download_lifecycle
+from hub.services import load_downloads
 from hub.services.models import cache_inventory, gguf_variants
 
 logger = get_logger(__name__)
@@ -384,6 +385,11 @@ async def cancel_download_model_response(body: CancelDownloadRequest):
             detail = f"Invalid gguf_variant: {variant!r}",
         )
     key = _download_job_key(repo_id, variant)
+    if load_downloads.is_load_owned(_registry, key):
+        raise HTTPException(
+            status_code = 409,
+            detail = "This repo is being fetched by a model load; cancel the load instead.",
+        )
 
     state = download_lifecycle.cancel_worker(
         _registry,

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -1252,6 +1252,7 @@ class DownloadMetadata:
     # Scoped jobs only: the exact files to fetch, kept so the XET -> HTTP retry respawns the same scoped download.
     scoped_files: tuple[str, ...] = ()
     owner: Optional[str] = None
+    load_attached: bool = False
 
 
 @dataclass(frozen = True)
@@ -1451,6 +1452,14 @@ class DownloadRegistry:
             if metadata is None or metadata.transport == transport:
                 return
             self._metadata[key] = replace(metadata, transport = transport)
+
+    def mark_load_attached(self, key: str, attached: bool) -> None:
+        key = normalize_job_key(key)
+        with self._lock:
+            metadata = self._metadata.get(key)
+            if metadata is None or metadata.load_attached == attached:
+                return
+            self._metadata[key] = replace(metadata, load_attached = attached)
 
     def release_active_slot(self, key: str) -> None:
         key = normalize_job_key(key)

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -1964,6 +1964,10 @@ class DownloadRegistry:
             for key, job in list(self._jobs.items()):
                 if job.state not in _ACTIVE_STATES or key in live_keys:
                     continue
+                placeholder = self._metadata.get(key)
+                if placeholder is not None and placeholder.owner is not None:
+                    self._jobs[key] = DownloadState("idle")
+                    continue
                 proc = self._processes.get(key)
                 if proc is not None:
                     if proc.poll() == 0:

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -1251,6 +1251,7 @@ class DownloadMetadata:
     xet_cache: Optional[str] = None
     # Scoped jobs only: the exact files to fetch, kept so the XET -> HTTP retry respawns the same scoped download.
     scoped_files: tuple[str, ...] = ()
+    owner: Optional[str] = None
 
 
 @dataclass(frozen = True)
@@ -1594,6 +1595,7 @@ class DownloadRegistry:
         hub_cache: Optional[str] = None,
         xet_cache: Optional[str] = None,
         scoped_files: Optional[Sequence[str]] = None,
+        owner: Optional[str] = None,
     ) -> tuple[bool, str]:
         key = normalize_job_key(key)
         repo = _repo_of_key(key)
@@ -1677,6 +1679,7 @@ class DownloadRegistry:
                     hub_cache = hub_cache,
                     xet_cache = xet_cache,
                     scoped_files = tuple(scoped_files or ()),
+                    owner = owner,
                 )
                 if cancel_marker_transport is not None:
                     self._cancel_marker_transports[key] = cancel_marker_transport

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -1670,6 +1670,7 @@ class DownloadRegistry:
                 self._generations[key] = self._generation_seq
             else:
                 self._generations[key] = generation
+            previous = self._metadata.get(key) if current in _ACTIVE_STATES else None
             self._jobs[key] = DownloadState("running")
             self._repo_active.setdefault(repo, active).add(key)
             if repo_type and repo_id:
@@ -1689,6 +1690,7 @@ class DownloadRegistry:
                     xet_cache = xet_cache,
                     scoped_files = tuple(scoped_files or ()),
                     owner = owner,
+                    load_attached = previous.load_attached if previous is not None else False,
                 )
                 if cancel_marker_transport is not None:
                     self._cancel_marker_transports[key] = cancel_marker_transport
@@ -1736,6 +1738,9 @@ class DownloadRegistry:
         or an in-progress delete, where no job exists for this key."""
         key = normalize_job_key(key)
         with self._lock:
+            metadata = self._metadata.get(key)
+            if metadata is not None and metadata.owner is not None:
+                return False
             return self._jobs.get(key, DownloadState("idle")).state in _ACTIVE_STATES
 
     def _active_job_variant_locked(self, key: str) -> Optional[str]:

--- a/studio/backend/hub/utils/download_registry.py
+++ b/studio/backend/hub/utils/download_registry.py
@@ -1453,6 +1453,26 @@ class DownloadRegistry:
                 return
             self._metadata[key] = replace(metadata, transport = transport)
 
+    def release_owned(self, key: str, owner: str) -> bool:
+        key = normalize_job_key(key)
+        with self._lock:
+            metadata = self._metadata.get(key)
+            if metadata is None or metadata.owner != owner:
+                return False
+            if self._jobs.get(key, DownloadState("idle")).state not in _ACTIVE_STATES:
+                return False
+            self._jobs[key] = DownloadState("idle")
+            self._discard_active_locked(key)
+            return True
+
+    def _discard_active_locked(self, key: str) -> None:
+        repo = _repo_of_key(key)
+        active = self._repo_active.get(repo)
+        if active is not None:
+            active.discard(key)
+            if not active:
+                self._repo_active.pop(repo, None)
+
     def mark_load_attached(self, key: str, attached: bool) -> None:
         key = normalize_job_key(key)
         with self._lock:
@@ -1972,6 +1992,7 @@ class DownloadRegistry:
                 placeholder = self._metadata.get(key)
                 if placeholder is not None and placeholder.owner is not None:
                     self._jobs[key] = DownloadState("idle")
+                    self._discard_active_locked(key)
                     continue
                 proc = self._processes.get(key)
                 if proc is not None:

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -45,7 +45,19 @@ def test_a_load_claims_running_jobs_the_active_list_reports(registry):
 
     assert _active(registry) == []
     assert registry.get_job(keys[0]).state == "idle"
+    assert registry._repo_active == {}
     assert registry.claim(keys[0], "http", repo_type = "model", repo_id = "owner/adapter")[0]
+
+
+def test_release_leaves_a_job_another_owner_took_over(registry):
+    keys = load_downloads.claim_load_downloads(["owner/base"])
+    assert registry.release_owned(keys[0], load_downloads.LOAD_OWNER)
+    assert registry.claim("owner/base::", "http", repo_type = "model", repo_id = "owner/base")[0]
+
+    load_downloads.release_load_downloads(keys)
+
+    assert registry.get_job("owner/base::").state == "running"
+    assert registry._repo_active == {"owner/base": {"owner/base::"}}
 
 
 def test_a_load_attaches_to_a_hub_download_of_the_same_repo(registry):

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -64,6 +64,23 @@ def test_a_load_attaches_to_a_hub_download_of_the_same_repo(registry):
     assert (ref.load_attached, ref.state) == (False, "running")
 
 
+def test_a_load_attaches_to_a_variant_download_of_the_same_repo(registry):
+    assert registry.claim(
+        "owner/base::q4_k_m", "http", repo_type = "model", repo_id = "owner/base", variant = "Q4_K_M"
+    )[0]
+
+    keys = load_downloads.claim_load_downloads(["owner/base"])
+
+    assert keys == ["owner/base::q4_k_m"]
+    ref = download_lifecycle.active_download_refs(registry, None, with_variant = True)[0]
+    assert (ref.repo_id, ref.variant, ref.load_attached) == ("owner/base", "Q4_K_M", True)
+
+    load_downloads.release_load_downloads(keys)
+
+    ref = download_lifecycle.active_download_refs(registry, None, with_variant = True)[0]
+    assert (ref.load_attached, ref.state) == (False, "running")
+
+
 def test_an_explicit_download_of_a_load_placeholder_is_refused(registry, monkeypatch):
     from hub.services.models import downloads
 
@@ -159,6 +176,7 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
     )
     loader = types.ModuleType("unsloth.models.loader")
     loader.ALLOW_PREQUANTIZED_MODELS = True
+    loader.ALLOW_BITSANDBYTES = True
     loader._strip_unsloth_bnb_4bit_suffix = lambda name: name.removesuffix("-bnb-4bit")
     for name, module in (
         ("unsloth", package),
@@ -195,6 +213,10 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
         "unsloth/base",
     ]
     loader.ALLOW_PREQUANTIZED_MODELS = True
+
+    loader.ALLOW_BITSANDBYTES = False
+    assert worker._load_download_repos(adapter, True, cuda) == ["owner/adapter", "owner/base"]
+    loader.ALLOW_BITSANDBYTES = True
 
     audio = SimpleNamespace(identifier = "owner/tts-lora", base_model = "owner/base", audio_type = "snac")
     assert worker._load_download_repos(audio, True, cuda, ["owner/tts-lora", "owner/codec"]) == [

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -279,7 +279,10 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
         "hubertsiuzdak/snac_24khz",
     ]
     audio_vlm = SimpleNamespace(
-        identifier = "owner/avlm-lora", base_model = "owner/base", audio_type = "audio_vlm", is_audio = False
+        identifier = "owner/avlm-lora",
+        base_model = "owner/base",
+        audio_type = "audio_vlm",
+        is_audio = False,
     )
     assert worker._load_download_repos(audio_vlm, True, cuda) == [
         "owner/avlm-lora",

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -64,7 +64,9 @@ def test_cancelling_a_load_owned_job_is_refused(registry, monkeypatch):
     load_downloads.claim_load_downloads(["owner/base"])
 
     with pytest.raises(HTTPException) as excinfo:
-        asyncio.run(downloads.cancel_download_model_response(CancelDownloadRequest(repo_id = "owner/base")))
+        asyncio.run(
+            downloads.cancel_download_model_response(CancelDownloadRequest(repo_id = "owner/base"))
+        )
 
     assert excinfo.value.status_code == 409
     assert registry.get_job("owner/base::").state == "running"
@@ -80,12 +82,15 @@ def test_the_orchestrator_registers_the_downloads_a_load_reports(registry, monke
 
     with patch("core.inference.orchestrator.threading.Thread", DummyThread):
         from core.inference.orchestrator import InferenceOrchestrator
-
         orchestrator = InferenceOrchestrator()
 
     responses = iter(
         [
-            {"type": "downloads", "repo_ids": ["owner/adapter", "owner/base"], "xet_disabled": True},
+            {
+                "type": "downloads",
+                "repo_ids": ["owner/adapter", "owner/base"],
+                "xet_disabled": True,
+            },
             {"type": "loaded", "success": True},
         ]
     )

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -93,6 +93,20 @@ def test_cancelling_a_load_owned_job_is_refused(registry, monkeypatch):
     assert registry.get_job("owner/base::").state == "running"
 
 
+def test_shutdown_leaves_no_cancel_marker_for_a_load_placeholder(registry, monkeypatch):
+    markers = []
+    monkeypatch.setattr(download_registry, "persist_cancel_marker", lambda *args, **kwargs: markers.append(args[1]))
+    load_downloads.claim_load_downloads(["owner/adapter", "owner/base"])
+    assert registry.claim("owner/other::", "http", repo_type = "model", repo_id = "owner/other")[0]
+
+    registry.terminate_all()
+
+    assert markers == ["owner/other"]
+    assert registry.get_job("owner/adapter::").state == "idle"
+    assert registry.get_job("owner/base::").state == "idle"
+    assert _active(registry) == [("owner/other", None, "cancelling")]
+
+
 def test_the_orchestrator_registers_the_downloads_a_load_reports(registry, monkeypatch):
     class DummyThread:
         def __init__(self, *args, **kwargs):
@@ -169,6 +183,8 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
     assert worker._load_download_repos(local, True, SimpleNamespace(device = "mlx")) == ["owner/base"]
     plain = SimpleNamespace(identifier = "owner/model", base_model = None)
     assert worker._load_download_repos(plain, True, cuda) == ["owner/model"]
+    legacy = SimpleNamespace(identifier = "owner/gpt2-lora", base_model = "gpt2")
+    assert worker._load_download_repos(legacy, False, cuda) == ["owner/gpt2-lora", "gpt2"]
 
     loader.ALLOW_PREQUANTIZED_MODELS = False
     assert worker._load_download_repos(adapter, True, cuda) == [

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -81,6 +81,28 @@ def test_a_load_attaches_to_a_variant_download_of_the_same_repo(registry):
     assert (ref.load_attached, ref.state) == (False, "running")
 
 
+def test_a_transport_retry_keeps_the_load_attachment(registry):
+    assert registry.claim("owner/base::", "xet", repo_type = "model", repo_id = "owner/base")[0]
+    load_downloads.claim_load_downloads(["owner/base"])
+
+    assert registry.claim(
+        "owner/base::", "http", repo_type = "model", repo_id = "owner/base", replace_active = True
+    )[0]
+
+    ref = download_lifecycle.active_download_refs(registry, None, with_variant = False)[0]
+    assert (ref.transport, ref.load_attached) == ("http", True)
+    registry.set_job("owner/base::", "complete")
+    assert registry.claim("owner/base::", "http", repo_type = "model", repo_id = "owner/base")[0]
+    assert registry.get_job_metadata("owner/base::").load_attached is False
+
+
+def test_a_load_placeholder_is_never_adoptable(registry):
+    load_downloads.claim_load_downloads(["owner/base"])
+    assert registry.adoptable("owner/base::") is False
+    assert registry.claim("owner/other::", "http", repo_type = "model", repo_id = "owner/other")[0]
+    assert registry.adoptable("owner/other::") is True
+
+
 def test_an_explicit_download_of_a_load_placeholder_is_refused(registry, monkeypatch):
     from hub.services.models import downloads
 

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -185,14 +185,18 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
         "owner/base",
         "hubertsiuzdak/snac_24khz",
     ]
-    spark = SimpleNamespace(identifier = "owner/spark-lora", base_model = "unsloth/Spark-TTS-0.5B/LLM", audio_type = "bicodec")
+    spark = SimpleNamespace(
+        identifier = "owner/spark-lora", base_model = "unsloth/Spark-TTS-0.5B/LLM", audio_type = "bicodec"
+    )
     monkeypatch.setattr(worker, "_load_download_repos", worker._load_download_repos)
     import utils.security.file_security as file_security
 
     monkeypatch.setattr(
         file_security,
         "load_scan_target",
-        lambda name, subdirs: ("unsloth/Spark-TTS-0.5B", ("LLM",)) if name.endswith("/LLM") else (name, subdirs),
+        lambda name, subdirs: ("unsloth/Spark-TTS-0.5B", ("LLM",))
+        if name.endswith("/LLM")
+        else (name, subdirs),
     )
     assert worker._load_download_repos(spark, True, SimpleNamespace(device = "mlx")) == [
         "owner/spark-lora",

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -269,12 +269,22 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
     assert worker._load_download_repos(adapter, True, cuda) == ["owner/adapter", "owner/base"]
     loader.ALLOW_BITSANDBYTES = True
 
-    audio = SimpleNamespace(identifier = "owner/tts-lora", base_model = "owner/base", audio_type = "snac")
+    audio = SimpleNamespace(
+        identifier = "owner/tts-lora", base_model = "owner/base", audio_type = "snac", is_audio = True
+    )
     assert worker._load_download_repos(audio, True, cuda, ["owner/tts-lora", "owner/codec"]) == [
         "owner/tts-lora",
         "owner/codec",
         "owner/base",
         "hubertsiuzdak/snac_24khz",
+    ]
+    audio_vlm = SimpleNamespace(
+        identifier = "owner/avlm-lora", base_model = "owner/base", audio_type = "audio_vlm", is_audio = False
+    )
+    assert worker._load_download_repos(audio_vlm, True, cuda) == [
+        "owner/avlm-lora",
+        "owner/base",
+        "unsloth/base-bnb-4bit",
     ]
     spark = SimpleNamespace(
         identifier = "owner/spark-lora", base_model = "unsloth/Spark-TTS-0.5B/LLM", audio_type = "bicodec"

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -200,11 +200,22 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
     loader.ALLOW_PREQUANTIZED_MODELS = True
     loader.ALLOW_BITSANDBYTES = True
     loader._strip_unsloth_bnb_4bit_suffix = lambda name: name.removesuffix("-bnb-4bit")
+    zoo = types.ModuleType("unsloth_zoo")
+    zoo_mlx = types.ModuleType("unsloth_zoo.mlx")
+    zoo_loader = types.ModuleType("unsloth_zoo.mlx.loader")
+    zoo_loader._remap_unsloth_bnb_hub_id_for_mlx = lambda name, revision: (
+        (name.removesuffix("-unsloth-bnb-4bit"), None, name)
+        if name.startswith("unsloth/") and name.endswith("-unsloth-bnb-4bit")
+        else (name, revision, None)
+    )
     for name, module in (
         ("unsloth", package),
         ("unsloth.models", models),
         ("unsloth.models.loader", loader),
         ("unsloth.models.loader_utils", loader_utils),
+        ("unsloth_zoo", zoo),
+        ("unsloth_zoo.mlx", zoo_mlx),
+        ("unsloth_zoo.mlx.loader", zoo_loader),
     ):
         monkeypatch.setitem(sys.modules, name, module)
 
@@ -220,6 +231,12 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
     assert worker._load_download_repos(adapter, True, SimpleNamespace(device = "mlx")) == [
         "owner/adapter",
         "owner/base",
+    ]
+    bnb = SimpleNamespace(identifier = "owner/adapter", base_model = "unsloth/base-unsloth-bnb-4bit")
+    assert worker._load_download_repos(bnb, True, SimpleNamespace(device = "mlx")) == [
+        "owner/adapter",
+        "unsloth/base-unsloth-bnb-4bit",
+        "unsloth/base",
     ]
     local = SimpleNamespace(identifier = "/models/adapter", base_model = "owner/base")
     assert worker._load_download_repos(local, True, SimpleNamespace(device = "mlx")) == ["owner/base"]

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -41,20 +41,41 @@ def test_a_load_claims_running_jobs_the_active_list_reports(registry):
     assert metadata.hub_cache == "/cache/hub"
     assert metadata.transport == "http"
 
-    load_downloads.release_load_downloads(keys, "complete")
+    load_downloads.release_load_downloads(keys)
 
     assert _active(registry) == []
-    assert registry.get_job(keys[0]).state == "complete"
+    assert registry.get_job(keys[0]).state == "idle"
+    assert registry.claim(keys[0], "http", repo_type = "model", repo_id = "owner/adapter")[0]
 
 
-def test_a_load_leaves_a_hub_download_of_the_same_repo_alone(registry):
+def test_a_load_attaches_to_a_hub_download_of_the_same_repo(registry):
     assert registry.claim("owner/base::", "http", repo_type = "model", repo_id = "owner/base")[0]
 
-    assert load_downloads.claim_load_downloads(["owner/base"]) == []
-    load_downloads.release_load_downloads(["owner/base::"], "complete")
+    keys = load_downloads.claim_load_downloads(["owner/base"])
 
-    assert registry.get_job("owner/base::").state == "running"
-    assert _active(registry) == [("owner/base", None, "running")]
+    assert keys == ["owner/base::"]
+    ref = download_lifecycle.active_download_refs(registry, None, with_variant = False)[0]
+    assert (ref.owner, ref.load_attached, ref.state) == (None, True, "running")
+    assert not load_downloads.is_load_owned(registry, "owner/base::")
+
+    load_downloads.release_load_downloads(keys)
+
+    ref = download_lifecycle.active_download_refs(registry, None, with_variant = False)[0]
+    assert (ref.load_attached, ref.state) == (False, "running")
+
+
+def test_an_explicit_download_of_a_load_placeholder_is_refused(registry, monkeypatch):
+    from hub.services.models import downloads
+
+    monkeypatch.setattr(downloads, "_registry", registry)
+    load_downloads.claim_load_downloads(["owner/base"])
+
+    with pytest.raises(HTTPException) as excinfo:
+        downloads._reject_if_load_owned("owner/base::")
+    assert excinfo.value.status_code == 409
+
+    load_downloads.release_load_downloads(["owner/base::"])
+    downloads._reject_if_load_owned("owner/base::")
 
 
 def test_cancelling_a_load_owned_job_is_refused(registry, monkeypatch):
@@ -102,10 +123,10 @@ def test_the_orchestrator_registers_the_downloads_a_load_reports(registry, monke
         ("owner/base", "load", "running"),
     ]
 
-    orchestrator._release_load_downloads("complete")
+    orchestrator._release_load_downloads()
 
     assert _active(registry) == []
-    orchestrator._release_load_downloads("complete")
+    orchestrator._release_load_downloads()
 
 
 def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
@@ -154,4 +175,26 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
         "owner/adapter",
         "owner/base",
         "unsloth/base",
+    ]
+    loader.ALLOW_PREQUANTIZED_MODELS = True
+
+    audio = SimpleNamespace(identifier = "owner/tts-lora", base_model = "owner/base", audio_type = "snac")
+    assert worker._load_download_repos(audio, True, cuda, ["owner/tts-lora", "owner/codec"]) == [
+        "owner/tts-lora",
+        "owner/codec",
+        "owner/base",
+        "hubertsiuzdak/snac_24khz",
+    ]
+    spark = SimpleNamespace(identifier = "owner/spark-lora", base_model = "unsloth/Spark-TTS-0.5B/LLM", audio_type = "bicodec")
+    monkeypatch.setattr(worker, "_load_download_repos", worker._load_download_repos)
+    import utils.security.file_security as file_security
+
+    monkeypatch.setattr(
+        file_security,
+        "load_scan_target",
+        lambda name, subdirs: ("unsloth/Spark-TTS-0.5B", ("LLM",)) if name.endswith("/LLM") else (name, subdirs),
+    )
+    assert worker._load_download_repos(spark, True, SimpleNamespace(device = "mlx")) == [
+        "owner/spark-lora",
+        "unsloth/Spark-TTS-0.5B",
     ]

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -120,9 +120,13 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
     loader_utils.get_model_name = (
         lambda name, load_in_4bit = True: "unsloth/base-bnb-4bit" if load_in_4bit else name
     )
+    loader = types.ModuleType("unsloth.models.loader")
+    loader.ALLOW_PREQUANTIZED_MODELS = True
+    loader._strip_unsloth_bnb_4bit_suffix = lambda name: name.removesuffix("-bnb-4bit")
     for name, module in (
         ("unsloth", package),
         ("unsloth.models", models),
+        ("unsloth.models.loader", loader),
         ("unsloth.models.loader_utils", loader_utils),
     ):
         monkeypatch.setitem(sys.modules, name, module)
@@ -144,3 +148,10 @@ def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
     assert worker._load_download_repos(local, True, SimpleNamespace(device = "mlx")) == ["owner/base"]
     plain = SimpleNamespace(identifier = "owner/model", base_model = None)
     assert worker._load_download_repos(plain, True, cuda) == ["owner/model"]
+
+    loader.ALLOW_PREQUANTIZED_MODELS = False
+    assert worker._load_download_repos(adapter, True, cuda) == [
+        "owner/adapter",
+        "owner/base",
+        "unsloth/base",
+    ]

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -95,7 +95,9 @@ def test_cancelling_a_load_owned_job_is_refused(registry, monkeypatch):
 
 def test_shutdown_leaves_no_cancel_marker_for_a_load_placeholder(registry, monkeypatch):
     markers = []
-    monkeypatch.setattr(download_registry, "persist_cancel_marker", lambda *args, **kwargs: markers.append(args[1]))
+    monkeypatch.setattr(
+        download_registry, "persist_cancel_marker", lambda *args, **kwargs: markers.append(args[1])
+    )
     load_downloads.claim_load_downloads(["owner/adapter", "owner/base"])
     assert registry.claim("owner/other::", "http", repo_type = "model", repo_id = "owner/other")[0]
 

--- a/studio/backend/tests/test_load_downloads.py
+++ b/studio/backend/tests/test_load_downloads.py
@@ -1,0 +1,141 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from hub.schemas.downloads import CancelDownloadRequest
+from hub.services import download_lifecycle, load_downloads
+from hub.utils import download_registry
+from hub.utils.download_registry import DownloadRegistry
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    fresh = DownloadRegistry()
+    monkeypatch.setattr(download_registry, "get_models_registry", lambda: fresh)
+    return fresh
+
+
+def _active(registry):
+    return [
+        (ref.repo_id, ref.owner, ref.state)
+        for ref in download_lifecycle.active_download_refs(registry, None, with_variant = False)
+    ]
+
+
+def test_a_load_claims_running_jobs_the_active_list_reports(registry):
+    keys = load_downloads.claim_load_downloads(
+        ["owner/adapter", "Owner/Base", "owner/adapter", ""],
+        xet_disabled = True,
+        hub_cache = "/cache/hub",
+    )
+
+    assert len(keys) == 2
+    assert sorted(_active(registry)) == [
+        ("Owner/Base", "load", "running"),
+        ("owner/adapter", "load", "running"),
+    ]
+    metadata = registry.get_job_metadata(keys[1])
+    assert metadata.hub_cache == "/cache/hub"
+    assert metadata.transport == "http"
+
+    load_downloads.release_load_downloads(keys, "complete")
+
+    assert _active(registry) == []
+    assert registry.get_job(keys[0]).state == "complete"
+
+
+def test_a_load_leaves_a_hub_download_of_the_same_repo_alone(registry):
+    assert registry.claim("owner/base::", "http", repo_type = "model", repo_id = "owner/base")[0]
+
+    assert load_downloads.claim_load_downloads(["owner/base"]) == []
+    load_downloads.release_load_downloads(["owner/base::"], "complete")
+
+    assert registry.get_job("owner/base::").state == "running"
+    assert _active(registry) == [("owner/base", None, "running")]
+
+
+def test_cancelling_a_load_owned_job_is_refused(registry, monkeypatch):
+    from hub.services.models import downloads
+
+    monkeypatch.setattr(downloads, "_registry", registry)
+    load_downloads.claim_load_downloads(["owner/base"])
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(downloads.cancel_download_model_response(CancelDownloadRequest(repo_id = "owner/base")))
+
+    assert excinfo.value.status_code == 409
+    assert registry.get_job("owner/base::").state == "running"
+
+
+def test_the_orchestrator_registers_the_downloads_a_load_reports(registry, monkeypatch):
+    class DummyThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            return None
+
+    with patch("core.inference.orchestrator.threading.Thread", DummyThread):
+        from core.inference.orchestrator import InferenceOrchestrator
+
+        orchestrator = InferenceOrchestrator()
+
+    responses = iter(
+        [
+            {"type": "downloads", "repo_ids": ["owner/adapter", "owner/base"], "xet_disabled": True},
+            {"type": "loaded", "success": True},
+        ]
+    )
+    monkeypatch.setattr(orchestrator, "_read_resp", lambda timeout = 1.0: next(responses))
+
+    assert orchestrator._wait_response("loaded", timeout = 5)["success"]
+    assert _active(registry) == [
+        ("owner/adapter", "load", "running"),
+        ("owner/base", "load", "running"),
+    ]
+
+    orchestrator._release_load_downloads("complete")
+
+    assert _active(registry) == []
+    orchestrator._release_load_downloads("complete")
+
+
+def test_the_worker_reports_the_repos_a_lora_load_fetches(monkeypatch):
+    import sys
+    import types
+
+    from core.inference import worker
+
+    package = types.ModuleType("unsloth")
+    models = types.ModuleType("unsloth.models")
+    loader_utils = types.ModuleType("unsloth.models.loader_utils")
+    loader_utils.get_model_name = (
+        lambda name, load_in_4bit = True: "unsloth/base-bnb-4bit" if load_in_4bit else name
+    )
+    for name, module in (
+        ("unsloth", package),
+        ("unsloth.models", models),
+        ("unsloth.models.loader_utils", loader_utils),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+
+    adapter = SimpleNamespace(identifier = "owner/adapter", base_model = "owner/base")
+    cuda = SimpleNamespace(device = "cuda")
+
+    assert worker._load_download_repos(adapter, True, cuda) == [
+        "owner/adapter",
+        "owner/base",
+        "unsloth/base-bnb-4bit",
+    ]
+    assert worker._load_download_repos(adapter, False, cuda) == ["owner/adapter", "owner/base"]
+    assert worker._load_download_repos(adapter, True, SimpleNamespace(device = "mlx")) == [
+        "owner/adapter",
+        "owner/base",
+    ]
+    local = SimpleNamespace(identifier = "/models/adapter", base_model = "owner/base")
+    assert worker._load_download_repos(local, True, SimpleNamespace(device = "mlx")) == ["owner/base"]
+    plain = SimpleNamespace(identifier = "owner/model", base_model = None)
+    assert worker._load_download_repos(plain, True, cuda) == ["owner/model"]

--- a/studio/backend/utils/third_party_source.py
+++ b/studio/backend/utils/third_party_source.py
@@ -96,6 +96,13 @@ _SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 _IMPORT_LOCK = threading.RLock()
 
 _DAC_REPOSITORY = "ibm-research/DAC.speech.v1.0"
+SNAC_REPOSITORY = "hubertsiuzdak/snac_24khz"
+SPARK_TTS_REPOSITORY = "unsloth/Spark-TTS-0.5B"
+SPEECH_CODEC_REPOSITORIES = {
+    "snac": (SNAC_REPOSITORY,),
+    "bicodec": (SPARK_TTS_REPOSITORY,),
+    "dac": (_DAC_REPOSITORY,),
+}
 _DAC_REVISION = "1ea7f64cd0678415e2d8c32d67b190722cb9b149"
 _DAC_FILENAME = "weights_24khz_1.5kbps_v1.0.pth"
 _DAC_SIZE = 295731578

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -136,8 +136,10 @@ class Harness:
         timeout = 30,
         error = None,
     ):
-        if f"/api/models/config/{ADAPTER}" in url:
-            return {"is_lora": True, "base_model": ADAPTER_BASE}
+        if url.endswith("/active-downloads"):
+            if self.model != ADAPTER:
+                return {"downloads": []}
+            return {"downloads": [{"repo_id": ADAPTER_BASE, "owner": "load", "state": "running"}]}
         if "download-progress" in url and urlencode({"repo_id": ADAPTER}) in url:
             return {
                 "downloaded_bytes": ADAPTER_BYTES,

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlencode
+
 import pytest
 import typer
 
@@ -13,6 +15,9 @@ import unsloth_cli.commands.start as start_cli
 
 BASE = "http://127.0.0.1:8888"
 MODEL = "unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF"
+ADAPTER = "owner/coder-lora"
+ADAPTER_BASE = "owner/coder-base"
+ADAPTER_BYTES = 20 * 1024**2
 KEY_LINE = f"{start_cli._START_API_KEY_PREFIX}sk-unsloth-test\n"
 EXPECTED_BYTES = 500 * 1024**3
 STEP_S = 120.0
@@ -89,6 +94,7 @@ class Harness:
         rebound = False,
         ready_at = None,
         tail = KEY_LINE,
+        model = MODEL,
     ):
         self.clock = FakeClock(STEP_S)
         self.log_path = None
@@ -106,6 +112,8 @@ class Harness:
         self.chunk_bytes = chunk_bytes
         self.ready_at = ready_at
         self.tail = tail
+        self.model = model
+        self.base_polls = 0
         self.server = FakePopen()
         self.iterations = 0
         self.polls = 0
@@ -128,6 +136,18 @@ class Harness:
         timeout = 30,
         error = None,
     ):
+        if f"/api/models/config/{ADAPTER}" in url:
+            return {"is_lora": True, "base_model": ADAPTER_BASE}
+        if "download-progress" in url and urlencode({"repo_id": ADAPTER}) in url:
+            return {
+                "downloaded_bytes": ADAPTER_BYTES,
+                "completed_bytes": ADAPTER_BYTES,
+                "expected_bytes": ADAPTER_BYTES,
+                "progress": 1.0,
+                "cache_measured": True,
+            }
+        if urlencode({"repo_id": ADAPTER_BASE}) in url:
+            self.base_polls += 1
         if "gguf-variants" in url:
             return {
                 "default_variant": "Q4_K_M",
@@ -212,12 +232,12 @@ class Harness:
             with open(self.log_path, "ab") as handle:
                 handle.write(self.chatter(self.iterations).encode())
         if self.ready_at is not None and self.iterations >= self.ready_at:
-            self.tail = f"{KEY_LINE}Model loaded: {MODEL}\n"
+            self.tail = f"{KEY_LINE}Model loaded: {self.model}\n"
             return True
         return False
 
     def start(self):
-        return start_cli._start_studio_server(BASE, MODEL, start_cli.LoadOptions())
+        return start_cli._start_studio_server(BASE, self.model, start_cli.LoadOptions())
 
 
 def test_a_live_download_survives_past_the_idle_cap(monkeypatch):
@@ -399,6 +419,34 @@ def test_a_vanished_cache_mount_is_not_progress(monkeypatch, capsys):
         harness.start()
 
     assert harness.vanished > 0
+    assert harness.shutdowns == [harness.server]
+    assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
+    assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_lora_base_model_download_counts_as_progress(monkeypatch):
+    harness = Harness(monkeypatch, model = ADAPTER, chunk_bytes = 1024**3, ready_at = 40)
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.base_polls >= 40
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_stalled_lora_base_model_still_times_out(monkeypatch, capsys):
+    harness = Harness(
+        monkeypatch,
+        model = ADAPTER,
+        downloaded_bytes = 12 * 1024**3,
+        chunk_bytes = 0,
+    )
+
+    with pytest.raises(typer.Exit):
+        harness.start()
+
+    assert harness.base_polls > 0
     assert harness.shutdowns == [harness.server]
     assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
     assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1060,6 +1060,7 @@ class _ModelDownloadProgress:
         self._disabled = not _is_hub_model_id(model)
         self._progress_prefix = "/api/hub"
         self._repo_bytes: dict[str, int] = {}
+        self._companions: list[str] = []
         self._companions_listed = True
 
     def _is_gguf(self) -> bool:
@@ -1107,7 +1108,7 @@ class _ModelDownloadProgress:
 
     def _companion_repos(self) -> list[str]:
         if not self._companions_listed:
-            return []
+            return self._companions
         try:
             listing = _http_json(
                 "GET",
@@ -1118,18 +1119,17 @@ class _ModelDownloadProgress:
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
                 self._companions_listed = False
-            return []
+            return self._companions
         except Exception:
-            return []
-        repos: list[str] = []
+            return self._companions
         for item in listing.get("downloads") or []:
             repo = str(item.get("repo_id") or "")
             loading = item.get("owner") == _LOAD_DOWNLOAD_OWNER or bool(item.get("load_attached"))
             if not loading or repo.lower() == self._model.lower():
                 continue
-            if repo and repo not in repos:
-                repos.append(repo)
-        return repos
+            if repo and repo not in self._companions:
+                self._companions.append(repo)
+        return self._companions
 
     def _read(
         self,

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1127,7 +1127,7 @@ class _ModelDownloadProgress:
             loading = item.get("owner") == _LOAD_DOWNLOAD_OWNER or bool(item.get("load_attached"))
             if not loading or repo.lower() == self._model.lower():
                 continue
-            if repo not in repos and _is_hub_model_id(repo):
+            if repo and repo not in repos:
                 repos.append(repo)
         return repos
 

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -929,6 +929,7 @@ class _DownloadProgressDisplay:
             # download that starts near zero after an adapter finished near the top.
             self._source = source
             self._samples.clear()
+            self._last_expected = 0
             # Not `_shown`: `_last_bucket = -1` already lets the next line through, while
             # clearing it would strand a finished bar below 100% and drop the closing
             # newline, since `complete()` and `close()` both gate on it.
@@ -1123,7 +1124,8 @@ class _ModelDownloadProgress:
         repos: list[str] = []
         for item in listing.get("downloads") or []:
             repo = str(item.get("repo_id") or "")
-            if item.get("owner") != _LOAD_DOWNLOAD_OWNER or repo.lower() == self._model.lower():
+            loading = item.get("owner") == _LOAD_DOWNLOAD_OWNER or bool(item.get("load_attached"))
+            if not loading or repo.lower() == self._model.lower():
                 continue
             if repo not in repos and _is_hub_model_id(repo):
                 repos.append(repo)

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1024,7 +1024,9 @@ def _in_flight_bytes(reading: dict) -> int:
 
 
 def _active_reading(
-    readings: list[tuple[str, dict]], grown: "frozenset[str]" = frozenset()
+    readings: list[tuple[str, dict]],
+    grown: "frozenset[str]" = frozenset(),
+    last: Optional[str] = None,
 ) -> tuple[str, dict]:
     """The one repo whose transfer the progress line should follow.
 
@@ -1040,7 +1042,9 @@ def _active_reading(
     # drops the live figure, so the biggest partial on disk is not the running download.
     moved = [item for item in readings if item[0] in grown and _in_flight_bytes(item[1]) > 0]
     active = max(moved or readings, key = lambda item: _in_flight_bytes(item[1]))
-    return active if _in_flight_bytes(active[1]) > 0 else readings[0]
+    if _in_flight_bytes(active[1]) > 0:
+        return active
+    return next((item for item in readings if item[0] == last), readings[0])
 
 
 class _ModelDownloadProgress:
@@ -1062,6 +1066,7 @@ class _ModelDownloadProgress:
         self._repo_bytes: dict[str, int] = {}
         self._companions: list[str] = []
         self._companions_listed = True
+        self._active_repo: Optional[str] = None
 
     def _is_gguf(self) -> bool:
         return bool(self._variant) or "gguf" in self._model.lower()
@@ -1188,7 +1193,8 @@ class _ModelDownloadProgress:
             self._downloaded_bytes = max(self._downloaded_bytes, sum(self._repo_bytes.values()))
             self._failures = 0
             self._retry_at = 0.0
-            active_repo, active = _active_reading(readings, grown)
+            active_repo, active = _active_reading(readings, grown, self._active_repo)
+            self._active_repo = active_repo
             self._display.update(active, active_repo)
         except Exception:
             # Progress is best-effort and never fails the load, but `_start_studio_server`

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -3,7 +3,6 @@
 
 """`unsloth start` — launch a coding agent against a running Unsloth server."""
 
-import ast
 import atexit
 import base64
 import contextlib
@@ -11,7 +10,6 @@ import errno
 import functools
 import hashlib
 import http.client
-import importlib.util
 import json
 import os
 import re
@@ -27,7 +25,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Literal, NamedTuple, NoReturn, Optional
-from urllib.parse import quote, urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 
 import click
 import typer
@@ -881,33 +879,7 @@ _SERVER_START_TIMEOUT_S = 900
 _DOWNLOAD_POLL_INTERVAL_S = 1.0
 # Ceiling on the doubling back-off the progress reader uses after a polling error.
 _DOWNLOAD_POLL_MAX_BACKOFF_S = 60.0
-# A 200 that reports no adapter can also be a failed inspection, so the answer is never
-# final. The endpoint runs several hub probes per request, so re-asking backs off instead
-# of stopping: giving up for good would leave a server that recovers later untracked.
-_COMPANION_LOOKUP_RETRY_S = 60.0
-_COMPANION_LOOKUP_MAX_RETRY_S = 300.0
-# The only answers that settle the question: the request itself was refused. Everything
-# else can be a server that is briefly offline or busy.
-_DEFINITIVE_HTTP_STATUS = frozenset((400, 401, 403, 405, 410, 422))
-# What the router says when nothing is registered at the path, as opposed to what the
-# handler says when it declines to answer.
-_ABSENT_ROUTE_DETAIL = "not found"
-
-
-def _is_absent_route(exc: urllib.error.HTTPError) -> bool:
-    """Whether a 404 came from the router rather than from the handler.
-
-    A handler that declines gives its own reason -- this route's is "cannot be authorized
-    without network access" -- while an unregistered path gets the framework's bare
-    "Not Found". Only the second is worth giving up on.
-    """
-    try:
-        detail = json.loads(exc.read().decode("utf-8", "replace")).get("detail")
-    except Exception:
-        return False
-    return isinstance(detail, str) and detail.strip().lower() == _ABSENT_ROUTE_DETAIL
-
-
+_LOAD_DOWNLOAD_OWNER = "load"
 _START_API_KEY_PREFIX = "UNSLOTH_START_API_KEY: "
 _START_API_KEY_MARKER_ENV = "_UNSLOTH_START_API_KEY_MARKER"
 
@@ -1070,256 +1042,6 @@ def _active_reading(
     return active if _in_flight_bytes(active[1]) > 0 else readings[0]
 
 
-_QUANT_MAPPERS: Optional[list[dict]] = None
-
-
-def _unsloth_package_dirs() -> list[Path]:
-    """Every `unsloth` package directory this CLI can see.
-
-    The server does the downloading, and it need not be this interpreter: `unsloth run`
-    re-execs into the managed Studio venv, which may hold a different Unsloth than the one
-    the CLI was launched from. Reading only the parent's tables would resolve a base by a
-    version the worker is not using, so both are read and their answers pooled.
-    """
-    dirs: list[Path] = []
-    try:
-        spec = importlib.util.find_spec("unsloth")
-        for location in list(spec.submodule_search_locations) if spec else []:
-            dirs.append(Path(location))
-    except Exception:
-        pass
-    try:
-        from unsloth_cli.commands.studio import STUDIO_HOME
-
-        venv = Path(STUDIO_HOME) / "unsloth_studio"
-        dirs.extend(venv.glob("lib/python*/site-packages/unsloth"))
-        dirs.append(venv / "Lib" / "site-packages" / "unsloth")
-    except Exception:
-        pass
-    # And ask that venv itself. `unsloth studio update --local` installs Unsloth with
-    # `-e`, which leaves a PEP 660 finder rather than a package directory, so the globs
-    # above see nothing. `find_spec` locates it without importing it, so this costs a
-    # short-lived interpreter and never loads torch.
-    try:
-        from unsloth_cli.commands.studio import _studio_venv_python
-        python = _studio_venv_python()
-        if python is not None:
-            found = subprocess.run(
-                [
-                    str(python),
-                    "-c",
-                    "import importlib.util as u;s=u.find_spec('unsloth');"
-                    "print(next(iter(s.submodule_search_locations)) if s else '')",
-                ],
-                capture_output = True,
-                text = True,
-                timeout = 20,
-                # Away from the caller's directory: an `unsloth/` folder in the cwd is on
-                # that interpreter's path too, and would answer for the venv's install.
-                cwd = str(python.parent),
-            ).stdout.strip()
-            if found:
-                dirs.append(Path(found))
-    except Exception:
-        pass
-    seen: set = set()
-    unique = []
-    for directory in dirs:
-        key = str(directory)
-        if key not in seen and directory.is_dir():
-            seen.add(key)
-            unique.append(directory)
-    return unique
-
-
-def _module_literal(path: Path, name: str) -> object:
-    """A module-level literal assignment, read without running the file.
-
-    The last binding wins, matching how the module would have ended up had it run.
-    """
-    found = None
-    for node in ast.parse(path.read_text(encoding = "utf-8")).body:
-        targets = getattr(node, "targets", [])
-        if not any(isinstance(t, ast.Name) and t.id == name for t in targets):
-            continue
-        try:
-            found = ast.literal_eval(node.value)
-        except Exception:
-            continue
-    return found
-
-
-def _unsloth_quant_mappers() -> list[dict]:
-    """What repo the loader may swap for another, per install, read without running anything.
-
-    `mapper.py` is discovered on `sys.path`, which can include the directory the CLI was
-    started in -- `unsloth start` opens a coding agent on a repository that is not
-    necessarily trusted -- so the file is parsed for its data and never imported. The
-    package makes the same distinction itself: `build_mappers` exists so that a mapper
-    fetched from GitHub "only ever supplies data".
-
-    Only `__INT_TO_FLOAT_MAPPER` is read, and every name in one of its entries is treated
-    as swappable for every other, since they are one model at different precisions. That
-    is the relation the derived tables express, without re-deriving them.
-    """
-    global _QUANT_MAPPERS
-    if _QUANT_MAPPERS is None:
-        _QUANT_MAPPERS = []
-        for directory in _unsloth_package_dirs():
-            path = directory / "models" / "mapper.py"
-            try:
-                if not path.is_file():
-                    continue
-                source = _module_literal(path, "__INT_TO_FLOAT_MAPPER")
-                if not isinstance(source, dict):
-                    continue
-                relation: dict = {}
-                for key, values in source.items():
-                    names: set = set()
-                    _flattened_repo_ids(key, names)
-                    _flattened_repo_ids(values, names)
-                    # Nothing in the inference path passes `load_in_fp8`, so an fp8 repo is
-                    # never what the worker fetches and polling it would only cost requests.
-                    names = {name for name in names if "fp8" not in name.lower()}
-                    for name in names:
-                        # Both spellings on both sides: `__get_model_name` looks the base
-                        # up lower-cased and returns whatever that entry holds, so the repo
-                        # it names can differ in case from the one written here.
-                        others = {
-                            spelling
-                            for other in names - {name}
-                            for spelling in (other, other.lower())
-                        }
-                        for spelling in (name, name.lower()):
-                            relation.setdefault(spelling, set()).update(others)
-                if relation:
-                    _QUANT_MAPPERS.append({k: tuple(v) for k, v in relation.items()})
-            except Exception:
-                # Nothing here is required; the recorded base alone is still worth polling.
-                continue
-    return _QUANT_MAPPERS
-
-
-def _without_prequantized_suffix(repo: str) -> str:
-    """`loader._strip_unsloth_bnb_4bit_suffix`: the rewrite applied when a device forbids
-    pre-quantized repos (`ALLOW_PREQUANTIZED_MODELS` is false on several ROCm paths)."""
-    for suffix in ("-unsloth-bnb-4bit", "-bnb-4bit"):
-        if len(repo) >= len(suffix) and repo.lower().endswith(suffix):
-            repo = repo[: -len(suffix)]
-    return repo
-
-
-def _flattened_repo_ids(value: object, found: set) -> None:
-    if isinstance(value, str):
-        found.add(value)
-    elif isinstance(value, (list, tuple)):
-        for item in value:
-            _flattened_repo_ids(item, found)
-    elif isinstance(value, dict):
-        for item in value.values():
-            _flattened_repo_ids(item, found)
-
-
-_BAD_MAPPINGS: Optional[list[dict]] = None
-
-
-def _literal_text(node: object) -> Optional[str]:
-    """A string literal, or a literal with `.lower()` applied, as written in the source."""
-    if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value
-    if (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "lower"
-        and not node.args
-    ):
-        inner = _literal_text(node.func.value)
-        return inner.lower() if inner is not None else None
-    return None
-
-
-def _unsloth_bad_mappings() -> list[dict]:
-    """One `unsloth.models.loader_utils.BAD_MAPPINGS` per install, read out of the source.
-
-    The loader rewrites a mapped name a second time through this table, so a candidate set
-    built from the mapper alone stops one step short. Unlike the mapper this module cannot
-    be executed for its data -- it imports torch -- so the literal is read from the syntax
-    tree instead.
-    """
-    global _BAD_MAPPINGS
-    if _BAD_MAPPINGS is None:
-        _BAD_MAPPINGS = []
-        for directory in _unsloth_package_dirs():
-            path = directory / "models" / "loader_utils.py"
-            try:
-                if not path.is_file():
-                    continue
-                for node in ast.parse(path.read_text(encoding = "utf-8")).body:
-                    targets = getattr(node, "targets", [])
-                    if not any(isinstance(t, ast.Name) and t.id == "BAD_MAPPINGS" for t in targets):
-                        continue
-                    if not isinstance(node.value, ast.Dict):
-                        continue
-                    table: dict = {}
-                    for key, value in zip(node.value.keys, node.value.values):
-                        name, mapped = _literal_text(key), _literal_text(value)
-                        if name and mapped:
-                            table[name] = mapped
-                    if table:
-                        # One table per install, not one merged dict: two installs can
-                        # disagree on the same key, and the worker's answer is as real as
-                        # the parent's, so both targets stay candidates.
-                        _BAD_MAPPINGS.append(table)
-            except Exception:
-                # Nothing here is required; the mapper candidates are still worth polling.
-                continue
-    return _BAD_MAPPINGS
-
-
-def _base_model_candidates(base_model: str) -> list[str]:
-    """`base_model` plus every repo the loader may download in its place.
-
-    `get_model_name` rewrites a PEFT adapter's recorded base before fetching it, so the
-    recorded name on its own can name a repo that never moves while the real download runs
-    unwatched. Which substitution applies depends on the precision the worker settles on,
-    which the CLI cannot see: `_resolve_lora_4bit` turns 4-bit on for a QLoRA adapter and
-    off for a plain LoRA one. Rather than replicate that resolution and drift from it, take
-    every repo any table pairs with this base -- in practice the 16-bit and pre-quantized
-    Unsloth builds. Polling one repo too many is a measured zero; missing the right one
-    costs the user their server.
-    """
-    tables = _unsloth_quant_mappers()
-    bad_tables = _unsloth_bad_mappings()
-    # The strip is applied after mapping, and an unmapped base falls through mapping
-    # unchanged, so the recorded name itself is a subject of it.
-    seeds = {base_model, _without_prequantized_suffix(base_model)}
-    found: set = seeds - {base_model}
-    pending = list(seeds)
-    # Followed to a fixed point: the loader maps a name, then rewrites the result through
-    # BAD_MAPPINGS, so the repo it downloads can be two steps from the recorded base.
-    while pending:
-        current = pending.pop()
-        step: set = set()
-        # Both cases: the tables carry the name as written and a lower-cased copy, and
-        # `__get_model_name` looks up the lower-cased one, so it can return a repo id whose
-        # case differs from the entry reached by the recorded spelling.
-        for key in (current, current.lower()):
-            for table in tables:
-                if key in table:
-                    _flattened_repo_ids(table[key], step)
-            for bad in bad_tables:
-                if key in bad:
-                    step.add(bad[key])
-        # The loader strips the 4-bit suffix after mapping when the device forbids
-        # pre-quantized repos, so the fetched name can be a third step out.
-        step.update(_without_prequantized_suffix(repo) for repo in list(step))
-        for repo in step:
-            if repo not in found and repo != base_model:
-                found.add(repo)
-                pending.append(repo)
-    return [base_model] + sorted(repo for repo in found if _is_hub_model_id(repo))
-
-
 class _ModelDownloadProgress:
     """Best-effort polling of the model download endpoints."""
 
@@ -1336,11 +1058,8 @@ class _ModelDownloadProgress:
         self._configured = False
         self._disabled = not _is_hub_model_id(model)
         self._progress_prefix = "/api/hub"
-        self._companions: Optional[list[str]] = None
         self._repo_bytes: dict[str, int] = {}
-        self._companion_lookups = 0
-        self._companion_retry_at = 0.0
-        self._companion_retry_s = _COMPANION_LOOKUP_RETRY_S
+        self._companions_listed = True
 
     def _is_gguf(self) -> bool:
         return bool(self._variant) or "gguf" in self._model.lower()
@@ -1385,45 +1104,32 @@ class _ModelDownloadProgress:
                 # Older servers lack this endpoint; byte progress is still useful.
                 pass
 
-    def _companion_repos(self) -> Optional[list[str]]:
-        # A resolved quant, not the name: `_is_gguf` is true for any repo with "gguf" in
-        # its id, and an adapter that happens to be named that way still has a base to
-        # watch. `_configure` only resolves a variant for a repo that really carries them.
-        if self._variant:
+    def _companion_repos(self) -> list[str]:
+        if not self._companions_listed:
             return []
         try:
-            info = _http_json(
+            listing = _http_json(
                 "GET",
-                f"{self._base}/api/models/config/{quote(self._model)}",
+                f"{self._base}{self._progress_prefix}/active-downloads",
                 self._key,
                 timeout = 10,
             )
         except urllib.error.HTTPError as exc:
-            # Only a status about the request itself is final. 404 is two answers: this
-            # route raises it when it judges the hub unreachable and the caller anonymous
-            # (routes/models.py:2417), which is worth retrying, and a server too old to
-            # carry the route raises it forever, which is not. The body separates them.
-            if exc.code in _DEFINITIVE_HTTP_STATUS:
-                return []
-            if exc.code == 404 and _is_absent_route(exc):
-                return []
-            return None
+            if exc.code == 404:
+                self._companions_listed = False
+            return []
         except Exception:
-            return None
-        if not info.get("is_lora"):
-            # The server reports is_lora=False both for a plain model and for an adapter
-            # whose adapter_config.json it could not read, so this answer is not final.
-            return None
-        base_model = str(info.get("base_model") or "")
-        if base_model != self._model and _is_hub_model_id(base_model):
-            return _base_model_candidates(base_model)
-        return []
+            return []
+        repos: list[str] = []
+        for item in listing.get("downloads") or []:
+            repo = str(item.get("repo_id") or "")
+            if item.get("owner") != _LOAD_DOWNLOAD_OWNER or repo.lower() == self._model.lower():
+                continue
+            if repo not in repos and _is_hub_model_id(repo):
+                repos.append(repo)
+        return repos
 
-    def _read(
-        self,
-        repo: str,
-        gguf: bool = False,
-    ) -> dict:
+    def _read(self, repo: str, gguf: bool = False) -> dict:
         if gguf:
             params = urlencode(
                 {"repo_id": repo, "variant": self._variant, "expected_bytes": self._expected_bytes}
@@ -1435,13 +1141,6 @@ class _ModelDownloadProgress:
         return _http_json("GET", url, self._key, timeout = 10)
 
     def _companion_reading(self, repo: str) -> Optional[dict]:
-        """A companion's reading, or None when its request failed.
-
-        Isolated on purpose: a companion is an extra request per poll against the same
-        server that is busy downloading, so a slow or failed one must not discard the
-        model's own good reading. Dropping the companion's bytes only ever lowers the
-        total, and the liveness baseline never follows a reading down.
-        """
         try:
             return self._read(repo)
         except Exception:
@@ -1455,18 +1154,6 @@ class _ModelDownloadProgress:
         if time.monotonic() < self._retry_at:
             return
         try:
-            if self._companions is None and time.monotonic() >= self._companion_retry_at:
-                self._companions = self._companion_repos()
-                if self._companions is None:
-                    # Every unresolved answer is rationed, errors included: retrying once a
-                    # second would load the server doing the downloading. The wait doubles
-                    # to a ceiling rather than running out, so a config route that is slow
-                    # or rate-limited for a few minutes does not cost the whole startup.
-                    self._companion_lookups += 1
-                    self._companion_retry_at = time.monotonic() + self._companion_retry_s
-                    self._companion_retry_s = min(
-                        self._companion_retry_s * 2.0, _COMPANION_LOOKUP_MAX_RETRY_S
-                    )
             try:
                 reading = self._read(self._model, gguf = self._is_gguf())
             except urllib.error.HTTPError as exc:
@@ -1475,46 +1162,23 @@ class _ModelDownloadProgress:
                 self._progress_prefix = "/api/models"
                 self.poll()
                 return
-            companions = [(repo, self._companion_reading(repo)) for repo in self._companions or []]
+            companions = [(repo, self._companion_reading(repo)) for repo in self._companion_repos()]
             readings = [(self._model, reading)] + [
                 (repo, item) for repo, item in companions if item is not None
             ]
-            # Only one candidate base is ever fetched, so once one is demonstrably moving
-            # the rest are dead weight and need not cost a request per poll. Growth against
-            # a reading already taken, never bytes merely being present: an abandoned
-            # transfer leaves `.incomplete` blobs behind, and pruning to a corpse would
-            # discard the repo the worker is about to fetch.
-            # Every candidate is polled for the whole load, deliberately. Narrowing to the
-            # one that looks live saves a few requests a second against a server on the
-            # same machine, and costs the user their server whenever the guess is wrong:
-            # bytes present are not bytes moving, a cache root appearing is not a transfer,
-            # an abandoned `.incomplete` blob looks exactly like a live one, and an
-            # unreadable root reports a lower bound that rebounds later. A candidate that
-            # is not being fetched answers with a measured zero, which is cheap and always
-            # right, so the extra requests buy correctness that no predicate here can.
-            # The liveness baseline only ever rises. A reading falls for reasons that are
-            # not "bytes left the disk": an incomplete scan reporting a lower bound, a
-            # cache mount vanishing cleanly (`hf_cache_state._safe_is_dir` calls that a
-            # measured absence, not an error), an XET run purging its partial. Following a
-            # reading down would make the recovery back to the same figure look like fresh
-            # growth and renew the deadline for a server that is downloading nothing, and a
-            # flapping mount could do that forever. The cost is that a transfer which truly
-            # restarts is not counted again until it passes its own high mark; that failure
-            # is bounded and says so, where a false renewal is an unbounded wait.
             grown = frozenset(
                 repo
                 for repo, item in readings
                 if repo in self._repo_bytes
                 and max(0, int(item.get("downloaded_bytes") or 0)) > self._repo_bytes[repo]
             )
+            # The liveness baseline only ever rises: a reading can fall for reasons that
+            # are not bytes leaving the disk, and following it down would let the same
+            # bytes count as fresh growth on the way back up.
             for repo, item in readings:
                 self._repo_bytes[repo] = max(
                     self._repo_bytes.get(repo, 0), max(0, int(item.get("downloaded_bytes") or 0))
                 )
-            # Per repo, and kept after a candidate is dropped: an alternative base already
-            # complete in the cache contributes its bytes to the first total, so forgetting
-            # it would drop the sum below a high mark the live download may never reach on
-            # its own, and the deadline would never renew again.
             self._downloaded_bytes = max(self._downloaded_bytes, sum(self._repo_bytes.values()))
             self._failures = 0
             self._retry_at = 0.0

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1129,7 +1129,11 @@ class _ModelDownloadProgress:
                 repos.append(repo)
         return repos
 
-    def _read(self, repo: str, gguf: bool = False) -> dict:
+    def _read(
+        self,
+        repo: str,
+        gguf: bool = False,
+    ) -> dict:
         if gguf:
             params = urlencode(
                 {"repo_id": repo, "variant": self._variant, "expected_bytes": self._expected_bytes}

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1003,68 +1003,93 @@ def _normalized_variant(value: object) -> str:
     return re.sub(r"[^a-z0-9]", "", str(value or "").lower())
 
 
-def _combined_reading(readings: list[dict]) -> dict:
-    if len(readings) == 1:
-        return readings[0]
-    combined = {
-        field: sum(max(0, int(reading.get(field) or 0)) for reading in readings)
-        for field in ("downloaded_bytes", "completed_bytes", "expected_bytes")
-    }
-    # Zero expected bytes means "total unknown", not "contributes nothing". Summing it
-    # would divide by one repo's total and report a finished adapter next to a base still
-    # transferring as 100%, so an unknown part makes the combined total unknown too and
-    # the display falls back to bytes.
-    if any(int(reading.get("expected_bytes") or 0) <= 0 for reading in readings):
-        combined["expected_bytes"] = 0
-    expected = combined["expected_bytes"]
-    combined["progress"] = min(1.0, combined["downloaded_bytes"] / expected) if expected else 0.0
-    return combined
+def _in_flight_bytes(reading: dict) -> int:
+    """Bytes in a repo's incomplete files: what the endpoint counts as a live transfer."""
+    downloaded = max(0, int(reading.get("downloaded_bytes") or 0))
+    completed = max(0, int(reading.get("completed_bytes") or 0))
+    return downloaded - completed
 
 
-_QUANT_MAPPER: Optional[dict] = None
+def _total_downloaded_bytes(readings: list[dict]) -> int:
+    return sum(max(0, int(reading.get("downloaded_bytes") or 0)) for reading in readings)
 
 
-def _unsloth_quant_mapper() -> dict:
-    """`unsloth.models.mapper.FLOAT_TO_INT_MAPPER`, read without importing unsloth.
+def _active_reading(readings: list[dict]) -> dict:
+    """The one repo whose transfer the progress line should follow.
 
-    The table is plain data with no imports of its own, so it loads straight from the
+    A model, its base, and the repos the loader may substitute for that base are separate
+    downloads, and the substitutes are alternatives, so no sum of them is a total anyone
+    is fetching: adding the totals of two candidate bases -- or of a base already sitting
+    complete in the cache -- renders a percentage against a denominator that does not
+    exist. Bytes are still summed for liveness, since any repo moving is progress, but the
+    line follows whichever repo has bytes in flight, and the model itself when none does.
+    """
+    active = max(readings, key = _in_flight_bytes)
+    return active if _in_flight_bytes(active) > 0 else readings[0]
+
+
+_QUANT_MAPPERS: Optional[list[dict]] = None
+
+
+def _unsloth_quant_mappers() -> list[dict]:
+    """The repo substitution tables in `unsloth.models.mapper`, read without importing unsloth.
+
+    That module is plain data with no imports of its own, so it loads straight from the
     package directory; importing `unsloth` would pull in torch to answer a dict lookup.
     """
-    global _QUANT_MAPPER
-    if _QUANT_MAPPER is None:
-        _QUANT_MAPPER = {}
+    global _QUANT_MAPPERS
+    if _QUANT_MAPPERS is None:
+        _QUANT_MAPPERS = []
         try:
             spec = importlib.util.find_spec("unsloth")
             locations = list(spec.submodule_search_locations) if spec else []
             path = Path(locations[0]) / "models" / "mapper.py" if locations else None
             if path is not None and path.is_file():
                 module_spec = importlib.util.spec_from_file_location(
-                    "unsloth_cli._quant_mapper", path
+                    "unsloth_cli._quant_mappers", path
                 )
                 module = importlib.util.module_from_spec(module_spec)
                 module_spec.loader.exec_module(module)
-                table = getattr(module, "FLOAT_TO_INT_MAPPER", None)
-                if isinstance(table, dict):
-                    _QUANT_MAPPER = table
+                _QUANT_MAPPERS = [
+                    value
+                    for name, value in vars(module).items()
+                    if not name.startswith("_") and isinstance(value, dict)
+                ]
         except Exception:
             # Nothing here is required; the recorded base alone is still worth polling.
             pass
-    return _QUANT_MAPPER
+    return _QUANT_MAPPERS
+
+
+def _flattened_repo_ids(value: object, found: set) -> None:
+    if isinstance(value, str):
+        found.add(value)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _flattened_repo_ids(item, found)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _flattened_repo_ids(item, found)
 
 
 def _base_model_candidates(base_model: str) -> list[str]:
-    """`base_model` plus the pre-quantized repo the loader substitutes for it.
+    """`base_model` plus every repo the loader may download in its place.
 
-    `get_model_name` rewrites a PEFT adapter's recorded base to an Unsloth 4-bit repo
-    before fetching it, which is the default for a QLoRA adapter, so the recorded name
-    on its own can name a repo that never moves while the real download runs unwatched.
-    Both are polled and summed: the one that is not being fetched reports zero bytes.
+    `get_model_name` rewrites a PEFT adapter's recorded base before fetching it, so the
+    recorded name on its own can name a repo that never moves while the real download runs
+    unwatched. Which substitution applies depends on the precision the worker settles on,
+    which the CLI cannot see: `_resolve_lora_4bit` turns 4-bit on for a QLoRA adapter and
+    off for a plain LoRA one. Rather than replicate that resolution and drift from it, take
+    every repo any table pairs with this base -- in practice the 16-bit and pre-quantized
+    Unsloth builds. Polling one repo too many is a measured zero; missing the right one
+    costs the user their server.
     """
-    candidates = [base_model]
-    mapped = _unsloth_quant_mapper().get(base_model)
-    if isinstance(mapped, str) and mapped and mapped not in candidates:
-        candidates.append(mapped)
-    return candidates
+    found: set = set()
+    for table in _unsloth_quant_mappers():
+        if base_model in table:
+            _flattened_repo_ids(table[base_model], found)
+    found.discard(base_model)
+    return [base_model] + sorted(repo for repo in found if _is_hub_model_id(repo))
 
 
 class _ModelDownloadProgress:
@@ -1131,7 +1156,10 @@ class _ModelDownloadProgress:
                 pass
 
     def _companion_repos(self) -> Optional[list[str]]:
-        if self._is_gguf():
+        # A resolved quant, not the name: `_is_gguf` is true for any repo with "gguf" in
+        # its id, and an adapter that happens to be named that way still has a base to
+        # watch. `_configure` only resolves a variant for a repo that really carries them.
+        if self._variant:
             return []
         try:
             info = _http_json(
@@ -1209,10 +1237,15 @@ class _ModelDownloadProgress:
                 self._progress_prefix = "/api/models"
                 self.poll()
                 return
-            companions = (self._companion_reading(repo) for repo in self._companions or [])
-            reading = _combined_reading(
-                [reading, *(item for item in companions if item is not None)]
-            )
+            companions = [(repo, self._companion_reading(repo)) for repo in self._companions or []]
+            readings = [reading] + [item for _, item in companions if item is not None]
+            # Only one candidate base is ever fetched. Once one of them is moving the rest
+            # are known dead weight, so stop spending a request per poll on them.
+            moving = [
+                repo for repo, item in companions if item is not None and _in_flight_bytes(item) > 0
+            ]
+            if len(moving) == 1:
+                self._companions = moving
             # The liveness baseline only ever rises. A reading falls for reasons that are
             # not "bytes left the disk": an incomplete scan reporting a lower bound, a
             # cache mount vanishing cleanly (`hf_cache_state._safe_is_dir` calls that a
@@ -1222,12 +1255,10 @@ class _ModelDownloadProgress:
             # flapping mount could do that forever. The cost is that a transfer which truly
             # restarts is not counted again until it passes its own high mark; that failure
             # is bounded and says so, where a false renewal is an unbounded wait.
-            self._downloaded_bytes = max(
-                self._downloaded_bytes, max(0, int(reading.get("downloaded_bytes") or 0))
-            )
+            self._downloaded_bytes = max(self._downloaded_bytes, _total_downloaded_bytes(readings))
             self._failures = 0
             self._retry_at = 0.0
-            self._display.update(reading)
+            self._display.update(_active_reading(readings))
         except Exception:
             # Progress is best-effort and never fails the load, but `_start_studio_server`
             # reads `downloaded_bytes` to tell a live transfer from a wedged one. Backing

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1087,7 +1087,11 @@ class _ModelDownloadProgress:
             return [base_model]
         return []
 
-    def _read(self, repo: str, gguf: bool = False) -> dict:
+    def _read(
+        self,
+        repo: str,
+        gguf: bool = False,
+    ) -> dict:
         if gguf:
             params = urlencode(
                 {"repo_id": repo, "variant": self._variant, "expected_bytes": self._expected_bytes}

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1132,35 +1132,68 @@ def _unsloth_package_dirs() -> list[Path]:
     return unique
 
 
-def _unsloth_quant_mappers() -> list[dict]:
-    """The repo substitution tables in `unsloth.models.mapper`, read without importing unsloth.
+def _module_literal(path: Path, name: str) -> object:
+    """A module-level literal assignment, read without running the file.
 
-    That module is plain data with no imports of its own, so it loads straight from the
-    package directory; importing `unsloth` would pull in torch to answer a dict lookup.
+    The last binding wins, matching how the module would have ended up had it run.
+    """
+    found = None
+    for node in ast.parse(path.read_text(encoding = "utf-8")).body:
+        targets = getattr(node, "targets", [])
+        if not any(isinstance(t, ast.Name) and t.id == name for t in targets):
+            continue
+        try:
+            found = ast.literal_eval(node.value)
+        except Exception:
+            continue
+    return found
+
+
+def _unsloth_quant_mappers() -> list[dict]:
+    """What repo the loader may swap for another, per install, read without running anything.
+
+    `mapper.py` is discovered on `sys.path`, which can include the directory the CLI was
+    started in -- `unsloth start` opens a coding agent on a repository that is not
+    necessarily trusted -- so the file is parsed for its data and never imported. The
+    package makes the same distinction itself: `build_mappers` exists so that a mapper
+    fetched from GitHub "only ever supplies data".
+
+    Only `__INT_TO_FLOAT_MAPPER` is read, and every name in one of its entries is treated
+    as swappable for every other, since they are one model at different precisions. That
+    is the relation the derived tables express, without re-deriving them.
     """
     global _QUANT_MAPPERS
     if _QUANT_MAPPERS is None:
         _QUANT_MAPPERS = []
-        for index, directory in enumerate(_unsloth_package_dirs()):
+        for directory in _unsloth_package_dirs():
             path = directory / "models" / "mapper.py"
             try:
                 if not path.is_file():
                     continue
-                module_spec = importlib.util.spec_from_file_location(
-                    f"unsloth_cli._quant_mappers_{index}", path
-                )
-                module = importlib.util.module_from_spec(module_spec)
-                module_spec.loader.exec_module(module)
-                # Every table except the fp8 ones: nothing in the inference path passes
-                # `load_in_fp8`, so an fp8 repo can never be what the worker fetches, and
-                # polling it would only cost the downloading server a request per poll.
-                _QUANT_MAPPERS.extend(
-                    value
-                    for name, value in vars(module).items()
-                    if not name.startswith("_")
-                    and "fp8" not in name.lower()
-                    and isinstance(value, dict)
-                )
+                source = _module_literal(path, "__INT_TO_FLOAT_MAPPER")
+                if not isinstance(source, dict):
+                    continue
+                relation: dict = {}
+                for key, values in source.items():
+                    names: set = set()
+                    _flattened_repo_ids(key, names)
+                    _flattened_repo_ids(values, names)
+                    # Nothing in the inference path passes `load_in_fp8`, so an fp8 repo is
+                    # never what the worker fetches and polling it would only cost requests.
+                    names = {name for name in names if "fp8" not in name.lower()}
+                    for name in names:
+                        # Both spellings on both sides: `__get_model_name` looks the base
+                        # up lower-cased and returns whatever that entry holds, so the repo
+                        # it names can differ in case from the one written here.
+                        others = {
+                            spelling
+                            for other in names - {name}
+                            for spelling in (other, other.lower())
+                        }
+                        for spelling in (name, name.lower()):
+                            relation.setdefault(spelling, set()).update(others)
+                if relation:
+                    _QUANT_MAPPERS.append({k: tuple(v) for k, v in relation.items()})
             except Exception:
                 # Nothing here is required; the recorded base alone is still worth polling.
                 continue

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -887,8 +887,27 @@ _DOWNLOAD_POLL_MAX_BACKOFF_S = 60.0
 _COMPANION_LOOKUP_RETRY_S = 60.0
 _COMPANION_LOOKUP_MAX_RETRY_S = 300.0
 # The only answers that settle the question: the request itself was refused. Everything
-# else, 404 included, can be a server that is briefly offline, busy or too old.
+# else can be a server that is briefly offline or busy.
 _DEFINITIVE_HTTP_STATUS = frozenset((400, 401, 403, 405, 410, 422))
+# What the router says when nothing is registered at the path, as opposed to what the
+# handler says when it declines to answer.
+_ABSENT_ROUTE_DETAIL = "not found"
+
+
+def _is_absent_route(exc: urllib.error.HTTPError) -> bool:
+    """Whether a 404 came from the router rather than from the handler.
+
+    A handler that declines gives its own reason -- this route's is "cannot be authorized
+    without network access" -- while an unregistered path gets the framework's bare
+    "Not Found". Only the second is worth giving up on.
+    """
+    try:
+        detail = json.loads(exc.read().decode("utf-8", "replace")).get("detail")
+    except Exception:
+        return False
+    return isinstance(detail, str) and detail.strip().lower() == _ABSENT_ROUTE_DETAIL
+
+
 _START_API_KEY_PREFIX = "UNSLOTH_START_API_KEY: "
 _START_API_KEY_MARKER_ENV = "_UNSLOTH_START_API_KEY_MARKER"
 
@@ -1031,7 +1050,9 @@ def _in_flight_bytes(reading: dict) -> int:
     return downloaded - completed
 
 
-def _active_reading(readings: list[tuple[str, dict]]) -> tuple[str, dict]:
+def _active_reading(
+    readings: list[tuple[str, dict]], grown: "frozenset[str]" = frozenset()
+) -> tuple[str, dict]:
     """The one repo whose transfer the progress line should follow.
 
     A model, its base, and the repos the loader may substitute for that base are separate
@@ -1041,7 +1062,11 @@ def _active_reading(readings: list[tuple[str, dict]]) -> tuple[str, dict]:
     exist. Bytes are still summed for liveness, since any repo moving is progress, but the
     line follows whichever repo has bytes in flight, and the model itself when none does.
     """
-    active = max(readings, key = lambda item: _in_flight_bytes(item[1]))
+    # A repo seen to move wins over one that merely holds bytes: an abandoned `.incomplete`
+    # blob can be larger than the live transfer's current partial, and a shard finalizing
+    # drops the live figure, so the biggest partial on disk is not the running download.
+    moved = [item for item in readings if item[0] in grown and _in_flight_bytes(item[1]) > 0]
+    active = max(moved or readings, key = lambda item: _in_flight_bytes(item[1]))
     return active if _in_flight_bytes(active[1]) > 0 else readings[0]
 
 
@@ -1341,11 +1366,15 @@ class _ModelDownloadProgress:
                 timeout = 10,
             )
         except urllib.error.HTTPError as exc:
-            # Only a status about the request itself is final. This route answers 404 when
-            # it judges the hub unreachable and the caller anonymous (routes/models.py:2417),
-            # and an older server without the route answers 404 too, so 404 has to stay
-            # retryable; the backoff keeps that cheap.
-            return [] if exc.code in _DEFINITIVE_HTTP_STATUS else None
+            # Only a status about the request itself is final. 404 is two answers: this
+            # route raises it when it judges the hub unreachable and the caller anonymous
+            # (routes/models.py:2417), which is worth retrying, and a server too old to
+            # carry the route raises it forever, which is not. The body separates them.
+            if exc.code in _DEFINITIVE_HTTP_STATUS:
+                return []
+            if exc.code == 404 and _is_absent_route(exc):
+                return []
+            return None
         except Exception:
             return None
         if not info.get("is_lora"):
@@ -1439,6 +1468,12 @@ class _ModelDownloadProgress:
             # flapping mount could do that forever. The cost is that a transfer which truly
             # restarts is not counted again until it passes its own high mark; that failure
             # is bounded and says so, where a false renewal is an unbounded wait.
+            grown = frozenset(
+                repo
+                for repo, item in readings
+                if repo in self._repo_bytes
+                and max(0, int(item.get("downloaded_bytes") or 0)) > self._repo_bytes[repo]
+            )
             for repo, item in readings:
                 self._repo_bytes[repo] = max(
                     self._repo_bytes.get(repo, 0), max(0, int(item.get("downloaded_bytes") or 0))
@@ -1450,7 +1485,7 @@ class _ModelDownloadProgress:
             self._downloaded_bytes = max(self._downloaded_bytes, sum(self._repo_bytes.values()))
             self._failures = 0
             self._retry_at = 0.0
-            active_repo, active = _active_reading(readings)
+            active_repo, active = _active_reading(readings, grown)
             self._display.update(active, active_repo)
         except Exception:
             # Progress is best-effort and never fails the load, but `_start_studio_server`

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -886,8 +886,9 @@ _DOWNLOAD_POLL_MAX_BACKOFF_S = 60.0
 # of stopping: giving up for good would leave a server that recovers later untracked.
 _COMPANION_LOOKUP_RETRY_S = 60.0
 _COMPANION_LOOKUP_MAX_RETRY_S = 300.0
-# Client statuses that mean "later", not "no".
-_TRANSIENT_HTTP_STATUS = frozenset((408, 425, 429))
+# The only answers that settle the question: the request itself was refused. Everything
+# else, 404 included, can be a server that is briefly offline, busy or too old.
+_DEFINITIVE_HTTP_STATUS = frozenset((400, 401, 403, 405, 410, 422))
 _START_API_KEY_PREFIX = "UNSLOTH_START_API_KEY: "
 _START_API_KEY_MARKER_ENV = "_UNSLOTH_START_API_KEY_MARKER"
 
@@ -1279,8 +1280,6 @@ class _ModelDownloadProgress:
         self._progress_prefix = "/api/hub"
         self._companions: Optional[list[str]] = None
         self._repo_bytes: dict[str, int] = {}
-        self._repo_in_flight: dict[str, int] = {}
-        self._repo_measured: dict[str, bool] = {}
         self._companion_lookups = 0
         self._companion_retry_at = 0.0
         self._companion_retry_s = _COMPANION_LOOKUP_RETRY_S
@@ -1342,10 +1341,11 @@ class _ModelDownloadProgress:
                 timeout = 10,
             )
         except urllib.error.HTTPError as exc:
-            # A timeout or a rate limit says try later, not "this is not an adapter".
-            if exc.code >= 500 or exc.code in _TRANSIENT_HTTP_STATUS:
-                return None
-            return []
+            # Only a status about the request itself is final. This route answers 404 when
+            # it judges the hub unreachable and the caller anonymous (routes/models.py:2417),
+            # and an older server without the route answers 404 too, so 404 has to stay
+            # retryable; the backoff keeps that cheap.
+            return [] if exc.code in _DEFINITIVE_HTTP_STATUS else None
         except Exception:
             return None
         if not info.get("is_lora"):
@@ -1422,22 +1422,14 @@ class _ModelDownloadProgress:
             # a reading already taken, never bytes merely being present: an abandoned
             # transfer leaves `.incomplete` blobs behind, and pruning to a corpse would
             # discard the repo the worker is about to fetch.
-            # Bytes in flight, not bytes on disk, and only between two complete scans.
-            # A cache mount that was absent and then appears grows the total by its whole
-            # cached size without anything transferring, and `cache_measured` false is an
-            # explicit lower bound from a root that could not be read; either read as
-            # growth would prune away the repo the worker really fetches. A server too old
-            # to send the flag never prunes, which only costs a request per poll.
-            grew = [
-                repo
-                for repo, item in companions
-                if item is not None
-                and self._repo_measured.get(repo)
-                and item.get("cache_measured") is True
-                and _in_flight_bytes(item) > self._repo_in_flight.get(repo, 0)
-            ]
-            if len(grew) == 1:
-                self._companions = grew
+            # Every candidate is polled for the whole load, deliberately. Narrowing to the
+            # one that looks live saves a few requests a second against a server on the
+            # same machine, and costs the user their server whenever the guess is wrong:
+            # bytes present are not bytes moving, a cache root appearing is not a transfer,
+            # an abandoned `.incomplete` blob looks exactly like a live one, and an
+            # unreadable root reports a lower bound that rebounds later. A candidate that
+            # is not being fetched answers with a measured zero, which is cheap and always
+            # right, so the extra requests buy correctness that no predicate here can.
             # The liveness baseline only ever rises. A reading falls for reasons that are
             # not "bytes left the disk": an incomplete scan reporting a lower bound, a
             # cache mount vanishing cleanly (`hf_cache_state._safe_is_dir` calls that a
@@ -1451,8 +1443,6 @@ class _ModelDownloadProgress:
                 self._repo_bytes[repo] = max(
                     self._repo_bytes.get(repo, 0), max(0, int(item.get("downloaded_bytes") or 0))
                 )
-                self._repo_in_flight[repo] = _in_flight_bytes(item)
-                self._repo_measured[repo] = item.get("cache_measured") is True
             # Per repo, and kept after a candidate is dropped: an alternative base already
             # complete in the cache contributes its bytes to the first total, so forgetting
             # it would drop the sum below a high mark the live download may never reach on

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -10,6 +10,7 @@ import errno
 import functools
 import hashlib
 import http.client
+import importlib.util
 import json
 import os
 import re
@@ -879,6 +880,10 @@ _SERVER_START_TIMEOUT_S = 900
 _DOWNLOAD_POLL_INTERVAL_S = 1.0
 # Ceiling on the doubling back-off the progress reader uses after a polling error.
 _DOWNLOAD_POLL_MAX_BACKOFF_S = 60.0
+# A 200 that reports no adapter can also be a failed inspection, so the answer is
+# re-asked a few times before it is trusted; the endpoint is too costly to poll.
+_COMPANION_LOOKUP_ATTEMPTS = 3
+_COMPANION_LOOKUP_RETRY_S = 60.0
 _START_API_KEY_PREFIX = "UNSLOTH_START_API_KEY: "
 _START_API_KEY_MARKER_ENV = "_UNSLOTH_START_API_KEY_MARKER"
 
@@ -1005,9 +1010,61 @@ def _combined_reading(readings: list[dict]) -> dict:
         field: sum(max(0, int(reading.get(field) or 0)) for reading in readings)
         for field in ("downloaded_bytes", "completed_bytes", "expected_bytes")
     }
+    # Zero expected bytes means "total unknown", not "contributes nothing". Summing it
+    # would divide by one repo's total and report a finished adapter next to a base still
+    # transferring as 100%, so an unknown part makes the combined total unknown too and
+    # the display falls back to bytes.
+    if any(int(reading.get("expected_bytes") or 0) <= 0 for reading in readings):
+        combined["expected_bytes"] = 0
     expected = combined["expected_bytes"]
     combined["progress"] = min(1.0, combined["downloaded_bytes"] / expected) if expected else 0.0
     return combined
+
+
+_QUANT_MAPPER: Optional[dict] = None
+
+
+def _unsloth_quant_mapper() -> dict:
+    """`unsloth.models.mapper.FLOAT_TO_INT_MAPPER`, read without importing unsloth.
+
+    The table is plain data with no imports of its own, so it loads straight from the
+    package directory; importing `unsloth` would pull in torch to answer a dict lookup.
+    """
+    global _QUANT_MAPPER
+    if _QUANT_MAPPER is None:
+        _QUANT_MAPPER = {}
+        try:
+            spec = importlib.util.find_spec("unsloth")
+            locations = list(spec.submodule_search_locations) if spec else []
+            path = Path(locations[0]) / "models" / "mapper.py" if locations else None
+            if path is not None and path.is_file():
+                module_spec = importlib.util.spec_from_file_location(
+                    "unsloth_cli._quant_mapper", path
+                )
+                module = importlib.util.module_from_spec(module_spec)
+                module_spec.loader.exec_module(module)
+                table = getattr(module, "FLOAT_TO_INT_MAPPER", None)
+                if isinstance(table, dict):
+                    _QUANT_MAPPER = table
+        except Exception:
+            # Nothing here is required; the recorded base alone is still worth polling.
+            pass
+    return _QUANT_MAPPER
+
+
+def _base_model_candidates(base_model: str) -> list[str]:
+    """`base_model` plus the pre-quantized repo the loader substitutes for it.
+
+    `get_model_name` rewrites a PEFT adapter's recorded base to an Unsloth 4-bit repo
+    before fetching it, which is the default for a QLoRA adapter, so the recorded name
+    on its own can name a repo that never moves while the real download runs unwatched.
+    Both are polled and summed: the one that is not being fetched reports zero bytes.
+    """
+    candidates = [base_model]
+    mapped = _unsloth_quant_mapper().get(base_model)
+    if isinstance(mapped, str) and mapped and mapped not in candidates:
+        candidates.append(mapped)
+    return candidates
 
 
 class _ModelDownloadProgress:
@@ -1027,6 +1084,8 @@ class _ModelDownloadProgress:
         self._disabled = not _is_hub_model_id(model)
         self._progress_prefix = "/api/hub"
         self._companions: Optional[list[str]] = None
+        self._companion_lookups = 0
+        self._companion_retry_at = 0.0
 
     def _is_gguf(self) -> bool:
         return bool(self._variant) or "gguf" in self._model.lower()
@@ -1076,15 +1135,22 @@ class _ModelDownloadProgress:
             return []
         try:
             info = _http_json(
-                "GET", f"{self._base}/api/models/config/{quote(self._model)}", self._key
+                "GET",
+                f"{self._base}/api/models/config/{quote(self._model)}",
+                self._key,
+                timeout = 10,
             )
         except urllib.error.HTTPError as exc:
             return [] if exc.code < 500 else None
         except Exception:
             return None
+        if not info.get("is_lora"):
+            # The server reports is_lora=False both for a plain model and for an adapter
+            # whose adapter_config.json it could not read, so this answer is not final.
+            return None
         base_model = str(info.get("base_model") or "")
-        if info.get("is_lora") and base_model != self._model and _is_hub_model_id(base_model):
-            return [base_model]
+        if base_model != self._model and _is_hub_model_id(base_model):
+            return _base_model_candidates(base_model)
         return []
 
     def _read(
@@ -1102,6 +1168,19 @@ class _ModelDownloadProgress:
             url = f"{self._base}{self._progress_prefix}/download-progress?{params}"
         return _http_json("GET", url, self._key, timeout = 10)
 
+    def _companion_reading(self, repo: str) -> Optional[dict]:
+        """A companion's reading, or None when its request failed.
+
+        Isolated on purpose: a companion is an extra request per poll against the same
+        server that is busy downloading, so a slow or failed one must not discard the
+        model's own good reading. Dropping the companion's bytes only ever lowers the
+        total, and the liveness baseline never follows a reading down.
+        """
+        try:
+            return self._read(repo)
+        except Exception:
+            return None
+
     def poll(self) -> None:
         if not self._configured:
             self._configure()
@@ -1110,8 +1189,18 @@ class _ModelDownloadProgress:
         if time.monotonic() < self._retry_at:
             return
         try:
-            if self._companions is None:
+            if (
+                self._companions is None
+                and self._companion_lookups < _COMPANION_LOOKUP_ATTEMPTS
+                and time.monotonic() >= self._companion_retry_at
+            ):
                 self._companions = self._companion_repos()
+                if self._companions is None:
+                    # Every unresolved answer is rationed, errors included. This endpoint
+                    # runs hub probes per request, so retrying it once a second for the
+                    # length of a download would load the server doing the downloading.
+                    self._companion_lookups += 1
+                    self._companion_retry_at = time.monotonic() + _COMPANION_LOOKUP_RETRY_S
             try:
                 reading = self._read(self._model, gguf = self._is_gguf())
             except urllib.error.HTTPError as exc:
@@ -1120,8 +1209,9 @@ class _ModelDownloadProgress:
                 self._progress_prefix = "/api/models"
                 self.poll()
                 return
+            companions = (self._companion_reading(repo) for repo in self._companions or [])
             reading = _combined_reading(
-                [reading, *(self._read(repo) for repo in self._companions or [])]
+                [reading, *(item for item in companions if item is not None)]
             )
             # The liveness baseline only ever rises. A reading falls for reasons that are
             # not "bytes left the disk": an incomplete scan reporting a lower bound, a

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1050,10 +1050,15 @@ def _unsloth_quant_mappers() -> list[dict]:
                 )
                 module = importlib.util.module_from_spec(module_spec)
                 module_spec.loader.exec_module(module)
+                # Every table except the fp8 ones: nothing in the inference path passes
+                # `load_in_fp8`, so an fp8 repo can never be what the worker fetches, and
+                # polling it would only cost the downloading server a request per poll.
                 _QUANT_MAPPERS = [
                     value
                     for name, value in vars(module).items()
-                    if not name.startswith("_") and isinstance(value, dict)
+                    if not name.startswith("_")
+                    and "fp8" not in name.lower()
+                    and isinstance(value, dict)
                 ]
         except Exception:
             # Nothing here is required; the recorded base alone is still worth polling.

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1161,7 +1161,7 @@ def _flattened_repo_ids(value: object, found: set) -> None:
             _flattened_repo_ids(item, found)
 
 
-_BAD_MAPPINGS: Optional[dict] = None
+_BAD_MAPPINGS: Optional[list[dict]] = None
 
 
 def _literal_text(node: object) -> Optional[str]:
@@ -1179,8 +1179,8 @@ def _literal_text(node: object) -> Optional[str]:
     return None
 
 
-def _unsloth_bad_mappings() -> dict:
-    """`unsloth.models.loader_utils.BAD_MAPPINGS`, read out of the source.
+def _unsloth_bad_mappings() -> list[dict]:
+    """One `unsloth.models.loader_utils.BAD_MAPPINGS` per install, read out of the source.
 
     The loader rewrites a mapped name a second time through this table, so a candidate set
     built from the mapper alone stops one step short. Unlike the mapper this module cannot
@@ -1189,7 +1189,7 @@ def _unsloth_bad_mappings() -> dict:
     """
     global _BAD_MAPPINGS
     if _BAD_MAPPINGS is None:
-        _BAD_MAPPINGS = {}
+        _BAD_MAPPINGS = []
         for directory in _unsloth_package_dirs():
             path = directory / "models" / "loader_utils.py"
             try:
@@ -1201,10 +1201,16 @@ def _unsloth_bad_mappings() -> dict:
                         continue
                     if not isinstance(node.value, ast.Dict):
                         continue
+                    table: dict = {}
                     for key, value in zip(node.value.keys, node.value.values):
                         name, mapped = _literal_text(key), _literal_text(value)
                         if name and mapped:
-                            _BAD_MAPPINGS.setdefault(name, mapped)
+                            table[name] = mapped
+                    if table:
+                        # One table per install, not one merged dict: two installs can
+                        # disagree on the same key, and the worker's answer is as real as
+                        # the parent's, so both targets stay candidates.
+                        _BAD_MAPPINGS.append(table)
             except Exception:
                 # Nothing here is required; the mapper candidates are still worth polling.
                 continue
@@ -1224,7 +1230,7 @@ def _base_model_candidates(base_model: str) -> list[str]:
     costs the user their server.
     """
     tables = _unsloth_quant_mappers()
-    bad = _unsloth_bad_mappings()
+    bad_tables = _unsloth_bad_mappings()
     # The strip is applied after mapping, and an unmapped base falls through mapping
     # unchanged, so the recorded name itself is a subject of it.
     seeds = {base_model, _without_prequantized_suffix(base_model)}
@@ -1242,8 +1248,9 @@ def _base_model_candidates(base_model: str) -> list[str]:
             for table in tables:
                 if key in table:
                     _flattened_repo_ids(table[key], step)
-            if key in bad:
-                step.add(bad[key])
+            for bad in bad_tables:
+                if key in bad:
+                    step.add(bad[key])
         # The loader strips the 4-bit suffix after mapping when the device forbids
         # pre-quantized repos, so the fetched name can be a third step out.
         step.update(_without_prequantized_suffix(repo) for repo in list(step))

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -25,7 +25,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Literal, NamedTuple, NoReturn, Optional
-from urllib.parse import urlencode, urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 import click
 import typer
@@ -998,6 +998,18 @@ def _normalized_variant(value: object) -> str:
     return re.sub(r"[^a-z0-9]", "", str(value or "").lower())
 
 
+def _combined_reading(readings: list[dict]) -> dict:
+    if len(readings) == 1:
+        return readings[0]
+    combined = {
+        field: sum(max(0, int(reading.get(field) or 0)) for reading in readings)
+        for field in ("downloaded_bytes", "completed_bytes", "expected_bytes")
+    }
+    expected = combined["expected_bytes"]
+    combined["progress"] = min(1.0, combined["downloaded_bytes"] / expected) if expected else 0.0
+    return combined
+
+
 class _ModelDownloadProgress:
     """Best-effort polling of the model download endpoints."""
 
@@ -1014,6 +1026,10 @@ class _ModelDownloadProgress:
         self._configured = False
         self._disabled = not _is_hub_model_id(model)
         self._progress_prefix = "/api/hub"
+        self._companions: Optional[list[str]] = None
+
+    def _is_gguf(self) -> bool:
+        return bool(self._variant) or "gguf" in self._model.lower()
 
     def _configure(self) -> None:
         self._configured = True
@@ -1021,7 +1037,7 @@ class _ModelDownloadProgress:
             return
         # GGUF repos need the selected quant's size; the repo endpoint totals every
         # quant. Resolve the variant first, otherwise show bytes only.
-        if self._variant or "gguf" in self._model.lower():
+        if self._is_gguf():
             try:
                 params = urlencode({"repo_id": self._model})
                 try:
@@ -1055,6 +1071,33 @@ class _ModelDownloadProgress:
                 # Older servers lack this endpoint; byte progress is still useful.
                 pass
 
+    def _companion_repos(self) -> Optional[list[str]]:
+        if self._is_gguf():
+            return []
+        try:
+            info = _http_json(
+                "GET", f"{self._base}/api/models/config/{quote(self._model)}", self._key
+            )
+        except urllib.error.HTTPError as exc:
+            return [] if exc.code < 500 else None
+        except Exception:
+            return None
+        base_model = str(info.get("base_model") or "")
+        if info.get("is_lora") and base_model != self._model and _is_hub_model_id(base_model):
+            return [base_model]
+        return []
+
+    def _read(self, repo: str, gguf: bool = False) -> dict:
+        if gguf:
+            params = urlencode(
+                {"repo_id": repo, "variant": self._variant, "expected_bytes": self._expected_bytes}
+            )
+            url = f"{self._base}{self._progress_prefix}/gguf-download-progress?{params}"
+        else:
+            params = urlencode({"repo_id": repo})
+            url = f"{self._base}{self._progress_prefix}/download-progress?{params}"
+        return _http_json("GET", url, self._key, timeout = 10)
+
     def poll(self) -> None:
         if not self._configured:
             self._configure()
@@ -1063,28 +1106,19 @@ class _ModelDownloadProgress:
         if time.monotonic() < self._retry_at:
             return
         try:
-            if self._variant or "gguf" in self._model.lower():
-                params = urlencode(
-                    {
-                        "repo_id": self._model,
-                        "variant": self._variant,
-                        "expected_bytes": self._expected_bytes,
-                    }
-                )
-                url = f"{self._base}{self._progress_prefix}/gguf-download-progress?{params}"
-            else:
-                url = (
-                    f"{self._base}{self._progress_prefix}/download-progress?"
-                    f"{urlencode({'repo_id': self._model})}"
-                )
+            if self._companions is None:
+                self._companions = self._companion_repos()
             try:
-                reading = _http_json("GET", url, self._key, timeout = 10)
+                reading = self._read(self._model, gguf = self._is_gguf())
             except urllib.error.HTTPError as exc:
                 if exc.code != 404 or self._progress_prefix == "/api/models":
                     raise
                 self._progress_prefix = "/api/models"
                 self.poll()
                 return
+            reading = _combined_reading(
+                [reading, *(self._read(repo) for repo in self._companions or [])]
+            )
             # The liveness baseline only ever rises. A reading falls for reasons that are
             # not "bytes left the disk": an incomplete scan reporting a lower bound, a
             # cache mount vanishing cleanly (`hf_cache_state._safe_is_dir` calls that a

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -10,6 +10,8 @@ import errno
 import functools
 import hashlib
 import http.client
+import ast
+import ast
 import importlib.util
 import json
 import os
@@ -918,9 +920,23 @@ class _DownloadProgressDisplay:
         self._last_bucket = -1
         self._last_line_length = 0
         self._last_expected = 0
+        self._source: Optional[str] = None
         self._interactive = bool(getattr(sys.stdout, "isatty", lambda: False)())
 
-    def update(self, progress: dict) -> None:
+    def update(
+        self,
+        progress: dict,
+        source: Optional[str] = None,
+    ) -> None:
+        if source != self._source:
+            # A different repo is a different transfer: its bytes and percentage are not a
+            # continuation of the last one. Without this the redirected-output branch below,
+            # which only prints when the bucket rises, stays silent for a whole base
+            # download that starts near zero after an adapter finished near the top.
+            self._source = source
+            self._samples.clear()
+            self._last_bucket = -1
+            self._shown = False
         downloaded = max(0, int(progress.get("downloaded_bytes") or 0))
         completed = max(0, int(progress.get("completed_bytes") or 0))
         expected = max(0, int(progress.get("expected_bytes") or 0))
@@ -1010,11 +1026,7 @@ def _in_flight_bytes(reading: dict) -> int:
     return downloaded - completed
 
 
-def _total_downloaded_bytes(readings: list[dict]) -> int:
-    return sum(max(0, int(reading.get("downloaded_bytes") or 0)) for reading in readings)
-
-
-def _active_reading(readings: list[dict]) -> dict:
+def _active_reading(readings: list[tuple[str, dict]]) -> tuple[str, dict]:
     """The one repo whose transfer the progress line should follow.
 
     A model, its base, and the repos the loader may substitute for that base are separate
@@ -1024,8 +1036,8 @@ def _active_reading(readings: list[dict]) -> dict:
     exist. Bytes are still summed for liveness, since any repo moving is progress, but the
     line follows whichever repo has bytes in flight, and the model itself when none does.
     """
-    active = max(readings, key = _in_flight_bytes)
-    return active if _in_flight_bytes(active) > 0 else readings[0]
+    active = max(readings, key = lambda item: _in_flight_bytes(item[1]))
+    return active if _in_flight_bytes(active[1]) > 0 else readings[0]
 
 
 _QUANT_MAPPERS: Optional[list[dict]] = None
@@ -1077,6 +1089,56 @@ def _flattened_repo_ids(value: object, found: set) -> None:
             _flattened_repo_ids(item, found)
 
 
+_BAD_MAPPINGS: Optional[dict] = None
+
+
+def _literal_text(node: object) -> Optional[str]:
+    """A string literal, or a literal with `.lower()` applied, as written in the source."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "lower"
+        and not node.args
+    ):
+        inner = _literal_text(node.func.value)
+        return inner.lower() if inner is not None else None
+    return None
+
+
+def _unsloth_bad_mappings() -> dict:
+    """`unsloth.models.loader_utils.BAD_MAPPINGS`, read out of the source.
+
+    The loader rewrites a mapped name a second time through this table, so a candidate set
+    built from the mapper alone stops one step short. Unlike the mapper this module cannot
+    be executed for its data -- it imports torch -- so the literal is read from the syntax
+    tree instead.
+    """
+    global _BAD_MAPPINGS
+    if _BAD_MAPPINGS is None:
+        _BAD_MAPPINGS = {}
+        try:
+            spec = importlib.util.find_spec("unsloth")
+            locations = list(spec.submodule_search_locations) if spec else []
+            path = Path(locations[0]) / "models" / "loader_utils.py" if locations else None
+            if path is not None and path.is_file():
+                for node in ast.parse(path.read_text(encoding = "utf-8")).body:
+                    targets = getattr(node, "targets", [])
+                    if not any(isinstance(t, ast.Name) and t.id == "BAD_MAPPINGS" for t in targets):
+                        continue
+                    if not isinstance(node.value, ast.Dict):
+                        continue
+                    for key, value in zip(node.value.keys, node.value.values):
+                        name, mapped = _literal_text(key), _literal_text(value)
+                        if name and mapped:
+                            _BAD_MAPPINGS[name] = mapped
+        except Exception:
+            # Nothing here is required; the mapper candidates are still worth polling.
+            pass
+    return _BAD_MAPPINGS
+
+
 def _base_model_candidates(base_model: str) -> list[str]:
     """`base_model` plus every repo the loader may download in its place.
 
@@ -1089,15 +1151,28 @@ def _base_model_candidates(base_model: str) -> list[str]:
     Unsloth builds. Polling one repo too many is a measured zero; missing the right one
     costs the user their server.
     """
+    tables = _unsloth_quant_mappers()
+    bad = _unsloth_bad_mappings()
     found: set = set()
-    for table in _unsloth_quant_mappers():
+    pending = [base_model]
+    # Followed to a fixed point: the loader maps a name, then rewrites the result through
+    # BAD_MAPPINGS, so the repo it downloads can be two steps from the recorded base.
+    while pending:
+        current = pending.pop()
+        step: set = set()
         # Both cases: the tables carry the name as written and a lower-cased copy, and
         # `__get_model_name` looks up the lower-cased one, so it can return a repo id whose
         # case differs from the entry reached by the recorded spelling.
-        for key in (base_model, base_model.lower()):
-            if key in table:
-                _flattened_repo_ids(table[key], found)
-    found.discard(base_model)
+        for key in (current, current.lower()):
+            for table in tables:
+                if key in table:
+                    _flattened_repo_ids(table[key], step)
+            if key in bad:
+                step.add(bad[key])
+        for repo in step:
+            if repo not in found and repo != base_model:
+                found.add(repo)
+                pending.append(repo)
     return [base_model] + sorted(repo for repo in found if _is_hub_model_id(repo))
 
 
@@ -1118,6 +1193,7 @@ class _ModelDownloadProgress:
         self._disabled = not _is_hub_model_id(model)
         self._progress_prefix = "/api/hub"
         self._companions: Optional[list[str]] = None
+        self._repo_bytes: dict[str, int] = {}
         self._companion_lookups = 0
         self._companion_retry_at = 0.0
 
@@ -1247,7 +1323,9 @@ class _ModelDownloadProgress:
                 self.poll()
                 return
             companions = [(repo, self._companion_reading(repo)) for repo in self._companions or []]
-            readings = [reading] + [item for _, item in companions if item is not None]
+            readings = [(self._model, reading)] + [
+                (repo, item) for repo, item in companions if item is not None
+            ]
             # Only one candidate base is ever fetched. Once one of them is moving the rest
             # are known dead weight, so stop spending a request per poll on them.
             moving = [
@@ -1264,10 +1342,19 @@ class _ModelDownloadProgress:
             # flapping mount could do that forever. The cost is that a transfer which truly
             # restarts is not counted again until it passes its own high mark; that failure
             # is bounded and says so, where a false renewal is an unbounded wait.
-            self._downloaded_bytes = max(self._downloaded_bytes, _total_downloaded_bytes(readings))
+            for repo, item in readings:
+                self._repo_bytes[repo] = max(
+                    self._repo_bytes.get(repo, 0), max(0, int(item.get("downloaded_bytes") or 0))
+                )
+            # Per repo, and kept after a candidate is dropped: an alternative base already
+            # complete in the cache contributes its bytes to the first total, so forgetting
+            # it would drop the sum below a high mark the live download may never reach on
+            # its own, and the deadline would never renew again.
+            self._downloaded_bytes = max(self._downloaded_bytes, sum(self._repo_bytes.values()))
             self._failures = 0
             self._retry_at = 0.0
-            self._display.update(_active_reading(readings))
+            active_repo, active = _active_reading(readings)
+            self._display.update(active, active_repo)
         except Exception:
             # Progress is best-effort and never fails the load, but `_start_studio_server`
             # reads `downloaded_bytes` to tell a live transfer from a wedged one. Backing

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -881,10 +881,11 @@ _SERVER_START_TIMEOUT_S = 900
 _DOWNLOAD_POLL_INTERVAL_S = 1.0
 # Ceiling on the doubling back-off the progress reader uses after a polling error.
 _DOWNLOAD_POLL_MAX_BACKOFF_S = 60.0
-# A 200 that reports no adapter can also be a failed inspection, so the answer is
-# re-asked a few times before it is trusted; the endpoint is too costly to poll.
-_COMPANION_LOOKUP_ATTEMPTS = 3
+# A 200 that reports no adapter can also be a failed inspection, so the answer is never
+# final. The endpoint runs several hub probes per request, so re-asking backs off instead
+# of stopping: giving up for good would leave a server that recovers later untracked.
 _COMPANION_LOOKUP_RETRY_S = 60.0
+_COMPANION_LOOKUP_MAX_RETRY_S = 300.0
 _START_API_KEY_PREFIX = "UNSLOTH_START_API_KEY: "
 _START_API_KEY_MARKER_ENV = "_UNSLOTH_START_API_KEY_MARKER"
 
@@ -1301,18 +1302,18 @@ class _ModelDownloadProgress:
         if time.monotonic() < self._retry_at:
             return
         try:
-            if (
-                self._companions is None
-                and self._companion_lookups < _COMPANION_LOOKUP_ATTEMPTS
-                and time.monotonic() >= self._companion_retry_at
-            ):
+            if self._companions is None and time.monotonic() >= self._companion_retry_at:
                 self._companions = self._companion_repos()
                 if self._companions is None:
-                    # Every unresolved answer is rationed, errors included. This endpoint
-                    # runs hub probes per request, so retrying it once a second for the
-                    # length of a download would load the server doing the downloading.
+                    # Every unresolved answer is rationed, errors included: retrying once a
+                    # second would load the server doing the downloading. The wait doubles
+                    # to a ceiling rather than running out, so a config route that is slow
+                    # or rate-limited for a few minutes does not cost the whole startup.
                     self._companion_lookups += 1
-                    self._companion_retry_at = time.monotonic() + _COMPANION_LOOKUP_RETRY_S
+                    self._companion_retry_at = time.monotonic() + min(
+                        _COMPANION_LOOKUP_RETRY_S * 2.0 ** (self._companion_lookups - 1),
+                        _COMPANION_LOOKUP_MAX_RETRY_S,
+                    )
             try:
                 reading = self._read(self._model, gguf = self._is_gguf())
             except urllib.error.HTTPError as exc:
@@ -1325,13 +1326,20 @@ class _ModelDownloadProgress:
             readings = [(self._model, reading)] + [
                 (repo, item) for repo, item in companions if item is not None
             ]
-            # Only one candidate base is ever fetched. Once one of them is moving the rest
-            # are known dead weight, so stop spending a request per poll on them.
-            moving = [
-                repo for repo, item in companions if item is not None and _in_flight_bytes(item) > 0
+            # Only one candidate base is ever fetched, so once one is demonstrably moving
+            # the rest are dead weight and need not cost a request per poll. Growth against
+            # a reading already taken, never bytes merely being present: an abandoned
+            # transfer leaves `.incomplete` blobs behind, and pruning to a corpse would
+            # discard the repo the worker is about to fetch.
+            grew = [
+                repo
+                for repo, item in companions
+                if item is not None
+                and repo in self._repo_bytes
+                and max(0, int(item.get("downloaded_bytes") or 0)) > self._repo_bytes[repo]
             ]
-            if len(moving) == 1:
-                self._companions = moving
+            if len(grew) == 1:
+                self._companions = grew
             # The liveness baseline only ever rises. A reading falls for reasons that are
             # not "bytes left the disk": an incomplete scan reporting a lower bound, a
             # cache mount vanishing cleanly (`hf_cache_state._safe_is_dir` calls that a

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -3,6 +3,7 @@
 
 """`unsloth start` — launch a coding agent against a running Unsloth server."""
 
+import ast
 import atexit
 import base64
 import contextlib
@@ -10,8 +11,6 @@ import errno
 import functools
 import hashlib
 import http.client
-import ast
-import ast
 import importlib.util
 import json
 import os

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -886,6 +886,8 @@ _DOWNLOAD_POLL_MAX_BACKOFF_S = 60.0
 # of stopping: giving up for good would leave a server that recovers later untracked.
 _COMPANION_LOOKUP_RETRY_S = 60.0
 _COMPANION_LOOKUP_MAX_RETRY_S = 300.0
+# Client statuses that mean "later", not "no".
+_TRANSIENT_HTTP_STATUS = frozenset((408, 425, 429))
 _START_API_KEY_PREFIX = "UNSLOTH_START_API_KEY: "
 _START_API_KEY_MARKER_ENV = "_UNSLOTH_START_API_KEY_MARKER"
 
@@ -935,8 +937,10 @@ class _DownloadProgressDisplay:
             # download that starts near zero after an adapter finished near the top.
             self._source = source
             self._samples.clear()
+            # Not `_shown`: `_last_bucket = -1` already lets the next line through, while
+            # clearing it would strand a finished bar below 100% and drop the closing
+            # newline, since `complete()` and `close()` both gate on it.
             self._last_bucket = -1
-            self._shown = False
         downloaded = max(0, int(progress.get("downloaded_bytes") or 0))
         completed = max(0, int(progress.get("completed_bytes") or 0))
         expected = max(0, int(progress.get("expected_bytes") or 0))
@@ -1064,6 +1068,32 @@ def _unsloth_package_dirs() -> list[Path]:
         venv = Path(STUDIO_HOME) / "unsloth_studio"
         dirs.extend(venv.glob("lib/python*/site-packages/unsloth"))
         dirs.append(venv / "Lib" / "site-packages" / "unsloth")
+    except Exception:
+        pass
+    # And ask that venv itself. `unsloth studio update --local` installs Unsloth with
+    # `-e`, which leaves a PEP 660 finder rather than a package directory, so the globs
+    # above see nothing. `find_spec` locates it without importing it, so this costs a
+    # short-lived interpreter and never loads torch.
+    try:
+        from unsloth_cli.commands.studio import _studio_venv_python
+        python = _studio_venv_python()
+        if python is not None:
+            found = subprocess.run(
+                [
+                    str(python),
+                    "-c",
+                    "import importlib.util as u;s=u.find_spec('unsloth');"
+                    "print(next(iter(s.submodule_search_locations)) if s else '')",
+                ],
+                capture_output = True,
+                text = True,
+                timeout = 20,
+                # Away from the caller's directory: an `unsloth/` folder in the cwd is on
+                # that interpreter's path too, and would answer for the venv's install.
+                cwd = str(python.parent),
+            ).stdout.strip()
+            if found:
+                dirs.append(Path(found))
     except Exception:
         pass
     seen: set = set()
@@ -1195,8 +1225,11 @@ def _base_model_candidates(base_model: str) -> list[str]:
     """
     tables = _unsloth_quant_mappers()
     bad = _unsloth_bad_mappings()
-    found: set = set()
-    pending = [base_model]
+    # The strip is applied after mapping, and an unmapped base falls through mapping
+    # unchanged, so the recorded name itself is a subject of it.
+    seeds = {base_model, _without_prequantized_suffix(base_model)}
+    found: set = seeds - {base_model}
+    pending = list(seeds)
     # Followed to a fixed point: the loader maps a name, then rewrites the result through
     # BAD_MAPPINGS, so the repo it downloads can be two steps from the recorded base.
     while pending:
@@ -1239,6 +1272,7 @@ class _ModelDownloadProgress:
         self._progress_prefix = "/api/hub"
         self._companions: Optional[list[str]] = None
         self._repo_bytes: dict[str, int] = {}
+        self._repo_in_flight: dict[str, int] = {}
         self._repo_measured: dict[str, bool] = {}
         self._companion_lookups = 0
         self._companion_retry_at = 0.0
@@ -1301,7 +1335,10 @@ class _ModelDownloadProgress:
                 timeout = 10,
             )
         except urllib.error.HTTPError as exc:
-            return [] if exc.code < 500 else None
+            # A timeout or a rate limit says try later, not "this is not an adapter".
+            if exc.code >= 500 or exc.code in _TRANSIENT_HTTP_STATUS:
+                return None
+            return []
         except Exception:
             return None
         if not info.get("is_lora"):
@@ -1378,18 +1415,19 @@ class _ModelDownloadProgress:
             # a reading already taken, never bytes merely being present: an abandoned
             # transfer leaves `.incomplete` blobs behind, and pruning to a corpse would
             # discard the repo the worker is about to fetch.
-            # Both readings have to be complete scans. `cache_measured` false is an
-            # explicit lower bound -- a cache root that could not be read -- so the larger
-            # figure that follows when the root returns is a rebound, not a transfer, and
-            # would otherwise prune away the repo the worker really fetches. A server too
-            # old to send the flag never prunes, which only costs a request per poll.
+            # Bytes in flight, not bytes on disk, and only between two complete scans.
+            # A cache mount that was absent and then appears grows the total by its whole
+            # cached size without anything transferring, and `cache_measured` false is an
+            # explicit lower bound from a root that could not be read; either read as
+            # growth would prune away the repo the worker really fetches. A server too old
+            # to send the flag never prunes, which only costs a request per poll.
             grew = [
                 repo
                 for repo, item in companions
                 if item is not None
                 and self._repo_measured.get(repo)
                 and item.get("cache_measured") is True
-                and max(0, int(item.get("downloaded_bytes") or 0)) > self._repo_bytes[repo]
+                and _in_flight_bytes(item) > self._repo_in_flight.get(repo, 0)
             ]
             if len(grew) == 1:
                 self._companions = grew
@@ -1406,6 +1444,7 @@ class _ModelDownloadProgress:
                 self._repo_bytes[repo] = max(
                     self._repo_bytes.get(repo, 0), max(0, int(item.get("downloaded_bytes") or 0))
                 )
+                self._repo_in_flight[repo] = _in_flight_bytes(item)
                 self._repo_measured[repo] = item.get("cache_measured") is True
             # Per repo, and kept after a candidate is dropped: an alternative base already
             # complete in the cache contributes its bytes to the first total, so forgetting

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1086,8 +1086,12 @@ def _base_model_candidates(base_model: str) -> list[str]:
     """
     found: set = set()
     for table in _unsloth_quant_mappers():
-        if base_model in table:
-            _flattened_repo_ids(table[base_model], found)
+        # Both cases: the tables carry the name as written and a lower-cased copy, and
+        # `__get_model_name` looks up the lower-cased one, so it can return a repo id whose
+        # case differs from the entry reached by the recorded spelling.
+        for key in (base_model, base_model.lower()):
+            if key in table:
+                _flattened_repo_ids(table[key], found)
     found.discard(base_model)
     return [base_model] + sorted(repo for repo in found if _is_hub_model_id(repo))
 

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1043,6 +1043,39 @@ def _active_reading(readings: list[tuple[str, dict]]) -> tuple[str, dict]:
 _QUANT_MAPPERS: Optional[list[dict]] = None
 
 
+def _unsloth_package_dirs() -> list[Path]:
+    """Every `unsloth` package directory this CLI can see.
+
+    The server does the downloading, and it need not be this interpreter: `unsloth run`
+    re-execs into the managed Studio venv, which may hold a different Unsloth than the one
+    the CLI was launched from. Reading only the parent's tables would resolve a base by a
+    version the worker is not using, so both are read and their answers pooled.
+    """
+    dirs: list[Path] = []
+    try:
+        spec = importlib.util.find_spec("unsloth")
+        for location in list(spec.submodule_search_locations) if spec else []:
+            dirs.append(Path(location))
+    except Exception:
+        pass
+    try:
+        from unsloth_cli.commands.studio import STUDIO_HOME
+
+        venv = Path(STUDIO_HOME) / "unsloth_studio"
+        dirs.extend(venv.glob("lib/python*/site-packages/unsloth"))
+        dirs.append(venv / "Lib" / "site-packages" / "unsloth")
+    except Exception:
+        pass
+    seen: set = set()
+    unique = []
+    for directory in dirs:
+        key = str(directory)
+        if key not in seen and directory.is_dir():
+            seen.add(key)
+            unique.append(directory)
+    return unique
+
+
 def _unsloth_quant_mappers() -> list[dict]:
     """The repo substitution tables in `unsloth.models.mapper`, read without importing unsloth.
 
@@ -1052,30 +1085,39 @@ def _unsloth_quant_mappers() -> list[dict]:
     global _QUANT_MAPPERS
     if _QUANT_MAPPERS is None:
         _QUANT_MAPPERS = []
-        try:
-            spec = importlib.util.find_spec("unsloth")
-            locations = list(spec.submodule_search_locations) if spec else []
-            path = Path(locations[0]) / "models" / "mapper.py" if locations else None
-            if path is not None and path.is_file():
+        for index, directory in enumerate(_unsloth_package_dirs()):
+            path = directory / "models" / "mapper.py"
+            try:
+                if not path.is_file():
+                    continue
                 module_spec = importlib.util.spec_from_file_location(
-                    "unsloth_cli._quant_mappers", path
+                    f"unsloth_cli._quant_mappers_{index}", path
                 )
                 module = importlib.util.module_from_spec(module_spec)
                 module_spec.loader.exec_module(module)
                 # Every table except the fp8 ones: nothing in the inference path passes
                 # `load_in_fp8`, so an fp8 repo can never be what the worker fetches, and
                 # polling it would only cost the downloading server a request per poll.
-                _QUANT_MAPPERS = [
+                _QUANT_MAPPERS.extend(
                     value
                     for name, value in vars(module).items()
                     if not name.startswith("_")
                     and "fp8" not in name.lower()
                     and isinstance(value, dict)
-                ]
-        except Exception:
-            # Nothing here is required; the recorded base alone is still worth polling.
-            pass
+                )
+            except Exception:
+                # Nothing here is required; the recorded base alone is still worth polling.
+                continue
     return _QUANT_MAPPERS
+
+
+def _without_prequantized_suffix(repo: str) -> str:
+    """`loader._strip_unsloth_bnb_4bit_suffix`: the rewrite applied when a device forbids
+    pre-quantized repos (`ALLOW_PREQUANTIZED_MODELS` is false on several ROCm paths)."""
+    for suffix in ("-unsloth-bnb-4bit", "-bnb-4bit"):
+        if len(repo) >= len(suffix) and repo.lower().endswith(suffix):
+            repo = repo[: -len(suffix)]
+    return repo
 
 
 def _flattened_repo_ids(value: object, found: set) -> None:
@@ -1118,11 +1160,11 @@ def _unsloth_bad_mappings() -> dict:
     global _BAD_MAPPINGS
     if _BAD_MAPPINGS is None:
         _BAD_MAPPINGS = {}
-        try:
-            spec = importlib.util.find_spec("unsloth")
-            locations = list(spec.submodule_search_locations) if spec else []
-            path = Path(locations[0]) / "models" / "loader_utils.py" if locations else None
-            if path is not None and path.is_file():
+        for directory in _unsloth_package_dirs():
+            path = directory / "models" / "loader_utils.py"
+            try:
+                if not path.is_file():
+                    continue
                 for node in ast.parse(path.read_text(encoding = "utf-8")).body:
                     targets = getattr(node, "targets", [])
                     if not any(isinstance(t, ast.Name) and t.id == "BAD_MAPPINGS" for t in targets):
@@ -1132,10 +1174,10 @@ def _unsloth_bad_mappings() -> dict:
                     for key, value in zip(node.value.keys, node.value.values):
                         name, mapped = _literal_text(key), _literal_text(value)
                         if name and mapped:
-                            _BAD_MAPPINGS[name] = mapped
-        except Exception:
-            # Nothing here is required; the mapper candidates are still worth polling.
-            pass
+                            _BAD_MAPPINGS.setdefault(name, mapped)
+            except Exception:
+                # Nothing here is required; the mapper candidates are still worth polling.
+                continue
     return _BAD_MAPPINGS
 
 
@@ -1169,6 +1211,9 @@ def _base_model_candidates(base_model: str) -> list[str]:
                     _flattened_repo_ids(table[key], step)
             if key in bad:
                 step.add(bad[key])
+        # The loader strips the 4-bit suffix after mapping when the device forbids
+        # pre-quantized repos, so the fetched name can be a third step out.
+        step.update(_without_prequantized_suffix(repo) for repo in list(step))
         for repo in step:
             if repo not in found and repo != base_model:
                 found.add(repo)
@@ -1194,8 +1239,10 @@ class _ModelDownloadProgress:
         self._progress_prefix = "/api/hub"
         self._companions: Optional[list[str]] = None
         self._repo_bytes: dict[str, int] = {}
+        self._repo_measured: dict[str, bool] = {}
         self._companion_lookups = 0
         self._companion_retry_at = 0.0
+        self._companion_retry_s = _COMPANION_LOOKUP_RETRY_S
 
     def _is_gguf(self) -> bool:
         return bool(self._variant) or "gguf" in self._model.lower()
@@ -1310,9 +1357,9 @@ class _ModelDownloadProgress:
                     # to a ceiling rather than running out, so a config route that is slow
                     # or rate-limited for a few minutes does not cost the whole startup.
                     self._companion_lookups += 1
-                    self._companion_retry_at = time.monotonic() + min(
-                        _COMPANION_LOOKUP_RETRY_S * 2.0 ** (self._companion_lookups - 1),
-                        _COMPANION_LOOKUP_MAX_RETRY_S,
+                    self._companion_retry_at = time.monotonic() + self._companion_retry_s
+                    self._companion_retry_s = min(
+                        self._companion_retry_s * 2.0, _COMPANION_LOOKUP_MAX_RETRY_S
                     )
             try:
                 reading = self._read(self._model, gguf = self._is_gguf())
@@ -1331,11 +1378,17 @@ class _ModelDownloadProgress:
             # a reading already taken, never bytes merely being present: an abandoned
             # transfer leaves `.incomplete` blobs behind, and pruning to a corpse would
             # discard the repo the worker is about to fetch.
+            # Both readings have to be complete scans. `cache_measured` false is an
+            # explicit lower bound -- a cache root that could not be read -- so the larger
+            # figure that follows when the root returns is a rebound, not a transfer, and
+            # would otherwise prune away the repo the worker really fetches. A server too
+            # old to send the flag never prunes, which only costs a request per poll.
             grew = [
                 repo
                 for repo, item in companions
                 if item is not None
-                and repo in self._repo_bytes
+                and self._repo_measured.get(repo)
+                and item.get("cache_measured") is True
                 and max(0, int(item.get("downloaded_bytes") or 0)) > self._repo_bytes[repo]
             ]
             if len(grew) == 1:
@@ -1353,6 +1406,7 @@ class _ModelDownloadProgress:
                 self._repo_bytes[repo] = max(
                     self._repo_bytes.get(repo, 0), max(0, int(item.get("downloaded_bytes") or 0))
                 )
+                self._repo_measured[repo] = item.get("cache_measured") is True
             # Per repo, and kept after a candidate is dropped: an alternative base already
             # complete in the cache contributes its bytes to the first total, so forgetting
             # it would drop the sum below a high mark the live download may never reach on

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -3990,7 +3990,14 @@ def test_model_download_progress_counts_a_base_the_load_reports(monkeypatch, cap
     calls = []
     base_bytes = iter([1024**3, 2 * 1024**3])
 
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         calls.append(url)
         if url.endswith("/api/hub/active-downloads"):
             return _load_listing("owner/adapter", "owner/base")
@@ -4025,7 +4032,14 @@ def test_model_download_progress_counts_a_base_the_load_reports(monkeypatch, cap
 def test_model_download_progress_ignores_downloads_the_load_does_not_own(monkeypatch):
     reads = []
 
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/api/hub/active-downloads"):
             return {
                 "downloads": [
@@ -4048,7 +4062,14 @@ def test_model_download_progress_ignores_downloads_the_load_does_not_own(monkeyp
 def test_model_download_progress_stops_listing_on_a_server_without_the_route(monkeypatch):
     listings = []
 
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/active-downloads"):
             listings.append(url)
             raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
@@ -4067,7 +4088,14 @@ def test_model_download_progress_stops_listing_on_a_server_without_the_route(mon
 def test_model_download_progress_asks_again_after_a_transient_listing_error(monkeypatch):
     listings = []
 
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/active-downloads"):
             listings.append(url)
             if len(listings) == 1:
@@ -4090,7 +4118,14 @@ def test_model_download_progress_asks_again_after_a_transient_listing_error(monk
 def test_model_download_progress_keeps_its_own_reading_when_a_base_read_fails(monkeypatch):
     adapter_bytes = iter([4 * 1024**2, 9 * 1024**2])
 
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/active-downloads"):
             return _load_listing("owner/base")
         if url.endswith("repo_id=owner%2Fbase"):
@@ -4109,7 +4144,14 @@ def test_model_download_progress_keeps_its_own_reading_when_a_base_read_fails(mo
 
 
 def test_model_download_progress_keeps_an_unknown_total_unknown(monkeypatch, capsys):
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/active-downloads"):
             return _load_listing("owner/base")
         if url.endswith("repo_id=owner%2Fadapter"):
@@ -4133,7 +4175,14 @@ def test_model_download_progress_keeps_an_unknown_total_unknown(monkeypatch, cap
 
 
 def test_model_download_progress_does_not_invent_a_total_across_repos(monkeypatch, capsys):
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/active-downloads"):
             return _load_listing("owner/base", "unsloth/base-unsloth-bnb-4bit")
         if url.endswith("repo_id=owner%2Fbase"):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4239,7 +4239,14 @@ def test_model_download_progress_keeps_polling_a_repo_the_list_dropped(monkeypat
     listings = iter([_load_listing("owner/base"), {"downloads": []}])
     base_bytes = iter([1024**3, 2 * 1024**3])
 
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/active-downloads"):
             return next(listings)
         if url.endswith("repo_id=owner%2Fbase"):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4235,6 +4235,26 @@ def test_model_download_progress_counts_a_hub_download_the_load_attached_to(monk
     assert progress.downloaded_bytes == 1024 + 3 * 1024**3
 
 
+def test_model_download_progress_keeps_polling_a_repo_the_list_dropped(monkeypatch):
+    listings = iter([_load_listing("owner/base"), {"downloads": []}])
+    base_bytes = iter([1024**3, 2 * 1024**3])
+
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/active-downloads"):
+            return next(listings)
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {"downloaded_bytes": next(base_bytes), "expected_bytes": 4 * 1024**3}
+        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    progress.poll()
+
+    assert progress.downloaded_bytes == 1024 + 2 * 1024**3
+
+
 def test_model_download_progress_polls_a_namespace_less_base_the_load_reports(monkeypatch):
     reads = []
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4322,12 +4322,29 @@ def test_model_download_progress_completes_the_transfer_it_last_showed(monkeypat
     monkeypatch.setattr(start.sys.stdout, "isatty", lambda: False, raising = False)
     base_readings = iter(
         [
-            {"downloaded_bytes": 2 * 1024**3, "completed_bytes": 0, "expected_bytes": 4 * 1024**3, "progress": 0.5},
-            {"downloaded_bytes": 4 * 1024**3, "completed_bytes": 4 * 1024**3, "expected_bytes": 4 * 1024**3, "progress": 0.99},
+            {
+                "downloaded_bytes": 2 * 1024**3,
+                "completed_bytes": 0,
+                "expected_bytes": 4 * 1024**3,
+                "progress": 0.5,
+            },
+            {
+                "downloaded_bytes": 4 * 1024**3,
+                "completed_bytes": 4 * 1024**3,
+                "expected_bytes": 4 * 1024**3,
+                "progress": 0.99,
+            },
         ]
     )
 
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/active-downloads"):
             return _load_listing("owner/base")
         if url.endswith("repo_id=owner%2Fbase"):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4210,6 +4210,41 @@ def test_model_download_progress_does_not_invent_a_total_across_repos(monkeypatc
     assert progress.downloaded_bytes == 18 * 1024**3
 
 
+def test_model_download_progress_counts_a_hub_download_the_load_attached_to(monkeypatch):
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/active-downloads"):
+            return {"downloads": [{"repo_id": "owner/base", "load_attached": True, "state": "running"}]}
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 4 * 1024**3}
+        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+
+    assert progress.downloaded_bytes == 1024 + 3 * 1024**3
+
+
+def test_download_progress_display_forgets_the_last_repos_total(monkeypatch, capsys):
+    monkeypatch.setattr(start.sys.stdout, "isatty", lambda: False, raising = False)
+    display = start._DownloadProgressDisplay()
+
+    display.update(
+        {"downloaded_bytes": 1024**3, "completed_bytes": 0, "expected_bytes": 60 * 1024**3, "progress": 0.02},
+        "owner/base",
+    )
+    display.update(
+        {"downloaded_bytes": 6 * 1024**3, "completed_bytes": 0, "expected_bytes": 6 * 1024**3, "progress": 0.99},
+        "unsloth/base-bnb-4bit",
+    )
+    display.complete()
+
+    out = capsys.readouterr().out
+    assert "100% 6.0 GiB / 6.0 GiB" in out
+    assert "60.0 GiB" not in out.splitlines()[-1]
+
+
 def test_active_reading_follows_the_repo_with_bytes_in_flight():
     model = ("owner/adapter", {"downloaded_bytes": 1024, "completed_bytes": 1024})
     cached_base = (

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4211,9 +4211,18 @@ def test_model_download_progress_does_not_invent_a_total_across_repos(monkeypatc
 
 
 def test_model_download_progress_counts_a_hub_download_the_load_attached_to(monkeypatch):
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/active-downloads"):
-            return {"downloads": [{"repo_id": "owner/base", "load_attached": True, "state": "running"}]}
+            return {
+                "downloads": [{"repo_id": "owner/base", "load_attached": True, "state": "running"}]
+            }
         if url.endswith("repo_id=owner%2Fbase"):
             return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 4 * 1024**3}
         return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
@@ -4231,11 +4240,21 @@ def test_download_progress_display_forgets_the_last_repos_total(monkeypatch, cap
     display = start._DownloadProgressDisplay()
 
     display.update(
-        {"downloaded_bytes": 1024**3, "completed_bytes": 0, "expected_bytes": 60 * 1024**3, "progress": 0.02},
+        {
+            "downloaded_bytes": 1024**3,
+            "completed_bytes": 0,
+            "expected_bytes": 60 * 1024**3,
+            "progress": 0.02,
+        },
         "owner/base",
     )
     display.update(
-        {"downloaded_bytes": 6 * 1024**3, "completed_bytes": 0, "expected_bytes": 6 * 1024**3, "progress": 0.99},
+        {
+            "downloaded_bytes": 6 * 1024**3,
+            "completed_bytes": 0,
+            "expected_bytes": 6 * 1024**3,
+            "progress": 0.99,
+        },
         "unsloth/base-bnb-4bit",
     )
     display.complete()

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -3982,21 +3982,18 @@ def test_start_studio_server_polls_progress_from_early_key(monkeypatch):
     assert not any(isinstance(event, tuple) and "server ready" in event[-1] for event in created)
 
 
-def test_model_download_progress_counts_a_lora_base_model(monkeypatch, capsys):
+def _load_listing(*repos):
+    return {"downloads": [{"repo_id": repo, "owner": "load", "state": "running"} for repo in repos]}
+
+
+def test_model_download_progress_counts_a_base_the_load_reports(monkeypatch, capsys):
     calls = []
     base_bytes = iter([1024**3, 2 * 1024**3])
 
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
         calls.append(url)
-        if url == f"{BASE}/api/models/config/owner/adapter":
-            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("/api/hub/active-downloads"):
+            return _load_listing("owner/adapter", "owner/base")
         if url.endswith("download-progress?repo_id=owner%2Fadapter"):
             return {
                 "downloaded_bytes": 8 * 1024**2,
@@ -4005,7 +4002,13 @@ def test_model_download_progress_counts_a_lora_base_model(monkeypatch, capsys):
                 "progress": 1.0,
             }
         if url.endswith("download-progress?repo_id=owner%2Fbase"):
-            return {"downloaded_bytes": next(base_bytes), "expected_bytes": 4 * 1024**3}
+            downloaded = next(base_bytes)
+            return {
+                "downloaded_bytes": downloaded,
+                "completed_bytes": 0,
+                "expected_bytes": 4 * 1024**3,
+                "progress": downloaded / (4 * 1024**3),
+            }
         raise AssertionError(f"unexpected request: {method} {url}")
 
     monkeypatch.setattr(start, "_http_json", http_json)
@@ -4015,28 +4018,61 @@ def test_model_download_progress_counts_a_lora_base_model(monkeypatch, capsys):
     progress.poll()
 
     assert progress.downloaded_bytes == 8 * 1024**2 + 2 * 1024**3
-    assert calls.count(f"{BASE}/api/models/config/owner/adapter") == 1
-    assert "1.0 GiB / 4.0 GiB" in capsys.readouterr().out
+    assert calls.count(f"{BASE}/api/hub/active-downloads") == 2
+    assert "2.0 GiB / 4.0 GiB" in capsys.readouterr().out
 
 
-def test_model_download_progress_retries_base_model_resolution(monkeypatch):
-    now = [1000.0]
-    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
-    lookups = []
+def test_model_download_progress_ignores_downloads_the_load_does_not_own(monkeypatch):
+    reads = []
 
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            lookups.append(url)
-            if len(lookups) == 1:
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/api/hub/active-downloads"):
+            return {
+                "downloads": [
+                    {"repo_id": "someone/else", "state": "running"},
+                    {"repo_id": "OWNER/ADAPTER", "owner": "load", "state": "running"},
+                ]
+            }
+        reads.append(url)
+        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+
+    assert progress.downloaded_bytes == 1024
+    assert reads == [f"{BASE}/api/hub/download-progress?repo_id=owner%2Fadapter"]
+
+
+def test_model_download_progress_stops_listing_on_a_server_without_the_route(monkeypatch):
+    listings = []
+
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/active-downloads"):
+            listings.append(url)
+            raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
+        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    progress.poll()
+
+    assert len(listings) == 1
+    assert progress.downloaded_bytes == 1024
+
+
+def test_model_download_progress_asks_again_after_a_transient_listing_error(monkeypatch):
+    listings = []
+
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/active-downloads"):
+            listings.append(url)
+            if len(listings) == 1:
                 raise urllib.error.URLError("busy")
-            return {"is_lora": True, "base_model": "owner/base"}
+            return _load_listing("owner/base")
         if url.endswith("repo_id=owner%2Fbase"):
             return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 4 * 1024**3}
         return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
@@ -4046,54 +4082,18 @@ def test_model_download_progress_retries_base_model_resolution(monkeypatch):
 
     progress.poll()
     assert progress.downloaded_bytes == 1024
-    now[0] += start._COMPANION_LOOKUP_RETRY_S
     progress.poll()
     assert progress.downloaded_bytes == 1024 + 3 * 1024**3
-    assert len(lookups) == 2
-
-
-def test_model_download_progress_asks_for_a_base_model_once_when_the_answer_is_final(monkeypatch):
-    lookups = []
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            lookups.append(url)
-            raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
-        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
-
-    progress.poll()
-    progress.poll()
-
-    assert progress.downloaded_bytes == 1024
-    assert len(lookups) == 1
+    assert len(listings) == 2
 
 
 def test_model_download_progress_keeps_its_own_reading_when_a_base_read_fails(monkeypatch):
     adapter_bytes = iter([4 * 1024**2, 9 * 1024**2])
 
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "owner/base"}
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/active-downloads"):
+            return _load_listing("owner/base")
         if url.endswith("repo_id=owner%2Fbase"):
-            # The base repo's cache walk is the big one, so its request is the one that
-            # times out; that must not discard the adapter's own reading.
             raise TimeoutError("the server took too long to answer")
         return {"downloaded_bytes": next(adapter_bytes), "expected_bytes": 40 * 1024**2}
 
@@ -4108,402 +4108,10 @@ def test_model_download_progress_keeps_its_own_reading_when_a_base_read_fails(mo
     assert progress._failures == 0
 
 
-def test_model_download_progress_counts_the_quantized_base_the_loader_substitutes(
-    monkeypatch, capsys
-):
-    monkeypatch.setattr(
-        start,
-        "_QUANT_MAPPERS",
-        [{"meta-llama/Llama-3.1-8B": "unsloth/Llama-3.1-8B-bnb-4bit"}],
-    )
-    polled = []
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "meta-llama/Llama-3.1-8B"}
-        polled.append(url)
-        # The loader downloads the mapped repo, so the recorded base never moves.
-        if url.endswith("repo_id=unsloth%2FLlama-3.1-8B-bnb-4bit"):
-            return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 4 * 1024**3}
-        return {"downloaded_bytes": 0, "expected_bytes": 0}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
-
-    progress.poll()
-
-    assert progress.downloaded_bytes == 3 * 1024**3
-    assert any("repo_id=meta-llama%2FLlama-3.1-8B" in url for url in polled)
-    assert any("repo_id=unsloth%2FLlama-3.1-8B-bnb-4bit" in url for url in polled)
-
-
-def test_model_download_progress_counts_a_sixteen_bit_substitute(monkeypatch):
-    # A plain (non-QLoRA) adapter makes the worker resolve load_in_4bit=False, and the
-    # loader then swaps the base for its 16-bit Unsloth build instead of a 4-bit one.
-    monkeypatch.setattr(
-        start,
-        "_QUANT_MAPPERS",
-        [
-            {"Qwen/Qwen3-32B": "unsloth/Qwen3-32B-unsloth-bnb-4bit"},
-            {"Qwen/Qwen3-32B": "unsloth/Qwen3-32B"},
-        ],
-    )
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "Qwen/Qwen3-32B"}
-        if url.endswith("repo_id=unsloth%2FQwen3-32B"):
-            return {"downloaded_bytes": 6 * 1024**3, "expected_bytes": 60 * 1024**3}
-        return {"downloaded_bytes": 0, "expected_bytes": 0}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
-
-    progress.poll()
-
-    assert progress.downloaded_bytes == 6 * 1024**3
-
-
-def test_base_model_candidates_cover_every_table_the_loader_consults():
-    candidates = start._base_model_candidates("meta-llama/Llama-3.1-8B-Instruct")
-
-    assert candidates[0] == "meta-llama/Llama-3.1-8B-Instruct"
-    # Both precisions, because the CLI cannot see which one the worker settles on.
-    assert "unsloth/Llama-3.1-8B-Instruct" in candidates
-    assert "unsloth/Llama-3.1-8B-Instruct-unsloth-bnb-4bit" in candidates
-    assert len(candidates) == len(set(candidates))
-
-
-def test_base_model_candidates_cover_the_case_the_loader_returns():
-    # `__get_model_name` looks the base up by its lower-cased name, so the repo it returns
-    # can be spelled differently from the entry reached by the recorded name. Verified
-    # against a real load: `Qwen/Qwen2.5-0.5B-Instruct` fetches this exact repo id.
-    candidates = start._base_model_candidates("Qwen/Qwen2.5-0.5B-Instruct")
-
-    assert "unsloth/qwen2.5-0.5b-instruct-unsloth-bnb-4bit" in candidates
-
-
-def test_base_model_candidates_survive_unsloth_not_being_installed(monkeypatch):
-    # The CLI can drive a remote server on a machine with no unsloth package; without the
-    # tables the recorded base is still the best guess, and nothing may raise.
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", None)
-    monkeypatch.setattr(start, "_BAD_MAPPINGS", None)
-    monkeypatch.setattr(
-        start.importlib.util, "find_spec", lambda name: None if name == "unsloth" else None
-    )
-
-    assert start._base_model_candidates("owner/base") == ["owner/base"]
-
-
-def test_base_model_candidates_keep_every_installs_bad_mapping(monkeypatch):
-    # Two installs can disagree on the same key; collapsing them to the first would leave
-    # the worker downloading a repo the CLI never polls.
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "owner/mapped"}])
-    monkeypatch.setattr(
-        start,
-        "_BAD_MAPPINGS",
-        [{"owner/mapped": "owner/parent-target"}, {"owner/mapped": "owner/venv-target"}],
-    )
-
-    candidates = start._base_model_candidates("owner/base")
-
-    assert "owner/parent-target" in candidates
-    assert "owner/venv-target" in candidates
-
-
-def test_base_model_candidates_follow_the_loaders_second_rewrite():
-    # get_model_name maps Qwen/Qwen3-32B to unsloth/Qwen3-32B-unsloth-bnb-4bit and then
-    # rewrites that through BAD_MAPPINGS, so the repo that downloads is two steps out.
-    candidates = start._base_model_candidates("Qwen/Qwen3-32B")
-
-    assert "unsloth/qwen3-32b-bnb-4bit" in candidates
-
-
-def test_bad_mappings_are_read_without_importing_the_loader():
-    torch_before = "torch" in sys.modules
-    monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr(start, "_BAD_MAPPINGS", None)
-    try:
-        tables = start._unsloth_bad_mappings()
-    finally:
-        monkeypatch.undo()
-
-    assert tables and all(isinstance(t, dict) and t for t in tables)
-    pairs = [(k, v) for t in tables for k, v in t.items()]
-    assert all(isinstance(k, str) and isinstance(v, str) for k, v in pairs)
-    # The source spells these as "...".lower(), which only evaluating the literal resolves.
-    assert all(key == key.lower() for key, _ in pairs)
-    assert ("torch" in sys.modules) == torch_before
-
-
-def test_base_model_candidates_include_the_loaders_suffix_strip():
-    # Where ALLOW_PREQUANTIZED_MODELS is false the loader strips the 4-bit suffix after
-    # mapping, so the fetched repo is a third step out from the recorded base. This base
-    # reaches unsloth/codellama-34b-bnb-4bit through the tables and the stripped repo
-    # through nothing else, so it isolates that rewrite.
-    candidates = start._base_model_candidates("codellama/CodeLlama-34b-hf")
-
-    assert "unsloth/codellama-34b-bnb-4bit" in candidates
-    assert "unsloth/codellama-34b" in candidates
-
-
-def test_base_model_candidates_strip_the_recorded_base_itself():
-    # The strip runs after mapping, and an unmapped base passes mapping unchanged, so the
-    # recorded name is a subject of it too.
-    assert start._base_model_candidates("owner/custom-bnb-4bit") == [
-        "owner/custom-bnb-4bit",
-        "owner/custom",
-    ]
-
-
-def test_unsloth_package_dirs_ask_the_venv_for_an_editable_install(monkeypatch, tmp_path):
-    # `unsloth studio update --local` installs with -e, leaving a PEP 660 finder and no
-    # site-packages/unsloth directory, so the globs find nothing and the venv is asked.
-    editable = tmp_path / "src" / "unsloth"
-    editable.mkdir(parents = True)
-    fake_python = tmp_path / "unsloth_studio" / "bin" / "python"
-    fake_python.parent.mkdir(parents = True)
-    fake_python.touch()
-    import unsloth_cli.commands.studio as studio_mod
-
-    monkeypatch.setattr(studio_mod, "STUDIO_HOME", tmp_path, raising = False)
-    monkeypatch.setattr(studio_mod, "_studio_venv_python", lambda: fake_python, raising = False)
-
-    class _Result:
-        stdout = f"{editable}\n"
-
-    monkeypatch.setattr(start.subprocess, "run", lambda *a, **k: _Result())
-
-    assert editable in start._unsloth_package_dirs()
-
-
-def test_unsloth_package_dirs_include_the_studio_venv(monkeypatch, tmp_path):
-    # The worker may run in the managed Studio venv, whose Unsloth can differ from the one
-    # this CLI was launched from, so both sets of tables have to be read.
-    venv_pkg = tmp_path / "unsloth_studio" / "lib" / "python3.11" / "site-packages" / "unsloth"
-    venv_pkg.mkdir(parents = True)
-    import unsloth_cli.commands.studio as studio_mod
-
-    monkeypatch.setattr(studio_mod, "STUDIO_HOME", tmp_path, raising = False)
-
-    assert venv_pkg in start._unsloth_package_dirs()
-
-
-def test_base_model_candidates_leave_out_repos_the_load_path_cannot_pick():
-    # Nothing in the inference path passes load_in_fp8, so an fp8 repo is never the
-    # download and polling it would only cost the downloading server a request per poll.
-    candidates = start._base_model_candidates("meta-llama/Llama-3.1-8B-Instruct")
-
-    assert not [repo for repo in candidates if "fp8" in repo.lower()]
-
-
-def test_quant_mappers_never_execute_the_discovered_file(monkeypatch, tmp_path):
-    # `unsloth start` opens a coding agent on a repository that is not necessarily trusted,
-    # and mapper.py is found on sys.path, which can include that repository. The file is
-    # read for its data; running it would hand it the user's privileges.
-    planted = tmp_path / "unsloth" / "models"
-    planted.mkdir(parents = True)
-    sentinel = tmp_path / "executed"
-    (planted / "mapper.py").write_text(
-        "import pathlib\n"
-        f"pathlib.Path({str(sentinel)!r}).write_text('x')\n"
-        '__INT_TO_FLOAT_MAPPER = {"owner/model-bnb-4bit": ("owner/model",)}\n'
-    )
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", None)
-    monkeypatch.setattr(start, "_unsloth_package_dirs", lambda: [tmp_path / "unsloth"])
-
-    tables = start._unsloth_quant_mappers()
-
-    assert not sentinel.exists()
-    # The data still came through.
-    assert "owner/model" in tables[0]["owner/model-bnb-4bit"]
-
-
-def test_quant_mappers_load_without_importing_unsloth():
-    # Only whether THIS call pulls torch in: another test in the session may have already
-    # imported it, and that is not this function's doing.
-    torch_before = "torch" in sys.modules
-    monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", None)
-    try:
-        tables = start._unsloth_quant_mappers()
-    finally:
-        monkeypatch.undo()
-
-    assert tables and all(isinstance(table, dict) for table in tables)
-    assert ("torch" in sys.modules) == torch_before
-
-
-def test_model_download_progress_watches_a_gguf_named_adapters_base(monkeypatch):
-    # "gguf" in the repo id does not make a repo a GGUF quant; the adapter still has a base.
-    polled = []
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "gguf-variants" in url:
-            return {"default_variant": "", "variants": []}
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "owner/base"}
-        polled.append(url)
-        if url.endswith("repo_id=owner%2Fbase"):
-            return {"downloaded_bytes": 5 * 1024**3, "expected_bytes": 8 * 1024**3}
-        return {"downloaded_bytes": 0, "expected_bytes": 0}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model-gguf-lora", None)
-
-    progress.poll()
-
-    assert progress.downloaded_bytes == 5 * 1024**3
-    assert any("repo_id=owner%2Fbase" in url for url in polled)
-
-
-def test_model_download_progress_reasks_after_an_inconclusive_adapter_answer(monkeypatch):
-    now = [1000.0]
-    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
-    answers = [
-        # A failed adapter_config.json inspection is served as a plain 200 is_lora=False.
-        {"is_lora": False},
-        {"is_lora": True, "base_model": "owner/base"},
-    ]
-    lookups = []
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            lookups.append(url)
-            return answers[min(len(lookups) - 1, len(answers) - 1)]
-        if url.endswith("repo_id=owner%2Fbase"):
-            return {"downloaded_bytes": 2 * 1024**3, "expected_bytes": 4 * 1024**3}
-        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
-
-    progress.poll()
-    assert progress.downloaded_bytes == 1024
-    assert len(lookups) == 1
-
-    # Inside the retry window the costly endpoint is left alone.
-    now[0] += 1.0
-    progress.poll()
-    assert len(lookups) == 1
-
-    now[0] += start._COMPANION_LOOKUP_RETRY_S
-    progress.poll()
-    assert len(lookups) == 2
-    assert progress.downloaded_bytes == 1024 + 2 * 1024**3
-
-
-def test_model_download_progress_survives_a_very_long_inconclusive_run(monkeypatch):
-    # The backoff is carried, not recomputed as 2 ** n: past ~1024 inconclusive lookups the
-    # power overflowed, and because the lookup runs before the model's own read, every
-    # later poll died there and the tracked bytes stopped moving.
-    now = [1000.0]
-    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
-    lookups = []
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            lookups.append(url)
-            return {"is_lora": False}
-        return {
-            "downloaded_bytes": 1024 * len(lookups),
-            "expected_bytes": 10 * 1024**3,
-            "cache_measured": True,
-        }
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
-
-    for _ in range(1100):
-        progress.poll()
-        now[0] += start._COMPANION_LOOKUP_MAX_RETRY_S
-
-    assert len(lookups) > 1024
-    assert progress._failures == 0
-    assert progress.downloaded_bytes == 1024 * len(lookups)
-
-
-def test_model_download_progress_keeps_reasking_an_inconclusive_answer(monkeypatch):
-    now = [1000.0]
-    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
-    asked_at = []
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            asked_at.append(now[0])
-            return {"is_lora": False}
-        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
-
-    for _ in range(4000):
-        progress.poll()
-        now[0] += 1.0
-
-    # It never stops: a config route that is slow or rate-limited for a few minutes must
-    # not cost the whole startup, since the worker may still be fetching a base.
-    assert len(asked_at) > 5
-    gaps = [b - a for a, b in zip(asked_at, asked_at[1:])]
-    # ... but the wait widens to a ceiling instead of costing a request per poll.
-    assert gaps[0] == start._COMPANION_LOOKUP_RETRY_S
-    assert gaps[1] > gaps[0]
-    assert max(gaps) == start._COMPANION_LOOKUP_MAX_RETRY_S
-
-
 def test_model_download_progress_keeps_an_unknown_total_unknown(monkeypatch, capsys):
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "owner/base"}
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/active-downloads"):
+            return _load_listing("owner/base")
         if url.endswith("repo_id=owner%2Fadapter"):
             return {
                 "downloaded_bytes": 20 * 1024**2,
@@ -4511,7 +4119,6 @@ def test_model_download_progress_keeps_an_unknown_total_unknown(monkeypatch, cap
                 "expected_bytes": 20 * 1024**2,
                 "progress": 1.0,
             }
-        # The base's total is not resolvable yet: unknown, not zero.
         return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 0}
 
     monkeypatch.setattr(start, "_http_json", http_json)
@@ -4523,6 +4130,35 @@ def test_model_download_progress_keeps_an_unknown_total_unknown(monkeypatch, cap
     assert progress.downloaded_bytes == 20 * 1024**2 + 3 * 1024**3
     assert "100%" not in out
     assert "3.0 GiB" in out
+
+
+def test_model_download_progress_does_not_invent_a_total_across_repos(monkeypatch, capsys):
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/active-downloads"):
+            return _load_listing("owner/base", "unsloth/base-unsloth-bnb-4bit")
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {
+                "downloaded_bytes": 16 * 1024**3,
+                "completed_bytes": 16 * 1024**3,
+                "expected_bytes": 16 * 1024**3,
+            }
+        if url.endswith("repo_id=unsloth%2Fbase-unsloth-bnb-4bit"):
+            return {
+                "downloaded_bytes": 2 * 1024**3,
+                "completed_bytes": 0,
+                "expected_bytes": 6 * 1024**3,
+            }
+        return {"downloaded_bytes": 0, "completed_bytes": 0, "expected_bytes": 0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+
+    out = capsys.readouterr().out
+    assert "2.0 GiB / 6.0 GiB" in out
+    assert "22.0 GiB" not in out
+    assert progress.downloaded_bytes == 18 * 1024**3
 
 
 def test_active_reading_follows_the_repo_with_bytes_in_flight():
@@ -4538,50 +4174,6 @@ def test_active_reading_follows_the_repo_with_bytes_in_flight():
     assert start._active_reading([model, cached_base, transferring]) is transferring
     # Nothing moving: fall back to the model's own reading rather than a stale companion.
     assert start._active_reading([model, cached_base]) is model
-
-
-def test_model_download_progress_keeps_a_dropped_candidates_bytes(monkeypatch):
-    # The recorded base sits complete in the cache and is dropped once the substitute
-    # starts moving; its bytes must stay in the total or the high-water mark it set would
-    # never be beaten again and the deadline would never renew.
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
-    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
-    substitute = iter([2 * 1024**3, 3 * 1024**3, 4 * 1024**3])
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "owner/base"}
-        if url.endswith("repo_id=owner%2Fbase"):
-            return {
-                "downloaded_bytes": 16 * 1024**3,
-                "completed_bytes": 16 * 1024**3,
-                "expected_bytes": 16 * 1024**3,
-            }
-        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
-            return {
-                "downloaded_bytes": next(substitute),
-                "completed_bytes": 0,
-                "expected_bytes": 6 * 1024**3,
-            }
-        return {"downloaded_bytes": 0, "completed_bytes": 0, "expected_bytes": 0}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
-
-    progress.poll()
-    first = progress.downloaded_bytes
-    progress.poll()
-    second = progress.downloaded_bytes
-
-    assert first == 18 * 1024**3
-    assert second == 19 * 1024**3
 
 
 def test_download_progress_display_restarts_when_the_repo_changes(monkeypatch, capsys):
@@ -4608,190 +4200,6 @@ def test_download_progress_display_restarts_when_the_repo_changes(monkeypatch, c
     assert "1.0 GiB / 40.0 GiB" in out
 
 
-def test_model_download_progress_does_not_invent_a_total_across_repos(monkeypatch, capsys):
-    # The recorded base sits complete in the cache while the substitute downloads; summing
-    # the two totals would render a denominator nobody is fetching.
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-unsloth-bnb-4bit"}])
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "owner/base"}
-        if url.endswith("repo_id=owner%2Fbase"):
-            return {
-                "downloaded_bytes": 16 * 1024**3,
-                "completed_bytes": 16 * 1024**3,
-                "expected_bytes": 16 * 1024**3,
-            }
-        if url.endswith("repo_id=unsloth%2Fbase-unsloth-bnb-4bit"):
-            return {
-                "downloaded_bytes": 2 * 1024**3,
-                "completed_bytes": 0,
-                "expected_bytes": 6 * 1024**3,
-            }
-        return {"downloaded_bytes": 0, "completed_bytes": 0, "expected_bytes": 0}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
-
-    progress.poll()
-
-    out = capsys.readouterr().out
-    assert "2.0 GiB / 6.0 GiB" in out
-    assert "22.0 GiB" not in out
-    assert progress.downloaded_bytes == 18 * 1024**3
-
-
-def test_model_download_progress_keeps_polling_every_base_candidate(monkeypatch):
-    # No narrowing to the candidate that looks live: bytes present are not bytes moving,
-    # and every wrong guess costs the user their server. A candidate that is not being
-    # fetched answers with a measured zero, which is cheap and always right.
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
-    monkeypatch.setattr(start, "_BAD_MAPPINGS", [])
-    polled = []
-    substitute = iter([1024**3, 2 * 1024**3, 3 * 1024**3, 4 * 1024**3])
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "owner/base"}
-        polled.append(url)
-        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
-            return {
-                "downloaded_bytes": next(substitute),
-                "completed_bytes": 0,
-                "expected_bytes": 6 * 1024**3,
-                "cache_measured": True,
-            }
-        return {
-            "downloaded_bytes": 0,
-            "completed_bytes": 0,
-            "expected_bytes": 0,
-            "cache_measured": True,
-        }
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
-
-    for _ in range(3):
-        progress.poll()
-
-    # The quiet candidate is still asked about on every poll, even though the other one
-    # has been growing the whole time.
-    assert len([url for url in polled if "repo_id=owner%2Fbase" in url]) == 3
-    assert progress.downloaded_bytes == 3 * 1024**3
-
-
-def test_companion_lookup_retries_an_offline_404(monkeypatch):
-    # routes/models.py raises 404 when it judges the hub unreachable and the caller
-    # anonymous, so a 404 is not proof that the model has no base.
-    now = [1000.0]
-    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
-    lookups = []
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            lookups.append(url)
-            if len(lookups) == 1:
-                raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
-            return {"is_lora": True, "base_model": "owner/base"}
-        if url.endswith("repo_id=owner%2Fbase"):
-            return {"downloaded_bytes": 5 * 1024**3, "expected_bytes": 8 * 1024**3}
-        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
-
-    progress.poll()
-    assert progress.downloaded_bytes == 1024
-    now[0] += start._COMPANION_LOOKUP_RETRY_S
-    progress.poll()
-
-    assert len(lookups) == 2
-    assert progress.downloaded_bytes == 1024 + 5 * 1024**3
-
-
-def test_companion_lookup_gives_up_on_a_server_without_the_route(monkeypatch):
-    # The router's bare "Not Found" means the path is not registered, so retrying it for
-    # the length of a download achieves nothing.
-    now = [1000.0]
-    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
-    lookups = []
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            lookups.append(url)
-            raise urllib.error.HTTPError(
-                url, 404, "Not Found", None, io.BytesIO(b'{"detail":"Not Found"}')
-            )
-        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
-
-    for _ in range(4):
-        progress.poll()
-        now[0] += start._COMPANION_LOOKUP_MAX_RETRY_S
-
-    assert len(lookups) == 1
-
-
-def test_companion_lookup_retries_the_routes_own_404(monkeypatch):
-    # The handler's own 404 carries its reason, and means try again later.
-    now = [1000.0]
-    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
-    lookups = []
-    body = b'{"detail":"This request cannot be authorized without network access."}'
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            lookups.append(url)
-            raise urllib.error.HTTPError(url, 404, "Not Found", None, io.BytesIO(body))
-        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
-
-    for _ in range(4):
-        progress.poll()
-        now[0] += start._COMPANION_LOOKUP_MAX_RETRY_S
-
-    assert len(lookups) == 4
-
-
 def test_active_reading_prefers_a_repo_that_moved_over_a_bigger_partial():
     corpse = ("unsloth/base-4bit", {"downloaded_bytes": 9 * 1024**3, "completed_bytes": 0})
     live = ("owner/base", {"downloaded_bytes": 2 * 1024**3, "completed_bytes": 0})
@@ -4801,74 +4209,6 @@ def test_active_reading_prefers_a_repo_that_moved_over_a_bigger_partial():
     assert start._active_reading([model, corpse, live]) is corpse
     # Once the live repo is seen to move it wins, however large the abandoned blob is.
     assert start._active_reading([model, corpse, live], frozenset({"owner/base"})) is live
-
-
-def test_companion_lookup_stops_on_a_refused_request(monkeypatch):
-    lookups = []
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            lookups.append(url)
-            raise urllib.error.HTTPError(url, 403, "Forbidden", None, None)
-        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
-
-    progress.poll()
-    progress.poll()
-
-    assert len(lookups) == 1
-
-
-def test_model_download_progress_does_not_prune_to_an_abandoned_partial(monkeypatch):
-    # A cancelled download leaves .incomplete blobs behind. Those bytes are present but
-    # never grow, and pruning to them would drop the repo the worker actually fetches.
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
-    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
-    real = iter([0, 0, 1024**3, 2 * 1024**3])
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "owner/base"}
-        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
-            # The corpse: bytes in flight from the first poll, never moving.
-            return {
-                "downloaded_bytes": 5 * 1024**2,
-                "completed_bytes": 0,
-                "expected_bytes": 6 * 1024**3,
-            }
-        if url.endswith("repo_id=owner%2Fbase"):
-            return {
-                "downloaded_bytes": next(real),
-                "completed_bytes": 0,
-                "expected_bytes": 40 * 1024**3,
-            }
-        return {"downloaded_bytes": 0, "completed_bytes": 0, "expected_bytes": 0}
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
-
-    for _ in range(4):
-        progress.poll()
-
-    # The repo that really downloaded is still watched, and its bytes are counted.
-    assert progress.downloaded_bytes == 2 * 1024**3 + 5 * 1024**2
-    assert "owner/base" in (progress._companions or [])
 
 
 def test_load_model_with_progress_uses_selected_gguf_size(monkeypatch, capsys):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4318,6 +4318,39 @@ def test_download_progress_display_forgets_the_last_repos_total(monkeypatch, cap
     assert "60.0 GiB" not in out.splitlines()[-1]
 
 
+def test_model_download_progress_completes_the_transfer_it_last_showed(monkeypatch, capsys):
+    monkeypatch.setattr(start.sys.stdout, "isatty", lambda: False, raising = False)
+    base_readings = iter(
+        [
+            {"downloaded_bytes": 2 * 1024**3, "completed_bytes": 0, "expected_bytes": 4 * 1024**3, "progress": 0.5},
+            {"downloaded_bytes": 4 * 1024**3, "completed_bytes": 4 * 1024**3, "expected_bytes": 4 * 1024**3, "progress": 0.99},
+        ]
+    )
+
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/active-downloads"):
+            return _load_listing("owner/base")
+        if url.endswith("repo_id=owner%2Fbase"):
+            return next(base_readings)
+        return {
+            "downloaded_bytes": 8 * 1024**2,
+            "completed_bytes": 8 * 1024**2,
+            "expected_bytes": 8 * 1024**2,
+            "progress": 1.0,
+        }
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    progress.poll()
+    progress.complete()
+
+    out = capsys.readouterr().out
+    assert "100% 4.0 GiB / 4.0 GiB" in out
+    assert "8.0 MiB" not in out
+
+
 def test_active_reading_follows_the_repo_with_bytes_in_flight():
     model = ("owner/adapter", {"downloaded_bytes": 1024, "completed_bytes": 1024})
     cached_base = (

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4238,7 +4238,14 @@ def test_model_download_progress_counts_a_hub_download_the_load_attached_to(monk
 def test_model_download_progress_polls_a_namespace_less_base_the_load_reports(monkeypatch):
     reads = []
 
-    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
         if url.endswith("/active-downloads"):
             return _load_listing("gpt2")
         reads.append(url)

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4235,6 +4235,26 @@ def test_model_download_progress_counts_a_hub_download_the_load_attached_to(monk
     assert progress.downloaded_bytes == 1024 + 3 * 1024**3
 
 
+def test_model_download_progress_polls_a_namespace_less_base_the_load_reports(monkeypatch):
+    reads = []
+
+    def http_json(method, url, token, payload = None, timeout = 30, error = None):
+        if url.endswith("/active-downloads"):
+            return _load_listing("gpt2")
+        reads.append(url)
+        if url.endswith("repo_id=gpt2"):
+            return {"downloaded_bytes": 500 * 1024**2, "expected_bytes": 1024**3}
+        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/gpt2-lora", None)
+
+    progress.poll()
+
+    assert progress.downloaded_bytes == 1024 + 500 * 1024**2
+    assert f"{BASE}/api/hub/download-progress?repo_id=gpt2" in reads
+
+
 def test_download_progress_display_forgets_the_last_repos_total(monkeypatch, capsys):
     monkeypatch.setattr(start.sys.stdout, "isatty", lambda: False, raising = False)
     display = start._DownloadProgressDisplay()

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4626,9 +4626,12 @@ def test_model_download_progress_does_not_invent_a_total_across_repos(monkeypatc
     assert progress.downloaded_bytes == 18 * 1024**3
 
 
-def test_model_download_progress_stops_polling_dead_base_candidates(monkeypatch):
+def test_model_download_progress_keeps_polling_every_base_candidate(monkeypatch):
+    # No narrowing to the candidate that looks live: bytes present are not bytes moving,
+    # and every wrong guess costs the user their server. A candidate that is not being
+    # fetched answers with a measured zero, which is cheap and always right.
     monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
-    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
+    monkeypatch.setattr(start, "_BAD_MAPPINGS", [])
     polled = []
     substitute = iter([1024**3, 2 * 1024**3, 3 * 1024**3, 4 * 1024**3])
 
@@ -4660,70 +4663,18 @@ def test_model_download_progress_stops_polling_dead_base_candidates(monkeypatch)
     monkeypatch.setattr(start, "_http_json", http_json)
     progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
 
-    def dead_polls():
-        return len([url for url in polled if "repo_id=owner%2Fbase" in url])
-
-    progress.poll()
-    # One reading is not growth, so the recorded base is still in play.
-    assert dead_polls() == 1
-    progress.poll()
-    assert dead_polls() == 2
-    progress.poll()
-    # The substitute has now grown twice; the recorded base is dropped.
-    assert dead_polls() == 2
-    assert progress.downloaded_bytes == 3 * 1024**3
-
-
-def test_model_download_progress_does_not_prune_when_a_cache_mount_appears(monkeypatch):
-    # A cached candidate whose mount was missing during one complete scan and present in
-    # the next grows its total by the whole cached size with nothing transferring.
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
-    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
-    mount = iter(
-        [
-            {"downloaded_bytes": 0, "completed_bytes": 0, "cache_measured": True},
-            {
-                "downloaded_bytes": 16 * 1024**3,
-                "completed_bytes": 16 * 1024**3,
-                "cache_measured": True,
-            },
-            {
-                "downloaded_bytes": 16 * 1024**3,
-                "completed_bytes": 16 * 1024**3,
-                "cache_measured": True,
-            },
-        ]
-    )
-
-    def http_json(
-        method,
-        url,
-        token,
-        payload = None,
-        timeout = 30,
-        error = None,
-    ):
-        if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "owner/base"}
-        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
-            return next(mount)
-        return {
-            "downloaded_bytes": 0,
-            "completed_bytes": 0,
-            "expected_bytes": 40 * 1024**3,
-            "cache_measured": True,
-        }
-
-    monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
-
     for _ in range(3):
         progress.poll()
 
-    assert "owner/base" in (progress._companions or [])
+    # The quiet candidate is still asked about on every poll, even though the other one
+    # has been growing the whole time.
+    assert len([url for url in polled if "repo_id=owner%2Fbase" in url]) == 3
+    assert progress.downloaded_bytes == 3 * 1024**3
 
 
-def test_companion_lookup_retries_a_rate_limited_config_route(monkeypatch):
+def test_companion_lookup_retries_an_offline_404(monkeypatch):
+    # routes/models.py raises 404 when it judges the hub unreachable and the caller
+    # anonymous, so a 404 is not proof that the model has no base.
     now = [1000.0]
     monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
     lookups = []
@@ -4739,10 +4690,10 @@ def test_companion_lookup_retries_a_rate_limited_config_route(monkeypatch):
         if "/api/models/config/" in url:
             lookups.append(url)
             if len(lookups) == 1:
-                raise urllib.error.HTTPError(url, 429, "Too Many Requests", None, None)
+                raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
             return {"is_lora": True, "base_model": "owner/base"}
         if url.endswith("repo_id=owner%2Fbase"):
-            return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 4 * 1024**3}
+            return {"downloaded_bytes": 5 * 1024**3, "expected_bytes": 8 * 1024**3}
         return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
 
     monkeypatch.setattr(start, "_http_json", http_json)
@@ -4754,61 +4705,11 @@ def test_companion_lookup_retries_a_rate_limited_config_route(monkeypatch):
     progress.poll()
 
     assert len(lookups) == 2
-    assert progress.downloaded_bytes == 1024 + 3 * 1024**3
+    assert progress.downloaded_bytes == 1024 + 5 * 1024**3
 
 
-def test_download_progress_display_completes_after_following_a_second_repo(monkeypatch, capsys):
-    monkeypatch.setattr(start.sys.stdout, "isatty", lambda: True, raising = False)
-    display = start._DownloadProgressDisplay()
-
-    display.update(
-        {
-            "downloaded_bytes": 2 * 1024**3,
-            "completed_bytes": 0,
-            "expected_bytes": 4 * 1024**3,
-            "progress": 0.5,
-        },
-        "owner/base",
-    )
-    # The base finished, so the line falls back to a fully cached adapter, which renders
-    # nothing. That must not wipe the state complete() and close() gate on.
-    display.update(
-        {"downloaded_bytes": 1024, "completed_bytes": 1024, "expected_bytes": 1024},
-        "owner/adapter",
-    )
-    display.complete()
-    display.close()
-
-    out = capsys.readouterr().out
-    assert "100%" in out
-    assert out.endswith("\n")
-
-
-def test_model_download_progress_does_not_prune_on_a_cache_scan_rebound(monkeypatch):
-    # An unreadable cache root makes the endpoint report a lower bound with
-    # cache_measured false; the larger figure when the root returns is a rebound, not a
-    # transfer, and must not capture the prune.
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
-    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
-    rebound = iter(
-        [
-            {
-                "downloaded_bytes": 2 * 1024**3,
-                "completed_bytes": 2 * 1024**3,
-                "cache_measured": False,
-            },
-            {
-                "downloaded_bytes": 9 * 1024**3,
-                "completed_bytes": 9 * 1024**3,
-                "cache_measured": True,
-            },
-            {
-                "downloaded_bytes": 9 * 1024**3,
-                "completed_bytes": 9 * 1024**3,
-                "cache_measured": True,
-            },
-        ]
-    )
+def test_companion_lookup_stops_on_a_refused_request(monkeypatch):
+    lookups = []
 
     def http_json(
         method,
@@ -4819,25 +4720,17 @@ def test_model_download_progress_does_not_prune_on_a_cache_scan_rebound(monkeypa
         error = None,
     ):
         if "/api/models/config/" in url:
-            return {"is_lora": True, "base_model": "owner/base"}
-        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
-            return next(rebound)
-        return {
-            "downloaded_bytes": 0,
-            "completed_bytes": 0,
-            "expected_bytes": 40 * 1024**3,
-            "cache_measured": True,
-        }
+            lookups.append(url)
+            raise urllib.error.HTTPError(url, 403, "Forbidden", None, None)
+        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
 
     monkeypatch.setattr(start, "_http_json", http_json)
-    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
 
     progress.poll()
     progress.poll()
-    progress.poll()
 
-    # The repo that has not started yet is still watched.
-    assert "owner/base" in (progress._companions or [])
+    assert len(lookups) == 1
 
 
 def test_model_download_progress_does_not_prune_to_an_abandoned_partial(monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4197,6 +4197,18 @@ def test_base_model_candidates_cover_the_case_the_loader_returns():
     assert "unsloth/qwen2.5-0.5b-instruct-unsloth-bnb-4bit" in candidates
 
 
+def test_base_model_candidates_survive_unsloth_not_being_installed(monkeypatch):
+    # The CLI can drive a remote server on a machine with no unsloth package; without the
+    # tables the recorded base is still the best guess, and nothing may raise.
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", None)
+    monkeypatch.setattr(start, "_BAD_MAPPINGS", None)
+    monkeypatch.setattr(
+        start.importlib.util, "find_spec", lambda name: None if name == "unsloth" else None
+    )
+
+    assert start._base_model_candidates("owner/base") == ["owner/base"]
+
+
 def test_base_model_candidates_follow_the_loaders_second_rewrite():
     # get_model_name maps Qwen/Qwen3-32B to unsloth/Qwen3-32B-unsloth-bnb-4bit and then
     # rewrites that through BAD_MAPPINGS, so the repo that downloads is two steps out.

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4197,6 +4197,28 @@ def test_base_model_candidates_cover_the_case_the_loader_returns():
     assert "unsloth/qwen2.5-0.5b-instruct-unsloth-bnb-4bit" in candidates
 
 
+def test_base_model_candidates_follow_the_loaders_second_rewrite():
+    # get_model_name maps Qwen/Qwen3-32B to unsloth/Qwen3-32B-unsloth-bnb-4bit and then
+    # rewrites that through BAD_MAPPINGS, so the repo that downloads is two steps out.
+    candidates = start._base_model_candidates("Qwen/Qwen3-32B")
+
+    assert "unsloth/qwen3-32b-bnb-4bit" in candidates
+
+
+def test_bad_mappings_are_read_without_importing_the_loader():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(start, "_BAD_MAPPINGS", None)
+    try:
+        table = start._unsloth_bad_mappings()
+    finally:
+        monkeypatch.undo()
+
+    assert table and all(isinstance(k, str) and isinstance(v, str) for k, v in table.items())
+    # The source spells these as "...".lower(), which only evaluating the literal resolves.
+    assert all(key == key.lower() for key in table)
+    assert "torch" not in sys.modules
+
+
 def test_base_model_candidates_leave_out_repos_the_load_path_cannot_pick():
     # Nothing in the inference path passes load_in_fp8, so an fp8 repo is never the
     # download and polling it would only cost the downloading server a request per poll.
@@ -4351,27 +4373,86 @@ def test_model_download_progress_keeps_an_unknown_total_unknown(monkeypatch, cap
 
 
 def test_active_reading_follows_the_repo_with_bytes_in_flight():
-    model = {"downloaded_bytes": 1024, "completed_bytes": 1024, "expected_bytes": 1024}
-    cached_base = {
-        "downloaded_bytes": 16 * 1024**3,
-        "completed_bytes": 16 * 1024**3,
-        "expected_bytes": 16 * 1024**3,
-    }
-    transferring = {
-        "downloaded_bytes": 2 * 1024**3,
-        "completed_bytes": 0,
-        "expected_bytes": 6 * 1024**3,
-    }
+    model = ("owner/adapter", {"downloaded_bytes": 1024, "completed_bytes": 1024})
+    cached_base = (
+        "owner/base",
+        {"downloaded_bytes": 16 * 1024**3, "completed_bytes": 16 * 1024**3},
+    )
+    transferring = ("unsloth/base-4bit", {"downloaded_bytes": 2 * 1024**3, "completed_bytes": 0})
 
     # A base already complete in the cache is not the transfer to render, even though it
     # carries by far the most bytes.
     assert start._active_reading([model, cached_base, transferring]) is transferring
     # Nothing moving: fall back to the model's own reading rather than a stale companion.
     assert start._active_reading([model, cached_base]) is model
-    # Liveness still counts every repo.
-    assert start._total_downloaded_bytes([model, cached_base, transferring]) == (
-        1024 + 16 * 1024**3 + 2 * 1024**3
+
+
+def test_model_download_progress_keeps_a_dropped_candidates_bytes(monkeypatch):
+    # The recorded base sits complete in the cache and is dropped once the substitute
+    # starts moving; its bytes must stay in the total or the high-water mark it set would
+    # never be beaten again and the deadline would never renew.
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
+    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
+    substitute = iter([2 * 1024**3, 3 * 1024**3, 4 * 1024**3])
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {
+                "downloaded_bytes": 16 * 1024**3,
+                "completed_bytes": 16 * 1024**3,
+                "expected_bytes": 16 * 1024**3,
+            }
+        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
+            return {
+                "downloaded_bytes": next(substitute),
+                "completed_bytes": 0,
+                "expected_bytes": 6 * 1024**3,
+            }
+        return {"downloaded_bytes": 0, "completed_bytes": 0, "expected_bytes": 0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    first = progress.downloaded_bytes
+    progress.poll()
+    second = progress.downloaded_bytes
+
+    assert first == 18 * 1024**3
+    assert second == 19 * 1024**3
+
+
+def test_download_progress_display_restarts_when_the_repo_changes(monkeypatch, capsys):
+    monkeypatch.setattr(start.sys.stdout, "isatty", lambda: False, raising = False)
+    display = start._DownloadProgressDisplay()
+
+    # An adapter finishing near the top of its bar.
+    display.update(
+        {"downloaded_bytes": 95, "completed_bytes": 0, "expected_bytes": 100, "progress": 0.95},
+        "owner/adapter",
     )
+    # Then a multi-gigabyte base starting from nothing.
+    display.update(
+        {
+            "downloaded_bytes": 1024**3,
+            "completed_bytes": 0,
+            "expected_bytes": 40 * 1024**3,
+            "progress": 0.025,
+        },
+        "owner/base",
+    )
+
+    out = capsys.readouterr().out
+    assert "1.0 GiB / 40.0 GiB" in out
 
 
 def test_model_download_progress_does_not_invent_a_total_across_repos(monkeypatch, capsys):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4112,7 +4112,9 @@ def test_model_download_progress_counts_the_quantized_base_the_loader_substitute
     monkeypatch, capsys
 ):
     monkeypatch.setattr(
-        start, "_QUANT_MAPPER", {"meta-llama/Llama-3.1-8B": "unsloth/Llama-3.1-8B-bnb-4bit"}
+        start,
+        "_QUANT_MAPPERS",
+        [{"meta-llama/Llama-3.1-8B": "unsloth/Llama-3.1-8B-bnb-4bit"}],
     )
     polled = []
 
@@ -4142,17 +4144,90 @@ def test_model_download_progress_counts_the_quantized_base_the_loader_substitute
     assert any("repo_id=unsloth%2FLlama-3.1-8B-bnb-4bit" in url for url in polled)
 
 
-def test_quant_mapper_loads_without_importing_unsloth():
+def test_model_download_progress_counts_a_sixteen_bit_substitute(monkeypatch):
+    # A plain (non-QLoRA) adapter makes the worker resolve load_in_4bit=False, and the
+    # loader then swaps the base for its 16-bit Unsloth build instead of a 4-bit one.
+    monkeypatch.setattr(
+        start,
+        "_QUANT_MAPPERS",
+        [
+            {"Qwen/Qwen3-32B": "unsloth/Qwen3-32B-unsloth-bnb-4bit"},
+            {"Qwen/Qwen3-32B": "unsloth/Qwen3-32B"},
+        ],
+    )
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "Qwen/Qwen3-32B"}
+        if url.endswith("repo_id=unsloth%2FQwen3-32B"):
+            return {"downloaded_bytes": 6 * 1024**3, "expected_bytes": 60 * 1024**3}
+        return {"downloaded_bytes": 0, "expected_bytes": 0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+
+    assert progress.downloaded_bytes == 6 * 1024**3
+
+
+def test_base_model_candidates_cover_every_table_the_loader_consults():
+    candidates = start._base_model_candidates("meta-llama/Llama-3.1-8B-Instruct")
+
+    assert candidates[0] == "meta-llama/Llama-3.1-8B-Instruct"
+    # Both precisions, because the CLI cannot see which one the worker settles on.
+    assert "unsloth/Llama-3.1-8B-Instruct" in candidates
+    assert "unsloth/Llama-3.1-8B-Instruct-unsloth-bnb-4bit" in candidates
+    assert len(candidates) == len(set(candidates))
+
+
+def test_quant_mappers_load_without_importing_unsloth():
     monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr(start, "_QUANT_MAPPER", None)
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", None)
     try:
-        table = start._unsloth_quant_mapper()
+        tables = start._unsloth_quant_mappers()
     finally:
         monkeypatch.undo()
 
-    assert isinstance(table, dict) and table
-    assert all(isinstance(key, str) for key in table)
+    assert tables and all(isinstance(table, dict) for table in tables)
     assert "torch" not in sys.modules
+
+
+def test_model_download_progress_watches_a_gguf_named_adapters_base(monkeypatch):
+    # "gguf" in the repo id does not make a repo a GGUF quant; the adapter still has a base.
+    polled = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "gguf-variants" in url:
+            return {"default_variant": "", "variants": []}
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "owner/base"}
+        polled.append(url)
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {"downloaded_bytes": 5 * 1024**3, "expected_bytes": 8 * 1024**3}
+        return {"downloaded_bytes": 0, "expected_bytes": 0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model-gguf-lora", None)
+
+    progress.poll()
+
+    assert progress.downloaded_bytes == 5 * 1024**3
+    assert any("repo_id=owner%2Fbase" in url for url in polled)
 
 
 def test_model_download_progress_reasks_after_an_inconclusive_adapter_answer(monkeypatch):
@@ -4258,16 +4333,104 @@ def test_model_download_progress_keeps_an_unknown_total_unknown(monkeypatch, cap
     assert "3.0 GiB" in out
 
 
-def test_combined_reading_keeps_a_known_total_when_every_part_is_known():
-    combined = start._combined_reading(
-        [
-            {"downloaded_bytes": 1024, "completed_bytes": 1024, "expected_bytes": 2048},
-            {"downloaded_bytes": 1024, "completed_bytes": 0, "expected_bytes": 2048},
-        ]
+def test_active_reading_follows_the_repo_with_bytes_in_flight():
+    model = {"downloaded_bytes": 1024, "completed_bytes": 1024, "expected_bytes": 1024}
+    cached_base = {
+        "downloaded_bytes": 16 * 1024**3,
+        "completed_bytes": 16 * 1024**3,
+        "expected_bytes": 16 * 1024**3,
+    }
+    transferring = {
+        "downloaded_bytes": 2 * 1024**3,
+        "completed_bytes": 0,
+        "expected_bytes": 6 * 1024**3,
+    }
+
+    # A base already complete in the cache is not the transfer to render, even though it
+    # carries by far the most bytes.
+    assert start._active_reading([model, cached_base, transferring]) is transferring
+    # Nothing moving: fall back to the model's own reading rather than a stale companion.
+    assert start._active_reading([model, cached_base]) is model
+    # Liveness still counts every repo.
+    assert start._total_downloaded_bytes([model, cached_base, transferring]) == (
+        1024 + 16 * 1024**3 + 2 * 1024**3
     )
 
-    assert combined["expected_bytes"] == 4096
-    assert combined["progress"] == 0.5
+
+def test_model_download_progress_does_not_invent_a_total_across_repos(monkeypatch, capsys):
+    # The recorded base sits complete in the cache while the substitute downloads; summing
+    # the two totals would render a denominator nobody is fetching.
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-unsloth-bnb-4bit"}])
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {
+                "downloaded_bytes": 16 * 1024**3,
+                "completed_bytes": 16 * 1024**3,
+                "expected_bytes": 16 * 1024**3,
+            }
+        if url.endswith("repo_id=unsloth%2Fbase-unsloth-bnb-4bit"):
+            return {
+                "downloaded_bytes": 2 * 1024**3,
+                "completed_bytes": 0,
+                "expected_bytes": 6 * 1024**3,
+            }
+        return {"downloaded_bytes": 0, "completed_bytes": 0, "expected_bytes": 0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+
+    out = capsys.readouterr().out
+    assert "2.0 GiB / 6.0 GiB" in out
+    assert "22.0 GiB" not in out
+    assert progress.downloaded_bytes == 18 * 1024**3
+
+
+def test_model_download_progress_stops_polling_dead_base_candidates(monkeypatch):
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-unsloth-bnb-4bit"}])
+    polled = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "owner/base"}
+        polled.append(url)
+        if url.endswith("repo_id=unsloth%2Fbase-unsloth-bnb-4bit"):
+            return {
+                "downloaded_bytes": 2 * 1024**3,
+                "completed_bytes": 0,
+                "expected_bytes": 6 * 1024**3,
+            }
+        return {"downloaded_bytes": 0, "completed_bytes": 0, "expected_bytes": 0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    first = len([url for url in polled if "repo_id=owner%2Fbase" in url])
+    progress.poll()
+    second = len([url for url in polled if "repo_id=owner%2Fbase" in url])
+
+    assert first == 1
+    assert second == 1
+    assert progress.downloaded_bytes == 2 * 1024**3
 
 
 def test_load_model_with_progress_uses_selected_gguf_size(monkeypatch, capsys):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4232,6 +4232,29 @@ def test_bad_mappings_are_read_without_importing_the_loader():
     assert ("torch" in sys.modules) == torch_before
 
 
+def test_base_model_candidates_include_the_loaders_suffix_strip():
+    # Where ALLOW_PREQUANTIZED_MODELS is false the loader strips the 4-bit suffix after
+    # mapping, so the fetched repo is a third step out from the recorded base. This base
+    # reaches unsloth/codellama-34b-bnb-4bit through the tables and the stripped repo
+    # through nothing else, so it isolates that rewrite.
+    candidates = start._base_model_candidates("codellama/CodeLlama-34b-hf")
+
+    assert "unsloth/codellama-34b-bnb-4bit" in candidates
+    assert "unsloth/codellama-34b" in candidates
+
+
+def test_unsloth_package_dirs_include_the_studio_venv(monkeypatch, tmp_path):
+    # The worker may run in the managed Studio venv, whose Unsloth can differ from the one
+    # this CLI was launched from, so both sets of tables have to be read.
+    venv_pkg = tmp_path / "unsloth_studio" / "lib" / "python3.11" / "site-packages" / "unsloth"
+    venv_pkg.mkdir(parents = True)
+    import unsloth_cli.commands.studio as studio_mod
+
+    monkeypatch.setattr(studio_mod, "STUDIO_HOME", tmp_path, raising = False)
+
+    assert venv_pkg in start._unsloth_package_dirs()
+
+
 def test_base_model_candidates_leave_out_repos_the_load_path_cannot_pick():
     # Nothing in the inference path passes load_in_fp8, so an fp8 repo is never the
     # download and polling it would only cost the downloading server a request per poll.
@@ -4326,6 +4349,43 @@ def test_model_download_progress_reasks_after_an_inconclusive_adapter_answer(mon
     progress.poll()
     assert len(lookups) == 2
     assert progress.downloaded_bytes == 1024 + 2 * 1024**3
+
+
+def test_model_download_progress_survives_a_very_long_inconclusive_run(monkeypatch):
+    # The backoff is carried, not recomputed as 2 ** n: past ~1024 inconclusive lookups the
+    # power overflowed, and because the lookup runs before the model's own read, every
+    # later poll died there and the tracked bytes stopped moving.
+    now = [1000.0]
+    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
+    lookups = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            lookups.append(url)
+            return {"is_lora": False}
+        return {
+            "downloaded_bytes": 1024 * len(lookups),
+            "expected_bytes": 10 * 1024**3,
+            "cache_measured": True,
+        }
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
+
+    for _ in range(1100):
+        progress.poll()
+        now[0] += start._COMPANION_LOOKUP_MAX_RETRY_S
+
+    assert len(lookups) > 1024
+    assert progress._failures == 0
+    assert progress.downloaded_bytes == 1024 * len(lookups)
 
 
 def test_model_download_progress_keeps_reasking_an_inconclusive_answer(monkeypatch):
@@ -4540,8 +4600,14 @@ def test_model_download_progress_stops_polling_dead_base_candidates(monkeypatch)
                 "downloaded_bytes": next(substitute),
                 "completed_bytes": 0,
                 "expected_bytes": 6 * 1024**3,
+                "cache_measured": True,
             }
-        return {"downloaded_bytes": 0, "completed_bytes": 0, "expected_bytes": 0}
+        return {
+            "downloaded_bytes": 0,
+            "completed_bytes": 0,
+            "expected_bytes": 0,
+            "cache_measured": True,
+        }
 
     monkeypatch.setattr(start, "_http_json", http_json)
     progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
@@ -4558,6 +4624,62 @@ def test_model_download_progress_stops_polling_dead_base_candidates(monkeypatch)
     # The substitute has now grown twice; the recorded base is dropped.
     assert dead_polls() == 2
     assert progress.downloaded_bytes == 3 * 1024**3
+
+
+def test_model_download_progress_does_not_prune_on_a_cache_scan_rebound(monkeypatch):
+    # An unreadable cache root makes the endpoint report a lower bound with
+    # cache_measured false; the larger figure when the root returns is a rebound, not a
+    # transfer, and must not capture the prune.
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
+    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
+    rebound = iter(
+        [
+            {
+                "downloaded_bytes": 2 * 1024**3,
+                "completed_bytes": 2 * 1024**3,
+                "cache_measured": False,
+            },
+            {
+                "downloaded_bytes": 9 * 1024**3,
+                "completed_bytes": 9 * 1024**3,
+                "cache_measured": True,
+            },
+            {
+                "downloaded_bytes": 9 * 1024**3,
+                "completed_bytes": 9 * 1024**3,
+                "cache_measured": True,
+            },
+        ]
+    )
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
+            return next(rebound)
+        return {
+            "downloaded_bytes": 0,
+            "completed_bytes": 0,
+            "expected_bytes": 40 * 1024**3,
+            "cache_measured": True,
+        }
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    progress.poll()
+    progress.poll()
+
+    # The repo that has not started yet is still watched.
+    assert "owner/base" in (progress._companions or [])
 
 
 def test_model_download_progress_does_not_prune_to_an_abandoned_partial(monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4218,6 +4218,7 @@ def test_base_model_candidates_follow_the_loaders_second_rewrite():
 
 
 def test_bad_mappings_are_read_without_importing_the_loader():
+    torch_before = "torch" in sys.modules
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(start, "_BAD_MAPPINGS", None)
     try:
@@ -4228,7 +4229,7 @@ def test_bad_mappings_are_read_without_importing_the_loader():
     assert table and all(isinstance(k, str) and isinstance(v, str) for k, v in table.items())
     # The source spells these as "...".lower(), which only evaluating the literal resolves.
     assert all(key == key.lower() for key in table)
-    assert "torch" not in sys.modules
+    assert ("torch" in sys.modules) == torch_before
 
 
 def test_base_model_candidates_leave_out_repos_the_load_path_cannot_pick():
@@ -4240,6 +4241,9 @@ def test_base_model_candidates_leave_out_repos_the_load_path_cannot_pick():
 
 
 def test_quant_mappers_load_without_importing_unsloth():
+    # Only whether THIS call pulls torch in: another test in the session may have already
+    # imported it, and that is not this function's doing.
+    torch_before = "torch" in sys.modules
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(start, "_QUANT_MAPPERS", None)
     try:
@@ -4248,7 +4252,7 @@ def test_quant_mappers_load_without_importing_unsloth():
         monkeypatch.undo()
 
     assert tables and all(isinstance(table, dict) for table in tables)
-    assert "torch" not in sys.modules
+    assert ("torch" in sys.modules) == torch_before
 
 
 def test_model_download_progress_watches_a_gguf_named_adapters_base(monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4197,6 +4197,14 @@ def test_base_model_candidates_cover_the_case_the_loader_returns():
     assert "unsloth/qwen2.5-0.5b-instruct-unsloth-bnb-4bit" in candidates
 
 
+def test_base_model_candidates_leave_out_repos_the_load_path_cannot_pick():
+    # Nothing in the inference path passes load_in_fp8, so an fp8 repo is never the
+    # download and polling it would only cost the downloading server a request per poll.
+    candidates = start._base_model_candidates("meta-llama/Llama-3.1-8B-Instruct")
+
+    assert not [repo for repo in candidates if "fp8" in repo.lower()]
+
+
 def test_quant_mappers_load_without_importing_unsloth():
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(start, "_QUANT_MAPPERS", None)

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4020,6 +4020,8 @@ def test_model_download_progress_counts_a_lora_base_model(monkeypatch, capsys):
 
 
 def test_model_download_progress_retries_base_model_resolution(monkeypatch):
+    now = [1000.0]
+    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
     lookups = []
 
     def http_json(
@@ -4044,6 +4046,7 @@ def test_model_download_progress_retries_base_model_resolution(monkeypatch):
 
     progress.poll()
     assert progress.downloaded_bytes == 1024
+    now[0] += start._COMPANION_LOOKUP_RETRY_S
     progress.poll()
     assert progress.downloaded_bytes == 1024 + 3 * 1024**3
     assert len(lookups) == 2
@@ -4073,6 +4076,198 @@ def test_model_download_progress_asks_for_a_base_model_once_when_the_answer_is_f
 
     assert progress.downloaded_bytes == 1024
     assert len(lookups) == 1
+
+
+def test_model_download_progress_keeps_its_own_reading_when_a_base_read_fails(monkeypatch):
+    adapter_bytes = iter([4 * 1024**2, 9 * 1024**2])
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("repo_id=owner%2Fbase"):
+            # The base repo's cache walk is the big one, so its request is the one that
+            # times out; that must not discard the adapter's own reading.
+            raise TimeoutError("the server took too long to answer")
+        return {"downloaded_bytes": next(adapter_bytes), "expected_bytes": 40 * 1024**2}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    assert progress.downloaded_bytes == 4 * 1024**2
+    progress.poll()
+
+    assert progress.downloaded_bytes == 9 * 1024**2
+    assert progress._failures == 0
+
+
+def test_model_download_progress_counts_the_quantized_base_the_loader_substitutes(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        start, "_QUANT_MAPPER", {"meta-llama/Llama-3.1-8B": "unsloth/Llama-3.1-8B-bnb-4bit"}
+    )
+    polled = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "meta-llama/Llama-3.1-8B"}
+        polled.append(url)
+        # The loader downloads the mapped repo, so the recorded base never moves.
+        if url.endswith("repo_id=unsloth%2FLlama-3.1-8B-bnb-4bit"):
+            return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 4 * 1024**3}
+        return {"downloaded_bytes": 0, "expected_bytes": 0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+
+    assert progress.downloaded_bytes == 3 * 1024**3
+    assert any("repo_id=meta-llama%2FLlama-3.1-8B" in url for url in polled)
+    assert any("repo_id=unsloth%2FLlama-3.1-8B-bnb-4bit" in url for url in polled)
+
+
+def test_quant_mapper_loads_without_importing_unsloth():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(start, "_QUANT_MAPPER", None)
+    try:
+        table = start._unsloth_quant_mapper()
+    finally:
+        monkeypatch.undo()
+
+    assert isinstance(table, dict) and table
+    assert all(isinstance(key, str) for key in table)
+    assert "torch" not in sys.modules
+
+
+def test_model_download_progress_reasks_after_an_inconclusive_adapter_answer(monkeypatch):
+    now = [1000.0]
+    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
+    answers = [
+        # A failed adapter_config.json inspection is served as a plain 200 is_lora=False.
+        {"is_lora": False},
+        {"is_lora": True, "base_model": "owner/base"},
+    ]
+    lookups = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            lookups.append(url)
+            return answers[min(len(lookups) - 1, len(answers) - 1)]
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {"downloaded_bytes": 2 * 1024**3, "expected_bytes": 4 * 1024**3}
+        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    assert progress.downloaded_bytes == 1024
+    assert len(lookups) == 1
+
+    # Inside the retry window the costly endpoint is left alone.
+    now[0] += 1.0
+    progress.poll()
+    assert len(lookups) == 1
+
+    now[0] += start._COMPANION_LOOKUP_RETRY_S
+    progress.poll()
+    assert len(lookups) == 2
+    assert progress.downloaded_bytes == 1024 + 2 * 1024**3
+
+
+def test_model_download_progress_stops_reasking_an_inconclusive_answer(monkeypatch):
+    now = [1000.0]
+    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
+    lookups = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            lookups.append(url)
+            return {"is_lora": False}
+        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
+
+    for _ in range(6):
+        progress.poll()
+        now[0] += start._COMPANION_LOOKUP_RETRY_S + 1.0
+
+    assert len(lookups) == start._COMPANION_LOOKUP_ATTEMPTS
+
+
+def test_model_download_progress_keeps_an_unknown_total_unknown(monkeypatch, capsys):
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("repo_id=owner%2Fadapter"):
+            return {
+                "downloaded_bytes": 20 * 1024**2,
+                "completed_bytes": 20 * 1024**2,
+                "expected_bytes": 20 * 1024**2,
+                "progress": 1.0,
+            }
+        # The base's total is not resolvable yet: unknown, not zero.
+        return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+
+    out = capsys.readouterr().out
+    assert progress.downloaded_bytes == 20 * 1024**2 + 3 * 1024**3
+    assert "100%" not in out
+    assert "3.0 GiB" in out
+
+
+def test_combined_reading_keeps_a_known_total_when_every_part_is_known():
+    combined = start._combined_reading(
+        [
+            {"downloaded_bytes": 1024, "completed_bytes": 1024, "expected_bytes": 2048},
+            {"downloaded_bytes": 1024, "completed_bytes": 0, "expected_bytes": 2048},
+        ]
+    )
+
+    assert combined["expected_bytes"] == 4096
+    assert combined["progress"] == 0.5
 
 
 def test_load_model_with_progress_uses_selected_gguf_size(monkeypatch, capsys):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4243,6 +4243,36 @@ def test_base_model_candidates_include_the_loaders_suffix_strip():
     assert "unsloth/codellama-34b" in candidates
 
 
+def test_base_model_candidates_strip_the_recorded_base_itself():
+    # The strip runs after mapping, and an unmapped base passes mapping unchanged, so the
+    # recorded name is a subject of it too.
+    assert start._base_model_candidates("owner/custom-bnb-4bit") == [
+        "owner/custom-bnb-4bit",
+        "owner/custom",
+    ]
+
+
+def test_unsloth_package_dirs_ask_the_venv_for_an_editable_install(monkeypatch, tmp_path):
+    # `unsloth studio update --local` installs with -e, leaving a PEP 660 finder and no
+    # site-packages/unsloth directory, so the globs find nothing and the venv is asked.
+    editable = tmp_path / "src" / "unsloth"
+    editable.mkdir(parents = True)
+    fake_python = tmp_path / "unsloth_studio" / "bin" / "python"
+    fake_python.parent.mkdir(parents = True)
+    fake_python.touch()
+    import unsloth_cli.commands.studio as studio_mod
+
+    monkeypatch.setattr(studio_mod, "STUDIO_HOME", tmp_path, raising = False)
+    monkeypatch.setattr(studio_mod, "_studio_venv_python", lambda: fake_python, raising = False)
+
+    class _Result:
+        stdout = f"{editable}\n"
+
+    monkeypatch.setattr(start.subprocess, "run", lambda *a, **k: _Result())
+
+    assert editable in start._unsloth_package_dirs()
+
+
 def test_unsloth_package_dirs_include_the_studio_venv(monkeypatch, tmp_path):
     # The worker may run in the managed Studio venv, whose Unsloth can differ from the one
     # this CLI was launched from, so both sets of tables have to be read.
@@ -4624,6 +4654,116 @@ def test_model_download_progress_stops_polling_dead_base_candidates(monkeypatch)
     # The substitute has now grown twice; the recorded base is dropped.
     assert dead_polls() == 2
     assert progress.downloaded_bytes == 3 * 1024**3
+
+
+def test_model_download_progress_does_not_prune_when_a_cache_mount_appears(monkeypatch):
+    # A cached candidate whose mount was missing during one complete scan and present in
+    # the next grows its total by the whole cached size with nothing transferring.
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
+    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
+    mount = iter(
+        [
+            {"downloaded_bytes": 0, "completed_bytes": 0, "cache_measured": True},
+            {
+                "downloaded_bytes": 16 * 1024**3,
+                "completed_bytes": 16 * 1024**3,
+                "cache_measured": True,
+            },
+            {
+                "downloaded_bytes": 16 * 1024**3,
+                "completed_bytes": 16 * 1024**3,
+                "cache_measured": True,
+            },
+        ]
+    )
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
+            return next(mount)
+        return {
+            "downloaded_bytes": 0,
+            "completed_bytes": 0,
+            "expected_bytes": 40 * 1024**3,
+            "cache_measured": True,
+        }
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    for _ in range(3):
+        progress.poll()
+
+    assert "owner/base" in (progress._companions or [])
+
+
+def test_companion_lookup_retries_a_rate_limited_config_route(monkeypatch):
+    now = [1000.0]
+    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
+    lookups = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            lookups.append(url)
+            if len(lookups) == 1:
+                raise urllib.error.HTTPError(url, 429, "Too Many Requests", None, None)
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 4 * 1024**3}
+        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    assert progress.downloaded_bytes == 1024
+    now[0] += start._COMPANION_LOOKUP_RETRY_S
+    progress.poll()
+
+    assert len(lookups) == 2
+    assert progress.downloaded_bytes == 1024 + 3 * 1024**3
+
+
+def test_download_progress_display_completes_after_following_a_second_repo(monkeypatch, capsys):
+    monkeypatch.setattr(start.sys.stdout, "isatty", lambda: True, raising = False)
+    display = start._DownloadProgressDisplay()
+
+    display.update(
+        {
+            "downloaded_bytes": 2 * 1024**3,
+            "completed_bytes": 0,
+            "expected_bytes": 4 * 1024**3,
+            "progress": 0.5,
+        },
+        "owner/base",
+    )
+    # The base finished, so the line falls back to a fully cached adapter, which renders
+    # nothing. That must not wipe the state complete() and close() gate on.
+    display.update(
+        {"downloaded_bytes": 1024, "completed_bytes": 1024, "expected_bytes": 1024},
+        "owner/adapter",
+    )
+    display.complete()
+    display.close()
+
+    out = capsys.readouterr().out
+    assert "100%" in out
+    assert out.endswith("\n")
 
 
 def test_model_download_progress_does_not_prune_on_a_cache_scan_rebound(monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4328,10 +4328,10 @@ def test_model_download_progress_reasks_after_an_inconclusive_adapter_answer(mon
     assert progress.downloaded_bytes == 1024 + 2 * 1024**3
 
 
-def test_model_download_progress_stops_reasking_an_inconclusive_answer(monkeypatch):
+def test_model_download_progress_keeps_reasking_an_inconclusive_answer(monkeypatch):
     now = [1000.0]
     monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
-    lookups = []
+    asked_at = []
 
     def http_json(
         method,
@@ -4342,18 +4342,25 @@ def test_model_download_progress_stops_reasking_an_inconclusive_answer(monkeypat
         error = None,
     ):
         if "/api/models/config/" in url:
-            lookups.append(url)
+            asked_at.append(now[0])
             return {"is_lora": False}
         return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
 
     monkeypatch.setattr(start, "_http_json", http_json)
     progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
 
-    for _ in range(6):
+    for _ in range(4000):
         progress.poll()
-        now[0] += start._COMPANION_LOOKUP_RETRY_S + 1.0
+        now[0] += 1.0
 
-    assert len(lookups) == start._COMPANION_LOOKUP_ATTEMPTS
+    # It never stops: a config route that is slow or rate-limited for a few minutes must
+    # not cost the whole startup, since the worker may still be fetching a base.
+    assert len(asked_at) > 5
+    gaps = [b - a for a, b in zip(asked_at, asked_at[1:])]
+    # ... but the wait widens to a ceiling instead of costing a request per poll.
+    assert gaps[0] == start._COMPANION_LOOKUP_RETRY_S
+    assert gaps[1] > gaps[0]
+    assert max(gaps) == start._COMPANION_LOOKUP_MAX_RETRY_S
 
 
 def test_model_download_progress_keeps_an_unknown_total_unknown(monkeypatch, capsys):
@@ -4512,8 +4519,10 @@ def test_model_download_progress_does_not_invent_a_total_across_repos(monkeypatc
 
 
 def test_model_download_progress_stops_polling_dead_base_candidates(monkeypatch):
-    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-unsloth-bnb-4bit"}])
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
+    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
     polled = []
+    substitute = iter([1024**3, 2 * 1024**3, 3 * 1024**3, 4 * 1024**3])
 
     def http_json(
         method,
@@ -4526,9 +4535,9 @@ def test_model_download_progress_stops_polling_dead_base_candidates(monkeypatch)
         if "/api/models/config/" in url:
             return {"is_lora": True, "base_model": "owner/base"}
         polled.append(url)
-        if url.endswith("repo_id=unsloth%2Fbase-unsloth-bnb-4bit"):
+        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
             return {
-                "downloaded_bytes": 2 * 1024**3,
+                "downloaded_bytes": next(substitute),
                 "completed_bytes": 0,
                 "expected_bytes": 6 * 1024**3,
             }
@@ -4537,14 +4546,61 @@ def test_model_download_progress_stops_polling_dead_base_candidates(monkeypatch)
     monkeypatch.setattr(start, "_http_json", http_json)
     progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
 
-    progress.poll()
-    first = len([url for url in polled if "repo_id=owner%2Fbase" in url])
-    progress.poll()
-    second = len([url for url in polled if "repo_id=owner%2Fbase" in url])
+    def dead_polls():
+        return len([url for url in polled if "repo_id=owner%2Fbase" in url])
 
-    assert first == 1
-    assert second == 1
-    assert progress.downloaded_bytes == 2 * 1024**3
+    progress.poll()
+    # One reading is not growth, so the recorded base is still in play.
+    assert dead_polls() == 1
+    progress.poll()
+    assert dead_polls() == 2
+    progress.poll()
+    # The substitute has now grown twice; the recorded base is dropped.
+    assert dead_polls() == 2
+    assert progress.downloaded_bytes == 3 * 1024**3
+
+
+def test_model_download_progress_does_not_prune_to_an_abandoned_partial(monkeypatch):
+    # A cancelled download leaves .incomplete blobs behind. Those bytes are present but
+    # never grow, and pruning to them would drop the repo the worker actually fetches.
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "unsloth/base-4bit"}])
+    monkeypatch.setattr(start, "_BAD_MAPPINGS", {})
+    real = iter([0, 0, 1024**3, 2 * 1024**3])
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("repo_id=unsloth%2Fbase-4bit"):
+            # The corpse: bytes in flight from the first poll, never moving.
+            return {
+                "downloaded_bytes": 5 * 1024**2,
+                "completed_bytes": 0,
+                "expected_bytes": 6 * 1024**3,
+            }
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {
+                "downloaded_bytes": next(real),
+                "completed_bytes": 0,
+                "expected_bytes": 40 * 1024**3,
+            }
+        return {"downloaded_bytes": 0, "completed_bytes": 0, "expected_bytes": 0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    for _ in range(4):
+        progress.poll()
+
+    # The repo that really downloaded is still watched, and its bytes are counted.
+    assert progress.downloaded_bytes == 2 * 1024**3 + 5 * 1024**2
+    assert "owner/base" in (progress._companions or [])
 
 
 def test_load_model_with_progress_uses_selected_gguf_size(monkeypatch, capsys):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4311,6 +4311,28 @@ def test_base_model_candidates_leave_out_repos_the_load_path_cannot_pick():
     assert not [repo for repo in candidates if "fp8" in repo.lower()]
 
 
+def test_quant_mappers_never_execute_the_discovered_file(monkeypatch, tmp_path):
+    # `unsloth start` opens a coding agent on a repository that is not necessarily trusted,
+    # and mapper.py is found on sys.path, which can include that repository. The file is
+    # read for its data; running it would hand it the user's privileges.
+    planted = tmp_path / "unsloth" / "models"
+    planted.mkdir(parents = True)
+    sentinel = tmp_path / "executed"
+    (planted / "mapper.py").write_text(
+        "import pathlib\n"
+        f"pathlib.Path({str(sentinel)!r}).write_text('x')\n"
+        '__INT_TO_FLOAT_MAPPER = {"owner/model-bnb-4bit": ("owner/model",)}\n'
+    )
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", None)
+    monkeypatch.setattr(start, "_unsloth_package_dirs", lambda: [tmp_path / "unsloth"])
+
+    tables = start._unsloth_quant_mappers()
+
+    assert not sentinel.exists()
+    # The data still came through.
+    assert "owner/model" in tables[0]["owner/model-bnb-4bit"]
+
+
 def test_quant_mappers_load_without_importing_unsloth():
     # Only whether THIS call pulls torch in: another test in the session may have already
     # imported it, and that is not this function's doing.

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4708,6 +4708,79 @@ def test_companion_lookup_retries_an_offline_404(monkeypatch):
     assert progress.downloaded_bytes == 1024 + 5 * 1024**3
 
 
+def test_companion_lookup_gives_up_on_a_server_without_the_route(monkeypatch):
+    # The router's bare "Not Found" means the path is not registered, so retrying it for
+    # the length of a download achieves nothing.
+    now = [1000.0]
+    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
+    lookups = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            lookups.append(url)
+            raise urllib.error.HTTPError(
+                url, 404, "Not Found", None, io.BytesIO(b'{"detail":"Not Found"}')
+            )
+        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
+
+    for _ in range(4):
+        progress.poll()
+        now[0] += start._COMPANION_LOOKUP_MAX_RETRY_S
+
+    assert len(lookups) == 1
+
+
+def test_companion_lookup_retries_the_routes_own_404(monkeypatch):
+    # The handler's own 404 carries its reason, and means try again later.
+    now = [1000.0]
+    monkeypatch.setattr(start.time, "monotonic", lambda: now[0])
+    lookups = []
+    body = b'{"detail":"This request cannot be authorized without network access."}'
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            lookups.append(url)
+            raise urllib.error.HTTPError(url, 404, "Not Found", None, io.BytesIO(body))
+        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
+
+    for _ in range(4):
+        progress.poll()
+        now[0] += start._COMPANION_LOOKUP_MAX_RETRY_S
+
+    assert len(lookups) == 4
+
+
+def test_active_reading_prefers_a_repo_that_moved_over_a_bigger_partial():
+    corpse = ("unsloth/base-4bit", {"downloaded_bytes": 9 * 1024**3, "completed_bytes": 0})
+    live = ("owner/base", {"downloaded_bytes": 2 * 1024**3, "completed_bytes": 0})
+    model = ("owner/adapter", {"downloaded_bytes": 10, "completed_bytes": 10})
+
+    # Nothing known to have moved: the biggest partial is all there is to go on.
+    assert start._active_reading([model, corpse, live]) is corpse
+    # Once the live repo is seen to move it wins, however large the abandoned blob is.
+    assert start._active_reading([model, corpse, live], frozenset({"owner/base"})) is live
+
+
 def test_companion_lookup_stops_on_a_refused_request(monkeypatch):
     lookups = []
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -3982,6 +3982,99 @@ def test_start_studio_server_polls_progress_from_early_key(monkeypatch):
     assert not any(isinstance(event, tuple) and "server ready" in event[-1] for event in created)
 
 
+def test_model_download_progress_counts_a_lora_base_model(monkeypatch, capsys):
+    calls = []
+    base_bytes = iter([1024**3, 2 * 1024**3])
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        calls.append(url)
+        if url == f"{BASE}/api/models/config/owner/adapter":
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("download-progress?repo_id=owner%2Fadapter"):
+            return {
+                "downloaded_bytes": 8 * 1024**2,
+                "completed_bytes": 8 * 1024**2,
+                "expected_bytes": 8 * 1024**2,
+                "progress": 1.0,
+            }
+        if url.endswith("download-progress?repo_id=owner%2Fbase"):
+            return {"downloaded_bytes": next(base_bytes), "expected_bytes": 4 * 1024**3}
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    progress.poll()
+
+    assert progress.downloaded_bytes == 8 * 1024**2 + 2 * 1024**3
+    assert calls.count(f"{BASE}/api/models/config/owner/adapter") == 1
+    assert "1.0 GiB / 4.0 GiB" in capsys.readouterr().out
+
+
+def test_model_download_progress_retries_base_model_resolution(monkeypatch):
+    lookups = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            lookups.append(url)
+            if len(lookups) == 1:
+                raise urllib.error.URLError("busy")
+            return {"is_lora": True, "base_model": "owner/base"}
+        if url.endswith("repo_id=owner%2Fbase"):
+            return {"downloaded_bytes": 3 * 1024**3, "expected_bytes": 4 * 1024**3}
+        return {"downloaded_bytes": 1024, "expected_bytes": 1024, "progress": 1.0}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/adapter", None)
+
+    progress.poll()
+    assert progress.downloaded_bytes == 1024
+    progress.poll()
+    assert progress.downloaded_bytes == 1024 + 3 * 1024**3
+    assert len(lookups) == 2
+
+
+def test_model_download_progress_asks_for_a_base_model_once_when_the_answer_is_final(monkeypatch):
+    lookups = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if "/api/models/config/" in url:
+            lookups.append(url)
+            raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
+        return {"downloaded_bytes": 1024, "expected_bytes": 4096}
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+    progress = start._ModelDownloadProgress(BASE, "sk-test", "owner/model", None)
+
+    progress.poll()
+    progress.poll()
+
+    assert progress.downloaded_bytes == 1024
+    assert len(lookups) == 1
+
+
 def test_load_model_with_progress_uses_selected_gguf_size(monkeypatch, capsys):
     release = start.threading.Event()
     calls = []

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4209,6 +4209,22 @@ def test_base_model_candidates_survive_unsloth_not_being_installed(monkeypatch):
     assert start._base_model_candidates("owner/base") == ["owner/base"]
 
 
+def test_base_model_candidates_keep_every_installs_bad_mapping(monkeypatch):
+    # Two installs can disagree on the same key; collapsing them to the first would leave
+    # the worker downloading a repo the CLI never polls.
+    monkeypatch.setattr(start, "_QUANT_MAPPERS", [{"owner/base": "owner/mapped"}])
+    monkeypatch.setattr(
+        start,
+        "_BAD_MAPPINGS",
+        [{"owner/mapped": "owner/parent-target"}, {"owner/mapped": "owner/venv-target"}],
+    )
+
+    candidates = start._base_model_candidates("owner/base")
+
+    assert "owner/parent-target" in candidates
+    assert "owner/venv-target" in candidates
+
+
 def test_base_model_candidates_follow_the_loaders_second_rewrite():
     # get_model_name maps Qwen/Qwen3-32B to unsloth/Qwen3-32B-unsloth-bnb-4bit and then
     # rewrites that through BAD_MAPPINGS, so the repo that downloads is two steps out.
@@ -4222,13 +4238,15 @@ def test_bad_mappings_are_read_without_importing_the_loader():
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(start, "_BAD_MAPPINGS", None)
     try:
-        table = start._unsloth_bad_mappings()
+        tables = start._unsloth_bad_mappings()
     finally:
         monkeypatch.undo()
 
-    assert table and all(isinstance(k, str) and isinstance(v, str) for k, v in table.items())
+    assert tables and all(isinstance(t, dict) and t for t in tables)
+    pairs = [(k, v) for t in tables for k, v in t.items()]
+    assert all(isinstance(k, str) and isinstance(v, str) for k, v in pairs)
     # The source spells these as "...".lower(), which only evaluating the literal resolves.
-    assert all(key == key.lower() for key in table)
+    assert all(key == key.lower() for key, _ in pairs)
     assert ("torch" in sys.modules) == torch_before
 
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -4188,6 +4188,15 @@ def test_base_model_candidates_cover_every_table_the_loader_consults():
     assert len(candidates) == len(set(candidates))
 
 
+def test_base_model_candidates_cover_the_case_the_loader_returns():
+    # `__get_model_name` looks the base up by its lower-cased name, so the repo it returns
+    # can be spelled differently from the entry reached by the recorded name. Verified
+    # against a real load: `Qwen/Qwen2.5-0.5B-Instruct` fetches this exact repo id.
+    candidates = start._base_model_candidates("Qwen/Qwen2.5-0.5B-Instruct")
+
+    assert "unsloth/qwen2.5-0.5b-instruct-unsloth-bnb-4bit" in candidates
+
+
 def test_quant_mappers_load_without_importing_unsloth():
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(start, "_QUANT_MAPPERS", None)


### PR DESCRIPTION
Follows #10453, which made the 15 minute startup cap measure time since the download last moved. A LoRA adapter's base model was still invisible to the CLI. The base is fetched inside the inference worker and never appeared as a download job, so only the small adapter was being watched. Once the adapter finished, the cap ran out while the base was still downloading.

The worker now tells the server which repos the load is about to fetch: the adapter, its recorded base, and the repo the loader's own name mapper substitutes for that base. The server registers them as download jobs owned by the load, so the existing active-downloads and download-progress routes report them, and it closes them when the load ends. The CLI just reads that list and adds the bytes together. Nothing about the mapper lives in the CLI. Cancelling one of these jobs from the downloads panel is refused with a message to cancel the load instead.

Tested on an A10G with a fresh install of this branch. While the LoRA loaded, the active-downloads list showed the adapter, the recorded base, and the substituted 4-bit base as load-owned jobs. The 4-bit base grew to 553 MB, then the adapter followed, and the list emptied when the model reached ready. The CLI showed the transfer the loader actually ran and reached ready. Earlier, a throttled 1 GB base that took 18 minutes was tracked to the end on this branch while the same run was stopped at 900 seconds without it.