### PR TITLE
Studio: avoid hidden PowerShell arguments in CLI setup and updates

### DIFF
--- a/tests/studio/test_installer_av_shapes.py
+++ b/tests/studio/test_installer_av_shapes.py
@@ -98,6 +98,9 @@ def test_no_encoded_or_base64_command_payloads(name: str) -> None:
 def test_a_hidden_window_never_pairs_with_a_bypassed_policy(name: str) -> None:
     # Microsoft's detections key on this pair;
     # install.rs already refuses it for the app's own launch.
+    # Python setup/refresh argv is exercised at the subprocess boundary by
+    # unsloth_cli/tests/test_studio_runtime_gate_powershell.py::
+    # test_windows_launch_uses_process_flags_without_windowstyle.
     for number, line in enumerate(_text(name).splitlines(), start = 1):
         if re.search(r"-WindowStyle\s+Hidden", line, re.IGNORECASE):
             assert not re.search(

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -4068,7 +4068,9 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
         # and a profile that aliases uv or python would break setup.ps1.
         powershell_args.append("-NoProfile")
         if _should_hide_windows_subprocesses():
-            powershell_args.extend(["-NoLogo", "-NonInteractive", "-WindowStyle", "Hidden"])
+            # CREATE_NO_WINDOW below hides the console without pairing
+            # -WindowStyle Hidden with -ExecutionPolicy Bypass.
+            powershell_args.extend(["-NoLogo", "-NonInteractive"])
         # Use -Command + `*>&1` (not -File) so setup.ps1's Write-Host output
         # (Information stream #6) merges into stdout. -File drops it when
         # stdout is a pipe, e.g. `unsloth studio update --local 2>&1 | tee`.
@@ -4269,7 +4271,8 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         # branch left the visible console path, where a profile is exactly what IS loaded.
         ps_argv.append("-NoProfile")
         if _should_hide_windows_subprocesses():
-            ps_argv.extend(["-NoLogo", "-NonInteractive", "-WindowStyle", "Hidden"])
+            # Both local and fetched runners set CREATE_NO_WINDOW.
+            ps_argv.extend(["-NoLogo", "-NonInteractive"])
 
         # Stops at the first candidate that launched; only an unlaunchable one moves on.
         if any(_run_installer_ps1(script, args, ps_argv, env) for script in checkouts):

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -4068,8 +4068,8 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
         # and a profile that aliases uv or python would break setup.ps1.
         powershell_args.append("-NoProfile")
         if _should_hide_windows_subprocesses():
-            # CREATE_NO_WINDOW below hides the console without pairing
-            # -WindowStyle Hidden with -ExecutionPolicy Bypass.
+            # Match install.rs: avoid the Hidden/Bypass detection pair.
+            # CREATE_NO_WINDOW below already hides the console.
             powershell_args.extend(["-NoLogo", "-NonInteractive"])
         # Use -Command + `*>&1` (not -File) so setup.ps1's Write-Host output
         # (Information stream #6) merges into stdout. -File drops it when
@@ -4271,7 +4271,8 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         # branch left the visible console path, where a profile is exactly what IS loaded.
         ps_argv.append("-NoProfile")
         if _should_hide_windows_subprocesses():
-            # Both local and fetched runners set CREATE_NO_WINDOW.
+            # Avoid the same Hidden/Bypass detection pair as setup above;
+            # both local and fetched runners set CREATE_NO_WINDOW.
             ps_argv.extend(["-NoLogo", "-NonInteractive"])
 
         # Stops at the first candidate that launched; only an unlaunchable one moves on.

--- a/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
+++ b/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
@@ -151,7 +151,11 @@ def test_the_launcher_refresh_spawns_the_resolved_interpreter(monkeypatch, tmp_p
 def test_windows_launch_uses_process_flags_without_windowstyle(
     monkeypatch, tmp_path, interactive, flow
 ):
-    """Inspect the actual handoffs, including refresh's separate -Command/-File paths."""
+    """Cover Python argv for test_installer_av_shapes.py's Hidden/Bypass rule.
+
+    Inspect the actual handoffs, including refresh's separate -Command/-File paths;
+    the shell-script scan cannot see arguments assembled across Python functions.
+    """
     studio = _windows_studio(monkeypatch)
     monkeypatch.setattr(studio.sys.stdout, "isatty", lambda: interactive)
     monkeypatch.setattr(studio.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising = False)

--- a/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
+++ b/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Regression coverage for Unsloth's PowerShell resolution (#9440)."""
+"""Regression coverage for Unsloth's PowerShell resolution and launch arguments."""
 
 import ntpath
 import os
@@ -69,6 +69,8 @@ def _windows_studio(monkeypatch):
 
 
 class _Process:
+    returncode = 0
+
     def wait(self):
         return 0
 
@@ -142,3 +144,76 @@ def test_the_launcher_refresh_spawns_the_resolved_interpreter(monkeypatch, tmp_p
     studio._refresh_desktop_shortcuts()
 
     assert spawned and spawned[0][0] == _RESOLVED, spawned
+
+
+@pytest.mark.parametrize("interactive", [False, True], ids = ["redirected", "console"])
+@pytest.mark.parametrize("flow", ["setup", "local-refresh", "fetched-refresh"])
+def test_windows_launch_uses_process_flags_without_windowstyle(
+    monkeypatch, tmp_path, interactive, flow
+):
+    """Inspect the actual handoffs, including refresh's separate -Command/-File paths."""
+    studio = _windows_studio(monkeypatch)
+    monkeypatch.setattr(studio.sys.stdout, "isatty", lambda: interactive)
+    monkeypatch.setattr(studio.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising = False)
+    monkeypatch.setattr(studio, "_with_studio_uv_cache", lambda env, **kw: env)
+    monkeypatch.setattr(studio, "_backfill_uv_cache_marker", lambda env: None)
+    monkeypatch.setattr(studio, "_probe_profile_proxy_defaults", lambda hosts: None)
+
+    repo_root = tmp_path / "owner's repo"
+    (repo_root / "studio").mkdir(parents = True)
+    setup_script = repo_root / "studio" / "setup.ps1"
+    setup_script.write_text("", encoding = "utf-8")
+    installer = repo_root / "install.ps1"
+    installer.write_text("", encoding = "utf-8")
+    fetched = b"Write-Output 'refresh'"
+    spawned = []
+
+    def capture(argv, **kwargs):
+        spawned.append((list(argv), kwargs))
+        if "-File" in argv:
+            path = Path(argv[argv.index("-File") + 1])
+            assert path.read_bytes() == b"\xef\xbb\xbf" + fetched
+        return _Process()
+
+    monkeypatch.setattr(studio.subprocess, "Popen", capture)
+    monkeypatch.setattr(studio.subprocess, "run", capture)
+    if flow == "setup":
+        studio._run_setup_script(repo_root = repo_root)
+    else:
+        monkeypatch.setattr(
+            studio,
+            "_installers_on_disk",
+            lambda candidates: [installer] if flow == "local-refresh" else [],
+        )
+        monkeypatch.setattr(studio, "_fetch_installer", lambda *a, **kw: fetched)
+        studio._refresh_desktop_shortcuts()
+
+    assert len(spawned) == 1
+    argv, kwargs = spawned[0]
+    assert argv[0] == _RESOLVED
+    assert "-NoProfile" in argv
+    assert "-WindowStyle" not in argv
+    assert argv[argv.index("-ExecutionPolicy") + 1] == "Bypass"
+    if interactive:
+        assert "-NonInteractive" not in argv
+        assert "creationflags" not in kwargs
+        assert "startupinfo" not in kwargs
+    else:
+        assert "-NonInteractive" in argv
+        assert "-NoLogo" in argv
+        assert kwargs["creationflags"] & 0x08000000
+    if flow == "fetched-refresh":
+        script_path = Path(argv[argv.index("-File") + 1])
+        assert argv[-1] == "--shortcuts-only"
+        assert not script_path.exists()
+    else:
+        script = setup_script if flow == "setup" else installer
+        quoted = str(script).replace("'", "''")
+        command = argv[argv.index("-Command") + 1]
+        assert f"& '{quoted}'" in command
+        assert command.endswith("*>&1")
+        if flow == "local-refresh":
+            assert "--shortcuts-only" in command
+        else:
+            assert "stdout" in kwargs
+            assert "stderr" in kwargs


### PR DESCRIPTION
## Problem

Studio's Windows installer and Desktop Rust launcher already avoid pairing `-WindowStyle Hidden` with `-ExecutionPolicy Bypass`, documenting the combination as a Microsoft detection signature. The CLI still assembled that pair. The existing installer AV-shape guard scans shell scripts, so it did not cover Python-generated arguments.

This path runs during Desktop updates: `spawn_update` in `studio/src-tauri/src/update.rs` pipes the CLI's stdout, making `sys.stdout.isatty()` false and selecting the hidden-launch branch for `setup.ps1`. The same subprocess already receives `CREATE_NO_WINDOW`, so removing the PowerShell window-style argument preserves console suppression.

The CLI has two argument builders and three affected handoffs: `setup.ps1`, a local `install.ps1 --shortcuts-only`, and a downloaded installer used when no local copy is available. Shortcut refresh applies to standalone updates; Tauri-initiated updates skip that refresh.

## Change

Remove `-WindowStyle Hidden` from both CLI argument builders. Redirected launches keep `CREATE_NO_WINDOW`, `-NoLogo` and `-NonInteractive`. Interactive launches keep their existing behavior.

The setup and local-refresh paths retain their `-Command` quoting and `*>&1` output handling. Downloaded refresh retains `-File`, UTF-8 BOM encoding and temporary-script cleanup. Execution policy is unchanged. Switching these paths to `RemoteSigned` needs separate path-origin compatibility work.

Both call sites now explain the launch policy. The behavioral regression test and the shell-script guard cross-reference each other so their complementary coverage is visible.

## Verification

- Six behavioral cases exercise the actual setup, local-refresh and fetched-refresh handoffs with console and redirected output, capturing subprocess arguments and creation flags.
- Against the previous implementation, all three redirected cases fail because `-WindowStyle` is present; the three console cases pass.
- Focused PowerShell launch, shortcut refresh, uv-cache handoff, Windows update-launcher and installer AV-shape suites: 197 passed, 6 skipped on Linux. Windows-only execution checks were skipped.
- Repository lint and formatting hooks passed.
- `git diff --check` passed.

## Scope

This brings the CLI setup and refresh launches into line with the existing Hidden/Bypass rule. It does not remove the installer native helper's runtime C# compilation, change path resolution or process detection, or repair denied caches and missing Python packages. Compiler removal is being addressed separately in #10540.

The packaged Windows application and Bitdefender were not tested. This is not a claim that the reported antivirus block is resolved.
