### PR TITLE
Studio: give the conversation archive's order a final tiebreaker

### DIFF
--- a/studio/backend/core/rag/conversation_archive.py
+++ b/studio/backend/core/rag/conversation_archive.py
@@ -2119,6 +2119,22 @@ def _document_matches_one_run(
     return any(_one_run_from(start) for start in range(len(transcript)))
 
 
+def _order_key(ordinal, created_at, document_rowid, chunk_index) -> tuple:
+    """The recall order, from the four values it reads, whatever they were spelled.
+
+    One definition because there are two callers: the single-query path reads a row's
+    snake_case columns and the two-query merge reads a source's camelCase keys. They must
+    agree component for component, and a second copy of a five-part key agrees only until
+    someone edits one of them.
+    """
+    created = created_at or ""
+    rowid = document_rowid or 0
+    index = chunk_index or 0
+    if ordinal is None:
+        return (0, 0, created, rowid, index)
+    return (1, int(ordinal), created, rowid, index)
+
+
 def _conversation_order(row) -> tuple:
     """Sort key putting recalled turns in the order they were said.
 
@@ -2149,13 +2165,12 @@ def _conversation_order(row) -> tuple:
     """
     if row is None:
         return (2, 0, "", 0, 0)
-    ordinal = tool._row_value(row, "archive_ordinal")
-    created = tool._row_value(row, "created_at") or ""
-    index = tool._row_value(row, "chunk_index") or 0
-    rowid = tool._row_value(row, "document_rowid") or 0
-    if ordinal is None:
-        return (0, 0, created, rowid, index)
-    return (1, int(ordinal), created, rowid, index)
+    return _order_key(
+        tool._row_value(row, "archive_ordinal"),
+        tool._row_value(row, "created_at"),
+        tool._row_value(row, "document_rowid"),
+        tool._row_value(row, "chunk_index"),
+    )
 
 
 def _above_floor(hits: list, min_dense_score: float) -> list:
@@ -2489,20 +2504,17 @@ def recall(
         if not merged:
             return None
         if config.CONVERSATION_RECALL_ORDER == "chronological":
-            # The same key `_conversation_order` uses on the single-query path, component
-            # for component: a turn with no ordinal predates every numbered one, and
-            # `chunkIndex` keeps a long turn's pieces in writing order rather than in the
-            # order the two queries returned them, which a stable sort would otherwise
-            # preserve. It has to stay in that order too, `documentRowid` above
-            # `chunkIndex`, or two tied documents interleave here while the single-query
+            # Literally the key `_conversation_order` uses, not a second copy of it that
+            # agrees today: `chunkIndex` keeps a long turn's pieces in writing order rather
+            # than in the order the two queries returned them, and it has to stay UNDER
+            # `documentRowid`, or two tied documents interleave here while the single-query
             # path groups them and the merged block disagrees with the unmerged one.
             merged.sort(
-                key = lambda source: (
-                    source.get("turn") is not None,
-                    source.get("turn") or 0,
-                    source.get("createdAt") or "",
-                    source.get("documentRowid") or 0,
-                    source.get("chunkIndex") or 0,
+                key = lambda source: _order_key(
+                    source.get("turn"),
+                    source.get("createdAt"),
+                    source.get("documentRowid"),
+                    source.get("chunkIndex"),
                 )
             )
             kept = merged[:limit]

--- a/studio/backend/core/rag/conversation_archive.py
+++ b/studio/backend/core/rag/conversation_archive.py
@@ -451,6 +451,7 @@ def archive_turns(
                 continue
             ordinal = None
             archived_at = None
+            archived_rowid = None
             if stale is not None:
                 # Same turn, vectors from an embedder the query side no longer asks for.
                 # The copy is replaced rather than deduplicated, as ingestion does, since
@@ -461,9 +462,16 @@ def archive_turns(
                 # reorder the archive by the order its vectors were rebuilt. NULL stays
                 # NULL, since numbering a pre-column row moves the oldest turn behind every
                 # numbered one and the header would call it the conversation's last word.
-                previous = store.get_document(conn, stale) or {}
+                #
+                # And its ROWID, which is what "keeps its timestamp" reduces to whenever the
+                # timestamp cannot separate two turns: rows archived in the same clock tick
+                # share a `created_at` to the byte, and insertion order is then the only
+                # surviving record of which was said first. Free to reuse because the row is
+                # deleted below in this same transaction.
+                previous = store.document_rewrite_identity(conn, stale) or {}
                 ordinal = previous.get("archive_ordinal")
                 archived_at = previous.get("created_at")
+                archived_rowid = previous.get("rowid")
                 store.delete_document(conn, stale, commit = False)
             else:
                 # The nth copy of a repeated turn takes the nth occurrence's position, so a
@@ -495,6 +503,9 @@ def archive_turns(
                 # When the turn was archived, not when this row was written. None for a turn
                 # seen for the first time, which takes the clock as before.
                 created_at = archived_at,
+                # Likewise None for a first sighting, which lets SQLite assign the next
+                # rowid exactly as it always has.
+                rowid = archived_rowid,
                 commit = False,
             )
             try:
@@ -2118,15 +2129,28 @@ def _conversation_order(row) -> tuple:
     breaks ties, because the ordinal is deliberately not UNIQUE: the write lock is
     best-effort, so two concurrent archive passes can compute the same MAX + 1 and must
     tie-break rather than raise.
+
+    The document's rowid ends the key, and it has to, because everything above it can tie:
+    `created_at` is a wall-clock reading, and a clock whose granularity is coarser than a
+    write is a clock that stamps several rows identically. Windows advances the system
+    clock about every 15.6 ms, so a compaction writing a whole conversation at once
+    routinely gives every turn the same timestamp to the byte. With the key exhausted the
+    sort is no longer a total order, `sorted` keeps whatever order relevance handed it, and
+    the turns are quoted scrambled under a header saying they are oldest first and that
+    each supersedes the one before. Insertion order is the tiebreak because it is what the
+    archive actually recorded, and the rewrite path preserves it (`create_document`'s
+    `rowid`) so a re-embed cannot move a turn. Last in the key, so it decides nothing that
+    an ordinal or a timestamp already decided.
     """
     if row is None:
-        return (2, 0, "", 0)
+        return (2, 0, "", 0, 0)
     ordinal = tool._row_value(row, "archive_ordinal")
     created = tool._row_value(row, "created_at") or ""
     index = tool._row_value(row, "chunk_index") or 0
+    rowid = tool._row_value(row, "document_rowid") or 0
     if ordinal is None:
-        return (0, 0, created, index)
-    return (1, int(ordinal), created, index)
+        return (0, 0, created, index, rowid)
+    return (1, int(ordinal), created, index, rowid)
 
 
 def _above_floor(hits: list, min_dense_score: float) -> list:
@@ -2470,6 +2494,7 @@ def recall(
                     source.get("turn") or 0,
                     source.get("createdAt") or "",
                     source.get("chunkIndex") or 0,
+                    source.get("documentRowid") or 0,
                 )
             )
             kept = merged[:limit]

--- a/studio/backend/core/rag/conversation_archive.py
+++ b/studio/backend/core/rag/conversation_archive.py
@@ -2124,13 +2124,11 @@ def _conversation_order(row) -> tuple:
 
     NULL ordinals sort FIRST, and that is not a fallback so much as a fact: they were
     written by a build that had no such column, so they genuinely predate every numbered
-    turn in the same scope. Within a turn, `chunk_index` keeps a long message's pieces
-    contiguous and in order, which relevance ordering gets wrong today. `created_at`
-    breaks ties, because the ordinal is deliberately not UNIQUE: the write lock is
-    best-effort, so two concurrent archive passes can compute the same MAX + 1 and must
-    tie-break rather than raise.
+    turn in the same scope. `created_at` breaks ties below that, because the ordinal is
+    deliberately not UNIQUE: the write lock is best-effort, so two concurrent archive
+    passes can compute the same MAX + 1 and must tie-break rather than raise.
 
-    The document's rowid ends the key, and it has to, because everything above it can tie:
+    Then the document's rowid, and it is needed because everything above it can tie:
     `created_at` is a wall-clock reading, and a clock whose granularity is coarser than a
     write is a clock that stamps several rows identically. Windows advances the system
     clock about every 15.6 ms, so a compaction writing a whole conversation at once
@@ -2139,8 +2137,15 @@ def _conversation_order(row) -> tuple:
     the turns are quoted scrambled under a header saying they are oldest first and that
     each supersedes the one before. Insertion order is the tiebreak because it is what the
     archive actually recorded, and the rewrite path preserves it (`create_document`'s
-    `rowid`) so a re-embed cannot move a turn. Last in the key, so it decides nothing that
-    an ordinal or a timestamp already decided.
+    `rowid`) so a re-embed cannot move a turn.
+
+    `chunk_index` comes LAST, under the rowid rather than over it, because it is a position
+    WITHIN a document and means nothing between two of them. Ranked above document
+    identity it does not order the turns, it interleaves them: two tied documents of three
+    chunks each sort A0, B0, A1, B1, A2, B2, and the long message whose pieces this
+    component exists to keep contiguous is shredded through its neighbour. That is the same
+    defect as the tie it sits beneath, one level down, and it only appears once two
+    DOCUMENTS tie, which is exactly the case the rowid was added for.
     """
     if row is None:
         return (2, 0, "", 0, 0)
@@ -2149,8 +2154,8 @@ def _conversation_order(row) -> tuple:
     index = tool._row_value(row, "chunk_index") or 0
     rowid = tool._row_value(row, "document_rowid") or 0
     if ordinal is None:
-        return (0, 0, created, index, rowid)
-    return (1, int(ordinal), created, index, rowid)
+        return (0, 0, created, rowid, index)
+    return (1, int(ordinal), created, rowid, index)
 
 
 def _above_floor(hits: list, min_dense_score: float) -> list:
@@ -2484,17 +2489,20 @@ def recall(
         if not merged:
             return None
         if config.CONVERSATION_RECALL_ORDER == "chronological":
-            # The same key `_conversation_order` uses on the single-query path: a turn with
-            # no ordinal predates every numbered one, and `chunkIndex` keeps a long turn's
-            # pieces in writing order rather than in the order the two queries returned
-            # them, which a stable sort would otherwise preserve.
+            # The same key `_conversation_order` uses on the single-query path, component
+            # for component: a turn with no ordinal predates every numbered one, and
+            # `chunkIndex` keeps a long turn's pieces in writing order rather than in the
+            # order the two queries returned them, which a stable sort would otherwise
+            # preserve. It has to stay in that order too, `documentRowid` above
+            # `chunkIndex`, or two tied documents interleave here while the single-query
+            # path groups them and the merged block disagrees with the unmerged one.
             merged.sort(
                 key = lambda source: (
                     source.get("turn") is not None,
                     source.get("turn") or 0,
                     source.get("createdAt") or "",
-                    source.get("chunkIndex") or 0,
                     source.get("documentRowid") or 0,
+                    source.get("chunkIndex") or 0,
                 )
             )
             kept = merged[:limit]

--- a/studio/backend/core/rag/conversation_archive.py
+++ b/studio/backend/core/rag/conversation_archive.py
@@ -462,11 +462,8 @@ def archive_turns(
                 # reorder the archive by the order its vectors were rebuilt. NULL stays
                 # NULL, since numbering a pre-column row moves the oldest turn behind every
                 # numbered one and the header would call it the conversation's last word.
-                #
-                # And its ROWID, which is what "keeps its timestamp" reduces to whenever the
-                # timestamp cannot separate two turns: rows archived in the same clock tick
-                # share a `created_at` to the byte, and insertion order is then the only
-                # surviving record of which was said first. Free to reuse because the row is
+                # And its ROWID: turns archived in one clock tick share a `created_at`, so
+                # insertion order is all that separates them. Reusable because the row is
                 # deleted below in this same transaction.
                 previous = store.document_rewrite_identity(conn, stale) or {}
                 ordinal = previous.get("archive_ordinal")
@@ -503,8 +500,7 @@ def archive_turns(
                 # When the turn was archived, not when this row was written. None for a turn
                 # seen for the first time, which takes the clock as before.
                 created_at = archived_at,
-                # Likewise None for a first sighting, which lets SQLite assign the next
-                # rowid exactly as it always has.
+                # Likewise None for a first sighting: SQLite then assigns the next rowid.
                 rowid = archived_rowid,
                 commit = False,
             )
@@ -2120,12 +2116,9 @@ def _document_matches_one_run(
 
 
 def _order_key(ordinal, created_at, document_rowid, chunk_index) -> tuple:
-    """The recall order, from the four values it reads, whatever they were spelled.
-
-    One definition because there are two callers: the single-query path reads a row's
-    snake_case columns and the two-query merge reads a source's camelCase keys. They must
-    agree component for component, and a second copy of a five-part key agrees only until
-    someone edits one of them.
+    """The recall order, spelling-independent: the single-query path passes a row's
+    snake_case columns and the merge passes a source's camelCase keys, and a second copy of
+    the key agrees only until someone edits one of them.
     """
     created = created_at or ""
     rowid = document_rowid or 0
@@ -2144,24 +2137,15 @@ def _conversation_order(row) -> tuple:
     deliberately not UNIQUE: the write lock is best-effort, so two concurrent archive
     passes can compute the same MAX + 1 and must tie-break rather than raise.
 
-    Then the document's rowid, and it is needed because everything above it can tie:
-    `created_at` is a wall-clock reading, and a clock whose granularity is coarser than a
-    write is a clock that stamps several rows identically. Windows advances the system
-    clock about every 15.6 ms, so a compaction writing a whole conversation at once
-    routinely gives every turn the same timestamp to the byte. With the key exhausted the
-    sort is no longer a total order, `sorted` keeps whatever order relevance handed it, and
-    the turns are quoted scrambled under a header saying they are oldest first and that
-    each supersedes the one before. Insertion order is the tiebreak because it is what the
-    archive actually recorded, and the rewrite path preserves it (`create_document`'s
-    `rowid`) so a re-embed cannot move a turn.
+    Then the document's rowid, because `created_at` ties whenever the clock is coarser than
+    the write: Windows advances it about every 15.6 ms, so a compaction stamps a whole
+    conversation identically and the sort falls back to relevance order under a header
+    saying oldest first. Insertion order is what the archive recorded, and the rewrite path
+    preserves it (`create_document`'s `rowid`) so a re-embed cannot move a turn.
 
-    `chunk_index` comes LAST, under the rowid rather than over it, because it is a position
-    WITHIN a document and means nothing between two of them. Ranked above document
-    identity it does not order the turns, it interleaves them: two tied documents of three
-    chunks each sort A0, B0, A1, B1, A2, B2, and the long message whose pieces this
-    component exists to keep contiguous is shredded through its neighbour. That is the same
-    defect as the tie it sits beneath, one level down, and it only appears once two
-    DOCUMENTS tie, which is exactly the case the rowid was added for.
+    `chunk_index` comes LAST because it is a position WITHIN a document: above the rowid it
+    interleaves two tied documents (A0, B0, A1, B1, ...) rather than ordering them,
+    shredding the long message it exists to keep contiguous.
     """
     if row is None:
         return (2, 0, "", 0, 0)
@@ -2504,11 +2488,9 @@ def recall(
         if not merged:
             return None
         if config.CONVERSATION_RECALL_ORDER == "chronological":
-            # Literally the key `_conversation_order` uses, not a second copy of it that
-            # agrees today: `chunkIndex` keeps a long turn's pieces in writing order rather
-            # than in the order the two queries returned them, and it has to stay UNDER
-            # `documentRowid`, or two tied documents interleave here while the single-query
-            # path groups them and the merged block disagrees with the unmerged one.
+            # Literally the key `_conversation_order` uses, not a second copy that agrees
+            # today: component order included, or the merged block contradicts the unmerged
+            # one on the same archive.
             merged.sort(
                 key = lambda source: _order_key(
                     source.get("turn"),

--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -568,9 +568,16 @@ def search_lexical(
     `newest_first` breaks TIES the other way round. FTS5 floors the IDF of a term the
     whole index shares, so every hit on a per-thread archive's own subject scores the
     same, and `ORDER BY s LIMIT k` then returns the k OLDEST rows: past k chunks on that
-    subject the newest assignment is unreachable at any k. Ordering is by rowid, which is
-    insertion order rather than exact conversation order, so this widens the candidate
-    set and does not decide anything; the caller still orders what it gets.
+    subject the newest assignment is unreachable at any k.
+
+    Both ordered forms SELECT rather than arrange: under the `LIMIT` they decide which rows
+    the caller is offered at all, and the caller cannot recover a row the query never
+    returned. So the tiebreak has to be `conversation_archive._conversation_order` component
+    for component -- ordinal, `created_at`, document rowid, chunk index -- and ending it on
+    a chunk id ends it on a uuid4. On a legacy archive, where every ordinal is NULL and one
+    clock tick stamped every row, that uuid IS the whole cut, so both halves come back with
+    the ends of the id space rather than the ends of the conversation.
+    `test_the_candidate_window_is_cut_in_conversation_order` pins the two orders together.
     """
     mq = match_query if match_query is not None else _match_query(query)
     if not mq:
@@ -589,25 +596,29 @@ def search_lexical(
         # The filtered form runs both subqueries for every matched row BEFORE the LIMIT, and with nothing
         # linked that work is provably wasted (linked_folder_rows_exist).
         if oldest_first:
-            # Order by archive ordinal, not rowid, which a re-embed scrambles; NULLs first as oldest, then
-            # created_at and chunk id, else on a legacy archive both halves return the same subset.
+            # Ordinal (NULLs first, as oldest), created_at, DOCUMENT rowid, chunk index:
+            # `_conversation_order` component for component, because this clause chooses the
+            # window rather than arranging it. The document rowid, not the chunk one, since
+            # a re-embed rewrites a document's chunk rows and only the document's own rowid
+            # survives that rewrite (`create_document`'s `rowid`).
             sql = (
                 f"SELECT chunks_fts.chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
                 f"JOIN chunks c ON c.id=chunks_fts.chunk_id "
                 f"JOIN documents d ON d.id=c.document_id "
                 f"WHERE chunks_fts MATCH ? AND chunks_fts.scope IN ({placeholders}) "
                 f"ORDER BY s, d.archive_ordinal IS NOT NULL, d.archive_ordinal ASC, "
-                f"d.created_at ASC, chunks_fts.chunk_id ASC LIMIT ?"
+                f"d.created_at ASC, d.rowid ASC, c.chunk_index ASC LIMIT ?"
             )
         elif newest_first:
-            # rowid is insertion order and a re-embed reinserts a chunk, so a rowid DESC window missed the newest turn.
+            # The mirror of the clause above, every component reversed, so the two halves cut
+            # the same run at opposite ends.
             sql = (
                 f"SELECT chunks_fts.chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
                 f"JOIN chunks c ON c.id=chunks_fts.chunk_id "
                 f"JOIN documents d ON d.id=c.document_id "
                 f"WHERE chunks_fts MATCH ? AND chunks_fts.scope IN ({placeholders}) "
                 f"ORDER BY s, d.archive_ordinal IS NULL, d.archive_ordinal DESC, "
-                f"d.created_at DESC, chunks_fts.chunk_id DESC LIMIT ?"
+                f"d.created_at DESC, d.rowid DESC, c.chunk_index DESC LIMIT ?"
             )
         elif linked_folder_rows_exist(conn):
             sql = (

--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -283,13 +283,11 @@ def create_document(
     before `archive_ordinal` existed is ordered by `created_at` alone, so a rewrite that
     takes a fresh timestamp moves that turn to the end of its own conversation.
 
-    ``rowid`` carries over for the same reason, one level down. Two rows archived in the
-    same clock tick hold the same `created_at` -- routine on Windows, whose wall clock
-    advances about every 15.6 ms -- and insertion order is then the only record left of
-    which turn was said first. A rewrite that takes a fresh rowid discards it, so the
-    rewritten turns sort behind the ones the pass never reached. Omitted, both arguments
-    leave this byte for byte what every other caller has always got: SQLite assigns the
-    next rowid for a NULL, exactly as it does when the column is not named at all.
+    ``rowid`` carries over one level down: rows archived in the same clock tick share a
+    `created_at` (routine on Windows, ~15.6 ms tick), so insertion order is all that
+    separates them and a fresh rowid sorts the rewritten turns behind the untouched ones.
+    Omitted, both arguments leave this byte for byte what every other caller has always
+    got: a NULL rowid is assigned exactly as if the column were not named.
     """
     document_id = document_id or str(uuid.uuid4())
     conn.execute(
@@ -397,10 +395,9 @@ def get_document(conn: sqlite3.Connection, document_id: str) -> dict | None:
 
 
 def document_rewrite_identity(conn: sqlite3.Connection, document_id: str) -> dict | None:
-    """What a re-embed has to carry over from the row it replaces, `rowid` included.
-
-    Separate from `get_document` because `SELECT *` does not return the implicit rowid and
-    widening that query would add the key to every caller's dict.
+    """What a re-embed carries over from the row it replaces. Separate from `get_document`
+    because `SELECT *` omits the implicit rowid and widening it would add the key to every
+    caller's dict.
     """
     row = conn.execute(
         "SELECT rowid, archive_ordinal, created_at FROM documents WHERE id=?", (document_id,)

--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -272,24 +272,33 @@ def create_document(
     archive_messages: int | None = None,
     archive_ordinal: int | None = None,
     created_at: str | None = None,
+    rowid: int | None = None,
     commit: bool = True,
 ) -> str:
-    """``created_at`` is for a REWRITE of a row that already exists, and nothing else.
+    """``created_at`` and ``rowid`` are for a REWRITE of a row that already exists.
 
     A re-embed deletes the old row and inserts a new one for the same content, so stamping
     it with the current time would say the turn was archived when its vectors were
     rebuilt. That is not a cosmetic difference for an archived turn: an archive written
     before `archive_ordinal` existed is ordered by `created_at` alone, so a rewrite that
-    takes a fresh timestamp moves that turn to the end of its own conversation. Omitted,
-    this is byte for byte what every other caller has always got.
+    takes a fresh timestamp moves that turn to the end of its own conversation.
+
+    ``rowid`` carries over for the same reason, one level down. Two rows archived in the
+    same clock tick hold the same `created_at` -- routine on Windows, whose wall clock
+    advances about every 15.6 ms -- and insertion order is then the only record left of
+    which turn was said first. A rewrite that takes a fresh rowid discards it, so the
+    rewritten turns sort behind the ones the pass never reached. Omitted, both arguments
+    leave this byte for byte what every other caller has always got: SQLite assigns the
+    next rowid for a NULL, exactly as it does when the column is not named at all.
     """
     document_id = document_id or str(uuid.uuid4())
     conn.execute(
-        "INSERT INTO documents(id, scope, kb_id, thread_id, project_id, filename, sha256, "
+        "INSERT INTO documents(rowid, id, scope, kb_id, thread_id, project_id, filename, sha256, "
         "status, stored_path, created_at, embedding_model, linked_folder_id, "
         "linked_relative_path, archive_messages, archive_ordinal) "
-        "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (
+            rowid,
             document_id,
             scope,
             kb_id,
@@ -384,6 +393,18 @@ def next_archive_ordinal(conn: sqlite3.Connection, scope: str) -> int:
 
 def get_document(conn: sqlite3.Connection, document_id: str) -> dict | None:
     row = conn.execute("SELECT * FROM documents WHERE id=?", (document_id,)).fetchone()
+    return dict(row) if row else None
+
+
+def document_rewrite_identity(conn: sqlite3.Connection, document_id: str) -> dict | None:
+    """What a re-embed has to carry over from the row it replaces, `rowid` included.
+
+    Separate from `get_document` because `SELECT *` does not return the implicit rowid and
+    widening that query would add the key to every caller's dict.
+    """
+    row = conn.execute(
+        "SELECT rowid, archive_ordinal, created_at FROM documents WHERE id=?", (document_id,)
+    ).fetchone()
     return dict(row) if row else None
 
 
@@ -737,7 +758,8 @@ def chunks_by_id(conn: sqlite3.Connection, ids) -> dict:
     placeholders = ",".join("?" * len(ids))
     rows = conn.execute(
         f"SELECT c.id, c.text, c.document_id, c.chunk_index, c.page_number, "
-        f"c.source_page_index, d.filename, d.archive_ordinal, d.created_at "
+        f"c.source_page_index, d.filename, d.archive_ordinal, d.created_at, "
+        f"d.rowid AS document_rowid "
         f"FROM chunks c JOIN documents d ON d.id=c.document_id "
         f"WHERE c.id IN ({placeholders}) AND NOT EXISTS "
         f"(SELECT 1 FROM linked_folder_retired_scopes r WHERE r.scope=d.scope) "

--- a/studio/backend/core/rag/store.py
+++ b/studio/backend/core/rag/store.py
@@ -568,12 +568,10 @@ def search_lexical(
     subject the newest assignment is unreachable at any k.
 
     Both ordered forms SELECT rather than arrange: under the `LIMIT` they decide which rows
-    the caller is offered at all, and the caller cannot recover a row the query never
-    returned. So the tiebreak has to be `conversation_archive._conversation_order` component
-    for component -- ordinal, `created_at`, document rowid, chunk index -- and ending it on
-    a chunk id ends it on a uuid4. On a legacy archive, where every ordinal is NULL and one
-    clock tick stamped every row, that uuid IS the whole cut, so both halves come back with
-    the ends of the id space rather than the ends of the conversation.
+    the caller is offered at all. So the tiebreak has to be
+    `conversation_archive._conversation_order` component for component, and ending it on a
+    chunk id ends it on a uuid4 -- which on a legacy archive, every ordinal NULL and one
+    clock tick over every row, IS the whole cut.
     `test_the_candidate_window_is_cut_in_conversation_order` pins the two orders together.
     """
     mq = match_query if match_query is not None else _match_query(query)
@@ -593,11 +591,9 @@ def search_lexical(
         # The filtered form runs both subqueries for every matched row BEFORE the LIMIT, and with nothing
         # linked that work is provably wasted (linked_folder_rows_exist).
         if oldest_first:
-            # Ordinal (NULLs first, as oldest), created_at, DOCUMENT rowid, chunk index:
-            # `_conversation_order` component for component, because this clause chooses the
-            # window rather than arranging it. The document rowid, not the chunk one, since
-            # a re-embed rewrites a document's chunk rows and only the document's own rowid
-            # survives that rewrite (`create_document`'s `rowid`).
+            # `_conversation_order` component for component. The DOCUMENT rowid, not the
+            # chunk one: a re-embed rewrites the chunk rows and only the document's own
+            # rowid survives it (`create_document`'s `rowid`).
             sql = (
                 f"SELECT chunks_fts.chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
                 f"JOIN chunks c ON c.id=chunks_fts.chunk_id "
@@ -607,8 +603,7 @@ def search_lexical(
                 f"d.created_at ASC, d.rowid ASC, c.chunk_index ASC LIMIT ?"
             )
         elif newest_first:
-            # The mirror of the clause above, every component reversed, so the two halves cut
-            # the same run at opposite ends.
+            # The mirror of the clause above, so the two halves cut the run at opposite ends.
             sql = (
                 f"SELECT chunks_fts.chunk_id, bm25(chunks_fts) AS s FROM chunks_fts "
                 f"JOIN chunks c ON c.id=chunks_fts.chunk_id "

--- a/studio/backend/core/rag/tool.py
+++ b/studio/backend/core/rag/tool.py
@@ -151,10 +151,8 @@ def format_conversation_recall(rows, hits) -> tuple[str, list[dict]]:
                 # ordinals are not UNIQUE.
                 "chunkIndex": _row_value(r, "chunk_index"),
                 "createdAt": _row_value(r, "created_at"),
-                # And insertion order under that, for the archives whose rows all carry the
-                # same timestamp because the clock that stamped them could not tell them
-                # apart. Without it the merge key runs out and the block contradicts its
-                # own "oldest first" header.
+                # And insertion order under that, for archives whose rows share a timestamp
+                # the clock was too coarse to separate; without it the merge key runs out.
                 "documentRowid": _row_value(r, "document_rowid"),
                 "score": round(float(h.score), 4) if h.score is not None else None,
             }

--- a/studio/backend/core/rag/tool.py
+++ b/studio/backend/core/rag/tool.py
@@ -151,6 +151,11 @@ def format_conversation_recall(rows, hits) -> tuple[str, list[dict]]:
                 # ordinals are not UNIQUE.
                 "chunkIndex": _row_value(r, "chunk_index"),
                 "createdAt": _row_value(r, "created_at"),
+                # And insertion order under that, for the archives whose rows all carry the
+                # same timestamp because the clock that stamped them could not tell them
+                # apart. Without it the merge key runs out and the block contradicts its
+                # own "oldest first" header.
+                "documentRowid": _row_value(r, "document_rowid"),
                 "score": round(float(h.score), 4) if h.score is not None else None,
             }
         )

--- a/studio/backend/tests/test_conversation_archive.py
+++ b/studio/backend/tests/test_conversation_archive.py
@@ -2214,26 +2214,17 @@ def test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved(conn, monk
 def test_the_sql_candidate_order_agrees_with_the_python_recall_order(conn):
     """The two orderings are written twice, in two languages, so pin them to each other.
 
-    `store.search_lexical`'s ordered clauses and `_conversation_order` have to sort the same
-    rows the same way. They cannot share an implementation across the SQL boundary, so
-    nothing but this test stops one from being extended and the other left behind, and the
-    consequence of drift is not cosmetic: the SQL runs under a LIMIT and CHOOSES the
-    candidates, the Python only arranges the survivors, so a disagreement silently deletes
-    whichever turns the two ends disagree about.
+    `store.search_lexical`'s ordered clauses and `_conversation_order` cannot share an
+    implementation across the SQL boundary, and drift is not cosmetic: the SQL runs under a
+    LIMIT and CHOOSES the candidates, so a disagreement silently deletes the turns the two
+    ends disagree about.
 
-    Agreement is asserted WITHIN each BM25 score, which is the whole of what is being
-    claimed and all that can be. The SQL sorts by relevance first and the recall key has no
-    relevance component at all, by design: relevance decides which turns are eligible and
-    the archive decides the order among them. A tied run is also the only place the question
-    arises, since it is exactly where the score stops separating rows and the conversation
-    order becomes the cut.
-
-    The document ids are assigned here rather than left to `uuid4`, and assigned so that
-    sorting by them REVERSES conversation order. Left random the test would pass or fail on
-    the draw, which for a guard against silent drift is no better than not having one. The
-    archive is mixed on purpose too, numbered turns and legacy NULL ones, a shared timestamp
-    and a distinct one, single-chunk and multi-chunk documents, so every component of the key
-    is exercised and not only the one the current bug lives in.
+    Asserted WITHIN each BM25 score, since the SQL sorts by relevance first and the recall
+    key deliberately has no relevance component: relevance decides which turns are eligible,
+    the archive decides the order among them. Document ids are assigned so that sorting by
+    them REVERSES conversation order, or the test would pass on the draw. The archive is
+    mixed on purpose (numbered and legacy turns, a shared timestamp and a distinct one,
+    single- and multi-chunk documents) so every component of the key is exercised.
     """
     import types
 

--- a/studio/backend/tests/test_conversation_archive.py
+++ b/studio/backend/tests/test_conversation_archive.py
@@ -2347,7 +2347,6 @@ def test_both_recall_paths_order_by_the_same_key():
     unmerged one on exactly the archives this ordering exists for.
     """
     from core.rag import conversation_archive
-
     for ordinal in (None, 0, 4):
         for created in ("", "2026-01-01T00:00:00Z"):
             for rowid in (None, 0, 12):

--- a/studio/backend/tests/test_conversation_archive.py
+++ b/studio/backend/tests/test_conversation_archive.py
@@ -2160,6 +2160,65 @@ def test_a_legacy_archive_written_in_one_clock_tick_is_still_ordered(conn, monke
     assert quoted == ["1", "2", "3", "4", "5"], quoted
 
 
+def test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved(conn, monkeypatch):
+    """Tied documents must GROUP, because `chunk_index` is a position inside one of them.
+
+    The tie is the same one the test above forces, a clock too coarse to separate two
+    writes, but the turns here are long enough to be stored as several chunks each. Ranked
+    above the document, `chunk_index` stops being the thing that keeps a long message
+    contiguous and becomes the thing that shreds it: every document's chunk 0 sorts before
+    any document's chunk 1, so two three-chunk turns come back A0, B0, A1, B1, A2, B2 and
+    each turn is quoted through the middle of the other. Ranked below it, the same
+    component does the job it was added for.
+    """
+    monkeypatch.setattr(config, "CHUNK_TOKENS", 30)
+    monkeypatch.setattr(config, "CHUNK_OVERLAP", 0)
+    monkeypatch.setattr(store, "_now", lambda: "2026-01-01T00:00:00+00:00")
+
+    def _long_turn(tag):
+        return _turn(
+            f"turn {tag} about pelicans",
+            f"{tag}HEAD pelicans at the opening "
+            + " ".join(f"w{index}" for index in range(25))
+            + f" {tag}TAIL pelicans at the closing "
+            + " ".join(f"z{index}" for index in range(25)),
+        )
+
+    history = [dict(message) for tag in ("AAA", "BBB") for message in _long_turn(tag)]
+    _save_thread(THREAD, history, append = True)
+    assert conversation_archive.archive_turns(THREAD, [dict(m) for m in history]) == 2
+    scope = store.conversation_archive_scope(THREAD)
+    conn.execute("UPDATE documents SET archive_ordinal=NULL WHERE scope=?", (scope,))
+    conn.commit()
+    # The premise, and it takes both halves: one timestamp for both documents, and more
+    # than one chunk each, or the interleave has nothing to interleave.
+    assert {row["created_at"] for row in
+            conn.execute("SELECT created_at FROM documents WHERE scope=?", (scope,))} == {
+        "2026-01-01T00:00:00+00:00"
+    }
+    per_document = [
+        row["n"]
+        for row in conn.execute(
+            "SELECT COUNT(*) AS n FROM chunks WHERE scope=? GROUP BY document_id", (scope,)
+        )
+    ]
+    assert min(per_document) > 1, per_document
+
+    _text, sources = conversation_archive.recall(THREAD, "pelicans", top_k = 8)
+
+    # Each turn is quoted in one unbroken run, and the run that was archived first leads.
+    documents = [source["documentId"] for source in sources]
+    runs = [document for index, document in enumerate(documents)
+            if index == 0 or documents[index - 1] != document]
+    assert len(runs) == len(set(documents)) == 2, documents
+    # And inside a run the pieces are still in writing order, which is what `chunk_index`
+    # is for once it is asked the question it can answer.
+    for document in runs:
+        indexes = [s["chunkIndex"] for s in sources if s["documentId"] == document]
+        assert indexes == sorted(indexes), (document, indexes)
+    assert "AAAHEAD" in sources[0]["text"], sources[0]["text"]
+
+
 def test_a_rewritten_turn_keeps_the_insertion_order_it_was_archived_in(conn, monkeypatch):
     """A re-embed replaces a row, and the replacement has to sit where the original sat.
 

--- a/studio/backend/tests/test_conversation_archive.py
+++ b/studio/backend/tests/test_conversation_archive.py
@@ -2222,6 +2222,108 @@ def test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved(conn, monk
     assert "AAAHEAD" in sources[0]["text"], sources[0]["text"]
 
 
+def test_the_sql_candidate_order_agrees_with_the_python_recall_order(conn):
+    """The two orderings are written twice, in two languages, so pin them to each other.
+
+    `store.search_lexical`'s ordered clauses and `_conversation_order` have to sort the same
+    rows the same way. They cannot share an implementation across the SQL boundary, so
+    nothing but this test stops one from being extended and the other left behind, and the
+    consequence of drift is not cosmetic: the SQL runs under a LIMIT and CHOOSES the
+    candidates, the Python only arranges the survivors, so a disagreement silently deletes
+    whichever turns the two ends disagree about.
+
+    Agreement is asserted WITHIN each BM25 score, which is the whole of what is being
+    claimed and all that can be. The SQL sorts by relevance first and the recall key has no
+    relevance component at all, by design: relevance decides which turns are eligible and
+    the archive decides the order among them. A tied run is also the only place the question
+    arises, since it is exactly where the score stops separating rows and the conversation
+    order becomes the cut.
+
+    The document ids are assigned here rather than left to `uuid4`, and assigned so that
+    sorting by them REVERSES conversation order. Left random the test would pass or fail on
+    the draw, which for a guard against silent drift is no better than not having one. The
+    archive is mixed on purpose too, numbered turns and legacy NULL ones, a shared timestamp
+    and a distinct one, single-chunk and multi-chunk documents, so every component of the key
+    is exercised and not only the one the current bug lives in.
+    """
+    import types
+
+    scope = store.conversation_archive_scope(THREAD)
+    plan = [
+        # (ordinal, created_at, chunk count). Two legacy rows tied on one clock tick, then
+        # a legacy row the clock could separate, then two numbered rows tied to each other.
+        (None, "2026-01-01T00:00:00+00:00", 3),
+        (None, "2026-01-01T00:00:00+00:00", 2),
+        (None, "2026-01-02T00:00:00+00:00", 1),
+        (7, "2026-01-03T00:00:00+00:00", 2),
+        (8, "2026-01-03T00:00:00+00:00", 2),
+    ]
+    for position, (ordinal, created, count) in enumerate(plan):
+        # Descending ids against ascending conversation order: id order is exactly wrong.
+        document_id = f"{len(plan) - position:04d}-turn"
+        store.create_document(
+            conn,
+            scope = scope,
+            thread_id = THREAD,
+            filename = "earlier turn",
+            sha256 = f"h{position}",
+            status = "completed",
+            embedding_model = "m",
+            archive_messages = 2,
+            archive_ordinal = ordinal,
+            document_id = document_id,
+            created_at = created,
+            commit = False,
+        )
+        store.add_chunks(
+            conn,
+            scope,
+            document_id,
+            [
+                types.SimpleNamespace(
+                    chunk_index = index,
+                    text = "ZQXAGREE statement " + "word " * (index + position),
+                    page_number = None,
+                    source_page_index = None,
+                    token_count = 5,
+                    char_count = 20,
+                )
+                for index in range(count)
+            ],
+            [[0.0] * 4] * count,
+        )
+    conn.commit()
+
+    def _tiers(**direction):
+        hits = store.search_lexical(conn, scope, "ZQXAGREE", 500, **direction)
+        grouped: list = []
+        for chunk_id, score in hits:
+            if grouped and grouped[-1][0] == score:
+                grouped[-1][1].append(chunk_id)
+            else:
+                grouped.append((score, [chunk_id]))
+        return grouped
+
+    oldest = _tiers(oldest_first = True)
+    newest = _tiers(newest_first = True)
+    every_id = [chunk_id for _score, tier in oldest for chunk_id in tier]
+    assert len(every_id) == sum(count for _o, _c, count in plan)
+    rows = store.chunks_by_id(conn, every_id)
+    # Non-vacuous: some score really is shared, or none of the above is being tested.
+    assert max(len(tier) for _score, tier in oldest) > 1, oldest
+
+    for score, tier in oldest:
+        expected = sorted(
+            tier, key = lambda chunk_id: conversation_archive._conversation_order(rows[chunk_id])
+        )
+        assert tier == expected, (score, tier, expected)
+    # And the other end is the exact mirror within each tier, or the two windows would not
+    # be cutting one run from its two ends.
+    assert [score for score, _ in newest] == [score for score, _ in oldest]
+    for (_score, forward), (_same, backward) in zip(oldest, newest):
+        assert backward == list(reversed(forward)), (forward, backward)
+
+
 def test_a_rewritten_turn_keeps_the_insertion_order_it_was_archived_in(conn, monkeypatch):
     """A re-embed replaces a row, and the replacement has to sit where the original sat.
 
@@ -2347,7 +2449,6 @@ def test_both_recall_paths_order_by_the_same_key():
     unmerged one on exactly the archives this ordering exists for.
     """
     from core.rag import conversation_archive
-
     for ordinal in (None, 0, 4):
         for created in ("", "2026-01-01T00:00:00Z"):
             for rowid in (None, 0, 12):

--- a/studio/backend/tests/test_conversation_archive.py
+++ b/studio/backend/tests/test_conversation_archive.py
@@ -2097,6 +2097,116 @@ def test_a_re_embed_that_stops_partway_does_not_reorder_a_legacy_archive(conn, m
     assert quoted == ["1", "2", "3", "4", "5"], quoted
 
 
+def test_a_legacy_archive_written_in_one_clock_tick_is_still_ordered(conn, monkeypatch):
+    """The same reorder as the test above, with the clock tie forced instead of hoped for.
+
+    That test only reaches the bug where the archive rows carry DISTINCT timestamps, which
+    is a property of the host clock and not of the code: `store._now` reads the wall clock,
+    and Windows advances it about every 15.6 ms, far slower than five turns are written.
+    So a compaction there stamps the whole conversation identically, on Linux and macOS it
+    almost never does, and the failure shows up on one CI leg as a different permutation
+    every run. Freezing `_now` reproduces it everywhere, in one shape, on purpose.
+
+    With `archive_ordinal` NULL and `created_at` equal, the sort key is spent. `sorted` is
+    stable, so the turns keep the order RELEVANCE handed them and are quoted scrambled
+    beneath a header promising oldest first. The assertion is on the order alone, because
+    the defect is that the key stopped being a total order.
+    """
+    from core.rag import embeddings
+
+    # One tick for every row: the archive cannot see that the five turns were written in
+    # sequence, which is exactly what a coarse system clock does to it.
+    monkeypatch.setattr(store, "_now", lambda: "2026-01-01T00:00:00+00:00")
+
+    identity = {"name": "st:model-a"}
+    real = embeddings.encode_with_identity
+    monkeypatch.setattr(
+        embeddings,
+        "encode_with_identity",
+        lambda texts, **kwargs: (real(texts, **kwargs)[0], identity["name"]),
+    )
+    monkeypatch.setattr(embeddings, "embedding_identity", lambda *_a, **_k: identity["name"])
+
+    turns = [_turn(f"turn {n} about pelicans", f"STATEMENT{n} about pelicans") for n in range(1, 6)]
+    history = [dict(message) for turn in turns for message in turn]
+    _save_thread(THREAD, history, append = True)
+    assert conversation_archive.archive_turns(THREAD, [dict(m) for m in history]) == 5
+    scope = store.conversation_archive_scope(THREAD)
+    conn.execute("UPDATE documents SET archive_ordinal=NULL WHERE scope=?", (scope,))
+    conn.commit()
+    # The premise: nothing above insertion order can separate these rows any more.
+    stamps = {
+        row["created_at"]
+        for row in conn.execute("SELECT created_at FROM documents WHERE scope=?", (scope,))
+    }
+    assert stamps == {"2026-01-01T00:00:00+00:00"}, stamps
+
+    identity["name"] = "st:model-b"
+    real_add = store.add_chunks
+    calls = {"n": 0}
+
+    def add_chunks_until_the_disk_fills(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise RuntimeError("database or disk is full")
+        return real_add(*args, **kwargs)
+
+    monkeypatch.setattr(store, "add_chunks", add_chunks_until_the_disk_fills)
+    conversation_archive.archive_turns(THREAD, [dict(m) for m in history])
+    monkeypatch.setattr(store, "add_chunks", real_add)
+
+    _text, sources = conversation_archive.recall(THREAD, "pelicans", top_k = 5)
+    quoted = [source["text"].split("STATEMENT")[1][0] for source in sources]
+    assert quoted == ["1", "2", "3", "4", "5"], quoted
+
+
+def test_a_rewritten_turn_keeps_the_insertion_order_it_was_archived_in(conn, monkeypatch):
+    """A re-embed replaces a row, and the replacement has to sit where the original sat.
+
+    `created_at` is carried over already, and on a clock that can separate the turns that
+    is enough. On one that cannot it is not: insertion order is the whole of what is left,
+    and a rewrite that took a fresh position would move every turn it reached to the end of
+    the conversation. Asserted on the stored rows rather than through `recall`, so a
+    regression here is named as the write-side defect it is.
+    """
+    from core.rag import embeddings
+
+    monkeypatch.setattr(store, "_now", lambda: "2026-01-01T00:00:00+00:00")
+    identity = {"name": "st:model-a"}
+    real = embeddings.encode_with_identity
+    monkeypatch.setattr(
+        embeddings,
+        "encode_with_identity",
+        lambda texts, **kwargs: (real(texts, **kwargs)[0], identity["name"]),
+    )
+    monkeypatch.setattr(embeddings, "embedding_identity", lambda *_a, **_k: identity["name"])
+
+    turns = [_turn(f"turn {n} about pelicans", f"STATEMENT{n} about pelicans") for n in range(1, 4)]
+    history = [dict(message) for turn in turns for message in turn]
+    _save_thread(THREAD, history, append = True)
+    assert conversation_archive.archive_turns(THREAD, [dict(m) for m in history]) == 3
+    scope = store.conversation_archive_scope(THREAD)
+    before = [
+        (row["rowid"], row["id"])
+        for row in conn.execute(
+            "SELECT rowid, id FROM documents WHERE scope=? ORDER BY rowid", (scope,)
+        )
+    ]
+
+    identity["name"] = "st:model-b"
+    conversation_archive.archive_turns(THREAD, [dict(m) for m in history])
+
+    after = [
+        (row["rowid"], row["id"])
+        for row in conn.execute(
+            "SELECT rowid, id FROM documents WHERE scope=? ORDER BY rowid", (scope,)
+        )
+    ]
+    # Every row really was rewritten, and every one of them landed back where it was.
+    assert [rowid for rowid, _ in after] == [rowid for rowid, _ in before]
+    assert [document_id for _, document_id in after] != [document_id for _, document_id in before]
+
+
 def test_merging_two_recall_queries_still_lists_legacy_turns_first(conn):
     """The merge key has to agree with `_conversation_order`, or the merged block
     contradicts its own "oldest first" header on an upgraded archive."""

--- a/studio/backend/tests/test_conversation_archive.py
+++ b/studio/backend/tests/test_conversation_archive.py
@@ -2100,22 +2100,15 @@ def test_a_re_embed_that_stops_partway_does_not_reorder_a_legacy_archive(conn, m
 def test_a_legacy_archive_written_in_one_clock_tick_is_still_ordered(conn, monkeypatch):
     """The same reorder as the test above, with the clock tie forced instead of hoped for.
 
-    That test only reaches the bug where the archive rows carry DISTINCT timestamps, which
-    is a property of the host clock and not of the code: `store._now` reads the wall clock,
-    and Windows advances it about every 15.6 ms, far slower than five turns are written.
-    So a compaction there stamps the whole conversation identically, on Linux and macOS it
-    almost never does, and the failure shows up on one CI leg as a different permutation
-    every run. Freezing `_now` reproduces it everywhere, in one shape, on purpose.
-
-    With `archive_ordinal` NULL and `created_at` equal, the sort key is spent. `sorted` is
-    stable, so the turns keep the order RELEVANCE handed them and are quoted scrambled
-    beneath a header promising oldest first. The assertion is on the order alone, because
-    the defect is that the key stopped being a total order.
+    That test only reaches the bug when the rows carry DISTINCT timestamps, a property of
+    the host clock: Windows advances it about every 15.6 ms, so a compaction there stamps
+    the whole conversation alike and the failure lands on one CI leg as a different
+    permutation every run. With the ordinal NULL and `created_at` equal the key is spent,
+    and a stable `sorted` quotes the turns in RELEVANCE order under an oldest-first header.
     """
     from core.rag import embeddings
 
-    # One tick for every row: the archive cannot see that the five turns were written in
-    # sequence, which is exactly what a coarse system clock does to it.
+    # One tick for every row, which is what a coarse system clock does to the archive.
     monkeypatch.setattr(store, "_now", lambda: "2026-01-01T00:00:00+00:00")
 
     identity = {"name": "st:model-a"}
@@ -2163,13 +2156,10 @@ def test_a_legacy_archive_written_in_one_clock_tick_is_still_ordered(conn, monke
 def test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved(conn, monkeypatch):
     """Tied documents must GROUP, because `chunk_index` is a position inside one of them.
 
-    The tie is the same one the test above forces, a clock too coarse to separate two
-    writes, but the turns here are long enough to be stored as several chunks each. Ranked
-    above the document, `chunk_index` stops being the thing that keeps a long message
-    contiguous and becomes the thing that shreds it: every document's chunk 0 sorts before
-    any document's chunk 1, so two three-chunk turns come back A0, B0, A1, B1, A2, B2 and
-    each turn is quoted through the middle of the other. Ranked below it, the same
-    component does the job it was added for.
+    Same clock tie as the test above, but with turns long enough to span several chunks.
+    Ranked above the document, `chunk_index` sorts every document's chunk 0 ahead of any
+    document's chunk 1, so two three-chunk turns come back A0, B0, A1, B1, A2, B2 and each
+    is quoted through the middle of the other.
     """
     monkeypatch.setattr(config, "CHUNK_TOKENS", 30)
     monkeypatch.setattr(config, "CHUNK_OVERLAP", 0)
@@ -2190,8 +2180,8 @@ def test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved(conn, monk
     scope = store.conversation_archive_scope(THREAD)
     conn.execute("UPDATE documents SET archive_ordinal=NULL WHERE scope=?", (scope,))
     conn.commit()
-    # The premise, and it takes both halves: one timestamp for both documents, and more
-    # than one chunk each, or the interleave has nothing to interleave.
+    # The premise takes both halves: one timestamp for both documents, more than one chunk
+    # each, or the interleave has nothing to interleave.
     assert {
         row["created_at"]
         for row in conn.execute("SELECT created_at FROM documents WHERE scope=?", (scope,))
@@ -2214,8 +2204,7 @@ def test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved(conn, monk
         if index == 0 or documents[index - 1] != document
     ]
     assert len(runs) == len(set(documents)) == 2, documents
-    # And inside a run the pieces are still in writing order, which is what `chunk_index`
-    # is for once it is asked the question it can answer.
+    # And inside a run the pieces are still in writing order.
     for document in runs:
         indexes = [s["chunkIndex"] for s in sources if s["documentId"] == document]
         assert indexes == sorted(indexes), (document, indexes)
@@ -2225,11 +2214,9 @@ def test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved(conn, monk
 def test_a_rewritten_turn_keeps_the_insertion_order_it_was_archived_in(conn, monkeypatch):
     """A re-embed replaces a row, and the replacement has to sit where the original sat.
 
-    `created_at` is carried over already, and on a clock that can separate the turns that
-    is enough. On one that cannot it is not: insertion order is the whole of what is left,
-    and a rewrite that took a fresh position would move every turn it reached to the end of
-    the conversation. Asserted on the stored rows rather than through `recall`, so a
-    regression here is named as the write-side defect it is.
+    Carrying `created_at` over is enough only on a clock that separates the turns; on one
+    that does not, a fresh rowid moves every turn the rewrite reached to the end. Asserted
+    on the stored rows, so a regression is named as the write-side defect it is.
     """
     from core.rag import embeddings
 
@@ -2315,11 +2302,8 @@ def test_merging_two_recall_queries_keeps_legacy_turns_in_the_order_they_were_sa
     them in whatever order the two queries happened to return them: the anchor's hits
     first, then the follow-up's. `_conversation_order` breaks exactly this tie with
     `created_at`, and the merged path has to agree with it or the block contradicts its own
-    oldest-first header on an upgraded database.
-
-    Sorted through `_order_key`, the function the product sorts with, rather than through a
-    copy of its key written out here. A copy passes for as long as nobody edits one side of
-    it, which is the failure this test exists to catch."""
+    oldest-first header on an upgraded database. Sorted through `_order_key` itself, since
+    a copy of the key written out here passes until somebody edits one side of it."""
     from core.rag import conversation_archive
 
     merged = [
@@ -2340,11 +2324,8 @@ def test_merging_two_recall_queries_keeps_legacy_turns_in_the_order_they_were_sa
 
 
 def test_both_recall_paths_order_by_the_same_key():
-    """The single-query path reads snake_case columns and the merge reads camelCase keys.
-
-    They are only "the same key" while both call `_order_key`; two hand-written five-part
-    tuples agree until one of them is edited, and the merged block then contradicts the
-    unmerged one on exactly the archives this ordering exists for.
+    """The single-query path reads snake_case columns and the merge reads camelCase keys;
+    they are only the same key while both call `_order_key`.
     """
     from core.rag import conversation_archive
     for ordinal in (None, 0, 4):
@@ -2376,11 +2357,8 @@ def test_both_recall_paths_order_by_the_same_key():
 def test_recall_sources_carry_the_fields_the_merge_orders_by():
     """The sort above is only as good as the field it reads, and nothing RENDERS
     `createdAt`, `documentRowid` or `chunkIndex`, so an unused-looking key is exactly the
-    sort of thing a later cleanup deletes. This pins the producer.
-
-    `documentRowid` most of all: it is the component that decides the order once the clock
-    has stopped separating rows, and it is the newest and least obviously load-bearing of
-    the three."""
+    sort of thing a later cleanup deletes. This pins the producer. `documentRowid` most of
+    all: it decides the order once the clock has stopped separating rows."""
     from types import SimpleNamespace
 
     from core.rag import tool

--- a/studio/backend/tests/test_conversation_archive.py
+++ b/studio/backend/tests/test_conversation_archive.py
@@ -2315,7 +2315,11 @@ def test_merging_two_recall_queries_keeps_legacy_turns_in_the_order_they_were_sa
     them in whatever order the two queries happened to return them: the anchor's hits
     first, then the follow-up's. `_conversation_order` breaks exactly this tie with
     `created_at`, and the merged path has to agree with it or the block contradicts its own
-    oldest-first header on an upgraded database."""
+    oldest-first header on an upgraded database.
+
+    Sorted through `_order_key`, the function the product sorts with, rather than through a
+    copy of its key written out here. A copy passes for as long as nobody edits one side of
+    it, which is the failure this test exists to catch."""
     from core.rag import conversation_archive
 
     merged = [
@@ -2324,21 +2328,60 @@ def test_merging_two_recall_queries_keeps_legacy_turns_in_the_order_they_were_sa
         {"turn": 3, "createdAt": "2026-01-03T00:00:00Z", "chunkIndex": 0, "text": "numbered"},
     ]
     merged.sort(
-        key = lambda source: (
-            source.get("turn") is not None,
-            source.get("turn") or 0,
-            source.get("createdAt") or "",
-            source.get("chunkIndex") or 0,
+        key = lambda source: conversation_archive._order_key(
+            source.get("turn"),
+            source.get("createdAt"),
+            source.get("documentRowid"),
+            source.get("chunkIndex"),
         )
     )
 
     assert [m["text"] for m in merged] == ["earlier", "later", "numbered"]
 
 
+def test_both_recall_paths_order_by_the_same_key():
+    """The single-query path reads snake_case columns and the merge reads camelCase keys.
+
+    They are only "the same key" while both call `_order_key`; two hand-written five-part
+    tuples agree until one of them is edited, and the merged block then contradicts the
+    unmerged one on exactly the archives this ordering exists for.
+    """
+    from core.rag import conversation_archive
+
+    for ordinal in (None, 0, 4):
+        for created in ("", "2026-01-01T00:00:00Z"):
+            for rowid in (None, 0, 12):
+                for index in (None, 0, 3):
+                    row = {
+                        "archive_ordinal": ordinal,
+                        "created_at": created,
+                        "document_rowid": rowid,
+                        "chunk_index": index,
+                    }
+                    source = {
+                        "turn": ordinal,
+                        "createdAt": created,
+                        "documentRowid": rowid,
+                        "chunkIndex": index,
+                    }
+                    assert conversation_archive._conversation_order(row) == (
+                        conversation_archive._order_key(
+                            source.get("turn"),
+                            source.get("createdAt"),
+                            source.get("documentRowid"),
+                            source.get("chunkIndex"),
+                        )
+                    ), row
+
+
 def test_recall_sources_carry_the_fields_the_merge_orders_by():
     """The sort above is only as good as the field it reads, and nothing RENDERS
-    `createdAt` or `chunkIndex`, so an unused-looking key is exactly the sort of thing a
-    later cleanup deletes. This pins the producer."""
+    `createdAt`, `documentRowid` or `chunkIndex`, so an unused-looking key is exactly the
+    sort of thing a later cleanup deletes. This pins the producer.
+
+    `documentRowid` most of all: it is the component that decides the order once the clock
+    has stopped separating rows, and it is the newest and least obviously load-bearing of
+    the three."""
     from types import SimpleNamespace
 
     from core.rag import tool
@@ -2351,6 +2394,7 @@ def test_recall_sources_carry_the_fields_the_merge_orders_by():
             "archive_ordinal": None,
             "chunk_index": 2,
             "created_at": "2026-01-01T00:00:00Z",
+            "document_rowid": 41,
         },
     }
     hits = [SimpleNamespace(chunk_id = "c1", score = 0.5)]
@@ -2359,6 +2403,7 @@ def test_recall_sources_carry_the_fields_the_merge_orders_by():
 
     assert sources[0]["createdAt"] == "2026-01-01T00:00:00Z"
     assert sources[0]["chunkIndex"] == 2
+    assert sources[0]["documentRowid"] == 41
     assert sources[0]["turn"] is None
 
 

--- a/studio/backend/tests/test_conversation_archive.py
+++ b/studio/backend/tests/test_conversation_archive.py
@@ -2192,10 +2192,10 @@ def test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved(conn, monk
     conn.commit()
     # The premise, and it takes both halves: one timestamp for both documents, and more
     # than one chunk each, or the interleave has nothing to interleave.
-    assert {row["created_at"] for row in
-            conn.execute("SELECT created_at FROM documents WHERE scope=?", (scope,))} == {
-        "2026-01-01T00:00:00+00:00"
-    }
+    assert {
+        row["created_at"]
+        for row in conn.execute("SELECT created_at FROM documents WHERE scope=?", (scope,))
+    } == {"2026-01-01T00:00:00+00:00"}
     per_document = [
         row["n"]
         for row in conn.execute(
@@ -2208,8 +2208,11 @@ def test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved(conn, monk
 
     # Each turn is quoted in one unbroken run, and the run that was archived first leads.
     documents = [source["documentId"] for source in sources]
-    runs = [document for index, document in enumerate(documents)
-            if index == 0 or documents[index - 1] != document]
+    runs = [
+        document
+        for index, document in enumerate(documents)
+        if index == 0 or documents[index - 1] != document
+    ]
     assert len(runs) == len(set(documents)) == 2, documents
     # And inside a run the pieces are still in writing order, which is what `chunk_index`
     # is for once it is asked the question it can answer.

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -412,6 +412,204 @@ def test_a_quoted_function_word_survives_the_stopword_filter():
     assert len(quoted) == 1
 
 
+def test_the_candidate_window_is_cut_in_conversation_order(rag_home, rag_conn):
+    """Ordering the candidates cannot rescue a candidate the SELECT never returned.
+
+    Past `_BRANCH_FILTER_MAX_CANDIDATES` the archive stops taking every match and takes two
+    windows instead, one from each end of the tied run, and the LIMIT that cuts them runs
+    in SQL. So this ORDER BY is not an arrangement of a full set, it is the choice of which
+    rows exist as far as the rest of recall is concerned.
+
+    On a legacy archive the run is one flat tie: FTS5 floors the IDF of the term the whole
+    scope shares, so every score is equal, every `archive_ordinal` is NULL and one clock
+    tick stamped every `created_at`. Cut at the chunk id, as it was, the two windows are
+    the ends of the UUID space, and the ids are assigned by `uuid4`, so which turns survive
+    is unrelated to the conversation. The oldest and the newest statement can BOTH be gone
+    before any comparator runs.
+
+    The ids here are rotated exactly half a turn against conversation order, so that the
+    lexicographic ends of the id space are the conversation's middle and the conversation's
+    two ends sit dead centre in it. That makes the right answer and the wrong one
+    distinguishable: a window cut by id cannot contain either true end, and one cut in
+    conversation order must contain both. Cut by id the windows come back holding
+    conversation positions 50 to 92 and 7 to 49.
+    """
+    import types
+
+    from core.rag import store
+
+    conn = rag_conn
+    scope = "convarchive_legacy"
+    documents, per_document = 100, 3
+    position_of = {}
+    for position in range(documents):
+        document_id = f"{(position + documents // 2) % documents:04d}-turn"
+        position_of[document_id] = position
+        store.create_document(
+            conn,
+            scope = scope,
+            thread_id = "t",
+            filename = "earlier turn",
+            sha256 = f"h{position}",
+            status = "completed",
+            embedding_model = "m",
+            archive_messages = 2,
+            archive_ordinal = None,
+            document_id = document_id,
+            # One tick for the whole archive, the way a Windows host stamps a compaction.
+            created_at = "2026-01-01T00:00:00+00:00",
+            commit = False,
+        )
+        chunks = [
+            types.SimpleNamespace(
+                chunk_index = index,
+                text = "ZQXTIEBREAK legacy turn statement",
+                page_number = None,
+                source_page_index = None,
+                token_count = 5,
+                char_count = 20,
+            )
+            for index in range(per_document)
+        ]
+        store.add_chunks(conn, scope, document_id, chunks, [[0.0] * 4] * per_document)
+    conn.commit()
+
+    # The premise: one score across the whole run, and more of it than the cap allows.
+    everything = store.search_lexical(conn, scope, "ZQXTIEBREAK", documents * per_document + 10)
+    assert len(everything) == documents * per_document
+    assert len({score for _, score in everything}) == 1
+
+    half = 128
+    oldest = [
+        c for c, _ in store.search_lexical(conn, scope, "ZQXTIEBREAK", half, oldest_first = True)
+    ]
+    newest = [
+        c for c, _ in store.search_lexical(conn, scope, "ZQXTIEBREAK", half, newest_first = True)
+    ]
+    in_oldest = sorted({position_of[chunk.rsplit(":", 1)[0]] for chunk in oldest})
+    in_newest = sorted({position_of[chunk.rsplit(":", 1)[0]] for chunk in newest})
+
+    # Both true ends survive the cut, which is the whole point of taking two windows.
+    assert 0 in in_oldest, in_oldest
+    assert documents - 1 in in_newest, in_newest
+    # And each window really is an END of the conversation, not a slice out of its middle.
+    assert in_oldest[0] == 0 and in_oldest == list(range(len(in_oldest))), in_oldest
+    assert in_newest[-1] == documents - 1, in_newest
+    assert in_newest == list(range(documents - len(in_newest), documents)), in_newest
+    # The two windows are disjoint, so the pair spans strictly more than either alone.
+    assert not set(in_oldest) & set(in_newest)
+
+
+def test_the_candidate_order_survives_a_re_embed(rag_home, rag_conn):
+    """The rowid this ORDER BY sorts on has to outlive a re-embed, so hold one and check.
+
+    A re-embed is a delete followed by an insert, which is exactly the operation that
+    scrambles insertion order, and the SQL above leans on that order whenever ordinal and
+    `created_at` have both run out. It survives only because `create_document` takes a
+    `rowid` and the archive hands it back the one it just deleted. That is a property of
+    another module, asserted here because this query is what breaks if it stops holding.
+
+    Rewritten in reverse, positions 4 then 3 then 2, so a fresh rowid would not merely be
+    different but wrongly ORDERED: the rewritten turns would come back 5, 4, 3 behind the
+    two the pass never touched. Rewriting them in conversation order would renumber them
+    ascending and pass on a tree where the carry had been deleted.
+
+    Document ids descend as the conversation advances, so an answer taken from the id
+    space is the exact reverse of the right one and the two cannot be confused.
+    """
+    import types
+
+    from core.rag import store
+
+    conn = rag_conn
+    scope = "convarchive_reembed"
+    turns = 5
+
+    def _document_id(position):
+        return f"{turns - position:04d}-turn"
+
+    def _write(
+        position,
+        model,
+        *,
+        rowid = None,
+        created = None,
+        ordinal = None,
+    ):
+        store.create_document(
+            conn,
+            scope = scope,
+            thread_id = "t",
+            filename = "earlier turn",
+            sha256 = f"h{position}",
+            status = "completed",
+            embedding_model = model,
+            archive_messages = 2,
+            archive_ordinal = ordinal,
+            document_id = _document_id(position),
+            # One tick for every turn, so `created_at` cannot separate them and the rowid
+            # is the only record left of which was said first.
+            created_at = created or "2026-01-01T00:00:00+00:00",
+            rowid = rowid,
+            commit = False,
+        )
+        store.add_chunks(
+            conn,
+            scope,
+            _document_id(position),
+            [
+                types.SimpleNamespace(
+                    chunk_index = 0,
+                    text = "ZQXREEMBED legacy turn statement",
+                    page_number = None,
+                    source_page_index = None,
+                    token_count = 5,
+                    char_count = 20,
+                )
+            ],
+            [[0.0] * 4],
+        )
+
+    for position in range(turns):
+        _write(position, "old-model")
+    conn.commit()
+
+    def _positions(**direction):
+        hits = store.search_lexical(conn, scope, "ZQXREEMBED", turns + 10, **direction)
+        return [turns - int(chunk.rsplit(":", 1)[0].split("-")[0]) for chunk, _s in hits]
+
+    assert _positions(oldest_first = True) == list(range(turns))
+    rowids_before = dict(
+        conn.execute("SELECT id, rowid FROM documents WHERE scope=?", (scope,)).fetchall()
+    )
+
+    for position in [4, 3, 2]:
+        identity = store.document_rewrite_identity(conn, _document_id(position)) or {}
+        store.delete_document(conn, _document_id(position), commit = False)
+        _write(
+            position,
+            "new-model",
+            rowid = identity.get("rowid"),
+            created = identity.get("created_at"),
+            ordinal = identity.get("archive_ordinal"),
+        )
+    conn.commit()
+
+    # The premise, and the test is vacuous without it: the rows really were replaced.
+    assert {
+        row[0]
+        for row in conn.execute("SELECT embedding_model FROM documents WHERE scope=?", (scope,))
+    } == {"old-model", "new-model"}
+    # The rowid the ORDER BY sorts on came across the rewrite unchanged.
+    assert (
+        dict(conn.execute("SELECT id, rowid FROM documents WHERE scope=?", (scope,)).fetchall())
+        == rowids_before
+    )
+    # And so the window is still cut in conversation order, from either end.
+    assert _positions(oldest_first = True) == list(range(turns))
+    assert _positions(newest_first = True) == list(reversed(range(turns)))
+
+
 def test_a_legacy_archive_still_gets_two_different_ends(rag_home, rag_conn):
     """Every ordinal NULL made both halves of the two-ended fetch the same query.
 

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -415,24 +415,15 @@ def test_a_quoted_function_word_survives_the_stopword_filter():
 def test_the_candidate_window_is_cut_in_conversation_order(rag_home, rag_conn):
     """Ordering the candidates cannot rescue a candidate the SELECT never returned.
 
-    Past `_BRANCH_FILTER_MAX_CANDIDATES` the archive stops taking every match and takes two
-    windows instead, one from each end of the tied run, and the LIMIT that cuts them runs
-    in SQL. So this ORDER BY is not an arrangement of a full set, it is the choice of which
-    rows exist as far as the rest of recall is concerned.
+    Past `_BRANCH_FILTER_MAX_CANDIDATES` the archive takes two windows, one from each end
+    of the tied run, and the LIMIT that cuts them runs in SQL: this ORDER BY chooses which
+    rows exist for the rest of recall. On a legacy archive the run is one flat tie (FTS5
+    floors the IDF of the scope's shared term, every ordinal NULL, one clock tick over every
+    `created_at`), so cutting at the chunk id cut at a `uuid4` and both true ends could go.
 
-    On a legacy archive the run is one flat tie: FTS5 floors the IDF of the term the whole
-    scope shares, so every score is equal, every `archive_ordinal` is NULL and one clock
-    tick stamped every `created_at`. Cut at the chunk id, as it was, the two windows are
-    the ends of the UUID space, and the ids are assigned by `uuid4`, so which turns survive
-    is unrelated to the conversation. The oldest and the newest statement can BOTH be gone
-    before any comparator runs.
-
-    The ids here are rotated exactly half a turn against conversation order, so that the
-    lexicographic ends of the id space are the conversation's middle and the conversation's
-    two ends sit dead centre in it. That makes the right answer and the wrong one
-    distinguishable: a window cut by id cannot contain either true end, and one cut in
-    conversation order must contain both. Cut by id the windows come back holding
-    conversation positions 50 to 92 and 7 to 49.
+    The ids are rotated half a turn against conversation order, putting the conversation's
+    ends dead centre of the id space: cut by id neither end survives, cut in conversation
+    order both must. Cut by id the windows held conversation positions 50-92 and 7-49.
     """
     import types
 
@@ -503,19 +494,15 @@ def test_the_candidate_window_is_cut_in_conversation_order(rag_home, rag_conn):
 def test_the_candidate_order_survives_a_re_embed(rag_home, rag_conn):
     """The rowid this ORDER BY sorts on has to outlive a re-embed, so hold one and check.
 
-    A re-embed is a delete followed by an insert, which is exactly the operation that
-    scrambles insertion order, and the SQL above leans on that order whenever ordinal and
-    `created_at` have both run out. It survives only because `create_document` takes a
-    `rowid` and the archive hands it back the one it just deleted. That is a property of
-    another module, asserted here because this query is what breaks if it stops holding.
+    A re-embed deletes and re-inserts, the one operation that scrambles insertion order,
+    and it survives only because `create_document` takes a `rowid` and the archive hands
+    back the one it just deleted. A property of another module, asserted here because this
+    query is what breaks if it stops holding.
 
-    Rewritten in reverse, positions 4 then 3 then 2, so a fresh rowid would not merely be
-    different but wrongly ORDERED: the rewritten turns would come back 5, 4, 3 behind the
-    two the pass never touched. Rewriting them in conversation order would renumber them
-    ascending and pass on a tree where the carry had been deleted.
-
-    Document ids descend as the conversation advances, so an answer taken from the id
-    space is the exact reverse of the right one and the two cannot be confused.
+    Rewritten in REVERSE, positions 4 then 3 then 2, so a fresh rowid would be wrongly
+    ordered rather than merely different; rewriting in conversation order would renumber
+    ascending and pass even with the carry deleted. Document ids descend as the
+    conversation advances, so an id-space answer is the exact reverse of the right one.
     """
     import types
 


### PR DESCRIPTION
`_conversation_order` is the sort key that puts recalled conversation turns back into the order they were said. For a legacy archive, one written before `archive_ordinal` existed, the key was `(0, 0, created_at, chunk_index)`, and for a set of one-chunk turns that reduces to `created_at` alone.

`created_at` is a wall-clock reading: `store._now()` returns `datetime.now(timezone.utc).isoformat()`. Windows advances the system clock in ticks of about 15.6 ms, which is far slower than a compaction writes rows, so a pass that archives a whole conversation at once stamps every turn with a byte-identical timestamp. The key then ties completely. `sorted` is stable, so the turns keep the order retrieval handed them, which is relevance order, and relevance order changes with the query.

### What the user sees

The recalled block is emitted under a header that states the turns are listed oldest first and that a later turn supersedes an earlier one. With the key exhausted, that header is describing an order the archive did not produce. The model is handed the user's own conversation scrambled and told the wrong statement is the current one, and because the tie is broken by relevance rather than by anything stable, two recalls against the same database can render the same turns in two different orders. The flaky test is the visible end of that: it is a silent reordering of a user's conversation.

### Two parts to the fix

**The key needs a total order.** The document's rowid goes in, surfaced through `store.chunks_by_id` as `document_rowid`, giving `(bucket, archive_ordinal, created_at, document rowid, chunk_index)`. Insertion order is the right thing to fall back to because it is what the archive actually recorded when the clock could not tell the rows apart.

It sits ABOVE `chunk_index`, not below it, and that ordering matters as soon as the tied turns are long enough to be stored as several chunks each. `chunk_index` is a position within a document and means nothing between two of them, so ranked above document identity it does not order the turns, it interleaves them: two tied three-chunk documents come back A0, B0, A1, B1, A2, B2, and the long message the component exists to keep contiguous is quoted through the middle of its neighbour. That is the same defect as the tie it sits beneath, one level down.

The merged two-query recall path carries the same value as `documentRowid` and in the same position, so its key stays in agreement with `_conversation_order`, which is what `test_merging_two_recall_queries_still_lists_legacy_turns_first` already asserts.

**The rewrite path has to stop discarding it.** The rowid on its own is not enough, and this is the part worth flagging. A re-embed does not update a document in place: it deletes the row and inserts a replacement. `archive_ordinal` and `created_at` are already carried over precisely so a rewrite cannot reorder the archive, but the rowid was not, so the replacement took a fresh, larger one. On a tied-timestamp archive that turns an intermittent scramble into a deterministic wrong answer: a re-embed that dies partway sorts every turn it reached behind every turn it never got to. Measured on the five-turn scenario with the clock frozen, ordering by rowid without preserving it gives `['3', '4', '5', '1', '2']`, every time.

So `store.create_document` gains a `rowid` argument alongside the `created_at` it already had, for the same stated reason and documented in the same place, and the re-embed path reads it back through the new `store.document_rewrite_identity`. Omitted, the argument is `None`, and SQLite assigns the next rowid for an explicit NULL exactly as it does when the column is not named at all, so every other caller is byte for byte unchanged.

### Reproducing it off Windows

`test_a_re_embed_that_stops_partway_does_not_reorder_a_legacy_archive` is left as it is. It only reaches this bug when the host clock happens to separate the rows, which is a property of the machine and not of the code, so it fails on the Windows leg with a different permutation every run and effectively never elsewhere.

The new `test_a_legacy_archive_written_in_one_clock_tick_is_still_ordered` forces the condition instead of waiting for it: `store._now` is frozen, so every row genuinely carries the same timestamp, and the test asserts that first before going on. It then runs the same partial re-embed and checks the recalled order. On the unpatched tree it fails on any platform, and it fails the way the Windows leg does, with a fresh permutation each run:

```
E       AssertionError: ['2', '1', '4', '3', '5']
E       AssertionError: ['4', '3', '5', '1', '2']
E       AssertionError: ['4', '5', '3', '1', '2']
```

`test_a_rewritten_turn_keeps_the_insertion_order_it_was_archived_in` covers the write half directly, on the stored rows rather than through `recall`, so a regression there is reported as the write-side defect it is. Unpatched it fails with `assert [4, 5, 6] == [1, 2, 3]`.

`test_two_turns_stamped_alike_are_quoted_whole_and_not_interleaved` pins the rank of `chunk_index` against the rowid. It forces the same clock tie but with turns long enough to chunk, and asserts each turn comes back as one unbroken run in writing order. With only the two key components swapped it fails with six runs where there should be two, the documents alternating chunk by chunk.

Both halves of the ordering claim are asserted, not just the one the original flake happened to expose.

### Verification

`studio/backend/tests/test_conversation_archive.py` passes in full, as do the other suites that reach `conversation_archive.py`, `store.chunks_by_id` or `create_document`. A differential against a worktree pinned to the merge base shows no new failures.

### Not covered by the neighbouring PRs

Distinct from #10536 and #10561. Both are confined to `test_rag_linked_folders.py` and `folder_sync.py` and neither touches `conversation_archive.py`, `store.py` ordering or the recall key.
