### PR TITLE
Key the recreated-project delete tests to state, not to a call count

### DIFF
--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -5986,11 +5986,9 @@ def test_a_project_created_during_the_record_write_keeps_its_files(tmp_path, mon
     (workspace / "sandbox").mkdir(parents = True)
     (workspace / "sandbox" / "fresh.csv").write_text("a,b\n", encoding = "utf-8")
 
-    # Created once the delete has looked and never removed again. A list popped per call says
-    # the project comes back and then vanishes, which no registry does, and it silently
-    # re-points the scenario at whichever probe happens to be second: adding one ownership
-    # read anywhere upstream moved the recreation onto a check that had already passed, and
-    # the workspace was deleted with the new project's files in it.
+    # Created once the delete has looked, and never removed again. A list popped per call has
+    # it come back and then vanish, which no registry does, and points the scenario at whichever
+    # probe is second: one added ownership read upstream moved it past every surviving check.
     looked = {"once": False}
 
     def created_after_the_first_look(pid):
@@ -6019,9 +6017,9 @@ def test_a_project_created_during_the_record_write_keeps_its_files(tmp_path, mon
 def test_a_project_created_inside_the_record_write_itself_keeps_its_files(tmp_path, monkeypatch):
     """The same rescue, pinned to the window the name describes rather than to a call count.
 
-    The test above is satisfied by the `recreated` probe, which runs well before the record
-    write, so it never reached the last check standing next to the delete. Here the project
-    appears during `record_orphaned_project` itself, so only that check can save the files.
+    The test above is satisfied by the `recreated` probe, well before the record write, so it
+    never reached the last check. Here the project appears during `record_orphaned_project`
+    itself, so only that check can save the files.
     """
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "home"))
 

--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -5986,11 +5986,68 @@ def test_a_project_created_during_the_record_write_keeps_its_files(tmp_path, mon
     (workspace / "sandbox").mkdir(parents = True)
     (workspace / "sandbox" / "fresh.csv").write_text("a,b\n", encoding = "utf-8")
 
-    answers = [None, {"id": project_id}]
+    # Created once the delete has looked and never removed again. A list popped per call says
+    # the project comes back and then vanishes, which no registry does, and it silently
+    # re-points the scenario at whichever probe happens to be second: adding one ownership
+    # read anywhere upstream moved the recreation onto a check that had already passed, and
+    # the workspace was deleted with the new project's files in it.
+    looked = {"once": False}
+
+    def created_after_the_first_look(pid):
+        if not looked["once"]:
+            looked["once"] = True
+            return None
+        return {"id": pid}
+
+    monkeypatch.setattr(chat_history, "get_chat_project", created_after_the_first_look)
+    monkeypatch.setattr(
+        studio_db,
+        "get_chat_project",
+        lambda pid: {
+            "id": pid,
+            "rootPath": str(workspace),
+            "sandboxPath": str(workspace / "sandbox"),
+        },
+    )
+    monkeypatch.setattr(studio_db, "sandbox_is_referenced_elsewhere", lambda s, e = None: False)
+    _deleted_project(tmp_path, monkeypatch, project_id, workspace)
+
+    assert (workspace / "sandbox" / "fresh.csv").is_file(), "the new project's files went"
+    assert tools.list_orphaned_projects() == [], "a live project was left recorded"
+
+
+def test_a_project_created_inside_the_record_write_itself_keeps_its_files(tmp_path, monkeypatch):
+    """The same rescue, pinned to the window the name describes rather than to a call count.
+
+    The test above is satisfied by the `recreated` probe, which runs well before the record
+    write, so it never reached the last check standing next to the delete. Here the project
+    appears during `record_orphaned_project` itself, so only that check can save the files.
+    """
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "home"))
+
+    from core.inference import tools
+    from routes import chat_history
+    from storage import studio_db
+
+    _forget_sandbox_state(tools)
+    project_id = "proj14141"
+    workspace = tmp_path / "Notes-proj1414"
+    (workspace / "sandbox").mkdir(parents = True)
+    (workspace / "sandbox" / "fresh.csv").write_text("a,b\n", encoding = "utf-8")
+
+    recreated = {"yet": False}
+    real_record = tools.record_orphaned_project
+
+    def record_then_recreate(*args, **kwargs):
+        result = real_record(*args, **kwargs)
+        recreated["yet"] = True
+        return result
+
+    monkeypatch.setattr(tools, "record_orphaned_project", record_then_recreate)
     monkeypatch.setattr(
         chat_history,
         "get_chat_project",
-        lambda pid: answers.pop(0) if answers else None,
+        lambda pid: {"id": pid} if recreated["yet"] else None,
     )
     monkeypatch.setattr(
         studio_db,
@@ -6004,6 +6061,7 @@ def test_a_project_created_during_the_record_write_keeps_its_files(tmp_path, mon
     monkeypatch.setattr(studio_db, "sandbox_is_referenced_elsewhere", lambda s, e = None: False)
     _deleted_project(tmp_path, monkeypatch, project_id, workspace)
 
+    assert recreated["yet"], "the record was never written, so this proves nothing"
     assert (workspace / "sandbox" / "fresh.csv").is_file(), "the new project's files went"
     assert tools.list_orphaned_projects() == [], "a live project was left recorded"
 


### PR DESCRIPTION
`Backend CI` is red on main: `test_a_project_created_during_the_record_write_keeps_its_files` fails with `AssertionError: the new project's files went`. I caused it in #10561 and this puts it right.

## What happened

The test scripted `get_chat_project` as a list popped once per call:

```python
answers = [None, {"id": project_id}]
monkeypatch.setattr(chat_history, "get_chat_project", lambda pid: answers.pop(0) if answers else None)
```

So which of `delete_project`'s probes saw the recreation depended entirely on how many times the delete path read the registry. #10561 added a second ownership read inside `_delete_project_rag_sources`, and traced against head the sequence is now:

```
1  _delete_project_rag_sources:1147  None      -> the delete proceeds
2  _delete_project_rag_sources:1153  PROJECT   -> RAG retirement aborts, consuming the answer
3  delete_project (recreated)        None
4  delete_project (once more)        None      -> workspace deleted
```

Before that read existed, the project landed on probe 2, which was `recreated`, and the files were kept.

## Which side is wrong

The extra read is not. `get_chat_project` is a real registry read in production, each one reflects true state, and reading it twice is what closes the race #10561 was about. Nothing goes wrong from asking again.

The list is. Popping per call says the project is recreated and then disappears again, which no registry does, and it silently re-points the scenario at whichever probe happens to be second. It returns `None` for the first look and the project from every look after, which is what "created during the delete" actually means, and it no longer cares how many times the delete path asks.

## The test also never reached the check it is named for

`recreated` is read well before the record write and already keeps the files, so the last check, the one standing next to the delete under the comment "the record write above is an await", was never exercised by this test at all. That gap is why one added read could turn the whole thing red without any test noticing the path it claims to cover.

`test_a_project_created_inside_the_record_write_itself_keeps_its_files` closes it: the project appears during `record_orphaned_project`, so `recreated` is already `False` and only the final check can save the files. Stubbing that check out fails the new test and leaves the old one passing, which is the proof it covers something the old one did not.

## Verification

`studio/backend/tests/test_sandbox_files_and_storage_roots.py`: 273 passed. Tests only, no product code in this diff.
