### PR TITLE
Studio: stop reading a success line like "Errors: 0" as a failed tool result

### DIFF
--- a/studio/backend/core/inference/tool_call_parser.py
+++ b/studio/backend/core/inference/tool_call_parser.py
@@ -118,7 +118,8 @@ _TOOL_ALL_PATS = _TOOL_CLOSED_PATS + [
 
 
 TOOL_ERROR_PREFIXES = (
-    "Error",
+    "Error:",
+    "Error ",
     "Search failed",
     "Execution error",
     "Blocked:",

--- a/studio/backend/tests/test_tool_loop_controller.py
+++ b/studio/backend/tests/test_tool_loop_controller.py
@@ -19,11 +19,12 @@ from core.inference.tool_loop_controller import (
     canonical_tool_call_key,
     coerce_arguments_by_schema,
     coerce_tool_arguments,
+    is_tool_error,
     status_for_tool,
     strip_result_for_model,
     tool_event_provenance,
 )
-from core.inference.tool_call_parser import parse_tool_calls_from_text
+from core.inference.tool_call_parser import TOOL_ERROR_NUDGE, parse_tool_calls_from_text
 from core.inference.tools import ALL_TOOLS, _mcp_specs_for_server
 
 
@@ -444,3 +445,30 @@ def test_a_declared_type_nested_in_a_container_is_read_too():
     # An already-typed container is descended into too: its elements can still be text.
     call = {"path": "app.py", "edits": json.loads(edits)}
     assert coerce_arguments_by_schema(call, props) == {"path": "app.py", "edits": typed}
+
+
+@pytest.mark.parametrize(
+    "result, failed",
+    [
+        ("Error: boom", True),
+        ("  Error: boom", True),
+        ("Error executing tool remote_thing: disk full", True),
+        ("Error running command `git push`: permission denied", True),
+        ("Errors: 0", False),
+        ("Errors: none found", False),
+        ("Errored, then recovered", False),
+        ("Error-free run", False),
+    ],
+)
+def test_only_a_delimited_error_marks_a_result_failed(result, failed):
+    assert is_tool_error(result) is failed
+
+
+def test_a_success_that_opens_with_error_is_not_nudged_as_a_failure():
+    controller = ToolLoopController(tools = [_tool("web_search")])
+    decision = controller.prepare_call(_call("web_search", {"url": "https://example.com/log"}))
+
+    completion = controller.record_result(decision, "Errors: 0 across 128 files")
+
+    assert not completion.is_error
+    assert TOOL_ERROR_NUDGE not in completion.model_message()["content"]

--- a/studio/backend/tests/test_tool_result_fits_window.py
+++ b/studio/backend/tests/test_tool_result_fits_window.py
@@ -2095,7 +2095,7 @@ class TestWhatTheLoopAppendsIsPricedToo:
         from core.inference.tool_call_parser import TOOL_ERROR_NUDGE
 
         # The same length, so the only thing between them is the nudge one of them will be
-        # given: "Error" is a `TOOL_ERROR_PREFIXES` entry and "Alpha" is not.
+        # given: "Error: " opens with a `TOOL_ERROR_PREFIXES` entry and "Alpha: " does not.
         failed = self._fitted(monkeypatch, "Error: ")
         fine = self._fitted(monkeypatch, "Alpha: ")
 


### PR DESCRIPTION
The list of error prefixes contained a bare "Error", so any tool output starting with those five letters was treated as a failed call. A build log that begins "Errors: 0" got a retry nudge, and in Deep Research the fetched page was dropped from the sources with no trace.

The prefix now matches "Error:" and "Error " only. Real errors from tools and MCP servers still match, since they write "Error: ..." or "Error running ...". Outputs like "Errors: 0" and "Error-free" no longer do.
