### PR TITLE
Bound RAG scope retirement by folder identity, not by the clock

### DIFF
--- a/studio/backend/core/rag/folder_sync.py
+++ b/studio/backend/core/rag/folder_sync.py
@@ -72,11 +72,6 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def now_iso() -> str:
-    """The timestamp format linked-folder rows are written and compared with."""
-    return _now()
-
-
 def _hash_file(path: str) -> str:
     digest = hashlib.sha256()
     with open(path, "rb") as source:
@@ -564,10 +559,34 @@ def _metadata_table_exists(conn, table: str) -> bool:
     )
 
 
+# SQLite's default host-parameter cap is 999, so a bound id list is applied in chunks.
+_ID_CHUNK = 500
+
+
+def _id_chunks(folder_ids: list[str]) -> list[list[str]]:
+    unique = list(dict.fromkeys(folder_ids))
+    return [unique[start : start + _ID_CHUNK] for start in range(0, len(unique), _ID_CHUNK)]
+
+
+def linked_folder_ids(scope: str) -> list[str]:
+    """The folders a scope owns right now, for bounding a later retirement to them.
+
+    Metadata connection, like retirement itself: the caller runs on the delete path, which
+    has to finish even when the vector extension cannot load.
+    """
+    with closing(rag_db.get_metadata_connection()) as conn:
+        if not _metadata_table_exists(conn, "linked_folders"):
+            return []
+        return [
+            row["id"]
+            for row in conn.execute("SELECT id FROM linked_folders WHERE scope=?", (scope,))
+        ]
+
+
 def _retire_scope_rows(
     conn,
     scope: str,
-    linked_before: str | None = None,
+    folder_ids: list[str] | None = None,
 ) -> None:
     folders_exist = _metadata_table_exists(conn, "linked_folders")
     jobs_exist = folders_exist and _metadata_table_exists(conn, "linked_folder_sync_jobs")
@@ -575,31 +594,39 @@ def _retire_scope_rows(
         "INSERT OR IGNORE INTO linked_folder_retired_scopes(scope, retired_at) VALUES(?, ?)",
         (scope, _now()),
     )
-    # the ownership check and this write cannot share a transaction across two databases
-    bound = "" if linked_before is None else " AND created_at<=?"
-    params = () if linked_before is None else (linked_before,)
-    if folders_exist:
-        conn.execute(
-            "UPDATE linked_folders SET auto_sync=0, status='retired', "
-            f"last_error='Owning scope was removed', updated_at=? WHERE scope=?{bound}",
-            (_now(), scope, *params),
-        )
-    if jobs_exist:
-        conn.execute(
-            "UPDATE linked_folder_sync_jobs SET status='failed', stage='error', "
-            "error='Owning scope was removed', successor_kind=NULL, completed_at=? "
-            "WHERE folder_id IN (SELECT id FROM linked_folders WHERE scope=?"
-            f"{bound}) AND (status IN ('pending','running') OR successor_kind IS NOT NULL)",
-            (_now(), scope, *params),
-        )
+    # The ownership check and this write cannot share a transaction across two databases, so
+    # the caller bounds the write to the folders it saw. Identity, not a timestamp: Windows
+    # reads its clock in ~15.6ms steps, so a folder linked by another process just after the
+    # check carries the check's own created_at, and any comparison has to guess which side of
+    # the boundary it belongs on. Guessing wrong here retires the new folders of a project
+    # recreated with the same id, and nothing ever puts them back.
+    # None means no bound at all; an empty list means the caller saw no folders.
+    batches = [None] if folder_ids is None else _id_chunks(folder_ids)
+    for batch in batches:
+        bound = "" if batch is None else f" AND id IN ({','.join('?' * len(batch))})"
+        params = () if batch is None else tuple(batch)
+        if folders_exist:
+            conn.execute(
+                "UPDATE linked_folders SET auto_sync=0, status='retired', "
+                f"last_error='Owning scope was removed', updated_at=? WHERE scope=?{bound}",
+                (_now(), scope, *params),
+            )
+        if jobs_exist:
+            conn.execute(
+                "UPDATE linked_folder_sync_jobs SET status='failed', stage='error', "
+                "error='Owning scope was removed', successor_kind=NULL, completed_at=? "
+                "WHERE folder_id IN (SELECT id FROM linked_folders WHERE scope=?"
+                f"{bound}) AND (status IN ('pending','running') OR successor_kind IS NOT NULL)",
+                (_now(), scope, *params),
+            )
 
 
-def retire_scope(scope: str, linked_before: str | None = None) -> None:
+def retire_scope(scope: str, folder_ids: list[str] | None = None) -> None:
     """Stop all future work, even when the vector extension cannot load."""
     conn = _retirement_connection()
     try:
         conn.execute("BEGIN IMMEDIATE")
-        _retire_scope_rows(conn, scope, linked_before)
+        _retire_scope_rows(conn, scope, folder_ids)
         conn.commit()
     except Exception:
         conn.rollback()
@@ -741,10 +768,10 @@ def reconcile_retired_scopes(project_exists) -> dict[str, list[str]]:
             # rechecked inside the lock create_folder takes: a project recreated with the same id must not have
             # its new folders retired
             with _scope_lock(scope):
-                checked_at = _now()
+                owned = linked_folder_ids(scope)
                 if project_exists(project_id):
                     continue
-                retire_scope(scope, checked_at)
+                retire_scope(scope, owned)
             retired_scopes.add(scope)
             retired.append(scope)
         except Exception:

--- a/studio/backend/core/rag/folder_sync.py
+++ b/studio/backend/core/rag/folder_sync.py
@@ -587,8 +587,9 @@ def _retire_scope_rows(
     conn,
     scope: str,
     folder_ids: list[str] | None = None,
+    rows: bool = True,
 ) -> None:
-    folders_exist = _metadata_table_exists(conn, "linked_folders")
+    folders_exist = rows and _metadata_table_exists(conn, "linked_folders")
     jobs_exist = folders_exist and _metadata_table_exists(conn, "linked_folder_sync_jobs")
     conn.execute(
         "INSERT OR IGNORE INTO linked_folder_retired_scopes(scope, retired_at) VALUES(?, ?)",
@@ -619,12 +620,18 @@ def _retire_scope_rows(
             )
 
 
-def retire_scope(scope: str, folder_ids: list[str] | None = None) -> None:
-    """Stop all future work, even when the vector extension cannot load."""
+def retire_scope(scope: str, folder_ids: list[str] | None = None, rows: bool = True) -> None:
+    """Stop all future work, even when the vector extension cannot load.
+
+    `rows = False` writes only the tombstone, which is already enough to stop new links and
+    uploads, and is the only half a caller can take back: `unretire_scope` deletes it, while
+    the folder and job updates overwrite state nobody recorded. A caller whose ownership check
+    can still go stale takes the tombstone first and comes back for the rest.
+    """
     conn = _retirement_connection()
     try:
         conn.execute("BEGIN IMMEDIATE")
-        _retire_scope_rows(conn, scope, folder_ids)
+        _retire_scope_rows(conn, scope, folder_ids, rows)
         conn.commit()
     except Exception:
         conn.rollback()

--- a/studio/backend/core/rag/folder_sync.py
+++ b/studio/backend/core/rag/folder_sync.py
@@ -571,8 +571,8 @@ def _id_chunks(folder_ids: list[str]) -> list[list[str]]:
 def linked_folder_ids(scope: str) -> list[str]:
     """The folders a scope owns right now, for bounding a later retirement to them.
 
-    Metadata connection, like retirement itself: the caller runs on the delete path, which
-    has to finish even when the vector extension cannot load.
+    Metadata connection, like retirement itself: the delete path has to finish even when the
+    vector extension cannot load.
     """
     with closing(rag_db.get_metadata_connection()) as conn:
         if not _metadata_table_exists(conn, "linked_folders"):
@@ -594,12 +594,10 @@ def _retire_scope_rows(
         "INSERT OR IGNORE INTO linked_folder_retired_scopes(scope, retired_at) VALUES(?, ?)",
         (scope, _now()),
     )
-    # The ownership check and this write cannot share a transaction across two databases, so
-    # the caller bounds the write to the folders it saw. Identity, not a timestamp: Windows
-    # reads its clock in ~15.6ms steps, so a folder linked by another process just after the
-    # check carries the check's own created_at, and any comparison has to guess which side of
-    # the boundary it belongs on. Guessing wrong here retires the new folders of a project
-    # recreated with the same id, and nothing ever puts them back.
+    # The ownership check and this write cannot share a transaction across two databases, so the
+    # caller bounds the write to the folders it saw. Identity, not created_at: Windows reads its
+    # clock in ~15.6ms steps, so a folder linked just after the check carries the check's own
+    # timestamp, and retiring it disables RAG for a project recreated with the same id, for good.
     # None means no bound at all; an empty list means the caller saw no folders.
     batches = [None] if folder_ids is None else _id_chunks(folder_ids)
     for batch in batches:

--- a/studio/backend/core/rag/folder_sync.py
+++ b/studio/backend/core/rag/folder_sync.py
@@ -620,7 +620,11 @@ def _retire_scope_rows(
             )
 
 
-def retire_scope(scope: str, folder_ids: list[str] | None = None, rows: bool = True) -> None:
+def retire_scope(
+    scope: str,
+    folder_ids: list[str] | None = None,
+    rows: bool = True,
+) -> None:
     """Stop all future work, even when the vector extension cannot load.
 
     `rows = False` writes only the tombstone, which is already enough to stop new links and

--- a/studio/backend/core/rag/folder_sync.py
+++ b/studio/backend/core/rag/folder_sync.py
@@ -627,10 +627,9 @@ def retire_scope(
 ) -> None:
     """Stop all future work, even when the vector extension cannot load.
 
-    `rows = False` writes only the tombstone, which is already enough to stop new links and
-    uploads, and is the only half a caller can take back: `unretire_scope` deletes it, while
-    the folder and job updates overwrite state nobody recorded. A caller whose ownership check
-    can still go stale takes the tombstone first and comes back for the rest.
+    `rows = False` writes only the tombstone: enough on its own to stop new links and uploads,
+    and the only half a caller can take back, since the folder and job updates overwrite state
+    nobody recorded. A caller whose ownership check can still go stale takes it first.
     """
     conn = _retirement_connection()
     try:

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -1151,7 +1151,12 @@ def _delete_project_rag_sources(project_id: str) -> None:
         # sparing the new folders above buys nothing unless it is skipped too. Recheck rather
         # than bound it: a recreated project wants its scope back whole, and the periodic
         # reconciler already refuses to purge a scope whose owner exists.
-        if rag_db.rag_available() and get_chat_project(project_id) is None:
+        if get_chat_project(project_id) is not None:
+            # And drop the tombstone this pass just wrote, rather than only skipping the purge:
+            # scope_retired reads it, so the recreated project would have its uploads 409ed and
+            # its folder links refused until the reconciler comes round, up to 30s later.
+            folder_sync.unretire_scope(scope)
+        elif rag_db.rag_available():
             folder_sync.delete_retired_scope(scope)
 
 

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -1143,10 +1143,10 @@ def _delete_project_rag_sources(project_id: str) -> None:
     # a project id is reusable, and the tombstone outlives the scope, so retiring one that
     # another client already recreated would permanently disable RAG for the new project
     with folder_sync.scope_lock(scope):
-        checked_at = folder_sync.now_iso()
+        owned = folder_sync.linked_folder_ids(scope)
         if get_chat_project(project_id) is not None:
             return
-        folder_sync.retire_scope(scope, checked_at)
+        folder_sync.retire_scope(scope, owned)
     if rag_db.rag_available():
         folder_sync.delete_retired_scope(scope)
 

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -1146,17 +1146,18 @@ def _delete_project_rag_sources(project_id: str) -> None:
         owned = folder_sync.linked_folder_ids(scope)
         if get_chat_project(project_id) is not None:
             return
+        # Tombstone first, folder rows after one more look. The tombstone alone already stops
+        # new links and uploads, and it is the only half that can be taken back: retiring the
+        # rows overwrites status, auto_sync and last_error that nobody recorded, and a retired
+        # row also makes create_folder refuse that path forever.
+        folder_sync.retire_scope(scope, owned, rows = False)
+        if get_chat_project(project_id) is not None:
+            folder_sync.unretire_scope(scope)
+            return
         folder_sync.retire_scope(scope, owned)
         # The purge deletes every folder and document under the scope, `owned` or not, so
-        # sparing the new folders above buys nothing unless it is skipped too. Recheck rather
-        # than bound it: a recreated project wants its scope back whole, and the periodic
-        # reconciler already refuses to purge a scope whose owner exists.
-        if get_chat_project(project_id) is not None:
-            # And drop the tombstone this pass just wrote, rather than only skipping the purge:
-            # scope_retired reads it, so the recreated project would have its uploads 409ed and
-            # its folder links refused until the reconciler comes round, up to 30s later.
-            folder_sync.unretire_scope(scope)
-        elif rag_db.rag_available():
+        # bounding retirement buys nothing unless the purge is skipped as well.
+        if rag_db.rag_available():
             folder_sync.delete_retired_scope(scope)
 
 

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -1146,17 +1146,16 @@ def _delete_project_rag_sources(project_id: str) -> None:
         owned = folder_sync.linked_folder_ids(scope)
         if get_chat_project(project_id) is not None:
             return
-        # Tombstone first, folder rows after one more look. The tombstone alone already stops
-        # new links and uploads, and it is the only half that can be taken back: retiring the
-        # rows overwrites status, auto_sync and last_error that nobody recorded, and a retired
-        # row also makes create_folder refuse that path forever.
+        # Tombstone first, rows after one more look: the tombstone already stops new links and
+        # uploads and is the only half `unretire_scope` can take back, while a retired row
+        # keeps auto_sync off and makes create_folder refuse that path for good.
         folder_sync.retire_scope(scope, owned, rows = False)
         if get_chat_project(project_id) is not None:
             folder_sync.unretire_scope(scope)
             return
         folder_sync.retire_scope(scope, owned)
-        # The purge deletes every folder and document under the scope, `owned` or not, so
-        # bounding retirement buys nothing unless the purge is skipped as well.
+        # The purge takes the whole scope, `owned` or not, so bounding retirement buys nothing
+        # unless the purge is skipped too.
         if rag_db.rag_available():
             folder_sync.delete_retired_scope(scope)
 

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -1147,8 +1147,12 @@ def _delete_project_rag_sources(project_id: str) -> None:
         if get_chat_project(project_id) is not None:
             return
         folder_sync.retire_scope(scope, owned)
-    if rag_db.rag_available():
-        folder_sync.delete_retired_scope(scope)
+        # The purge deletes every folder and document under the scope, `owned` or not, so
+        # sparing the new folders above buys nothing unless it is skipped too. Recheck rather
+        # than bound it: a recreated project wants its scope back whole, and the periodic
+        # reconciler already refuses to purge a scope whose owner exists.
+        if rag_db.rag_available() and get_chat_project(project_id) is None:
+            folder_sync.delete_retired_scope(scope)
 
 
 @router.delete("/projects/{project_id}", response_model = ChatProjectDeleted)

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -2327,10 +2327,11 @@ def test_a_project_recreated_during_delete_keeps_its_rag_scope(rag_home, monkeyp
 def test_the_purge_is_skipped_for_a_project_recreated_after_the_ownership_check(
     rag_home, monkeypatch
 ):
-    """The purge deletes the whole scope, so the retirement bound is moot unless it is skipped.
+    """A recreated project must be left exactly as the delete found it, not merely unpurged.
 
-    The reconciler already refuses to purge a scope whose owner exists; this is the same
-    guard on the delete route, which reached the purge unconditionally.
+    The reconciler already refuses to purge a scope whose owner exists; this is the same guard
+    on the delete route, which reached the purge unconditionally. Aborting has to put back
+    everything the pass did, which is why only the tombstone is written before this recheck.
     """
     from routes import chat_history
 
@@ -2349,7 +2350,15 @@ def test_the_purge_is_skipped_for_a_project_recreated_after_the_ownership_check(
 
     chat_history._delete_project_rag_sources("p1")
 
-    assert folder_sync.get_folder(folder["id"]) is not None
+    survivor = folder_sync.get_folder(folder["id"])
+    assert survivor is not None
+    # untouched, not just undeleted: a retired row keeps auto_sync off and makes create_folder
+    # refuse that path for good, so an abort that leaves one behind is not an abort
+    assert (survivor["status"], survivor["auto_sync"], survivor["last_error"]) == (
+        folder["status"],
+        folder["auto_sync"],
+        None,
+    )
     assert seen["checks"] == 2
     # and the scope is usable again immediately, not once the reconciler next runs
     assert folder_sync.scope_retired(scope) is False

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -2352,8 +2352,7 @@ def test_the_purge_is_skipped_for_a_project_recreated_after_the_ownership_check(
 
     survivor = folder_sync.get_folder(folder["id"])
     assert survivor is not None
-    # untouched, not just undeleted: a retired row keeps auto_sync off and makes create_folder
-    # refuse that path for good, so an abort that leaves one behind is not an abort
+    # untouched, not just undeleted: a retired row left behind is not an abort
     assert (survivor["status"], survivor["auto_sync"], survivor["last_error"]) == (
         folder["status"],
         folder["auto_sync"],

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -2324,6 +2324,36 @@ def test_a_project_recreated_during_delete_keeps_its_rag_scope(rag_home, monkeyp
 
 
 @requires_sqlite_vec
+def test_the_purge_is_skipped_for_a_project_recreated_after_the_ownership_check(
+    rag_home, monkeypatch
+):
+    """The purge deletes the whole scope, so the retirement bound is moot unless it is skipped.
+
+    The reconciler already refuses to purge a scope whose owner exists; this is the same
+    guard on the delete route, which reached the purge unconditionally.
+    """
+    from routes import chat_history
+
+    scope = store.project_scope("p1")
+    source = rag_home / "relinked-by-the-new-project"
+    source.mkdir()
+    seen = {"checks": 0}
+
+    def recreated_after_the_check(project_id):
+        # gone for the check that decides to retire, back by the time the purge asks
+        seen["checks"] += 1
+        return None if seen["checks"] == 1 else {"id": project_id}
+
+    folder = folder_sync.create_folder(scope_type = "project", scope_id = "p1", path = str(source))
+    monkeypatch.setattr(chat_history, "get_chat_project", recreated_after_the_check)
+
+    chat_history._delete_project_rag_sources("p1")
+
+    assert folder_sync.get_folder(folder["id"]) is not None
+    assert seen["checks"] == 2
+
+
+@requires_sqlite_vec
 def test_reconciliation_restores_a_scope_whose_project_came_back(rag_home):
     scope = store.project_scope("p1")
     source = rag_home / "recreated-project"

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -2374,16 +2374,104 @@ def test_retirement_leaves_a_folder_linked_after_the_ownership_check(rag_home):
     source = rag_home / "before-check"
     source.mkdir()
     existing = folder_sync.create_folder(scope_type = "project", scope_id = "p1", path = str(source))
-    checked_at = folder_sync.now_iso()
+    owned = folder_sync.linked_folder_ids(scope)
     # a second backend process links this one after the check and before the write
     later = rag_home / "after-check"
     later.mkdir()
     fresh = folder_sync.create_folder(scope_type = "project", scope_id = "p1", path = str(later))
 
-    folder_sync.retire_scope(scope, checked_at)
+    folder_sync.retire_scope(scope, owned)
 
     assert folder_sync.get_folder(existing["id"])["status"] == "retired"
     survivor = folder_sync.get_folder(fresh["id"])
     assert survivor["status"] == fresh["status"]
     assert survivor["auto_sync"] == fresh["auto_sync"]
     assert survivor["last_error"] is None
+
+
+@requires_sqlite_vec
+def test_the_ownership_bound_survives_a_clock_that_cannot_separate_the_two(rag_home, monkeypatch):
+    """Windows reads its clock in ~15.6ms steps, so both links can share one timestamp.
+
+    This froze `_now` outright, which is that quantisation taken to its limit: any bound
+    derived from the clock has to guess here, and guessing that the second link predates the
+    check retires the folders of a project recreated with the same id, permanently.
+    """
+    scope = store.project_scope("p1")
+    monkeypatch.setattr(folder_sync, "_now", lambda: "2026-01-01T00:00:00+00:00")
+    for name in ("before-check", "after-check"):
+        (rag_home / name).mkdir()
+    existing = folder_sync.create_folder(
+        scope_type = "project", scope_id = "p1", path = str(rag_home / "before-check")
+    )
+    owned = folder_sync.linked_folder_ids(scope)
+    fresh = folder_sync.create_folder(
+        scope_type = "project", scope_id = "p1", path = str(rag_home / "after-check")
+    )
+    assert existing["created_at"] == fresh["created_at"]
+
+    folder_sync.retire_scope(scope, owned)
+
+    assert folder_sync.get_folder(existing["id"])["status"] == "retired"
+    assert folder_sync.get_folder(fresh["id"])["status"] == fresh["status"]
+
+
+@requires_sqlite_vec
+def test_an_empty_ownership_snapshot_retires_nothing_but_still_tombstones(rag_home):
+    """`None` means no bound; `[]` means the check saw no folders, and is not the same thing."""
+    scope = store.project_scope("p1")
+    (rag_home / "linked-late").mkdir()
+    fresh = folder_sync.create_folder(
+        scope_type = "project", scope_id = "p1", path = str(rag_home / "linked-late")
+    )
+
+    folder_sync.retire_scope(scope, [])
+
+    assert folder_sync.scope_retired(scope) is True
+    assert folder_sync.get_folder(fresh["id"])["status"] == fresh["status"]
+
+
+@requires_sqlite_vec
+def test_the_ownership_bound_is_applied_past_the_sqlite_parameter_cap(rag_home, monkeypatch):
+    """A scope with more folders than SQLite takes host parameters still retires all of them."""
+    scope = store.project_scope("p1")
+    monkeypatch.setattr(folder_sync, "_ID_CHUNK", 3)
+    folders = []
+    for index in range(7):
+        source = rag_home / f"folder-{index}"
+        source.mkdir()
+        folders.append(
+            folder_sync.create_folder(scope_type = "project", scope_id = "p1", path = str(source))
+        )
+    owned = folder_sync.linked_folder_ids(scope)
+    assert len(owned) == len(folders)
+
+    folder_sync.retire_scope(scope, owned)
+
+    assert [folder_sync.get_folder(f["id"])["status"] for f in folders] == ["retired"] * 7
+
+
+@requires_sqlite_vec
+def test_the_ownership_snapshot_survives_an_unloadable_vector_extension(rag_home, monkeypatch):
+    """Retirement is the delete path, and it already runs without sqlite-vec loaded.
+
+    The snapshot the bound is built from has to hold to that too, or a project delete starts
+    failing exactly when the extension is missing, which is when it least can.
+    """
+    scope = store.project_scope("p1")
+    source = rag_home / "linked"
+    source.mkdir()
+    folder = folder_sync.create_folder(scope_type = "project", scope_id = "p1", path = str(source))
+
+    def unavailable():
+        raise sqlite3.OperationalError("cannot load sqlite-vec")
+
+    # scoped, not monkeypatch.undo(): rag_home patches through the same fixture, and undoing
+    # it here would put the database path back before the assertions read it
+    with monkeypatch.context() as no_vec:
+        no_vec.setattr(folder_sync.rag_db, "get_connection", unavailable)
+        owned = folder_sync.linked_folder_ids(scope)
+        folder_sync.retire_scope(scope, owned)
+
+    assert owned == [folder["id"]]
+    assert folder_sync.get_folder(folder["id"])["status"] == "retired"

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -2351,6 +2351,8 @@ def test_the_purge_is_skipped_for_a_project_recreated_after_the_ownership_check(
 
     assert folder_sync.get_folder(folder["id"]) is not None
     assert seen["checks"] == 2
+    # and the scope is usable again immediately, not once the reconciler next runs
+    assert folder_sync.scope_retired(scope) is False
 
 
 @requires_sqlite_vec

--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -2393,9 +2393,8 @@ def test_retirement_leaves_a_folder_linked_after_the_ownership_check(rag_home):
 def test_the_ownership_bound_survives_a_clock_that_cannot_separate_the_two(rag_home, monkeypatch):
     """Windows reads its clock in ~15.6ms steps, so both links can share one timestamp.
 
-    This froze `_now` outright, which is that quantisation taken to its limit: any bound
-    derived from the clock has to guess here, and guessing that the second link predates the
-    check retires the folders of a project recreated with the same id, permanently.
+    Freezing `_now` is that quantisation at its limit: any clock-derived bound has to guess,
+    and guessing wrong retires the folders of a project recreated with the same id, for good.
     """
     scope = store.project_scope("p1")
     monkeypatch.setattr(folder_sync, "_now", lambda: "2026-01-01T00:00:00+00:00")
@@ -2453,11 +2452,7 @@ def test_the_ownership_bound_is_applied_past_the_sqlite_parameter_cap(rag_home, 
 
 @requires_sqlite_vec
 def test_the_ownership_snapshot_survives_an_unloadable_vector_extension(rag_home, monkeypatch):
-    """Retirement is the delete path, and it already runs without sqlite-vec loaded.
-
-    The snapshot the bound is built from has to hold to that too, or a project delete starts
-    failing exactly when the extension is missing, which is when it least can.
-    """
+    """Retirement already runs without sqlite-vec loaded, so the snapshot must too."""
     scope = store.project_scope("p1")
     source = rag_home / "linked"
     source.mkdir()
@@ -2466,8 +2461,8 @@ def test_the_ownership_snapshot_survives_an_unloadable_vector_extension(rag_home
     def unavailable():
         raise sqlite3.OperationalError("cannot load sqlite-vec")
 
-    # scoped, not monkeypatch.undo(): rag_home patches through the same fixture, and undoing
-    # it here would put the database path back before the assertions read it
+    # scoped, not monkeypatch.undo(): rag_home patches through the same fixture, so undoing
+    # here would restore the database path before the assertions read it
     with monkeypatch.context() as no_vec:
         no_vec.setattr(folder_sync.rag_db, "get_connection", unavailable)
         owned = folder_sync.linked_folder_ids(scope)


### PR DESCRIPTION
`Uploads (windows-latest)` went red on `test_retirement_leaves_a_folder_linked_after_the_ownership_check` with `assert 'retired' == 'pending'`. The test is right and the code is wrong, in a way that only Windows can show.

## The bound cannot be a timestamp

`reconcile_retired_scopes` and `_delete_project_rag_sources` both decide "this scope is ownerless" and then write in a second transaction against a different database. The two cannot share a transaction, so the write is bounded to what the check saw. That bound was `created_at<=?` against the instant of the check.

Windows reads its clock in ~15.6ms steps, so two calls inside one step return the identical string. A folder linked by another backend process just after the check therefore carries the check's own `created_at`, falls on the wrong side of `<=`, and is retired with `auto_sync=0` and `last_error='Owning scope was removed'`. That is precisely the case the bound exists to prevent: `chat_history.py` says it in as many words, "a project id is reusable, and the tombstone outlives the scope, so retiring one that another client already recreated would permanently disable RAG for the new project". Nothing repairs it either. The next reconcile pass sees the owner and calls `unretire_scope`, which drops the tombstone but leaves the folder rows retired for good.

Flipping to `<` only moves the damage: a folder that genuinely predates the check would be spared whenever the two share a step. A clock this coarse cannot decide the question in either direction.

## Bound by identity

The caller snapshots the folder ids it can see, inside the scope lock it already holds, and retirement writes only those. A folder inserted after the snapshot is not in the set, which states the intended semantics exactly rather than approximating it with a comparison. `None` still means no bound at all, and an empty list means the check saw no folders, which are different things. The list is applied in chunks so a scope holding more folders than SQLite accepts host parameters still retires all of them.

The snapshot reads through `get_metadata_connection`, the same connection retirement itself uses, because this runs on the delete path and that path already has to finish when the vector extension will not load.

`now_iso` existed only to build the old bound, so it goes with it. `retire_scope`'s second parameter is renamed; both call sites are in this diff.

## Verification

- The failing test now passes on any clock. A new test freezes `_now` outright, which is that quantisation taken to its limit and holds the Windows condition on every platform. Against the code before this change it reproduces the CI failure verbatim, `AssertionError: assert 'retired' == 'pending'`; against this change it passes.
- Two further tests cover the parameter-cap chunking and the snapshot running with `get_connection` raising, which is the state the delete path must survive.
- `studio/backend/tests/test_rag_linked_folders.py` 90 passed, plus `test_rag_ingestion.py`, `test_chat_history_routes.py` and `test_rag_project_source_upload.py` green. The full backend suite is running.

No UI, HTTP route shape or browser code changes, so this has no browser dimension.

## Known remaining gap

`_reauthorize_folder` reuses the existing row id when the recreated project relinks the same
path, so that row is still in the snapshot and is still retired. The bound it replaces had the
same hole, since reauthorization leaves `created_at` alone, so nothing here regresses. Closing it
needs either a fresh id on reauthorization, which `linked_folder_files` and
`linked_folder_sync_jobs` reference, or a separate authorization generation column. Both are
larger than this diff.

The residual window between the purge's owner recheck and its commit is #10567: narrowed here,
not closed, and closing it is a project-lifecycle decision rather than a retirement one.
