### PR TITLE
Keep model.device on the decoder while the embedding is offloaded to RAM

### DIFF
--- a/tests/test_offload_device_property.py
+++ b/tests/test_offload_device_property.py
@@ -1,0 +1,128 @@
+"""Tests _pin_device_to_decoder in vision.py: while the embedding is offloaded to RAM,
+`model.device` must report the decoder device, because `inputs.to(model.device)` is the
+documented idiom and CPU ids make generation build position_ids on the wrong device.
+No GPU needed: a meta parameter stands in for the accelerator."""
+
+import ast, os
+import torch
+import torch.nn as nn
+
+HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VISION = os.path.join(HERE, "unsloth", "models", "vision.py")
+
+
+def _load_pinner():
+    src = open(VISION, encoding = "utf-8").read()
+    mod = ast.parse(src)
+    for node in mod.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_pin_device_to_decoder":
+            ns = {"torch": torch}
+            exec(ast.get_source_segment(src, node), ns)
+            return ns["_pin_device_to_decoder"]
+    raise AssertionError("_pin_device_to_decoder not found in vision.py")
+
+
+pin = _load_pinner()
+DECODER = "meta" if not torch.cuda.is_available() else "cuda"
+
+
+class _Base(nn.Module):
+    """Stands in for transformers' ModuleUtilsMixin.device: first parameter wins."""
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+
+def _model(cls, decoder_device = DECODER):
+    model = cls()
+    model.embed_tokens = nn.Embedding(32, 8)
+    model.layer = nn.Linear(8, 8, bias = False)
+    model.layer.to(decoder_device)
+    return model
+
+
+def test_reports_decoder_device_while_offloaded():
+    class _M(_Base):
+        pass
+
+    model = _model(_M)
+    assert model.device.type == "cpu", "embedding must be first, or the repro is not reproduced"
+    assert pin(model) is True
+    assert model.device.type == DECODER, model.device
+
+
+def test_untouched_model_of_same_class_is_unaffected():
+    # The property lives on the class, so a second instance that never offloaded must
+    # keep the stock answer.
+    class _M(_Base):
+        pass
+
+    pin(_model(_M))
+    assert _model(_M).device.type == "cpu"
+
+
+def test_whole_model_on_cpu_falls_back():
+    # model.to("cpu") after an offload: there is no accelerator parameter left to report.
+    class _M(_Base):
+        pass
+
+    model = _model(_M, decoder_device = "cpu")
+    pin(model)
+    assert model.device.type == "cpu", model.device
+
+
+def test_follows_a_later_move():
+    class _M(_Base):
+        pass
+
+    model = _model(_M, decoder_device = "cpu")
+    pin(model)
+    model.layer.to(DECODER)
+    assert model.device.type == DECODER, model.device
+
+
+def test_flag_adds_no_parameters_or_state():
+    class _M(_Base):
+        pass
+
+    model = _model(_M)
+    before = list(model.state_dict())
+    pin(model)
+    assert list(model.state_dict()) == before
+    assert [n for n, _ in model.named_parameters()] == ["embed_tokens.weight", "layer.weight"]
+
+
+def test_repeated_pin_is_idempotent():
+    class _M(_Base):
+        pass
+
+    model = _model(_M)
+    pin(model)
+    pin(model)
+    assert model.device.type == DECODER, model.device
+
+
+def test_class_without_device_property_is_left_alone():
+    class _M(nn.Module):
+        pass
+
+    assert pin(_model(_M)) is False
+
+
+if __name__ == "__main__":
+    test_reports_decoder_device_while_offloaded()
+    print("[PASS] offloaded model reports the decoder device")
+    test_untouched_model_of_same_class_is_unaffected()
+    print("[PASS] non-offloaded instance of the same class unaffected")
+    test_whole_model_on_cpu_falls_back()
+    print("[PASS] all-cpu model falls back to the stock answer")
+    test_follows_a_later_move()
+    print("[PASS] a later .to() move is followed")
+    test_flag_adds_no_parameters_or_state()
+    print("[PASS] no extra parameters or state_dict keys")
+    test_repeated_pin_is_idempotent()
+    print("[PASS] repeated pin is idempotent")
+    test_class_without_device_property_is_left_alone()
+    print("[PASS] a class with no device property is left alone")
+    print("OK: model.device reports the decoder device while the embedding is offloaded")

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -483,7 +483,6 @@ def _pin_device_to_decoder(model):
                 for param in self.parameters():
                     if param.device.type != "cpu":
                         return param.device
-                pass
             return original.fget(self)
 
         cls.device = property(_unsloth_device)

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -464,6 +464,35 @@ def _install_offload_embedding_hooks(embed_tokens, output_embeddings, return_dev
     return True
 
 
+def _pin_device_to_decoder(model):
+    # `model.device` is the device of the first parameter, and the embedding we offload is it, so
+    # the documented `inputs.to(model.device)` hands a CUDA model CPU ids. The lookup itself still
+    # works through the hooks above, but `cache_position` is built from `input_ids.device`, so
+    # `position_ids` stays on the CPU while the hidden states are already on CUDA and the rotary
+    # embedding dies on a cpu/cuda matmul. Report the first parameter still on an accelerator
+    # instead, read live so `model.to()` moves are followed and a whole-model move to the CPU
+    # falls back to the original answer.
+    cls = type(model)
+    if not cls.__dict__.get("_unsloth_device_skips_offload", False):
+        original = getattr(cls, "device", None)
+        if not isinstance(original, property):
+            return False
+
+        def _unsloth_device(self):
+            if getattr(self, "_unsloth_embedding_offloaded", False):
+                for param in self.parameters():
+                    if param.device.type != "cpu":
+                        return param.device
+                pass
+            return original.fget(self)
+
+        cls.device = property(_unsloth_device)
+        cls._unsloth_device_skips_offload = True
+    # A plain bool, so nn.Module.__setattr__ leaves it off the parameter and module registries.
+    model._unsloth_embedding_offloaded = True
+    return True
+
+
 def _embeddings_are_tied(input_embeddings, output_embeddings):
     # A tied lm_head reuses this weight, so offloading to CPU would strand the output projection.
     if input_embeddings is None or output_embeddings is None:
@@ -1709,6 +1738,7 @@ class FastBaseModel:
 
                     # Device-safe embedding offload.
                     _install_offload_embedding_hooks(embed_tokens, out_embed, _embed_device)
+                    _pin_device_to_decoder(model)
                     # GPU memory must be freed explicitly or it will not be freed.
                     clean_gpu_cache()
                     gc.collect()


### PR DESCRIPTION
### Symptom

With the embedding offloaded to RAM (either chosen automatically on a memory tight card, or asked for with `offload_embedding = True`), the documented Hugging Face idiom fails:

```python
inputs = tokenizer("Explain why the sky is blue.", return_tensors = "pt").to(model.device)
model.generate(**inputs)
```

```
RuntimeError: Expected all tensors to be on the same device, but got mat2 is on cpu,
different from other tensors on cuda:0 (when checking argument in method wrapper_CUDA_bmm)
```

raised at `position_embeddings = self.rotary_emb(hidden_states, position_ids)`. Passing the ids to `cuda:0` by hand worked, which is what made this look like a rotary embedding problem.

### Root cause

The offload itself is fine. `_install_offload_embedding_hooks` sends the ids down to the CPU weight and brings the hidden states back to the decoder device, so the lookup is correct in isolation.

The damage is second order. `model.embed_tokens.weight` is the model's first parameter, and `ModuleUtilsMixin.device` is just the device of the first parameter, so `model.device` reports `cpu` on a model whose decoder is entirely on CUDA. Users then hand the model CPU `input_ids`. The embedding survives that, but `cache_position` is built from `input_ids.device` in `_get_initial_cache_position`, so `position_ids` stays on the CPU while the hidden states are already back on CUDA, and `inv_freq_expanded.to(x.device) @ position_ids_expanded` is a CUDA by CPU matmul.

### The fix

Correcting `model.device` is the right level. The rotary embedding is only the first consumer to hit the bad device, every other consumer of `model.device` is wrong in the same way, and patching position tensors inside the offload pre-hook would fix the one caller I happened to reproduce and leave the rest.

`_pin_device_to_decoder` installs a `device` property on the model's class that, for instances flagged as having an offloaded embedding, returns the first parameter that is not on the CPU, and otherwise defers to the stock property. Consequences worth stating:

- It is read live off `parameters()`, so a later `model.to()` is followed rather than a device captured at load time.
- A whole model move to the CPU leaves no accelerator parameter, and the stock answer is returned.
- The flag is per instance, so another model of the same class that never offloaded keeps stock behaviour.
- The flag is a plain bool, so `nn.Module.__setattr__` keeps it out of the parameter and module registries and `state_dict()` is unchanged.
- It is only reached from inside `if offload_embedding:`, so the declines in `_resolve_offload_embedding` (tied embeddings, dispatched models, distributed launches, unsupported platforms, vLLM) and the ordinary large GPU path are untouched.

### Verification

Repro (forces the offload so it reproduces on any card):

```
python3 -u scripts/repro_embed_offload.py
```

`unsloth/gpt-oss-20b-unsloth-bnb-4bit`, 4bit, `offload_embedding = True`, transformers 4.57.6, torch 2.14.

Before:

```
cpu_params      : ['model.embed_tokens.weight']
model.device    : cpu
=== A: inputs.to(model.device)  [the documented idiom] -> input on cpu ===
   RuntimeError: Expected all tensors to be on the same device, but got mat2 is on cpu, ...
   site: position_embeddings = self.rotary_emb(hidden_states, position_ids)
=== B: inputs on the decoder device [workaround] -> input on cuda:0 ===
   OK: ' The sky is blue because the atmosphere scat'
```

After:

```
cpu_params      : ['model.embed_tokens.weight']
model.device    : cuda:0
=== A: inputs.to(model.device)  [the documented idiom] -> input on cuda:0 ===
   OK: ' The sky is blue because the atmosphere scat'
=== B: inputs on the decoder device [workaround] -> input on cuda:0 ===
   OK: ' The sky is blue because the atmosphere scat'
```

`cpu_params` still lists `model.embed_tokens.weight`, so the VRAM saving is retained. This is a reporting fix, not a retreat from the offload.

Control with `offload_embedding = False` on the same script and model: loads, `cpu_params : []`, `model.device : cuda:0`, both arms generate the same text.

New `tests/test_offload_device_property.py` covers the decoder device, the non-offloaded instance of the same class, the all CPU fallback, a later `.to()` move, `state_dict()` being unchanged, repeated pins, and a class with no `device` property. It needs no GPU. Existing `tests/test_offload_embedding_hooks.py`, `test_offload_tied_autodisable.py`, `test_offload_tied_guard.py` and `test_offloaded_parameter_hint.py` still pass.
