### PR TITLE
Studio: let unsloth start poll a server that never prints the early API key

### DIFF
--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -91,10 +91,13 @@ class Harness:
         tail = KEY_LINE,
         healthy = False,
         startup_key = None,
+        startup_key_at = None,
         marker_at = None,
         ready_tail = None,
+        flap_every = 0,
+        step = STEP_S,
     ):
-        self.clock = FakeClock(STEP_S)
+        self.clock = FakeClock(step)
         self.log_path = None
         self.chatter = chatter
         self.fail_every = fail_every
@@ -112,7 +115,9 @@ class Harness:
         self.tail = tail
         self.healthy = healthy
         self.startup_key = startup_key
+        self.startup_key_at = startup_key_at
         self.marker_at = marker_at
+        self.flap_every = flap_every
         self.ready_tail = ready_tail or f"{KEY_LINE}Model loaded: {MODEL}\n"
         self.mints = 0
         self.server = FakePopen()
@@ -221,6 +226,8 @@ class Harness:
         if self.chatter and self.log_path is not None:
             with open(self.log_path, "ab") as handle:
                 handle.write(self.chatter(self.iterations).encode())
+        if self.flap_every and self.iterations % self.flap_every == 0:
+            return False
         if self.marker_at is not None and self.iterations >= self.marker_at:
             self.tail = KEY_LINE
         if self.ready_at is not None and self.iterations >= self.ready_at:
@@ -230,6 +237,9 @@ class Harness:
 
     def startup_api_key(self, base):
         self.mints += 1
+        # Auth that only settles some way past the health gate.
+        if self.startup_key_at is not None and self.iterations < self.startup_key_at:
+            return None
         return self.startup_key
 
     def start(self):
@@ -446,7 +456,7 @@ def test_an_older_child_with_no_mintable_key_still_times_out(monkeypatch, capsys
     with pytest.raises(typer.Exit):
         harness.start()
 
-    assert 0 < harness.mints <= start_cli._KEY_MINT_ATTEMPTS
+    assert harness.mints > 0
     assert harness.polls == 0
     assert harness.shutdowns == [harness.server]
     assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
@@ -504,3 +514,63 @@ def test_a_marker_one_poll_behind_health_does_not_mint(monkeypatch):
     assert server is harness.server
     assert harness.mints == 0
     assert harness.polls >= 38
+
+
+def test_minting_is_retried_at_a_slow_cadence_not_every_poll(monkeypatch, capsys):
+    # A server that never mints must not be asked once per sleep for 15 minutes, and
+    # a handful of early failures must not retire the attempt for the whole window.
+    harness = Harness(monkeypatch, tail = "starting\n", healthy = True, step = 2.0)
+
+    with pytest.raises(typer.Exit):
+        harness.start()
+
+    polls = harness.iterations
+    assert polls > 400, f"the loop only ran {polls} passes, so nothing was throttled"
+    # Spelled out rather than read off the module so an implementation without the
+    # cadence fails the rate assertion instead of erroring on a missing attribute.
+    ceiling = harness.clock.elapsed / 30.0 + 2
+    assert 3 < harness.mints <= ceiling, f"{harness.mints} mint attempts over {polls} passes"
+    assert start_cli._KEY_MINT_RETRY_S == 30.0
+
+
+def test_auth_that_settles_after_the_health_gate_still_starts_progress(monkeypatch):
+    # `/api/health` can open before `/api/auth` is usable. Minting fails until it
+    # settles; the download behind it must still be tracked instead of timing out.
+    harness = Harness(
+        monkeypatch,
+        tail = "starting\n",
+        healthy = True,
+        startup_key = "sk-unsloth-minted",
+        startup_key_at = 100,
+        chunk_bytes = 1024**3,
+        ready_at = 500,
+        step = 2.0,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.polls > 0
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_a_health_probe_that_times_out_under_load_does_not_retire_minting(monkeypatch):
+    # Health is polled with a 3s timeout while the disk is saturated by the download,
+    # so it can miss a pass. A missed pass must not mean the loop never mints.
+    harness = Harness(
+        monkeypatch,
+        tail = "starting\n",
+        healthy = True,
+        startup_key = "sk-unsloth-minted",
+        chunk_bytes = 1024**3,
+        flap_every = 2,
+        ready_at = 41,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.mints == 1
+    assert harness.polls > 0

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -89,6 +89,10 @@ class Harness:
         rebound = False,
         ready_at = None,
         tail = KEY_LINE,
+        healthy = False,
+        startup_key = None,
+        marker_at = None,
+        ready_tail = None,
     ):
         self.clock = FakeClock(STEP_S)
         self.log_path = None
@@ -106,6 +110,11 @@ class Harness:
         self.chunk_bytes = chunk_bytes
         self.ready_at = ready_at
         self.tail = tail
+        self.healthy = healthy
+        self.startup_key = startup_key
+        self.marker_at = marker_at
+        self.ready_tail = ready_tail or f"{KEY_LINE}Model loaded: {MODEL}\n"
+        self.mints = 0
         self.server = FakePopen()
         self.iterations = 0
         self.polls = 0
@@ -114,6 +123,7 @@ class Harness:
         monkeypatch.setattr(start_cli, "_http_json", self.http_json)
         monkeypatch.setattr(start_cli, "_log_tail", self.log_tail)
         monkeypatch.setattr(start_cli, "_studio_healthy", self.studio_healthy)
+        monkeypatch.setattr(start_cli, "_startup_api_key", self.startup_api_key)
         monkeypatch.setattr(start_cli, "_shutdown_server", self.shutdowns.append)
         monkeypatch.setattr(start_cli, "_auto_served_server", None)
         monkeypatch.setattr(start_cli.atexit, "register", lambda *a, **k: None)
@@ -211,10 +221,16 @@ class Harness:
         if self.chatter and self.log_path is not None:
             with open(self.log_path, "ab") as handle:
                 handle.write(self.chatter(self.iterations).encode())
+        if self.marker_at is not None and self.iterations >= self.marker_at:
+            self.tail = KEY_LINE
         if self.ready_at is not None and self.iterations >= self.ready_at:
-            self.tail = f"{KEY_LINE}Model loaded: {MODEL}\n"
+            self.tail = self.ready_tail
             return True
-        return False
+        return self.healthy
+
+    def startup_api_key(self, base):
+        self.mints += 1
+        return self.startup_key
 
     def start(self):
         return start_cli._start_studio_server(BASE, MODEL, start_cli.LoadOptions())
@@ -402,3 +418,68 @@ def test_a_vanished_cache_mount_is_not_progress(monkeypatch, capsys):
     assert harness.shutdowns == [harness.server]
     assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
     assert harness.clock.elapsed < 2 * start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_an_older_child_is_polled_with_a_minted_key(monkeypatch):
+    harness = Harness(
+        monkeypatch,
+        tail = "starting\n",
+        healthy = True,
+        startup_key = "sk-unsloth-minted",
+        chunk_bytes = 1024**3,
+        ready_at = 40,
+        ready_tail = f"API Key: sk-unsloth-old\nModel loaded: {MODEL}\n",
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.mints == 1
+    assert harness.polls >= 40
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_an_older_child_with_no_mintable_key_still_times_out(monkeypatch, capsys):
+    harness = Harness(monkeypatch, tail = "starting\n", healthy = True)
+
+    with pytest.raises(typer.Exit):
+        harness.start()
+
+    assert harness.mints > 0
+    assert harness.polls == 0
+    assert harness.shutdowns == [harness.server]
+    assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
+
+
+def test_a_minted_key_does_not_retire_the_early_key_marker(monkeypatch):
+    harness = Harness(
+        monkeypatch,
+        tail = "starting\n",
+        healthy = True,
+        startup_key = "sk-unsloth-minted",
+        chunk_bytes = 1024**3,
+        marker_at = 3,
+        ready_at = 40,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.mints == 1
+    assert harness.iterations >= 40
+
+
+def test_a_ready_banner_is_not_mistaken_for_a_child_that_needs_a_key(monkeypatch):
+    harness = Harness(
+        monkeypatch,
+        tail = f"API Key: sk-unsloth-old\nModel loaded: {MODEL}\n",
+        healthy = True,
+        startup_key = "sk-unsloth-minted",
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.mints == 0
+    assert harness.polls == 0

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -436,7 +436,7 @@ def test_an_older_child_is_polled_with_a_minted_key(monkeypatch):
     assert server is harness.server
     assert harness.shutdowns == []
     assert harness.mints == 1
-    assert harness.polls >= 40
+    assert harness.polls >= 39
     assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
 
 
@@ -446,7 +446,7 @@ def test_an_older_child_with_no_mintable_key_still_times_out(monkeypatch, capsys
     with pytest.raises(typer.Exit):
         harness.start()
 
-    assert harness.mints > 0
+    assert 0 < harness.mints <= start_cli._KEY_MINT_ATTEMPTS
     assert harness.polls == 0
     assert harness.shutdowns == [harness.server]
     assert f"made no progress for {start_cli._SERVER_START_TIMEOUT_S}s" in capsys.readouterr().err
@@ -483,3 +483,24 @@ def test_a_ready_banner_is_not_mistaken_for_a_child_that_needs_a_key(monkeypatch
     assert server is harness.server
     assert harness.mints == 0
     assert harness.polls == 0
+
+
+def test_a_marker_one_poll_behind_health_does_not_mint(monkeypatch):
+    # The child prints the marker just after its own health gate opens, so the loop can
+    # see a healthy server one pass before the line lands. That is a normal launch, not
+    # an older child, and it must not cost an extra key.
+    harness = Harness(
+        monkeypatch,
+        tail = "starting\n",
+        healthy = True,
+        startup_key = "sk-unsloth-minted",
+        chunk_bytes = 1024**3,
+        marker_at = 1,
+        ready_at = 40,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.mints == 0
+    assert harness.polls >= 38

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -95,6 +95,7 @@ class Harness:
         marker_at = None,
         ready_tail = None,
         flap_every = 0,
+        healthy_until = None,
         step = STEP_S,
     ):
         self.clock = FakeClock(step)
@@ -118,6 +119,7 @@ class Harness:
         self.startup_key_at = startup_key_at
         self.marker_at = marker_at
         self.flap_every = flap_every
+        self.healthy_until = healthy_until
         self.ready_tail = ready_tail or f"{KEY_LINE}Model loaded: {MODEL}\n"
         self.mints = 0
         self.server = FakePopen()
@@ -227,6 +229,11 @@ class Harness:
             with open(self.log_path, "ab") as handle:
                 handle.write(self.chatter(self.iterations).encode())
         if self.flap_every and self.iterations % self.flap_every == 0:
+            return False
+        if self.healthy_until is not None and self.iterations > self.healthy_until:
+            if self.ready_at is not None and self.iterations >= self.ready_at:
+                self.tail = self.ready_tail
+                return True
             return False
         if self.marker_at is not None and self.iterations >= self.marker_at:
             self.tail = KEY_LINE
@@ -574,3 +581,26 @@ def test_a_health_probe_that_times_out_under_load_does_not_retire_minting(monkey
     assert harness.shutdowns == []
     assert harness.mints == 1
     assert harness.polls > 0
+
+
+def test_one_healthy_answer_is_enough_to_start_minting(monkeypatch):
+    # Under download pressure the 3s health probe can miss every pass after the first.
+    # The marker grace period is wall clock, so that first answer is all it takes.
+    harness = Harness(
+        monkeypatch,
+        tail = "starting\n",
+        healthy = True,
+        healthy_until = 1,
+        startup_key = "sk-unsloth-minted",
+        chunk_bytes = 1024**3,
+        ready_at = 500,
+        step = 2.0,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.shutdowns == []
+    assert harness.mints == 1
+    assert harness.polls > 0
+    assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S

--- a/tests/studio/test_cli_start_download_liveness.py
+++ b/tests/studio/test_cli_start_download_liveness.py
@@ -122,6 +122,7 @@ class Harness:
         self.healthy_until = healthy_until
         self.ready_tail = ready_tail or f"{KEY_LINE}Model loaded: {MODEL}\n"
         self.mints = 0
+        self.calls = []
         self.server = FakePopen()
         self.iterations = 0
         self.polls = 0
@@ -152,6 +153,7 @@ class Harness:
             }
         if "download-progress" in url:
             self.polls += 1
+            self.calls.append("progress")
             if self.polls <= self.fail_first or (
                 self.fail_every and self.polls % self.fail_every == 0
             ):
@@ -220,6 +222,7 @@ class Harness:
         base,
         timeout = 3.0,
     ):
+        self.calls.append("health")
         self.iterations += 1
         assert self.iterations <= MAX_ITERATIONS, (
             f"readiness loop still running after {self.iterations} passes "
@@ -604,3 +607,23 @@ def test_one_healthy_answer_is_enough_to_start_minting(monkeypatch):
     assert harness.mints == 1
     assert harness.polls > 0
     assert harness.clock.elapsed > start_cli._SERVER_START_TIMEOUT_S
+
+
+def test_readiness_is_declared_on_a_health_answer_taken_after_the_progress_request(monkeypatch):
+    # A progress request can take seconds, so a health answer read before it is already
+    # stale when the loop decides the server is ready -- the child can have exited in
+    # between, and the agent would then be handed a dead server. Probe health last.
+    harness = Harness(
+        monkeypatch,
+        tail = "starting\n",
+        healthy = True,
+        startup_key = "sk-unsloth-minted",
+        chunk_bytes = 1024**3,
+        ready_at = 10,
+    )
+
+    server = harness.start()
+
+    assert server is harness.server
+    assert harness.polls > 0
+    assert harness.calls[-1] == "health", f"readiness read a stale probe: {harness.calls[-3:]}"

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1365,7 +1365,9 @@ def _start_studio_server(
                 _shutdown_auto_served()
                 _fail(f"The Unsloth server stopped before it was ready. Last log lines:\n{tail}")
             tail = _log_tail(log_path, lines = 400)
-            if progress is None:
+            healthy = _studio_healthy(base)
+            key = None
+            if not early_key_seen:
                 marker = re.search(
                     rf"^{re.escape(_START_API_KEY_PREFIX)}(sk-unsloth-[^\s]+)$",
                     tail,
@@ -1373,12 +1375,14 @@ def _start_studio_server(
                 )
                 if marker:
                     early_key_seen = True
-                    progress = _ModelDownloadProgress(
-                        base,
-                        marker.group(1),
-                        model,
-                        load.gguf_variant,
-                    )
+                    key = marker.group(1)
+            # New children emit an early key marker, so wait for the final model banner;
+            # older children only print the key after load, so fall back to that.
+            ready_signal = "Model loaded:" in tail if early_key_seen else "sk-unsloth-" in tail
+            if progress is None and key is None and healthy and not ready_signal:
+                key = _startup_api_key(base)
+            if progress is None and key:
+                progress = _ModelDownloadProgress(base, key, model, load.gguf_variant)
             if progress is not None:
                 progress.poll()
             # Fresh bytes are the one unambiguous sign the child is moving, so the cap
@@ -1390,10 +1394,7 @@ def _start_studio_server(
             if bytes_now > downloaded_bytes:
                 deadline = time.monotonic() + _SERVER_START_TIMEOUT_S
             downloaded_bytes = bytes_now
-            # New children emit an early key marker, so wait for the final model banner;
-            # older children only print the key after load, so fall back to that.
-            ready_signal = "Model loaded:" in tail if early_key_seen else "sk-unsloth-" in tail
-            if _studio_healthy(base) and ready_signal:
+            if healthy and ready_signal:
                 if progress is not None:
                     progress.complete()
                     progress.close()
@@ -1613,17 +1614,24 @@ def _remember_key(cache: Path, base: str, key: str, source: str) -> None:
         pass  # worst case the next launch mints another key
 
 
-def _key_accepted(base: str, key: str) -> bool:
-    # Only a genuine auth rejection (401/403) means "this key is bad -- skip it and try
-    # the next cached key or mint a fresh one". A 5xx or a network blip is a server-side
-    # outage, not a bad key: fail with a clean message (never a traceback) instead of
-    # silently discarding a working key and minting extras against a struggling server.
+def _key_works(base: str, key: str) -> bool:
     try:
         _http_json("GET", f"{base}/v1/models", key)
         return True
     except urllib.error.HTTPError as exc:
         if exc.code in (401, 403):
             return False
+        raise
+
+
+def _key_accepted(base: str, key: str) -> bool:
+    # Only a genuine auth rejection (401/403) means "this key is bad -- skip it and try
+    # the next cached key or mint a fresh one". A 5xx or a network blip is a server-side
+    # outage, not a bad key: fail with a clean message (never a traceback) instead of
+    # silently discarding a working key and minting extras against a struggling server.
+    try:
+        return _key_works(base, key)
+    except urllib.error.HTTPError as exc:
         _fail(
             f"Unsloth server error while checking an API key ({exc.code}). "
             "The server may be starting up or unhealthy; try again shortly."
@@ -1633,6 +1641,30 @@ def _key_accepted(base: str, key: str) -> bool:
             "Couldn't reach the Unsloth server while checking an API key: "
             f"{getattr(exc, 'reason', None) or exc}"
         )
+
+
+_MINTED_KEY_NAME = "Coding agents (unsloth start)"
+
+
+def _startup_api_key(base: str) -> Optional[str]:
+    if not is_loopback_url(base) or not verify_studio_identity(base):
+        return None
+    cache = _key_cache_path()
+    try:
+        for key in _cached_keys(cache, base, "minted"):
+            if _key_works(base, key):
+                return key
+        token = _studio_token()
+        if token is None:
+            return None
+        response = _http_json(
+            "POST", f"{base}/api/auth/api-keys", token, {"name": _MINTED_KEY_NAME}
+        )
+        key = response["key"]
+    except Exception:
+        return None
+    _remember_key(cache, base, key, "minted")
+    return key
 
 
 def _agent_api_key(
@@ -1696,7 +1728,7 @@ def _agent_api_key(
         "POST",
         f"{base}/api/auth/api-keys",
         token,
-        {"name": "Coding agents (unsloth start)"},
+        {"name": _MINTED_KEY_NAME},
         error = "Couldn't create an API key",
     )["key"]
     _remember_key(cache, base, key, "minted")

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1358,7 +1358,7 @@ def _start_studio_server(
     downloaded_bytes = 0
     early_key_seen = False
     healthy_polls = 0
-    mints = 0
+    next_mint = 0.0
     try:
         while time.monotonic() < deadline:
             if server.poll() is not None:
@@ -1368,7 +1368,7 @@ def _start_studio_server(
                 _fail(f"The Unsloth server stopped before it was ready. Last log lines:\n{tail}")
             tail = _log_tail(log_path, lines = 400)
             healthy = _studio_healthy(base)
-            healthy_polls = healthy_polls + 1 if healthy else 0
+            healthy_polls += 1 if healthy else 0
             key = None
             if not early_key_seen:
                 marker = re.search(
@@ -1382,18 +1382,20 @@ def _start_studio_server(
             # New children emit an early key marker, so wait for the final model banner;
             # older children only print the key after load, so fall back to that.
             ready_signal = "Model loaded:" in tail if early_key_seen else "sk-unsloth-" in tail
-            # A new child echoes the marker just after the health gate opens, so a single
-            # healthy poll doesn't mean it will never print one -- minting on the first
-            # one would race a normal launch into an extra key. Give it another pass, and
-            # cap the attempts so a server that never mints isn't asked once per sleep.
+            # A new child echoes the marker just after the health gate opens, so the
+            # first healthy poll doesn't mean it will never print one -- minting on that
+            # one would race a normal launch into an extra key. Count healthy polls
+            # rather than a streak, so a health probe that times out under load only
+            # delays this instead of retiring it, then keep retrying at a slow cadence:
+            # auth may only settle well after health does.
             if (
                 progress is None
                 and key is None
                 and healthy_polls > 1
                 and not ready_signal
-                and mints < _KEY_MINT_ATTEMPTS
+                and time.monotonic() >= next_mint
             ):
-                mints += 1
+                next_mint = time.monotonic() + _KEY_MINT_RETRY_S
                 key = _startup_api_key(base)
             if progress is None and key:
                 progress = _ModelDownloadProgress(base, key, model, load.gguf_variant)
@@ -1658,7 +1660,9 @@ def _key_accepted(base: str, key: str) -> bool:
 
 
 _MINTED_KEY_NAME = "Coding agents (unsloth start)"
-_KEY_MINT_ATTEMPTS = 3
+# Auth can lag the health gate on a cold start, and a loading server can time a
+# request out, so a failed mint is retried -- just not once per sleep.
+_KEY_MINT_RETRY_S = 30.0
 
 
 def _startup_api_key(base: str) -> Optional[str]:

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1635,9 +1635,13 @@ def _remember_key(cache: Path, base: str, key: str, source: str) -> None:
         pass  # worst case the next launch mints another key
 
 
-def _key_works(base: str, key: str) -> bool:
+def _key_works(
+    base: str,
+    key: str,
+    timeout: float = 30,
+) -> bool:
     try:
-        _http_json("GET", f"{base}/v1/models", key)
+        _http_json("GET", f"{base}/v1/models", key, timeout = timeout)
         return True
     except urllib.error.HTTPError as exc:
         if exc.code in (401, 403):
@@ -1678,8 +1682,15 @@ def _startup_api_key(base: str) -> Optional[str]:
     cache = _key_cache_path()
     try:
         for key in _cached_keys(cache, base, "minted"):
-            if _key_works(base, key):
-                return key
+            try:
+                # /v1/models builds the local model catalog off the filesystem, which the
+                # download saturating that disk can stall. A check that doesn't complete
+                # says nothing about the key, so mint a fresh one rather than give up on
+                # a startup this exists to keep alive.
+                if _key_works(base, key, timeout = 10):
+                    return key
+            except Exception:
+                break
         token = _studio_token()
         if token is None:
             return None

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1358,6 +1358,7 @@ def _start_studio_server(
     downloaded_bytes = 0
     early_key_seen = False
     first_healthy_at: Optional[float] = None
+    healthy = False
     next_mint = 0.0
     try:
         while time.monotonic() < deadline:
@@ -1367,7 +1368,8 @@ def _start_studio_server(
                 _shutdown_auto_served()
                 _fail(f"The Unsloth server stopped before it was ready. Last log lines:\n{tail}")
             tail = _log_tail(log_path, lines = 400)
-            healthy = _studio_healthy(base)
+            # Last pass's probe: the readiness check below wants a health answer taken
+            # after the progress request, so this loop only ever makes one per pass.
             if healthy and first_healthy_at is None:
                 first_healthy_at = time.monotonic()
             key = None
@@ -1412,6 +1414,7 @@ def _start_studio_server(
             if bytes_now > downloaded_bytes:
                 deadline = time.monotonic() + _SERVER_START_TIMEOUT_S
             downloaded_bytes = bytes_now
+            healthy = _studio_healthy(base)
             if healthy and ready_signal:
                 if progress is not None:
                     progress.complete()

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1357,7 +1357,7 @@ def _start_studio_server(
     progress: Optional[_ModelDownloadProgress] = None
     downloaded_bytes = 0
     early_key_seen = False
-    healthy_polls = 0
+    first_healthy_at: Optional[float] = None
     next_mint = 0.0
     try:
         while time.monotonic() < deadline:
@@ -1368,7 +1368,8 @@ def _start_studio_server(
                 _fail(f"The Unsloth server stopped before it was ready. Last log lines:\n{tail}")
             tail = _log_tail(log_path, lines = 400)
             healthy = _studio_healthy(base)
-            healthy_polls += 1 if healthy else 0
+            if healthy and first_healthy_at is None:
+                first_healthy_at = time.monotonic()
             key = None
             if not early_key_seen:
                 marker = re.search(
@@ -1382,16 +1383,17 @@ def _start_studio_server(
             # New children emit an early key marker, so wait for the final model banner;
             # older children only print the key after load, so fall back to that.
             ready_signal = "Model loaded:" in tail if early_key_seen else "sk-unsloth-" in tail
-            # A new child echoes the marker just after the health gate opens, so the
-            # first healthy poll doesn't mean it will never print one -- minting on that
-            # one would race a normal launch into an extra key. Count healthy polls
-            # rather than a streak, so a health probe that times out under load only
-            # delays this instead of retiring it, then keep retrying at a slow cadence:
-            # auth may only settle well after health does.
+            # A new child echoes the marker a moment after its own health gate opens, so
+            # minting the instant this loop sees health would race a normal launch into an
+            # extra key. Wait out a grace period measured from the first healthy answer --
+            # wall clock, not further healthy polls, since the 3s health probe can miss
+            # every pass under download load -- then retry at a slow cadence, because auth
+            # may only settle well after health does.
             if (
                 progress is None
                 and key is None
-                and healthy_polls > 1
+                and first_healthy_at is not None
+                and time.monotonic() - first_healthy_at >= _MARKER_GRACE_S
                 and not ready_signal
                 and time.monotonic() >= next_mint
             ):
@@ -1660,6 +1662,8 @@ def _key_accepted(base: str, key: str) -> bool:
 
 
 _MINTED_KEY_NAME = "Coding agents (unsloth start)"
+# The early key marker follows the child's own health gate by well under a second.
+_MARKER_GRACE_S = 5.0
 # Auth can lag the health gate on a cold start, and a loading server can time a
 # request out, so a failed mint is retried -- just not once per sleep.
 _KEY_MINT_RETRY_S = 30.0

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1357,6 +1357,8 @@ def _start_studio_server(
     progress: Optional[_ModelDownloadProgress] = None
     downloaded_bytes = 0
     early_key_seen = False
+    healthy_polls = 0
+    mints = 0
     try:
         while time.monotonic() < deadline:
             if server.poll() is not None:
@@ -1366,6 +1368,7 @@ def _start_studio_server(
                 _fail(f"The Unsloth server stopped before it was ready. Last log lines:\n{tail}")
             tail = _log_tail(log_path, lines = 400)
             healthy = _studio_healthy(base)
+            healthy_polls = healthy_polls + 1 if healthy else 0
             key = None
             if not early_key_seen:
                 marker = re.search(
@@ -1379,7 +1382,18 @@ def _start_studio_server(
             # New children emit an early key marker, so wait for the final model banner;
             # older children only print the key after load, so fall back to that.
             ready_signal = "Model loaded:" in tail if early_key_seen else "sk-unsloth-" in tail
-            if progress is None and key is None and healthy and not ready_signal:
+            # A new child echoes the marker just after the health gate opens, so a single
+            # healthy poll doesn't mean it will never print one -- minting on the first
+            # one would race a normal launch into an extra key. Give it another pass, and
+            # cap the attempts so a server that never mints isn't asked once per sleep.
+            if (
+                progress is None
+                and key is None
+                and healthy_polls > 1
+                and not ready_signal
+                and mints < _KEY_MINT_ATTEMPTS
+            ):
+                mints += 1
                 key = _startup_api_key(base)
             if progress is None and key:
                 progress = _ModelDownloadProgress(base, key, model, load.gguf_variant)
@@ -1644,6 +1658,7 @@ def _key_accepted(base: str, key: str) -> bool:
 
 
 _MINTED_KEY_NAME = "Coding agents (unsloth start)"
+_KEY_MINT_ATTEMPTS = 3
 
 
 def _startup_api_key(base: str) -> Optional[str]:

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -6473,8 +6473,7 @@ def test_startup_api_key_is_silent_when_identity_fails(fake_studio, monkeypatch,
     assert capsys.readouterr().err == ""
 
 
-def test_startup_api_key_swallows_a_server_outage(fake_studio, tmp_path, monkeypatch, capsys):
-    start._remember_key(tmp_path / "agent_api_key.json", BASE, "sk-unsloth-cached", "minted")
+def _outage_on(urls, monkeypatch, exc):
     inner = start._http_json
 
     def http_json(
@@ -6485,14 +6484,58 @@ def test_startup_api_key_swallows_a_server_outage(fake_studio, tmp_path, monkeyp
         timeout = 30,
         error = None,
     ):
-        if url.endswith("/v1/models"):
-            raise urllib.error.HTTPError(url, 503, "Service Unavailable", None, None)
+        if any(url.endswith(suffix) for suffix in urls):
+            raise exc(url)
         return inner(method, url, token, payload, timeout, error)
 
     monkeypatch.setattr(start, "_http_json", http_json)
 
+
+def test_startup_api_key_swallows_a_server_outage(fake_studio, tmp_path, monkeypatch, capsys):
+    start._remember_key(tmp_path / "agent_api_key.json", BASE, "sk-unsloth-cached", "minted")
+    _outage_on(
+        ("/v1/models", "/api/auth/api-keys"),
+        monkeypatch,
+        lambda url: urllib.error.HTTPError(url, 503, "Service Unavailable", None, None),
+    )
+
     assert start._startup_api_key(BASE) is None
     assert capsys.readouterr().err == ""
+
+
+def test_startup_api_key_mints_when_the_catalog_check_stalls(fake_studio, tmp_path, monkeypatch):
+    # /v1/models scans the filesystem, and the download this runs beside is what
+    # saturates that disk. A cached key that can't be checked must not retire the mint.
+    start._remember_key(tmp_path / "agent_api_key.json", BASE, "sk-unsloth-cached", "minted")
+    _outage_on(("/v1/models",), monkeypatch, lambda url: TimeoutError("timed out"))
+
+    assert start._startup_api_key(BASE) == "sk-unsloth-feedfacefeedface"
+
+
+def test_startup_api_key_checks_a_cached_key_on_a_short_timeout(fake_studio, tmp_path, monkeypatch):
+    # The readiness loop is waiting on this, so the catalog check gets the same 10s
+    # budget the progress requests use, not the 30s default the ready path can afford.
+    start._remember_key(tmp_path / "agent_api_key.json", BASE, "sk-unsloth-cached", "minted")
+    inner = start._http_json
+    timeouts = []
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        timeouts.append((url, timeout))
+        return inner(method, url, token, payload, timeout, error)
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+
+    assert start._startup_api_key(BASE) == "sk-unsloth-cached"
+    assert timeouts == [(f"{BASE}/v1/models", 10)]
+    assert start._key_accepted(BASE, "sk-unsloth-cached")
+    assert timeouts[-1] == (f"{BASE}/v1/models", 30)
 
 
 def test_session_config_no_launch_preserves_existing_state(fake_studio, tmp_path):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -6450,6 +6450,51 @@ def test_agent_api_key_auto_started_accepted_key_is_honored(fake_studio, tmp_pat
     assert cached["servers"][BASE]["saved"] == ["sk-unsloth-deadbeefdeadbeef"]
 
 
+def test_startup_api_key_mints_once_and_the_agent_key_replays_it(fake_studio):
+    key = start._startup_api_key(BASE)
+
+    assert key == "sk-unsloth-feedfacefeedface"
+    assert start._agent_api_key(BASE, None, auto_started = True) == key
+    assert len([c for c in fake_studio if c[1].endswith("/api/auth/api-keys")]) == 1
+
+
+def test_startup_api_key_replays_a_cached_minted_key(fake_studio, tmp_path):
+    start._remember_key(tmp_path / "agent_api_key.json", BASE, "sk-unsloth-cached", "minted")
+
+    assert start._startup_api_key(BASE) == "sk-unsloth-cached"
+    assert not any(c[1].endswith("/api/auth/api-keys") for c in fake_studio)
+
+
+def test_startup_api_key_is_silent_when_identity_fails(fake_studio, monkeypatch, capsys):
+    monkeypatch.setattr(start, "verify_studio_identity", lambda base: False)
+
+    assert start._startup_api_key(BASE) is None
+    assert fake_studio == []
+    assert capsys.readouterr().err == ""
+
+
+def test_startup_api_key_swallows_a_server_outage(fake_studio, tmp_path, monkeypatch, capsys):
+    start._remember_key(tmp_path / "agent_api_key.json", BASE, "sk-unsloth-cached", "minted")
+    inner = start._http_json
+
+    def http_json(
+        method,
+        url,
+        token,
+        payload = None,
+        timeout = 30,
+        error = None,
+    ):
+        if url.endswith("/v1/models"):
+            raise urllib.error.HTTPError(url, 503, "Service Unavailable", None, None)
+        return inner(method, url, token, payload, timeout, error)
+
+    monkeypatch.setattr(start, "_http_json", http_json)
+
+    assert start._startup_api_key(BASE) is None
+    assert capsys.readouterr().err == ""
+
+
 def test_session_config_no_launch_preserves_existing_state(fake_studio, tmp_path):
     # A previously printed recipe may still be running an agent whose sessions
     # or sqlite state live in the stable home; a re-run must not wipe it.


### PR DESCRIPTION
Follows #10453, which made the 15 minute startup cap measure time since the download last moved. When the server child never prints the early API key line, the CLI has no key to poll with until the load finishes, so a healthy download shows nothing and the cap can still stop it.

Once the server has been healthy for a moment without that line, the CLI now creates its own key through the existing local identity check, reusing a cached one when it has it, and polls download progress with that. The early key line still takes priority when it does appear, so a normal child behaves exactly as before.

The timing matters, because a new child echoes its key line a fraction of a second after its own health gate opens. Minting starts only after a 5 second grace period measured from the first healthy answer, so a normal launch never races that line into an extra key, and the grace period is wall clock rather than a count of healthy polls, because the 3 second health probe can miss passes while the download saturates the disk. A mint that fails, because auth has not settled yet or the server is busy, is retried every 30 seconds for the rest of the startup window rather than once per two second sleep or a fixed number of times. The cached key check goes to `/v1/models`, which builds the local catalog off that same disk, so it runs on a 10 second budget and a check that does not finish falls through to minting instead of giving up.

Tested with a throttled 17 minute download and the key line suppressed. Before this change the server was stopped at 900 seconds. With it, the download was tracked to the end and the server reached ready. Also checked against a July 2026 server that predates the key line: the key is created, progress is polled, and the model reaches ready. Servers that old also predate the padded load response, so their own 600 second load timeout ends a long download before this cap would.
