### PR TITLE
Fix Studio vision mmproj batch defaults

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5579,6 +5579,57 @@ def _emitted_n_batch(n_batch: Optional[int], n_parallel: int) -> Optional[int]:
     return max(int(n_batch), max(2, int(n_parallel or 1)))
 
 
+# Vision AND audio towers run non-causal, and llama.cpp asserts the physical
+# micro-batch covers the whole encoded chunk (llama-context.cpp: "non-causal
+# attention requires n_ubatch >= n_tokens"). ggml-org/llama.cpp#18757 is the image
+# side of it and #21816 the audio side, so the floor is keyed on a projector
+# launching at all, not on the modality it serves. 2048 clears every Gemma 4 visual
+# token budget (the largest is 1120) and the 600-token audio chunk in #21816.
+_MMPROJ_NON_CAUSAL_MIN_BATCH = 2048
+
+
+def _mmproj_batch_floor(
+    n_batch: Optional[int],
+    n_ubatch: Optional[int],
+    env: Optional[Mapping[str, str]] = None,
+    floor: int = _MMPROJ_NON_CAUSAL_MIN_BATCH,
+) -> tuple[int, int]:
+    """The (batch, ubatch) a launch that opens a projector has to emit.
+
+    Called by the loader and by the two estimators that price the same launch, so a
+    panel and a training-guard verdict cannot describe a child sized differently
+    from the one that starts.
+
+    Three things the floor has to respect. A larger first-class field is the user
+    asking for a bigger batch and is kept. So is a larger LLAMA_ARG_BATCH /
+    LLAMA_ARG_UBATCH: the emitted flag beats the environment in llama.cpp, so
+    writing the floor from the field alone would silently downgrade an inherited
+    4096 to 2048 and reinstate the very assert this raises past. And llama.cpp
+    derives ``cparams.n_ubatch = min(n_batch, n_ubatch)``, so a micro-batch above
+    the batch is clamped back down; carry the batch up with it or the raise buys
+    nothing.
+    """
+    source_env = os.environ if env is None else env
+
+    def _resolved(value: Optional[int], env_name: str) -> int:
+        best = floor
+        if value is not None:
+            best = max(best, int(value))
+        raw = source_env.get(env_name)
+        if raw:
+            try:
+                best = max(best, int(raw))
+            except (TypeError, ValueError):
+                # Unparseable env is what llama.cpp itself ignores, so ignore it here
+                # rather than letting it decide the budget.
+                pass
+        return best
+
+    batch = _resolved(n_batch, "LLAMA_ARG_BATCH")
+    ubatch = _resolved(n_ubatch, "LLAMA_ARG_UBATCH")
+    return max(batch, ubatch), ubatch
+
+
 def _extra_args_split_mode(
     extra_args: Optional[Iterable[str]], env: Optional[Mapping[str, str]] = None
 ) -> Optional[str]:
@@ -12751,7 +12802,6 @@ class LlamaCppBackend:
         )
 
     _DEFAULT_N_UBATCH = _DEFAULT_LLAMA_N_UBATCH
-    _MMPROJ_NON_CAUSAL_MIN_BATCH = 2048
     _COMPUTE_BUFFER_SAFETY = 1.15  # upper-bound margin on the compute-buffer estimate
     # Soft VRAM the modeled terms omit; charged to the fit budget on tight tiers (#6682).
     _CUDA_CONTEXT_RESERVE_BYTES = 320 * 1024 * 1024  # CUDA ctx + cuBLAS workspace (~330 MiB)
@@ -19414,23 +19464,37 @@ class LlamaCppBackend:
                 # mmproj passing the family-name heuristic must not flip a non-VLM
                 # GGUF into vision mode.
                 effective_is_vision = bool(launch_mmproj_path) and bool(is_vision)
-                if effective_is_vision:
-                    # Vision encoders use non-causal attention, where llama.cpp requires
-                    # the physical micro-batch to cover the full image-token batch.
-                    n_batch = max(
-                        self._MMPROJ_NON_CAUSAL_MIN_BATCH,
-                        int(n_batch or 0),
-                    )
-                    n_ubatch = max(
-                        self._MMPROJ_NON_CAUSAL_MIN_BATCH,
-                        int(n_ubatch or 0),
-                    )
-                    _effective_ubatch = _ubatch_for_slots(n_parallel)
                 if is_vision and not effective_is_vision and not _pv_mmproj_unpinnable:
                     logger.warning(
                         "Vision-capable GGUF loaded without a usable mmproj; "
                         "image input will be disabled for this session"
                     )
+                # A projector is about to launch, so raise past the non-causal
+                # micro-batch assert (#10559). Gated on effective_is_vision because that
+                # is the same condition --mmproj is emitted on below: no projector in the
+                # child, nothing non-causal to size for. Deliberately NOT narrowed to
+                # image-capable projectors -- an audio tower is non-causal too and trips
+                # the identical assert (ggml-org/llama.cpp#21816), so excluding it would
+                # leave speech models crashing on the bug this fixes.
+                #
+                # Before every sizing consumer and after the resolution that decides
+                # whether there is a projector at all, so the fit, the slot search and
+                # every compute-buffer reserve are priced from the batch that launches.
+                if effective_is_vision:
+                    _floor_from = (n_batch, n_ubatch)
+                    n_batch, n_ubatch = _mmproj_batch_floor(n_batch, n_ubatch)
+                    if _floor_from != (n_batch, n_ubatch):
+                        # Said out loud for the same reason the slot floor below says it:
+                        # the emitted flag beats an inherited LLAMA_ARG_BATCH, so a user
+                        # who set one deserves to see it move rather than wonder.
+                        logger.info(
+                            "Raising batch to %d and micro-batch to %d for the projector: "
+                            "its encoder runs non-causal and llama.cpp aborts when a "
+                            "micro-batch cannot hold one whole image or audio chunk.",
+                            n_batch,
+                            n_ubatch,
+                        )
+                    _effective_ubatch = _ubatch_for_slots(n_parallel)
                 # Seed before the try: the except (GPU-selection failure ->
                 # --fit on) falls through to the launch which reads this, and the
                 # probe that assigns it may throw first. Captured before manual

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17870,6 +17870,40 @@ class LlamaCppBackend:
         return env.pop("LLAMA_ARG_N_PARALLEL", None) is not None or dropped
 
     @staticmethod
+    def _restore_batch_args(
+        cmd: list[str], n_batch: Optional[int], n_ubatch: Optional[int], n_parallel: int
+    ) -> list[str]:
+        """Put the REQUESTED --batch-size / --ubatch-size back on a retry argv.
+
+        The projector floor is bought with compute buffers four times the size, and the
+        text-only retry has just dropped the projector, so nothing on that child encodes
+        non-causally and the raise buys nothing. Leaving it costs 1.8-2.3 GB on a
+        12B-class VLM in exactly the recovery meant to rescue a load that ran out of
+        memory with the projector attached.
+
+        ``None`` means the request named no batch at all, so the flag is removed rather
+        than pinned: emitting nothing is what lets llama.cpp apply its own defaults.
+        """
+        emitted = {
+            "--batch-size": _emitted_n_batch(n_batch, n_parallel),
+            "--ubatch-size": n_ubatch,
+        }
+        out: list[str] = []
+        skip_value = False
+        for tok in cmd:
+            if skip_value:
+                skip_value = False
+                continue
+            if tok in emitted:
+                skip_value = True
+                continue
+            out.append(tok)
+        for flag, value in emitted.items():
+            if value is not None:
+                out.extend([flag, str(value)])
+        return out
+
+    @staticmethod
     def _strip_mmproj_args(cmd: list[str]) -> list[str]:
         """Return cmd without the '--mmproj <path>' pair (text-only retry).
         Every other flag is preserved; a no-op when --mmproj is absent.
@@ -19470,17 +19504,32 @@ class LlamaCppBackend:
                         "image input will be disabled for this session"
                     )
                 # A projector is about to launch, so raise past the non-causal
-                # micro-batch assert (#10559). Gated on effective_is_vision because that
-                # is the same condition --mmproj is emitted on below: no projector in the
-                # child, nothing non-causal to size for. Deliberately NOT narrowed to
+                # micro-batch assert (#10559). Deliberately NOT narrowed to
                 # image-capable projectors -- an audio tower is non-causal too and trips
                 # the identical assert (ggml-org/llama.cpp#21816), so excluding it would
                 # leave speech models crashing on the bug this fixes.
                 #
+                # Studio's own projector is not the only one that reaches the child.
+                # _resolve_launch_mmproj_path only ever looks at intent.mmproj_path, so a
+                # --mmproj typed into Advanced Arguments leaves effective_is_vision False
+                # while the extras, appended last, still hand the child a projector to
+                # load. That launch hit the assert with no flags emitted at all, which is
+                # #10559 reached through the settings box instead of the model picker.
+                _extras_mmproj = (
+                    None
+                    if extra_args_disable_mmproj(extra_args)
+                    else _extra_args_device(extra_args, {"--mmproj", "-mm"})
+                )
+                _launch_opens_projector = bool(effective_is_vision) or bool(
+                    _extras_mmproj and os.path.isfile(_extras_mmproj)
+                )
                 # Before every sizing consumer and after the resolution that decides
                 # whether there is a projector at all, so the fit, the slot search and
                 # every compute-buffer reserve are priced from the batch that launches.
-                if effective_is_vision:
+                # Kept for the text-only retry far below, which drops the projector and
+                # so has nothing non-causal left to hold: see _restore_batch_args.
+                _requested_batch_pair = (n_batch, n_ubatch)
+                if _launch_opens_projector:
                     _floor_from = (n_batch, n_ubatch)
                     n_batch, n_ubatch = _mmproj_batch_floor(n_batch, n_ubatch)
                     if _floor_from != (n_batch, n_ubatch):
@@ -25146,7 +25195,11 @@ class LlamaCppBackend:
                                     "session; check memory, GPU/driver logs, or update Unsloth."
                                 )
                                 self._mmproj_fallback_reason = "projector_startup_failure"
-                            cmd = self._strip_mmproj_args(_vision_gpu_cmd)
+                            cmd = self._restore_batch_args(
+                                self._strip_mmproj_args(_vision_gpu_cmd),
+                                *_requested_batch_pair,
+                                n_parallel,
+                            )
                             _unified_withdraw_if_unneeded(cmd, why = "The text-only retry")
                             # This retry bypasses _spawn_and_wait, so refresh the
                             # launched-argv snapshot itself -- the zero-offload

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5607,11 +5607,16 @@ def _mmproj_batch_floor(
     the field before the environment, because the field is emitted as a flag and
     arg.cpp lets a flag overwrite what it read from the environment.
 
-    Two llama.cpp normalizations have to happen BEFORE the floor, not after. A zero
-    micro-batch means "use batch", so a 4096/0 pair is really 4096/4096 and
-    flooring the literal zero would emit 4096/2048 -- a downgrade wearing a raise.
-    And ``cparams.n_ubatch = min(n_batch, n_ubatch)`` clamps a micro-batch above
-    its batch, so the batch is carried up with it or the raise buys nothing.
+    Resolve exactly as llama.cpp does before flooring, or the floor reads a number
+    the launch was never going to run at. Both of its normalizations come first: a
+    zero micro-batch means "use batch", so a 4096/0 pair is really 4096/4096 and
+    flooring the literal zero would emit 4096/2048, a downgrade wearing a raise;
+    and ``cparams.n_ubatch = min(n_batch, n_ubatch)`` clamps a micro-batch above
+    its batch, so an explicit 2048 batch beside an inherited 32768 micro-batch runs
+    at 2048, and taking the raw 32768 into the floor would emit 32768 for both --
+    overriding the batch the caller set and reserving tens of GB of compute buffer
+    for it. Only after that does the floor apply, and only then is the batch carried
+    up with the micro-batch, so the clamp cannot undo the raise.
     """
     source_env = os.environ if env is None else env
 
@@ -5631,10 +5636,13 @@ def _mmproj_batch_floor(
 
     batch = _requested(n_batch, "LLAMA_ARG_BATCH")
     ubatch = _requested(n_ubatch, "LLAMA_ARG_UBATCH")
+    if batch is None:
+        batch = _DEFAULT_LLAMA_N_BATCH
+    if ubatch is None:
+        ubatch = _DEFAULT_LLAMA_N_UBATCH
     if ubatch == 0:
         ubatch = batch
-    batch = max(floor, batch or 0)
-    ubatch = max(floor, ubatch or 0)
+    ubatch = max(floor, min(batch, ubatch))
     return max(batch, ubatch), ubatch
 
 
@@ -19556,10 +19564,21 @@ class LlamaCppBackend:
                     if not disable_vision
                     else _mmproj_env_is_audio_only(os.environ.get("LLAMA_ARG_MMPROJ"))
                 )
+                # And a remembered --mmproj-auto, which asks llama-server to rediscover
+                # the adjacent projector by itself -- the same mechanism the vision
+                # switch already has to counter with --no-mmproj-auto below. Nothing
+                # Studio resolved, nothing named, nothing inherited, and the child still
+                # ends up with a non-causal encoder.
+                _extras_mmproj_auto = bool(
+                    extra_args
+                    and any(_flag_name(str(a)) == "--mmproj-auto" for a in extra_args)
+                    and not extra_args_disable_mmproj(extra_args)
+                )
                 _launch_opens_projector = (
                     bool(effective_is_vision)
                     or bool(_extras_mmproj and os.path.isfile(_extras_mmproj))
                     or _env_mmproj_survives
+                    or _extras_mmproj_auto
                 )
                 # Before every sizing consumer and after the resolution that decides
                 # whether there is a projector at all, so the fit, the slot search and

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -19533,8 +19533,25 @@ class LlamaCppBackend:
                 # decide whether a --mmproj is emitted at all; here the file is already
                 # on the command line and the child will load it.
                 _extras_mmproj = _extra_args_device(extra_args, {"--mmproj", "-mm"})
-                _launch_opens_projector = bool(effective_is_vision) or bool(
-                    _extras_mmproj and os.path.isfile(_extras_mmproj)
+                # And an inherited one. arg.cpp applies LLAMA_ARG_MMPROJ / _URL before
+                # argv, so the env alone loads a projector the child then encodes
+                # non-causally. It reaches that child unless a later scrub takes it, and
+                # both scrub conditions are already decided here: the paravirtual guard
+                # drops both vars outright, and the vision switch drops the URL and every
+                # image-capable path, keeping only an audio-only file -- which is still a
+                # non-causal encoder, so it still needs the floor.
+                _env_mmproj_survives = not _paravirtual_cpu_forced and (
+                    bool(
+                        (os.environ.get("LLAMA_ARG_MMPROJ") or "").strip()
+                        or (os.environ.get("LLAMA_ARG_MMPROJ_URL") or "").strip()
+                    )
+                    if not disable_vision
+                    else _mmproj_env_is_audio_only(os.environ.get("LLAMA_ARG_MMPROJ"))
+                )
+                _launch_opens_projector = (
+                    bool(effective_is_vision)
+                    or bool(_extras_mmproj and os.path.isfile(_extras_mmproj))
+                    or _env_mmproj_survives
                 )
                 # Before every sizing consumer and after the resolution that decides
                 # whether there is a projector at all, so the fit, the slot search and
@@ -19557,6 +19574,9 @@ class LlamaCppBackend:
                             n_ubatch,
                         )
                     _effective_ubatch = _ubatch_for_slots(n_parallel)
+                # What the vision argv was built with, for the CPU replay far below that
+                # puts that argv back after a text-only retry also crashed.
+                _floored_batch_pair = (n_batch, n_ubatch)
                 # Seed before the try: the except (GPU-selection failure ->
                 # --fit on) falls through to the launch which reads this, and the
                 # probe that assigns it may throw first. Captured before manual
@@ -25277,6 +25297,14 @@ class LlamaCppBackend:
                                         # vision argv supersedes the text-only diagnosis.
                                         if not _projector_msg:
                                             self._mmproj_fallback_reason = None
+                                            # That argv carries the projector and its
+                                            # floor, so put the fields back with it. The
+                                            # text-only retry above unwound them, and the
+                                            # post-launch record reads these, not the
+                                            # command line: left unwound it reports 512
+                                            # for a child running 2048 and understates
+                                            # the prompt-cache slot estimate.
+                                            n_batch, n_ubatch = _floored_batch_pair
                                     else:
                                         if _finish_cancelled_health_wait(
                                             "Load cancelled during the CPU replay health wait"

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5600,33 +5600,41 @@ def _mmproj_batch_floor(
     panel and a training-guard verdict cannot describe a child sized differently
     from the one that starts.
 
-    Three things the floor has to respect. A larger first-class field is the user
-    asking for a bigger batch and is kept. So is a larger LLAMA_ARG_BATCH /
-    LLAMA_ARG_UBATCH: the emitted flag beats the environment in llama.cpp, so
-    writing the floor from the field alone would silently downgrade an inherited
-    4096 to 2048 and reinstate the very assert this raises past. And llama.cpp
-    derives ``cparams.n_ubatch = min(n_batch, n_ubatch)``, so a micro-batch above
-    the batch is clamped back down; carry the batch up with it or the raise buys
-    nothing.
+    A floor, never a setting: anything the launch already asked for that is larger
+    survives, including a larger LLAMA_ARG_BATCH / LLAMA_ARG_UBATCH, or the raise
+    would downgrade an inherited 4096 to 2048 and reinstate the very assert it
+    exists to clear. Resolution order is _extra_args_n_ubatch's and llama.cpp's:
+    the field before the environment, because the field is emitted as a flag and
+    arg.cpp lets a flag overwrite what it read from the environment.
+
+    Two llama.cpp normalizations have to happen BEFORE the floor, not after. A zero
+    micro-batch means "use batch", so a 4096/0 pair is really 4096/4096 and
+    flooring the literal zero would emit 4096/2048 -- a downgrade wearing a raise.
+    And ``cparams.n_ubatch = min(n_batch, n_ubatch)`` clamps a micro-batch above
+    its batch, so the batch is carried up with it or the raise buys nothing.
     """
     source_env = os.environ if env is None else env
 
-    def _resolved(value: Optional[int], env_name: str) -> int:
-        best = floor
+    def _requested(value: Optional[int], env_name: str) -> Optional[int]:
+        """What this launch would run at before the floor, None at llama.cpp's default."""
         if value is not None:
-            best = max(best, int(value))
+            return int(value)
         raw = source_env.get(env_name)
         if raw:
             try:
-                best = max(best, int(raw))
+                return int(raw)
             except (TypeError, ValueError):
                 # Unparseable env is what llama.cpp itself ignores, so ignore it here
                 # rather than letting it decide the budget.
                 pass
-        return best
+        return None
 
-    batch = _resolved(n_batch, "LLAMA_ARG_BATCH")
-    ubatch = _resolved(n_ubatch, "LLAMA_ARG_UBATCH")
+    batch = _requested(n_batch, "LLAMA_ARG_BATCH")
+    ubatch = _requested(n_ubatch, "LLAMA_ARG_UBATCH")
+    if ubatch == 0:
+        ubatch = batch
+    batch = max(floor, batch or 0)
+    ubatch = max(floor, ubatch or 0)
     return max(batch, ubatch), ubatch
 
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17883,24 +17883,33 @@ class LlamaCppBackend:
 
         ``None`` means the request named no batch at all, so the flag is removed rather
         than pinned: emitting nothing is what lets llama.cpp apply its own defaults.
+
+        Only the FIRST occurrence of each flag is rewritten, in place. The argv is built
+        managed-flags-first with the user's extras appended after, so the first one is
+        ours and any later one is theirs; rewriting every occurrence would delete a
+        pass-through ``--batch-size`` from Advanced Arguments, and appending ours at the
+        end would put it after a pass-through ``-b`` and quietly win. Both invert the
+        last-wins contract the rest of the argv builder documents.
         """
         emitted = {
             "--batch-size": _emitted_n_batch(n_batch, n_parallel),
             "--ubatch-size": n_ubatch,
         }
+        seen: set[str] = set()
         out: list[str] = []
         skip_value = False
         for tok in cmd:
             if skip_value:
                 skip_value = False
                 continue
-            if tok in emitted:
+            if tok in emitted and tok not in seen:
+                seen.add(tok)
                 skip_value = True
+                value = emitted[tok]
+                if value is not None:
+                    out.extend([tok, str(value)])
                 continue
             out.append(tok)
-        for flag, value in emitted.items():
-            if value is not None:
-                out.extend([flag, str(value)])
         return out
 
     @staticmethod
@@ -19515,11 +19524,15 @@ class LlamaCppBackend:
                 # while the extras, appended last, still hand the child a projector to
                 # load. That launch hit the assert with no flags emitted at all, which is
                 # #10559 reached through the settings box instead of the model picker.
-                _extras_mmproj = (
-                    None
-                    if extra_args_disable_mmproj(extra_args)
-                    else _extra_args_device(extra_args, {"--mmproj", "-mm"})
-                )
+                # NOT gated on the extras opt-out. --no-mmproj sets params.no_mmproj,
+                # which stops Unsloth resolving one and stops the HF auto-download, but
+                # server-context.cpp gates the load on a non-empty mmproj.path and never
+                # reads that field, so an explicitly named projector opens straight
+                # through it. Upstream scopes the flag to the -hf auto-download too. The
+                # opt-out still governs Studio's own resolution above, where it does
+                # decide whether a --mmproj is emitted at all; here the file is already
+                # on the command line and the child will load it.
+                _extras_mmproj = _extra_args_device(extra_args, {"--mmproj", "-mm"})
                 _launch_opens_projector = bool(effective_is_vision) or bool(
                     _extras_mmproj and os.path.isfile(_extras_mmproj)
                 )
@@ -25195,9 +25208,17 @@ class LlamaCppBackend:
                                     "session; check memory, GPU/driver logs, or update Unsloth."
                                 )
                                 self._mmproj_fallback_reason = "projector_startup_failure"
+                            # The fields too, not just the argv. The post-launch record
+                            # below re-derives self._n_ubatch from these locals, and a
+                            # stale 2048 against a child running llama.cpp's 512 enters
+                            # the slot fingerprint and over-states the prompt-cache slot
+                            # estimate fourfold, which silently skips saves under the
+                            # size cap.
+                            n_batch, n_ubatch = _requested_batch_pair
                             cmd = self._restore_batch_args(
                                 self._strip_mmproj_args(_vision_gpu_cmd),
-                                *_requested_batch_pair,
+                                n_batch,
+                                n_ubatch,
                                 n_parallel,
                             )
                             _unified_withdraw_if_unneeded(cmd, why = "The text-only retry")

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -19565,14 +19565,20 @@ class LlamaCppBackend:
                     else _mmproj_env_is_audio_only(os.environ.get("LLAMA_ARG_MMPROJ"))
                 )
                 # And a remembered --mmproj-auto, which asks llama-server to rediscover
-                # the adjacent projector by itself -- the same mechanism the vision
-                # switch already has to counter with --no-mmproj-auto below. Nothing
-                # Studio resolved, nothing named, nothing inherited, and the child still
-                # ends up with a non-causal encoder.
+                # the adjacent projector by itself. Nothing Studio resolved, nothing
+                # named, nothing inherited, and the child still ends up with a
+                # non-causal encoder.
+                #
+                # Except where the switch already countered it. The argv builder appends
+                # --no-mmproj-auto, last so it wins, on exactly the condition below, so
+                # that child rediscovers nothing and flooring it would hold four times
+                # the compute buffers for no encoder -- in the one mode whose whole
+                # purpose is giving that memory back.
                 _extras_mmproj_auto = bool(
                     extra_args
                     and any(_flag_name(str(a)) == "--mmproj-auto" for a in extra_args)
                     and not extra_args_disable_mmproj(extra_args)
+                    and not (disable_vision and not launch_mmproj_path and not _env_mmproj_survives)
                 )
                 _launch_opens_projector = (
                     bool(effective_is_vision)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -19549,43 +19549,20 @@ class LlamaCppBackend:
                 # decide whether a --mmproj is emitted at all; here the file is already
                 # on the command line and the child will load it.
                 _extras_mmproj = _extra_args_device(extra_args, {"--mmproj", "-mm"})
-                # And an inherited one. arg.cpp applies LLAMA_ARG_MMPROJ / _URL before
-                # argv, so the env alone loads a projector the child then encodes
-                # non-causally. It reaches that child unless a later scrub takes it, and
-                # both scrub conditions are already decided here: the paravirtual guard
-                # drops both vars outright, and the vision switch drops the URL and every
-                # image-capable path, keeping only an audio-only file -- which is still a
-                # non-causal encoder, so it still needs the floor.
-                _env_mmproj_survives = not _paravirtual_cpu_forced and (
-                    bool(
-                        (os.environ.get("LLAMA_ARG_MMPROJ") or "").strip()
-                        or (os.environ.get("LLAMA_ARG_MMPROJ_URL") or "").strip()
-                    )
-                    if not disable_vision
-                    else _mmproj_env_is_audio_only(os.environ.get("LLAMA_ARG_MMPROJ"))
+                _launch_opens_projector = bool(effective_is_vision) or bool(
+                    _extras_mmproj and os.path.isfile(_extras_mmproj)
                 )
-                # And a remembered --mmproj-auto, which asks llama-server to rediscover
-                # the adjacent projector by itself. Nothing Studio resolved, nothing
-                # named, nothing inherited, and the child still ends up with a
-                # non-causal encoder.
-                #
-                # Except where the switch already countered it. The argv builder appends
-                # --no-mmproj-auto, last so it wins, on exactly the condition below, so
-                # that child rediscovers nothing and flooring it would hold four times
-                # the compute buffers for no encoder -- in the one mode whose whole
-                # purpose is giving that memory back.
-                _extras_mmproj_auto = bool(
-                    extra_args
-                    and any(_flag_name(str(a)) == "--mmproj-auto" for a in extra_args)
-                    and not extra_args_disable_mmproj(extra_args)
-                    and not (disable_vision and not launch_mmproj_path and not _env_mmproj_survives)
-                )
-                _launch_opens_projector = (
-                    bool(effective_is_vision)
-                    or bool(_extras_mmproj and os.path.isfile(_extras_mmproj))
-                    or _env_mmproj_survives
-                    or _extras_mmproj_auto
-                )
+                # An inherited LLAMA_ARG_MMPROJ / _URL and a remembered --mmproj-auto
+                # reach the child too, and they hit the same assert. They are NOT floored
+                # here, deliberately. The projector-recovery gate is a literal
+                # `"--mmproj" in cmd` (see launched_with_mmproj), so neither source can
+                # reach the CPU-projector or text-only retries: raising their compute
+                # buffers fourfold would make a launch that used to fit fail outright
+                # with no fallback, which is a worse trade than the crash it prevents.
+                # Both were already failing this way before this change and are no worse
+                # for it. Fixing them needs the recovery gate to learn the same sources
+                # and the text-only retry to scrub the env and emit --no-mmproj-auto, so
+                # it belongs in its own change rather than riding along here.
                 # Before every sizing consumer and after the resolution that decides
                 # whether there is a projector at all, so the fit, the slot search and
                 # every compute-buffer reserve are priced from the batch that launches.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12751,6 +12751,7 @@ class LlamaCppBackend:
         )
 
     _DEFAULT_N_UBATCH = _DEFAULT_LLAMA_N_UBATCH
+    _MMPROJ_NON_CAUSAL_MIN_BATCH = 2048
     _COMPUTE_BUFFER_SAFETY = 1.15  # upper-bound margin on the compute-buffer estimate
     # Soft VRAM the modeled terms omit; charged to the fit budget on tight tiers (#6682).
     _CUDA_CONTEXT_RESERVE_BYTES = 320 * 1024 * 1024  # CUDA ctx + cuBLAS workspace (~330 MiB)
@@ -19413,6 +19414,18 @@ class LlamaCppBackend:
                 # mmproj passing the family-name heuristic must not flip a non-VLM
                 # GGUF into vision mode.
                 effective_is_vision = bool(launch_mmproj_path) and bool(is_vision)
+                if effective_is_vision:
+                    # Vision encoders use non-causal attention, where llama.cpp requires
+                    # the physical micro-batch to cover the full image-token batch.
+                    n_batch = max(
+                        self._MMPROJ_NON_CAUSAL_MIN_BATCH,
+                        int(n_batch or 0),
+                    )
+                    n_ubatch = max(
+                        self._MMPROJ_NON_CAUSAL_MIN_BATCH,
+                        int(n_ubatch or 0),
+                    )
+                    _effective_ubatch = _ubatch_for_slots(n_parallel)
                 if is_vision and not effective_is_vision and not _pv_mmproj_unpinnable:
                     logger.warning(
                         "Vision-capable GGUF loaded without a usable mmproj; "

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11179,19 +11179,33 @@ def _launch_raises_projector_batch(
     an estimator that keeps pricing 512 understates the Load-Model panel and lets the
     coexistence guard admit a chat load over VRAM a running training job needs.
 
-    Mirrors the loader's own condition, which is two things OR'd. Studio's resolved
-    projector, which needs the config's vision flag; and a --mmproj typed into Advanced
+    Mirrors the loader's own condition, which is three things OR'd: Studio's resolved
+    projector, which needs the config's vision flag; a --mmproj typed into Advanced
     Arguments, which does not, because the extras are appended last and hand the child a
-    projector whatever the config says. A projector arriving only through
-    ``LLAMA_ARG_MMPROJ`` is in neither: the loader does not floor that one, and a panel
-    must not quote a raise the launch will not emit.
+    projector whatever the config says; and an inherited LLAMA_ARG_MMPROJ / _URL, which
+    arg.cpp applies before argv.
     """
-    from core.inference.llama_cpp import _extra_args_device, extra_args_disable_mmproj
+    from core.inference.llama_cpp import (
+        _extra_args_device,
+        _mmproj_env_is_audio_only,
+        extra_args_disable_mmproj,
+    )
 
     # An explicitly named projector opens even under --no-mmproj, which only stops the
     # resolve and the auto-download; server-context.cpp gates on a non-empty mmproj.path.
     override = _extra_args_device(extras, {"--mmproj", "-mm"})
     if override and Path(override).is_file():
+        return True
+    # The vision switch drops the URL and every image-capable inherited path, keeping
+    # only an audio-only file, which is still a non-causal encoder and still floored.
+    if (
+        _mmproj_env_is_audio_only(os.environ.get("LLAMA_ARG_MMPROJ"))
+        if disable_vision
+        else (
+            (os.environ.get("LLAMA_ARG_MMPROJ") or "").strip()
+            or (os.environ.get("LLAMA_ARG_MMPROJ_URL") or "").strip()
+        )
+    ):
         return True
     if extra_args_disable_mmproj(extras):
         return False

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -10253,7 +10253,6 @@ def _estimate_gguf_required_gb(
         # decides whether a chat load may sit next to a training job.
         if _launch_raises_projector_batch(config, llama_extra_args, disable_vision):
             from core.inference.llama_cpp import _mmproj_batch_floor
-
             n_batch, n_ubatch = _mmproj_batch_floor(n_batch, n_ubatch)
 
         _spec_mode = _canonicalize_spec_mode(speculative_type) or "auto"
@@ -10548,7 +10547,6 @@ def _estimate_gguf_required_gb(
             # 4x compute reserve belongs in the charge.
             if has_vision and not extra_args_disable_mmproj(llama_extra_args):
                 from core.inference.llama_cpp import _mmproj_batch_floor
-
                 n_batch, n_ubatch = _mmproj_batch_floor(n_batch, n_ubatch)
             companions = _remote_gguf_companion_bytes(
                 repo,
@@ -11564,7 +11562,6 @@ def _gguf_memory_breakdown(
     # which is the half of the row that moves with the settings above it.
     if _launch_raises_projector_batch(config, llama_extra_args, disable_vision):
         from core.inference.llama_cpp import _mmproj_batch_floor
-
         n_batch, n_ubatch = _mmproj_batch_floor(n_batch, n_ubatch)
 
     # Manual owns the offload flags: /load translates the last -ngl into the field and

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11009,6 +11009,14 @@ def _gguf_resident_file_gb(
     required_gb = _estimate_gguf_required_gb(config, max_seq_length = 0, **priced)
     if required_gb is None:
         return None  # deliberately not cached: usually a download still in flight
+    # The batch the required-GB arm priced with. It applies the projector floor
+    # internally, so a subtraction taken at llama.cpp's 512 default leaves the
+    # difference between the two compute buffers behind and reports it as FILES.
+    _term_batch, _term_ubatch = (None, None)
+    if _launch_raises_projector_batch(config, llama_extra_args, disable_vision):
+        from core.inference.llama_cpp import _mmproj_batch_floor
+
+        _term_batch, _term_ubatch = _mmproj_batch_floor(None, None)
     if local_arm:
         # Same identifier the required-GB arm classifies with, or the two halves of the
         # subtraction below stop being paired and the weights figure moves with context.
@@ -11016,12 +11024,16 @@ def _gguf_resident_file_gb(
             str(main),
             0,
             llama_extra_args,
+            n_batch = _term_batch,
+            n_ubatch = _term_ubatch,
             model_identifier = getattr(config, "identifier", None),
         )
     else:
         context_term_gb = _remote_gguf_compute_reserve_gb(
             llama_extra_args = llama_extra_args,
             max_seq_length = 0,
+            n_batch = _term_batch,
+            n_ubatch = _term_ubatch,
         )
     files_gb = max(0.0, required_gb - context_term_gb)
     # Under the lock: the route body runs in an asyncio.to_thread worker, so two panel
@@ -11168,23 +11180,23 @@ def _launch_raises_projector_batch(
     an estimator that keeps pricing 512 understates the Load-Model panel and lets the
     coexistence guard admit a chat load over VRAM a running training job needs.
 
-    Same condition ``effective_is_vision`` is: the config's vision flag AND a projector
-    that actually resolves. A projector arriving only through ``LLAMA_ARG_MMPROJ`` is
-    excluded, because the loader does not floor that one either and a panel must not
-    quote a raise the launch will not emit.
+    Mirrors the loader's own condition, which is two things OR'd. Studio's resolved
+    projector, which needs the config's vision flag; and a --mmproj typed into Advanced
+    Arguments, which does not, because the extras are appended last and hand the child a
+    projector whatever the config says. A projector arriving only through
+    ``LLAMA_ARG_MMPROJ`` is in neither: the loader does not floor that one, and a panel
+    must not quote a raise the launch will not emit.
     """
     from core.inference.llama_cpp import _extra_args_device, extra_args_disable_mmproj
 
-    if not getattr(config, "is_vision", False):
-        return False
     if extra_args_disable_mmproj(extras):
         return False
     override = _extra_args_device(extras, {"--mmproj", "-mm"})
-    resolved = (
-        override
-        if (override and Path(override).is_file())
-        else getattr(config, "gguf_mmproj_file", None)
-    )
+    if override and Path(override).is_file():
+        return True
+    if not getattr(config, "is_vision", False):
+        return False
+    resolved = getattr(config, "gguf_mmproj_file", None)
     if not resolved or not Path(str(resolved)).is_file():
         return False
     if disable_vision:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11188,16 +11188,30 @@ def _launch_raises_projector_batch(
     """
     from core.inference.llama_cpp import _extra_args_device, extra_args_disable_mmproj
 
-    if extra_args_disable_mmproj(extras):
-        return False
+    # An explicitly named projector opens even under --no-mmproj, which only stops the
+    # resolve and the auto-download; server-context.cpp gates on a non-empty mmproj.path.
     override = _extra_args_device(extras, {"--mmproj", "-mm"})
     if override and Path(override).is_file():
         return True
+    if extra_args_disable_mmproj(extras):
+        return False
     if not getattr(config, "is_vision", False):
         return False
     resolved = getattr(config, "gguf_mmproj_file", None)
     if not resolved or not Path(str(resolved)).is_file():
         return False
+    # The loader resolves through _resolve_launch_mmproj_path, which rejects a projector
+    # whose name does not match the model family and launches text-only. Pricing 2048
+    # for that child overstates the panel and the guard by the same 1.8-2.3 GB the
+    # missing floor understated them by, just in the other direction.
+    main = getattr(config, "gguf_file", None)
+    if main:
+        try:
+            from utils.models.model_config import mmproj_matches_model_family
+            if not mmproj_matches_model_family(str(main), str(resolved)):
+                return False
+        except Exception:
+            pass
     if disable_vision:
         # The switch drops an image tower and keeps an audio-only one, and the kept
         # projector still launches, so it still carries the floor.

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11187,6 +11187,7 @@ def _launch_raises_projector_batch(
     """
     from core.inference.llama_cpp import (
         _extra_args_device,
+        _flag_name,
         _metal_device_is_paravirtual,
         _mmproj_env_is_audio_only,
         extra_args_disable_mmproj,
@@ -11196,6 +11197,14 @@ def _launch_raises_projector_batch(
     # resolve and the auto-download; server-context.cpp gates on a non-empty mmproj.path.
     override = _extra_args_device(extras, {"--mmproj", "-mm"})
     if override and Path(override).is_file():
+        return True
+    # A remembered --mmproj-auto asks llama-server to find the adjacent projector on
+    # its own, so the launch opens one with nothing named anywhere.
+    if (
+        extras
+        and any(_flag_name(str(a)) == "--mmproj-auto" for a in extras)
+        and not extra_args_disable_mmproj(extras)
+    ):
         return True
     # An inherited one, under the loader's own two scrubs. The paravirtual guard takes
     # both variables off the child, so there is no projector left to floor; the vision

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11179,47 +11179,24 @@ def _launch_raises_projector_batch(
     an estimator that keeps pricing 512 understates the Load-Model panel and lets the
     coexistence guard admit a chat load over VRAM a running training job needs.
 
-    Mirrors the loader's own condition, which is three things OR'd: Studio's resolved
-    projector, which needs the config's vision flag; a --mmproj typed into Advanced
+    Mirrors the loader's own condition, which is two things OR'd: Studio's resolved
+    projector, which needs the config's vision flag; and a --mmproj typed into Advanced
     Arguments, which does not, because the extras are appended last and hand the child a
-    projector whatever the config says; and an inherited LLAMA_ARG_MMPROJ / _URL, which
-    arg.cpp applies before argv.
+    projector whatever the config says.
     """
-    from core.inference.llama_cpp import (
-        _extra_args_device,
-        _flag_name,
-        _metal_device_is_paravirtual,
-        _mmproj_env_is_audio_only,
-        extra_args_disable_mmproj,
-    )
+    from core.inference.llama_cpp import _extra_args_device, extra_args_disable_mmproj
 
     # An explicitly named projector opens even under --no-mmproj, which only stops the
     # resolve and the auto-download; server-context.cpp gates on a non-empty mmproj.path.
     override = _extra_args_device(extras, {"--mmproj", "-mm"})
     if override and Path(override).is_file():
         return True
-    # A remembered --mmproj-auto asks llama-server to find the adjacent projector on
-    # its own, so the launch opens one with nothing named anywhere.
-    if (
-        extras
-        and any(_flag_name(str(a)) == "--mmproj-auto" for a in extras)
-        and not extra_args_disable_mmproj(extras)
-    ):
-        return True
-    # An inherited one, under the loader's own two scrubs. The paravirtual guard takes
-    # both variables off the child, so there is no projector left to floor; the vision
-    # switch drops the URL and every image-capable path, keeping only an audio-only
-    # file, which is still a non-causal encoder and still floored. Cached hardware
-    # probe that answers False off darwin, so the panel pays nothing for asking.
-    if not _metal_device_is_paravirtual() and (
-        _mmproj_env_is_audio_only(os.environ.get("LLAMA_ARG_MMPROJ"))
-        if disable_vision
-        else (
-            (os.environ.get("LLAMA_ARG_MMPROJ") or "").strip()
-            or (os.environ.get("LLAMA_ARG_MMPROJ_URL") or "").strip()
-        )
-    ):
-        return True
+    # An inherited LLAMA_ARG_MMPROJ / _URL and a remembered --mmproj-auto are NOT
+    # priced at the floor, because load_model does not apply it to them: the recovery
+    # gate cannot see either source, so raising their buffers would remove the fallback
+    # from a launch that used to fit. Mirrored here so the panel keeps describing the
+    # child that actually starts. Both are tracked for a follow-up that teaches the
+    # recovery path the same sources.
     if extra_args_disable_mmproj(extras):
         return False
     if not getattr(config, "is_vision", False):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -10246,6 +10246,16 @@ def _estimate_gguf_required_gb(
             extra_args_disable_mmproj,
         )
 
+        # Price the batch the launch will emit, not the one that was requested: a
+        # projector load is floored to 2048 before any of load_model's own reserves are
+        # sized, so charging llama.cpp's 512 default here under-reserves the compute
+        # buffers by 4x (~1.8-2.3 GB on a 12B-class VLM) in the one estimate that
+        # decides whether a chat load may sit next to a training job.
+        if _launch_raises_projector_batch(config, llama_extra_args, disable_vision):
+            from core.inference.llama_cpp import _mmproj_batch_floor
+
+            n_batch, n_ubatch = _mmproj_batch_floor(n_batch, n_ubatch)
+
         _spec_mode = _canonicalize_spec_mode(speculative_type) or "auto"
         _extra_args_own_spec = _extra_args_set_spec_type(llama_extra_args)
         # Extras owning --spec-type end _build_speculative_flags before any mode
@@ -10532,6 +10542,14 @@ def _estimate_gguf_required_gb(
             main_bytes = selected.size_bytes if selected is not None else None
             if main_bytes is None:
                 return None
+            # Nothing is on disk yet, so the predicate above could not see a projector.
+            # The listing can: a repo shipping one is a load that will fetch it and
+            # launch floored, and this is the guard that protects a training job, so the
+            # 4x compute reserve belongs in the charge.
+            if has_vision and not extra_args_disable_mmproj(llama_extra_args):
+                from core.inference.llama_cpp import _mmproj_batch_floor
+
+                n_batch, n_ubatch = _mmproj_batch_floor(n_batch, n_ubatch)
             companions = _remote_gguf_companion_bytes(
                 repo,
                 hf_token = hf_token,
@@ -11140,6 +11158,48 @@ def _tensor_split_possible(requested_gpu_ids: Optional[list[int]]) -> bool:
         return True
 
 
+def _launch_raises_projector_batch(
+    config: ModelConfig, extras: Optional[list[str]], disable_vision: bool
+) -> bool:
+    """Whether the launch being priced will carry the loader's non-causal batch floor.
+
+    ``load_model`` raises --batch-size / --ubatch-size to at least 2048 whenever it
+    emits --mmproj, because a projector's encoder runs non-causal and llama.cpp aborts
+    on a micro-batch that cannot hold one whole image or audio chunk (#10559). That
+    quadruples the ubatch-dependent compute buffers against llama.cpp's 512 default, so
+    an estimator that keeps pricing 512 understates the Load-Model panel and lets the
+    coexistence guard admit a chat load over VRAM a running training job needs.
+
+    Same condition ``effective_is_vision`` is: the config's vision flag AND a projector
+    that actually resolves. A projector arriving only through ``LLAMA_ARG_MMPROJ`` is
+    excluded, because the loader does not floor that one either and a panel must not
+    quote a raise the launch will not emit.
+    """
+    from core.inference.llama_cpp import _extra_args_device, extra_args_disable_mmproj
+
+    if not getattr(config, "is_vision", False):
+        return False
+    if extra_args_disable_mmproj(extras):
+        return False
+    override = _extra_args_device(extras, {"--mmproj", "-mm"})
+    resolved = (
+        override
+        if (override and Path(override).is_file())
+        else getattr(config, "gguf_mmproj_file", None)
+    )
+    if not resolved or not Path(str(resolved)).is_file():
+        return False
+    if disable_vision:
+        # The switch drops an image tower and keeps an audio-only one, and the kept
+        # projector still launches, so it still carries the floor.
+        try:
+            from utils.models.gguf_metadata import mmproj_accepts_image
+            return not mmproj_accepts_image(str(resolved))
+        except Exception:
+            return False
+    return True
+
+
 def _charged_projector_bytes(
     config: ModelConfig, extras: Optional[list[str]], disable_vision: bool
 ) -> int:
@@ -11497,6 +11557,15 @@ def _gguf_memory_breakdown(
         parse_gpu_layers_override,
         strip_shadowing_flags,
     )
+
+    # The panel quotes what the launch will really run, and a projector load runs
+    # floored to 2048 (see _launch_raises_projector_batch). Priced at llama.cpp's 512
+    # default the compute line reads a quarter of the buffers the child allocates,
+    # which is the half of the row that moves with the settings above it.
+    if _launch_raises_projector_batch(config, llama_extra_args, disable_vision):
+        from core.inference.llama_cpp import _mmproj_batch_floor
+
+        n_batch, n_ubatch = _mmproj_batch_floor(n_batch, n_ubatch)
 
     # Manual owns the offload flags: /load translates the last -ngl into the field and
     # then strips the raw flags, so the launch carries neither. Price that same list,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11187,6 +11187,7 @@ def _launch_raises_projector_batch(
     """
     from core.inference.llama_cpp import (
         _extra_args_device,
+        _metal_device_is_paravirtual,
         _mmproj_env_is_audio_only,
         extra_args_disable_mmproj,
     )
@@ -11196,9 +11197,12 @@ def _launch_raises_projector_batch(
     override = _extra_args_device(extras, {"--mmproj", "-mm"})
     if override and Path(override).is_file():
         return True
-    # The vision switch drops the URL and every image-capable inherited path, keeping
-    # only an audio-only file, which is still a non-causal encoder and still floored.
-    if (
+    # An inherited one, under the loader's own two scrubs. The paravirtual guard takes
+    # both variables off the child, so there is no projector left to floor; the vision
+    # switch drops the URL and every image-capable path, keeping only an audio-only
+    # file, which is still a non-causal encoder and still floored. Cached hardware
+    # probe that answers False off darwin, so the panel pays nothing for asking.
+    if not _metal_device_is_paravirtual() and (
         _mmproj_env_is_audio_only(os.environ.get("LLAMA_ARG_MMPROJ"))
         if disable_vision
         else (

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11015,7 +11015,6 @@ def _gguf_resident_file_gb(
     _term_batch, _term_ubatch = (None, None)
     if _launch_raises_projector_batch(config, llama_extra_args, disable_vision):
         from core.inference.llama_cpp import _mmproj_batch_floor
-
         _term_batch, _term_ubatch = _mmproj_batch_floor(None, None)
     if local_arm:
         # Same identifier the required-GB arm classifies with, or the two halves of the

--- a/studio/backend/tests/test_batch_sizes_per_load.py
+++ b/studio/backend/tests/test_batch_sizes_per_load.py
@@ -648,8 +648,9 @@ def test_the_recorded_micro_batch_is_derived_from_the_slots_that_launched():
         and isinstance(node.func, ast.Name)
         and node.func.id == "_ubatch_for_slots"
     ]
-    # sizing pass, embedding slot clamp, fit-time reduction, then the post-launch record
-    assert len(calls) == 4, f"expected four re-derivations, found {len(calls)}"
+    # sizing pass, embedding slot clamp, projector batch floor, fit-time reduction,
+    # then the post-launch record
+    assert len(calls) == 5, f"expected five re-derivations, found {len(calls)}"
     # the record must not reuse the sizing pass's value
     compact = "".join(src.split())
     assert "self._n_ubatch=max(0,int(self._DEFAULT_N_UBATCHif_launched_ubatchisNone" in compact

--- a/studio/backend/tests/test_batch_sizes_per_load.py
+++ b/studio/backend/tests/test_batch_sizes_per_load.py
@@ -735,3 +735,26 @@ def test_the_remote_guard_charges_the_flat_output_buffer():
     assert layer_2 - layer_1 < 30.0
     # tensor mode replicates the whole buffer on every card, so it does roughly double
     assert tensor_2 > tensor_1 * 1.8
+
+
+def test_the_text_only_retry_unwinds_the_projector_floor_in_the_fields_too():
+    """self._n_ubatch is re-derived from the load_model locals AFTER the retry, so
+    rewriting only the argv leaves the record at the projector's 2048 while the child
+    runs llama.cpp's default. That stale value enters the slot fingerprint and the
+    prompt-cache size estimate, where a fourfold overstatement silently skips saves
+    under the cap. Pinned on the source, since reaching the retry needs a real spawn."""
+    import inspect
+    import textwrap
+
+    src = textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model))
+    compact = "".join(src.split())
+    # The fields are put back, not just the command line...
+    assert "n_batch,n_ubatch=_requested_batch_pair" in compact
+    # ...and before the argv rewrite that reads them.
+    assert compact.index("n_batch,n_ubatch=_requested_batch_pair") < compact.index(
+        "self._restore_batch_args("
+    )
+    # And the pair it restores is captured before the floor is applied.
+    assert compact.index("_requested_batch_pair=(n_batch,n_ubatch)") < compact.index(
+        "n_batch,n_ubatch=_mmproj_batch_floor("
+    )

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -281,11 +281,16 @@ def test_the_retry_leaves_a_pass_through_batch_last_wins(tmp_path):
     appending ours at the end puts it after their -b and quietly wins."""
     vision_cmd = [
         "/fake/llama-server",
-        "--batch-size", "2048",          # managed
-        "--ubatch-size", "2048",         # managed
-        "--mmproj", "mmproj-F16.gguf",
-        "-b", "4096",                    # user extras, appended last
-        "--batch-size", "4096",          # the same thing spelled long
+        "--batch-size",
+        "2048",  # managed
+        "--ubatch-size",
+        "2048",  # managed
+        "--mmproj",
+        "mmproj-F16.gguf",
+        "-b",
+        "4096",  # user extras, appended last
+        "--batch-size",
+        "4096",  # the same thing spelled long
     ]
 
     retried = LlamaCppBackend._restore_batch_args(

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -180,6 +180,9 @@ def test_vulkan_selection_uses_ordinals_and_owns_device_flags(tmp_path):
 
 
 def test_vision_mmproj_defaults_batch_and_ubatch_above_image_tokens(tmp_path):
+    """A projector encodes non-causally, so llama.cpp aborts when the micro-batch
+    cannot hold one whole image chunk (#10559). At llama.cpp's 512 default that is
+    every Gemma 4 image, so the launch has to carry its own floor."""
     backend, gguf = _backend(
         tmp_path,
         vulkan = True,
@@ -199,6 +202,81 @@ def test_vision_mmproj_defaults_batch_and_ubatch_above_image_tokens(tmp_path):
     assert cmd[cmd.index("--mmproj") + 1] == str(mmproj)
     assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
     assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+
+
+def test_a_text_only_load_keeps_the_llama_cpp_batch_defaults(tmp_path):
+    """The floor is bought with compute buffers four times the size, so it has to stop
+    at the launches that need it. No projector, no non-causal encode, no flags."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+
+    cmd = _launch(backend, gguf)["cmd"]
+
+    assert "--mmproj" not in cmd
+    assert "--batch-size" not in cmd
+    assert "--ubatch-size" not in cmd
+
+
+@pytest.mark.parametrize(
+    "env,expected_batch,expected_ubatch",
+    [
+        # Both above the floor: the emitted flags beat the environment in llama.cpp, so
+        # writing 2048 here would downgrade the user and reinstate the assert.
+        ({"LLAMA_ARG_BATCH": "4096", "LLAMA_ARG_UBATCH": "4096"}, "4096", "4096"),
+        # A micro-batch alone still carries the batch up with it: llama.cpp derives
+        # n_ubatch = min(n_batch, n_ubatch), so 2048/4096 would clamp straight back.
+        ({"LLAMA_ARG_UBATCH": "4096"}, "4096", "4096"),
+        # Below the floor is what the floor is for.
+        ({"LLAMA_ARG_BATCH": "128", "LLAMA_ARG_UBATCH": "128"}, "2048", "2048"),
+        # Unparseable is what llama.cpp itself ignores.
+        ({"LLAMA_ARG_UBATCH": "not-a-number"}, "2048", "2048"),
+    ],
+)
+def test_the_projector_floor_keeps_a_larger_inherited_batch(
+    tmp_path, monkeypatch, env, expected_batch, expected_ubatch
+):
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: str(mmproj)
+    for name in ("LLAMA_ARG_BATCH", "LLAMA_ARG_UBATCH"):
+        monkeypatch.delenv(name, raising = False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    cmd = _launch(backend, gguf, is_vision = True, mmproj_path = str(mmproj))["cmd"]
+
+    assert cmd[cmd.index("--batch-size") + 1] == expected_batch
+    assert cmd[cmd.index("--ubatch-size") + 1] == expected_ubatch
+
+
+def test_an_explicitly_larger_batch_field_survives_the_projector_floor(tmp_path):
+    """The floor is a minimum, not a setting. A user asking for 8192 gets 8192."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: str(mmproj)
+
+    cmd = _launch(
+        backend,
+        gguf,
+        is_vision = True,
+        mmproj_path = str(mmproj),
+        n_batch = 8192,
+        n_ubatch = 8192,
+    )["cmd"]
+
+    assert cmd[cmd.index("--batch-size") + 1] == "8192"
+    assert cmd[cmd.index("--ubatch-size") + 1] == "8192"
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -380,9 +380,11 @@ def test_a_text_only_load_keeps_the_llama_cpp_batch_defaults(tmp_path):
         # Both above the floor: the emitted flags beat the environment in llama.cpp, so
         # writing 2048 here would downgrade the user and reinstate the assert.
         ({"LLAMA_ARG_BATCH": "4096", "LLAMA_ARG_UBATCH": "4096"}, "4096", "4096"),
-        # A micro-batch alone still carries the batch up with it: llama.cpp derives
-        # n_ubatch = min(n_batch, n_ubatch), so 2048/4096 would clamp straight back.
-        ({"LLAMA_ARG_UBATCH": "4096"}, "4096", "4096"),
+        # A micro-batch alone is NOT carried up. llama.cpp's own batch default is
+        # 2048 and it derives n_ubatch = min(n_batch, n_ubatch), so this launch was
+        # always going to run at 2048; raising the batch to honour the 4096 would
+        # change the setting rather than floor it.
+        ({"LLAMA_ARG_UBATCH": "4096"}, "2048", "2048"),
         # Below the floor is what the floor is for.
         ({"LLAMA_ARG_BATCH": "128", "LLAMA_ARG_UBATCH": "128"}, "2048", "2048"),
         # Unparseable is what llama.cpp itself ignores.
@@ -3941,3 +3943,69 @@ def test_an_explicit_field_beats_a_larger_environment_batch(tmp_path, monkeypatc
     # the environment would have contributed to a max().
     assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
     assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+
+
+def test_an_inherited_micro_batch_is_clamped_to_the_batch_before_the_floor(tmp_path, monkeypatch):
+    """llama.cpp derives n_ubatch = min(n_batch, n_ubatch), so an explicit 2048 batch
+    beside an inherited 32768 micro-batch runs at 2048. Taking the raw 32768 into the
+    floor emitted 32768 for both: it overrides the batch the caller set and reserves
+    tens of GB of compute buffer for a micro-batch the launch never had."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: str(mmproj)
+    monkeypatch.delenv("LLAMA_ARG_BATCH", raising = False)
+    monkeypatch.setenv("LLAMA_ARG_UBATCH", "32768")
+
+    cmd = _launch(
+        backend,
+        gguf,
+        is_vision = True,
+        mmproj_path = str(mmproj),
+        n_batch = 2048,
+    )["cmd"]
+
+    assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+    assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+
+
+def test_a_remembered_mmproj_auto_gets_the_floor(tmp_path):
+    """--mmproj-auto asks llama-server to rediscover the adjacent projector by itself,
+    the same mechanism the vision switch has to counter with --no-mmproj-auto. With
+    vision on and nothing resolved, named or inherited, that child still gets a
+    non-causal encoder, and it was getting llama.cpp's 512 with it."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+
+    cmd = _launch(backend, gguf, is_vision = True, extra_args = ["--mmproj-auto"])["cmd"]
+
+    assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+    assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+
+
+def test_mmproj_auto_turned_back_off_gets_no_floor(tmp_path):
+    """llama.cpp is last-wins on the enable/disable pair, so a trailing
+    --no-mmproj-auto means nothing is rediscovered and nothing needs sizing."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+
+    cmd = _launch(
+        backend,
+        gguf,
+        is_vision = True,
+        extra_args = ["--mmproj-auto", "--no-mmproj-auto"],
+    )["cmd"]
+
+    assert "--batch-size" not in cmd
+    assert "--ubatch-size" not in cmd

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -3880,3 +3880,64 @@ def test_the_cpu_replay_that_restores_vision_restores_the_floor_too():
     )
     # The restore belongs to the same branch that clears the text-only diagnosis.
     assert ast.parse(src) is not None
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        # Zero micro-batch means "use batch", so this pair is really 4096/4096 and
+        # flooring the literal zero would emit 4096/2048 -- a downgrade wearing a
+        # raise, and the assert back for any chunk between 2049 and 4096 tokens.
+        ({"LLAMA_ARG_BATCH": "4096", "LLAMA_ARG_UBATCH": "0"}, ("4096", "4096")),
+        # Zero with nothing to borrow from still lands on the floor.
+        ({"LLAMA_ARG_UBATCH": "0"}, ("2048", "2048")),
+    ],
+)
+def test_a_zero_micro_batch_means_use_batch_before_it_means_floor(
+    tmp_path, monkeypatch, env, expected
+):
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: str(mmproj)
+    for name in ("LLAMA_ARG_BATCH", "LLAMA_ARG_UBATCH"):
+        monkeypatch.delenv(name, raising = False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    cmd = _launch(backend, gguf, is_vision = True, mmproj_path = str(mmproj))["cmd"]
+
+    assert cmd[cmd.index("--batch-size") + 1] == expected[0]
+    assert cmd[cmd.index("--ubatch-size") + 1] == expected[1]
+
+
+def test_an_explicit_field_beats_a_larger_environment_batch(tmp_path, monkeypatch):
+    """The field is emitted as a flag and arg.cpp lets a flag overwrite what it read
+    from the environment, so the field is what the launch runs at. Taking the max of
+    both would emit a value the user's own field contradicts."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: str(mmproj)
+    monkeypatch.setenv("LLAMA_ARG_BATCH", "8192")
+    monkeypatch.setenv("LLAMA_ARG_UBATCH", "8192")
+
+    cmd = _launch(
+        backend,
+        gguf,
+        is_vision = True,
+        mmproj_path = str(mmproj),
+        n_batch = 1024,
+        n_ubatch = 1024,
+    )["cmd"]
+
+    # The field is below the floor, so the floor wins -- but at 2048, not the 8192
+    # the environment would have contributed to a max().
+    assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+    assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -230,8 +230,12 @@ def test_a_projector_named_only_in_advanced_arguments_still_gets_the_floor(tmp_p
     assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
 
 
-def test_no_mmproj_in_the_extras_beats_an_extras_projector(tmp_path):
-    """--no-mmproj is the opt-out, so nothing loads and nothing is floored."""
+def test_no_mmproj_does_not_excuse_an_explicitly_named_projector(tmp_path):
+    """--no-mmproj sets params.no_mmproj, which stops Unsloth resolving one and stops
+    the HF auto-download, but server-context.cpp gates the load on a non-empty
+    mmproj.path and never reads that field (the same reasoning
+    test_mmproj_placement_policy.py applies to an inherited projector). The named file
+    still opens, so it still needs the floor."""
     backend, gguf = _backend(
         tmp_path,
         vulkan = True,
@@ -247,8 +251,49 @@ def test_no_mmproj_in_the_extras_beats_an_extras_projector(tmp_path):
         extra_args = ["--mmproj", str(mmproj), "--no-mmproj"],
     )["cmd"]
 
+    # The projector is still on the command line, which is the whole premise.
+    assert cmd[cmd.index("--mmproj") + 1] == str(mmproj)
+    assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+    assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+
+
+def test_no_mmproj_alone_still_floors_nothing(tmp_path):
+    """Without a named path there is nothing for the opt-out to fail to unload, so the
+    resolve is suppressed, no projector opens, and no floor is priced."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: str(mmproj)
+
+    cmd = _launch(backend, gguf, is_vision = True, extra_args = ["--no-mmproj"])["cmd"]
+
+    assert "--mmproj" not in cmd
     assert "--batch-size" not in cmd
     assert "--ubatch-size" not in cmd
+
+
+def test_the_retry_leaves_a_pass_through_batch_last_wins(tmp_path):
+    """The argv is managed-flags-first with the extras appended after, so only the
+    first occurrence is ours. Rewriting every one deletes the user's pass-through, and
+    appending ours at the end puts it after their -b and quietly wins."""
+    vision_cmd = [
+        "/fake/llama-server",
+        "--batch-size", "2048",          # managed
+        "--ubatch-size", "2048",         # managed
+        "--mmproj", "mmproj-F16.gguf",
+        "-b", "4096",                    # user extras, appended last
+        "--batch-size", "4096",          # the same thing spelled long
+    ]
+
+    retried = LlamaCppBackend._restore_batch_args(
+        LlamaCppBackend._strip_mmproj_args(vision_cmd), None, None, 1
+    )
+
+    # Ours is gone; both of theirs survive, in their original order and position.
+    assert retried == ["/fake/llama-server", "-b", "4096", "--batch-size", "4096"]
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -3819,10 +3819,13 @@ def test_a_restored_cpu_fallback_the_host_can_hold_says_nothing(tmp_path, monkey
 
 
 @pytest.mark.parametrize("var", ["LLAMA_ARG_MMPROJ", "LLAMA_ARG_MMPROJ_URL"])
-def test_a_projector_inherited_from_the_environment_gets_the_floor(tmp_path, monkeypatch, var):
-    """arg.cpp applies LLAMA_ARG_MMPROJ / _URL before argv, so the environment alone
-    loads a projector that then encodes non-causally. Nothing is on Studio's command
-    line, so this launch emitted no batch flags and ran at llama.cpp's 512."""
+def test_an_inherited_projector_is_deliberately_not_floored(tmp_path, monkeypatch, var):
+    """arg.cpp applies these before argv, so the environment alone does load a
+    projector that encodes non-causally, and it does hit the assert. It is still not
+    floored, because the projector-recovery gate is a literal `"--mmproj" in cmd` and
+    cannot see this source: quadrupling its compute buffers would turn a launch that
+    used to fit into a startup failure with no fallback. It was already broken this way
+    and is no worse for the change. The follow-up has to teach recovery first."""
     backend, gguf = _backend(
         tmp_path,
         vulkan = True,
@@ -3836,8 +3839,8 @@ def test_a_projector_inherited_from_the_environment_gets_the_floor(tmp_path, mon
 
     cmd = _launch(backend, gguf, is_vision = True)["cmd"]
 
-    assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
-    assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+    assert "--batch-size" not in cmd
+    assert "--ubatch-size" not in cmd
 
 
 def test_an_inherited_projector_the_vision_switch_scrubs_is_not_floored(tmp_path, monkeypatch):
@@ -3972,11 +3975,11 @@ def test_an_inherited_micro_batch_is_clamped_to_the_batch_before_the_floor(tmp_p
     assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
 
 
-def test_a_remembered_mmproj_auto_gets_the_floor(tmp_path):
-    """--mmproj-auto asks llama-server to rediscover the adjacent projector by itself,
-    the same mechanism the vision switch has to counter with --no-mmproj-auto. With
-    vision on and nothing resolved, named or inherited, that child still gets a
-    non-causal encoder, and it was getting llama.cpp's 512 with it."""
+def test_a_remembered_mmproj_auto_is_deliberately_not_floored(tmp_path):
+    """--mmproj-auto really does make llama-server rediscover the adjacent projector,
+    so this child gets a non-causal encoder at llama.cpp's 512 and can hit the assert.
+    Not floored, for the same reason as the inherited case: the recovery gate cannot
+    see this source either, so the raise would cost the fallback."""
     backend, gguf = _backend(
         tmp_path,
         vulkan = True,
@@ -3986,8 +3989,8 @@ def test_a_remembered_mmproj_auto_gets_the_floor(tmp_path):
 
     cmd = _launch(backend, gguf, is_vision = True, extra_args = ["--mmproj-auto"])["cmd"]
 
-    assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
-    assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+    assert "--batch-size" not in cmd
+    assert "--ubatch-size" not in cmd
 
 
 def test_mmproj_auto_turned_back_off_gets_no_floor(tmp_path):
@@ -4007,30 +4010,5 @@ def test_mmproj_auto_turned_back_off_gets_no_floor(tmp_path):
         extra_args = ["--mmproj-auto", "--no-mmproj-auto"],
     )["cmd"]
 
-    assert "--batch-size" not in cmd
-    assert "--ubatch-size" not in cmd
-
-
-def test_mmproj_auto_countered_by_the_vision_switch_gets_no_floor(tmp_path):
-    """The argv builder appends --no-mmproj-auto, last so it wins, when the switch is
-    off and nothing else kept a projector. That child rediscovers nothing, so flooring
-    it would hold 4x the compute buffers for no encoder, in the one mode whose whole
-    purpose is giving that memory back."""
-    backend, gguf = _backend(
-        tmp_path,
-        vulkan = True,
-        memory = [(0, 24_000, 24_000)],
-    )
-    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
-
-    cmd = _launch(
-        backend,
-        gguf,
-        is_vision = True,
-        disable_vision = True,
-        extra_args = ["--mmproj-auto"],
-    )["cmd"]
-
-    assert "--no-mmproj-auto" in cmd
     assert "--batch-size" not in cmd
     assert "--ubatch-size" not in cmd

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -204,6 +204,106 @@ def test_vision_mmproj_defaults_batch_and_ubatch_above_image_tokens(tmp_path):
     assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
 
 
+def test_a_projector_named_only_in_advanced_arguments_still_gets_the_floor(tmp_path):
+    """_resolve_launch_mmproj_path reads intent.mmproj_path and nothing else, so a
+    --mmproj typed into Advanced Arguments leaves effective_is_vision False while the
+    extras, appended last, still hand the child a projector. That launch emitted no
+    batch flags at all and hit the same non-causal assert #10559 is about."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    # Studio's own resolution finds nothing: the projector exists only in the extras.
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+
+    cmd = _launch(
+        backend,
+        gguf,
+        is_vision = True,
+        extra_args = ["--mmproj", str(mmproj)],
+    )["cmd"]
+
+    assert cmd[cmd.index("--mmproj") + 1] == str(mmproj)
+    assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+    assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+
+
+def test_no_mmproj_in_the_extras_beats_an_extras_projector(tmp_path):
+    """--no-mmproj is the opt-out, so nothing loads and nothing is floored."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+
+    cmd = _launch(
+        backend,
+        gguf,
+        is_vision = True,
+        extra_args = ["--mmproj", str(mmproj), "--no-mmproj"],
+    )["cmd"]
+
+    assert "--batch-size" not in cmd
+    assert "--ubatch-size" not in cmd
+
+
+@pytest.mark.parametrize(
+    "requested,expected",
+    [
+        # Nothing was asked for, so nothing is emitted and llama.cpp keeps its own
+        # defaults -- pinning 2048 here is the 4x compute buffer the retry is trying
+        # to give back.
+        ((None, None), None),
+        ((1024, 1024), ("1024", "1024")),
+    ],
+)
+def test_the_text_only_retry_gives_back_the_projector_batch_floor(requested, expected):
+    """The retry has just dropped the projector, so nothing on that child encodes
+    non-causally. Carrying the floor into it keeps 1.8-2.3 GB of compute buffers in
+    precisely the recovery meant to rescue a load that ran out of memory."""
+    vision_cmd = [
+        "/fake/llama-server",
+        "-m", "model.gguf",
+        "--batch-size", "2048",
+        "--mmproj", "mmproj-F16.gguf",
+        "--ubatch-size", "2048",
+        "--jinja",
+    ]
+
+    retried = LlamaCppBackend._restore_batch_args(
+        LlamaCppBackend._strip_mmproj_args(vision_cmd), *requested, 1
+    )
+
+    assert "--mmproj" not in retried
+    # Everything the retry is not about survives the rewrite.
+    assert retried[:3] == ["/fake/llama-server", "-m", "model.gguf"]
+    assert "--jinja" in retried
+    if expected is None:
+        assert "--batch-size" not in retried
+        assert "--ubatch-size" not in retried
+    else:
+        assert retried[retried.index("--batch-size") + 1] == expected[0]
+        assert retried[retried.index("--ubatch-size") + 1] == expected[1]
+
+
+def test_the_text_only_retry_keeps_the_slot_floor_on_the_batch():
+    """--batch-size below the slot count aborts llama-server, so the restored value
+    goes back through the same emitted-batch floor the launch used."""
+    retried = LlamaCppBackend._restore_batch_args(
+        ["/fake/llama-server", "--batch-size", "2048", "--ubatch-size", "2048"],
+        4,
+        None,
+        8,
+    )
+
+    assert retried[retried.index("--batch-size") + 1] == "8"
+    assert "--ubatch-size" not in retried
+
+
 def test_a_text_only_load_keeps_the_llama_cpp_batch_defaults(tmp_path):
     """The floor is bought with compute buffers four times the size, so it has to stop
     at the launches that need it. No projector, no non-causal encode, no flags."""

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -4009,3 +4009,28 @@ def test_mmproj_auto_turned_back_off_gets_no_floor(tmp_path):
 
     assert "--batch-size" not in cmd
     assert "--ubatch-size" not in cmd
+
+
+def test_mmproj_auto_countered_by_the_vision_switch_gets_no_floor(tmp_path):
+    """The argv builder appends --no-mmproj-auto, last so it wins, when the switch is
+    off and nothing else kept a projector. That child rediscovers nothing, so flooring
+    it would hold 4x the compute buffers for no encoder, in the one mode whose whole
+    purpose is giving that memory back."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+
+    cmd = _launch(
+        backend,
+        gguf,
+        is_vision = True,
+        disable_vision = True,
+        extra_args = ["--mmproj-auto"],
+    )["cmd"]
+
+    assert "--no-mmproj-auto" in cmd
+    assert "--batch-size" not in cmd
+    assert "--ubatch-size" not in cmd

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -3814,3 +3814,69 @@ def test_a_restored_cpu_fallback_the_host_can_hold_says_nothing(tmp_path, monkey
     _launch_with_vulkan_cpu_replay(backend, gguf, crash = False, cpu_fallback = True)
 
     assert backend.last_load_warning is None
+
+
+@pytest.mark.parametrize("var", ["LLAMA_ARG_MMPROJ", "LLAMA_ARG_MMPROJ_URL"])
+def test_a_projector_inherited_from_the_environment_gets_the_floor(tmp_path, monkeypatch, var):
+    """arg.cpp applies LLAMA_ARG_MMPROJ / _URL before argv, so the environment alone
+    loads a projector that then encodes non-causally. Nothing is on Studio's command
+    line, so this launch emitted no batch flags and ran at llama.cpp's 512."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+    for name in ("LLAMA_ARG_MMPROJ", "LLAMA_ARG_MMPROJ_URL"):
+        monkeypatch.delenv(name, raising = False)
+    monkeypatch.setenv(var, str(mmproj))
+
+    cmd = _launch(backend, gguf, is_vision = True)["cmd"]
+
+    assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+    assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+
+
+def test_an_inherited_projector_the_vision_switch_scrubs_is_not_floored(tmp_path, monkeypatch):
+    """The switch drops the URL and every image-capable inherited path before the
+    child sees them, so there is no non-causal encoder left to size for."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+    monkeypatch.delenv("LLAMA_ARG_MMPROJ_URL", raising = False)
+    monkeypatch.setenv("LLAMA_ARG_MMPROJ", str(mmproj))
+
+    cmd = _launch(backend, gguf, is_vision = True, disable_vision = True)["cmd"]
+
+    assert "--batch-size" not in cmd
+    assert "--ubatch-size" not in cmd
+
+
+def test_the_cpu_replay_that_restores_vision_restores_the_floor_too():
+    """A text-only retry that also signal-crashes replays the ORIGINAL vision argv on
+    CPU, projector and 2048 flags included. The retry unwound the fields, and the
+    post-launch record reads the fields rather than the argv, so leaving them unwound
+    reports 512 for a 2048 child and understates the prompt-cache slot estimate."""
+    import ast
+    import inspect
+    import textwrap
+
+    src = textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model))
+    compact = "".join(src.split())
+    assert "_floored_batch_pair=(n_batch,n_ubatch)" in compact
+    # Captured after the floor was applied, not before it.
+    assert compact.index("n_batch,n_ubatch=_mmproj_batch_floor(") < compact.index(
+        "_floored_batch_pair=(n_batch,n_ubatch)"
+    )
+    # And put back on the branch that keeps vision, after the retry unwound them.
+    assert "n_batch,n_ubatch=_floored_batch_pair" in compact
+    assert compact.index("n_batch,n_ubatch=_requested_batch_pair") < compact.index(
+        "n_batch,n_ubatch=_floored_batch_pair"
+    )
+    # The restore belongs to the same branch that clears the text-only diagnosis.
+    assert ast.parse(src) is not None

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -267,10 +267,14 @@ def test_the_text_only_retry_gives_back_the_projector_batch_floor(requested, exp
     precisely the recovery meant to rescue a load that ran out of memory."""
     vision_cmd = [
         "/fake/llama-server",
-        "-m", "model.gguf",
-        "--batch-size", "2048",
-        "--mmproj", "mmproj-F16.gguf",
-        "--ubatch-size", "2048",
+        "-m",
+        "model.gguf",
+        "--batch-size",
+        "2048",
+        "--mmproj",
+        "mmproj-F16.gguf",
+        "--ubatch-size",
+        "2048",
         "--jinja",
     ]
 

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -71,6 +71,7 @@ if "httpx" not in sys.modules:
 from core.inference.llama_cpp import GgufLoadIntent, LlamaCppBackend, _loader_path_var
 
 _REAL_POPEN = subprocess.Popen
+VISION_MMPROJ_MIN_BATCH = "2048"
 
 
 def _write_gguf(path: Path, architecture: str = "llama") -> Path:
@@ -176,6 +177,28 @@ def test_vulkan_selection_uses_ordinals_and_owns_device_flags(tmp_path):
     assert cmd[cmd.index("--top-k") + 1] == "5"
     assert backend.requested_gpu_ids == [0, 1]
     assert backend.gpu_ids == [1]
+
+
+def test_vision_mmproj_defaults_batch_and_ubatch_above_image_tokens(tmp_path):
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 24_000, 24_000)],
+    )
+    mmproj = _write_gguf(tmp_path / "mmproj-F16.gguf", architecture = "clip")
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: str(mmproj)
+
+    result = _launch(
+        backend,
+        gguf,
+        is_vision = True,
+        mmproj_path = str(mmproj),
+    )
+
+    cmd = result["cmd"]
+    assert cmd[cmd.index("--mmproj") + 1] == str(mmproj)
+    assert cmd[cmd.index("--batch-size") + 1] == VISION_MMPROJ_MIN_BATCH
+    assert cmd[cmd.index("--ubatch-size") + 1] == VISION_MMPROJ_MIN_BATCH
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_memory_estimate.py
+++ b/studio/backend/tests/test_memory_estimate.py
@@ -3163,3 +3163,84 @@ class TestFourMoreLaunchNormalizations:
         )
         out = ri._gguf_memory_breakdown(config, gguf, n_ctx = 8192, n_parallel = 4)
         assert out.n_parallel == 4
+
+
+class TestTheProjectorBatchFloorIsPricedNotJustLaunched:
+    """load_model raises --batch-size / --ubatch-size to 2048 whenever it emits
+    --mmproj, because a projector's encoder runs non-causal and llama.cpp aborts on a
+    micro-batch that cannot hold one whole image or audio chunk (#10559). Its own fit
+    is sized from the raised value, but the panel and the training-coexistence guard
+    are a different code path: priced at llama.cpp's 512 default they charge a quarter
+    of the compute buffers the child allocates, which on a 12B-class VLM is 1.8-2.3 GB
+    the guard would let a chat load take out from under a running training job.
+    """
+
+    @pytest.fixture
+    def vision(self, tmp_path):
+        weight = _write_gguf(
+            tmp_path, "qwen3", {**_GQA_FIELDS, "context_length": 262144},
+            name = "model-Q4_K_M.gguf",
+        )
+        projector = _write_gguf(
+            tmp_path, "clip", {"block_count": 2}, name = "mmproj-F16.gguf"
+        )
+        config = SimpleNamespace(
+            identifier = "local/vision",
+            gguf_file = weight,
+            is_gguf = True,
+            is_vision = True,
+            gguf_variant = None,
+            gguf_mmproj_file = projector,
+            gguf_mtp_file = None,
+            gguf_dspark_file = None,
+            gguf_dflash_file = None,
+        )
+        return weight, config
+
+    @pytest.fixture(autouse = True)
+    def _no_inherited_batch(self, monkeypatch):
+        for name in ("LLAMA_ARG_BATCH", "LLAMA_ARG_UBATCH", "LLAMA_ARG_MMPROJ"):
+            monkeypatch.delenv(name, raising = False)
+
+    def test_the_panel_prices_the_raised_micro_batch(self, vision):
+        weight, config = vision
+        priced = ri._gguf_memory_breakdown(config, weight, n_ctx = 8192)
+        pinned = ri._gguf_memory_breakdown(
+            config, weight, n_ctx = 8192, n_batch = 2048, n_ubatch = 2048
+        )
+        # Identical, because the launch runs at 2048 either way. Before the mirror the
+        # left-hand side priced 512 and came out four times smaller.
+        assert priced.compute_bytes == pinned.compute_bytes
+
+    def test_a_text_only_load_still_prices_the_llama_cpp_default(self, vision):
+        weight, config = vision
+        text_only = SimpleNamespace(**{**vars(config), "is_vision": False,
+                                       "gguf_mmproj_file": None})
+        priced = ri._gguf_memory_breakdown(text_only, weight, n_ctx = 8192)
+        floored = ri._gguf_memory_breakdown(
+            text_only, weight, n_ctx = 8192, n_batch = 2048, n_ubatch = 2048
+        )
+        # No projector, no floor: the two must NOT agree, or the mirror leaked into
+        # every text load and inflated the panel for models that never encode an image.
+        assert priced.compute_bytes < floored.compute_bytes
+
+    def test_the_training_guard_charges_the_raised_micro_batch(self, vision):
+        weight, config = vision
+        charged = ri._estimate_gguf_required_gb(config, max_seq_length = 8192)
+        pinned = ri._estimate_gguf_required_gb(
+            config, max_seq_length = 8192, n_batch = 2048, n_ubatch = 2048
+        )
+        assert charged == pytest.approx(pinned)
+
+    def test_no_mmproj_in_the_extras_prices_no_floor(self, vision):
+        weight, config = vision
+        # --no-mmproj stops Unsloth resolving one, so nothing non-causal launches and
+        # the panel must not quote a raise the child never gets.
+        suppressed = ri._gguf_memory_breakdown(
+            config, weight, n_ctx = 8192, llama_extra_args = ["--no-mmproj"]
+        )
+        floored = ri._gguf_memory_breakdown(
+            config, weight, n_ctx = 8192, n_batch = 2048, n_ubatch = 2048,
+            llama_extra_args = ["--no-mmproj"],
+        )
+        assert suppressed.compute_bytes < floored.compute_bytes

--- a/studio/backend/tests/test_memory_estimate.py
+++ b/studio/backend/tests/test_memory_estimate.py
@@ -3256,8 +3256,7 @@ class TestTheProjectorBatchFloorIsPricedNotJustLaunched:
         weight, config = vision
         files_gb = ri._gguf_resident_file_gb(config)
         on_disk = (
-            Path(weight).stat().st_size
-            + Path(config.gguf_mmproj_file).stat().st_size
+            Path(weight).stat().st_size + Path(config.gguf_mmproj_file).stat().st_size
         ) / 1024**3
         # Whatever the projector's runtime allowance adds, it is nothing like the
         # ~1.8 GB an unpaired subtraction leaked here.

--- a/studio/backend/tests/test_memory_estimate.py
+++ b/studio/backend/tests/test_memory_estimate.py
@@ -3247,3 +3247,18 @@ class TestTheProjectorBatchFloorIsPricedNotJustLaunched:
             llama_extra_args = ["--no-mmproj"],
         )
         assert suppressed.compute_bytes < floored.compute_bytes
+
+    def test_the_resident_files_figure_does_not_absorb_the_raised_buffers(self, vision):
+        """_gguf_resident_file_gb subtracts a context term from the required-GB total,
+        so both halves have to be priced at the same batch. Floored on one side only,
+        the difference between a 512 and a 2048 compute buffer stays behind and is
+        reported to the panel as FILES, which do not move with the batch at all."""
+        weight, config = vision
+        files_gb = ri._gguf_resident_file_gb(config)
+        on_disk = (
+            Path(weight).stat().st_size
+            + Path(config.gguf_mmproj_file).stat().st_size
+        ) / 1024**3
+        # Whatever the projector's runtime allowance adds, it is nothing like the
+        # ~1.8 GB an unpaired subtraction leaked here.
+        assert files_gb == pytest.approx(on_disk, abs = 0.2)

--- a/studio/backend/tests/test_memory_estimate.py
+++ b/studio/backend/tests/test_memory_estimate.py
@@ -3267,15 +3267,9 @@ class TestTheProjectorBatchFloorIsPricedNotJustLaunched:
         different model-family token and launches text-only, so pricing 2048 for that
         child overstates the panel by the same amount the missing floor understated it
         by, just in the other direction."""
-        weight = _write_gguf(
-            tmp_path, "qwen3", _GQA_FIELDS, name = "gemma-3-12b-Q4_K_M.gguf"
-        )
-        matching = _write_gguf(
-            tmp_path, "clip", {"block_count": 2}, name = "mmproj-gemma-3-F16.gguf"
-        )
-        stranger = _write_gguf(
-            tmp_path, "clip", {"block_count": 2}, name = "mmproj-qwen3vl-F16.gguf"
-        )
+        weight = _write_gguf(tmp_path, "qwen3", _GQA_FIELDS, name = "gemma-3-12b-Q4_K_M.gguf")
+        matching = _write_gguf(tmp_path, "clip", {"block_count": 2}, name = "mmproj-gemma-3-F16.gguf")
+        stranger = _write_gguf(tmp_path, "clip", {"block_count": 2}, name = "mmproj-qwen3vl-F16.gguf")
         base = dict(
             identifier = "local/vision",
             gguf_file = weight,

--- a/studio/backend/tests/test_memory_estimate.py
+++ b/studio/backend/tests/test_memory_estimate.py
@@ -3178,12 +3178,12 @@ class TestTheProjectorBatchFloorIsPricedNotJustLaunched:
     @pytest.fixture
     def vision(self, tmp_path):
         weight = _write_gguf(
-            tmp_path, "qwen3", {**_GQA_FIELDS, "context_length": 262144},
+            tmp_path,
+            "qwen3",
+            {**_GQA_FIELDS, "context_length": 262144},
             name = "model-Q4_K_M.gguf",
         )
-        projector = _write_gguf(
-            tmp_path, "clip", {"block_count": 2}, name = "mmproj-F16.gguf"
-        )
+        projector = _write_gguf(tmp_path, "clip", {"block_count": 2}, name = "mmproj-F16.gguf")
         config = SimpleNamespace(
             identifier = "local/vision",
             gguf_file = weight,
@@ -3205,17 +3205,16 @@ class TestTheProjectorBatchFloorIsPricedNotJustLaunched:
     def test_the_panel_prices_the_raised_micro_batch(self, vision):
         weight, config = vision
         priced = ri._gguf_memory_breakdown(config, weight, n_ctx = 8192)
-        pinned = ri._gguf_memory_breakdown(
-            config, weight, n_ctx = 8192, n_batch = 2048, n_ubatch = 2048
-        )
+        pinned = ri._gguf_memory_breakdown(config, weight, n_ctx = 8192, n_batch = 2048, n_ubatch = 2048)
         # Identical, because the launch runs at 2048 either way. Before the mirror the
         # left-hand side priced 512 and came out four times smaller.
         assert priced.compute_bytes == pinned.compute_bytes
 
     def test_a_text_only_load_still_prices_the_llama_cpp_default(self, vision):
         weight, config = vision
-        text_only = SimpleNamespace(**{**vars(config), "is_vision": False,
-                                       "gguf_mmproj_file": None})
+        text_only = SimpleNamespace(
+            **{**vars(config), "is_vision": False, "gguf_mmproj_file": None}
+        )
         priced = ri._gguf_memory_breakdown(text_only, weight, n_ctx = 8192)
         floored = ri._gguf_memory_breakdown(
             text_only, weight, n_ctx = 8192, n_batch = 2048, n_ubatch = 2048
@@ -3240,7 +3239,11 @@ class TestTheProjectorBatchFloorIsPricedNotJustLaunched:
             config, weight, n_ctx = 8192, llama_extra_args = ["--no-mmproj"]
         )
         floored = ri._gguf_memory_breakdown(
-            config, weight, n_ctx = 8192, n_batch = 2048, n_ubatch = 2048,
+            config,
+            weight,
+            n_ctx = 8192,
+            n_batch = 2048,
+            n_ubatch = 2048,
             llama_extra_args = ["--no-mmproj"],
         )
         assert suppressed.compute_bytes < floored.compute_bytes

--- a/studio/backend/tests/test_memory_estimate.py
+++ b/studio/backend/tests/test_memory_estimate.py
@@ -3261,3 +3261,36 @@ class TestTheProjectorBatchFloorIsPricedNotJustLaunched:
         # Whatever the projector's runtime allowance adds, it is nothing like the
         # ~1.8 GB an unpaired subtraction leaked here.
         assert files_gb == pytest.approx(on_disk, abs = 0.2)
+
+    def test_a_family_mismatched_projector_is_not_priced_at_the_floor(self, tmp_path):
+        """_resolve_launch_mmproj_path rejects a projector whose filename carries a
+        different model-family token and launches text-only, so pricing 2048 for that
+        child overstates the panel by the same amount the missing floor understated it
+        by, just in the other direction."""
+        weight = _write_gguf(
+            tmp_path, "qwen3", _GQA_FIELDS, name = "gemma-3-12b-Q4_K_M.gguf"
+        )
+        matching = _write_gguf(
+            tmp_path, "clip", {"block_count": 2}, name = "mmproj-gemma-3-F16.gguf"
+        )
+        stranger = _write_gguf(
+            tmp_path, "clip", {"block_count": 2}, name = "mmproj-qwen3vl-F16.gguf"
+        )
+        base = dict(
+            identifier = "local/vision",
+            gguf_file = weight,
+            is_gguf = True,
+            is_vision = True,
+            gguf_variant = None,
+            gguf_mtp_file = None,
+            gguf_dspark_file = None,
+            gguf_dflash_file = None,
+        )
+
+        ok = SimpleNamespace(**base, gguf_mmproj_file = matching)
+        mismatched = SimpleNamespace(**base, gguf_mmproj_file = stranger)
+
+        # Both files exist; only the family token separates them.
+        assert Path(stranger).is_file()
+        assert ri._launch_raises_projector_batch(ok, None, False) is True
+        assert ri._launch_raises_projector_batch(mismatched, None, False) is False


### PR DESCRIPTION
## Summary
- Raise Studio's managed llama-server batch and ubatch values to 2048 when a resolved vision mmproj is launched.
- Keep user extra args appended after the managed flags, so manual overrides remain last-wins.
- Add regression coverage for the launched argv.

## Test verification (RED -> GREEN)
- RED: `test_vision_mmproj_defaults_batch_and_ubatch_above_image_tokens` fails on upstream/reverted production code because `--batch-size` is missing from the spawned llama-server command.
- GREEN: the same regression passes with the fix.
- Revert proof: removing the production fix makes the regression fail again for the original missing flag.
- Full local suite baseline: `./run-ci.sh` on `origin/main` passed, `189 passed`.
- Full local suite final: `./run-ci.sh` on commit `a6e987bcc` passed, `190 passed`, with `python-diff-coverage: PASS 5/5 changed production lines covered`.
- Additional local checks: `compileall` and `ruff check` passed on the touched Python files.

Closes #10559
