### PR TITLE
Stop a blocked sentencepiece extension from silently changing prompt formatting

### DIFF
--- a/studio/backend/core/inference/chat_template_helpers.py
+++ b/studio/backend/core/inference/chat_template_helpers.py
@@ -3380,6 +3380,31 @@ def apply_chat_template_for_generation(
         raise
 
 
+# Windows loader errors that mean the image was refused rather than missing: 577
+# ERROR_INVALID_IMAGE_HASH is Smart App Control and App Control for Business, 225
+# ERROR_VIRUS_INFECTED is an antivirus blocking on access, 1260 is AppLocker or SRP.
+_BLOCKED_IMAGE_WINERRORS = frozenset({225, 577, 1260})
+
+
+def _looks_like_a_blocked_import(exc: BaseException | None) -> bool:
+    """Whether an exception is a native module that would not load.
+
+    The winerror is checked first because it is unambiguous; the text match is the
+    fallback for a wrapper that re-raises without one, which is what a tokenizer class
+    raising ImportError from its own backend guard looks like. The chain is walked
+    because transformers wraps the original.
+    """
+    while exc is not None:
+        if getattr(exc, "winerror", None) in _BLOCKED_IMAGE_WINERRORS:
+            return True
+        if isinstance(exc, ImportError):
+            text = str(exc).lower()
+            if "dll load failed" in text or "sentencepiece" in text:
+                return True
+        exc = exc.__cause__ or exc.__context__
+    return False
+
+
 def resolve_native_chat_template(
     model_info: dict,
     active_model_name,
@@ -3411,7 +3436,25 @@ def resolve_native_chat_template(
         )
         native_tpl = nt.chat_template or False
     except Exception as exc:
-        logger.warning("Could not load native chat template for '%s': %s", template_source, exc)
+        # A tokenizer that will not build is not always a network problem. Smart App
+        # Control blocks sentencepiece's compiled extension by reputation, and the
+        # import error that follows arrived here as one warning among many while the
+        # model went on generating under a substituted template: wrong prompt
+        # formatting, and nothing naming the cause. Named at error level instead, since
+        # nothing downstream can recover from it and the user can act on it.
+        if _looks_like_a_blocked_import(exc):
+            logger.error(
+                "Could not load the native chat template for '%s' because a Python "
+                "extension would not load: %s. Prompt formatting falls back to a "
+                "generic template until this is resolved. If Windows blocked the file "
+                "(Smart App Control or antivirus), allow it and restart.",
+                template_source,
+                exc,
+            )
+        else:
+            logger.warning(
+                "Could not load native chat template for '%s': %s", template_source, exc
+            )
         # A failed fetch is not "no template": leave the sentinel unset so the next call
         # retries (caching False would pin the tool-dropping override).
         return None

--- a/studio/backend/core/inference/chat_template_helpers.py
+++ b/studio/backend/core/inference/chat_template_helpers.py
@@ -3386,21 +3386,39 @@ def apply_chat_template_for_generation(
 _BLOCKED_IMAGE_WINERRORS = frozenset({225, 577, 1260})
 
 
-def _looks_like_a_blocked_import(exc: BaseException | None) -> bool:
-    """Whether an exception is a native module that would not load.
+"""Loader wording, for the case where the winerror did not survive the re-raise.
 
-    The winerror is checked first because it is unambiguous; the text match is the
-    fallback for a wrapper that re-raises without one, which is what a tokenizer class
-    raising ImportError from its own backend guard looks like. The chain is walked
-    because transformers wraps the original.
+Deliberately not the package name. "sentencepiece" appears in the ordinary message
+transformers emits when the package is simply not installed, and calling that a
+security block would tell an operator to go looking through their antivirus for a
+file that was never there. Only a refusal to load an image counts.
+"""
+_BLOCKED_IMAGE_PHRASES = (
+    "dll load failed",
+    "is not a valid win32 application",
+    "cannot verify the digital signature",
+    "blocked by",
+    "violated code integrity",
+)
+
+
+def _looks_like_a_blocked_import(exc: Optional[BaseException]) -> bool:
+    """Whether an exception is a native module the loader refused.
+
+    Optional[...] rather than the PEP 604 spelling: this module has no
+    ``from __future__ import annotations`` and the project floor is 3.9, where the
+    union is evaluated at definition time and would stop the module importing.
+
+    The winerror is checked first because it is unambiguous. The wording match is the
+    fallback for a wrapper that re-raised without one. The chain is walked because
+    transformers raises its own error from the original.
     """
     while exc is not None:
         if getattr(exc, "winerror", None) in _BLOCKED_IMAGE_WINERRORS:
             return True
-        if isinstance(exc, ImportError):
-            text = str(exc).lower()
-            if "dll load failed" in text or "sentencepiece" in text:
-                return True
+        text = str(exc).lower()
+        if any(phrase in text for phrase in _BLOCKED_IMAGE_PHRASES):
+            return True
         exc = exc.__cause__ or exc.__context__
     return False
 

--- a/studio/backend/core/inference/chat_template_helpers.py
+++ b/studio/backend/core/inference/chat_template_helpers.py
@@ -3452,9 +3452,7 @@ def resolve_native_chat_template(
                 exc,
             )
         else:
-            logger.warning(
-                "Could not load native chat template for '%s': %s", template_source, exc
-            )
+            logger.warning("Could not load native chat template for '%s': %s", template_source, exc)
         # A failed fetch is not "no template": leave the sentinel unset so the next call
         # retries (caching False would pin the tool-dropping override).
         return None

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -248,7 +248,6 @@ if sys.platform == "win32":
     # there rather than here keeps the CLI and the backend on one implementation.
     try:
         from unsloth.import_fixes import disable_sentencepiece_if_blocked
-
         disable_sentencepiece_if_blocked()
     except Exception:
         pass

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -240,14 +240,17 @@ if sys.platform == "win32":
     # transformers decides the package is available from find_spec and metadata alone,
     # so is_sentencepiece_available() answers True while every import of it raises. The
     # quiet consequence is a model generating under a substituted chat template, since
-    # get_native_chat_template catches the failure. Corrected here, at the top of the
+    # resolve_native_chat_template catches the failure. Corrected here, at the top of
     # process, so no tokenizer is ever built while the flag still reads True.
     #
     # Windows only, so no other platform pays the probe, and a no-op unless the import
-    # really fails. The unsloth package is installed into this venv; the guard living
-    # there rather than here keeps the CLI and the backend on one implementation.
+    # really fails. Deliberately NOT unsloth.import_fixes, which carries the same guard
+    # for pip users: importing it would run unsloth/__init__.py, whose GPU branch pulls
+    # torch, Triton, transformers and the model stack into this long-lived parent and can
+    # open a competing GPU context. The ML work happens in spawned workers and the parent
+    # stays light. utils.sentencepiece_guard imports nothing heavy.
     try:
-        from unsloth.import_fixes import disable_sentencepiece_if_blocked
+        from utils.sentencepiece_guard import disable_sentencepiece_if_blocked
         disable_sentencepiece_if_blocked()
     except Exception:
         pass

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -235,6 +235,24 @@ if _STUDIO_ROOT_RESOLVED != _LEGACY_STUDIO_ROOT:
 # lazy submodule imports and the DiffusionGemma runner don't trip the install guard.
 os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
 
+if sys.platform == "win32":
+    # Smart App Control blocks sentencepiece's compiled extension by reputation, and
+    # transformers decides the package is available from find_spec and metadata alone,
+    # so is_sentencepiece_available() answers True while every import of it raises. The
+    # quiet consequence is a model generating under a substituted chat template, since
+    # get_native_chat_template catches the failure. Corrected here, at the top of the
+    # process, so no tokenizer is ever built while the flag still reads True.
+    #
+    # Windows only, so no other platform pays the probe, and a no-op unless the import
+    # really fails. The unsloth package is installed into this venv; the guard living
+    # there rather than here keeps the CLI and the backend on one implementation.
+    try:
+        from unsloth.import_fixes import disable_sentencepiece_if_blocked
+
+        disable_sentencepiece_if_blocked()
+    except Exception:
+        pass
+
 import hashlib
 import ipaddress
 import mimetypes

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -235,25 +235,31 @@ if _STUDIO_ROOT_RESOLVED != _LEGACY_STUDIO_ROOT:
 # lazy submodule imports and the DiffusionGemma runner don't trip the install guard.
 os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
 
-if sys.platform == "win32":
-    # Smart App Control blocks sentencepiece's compiled extension by reputation, and
-    # transformers decides the package is available from find_spec and metadata alone,
-    # so is_sentencepiece_available() answers True while every import of it raises. The
-    # quiet consequence is a model generating under a substituted chat template, since
-    # resolve_native_chat_template catches the failure. Corrected here, at the top of
-    # process, so no tokenizer is ever built while the flag still reads True.
-    #
-    # Windows only, so no other platform pays the probe, and a no-op unless the import
-    # really fails. Deliberately NOT unsloth.import_fixes, which carries the same guard
-    # for pip users: importing it would run unsloth/__init__.py, whose GPU branch pulls
-    # torch, Triton, transformers and the model stack into this long-lived parent and can
-    # open a competing GPU context. The ML work happens in spawned workers and the parent
-    # stays light. utils.sentencepiece_guard imports nothing heavy.
-    try:
-        from utils.sentencepiece_guard import disable_sentencepiece_if_blocked
-        disable_sentencepiece_if_blocked()
-    except Exception:
-        pass
+# Smart App Control blocks sentencepiece's compiled extension by reputation, and
+# transformers decides the package is available from find_spec and metadata alone, so
+# is_sentencepiece_available() answers True while every import of it raises. The quiet
+# consequence is a model generating under a substituted chat template, since
+# resolve_native_chat_template catches the failure. Corrected here, at the top of process,
+# so no tokenizer is ever built while the flag still reads True.
+#
+# As a temporary measure sentencepiece is off by DEFAULT on Windows rather than only when a
+# block is detected, so the extension is never touched there; UNSLOTH_DISABLE_SENTENCEPIECE=0
+# puts it back, and even then a genuinely refused import is still caught.
+#
+# Called on every platform rather than under a `win32` branch, because the flag is honoured
+# everywhere and a branch here would silently ignore it off Windows. It costs nothing there:
+# with no flag set the guard returns without importing anything.
+#
+# Deliberately NOT unsloth.import_fixes, which carries the same guard for pip users:
+# importing it would run unsloth/__init__.py, whose GPU branch pulls torch, Triton,
+# transformers and the model stack into this long-lived parent and can open a competing GPU
+# context. The ML work happens in spawned workers and the parent stays light.
+# utils.sentencepiece_guard imports nothing heavy.
+try:
+    from utils.sentencepiece_guard import disable_sentencepiece_if_blocked
+    disable_sentencepiece_if_blocked()
+except Exception:
+    pass
 
 import hashlib
 import ipaddress

--- a/studio/backend/tests/test_native_template_blocked_extension.py
+++ b/studio/backend/tests/test_native_template_blocked_extension.py
@@ -71,7 +71,9 @@ def test_an_ordinary_failure_is_not_mistaken_for_a_block():
 def test_a_missing_optional_package_is_not_a_block():
     """An ImportError naming a package nobody installed is not a refusal, and it already
     has a good message of its own."""
-    assert helpers._looks_like_a_blocked_import(ImportError("No module named 'flash_attn'")) is False
+    assert (
+        helpers._looks_like_a_blocked_import(ImportError("No module named 'flash_attn'")) is False
+    )
 
 
 def test_a_blocked_extension_is_reported_at_error_level(monkeypatch, caplog):
@@ -118,10 +120,7 @@ def test_an_ordinary_failure_still_logs_a_warning(monkeypatch, caplog):
     monkeypatch.setitem(sys.modules, "transformers", module)
 
     with caplog.at_level(logging.WARNING):
-        assert helpers.resolve_native_chat_template(
-            model_info,
-            "unsloth/Qwen3.5-2B",
-        ) is None
+        assert helpers.resolve_native_chat_template(model_info, "unsloth/Qwen3.5-2B") is None
 
     assert [r for r in caplog.records if r.levelno == logging.WARNING]
     assert not [r for r in caplog.records if r.levelno >= logging.ERROR]

--- a/studio/backend/tests/test_native_template_blocked_extension.py
+++ b/studio/backend/tests/test_native_template_blocked_extension.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A native extension the loader refuses, arriving at the native chat template lookup.
+
+Smart App Control blocked ``_sentencepiece.cp313-win_amd64.pyd`` on a reporting machine
+(Code Integrity event 3077, publisher Unknown, signature type None). The field report
+records that it "failed silently": no error surfaced and inference continued. That is
+this catch. ``AutoTokenizer.from_pretrained`` raises the ImportError from inside the
+tokenizer machinery, everything is caught, a warning is logged among many, None is
+returned, and the model goes on generating under a substituted chat template. The
+symptom is wrong prompt formatting with nothing naming the cause.
+
+The template still falls back, because nothing here can invent a template that is not
+loadable. What changes is that the line naming the blocked file is an error the operator
+can act on rather than one warning in a stream of them.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+from core.inference import chat_template_helpers as helpers  # noqa: E402
+
+
+def _blocked(winerror = 577):
+    """What a refused module load looks like by the time it reaches this catch."""
+    error = ImportError(
+        "DLL load failed while importing _sentencepiece: "
+        "Windows cannot verify the digital signature for this file."
+    )
+    error.winerror = winerror
+    return error
+
+
+@pytest.mark.parametrize("winerror", [225, 577, 1260])
+def test_every_refusal_code_is_recognised(winerror: int):
+    """577 is App Control and Smart App Control, 225 is an antivirus blocking on access,
+    1260 is AppLocker or SRP. All three mean the same thing to a user: the file is there
+    and Windows will not load it."""
+    assert helpers._looks_like_a_blocked_import(_blocked(winerror)) is True
+
+
+def test_a_wrapped_refusal_is_still_recognised():
+    """transformers raises its own error from the original, so the winerror is a link or
+    two down the chain rather than on the exception that arrives here."""
+    original = _blocked()
+    try:
+        try:
+            raise original
+        except ImportError as exc:
+            raise RuntimeError("could not build a tokenizer") from exc
+    except RuntimeError as wrapper:
+        assert helpers._looks_like_a_blocked_import(wrapper) is True
+
+
+def test_an_ordinary_failure_is_not_mistaken_for_a_block():
+    """The common case by far is a network error or a gated repository, and calling that
+    a security block would send every operator looking at their antivirus."""
+    assert helpers._looks_like_a_blocked_import(OSError("connection reset")) is False
+    assert helpers._looks_like_a_blocked_import(ValueError("no such revision")) is False
+    assert helpers._looks_like_a_blocked_import(None) is False
+
+
+def test_a_missing_optional_package_is_not_a_block():
+    """An ImportError naming a package nobody installed is not a refusal, and it already
+    has a good message of its own."""
+    assert helpers._looks_like_a_blocked_import(ImportError("No module named 'flash_attn'")) is False
+
+
+def test_a_blocked_extension_is_reported_at_error_level(monkeypatch, caplog):
+    """The behaviour that changes. Before this the line was a warning identical in shape
+    to a failed fetch, and the model kept generating under a substituted template with
+    nothing to point at."""
+    model_info: dict = {}
+
+    class _RaisingAutoTokenizer:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise _blocked()
+
+    module = type(sys)("transformers")
+    module.AutoTokenizer = _RaisingAutoTokenizer
+    monkeypatch.setitem(sys.modules, "transformers", module)
+
+    with caplog.at_level(logging.WARNING):
+        result = helpers.resolve_native_chat_template(
+            model_info,
+            "unsloth/Qwen3.5-2B",
+        )
+
+    assert result is None
+    blocked = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert blocked, "a refused extension must not read as an ordinary fetch failure"
+    assert "extension" in blocked[0].getMessage()
+    # Still not cached: a caching of False would pin the substituted template for the
+    # rest of the session, so allowing the file and restarting would not be enough.
+    assert "native_chat_template" not in model_info
+
+
+def test_an_ordinary_failure_still_logs_a_warning(monkeypatch, caplog):
+    """The other side of the branch, so the escalation cannot swallow the common case."""
+    model_info: dict = {}
+
+    class _RaisingAutoTokenizer:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise OSError("connection reset by peer")
+
+    module = type(sys)("transformers")
+    module.AutoTokenizer = _RaisingAutoTokenizer
+    monkeypatch.setitem(sys.modules, "transformers", module)
+
+    with caplog.at_level(logging.WARNING):
+        assert helpers.resolve_native_chat_template(
+            model_info,
+            "unsloth/Qwen3.5-2B",
+        ) is None
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]

--- a/studio/backend/utils/sentencepiece_guard.py
+++ b/studio/backend/utils/sentencepiece_guard.py
@@ -231,7 +231,10 @@ def tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
             # By key as well as by identity. Identity alone misses an entry transformers
             # built from a different callable, and key alone would rewrite an unrelated
             # backend, so either match is enough but the name is checked too.
-            if entry[0] is original or str(key).split(">")[0].split("=")[0].strip() == "sentencepiece":
+            if (
+                entry[0] is original
+                or str(key).split(">")[0].split("=")[0].strip() == "sentencepiece"
+            ):
                 mapping[key] = (_sentencepiece_is_absent,) + tuple(entry[1:])
 
     try:

--- a/studio/backend/utils/sentencepiece_guard.py
+++ b/studio/backend/utils/sentencepiece_guard.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Tell transformers sentencepiece is absent when Windows will not load its extension.
+"""Tell transformers sentencepiece is absent on Windows, or when its extension is refused.
 
 Standalone on purpose. The same guard exists in ``unsloth.import_fixes`` for people who
 installed the pip package, but importing it from here would run ``unsloth/__init__.py``,
 whose GPU branch pulls in torch, Triton, transformers and the model stack. The Studio
 parent is deliberately light because the ML work happens in spawned workers, so that
 would add a full stack to the long-lived process and can open a competing GPU context
-on the machines least able to afford one. Nothing imported here is heavy, and on a
-machine where the extension loads nothing at all is imported.
+on the machines least able to afford one. Nothing imported here is heavy. Where the
+correction applies, ``transformers.utils.import_utils`` is imported so the flag can be
+set before any tokenizer is built; that is transformers' pure-python availability module
+and pulls in no torch, and it is what makes the correction land at all.
 
 The two copies must agree; ``tests/studio/test_sentencepiece_guard_parity.py`` holds
 them to the same error codes and the same decision.
@@ -19,8 +21,13 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import logging
+import os
 import sys
 import warnings
+from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # Windows loader errors that mean "this image was refused", not "this file is broken".
 # 577 ERROR_INVALID_IMAGE_HASH is Smart App Control and App Control for Business, 225
@@ -29,10 +36,45 @@ import warnings
 # message can name a cause; every failure to load the extension is handled the same way.
 BLOCKED_IMAGE_WINERRORS = frozenset({225, 577, 1260})
 
-_RESULT: bool | None = None
+_RESULT: Optional[bool] = None
+
+# On Windows the extension is disabled by DEFAULT, not only when its load is refused. A
+# deliberate temporary measure: the refusals arrive faster than they can be diagnosed one
+# machine at a time, they are silent here in particular (a substituted chat template, not
+# an error), and the cost of going without is now small. transformers 4.57.6 gates 67
+# tokenizer entries on sentencepiece and 5.x gates 8; across the 93 models the Unsloth
+# notebooks use, 3 break without it on 4.57.6 and none on 5.5.0 or 5.10.4.
+#
+# The package stays installed and installable. This flag is the way back.
+DISABLE_SENTENCEPIECE_VARIABLE = "UNSLOTH_DISABLE_SENTENCEPIECE"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"0", "false", "no", "off"})
 
 
-def smart_app_control_state() -> int | None:
+def sentencepiece_disabled_by_policy() -> Optional[str]:
+    """Why policy disables sentencepiece here, or None to leave it to the import probe.
+
+    ``"environment"`` when ``UNSLOTH_DISABLE_SENTENCEPIECE`` is truthy, which applies on
+    every platform, and ``"windows"`` for the platform default. Off Windows there is no
+    default, and WSL reports ``linux``, so a WSL session is treated as the Linux box it is
+    rather than inheriting a Windows policy that has no loader to justify it.
+
+    An unrecognised value falls back to the platform default rather than raising. This
+    runs at the top of the Studio process, where a typo in an environment variable must
+    not cost the user the backend.
+
+    A falsy value only says policy is not disabling it. It cannot re-enable an extension
+    the loader refuses, because the caller runs the block detection afterwards either way.
+    """
+    value = (os.environ.get(DISABLE_SENTENCEPIECE_VARIABLE) or "").strip().lower()
+    if value in _TRUTHY:
+        return "environment"
+    if value in _FALSY:
+        return None
+    return "windows" if sys.platform == "win32" else None
+
+
+def smart_app_control_state() -> Optional[int]:
     """Smart App Control's state: 0 off, 1 enforced, 2 evaluation, or None if unknown.
 
     Read from ``HKLM\\SYSTEM\\CurrentControlSet\\Control\\CI\\Policy``, which a standard
@@ -63,7 +105,7 @@ def smart_app_control_state() -> int | None:
     return value if isinstance(value, int) else None
 
 
-def sentencepiece_import_error() -> BaseException | None:
+def sentencepiece_import_error() -> Optional[BaseException]:
     """The exception importing sentencepiece raises here, or None when it imports.
 
     Windows only, and only when the package is installed: everywhere else the answer is
@@ -87,6 +129,37 @@ def sentencepiece_import_error() -> BaseException | None:
     except Exception as exception:
         return exception
     return None
+
+
+def _materialise_tokenizer_mapping(import_utils) -> None:
+    """Import transformers' auto tokenizer module before the flag is changed.
+
+    Ordering is load bearing, and the intuitive order is the wrong one. On 4.52 through
+    4.57, ``models/auto/tokenization_auto.py`` evaluates ``is_sentencepiece_available()``
+    while building ``TOKENIZER_MAPPING_NAMES`` (71 times in 4.57.6). Patch first and the
+    slow entries are built as ``None``; ``tokenizer_class_from_name`` then misses the
+    mapping and falls through to the dummy-class fallback, which does
+    ``importlib.import_module("transformers")`` and reaches an unguarded top level
+    ``import sentencepiece as spm`` in the slow tokenizer module. The user gets the raw
+    loader error the guard exists to prevent. Measured on 4.57.6 with the extension
+    blocked: no patch fails, patching first fails identically, patching after this import
+    loads the tokenizer.
+
+    On 5.x the mapping gates only 8 model types and every ordering works, so doing it
+    unconditionally costs nothing and keeps one code path.
+
+    Only for the real transformers module. The synthetic modules the parity tests pass in
+    must not drag the real package into the process, or the tests stop testing the shapes
+    they claim to.
+    """
+    if not getattr(import_utils, "__name__", "").startswith("transformers"):
+        return
+    try:
+        importlib.import_module("transformers.models.auto.tokenization_auto")
+    except Exception:
+        # A transformers too broken to import its own auto module is not something to
+        # fail on here; the caller still patches, and the flag is still corrected.
+        pass
 
 
 def tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
@@ -117,6 +190,10 @@ def tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
     original = getattr(import_utils, "is_sentencepiece_available", None)
     if original is None:
         return False
+
+    # Before anything is rebound. See the helper: on 4.x the mapping must already be
+    # built, or the correction sends the user into the loader error instead of past it.
+    _materialise_tokenizer_mapping(import_utils)
 
     if hasattr(import_utils, "_sentencepiece_available"):
         import_utils._sentencepiece_available = False
@@ -149,7 +226,12 @@ def tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
     mapping = getattr(import_utils, "BACKENDS_MAPPING", None)
     if isinstance(mapping, dict):
         for key, entry in list(mapping.items()):
-            if isinstance(entry, tuple) and entry and entry[0] is original:
+            if not isinstance(entry, tuple) or not entry:
+                continue
+            # By key as well as by identity. Identity alone misses an entry transformers
+            # built from a different callable, and key alone would rewrite an unrelated
+            # backend, so either match is enough but the name is checked too.
+            if entry[0] is original or str(key).split(">")[0].split("=")[0].strip() == "sentencepiece":
                 mapping[key] = (_sentencepiece_is_absent,) + tuple(entry[1:])
 
     try:
@@ -159,19 +241,27 @@ def tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
 
 
 def disable_sentencepiece_if_blocked() -> bool:
-    """Correct the availability flag when the extension will not load.
+    """Correct the availability flag when policy or the loader says sentencepiece is out.
 
-    Returns True only when a real block was found and the correction took. On every
-    other machine this is a no-op: not Windows, not installed, or it imported. The
-    verdict is cached, except when transformers is not imported yet, so a later call
-    still gets its chance.
+    Two triggers, checked in that order: ``sentencepiece_disabled_by_policy`` for the
+    Windows default and the explicit flag, then the import probe for a machine whose
+    extension is genuinely refused.
+
+    Returns True only when sentencepiece was actually turned off here. On every other
+    machine this is a no-op: policy is silent and the extension imported. The verdict is
+    cached, except when transformers is not imported yet, so a later call still gets its
+    chance.
     """
     global _RESULT
     if _RESULT is not None:
         return _RESULT
 
-    exception = sentencepiece_import_error()
-    if exception is None:
+    # Policy first, and the probe strictly as a fallback. The Windows default exists so
+    # the extension is never touched, so probing first would hand the blocked file exactly
+    # the load the default is there to avoid.
+    policy = sentencepiece_disabled_by_policy()
+    exception = sentencepiece_import_error() if policy is None else None
+    if policy is None and exception is None:
         _RESULT = False
         return False
 
@@ -184,6 +274,30 @@ def disable_sentencepiece_if_blocked() -> bool:
         # The correction did not take, so warning that it did would be worse than
         # saying nothing: the operator would stop looking.
         return False
+
+    if exception is None:
+        # Logged, not warned. A block is a fault on one machine that the operator has to
+        # act on, so it earns a warning. The policy default is the expected state of every
+        # healthy Windows box, and warnings.warn prints by default: a UserWarning on every
+        # single launch is the kind of noise that teaches people to stop reading them. The
+        # models that need the extension still fail loudly at the point of use with the
+        # backend message naming it, which is where the question is actually asked.
+        if policy == "environment":
+            logger.info(
+                "Unsloth: sentencepiece is disabled because %s is set. transformers will "
+                "use fast tokenizers only.",
+                DISABLE_SENTENCEPIECE_VARIABLE,
+            )
+        else:
+            logger.info(
+                "Unsloth: sentencepiece is disabled by default on Windows, so transformers "
+                "will use fast tokenizers only. Nothing was blocked and nothing was "
+                "uninstalled; this is a temporary measure while the Windows loader "
+                "refusals are worked through. Set %s=0 to use it again.",
+                DISABLE_SENTENCEPIECE_VARIABLE,
+            )
+        _RESULT = True
+        return True
 
     winerror = getattr(exception, "winerror", None)
     if winerror in BLOCKED_IMAGE_WINERRORS:

--- a/studio/backend/utils/sentencepiece_guard.py
+++ b/studio/backend/utils/sentencepiece_guard.py
@@ -129,8 +129,7 @@ def tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
     def _sentencepiece_is_absent(*args, **kwargs):
         return False
 
-    _sentencepiece_is_absent.__name__ = getattr(
-        original, "__name__", "is_sentencepiece_available")
+    _sentencepiece_is_absent.__name__ = getattr(original, "__name__", "is_sentencepiece_available")
     import_utils.is_sentencepiece_available = _sentencepiece_is_absent
 
     for module in list(sys.modules.values()):

--- a/studio/backend/utils/sentencepiece_guard.py
+++ b/studio/backend/utils/sentencepiece_guard.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tell transformers sentencepiece is absent when Windows will not load its extension.
+
+Standalone on purpose. The same guard exists in ``unsloth.import_fixes`` for people who
+installed the pip package, but importing it from here would run ``unsloth/__init__.py``,
+whose GPU branch pulls in torch, Triton, transformers and the model stack. The Studio
+parent is deliberately light because the ML work happens in spawned workers, so that
+would add a full stack to the long-lived process and can open a competing GPU context
+on the machines least able to afford one. Nothing imported here is heavy, and on a
+machine where the extension loads nothing at all is imported.
+
+The two copies must agree; ``tests/studio/test_sentencepiece_guard_parity.py`` holds
+them to the same error codes and the same decision.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+import warnings
+
+# Windows loader errors that mean "this image was refused", not "this file is broken".
+# 577 ERROR_INVALID_IMAGE_HASH is Smart App Control and App Control for Business, 225
+# ERROR_VIRUS_INFECTED is an antivirus blocking on access, 1260
+# ERROR_ACCESS_DISABLED_BY_POLICY is AppLocker or SRP. They are separated only so the
+# message can name a cause; every failure to load the extension is handled the same way.
+BLOCKED_IMAGE_WINERRORS = frozenset({225, 577, 1260})
+
+_RESULT: bool | None = None
+
+
+def smart_app_control_state() -> int | None:
+    """Smart App Control's state: 0 off, 1 enforced, 2 evaluation, or None if unknown.
+
+    Read from ``HKLM\\SYSTEM\\CurrentControlSet\\Control\\CI\\Policy``, which a standard
+    user can already read, so this needs no elevation and prompts for nothing.
+    ``Win32_DeviceGuard`` answers a related question and does require admin, which is why
+    it is not used.
+
+    None covers every "cannot say": not Windows, no winreg, the value absent because the
+    build never configured SAC, or the read denied. Callers must treat None as unknown
+    rather than off, and nothing here decides anything on this value alone.
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        import winreg
+    except ImportError:
+        return None
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\CI\Policy",
+            0,
+            winreg.KEY_READ,
+        ) as key:
+            value, _ = winreg.QueryValueEx(key, "VerifiedAndReputablePolicyState")
+    except (OSError, ValueError):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def sentencepiece_import_error() -> BaseException | None:
+    """The exception importing sentencepiece raises here, or None when it imports.
+
+    Windows only, and only when the package is installed: everywhere else the answer is
+    already right and paying an import to confirm it would slow every launch.
+
+    The import is the only authoritative test. Smart App Control blocks by reputation,
+    one file at a time, so it can refuse this extension on a machine where it is on and
+    everything else loads, and it can be off while an antivirus refuses the same file.
+    Reading the policy state and disabling sentencepiece on that alone would take the
+    tokenizer away from the large majority of SAC users whose extension loads fine.
+    """
+    if sys.platform != "win32":
+        return None
+    if "sentencepiece" in sys.modules:
+        return None
+    if importlib.util.find_spec("sentencepiece") is None:
+        # Genuinely not installed. transformers already agrees.
+        return None
+    try:
+        importlib.import_module("sentencepiece")
+    except Exception as exception:
+        return exception
+    return None
+
+
+def tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
+    """Make every consumer of ``is_sentencepiece_available`` answer False.
+
+    The two shipped shapes need different work, and neither is covered by patching only
+    the defining module:
+
+    4.x keeps a module global, ``_sentencepiece_available``, that the function returns.
+    Setting it is enough there and is done first, since it also fixes code reading the
+    global directly.
+
+    5.x has no such global: the function is ``@lru_cache``-wrapped around
+    ``_is_package_available("sentencepiece")``, which asks ``find_spec`` and loads
+    nothing, so it answers True while the extension is refused. Assigning the global
+    there creates an unused attribute and changes nothing.
+
+    In both, replacing ``import_utils.is_sentencepiece_available`` is not enough on its
+    own. ``BACKENDS_MAPPING`` captures the function object at import time, and so does
+    every module that did ``from ... import is_sentencepiece_available`` before this ran.
+    Those copies keep the original and keep saying True.
+
+    So the original is rebound everywhere it is already bound: every module in
+    sys.modules holding it under any name, and the ``BACKENDS_MAPPING`` entry, whose
+    tuple is rebuilt rather than mutated so the install message survives. Modules
+    imported afterwards need nothing, since they read the replaced name.
+    """
+    original = getattr(import_utils, "is_sentencepiece_available", None)
+    if original is None:
+        return False
+
+    if hasattr(import_utils, "_sentencepiece_available"):
+        import_utils._sentencepiece_available = False
+    try:
+        if import_utils.is_sentencepiece_available() is False:
+            return True
+    except Exception:
+        return False
+
+    def _sentencepiece_is_absent(*args, **kwargs):
+        return False
+
+    _sentencepiece_is_absent.__name__ = getattr(
+        original, "__name__", "is_sentencepiece_available")
+    import_utils.is_sentencepiece_available = _sentencepiece_is_absent
+
+    for module in list(sys.modules.values()):
+        if module is None or module is import_utils:
+            continue
+        try:
+            names = vars(module)
+        except Exception:
+            continue
+        for name, value in list(names.items()):
+            if value is original:
+                try:
+                    setattr(module, name, _sentencepiece_is_absent)
+                except Exception:
+                    pass
+
+    mapping = getattr(import_utils, "BACKENDS_MAPPING", None)
+    if isinstance(mapping, dict):
+        for key, entry in list(mapping.items()):
+            if isinstance(entry, tuple) and entry and entry[0] is original:
+                mapping[key] = (_sentencepiece_is_absent,) + tuple(entry[1:])
+
+    try:
+        return import_utils.is_sentencepiece_available() is False
+    except Exception:
+        return False
+
+
+def disable_sentencepiece_if_blocked() -> bool:
+    """Correct the availability flag when the extension will not load.
+
+    Returns True only when a real block was found and the correction took. On every
+    other machine this is a no-op: not Windows, not installed, or it imported. The
+    verdict is cached, except when transformers is not imported yet, so a later call
+    still gets its chance.
+    """
+    global _RESULT
+    if _RESULT is not None:
+        return _RESULT
+
+    exception = sentencepiece_import_error()
+    if exception is None:
+        _RESULT = False
+        return False
+
+    try:
+        import transformers.utils.import_utils as import_utils
+    except Exception:
+        return False
+
+    if not tell_transformers_sentencepiece_is_absent(import_utils):
+        # The correction did not take, so warning that it did would be worse than
+        # saying nothing: the operator would stop looking.
+        return False
+
+    winerror = getattr(exception, "winerror", None)
+    if winerror in BLOCKED_IMAGE_WINERRORS:
+        cause = f"blocked by Windows (error {winerror})"
+    else:
+        cause = "could not be loaded"
+    state = smart_app_control_state()
+    if state == 1:
+        cause += "; Smart App Control is on"
+    elif state == 2:
+        cause += "; Smart App Control is in evaluation mode"
+    warnings.warn(
+        f"Unsloth: the sentencepiece extension {cause}: {exception}\n"
+        "Continuing without it. Models that ship a fast tokenizer (tokenizer.json) are "
+        "unaffected; a model that only ships tokenizer.model will now say sentencepiece "
+        "is required instead of failing later with a loader error.\n"
+        "To restore it, allow the file in your security software, or reinstall "
+        "sentencepiece so a differently named copy is written.",
+        stacklevel = 2,
+    )
+    _RESULT = True
+    return True

--- a/tests/studio/test_sentencepiece_guard_parity.py
+++ b/tests/studio/test_sentencepiece_guard_parity.py
@@ -92,7 +92,11 @@ def _refuse_every_import(monkeypatch, reason):
     monkeypatch.setattr(importlib, "import_module", _explode)
 
 
-def _blocked_import(monkeypatch, winerror = 577, flag = "0"):
+def _blocked_import(
+    monkeypatch,
+    winerror = 577,
+    flag = "0",
+):
     """A Windows box whose sentencepiece is installed and refuses to load.
 
     The flag defaults to "0" because the block path is only reachable that way now: with
@@ -508,9 +512,7 @@ def test_the_auto_tokenizer_mapping_is_built_before_the_flag_is_changed(
         "the auto tokenizer module must be imported so its mapping is materialised while "
         "sentencepiece still reads as available"
     )
-    first_write = next(
-        (i for i, (kind, _) in enumerate(order) if kind == "mapping"), len(order)
-    )
+    first_write = next((i for i, (kind, _) in enumerate(order) if kind == "mapping"), len(order))
     first_import = order.index(("import", "transformers.models.auto.tokenization_auto"))
     assert first_import < first_write, (
         "the mapping must be built BEFORE anything is rebound, or the correction sends "
@@ -531,15 +533,13 @@ def test_a_synthetic_module_does_not_drag_in_real_transformers(
         "import_module",
         lambda name, *a, **k: (calls.append(name), types.ModuleType(name))[1],
     )
-    import_utils = _transformers_5x()          # __name__ is "fake_import_utils"
+    import_utils = _transformers_5x()  # __name__ is "fake_import_utils"
     assert getattr(module, patcher)(import_utils) is True
     assert calls == [], f"nothing should have been imported, got {calls}"
 
 
 @pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
-def test_a_versioned_backend_entry_is_corrected_too(
-    module, probe, patcher, policy, entry, cache
-):
+def test_a_versioned_backend_entry_is_corrected_too(module, probe, patcher, policy, entry, cache):
     """BACKENDS_MAPPING is matched by key as well as by function identity.
 
     Latent today: every shipped `@requires(backends=("sentencepiece",))` uses the bare

--- a/tests/studio/test_sentencepiece_guard_parity.py
+++ b/tests/studio/test_sentencepiece_guard_parity.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The two copies of the blocked-sentencepiece guard, held to the same behaviour.
+
+There are two on purpose. ``unsloth.import_fixes`` carries it for people who installed
+the pip package, where importing unsloth is the point. ``studio/backend/utils`` carries
+it because the Studio parent must not import unsloth: that runs ``unsloth/__init__.py``,
+whose GPU branch pulls torch, Triton, transformers and the model stack into a
+long-lived process that exists to stay light, and can open a competing GPU context.
+
+Two copies drift. These tests are the thing that stops them, and they drive both through
+the same cases rather than comparing source text, which would pass on two
+implementations that had quietly stopped agreeing about what they do.
+"""
+
+import importlib
+import sys
+import types
+import warnings
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+for candidate in (REPO, REPO / "studio" / "backend"):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+from unsloth import import_fixes as PACKAGE_COPY  # noqa: E402
+from utils import sentencepiece_guard as STUDIO_COPY  # noqa: E402
+
+# (module, probe, patcher, policy reader, entry point), so each case runs on both.
+COPIES = [
+    pytest.param(
+        PACKAGE_COPY,
+        "sentencepiece_import_error",
+        "_tell_transformers_sentencepiece_is_absent",
+        "smart_app_control_state",
+        "disable_sentencepiece_if_blocked",
+        "_SENTENCEPIECE_GUARD_RESULT",
+        id = "unsloth.import_fixes",
+    ),
+    pytest.param(
+        STUDIO_COPY,
+        "sentencepiece_import_error",
+        "tell_transformers_sentencepiece_is_absent",
+        "smart_app_control_state",
+        "disable_sentencepiece_if_blocked",
+        "_RESULT",
+        id = "studio.utils.sentencepiece_guard",
+    ),
+]
+
+
+@pytest.fixture(autouse = True)
+def _reset():
+    PACKAGE_COPY._SENTENCEPIECE_GUARD_RESULT = None
+    STUDIO_COPY._RESULT = None
+    yield
+    PACKAGE_COPY._SENTENCEPIECE_GUARD_RESULT = None
+    STUDIO_COPY._RESULT = None
+
+
+def _blocked_import(monkeypatch, winerror = 577):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+
+    def _raise(name, *args, **kwargs):
+        error = ImportError(
+            "DLL load failed while importing _sentencepiece: "
+            "Windows cannot verify the digital signature for this file."
+        )
+        error.winerror = winerror
+        raise error
+
+    monkeypatch.setattr(importlib, "import_module", _raise)
+
+
+def _transformers_5x():
+    """The 5.5.0 shape: an lru_cache function, no global, and captured consumers."""
+    import functools
+
+    module = types.ModuleType("fake_import_utils")
+
+    @functools.lru_cache
+    def is_sentencepiece_available():
+        return True
+
+    module.is_sentencepiece_available = is_sentencepiece_available
+    module.BACKENDS_MAPPING = {
+        "sentencepiece": (is_sentencepiece_available, "pip install sentencepiece"),
+    }
+    return module
+
+
+def _transformers_4x():
+    """The 4.57 shape: a module global the function returns."""
+    module = types.ModuleType("fake_import_utils_4")
+    module._sentencepiece_available = True
+    module.is_sentencepiece_available = lambda: module._sentencepiece_available
+    return module
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_the_error_codes_are_the_same(module, probe, patcher, policy, entry, cache):
+    """Drift here would mean one copy calls a block what the other calls a plain failure."""
+    codes = getattr(module, "BLOCKED_IMAGE_WINERRORS", None) or getattr(
+        module, "_BLOCKED_IMAGE_WINERRORS")
+    assert set(codes) == {225, 577, 1260}
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_a_transformers_5x_layout_is_corrected_through_its_captured_consumers(
+    module, probe, patcher, policy, entry, cache
+):
+    """The shape Studio actually installs. is_sentencepiece_available is lru_cache-wrapped
+    around _is_package_available, which asks find_spec and loads nothing, so it answers
+    True while the extension is refused; and BACKENDS_MAPPING plus every module that did
+    a `from ... import` hold the original object, so replacing only the defining module
+    leaves them all still saying True."""
+    import_utils = _transformers_5x()
+    original = import_utils.is_sentencepiece_available
+    consumer = types.ModuleType("fake_consumer")
+    consumer.is_sentencepiece_available = original
+    sys.modules["fake_consumer"] = consumer
+    try:
+        assert getattr(module, patcher)(import_utils) is True
+        assert import_utils.is_sentencepiece_available() is False
+        assert consumer.is_sentencepiece_available() is False, (
+            "a captured copy must be corrected too, or models.auto still tries the "
+            "blocked extension"
+        )
+        assert import_utils.BACKENDS_MAPPING["sentencepiece"][0]() is False
+        assert import_utils.BACKENDS_MAPPING["sentencepiece"][1] == "pip install sentencepiece", (
+            "requires_backends must still be able to tell the user how to install it"
+        )
+    finally:
+        sys.modules.pop("fake_consumer", None)
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_a_transformers_4x_layout_is_corrected_through_its_global(
+    module, probe, patcher, policy, entry, cache
+):
+    """The older shape, still what a pinned 4.57 install has."""
+    import_utils = _transformers_4x()
+    assert getattr(module, patcher)(import_utils) is True
+    assert import_utils.is_sentencepiece_available() is False
+    assert import_utils._sentencepiece_available is False
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_a_working_extension_is_left_alone(module, probe, patcher, policy, entry, cache):
+    """The 99.9% case on the platform this runs on. A healthy Windows machine must lose
+    nothing, and must not even read the registry."""
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+        monkeypatch.setattr(importlib, "import_module", lambda name, *a, **k: object())
+
+        def _no_registry():
+            raise AssertionError("a healthy machine must not be asked about policy")
+
+        monkeypatch.setattr(module, policy, _no_registry)
+        with warnings.catch_warnings(record = True) as caught:
+            warnings.simplefilter("always")
+            assert getattr(module, entry)() is False
+        assert caught == []
+    finally:
+        monkeypatch.undo()
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_nothing_is_imported_off_windows(module, probe, patcher, policy, entry, cache):
+    """The probe is an import; paying it on Linux and macOS would slow every launch to
+    answer a question already answered."""
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(
+            importlib,
+            "import_module",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("imported off Windows")),
+        )
+        assert getattr(module, probe)() is None
+        assert getattr(module, entry)() is False
+    finally:
+        monkeypatch.undo()
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_a_block_warns_and_names_the_loader_error(
+    module, probe, patcher, policy, entry, cache, monkeypatch
+):
+    _blocked_import(monkeypatch)
+    import_utils = _transformers_5x()
+    monkeypatch.setitem(sys.modules, "transformers", types.ModuleType("transformers"))
+    monkeypatch.setitem(sys.modules, "transformers.utils", types.ModuleType("transformers.utils"))
+    monkeypatch.setitem(sys.modules, "transformers.utils.import_utils", import_utils)
+
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        assert getattr(module, entry)() is True
+
+    assert import_utils.is_sentencepiece_available() is False
+    assert "577" in str(caught[0].message)
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_the_policy_state_is_not_what_decides(
+    module, probe, patcher, policy, entry, cache, monkeypatch
+):
+    """Smart App Control blocks by reputation, one file at a time. It is on for many
+    machines whose sentencepiece loads perfectly and off on machines where an antivirus
+    refuses the same file, so deciding on the state would break the first group and miss
+    the second."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(importlib, "import_module", lambda name, *a, **k: object())
+    monkeypatch.setattr(module, policy, lambda: 1)
+    assert getattr(module, entry)() is False
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_a_denied_policy_read_is_unknown_not_off(
+    module, probe, patcher, policy, entry, cache, monkeypatch
+):
+    """It reads HKLM, which a standard user can read, so it needs no elevation and
+    prompts for nothing. Every "cannot say" is None."""
+    assert getattr(module, policy)() is None  # not Windows, here
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    fake = types.ModuleType("winreg")
+    fake.HKEY_LOCAL_MACHINE = 0
+    fake.KEY_READ = 0
+    fake.OpenKey = lambda *a, **k: (_ for _ in ()).throw(PermissionError("denied"))
+    fake.QueryValueEx = lambda *a, **k: (0, 0)
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    assert getattr(module, policy)() is None
+
+
+def test_the_studio_copy_does_not_import_unsloth():
+    """The reason there are two. Importing unsloth here runs unsloth/__init__.py, whose
+    GPU branch pulls torch, Triton, transformers and the model stack into the parent
+    process, and can open a competing GPU context on a machine already short of memory."""
+    source = (
+        REPO / "studio" / "backend" / "utils" / "sentencepiece_guard.py"
+    ).read_text(encoding = "utf-8")
+    assert "import unsloth" not in source
+    assert "from unsloth" not in source
+    for heavy in ("import torch", "import transformers\n", "import numpy"):
+        assert heavy not in source, f"the Studio parent must not pay for {heavy!r}"
+
+    main = (REPO / "studio" / "backend" / "main.py").read_text(encoding = "utf-8")
+    assert "from utils.sentencepiece_guard import disable_sentencepiece_if_blocked" in main
+    assert "from unsloth.import_fixes import" not in main

--- a/tests/studio/test_sentencepiece_guard_parity.py
+++ b/tests/studio/test_sentencepiece_guard_parity.py
@@ -107,7 +107,8 @@ def _transformers_4x():
 def test_the_error_codes_are_the_same(module, probe, patcher, policy, entry, cache):
     """Drift here would mean one copy calls a block what the other calls a plain failure."""
     codes = getattr(module, "BLOCKED_IMAGE_WINERRORS", None) or getattr(
-        module, "_BLOCKED_IMAGE_WINERRORS")
+        module, "_BLOCKED_IMAGE_WINERRORS"
+    )
     assert set(codes) == {225, 577, 1260}
 
 
@@ -133,9 +134,9 @@ def test_a_transformers_5x_layout_is_corrected_through_its_captured_consumers(
             "blocked extension"
         )
         assert import_utils.BACKENDS_MAPPING["sentencepiece"][0]() is False
-        assert import_utils.BACKENDS_MAPPING["sentencepiece"][1] == "pip install sentencepiece", (
-            "requires_backends must still be able to tell the user how to install it"
-        )
+        assert (
+            import_utils.BACKENDS_MAPPING["sentencepiece"][1] == "pip install sentencepiece"
+        ), "requires_backends must still be able to tell the user how to install it"
     finally:
         sys.modules.pop("fake_consumer", None)
 
@@ -248,9 +249,9 @@ def test_the_studio_copy_does_not_import_unsloth():
     """The reason there are two. Importing unsloth here runs unsloth/__init__.py, whose
     GPU branch pulls torch, Triton, transformers and the model stack into the parent
     process, and can open a competing GPU context on a machine already short of memory."""
-    source = (
-        REPO / "studio" / "backend" / "utils" / "sentencepiece_guard.py"
-    ).read_text(encoding = "utf-8")
+    source = (REPO / "studio" / "backend" / "utils" / "sentencepiece_guard.py").read_text(
+        encoding = "utf-8"
+    )
     assert "import unsloth" not in source
     assert "from unsloth" not in source
     for heavy in ("import torch", "import transformers\n", "import numpy"):

--- a/tests/studio/test_sentencepiece_guard_parity.py
+++ b/tests/studio/test_sentencepiece_guard_parity.py
@@ -54,15 +54,53 @@ COPIES = [
 
 
 @pytest.fixture(autouse = True)
-def _reset():
+def _reset(monkeypatch):
     PACKAGE_COPY._SENTENCEPIECE_GUARD_RESULT = None
     STUDIO_COPY._RESULT = None
+    # The flag decides half of what is under test here, so an operator who exported it in
+    # the shell running pytest must not be able to change what these tests mean.
+    monkeypatch.delenv(VARIABLE, raising = False)
     yield
     PACKAGE_COPY._SENTENCEPIECE_GUARD_RESULT = None
     STUDIO_COPY._RESULT = None
 
 
-def _blocked_import(monkeypatch, winerror = 577):
+def _variable(module):
+    """The env var name, under whichever of the two spellings this copy uses."""
+    return getattr(module, "DISABLE_SENTENCEPIECE_VARIABLE", None) or getattr(
+        module, "_DISABLE_SENTENCEPIECE_VARIABLE"
+    )
+
+
+VARIABLE = _variable(PACKAGE_COPY)
+
+
+def _install_fake_transformers(monkeypatch, import_utils):
+    """A transformers whose import_utils is the fake, so the entry point patches that."""
+    monkeypatch.setitem(sys.modules, "transformers", types.ModuleType("transformers"))
+    monkeypatch.setitem(sys.modules, "transformers.utils", types.ModuleType("transformers.utils"))
+    monkeypatch.setitem(sys.modules, "transformers.utils.import_utils", import_utils)
+
+
+def _refuse_every_import(monkeypatch, reason):
+    """Any import at all becomes the test failure it would be in production."""
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+
+    def _explode(name, *args, **kwargs):
+        raise AssertionError(reason)
+
+    monkeypatch.setattr(importlib, "import_module", _explode)
+
+
+def _blocked_import(monkeypatch, winerror = 577, flag = "0"):
+    """A Windows box whose sentencepiece is installed and refuses to load.
+
+    The flag defaults to "0" because the block path is only reachable that way now: with
+    the flag unset, Windows disables sentencepiece by policy and never probes it. Blocked
+    machines are therefore covered by the policy default first, and this path is what
+    still protects the user who turned the policy back off.
+    """
+    monkeypatch.setenv(VARIABLE, flag)
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
     monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
@@ -154,10 +192,12 @@ def test_a_transformers_4x_layout_is_corrected_through_its_global(
 
 @pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
 def test_a_working_extension_is_left_alone(module, probe, patcher, policy, entry, cache):
-    """The 99.9% case on the platform this runs on. A healthy Windows machine must lose
-    nothing, and must not even read the registry."""
+    """A healthy Windows machine that has opted back in must lose nothing, and must not
+    even read the registry. The opt-in is what this test is about: with the flag unset,
+    Windows now disables sentencepiece by policy whether or not it would have loaded."""
     monkeypatch = pytest.MonkeyPatch()
     try:
+        monkeypatch.setenv(VARIABLE, "0")
         monkeypatch.setattr(sys, "platform", "win32")
         monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
         monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
@@ -218,7 +258,9 @@ def test_the_policy_state_is_not_what_decides(
     """Smart App Control blocks by reputation, one file at a time. It is on for many
     machines whose sentencepiece loads perfectly and off on machines where an antivirus
     refuses the same file, so deciding on the state would break the first group and miss
-    the second."""
+    the second. Asked with the flag off, since that is the only configuration in which the
+    import probe still runs at all."""
+    monkeypatch.setenv(VARIABLE, "0")
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
     monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
@@ -245,6 +287,165 @@ def test_a_denied_policy_read_is_unknown_not_off(
     assert getattr(module, policy)() is None
 
 
+# ---- the policy default -------------------------------------------------------------
+#
+# Windows disables sentencepiece by default, not only when a block is detected. A
+# temporary measure, so the flag that turns it back on is part of the contract and is
+# tested as such.
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_both_copies_name_the_same_variable_and_helper(
+    module, probe, patcher, policy, entry, cache
+):
+    """Drift here would mean one copy honours a flag the other has never heard of."""
+    assert _variable(module) == "UNSLOTH_DISABLE_SENTENCEPIECE"
+    assert callable(module.sentencepiece_disabled_by_policy)
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_windows_disables_by_default_without_touching_the_extension(
+    module, probe, patcher, policy, entry, cache, monkeypatch
+):
+    """The whole point of the default: on Windows the extension is never loaded, so a
+    machine whose loader would refuse it never gives the loader the chance. Any import at
+    all here is the failure."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+    _refuse_every_import(monkeypatch, "the policy default must not import sentencepiece")
+    import_utils = _transformers_5x()
+    _install_fake_transformers(monkeypatch, import_utils)
+
+    assert module.sentencepiece_disabled_by_policy() == "windows"
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        assert getattr(module, entry)() is True
+    assert import_utils.is_sentencepiece_available() is False
+    assert caught == [], (
+        "a healthy Windows machine gets this on every launch, so it is logged rather "
+        "than warned; only a real block earns a warning"
+    )
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+@pytest.mark.parametrize("shape", ["4x", "5x"])
+def test_the_policy_path_corrects_both_transformers_shapes(
+    module, probe, patcher, policy, entry, cache, shape, monkeypatch
+):
+    """The policy default reaches the same correction as the block path, on the 4.57.6
+    module global and on the 5.x lru_cache function alike."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    import_utils = _transformers_4x() if shape == "4x" else _transformers_5x()
+    _install_fake_transformers(monkeypatch, import_utils)
+
+    assert getattr(module, entry)() is True
+    assert import_utils.is_sentencepiece_available() is False
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+@pytest.mark.parametrize("platform", ["linux", "darwin"])
+def test_no_platform_default_off_windows(
+    module, probe, patcher, policy, entry, cache, platform, monkeypatch
+):
+    """Linux and macOS keep sentencepiece. WSL reports "linux", so it lands here too,
+    which is right: it runs the Linux loader, not the Windows one."""
+    monkeypatch.setattr(sys, "platform", platform)
+    import_utils = _transformers_5x()
+    _install_fake_transformers(monkeypatch, import_utils)
+
+    assert module.sentencepiece_disabled_by_policy() is None
+    assert getattr(module, entry)() is False
+    assert import_utils.is_sentencepiece_available() is True
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+@pytest.mark.parametrize("value", ["1", "true", "YES", " On ", "TRUE"])
+def test_a_truthy_flag_disables_on_every_platform(
+    module, probe, patcher, policy, entry, cache, value, monkeypatch
+):
+    """Case and surrounding whitespace are the operator's, not the contract's."""
+    monkeypatch.setenv(VARIABLE, value)
+    monkeypatch.setattr(sys, "platform", "linux")
+    import_utils = _transformers_5x()
+    _install_fake_transformers(monkeypatch, import_utils)
+
+    assert module.sentencepiece_disabled_by_policy() == "environment"
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        assert getattr(module, entry)() is True
+    assert import_utils.is_sentencepiece_available() is False
+    assert caught == [], "the operator asked for this; telling them so is pure noise"
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+@pytest.mark.parametrize("value", ["0", "false", "NO", " off "])
+def test_a_falsy_flag_on_windows_leaves_a_healthy_machine_alone(
+    module, probe, patcher, policy, entry, cache, value, monkeypatch
+):
+    """The way back. An extension that loads stays available."""
+    monkeypatch.setenv(VARIABLE, value)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(importlib, "import_module", lambda name, *a, **k: object())
+    import_utils = _transformers_5x()
+    _install_fake_transformers(monkeypatch, import_utils)
+
+    assert module.sentencepiece_disabled_by_policy() is None
+    assert getattr(module, entry)() is False
+    assert import_utils.is_sentencepiece_available() is True
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_a_falsy_flag_cannot_re_enable_a_refused_extension(
+    module, probe, patcher, policy, entry, cache, monkeypatch
+):
+    """The important half of the flag. It says "do not disable this by policy", not "this
+    works": a user who opts back in on a machine whose loader refuses the file is still
+    protected, and still gets the warning naming the loader error."""
+    _blocked_import(monkeypatch, flag = "0")
+    import_utils = _transformers_5x()
+    _install_fake_transformers(monkeypatch, import_utils)
+
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        assert getattr(module, entry)() is True
+    assert import_utils.is_sentencepiece_available() is False
+    assert "577" in str(caught[0].message)
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+@pytest.mark.parametrize("value", ["maybe", "2", "", "   ", "disable"])
+def test_an_unrecognised_value_falls_back_to_the_platform_default(
+    module, probe, patcher, policy, entry, cache, value, monkeypatch
+):
+    """This runs during import. Raising on a typo would cost the user the whole package
+    over a shell variable, so an unreadable value is treated as unset."""
+    monkeypatch.setenv(VARIABLE, value)
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert module.sentencepiece_disabled_by_policy() == "windows"
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert module.sentencepiece_disabled_by_policy() is None
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_a_policy_disable_before_transformers_does_not_poison_the_cache(
+    module, probe, patcher, policy, entry, cache, monkeypatch
+):
+    """Same rule as the block path: a call that could not reach transformers has not
+    decided anything, so the next call must get its chance."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "transformers", None)
+    assert getattr(module, entry)() is False
+    assert getattr(module, cache) is None
+
+    monkeypatch.delitem(sys.modules, "transformers")
+    import_utils = _transformers_5x()
+    _install_fake_transformers(monkeypatch, import_utils)
+    assert getattr(module, entry)() is True
+    assert getattr(module, cache) is True
+
+
 def test_the_studio_copy_does_not_import_unsloth():
     """The reason there are two. Importing unsloth here runs unsloth/__init__.py, whose
     GPU branch pulls torch, Triton, transformers and the model stack into the parent
@@ -260,3 +461,94 @@ def test_the_studio_copy_does_not_import_unsloth():
     main = (REPO / "studio" / "backend" / "main.py").read_text(encoding = "utf-8")
     assert "from utils.sentencepiece_guard import disable_sentencepiece_if_blocked" in main
     assert "from unsloth.import_fixes import" not in main
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_the_auto_tokenizer_mapping_is_built_before_the_flag_is_changed(
+    module, probe, patcher, policy, entry, cache, monkeypatch
+):
+    """Ordering, and the intuitive order is the wrong one.
+
+    transformers 4.52 through 4.57 evaluate is_sentencepiece_available() while building
+    TOKENIZER_MAPPING_NAMES. Correct the flag first and the slow entries are built as
+    None, tokenizer_class_from_name misses the mapping, and the dummy-class fallback
+    imports transformers and reaches an unguarded top level `import sentencepiece as spm`.
+    The user gets the raw loader error this guard exists to prevent. Measured on 4.57.6
+    with the extension blocked: unpatched fails, patched-first fails identically, and
+    patched after this import loads the tokenizer.
+
+    Asserting only that is_sentencepiece_available() ends up False would pass in both
+    orderings and catch none of this, so the order itself is what is pinned.
+    """
+    order = []
+    import_utils = _transformers_4x()
+    # Named like the real module, since the helper deliberately only does this for
+    # transformers and ignores the synthetic modules the other cases pass in.
+    import_utils.__name__ = "transformers.utils.import_utils"
+    original = import_utils.is_sentencepiece_available
+
+    def _record_import(name, *args, **kwargs):
+        order.append(("import", name))
+        return types.ModuleType(name)
+
+    monkeypatch.setattr(importlib, "import_module", _record_import)
+
+    class _Watched(dict):
+        def __setitem__(self, key, value):
+            order.append(("mapping", key))
+            super().__setitem__(key, value)
+
+    import_utils.BACKENDS_MAPPING = _Watched(
+        {"sentencepiece": (original, "pip install sentencepiece")}
+    )
+    assert getattr(module, patcher)(import_utils) is True
+
+    imports = [name for kind, name in order if kind == "import"]
+    assert "transformers.models.auto.tokenization_auto" in imports, (
+        "the auto tokenizer module must be imported so its mapping is materialised while "
+        "sentencepiece still reads as available"
+    )
+    first_write = next(
+        (i for i, (kind, _) in enumerate(order) if kind == "mapping"), len(order)
+    )
+    first_import = order.index(("import", "transformers.models.auto.tokenization_auto"))
+    assert first_import < first_write, (
+        "the mapping must be built BEFORE anything is rebound, or the correction sends "
+        "the user into the loader error instead of past it"
+    )
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_a_synthetic_module_does_not_drag_in_real_transformers(
+    module, probe, patcher, policy, entry, cache, monkeypatch
+):
+    """The other cases pass hand-built modules. If the helper imported transformers for
+    those too, every test here would be running against the installed package instead of
+    the shape it claims to model."""
+    calls = []
+    monkeypatch.setattr(
+        importlib,
+        "import_module",
+        lambda name, *a, **k: (calls.append(name), types.ModuleType(name))[1],
+    )
+    import_utils = _transformers_5x()          # __name__ is "fake_import_utils"
+    assert getattr(module, patcher)(import_utils) is True
+    assert calls == [], f"nothing should have been imported, got {calls}"
+
+
+@pytest.mark.parametrize("module,probe,patcher,policy,entry,cache", COPIES)
+def test_a_versioned_backend_entry_is_corrected_too(
+    module, probe, patcher, policy, entry, cache
+):
+    """BACKENDS_MAPPING is matched by key as well as by function identity.
+
+    Latent today: every shipped `@requires(backends=("sentencepiece",))` uses the bare
+    name, so identity matching happens to be enough. It stops being enough the moment
+    transformers declares a versioned sentencepiece backend, and matching the name costs
+    nothing now.
+    """
+    import_utils = _transformers_5x()
+    other = lambda: True  # noqa: E731 - a distinct object, so identity cannot match
+    import_utils.BACKENDS_MAPPING["sentencepiece>=0.1.91"] = (other, "pip install sentencepiece")
+    assert getattr(module, patcher)(import_utils) is True
+    assert import_utils.BACKENDS_MAPPING["sentencepiece>=0.1.91"][0]() is False

--- a/tests/test_windows_sentencepiece_blocked.py
+++ b/tests/test_windows_sentencepiece_blocked.py
@@ -189,3 +189,27 @@ def test_the_guard_runs_at_import(monkeypatch):
     source = (PACKAGE_ROOT / "unsloth" / "__init__.py").read_text(encoding = "utf-8")
     assert "disable_sentencepiece_if_blocked" in source
     assert source.count("_guard_sentencepiece()") == 1
+
+
+def test_the_guard_runs_before_anything_resolves_autotokenizer():
+    """Codex 3964051672, P2. transformers freezes derived state at import, so ordering is
+    the whole fix rather than a detail of it.
+
+    models/auto/tokenization_auto.py evaluates ``is_sentencepiece_available()`` at module
+    scope in 5.x, twice over: once to decide whether to import SentencePieceBackend, and
+    once per sentencepiece-only entry of TOKENIZER_MAPPING_NAMES, as in
+    ``("marian", "MarianTokenizer" if is_sentencepiece_available() else None)``. Those
+    values are materialised at that moment and no later rebinding of the function reaches
+    them, so a guard running after AutoTokenizer resolves leaves a Marian or M2M100 load
+    importing the blocked extension and raising the loader error the guard exists to
+    replace.
+
+    _gpu_init resolves AutoTokenizer on the GPU path, so the guard has to precede it.
+    """
+    source = (PACKAGE_ROOT / "unsloth" / "__init__.py").read_text(encoding = "utf-8")
+    guard_at = source.index("_guard_sentencepiece()")
+    gpu_init_at = source.index("from ._gpu_init import")
+    assert guard_at < gpu_init_at, (
+        "the sentencepiece guard must run before _gpu_init resolves AutoTokenizer, or "
+        "TOKENIZER_MAPPING_NAMES is already frozen as available"
+    )

--- a/tests/test_windows_sentencepiece_blocked.py
+++ b/tests/test_windows_sentencepiece_blocked.py
@@ -14,9 +14,11 @@ a tokenizer that will not build; the quiet one is Studio's ``get_native_chat_tem
 which catches any exception, logs a warning and returns None, leaving the model to
 generate under a substituted chat template.
 
-What is asserted here is the shape of the correction rather than the block itself: the
-guard fires only when the import really fails, only on Windows, and leaves a working
-install untouched.
+What is asserted here is the shape of the correction rather than the block itself. As a
+temporary measure the guard now fires on Windows by default, so the extension is never
+loaded there at all; ``UNSLOTH_DISABLE_SENTENCEPIECE=0`` opts back in, and a machine that
+has opted back in is still protected when the import really fails. Off Windows nothing
+happens unless the flag is set truthy.
 """
 
 import importlib
@@ -33,10 +35,18 @@ if str(PACKAGE_ROOT) not in sys.path:
 from unsloth import import_fixes  # noqa: E402
 
 
+VARIABLE = import_fixes._DISABLE_SENTENCEPIECE_VARIABLE
+
+
 @pytest.fixture(autouse = True)
-def _reset_guard():
-    """The guard caches its verdict for the process; each test starts from unknown."""
+def _reset_guard(monkeypatch):
+    """The guard caches its verdict for the process; each test starts from unknown.
+
+    The flag is cleared too, so an operator who exported it in the shell running pytest
+    cannot change what these tests mean.
+    """
     import_fixes._SENTENCEPIECE_GUARD_RESULT = None
+    monkeypatch.delenv(VARIABLE, raising = False)
     yield
     import_fixes._SENTENCEPIECE_GUARD_RESULT = None
 
@@ -53,7 +63,13 @@ def transformers_flag():
 
 
 def _blocked_import(monkeypatch, *, winerror = 577):
-    """A Windows box whose sentencepiece is installed and refuses to load."""
+    """A Windows box whose sentencepiece is installed and refuses to load.
+
+    With the flag set falsy, because that is the only configuration in which the import
+    probe still runs: unset, Windows disables sentencepiece by policy and never touches
+    the extension, so a blocked machine is already covered before this path is reached.
+    """
+    monkeypatch.setenv(VARIABLE, "0")
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
 
@@ -94,9 +110,11 @@ def test_a_blocked_extension_makes_transformers_say_sentencepiece_is_absent(
 
 
 def test_a_working_sentencepiece_is_left_alone(monkeypatch, transformers_flag):
-    """The 99.9% case, on the platform the guard runs on: an import that succeeds must
-    leave the flag exactly where it was, or a Windows machine with a healthy extension
-    loses every slow tokenizer for nothing."""
+    """A Windows machine that has opted back in: an import that succeeds must leave the
+    flag exactly where it was, or opting in would achieve nothing. The opt-in is required
+    here, since with the flag unset Windows disables sentencepiece by policy whether or
+    not the extension would have loaded."""
+    monkeypatch.setenv(VARIABLE, "0")
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
     monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
@@ -111,9 +129,44 @@ def test_a_working_sentencepiece_is_left_alone(monkeypatch, transformers_flag):
     assert caught == []
 
 
+def test_windows_disables_by_default_without_touching_the_extension(
+    monkeypatch, transformers_flag
+):
+    """The temporary Windows default, against the transformers actually installed here.
+
+    Disabled because the platform is Windows, not because anything was probed: the point
+    is that the extension is never loaded, so a machine whose loader would refuse it never
+    gives the loader the chance. Any import at all is the failure.
+
+    UNSLOTH_DISABLE_SENTENCEPIECE=0 is the way back, and is covered above.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+
+    def _explode(name, *args, **kwargs):
+        raise AssertionError("the Windows default must not import sentencepiece")
+
+    monkeypatch.setattr(importlib, "import_module", _explode)
+    transformers_flag._sentencepiece_available = True
+
+    assert import_fixes.sentencepiece_disabled_by_policy() == "windows"
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        assert import_fixes.disable_sentencepiece_if_blocked() is True
+
+    assert transformers_flag.is_sentencepiece_available() is False
+    assert caught == [], (
+        "every healthy Windows launch would print this, so it is logged rather than "
+        "warned; only a real block earns a warning"
+    )
+
+
 def test_a_sentencepiece_that_is_not_installed_is_not_a_block(monkeypatch, transformers_flag):
     """find_spec answering None is the ordinary uninstalled case. transformers already
-    reports it correctly, so there is nothing to correct and nothing to warn about."""
+    reports it correctly, so there is nothing to correct and nothing to warn about. Asked
+    with the flag off, which is where "is this a block?" is still a question."""
+    monkeypatch.setenv(VARIABLE, "0")
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
     monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
@@ -171,7 +224,9 @@ def test_the_state_is_not_what_decides(monkeypatch, transformers_flag):
     """Smart App Control blocks by reputation, one file at a time, so it is on for many
     machines whose sentencepiece loads perfectly and off on machines where an antivirus
     refuses the same file. Deciding on the state rather than on the import would take
-    the tokenizer away from the first group and leave the second broken."""
+    the tokenizer away from the first group and leave the second broken. Asked with the
+    flag off, since that is the only configuration in which the probe still runs."""
+    monkeypatch.setenv(VARIABLE, "0")
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
     monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())

--- a/tests/test_windows_sentencepiece_blocked.py
+++ b/tests/test_windows_sentencepiece_blocked.py
@@ -129,9 +129,7 @@ def test_a_working_sentencepiece_is_left_alone(monkeypatch, transformers_flag):
     assert caught == []
 
 
-def test_windows_disables_by_default_without_touching_the_extension(
-    monkeypatch, transformers_flag
-):
+def test_windows_disables_by_default_without_touching_the_extension(monkeypatch, transformers_flag):
     """The temporary Windows default, against the transformers actually installed here.
 
     Disabled because the platform is Windows, not because anything was probed: the point

--- a/tests/test_windows_sentencepiece_blocked.py
+++ b/tests/test_windows_sentencepiece_blocked.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+
+"""Smart App Control blocking sentencepiece's compiled extension.
+
+Reported from a Windows machine as "Part of this app has been blocked / Some features of
+Python may not work because we can't confirm who published
+_sentencepiece.cp313-win_amd64.pyd that the app tried to load."
+
+``transformers._is_package_available`` decides availability from ``find_spec`` plus
+installed metadata, and neither loads the extension, so ``is_sentencepiece_available()``
+answers True on that machine while every import of it raises. The loudest consequence is
+a tokenizer that will not build; the quiet one is Studio's ``get_native_chat_template``,
+which catches any exception, logs a warning and returns None, leaving the model to
+generate under a substituted chat template.
+
+What is asserted here is the shape of the correction rather than the block itself: the
+guard fires only when the import really fails, only on Windows, and leaves a working
+install untouched.
+"""
+
+import importlib
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))
+
+from unsloth import import_fixes  # noqa: E402
+
+
+@pytest.fixture(autouse = True)
+def _reset_guard():
+    """The guard caches its verdict for the process; each test starts from unknown."""
+    import_fixes._SENTENCEPIECE_GUARD_RESULT = None
+    yield
+    import_fixes._SENTENCEPIECE_GUARD_RESULT = None
+
+
+@pytest.fixture
+def transformers_flag():
+    """transformers' availability flag, restored afterwards."""
+    module = importlib.import_module("transformers.utils.import_utils")
+    original_flag = module._sentencepiece_available
+    original_function = module.is_sentencepiece_available
+    yield module
+    module._sentencepiece_available = original_flag
+    module.is_sentencepiece_available = original_function
+
+
+def _blocked_import(monkeypatch, *, winerror = 577):
+    """A Windows box whose sentencepiece is installed and refuses to load."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+
+    class _Spec:
+        origin = r"C:\\Users\\u\\.unsloth\\studio\\Lib\\site-packages\\sentencepiece\\__init__.py"
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: _Spec())
+
+    def _raise(name, *args, **kwargs):
+        error = ImportError(
+            "DLL load failed while importing _sentencepiece: "
+            "Windows cannot verify the digital signature for this file."
+        )
+        error.winerror = winerror
+        raise error
+
+    monkeypatch.setattr(importlib, "import_module", _raise)
+
+
+def test_a_blocked_extension_makes_transformers_say_sentencepiece_is_absent(
+    monkeypatch, transformers_flag
+):
+    """The correction itself. transformers then takes the path it takes on a machine
+    where sentencepiece was never installed, which is supported for every model that
+    ships tokenizer.json, and the models that truly need it fail with the backend
+    message that names it rather than a loader error from inside the tokenizer."""
+    _blocked_import(monkeypatch)
+    transformers_flag._sentencepiece_available = True
+
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        assert import_fixes.disable_sentencepiece_if_blocked() is True
+
+    assert transformers_flag.is_sentencepiece_available() is False
+    message = str(caught[0].message)
+    assert "sentencepiece" in message
+    assert "577" in message, "the loader error is what tells the user it was a block"
+
+
+def test_a_working_sentencepiece_is_left_alone(monkeypatch, transformers_flag):
+    """The 99.9% case, on the platform the guard runs on: an import that succeeds must
+    leave the flag exactly where it was, or a Windows machine with a healthy extension
+    loses every slow tokenizer for nothing."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(importlib, "import_module", lambda name, *a, **k: object())
+    transformers_flag._sentencepiece_available = True
+
+    with warnings.catch_warnings(record = True) as caught:
+        warnings.simplefilter("always")
+        assert import_fixes.disable_sentencepiece_if_blocked() is False
+
+    assert transformers_flag.is_sentencepiece_available() is True
+    assert caught == []
+
+
+def test_a_sentencepiece_that_is_not_installed_is_not_a_block(monkeypatch, transformers_flag):
+    """find_spec answering None is the ordinary uninstalled case. transformers already
+    reports it correctly, so there is nothing to correct and nothing to warn about."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    assert import_fixes.sentencepiece_import_error() is None
+    assert import_fixes.disable_sentencepiece_if_blocked() is False
+
+
+def test_the_guard_never_costs_an_import_off_windows(monkeypatch):
+    """Nobody has reported this off Windows, and the probe is an import: paying it on
+    Linux and macOS would slow every session to answer a question already answered."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    def _explode(name, *args, **kwargs):
+        raise AssertionError("the guard must not import anything off Windows")
+
+    monkeypatch.setattr(importlib, "import_module", _explode)
+    assert import_fixes.sentencepiece_import_error() is None
+    assert import_fixes.disable_sentencepiece_if_blocked() is False
+
+
+def test_an_already_imported_sentencepiece_is_not_reimported(monkeypatch):
+    """It is in sys.modules, so it loaded; probing again would only be a way to get a
+    different answer than the process is already running under."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "sentencepiece", object())
+
+    def _explode(name, *args, **kwargs):
+        raise AssertionError("already imported, so there is nothing to probe")
+
+    monkeypatch.setattr(importlib, "import_module", _explode)
+    assert import_fixes.sentencepiece_import_error() is None
+
+
+def test_the_smart_app_control_read_answers_rather_than_raising(monkeypatch):
+    """It reads HKLM\\SYSTEM\\CurrentControlSet\\Control\\CI\\Policy, which a standard
+    user can read, so it needs no elevation and prompts for nothing. Every "cannot say"
+    is None, including this machine, which is not Windows."""
+    assert import_fixes.smart_app_control_state() is None
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    fake = type(sys)("winreg")
+    fake.HKEY_LOCAL_MACHINE = 0
+    fake.KEY_READ = 0
+
+    def _open_key(*args, **kwargs):
+        raise PermissionError("denied")
+
+    fake.OpenKey = _open_key
+    fake.QueryValueEx = lambda *a, **k: (0, 0)
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    assert import_fixes.smart_app_control_state() is None, "a denied read is unknown, not off"
+
+
+def test_the_state_is_not_what_decides(monkeypatch, transformers_flag):
+    """Smart App Control blocks by reputation, one file at a time, so it is on for many
+    machines whose sentencepiece loads perfectly and off on machines where an antivirus
+    refuses the same file. Deciding on the state rather than on the import would take
+    the tokenizer away from the first group and leave the second broken."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delitem(sys.modules, "sentencepiece", raising = False)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(importlib, "import_module", lambda name, *a, **k: object())
+    monkeypatch.setattr(import_fixes, "smart_app_control_state", lambda: 1)
+    transformers_flag._sentencepiece_available = True
+
+    assert import_fixes.disable_sentencepiece_if_blocked() is False
+    assert transformers_flag.is_sentencepiece_available() is True
+
+
+def test_the_guard_runs_at_import(monkeypatch):
+    """A fix nobody calls is not a fix. Read off the source rather than by importing
+    unsloth a second time, which costs seconds and cannot be undone in-process."""
+    source = (PACKAGE_ROOT / "unsloth" / "__init__.py").read_text(encoding = "utf-8")
+    assert "disable_sentencepiece_if_blocked" in source
+    assert source.count("_guard_sentencepiece()") == 1

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -1587,3 +1587,14 @@ try:
     del _fix_dill
 except Exception:
     pass
+
+# Smart App Control blocks _sentencepiece.cp313-win_amd64.pyd by reputation, while
+# transformers decides sentencepiece is available from find_spec and metadata alone, so
+# every path gated on that flag walks into a loader error. See
+# import_fixes.disable_sentencepiece_if_blocked; a no-op off Windows.
+try:
+    from .import_fixes import disable_sentencepiece_if_blocked as _guard_sentencepiece
+    _guard_sentencepiece()
+    del _guard_sentencepiece
+except Exception:
+    pass

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -78,6 +78,28 @@ else:
             pass
     del _TRUE, _import_utils, _var, _flag, _const, _modules, _opt_ins, _cached
 
+# Smart App Control blocks _sentencepiece.cp313-win_amd64.pyd by reputation, while
+# transformers decides sentencepiece is available from find_spec and metadata alone, so every
+# path gated on that flag walks into a loader error. See
+# import_fixes.disable_sentencepiece_if_blocked; a no-op off Windows, and a no-op on Windows
+# unless the import really fails.
+#
+# Here rather than at the end of this file, and for the same reason the block above sits here:
+# transformers freezes derived state at import. models/auto/tokenization_auto.py evaluates
+# `if is_sentencepiece_available()` at module scope in 5.x, both for the SentencePieceBackend
+# import and for every sentencepiece-only entry of TOKENIZER_MAPPING_NAMES ("MarianTokenizer"
+# if is_sentencepiece_available() else None, and the same for m2m_100, gpt-sw3, siglip and the
+# rest). _gpu_init resolves AutoTokenizer on the GPU path, so a guard running after it left
+# those values materialised as available, and rebinding the function afterwards cannot reach
+# them: loading a Marian or M2M100 tokenizer still imported the blocked extension and produced
+# the loader error this exists to replace.
+try:
+    from .import_fixes import disable_sentencepiece_if_blocked as _guard_sentencepiece
+    _guard_sentencepiece()
+    del _guard_sentencepiece
+except Exception:
+    pass
+
 # Relax Metal's context-store timeout before MLX modules can initialize Metal; an explicit user
 # value stays authoritative.
 if platform.system() == "Darwin" and platform.machine() == "arm64":
@@ -1585,16 +1607,5 @@ try:
     from .import_fixes import fix_dill_module_by_value_pickling as _fix_dill
     _fix_dill()
     del _fix_dill
-except Exception:
-    pass
-
-# Smart App Control blocks _sentencepiece.cp313-win_amd64.pyd by reputation, while
-# transformers decides sentencepiece is available from find_spec and metadata alone, so
-# every path gated on that flag walks into a loader error. See
-# import_fixes.disable_sentencepiece_if_blocked; a no-op off Windows.
-try:
-    from .import_fixes import disable_sentencepiece_if_blocked as _guard_sentencepiece
-    _guard_sentencepiece()
-    del _guard_sentencepiece
 except Exception:
     pass

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -81,8 +81,10 @@ else:
 # Smart App Control blocks _sentencepiece.cp313-win_amd64.pyd by reputation, while
 # transformers decides sentencepiece is available from find_spec and metadata alone, so every
 # path gated on that flag walks into a loader error. See
-# import_fixes.disable_sentencepiece_if_blocked; a no-op off Windows, and a no-op on Windows
-# unless the import really fails.
+# import_fixes.disable_sentencepiece_if_blocked. As a temporary measure sentencepiece is off
+# by default on Windows rather than only when a block is detected, so the extension is never
+# touched there; UNSLOTH_DISABLE_SENTENCEPIECE=0 puts it back, and even then a genuinely
+# refused import is still caught. Off Windows this is a no-op unless the flag is set truthy.
 #
 # Here rather than at the end of this file, and for the same reason the block above sits here:
 # transformers freezes derived state at import. models/auto/tokenization_auto.py evaluates

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -6127,6 +6127,83 @@ def sentencepiece_import_error():
     return None
 
 
+def _tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
+    """Make every consumer of ``is_sentencepiece_available`` answer False.
+
+    The two shipped shapes need different work, and neither is covered by patching
+    only the defining module:
+
+    4.x keeps a module global, ``_sentencepiece_available``, that the function
+    returns. Setting it is enough there and is done first, because it also fixes any
+    code reading the global directly.
+
+    5.x has no such global: the function is ``@lru_cache``-wrapped around
+    ``_is_package_available("sentencepiece")``, which asks ``find_spec`` and loads
+    nothing, so it answers True while the extension is refused. Assigning the global
+    there creates an unused attribute and changes nothing.
+
+    In both, replacing ``import_utils.is_sentencepiece_available`` is not enough on
+    its own. ``BACKENDS_MAPPING`` captures the function object at import time, and so
+    does every module that did ``from ... import is_sentencepiece_available`` before
+    this ran, which includes ``models.auto.tokenization_auto`` by the time a tokenizer
+    has been touched. Those copies keep the original and keep saying True.
+
+    So the original object is rebound everywhere it is already bound: every module in
+    sys.modules holding it under any name, and the ``BACKENDS_MAPPING`` entry, whose
+    tuple is rebuilt rather than mutated. Modules imported after this need nothing,
+    since they read the replaced name from the defining module.
+
+    Returns whether the answer is now False, so a caller does not warn about a
+    correction that did not take.
+    """
+    original = getattr(import_utils, "is_sentencepiece_available", None)
+    if original is None:
+        return False
+
+    # First, in case a future version reads a global again.
+    if hasattr(import_utils, "_sentencepiece_available"):
+        import_utils._sentencepiece_available = False
+    try:
+        if import_utils.is_sentencepiece_available() is False:
+            return True
+    except Exception:
+        return False
+
+    def _sentencepiece_is_absent(*args, **kwargs):
+        return False
+
+    _sentencepiece_is_absent.__name__ = getattr(original, "__name__", "is_sentencepiece_available")
+    import_utils.is_sentencepiece_available = _sentencepiece_is_absent
+
+    for module in list(sys.modules.values()):
+        if module is None or module is import_utils:
+            continue
+        try:
+            names = vars(module)
+        except Exception:
+            continue
+        for name, value in list(names.items()):
+            if value is original:
+                try:
+                    setattr(module, name, _sentencepiece_is_absent)
+                except Exception:
+                    pass
+
+    mapping = getattr(import_utils, "BACKENDS_MAPPING", None)
+    # An OrderedDict of name -> (predicate, message). The tuple is immutable, so the
+    # entry is replaced rather than edited, and the message is carried across so
+    # requires_backends still tells the user how to install it.
+    if isinstance(mapping, dict):
+        for key, entry in list(mapping.items()):
+            if isinstance(entry, tuple) and entry and entry[0] is original:
+                mapping[key] = (_sentencepiece_is_absent,) + tuple(entry[1:])
+
+    try:
+        return import_utils.is_sentencepiece_available() is False
+    except Exception:
+        return False
+
+
 def disable_sentencepiece_if_blocked():
     """Tell transformers sentencepiece is absent when its extension will not load.
 
@@ -6164,21 +6241,8 @@ def disable_sentencepiece_if_blocked():
         # imported still gets the chance.
         return False
 
-    # The module global, not the function: is_sentencepiece_available() returns it, and
-    # transformers.utils re-exports the same function object, so one assignment covers
-    # every caller. The function is replaced only if a future version stops reading it.
-    _import_utils._sentencepiece_available = False
-    try:
-        still_available = bool(_import_utils.is_sentencepiece_available())
-    except Exception:
-        still_available = False
-    if still_available:
-        _import_utils.is_sentencepiece_available = lambda: False
-        _transformers_utils = sys.modules.get("transformers.utils")
-        if _transformers_utils is not None:
-            _transformers_utils.is_sentencepiece_available = (
-                _import_utils.is_sentencepiece_available
-            )
+    if not _tell_transformers_sentencepiece_is_absent(_import_utils):
+        return False
 
     winerror = getattr(exception, "winerror", None)
     if winerror in _BLOCKED_IMAGE_WINERRORS:

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -6054,3 +6054,150 @@ def fix_dill_module_by_value_pickling():
             "site-packages tree."
         )
     return True
+
+
+# Windows loader errors that mean "this image was refused", not "this file is broken".
+# 577 ERROR_INVALID_IMAGE_HASH is what Smart App Control and App Control for Business
+# raise, 225 ERROR_VIRUS_INFECTED is what an antivirus blocking on access raises, and
+# 1260 ERROR_ACCESS_DISABLED_BY_POLICY is AppLocker or SRP. They are separated from the
+# rest only so the message can name a cause the user can act on; every failure to load
+# the extension is handled the same way.
+_BLOCKED_IMAGE_WINERRORS = frozenset({225, 577, 1260})
+
+_SENTENCEPIECE_GUARD_RESULT = None
+
+
+def smart_app_control_state():
+    """Smart App Control's state: 0 off, 1 enforced, 2 evaluation, or None if unknown.
+
+    Read from HKLM\\SYSTEM\\CurrentControlSet\\Control\\CI\\Policy, which a standard
+    user can already read, so this needs no elevation and prompts for nothing.
+    Win32_DeviceGuard answers a related question and does require admin, which is why
+    it is not used here.
+
+    None covers every "cannot say": not Windows, no winreg, the value absent because
+    the build never configured SAC, or the read denied. Callers must treat None as
+    unknown rather than off, and none of them decides anything on this value alone.
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        import winreg
+    except ImportError:
+        return None
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\CI\Policy",
+            0,
+            winreg.KEY_READ,
+        ) as key:
+            value, _ = winreg.QueryValueEx(key, "VerifiedAndReputablePolicyState")
+    except (OSError, ValueError):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def sentencepiece_import_error():
+    """The exception importing sentencepiece raises here, or None when it imports.
+
+    Windows only, and only when the package is installed: everywhere else the answer
+    is already right, and paying an import to confirm it would slow every session on
+    the platforms nobody reported this from.
+
+    The import is the only authoritative test. Smart App Control blocks a file by
+    reputation, so it can refuse this one extension on a machine where SAC is on and
+    everything else loads, and it can be off while an antivirus refuses the same file.
+    Reading the SAC state and disabling sentencepiece on that alone would take the
+    tokenizer away from the large majority of SAC users whose extension loads fine.
+    """
+    if sys.platform != "win32":
+        return None
+    if "sentencepiece" in sys.modules:
+        # Already imported, so it loaded.
+        return None
+    if importlib.util.find_spec("sentencepiece") is None:
+        # Genuinely not installed. transformers already agrees, and there is nothing
+        # here to correct.
+        return None
+    try:
+        importlib.import_module("sentencepiece")
+    except Exception as exception:
+        return exception
+    return None
+
+
+def disable_sentencepiece_if_blocked():
+    """Tell transformers sentencepiece is absent when its extension will not load.
+
+    Smart App Control blocks ``_sentencepiece.cp313-win_amd64.pyd`` by reputation, and
+    ``transformers._is_package_available`` decides on ``find_spec`` plus installed
+    metadata, neither of which loads anything: ``is_sentencepiece_available()`` answers
+    True and every path gated on it walks into an ImportError raised from inside the
+    tokenizer machinery. The worst of those is quiet rather than loud. Studio's
+    ``get_native_chat_template`` catches any exception from
+    ``AutoTokenizer.from_pretrained``, logs a warning and returns None, so the model
+    keeps generating with a substituted template and the user sees wrong formatting
+    rather than an error naming a blocked file.
+
+    Correcting the flag makes transformers take the fast-tokenizer path it takes on a
+    machine without sentencepiece, which is the supported configuration for every model
+    shipping ``tokenizer.json``, and makes the models that genuinely need the extension
+    fail with the backend message that names it instead of a loader error.
+
+    Returns True only when a real block was found and the flag was corrected. On every
+    other machine this is a no-op: not Windows, not installed, or it imported.
+    """
+    global _SENTENCEPIECE_GUARD_RESULT
+    if _SENTENCEPIECE_GUARD_RESULT is not None:
+        return _SENTENCEPIECE_GUARD_RESULT
+
+    exception = sentencepiece_import_error()
+    if exception is None:
+        _SENTENCEPIECE_GUARD_RESULT = False
+        return False
+
+    try:
+        import transformers.utils.import_utils as _import_utils
+    except Exception:
+        # Nothing to correct yet. Not cached, so a later call after transformers is
+        # imported still gets the chance.
+        return False
+
+    # The module global, not the function: is_sentencepiece_available() returns it, and
+    # transformers.utils re-exports the same function object, so one assignment covers
+    # every caller. The function is replaced only if a future version stops reading it.
+    _import_utils._sentencepiece_available = False
+    try:
+        still_available = bool(_import_utils.is_sentencepiece_available())
+    except Exception:
+        still_available = False
+    if still_available:
+        _import_utils.is_sentencepiece_available = lambda: False
+        _transformers_utils = sys.modules.get("transformers.utils")
+        if _transformers_utils is not None:
+            _transformers_utils.is_sentencepiece_available = (
+                _import_utils.is_sentencepiece_available
+            )
+
+    winerror = getattr(exception, "winerror", None)
+    if winerror in _BLOCKED_IMAGE_WINERRORS:
+        cause = f"blocked by Windows (error {winerror})"
+    else:
+        cause = "could not be loaded"
+    sac = smart_app_control_state()
+    if sac == 1:
+        cause += "; Smart App Control is on"
+    elif sac == 2:
+        cause += "; Smart App Control is in evaluation mode"
+    warnings.warn(
+        f"Unsloth: the sentencepiece extension {cause}: {exception}\n"
+        "Continuing without it. Models that ship a fast tokenizer (tokenizer.json) are "
+        "unaffected; a model that only ships tokenizer.model will now say sentencepiece "
+        "is required instead of failing later with a loader error.\n"
+        "To restore it, allow the file in your security software, or reinstall "
+        "sentencepiece so a differently named copy is written.",
+        stacklevel = 2,
+    )
+    _SENTENCEPIECE_GUARD_RESULT = True
+    return True

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -6066,6 +6066,41 @@ _BLOCKED_IMAGE_WINERRORS = frozenset({225, 577, 1260})
 
 _SENTENCEPIECE_GUARD_RESULT = None
 
+# On Windows the extension is disabled by DEFAULT, not only when its load is refused. A
+# deliberate temporary measure: the refusals arrive faster than they can be diagnosed one
+# machine at a time, they are silent (a substituted chat template, not an error), and the
+# cost of going without is now small. transformers 4.57.6 gates 67 tokenizer entries on
+# sentencepiece and 5.x gates 8; across the 93 models the Unsloth notebooks use, 3 break
+# without it on 4.57.6 and none on 5.5.0 or 5.10.4.
+#
+# The package stays installed and installable. This flag is the way back.
+_DISABLE_SENTENCEPIECE_VARIABLE = "UNSLOTH_DISABLE_SENTENCEPIECE"
+_SENTENCEPIECE_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_SENTENCEPIECE_FALSY = frozenset({"0", "false", "no", "off"})
+
+
+def sentencepiece_disabled_by_policy():
+    """Why policy disables sentencepiece here, or None to leave it to the import probe.
+
+    ``"environment"`` when ``UNSLOTH_DISABLE_SENTENCEPIECE`` is truthy, which applies on
+    every platform, and ``"windows"`` for the platform default. Off Windows there is no
+    default, and WSL reports ``linux``, so a WSL session is treated as the Linux box it is
+    rather than inheriting a Windows policy that has no loader to justify it.
+
+    An unrecognised value falls back to the platform default rather than raising. This
+    runs inside ``import unsloth``, where a typo in an environment variable must not cost
+    the user the whole package.
+
+    A falsy value only says policy is not disabling it. It cannot re-enable an extension
+    the loader refuses, because the caller runs the block detection afterwards either way.
+    """
+    value = (os.environ.get(_DISABLE_SENTENCEPIECE_VARIABLE) or "").strip().lower()
+    if value in _SENTENCEPIECE_TRUTHY:
+        return "environment"
+    if value in _SENTENCEPIECE_FALSY:
+        return None
+    return "windows" if sys.platform == "win32" else None
+
 
 def smart_app_control_state():
     """Smart App Control's state: 0 off, 1 enforced, 2 evaluation, or None if unknown.
@@ -6127,6 +6162,37 @@ def sentencepiece_import_error():
     return None
 
 
+def _materialise_tokenizer_mapping(import_utils) -> None:
+    """Import transformers' auto tokenizer module before the flag is changed.
+
+    Ordering is load bearing, and the intuitive order is the wrong one. On 4.52 through
+    4.57, ``models/auto/tokenization_auto.py`` evaluates ``is_sentencepiece_available()``
+    while building ``TOKENIZER_MAPPING_NAMES`` (71 times in 4.57.6). Patch first and the
+    slow entries are built as ``None``; ``tokenizer_class_from_name`` then misses the
+    mapping and falls through to the dummy-class fallback, which does
+    ``importlib.import_module("transformers")`` and reaches an unguarded top level
+    ``import sentencepiece as spm`` in the slow tokenizer module. The user gets the raw
+    loader error the guard exists to prevent. Measured on 4.57.6 with the extension
+    blocked: no patch fails, patching first fails identically, patching after this import
+    loads the tokenizer.
+
+    On 5.x the mapping gates only 8 model types and every ordering works, so doing it
+    unconditionally costs nothing and keeps one code path.
+
+    Only for the real transformers module. The synthetic modules the parity tests pass in
+    must not drag the real package into the process, or the tests stop testing the shapes
+    they claim to.
+    """
+    if not getattr(import_utils, "__name__", "").startswith("transformers"):
+        return
+    try:
+        importlib.import_module("transformers.models.auto.tokenization_auto")
+    except Exception:
+        # A transformers too broken to import its own auto module is not something to
+        # fail on here; the caller still patches, and the flag is still corrected.
+        pass
+
+
 def _tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
     """Make every consumer of ``is_sentencepiece_available`` answer False.
 
@@ -6159,6 +6225,10 @@ def _tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
     original = getattr(import_utils, "is_sentencepiece_available", None)
     if original is None:
         return False
+
+    # Before anything is rebound. See the helper: on 4.x the mapping must already be
+    # built, or the correction sends the user into the loader error instead of past it.
+    _materialise_tokenizer_mapping(import_utils)
 
     # First, in case a future version reads a global again.
     if hasattr(import_utils, "_sentencepiece_available"):
@@ -6195,7 +6265,12 @@ def _tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
     # requires_backends still tells the user how to install it.
     if isinstance(mapping, dict):
         for key, entry in list(mapping.items()):
-            if isinstance(entry, tuple) and entry and entry[0] is original:
+            if not isinstance(entry, tuple) or not entry:
+                continue
+            # By key as well as by identity. Identity alone misses an entry transformers
+            # built from a different callable, and key alone would rewrite an unrelated
+            # backend, so either match is enough but the name is checked too.
+            if entry[0] is original or str(key).split(">")[0].split("=")[0].strip() == "sentencepiece":
                 mapping[key] = (_sentencepiece_is_absent,) + tuple(entry[1:])
 
     try:
@@ -6205,7 +6280,11 @@ def _tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
 
 
 def disable_sentencepiece_if_blocked():
-    """Tell transformers sentencepiece is absent when its extension will not load.
+    """Tell transformers sentencepiece is absent when policy or the loader says so.
+
+    Two triggers, checked in that order. ``sentencepiece_disabled_by_policy`` covers the
+    Windows default and the explicit flag; the block detection below covers a machine
+    whose extension is genuinely refused.
 
     Smart App Control blocks ``_sentencepiece.cp313-win_amd64.pyd`` by reputation, and
     ``transformers._is_package_available`` decides on ``find_spec`` plus installed
@@ -6222,15 +6301,19 @@ def disable_sentencepiece_if_blocked():
     shipping ``tokenizer.json``, and makes the models that genuinely need the extension
     fail with the backend message that names it instead of a loader error.
 
-    Returns True only when a real block was found and the flag was corrected. On every
-    other machine this is a no-op: not Windows, not installed, or it imported.
+    Returns True only when sentencepiece was actually turned off here. On every other
+    machine this is a no-op: policy is silent and the extension imported.
     """
     global _SENTENCEPIECE_GUARD_RESULT
     if _SENTENCEPIECE_GUARD_RESULT is not None:
         return _SENTENCEPIECE_GUARD_RESULT
 
-    exception = sentencepiece_import_error()
-    if exception is None:
+    # Policy first, and the probe strictly as a fallback. The Windows default exists so
+    # the extension is never touched, so probing first would hand the blocked file exactly
+    # the load the default is there to avoid.
+    policy = sentencepiece_disabled_by_policy()
+    exception = sentencepiece_import_error() if policy is None else None
+    if policy is None and exception is None:
         _SENTENCEPIECE_GUARD_RESULT = False
         return False
 
@@ -6243,6 +6326,30 @@ def disable_sentencepiece_if_blocked():
 
     if not _tell_transformers_sentencepiece_is_absent(_import_utils):
         return False
+
+    if exception is None:
+        # Logged, not warned. A block is a fault on one machine that the user has to act
+        # on, so it earns a warning. The policy default is the expected state of every
+        # healthy Windows box, and warnings.warn prints by default: a UserWarning on every
+        # import unsloth, in every script and every notebook cell, is the kind of noise
+        # that teaches people to stop reading Unsloth's warnings. The models that need the
+        # extension still fail loudly at the point of use with the backend message naming
+        # it, which is where the question is actually asked.
+        if policy == "environment":
+            logger.info(
+                f"Unsloth: sentencepiece is disabled because {_DISABLE_SENTENCEPIECE_VARIABLE} "
+                "is set. transformers will use fast tokenizers only."
+            )
+        else:
+            logger.info(
+                "Unsloth: sentencepiece is disabled by default on Windows, so transformers "
+                "will use fast tokenizers only. Nothing was blocked and nothing was "
+                "uninstalled; this is a temporary measure while the Windows loader "
+                f"refusals are worked through. Set {_DISABLE_SENTENCEPIECE_VARIABLE}=0 to "
+                "use it again."
+            )
+        _SENTENCEPIECE_GUARD_RESULT = True
+        return True
 
     winerror = getattr(exception, "winerror", None)
     if winerror in _BLOCKED_IMAGE_WINERRORS:

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -6270,7 +6270,10 @@ def _tell_transformers_sentencepiece_is_absent(import_utils) -> bool:
             # By key as well as by identity. Identity alone misses an entry transformers
             # built from a different callable, and key alone would rewrite an unrelated
             # backend, so either match is enough but the name is checked too.
-            if entry[0] is original or str(key).split(">")[0].split("=")[0].strip() == "sentencepiece":
+            if (
+                entry[0] is original
+                or str(key).split(">")[0].split("=")[0].strip() == "sentencepiece"
+            ):
                 mapping[key] = (_sentencepiece_is_absent,) + tuple(entry[1:])
 
     try:


### PR DESCRIPTION
> **Field measurement, added after opening, and corrected since:** the exact file that produced the 3077 now loads on that same machine, with Smart App Control still enforcing and the file still unsigned. The block was real, sits in the event log, and is no longer active, so this guard is a no-op there today.
>
> I first wrote that this was "the reputation half of the mechanism". That claim is withdrawn. Eight candidate mechanisms have since been tested and eliminated on that machine, including the two I proposed: signature status, content-hash novelty, path and filename, Mark-of-the-Web, Defender definitions, SAC policy and Windows updates, the trust of the writing process, and an unreachable ISG lookup. **The cause is unknown.** This PR is insurance for a window whose trigger nobody has identified, and it should not be read as understanding the mechanism. Full numbers in the comment below.

## What happens

Smart App Control refused `_sentencepiece.cp313-win_amd64.pyd` on a reporting machine. Code Integrity event 3077, correlated by `ActivityID` with 3033, two 3089s and a 3118:

```
Code Integrity determined that a process
  (...\Programs\Python\Python313\python.exe)
attempted to load
  ...\.unsloth\studio\unsloth_studio\Lib\site-packages\sentencepiece\_sentencepiece.cp313-win_amd64.pyd
that did not meet the Enterprise signing level requirements or violated code
integrity policy.
```

The 3089 detail reports publisher `Unknown`, issuer `Unknown`, signature type `None`. The loading `python.exe` is Authenticode-valid; a signed parent bought nothing. The file is present and healthy on disk. Only the loader will not take it, so no payload or integrity check can see this.

## Why it is silent

`transformers` decides availability with `_is_package_available`, which reads `find_spec` plus installed metadata and loads nothing. So `is_sentencepiece_available()` answers **True** on that machine while every import of the package raises. The package's own `__init__.py` does a bare `from . import _sentencepiece` at module scope, so there is no version of this where the import quietly succeeds.

The loud consequence is a tokenizer that will not build. The quiet one is what the field report describes as failing silently: `resolve_native_chat_template` catches everything `AutoTokenizer.from_pretrained` raises, logs one warning among many, and returns `None`. The model keeps generating under a substituted chat template. Wrong prompt formatting, nothing naming a cause.

## The changes

**`unsloth.import_fixes.disable_sentencepiece_if_blocked`** corrects the flag `transformers` reads, on either of two triggers: the Windows default described below, or an import that really fails. That puts the process in the configuration of a machine where sentencepiece was never installed, which is supported for every model shipping `tokenizer.json`, and makes a model that genuinely needs the extension fail with the backend message naming it rather than a loader error from inside the tokenizer machinery.

**`resolve_native_chat_template`** classifies a refused module load (winerror 577 App Control / Smart App Control, 225 antivirus, 1260 AppLocker or SRP, walking the exception chain) and reports it at error level naming the file and the remedy. The template still falls back, because nothing here can invent a template that will not load. The operator now has a line to act on.

## Probe-driven, not policy-driven

Smart App Control blocks by reputation, one file at a time. It is on for many machines whose sentencepiece loads perfectly, and off on machines where an antivirus refuses the same file. Deciding on the policy state would take the tokenizer away from the first group and miss the second entirely.

The state is read only to phrase the warning, after a block is already confirmed, from `HKLM\SYSTEM\CurrentControlSet\Control\CI\Policy`, which a standard user can read. Never `Win32_DeviceGuard`, which needs admin. No elevation, no subprocess, no PowerShell. On a healthy machine the registry is never touched at all.

## Why this cannot break an install

- Off Windows the guard returns before doing any work. Linux and macOS never execute a line of it.
- On Windows it runs one `import sentencepiece`. If that succeeds, it returns immediately: patches nothing, warns nothing, reads no registry.
- It acts only when the import genuinely raises, which is a state where the tokenizer was already broken.
- Every failure path in the SAC read returns "unknown", never "off".

Covered by tests: a working extension is left untouched, Smart App Control being **on** with a working extension changes nothing, an uninstalled sentencepiece is not treated as a block, and the guard costs no import off Windows.

## Scope this does not cover

From the same probe run in #10408: the Studio venv holds **657 unsigned PE files across 70 packages, 463 of them `.pyd`**. sentencepiece ranks 63rd of 70 by count. It was blocked for sitting on the startup import path, not for being special, and a different feature path draws a different ticket.

This fixes the one file whose availability flag independently lies about it, and makes any other refused extension reported rather than swallowed at the chat-template lookup. The remaining 656 are still exposed, and signing our own binaries does not reach them.

## Off by default on Windows, with a way back

Added after the above. On Windows sentencepiece is now disabled by **default**, not only when a load is refused, so the extension is never touched there. `UNSLOTH_DISABLE_SENTENCEPIECE` controls it on every platform: truthy disables anywhere, falsy declines the policy. A falsy value cannot re-enable an extension the loader refuses, because the block detection still runs afterwards.

The package stays installed and installable. This is a temporary measure while the refusals are worked through, and the flag is the way back.

What the default costs, measured rather than estimated. transformers 4.57.6 gates 67 tokenizer entries on sentencepiece; 5.x gates 8, none of them in the llama, mistral, gemma or qwen families. Sweeping all 93 models the notebooks use, loading each in a clean interpreter with sentencepiece present and then genuinely blocked:

| transformers | models tested | break without sentencepiece |
|---|---|---|
| 4.57.6 | 91 | 3 |
| 5.5.0 | 93 | 0 |
| 5.10.4 | 93 | 0 |

The three on 4.57.6 are `unsloth/mistral-7b-v0.3`, `unsloth/mistral-7b-instruct-v0.3-bnb-4bit` and `unsloth/ERNIE-4.5-21B-A3B-PT`. Studio installs 5.5.0, so the default costs Studio users nothing.

## The ordering fix

The guard has to run **after** `transformers.models.auto.tokenization_auto` is imported, and this branch had it the other way round, which made it inert on the whole 4.x range.

4.52 through 4.57 evaluate `is_sentencepiece_available()` while building `TOKENIZER_MAPPING_NAMES` (71 times in 4.57.6). Correct the flag first and the slow entries are built as `None`, `tokenizer_class_from_name` misses the mapping, and the dummy-class fallback at `models/auto/tokenization_auto.py:797-801` does `importlib.import_module("transformers")` and reaches an unguarded top level `import sentencepiece as spm`. The user gets the raw loader error this guard exists to prevent.

Measured on 4.57.6 with the extension blocked:

| | `unsloth/gemma-3-270m-it` | `unsloth/mistral-7b-v0.3` |
|---|---|---|
| no patch | DLL load failed | DLL load failed |
| patched before | DLL load failed | DLL load failed |
| patched after | loads | `Cannot instantiate this tokenizer from a slow version` |

Fixed inside the guard, which now imports that module itself before rebinding anything, rather than by moving a call site that a later reorder could undo. On 5.x every ordering works, so this costs nothing there and keeps one code path. It only does this for the real `transformers` module, so the synthetic modules the parity tests use are not silently replaced by the installed package.

`BACKENDS_MAPPING` entries are now matched by key name as well as by function identity. `Backend.is_satisfied` calls `_is_package_available` directly and still answers True after the patch; that is unreachable today because every shipped backend requirement uses the bare name, and it stops being unreachable the moment a versioned one is declared.

**transformers 4.51.3 cannot be fixed by any ordering.** `from_pretrained` resolves the config's slow `tokenizer_class` unconditionally and consults no availability flag, so it reaches the unguarded import directly. It is inside the declared pin and is unprotected.

## Compatibility

The patch produces `is_sentencepiece_available()` False and preserves the `BACKENDS_MAPPING` install message on 4.57.6, 5.0.0, 5.2.0, 5.5.0, 5.10.4, 5.13.0 and 5.16.1. There is no third code shape anywhere in that range: 4.x keeps a module global, 5.x has an `lru_cache` function plus captured consumers, and both are handled.

torch, PEFT and TRL never consult sentencepiece. vllm has an independent path through `mistral_common` that this neither affects nor fixes. WSL reports `sys.platform == "linux"` and is treated as Linux, which is correct because App Control and AppLocker do not enforce over ELF binaries in the guest.

## Tests

```
tests/studio/test_sentencepiece_guard_parity.py                         67 passed
tests/test_windows_sentencepiece_blocked.py
studio/backend/tests/test_native_template_blocked_extension.py
tests/test_python39_compatibility.py
  the four together                                                     93 passed

every sentencepiece-adjacent suite            1 failed, 2915 passed, 285 skipped
```

The single failure is `tests/test_torchao_nf4tensor_move.py::test_it_is_idempotent`, which fails identically on a clean `main` worktree, so it is pre-existing and unrelated.

The parity suite drives both copies of the guard through the same cases, and now pins the ordering itself: asserting only that `is_sentencepiece_available()` ends up False passes in both orderings and would have caught none of the defect above.

Studio was driven end to end on Linux with the flag set and unset, restarting between runs, with the backend's environment read back from `/proc/<pid>/environ` and transformers asked directly whether it still saw sentencepiece. Both runs load the same local GGUF and stream a reply.


